### PR TITLE
fix: accuracy dashboard pipeline fixes

### DIFF
--- a/.github/scripts/accuracy_to_dashboard.py
+++ b/.github/scripts/accuracy_to_dashboard.py
@@ -80,18 +80,23 @@ def build_entries(
         except (TypeError, ValueError):
             pass
 
-        # Include num_fewshot from lm_eval config
+        # Include num_fewshot: check configs.gsm8k first, then top-level config
         lm_config = data.get("config", {})
-        num_fewshot = lm_config.get("num_fewshot")
+        task_configs = data.get("configs", {})
+        num_fewshot = task_configs.get("gsm8k", {}).get("num_fewshot") or lm_config.get(
+            "num_fewshot"
+        )
         if num_fewshot is not None:
             extra_parts.append(f"fewshot: {num_fewshot}")
 
         model_args = lm_config.get("model_args", "")
-        if model_args:
+        if isinstance(model_args, str) and model_args:
             for arg in model_args.split(","):
                 if arg.startswith("model="):
                     extra_parts.append(f"Model: {arg[6:]}")
                     break
+        elif isinstance(model_args, dict) and "model" in model_args:
+            extra_parts.append(f"Model: {model_args['model']}")
 
         extra = " | ".join(extra_parts) if extra_parts else None
 

--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -96,7 +96,7 @@ if [ "$TYPE" == "accuracy" ]; then
   mkdir -p accuracy_test_results
   RESULT_FILENAME=accuracy_test_results/$(date +%Y%m%d%H%M%S).json
   lm_eval --model local-completions \
-          --model_args model="$MODEL_PATH",base_url=http://localhost:8000/v1/completions,num_concurrent=16,max_retries=3,tokenized_requests=False,trust_remote_code=True \
+          --model_args model="$MODEL_PATH",base_url=http://localhost:8000/v1/completions,num_concurrent=65,max_retries=3,tokenized_requests=False,trust_remote_code=True \
           --tasks gsm8k \
           --num_fewshot 3 \
           --output_path "${RESULT_FILENAME}"

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -443,8 +443,20 @@ jobs:
 
       - name: Collect Test Summary
         if: success()
+        env:
+          MODEL_NAME: ${{ matrix.model_name }}
         run: |
-          echo "Accuracy Test Summary for ${{ matrix.model_name }}:" >> $GITHUB_STEP_SUMMARY
+          # Read threshold and score for summary
+          threshold=$(python3 -c "
+          import json, os
+          models = json.load(open('.github/benchmark/models_accuracy.json', encoding='utf-8'))
+          name = os.environ['MODEL_NAME']
+          print(next((m.get('accuracy_threshold', 0) for m in models if m['model_name'] == name), 0))
+          ")
+          result_file=$(ls -1t accuracy_test_results/*.json 2>/dev/null | head -n 1)
+          score=$(jq '.results.gsm8k["exact_match,flexible-extract"]' "$result_file" 2>/dev/null || echo "N/A")
+
+          echo "Accuracy Test Summary for ${{ matrix.model_name }} (threshold: ${threshold}, score: ${score}):" >> $GITHUB_STEP_SUMMARY
           awk '/\|Tasks\|Version\|/,/^$/ { if (NF > 0) print }' atom_accuracy_output.txt >> $GITHUB_STEP_SUMMARY
 
       - name: Upload output


### PR DESCRIPTION
## Summary

Fixes for the accuracy dashboard pipeline (#433) based on first CI run failure.

- **`accuracy_to_dashboard.py`**: `model_args` in lm_eval output is a `dict`, not a `string` — caused `AttributeError: 'dict' object has no attribute 'split'`
- **`accuracy_to_dashboard.py`**: `num_fewshot` is stored in `configs.gsm8k.num_fewshot`, not `config.num_fewshot`
- **`atom-test.yaml`**: Add threshold and score to CI step summary (e.g. `Accuracy Test Summary for DeepSeek-R1-0528 (threshold: 0.94, score: 0.9515):`)

## Test plan
- [ ] Verified with real CI artifacts downloaded from run #23678762020
- [ ] Script produces correct output with 3 test models
- [ ] CI: accuracy-dashboard job should succeed on this PR's merge