### PR TITLE
Update DeepSeek-R1-0528-FP4 MTP model path

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -135,7 +135,7 @@ jobs:
             runner: atom-mi355-8gpu.predownload
             run_on_pr: true
           - model_name: "DeepSeek-R1-0528-FP4"
-            model_path: "amd/DeepSeek-R1-0528-mtp-mxfp4"
+            model_path: "amd/DeepSeek-R1-0528-MXFP4"
             extraArgs: "--kv_cache_dtype fp8 -tp 8"
             env_vars: ""
             accuracy_test_threshold: "0.93"


### PR DESCRIPTION
Update model_path for DeepSeek-R1-0528-FP4 MTP from `amd/DeepSeek-R1-0528-mtp-mxfp4` to `amd/DeepSeek-R1-0528-MXFP4`.