### PR TITLE
Fix: prevent permission denied error on OOT CI workspace cleanup

### DIFF
--- a/.github/workflows/atom-vllm-oot-full-test.yaml
+++ b/.github/workflows/atom-vllm-oot-full-test.yaml
@@ -127,7 +127,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             "${{ needs.build-oot-image.outputs.oot_image_tag }}" \
-            bash -lc "pytest -q tests/plugin"
+            bash -lc "pytest -q tests/plugin -o cache_dir=/tmp/.pytest_cache"
 
   oot-model-accuracy:
     name: OOT Model Accuracy (${{ matrix.model_name }})

--- a/.github/workflows/atom-vllm-oot-test.yaml
+++ b/.github/workflows/atom-vllm-oot-test.yaml
@@ -74,7 +74,7 @@ jobs:
             docker kill $containers || true
           fi
           docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
-          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "ls -la /workspace/ && rm -rf /workspace/*" || true
+          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "ls -la /workspace/ && find /workspace -mindepth 1 -delete" || true
 
       - name: Checkout ATOM repo
         uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             "$OOT_IMAGE_TAG" \
-            bash -lc "pytest -q tests/plugin"
+            bash -lc "pytest -q tests/plugin -o cache_dir=/tmp/.pytest_cache"
 
       - name: Prepare model cache mount
         run: |


### PR DESCRIPTION
## Summary

- Fix `EACCES: permission denied` error in the "Checkout ATOM repo" step of the vLLM OOT CI workflow
- Root cause: `pytest` running as root inside Docker creates `.pytest_cache/` in the mounted workspace; on the next CI run, the runner user cannot delete these root-owned dotfiles
- Use `find -mindepth 1 -delete` instead of `rm -rf *` in workspace cleanup to cover hidden files
- Redirect pytest cache dir to `/tmp` inside the container to prevent root-owned files from being written to the host workspace

## Test plan

- [ ] Verify the OOT CI job no longer fails at the "Checkout ATOM repo" step with permission errors

Made with [Cursor](https://cursor.com)