### PR TITLE
feat(qwen3_next): add DualRMSNorm and QKVGParallelLinear

### DIFF
--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -1,35 +1,28 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-from typing import Tuple, Optional
-import torch
-from torch import Tensor
+from typing import Optional, Tuple
 
-from torch.overrides import (
-    has_torch_function_unary,
-    handle_torch_function,
+import aiter
+import torch
+from aiter import (
+    QuantType,
+    layernorm2d_fwd,
+    layernorm2d_fwd_with_add,
+    rmsnorm2d_fwd,
+    rmsnorm2d_fwd_with_add,
 )
+from aiter.dist.communication_op import tensor_model_parallel_fused_allreduce_rmsnorm
+from aiter.dist.parallel_state import get_tensor_model_parallel_world_size
+from aiter.jit.utils.torch_guard import torch_compile_guard
+from aiter.ops.gated_rmsnorm_fp8_group_quant import gated_rmsnorm_fp8_group_quant
+from aiter.ops.triton.fused_add_rmsnorm_pad import fused_add_rmsnorm_pad
 from atom.config import QuantizationConfig
 from atom.model_ops.utils import atom_parameter
 from atom.quant_spec import LayerQuantConfig
 from atom.utils.decorators import mark_trace
-from torch import nn
-from aiter import (
-    rmsnorm2d_fwd,
-    rmsnorm2d_fwd_with_add,
-    layernorm2d_fwd,
-    layernorm2d_fwd_with_add,
-)
-import aiter
-from aiter.dist.communication_op import tensor_model_parallel_fused_allreduce_rmsnorm
-from aiter.dist.parallel_state import get_tensor_model_parallel_world_size
-from aiter.ops.triton.fused_add_rmsnorm_pad import fused_add_rmsnorm_pad
-from aiter.jit.utils.torch_guard import torch_compile_guard
-from aiter.ops.gated_rmsnorm_fp8_group_quant import gated_rmsnorm_fp8_group_quant
-
-from aiter import (
-    QuantType,
-)
+from torch import Tensor, nn
+from torch.overrides import handle_torch_function, has_torch_function_unary
 
 
 def silu(input: Tensor, inplace: bool = False) -> Tensor:
@@ -163,9 +156,7 @@ def mxfp4_rms_quant_fuse(
     shuffle: bool = False,
     res1: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    from aiter.ops.triton.fused_mxfp4_quant import (
-        fused_rms_mxfp4_quant,
-    )
+    from aiter.ops.triton.fused_mxfp4_quant import fused_rms_mxfp4_quant
 
     (x_quant, x_scale), _, _, residual_out = fused_rms_mxfp4_quant(
         x, weight, eps, shuffle=shuffle, res1=res1
@@ -237,10 +228,10 @@ class RMSNorm(nn.Module):
             return x, residual
         else:
             if x_scale is not None and self.use_fused_quant:
+                import aiter as rocm_aiter
                 from aiter.ops.triton.fused_fp8_quant import (
                     fused_rms_fp8_per_tensor_static_quant,
                 )
-                import aiter as rocm_aiter
 
                 rocm_aiter_fp8_dtype = rocm_aiter.dtypes.fp8
 
@@ -561,6 +552,213 @@ class GemmaRMSNorm(nn.Module):
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         return self.forward_cuda(x, residual)
+
+
+# ---------------------------------------------------------------------------
+# Fused Q/K RMSNorm Triton kernel
+# ---------------------------------------------------------------------------
+import triton  # noqa: E402
+import triton.language as tl  # noqa: E402
+
+
+@triton.jit
+def _fused_qk_norm_single_kernel(
+    q_ptr,
+    k_ptr,
+    q_out_ptr,
+    k_out_ptr,
+    q_weight_ptr,
+    k_weight_ptr,
+    eps,
+    num_tokens,
+    head_dim,
+    q_in_stride0,
+    k_in_stride0,
+    q_out_stride0,
+    k_out_stride0,
+    num_q_heads,
+    num_k_heads,
+    ADD_UNIT_OFFSET: tl.constexpr,
+    RBLOCK: tl.constexpr,
+    XBLOCK: tl.constexpr,
+):
+    """Fused Q/K RMSNorm in a single kernel launch (out-of-place)."""
+    num_q_rows = num_tokens * num_q_heads
+    total_rows = num_tokens * (num_q_heads + num_k_heads)
+
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < total_rows
+    cols = tl.arange(0, RBLOCK)[None, :]
+    col_mask = cols < head_dim
+
+    is_q = xindex < num_q_rows
+    row_in_section = tl.where(is_q, xindex, xindex - num_q_rows)
+    cur_num_heads = tl.where(is_q, num_q_heads, num_k_heads)
+
+    tokens = row_in_section // cur_num_heads
+    heads = row_in_section % cur_num_heads
+
+    in_stride = tl.where(is_q, q_in_stride0, k_in_stride0)
+    in_bases = tokens * in_stride + heads * head_dim
+
+    # Output: contiguous, stride(1) = head_dim
+    out_stride0 = tl.where(is_q, q_out_stride0, k_out_stride0)
+    out_bases = tokens * out_stride0 + heads * head_dim
+
+    mask = xmask & col_mask
+
+    # Weight: load both, select via is_q
+    qw = tl.load(
+        q_weight_ptr + cols, mask=col_mask, other=0.0, eviction_policy="evict_last"
+    ).to(tl.float32)
+    kw = tl.load(
+        k_weight_ptr + cols, mask=col_mask, other=0.0, eviction_policy="evict_last"
+    ).to(tl.float32)
+    if ADD_UNIT_OFFSET:
+        qw = qw + 1.0
+        kw = kw + 1.0
+    w = tl.where(is_q, qw, kw)
+
+    # Use runtime branching for pointer selection (avoids tl.where on pointers)
+    # Since all threads in a program have the same is_q value (XBLOCK rows are
+    # consecutive and Q/K boundary is far apart), this branch is uniform.
+    # For the rare program straddling Q/K boundary, both branches execute.
+    x = tl.load(
+        q_ptr + in_bases + cols,
+        mask=mask & is_q,
+        other=0.0,
+        eviction_policy="evict_first",
+    ).to(tl.float32)
+    x = x + tl.load(
+        k_ptr + in_bases + cols,
+        mask=mask & ~is_q,
+        other=0.0,
+        eviction_policy="evict_first",
+    ).to(tl.float32)
+
+    var = tl.sum(x * x, 1)[:, None]
+    rstd = tl.rsqrt(var / head_dim + eps)
+
+    out = (x * rstd * w).to(tl.bfloat16)
+    tl.store(
+        q_out_ptr + out_bases + cols,
+        out,
+        mask=mask & is_q,
+        eviction_policy="evict_first",
+    )
+    tl.store(
+        k_out_ptr + out_bases + cols,
+        out,
+        mask=mask & ~is_q,
+        eviction_policy="evict_first",
+    )
+
+
+def fused_qk_norm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float,
+    add_unit_offset: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fused Q/K RMSNorm in a single Triton kernel launch.
+
+    Args:
+        q: [num_tokens, num_heads, head_dim]
+        k: [num_tokens, num_kv_heads, head_dim]
+        q_weight, k_weight: [head_dim] norm weights
+        eps: epsilon for numerical stability
+        add_unit_offset: True for GemmaRMSNorm (w+1), False for standard
+    """
+    head_dim = q_weight.shape[0]
+    num_tokens = q.shape[0]
+    num_q_heads = q.shape[1]
+    num_k_heads = k.shape[1]
+    total_rows = num_tokens * (num_q_heads + num_k_heads)
+    RBLOCK = triton.next_power_of_2(head_dim)
+
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
+
+    # Adaptive XBLOCK based on batch size.
+    # Small batch: XBLOCK=1 minimizes register pressure per program.
+    # Large batch: XBLOCK=2 amortizes overhead, but XBLOCK>2 hurts due to
+    # cross-token stride jumps in non-contiguous split views.
+    # num_warps=1 is universally optimal for head_dim=256 workloads on MI355X.
+    XBLOCK = 2 if total_rows > 8192 else 1
+    NUM_WARPS = 1
+    _fused_qk_norm_single_kernel[((total_rows + XBLOCK - 1) // XBLOCK,)](
+        q,
+        k,
+        q_out,
+        k_out,
+        q_weight,
+        k_weight,
+        eps,
+        num_tokens,
+        head_dim,
+        q.stride(0),
+        k.stride(0),
+        q_out.stride(0),
+        k_out.stride(0),
+        num_q_heads,
+        num_k_heads,
+        ADD_UNIT_OFFSET=add_unit_offset,
+        RBLOCK=RBLOCK,
+        XBLOCK=XBLOCK,
+        num_warps=NUM_WARPS,
+    )
+    return q_out, k_out
+
+
+class DualRMSNorm:
+    """Fused Q/K RMSNorm — single Triton kernel launch.
+
+    Not an nn.Module. References existing q_norm/k_norm for weights.
+    """
+
+    def __init__(
+        self,
+        q_norm: nn.Module,
+        k_norm: nn.Module,
+        num_q_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        prefix: str,
+    ) -> None:
+        self.q_norm = q_norm
+        self.k_norm = k_norm
+        self.num_q_heads = num_q_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.add_unit_offset = isinstance(q_norm, GemmaRMSNorm)
+        self.prefix = prefix
+
+    @mark_trace
+    def __call__(
+        self, q: torch.Tensor, k: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Args:
+            q: [num_tokens, num_q_heads * head_dim]
+            k: [num_tokens, num_kv_heads * head_dim]
+        Returns:
+            (q_normed, k_normed) same shapes as input
+        """
+        q, k = fused_qk_norm(
+            q.view(-1, self.num_q_heads, self.head_dim),
+            k.view(-1, self.num_kv_heads, self.head_dim),
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.q_norm.variance_epsilon,
+            add_unit_offset=self.add_unit_offset,
+        )
+        return (
+            q.view(-1, self.num_q_heads * self.head_dim),
+            k.view(-1, self.num_kv_heads * self.head_dim),
+        )
 
 
 @torch_compile_guard()

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -640,7 +640,7 @@ def _fused_qk_norm_single_kernel(
     var = tl.sum(x * x, 1)[:, None]
     rstd = tl.rsqrt(var / head_dim + eps)
 
-    out = (x * rstd * w).to(tl.bfloat16)
+    out = (x * rstd * w).to(q_out_ptr.dtype.element_ty)
     tl.store(
         q_out_ptr + out_bases + cols,
         out,

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -729,6 +729,153 @@ class QKVZBAParallelLinear(ColumnParallelLinear):
         param.weight_loader_process(param_data, loaded_weight)
 
 
+class QKVGParallelLinear(ColumnParallelLinear):
+    """QKV + output-Gate parallel linear.
+
+    Rearranges interleaved Q+Gate weights from HF checkpoint into grouped
+    layout [Gate, Q, K, V] during loading, so inference uses a single split().
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_size: int,
+        total_num_heads: int,
+        total_num_kv_heads: int | None = None,
+        bias: bool = False,
+        quant_config: Optional[QuantizationConfig] = None,
+        source_quant_dtype: torch.dtype | None = None,
+        prefix: str = "",
+        **kwargs,
+    ):
+        self.head_size = head_size
+        self.total_num_heads = total_num_heads
+        self.total_num_kv_heads = total_num_kv_heads or total_num_heads
+        tp_size = get_tp_group().world_size
+        self.num_heads = divide(self.total_num_heads, tp_size)
+        if self.total_num_kv_heads >= tp_size:
+            self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
+            self.num_kv_head_replicas = 1
+        else:
+            self.num_kv_heads = 1
+            self.num_kv_head_replicas = divide(tp_size, self.total_num_kv_heads)
+
+        input_size = hidden_size
+        output_sizes = [
+            self.num_heads * self.head_size * tp_size,  # Gate
+            self.num_heads * self.head_size * tp_size,  # Q
+            self.num_kv_heads * self.head_size * tp_size,  # K
+            self.num_kv_heads * self.head_size * tp_size,  # V
+        ]
+
+        super().__init__(
+            input_size,
+            output_sizes,
+            bias=bias,
+            quant_config=quant_config,
+            source_quant_dtype=source_quant_dtype,
+            prefix=prefix,
+        )
+
+    def _deinterleave(
+        self, weight: torch.Tensor, head_stride: int | None = None
+    ) -> torch.Tensor:
+        """Rearrange Q+Gate from interleaved [q0,g0,q1,g1,...] to grouped [Q_all, Gate_all].
+
+        Args:
+            head_stride: number of elements per head along dim 0.
+                         Defaults to self.head_size (weights); use head_size//128
+                         for per-1x128 scales.
+        """
+        hs = head_stride if head_stride is not None else self.head_size
+        return (
+            weight.view(self.num_heads, 2, hs, -1)
+            .transpose(0, 1)
+            .reshape(self.num_heads * 2 * hs, -1)
+        )
+
+    def weight_loader(
+        self, param: nn.Parameter, loaded_weight: torch.Tensor, loaded_shard_id: str
+    ):
+        param_data = param.data
+        assert loaded_shard_id in ["q", "k", "v"]
+        q_size = self.num_heads * self.head_size
+        kv_size = self.num_kv_heads * self.head_size
+        # Layout: [Gate, Q, K, V]
+        if loaded_shard_id == "q":
+            # HF q_proj contains interleaved Q+Gate; deinterleave then
+            # write Gate to offset 0 and Q to offset q_size
+            shard_size = q_size * 2
+            shard_offset = 0  # placeholder, handled below
+            shard_rank = self.tp_rank
+        elif loaded_shard_id == "k":
+            shard_size = kv_size
+            shard_offset = q_size * 2
+            shard_rank = self.tp_rank // self.num_kv_head_replicas
+        else:
+            shard_size = kv_size
+            shard_offset = q_size * 2 + kv_size
+            shard_rank = self.tp_rank // self.num_kv_head_replicas
+
+        is_scale = param is getattr(self, "weight_scale", None) or param is getattr(
+            self, "input_scale", None
+        )
+
+        if loaded_shard_id == "q":
+            # Q+Gate: deinterleave [q0,g0,...] -> [Q_all, Gate_all], then
+            # write Gate to offset 0 and Q to offset q_size → layout [Gate, Q, ...]
+            if is_scale and self.quant_type == QuantType.per_Tensor:
+                loaded_weight = loaded_weight.view(1, 1).repeat(self.tp_size, 1)
+                # Gate scale -> slot 0, Q scale -> slot 1
+                q_scale = loaded_weight.narrow(self.tp_dim, shard_rank, 1)
+                param.weight_loader_process(
+                    param_data.narrow(self.tp_dim, 0, 1), q_scale.clone()
+                )
+                param.weight_loader_process(
+                    param_data.narrow(self.tp_dim, 1, 1), q_scale
+                )
+                return
+
+            scale_factor = (
+                128 if (is_scale and self.quant_type == QuantType.per_1x128) else 1
+            )
+            half = q_size // scale_factor
+            start_idx = shard_rank * shard_size // scale_factor
+            loaded_weight = loaded_weight.narrow(
+                self.tp_dim, start_idx, shard_size // scale_factor
+            )
+            stride = self.head_size // scale_factor
+            loaded_weight = self._deinterleave(
+                loaded_weight, head_stride=stride if scale_factor > 1 else None
+            )
+            q_part = loaded_weight.narrow(self.tp_dim, 0, half)
+            gate_part = loaded_weight.narrow(self.tp_dim, half, half)
+            q_offset = q_size // scale_factor
+            # Gate at offset 0, Q at offset q_size
+            param.weight_loader_process(
+                param_data.narrow(self.tp_dim, 0, half), gate_part
+            )
+            param.weight_loader_process(
+                param_data.narrow(self.tp_dim, q_offset, half), q_part
+            )
+        else:
+            # K or V: straightforward load
+            if is_scale:
+                if self.quant_type == QuantType.per_1x128:
+                    shard_offset //= 128
+                    shard_size //= 128
+                elif self.quant_type == QuantType.per_Tensor:
+                    loaded_weight = loaded_weight.view(1, 1).repeat(self.tp_size, 1)
+                    # [Gate, Q, K, V] -> K=2, V=3
+                    shard_offset = {"k": 2, "v": 3}[loaded_shard_id]
+                    shard_size = 1
+
+            start_idx = shard_rank * shard_size
+            param_data = param_data.narrow(self.tp_dim, shard_offset, shard_size)
+            loaded_weight = loaded_weight.narrow(self.tp_dim, start_idx, shard_size)
+            param.weight_loader_process(param_data, loaded_weight)
+
+
 class QKVParallelLinear(ColumnParallelLinear):
     def __init__(
         self,

--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -1,57 +1,54 @@
 from typing import Optional, Union
 
 import torch
-from torch import nn
 import torch.nn.functional as F
-from einops import rearrange
-
-from aiter.dist.parallel_state import get_tensor_model_parallel_rank
-from transformers.activations import ACT2FN
-from atom.config import QuantizationConfig, Config
-
+from aiter.dist.communication_op import tensor_model_parallel_all_reduce
+from aiter.dist.parallel_state import (
+    get_ep_group,
+    get_pp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from aiter.rotary_embedding import get_rope
+from atom.config import Config, QuantizationConfig
+from atom.model_config.qwen3_next import Qwen3NextConfig
 from atom.model_ops.activation import SiluAndMul
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
+from atom.model_ops.base_attention import LinearAttention
+from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
+from atom.model_ops.layernorm import DualRMSNorm
+from atom.model_ops.layernorm import GemmaRMSNorm
+from atom.model_ops.layernorm import GemmaRMSNorm as Qwen3NextRMSNorm
+from atom.model_ops.layernorm import RMSNormGated
+from atom.model_ops.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    MergedReplicatedLinear,
+    QKVGParallelLinear,
+    QKVParallelLinear,
+    QKVZBAParallelLinear,
+    RowParallelLinear,
+)
+from atom.model_ops.moe import FusedMoE
 from atom.model_ops.split_chunk import (
     fused_split_chunk_qwen_next_qkvz_ba,
     fused_split_chunk_qwen_next_qkvzba,
 )
-
-from atom.model_ops.base_attention import LinearAttention
-from atom.model_ops.layernorm import RMSNormGated, GemmaRMSNorm
-from atom.model_ops.layernorm import GemmaRMSNorm as Qwen3NextRMSNorm
-from atom.model_ops.linear import (
-    QKVZBAParallelLinear,
-    QKVParallelLinear,
-    MergedColumnParallelLinear,
-    MergedReplicatedLinear,
-    RowParallelLinear,
-    ColumnParallelLinear,
-)
-from atom.model_config.qwen3_next import Qwen3NextConfig
-from atom.plugin.prepare import is_vllm
-
-
-from aiter.dist.communication_op import tensor_model_parallel_all_reduce
-from atom.utils.decorators import support_torch_compile
-
-from aiter.rotary_embedding import get_rope
-from atom.model_ops.embed_head import VocabParallelEmbedding, ParallelLMHead
-from atom.model_ops.moe import FusedMoE
+from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.model_ops.utils import atom_parameter
-from aiter.dist.parallel_state import (
-    get_pp_group,
-    get_tensor_model_parallel_world_size,
-    get_ep_group,
-)
 from atom.models.utils import (
     IntermediateTensors,
     PPMissingLayer,
+    extract_layer_index,
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
-    extract_layer_index,
 )
+from atom.plugin.prepare import is_vllm
 from atom.utils import envs
+from atom.utils.decorators import support_torch_compile
+from einops import rearrange
+from torch import nn
+from transformers.activations import ACT2FN
 
 if is_vllm():
     from vllm.config import get_current_vllm_config
@@ -316,10 +313,11 @@ class Qwen3NextAttention(nn.Module):
         )
         self.attn_output_gate = getattr(config, "attn_output_gate", True)
 
-        self.qkv_proj = QKVParallelLinear(
+        qkv_cls = QKVGParallelLinear if self.attn_output_gate else QKVParallelLinear
+        self.qkv_proj = qkv_cls(
             config.hidden_size,
             self.head_dim,
-            self.total_num_heads * (1 + self.attn_output_gate),
+            self.total_num_heads,
             self.total_num_kv_heads,
             bias=getattr(config, "qkv_bias", False),
             quant_config=quant_config,
@@ -400,6 +398,14 @@ class Qwen3NextAttention(nn.Module):
 
         self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.qk_norm = DualRMSNorm(
+            self.q_norm,
+            self.k_norm,
+            self.num_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            prefix=f"{prefix}.qk_norm",
+        )
 
     def forward(
         self,
@@ -410,25 +416,15 @@ class Qwen3NextAttention(nn.Module):
         qkv = self.qkv_proj(hidden_states)
 
         if self.attn_output_gate:
-            q_gate, k, v = torch.split(
-                qkv, [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
+            gate, q, k, v = torch.split(
+                qkv, [self.q_size, self.q_size, self.kv_size, self.kv_size], dim=-1
             )
-            orig_shape = q_gate.shape[:-1]
-            q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
-            q, gate = torch.chunk(q_gate, 2, dim=-1)
-            q = q.reshape(*orig_shape, -1)
-            gate = gate.reshape(*orig_shape, -1)
         else:
             q, k, v = torch.split(
                 qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1
             )
 
-        q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(
-            -1, self.num_heads * self.head_dim
-        )
-        k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
-            -1, self.num_kv_heads * self.head_dim
-        )
+        q, k = self.qk_norm(q, k)
 
         q, k = self.rotary_emb(positions, q, k)
 
@@ -764,10 +760,10 @@ class Qwen3NextGatedDeltaNet(nn.Module):
 if is_vllm():
     from vllm.model_executor.layers.mamba.abstract import MambaBase
     from vllm.model_executor.layers.mamba.mamba_utils import (
-        MambaStateShapeCalculator,
-        MambaStateDtypeCalculator,
         MambaStateCopyFunc,
         MambaStateCopyFuncCalculator,
+        MambaStateDtypeCalculator,
+        MambaStateShapeCalculator,
     )
 
     class Qwen3NextGatedDeltaNetVllm(Qwen3NextGatedDeltaNet, MambaBase):
@@ -1139,8 +1135,8 @@ class Qwen3NextForCausalLM(nn.Module):
 
 if is_vllm():
     from atom.plugin.vllm.model_wrapper import ATOMMoEForCausalLM
-    from vllm.model_executor.models.interfaces import IsHybrid
     from vllm.config import VllmConfig
+    from vllm.model_executor.models.interfaces import IsHybrid
 
     class Qwen3NextForCausalLMVllm(ATOMMoEForCausalLM, IsHybrid):
         @classmethod


### PR DESCRIPTION
## Summary

- **DualRMSNorm**: Fused Q/K RMSNorm Triton kernel wrapper that reduces 10 lines of view/norm/reshape to `q, k = self.qk_norm(q, k)`. Non-nn.Module design avoids state_dict duplication. Supports `@mark_trace` via `self.prefix`.
- **QKVGParallelLinear**: Deinterleaves HF checkpoint's interleaved `[q0,g0,q1,g1,...]` Q+Gate weights into grouped `[Gate, Q, K, V]` layout during loading, enabling a simple `torch.split()` in forward.
- **Triton kernel**: Single-launch `_fused_qk_norm_single_kernel` with separate `q_in_stride0`/`k_in_stride0` for correct addressing of non-contiguous split views.

## Verification

- GSM8K accuracy: Qwen3-Next-80B (0.855, no regression) and Qwen3.5-397B-FP8 (0.872, no regression)
- Performance: decode 3-4x speedup, prefill 25% speedup, peak 5049 GB/s at T=65536 on MI355X

## Test plan

- [x] GSM8K accuracy on Qwen3-Next-80B-A3B
- [x] GSM8K accuracy on Qwen3.5-397B-A17B-FP8
- [x] fused_qk_norm micro-benchmark (T=32..65536)
- [x] Weight loading correctness (bit-exact across 4 TP ranks)
- [ ] CI nightly pass