### PR TITLE
[Refactor] refactor quant_config for layer-wise quantization

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -2,12 +2,13 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import enum
+import fnmatch
 import hashlib
 import logging
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, cast, Optional, Union
 
 import torch
 from aiter import QuantType
@@ -250,126 +251,304 @@ class CompilationConfig:
             ]
 
 
-class QuantizationConfig(dict):
+class LayerQuantConfig(dict):
     def __init__(
         self,
         quant_type=QuantType.No,
         quant_dtype=torch.bfloat16,
         is_dynamic=True,
+        quant_method="",
         quant_name="",
-        quant_method=None,
-        exclude_layers: Optional[list[str]] = None,
     ):
+        """
+        Core components of layer_quant
+        """
         super().__init__()
         self["quant_type"] = quant_type if quant_type is not None else QuantType.No
         self["quant_dtype"] = quant_dtype if quant_dtype is not None else torch.bfloat16
-        self["quant_name"] = quant_name
         self["is_dynamic"] = is_dynamic
         self["quant_method"] = quant_method
-        self["exclude_layers"] = exclude_layers if exclude_layers is not None else []
+        self["quant_name"] = quant_name
+
+
+class QuantizationConfig:
+    def __init__(self, config: PretrainedConfig = None):
+        if config is None:
+            self.torch_dtype = torch.bfloat16
+            self.hf_quant_config = None
+            self.global_quant_config = LayerQuantConfig()
+            self.layer_quant_config = {}
+            self.exclude_layers = []
+            self.quant_method = ""
+            return
+
+        self.torch_dtype = getattr(config, "torch_dtype", "bf16")
+        self.hf_quant_config = getattr(config, "quantization_config", None)
+        self.global_quant_config = None
+        self.layer_quant_config = {}
+        self.exclude_layers = []
+
+        if self.hf_quant_config is None:
+            self.global_quant_config = LayerQuantConfig(
+                quant_type=QuantType.No, quant_dtype=self.torch_dtype
+            )
+            self.quant_method = ""
+            return
+
+        self.quant_method = self.hf_quant_config.get("quant_method", "")
+        if self.quant_method == "quark":
+            layer_quant_config_dict = cast(
+                dict[str, Any], self.hf_quant_config.get("layer_quant_config", {})
+            )
+            for layer_name, layer_cfg in layer_quant_config_dict.items():
+                self.layer_quant_config[layer_name] = self.parse_quark_config_dict(
+                    layer_cfg
+                )
+
+            global_quant_config_dict = cast(
+                dict[str, Any], self.hf_quant_config.get("global_quant_config", {})
+            )
+            self.global_quant_config = self.parse_quark_config_dict(
+                global_quant_config_dict
+            )
+
+            self.exclude_layers = cast(
+                list[str], self.hf_quant_config.get("exclude", [])
+            )
+        else:
+            self.parse_other_config()
 
     def get_name(self):
-        return self["quant_name"]
-
-    def compute_hash(self) -> str:
         """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
+        Returns the quantization method name.
         """
-        factors: list[Any] = []
-        factors.append(self["quant_type"])
-        factors.append(self["quant_dtype"])
-        factors.append(self["quant_name"])
-        factors.append(self["is_dynamic"])
-        factors.append(self["quant_method"])
-        # assert_hashable(str_factors)
-        return hashlib.sha256(str(factors).encode()).hexdigest()
+        return self.quant_method
 
+    def parse_quark_config_dict(self, config: dict) -> LayerQuantConfig:
+        quant_type = None
+        quant_dtype = None
+        is_dynamic = True
+        weight_config = cast(dict[str, Any], config.get("weight", {}))
+        input_config = cast(dict[str, Any], config.get("input_tensors", {}))
+        weight_qscheme = cast(str, weight_config.get("qscheme", ""))
+        weight_dtype = weight_config.get("dtype", "")
 
-def get_quant_config(config: PretrainedConfig) -> QuantizationConfig:
-    torch_dtype = getattr(config, "dtype", "bf16")
-    orig_quant_config = getattr(config, "quantization_config", None)
-    if orig_quant_config is None:
-        return QuantizationConfig(
-            quant_type=QuantType.No,
-            quant_dtype=torch_dtype,
-        )
-
-    quant_method = orig_quant_config.get("quant_method", None)
-    RE_QUANT_BLOCKSIZE = r"\'(?:group_size|weight_block_size)\'\:\s*(?:\[\n*)\s*(\d+),"
-    orig_quant_config_str = str(orig_quant_config)
-    if quant_method == "compressed-tensors" or "channel'," in orig_quant_config_str:
-        quant_type = QuantType.per_Token
-    elif group_size := re.search(RE_QUANT_BLOCKSIZE, orig_quant_config_str):
-        group_size = int(group_size.group(1))
-        assert group_size in (32, 128), f"Unsupported group size {group_size}"
-        if group_size == 128:
-            quant_type = QuantType.per_1x128
-        elif group_size == 32:
+        # quant_type
+        if weight_qscheme == "per_channel":
+            quant_type = QuantType.per_Token
+        elif weight_qscheme == "per_tensor":
+            quant_type = QuantType.per_Tensor
+        elif weight_qscheme == "per_group":
+            # Currently, quark only supports group_size=32
             quant_type = QuantType.per_1x32
-    else:
-        quant_type = QuantType.per_Tensor
+        else:
+            quant_type = QuantType.No
 
-    RE_QUANT_DTYPE = r"\'(?:d?type|weight_dtype|quant_method)\'\:\s*\'(\w+)\'"
-    quant_dtype = None
-    m = re.search(RE_QUANT_DTYPE, orig_quant_config_str)
-    if m and m.group(1).lower() in ["fp8", "fp4", "int8", "int4", "fp8_e4m3", "mxfp4"]:
-        dtype = m.group(1).lower().split("_")[0]
-        if dtype == "mxfp4":
-            dtype = "fp4"
+        # quant_dtype
+        dtype = weight_dtype.split("_")[0]
         if dtype.endswith("4"):
             dtype += "x2"
         quant_dtype = d_dtypes[dtype]
-    else:
-        bit_match = re.search(r"\'(?:num_)?bits\'\:\s*(\d+)", orig_quant_config_str)
-        if bit_match:
-            bit = int(bit_match.group(1))
-            dtype_match = re.search(RE_QUANT_DTYPE, orig_quant_config_str)
-            if dtype_match:
-                dtype = dtype_match.group(1).lower()
-                dtype_prefix = "i" if dtype.startswith("int") else "fp"
-            else:
-                dtype_prefix = "i"
-            quant_dtype_str = (
-                f"{dtype_prefix}{bit}" if bit != 4 else f"{dtype_prefix}{bit}x2"
-            )
-            quant_dtype = d_dtypes.get(quant_dtype_str, None)
-    assert (
-        quant_dtype is not None
-    ), f"Cannot parse quant dtype from {orig_quant_config_str}"
-    if quant_dtype == d_dtypes["fp4x2"]:
-        quant_type = QuantType.per_1x32
 
