### PR TITLE
Fix Kimi-K2-Instruct Quark MXFP4

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -99,7 +99,7 @@ def load_model(
         ):
             if load_dummy:
                 continue
-            if name.endswith("kv_scale"):
+            if name.endswith("kv_scale") or "inv_freq" in name:
                 continue
             if spec_decode:
                 if hf_config.model_type == "deepseek_mtp":


### PR DESCRIPTION
"inv_freq" is not needed from checkpoint, so skip it

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Serve:
```
python -m atom.entrypoints.openai_server  \
  --model /scratch/models/Kimi-K2-Instruct-0905-MXFP4/ \
  -tp 4 \
  --kv_cache_dtype fp8 \
  --trust-remote-code
```
lm-eval
```
lm_eval --model local-completions  \
  --model_args model=/opt/group/huggingface/pretrained_models/amd/Kimi-K2-Instruct-0905-MXFP4/,base_url=http://localhost:8000/v1/completions,num_concurrent=100,max_retries=3,tokenized_requests=False  \
  --tasks gsm8k \
  --num_fewshot 5 \
  --trust_remote_code
```

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9469|±  |0.0062|
|     |       |strict-match    |     5|exact_match|↑  |0.9469|±  |0.0062|
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
