### PR TITLE
[Feat] enable pure data parallel(not dp attention) in sgl + atom

### DIFF
--- a/atom/plugin/config.py
+++ b/atom/plugin/config.py
@@ -35,6 +35,42 @@ class PluginConfig:
     sglang_port_args: Any = None
 
 
+def _normalize_sglang_parallel_config(
+    tp_size: int,
+    dp_size: int,
+    tp_rank: int,
+    enable_dp_attention: bool,
+) -> tuple[int, int, int, int]:
+    """Translate SGLang parallel args into the runtime layout ATOM expects.
+
+    SGLang's ``tp_size`` is the whole world used by the model runner, while
+    ``dp_size`` under dp-attention is only an attention-layout factor inside
+    that world. For pure-DP, SGLang launches multiple independent TP workers,
+    so ATOM should treat that DP dimension as external scheduling rather than
+    a model-internal communication group.
+    """
+
+    if enable_dp_attention:
+        if dp_size < 1:
+            raise ValueError(f"SGLang dp_size must be >= 1, got {dp_size}")
+        if tp_size % dp_size != 0:
+            raise ValueError(
+                "SGLang tp_size must be divisible by dp_size when "
+                f"enable_dp_attention=True, got tp_size={tp_size}, dp_size={dp_size}"
+            )
+
+        runtime_tp_size = 1
+        runtime_dp_size = tp_size
+        runtime_dp_rank = tp_rank
+        aiter_rank_id = 0
+        return runtime_tp_size, runtime_dp_size, runtime_dp_rank, aiter_rank_id
+
+    # Without dp-attention, SGLang's DP workers are external replicas. Keep
+    # ATOM/aiter on the per-worker TP world and do not create an internal DP
+    # communication group.
+    return tp_size, 1, 0, tp_rank
+
+
 def _generate_atom_config_from_vllm_config(config: Any) -> PluginConfig:
     from atom.config import Config, CompilationConfig
 
@@ -159,18 +195,23 @@ def _generate_atom_config_from_sglang_config(config: Any):
     # get rank number through the torch.distributed.get_rank()
     rank = torch.distributed.get_rank()
 
