### PR TITLE
[atom-vllm][atom-sglang][CI] build CI image on GPU machine instead of a build-only machine

### DIFF
--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -103,7 +103,7 @@
   },
   {
     "model_name": "DeepSeek-R1-0528-MXFP4 TP8",
-    "model_path": "amd/DeepSeek-R1-0528-MXFP4",
+    "model_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
     "extraArgs": "--tensor-parallel-size 8",
     "env_vars": "",
     "runner": "linux-atom-mi35x-8",

--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -1,0 +1,14 @@
+[
+  {
+    "model_name": "DeepSeek-R1-FP8 TP4",
+    "model_path": "deepseek-ai/DeepSeek-R1-0528",
+    "extraArgs": "--tensor-parallel-size 4",
+    "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+    "runner": "linux-atom-mi35x-4",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.92,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "deepseek-ai/DeepSeek-R1-0528",
+    "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
+  }
+]

--- a/.github/scripts/accuracy_to_dashboard.py
+++ b/.github/scripts/accuracy_to_dashboard.py
@@ -74,6 +74,11 @@ def build_entries(
         if baseline_note:
             extra_parts.append(f"BaselineNote: {baseline_note}")
 
+        ci_metadata = data.get("atom_ci_metadata", {})
+        docker_image = ci_metadata.get("docker_image")
+        if docker_image:
+            extra_parts.append(f"Docker: {docker_image}")
+
         try:
             if strict_score is not None:
                 extra_parts.append(f"strict-match: {round(float(strict_score), 4)}")

--- a/.github/scripts/atom_oot_test.sh
+++ b/.github/scripts/atom_oot_test.sh
@@ -48,6 +48,7 @@ KEEP_SERVER_ALIVE_ON_EXIT=${KEEP_SERVER_ALIVE_ON_EXIT:-0}
 EXPLICIT_MODEL_NAME=${OOT_MODEL_NAME:-}
 EXPLICIT_MODEL_PATH=${OOT_MODEL_PATH:-}
 EXPLICIT_EXTRA_ARGS=${OOT_EXTRA_ARGS:-}
+OOT_DOCKER_IMAGE=${OOT_DOCKER_IMAGE:-}
 LAST_VLLM_LOG_LINE=0
 
 declare -a ACTIVE_MODELS=()
@@ -251,6 +252,26 @@ PY
   if [[ "${result_file}" != "${flat_result_file}" ]]; then
     cp -f "${result_file}" "${flat_result_file}"
     result_file="${flat_result_file}"
+  fi
+
+  if [[ -n "${OOT_DOCKER_IMAGE}" ]]; then
+    RESULT_FILE="${result_file}" \
+    OOT_DOCKER_IMAGE="${OOT_DOCKER_IMAGE}" \
+    python - <<'PY'
+import json
+import os
+
+result_file = os.environ["RESULT_FILE"]
+with open(result_file, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+metadata = data.setdefault("atom_ci_metadata", {})
+if os.environ.get("OOT_DOCKER_IMAGE"):
+    metadata["docker_image"] = os.environ["OOT_DOCKER_IMAGE"]
+
+with open(result_file, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2)
+PY
   fi
 
   local value

--- a/.github/scripts/atom_sglang_test.sh
+++ b/.github/scripts/atom_sglang_test.sh
@@ -50,6 +50,7 @@ MODEL_NAME=${SGLANG_MODEL_NAME:-}
 MODEL_PATH=${SGLANG_MODEL_PATH:-}
 MODEL_EXTRA_ARGS=${SGLANG_EXTRA_ARGS:-}
 MODEL_ENV_VARS=${SGLANG_ENV_VARS:-}
+SGLANG_DOCKER_IMAGE=${SGLANG_DOCKER_IMAGE:-}
 
 LAST_SGLANG_LOG_LINE=0
 
@@ -254,6 +255,26 @@ PY
   if [[ "${result_file}" != "${flat_result_file}" ]]; then
     cp -f "${result_file}" "${flat_result_file}"
     result_file="${flat_result_file}"
+  fi
+
+  if [[ -n "${SGLANG_DOCKER_IMAGE}" ]]; then
+    RESULT_FILE="${result_file}" \
+    SGLANG_DOCKER_IMAGE="${SGLANG_DOCKER_IMAGE}" \
+    python3 - <<'PY'
+import json
+import os
+
+result_file = os.environ["RESULT_FILE"]
+with open(result_file, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+metadata = data.setdefault("atom_ci_metadata", {})
+if os.environ.get("SGLANG_DOCKER_IMAGE"):
+    metadata["docker_image"] = os.environ["SGLANG_DOCKER_IMAGE"]
+
+with open(result_file, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2)
+PY
   fi
 
   local value

--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 TYPE=${1:-launch}
 MODEL_PATH=${2:-meta-llama/Meta-Llama-3-8B-Instruct}
 EXTRA_ARGS=("${@:3}")
+ATOM_DOCKER_IMAGE=${ATOM_DOCKER_IMAGE:-}
 
 
 if [ "$TYPE" == "launch" ]; then
@@ -124,6 +125,26 @@ if [ "$TYPE" == "accuracy" ]; then
           --num_fewshot 3 \
           --output_path "${RESULT_FILENAME}" \
           2>&1 | tee "$ATOM_CLIENT_LOG"
+
+  if [ -n "${ATOM_DOCKER_IMAGE}" ]; then
+    RESULT_FILE="${RESULT_FILENAME}" \
+    ATOM_DOCKER_IMAGE="${ATOM_DOCKER_IMAGE}" \
+    python3 - <<'PY'
+import json
+import os
+
+result_file = os.environ["RESULT_FILE"]
+with open(result_file, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+metadata = data.setdefault("atom_ci_metadata", {})
+metadata["docker_image"] = os.environ["ATOM_DOCKER_IMAGE"]
+
+with open(result_file, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2)
+PY
+  fi
+
   echo "Accuracy test results saved to ${RESULT_FILENAME}"
 fi
 

--- a/.github/scripts/resolve_atom_image.py
+++ b/.github/scripts/resolve_atom_image.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""Resolve a stable published ATOM plugin image reference from a floating tag.
+"""Resolve a stable published ATOM image reference from a floating tag.
 
-Given a floating tag like ``vllm-latest`` or ``sglang-latest``, this script
-looks up its manifest digest and then searches the same repository for the
-newest same-digest nightly tag in the matching image family. If no nightly tag
-matches, or if the reverse lookup cannot complete after the floating tag digest
-is known, it returns a digest-pinned ``latest`` reference instead.
+Supported floating tags:
+- ``latest`` -> native nightly tags like ``nightly_YYYYMMDDHHMM``
+- ``vllm-latest`` -> plugin nightly tags like ``vllm-vVERSION-nightly_YYYYMMDD``
+- ``sglang-latest`` -> plugin nightly tags like ``sglang-vVERSION-nightly_YYYYMMDD``
+
+The resolver first looks up the floating tag digest, then scans the same
+repository for the newest same-digest nightly tag in the matching family. If no
+nightly tag matches, or if reverse lookup cannot complete after the floating tag
+digest is known, it returns a digest-pinned floating reference instead.
 """
 
 from __future__ import annotations
@@ -30,15 +34,33 @@ MANIFEST_ACCEPT = ", ".join(
         "application/vnd.docker.distribution.manifest.v2+json",
     )
 )
-USER_AGENT = "ATOM Plugin Image Resolver/1.0"
-SUPPORTED_IMAGE_FAMILIES = ("vllm", "sglang")
+USER_AGENT = "ATOM Image Resolver/1.0"
+IMAGE_FAMILY_CONFIG = {
+    "native": {
+        "reference_tag": "latest",
+        "nightly_regex": re.compile(r"^nightly_(?P<date>\d{12})$"),
+        "supports_version": False,
+    },
+    "vllm": {
+        "reference_tag": "vllm-latest",
+        "nightly_regex": re.compile(r"^vllm-v(?P<version>.+)-nightly_(?P<date>\d{8})$"),
+        "supports_version": True,
+    },
+    "sglang": {
+        "reference_tag": "sglang-latest",
+        "nightly_regex": re.compile(
+            r"^sglang-v(?P<version>.+)-nightly_(?P<date>\d{8})$"
+        ),
+        "supports_version": True,
+    },
+}
 
 
 @dataclass(frozen=True)
 class CandidateTag:
     tag: str
-    version: str
     date: str
+    version: str = ""
 
 
 def build_resolution(
@@ -161,30 +183,28 @@ def list_tags(repository: str, token: str) -> list[str]:
     return tags
 
 
-def nightly_regex(image_family: str) -> re.Pattern[str]:
-    if image_family not in SUPPORTED_IMAGE_FAMILIES:
-        raise ValueError(
-            f"Unsupported image family {image_family!r}; expected one of {SUPPORTED_IMAGE_FAMILIES}"
-        )
-    return re.compile(
-        rf"^{re.escape(image_family)}-v(?P<version>.+)-nightly_(?P<date>\d{{8}})$"
-    )
-
-
 def infer_image_family(reference_tag: str) -> str:
-    for family in SUPPORTED_IMAGE_FAMILIES:
-        if reference_tag == f"{family}-latest":
+    for family, config in IMAGE_FAMILY_CONFIG.items():
+        if reference_tag == config["reference_tag"]:
             return family
+    expected = ", ".join(
+        config["reference_tag"] for config in IMAGE_FAMILY_CONFIG.values()
+    )
     raise ValueError(
-        f"Unable to infer image family from reference tag {reference_tag!r}; expected one of "
-        + ", ".join(f"{family}-latest" for family in SUPPORTED_IMAGE_FAMILIES)
+        f"Unable to infer image family from reference tag {reference_tag!r}; expected one of {expected}"
     )
 
 
 def nightly_candidates(
     tags: Iterable[str], preferred_version: str | None, image_family: str = "vllm"
 ) -> list[CandidateTag]:
-    pattern = nightly_regex(image_family)
+    if image_family not in IMAGE_FAMILY_CONFIG:
+        raise ValueError(
+            f"Unsupported image family {image_family!r}; expected one of {tuple(IMAGE_FAMILY_CONFIG)}"
+        )
+
+    config = IMAGE_FAMILY_CONFIG[image_family]
+    pattern = config["nightly_regex"]
     candidates: list[CandidateTag] = []
     for tag in tags:
         match = pattern.match(tag)
@@ -193,15 +213,17 @@ def nightly_candidates(
         candidates.append(
             CandidateTag(
                 tag=tag,
-                version=match.group("version"),
                 date=match.group("date"),
+                version=match.groupdict().get("version", ""),
             )
         )
 
     def sort_key(candidate: CandidateTag) -> tuple[int, str, str]:
-        preferred = (
-            1 if preferred_version and candidate.version == preferred_version else 0
-        )
+        preferred = 0
+        if config["supports_version"]:
+            preferred = (
+                1 if preferred_version and candidate.version == preferred_version else 0
+            )
         return (preferred, candidate.date, candidate.tag)
 
     return sorted(candidates, key=sort_key, reverse=True)
@@ -258,7 +280,7 @@ def resolve_image(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Resolve a floating ATOM plugin image tag to a same-digest nightly tag when possible."
+        description="Resolve a floating ATOM image tag to a same-digest nightly tag when possible."
     )
     parser.add_argument(
         "--repository",
@@ -268,7 +290,7 @@ def main() -> None:
     parser.add_argument(
         "--reference-tag",
         required=True,
-        help="Floating tag to resolve, for example vllm-latest or sglang-latest",
+        help="Floating tag to resolve, for example latest, vllm-latest, or sglang-latest",
     )
     parser.add_argument(
         "--preferred-version",
@@ -278,7 +300,7 @@ def main() -> None:
     parser.add_argument(
         "--image-family",
         default="",
-        help="Optional image family override (for example vllm or sglang). By default this is inferred from the reference tag.",
+        help="Optional image family override (for example native, vllm, or sglang). By default this is inferred from the reference tag.",
     )
     args = parser.parse_args()
 

--- a/.github/scripts/resolve_atom_plugin_image.py
+++ b/.github/scripts/resolve_atom_plugin_image.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Resolve a stable published OOT image reference for benchmarking.
+"""Resolve a stable published ATOM plugin image reference from a floating tag.
 
-Given a floating tag like ``vllm-latest``, this script looks up its manifest
-digest and then searches the same repository for the newest
-``vllm-v*-nightly_*`` tag with that exact digest. If no nightly tag matches, or
-if the reverse lookup cannot complete after the floating tag digest is known, it
-returns a digest-pinned ``latest`` reference instead.
+Given a floating tag like ``vllm-latest`` or ``sglang-latest``, this script
+looks up its manifest digest and then searches the same repository for the
+newest same-digest nightly tag in the matching image family. If no nightly tag
+matches, or if the reverse lookup cannot complete after the floating tag digest
+is known, it returns a digest-pinned ``latest`` reference instead.
 """
 
 from __future__ import annotations
@@ -30,8 +30,8 @@ MANIFEST_ACCEPT = ", ".join(
         "application/vnd.docker.distribution.manifest.v2+json",
     )
 )
-NIGHTLY_RE = re.compile(r"^vllm-v(?P<version>.+)-nightly_(?P<date>\d{8})$")
-USER_AGENT = "ATOM OOT Image Resolver/1.0"
+USER_AGENT = "ATOM Plugin Image Resolver/1.0"
+SUPPORTED_IMAGE_FAMILIES = ("vllm", "sglang")
 
 
 @dataclass(frozen=True)
@@ -161,12 +161,33 @@ def list_tags(repository: str, token: str) -> list[str]:
     return tags
 
 
+def nightly_regex(image_family: str) -> re.Pattern[str]:
+    if image_family not in SUPPORTED_IMAGE_FAMILIES:
+        raise ValueError(
+            f"Unsupported image family {image_family!r}; expected one of {SUPPORTED_IMAGE_FAMILIES}"
+        )
+    return re.compile(
+        rf"^{re.escape(image_family)}-v(?P<version>.+)-nightly_(?P<date>\d{{8}})$"
+    )
+
+
+def infer_image_family(reference_tag: str) -> str:
+    for family in SUPPORTED_IMAGE_FAMILIES:
+        if reference_tag == f"{family}-latest":
+            return family
+    raise ValueError(
+        f"Unable to infer image family from reference tag {reference_tag!r}; expected one of "
+        + ", ".join(f"{family}-latest" for family in SUPPORTED_IMAGE_FAMILIES)
+    )
+
+
 def nightly_candidates(
-    tags: Iterable[str], preferred_version: str | None
+    tags: Iterable[str], preferred_version: str | None, image_family: str = "vllm"
 ) -> list[CandidateTag]:
+    pattern = nightly_regex(image_family)
     candidates: list[CandidateTag] = []
     for tag in tags:
-        match = NIGHTLY_RE.match(tag)
+        match = pattern.match(tag)
         if not match:
             continue
         candidates.append(
@@ -187,13 +208,19 @@ def nightly_candidates(
 
 
 def resolve_image(
-    repository: str, reference_tag: str, preferred_version: str | None
+    repository: str,
+    reference_tag: str,
+    preferred_version: str | None,
+    image_family: str | None = None,
 ) -> dict[str, object]:
+    image_family = image_family or infer_image_family(reference_tag)
     token = get_registry_token(repository)
     reference_digest = get_manifest_digest(repository, reference_tag, token)
     candidates: list[CandidateTag] = []
     try:
-        candidates = nightly_candidates(list_tags(repository, token), preferred_version)
+        candidates = nightly_candidates(
+            list_tags(repository, token), preferred_version, image_family=image_family
+        )
         for candidate in candidates:
             if (
                 get_manifest_digest(repository, candidate.tag, token)
@@ -231,7 +258,7 @@ def resolve_image(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Resolve a floating OOT image tag to a same-digest nightly tag when possible."
+        description="Resolve a floating ATOM plugin image tag to a same-digest nightly tag when possible."
     )
     parser.add_argument(
         "--repository",
@@ -241,12 +268,17 @@ def main() -> None:
     parser.add_argument(
         "--reference-tag",
         required=True,
-        help="Floating tag to resolve, for example vllm-latest",
+        help="Floating tag to resolve, for example vllm-latest or sglang-latest",
     )
     parser.add_argument(
         "--preferred-version",
         default="",
-        help="Optional preferred vLLM version to prioritize when scanning nightly tags",
+        help="Optional preferred backend version to prioritize when scanning nightly tags",
+    )
+    parser.add_argument(
+        "--image-family",
+        default="",
+        help="Optional image family override (for example vllm or sglang). By default this is inferred from the reference tag.",
     )
     args = parser.parse_args()
 
@@ -254,6 +286,7 @@ def main() -> None:
         repository=args.repository,
         reference_tag=args.reference_tag,
         preferred_version=args.preferred_version or None,
+        image_family=args.image_family or None,
     )
     json.dump(resolution, sys.stdout, sort_keys=True)
     sys.stdout.write("\n")

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -93,7 +93,7 @@ jobs:
 
           if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ] || [ "${GITHUB_REF_NAME}" = "main" ]; then
             if RESOLUTION_JSON="$(
-              python3 .github/scripts/resolve_atom_plugin_image.py \
+              python3 .github/scripts/resolve_atom_image.py \
                 --repository "${VALIDATION_IMAGE_REPO}" \
                 --reference-tag sglang-latest \
                 --preferred-version "${SGLANG_REF#v}"

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -14,6 +14,11 @@ on:
         required: false
         type: boolean
         default: false
+      upload_accuracy_to_dashboard:
+        description: "Optional: upload SGLANG accuracy results to dashboard after this manual run"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -87,12 +92,31 @@ jobs:
           PY
 
           if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ] || [ "${GITHUB_REF_NAME}" = "main" ]; then
-            if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-              echo "Manual run on main reuses published SGLANG image: ${NIGHTLY_SGLANG_IMAGE_TAG}"
+            if RESOLUTION_JSON="$(
+              python3 .github/scripts/resolve_atom_plugin_image.py \
+                --repository "${VALIDATION_IMAGE_REPO}" \
+                --reference-tag sglang-latest \
+                --preferred-version "${SGLANG_REF#v}"
+            )"; then
+              RESOLVED_SGLANG_IMAGE="$(
+                RESOLUTION_JSON="${RESOLUTION_JSON}" python3 - <<'PY'
+          import json
+          import os
+
+          resolution = json.loads(os.environ["RESOLUTION_JSON"])
+          print(resolution["resolved_image"])
+          PY
+              )"
             else
-              echo "Scheduled run uses published SGLANG image: ${NIGHTLY_SGLANG_IMAGE_TAG}"
+              echo "::warning::Failed to resolve ${NIGHTLY_SGLANG_IMAGE_TAG} to an immutable reference; falling back to the floating tag."
+              RESOLVED_SGLANG_IMAGE="${NIGHTLY_SGLANG_IMAGE_TAG}"
             fi
-            echo "sglang_image_tag=${NIGHTLY_SGLANG_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+            if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+              echo "Manual run on main reuses published SGLANG image: ${RESOLVED_SGLANG_IMAGE}"
+            else
+              echo "Scheduled run uses published SGLANG image: ${RESOLVED_SGLANG_IMAGE}"
+            fi
+            echo "sglang_image_tag=${RESOLVED_SGLANG_IMAGE}" >> "$GITHUB_OUTPUT"
             echo "cleanup_temp_image=false" >> "$GITHUB_OUTPUT"
             echo "manual_base_image_tag=" >> "$GITHUB_OUTPUT"
             exit 0
@@ -346,6 +370,7 @@ jobs:
             -e SGLANG_MODEL_PATH="${SGLANG_RESOLVED_MODEL_PATH:-$SGLANG_MODEL_PATH}" \
             -e SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS}" \
             -e SGLANG_ENV_VARS="${SGLANG_ENV_VARS}" \
+            -e SGLANG_DOCKER_IMAGE="${SGLANG_IMAGE_TAG}" \
             -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
             -e STREAM_SGLANG_LOGS="${STREAM_SGLANG_LOGS}" \
             -e LM_EVAL_TASK="${LM_EVAL_TASK}" \
@@ -402,7 +427,7 @@ jobs:
             atom_sglang_accuracy_results
 
       - name: Upload accuracy results for dashboard
-        if: always()
+        if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard)) }}
         uses: actions/upload-artifact@v7
         with:
           name: accuracy-${{ matrix.model_name }}
@@ -416,3 +441,65 @@ jobs:
           docker stop "$CONTAINER_NAME" || true
           docker rm "$CONTAINER_NAME" || true
           docker rmi "${SGLANG_IMAGE_TAG}" || true
+
+  accuracy-dashboard:
+    name: Update SGLANG accuracy dashboard
+    needs: [sglang-model-accuracy]
+    if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard)) }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Prepare accuracy artifact directory
+        run: mkdir -p /tmp/accuracy-results
+
+      - name: Download accuracy artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/accuracy-results
+          pattern: accuracy-*
+        continue-on-error: true
+
+      - name: Count downloaded accuracy artifacts
+        id: downloaded
+        run: |
+          json_count=$(find /tmp/accuracy-results -type f -name '*.json' | wc -l | tr -d ' ')
+          echo "json_count=${json_count}" >> "$GITHUB_OUTPUT"
+          echo "Downloaded ${json_count} SGLANG accuracy JSON files"
+
+      - name: List downloaded accuracy artifacts
+        if: steps.downloaded.outputs.json_count != '0'
+        run: |
+          echo "=== Downloaded SGLANG accuracy artifacts ==="
+          find /tmp/accuracy-results -type f -name '*.json' | head -20 || echo "No JSON files found"
+
+      - name: Transform SGLANG accuracy results for dashboard
+        if: steps.downloaded.outputs.json_count != '0'
+        run: |
+          python3 .github/scripts/accuracy_to_dashboard.py \
+            /tmp/accuracy-results \
+            --output accuracy-benchmark-input.json \
+            --models .github/benchmark/sglang_models_accuracy.json \
+            --backend "ATOM-SGLang" \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "=== Generated entries ==="
+          cat accuracy-benchmark-input.json
+
+      - name: Store SGLANG accuracy result to dashboard
+        if: steps.downloaded.outputs.json_count != '0'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: customBiggerIsBetter
+          output-file-path: accuracy-benchmark-input.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: benchmark-dashboard
+          auto-push: true
+          max-items-in-chart: 90
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -109,190 +109,8 @@ jobs:
           path: aiter-whl/amd_aiter*.whl
           retention-days: 1
 
