### PR TITLE
[atom-vllm] use aiter greedy sampler

### DIFF
--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -124,3 +124,13 @@ def register_model() -> None:
     from atom.plugin.vllm.graph_capture_patch import apply_graph_capture_patch
 
     apply_graph_capture_patch()
+
+    # The sampler patch follows the ATOM platform/plugin-mode lifecycle: if the
+    # ATOM vLLM platform is enabled, we also install the ATOM greedy sampler
+    # patch; if plugin mode is disabled, register_model() has already returned.
+    from atom.plugin.vllm.sampler_patch import apply_vllm_sampler_patch
+
+    # Install the ATOM-owned greedy sampler patch after the core vLLM model
+    # integration is in place. This keeps vLLM as the runtime while letting
+    # ATOM own the hot greedy argmax path.
+    apply_vllm_sampler_patch()

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -125,6 +125,10 @@ def register_model() -> None:
 
     apply_graph_capture_patch()
 
+    if not envs.ATOM_VLLM_SAMPLER:
+        logger.info("Disable ATOM vLLM sampler patch")
+        return
+
     # The sampler patch follows the ATOM platform/plugin-mode lifecycle: if the
     # ATOM vLLM platform is enabled, we also install the ATOM greedy sampler
     # patch; if plugin mode is disabled, register_model() has already returned.

--- a/atom/plugin/vllm/sampler_ops.py
+++ b/atom/plugin/vllm/sampler_ops.py
@@ -1,0 +1,15 @@
+import torch
+import aiter
+
+
+def greedy_sample_tokens(logits: torch.Tensor) -> torch.Tensor:
+    """Plugin-local greedy sampler wrapper that routes to AITER."""
+
+    if not logits.is_contiguous():
+        logits = logits.contiguous()
+
+    sampled_tokens = torch.empty(
+        logits.size(0), dtype=torch.int32, device=logits.device
+    )
+    aiter.greedy_sample(sampled_tokens, logits)
+    return sampled_tokens

--- a/atom/plugin/vllm/sampler_patch.py
+++ b/atom/plugin/vllm/sampler_patch.py
@@ -1,0 +1,51 @@
+import functools
+import logging
+
+from atom.plugin.vllm.sampler_ops import greedy_sample_tokens
+from atom.utils import envs
+
+logger = logging.getLogger("atom")
+
+_PATCH_ATTR = "_atom_vllm_sampler_patch_installed"
+
+
+def _mark_patched(wrapper, original) -> None:
+    setattr(wrapper, _PATCH_ATTR, True)
+    setattr(wrapper, "_atom_vllm_sampler_original", original)
+
+
+def _patch_v1_sampler() -> bool:
+    try:
+        from vllm.v1.sample.sampler import Sampler as V1Sampler
+    except ImportError:
+        logger.debug("vLLM V1 sampler module is unavailable; skip ATOM sampler patch.")
+        return False
+
+    original = V1Sampler.greedy_sample
+    if getattr(original, _PATCH_ATTR, False):
+        return False
+
+    @functools.wraps(original)
+    def _atom_greedy_sample(logits):
+        # vLLM V1's original greedy path returns int64 token ids.
+        return greedy_sample_tokens(logits).long()
+
+    _mark_patched(_atom_greedy_sample, original)
+    V1Sampler.greedy_sample = staticmethod(_atom_greedy_sample)
+    return True
+
+
+def apply_vllm_sampler_patch() -> None:
+    """Install ATOM's greedy sampler patch into vLLM V1 only."""
+
+    if envs.ATOM_DISABLE_VLLM_PLUGIN:
+        logger.info("Skip ATOM vLLM sampler patch because ATOM platform is disabled.")
+        return
+
+    # Only vLLM V1 is patched. V2 keeps the original vLLM sampler path.
+    try:
+        if _patch_v1_sampler():
+            logger.info("Enabled ATOM vLLM V1 greedy sampler patch.")
+    except Exception:
+        # Patching remains best-effort because vLLM internal symbols can drift.
+        logger.exception("Failed to apply ATOM vLLM V1 sampler patch.")

--- a/atom/plugin/vllm/sampler_patch.py
+++ b/atom/plugin/vllm/sampler_patch.py
@@ -42,6 +42,10 @@ def apply_vllm_sampler_patch() -> None:
         logger.info("Skip ATOM vLLM sampler patch because ATOM platform is disabled.")
         return
 
+    if not envs.ATOM_VLLM_SAMPLER:
+        logger.info("Skip ATOM vLLM sampler patch because ATOM_VLLM_SAMPLER=0.")
+        return
+
     # Only vLLM V1 is patched. V2 keeps the original vLLM sampler path.
     try:
         if _patch_v1_sampler():

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -83,6 +83,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "ATOM_DISABLE_VLLM_PLUGIN_ATTENTION", "0"
     ).lower()
     == "1",
+    # Temporary plugin-side switch for vLLM sampler A/B testing.
+    "ATOM_VLLM_SAMPLER": lambda: os.getenv("ATOM_VLLM_SAMPLER", "1").lower() == "1",
     "ATOM_USE_CUSTOM_ALL_GATHER": lambda: os.getenv(
         "ATOM_USE_CUSTOM_ALL_GATHER", "1"
     ).lower()


### PR DESCRIPTION
use aiter greedy sampler to replace the vLLM original greedy sampler
accuracy status:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9242|±  |0.0073|
|     |       |strict-match    |     3|exact_match|↑  |0.9234|±  |0.0073|

with aiter sampler(1k1k con8):
<img width="558" height="520" alt="image" src="https://github.com/user-attachments/assets/ee7c5b4f-dbe2-4fdc-95bb-f73e90ace03c" />

without aiter sampler(1k1k con 8):
<img width="554" height="521" alt="image" src="https://github.com/user-attachments/assets/f66224e2-78ce-4ad6-b87a-688b2a1759fe" />

with aiter sampler(1k1k con32):
<img width="555" height="518" alt="image" src="https://github.com/user-attachments/assets/3accbd86-874c-43b7-8661-692dc4ca196c" />

without aiter sampler(1k1k con 32):
<img width="553" height="518" alt="image" src="https://github.com/user-attachments/assets/21d8bf0f-6ee4-4c54-afa4-149efb11a145" />