### PR TITLE
add ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD env to disable deepseek dual stream path

### DIFF
--- a/.github/scripts/atom_oot_test.sh
+++ b/.github/scripts/atom_oot_test.sh
@@ -174,6 +174,8 @@ launch_one_model() {
   export VLLM_RPC_TIMEOUT=1800000
   export VLLM_CACHE_ROOT=/tmp/.cache/vllm
   export TORCHINDUCTOR_CACHE_DIR=/tmp/.cache/inductor
+  # FIXME here disable the dual stream in OOT CI for avoid the hang issue
+  export ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD=0
   rm -rf /tmp/.cache
 
   rm -f "${VLLM_PID_FILE}" || true

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -729,12 +729,11 @@ def maybe_dual_stream_forward(
     """Dual-stream MoE forward: shared experts on alt stream, routed on main."""
     atom_config = get_current_atom_config()
     self = atom_config.compilation_config.static_forward_context[layer_name]
-    DUAL_STREAM_TOKEN_THRESHOLD = 1024
     num_tokens, hidden_dim = hidden_states.shape
     if (
         self._use_dual_stream
         and num_tokens > 0
-        and num_tokens <= DUAL_STREAM_TOKEN_THRESHOLD
+        and num_tokens <= envs.ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD
     ):
         return self.dual_stream_moe_forward(hidden_states)
     else:
@@ -827,10 +826,11 @@ class DeepseekV2MoE(nn.Module):
 
         if config.n_shared_experts is not None:
             if not is_rocm_aiter_fusion_shared_expert_enabled():
-                self._use_dual_stream = True
-                self.alt_stream = DeepseekV2MoE._get_shared_stream()
-                compilation_config = get_current_atom_config().compilation_config
-                compilation_config.static_forward_context[prefix] = self
+                if envs.ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD > 0:
+                    self._use_dual_stream = True
+                    self.alt_stream = DeepseekV2MoE._get_shared_stream()
+                    compilation_config = get_current_atom_config().compilation_config
+                    compilation_config.static_forward_context[prefix] = self
                 intermediate_size = (
                     config.moe_intermediate_size * config.n_shared_experts
                 )

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -79,6 +79,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "ATOM_USE_CUSTOM_ALL_GATHER", "1"
     ).lower()
     == "1",
+    # --- MoE (DeepSeek-style shared experts) ---
+    # Dual-stream MoE only when num_tokens <= threshold; 0 disables dual-stream registration.
+    "ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD": lambda: int(
+        os.getenv("ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD", "1024")
+    ),
 }
 
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -56,6 +56,7 @@ This document describes the environment variables used in the ATOM project.
 |----------|------|---------|-------------|
 | **ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION** | bool | 1 (true) | If set to `1`, fuse RMSNorm with quantization. |
 | **ATOM_ENABLE_DS_QKNORM_QUANT_FUSION** | bool | 1 (true) | If set to `1`, fuse QK norm with quantization in MLA attention module. |
+| **ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD** | int | 1024 | Upper bound on MoE token count (`num_tokens` in the MoE forward) for using the dual-stream path: shared experts on a secondary CUDA stream while routed experts run on the default stream. If `num_tokens` exceeds this value, that forward uses single-stream MoE instead. Set to `0` to disable dual-stream setup entirely (no alt stream, no `maybe_dual_stream_forward` registration). |
 
 ### Qwen3-MoE style
 


### PR DESCRIPTION
This PR is about adding env **ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD** to disable deepseek dual stream, because we met a hang issue for kimi-2 when capture more graph size with set **AITER_QUICK_REDUCE_QUANTIZATION=INT4**: **"[1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512]".** those sizes are the defaule graph sizes used in vllm. This issue can be reproduced in the ATOM side or the OOT path.