### PR TITLE
[plugin][OOT CI] refine OOT CI behavior

### DIFF
--- a/.github/workflows/atom-vllm-oot-test.yaml
+++ b/.github/workflows/atom-vllm-oot-test.yaml
@@ -133,7 +133,7 @@ jobs:
             extra_args: "--tensor-parallel-size 8"
             env_vars: ""
             accuracy_test_threshold: 0.93
-            runner: linux-atom-mi350-8
+            runner: atom-mi355-8gpu.predownload
           - model_name: "gpt-oss-120b"
             model_path: "openai/gpt-oss-120b"
             extra_args: "--tensor-parallel-size 1"
@@ -147,7 +147,7 @@ jobs:
             extra_args: "--tensor-parallel-size 4"
             env_vars: ""
             accuracy_test_threshold: 0.90
-            runner: linux-atom-mi350-4
+            runner: linux-atom-mi355-4
           - model_name: "Qwen3.5-35B-A3B-FP8"
             model_path: "Qwen/Qwen3.5-35B-A3B"
             extra_args: "--tensor-parallel-size 2"
@@ -157,7 +157,7 @@ jobs:
               ATOM_DISABLE_VLLM_PLUGIN_ATTENTION=1
               ATOM_USE_CUSTOM_ALL_GATHER=0
             accuracy_test_threshold: 0.83
-            runner: linux-atom-mi350-4
+            runner: linux-atom-mi355-4
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     env:


### PR DESCRIPTION
1. GPTOSS machine moves to single GPU machine
2. OOT CI shutdown when PR has been closed/merged
3. Remove OOT CI schedule run
4. Adjust the accuracy value threshold
5. Cache previous 3 docker images for speedup pulling