### PR TITLE
fix(dashboard): deduplicate historyMap entries per commit

### DIFF
--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -577,13 +577,50 @@ function parseRunConfigs(run) {
   return configs;
 }
 
-// All parsed configs from all runs, keyed by configKey, each holding array of values over time
+// All parsed configs from all runs, keyed by configKey, each holding array of values over time.
+// When multiple runs share the same commit, keep only the newest run per (configKey, commit)
+// so that all consumers (table, trend chart, tooltip, detail panel) see consistent data.
 const historyMap = {}; // key -> [{date, commit, throughput, ...}, ...]
+const _seenCommits = {}; // key -> Set of 7-char commit prefixes already added
+// Use 7-char prefix for dedup: data.js may store the same commit as abbreviated
+// (e.g. "450f14b7") or full hash — both must be treated as the same commit.
 for (const run of allRuns) {
   const configs = parseRunConfigs(run);
   for (const [key, cfg] of Object.entries(configs)) {
-    if (!historyMap[key]) historyMap[key] = [];
+    if (!historyMap[key]) { historyMap[key] = []; _seenCommits[key] = new Set(); }
+    const cid7 = cfg.commit.id.slice(0, 7);
+    // allRuns is sorted desc by date, so first entry for a commit is the newest — skip duplicates
+    if (_seenCommits[key].has(cid7)) continue;
+    _seenCommits[key].add(cid7);
     historyMap[key].push(cfg);
+  }
+}
+
+// Unify metadata across configKeys that share the same commit.
+// Different benchmark runs for the same commit may have different Docker tags,
+// dates, and run URLs; pick the newest run's metadata so all configKeys are consistent.
+// Note: _gpu_count/_tp are NOT unified — they are real per-config values tied to throughput data.
+// Key by (backend, cid7): different backends (ATOM, ATOM-vLLM, ATOM-sglang)
+// legitimately use different Docker images on the same commit.
+const _commitMeta = {}; // "backend|cid7" -> metadata from newest run
+for (const history of Object.values(historyMap)) {
+  for (const cfg of history) {
+    const mk = cfg.backend + '|' + cfg.commit.id.slice(0, 7);
+    if (!_commitMeta[mk] || cfg.date > _commitMeta[mk].date) {
+      _commitMeta[mk] = { date: cfg.date, runUrl: cfg.runUrl, _oot_image_tag: cfg._oot_image_tag, _gpu_name: cfg._gpu_name, _gpu_vram_gb: cfg._gpu_vram_gb, _rocm_version: cfg._rocm_version };
+    }
+  }
+}
+for (const history of Object.values(historyMap)) {
+  for (const cfg of history) {
+    const meta = _commitMeta[cfg.backend + '|' + cfg.commit.id.slice(0, 7)];
+    if (!meta) continue;
+    cfg.date = meta.date;
+    if (meta.runUrl) cfg.runUrl = meta.runUrl;
+    if (meta._oot_image_tag) cfg._oot_image_tag = meta._oot_image_tag;
+    if (meta._gpu_name) cfg._gpu_name = meta._gpu_name;
+    if (meta._gpu_vram_gb) cfg._gpu_vram_gb = meta._gpu_vram_gb;
+    if (meta._rocm_version) cfg._rocm_version = meta._rocm_version;
   }
 }
 
@@ -1965,18 +2002,24 @@ function renderTrendsTab() {
   const [trendBackend, trendModel] = state.trendModelKey.split('|');
 
   // Build ordered x-axis: use date as primary key (not commit ID)
-  // Each run gets a unique index; x-axis shows short date labels
-  const runsAsc = [...allRuns].reverse();
+  // Each run gets a unique index; x-axis shows short date labels.
+  // Use _commitMeta date when available (unified across configKeys) to stay
+  // consistent with popover/detail dates; fall back to run date for accuracy-only commits.
   const seen = new Set();
   const orderedRuns = []; // [{cid, date, label}]
-  for (const r of runsAsc) {
+  for (const r of allRuns) {
     const cid = r.commit.id.slice(0, 7);
     if (!seen.has(cid)) {
       seen.add(cid);
-      const d = new Date(r.date);
-      orderedRuns.push({ cid, date: r.date, label: (d.getMonth()+1) + '/' + d.getDate() + ' ' + cid });
+      // _commitMeta is keyed by "backend|cid7"; find newest date across all backends
+      let metaDate = null;
+      for (const mk of Object.keys(_commitMeta)) { if (mk.endsWith('|' + cid)) { const d = _commitMeta[mk].date; if (!metaDate || d > metaDate) metaDate = d; } }
+      const useDate = metaDate || r.date;
+      const d = new Date(useDate);
+      orderedRuns.push({ cid, date: useDate, label: (d.getMonth()+1) + '/' + d.getDate() + ' ' + cid });
     }
   }
+  orderedRuns.reverse(); // chronological order for x-axis
   const orderedLabels = orderedRuns.map(r => r.label);
   const commitDateMap = {}; const labelToCid = {};
   orderedRuns.forEach(r => { commitDateMap[r.label] = r.date; labelToCid[r.label] = r.cid; });
@@ -2341,7 +2384,8 @@ function renderTimeline() {
    ================================================================ */
 function buildDetailHTML(key, cfg) {
   const hist = historyMap[key];
-  const prev = (hist && hist.length > 1) ? hist[1] : null;
+  const idx = hist ? hist.indexOf(cfg) : -1;
+  const prev = hist && idx >= 0 && idx + 1 < hist.length ? hist[idx + 1] : (hist && hist.length > 1 ? hist[1] : null);
   const reg = regressions[key];
 
   const interactive = cfg.TPOT && cfg.TPOT > 0 ? 1000 / cfg.TPOT : null;
@@ -2387,7 +2431,8 @@ function buildDetailHTML(key, cfg) {
    ================================================================ */
 function showPopover(key, cfg) {
   const hist = historyMap[key];
-  const prev = (hist && hist.length > 1) ? hist[1] : null;
+  const idx = hist ? hist.indexOf(cfg) : -1;
+  const prev = hist && idx >= 0 && idx + 1 < hist.length ? hist[idx + 1] : (hist && hist.length > 1 ? hist[1] : null);
   const reg = regressions[key];
 
   const pop = document.getElementById('popover');


### PR DESCRIPTION
## Summary
- Fix trend chart showing stale per-GPU throughput when multiple benchmark runs share the same commit hash
- Root cause: `historyMap` stored all runs, and the trend chart loop overwrote newest data with oldest when they mapped to the same x-axis label
- Fix: deduplicate at `historyMap` construction — keep only the newest run per (configKey, commit), so all downstream consumers (table, trend chart, tooltip, detail panel) see consistent data

## Example
MiniMax-M2.5 1k/1k c=128 had two runs on commit `108a70ed`:
- Newer run: Total Tput = 7492.8 → per GPU = 3746.4
- Older run: Total Tput = 5051.0 → per GPU = 2525.5

Before fix: trend chart showed **2525.5** (stale)
After fix: trend chart shows **3746.4** (correct)

## Test plan
- [x] Local preview verified at `http://localhost:8888`
- [x] JS syntax check passed
- [ ] Dashboard renders correctly after deploy