### PR TITLE
CI: make ATOM test workflow reusable

### DIFF
--- a/.github/workflows/atom-test-trigger.yaml
+++ b/.github/workflows/atom-test-trigger.yaml
@@ -1,0 +1,47 @@
+name: ATOM Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  schedule:
+    # Nightly at 00:00 Beijing time (16:00 UTC)
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+    inputs:
+      aiter_branch:
+        description: 'ROCm/aiter branch to build inside the CI image'
+        required: false
+        default: 'main'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  atom-test:
+    uses: ./.github/workflows/atom-test.yaml
+    with:
+      checkout_repository: ${{ github.repository }}
+      checkout_ref: ${{ github.sha }}
+      source_repo_url: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.clone_url || format('https://github.com/{0}.git', github.repository) }}
+      source_commit_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
+      aiter_branch: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.aiter_branch || 'main' }}
+      model_scope: ${{ github.event_name == 'schedule' && 'nightly' || github.event_name == 'workflow_dispatch' && 'nightly' || github.event_name == 'push' && 'main' || 'pr' }}
+      run_precheck: ${{ github.event_name != 'workflow_dispatch' }}
+      is_draft_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft || false }}
+      is_fork_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork || false }}
+      publish_dashboard: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+    secrets:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      docker_username: ${{ secrets.DOCKER_USERNAME }}
+      docker_password: ${{ secrets.DOCKER_PASSWORD }}
+      amd_hf_token: ${{ secrets.AMD_HF_TOKEN }}

--- a/.github/workflows/atom-test-trigger.yaml
+++ b/.github/workflows/atom-test-trigger.yaml
@@ -43,7 +43,7 @@ jobs:
       is_fork_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork || false }}
       publish_dashboard: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') }}
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      repo_token: ${{ secrets.GITHUB_TOKEN }}
       docker_username: ${{ secrets.DOCKER_USERNAME }}
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
       amd_hf_token: ${{ secrets.AMD_HF_TOKEN }}

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -59,7 +59,7 @@ on:
         default: false
         type: boolean
     secrets:
-      github_token:
+      repo_token:
         required: false
       docker_username:
         required: false
@@ -88,12 +88,12 @@ jobs:
         with:
           repository: ${{ inputs.checkout_repository }}
           ref: ${{ inputs.checkout_ref }}
-          token: ${{ secrets.github_token || github.token }}
+          token: ${{ secrets.repo_token || github.token }}
 
       - name: Download and check pre-checkin signal
         run: bash ./.github/scripts/check_signal.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token || github.token }}
+          GITHUB_TOKEN: ${{ secrets.repo_token || github.token }}
           GITHUB_REPOSITORY: ${{ inputs.checkout_repository }}
           GITHUB_SHA: ${{ inputs.signal_commit_sha || inputs.checkout_ref }}
 
@@ -110,7 +110,7 @@ jobs:
 
           S3_MAIN_MANIFEST_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950/main/latest.json"
           API_URL="https://api.github.com"
