### PR TITLE
Add rocm-trace-lite (RTL) for GPU kernel profiling

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -17,8 +17,22 @@ if [ "$TYPE" == "launch" ]; then
     PROFILER_ARGS="--torch-profiler-dir /app/trace --mark-trace"
     echo "Torch profiler enabled, trace output: /app/trace"
   fi
+
+  # RTL (rocm-trace-lite) GPU kernel tracing
+  RTL_CMD=""
+  if [ "${ENABLE_RTL_PROFILER:-0}" == "1" ]; then
+    RTL_TRACE_DIR="${ATOM_RTL_TRACE_DIR:-/app/rtl_traces}"
+    mkdir -p "$RTL_TRACE_DIR"
+    if command -v rtl &>/dev/null; then
+      RTL_CMD="rtl trace -o ${RTL_TRACE_DIR}/trace.db --"
+      echo "RTL profiler enabled, trace output: ${RTL_TRACE_DIR}"
+    else
+      echo "WARNING: RTL profiler requested but rtl command not found, skipping"
+    fi
+  fi
+
   ATOM_SERVER_LOG="/tmp/atom_server.log"
-  python -m atom.entrypoints.openai_server --model "$MODEL_PATH" $PROFILER_ARGS "${EXTRA_ARGS[@]}" 2>&1 | tee "$ATOM_SERVER_LOG" &
+  $RTL_CMD python -m atom.entrypoints.openai_server --model "$MODEL_PATH" $PROFILER_ARGS "${EXTRA_ARGS[@]}" 2>&1 | tee "$ATOM_SERVER_LOG" &
   atom_server_pid=$!
 
   echo ""
@@ -106,6 +120,16 @@ fi
 if [ "$TYPE" == "stop" ]; then
   echo ""
   echo "========== Stopping ATOM server =========="
+
+  # Generate RTL trace summary before killing the server
+  RTL_TRACE_DIR="${ATOM_RTL_TRACE_DIR:-/app/rtl_traces}"
+  if [ -d "$RTL_TRACE_DIR" ] && ls "$RTL_TRACE_DIR"/trace*.db 1>/dev/null 2>&1; then
+    echo "Generating RTL trace summary..."
+    for db in "$RTL_TRACE_DIR"/trace*.db; do
+      rtl summary "$db" > "${db%.db}_summary.txt" 2>/dev/null || true
+    done
+    echo "RTL traces: $(ls "$RTL_TRACE_DIR"/*.db 2>/dev/null | wc -l) db files"
+  fi
 
   # Wait for trace files to finish writing (before killing the server process)
   TRACE_DIR="${TORCH_PROFILER_DIR:-/app/trace}"

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -45,6 +45,10 @@ on:
         description: "Enable torch profiler to collect trace for performance debugging"
         type: boolean
         default: false
+      enable_rtl:
+        description: "Enable RTL (rocm-trace-lite) GPU kernel tracing for prefill/decode analysis"
+        type: boolean
+        default: false
       param_lists:
         description: |
           "Benchmark parameter lists. 
@@ -185,6 +189,7 @@ jobs:
             -e ISL=${{ env.ISL }} -e OSL=${{ env.OSL }} \
             -e CONC=${{ env.CONC }} -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }} \
             -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
+            -e ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
             $ENV_FLAGS \
             --name atom-benchmark \
             ${{ inputs.image || 'rocm/atom-dev:latest' }}
@@ -219,6 +224,7 @@ jobs:
 
           docker exec atom-benchmark bash -lc "set -euo pipefail
             ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
+              ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
               .github/scripts/atom_test.sh launch $model_path ${{ env.ARGS }} ${{ inputs.extra_args || '' }}
             echo '========== Running benchmark =========='
             ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
@@ -262,6 +268,20 @@ jobs:
         with:
           name: profiler-traces-${{ env.RESULT_FILENAME }}
           path: profiler-traces/
+
+      - name: Stop server and collect RTL traces
+        if: inputs.enable_rtl
+        run: |
+          docker exec atom-benchmark bash -lc \
+            "ENABLE_RTL_PROFILER=1 .github/scripts/atom_test.sh stop" || true
+          docker cp atom-benchmark:/app/rtl_traces ./rtl-traces 2>/dev/null || true
+
+      - name: Upload RTL traces
+        if: inputs.enable_rtl
+        uses: actions/upload-artifact@v7
+        with:
+          name: rtl-traces-${{ env.RESULT_FILENAME }}
+          path: rtl-traces/
 
       - name: Upload benchmark result
         uses: actions/upload-artifact@v7

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -67,6 +67,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_TORCH_PROFILER_DIR": lambda: os.getenv("ATOM_TORCH_PROFILER_DIR", None),
     "ATOM_PROFILER_MORE": lambda: os.getenv("ATOM_PROFILER_MORE", "0") == "1",
     "ATOM_LOG_MORE": lambda: int(os.getenv("ATOM_LOG_MORE", "0")) != 0,
