### PR TITLE
feat: improve profiler robustness and enable stream parallelism for decode metadata

### DIFF
--- a/atom/model_engine/async_proc.py
+++ b/atom/model_engine/async_proc.py
@@ -265,9 +265,11 @@ class AsyncIOProcManager:
             _self = self_ref()
             if not _self or not _self.keep_monitoring:
                 return
-            proc_name = next(proc.name for proc in procs if proc.sentinel == died[0])
+            dead_proc = next(proc for proc in procs if proc.sentinel == died[0])
+            dead_proc.join(timeout=5)
             logger.error(
-                f"{self.label}: [{proc_name}] proc died unexpectedly, shutting down.",
+                f"{self.label}: [{dead_proc.name}] proc died unexpectedly "
+                f"(exitcode={dead_proc.exitcode}), shutting down.",
             )
             _self.exit()
 

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -6,6 +6,7 @@ import logging
 import pickle
 import queue
 import threading
+import time
 from contextlib import ExitStack
 from typing import List
 
@@ -308,8 +309,9 @@ class EngineCore:
     def stop_profiler(self):
         if self.profile_enbaled:
             logger.info("Profiler stopping...")
+            t0 = time.monotonic()
             self.runner_mgr.call_func("stop_profiler", wait_out=True)
-            logger.info("Profiler stopped.")
+            logger.info("Profiler stopped in %.1fs", time.monotonic() - t0)
 
     def print_mtp_statistics(self):
         if self.scheduler.spec_stats is not None:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-import gzip
 import logging
 import math
 import os
@@ -91,7 +90,7 @@ class tokenIDProcessor:
         self.use_spec = use_spec
         self.num_spec_tokens = num_spec_tokens
 
-        self.async_copy_stream = torch.cuda.Stream()
+        self.async_copy_stream = torch.cuda.Stream(runner.device)
         self.default_num_rejected_tokens = torch.zeros(
             max_num_batched_tokens, dtype=torch.int32, device=device
         )
@@ -587,6 +586,7 @@ class ModelRunner:
             logger.info("Loading drafter model...")
             self.drafter.load_model(self.model)
         torch.set_default_device(self.device)