-          AUTH_HEADER="Authorization: token ${{ secrets.github_token || github.token }}"
+          AUTH_HEADER="Authorization: token ${{ secrets.repo_token || github.token }}"
           AITER_TEST_WORKFLOW_ID=179476100
 
           download_from_s3_manifest() {
@@ -215,7 +215,7 @@ jobs:
         with:
           repository: ${{ inputs.checkout_repository }}
           ref: ${{ inputs.checkout_ref }}
-          token: ${{ secrets.github_token || github.token }}
+          token: ${{ secrets.repo_token || github.token }}
       - id: load
         env:
           MODEL_SCOPE: ${{ inputs.model_scope }}
@@ -279,7 +279,7 @@ jobs:
         with:
           repository: ${{ inputs.checkout_repository }}
           ref: ${{ inputs.checkout_ref }}
-          token: ${{ secrets.github_token || github.token }}
+          token: ${{ secrets.repo_token || github.token }}
       
       - name: Docker Login
         if: ${{ !inputs.is_fork_pr }}
@@ -634,7 +634,7 @@ jobs:
         with:
           repository: ${{ inputs.checkout_repository }}
           ref: ${{ inputs.checkout_ref }}
-          token: ${{ secrets.github_token || github.token }}
+          token: ${{ secrets.repo_token || github.token }}
 
       - uses: actions/setup-python@v6
         with:
@@ -671,5 +671,5 @@ jobs:
           benchmark-data-dir-path: benchmark-dashboard
           auto-push: true
           max-items-in-chart: 90
-          github-token: ${{ secrets.github_token || github.token }}
+          github-token: ${{ secrets.repo_token || github.token }}
 

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -1,41 +1,77 @@
-name: ATOM Test
+name: ATOM Test Reusable
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]  # Triggers on PRs targeting `main`
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
-  schedule:
-    # Nightly at 00:00 Beijing time (16:00 UTC)
-    - cron: '0 16 * * *'
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      checkout_repository:
+        description: 'Repository to check out into the workflow workspace'
+        required: false
+        default: 'ROCm/ATOM'
+        type: string
+      checkout_ref:
+        description: 'Git ref or commit SHA to check out into the workflow workspace'
+        required: false
+        default: 'main'
+        type: string
+      source_repo_url:
+        description: 'Clone URL used inside container-side source build flows'
+        required: false
+        default: ''
+        type: string
+      source_commit_sha:
+        description: 'Commit SHA used inside container-side source build flows'
+        required: false
+        default: ''
+        type: string
       aiter_branch:
         description: 'ROCm/aiter branch to build inside the CI image'
         required: false
         default: 'main'
         type: string
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+      model_scope:
+        description: 'Model scope to run: pr, main, or nightly'
+        required: false
+        default: 'pr'
+        type: string
+      run_precheck:
+        description: 'Whether to gate the run on the pre-checkin signal artifact'
+        required: false
+        default: false
+        type: boolean
+      is_draft_pr:
+        description: 'Whether the source change is a draft pull request'
+        required: false
+        default: false
+        type: boolean
+      is_fork_pr:
+        description: 'Whether the source change comes from a fork'
+        required: false
+        default: false
+        type: boolean
+      publish_dashboard:
+        description: 'Whether to publish accuracy results to the benchmark dashboard'
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      github_token:
+        required: false
+      docker_username:
+        required: false
+      docker_password:
+        required: false
+      amd_hf_token:
+        required: false
 
 env:
   ATOM_BASE_IMAGE: rocm/atom-dev:latest
-  GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/ATOM.git' }}
-  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
-  # workflow_dispatch: inputs.aiter_branch; otherwise main (matches previous default-branch shallow clone)
-  AITER_GIT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.aiter_branch || 'main' }}
+  GITHUB_REPO_URL: ${{ inputs.source_repo_url || format('https://github.com/{0}.git', inputs.checkout_repository) }}
+  GITHUB_COMMIT_SHA: ${{ inputs.source_commit_sha || inputs.checkout_ref }}
+  AITER_GIT_REF: ${{ inputs.aiter_branch }}
 
 jobs:
   check-signal:
-    if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
+    if: ${{ !inputs.is_draft_pr && inputs.run_precheck }}
     name: Check Pre Checkin Signal
     runs-on: ubuntu-latest
     permissions:
@@ -43,18 +79,21 @@ jobs:
       contents: read
     steps:
       - name: Checkout ATOM repo
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repository }}
+          ref: ${{ inputs.checkout_ref }}
+          token: ${{ secrets.github_token || github.token }}
 
       - name: Download and check pre-checkin signal
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: bash ./.github/scripts/check_signal.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.github_token || github.token }}
+          GITHUB_REPOSITORY: ${{ inputs.checkout_repository }}
+          GITHUB_SHA: ${{ env.GITHUB_COMMIT_SHA }}
 
   download_aiter_wheel:
-    if: ${{ needs.check-signal.result == 'success' && (!github.event.pull_request || github.event.pull_request.draft == false) }}
+    if: ${{ !inputs.is_draft_pr && (!inputs.run_precheck || needs.check-signal.result == 'success') }}
     needs: [check-signal]
     name: Download aiter wheel
     runs-on: ubuntu-latest
@@ -66,7 +105,7 @@ jobs:
 
           S3_MAIN_MANIFEST_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950/main/latest.json"
           API_URL="https://api.github.com"
-          AUTH_HEADER="Authorization: token ${{ secrets.GITHUB_TOKEN }}"
+          AUTH_HEADER="Authorization: token ${{ secrets.github_token || github.token }}"
           AITER_TEST_WORKFLOW_ID=179476100
 
           download_from_s3_manifest() {
@@ -161,28 +200,32 @@ jobs:
           retention-days: 1
 
   load-test-models:
+    if: ${{ !inputs.is_draft_pr }}
     name: Load test model configs
     runs-on: ubuntu-latest
     outputs:
       models_json: ${{ steps.load.outputs.models_json }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repository }}
+          ref: ${{ inputs.checkout_ref }}
+          token: ${{ secrets.github_token || github.token }}
       - id: load
         env:
