### PR TITLE
[DS-FP4](fix): fix ds fp4 weight loading and accuracy

### DIFF
--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -59,7 +59,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         quant_config = atom_config.quant_config
         if quant_config["quant_dtype"] == dtypes.fp4x2:
             quant_config = QuantizationConfig()
-        
+
         self.mtp_block = DeepseekV2DecoderLayer(
             prefix=prefix,
             config=self.config,


### PR DESCRIPTION
## Motivation

This PR aims to support DeepSeek FP4 MTP functionality and fix accuracy issues.

We utilized the new quantized ds-fp4-mtp weights, fixed the model loading component, used the latest aiter(784270966) main branch, and completed support for DeepSeek FP4 accuracy MTP.

## Test Plan

**Notice**: please make sure this pr(https://github.com/ROCm/ATOM/pull/190) has been merged before testing.

Download new deepseek-fp4-mtp weights(https://huggingface.co/amd/DeepSeek-R1-0528-mtp-mxfp4).

**Server**
```
MODEL_PATH="/data/pretrained-models/deepseek-ai/DeepSeek-R1-0528-mtp-mxfp4"

python -m  atom.entrypoints.openai_server \
            --model $MODEL_PATH \
            -tp 8 \
            --block-size 16 \
            --method mtp
```
**Client**
```
MODEL_PATH="/data/pretrained-models/deepseek-ai/DeepSeek-R1-0528-mtp-mxfp4"

python -m  atom.entrypoints.openai_server \
            --model $MODEL_PATH \
            -tp 8 \
            --block-size 16 \
            --method mtp
```
## Test Result

<img width="515" height="73" alt="image" src="https://github.com/user-attachments/assets/553cafdf-984f-48bb-be46-6add1bc63411" />

Deepseek fp4 mtp accuracy is very close to non-mtp accuracy, but the mtp acceptance rate is only around 73%, which is 90% in vllm framework.  
