### PR TITLE
[fix](ci): remove rmsnorm allreduce fusion in gpt-oss

### DIFF
--- a/.github/workflows/atom-vllm-oot-test.yaml
+++ b/.github/workflows/atom-vllm-oot-test.yaml
@@ -892,7 +892,7 @@ jobs:
                   "model_path": "openai/gpt-oss-120b",
                   "extra_args": "--tensor-parallel-size 2",
                   "accuracy_test_threshold": 0.38,
-                  "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
+                  "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION=0",
                   "runner": "linux-atom-mi35x-4",
               },
           ]

--- a/.github/workflows/atom-vllm-oot-test.yaml
+++ b/.github/workflows/atom-vllm-oot-test.yaml
@@ -892,7 +892,7 @@ jobs:
                   "model_path": "openai/gpt-oss-120b",
                   "extra_args": "--tensor-parallel-size 2",
                   "accuracy_test_threshold": 0.38,
-                  "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION=0",
+                  "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
                   "runner": "linux-atom-mi35x-4",
               },
           ]

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -192,10 +192,6 @@ class RMSNorm(nn.Module):
         self.fused_allreduce = fused_allreduce
         self.use_fused_quant = fused_quant
         self.tp_size = get_tensor_model_parallel_world_size()
-        # AITER fused allreduce+rmsnorm kernel requires n_bytes % 1024 == 0
-        # (i.e. dim * dtype_size must be a multiple of 1024).
-        # For bf16: dim must be a multiple of 512.
-        self._fused_ar_supported = (dim * 2) % 1024 == 0
 
         layer_quant_config = (
             LayerQuantConfig()
@@ -230,21 +226,14 @@ class RMSNorm(nn.Module):
             assert (
                 residual is not None
             ), "fused_allreduce_rmsnorm requires residual input!"
-            if self._fused_ar_supported:
-                x, residual = tensor_model_parallel_fused_allreduce_rmsnorm(
-                    x,
-                    residual,
-                    self.weight,
-                    self.eps,
-                )
-                return x, residual
-            else:
-                # Shape not supported by fused kernel; do allreduce separately
-                x = tensor_model_parallel_all_reduce(x)
-                x, residual = rmsnorm2d_fwd_with_add_(
-                    x, self.weight, residual, self.eps, self.dim
-                )
-                return x, residual
+            # tensor_model_parallel_fused_allreduce_rmsnorm does not support non-contiguous input
+            x, residual = tensor_model_parallel_fused_allreduce_rmsnorm(
+                x.contiguous(),
+                residual,
+                self.weight,
+                self.eps,
+            )
+            return x, residual
         else:
             if x_scale is not None and self.use_fused_quant:
                 from aiter.ops.triton.fused_fp8_quant import (


### PR DESCRIPTION
## Motivation

This PR added contiguous to tensor_model_parallel_fused_allreduce_rmsnorm ops because it does not support non-contiguous input.
