### PR TITLE
(ci)(recipe): Add DeepSeek-R1 FP4 TP4 validation and DS recipe for SGLang-ATOM

### DIFF
--- a/.github/benchmark/sglang_benchmark_models.json
+++ b/.github/benchmark/sglang_benchmark_models.json
@@ -6,7 +6,7 @@
     "prefix": "deepseek-r1-fp8-tp8",
     "extra_args": "--trust-remote-code --tensor-parallel-size 8",
     "bench_args": "",
-    "runner": "atom-mi355-8gpu-oot-benchmark",
+    "runner": "atom-mi355-8gpu-aac-runner",
     "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1"
   },
   {
@@ -17,7 +17,7 @@
     "prefix": "deepseek-r1-fp8-tp4",
     "extra_args": "--trust-remote-code --tensor-parallel-size 4",
     "bench_args": "",
-    "runner": "atom-mi355-8gpu-oot-benchmark",
+    "runner": "atom-mi355-8gpu-aac-runner",
     "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1"
   },
   {
@@ -27,7 +27,7 @@
     "prefix": "deepseek-r1-fp4-tp8",
     "extra_args": "--trust-remote-code --tensor-parallel-size 8",
     "bench_args": "",
-    "runner": "atom-mi355-8gpu-oot-benchmark",
+    "runner": "atom-mi355-8gpu-aac-runner",
     "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1"
   },
   {
@@ -38,7 +38,7 @@
     "prefix": "deepseek-r1-fp4-tp4",
     "extra_args": "--trust-remote-code --tensor-parallel-size 4",
     "bench_args": "",
-    "runner": "atom-mi355-8gpu-oot-benchmark",
+    "runner": "atom-mi355-8gpu-aac-runner",
     "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1"
   },
   {
@@ -49,7 +49,7 @@
   "prefix": "deepseek-r1-fp4-tp8-ep8",
   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --expert-parallel-size 8",
   "bench_args": "",
-  "runner": "atom-mi355-8gpu-oot-benchmark",
+  "runner": "atom-mi355-8gpu-aac-runner",
   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1"
   }
 ]

--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -3,12 +3,48 @@
     "model_name": "DeepSeek-R1-FP8 TP4",
     "model_path": "deepseek-ai/DeepSeek-R1-0528",
     "extraArgs": "--tensor-parallel-size 4",
-    "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+    "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
     "runner": "linux-atom-mi35x-4",
     "test_level": "nightly",
-    "accuracy_threshold": 0.92,
+    "accuracy_threshold": 0.91,
     "accuracy_baseline": null,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-R1-0528",
+    "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
+  },
+  {
+    "model_name": "DeepSeek-R1-FP8 TP8",
+    "model_path": "deepseek-ai/DeepSeek-R1-0528",
+    "extraArgs": "--tensor-parallel-size 8",
+    "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+    "runner": "linux-atom-mi35x-8",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.93,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "deepseek-ai/DeepSeek-R1-0528",
+    "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
+  },
+  {
+    "model_name": "DeepSeek-R1-FP4 TP4",
+    "model_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
+    "extraArgs": "--tensor-parallel-size 4",
+    "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+    "runner": "linux-atom-mi35x-4",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.93,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
+    "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
+  },
+  {
+    "model_name": "DeepSeek-R1-FP4 TP8",
+    "model_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
+    "extraArgs": "--tensor-parallel-size 8",
+    "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+    "runner": "linux-atom-mi35x-8",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.93,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
     "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
   }
 ]

--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -30,7 +30,7 @@
     "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
     "runner": "linux-atom-mi35x-4",
     "test_level": "nightly",
-    "accuracy_threshold": 0.93,
+    "accuracy_threshold": 0.91,
     "accuracy_baseline": null,
     "accuracy_baseline_model": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
     "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."

--- a/.github/runner-config.yml
+++ b/.github/runner-config.yml
@@ -6,6 +6,10 @@ runners:
     gpu_arch: MI355
     gpu_count: 8
 
+  atom-mi355-8gpu-aac-runner:
+    gpu_arch: MI355
+    gpu_count: 8
+
   linux-atom-mi355-1:
     gpu_arch: MI355
     gpu_count: 1

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -14,6 +14,21 @@ on:
         required: false
         type: boolean
         default: false
+      run_dsr1_fp8_tp8:
+        description: "DeepSeek-R1-FP8 TP8"
+        required: false
+        type: boolean
+        default: false
+      run_dsr1_fp4_tp4:
+        description: "DeepSeek-R1-FP4 TP4"
+        required: false
+        type: boolean
+        default: false
+      run_dsr1_fp4_tp8:
+        description: "DeepSeek-R1-FP4 TP8"
+        required: false
+        type: boolean
+        default: false
       upload_accuracy_to_dashboard:
         description: "Optional: upload SGLANG accuracy results to dashboard after this manual run"
         required: false
@@ -55,6 +70,9 @@ jobs:
         id: meta
         env:
           RUN_DSR1_FP8_TP4: ${{ inputs.run_dsr1_fp8_tp4 }}
+          RUN_DSR1_FP8_TP8: ${{ inputs.run_dsr1_fp8_tp8 }}
+          RUN_DSR1_FP4_TP4: ${{ inputs.run_dsr1_fp4_tp4 }}
+          RUN_DSR1_FP4_TP8: ${{ inputs.run_dsr1_fp4_tp8 }}
         run: |
           set -euo pipefail
 
