### PR TITLE
CI: skip model download when cache exists

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -328,10 +328,15 @@ jobs:
       - name: Download models
         run: |
           if [ -d "/models" ]; then
-            echo "/models directory found, downloading model to /models/${{ matrix.model_path }}"
-            if ! docker exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "hf download ${{ matrix.model_path }} --local-dir /models/${{ matrix.model_path }}"; then
-              echo "Model download failed for '${{ matrix.model_path }}'. Aborting."
-              exit 1
+            model_dir="/models/${{ matrix.model_path }}"
+            if docker exec "$CONTAINER_NAME" bash -lc "[ -d \"$model_dir\" ] && [ -f \"$model_dir/config.json\" ]"; then
+              echo "Model already exists under ${model_dir}; skip download"
+            else
+              echo "Model not found under ${model_dir}; downloading model"
+              if ! docker exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "hf download ${{ matrix.model_path }} --local-dir \"$model_dir\""; then
+                echo "Model download failed for '${{ matrix.model_path }}'. Aborting."
+                exit 1
+              fi
             fi
           else
             echo "/models directory not found, skipping model download"


### PR DESCRIPTION
## Summary
- Update the `Download models` step in `.github/workflows/atom-test.yaml` to check model cache before downloading.
- If `/models` exists and `/models/<model_path>/config.json` already exists, skip `hf download`.
- Only download the model when the target model directory is missing or incomplete.

## Test plan
- [x] Verified workflow logic checks `/models` first.
- [x] Verified existing model cache path now short-circuits download.
- [x] Confirmed branch diff only changes `.github/workflows/atom-test.yaml`.