### PR TITLE
Fix typos, dead code, uninitialized variable, and improve error handling

### DIFF
--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -62,7 +62,7 @@ class EngineCore:
         )
         self.input_thread.start()
 
-        self.profile_enbaled = config.torch_profiler_dir is not None
+        self.profile_enabled = config.torch_profiler_dir is not None
         init_exit_handler(self)
         self._init_data_parallel(config)
 
@@ -283,11 +283,11 @@ class EngineCore:
                     break
 
     def start_profiler(self):
-        if self.profile_enbaled:
+        if self.profile_enabled:
             self.runner_mgr.call_func("start_profiler")
 
     def stop_profiler(self):
-        if self.profile_enbaled:
+        if self.profile_enabled:
             logger.info("Profiler stopping...")
             self.runner_mgr.call_func("stop_profiler", wait_out=True)
             logger.info("Profiler stopped.")

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -35,7 +35,6 @@ class LLMEngine:
         # Set data parallel size in config
         config.parallel_config.data_parallel_size = data_parallel_size
         self.data_parallel_size = data_parallel_size
-        self.rquest_ids = set()
         self.io_processor = InputOutputProcessor(
             config, self.tokenizer, config.kv_cache_block_size
         )

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -382,6 +382,7 @@ class Scheduler:
             if self.spec_stats:
                 self.spec_stats.update(num_new_token)
             idx = fwd_output.req_ids.index(seq.id)
+            num_rejected = 0
             if is_deferred_out or self.use_spec:
                 num_rejected = fwd_output.num_rejected[idx]
                 num_bonus = fwd_output.num_bonus[idx]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -121,7 +121,10 @@ class TestPostprocess:
 
     def _output(self, seq_id, tokens):
         return ScheduledBatchOutput(
-            token_ids={seq_id: tuple(tokens)}, draft_token_ids=None
+            token_ids={seq_id: tuple(tokens)},
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
         )
 
     def test_appends_token(self, scheduler, seq_factory):
@@ -166,7 +169,12 @@ class TestPostprocess:
         sched.schedule()
         finished = sched.postprocess(
             list(sched.running),
-            ScheduledBatchOutput(token_ids={seq.id: (99,)}, draft_token_ids=None),
+            ScheduledBatchOutput(
+                token_ids={seq.id: (99,)},
+                num_rejected=None,
+                num_bonus=None,
+                draft_token_ids=None,
+            ),
         )
         assert len(finished) == 1
         assert "stop_99" in finished[0].leave_reason


### PR DESCRIPTION
While reading through the codebase I noticed a handful of small issues. Most are cosmetic, but one (`num_rejected` being uninitialized on the non-speculative path) causes a runtime `UnboundLocalError`.

- `Scheduler.postprocess`: `num_rejected` is assigned inside the speculative branch but referenced unconditionally at line 410. Fixed by initializing to 0 before the conditional. This also unblocked 7 failing unit tests in `test_scheduler.py::TestPostprocess`.
- Fixed typo `profile_enbaled` in `engine_core.py` (3 occurrences).
- Removed dead field `self.rquest_ids = set()` in `llm_engine.py` (assigned in `__init__`, never read).
- Replaced two bare `assert` checks with `ValueError` in `Config.__post_init__` and `get_quant_config` (bare asserts get stripped by `python -O`).
- Fixed double comma in speculative tokens error message and `incompatiable` typo in `CompilationConfig` docstring.
- Updated `ScheduledBatchOutput` constructor calls in tests to include the `num_rejected` and `num_bonus` positional args added since the tests were written. All 71 GPU-free unit tests now pass.

Tested with `python -m pytest tests/ --ignore=tests/test_utils.py --ignore=tests/test_envs.py` (71/71 pass). The two excluded test files have a pre-existing triton/torch version mismatch unrelated to this PR.