@@ -72,9 +90,36 @@ jobs:
                   "model_name": "DeepSeek-R1-FP8 TP4",
                   "model_path": "deepseek-ai/DeepSeek-R1-0528",
                   "extra_args": "--tensor-parallel-size 4",
-                  "accuracy_test_threshold": 0.92,
-                  "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+                  "accuracy_test_threshold": 0.91,
+                  "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
                   "runner": "linux-atom-mi35x-4",
+              },
+              {
+                  "toggle_env": "RUN_DSR1_FP8_TP8",
+                  "model_name": "DeepSeek-R1-FP8 TP8",
+                  "model_path": "deepseek-ai/DeepSeek-R1-0528",
+                  "extra_args": "--tensor-parallel-size 8",
+                  "accuracy_test_threshold": 0.93,
+                  "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+                  "runner": "linux-atom-mi35x-8",
+              },
+              {
+                  "toggle_env": "RUN_DSR1_FP4_TP4",
+                  "model_name": "DeepSeek-R1-FP4 TP4",
+                  "model_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
+                  "extra_args": "--tensor-parallel-size 4",
+                  "accuracy_test_threshold": 0.93,
+                  "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+                  "runner": "linux-atom-mi35x-4",
+              },
+              {
+                  "toggle_env": "RUN_DSR1_FP4_TP8",
+                  "model_name": "DeepSeek-R1-FP4 TP8",
+                  "model_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
+                  "extra_args": "--tensor-parallel-size 8",
+                  "accuracy_test_threshold": 0.93,
+                  "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
+                  "runner": "linux-atom-mi35x-8",
               },
           ]
 

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -108,7 +108,7 @@ jobs:
                   "model_name": "DeepSeek-R1-FP4 TP4",
                   "model_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
                   "extra_args": "--tensor-parallel-size 4",
-                  "accuracy_test_threshold": 0.93,
+                  "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
                   "runner": "linux-atom-mi35x-4",
               },

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -5,6 +5,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
+  schedule:
+    # Nightly at 01:00 Beijing time (17:00 UTC on the previous day)
+    - cron: '0 17 * * *'
   workflow_dispatch:
     inputs:
       deepseek-r1-fp8-tp8:
@@ -83,6 +86,10 @@ jobs:
           REBUILD_SGLANG_IMAGE=false
           SGLANG_IMAGE_SOURCE="prebuilt"
           USER_PROVIDED_SGLANG_IMAGE=false
+          RESOLVED_PREBUILT_ALIAS=""
+          RESOLVED_PREBUILT_DIGEST=""
+          PREBUILT_RESOLUTION_TYPE=""
+          RESOLVED_NIGHTLY_TAG=""
           if [[ -n "${INPUT_SGLANG_IMAGE}" ]]; then
             PREBUILT_SGLANG_IMAGE="${INPUT_SGLANG_IMAGE}"
             SGLANG_IMAGE_SOURCE="user-provided"
@@ -115,6 +122,39 @@ jobs:
 
           SELECTED_SGLANG_REF="${VLLM_META[0]}"
           SELECTED_SGLANG_VERSION="${VLLM_META[1]}"
+
+          if [[ "${SGLANG_IMAGE_SOURCE}" == "prebuilt" ]]; then
+            if RESOLUTION_JSON="$(
+              python3 .github/scripts/resolve_atom_image.py \
+                --repository rocm/atom-dev \
+                --reference-tag sglang-latest \
+                --preferred-version "${SELECTED_SGLANG_VERSION}"
+            )"; then
+              mapfile -t RESOLVED_IMAGE_META < <(
+                RESOLUTION_JSON="${RESOLUTION_JSON}" python3 - <<'PY'
+          import json
+          import os
+
+          resolution = json.loads(os.environ["RESOLUTION_JSON"])
+          print(resolution["resolved_image"])
+          print(resolution["reference_image"])
+          print(resolution["reference_digest"])
+          print(resolution["match_type"])
+          print(resolution.get("matched_tag", ""))
+          PY
+              )
+              PREBUILT_SGLANG_IMAGE="${RESOLVED_IMAGE_META[0]}"
+              RESOLVED_PREBUILT_ALIAS="${RESOLVED_IMAGE_META[1]}"
+              RESOLVED_PREBUILT_DIGEST="${RESOLVED_IMAGE_META[2]}"
+              PREBUILT_RESOLUTION_TYPE="${RESOLVED_IMAGE_META[3]}"
+              RESOLVED_NIGHTLY_TAG="${RESOLVED_IMAGE_META[4]}"
+            else
+              echo "::warning::Failed to resolve rocm/atom-dev:sglang-latest to an immutable digest; falling back to the floating tag."
+              PREBUILT_SGLANG_IMAGE="rocm/atom-dev:sglang-latest"
+              RESOLVED_PREBUILT_ALIAS="rocm/atom-dev:sglang-latest"
+              PREBUILT_RESOLUTION_TYPE="resolution-failed"
+            fi
+          fi
 
           {
             echo "atom_repository=${ATOM_REPOSITORY}"
@@ -153,6 +193,32 @@ jobs:
               "${PREBUILT_SGLANG_IMAGE}" \
               "${SELECTED_SGLANG_VERSION}" \
               "${SELECTED_SGLANG_REF}" >> "$GITHUB_STEP_SUMMARY"
+            if [[ -n "${RESOLVED_PREBUILT_ALIAS}" ]]; then
+              printf -- '- Floating alias: `%s`\n' \
+                "${RESOLVED_PREBUILT_ALIAS}" >> "$GITHUB_STEP_SUMMARY"
+            fi
+            if [[ -n "${RESOLVED_PREBUILT_DIGEST}" ]]; then
+              printf -- '- Resolved digest: `%s`\n' \
+                "${RESOLVED_PREBUILT_DIGEST}" >> "$GITHUB_STEP_SUMMARY"
+            fi
+            case "${PREBUILT_RESOLUTION_TYPE}" in
+              matched-nightly-tag)
+                printf -- '- Resolution: reverse-matched same digest to nightly tag `%s`\n' \
+                  "${RESOLVED_NIGHTLY_TAG}" >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              digest-pinned-latest)
+                printf -- '- Resolution: no nightly tag with the same digest was found, so this run pins `sglang-latest` to its current digest instead.\n' \
+                  >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              reverse-lookup-failed-digest-pinned-latest)
+                printf -- '- Resolution: reverse lookup could not complete, so this run pins `sglang-latest` to its current digest instead of falling back to the floating tag.\n' \
+                  >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              resolution-failed)
+                printf -- '- Resolution: digest pinning itself failed, so this run falls back to floating `sglang-latest`.\n' \
+                  >> "$GITHUB_STEP_SUMMARY"
+                ;;
+            esac
           fi
 
           printf -- '- Upload to dashboard: `%s`\n' \
