### PR TITLE
Fix prefix caching crash: recalculate num_new_tokens after block allocation

### DIFF
--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -276,6 +276,9 @@ class Scheduler:
                 break
             num_seqs_prefill += 1
             self.block_manager.allocate(seq)
+            # Recalculate after allocation: prefix caching may have updated
+            # seq.num_cached_tokens, reducing the actual number of new tokens.
+            num_new_tokens = seq.num_tokens - seq.num_cached_tokens
             num_batched_tokens += num_new_tokens
             seq.status = SequenceStatus.RUNNING
             seq.type = SequenceType.PREFILL


### PR DESCRIPTION
## Summary

- **Bug**: When prefix caching is enabled, the scheduler computed \
um_new_tokens\ *before* calling \lock_manager.allocate()\, which updates \seq.num_cached_tokens\ on cache hits. This caused an inflated token count in \ScheduledBatch\, leading to a shape mismatch (\ValueError\) in \prepare_prefill\ when the \positions\ array didn't match the expected buffer size.

- **Fix**: Recalculate \
um_new_tokens = seq.num_tokens - seq.num_cached_tokens\ immediately after \lock_manager.allocate(seq)\ so all downstream consumers (\
um_batched_tokens\, \
um_scheduled_tokens\, \scheduled_tokens\) use the correct post-cache-hit token count.

- **Tests**: Added 3 unit tests in \TestPrefixCaching\ covering: cache hit reduces token count, scheduled tokens contain only the non-cached suffix, and control test without prefix caching.

## Root Cause

\\\
scheduler.py (before fix):

  num_new_tokens = seq.num_tokens - seq.num_cached_tokens   # line 146: cached=0 -> all tokens
  ...
  self.block_manager.allocate(seq)                           # line 153: updates seq.num_cached_tokens!
  num_batched_tokens += num_new_tokens                       # line 154: uses STALE value
  ...
  num_scheduled_tokens.append(num_new_tokens)                # line 160: uses STALE value
\\\

This inflated \	otal_tokens_num_prefill\ propagated to \prepare_prefill()\ in \ackends.py\, which correctly sized the \positions\ array using the updated \
um_cached_tokens\, causing:
\\\
ValueError: could not broadcast input array from shape (X,) into shape (Y,)
\\\
where Y > X because the buffer was sized with inflated counts but the actual data was smaller.

## Test plan

- [x] All 26 scheduler tests pass (including 3 new prefix caching tests)
- [x] All existing block_manager, sequence, sampling_params, request tests pass
- [ ] E2E verification with Qwen3-235B-A22B + \--enable_prefix_caching\ on MI355X