### PR TITLE
feat: Add fused attention output + RMSNorm support for GPT-OSS

### DIFF
--- a/atom/models/gpt_oss.py
+++ b/atom/models/gpt_oss.py
@@ -43,6 +43,10 @@ from atom.model_ops.moe import FusedMoE
 # from vllm.model_executor.layers.fused_moe.config import FusedMoEParallelConfig
 from atom.model_ops.layernorm import RMSNorm
 from atom.model_ops.linear import QKVParallelLinear, RowParallelLinear, ReplicatedLinear
+from atom.utils import envs
+
+# Check if fused attention output + RMSNorm is enabled
+ATOM_ENABLE_FUSED_ATTN_OUTPUT_RMSNORM = envs.ATOM_ENABLE_FUSED_ATTN_OUTPUT_RMSNORM
 
 # from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from aiter.rotary_embedding import get_rope
@@ -233,6 +237,17 @@ class TransformerBlock(torch.nn.Module):
         self.post_attention_layernorm = RMSNorm(
             config.hidden_size, eps=1e-5, x_pad_to_multiple=256
         )
+        
+        # Enable fused attention output + RMSNorm if available
+        self.use_fused_attn_rmsnorm = ATOM_ENABLE_FUSED_ATTN_OUTPUT_RMSNORM
+        if self.use_fused_attn_rmsnorm:
+            try:
+                from aiter.ops.triton.fusions.fused_attn_output_rmsnorm import (
+                    fused_attn_output_rmsnorm,
+                )
+                self._fused_attn_output_rmsnorm = fused_attn_output_rmsnorm
+            except ImportError:
+                self.use_fused_attn_rmsnorm = False
 
     def forward(
         self,
@@ -248,8 +263,19 @@ class TransformerBlock(torch.nn.Module):
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
         hidden_states = self.self_attn(hidden_states, positions)
 
-        # Fully Connected
-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        # Fully Connected - use fused kernel if enabled
+        if self.use_fused_attn_rmsnorm:
+            # Fused: attention_output + residual + RMSNorm in one kernel
+            # Supports x_pad_to_multiple=256 for MoE compatibility
+            hidden_states, residual = self._fused_attn_output_rmsnorm(
+                hidden_states,
+                self.post_attention_layernorm.weight,
+                epsilon=self.post_attention_layernorm.eps,
+                residual=residual,
+                x_pad_to_multiple=self.post_attention_layernorm.x_pad_to_multiple,
+            )
+        else:
+            hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         output = self.mlp(hidden_states)[:, : self.hidden_size]
         return output, residual
 

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -46,6 +46,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_SILU_MUL_QUANT", "1"
     )
     == "1",
+    # Enable fused attention output + residual + RMSNorm kernel for GPT-OSS
+    # This fuses 3 operations into 1 kernel for better performance
+    "ATOM_ENABLE_FUSED_ATTN_OUTPUT_RMSNORM": lambda: os.getenv(
+        "ATOM_ENABLE_FUSED_ATTN_OUTPUT_RMSNORM", "0"
+    )
+    == "1",
 }
 
 


### PR DESCRIPTION
## Summary

Integrate AITER's new \used_attn_output_rmsnorm\ kernel into GPT-OSS model.

## Changes

- Add \ATOM_ENABLE_FUSED_ATTN_OUTPUT_RMSNORM\ environment variable (default: disabled)
- Update \TransformerBlock\ to use fused kernel when enabled
- Supports \x_pad_to_multiple\ for MoE compatibility

## Usage

\\\ash
export ATOM_ENABLE_FUSED_ATTN_OUTPUT_RMSNORM=1
\\\

## Dependencies

**Requires**: AITER PR https://github.com/ROCm/aiter/pull/1863 merged first

## Performance Benefits

- Reduces kernel launch overhead (3 kernels -> 1)
- Saves memory bandwidth
- Expected ~5-8% E2E improvement for GPT-OSS prefill