### PR TITLE
[ds3.2](fix): add one param for top_k_per_row_prefill ops

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -344,13 +344,14 @@ def sparse_attn_indexer(
             num_decode_tokens:num_tokens, :topk_tokens
         ]
         top_k_per_row_prefill(
-            logits,
-            cu_seqlen_ks,
-            cu_seqlen_ke,
-            topk_indices,
-            num_rows,
-            logits.stride(0),
-            logits.stride(1),
+            logits=logits,
+            rowStarts=cu_seqlen_ks,
+            rowEnds=cu_seqlen_ke,
+            indices=topk_indices,
+            values=None,
+            numRows=num_rows,
+            stride0=logits.stride(0),
+            stride1=logits.stride(1),
         )
     else:
         decode_metadata = attn_metadata


### PR DESCRIPTION
after fix the param error, it can run normally.
<img width="1352" height="158" alt="image" src="https://github.com/user-attachments/assets/39d6c661-5613-409b-a19b-0edbe263946e" />


