### PR TITLE
[benchmark] Add TP8 EP8 case for deepseek FP4

### DIFF
--- a/.github/benchmark/sglang_benchmark_models.json
+++ b/.github/benchmark/sglang_benchmark_models.json
@@ -40,5 +40,16 @@
     "bench_args": "",
     "runner": "atom-mi355-8gpu-oot-benchmark",
     "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1"
+  },
+  {
+  "display": "DeepSeek-R1-0528-MXFP4 FP4 TP8 EP8",
+  "dashboard_model": "DeepSeek-R1-0528-MXFP4-tp8-ep8",
+  "source_path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
+  "path": "amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4",
+  "prefix": "deepseek-r1-fp4-tp8-ep8",
+  "extra_args": "--trust-remote-code --tensor-parallel-size 8 --expert-parallel-size 8",
+  "bench_args": "",
+  "runner": "atom-mi355-8gpu-oot-benchmark",
+  "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1"
   }
 ]

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -23,6 +23,10 @@ on:
         description: "DeepSeek-R1-0528-MXFP4 FP4 TP4"
         type: boolean
         default: false
+      deepseek-r1-fp4-tp8-ep8:
+        description: "DeepSeek-R1-0528-MXFP4 FP4 TP8 EP8"
+        type: boolean
+        default: false
       sglang_image:
         description: "Optional SGLang benchmark image override. Leave empty to use sglang-latest on main or rebuild from the selected non-main branch."
         type: string
@@ -212,6 +216,7 @@ jobs:
           ENABLE_DEEPSEEK_R1_FP8_TP4: ${{ inputs.deepseek-r1-fp8-tp4 }}
           ENABLE_DEEPSEEK_R1_FP4_TP8: ${{ inputs.deepseek-r1-fp4-tp8 }}
           ENABLE_DEEPSEEK_R1_FP4_TP4: ${{ inputs.deepseek-r1-fp4-tp4 }}
+          ENABLE_DEEPSEEK_R1_FP4_TP8_EP8: ${{ inputs.deepseek-r1-fp4-tp8-ep8 }}
         run: |
           MODELS_JSON="$(jq -c '
             map(select(
@@ -219,6 +224,7 @@ jobs:
               or (.prefix == "deepseek-r1-fp8-tp4" and env.ENABLE_DEEPSEEK_R1_FP8_TP4 == "true")
               or (.prefix == "deepseek-r1-fp4-tp8" and env.ENABLE_DEEPSEEK_R1_FP4_TP8 == "true")
               or (.prefix == "deepseek-r1-fp4-tp4" and env.ENABLE_DEEPSEEK_R1_FP4_TP4 == "true")
+              or (.prefix == "deepseek-r1-fp4-tp8-ep8" and env.ENABLE_DEEPSEEK_R1_FP4_TP8_EP8 == "true")
             ))
           ' .github/benchmark/sglang_benchmark_models.json)"
           echo "models_json=${MODELS_JSON}" >> "$GITHUB_OUTPUT"
@@ -454,6 +460,7 @@ jobs:
             deepseek-r1-fp8-tp4) echo "enabled=${{ inputs.deepseek-r1-fp8-tp4 }}" >> "$GITHUB_OUTPUT" ;;
             deepseek-r1-fp4-tp8) echo "enabled=${{ inputs.deepseek-r1-fp4-tp8 }}" >> "$GITHUB_OUTPUT" ;;
             deepseek-r1-fp4-tp4) echo "enabled=${{ inputs.deepseek-r1-fp4-tp4 }}" >> "$GITHUB_OUTPUT" ;;
+            deepseek-r1-fp4-tp8-ep8) echo "enabled=${{ inputs.deepseek-r1-fp4-tp8-ep8 }}" >> "$GITHUB_OUTPUT" ;;
             *) echo "enabled=true" >> "$GITHUB_OUTPUT" ;;
           esac
 


### PR DESCRIPTION
## Motivation
This PR extends the SGLang benchmark workflow introduced in [#548](https://github.com/ROCm/ATOM/pull/548) by adding coverage for the DeepSeek-R1-0528 MXFP4 FP4 TP8+EP8 configuration.
The goal is to make this DeepSeek FP4 expert-parallel setup selectable from the existing manual benchmark workflow so its performance can be collected and compared consistently with the other SGLang benchmark cases already tracked in the dashboard flow.
## Technical Details
This change adds a new SGLang benchmark model entry for `DeepSeek-R1-0528-MXFP4 FP4 TP8+EP8` in `.github/benchmark/sglang_benchmark_models.json`, following the same JSON-driven configuration pattern established in [#548](https://github.com/ROCm/ATOM/pull/548).
It also updates `.github/workflows/atom-sglang-benchmark.yaml` so the new case can be selected via `workflow_dispatch`, included in the model filtering logic, and executed through the existing matrix path. The new case uses `--tensor-parallel-size 8 --expert-parallel-size 8` and publishes under a dedicated dashboard model name to avoid mixing TP8 and TP8+EP8 results.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