@@ -220,7 +286,8 @@ jobs:
         run: |
           MODELS_JSON="$(jq -c '
             map(select(
-              (.prefix == "deepseek-r1-fp8-tp8" and env.ENABLE_DEEPSEEK_R1_FP8_TP8 == "true")
+              env.GITHUB_EVENT_NAME == "schedule"
+              or (.prefix == "deepseek-r1-fp8-tp8" and env.ENABLE_DEEPSEEK_R1_FP8_TP8 == "true")
               or (.prefix == "deepseek-r1-fp8-tp4" and env.ENABLE_DEEPSEEK_R1_FP8_TP4 == "true")
               or (.prefix == "deepseek-r1-fp4-tp8" and env.ENABLE_DEEPSEEK_R1_FP4_TP8 == "true")
               or (.prefix == "deepseek-r1-fp4-tp4" and env.ENABLE_DEEPSEEK_R1_FP4_TP4 == "true")

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -536,6 +536,11 @@ jobs:
       - name: Check if model is enabled
         id: check
         run: |
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           case "${{ matrix.model.prefix }}" in
             deepseek-r1-fp8-tp8) echo "enabled=${{ inputs.deepseek-r1-fp8-tp8 }}" >> "$GITHUB_OUTPUT" ;;
             deepseek-r1-fp8-tp4) echo "enabled=${{ inputs.deepseek-r1-fp8-tp4 }}" >> "$GITHUB_OUTPUT" ;;

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -50,55 +50,140 @@ jobs:
       aiter_artifact_id: ${{ steps.download.outputs.aiter_artifact_id }}
       aiter_wheel_name: ${{ steps.download.outputs.aiter_wheel_name }}
     steps:
-      - name: Find and download latest aiter wheel
+      - name: Prefer latest main aiter wheel manifest and fallback to artifact
         id: download
         run: |
           set -euo pipefail
-          echo "=== Finding latest aiter-whl-main artifact from ROCm/aiter ==="
+          echo "=== Trying latest main aiter wheel manifest from S3 first ==="
 
+          S3_MAIN_MANIFEST_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950/main/latest.json"
           API_URL="https://api.github.com"
           AUTH_HEADER="Authorization: token ${{ secrets.GITHUB_TOKEN }}"
           AITER_TEST_WORKFLOW_ID=179476100
 
-          RUNS=$(curl -s -H "$AUTH_HEADER" \
-            "$API_URL/repos/ROCm/aiter/actions/workflows/$AITER_TEST_WORKFLOW_ID/runs?per_page=100&branch=main&event=push")
-
           ARTIFACT_ID=""
           ARTIFACT_NAME=""
-          for RUN_ID in $(echo "$RUNS" | jq -r '.workflow_runs[].id'); do
-            ARTIFACT_JSON=$(curl -s -H "$AUTH_HEADER" \
-              "$API_URL/repos/ROCm/aiter/actions/runs/$RUN_ID/artifacts" \
-              | jq '[.artifacts[] | select(.name | startswith("aiter-whl-main")) | select(.expired == false)] | first')
+          ARTIFACT_RUN_ID=""
+          ARTIFACT_RUN_SHA=""
+          ARTIFACT_RUN_CREATED_AT=""
 
