### PR TITLE
fix: dashboard concurrency scaling use Total Tput, add MiniMax-M2.5, optimize topK

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -57,6 +57,16 @@
     "bench_args": "",
     "suffix": "",
     "runner": "atom-mi355-8gpu.predownload",
-    "env_vars": "HSA_NO_SCRATCH_RECLAIM=1"
+    "env_vars": ""
+  },
+  {
+    "display": "MiniMax-M2.5",
+    "path": "MiniMaxAI/MiniMax-M2.5",
+    "prefix": "MiniMax-M2.5",
+    "args": "--kv_cache_dtype fp8 -tp 2 --trust-remote-code",
+    "bench_args": "",
+    "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
   }
 ]

--- a/.github/benchmark/nightly_params.json
+++ b/.github/benchmark/nightly_params.json
@@ -8,7 +8,7 @@
   {
     "isl": 1024,
     "osl": 8192,
-    "concurrency": [1, 2, 4, 8, 16, 32, 64, 128, 256],
+    "concurrency": [1, 2, 4, 8, 16, 32, 64, 128],
     "random_range_ratio": 0.8
   },
   {

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -1210,7 +1210,7 @@ function buildConcurrencyScaling(canvasId, configs, familyName, famModels) {
   for (const [key, cfg] of Object.entries(configs)) {
     const sKey = `${cfg.backend}|${cfg.model}|${cfg.islOsl}`;
     if (!byKey[sKey]) byKey[sKey] = { backend: cfg.backend, model: cfg.model, islOsl: cfg.islOsl, tputPoints: [], tpotPoints: [], tputKeys: [], tpotKeys: [] };
-    if (cfg.throughput != null) { byKey[sKey].tputPoints.push({ x: cfg.conc, y: cfg.throughput }); byKey[sKey].tputKeys.push(key); }
+    if (cfg['Total Tput'] != null) { byKey[sKey].tputPoints.push({ x: cfg.conc, y: cfg['Total Tput'] }); byKey[sKey].tputKeys.push(key); }
     if (cfg.TPOT != null) { byKey[sKey].tpotPoints.push({ x: cfg.conc, y: cfg.TPOT }); byKey[sKey].tpotKeys.push(key); }
   }
 
@@ -1271,7 +1271,7 @@ function buildConcurrencyScaling(canvasId, configs, familyName, famModels) {
             const isTPOT = item.dataset.yAxisID === 'y2';
             return isTPOT
               ? ` TPOT:        ${fmtNum(item.parsed.y, 2)} ms`
-              : ` Throughput:  ${fmtNum(item.parsed.y, 1)} tok/s`;
+              : ` Total Tput:  ${fmtNum(item.parsed.y, 1)} tok/s`;
           },
           afterBody: () => '\nClick for details'
         }}
@@ -1286,7 +1286,7 @@ function buildConcurrencyScaling(canvasId, configs, familyName, famModels) {
         },
         y: {
           position: 'left', grid: chartGridOpts(),
-          title: { display: true, text: 'Throughput (tok/s)', color: C_TICK },
+          title: { display: true, text: 'Total Throughput (tok/s)', color: C_TICK },
           ticks: { color: C_TICK }, grace: '5%'
         },
         y2: {

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -5,10 +5,10 @@ from functools import lru_cache
 from typing import Optional
 
 import torch
-from atom.utils.custom_register import direct_register_custom_op
+from aiter.jit.utils.torch_guard import torch_compile_guard
 from atom.config import get_current_atom_config
 from atom.model_ops.utils import _has_module
-from aiter.jit.utils.torch_guard import torch_compile_guard
+from atom.utils.custom_register import direct_register_custom_op
 
 
 @torch_compile_guard()
@@ -99,7 +99,8 @@ def rocm_aiter_topk_softmax_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    is_fused = is_rocm_aiter_fusion_shared_expert_enabled()
+    if is_fused and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -134,7 +135,7 @@ def rocm_aiter_topk_softmax_impl(
         fused_shared_experts_for_kernel,
         fused_shared_experts_scoring_func,
     )
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    if is_fused and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 


### PR DESCRIPTION
## Summary
- Fix Concurrency Scaling chart in benchmark dashboard to use **Total Token throughput** instead of Output throughput, consistent with other dashboard metrics
- Add **MiniMax-M2.5** model to benchmark matrix (tp=2, trust-remote-code)
- Remove c=256 from 8k/1k nightly benchmark params
- Remove `HSA_NO_SCRATCH_RECLAIM` from Kimi config
- Cache `is_fused` check in `topK.py` to avoid redundant function calls

## Test plan
- [ ] Verify dashboard Concurrency Scaling chart shows Total Tput values
- [ ] Verify MiniMax-M2.5 benchmark runs successfully
- [ ] Verify topK behavior unchanged with cached is_fused check