-          EVENT_NAME: ${{ github.event_name }}
+          MODEL_SCOPE: ${{ inputs.model_scope }}
         run: |
           python3 << 'PY'
           import json, os
-          event = os.environ["EVENT_NAME"]
-          # pr → pr models only; push to main → pr+main; schedule/dispatch → all
-          level_map = {"schedule": "nightly", "workflow_dispatch": "nightly", "push": "main"}
-          current = level_map.get(event, "pr")
-          allowed = {"pr": {"pr"}, "main": {"pr", "main"}, "nightly": {"pr", "main", "nightly"}}[current]
+          current = os.environ["MODEL_SCOPE"]
+          allowed = {"pr": {"pr"}, "main": {"pr", "main"}, "nightly": {"pr", "main", "nightly"}}.get(current)
+          if allowed is None:
+              raise SystemExit(f"Unsupported model_scope: {current}")
           models = json.load(open(".github/benchmark/models_accuracy.json", encoding="utf-8"))
           filtered = [m for m in models if m.get("test_level", "nightly") in allowed]
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"models_json={json.dumps(filtered)}\n")
-          print(f"Event={event} level={current}: {len(filtered)}/{len(models)} models")
+          print(f"Scope={current}: {len(filtered)}/{len(models)} models")
           print(f"{'Model':<45} {'Level':<10} {'Runner'}")
           print("-" * 80)
           for m in models:
@@ -197,7 +240,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.load-test-models.outputs.models_json) }}
-    if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
+    if: ${{ !inputs.is_draft_pr }}
     runs-on: ${{ matrix.runner }}
 
     env:
@@ -228,17 +271,28 @@ jobs:
 
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repository }}
+          ref: ${{ inputs.checkout_ref }}
+          token: ${{ secrets.github_token || github.token }}
       
       - name: Docker Login
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: ${{ !inputs.is_fork_pr }}
+        env:
+          DOCKER_USERNAME: ${{ secrets.docker_username }}
+          DOCKER_PASSWORD: ${{ secrets.docker_password }}
         run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          if [ -z "${DOCKER_USERNAME:-}" ] || [ -z "${DOCKER_PASSWORD:-}" ]; then
+            echo "Docker credentials not provided; skipping docker login."
+            exit 0
+          fi
+          echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 
       - name: Generate Dockerfile for forked repo
-        if: ${{ github.event.pull_request.head.repo.fork }}
+        if: ${{ inputs.is_fork_pr }}
         run: |
           cat <<EOF > Dockerfile.mod
-          FROM ${{ env.ATOM_BASE_NIGHTLY_IMAGE }}
+          FROM ${{ env.ATOM_BASE_IMAGE }}
           RUN pip install -U lm-eval[api]
           RUN pip show lm-eval || true
           RUN pip install hf_transfer
@@ -273,7 +327,7 @@ jobs:
 
       - name: Set HF token for predownload runner
         if: matrix.runner == 'atom-mi355-8gpu.predownload'
-        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> "$GITHUB_ENV"
+        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.amd_hf_token }}}" >> "$GITHUB_ENV"
 
       - name: Start CI container
         run: |
@@ -565,10 +619,14 @@ jobs:
   accuracy-dashboard:
     name: Update accuracy dashboard
     needs: [atom-test]
-    if: always() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule')
+    if: ${{ always() && inputs.publish_dashboard }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repository }}
+          ref: ${{ inputs.checkout_ref }}
+          token: ${{ secrets.github_token || github.token }}
 
       - uses: actions/setup-python@v6
         with:
@@ -605,5 +663,5 @@ jobs:
           benchmark-data-dir-path: benchmark-dashboard
           auto-push: true
           max-items-in-chart: 90
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.github_token || github.token }}
 


### PR DESCRIPTION
## Summary
- split `atom-test.yaml` into a reusable `workflow_call` entrypoint plus a lightweight trigger wrapper
- parameterize checkout, repo/ref, fork handling, model scope, and dashboard publishing so other repos can call the same ATOM test pipeline
- keep the existing `push` / `pull_request` / `schedule` / `workflow_dispatch` entrypoints via `atom-test-trigger.yaml`

## Test plan
- [x] Checked workflow YAML with editor diagnostics (`ReadLints`)
- [ ] Trigger the new wrapper workflow in `ROCm/ATOM`
- [ ] Invoke the reusable workflow from an external test workflow
- [ ] Verify pre-checkin signal lookup still works with the passed ATOM commit SHA
- [ ] Verify dashboard publishing still only runs from the wrapper on main push/schedule