### PR TITLE
ci: add Qwen3.5-397B-A17B-MXFP4 to per-PR accuracy test

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -100,6 +100,26 @@
     "env_vars": ""
   },
   {
+    "display": "Qwen3.5-397B-A17B-FP8",
+    "path": "Qwen/Qwen3.5-397B-A17B-FP8",
+    "prefix": "qwen35-397b-fp8",
+    "args": "--kv_cache_dtype fp8 -tp 4",
+    "bench_args": "",
+    "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  },
+  {
+    "display": "Qwen3.5-397B-A17B-MXFP4",
+    "path": "amd/Qwen3.5-397B-A17B-MXFP4",
+    "prefix": "qwen35-397b-mxfp4",
+    "args": "--kv_cache_dtype fp8 -tp 4",
+    "bench_args": "",
+    "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  },
+  {
     "display": "Llama-3.3-70B-Instruct-MXFP4",
     "path": "amd/Llama-3.3-70B-Instruct-MXFP4-Preview",
     "prefix": "llama-3-3-70b-instruct-mxfp4",

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -174,10 +174,22 @@
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "pr",
-    "accuracy_threshold": 0.875,
+    "accuracy_threshold": 0.87,
     "accuracy_baseline": 0.9545,
     "accuracy_baseline_model": "zai-org/GLM-5.1",
     "_baseline_note": "CI uses 3-shot, not comparable to HF 5-shot baseline"
+  },
+  {
+    "model_name": "Qwen3.5-397B-A17B-FP8",
+    "model_path": "Qwen/Qwen3.5-397B-A17B-FP8",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 4",
+    "env_vars": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.85,
+    "accuracy_baseline": 0.9538,
+    "accuracy_baseline_model": "Qwen/Qwen3.5-397B-A17B-FP8",
+    "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
   },
   {
     "model_name": "Qwen3.5-397B-A17B-MXFP4",
@@ -186,10 +198,10 @@
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "pr",
-    "accuracy_threshold": 0.87,
-    "accuracy_baseline": 0.909,
-    "accuracy_baseline_model": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-    "_baseline_note": "Using Qwen3-235B baseline as proxy; needs CI measurement for Qwen3.5 specific baseline"
+    "accuracy_threshold": 0.835,
+    "accuracy_baseline": 0.9538,
+    "accuracy_baseline_model": "Qwen/Qwen3.5-397B-A17B-FP8",
+    "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
   },
   {
     "model_name": "MiniMax-M2.5",

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -180,6 +180,18 @@
     "_baseline_note": "CI uses 3-shot, not comparable to HF 5-shot baseline"
   },
   {
+    "model_name": "Qwen3.5-397B-A17B-MXFP4",
+    "model_path": "amd/Qwen3.5-397B-A17B-MXFP4",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 4",
+    "env_vars": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "test_level": "pr",
+    "accuracy_threshold": 0.87,
+    "accuracy_baseline": 0.909,
+    "accuracy_baseline_model": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+    "_baseline_note": "Using Qwen3-235B baseline as proxy; needs CI measurement for Qwen3.5 specific baseline"
+  },
+  {
     "model_name": "MiniMax-M2.5",
     "model_path": "MiniMaxAI/MiniMax-M2.5",
     "extraArgs": "--kv_cache_dtype fp8 -tp 2 --trust-remote-code",

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -34,6 +34,14 @@ on:
         description: "Benchmark MiniMax-M2.5"
         type: boolean
         default: true
+      qwen35-397b-fp8:
+        description: "Benchmark Qwen3.5-397B-A17B-FP8"
+        type: boolean
+        default: true
+      qwen35-397b-mxfp4:
+        description: "Benchmark Qwen3.5-397B-A17B-MXFP4"
+        type: boolean
+        default: true
       llama-3-3-70b-instruct-mxfp4:
         description: "Benchmark Llama-3.3-70B-Instruct-MXFP4"
         type: boolean

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -205,6 +205,9 @@ jobs:
         run: |
           # Run rocm-smi inside the container for consistent output across runners
           GPU_NAME=$(docker exec atom-benchmark rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
+          if [ -z "$GPU_NAME" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
+            GPU_NAME=$(docker exec atom-benchmark rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
+          fi
           GPU_VRAM_GB=$(docker exec atom-benchmark rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
           ROCM_VERSION=$(docker exec atom-benchmark cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
           echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -559,6 +559,9 @@ jobs:
         id: gpu-info
         run: |
           GPU_NAME=$(docker exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
+          if [ -z "$GPU_NAME" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
+            GPU_NAME=$(docker exec "$CONTAINER_NAME" rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
+          fi
           GPU_VRAM_GB=$(docker exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
           ROCM_VERSION=$(docker exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
           echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -707,6 +707,9 @@ jobs:
         id: gpu-info
         run: |
           GPU_NAME=$(docker exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
+          if [ -z "$GPU_NAME" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
+            GPU_NAME=$(docker exec "$CONTAINER_NAME" rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
+          fi
           GPU_VRAM_GB=$(docker exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
           ROCM_VERSION=$(docker exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
           echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- Model: amd/Qwen3.5-397B-A17B-MXFP4, tp=4
- Test level: pr
- Accuracy threshold: 0.87 (GSM8K 3-shot flexible-extract)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
