### PR TITLE
docker: pin base image from ubuntu 24.04 py3.12 to ubuntu 22.04 py3.10

### DIFF
--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -14,6 +14,11 @@ on:
         required: false
         type: boolean
         default: false
+      rebuild_atom_base_from_dockerfile:
+        description: "Full build image before validation"
+        required: false
+        type: boolean
+        default: false
       upload_accuracy_to_dashboard:
         description: "Optional: upload SGLANG accuracy results to dashboard after this manual run"
         required: false
@@ -47,7 +52,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Docker Login
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'main' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && (github.ref_name != 'main' || inputs.rebuild_atom_base_from_dockerfile) }}
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
@@ -55,6 +60,7 @@ jobs:
         id: meta
         env:
           RUN_DSR1_FP8_TP4: ${{ inputs.run_dsr1_fp8_tp4 }}
+          REBUILD_ATOM_BASE_FROM_DOCKERFILE: ${{ inputs.rebuild_atom_base_from_dockerfile }}
         run: |
           set -euo pipefail
 
@@ -91,7 +97,18 @@ jobs:
           print(f"model_matrix={json.dumps({'include': selected})}")
           PY
 
-          if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ] || [ "${GITHUB_REF_NAME}" = "main" ]; then
+          REBUILD_FROM_DOCKERFILE="${REBUILD_ATOM_BASE_FROM_DOCKERFILE:-false}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${REBUILD_FROM_DOCKERFILE}" = "true" ]; then
+              echo "Manual run selected full ATOM base rebuild from docker/Dockerfile"
+            elif [ "${GITHUB_REF_NAME}" = "main" ]; then
+              echo "Manual run on main reuses published SGLANG image"
+            else
+              echo "Manual run selected fast overlay rebuild from ${ATOM_BASE_NIGHTLY_IMAGE}"
+            fi
+          fi
+
+          if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ] || { [ "${GITHUB_REF_NAME}" = "main" ] && [ "${REBUILD_FROM_DOCKERFILE}" != "true" ]; }; then
             if RESOLUTION_JSON="$(
               python3 .github/scripts/resolve_atom_image.py \
                 --repository "${VALIDATION_IMAGE_REPO}" \
@@ -119,16 +136,58 @@ jobs:
             echo "sglang_image_tag=${RESOLVED_SGLANG_IMAGE}" >> "$GITHUB_OUTPUT"
             echo "cleanup_temp_image=false" >> "$GITHUB_OUTPUT"
             echo "manual_base_image_tag=" >> "$GITHUB_OUTPUT"
+            echo "rebuilt_atom_base_image_tag=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           SHORT_SHA="$(git rev-parse --short=12 HEAD)"
           MANUAL_BASE_IMAGE_TAG="atom_sglang_manual_base:${GITHUB_RUN_ID}-${SHORT_SHA}"
+          REBUILT_ATOM_BASE_IMAGE_TAG="atom_sglang_rebuilt_base:${GITHUB_RUN_ID}-${SHORT_SHA}"
           SGLANG_IMAGE_TAG="${VALIDATION_IMAGE_REPO}:sglang-full-manual-${GITHUB_RUN_ID}-${SHORT_SHA}"
           BUILD_CONTEXT="$(mktemp -d)"
           trap 'rm -rf "${BUILD_CONTEXT}"' EXIT
 
