### PR TITLE
feat: Qwen3.5 MTP support, dashboard MTP acceptance, model name normalization

### DIFF
--- a/.claude/commands/add-model.md
+++ b/.claude/commands/add-model.md
@@ -2,30 +2,38 @@
 
 ## Steps
 
-### 1. Evaluate Reuse of Existing Implementations
+### 1. Evaluate Reuse
 
 Current model reuse relationships:
 - `deepseek_v2.py` ← shared by DeepSeek V3, V3.2, GLM-5
 - `deepseek_mtp.py` ← DeepSeek MTP models
 - `qwen3_next_mtp.py` ← Qwen3-Next MTP models
+- `qwen3_5_mtp.py` ← Qwen3.5 MTP (hybrid attention: full + GatedDeltaNet)
 
-If the new model architecture is similar to an existing one, prefer reuse.
+If the new model architecture is similar to an existing one, prefer reuse over new implementation.
 
 ### 2. Implement the Model
 
-Create a model file under `atom/models/`:
+Create a model file under `atom/models/`. Minimum required:
 
 ```python
-# atom/models/new_model.py
 class NewModelForCausalLM(nn.Module):
-    def __init__(self, *, config, ...):
+    # Weight loading mappings (see Step 6)
+    packed_modules_mapping = { ... }
+    weights_mapping = { ... }
+
+    def __init__(self, atom_config: Config, prefix: str = ""):
         ...
 
-    def forward(self, input_ids, positions, intermediate_tensors, ...):
+    def forward(self, input_ids, positions, intermediate_tensors=None, inputs_embeds=None):
         ...
+        return hidden_states
+
+    def compute_logits(self, hidden_states):
+        return self.lm_head(hidden_states)
 ```
 
-Reference existing implementations (e.g., `llama.py`, `qwen3.py`).
+Reference: `llama.py` (simple), `qwen3_5.py` (hybrid attention), `deepseek_v2.py` (MoE + MLA).
 
 ### 3. Register the Model
 
@@ -40,45 +48,173 @@ support_model_arch_dict = {
 
 Optional: register vLLM plugin in `atom/plugin/register.py`.
 
-### 4. Validate
+### 4. Handle Multimodal Wrappers
+
+If the HF model is multimodal (e.g. `Qwen3_5MoeForConditionalGeneration`), create a `TextOnly` wrapper:
+
+```python
+class NewModelTextOnly(nn.Module):
+    weights_mapping = {
+        "model.language_model.": "language_model.model.",
+        "lm_head.": "language_model.lm_head.",
+    }
+    skip_weight_prefixes = ["model.visual."]
+
+    def __init__(self, atom_config, prefix=""):
+        self.language_model = NewModelForCausalLM(atom_config)
+        ...
+```
+
+Register the `TextOnly` variant in `support_model_arch_dict`.
+
+### 5. Weight Loading
+
+The loader uses class-level attributes on the model class to handle checkpoint ↔ model name mismatches:
+
+**`packed_modules_mapping`** — Maps checkpoint's separate weights into fused model parameters:
+```python
+packed_modules_mapping = {
+    "q_proj": ("qkv_proj", "q"),   # checkpoint q_proj → model's fused qkv_proj, shard "q"
+    "k_proj": ("qkv_proj", "k"),
+    "v_proj": ("qkv_proj", "v"),
+    "gate_proj": ("gate_up_proj", 0),
+    "up_proj": ("gate_up_proj", 1),
+    # MoE shared expert gate (if applicable)
+    ".gate.": (".gate.", 0),
+    "shared_expert_gate": ("gate", 1),
+}
+```
+
+**`weights_mapping`** — Bulk substring replacement applied to every weight name:
+```python
+weights_mapping = {
+    "model.language_model.": "language_model.model.",  # multimodal wrapper remap
+    "mtp.": "model.",                                   # MTP checkpoint prefix remap
+}
+```
+
+**`skip_weight_prefixes`** — List of checkpoint name prefixes to skip entirely:
+```python
+skip_weight_prefixes = ["model.visual."]  # skip vision encoder weights
+```
+
+**Quantization exclusion** — Some checkpoint layers are BF16 while the rest are FP8, listed in `quantization_config.modules_to_not_convert`. For the exclusion to work, `ColumnParallelLinear` must receive the correct `prefix` argument so `get_layer_quant_config(prefix)` can match:
+```python
+# Wrong: prefix="" → get_layer_quant_config("") → global FP8 config → BF16 weight cast to FP8 → zeros
+self.fc = ColumnParallelLinear(in_size, out_size, quant_config=quant_config)
+
+# Right: prefix matches modules_to_not_convert entry → BF16 preserved
+self.fc = ColumnParallelLinear(in_size, out_size, quant_config=quant_config, prefix=f"{prefix}.fc")
+```
+
+### 6. Adding MTP (Speculative Decoding) Support
+
+If the model has native MTP layers in its checkpoint:
+
+**a) Create the MTP model** (`atom/models/new_model_mtp.py`):
+
+```python
+class NewModelMTP(nn.Module):
+    packed_modules_mapping = { ... }
+    weights_mapping = {"mtp.": "model."}  # checkpoint mtp.* → model state_dict model.*
+
+    @staticmethod
+    def remap_mtp_weight_name(name):
+        """Filter: return name to load, None to skip."""
+        shared_weight_names = ["embed_tokens", "lm_head"]
+        if name.startswith("mtp."):
+            return name
+        if any(key in name for key in shared_weight_names):
+            return name
+        return None  # skip target model weights
+
+    def __init__(self, atom_config, prefix=""):
+        self.model = NewModelMultiTokenPredictor(atom_config, ...)
+        self.lm_head = ParallelLMHead(...)
+
+    def forward(self, input_ids, positions, hidden_states, ...):
+        ...
+    def compute_logits(self, hidden_states):
+        return self.lm_head(hidden_states)
+```
+
+**b) Register in `eagle.py`**:
+```python
+support_eagle_model_arch_dict = {
+    ...
+    "NewModelMTPArch": "atom.models.new_model_mtp.NewModelMTP",
+}
+```
+
+**c) Register in `config.py`**:
+```python
+# In SpeculativeConfig:
+_MTP_TYPE_MAP = { ..., "new_model_type": "new_model_mtp" }
+_MTP_CONFIG = { ..., "new_model_mtp": ("mtp_num_hidden_layers", "NewModelMTPArch") }
+```
+
+**d) Register in `loader.py`** — If the model uses `weights_mapping` + `remap_mtp_weight_name` (Qwen-style), no loader changes needed. If it uses layer-index based remap (DeepSeek-style), add the model type to `_remap_mtp_weight` or define `remap_mtp_weight_name` as an instance method on the MTP class.
+
+**e) MHA vs MLA attention in propose loop** — If the model uses paged attention (MHA) instead of MLA, the draft propose loop in `eagle.py` needs MHA-specific metadata updates (`block_tables`, `context_lens` instead of `kv_last_page_lens`). Check the `use_mla` branching.
+
+**f) GDN/hybrid attention** — If the model uses GatedDeltaNet + full attention, ensure `GDNAttentionMetadataBuilder.prepare_mtp_decode` handles the draft step metadata update.
+
+### 7. Validate
 
 ```bash
-# Quick smoke test
+# Quick smoke test (no server needed)
 python -m atom.examples.simple_inference --model <model_path> --kv_cache_dtype fp8
 
-# Accuracy validation
+# Server + accuracy
+python -m atom.entrypoints.openai_server --model <model_path> --kv_cache_dtype fp8 -tp <N>
 lm_eval --model local-completions \
   --model_args model=<model>,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False \
-  --tasks gsm8k --num_fewshot 5
+  --tasks gsm8k --num_fewshot 3
+
+# MTP validation (if applicable)
+python -m atom.entrypoints.openai_server --model <model_path> --kv_cache_dtype fp8 -tp <N> --method mtp
+# Check: (1) output is coherent, (2) MTP Stats acceptance rate > 0%, (3) GSM8K score matches non-MTP baseline
 ```
 
-### 5. Add CI Test Entry
+### 8. Add CI Test Entry
 
-Add to `matrix.include` in `.github/workflows/atom-test.yaml`:
-
-```yaml
-- model_name: "New-Model-Name"
-  model_path: "org/model-name"
-  extraArgs: "--kv_cache_dtype fp8 -tp 8"
-  env_vars: ""
-  accuracy_test_threshold: "0.XX"  # set based on actual test results
-  runner: atom-mi355-8gpu.predownload
-  run_on_pr: true
+Add to `.github/benchmark/models_accuracy.json`:
+```json
+{
+  "display": "New-Model-Name",
+  "path": "org/model-name",
+  "prefix": "new-model",
+  "args": "--kv_cache_dtype fp8 -tp 4",
+  "threshold": "0.XX",
+  "baseline": "0.XXXX",
+  "runner": "atom-mi355-8gpu.predownload",
+  "frequency": "pr"
+}
 ```
 
-## Important Notes
+## Checklist
 
-- **NEVER modify** `@support_torch_compile` decorated model files
-- Define custom env vars in `atom/utils/envs.py`
-- Quantization format is auto-detected from HF `config.json` `quantization_config`
-- Supported quant formats: FP8 (per-tensor, per-token), INT8, MXFP4, Quark
+- [ ] Model file created under `atom/models/`
+- [ ] Registered in `support_model_arch_dict`
+- [ ] `packed_modules_mapping` covers all fused weights
+- [ ] `weights_mapping` handles checkpoint ↔ model name differences
+- [ ] BF16 layers have correct `prefix` for quant exclusion
+- [ ] `@support_torch_compile` NOT added unless verified with Dynamo
+- [ ] Smoke test passes (`simple_inference`)
+- [ ] Accuracy validated (`lm_eval gsm8k`)
+- [ ] CI entry added
+- [ ] Recipe created under `recipes/`
+- [ ] If MTP: acceptance rate > 0%, GSM8K matches baseline
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
 | `atom/models/` | Model implementations |
-| `atom/model_engine/model_runner.py` | Model registration (`support_model_arch_dict`) |
-| `atom/plugin/register.py` | vLLM plugin registration |
+| `atom/model_engine/model_runner.py` | Registration (`support_model_arch_dict`), KV cache binding |
+| `atom/spec_decode/eagle.py` | MTP registration (`support_eagle_model_arch_dict`), propose loop |
+| `atom/config.py` | `SpeculativeConfig` MTP type mapping |
+| `atom/model_loader/loader.py` | Weight loading, name remap dispatch |
 | `atom/model_ops/` | AITER kernel wrappers (linear, attention, fused_moe) |
-| `atom/config.py` | Configuration definitions |
+| `atom/plugin/register.py` | vLLM plugin registration |
+| `atom/model_ops/attentions/gdn_attn.py` | GDN attention backend (hybrid models) |

--- a/.claude/commands/debug-guide.md
+++ b/.claude/commands/debug-guide.md
@@ -7,26 +7,33 @@
 | Server won't start / hangs on startup | [Server Setup](#server-setup), [Multi-Process](#multi-process--zmq) |
 | GPU OOM | [GPU / CUDA](#gpu--cuda) |
 | Server hangs during serving | [Multi-Process](#multi-process--zmq), [Scheduler](#scheduler), [NCCL](#nccl--distributed) |
-| Wrong or garbled output | [Sampling & Output](#sampling--output) |
+| Wrong or garbled output | [Sampling & Output](#sampling--output), [Speculative Decoding / MTP](#speculative-decoding--mtp) |
+| Low / zero MTP acceptance rate | [Speculative Decoding / MTP](#speculative-decoding--mtp), [Weight Loading & Quantization](#weight-loading--quantization) |
 | Slow first request / cold start | [Compilation](#compilation) |
 | Low throughput / decode starvation | [Scheduler](#scheduler) |
-| Low speculative decode acceptance | [Speculative Decoding / MTP](#speculative-decoding--mtp) |
 | NCCL hang / timeout | [NCCL](#nccl--distributed) |
 | Weight loading failure | [Weight Loading & Quantization](#weight-loading--quantization) |
 
-> **First step for any model execution issue:** Run with `--enforce-eager` to disable compilation and CUDA graphs. This eliminates an entire class of problems.
+> **First step for any model execution issue:** Run with `--level 0 --enforce-eager` to disable both torch.compile and CUDA graphs. This eliminates an entire class of problems. (`--enforce-eager` alone only disables CUDA graphs; Dynamo tracing still runs.)
+
+## General Debugging Methodology
+
+1. **Isolate with minimal tests.** Don't repeatedly restart the server to test hypotheses. Write standalone Python scripts that call the specific kernel/function in question, comparing spec vs non-spec or different input shapes. This is faster and produces definitive results.
+2. **Compare known-good vs broken.** Use the same input prompt with `--level 0 --enforce-eager`. Dump logits argmax and hidden-state norms at each stage. The first point of divergence is the bug.
+3. **Check weight loading before checking model logic.** Print `module.weight.dtype` and `module.weight.float().norm()` at runtime. A `norm=0.0` or wrong `dtype` means loading issue, not inference bug.
+4. **Read the safetensors index, not individual shards.** Weights may be spread across 90+ shards. Use `model.safetensors.index.json` to locate specific weights.
+5. **Reference existing implementations.** Before assuming a bug, check if a similar model (e.g. Qwen3-Next for Qwen3.5, MiMo-V2-Flash for MHA MTP) works. If it does, diff the code paths.
 
 ## Server Setup
 
-- **[CRITICAL] Verify server is truly running with GPU loaded** — `curl /health` returning OK is NOT sufficient. A stale process or partial startup can respond to HTTP while the model is not loaded. Always verify with:
+- **[CRITICAL] Verify server is truly running with GPU loaded** — `curl /health` returning OK is NOT sufficient. Always verify with:
   ```bash