-  build_sglang_image:
-    if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false }}
-    needs: [check-signal, download_aiter_wheel]
-    name: Reuse SGLANG CI image
-    runs-on: build-only-atom
-    env:
-      SGLANG_REF: v0.5.10
-      AITER_ARTIFACT_ID: ${{ needs.download_aiter_wheel.outputs.aiter_artifact_id }}
-    steps:
-      - name: Initialize SGLANG image tag
-        run: |
-          echo "SGLANG_IMAGE_TAG=rocm/atom-dev:sglang-pre-build-${GITHUB_COMMIT_SHA}" >> "$GITHUB_ENV"
-
-      - name: Checkout ATOM repo
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        uses: actions/checkout@v6
-
-      - name: Docker Login
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-      - name: Check existing prebuilt SGLANG image
-        id: existing_sglang_image
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        run: |
-          set -euo pipefail
-          echo "image_exists=false" >> "$GITHUB_OUTPUT"
-
-          if ! docker manifest inspect "${SGLANG_IMAGE_TAG}" >/dev/null 2>&1; then
-            echo "No existing SGLANG image found for ${SGLANG_IMAGE_TAG}; building a new one."
-            exit 0
-          fi
-
-          echo "Found existing SGLANG image for ${SGLANG_IMAGE_TAG}; validating SGLang commit label."
-          if ! docker pull "${SGLANG_IMAGE_TAG}"; then
-            echo "Failed to pull existing image ${SGLANG_IMAGE_TAG}; rebuilding it."
-            exit 0
-          fi
-
-          EXISTING_SGLANG_REF="$(docker inspect --format '{{ index .Config.Labels "com.rocm.atom.sglang_ref" }}' "${SGLANG_IMAGE_TAG}" 2>/dev/null || true)"
-          EXISTING_AITER_ARTIFACT_ID="$(docker inspect --format '{{ index .Config.Labels "com.rocm.atom.aiter_artifact_id" }}' "${SGLANG_IMAGE_TAG}" 2>/dev/null || true)"
-          if [ -n "${EXISTING_SGLANG_REF}" ] && [ "${EXISTING_SGLANG_REF}" = "${SGLANG_REF}" ] && [ -n "${EXISTING_AITER_ARTIFACT_ID}" ] && [ "${EXISTING_AITER_ARTIFACT_ID}" = "${AITER_ARTIFACT_ID}" ]; then
-            echo "image_exists=true" >> "$GITHUB_OUTPUT"
-            echo "Reusing existing SGLANG image for ${SGLANG_IMAGE_TAG} (SGLang commit ${EXISTING_SGLANG_REF}, aiter artifact ${EXISTING_AITER_ARTIFACT_ID})."
-          else
-            echo "Existing image label mismatch or missing."
-            echo "Expected SGLang commit ${SGLANG_REF}, got ${EXISTING_SGLANG_REF:-<missing>}."
-            echo "Expected aiter artifact ${AITER_ARTIFACT_ID}, got ${EXISTING_AITER_ARTIFACT_ID:-<missing>}."
-          fi
-
-      - name: Download aiter wheel
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_sglang_image.outputs.image_exists != 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: aiter-whl
-          path: aiter-whl
-
-      - name: Generate SGLANG overlay Dockerfile
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_sglang_image.outputs.image_exists != 'true' }}
-        run: |
-          cat <<'EOF' > Dockerfile.mod
-          ARG SGLANG_BASE_IMAGE
-          FROM ${SGLANG_BASE_IMAGE}
-          ARG GITHUB_REPO_URL
-          ARG GITHUB_COMMIT_SHA
-          ARG SGLANG_REF
-          ARG AITER_ARTIFACT_ID
-          ARG INSTALL_LM_EVAL=1
-          LABEL com.rocm.atom.sglang_ref="${SGLANG_REF}"
-          LABEL com.rocm.atom.aiter_artifact_id="${AITER_ARTIFACT_ID}"
-          COPY aiter-whl/ /tmp/aiter-whl/
-          RUN if [ "${INSTALL_LM_EVAL}" = "1" ]; then pip install -U "lm-eval[api]"; else echo "Skip lm-eval install"; fi
-          RUN pip show lm-eval || true
-          RUN pip install hf_transfer
-          RUN pip show hf_transfer || true
-          RUN pip install --upgrade "pybind11>=3.0.1"
-          RUN pip show pybind11
-          RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true && \
-              pip uninstall -y amd-aiter || true && \
-              rm -rf /app/aiter-test && \
-              AITER_WHL="$(ls -t /tmp/aiter-whl/amd_aiter*.whl 2>/dev/null | head -1)" && \
-              if [ -z "${AITER_WHL}" ]; then echo "ERROR: No amd_aiter wheel found under /tmp/aiter-whl"; ls -la /tmp/aiter-whl || true; exit 1; fi && \
-              pip install "${AITER_WHL}" && \
-              echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true && \
-              rm -rf /tmp/aiter-whl
-          RUN echo "=== ATOM version BEFORE uninstall ===" && pip show atom || true && \
-              pip uninstall -y atom || true && \
-              rm -rf /app/ATOM && \
-              git clone "${GITHUB_REPO_URL}" /app/ATOM && \
-              cd /app/ATOM && \
-              git checkout "${GITHUB_COMMIT_SHA}" && \
-              pip install -e . --no-deps && \
-              echo "=== ATOM version AFTER installation ===" && pip show atom || true
-          RUN pip show amd-aiter atom sglang torch triton mori || true
-          EOF
-
-      - name: Resolve SGLANG CI build mode
-        id: build_mode
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_sglang_image.outputs.image_exists != 'true' }}
-        run: |
-          set -euo pipefail
-          echo "build_mode=full" >> "$GITHUB_OUTPUT"
-
-          if ! docker pull "${NIGHTLY_SGLANG_IMAGE_TAG}"; then
-            echo "Unable to pull ${NIGHTLY_SGLANG_IMAGE_TAG}; falling back to a full SGLang rebuild."
-            exit 0
-          fi
-
-          echo "Inspecting ${NIGHTLY_SGLANG_IMAGE_TAG} labels before deciding whether to reuse it."
-          docker inspect --format 'Image ID: {{.Id}}' "${NIGHTLY_SGLANG_IMAGE_TAG}" || true
-          docker inspect --format 'Image labels: {{json .Config.Labels}}' "${NIGHTLY_SGLANG_IMAGE_TAG}" || true
-          LATEST_SGLANG_REF="$(docker inspect --format '{{ index .Config.Labels "com.rocm.atom.sglang_ref" }}' "${NIGHTLY_SGLANG_IMAGE_TAG}" 2>/dev/null || true)"
-          echo "Expected SGLang commit label: ${SGLANG_REF}"
-          echo "Resolved ${NIGHTLY_SGLANG_IMAGE_TAG} label com.rocm.atom.sglang_ref: ${LATEST_SGLANG_REF:-<missing>}"
-          if [ -n "${LATEST_SGLANG_REF}" ] && [ "${LATEST_SGLANG_REF}" = "${SGLANG_REF}" ]; then
-            echo "build_mode=fast" >> "$GITHUB_OUTPUT"
-            echo "Reusing ${NIGHTLY_SGLANG_IMAGE_TAG} as the SGLANG CI base (SGLang commit ${LATEST_SGLANG_REF})."
-          else
-            echo "SGLANG CI latest image label mismatch or missing. Expected ${SGLANG_REF}, got ${LATEST_SGLANG_REF:-<missing>}; rebuilding SGLang."
-          fi
-
-      - name: Build SGLANG overlay image from reusable latest
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_sglang_image.outputs.image_exists != 'true' && steps.build_mode.outputs.build_mode == 'fast' }}
-        run: |
-          DOCKER_BUILDKIT=1 docker build --network=host \
-            -t atom_sglang:ci \
-            --build-arg SGLANG_BASE_IMAGE="${NIGHTLY_SGLANG_IMAGE_TAG}" \
-            --build-arg GITHUB_REPO_URL="${GITHUB_REPO_URL}" \
-            --build-arg GITHUB_COMMIT_SHA="${GITHUB_COMMIT_SHA}" \
-            --build-arg SGLANG_REF="${SGLANG_REF}" \
-            --build-arg AITER_ARTIFACT_ID="${AITER_ARTIFACT_ID}" \
-            --build-arg INSTALL_LM_EVAL=1 \
-            -f Dockerfile.mod .
-
-      - name: Build SGLANG overlay base image
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_sglang_image.outputs.image_exists != 'true' && steps.build_mode.outputs.build_mode != 'fast' }}
-        run: |
-          DOCKER_BUILDKIT=1 docker build --pull --network=host \
-            --no-cache \
-            -t atom_sglang_base:ci \
-            --build-arg SGLANG_BASE_IMAGE="${ATOM_BASE_NIGHTLY_IMAGE}" \
-            --build-arg GITHUB_REPO_URL="${GITHUB_REPO_URL}" \
-            --build-arg GITHUB_COMMIT_SHA="${GITHUB_COMMIT_SHA}" \
-            --build-arg SGLANG_REF="${SGLANG_REF}" \
-            --build-arg AITER_ARTIFACT_ID="${AITER_ARTIFACT_ID}" \
-            --build-arg INSTALL_LM_EVAL=1 \
-            -f Dockerfile.mod .
-
-      - name: Build SGLANG SGLang image
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_sglang_image.outputs.image_exists != 'true' && steps.build_mode.outputs.build_mode != 'fast' }}
-        run: |
-          DOCKER_BUILDKIT=1 docker build --network=host \
-            --no-cache \
-            -t atom_sglang:ci \
-            --target atom_sglang \
-            --build-arg SGLANG_BASE_IMAGE="atom_sglang_base:ci" \
-            --build-arg MAX_JOBS=64 \
-            --build-arg SGLANG_REF="${SGLANG_REF}" \
-            --build-arg INSTALL_LM_EVAL=1 \
-            --build-arg INSTALL_FASTSAFETENSORS=1 \
-            -f docker/Dockerfile .
-
-      - name: Push Docker image
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_sglang_image.outputs.image_exists != 'true' }}
-        run: |
-          docker tag atom_sglang:ci "${SGLANG_IMAGE_TAG}"
-          docker push "${SGLANG_IMAGE_TAG}"
-
-      - name: Skip remote build for fork PR
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
-        run: |
-          echo "Fork PRs build the SGLANG image locally on each test runner."
-
-      - name: Clean up build images
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && always() }}
-        run: |
-          rm -f Dockerfile.mod || true
-          docker rmi "atom_sglang_base:ci" || true
-          docker rmi "atom_sglang:ci" || true
-          docker rmi "${SGLANG_IMAGE_TAG}" || true
-
   atom-sglang-accuracy:
-    needs: [check-signal, download_aiter_wheel, build_sglang_image]
+    needs: [check-signal, download_aiter_wheel]
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false }}
     name: Accuracy (${{ matrix.model_name }})
     strategy:
@@ -340,14 +158,12 @@ jobs:
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Download aiter wheel
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
         uses: actions/download-artifact@v4
         with:
           name: aiter-whl
           path: aiter-whl
 
-      - name: Generate SGLANG overlay Dockerfile for forked repo
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+      - name: Generate SGLANG overlay Dockerfile
         run: |
           cat <<'EOF' > Dockerfile.mod
           ARG SGLANG_BASE_IMAGE
@@ -385,8 +201,7 @@ jobs:
           RUN pip show amd-aiter atom sglang torch triton mori || true
           EOF
 
-      - name: Build SGLANG image for forked repo
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+      - name: Build SGLANG image locally
         run: |
           set -euo pipefail
           docker rmi "atom_sglang_base:ci" || true
@@ -404,7 +219,7 @@ jobs:
             echo "Resolved ${NIGHTLY_SGLANG_IMAGE_TAG} label com.rocm.atom.sglang_ref: ${LATEST_SGLANG_REF:-<missing>}"
             if [ -n "${LATEST_SGLANG_REF}" ] && [ "${LATEST_SGLANG_REF}" = "${SGLANG_REF}" ]; then
               BUILD_MODE="fast"