-            if [ "$ARTIFACT_JSON" != "null" ] && [ -n "$ARTIFACT_JSON" ]; then
-              ARTIFACT_ID=$(echo "$ARTIFACT_JSON" | jq -r '.id')
-              ARTIFACT_NAME=$(echo "$ARTIFACT_JSON" | jq -r '.name')
-              echo "Found artifact in run $RUN_ID: $ARTIFACT_NAME (ID: $ARTIFACT_ID)"
-              break
+          resolve_download_url() {
+            python3 -c 'import sys
+            from urllib.parse import quote, unquote, urlsplit, urlunsplit
+            parts = urlsplit(sys.argv[1])
+            encoded_path = "/".join(quote(unquote(segment), safe="") for segment in parts.path.split("/"))
+            print(urlunsplit((parts.scheme, parts.netloc, encoded_path, parts.query, parts.fragment)))' "$1"
+          }
+
+          find_latest_artifact() {
+            local runs_json artifact_json run_id
+
+            if [ -n "$ARTIFACT_ID" ] && [ "$ARTIFACT_ID" != "null" ]; then
+              return 0
             fi
-          done
 
-          if [ -z "$ARTIFACT_ID" ] || [ "$ARTIFACT_ID" = "null" ]; then
-            echo "ERROR: No aiter-whl-main artifact found in recent Aiter Test runs"
-            exit 1
+            echo "=== Finding latest aiter-whl-* artifact from ROCm/aiter ==="
+            runs_json=$(curl -fsSL -H "$AUTH_HEADER" \
+              "$API_URL/repos/ROCm/aiter/actions/workflows/$AITER_TEST_WORKFLOW_ID/runs?per_page=100&branch=main&event=push")
+
+            for run_id in $(echo "$runs_json" | jq -r '.workflow_runs[].id'); do
+              artifact_json=$(curl -fsSL -H "$AUTH_HEADER" \
+                "$API_URL/repos/ROCm/aiter/actions/runs/$run_id/artifacts" \
+                | jq '[.artifacts[] | select(.name | startswith("aiter-whl-")) | select(.expired == false)] | sort_by(.created_at) | last')
+
+              if [ "$artifact_json" != "null" ] && [ -n "$artifact_json" ]; then
+                ARTIFACT_ID=$(echo "$artifact_json" | jq -r '.id')
+                ARTIFACT_NAME=$(echo "$artifact_json" | jq -r '.name')
+                ARTIFACT_RUN_ID="$run_id"
+                ARTIFACT_RUN_SHA=$(echo "$runs_json" | jq -r --arg run_id "$run_id" '.workflow_runs[] | select((.id | tostring) == $run_id) | .head_sha')
+                ARTIFACT_RUN_CREATED_AT=$(echo "$runs_json" | jq -r --arg run_id "$run_id" '.workflow_runs[] | select((.id | tostring) == $run_id) | .created_at')
+                echo "Found artifact in run $ARTIFACT_RUN_ID: $ARTIFACT_NAME (ID: $ARTIFACT_ID, SHA: $ARTIFACT_RUN_SHA)"
+                return 0
+              fi
+            done
+
+            return 1
+          }
+
+          download_from_s3_manifest() {
+            local manifest_file manifest_fetch_url manifest_branch manifest_timestamp manifest_commit wheel_name wheel_url resolved_wheel_url
+
+            mkdir -p aiter-whl
+            rm -f aiter-whl/amd_aiter*.whl
+
+            manifest_file=$(mktemp)
+            trap 'rm -f "$manifest_file"' RETURN
+            manifest_fetch_url="${S3_MAIN_MANIFEST_URL}?ts=$(date +%s)"
+            curl -fsSL -H "Cache-Control: no-cache" "$manifest_fetch_url" -o "$manifest_file" || return 1
+
+            manifest_branch=$(jq -r '.branch // empty' "$manifest_file")
+            manifest_timestamp=$(jq -r '.timestamp // empty' "$manifest_file")
+            manifest_commit=$(jq -r '.commit // empty' "$manifest_file")
+            wheel_name=$(jq -r '.wheel_name // empty' "$manifest_file")
+            wheel_url=$(jq -r '.wheel_url // empty' "$manifest_file")
+
+            if [ "$manifest_branch" != "main" ] || [ -z "$manifest_timestamp" ] || [ -z "$manifest_commit" ] || [ -z "$wheel_name" ] || [ -z "$wheel_url" ]; then
+              echo "Invalid latest main wheel manifest"
+              return 1
+            fi
+
+            if find_latest_artifact; then
+              if [ -n "$ARTIFACT_RUN_SHA" ] && [ "$manifest_commit" != "$ARTIFACT_RUN_SHA" ]; then
+                if [ -n "$ARTIFACT_RUN_CREATED_AT" ] && [[ "$manifest_timestamp" < "$ARTIFACT_RUN_CREATED_AT" ]]; then
+                  echo "Manifest commit $manifest_commit is older than latest artifact run $ARTIFACT_RUN_ID ($ARTIFACT_RUN_SHA); treating manifest as stale"
+                  return 1
+                fi
+                echo "Manifest commit $manifest_commit differs from latest artifact run $ARTIFACT_RUN_ID ($ARTIFACT_RUN_SHA), but manifest timestamp is not older"
+              fi
+            else
+              echo "No GitHub fallback artifact found while checking manifest freshness"
+            fi
+
+            resolved_wheel_url=$(resolve_download_url "$wheel_url")
+
+            echo "Selected latest main wheel manifest: $S3_MAIN_MANIFEST_URL"
+            echo "Manifest timestamp: $manifest_timestamp"
+            echo "Manifest commit: $manifest_commit"
+            echo "Manifest wheel: $wheel_name"
+            echo "Downloading manifest-selected wheel: $resolved_wheel_url"
+            curl -fsSL "$resolved_wheel_url" -o "aiter-whl/$wheel_name" || return 1
+            echo "Downloaded wheel from manifest: aiter-whl/$wheel_name"
+
+            rm -f "$manifest_file"
+            trap - RETURN
+          }
+
+          download_from_artifact() {
+            echo "=== Falling back to latest aiter-whl-* artifact from ROCm/aiter ==="
+            find_latest_artifact || {
+              echo "ERROR: No aiter-whl-* artifact found in recent Aiter Test runs"
+              return 1
+            }
+
+            mkdir -p aiter-whl
+            rm -f aiter-whl/amd_aiter*.whl
+            curl -fsSL -H "$AUTH_HEADER" \
+              "$API_URL/repos/ROCm/aiter/actions/artifacts/$ARTIFACT_ID/zip" \
+              -o aiter-whl.zip
+            unzip -o aiter-whl.zip -d aiter-whl
+            rm -f aiter-whl.zip
+          }
+
+          if download_from_s3_manifest; then
+            echo "Using wheel from S3 main manifest"
+          else
+            echo "Main wheel manifest download failed, falling back to GitHub artifact"
+            download_from_artifact
           fi
