### PR TITLE
[Performance] Relaxed mtp 

### DIFF
--- a/atom/model_ops/rejection_sampler.py
+++ b/atom/model_ops/rejection_sampler.py
@@ -3,8 +3,17 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
+from atom.utils import envs
 from atom.utils.forward_context import SpecDecodeMetadata
 from torch import nn
+
+ATOM_ENABLE_RELAXED_MTP = envs.ATOM_ENABLE_RELAXED_MTP
+if ATOM_ENABLE_RELAXED_MTP:
+    RELAXED_TOP_N = 10
+    RELAXED_DELTA = 0.6
+else:
+    RELAXED_TOP_N = 1
+    RELAXED_DELTA = 0.0
 
 
 class RejectionSampler(nn.Module):
@@ -79,18 +88,42 @@ def rejection_sample(
     )
     num_bonus_tokens = torch.empty(batch_size, dtype=torch.int32, device=device)
 
-    # Rejection sampling for greedy sampling requests.
-    target_argmax = target_probs.argmax(dim=-1)
-    rejection_greedy_sample_kernel[(batch_size,)](
-        output_token_ids,
-        num_bonus_tokens,
-        cu_num_draft_tokens,
-        draft_token_ids,
-        target_argmax,
-        bonus_token_ids,
-        num_spec_steps,
-        num_warps=1,
-    )
+    if RELAXED_TOP_N <= 1:
+        # Strict greedy path: draft must exactly match target argmax
+        target_argmax = target_probs.argmax(dim=-1)
+        rejection_greedy_sample_kernel[(batch_size,)](
+            output_token_ids,
+            num_bonus_tokens,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            num_spec_steps,
+            num_warps=1,
+        )
+    else:
+        # Relaxed acceptance path: accept if draft is among top-N
+        # candidates with prob >= (top1_prob - delta)
+        probs = target_probs.softmax(dim=-1, dtype=torch.float32)
+        topn_probs, topn_ids = torch.topk(probs, RELAXED_TOP_N, dim=-1)
+
+        top1_probs = topn_probs[:, 0:1]
+        valid_mask = topn_probs >= (top1_probs - RELAXED_DELTA)
+        topn_ids[~valid_mask] = -1
+        topn_ids = topn_ids.to(torch.int32).contiguous()
+
+        rejection_relaxed_sample_kernel[(batch_size,)](
+            output_token_ids,
+            num_bonus_tokens,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            topn_ids,
+            bonus_token_ids,
+            num_spec_steps,
+            RELAXED_TOP_N,
+            num_warps=1,
+        )
+
     return output_token_ids, num_bonus_tokens
 
 
