### PR TITLE
Enable INT4 QR for LLFP4

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -231,6 +231,8 @@ class ModelRunner:
         self.rank = rank
         self.label = f"Model Runner{rank}/{self.world_size}"
         self.hf_text_config = get_hf_text_config(hf_config)
+        if (self.hf_text_config.model_type in ["llama"] and self.hf_text_config.torch_dtype in [torch.bfloat16, torch.float16]):
+            os.environ["AITER_QUICK_REDUCE_QUANTIZATION"] = "INT4"
         self.use_mla = self.is_deepseek_mla()
         self.is_deepseek_v32 = (
             hasattr(hf_config, "index_topk") if self.use_mla else False


### PR DESCRIPTION
## Motivation

Enable INT4 QR for LLFP4. For maximum performance requires cap implemented in separate aiter PR

## Technical Details

Update env before model is loaded to enable qr_comm

## Test Plan

Trace output shows updated kernel and lm_eval does not deviate.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