-              echo "Reusing ${NIGHTLY_SGLANG_IMAGE_TAG} locally for fork PR SGLANG CI."
+              echo "Reusing ${NIGHTLY_SGLANG_IMAGE_TAG} locally for SGLANG CI."
             else
               echo "SGLANG CI latest image label mismatch or missing. Expected ${SGLANG_REF}, got ${LATEST_SGLANG_REF:-<missing>}; rebuilding SGLang locally."
             fi
@@ -446,19 +261,8 @@ jobs:
             -f docker/Dockerfile .
 
       - name: Set SGLANG image tag
-        env:
-          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
         run: |
-          if [ "${IS_FORK_PR}" = "true" ]; then
-            echo "SGLANG_IMAGE_TAG=atom_sglang:ci" >> "$GITHUB_ENV"
-          else
-            echo "SGLANG_IMAGE_TAG=rocm/atom-dev:sglang-pre-build-${GITHUB_COMMIT_SHA}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Pull SGLANG image
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        run: |
-          docker pull "${SGLANG_IMAGE_TAG}"
+          echo "SGLANG_IMAGE_TAG=atom_sglang:ci" >> "$GITHUB_ENV"
 
       - name: Prepare model cache mount
         run: |
@@ -661,25 +465,4 @@ jobs:
           rm -f Dockerfile.mod || true
           docker rmi "atom_sglang_base:ci" || true
           docker rmi "atom_sglang:ci" || true
