### PR TITLE
CI: Fix container name, clean up images, and update runner in docker-release

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -26,12 +26,12 @@ on:
       runner:
         description: "Runner label to use"
         type: string
-        default: "linux-atom-mi355-1"
+        default: "atom-mi355-8gpu.predownload"
 
 jobs:
   docker-release:
     name: Nightly Docker Release
-    runs-on: ${{ inputs.runner || 'linux-atom-mi355-1' }}
+    runs-on: ${{ inputs.runner || 'atom-mi355-8gpu.predownload' }}
     strategy:
       fail-fast: false
       matrix:
@@ -70,7 +70,6 @@ jobs:
           docker build --pull --network=host -t atom_release:ci \
           --build-arg BASE_IMAGE="${{ matrix.base_image }}" \
           --build-arg GPU_ARCH="${{ env.GPU_ARCH }}" \
-          --build-arg MAX_JOBS=64 \
           --build-arg ATOM_REPO="${{ inputs.atom_repo || env.ATOM_REPO }}" \
           --build-arg ATOM_COMMIT="${{ inputs.atom_commit || env.ATOM_COMMIT }}" \
           --build-arg AITER_REPO="${{ inputs.aiter_repo || env.AITER_REPO }}" \
@@ -140,5 +139,10 @@ jobs:
       - name: Clean Up
         if: always()
         run: |
-          docker stop atom_release || true
-          docker rm atom_release || true
+          docker stop atom_release_ci || true
+          docker rm atom_release_ci || true
+          # Remove build and tagged images to free disk space
+          docker rmi atom_release:ci || true
+          docker rmi rocm/atom-dev:latest || true
+          # Remove nightly tagged image if it exists
+          docker images "rocm/atom-dev:nightly_*" -q | xargs -r docker rmi || true


### PR DESCRIPTION
## Summary
- Fix container name in Clean Up step (`atom_release` → `atom_release_ci`) to match the name used when creating the container
- Add `docker rmi` to remove build artifacts (`atom_release:ci`, `rocm/atom-dev:latest`, `rocm/atom-dev:nightly_*`) after job completion to free disk space on the runner
- Change default runner from `linux-atom-mi355-1` to `atom-mi355-8gpu.predownload`
- Remove `MAX_JOBS=64` build arg

## Test plan
- [ ] Trigger a manual workflow_dispatch run to verify the nightly release pipeline still works end-to-end
- [ ] Verify disk space is reclaimed after the cleanup step