### PR TITLE
CI: add nightly schedule and run_on_pr matrix option

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -12,8 +12,8 @@ on:
       - 'LICENSE'
       - '.gitignore'
   schedule:
-    # Nightly at 00:00 Beijing time (16:00 UTC)
-    - cron: '0 16 * * *'
+    # Nightly at 01:00 Beijing time (17:00 UTC)
+    - cron: '0 17 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Trigger workflow at midnight Beijing time; allow excluding models from PR runs via run_on_pr. Use step-level condition to avoid matrix in job if.

