### PR TITLE
[Graph](fix): add param check for cuda graph capture

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -894,6 +894,8 @@ class ModelRunner:
                 self.graph_bs = cuda_graph_sizes
         self.graph_bs.sort(reverse=True)
 
+        assert self.graph_bs[0] <= self.config.max_num_seqs, "cudagraph capture sizes must be less than max_num_seqs."
+
         self.forward_vars["cu_seqlens_q"].np[: self.graph_bs[0] + 1] = np.arange(
             0, self.graph_bs[0] + 1
         )


### PR DESCRIPTION
## Motivation

This PR adds a check for `--max-num-seqs` config to avoid errors in unknown place like:

<img width="693" height="83" alt="image" src="https://github.com/user-attachments/assets/e27cd55d-2a78-4c98-889e-516d50778385" />