-    RE_STATIC_QUANT = r"\'(?:activation_scheme)\'\:\s*\'(static)\'"
-    if re.search(RE_STATIC_QUANT, orig_quant_config_str):
-        is_dynamic = False
-    else:
-        is_dynamic = True
-    if quant_method == "compressed-tensors":
-        exclude_layers_key = "ignore"
-    elif quant_method == "quark":
-        exclude_layers_key = "exclude"
-    else:
-        logger.warning(
-            f"Using 'ignore' as key for exclude layers with quant_method {quant_method}, \
-                       please double check the quantization config."
+        # is_dynamic
+        if input_config:
+            # input_dtype = input_config.get("dtype")
+            # input_qscheme = cast(str, input_config.get("qscheme"))
+            is_dynamic = cast(bool, input_config.get("is_dynamic"))
+        return LayerQuantConfig(
+            quant_type=quant_type,
+            quant_dtype=quant_dtype,
+            is_dynamic=is_dynamic,
+            quant_method="quark",
         )
-        exclude_layers_key = "ignore"
-    exclude_layers = orig_quant_config.get(exclude_layers_key, None)
-    return QuantizationConfig(
-        quant_type,
-        quant_dtype,
-        is_dynamic,
-        quant_method=quant_method,
-        exclude_layers=exclude_layers,
-    )
+
+    # TODO: For now, it's just a temporary migration.
+    # We should subsequently refine them in a targeted manner.
+    def parse_other_config(self):
+        RE_QUANT_BLOCKSIZE = (
+            r"\'(?:group_size|weight_block_size)\'\:\s*(?:\[\n*)\s*(\d+),"
+        )
+        orig_quant_config = self.hf_quant_config
+        quant_method = self.quant_method
+        orig_quant_config_str = str(orig_quant_config)
+        if quant_method == "compressed-tensors" or "channel'," in orig_quant_config_str:
+            quant_type = QuantType.per_Token
+        elif group_size := re.search(RE_QUANT_BLOCKSIZE, orig_quant_config_str):
+            group_size = int(group_size.group(1))
+            assert group_size in (32, 128), f"Unsupported group size {group_size}"
+            if group_size == 128:
+                quant_type = QuantType.per_1x128
+            elif group_size == 32:
+                quant_type = QuantType.per_1x32
+        else:
+            quant_type = QuantType.per_Tensor
+
+        RE_QUANT_DTYPE = r"\'(?:d?type|weight_dtype|quant_method)\'\:\s*\'(\w+)\'"
+        quant_dtype = None
+        m = re.search(RE_QUANT_DTYPE, orig_quant_config_str)
+        if m and m.group(1).lower() in [
+            "fp8",
+            "fp4",
+            "int8",
+            "int4",
+            "fp8_e4m3",
+            "mxfp4",
+        ]:
+            dtype = m.group(1).lower().split("_")[0]
+            if dtype == "mxfp4":
+                dtype = "fp4"
+            if dtype.endswith("4"):
+                dtype += "x2"
+            quant_dtype = d_dtypes[dtype]
+        else:
+            bit_match = re.search(r"\'(?:num_)?bits\'\:\s*(\d+)", orig_quant_config_str)
+            if bit_match:
+                bit = int(bit_match.group(1))
+                dtype_match = re.search(RE_QUANT_DTYPE, orig_quant_config_str)
+                if dtype_match:
+                    dtype = dtype_match.group(1).lower()
+                    dtype_prefix = "i" if dtype.startswith("int") else "fp"
+                else:
+                    dtype_prefix = "i"
+                quant_dtype_str = (
+                    f"{dtype_prefix}{bit}" if bit != 4 else f"{dtype_prefix}{bit}x2"
+                )
+                quant_dtype = d_dtypes.get(quant_dtype_str, None)
+        assert (
+            quant_dtype is not None
+        ), f"Cannot parse quant dtype from {orig_quant_config_str}"
+        if quant_dtype == d_dtypes["fp4x2"]:
+            quant_type = QuantType.per_1x32
+
+        RE_STATIC_QUANT = r"\'(?:activation_scheme)\'\:\s*\'(static)\'"
+        if re.search(RE_STATIC_QUANT, orig_quant_config_str):
+            is_dynamic = False
+        else:
+            is_dynamic = True
+        if quant_method == "compressed-tensors":
+            exclude_layers_key = "ignore"
+        else:
+            logger.warning(
+                f"Using 'ignore' as key for exclude layers with quant_method "
+                f"{quant_method}, please double check the quantization config."
+            )
+            exclude_layers_key = "ignore"
+        exclude_layers = orig_quant_config.get(exclude_layers_key, [])
+
+        self.global_quant_config = LayerQuantConfig(
+            quant_type=quant_type,
+            quant_dtype=quant_dtype,
+            is_dynamic=is_dynamic,
+            quant_method=quant_method,
+        )
+        self.exclude_layers = exclude_layers
+
+    def should_ignore_layer_quant(self, layer_name: str) -> bool:
+        # TODO: solve fused_mapping case
+        if layer_name is None or not self.exclude_layers:
+            return False
+        return any(
+            self.is_equal_or_regex_match(layer_name, ignore_str)
+            for ignore_str in self.exclude_layers
+        )
+
+    def is_equal_or_regex_match(
+        self, layer_name: str, ignore_str: str, check_contains: bool = False
+    ) -> bool:
+        """Match the target string or regular expression"""
+        if ignore_str.startswith("re:"):
+            # case "re:model.layers.*self_attn.*", remove the 're:' prefix
+            pattern = ignore_str[3:]
+            if re.search(pattern, layer_name):
+                return True
+        # case exclude_layer like "model.layers.0.self_attn.q_a_proj" (dpsk-attn)
+        # a common prefix for linear layers in attn like "model.layers.0.self_attn"
+        elif check_contains:
+            return layer_name.lower() in ignore_str.lower()
+        elif ignore_str == layer_name:
+            return True
+        return False
+
+    def get_layer_quant_config(self, layer_name: str) -> LayerQuantConfig:
+        if self.should_ignore_layer_quant(layer_name=layer_name):
+            # return unquantized config
+            return LayerQuantConfig(quant_dtype=self.torch_dtype)
+        # layer quant config
+        layer_quant_config = None
+        if self.layer_quant_config:
+
+            def _matches_pattern(layer_name, pattern):
+                if "*" not in pattern:
+                    return layer_name in pattern
+                return fnmatch.fnmatch(layer_name, pattern)
+
+            for name_pattern, config in self.layer_quant_config.items():
+                if _matches_pattern(layer_name, name_pattern):
+                    layer_quant_config = config
+
+        layer_quant_config = (
+            self.global_quant_config
+            if layer_quant_config is None
+            else layer_quant_config
+        )
+        # TODO: if use_aiter, we can customize the quantization format here, such as dpsk
+        # For FP4 and use_triton_gemm(), fused_qkv_a_proj and q_b_proj are AITER-Triton FP4 GEMMs but o_proj remains AITER BF16 GEMMs,
+        # For FP8 and use_triton_gemm(), fused_qkv_a_proj is AITER-Triton FP8 GEMMs while others remain AITER FP8 GEMMs
+
+        return layer_quant_config
+
+    def remap_layer_name(
+        self, hf_config: PretrainedConfig, packed_modules_mapping: dict | None = None
+    ):
+        model_type = hf_config.model_type
+        self.packed_modules_mapping = (
+            packed_modules_mapping if packed_modules_mapping is not None else {}
+        )
+        # for special models
+        if model_type == "deepseek_mtp" or model_type == "deepseek_v3":
+            if hasattr(hf_config, "q_lora_rank") and hf_config.q_lora_rank is not None:
+                self.packed_modules_mapping = {
+                    "q_a_proj": ("fused_qkv_a_proj", 0),
+                    "kv_a_proj_with_mqa": ("fused_qkv_a_proj", 1),
+                    "gate_proj": ("gate_up_proj", 0),
+                    "up_proj": ("gate_up_proj", 1),
+                }
+            else:
+                self.packed_modules_mapping = {
+                    "gate_proj": ("gate_up_proj", 0),
+                    "up_proj": ("gate_up_proj", 1),
+                }
+        elif model_type == "qwen3_moe" or model_type == "qwen3_next":
+            if getattr(hf_config, "mlp_only_layers", []):
+                self.packed_modules_mapping["gate_up_proj"] = ["gate_proj", "up_proj"]
+
+        # remap
+        def _remap_layer_name(name: str) -> list[str]:
+            for packed_key, packed_value in self.packed_modules_mapping.items():
+                # for self_attn.up_proj and self_attn.gate_up_proj
+                # up_proj in gate_up_proj, so add prefix .
+                if f".{packed_key}" in name:
+                    if isinstance(packed_value, list):
+                        # "gate_up_proj" → ["gate_proj", "up_proj"]
+                        return [
+                            name.replace(packed_key, part, 1) for part in packed_value
+                        ]
+                    else:
+                        # "gate_proj" → ("gate_up_proj", 0)
+                        packed_remap_part, _ = packed_value
+                        return [name.replace(packed_key, packed_remap_part, 1)]
+            return [name]
+
+        new_layer_quant_config = {}
+        for layer_name, layer_qconfig in self.layer_quant_config.items():
+            for remapped in _remap_layer_name(layer_name):
+                new_layer_quant_config[remapped] = layer_qconfig
+        self.layer_quant_config = new_layer_quant_config
+
+        new_exclude = []
+        for name in self.exclude_layers:
+            new_exclude.extend(_remap_layer_name(name))
+        self.exclude_layers = list(dict.fromkeys(new_exclude))
 
 
 _CONFIG_REGISTRY: dict[str, str] = {
@@ -590,9 +769,7 @@ class Config:
     port: int = 8006
     torch_profiler_dir: str | None = os.getenv("ATOM_TORCH_PROFILER_DIR", None)
     compilation_config: CompilationConfig = field(default_factory=CompilationConfig)
-    quant_config: QuantizationConfig = field(
-        default_factory=lambda: QuantizationConfig()
-    )
+    quant_config: QuantizationConfig = field(init=False)
     asyncio_mode: bool = False
     mark_trace: bool = False
     load_dummy: bool = False
@@ -638,7 +815,7 @@ class Config:
                 eos_ids := getattr(self.generation_config, "eos_token_id", None)
             ) is not None:
                 self.stop_token_ids = [eos_ids] if isinstance(eos_ids, int) else eos_ids
-        self.quant_config = get_quant_config(self.hf_config)
+        self.quant_config = QuantizationConfig(self.hf_config)
         hf_config_max_position_embeddings = getattr(
             self.hf_config, "max_position_embeddings", 8192
         )
@@ -696,8 +873,9 @@ class Config:
 
         # summarize vllm config
         vllm_factors: list[Any] = []
-        if self.quant_config:
-            vllm_factors.append(self.quant_config.compute_hash())
+        # TODO: fix here
+        # if self.quant_config:
+        # vllm_factors.append(self.quant_config.compute_hash())
 
         if self.compilation_config:
             vllm_factors.append(self.compilation_config.compute_hash())

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -571,6 +571,11 @@ class ModelRunner:
         )
 
         model_class = resolve_obj_by_qualname(support_model_arch_dict[hf_config.architectures[0]])  # type: ignore
