### PR TITLE
[FIX] wrapper fused_qk_rmsnorm to ensure correct dispatch

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -683,6 +683,36 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant(
     return q_c, q_c_scale, kv_c_normed, k_pe
 
 
+def _fused_qk_rmsnorm_fake(
+    q_c: torch.Tensor,
+    q_a_layernorm_weight: torch.Tensor,
+    q_a_layernorm_variance_epsilon: float,
+    kv_c: torch.Tensor,
+    kv_a_layernorm_weight: torch.Tensor,
+    kv_a_layernorm_variance_epsilon: float,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return torch.empty_like(q_c), torch.empty_like(kv_c)
+
+
+@torch_compile_guard(gen_fake=_fused_qk_rmsnorm_fake)
+def _fused_qk_rmsnorm(
+    q_c: torch.Tensor,
+    q_a_layernorm_weight: torch.Tensor,
+    q_a_layernorm_variance_epsilon: float,
+    kv_c: torch.Tensor,
+    kv_a_layernorm_weight: torch.Tensor,
+    kv_a_layernorm_variance_epsilon: float,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return fused_qk_rmsnorm(
+        q_c,
+        q_a_layernorm_weight,
+        q_a_layernorm_variance_epsilon,
+        kv_c,
+        kv_a_layernorm_weight,
+        kv_a_layernorm_variance_epsilon,
+    )
+
+
 class DeepseekV2MLP(nn.Module):
 
     def __init__(
@@ -1519,7 +1549,7 @@ class DeepseekV2MLAAttention(nn.Module):
                         transpose_scale=True,
                     )
                 elif self.fuse_qknorm:
-                    hidden_states_or_q_c, kv_c_normed = fused_qk_rmsnorm(
+                    hidden_states_or_q_c, kv_c_normed = _fused_qk_rmsnorm(
                         q_c,
                         self.q_a_layernorm.weight,
                         self.q_a_layernorm.eps,


### PR DESCRIPTION
## Motivation
The fused_qk_rmsnorm kernel will fallback to two split rmsnorm calls when m>=16384, and call fused kernel otherwise, refer to https://github.com/ROCm/aiter/blob/91c00dfa330bc2feb884edd0cb1a5e87d8d80d7d/aiter/ops/fused_qk_norm_rope_cache_quant.py#L66-L85.
When launching vllm server with _**--max-num-batched-tokens 16384, --max-model-len 16384**_  , it failed to call the fused kernel even m < 16384, since m was bind to 16384 in profile run.
   
## Solution
Wrapper the fused_qk_rmsnorm in ATOM side to ensure correct dispatch during runtime.


## Test Plan and Result
Launch Kimi-K2 with _**--max-num-batched-tokens 16384, --max-model-len 16384**_ , the fused kernel is called as expected:
<img width="1275" height="274" alt="image" src="https://github.com/user-attachments/assets/696c4849-d920-4c27-b6c9-13e97d985de0" />


<!-- Explain any relevant testing done to verify this PR. -->



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
