### PR TITLE
docs: fix logo path and update documentation URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ html_theme_options = {
     "titles_only": False,
 }
 
-html_logo = "atom_logo.png"
+html_logo = "assets/atom_logo.png"
 html_favicon = None
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ ATOM Documentation
 
 **ATOM** (Accelerated Training and Optimization for Models) is AMD's high-performance LLM serving framework optimized for ROCm platforms.
 
-.. image:: atom_logo.png
+.. image:: assets/atom_logo.png
    :align: center
    :width: 400px
 
@@ -77,7 +77,7 @@ Quick Links
 Getting Help
 ------------
 
-* **Documentation**: https://sunway513.github.io/ATOM/
+* **Documentation**: https://rocm.github.io/ATOM/
 * **GitHub Issues**: https://github.com/ROCm/ATOM/issues
 * **ROCm Community**: https://github.com/ROCm/ROCm/discussions
 


### PR DESCRIPTION
## Summary
- Fix logo not displaying on GitHub Pages by correcting path from `atom_logo.png` to `assets/atom_logo.png` in `conf.py` and `index.rst`
- Update documentation URL from `sunway513.github.io/ATOM` to `rocm.github.io/ATOM`

## Test plan
- [ ] Verify logo displays correctly on https://rocm.github.io/ATOM/ after merge
- [ ] Verify documentation link in index page points to correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)