### PR TITLE
llfp4 output scale workaround

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -108,13 +108,13 @@ def load_model(
                 if k in name:
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
-                    param = model.get_parameter(param_name)
-                    #test if git config works properly
-                    weight_loader = getattr(param, "weight_loader")
-                    # weight_loader(param, weight_tensor, shard_id)
-                    futures.append(
-                        executor.submit(weight_loader, param, weight_tensor, shard_id)
-                    )
+                    if ("output_scale" not in param_name):
+                        param = model.get_parameter(param_name)
+                        weight_loader = getattr(param, "weight_loader")
+                        # weight_loader(param, weight_tensor, shard_id)
+                        futures.append(
+                            executor.submit(weight_loader, param, weight_tensor, shard_id)
+                        )
                     break
             else:
                 # Check if model has expert mapping before processing

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -109,6 +109,7 @@ def load_model(
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
                     param = model.get_parameter(param_name)
+                    #test if git config works properly
                     weight_loader = getattr(param, "weight_loader")
                     # weight_loader(param, weight_tensor, shard_id)
                     futures.append(

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -108,12 +108,13 @@ def load_model(
                 if k in name:
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
-                    param = model.get_parameter(param_name)
-                    weight_loader = getattr(param, "weight_loader")
-                    # weight_loader(param, weight_tensor, shard_id)
-                    futures.append(
-                        executor.submit(weight_loader, param, weight_tensor, shard_id)
-                    )
+                    if ("output_scale" not in param_name):
+                        param = model.get_parameter(param_name)
+                        weight_loader = getattr(param, "weight_loader")
+                        # weight_loader(param, weight_tensor, shard_id)
+                        futures.append(
+                            executor.submit(weight_loader, param, weight_tensor, shard_id)
+                        )
                     break
             else:
                 # Check if model has expert mapping before processing

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -108,13 +108,12 @@ def load_model(
                 if k in name:
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
-                    if ("output_scale" not in param_name):
-                        param = model.get_parameter(param_name)
-                        weight_loader = getattr(param, "weight_loader")
-                        # weight_loader(param, weight_tensor, shard_id)
-                        futures.append(
-                            executor.submit(weight_loader, param, weight_tensor, shard_id)
-                        )
+                    param = model.get_parameter(param_name)
+                    weight_loader = getattr(param, "weight_loader")
+                    # weight_loader(param, weight_tensor, shard_id)
+                    futures.append(
+                        executor.submit(weight_loader, param, weight_tensor, shard_id)
+                    )
                     break
             else:
                 # Check if model has expert mapping before processing

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -59,12 +59,12 @@ def gemm_a4w4_quant(x: torch.Tensor, weight: torch.Tensor, otype: torch.dtype, w
         dtype=otype,
         device=x.device,
     )
-    w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
+    #w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
     y = gemm_a4w4(
         x,
         weight,
         x_scale,
-        w_scale,
+        weight_scale, #w_scale
         y,
     )
     return y[:m, ...]
@@ -170,6 +170,8 @@ class LinearBase(nn.Module):
             self.bias.weight_loader = self.weight_loader
         if self.weight_scale is not None:
             self.weight_scale.weight_loader = self.weight_loader
+            # shuffle weight scale once so no reshuffling for every gemm
+            self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         self.need_normalize_e4m3fn_to_e4m3fnuz = params_dtype == torch.float8_e4m3fnuz
 
     @staticmethod

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -59,12 +59,12 @@ def gemm_a4w4_quant(x: torch.Tensor, weight: torch.Tensor, otype: torch.dtype, w
         dtype=otype,
         device=x.device,
     )
-    #w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
+    w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
     y = gemm_a4w4(
         x,
         weight,
         x_scale,
-        weight_scale, #w_scale
+        w_scale,
         y,
     )
     return y[:m, ...]
@@ -170,8 +170,6 @@ class LinearBase(nn.Module):
             self.bias.weight_loader = self.weight_loader
         if self.weight_scale is not None:
             self.weight_scale.weight_loader = self.weight_loader
-            # shuffle weight scale once so no reshuffling for every gemm
-            self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         self.need_normalize_e4m3fn_to_e4m3fnuz = params_dtype == torch.float8_e4m3fnuz
 
     @staticmethod


### PR DESCRIPTION
## Motivation

Workaround to prevent LLFP4 network from failing to run, so traces can be collected and optimizations can be made to the model.

## Technical Details

Quick fix to skip the output_scale parameter for the LLFP4 model since the parameter does not exist for QKV layer (output scale is constant), but the parameter contains data, which causes some accuracy issues.

## Test Plan

Manual testing to check if the model runs.

## Test Result

Allows LLFP4 to run, but causes some accuracy issues (lm_eval outputs 90 and 60).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
