### PR TITLE
[QUARK-401] Add support for Kimi-K2.5 models

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -549,7 +549,7 @@ class QuantizationConfig:
             packed_modules_mapping if packed_modules_mapping is not None else {}
         )
         # for special models
-        if model_type == "deepseek_mtp" or model_type == "deepseek_v3":
+        if model_type in ("deepseek_mtp", "deepseek_v3", "kimi_k2"):
             if hasattr(hf_config, "q_lora_rank") and hf_config.q_lora_rank is not None:
                 self.packed_modules_mapping = {
                     "q_a_proj": ("fused_qkv_a_proj", 0),
@@ -598,6 +598,13 @@ class QuantizationConfig:
 _CONFIG_REGISTRY: dict[str, str] = {
     "deepseek_v32": "deepseek_v3",
     "glm_moe_dsa": "deepseek_v3",  # GLM 5.0 MoE, structure similar to DeepSeek v3.2
+    "kimi_k2": "deepseek_v3",
+}
+
+
+_MULTIMODAL_MODEL_TYPES: dict[str, str] = {
+    # Maps multimodal model_type -> key in config_dict for the text sub-config
+    "kimi_k25": "text_config",
 }
 
 
@@ -612,6 +619,35 @@ def get_hf_config(model: str) -> PretrainedConfig:
         if token and token.strip():
             return token
         return None
+
+    # For multimodal models, extract the text sub-config so the rest of ATOM
+    # (which is text-only today) works transparently.
+    if model_type in _MULTIMODAL_MODEL_TYPES:
+        text_config_key = _MULTIMODAL_MODEL_TYPES[model_type]
+        text_config_dict = config_dict.get(text_config_key, {}).copy()
+        # Remove auto_map to avoid trust_remote_code issues
+        text_config_dict.pop("auto_map", None)
+        # Propagate quantization_config from root level into text config
+        # (quantization_config lives alongside text_config, not inside it).
+        if (
+            "quantization_config" not in text_config_dict
+            and "quantization_config" in config_dict
+        ):
+            text_config_dict["quantization_config"] = config_dict["quantization_config"]
+        text_model_type = text_config_dict.get("model_type", "deepseek_v3")
+        mapped_type = _CONFIG_REGISTRY.get(text_model_type, text_model_type)
+        config_class = AutoConfig.for_model(mapped_type)
+        hf_config = config_class.from_dict(text_config_dict)
+        # Override architectures so that ATOM selects the correct model class
+        # which can handle the multimodal weight prefix during loading.
+        original_arch = config_dict.get("architectures", [])
+        if original_arch:
+            hf_config.architectures = original_arch
+        # Propagate top-level token IDs if missing in text config
+        for field in ("bos_token_id", "eos_token_id", "pad_token_id"):
+            if getattr(hf_config, field, None) is None and field in config_dict:
+                setattr(hf_config, field, config_dict[field])
+        return hf_config
 
     if model_type in _CONFIG_REGISTRY:
         config_class = AutoConfig.for_model(_CONFIG_REGISTRY[model_type])

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -59,6 +59,7 @@ support_model_arch_dict = {
     "GlmMoeDsaForCausalLM": "atom.models.deepseek_v2.GlmMoeDsaForCausalLM",
     "Glm4MoeForCausalLM": "atom.models.glm4_moe.Glm4MoeForCausalLM",
     "Qwen3NextForCausalLM": "atom.models.qwen3_next.Qwen3NextForCausalLM",
+    "KimiK25ForConditionalGeneration": "atom.models.kimi_k25.KimiK25ForCausalLM",
 }
 # seed = 34567
 # np.random.seed(seed)
@@ -609,6 +610,7 @@ class ModelRunner:
             "deepseek_v32",
             "deepseek_mtp",
             "glm_moe_dsa",
+            "kimi_k2",
         ):
             return self.hf_text_config.kv_lora_rank is not None
         elif self.hf_text_config.model_type == "eagle":

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -245,6 +245,7 @@ def load_model(
 
     packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
     weights_mapping = getattr(model, "weights_mapping", {})
+    skip_weight_prefixes = getattr(model, "skip_weight_prefixes", [])
     params_dict = dict(model.named_parameters())
 
     # Pre-index expert_mapping by weight_name_part for O(1) lookup.
@@ -286,6 +287,13 @@ def load_model(
             if "mtp" in name and not spec_decode:
                 continue
             if name.endswith("kv_scale") or "inv_freq" in name:
+                continue
+            # Skip weights matching model-defined prefixes (e.g. vision encoder
+            # weights in multimodal checkpoints that are not needed for text-only
+            # inference).
+            if skip_weight_prefixes and any(
+                name.startswith(p) for p in skip_weight_prefixes
+            ):
                 continue
             if spec_decode:
                 if hf_config.model_type == "deepseek_mtp":

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2224,10 +2224,10 @@ class FusedMoE(torch.nn.Module):
             if load_shard_size != shard_size:
                 expert_data = expert_data.narrow(shard_dim, 0, load_shard_size)
         # w2, down_proj: Load into only logical weight of w2.
-        if expert_data.dtype != dtypes.fp4x2:
-            expert_data.copy_(loaded_weight)
-        else:
+        if expert_data.dtype == dtypes.fp4x2:
             expert_data.view(torch.uint8).copy_(loaded_weight.view(torch.uint8))
+        else:
+            expert_data.copy_(loaded_weight)
 
     def _load_single_value(
         self, param: torch.nn.Parameter, loaded_weight: torch.Tensor, expert_id: int

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1269,7 +1269,14 @@ class DeepseekV2MLAAttention(nn.Module):
                 base_quant_config = None
         else:
             source_quant_dtype = None
-            base_quant_config = quant_config
+            # Check exclude patterns (e.g. W4A8 checkpoints exclude attention)
+            if quant_config is not None and quant_config.should_ignore_layer_quant(
+                prefix
+            ):
+                quant_config = None
+                base_quant_config = None
+            else:
+                base_quant_config = quant_config
 
         if self.q_lora_rank is not None:
             # self.q_a_proj = ReplicatedLinear(self.hidden_size,

--- a/atom/models/kimi_k25.py
+++ b/atom/models/kimi_k25.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Inference-only Kimi-K2.5 model (text-only backbone).
+
+Kimi-K2.5 is a multimodal model whose language backbone is a DeepseekV3-style
+MoE transformer with MLA attention.  For text-only serving we load only the
+``language_model.*`` weights and delegate to the existing
+:class:`DeepseekV2ForCausalLM` implementation.
+
+Vision encoder and multimodal projector weights are skipped during loading
+via :pyattr:`skip_weight_prefixes`.
+"""
+
+from typing import Optional, Union
+
+import torch
+from torch import nn
+
+from atom.config import Config
+from atom.models.deepseek_v2 import DeepseekV2ForCausalLM
+from atom.models.utils import IntermediateTensors
+
+
+class KimiK25ForCausalLM(nn.Module):
+    """Kimi-K2.5 text-only wrapper around :class:`DeepseekV2ForCausalLM`.
+
+    The HuggingFace checkpoint stores the LLM weights under the
+    ``language_model.*`` prefix.  By placing the underlying model as
+    ``self.language_model``, PyTorch's parameter naming automatically
+    matches the checkpoint layout so no explicit prefix stripping is needed.
+
+    Vision tower and multimodal projector weights are excluded via
+    :pyattr:`skip_weight_prefixes` which the model loader respects.
+    """
+
+    # Weight prefixes that should be silently skipped during loading
+    # (these belong to the vision encoder / MM projector that we don't use).
+    skip_weight_prefixes = [
+        "vision_tower.",
+        "mm_projector.",
+    ]
+
+    def __init__(
+        self,
+        atom_config: Config,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = atom_config.hf_config
+
+        # The underlying LLM – named ``language_model`` so that its parameter
+        # names match the ``language_model.*`` keys in the checkpoint.
+        self.language_model = DeepseekV2ForCausalLM(
+            atom_config=atom_config,
+            prefix="",
+        )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+
+    # ---- properties forwarded to the inner model ----
+
+    @property
+    def packed_modules_mapping(self):
+        return self.language_model.packed_modules_mapping
+
+    # ---- forward / inference API ----
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.language_model.get_input_embeddings(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        return self.language_model(
+            input_ids, positions, intermediate_tensors, inputs_embeds
+        )
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> Optional[torch.Tensor]:
+        return self.language_model.compute_logits(hidden_states)
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.language_model.get_expert_mapping()

--- a/recipes/Kimi-K2.5.md
+++ b/recipes/Kimi-K2.5.md
@@ -1,0 +1,84 @@
+# Kimi-K2.5 Usage Guide
+
+[Kimi-K2.5](https://huggingface.co/moonshotai/Kimi-K2.5) is a native multimodal agentic model developed by Moonshot AI, built through continual pretraining on approximately 15 trillion mixed visual and text tokens atop Kimi-K2-Base.
+
+ATOM currently supports the **text-only** backbone of Kimi-K2.5 (i.e. the DeepseekV3-style MoE language model with MLA attention) in the **MXFP4** quantized variant:
+
+| Variant | Quantization | Description |
+|---------|-------------|-------------|
+| **MXFP4** | Quark MXFP4 (w4a4, e8m0 scales, group_size=32) | Routed MoE expert weights in microscale FP4 format. Activations quantised dynamically at runtime. |
+
+## Preparing environment
+Pull the nightly docker from https://hub.docker.com/r/rocm/atom/.
+All the operations below will be executed inside the container.
+
+## Launching server
+ATOM supports running the model with different parallelism, e.g., tensor parallel, expert parallel, data parallel.
+
+### MXFP4 variant on 8×MI355 GPUs (TP8)
+
+```bash
+#!/bin/bash
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+HSA_NO_SCRATCH_RECLAIM=1 python -m atom.entrypoints.openai_server \
+    --model <path-to-Kimi-K2.5-MXFP4> \
+    --trust-remote-code \
+    -tp 8 \
+    --kv_cache_dtype fp8
+```
+
+### BF16 (unquantized) on 4×MI355 GPUs (TP4)
+
+```bash
+#!/bin/bash
+export HIP_VISIBLE_DEVICES=0,1,2,3
+
+python -m atom.entrypoints.openai_server \
+    --model moonshotai/Kimi-K2.5 \
+    --trust-remote-code \
+    -tp 4 \
+    --kv_cache_dtype fp8
+```
+
+**Notes**:
+- The `--trust-remote-code` flag is required for loading the model's custom tokenizer.
+- Kimi-K2.5 uses a DeepseekV3-style architecture with MLA attention, so it leverages the same optimized kernels (MLA, FP8 KV cache, etc.) as DeepSeek models.
+- For the MXFP4 variant, `HSA_NO_SCRATCH_RECLAIM=1` is recommended for stability.
+- Non-MoE layers (attention, shared experts, dense MLPs) remain in BF16 for all quantized variants.
+
+## Performance baseline
+
+The following script can be used to benchmark the performance:
+
+```bash
+python -m atom.benchmarks.benchmark_serving \
+    --model=<model-path> --backend=vllm --base-url=http://localhost:$PORT \
+    --trust-remote-code --dataset-name=random \
+    --random-input-len=${ISL} --random-output-len=${OSL} \
+    --random-range-ratio 0.8 \
+    --num-prompts=$(( $CONC * 10 )) \
+    --max-concurrency=$CONC \
+    --request-rate=inf --ignore-eos \
+    --save-result --result-dir=${result_dir} --result-filename=$RESULT_FILENAME.json \
+    --percentile-metrics="ttft,tpot,itl,e2el"
+```
+
+### Accuracy test
+You can verify accuracy using the lm_eval framework:
+```bash
+lm_eval \
+--model local-completions \
+--model_args model=<model-path>,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True \
+--tasks gsm8k \
+--num_fewshot 3
+```
+
+## Architecture Details
+
+Kimi-K2.5 is a multimodal model (`KimiK25ForConditionalGeneration`) that wraps:
+- **Language model**: A DeepseekV3-style MoE transformer with MLA attention (61 layers, 7168 hidden size, 64 attention heads, 384 routed experts, 8 experts per token)
+- **Vision encoder**: MoonViT3d (not loaded in text-only mode)
+- **MM Projector**: PatchMerger (not loaded in text-only mode)
+
+ATOM loads only the language model backbone, skipping vision and projector weights for efficient text-only inference.

--- a/tests/test_kimi_k25.py
+++ b/tests/test_kimi_k25.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: MIT
+# Tests for Kimi-K2.5 model support (kimi_k25.py, config.py, loader.py,
+# model_runner.py).
+#
+# Covers: multimodal text_config extraction, config registry entries,
+# skip_weight_prefixes filtering, model arch registration, remap_layer_name
+# for kimi_k2, and KimiK25ForCausalLM wrapper class attributes.
+
+import contextlib
+import enum
+import importlib
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+ATOM_ROOT = str(Path(__file__).resolve().parent.parent)
+
+# ---------------------------------------------------------------------------
+# Mock primitives (same pattern as test_quant_config.py)
+# ---------------------------------------------------------------------------
+
+
+class QuantType(enum.IntEnum):
+    No = 0
+    per_Token = 1
+    per_Tensor = 2
+    per_1x32 = 3
+    per_1x128 = 4
+
+
+BF16 = "torch.bfloat16"
+FP8 = "mock_fp8"
+FP4X2 = "mock_fp4x2"
+INT8 = "mock_int8"
+
+D_DTYPES = {
+    "fp8": FP8,
+    "fp4x2": FP4X2,
+    "int8": INT8,
+    "int4x2": "mock_int4x2",
+    "i8": INT8,
+    "i4x2": "mock_int4x2",
+}
+
+
+class FakeHFConfig:
+    """Lightweight stand-in for transformers.PretrainedConfig."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    @staticmethod
+    def get_config_dict(model, **kwargs):
+        return {}, {}
+
+
+class FakeAutoConfig:
+    """Mock for transformers.AutoConfig."""
+
+    _registry: dict = {}
+
+    @classmethod
+    def for_model(cls, model_type):
+        return cls
+
+    @classmethod
+    def from_dict(cls, d):
+        return FakeHFConfig(**d)
+
+    @classmethod
+    def from_pretrained(cls, model, **kwargs):
+        return FakeHFConfig(model_type=model)
+
+
+# ---------------------------------------------------------------------------
+# Module loader — same approach as test_quant_config.py
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _temporary_mocks():
+    mock_torch = MagicMock()
+    mock_torch.bfloat16 = BF16
+
+    mock_aiter = types.ModuleType("aiter")
+    mock_aiter.QuantType = QuantType
+    mock_aiter.__path__ = []
+
+    mock_aiter_dtypes = types.ModuleType("aiter.utility.dtypes")
+    mock_aiter_dtypes.d_dtypes = D_DTYPES
+
+    mock_transformers = types.ModuleType("transformers")
+    mock_transformers.PretrainedConfig = FakeHFConfig
+    mock_transformers.AutoConfig = FakeAutoConfig
+    mock_transformers.GenerationConfig = MagicMock()
+
+    mock_atom_utils = types.ModuleType("atom.utils")
+    mock_atom_utils.envs = MagicMock()
+    mock_atom_utils.get_open_port = MagicMock(return_value=8000)
+
+    mock_dist_utils = types.ModuleType("atom.utils.distributed.utils")
+    mock_dist_utils.stateless_init_torch_distributed_process_group = MagicMock()
+
+    mock_plugin = types.ModuleType("atom.plugin")
+    mock_plugin.is_plugin_mode = MagicMock(return_value=False)
+    mock_plugin_config = types.ModuleType("atom.plugin.config")
+    mock_plugin_config.PluginConfig = MagicMock()
+
+    patches = {
+        "torch": mock_torch,
+        "torch.distributed": MagicMock(),
+        "aiter": mock_aiter,
+        "aiter.utility": types.ModuleType("aiter.utility"),
+        "aiter.utility.dtypes": mock_aiter_dtypes,
+        "transformers": mock_transformers,
+        "atom.utils": mock_atom_utils,
+        "atom.utils.distributed": types.ModuleType("atom.utils.distributed"),
+        "atom.utils.distributed.utils": mock_dist_utils,
+        "atom.plugin": mock_plugin,
+        "atom.plugin.config": mock_plugin_config,
+    }
+
+    saved = {}
+    for name, mock in patches.items():
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = mock
+    try:
+        yield
+    finally:
+        for name, orig in saved.items():
+            if orig is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = orig
+
+
+def _load_config():
+    path = os.path.join(ATOM_ROOT, "atom", "config.py")
+    spec = importlib.util.spec_from_file_location("_atom_config_kimi_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    with _temporary_mocks():
+        spec.loader.exec_module(mod)
+    return mod
+
+
+_m = _load_config()
+QuantizationConfig = _m.QuantizationConfig
+LayerQuantConfig = _m.LayerQuantConfig
+_CONFIG_REGISTRY = _m._CONFIG_REGISTRY
+_MULTIMODAL_MODEL_TYPES = _m._MULTIMODAL_MODEL_TYPES
+get_hf_config = _m.get_hf_config
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestConfigRegistry:
+    """Verify Kimi K2 / K2.5 entries in config registries."""
+
+    def test_kimi_k2_in_config_registry(self):
+        assert "kimi_k2" in _CONFIG_REGISTRY
+        assert _CONFIG_REGISTRY["kimi_k2"] == "deepseek_v3"
+
+    def test_kimi_k25_in_multimodal_registry(self):
+        assert "kimi_k25" in _MULTIMODAL_MODEL_TYPES
+        assert _MULTIMODAL_MODEL_TYPES["kimi_k25"] == "text_config"
+
+
+class TestGetHfConfigMultimodal:
+    """Test multimodal text_config extraction in get_hf_config."""
+
+    def _make_config_dict(self, **overrides):
+        """Build a realistic kimi_k25 config_dict."""
+        base = {
+            "model_type": "kimi_k25",
+            "architectures": ["KimiK25ForConditionalGeneration"],
+            "bos_token_id": 100000,
+            "eos_token_id": 100001,
+            "pad_token_id": 100002,
+            "quantization_config": {
+                "quant_method": "mxfp",
+                "quant_type": "mxfp4",
+            },
+            "text_config": {
+                "model_type": "kimi_k2",
+                "hidden_size": 7168,
+                "num_hidden_layers": 61,
+                "auto_map": {"AutoModel": "modeling.KimiK25Model"},
+            },
+        }
+        base.update(overrides)
+        return base
+
+    @contextlib.contextmanager
+    def _patch_get_config_dict(self, config_dict):
+        """Temporarily patch FakeHFConfig.get_config_dict."""
+        original = FakeHFConfig.get_config_dict
+
+        @staticmethod
+        def patched(model, **kwargs):
+            return config_dict, {}
+
+        FakeHFConfig.get_config_dict = patched
+        try:
+            yield
+        finally:
+            FakeHFConfig.get_config_dict = original
+
+    def test_extracts_text_config(self):
+        config_dict = self._make_config_dict()
+        with self._patch_get_config_dict(config_dict):
+            hf_config = get_hf_config("amd/Kimi-K2.5-MXFP4")
+
+        assert hf_config.hidden_size == 7168
+        assert hf_config.num_hidden_layers == 61
+
+    def test_propagates_quantization_config(self):
+        config_dict = self._make_config_dict()
+        with self._patch_get_config_dict(config_dict):
+            hf_config = get_hf_config("amd/Kimi-K2.5-MXFP4")
+
+        assert hasattr(hf_config, "quantization_config")
+        assert hf_config.quantization_config["quant_method"] == "mxfp"
+
+    def test_does_not_overwrite_existing_quant_config(self):
+        """If text_config already has quantization_config, don't override it."""
+        config_dict = self._make_config_dict()
+        config_dict["text_config"]["quantization_config"] = {
+            "quant_method": "inner",
+        }
+        with self._patch_get_config_dict(config_dict):
+            hf_config = get_hf_config("amd/Kimi-K2.5-MXFP4")
+
+        assert hf_config.quantization_config["quant_method"] == "inner"
+
+    def test_preserves_original_architectures(self):
+        config_dict = self._make_config_dict()
+        with self._patch_get_config_dict(config_dict):
+            hf_config = get_hf_config("amd/Kimi-K2.5-MXFP4")
+
+        assert hf_config.architectures == ["KimiK25ForConditionalGeneration"]
+
+    def test_propagates_token_ids(self):
+        config_dict = self._make_config_dict()
+        with self._patch_get_config_dict(config_dict):
+            hf_config = get_hf_config("amd/Kimi-K2.5-MXFP4")
+
+        assert hf_config.bos_token_id == 100000
+        assert hf_config.eos_token_id == 100001
+        assert hf_config.pad_token_id == 100002
+
+    def test_removes_auto_map_from_text_config(self):
+        """auto_map should be stripped to avoid trust_remote_code issues."""
+        config_dict = self._make_config_dict()
+        with self._patch_get_config_dict(config_dict):
+            hf_config = get_hf_config("amd/Kimi-K2.5-MXFP4")
+
+        assert not hasattr(hf_config, "auto_map")
+
+    def test_missing_text_config_uses_empty_dict(self):
+        """If text_config key is absent, should use empty dict."""
+        config_dict = self._make_config_dict()
+        del config_dict["text_config"]
+        with self._patch_get_config_dict(config_dict):
+            hf_config = get_hf_config("amd/Kimi-K2.5-MXFP4")
+
+        # Should still return a config (from empty dict), not crash
+        assert hf_config is not None
+
+
+class TestRemapLayerNameKimiK2:
+    """Verify remap_layer_name handles kimi_k2 model_type correctly."""
+
+    def test_kimi_k2_with_q_lora_rank(self):
+        """kimi_k2 should get deepseek-v3-style fused packed_modules_mapping."""
+        qcfg = QuantizationConfig(config=None)
+        qcfg.layer_quant_config = {
+            "*.q_a_proj": LayerQuantConfig(quant_type=QuantType.per_Token),
+            "*.gate_proj": LayerQuantConfig(quant_type=QuantType.per_1x32),
+        }
+        qcfg.exclude_layers = ["model.layers.0.q_a_proj"]
+
+        hf = FakeHFConfig(model_type="kimi_k2", q_lora_rank=512)
+        qcfg.remap_layer_name(hf)
+
+        # Should fuse q_a_proj -> fused_qkv_a_proj
+        assert "*.fused_qkv_a_proj" in qcfg.layer_quant_config
+        assert "*.q_a_proj" not in qcfg.layer_quant_config
+        # Should fuse gate_proj -> gate_up_proj
+        assert "*.gate_up_proj" in qcfg.layer_quant_config
+        assert "*.gate_proj" not in qcfg.layer_quant_config
+        # Exclude layers should also be remapped
+        assert "model.layers.0.fused_qkv_a_proj" in qcfg.exclude_layers
+
+    def test_kimi_k2_without_q_lora_rank(self):
+        """kimi_k2 without q_lora_rank should still fuse gate/up proj."""
+        qcfg = QuantizationConfig(config=None)
+        qcfg.layer_quant_config = {
+            "*.gate_proj": LayerQuantConfig(quant_type=QuantType.per_Token),
+        }
+        qcfg.exclude_layers = []
+
+        hf = FakeHFConfig(model_type="kimi_k2")
+        qcfg.remap_layer_name(hf)
+
+        assert "*.gate_up_proj" in qcfg.layer_quant_config
+        assert "*.gate_proj" not in qcfg.layer_quant_config
+
+
+class TestModelArchRegistration:
+    """Verify KimiK25ForConditionalGeneration is in model_runner."""
+
+    def test_kimi_k25_in_support_model_arch_dict(self):
+        path = os.path.join(ATOM_ROOT, "atom", "model_engine", "model_runner.py")
+        with open(path) as f:
+            content = f.read()
+        assert "KimiK25ForConditionalGeneration" in content
+        assert "atom.models.kimi_k25.KimiK25ForCausalLM" in content
+
+    def test_kimi_k2_in_is_deepseek_mla(self):
+        """kimi_k2 model_type should be recognized as MLA architecture."""
+        path = os.path.join(ATOM_ROOT, "atom", "model_engine", "model_runner.py")
+        with open(path) as f:
+            content = f.read()
+        # kimi_k2 should be in the is_deepseek_mla model_type tuple
+        assert '"kimi_k2"' in content
+
+
+class TestKimiK25ModelClass:
+    """Test the KimiK25ForCausalLM class attributes without instantiation."""
+
+    def test_skip_weight_prefixes_defined(self):
+        """Model class should define prefixes for vision/projector weights."""
+        path = os.path.join(ATOM_ROOT, "atom", "models", "kimi_k25.py")
+        with open(path) as f:
+            content = f.read()
+        assert "vision_tower." in content
+        assert "mm_projector." in content
+
+    def test_skip_weight_prefixes_values(self):
+        """Import the class attributes without full init to check values."""
+        path = os.path.join(ATOM_ROOT, "atom", "models", "kimi_k25.py")
+        with open(path) as f:
+            src = f.read()
+        # Execute in a sandbox with mocked imports
+        ns = {}
+        import torch as real_torch
+
+        mock_config = types.ModuleType("atom.config")
+        mock_config.Config = MagicMock()
+
+        mock_deepseek = types.ModuleType("atom.models.deepseek_v2")
+        mock_deepseek.DeepseekV2ForCausalLM = MagicMock()
+
+        mock_utils = types.ModuleType("atom.models.utils")
+        mock_utils.IntermediateTensors = MagicMock()
+
+        saved = {}
+        patches = {
+            "torch": real_torch,
+            "torch.nn": real_torch.nn,
+            "atom.config": mock_config,
+            "atom.models.deepseek_v2": mock_deepseek,
+            "atom.models.utils": mock_utils,
+        }
+        for name, mock in patches.items():
+            saved[name] = sys.modules.get(name)
+            sys.modules[name] = mock
+        try:
+            exec(compile(src, path, "exec"), ns)
+        finally:
+            for name, orig in saved.items():
+                if orig is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = orig
+
+        cls = ns["KimiK25ForCausalLM"]
+        assert cls.skip_weight_prefixes == ["vision_tower.", "mm_projector."]
+
+
+class TestSkipWeightPrefixesLogic:
+    """Test the skip_weight_prefixes filtering logic from the loader."""
+
+    @pytest.fixture
+    def skip_prefixes(self):
+        return ["vision_tower.", "mm_projector."]
+
+    def _should_skip(self, name, prefixes):
+        """Replicate the exact logic from loader.py."""
+        return prefixes and any(name.startswith(p) for p in prefixes)
+
+    def test_skips_vision_tower_weights(self, skip_prefixes):
+        assert self._should_skip("vision_tower.encoder.layer.0.weight", skip_prefixes)
+
+    def test_skips_mm_projector_weights(self, skip_prefixes):
+        assert self._should_skip("mm_projector.linear.weight", skip_prefixes)
+
+    def test_does_not_skip_language_model_weights(self, skip_prefixes):
+        assert not self._should_skip(
+            "language_model.model.layers.0.self_attn.q_proj.weight",
+            skip_prefixes,
+        )
+
+    def test_does_not_skip_lm_head(self, skip_prefixes):
+        assert not self._should_skip("language_model.lm_head.weight", skip_prefixes)
+
+    def test_does_not_skip_embed_tokens(self, skip_prefixes):
+        assert not self._should_skip(
+            "language_model.model.embed_tokens.weight", skip_prefixes
+        )
+
+    def test_empty_prefixes_skip_nothing(self):
+        assert not self._should_skip("vision_tower.weight", [])
+
+    def test_partial_name_match_is_prefix_only(self, skip_prefixes):
+        """'vision_tower' without the dot should not match 'vision_tower.'."""
+        assert not self._should_skip("vision_tower_extra", skip_prefixes)
+
+    def test_mm_projector_partial_no_match(self, skip_prefixes):
+        assert not self._should_skip("mm_projector_v2.weight", skip_prefixes)
+
+
+class TestLoaderSkipWeightPrefixesIntegration:
+    """Verify the loader.py actually reads skip_weight_prefixes from model."""
+
+    def test_loader_reads_skip_weight_prefixes(self):
+        """The loader should call getattr(model, 'skip_weight_prefixes', [])."""
+        path = os.path.join(ATOM_ROOT, "atom", "model_loader", "loader.py")
+        with open(path) as f:
+            content = f.read()
+        assert 'getattr(model, "skip_weight_prefixes", [])' in content
+
+    def test_loader_uses_startswith_for_filtering(self):
+        """The loader should use name.startswith(p) to match prefixes."""
+        path = os.path.join(ATOM_ROOT, "atom", "model_loader", "loader.py")
+        with open(path) as f:
+            content = f.read()
+        assert "name.startswith(p) for p in skip_weight_prefixes" in content


### PR DESCRIPTION
…l runner

- Updated configuration to include mappings for Kimi-K25.
- Modified model loading to skip unnecessary weight prefixes for multimodal models.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
