### PR TITLE
ci: add --pull to docker build to always fetch latest base image

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -80,11 +80,11 @@ jobs:
       - name: Build Docker image 
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
-          docker build --network=host \
+          docker build --pull --network=host \
             --no-cache \
             -t atom_test:ci \
             -f Dockerfile.mod .
-          
+
       - name: Push Docker image
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
@@ -260,7 +260,7 @@ jobs:
       - name: Build Docker image for forked repo
         if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && github.event.pull_request.head.repo.fork
         run: |
-          docker build --network=host \
+          docker build --pull --network=host \
             --no-cache \
             -t atom_test:ci \
             -f Dockerfile.mod .

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Build Docker image
         timeout-minutes: 120
         run: |
-          docker build --network=host -t atom_release:ci \
+          docker build --pull --network=host -t atom_release:ci \
           --build-arg BASE_IMAGE="${{ matrix.base_image }}" \
           --build-arg GPU_ARCH="${{ env.GPU_ARCH }}" \
           --build-arg MAX_JOBS=64 \


### PR DESCRIPTION
## Summary
- Add `--pull` flag to all `docker build` commands in `atom-test.yaml` and `docker-release.yaml`
- Without `--pull`, Docker uses the locally cached base image even when the tag is `:latest`, which can result in stale images being used
- With `--pull`, Docker always fetches the latest base image from the registry before building

## Test plan
- [ ] Verify CI builds pull fresh base images (check build logs for `#2 [internal] load metadata` showing actual pull instead of `CACHED`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)