### PR TITLE
[plugin] fix dual stream error for vllm plugin path

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -730,13 +730,16 @@ def maybe_dual_stream_forward(
     atom_config = get_current_atom_config()
     self = atom_config.compilation_config.static_forward_context[layer_name]
     # DUAL_STREAM_TOKEN_THRESHOLD = 1024
-    num_tokens, hidden_dim = hidden_states.shape
-    if (
-        self._use_dual_stream
-        and num_tokens > 0
-        # and num_tokens <= DUAL_STREAM_TOKEN_THRESHOLD
-        and not get_forward_context().context.is_prefill
-    ):
+    num_tokens, _ = hidden_states.shape
+    fwd_ctx = get_forward_context()
+    is_prefill = getattr(getattr(fwd_ctx, "context", None), "is_prefill", None)
+    is_decode = (
+        num_tokens <= envs.ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD
+        if is_prefill is None
+        else not is_prefill
+    )
+    use_dual_stream = self._use_dual_stream and num_tokens > 0 and is_decode
+    if use_dual_stream:
         return self.dual_stream_moe_forward(hidden_states)
     else:
         return self.single_stream_moe_forward(hidden_states)


### PR DESCRIPTION
## Motivation

For vLLM plugin path, there doesn't have a context attribute for **get_forward_context()**; the dual stream path will have an Attribute error when running the vLLM plugin path.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
