### PR TITLE
fix(plugin): guard mixed attention metadata reductions

### DIFF
--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -345,17 +345,18 @@ class vllmAttentionMetadataBuilderMethods:
         )
 
         if mixed:
-            prefill_max_query_len = (
-                query_lens_cpu[num_decodes + num_extends :].max().item()
-            )
-            prefill_max_seq_len = seq_lens[num_decodes + num_extends :].max().item()
-            prefill_query_start_loc = (
-                prefill_query_start_loc[num_decodes + num_extends :]
-                - prefill_query_start_loc[num_decodes + num_extends]
-            )
-            decode_max_query_len = query_lens_cpu[:num_decodes].max().item()
-            decode_max_seq_len = seq_lens[:num_decodes].max().item()
-            decode_query_start_loc = decode_query_start_loc[: num_decodes + 1]
+            prefill_start = num_decodes + num_extends
+            if num_prefills > 0:
+                prefill_max_query_len = query_lens_cpu[prefill_start:].max().item()
+                prefill_max_seq_len = seq_lens[prefill_start:].max().item()
+                prefill_query_start_loc = (
+                    prefill_query_start_loc[prefill_start:]
+                    - prefill_query_start_loc[prefill_start]
+                )
+            if num_decodes > 0:
+                decode_max_query_len = query_lens_cpu[:num_decodes].max().item()
+                decode_max_seq_len = seq_lens[:num_decodes].max().item()
+                decode_query_start_loc = decode_query_start_loc[: num_decodes + 1]
 
         prefill_metadata = None
         decode_metadata = None


### PR DESCRIPTION
## Summary
- guard mixed attention metadata reductions so empty decode/prefill slices do not call `.max()`
- handle mixed batches that only contain a subset of decode, extend, and prefill request types
- prevent attention metadata build failures in mixed edge cases such as decode+extend without prefills

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test plan
- Not run
- Reproduce the mixed-batch case that previously hit `query_lens_cpu[num_decodes + num_extends :].max()`
- Verify metadata build succeeds when `num_prefills == 0` or `num_decodes == 0`


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
