### PR TITLE
[ci] Add benchmark regression detection to nightly summary

### DIFF
--- a/.github/scripts/summarize.py
+++ b/.github/scripts/summarize.py
@@ -1,34 +1,57 @@
 #! /usr/bin/env python3
+"""Summarize ATOM benchmark results with optional regression detection.
 
-import json
+Usage:
+    # Basic (existing behavior):
+    python summarize.py <result_dir>
+
+    # With regression detection against a previous run:
+    python summarize.py <result_dir> --baseline-dir <baseline_dir>
+"""
+
+import argparse
 import datetime
+import json
 import sys
 from pathlib import Path
 
+THROUGHPUT_REGRESSION_PCT = -5.0  # throughput drop >5% = regression
+LATENCY_REGRESSION_PCT = 10.0  # latency increase >10% = regression
 
-def main():
-    # Usage: python .github/scripts/summarize.py input.json
-    if len(sys.argv) < 2:
-        print(
-            "Usage: python .github/scripts/summarize.py <result_dir>", file=sys.stderr
-        )
-        sys.exit(1)
+TRACKED_METRICS = [
+    # (json_key, display_name, higher_is_better)
+    ("output_throughput", "Output Tput", True),
+    ("total_token_throughput", "Total Tput", True),
+    ("mean_ttft_ms", "Mean TTFT", False),
+    ("mean_tpot_ms", "Mean TPOT", False),
+]
 
