### PR TITLE
CI: pin setuptools_scm below v9 in Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,6 +100,7 @@ RUN pip install --upgrade pip && \
         git cython3 ibverbs-utils openmpi-bin libopenmpi-dev \
         libpci-dev cmake libdw1 locales && \
     rm -rf /var/lib/apt/lists/*
+RUN pip install --upgrade "setuptools_scm<9"
 
 # --------------------------------------------------------------------
 # Stage 1: MORI — parallel
@@ -108,6 +109,7 @@ FROM base AS build_mori
 ARG MORI_COMMIT="b0dce4beebeb1f26c784eee17d5fd9785ee9447f"
 
 RUN echo "========== [Parallel] Building MORI ==========" && \
+    rm -rf /app/mori && \
     git clone https://github.com/ROCm/mori.git /app/mori && \
     cd /app/mori && \
     git checkout $MORI_COMMIT && \


### PR DESCRIPTION
## Summary
- add `RUN pip install --upgrade "setuptools_scm<9"` to `docker/Dockerfile`
- pin `setuptools_scm` below v9 to keep Docker build behavior stable

## Test plan
- [x] verify `docker/Dockerfile` includes the new pinning step after `pip install --upgrade pip`