### PR TITLE
Remove Qwen3.5 from OOT CI

### DIFF
--- a/.github/scripts/atom_oot_test.sh
+++ b/.github/scripts/atom_oot_test.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 #   accuracy - run gsm8k accuracy test and save result JSON
 #
 # MODE:
-#   ci    - DeepSeek-R1 FP8, gpt-oss-120b, Kimi-K2 TP4, Qwen3.5-35B-A3B-FP8
+#   ci    - DeepSeek-R1 FP8, gpt-oss-120b, Kimi-K2 TP4
 #   full  - all OOT-supported models
 #
 # Optional model_name can be used to run a single model in full mode.

--- a/.github/workflows/atom-vllm-oot-test.yaml
+++ b/.github/workflows/atom-vllm-oot-test.yaml
@@ -148,16 +148,6 @@ jobs:
             env_vars: ""
             accuracy_test_threshold: 0.90
             runner: linux-atom-mi355-4
-          - model_name: "Qwen3.5-35B-A3B-FP8"
-            model_path: "Qwen/Qwen3.5-35B-A3B"
-            extra_args: "--tensor-parallel-size 2"
-            # FIXME: Remove these temporary Qwen3.5 workarounds after the
-            # aiter fix landed
-            env_vars: |
-              ATOM_DISABLE_VLLM_PLUGIN_ATTENTION=1
-              ATOM_USE_CUSTOM_ALL_GATHER=0
-            accuracy_test_threshold: 0.83
-            runner: linux-atom-mi355-4
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     env:


### PR DESCRIPTION
We found an accuracy regression issue on Qwen3.5. We need time for debugging. It may not be an easy case with a quick fix. To avoid influencing the other PRs, we decide to remove it from OOT CI first. When the functionality/accuracy come back and become stable, we will add it back.