### PR TITLE
[OOT CI] total remove Qwen3.5 in OOT CI as it has functionality regression

### DIFF
--- a/.github/workflows/atom-vllm-oot-test.yaml
+++ b/.github/workflows/atom-vllm-oot-test.yaml
@@ -148,16 +148,6 @@ jobs:
             env_vars: ""
             accuracy_test_threshold: 0.90
             runner: linux-atom-mi355-4
-          - model_name: "Qwen3.5-35B-A3B-FP8"
-            model_path: "Qwen/Qwen3.5-35B-A3B"
-            extra_args: "--tensor-parallel-size 2"
-            # FIXME: Remove these temporary Qwen3.5 workarounds after the
-            # aiter fix landed
-            env_vars: |
-              ATOM_DISABLE_VLLM_PLUGIN_ATTENTION=1
-              ATOM_USE_CUSTOM_ALL_GATHER=0
-            accuracy_test_threshold: 0.83
-            runner: linux-atom-mi355-4
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     env:


### PR DESCRIPTION
<img width="800" height="246" alt="image" src="https://github.com/user-attachments/assets/00b3c3f8-fe1d-4dd6-90ca-cb4d3ca57453" />