### PR TITLE
CI: Set HF_TOKEN from runner env with secret fallback

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -194,6 +194,10 @@ jobs:
       CONTAINER_NAME: atom_test_${{ strategy.job-index }}
 
     steps:
+      - name: Set HF_TOKEN
+        if: matrix.run_on_pr == true || github.event_name != 'pull_request'
+        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> $GITHUB_ENV
+
       - name: Kill all Docker containers and clean up workspace
         if: (matrix.run_on_pr == true || github.event_name != 'pull_request') && matrix.runner == 'atom-mi355-8gpu.predownload'
         run: |


### PR DESCRIPTION
Prioritize HF_TOKEN from runner environment variable if available, otherwise fall back to secrets.AMD_HF_TOKEN.