### PR TITLE
llfp4 weight scale shuffle fix

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -108,13 +108,13 @@ def load_model(
                 if k in name:
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
-                    param = model.get_parameter(param_name)
-                    #test if git config works properly
-                    weight_loader = getattr(param, "weight_loader")
-                    # weight_loader(param, weight_tensor, shard_id)
-                    futures.append(
-                        executor.submit(weight_loader, param, weight_tensor, shard_id)
-                    )
+                    if ("output_scale" not in param_name):
+                        param = model.get_parameter(param_name)
+                        weight_loader = getattr(param, "weight_loader")
+                        # weight_loader(param, weight_tensor, shard_id)
+                        futures.append(
+                            executor.submit(weight_loader, param, weight_tensor, shard_id)
+                        )
                     break
             else:
                 # Check if model has expert mapping before processing

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -109,6 +109,7 @@ def load_model(
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
                     param = model.get_parameter(param_name)
+                    #test if git config works properly
                     weight_loader = getattr(param, "weight_loader")
                     # weight_loader(param, weight_tensor, shard_id)
                     futures.append(

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -108,12 +108,13 @@ def load_model(
                 if k in name:
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
-                    param = model.get_parameter(param_name)
-                    weight_loader = getattr(param, "weight_loader")
-                    # weight_loader(param, weight_tensor, shard_id)
-                    futures.append(
-                        executor.submit(weight_loader, param, weight_tensor, shard_id)
-                    )
+                    if ("output_scale" not in param_name):
+                        param = model.get_parameter(param_name)
+                        weight_loader = getattr(param, "weight_loader")
+                        # weight_loader(param, weight_tensor, shard_id)
+                        futures.append(
+                            executor.submit(weight_loader, param, weight_tensor, shard_id)
+                        )
                     break
             else:
                 # Check if model has expert mapping before processing

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -108,13 +108,12 @@ def load_model(
                 if k in name:
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
-                    if ("output_scale" not in param_name):
-                        param = model.get_parameter(param_name)
-                        weight_loader = getattr(param, "weight_loader")
-                        # weight_loader(param, weight_tensor, shard_id)
-                        futures.append(
-                            executor.submit(weight_loader, param, weight_tensor, shard_id)
-                        )
+                    param = model.get_parameter(param_name)
+                    weight_loader = getattr(param, "weight_loader")
+                    # weight_loader(param, weight_tensor, shard_id)
+                    futures.append(
+                        executor.submit(weight_loader, param, weight_tensor, shard_id)
+                    )
                     break
             else:
                 # Check if model has expert mapping before processing

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -59,12 +59,12 @@ def gemm_a4w4_quant(x: torch.Tensor, weight: torch.Tensor, otype: torch.dtype, w
         dtype=otype,
         device=x.device,
     )
-    w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
+    #w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
     y = gemm_a4w4(
         x,
         weight,
         x_scale,
-        w_scale,
+        weight_scale, #w_scale
         y,
     )
     return y[:m, ...]
@@ -170,6 +170,8 @@ class LinearBase(nn.Module):
             self.bias.weight_loader = self.weight_loader
         if self.weight_scale is not None:
             self.weight_scale.weight_loader = self.weight_loader
+            # shuffle weight scale once so no reshuffling for every gemm
+            self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         self.need_normalize_e4m3fn_to_e4m3fnuz = params_dtype == torch.float8_e4m3fnuz
 
     @staticmethod

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -59,12 +59,12 @@ def gemm_a4w4_quant(x: torch.Tensor, weight: torch.Tensor, otype: torch.dtype, w
         dtype=otype,
         device=x.device,
     )
-    #w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
+    w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
     y = gemm_a4w4(
         x,
         weight,
         x_scale,
-        weight_scale, #w_scale
+        w_scale,
         y,
     )
     return y[:m, ...]
@@ -170,8 +170,6 @@ class LinearBase(nn.Module):
             self.bias.weight_loader = self.weight_loader
         if self.weight_scale is not None:
             self.weight_scale.weight_loader = self.weight_loader
-            # shuffle weight scale once so no reshuffling for every gemm
-            self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         self.need_normalize_e4m3fn_to_e4m3fnuz = params_dtype == torch.float8_e4m3fnuz
 
     @staticmethod

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -59,12 +59,11 @@ def gemm_a4w4_quant(x: torch.Tensor, weight: torch.Tensor, otype: torch.dtype, w
         dtype=otype,
         device=x.device,
     )
-    #w_scale = fp4_utils.e8m0_shuffle(weight_scale.data)
     y = gemm_a4w4(
         x,
         weight,
         x_scale,
-        weight_scale, #w_scale
+        weight_scale,
         y,
     )
     return y[:m, ...]

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -170,8 +170,6 @@ class LinearBase(nn.Module):
             self.bias.weight_loader = self.weight_loader
         if self.weight_scale is not None:
             self.weight_scale.weight_loader = self.weight_loader
-            # shuffle weight scale once so no reshuffling for every gemm
-            self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         self.need_normalize_e4m3fn_to_e4m3fnuz = params_dtype == torch.float8_e4m3fnuz
 
     @staticmethod
@@ -218,6 +216,8 @@ class LinearBase(nn.Module):
             self.quant_type == QuantType.per_Token and self.params_dtype == dtypes.fp8
         ) or (self.quant_type in [QuantType.per_1x32, QuantType.per_1x128]):
             self.weight.data = shuffle_weight(self.weight.data, (16, 16))
+            # shuffle weight scale once so no reshuffling for every gemm
+            self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
 
     def forward(
         self, x: torch.Tensor, x_scale: Optional[torch.Tensor] = None, otype=dtypes.bf16


### PR DESCRIPTION
## Motivation

Cleans up some comments from previous output scale fix and eliminates redundant weight scale shuffling.

## Technical Details

Remove the weight scale shuffle and do the weight scale shuffle on model load rather than every time a GEMM is done. Should eliminate multiple redundant kernels and improve performance times.

## Test Plan

lm_eval returns no difference from original modified model (with fix to run model impacting accuracy). Manual kernel traces checked to verify performance changes. 

## Test Result

No change from previous accuracy numbers. Manual kernel traces show redundant kernels are eliminated.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