+        # The model construction depends on quant_config,
+        # so we must complete the remapping for layers before constructing the model.
+        config.quant_config.remap_layer_name(
+            config.hf_config, getattr(model_class, "packed_modules_mapping", {})
+        )
         self.model = model_class(config)
         torch.set_default_device(None)
         load_model(self.model, config.model, config.hf_config, config.load_dummy)

--- a/atom/model_ops/activation.py
+++ b/atom/model_ops/activation.py
@@ -6,7 +6,7 @@ from typing import Optional
 from torch import nn
 import torch.nn.functional as F
 from aiter import silu_and_mul
-from atom.config import QuantizationConfig
+from atom.config import QuantizationConfig, LayerQuantConfig
 from aiter.jit.utils.torch_guard import torch_compile_guard
 
 from aiter import (
@@ -62,11 +62,14 @@ class SiluAndMul(nn.Module):
     ):
         super().__init__()
         self.fused_quant = fused_quant
-        if quant_config is None:
-            quant_config = QuantizationConfig()
+        layer_quant_config = (
+            LayerQuantConfig()
+            if quant_config is None
+            else quant_config.global_quant_config
+        )
 
-        quant_type = quant_config["quant_type"]
-        params_dtype = quant_config["quant_dtype"]
+        quant_type = layer_quant_config["quant_type"]
+        params_dtype = layer_quant_config["quant_dtype"]
         self.quant_type = quant_type
         self.params_dtype = params_dtype
 

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-import itertools
 from typing import Type
 
 import aiter

--- a/atom/model_ops/fused_moe/config.py
+++ b/atom/model_ops/fused_moe/config.py
@@ -198,7 +198,9 @@ class FusedMoEQuantConfig:
         if weight_dtype is None:
             weight_dtype = quant_dtype
 
-        a_shape, w_shape = _quant_flags_to_group_shape(quant_dtype, per_act_token_quant, block_shape)
+        a_shape, w_shape = _quant_flags_to_group_shape(
+            quant_dtype, per_act_token_quant, block_shape
+        )
         quant_config = FusedMoEQuantConfig(
             _a1=FusedMoEQuantDesc(quant_dtype, a_shape, a1_scale),
             _a2=FusedMoEQuantDesc(quant_dtype, a_shape, a2_scale),

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -8,7 +8,7 @@ from torch.overrides import (
     has_torch_function_unary,
     handle_torch_function,
 )
-from atom.config import QuantizationConfig
+from atom.config import QuantizationConfig, LayerQuantConfig
 from torch import nn
 from aiter import (
     rmsnorm2d_fwd,
@@ -187,10 +187,13 @@ class RMSNorm(nn.Module):
         self.use_fused_quant = fused_quant
         self.tp_size = get_tensor_model_parallel_world_size()
 
-        if quant_config is None:
-            quant_config = QuantizationConfig()
-        quant_type = quant_config["quant_type"]
-        params_dtype = quant_config["quant_dtype"]
+        layer_quant_config = (
+            LayerQuantConfig()
+            if quant_config is None
+            else quant_config.global_quant_config
+        )
+        quant_type = layer_quant_config["quant_type"]
+        params_dtype = layer_quant_config["quant_dtype"]
         self.quant_type = quant_type
         self.params_dtype = params_dtype
 

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -17,9 +17,8 @@ from aiter import (
 )
 from torch import nn
 
-from atom.config import QuantizationConfig, get_current_atom_config
+from atom.config import QuantizationConfig, get_current_atom_config, LayerQuantConfig
 from atom.model_ops.utils import normalize_e4m3fn_to_e4m3fnuz, requantize_with_max_scale
-from atom.models.utils import get_quant_config_for_layer
 
 # import torch.distributed as dist
 from aiter.dist.parallel_state import get_tp_group
@@ -207,13 +206,17 @@ class LinearBase(nn.Module):
         source_quant_dtype: torch.dtype | None = None,
         prefix: str = "",
     ):
-        if quant_config is None:
-            quant_config = QuantizationConfig()
-        self.source_quant_dtype = source_quant_dtype
-        quant_type = quant_config["quant_type"]
-        params_dtype = quant_config["quant_dtype"]
-        super().__init__()
         self.prefix = prefix
+        layer_quant_config = (
+            quant_config.get_layer_quant_config(prefix)
+            if quant_config is not None
+            else LayerQuantConfig()
+        )
+        quant_type = layer_quant_config["quant_type"]
+        params_dtype = layer_quant_config["quant_dtype"]
+        self.source_quant_dtype = source_quant_dtype
+        self.layer_quant_config = layer_quant_config
+        super().__init__()
         self.reduce_results = reduce_results
         self.input_size = input_size
         self.output_size = (
@@ -266,7 +269,7 @@ class LinearBase(nn.Module):
                     torch.empty(len(self.output_partition_sizes), 1, dtype=dtypes.fp32),
                     requires_grad=False,
                 )
-                if not quant_config["is_dynamic"]:
+                if not layer_quant_config["is_dynamic"]:
                     self.input_scale = nn.Parameter(
                         torch.empty(
                             len(self.output_partition_sizes), 1, dtype=dtypes.fp32
@@ -322,7 +325,10 @@ class LinearBase(nn.Module):
         ):
             param.data = param.data.view(loaded_weight.dtype)
         loaded_weight = post_process_func(loaded_weight)
-        if loaded_weight.shape != param.data.shape and loaded_weight.numel() == param.data.numel():
+        if (
+            loaded_weight.shape != param.data.shape
+            and loaded_weight.numel() == param.data.numel()
+        ):
             loaded_weight = loaded_weight.reshape(param.data.shape)
         param.data.copy_(loaded_weight)
 
@@ -466,6 +472,7 @@ class ReplicatedLinear(LinearBase):
         bias: bool = False,
         quant_config: Optional[QuantizationConfig] = None,
         source_quant_dtype: torch.dtype = None,
+        prefix: str = "",
         **kwargs,
     ):
         super().__init__(
@@ -475,7 +482,7 @@ class ReplicatedLinear(LinearBase):
             bias=bias,
             quant_config=quant_config,
             source_quant_dtype=source_quant_dtype,
-            prefix=kwargs.get("prefix", ""),
+            prefix=prefix,
         )
 
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor):
@@ -491,6 +498,7 @@ class ColumnParallelLinear(LinearBase):
         bias: bool = False,
         quant_config: Optional[QuantizationConfig] = None,
         source_quant_dtype: torch.dtype = None,
