### PR TITLE
Fix: add missing value for --pull flag in benchmark workflow

### DIFF
--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -149,7 +149,7 @@ jobs:
           -e HF_TOKEN="${HF_TOKEN:-}" \
           --security-opt seccomp=unconfined \
           --ulimit memlock=-1 \
-          --pull \
+          --pull always \
           --ulimit stack=67108864 \
           -e ISL=${{ env.ISL }} \
           -e OSL=${{ env.OSL }} \


### PR DESCRIPTION
## Summary

The `deepseek-r1-0528-benchmark` job in `atom-benchmark.yaml` has a bare `--pull` flag (without a value) in its `docker run` command. Docker interprets the next argument (`--ulimit`) as the value for `--pull`, causing the error:

```
docker: invalid pull option: '--ulimit': must be one of "always", "missing" or "never"
```

This fix adds `always` as the value for `--pull`, ensuring the latest image is always pulled before running the benchmark.