### PR TITLE
[atom-vllm] by default disable vllm mori because the atom mori will be used for atom-vllm

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -24,7 +24,6 @@ from transformers import AutoConfig, GenerationConfig, PretrainedConfig
 # plugin-related utilities
 from atom.plugin import is_plugin_mode, is_vllm
 from atom.plugin.config import PluginConfig
-from atom.utils import resolve_obj_by_qualname
 
 logger = logging.getLogger("atom")
 

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -11,6 +11,8 @@ logger = logging.getLogger("atom")
 # this flag is used to enable the vllm plugin mode
 disable_vllm_plugin = envs.ATOM_DISABLE_VLLM_PLUGIN
 disable_vllm_plugin_attention = envs.ATOM_DISABLE_VLLM_PLUGIN_ATTENTION
+disable_vllm_mori = envs.ATOM_DISABLE_VLLM_MORI
+_warned_vllm_mori_import_opt_out = False
 
 # those 2 models are covering most of dense and moe models
 ATOM_CAUSAL_LM_MODEL_WRAPPER = "atom.plugin.vllm.model_wrapper:ATOMForCausalLM"
@@ -37,6 +39,66 @@ def _set_plugin_mode() -> None:
     _set_framework_backbone("vllm")
 
 
+def _maybe_disable_vllm_mori_import() -> None:
+    """Control whether vLLM can see its own optional ``mori`` package.
+
+    In ATOM-vLLM plugin mode, ATOM provides the model implementation while vLLM
+    mainly acts as the runtime shell. For the MoE path, ATOM uses ATOM's own
+    mori integration instead of vLLM's. However, newer vLLM versions may import
+    their optional mori path very early during quantization/config validation,
+    before the model is actually built. If the environment contains a mori build
+    that matches ATOM's path but not vLLM's ABI expectations, that eager import
+    can fail the whole process even though the run never intends to use vLLM's
+    mori implementation.
+
+    To keep plugin mode stable, we hide vLLM's own ``has_mori()`` detection by
+    default. Users can opt out with ``ATOM_DISABLE_VLLM_MORI=0`` if they
+    intentionally want vLLM to use its mori path, but then they are responsible
+    for installing a mori build that is compatible with their vLLM environment.
+    """
+    global _warned_vllm_mori_import_opt_out
+
+    if not disable_vllm_mori:
+        if not _warned_vllm_mori_import_opt_out:
+            logger.warning(
+                "ATOM plugin: keeping vLLM mori detection enabled because "
+                "ATOM_DISABLE_VLLM_MORI=0. In ATOM-vLLM plugin mode, "
+                "ATOM normally uses ATOM's mori path instead of vLLM's. "
+                "If vLLM imports its own mori path, ABI/environment conflicts "
+                "may occur. Please make sure you installed a mori version "
+                "compatible with this vLLM environment."
+            )
+            _warned_vllm_mori_import_opt_out = True
+        return
+
+    try:
+        import vllm.utils.import_utils as vllm_import_utils
+    except ImportError:
+        logger.debug(
+            "ATOM plugin: skip disabling vLLM mori import; import utils unavailable"
+        )
+        return
+
+    has_mori = getattr(vllm_import_utils, "has_mori", None)
+    if has_mori is None:
+        logger.debug("ATOM plugin: skip disabling vLLM mori import; has_mori missing")
+        return
+
+    if getattr(has_mori, "_atom_vllm_mori_disabled", False):
+        return
+
+    def _disabled_has_mori() -> bool:
+        # ATOM plugin mode intentionally hides vLLM's optional mori path.
+        return False
+
+    setattr(_disabled_has_mori, "_atom_vllm_mori_disabled", True)
+    vllm_import_utils.has_mori = _disabled_has_mori
+    logger.info(
+        "ATOM plugin: disabled vLLM mori detection in plugin mode so ATOM "
+        "uses its own mori path without pulling in vLLM's optional mori import"
+    )
+
+
 def register_platform() -> Optional[str]:
 
     if disable_vllm_plugin:
@@ -45,6 +107,7 @@ def register_platform() -> Optional[str]:
         logger.info("Disable ATOM OOT plugin platforms")
         return None
 
+    _maybe_disable_vllm_mori_import()
     _set_plugin_mode()
 
     # return the ATOM platform to vllm
@@ -85,6 +148,7 @@ def register_model() -> None:
         logger.info("Disable ATOM model register")
         return
 
+    _maybe_disable_vllm_mori_import()
     import vllm.model_executor.models.registry as vllm_model_registry
 
     any_updated = False

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -83,6 +83,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "ATOM_DISABLE_VLLM_PLUGIN_ATTENTION", "0"
     ).lower()
     == "1",
+    # In ATOM-vLLM plugin mode, ATOM uses ATOM's own mori path rather than
+    # vLLM's optional mori integration. Keep vLLM from detecting/importing its
+    # own mori path by default to avoid ABI/environment conflicts during vLLM's
+    # early quantization/config validation. Set to "0" only if you explicitly
+    # want vLLM to use its mori path and have installed a mori build compatible
+    # with that vLLM environment.
+    "ATOM_DISABLE_VLLM_MORI": lambda: os.getenv("ATOM_DISABLE_VLLM_MORI", "1").lower()
+    == "1",
     "ATOM_USE_CUSTOM_ALL_GATHER": lambda: os.getenv(
         "ATOM_USE_CUSTOM_ALL_GATHER", "1"
     ).lower()


### PR DESCRIPTION
Disable the vllm mori import because when atom-vllm mode, the atom mori will be used for model implementation. When atom upgrades the mori version, there could be ABI issue if importing vllm mori. Meanwhile warn users when set the flag `ATOM_DISABLE_VLLM_MORI` to 0 because there could be high risky to encounter an ABI issue.