-    # Derive DP rank from SGLang's TP-local rank rather than the global
-    # distributed rank so PP/multi-stage layouts do not skew the result.
-    data_parallel_rank = 0
-    if server_args.dp_size > 1:
-        tp_rank = get_tensor_model_parallel_rank()
-        tp_group_size = max(1, server_args.tp_size // server_args.dp_size)
-        data_parallel_rank = tp_rank // tp_group_size
+    tp_rank = get_tensor_model_parallel_rank()
+    (
+        atom_tensor_parallel_size,
+        atom_data_parallel_size,
+        atom_data_parallel_rank,
+        sglang_aiter_rank_id,
+    ) = _normalize_sglang_parallel_config(
+        tp_size=server_args.tp_size,
+        dp_size=server_args.dp_size,
+        tp_rank=tp_rank,
+        enable_dp_attention=server_args.enable_dp_attention,
+    )
 
     # sglang uses the atom parallel config
     sgl_parallel_config = ParallelConfig(
-        data_parallel_size=server_args.dp_size,
-        data_parallel_rank=data_parallel_rank,
+        data_parallel_size=atom_data_parallel_size,
+        data_parallel_rank=atom_data_parallel_rank,
     )
 
     # use sglang torch compile policy and cuda graph policy
@@ -207,7 +248,7 @@ def _generate_atom_config_from_sglang_config(config: Any):
         max_num_seqs=server_args.max_running_requests,
         max_model_len=server_args.context_length,
         gpu_memory_utilization=server_args.mem_fraction_static,
-        tensor_parallel_size=server_args.tp_size,
+        tensor_parallel_size=atom_tensor_parallel_size,
         # Disable ATOM's own torch.compile and CUDA graph capture —
         # sglang manages its own compilation/graph strategy, and the
         # @support_torch_compile decorator checks enforce_eager to skip,


### PR DESCRIPTION
## Motivation

enable pure data parallel(not dp attention) in sgl + atom

## command
```
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1


model_path=/workspace/model/DeepSeek-R1-0528-MXFP4/
export PYTHONPATH=/workspace/dpsk-r1-fp4/sglang/python:/workspace/dpsk-r1-fp4/ATOM_main/ATOM
 
 
export SGLANG_PROFILE_RECORD_SHAPES=1
export SGLANG_PROFILE_WITH_STACK=1
export SGLANG_TORCH_PROFILER_DIR=/workspace/dpsk-r1-fp4/sglang/profile_log

export SGLANG_ENABLE_TORCH_COMPILE=128

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models

python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 2 \
    --data-parallel-size 2 \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.9 \
    --page-size 1 \
    --disable-radix-cache
```

curl:
```
#!/usr/bin/env bash

set -euo pipefail

HOST="${HOST:-localhost}"
PORT="${PORT:-8000}"
MODEL="${MODEL:-/workspace/model/DeepSeek-R1-0528-MXFP4/}"
MAX_TOKENS="${MAX_TOKENS:-1000}"
TEMPERATURE="${TEMPERATURE:-0}"

PROMPT="${*:-你好，请简短介绍一下你自己。}"
BASE_URL="http://${HOST}:${PORT}"

server_info_json="$(curl -fsS "${BASE_URL}/server_info")"

read -r dp_size tp_size internal_state_count < <(
  SERVER_INFO_JSON="$server_info_json" python3 - <<'PY'
import json
import os

info = json.loads(os.environ["SERVER_INFO_JSON"])

if info.get("enable_dp_attention", False):
    raise SystemExit("server_info says enable_dp_attention=true")

dp_size = int(info.get("dp_size", 0))
if dp_size <= 1:
    raise SystemExit(f"server_info says dp_size={dp_size}, expected > 1")

tp_size = int(info.get("tp_size", 0))
internal_states = info.get("internal_states") or []
if len(internal_states) < dp_size:
    raise SystemExit(
        f"server_info returned only {len(internal_states)} internal_states, expected at least {dp_size}"
    )

print(dp_size, tp_size, len(internal_states))
PY
)

printf 'server_info check passed: enable_dp_attention=false dp_size=%s tp_size=%s internal_states=%s\n' \
  "$dp_size" "$tp_size" "$internal_state_count"

tmp_dir="$(mktemp -d)"
trap 'rm -rf "$tmp_dir"' EXIT

declare -a pids

for dp_rank in $(seq 0 $((dp_size - 1))); do
  payload="$(
    python3 - "$MODEL" "$PROMPT" "$MAX_TOKENS" "$TEMPERATURE" "$dp_rank" <<'PY'
import json
import sys

model, prompt, max_tokens, temperature, routed_dp_rank = sys.argv[1:]

request_prompt = f"{prompt}\n\n[target_dp_rank={routed_dp_rank}]"

print(
    json.dumps(
        {
            "model": model,
            "messages": [
                {"role": "user", "content": request_prompt},
            ],
            "max_tokens": int(max_tokens),
            "temperature": float(temperature),
            "stream": False,
            "routed_dp_rank": int(routed_dp_rank),
        }
    )
)
PY
  )"

  payload_file="${tmp_dir}/payload_${dp_rank}.json"
  response_file="${tmp_dir}/response_${dp_rank}.json"
  error_file="${tmp_dir}/curl_${dp_rank}.log"

  printf '%s' "$payload" > "$payload_file"

  curl -fsS "${BASE_URL}/v1/chat/completions" \
    -H "Content-Type: application/json" \
    -H "X-Data-Parallel-Rank: ${dp_rank}" \
    --data-binary @"$payload_file" \
    > "$response_file" 2> "$error_file" &
  pids[$dp_rank]=$!
done

echo "launched ${dp_size} routed requests in parallel."

for dp_rank in $(seq 0 $((dp_size - 1))); do
  if ! wait "${pids[$dp_rank]}"; then
    echo "request for dp_rank=${dp_rank} failed:" >&2
    if [[ -s "${tmp_dir}/curl_${dp_rank}.log" ]]; then
      sed 's/^/  /' "${tmp_dir}/curl_${dp_rank}.log" >&2
    fi
    exit 1
  fi
done

for dp_rank in $(seq 0 $((dp_size - 1))); do
  response_json="$(< "${tmp_dir}/response_${dp_rank}.json")"
  response_text="$(
    RESPONSE_JSON="$response_json" python3 - <<'PY'
import json
import os

resp = json.loads(os.environ["RESPONSE_JSON"])
content = resp["choices"][0]["message"]["content"].strip()
if not content:
    raise SystemExit("empty assistant content")
print(content.replace("\n", "\\n"))
PY
  )"

  printf 'dp_rank=%s response=%s\n' "$dp_rank" "$response_text"
done

echo "pure dp verification passed."
```
