### PR TITLE
fix: profiler-analysis gracefully handles missing trace artifacts

### DIFF
--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -565,7 +565,7 @@ jobs:
         if: always()
         run: |
           docker cp atom-regression:/app/trace ./regression-traces 2>/dev/null || echo "No traces found"
-          TRACE_COUNT=$(find ./regression-traces -name "*.json.gz" -o -name "*.pt.trace.*" 2>/dev/null | wc -l)
+          TRACE_COUNT=$(find ./regression-traces -type f \( -name "*.json.gz" -o -name "*.pt.trace.*" \) 2>/dev/null | wc -l | tr -d ' ')
           echo "trace_count=$TRACE_COUNT" >> $GITHUB_OUTPUT
           if [ "$TRACE_COUNT" -gt 0 ]; then
             echo "Found $TRACE_COUNT trace files"
@@ -575,7 +575,7 @@ jobs:
           fi
 
       - name: Upload regression traces
-        if: always() && steps.copy-traces.outputs.trace_count > 0
+        if: always() && fromJSON(steps.copy-traces.outputs.trace_count) > 0
         uses: actions/upload-artifact@v7
         with:
           name: regression-traces-${{ github.run_id }}


### PR DESCRIPTION
## Summary

Fixes profiler-analysis job failing when regression-rerun produces no trace files.

### Root cause
`upload-artifact@v7` silently succeeds on empty directories but creates no artifact. `download-artifact@v8` then fails with `Artifact not found`.

### Fixes
- **Upload**: Check trace file count before upload, skip if 0, emit warning
- **Download**: Add `continue-on-error: true` to both download paths
- **Analysis**: Already handles empty dirs (exits 0)

Prevents the entire nightly benchmark run from showing as "failed" when the only issue is missing profiler traces.

**Failed run**: https://github.com/ROCm/ATOM/actions/runs/23258004061/job/67658427868

1 file, 13 lines changed.