### PR TITLE
Fix CI container name collision for parallel matrix jobs

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -190,6 +190,9 @@ jobs:
     if: ${{ needs.pre-checks.result == 'success' && (!github.event.pull_request || github.event.pull_request.draft == false) }}
     runs-on: ${{ matrix.runner }}
 
+    env:
+      CONTAINER_NAME: atom_test_${{ strategy.job-index }}
+
     steps:
       - name: Kill all Docker containers and clean up workspace
         if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && matrix.runner == 'atom-mi355-8gpu.predownload'


### PR DESCRIPTION
## Summary
- Multiple matrix jobs sharing the same runner used a hardcoded container name `atom_test`, causing cleanup steps to kill sibling jobs' containers and leading to intermittent GPU OOM errors.
- Use `CONTAINER_NAME=atom_test_${{ strategy.job-index }}` so each job operates on its own container without interference.
- GPU isolation is already handled by `gha-render-devices` — the container name collision was the sole root cause.

## Changes
- Added `CONTAINER_NAME` env var using `strategy.job-index` for unique per-job container names
- Replaced all 12 hardcoded `atom_test` container references with `$CONTAINER_NAME`
- Used exact-match filter `name="^${CONTAINER_NAME}$"` in cleanup to avoid interfering with sibling jobs
- Docker image tag `atom_test:ci` left unchanged (shared image is fine)

## Test plan
- [ ] Verify CI passes with parallel jobs on shared runners (linux-atom-mi355-1)
- [ ] Confirm no container name collisions in job logs
- [ ] Verify cleanup step only stops/removes its own container