### PR TITLE
[QUARK-495] Fix Qwen3-Coder MXFP4 loading: fp4x2 copy_ and missing attention prefix

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -332,7 +332,10 @@ class LinearBase(nn.Module):
             and loaded_weight.numel() == param.data.numel()
         ):
             loaded_weight = loaded_weight.reshape(param.data.shape)
-        param.data.copy_(loaded_weight)
+        if param.data.dtype != dtypes.fp4x2:
+            param.data.copy_(loaded_weight)
+        else:
+            param.data.view(torch.uint8).copy_(loaded_weight.view(torch.uint8))
 
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor):
         param_data = param.data

--- a/atom/models/qwen3_moe.py
+++ b/atom/models/qwen3_moe.py
@@ -182,6 +182,7 @@ class Qwen3MoeAttention(nn.Module):
             self.total_num_kv_heads,
             bias=qkv_bias,
             quant_config=atom_config.quant_config,
+            prefix=f"{prefix}.qkv_proj",
         )
 
         self.o_proj = RowParallelLinear(
@@ -190,6 +191,7 @@ class Qwen3MoeAttention(nn.Module):
             bias=False,
             quant_config=atom_config.quant_config,
             reduce_results=not ENABLE_ALLREDUCE_RMSNORM_FUSION,
+            prefix=f"{prefix}.o_proj",
         )
 
         self.rotary_emb = get_rope(

--- a/tests/test_qwen3_coder_fixes.py
+++ b/tests/test_qwen3_coder_fixes.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+# Tests for Qwen3-Coder MXFP4 loading fixes:
+#   1. fp4x2-aware copy in LinearBase.weight_loader_process
+#   2. prefix propagation in Qwen3MoeAttention.__init__
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+ATOM_ROOT = str(Path(__file__).resolve().parent.parent)
+
+
+# ---------------------------------------------------------------------------
+# 1. Tests for weight_loader_process fp4x2 copy fix
+# ---------------------------------------------------------------------------
+#
+# We replicate the exact branch logic from LinearBase.weight_loader_process
+# and test it in isolation, avoiding the heavy import chain.
+
+
+_FP4X2 = "fake_fp4x2_dtype"
+_UINT8 = "torch.uint8"
+
+
+def _weight_loader_process_logic(param_data, loaded_weight, fp4x2_dtype, uint8):
+    """Replicate the copy branch from LinearBase.weight_loader_process.
+
+    This mirrors lines 335-338 of atom/model_ops/linear.py exactly.
+    """
+    if param_data.dtype != fp4x2_dtype:
+        param_data.copy_(loaded_weight)
+    else:
+        param_data.view(uint8).copy_(loaded_weight.view(uint8))
+
+
+def _make_mock_tensor(dtype):
+    t = MagicMock()
+    t.dtype = dtype
+    t.view = MagicMock(return_value=MagicMock())
+    return t
+
+
+class TestWeightLoaderProcessFp4x2:
+    """Verify the fp4x2-aware copy logic in weight_loader_process."""
+
+    def test_non_fp4x2_uses_direct_copy(self):
+        """Non-fp4x2 param should use param.data.copy_(loaded_weight)."""
+        param_data = _make_mock_tensor(dtype="torch.bfloat16")
+        loaded = _make_mock_tensor(dtype="torch.bfloat16")
+
+        _weight_loader_process_logic(param_data, loaded, _FP4X2, _UINT8)
+
+        param_data.copy_.assert_called_once_with(loaded)
+        param_data.view.assert_not_called()
+
+    def test_fp4x2_uses_uint8_view_copy(self):
+        """fp4x2 param should view both tensors as uint8 before copy."""
+        param_data = _make_mock_tensor(dtype=_FP4X2)
+        loaded = _make_mock_tensor(dtype=_FP4X2)
+
+        _weight_loader_process_logic(param_data, loaded, _FP4X2, _UINT8)
+
+        # Should NOT use direct copy_
+        param_data.copy_.assert_not_called()
+        # Both should be viewed as uint8
+        param_data.view.assert_called_once_with(_UINT8)
+        loaded.view.assert_called_once_with(_UINT8)
+        # The uint8 view of param should copy_ from uint8 view of loaded
+        param_data.view.return_value.copy_.assert_called_once_with(
+            loaded.view.return_value
+        )
+
+    def test_non_fp4x2_does_not_view_as_uint8(self):
+        """Ensure the uint8 view path is NOT taken for regular dtypes."""
+        for dtype in ("torch.bfloat16", "torch.float16", "mock_fp8"):
+            param_data = _make_mock_tensor(dtype=dtype)
+            loaded = _make_mock_tensor(dtype=dtype)
+            _weight_loader_process_logic(param_data, loaded, _FP4X2, _UINT8)
+            param_data.view.assert_not_called()
+            loaded.view.assert_not_called()
+
+    def test_source_has_fp4x2_branch(self):
+        """Verify the actual source code contains the fp4x2 branch."""
+        path = Path(ATOM_ROOT) / "atom" / "model_ops" / "linear.py"
+        source = path.read_text()
+        assert "dtypes.fp4x2" in source, "linear.py should reference dtypes.fp4x2"
+        assert (
+            ".view(torch.uint8).copy_" in source
+        ), "linear.py should have uint8 view copy path"
+
+
+# ---------------------------------------------------------------------------
+# 2. Tests for Qwen3MoeAttention prefix propagation
+# ---------------------------------------------------------------------------
+
+
+class TestQwen3MoeAttentionPrefix:
+    """Verify that Qwen3MoeAttention passes prefix to qkv_proj and o_proj."""
+
+    @pytest.fixture(scope="class")
+    def source(self):
+        path = Path(ATOM_ROOT) / "atom" / "models" / "qwen3_moe.py"
+        return path.read_text()
+
+    def test_qkv_proj_receives_prefix(self, source):
+        assert 'prefix=f"{prefix}.qkv_proj"' in source
+
+    def test_o_proj_receives_prefix(self, source):
+        assert 'prefix=f"{prefix}.o_proj"' in source
+
+    def test_init_has_at_least_two_prefix_kwargs(self, source):
+        """Qwen3MoeAttention.__init__ should pass prefix= at least twice."""
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "Qwen3MoeAttention":
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef) and item.name == "__init__":
+                        count = sum(
+                            1
+                            for n in ast.walk(item)
+                            if isinstance(n, ast.keyword) and n.arg == "prefix"
+                        )
+                        assert count >= 2, f"Expected >=2 prefix= kwargs, found {count}"
+                        return
+        pytest.fail("Qwen3MoeAttention.__init__ not found")


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix Qwen3-Coder MXFP4 loading: fp4x2 copy_ and missing attention prefix

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Server:
```
python -m atom.entrypoints.openai_server --model /data/huggingface/models/amd/Qwen3-Coder-480B-A35B-Instruct-MXFP4/ \
  --trust-remote-code \
  -tp 4 \
  --kv_cache_dtype fp8
```
lm-eval
```
 lm_eval --model local-completions \
  --model_args "model=/data/huggingface/models/amd/Qwen3-Coder-480B-A35B-Instruct-MXFP4/,base_url=http://0.0.0.0:8000/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size 1
````

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9030|±  |0.0082|
|     |       |strict-match    |     5|exact_match|↑  |0.8954|±  |0.0084|

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
