### PR TITLE
fix: disable gradient tracking on all nn.Parameter for inference

### DIFF
--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -2,17 +2,19 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 import triton
 import triton.language as tl
 from aiter.dist.communication_op import tensor_model_parallel_all_gather
 from aiter.dist.parallel_state import get_tp_group
 from aiter.jit.utils.torch_guard import torch_compile_guard
-from aiter.tuned_gemm import tgemm
+
+from atom.model_ops.utils import atom_parameter
 from atom.plugin import is_plugin_mode
 from atom.utils import envs
 from atom.utils.forward_context import ForwardContext, get_forward_context
-from torch import nn
+from aiter.tuned_gemm import tgemm
 
 
 @triton.jit
@@ -115,8 +117,8 @@ class VocabParallelEmbedding(nn.Module):
         self.num_embeddings_per_partition = self.num_embeddings // self.tp_size
         self.vocab_start_idx = self.num_embeddings_per_partition * self.tp_rank
         self.vocab_end_idx = self.vocab_start_idx + self.num_embeddings_per_partition
-        self.weight = nn.Parameter(
-            torch.empty(self.num_embeddings_per_partition, embedding_dim)
+        self.weight = atom_parameter(
+            torch.empty(self.num_embeddings_per_partition, embedding_dim),
         )
         self.weight.weight_loader = self.weight_loader
 
@@ -160,7 +162,9 @@ class ParallelLMHead(VocabParallelEmbedding):
     ):
         super().__init__(num_embeddings, embedding_dim)
         if bias:
-            self.bias = nn.Parameter(torch.empty(self.num_embeddings_per_partition))
+            self.bias = atom_parameter(
+                torch.empty(self.num_embeddings_per_partition),
+            )
             self.bias.weight_loader = self.weight_loader
         else:
             self.register_parameter("bias", None)

--- a/atom/model_ops/fla_ops/layernorm_guard.py
+++ b/atom/model_ops/fla_ops/layernorm_guard.py
@@ -23,6 +23,9 @@ from einops import rearrange
 import triton
 import triton.language as tl
 
+
+from atom.model_ops.utils import atom_parameter
+
 from .utils import input_guard
 
 
@@ -347,8 +350,8 @@ class LayerNormGated(nn.Module):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
         self.eps = eps
-        self.weight = nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
-        self.bias = nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
+        self.weight = atom_parameter(torch.empty(hidden_size, **factory_kwargs))
+        self.bias = atom_parameter(torch.empty(hidden_size, **factory_kwargs))
         self.group_size = group_size
         self.norm_before_gate = norm_before_gate
         self.reset_parameters()
@@ -386,7 +389,7 @@ class RMSNormGated(nn.Module):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
         self.eps = eps
-        self.weight = nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
+        self.weight = atom_parameter(torch.empty(hidden_size, **factory_kwargs))
         self.register_parameter("bias", None)
         self.group_size = group_size
         self.norm_before_gate = norm_before_gate

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -4,11 +4,13 @@
 from typing import Tuple, Optional
 import torch
 from torch import Tensor
+
 from torch.overrides import (
     has_torch_function_unary,
     handle_torch_function,
 )
 from atom.config import QuantizationConfig
+from atom.model_ops.utils import atom_parameter
 from atom.quant_spec import LayerQuantConfig
 from atom.utils.decorators import mark_trace
 from torch import nn
@@ -186,7 +188,7 @@ class RMSNorm(nn.Module):
         super().__init__()
         self.dim = dim
         self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim))
+        self.weight = atom_parameter(torch.ones(dim))
         self.x_pad_to_multiple = x_pad_to_multiple
         self.fused_allreduce = fused_allreduce
         self.use_fused_quant = fused_quant
