### PR TITLE
llfp4 weight scale shuffle fix

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -230,8 +230,9 @@ class LinearBase(nn.Module):
             self.quant_type == QuantType.per_Token and self.params_dtype == dtypes.fp8
         ) or (self.quant_type in [QuantType.per_1x32, QuantType.per_1x128]):
             self.weight.data = shuffle_weight(self.weight.data, (16, 16))
-            # shuffle weight scale once so no reshuffling for every gemm
-        self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
+        # shuffle weight scale once so no reshuffling for every gemm
+        if self.quant_type == QuantType.per_1x32:
+            self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
 
     def forward(
         self, x: torch.Tensor, x_scale: Optional[torch.Tensor] = None, otype=dtypes.bf16


### PR DESCRIPTION
## Motivation

Cleans up some comments from previous output scale fix and eliminates redundant weight scale shuffling.

## Technical Details

Remove the weight scale shuffle and do the weight scale shuffle on model load rather than every time a GEMM is done. Should eliminate multiple redundant kernels and improve performance times.

## Test Plan

lm_eval returns no difference from original modified model (with fix to run model impacting accuracy). Manual kernel traces checked to verify performance changes. 

## Test Result

No change from previous accuracy numbers. Manual kernel traces show redundant kernels are eliminated.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
