### PR TITLE
refactor: extract regression re-run into models.json + regression_rerun.py

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -1,0 +1,42 @@
+[
+  {
+    "display": "DeepSeek-R1-0528",
+    "path": "deepseek-ai/DeepSeek-R1-0528",
+    "prefix": "deepseek-r1-0528",
+    "args": "--kv_cache_dtype fp8 -tp 8",
+    "bench_args": "",
+    "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  },
+  {
+    "display": "DeepSeek-R1-0528 MTP3",
+    "path": "deepseek-ai/DeepSeek-R1-0528",
+    "prefix": "deepseek-r1-0528",
+    "args": "--kv_cache_dtype fp8 -tp 8 --method mtp --num-speculative-tokens 3",
+    "bench_args": "--use-chat-template",
+    "suffix": "-mtp3",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  },
+  {
+    "display": "GLM-5-FP8",
+    "path": "zai-org/GLM-5-FP8",
+    "prefix": "glm-5-fp8",
+    "args": "--kv_cache_dtype fp8 -tp 8",
+    "bench_args": "",
+    "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  },
+  {
+    "display": "gpt-oss-120b",
+    "path": "openai/gpt-oss-120b",
+    "prefix": "gpt-oss-120b",
+    "args": "--kv_cache_dtype fp8",
+    "bench_args": "",
+    "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  }
+]

--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -11,7 +11,7 @@ if [ "$TYPE" == "launch" ]; then
   echo "========== Launching ATOM server =========="
   PROFILER_ARGS=""
   if [ "${ENABLE_TORCH_PROFILER:-0}" == "1" ]; then
-    PROFILER_ARGS="--torch-profiler-dir /app/trace"
+    PROFILER_ARGS="--torch-profiler-dir /app/trace --mark-trace"
     echo "Torch profiler enabled, trace output: /app/trace"
   fi
   ATOM_SERVER_LOG="/tmp/atom_server.log"
@@ -96,6 +96,14 @@ if [ "$TYPE" == "accuracy" ]; then
           --output_path "${RESULT_FILENAME}"
   echo "Accuracy test results saved to ${RESULT_FILENAME}"
   chmod -R 777 accuracy_test_results
+fi
+
+if [ "$TYPE" == "stop" ]; then
+  echo ""
+  echo "========== Stopping ATOM server =========="
+  pkill -f 'atom.entrypoints' || true
+  sleep 5
+  echo "Server stopped."
 fi
 
 if [ "$TYPE" == "benchmark" ]; then

--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -9,6 +9,9 @@ EXTRA_ARGS=("${@:3}")
 if [ "$TYPE" == "launch" ]; then
   echo ""
   echo "========== Launching ATOM server =========="
+  # Clear stale compile cache to avoid NameError from outdated generated code
+  echo "Clearing compile cache..."
+  rm -rf ~/.cache/atom/*
   PROFILER_ARGS=""
   if [ "${ENABLE_TORCH_PROFILER:-0}" == "1" ]; then
     PROFILER_ARGS="--torch-profiler-dir /app/trace --mark-trace"

--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -101,6 +101,7 @@ fi
 if [ "$TYPE" == "benchmark" ]; then
   echo ""
   echo "========== Running benchmark test =========="
+  RESULT_FILENAME=${RESULT_FILENAME:-benchmark_result}
   PROFILE_ARG=""
   if [ "${ENABLE_TORCH_PROFILER:-0}" == "1" ]; then
     PROFILE_ARG="--profile"
@@ -111,7 +112,7 @@ if [ "$TYPE" == "benchmark" ]; then
     --dataset-name=random \
     --random-input-len=$ISL --random-output-len=$OSL --random-range-ratio=$RANDOM_RANGE_RATIO \
     --max-concurrency=$CONC \
-    --num-prompts=$(( $CONC * 10 )) \
+    --num-prompts=${NUM_PROMPTS_OVERRIDE:-$(( $CONC * 10 ))} \
     --trust-remote-code \
     --num-warmups=1 \
     --request-rate=inf --ignore-eos \

--- a/.github/scripts/regression_rerun.py
+++ b/.github/scripts/regression_rerun.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-"""Generate regression re-run actions from a regression report and model registry.
+"""Generate regression re-run configs from a regression report and model registry.
 
 Reads regression_report.json (from summarize.py) and models.json (model config
-registry), then outputs a pipe-delimited action file consumed by the CI workflow.
+registry), selects the top-N most regressed configs, resolves their full model
+config (server args, bench args), and outputs a flat config list.
+
+The output is consumed by the CI workflow's "Run configs with profiler" step,
+which uses the same atom_test.sh launch/benchmark pattern as the benchmark job.
 
 Usage:
     python3 regression_rerun.py REPORT_JSON MODELS_JSON [-o OUTPUT] [--top-n 3]
 
-Output format (one action per line):
-    DOWNLOAD|<hf_path>
-    LAUNCH|<hf_path>|<server_args>
-    BENCHMARK|<hf_path>|<ISL>|<OSL>|<CONC>|<bench_args>
-    STOP
+Output format (pipe-delimited, one config per line, sorted by model+args for grouping):
+    <model_path>|<server_args>|<bench_args>|<isl>|<osl>|<conc>
 """
 
 import argparse
@@ -60,8 +61,8 @@ def _regression_severity(r):
     return min(throughput_pct, -tpot_pct)
 
 
-def generate_actions(report_path, models_path, top_n=3):
-    """Generate action lines from regression report and model registry."""
+def generate_configs(report_path, models_path, top_n=3):
+    """Generate flat config list from regression report and model registry."""
     report = json.loads(Path(report_path).read_text(encoding="utf-8"))
     models = json.loads(Path(models_path).read_text(encoding="utf-8"))
 
@@ -73,53 +74,31 @@ def generate_actions(report_path, models_path, top_n=3):
     regressions.sort(key=_regression_severity)
     regressions = regressions[:top_n]
 
-    # Group by model config (same server instance can run multiple benchmarks)
-    groups = {}
+    configs = []
     for r in regressions:
-        config = _find_model_config(r, models)
-        if config is None:
+        model_cfg = _find_model_config(r, models)
+        if model_cfg is None:
             print(
                 f"WARNING: No model config found for {r.get('model', '?')}, skipping",
                 file=sys.stderr,
             )
             continue
 
-        # Group key: path + suffix (determines unique server instance)
-        key = (config["path"], config.get("suffix", ""))
-        if key not in groups:
-            groups[key] = {
-                "config": config,
-                "benchmarks": [],
+        configs.append(
+            {
+                "model_path": model_cfg["path"],
+                "server_args": model_cfg.get("args", ""),
+                "bench_args": model_cfg.get("bench_args", ""),
+                "isl": r["isl"],
+                "osl": r["osl"],
+                "conc": r["conc"],
             }
-        groups[key]["benchmarks"].append(r)
+        )
 
-    # Generate actions
-    actions = []
-    seen_downloads = set()
-    for (path, _suffix), group in groups.items():
-        config = group["config"]
-
-        # DOWNLOAD (deduplicate by HF path)
-        if path not in seen_downloads:
-            actions.append(f"DOWNLOAD|{path}")
-            seen_downloads.add(path)
-
-        # LAUNCH with profiler args appended
-        server_args = config.get("args", "")
-        profiler_args = "--torch-profiler-dir /app/trace --mark-trace"
-        full_args = f"{server_args} {profiler_args}".strip()
-        actions.append(f"LAUNCH|{path}|{full_args}")
-
-        # BENCHMARK for each regressed config
-        bench_args = config.get("bench_args", "")
-        for r in group["benchmarks"]:
-            actions.append(
-                f"BENCHMARK|{path}|{r['isl']}|{r['osl']}|{r['conc']}|{bench_args}"
-            )
-
-        actions.append("STOP")
-
-    return actions
+    # Sort by model_path + server_args so same-server configs are adjacent
+    # (allows the YAML loop to group server launches)
+    configs.sort(key=lambda c: (c["model_path"], c["server_args"]))
+    return configs
 
 
 def main():
@@ -135,16 +114,23 @@ def main():
     )
     args = parser.parse_args()
 
-    actions = generate_actions(args.report, args.models, args.top_n)
+    configs = generate_configs(args.report, args.models, args.top_n)
 
-    if not actions:
+    if not configs:
         print("No regressions to re-run", file=sys.stderr)
         return
 
-    output = "\n".join(actions) + "\n"
+    lines = []
+    for c in configs:
+        lines.append(
+            f"{c['model_path']}|{c['server_args']}|{c['bench_args']}"
+            f"|{c['isl']}|{c['osl']}|{c['conc']}"
+        )
+
+    output = "\n".join(lines) + "\n"
     if args.output:
         Path(args.output).write_text(output, encoding="utf-8")
-        print(f"Wrote {len(actions)} actions to {args.output}", file=sys.stderr)
+        print(f"Wrote {len(lines)} configs to {args.output}", file=sys.stderr)
     else:
         sys.stdout.write(output)
 

--- a/.github/scripts/regression_rerun.py
+++ b/.github/scripts/regression_rerun.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Generate regression re-run actions from a regression report and model registry.
+
+Reads regression_report.json (from summarize.py) and models.json (model config
+registry), then outputs a pipe-delimited action file consumed by the CI workflow.
+
+Usage:
+    python3 regression_rerun.py REPORT_JSON MODELS_JSON [-o OUTPUT] [--top-n 3]
+
+Output format (one action per line):
+    DOWNLOAD|<hf_path>
+    LAUNCH|<hf_path>|<server_args>
+    BENCHMARK|<hf_path>|<ISL>|<OSL>|<CONC>|<bench_args>
+    STOP
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def _find_model_config(regression_entry, models):
+    """Match a regression entry to a models.json config.
+
+    Matches by model_id (HF path) + variant suffix, NOT by display name,
+    because display name formats differ between summarize.py output
+    (e.g. "DeepSeek-R1-0528-mtp3") and models.json (e.g. "DeepSeek-R1-0528 MTP3").
+    """
+    model_id = regression_entry.get("model_id", "")
+    display = regression_entry.get("model", "")
+
+    # Detect variant from display name (e.g. "...-mtp3" -> suffix "-mtp3")
+    variant_match = re.search(r"-(mtp\d*)$", display, re.IGNORECASE)
+    variant_suffix = f"-{variant_match.group(1).lower()}" if variant_match else ""
+
+    # Primary match: model_id (HF path) + suffix
+    if model_id:
+        for m in models:
+            if m["path"] == model_id and m.get("suffix", "") == variant_suffix:
+                return m
+
+    # Fallback: match by path basename (for old reports without model_id)
+    display_base = re.sub(r"-(mtp\d*)$", "", display, flags=re.IGNORECASE)
+    for m in models:
+        path_basename = m["path"].split("/")[-1]
+        if path_basename == display_base and m.get("suffix", "") == variant_suffix:
+            return m
+
+    return None
+
+
+def _regression_severity(r):
+    """Sort key: most severe regression first (largest throughput drop)."""
+    metrics = r.get("metrics", {})
+    throughput_pct = metrics.get("output_throughput", {}).get("pct", 0)
+    tpot_pct = metrics.get("mean_tpot_ms", {}).get("pct", 0)
+    # Throughput drop is negative, TPOT increase is positive — both are bad
+    return min(throughput_pct, -tpot_pct)
+
+
+def generate_actions(report_path, models_path, top_n=3):
+    """Generate action lines from regression report and model registry."""
+    report = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    models = json.loads(Path(models_path).read_text(encoding="utf-8"))
+
+    regressions = report.get("regressions", [])
+    if not regressions:
+        return []
+
+    # Sort by severity and take top N
+    regressions.sort(key=_regression_severity)
+    regressions = regressions[:top_n]
+
+    # Group by model config (same server instance can run multiple benchmarks)
+    groups = {}
+    for r in regressions:
+        config = _find_model_config(r, models)
+        if config is None:
+            print(
+                f"WARNING: No model config found for {r.get('model', '?')}, skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        # Group key: path + suffix (determines unique server instance)
+        key = (config["path"], config.get("suffix", ""))
+        if key not in groups:
+            groups[key] = {
+                "config": config,
+                "benchmarks": [],
+            }
+        groups[key]["benchmarks"].append(r)
+
+    # Generate actions
+    actions = []
+    seen_downloads = set()
+    for (path, _suffix), group in groups.items():
+        config = group["config"]
+
+        # DOWNLOAD (deduplicate by HF path)
+        if path not in seen_downloads:
+            actions.append(f"DOWNLOAD|{path}")
+            seen_downloads.add(path)
+
+        # LAUNCH with profiler args appended
+        server_args = config.get("args", "")
+        profiler_args = "--torch-profiler-dir /app/trace --mark-trace"
+        full_args = f"{server_args} {profiler_args}".strip()
+        actions.append(f"LAUNCH|{path}|{full_args}")
+
+        # BENCHMARK for each regressed config
+        bench_args = config.get("bench_args", "")
+        for r in group["benchmarks"]:
+            actions.append(
+                f"BENCHMARK|{path}|{r['isl']}|{r['osl']}|{r['conc']}|{bench_args}"
+            )
+
+        actions.append("STOP")
+
+    return actions
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", help="Path to regression_report.json")
+    parser.add_argument("models", help="Path to models.json")
+    parser.add_argument("-o", "--output", help="Output file (default: stdout)")
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=3,
+        help="Max regressed configs to re-run (default: 3)",
+    )
+    args = parser.parse_args()
+
+    actions = generate_actions(args.report, args.models, args.top_n)
+
+    if not actions:
+        print("No regressions to re-run", file=sys.stderr)
+        return
+
+    output = "\n".join(actions) + "\n"
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+        print(f"Wrote {len(actions)} actions to {args.output}", file=sys.stderr)
+    else:
+        sys.stdout.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/summarize.py
+++ b/.github/scripts/summarize.py
@@ -233,6 +233,7 @@ def print_regression_report(current_results, baseline_results):
             regressions.append(
                 {
                     "model": model,
+                    "model_id": data.get("model_id", ""),
                     "isl": isl,
                     "osl": osl,
                     "conc": conc,

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -131,10 +131,11 @@ jobs:
             echo "enabled=true" >> $GITHUB_OUTPUT
           else
             # Map model prefix to workflow input
+            # Note: inputs are boolean; "|| 'true'" would swallow explicit false
             case "${{ matrix.model.prefix }}" in
-              deepseek-r1-0528) echo "enabled=${{ inputs.deepseek-r1-0528 || 'true' }}" >> $GITHUB_OUTPUT ;;
-              glm-5-fp8) echo "enabled=${{ inputs.glm-5-fp8 || 'true' }}" >> $GITHUB_OUTPUT ;;
-              gpt-oss-120b) echo "enabled=${{ inputs.gpt-oss-120b || 'true' }}" >> $GITHUB_OUTPUT ;;
+              deepseek-r1-0528) echo "enabled=${{ inputs.deepseek-r1-0528 }}" >> $GITHUB_OUTPUT ;;
+              glm-5-fp8) echo "enabled=${{ inputs.glm-5-fp8 }}" >> $GITHUB_OUTPUT ;;
+              gpt-oss-120b) echo "enabled=${{ inputs.gpt-oss-120b }}" >> $GITHUB_OUTPUT ;;
               *) echo "enabled=true" >> $GITHUB_OUTPUT ;;
             esac
           fi

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -449,69 +449,81 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
-      - name: Re-run regressed configs with profiler
+      - name: Prepare regression configs
+        id: prepare
+        run: |
+          python3 .github/scripts/regression_rerun.py \
+            regression_report.json \
+            .github/benchmark/models.json \
+            -o /tmp/regression_configs.txt
+
+          if [ -s /tmp/regression_configs.txt ]; then
+            echo "has_configs=true" >> $GITHUB_OUTPUT
+            echo "=== Configs to profile ==="
+            cat -n /tmp/regression_configs.txt
+          else
+            echo "has_configs=false" >> $GITHUB_OUTPUT
+            echo "No regression configs generated"
+          fi
+
+      - name: Download models
+        if: steps.prepare.outputs.has_configs == 'true'
+        run: |
+          cut -d'|' -f1 /tmp/regression_configs.txt | sort -u | while read MODEL_PATH; do
+            echo "=== Downloading $MODEL_PATH ==="
+            if [ -d "/models" ]; then
+              docker exec -e HF_TOKEN=${{ secrets.AMD_HF_TOKEN }} atom-regression bash -lc \
+                "hf download $MODEL_PATH --local-dir /models/$MODEL_PATH" \
+                || echo "::warning::Failed to download $MODEL_PATH, will use HF online"
+            fi
+          done
+
+      - name: Run configs with profiler
+        if: steps.prepare.outputs.has_configs == 'true'
         timeout-minutes: 60
         run: |
           set -euo pipefail
 
-          # Generate action plan from regression report + model registry
-          python3 .github/scripts/regression_rerun.py \
-            regression_report.json \
-            .github/benchmark/models.json \
-            -o /tmp/regression_actions.txt
+          # Track current server to avoid unnecessary restarts
+          CURRENT_SERVER=""
 
-          if [ ! -s /tmp/regression_actions.txt ]; then
-            echo "No regression actions generated, skipping"
-            exit 0
-          fi
+          while IFS='|' read -r MODEL_PATH SERVER_ARGS BENCH_ARGS ISL OSL CONC; do
+            if [ -d "/models" ]; then MODEL_DIR="/models/$MODEL_PATH"; else MODEL_DIR="$MODEL_PATH"; fi
+            SERVER_KEY="$MODEL_PATH|$SERVER_ARGS"
 
-          cat /tmp/regression_actions.txt
+            # Launch server if model/args changed (same pattern as benchmark job)
+            if [ "$SERVER_KEY" != "$CURRENT_SERVER" ]; then
+              [ -n "$CURRENT_SERVER" ] && \
+                docker exec atom-regression bash -lc ".github/scripts/atom_test.sh stop"
+              echo "=== Launching: $MODEL_DIR $SERVER_ARGS ==="
+              docker exec atom-regression bash -lc "set -euo pipefail
+                ENABLE_TORCH_PROFILER=1 \
+                .github/scripts/atom_test.sh launch $MODEL_DIR $SERVER_ARGS"
+              CURRENT_SERVER="$SERVER_KEY"
+            fi
 
-          # State: track current server args across LAUNCH/BENCHMARK
-          CURRENT_SERVER_ARGS=""
+            # Run benchmark with profiler (same pattern as benchmark job)
+            echo "=== Profiling: ISL=$ISL OSL=$OSL CONC=$CONC ==="
+            docker exec atom-regression bash -lc "
+              ENABLE_TORCH_PROFILER=1 \
+              ISL=$ISL OSL=$OSL CONC=$CONC \
+              RANDOM_RANGE_RATIO=0.8 \
+              NUM_PROMPTS_OVERRIDE=\$((${CONC}*2)) \
+              RESULT_FILENAME=regression-${ISL}-${OSL}-${CONC} \
+              BENCH_EXTRA_ARGS='$BENCH_ARGS' \
+              SERVER_ARGS='$SERVER_ARGS' \
+              .github/scripts/atom_test.sh benchmark $MODEL_DIR"
+          done < /tmp/regression_configs.txt
 
-          # Execute actions
-          while IFS='|' read -r ACTION ARG1 ARG2 ARG3 ARG4 ARG5; do
-            case "$ACTION" in
-              DOWNLOAD)
-                echo "=== Downloading model: $ARG1 ==="
-                if [ -d "/models" ]; then
-                  docker exec -e HF_TOKEN=${{ secrets.AMD_HF_TOKEN }} atom-regression bash -lc \
-                    "hf download $ARG1 --local-dir /models/$ARG1" || echo "::warning::Failed to download $ARG1, will use HF online"
-                fi
-                ;;
-              LAUNCH)
-                echo "=== Launching server: $ARG1 args: $ARG2 ==="
-                CURRENT_SERVER_ARGS="$ARG2"
-                if [ -d "/models" ]; then MODEL_DIR="/models/$ARG1"; else MODEL_DIR="$ARG1"; fi
-                docker exec atom-regression bash -lc "set -euo pipefail
-                  pkill -f 'atom.entrypoints' || true; sleep 3
-                  .github/scripts/atom_test.sh launch $MODEL_DIR $ARG2"
-                ;;
-              BENCHMARK)
-                echo "=== Profiling: $ARG1 ISL=$ARG2 OSL=$ARG3 CONC=$ARG4 ==="
-                if [ -d "/models" ]; then MODEL_DIR="/models/$ARG1"; else MODEL_DIR="$ARG1"; fi
-                docker exec atom-regression bash -lc "
-                  ENABLE_TORCH_PROFILER=1 \
-                  ISL=$ARG2 OSL=$ARG3 CONC=$ARG4 \
-                  RANDOM_RANGE_RATIO=0.8 \
-                  NUM_PROMPTS_OVERRIDE=\$((${ARG4}*2)) \
-                  RESULT_FILENAME=regression-${ARG2}-${ARG3}-${ARG4} \
-                  BENCH_EXTRA_ARGS='$ARG5' \
-                  SERVER_ARGS='$CURRENT_SERVER_ARGS' \
-                  .github/scripts/atom_test.sh benchmark $MODEL_DIR"
-                ;;
-              STOP)
-                echo "=== Stopping server ==="
-                docker exec atom-regression bash -lc "pkill -f 'atom.entrypoints' || true; sleep 5"
-                ;;
-            esac
-          done < /tmp/regression_actions.txt
+          # Stop last server
+          docker exec atom-regression bash -lc ".github/scripts/atom_test.sh stop"
 
-          # Wait for trace compression
-          echo "Waiting for trace files..."
+      - name: Wait for trace completion
+        if: steps.prepare.outputs.has_configs == 'true'
+        run: |
           for i in $(seq 1 60); do
-            TMP_COUNT=$(docker exec atom-regression bash -lc "find /app/trace -name '*.tmp' 2>/dev/null | wc -l" || echo "0")
+            TMP_COUNT=$(docker exec atom-regression bash -lc \
+              "find /app/trace -name '*.tmp' 2>/dev/null | wc -l" || echo "0")
             [ "$TMP_COUNT" -eq 0 ] && echo "Traces ready after ${i}s" && break
             sleep 1
           done

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -83,47 +83,28 @@ jobs:
         run: |
           echo "Matrix JSON: ${{ steps.parse-param-lists.outputs.matrix_json }}"
 
+  load-models:
+    name: Load model configs
+    runs-on: ubuntu-latest
+    outputs:
+      models_json: ${{ steps.load.outputs.models_json }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: load
+        run: echo "models_json=$(jq -c . .github/benchmark/models.json)" >> $GITHUB_OUTPUT
+
   benchmark:
     name: ${{ matrix.model.display }} (isl=${{ matrix.config.input_length }} osl=${{ matrix.config.output_length }} c=${{ matrix.config.concurrency }})
-    needs: [parse-param-lists]
-    if: always() && needs.parse-param-lists.result == 'success'
+    needs: [parse-param-lists, load-models]
+    if: >-
+      always()
+      && needs.parse-param-lists.result == 'success'
+      && needs.load-models.result == 'success'
     strategy:
       fail-fast: false
       matrix:
         config: ${{ fromJson(needs.parse-param-lists.outputs.matrix_json) }}
-        model:
-          - display: "DeepSeek-R1-0528"
-            path: "deepseek-ai/DeepSeek-R1-0528"
-            prefix: "deepseek-r1-0528"
-            args: "--kv_cache_dtype fp8 -tp 8"
-            bench_args: ""
-            suffix: ""
-            runner: "atom-mi355-8gpu.predownload"
-            env_vars: ""
-          - display: "DeepSeek-R1-0528 MTP3"
-            path: "deepseek-ai/DeepSeek-R1-0528"
-            prefix: "deepseek-r1-0528"
-            args: "--kv_cache_dtype fp8 -tp 8 --method mtp --num-speculative-tokens 3"
-            bench_args: "--use-chat-template"
-            suffix: "-mtp3"
-            runner: "atom-mi355-8gpu.predownload"
-            env_vars: ""
-          - display: "GLM-5-FP8"
-            path: "zai-org/GLM-5-FP8"
-            prefix: "glm-5-fp8"
-            args: "--kv_cache_dtype fp8 -tp 8"
-            bench_args: ""
-            suffix: ""
-            runner: "atom-mi355-8gpu.predownload"
-            env_vars: ""
-          - display: "gpt-oss-120b"
-            path: "openai/gpt-oss-120b"
-            prefix: "gpt-oss-120b"
-            args: "--kv_cache_dtype fp8"
-            bench_args: ""
-            suffix: ""
-            runner: "atom-mi355-8gpu.predownload"
-            env_vars: ""
+        model: ${{ fromJson(needs.load-models.outputs.models_json) }}
         exclude:
           # Skip low-concurrency MTP runs to limit CI time
           - model: { suffix: "-mtp3" }
@@ -467,136 +448,72 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
-      - name: Download models for regressed configs
-        run: |
-          # Extract unique model HF paths from regression report
-          python3 -c "
-          import json, re
-          report = json.load(open('regression_report.json'))
-          # Model display names like 'DeepSeek-R1-0528' or 'DeepSeek-R1-0528-mtp3'
-          # Map back to HF paths (strip variant suffix)
-          models = set()
-          for r in report.get('regressions', []):
-              name = re.sub(r'-mtp\d*$', '', r.get('model', ''))
-              models.add(name)
-          for m in models:
-              print(m)
-          " | while read MODEL_NAME; do
-            echo "Downloading $MODEL_NAME..."
-            if [ -d "/models" ]; then
-              # Try common HF orgs
-              for org in deepseek-ai openai zai-org amd; do
-                docker exec -e HF_TOKEN=${{ secrets.AMD_HF_TOKEN }} atom-regression bash -lc \
-                  "hf download ${org}/${MODEL_NAME} --local-dir /models/${org}/${MODEL_NAME}" 2>/dev/null && break || true
-              done
-            fi
-          done
-
       - name: Re-run regressed configs with profiler
         timeout-minutes: 60
         run: |
           set -euo pipefail
 
-          # Pick the top 3 most regressed configs, grouped by variant (server args differ)
-          python3 -c "
-          import json, sys
-          report = json.load(open('regression_report.json'))
-          regressions = report.get('regressions', [])
-          if not regressions:
-              print('No regressions to analyze')
-              sys.exit(0)
-          regressions.sort(key=lambda r: min(
-              r['metrics'].get('output_throughput', {}).get('pct', 0),
-              -r['metrics'].get('mean_tpot_ms', {}).get('pct', 0)
-          ))
-          for r in regressions[:3]:
-              is_mtp = 'mtp' in r.get('model', '').lower()
-              print(f\"Regressed: {r['model']} {r['isl']}/{r['osl']} c={r['conc']} mtp={is_mtp}\")
-          json.dump(regressions[:3], open('regressed_configs.json', 'w'))
-          "
+          # Generate action plan from regression report + model registry
+          python3 .github/scripts/regression_rerun.py \
+            regression_report.json \
+            .github/benchmark/models.json \
+            -o /tmp/regression_actions.txt
 
-          # Group regressed configs by model+variant and profile each group
-          python3 << 'PYEOF'
-          import json, re
-          configs = json.load(open('regressed_configs.json'))
-          # Group by base model name (strip mtp suffix) + mtp flag
-          groups = {}
-          for c in configs:
-              model = c.get('model', '')
-              is_mtp = 'mtp' in model.lower()
-              base_model = re.sub(r'-mtp\d*$', '', model)
-              key = f"{base_model}|{'mtp' if is_mtp else 'base'}"
-              if key not in groups:
-                  groups[key] = {
-                      "base_model": base_model,
-                      "server_args": "--method mtp --num-speculative-tokens 3" if is_mtp else "",
-                      "bench_args": "--use-chat-template" if is_mtp else "",
-                      "configs": []
-                  }
-              groups[key]["configs"].append(c)
-          result = list(groups.values())
-          json.dump(result, open('regression_groups.json', 'w'))
-          print(f"Groups: {len(result)}")
-          for g in result:
-              print(f"  {g['base_model']} ({len(g['configs'])} configs, server_args: {g['server_args'] or 'default'})")
-          PYEOF
+          if [ ! -s /tmp/regression_actions.txt ]; then
+            echo "No regression actions generated, skipping"
+            exit 0
+          fi
 
-          # For each group: find model path, launch server, profile, stop
-          python3 -c "
-          import json
-          for g in json.load(open('regression_groups.json')):
-              bm = g['base_model']
-              sa = g['server_args']
-              ba = g['bench_args']
-              configs = ' '.join(f\"{c['isl']},{c['osl']},{c['conc']}\" for c in g['configs'])
-              print(f\"{bm}|{sa}|{ba}|{configs}\")
-          " | while IFS='|' read BASE_MODEL SERVER_ARGS BENCH_ARGS CONFIG_LIST; do
-            echo "========== Model: $BASE_MODEL  Server args: ${SERVER_ARGS:-default} =========="
-            # Find model path on runner
-            if [ -d "/models" ]; then
-              MODEL_PATH=$(find /models -maxdepth 2 -type d -name "$BASE_MODEL" | head -1)
-              [ -z "$MODEL_PATH" ] && MODEL_PATH="$BASE_MODEL"
-            else
-              MODEL_PATH="$BASE_MODEL"
-            fi
-            ARGS="--kv_cache_dtype fp8 -tp 8 --torch-profiler-dir /app/trace --mark-trace ${SERVER_ARGS}"
-            docker exec atom-regression bash -lc "set -euo pipefail
-              pkill -f 'atom.entrypoints' || true; sleep 3
-              .github/scripts/atom_test.sh launch $MODEL_PATH $ARGS
-            "
+          cat /tmp/regression_actions.txt
 
-            for cfg in $CONFIG_LIST; do
-              IFS=',' read ISL OSL CONC <<< "$cfg"
-              echo "========== Profiling ISL=$ISL OSL=$OSL CONC=$CONC =========="
-              NUM_PROMPTS=$((CONC * 2))
-              docker exec atom-regression bash -lc "
-                python -m atom.benchmarks.benchmark_serving \
-                  --model=$MODEL_PATH --backend=vllm --base-url=http://localhost:8000 \
-                  --dataset-name=random \
-                  --random-input-len=$ISL --random-output-len=$OSL \
-                  --random-range-ratio=0.8 \
-                  --max-concurrency=$CONC \
-                  --num-prompts=$NUM_PROMPTS \
-                  --trust-remote-code --num-warmups=1 \
-                  --request-rate=inf --ignore-eos \
-                  --profile $BENCH_ARGS
-              "
-            done
-          done
+          # State: track current server args across LAUNCH/BENCHMARK
+          CURRENT_SERVER_ARGS=""
 
-          # Wait for trace gzip compression to complete
-          echo "Waiting for trace files to finish writing..."
+          # Execute actions
+          while IFS='|' read -r ACTION ARG1 ARG2 ARG3 ARG4 ARG5; do
+            case "$ACTION" in
+              DOWNLOAD)
+                echo "=== Downloading model: $ARG1 ==="
+                if [ -d "/models" ]; then
+                  docker exec -e HF_TOKEN=${{ secrets.AMD_HF_TOKEN }} atom-regression bash -lc \
+                    "hf download $ARG1 --local-dir /models/$ARG1" || echo "::warning::Failed to download $ARG1, will use HF online"
+                fi
+                ;;
+              LAUNCH)
+                echo "=== Launching server: $ARG1 args: $ARG2 ==="
+                CURRENT_SERVER_ARGS="$ARG2"
+                if [ -d "/models" ]; then MODEL_DIR="/models/$ARG1"; else MODEL_DIR="$ARG1"; fi
+                docker exec atom-regression bash -lc "set -euo pipefail
+                  pkill -f 'atom.entrypoints' || true; sleep 3
+                  .github/scripts/atom_test.sh launch $MODEL_DIR $ARG2"
+                ;;
+              BENCHMARK)
+                echo "=== Profiling: $ARG1 ISL=$ARG2 OSL=$ARG3 CONC=$ARG4 ==="
+                if [ -d "/models" ]; then MODEL_DIR="/models/$ARG1"; else MODEL_DIR="$ARG1"; fi
+                docker exec atom-regression bash -lc "
+                  ENABLE_TORCH_PROFILER=1 \
+                  ISL=$ARG2 OSL=$ARG3 CONC=$ARG4 \
+                  RANDOM_RANGE_RATIO=0.8 \
+                  NUM_PROMPTS_OVERRIDE=\$((${ARG4}*2)) \
+                  RESULT_FILENAME=regression-${ARG2}-${ARG3}-${ARG4} \
+                  BENCH_EXTRA_ARGS='$ARG5' \
+                  SERVER_ARGS='$CURRENT_SERVER_ARGS' \
+                  .github/scripts/atom_test.sh benchmark $MODEL_DIR"
+                ;;
+              STOP)
+                echo "=== Stopping server ==="
+                docker exec atom-regression bash -lc "pkill -f 'atom.entrypoints' || true; sleep 5"
+                ;;
+            esac
+          done < /tmp/regression_actions.txt
+
+          # Wait for trace compression
+          echo "Waiting for trace files..."
           for i in $(seq 1 60); do
-            TMP_COUNT=$(docker exec atom-regression bash -lc "find /app/trace -name '*.tmp' 2>/dev/null | wc -l")
-            if [ "$TMP_COUNT" -eq 0 ]; then
-              echo "Trace files ready after ${i}s"
-              break
-            fi
+            TMP_COUNT=$(docker exec atom-regression bash -lc "find /app/trace -name '*.tmp' 2>/dev/null | wc -l" || echo "0")
+            [ "$TMP_COUNT" -eq 0 ] && echo "Traces ready after ${i}s" && break
             sleep 1
           done
-
-          # Stop server
-          docker exec atom-regression bash -lc "pkill -f 'atom.entrypoints' || true; sleep 5"
 
       - name: Copy profiler traces from container
         if: always()

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -396,9 +396,10 @@ jobs:
           git push origin gh-pages
           git checkout "$CURRENT_SHA"
 
-  regression-analysis:
+  # ---------- Regression re-run (GPU, only on regression) ----------
+  regression-rerun:
     if: always() && needs.summarize-benchmark-result.outputs.has_regression == 'true'
-    name: Regression Analysis (profiler trace collection)
+    name: Re-run regressed configs with profiler
     needs: [summarize-benchmark-result]
     runs-on: atom-mi355-8gpu.predownload
     steps:
@@ -528,51 +529,102 @@ jobs:
             sleep 1
           done
 
-      - name: Copy profiler traces from container
+      - name: Copy and upload profiler traces
         if: always()
         run: |
           docker cp atom-regression:/app/trace ./regression-traces 2>/dev/null || echo "No traces found"
           ls -lhR ./regression-traces/ 2>/dev/null || true
 
-      - name: Analyze traces with parse_trace.py + summary
+      - name: Upload regression traces
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: regression-traces-${{ github.run_id }}
+          path: regression-traces/
+
+      - name: Clean Up
         if: always()
         run: |
-          mkdir -p regression-analysis
+          docker stop atom-regression || true
+          docker rm atom-regression || true
+
+  # ---------- Profiler analysis (lightweight, runs on regression OR manual profiler) ----------
+  profiler-analysis:
+    if: >-
+      always()
+      && (needs.regression-rerun.result == 'success'
+          || inputs.enable_profiler == true)
+    name: Profiler trace analysis
+    needs: [benchmark, summarize-benchmark-result, regression-rerun]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+
+      - name: Download regression traces
+        if: needs.regression-rerun.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: regression-traces-${{ github.run_id }}
+          path: profiler-traces/
+
+      - name: Download benchmark profiler traces
+        if: needs.regression-rerun.result != 'success'
+        uses: actions/download-artifact@v8
+        with:
+          pattern: profiler-traces-*
+          merge-multiple: true
+          path: profiler-traces/
+
+      - name: Analyze traces
+        run: |
+          mkdir -p profiler-analysis
           pip install -q openpyxl 2>/dev/null || true
-          for rank_dir in regression-traces/rank_*/; do
+
+          TRACE_DIRS=$(find profiler-traces -type d -name "rank_*" 2>/dev/null || true)
+          if [ -z "$TRACE_DIRS" ]; then
+            echo "No rank directories found in profiler-traces/"
+            ls -lhR profiler-traces/ 2>/dev/null || true
+            exit 0
+          fi
+
+          for rank_dir in $TRACE_DIRS; do
             rank=$(basename "$rank_dir")
             RUN_TRACE=$(find "$rank_dir" -name "*.pt.trace.json.gz" ! -name "capture_graph_*" | sort | tail -1)
             if [ -n "$RUN_TRACE" ]; then
               echo "=== Analyzing $rank: $RUN_TRACE ==="
-              # Kernel breakdown XLSX
-              cd regression-analysis
+              cd profiler-analysis
               python ../tools/parse_trace.py "../$RUN_TRACE" --layer 3 2>&1 | tee "${rank}_analysis.log" || true
               for f in prefill_breakdown.xlsx decode_breakdown.xlsx; do
                 [ -f "$f" ] && mv "$f" "${rank}_${f}"
               done
               cd ..
-              # Performance summary report (only rank_0)
               if [ "$rank" = "rank_0" ]; then
                 python tools/analyze_trace_summary.py "$RUN_TRACE" \
-                  --output regression-analysis/performance_summary.md 2>&1 || true
+                  --output profiler-analysis/performance_summary.md 2>&1 || true
                 echo "=== Performance Summary ==="
-                cat regression-analysis/performance_summary.md
+                cat profiler-analysis/performance_summary.md
               fi
             fi
           done
-          ls -la regression-analysis/ 2>/dev/null || true
+          ls -la profiler-analysis/ 2>/dev/null || true
 
-      - name: Upload regression traces and analysis
+      - name: Upload analysis results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: regression-traces-${{ github.run_id }}
-          path: |
-            regression-traces/
-            regression-analysis/
+          name: profiler-analysis-${{ github.run_id }}
+          path: profiler-analysis/
 
-      - name: Create GitHub Issue with regression report
-        if: always()
+      - name: Download regression report
+        if: needs.regression-rerun.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: regression-report
+        continue-on-error: true
+
+      - name: Create GitHub Issue for regression
+        if: needs.regression-rerun.result == 'success'
         uses: actions/github-script@v7
         with:
           script: |
@@ -592,6 +644,10 @@ jobs:
               return `| ${r.model} | ${r.isl}/${r.osl} | ${r.conc} | ${throughput.current?.toFixed(1) || 'N/A'} | ${throughput.baseline?.toFixed(1) || 'N/A'} | ${throughput.pct?.toFixed(1) || 'N/A'}% | ${tpot.current?.toFixed(2) || 'N/A'} | ${tpot.baseline?.toFixed(2) || 'N/A'} | ${tpot.pct?.toFixed(1) || 'N/A'}% |`;
             }).join('\n');
 
+            let summary = 'Summary not available';
+            try { summary = fs.readFileSync('profiler-analysis/performance_summary.md', 'utf8'); }
+            catch(e) { /* ignore */ }
+
             const body = `## Performance Regression Detected
 
             **Commit:** \`${context.sha.substring(0, 8)}\`
@@ -607,10 +663,7 @@ jobs:
             ### Performance Summary
 
             \`\`\`
-            ${(() => {
-              try { return require('fs').readFileSync('regression-analysis/performance_summary.md', 'utf8'); }
-              catch(e) { return 'Summary not available'; }
-            })()}
+            ${summary}
             \`\`\`
 
             ### Profiler Traces
@@ -619,7 +672,7 @@ jobs:
             Open in [Perfetto UI](https://ui.perfetto.dev/) or Chrome \`chrome://tracing\` for analysis.
 
             ### Next Steps
-            1. Download \`regression-traces-${context.runId}\` artifact
+            1. Download \`profiler-analysis-${context.runId}\` artifact
             2. Open trace files in Perfetto UI
             3. Compare kernel durations against previous traces
             4. Identify bottleneck changes
@@ -632,9 +685,3 @@ jobs:
               body: body,
               labels: ['performance', 'regression']
             });
-
-      - name: Clean Up
-        if: always()
-        run: |
-          docker stop atom-regression || true
-          docker rm atom-regression || true


### PR DESCRIPTION
## Summary

- Create `.github/benchmark/models.json` as single source of truth for model configs, shared between benchmark matrix and regression re-run
- Create `.github/scripts/regression_rerun.py` to parse regression report and generate action file (DOWNLOAD/LAUNCH/BENCHMARK/STOP), matching by `model_id` + variant suffix instead of fragile display name / org guessing
- Add `model_id` field to regression report entries in `summarize.py`
- Add `NUM_PROMPTS_OVERRIDE` and `RESULT_FILENAME` fallback to `atom_test.sh`
- Add `load-models` job to read `models.json` for benchmark matrix via `fromJson`
- Replace ~130 lines of inline shell+python in regression-analysis with ~40 lines that delegate to `regression_rerun.py` + `atom_test.sh`

### Key improvements

| Before | After |
|--------|-------|
| 4 org hardcoded download loop | Direct HF path from models.json |
| server args hardcoded in inline python | Read from models.json config |
| 3 inline python blocks in YAML | Single regression_rerun.py script |
| find pipe head SIGPIPE risk | File redirect |
| NUM_PROMPTS not overridable | NUM_PROMPTS_OVERRIDE env var |
| New model = edit YAML + regression python | New model = edit models.json only |

## Test plan

- [x] YAML syntax validation
- [x] ruff check + black --check pass
- [x] pytest tests/ -- 159 tests pass
- [x] regression_rerun.py mock test -- MTP3 matching, fallback, empty report
- [x] E2E simulation -- bash while-read parsing, SERVER_ARGS propagation
- [ ] CI workflow_dispatch trigger to verify load-models + fromJson matrix