### PR TITLE
fix(docker): remove setuptools_scm<9 pin to fix aiter build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -313,7 +313,7 @@ ARG AITER_COMMIT="HEAD"
 ARG PREBUILD_KERNELS=1
 ARG MAX_JOBS
 
-RUN pip install --upgrade "setuptools_scm<9"
+RUN pip install --upgrade setuptools_scm
 RUN echo "========== [Parallel] Building Aiter ==========" && \
     git clone --depth 1 $AITER_REPO /app/aiter-test && \
     cd /app/aiter-test && \


### PR DESCRIPTION
## Summary
- Remove `setuptools_scm<9` version pin in Dockerfile that broke nightly Docker build
- `vcs_versioning==1.1.1` (used by aiter) requires `setuptools_scm>=9` for `config.scm` attribute, pinning to <9 causes `AttributeError: 'Configuration' object has no attribute 'scm'`

## Test plan
- [x] Reproduced locally: `setuptools_scm==8.3.1` → `config.scm` missing, error
- [x] Verified fix: `setuptools_scm==10.0.5` → `config.scm` present, OK
- [ ] Nightly Docker build passes