-          KEEP_COUNT="${SGLANG_IMAGE_CACHE_KEEP:-3}"
-          if [[ "${SGLANG_IMAGE_TAG}" == rocm/atom-dev:sglang-pre-build-* ]]; then
-            echo "Keeping current SGLANG image tag and the ${KEEP_COUNT} most recent sglang-pre-build tags."
-            mapfile -t OLD_SGLANG_TAGS < <(
-              docker image ls --filter=reference='rocm/atom-dev:sglang-pre-build-*' --format '{{.Repository}}:{{.Tag}}' \
-                | while read -r tag; do
-                    [ -n "${tag}" ] || continue
-                    created_at=$(docker image inspect --format '{{.Created}}' "${tag}" 2>/dev/null || true)
-                    [ -n "${created_at}" ] && printf '%s %s\n' "${created_at}" "${tag}"
-                  done \
-                | sort -r \
-                | awk -v keep="${KEEP_COUNT}" 'NR > keep { print $2 }'
-            )
-            for tag in "${OLD_SGLANG_TAGS[@]}"; do
-              if [ "${tag}" = "${SGLANG_IMAGE_TAG}" ]; then
-                continue
-              fi
-              echo "Removing old SGLANG image tag: ${tag}"
-              docker rmi "${tag}" || true
-            done
-          fi
 

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -235,6 +235,39 @@ jobs:
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Resolve immutable native dashboard image
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+        run: |
+          set -euo pipefail
+          if RESOLUTION_JSON="$(
+            python3 .github/scripts/resolve_atom_image.py \
+              --repository rocm/atom-dev \
+              --reference-tag latest \
+              --image-family native
+          )"; then
+            RESOLVED_ATOM_IMAGE="$(
+              RESOLUTION_JSON="${RESOLUTION_JSON}" python3 - <<'PY'
+          import json
+          import os
+
+          resolution = json.loads(os.environ["RESOLUTION_JSON"])
+          print(resolution["resolved_image"])
+          PY
+            )"
+            echo "Resolved native dashboard image: ${RESOLVED_ATOM_IMAGE}"
+          else
+            echo "::error::Failed to resolve ${ATOM_BASE_IMAGE} to an immutable reference for dashboard-uploading native runs."
+            exit 1
+          fi
+          echo "RESOLVED_ATOM_BASE_IMAGE=${RESOLVED_ATOM_IMAGE}" >> "$GITHUB_ENV"
+          echo "ATOM_DASHBOARD_DOCKER_IMAGE=${RESOLVED_ATOM_IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Pull immutable native dashboard image
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+        run: |
+          echo "Pulling immutable native dashboard image: ${RESOLVED_ATOM_BASE_IMAGE}"
+          docker pull "${RESOLVED_ATOM_BASE_IMAGE}"
+
       - name: Generate Dockerfile for forked repo
         if: ${{ github.event.pull_request.head.repo.fork }}
         run: |
