### PR TITLE
re-enable ATOM_ENABLE_DS_QKNORM_QUANT_FUSION regardless of ATOM_USE_T…

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1213,12 +1213,12 @@ class DeepseekV2MLAAttention(nn.Module):
             prefix=prefix,
         )
 
-        # When ATOM_ENABLE_DS_QKNORM_QUANT_FUSION is turned on, self.fuse_qknorm_quant is turned on only if use_triton_gemm() and (FP8 or FP4),
+        # When ATOM_ENABLE_DS_QKNORM_QUANT_FUSION is turned on, self.fuse_qknorm_quant is turned on only if FP8 or (use_triton_gemm() and FP4),
         self.prefix = prefix
         self.quant_dtype = None
         self.fuse_qknorm_quant = False
         if quant_config is not None and ENABLE_DS_QKNORM_QUANT_FUSION:
-            if (quant_config["quant_dtype"] == dtypes.fp8 or quant_config["quant_dtype"] == dtypes.fp4x2) and use_triton_gemm():
+            if quant_config["quant_dtype"] == dtypes.fp8 or (quant_config["quant_dtype"] == dtypes.fp4x2 and use_triton_gemm()):
                 self.quant_dtype = quant_config["quant_dtype"]
                 self.fuse_qknorm_quant = True
 
@@ -1232,7 +1232,7 @@ class DeepseekV2MLAAttention(nn.Module):
             hidden_states, hidden_states_scale = hidden_states
 
         if self.q_lora_rank is not None:
-            if self.fuse_qknorm_quant:
+            if self.fuse_qknorm_quant and use_triton_gemm():
                 q_c, q_c_scale, kv_c_normed, k_pe = _fuse_qkv_a_proj_reduce_rmsnorm_quant(
                     hidden_states,
                     self.fused_qkv_a_proj.weight,
@@ -1263,7 +1263,25 @@ class DeepseekV2MLAAttention(nn.Module):
                     dim=-1,
                 )
                 # fuse q_c norm + kv_c norm + quant of hidden_states_or_q_c
-                hidden_states_or_q_c = self.q_a_layernorm(q_c)
+                if self.fuse_qknorm_quant:
+                    (hidden_states_or_q_c,
+                    hidden_states_or_q_c_scale), _, kv_c_normed, _ = _fuse_rmsnorm_quant(
+                        q_c,
+                        self.q_a_layernorm.weight,
+                        self.q_a_layernorm.eps,
+                        kv_c,
+                        self.kv_a_layernorm.weight,
+                        self.kv_a_layernorm.eps,
+                        None,
+                        dtype_quant=self.quant_dtype,
+                        shuffle=False,
+                        scale_shuffle_padding=False,
+                        group_size=128,
+                        output_unquantized_inp1=False,
+                        transpose_scale=True,
+                    )
+                else:
+                    hidden_states_or_q_c = self.q_a_layernorm(q_c)
         else:
             hidden_states_or_q_c = hidden_states
             kv_c, k_pe = torch.split(self.kv_a_proj_with_mqa(hidden_states, hidden_states_scale),


### PR DESCRIPTION
This PR re-enables ATOM_ENABLE_DS_QKNORM_QUANT_FUSION by default

server:
```
python -m atom.entrypoints.openai_server \
    --model /data/deepseek-ai/DeepSeek-R1-0528/ \
    -tp 8 \
    --kv_cache_dtype fp8 \
    --server-port 8989 2>&1 | tee server.out
```

lm_eval:
```
model=/data/deepseek-ai/DeepSeek-R1-0528/
batch_size=65
lm_eval --model local-completions \
        --model_args model=${model},base_url=http://localhost:8989/v1/completions,num_concurrent=${batch_size},max_retries=1,tokenized_requests=False \
        --tasks gsm8k \
        --num_fewshot 3 \
        2>&1 | tee eval.log
```

results:
```
local-completions ({'model': '/data/deepseek-ai/DeepSeek-R1-0528/', 'base_url': 'http://localhost:8989/v1/completions', 'num_concurrent': 65, 'max_retries': 1, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 3, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9477|±  |0.0061|
|     |       |strict-match    |     3|exact_match|↑  |0.9401|±  |0.0065|
```