+    # RTL (rocm-trace-lite) GPU kernel tracing — set to output directory to enable.
+    # When set, the server launch is wrapped with `rtl trace` to collect per-kernel
+    # GPU timestamps for both prefill and decode phases.
+    "ATOM_RTL_TRACE_DIR": lambda: os.getenv("ATOM_RTL_TRACE_DIR", None),
     # --- Model Loading ---
     "ATOM_DISABLE_MMAP": lambda: os.getenv("ATOM_DISABLE_MMAP", "false").lower()
     == "true",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -373,6 +373,10 @@ COPY --from=build_aiter /app/aiter-test /app/aiter-test
 RUN cd /app/aiter-test && pip install -e . --no-build-isolation && \
     pip show amd-aiter
 
+# RTL (rocm-trace-lite): lightweight GPU kernel profiler (~250KB, no build deps)
+RUN pip install rocm-trace-lite && \
+    rtl --version || true
+
 # ATOM: lightweight install (no compilation needed)
 # CACHEBUST invalidates only this layer so parallel stages stay cached
 ARG CACHEBUST=1


### PR DESCRIPTION
## Summary

- Add [rocm-trace-lite](https://github.com/sunway513/rocm-trace-lite) (RTL) as an optional GPU kernel profiler in ATOM nightly image and benchmark workflow
- RTL captures per-kernel GPU timestamps via HSA queue intercept — no dependency on roctracer/rocprofiler
- Produces SQLite (queryable) + Perfetto-compatible traces for prefill and decode kernel analysis

## Changes

| File | What |
|------|------|
| `docker/Dockerfile` | `pip install rocm-trace-lite` in nightly image (~250KB) |
| `atom/utils/envs.py` | Add `ATOM_RTL_TRACE_DIR` env var |
| `.github/scripts/atom_test.sh` | Wrap server with `rtl trace` when `ENABLE_RTL_PROFILER=1`, generate summaries on stop |
| `.github/workflows/atom-benchmark.yaml` | Add `enable_rtl` workflow input, upload RTL traces as artifacts |

## Usage

**Via workflow dispatch:**
Set `enable_rtl: true` when triggering ATOM Benchmark workflow. RTL traces uploaded as `rtl-traces-<config>` artifacts.

**Via env var (any container):**
```bash
ENABLE_RTL_PROFILER=1 .github/scripts/atom_test.sh launch <model> -tp 8
```

## CUDAGraph Compatibility

RTL works with ATOM default CUDAGraph mode (level=3, piecewise+CUDAGraph). **No need for `--enforce-eager`.**

| RTL_MODE | Prefill | Decode (graph capture) | Decode (graph replay) | Notes |
|----------|---------|----------------------|---------------------|-------|
| `default` | Full profiling | Full profiling | Skipped (safe) | **Recommended.** Zero overhead on replay path. |
| `lite` | Partial | Partial | Skipped | Lowest overhead, partial coverage |
| `full` | Full | Full | Full | Requires ROCm 7.13+ ROCR fix (559d48b1) |

With `RTL_MODE=default` (the default):
- **Prefill**: all GPU kernels captured with timestamps
- **Decode graph capture**: each batch size config runs once during CUDAGraph capture — RTL profiles these, giving complete kernel composition and relative timing for decode
- **Decode graph replay**: safely skipped — no signal injection, no overhead, no crash

This means we get the full kernel breakdown for both prefill and decode phases while maintaining production-level performance.

## Key validation points

1. **Performance impact**: RTL overhead must not affect throughput/latency results — validate by comparing with and without `enable_rtl`
2. **Trace completeness**: Confirm traces capture all GPU kernels for both prefill and decode phases
3. **Top kernel analysis**: Trace summaries show top kernels by GPU time, enabling focused optimization per phase

## Known limitation

RTL signal injection does not work with ATOM multi-process worker architecture (`AsyncIOProcManager` + `multiprocessing.spawn`). The external wrapper approach profiles the main process and its direct kernel dispatches. For full multi-worker profiling, see sunway513/rocm-trace-lite#79 (HIP-level callback API proposal).

## RFC

ROCm/ATOM#534

## Test plan

- [ ] Build Docker image with RTL installed, verify `rtl --version` works
- [ ] Run benchmark with `enable_rtl=false` — baseline throughput/latency
- [ ] Run benchmark with `enable_rtl=true` — compare throughput/latency (expect < 2% overhead)
- [ ] Verify RTL trace artifact is uploaded and contains kernel data
- [ ] Verify trace summary shows top kernels for prefill and decode phases
- [ ] Verify Perfetto trace loads correctly in https://ui.perfetto.dev
- [ ] Verify CUDAGraph level=3 works correctly with RTL (no enforce-eager needed)