### PR TITLE
[Perf][Qwen3-Next] Fused shared experts for qwen3_next

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -93,7 +93,7 @@ def load_model(
         for maybe_matching_name in maybe_matching_list:
             if maybe_matching_name in name:
                 return maybe_matching_name
-        return None 
+        return None
 
     packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
     weights_mapping = getattr(model, "weights_mapping", {})

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -5,6 +5,9 @@ import logging
 from dataclasses import dataclass
 from functools import partial as functools_partial
 from typing import Optional
+import triton
+import triton.language as tl
+
 
 import torch
 from aiter import (
@@ -643,10 +646,6 @@ class MLAAttention(nn.Module):
                 output = self._forward_decode(q_out, kv_cache, attn_metadata)
 
         return output
-
-
-import triton
-import triton.language as tl
 
 
 @triton.jit

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -301,11 +301,11 @@ class FusedMoEMethodBase(QuantizeMethodBase):
 
             # For FP8: use FP8 dtype for communication
             # For FP4/no quant: use bfloat16
-            mori_dtype = (
-                quant_config.quant_dtype
-                if is_fp8 and quant_type is not None
-                else torch.bfloat16
-            )
+            # mori_dtype = (
+            #     quant_config.quant_dtype
+            #     if is_fp8 and quant_type is not None
+            #     else torch.bfloat16
+            # )
             # mori_dtype = torch.bfloat16
 
             all_to_all_args = dict(
@@ -877,7 +877,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
     ) -> torch.Tensor:
         if self.use_triton:
             from atom.model_ops.fused_moe_triton import triton_kernel_moe_forward
-            assert fused_shared_experts_scoring_func is None, "triton kernel does not support fused shared experts func"
+
+            assert (
+                fused_shared_experts_scoring_func is None
+            ), "triton kernel does not support fused shared experts func"
 
             return triton_kernel_moe_forward(
                 x,
@@ -1471,7 +1474,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
-            assert self.quant_config["is_dynamic"] == True
+            assert self.quant_config["is_dynamic"]
 
         # Add the quantization method used (per tensor/grouped/channel)
         # to ensure the weight scales are loaded in properly
@@ -1512,7 +1515,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         # TODO (rob): refactor block quant into separate class.
         if self.block_quant:
-            assert self.quant_config["is_dynamic"] == True
+            assert self.quant_config["is_dynamic"]
             if self.need_normalize_e4m3fn_to_e4m3fnuz:
                 w13_weight, w13_weight_scale, w13_input_scale = (
                     normalize_e4m3fn_to_e4m3fnuz(
@@ -1834,7 +1837,6 @@ class FusedMoE(torch.nn.Module):
         self.moe_parallel_config = FusedMoEParallelConfig.make(
             tp_size, dp_size, atom_config
         )
-        tp_rank = 0 if self.tp_size == 1 else get_tp_group().rank_in_group
         self.global_num_experts = num_experts
         if self.use_ep:
             self.local_num_experts, self.expert_map = determine_expert_map(
@@ -2548,7 +2550,7 @@ class FusedMoE(torch.nn.Module):
                     if weight_name in [ckpt_gate_proj_name, ckpt_up_proj_name]
                     else "experts.w2_"
                 ),
-            f"experts.{expert_id}.{weight_name}.",
+                f"experts.{expert_id}.{weight_name}.",
                 expert_id,
                 shard_id,
             )

--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -203,7 +203,10 @@ class Qwen3NextSparseMoeBlock(nn.Module):
 
         # self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
 
-        if config.shared_expert_intermediate_size > 0 and not is_rocm_aiter_fusion_shared_expert_enabled():
+        if (
+            config.shared_expert_intermediate_size > 0
+            and not is_rocm_aiter_fusion_shared_expert_enabled()
+        ):
             self.shared_expert = Qwen3NextMLP(
                 hidden_size=config.hidden_size,
                 intermediate_size=config.shared_expert_intermediate_size,
@@ -225,7 +228,9 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             renormalize=config.norm_topk_prob,
             quant_config=quant_config,
             use_grouped_topk=False,
-            shared_expert_scoring_func='sigmoid' if self.shared_expert is None else None,
+            shared_expert_scoring_func=(
+                "sigmoid" if self.shared_expert is None else None
+            ),
             prefix=f"{prefix}.experts",
             config=config,
         )
@@ -860,7 +865,7 @@ class Qwen3NextForCausalLM(nn.Module):
         "gate_proj": ("gate_up_proj", 0),
         "up_proj": ("gate_up_proj", 1),
         ".gate.": (".gate.", 0),
-        "shared_expert_gate": ("gate", 1)
+        "shared_expert_gate": ("gate", 1),
     }
 
     def __init__(


### PR DESCRIPTION
## Motivation
Fusing shared experts in qwen3-next into moe in pure tp case. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
gsm8k test
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
### Accuracy Test
```
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8643|±  |0.0094|
|     |       |strict-match    |     5|exact_match|↑  |0.8461|±  |0.0099|
```

### Performance Test:
4k/1k
w/o fuse
``` 
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Maximum request concurrency:             64        
Benchmark duration (s):                  276.72    
Total input tokens:                      1024000   
Total generated tokens:                  255944    
Request throughput (req/s):              0.93      
Output token throughput (tok/s):         924.92    
Peak output token throughput (tok/s):    1575.00   
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          4625.40   
---------------Time to First Token----------------
Mean TTFT (ms):                          24370.17  
Median TTFT (ms):                        16635.07  
P99 TTFT (ms):                           54174.55  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          37.98     
Median TPOT (ms):                        36.34     
P99 TPOT (ms):                           70.04     
---------------Inter-token Latency----------------
Mean ITL (ms):                           37.94     
Median ITL (ms):                         32.26     
P99 ITL (ms):                            90.17     
==================================================

```

w fused

```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Maximum request concurrency:             64        
Benchmark duration (s):                  259.51    
Total input tokens:                      1024000   
Total generated tokens:                  255942    
Request throughput (req/s):              0.99      
Output token throughput (tok/s):         986.24    
Peak output token throughput (tok/s):    1620.00   
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          4932.07   
---------------Time to First Token----------------
Mean TTFT (ms):                          23286.07  
Median TTFT (ms):                        16533.55  
P99 TTFT (ms):                           51791.78  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.38     
Median TPOT (ms):                        33.86     
P99 TPOT (ms):                           65.38     
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.34     
Median ITL (ms):                         29.70     
P99 ITL (ms):                            94.75     
==================================================

```
We can see there is about 7% throughput gain over e2e scenario and benefits both ttft and tpot on fused shared expert case.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
