### PR TITLE
CI: inject AMD_HF_TOKEN on predownload runner

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -226,6 +226,10 @@ jobs:
           name: aiter-whl
           path: /tmp/aiter-whl
 
+      - name: Set HF token for predownload runner
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> "$GITHUB_ENV"
+
       - name: Start CI container
         run: |
           echo "Clean up containers..."


### PR DESCRIPTION
## Summary
- set `HF_TOKEN` from `secrets.AMD_HF_TOKEN` for the `atom-mi355-8gpu.predownload` runner in `atom-test.yaml`
- ensure the predownload runner passes an authenticated token into the existing container startup and model download steps
- reduce Hugging Face rate limiting for model fetches on the predownload machine

## Test plan
- validated the workflow YAML parses successfully with `python3` + `yaml.safe_load`
- checked the diff is limited to the predownload runner token injection step
- not run: GitHub Actions job execution