-  # Both checks must pass:
   curl -sf http://localhost:8000/v1/models          # API responds with model name
   rocm-smi --showmemuse | grep "GPU Memory Allocated"  # VRAM% > 0
   ```
-- **Set** `AITER_LOG_LEVEL=WARNING` to suppress aiter kernel-level log flooding (this is an aiter library env var, not ATOM's)
+- **Set** `AITER_LOG_LEVEL=WARNING` to suppress aiter kernel-level log flooding
 - **Kill old servers before starting new ones.** Check `rocm-smi` for VRAM usage — leftover processes hold GPU memory
-- **Detect server hangs:** Use polling (`grep -q` in a loop with timeout), never blocking `tail -f | grep` which hangs indefinitely if the process crashes
+- **Detect server hangs:** Use polling (`grep -q` in a loop with timeout), never blocking `tail -f | grep`
 - **Always delete `gpucore.*` files** when GPU hang occurs
 
 ## Observability
@@ -39,88 +46,92 @@
 
 ## Instrumentation Rules
 
-- **[CRITICAL] Never modify `@support_torch_compile` decorated models.** This breaks Dynamo tracing even with `--enforce-eager`. Find all affected models: `grep -rn "@support_torch_compile" atom/models/`
+- **[CRITICAL] Never modify `@support_torch_compile` decorated models.** This breaks Dynamo tracing. Find all: `grep -rn "@support_torch_compile" atom/models/`
   - Currently decorated: `deepseek_v2.py`, `deepseek_mtp.py`, `qwen3.py`, `qwen3_moe.py`, `qwen3_next.py`, `llama.py`, `mixtral.py`, `glm4_moe.py`, `gpt_oss.py`
-- **Instrument at call sites instead.** Add checks before/after `self.model()` in callers (e.g., `EagleProposer.propose()` for MTP, `ModelRunner.run_model()` for the target model)
+- **[CRITICAL] `--enforce-eager` and `--level 0` are independent.** `--enforce-eager` disables CUDA graphs only. `--level 0` disables torch.compile only. Debug instrumentation requires **both**: `--level 0 --enforce-eager`
+- **[CRITICAL] Do NOT add debug code in `run_model()`.** It runs during CUDA graph warmup within a Dynamo-traced context. Class variables and `forward_context` attribute access trigger `InternalTorchDynamoError`. **Put debug code in `forward()` instead** (has `@torch.inference_mode()`), guarded by `not batch.is_dummy_run`
+- **Instrument at call sites.** Add checks in `EagleProposer.propose()` for MTP, or `ModelRunner.forward()` for target model — never inside compiled model code
 - **Clear compile cache after accidental modification:** `rm -rf ~/.cache/atom/torch_compile_cache/`
 
 ## GPU / CUDA
 
-- **[COMMON] OOM during startup:** Reduce `max_num_seqs` or `max_num_batched_tokens`. Check `rocm-smi` for fragmentation. Run `torch.cuda.empty_cache()` between attempts
+- **[COMMON] OOM during startup:** Reduce `max_num_seqs` or `max_num_batched_tokens`. Check `rocm-smi` for fragmentation
 - **GPU memory fault (SIGBUS/SIGSEGV):** Trace the bad index backward — check `block_tables`, `kv_indices`, `slot_mapping` shapes and bounds
-- **[COMMON] CUDA graph capture failures:** Happen during `ModelRunner.capture_cudagraph()`. Sizes are `[1, 2, 4, 8, ..., max_num_seqs]`. If capture fails at a specific size, it may exceed KV cache capacity. **Fix:** Use `--enforce-eager` to bypass
-- **CUDA graph replay mismatch:** `CUDAGraphWrapper` checks input tensor addresses match between capture and replay. Address mismatch means input buffers changed between capture and replay. **Fix:** Check `allocate_forward_vars()` and `copy_and_call()` in attention backends
-- **Stale graph pool:** After model changes, old graphs reference freed memory. Always restart the server; don't hot-reload
+- **[COMMON] CUDA graph capture failures:** Use `--enforce-eager` to bypass. Sizes are `[1, 2, 4, 8, ..., max_num_seqs]`
+- **CUDA graph replay mismatch:** Input tensor addresses must match between capture and replay. Check `allocate_forward_vars()` and `copy_and_call()` in attention backends
+- **Stale graph pool:** After model changes, always restart the server; don't hot-reload
 
 ## Compilation
 
-- **Levels:** 0=eager, 1=dynamo-eager, 2=dynamo-inductor, 3=piecewise (default). Use `--enforce-eager` for level 0
+- **Levels:** 0=eager (no torch.compile), 1=dynamo-eager, 2=dynamo-inductor, 3=piecewise (default). `--level 0` disables torch.compile; `--enforce-eager` disables CUDA graphs. For full eager mode use both: `--level 0 --enforce-eager`
 - **Cold start slow?** Cache key = config hash + traced code hash + compiler hash. **Any** change invalidates. Clear: `rm -rf ~/.cache/atom/torch_compile_cache/`
-- **"vLLM failed to compile the model":** Usually corrupted cache. **Fix:** `rm -rf ~/.cache/atom/torch_compile_cache/` and retry
-- **PyTorch 2.8+** uses `InductorStandaloneAdaptor`; older uses `InductorAdaptor`. See `make_compiler()` in `backends.py`
-- **[RARE] Piecewise compilation stall:** `PiecewiseBackend` lazily compiles new batch sizes on first encounter. **Diagnose:** Check logs for "Compiling a graph for shape" messages. **Mitigate:** Pre-populate `compile_sizes` with expected batch sizes
+- **"vLLM failed to compile the model":** Usually corrupted cache. Clear and retry
+- **[RARE] Piecewise compilation stall:** `PiecewiseBackend` lazily compiles new batch sizes on first encounter. Check logs for "Compiling a graph for shape" messages
 
 ## Multi-Process / ZMQ
 
 - **Architecture:** `CoreManager` → ZMQ → `EngineCore` (per DP rank) → `AsyncIOProcManager` → `ModelRunner` (per TP rank)
-- **[COMMON] DP hang on startup:** EngineCore sends `READY` only after model load + CUDA graph capture. `CoreManager._wait_for_all_ready_signals()` blocks until all ranks report. If one rank OOMs, all hang. **Fix:** Check per-rank logs
-- **ZMQ socket types:** Input: `ROUTER`→`DEALER`. Output: `PUSH`→`PULL`. Pickle-serialized `Sequence` objects
-- **Process crash silent failure:** `AsyncIOProcManager` monitors children. If `ModelRunner` dies, `EXECUTOR_FAILED` is sent. Check if `runner_mgr.call_func()` returns or hangs
-- **DP round-robin stuck:** `CoreManager._rr_counter` dispatches round-robin. If one EngineCore is slow, requests queue. Check per-rank scheduler state
-- **Multiprocessing start method:** Must be `spawn` (set in `engine_core_mgr.py:58` and `:462`). `fork` causes CUDA re-init issues
+- **[COMMON] DP hang on startup:** EngineCore sends `READY` only after model load + CUDA graph capture. If one rank OOMs, all hang. **Fix:** Check per-rank logs
+- **Process crash silent failure:** `AsyncIOProcManager` monitors children. If `ModelRunner` dies, `EXECUTOR_FAILED` is sent
+- **Multiprocessing start method:** Must be `spawn`. `fork` causes CUDA re-init issues
 
 ## KV Cache / Block Manager
 
 - **[COMMON] "Failed to allocate kv cache":** `num_blocks` returned 0. Model + KV cache don't fit in VRAM. **Fix:** Reduce `max_num_seqs` or use `--kv_cache_dtype fp8`
-- **Block exhaustion during serving:** Scheduler preempts the last running sequence when blocks run out. Monitor `len(free_block_ids)` in `BlockManager`
-- **[RARE] Prefix caching hash collision:** Uses `xxhash64` with chain hashing. Collisions cause cache miss (performance only, not correctness). **Diagnose:** Monitor `BlockManager.allocate()` for `token_ids` mismatch fallthrough
-- **Block leak (ref_count never reaches 0):** If `deallocate()` is never called, blocks leak. **Fix:** Verify `seq.block_table` is cleared on sequence completion
-- **Mamba block table:** Mamba-like models use separate `mamba_block_table`. No prefix caching support
+- **Block exhaustion during serving:** Scheduler preempts last running sequence when blocks run out
+- **Block leak (ref_count never reaches 0):** Verify `seq.block_table` is cleared on sequence completion
+- **Mamba/GDN block table:** Hybrid models use separate `mamba_block_table` for linear attention state. No prefix caching support
 
 ## Scheduler
 
-- **Prefill-first policy:** Prefill always runs before decode. High request rate → decode starvation. **Diagnose:** Monitor `scheduler.waiting` vs `scheduler.running` queue lengths
+- **Prefill-first policy:** Prefill always runs before decode. High request rate → decode starvation
 - **Preemption:** KV cache exhausted → scheduler preempts last running sequence. Excessive preemption = insufficient KV cache blocks
-- **Batch size mismatch with CUDA graph:** Scheduler pads to nearest captured graph size. If batch exceeds largest captured size, falls back to eager. Check `graph_bs` in `ModelRunner`
+- **Batch size mismatch with CUDA graph:** Scheduler pads to nearest captured graph size. If batch exceeds largest captured size, falls back to eager
 
 ## ForwardContext
 
-- **"Forward context is not set":** `set_forward_context()` was not called before model forward. Lifecycle bug — check `ModelRunner` forward path in `model_runner.py`
-- **[COMMON] DP metadata wrong:** `DPMetadata.make()` does CPU `all_reduce` via Gloo. If one rank has 0 tokens, `local_size` is clamped to 1. Mismatch causes NCCL hang. **Diagnose:** Log `num_tokens_across_dp` before `DPMetadata.make()` at `forward_context.py`. Check if any rank shows 0 tokens unexpectedly
-- **Stale context after exception:** If forward throws, `reset_forward_context()` may not be called. **Fix:** Always wrap forward in try/finally
+- **"Forward context is not set":** `set_forward_context()` was not called before model forward. Lifecycle bug — check `ModelRunner` forward path
+- **[COMMON] DP metadata wrong:** `DPMetadata.make()` does CPU `all_reduce` via Gloo. If one rank has 0 tokens, mismatch causes NCCL hang
+- **Stale context after exception:** If forward throws, `reset_forward_context()` may not be called. Wrap forward in try/finally
 
 ## Speculative Decoding / MTP
 
-- **Low acceptance rate:** Check `SpecStats` in scheduler — logs acceptance distribution every `log_interval * mtp_k` draft tokens (default `log_interval=1000`). Distribution shows how many draft tokens (0..k) were accepted per step
-- **Draft model mismatch:** `EagleProposer` calls the MTP model. If draft weights are stale/mismatched, acceptance drops to near-zero. **Fix:** Verify `--speculative-model` path
-- **Rejection sampler issues:** `RejectionSampler` compares target vs draft logits. NaN/Inf in logits causes silent rejection of all tokens. **Diagnose:** Add `torch.isnan(logits).any()` checks at `ModelRunner` call sites
+- **Low acceptance rate:** Check `SpecStats` in scheduler logs. Distribution shows how many draft tokens (0..k) were accepted per step
+- **0% acceptance with correct output:** The MTP model produces all-zero hidden states → weight loading issue. **Diagnose:** Print `logits[0].float().norm()` in `EagleProposer.propose()`. If `0.0`:
+  1. Check `fc.weight` dtype — BF16 checkpoint weight may be silently quantized to FP8 if `ColumnParallelLinear` lacks the correct `prefix` argument (see [Weight Loading](#weight-loading--quantization))
+  2. Check `loaded_weights_record` from `load_model()` — is the weight present?
+  3. Check `_share_if_not_loaded` log for `lm_head` sharing
+- **Garbled output with MTP (GDN hybrid models):** Compare logits at position 0 between MTP (q_len=2) and non-MTP (q_len=1) using `--level 0 --enforce-eager`. If they differ → GDN kernel bug. Write standalone tests for `causal_conv1d_update` and `fused_recurrent_gated_delta_rule` comparing spec vs non-spec at token 0. **Do not suspect `pa_fwd_asm`** — it handles causal masking correctly with `max_qlen > 1` (verified)
+- **MTP crash in propose loop (mtp_k > 1):** The propose loop updates attention metadata per draft step. MHA and MLA need different fields (`block_tables`/`context_lens` vs `kv_last_page_lens`). Check `use_mla` branching in `eagle.py`. Ref: PR #560 (MiMo-V2-Flash)
+- **Rejection sampler issues:** NaN/Inf in logits causes silent rejection of all tokens
 
 ## Sampling & Output
 
-- **Wrong/garbled output:** Check tokenizer BOS/EOS token IDs (`config.bos_token_id`, `config.eos_token_id`). Verify `InputOutputProcessor` in `llm_engine.py`
-- **Unexpected EOS:** Check `SamplingParams.stop` and `stop_token_ids` in `sampling_params.py`
+- **Wrong/garbled output:** Check tokenizer BOS/EOS token IDs. Verify `InputOutputProcessor` in `llm_engine.py`
+- **Unexpected EOS:** Check `SamplingParams.stop` and `stop_token_ids`
 - **Temperature/top-p issues:** Check `Sampler` in `model_ops/sampler.py`
 
 ## Weight Loading & Quantization
 
-- **Shape mismatch on load:** Check `load_model()` in `model_loader/loader.py`. Verify HF `config.json` `architectures` field matches `support_model_arch_dict`
-- **Quant format issues:** Auto-detected from HF `config.json` `quantization_config`. Supported: FP8 (per-tensor, per-token), INT8, MXFP4, Quark
-- **FP8 KV cache:** Ensure `--kv_cache_dtype fp8` is set consistently
+- **Shape mismatch on load:** Verify HF `config.json` `architectures` field matches `support_model_arch_dict`
+- **Quant format issues:** Auto-detected from `quantization_config`. Supported: FP8, INT8, MXFP4, Quark
+- **BF16 weight silently quantized to FP8:** Happens when `ColumnParallelLinear` is created without the correct `prefix` — `get_layer_quant_config("")` returns the global FP8 config instead of checking `modules_to_not_convert`. **Diagnose:** Print `module.weight.dtype` at runtime. **Fix:** Pass `prefix=f"{prefix}.fc"`. Don't remove `quant_config`; the quant system handles BF16 correctly when prefix matches
+- **Weight not found in checkpoint:** Check `model.safetensors.index.json` for weight locations across shards. Inspecting a single shard is insufficient
+- **MTP weight remap:** Each MTP model class defines `remap_mtp_weight_name` and `weights_mapping`. Loader calls `model.remap_mtp_weight_name(name)` to filter, then applies `weights_mapping` for name transformation
 
 ## NCCL / Distributed
 
 - **NCCL hang:** Set `NCCL_DEBUG=INFO` for verbose logs. Common cause: one rank diverges in collective op count
-- **NCCL timeout:** Set `NCCL_TIMEOUT` env var (default 1800s). Check rank synchronization
-- **DP Gloo all_reduce hang:** Check `DPMetadata.num_tokens_across_dp()` in `forward_context.py`. Uses `get_dp_group().cpu_group`
-- **TP NCCL init failure:** Check `init_dist_env()` call in `ModelRunner`. Verify `MASTER_ADDR` and `MASTER_PORT`
-- **Expert parallelism hang:** Check MORI all-to-all communication layer. Verify `--enable-expert-parallel` flag. Check `FusedMoE` in `model_ops/moe.py` for expert load distribution
+- **NCCL timeout:** Set `NCCL_TIMEOUT` env var (default 1800s)
+- **TP NCCL init failure:** Check `init_dist_env()`. Verify `MASTER_ADDR` and `MASTER_PORT`
+- **Expert parallelism hang:** Check MORI all-to-all communication layer. Verify `--enable-expert-parallel` flag
 
 ## Testing & Validation
 
-- **Quick smoke test:** `python -m atom.examples.simple_inference --model <model> --kv_cache_dtype fp8` — runs 4 prompts with profiling, prints MTP stats. Good for verifying end-to-end inference, sampling, and speculative decoding in one shot
+- **Quick smoke test:** `python -m atom.examples.simple_inference --model <model> --kv_cache_dtype fp8` — runs 4 prompts with profiling, prints MTP stats
 - **Unit tests:** `pytest tests/test_scheduler.py -v`
-- **Accuracy:** `lm_eval --model local-completions --tasks gsm8k --num_fewshot 5` (see CLAUDE.md for full command)
-- **Test stubs:** `conftest.py` mocks GPU/ZMQ/HF dependencies — unit tests run without a GPU
+- **Accuracy:** `lm_eval --model local-completions --tasks gsm8k --num_fewshot 5`
+- **Kernel isolation test:** To verify a specific kernel (e.g. `causal_conv1d_update`, `pa_fwd_asm`), write a standalone script that creates minimal inputs, calls the kernel with both spec and non-spec parameters, and compares outputs. This is the fastest way to isolate kernel bugs without server restarts
 
 ## Quick Reference
 
@@ -136,7 +147,8 @@
 | Compilation | `utils/backends.py` | VllmBackend, CompilerManager |
 | CUDA graph | `utils/cuda_graph.py` | CUDAGraphWrapper |
 | MTP proposer | `spec_decode/eagle.py` | Safe to instrument |
-| MTP model | `models/deepseek_mtp.py` | **Compiled — do NOT modify** |
+| MTP model (DeepSeek) | `models/deepseek_mtp.py` | **Compiled — do NOT modify** |
+| MTP model (Qwen3.5) | `models/qwen3_5_mtp.py` | **Compiled — do NOT modify** |
 | Target model | `models/deepseek_v2.py` | **Compiled — do NOT modify** |
 | MoE | `model_ops/moe.py` | FusedMoE, expert parallelism |
 | Sampler | `model_ops/sampler.py` | Token sampling |

--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -20,7 +20,7 @@
     "env_vars": ""
   },
   {
-    "display": "DeepSeek-R1-0528 MXFP4",
+    "display": "DeepSeek-R1-0528-MXFP4",
     "path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
     "prefix": "deepseek-r1-0528-mxfp4",
     "args": "--kv_cache_dtype fp8 -tp 4",
@@ -30,7 +30,7 @@
     "env_vars": ""
   },
   {
-    "display": "DeepSeek-R1-0528 MXFP4-MTP3",
+    "display": "DeepSeek-R1-0528-MXFP4 MTP3",
     "path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
     "prefix": "deepseek-r1-0528-mxfp4",
     "args": "--kv_cache_dtype fp8 -tp 4 --method mtp --num-speculative-tokens 3",
@@ -106,6 +106,16 @@
     "args": "--kv_cache_dtype fp8 -tp 4",
     "bench_args": "",
     "suffix": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "env_vars": ""
+  },
+  {
+    "display": "Qwen3.5-397B-A17B-FP8 MTP3",
+    "path": "Qwen/Qwen3.5-397B-A17B-FP8",
+    "prefix": "qwen35-397b-fp8",
+    "args": "--kv_cache_dtype fp8 -tp 4 --method mtp --num-speculative-tokens 3",
+    "bench_args": "",
+    "suffix": "-mtp3",
     "runner": "atom-mi355-8gpu.predownload",
     "env_vars": ""
   },

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -192,6 +192,18 @@
     "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
   },
   {
+    "model_name": "Qwen3.5-397B-A17B-FP8 MTP3",
+    "model_path": "Qwen/Qwen3.5-397B-A17B-FP8",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 4 --method mtp --num-speculative-tokens 3",
+    "env_vars": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "test_level": "main",
+    "accuracy_threshold": 0.85,
+    "accuracy_baseline": 0.9538,
+    "accuracy_baseline_model": "Qwen/Qwen3.5-397B-A17B-FP8",
+    "_baseline_note": "Same base model as Qwen3.5-397B-A17B-FP8; MTP3 speculative decoding"
+  },
+  {
     "model_name": "Qwen3.5-397B-A17B-MXFP4",
     "model_path": "amd/Qwen3.5-397B-A17B-MXFP4",
     "extraArgs": "--kv_cache_dtype fp8 -tp 4",

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -345,6 +345,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha384-bs/nf9FbdNouRbMiFcrcZfLXYPKiPaGVGplVbv7dLGECccEXDW+S3zjqSKR5ZEaD" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js" integrity="sha384-y49Zu59jZHJL/PLKgZPv3k2WI9c0Yp3pWB76V8OBVCb0QBKS8l4Ff3YslzHVX76Y" crossorigin="anonymous"></script>
 <script src="data.js"></script>
+<script src="models_map.js"></script>
 <script>
 'use strict';
 (function() {
@@ -503,6 +504,17 @@ const REGRESSION_CRITICAL = 0.10;  // 10% → critical
    ================================================================ */
 const rawData = window.BENCHMARK_DATA;
 
+// Normalize legacy model names using HF-path->display mapping from models_map.js
+const _displayMap = window.MODELS_DISPLAY_MAP || {};
+const _displayEntries = Object.entries(_displayMap).sort((a, b) => b[0].length - a[0].length);
+function normalizeModelName(name) {
+  const lc = name.toLowerCase();
+  for (const [key, display] of _displayEntries) {
+    if (lc === key) return display;
+  }
+  return name;
+}
+
 function parseBenchName(name) {
   let backend = 'ATOM';
   let rawName = name;
@@ -514,11 +526,17 @@ function parseBenchName(name) {
   if (backend === 'OOT') backend = 'ATOM-vLLM';
   // Accuracy entries: "ModelName accuracy (GSM8K)" — (.+?) for multi-word model names
   let m = rawName.match(/^(.+?)\s+accuracy\s+\((\w+)\)$/);
-  if (m) return { backend, model: m[1], metric: 'accuracy', unit: m[2], isAccuracy: true };
+  if (m) return { backend, model: normalizeModelName(m[1]), metric: 'accuracy', unit: m[2], isAccuracy: true };
+  // MTP acceptance: "ModelName MTP acceptance (%)"
+  m = rawName.match(/^(.+?)\s+MTP acceptance\s+\((%)\)$/);
+  if (m) return { backend, model: normalizeModelName(m[1]), metric: 'MTP acceptance', unit: m[2] };
+  // avg toks/fwd: "ModelName avg toks/fwd (tok/fwd)"
+  m = rawName.match(/^(.+?)\s+avg toks\/fwd\s+\((.+)\)$/);
+  if (m) return { backend, model: normalizeModelName(m[1]), metric: 'avg toks/fwd', unit: m[2] };
   m = rawName.match(/^(\S+)\s+(\d+\/\d+)\s+c=(\d+)\s+(.+?)\s*\((.+)\)$/);
-  if (m) return { backend, model: m[1], islOsl: m[2], conc: +m[3], metric: m[4].trim(), unit: m[5] };
+  if (m) return { backend, model: normalizeModelName(m[1]), islOsl: m[2], conc: +m[3], metric: m[4].trim(), unit: m[5] };
   m = rawName.match(/^(\S+)\s+(\d+\/\d+)\s+c=(\d+)\s+(_gpu_count)$/);
-  if (m) return { backend, model: m[1], islOsl: m[2], conc: +m[3], metric: '_gpu_count', unit: '' };
+  if (m) return { backend, model: normalizeModelName(m[1]), islOsl: m[2], conc: +m[3], metric: '_gpu_count', unit: '' };
   return null;
 }
 
@@ -530,7 +548,7 @@ function parseRunConfigs(run) {
   const configs = {}; // key: "backend|model|isl/osl|conc"
   for (const b of run.benches) {
     const p = parseBenchName(b.name);
-    if (!p || p.isAccuracy || p.islOsl === '0/0') continue;
+    if (!p || p.isAccuracy || !p.islOsl || p.islOsl === '0/0') continue;
     const key = `${p.backend}|${p.model}|${p.islOsl}|${p.conc}`;
     if (!configs[key]) configs[key] = { backend: p.backend, model: p.model, islOsl: p.islOsl, conc: p.conc, commit: run.commit, date: run.date, runUrl: '' };
     configs[key][p.metric] = b.value;
@@ -591,10 +609,27 @@ const regressions = detectRegressions();
 
 /* ---- Accuracy data ---- */
 const accuracyMap = {}; // "backend|model" -> [{date, commit, score, runUrl, threshold}, ...]
+const mtpAcceptanceMap = {}; // "backend|model" -> [{date, commit, rate, avgToks, runUrl}, ...]
 for (const run of allRuns) {
   for (const b of run.benches) {
     const p = parseBenchName(b.name);
-    if (!p || !p.isAccuracy) continue;
+    if (!p) continue;
+    // MTP acceptance entries from perf benchmark
+    if (p.metric === 'MTP acceptance') {
+      const mkey = `${p.backend}|${p.model}`;
+      if (!mtpAcceptanceMap[mkey]) mtpAcceptanceMap[mkey] = [];
+      const mEntry = { date: run.date, commit: run.commit, rate: b.value, runUrl: '' };
+      if (b.extra) { const rm = b.extra.match(/Run:\s*(https:\/\/\S+)/); if (rm) mEntry.runUrl = rm[1]; }
+      mtpAcceptanceMap[mkey].push(mEntry);
+      continue;
+    }
+    if (p.metric === 'avg toks/fwd') {
+      const mkey = `${p.backend}|${p.model}`;
+      const arr = mtpAcceptanceMap[mkey];
+      if (arr && arr.length > 0) { const last = arr[arr.length - 1]; if (last.date === run.date) last.avgToks = b.value; }
+      continue;
+    }
+    if (!p.isAccuracy) continue;
     const key = `${p.backend}|${p.model}`;
     if (!accuracyMap[key]) accuracyMap[key] = [];
     const entry = { date: run.date, commit: run.commit, score: b.value, runUrl: '' };
@@ -620,6 +655,7 @@ for (const run of allRuns) {
 for (const history of Object.values(accuracyMap)) {
   history.sort((a, b) => b.date - a.date);
 }
+for (const h of Object.values(mtpAcceptanceMap)) h.sort((a, b) => b.date - a.date);
 const latestAccuracy = {};
 for (const [key, history] of Object.entries(accuracyMap)) {
   if (!history.length) continue;
@@ -727,12 +763,14 @@ function fmtIslOsl(s) { return s.replace(/\d+/g, n => +n >= 1024 ? parseFloat((+
 
 // Model family grouping: "DeepSeek-R1-0528-mtp3" → family "DeepSeek-R1-0528", variant "mtp3"
 function modelFamily(name) {
-  const m = name.match(/^([A-Za-z][\w.]*(?:-[A-Za-z0-9.]+){1,3}?)(?:[-_](?:mtp|MTP|moe|MoE|MXFP|mxfp).*)?$/);
-  return m ? m[1] : name;
+  // Strip space-separated quant/MTP suffixes (e.g. "DeepSeek-R1-0528 MXFP4 MTP3" -> "DeepSeek-R1-0528")
+  const base = name.replace(/(\s+(?:MTP|MXFP|FP)\d*)+$/i, '');
+  const m = base.match(/^([A-Za-z][\w.]*(?:-[A-Za-z0-9.]+){1,6}?)(?:[-_](?:mtp|MTP|moe|MoE|MXFP|mxfp|FP|fp)\d*.*)?$/);
+  return m ? m[1] : base;
 }
 function modelVariant(name) {
   const fam = modelFamily(name);
-  return name === fam ? 'base' : name.slice(fam.length).replace(/^[-_]+/, '');
+  return name === fam ? 'base' : name.slice(fam.length).replace(/^[-_\s]+/, '');
 }
 const MERGED_KIMI_TRADEOFF_FAMILY = 'Kimi-K2&K2.5-MXFP4';
 function tradeoffFamilyInfo(name) {
@@ -1188,8 +1226,7 @@ function renderKPICards() {
   const atRiskCount = accEntries.filter(([, a]) => a.threshold && a.score >= 0.1 && a.score >= a.threshold && (a.score - a.threshold) < 0.005).length;
   const healthyCount = accEntries.filter(([, a]) => a.threshold && a.score >= 0.1 && a.score >= a.threshold && (a.score - a.threshold) >= 0.005).length;
   const accCardClass = failCount > 0 ? 'alert clickable' : atRiskCount > 0 ? 'alert-warning clickable' : (accEntries.length > 0 ? 'ok clickable' : 'clickable');
-  const accSub = accEntries.length === 0
-    ? (Object.keys(latestAccuracy).length === 0 ? 'No accuracy data' : 'No rows match Backend/Model filters')
+  const accSub = accEntries.length === 0 ? 'No accuracy data'
     : failCount > 0 ? `${failCount} failed` + (atRiskCount > 0 ? ` · ${atRiskCount} at risk` : '')
     : atRiskCount > 0 ? `${healthyCount} healthy · ${atRiskCount} at risk`
     : 'All healthy';
@@ -2473,8 +2510,8 @@ function readFromHash() {
 /** Accuracy keys are "backend|model"; ISL/conc do not apply to GSM8K rows. */
 function filteredAccuracyEntries() {
   return Object.entries(latestAccuracy).filter(([key]) => {
-    const [backend, model] = key.split('|');
-    return state.filters.backends.includes(backend) && state.filters.models.includes(model);
+    const [backend] = key.split('|');
+    return state.filters.backends.includes(backend);
   });
 }
 
@@ -2501,7 +2538,7 @@ function renderAccuracyTab() {
           <th class="num">flexible-extract</th><th class="num">strict-match</th>
           <th class="num">Baseline</th><th class="num">Recovery</th>
           <th class="num">Threshold</th><th class="num">Margin</th>
-          <th>Trend</th><th>Fewshot</th><th>Last Tested</th><th>Run</th>
+          <th>Trend</th><th>Fewshot</th><th class="num">MTP Accept%</th><th class="num">toks/fwd</th><th>Last Tested</th><th>Run</th>
         </tr></thead>
         <tbody>`;
 