+        prefix: str = "",
         **kwargs,
     ):
         self.tp_dim = 0
@@ -501,7 +509,7 @@ class ColumnParallelLinear(LinearBase):
             bias,
             quant_config=quant_config,
             source_quant_dtype=source_quant_dtype,
-            prefix=kwargs.get("prefix", ""),
+            prefix=prefix,
         )
 
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor):
@@ -524,8 +532,6 @@ class MergedColumnParallelLinear(LinearBase):
         **kwargs,
     ):
         self.output_sizes = output_sizes
-        if quant_config is not None and prefix:
-            quant_config = get_quant_config_for_layer(quant_config, prefix)
         super().__init__(
             input_size,
             output_sizes,
@@ -569,6 +575,7 @@ class QKVZBAParallelLinear(ColumnParallelLinear):
         bias: bool = False,
         quant_config: Optional[QuantizationConfig] = None,
         source_quant_dtype: torch.dtype = None,
+        prefix: str = "",
         **kwargs,
     ):
         self.head_k_dim = head_k_dim
@@ -589,6 +596,7 @@ class QKVZBAParallelLinear(ColumnParallelLinear):
             bias=bias,
             quant_config=quant_config,
             source_quant_dtype=source_quant_dtype,
+            prefix=prefix,
         )
 
     def weight_loader(
@@ -637,6 +645,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         bias: bool = False,
         quant_config: Optional[QuantizationConfig] = None,
         source_quant_dtype: torch.dtype = None,
+        prefix: str = "",
         **kwargs,
     ):
         self.head_size = head_size
@@ -668,7 +677,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             bias=bias,
             quant_config=quant_config,
             source_quant_dtype=source_quant_dtype,
-            prefix=kwargs.get("prefix", ""),
+            prefix=prefix,
         )
 
     def weight_loader(
@@ -720,8 +729,6 @@ class RowParallelLinear(LinearBase):
         **kwargs,
     ):
         self.tp_rank = get_tp_group().rank_in_group
-        if quant_config is not None and prefix:
-            quant_config = get_quant_config_for_layer(quant_config, prefix)
         super().__init__(
             input_size,
             output_size,
@@ -762,6 +769,7 @@ class MergedReplicatedLinear(ReplicatedLinear):
         bias: bool = False,
         quant_config: Optional[QuantizationConfig] = None,
         source_quant_dtype: torch.dtype = None,
+        prefix: str = "",
         **kwargs,
     ):
         self.output_sizes = output_size
@@ -771,7 +779,7 @@ class MergedReplicatedLinear(ReplicatedLinear):
             bias=bias,
             quant_config=quant_config,
             source_quant_dtype=source_quant_dtype,
