### PR TITLE
[Fix](cache): fix kv cache shape for extend prefill

### DIFF
--- a/atom/plugin/attention_mha.py
+++ b/atom/plugin/attention_mha.py
@@ -349,7 +349,7 @@ class PagedAttentionImplPluginModeMethods:
             token_to_batch=swa_token_to_batch,
             seq_starts=swa_seq_starts,
             dequant=self.kv_cache_dtype.startswith("fp8"),
-            kv_cache_layout="NHD",
+            kv_cache_layout="SHUFFLE",
             total_tokens=swa_total_tokens,
             per_token_quant=self.per_token_quant,
         )
@@ -645,6 +645,20 @@ class PagedAttentionImplPluginModeMethods:
 
         # calculate for extends
         if num_extends > 0:
+            num_blocks, block_size, num_kv_heads, head_size = k_cache.shape
+            x = 16 // k_cache.element_size()
+            k_cache_template = torch.empty(
+                [num_blocks, num_kv_heads, head_size // x, block_size, x],
+                dtype=k_cache.dtype,
+                device="meta",
+            )
+            v_cache_template = torch.empty(
+                [num_blocks, num_kv_heads, block_size // x, head_size, x],
+                dtype=v_cache.dtype,
+                device="meta",
+            )
+            new_key_cache = k_cache.view_as(k_cache_template)
+            new_value_cache = v_cache.view_as(v_cache_template)
             assert attn_metadata.plugin_metadata.extend_metadata is not None
             extend_tokens_slice = slice(
                 num_decode_tokens, num_decode_tokens + num_extend_tokens
@@ -664,8 +678,8 @@ class PagedAttentionImplPluginModeMethods:
                 query=extend_querys,
                 key=extend_keys,
                 value=extend_values,
-                key_cache=k_cache,
-                value_cache=v_cache,
+                key_cache=new_key_cache,
+                value_cache=new_value_cache,
                 output=extend_outputs,
                 cu_seqlens_q=attn_metadata.plugin_metadata.extend_metadata.query_start_loc,
                 max_seqlen_q=attn_metadata.plugin_metadata.extend_metadata.max_query_len,


### PR DESCRIPTION
## Motivation

This PR is for atom-vllm chuncked prefill scenario. currently, `cp_mha_gather_cache` function uses shuffled kv cache which shape is [num_blocks, num_kv_heads, head_size // x, block_size, x] for atom prefix cache, so we should synchronize the kv cache shape in vllm's chunked prefill. 

## Test Result

<img width="513" height="77" alt="image" src="https://github.com/user-attachments/assets/a6148ec4-3629-431d-a9ef-a44b3089248b" />

