### PR TITLE
Review: improve blog-atom-vllm-plugin.md clarity, completeness, and references

### DIFF
--- a/docs/blogs/blog-atom-vllm-plugin.md
+++ b/docs/blogs/blog-atom-vllm-plugin.md
@@ -4,7 +4,7 @@ Authors:  Zejun Chen, Hattie Wu, Lingpeng Jin, Carlus Huang, Chuan Li, Peng Sun,
 
 ## 1. Introduction
 
-LLM inference has long been caught in a core dilemma: balancing hardware-specific optimization and framework compatibility. To unlock the full performance potential of AMD Instinct GPUs, in-depth hardware-aware kernel engineering is a must; yet production-grade LLM serving is overwhelmingly built on [vLLM](https://github.com/vllm-project/vllm) — the de facto industry standard—thanks to its robust scheduling mechanisms, sophisticated memory management, and universal API compatibility.
+LLM inference faces a persistent dilemma: balancing hardware-specific optimization and framework compatibility. To unlock the full performance potential of AMD Instinct GPUs, in-depth hardware-aware kernel engineering is a must; yet production-grade LLM serving is overwhelmingly built on [vLLM](https://github.com/vllm-project/vllm) — the de facto industry standard—thanks to its robust scheduling mechanisms, sophisticated memory management, and universal API compatibility.
 
 
 ATOM, a high-performance inference engine purpose-built for AMD Instinct GPUs, resolves this conflict with its dual-mode architecture. It can run as a standalone inference server or integrate seamlessly into vLLM as a plugin backend, delivering AMD-native model and kernel optimizations without any modifications to vLLM’s core codebase.
@@ -24,7 +24,7 @@ Integrating ATOM as a vLLM plugin creates a win-win for all stakeholders, with f
 
 - **Mature optimizations upstreamed for all:** ATOM serves as a temporary proving ground for new optimizations; once stabilized, kernels, optimization strategies, and new features are upstreamed to vLLM’s native ROCm backend, benefiting the entire ROCm user community and strengthening the open-source LLM ecosystem.
 
-This plugin enables a closed, iterative innovation cycle: **new hardware/ideas/libraries** → **rapid validation via ATOM** → **upstream integration into vLLM core when mature** → **universal access for all ROCm users**. The model accelerates the delivery of AMD’s hardware advantages to end users through ATOM, while long-term technical improvements flow back to the broader open-source community via vLLM. The remainder of this post dives into the design, architecture, and technical implementation of the ATOM vLLM plugin system.
+This plugin enables a closed, iterative innovation cycle: **new hardware/ideas/libraries** → **rapid validation via ATOM** → **upstream integration into vLLM core when mature** → **universal access for all ROCm users**. This approach accelerates the delivery of AMD’s hardware advantages to end users through ATOM, while long-term technical improvements flow back to the broader open-source community via vLLM. The remainder of this post dives into the design, architecture, and technical implementation of the ATOM vLLM plugin system.
 
 
 ## 2. Architecture Overview
@@ -92,6 +92,10 @@ The `ATOMModelBase` wrapper fully implements vLLM's model interface while delega
 - **Model construction** — Instantiates the ATOM model class and initializes AITER’s distributed backend for multi-GPU/rack-scale inference.
 - **Weight loading** — Uses ATOM’s `load_model_in_plugin_mode()` method to load models in ATOM-specific formats and support AMD-optimized quantization schemes, ensuring optimal weight utilization on Instinct GPUs.
 
+### 3.4. Inference Serving (Steps 10–11)
+
+Once the model is constructed and weights are loaded, vLLM drives the serving loop. During each forward pass, vLLM’s scheduler assembles a batch of requests and invokes `ATOMModelBase.forward()`, which delegates to ATOM’s native model implementation. The attention layers execute through ATOM’s AITER-backed kernels (AiterBackend or AiterMLABackend), while vLLM retains full control over request scheduling, KV cache allocation, and output sampling. This clear separation ensures that ATOM handles the performance-critical compute path while vLLM manages the production-critical serving infrastructure.
+
 ## 4. Supported Models
 
 The ATOM vLLM plugin backend supports both LLMs and VLMs through a unified serving pipeline, covering text-only LLM models and Qwen3.5-based conditional-generation VLM models (including both dense and Mixture-of-Experts (MoE) variants). The table below lists the supported model architectures, types, representative examples, and their corresponding ATOM model classes:
@@ -106,12 +110,30 @@ The ATOM vLLM plugin backend supports both LLMs and VLMs through a unified servi
 | Qwen3_5ForConditionalGeneration | Dense (Text/VLM) | Qwen/Qwen3.5-35B-A3B-FP8 | `atom.models.qwen3_5` |
 | Qwen3_5MoeForConditionalGeneration | MoE (Text/VLM) | Qwen/Qwen3.5-397B-A17B-FP8 | `atom.models.qwen3_5` |
 
+> **Note:** Kimi-K2 (`amd/Kimi-K2-Thinking-MXFP4`) shares the DeepSeek V3-style MLA+MoE architecture and is served through the same `DeepseekV3ForCausalLM` pathway with `--trust-remote-code`.
 
-For step-by-step deployment guides—including Docker environment setup, server launch commands, performance benchmarking, and accuracy validation—refer to the [ATOM vLLM Recipes](https://github.com/ROCm/ATOM/tree/main/recipes/atom_vllm). 
+For step-by-step deployment guides—including Docker environment setup, server launch commands, performance benchmarking, and accuracy validation—refer to the [ATOM vLLM Recipes](https://github.com/ROCm/ATOM/tree/main/recipes/atom_vllm).
+
+### Quick Start
+
+Pull the pre-built Docker image and launch a vLLM server with ATOM in just two commands:
+
+```bash
+docker pull rocm/atom-dev:vllm-latest
+
+vllm serve ${model} \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --gpu_memory_utilization 0.9
+```
+
+ATOM activates automatically when installed alongside vLLM—no additional configuration is needed. For the full set of server options, refer to the [official vLLM documentation](https://docs.vllm.ai/en/latest/).
+
+> **Version compatibility:** The ATOM vLLM plugin is tested against vLLM v0.17.x. Pre-built Docker images for specific vLLM versions are available on [Docker Hub](https://hub.docker.com/r/rocm/atom-dev/tags?name=vllm).
 
 ## 5. Performance Characteristics
 
-ATOM prioritizes four key areas of performance optimization for the vLLM plugin backend, while also providing a live benchmark dashboard to enable transparent performance and quality tracking in production-like environments (**Dashboard URL:** [ATOM vLLM Benchmark Dashboard](https://rocm.github.io/ATOM/benchmark-dashboard/#backend=ATOM-vLLM)).
+To enable transparent performance and quality tracking in production-like environments, ATOM provides a live benchmark dashboard (**Dashboard URL:** [ATOM vLLM Benchmark Dashboard](https://rocm.github.io/ATOM/benchmark-dashboard/#backend=ATOM-vLLM)).
 
 The dashboard serves as a single pane of glass for monitoring and validating the plugin’s performance, with core features including:
 
@@ -123,12 +145,18 @@ The dashboard serves as a single pane of glass for monitoring and validating the
 In practice, the dashboard is an essential tool for release validation: after every ATOM or vLLM plugin update, teams can quickly verify that throughput, latency, and model accuracy remain within expected production ranges.
 
 
-## Conclusion
+## 6. Conclusion
 
 The ATOM vLLM plugin proves that hardware-specific optimization and framework compatibility are not mutually exclusive. By leveraging vLLM’s out-of-the-box plugin mechanism, ATOM delivers AMD-native kernel optimizations—including fused attention, quantized GEMM, and optimized MoE routing—while preserving the full feature set of vLLM that production LLM deployments rely on.
 
 Beyond immediate performance gains, the plugin’s architecture serves as a critical proving ground for AMD’s hardware and software innovations: optimizations validated in ATOM’s plugin mode are gradually upstreamed to vLLM’s native ROCm backend, benefiting the entire ROCm and open-source LLM community. For end users, this means immediate access to the latest AMD hardware capabilities without waiting for slow upstream integration cycles—creating a virtuous cycle of co-evolution between AMD’s hardware innovation and the vLLM serving ecosystem.
 
-## Reference 
+## References
 
-For more information, see the [ATOM Documentation](https://rocm.github.io/ATOM/docs/), the [RFC on GitHub](https://github.com/ROCm/ATOM/issues/201), and the [ATOM repository](https://github.com/ROCm/ATOM).
+- [ATOM Documentation](https://rocm.github.io/ATOM/docs/)
+- [ATOM vLLM Plugin Backend Guide](https://rocm.github.io/ATOM/docs/vllm_plugin_backend_guide.html)
+- [RFC: Enable ATOM as vLLM out-of-tree Platform](https://github.com/ROCm/ATOM/issues/201)
+- [ATOM Repository](https://github.com/ROCm/ATOM)
+- [AITER — AMD Inference Tensor Engine for ROCm](https://github.com/ROCm/aiter)
+- [ATOM vLLM Recipes](https://github.com/ROCm/ATOM/tree/main/recipes/atom_vllm)
+- [Docker Hub — ATOM + vLLM Images](https://hub.docker.com/r/rocm/atom-dev/tags?name=vllm)


### PR DESCRIPTION
## Summary

Review and improvements for `blog-atom-vllm-plugin.md` covering clarity, structural completeness, and reader experience.

### Changes

**Structural fixes:**
- **Add missing Section 3.4 (Inference Serving, Steps 10–11):** The execution flow diagram describes four phases, but only three had corresponding subsections. Added the fourth to close the gap.
- **Number Conclusion as Section 6** for consistency with the numbered Sections 1–5.

**Wording fixes:**
- **"The model accelerates..." → "This approach accelerates...":** In a blog about LLM *models*, "The model" is ambiguous — readers may momentarily think it refers to an LLM rather than the collaboration model.
- **"has long been caught" → "faces a persistent dilemma":** The LLM inference field is relatively young; "long" can feel overstated.
- **Section 5 opening:** The original text promised "four key areas of performance optimization" but then only described dashboard features. Reworded to directly introduce the dashboard.

**New content:**
- **Kimi-K2 note** below the supported models table, since it is a high-visibility model but only appears as a sub-item in the DeepseekV3 row.
- **Quick Start snippet** (`docker pull` + `vllm serve`) to lower the barrier for first-time readers.
- **vLLM version compatibility note** (tested against v0.17.x, with Docker Hub link for versioned images).
- **Expanded References** from 3 inline links to a structured list of 7 resources (added Plugin Backend Guide, AITER repo, Recipes, Docker Hub).

### Not addressed (suggestions for authors)
- **No actual performance numbers in Section 5** — consider embedding a representative benchmark snapshot (e.g., from the Dashboard) with an "as of [date]" timestamp.
- **Model table vs docs inconsistency** — the blog includes `Qwen3NextForCausalLM` / `Qwen3_5*` which are absent from the Plugin Backend Guide, and the Guide lists `Qwen3ForCausalLM` (dense) which is absent from the blog. Consider syncing.
- **`Qwen3_5ForConditionalGeneration` labeled "Dense"** but its representative model `Qwen3.5-35B-A3B-FP8` has `-A3B` in the name (typically indicating MoE active params). Worth clarifying.
- **SVG images** — confirm they render correctly on the final publishing platform (GitHub Pages should work, but raw GitHub markdown viewing may not inline SVGs).

### Suggested keywords / tags for SEO
`AMD Instinct GPU`, `ROCm`, `MI300X`, `MI355X`, `vLLM plugin`, `out-of-tree plugin`, `ATOM inference engine`, `AITER kernels`, `LLM inference`, `LLM serving`, `DeepSeek R1`, `Kimi-K2`, `Qwen3`, `MoE`, `MLA`, `FP8`, `FP4/MXFP4`, `fused attention`, `quantized GEMM`, `CUDAGraph`, `tensor parallelism`, `continuous batching`
