### PR TITLE
[Misc] Support DeepSeek-R1-0528-MTP-MoE-MXFP4-Attn-PTPC-FP8

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -529,6 +529,7 @@ class QuantizationConfig:
             for name_pattern, config in self.layer_quant_config.items():
                 if _matches_pattern(layer_name, name_pattern):
                     layer_quant_config = config
+                    break
 
         layer_quant_config = (
             self.global_quant_config

--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -4,7 +4,6 @@ from typing import Optional, Union
 
 import torch
 import torch.nn as nn
-from aiter import dtypes
 from aiter.dist.communication_op import tensor_model_parallel_all_reduce
 from atom.config import Config, QuantizationConfig
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
@@ -56,9 +55,6 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         )
 
         quant_config = atom_config.quant_config
-        layer_quant_config = quant_config.get_layer_quant_config(prefix)
-        if layer_quant_config["quant_dtype"] == dtypes.fp4x2:
-            quant_config = QuantizationConfig()
 
         self.mtp_block = DeepseekV2DecoderLayer(
             prefix=prefix,


### PR DESCRIPTION
https://huggingface.co/amd/DeepSeek-R1-0528-MTP-MoE-MXFP4-Attn-PTPC-FP8
ptpc for linear, mxfp4 for moe (includeing mtp)

1. For layer-wise quantization of DPSK, the quantization configurations for "*self_attn*" and "model.layers.61*" overlap, and by default the selection follows the order.
2. Eliminate hardcoding in dpsk-mtp