### PR TITLE
fix: prefix benchmark artifacts to avoid downloading multi-GB traces

### DIFF
--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -300,7 +300,7 @@ jobs:
       - name: Upload benchmark result
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.RESULT_FILENAME }}
+          name: benchmark-${{ env.RESULT_FILENAME }}
           path: ${{ env.RESULT_FILENAME }}.json
 
       - name: Clean Up
@@ -325,7 +325,7 @@ jobs:
       - name: Download all benchmark results
         uses: actions/download-artifact@v8
         with:
-          pattern: '*'
+          pattern: 'benchmark-*'
           merge-multiple: true
           path: .
 
@@ -346,7 +346,9 @@ jobs:
           if [ -n "$PREV_RUN_ID" ] && [ "$PREV_RUN_ID" != "${{ github.run_id }}" ]; then
             echo "Downloading baseline from run #$PREV_RUN_ID"
             mkdir -p /tmp/baseline
-            gh run download "$PREV_RUN_ID" --dir /tmp/baseline || echo "::warning::Failed to download baseline artifacts"
+            # Only download benchmark result artifacts (prefix: benchmark-),
+            # not profiler/regression traces which can be multi-GB.
+            gh run download "$PREV_RUN_ID" --dir /tmp/baseline --pattern 'benchmark-*' || echo "::warning::Failed to download baseline artifacts"
             BASELINE_COUNT=$(find /tmp/baseline -name '*.json' | wc -l)
             echo "Downloaded $BASELINE_COUNT baseline files"
             echo "baseline_dir=/tmp/baseline" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Add `benchmark-` prefix to benchmark result artifact names
- Filter `download-artifact` and `gh run download` by `benchmark-*` pattern
- Prevents downloading profiler/regression trace artifacts (4GB+) during the summarize step

## Root Cause

The summarize job's baseline download (`gh run download`) fetched ALL artifacts from the previous nightly run, including `regression-traces` (2.1GB + 1.2GB + 912MB). This caused the summarize step to hang for 46 minutes before the job timed out.

## Note

First nightly run after merge will have no baseline match (old artifacts lack the `benchmark-` prefix). Regression detection will resume on the second run.

## Test plan

- [ ] Nightly benchmark runs and summarize step completes quickly
- [ ] Dashboard data is correctly updated