### PR TITLE
fix: correct MXFP4 MoE weight shuffle for Quark models (MiniMax-M2.1)

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -869,6 +869,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 True,
             )
             layer.w2_weight.data = shuffle_weight_a16w4(layer.w2_weight, 16, False)
+            layer.w2_weight.is_shuffled = True
             shuffled_w2_scale = shuffle_scale_a16w4(
                 layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
                 self.num_experts,
@@ -883,16 +884,26 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 )
         # quark method for moe, split it out?
         elif self.quant_method == "quark":
-            shuffle_weights(layer.w13_weight, layer.w2_weight)
+            # W1/W13 (gate+up): both stage1 (ck_moe_stage1) and stage2
+            # (ck_moe_stage2) use DeviceMoeGemmMXBPreShuffle with preShuffleBuffer
+            # layout (gate_up=False). The a4w4 kernel expects gate_up=False even
+            # though w1 has 2*N rows.
+            layer.w13_weight.data = shuffle_weight_a16w4(layer.w13_weight, 16, False)
+            layer.w13_weight.is_shuffled = True
             s0, s1, _ = layer.w13_weight_scale.shape
             w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
-            w13_weight_scale = fp4_utils.e8m0_shuffle(w13_weight_scale)
+            w13_weight_scale = shuffle_scale_a16w4(w13_weight_scale, s0, False)
             layer.w13_weight_scale.data = w13_weight_scale.view(s0, s1, -1)
 
-            s0, s1, _ = layer.w2_weight_scale.shape
-            w2_weight_scale = layer.w2_weight_scale.view(s0 * s1, -1)
-            w2_weight_scale = fp4_utils.e8m0_shuffle(w2_weight_scale)
-            layer.w2_weight_scale.data = w2_weight_scale.view(s0, s1, -1)
+            # W2 (down-proj): same preShuffleBuffer layout with gate_up=False.
+            layer.w2_weight.data = shuffle_weight_a16w4(layer.w2_weight, 16, False)
+            layer.w2_weight.is_shuffled = True
+            shuffled_w2_scale = shuffle_scale_a16w4(
+                layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
+                self.num_experts,
+                False,
+            )
+            layer.w2_weight_scale = atom_parameter(shuffled_w2_scale)
             return
         else:
             shuffle_weights(layer.w13_weight, layer.w2_weight)


### PR DESCRIPTION
Fix the Quark branch of Mxfp4MoEMethod.process_weights_after_loading() to use the correct pre-shuffle format expected by CK JIT MoE kernels (DeviceMoeGemmMXBPreShuffle).

Previously the Quark path called shuffle_weights() (a16w4 interleave format) and e8m0_shuffle() for scales. The CK JIT a4w4 kernels (ck_moe_stage1/ck_moe_stage2_fwd) expect shuffle_weight_a16w4(gate_up= False) format for both w1 and w2, and shuffle_scale_a16w4() for scales.

Changes:
- w13 (gate+up): shuffle_weight_a16w4(w13, 16, gate_up=False) + shuffle_scale_a16w4(scale, E, gate_up=False). The a4w4 kernel uses gate_up=False even for w1 which has 2*N rows (unlike the a16w4 path which uses gate_up=True for w1).
- w2 (down-proj): shuffle_weight_a16w4(w2, 16, gate_up=False) + shuffle_scale_a16w4(scale, E, gate_up=False).
- Set is_shuffled=True on both w13_weight and w2_weight so that ck_moe_stage2_fwd selects the preshuffle_on module variant.
- Also set is_shuffled=True on w2_weight in the existing gpt_oss/Swiglu branch (latent bug: weight was shuffled but attribute was missing).

Scope: Only the Quark branch is new code. Currently only MiniMax-M2.1- MXFP4 uses quant_method="quark" with fp4x2 MoE. The gpt_oss is_shuffled fix is a one-line correctness fix for DeepSeek-R1 FP4 and similar models.

Depends on: [ROCm/aiter thpereir/cktile_a4w4 branch](https://github.com/ROCm/aiter/pull/2642) (CK JIT a4w4 dispatch)

Tested: MiniMax-M2.1-MXFP4 TP=8 server starts and produces correct output.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->
Serving with ATOM:
```
python -m atom.entrypoints.openai_server \
  --model amd/MiniMax-M2.1-MXFP4 \
  --trust-remote-code \
  -tp 8
```

```
lm_eval \
  --model local-completions \
  --model_args model=amd/MiniMax-M2.1-MXFP4,base_url=http://localhost:8000/v1/completions,num_concurrent=32,max_retries=3,tokenized_requests=False \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size 1
```

lm-eval before changes:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0|±  |0|
|     |       |strict-match    |     5|exact_match|↑  |0|±  |0|

lm-eval after changes:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9371|±  |0.0067|
|     |       |strict-match    |     5|exact_match|↑  |0.9348|±  |0.0068|

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
