### PR TITLE
Fix GLM-5-FP8 Indexer.weights_proj GEMM crash via exclude name remapping

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -402,7 +402,10 @@ class QuantizationConfig:
         return False
 
     def remap_layer_name(
-        self, hf_config: PretrainedConfig, packed_modules_mapping: dict | None = None
+        self,
+        hf_config: PretrainedConfig,
+        packed_modules_mapping: dict | None = None,
+        quant_exclude_name_mapping: dict[str, str] | None = None,
     ):
         model_type = hf_config.model_type
         self.packed_modules_mapping = (
@@ -453,6 +456,17 @@ class QuantizationConfig:
         for name in self.exclude_layers:
             new_exclude.extend(_remap_layer_name(name))
         self.exclude_layers = list(dict.fromkeys(new_exclude))
+
+        # Apply model-declared HF-name to ATOM-path translations for exclude entries.
+        # Models that have a mismatch between their HF quant config names and ATOM
+        # module paths declare `quant_exclude_name_mapping` as a class attribute.
+        if quant_exclude_name_mapping:
+            new_excludes = []
+            for name in self.exclude_layers:
+                for old, new in quant_exclude_name_mapping.items():
+                    name = name.replace(old, new)
+                new_excludes.append(name)
+            self.exclude_layers = list(dict.fromkeys(new_excludes))
 
 
 _CONFIG_REGISTRY: dict[str, str] = {

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -572,7 +572,9 @@ class ModelRunner:
         # The model construction depends on quant_config,
         # so we must complete the remapping for layers before constructing the model.
         config.quant_config.remap_layer_name(
-            config.hf_config, getattr(model_class, "packed_modules_mapping", {})
+            config.hf_config,
+            getattr(model_class, "packed_modules_mapping", {}),
+            getattr(model_class, "quant_exclude_name_mapping", {}),
         )
         self.model = model_class(config)
         torch.set_default_device(None)

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1172,7 +1172,7 @@ class Indexer(nn.Module):
         self.weights_proj = ReplicatedLinear(
             hidden_size,
             self.n_head,
-            quant_config=None,
+            quant_config=quant_config,
             prefix=f"{prefix}.weights_proj",
         )
         self.softmax_scale = self.head_dim**-0.5
@@ -1991,4 +1991,11 @@ class DeepseekV3ForCausalLM(DeepseekV2ForCausalLM):
 class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
     """GLM 5.0 MoE (structurally similar to DeepSeek v3.2). Reuses DeepseekV2 implementation."""
 
-    pass
+    # GLM-5's HF quant config uses `indexers_proj` in modules_to_not_convert, but
+    # the ATOM module path is `indexer.weights_proj`.  Declaring the mapping here
+    # keeps the translation co-located with the model and out of config.py.
+    quant_exclude_name_mapping: dict[str, str] = {
+        # HF quant config uses "indexers_proj" but the ATOM module path is
+        # "indexer.weights_proj".  str.replace translates each exclude entry.
+        "indexers_proj": "indexer.weights_proj",
+    }


### PR DESCRIPTION
GLM-5's HF quant config lists `indexers_proj` in modules_to_not_convert, but ATOM's actual module path is `indexer.weights_proj`. The name mismatch meant _is_excluded() was never matched, so weights_proj received an FP8 quant config and was routed to blockscale GEMM, which doesn't support that shape.

Fix: translate `indexers_proj` -> `indexer.weights_proj` in remap_layer_name() for glm_moe_dsa models, so the HF exclude list flows through correctly. Removes the quant_config=None reverting #439 .

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
GLM-5-FP8 served with
```
 python -m atom.entrypoints.openai_server --model /scratch/models/zai-org/GLM-5-FP8/ --trust-remote-code -tp 8 --kv_cache_dtype fp8 
```
lm-eval scores are the same
```
lm_eval --model local-completions   --model_args "model=/scratch/models/zai-org/GLM-5-FP8/,base_url=http://localhost:8000/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32"   --tasks gsm8k   --num_fewshot 5   --batch_size 1
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9447|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9447|±  |0.0063|

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
