### PR TITLE
fix: increase Docker build timeout from 120 to 180 minutes

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -83,7 +83,7 @@ jobs:
           echo "RCCL_BRANCH: ${{ inputs.rccl_branch || env.RCCL_BRANCH }}"
 
       - name: Build Docker image
-        timeout-minutes: 120
+        timeout-minutes: 180
         run: |
           docker build --pull --network=host -t atom_release:ci \
           --target atom_image \


### PR DESCRIPTION
## Summary

aiter `PREBUILD_KERNELS=1` with dual GPU archs (gfx942+gfx950) now exceeds 120 minutes, causing nightly Docker build to timeout.

**Change:** `timeout-minutes: 120` → `180` (aligned with OOT build step which is already 180m)

**Failed run:** https://github.com/ROCm/ATOM/actions/runs/23226096837/job/67508994344

1 file, 1 line change.