### PR TITLE
[Enhancement] Support quark gpt_oss 120b wmxfp4 afp8

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -239,6 +239,24 @@ def load_model(
                 return maybe_matching_name
         return None
 
+    def extract_expert_target_and_id(name: str) -> Tuple[str, int] | None:
+        """Extract fused parameter name and expert id from expert checkpoint name.
+        like 'model.layers.10.mlp.experts.100.w2_bias' -> model.layers.10.mlp.experts.w2_bias and 100
+        """
+        if "experts" not in name:
+            return None
+        parts = name.split(".")
+        ids = [s for s in parts if s.isdigit()]
+        if len(ids) != 2:
+            return None
+        expert_id = int(ids[-1])
+        expert_token = str(expert_id)
+        if expert_token not in parts:
+            return None
+        fused_parts = parts.copy()
+        fused_parts.pop(len(parts) - 1 - parts[::-1].index(expert_token))
+        return ".".join(fused_parts), expert_id
+
     # need to record the loaded weight name for vllm load check
     # it is only used in plugin mode for vllm
     loaded_weights_record: set[str] = set()
@@ -306,9 +324,9 @@ def load_model(
                     if remapped_name is None:
                         continue
                     name = remapped_name
-            name_suffix = name.split(".")[-1]
-            if name_suffix in weights_mapping.keys():
-                name = name.replace(name_suffix, weights_mapping[name_suffix])
+            for mapping_part in weights_mapping.keys():
+                if mapping_part in name:
+                    name = name.replace(mapping_part, weights_mapping[mapping_part])
             if "weight_scale_inv" in name:
                 name = name.replace("weight_scale_inv", "weight_scale")
 
@@ -454,6 +472,26 @@ def load_model(
                     if not matched:
                         if "mtp" in name and not spec_decode:
                             continue
+                        if merged_target := extract_expert_target_and_id(name):
+                            fused_name, expert_id = merged_target
+                            try:
+                                param = model.get_parameter(fused_name)
+                            except AttributeError:
+                                continue
+                            weight_loader = getattr(
+                                param, "weight_loader", default_weight_loader
+                            )
+                            futures.append(
+                                executor.submit(
+                                    weight_loader,
+                                    param,
+                                    weight_tensor,
+                                    "",  # use merged moe loader
+                                    "",
+                                    expert_id,
+                                )
+                            )
+                            loaded_weights_record.add(prefix + name)
                         try:
                             param = model.get_parameter(name)
                         except AttributeError:

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -636,6 +636,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.quant_type = quant_config.quant_type
         self.quant_dtype = quant_config.quant_dtype
         self.quant_method = quant_config.quant_method or ""
+        self.static_input_scales = not quant_config.is_dynamic
         self.block_quant = (
             self.quant_type == QuantType.per_1x128
             or self.quant_type == QuantType.per_1x32
@@ -758,6 +759,24 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             set_weight_attrs(w2_bias, extra_weight_attrs)
         else:
             layer.register_parameter("w2_bias", None)
+
+        if self.static_input_scales:
+            w13_input_scale = torch.nn.Parameter(
+                torch.ones(num_experts, dtype=torch.float32),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_input_scale", w13_input_scale)
+            set_weight_attrs(w13_input_scale, extra_weight_attrs)
+
+            w2_input_scale = torch.nn.Parameter(
+                torch.ones(num_experts, dtype=torch.float32),
+                requires_grad=False,
+            )
+            layer.register_parameter("w2_input_scale", w2_input_scale)
+            set_weight_attrs(w2_input_scale, extra_weight_attrs)
+        else:
+            layer.w13_input_scale = None
+            layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer):
         if layer.w13_bias is not None:
@@ -987,6 +1006,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             fused_shared_experts_scoring_func=fused_shared_experts_scoring_func,
             routed_scaling_factor=layer.routed_scaling_factor,
         )
+        a1_scale = getattr(layer, "w13_input_scale", None)
+        a2_scale = getattr(layer, "w2_input_scale", None)
         if self.fused_experts is None:
             return fused_moe(
                 x,
@@ -999,6 +1020,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 quant_type=self.quant_type,
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
+                a1_scale=a1_scale,
+                a2_scale=a2_scale,
                 doweight_stage1=apply_router_weight_on_input,
                 hidden_pad=self.hidden_pad,
                 intermediate_pad=self.intermediate_pad,
@@ -1019,8 +1042,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             expert_map=expert_map,
             w1_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
-            a1_scale=None,
-            a2_scale=None,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
             bias1=layer.w13_bias,
             bias2=layer.w2_bias,
             hidden_pad=self.hidden_pad,
@@ -2267,7 +2290,20 @@ class FusedMoE(torch.nn.Module):
         self,
         param: torch.nn.Parameter,
         loaded_weight: torch.Tensor,
+        expert_id: Optional[int] = None,
     ):
+        target_param = param
+        # single_expert means gate_up_proj.shape=[2880*2, 1440] from quark
+        maybe_single_expert_input = loaded_weight.dim() == param.dim() - 1
+        if expert_id is not None and maybe_single_expert_input:
+            local_expert_id = self._map_global_expert_id_to_local_expert_id(expert_id)
+            if local_expert_id == -1:
+                return
+            # Support loading a split/single expert tensor while reusing the
+            # original merged loading logic.
+            if loaded_weight.dim() == param.dim() - 1:
+                loaded_weight = loaded_weight.unsqueeze(0)
+                target_param = param[local_expert_id : local_expert_id + 1]
         # (FIXME) for gpt-oss all experts are combined
         mxfp4_block = 32
         ep_rank_start = self.ep_rank * self.local_num_experts
@@ -2276,62 +2312,91 @@ class FusedMoE(torch.nn.Module):
         tp_rank_end = tp_rank_start + self.intermediate_size_per_partition
         if param is getattr(self, "w13_bias", None):
             if self.use_ep:
-                narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
+                if loaded_weight.shape[0] == target_param.shape[0]:
+                    narrow_weight = loaded_weight
+                else:
+                    narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
             else:
                 narrow_weight = loaded_weight[:, 2 * tp_rank_start : 2 * tp_rank_end]
             dim1 = narrow_weight.shape[1]
-            param[:, :dim1].copy_(narrow_weight)
+            target_param[:, :dim1].copy_(narrow_weight)
         elif param is getattr(self, "w2_bias", None):
             if self.use_ep:
-                narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
+                if loaded_weight.shape[0] == target_param.shape[0]:
+                    narrow_weight = loaded_weight
+                else:
+                    narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
             else:
                 narrow_weight = loaded_weight
                 if self.tp_rank != 0:
                     narrow_weight.zero_()
             dim1 = narrow_weight.shape[1]
-            param[:, :dim1].copy_(narrow_weight)
+            target_param[:, :dim1].copy_(narrow_weight)
         elif param is getattr(self, "w13_weight", None):
             loaded_weight = loaded_weight.view(*loaded_weight.shape[:2], -1)
             if self.use_ep:
-                narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
+                if loaded_weight.shape[0] == target_param.shape[0]:
+                    narrow_weight = loaded_weight
+                else:
+                    narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
             else:
                 narrow_weight = loaded_weight[
                     :, 2 * tp_rank_start : 2 * tp_rank_end, ...
                 ]
             dim1, dim2 = narrow_weight.shape[1:]
-            param.view(torch.uint8)[:, :dim1, :dim2].copy_(
+            target_param.view(torch.uint8)[:, :dim1, :dim2].copy_(
                 narrow_weight.view(torch.uint8)
             )
         elif param is getattr(self, "w2_weight", None):
             loaded_weight = loaded_weight.view(*loaded_weight.shape[:2], -1)
             if self.use_ep:
-                narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
+                if loaded_weight.shape[0] == target_param.shape[0]:
+                    narrow_weight = loaded_weight
+                else:
+                    narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
             else:
                 narrow_weight = loaded_weight[
                     ..., tp_rank_start // 2 : tp_rank_end // 2
                 ]
             dim1, dim2 = narrow_weight.shape[1:]
-            param.view(torch.uint8)[:, :dim1, :dim2].copy_(
+            target_param.view(torch.uint8)[:, :dim1, :dim2].copy_(
                 narrow_weight.view(torch.uint8)
             )
         elif param is getattr(self, "w13_weight_scale", None):
             if self.use_ep:
-                narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
+                if loaded_weight.shape[0] == target_param.shape[0]:
+                    narrow_weight = loaded_weight
+                else:
+                    narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
             else:
                 narrow_weight = loaded_weight[
                     :, 2 * tp_rank_start : 2 * tp_rank_end, ...
                 ]
             dim1, dim2 = narrow_weight.shape[1:]
-            param[:, :dim1, :dim2].copy_(narrow_weight)
+            target_param[:, :dim1, :dim2].copy_(narrow_weight)
         elif param is getattr(self, "w2_weight_scale", None):
             if self.use_ep:
-                narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
+                if loaded_weight.shape[0] == target_param.shape[0]:
+                    narrow_weight = loaded_weight
+                else:
+                    narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
             else:
                 narrow_weight = loaded_weight[
                     ..., tp_rank_start // mxfp4_block : tp_rank_end // mxfp4_block
                 ]
             dim1, dim2 = narrow_weight.shape[1:]
-            param[:, :dim1, :dim2].copy_(narrow_weight)
+            target_param[:, :dim1, :dim2].copy_(narrow_weight)
+        elif param is getattr(self, "w13_input_scale", None) or param is getattr(
+            self, "w2_input_scale", None
+        ):
+            # input_scale is scalar per expert.
+            if loaded_weight.dim() == 0:
+                loaded_weight = loaded_weight.unsqueeze(0)
+            if self.use_ep and loaded_weight.shape[0] != target_param.shape[0]:
+                narrow_weight = loaded_weight[ep_rank_start:ep_rank_end, ...]
+            else:
+                narrow_weight = loaded_weight
+            target_param[: narrow_weight.shape[0]].copy_(narrow_weight)
 
     def weight_loader(
         self,
@@ -2342,7 +2407,7 @@ class FusedMoE(torch.nn.Module):
         expert_id: int = 0,
     ) -> None:
         if self.layer_quant_config.quant_dtype == dtypes.fp4x2 and weight_name == "":
-            self.mxf4_merged_weight_loader(param, loaded_weight)
+            self.mxf4_merged_weight_loader(param, loaded_weight, expert_id)
             return
 
         expert_id = self._map_global_expert_id_to_local_expert_id(expert_id)

--- a/atom/models/gpt_oss.py
+++ b/atom/models/gpt_oss.py
@@ -376,12 +376,17 @@ class GptOssForCausalLM(nn.Module):
         "gate_up_proj_input_scale": "w13_input_scale",
         "down_proj_scales": "w2_weight_scale",
         "down_proj_input_scale": "w2_input_scale",
-        # MoE other weights
-        "gate_up_proj": "w13_weight",
-        "down_proj": "w2_weight",
-        # MoE Bias
         "gate_up_proj_bias": "w13_bias",
         "down_proj_bias": "w2_bias",
+        # Quark weights
+        ".gate_up_proj.weight": ".w13_weight",
+        ".gate_up_proj.weight_scale": ".w13_weight_scale",
+        ".gate_up_proj.input_scale": ".w13_input_scale",
+        ".gate_up_proj.bias": ".w13_bias",
+        ".down_proj.weight": ".w2_weight",
+        ".down_proj.weight_scale": ".w2_weight_scale",
+        ".down_proj.input_scale": ".w2_input_scale",
+        ".down_proj.bias": ".w2_bias",
     }
 
     def __init__(


### PR DESCRIPTION
load [amd/gpt_oss_120b_w_mxfp4_a_fp8](https://huggingface.co/amd/gpt-oss-120b-w-mxfp4-a-fp8)

```
export ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION=0
python3 -m atom.entrypoints.openai_server --model /shareddata/amd/gpt-oss-120b-w-mxfp4-a-fp8 --port 8000
lm_eval \
  --model local-completions \
  --model_args "model=/shareddata/amd/gpt-oss-120b-w-mxfp4-a-fp8,base_url=http://localhost:8000/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto 
```


**gpt-oss-120b**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4647|±  |0.0137|
|     |       |strict-match    |     5|exact_match|↑  |0.3108|±  |0.0127|

**amd/gpt-oss-120b-w-mxfp4-a-fp8 tp1**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4807|±  |0.0138|
|     |       |strict-match    |     5|exact_match|↑  |0.2889|±  |0.0125|

Thanks to https://github.com/ROCm/ATOM/pull/449

**amd/gpt-oss-120b-w-mxfp4-a-fp8 tp4**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5110|±  |0.0138|
|     |       |strict-match    |     5|exact_match|↑  |0.2441|±  |0.0118|

```
python3 -m atom.examples.simple_inference  --model /shareddata/amd/gpt-oss-120b-w-mxfp4-a-fp8  -tp 2 --port 8000 --enable-expert-parallel
lm_eval \
  --model local-completions \
  --model_args "model=/shareddata/amd/gpt-oss-120b-w-mxfp4-a-fp8,base_url=http://localhost:8000/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto 
```

**amd/gpt-oss-120b-w-mxfp4-a-fp8 tp2**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4807|±  |0.0138|
|     |       |strict-match    |     5|exact_match|↑  |0.2790|±  |0.0124|




