### PR TITLE
CI: Pass ATOM_DISABLE_MMAP=true to benchmark containers

### DIFF
--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -156,6 +156,7 @@ jobs:
           -e CONC=${{ env.CONC }} \
           -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }} \
           -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
+          -e ATOM_DISABLE_MMAP=true \
           -v "${{ github.workspace }}:/workspace" \
           -w /workspace \
           --name atom-benchmark \
@@ -302,6 +303,7 @@ jobs:
           -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }} \
           -e ATOM_GPT_OSS_MODEL=1 \
           -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
+          -e ATOM_DISABLE_MMAP=true \
           -v "${{ github.workspace }}:/workspace" \
           -w /workspace \
           --name atom-benchmark \


### PR DESCRIPTION
## Summary
- Add `-e ATOM_DISABLE_MMAP=true` to `docker run` in both DeepSeek-R1-0528 and GPT-OSS-120b benchmark jobs
- This is consistent with the `atom-test` workflow which already passes this env var

## Test plan
- [ ] Trigger a benchmark run on this branch to verify it works correctly