@@ -298,13 +331,15 @@ jobs:
           # Write env_vars via env block (avoids expression injection)
           printenv MODEL_ENV_VARS | grep -v '^$' > /tmp/env_file.txt || true
 
-          IMAGE_TAG=${{ env.ATOM_BASE_IMAGE }}
+          IMAGE_TAG="${RESOLVED_ATOM_BASE_IMAGE:-$ATOM_BASE_IMAGE}"
           echo "Starting container with image: $IMAGE_TAG"
           echo "Model-specific environment variables:"
           cat /tmp/env_file.txt
 
           PULL_FLAG=""
-          if [ "${{ matrix.runner }}" = "atom-mi355-8gpu.predownload" ]; then
+          if [ -n "${RESOLVED_ATOM_BASE_IMAGE:-}" ]; then
+            PULL_FLAG=""
+          elif [ "${{ matrix.runner }}" = "atom-mi355-8gpu.predownload" ]; then
             PULL_FLAG="--pull always"
           fi
 
@@ -317,6 +352,7 @@ jobs:
           --privileged \
           --cap-add=SYS_PTRACE \
           -e HF_TOKEN="${HF_TOKEN:-}" \
+          -e ATOM_DOCKER_IMAGE="${ATOM_DASHBOARD_DOCKER_IMAGE:-}" \
           --env-file /tmp/env_file.txt \
           --security-opt seccomp=unconfined \
           --ulimit memlock=-1 \

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -217,7 +217,7 @@ jobs:
               {
                   "toggle_env": "RUN_DSR1_FP4_TP8",
                   "model_name": "DeepSeek-R1-0528-MXFP4 TP8",
-                  "model_path": "amd/DeepSeek-R1-0528-MXFP4",
+                  "model_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
                   "extra_args": "--tensor-parallel-size 8",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "",

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -257,8 +257,26 @@ jobs:
           PY
 
           if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
-            echo "Scheduled run uses published OOT image: ${NIGHTLY_OOT_IMAGE_TAG}"
-            echo "oot_image_tag=${NIGHTLY_OOT_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+            if RESOLUTION_JSON="$(
+              python3 .github/scripts/resolve_atom_plugin_image.py \
+                --repository "${VALIDATION_IMAGE_REPO}" \
+                --reference-tag vllm-latest
+            )"; then
+              RESOLVED_OOT_IMAGE="$(
+                RESOLUTION_JSON="${RESOLUTION_JSON}" python3 - <<'PY'
+          import json
+          import os
+
+          resolution = json.loads(os.environ["RESOLUTION_JSON"])
+          print(resolution["resolved_image"])
+          PY
+              )"
+              echo "Scheduled run resolved published OOT image: ${RESOLVED_OOT_IMAGE}"
+            else
+              echo "::warning::Failed to resolve ${NIGHTLY_OOT_IMAGE_TAG} to an immutable reference; falling back to the floating tag."
+              RESOLVED_OOT_IMAGE="${NIGHTLY_OOT_IMAGE_TAG}"
+            fi
+            echo "oot_image_tag=${RESOLVED_OOT_IMAGE}" >> "$GITHUB_OUTPUT"
             echo "cleanup_temp_image=false" >> "$GITHUB_OUTPUT"
             echo "manual_base_image_tag=" >> "$GITHUB_OUTPUT"
             exit 0
@@ -266,7 +284,7 @@ jobs:
 
           SHORT_SHA="$(git rev-parse --short=12 HEAD)"
           MANUAL_BASE_IMAGE_TAG="atom_oot_manual_base:${GITHUB_RUN_ID}-${SHORT_SHA}"
-          OOT_IMAGE_TAG="${VALIDATION_IMAGE_REPO}:oot-full-manual-${GITHUB_RUN_ID}-${SHORT_SHA}"
+          OOT_IMAGE_TAG="${VALIDATION_IMAGE_REPO}:vllm-full-manual-${GITHUB_RUN_ID}-${SHORT_SHA}"
           BUILD_CONTEXT="$(mktemp -d)"
           trap 'rm -rf "${BUILD_CONTEXT}"' EXIT
 
@@ -511,6 +529,7 @@ jobs:
             -e OOT_MODEL_PATH="${OOT_RESOLVED_MODEL_PATH:-$OOT_MODEL_PATH}" \
             -e OOT_EXTRA_ARGS="${OOT_EXTRA_ARGS}" \
             -e OOT_ENV_VARS="${OOT_ENV_VARS}" \
+            -e OOT_DOCKER_IMAGE="${OOT_IMAGE_TAG}" \
             -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
             -e STREAM_VLLM_LOGS="${STREAM_VLLM_LOGS}" \
             "$CONTAINER_NAME" bash -lc "

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -258,7 +258,7 @@ jobs:
 
           if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
             if RESOLUTION_JSON="$(
-              python3 .github/scripts/resolve_atom_plugin_image.py \
+              python3 .github/scripts/resolve_atom_image.py \
                 --repository "${VALIDATION_IMAGE_REPO}" \
                 --reference-tag vllm-latest
             )"; then

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -155,7 +155,7 @@ jobs:
             USER_PROVIDED_OOT_IMAGE=true
           elif [[ "${NORMALIZED_REF}" == "main" ]]; then
             if RESOLUTION_JSON="$(
-              python3 .github/scripts/resolve_atom_plugin_image.py \
+              python3 .github/scripts/resolve_atom_image.py \
                 --repository rocm/atom-dev \
                 --reference-tag vllm-latest \
                 --preferred-version "${SELECTED_VLLM_VERSION}"

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -155,7 +155,7 @@ jobs:
             USER_PROVIDED_OOT_IMAGE=true
           elif [[ "${NORMALIZED_REF}" == "main" ]]; then
             if RESOLUTION_JSON="$(
-              python3 .github/scripts/resolve_vllm_atom_image.py \
+              python3 .github/scripts/resolve_atom_plugin_image.py \
                 --repository rocm/atom-dev \
                 --reference-tag vllm-latest \
                 --preferred-version "${SELECTED_VLLM_VERSION}"

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -109,190 +109,8 @@ jobs:
           path: aiter-whl/amd_aiter*.whl
           retention-days: 1
 
