### PR TITLE
Kill all Docker containers before 8gpu workloads launch

### DIFF
--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -81,9 +81,26 @@ jobs:
 
     runs-on: atom-mi355-8gpu.predownload
     steps:
+      - name: Kill all Docker containers
+        run: |
+          echo "=== Cleaning up containers on $(hostname) ==="
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+
+      - name: Show Docker containers
+        run: docker ps -a
+
+      - name: Show ROCm memory usage
+        run: rocm-smi --showmemuse
+
+      - name: Show ROCm GPU processes
+        run: rocm-smi --showpidgpus
+
       - name: Checkout ATOM repo
         uses: actions/checkout@v4
-      
+
       - name: Start CI container
         run: |
           echo "Clean up containers..."
@@ -145,7 +162,7 @@ jobs:
           RESULT_FILENAME=${{ env.RESULT_FILENAME }} .github/scripts/atom_test.sh benchmark $model_path
           ls -all .
           "
-      
+
       - name: Upload benchmark result
         uses: actions/upload-artifact@v4
         with:
@@ -183,9 +200,26 @@ jobs:
 
     runs-on: atom-mi355-8gpu.predownload
     steps:
+      - name: Kill all Docker containers
+        run: |
+          echo "=== Cleaning up containers on $(hostname) ==="
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+
+      - name: Show Docker containers
+        run: docker ps -a
+
+      - name: Show ROCm memory usage
+        run: rocm-smi --showmemuse
+
+      - name: Show ROCm GPU processes
+        run: rocm-smi --showpidgpus
+
       - name: Checkout ATOM repo
         uses: actions/checkout@v4
-      
+
       - name: Start CI container
         run: |
           echo "Clean up containers..."

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -81,6 +81,27 @@ jobs:
       GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
 
     steps:
+      - name: Kill all Docker containers
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: |
+          echo "=== Cleaning up containers on $(hostname) ==="
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+
+      - name: Show Docker containers
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: docker ps -a
+
+      - name: Show ROCm memory usage
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: rocm-smi --showmemuse
+
+      - name: Show ROCm GPU processes
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: rocm-smi --showpidgpus
+
       - name: Checkout ATOM repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Adds container cleanup steps as the first thing that runs on `atom-mi355-8gpu.predownload` nodes
- Kills all running Docker containers before any 8gpu workload launches
- Adds diagnostic steps after cleanup: `docker ps -a`, `rocm-smi --showmemuse`, `rocm-smi --showpidgpus`
- Applied to both `atom-test.yaml` and `atom-benchmark.yaml`