### PR TITLE
[Draft] [plugin][profiler] refine OOT profiler with record_function

### DIFF
--- a/atom/plugin/vllm/model_wrapper.py
+++ b/atom/plugin/vllm/model_wrapper.py
@@ -125,6 +125,7 @@ def _patch_vllm_profile_labels() -> None:
                         and is_forward_context_available()
                     ):
                         record_label = _build_step_profiler_label()
+                        print('[zejun] record_label = ', record_label, flush=True)
                         if record_label is not None:
                             self.ctx = record_function(record_label)
                             return self.ctx.__enter__()


### PR DESCRIPTION
We use below label to demonstrate the info in profiler
`d[req128, tok128, dec128, tok128, pre0, tok0, ext0, tok0] `, which means decode step, 128 requests, 128 tokens
pre means prefill, ext means extend path for attention