### PR TITLE
[ATOM sglang workflow] Allow users to overwrite atom in docker easily

### DIFF
--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -365,7 +365,7 @@ jobs:
           RUN pip uninstall -y atom || true
           RUN rm -rf /app/ATOM
           COPY . /app/ATOM
-          RUN cd /app/ATOM && pip install -e .
+          RUN cd /app/ATOM && pip install . --no-deps
           RUN echo "=== ATOM version AFTER installation ===" && pip show atom || true
           EOF
 

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -365,7 +365,7 @@ jobs:
           RUN pip uninstall -y atom || true
           RUN rm -rf /app/ATOM
           COPY . /app/ATOM
-          RUN cd /app/ATOM && pip install . --no-deps
+          RUN cd /app/ATOM && pip install .
           RUN echo "=== ATOM version AFTER installation ===" && pip show atom || true
           EOF
 


### PR DESCRIPTION
## Motivation

This PR intends to let advanced-user(develop) to overwrite atom in docker easier.

## Technical Details

 Currently, the atom is installed via `pip install -e .` editable mode.  When users want to develop atom like debugging, they can not easily uninstall atom in docker and will meet issue, due to cached egg info.
<img width="990" height="116" alt="image" src="https://github.com/user-attachments/assets/e2f10dd0-950c-45e9-ad61-4095dfd51432" />

This PR change the editable mode to normal mode installation.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
