### PR TITLE
[fix](benchmark): support podman as container engine fallback in vLLM and SGLang benchmark workflows

### DIFF
--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -446,6 +446,19 @@ jobs:
       SGLANG_VERSION_USED: ${{ needs.resolve-atom-source.outputs.selected_sglang_version }}
       PUBLISH_TO_DASHBOARD: ${{ needs.resolve-atom-source.outputs.publish_to_dashboard }}
     steps:
+      - name: Detect container engine
+        run: |
+          if docker info > /dev/null 2>&1; then
+            echo "CONTAINER_ENGINE=docker" >> "$GITHUB_ENV"
+            echo "Container engine: docker"
+          elif command -v podman > /dev/null 2>&1; then
+            echo "CONTAINER_ENGINE=podman" >> "$GITHUB_ENV"
+            echo "Container engine: podman"
+          else
+            echo "ERROR: Neither docker nor podman is available on this runner."
+            exit 1
+          fi
+
       - name: Check if model is enabled
         id: check
         run: |
@@ -461,12 +474,12 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         run: |
           echo "=== Cleaning up containers on $(hostname) ==="
-          containers=$(docker ps -q)
+          containers=$($CONTAINER_ENGINE ps -q)
           if [ -n "$containers" ]; then
-            docker kill $containers || true
+            $CONTAINER_ENGINE kill $containers || true
           fi
-          docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
-          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
+          $CONTAINER_ENGINE rm -f "$CONTAINER_NAME" 2>/dev/null || true
+          $CONTAINER_ENGINE run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
 
       - name: Checkout benchmark ATOM source
         if: steps.check.outputs.enabled == 'true'
@@ -483,10 +496,10 @@ jobs:
           echo "ATOM_SOURCE_SHA=${SOURCE_SHA}" >> "$GITHUB_ENV"
           echo "Benchmarking ${ATOM_SOURCE_REPOSITORY}@${ATOM_SOURCE_REF} (${SOURCE_SHA}) with ${SGLANG_IMAGE_SOURCE} image ${SGLANG_IMAGE_TAG}"
 
-      - name: Docker Login
+      - name: Container Engine Login
         if: steps.check.outputs.enabled == 'true'
         run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          echo "${{ secrets.DOCKER_PASSWORD }}" | $CONTAINER_ENGINE login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Set HF_TOKEN
         if: steps.check.outputs.enabled == 'true'
@@ -496,7 +509,7 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         run: |
           echo "Pulling SGLang benchmark image: ${SGLANG_IMAGE_TAG}"
-          docker pull "${SGLANG_IMAGE_TAG}"
+          $CONTAINER_ENGINE pull "${SGLANG_IMAGE_TAG}"
 
       - name: Prepare model cache mount
         if: steps.check.outputs.enabled == 'true'
@@ -536,7 +549,7 @@ jobs:
           ${{ matrix.model.env_vars }}
           EOF
 
-          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
+          $CONTAINER_ENGINE run -dt --device=/dev/kfd $DEVICE_FLAG \
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
@@ -558,12 +571,12 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         id: gpu-info
         run: |
