### PR TITLE
Add Qwen3.5 to proper layer remap

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -422,7 +422,14 @@ class QuantizationConfig:
                     "gate_proj": ("gate_up_proj", 0),
                     "up_proj": ("gate_up_proj", 1),
                 }
-        elif model_type == "qwen3_moe" or model_type == "qwen3_next":
+        elif model_type in (
+            "qwen3_moe",
+            "qwen3_next",
+            "qwen3_5",
+            "qwen3_5_text",
+            "qwen3_5_moe",
+            "qwen3_5_moe_text",
+        ):
             if getattr(hf_config, "mlp_only_layers", []):
                 self.packed_modules_mapping["gate_up_proj"] = ["gate_proj", "up_proj"]
 


### PR DESCRIPTION
remap_layer_name already has the correct mechanism but it doesn't include Qwen3.5. This PR adds it enabling proper remapping from "gate_up_proj" -> ["gate_proj", "up_proj"]

Fix regression from #237 

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
