### PR TITLE
ci: add optional torch profiler support to benchmark workflow

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -9,7 +9,12 @@ EXTRA_ARGS=("${@:3}")
 if [ "$TYPE" == "launch" ]; then
   echo ""
   echo "========== Launching ATOM server =========="
-  python -m atom.entrypoints.openai_server --model "$MODEL_PATH" "${EXTRA_ARGS[@]}" &
+  PROFILER_ARGS=""
+  if [ "${ENABLE_TORCH_PROFILER:-0}" == "1" ]; then
+    PROFILER_ARGS="--torch-profiler-dir /app/trace"
+    echo "Torch profiler enabled, trace output: /app/trace"
+  fi
+  python -m atom.entrypoints.openai_server --model "$MODEL_PATH" $PROFILER_ARGS "${EXTRA_ARGS[@]}" &
   atom_server_pid=$!
 
   echo ""
@@ -58,6 +63,10 @@ if [ "$TYPE" == "benchmark" ]; then
   echo "========== Cloning bench_serving =========="
   git clone https://github.com/kimbochen/bench_serving.git && chmod +x bench_serving/benchmark_serving.py
   echo "========== Running benchmark test =========="
+  if [ "${ENABLE_TORCH_PROFILER:-0}" == "1" ]; then
+    echo "Starting torch profiler..."
+    curl -s -S -X POST http://127.0.0.1:8000/start_profile || echo "Warning: failed to start profiler"
+  fi
   python bench_serving/benchmark_serving.py \
     --model=$MODEL_PATH --backend=vllm --base-url="http://localhost:8000" \
     --dataset-name=random \
@@ -68,6 +77,12 @@ if [ "$TYPE" == "benchmark" ]; then
     --request-rate=inf --ignore-eos \
     --save-result --percentile-metrics="ttft,tpot,itl,e2el" \
     --result-dir=. --result-filename=${RESULT_FILENAME}.json
+
+  if [ "${ENABLE_TORCH_PROFILER:-0}" == "1" ]; then
+    echo "Stopping torch profiler..."
+    curl -s -S -X POST http://127.0.0.1:8000/stop_profile || echo "Warning: failed to stop profiler"
+    echo "Profiler traces should be saved to /app/trace"
+  fi
 
   # Inject ISL/OSL into result JSON for summary table
   if [ -f "${RESULT_FILENAME}.json" ]; then

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -25,6 +25,10 @@ on:
         description: "Image to use for the benchmark"
         type: string
         default: "rocm/atom-dev:latest"
+      enable_profiler:
+        description: "Enable torch profiler to collect trace for performance debugging"
+        type: boolean
+        default: false
       param_lists:
         description: |
           "Benchmark parameter lists. 
@@ -150,6 +154,7 @@ jobs:
           -e OSL=${{ env.OSL }} \
           -e CONC=${{ env.CONC }} \
           -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }} \
+          -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
           -v "${{ github.workspace }}:/workspace" \
           -w /workspace \
           --name atom-benchmark \
@@ -183,11 +188,24 @@ jobs:
           fi
           # Run launch and benchmark in a single exec so the server process is not killed when the first shell exits
           docker exec atom-benchmark bash -lc "
-            .github/scripts/atom_test.sh launch $model_path ${{ env.ARGS }} ${{ inputs.extra_args || '' }}
+            ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} .github/scripts/atom_test.sh launch $model_path ${{ env.ARGS }} ${{ inputs.extra_args || '' }}
             echo '========== Running benchmark test =========='
-            RESULT_FILENAME=${{ env.RESULT_FILENAME }} .github/scripts/atom_test.sh benchmark $model_path
+            ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} RESULT_FILENAME=${{ env.RESULT_FILENAME }} .github/scripts/atom_test.sh benchmark $model_path
             ls -all .
           "
+
+      - name: Copy profiler traces from container
+        if: ${{ inputs.enable_profiler }}
+        run: |
+          docker cp atom-benchmark:/app/trace ./profiler-traces || echo "No profiler traces found"
+          ls -la ./profiler-traces/ 2>/dev/null || true
+
+      - name: Upload profiler traces
+        if: ${{ inputs.enable_profiler }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: profiler-traces-deepseek-r1-0528-${{ matrix.config.input_length }}-${{ matrix.config.output_length }}-${{ matrix.config.concurrency }}
+          path: profiler-traces/
 
       - name: Upload benchmark result
         uses: actions/upload-artifact@v4
@@ -282,6 +300,7 @@ jobs:
           -e CONC=${{ env.CONC }} \
           -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }} \
           -e ATOM_GPT_OSS_MODEL=1 \
+          -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
           -v "${{ github.workspace }}:/workspace" \
           -w /workspace \
           --name atom-benchmark \
@@ -315,12 +334,25 @@ jobs:
           fi
           # Run launch and benchmark in a single exec so the server process is not killed when the first shell exits
           docker exec atom-benchmark bash -lc "
-            .github/scripts/atom_test.sh launch $model_path ${{ env.ARGS }} ${{ inputs.extra_args || '' }}
+            ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} .github/scripts/atom_test.sh launch $model_path ${{ env.ARGS }} ${{ inputs.extra_args || '' }}
             echo '========== Running benchmark test =========='
-            RESULT_FILENAME=${{ env.RESULT_FILENAME }} .github/scripts/atom_test.sh benchmark $model_path
+            ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} RESULT_FILENAME=${{ env.RESULT_FILENAME }} .github/scripts/atom_test.sh benchmark $model_path
             ls -all .
           "
-      
+
+      - name: Copy profiler traces from container
+        if: ${{ inputs.enable_profiler }}
+        run: |
+          docker cp atom-benchmark:/app/trace ./profiler-traces || echo "No profiler traces found"
+          ls -la ./profiler-traces/ 2>/dev/null || true
+
+      - name: Upload profiler traces
+        if: ${{ inputs.enable_profiler }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: profiler-traces-gpt-oss-120b-${{ matrix.config.input_length }}-${{ matrix.config.output_length }}-${{ matrix.config.concurrency }}
+          path: profiler-traces/
+
       - name: Upload benchmark result
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Add `enable_profiler` toggle to benchmark workflow dispatch inputs (default: false)
- When enabled, ATOM server starts with `--torch-profiler-dir /app/trace` and profiling is activated via `start_profile`/`stop_profile` API calls around the benchmark run
- Profiler trace files are collected from the container and uploaded as artifacts for performance debugging

## Test plan
- [ ] Trigger workflow with `enable_profiler` unchecked — verify benchmark runs as before (no regression)
- [ ] Trigger workflow with `enable_profiler` checked — verify profiler traces are uploaded as artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)