### PR TITLE
CI: Extend ATOM server readiness wait to 45 minutes

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -41,8 +41,8 @@ if [ "$TYPE" == "launch" ]; then
 
   echo ""
   echo "========== Waiting for ATOM server to start =========="
-  # Phase 1: Wait for HTTP server to be up via /health endpoint
-  max_retries=30
+  # Phase 1: Wait for HTTP server to be up via /health endpoint (45 min max)
+  max_retries=45
   retry_interval=60
   server_up=false
   for ((i=1; i<=max_retries; i++)); do


### PR DESCRIPTION
## Summary
- Increase Phase 1 `/health` polling in `.github/scripts/atom_test.sh` from 30 to 45 retries at 60s intervals (1800s → 2700s).
- Helps aiter ATOM accuracy jobs when model weights load slowly from shared cache.

## Related
- Companion aiter workflow PR raises the `Run ATOM accuracy test` step `timeout-minutes` so the job is not cut off after the longer startup window.