### PR TITLE
CI: Add configurable runner input for docker-release workflow

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -23,11 +23,15 @@ on:
       rccl_branch:
         description: "RCCL branch"
         default: "29e1567b95e28823b0beb1a988adc587bfab5b4f"
+      runner:
+        description: "Runner label to use"
+        type: string
+        default: "linux-atom-mi355-1"
 
 jobs:
   docker-release:
     name: Nightly Docker Release
-    runs-on: linux-atom-mi355-1
+    runs-on: ${{ inputs.runner || 'linux-atom-mi355-1' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Add `runner` input to the docker-release workflow for manual dispatch
- Defaults to `linux-atom-mi355-1` (unchanged from current behavior)
- Allows selecting a different runner when triggering manually

## Test plan
- [ ] Verify nightly scheduled runs still use `linux-atom-mi355-1` by default
- [ ] Manually trigger with a different runner label and confirm it runs on the specified runner