### PR TITLE
fix(dashboard): MTP acceptance trend chart and docker image resolution

### DIFF
--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -511,9 +511,11 @@ const _displayEntries = Object.entries(_displayMap).sort((a, b) => b[0].length -
 // TODO: Remove after old "MTP3" data ages out of dashboard history (~90 runs)
 const _accuracyRenames = {
   'Qwen3.5-397B-A17B-FP8 MTP3': 'Qwen3.5-397B-A17B-FP8 MTP',
+  'DeepSeek-R1-0528 MTP3': 'DeepSeek-R1-0528 MTP',
+  'DeepSeek-R1-0528-MXFP4 MTP3': 'DeepSeek-R1-0528-MXFP4 MTP',
 };
-function normalizeModelName(name) {
-  if (_accuracyRenames[name]) return _accuracyRenames[name];
+function normalizeModelName(name, accRename = false) {
+  if (accRename && _accuracyRenames[name]) return _accuracyRenames[name];
   const lc = name.toLowerCase();
   for (const [key, display] of _displayEntries) {
     if (lc === key) return display;
@@ -532,13 +534,13 @@ function parseBenchName(name) {
   if (backend === 'OOT') backend = 'ATOM-vLLM';
   // Accuracy entries: "ModelName accuracy (GSM8K)" — (.+?) for multi-word model names
   let m = rawName.match(/^(.+?)\s+accuracy\s+\((\w+)\)$/);
-  if (m) return { backend, model: normalizeModelName(m[1]), metric: 'accuracy', unit: m[2], isAccuracy: true };
+  if (m) return { backend, model: normalizeModelName(m[1], true), metric: 'accuracy', unit: m[2], isAccuracy: true };
   // MTP acceptance: "ModelName MTP acceptance (%)"
   m = rawName.match(/^(.+?)\s+MTP acceptance\s+\((%)\)$/);
-  if (m) return { backend, model: normalizeModelName(m[1]), metric: 'MTP acceptance', unit: m[2] };
+  if (m) return { backend, model: normalizeModelName(m[1], true), metric: 'MTP acceptance', unit: m[2] };
   // avg toks/fwd: "ModelName avg toks/fwd (tok/fwd)"
   m = rawName.match(/^(.+?)\s+avg toks\/fwd\s+\((.+)\)$/);
-  if (m) return { backend, model: normalizeModelName(m[1]), metric: 'avg toks/fwd', unit: m[2] };
+  if (m) return { backend, model: normalizeModelName(m[1], true), metric: 'avg toks/fwd', unit: m[2] };
   m = rawName.match(/^(.+?)\s+(\d+\/\d+)\s+c=(\d+)\s+(.+?)\s*\((.+)\)$/);
   if (m) return { backend, model: normalizeModelName(m[1]), islOsl: m[2], conc: +m[3], metric: m[4].trim(), unit: m[5] };
   m = rawName.match(/^(.+?)\s+(\d+\/\d+)\s+c=(\d+)\s+(_gpu_count|_tp)$/);
@@ -2610,7 +2612,7 @@ function renderAccuracyTab() {
     html += `<div style="flex:1;min-width:280px;display:flex;flex-direction:column;gap:var(--gap-md)">`;
     html += `<div><canvas id="${canvasId}" style="height:180px"></canvas></div>`;
     if (mtpHistory && mtpHistory.length > 0) {
-      html += `<div data-mtp-history="${escHTML(JSON.stringify(mtpHistory.slice(0, 30)))}"><canvas id="${mtpCanvasId}" style="height:180px"></canvas></div>`;
+      html += `<div><canvas id="${mtpCanvasId}" style="height:180px"></canvas></div>`;
     }
     html += `</div>`;
     // Right: info
@@ -2823,10 +2825,8 @@ function renderMtpAcceptanceMiniChart(key) {
   const mtpCanvasId = 'mtp-trend-' + key.replace(/[^a-zA-Z0-9]/g, '_');
   const canvas = document.getElementById(mtpCanvasId);
   if (!canvas) return;
-  const wrapper = canvas.parentElement;
-  let history;
-  try { history = JSON.parse(wrapper.dataset.mtpHistory || '[]'); } catch { return; }
-  if (!history.length) return;
+  const history = mtpAcceptanceMap[key];
+  if (!history || !history.length) return;
   const sorted = [...history].sort((a, b) => a.date - b.date);
   const labels = sorted.map(h => { const dt = new Date(h.date); return `${dt.getMonth()+1}/${dt.getDate()}`; });
   const datasets = [{
@@ -2884,7 +2884,7 @@ function renderMtpAcceptanceMiniChart(key) {
             <div class="pop-row"><span class="pop-key">GPU</span><span class="pop-val" style="font-family:inherit">${escHTML(gpuLabel)}</span></div>
             <div class="pop-row"><span class="pop-key">ROCm</span><span class="pop-val">${escHTML(acc._rocm_version || '—')}</span></div>
             <div class="pop-row"><span class="pop-key">Docker</span><span class="pop-val" style="font-size:11px;max-width:260px;overflow-wrap:anywhere">${escHTML(acc.dockerImage || '—')}</span></div>
-            <div class="pop-row"><span class="pop-key">Commit</span><span class="pop-val">${commitHref ? '<a href="' + escHTML(commitHref) + '" target="_blank" rel="noopener noreferrer">' + (h.commit.id?.slice(0,7) || '—') + '</a>' : (h.commit?.id?.slice(0,7) || '—')}</span></div>
+            <div class="pop-row"><span class="pop-key">Commit</span><span class="pop-val">${commitHref ? '<a href="' + escHTML(commitHref) + '" target="_blank" rel="noopener noreferrer">' + (h.commit?.id?.slice(0,7) || '—') + '</a>' : (h.commit?.id?.slice(0,7) || '—')}</span></div>
             <div class="pop-row"><span class="pop-key">Message</span><span class="pop-val" style="font-family:inherit;font-size:12px">${escHTML(h.commit?.message?.split('\\n')[0] || '—')}</span></div>
             <div class="pop-row"><span class="pop-key">Author</span><span class="pop-val" style="font-family:inherit">${escHTML(h.commit?.author?.name || '—')}</span></div>
             <div class="pop-row"><span class="pop-key">Date</span><span class="pop-val">${fmtDate(h.date)}</span></div>

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -222,10 +222,20 @@ jobs:
           fi
           GPU_VRAM_GB=$(docker exec atom-benchmark rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
           ROCM_VERSION=$(docker exec atom-benchmark cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
+          # Resolve latest → nightly_YYYYMMDDHHMMSS for dashboard display
+          DOCKER_IMAGE="${{ inputs.image || 'rocm/atom-dev:latest' }}"
+          if [ "$DOCKER_IMAGE" = "rocm/atom-dev:latest" ]; then
+            RESOLVED_IMAGE=""
+            if RESOLUTION_JSON="$(python3 .github/scripts/resolve_atom_image.py --repository rocm/atom-dev --reference-tag latest --image-family native 2>/dev/null)"; then
+              RESOLVED_IMAGE="$(echo "$RESOLUTION_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("resolved_image",""))')" || true
+            fi
+            DOCKER_IMAGE="${RESOLVED_IMAGE:-$DOCKER_IMAGE}"
+          fi
           echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT
           echo "gpu_vram_gb=${GPU_VRAM_GB}" >> $GITHUB_OUTPUT
           echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
-          echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}"
+          echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
+          echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}, Docker: ${DOCKER_IMAGE}"
 
       - name: Download models
         run: |
@@ -269,7 +279,7 @@ jobs:
             -e GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
             -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
             -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
-            -e DOCKER_IMAGE="${{ inputs.image || 'rocm/atom-dev:latest' }}" \
+            -e DOCKER_IMAGE="${{ steps.gpu-info.outputs.docker_image }}" \
             -e RESULT_PATH="${{ env.RESULT_FILENAME }}.json" \
             -e DISPLAY_NAME="${{ matrix.model.display }}" \
             atom-benchmark python3 -c "


### PR DESCRIPTION
## Summary

- **MTP trend chart fix**: `escHTML` (textContent→innerHTML) doesn't escape `"`, so JSON in `data-*` attributes was truncated at the first double quote (attribute value became just `[{`). Fix: read `mtpAcceptanceMap` directly in JS instead of HTML attribute round-trip.
- **MTP3/MTP naming**: `_accuracyRenames` now only applies to accuracy/MTP entries (`accRename` flag), so Performance tab keeps `MTP3` while Accuracy tab shows `MTP`.
- **Docker image resolution**: Benchmark workflow now resolves `rocm/atom-dev:latest` → `nightly_YYYYMMDDHHMMSS` via `resolve_atom_image.py` for accurate dashboard display.

## Test plan

- [x] Local preview: MTP acceptance trend chart renders on row expand
- [x] Local preview: Performance tab shows MTP3, Accuracy tab shows MTP
- [ ] CI: benchmark workflow resolves Docker image tag correctly