### PR TITLE
[Plugin] [Feature] Supoort MLA q/k norm-quant fusion with SGLang + ATOM plugin for Deepseek

### DIFF
--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -114,6 +114,52 @@ def _unwrap_linear_output(output: Any) -> torch.Tensor:
     return output
 
 
+def _fuse_qk_rmsnorm_and_q_quant(
+    attn: DeepseekV2MLAAttention,
+    q: torch.Tensor,
+    k_nope: torch.Tensor,
+    *,
+    output_unquantized_q: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    """Fuse q/k RMSNorm and q quant using ATOM's DeepSeek-V2 path."""
+    from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
+
+    (q_quantized, q_scale), q_normed, k_nope_normed, _ = _fuse_rmsnorm_quant(
+        q,
+        attn.q_a_layernorm.weight,
+        attn.q_a_layernorm.eps,
+        k_nope,
+        attn.kv_a_layernorm.weight,
+        attn.kv_a_layernorm.eps,
+        None,
+        dtype_quant=attn.quant_dtype,
+        shuffle=False,
+        scale_shuffle_padding=False,
+        group_size=128,
+        output_unquantized_inp1=output_unquantized_q,
+        transpose_scale=True,
+    )
+    return q_quantized, q_scale, q_normed, k_nope_normed
+
+
+def _fuse_qk_rmsnorm(
+    attn: DeepseekV2MLAAttention,
+    q: torch.Tensor,
+    k_nope: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse q/k RMSNorm without quantizing q."""
+    from atom.models.deepseek_v2 import _fused_qk_rmsnorm
+
+    return _fused_qk_rmsnorm(
+        q,
+        attn.q_a_layernorm.weight,
+        attn.q_a_layernorm.eps,
+        k_nope,
+        attn.kv_a_layernorm.weight,
+        attn.kv_a_layernorm.eps,
+    )
+
+
 # Init helpers
 def init_sgl_attrs(
     attn: DeepseekV2MLAAttention,
@@ -321,9 +367,22 @@ def forward_sgl_prepare(
             )
 
         k_nope = latent_cache[..., : attn.kv_lora_rank]
+        q_scale = None
 
-        # overlap qk norm
-        if attn.alt_stream is not None and get_is_capture_mode():
+        # Reuse native ATOM gating for q/k RMSNorm fusion. Quant fusion is used
+        # when DeepSeek enables qknorm-quant; otherwise keep the non-quant fused
+        # path aligned with native ATOM before falling back to plain layernorm.
+        if getattr(attn, "fuse_qknorm_quant", False):
+            q, q_scale, q_lora, k_nope = _fuse_qk_rmsnorm_and_q_quant(
+                attn,
+                q,
+                k_nope,
+                output_unquantized_q=attn.use_nsa,
+            )
+        elif getattr(attn, "fuse_qknorm", False):
+            q, k_nope = _fuse_qk_rmsnorm(attn, q, k_nope)
+        # Otherwise keep the original overlap path for unfused qk norm.
+        elif attn.alt_stream is not None and get_is_capture_mode():
             current_stream = torch.cuda.current_stream()
             attn.alt_stream.wait_stream(current_stream)
             q = attn.q_a_layernorm(q)
@@ -349,7 +408,11 @@ def forward_sgl_prepare(
             attn.alt_stream.wait_stream(current_stream)
             with torch.cuda.stream(attn.alt_stream):
                 k_nope = k_nope.unsqueeze(1)
-                q = attn.q_b_proj(q).view(-1, attn.num_local_heads, attn.qk_head_dim)
+                q = _unwrap_linear_output(
+                    attn.q_b_proj(q, q_scale)
+                    if q_scale is not None
+                    else attn.q_b_proj(q)
+                ).view(-1, attn.num_local_heads, attn.qk_head_dim)
             topk_indices = attn.indexer(
                 x=hidden_states,
                 q_lora=q_lora,
@@ -360,7 +423,9 @@ def forward_sgl_prepare(
             current_stream.wait_stream(attn.alt_stream)
         else:
             k_nope = k_nope.unsqueeze(1)
-            q = attn.q_b_proj(q).view(-1, attn.num_local_heads, attn.qk_head_dim)
+            q = _unwrap_linear_output(
+                attn.q_b_proj(q, q_scale) if q_scale is not None else attn.q_b_proj(q)
+            ).view(-1, attn.num_local_heads, attn.qk_head_dim)
             if q_lora is not None:
                 topk_indices = attn.indexer(
                     x=hidden_states,


### PR DESCRIPTION
## Motivation

DeepSeek MLA preprocessing in the SGLang + ATOM plugin was still doing q/k RMSNorm and q quantization in separate steps, leaving unnecessary kernel and memory overhead in a hot path. Since ATOM already provides a gated fused norm-quant implementation for DeepSeek, this PR integrates that path into the plugin so supported workloads can benefit from the fusion while unsupported cases continue to use the existing fallback path.

before :
<img width="2301" height="100" alt="image" src="https://github.com/user-attachments/assets/6994f8c5-c508-4f69-bf78-fd183a82e9bb" />

after : 
<img width="1931" height="116" alt="image" src="https://github.com/user-attachments/assets/6b879536-b44f-494f-b076-4a45b40dec72" />

## Test Plan

lauch server:
```
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1

model_path=/shared/data/amd_int/models/DeepSeek-R1-0528

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models

TORCHINDUCTOR_COMPILE_THREADS=128 python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 9000 \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.9 \
    --page-size 1 \
    --disable-radix-cache \
```
client:
```
model_path=/shared/data/amd_int/models/DeepSeek-R1-0528-MXFP4

ISL=8000
OSL=1000
CON=4
NUM=$(( CON * 2 ))
RANGE_RATIO=1.0

PYTHONDONTWRITEBYTECODE=1 python "/home/qichu_qle/my_sgl/bench_serving/benchmark_serving.py" \
  --model=$model_path \
  --backend=sglang \
  --base-url=http://127.0.0.1:9000 \
  --dataset-name=random \
  --random-input-len="${ISL}" \
  --random-output-len="${OSL}" \
  --random-range-ratio "${RANGE_RATIO}" \
  --num-prompts="${NUM}" \
  --max-concurrency="${CON}" \
  --trust-remote-code \
  --request-rate=inf \
  --num-warmups="$(( 2 * CON ))" \
  --ignore-eos \
  --save-result \
  --percentile-metrics="ttft,tpot,itl,e2el" \
  --result-dir="./tmp/oot-benchmark-results" \
  --result-filename="${ISL}_${OSL}_${CON}.json" \
  --profile
```
## Test Result

```
============ Serving Benchmark Result ============
Successful requests:                     8         
Benchmark duration (s):                  97.66     
Total input tokens:                      64000     
Total generated tokens:                  8000      
Request throughput (req/s):              0.08      
Output token throughput (tok/s):         81.92     
Total Token throughput (tok/s):          737.26    
---------------Time to First Token----------------
Mean TTFT (ms):                          1330.96   
Median TTFT (ms):                        1457.61   
P99 TTFT (ms):                           1891.41   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.20     
Median TPOT (ms):                        20.08     
P99 TPOT (ms):                           21.02     
---------------Inter-token Latency----------------
Mean ITL (ms):                           20.20     
Median ITL (ms):                         19.68     
P99 ITL (ms):                            20.15     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          21514.63  
Median E2EL (ms):                        21514.56  
P99 E2EL (ms):                           21516.52  
==================================================
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