-
-          echo "=== Downloading artifact ==="
-          mkdir -p aiter-whl
-          curl -s -L -H "$AUTH_HEADER" \
-            "$API_URL/repos/ROCm/aiter/actions/artifacts/$ARTIFACT_ID/zip" \
-            -o aiter-whl.zip
-          unzip -o aiter-whl.zip -d aiter-whl
-          rm -f aiter-whl.zip
 
           AITER_WHL=$(ls -t aiter-whl/amd_aiter*.whl 2>/dev/null | head -1)
           if [ -z "$AITER_WHL" ]; then
-            echo "ERROR: No amd_aiter wheel found in artifact"
-            ls -la aiter-whl/
+            echo "ERROR: No amd_aiter wheel available after S3/artifact attempts"
+            ls -la aiter-whl/ || true
             exit 1
           fi
 
-          echo "Downloaded wheel: $AITER_WHL"
+          echo "Selected wheel: $AITER_WHL"
           echo "aiter_artifact_id=${ARTIFACT_ID}" >> "$GITHUB_OUTPUT"
           echo "aiter_wheel_name=$(basename "$AITER_WHL")" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -206,7 +206,6 @@ jobs:
             model_path: "deepseek-ai/DeepSeek-R1-0528"
             extra_args: "--tensor-parallel-size 4"
             env_vars: |
-              AITER_QUICK_REDUCE_QUANTIZATION=INT4
               SGLANG_AITER_FP8_PREFILL_ATTN=0
               SGLANG_USE_AITER=1
               ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
@@ -216,7 +215,6 @@ jobs:
             model_path: "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4"
             extra_args: "--tensor-parallel-size 4"
             env_vars: |
-              AITER_QUICK_REDUCE_QUANTIZATION=INT4
               SGLANG_AITER_FP8_PREFILL_ATTN=0
               SGLANG_USE_AITER=1
               ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -125,7 +125,7 @@ jobs:
               SGLANG_AITER_FP8_PREFILL_ATTN=0
               SGLANG_USE_AITER=1
               ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
-            accuracy_test_threshold: 0.92
+            accuracy_test_threshold: 0.91
             runner: linux-atom-mi35x-4
           - model_name: "DeepSeek-R1-FP4 TP4"
             model_path: "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4"

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -218,7 +218,7 @@ jobs:
               SGLANG_AITER_FP8_PREFILL_ATTN=0
               SGLANG_USE_AITER=1
               ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
-            accuracy_test_threshold: 0.93
+            accuracy_test_threshold: 0.91
             runner: linux-atom-mi35x-4
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -127,6 +127,16 @@ jobs:
               ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
             accuracy_test_threshold: 0.92
             runner: linux-atom-mi35x-4
+          - model_name: "DeepSeek-R1-FP4 TP4"
+            model_path: "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4"
+            extra_args: "--tensor-parallel-size 4"
+            env_vars: |
+              AITER_QUICK_REDUCE_QUANTIZATION=INT4
+              SGLANG_AITER_FP8_PREFILL_ATTN=0
+              SGLANG_USE_AITER=1
+              ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
+            accuracy_test_threshold: 0.93
+            runner: linux-atom-mi35x-4
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     env:

--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 import torch
 from aiter import dtypes
 from aiter.dist.parallel_state import get_tensor_model_parallel_world_size, get_tp_group
