### PR TITLE
fix: skip FP8 quant for Indexer.weights_proj + dashboard date fix

### DIFF
--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -2143,7 +2143,7 @@ function renderAccuracyTab() {
     const statusClass = !hasThreshold ? 'trend-neutral' : margin >= 0 ? 'trend-up' : 'trend-down';
     const reg = accuracyRegressions[key];
     const regClass = reg ? (reg.severity === 'critical' ? 'regression' : 'regression-warning') : '';
-    const dateStr = new Date(acc.date * 1000).toLocaleDateString();
+    const dateStr = fmtDate(acc.date);
     const href = safeHref(acc.runUrl);
 
     html += `
@@ -2219,7 +2219,7 @@ function renderAccuracyMiniChart(key, chartCache) {
   // Build data sorted ascending by date
   const sorted = [...history].sort((a, b) => a.date - b.date);
   const labels = sorted.map(h => {
-    const dt = new Date(h.date * 1000);
+    const dt = new Date(h.date);
     return `${dt.getMonth()+1}/${dt.getDate()}`;
   });
   const scores = sorted.map(h => h.score);

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1937,11 +1937,12 @@ class FusedMoE(torch.nn.Module):
         self.global_num_experts = num_experts
         self.shared_expert_scoring_func = shared_expert_scoring_func
 
+        fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
         self.num_fused_shared_experts = (
             config.n_shared_experts
             if config is not None
             and hasattr(config, "n_shared_experts")
-            and is_rocm_aiter_fusion_shared_expert_enabled()
+            and fuse_shared_experts
             else 0
         )
         self.routed_scaling_factor = (
@@ -1971,10 +1972,7 @@ class FusedMoE(torch.nn.Module):
                 ),
                 dim=0,
             )
-        if (
-            is_rocm_aiter_fusion_shared_expert_enabled()
-            and self.num_fused_shared_experts > 0
-        ):
+        if fuse_shared_experts and self.num_fused_shared_experts > 0:
             init_aiter_topK_meta_data(
                 n_routed_experts=self.global_num_experts,
                 n_shared_experts=self.num_fused_shared_experts,
@@ -1989,7 +1987,7 @@ class FusedMoE(torch.nn.Module):
                 max_num_tokens=atom_config.max_num_batched_tokens,
                 is_EP=self.use_ep,
             )
-        if is_rocm_aiter_fusion_shared_expert_enabled():
+        if fuse_shared_experts:
             self.local_num_experts += self.num_fused_shared_experts
         assert intermediate_size % self.tp_size == 0
         self.hidden_size = hidden_size

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -99,8 +99,8 @@ def rocm_aiter_topk_softmax_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    is_fused = is_rocm_aiter_fusion_shared_expert_enabled()
-    if is_fused and num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -135,7 +135,7 @@ def rocm_aiter_topk_softmax_impl(
         fused_shared_experts_for_kernel,
         fused_shared_experts_scoring_func,
     )
-    if is_fused and num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -169,7 +169,8 @@ def rocm_aiter_biased_grouped_topk_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -200,7 +201,7 @@ def rocm_aiter_biased_grouped_topk_impl(
         need_renorm,
         routed_scaling_factor,
     )
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -217,7 +218,8 @@ def rocm_aiter_biased_grouped_topk_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     token = gating_output.shape[0]
     device = gating_output.device
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -248,7 +250,7 @@ def rocm_aiter_biased_grouped_topk_fake(
     else:
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -270,7 +272,8 @@ def rocm_aiter_grouped_topk_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -301,7 +304,7 @@ def rocm_aiter_grouped_topk_impl(
         scoring_func,
         routed_scaling_factor,
     )
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -320,7 +323,8 @@ def rocm_aiter_grouped_topk_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     token = gating_output.shape[0]
     device = gating_output.device
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -351,7 +355,7 @@ def rocm_aiter_grouped_topk_fake(
     else:
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
-    if is_rocm_aiter_fusion_shared_expert_enabled() and num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1142,7 +1142,7 @@ class Indexer(nn.Module):
         self.weights_proj = ReplicatedLinear(
             hidden_size,
             self.n_head,
-            quant_config=quant_config,
+            quant_config=None,
             prefix=f"{prefix}.weights_proj",
         )
         self.softmax_scale = self.head_dim**-0.5


### PR DESCRIPTION
## Summary

- **Fix GLM-5 GEMM crash**: `Indexer.weights_proj` was incorrectly routed to FP8 blockscale GEMM, causing `RuntimeError: This GEMM is not supported!` during model loading. The HF config excludes `indexers_proj` but ATOM's actual layer path is `indexer.weights_proj` — name mismatch causes the exclude check to fail silently. Fix: `quant_config=None` for `weights_proj` to use BF16 GEMM.
- **Fix dashboard date display**: Accuracy tab was multiplying millisecond timestamps by 1000, showing wrong dates.
- **Cache `is_rocm_aiter_fusion_shared_expert_enabled()`**: Avoid repeated function calls in hot-path topK functions and MoE init by caching result in local var `fuse_shared_experts`.

## Test plan

- [x] GLM-5-FP8 server starts successfully with `--trust-remote-code`
- [x] GSM8K accuracy: flexible-extract=0.9477, strict-match=0.9492 (threshold: 0.93)