-  build_oot_image:
-    if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false }}
-    needs: [check-signal, download_aiter_wheel]
-    name: Reuse OOT CI image
-    runs-on: build-only-atom
-    env:
-      VLLM_COMMIT: 2a69949bdadf0e8942b7a1619b229cb475beef20
-      AITER_ARTIFACT_ID: ${{ needs.download_aiter_wheel.outputs.aiter_artifact_id }}
-    steps:
-      - name: Initialize OOT image tag
-        run: |
-          echo "OOT_IMAGE_TAG=rocm/atom-dev:oot-pre-build-${GITHUB_COMMIT_SHA}" >> "$GITHUB_ENV"
-
-      - name: Checkout ATOM repo
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        uses: actions/checkout@v6
-
-      - name: Docker Login
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-      - name: Check existing prebuilt OOT image
-        id: existing_oot_image
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        run: |
-          set -euo pipefail
-          echo "image_exists=false" >> "$GITHUB_OUTPUT"
-
-          if ! docker manifest inspect "${OOT_IMAGE_TAG}" >/dev/null 2>&1; then
-            echo "No existing OOT image found for ${OOT_IMAGE_TAG}; building a new one."
-            exit 0
-          fi
-
-          echo "Found existing OOT image for ${OOT_IMAGE_TAG}; validating vLLM commit label."
-          if ! docker pull "${OOT_IMAGE_TAG}"; then
-            echo "Failed to pull existing image ${OOT_IMAGE_TAG}; rebuilding it."
-            exit 0
-          fi
-
-          EXISTING_VLLM_COMMIT="$(docker inspect --format '{{ index .Config.Labels "com.rocm.atom.vllm_commit" }}' "${OOT_IMAGE_TAG}" 2>/dev/null || true)"
-          EXISTING_AITER_ARTIFACT_ID="$(docker inspect --format '{{ index .Config.Labels "com.rocm.atom.aiter_artifact_id" }}' "${OOT_IMAGE_TAG}" 2>/dev/null || true)"
-          if [ -n "${EXISTING_VLLM_COMMIT}" ] && [ "${EXISTING_VLLM_COMMIT}" = "${VLLM_COMMIT}" ] && [ -n "${EXISTING_AITER_ARTIFACT_ID}" ] && [ "${EXISTING_AITER_ARTIFACT_ID}" = "${AITER_ARTIFACT_ID}" ]; then
-            echo "image_exists=true" >> "$GITHUB_OUTPUT"
-            echo "Reusing existing OOT image for ${OOT_IMAGE_TAG} (vLLM commit ${EXISTING_VLLM_COMMIT}, aiter artifact ${EXISTING_AITER_ARTIFACT_ID})."
-          else
-            echo "Existing image label mismatch or missing."
-            echo "Expected vLLM commit ${VLLM_COMMIT}, got ${EXISTING_VLLM_COMMIT:-<missing>}."
-            echo "Expected aiter artifact ${AITER_ARTIFACT_ID}, got ${EXISTING_AITER_ARTIFACT_ID:-<missing>}."
-          fi
-
-      - name: Download aiter wheel
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_oot_image.outputs.image_exists != 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: aiter-whl
-          path: aiter-whl
-
-      - name: Generate OOT overlay Dockerfile
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_oot_image.outputs.image_exists != 'true' }}
-        run: |
-          cat <<'EOF' > Dockerfile.mod
-          ARG OOT_BASE_IMAGE
-          FROM ${OOT_BASE_IMAGE}
-          ARG GITHUB_REPO_URL
-          ARG GITHUB_COMMIT_SHA
-          ARG VLLM_COMMIT
-          ARG AITER_ARTIFACT_ID
-          ARG INSTALL_LM_EVAL=1
-          LABEL com.rocm.atom.vllm_commit="${VLLM_COMMIT}"
-          LABEL com.rocm.atom.aiter_artifact_id="${AITER_ARTIFACT_ID}"
-          COPY aiter-whl/ /tmp/aiter-whl/
-          RUN if [ "${INSTALL_LM_EVAL}" = "1" ]; then pip install -U "lm-eval[api]"; else echo "Skip lm-eval install"; fi
-          RUN pip show lm-eval || true
-          RUN pip install hf_transfer
-          RUN pip show hf_transfer || true
-          RUN pip install --upgrade "pybind11>=3.0.1"
-          RUN pip show pybind11
-          RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true && \
-              pip uninstall -y amd-aiter || true && \
-              rm -rf /app/aiter-test && \
-              AITER_WHL="$(ls -t /tmp/aiter-whl/amd_aiter*.whl 2>/dev/null | head -1)" && \
-              if [ -z "${AITER_WHL}" ]; then echo "ERROR: No amd_aiter wheel found under /tmp/aiter-whl"; ls -la /tmp/aiter-whl || true; exit 1; fi && \
-              pip install "${AITER_WHL}" && \
-              echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true && \
-              rm -rf /tmp/aiter-whl
-          RUN echo "=== ATOM version BEFORE uninstall ===" && pip show atom || true && \
-              pip uninstall -y atom || true && \
-              rm -rf /app/ATOM && \
-              git clone "${GITHUB_REPO_URL}" /app/ATOM && \
-              cd /app/ATOM && \
-              git checkout "${GITHUB_COMMIT_SHA}" && \
-              pip install -e . --no-deps && \
-              echo "=== ATOM version AFTER installation ===" && pip show atom || true
-          RUN pip show amd-aiter atom vllm torch triton mori || true
-          EOF
-
-      - name: Resolve OOT CI build mode
-        id: build_mode
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_oot_image.outputs.image_exists != 'true' }}
-        run: |
-          set -euo pipefail
-          echo "build_mode=full" >> "$GITHUB_OUTPUT"
-
-          if ! docker pull "${NIGHTLY_OOT_IMAGE_TAG}"; then
-            echo "Unable to pull ${NIGHTLY_OOT_IMAGE_TAG}; falling back to a full vLLM rebuild."
-            exit 0
-          fi
-
-          echo "Inspecting ${NIGHTLY_OOT_IMAGE_TAG} labels before deciding whether to reuse it."
-          docker inspect --format 'Image ID: {{.Id}}' "${NIGHTLY_OOT_IMAGE_TAG}" || true
-          docker inspect --format 'Image labels: {{json .Config.Labels}}' "${NIGHTLY_OOT_IMAGE_TAG}" || true
-          LATEST_VLLM_COMMIT="$(docker inspect --format '{{ index .Config.Labels "com.rocm.atom.vllm_commit" }}' "${NIGHTLY_OOT_IMAGE_TAG}" 2>/dev/null || true)"
-          echo "Expected vLLM commit label: ${VLLM_COMMIT}"
-          echo "Resolved ${NIGHTLY_OOT_IMAGE_TAG} label com.rocm.atom.vllm_commit: ${LATEST_VLLM_COMMIT:-<missing>}"
-          if [ -n "${LATEST_VLLM_COMMIT}" ] && [ "${LATEST_VLLM_COMMIT}" = "${VLLM_COMMIT}" ]; then
-            echo "build_mode=fast" >> "$GITHUB_OUTPUT"
-            echo "Reusing ${NIGHTLY_OOT_IMAGE_TAG} as the OOT CI base (vLLM commit ${LATEST_VLLM_COMMIT})."
-          else
-            echo "OOT CI latest image label mismatch or missing. Expected ${VLLM_COMMIT}, got ${LATEST_VLLM_COMMIT:-<missing>}; rebuilding vLLM."
-          fi
-
-      - name: Build OOT overlay image from reusable latest
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_oot_image.outputs.image_exists != 'true' && steps.build_mode.outputs.build_mode == 'fast' }}
-        run: |
-          DOCKER_BUILDKIT=1 docker build --network=host \
-            -t atom_oot:ci \
-            --build-arg OOT_BASE_IMAGE="${NIGHTLY_OOT_IMAGE_TAG}" \
-            --build-arg GITHUB_REPO_URL="${GITHUB_REPO_URL}" \
-            --build-arg GITHUB_COMMIT_SHA="${GITHUB_COMMIT_SHA}" \
-            --build-arg VLLM_COMMIT="${VLLM_COMMIT}" \
-            --build-arg AITER_ARTIFACT_ID="${AITER_ARTIFACT_ID}" \
-            --build-arg INSTALL_LM_EVAL=1 \
-            -f Dockerfile.mod .
-
-      - name: Build OOT overlay base image
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_oot_image.outputs.image_exists != 'true' && steps.build_mode.outputs.build_mode != 'fast' }}
-        run: |
-          DOCKER_BUILDKIT=1 docker build --pull --network=host \
-            --no-cache \
-            -t atom_oot_base:ci \
-            --build-arg OOT_BASE_IMAGE="${ATOM_BASE_NIGHTLY_IMAGE}" \
-            --build-arg GITHUB_REPO_URL="${GITHUB_REPO_URL}" \
-            --build-arg GITHUB_COMMIT_SHA="${GITHUB_COMMIT_SHA}" \
-            --build-arg VLLM_COMMIT="${VLLM_COMMIT}" \
-            --build-arg AITER_ARTIFACT_ID="${AITER_ARTIFACT_ID}" \
-            --build-arg INSTALL_LM_EVAL=1 \
-            -f Dockerfile.mod .
-
-      - name: Build OOT vLLM image
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_oot_image.outputs.image_exists != 'true' && steps.build_mode.outputs.build_mode != 'fast' }}
-        run: |
-          DOCKER_BUILDKIT=1 docker build --network=host \
-            --no-cache \
-            -t atom_oot:ci \
-            --target atom_oot \
-            --build-arg OOT_BASE_IMAGE="atom_oot_base:ci" \
-            --build-arg MAX_JOBS=64 \
-            --build-arg VLLM_COMMIT="${VLLM_COMMIT}" \
-            --build-arg INSTALL_LM_EVAL=1 \
-            --build-arg INSTALL_FASTSAFETENSORS=1 \
-            -f docker/Dockerfile .
-
-      - name: Push Docker image
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && steps.existing_oot_image.outputs.image_exists != 'true' }}
-        run: |
-          docker tag atom_oot:ci "${OOT_IMAGE_TAG}"
-          docker push "${OOT_IMAGE_TAG}"
-
-      - name: Skip remote build for fork PR
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
-        run: |
-          echo "Fork PRs build the OOT image locally on each test runner."
-
-      - name: Clean up build images
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && always() }}
-        run: |
-          rm -f Dockerfile.mod || true
-          docker rmi "atom_oot_base:ci" || true
-          docker rmi "atom_oot:ci" || true
-          docker rmi "${OOT_IMAGE_TAG}" || true
-
   atom-vllm-oot:
