### PR TITLE
[GPT-OSS](plugin): remove ones kernel in each iteration

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -60,12 +60,12 @@ class PagedAttentionImpl(nn.Module):
         self.k_scale = self.v_scale = None
         self.device = "cuda:" + str(torch.cuda.current_device())
         self.layer_num = layer_num
-        self.one_scale_float = (
+        self.kv_scale_float = (
             torch.finfo(torch.float8_e4m3fn).max / torch.finfo(aiter.dtypes.fp8).max
             if self.kv_cache_dtype == "fp8"
             else 1.0
         )
-        self.one_scale = torch.tensor(self.one_scale_float, dtype=torch.float32)
+        self.kv_scale = torch.tensor(self.kv_scale_float, dtype=torch.float32)
         self.per_token_quant = True
         self.sinks = sinks
         self.sliding_window = sliding_window if sliding_window is not None else -1
@@ -158,7 +158,7 @@ class PagedAttentionImpl(nn.Module):
             )
         elif use_triton_attn and self.rotary_emb is not None:
             self.per_token_quant = False
-            k_scale = v_scale = self.one_scale
+            k_scale = v_scale = self.kv_scale
 
             q, k, k_cache, v_cache = fused_qk_rope_reshape_and_cache(
                 q,
@@ -421,8 +421,8 @@ class PagedAttentionImpl(nn.Module):
             block_table=block_tables,
             softcap=0,
             q_descale=None,
-            k_descale=self.one_scale.expand(descale_shape),
-            v_descale=self.one_scale.expand(descale_shape),
+            k_descale=self.kv_scale.expand(descale_shape),
+            v_descale=self.kv_scale.expand(descale_shape),
             sinks=self.sinks,
         )
 

--- a/atom/model_ops/base_attention.py
+++ b/atom/model_ops/base_attention.py
@@ -88,15 +88,16 @@ def cp_mha_gather_cache_kernel(
         k_reg = tl.load(key_cache_ptr_offset + col_offsets)
         v_reg = tl.load(value_cache_ptr_offset + col_offsets)
         if DEQUANT:
-            if not PER_TOKEN_QUANT:
-                k_scale = 1.0
-                v_scale = 1.0
-            else:
+            if PER_TOKEN_QUANT:
                 scale_offset = (
                     block_id * num_heads * PAGE_SIZE + head_id * PAGE_SIZE + slot_id
                 )
                 k_scale = tl.load(k_scale_ptr + scale_offset)
                 v_scale = tl.load(v_scale_ptr + scale_offset)
+            else:
+                # per-tensor: one scale per ptr, no offset
+                k_scale = tl.load(k_scale_ptr)
+                v_scale = tl.load(v_scale_ptr)
             k_dtype = k_reg.dtype
             v_dtype = v_reg.dtype
             k_reg = (k_reg.to(tl.float32) * k_scale).to(k_dtype)
@@ -127,14 +128,15 @@ def cp_mha_gather_cache_kernel(
         v_reg = tl.load(value_cache_ptr_offset + v_reg_offset)
         if DEQUANT:
             if PER_TOKEN_QUANT:
-                k_scale = 1.0
-                v_scale = 1.0
-            else:
                 scale_offset = (
                     block_id * num_heads * PAGE_SIZE + head_id * PAGE_SIZE + slot_id
                 )
                 k_scale = tl.load(k_scale_ptr + scale_offset)
                 v_scale = tl.load(v_scale_ptr + scale_offset)
+            else:
+                # per-tensor: one scale per ptr, no offset
+                k_scale = tl.load(k_scale_ptr)
+                v_scale = tl.load(v_scale_ptr)
             k_reg = k_reg.to(tl.float32) * k_scale
             v_reg = v_reg.to(tl.float32) * v_scale
         tl.store(key_ptr_offset + col_offsets, k_reg)

--- a/atom/plugin/attention_mha.py
+++ b/atom/plugin/attention_mha.py
@@ -135,7 +135,7 @@ class PagedAttentionImplPluginModeMethods:
             )
         elif use_triton_attn and self.rotary_emb is not None:
 
-            k_scale = v_scale = self.one_scale
+            k_scale = v_scale = self.per_tensor_scale
             self.per_token_quant = False
             qkv = qkv.view(qkv.shape[0], -1, self.head_dim)
             q, k, v = qkv.split(
@@ -351,6 +351,7 @@ class PagedAttentionImplPluginModeMethods:
             dequant=self.kv_cache_dtype.startswith("fp8"),
             kv_cache_layout="NHD",
             total_tokens=swa_total_tokens,
+            per_token_quant=self.per_token_quant,
         )
 
         sliding_window = (
@@ -559,6 +560,8 @@ class PagedAttentionImplPluginModeMethods:
         # usually it is created when cuda graph capture for decode phase
         if self.kv_cache_dtype == "fp8":
             if self.k_scale is None or self.v_scale is None:
+                # origin kv_scale is per tensor scale of value one.
+                self.per_tensor_scale = self.kv_scale
                 self.kv_scale = torch.zeros(
                     2,
                     num_blocks,


### PR DESCRIPTION
## Motivation

This PR removes `ones` in the forward step, only use the initial layer params.

<img width="522" height="80" alt="image" src="https://github.com/user-attachments/assets/3b2e8248-d951-4ff9-8097-95cd17d1846a" />
