### PR TITLE
test: add profiler regression guard for HIP graph replay

### DIFF
--- a/tests/test_profiler_regression.py
+++ b/tests/test_profiler_regression.py
@@ -16,7 +16,6 @@ new ROCm container or PyTorch build.
 Reference: ROCm/rocm-systems#4401, ROCm/pytorch#2579, ROCm/pytorch#3056
 """
 
-import ctypes
 import json
 import os
 import subprocess
@@ -25,7 +24,6 @@ import tempfile
 import pytest
 import torch
 import torch.nn as nn
-
 
 # ---------------------------------------------------------------------------
 # Thresholds
@@ -224,9 +222,9 @@ class TestProfilerRegression:
         backend = _get_libtorch_profiler_backend()
         if backend == "rocprofiler-sdk":
             pytest.fail(
-                f"libtorch_cpu.so links librocprofiler-sdk.so instead of "
-                f"libroctracer64.so. This causes ~270us overhead per "
-                f"hipGraphLaunch. See ROCm/pytorch#2579 for the fix."
+                "libtorch_cpu.so links librocprofiler-sdk.so instead of "
+                "libroctracer64.so. This causes ~270us overhead per "
+                "hipGraphLaunch. See ROCm/pytorch#2579 for the fix."
             )
         assert backend in (
             "roctracer",


### PR DESCRIPTION
## Summary

- Adds a lightweight integration test (~3 seconds on MI355) that detects rocprofiler-sdk interception overhead in HIP graph replay
- When PyTorch kineto links `librocprofiler-sdk.so` instead of `libroctracer64.so`, every `hipGraphLaunch` incurs ~270us of overhead, dropping GPU occupancy from ~97% to ~75%
- This directly impacts decode throughput in TP>1 serving scenarios

## What it checks

| Metric | Pass | Fail (regression) |
|---|---|---|
| `ldd libtorch_cpu.so` | `libroctracer64.so` | `librocprofiler-sdk.so` |
| GPU occupancy | > 80% | < 80% (healthy = 97%) |
| Gaps > 100us | <= 5 | > 5 (healthy = 0) |
| hipGraphLaunch avg | < 150us | > 150us (healthy = 50us) |

## Background

ROCm/pytorch#3056 (merged 2026-03-17) re-enabled rocprofiler-sdk in kineto after ROCm/pytorch#2579 had reverted it. The SDK's interception hooks add overhead to every HIP API call, which is particularly harmful for HIP graph replay where kernel execution times are small relative to dispatch overhead.

On a real model (Qwen3-0.6B, 28 layers, TP=1), the regression drops graph replay GPU occupancy from 89.5% to 9.0%, with hipGraphLaunch taking 103ms vs 7ms.

## Test plan

- [x] PASS on `rocm/vllm-dev:base_custom_rocm_7.2.1_torch_triton_20260326_full_fix` (roctracer kineto)
- [x] Correctly FAIL on `rocm/vllm-dev:base_custom_rocm_7.2.1_torch_triton_20260326` (rocprofiler-sdk kineto)
- [x] Runs via `pytest` (2 tests, 3.27s) and standalone `python3` (3.8s)
- [x] No dependency on ATOM or AITER — uses only PyTorch + standard transformer ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)