### PR TITLE
[BugFix] enable deepseek r1 fp4

### DIFF
--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -909,11 +909,6 @@ def _split_and_assign_kc_vc(
             w_vc = w_vc.contiguous()
         attn.w_vc = bind_or_assign(attn.w_vc, w_vc)
 
-        if hasattr(attn.kv_b_proj, "weight_scale") and attn.w_scale is None:
-            attn.w_scale = bind_or_assign(attn.w_scale, attn.kv_b_proj.weight_scale)
-            if _is_hip:
-                attn.w_scale *= 2.0
-
         if _is_cpu and _is_cpu_amx_available and w.dtype == torch.float8_e4m3fn:
             attn.w_kc = attn.w_kc.to(torch.bfloat16) * attn.w_scale
             attn.w_vc = attn.w_vc.to(torch.bfloat16) * attn.w_scale


### PR DESCRIPTION
## Motivation

For FP4 DeepSeek, the attention part is fully BF16 while the MoE part is FP4. Therefore, the scale for the attention part is None. For regular DeepSeek FP8, the attention part is also FP8 and requires quantization. However, the case where scale is None was previously ignored. This PR fixes that bug.

## command
```
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
 
model_path=/workspace/model/DeepSeek-R1-0528-MXFP4/
export PYTHONPATH=/workspace/dpsk-r1-fp4/sglang/python:/workspace/dpsk-r1-fp4/ATOM_oot/ATOM
 
 
export SGLANG_PROFILE_RECORD_SHAPES=1
export SGLANG_PROFILE_WITH_STACK=1
export SGLANG_TORCH_PROFILER_DIR=/workspace/dpsk-r1-fp4/sglang/profile_log
 
# export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.model_wrapper
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models

export ATOM_PROFILE_MLA_ABSORBED_BMM=1

TORCHINDUCTOR_COMPILE_THREADS=128 python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 8 \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.9 \
    --page-size 1 \
    --disable-radix-cache \
    --skip-server-warmup > log.serve.atom.oot.fp4.log 2>&1
```