### PR TITLE
CI: add build-only-atom runner option and skip_tests input for docker release

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -30,6 +30,7 @@ on:
         options:
           - linux-atom-mi355-1
           - build-only-atom
+          - atom-mi355-8gpu.predownload
       skip_tests:
         description: "Skip test step"
         type: boolean


### PR DESCRIPTION
- Add `build-only-atom` as a runner choice for docker release workflow
- Add `skip_tests` boolean input to optionally skip the test step