### PR TITLE
fix: remap MXFP4 exclude list for Qwen3.5 MTP layers

### DIFF
--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -216,6 +216,18 @@
     "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
   },
   {
+    "model_name": "Qwen3.5-397B-A17B-MXFP4 MTP",
+    "model_path": "amd/Qwen3.5-397B-A17B-MXFP4",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 4 --method mtp --num-speculative-tokens 3",
+    "env_vars": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "test_level": "main",
+    "accuracy_threshold": 0.835,
+    "accuracy_baseline": 0.9538,
+    "accuracy_baseline_model": "Qwen/Qwen3.5-397B-A17B-FP8",
+    "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
+  },
+  {
     "model_name": "MiniMax-M2.5",
     "model_path": "MiniMaxAI/MiniMax-M2.5",
     "extraArgs": "--kv_cache_dtype fp8 -tp 2 --trust-remote-code",

--- a/atom/models/qwen3_5_mtp.py
+++ b/atom/models/qwen3_5_mtp.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Qwen3.5 MTP model."""
 
+import re
+
 import torch
 import torch.nn as nn
 from aiter.dist.parallel_state import get_tp_group
@@ -137,6 +139,28 @@ class Qwen3_5MTP(nn.Module):
         if atom_config.enable_prefix_caching:
             raise ValueError("Qwen3_5MTP currently does not support prefix caching")
         self.config = config
+
+        # Remap exclude entries: checkpoint uses 0-based MTP layer indices
+        # (e.g. "mtp.layers.0.*") but the model constructs layers with absolute
+        # indices starting at num_hidden_layers (e.g. "mtp.layers.60.*").
+        # Reindex so _is_excluded matches the construction prefix.
+        mtp_start = config.num_hidden_layers
+        num_mtp = getattr(config, "mtp_num_hidden_layers", 1)
+        if atom_config.quant_config is not None and mtp_start > 0:
+            pat = re.compile(r"^mtp\.layers\.(\d+)\.")
+            new_excludes = []
+            for entry in atom_config.quant_config.exclude_layers:
+                m = pat.match(entry)
+                if m:
+                    old_idx = int(m.group(1))
+                    entry = pat.sub(f"mtp.layers.{mtp_start + old_idx}.", entry)
+                new_excludes.append(entry)
+            # Add layer-level prefixes so that _is_excluded matches module
+            # prefixes like "mtp.layers.60.mlp.experts" (not just leaf names).
+            for i in range(num_mtp):
+                new_excludes.append(f"mtp.layers.{mtp_start + i}")
+            atom_config.quant_config.exclude_layers = list(dict.fromkeys(new_excludes))
+
         self.model = Qwen3_5MultiTokenPredictor(
             atom_config=atom_config, prefix=maybe_prefix(prefix, "mtp")
         )


### PR DESCRIPTION
## Summary
- Qwen3.5 MXFP4 MTP3 server crashes during weight loading because MTP layers are incorrectly allocated as fp4x2 instead of BF16
- Root cause: checkpoint `quantization_config.exclude` uses 0-based MTP layer indices (`mtp.layers.0.*`) but model constructs layers with absolute indices (`mtp.layers.60.*`), so `_is_excluded` misses the MTP layers
- Fix: reindex exclude entries to absolute indices and add layer-level prefix entries in `Qwen3_5MTP.__init__`

## Test plan
- [x] Qwen3.5-397B-A17B-MXFP4 MTP3 tp=4 server starts successfully
- [x] GSM8K 3-shot: flexible-extract=0.841, acceptance rate=83%
- [x] Non-MTP baseline unaffected (0.857)
- [ ] CI accuracy test