### PR TITLE
ci: fix benchmark workflow bugs and add GLM-5.1-MXFP4

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -50,6 +50,16 @@
     "env_vars": ""
   },
   {
+    "display": "GLM-5.1-MXFP4",
+    "path": "amd/GLM-5.1-MXFP4",
+    "prefix": "glm-5.1-fp4",
+    "args": "--kv_cache_dtype fp8 -tp 4",
+    "bench_args": "",
+    "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  },
+  {
     "display": "gpt-oss-120b",
     "path": "openai/gpt-oss-120b",
     "prefix": "gpt-oss-120b",

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -146,10 +146,10 @@
   {
     "model_name": "GLM-5-FP8",
     "model_path": "zai-org/GLM-5-FP8",
-    "extraArgs": "--kv_cache_dtype fp8 -tp 8",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 8 --default-chat-template-kwargs '{\"enable_thinking\":false}'",
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
-    "test_level": "pr",
+    "test_level": "nightly",
     "accuracy_threshold": 0.93,
     "accuracy_baseline": 0.9545,
     "accuracy_baseline_model": "zai-org/GLM-5",
@@ -158,7 +158,19 @@
   {
     "model_name": "GLM-5.1-FP8",
     "model_path": "zai-org/GLM-5.1-FP8",
-    "extraArgs": "--kv_cache_dtype fp8 -tp 8",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 8 --default-chat-template-kwargs '{\"enable_thinking\":false}'",
+    "env_vars": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "test_level": "pr",
+    "accuracy_threshold": 0.88,
+    "accuracy_baseline": 0.9545,
+    "accuracy_baseline_model": "zai-org/GLM-5.1",
+    "_baseline_note": "CI uses 3-shot, not comparable to HF 5-shot baseline"
+  },
+  {
+    "model_name": "GLM-5.1-MXFP4",
+    "model_path": "amd/GLM-5.1-MXFP4",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 4 --default-chat-template-kwargs '{\"enable_thinking\":false}'",
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "pr",

--- a/.github/benchmark/nightly_params.json
+++ b/.github/benchmark/nightly_params.json
@@ -2,13 +2,13 @@
   {
     "isl": 1024,
     "osl": 1024,
-    "concurrency": [1, 2, 4, 8, 16, 32, 64, 128, 256],
+    "concurrency": [4, 8, 16, 32, 64, 128, 256],
     "random_range_ratio": 0.8
   },
   {
     "isl": 8192,
     "osl": 1024,
-    "concurrency": [1, 2, 4, 8, 16, 32, 64, 128, 256],
+    "concurrency": [4, 8, 16, 32, 64, 128, 256],
     "random_range_ratio": 0.8
   }
 ]

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -125,7 +125,7 @@ jobs:
     name: ${{ matrix.model.display }} (isl=${{ matrix.config.input_length }} osl=${{ matrix.config.output_length }} c=${{ matrix.config.concurrency }})
     needs: [parse-param-lists, load-models]
     if: >-
-      always()
+      !cancelled()
       && needs.parse-param-lists.result == 'success'
       && needs.load-models.result == 'success'
     strategy:
@@ -512,7 +512,7 @@ jobs:
   # ---------- Regression re-run (GPU, matrix by model) ----------
   regression-rerun:
     if: >-
-      always()
+      !cancelled()
       && needs.generate-regression-matrix.outputs.has_matrix == 'true'
     name: Rerun ${{ matrix.cell.prefix }}
     needs: [generate-regression-matrix]
@@ -609,7 +609,7 @@ jobs:
             docker exec atom-regression bash -lc "mkdir -p /app/trace/$TRACE_SUBDIR"
 
             # Record profiler stop count before benchmark (to detect new completions)
-            STOP_COUNT_BEFORE=$(docker exec atom-regression grep -c "Profiler stopped." /tmp/atom_server.log 2>/dev/null || echo 0)
+            STOP_COUNT_BEFORE=$(docker exec atom-regression grep -c "Profiler stopped." /tmp/atom_server.log 2>/dev/null) || STOP_COUNT_BEFORE=0
 
             echo "=== Profiling: $PREFIX ISL=$ISL OSL=$OSL CONC=$CONC ==="
             if ! docker exec atom-regression bash -lc "
@@ -630,7 +630,7 @@ jobs:
             # Wait for engine core to finish exporting profiler trace (blocks inference)
             # See .claude/plan/profiler-async-refactor.md for long-term fix
             for i in $(seq 1 300); do
-              STOP_COUNT=$(docker exec atom-regression grep -c "Profiler stopped." /tmp/atom_server.log 2>/dev/null || echo 0)
+              STOP_COUNT=$(docker exec atom-regression grep -c "Profiler stopped." /tmp/atom_server.log 2>/dev/null) || STOP_COUNT=0
               [ "$STOP_COUNT" -gt "$STOP_COUNT_BEFORE" ] && echo "Profiler trace export done after ${i}s" && break
               [ "$i" -eq 1 ] && echo "Waiting for profiler trace export..."
               [ "$i" -eq 300 ] && echo "WARNING: Profiler did not finish after 300s, proceeding anyway"

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -463,6 +463,8 @@ jobs:
       
       - name: Run ATOM accuracy test
         timeout-minutes: 30
+        env:
+          MODEL_EXTRA_ARGS: ${{ matrix.extraArgs }}
         run: |
           set -euo pipefail
           echo ""
@@ -472,9 +474,10 @@ jobs:
           else
             model_path="${{ matrix.model_path }}"
           fi
-          docker exec "$CONTAINER_NAME" bash -lc "
-            .github/scripts/atom_test.sh launch $model_path ${{ matrix.extraArgs }}
-          "
+          # Pipe via stdin so container bash parses shell quoting in extraArgs
+          # (e.g. single-quoted JSON in --default-chat-template-kwargs) naturally.
+          echo ".github/scripts/atom_test.sh launch $model_path $MODEL_EXTRA_ARGS" | \
+            docker exec -i "$CONTAINER_NAME" bash -l
           echo ""
           echo "========== Running accuracy test =========="
           docker exec "$CONTAINER_NAME" bash -lc "

--- a/.github/workflows/gpu-load-test.yaml
+++ b/.github/workflows/gpu-load-test.yaml
@@ -158,7 +158,7 @@ jobs:
         run: |
           LOG_FILE="gpu_load_test.log"
           HOSTNAME=$(hostname)
-          LOAD_COUNT=$(grep -c "\[LOAD DONE\]" "$LOG_FILE" 2>/dev/null || echo 0)
+          LOAD_COUNT=$(grep -c "\[LOAD DONE\]" "$LOG_FILE" 2>/dev/null) || LOAD_COUNT=0
 
           # Start summary
           {

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -2,8 +2,11 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import argparse
+import logging
 from dataclasses import dataclass, fields
 from typing import List, Optional
+
+logger = logging.getLogger("atom")
 
 from atom import LLMEngine
 from atom.config import CompilationConfig, SpeculativeConfig
@@ -218,6 +221,8 @@ class EngineArgs:
             kwargs.pop("method")
             kwargs.pop("num_speculative_tokens")
             kwargs["speculative_config"] = None
+
+        logger.info(f"Engine kwargs: {kwargs}")
 
         return kwargs
 

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -6,10 +6,10 @@ import logging
 from dataclasses import dataclass, fields
 from typing import List, Optional
 
-logger = logging.getLogger("atom")
-
 from atom import LLMEngine
 from atom.config import CompilationConfig, SpeculativeConfig
+
+logger = logging.getLogger("atom")
 
 
 def parse_size_list(size_str: str) -> List[int]:


### PR DESCRIPTION
## Summary
- Fix `[: 00: integer expression expected` in regression profiler wait loop — `$(grep -c ... || echo 0)` double-captures stdout producing `00`
- Fix cancel workflow not working — replace job-level `always()` with `!cancelled()` on GPU-heavy jobs (`benchmark`, `regression-rerun`)
- Fix `extraArgs` quoting for `--default-chat-template-kwargs` — pipe via stdin to `docker exec -i bash -l` so single-quoted JSON is parsed correctly
- Fix `enable_thinking` using JSON string `"false"` (truthy in Jinja) instead of boolean `false`
- Add GLM-5.1-MXFP4 to benchmark and accuracy configs
- Drop concurrency 1,2 from nightly params to reduce CI time
- Add engine kwargs logging in `_get_engine_kwargs`

## Test plan
- [ ] Nightly benchmark run completes without `integer expression expected` errors
- [ ] Cancel workflow from GitHub UI actually stops GPU jobs
- [ ] GLM-5 / GLM-5.1 accuracy tests pass with `--default-chat-template-kwargs` (thinking disabled)
- [ ] GLM-5.1-MXFP4 benchmark runs successfully