### PR TITLE
[fix](benchmark): fix podman compatibility in SGLang and vLLM benchmark workflows

### DIFF
--- a/.github/scripts/atom_sglang_test.sh
+++ b/.github/scripts/atom_sglang_test.sh
@@ -224,6 +224,12 @@ run_accuracy() {
     --tasks "${LM_EVAL_TASK}" \
     --num_fewshot "${LM_EVAL_NUM_FEWSHOT}" \
     --output_path "${output_path}" 2>&1 | tee -a "${ACCURACY_LOG_FILE}"
+  # Capture lm_eval exit code explicitly; tee always exits 0 so PIPESTATUS is needed.
+  lm_eval_exit="${PIPESTATUS[0]}"
+  if [[ "${lm_eval_exit}" -ne 0 ]]; then
+    echo "ERROR: lm_eval exited with code ${lm_eval_exit}"
+    return "${lm_eval_exit}"
+  fi
 
   local result_file=""
   result_file=$(python3 - <<PY

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -495,6 +495,7 @@ jobs:
           find /tmp/accuracy-results -type f -name '*.json' | head -20 || echo "No JSON files found"
 
       - name: Transform SGLANG accuracy results for dashboard
+        id: transform
         if: steps.downloaded.outputs.json_count != '0'
         run: |
           python3 .github/scripts/accuracy_to_dashboard.py \
@@ -505,9 +506,14 @@ jobs:
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           echo "=== Generated entries ==="
           cat accuracy-benchmark-input.json
+          entries_count=$(python3 -c "import json; data=json.load(open('accuracy-benchmark-input.json')); print(len(data))")
+          echo "entries_count=${entries_count}" >> "$GITHUB_OUTPUT"
+          if [ "${entries_count}" = "0" ]; then
+            echo "::warning::No valid SGLANG accuracy entries were produced. Check that the result JSON files contain 'results.gsm8k[\"exact_match,flexible-extract\"]'."
+          fi
 
       - name: Store SGLANG accuracy result to dashboard
-        if: steps.downloaded.outputs.json_count != '0'
+        if: steps.transform.outputs.entries_count != '0' && steps.transform.outputs.entries_count != ''
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: customBiggerIsBetter

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -568,17 +568,11 @@ jobs:
 
           printf '%s\n' "${{ matrix.model.env_vars }}" | sed 's/^[[:space:]]*//' > /tmp/oot_env_file.txt
 
-          SHM_FLAG=(--shm-size=16G)
-          if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
-            SHM_FLAG=()
-          fi
-
           $CONTAINER_ENGINE run -dt --device=/dev/kfd $DEVICE_FLAG \
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
             --ipc=host --group-add video \
-            "${SHM_FLAG[@]}" \
             --privileged \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -339,7 +339,7 @@ jobs:
 
       - name: Docker Login
         run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login docker.io -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Generate custom SGLang base Dockerfile
         run: |

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -480,7 +480,7 @@ jobs:
             $CONTAINER_ENGINE kill $containers || true
           fi
           $CONTAINER_ENGINE rm -f "$CONTAINER_NAME" 2>/dev/null || true
-          $CONTAINER_ENGINE run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
+          $CONTAINER_ENGINE run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged docker.io/rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
 
       - name: Checkout benchmark ATOM source
         if: steps.check.outputs.enabled == 'true'
@@ -566,9 +566,7 @@ jobs:
           MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
           echo "Using model cache backend: ${MODEL_CACHE_DESC}"
 
-          cat > /tmp/oot_env_file.txt << 'EOF'
-          ${{ matrix.model.env_vars }}
-          EOF
+          printf '%s\n' "${{ matrix.model.env_vars }}" | sed 's/^[[:space:]]*//' > /tmp/oot_env_file.txt
 
           SHM_FLAG=(--shm-size=16G)
           if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -634,7 +634,7 @@ jobs:
             $CONTAINER_ENGINE kill $containers || true
           fi
           $CONTAINER_ENGINE rm -f "$CONTAINER_NAME" 2>/dev/null || true
-          $CONTAINER_ENGINE run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
+          $CONTAINER_ENGINE run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged docker.io/rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
 
       - name: Checkout benchmark ATOM source
         if: steps.check.outputs.enabled == 'true'
@@ -720,9 +720,7 @@ jobs:
           MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
           echo "Using model cache backend: ${MODEL_CACHE_DESC}"
 
-          cat > /tmp/oot_env_file.txt << 'EOF'
-          ${{ matrix.model.env_vars }}
-          EOF
+          printf '%s\n' "${{ matrix.model.env_vars }}" | sed 's/^[[:space:]]*//' > /tmp/oot_env_file.txt
 
           SHM_FLAG=(--shm-size=16G)
           if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -722,17 +722,11 @@ jobs:
 
           printf '%s\n' "${{ matrix.model.env_vars }}" | sed 's/^[[:space:]]*//' > /tmp/oot_env_file.txt
 
-          SHM_FLAG=(--shm-size=16G)
-          if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
-            SHM_FLAG=()
-          fi
-
           $CONTAINER_ENGINE run -dt --device=/dev/kfd $DEVICE_FLAG \
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
             --ipc=host --group-add video \
-            "${SHM_FLAG[@]}" \
             --privileged \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -481,7 +481,7 @@ jobs:
 
       - name: Docker Login
         run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login docker.io -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Generate custom OOT base Dockerfile
         run: |


### PR DESCRIPTION
## Motivation
Fix two Podman compatibility bugs:                                                                                                                                                            
  1. **env-file leading whitespace**: YAML-indented heredoc writes `KEY=VALUE` lines with leading spaces. Docker tolerates this; Podman exits 125. Replace heredoc with `printf | sed` to strip whitespace before writing.                                                                                                                                                            
                                                                                                                                                                                                                                        
  2. **Unqualified image name**: `rocm/pytorch:latest` in workspace cleanup fails under Podman. Replace with `docker.io/rocm/pytorch:latest`.  
