### PR TITLE
fix(dashboard): regression detection, MTP parsing, TP/GPU display

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -93,7 +93,7 @@
     "display": "MiniMax-M2.5-MXFP4",
     "path": "amd/MiniMax-M2.5-MXFP4",
     "prefix": "MiniMax-M2.5-MXFP4",
-    "args": "--kv_cache_dtype fp8 --trust-remote-code",
+    "args": "--kv_cache_dtype fp8 -tp 1 --trust-remote-code",
     "bench_args": "",
     "suffix": "",
     "runner": "atom-mi355-8gpu.predownload",

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -26,7 +26,7 @@
   {
     "model_name": "DeepSeek-R1-0528 MTP",
     "model_path": "deepseek-ai/DeepSeek-R1-0528",
-    "extraArgs": "--kv_cache_dtype fp8 -tp 8 --method mtp",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 8 --method mtp --num-speculative-tokens 3",
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "main",
@@ -74,7 +74,7 @@
   {
     "model_name": "DeepSeek-R1-0528-FP4 MTP",
     "model_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
-    "extraArgs": "--kv_cache_dtype fp8 -tp 4 --method mtp",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 4 --method mtp --num-speculative-tokens 3",
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "pr",
@@ -192,7 +192,7 @@
     "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
   },
   {
-    "model_name": "Qwen3.5-397B-A17B-FP8 MTP3",
+    "model_name": "Qwen3.5-397B-A17B-FP8 MTP",
     "model_path": "Qwen/Qwen3.5-397B-A17B-FP8",
     "extraArgs": "--kv_cache_dtype fp8 -tp 4 --method mtp --num-speculative-tokens 3",
     "env_vars": "",

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -507,7 +507,13 @@ const rawData = window.BENCHMARK_DATA;
 // Normalize legacy model names using HF-path->display mapping from models_map.js
 const _displayMap = window.MODELS_DISPLAY_MAP || {};
 const _displayEntries = Object.entries(_displayMap).sort((a, b) => b[0].length - a[0].length);
+// Accuracy model name renames: unify legacy "MTP3" suffix to "MTP"
+// TODO: Remove after old "MTP3" data ages out of dashboard history (~90 runs)
+const _accuracyRenames = {
+  'Qwen3.5-397B-A17B-FP8 MTP3': 'Qwen3.5-397B-A17B-FP8 MTP',
+};
 function normalizeModelName(name) {
+  if (_accuracyRenames[name]) return _accuracyRenames[name];
   const lc = name.toLowerCase();
   for (const [key, display] of _displayEntries) {
     if (lc === key) return display;
@@ -533,10 +539,10 @@ function parseBenchName(name) {
   // avg toks/fwd: "ModelName avg toks/fwd (tok/fwd)"
   m = rawName.match(/^(.+?)\s+avg toks\/fwd\s+\((.+)\)$/);
   if (m) return { backend, model: normalizeModelName(m[1]), metric: 'avg toks/fwd', unit: m[2] };
-  m = rawName.match(/^(\S+)\s+(\d+\/\d+)\s+c=(\d+)\s+(.+?)\s*\((.+)\)$/);
+  m = rawName.match(/^(.+?)\s+(\d+\/\d+)\s+c=(\d+)\s+(.+?)\s*\((.+)\)$/);
   if (m) return { backend, model: normalizeModelName(m[1]), islOsl: m[2], conc: +m[3], metric: m[4].trim(), unit: m[5] };
-  m = rawName.match(/^(\S+)\s+(\d+\/\d+)\s+c=(\d+)\s+(_gpu_count)$/);
-  if (m) return { backend, model: normalizeModelName(m[1]), islOsl: m[2], conc: +m[3], metric: '_gpu_count', unit: '' };
+  m = rawName.match(/^(.+?)\s+(\d+\/\d+)\s+c=(\d+)\s+(_gpu_count|_tp)$/);
+  if (m) return { backend, model: normalizeModelName(m[1]), islOsl: m[2], conc: +m[3], metric: m[4], unit: '' };
   return null;
 }
 
@@ -597,6 +603,9 @@ function detectRegressions() {
     if (!prev || !prev['Total Tput'] || !cfg['Total Tput']) continue;
     const tputChange = (cfg['Total Tput'] - prev['Total Tput']) / prev['Total Tput'];
     const tpotChange = (prev.TPOT && cfg.TPOT) ? (cfg.TPOT - prev.TPOT) / prev.TPOT : 0;
+    // Skip regression check when throughput improved significantly —
+    // TPOT increase alongside throughput gain is a normal batching tradeoff, not a regression.
+    if (tputChange >= REGRESSION_WARNING) continue;
     const worstDelta = Math.max(-tputChange, tpotChange);
     if (worstDelta >= REGRESSION_WARNING) {
       const severity = worstDelta >= REGRESSION_CRITICAL ? 'critical' : 'warning';
@@ -1178,7 +1187,7 @@ function renderKPICards() {
 
   const models = new Set(entries.map(([, c]) => c.model));
   const backends = new Set(entries.map(([, c]) => c.backend));
-  const gpuCounts = [...new Set(entries.map(([, c]) => c._gpu_count).filter(Boolean))].sort((a, b) => a - b);
+  const gpuCounts = [...new Set(entries.map(([, c]) => c._gpu_count || c._tp).filter(Boolean))].sort((a, b) => a - b);
   const gpuLabel = gpuCounts.length === 1 ? gpuCounts[0] + '× GPU' : gpuCounts.length > 1 ? gpuCounts[0] + '-' + gpuCounts[gpuCounts.length - 1] + '× GPU' : '';
 
   // GPU platform info from latest configs
@@ -1462,7 +1471,7 @@ function renderPerformanceTab() {
       <td class="model-name" style="color:${modelTextColor}">${reg ? '⚠ ' : ''}${escHTML(cfg.model)}</td>
       <td>${fmtIslOsl(cfg.islOsl)}</td>
       <td class="num">${cfg.conc}</td>
-      <td class="num">${cfg._gpu_count || '—'}</td>
+      <td class="num">${cfg._tp || cfg._gpu_count || 1}</td>
       <td style="white-space:nowrap;font-size:11px">${cfg._gpu_name ? (cfg._gpu_count ? cfg._gpu_count + '× ' : '') + cfg._gpu_name : '—'}</td>
       <td class="num data-bar"><div class="data-bar-fill" style="width:${totalTputPct}%;background:rgba(109,191,128,0.12)"></div><span class="data-bar-text">${cfg['Total Tput'] != null ? fmtNum(cfg['Total Tput'], 1) : '—'}</span></td>
       <td class="num data-bar"><div class="data-bar-fill" style="width:${outTputPct}%;background:rgba(126,143,174,0.10)"></div><span class="data-bar-text">${fmtNum(cfg.throughput, 1)}</span></td>
@@ -1604,7 +1613,7 @@ function renderTradeoffTab() {
     if (!seriesMap[sKey]) seriesMap[sKey] = { backend: cfg.backend, model: cfg.model, islOsl: cfg.islOsl, points: [], concLabels: [], configKeys: [] };
     const tpot = cfg.TPOT;
     const totalTput = cfg['Total Tput'];
-    const gpuCount = cfg._gpu_count || 8;
+    const gpuCount = cfg._gpu_count || cfg._tp || 1;
     if (tpot && tpot > 0 && totalTput) {
       seriesMap[sKey].points.push({ x: 1000 / tpot, y: totalTput / gpuCount });
       seriesMap[sKey].concLabels.push(cfg.conc);
@@ -1817,7 +1826,7 @@ function buildConcurrencyScaling(canvasId, configs, familyName, famModels) {
   for (const [key, cfg] of Object.entries(configs)) {
     const sKey = `${cfg.backend}|${cfg.model}|${cfg.islOsl}`;
     if (!byKey[sKey]) byKey[sKey] = { backend: cfg.backend, model: cfg.model, islOsl: cfg.islOsl, tputPoints: [], tpotPoints: [], tputKeys: [], tpotKeys: [] };
-    const gpuCount = cfg._gpu_count || 8;
+    const gpuCount = cfg._gpu_count || cfg._tp || 1;
     if (cfg['Total Tput'] != null) { byKey[sKey].tputPoints.push({ x: cfg.conc, y: cfg['Total Tput'] / gpuCount }); byKey[sKey].tputKeys.push(key); }
     if (cfg.TPOT != null) { byKey[sKey].tpotPoints.push({ x: cfg.conc, y: cfg.TPOT }); byKey[sKey].tpotKeys.push(key); }
   }
@@ -2010,8 +2019,8 @@ function renderTrendsTab() {
           let val = pt[met.key];
           // Normalize Total Tput to per-GPU for cross-config comparability
           if (met.key === 'Total Tput') {
-            const gpuCount = pt._gpu_count;
-            if (!Number.isFinite(gpuCount) || gpuCount <= 0) continue;
+            const gpuCount = pt._gpu_count || pt._tp;
+            if (!gpuCount) continue;
             val = val / gpuCount;
           }
           pointMap[matchLabel] = val;
@@ -2161,7 +2170,7 @@ function renderDataTab() {
           if (!state.filters.islOsl.includes(cfg.islOsl)) continue;
           if (!state.filters.conc.includes(cfg.conc)) continue;
           rows.push([fmtDate(cfg.date), cfg.commit.id?.slice(0,7), cfg.backend, cfg.model, cfg.islOsl, cfg.conc,
-            cfg._gpu_count ?? '', cfg['Total Tput'] ?? '', cfg.TPOT ?? '', cfg.TTFT ?? '', cfg.runUrl].join(','));
+            cfg._tp ?? cfg._gpu_count ?? '', cfg['Total Tput'] ?? '', cfg.TPOT ?? '', cfg.TTFT ?? '', cfg.runUrl].join(','));
         }
       }
       navigator.clipboard.writeText(header + '\n' + rows.join('\n'));
@@ -2229,7 +2238,7 @@ function renderDataTable() {
       case 'model': return dir * a.cfg.model.localeCompare(b.cfg.model);
       case 'islOsl': return dir * a.cfg.islOsl.localeCompare(b.cfg.islOsl);
       case 'conc': return dir * (a.cfg.conc - b.cfg.conc);
-      case 'tp': return dir * ((a.cfg._gpu_count || 0) - (b.cfg._gpu_count || 0));
+      case 'tp': return dir * ((a.cfg._tp || a.cfg._gpu_count || 0) - (b.cfg._tp || b.cfg._gpu_count || 0));
       case 'gpu': return dir * (a.cfg._gpu_name || '').localeCompare(b.cfg._gpu_name || '');
       case 'totalTput': return dir * ((a.cfg['Total Tput'] || 0) - (b.cfg['Total Tput'] || 0));
       case 'tpot': return dir * ((a.cfg.TPOT || 0) - (b.cfg.TPOT || 0));
@@ -2263,7 +2272,7 @@ function renderDataTable() {
       <td class="model-name" style="color:${getModelColor(cfg.backend, cfg.model).text}">${escHTML(cfg.model)}</td>
       <td>${fmtIslOsl(cfg.islOsl)}</td>
       <td class="num">${cfg.conc}</td>
-      <td class="num">${cfg._gpu_count || '—'}</td>
+      <td class="num">${cfg._tp || cfg._gpu_count || 1}</td>
       <td style="white-space:nowrap;font-size:11px">${cfg._gpu_count ? cfg._gpu_count + '× ' : ''}${escHTML(cfg._gpu_name || '—')}</td>
       <td class="num">${cfg['Total Tput'] != null ? fmtNum(cfg['Total Tput'], 1) : '—'}</td>
       <td class="num">${cfg.TPOT != null ? fmtNum(cfg.TPOT, 2) : '—'}</td>
@@ -2313,7 +2322,7 @@ function renderTimeline() {
         </tr></thead><tbody>`;
     for (const [, cfg] of entries) {
       html += `<tr>
-        <td style="white-space:nowrap;font-weight:600">${escHTML(cfg.backend)}</td><td class="model-name" style="color:${getModelColor(cfg.backend, cfg.model).text}">${escHTML(cfg.model)}</td><td>${fmtIslOsl(cfg.islOsl)}</td><td class="num">${cfg.conc}</td><td class="num">${cfg._gpu_count || '—'}</td><td style="white-space:nowrap;font-size:11px">${cfg._gpu_count ? cfg._gpu_count + '× ' : ''}${escHTML(cfg._gpu_name || '—')}</td>
+        <td style="white-space:nowrap;font-weight:600">${escHTML(cfg.backend)}</td><td class="model-name" style="color:${getModelColor(cfg.backend, cfg.model).text}">${escHTML(cfg.model)}</td><td>${fmtIslOsl(cfg.islOsl)}</td><td class="num">${cfg.conc}</td><td class="num">${cfg._tp || cfg._gpu_count || 1}</td><td style="white-space:nowrap;font-size:11px">${cfg._gpu_count ? cfg._gpu_count + '× ' : ''}${escHTML(cfg._gpu_name || '—')}</td>
         <td class="num">${cfg['Total Tput'] != null ? fmtNum(cfg['Total Tput'], 1) : '—'}</td>
         <td class="num">${cfg.TPOT != null ? fmtNum(cfg.TPOT, 2) : '—'}</td>
         <td class="num">${cfg.TTFT != null ? fmtNum(cfg.TTFT, 1) : '—'}</td>
@@ -2341,6 +2350,7 @@ function buildDetailHTML(key, cfg) {
     ['Interactive', interactive, 'tok/s/user', prevInteractive, false],
     ['TPOT', cfg.TPOT, 'ms', prev?.TPOT, true],
     ['TTFT', cfg.TTFT, 'ms', prev?.TTFT, true],
+    ['TP', cfg._tp || cfg._gpu_count, '', null, false],
     ['GPU Count', cfg._gpu_count, '', null, false],
   ].map(([label, val, unit, prevVal, inv]) =>
     `<div class="detail-item"><span class="detail-key">${label}</span><span class="detail-val">${val != null ? fmtNum(val, 2) + ' ' + unit : '—'} ${prevVal != null ? trendHTML(val, prevVal, inv) : ''}</span></div>`

--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -191,10 +191,9 @@ with open(result_file, "w", encoding="utf-8") as f:
 PY
   fi
 
-  # Extract MTP acceptance rate from server log (if MTP enabled)
+  # Extract MTP acceptance rate from server log (if present)
   ATOM_SERVER_LOG="${ATOM_SERVER_LOG:-/tmp/atom_server.log}"
-  SERVER_ARGS="${SERVER_ARGS:-${EXTRA_ARGS[*]:-}}"
-  if [ -f "$ATOM_SERVER_LOG" ] && echo "$SERVER_ARGS" | grep -qi mtp; then
+  if [ -f "$ATOM_SERVER_LOG" ]; then
     RESULT_FILE="${RESULT_FILENAME}" \
     ATOM_SERVER_LOG="$ATOM_SERVER_LOG" \
     python3 - <<'PY'
@@ -321,9 +320,12 @@ d["random_input_len"] = int(os.environ["ISL"])
 d["random_output_len"] = int(os.environ["OSL"])
 d["benchmark_backend"] = "ATOM"
 
-tp_match = re.search(r"-tp\s+(\d+)", os.environ.get("SERVER_ARGS", ""))
-if tp_match:
-    d["tensor_parallel_size"] = int(tp_match.group(1))
+server_args = os.environ.get("SERVER_ARGS", "")
+tp_match = re.search(r"(?:^|\s)-tp\s+(\d+)", server_args)
+d["tensor_parallel_size"] = int(tp_match.group(1)) if tp_match else 1
+dp_match = re.search(r"(?:--data-parallel-size|(?:^|\s)-dp)\s+(\d+)", server_args)
+d["data_parallel_size"] = int(dp_match.group(1)) if dp_match else 1
+d["enable_dp_attention"] = "--enable-dp-attention" in server_args
 
 with open(result_path, "w", encoding="utf-8") as f:
     json.dump(d, f, indent=2)

--- a/.github/scripts/plugin_benchmark_to_dashboard.py
+++ b/.github/scripts/plugin_benchmark_to_dashboard.py
@@ -91,8 +91,13 @@ def build_entries(
         gpu_vram = payload.get("gpu_vram_gb", 0)
         rocm_ver = payload.get("rocm_version", "")
 
-        # Support both OOT and SGLang image tag fields
-        image_tag = payload.get("oot_image_tag", payload.get("sglang_image_tag", ""))
+        # Support ATOM, OOT, and SGLang image tag fields
+        image_tag = (
+            payload.get("docker_image")
+            or payload.get("oot_image_tag")
+            or payload.get("sglang_image_tag")
+            or ""
+        )
 
         if gpu_name:
             extra += f" | GPU: {gpu_name}"
@@ -137,13 +142,26 @@ def build_entries(
             extra=extra,
         )
 
-        gpu_count = payload.get("tensor_parallel_size")
-        if gpu_count is not None:
+        if "tensor_parallel_size" in payload:
+            tp = int(payload["tensor_parallel_size"])
+            dp = int(payload.get("data_parallel_size", 1))
+            dp_attn = payload.get("enable_dp_attention", False)
+            # dp_attention folds DP into TP — each GPU runs independently,
+            # so effective GPU count for throughput normalization is tp alone.
+            gpu_count = tp if dp_attn else tp * dp
+
             entries.append(
                 {
                     "name": f"{label_prefix} _gpu_count",
                     "unit": "",
-                    "value": int(gpu_count),
+                    "value": gpu_count,
+                }
+            )
+            entries.append(
+                {
+                    "name": f"{label_prefix} _tp",
+                    "unit": "",
+                    "value": tp,
                 }
             )
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: MIT
 # Tests for atom/model_engine/scheduler.py — public API only
 
-import pytest
 
 from atom.model_engine.scheduler import Scheduler, ScheduledBatchOutput, SpecStats
 from atom.model_engine.sequence import SequenceStatus, SequenceType
 from atom.sampling_params import SamplingParams
 from conftest import MockConfig
-
 
 # ── SpecStats ──────────────────────────────────────────────────────────────
 
@@ -28,6 +26,7 @@ class TestSpecStats:
     def test_acceptance_rate_zero_when_no_updates(self):
         stats = SpecStats(mtp_k=3)
         assert stats.acceptance_rate == 0.0
+
 
 # ── add / extend / query ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fix false-positive regression alerts when throughput improved (e.g. Qwen3.5 MXFP4 flagged as CRITICAL despite 199.5% throughput gain)
- Fix `parseBenchName` regex to handle multi-word model names like "Qwen3.5-397B-A17B-FP8 MTP3" — previously silently dropped
- Add `_tp` field for correct TP column display, separate from `_gpu_count` (tp*dp)
- Compute `gpu_count = tp * dp` (`tp` alone when `dp_attn` enabled) for accurate per-GPU normalization
- Extract MTP acceptance rate unconditionally from server log (was gated on `SERVER_ARGS` containing "mtp")
- Add `docker_image` field support in benchmark data (was only reading `oot_image_tag`/`sglang_image_tag`)
- Add explicit `-tp 1` for MiniMax-M2.5-MXFP4 benchmark config
- Unify DeepSeek accuracy MTP tests to use `--num-speculative-tokens 3`
- Rename Qwen3.5 accuracy display from "MTP3" to "MTP" with legacy name normalization

## Test plan
- [ ] Local dashboard preview verified with live data.js
- [ ] Regression detection: Qwen3.5 MXFP4 no longer flagged as regression
- [ ] MTP3 perf data visible in detail table and family charts
- [ ] TP column shows correct values (fallback to 1 when missing)
- [ ] MiniMax-M2.5-MXFP4 shows TP=1 instead of "—"
- [ ] Trends tab per-GPU normalization skips points without GPU info
- [ ] Verify next CI run captures MTP acceptance and docker image