### PR TITLE
[Enhancement] support online quantization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ __pycache__
 debug
 aiter_logs
 *.log
+online_quant_info_*.json
 .claude/plan/

--- a/atom/config.py
+++ b/atom/config.py
@@ -263,7 +263,11 @@ class QuantizationConfig:
     - ``quant_type``, ``quant_dtype``, ``is_dynamic`` convenience properties
     """
 
-    def __init__(self, config: PretrainedConfig = None):
+    def __init__(
+        self,
+        config: PretrainedConfig = None,
+        online_quant_config: Optional[dict] = None,
+    ):
         if config is None:
             self.torch_dtype = torch.bfloat16
             self.hf_quant_config = None
@@ -271,6 +275,11 @@ class QuantizationConfig:
             self.layer_pattern_specs: list[tuple[str, LayerQuantConfig]] = []
             self.exclude_layers: list[str] = []
             self.quant_method = ""
+            self.online_quant = False
+            self.online_quant_config_raw = None
+            self.online_global_spec: LayerQuantConfig = LayerQuantConfig()
+            self.online_layer_pattern_specs: list[tuple[str, LayerQuantConfig]] = []
+            self.online_exclude_layers: list[str] = []
             return
 
         # Some HF configs set torch_dtype=None; normalize to bf16 default.
@@ -284,10 +293,28 @@ class QuantizationConfig:
             self.layer_pattern_specs = []
             self.exclude_layers = []
             self.quant_method = ""
+        else:
+            self.quant_method = self.hf_quant_config.get("quant_method", "")
+
+        # Online quantization: re-quantize float / FP8 / MXFP4 models at load time
+        self.online_quant = False
+        self.online_quant_config_raw = online_quant_config
+        if online_quant_config is not None and self.quant_method in [
+            "",
+            "fp8",
+            "mxfp4",
+        ]:
+            self.online_quant = True
+            online_parser = get_quant_parser("online_quant")
+            online_parsed_quant_config = online_parser.parse(online_quant_config)
+            self.online_global_spec = online_parsed_quant_config.global_spec
+            self.online_layer_pattern_specs = (
+                online_parsed_quant_config.layer_pattern_specs
+            )
+            self.online_exclude_layers = list(online_parsed_quant_config.exclude_layers)
+
+        if self.quant_method == "":
             return
-
-        self.quant_method = self.hf_quant_config.get("quant_method", "")
-
         # Use the parser registry to build a structured ParsedQuantConfig
         parser = get_quant_parser(self.quant_method)
         parsed_quant_config = parser.parse(self.hf_quant_config)
@@ -303,7 +330,11 @@ class QuantizationConfig:
         return self.global_spec
 
     def get_layer_quant_config(
-        self, layer_name: str, *, check_children: bool = False
+        self,
+        layer_name: str,
+        use_online_quant: bool = False,
+        *,
+        check_children: bool = False,
     ) -> LayerQuantConfig:
         """Return the :class:`LayerQuantConfig` for *layer_name*.
 
@@ -312,12 +343,21 @@ class QuantizationConfig:
         2. fnmatch-style pattern match in ``layer_pattern_specs``.
         3. Fall back to ``global_spec``.
         """
+        if use_online_quant:
+            layer_pattern_specs = self.online_layer_pattern_specs
+            global_spec = self.online_global_spec
+            exclude_layers = self.online_exclude_layers
+        else:
+            layer_pattern_specs = self.layer_pattern_specs
+            global_spec = self.global_spec
+            exclude_layers = self.exclude_layers
+
         # 1. Exclude list
-        if self._is_excluded(layer_name, check_children=check_children):
+        if self._is_excluded(layer_name, exclude_layers, check_children=check_children):
             return LayerQuantConfig(quant_dtype=self.torch_dtype)
 
         # 2. Pattern match
-        for pattern, spec in self.layer_pattern_specs:
+        for pattern, spec in layer_pattern_specs:
             if "*" not in pattern:
                 if layer_name in pattern:
                     return spec
@@ -325,7 +365,7 @@ class QuantizationConfig:
                 return spec
 
         # 3. Global default
-        return self.global_spec
+        return global_spec
 
     # -- convenience properties (delegate to global_spec) ---------------------
 
@@ -359,6 +399,10 @@ class QuantizationConfig:
         factors.append(self.global_spec)
         factors.append(self.layer_pattern_specs)
         factors.append(self.exclude_layers)
+        if self.online_quant:
+            factors.append(self.online_layer_pattern_specs)
+            factors.append(self.online_global_spec)
+            factors.append(self.online_exclude_layers)
         hash_value = hashlib.sha256(str(factors).encode()).hexdigest()
         return hash_value
 
@@ -368,11 +412,19 @@ class QuantizationConfig:
 
     # -- internal helpers ---------------------------------------------------
 
-    def _is_excluded(self, layer_name: str, *, check_children: bool = False) -> bool:
-        if layer_name is None or not self.exclude_layers:
+    def _is_excluded(
+        self,
+        layer_name: str,
+        exclude_layers: Optional[list[str]] = None,
+        *,
+        check_children: bool = False,
+    ) -> bool:
+        if exclude_layers is None:
+            exclude_layers = self.exclude_layers
+        if layer_name is None or not exclude_layers:
             return False
         prefix = layer_name + "."
-        for ignore_str in self.exclude_layers:
+        for ignore_str in exclude_layers:
             if self._matches_exclude(layer_name, ignore_str):
                 return True
             # When check_children is True, also match if any exclude entry
@@ -489,6 +541,17 @@ class QuantizationConfig:
         for name in self.exclude_layers:
             new_exclude.extend(_remap_layer_name(name))
         self.exclude_layers = list(dict.fromkeys(new_exclude))
+        if self.online_quant:
+            new_online_pattern_specs = []
+            for pattern, spec in self.online_layer_pattern_specs:
+                for remapped in _remap_layer_name(pattern):
+                    new_online_pattern_specs.append((remapped, spec))
+            self.online_layer_pattern_specs = new_online_pattern_specs
+
+            new_online_exclude = []
+            for name in self.online_exclude_layers:
+                new_online_exclude.extend(_remap_layer_name(name))
+            self.online_exclude_layers = list(dict.fromkeys(new_online_exclude))
 
         # Apply model-declared HF-name to ATOM-path translations for exclude entries.
         # Models that have a mismatch between their HF quant config names and ATOM
@@ -877,6 +940,8 @@ class Config:
 
     # only use for plugin mode
     plugin_config: Optional[PluginConfig] = None
+    # only for quark_online_quantization
+    online_quant_config: Optional[dict] = None
 
     def _set_cudagraph_sizes(self):
         if self.compilation_config.cudagraph_capture_sizes:
@@ -921,7 +986,10 @@ class Config:
                 eos_ids := getattr(self.generation_config, "eos_token_id", None)
             ) is not None:
                 self.stop_token_ids = [eos_ids] if isinstance(eos_ids, int) else eos_ids
-        self.quant_config = QuantizationConfig(self.hf_config)
+        self.quant_config = QuantizationConfig(
+            self.hf_config,
+            self.online_quant_config,
+        )
         # In plugin mode, supplement exclude_layers with vLLM's ignored_layers when
         # the HF quant config didn't produce any exclusions (non-quark quant methods).
         if (

--- a/atom/config.py
+++ b/atom/config.py
@@ -299,7 +299,10 @@ class QuantizationConfig:
         # Online quantization: re-quantize float / FP8 / MXFP4 models at load time
         self.online_quant = False
         self.online_quant_config_raw = online_quant_config
-        if online_quant_config is not None and self.quant_method in [
+        self.online_global_spec: LayerQuantConfig = LayerQuantConfig()
+        self.online_layer_pattern_specs: list[tuple[str, LayerQuantConfig]] = []
+        self.online_exclude_layers: list[str] = []
+        if online_quant_config and self.quant_method in [
             "",
             "fp8",
             "mxfp4",

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -223,9 +223,6 @@ class EngineArgs:
             "--online_quant_config",
             type=json.loads,
             default=None,
-            # default= '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": "lm_head"}',
-            # default= '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": "lm_head, *.gate.*"}',
-            # default= '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "ptpc_fp8"}, "exclude_layer": "lm_head, *.gate.*"}',
             help=(
                 "Online quantization config as a JSON string. "
                 "Supported quantization formats: ptpc_fp8, mxfp4. "

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -3,6 +3,7 @@
 
 import argparse
 import logging
+import json
 from dataclasses import dataclass, fields
 from typing import List, Optional
 
@@ -53,6 +54,7 @@ class EngineArgs:
     kv_transfer_config: str = "{}"
     draft_model: Optional[str] = None
     mark_trace: bool = False
+    online_quant_config: Optional[dict] = None
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -216,6 +218,31 @@ class EngineArgs:
             "--mark-trace",
             action="store_true",
             help="Enable graph_marker nodes for tracing/profile instrumentation.",
+        )
+        parser.add_argument(
+            "--online_quant_config",
+            type=json.loads,
+            default=None,
+            # default= '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": "lm_head"}',
+            # default= '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": "lm_head, *.gate.*"}',
+            # default= '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "ptpc_fp8"}, "exclude_layer": "lm_head, *.gate.*"}',
+            help=(
+                "Online quantization config as a JSON string. "
+                "Supported quantization formats: ptpc_fp8, mxfp4. "
+                "The JSON object has three fields "
+                "(at least one must be provided):\n"
+                '  - "global_quant_config": str, default quantization '
+                "format applied to all layers.\n"
+                '  - "layer_quant_config": dict, per-layer overrides '
+                "using glob patterns as keys. "
+                "Overrides global_quant_config for matched layers.\n"
+                '  - "exclude_layer": str or list[str], layer name '
+                "patterns to exclude from quantization.\n"
+                "Example:\n"
+                """  '{"global_quant_config": "ptpc_fp8", """
+                """"layer_quant_config": {"*expert*": "mxfp4"}, """
+                """"exclude_layer": "lm_head"}'"""
+            ),
         )
 
         return parser

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -2,9 +2,11 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import concurrent.futures
+import json
 import os
 import logging
 import re