+          echo "sglang_image_tag=${SGLANG_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "cleanup_temp_image=true" >> "$GITHUB_OUTPUT"
+          if [ "${REBUILD_FROM_DOCKERFILE}" = "true" ]; then
+            echo "manual_base_image_tag=" >> "$GITHUB_OUTPUT"
+            echo "rebuilt_atom_base_image_tag=${REBUILT_ATOM_BASE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "manual_base_image_tag=${MANUAL_BASE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+            echo "rebuilt_atom_base_image_tag=" >> "$GITHUB_OUTPUT"
+          fi
+
           git archive --format=tar HEAD | tar -xf - -C "${BUILD_CONTEXT}"
+
+          if [ "${REBUILD_FROM_DOCKERFILE}" = "true" ]; then
+            echo "Manual run rebuilds ATOM base and SGLANG image from branch ${GITHUB_REF_NAME}"
+
+            DOCKER_BUILDKIT=1 docker build --pull --network=host --no-cache \
+              -t "${REBUILT_ATOM_BASE_IMAGE_TAG}" \
+              --target atom_image \
+              --build-arg GPU_ARCH="${GPU_ARCH}" \
+              --build-arg AITER_REPO="${AITER_REPO}" \
+              --build-arg AITER_COMMIT="${AITER_COMMIT}" \
+              --build-arg MAX_JOBS=64 \
+              --build-arg ATOM_REPO="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" \
+              --build-arg ATOM_COMMIT="${GITHUB_SHA}" \
+              -f "${BUILD_CONTEXT}/docker/Dockerfile" \
+              "${BUILD_CONTEXT}"
+
+            DOCKER_BUILDKIT=1 docker build --network=host --no-cache \
+              -t "${SGLANG_IMAGE_TAG}" \
+              --target atom_sglang \
+              --build-arg SGLANG_BASE_IMAGE="${REBUILT_ATOM_BASE_IMAGE_TAG}" \
+              --build-arg MAX_JOBS=64 \
+              --build-arg SGLANG_REF="${SGLANG_REF}" \
+              --build-arg INSTALL_LM_EVAL=1 \
+              --build-arg INSTALL_FASTSAFETENSORS=1 \
+              -f "${BUILD_CONTEXT}/docker/Dockerfile" \
+              "${BUILD_CONTEXT}"
+
+            docker push "${SGLANG_IMAGE_TAG}"
+            exit 0
+          fi
 
           cat <<'EOF' > "${BUILD_CONTEXT}/Dockerfile.mod"
           ARG ATOM_BASE_NIGHTLY_IMAGE
@@ -183,15 +242,17 @@ jobs:
 
           docker push "${SGLANG_IMAGE_TAG}"
 
-          echo "sglang_image_tag=${SGLANG_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-          echo "cleanup_temp_image=true" >> "$GITHUB_OUTPUT"
-          echo "manual_base_image_tag=${MANUAL_BASE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-
       - name: Clean up builder images
         if: ${{ always() && steps.meta.outputs.cleanup_temp_image == 'true' }}
         run: |
-          docker rmi "${{ steps.meta.outputs.sglang_image_tag }}" || true
-          docker rmi "${{ steps.meta.outputs.manual_base_image_tag }}" || true
+          for image in \
+            "${{ steps.meta.outputs.sglang_image_tag }}" \
+            "${{ steps.meta.outputs.manual_base_image_tag }}" \
+            "${{ steps.meta.outputs.rebuilt_atom_base_image_tag }}"; do
+            if [ -n "${image}" ]; then
+              docker rmi "${image}" || true
+            fi
+          done
 
   sglang-model-accuracy:
     name: SGLANG Model Accuracy (${{ matrix.model_name }})

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -75,7 +75,7 @@ on:
         type: boolean
         default: false
       rebuild_atom_base_from_dockerfile:
-        description: "Rebuild ATOM base image from docker/Dockerfile before OOT validation (slow)"
+        description: "Full build image before validation"
         required: false
         type: boolean
         default: false

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -74,6 +74,11 @@ on:
         required: false
         type: boolean
         default: false
+      rebuild_atom_base_from_dockerfile:
+        description: "Rebuild ATOM base image from docker/Dockerfile before OOT validation (slow)"
+        required: false
+        type: boolean
+        default: false
       upload_accuracy_to_dashboard:
         description: "Optional: upload OOT accuracy results to dashboard after this manual run"
         required: false
@@ -127,6 +132,7 @@ jobs:
           RUN_GPT_OSS_120B_TP1: ${{ inputs.run_gpt_oss_120b_tp1 }}
           RUN_GPT_OSS_120B_TP2: ${{ inputs.run_gpt_oss_120b_tp2 }}
           RUN_GLM5_1_FP8_TP8: ${{ inputs.run_glm5_1_fp8_tp8 }}
+          REBUILD_ATOM_BASE_FROM_DOCKERFILE: ${{ inputs.rebuild_atom_base_from_dockerfile }}
         run: |
           set -euo pipefail
 
@@ -272,6 +278,15 @@ jobs:
           print(f"model_matrix={json.dumps({'include': selected})}")
           PY
 
+          REBUILD_FROM_DOCKERFILE="${REBUILD_ATOM_BASE_FROM_DOCKERFILE:-false}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${REBUILD_FROM_DOCKERFILE}" = "true" ]; then
+              echo "Manual run selected full ATOM base rebuild from docker/Dockerfile"
+            else
+              echo "Manual run selected fast overlay rebuild from ${ATOM_BASE_NIGHTLY_IMAGE}"
+            fi
+          fi
+
           if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
             if RESOLUTION_JSON="$(
               python3 .github/scripts/resolve_atom_image.py \