-          GPU_NAME=$(docker exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
+          GPU_NAME=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
           if [ -z "$GPU_NAME" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
-            GPU_NAME=$(docker exec "$CONTAINER_NAME" rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
+            GPU_NAME=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
           fi
-          GPU_VRAM_GB=$(docker exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
-          ROCM_VERSION=$(docker exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
+          GPU_VRAM_GB=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
+          ROCM_VERSION=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
           echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT
           echo "gpu_vram_gb=${GPU_VRAM_GB}" >> $GITHUB_OUTPUT
           echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
@@ -584,7 +597,7 @@ jobs:
           fi
           if [ -n "${MODEL_CACHE_MOUNT}" ]; then
             echo "/models directory found, downloading model to ${model_dir}"
-            if ! docker exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "hf download \"${MODEL_SOURCE_PATH}\" --local-dir \"$model_dir\""; then
+            if ! $CONTAINER_ENGINE exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "hf download \"${MODEL_SOURCE_PATH}\" --local-dir \"$model_dir\""; then
               echo "Model download failed for '${MODEL_SOURCE_PATH}'. Aborting."
               exit 1
             fi
@@ -616,7 +629,7 @@ jobs:
       - name: Prepare SGLang benchmark runner in container
         if: steps.check.outputs.enabled == 'true'
         run: |
-          docker exec "$CONTAINER_NAME" bash -lc "
+          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "
             set -euo pipefail
             rm -rf \"${CONTAINER_BENCH_SERVING_DIR%/bench_serving}\"
             mkdir -p \"${CONTAINER_BENCH_SERVING_DIR%/bench_serving}\"
@@ -632,7 +645,7 @@ jobs:
           STREAM_SGLANG_LOGS: "1"
         run: |
           set -euo pipefail
-          docker exec \
+          $CONTAINER_ENGINE exec \
             -e SGLANG_MODEL_NAME="${MODEL_NAME}" \
             -e SGLANG_MODEL_PATH="${SGLANG_RESOLVED_MODEL_PATH:-$MODEL_PATH}" \
             -e SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS}" \
@@ -651,7 +664,7 @@ jobs:
 
           echo "=== Benchmark config: ${MODEL_NAME} ISL=${ISL} OSL=${OSL} CONC=${CONC} RANDOM_RANGE_RATIO=${RANDOM_RANGE_RATIO} ==="
 
-          docker exec \
+          $CONTAINER_ENGINE exec \
             -e ISL="${ISL}" \
             -e OSL="${OSL}" \
             -e CONC="${CONC}" \
@@ -683,7 +696,7 @@ jobs:
                 ${BENCH_EXTRA_ARGS:-}
             "
 
-          docker exec -i \
+          $CONTAINER_ENGINE exec -i \
             -e RESULT_PATH="${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" \
             -e ISL="${ISL}" \
             -e OSL="${OSL}" \
@@ -736,7 +749,7 @@ jobs:
               json.dump(data, f, indent=2)
           PY
 
-          docker cp "${CONTAINER_NAME}:${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" "./${RESULT_FILENAME}.json"
+          $CONTAINER_ENGINE cp "${CONTAINER_NAME}:${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" "./${RESULT_FILENAME}.json"
 
       - name: Inject GPU metadata into benchmark results
         if: steps.check.outputs.enabled == 'true'
@@ -778,11 +791,11 @@ jobs:
       - name: Clean up SGLang benchmark container
         if: always() && steps.check.outputs.enabled == 'true'
         run: |
-          docker exec "$CONTAINER_NAME" bash -lc "if [ -f /tmp/atom_sglang.pid ]; then kill \$(cat /tmp/atom_sglang.pid) || true; fi" || true
-          docker stop "$CONTAINER_NAME" || true
-          docker rm "$CONTAINER_NAME" || true
+          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "if [ -f /tmp/atom_sglang.pid ]; then kill \$(cat /tmp/atom_sglang.pid) || true; fi" || true
+          $CONTAINER_ENGINE stop "$CONTAINER_NAME" || true
+          $CONTAINER_ENGINE rm "$CONTAINER_NAME" || true
           if [[ "${SGLANG_IMAGE_SOURCE}" == "rebuild" ]]; then
-            docker rmi "$SGLANG_IMAGE_TAG" || true
+            $CONTAINER_ENGINE rmi "$SGLANG_IMAGE_TAG" || true
           else
             echo "Keeping prebuilt SGLang image cached on runner: ${SGLANG_IMAGE_TAG}"
           fi

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -353,6 +353,7 @@ jobs:
           RUN pip uninstall -y amd-aiter
           RUN pip install --upgrade "pybind11>=3.0.1"
           RUN pip show pybind11
+          RUN pip install "vcs-versioning>=1"
           RUN rm -rf /app/aiter-test
           RUN git clone --depth 1 https://github.com/ROCm/aiter.git /app/aiter-test && \\
               cd /app/aiter-test && \\

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -500,7 +500,14 @@ jobs:
       - name: Container Engine Login
         if: steps.check.outputs.enabled == 'true'
         run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | $CONTAINER_ENGINE login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          # Podman requires an explicit registry when registries.conf has no search list;
+          # Docker Hub short names (e.g. rocm/foo) must use docker.io here.
+          REG="${SGLANG_IMAGE_TAG%%/*}"
+          if [[ "$REG" != *.* && "$REG" != localhost* && "$REG" != *:* ]]; then
+            REG="docker.io"
+          fi
+          echo "Logging in to registry: ${REG}"
+          echo "${{ secrets.DOCKER_PASSWORD }}" | $CONTAINER_ENGINE login "$REG" -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Set HF_TOKEN
         if: steps.check.outputs.enabled == 'true'
@@ -509,8 +516,21 @@ jobs:
       - name: Pull SGLang benchmark image
         if: steps.check.outputs.enabled == 'true'
         run: |
-          echo "Pulling SGLang benchmark image: ${SGLANG_IMAGE_TAG}"
-          $CONTAINER_ENGINE pull "${SGLANG_IMAGE_TAG}"
+          set -euo pipefail
+          IMG="${SGLANG_IMAGE_TAG}"
+          if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
+            if [[ "${IMG}" != */* ]]; then
+              IMG="docker.io/library/${IMG}"
+            else
+              reg="${IMG%%/*}"
+              if [[ "${reg}" != *.* && "${reg}" != localhost* && "${reg}" != *:* ]]; then
+                IMG="docker.io/${IMG}"
+              fi
+            fi
+          fi
+          echo "SGLANG_IMAGE_REF=${IMG}" >> "$GITHUB_ENV"
+          echo "Pulling SGLang benchmark image: ${IMG} (workflow tag: ${SGLANG_IMAGE_TAG})"
+          $CONTAINER_ENGINE pull "${IMG}"
 
       - name: Prepare model cache mount
         if: steps.check.outputs.enabled == 'true'
@@ -550,12 +570,17 @@ jobs:
           ${{ matrix.model.env_vars }}
           EOF
 
+          SHM_FLAG=(--shm-size=16G)
+          if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
+            SHM_FLAG=()
+          fi
+
           $CONTAINER_ENGINE run -dt --device=/dev/kfd $DEVICE_FLAG \
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
             --ipc=host --group-add video \
-            --shm-size=16G \
+            "${SHM_FLAG[@]}" \
             --privileged \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \
@@ -564,7 +589,7 @@ jobs:
             --env-file /tmp/oot_env_file.txt \
             -e HF_TOKEN="${HF_TOKEN:-}" \
             --name "$CONTAINER_NAME" \
-            "${SGLANG_IMAGE_TAG}"
+            "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}"
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
@@ -796,7 +821,7 @@ jobs:
           $CONTAINER_ENGINE stop "$CONTAINER_NAME" || true
           $CONTAINER_ENGINE rm "$CONTAINER_NAME" || true
           if [[ "${SGLANG_IMAGE_SOURCE}" == "rebuild" ]]; then
-            $CONTAINER_ENGINE rmi "$SGLANG_IMAGE_TAG" || true
+            $CONTAINER_ENGINE rmi "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}" || true
           else
             echo "Keeping prebuilt SGLang image cached on runner: ${SGLANG_IMAGE_TAG}"
           fi

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -654,7 +654,14 @@ jobs:
       - name: Container Engine Login
         if: steps.check.outputs.enabled == 'true'
         run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | $CONTAINER_ENGINE login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          # Podman requires an explicit registry when registries.conf has no search list;
+          # Docker Hub short names (e.g. rocm/foo) must use docker.io here.
+          REG="${OOT_IMAGE_TAG%%/*}"
+          if [[ "$REG" != *.* && "$REG" != localhost* && "$REG" != *:* ]]; then
+            REG="docker.io"
+          fi
+          echo "Logging in to registry: ${REG}"
+          echo "${{ secrets.DOCKER_PASSWORD }}" | $CONTAINER_ENGINE login "$REG" -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Set HF_TOKEN
         if: steps.check.outputs.enabled == 'true'
@@ -663,8 +670,21 @@ jobs:
       - name: Pull OOT benchmark image
         if: steps.check.outputs.enabled == 'true'
         run: |
-          echo "Pulling OOT benchmark image: ${OOT_IMAGE_TAG}"
-          $CONTAINER_ENGINE pull "${OOT_IMAGE_TAG}"
+          set -euo pipefail
+          IMG="${OOT_IMAGE_TAG}"
+          if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
+            if [[ "${IMG}" != */* ]]; then
+              IMG="docker.io/library/${IMG}"
+            else
+              reg="${IMG%%/*}"
+              if [[ "${reg}" != *.* && "${reg}" != localhost* && "${reg}" != *:* ]]; then
+                IMG="docker.io/${IMG}"
+              fi
+            fi
+          fi
+          echo "OOT_IMAGE_REF=${IMG}" >> "$GITHUB_ENV"
+          echo "Pulling OOT benchmark image: ${IMG} (workflow tag: ${OOT_IMAGE_TAG})"
+          $CONTAINER_ENGINE pull "${IMG}"
 
       - name: Prepare model cache mount
         if: steps.check.outputs.enabled == 'true'
@@ -704,12 +724,17 @@ jobs:
           ${{ matrix.model.env_vars }}
           EOF
 
+          SHM_FLAG=(--shm-size=16G)
+          if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
+            SHM_FLAG=()
+          fi
+
           $CONTAINER_ENGINE run -dt --device=/dev/kfd $DEVICE_FLAG \
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
             --ipc=host --group-add video \
-            --shm-size=16G \
+            "${SHM_FLAG[@]}" \
             --privileged \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \
@@ -718,7 +743,7 @@ jobs:
             --env-file /tmp/oot_env_file.txt \
             -e HF_TOKEN="${HF_TOKEN:-}" \
             --name "$CONTAINER_NAME" \
-            "${OOT_IMAGE_TAG}"
+            "${OOT_IMAGE_REF:-${OOT_IMAGE_TAG}}"
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
@@ -950,7 +975,7 @@ jobs:
           $CONTAINER_ENGINE stop "$CONTAINER_NAME" || true
           $CONTAINER_ENGINE rm "$CONTAINER_NAME" || true
           if [[ "${OOT_IMAGE_SOURCE}" == "rebuild" ]]; then
-            $CONTAINER_ENGINE rmi "$OOT_IMAGE_TAG" || true
+            $CONTAINER_ENGINE rmi "${OOT_IMAGE_REF:-${OOT_IMAGE_TAG}}" || true
           else
             echo "Keeping prebuilt OOT image cached on runner: ${OOT_IMAGE_TAG}"
           fi

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -588,6 +588,19 @@ jobs:
       VLLM_VERSION_USED: ${{ needs.resolve-atom-source.outputs.selected_vllm_version }}
       PUBLISH_TO_DASHBOARD: ${{ needs.resolve-atom-source.outputs.publish_to_dashboard }}
     steps:
+      - name: Detect container engine
+        run: |
+          if docker info > /dev/null 2>&1; then
+            echo "CONTAINER_ENGINE=docker" >> "$GITHUB_ENV"
+            echo "Container engine: docker"
+          elif command -v podman > /dev/null 2>&1; then
+            echo "CONTAINER_ENGINE=podman" >> "$GITHUB_ENV"
+            echo "Container engine: podman"
+          else
+            echo "ERROR: Neither docker nor podman is available on this runner."
+            exit 1
+          fi
+
       - name: Check if model is enabled
         id: check
         run: |
@@ -616,12 +629,12 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         run: |
           echo "=== Cleaning up containers on $(hostname) ==="
-          containers=$(docker ps -q)
+          containers=$($CONTAINER_ENGINE ps -q)
           if [ -n "$containers" ]; then
-            docker kill $containers || true
+            $CONTAINER_ENGINE kill $containers || true
           fi
-          docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
-          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
+          $CONTAINER_ENGINE rm -f "$CONTAINER_NAME" 2>/dev/null || true
+          $CONTAINER_ENGINE run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
 
       - name: Checkout benchmark ATOM source
         if: steps.check.outputs.enabled == 'true'
@@ -638,10 +651,10 @@ jobs:
           echo "ATOM_SOURCE_SHA=${SOURCE_SHA}" >> "$GITHUB_ENV"
           echo "Benchmarking ${ATOM_SOURCE_REPOSITORY}@${ATOM_SOURCE_REF} (${SOURCE_SHA}) with ${OOT_IMAGE_SOURCE} image ${OOT_IMAGE_TAG}"
 
-      - name: Docker Login
+      - name: Container Engine Login
         if: steps.check.outputs.enabled == 'true'
         run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          echo "${{ secrets.DOCKER_PASSWORD }}" | $CONTAINER_ENGINE login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Set HF_TOKEN
         if: steps.check.outputs.enabled == 'true'
@@ -651,7 +664,7 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         run: |
           echo "Pulling OOT benchmark image: ${OOT_IMAGE_TAG}"
-          docker pull "${OOT_IMAGE_TAG}"
+          $CONTAINER_ENGINE pull "${OOT_IMAGE_TAG}"
 
       - name: Prepare model cache mount
         if: steps.check.outputs.enabled == 'true'
@@ -691,7 +704,7 @@ jobs:
           ${{ matrix.model.env_vars }}
           EOF
 
-          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
+          $CONTAINER_ENGINE run -dt --device=/dev/kfd $DEVICE_FLAG \
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
@@ -713,12 +726,12 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         id: gpu-info
         run: |
-          GPU_NAME=$(docker exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
+          GPU_NAME=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
           if [ -z "$GPU_NAME" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
-            GPU_NAME=$(docker exec "$CONTAINER_NAME" rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
+            GPU_NAME=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
           fi
-          GPU_VRAM_GB=$(docker exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
-          ROCM_VERSION=$(docker exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
+          GPU_VRAM_GB=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
+          ROCM_VERSION=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
           echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT
           echo "gpu_vram_gb=${GPU_VRAM_GB}" >> $GITHUB_OUTPUT
           echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
@@ -739,7 +752,7 @@ jobs:
           fi
           if [ -n "${MODEL_CACHE_MOUNT}" ]; then
             echo "/models directory found, downloading model to ${model_dir}"
-            if ! docker exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "hf download \"${MODEL_SOURCE_PATH}\" --local-dir \"$model_dir\""; then
+            if ! $CONTAINER_ENGINE exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "hf download \"${MODEL_SOURCE_PATH}\" --local-dir \"$model_dir\""; then
               echo "Model download failed for '${MODEL_SOURCE_PATH}'. Aborting."
               exit 1
             fi
@@ -771,7 +784,7 @@ jobs:
       - name: Prepare OOT benchmark runner in container
         if: steps.check.outputs.enabled == 'true'
         run: |
-          docker exec "$CONTAINER_NAME" bash -lc "
+          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "
             set -euo pipefail
             rm -rf \"${CONTAINER_BENCH_SERVING_DIR%/bench_serving}\"
             mkdir -p \"${CONTAINER_BENCH_SERVING_DIR%/bench_serving}\"
@@ -787,7 +800,7 @@ jobs:
           STREAM_VLLM_LOGS: "1"
         run: |
           set -euo pipefail
-          docker exec \
+          $CONTAINER_ENGINE exec \
             -e OOT_MODEL_NAME="${MODEL_NAME}" \
             -e OOT_MODEL_PATH="${OOT_RESOLVED_MODEL_PATH:-$MODEL_PATH}" \
             -e OOT_EXTRA_ARGS="${OOT_EXTRA_ARGS}" \
@@ -806,7 +819,7 @@ jobs:
 
           echo "=== Benchmark config: ${MODEL_NAME} ISL=${ISL} OSL=${OSL} CONC=${CONC} RANDOM_RANGE_RATIO=${RANDOM_RANGE_RATIO} ==="
 
-          docker exec \
+          $CONTAINER_ENGINE exec \
             -e ISL="${ISL}" \
             -e OSL="${OSL}" \
             -e CONC="${CONC}" \
@@ -838,7 +851,7 @@ jobs:
                 ${BENCH_EXTRA_ARGS:-}
             "
 
-          docker exec -i \
+          $CONTAINER_ENGINE exec -i \
             -e RESULT_PATH="${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" \
             -e ISL="${ISL}" \
             -e OSL="${OSL}" \
@@ -891,7 +904,7 @@ jobs:
               json.dump(data, f, indent=2)
           PY
 
-          docker cp "${CONTAINER_NAME}:${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" "./${RESULT_FILENAME}.json"
+          $CONTAINER_ENGINE cp "${CONTAINER_NAME}:${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" "./${RESULT_FILENAME}.json"
 
       - name: Inject GPU metadata into benchmark results
         if: steps.check.outputs.enabled == 'true'
@@ -933,11 +946,11 @@ jobs:
       - name: Clean up OOT benchmark container
         if: always() && steps.check.outputs.enabled == 'true'
         run: |
-          docker exec "$CONTAINER_NAME" bash -lc "if [ -f /tmp/vllm_oot.pid ]; then kill \$(cat /tmp/vllm_oot.pid) || true; fi" || true
-          docker stop "$CONTAINER_NAME" || true
-          docker rm "$CONTAINER_NAME" || true
+          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "if [ -f /tmp/vllm_oot.pid ]; then kill \$(cat /tmp/vllm_oot.pid) || true; fi" || true
+          $CONTAINER_ENGINE stop "$CONTAINER_NAME" || true
+          $CONTAINER_ENGINE rm "$CONTAINER_NAME" || true
           if [[ "${OOT_IMAGE_SOURCE}" == "rebuild" ]]; then
-            docker rmi "$OOT_IMAGE_TAG" || true
+            $CONTAINER_ENGINE rmi "$OOT_IMAGE_TAG" || true
           else
             echo "Keeping prebuilt OOT image cached on runner: ${OOT_IMAGE_TAG}"
           fi


### PR DESCRIPTION
## Motivation

  On some runner machines, the Docker daemon socket is not accessible due to permission restrictions:                                                                                                                                                      
                                                                                                                                                                                                                                                           
  permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock                                                                                                                                                     
                                                                                                                                                                                                                                                           
  This caused the `Clean up containers and workspace` step to fail immediately (exit code 1) in both the vLLM and SGLang benchmark workflows, as seen in [run #24568937536](https://github.com/ROCm/ATOM/actions/runs/24568937536/job/71836637164). These machines have Podman installed as an alternative container runtime.                                                                                                                                                                                      
                                                                  
## Technical Details                                                                                                                                                                                                                                       
                                                                  
  Both `atom-vllm-benchmark.yaml` and `atom-sglang-benchmark.yaml` `benchmark` jobs are updated to:                                                                                                                                                        
                                                                  
  - Add a **`Detect container engine`** step at the beginning of each `benchmark` job that checks if `docker` is available (via `docker info`), falls back to `podman` if not, and exports the result as `CONTAINER_ENGINE` env var. Fails fast if neither 
  is found.                                                       
  - Replace all hardcoded `docker` calls with `$CONTAINER_ENGINE` throughout the `benchmark` job: `run`, `exec`, `cp`, `pull`, `login`, `stop`, `rm`, `rmi`, `kill`, `ps`.                                                                                 
                                                                                                                                                                                                                                                           
  The `build-vllm-image` and `build-sglang-image` jobs (which run on `build-only-atom` runners with full Docker access) are intentionally left unchanged.                                                                                                   
                                                                                                                                                                                                                                                           
  ### Notes                                                                                                                                                                                                                                   
                                                                  
  - Podman's CLI is a drop-in replacement for Docker for all commands used here (`run`, `exec`, `cp`, `pull`, `login`, `stop`, `rm`, `rmi`).                                                                                                               
  - `podman login` writes to `~/.config/containers/auth.json`; `podman pull` reads from it automatically — no functional difference.
  - `podman run --privileged` works correctly in rootful Podman mode (which is required on these machines to access GPU devices anyway). 
