### PR TITLE
Sort benchmark summary table by Model and Max concurrency

### DIFF
--- a/.github/scripts/summarize.py
+++ b/.github/scripts/summarize.py
@@ -22,10 +22,22 @@ def main():
 
     in_path = Path(sys.argv[1])
 
-    files = sorted(in_path.glob("*.json"))
-    for json_path in files:
+    # Load all benchmark results first
+    results = []
+    for json_path in in_path.glob("*.json"):
         with open(json_path, encoding="utf-8") as f:
             data = json.load(f)
+        results.append(data)
+
+    # Sort by Model name, then by Max concurrency (numerically)
+    results.sort(
+        key=lambda d: (
+            d.get("model_id", "").split("/")[-1],
+            int(d.get("max_concurrency", 0)),
+        )
+    )
+
+    for data in results:
         row = [
             datetime.datetime.strptime(data.get("date", ""), "%Y%m%d-%H%M%S").strftime(
                 "%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
## Summary
- Sort benchmark summary table by **Model** name first, then by **Max concurrency** (numerically ascending)
- Previously the table was ordered by filename, making it hard to compare results across concurrency levels for the same model
- Now results are grouped by model with concurrency in ascending order (1, 2, 4, 8, 16, 32, 64, 128, 256)

## Test plan
- [ ] Trigger a benchmark workflow run and verify the summary table is sorted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)