-    summary_header = """\
-| Date | Backend | Model | ISL | OSL | Best of | Number of prompts | Request rate | Burstiness | Max concurrency | Duration | Completed | Total input tokens | Total output tokens | Request throughput | Request goodput | Output throughput | Total token throughput | Mean TTFT (ms) | Median TTFT (ms) | Std TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | Std TPOT (ms) | P99 TPOT (ms) | Mean ITL (ms) | Median ITL (ms) | Std ITL (ms) | P99 ITL (ms) | Mean E2EL (ms) | Median E2EL (ms) | Std E2EL (ms) | P99 E2EL (ms) |
-| :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |\
+
+def load_results(result_dir, recursive=False):
+    """Load benchmark JSON files from a directory.
+
+    Args:
+        result_dir: Path to directory containing JSON result files.
+        recursive: If True, search subdirectories (needed for ``gh run download``
+                   output which nests each artifact in its own folder).
+
+    Returns:
+        Sorted list of benchmark result dicts.
     """
-    print(summary_header)
+    root = Path(result_dir)
+    if not root.exists():
+        return []
 
-    in_path = Path(sys.argv[1])
-
-    # Load all benchmark results first
+    glob_fn = root.rglob if recursive else root.glob
     results = []
-    for json_path in in_path.glob("*.json"):
-        with open(json_path, encoding="utf-8") as f:
-            data = json.load(f)
-        # Parse ISL/OSL from filename if not in JSON
-        # Filename format: {model}-{ISL}-{OSL}-{CONC}-{RATIO}.json
+    for json_path in glob_fn("*.json"):
+        try:
+            with open(json_path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+            continue
+        if "output_throughput" not in data:
+            continue
         if "random_input_len" not in data or "random_output_len" not in data:
             parts = json_path.stem.rsplit("-", 4)
             if len(parts) == 5:
@@ -36,7 +59,6 @@ def main():
                 data.setdefault("random_output_len", int(parts[2]))
         results.append(data)
 
-    # Sort by Model name, then by ISL, OSL, and Max concurrency (numerically)
     results.sort(
         key=lambda d: (
             d.get("model_id", "").split("/")[-1],
@@ -45,6 +67,47 @@ def main():
             int(d.get("max_concurrency", 0)),
         )
     )
+    return results
+
+
+def _config_key(data):
+    """Unique identifier for matching a benchmark configuration across runs."""
+    return (
+        data.get("model_id", "").split("/")[-1],
+        int(data.get("random_input_len", 0)),
+        int(data.get("random_output_len", 0)),
+        int(data.get("max_concurrency", 0)),
+    )
+
+
+def _pct_change(current, baseline):
+    if baseline == 0:
+        return float("inf") if current != 0 else 0.0
+    return ((current - baseline) / abs(baseline)) * 100.0
+
+
+def _is_regression(pct, higher_is_better):
+    if higher_is_better:
+        return pct <= THROUGHPUT_REGRESSION_PCT
+    else:
+        return pct >= LATENCY_REGRESSION_PCT
+
+
+def _format_delta(value, pct, higher_is_better):
+    """Format a metric value with percentage change indicator."""
+    sign = "+" if pct >= 0 else ""
+    if _is_regression(pct, higher_is_better):
+        return f"**{value:.2f}** ({sign}{pct:.1f}%)"
+    return f"{value:.2f} ({sign}{pct:.1f}%)"
+
+
+def print_results_table(results):
+    """Print the full benchmark results table (preserves existing output format)."""
+    summary_header = """\
+| Date | Backend | Model | ISL | OSL | Best of | Number of prompts | Request rate | Burstiness | Max concurrency | Duration | Completed | Total input tokens | Total output tokens | Request throughput | Request goodput | Output throughput | Total token throughput | Mean TTFT (ms) | Median TTFT (ms) | Std TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | Std TPOT (ms) | P99 TPOT (ms) | Mean ITL (ms) | Median ITL (ms) | Std ITL (ms) | P99 ITL (ms) | Mean E2EL (ms) | Median E2EL (ms) | Std E2EL (ms) | P99 E2EL (ms) |
+| :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |\
+    """
+    print(summary_header)
 
     for data in results:
         row = [
@@ -86,6 +149,107 @@ def main():
             f"{data.get('p99_e2el_ms', ''):.2f}",
         ]
         print("| " + " | ".join(str(x) for x in row) + " |")
+
+
+def print_regression_report(current_results, baseline_results):
+    """Compare current results against baseline and print a regression summary.
+
+    Returns:
+        Number of configurations with at least one regressed metric.
+    """
+    baseline_map = {_config_key(d): d for d in baseline_results}
+    if not baseline_map:
+        return 0
+
+    print("\n---\n")
+    print("## Regression Report\n")
+    print(
+        f"Compared against previous nightly run "
+        f"({len(baseline_map)} baseline configurations).  "
+    )
+    print(
+        f"Thresholds: throughput drop **>{abs(THROUGHPUT_REGRESSION_PCT):.0f}%** "
+        f"or latency increase **>{LATENCY_REGRESSION_PCT:.0f}%**\n"
+    )
+
+    cols = ["Model", "ISL", "OSL", "Conc"]
+    for _, display_name, _ in TRACKED_METRICS:
+        cols.append(display_name)
+    cols.append("Status")
+
+    print("| " + " | ".join(cols) + " |")
+    print("| " + " | ".join([":-:"] * len(cols)) + " |")
+
+    regression_count = 0
+
+    for data in current_results:
+        key = _config_key(data)
+        baseline = baseline_map.get(key)
+        model, isl, osl, conc = key
+        row = [model, str(isl), str(osl), str(conc)]
+
+        has_regression = False
+
+        for metric_key, _, higher_is_better in TRACKED_METRICS:
+            cur_val = data.get(metric_key, 0)
+            if baseline is not None:
+                base_val = baseline.get(metric_key, 0)
+                pct = _pct_change(cur_val, base_val)
+                row.append(_format_delta(cur_val, pct, higher_is_better))
+                if _is_regression(pct, higher_is_better):
+                    has_regression = True
+            else:
+                row.append(f"{cur_val:.2f}")
+
+        if has_regression:
+            row.append("⚠️ **REGRESSION**")
+            regression_count += 1
+        elif baseline is None:
+            row.append("🆕 New")
+        else:
+            row.append("✅ OK")
+
+        print("| " + " | ".join(row) + " |")
+
+    print()
+    if regression_count > 0:
+        print(
+            f"> ⚠️ **{regression_count} configuration(s) show performance regression**"
+        )
+    else:
+        print("> ✅ **No regressions detected** across all configurations")
+
+    return regression_count
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Summarize ATOM benchmark results with optional regression detection"
+    )
+    parser.add_argument(
+        "result_dir",
+        help="Directory containing current benchmark result JSON files",
+    )
+    parser.add_argument(
+        "--baseline-dir",
+        default=None,
+        help="Directory containing baseline result JSON files for comparison",
+    )
+    args = parser.parse_args()
+
+    current_results = load_results(args.result_dir)
+    if not current_results:
+        print("No benchmark results found.", file=sys.stderr)
+        sys.exit(1)
+
+    print_results_table(current_results)
+
+    if args.baseline_dir:
+        baseline_results = load_results(args.baseline_dir, recursive=True)
+        if baseline_results:
+            print_regression_report(current_results, baseline_results)
+        else:
+            print("\n> No baseline results found for regression comparison\n")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -385,11 +385,46 @@ jobs:
           pattern: '*'
           merge-multiple: true
           path: .
+
+      - name: Download baseline from previous nightly run
+        id: baseline
+        run: |
+          PREV_RUN_ID=$(gh run list \
+            --workflow="ATOM Benchmark" \
+            --branch=main \
+            --event=schedule \
+            --status=success \
+            --limit=1 \
+            --json databaseId \
+            --jq '.[0].databaseId // empty')
+
+          if [ -n "$PREV_RUN_ID" ] && [ "$PREV_RUN_ID" != "${{ github.run_id }}" ]; then
+            echo "Downloading baseline from run #$PREV_RUN_ID"
+            mkdir -p /tmp/baseline
+            gh run download "$PREV_RUN_ID" --dir /tmp/baseline || echo "::warning::Failed to download baseline artifacts"
+            BASELINE_COUNT=$(find /tmp/baseline -name '*.json' | wc -l)
+            echo "Downloaded $BASELINE_COUNT baseline files"
+            echo "baseline_dir=/tmp/baseline" >> $GITHUB_OUTPUT
+          else
+            echo "No previous successful nightly run found"
+            echo "baseline_dir=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       
       - name: List all benchmark results
         run: |
-          ls -all .
+          echo "=== Current results ==="
+          ls -la *.json 2>/dev/null || echo "No JSON files in current dir"
+          if [ -d "/tmp/baseline" ]; then
+            echo "=== Baseline results ==="
+            find /tmp/baseline -name '*.json' | head -20
+          fi
       
       - name: Summarize benchmark result
         run: |
-          .github/scripts/summarize.py . >> $GITHUB_STEP_SUMMARY
+          BASELINE_ARG=""
+          if [ -n "${{ steps.baseline.outputs.baseline_dir }}" ]; then
+            BASELINE_ARG="--baseline-dir ${{ steps.baseline.outputs.baseline_dir }}"
+          fi
+          .github/scripts/summarize.py . $BASELINE_ARG >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Add automatic regression detection to the nightly benchmark summary
- Download baseline artifacts from the previous successful nightly run using `gh` CLI
- Compare key metrics (output throughput, total throughput, mean TTFT, mean TPOT) with percentage deltas
- Print a clear regression report table in `$GITHUB_STEP_SUMMARY` with visual indicators

## Motivation

Currently, nightly benchmark results are uploaded as artifacts and displayed in a summary table, but there is **no comparison against historical data**. Performance regressions can go unnoticed unless someone manually compares numbers across runs. This PR adds automated regression detection to flag issues early.

## How it works

### Workflow changes (`atom-benchmark.yaml`)

A new step in the `summarize-benchmark-result` job:
1. Uses `gh run list` to find the most recent successful nightly run on `main`
2. Downloads its artifacts to `/tmp/baseline` via `gh run download`
3. Passes `--baseline-dir /tmp/baseline` to `summarize.py`

### Script changes (`summarize.py`)

Enhanced with `--baseline-dir` argument (backward compatible — without it, produces identical output):
1. Loads baseline results (recursively, to handle `gh run download`'s nested directory structure)
2. Matches configurations by `(model, ISL, OSL, concurrency)` key
3. Computes percentage delta for 4 key metrics
4. Prints a **Regression Report** section with:
   - Per-config delta values with `+/-` percentages
   - Bold highlighting for regressed metrics
   - Status column: ✅ OK / ⚠️ REGRESSION / 🆕 New
   - Summary line with total regression count

### Thresholds

| Type | Threshold | Direction |
|------|-----------|-----------|
| Throughput (output, total) | >5% decrease | ⚠️ Regression |
| Latency (TTFT, TPOT) | >10% increase | ⚠️ Regression |

### Example output

```
## Regression Report

| Model | ISL | OSL | Conc | Output Tput | Total Tput | Mean TTFT | Mean TPOT | Status |
|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| DeepSeek-R1-0528 | 1024 | 1024 | 128 | 1234.56 (+2.3%) | 2345.67 (+1.8%) | 45.67 (-3.2%) | 12.34 (+0.5%) | ✅ OK |
| gpt-oss-120b | 1024 | 1024 | 128 | **567.89** (-7.2%) | **890.12** (-6.5%) | 89.01 (+8.3%) | 23.45 (+3.1%) | ⚠️ **REGRESSION** |

> ⚠️ **1 configuration(s) show performance regression**
```

## Test plan

- [ ] Verify `summarize.py .` (no baseline) produces identical output to the current script
- [ ] Verify `summarize.py . --baseline-dir /tmp/baseline` produces regression report when baseline exists
- [ ] Verify graceful handling when baseline dir is empty or missing
- [ ] Verify the workflow step correctly finds and downloads previous nightly run artifacts
- [ ] Run a manual `workflow_dispatch` to confirm end-to-end
