### PR TITLE
fix: robust MTP quant exclude for MXFP4 and FP8

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -302,7 +302,9 @@ class QuantizationConfig:
         """Alias for ``global_spec``."""
         return self.global_spec
 
-    def get_layer_quant_config(self, layer_name: str) -> LayerQuantConfig:
+    def get_layer_quant_config(
+        self, layer_name: str, *, check_children: bool = False
+    ) -> LayerQuantConfig:
         """Return the :class:`LayerQuantConfig` for *layer_name*.
 
         Resolution order:
@@ -311,7 +313,7 @@ class QuantizationConfig:
         3. Fall back to ``global_spec``.
         """
         # 1. Exclude list
-        if self._is_excluded(layer_name):
+        if self._is_excluded(layer_name, check_children=check_children):
             return LayerQuantConfig(quant_dtype=self.torch_dtype)
 
         # 2. Pattern match
@@ -366,13 +368,21 @@ class QuantizationConfig:
 
     # -- internal helpers ---------------------------------------------------
 
-    def _is_excluded(self, layer_name: str) -> bool:
+    def _is_excluded(self, layer_name: str, *, check_children: bool = False) -> bool:
         if layer_name is None or not self.exclude_layers:
             return False
-        return any(
-            self._matches_exclude(layer_name, ignore_str)
-            for ignore_str in self.exclude_layers
-        )
+        prefix = layer_name + "."
+        for ignore_str in self.exclude_layers:
+            if self._matches_exclude(layer_name, ignore_str):
+                return True
+            # When check_children is True, also match if any exclude entry
+            # is a child of layer_name.  This is needed by container modules
+            # like FusedMoE whose prefix (e.g. "mtp.layers.60.mlp.experts")
+            # is a parent of the leaf-level exclude entries (e.g.
+            # "mtp.layers.60.mlp.experts.0.gate_up_proj").
+            if check_children and ignore_str.startswith(prefix):
+                return True
+        return False
 
     @staticmethod
     def _matches_exclude(

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1932,7 +1932,9 @@ class FusedMoE(torch.nn.Module):
         super().__init__()
         self.prefix = prefix
         layer_quant_config = (
-            quant_config.get_layer_quant_config(prefix) if quant_config else None
+            quant_config.get_layer_quant_config(prefix, check_children=True)
+            if quant_config
+            else None
         )
         self.params_dtype = (
             layer_quant_config.quant_dtype

--- a/atom/models/qwen3_5_mtp.py
+++ b/atom/models/qwen3_5_mtp.py
@@ -140,29 +140,32 @@ class Qwen3_5MTP(nn.Module):
             raise ValueError("Qwen3_5MTP currently does not support prefix caching")
         self.config = config
 
-        # Remap exclude entries: checkpoint uses 0-based MTP layer indices
-        # (e.g. "mtp.layers.0.*") but the model constructs layers with absolute
-        # indices starting at num_hidden_layers (e.g. "mtp.layers.60.*").
-        # Reindex so _is_excluded matches the construction prefix.
+        # Reindex MTP exclude entries on a copy: checkpoint uses 0-based
+        # indices (mtp.layers.0.*) but the model uses absolute indices
+        # starting at num_hidden_layers (mtp.layers.60.*).
         mtp_start = config.num_hidden_layers
-        num_mtp = getattr(config, "mtp_num_hidden_layers", 1)
+        mtp_atom_config = atom_config
         if atom_config.quant_config is not None and mtp_start > 0:
+            import copy
+
             pat = re.compile(r"^mtp\.layers\.(\d+)\.")
             new_excludes = []
+            changed = False
             for entry in atom_config.quant_config.exclude_layers:
                 m = pat.match(entry)
                 if m:
+                    changed = True
                     old_idx = int(m.group(1))
                     entry = pat.sub(f"mtp.layers.{mtp_start + old_idx}.", entry)
                 new_excludes.append(entry)
-            # Add layer-level prefixes so that _is_excluded matches module
-            # prefixes like "mtp.layers.60.mlp.experts" (not just leaf names).
-            for i in range(num_mtp):
-                new_excludes.append(f"mtp.layers.{mtp_start + i}")
-            atom_config.quant_config.exclude_layers = list(dict.fromkeys(new_excludes))
+            if changed:
+                mtp_atom_config = copy.copy(atom_config)
+                mtp_qc = copy.copy(atom_config.quant_config)
+                mtp_qc.exclude_layers = list(dict.fromkeys(new_excludes))
+                mtp_atom_config.quant_config = mtp_qc
 
         self.model = Qwen3_5MultiTokenPredictor(
-            atom_config=atom_config, prefix=maybe_prefix(prefix, "mtp")
+            atom_config=mtp_atom_config, prefix=maybe_prefix(prefix, "mtp")
         )
 
         self.lm_head = ParallelLMHead(

--- a/tests/test_quant_config.py
+++ b/tests/test_quant_config.py
@@ -400,6 +400,43 @@ class TestExcludeMatching:
         qcfg = self._make(["lm_head"])
         assert not qcfg._is_excluded("self_attn.q_proj")
 
+    def test_check_children_matches_child_entries(self):
+        """check_children=True: parent excluded when child entries exist."""
+        qcfg = self._make(
+            [
+                "mtp.layers.60.mlp.experts.0.gate_up_proj",
+                "mtp.layers.60.mlp.experts.0.down_proj",
+            ]
+        )
+        # Without check_children: module-level prefix does NOT match
+        assert not qcfg._is_excluded("mtp.layers.60.mlp.experts")
+        # With check_children: child entries trigger a match
+        assert qcfg._is_excluded("mtp.layers.60.mlp.experts", check_children=True)
+
+    def test_check_children_no_false_positive_on_siblings(self):
+        """check_children must not match sibling modules."""
+        qcfg = self._make(["mtp.layers.60.mlp.gate"])
+        # "mlp.gate" is a sibling of "mlp.experts", not a child
+        assert not qcfg._is_excluded("mtp.layers.60.mlp.experts", check_children=True)
+
+    def test_check_children_propagates_through_get_layer_quant_config(self):
+        qcfg = QuantizationConfig(config=None)
+        qcfg.torch_dtype = BF16
+        qcfg.global_spec = LayerQuantConfig(
+            quant_type=QuantType.per_Token, quant_dtype=FP8
+        )
+        qcfg.exclude_layers = ["mtp.layers.60.mlp.experts.0.gate_up_proj"]
+
+        # Without check_children: returns global FP8
+        result = qcfg.get_layer_quant_config("mtp.layers.60.mlp.experts")
+        assert result.quant_dtype == FP8
+
+        # With check_children: returns BF16 (excluded)
+        result = qcfg.get_layer_quant_config(
+            "mtp.layers.60.mlp.experts", check_children=True
+        )
+        assert result.quant_dtype == BF16
+
 
 class TestMatchesExclude:
     def test_exact(self):


### PR DESCRIPTION
## Summary

- Fixes MXFP4 MTP3 producing garbage output (GSM8K=0, acceptance=96.6%) caused by #640's reverse prefix match in `_matches_exclude`
- Adds opt-in `check_children` parameter to `_is_excluded` / `get_layer_quant_config` — FusedMoE uses it to correctly detect when all expert sub-weights are excluded
- Reindexes MTP exclude entries on a **copy** of quant_config (no mutation of shared state)

**Root cause**: FusedMoE queries at module level (`mtp.layers.60.mlp.experts`) but exclude list has leaf entries (`mtp.layers.60.mlp.experts.0.gate_up_proj`). The reverse prefix match fixed this but also broke the target model (`model.layers.0.mlp` matched `model.layers.0.mlp.gate`).

**Approach**: Same pattern as vLLM's `is_layer_skipped` which special-cases expert prefixes to check child entries.

| Config | GSM8K | Accept | CI threshold | Status |
|--------|-------|--------|-------------|--------|
| FP8 MTP3 | 0.870 | 82.9% | 0.85 | ✅ |
| MXFP4 MTP3 | 0.852 | 82.7% | 0.835 | ✅ |

## Test plan

- [x] Qwen3.5-397B-A17B-FP8 MTP3 GSM8K ≥ 0.85
- [x] Qwen3.5-397B-A17B-MXFP4 MTP3 GSM8K ≥ 0.835
- [x] Acceptance rate ~82% (not 96%+ indicating broken target)
- [x] Unit tests for `check_children` logic (3 new tests)
- [ ] CI: FP8 non-MTP, MXFP4 non-MTP regression check