### PR TITLE
Remove watermark overlay from dashboard

### DIFF
--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -28,7 +28,6 @@
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html, body { overflow-x: hidden; }
     body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background: var(--bg-primary); color: var(--text-secondary); }
-    body::after { content: ''; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: url('atom_logo.png') no-repeat center/240px 60px; opacity: 0.04; pointer-events: none; z-index: 0; }
     .container { max-width: 1440px; margin: 0 auto; padding: var(--gap-lg); }
     a { color: var(--ui-bright); text-decoration: none; }
     a:hover { text-decoration: underline; }


### PR DESCRIPTION
via claude code vibecoding

## Summary
- Remove the `body::after` pseudo-element that rendered a faint `atom_logo.png` watermark across the entire dashboard page, resulting in a cleaner UI.

## Test plan
- [ ] Open `.github/dashboard/index.html` in a browser and confirm no faint logo watermark appears behind the content

🤖 Generated with [Claude Code](https://claude.com/claude-code)