+import time
 from glob import glob
 from typing import Generator, Tuple
 from collections.abc import Iterable, Mapping
@@ -234,6 +236,35 @@ def load_model_in_plugin_mode(
     )
     _empty_cache()
     return loaded_weights_record
+
+
+def _save_online_quant_info(
+    oq_layers: list[dict],
+    model_name_or_path: str,
+    elapsed_seconds: float,
+    online_quant_config: dict,
+):
+    """Save online quantization info to a JSON file (rank 0 only)."""
+    if get_tp_group().rank_in_group != 0:
+        return
+    output_dir = envs.ATOM_TORCH_PROFILER_DIR or os.getcwd()
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    timestamp_ns = time.time_ns() % 1_000_000_000
+    filepath = os.path.join(
+        output_dir, f"online_quant_info_{timestamp}_{timestamp_ns:09d}.json"
+    )
+
+    payload = {
+        "model": model_name_or_path,
+        "online_quant_config": online_quant_config,
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "num_layers": len(oq_layers),
+        "layers": oq_layers,
+    }
+    with open(filepath, "w") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+    logger.info("Online quantization info saved to %s", filepath)
 
 
 def load_model(
@@ -624,6 +655,17 @@ def load_model(
 
     # Avoid holding stale Parameter refs that prevent storage release.
     del params_dict
+    has_online_quant = any(
+        getattr(m, "online_quant", False)
+        or (
+            getattr(m, "quant_config", None) is not None
+            and getattr(m.quant_config, "online_quant", False)
+        )
+        for _, m in model.named_modules()
+    )
+    if has_online_quant:
+        logger.info("Weight post-processing started (includes online quantization)")
+    pp_start = time.perf_counter()
 
     for _, module in model.named_modules():
         if hasattr(module, "process_weights_after_loading"):
@@ -636,5 +678,29 @@ def load_model(
             quant_method.process_weights_after_loading(module)
         if isinstance(quant_method, FusedMoEMethodBase):
             quant_method.init_prepare_finalize(module)
+
+    if has_online_quant:
+        pp_elapsed = time.perf_counter() - pp_start
+        oq_layers = []
+        raw_online_quant_config = None
+        for _, module in model.named_modules():
+            info = getattr(module, "_online_quant_info", None)
+            if info is not None:
+                oq_layers.append(info)
+            if raw_online_quant_config is None:
+                qc = getattr(module, "quant_config", None)
+                if qc is not None and hasattr(qc, "online_quant_config_raw"):
+                    raw_online_quant_config = qc.online_quant_config_raw
+        logger.info(
+            "Weight post-processing done: %.2f seconds, " "%d layers online-quantized",
+            pp_elapsed,
+            len(oq_layers),
+        )
+        _save_online_quant_info(
+            oq_layers,
+            model_name_or_path,
+            pp_elapsed,
+            raw_online_quant_config or {},
+        )
 
     return loaded_weights_record

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -32,6 +32,7 @@ from atom.model_ops.utils import (
 )
 from atom.utils import envs
 from atom.utils.decorators import mark_trace
+from atom.quantization.quark.utils import weight_dequant_fp8
 from torch import nn
 
 logger = logging.getLogger("atom")
@@ -225,6 +226,7 @@ class LinearBase(nn.Module):
         params_dtype = layer_quant_config.quant_dtype
         self.source_quant_dtype = source_quant_dtype
         self.layer_quant_config = layer_quant_config
+        self.quant_config = quant_config
         super().__init__()
         self.reduce_results = reduce_results
         self.input_size = input_size
@@ -346,7 +348,123 @@ class LinearBase(nn.Module):
         param_data = param.data
         param.weight_loader_process(param_data, loaded_weight)
 
+    def _gather_full_weight(self, weight):
+        """Gather sharded weight from all TP ranks to reconstruct the full unpartitioned weight."""
+        if self.tp_size <= 1 or self.tp_dim is None:
+            return weight
+        return get_tp_group().all_gather(weight, dim=self.tp_dim)
+
+    def _shard_quantized_weight(self, q_weight, weight_scale):
+        """Split the quantized full weight and scale back to this rank's shard."""
+        if self.tp_size <= 1 or self.tp_dim is None:
+            return q_weight, weight_scale
+        # fp4x2 packs 2 values per byte; view as uint8 so narrow() works correctly
+        is_mxfp4 = q_weight.dtype == torch.float4_e2m1fn_x2
+        if is_mxfp4:
+            q_weight = q_weight.view(torch.uint8)
+        w_shard = q_weight.shape[self.tp_dim] // self.tp_size
+        w_start = self.tp_rank * w_shard
+        q_weight_local = q_weight.narrow(self.tp_dim, w_start, w_shard).contiguous()
+        if is_mxfp4:
+            q_weight_local = q_weight_local.view(torch.float4_e2m1fn_x2)
+
+        # for col linear qkv, w13, [m, n] -> [m // tp, n] -> [m // tp, 1], TP and non-TP are equivalent
+        if weight_scale.dim() > self.tp_dim and weight_scale.shape[self.tp_dim] > 1:
+            s_shard = weight_scale.shape[self.tp_dim] // self.tp_size
+            s_start = self.tp_rank * s_shard
+            weight_scale_local = weight_scale.narrow(
+                self.tp_dim, s_start, s_shard
+            ).contiguous()
+        # for row linear o, w2, [m, n] -> [m, n // tp] -> [m, 1], TP and non-TP are not equivalent
+        else:
+            weight_scale_local = weight_scale
+
+        return q_weight_local, weight_scale_local
+
+    def online_quantize_weight(self):
+        """Re-quantize this layer's weight at load time using the online quant config.
+
+        Handles TP gather/shard when local quantization would produce
+        different results than quantizing the full unpartitioned weight.
+        """
+        online_layer_quant_config = self.quant_config.get_layer_quant_config(
+            self.prefix, use_online_quant=True
+        )
+        online_quant_type = online_layer_quant_config.quant_type
+        online_quant_dtype = online_layer_quant_config.quant_dtype
+        online_quant_func = get_hip_quant(online_quant_type)
+        assert online_quant_dtype in [
+            torch.float8_e4m3fn,
+            torch.float4_e2m1fn_x2,
+        ], (
+            f"Unsupported online quant: "
+            f"dtype={online_quant_dtype}, type={online_quant_type}"
+        )
+        assert self.quant_type in [QuantType.No, QuantType.per_1x128], (
+            f"Unsupported source quant_type for online quantization: "
+            f"{self.quant_type} (layer={self.prefix})"
+        )
+        weight = self.weight.data
+        weight_scale = getattr(self, "weight_scale", None)
+        # Gather is required whenever local quantization would differ from
+        # quantizing the full unpartitioned weight (bit-exact with offline).
+        need_gather = False
+        if self.tp_size > 1 and self.tp_dim is not None:
+            if isinstance(self, ReplicatedLinear):
+                # W and S of kv_a_proj_with_mqa don't match,
+                # but it doesn't need to be split.
+                return
+            # col qkv w13, tp_dim=0, [m, n] -> [m // tp, n] -> [m // tp, 1], don't need gather
+            # row o, w2, tp_dim=1, [m, n] -> [m, n //tp] -> [m, 1], need gather
+            if online_quant_type == QuantType.per_Token:
+                # per_Token: scale = max(|full_row|), tp_dim=1 has partial rows
+                need_gather = self.tp_dim == 1
+            elif online_quant_type == QuantType.per_1x128:
+                # 128×128 blocks: misaligned if partition size % 128 != 0
+                if self.tp_dim == 0:
+                    need_gather = self.output_size % 128 != 0
+                else:
+                    need_gather = self.input_size % 128 != 0
+            elif online_quant_type == QuantType.per_1x32:
+                # 1×32 blocks: row dim is 1 (always aligned), only column matters
+                # col qkv w13, tp_dim=0, [m, n] -> [m // tp, n] -> [m // tp, n // 32], don't need gather
+                # row o, w2, tp_dim=1, [m, n] -> [m, n //tp] -> [m, n // tp // 32], need gather
+                need_gather = self.tp_dim == 1 and self.input_size % 32 != 0
+        if need_gather:
+            weight = self._gather_full_weight(weight)
+            if weight_scale is not None:
+                weight_scale = self._gather_full_weight(weight_scale)
+
+        if self.quant_type == QuantType.per_1x128:
+            # dequant per block fp8
+            weight = weight_dequant_fp8(weight, weight_scale)
+        q_weight, weight_scale = online_quant_func(
+            weight, quant_dtype=online_quant_dtype
+        )
+        if need_gather:
+            q_weight, weight_scale = self._shard_quantized_weight(
+                q_weight, weight_scale
+            )
+        self.weight = nn.Parameter(q_weight, requires_grad=False)
+        self.weight_scale = nn.Parameter(weight_scale, requires_grad=False)
+
+        # Update quant state
+        self.quant_type = online_quant_type
+        self.params_dtype = online_quant_dtype
+        self.quant_func = online_quant_func
+        self.need_normalize_e4m3fn_to_e4m3fnuz = (
+            online_quant_dtype == torch.float8_e4m3fnuz
+        )
+        self._online_quant_info = {
+            "layer": self.prefix,
+            "quant_type": online_quant_type.name,
+            "quant_dtype": str(online_quant_dtype),
+        }
+
     def process_weights_after_loading(self):
+        # Re-quantize before process_weights if online quantization is enabled
+        if self.quant_config is not None and self.quant_config.online_quant:
+            self.online_quantize_weight()
         if (
             self.quant_type == QuantType.per_Tensor
             and len(self.output_partition_sizes) > 1

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2266,13 +2266,6 @@ class FusedMoE(torch.nn.Module):
         if need_dequant:
             del old_w13_scale, old_w2_scale
 
-        # print(
-        #     f"[online_quant] {self.layer_name}: "
-        #     f"w13={self.w13_weight.shape} {self.w13_weight.dtype}, "
-        #     f"w13_scale={self.w13_weight_scale.shape} {self.w13_weight_scale.dtype}, "
-        #     f"w2={self.w2_weight.shape} {self.w2_weight.dtype}, "
-        #     f"w2_scale={self.w2_weight_scale.shape} {self.w2_weight_scale.dtype}"
-        # )
         self._online_quant_info = {
             "layer": self.layer_name,
             "quant_type": online_quant_type.name,

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -56,6 +56,7 @@ from atom.utils.decorators import mark_trace
 from torch import nn
 from transformers import PretrainedConfig
 from atom.plugin.moe import FusedMoEDecoratorForPluginMode
+from atom.quantization.quark.utils import weight_dequant_fp8
 
 
 class FusedMoeWeightScaleSupported(Enum):
@@ -2054,9 +2055,8 @@ class FusedMoE(torch.nn.Module):
             is_lora_enabled=False,
         )
         self.moe_config = moe
-
-        # Note: get_quant_method will look at the layer's local_num_experts
-        # for heuristic purposes, so it must be initialized first.
+        self.quant_config = quant_config
+        self.online_quant = quant_config is not None and quant_config.online_quant
 
         quant_method_str = (
             layer_quant_config.quant_method if layer_quant_config else None
@@ -2083,19 +2083,201 @@ class FusedMoE(torch.nn.Module):
         assert self.quant_method is not None
 
         self.apply_router_weight_on_input = apply_router_weight_on_input
-        moe_quant_params = {
+        self.moe_quant_params = {
             "num_experts": self.local_num_experts,
             "hidden_size": hidden_size,
             "intermediate_size_per_partition": self.intermediate_size_per_partition,
             "params_dtype": self.params_dtype,
             "weight_loader": self.weight_loader,
         }
-        self.quant_method.create_weights(layer=self, **moe_quant_params)
+        self.quant_method.create_weights(layer=self, **self.moe_quant_params)
         compilation_config = atom_config.compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError("Duplicate layer name: {}".format(prefix))
         compilation_config.static_forward_context[prefix] = self
         self.layer_name = prefix
+
+    def process_weights_after_loading(self):
+        self._online_quant()
+
+    def _online_quant(self):
+        """Handle online quantization: (optionally dequant →) quantize weights,
+        then switch quant_method.
+
+        Called by the loader BEFORE quant_method.process_weights_after_loading().
+        Flow:
+          1. If source is already quantized (e.g. per_1x128 FP8), dequant → bf16
+          2. Switch quant_method and allocate target quantized buffers
+          3. Per-expert: quantize bf16 → write into buffers via
+             _load_model_weight_or_group_weight_scale (reuses TP-shard + padding)
+          4. Loader then calls target method's process_weights_after_loading
+             which does fn→fnuz normalization and shuffle on the already-FP8 weights.
+        """
+        if not self.online_quant:
+            return
+
+        online_quant_config = self.quant_config.get_layer_quant_config(
+            self.layer_name, use_online_quant=True
+        )
+        online_quant_type = online_quant_config.quant_type
+        online_quant_dtype = online_quant_config.quant_dtype
+        quant_func = get_hip_quant(online_quant_type)
+
+        source_quant_type = self.layer_quant_config.quant_type
+        assert source_quant_type in (QuantType.No, QuantType.per_1x128), (
+            f"Unsupported source quant_type for MoE online quantization: "
+            f"{source_quant_type} (layer={self.layer_name})"
+        )
+        need_dequant = source_quant_type == QuantType.per_1x128
+
+        # Determine whether each weight needs all_gather to match offline quantization.
+        # w13 (column parallel): (E, (2*intermediate/tp, hidden)) — TP dim 0
+        # w2  (row parallel):    (E, (hidden, intermediate/tp)) — TP dim 1
+        # w13 [e, m, n]->[e, m//tp, n//2]->[e, m//tp, n//32]
+        def check_need_allgather():
+            if self.use_ep:
+                assert self.tp_size == 1, "EP MoE should not TP-shard expert weights"
+                return False
+
+            need_gather_w2 = False
+            if self.tp_size > 1:
+                # self.intermediate_size_per_partition = intermediate_size // self.tp_size
+                w2_in = self.intermediate_size_per_partition
+                if online_quant_type == QuantType.per_Token:
+                    need_gather_w2 = True
+                elif online_quant_type == QuantType.per_1x32:
+                    need_gather_w2 = w2_in % 32 != 0
+            return need_gather_w2
+
+        need_gather_w2 = check_need_allgather()
+        tp_group = get_tp_group() if need_gather_w2 else None
+        load_full_w2 = not need_gather_w2
+
+        # Save references to old weights before create_weights overwrites them.
+        # For per_1x128 source we also need the old scales for dequantization.
+        old_w13_data = self.w13_weight.data
+        old_w2_data = self.w2_weight.data
+        old_w13_scale = self.w13_weight_scale.data if need_dequant else None
+        old_w2_scale = self.w2_weight_scale.data if need_dequant else None
+        device = old_w13_data.device
+
+        # Switch quant_method and allocate target quantized-type buffers.
+        if online_quant_dtype == dtypes.fp8:
+            self.quant_method = Fp8MoEMethod(online_quant_config, self.moe_config)
+        elif online_quant_dtype == dtypes.fp4x2:
+            self.quant_method = Mxfp4MoEMethod(online_quant_config, self.moe_config)
+        else:
+            raise ValueError(
+                f"Unsupported online quant_dtype for MoE: {online_quant_dtype}"
+            )
+        self.moe_quant_params["params_dtype"] = online_quant_dtype
+        with torch.device(device):
+            self.quant_method.create_weights(layer=self, **self.moe_quant_params)
+
+        self.w13_input_scale = None
+        self.w2_input_scale = None
+
+        for expert_id in range(self.local_num_experts):
+            # --- w13 column-parallel ---
+            w13_local = old_w13_data[expert_id]
+            w1_size = w13_local.shape[0] // 2
+
+            if need_dequant:
+                w13_scale = old_w13_scale[expert_id]
+                s1_size = w13_scale.shape[0] // 2
+                w1_bf16 = weight_dequant_fp8(
+                    w13_local[:w1_size].contiguous(),
+                    w13_scale[:s1_size].contiguous(),
+                )
+                w3_bf16 = weight_dequant_fp8(
+                    w13_local[w1_size:].contiguous(),
+                    w13_scale[s1_size:].contiguous(),
+                )
+            else:
+                w1_bf16 = w13_local[:w1_size]
+                w3_bf16 = w13_local[w1_size:]
+
+            w1_q, w1_s = quant_func(w1_bf16, quant_dtype=online_quant_dtype)
+            w3_q, w3_s = quant_func(w3_bf16, quant_dtype=online_quant_dtype)
+            del w1_bf16, w3_bf16
+
+            w13_expert = self.w13_weight.data[expert_id]
+            w13_scale_expert = self.w13_weight_scale.data[expert_id]
+            for shard_id, wq, ws in (("w1", w1_q, w1_s), ("w3", w3_q, w3_s)):
+                self._load_model_weight_or_group_weight_scale(
+                    shard_dim=0,
+                    expert_data=w13_expert,
+                    shard_id=shard_id,
+                    loaded_weight=wq,
+                    tp_rank=self.tp_rank,
+                    load_full=True,
+                )
+                self._load_quant_weight_scale(
+                    expert_data=w13_scale_expert,
+                    shard_dim=0,
+                    shard_id=shard_id,
+                    loaded_weight=ws,
+                    tp_rank=self.tp_rank,
+                    quant_type=online_quant_type,
+                    load_full=True,
+                )
+            del w1_q, w3_q, w1_s, w3_s
+
+            # w2 row-parallel: optionally gather before quantization
+            # w2 mxfp4    [e, m, n]->[e, m, n//2//tp]->[e, m, n//32//tp]
+            # w2 ptpc_fp8 [e, m, n]->[e, m, n//tp]->[e, m, 1]
+            w2_local = old_w2_data[expert_id]
+            if need_dequant:
+                w2_local = weight_dequant_fp8(
+                    w2_local.contiguous(),
+                    old_w2_scale[expert_id].contiguous(),
+                )
+            if need_gather_w2:
+                w2_full = tp_group.all_gather(w2_local, dim=1)
+                w2_q, w2_s = quant_func(w2_full, quant_dtype=online_quant_dtype)
+                del w2_full
+            else:
+                w2_q, w2_s = quant_func(w2_local, quant_dtype=online_quant_dtype)
+
+            self._load_model_weight_or_group_weight_scale(
+                shard_dim=1,
+                expert_data=self.w2_weight.data[expert_id],
+                shard_id="w2",
+                loaded_weight=w2_q,
+                tp_rank=self.tp_rank,
+                load_full=load_full_w2,
+            )
+            # per_Token scale is along output dim (not TP-split), never needs shard
+            w2_scale_load_full = (
+                False if online_quant_type == QuantType.per_Token else load_full_w2
+            )
+            self._load_quant_weight_scale(
+                expert_data=self.w2_weight_scale.data[expert_id],
+                shard_dim=1,
+                shard_id="w2",
+                loaded_weight=w2_s,
+                tp_rank=self.tp_rank,
+                quant_type=online_quant_type,
+                load_full=w2_scale_load_full,
+            )
+            del w2_q, w2_s
+
+        del old_w13_data, old_w2_data
+        if need_dequant:
+            del old_w13_scale, old_w2_scale
+
+        # print(
+        #     f"[online_quant] {self.layer_name}: "
+        #     f"w13={self.w13_weight.shape} {self.w13_weight.dtype}, "
+        #     f"w13_scale={self.w13_weight_scale.shape} {self.w13_weight_scale.dtype}, "
+        #     f"w2={self.w2_weight.shape} {self.w2_weight.dtype}, "
+        #     f"w2_scale={self.w2_weight_scale.shape} {self.w2_weight_scale.dtype}"
+        # )
+        self._online_quant_info = {
+            "layer": self.layer_name,
+            "quant_type": online_quant_type.name,
+            "quant_dtype": str(online_quant_dtype),
+        }
 
     @property
     def tp_size(self):
@@ -2150,7 +2332,7 @@ class FusedMoE(torch.nn.Module):
         shard_id: str,
         loaded_weight: torch.Tensor,
         tp_rank: int,
-        load_full_w2: bool = False,
+        load_full: bool = False,
     ):
         """
         Load grouped weight scales for group quantization or model weights
@@ -2169,7 +2351,7 @@ class FusedMoE(torch.nn.Module):
                 loaded_weight=loaded_weight,
                 expert_data=expert_data,
                 tp_rank=tp_rank,
-                load_full=load_full_w2,
+                load_full=load_full,
             )
         elif shard_id in ("w1", "w3"):
             self._load_w13(
@@ -2178,6 +2360,38 @@ class FusedMoE(torch.nn.Module):
                 loaded_weight=loaded_weight,
                 expert_data=expert_data,
                 tp_rank=tp_rank,
+                load_full=load_full,
+            )
+
+    def _load_quant_weight_scale(
+        self,
+        expert_data: torch.Tensor,
+        shard_dim: int,
+        shard_id: str,
+        loaded_weight: torch.Tensor,
+        tp_rank: int,
+        quant_type,
+        load_full: bool = False,
+    ):
+        """Dispatch weight-scale loading by quant_type."""
+        if quant_type == QuantType.per_Token:
+            self._load_per_channel_weight_scale(
+                expert_data=expert_data,
+                shard_dim=shard_dim,
+                shard_id=shard_id,
+                loaded_weight=loaded_weight.squeeze(-1),
+                tp_rank=tp_rank,
+                load_full=load_full,
+            )
+        else:
+            # The Aiter FP4 quantization function returns a value of type FP4*2
+            self._load_model_weight_or_group_weight_scale(
+                shard_dim=shard_dim,
+                expert_data=expert_data,
+                shard_id=shard_id,
+                loaded_weight=loaded_weight.view(torch.uint8),
+                tp_rank=tp_rank,
+                load_full=load_full,
             )
 
     def _load_per_channel_weight_scale(
@@ -2187,8 +2401,25 @@ class FusedMoE(torch.nn.Module):
         shard_id: str,
         loaded_weight: torch.Tensor,
         tp_rank: int,
+        load_full: bool = False,
     ):
         # for per channel weight quantization
+        if load_full:
+            if shard_id == "w2":
+                load_size = loaded_weight.shape[shard_dim]
+                if load_size != expert_data.shape[shard_dim]:
+                    expert_data = expert_data.narrow(shard_dim, 0, load_size)
+                expert_data.copy_(loaded_weight)
+            elif shard_id in ("w1", "w3"):
+                self._load_w13(
+                    shard_id=shard_id,
+                    shard_dim=shard_dim,
+                    loaded_weight=loaded_weight,
+                    expert_data=expert_data,
+                    tp_rank=tp_rank,
+                    load_full=True,
+                )
+            return
         if shard_id == "w2":
             expert_data.copy_(loaded_weight)
         elif shard_id in ("w1", "w3"):
@@ -2207,7 +2438,26 @@ class FusedMoE(torch.nn.Module):
         shard_id: str,
         loaded_weight: torch.Tensor,
         tp_rank: int,
+        load_full: bool = False,
     ):
+        # for online local quantizaiton
+        if load_full:
+            expert_shard_size = expert_data.shape[shard_dim] // 2
+            if shard_id == "w1":
+                expert_data = expert_data.narrow(shard_dim, 0, expert_shard_size)
+            else:
+                assert shard_id == "w3"
+                expert_data = expert_data.narrow(
+                    shard_dim, expert_shard_size, expert_shard_size
+                )
+            load_size = loaded_weight.shape[shard_dim]
+            if load_size != expert_shard_size:
+                expert_data = expert_data.narrow(shard_dim, 0, load_size)
+            if expert_data.dtype != dtypes.fp4x2:
+                expert_data.copy_(loaded_weight)
+            else:
+                expert_data.view(torch.uint8).copy_(loaded_weight.view(torch.uint8))
+            return
 
         # Index the loaded weight for tp sharding.
         # gate_up_proj: "MergedColumnParallel", so tp sharding on output_dim
@@ -2254,20 +2504,28 @@ class FusedMoE(torch.nn.Module):
         tp_rank: int,
         load_full: bool = False,
     ):
+        # # for online local quantizaiton
+        if load_full:
+            shard_size = expert_data.shape[shard_dim]
+            load_size = loaded_weight.shape[shard_dim]
+            if load_size != shard_size:
+                expert_data = expert_data.narrow(shard_dim, 0, load_size)
+            if expert_data.dtype != dtypes.fp4x2:
+                expert_data.copy_(loaded_weight)
+            else:
+                expert_data.view(torch.uint8).copy_(loaded_weight.view(torch.uint8))
+            return
 
         # Index the loaded weight for tp sharding.
         # down_proj: "RowParallel" so tp sharding on input_dim
         # Narrow parameter and load.
         shard_size = expert_data.shape[shard_dim]
-        if not load_full:
-            # Derive shard size from loaded_weight (unpadded checkpoint) to
-            # avoid out-of-bounds when expert_data is padded (e.g. MXFP4).
-            load_shard_size = loaded_weight.shape[shard_dim] // self.tp_size
-            loaded_weight = loaded_weight.narrow(
-                shard_dim, load_shard_size * tp_rank, load_shard_size
-            )
-            if load_shard_size != shard_size:
-                expert_data = expert_data.narrow(shard_dim, 0, load_shard_size)
+        load_shard_size = loaded_weight.shape[shard_dim] // self.tp_size
+        loaded_weight = loaded_weight.narrow(
+            shard_dim, load_shard_size * tp_rank, load_shard_size
+        )
+        if load_shard_size != shard_size:
+            expert_data = expert_data.narrow(shard_dim, 0, load_shard_size)
         # w2, down_proj: Load into only logical weight of w2.
         if expert_data.dtype == dtypes.fp4x2:
             expert_data.view(torch.uint8).copy_(loaded_weight.view(torch.uint8))
@@ -2530,7 +2788,7 @@ class FusedMoE(torch.nn.Module):
                     loaded_weight=loaded_weight,
                     expert_data=expert_data,
                     tp_rank=self.tp_rank,
-                    load_full_w2=getattr(param, "load_full_w2", False),
+                    load_full=getattr(param, "load_full_w2", False),
                 )
             elif quant_method == QuantType.per_Tensor:
                 self._load_per_tensor_weight_scale(

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -186,6 +186,93 @@ class QuarkParser(QuantConfigParser):
         )
 
 
+# -- Online quantization ----------------------------------------------------
+
+
+@register_quant_parser("online_quant")
+class QuarkOnlineParser(QuantConfigParser):
+    """Parser for Quark-style online ``quantization_config``."""
+
+    def parse(self, online_quant_config: dict) -> ParsedQuantConfig:
+        """Parse the user-facing online quantization dict and populate
+        ``online_global_qconfig_dict``, ``online_layer_qconfig_dict``,
+        and ``online_exclude_layers_list``.
+
+        Supported format strings:
+        - ``"ptpc_fp8"``  — per-tensor-per-channel FP8
+        - ``"mxfp4"``     — microscaling FP4 (block size 32)
+        """
+        if not isinstance(online_quant_config, dict):
+            raise TypeError("online_quant_config must be a dict parsed from JSON.")
+
+        SCHEME_MAP = {
+            "ptpc": QuantType.per_Token,
+        }
+
+        def _parse_online_quant_format(quant_format_str: str) -> LayerQuantConfig:
+            quant_format_str = quant_format_str.strip().lower()
+            quant_type = None
+            dtype_str = None
+
+            if quant_format_str.startswith("mx"):
+                quant_type = QuantType.per_1x32
+                dtype_str = quant_format_str[2:]
+            else:
+                parts = quant_format_str.split("_", 1)
+                if len(parts) == 2 and parts[0] in SCHEME_MAP:
+                    quant_type = SCHEME_MAP[parts[0]]
+                    dtype_str = parts[1]
+                else:
+                    raise ValueError(
+                        f"Unsupported online quant format: '{quant_format_str}'. "
+                        f"Expected '<scheme>_<dtype>' (e.g. ptpc_fp8) or 'mx<dtype>' (e.g. mxfp4)."
+                    )
+
+            dtype_str = dtype_str.split("_")[0]
+            if dtype_str.endswith("4"):
+                dtype_str += "x2"
+            quant_dtype = d_dtypes.get(dtype_str)
+            if quant_dtype is None:
+                raise ValueError(
+                    f"Unsupported online quant dtype: '{dtype_str}' "
+                    f"(from '{quant_format_str}')"
+                )
+
+            return LayerQuantConfig(
+                quant_type=quant_type,
+                quant_dtype=quant_dtype,
+                is_dynamic=True,
+                quant_method="quark",
+            )
+
+        global_quant_str = online_quant_config.get("global_quant_config", "")
+        if global_quant_str:
+            online_global_qconfig_dict = _parse_online_quant_format(global_quant_str)
+        else:
+            online_global_qconfig_dict = LayerQuantConfig()
+
+        layer_quant_dict = online_quant_config.get("layer_quant_config", {})
+        layer_pattern_specs: list[tuple[str, LayerQuantConfig]] = []
+        if isinstance(layer_quant_dict, dict):
+            for layer_pattern, quant_str in layer_quant_dict.items():
+                layer_pattern_specs.append(
+                    (layer_pattern, _parse_online_quant_format(quant_str))
+                )
+
+        exclude_layers = online_quant_config.get("exclude_layer", [])
+        if isinstance(exclude_layers, str):
+            online_exclude_layers_list = [exclude_layers] if exclude_layers else []
+        elif isinstance(exclude_layers, list):
+            online_exclude_layers_list = exclude_layers
+        else:
+            online_exclude_layers_list = []
+        return ParsedQuantConfig(
+            global_spec=online_global_qconfig_dict,
+            layer_pattern_specs=layer_pattern_specs,
+            exclude_layers=online_exclude_layers_list,
+        )
+
+
 # -- Generic (compressed-tensors, GPTQ, AWQ, …) ----------------------------
 
 

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -4,6 +4,9 @@
 from collections.abc import Iterable
 from typing import Any
 import regex as re
+import triton
+import triton.language as tl
+import torch
 
 
 def deep_compare(dict1: Any, dict2: Any) -> bool:
@@ -49,3 +52,48 @@ def _is_equal_or_regex_match(
     elif target == value:
         return True
     return False
+
+
+@triton.jit
+def _weight_dequant_kernel(  # type: ignore[no-untyped-def]
+    x_ptr,
+    s_ptr,
+    y_ptr,
+    M,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+):  # type: ignore[no-untyped-def]
+    """
+    Triton kernel for dequantizing FP8 weights using scaling factors.
+
+    This kernel is provided by deepseek-ai for efficient FP8 weight dequantization.
+    """
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    n = tl.cdiv(N, BLOCK_SIZE)
+    offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs_n = pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs = offs_m[:, None] * N + offs_n[None, :]
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
+    s = tl.load(s_ptr + pid_m * n + pid_n)
+    y = x * s
+    tl.store(y_ptr + offs, y, mask=mask)
+
+
+def weight_dequant_fp8(
+    x: torch.Tensor, s: torch.Tensor, block_size: int = 128
+) -> torch.Tensor:
+    """
+    Dequantize FP8 weight tensor using inverse scale with Triton kernel.
+    """
+    assert x.is_contiguous() and s.is_contiguous(), "Input tensors must be contiguous"
+    assert x.dim() == 2 and s.dim() == 2, "Input tensors must have 2 dimensions"
+    M, N = x.size()
+    y = torch.empty_like(x, dtype=torch.get_default_dtype())
+
+    def grid(meta: dict[str, int]) -> tuple[int, int]:
+        return (triton.cdiv(M, meta["BLOCK_SIZE"]), triton.cdiv(N, meta["BLOCK_SIZE"]))
+
+    _weight_dequant_kernel[grid](x, s, y, M, N, BLOCK_SIZE=block_size)
+    return y

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -208,6 +208,45 @@ parameters:
 
 Linear layers, MoE layers, and fused ops call `quant_config.get_layer_quant_config(prefix)` to obtain the appropriate `LayerQuantConfig` for their position in the model. This enables mixed-precision quantization where different layers can have different quant types and dtypes (e.g., FP8 for attention, FP4 for MLP).
 
+### 3.7 Online Quantization at Load Time
+
+ATOM can re-quantize model weights while loading them by passing
+`--online_quant_config` to the engine. This is useful when the source checkpoint
+is unquantized or uses a different supported quantization layout than the runtime
+layout you want to benchmark.
+
+The flag accepts a JSON object:
+
+```bash
+--online_quant_config '{
+  "global_quant_config": "ptpc_fp8",
+  "layer_quant_config": {"*expert*": "mxfp4"},
+  "exclude_layer": ["lm_head", "*.gate.*"]
+}'
+```
+
+Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `global_quant_config` | `str` | Default target quantization format for all layers. |
+| `layer_quant_config` | `dict[str, str]` | Per-layer target overrides. Keys are fnmatch-style layer patterns such as `"*expert*"`. |
+| `exclude_layer` | `str \| list[str]` | Layers to leave unquantized. Supports exact/prefix matches, glob patterns, and `re:` regex entries. Prefer a JSON list when excluding multiple patterns. |
+
+Supported target format strings:
+
+| Format | Target config |
+|---|---|
+| `ptpc_fp8` | `QuantType.per_Token` with FP8 weights |
+| `mxfp4` | `QuantType.per_1x32` with packed MXFP4 weights |
+
+Notes:
+
+- An empty JSON object (`--online_quant_config '{}'`) is treated the same as not passing the flag and does not enable online quantization.
+- Online quantization currently applies when the source model is unquantized or uses supported FP8 block quantization (`QuantType.per_1x128`). The loader dequantizes FP8 block weights before applying the requested target format.
+- Tensor-parallel weights are gathered before quantization only when local quantization would produce different scales than quantizing the full unpartitioned weight.
+- Rank 0 writes an `online_quant_info_*.json` summary with elapsed time and per-layer target formats. The file is written under `ATOM_TORCH_PROFILER_DIR` when set, otherwise the current working directory.
+
 ---
 
 ## 4. Parallel Configuration (`ParallelConfig`)
@@ -340,6 +379,7 @@ all flags via `add_cli_args()` and converts them into a `Config` via
 | `--max-num-seqs` | | `int` | `512` | Maximum number of sequences to batch together |
 | `--gpu-memory-utilization` | | `float` | `0.9` | Fraction of GPU memory to use (0.0 -- 1.0) |
 | `--scheduler-delay-factor` | | `float` | `0.0` | Delay factor multiplied by previous prompt latency before scheduling next prompt |
+| `--online_quant_config` | | JSON string | `None` | Load-time online quantization override; see Section 3.7 |
 
 **Example:**
 

--- a/recipes/DeepSeek-R1.md
+++ b/recipes/DeepSeek-R1.md
@@ -48,6 +48,24 @@ python -m atom.entrypoints.openai_server \
   --method mtp --num-speculative-tokens 3
 ```
 
+### Online Quantization from the FP8 Checkpoint
+
+Use `--online_quant_config` to quantize the source checkpoint during weight
+loading. The following command matches the common DeepSeek-R1-0528 mixed
+precision layout: FP8 for non-expert layers, MXFP4 for MoE experts, and no
+quantization for `lm_head` or gate/router weights.
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model deepseek-ai/DeepSeek-R1-0528 \
+  --kv_cache_dtype fp8 -tp 8 \
+  --method mtp --num-speculative-tokens 3 \
+  --online_quant_config '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": ["lm_head", "*.gate.*"]}'
+```
+
+`exclude_layer` should be a JSON list when more than one pattern is needed. An
+empty config (`--online_quant_config '{}'`) disables online quantization.
+
 Tips on server configuration:
 - Always use `--kv_cache_dtype fp8` for better memory efficiency.
 - MTP with `--num-speculative-tokens 3` provides the best throughput/latency tradeoff.

--- a/tests/test_quant_config.py
+++ b/tests/test_quant_config.py
@@ -146,6 +146,7 @@ _m = _load_module("config.py", "_atom_config_test")
 QuantizationConfig = _m.QuantizationConfig
 LayerQuantConfig = _qs.LayerQuantConfig
 QuarkParser = _qs.QuarkParser
+QuarkOnlineParser = _qs.QuarkOnlineParser
 GenericParser = _qs.GenericParser
 get_quant_parser = _qs.get_quant_parser
 
@@ -189,6 +190,10 @@ class TestParserRegistry:
     def test_quark_registered(self):
         parser = get_quant_parser("quark")
         assert isinstance(parser, QuarkParser)
+
+    def test_online_quant_registered(self):
+        parser = get_quant_parser("online_quant")
+        assert isinstance(parser, QuarkOnlineParser)
 
     def test_generic_fallback(self):
         parser = get_quant_parser("compressed-tensors")
@@ -276,6 +281,69 @@ class TestQuarkParser:
 
 
 # =========================================================================
+# Tests — QuarkOnlineParser
+# =========================================================================
+
+
+class TestQuarkOnlineParser:
+    def test_ptpc_fp8_global_config(self):
+        parser = QuarkOnlineParser()
+        result = parser.parse({"global_quant_config": "ptpc_fp8"})
+
+        assert result.global_spec.quant_type == QuantType.per_Token
+        assert result.global_spec.quant_dtype == FP8
+        assert result.global_spec.is_dynamic is True
+        assert result.global_spec.quant_method == "quark"
+        assert result.layer_pattern_specs == []
+        assert result.exclude_layers == []
+
+    def test_mxfp4_layer_override_and_exclude_list(self):
+        parser = QuarkOnlineParser()
+        result = parser.parse(
+            {
+                "global_quant_config": "ptpc_fp8",
+                "layer_quant_config": {"*expert*": "mxfp4"},
+                "exclude_layer": ["lm_head", "*.gate.*"],
+            }
+        )
+
+        assert result.global_spec.quant_type == QuantType.per_Token
+        assert result.global_spec.quant_dtype == FP8
+        assert len(result.layer_pattern_specs) == 1
+        pattern, spec = result.layer_pattern_specs[0]
+        assert pattern == "*expert*"
+        assert spec.quant_type == QuantType.per_1x32
+        assert spec.quant_dtype == FP4X2
+        assert result.exclude_layers == ["lm_head", "*.gate.*"]
+
+    def test_string_exclude_layer_is_preserved_as_single_pattern(self):
+        parser = QuarkOnlineParser()
+        result = parser.parse(
+            {
+                "global_quant_config": "ptpc_fp8",
+                "exclude_layer": "lm_head",
+            }
+        )
+
+        assert result.exclude_layers == ["lm_head"]
+
+    def test_empty_config_returns_no_quant_defaults(self):
+        parser = QuarkOnlineParser()
+        result = parser.parse({})
+
+        assert result.global_spec.quant_type == QuantType.No
+        assert result.global_spec.quant_dtype == BF16
+        assert result.layer_pattern_specs == []
+        assert result.exclude_layers == []
+
+    def test_invalid_online_quant_format_raises(self):
+        parser = QuarkOnlineParser()
+
+        with pytest.raises(ValueError, match="Unsupported online quant format"):
+            parser.parse({"global_quant_config": "unsupported_fp8"})
+
+
+# =========================================================================
 # Tests — QuantizationConfig init
 # =========================================================================
 
@@ -294,6 +362,41 @@ class TestQuantizationConfigInit:
         assert qcfg.quant_method == ""
         assert qcfg.global_quant_config.quant_type == QuantType.No
         assert qcfg.global_quant_config.quant_dtype == BF16
+        assert qcfg.online_quant is False
+        assert qcfg.online_global_spec.quant_type == QuantType.No
+        assert qcfg.online_layer_pattern_specs == []
+        assert qcfg.online_exclude_layers == []
+
+    def test_empty_online_quant_config_does_not_enable_online_quant(self):
+        hf = FakeHFConfig(torch_dtype=BF16)
+        qcfg = QuantizationConfig(hf, online_quant_config={})
+
+        assert qcfg.online_quant is False
+        assert qcfg.online_quant_config_raw == {}
+        assert qcfg.online_global_spec.quant_type == QuantType.No
+        assert qcfg.online_layer_pattern_specs == []
+        assert qcfg.online_exclude_layers == []
+
+    def test_online_quant_config_parses_global_layer_and_exclude(self):
+        hf = FakeHFConfig(torch_dtype=BF16)
+        qcfg = QuantizationConfig(
+            hf,
+            online_quant_config={
+                "global_quant_config": "ptpc_fp8",
+                "layer_quant_config": {"*expert*": "mxfp4"},
+                "exclude_layer": ["lm_head", "*.gate.*"],
+            },
+        )
+
+        assert qcfg.online_quant is True
+        assert qcfg.online_global_spec.quant_type == QuantType.per_Token
+        assert qcfg.online_global_spec.quant_dtype == FP8
+        assert len(qcfg.online_layer_pattern_specs) == 1
+        pattern, spec = qcfg.online_layer_pattern_specs[0]
+        assert pattern == "*expert*"
+        assert spec.quant_type == QuantType.per_1x32
+        assert spec.quant_dtype == FP4X2
+        assert qcfg.online_exclude_layers == ["lm_head", "*.gate.*"]
 
     def test_quark_config_parses_global_and_layer(self):
         hf = FakeHFConfig(
@@ -367,6 +470,34 @@ class TestGetLayerQuantConfig:
         result = qcfg.get_layer_quant_config("lm_head")
         assert result.quant_type == QuantType.No
         assert result.quant_dtype == BF16
+
+    def test_online_quant_resolution_uses_online_specs(self):
+        qcfg = QuantizationConfig(
+            FakeHFConfig(torch_dtype=BF16),
+            online_quant_config={
+                "global_quant_config": "ptpc_fp8",
+                "layer_quant_config": {"*expert*": "mxfp4"},
+                "exclude_layer": ["lm_head", "*.gate.*"],
+            },
+        )
+
+        expert = qcfg.get_layer_quant_config(
+            "model.layers.0.mlp.experts.0.w13_weight",
+            use_online_quant=True,
+        )
+        assert expert.quant_type == QuantType.per_1x32
+        assert expert.quant_dtype == FP4X2
+
+        attention = qcfg.get_layer_quant_config(
+            "model.layers.0.self_attn.q_proj",
+            use_online_quant=True,
+        )
+        assert attention.quant_type == QuantType.per_Token
+        assert attention.quant_dtype == FP8
+
+        excluded = qcfg.get_layer_quant_config("lm_head", use_online_quant=True)
+        assert excluded.quant_type == QuantType.No
+        assert excluded.quant_dtype == BF16
 
 
 # =========================================================================


### PR DESCRIPTION
Doc: https://[github.com/ROCm/ATOM/blob/main/docs/online_quantization_guide.md](https://github.com/ROCm/ATOM/blob/main/docs/online_quantization_guide.md)
In terms of user interaction, there is a JSON-based `online_quant_config` object, which is divided into `global_quant_config`, `layer_quant_config`, and `exclude_layer`. It uses wildcards to capture `full_name` values.

Once a name is matched, PTPC or MXFP4 quantization is applied, the value is modified in place, and the quantization attribute is updated. If the value cannot be retrieved, the original quantization type or a high-precision type is used instead.





**Feature**
1. support linear mixed mxfp4 and ptpc_fp8
2. support moe mixed mxfp4 and ptpc_fp8
3. for PTPC format and certain necessary cases, gather all weights before quantization.
4. suport dpsk DQ and Q
5. check EP mode


  | TTFT | TTFT | TPOT | TPOT | gsm8k | gsm8k | elapsed_seconds/s
-- | -- | -- | -- | -- | -- | -- | --
model | offline | online | offline | online | offline | online |  
Qwen3-30B-A3B-Thinking-2507-ptpc | 126.81 | 126.93 | 11.65 | 11.55 | 0.6861 | 0.6971 | 0.834
Qwen3-235B-A22B-Instruct-2507-MXFP4 | 450.51 | 445.52 | 34.16 | 34.03 | 0.8961 | 0.8976 | 1.398
DeepSeek-R1-0528-attn-ptpc-moe-mxfp4 | 296.06 | 296.39 | 65.46 | 65.22 | 0.9462 | 0.9484 | 8.148
DeepSeek-R1-0528-attn-ptpc-moe-mxfp4 with mtp | 339.86 | 339.78 | 26.39 | 26.47 | 0.9439 | 0.9439 | 8.975



Reproduction
aiter: d6e73f96141bcdb61c2cc7ed1b09d874dea8ecf8
atom: 81054f972af190c49a141fbaa6c85124ab8c1d90

command:

```
qwen3-30B ptpc online & offline command
python3 -m atom.entrypoints.openai_server --model /shareddata/Qwen/Qwen3-30B-A3B-Thinking-2507 \
  -tp 4 --port 5679 --server-port 7778 \
  --online_quant_config '{"global_quant_config":"ptpc_fp8","layer_quant_config":{"*expert*":"ptpc_fp8"},"exclude_layer":["lm_head","*.gate.*"]}' 

python3 -m atom.entrypoints.openai_server --model /shareddata/amd/Qwen3-30B-A3B-Thinking-2507-ptpc \
  -tp 4 --port 5679 --server-port 7778

deepseek-r1-0528 online & offline command
python3 -m atom.entrypoints.openai_server --model /shareddata/deepseek-ai/DeepSeek-R1-0528 \
  --enforce-eager -tp 8 \
  --port 5679 --server-port 7778 \
  --online_quant_config '{"global_quant_config":"ptpc_fp8","layer_quant_config":{"*expert*":"mxfp4"},"exclude_layer":["lm_head","*.gate.*"]}' \
  --method mtp --num-speculative-tokens 3 

Qwen3-235B-A22B-Instruct-2507 mxfp4 online & offline command
 python -m atom.entrypoints.openai_server \
  --model /shareddata/Qwen/Qwen3-235B-A22B-Instruct-2507 \
  -tp 2 --enable-expert-parallel \
  --port 5679 --server-port 7778 \
  --online_quant_config '{"global_quant_config":"mxfp4","exclude_layer":["lm_head","*.gate.*"]}'

  

**ACC & performance command**
lm_eval \
  --model local-completions \
  --model_args "model=model_path,base_url=http://localhost:7778/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto
  
python -m atom.benchmarks.benchmark_serving \
  --model=model_path --backend=vllm --base-url=http://localhost:7778 \
  --dataset-name=random \
  --random-input-len=1024 --random-output-len=1024 \
  --random-range-ratio=0.8 \
  --num-prompts=1280 --max-concurrency=128 \
  --request-rate=inf --ignore-eos \
  --save-result --percentile-metrics="ttft,tpot,itl,e2el"

```