### PR TITLE
Add ISL/OSL columns to benchmark summary table

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -68,4 +68,12 @@ if [ "$TYPE" == "benchmark" ]; then
     --request-rate=inf --ignore-eos \
     --save-result --percentile-metrics="ttft,tpot,itl,e2el" \
     --result-dir=. --result-filename=${RESULT_FILENAME}.json
+
+  # Inject ISL/OSL into result JSON for summary table
+  if [ -f "${RESULT_FILENAME}.json" ]; then
+    jq --argjson isl "$ISL" --argjson osl "$OSL" \
+      '. + {random_input_len: $isl, random_output_len: $osl}' \
+      "${RESULT_FILENAME}.json" > "${RESULT_FILENAME}.tmp" && \
+      mv "${RESULT_FILENAME}.tmp" "${RESULT_FILENAME}.json"
+  fi
 fi

--- a/.github/scripts/summarize.py
+++ b/.github/scripts/summarize.py
@@ -15,8 +15,8 @@ def main():
         sys.exit(1)
 
     summary_header = """\
-| Date | Backend | Model | Best of | Number of prompts | Request rate | Burstiness | Max concurrency | Duration | Completed | Total input tokens | Total output tokens | Request throughput | Request goodput | Output throughput | Total token throughput | Mean TTFT (ms) | Median TTFT (ms) | Std TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | Std TPOT (ms) | P99 TPOT (ms) | Mean ITL (ms) | Median ITL (ms) | Std ITL (ms) | P99 ITL (ms) | Mean E2EL (ms) | Median E2EL (ms) | Std E2EL (ms) | P99 E2EL (ms) |
-| :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |\
+| Date | Backend | Model | ISL | OSL | Best of | Number of prompts | Request rate | Burstiness | Max concurrency | Duration | Completed | Total input tokens | Total output tokens | Request throughput | Request goodput | Output throughput | Total token throughput | Mean TTFT (ms) | Median TTFT (ms) | Std TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | Std TPOT (ms) | P99 TPOT (ms) | Mean ITL (ms) | Median ITL (ms) | Std ITL (ms) | P99 ITL (ms) | Mean E2EL (ms) | Median E2EL (ms) | Std E2EL (ms) | P99 E2EL (ms) |
+| :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |\
     """
     print(summary_header)
 
@@ -27,12 +27,21 @@ def main():
     for json_path in in_path.glob("*.json"):
         with open(json_path, encoding="utf-8") as f:
             data = json.load(f)
+        # Parse ISL/OSL from filename if not in JSON
+        # Filename format: {model}-{ISL}-{OSL}-{CONC}-{RATIO}.json
+        if "random_input_len" not in data or "random_output_len" not in data:
+            parts = json_path.stem.rsplit("-", 4)
+            if len(parts) == 5:
+                data.setdefault("random_input_len", int(parts[1]))
+                data.setdefault("random_output_len", int(parts[2]))
         results.append(data)
 
-    # Sort by Model name, then by Max concurrency (numerically)
+    # Sort by Model name, then by ISL, OSL, and Max concurrency (numerically)
     results.sort(
         key=lambda d: (
             d.get("model_id", "").split("/")[-1],
+            int(d.get("random_input_len", 0)),
+            int(d.get("random_output_len", 0)),
             int(d.get("max_concurrency", 0)),
         )
     )
@@ -44,6 +53,8 @@ def main():
             ),
             "ATOM",
             data.get("model_id", "").split("/")[-1],
+            data.get("random_input_len", ""),
+            data.get("random_output_len", ""),
             data.get("best_of", ""),
             data.get("num_prompts", ""),
             data.get("request_rate", ""),


### PR DESCRIPTION
## Summary
- Add ISL (Input Sequence Length) and OSL (Output Sequence Length) columns to the benchmark summary table in GitHub Actions
- Inject `random_input_len` and `random_output_len` into benchmark result JSON via `atom_test.sh`
- `summarize.py` reads ISL/OSL from JSON, with fallback to parsing from filename for backward compatibility
- Sort results by Model → ISL → OSL → Concurrency for better readability

## Test plan
- [ ] Trigger a nightly benchmark run and verify ISL/OSL columns appear in the summary table
- [ ] Verify backward compatibility with old result JSON files (filename fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)