### PR TITLE
[fix] disable gluon pa for llama

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -405,4 +405,6 @@ class Attention(nn.Module):
                 return self.paged_attention_triton
             else:
                 # Qwen only uses gluon pa decode when bs=64
-                return self.paged_attention_triton if ctx.batch_size == 64 else self.paged_attention_asm
+                if ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION:
+                    return self.paged_attention_triton if ctx.batch_size == 64 else self.paged_attention_asm
+                return self.paged_attention_asm


### PR DESCRIPTION
## Motivation
Gluon pa is not fully verified with llama, thus disable this path for llama for now.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
