### PR TITLE
Add documentation site link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ git clone https://github.com/ROCm/ATOM.git; pip install ./ATOM
 
 ## 📚 Documentation
 
+**Full documentation: [rocm.github.io/ATOM](https://rocm.github.io/ATOM)**
+
 | **Topic** | **Description** | **Guide** |
 |---|---|---|
 | Architecture | System overview, request lifecycle, component design | [Architecture Guide](docs/architecture_guide.md) |


### PR DESCRIPTION
## Summary
- Add prominent link to hosted documentation site (https://rocm.github.io/ATOM) at the top of the Documentation section in README

## Follow-up (requires repo admin)
After merging, please also update the repository settings:

| Setting | Value |
|---------|-------|
| **Homepage** | `https://rocm.github.io/ATOM` |
| **Description** | `AMD's high-performance LLM inference engine optimized for ROCm GPUs` |
| **Topics** | `llm`, `inference`, `rocm`, `amd-gpu`, `serving`, `vllm` |