### PR TITLE
[shuffle weight][model_ops] chunk shuffle_weights to reduce load-time memory usage

### DIFF
--- a/atom/model_ops/utils.py
+++ b/atom/model_ops/utils.py
@@ -3,6 +3,7 @@
 
 import importlib.util
 import logging
+import os
 from functools import cache
 from typing import List, Optional, Tuple, Union
 
@@ -139,11 +140,23 @@ def shuffle_weights(*tensors: torch.nn.Parameter, layout: tuple[int, int] = (16,
     A Tuple of shuffled tensors.
     """
     for tensor in tensors:
-        if isinstance(tensor, torch.nn.Parameter):
-            tensor.data = shuffle_weight(tensor, layout=layout)
-            tensor.is_shuffled = True
-        else:
+        if not isinstance(tensor, torch.nn.Parameter):
             raise TypeError(f"Expected torch.nn.Parameter, but got {type(tensor)}")
+
+        weight = tensor.data
+        if weight.dim() == 2:
+            tensor.data = shuffle_weight(weight, layout=layout)
+        elif weight.dim() == 3:
+            # Split fully on dim0 and shuffle each 2D slice independently.
+            for i in range(weight.shape[0]):
+                weight[i].copy_(shuffle_weight(weight[i], layout=layout))
+            tensor.data = weight
+        else:
+            raise ValueError(
+                f"Expected weight dim to be 2 or 3 for shuffle, got {weight.dim()}"
+            )
+
+        tensor.is_shuffled = True
 
 
 def all_close_1d(x: torch.Tensor) -> bool:

--- a/atom/model_ops/utils.py
+++ b/atom/model_ops/utils.py
@@ -3,7 +3,6 @@
 
 import importlib.util
 import logging
-import os
 from functools import cache
 from typing import List, Optional, Tuple, Union
 


### PR DESCRIPTION
## Summary
Currently there exists an OOM error when running GLM5 on mi355 with TP4. The error is introduced by `shuffle_weights` after loading the model. For MoE models the gemm weights are `[num_experts, k, n]`. Original version shuffle this weight once. This PR solves this problem by spliting MoE gemm weights expert by expert.

## Test plan
- [x] Reproduce OOM with GLM-5 in vLLM startup before fix (`shuffle_weight(...).contiguous()` path)
- [x] Start vLLM with this patch and verify model loads successfully without OOM
- [ ] Run ATOM unit/integration tests covering model_ops shuffle paths