-            prefix=kwargs.get("prefix", ""),
+            prefix=prefix,
         )
 
     def weight_loader(

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -14,8 +14,12 @@ from aiter.jit.utils.chip_info import get_gfx
 from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
 from aiter.utility import fp4_utils
-from atom.config import Config, QuantizationConfig, get_current_atom_config
-from atom.models.utils import get_quant_config_for_layer
+from atom.config import (
+    Config,
+    QuantizationConfig,
+    get_current_atom_config,
+    LayerQuantConfig,
+)
 from atom.model_loader.weight_utils import set_weight_attrs
 from atom.model_ops.base_config import QuantizeMethodBase
 from atom.model_ops.fused_moe.config import (
@@ -630,7 +634,7 @@ direct_register_custom_op(
 
 
 class Mxfp4MoEMethod(FusedMoEMethodBase):
-    def __init__(self, quant_config: QuantizationConfig, moe: FusedMoEConfig):
+    def __init__(self, quant_config: LayerQuantConfig, moe: FusedMoEConfig):
         super().__init__(moe)
         self.quant_config = quant_config
         self.quant_type = self.quant_config["quant_type"]
@@ -964,7 +968,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 # Refer to CompressedTensorsW8A8Fp8MoEMethod in vllm
 class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
 
-    def __init__(self, quant_config: QuantizationConfig, moe: FusedMoEConfig):
+    def __init__(self, quant_config: LayerQuantConfig, moe: FusedMoEConfig):
         super().__init__(moe)
         self.quant_config = quant_config
         self.quant_type = quant_config["quant_type"]
@@ -1371,7 +1375,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         quant_config: The quantization config.
     """
 
-    def __init__(self, quant_config: QuantizationConfig, moe: FusedMoEConfig):
+    def __init__(self, quant_config: LayerQuantConfig, moe: FusedMoEConfig):
         super().__init__(moe)
         self.quant_config = quant_config
         self.quant_type = self.quant_config["quant_type"]
@@ -1462,9 +1466,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 requires_grad=False,
             )
             w2_weight_scale = torch.nn.Parameter(
-                torch.ones(
-                    num_experts, hidden_size, dtype=torch.float32
-                ),
+                torch.ones(num_experts, hidden_size, dtype=torch.float32),
                 requires_grad=False,
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
@@ -1525,28 +1527,20 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def _normalize_weights_and_scales(self, layer: nn.Module):
         if not self.need_normalize_e4m3fn_to_e4m3fnuz:
             return
-        w13_weight, w13_weight_scale, w13_input_scale = (
-            normalize_e4m3fn_to_e4m3fnuz(
-                layer.w13_weight, layer.w13_weight_scale, layer.w13_input_scale
-            )
+        w13_weight, w13_weight_scale, w13_input_scale = normalize_e4m3fn_to_e4m3fnuz(
+            layer.w13_weight, layer.w13_weight_scale, layer.w13_input_scale
         )
-        w2_weight, w2_weight_scale, w2_input_scale = (
-            normalize_e4m3fn_to_e4m3fnuz(
-                layer.w2_weight, layer.w2_weight_scale, layer.w2_input_scale
-            )
+        w2_weight, w2_weight_scale, w2_input_scale = normalize_e4m3fn_to_e4m3fnuz(
+            layer.w2_weight, layer.w2_weight_scale, layer.w2_input_scale
         )
         layer.w13_weight = nn.Parameter(w13_weight, requires_grad=False)
         layer.w13_weight_scale = nn.Parameter(w13_weight_scale, requires_grad=False)
         layer.w2_weight = nn.Parameter(w2_weight, requires_grad=False)
         layer.w2_weight_scale = nn.Parameter(w2_weight_scale, requires_grad=False)
         if w13_input_scale is not None:
-            layer.w13_input_scale = nn.Parameter(
-                w13_input_scale, requires_grad=False
-            )
+            layer.w13_input_scale = nn.Parameter(w13_input_scale, requires_grad=False)
         if w2_input_scale is not None:
-            layer.w2_input_scale = nn.Parameter(
-                w2_input_scale, requires_grad=False
-            )
+            layer.w2_input_scale = nn.Parameter(w2_input_scale, requires_grad=False)
 
     def process_weights_after_loading(self, layer: nn.Module) -> None:
         if self.block_quant:
@@ -1561,15 +1555,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self._normalize_weights_and_scales(layer)
 
         if not self.need_normalize_e4m3fn_to_e4m3fnuz:
-            layer.w13_weight = nn.Parameter(
-                layer.w13_weight.data, requires_grad=False
-            )
+            layer.w13_weight = nn.Parameter(layer.w13_weight.data, requires_grad=False)
             layer.w13_weight_scale = nn.Parameter(
                 layer.w13_weight_scale.data, requires_grad=False
             )
-            layer.w2_weight = nn.Parameter(
-                layer.w2_weight.data, requires_grad=False
-            )
+            layer.w2_weight = nn.Parameter(layer.w2_weight.data, requires_grad=False)
             layer.w2_weight_scale = nn.Parameter(
                 layer.w2_weight_scale.data, requires_grad=False
             )
@@ -1631,9 +1621,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         shuffle_weights(layer.w13_weight, layer.w2_weight)
 
-        layer.w13_weight_scale = torch.nn.Parameter(
-            max_w13_scales, requires_grad=False
-        )
+        layer.w13_weight_scale = torch.nn.Parameter(max_w13_scales, requires_grad=False)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
@@ -1850,10 +1838,15 @@ class FusedMoE(torch.nn.Module):
     ):
         super().__init__()
         self.prefix = prefix
-        self.params_dtype = (
-            quant_config["quant_dtype"] if quant_config else torch.get_default_dtype()
+        layer_quant_config = (
+            quant_config.get_layer_quant_config(prefix) if quant_config else None
         )
-        self.quant_config = quant_config
+        self.params_dtype = (
+            layer_quant_config["quant_dtype"]
+            if layer_quant_config
+            else torch.get_default_dtype()
+        )
+        self.layer_quant_config = layer_quant_config
         self.has_bias = has_bias
         # Note: here we guard against accessing the TP and DP groups when
         # uninitialized (this happens when testing)
@@ -1968,28 +1961,28 @@ class FusedMoE(torch.nn.Module):
         )
         self.moe_config = moe
 
-        if quant_config is not None and prefix:
-            quant_config = get_quant_config_for_layer(quant_config, prefix)
-
         # Note: get_quant_method will look at the layer's local_num_experts
         # for heuristic purposes, so it must be initialized first.
-        quant_method_str = quant_config.get("quant_method", None)
-        if quant_config["quant_type"] == QuantType.No:
+
+        quant_method_str = layer_quant_config.get("quant_method", None)
+        if layer_quant_config["quant_type"] == QuantType.No:
             self.quant_method: Optional[QuantizeMethodBase] = UnquantizedFusedMoEMethod(
                 moe
             )
         elif (
             quant_method_str == "compressed-tensors"
-            and quant_config["quant_dtype"] == dtypes.fp8
+            and layer_quant_config["quant_dtype"] == dtypes.fp8
         ):
             # Use CompressedTensorsFp8MoEMethod for compressed-tensors format
-            self.quant_method = CompressedTensorsFp8MoEMethod(quant_config, moe)
-        elif quant_config["quant_dtype"] == dtypes.fp8:
-            self.quant_method = Fp8MoEMethod(quant_config, moe)
-        elif quant_config["quant_dtype"] == dtypes.fp4x2:
-            self.quant_method = Mxfp4MoEMethod(quant_config, moe)
+            self.quant_method = CompressedTensorsFp8MoEMethod(layer_quant_config, moe)
+        elif layer_quant_config["quant_dtype"] == dtypes.fp8:
+            self.quant_method = Fp8MoEMethod(layer_quant_config, moe)
+        elif layer_quant_config["quant_dtype"] == dtypes.fp4x2:
+            self.quant_method = Mxfp4MoEMethod(layer_quant_config, moe)
         else:
-            raise ValueError(f"Unsupported quant dtype: {quant_config['quant_dtype']}")
+            raise ValueError(
+                f"Unsupported quant dtype: {layer_quant_config['quant_dtype']}"
+            )
 
         assert self.quant_method is not None
 
@@ -2273,7 +2266,7 @@ class FusedMoE(torch.nn.Module):
         shard_id: str = "",
         expert_id: int = 0,
     ) -> None:
-        if self.quant_config["quant_dtype"] == dtypes.fp4x2 and weight_name == "":
+        if self.layer_quant_config["quant_dtype"] == dtypes.fp4x2 and weight_name == "":
             self.mxf4_merged_weight_loader(param, loaded_weight)
             return
 
@@ -2351,7 +2344,7 @@ class FusedMoE(torch.nn.Module):
             # FusedMoeWeightScaleSupported
             # TODO @dsikka: once hardened, refactor to use vLLM Parameters
             # specific to each case
-            quant_method = self.quant_config["quant_type"]
+            quant_method = self.layer_quant_config["quant_type"]
             if quant_method == QuantType.per_Token:
                 self._load_per_channel_weight_scale(
                     shard_id=shard_id,

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -19,7 +19,7 @@ def is_rocm_aiter_fusion_shared_expert_enabled() -> bool:
     quant_config = config.quant_config
     is_shared_experts_excluded = False
     is_experts_excluded = False
-    exclude_layers = quant_config["exclude_layers"]
+    exclude_layers = quant_config.exclude_layers
     for layer in exclude_layers:
         if "shared_experts" in layer:
             is_shared_experts_excluded = True

--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -56,7 +56,8 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         )
 
         quant_config = atom_config.quant_config
-        if quant_config["quant_dtype"] == dtypes.fp4x2:
+        layer_quant_config = quant_config.get_layer_quant_config(prefix)
+        if layer_quant_config["quant_dtype"] == dtypes.fp4x2:
             quant_config = QuantizationConfig()
 
         self.mtp_block = DeepseekV2DecoderLayer(

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -82,7 +82,6 @@ from atom.models.utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
-    should_ignore_layer,
 )
 from atom.utils import envs
 from atom.utils.custom_register import direct_register_custom_op
@@ -1247,13 +1246,14 @@ class DeepseekV2MLAAttention(nn.Module):
 
         # For FP4 and use_triton_gemm(), fused_qkv_a_proj and q_b_proj are AITER-Triton FP4 GEMMs but o_proj remains AITER BF16 GEMMs,
         # For FP8 and use_triton_gemm(), fused_qkv_a_proj is AITER-Triton FP8 GEMMs while others remain AITER FP8 GEMMs
-        if quant_config["quant_dtype"] == dtypes.fp4x2:
-            # normally linear layers in attn share the same quant config
-            if should_ignore_layer(quant_config, prefix):
-                source_quant_dtype = None
-                quant_config = None
-                base_quant_config = None
-            elif not use_triton_gemm():
+        q_a_proj_name = (
+            "fused_qkv_a_proj" if self.q_lora_rank is not None else "q_a_proj"
+        )
+        layer_quant_dtype = quant_config.get_layer_quant_config(
+            f"{prefix}.{q_a_proj_name}"
+        )["quant_dtype"]
+        if layer_quant_dtype == dtypes.fp4x2:
+            if not use_triton_gemm():
                 source_quant_dtype = None
                 quant_config = None
                 base_quant_config = None
@@ -1276,7 +1276,7 @@ class DeepseekV2MLAAttention(nn.Module):
                 bias=False,
                 quant_config=quant_config,
                 source_quant_dtype=source_quant_dtype,
-                prefix=f"{prefix}.q_a_proj",
+                prefix=f"{prefix}.fused_qkv_a_proj",
             )
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = ColumnParallelLinear(
@@ -1408,10 +1408,10 @@ class DeepseekV2MLAAttention(nn.Module):
         self.quant_dtype = None
         self.fuse_qknorm_quant = False
         if quant_config is not None and ENABLE_DS_QKNORM_QUANT_FUSION:
-            if quant_config["quant_dtype"] == dtypes.fp8 or (
-                quant_config["quant_dtype"] == dtypes.fp4x2 and use_triton_gemm()
+            if layer_quant_dtype == dtypes.fp8 or (
+                layer_quant_dtype == dtypes.fp4x2 and use_triton_gemm()
             ):
-                self.quant_dtype = quant_config["quant_dtype"]
+                self.quant_dtype = layer_quant_dtype
                 self.fuse_qknorm_quant = True
 
     def forward(
@@ -1550,15 +1550,17 @@ class DeepseekV2DecoderLayer(nn.Module):
         #   1. RMS_Quant fusion is only used for input_layernorm
         #   2. The reduce_results variable is re-enabled for feed forward layers (MOE and MLP), because AR_RMS is now disabled in the beginning of the next layer
         #   3. AR_RMS is turned off for input_layernorm but still enabled for post_attention_layernorm if ENABLE_ALLREDUCE_RMSNORM_FUSION is turned on
-        self.quant_dtype = None
+        self.quant_dtype = (
+            None
+            if quant_config is None
+            else quant_config.global_quant_config["quant_dtype"]
+        )
         self.fuse_input_norm_quant = False
         self.fuse_ar_input_norm = ENABLE_ALLREDUCE_RMSNORM_FUSION
         if quant_config is not None and ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION:
             if (
-                quant_config["quant_dtype"] == dtypes.fp8
-                or quant_config["quant_dtype"] == dtypes.fp4x2
+                self.quant_dtype == dtypes.fp8 or self.quant_dtype == dtypes.fp4x2
             ) and use_triton_gemm():
-                self.quant_dtype = quant_config["quant_dtype"]
                 self.fuse_input_norm_quant = True
                 if self.fuse_ar_input_norm:
                     self.fuse_ar_input_norm = False
@@ -1605,7 +1607,6 @@ class DeepseekV2DecoderLayer(nn.Module):
             fused_allreduce=ENABLE_ALLREDUCE_RMSNORM_FUSION,
         )
         self.routed_scaling_factor = config.routed_scaling_factor
-        self.quant_dtype = quant_config["quant_dtype"] if quant_config else None
         self.fuse_rmsnorm_quant = (
             ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION and self.quant_dtype is not None
         )
@@ -1810,12 +1811,6 @@ class DeepseekV2Model(nn.Module):
 
 
 class DeepseekV2ForCausalLM(nn.Module):
-    # packed_modules_mapping = {
-    #     "q_a_proj" : ("fused_qkv_a_proj", 0),
-    #     "kv_a_proj_with_mqa":  ("fused_qkv_a_proj", 1),
-    #     "gate_proj": ("gate_up_proj", 0),
-    #     "up_proj": ("gate_up_proj", 1),
-    # }
 
     def __init__(
         self,

--- a/atom/models/llama.py
+++ b/atom/models/llama.py
@@ -69,7 +69,7 @@ class LlamaMLP(nn.Module):
         hidden_size: int,
         intermediate_size: int,
         hidden_act: str,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig,
         bias: bool = False,
         prefix: str = "",
         reduce_results: bool = True,
@@ -99,7 +99,7 @@ class LlamaMLP(nn.Module):
         self.act_fn = SiluAndMul(
             fused_quant=self.fused_act_quant, quant_config=quant_config
         )
-        self.quant_type = quant_config["quant_type"]
+        self.quant_type = quant_config.global_quant_config["quant_type"]
 
     def forward(self, x, x_scale: Optional[torch.Tensor] = None):
         x = self.gate_up_proj(x, x_scale=x_scale)
@@ -240,8 +240,8 @@ class LlamaDecoderLayer(nn.Module):
     def __init__(
         self,
         config: LlamaConfig,
+        quant_config: QuantizationConfig,
         cache_config: str = "bf16",
-        quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         layer_num: int = 0,
     ) -> None:
@@ -271,7 +271,7 @@ class LlamaDecoderLayer(nn.Module):
             ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_RMSNORM_QUANT
         )
 
-        self.quant_type = quant_config["quant_type"]
+        self.quant_type = quant_config.global_quant_config["quant_type"]
 
         self.self_attn = LlamaAttention(
             config=config,

--- a/atom/models/utils.py
+++ b/atom/models/utils.py
@@ -7,14 +7,11 @@ from typing import (
     Protocol,
     Tuple,
     Union,
-    Optional,
 )
 
 import torch
 import os
-import re
 
-from atom.config import QuantizationConfig
 
 import logging
 
@@ -235,41 +232,6 @@ def fast_topk(values, topk, dim):
     else:
         # Use topk for efficiency with larger k values
         return torch.topk(values, topk, dim=dim)
-
-
-def should_ignore_layer(
-    quantization_config: Optional[QuantizationConfig], prefix: str
-) -> bool:
-    if quantization_config is None:
-        return True
-    exclude_layers: List[str] = quantization_config.get("exclude_layers", [])
-    if not exclude_layers:
-        return False
-    for exclude_layer in exclude_layers:
-        if exclude_layer.startswith("re"):
-            # case "re:model.layers.*self_attn.*", remove the 're:' prefix
-            regex_pattern = exclude_layer[3:]
-            if re.search(regex_pattern, prefix):
-                return True
-        elif prefix in exclude_layer:
-            # case exclude_layer like "model.layers.0.self_attn.q_a_proj"
-            # a common prefix for linear layers in attn like "model.layers.0.self_attn"
-            return True
-        else:
-            # case "lm_head". Common practice won't quant lm_head, however.
-            if prefix.split(".")[-1] == exclude_layer:
-                return True
-    return False
-
-
-def get_quant_config_for_layer(
-    quantization_config: Optional[QuantizationConfig], prefix: str
-) -> Optional[QuantizationConfig]:
-    return (
-        None
-        if should_ignore_layer(quantization_config, prefix)
-        else quantization_config
-    )
 
 
 def extract_layer_index(layer_name: str, num_attn_module: int = 1) -> int:

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable, Mapping
-from types import MappingProxyType
-from typing import Any, Optional
+from collections.abc import Iterable
+from typing import Any
 import regex as re
 
 
@@ -18,61 +17,6 @@ def deep_compare(dict1: Any, dict2: Any) -> bool:
         return set(dict1) == set(dict2)
     else:
         return dict1 == dict2
-
-
-def should_ignore_layer(
-    layer_name: Optional[str],
-    ignore: Iterable[str],
-    fused_mapping: Mapping[str, list[str]] = MappingProxyType({}),
-) -> bool:
-    if layer_name is None:
-        return False
-
-    # layer_name = model.layers.0.self_attn.qkv_proj
-    # proj_name = qkv_proj
-    proj_name = layer_name.split(".")[-1]
-
-    # Fused layers like gate_up_proj or qkv_proj will not be fused
-    # in the safetensors checkpoint. So, we convert the name
-    # from the fused version to unfused + check to make sure that
-    # each shard of the fused layer has the same scheme.
-    if proj_name in fused_mapping:
-        shard_proj_names = fused_mapping[proj_name]
-
-        # Convert fused_name --> [shard_names]
-        shard_names = [
-            layer_name.replace(proj_name, shard_proj_name)
-            for shard_proj_name in shard_proj_names
-        ]
-
-        # Layer should be ignored if shards are ignored.
-        should_ignore_layer = None
-        for shard_name in shard_names:
-            should_ignore_shard = check_equal_or_regex_match(
-                layer_name=shard_name, targets=ignore
-            )
-
-            # If shard_idx=0, set layer ignore to match shard.
-            if should_ignore_layer is None:
-                should_ignore_layer = should_ignore_shard
-
-            # If shard_idx=1+ confirm scheme matches prior shards.
-            elif should_ignore_shard != should_ignore_layer:
-                raise ValueError(
-                    f"Found a different quantization schemes for "
-                    f"{shard_proj_names} in {layer_name}. vLLM "
-                    "requires all to use the same scheme."
-                )
-
-    # Unfused layers like down_proj and o_proj will match
-    # the safetensors checkpoint already.
-    else:
-        should_ignore_layer = check_equal_or_regex_match(
-            layer_name=layer_name, targets=ignore
-        )
-
-    assert should_ignore_layer is not None
-    return should_ignore_layer
 
 
 def check_equal_or_regex_match(layer_name: str, targets: Iterable[str]) -> bool:

--- a/tests/test_quant_config.py
+++ b/tests/test_quant_config.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: MIT
+# Tests for LayerQuantConfig and QuantizationConfig refactoring (atom/config.py).
+#
+# Covers: per-layer quant config dispatch, quark config parsing,
+# layer name matching (exact / regex / fnmatch), and packed-module remapping.
+#
+# atom.config depends on torch, aiter, and transformers.  We load the source
+# file under temporary sys.modules mocks so the tests run in any environment.
+
+import contextlib
+import enum
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+ATOM_ROOT = str(Path(__file__).resolve().parent.parent)
+
+# ---------------------------------------------------------------------------
+# Mock primitives
+# ---------------------------------------------------------------------------
+
+
+class QuantType(enum.IntEnum):
+    No = 0
+    per_Token = 1
+    per_Tensor = 2
+    per_1x32 = 3
+    per_1x128 = 4
+
+
+BF16 = "torch.bfloat16"
+FP8 = "mock_fp8"
+FP4X2 = "mock_fp4x2"
+INT8 = "mock_int8"
+
+D_DTYPES = {
+    "fp8": FP8,
+    "fp4x2": FP4X2,
+    "int8": INT8,
+    "int4x2": "mock_int4x2",
+    "i8": INT8,
+    "i4x2": "mock_int4x2",
+}
+
+
+class FakeHFConfig:
+    """Lightweight stand-in for transformers.PretrainedConfig."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    @staticmethod
+    def get_config_dict(model):
+        return {}, {}
+
+
+# ---------------------------------------------------------------------------
+# Module loader — patch sys.modules only while exec-ing config.py
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _temporary_mocks():
+    mock_torch = MagicMock()
+    mock_torch.bfloat16 = BF16
+
+    mock_aiter = types.ModuleType("aiter")
+    mock_aiter.QuantType = QuantType
+
+    mock_aiter_dtypes = types.ModuleType("aiter.utility.dtypes")
+    mock_aiter_dtypes.d_dtypes = D_DTYPES
+
+    mock_transformers = types.ModuleType("transformers")
+    mock_transformers.PretrainedConfig = FakeHFConfig
+    mock_transformers.AutoConfig = MagicMock()
+    mock_transformers.GenerationConfig = MagicMock()
+
+    mock_atom_utils = types.ModuleType("atom.utils")
+    mock_atom_utils.envs = MagicMock()
+    mock_atom_utils.get_open_port = MagicMock(return_value=8000)
+
+    mock_dist_utils = types.ModuleType("atom.utils.distributed.utils")
+    mock_dist_utils.stateless_init_torch_distributed_process_group = MagicMock()
+
+    mock_aiter.__path__ = []
+
+    mock_plugin = types.ModuleType("atom.plugin")
+    mock_plugin.is_plugin_mode = MagicMock(return_value=False)
+    mock_plugin_config = types.ModuleType("atom.plugin.config")
+    mock_plugin_config.PluginConfig = MagicMock()
+
+    patches = {
+        "torch": mock_torch,
+        "torch.distributed": MagicMock(),
+        "aiter": mock_aiter,
+        "aiter.utility": types.ModuleType("aiter.utility"),
+        "aiter.utility.dtypes": mock_aiter_dtypes,
+        "transformers": mock_transformers,
+        "atom.utils": mock_atom_utils,
+        "atom.utils.distributed": types.ModuleType("atom.utils.distributed"),
+        "atom.utils.distributed.utils": mock_dist_utils,
+        "atom.plugin": mock_plugin,
+        "atom.plugin.config": mock_plugin_config,
+    }
+
+    saved = {}
+    for name, mock in patches.items():
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = mock
+    try:
+        yield
+    finally:
+        for name, orig in saved.items():
+            if orig is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = orig
+
+
+def _load_config():
+    path = os.path.join(ATOM_ROOT, "atom", "config.py")
+    spec = importlib.util.spec_from_file_location("_atom_config_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    with _temporary_mocks():
+        spec.loader.exec_module(mod)
+    return mod
+
+
+_m = _load_config()
+LayerQuantConfig = _m.LayerQuantConfig
+QuantizationConfig = _m.QuantizationConfig
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestLayerQuantConfig:
+    def test_defaults(self):
+        cfg = LayerQuantConfig()
+        assert cfg["quant_type"] == QuantType.No
+        assert cfg["quant_dtype"] == BF16
+        assert cfg["is_dynamic"] is True
+        assert cfg["quant_method"] == ""
+
+    def test_custom_values_and_dict_interface(self):
+        cfg = LayerQuantConfig(
+            quant_type=QuantType.per_Token,
+            quant_dtype=FP8,
+            is_dynamic=False,
+            quant_method="quark",
+        )
+        assert isinstance(cfg, dict)
+        assert cfg["quant_type"] == QuantType.per_Token
+        assert cfg["quant_dtype"] == FP8
+        assert cfg["is_dynamic"] is False
+
+
+class TestQuantizationConfigInit:
+    def test_none_config(self):
+        qcfg = QuantizationConfig(config=None)
+        assert qcfg.quant_method == ""
+        assert qcfg.exclude_layers == []
+        assert qcfg.layer_quant_config == {}
+        assert qcfg.global_quant_config["quant_type"] == QuantType.No
+
+    def test_config_without_quantization(self):
+        hf = FakeHFConfig(torch_dtype=BF16)
+        qcfg = QuantizationConfig(hf)
+        assert qcfg.quant_method == ""
+        assert qcfg.global_quant_config["quant_type"] == QuantType.No
+        assert qcfg.global_quant_config["quant_dtype"] == BF16
+
+    def test_quark_config_parses_global_and_layer(self):
+        hf = FakeHFConfig(
+            torch_dtype=BF16,
+            quantization_config={
+                "quant_method": "quark",
+                "global_quant_config": {
+                    "weight": {"qscheme": "per_channel", "dtype": "fp8_e4m3"},
+                    "input_tensors": {"is_dynamic": True},
+                },
+                "layer_quant_config": {
+                    "*.mlp.*": {
+                        "weight": {"qscheme": "per_group", "dtype": "fp4_e2m1"},
+                        "input_tensors": {"is_dynamic": False},
+                    }
+                },
+                "exclude": ["lm_head"],
+            },
+        )
+        qcfg = QuantizationConfig(hf)
+        assert qcfg.quant_method == "quark"
+        assert qcfg.global_quant_config["quant_type"] == QuantType.per_Token
+        assert qcfg.global_quant_config["quant_dtype"] == FP8
+
+        assert "*.mlp.*" in qcfg.layer_quant_config
+        mlp = qcfg.layer_quant_config["*.mlp.*"]
+        assert mlp["quant_type"] == QuantType.per_1x32
+        assert mlp["quant_dtype"] == FP4X2
+        assert mlp["is_dynamic"] is False
+
+        assert qcfg.exclude_layers == ["lm_head"]
+
+
+class TestParseQuarkConfigDict:
+    @pytest.fixture
+    def qcfg(self):
+        return QuantizationConfig(config=None)
+
+    def test_per_channel_fp8(self, qcfg):
+        result = qcfg.parse_quark_config_dict(
+            {
+                "weight": {"qscheme": "per_channel", "dtype": "fp8_e4m3"},
+                "input_tensors": {"is_dynamic": True},
+            }
+        )
+        assert result["quant_type"] == QuantType.per_Token
+        assert result["quant_dtype"] == FP8
+        assert result["is_dynamic"] is True
+        assert result["quant_method"] == "quark"
+
+    def test_per_group_fp4(self, qcfg):
+        result = qcfg.parse_quark_config_dict(
+            {
+                "weight": {"qscheme": "per_group", "dtype": "fp4_e2m1"},
+                "input_tensors": {"is_dynamic": False},
+            }
+        )
+        assert result["quant_type"] == QuantType.per_1x32
+        assert result["quant_dtype"] == FP4X2
+        assert result["is_dynamic"] is False
+
+    def test_no_input_tensors_defaults_dynamic(self, qcfg):
+        """When input_tensors is absent/None, is_dynamic keeps its True default."""
+        result = qcfg.parse_quark_config_dict(
+            {
+                "weight": {"qscheme": "per_tensor", "dtype": "int8"},
+                "input_tensors": None,
+            }
+        )
+        assert result["quant_type"] == QuantType.per_Tensor
+        assert result["is_dynamic"] is True
+
+
+class TestShouldIgnoreLayerQuant:
+    def _make(self, exclude_layers):
+        qcfg = QuantizationConfig(config=None)
+        qcfg.exclude_layers = exclude_layers
+        return qcfg
+
+    def test_empty_exclude(self):
+        assert self._make([]).should_ignore_layer_quant("any_layer") is False
+
+    def test_none_layer_name(self):
+        assert self._make(["lm_head"]).should_ignore_layer_quant(None) is False
+
+    def test_exact_match(self):
+        assert self._make(["lm_head"]).should_ignore_layer_quant("lm_head") is True
+
+    def test_regex_match(self):
+        qcfg = self._make(["re:model\\.layers\\..*shared_expert.*"])
+        assert (
+            qcfg.should_ignore_layer_quant("model.layers.3.shared_expert.gate_proj")
+            is True
+        )
+
+    def test_no_match(self):
+        assert (
+            self._make(["lm_head"]).should_ignore_layer_quant("self_attn.q_proj")
+            is False
+        )
+
+
+class TestIsEqualOrRegexMatch:
+    @pytest.fixture
+    def qcfg(self):
+        return QuantizationConfig(config=None)
+
+    def test_exact(self, qcfg):
+        assert qcfg.is_equal_or_regex_match("lm_head", "lm_head") is True
+        assert qcfg.is_equal_or_regex_match("lm_head", "other") is False
+
+    def test_regex(self, qcfg):
+        assert (
+            qcfg.is_equal_or_regex_match(
+                "model.layers.5.self_attn.q_proj",
+                "re:model\\.layers\\..*self_attn.*",
+            )
+            is True
+        )
+        assert (
+            qcfg.is_equal_or_regex_match(
+                "model.layers.5.mlp.gate_proj",
+                "re:model\\.layers\\..*self_attn.*",
+            )
+            is False
+        )
+
+    def test_contains_mode(self, qcfg):
+        assert (
+            qcfg.is_equal_or_regex_match(
+                "self_attn",
+                "model.layers.0.self_attn.q_a_proj",
+                check_contains=True,
+            )
+            is True
+        )
+        assert (
+            qcfg.is_equal_or_regex_match("mlp", "self_attn.q_proj", check_contains=True)
+            is False
+        )
+
+
+class TestGetLayerQuantConfig:
+    def test_falls_back_to_global(self):
+        qcfg = QuantizationConfig(config=None)
+        qcfg.global_quant_config = LayerQuantConfig(
+            quant_type=QuantType.per_Token, quant_dtype=FP8
+        )
+        result = qcfg.get_layer_quant_config("model.layers.0.self_attn.q_proj")
+        assert result["quant_type"] == QuantType.per_Token
+        assert result["quant_dtype"] == FP8
+
+    def test_layer_specific_overrides_global(self):
+        qcfg = QuantizationConfig(config=None)
+        qcfg.global_quant_config = LayerQuantConfig(quant_dtype=FP8)
+        mlp_cfg = LayerQuantConfig(quant_type=QuantType.per_1x32, quant_dtype=FP4X2)
+        qcfg.layer_quant_config = {"*.mlp.*": mlp_cfg}
+
+        result = qcfg.get_layer_quant_config("model.layers.0.mlp.gate_proj")
+        assert result["quant_dtype"] == FP4X2
+        assert result["quant_type"] == QuantType.per_1x32
+
+    def test_excluded_layer_returns_unquantized(self):
+        qcfg = QuantizationConfig(config=None)
+        qcfg.torch_dtype = BF16
+        qcfg.global_quant_config = LayerQuantConfig(
+            quant_type=QuantType.per_Token, quant_dtype=FP8
+        )
+        qcfg.exclude_layers = ["lm_head"]
+
+        result = qcfg.get_layer_quant_config("lm_head")
+        assert result["quant_type"] == QuantType.No
+        assert result["quant_dtype"] == BF16
+
+
+class TestRemapLayerName:
+    def test_deepseek_v3_with_q_lora_rank(self):
+        """Individual proj names -> fused names for deepseek_v3."""
+        qcfg = QuantizationConfig(config=None)
+        qcfg.layer_quant_config = {
+            "*.q_a_proj": LayerQuantConfig(quant_type=QuantType.per_Token),
+            "*.gate_proj": LayerQuantConfig(quant_type=QuantType.per_1x32),
+        }
+        qcfg.exclude_layers = ["model.layers.0.q_a_proj"]
+
+        hf = FakeHFConfig(model_type="deepseek_v3", q_lora_rank=512)
+        qcfg.remap_layer_name(hf)
+
+        assert "*.fused_qkv_a_proj" in qcfg.layer_quant_config
+        assert "*.gate_up_proj" in qcfg.layer_quant_config
+        assert "*.q_a_proj" not in qcfg.layer_quant_config
+        assert "model.layers.0.fused_qkv_a_proj" in qcfg.exclude_layers
+
+    def test_qwen3_moe_splits_fused(self):
+        """Fused gate_up_proj -> [gate_proj, up_proj] for qwen3_moe."""
+        qcfg = QuantizationConfig(config=None)
+        qcfg.layer_quant_config = {
+            "*.gate_up_proj": LayerQuantConfig(quant_type=QuantType.per_Token),
+        }
+        qcfg.exclude_layers = []
+
+        hf = FakeHFConfig(model_type="qwen3_moe", mlp_only_layers=[1])
+        qcfg.remap_layer_name(hf, packed_modules_mapping={})
+
+        assert "*.gate_proj" in qcfg.layer_quant_config
+        assert "*.up_proj" in qcfg.layer_quant_config
+        assert "*.gate_up_proj" not in qcfg.layer_quant_config
+
+    def test_exclude_layers_deduplication(self):
+        """gate_proj and up_proj both map to gate_up_proj -- only one remains."""
+        qcfg = QuantizationConfig(config=None)
+        qcfg.layer_quant_config = {}
+        qcfg.exclude_layers = [
+            "model.layers.0.gate_proj",
+            "model.layers.0.up_proj",
+        ]
+
+        hf = FakeHFConfig(model_type="deepseek_v3", q_lora_rank=512)
+        qcfg.remap_layer_name(hf)
+
+        assert qcfg.exclude_layers.count("model.layers.0.gate_up_proj") == 1


### PR DESCRIPTION
1. Please refer to this [proposal](https://amdcloud-my.sharepoint.com/:w:/r/personal/xniu_amd_com/_layouts/15/Doc2.aspx?action=edit&sourcedoc=%7B359dfbd8-9f94-44a4-9516-888aee1cf376%7D&wdOrigin=TEAMS-MAGLEV.undefined_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1772783717667&web=1), which has been reviewed by the quark-team along with @valarLip and @carlushuang 
2. Thanks to @ZhangLirong-amd for implementing full support for the ptpc format in Atom.
3. Acc
https://huggingface.co/amd/DeepSeek-R1-0528-MoE-MXFP4-Attn-MTP-PTPC-FP8
```
python3 -m atom.entrypoints.openai_server --model /mnt/amd/DeepSeek-R1-0528-moe-mxfp4-other-ptpc-2 -tp 4 --port 5678 --server-port 7777 

lm_eval \
  --model local-completions \
  --model_args "model=/mnt/amd/DeepSeek-R1-0528-moe-mxfp4-other-ptpc-2,base_url=http://localhost:7777/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9522|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9477|±  |0.0061|
```
python3 -m atom.entrypoints.openai_server --model /mnt/amd/DeepSeek-R1-0528-moe-mxfp4-other-ptpc-2 -tp 4 --port 5678 --server-port 7777  --num-speculative-tokens 2 --method mtp

lm_eval \
  --model local-completions \
  --model_args "model=/mnt/amd/DeepSeek-R1-0528-moe-mxfp4-other-ptpc-2,base_url=http://localhost:7777/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto \
  ```
  |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9477|±  |0.0061|
|     |       |strict-match    |     5|exact_match|↑  |0.9424|±  |0.0064|

4. Next PR:
(1) Since quant_config is held by the entire model, we can have it store the original data type. I've seen many instances where values are directly assigned as bf16, which is non-standard.
(2) We should define their own analysis methods for each quant format. Currently, this simple if-else approach lacks scalability.