@@ -295,16 +310,58 @@ jobs:
             echo "oot_image_tag=${RESOLVED_OOT_IMAGE}" >> "$GITHUB_OUTPUT"
             echo "cleanup_temp_image=false" >> "$GITHUB_OUTPUT"
             echo "manual_base_image_tag=" >> "$GITHUB_OUTPUT"
+            echo "rebuilt_atom_base_image_tag=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           SHORT_SHA="$(git rev-parse --short=12 HEAD)"
           MANUAL_BASE_IMAGE_TAG="atom_oot_manual_base:${GITHUB_RUN_ID}-${SHORT_SHA}"
+          REBUILT_ATOM_BASE_IMAGE_TAG="atom_oot_rebuilt_base:${GITHUB_RUN_ID}-${SHORT_SHA}"
           OOT_IMAGE_TAG="${VALIDATION_IMAGE_REPO}:vllm-full-manual-${GITHUB_RUN_ID}-${SHORT_SHA}"
           BUILD_CONTEXT="$(mktemp -d)"
           trap 'rm -rf "${BUILD_CONTEXT}"' EXIT
 
+          echo "oot_image_tag=${OOT_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "cleanup_temp_image=true" >> "$GITHUB_OUTPUT"
+          if [ "${REBUILD_FROM_DOCKERFILE}" = "true" ]; then
+            echo "manual_base_image_tag=" >> "$GITHUB_OUTPUT"
+            echo "rebuilt_atom_base_image_tag=${REBUILT_ATOM_BASE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "manual_base_image_tag=${MANUAL_BASE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+            echo "rebuilt_atom_base_image_tag=" >> "$GITHUB_OUTPUT"
+          fi
+
           git archive --format=tar HEAD | tar -xf - -C "${BUILD_CONTEXT}"
+
+          if [ "${REBUILD_FROM_DOCKERFILE}" = "true" ]; then
+            echo "Manual run rebuilds ATOM base and OOT image from branch ${GITHUB_REF_NAME}"
+
+            DOCKER_BUILDKIT=1 docker build --pull --network=host --no-cache \
+              -t "${REBUILT_ATOM_BASE_IMAGE_TAG}" \
+              --target atom_image \
+              --build-arg GPU_ARCH="${GPU_ARCH}" \
+              --build-arg AITER_REPO="${AITER_REPO}" \
+              --build-arg AITER_COMMIT="${AITER_COMMIT}" \
+              --build-arg MAX_JOBS=64 \
+              --build-arg ATOM_REPO="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" \
+              --build-arg ATOM_COMMIT="${GITHUB_SHA}" \
+              -f "${BUILD_CONTEXT}/docker/Dockerfile" \
+              "${BUILD_CONTEXT}"
+
+            DOCKER_BUILDKIT=1 docker build --network=host --no-cache \
+              -t "${OOT_IMAGE_TAG}" \
+              --target atom_oot \
+              --build-arg OOT_BASE_IMAGE="${REBUILT_ATOM_BASE_IMAGE_TAG}" \
+              --build-arg MAX_JOBS=64 \
+              --build-arg VLLM_COMMIT="${VLLM_COMMIT}" \
+              --build-arg INSTALL_LM_EVAL=1 \
+              --build-arg INSTALL_FASTSAFETENSORS=1 \
+              -f "${BUILD_CONTEXT}/docker/Dockerfile" \
+              "${BUILD_CONTEXT}"
+
+            docker push "${OOT_IMAGE_TAG}"
+            exit 0
+          fi
 
           cat <<'EOF' > "${BUILD_CONTEXT}/Dockerfile.mod"
           ARG ATOM_BASE_NIGHTLY_IMAGE
@@ -359,15 +416,17 @@ jobs:
 
           docker push "${OOT_IMAGE_TAG}"
 
-          echo "oot_image_tag=${OOT_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-          echo "cleanup_temp_image=true" >> "$GITHUB_OUTPUT"
-          echo "manual_base_image_tag=${MANUAL_BASE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-
       - name: Clean up builder images
         if: ${{ always() && steps.meta.outputs.cleanup_temp_image == 'true' }}
         run: |
-          docker rmi "${{ steps.meta.outputs.oot_image_tag }}" || true
-          docker rmi "${{ steps.meta.outputs.manual_base_image_tag }}" || true
+          for image in \
+            "${{ steps.meta.outputs.oot_image_tag }}" \
+            "${{ steps.meta.outputs.manual_base_image_tag }}" \
+            "${{ steps.meta.outputs.rebuilt_atom_base_image_tag }}"; do
+            if [ -n "${image}" ]; then
+              docker rmi "${image}" || true
+            fi
+          done
 
   oot-model-accuracy:
     name: Model Accuracy (${{ matrix.model_name }})

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -187,7 +187,8 @@ RUN echo "========== [SGLANG-ATOM 3/6] Install SGLang dependencies ==========" &
     rm -f pyproject.toml && \
     cp pyproject_other.toml pyproject.toml && \
     "${VENV_PYTHON}" -m pip install --no-cache-dir --no-deps -e . && \
-    "${VENV_PYTHON}" -c "import tomllib; from pathlib import Path; deps = tomllib.loads(Path('pyproject_other.toml').read_text())['project']['optional-dependencies']['runtime_common']; blocked_prefixes = ('compressed-tensors', 'outlines==', 'timm==', 'torchao==', 'transformers==', 'xgrammar=='); Path('/tmp/sglang-runtime-common.txt').write_text(''.join(f'{dep}\\n' for dep in deps if dep != 'numpy' and not any(dep.startswith(prefix) for prefix in blocked_prefixes)))" && \
+    "${VENV_PYTHON}" -m pip install --no-cache-dir tomli && \
+    "${VENV_PYTHON}" -c "import tomli; from pathlib import Path; deps = tomli.loads(Path('pyproject_other.toml').read_text())['project']['optional-dependencies']['runtime_common']; blocked_prefixes = ('compressed-tensors', 'outlines==', 'timm==', 'torchao==', 'transformers==', 'xgrammar=='); Path('/tmp/sglang-runtime-common.txt').write_text(''.join(f'{dep}\\n' for dep in deps if dep != 'numpy' and not any(dep.startswith(prefix) for prefix in blocked_prefixes)))" && \
     "${VENV_PYTHON}" -m pip install --no-cache-dir \
       -r /tmp/sglang-runtime-common.txt \
       airportsdata \
@@ -199,6 +200,7 @@ RUN echo "========== [SGLANG-ATOM 3/6] Install SGLang dependencies ==========" &
       nest_asyncio \
       outlines_core==0.1.26 \
       pycountry \
+      pybase64 \
       referencing \
       safetensors && \
     "${VENV_PYTHON}" -m pip install --no-cache-dir --no-deps \
@@ -370,5 +372,89 @@ RUN git clone $ATOM_REPO /app/ATOM && \
     git checkout $ATOM_COMMIT && \
     pip install -e .
 RUN pip show atom || true
+
+# ========== Mooncake TransferEngine ==========
+ARG INSTALL_MOONCAKE=1
+ARG MOONCAKE_REPO="https://github.com/kvcache-ai/Mooncake.git"
+ARG MOONCAKE_COMMIT="v0.3.10.post1"
+ARG VENV_PYTHON="/opt/venv/bin/python"
+
+# [MC 1/4] Clone
+RUN if [ "${INSTALL_MOONCAKE}" = "1" ]; then \
+        echo "========== [MC 1/4] Clone Mooncake =========="; \
+        git clone --depth 1 ${MOONCAKE_REPO} /app/mooncake; \
+        if [ -n "${MOONCAKE_COMMIT}" ]; then \
+            cd /app/mooncake && git fetch --depth 1 origin "${MOONCAKE_COMMIT}" && git checkout "${MOONCAKE_COMMIT}"; \
+        fi; \
+        cd /app/mooncake && echo "Mooncake commit: $(git rev-parse HEAD)"; \
+    else \
+        echo "========== Skipped Mooncake (INSTALL_MOONCAKE=0) =========="; \
+    fi
+
+# [MC 2/4] Install dependencies (system packages + yalantinglibs + Go + submodules)
+ENV PATH="/usr/local/go/bin:${PATH}"
+RUN if [ "${INSTALL_MOONCAKE}" = "1" ]; then \
+        echo "========== [MC 2/4] Install Mooncake dependencies =========="; \
+        apt-get update \
+        && apt --fix-broken install -y \
+        && apt-mark hold rccl rccl-dev rocm-hip 2>/dev/null || true \
+        && cd /app/mooncake && bash dependencies.sh -y; \
+    fi
+
+# [MC 3/4] CMake build with HIP support
+RUN if [ "${INSTALL_MOONCAKE}" = "1" ]; then \
+        echo "========== [MC 3/4] Build Mooncake (USE_HIP=ON) =========="; \
+        mkdir -p /app/mooncake/build && cd /app/mooncake/build \
+        && cmake .. \
+            -DUSE_HIP=ON \
+            -DUSE_TCP=ON \
+            -DUSE_HTTP=ON \
+            -DUSE_CUDA=OFF \
+            -DBUILD_UNIT_TESTS=ON \
+            -DBUILD_EXAMPLES=OFF \
+            -DWITH_STORE=OFF \
+            -DWITH_STORE_RUST=OFF \
+            -DWITH_P2P_STORE=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+        && make -j$(nproc); \
+    fi
+
+# [MC 4/4] Install Python wheel, copy artifacts, clean up
+RUN if [ "${INSTALL_MOONCAKE}" = "1" ]; then \
+        echo "========== [MC 4/4] Install Mooncake Python package =========="; \
+        cd /app/mooncake \
+        && "${VENV_PYTHON}" -m pip install mooncake-wheel/ \
+        && MOONCAKE_PKG=$("${VENV_PYTHON}" -c "import mooncake, os; print(os.path.dirname(mooncake.__file__))") \
+        && cp build/mooncake-integration/engine.cpython-310-x86_64-linux-gnu.so \
+              "${MOONCAKE_PKG}/engine.so" \
+        && cp build/mooncake-asio/libasio.so \
+              "${MOONCAKE_PKG}/" \
+        && echo "Mooncake engine.so linkage:" \
+        && ldd "${MOONCAKE_PKG}/engine.so" | grep -E "hip|cuda" || true \
+        && echo "--- Save RDMA test binaries ---" \
+        && mkdir -p /usr/local/bin/mooncake-tests \
+        && cp build/mooncake-transfer-engine/tests/rdma_loopback_test \
+              build/mooncake-transfer-engine/tests/rdma_transport_test \
+              build/mooncake-transfer-engine/tests/rdma_transport_test2 \
+              /usr/local/bin/mooncake-tests/ 2>/dev/null || true \
+        && ls -lh /usr/local/bin/mooncake-tests/ \
+        && echo "--- Clean up build artifacts ---" \
+        && rm -rf /app/mooncake/build /app/mooncake/.git; \
+    fi
+
+ENV LD_LIBRARY_PATH="/opt/venv/lib/python3.10/site-packages/mooncake:${LD_LIBRARY_PATH}"
+
+# ========== Install Rust toolchain ==========
+ARG RUST_VERSION="1.94.0"
+
+RUN echo "========== Install Rust toolchain ==========" \
+    && apt-get update && apt-get install -y --no-install-recommends curl build-essential pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain "${RUST_VERSION}" --profile minimal \
+    && . "$HOME/.cargo/env" \
+    && rustc --version && cargo --version
+
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Default base images
-ARG BASE_IMAGE="rocm/pytorch:latest"
+ARG BASE_IMAGE="rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0"
 ARG OOT_BASE_IMAGE="rocm/atom-dev:latest"
 ARG SGLANG_BASE_IMAGE="rocm/atom-dev:latest"
 ARG GPU_ARCH="gfx942;gfx950"
@@ -18,7 +18,7 @@ LABEL com.rocm.atom.vllm_commit="${VLLM_COMMIT}"
 
 ENV PATH="/opt/venv/bin:${PATH}"
 ENV MAX_JOBS=${MAX_JOBS}
-ENV LD_LIBRARY_PATH="/opt/venv/lib/python3.12/site-packages/torch/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/venv/lib/python3.10/site-packages/torch/lib:${LD_LIBRARY_PATH}"
 ENV VLLM_TARGET_DEVICE=rocm
 ENV CMAKE_MAKE_PROGRAM=/usr/local/bin/ninja
 
@@ -42,10 +42,10 @@ RUN echo "========== [OOT 2/7] Verify base packages (atom/aiter/mori) ==========
     echo "========== [OOT 2/7] Back up base image triton ==========" && \
     BASE_TRITON_VERSION="$("${VENV_PYTHON}" -c "import triton; print(triton.__version__)")" && \
     mkdir -p /tmp/triton-base-backup && \
-    cp -a /opt/venv/lib/python3.12/site-packages/triton /tmp/triton-base-backup/ && \
+    cp -a /opt/venv/lib/python3.10/site-packages/triton /tmp/triton-base-backup/ && \
     MATCHED_DIST_INFO="" && \
     MATCH_COUNT=0 && \
-    for f in /opt/venv/lib/python3.12/site-packages/triton-*.dist-info; do \
+    for f in /opt/venv/lib/python3.10/site-packages/triton-*.dist-info; do \
       [ -d "$f" ] || continue; \
       DIST_VERSION="$(awk -F': ' '$1 == "Version" { print $2; exit }' "$f/METADATA")"; \
       if [ "${DIST_VERSION}" = "${BASE_TRITON_VERSION}" ]; then \
@@ -56,7 +56,7 @@ RUN echo "========== [OOT 2/7] Verify base packages (atom/aiter/mori) ==========
     done && \
     if [ "${MATCH_COUNT}" -ne 1 ]; then \
       echo "ERROR: Expected exactly one triton dist-info matching imported version ${BASE_TRITON_VERSION}, found ${MATCH_COUNT}." && \
-      ls -d /opt/venv/lib/python3.12/site-packages/triton-*.dist-info || true && \
+      ls -d /opt/venv/lib/python3.10/site-packages/triton-*.dist-info || true && \
       exit 1; \
     fi && \
     echo "Base image triton backed up: version=${BASE_TRITON_VERSION}, dist-info=${MATCHED_DIST_INFO}"
@@ -108,21 +108,21 @@ RUN echo "========== [VLLM-ATOM] Validate vision/audio wheels ==========" && \
 # behavior and fail fast if `pip show triton` would disagree with `import triton`.
 RUN echo "========== [OOT] Restore base image triton ==========" && \
     "${VENV_PYTHON}" -m pip uninstall -y triton 2>/dev/null || true && \
-    rm -rf /opt/venv/lib/python3.12/site-packages/triton \
-           /opt/venv/lib/python3.12/site-packages/triton-*.dist-info && \
-    cp -a /tmp/triton-base-backup/triton /opt/venv/lib/python3.12/site-packages/ && \
+    rm -rf /opt/venv/lib/python3.10/site-packages/triton \
+           /opt/venv/lib/python3.10/site-packages/triton-*.dist-info && \
+    cp -a /tmp/triton-base-backup/triton /opt/venv/lib/python3.10/site-packages/ && \
     RESTORED_DIST_INFO="" && \
     RESTORED_COUNT=0 && \
     for f in /tmp/triton-base-backup/triton-*.dist-info; do \
       [ -d "$f" ] || continue; \
-      cp -a "$f" /opt/venv/lib/python3.12/site-packages/; \
+      cp -a "$f" /opt/venv/lib/python3.10/site-packages/; \
       RESTORED_DIST_INFO="$(basename "$f")"; \
       RESTORED_COUNT=$((RESTORED_COUNT + 1)); \
     done && \
     rm -rf /tmp/triton-base-backup && \
     if [ "${RESTORED_COUNT}" -ne 1 ]; then \
       echo "ERROR: Expected exactly one restored triton dist-info, found ${RESTORED_COUNT}." && \
-      ls -d /opt/venv/lib/python3.12/site-packages/triton-*.dist-info || true && \
+      ls -d /opt/venv/lib/python3.10/site-packages/triton-*.dist-info || true && \
       exit 1; \
     fi && \
     "${VENV_PYTHON}" -m pip show triton > /tmp/triton_pip_show.txt && \
@@ -131,7 +131,7 @@ RUN echo "========== [OOT] Restore base image triton ==========" && \
     if [ -z "${PIP_TRITON_VERSION}" ] || [ "${PIP_TRITON_VERSION}" != "${IMPORT_TRITON_VERSION}" ]; then \
       echo "ERROR: pip show triton reports '${PIP_TRITON_VERSION}', but import triton reports '${IMPORT_TRITON_VERSION}'." && \
       cat /tmp/triton_pip_show.txt || true && \
-      ls -d /opt/venv/lib/python3.12/site-packages/triton-*.dist-info || true && \
+      ls -d /opt/venv/lib/python3.10/site-packages/triton-*.dist-info || true && \
       exit 1; \
     fi && \
     echo "Restored base image triton: version=${IMPORT_TRITON_VERSION}, dist-info=${RESTORED_DIST_INFO}" && \
@@ -347,9 +347,9 @@ RUN DEBIAN_FRONTEND=noninteractive dpkg -i --force-all /tmp/rccl/*.deb && \
 
 # Triton: copy package from build stage into current venv
 # Use RUN --mount to avoid COPY glob issues, and preserve mori already in venv
-RUN --mount=from=build_triton,source=/opt/venv/lib/python3.12/site-packages,target=/triton-pkgs \
-    cp -a /triton-pkgs/triton /opt/venv/lib/python3.12/site-packages/ && \
-    cp -a /triton-pkgs/triton-*.dist-info /opt/venv/lib/python3.12/site-packages/ && \
+RUN --mount=from=build_triton,source=/opt/venv/lib/python3.10/site-packages,target=/triton-pkgs \
+    cp -a /triton-pkgs/triton /opt/venv/lib/python3.10/site-packages/ && \
+    cp -a /triton-pkgs/triton-*.dist-info /opt/venv/lib/python3.10/site-packages/ && \
     pip show triton
 
 # Aiter: copy compiled source tree + re-register editable install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -342,38 +342,11 @@ COPY --from=build_mori /opt/venv /opt/venv
 COPY --from=build_mori /app/mori /app/mori
 RUN pip show mori || true
 
-# RCCL: install .deb from build stage
-COPY --from=build_rccl /app/rccl/build/release/*.deb /tmp/rccl/
-RUN DEBIAN_FRONTEND=noninteractive dpkg -i --force-all /tmp/rccl/*.deb && \
-    rm -rf /tmp/rccl
-
-# Triton: copy package from build stage into current venv
-# Use RUN --mount to avoid COPY glob issues, and preserve mori already in venv
-RUN --mount=from=build_triton,source=/opt/venv/lib/python3.10/site-packages,target=/triton-pkgs \
-    cp -a /triton-pkgs/triton /opt/venv/lib/python3.10/site-packages/ && \
-    cp -a /triton-pkgs/triton-*.dist-info /opt/venv/lib/python3.10/site-packages/ && \
-    pip show triton
-
-# Aiter: copy compiled source tree + re-register editable install
-# (pip install -e creates egg-link automatically, no need to COPY them)
-COPY --from=build_aiter /app/aiter-test /app/aiter-test
-RUN cd /app/aiter-test && pip install -e . --no-build-isolation && \
-    pip show amd-aiter
-
-# RTL (rocm-trace-lite): lightweight GPU kernel profiler (~250KB, no build deps)
-RUN pip install rocm-trace-lite && \
-    rtl --version || true
-
-# ATOM: lightweight install (no compilation needed)
-# CACHEBUST invalidates only this layer so parallel stages stay cached
-ARG CACHEBUST=1
-RUN git clone $ATOM_REPO /app/ATOM && \
-    cd /app/ATOM && \
-    git checkout $ATOM_COMMIT && \
-    pip install -e .
-RUN pip show atom || true
-
 # ========== Mooncake TransferEngine ==========
+# Mooncake and Rust apt operations MUST run before the RCCL dpkg -i --force-all
+# step below, because that step overwrites the Ubuntu-repo rccl with a custom
+# ROCm build whose version string doesn't match rocm-hip's declared dependency,
+# leaving dpkg in a broken state that blocks all subsequent apt-get install calls.
 ARG INSTALL_MOONCAKE=1
 ARG MOONCAKE_REPO="https://github.com/kvcache-ai/Mooncake.git"
 ARG MOONCAKE_COMMIT="v0.3.10.post1"
@@ -382,10 +355,10 @@ ARG VENV_PYTHON="/opt/venv/bin/python"
 # [MC 1/4] Clone
 RUN if [ "${INSTALL_MOONCAKE}" = "1" ]; then \
         echo "========== [MC 1/4] Clone Mooncake =========="; \
-        git clone --depth 1 ${MOONCAKE_REPO} /app/mooncake; \
+        git clone --depth 1 ${MOONCAKE_REPO} /app/mooncake && \
         if [ -n "${MOONCAKE_COMMIT}" ]; then \
-            cd /app/mooncake && git fetch --depth 1 origin "${MOONCAKE_COMMIT}" && git checkout "${MOONCAKE_COMMIT}"; \
-        fi; \
+            cd /app/mooncake && git fetch --depth 1 origin "${MOONCAKE_COMMIT}" && git checkout FETCH_HEAD; \
+        fi && \
         cd /app/mooncake && echo "Mooncake commit: $(git rev-parse HEAD)"; \
     else \
         echo "========== Skipped Mooncake (INSTALL_MOONCAKE=0) =========="; \
@@ -396,8 +369,6 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 RUN if [ "${INSTALL_MOONCAKE}" = "1" ]; then \
         echo "========== [MC 2/4] Install Mooncake dependencies =========="; \
         apt-get update \
-        && apt --fix-broken install -y \
-        && apt-mark hold rccl rccl-dev rocm-hip 2>/dev/null || true \
         && cd /app/mooncake && bash dependencies.sh -y; \
     fi
 
@@ -456,5 +427,39 @@ RUN echo "========== Install Rust toolchain ==========" \
     && rustc --version && cargo --version
 
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+# RCCL: install .deb from build stage
+# WARNING: dpkg -i --force-all overwrites Ubuntu-repo rccl with the ROCm custom
+# build, breaking rocm-hip's version dep in dpkg metadata. All apt-get install
+# operations (Mooncake, Rust, etc.) MUST be completed before this step.
+COPY --from=build_rccl /app/rccl/build/release/*.deb /tmp/rccl/
+RUN DEBIAN_FRONTEND=noninteractive dpkg -i --force-all /tmp/rccl/*.deb && \
+    rm -rf /tmp/rccl
+
+# Triton: copy package from build stage into current venv
+# Use RUN --mount to avoid COPY glob issues, and preserve mori already in venv
+RUN --mount=from=build_triton,source=/opt/venv/lib/python3.10/site-packages,target=/triton-pkgs \
+    cp -a /triton-pkgs/triton /opt/venv/lib/python3.10/site-packages/ && \
+    cp -a /triton-pkgs/triton-*.dist-info /opt/venv/lib/python3.10/site-packages/ && \
+    pip show triton
+
+# Aiter: copy compiled source tree + re-register editable install
+# (pip install -e creates egg-link automatically, no need to COPY them)
+COPY --from=build_aiter /app/aiter-test /app/aiter-test
+RUN cd /app/aiter-test && pip install -e . --no-build-isolation && \
+    pip show amd-aiter
+
+# RTL (rocm-trace-lite): lightweight GPU kernel profiler (~250KB, no build deps)
+RUN pip install rocm-trace-lite && \
+    rtl --version || true
+
+# ATOM: lightweight install (no compilation needed)
+# CACHEBUST invalidates only this layer so parallel stages stay cached
+ARG CACHEBUST=1
+RUN git clone $ATOM_REPO /app/ATOM && \
+    cd /app/ATOM && \
+    git checkout $ATOM_COMMIT && \
+    pip install -e .
+RUN pip show atom || true
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary

  Replace the rolling rocm/pytorch:latest tag with the pinned rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0 image, and update
  all hardcoded /opt/venv/lib/python3.12/site-packages paths to python3.10 to match the new base interpreter.

 ## Motivation

  The MI355 host runs Ubuntu 22.04 with its native RDMA stack. The current rocm/pytorch:latest tag has rolled forward to an Ubuntu
  24.04-based image, whose RDMA userspace libraries (libibverbs / librdmacm) are not ABI-compatible with the Ubuntu 22.04 kernel-side
   RDMA on the host. This mismatch causes RDMA initialization failures at runtime and breaks multi-node workflows on MI355.