### PR TITLE
fix kv cache fp8 issue

### DIFF
--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -391,6 +391,7 @@ class Qwen3NextAttention(nn.Module):
                 self.head_dim,
                 self.scaling,
                 num_kv_heads=self.num_kv_heads,
+                kv_cache_dtype=atom_config.kv_cache_dtype,
                 quant_config=quant_config,
                 use_mla=False,
                 layer_num=extract_layer_index(prefix),


### PR DESCRIPTION
## Motivation
gsm8k score

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7998|±  |0.0110|
|     |       |strict-match    |     5|exact_match|↑  |0.7801|±  |0.0114|
```

launch script:
```
python -m atom.entrypoints.openai_server \
  --model /workspace/shared/data/amd_int/models/Qwen3.5-397B-A17B-MXFP4\
  -tp 2 \
  --kv_cache_dtype fp8 \
  --server-port 8100
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