+        self.async_execute_stream = torch.cuda.Stream(self.device)
         self.allocate_forward_vars()
         self.attn_metadata_builder = self.attn_backend.get_builder_cls()(
             model_runner=self
@@ -717,18 +717,42 @@ class ModelRunner:
             output_prefix = os.path.join(self.profiler_dir, worker_name)
 
             def _on_trace_ready(prof):
+                import gzip as _gzip
+
                 # Use a short human-readable timestamp in file name.
                 ts = time.strftime("%Y%m%d_%H%M%S", time.localtime())
                 ms = int((time.time() % 1) * 1000)
                 output_path = f"{output_prefix}_ts_{ts}_{ms:03d}.pt.trace.json.gz"
                 tmp_json_path = output_path[:-3]
-                prof.export_chrome_trace(tmp_json_path)
-                with (
-                    open(tmp_json_path, "rb") as src,
-                    gzip.open(output_path, "wb") as dst,
-                ):
-                    dst.write(src.read())
-                os.remove(tmp_json_path)
+                try:
+                    t0 = time.monotonic()
+                    prof.export_chrome_trace(tmp_json_path)
+                    # Chunked gzip: read 64 MB at a time to avoid loading
+                    # the entire JSON (~30 GB) into memory at once.
+                    with (
+                        open(tmp_json_path, "rb") as src,
+                        _gzip.open(output_path, "wb") as dst,
+                    ):
+                        while chunk := src.read(64 * 1024 * 1024):
+                            dst.write(chunk)
+                    os.remove(tmp_json_path)
+                    sz = os.path.getsize(output_path)
+                    logger.info(
+                        "Rank %d: trace exported to %s (%.1f MB, %.1fs)",
+                        self.rank,
+                        output_path,
+                        sz / 1e6,
+                        time.monotonic() - t0,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Rank %d: failed to export trace to %s",
+                        self.rank,
+                        output_path,
+                    )
+                    for p in (tmp_json_path, output_path):
+                        if os.path.exists(p):
+                            os.remove(p)
 
             self.profiler = torch_profiler.profile(
                 activities=[
@@ -741,13 +765,31 @@ class ModelRunner:
                 on_trace_ready=_on_trace_ready,
             )
             self.profiler.__enter__()
+            logger.info(
+                "Rank %d: profiler started (detailed=%s, dir=%s)",
+                self.rank,
+                enable_detailed_profiling,
+                self.profiler_dir,
+            )
         return True
 
     def stop_profiler(self):
-        """Stop profiling for this rank"""
-        if self.profiler is not None:
+        """Stop profiling for this rank."""
+        if self.profiler is None:
+            return True
+        t0 = time.monotonic()
+        logger.info("Rank %d: stopping profiler...", self.rank)
+        try:
             self.profiler.__exit__(None, None, None)
+        except Exception:
+            logger.exception("Rank %d: profiler stop failed", self.rank)
+        finally:
             self.profiler = None
+        logger.info(
+            "Rank %d: profiler stop completed in %.1fs",
+            self.rank,
+            time.monotonic() - t0,
+        )
         return True
 
     def debug(self, *args: Any):

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -7,14 +7,19 @@ from typing import Type
 import numpy as np
 import torch
 from aiter import (
+    decode_update_mla_metadata_v1,
     dtypes,
     get_mla_metadata_info_v1,
     get_mla_metadata_v1,
-    decode_update_mla_metadata_v1,
 )
 from aiter.dist.parallel_state import get_tp_group
 from atom.model_engine.scheduler import ScheduledBatch
-from atom.model_ops.attention_mla import MLAAttention, _MLA_MIN_HEADS
+from atom.model_ops.attention_mla import _MLA_MIN_HEADS, MLAAttention
+from atom.plugin.attention import (
+    AiterBackendDecoratorForPluginMode,
+    AiterMLAAttentionMetadataBuilderDecoratorForPluginMode,
+)
+from atom.plugin.prepare import is_plugin_mode
 from atom.utils import CpuGpuBuffer
 from atom.utils.block_convert import (
     block_table_convert_triton,
@@ -23,10 +28,6 @@ from atom.utils.block_convert import (
 from atom.utils.forward_context import AttentionMetaData, Context
 
 from .backends import AttentionBackend, CommonAttentionBuilder
-
-from atom.plugin.prepare import is_plugin_mode
-from atom.plugin.attention import AiterMLAAttentionMetadataBuilderDecoratorForPluginMode
-from atom.plugin.attention import AiterBackendDecoratorForPluginMode
 
 logger = logging.getLogger("atom")
 
@@ -146,7 +147,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
     @property
     def prep_stream(self):
-        return self.model_runner.tokenID_processor.async_copy_stream
+        # return self.model_runner.tokenID_processor.async_copy_stream
+        return self.model_runner.async_execute_stream
 
     def set_mla_persistent_worker_buffers(
         self,
@@ -410,13 +412,18 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         )
         var["kv_last_page_lens"].np[scheduled_bs:bs] = 0
         vars_used = [
-            ("block_tables", bs),
             ("slot_mapping", bs * max_seqlen_q),
             ("context_lens", bs),
             ("cu_seqlens_q", bs + 1),
-            ("kv_indptr", bs + 1),
+            # ("kv_indptr", bs + 1),
             ("kv_last_page_lens", bs),
+            ("block_tables", bs),
         ]
+        metadata_deps = {
+            "cu_seqlens_q",
+            "kv_last_page_lens",
+        }
+
         if self.is_sparse:
             index_topk = self.index_topk
             sparse_context_lens = np.clip(var["context_lens"].np[:bs], None, index_topk)
@@ -427,21 +434,15 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 "sparse_kv_indptr"
             ].np[scheduled_bs]
             vars_used.append(("sparse_kv_indptr", bs + 1))
+            metadata_deps.add("sparse_kv_indptr")
 
         prep_stream = self.prep_stream
-        metadata_deps = {
-            "cu_seqlens_q",
-            "kv_indptr",
-            "kv_last_page_lens",
-            "sparse_kv_indptr",
-        }
         vars_for_metadata = [(el, num) for el, num in vars_used if el in metadata_deps]
         vars_remaining = [(el, num) for el, num in vars_used if el not in metadata_deps]
         max_seqlen_k = context_lens.max()
 
-        # metadata copies on main_stream
-        ctx = {el: var[el].copy_to_gpu(num) for el, num in vars_for_metadata}
-
+        ctx = {}
+        ctx["kv_indptr"] = var["kv_indptr"].copy_to_gpu(bs + 1)
         # prep_stream does remaining copies + kv_indices
         current_stream = torch.cuda.current_stream()
         prep_stream.wait_stream(current_stream)
@@ -457,9 +458,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 max_seqlen_k,
             )
 
+        # metadata copies on main_stream
+        positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
+        ctx.update({el: var[el].copy_to_gpu(num) for el, num in vars_for_metadata})
         ctx_mla_ps = self.set_mla_persistent_worker_buffers(bs, max_seqlen_q)
         ctx.update(ctx_mla_ps)
-        positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
         current_stream.wait_stream(prep_stream)
         # if self.block_ratio > 1:
         #     if "block_tables" in ctx:


### PR DESCRIPTION
## Summary
- **Profiler**: chunked gzip export (64MB), per-rank logging, error handling — prevents OOM on large traces (~30GB with `ATOM_PROFILER_MORE=1`)
- **Stream parallelism**: use dedicated `async_execute_stream` for `kv_indices_generate` in decode metadata prep, enabling GPU concurrent execution with `get_mla_metadata` on main stream. The previous `async_copy_stream` had accumulated event dependencies from `prepare_input_ids`, causing GPU-level serialization.
- **Diagnostics**: log worker exitcode on unexpected death, profiler start/stop timing

## Test plan
- [ ] Start server with `--torch-profiler-dir`, run benchmark, verify trace files generated without crash
- [ ] Verify `kv_indices_generate_kernel` on separate stream in trace (search `kv_indices` in Perfetto)
- [ ] Start server with `ATOM_PROFILER_MORE=1`, verify no OOM during trace export
- [ ] Run accuracy test (GSM8K) to confirm no regression