### PR TITLE
Fix shutdown error ValueError("process object is closed")

### DIFF
--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -138,7 +138,11 @@ class EngineCore:
         except Exception:
             pass  # shared memory may already be freed
         for proc in self.runner_mgr.procs:
-            if proc.is_alive():
+            try:
+                alive = proc.is_alive()
+            except ValueError:
+                continue  # process object already closed by CoreManager
+            if alive:
                 proc.join(timeout=5)
         self._send_engine_dead()
         logger.debug(f"{self.label}: model runner exit")


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
CoreManager.close() calls proc.close() on the EngineCore process objects (to release the sentinel semaphore) while the EngineCore process is concurrently inside its own exit(). The EngineCore's exit() iterates runner_mgr.procs (its ModelRunner child processes) — but those same process objects have already been closed by CoreManager from the parent side. Python 3.12's multiprocessing.Process.is_alive() calls _check_closed() first, which raises ValueError if the object is already closed.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
