### PR TITLE
llfp4 fail temporary workaround

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -118,6 +118,7 @@ def load_model(
                 if k in name:
                     v, shard_id = packed_modules_mapping[k]
                     param_name = name.replace(k, v)
+                    #FIXME output_scale has a value, so accuracy is incorrect. this should be loaded and used in llfp4.
                     if ("output_scale" not in param_name):
                         param = model.get_parameter(param_name)
                         weight_loader = getattr(param, "weight_loader")


### PR DESCRIPTION
## Motivation

Workaround to prevent LLFP4 network from failing to run, so traces can be collected and optimizations can be made to the model.

## Technical Details

Quick fix to skip the output_scale parameter for the LLFP4 model since the parameter does not exist for QKV layer (output scale is constant), but the parameter contains data, which causes some accuracy issues.

## Test Plan

Manual testing to check if the model runs.

## Test Result

Allows LLFP4 to run, but causes some accuracy issues (lm_eval outputs 90 and 60).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
