### PR TITLE
[Fix](OOT): fix transformers version and quant config

### DIFF
--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -19,7 +19,7 @@ def is_rocm_aiter_fusion_shared_expert_enabled() -> bool:
     quant_config = config.quant_config
     is_shared_experts_excluded = False
     is_experts_excluded = False
-    exclude_layers = quant_config.exclude_layers
+    exclude_layers = quant_config.exclude_layers or []
     for layer in exclude_layers:
         if "shared_experts" in layer:
             is_shared_experts_excluded = True

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN echo "========== [OOT 4/7] Install vLLM ROCm build dependencies ==========" 
     "${VENV_PYTHON}" -m pip install --no-deps xgrammar==0.1.29 compressed-tensors==0.13.0 loguru && \
     sed -i -e '/peft/d' -e '/tensorizer/d' -e '/runai/d' -e '/timm/d' requirements/rocm.txt && \
     "${VENV_PYTHON}" -m pip install --no-deps peft tensorizer==2.10.1 runai-model-streamer[s3,gcs]==0.15.3 timm>=1.0.17 && \
-    "${VENV_PYTHON}" -m pip install -r requirements/rocm.txt
+    transformers==5.2.0 && "${VENV_PYTHON}" -m pip install -r requirements/rocm.txt
 
 RUN echo "========== [OOT 5/7] Build and install amd-smi wheel ==========" && \
     cd /opt/rocm/share/amd_smi && \


### PR DESCRIPTION
## Motivation

This PR fixed two error in gpt-oss:
- fix the transformers version in atom-vllm docker, transformers<=5.0 will cause precision errors.
- fix quant config error, atom-vllm receives vllm config, and the `exclude_layers` attribute is None.
