### PR TITLE
Add workflow to kill Docker containers and check ROCm on MI355 nodes

### DIFF
--- a/.github/workflows/kill-containers-rocm-check.yml
+++ b/.github/workflows/kill-containers-rocm-check.yml
@@ -1,0 +1,32 @@
+name: Kill Docker Containers and Check ROCm
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    if: github.ref == 'refs/heads/okakarpa/kill-containers-rocm-check-v2'
+    runs-on: atom-mi355-8gpu.predownload
+    strategy:
+      matrix:
+        node: [1, 2, 3]
+      max-parallel: 3
+      fail-fast: false
+    steps:
+      - name: Kill all Docker containers
+        run: |
+          echo "=== Node ${{ matrix.node }} - $(hostname) ==="
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            echo "Killing running containers..."
+            docker kill $containers
+            echo "Containers killed."
+          else
+            echo "No running containers found."
+          fi
+
+      - name: Show ROCm memory usage
+        run: rocm-smi --showmemuse
+
+      - name: Show ROCm PIDs
+        run: rocm-smi --showpids


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` workflow targeting `atom-mi355-8gpu.predownload` runners (3 nodes)
- Kills all running Docker containers on each node
- Runs `rocm-smi --showmemuse` and `rocm-smi --showpids` after cleanup
- Restricted to only run from this branch