### PR TITLE
CI: wait for profiler stopped log instead of trace file existence

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -14,7 +14,8 @@ if [ "$TYPE" == "launch" ]; then
     PROFILER_ARGS="--torch-profiler-dir /app/trace"
     echo "Torch profiler enabled, trace output: /app/trace"
   fi
-  python -m atom.entrypoints.openai_server --model "$MODEL_PATH" $PROFILER_ARGS "${EXTRA_ARGS[@]}" &
+  ATOM_SERVER_LOG="/tmp/atom_server.log"
+  python -m atom.entrypoints.openai_server --model "$MODEL_PATH" $PROFILER_ARGS "${EXTRA_ARGS[@]}" 2>&1 | tee "$ATOM_SERVER_LOG" &
   atom_server_pid=$!
 
   echo ""
@@ -81,19 +82,21 @@ if [ "$TYPE" == "benchmark" ]; then
   if [ "${ENABLE_TORCH_PROFILER:-0}" == "1" ]; then
     echo "Stopping torch profiler..."
     curl -s -S -X POST http://127.0.0.1:8000/stop_profile || echo "Warning: failed to stop profiler"
-    echo "Waiting for profiler traces to be written to /app/trace ..."
-    for i in $(seq 1 60); do
-      trace_files=$(find /app/trace -name "*.json" -o -name "*.json.gz" 2>/dev/null | head -1)
-      if [ -n "$trace_files" ]; then
-        echo "Profiler trace files found after ${i}s"
+    ATOM_SERVER_LOG="/tmp/atom_server.log"
+    echo "Waiting for 'Profiler stopped.' in server log ..."
+    profiler_done=false
+    for i in $(seq 1 300); do
+      if grep -q "Profiler stopped." "$ATOM_SERVER_LOG" 2>/dev/null; then
+        echo "Profiler stopped after ${i}s"
         ls -lhR /app/trace/
+        profiler_done=true
         break
       fi
-      echo "Waiting for trace files... ($i/60)"
+      echo "Waiting for profiler to finish... ($i/300)"
       sleep 1
     done
-    if [ -z "$trace_files" ]; then
-      echo "Warning: no profiler trace files found after 60s"
+    if [ "$profiler_done" = false ]; then
+      echo "Warning: 'Profiler stopped.' not found in server log after 300s"
       ls -lhR /app/trace/ 2>/dev/null || true
     fi
   fi


### PR DESCRIPTION
## Summary
- Tee ATOM server output to `/tmp/atom_server.log` so the benchmark script can inspect it
- Replace the trace file existence check with grepping for `Profiler stopped.` in the server log, ensuring traces are fully written before proceeding
- Increase wait timeout from 60s to 300s to accommodate large models

## Test plan
- [ ] Run a profiler-enabled benchmark and verify the script waits until `Profiler stopped.` appears
- [ ] Verify trace files are complete (not truncated) after the wait