@@ -2532,6 +2569,11 @@ function renderAccuracyTab() {
     const dateStr = fmtDate(acc.date);
     const href = safeHref(acc.runUrl);
 
+    // MTP acceptance lookup — exact key match
+    let mtpRate = null, mtpToks = null, mtpHistory = null;
+    const mh = mtpAcceptanceMap[key];
+    if (mh && mh.length > 0) { mtpRate = mh[0].rate; mtpToks = mh[0].avgToks; mtpHistory = mh; }
+
     html += `
       <tr class="${rowClass}" data-acc-key="${escHTML(key)}">
         <td style="white-space:nowrap;font-weight:600">${escHTML(backend)}</td>
@@ -2544,15 +2586,23 @@ function renderAccuracyTab() {
         <td class="num"><span class="${marginClass}">${hasThreshold ? (margin >= 0 ? '+' : '') + fmtNum(margin, 4) : '—'}</span></td>
         <td>${trendHTML(acc.score, prev?.score, false)}</td>
         <td class="num">${acc.fewshot != null ? acc.fewshot : '—'}</td>
+        <td class="num">${mtpRate != null ? '<span style="color:var(--accent-green)">' + fmtNum(mtpRate, 1) + '%</span>' : '—'}</td>
+        <td class="num">${mtpToks != null ? fmtNum(mtpToks, 2) : '—'}</td>
         <td>${dateStr}</td>
         <td>${href ? `<a href="${escHTML(href)}" target="_blank" rel="noopener noreferrer">→</a>` : '—'}</td>
       </tr>`;
 
     // Detail row with inline trend chart
     const canvasId = 'acc-trend-' + key.replace(/[^a-zA-Z0-9]/g, '_');
-    html += `<tr class="detail-row" data-detail-acc="${escHTML(key)}"><td colspan="12"><div class="detail-inner" style="display:flex;gap:var(--gap-lg);flex-wrap:wrap;align-items:flex-start">`;
-    // Left: trend chart
-    html += `<div style="flex:1;min-width:280px"><canvas id="${canvasId}" style="height:180px"></canvas></div>`;
+    html += `<tr class="detail-row" data-detail-acc="${escHTML(key)}"><td colspan="14"><div class="detail-inner" style="display:flex;gap:var(--gap-lg);flex-wrap:wrap;align-items:flex-start">`;
+    // Left: charts stacked vertically (accuracy trend + MTP acceptance)
+    const mtpCanvasId = 'mtp-trend-' + key.replace(/[^a-zA-Z0-9]/g, '_');
+    html += `<div style="flex:1;min-width:280px;display:flex;flex-direction:column;gap:var(--gap-md)">`;
+    html += `<div><canvas id="${canvasId}" style="height:180px"></canvas></div>`;
+    if (mtpHistory && mtpHistory.length > 0) {
+      html += `<div data-mtp-history="${escHTML(JSON.stringify(mtpHistory.slice(0, 30)))}"><canvas id="${mtpCanvasId}" style="height:180px"></canvas></div>`;
+    }
+    html += `</div>`;
     // Right: info
     html += `<div style="flex:0 0 auto;min-width:200px">`;
     if (acc.baselineModel || acc.baselineNote) {
@@ -2593,7 +2643,10 @@ function renderAccuracyTab() {
       detail.classList.toggle('expanded');
       row.classList.toggle('row-open');
       if (expanding && !accCharts[key]) {
-        requestAnimationFrame(() => renderAccuracyMiniChart(key, accCharts));
+        requestAnimationFrame(() => {
+          renderAccuracyMiniChart(key, accCharts);
+          renderMtpAcceptanceMiniChart(key);
+        });
       }
     });
   });