@@ -331,7 +333,7 @@ class RMSNormGated(nn.Module):
         """
         super().__init__()
         self.eps = eps
-        self.weight = nn.Parameter(torch.empty(hidden_size))
+        self.weight = atom_parameter(torch.empty(hidden_size))
         self.register_parameter("bias", None)
         self.group_size = group_size
         self.norm_before_gate = norm_before_gate
@@ -503,7 +505,7 @@ class GemmaRMSNorm(nn.Module):
         eps: float = 1e-6,
     ) -> None:
         super().__init__()
-        self.weight = nn.Parameter(torch.zeros(hidden_size))
+        self.weight = atom_parameter(torch.zeros(hidden_size))
         self.variance_epsilon = eps
 
     @staticmethod
@@ -596,8 +598,8 @@ class LayerNorm(nn.Module):
         super().__init__()
         self.dim = dim
         self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim))
-        self.bias = nn.Parameter(torch.zeros(dim))
+        self.weight = atom_parameter(torch.ones(dim))
+        self.bias = atom_parameter(torch.zeros(dim))
 
     def forward(
         self,

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -24,6 +24,7 @@ from aiter.utility import fp4_utils
 from atom.config import QuantizationConfig, get_current_atom_config
 from atom.quant_spec import LayerQuantConfig
 from atom.model_ops.utils import (
+    atom_parameter,
     normalize_e4m3fn_to_e4m3fnuz,
     requantize_with_max_scale,
     shuffle_weights,
@@ -245,9 +246,8 @@ class LinearBase(nn.Module):
 
         if self.source_quant_dtype is not None:
             weight_size = (self.output_size, self.input_size)
-            self.weight = nn.Parameter(
-                torch.empty(weight_size, dtype=self.source_quant_dtype),
-                requires_grad=False,
+            self.weight = atom_parameter(
+                torch.empty(weight_size, dtype=self.source_quant_dtype)
             )
         else:
             weight_size = (
@@ -255,15 +255,10 @@ class LinearBase(nn.Module):
                 if params_dtype not in [dtypes.fp4x2, dtypes.i4x2]
                 else (self.output_size, self.input_size // 2)
             )
-            self.weight = nn.Parameter(
-                torch.empty(weight_size, dtype=params_dtype),
-                requires_grad=False,
-            )
+            self.weight = atom_parameter(torch.empty(weight_size, dtype=params_dtype))
         if bias:
             output_type = get_current_atom_config().torch_dtype
-            self.bias = nn.Parameter(
-                torch.empty(self.output_size, dtype=output_type), requires_grad=False
-            )
+            self.bias = atom_parameter(torch.empty(self.output_size, dtype=output_type))
             self.bias.weight_loader_process = self.weight_loader_process
         else:
             self.register_parameter("bias", None)
@@ -272,41 +267,36 @@ class LinearBase(nn.Module):
 
         if quant_type != QuantType.No and self.source_quant_dtype is None:
             if quant_type == QuantType.per_Tensor:
-                self.weight_scale = nn.Parameter(
-                    torch.empty(len(self.output_partition_sizes), 1, dtype=dtypes.fp32),
-                    requires_grad=False,
+                self.weight_scale = atom_parameter(
+                    torch.empty(len(self.output_partition_sizes), 1, dtype=dtypes.fp32)
                 )
                 if not layer_quant_config.is_dynamic:
-                    self.input_scale = nn.Parameter(
+                    self.input_scale = atom_parameter(
                         torch.empty(
                             len(self.output_partition_sizes), 1, dtype=dtypes.fp32
-                        ),
-                        requires_grad=False,
+                        )
                     )
                     self.input_scale.weight_loader_process = self.weight_loader_process
                     self.input_scale.weight_loader = self.weight_loader
             elif quant_type == QuantType.per_Token:
-                self.weight_scale = nn.Parameter(
-                    torch.empty(self.output_size, 1, dtype=dtypes.fp32),
-                    requires_grad=False,
+                self.weight_scale = atom_parameter(
+                    torch.empty(self.output_size, 1, dtype=dtypes.fp32)
                 )
             elif quant_type == QuantType.per_1x128:
-                self.weight_scale = nn.Parameter(
+                self.weight_scale = atom_parameter(
                     torch.empty(
                         (self.output_size + 127) // 128,
                         (self.input_size + 127) // 128,
                         dtype=dtypes.fp32,
-                    ),
-                    requires_grad=False,
+                    )
                 )
             elif quant_type == QuantType.per_1x32:
-                self.weight_scale = nn.Parameter(
+                self.weight_scale = atom_parameter(
                     torch.empty(
                         self.output_size,
                         (self.input_size + 31) // 32,
                         dtype=dtypes.fp8_e8m0,
-                    ),
-                    requires_grad=False,
+                    )
                 )
             self.weight.weight_loader_process = self.weight_loader_process
             self.weight_scale.weight_loader_process = self.weight_loader_process
@@ -381,7 +371,7 @@ class LinearBase(nn.Module):
                 shuffle=False,
             )
             self.weight.data = w_q
-            self.weight_scale = torch.nn.Parameter(w_s, requires_grad=False)
+            self.weight_scale = atom_parameter(w_s)
             shuffle_weights(self.weight)
             # self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         else:

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -43,6 +43,7 @@ from atom.model_ops.topK import rocm_aiter_grouped_topk as grouped_topk
 from atom.model_ops.topK import rocm_aiter_topk_softmax as fused_topk
 from atom.model_ops.utils import (
     _has_module,
+    atom_parameter,
     normalize_e4m3fn_to_e4m3fnuz,
     per_tensor_dequantize,
     shuffle_weights,
@@ -405,27 +406,25 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
         **extra_weight_attrs,
     ):
         # Fused gate_up_proj (column parallel)
-        w13_weight = torch.nn.Parameter(
+        w13_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 2 * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w13_weight", w13_weight)
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         # down_proj (row parallel)
-        w2_weight = torch.nn.Parameter(
+        w2_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,
                 dtype=params_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w2_weight", w2_weight)
         set_weight_attrs(w2_weight, extra_weight_attrs)
@@ -436,12 +435,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)
 
-        layer.w13_weight = torch.nn.Parameter(
-            self._maybe_pad_weight(layer.w13_weight.data), requires_grad=False
-        )
-        layer.w2_weight = torch.nn.Parameter(
-            self._maybe_pad_weight(layer.w2_weight.data), requires_grad=False
-        )
+        layer.w13_weight = atom_parameter(self._maybe_pad_weight(layer.w13_weight.data))
+        layer.w2_weight = atom_parameter(self._maybe_pad_weight(layer.w2_weight.data))
         # reshaping weights is required for aiter moe kernel.
         shuffle_weights(layer.w13_weight, layer.w2_weight)
 
@@ -679,14 +674,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.intermediate_size - layer.intermediate_size_per_partition
         )
         # Fused gate_up_proj (column parallel)
-        w13_weight = torch.nn.Parameter(
+        w13_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 2 * intermediate_size_per_partition_after_pad,
                 hidden_size // 2,
                 dtype=weight_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w13_weight", w13_weight)
         # Zero-fill padding region: FP4 dtype doesn't support torch.zeros,
@@ -694,26 +688,24 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w13_weight.data.view(torch.uint8).zero_()
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
-        w13_weight_scale = torch.nn.Parameter(
+        w13_weight_scale = atom_parameter(
             torch.zeros(
                 num_experts,
                 2 * intermediate_size_per_partition_after_pad,
                 hidden_size // mxfp4_block,
                 dtype=scale_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w13_weight_scale", w13_weight_scale)
         set_weight_attrs(w13_weight_scale, extra_weight_attrs)
 
         if layer.has_bias:
-            w13_bias = torch.nn.Parameter(
+            w13_bias = atom_parameter(
                 torch.empty(
                     num_experts,
                     2 * intermediate_size_per_partition_after_pad,
                     dtype=torch.bfloat16,
-                ),
-                requires_grad=False,
+                )
             )
             layer.register_parameter("w13_bias", w13_bias)
             set_weight_attrs(w13_bias, extra_weight_attrs)
@@ -721,39 +713,36 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.register_parameter("w13_bias", None)
 
         # down_proj (row parallel)
-        w2_weight = torch.nn.Parameter(
+        w2_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition_after_pad // 2,
                 dtype=weight_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w2_weight", w2_weight)
         w2_weight.data.view(torch.uint8).zero_()
         set_weight_attrs(w2_weight, extra_weight_attrs)
 
-        w2_weight_scale = torch.nn.Parameter(
+        w2_weight_scale = atom_parameter(
             torch.zeros(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition_after_pad // mxfp4_block,
                 dtype=scale_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w2_weight_scale", w2_weight_scale)
         set_weight_attrs(w2_weight_scale, extra_weight_attrs)
 
         if layer.has_bias:
-            w2_bias = torch.nn.Parameter(
+            w2_bias = atom_parameter(
                 torch.empty(
                     num_experts,
                     hidden_size,
                     dtype=torch.bfloat16,
-                ),
-                requires_grad=False,
+                )
             )
             layer.register_parameter("w2_bias", w2_bias)
             set_weight_attrs(w2_bias, extra_weight_attrs)
@@ -761,16 +750,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.register_parameter("w2_bias", None)
 
         if self.static_input_scales:
-            w13_input_scale = torch.nn.Parameter(
-                torch.ones(num_experts, dtype=torch.float32),
-                requires_grad=False,
+            w13_input_scale = atom_parameter(
+                torch.ones(num_experts, dtype=torch.float32)
             )
             layer.register_parameter("w13_input_scale", w13_input_scale)
             set_weight_attrs(w13_input_scale, extra_weight_attrs)
 
-            w2_input_scale = torch.nn.Parameter(
-                torch.ones(num_experts, dtype=torch.float32),
-                requires_grad=False,
+            w2_input_scale = atom_parameter(
+                torch.ones(num_experts, dtype=torch.float32)
             )
             layer.register_parameter("w2_input_scale", w2_input_scale)
             set_weight_attrs(w2_input_scale, extra_weight_attrs)
@@ -868,12 +855,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 layer.w2_weight_scale.view(self.num_experts, -1)
             )
 
-        layer.w13_weight_scale = torch.nn.Parameter(
-            shuffled_w13_scale, requires_grad=False
-        )
-        layer.w2_weight_scale = torch.nn.Parameter(
-            shuffled_w2_scale, requires_grad=False
-        )
+        layer.w13_weight_scale = atom_parameter(shuffled_w13_scale)
+        layer.w2_weight_scale = atom_parameter(shuffled_w2_scale)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
@@ -1119,26 +1102,24 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
                 )
 
         # WEIGHTS
-        w13_weight = torch.nn.Parameter(
+        w13_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 2 * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w13_weight", w13_weight)
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
-        w2_weight = torch.nn.Parameter(
+        w2_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,
                 dtype=params_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w2_weight", w2_weight)
         set_weight_attrs(w2_weight, extra_weight_attrs)
@@ -1147,25 +1128,23 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
         if self.per_channel:
             # Per-channel quantization: shape [E, N, 1]
             # This is the key difference for compressed-tensors
-            w13_weight_scale = torch.nn.Parameter(
+            w13_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
                     2 * intermediate_size_per_partition,
                     1,  # Important: dimension is 1, not omitted
                     dtype=torch.float32,
-                ),
-                requires_grad=False,
+                )
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
 
-            w2_weight_scale = torch.nn.Parameter(
+            w2_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
                     hidden_size,
                     1,  # Important: dimension is 1, not omitted
                     dtype=torch.float32,
-                ),
-                requires_grad=False,
+                )
             )
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
 
@@ -1178,7 +1157,7 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
 
         elif self.block_quant:
             # Block quantization
-            w13_weight_scale = torch.nn.Parameter(
+            w13_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
                     2
@@ -1188,20 +1167,18 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
                     ),
                     (hidden_size + self.block_k - 1) // self.block_k,
                     dtype=torch.float32,
-                ),
-                requires_grad=False,
+                )
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
 
-            w2_weight_scale = torch.nn.Parameter(
+            w2_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
                     (hidden_size + self.block_n - 1) // self.block_n,
                     (intermediate_size_per_partition + self.block_k - 1)
                     // self.block_k,
                     dtype=torch.float32,
-                ),
-                requires_grad=False,
+                )
             )
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
 
@@ -1213,15 +1190,13 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
 
         else:
             # Per-tensor quantization: shape [E, 2] for w13, [E] for w2
-            w13_weight_scale = torch.nn.Parameter(
-                torch.ones(num_experts, 2, dtype=torch.float32),
-                requires_grad=False,
+            w13_weight_scale = atom_parameter(
+                torch.ones(num_experts, 2, dtype=torch.float32)
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
 
-            w2_weight_scale = torch.nn.Parameter(
-                torch.ones(num_experts, dtype=torch.float32),
-                requires_grad=False,
+            w2_weight_scale = atom_parameter(
+                torch.ones(num_experts, dtype=torch.float32)
             )
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
 
@@ -1233,16 +1208,14 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
 
         # INPUT_SCALES (activation scales)
         if self.static_input_scales:
-            w13_input_scale = torch.nn.Parameter(
-                torch.ones(num_experts, dtype=torch.float32),
-                requires_grad=False,
+            w13_input_scale = atom_parameter(
+                torch.ones(num_experts, dtype=torch.float32)
             )
             layer.register_parameter("w13_input_scale", w13_input_scale)
             set_weight_attrs(w13_input_scale, extra_weight_attrs)
 
-            w2_input_scale = torch.nn.Parameter(
-                torch.ones(num_experts, dtype=torch.float32),
-                requires_grad=False,
+            w2_input_scale = atom_parameter(
+                torch.ones(num_experts, dtype=torch.float32)
             )
             layer.register_parameter("w2_input_scale", w2_input_scale)
             set_weight_attrs(w2_input_scale, extra_weight_attrs)
@@ -1321,9 +1294,7 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
                     w13.data[expert_id, shard_size:, :] = w3_q.to(w13.dtype)
 
             # Update scale to single max scale per expert [E]
-            layer.w13_weight_scale = torch.nn.Parameter(
-                max_w13_scales, requires_grad=False
-            )
+            layer.w13_weight_scale = atom_parameter(max_w13_scales)
 
         # Shuffle weights for asm moe (moved from inference to load time for better performance)
         if w13.dtype in [
@@ -1516,26 +1487,24 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 )
 
         # WEIGHTS
-        w13_weight = torch.nn.Parameter(
+        w13_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 2 * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w13_weight", w13_weight)
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
-        w2_weight = torch.nn.Parameter(
+        w2_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,
                 dtype=params_dtype,
-            ),
-            requires_grad=False,
+            )
         )
         layer.register_parameter("w2_weight", w2_weight)
         set_weight_attrs(w2_weight, extra_weight_attrs)
@@ -1544,49 +1513,45 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if self.channel_quant:
             # Per-channel (PTPTC): one scale per output channel per expert.
             # w13: [E, 2*N], w2: [E, hidden_size]
-            w13_weight_scale = torch.nn.Parameter(
+            w13_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
                     2 * intermediate_size_per_partition,
                     dtype=torch.float32,
-                ),
-                requires_grad=False,
+                )
             )
-            w2_weight_scale = torch.nn.Parameter(
-                torch.ones(num_experts, hidden_size, dtype=torch.float32),
-                requires_grad=False,
+            w2_weight_scale = atom_parameter(
+                torch.ones(num_experts, hidden_size, dtype=torch.float32)
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
         elif self.block_quant:
-            w13_weight_scale = torch.nn.Parameter(
+            w13_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
                     2 * ((intermediate_size_per_partition + block_n - 1) // block_n),
                     (hidden_size + block_k - 1) // block_k,
                     dtype=torch.float32,
-                ),
-                requires_grad=False,
+                )
             )
-            w2_weight_scale = torch.nn.Parameter(
+            w2_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
                     (hidden_size + block_n - 1) // block_n,
                     (intermediate_size_per_partition + block_k - 1) // block_k,
                     dtype=torch.float32,
-                ),
-                requires_grad=False,
+                )
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
             assert self.quant_config.is_dynamic
         else:
             # Per-tensor
-            w13_weight_scale = torch.nn.Parameter(
-                torch.ones(num_experts, 2, dtype=torch.float32), requires_grad=False
+            w13_weight_scale = atom_parameter(
+                torch.ones(num_experts, 2, dtype=torch.float32)
             )
-            w2_weight_scale = torch.nn.Parameter(
-                torch.ones(num_experts, dtype=torch.float32), requires_grad=False
+            w2_weight_scale = atom_parameter(
+                torch.ones(num_experts, dtype=torch.float32)
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
@@ -1600,13 +1565,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w13_input_scale = None
             layer.w2_input_scale = None
         else:
-            w13_input_scale = torch.nn.Parameter(
-                torch.ones(num_experts, dtype=torch.float32), requires_grad=False
+            w13_input_scale = atom_parameter(
+                torch.ones(num_experts, dtype=torch.float32)
             )
             layer.register_parameter("w13_input_scale", w13_input_scale)
             set_weight_attrs(w13_input_scale, extra_weight_attrs)
-            w2_input_scale = torch.nn.Parameter(
-                torch.ones(num_experts, dtype=torch.float32), requires_grad=False
+            w2_input_scale = atom_parameter(
+                torch.ones(num_experts, dtype=torch.float32)
             )
             layer.register_parameter("w2_input_scale", w2_input_scale)
             set_weight_attrs(w2_input_scale, extra_weight_attrs)
@@ -1620,14 +1585,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         w2_weight, w2_weight_scale, w2_input_scale = normalize_e4m3fn_to_e4m3fnuz(
             layer.w2_weight, layer.w2_weight_scale, layer.w2_input_scale
         )
-        layer.w13_weight = nn.Parameter(w13_weight, requires_grad=False)
-        layer.w13_weight_scale = nn.Parameter(w13_weight_scale, requires_grad=False)
-        layer.w2_weight = nn.Parameter(w2_weight, requires_grad=False)
-        layer.w2_weight_scale = nn.Parameter(w2_weight_scale, requires_grad=False)
+        layer.w13_weight = atom_parameter(w13_weight)
+        layer.w13_weight_scale = atom_parameter(w13_weight_scale)
+        layer.w2_weight = atom_parameter(w2_weight)
+        layer.w2_weight_scale = atom_parameter(w2_weight_scale)
         if w13_input_scale is not None:
-            layer.w13_input_scale = nn.Parameter(w13_input_scale, requires_grad=False)
+            layer.w13_input_scale = atom_parameter(w13_input_scale)
         if w2_input_scale is not None:
-            layer.w2_input_scale = nn.Parameter(w2_input_scale, requires_grad=False)
+            layer.w2_input_scale = atom_parameter(w2_input_scale)
 
     def process_weights_after_loading(self, layer: nn.Module) -> None:
         if self.block_quant:
@@ -1642,14 +1607,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self._normalize_weights_and_scales(layer)
 
         if not self.need_normalize_e4m3fn_to_e4m3fnuz:
-            layer.w13_weight = nn.Parameter(layer.w13_weight.data, requires_grad=False)
-            layer.w13_weight_scale = nn.Parameter(
-                layer.w13_weight_scale.data, requires_grad=False
-            )
-            layer.w2_weight = nn.Parameter(layer.w2_weight.data, requires_grad=False)
-            layer.w2_weight_scale = nn.Parameter(
-                layer.w2_weight_scale.data, requires_grad=False
-            )
+            layer.w13_weight = atom_parameter(layer.w13_weight.data)
+            layer.w13_weight_scale = atom_parameter(layer.w13_weight_scale.data)
+            layer.w2_weight = atom_parameter(layer.w2_weight.data)
+            layer.w2_weight_scale = atom_parameter(layer.w2_weight_scale.data)
 
         shuffle_weights(layer.w13_weight, layer.w2_weight)
 
@@ -1681,12 +1642,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     "QuantConfig has static quantization, but found "
                     "activation scales are None."
                 )
-            layer.w13_input_scale = torch.nn.Parameter(
-                layer.w13_input_scale.max(), requires_grad=False
-            )
-            layer.w2_input_scale = torch.nn.Parameter(
-                layer.w2_input_scale.max(), requires_grad=False
-            )
+            layer.w13_input_scale = atom_parameter(layer.w13_input_scale.max())
+            layer.w2_input_scale = atom_parameter(layer.w2_input_scale.max())
 
         self._normalize_weights_and_scales(layer)
 
@@ -1708,7 +1665,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         shuffle_weights(layer.w13_weight, layer.w2_weight)
 
-        layer.w13_weight_scale = torch.nn.Parameter(max_w13_scales, requires_grad=False)
+        layer.w13_weight_scale = atom_parameter(max_w13_scales)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/atom/model_ops/utils.py
+++ b/atom/model_ops/utils.py
@@ -26,7 +26,10 @@ def atom_parameter(data: torch.Tensor) -> nn.Parameter:
     inference vs. training gradient behaviour is controlled from a single
     place.
     """
