### PR TITLE
Fix block allocation for multi-token decode (speculative decoding)

### DIFF
--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -307,9 +307,10 @@ class Scheduler:
 
         # decode
         num_seqs_decode = 0
+        num_new_tokens = self.mtp_k + 1
         while self.running and num_seqs_decode < self.max_num_seqs:
             seq = self.running.popleft()
-            while not self.block_manager.can_append(seq):
+            while not self.block_manager.can_append(seq, num_new_tokens):
                 if self.running:
                     self.preempt(self.running.pop())
                 else:
@@ -319,7 +320,6 @@ class Scheduler:
                 if seq.spec_token_ids.size > 0:
                     scheduled_spec_decode_tokens[seq.id] = seq.spec_token_ids
                 num_seqs_decode += 1
-                num_new_tokens = self.mtp_k + 1
                 self.block_manager.may_append(seq, num_new_tokens)
                 scheduled_seqs[seq.id] = seq
                 seq.type = SequenceType.DECODE
@@ -382,6 +382,7 @@ class Scheduler:
             if self.spec_stats:
                 self.spec_stats.update(num_new_token)
             idx = fwd_output.req_ids.index(seq.id)
+            num_rejected = 0
             if is_deferred_out or self.use_spec:
                 num_rejected = fwd_output.num_rejected[idx]
                 num_bonus = fwd_output.num_bonus[idx]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -121,7 +121,10 @@ class TestPostprocess:
 
     def _output(self, seq_id, tokens):
         return ScheduledBatchOutput(
-            token_ids={seq_id: tuple(tokens)}, draft_token_ids=None
+            token_ids={seq_id: tuple(tokens)},
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
         )
 
     def test_appends_token(self, scheduler, seq_factory):
@@ -166,7 +169,12 @@ class TestPostprocess:
         sched.schedule()
         finished = sched.postprocess(
             list(sched.running),
-            ScheduledBatchOutput(token_ids={seq.id: (99,)}, draft_token_ids=None),
+            ScheduledBatchOutput(
+                token_ids={seq.id: (99,)},
+                num_rejected=None,
+                num_bonus=None,
+                draft_token_ids=None,
+            ),
         )
         assert len(finished) == 1
         assert "stop_99" in finished[0].leave_reason


### PR DESCRIPTION
`BlockManager.can_append` and `may_append` assumed at most 1 new token per decode step. With speculative decoding (`mtp_k > 0`), the scheduler generates `mtp_k + 1` tokens per step, which can cross multiple block boundaries. The old code under-allocated KV cache blocks.

The old `can_append` used a boolean expression — `(len(seq) % block_size == 1)` evaluates to `True`/`False`, so it checked for at most 1 free block regardless of how many tokens were about to be generated. Fixed to accept `num_new_tokens` and compute the exact block deficit.

`may_append` had a similar issue: `needed_blocks = (seq_len + block_size - 1) // block_size` only accounted for the current sequence length, not the tokens about to be generated. The `elif seq_len % block_size == 0` branch also only updated the hash but never allocated new blocks. Restructured into two phases: (1) register the hash if the last block just became full, (2) allocate blocks for `ceil((seq_len + num_new_tokens) / block_size)`.

On the scheduler side, hoisted `num_new_tokens = self.mtp_k + 1` before the `can_append` loop so the check uses the correct token count. Also initialized `num_rejected = 0` before the speculative decoding branch in `postprocess` to fix an `UnboundLocalError` on the non-speculative path.

Added 15 new GPU-free unit tests covering multi-token `can_append`/`may_append` scenarios (boundary conditions, exact-fit, insufficient blocks) and prefix caching during decode (hash registration, cache reuse by new sequences, multi-step prefix building). All 87 tests pass.

Test plan:
- `python -m pytest tests/ --ignore=tests/test_utils.py --ignore=tests/test_envs.py` — 87/87 pass
- Speculative decoding inference with `mtp_k > 0` and prefix caching enabled needs GPU validation
- Standard (non-speculative) inference should be regression-free
