### PR TITLE
EP infrastructure and decode buffer pooling for GPT-OSS-120B

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -78,6 +78,8 @@ class PagedAttentionImpl(nn.Module):
         self.q_norm = q_norm
         self.k_norm = k_norm
 
+        self._decode_workspace: dict[tuple, dict[str, torch.Tensor]] = {}
+
         # for plugin mode(vllm), the query quant is disabled for now
         if is_vllm():
             self.supports_quant_query_input = False
@@ -320,6 +322,35 @@ class PagedAttentionImpl(nn.Module):
 
         return q, k_full, v_full, k_cache, v_cache, k_scale, v_scale
 
+    def _get_decode_workspace(
+        self,
+        q: torch.Tensor,
+        intermediate_shape: tuple,
+        head_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return (o, exp_sums, max_logits, temporary_output), reusing cached buffers
+        when the shape matches a previous decode call on this layer."""
+        cache_key = (intermediate_shape, head_size, q.dtype)
+        ws = self._decode_workspace.get(cache_key)
+        if ws is not None:
+            return ws["o"], ws["exp_sums"], ws["max_logits"], ws["tmp_out"]
+
+        o = torch.empty_like(q)
+        exp_sums = torch.empty(intermediate_shape, dtype=torch.float32, device=q.device)
+        max_logits = torch.empty(
+            intermediate_shape, dtype=torch.float32, device=q.device
+        )
+        temporary_output = torch.empty(
+            *intermediate_shape, head_size, dtype=q.dtype, device=q.device
+        )
+        self._decode_workspace[cache_key] = {
+            "o": o,
+            "exp_sums": exp_sums,
+            "max_logits": max_logits,
+            "tmp_out": temporary_output,
+        }
+        return o, exp_sums, max_logits, temporary_output
+
     @mark_trace(prefix="paged_attention_triton", torch_compile=False)
     def paged_attention_triton(
         self, q, k, v, k_cache, v_cache, k_scale, v_scale, fwd_ctx: ForwardContext
@@ -327,11 +358,9 @@ class PagedAttentionImpl(nn.Module):
 
         attn_metadata = fwd_ctx.attn_metadata
 
-        o = torch.empty_like(q)
         num_seqs = attn_metadata.context_lens.shape[0]
         _, num_q_heads_total, head_size = q.shape
         num_blocks, num_kv_heads, _, block_size, _ = k_cache.shape
-        # assume all query have same length
         query_group_size = attn_metadata.max_seqlen_q * (
             num_q_heads_total // num_kv_heads
         )
@@ -344,23 +373,28 @@ class PagedAttentionImpl(nn.Module):
             max_context_partition_num = 1
             context_partition_size = 128
 
-        # Output buffers (same as Triton)
         intermediate_shape = (
             num_seqs,
             num_kv_heads,
             max_context_partition_num,
             query_group_size,
         )
-        exp_sums = torch.empty(intermediate_shape, dtype=torch.float32, device=q.device)
-        max_logits = torch.empty(
-            intermediate_shape, dtype=torch.float32, device=q.device
-        )
-        temporary_output = torch.empty(
-            *intermediate_shape,
-            head_size,
-            dtype=q.dtype,
-            device=q.device,
-        )
+
+        if not fwd_ctx.context.is_prefill:
+            o, exp_sums, max_logits, temporary_output = self._get_decode_workspace(
+                q, intermediate_shape, head_size
+            )
+        else:
+            o = torch.empty_like(q)
+            exp_sums = torch.empty(
+                intermediate_shape, dtype=torch.float32, device=q.device
+            )
+            max_logits = torch.empty(
+                intermediate_shape, dtype=torch.float32, device=q.device
+            )
+            temporary_output = torch.empty(
+                *intermediate_shape, head_size, dtype=q.dtype, device=q.device
+            )
 
         if k_scale is not None and k_scale.numel() > 1:
             k_scale = k_scale.unsqueeze(-1)

--- a/atom/model_ops/fused_moe/mori_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_prepare_finalize.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import logging
 from typing import Any
 
 import torch
@@ -8,8 +9,11 @@ import torch
 import atom.model_ops.fused_moe.modular_kernel as mk
 from atom.model_ops.fused_moe.config import FusedMoEQuantConfig
 from atom.utils.forward_context import get_forward_context
+from atom.utils import envs
 from aiter import dtypes
 from aiter import QuantType
+
+logger = logging.getLogger("atom")
 
 # Lazy import mori
 try:
@@ -47,6 +51,19 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         self.use_fp8_dispatch = use_fp8_dispatch
         self.quant_type = quant_type
         self.quant_dtype = quant_dtype
+
+        self._decode_block_num = envs.ATOM_MORI_DECODE_BLOCK_NUM
+        self._decode_warp_per_block = envs.ATOM_MORI_DECODE_WARP_PER_BLOCK
+        self._prefill_block_num = envs.ATOM_MORI_PREFILL_BLOCK_NUM
+        self._prefill_warp_per_block = envs.ATOM_MORI_PREFILL_WARP_PER_BLOCK
+        logger.info(
+            "MORI launch config: prefill(block=%d, warp=%d) "
+            "decode(block=%d, warp=%d)",
+            self._prefill_block_num,
+            self._prefill_warp_per_block,
+            self._decode_block_num,
+            self._decode_warp_per_block,
+        )
 
     @property
     def activation_format(self) -> mk.FusedMoEActivationFormat:
@@ -99,11 +116,11 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             a1, scale = quant_func(a1, quant_dtype=dtypes.fp8)
         context = get_forward_context().context
         if context.is_prefill:
-            block_num = 128
-            warp_per_block = 16
+            block_num = self._prefill_block_num
+            warp_per_block = self._prefill_warp_per_block
         else:
-            block_num = 64
-            warp_per_block = 4
+            block_num = self._decode_block_num
+            warp_per_block = self._decode_warp_per_block
 
         (
             dispatch_a1,
@@ -138,11 +155,11 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
     ) -> None:
         context = get_forward_context().context
         if context.is_prefill:
-            block_num = 128
-            warp_per_block = 16
+            block_num = self._prefill_block_num
+            warp_per_block = self._prefill_warp_per_block
         else:
-            block_num = 64
-            warp_per_block = 4
+            block_num = self._decode_block_num
+            warp_per_block = self._decode_warp_per_block
 
         num_token = output.shape[0]
         result = self.mori_op.combine(

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+import logging
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -54,6 +55,8 @@ from atom.utils.decorators import mark_trace
 from torch import nn
 from transformers import PretrainedConfig
 from atom.plugin.moe import FusedMoEDecoratorForPluginMode
+
+logger = logging.getLogger("atom")
 
 
 class FusedMoeWeightScaleSupported(Enum):
@@ -177,6 +180,25 @@ def naive_multicast(
     return buffer
 
 
+_ep_comm_buffer_cache: dict[tuple, torch.Tensor] = {}
+
+
+def _get_or_alloc_buffer(
+    key: tuple, shape: tuple, dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    """Return a cached zero-filled buffer or allocate a new one."""
+    from atom.utils import envs
+
+    if envs.ATOM_EP_PREALLOCATE_COMM_BUFFERS and key in _ep_comm_buffer_cache:
+        buf = _ep_comm_buffer_cache[key]
+        if buf.shape == shape and buf.dtype == dtype:
+            return buf
+    buf = torch.zeros(shape, dtype=dtype, device=device)
+    if envs.ATOM_EP_PREALLOCATE_COMM_BUFFERS:
+        _ep_comm_buffer_cache[key] = buf
+    return buf
+
+
 def all_gather_with_padding(x: torch.Tensor):
     max_batch_size = get_forward_context().context.graph_bs
     dim = 0
@@ -184,12 +206,15 @@ def all_gather_with_padding(x: torch.Tensor):
     padded_x = x
     if original_batch_size < max_batch_size:
         padding_size = max_batch_size - original_batch_size
-
         padding_shape = list(x.shape)
         padding_shape[dim] = padding_size
 
-        padding = torch.empty(padding_shape, dtype=x.dtype, device=x.device)
-        padding.zero_()
+        padding = _get_or_alloc_buffer(
+            ("ag_pad", x.shape[1], x.dtype),
+            tuple(padding_shape),
+            x.dtype,
+            x.device,
+        )
         padded_x = torch.cat([x, padding], dim=dim)
 
     gathered_hidden_states = get_dp_group().all_gather(padded_x, dim=dim)
@@ -202,7 +227,6 @@ def reduce_scatter_with_unpadding(
     dim = 0
     dp_group = get_dp_group()
 
-    # scattered_output = dp_group.reduce_scatter(x, dim=dim)
     scattered_output = dp_group.reduce_scatter_tensor(x)
 
     if scattered_output.shape[dim] > original_batch_size:
@@ -286,8 +310,8 @@ class FusedMoEMethodBase(QuantizeMethodBase):
             # For 1x128 quant, the scale dim for each token is hidden_dim // 128
             scale_dim = 1 if quant_config.is_per_act_token else moe.hidden_dim // 128
 
-            # Check if quant_dtype is an FP8 type
             from aiter import QuantType
+            from atom.utils import envs
 
             fp8_dtypes = (
                 torch.float8_e4m3fn,
@@ -296,9 +320,9 @@ class FusedMoEMethodBase(QuantizeMethodBase):
                 torch.float8_e5m2fnuz,
             )
             is_fp8 = quant_config.quant_dtype in fp8_dtypes
-            # For FP8: enable FP8 dispatch in Mori (quantize before communication)
-            # Note: per_Tensor quant doesn't support num_local_tokens, so we use per_Token
-            use_fp8_dispatch = is_fp8
+            ep_fp8_dispatch_enabled = envs.ATOM_EP_FP8_DISPATCH
+
+            use_fp8_dispatch = is_fp8 and ep_fp8_dispatch_enabled
             quant_type = None
             if use_fp8_dispatch:
                 if quant_config.is_block_quantized:
@@ -306,27 +330,20 @@ class FusedMoEMethodBase(QuantizeMethodBase):
                 elif quant_config.is_per_act_token:
                     quant_type = QuantType.per_Token
 
-            # For FP8: use FP8 dtype for communication
-            # For FP4/no quant: use bfloat16
-            # mori_dtype = (
-            #     quant_config.quant_dtype
-            #     if is_fp8 and quant_type is not None
-            #     else torch.bfloat16
-            # )
-            # mori_dtype = torch.bfloat16
+            mori_dtype = (
+                quant_config.quant_dtype
+                if use_fp8_dispatch and quant_type is not None
+                else moe.in_dtype
+            )
 
             all_to_all_args = dict(
                 rank=all2all_manager.rank,
                 num_ep_ranks=all2all_manager.world_size,
-                # quant_dtype=mori_dtype,
-                # We now use bfloat16 for mori
-                # TODO: To support quant
-                quant_dtype=moe.in_dtype,
+                quant_dtype=mori_dtype,
                 token_hidden_size=moe.hidden_dim,
                 scale_dim=scale_dim,
                 scale_type_size=torch.float32.itemsize,
                 max_num_tokens_per_dp_rank=16384,
-                # input_dtype=moe.in_dtype,
                 input_dtype=moe.in_dtype,
                 num_local_experts=moe.num_experts // all2all_manager.world_size,
                 num_experts_per_token=moe.experts_per_token,
@@ -334,9 +351,13 @@ class FusedMoEMethodBase(QuantizeMethodBase):
             )
             handle = all2all_manager.get_handle(all_to_all_args)
 
-            # We not use quant for mori now
-            use_fp8_dispatch = False
-            quant_type = None
+            if use_fp8_dispatch:
+                logger.info(
+                    "EP FP8 dispatch enabled: comm dtype=%s, quant_type=%s "
+                    "(halving all2all volume)",
+                    mori_dtype,
+                    quant_type,
+                )
 
             prepare_finalize = MoriPrepareAndFinalize(
                 handle,

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -10,6 +10,38 @@ from atom.config import get_current_atom_config
 from atom.model_ops.utils import _has_module
 from atom.utils.custom_register import direct_register_custom_op
 
+# Buffer pool for TopK outputs: keyed by (token, topk) to avoid per-step
+# GPU allocations during decode.  Each entry holds (ids, weights, indicies).
+_topk_buffer_pool: dict[tuple, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+
+
+def _get_pooled_topk_buffers(
+    token: int, topk: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    key = (token, topk)
+    cached = _topk_buffer_pool.get(key)
+    if cached is not None:
+        return cached
+    ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+    weights = torch.empty((token, topk), dtype=torch.float32, device=device)
+    indicies = torch.empty(token, topk, dtype=torch.int32, device=device)
+    _topk_buffer_pool[key] = (ids, weights, indicies)
+    return ids, weights, indicies
+
+
+# Separate pool for token_expert_indicies (scratch only, never returned to caller).
+_indicies_pool: dict[tuple, torch.Tensor] = {}
+
+
+def _get_pooled_indicies(token: int, topk: int, device: torch.device) -> torch.Tensor:
+    key = (token, topk)
+    cached = _indicies_pool.get(key)
+    if cached is not None:
+        return cached
+    indicies = torch.empty(token, topk, dtype=torch.int32, device=device)
+    _indicies_pool[key] = indicies
+    return indicies
+
 
 @torch_compile_guard()
 def is_rocm_aiter_fusion_shared_expert_enabled() -> bool:
@@ -96,9 +128,11 @@ def rocm_aiter_topk_softmax_impl(
     fused_shared_experts_scoring_func: Optional[str] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     from aiter import topk_softmax
+    from atom.utils import envs
 
     token = gating_output.shape[0]
     device = gating_output.device
+    pool = envs.ATOM_EP_PREALLOCATE_COMM_BUFFERS
     fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
     if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
@@ -115,12 +149,24 @@ def rocm_aiter_topk_softmax_impl(
         topk_ids, _ = torch.split(
             total_topk_ids, [topk, total_topk_ids.shape[1] - topk], dim=1
         )
+        token_expert_indicies = (
+            _get_pooled_indicies(token, topk, device)
+            if pool
+            else torch.empty(token, topk, dtype=torch.int32, device=device)
+        )
     else:
-        topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
-        topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
-    token_expert_indicies = torch.empty(
-        gating_output.shape[0], topk, dtype=torch.int32, device=gating_output.device
-    )
+        if pool:
+            topk_ids, topk_weights, token_expert_indicies = _get_pooled_topk_buffers(
+                token, topk, device
+            )
+        else:
+            topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+            topk_weights = torch.empty(
+                (token, topk), dtype=torch.float32, device=device
+            )
+            token_expert_indicies = torch.empty(
+                token, topk, dtype=torch.int32, device=device
+            )
     if fused_shared_experts_scoring_func is None:
         fused_shared_experts_scoring_func = ""
         fused_shared_experts_for_kernel = 0

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -88,6 +88,27 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD": lambda: int(
         os.getenv("ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD", "1024")
     ),
+    # --- Expert Parallelism ---
+    # Enable FP8 quantization before MORI EP dispatch to halve all2all volume.
+    "ATOM_EP_FP8_DISPATCH": lambda: os.getenv("ATOM_EP_FP8_DISPATCH", "0") == "1",
+    # MORI decode kernel launch tuning (MI355-optimized defaults).
+    "ATOM_MORI_DECODE_BLOCK_NUM": lambda: int(
+        os.getenv("ATOM_MORI_DECODE_BLOCK_NUM", "64")
+    ),
+    "ATOM_MORI_DECODE_WARP_PER_BLOCK": lambda: int(
+        os.getenv("ATOM_MORI_DECODE_WARP_PER_BLOCK", "4")
+    ),
+    "ATOM_MORI_PREFILL_BLOCK_NUM": lambda: int(
+        os.getenv("ATOM_MORI_PREFILL_BLOCK_NUM", "128")
+    ),
+    "ATOM_MORI_PREFILL_WARP_PER_BLOCK": lambda: int(
+        os.getenv("ATOM_MORI_PREFILL_WARP_PER_BLOCK", "16")
+    ),
+    # Pre-allocate EP communication buffers for decode to avoid per-step allocations.
+    "ATOM_EP_PREALLOCATE_COMM_BUFFERS": lambda: os.getenv(
+        "ATOM_EP_PREALLOCATE_COMM_BUFFERS", "1"
+    )
+    == "1",
 }
 
 


### PR DESCRIPTION
## Summary

- Add Expert Parallelism (EP) infrastructure with configurable MORI kernel launch parameters, FP8 dispatch option, and EP communication buffer pre-allocation
- Pool TopK output buffers (~180 GPU allocs/step eliminated) and paged attention workspace buffers (~240 GPU allocs/step eliminated) during decode to reduce memory allocation overhead
- Add 6 new environment variables for EP tuning: ATOM_EP_FP8_DISPATCH, ATOM_MORI_DECODE_BLOCK_NUM/WARP_PER_BLOCK, ATOM_MORI_PREFILL_BLOCK_NUM/WARP_PER_BLOCK, ATOM_EP_PREALLOCATE_COMM_BUFFERS

## Files Changed

| File | Change |
|---|---|
| atom/utils/envs.py | Add EP/MORI environment variables |
| atom/model_ops/topK.py | Pool topk_ids/weights/indicies across decode steps |
| atom/model_ops/attention_mha.py | Cache decode workspace (o, exp_sums, max_logits) per layer |
| atom/model_ops/moe.py | Configurable FP8 dispatch for MORI EP, pre-alloc comm buffers, add logger |
| atom/model_ops/fused_moe/mori_prepare_finalize.py | Configurable block_num/warp_per_block for MI355 tuning |

## E2E Benchmark Results (GPT-OSS-120B, MI355X 8xGPU)

| Scenario | Config | Throughput (tok/s) | Mean TTFT (ms) | Mean TPOT (ms) | P99 TTFT (ms) | P99 TPOT (ms) |
|---|---|---|---|---|---|---|
| 1K/1K c128 | baseline | 7591 | 239 | 30.37 | 810 | 31.50 |
| 1K/1K c128 | EP | 7607 | 283 | 30.34 | 737 | 31.66 |
| 1K/8K c128 | baseline | 2281 | 220 | 28.43 | 291 | 28.47 |
| 1K/8K c128 | EP | 2232 | 257 | 29.05 | 365 | 29.09 |
| 8K/1K c128 | baseline | 16718 | 1230 | 29.80 | 1944 | 30.38 |
| 8K/1K c128 | EP | 16324 | 1380 | 30.42 | 2458 | 31.42 |
| 1K/1K c1 | baseline | 75.78 | 66 | 26.24 | 72 | 26.88 |
| 1K/1K c1 | EP | 75.58 | 68 | 26.30 | 75 | 27.24 |

EP adds communication overhead for this model; the main value is the buffer pooling infrastructure which reduces ~420 GPU allocs/step and prepares for CUDAGraph capture.

## Test Plan

- [x] Verified on MI355X with GPT-OSS-120B (8xGPU, TP=8)
- [x] Baseline and EP configurations both serve correctly
- [x] All 4 benchmark scenarios pass (1K/1K, 1K/8K, 8K/1K, 1K/1K single)
- [ ] CI linting (black, ruff)
- [ ] Existing model regression tests

Made with [Cursor](https://cursor.com)