-    return nn.Parameter(data, requires_grad=envs.ATOM_REQUIRES_GRAD)
+    requires_grad = envs.ATOM_REQUIRES_GRAD and (
+        data.is_floating_point() or data.is_complex()
+    )
+    return nn.Parameter(data, requires_grad=requires_grad)
 
 
 @cache

--- a/atom/model_ops/utils.py
+++ b/atom/model_ops/utils.py
@@ -13,7 +13,20 @@ from aiter.ops.triton.quant import dynamic_mxfp4_quant
 from aiter.utility.fp4_utils import e8m0_to_f32, mxfp4_to_f32
 from torch import nn
 
+from atom.utils import envs
+
 logger = logging.getLogger("atom")
+
+
+def atom_parameter(data: torch.Tensor) -> nn.Parameter:
+    """Create an ``nn.Parameter`` with gradient tracking controlled by
+    the ``ATOM_REQUIRES_GRAD`` environment variable (default: disabled).
+
+    Use this instead of ``nn.Parameter(...)`` everywhere in ATOM so that
+    inference vs. training gradient behaviour is controlled from a single
+    place.
+    """
+    return nn.Parameter(data, requires_grad=envs.ATOM_REQUIRES_GRAD)
 
 
 @cache

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -65,7 +65,7 @@ from atom.model_ops.linear import (
 )
 from atom.model_ops.moe import FusedMoE
 from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
