### PR TITLE
ci: add MiniMax-M2.5-MXFP4 to nightly benchmark and accuracy test

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -90,6 +90,16 @@
     "env_vars": ""
   },
   {
+    "display": "MiniMax-M2.5-MXFP4",
+    "path": "amd/MiniMax-M2.5-MXFP4",
+    "prefix": "MiniMax-M2.5-MXFP4",
+    "args": "--kv_cache_dtype fp8 --trust-remote-code",
+    "bench_args": "",
+    "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  },
+  {
     "display": "Llama-3.3-70B-Instruct-MXFP4",
     "path": "amd/Llama-3.3-70B-Instruct-MXFP4-Preview",
     "prefix": "llama-3-3-70b-instruct-mxfp4",

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -190,5 +190,17 @@
     "accuracy_baseline": 0.9401,
     "accuracy_baseline_model": "MiniMaxAI/MiniMax-M2.5",
     "_baseline_note": "HF: amd/MiniMax-M2.5-MXFP4 card shows baseline=0.9401"
+  },
+  {
+    "model_name": "MiniMax-M2.5-MXFP4",
+    "model_path": "amd/MiniMax-M2.5-MXFP4",
+    "extraArgs": "--kv_cache_dtype fp8 --trust-remote-code",
+    "env_vars": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.91,
+    "accuracy_baseline": 0.9401,
+    "accuracy_baseline_model": "MiniMaxAI/MiniMax-M2.5",
+    "_baseline_note": "HF: amd/MiniMax-M2.5-MXFP4 card shows MXFP4=0.9256, baseline=0.9401"
   }
 ]


### PR DESCRIPTION
## Summary
- Add `amd/MiniMax-M2.5-MXFP4` to nightly benchmark (`models.json`) and accuracy test (`models_accuracy.json`)
- tp=1, `--trust-remote-code`
- Accuracy threshold=0.91 (HF card: MXFP4=0.9256, BF16 baseline=0.9401, recovery=98.46%)

## Test plan
- [ ] Nightly benchmark picks up MiniMax-M2.5-MXFP4 and runs successfully
- [ ] Nightly accuracy test passes with threshold 0.91