### PR TITLE
Add manual GPU load test workflow

### DIFF
--- a/.github/scripts/gpu_load_test.sh
+++ b/.github/scripts/gpu_load_test.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+
+#############################################
+# GPU Load Test for DeepSeek-R1 Model
+# Tests if all GPUs load simultaneously or if any GPU is slow
+#############################################
+
+MODEL_NAME="deepseek-ai/DeepSeek-R1-0528"
+MODEL_LOCAL_PATH="/data/deepseek-ai/DeepSeek-R1-0528"
+TENSOR_PARALLEL=8
+KV_CACHE_DTYPE="fp8"
+TEMPERATURE=0
+
+LOG_FILE="/tmp/gpu_load_test_$(hostname)_$(date +%Y%m%d_%H%M%S).log"
+
+echo "========================================="
+echo "GPU Load Test - DeepSeek-R1"
+echo "========================================="
+echo "Hostname: $(hostname)"
+echo "Date: $(date)"
+echo "Log: $LOG_FILE"
+echo ""
+
+# Check if model exists locally
+echo "Checking for model..."
+if [ -f "$MODEL_LOCAL_PATH/config.json" ]; then
+    echo "Found model locally at: $MODEL_LOCAL_PATH"
+    MODEL_PATH="$MODEL_LOCAL_PATH"
+else
+    echo "Model not found locally"
+    echo "Will download from HuggingFace: $MODEL_NAME"
+    MODEL_PATH="$MODEL_NAME"
+fi
+
+# Pre-flight GPU check
+echo ""
+echo "========================================="
+echo "GPU Status"
+echo "========================================="
+if command -v rocm-smi &> /dev/null; then
+    GPU_COUNT=$(rocm-smi --showid 2>/dev/null | grep -c 'GPU' || echo 'Unknown')
+    echo "GPU Count: $GPU_COUNT"
+    echo ""
+    echo "Temperatures:"
+    rocm-smi --showtemp 2>&1 | grep "Temperature (Sensor junction)" | head -8
+else
+    echo "rocm-smi not available"
+fi
+echo ""
+
+# Remove existing container
+docker rm -f atom_inference 2>/dev/null
+
+# Run the test
+echo "========================================="
+echo "Starting Model Load Test..."
+echo "========================================="
+echo ""
+
+docker run \
+  --name atom_inference \
+  --network=host \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  -v /data:/data \
+  -e HF_HOME=/data/huggingface_cache \
+  -e NCCL_DEBUG=WARN \
+  -e RCCL_DEBUG=WARN \
+  --shm-size=16G \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  rocm/atom-dev:latest \
+  bash -c '
+    MODEL_RUNNER="/app/ATOM/atom/model_engine/model_runner.py"
+
+    # Add timing instrumentation
+    if ! grep -q "^import time$" "$MODEL_RUNNER"; then
+        sed -i "1a import time" "$MODEL_RUNNER"
+    fi
+
+    # Instrument model loading with timing
+    sed -i "/load_model(self.model, config.model, config.hf_config, config.load_dummy)/i\\
+        load_start_time = time.time()\\
+        logger.info(f\"[LOAD START] GPU {self.rank} | Time: {load_start_time:.6f}\")" \
+        "$MODEL_RUNNER"
+
+    sed -i "/load_model(self.model, config.model, config.hf_config, config.load_dummy)/a\\
+        load_elapsed = time.time() - load_start_time\\
+        logger.info(f\"[LOAD DONE] GPU {self.rank} | Duration: {load_elapsed:.2f}s | Time: {time.time():.6f}\")" \
+        "$MODEL_RUNNER"
+
+    # Run inference
+    python3 -m atom.examples.simple_inference \
+      --model "'"$MODEL_PATH"'" \
+      --kv_cache_dtype "'"$KV_CACHE_DTYPE"'" \
+      -tp "'"$TENSOR_PARALLEL"'" \
+      --temperature "'"$TEMPERATURE"'"
+  ' 2>&1 | tee "$LOG_FILE"
+
+# Analyze results
+echo ""
+echo "========================================="
+echo "DETAILED ANALYSIS RESULTS"
+echo "========================================="
+echo ""
+
+# Check if test completed
+LOAD_COUNT=$(grep -c "\[LOAD DONE\]" "$LOG_FILE" 2>/dev/null || echo 0)
+
+if [ "$LOAD_COUNT" -eq 0 ]; then
+    echo "FAIL: Test did not complete successfully"
+    echo "   No GPU load completion markers found in log"
+    echo ""
+    echo "Possible issues:"
+    echo "  - Model download failed"
+    echo "  - Docker container crashed"
+    echo "  - Out of memory"
+    echo ""
+    echo "Check log file: $LOG_FILE"
+    exit 1
+fi
+
+if [ "$LOAD_COUNT" -lt 8 ]; then
+    echo "WARNING: Only $LOAD_COUNT GPUs completed loading (expected 8)"
+    echo ""
+fi
+
+# Extract and analyze timing data
+echo "PER-GPU LOAD TIME ANALYSIS"
+echo "========================================="
+echo ""
+
+# Get all load times with GPU IDs
+LOAD_DATA=$(grep "\[LOAD DONE\]" "$LOG_FILE" | \
+  sed 's/.*\[atom\] //' | \
+  grep -oP 'GPU \K\d+.*Duration: [0-9.]+s' | \
+  sort -t' ' -k1 -n)
+
+# Find min and max for comparison
+MIN_TIME=$(echo "$LOAD_DATA" | awk '{print $3}' | sed 's/s$//' | sort -n | head -1)
+MAX_TIME=$(echo "$LOAD_DATA" | awk '{print $3}' | sed 's/s$//' | sort -n | tail -1)
+
+echo "GPU | Load Time | Delta from Fastest | Status"
+echo "----|-----------|-------------------|------------------"
+
+while IFS= read -r line; do
+    GPU=$(echo "$line" | awk '{print $1}')
+    TIME=$(echo "$line" | awk '{print $3}' | sed 's/s$//')
+    DELTA=$(awk "BEGIN {printf \"%.2f\", $TIME - $MIN_TIME}")
+    PERCENT=$(awk "BEGIN {printf \"%.1f\", ($TIME - $MIN_TIME) / $MIN_TIME * 100}")
+
+    # Determine status
+    if (( $(echo "$DELTA < 1" | bc -l) )); then
+        STATUS="Excellent"
+        MARKER=""
+    elif (( $(echo "$DELTA < 5" | bc -l) )); then
+        STATUS="Good"
+        MARKER=""
+    elif (( $(echo "$DELTA < 10" | bc -l) )); then
+        STATUS="Moderate"
+        MARKER="  <--"
+    else
+        STATUS="SLOW"
+        MARKER="  <-- PROBLEM"
+    fi
+
+    printf " %1s  | %8.2fs | +%6.2fs (%5.1f%%) | %-20s%s\n" "$GPU" "$TIME" "$DELTA" "$PERCENT" "$STATUS" "$MARKER"
+done <<< "$LOAD_DATA"
+
+echo ""
+
+# Calculate comprehensive statistics
+echo "STATISTICAL SUMMARY"
+echo "========================================="
+echo ""
+
+STATS=$(grep "\[LOAD DONE\]" "$LOG_FILE" | grep -oP 'Duration: \K[0-9.]+' | awk '{
+    times[NR] = $1;
+    sum += $1;
+    if(NR==1) { min=max=$1 }
+    if($1 < min) { min=$1 }
+    if($1 > max) { max=$1 }
+}
+END {
+    if(NR > 0) {
+        avg = sum / NR;
+        delta = max - min;
+        variance = (delta / avg) * 100;
+
+        # Calculate median
+        n = asort(times, sorted);
+        if(n % 2) {
+            median = sorted[(n+1)/2];
+        } else {
+            median = (sorted[n/2] + sorted[n/2+1]) / 2;
+        }
+
+        # Calculate standard deviation
+        sum_sq_diff = 0;
+        for(i=1; i<=NR; i++) {
+            diff = times[i] - avg;
+            sum_sq_diff += diff * diff;
+        }
+        stddev = sqrt(sum_sq_diff / NR);
+
+        printf "GPUs Tested:     %d\n", NR;
+        printf "Min Load Time:   %.2fs\n", min;
+        printf "Max Load Time:   %.2fs\n", max;
+        printf "Average:         %.2fs\n", avg;
+        printf "Median:          %.2fs\n", median;
+        printf "Std Deviation:   %.2fs\n", stddev;
+        printf "Delta (Max-Min): %.2fs\n", delta;
+        printf "Variance:        %.2f%%\n", variance;
+        printf "DELTA_VALUE:%.2f\n", delta;
+        printf "VARIANCE_VALUE:%.2f\n", variance;
+        printf "MIN_VALUE:%.2f\n", min;
+        printf "MAX_VALUE:%.2f\n", max;
+    }
+}')
+
+echo "$STATS" | grep -v "_VALUE:" | while IFS=: read -r key value; do
+    if [ -n "$key" ]; then
+        printf "  %-18s %s\n" "$key:" "$value"
+    fi
+done
+
+echo ""
+
+# Extract key values for decision making
+DELTA=$(echo "$STATS" | grep "^DELTA_VALUE:" | cut -d: -f2)
+VARIANCE=$(echo "$STATS" | grep "^VARIANCE_VALUE:" | cut -d: -f2)
+
+# Determine overall status
+echo "DIAGNOSTIC ASSESSMENT"
+echo "========================================="
+echo ""
+
+if (( $(echo "$DELTA < 1" | bc -l) )); then
+    echo "Status: EXCELLENT"
+    echo ""
+    echo "All GPUs loaded within ${DELTA}s of each other."
+    echo "All GPUs are loading the model simultaneously."
+    echo "No GPU hardware issues detected."
+
+elif (( $(echo "$DELTA < 5" | bc -l) )); then
+    echo "Status: GOOD"
+    echo ""
+    echo "All GPUs loaded within ${DELTA}s variance."
+    echo "Minor variance detected but within acceptable range."
+
+elif (( $(echo "$DELTA < 10" | bc -l) )); then
+    echo "Status: MODERATE VARIANCE"
+    echo ""
+    echo "Delta is ${DELTA}s - some imbalance detected."
+    echo "Recommended: run test again to check if same GPUs are slow."
+
+else
+    echo "Status: HIGH VARIANCE - ISSUE DETECTED"
+    echo ""
+    echo "Delta is ${DELTA}s - significant GPU load imbalance!"
+    echo ""
+
+    # Identify slow GPUs
+    SLOW_GPUS=$(echo "$LOAD_DATA" | awk -v min="$MIN_TIME" '{
+        time = $3;
+        gsub(/s$/, "", time);
+        if(time > min + 10) {
+            print $1;
+        }
+    }' | tr '\n' ',' | sed 's/,$//')
+
+    if [ -n "$SLOW_GPUS" ]; then
+        echo "Slow GPU(s) identified: $SLOW_GPUS"
+        echo ""
+    fi
+
+    echo "Most likely causes:"
+    echo "  1. Storage I/O bottleneck"
+    echo "  2. Model shard distribution"
+    echo "  3. NUMA/memory issues"
+    echo "  4. PCIe link degradation"
+fi
+
+echo ""
+echo "========================================="
+echo "TEST SUMMARY"
+echo "========================================="
+echo "Hostname:     $(hostname)"
+echo "Test Date:    $(date)"
+echo "Model:        $MODEL_PATH"
+echo "GPUs Tested:  $LOAD_COUNT"
+echo "Full Log:     $LOG_FILE"
+echo "========================================="

--- a/.github/workflows/gpu-load-test.yaml
+++ b/.github/workflows/gpu-load-test.yaml
@@ -1,0 +1,304 @@
+name: GPU Load Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      runners:
+        description: 'Runners to test (comma-separated, or "all")'
+        type: string
+        default: 'all'
+      image:
+        description: 'Docker image'
+        type: string
+        default: 'rocm/atom-dev:latest'
+
+jobs:
+  parse-runners:
+    name: Parse runners
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.parse.outputs.matrix }}
+    steps:
+      - name: Parse runner input
+        id: parse
+        run: |
+          INPUT="${{ inputs.runners || 'all' }}"
+          if [ "$INPUT" = "all" ]; then
+            MATRIX='[{"runner":"atom-mi355-8gpu.predownload","label":"MI355-8GPU"}]'
+          else
+            MATRIX="["
+            SEP=""
+            IFS=',' read -ra RUNNERS <<< "$INPUT"
+            for r in "${RUNNERS[@]}"; do
+              r=$(echo "$r" | xargs)
+              MATRIX="${MATRIX}${SEP}{\"runner\":\"${r}\",\"label\":\"${r}\"}"
+              SEP=","
+            done
+            MATRIX="${MATRIX}]"
+          fi
+          echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
+          echo "Runner matrix: ${MATRIX}"
+
+  gpu-load-test:
+    name: GPU Load Test (${{ matrix.config.label }})
+    needs: parse-runners
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.parse-runners.outputs.matrix) }}
+    runs-on: ${{ matrix.config.runner }}
+
+    env:
+      CONTAINER_NAME: gpu_load_test
+      MODEL_NAME: "deepseek-ai/DeepSeek-R1-0528"
+      TENSOR_PARALLEL: 8
+      KV_CACHE_DTYPE: "fp8"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Clean up existing containers
+        run: |
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+          docker rm -f ${{ env.CONTAINER_NAME }} 2>/dev/null || true
+
+      - name: GPU status
+        run: |
+          echo "Hostname: $(hostname)"
+          echo ""
+          if command -v rocm-smi &> /dev/null; then
+            rocm-smi --showid || true
+            echo ""
+            rocm-smi --showtemp 2>&1 | grep "Temperature (Sensor junction)" | head -8 || true
+            echo ""
+            rocm-smi --showmemuse || true
+          fi
+
+      - name: Resolve model path
+        id: model
+        run: |
+          if [ -f "/models/${{ env.MODEL_NAME }}/config.json" ]; then
+            echo "path=/models/${{ env.MODEL_NAME }}" >> $GITHUB_OUTPUT
+            echo "Found model at /models/${{ env.MODEL_NAME }}"
+          elif [ -f "/data/${{ env.MODEL_NAME }}/config.json" ]; then
+            echo "path=/data/${{ env.MODEL_NAME }}" >> $GITHUB_OUTPUT
+            echo "Found model at /data/${{ env.MODEL_NAME }}"
+          else
+            echo "path=${{ env.MODEL_NAME }}" >> $GITHUB_OUTPUT
+            echo "Model not found locally, will download from HuggingFace"
+          fi
+
+      - name: Start container
+        run: |
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+
+          MOUNT_FLAGS=""
+          [ -d "/data" ] && MOUNT_FLAGS="$MOUNT_FLAGS -v /data:/data"
+          [ -d "/models" ] && MOUNT_FLAGS="$MOUNT_FLAGS -v /models:/models"
+
+          docker run -dt \
+            --name ${{ env.CONTAINER_NAME }} \
+            --network=host \
+            --device=/dev/kfd $DEVICE_FLAG \
+            --group-add video \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            $MOUNT_FLAGS \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            -e HF_HOME=/data/huggingface_cache \
+            -e NCCL_DEBUG=WARN \
+            -e RCCL_DEBUG=WARN \
+            --shm-size=16G \
+            --ulimit memlock=-1 \
+            --ulimit stack=67108864 \
+            ${{ inputs.image || 'rocm/atom-dev:latest' }}
+
+      - name: Run GPU load test
+        id: test
+        timeout-minutes: 45
+        run: |
+          MODEL_PATH="${{ steps.model.outputs.path }}"
+
+          docker exec ${{ env.CONTAINER_NAME }} bash -c '
+            MODEL_RUNNER="/app/ATOM/atom/model_engine/model_runner.py"
+
+            # Add timing instrumentation
+            if ! grep -q "^import time$" "$MODEL_RUNNER"; then
+                sed -i "1a import time" "$MODEL_RUNNER"
+            fi
+
+            sed -i "/load_model(self.model, config.model, config.hf_config, config.load_dummy)/i\\
+                load_start_time = time.time()\\
+                logger.info(f\"[LOAD START] GPU {self.rank} | Time: {load_start_time:.6f}\")" \
+                "$MODEL_RUNNER"
+
+            sed -i "/load_model(self.model, config.model, config.hf_config, config.load_dummy)/a\\
+                load_elapsed = time.time() - load_start_time\\
+                logger.info(f\"[LOAD DONE] GPU {self.rank} | Duration: {load_elapsed:.2f}s | Time: {time.time():.6f}\")" \
+                "$MODEL_RUNNER"
+
+            python3 -m atom.examples.simple_inference \
+              --model "'"$MODEL_PATH"'" \
+              --kv_cache_dtype '"${{ env.KV_CACHE_DTYPE }}"' \
+              -tp '"${{ env.TENSOR_PARALLEL }}"' \
+              --temperature 0
+          ' 2>&1 | tee gpu_load_test.log
+
+      - name: Analyze results and generate summary
+        if: always()
+        run: |
+          LOG_FILE="gpu_load_test.log"
+          HOSTNAME=$(hostname)
+          LOAD_COUNT=$(grep -c "\[LOAD DONE\]" "$LOG_FILE" 2>/dev/null || echo 0)
+
+          # Start summary
+          {
+            echo "## GPU Load Test - ${HOSTNAME} (${{ matrix.config.label }})"
+            echo ""
+            echo "| Item | Value |"
+            echo "|------|-------|"
+            echo "| Hostname | \`${HOSTNAME}\` |"
+            echo "| Runner | \`${{ matrix.config.runner }}\` |"
+            echo "| Date | $(date -u '+%Y-%m-%d %H:%M:%S UTC') |"
+            echo "| Model | \`${{ env.MODEL_NAME }}\` |"
+            echo "| GPUs Completed | ${LOAD_COUNT} / 8 |"
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
+
+          if [ "$LOAD_COUNT" -eq 0 ]; then
+            echo "### Result: FAILED" >> $GITHUB_STEP_SUMMARY
+            echo "No GPU load completion markers found. Check the logs." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          # Extract timing data
+          LOAD_DATA=$(grep "\[LOAD DONE\]" "$LOG_FILE" | \
+            sed 's/.*\[atom\] //' | \
+            grep -oP 'GPU \K\d+.*Duration: [0-9.]+s' | \
+            sort -t' ' -k1 -n)
+
+          MIN_TIME=$(echo "$LOAD_DATA" | awk '{print $3}' | sed 's/s$//' | sort -n | head -1)
+          MAX_TIME=$(echo "$LOAD_DATA" | awk '{print $3}' | sed 's/s$//' | sort -n | tail -1)
+          DELTA=$(awk "BEGIN {printf \"%.2f\", $MAX_TIME - $MIN_TIME}")
+
+          # Determine overall status
+          if (( $(echo "$DELTA < 1" | bc -l) )); then
+            STATUS_EMOJI="✅"
+            STATUS_TEXT="EXCELLENT"
+          elif (( $(echo "$DELTA < 5" | bc -l) )); then
+            STATUS_EMOJI="✅"
+            STATUS_TEXT="GOOD"
+          elif (( $(echo "$DELTA < 10" | bc -l) )); then
+            STATUS_EMOJI="⚠️"
+            STATUS_TEXT="MODERATE"
+          else
+            STATUS_EMOJI="❌"
+            STATUS_TEXT="HIGH VARIANCE"
+          fi
+
+          # Per-GPU table
+          {
+            echo "### Per-GPU Load Times"
+            echo ""
+            echo "| GPU | Load Time | Delta from Fastest | Status |"
+            echo "|-----|-----------|-------------------|--------|"
+          } >> $GITHUB_STEP_SUMMARY
+
+          while IFS= read -r line; do
+            GPU=$(echo "$line" | awk '{print $1}')
+            TIME=$(echo "$line" | awk '{print $3}' | sed 's/s$//')
+            D=$(awk "BEGIN {printf \"%.2f\", $TIME - $MIN_TIME}")
+            PCT=$(awk "BEGIN {printf \"%.1f\", ($TIME - $MIN_TIME) / $MIN_TIME * 100}")
+
+            if (( $(echo "$D < 1" | bc -l) )); then
+              S="✅ Excellent"
+            elif (( $(echo "$D < 5" | bc -l) )); then
+              S="✅ Good"
+            elif (( $(echo "$D < 10" | bc -l) )); then
+              S="⚠️ Moderate"
+            else
+              S="❌ SLOW"
+            fi
+
+            echo "| GPU ${GPU} | ${TIME}s | +${D}s (${PCT}%) | ${S} |" >> $GITHUB_STEP_SUMMARY
+          done <<< "$LOAD_DATA"
+
+          # Statistics
+          STATS=$(grep "\[LOAD DONE\]" "$LOG_FILE" | grep -oP 'Duration: \K[0-9.]+' | awk '{
+              times[NR] = $1; sum += $1;
+              if(NR==1) { min=max=$1 }
+              if($1 < min) min=$1;
+              if($1 > max) max=$1;
+          } END {
+              if(NR > 0) {
+                  avg = sum / NR;
+                  n = asort(times, sorted);
+                  median = (n % 2) ? sorted[(n+1)/2] : (sorted[n/2] + sorted[n/2+1]) / 2;
+                  sum_sq = 0;
+                  for(i=1; i<=NR; i++) { d = times[i] - avg; sum_sq += d*d; }
+                  stddev = sqrt(sum_sq / NR);
+                  printf "%.2f %.2f %.2f %.2f %.2f %.2f", min, max, avg, median, stddev, max-min;
+              }
+          }')
+          read S_MIN S_MAX S_AVG S_MED S_STD S_DELTA <<< "$STATS"
+
+          {
+            echo ""
+            echo "### Statistics"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Min Load Time | ${S_MIN}s |"
+            echo "| Max Load Time | ${S_MAX}s |"
+            echo "| Average | ${S_AVG}s |"
+            echo "| Median | ${S_MED}s |"
+            echo "| Std Deviation | ${S_STD}s |"
+            echo "| Delta (Max-Min) | **${S_DELTA}s** |"
+            echo ""
+            echo "### Overall: ${STATUS_EMOJI} ${STATUS_TEXT} (delta: ${S_DELTA}s)"
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
+
+          # Detailed diagnostics for high variance
+          if (( $(echo "$DELTA >= 10" | bc -l) )); then
+            {
+              echo "<details>"
+              echo "<summary>Diagnostic Details (High Variance Detected)</summary>"
+              echo ""
+              echo "**Likely causes (in order of probability):**"
+              echo "1. Storage I/O bottleneck - check if \`/data\` is NFS/network mounted"
+              echo "2. Model shard distribution - different shard sizes for different GPUs"
+              echo "3. NUMA/memory issues - cross-NUMA memory access"
+              echo "4. PCIe link degradation - reduced bandwidth on specific GPUs"
+              echo ""
+              echo "**Recommended actions:**"
+              echo "- Run test again to check if same GPUs are consistently slow"
+              echo "- Check storage mount: \`mount | grep /data\`"
+              echo "- Check NUMA topology: \`rocm-smi --showtopo\`"
+              echo "- Check PCIe link: \`lspci -vv | grep -A 10 'AMD/ATI' | grep LnkSta\`"
+              echo "</details>"
+              echo ""
+            } >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-load-test-${{ matrix.config.label }}-${{ github.run_id }}
+          path: gpu_load_test.log
+
+      - name: Clean up
+        if: always()
+        run: |
+          docker stop ${{ env.CONTAINER_NAME }} || true
+          docker rm ${{ env.CONTAINER_NAME }} || true


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` workflow to manually test GPU load balance for DeepSeek-R1-0528
- Instruments `model_runner.py` with timing around `load_model()` to measure per-GPU load time
- Generates a markdown summary table in GitHub Actions showing per-GPU load times, delta analysis, and diagnostic assessment

## How to use
1. Go to Actions > "GPU Load Test" > Run workflow
2. Optionally specify runners (comma-separated) or leave as "all"
3. Check the Summary tab for results

## Example output

| GPU | Load Time | Delta from Fastest | Status |
|-----|-----------|-------------------|--------|
| GPU 5 | 318.30s | +0.00s (0.0%) | ✅ Excellent |
| GPU 4 | 318.35s | +0.05s (0.0%) | ✅ Excellent |
| GPU 0 | 662.88s | +344.58s (108.3%) | ❌ SLOW |
| GPU 7 | 755.24s | +436.94s (137.3%) | ❌ SLOW |