### PR TITLE
Support enable_thinking False in v1/chat/completions mode

### DIFF
--- a/atom/entrypoints/openai_server.py
+++ b/atom/entrypoints/openai_server.py
@@ -72,6 +72,7 @@ class ChatCompletionRequest(BaseModel):
     ignore_eos: Optional[bool] = False
     stream: Optional[bool] = False
     seed: Optional[int] = None
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
 
     def get_messages(self) -> List[ChatMessage]:
         """Get messages from either 'messages' or 'prompt' field."""
@@ -129,6 +130,7 @@ class CompletionResponse(BaseModel):
 engine = None
 tokenizer: Optional[AutoTokenizer] = None
 model_name: str = ""
+default_chat_template_kwargs: Dict[str, Any] = {}
 _stream_queues: Dict[str, asyncio.Queue] = {}
 _seq_id_to_request_id: Dict[int, str] = {}
 _stream_loops: Dict[str, AbstractEventLoop] = {}
@@ -666,10 +668,16 @@ async def chat_completions(request: ChatCompletionRequest):
     try:
         # Get messages and format prompt
         messages = request.get_messages()
+
+        merged_kwargs = dict(default_chat_template_kwargs)
+        if request.chat_template_kwargs:
+            merged_kwargs.update(request.chat_template_kwargs)
+        merged_kwargs["tokenize"] = False
+        merged_kwargs["add_generation_prompt"] = True
+
         prompt = tokenizer.apply_chat_template(
             [{"role": msg.role, "content": msg.content} for msg in messages],
-            tokenize=False,
-            add_generation_prompt=True,
+            **merged_kwargs,
         )
 
         # Create sampling parameters
@@ -902,7 +910,7 @@ async def stop_profile():
 
 def main():
     """Main entry point for the server."""
-    global engine, tokenizer, model_name
+    global engine, tokenizer, model_name, default_chat_template_kwargs
 
     parser = argparse.ArgumentParser(description="Atom OpenAI API Server")
     EngineArgs.add_cli_args(parser)
@@ -913,7 +921,21 @@ def main():
         default=DEFAULT_PORT,
         help="Server port (note: --port is used for internal engine communication)",
     )
+    parser.add_argument(
+        "--default-chat-template-kwargs",
+        type=str,
+        default=None,
+        help=(
+            "Default kwargs for chat template rendering (JSON string). "
+            "Merged with per-request chat_template_kwargs (request wins). "
+            "Example: '{\"enable_thinking\": false}'"
+        ),
+    )
     args = parser.parse_args()
+
+    if args.default_chat_template_kwargs:
+        default_chat_template_kwargs = json.loads(args.default_chat_template_kwargs)
+        logger.info(f"Default chat template kwargs: {default_chat_template_kwargs}")
 
     logger.info(f"Loading tokenizer from {args.model}...")
     tokenizer = _load_tokenizer(args.model, args.trust_remote_code)


### PR DESCRIPTION
## Motivation
enable_thinking is a flag passed to tokenizer.apply_chat_template() that controls whether the model generates a chain-of-thought reasoning block before the actual answer.
We can use `--default-chat-template-kwargs '{"enable_thinking": false}'` in /v1/chat/completions.
```
python3 -m atom.entrypoints.openai_server --model /data/models/zai-org/GLM-5-FP8/ -tp 8 --kv_cache_dtype fp8 --port 5678 --server-port 7777 --trust-remote-code --default-chat-template-kwargs '{"enable_thinking": false}'


lm_eval --model local-chat-completions     --apply_chat_template     --model_args model="/data/models/zai-org/GLM-5-FP8/",base_url=http://localhost:7777/v1/chat/completions,num_concurrent=65,max_retries=3,tokenized_requests=False,max_length=4096     --gen_kwargs max_tokens=512,temperature=0,top_p=1     --tasks gsm8k     --num_fewshot 3

```

2026-04-02:08:16:27 INFO     [loggers.evaluation_tracker:119] Saving per-task samples to results/__data__models__zai-org__GLM-5-FP8__/*.jsonl
local-chat-completions ({'model': '/data/models/zai-org/GLM-5-FP8/', 'base_url': 'http://localhost:7777/v1/chat/completions', 'num_concurrent': 65, 'max_retries': 3, 'tokenized_requests': False, 'max_length': 4096}), gen_kwargs: ({'max_tokens': 512, 'temperature': 0, 'top_p': 1}), limit: 50.0, num_fewshot: 3, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  | 0.96|±  | 0.028|
|     |       |strict-match    |     3|exact_match|↑  | 0.96|±  | 0.028|

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