-    needs: [check-signal, download_aiter_wheel, build_oot_image]
+    needs: [check-signal, download_aiter_wheel]
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false }}
     name: Accuracy (${{ matrix.display_name }})
     strategy:
@@ -363,14 +181,12 @@ jobs:
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Download aiter wheel
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
         uses: actions/download-artifact@v4
         with:
           name: aiter-whl
           path: aiter-whl
 
-      - name: Generate OOT overlay Dockerfile for forked repo
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+      - name: Generate OOT overlay Dockerfile
         run: |
           cat <<'EOF' > Dockerfile.mod
           ARG OOT_BASE_IMAGE
@@ -408,8 +224,7 @@ jobs:
           RUN pip show amd-aiter atom vllm torch triton mori || true
           EOF
 
-      - name: Build OOT image for forked repo
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+      - name: Build OOT image locally
         run: |
           set -euo pipefail
           docker rmi "atom_oot_base:ci" || true
@@ -427,7 +242,7 @@ jobs:
             echo "Resolved ${NIGHTLY_OOT_IMAGE_TAG} label com.rocm.atom.vllm_commit: ${LATEST_VLLM_COMMIT:-<missing>}"
             if [ -n "${LATEST_VLLM_COMMIT}" ] && [ "${LATEST_VLLM_COMMIT}" = "${VLLM_COMMIT}" ]; then
               BUILD_MODE="fast"
-              echo "Reusing ${NIGHTLY_OOT_IMAGE_TAG} locally for fork PR OOT CI."
+              echo "Reusing ${NIGHTLY_OOT_IMAGE_TAG} locally for OOT CI."
             else
               echo "OOT CI latest image label mismatch or missing. Expected ${VLLM_COMMIT}, got ${LATEST_VLLM_COMMIT:-<missing>}; rebuilding vLLM locally."
             fi
@@ -469,19 +284,8 @@ jobs:
             -f docker/Dockerfile .
 
       - name: Set OOT image tag
-        env:
-          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
         run: |
-          if [ "${IS_FORK_PR}" = "true" ]; then
-            echo "OOT_IMAGE_TAG=atom_oot:ci" >> "$GITHUB_ENV"
-          else
-            echo "OOT_IMAGE_TAG=rocm/atom-dev:oot-pre-build-${GITHUB_COMMIT_SHA}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Pull OOT image
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-        run: |
-          docker pull "${OOT_IMAGE_TAG}"
+          echo "OOT_IMAGE_TAG=atom_oot:ci" >> "$GITHUB_ENV"
 
       - name: Prepare model cache mount
         run: |
@@ -682,25 +486,4 @@ jobs:
           rm -f Dockerfile.mod || true
           docker rmi "atom_oot_base:ci" || true
           docker rmi "atom_oot:ci" || true
-          KEEP_COUNT="${OOT_IMAGE_CACHE_KEEP:-3}"
-          if [[ "${OOT_IMAGE_TAG}" == rocm/atom-dev:oot-pre-build-* ]]; then
-            echo "Keeping current OOT image tag and the ${KEEP_COUNT} most recent oot-pre-build tags."
-            mapfile -t OLD_OOT_TAGS < <(
-              docker image ls --filter=reference='rocm/atom-dev:oot-pre-build-*' --format '{{.Repository}}:{{.Tag}}' \
-                | while read -r tag; do
-                    [ -n "${tag}" ] || continue
-                    created_at=$(docker image inspect --format '{{.Created}}' "${tag}" 2>/dev/null || true)
-                    [ -n "${created_at}" ] && printf '%s %s\n' "${created_at}" "${tag}"
-                  done \
-                | sort -r \
-                | awk -v keep="${KEEP_COUNT}" 'NR > keep { print $2 }'
-            )
-            for tag in "${OLD_OOT_TAGS[@]}"; do
-              if [ "${tag}" = "${OOT_IMAGE_TAG}" ]; then
-                continue
-              fi
-              echo "Removing old OOT image tag: ${tag}"
-              docker rmi "${tag}" || true
-            done
-          fi
 


### PR DESCRIPTION
1. remove the logic of using the dedicated machine building atom-vllm atom-sglang image. This PR uses the gpu machine to pull nightly image directly and begin test
2. add accuracy upload for atom-sglang nightly acc validation
3. add docker image name to dashboard accuracy chart
4. change model to ds mxfp4 mtp model for nightly