### PR TITLE
fix: run all models on nightly schedule regardless of run_on_pr flag

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # run_on_pr: true = run on PR + push/schedule; false = nightly/schedule only
+          # run_on_pr: true = run on all events; false = skip on PR (still runs on push/schedule/workflow_dispatch)
           - model_name: "Meta-Llama-3-8B-Instruct"
             model_path: "meta-llama/Meta-Llama-3-8B-Instruct"
             extraArgs: "--kv_cache_dtype fp8 --gpu-memory-utilization 0.3"
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Kill all Docker containers and clean up workspace
-        if: matrix.run_on_pr == true && matrix.runner == 'atom-mi355-8gpu.predownload'
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && matrix.runner == 'atom-mi355-8gpu.predownload'
         run: |
           echo "=== Cleaning up containers on $(hostname) ==="
           containers=$(docker ps -q)
@@ -202,28 +202,28 @@ jobs:
           docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "ls -la /workspace/ && rm -rf /workspace/*" || true 
 
       - name: Show Docker containers
-        if: matrix.run_on_pr == true && matrix.runner == 'atom-mi355-8gpu.predownload'
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && matrix.runner == 'atom-mi355-8gpu.predownload'
         run: docker ps -a
 
       - name: Show ROCm memory usage
-        if: matrix.run_on_pr == true && matrix.runner == 'atom-mi355-8gpu.predownload'
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && matrix.runner == 'atom-mi355-8gpu.predownload'
         run: rocm-smi --showmemuse
 
       - name: Show ROCm GPU processes
-        if: matrix.run_on_pr == true && matrix.runner == 'atom-mi355-8gpu.predownload'
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && matrix.runner == 'atom-mi355-8gpu.predownload'
         run: rocm-smi --showpidgpus
 
       - name: Checkout ATOM repo
-        if: matrix.run_on_pr == true
+        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
         uses: actions/checkout@v4
       
       - name: Docker Login
-        if: matrix.run_on_pr == true && !github.event.pull_request.head.repo.fork
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && !github.event.pull_request.head.repo.fork
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Generate Dockerfile for forked repo
-        if: matrix.run_on_pr == true && github.event.pull_request.head.repo.fork
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && github.event.pull_request.head.repo.fork
         run: |
           cat <<EOF > Dockerfile.mod
           FROM ${{ env.ATOM_BASE_NIGTHLY_IMAGE }}
@@ -255,7 +255,7 @@ jobs:
           EOF
 
       - name: Build Docker image for forked repo
-        if: matrix.run_on_pr == true && github.event.pull_request.head.repo.fork
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && github.event.pull_request.head.repo.fork
         run: |
           docker build --network=host \
             --no-cache \
@@ -263,7 +263,7 @@ jobs:
             -f Dockerfile.mod .
 
       - name: Start CI container
-        if: matrix.run_on_pr == true
+        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
         run: |
           echo "Clean up containers..."
           (docker ps -aq -f name=atom_test | xargs -r docker stop) || true
@@ -320,12 +320,12 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: Check shm size
-        if: matrix.run_on_pr == true
+        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
         run: |
           docker exec atom_test df -h /dev/shm
 
       - name: Download models
-        if: matrix.run_on_pr == true
+        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
         run: |
           if [ -d "/models" ]; then
             echo "/models directory found, downloading model to /models/${{ matrix.model_path }}"
@@ -338,7 +338,7 @@ jobs:
           fi
 
       - name: Run ATOM simple inference
-        if: matrix.run_on_pr == true
+        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
         timeout-minutes: 30
         run: |
           # Run the inference and capture output
@@ -375,7 +375,7 @@ jobs:
           cat atom_test_output.txt
 
       - name: Compare output with golden outputs
-        if: matrix.run_on_pr == true && false
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && false
         timeout-minutes: 30
         # TODO: skip for all test until it's fixed
         run: |
@@ -390,7 +390,7 @@ jobs:
           fi
       
       - name: Run ATOM accuracy test
-        if: matrix.run_on_pr == true
+        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
         timeout-minutes: 30
         run: |
           set -euo pipefail
@@ -411,7 +411,7 @@ jobs:
           " 2>&1 | tee atom_accuracy_output.txt
       
       - name: Check accuracy test results
-        if: matrix.run_on_pr == true && success()
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && success()
         run: |
           result_file=$(ls -1t accuracy_test_results/*.json 2>/dev/null | head -n 1)
           if [ -z "$result_file" ] || [ ! -f "$result_file" ]; then
@@ -435,20 +435,20 @@ jobs:
           fi
 
       - name: Collect Test Summary
-        if: matrix.run_on_pr == true && success()
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && success()
         run: |
           echo "Accuracy Test Summary for ${{ matrix.model_name }}:" >> $GITHUB_STEP_SUMMARY
           awk '/\|Tasks\|Version\|/,/^$/ { if (NF > 0) print }' atom_accuracy_output.txt >> $GITHUB_STEP_SUMMARY
 
       - name: Upload output
-        if: matrix.run_on_pr == true && always()
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.model_name }}_atom_test_output.txt
           path: atom_test_output.txt
 
       - name: Clean Up
-        if: matrix.run_on_pr == true && always()
+        if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && always()
         run: |
           # TODO: run a separate container for cleanup of the workspace due to permission issue to remove some pyc files under __pycache__ whose owners are root.
           # We should use non-root user to run the test to avoid this issue.


### PR DESCRIPTION
Models with `run_on_pr: false` (e.g., Qwen3-235B-A22B-Instruct-2507-MXFP4) were being skipped on all events including nightly schedule, because step conditions only checked `matrix.run_on_pr == true`. This change adds `github.event_name != 'pull_request'` so that `run_on_pr: false` only skips on PR events, while still running on schedule, push, and workflow_dispatch.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
