### PR TITLE
CI: Set HF_TOKEN and update default runner in docker-release

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -26,12 +26,12 @@ on:
       runner:
         description: "Runner label to use"
         type: string
-        default: "atom-mi355-8gpu.predownload"
+        default: "linux-atom-mi355-1"
 
 jobs:
   docker-release:
     name: Nightly Docker Release
-    runs-on: ${{ inputs.runner || 'atom-mi355-8gpu.predownload' }}
+    runs-on: ${{ inputs.runner || 'linux-atom-mi355-1' }}
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +48,9 @@ jobs:
       GPU_ARCH: "gfx942;gfx950"
 
     steps:
+      - name: Set HF_TOKEN
+        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> $GITHUB_ENV
+
       - name: Checkout ATOM repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Add `Set HF_TOKEN` step to docker-release workflow, prioritizing runner env variable with `secrets.AMD_HF_TOKEN` as fallback (consistent with atom-test.yaml from #310)
- Change default runner from `atom-mi355-8gpu.predownload` to `linux-atom-mi355-1`