@@ -2751,6 +2804,87 @@ function renderAccuracyMiniChart(key, chartCache) {
         const prevEntry = pointIdx > 0 ? sorted[pointIdx - 1] : null;
         hideAccuracyHover();
         showAccuracyPopover(key, accEntry, prevEntry);
+      },
+    },
+  });
+}
+
+function renderMtpAcceptanceMiniChart(key) {
+  const mtpCanvasId = 'mtp-trend-' + key.replace(/[^a-zA-Z0-9]/g, '_');
+  const canvas = document.getElementById(mtpCanvasId);
+  if (!canvas) return;
+  const wrapper = canvas.parentElement;
+  let history;
+  try { history = JSON.parse(wrapper.dataset.mtpHistory || '[]'); } catch { return; }
+  if (!history.length) return;
+  const sorted = [...history].sort((a, b) => a.date - b.date);
+  const labels = sorted.map(h => { const dt = new Date(h.date); return `${dt.getMonth()+1}/${dt.getDate()}`; });
+  const datasets = [{
+    label: 'Acceptance %', data: sorted.map(h => h.rate),
+    borderColor: 'hsl(145,63%,49%)', backgroundColor: 'hsla(145,63%,49%,0.15)',
+    borderWidth: 2, pointRadius: 4, pointHoverRadius: 6, tension: 0.3, fill: true, yAxisID: 'y',
+  }];
+  const hasAvgToks = sorted.some(h => h.avgToks != null);
+  if (hasAvgToks) {
+    datasets.push({
+      label: 'avg toks/fwd', data: sorted.map(h => h.avgToks ?? null),
+      borderColor: 'hsl(210,80%,60%)', backgroundColor: 'hsla(210,80%,60%,0.1)',
+      borderWidth: 1.5, borderDash: [4,3], pointRadius: 3, tension: 0.3, fill: false, yAxisID: 'y2',
+    });
+  }
+  new Chart(canvas, {
+    type: 'line', data: { labels, datasets },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: {
+        legend: { labels: { color: C_LEGEND, font: { size: 10 }, boxWidth: 10 } },
+        title: { display: true, text: 'MTP Acceptance Rate', color: C_LEGEND, font: { size: 12 } },
+        tooltip: { ...chartTooltipOpts() },
+        datalabels: { display: false },
+      },
+      scales: {
+        x: { grid: chartGridOpts(), ticks: { color: C_TICK, font: { size: 10 } } },
+        y: { position: 'left', grid: chartGridOpts(),
+          title: { display: true, text: 'Acceptance %', color: C_TICK, font: { size: 10 } },
+          ticks: { color: C_TICK } },
+        ...(hasAvgToks ? { y2: { position: 'right', grid: { display: false },
+          title: { display: true, text: 'toks/fwd', color: C_TICK, font: { size: 10 } },
+          ticks: { color: C_TICK } } } : {}),
+      },
+      onClick: (_e, elems) => {
+        if (!elems.length) return;
+        const h = sorted[elems[0].index];
+        if (!h) return;
+        const [backend, model] = key.split('|');
+        const acc = latestAccuracy[key] || {};
+        const gpuParts = [];
+        if (acc._gpu_name) gpuParts.push(acc._gpu_name);
+        if (acc._gpu_vram_gb) gpuParts.push(acc._gpu_vram_gb + 'GB');
+        const gpuLabel = gpuParts.length ? gpuParts.join(' · ') : '—';
+        const commitHref = safeHref(h.commit?.url);
+        const runHref = safeHref(h.runUrl);
+        const pop = document.getElementById('popover');
+        pop.innerHTML = `<button class="pop-close" id="pop-close-btn">&times;</button>
+          <h3>${escHTML(model)} MTP Acceptance</h3>
+          <div class="pop-row"><span class="pop-key">Acceptance Rate</span><span class="pop-val" style="color:var(--accent-green)">${fmtNum(h.rate, 2)}%</span></div>
+          ${h.avgToks != null ? `<div class="pop-row"><span class="pop-key">Avg toks/fwd</span><span class="pop-val">${fmtNum(h.avgToks, 2)}</span></div>` : ''}
+          <div class="pop-section">
+            <div class="pop-row"><span class="pop-key">Model</span><span class="pop-val" style="font-family:inherit">${escHTML(model)}</span></div>
+            <div class="pop-row"><span class="pop-key">Backend</span><span class="pop-val" style="font-family:inherit">${escHTML(backend)}</span></div>
+            <div class="pop-row"><span class="pop-key">GPU</span><span class="pop-val" style="font-family:inherit">${escHTML(gpuLabel)}</span></div>
+            <div class="pop-row"><span class="pop-key">ROCm</span><span class="pop-val">${escHTML(acc._rocm_version || '—')}</span></div>
+            <div class="pop-row"><span class="pop-key">Docker</span><span class="pop-val" style="font-size:11px;max-width:260px;overflow-wrap:anywhere">${escHTML(acc.dockerImage || '—')}</span></div>
+            <div class="pop-row"><span class="pop-key">Commit</span><span class="pop-val">${commitHref ? '<a href="' + escHTML(commitHref) + '" target="_blank" rel="noopener noreferrer">' + (h.commit.id?.slice(0,7) || '—') + '</a>' : (h.commit?.id?.slice(0,7) || '—')}</span></div>
+            <div class="pop-row"><span class="pop-key">Message</span><span class="pop-val" style="font-family:inherit;font-size:12px">${escHTML(h.commit?.message?.split('\\n')[0] || '—')}</span></div>
+            <div class="pop-row"><span class="pop-key">Author</span><span class="pop-val" style="font-family:inherit">${escHTML(h.commit?.author?.name || '—')}</span></div>
+            <div class="pop-row"><span class="pop-key">Date</span><span class="pop-val">${fmtDate(h.date)}</span></div>
+          </div>
+          <div class="action-row">
+            ${runHref ? '<a class="action-btn" href="' + escHTML(runHref) + '" target="_blank" rel="noopener noreferrer">Open Run ↗</a>' : ''}
+            ${commitHref ? '<a class="action-btn" href="' + escHTML(commitHref) + '" target="_blank" rel="noopener noreferrer">View Commit ↗</a>' : ''}
+          </div>`;
+        document.getElementById('popover-overlay').classList.add('open');
+        document.getElementById('pop-close-btn').addEventListener('click', (e) => { e.stopPropagation(); hidePopover(); });
       },
     },
   });

