### PR TITLE
mla: drop max_split_per_batch=16 cap to match vLLM

### DIFF
--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -274,12 +274,20 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         only_update: bool = False,
         num_reject_tokens: torch.Tensor = None,
     ):
+        # NOTE: deliberately omit `max_split_per_batch` so aiter falls back to
+        # the default (-1) and lets the MLA decode-stage1 kernel use
+        # `num_clusters` work splits (all available CUs). This mirrors vLLM's
+        # AiterMLAMetadataBuilder._build_decode in
+        # `vllm/v1/attention/backends/mla/rocm_aiter_mla.py`. The historical
+        # ATOM cap of 16 (introduced in #47 and propagated to the plugin)
+        # capped per-batch splits to `min(num_clusters, 16 * bs)`, which
+        # severely under-utilizes the GPU at small batch / large KV and made
+        # `mla_a8w8_qh16_qseqlen1_gqaratio16_ps` ~4x slower than vLLM.
         split_params = {
             "kv_granularity": max(self.block_size, 16),
             "max_seqlen_qo": max_q_len,
             "uni_seqlen_qo": max_q_len,
             "fast_mode": 1,
-            "max_split_per_batch": 16,
         }
         var = self.model_runner.forward_vars
         work_meta_data = var["work_meta_data"]
@@ -754,7 +762,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             max_seqlen_qo=max_q_len,
             uni_seqlen_qo=max_q_len,
             fast_mode=1,
-            max_split_per_batch=16,
+            # See note in `set_mla_persistent_worker_buffers` above:
+            # omit `max_split_per_batch` (defaults to -1 = use all CUs) to
+            # match vLLM's MLA decode metadata configuration.
         )
 
     def build_for_cudagraph_capture(self, bs: int) -> AttentionMetaData:

--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -751,12 +751,19 @@ class vllmMLAAttentionMetadataBuilderMethods:
     def _set_mla_persistent_worker_buffers(
         self, bs: int, cu_seqlens_q: torch.Tensor, max_q_len: int = 1
     ):
+        # NOTE: deliberately omit `max_split_per_batch` so aiter falls back to
+        # the default (-1) and lets the MLA decode-stage1 kernel use
+        # `num_clusters` work splits (all available CUs). This mirrors vLLM's
+        # AiterMLAMetadataBuilder._build_decode in
+        # `vllm/v1/attention/backends/mla/rocm_aiter_mla.py`. The historical
+        # ATOM cap of 16 capped per-batch splits to `min(num_clusters, 16*bs)`,
+        # which severely under-utilizes the GPU at small batch / large KV and
+        # made `mla_a8w8_qh16_qseqlen1_gqaratio16_ps` ~4x slower than vLLM.
         split_params = {
             "kv_granularity": max(self.block_size, 16),
             "max_seqlen_qo": max_q_len,
             "uni_seqlen_qo": max_q_len,
             "fast_mode": 1,
-            "max_split_per_batch": 16,
         }
         var = self.mla_persistent_metadata
         work_meta_data = var["work_meta_data"]


### PR DESCRIPTION
## Summary

ATOM was passing `max_split_per_batch=16` to aiter's `get_mla_metadata_v1`
in three sites (one in `atom/plugin/attention.py`, two in
`atom/model_ops/attentions/aiter_mla.py`). aiter then computes the work
split as `min(num_clusters, max_split_per_batch * bs)`, which severely
under-utilizes the GPU at small batch / large KV.

vLLM's `AiterMLAMetadataBuilder._build_decode` (in
`vllm/v1/attention/backends/mla/rocm_aiter_mla.py`) omits the parameter
entirely, letting it default to `-1` so the kernel uses all
`num_clusters` splits. This PR aligns ATOM with vLLM.

## Why

- The FP8 MLA decode-stage1 kernel `mla_a8w8_qh16_qseqlen1_gqaratio16_ps`
  was running ~4x slower in ATOM than in vLLM on the same workload.
- Root cause: `min(num_clusters, 16 * bs)` caps splits far below the
  available CUs at small batches. e.g. `bs=2` on a 256-CU GPU yields
  only 32 splits used out of 256 CUs.
- Buffer safety: `get_mla_metadata_info_v1` pre-sizes the reduce/partial
  buffers for `~2 * num_clusters` tiles, so passing `-1` is within the
  pre-allocated capacity.

## Test plan

The aiter persistent-MLA op test reproduces the difference directly.
`-ms` is the same `max_split_per_batch` knob exposed at the test layer:

    python op_tests/test_mla_persistent.py -d fp8 -kvd fp8 -n 16,1 \
        -k 512 -qr 64 -vh 512 -blk 1 -b 4 -c 100000 -ms 16

vs.

    python op_tests/test_mla_persistent.py -d fp8 -kvd fp8 -n 16,1 \
        -k 512 -qr 64 -vh 512 -blk 1 -b 4 -c 100000 -ms -1

The `-ms -1` run reports a substantially lower MLA decode kernel time.
Mirror runs through ATOM's serving stack on the same GPU show the same
speedup on the `mla_a8w8_qh16_qseqlen1_gqaratio16_ps` invocation.

- [ ] Re-run the aiter op test on gfx950 with both `-ms 16` and `-ms -1`
- [ ] Re-run an ATOM kimi-2.5 long-context decode trace and confirm the
      `mla_a8w8_qh16_qseqlen1_gqaratio16_ps` kernel time matches vLLM
- [ ] Smoke-test ATOM short-context / small-batch decode for regressions

## Notes

Other `max_split_per_batch` references are intentionally left untouched:
`atom/model_ops/attentions/aiter_attention.py` already passes `-1`, and
the SGLang backend in
`atom/plugin/sglang/attention_backend/sgl_attn_backend.py` keeps its own
configurable knob.

Historical context: the cap was introduced in #47 ("limit
max_split_per_batch to 16") with no recorded rationale, and propagated
to the plugin via #304. vLLM's MLA backend never set the cap.