### PR TITLE
CI: Add warmup requests before benchmark to avoid JIT compilation during timed run

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -75,7 +75,7 @@ if [ "$TYPE" == "benchmark" ]; then
     --max-concurrency=$CONC \
     --num-prompts=$(( $CONC * 10 )) \
     --trust-remote-code \
-    --num-warmups=$CONC \
+    --num-warmups=1 \
     --request-rate=inf --ignore-eos \
     --save-result --percentile-metrics="ttft,tpot,itl,e2el" \
     --result-dir=. --result-filename=${RESULT_FILENAME}.json

--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -75,6 +75,7 @@ if [ "$TYPE" == "benchmark" ]; then
     --max-concurrency=$CONC \
     --num-prompts=$(( $CONC * 10 )) \
     --trust-remote-code \
+    --num-warmups=$CONC \
     --request-rate=inf --ignore-eos \
     --save-result --percentile-metrics="ttft,tpot,itl,e2el" \
     --result-dir=. --result-filename=${RESULT_FILENAME}.json


### PR DESCRIPTION
## Summary
- Add `--num-warmups=$CONC` to `benchmark_serving.py` invocation in `atom_test.sh`
- This sends warmup requests before the timed benchmark run, triggering JIT compilation of prefill-path kernels (e.g. `mha_varlen_fwd`) so they don't compile during the actual measurement
- Without this, the first batch of benchmark requests triggers ~24s of aiter JIT compilation, skewing TTFT and throughput numbers

## Test plan
- [ ] Run a benchmark CI job and verify `Warming up with N requests...` appears before `Starting main benchmark run...`
- [ ] Confirm no `[aiter] start build` messages appear after `Starting main benchmark run...`