### PR TITLE
[plugin][triton version] align triton version with ATOM native

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,12 @@ RUN echo "========== [OOT 1/7] Prepare build tools ==========" && \
 RUN echo "========== [OOT 2/7] Verify base packages (atom/aiter/mori) ==========" && \
     "${VENV_PYTHON}" -m pip show atom || true && \
     "${VENV_PYTHON}" -m pip show amd-aiter || true && \
-    "${VENV_PYTHON}" -m pip show mori || true
+    "${VENV_PYTHON}" -m pip show mori || true && \
+    echo "========== [OOT 2/7] Back up base image triton ==========" && \
+    mkdir -p /tmp/triton-base-backup && \
+    cp -a /opt/venv/lib/python3.12/site-packages/triton /tmp/triton-base-backup/ && \
+    cp -a /opt/venv/lib/python3.12/site-packages/triton-*.dist-info /tmp/triton-base-backup/ && \
+    "${VENV_PYTHON}" -c "import triton; print(f'Base image triton backed up: {triton.__version__}')"
 
 RUN echo "========== [OOT 3/7] Clone vLLM ==========" && \
     rm -rf /app/vllm && \
@@ -81,6 +86,17 @@ RUN echo "FIXME: rocm/pytorch:latest currently resolves incompatible torchvision
       "torchvision==${ROCM_TORCHVISION_VERSION}" \
       "torchaudio==${ROCM_TORCHAUDIO_VERSION}" && \
     "${VENV_PYTHON}" -c "import torch, torchvision, torchaudio; from torchvision.transforms import InterpolationMode; from transformers.models.auto.image_processing_auto import get_image_processor_config; print(f'torch: {torch.__version__}'); print(f'torchvision: {torchvision.__version__}'); print(f'torchaudio: {torchaudio.__version__}'); print(f'InterpolationMode: {InterpolationMode.BILINEAR}'); print(f'get_image_processor_config: {get_image_processor_config.__name__}')"
+
+RUN echo "========== [OOT] Restore base image triton ==========" && \
+    "${VENV_PYTHON}" -m pip uninstall -y triton 2>/dev/null || true && \
+    rm -rf /opt/venv/lib/python3.12/site-packages/triton \
+           /opt/venv/lib/python3.12/site-packages/triton-*.dist-info && \
+    cp -a /tmp/triton-base-backup/triton /opt/venv/lib/python3.12/site-packages/ && \
+    for f in /tmp/triton-base-backup/triton-*.dist-info; do \
+      cp -a "$f" /opt/venv/lib/python3.12/site-packages/; \
+    done && \
+    rm -rf /tmp/triton-base-backup && \
+    "${VENV_PYTHON}" -c "import triton; print(f'Restored base image triton: {triton.__version__}')"
 
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
<img width="863" height="233" alt="image" src="https://github.com/user-attachments/assets/794f2ad2-4810-489f-9c27-bfb1c641d27b" />
<img width="1521" height="172" alt="image" src="https://github.com/user-attachments/assets/3317ed84-d4c6-4970-82f5-6519892ab089" />

OOT docker环境中的triton版本产生了漂移，为啥呢？因为作为基座的torch base image中的rocm版本和torch版本发生了变化，于是之前atom native本身就会构建的triton版本被pypi认定为不符合目前新torch的要求，所以pip在安装其他包的时候，会根据PEP400的要求，更新成torch规定的triton版本，于是triton版本发生了漂移，于是qwen3.5的精度开始crash

这个PR是通过retrieve triton版本让OOT docker最终和atom的triton版本保持一致，不发生漂移，不受基座环境torch的影响