+from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
 from atom.model_ops.base_attention import Attention
 from atom.model_ops.attention_mla import (
     dynamic_per_batched_tensor_quant,
@@ -116,11 +117,6 @@ def _unwrap_linear_output(output: Any) -> torch.Tensor:
     return output
 
 
-def _linear_quant_type_value(linear: Any) -> Optional[int]:
-    quant_type = getattr(linear, "quant_type", None)
-    return None if quant_type is None else getattr(quant_type, "value", quant_type)
-
-
 def _fuse_qk_rmsnorm_and_q_quant(
     attn: DeepseekV2MLAAttention,
     q: torch.Tensor,
@@ -143,7 +139,6 @@ def _fuse_qk_rmsnorm_and_q_quant(
         shuffle=False,
         scale_shuffle_padding=False,
         group_size=128,
-        quant_type=attn.qknorm_quant_type,
         output_unquantized_inp1=output_unquantized_q,
         transpose_scale=True,
     )
@@ -686,19 +681,16 @@ def forward_sgl_mha_prepare(
             )
 
         if _use_aiter_gfx95 and attn.q_b_proj.weight.dtype == torch.float8_e4m3fn:
-            from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
-
-            (q, q_scale), _, _, _ = _fuse_rmsnorm_quant(
+            (q, q_scale), _, _, _ = fused_rms_fp8_group_quant(
                 q,
                 attn.q_a_layernorm.weight,
                 attn.q_a_layernorm.eps,
                 None,
                 None,
                 None,
-                res1=None,
-                dtype_quant=torch.float8_e4m3fn,
                 group_size=128,
-                quant_type=attn.qknorm_quant_type,
+                dtype_quant=torch.float8_e4m3fn,
+                res1=None,
                 output_unquantized_inp1=False,
                 transpose_scale=True,
             )
@@ -723,19 +715,16 @@ def forward_sgl_mha_prepare(
     latent_cache = latent_cache.unsqueeze(1)
 
     if _use_aiter_gfx95 and attn.kv_b_proj.weight.dtype == torch.float8_e4m3fn:
-        from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
-
-        (kv_a_quanted, kv_a_quanted_scale), kv_a, _, _ = _fuse_rmsnorm_quant(
+        (kv_a_quanted, kv_a_quanted_scale), kv_a, _, _ = fused_rms_fp8_group_quant(
             kv_a,
             attn.kv_a_layernorm.weight,
             attn.kv_a_layernorm.eps,
             None,
             None,
             None,
-            res1=None,
-            dtype_quant=torch.float8_e4m3fn,
             group_size=128,
-            quant_type=_linear_quant_type_value(attn.kv_b_proj),
+            dtype_quant=torch.float8_e4m3fn,
+            res1=None,
             output_unquantized_inp1=True,
             transpose_scale=True,
         )

--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 import torch
 from aiter import dtypes
 from aiter.dist.parallel_state import get_tensor_model_parallel_world_size, get_tp_group
-from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
 from atom.model_ops.base_attention import Attention
 from atom.model_ops.attention_mla import (
     dynamic_per_batched_tensor_quant,
@@ -117,6 +116,11 @@ def _unwrap_linear_output(output: Any) -> torch.Tensor:
     return output
 
 
+def _linear_quant_type_value(linear: Any) -> Optional[int]:
+    quant_type = getattr(linear, "quant_type", None)
+    return None if quant_type is None else getattr(quant_type, "value", quant_type)
+
+
 def _fuse_qk_rmsnorm_and_q_quant(
     attn: DeepseekV2MLAAttention,
     q: torch.Tensor,
@@ -139,6 +143,7 @@ def _fuse_qk_rmsnorm_and_q_quant(
         shuffle=False,
         scale_shuffle_padding=False,
         group_size=128,
+        quant_type=attn.qknorm_quant_type,
         output_unquantized_inp1=output_unquantized_q,
         transpose_scale=True,
     )
@@ -681,16 +686,19 @@ def forward_sgl_mha_prepare(
             )
 
         if _use_aiter_gfx95 and attn.q_b_proj.weight.dtype == torch.float8_e4m3fn:
-            (q, q_scale), _, _, _ = fused_rms_fp8_group_quant(
+            from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
+
+            (q, q_scale), _, _, _ = _fuse_rmsnorm_quant(
                 q,
                 attn.q_a_layernorm.weight,
                 attn.q_a_layernorm.eps,
                 None,
                 None,
                 None,
-                group_size=128,
-                dtype_quant=torch.float8_e4m3fn,
                 res1=None,
+                dtype_quant=torch.float8_e4m3fn,
+                group_size=128,
+                quant_type=attn.qknorm_quant_type,
                 output_unquantized_inp1=False,
                 transpose_scale=True,
             )
@@ -715,16 +723,19 @@ def forward_sgl_mha_prepare(
     latent_cache = latent_cache.unsqueeze(1)
 
     if _use_aiter_gfx95 and attn.kv_b_proj.weight.dtype == torch.float8_e4m3fn:
-        (kv_a_quanted, kv_a_quanted_scale), kv_a, _, _ = fused_rms_fp8_group_quant(
+        from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
+
+        (kv_a_quanted, kv_a_quanted_scale), kv_a, _, _ = _fuse_rmsnorm_quant(
             kv_a,
             attn.kv_a_layernorm.weight,
             attn.kv_a_layernorm.eps,
             None,
             None,
             None,
-            group_size=128,
-            dtype_quant=torch.float8_e4m3fn,
             res1=None,
+            dtype_quant=torch.float8_e4m3fn,
+            group_size=128,
+            quant_type=_linear_quant_type_value(attn.kv_b_proj),
             output_unquantized_inp1=True,
             transpose_scale=True,
         )

--- a/recipes/atom_sglang/DeepSeek-R1.md
+++ b/recipes/atom_sglang/DeepSeek-R1.md
@@ -103,7 +103,7 @@ RANDOM_RANGE_RATIO=0.8
 RESULT_DIR=./benchmark-results
 RESULT_FILENAME=deepseek-r1-fp4-tp4-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}.json
 
-python /tmp/bench_serving/benchmark_serving.py \
+python3 /tmp/bench_serving/benchmark_serving.py \
     --model=amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 \
     --backend=sglang \
     --base-url=http://127.0.0.1:8000 \

--- a/recipes/atom_sglang/DeepSeek-R1.md
+++ b/recipes/atom_sglang/DeepSeek-R1.md
@@ -1,0 +1,146 @@
+# DeepSeek-R1 with ATOM SGLang Backend
+
+This recipe shows how to run `deepseek-ai/DeepSeek-R1-0528` or `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4` with the SGLang-ATOM backend. For background on the SGLang-ATOM integration, see [Introduce ATOM as external model package of SGLang](https://github.com/ROCm/ATOM/issues/359).
+
+## Step 1: Pull the SGLang-ATOM Docker
+
+```bash
+docker pull rocm/atom-dev:sglang-latest
+```
+
+Launch a container from this image and run the remaining commands inside the container.
+
+## Step 2: Launch SGLang-ATOM Server
+
+The SGLang-ATOM backend keeps the standard SGLang CLI, server APIs, and general usage flow compatible with upstream SGLang. For general server options and API usage, users can refer to the [official SGLang documentation](https://docs.sglang.ai/).
+
+Before launching the server, export the same SGLang-ATOM settings used by the benchmark workflow:
+
+```bash
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
+export SGLANG_AITER_FP8_PREFILL_ATTN=0
+export SGLANG_USE_AITER=1
+export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
+# Introduce ATOM as external model package of SGLang
+export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
+```
+
+### DeepSeek with FP8 (TP=8)
+
+Users can use this command to launch the FP8 server with the same settings as the SGLang benchmark workflow.
+
+```bash
+python3 -m sglang.launch_server \
+    --model-path deepseek-ai/DeepSeek-R1-0528 \
+    --host localhost \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --kv-cache-dtype fp8_e4m3 \
+    --mem-fraction-static 0.8 \
+    --page-size 1 \
+    --disable-radix-cache
+```
+
+### DeepSeek with FP8 (TP=4)
+
+```bash
+python3 -m sglang.launch_server \
+    --model-path deepseek-ai/DeepSeek-R1-0528 \
+    --host localhost \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --kv-cache-dtype fp8_e4m3 \
+    --mem-fraction-static 0.8 \
+    --page-size 1 \
+    --disable-radix-cache
+```
+
+### DeepSeek with MXFP4 (TP=8)
+
+AMD Instinct MI355X GPU supports MXFP4 computation instructions, and users can use the following command to launch the MXFP4 server on MI355X. For MXFP4 model weight, we suggest using the checkpoint quantized from AMD Quark.
+
+```bash
+python3 -m sglang.launch_server \
+    --model-path amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 \
+    --host localhost \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --kv-cache-dtype fp8_e4m3 \
+    --mem-fraction-static 0.8 \
+    --page-size 1 \
+    --disable-radix-cache
+```
+
+### DeepSeek with MXFP4 (TP=4)
+
+```bash
+python3 -m sglang.launch_server \
+    --model-path amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 \
+    --host localhost \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --kv-cache-dtype fp8_e4m3 \
+    --mem-fraction-static 0.8 \
+    --page-size 1 \
+    --disable-radix-cache
+```
+
+## Step 3: Performance Benchmark
+
+The SGLang benchmark workflow uses the `bench_serving` client for performance benchmarking. The following example matches the workflow command pattern for an MXFP4 TP4 case.
+
+```bash
+git clone --depth 1 https://github.com/kimbochen/bench_serving.git /tmp/bench_serving
+
+ISL=8192
+OSL=1024
+CONC=64
+RANDOM_RANGE_RATIO=0.8
+RESULT_DIR=./benchmark-results
+RESULT_FILENAME=deepseek-r1-fp4-tp4-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}.json
+
+python /tmp/bench_serving/benchmark_serving.py \
+    --model=amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 \
+    --backend=sglang \
+    --base-url=http://127.0.0.1:8000 \
+    --dataset-name=random \
+    --random-input-len="${ISL}" \
+    --random-output-len="${OSL}" \
+    --random-range-ratio "${RANDOM_RANGE_RATIO}" \
+    --num-prompts="$(( CONC * 10 ))" \
+    --max-concurrency="${CONC}" \
+    --trust-remote-code \
+    --num-warmups="$(( 2 * CONC ))" \
+    --request-rate=inf \
+    --ignore-eos \
+    --save-result \
+    --percentile-metrics="ttft,tpot,itl,e2el" \
+    --result-dir="${RESULT_DIR}" \
+    --result-filename="${RESULT_FILENAME}"
+```
+
+For FP8 or TP8 cases, keep the same benchmark command and replace `--model` with the checkpoint used in Step 2.
+
+### Optional: Enable Profiling
+If you want to collect profiling trace, set the SGLang profiling environment variables before launching the server, and add `--profile` to the benchmark client command.
+
+```bash
+export SGLANG_PROFILE_RECORD_SHAPES=1
+export SGLANG_PROFILE_WITH_STACK=1
+export SGLANG_TORCH_PROFILER_DIR=./profile_sglang/
+```
+
+Then append `--profile` to the `benchmark_serving.py` command in Step 3.
+
+## Step 4: Accuracy Validation
+
+```bash
+lm_eval --model local-completions \
+        --model_args model=amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4,base_url=http://localhost:8000/v1/completions,num_concurrent=65,max_retries=1,tokenized_requests=False,trust_remote_code=True \
+        --tasks gsm8k \
+        --num_fewshot 3
+```


### PR DESCRIPTION
## Motivation
- add `DeepSeek-R1-FP4 TP4` coverage to SGLang-ATOM accuracy flows, including nightly/manual validation and dashboard metadata, with a `0.91` GSM8K threshold
- align the `DeepSeek-R1-FP8 TP4` GSM8K threshold to `0.91` across the ATOM SGLang PR and nightly accuracy workflows  to avoid data floating issues.
- add `recipes/sglang_atom/DeepSeek-R1.md` in the same style as the vLLM-ATOM recipe, covering server launch, benchmarking, accuracy validation, and profiling usage
- Updates aiter wheel download, align with PR #706

# ATOM SGLang CI / Nightly / Benchmark Scope

| Scope | Workflow | Trigger | Case 数 | 用途 |
| --- | --- | --- | ---: | --- |
| CI | `.github/workflows/atom-sglang-test.yaml` | PR to `main`，非 draft，非 closed | 2 | PR SGLang accuracy smoke |
| Nightly Accuracy | `.github/workflows/atom-sglang-accuracy-validation.yaml` | 每天 18:00 UTC / 北京 02:00，或手动触发 | 4 | 全量 SGLang GSM8K accuracy validation |
| Nightly Benchmark | `.github/workflows/atom-sglang-benchmark.yaml` | 每天 17:00 UTC / 北京 01:00，或手动触发 | nightly: 5 × 10 = 50 | SGLang serving performance benchmark |

## Shared Accuracy Parameters

| Item | Value |
| --- | --- |
| SGLang ref | `v0.5.10` |
| Task | `gsm8k` |
| Metric checked | `results.gsm8k["exact_match,flexible-extract"]` |
| Few-shot | `3` |
| LM Eval concurrency | `65` |
| Server args | `--trust-remote-code --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --page-size 1 --disable-radix-cache` |
| Common env | `SGLANG_AITER_FP8_PREFILL_ATTN=0`, `SGLANG_USE_AITER=1`, `ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1` |

## CI Cases

| Model | Weight | Runner | TP | Extra Args | Env Vars | Threshold |
| --- | --- | --- | ---: | --- | --- | ---: |
| DeepSeek-R1-FP8 TP4 | `deepseek-ai/DeepSeek-R1-0528` | `linux-atom-mi35x-4` | 4 | `--tensor-parallel-size 4` | `AITER_QUICK_REDUCE_QUANTIZATION=INT4`; common env | `0.91` |
| DeepSeek-R1-FP4 TP4 | `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4` | `linux-atom-mi35x-4` | 4 | `--tensor-parallel-size 4` | `AITER_QUICK_REDUCE_QUANTIZATION=INT4`; common env | `0.91` |

## Nightly Accuracy Cases

| Model | Weight | Runner | TP | Extra Args | Threshold |
| --- | --- | --- | ---: | --- | ---: |
| DeepSeek-R1-FP8 TP4 | `deepseek-ai/DeepSeek-R1-0528` | `linux-atom-mi35x-4` | 4 | `--tensor-parallel-size 4` | `0.91` |
| DeepSeek-R1-FP8 TP8 | `deepseek-ai/DeepSeek-R1-0528` | `linux-atom-mi35x-8` | 8 | `--tensor-parallel-size 8` | `0.93` |
| DeepSeek-R1-FP4 TP4 | `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4` | `linux-atom-mi35x-4` | 4 | `--tensor-parallel-size 4` | `0.91` |
| DeepSeek-R1-FP4 TP8 | `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4` | `linux-atom-mi35x-8` | 8 | `--tensor-parallel-size 8` | `0.93` |

## Benchmark Schedule

当前 benchmark workflow 支持两种模式：

| Mode | Model Selection | Param Selection | Dashboard |
| --- | --- | --- | --- |
| Scheduled nightly | 自动选择全部 5 个 SGLang benchmark models | 默认 10 组参数 | 默认 publish |
| Manual dispatch | 通过 checkbox 选择模型 | `param_lists` 输入，默认 10 组参数 | `publish_to_dashboard` 控制，默认 true |

Schedule:
- Cron: `0 17 * * *`
- Beijing time: 每晚 `01:00`

## Benchmark Parameters

Default param sets:

| ISL | OSL | Concurrency | Random Range Ratio |
| ---: | ---: | ---: | ---: |
| 1024 | 1024 | 4, 8, 16, 32, 64 | 0.8 |
| 8192 | 1024 | 4, 8, 16, 32, 64 | 0.8 |

Benchmark command:
- backend: `sglang`
- dataset: `random`
- `num-prompts = concurrency * 10`
- `num-warmups = 2 * concurrency`
- `request-rate=inf`
- metrics: `ttft,tpot,itl,e2el`

## Benchmark Models

| Model | Weight | Serve Args | Runner |
| --- | --- | --- | --- |
| DeepSeek-R1-0528 FP8 TP8 | `deepseek-ai/DeepSeek-R1-0528` | `--trust-remote-code --tensor-parallel-size 8` | `atom-mi355-8gpu-oot-benchmark` |
| DeepSeek-R1-0528 FP8 TP4 | `deepseek-ai/DeepSeek-R1-0528` | `--trust-remote-code --tensor-parallel-size 4` | `atom-mi355-8gpu-oot-benchmark` |
| DeepSeek-R1-0528-MXFP4 FP4 TP8 | `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4` | `--trust-remote-code --tensor-parallel-size 8` | `atom-mi355-8gpu-oot-benchmark` |
| DeepSeek-R1-0528-MXFP4 FP4 TP4 | `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4` | `--trust-remote-code --tensor-parallel-size 4` | `atom-mi355-8gpu-oot-benchmark` |
| DeepSeek-R1-0528-MXFP4 FP4 TP8 EP8 | `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4` | `--trust-remote-code --tensor-parallel-size 8 --expert-parallel-size 8` | `atom-mi355-8gpu-oot-benchmark` |