--- a/.github/scripts/accuracy_to_dashboard.py
+++ b/.github/scripts/accuracy_to_dashboard.py
@@ -136,6 +136,28 @@ def build_entries(
             entry["extra"] = extra
         entries.append(entry)
 
+        # MTP acceptance rate (extracted from server log during accuracy test)
+        mtp_rate = ci_metadata.get("mtp_acceptance_rate")
+        if mtp_rate is not None:
+            mtp_entry = {
+                "name": f"{backend}::{model_name} MTP acceptance (%)",
+                "unit": "%",
+                "value": round(float(mtp_rate), 2),
+            }
+            if extra:
+                mtp_entry["extra"] = extra
+            entries.append(mtp_entry)
+
+            avg_toks = ci_metadata.get("avg_tokens_per_forward")
+            if avg_toks is not None:
+                entries.append(
+                    {
+                        "name": f"{backend}::{model_name} avg toks/fwd (tok/fwd)",
+                        "unit": "tok/fwd",
+                        "value": round(float(avg_toks), 2),
+                    }
+                )
+
     return entries
 
 

--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -191,6 +191,39 @@ with open(result_file, "w", encoding="utf-8") as f:
 PY
   fi
 
+  # Extract MTP acceptance rate from server log (if MTP enabled)
+  ATOM_SERVER_LOG="${ATOM_SERVER_LOG:-/tmp/atom_server.log}"
+  SERVER_ARGS="${SERVER_ARGS:-${EXTRA_ARGS[*]:-}}"
+  if [ -f "$ATOM_SERVER_LOG" ] && echo "$SERVER_ARGS" | grep -qi mtp; then
+    RESULT_FILE="${RESULT_FILENAME}" \
+    ATOM_SERVER_LOG="$ATOM_SERVER_LOG" \
+    python3 - <<'PY'
+import json, os, re
+
+result_file = os.environ["RESULT_FILE"]
+server_log = os.environ["ATOM_SERVER_LOG"]
+
+with open(result_file, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+with open(server_log, encoding="utf-8", errors="replace") as f:
+    for line in reversed(f.readlines()):
+        if "[MTP Stats " in line and "Interval" not in line:
+            m = re.search(
+                r"Average toks/fwd: ([\d.]+).*Acceptance rate: ([\d.]+)%",
+                line,
+            )
+            if m:
+                meta = data.setdefault("atom_ci_metadata", {})
+                meta["mtp_acceptance_rate"] = float(m.group(2))
+                meta["avg_tokens_per_forward"] = float(m.group(1))
+                break
+
+with open(result_file, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2)
+PY
+  fi
+
   echo "Accuracy test results saved to ${RESULT_FILENAME}"
 fi
 

--- a/.github/scripts/plugin_benchmark_to_dashboard.py
+++ b/.github/scripts/plugin_benchmark_to_dashboard.py
@@ -16,6 +16,7 @@ def derive_model_name(result_path: Path, payload: dict) -> str:
     if display_name:
         return str(display_name)
 
+    # Fallback: derive from model_id + filename variant
     model = str(payload.get("model_id", "")).split("/")[-1]
     if not model:
         model = result_path.stem

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -267,6 +267,7 @@ jobs:
             -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
             -e DOCKER_IMAGE="${{ inputs.image || 'rocm/atom-dev:latest' }}" \
             -e RESULT_PATH="${{ env.RESULT_FILENAME }}.json" \
+            -e DISPLAY_NAME="${{ matrix.model.display }}" \
             atom-benchmark python3 -c "
           import json, os
           p = os.environ['RESULT_PATH']
@@ -279,6 +280,9 @@ jobs:
               d['gpu_vram_gb'] = int(os.environ.get('GPU_VRAM_GB') or 0)
               d['rocm_version'] = os.environ.get('ROCM_VERSION', '')
               d['docker_image'] = os.environ.get('DOCKER_IMAGE', '')
+              display_name = os.environ.get('DISPLAY_NAME', '')
+              if display_name:
+                  d['benchmark_model_name'] = display_name
               with open(p, 'w') as f:
                   json.dump(d, f, indent=2)
           "
@@ -411,51 +415,11 @@ jobs:
 
       - name: Transform results for benchmark dashboard
         run: |
-          python3 -c "
-          import json, glob, re
-          run_url = f'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-          entries = []
-          for f in sorted(glob.glob('*.json')):
-              if f == 'regression_report.json':
-                  continue
-              try:
-                  d = json.load(open(f))
-              except (json.JSONDecodeError, OSError):
-                  continue
-              if 'output_throughput' not in d:
-                  continue
-              model = d.get('model_id', '').split('/')[-1]
-              m = re.search(r'-(mtp\d*)-', f)
-              if m:
-                  model = f'{model}-{m.group(1)}'
-              isl = d.get('random_input_len', 0)
-              osl = d.get('random_output_len', 0)
-              conc = d.get('max_concurrency', 0)
-              label = f'{model} {isl}/{osl} c={conc}'
-              gpu_name = d.get('gpu_name', '')
-              gpu_vram = d.get('gpu_vram_gb', 0)
-              rocm_ver = d.get('rocm_version', '')
-              extra = f'Run: {run_url}'
-              if gpu_name:
-                  extra += f' | GPU: {gpu_name}'
-              if gpu_vram:
-                  extra += f' | VRAM: {gpu_vram}GB'
-              if rocm_ver:
-                  extra += f' | ROCm: {rocm_ver}'
-              entries.append({'name': f'{label} throughput (tok/s)', 'unit': 'tok/s',
-                              'value': round(d['output_throughput'], 2), 'extra': extra})
-              entries.append({'name': f'{label} Total Tput (tok/s)', 'unit': 'tok/s',
-                              'value': round(d.get('total_token_throughput', 0), 2), 'extra': extra})
-              entries.append({'name': f'{label} TTFT (ms)', 'unit': 'ms',
-                              'value': round(d.get('mean_ttft_ms', 0), 2), 'extra': extra})
-              entries.append({'name': f'{label} TPOT (ms)', 'unit': 'ms',
-                              'value': round(d.get('mean_tpot_ms', 0), 2), 'extra': extra})
-              tp = d.get('tensor_parallel_size', 1)
-              entries.append({'name': f'{label} _gpu_count', 'unit': '',
-                              'value': int(tp)})
-          json.dump(entries, open('benchmark-action-input.json', 'w'), indent=2)
-          print(f'Generated {len(entries)} entries for benchmark dashboard')
-          "
+          python3 .github/scripts/plugin_benchmark_to_dashboard.py \
+            . \
+            --output benchmark-action-input.json \
+            --default-backend ATOM \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Store benchmark result to dashboard
         uses: benchmark-action/github-action-benchmark@v1
@@ -476,6 +440,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           CURRENT_SHA=$(git rev-parse HEAD)
+          # Generate prefix→display name mapping from models.json
+          python3 -c "
+          import json
+          models = json.loads(open('.github/benchmark/models.json').read())
+          mapping = {}
+          for m in models:
+              display = m.get('display','')
+              path = m.get('path','')
+              suffix = m.get('suffix','')
+              if not display or not path: continue
+              hf_name = path.split('/')[-1].lower()
+              # HF path-derived key (old data used model_id last segment + optional suffix)
+              hf_key = hf_name + suffix.lower() if suffix else hf_name
+              mapping[hf_key] = display
+          with open('/tmp/dashboard_models_map.js','w') as f:
+              f.write('window.MODELS_DISPLAY_MAP = ' + json.dumps(mapping) + ';')
+          "
           # Save dashboard assets before switching branches
           cp .github/dashboard/index.html /tmp/dashboard_index.html
           cp docs/assets/atom_logo.png /tmp/dashboard_logo.png
@@ -484,6 +465,7 @@ jobs:
           git checkout gh-pages
           # Replace auto-generated index.html with custom dashboard + logo
           cp /tmp/dashboard_index.html benchmark-dashboard/index.html
+          cp /tmp/dashboard_models_map.js benchmark-dashboard/models_map.js
           cp /tmp/dashboard_logo.png benchmark-dashboard/atom_logo.png
           cp /tmp/dashboard_logo_mini.png benchmark-dashboard/atom_logo_mini.png
           git add benchmark-dashboard/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Key entry points:
 ## Key Development Patterns
 
 - **Adding a model**: see `/add-model` for full guide
-- **Model reuse**: DeepSeek V3/V3.2/GLM-5 share `deepseek_v2.py`; MTP models in `deepseek_mtp.py` and `qwen3_next_mtp.py`
+- **Model reuse**: DeepSeek V3/V3.2/GLM-5 share `deepseek_v2.py`; MTP models in `deepseek_mtp.py`, `qwen3_next_mtp.py`, and `qwen3_5_mtp.py`
 - **Compilation levels**: `--level` 0=eager, 1=torch.compile, 2=dynamo once, 3=piecewise+CUDAGraph (default)
 
 ## Dependencies

--- a/atom/config.py
+++ b/atom/config.py
@@ -8,7 +8,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, ClassVar, Optional, Union
 
 import torch
 from aiter import QuantType
@@ -24,7 +24,6 @@ from transformers import AutoConfig, GenerationConfig, PretrainedConfig
 # plugin-related utilities
 from atom.plugin import is_plugin_mode, is_vllm
 from atom.plugin.config import PluginConfig
-from atom.utils import resolve_obj_by_qualname
 
 logger = logging.getLogger("atom")
 
@@ -696,46 +695,63 @@ class SpeculativeConfig:
     num_speculative_tokens: Optional[int] = None
     draft_model_hf_config: Optional[PretrainedConfig] = None
 
+    # model_type → mtp_model_type mapping
+    _MTP_TYPE_MAP: ClassVar[dict[str, str]] = {
+        "deepseek_v3": "deepseek_mtp",
+        "glm_moe_dsa": "deepseek_mtp",
+        "qwen3_next": "qwen3_next_mtp",
+        "qwen3_5": "qwen3_5_mtp",
+        "qwen3_5_moe": "qwen3_5_mtp",
+        "qwen3_5_text": "qwen3_5_mtp",
+        "qwen3_5_moe_text": "qwen3_5_mtp",
+    }
+
+    # mtp_model_type → (n_predict_attr, architecture)
+    _MTP_CONFIG: ClassVar[dict[str, tuple[str, str]]] = {
+        "deepseek_mtp": ("num_nextn_predict_layers", "DeepSeekMTPModel"),
+        "qwen3_next_mtp": ("num_nextn_predict_layers", "Qwen3NextMTPModel"),
+        "qwen3_5_mtp": ("mtp_num_hidden_layers", "Qwen3_5MTPModel"),
+    }
+
     def __post_init__(self):
         if self.draft_model_hf_config is None:
             self.draft_model_hf_config = AutoConfig.from_pretrained(self.model)
+        # For multimodal models, extract text_config
+        if hasattr(self.draft_model_hf_config, "text_config"):
+            self.draft_model_hf_config = self.draft_model_hf_config.text_config
         self.hf_config_override(self.draft_model_hf_config)
 
     @staticmethod
-    def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
-        if hf_config.model_type in ("deepseek_v3", "glm_moe_dsa"):
-            hf_config.model_type = "deepseek_mtp"
-        if hf_config.model_type == "qwen3_next":
-            hf_config.model_type = "qwen3_next_mtp"
+    def hf_config_override(hf_config: PretrainedConfig) -> None:
+        # Step 1: resolve model_type → mtp model_type
+        mtp_type = SpeculativeConfig._MTP_TYPE_MAP.get(hf_config.model_type)
+        if mtp_type is not None:
+            hf_config.model_type = mtp_type
 
-        if hf_config.model_type == "deepseek_mtp":
-            # DeepSeek MTP typically uses only 1 layer that gets reused
-            n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
-            # Override to use only 1 layer if config says otherwise
+        # Step 2: apply MTP-specific config overrides
+        entry = SpeculativeConfig._MTP_CONFIG.get(hf_config.model_type)
+        if entry is not None:
+            n_predict_attr, arch = entry
+            n_predict = getattr(hf_config, n_predict_attr, 1)
             if n_predict != 1:
                 logger.warning(
-                    f"Overriding num_nextn_predict_layers from {n_predict} to 1 "
+                    f"Overriding {n_predict_attr} from {n_predict} to 1 "
                     "(MTP typically uses 1 layer that gets reused)"
                 )
                 n_predict = 1
-            hf_config.update(
-                {
-                    "n_predict": n_predict,
-                    "num_nextn_predict_layers": n_predict,
-                    "architectures": ["DeepSeekMTPModel"],
-                }
-            )
-        if hf_config.model_type == "qwen3_next_mtp":
-            n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
-            if n_predict != 1:
-                logger.warning(
-                    f"Overriding num_nextn_predict_layers from {n_predict} to 1 "
-                    "(MTP typically uses 1 layer that gets reused)"
-                )
-                n_predict = 1
-            hf_config.update(
-                {"n_predict": n_predict, "architectures": ["Qwen3NextMTPModel"]}
-            )
+
+            updates: dict[str, Any] = {
+                "n_predict": n_predict,
+                "num_nextn_predict_layers": n_predict,
+                "architectures": [arch],
+            }
+            # Qwen3.5 MTP needs expert counts for MoE layer construction
+            if hf_config.model_type == "qwen3_5_mtp":
+                updates["n_shared_experts"] = 1
+                updates["n_routed_experts"] = getattr(hf_config, "num_experts", 0)
+
+            hf_config.update(updates)
+
         logger.info(f"hf config is: {hf_config}")
 
     def __repr__(self) -> str:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -34,7 +34,6 @@ from atom.utils import (
     init_exit_handler,
     resolve_obj_by_qualname,
 )
-from atom.utils.tbo import UBatchWrapper, maybe_create_ubatch_slices
 from atom.utils.forward_context import (
     Context,
     DPMetadata,
@@ -44,6 +43,7 @@ from atom.utils.forward_context import (
     set_kv_cache_data,
 )
 from atom.utils.selector import get_attn_backend
+from atom.utils.tbo import UBatchWrapper, maybe_create_ubatch_slices
 from torch.profiler import record_function
 
 logger = logging.getLogger("atom")
@@ -545,22 +545,6 @@ class ModelRunner:
             use_mla=self.use_mla,
             use_gdn=self.use_gdn,
         )
-        if self.config.speculative_config and get_pp_group().is_last_rank:
-            from atom.utils.backends import set_model_tag
-
-            with set_model_tag("drafter"):
-                self.drafter = EagleProposer(self.config, self.device, self)
-            self.rejection_sampler = RejectionSampler()
-            self.mtp_total_draft_tokens = 0
-            self.mtp_total_accepted_tokens = 0
-        self.num_spec_tokens = self.drafter.mtp_k if hasattr(self, "drafter") else 0
-        self.tokenID_processor = tokenIDProcessor(
-            self,
-            self.config.max_num_batched_tokens,
-            hasattr(self, "drafter"),
-            self.num_spec_tokens,
-        )
-        self.sampler = Sampler()
         self.arange_np = np.arange(
             max(
                 self.config.max_num_seqs + 1,
@@ -594,9 +578,24 @@ class ModelRunner:
         )
         logger.info(f"Model load done: {config.model}")
 
-        if hasattr(self, "drafter"):
+        if self.config.speculative_config and get_pp_group().is_last_rank:
+            from atom.utils.backends import set_model_tag
+
+            torch.set_default_device(self.device)
+            with set_model_tag("drafter"):
+                self.drafter = EagleProposer(self.config, self.device, self)
+            self.rejection_sampler = RejectionSampler()
+            torch.set_default_device(None)
             logger.info("Loading drafter model...")
             self.drafter.load_model(self.model)
+        self.num_spec_tokens = self.drafter.mtp_k if hasattr(self, "drafter") else 0
+        self.tokenID_processor = tokenIDProcessor(
+            self,
+            self.config.max_num_batched_tokens,
+            hasattr(self, "drafter"),
+            self.num_spec_tokens,
+        )
+        self.sampler = Sampler()
         torch.set_default_device(self.device)
         self.async_execute_stream = torch.cuda.Stream(self.device)
         self.allocate_forward_vars()
@@ -1327,6 +1326,11 @@ class ModelRunner:
         kv_cache_tensors = []
         layer_id = 0
         x = 16 // self.kv_cache.element_size()
+        mtp_start_layer_idx = (
+            self.drafter.model.model.mtp_start_layer_idx
+            if hasattr(self, "drafter")
+            else hf_config.num_hidden_layers
+        )
         for model_name, model in models_to_bind:
             logger.info(
                 f"Binding KV cache for {model_name} model starting at layer_id={layer_id}"
@@ -1336,9 +1340,17 @@ class ModelRunner:
                 # Since use attention base and there are child in attention, add base condition
                 if hasattr(module, "base_attention"):
                     if hasattr(module, "use_mla") and not module.use_mla:
-                        # Non-MLA attention
+                        # Non-MLA attention: hybrid models interleave full
+                        # attention and linear attention, so attn_idx must
+                        # skip linear-attention layers for target, and use
+                        # consecutive slots after num_full_attn for draft.
                         if self.is_qwen_next():
-                            attn_idx = layer_id // self.full_attention_interval
+                            if layer_id < mtp_start_layer_idx:
+                                attn_idx = layer_id // self.full_attention_interval
+                            else:
+                                attn_idx = self.num_full_attn + (
+                                    layer_id - mtp_start_layer_idx
+                                )
                         else:
                             attn_idx = layer_id
                         k_cache = self.kv_cache[0, attn_idx].view(
@@ -1712,6 +1724,7 @@ class ModelRunner:
         bs = context.batch_size
         is_prefill = context.is_prefill
         positions = context.positions
+
         if is_prefill or self.enforce_eager or bs > self.graph_bs[-1]:
             # prefill[bs=1 tok=115 ctx=115]
             label = f"prefill[bs={bs}"

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -434,6 +434,18 @@ class Scheduler:
 
     def preempt(self, seq: Sequence):
         seq.status = SequenceStatus.WAITING
+        # Strip placeholder + rejected draft tokens added by postprocess.
+        # Real token count = seq.num_tokens - mtp_k - num_rejected
+        # (same formula as postprocess line: num_tokens = seq.num_tokens - self.mtp_k - num_rejected)
+        if self.mtp_k > 0:
+            strip = self.mtp_k + seq.num_rejected
+            if strip > 0:
+                del seq.token_ids[-strip:]
+                del seq.output_tokens[-strip:]
+                seq.num_tokens -= strip
+        seq.num_rejected = 0
+        seq.num_bonus_tokens = 0
+        seq.spec_token_ids = np.array([], dtype=np.int32)
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
 

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -24,17 +24,12 @@ from atom.model_loader.weight_utils import (
     download_weights_from_hf,
     filter_duplicate_safetensors_files,
 )
-from atom.models.deepseek_mtp import (
-    get_spec_layer_idx_from_weight_name,
-    rewrite_spec_layer_name,
-)
 from atom.model_ops.base_config import QuantizeMethodBase
 from atom.model_ops.moe import (
     FusedMoEMethodBase,
     is_rocm_aiter_fusion_shared_expert_enabled,
 )
 from aiter.dist.parallel_state import get_tp_group
-from atom.models.qwen3_next_mtp import remap_mtp_weight_name
 
 from atom.plugin.prepare import is_sglang
 
@@ -264,6 +259,7 @@ def load_model(
     packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
     weights_mapping = getattr(model, "weights_mapping", {})
     skip_weight_prefixes = getattr(model, "skip_weight_prefixes", [])
+    mtp_remap = getattr(model, "remap_mtp_weight_name", None)
     params_dict = dict(model.named_parameters())
 
     # Pre-index expert_mapping by weight_name_part for O(1) lookup.
@@ -313,17 +309,11 @@ def load_model(
                 name.startswith(p) for p in skip_weight_prefixes
             ):
                 continue
-            if spec_decode:
-                if hf_config.model_type == "deepseek_mtp":
-                    spec_layer = get_spec_layer_idx_from_weight_name(hf_config, name)
-                    if spec_layer is None:
-                        continue
-                    name = rewrite_spec_layer_name(spec_layer, name)
-                elif hf_config.model_type == "qwen3_next_mtp":
-                    remapped_name = remap_mtp_weight_name(name)
-                    if remapped_name is None:
-                        continue
-                    name = remapped_name
+            if spec_decode and mtp_remap is not None:
+                remapped = mtp_remap(name)
+                if remapped is None:
+                    continue
+                name = remapped
             for mapping_part in weights_mapping.keys():
                 if mapping_part in name:
                     name = name.replace(mapping_part, weights_mapping[mapping_part])
@@ -534,5 +524,4 @@ def load_model(
         if isinstance(quant_method, FusedMoEMethodBase):
             quant_method.init_prepare_finalize(module)
 
-    if is_plugin_mode:
-        return loaded_weights_record
+    return loaded_weights_record

--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -11,7 +11,11 @@ from atom.model_ops.attention_gdn import GatedDeltaNet
 from atom.utils import CpuGpuBuffer
 from atom.utils.forward_context import AttentionMetaData, Context
 
-from .aiter_attention import AiterBackend, AiterAttentionMetadataBuilder
+from .aiter_attention import (
+    AiterBackend,
+    AiterAttentionMetadataBuilder,
+    kv_indices_generate_triton,
+)
 
 
 class GDNAttentionBackend(AiterBackend):
@@ -322,6 +326,37 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
 
         attn_metadata.gdn_metadata = gdn_metadata
         return attn_metadata, positions
+
+    def prepare_mtp_decode(
+        self,
+        bs: int,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        only_update: bool = False,
+        num_reject_tokens=None,
+    ):
+        var = self.model_runner.forward_vars
+
+        # GDN hybrid models use paged KV cache for full-attention layers.
+        # Regenerate kv_indices for the new max_seqlen_k after adding a
+        # draft token; kv_indptr stays unchanged (block count is stable).
+        # Note: only_update and num_reject_tokens are unused here — GDN's
+        # paged attention does not use persistent worker buffers that need
+        # incremental updates (unlike MLA). The full kv_indices regeneration
+        # is always correct regardless of the update mode.
+        kv_indptr = var["kv_indptr"].gpu[: bs + 1]
+        kv_indices_generate_triton(
+            var["block_tables"].gpu[:bs],
+            var["kv_indices"].gpu,
+            kv_indptr,
+            self.block_ratio,
+            max_seqlen_k,
+        )
+
+        result = {}
+        if self.block_size == 1024:
+            result = self.set_aiter_persistent_worker_buffers(bs)
+        return result
 
     def build_for_cudagraph_capture(self, bs: int):
         var = self.model_runner.forward_vars

--- a/atom/model_ops/mamba_ops/causal_conv1d.py
+++ b/atom/model_ops/mamba_ops/causal_conv1d.py
@@ -894,21 +894,24 @@ def _causal_conv1d_update_kernel(
     dim_limits = dim
     if idx_feats_start < k_start_point:
         o_ptr = query_ptr
-        stride_o_token = stride_q_token
+        # In VARLEN mode, tokens are indexed along dim-0 of the output tensor,
+        # so the token stride is stride_q_seq (not stride_q_token which is the
+        # last-dim stride of the [num_tokens, k_dim, 1] output).
+        stride_o_token = stride_q_seq if IS_VARLEN else stride_q_token
         stride_o_dim = stride_q_dim
         idx_feats_o = idx_feats
         dim_limits = k_dim_size
         stride_o_seq = stride_q_seq
     elif idx_feats_start < v_start_point:
         o_ptr = key_ptr
-        stride_o_token = stride_k_token
+        stride_o_token = stride_k_seq if IS_VARLEN else stride_k_token
         stride_o_dim = stride_k_dim
         idx_feats_o = idx_feats - k_start_point
         dim_limits = k_dim_size
         stride_o_seq = stride_k_seq
     elif idx_feats_start < dim:
         o_ptr = value_ptr
-        stride_o_token = stride_v_token
+        stride_o_token = stride_v_seq if IS_VARLEN else stride_v_token
         stride_o_dim = stride_v_dim
         idx_feats_o = idx_feats - v_start_point
         dim_limits = v_dim_size

--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -171,6 +171,12 @@ class DeepSeekMTP(nn.Module):
             atom_config=atom_config, prefix=maybe_prefix(prefix, "model")
         )
 
+    def remap_mtp_weight_name(self, name: str) -> str | None:
+        spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
+        if spec_layer is None:
+            return None
+        return rewrite_spec_layer_name(spec_layer, name)
+
     def forward(
         self,
         input_ids: torch.Tensor,

--- a/atom/models/qwen3_5_mtp.py
+++ b/atom/models/qwen3_5_mtp.py
@@ -1,37 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Inference-only Qwen3Next MTP model."""
+"""Inference-only Qwen3.5 MTP model."""
 
 import torch
 import torch.nn as nn
+from aiter.dist.parallel_state import get_tp_group
 from atom.config import Config
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
-from atom.model_ops.moe import FusedMoE
-from aiter.dist.parallel_state import get_tp_group
-from atom.models.utils import IntermediateTensors
-from atom.models.qwen3_next import Qwen3NextDecoderLayer, Qwen3NextRMSNorm
 from atom.model_ops.linear import ColumnParallelLinear
-from atom.model_config.qwen3_next import Qwen3NextConfig
+from atom.model_ops.moe import FusedMoE
+from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
+from atom.models.qwen3_5 import (
+    Qwen3_5DecoderLayer,
+    Qwen3_5RMSNorm,
+    get_qwen3_5_text_config,
+)
+from atom.models.utils import IntermediateTensors
 from .utils import maybe_prefix
-
-KVCache = tuple[torch.Tensor, torch.Tensor]
 
 
 # @support_torch_compile
-class Qwen3NextMultiTokenPredictor(nn.Module):
+class Qwen3_5MultiTokenPredictor(nn.Module):
     def __init__(self, atom_config: Config, prefix: str = ""):
         super().__init__()
 
         quant_config = atom_config.quant_config
 
-        config: Qwen3NextConfig = atom_config.hf_config
+        config = get_qwen3_5_text_config(atom_config)
 
         self.config = config
 
         self.vocab_size = config.vocab_size
 
         self.mtp_start_layer_idx = config.num_hidden_layers
-        self.num_mtp_layers = getattr(config, "num_nextn_predict_layers", 1)
+        self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
 
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
@@ -43,25 +45,27 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
             self.config.hidden_size,
             bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.fc",
         )
 
         self.layers = torch.nn.ModuleList(
-            Qwen3NextDecoderLayer(
+            Qwen3_5DecoderLayer(
                 atom_config,
                 layer_type="full_attention",
                 prefix=f"{prefix}.layers.{idx}",
                 layer_num=idx,
             )
             for idx in range(
-                self.mtp_start_layer_idx, self.mtp_start_layer_idx + self.num_mtp_layers
+                self.mtp_start_layer_idx,
+                self.mtp_start_layer_idx + self.num_mtp_layers,
             )
         )
 
-        self.norm = Qwen3NextRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.pre_fc_norm_hidden = Qwen3NextRMSNorm(
+        self.norm = Qwen3_5RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_fc_norm_hidden = Qwen3_5RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
-        self.pre_fc_norm_embedding = Qwen3NextRMSNorm(
+        self.pre_fc_norm_embedding = Qwen3_5RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
 
@@ -100,13 +104,15 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
 
 
 # @support_torch_compile
-class Qwen3NextMTP(nn.Module):
+class Qwen3_5MTP(nn.Module):
     packed_modules_mapping = {
         "q_proj": ("qkv_proj", "q"),
         "k_proj": ("qkv_proj", "k"),
         "v_proj": ("qkv_proj", "v"),
         "gate_proj": ("gate_up_proj", 0),
         "up_proj": ("gate_up_proj", 1),
+        ".gate.": (".gate.", 0),
+        "shared_expert_gate": ("gate", 1),
     }
     weights_mapping = {"mtp.": "model."}
 
@@ -127,11 +133,11 @@ class Qwen3NextMTP(nn.Module):
 
     def __init__(self, atom_config: Config, prefix: str = ""):
         super().__init__()
-        config = atom_config.hf_config
+        config = get_qwen3_5_text_config(atom_config)
         if atom_config.enable_prefix_caching:
-            raise ValueError("Qwen3NextMTP currently does not support prefix caching")
+            raise ValueError("Qwen3_5MTP currently does not support prefix caching")
         self.config = config
-        self.model = Qwen3NextMultiTokenPredictor(
+        self.model = Qwen3_5MultiTokenPredictor(
             atom_config=atom_config, prefix=maybe_prefix(prefix, "mtp")
         )
 
@@ -165,12 +171,17 @@ class Qwen3NextMTP(nn.Module):
     ) -> torch.Tensor | None:
         return self.lm_head(hidden_states)
 
-    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:  # noqa: D401
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
         return FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.num_experts,
+            num_experts=self.config.n_routed_experts
+            + (
+                self.config.n_shared_experts
+                if is_rocm_aiter_fusion_shared_expert_enabled()
+                else 0
+            ),
         )

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -16,6 +16,7 @@ logger = logging.getLogger("atom")
 support_eagle_model_arch_dict = {
     "DeepSeekMTPModel": "atom.models.deepseek_mtp.DeepSeekMTP",
     "Qwen3NextMTPModel": "atom.models.qwen3_next_mtp.Qwen3NextMTP",
+    "Qwen3_5MTPModel": "atom.models.qwen3_5_mtp.Qwen3_5MTP",
 }
 
 
@@ -57,9 +58,26 @@ class EagleProposer:
         self.target_logits_indices = CpuGpuBuffer(max_bs * self.mtp_k, **i64_kwargs)
         self.bonus_logits_indices = CpuGpuBuffer(max_bs, **i64_kwargs)
 
-    def load_model(self, target_model: nn.Module) -> None:
+    @staticmethod
+    def _share_if_not_loaded(
+        owner: nn.Module,
+        attr: str,
+        source: nn.Module,
+        loaded: set[str],
+        param_key: str,
+        label: str,
+    ):
+        """Replace *owner.attr* with *source* if the weight was not loaded."""
+        if param_key not in loaded and getattr(owner, attr, None) is not None:
+            logger.info(
+                f"MTP {label} not loaded from checkpoint, "
+                "sharing from the target model."
+            )
+            delattr(owner, attr)
+            setattr(owner, attr, source)
 
-        load_model(
+    def load_model(self, target_model: nn.Module) -> None:
+        loaded = load_model(
             self.model,
             self.config.model,
             self.speculative_config.draft_model_hf_config,
@@ -67,41 +85,55 @@ class EagleProposer:
             True,
         )
 
-        # share embed_tokens with the target model if needed
+        # Resolve the base model (unwrap multimodal wrapper if present)
+        target_base = getattr(target_model, "language_model", target_model)
+
+        # Share embed_tokens with the target model
         if (
             get_pp_group().world_size == 1
             and self.model.model.embed_tokens.weight.shape
-            == target_model.model.embed_tokens.weight.shape
+            == target_base.model.embed_tokens.weight.shape
         ):
             logger.info(
                 "Assuming the EAGLE head shares the same vocab embedding"
                 " with the target model."
             )
             del self.model.model.embed_tokens
-            self.model.model.embed_tokens = target_model.model.embed_tokens
+            self.model.model.embed_tokens = target_base.model.embed_tokens
         else:
             logger.info(
                 "The EAGLE head's vocab embedding will be loaded separately"
                 " from the target model."
             )
 
-        # If MTP shared_head.head was not in checkpoint (weight is all zeros),
-        # share lm_head from the target model as fallback.
+        # Share lm_head from target if not loaded from checkpoint.
+        # Case 1: per-layer shared_head.head (DeepSeek MTP)
         if hasattr(self.model, "model") and hasattr(self.model.model, "layers"):
             layers = self.model.model.layers
-            layer_iter = layers.values() if hasattr(layers, "values") else layers
-            for layer in layer_iter:
-                if (
-                    hasattr(layer, "shared_head")
-                    and hasattr(layer.shared_head, "head")
-                    and not layer.shared_head.head.weight.any()
-                ):
-                    logger.info(
-                        "MTP shared_head.head not found in checkpoint, "
-                        "sharing lm_head from the target model."
+            # ModuleDict uses string keys (actual layer indices like "61"),
+            # ModuleList uses integer indices.
+            layer_items = (
+                layers.items() if hasattr(layers, "items") else enumerate(layers)
+            )
+            for key, layer in layer_items:
+                if hasattr(layer, "shared_head"):
+                    self._share_if_not_loaded(
+                        layer.shared_head,
+                        "head",
+                        target_base.lm_head,
+                        loaded,
+                        f"model.layers.{key}.shared_head.head.weight",
+                        "shared_head.head",
                     )
-                    del layer.shared_head.head
-                    layer.shared_head.head = target_model.lm_head
+        # Case 2: top-level lm_head (Qwen3.5 / Qwen3-Next MTP)
+        self._share_if_not_loaded(
+            self.model,
+            "lm_head",
+            target_base.lm_head,
+            loaded,
+            "lm_head.weight",
+            "lm_head",
+        )
 
     def propose(
         self,
@@ -135,6 +167,7 @@ class EagleProposer:
         )
         # return draft_token_ids.fill_(1) # for debug
         var = self.runner.forward_vars
+        use_mla = self.runner.use_mla
         for i in range(self.mtp_k):
             with record_function(f"draft[{i}/{self.mtp_k} bs={bs}]"):
                 ret_hidden_states = self.model(
@@ -165,20 +198,32 @@ class EagleProposer:
                         slot_mapping = var["slot_mapping"].gpu[
                             : bs * attn_metadata.max_seqlen_q
                         ]
-                        kv_last_page_lens = var["kv_last_page_lens"].gpu[:bs]
                         cu_seqlens_q = var["cu_seqlens_q"].gpu[: bs + 1]
                         attn_metadata.kv_indptr = kv_indptr
                         attn_metadata.kv_indices = kv_indices
                         attn_metadata.cu_seqlens_q = cu_seqlens_q
                         attn_metadata.slot_mapping = slot_mapping
-                        attn_metadata.kv_last_page_lens = kv_last_page_lens
+                        if use_mla:
+                            kv_last_page_lens = var["kv_last_page_lens"].gpu[:bs]
+                            attn_metadata.kv_last_page_lens = kv_last_page_lens
+                        else:
+                            # MHA needs block_tables and context_lens
+                            attn_metadata.block_tables = var["block_tables"].gpu[:bs]
+                            attn_metadata.context_lens = var["context_lens"].gpu[:bs]
                         cu_seqlens_q[: bs + 1] = self.arrange_bs[: bs + 1]
-                        kv_indptr[1 : bs + 1] -= torch.cumsum(num_reject_tokens, dim=0)
+                        if use_mla:
+                            # MLA: block_size=1, kv_indptr tracks tokens
+                            kv_indptr[1 : bs + 1] -= torch.cumsum(
+                                num_reject_tokens, dim=0
+                            )
                         positions = torch.gather(positions, 0, last_token_indices)
                         context.is_prefill = False
 
                     # update metadata
                     attn_metadata.max_seqlen_k += 1
+                    if not use_mla:
+                        # MHA: update context_lens for this draft step
+                        attn_metadata.context_lens[:bs] += 1
                     workinfos = self.runner.attn_metadata_builder.prepare_mtp_decode(
                         bs,
                         (

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -223,6 +223,49 @@ WAITING ──(scheduled for prefill)──► RUNNING ──(stop condition met
 
 ---
 
+## 7. Speculative Decoding (MTP / EAGLE)
+
+ATOM supports speculative decoding via `EagleProposer` (in `atom/spec_decode/eagle.py`), which uses Multi-Token Prediction (MTP) draft models to propose candidate tokens that are verified by the target model through rejection sampling.
+
+### Supported MTP architectures
+
+The `support_eagle_model_arch_dict` maps HuggingFace architecture keys to draft model implementations:
+
+| Architecture key | Implementation | Used by |
+|---|---|---|
+| `DeepSeekMTPModel` | `atom.models.deepseek_mtp.DeepSeekMTP` | DeepSeek-R1, DeepSeek-V3 |
+| `Qwen3NextMTPModel` | `atom.models.qwen3_next_mtp.Qwen3NextMTP` | Qwen3-Next |
+| `Qwen3_5MTPModel` | `atom.models.qwen3_5_mtp.Qwen3_5MTP` | Qwen3.5 |
+
+### Weight sharing
+
+`EagleProposer.load_model()` shares weights between the draft and target models to save memory. It uses `_share_if_not_loaded()`, which checks whether a parameter key exists in the `loaded_weights_record` set returned by the model loader. If the key is absent (meaning the checkpoint did not contain that weight), the draft module's attribute is replaced with a reference to the target model's corresponding parameter. This avoids comparing tensor values and instead relies on the loader's bookkeeping of which weights were actually present in the checkpoint.
+
+Two sharing patterns are handled:
+
+- **Per-layer `shared_head.head`** (DeepSeek MTP) -- each MTP layer has a `shared_head` whose `head` weight is shared with `target_base.lm_head` if not loaded from the checkpoint.
+- **Top-level `lm_head`** (Qwen3.5 / Qwen3-Next MTP) -- the draft model's `lm_head` is shared with the target if not loaded.
+
+The `embed_tokens` layer is always shared when shapes match and pipeline parallelism is not used.
+
+### Propose loop: MHA vs MLA branching
+
+The `propose()` method iterates `mtp_k` draft steps. On the first iteration (`i == 0`), it sets up attention metadata for single-token decode. The metadata setup branches based on `runner.use_mla`:
+
+- **MLA models** (DeepSeek, Qwen3 MoE) -- use `kv_indptr` and `kv_last_page_lens` with block_size=1 paged KV cache. `kv_indptr` is adjusted by subtracting the cumulative `num_reject_tokens` to account for rejected speculative tokens from the previous step.
+- **MHA models** (GDN/hybrid architectures) -- use `block_tables` and `context_lens`. `context_lens` is incremented by 1 at each draft step to reflect the additional KV entries.
+
+On subsequent iterations (`i > 0`), `max_seqlen_k` is incremented and `prepare_mtp_decode()` is called to update backend-specific attention metadata.
+
+### `prepare_mtp_decode()`
+
+Each attention backend provides its own `prepare_mtp_decode()` implementation:
+
+- **`AiterMLAAttnMetadataBuilder`** (`atom/model_ops/attentions/aiter_mla.py`) -- for MLA attention, increments `kv_indptr` by the cumulative query sequence lengths and regenerates `kv_indices` via `kv_indices_generate_triton`. Supports incremental updates (`only_update=True`) for persistent worker buffers used by AITER's paged attention.
+- **`GDNAttnMetadataBuilder`** (`atom/model_ops/attentions/gdn_attn.py`) -- for GDN hybrid models with paged KV cache, regenerates `kv_indices` for the new `max_seqlen_k` after each draft token. The `kv_indptr` (block count) stays unchanged since the page table is stable within a draft step. The `only_update` and `num_reject_tokens` parameters are unused -- GDN always does a full `kv_indices` regeneration.
+
+---
+
 ## Source Files
 
 | File | Description |

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -242,10 +242,55 @@ method with `num_speculative_tokens=1` is supported.
 | `num_speculative_tokens` | `Optional[int]` | `None` | Number of speculative tokens per iteration; **must be `1`** |
 | `draft_model_hf_config` | `Optional[PretrainedConfig]` | `None` | HuggingFace config for the draft model; auto-loaded from `model` when `None` |
 
-**Post-init behaviour:**
+### 5.1 Table-Driven MTP Config
+
+MTP configuration uses two class-level lookup tables to support multiple model
+families without per-model branching.
+
+**`_MTP_TYPE_MAP`** -- maps a base `model_type` to its MTP `model_type`:
+
+| Base `model_type` | MTP `model_type` |
+|---|---|
+| `deepseek_v3` | `deepseek_mtp` |
+| `glm_moe_dsa` | `deepseek_mtp` |
+| `qwen3_next` | `qwen3_next_mtp` |
+| `qwen3_5` | `qwen3_5_mtp` |
+| `qwen3_5_moe` | `qwen3_5_mtp` |
+| `qwen3_5_text` | `qwen3_5_mtp` |
+| `qwen3_5_moe_text` | `qwen3_5_mtp` |
+
+**`_MTP_CONFIG`** -- maps MTP `model_type` to a `(n_predict_attr, architecture)` tuple:
+
+| MTP `model_type` | `n_predict_attr` | Architecture |
+|---|---|---|
+| `deepseek_mtp` | `num_nextn_predict_layers` | `DeepSeekMTPModel` |
+| `qwen3_next_mtp` | `num_nextn_predict_layers` | `Qwen3NextMTPModel` |
+| `qwen3_5_mtp` | `mtp_num_hidden_layers` | `Qwen3_5MTPModel` |
+
+### 5.2 Post-init behaviour (`hf_config_override`)
+
+The static method `hf_config_override` applies a two-step transformation to the
+draft model's HuggingFace config:
+
+1. **Resolve model type** -- looks up `hf_config.model_type` in `_MTP_TYPE_MAP`.
+   If found, rewrites `model_type` to the MTP variant (e.g.
+   `deepseek_v3` -> `deepseek_mtp`).
+
+2. **Apply MTP overrides** -- looks up the (possibly rewritten) `model_type` in
+   `_MTP_CONFIG`. If found:
+   - Reads `n_predict` from the model-specific attribute (e.g.
+     `num_nextn_predict_layers` or `mtp_num_hidden_layers`), defaulting to 1.
+     Warns and forces it to 1 if the original value differs.
+   - Sets `n_predict=1`, `num_nextn_predict_layers=1` (universal across all MTP
+     families), and `architectures` to the corresponding MTP model class.
+   - **Qwen3.5 MTP only**: additionally injects `n_shared_experts=1` and
+     `n_routed_experts` (read from `hf_config.num_experts`, default 0) so the
+     MTP module can construct its MoE layer.
+
+Other post-init steps:
 
 - Loads `draft_model_hf_config` from `model` if not provided.
-- For DeepSeek V3 / MTP models: overrides `model_type` to `"deepseek_mtp"`, sets `n_predict=1` and `num_nextn_predict_layers=1`, and switches architectures to `["DeepSeekMTPModel"]`.
+- Extracts `text_config` from multimodal model configs when present.
 - `Config.__post_init__` raises `ValueError` if `num_speculative_tokens != 1`.
 
 ---

--- a/docs/model_support_guide.md
+++ b/docs/model_support_guide.md
@@ -10,6 +10,8 @@ The model registry lives in `atom/model_engine/model_runner.py` as `support_mode
 support_model_arch_dict = {
     "Qwen3ForCausalLM": "atom.models.qwen3.Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM": "atom.models.qwen3_moe.Qwen3MoeForCausalLM",
+    "Qwen3_5ForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5ForConditionalGenerationTextOnly",
+    "Qwen3_5MoeForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5MoeForConditionalGenerationTextOnly",
     "LlamaForCausalLM": "atom.models.llama.LlamaForCausalLM",
     "MixtralForCausalLM": "atom.models.mixtral.MixtralForCausalLM",
     "DeepseekV3ForCausalLM": "atom.models.deepseek_v2.DeepseekV2ForCausalLM",
@@ -31,6 +33,8 @@ ATOM resolves the HuggingFace `architectures` field from a model's `config.json`
 |---|---|---|---|---|---|
 | `Qwen3ForCausalLM` | `atom.models.qwen3` | `Qwen3ForCausalLM` | No | No | GQA, QK norm, RoPE |
 | `Qwen3MoeForCausalLM` | `atom.models.qwen3_moe` | `Qwen3MoeForCausalLM` | Yes | No | GQA, QK norm, FusedMoE, sparse+dense layer mixing, QK norm+RoPE+cache+quant fusion |
+| `Qwen3_5ForConditionalGeneration` | `atom.models.qwen3_5` | `Qwen3_5ForConditionalGenerationTextOnly` | No | No | Hybrid architecture: full attention + Gated DeltaNet linear attention, GQA, QK norm, RoPE |
+| `Qwen3_5MoeForConditionalGeneration` | `atom.models.qwen3_5` | `Qwen3_5MoeForConditionalGenerationTextOnly` | Yes | No | Hybrid architecture: full attention + Gated DeltaNet, GQA, QK norm, FusedMoE |
 | `LlamaForCausalLM` | `atom.models.llama` | `LlamaForCausalLM` | No | No | GQA, RoPE, fused RMSNorm+quant, fused SiLU+mul+quant |
 | `MixtralForCausalLM` | `atom.models.mixtral` | `MixtralForCausalLM` | Yes | No | GQA, RoPE, FusedMoE with TP sharding |
 | `DeepseekV3ForCausalLM` | `atom.models.deepseek_v2` | `DeepseekV2ForCausalLM` | Yes | Yes | MLA attention, LoRA-compressed QKV, FusedMoE with shared experts, FP4/FP8 fused kernels |
@@ -40,7 +44,7 @@ ATOM resolves the HuggingFace `architectures` field from a model's `config.json`
 | `Glm4MoeForCausalLM` | `atom.models.glm4_moe` | `Glm4MoeForCausalLM` | Yes | No | GQA, partial RoPE (0.5 factor), QK norm, shared+routed experts, sigmoid scoring, grouped top-k |
 | `Qwen3NextForCausalLM` | `atom.models.qwen3_next` | `Qwen3NextForCausalLM` | Yes | No | Hybrid architecture: full attention + Gated DeltaNet linear attention, GQA, QK norm, FusedMoE |
 
-**Note:** `DeepSeekMTP` (`atom.models.deepseek_mtp.DeepSeekMTP`) and `Qwen3NextMTP` (`atom.models.qwen3_next_mtp`) are not in the registry -- they are used exclusively as speculative draft models and are loaded separately.
+**Note:** `DeepSeekMTP` (`atom.models.deepseek_mtp.DeepSeekMTP`), `Qwen3NextMTP` (`atom.models.qwen3_next_mtp.Qwen3NextMTP`), and `Qwen3_5MTP` (`atom.models.qwen3_5_mtp.Qwen3_5MTP`) are not in the registry -- they are used exclusively as speculative draft models and are loaded separately via `EagleProposer`.
 
 ---
 
@@ -132,6 +136,25 @@ ATOM resolves the HuggingFace `architectures` field from a model's `config.json`
 - **MoE:** `Qwen3NextSparseMoeBlock` with `FusedMoE`, shared expert fusion support.
 - **Normalization:** Uses `GemmaRMSNorm` (aliased as `Qwen3NextRMSNorm`).
 - **MTP:** Separate draft model in `atom/models/qwen3_next_mtp.py` (`Qwen3NextMTP`).
+
+### Qwen3.5 (`Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration`)
+
+- **Architecture:** Hybrid transformer with two attention types: full attention and Gated DeltaNet linear attention. Layer type is determined by `config.layer_types`. Dense or MoE variants.
+- **Layer structure:** `Qwen3_5DecoderLayer` containing either full attention or linear attention, plus either `Qwen3_5SparseMoeBlock` (MoE variants) or `Qwen3_5MLP` (dense variants).
+- **Attention:** Full attention layers use `QKVParallelLinear` with QK norm, RoPE, GQA. Linear attention layers use `QKVZBAParallelLinear` for fused QKVZ+BA projections with Gated DeltaNet.
+- **MoE:** `Qwen3_5SparseMoeBlock` with `FusedMoE`, shared expert fusion support.
+- **Normalization:** RMSNorm with optional fused allreduce for MoE models.
+- **MTP:** Separate draft model in `atom/models/qwen3_5_mtp.py` (`Qwen3_5MTP`). The MTP predictor uses only full attention layers (no Gated DeltaNet) for efficiency, supporting both MTP1 and MTP3 variants via `num_speculative_tokens`.
+
+### Qwen3.5 MTP (`Qwen3_5MTP`)
+
+- **Architecture:** Multi-Token Prediction draft model for speculative decoding with Qwen3.5.
+- **Layer structure:** `Qwen3_5MultiTokenPredictor` containing embedding, projection, and full-attention-only layers (no linear attention), followed by an LM head.
+- **Design:** Takes main model's hidden states and the next token's embedding as inputs. Concatenates normalized embeddings with normalized hidden states, applies a linear projection, then processes through one or more full-attention decoder layers.
+- **Weight loading:** Uses `weights_mapping = {"mtp.": "model."}` to map MTP weights from checkpoint. The `fc` layer uses a `prefix` parameter to enable weight quantization exclusion.
+- **Shared weights:** `embed_tokens` and `lm_head` are shared with the main model when loaded from the same checkpoint.
+- **Performance:** Typical acceptance rates of ~94% for MTP1 and ~83% for MTP3, with draft token generation overhead of ~1.94 and ~3.49 tokens per forward pass respectively.
+- **Attention metadata:** Since MTP only uses full attention (not MLA), the attention builder calls `prepare_mtp_decode()` with block table and context length updates (unlike MLA which uses kv_indptr).
 
 ---
 
@@ -311,12 +334,30 @@ When `ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION` is enabled, the `Qwen3MoeAtte
 
 Additionally, `ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION` fuses allreduce with RMSNorm for both attention output and MoE output, reducing communication overhead.
 
-### MTP: DeepSeek Multi-Token Prediction
+### MTP: Multi-Token Prediction (Speculative Decoding)
 
-The `DeepSeekMTP` model serves as a speculative draft model:
+Multi-Token Prediction (MTP) models serve as lightweight draft models for speculative decoding, proposing multiple tokens per forward pass to improve throughput while maintaining accuracy through rejection sampling. ATOM supports three MTP variants:
+
+**DeepSeekMTP** (`DeepSeekMTP`):
 - Each `DeepSeekMultiTokenPredictorLayer` takes the previous hidden state and the next token's embedding, normalizes both (`enorm`, `hnorm`), concatenates them, and passes through a linear projection (`eh_proj`) followed by a standard `DeepseekV2DecoderLayer`.
-- The `SharedHead` provides per-layer norm + LM head for logit computation.
+- The `SharedHead` provides per-layer norm + LM head for logit computation (one shared head per MTP layer).
 - For FP4 quantized main models, MTP blocks fall back to non-FP4 quantization config to maintain draft model accuracy.
+
+**Qwen3NextMTP** (`Qwen3NextMTP`):
+- Similar layer-by-layer structure to DeepSeek MTP with per-layer `SharedHead`.
+- Uses Qwen3-Next decoder layers with full attention only (no Gated DeltaNet linear attention).
+- Supports the hybrid architecture of the main Qwen3-Next model.
+
+**Qwen3_5MTP** (`Qwen3_5MTP`):
+- Simpler single-stage design: takes hidden states and token embeddings, projects them through a single full-attention block, then computes logits via a top-level `lm_head`.
+- All MTP layers are full-attention only (no Gated DeltaNet) for efficiency, even though the main Qwen3.5 model is hybrid.
+- Weight loading maps MTP weights via `weights_mapping = {"mtp.": "model."}`, allowing flexible quantization via the `fc` layer's prefix parameter.
+- Shares `embed_tokens` and `lm_head` with the main model when available.
+
+**General MTP Properties**:
+- Loaded separately via `EagleProposer` in `atom/spec_decode/eagle.py`, registered in `support_eagle_model_arch_dict`.
+- Each MTP variant uses `num_speculative_tokens` to control the number of draft tokens (e.g., MTP1 = 1 token, MTP3 = 3 tokens).
+- Attention metadata is updated incrementally: MLA models use `kv_indptr` tracking, while hybrid/GDN models (Qwen3.5 MTP) use block tables and context length updates.
 
 ---
 
@@ -333,8 +374,10 @@ The `DeepSeekMTP` model serves as a speculative draft model:
 | `atom/models/mixtral.py` | Mixtral model: `MixtralForCausalLM`, `MixtralModel`, `MixtralDecoderLayer`, `MixtralAttention`, `MixtralMoE` |
 | `atom/models/gpt_oss.py` | GPT-OSS model: `GptOssForCausalLM`, `GptOssModel`, `TransformerBlock`, `OAIAttention`, `MLPBlock` |
 | `atom/models/glm4_moe.py` | GLM4-MoE model: `Glm4MoeForCausalLM`, `Glm4MoeModel`, `Glm4MoeDecoderLayer`, `Glm4MoeAttention`, `Glm4MoE`, `Glm4MoeMLP` |
+| `atom/models/qwen3_5.py` | Qwen3.5 model: `Qwen3_5ForConditionalGenerationTextOnly`, `Qwen3_5MoeForConditionalGenerationTextOnly`, `Qwen3_5Model`, `Qwen3_5MoeModel`, `Qwen3_5DecoderLayer`, `Qwen3_5RMSNorm`, `Qwen3_5Attention`, `Qwen3_5GatedDeltaNet`, `Qwen3_5SparseMoeBlock`, `Qwen3_5MLP` |
 | `atom/models/qwen3_next.py` | Qwen3-Next model: `Qwen3NextForCausalLM`, `Qwen3NextModel`, `Qwen3NextDecoderLayer`, `Qwen3NextAttention`, `Qwen3NextGatedDeltaNet`, `Qwen3NextSparseMoeBlock`, `Qwen3NextMLP` |
 | `atom/models/qwen3_next_mtp.py` | Qwen3-Next MTP draft model |
+| `atom/models/qwen3_5_mtp.py` | Qwen3.5 MTP draft model: `Qwen3_5MTP`, `Qwen3_5MultiTokenPredictor` |
 | `atom/models/utils.py` | Model utilities: `IntermediateTensors`, `PPMissingLayer`, `make_layers`, `maybe_prefix`, `extract_layer_index` |
 | `atom/model_loader/loader.py` | Weight loading: `load_model`, `safetensors_weights_iterator`, `default_weight_loader` |
 | `atom/model_loader/weight_utils.py` | Weight utilities: `download_weights_from_hf`, `set_weight_attrs`, `filter_duplicate_safetensors_files` |

--- a/docs/scheduling_kv_cache_guide.md
+++ b/docs/scheduling_kv_cache_guide.md
@@ -111,11 +111,25 @@ When a decode step cannot extend a sequence's KV cache (no free blocks), the sch
 ```python
 def preempt(self, seq: Sequence):
     seq.status = SequenceStatus.WAITING
+    # Strip placeholder + rejected draft tokens added by postprocess.
+    if self.mtp_k > 0:
+        strip = self.mtp_k + seq.num_rejected
+        if strip > 0:
+            del seq.token_ids[-strip:]
+            del seq.output_tokens[-strip:]
+            seq.num_tokens -= strip
+    seq.num_rejected = 0
+    seq.num_bonus_tokens = 0
+    seq.spec_token_ids = np.array([], dtype=np.int32)
     self.block_manager.deallocate(seq)
     self.waiting.appendleft(seq)
 ```
 
 The preempted sequence is pushed to the front of the waiting queue and its blocks are fully deallocated, so it will be re-prefilled on the next scheduling cycle.
+
+**MTP placeholder stripping:** When speculative decoding is active (`mtp_k > 0`), `postprocess()` appends placeholder tokens (EOS) to running sequences to reserve KV cache slots for the next step (see section 5.6). If a sequence is preempted before those placeholders are consumed, they must be removed so that re-prefill starts from the correct token history. The strip count is `mtp_k + seq.num_rejected` -- this accounts for both the `mtp_k` placeholder slots and any tokens that were rejected during the last verification step. The method deletes that many trailing entries from both `seq.token_ids` and `seq.output_tokens` and decrements `seq.num_tokens` accordingly.
+
+**Speculative state reset:** After stripping, the sequence's speculative decoding state is fully cleared: `num_rejected` and `num_bonus_tokens` are zeroed, and `spec_token_ids` is set to an empty array. This ensures the sequence re-enters the scheduling pipeline with a clean state -- no stale draft predictions or acceptance metadata carry over across preemption.
 
 ---
 

--- a/recipes/Qwen3.5.md
+++ b/recipes/Qwen3.5.md
@@ -1,0 +1,81 @@
+# Qwen3.5 Usage Guide
+
+[Qwen3.5](https://huggingface.co/Qwen/Qwen3.5-397B-A17B-FP8) is a large language model developed by the Qwen team from Alibaba Cloud. It features several key architectural innovations:
+* A hybrid attention design mixing Full Attention and Gated-Delta-Net (GDN) linear attention with a 1:3 ratio (`full_attention_interval=4`)
+* A highly sparse Mixture-of-Experts (MoE) structure with 512 routed experts
+* Native Multi-Token Prediction (MTP) with 1 reusable draft layer for speculative decoding
+
+## Preparing environment
+
+Pull the latest docker from https://hub.docker.com/r/rocm/atom/ :
+```bash
+docker pull rocm/atom:latest
+```
+All the operations below will be executed inside the container.
+
+## Launching Qwen3.5 with ATOM
+
+### Serving on 4xMI355 GPUs (TP4, FP8 KV Cache)
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model Qwen/Qwen3.5-397B-A17B-FP8 \
+  --kv_cache_dtype fp8 -tp 4
+```
+
+### Serving with MTP Speculative Decoding
+
+MTP-1 reduces per-token latency with ~94% acceptance rate:
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model Qwen/Qwen3.5-397B-A17B-FP8 \
+  --kv_cache_dtype fp8 -tp 4 \
+  --method mtp --num-speculative-tokens 1
+```
+
+MTP-3 for higher throughput (~83% acceptance rate, 3.49 avg tokens/fwd):
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model Qwen/Qwen3.5-397B-A17B-FP8 \
+  --kv_cache_dtype fp8 -tp 4 \
+  --method mtp --num-speculative-tokens 3
+```
+
+## Performance Metrics
+
+### Benchmarking
+
+```bash
+python -m atom.benchmarks.benchmark_serving \
+  --model=Qwen/Qwen3.5-397B-A17B-FP8 --backend=vllm --base-url=http://localhost:8000 \
+  --dataset-name=random \
+  --random-input-len=1024 --random-output-len=1024 \
+  --random-range-ratio=0.8 \
+  --num-prompts=1280 --max-concurrency=128 \
+  --request-rate=inf --ignore-eos \
+  --save-result --percentile-metrics="ttft,tpot,itl,e2el"
+```
+
+### Accuracy
+
+Install `lm-eval` first:
+```bash
+pip install lm-eval[api]
+```
+
+Run the evaluation:
+```bash
+lm_eval --model local-completions \
+  --model_args model=Qwen/Qwen3.5-397B-A17B-FP8,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False \
+  --tasks gsm8k --num_fewshot 3
+```
+
+Reference values (TP4, FP8 KV Cache, MTP-1):
+```
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.8613|±  |0.0095|
+|     |       |strict-match    |     3|exact_match|↑  |0.8484|±  |0.0099|
+```


### PR DESCRIPTION
## Summary

- **Qwen3.5 MTP**: Add Qwen3_5MTPModel with GDN hybrid attention (MTP1/MTP3), fix causal_conv1d_update VARLEN stride bug, MHA/MLA branching in EagleProposer, table-driven MTP config
- **Dashboard**: MTP acceptance rate columns/charts in accuracy table, model name normalization via models_map.js, backend-only accuracy filter
- **CI/Pipeline**: Use plugin_benchmark_to_dashboard.py, extract MTP acceptance from accuracy tests, add Qwen3.5 MTP3 to nightly

## Test plan

- [x] GSM8K: Qwen3.5 FP8 = 0.8673, MTP3 = 0.8666 (threshold 0.85)
- [x] Dashboard preview verified with real + mock data
- [ ] CI nightly run with new pipeline
