### PR TITLE
fix: use completed nightly runs as regression baseline

### DIFF
--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -264,14 +264,16 @@ jobs:
       - name: Download baseline from previous nightly run
         id: baseline
         run: |
+          # Use the most recent completed nightly run (regardless of success/failure)
+          # because even failed runs have valid per-model benchmark artifacts.
+          # Only requiring --status=success misses baselines when any single job fails.
           PREV_RUN_ID=$(gh run list \
             --workflow="ATOM Benchmark" \
             --branch=main \
             --event=schedule \
-            --status=success \
-            --limit=1 \
-            --json databaseId \
-            --jq '.[0].databaseId // empty')
+            --limit=5 \
+            --json databaseId,status \
+            --jq '[.[] | select(.status == "completed")][0].databaseId // empty')
 
           if [ -n "$PREV_RUN_ID" ] && [ "$PREV_RUN_ID" != "${{ github.run_id }}" ]; then
             echo "Downloading baseline from run #$PREV_RUN_ID"
@@ -281,7 +283,7 @@ jobs:
             echo "Downloaded $BASELINE_COUNT baseline files"
             echo "baseline_dir=/tmp/baseline" >> $GITHUB_OUTPUT
           else
-            echo "No previous successful nightly run found"
+            echo "No previous completed nightly run found"
             echo "baseline_dir=" >> $GITHUB_OUTPUT
           fi
         env:


### PR DESCRIPTION
## Summary
- Remove `--status=success` filter when selecting baseline nightly run
- Use the most recent **completed** run regardless of conclusion (success/failure)
- Failed runs still have valid per-model benchmark artifacts that should serve as baselines

## Problem
Since Mar 13, all nightly runs have been marked `failure` (one job failing = whole run fails). The `--status=success` filter kept picking the Mar 13 run as baseline, which had no MXFP4, MTP3, GLM-5, or Kimi models. These models were always marked as "New" instead of being compared against recent results.

## Test plan
- [ ] Next nightly run should pick the most recent completed run as baseline
- [ ] New models (MXFP4-MTP3, GLM-5, Kimi) should show delta% instead of "New"