@@ -125,7 +158,7 @@ def rejection_greedy_sample_kernel(
             target_argmax_id = tl.load(target_argmax_ptr + start_idx + pos)
             target_argmax_id = tl.cast(target_argmax_id, tl.int32)
             if draft_token_id != target_argmax_id:
-                # Reject.
+                # rejected = False
                 rejected = True
             num_bonus_token += 1
         tl.store(
@@ -136,7 +169,70 @@ def rejection_greedy_sample_kernel(
     if rejected:
         bonus_token_id = INVALID_TOKEN
     else:
-        # If all tokens are accepted, append the bonus token.
+        bonus_token_id = tl.load(bonus_token_ids_ptr + req_idx)
+        num_bonus_token += 1
+    tl.store(
+        output_token_ids_ptr + req_idx * (num_spec_steps + 1) + num_draft_tokens,
+        bonus_token_id,
+    )
+    tl.store(num_bonus_tokens_ptr + req_idx, num_bonus_token)
+
+
+@triton.jit(do_not_specialize=["num_spec_steps", "top_n"])
+def rejection_relaxed_sample_kernel(
+    output_token_ids_ptr,  # [batch_size, num_spec_steps + 1]
+    num_bonus_tokens_ptr,
+    cu_num_draft_tokens_ptr,  # [batch_size]
+    draft_token_ids_ptr,  # [num_tokens]
+    topn_ids_ptr,  # [num_tokens, top_n] — candidate token ids, -1 = invalid
+    bonus_token_ids_ptr,  # [batch_size]
+    num_spec_steps,
+    top_n,
+):
+    req_idx = tl.program_id(0)
+
+    if req_idx == 0:
+        start_idx = 0
+    else:
+        start_idx = tl.load(cu_num_draft_tokens_ptr + req_idx - 1)
+    end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
+    num_draft_tokens = end_idx - start_idx
+
+    rejected = False
+    num_bonus_token = -1
+    INVALID_TOKEN: tl.constexpr = -1
+
+    for pos in range(num_draft_tokens):
+        if rejected:
+            output_id = INVALID_TOKEN
+        else:
+            draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
+
+            base_offset = (start_idx + pos) * top_n
+            top1_id = tl.load(topn_ids_ptr + base_offset)
+
+            found = False
+            for k in range(top_n):
+                candidate_id = tl.load(topn_ids_ptr + base_offset + k)
+                if candidate_id == draft_token_id:
+                    found = True
+
+            if found:
+                output_id = draft_token_id
+            else:
+                output_id = top1_id
+                rejected = True
+
+            num_bonus_token += 1
+
+        tl.store(
+            output_token_ids_ptr + req_idx * (num_spec_steps + 1) + pos,
+            output_id,
+        )
+
+    if rejected:
+        bonus_token_id = INVALID_TOKEN
+    else:
         bonus_token_id = tl.load(bonus_token_ids_ptr + req_idx)
         num_bonus_token += 1
     tl.store(

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -88,6 +88,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD": lambda: int(
         os.getenv("ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD", "1024")
     ),
+    # --- MTP (relaxed mtp for quantized mtp) ---
+    "ATOM_ENABLE_RELAXED_MTP": lambda: os.getenv("ATOM_ENABLE_RELAXED_MTP", "0").lower()
+    == "1",
 }
 
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -25,6 +25,7 @@ _ATOM_ENV_VARS = [
     "ATOM_DISABLE_VLLM_PLUGIN",
     "ATOM_DISABLE_VLLM_PLUGIN_ATTENTION",
     "ATOM_USE_CUSTOM_ALL_GATHER",
+    "ATOM_ENABLE_RELAXED_MTP",
 ]
 
 
@@ -84,6 +85,9 @@ class TestEnvsDefaults:
     def test_disable_vllm_plugin_attention_default(self):
         assert _get_envs().ATOM_DISABLE_VLLM_PLUGIN_ATTENTION is False
 
+    def test_atom_enable_relaxed_mtp_default(self):
+        assert _get_envs().ATOM_ENABLE_RELAXED_MTP is False
+
     def test_unknown_attr_raises(self):
         with pytest.raises(AttributeError):
             _ = _get_envs().ATOM_NONEXISTENT_VAR
@@ -131,6 +135,10 @@ class TestEnvsOverrides:
     def test_disable_vllm_plugin_attention_enabled(self, monkeypatch):
         monkeypatch.setenv("ATOM_DISABLE_VLLM_PLUGIN_ATTENTION", "1")
         assert _get_envs().ATOM_DISABLE_VLLM_PLUGIN_ATTENTION is True
+
+    def test_atom_enable_relaxed_mtp_enabled(self, monkeypatch):
+        monkeypatch.setenv("ATOM_ENABLE_RELAXED_MTP", "1")
+        assert _get_envs().ATOM_ENABLE_RELAXED_MTP is True
 
 
 class TestIsSet:


### PR DESCRIPTION
https://nvidia.github.io/TensorRT-LLM/blogs/tech_blog/blog02_DeepSeek_R1_MTP_Implementation_and_Optimization.html
TODO:
Note that the Relaxed Acceptance will only be used during the thinking phase, while the Strict Acceptance will still be used during the non-thinking phase. And the Relaxed Acceptance only supports the DeepSeek-R1 model now.
https://huggingface.co/amd/DeepSeek-R1-0528-MXFP4-ASQ/blob/main/tokenizer_config.json

1.
```
python -m atom.entrypoints.openai_server --kv_cache_dtype fp8 \
  --model  /shareddata/amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4/  -tp 8   --method mtp --num-speculative-tokens 3
  
python -m atom.benchmarks.benchmark_serving \
        --model="$MODEL_PATH" \
        --backend=vllm \
        --base-url="http://localhost:$PORT" \
        --dataset-name=random \
        --random-input-len="$ISL" \
        --random-output-len="$OSL" \
        --random-range-ratio 0.8 \
        --num-prompts=$(( CONC * 10 )) \
        --max-concurrency="$CONC" \
        --request-rate=inf \
        --ignore-eos \
        --percentile-metrics="ttft,tpot,itl,e2el" 2>&1 | tee -a "$LOG_FILE"

lm_eval \
  --model local-completions \
  --model_args model=/shareddata/amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4/,base_url=http://localhost:8000/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32 \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto

```


  | inp/out | 1k/1k |   |   |  
-- | -- | -- | -- | -- | --
  | batch_size | 1 | 4 | 16 | 128
TTFT/ms | baseline | 80.16 | 87 | 128.01 | 312.5
  | relaxed mtp | 74.66 | 90.29 | 123.41 | 310.09
TPOT/ms | baseline | 3.37 | 4.13 | 6.05 | 15.04
  | relaxed mtp | 3.16 | 3.9 | 5.94 | 14.6
throughput | baseline | 576.83 | 1836.6 | 4900.17 | 16191.63
  | relaxed mtp | 617.12 | 1904.39 | 5170.82 | 16689.51
uplift |   | 0.069847269 | 0.036910596 | 0.055232778 | 0.03074922
  |   |   |   |   |  
  | inp/out | 8k/1k
  | batch_size | 1 | 4 | 16 | 128
TTFT/ms | baseline | 247.38 | 308.99 | 467.68 | 1782.76
  | relaxed mtp | 247.82 | 297.22 | 452.26 | 1784.48
TPOT/ms | baseline | 3.5 | 4.85 | 8.76 | 36.36
  | relaxed mtp | 3.39 | 4.6 | 8.67 | 36.2
throughput | baseline | 2385.62 | 6850.53 | 14963.06 | 29758.57
  | relaxed mtp | 2453.04 | 7015.59 | 15427.88 | 30013.47
uplift |   | 0.028260997 | 0.024094486 | 0.031064502 | 0.0085656

2. 
deepseek-r1-0528
deepseek-r1-0528 | org | relaxed mxtp
-- | -- | --
Tasks | Value | Value
gpqa_diamond_generative_n_shot | 0.4899 | 0.4899
gsm8k | 0.9591 | 0.9303
gsm8k_platinum | 0.9777 | 0.9611
mmlu_redux (generative) | 0.4739 | 0.4486
- humanities | 0.505 | 0.4694
- other | 0.525 | 0.4561
- social sciences | 0.5388 | 0.5048
- stem | 0.3795 | 0.3944

deepseek-r1-0528-mxfp4


deepseek-r1-0528-moe-mxfp4 | org | relaxed mxtp
-- | -- | --
Tasks | Value | Value
gpqa_diamond_generative_n_shot | 0.4646 | 0.5
gsm8k_platinum | 0.9702 | 0.9586
gsm8k | 0.9431 | 0.9333
mmlu_redux (generative) | 0.4998 | 0.6315
- humanities | 0.5662 | 0.6813
- other | 0.531 | 0.6497
- social sciences | 0.5414 | 0.7097


3. 
```
MODEL=/shareddata/amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4/
ISL=1024
OSL=1024
CONC=10
PORT=8000
RESULT_FILENAME=Deepseek-R1-result
python -m atom.benchmarks.benchmark_serving \
  --model=$MODEL --backend=vllm --base-url=http://localhost:$PORT \
  --dataset-name=random \
  --random-input-len=$ISL --random-output-len=$OSL \
  --random-range-ratio 0.8 \
  --num-prompts=$(( $CONC * 20 )) \
  --max-concurrency=$CONC \
  --request-rate=inf --ignore-eos \
  --save-result --percentile-metrics="ttft,tpot,itl,e2el"
```  
**Acceptance** 
deepseek-r1-0528
**85.30%->89.36%**
deepseek-r1-0528-mxfp4-mtp-moe-ptpc-fp8
**81.72%->85.49%**
deepseek-r1-0528-mxfp4-mtp-moe-mxfp4
**81.47%->86.29%**

```
MODEL=/mnt/deepseek-ai/DeepSeek-R1-0528
ISL=1024
OSL=1024
CONC=10
PORT=8000
RESULT_FILENAME=Deepseek-R1-result
python -m atom.benchmarks.benchmark_serving \
  --model=$MODEL --backend=vllm --base-url=http://localhost:$PORT \
  --dataset-name=random \
  --random-input-len=$ISL --random-output-len=$OSL \
  --random-range-ratio 0.8 \
  --num-prompts=$(( $CONC * 20 )) \
  --max-concurrency=$CONC \
  --request-rate=inf --ignore-eos \
  --save-result --percentile-metrics="ttft,tpot,itl,e2el" \
  --use-chat-template

```
**Acceptance** 
deepseek-r1-0528
**48.21%->65.68%**
deepseek-r1-0528-mxfp4-mtp-moe-ptpc-fp8
**53.44%->68.48%**
deepseek-r1-0528-mxfp4-mtp-moe-mxfp4
**52.46%->67.76%**
 