### PR TITLE
CI: improve atom test image and model cache handling

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -335,47 +335,60 @@ jobs:
           set -euo pipefail
           if [ -d "/models" ]; then
             model_dir="/models/${{ matrix.model_path }}"
-            completion_flag="$model_dir/.download-complete"
             lock_suffix="$(printf '%s' "${{ matrix.model_path }}" | tr '/:@' '___')"
-            lock_file="/models/.download-lock-${lock_suffix}"
-            runner_name="${{ matrix.runner }}"
-            use_model_lock="true"
+            if ! docker exec \
+              -e HF_TOKEN="${HF_TOKEN:-}" \
+              -e MODEL_PATH="${{ matrix.model_path }}" \
+              -e MODEL_DIR="$model_dir" \
+              -e RUNNER_NAME="${{ matrix.runner }}" \
+              -e LOCK_SUFFIX="$lock_suffix" \
+              "$CONTAINER_NAME" \
+              bash -lc '
+                set -euo pipefail
+                completion_flag="$MODEL_DIR/.download-complete"
+                use_model_lock="true"
 
-            if [ "$runner_name" = "atom-mi355-8gpu.predownload" ]; then
-              use_model_lock="false"
-            fi
+                if [ "$RUNNER_NAME" = "atom-mi355-8gpu.predownload" ]; then
+                  use_model_lock="false"
+                fi
 
-            download_model() {
-              if docker exec "$CONTAINER_NAME" bash -lc "[ -f \"$model_dir/config.json\" ]"; then
-                echo "Model directory exists without a completion marker under ${model_dir}; validating download"
-              else
-                echo "Model not found under ${model_dir}; downloading model"
-              fi
+                download_model() {
+                  if [ -f "$MODEL_DIR/config.json" ]; then
+                    echo "Model directory exists without a completion marker under ${MODEL_DIR}; validating download"
+                  else
+                    echo "Model not found under ${MODEL_DIR}; downloading model"
+                  fi
 
-              if ! docker exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "set -euo pipefail; rm -f \"$completion_flag\"; hf download ${{ matrix.model_path }} --local-dir \"$model_dir\"; touch \"$completion_flag\""; then
-                echo "Model download failed for '${{ matrix.model_path }}'. Aborting."
-                exit 1
-              fi
-            }
+                  rm -f "$completion_flag"
+                  hf download "$MODEL_PATH" --local-dir "$MODEL_DIR"
+                  touch "$completion_flag"
+                }
 
-            if docker exec "$CONTAINER_NAME" bash -lc "[ -f \"$completion_flag\" ]"; then
-              echo "Model already exists under ${model_dir}; skip download"
-            elif [ "$use_model_lock" != "true" ]; then
-              echo "Baremetal runner ${runner_name} detected; skipping shared model download lock"
-              download_model
-            else
-              exec 9>"$lock_file"
-              echo "Waiting for model download lock: $lock_file"
-              if ! flock -w 7200 9; then
-                echo "Timed out waiting for model download lock: $lock_file"
-                exit 1
-              fi
+                if [ -f "$completion_flag" ]; then
+                  echo "Model already exists under ${MODEL_DIR}; skip download"
+                elif [ "$use_model_lock" != "true" ]; then
+                  echo "Baremetal runner ${RUNNER_NAME} detected; skipping shared model download lock"
+                  download_model
+                else
+                  lock_dir="/models/.cache/atom-download-locks"
+                  mkdir -p "$lock_dir"
+                  lock_file="$lock_dir/${LOCK_SUFFIX}.lock"
+                  exec 9>"$lock_file"
+                  echo "Waiting for model download lock: $lock_file"
+                  if ! flock -w 7200 9; then
+                    echo "Timed out waiting for model download lock: $lock_file"
+                    exit 1
+                  fi
 
-              if docker exec "$CONTAINER_NAME" bash -lc "[ -f \"$completion_flag\" ]"; then
-                echo "Model became available under ${model_dir} while waiting for the lock; skip download"
-              else
-                download_model
-              fi
+                  if [ -f "$completion_flag" ]; then
+                    echo "Model became available under ${MODEL_DIR} while waiting for the lock; skip download"
+                  else
+                    download_model
+                  fi
+                fi
+              '; then
+              echo "Model download failed for '${{ matrix.model_path }}'. Aborting."
+              exit 1
             fi
           else
             echo "/models directory not found, skipping model download"


### PR DESCRIPTION
## Summary
* use the internal image cache for most ATOM test runners while keeping `--pull always` on `atom-mi355-8gpu.predownload`
* serialize shared `/models` downloads with `flock` and a `.download-complete` marker to avoid concurrent Hugging Face downloads blocking on the same cache path
* preserve cached model reuse and skip re-downloading when the shared model directory is already complete

## Test plan
* [ ] run `ATOM Test` on a non-`atom-mi355-8gpu.predownload` runner and verify the container starts without `--pull always`
* [ ] run `ATOM Test` on `atom-mi355-8gpu.predownload` and verify it still forces an image pull
* [ ] trigger concurrent jobs for the same model path and verify only one job downloads while others wait and reuse the completed model