-from atom.model_ops.utils import MXFP4_QUANT_BLOCK_SIZE
+from atom.model_ops.utils import MXFP4_QUANT_BLOCK_SIZE, atom_parameter
 from atom.models.utils import (
     IntermediateTensors,
     PPMissingLayer,
@@ -836,7 +836,7 @@ class DeepseekV2MoE(nn.Module):
             prefix=f"{prefix}.gate",
         )
         if config.topk_method == "noaux_tc":
-            self.gate.e_score_correction_bias = nn.Parameter(
+            self.gate.e_score_correction_bias = atom_parameter(
                 torch.empty(config.n_routed_experts)
             )
         else:

--- a/atom/models/glm4_moe.py
+++ b/atom/models/glm4_moe.py
@@ -17,6 +17,7 @@ from atom.model_ops.linear import (
     RowParallelLinear,
 )
 from atom.model_ops.moe import FusedMoE
+from atom.model_ops.utils import atom_parameter
 from atom.model_ops.topK import (
     is_rocm_aiter_fuse_routed_scaling_factor,
     is_rocm_aiter_fusion_shared_expert_enabled,
@@ -106,7 +107,7 @@ class Glm4MoE(nn.Module):
             bias=False,
             dtype=torch.float32,
         )
-        self.gate.e_score_correction_bias = nn.Parameter(
+        self.gate.e_score_correction_bias = atom_parameter(
             torch.empty(config.n_routed_experts, dtype=torch.float32)
         )
 

--- a/atom/models/gpt_oss.py
+++ b/atom/models/gpt_oss.py
@@ -39,6 +39,7 @@ from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.layernorm import RMSNorm
 from atom.model_ops.linear import QKVParallelLinear, ReplicatedLinear, RowParallelLinear
 from atom.model_ops.moe import FusedMoE
+from atom.model_ops.utils import atom_parameter
 
 from atom.utils import envs
 
@@ -91,9 +92,7 @@ class OAIAttention(nn.Module):
 
         tp_size = get_tensor_model_parallel_world_size()
 
-        self.sinks = torch.nn.Parameter(
-            torch.empty(config.num_attention_heads // tp_size, requires_grad=False)
-        )
+        self.sinks = atom_parameter(torch.empty(config.num_attention_heads // tp_size))
 
         self.q_size = self.num_attention_heads * self.head_dim // tp_size
         self.kv_size = self.num_key_value_heads * self.head_dim // tp_size

--- a/atom/models/minimax_m2.py
+++ b/atom/models/minimax_m2.py
@@ -14,6 +14,7 @@ from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.layernorm import RMSNorm
 from atom.model_ops.linear import QKVParallelLinear, ReplicatedLinear, RowParallelLinear
 from atom.model_ops.moe import FusedMoE
+from atom.model_ops.utils import atom_parameter
 from atom.models.utils import (
     IntermediateTensors,
     PPMissingLayer,
@@ -47,7 +48,7 @@ class MiniMaxM2SparseMoeBlock(nn.Module):
             )
 
         if getattr(config, "use_routing_bias", False):
-            self.e_score_correction_bias = nn.Parameter(
+            self.e_score_correction_bias = atom_parameter(
                 torch.zeros(self.num_experts, dtype=torch.float32)
             )
         else:
@@ -80,9 +81,7 @@ class MiniMaxM2SparseMoeBlock(nn.Module):
         )
         # Match vLLM: gate weights in fp32 for routing precision
         old_wlp = self.gate.weight.weight_loader_process
-        self.gate.weight = nn.Parameter(
-            self.gate.weight.data.to(torch.float32), requires_grad=False
-        )
+        self.gate.weight = atom_parameter(self.gate.weight.data.to(torch.float32))
         self.gate.weight.weight_loader_process = old_wlp
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/atom/models/qwen3_5.py
+++ b/atom/models/qwen3_5.py
@@ -7,6 +7,7 @@ from torch import nn
 from atom.config import QuantizationConfig, Config
 
 from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
+from atom.model_ops.utils import atom_parameter
 from atom.utils.decorators import support_torch_compile
 
 from atom.model_ops.embed_head import VocabParallelEmbedding, ParallelLMHead
@@ -352,19 +353,19 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
 
         self.layer_scale = getattr(config, "layer_scale", False)
         if self.layer_scale:
-            self.attn_layer_scale = torch.nn.Parameter(
+            self.attn_layer_scale = atom_parameter(
                 torch.zeros(
                     1,
                     1,
                     config.hidden_size,
-                ),
+                )
             )
-            self.ffn_layer_scale = torch.nn.Parameter(
+            self.ffn_layer_scale = atom_parameter(
                 torch.zeros(
                     1,
                     1,
                     config.hidden_size,
-                ),
+                )
             )
 
 

--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -37,6 +37,7 @@ from atom.utils.decorators import support_torch_compile
 from aiter.rotary_embedding import get_rope
 from atom.model_ops.embed_head import VocabParallelEmbedding, ParallelLMHead
 from atom.model_ops.moe import FusedMoE
+from atom.model_ops.utils import atom_parameter
 from aiter.dist.parallel_state import (
     get_pp_group,
     get_tensor_model_parallel_world_size,
@@ -513,10 +514,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
 
         # time step projection (discretization)
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
-        self.dt_bias = nn.Parameter(
-            torch.ones(self.num_v_heads // self.tp_size),
-        )
-        self.A_log = nn.Parameter(
+        self.dt_bias = atom_parameter(torch.ones(self.num_v_heads // self.tp_size))
+        self.A_log = atom_parameter(
             torch.empty(
                 (self.num_v_heads // self.tp_size),
             )
@@ -876,21 +875,21 @@ class Qwen3NextDecoderLayer(nn.Module):
 
         self.layer_scale = getattr(config, "layer_scale", False)
         if self.layer_scale:
-            self.attn_layer_scale = torch.nn.Parameter(
+            self.attn_layer_scale = atom_parameter(
                 torch.zeros(
                     1,
                     1,
                     config.hidden_size,
                     dtype=config.dtype,
-                ),
+                )
             )
-            self.ffn_layer_scale = torch.nn.Parameter(
+            self.ffn_layer_scale = atom_parameter(
                 torch.zeros(
                     1,
                     1,
                     config.hidden_size,
                     dtype=config.dtype,
-                ),
+                )
             )
 
     def forward(

--- a/atom/plugin/sglang/attention_backend/radix_attention.py
+++ b/atom/plugin/sglang/attention_backend/radix_attention.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 from atom.model_ops.attention_mla import MLAModules
 from atom.model_ops.base_attention import BaseAttention
+from atom.model_ops.utils import atom_parameter
 from atom.plugin.prepare import is_plugin_mode, is_sglang
 from atom.models.utils import maybe_prefix
 
@@ -84,14 +85,12 @@ class RadixAttention(BaseAttention):
             # device="cuda" is safe here: this branch is guarded by is_sglang(),
             # which only activates in GPU-based sglang plugin mode.
             if self.attn.k_scale is None:
-                self.attn.k_scale = torch.nn.Parameter(
-                    torch.tensor([1.0], dtype=torch.float32, device="cuda"),
-                    requires_grad=False,
+                self.attn.k_scale = atom_parameter(
+                    torch.tensor([1.0], dtype=torch.float32, device="cuda")
                 )
             if self.attn.v_scale is None:
-                self.attn.v_scale = torch.nn.Parameter(
-                    torch.tensor([1.0], dtype=torch.float32, device="cuda"),
-                    requires_grad=False,
+                self.attn.v_scale = atom_parameter(
+                    torch.tensor([1.0], dtype=torch.float32, device="cuda")
                 )
             # Some SGLang attention backends consume the host-side float scales
             # directly. Keep them in sync with the device-side defaults so the

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -95,6 +95,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # --- MTP (relaxed mtp for quantized mtp) ---
     "ATOM_ENABLE_RELAXED_MTP": lambda: os.getenv("ATOM_ENABLE_RELAXED_MTP", "0").lower()
     == "1",
+    # --- Gradient Control ---
+    # Enable gradient tracking on model parameters.  Default "0" (disabled)
+    # is correct for inference; set to "1" only for training / fine-tuning.
+    "ATOM_REQUIRES_GRAD": lambda: os.getenv("ATOM_REQUIRES_GRAD", "0") == "1",
 }
 
 


### PR DESCRIPTION
## Summary

- Add `ATOM_REQUIRES_GRAD` env var (default: `0` / disabled) to control gradient tracking on all model parameters
- Add centralized `atom_parameter()` factory in `atom/model_ops/utils.py` that wraps `nn.Parameter` with the env var
- Replace all `nn.Parameter(...)` constructor calls across the codebase (14 files, ~80 call sites) with `atom_parameter(...)`

## Root Cause

`nn.Parameter` defaults to `requires_grad=True`. ATOM is an inference engine and never explicitly disabled gradients. With newer aiter versions (>= 0.1.12), `flydsl_hgemm` uses `__dlpack__` to export tensors, which refuses `requires_grad=True` tensors:

```
RuntimeError: hgemm_bf16_32x64x128_S2TN_AS_BS failed:
  Failed to construct JitArgument for parameter 'B':
  Can't export tensors that require gradient, use tensor.detach()
```

Crash path: `lm_head.weight` → `tgemm.mm` → `gemm_a16w16` → `flydsl_hgemm` → `__dlpack__`

## Test plan

- [ ] GLM-5.1-MXFP4 accuracy test passes (previously crashed during warmup)
- [ ] DeepSeek-R1-0528 accuracy test passes
- [ ] Existing unit tests pass (251 passed, same as before)