### PR TITLE
[vllm-atom] Fix GLM-5 accuracy in vLLM plugin

### DIFF
--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -1730,9 +1730,6 @@ class AiterMLASparseMetadataForPluginMode:
     block_size: int = 1
     topk_tokens: int = 2048
 
-    # Flag to run ragged layout conversion only once per forward (shared across MLA layers)
-    ragged_layout_built: bool = False
-
 
 class vllmMLASparseAttentionMetadataBuilderMethods:
     def __init__(self):

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -119,18 +119,15 @@ class MLASparseAttentionImplPluginModeMethods:
             device=q.device,
         )
 
-        # Build ragged layout only once per forward as it shared across MLA layers
-        if not getattr(sparse_meta, "ragged_layout_built", False):
-            seq_len = (topk_indices_global != -1).sum(dim=-1)
-            torch.cumsum(seq_len, dim=0, out=sparse_meta.paged_kv_indptr[1:])
-            sparse_meta.paged_kv_indptr_rest.fill_(sparse_meta.paged_kv_indptr[-1])
-            fetch_id_to_ragged_triton(
-                topk_indices_global,
-                sparse_meta.paged_kv_indptr,
-                sparse_meta.paged_kv_indices,
-                sparse_meta.topk_tokens,
-            )
-            sparse_meta.ragged_layout_built = True
+        seq_len = (topk_indices_global != -1).sum(dim=-1)
+        torch.cumsum(seq_len, dim=0, out=sparse_meta.paged_kv_indptr[1:])
+        sparse_meta.paged_kv_indptr_rest.fill_(sparse_meta.paged_kv_indptr[-1])
+        fetch_id_to_ragged_triton(
+            topk_indices_global,
+            sparse_meta.paged_kv_indptr,
+            sparse_meta.paged_kv_indices,
+            sparse_meta.topk_tokens,
+        )
 
         kv_buffer = kv_cache.unsqueeze(2)
 
@@ -483,20 +480,19 @@ def sparse_attn_indexer_plugin_mode(
             topk_indices = topk_indices_buffer[
                 chunk.token_start : chunk.token_end, :topk_tokens
             ]
-            top_k_per_row_prefill(
-                logits=logits,
-                rowStarts=chunk.cu_seqlen_ks,
-                rowEnds=chunk.cu_seqlen_ke,
-                indices=topk_indices,
-                values=None,
-                numRows=num_rows,
-                stride0=logits.stride(0),
-                stride1=logits.stride(1),
+            # Use top_k_per_row_prefill from vLLM to correctly handle row starts
+            # and ends. It also produces 0-based local indices, eliminating the
+            # need for conversion from global.
+            torch.ops._C.top_k_per_row_prefill(
+                logits,
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
             )
-            # Convert global concatenated KV buffer indices to request-local
-            valid_mask = topk_indices != -1
-            topk_indices.sub_(chunk.cu_seqlen_ks.unsqueeze(1))
-            topk_indices.masked_fill_(~valid_mask, -1)
 
     if has_decode:
         decode_metadata = indexer_meta.decode


### PR DESCRIPTION
## Motivation
This PR fixes the accuracy drop of GLM-5 in vLLM-ATOM mode.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Build ragged layout in every layer.
Use `top_k_per_row_prefill` from vLLM that handles indexing more consistently across short/long context lengths.
In combination with bugfix for `cp_gather_indexer_k_quant_cache` in aiter https://github.com/ROCm/aiter/pull/2954, accuracy is restored to baseline.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Accuracy test with `lm_eval`

Model: `zai-org/GLM-5-FP8`

Server command
```
ATOM_DISABLE_VLLM_PLUGIN=0 \
ATOM_DISABLE_VLLM_PLUGIN_ATTENTION=0 \
vllm serve zai-org/GLM-5-FP8 \
  -tp 8 \
  --gpu-memory-utilization 0.7 \
  --no-enable-prefix-caching \
  --disable-uvicorn-access-log \
  --trust-remote-code \
  --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
  --kv-cache-dtype fp8 \
  --block-size 1
```

`lm_eval` command:
```
lm_eval --model local-completions   --model_args model=zai-org/GLM-5-FP8,base_url=http://localhost:8000/v1/completions,num_concurrent=64,tokenized_requests=False  --tasks gsm8k --num_fewshot 20
```

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|_  |0.9431|_  |0.0064|
|     |       |strict-match    |    20|exact_match|_  |0.9431|_  |0.0064|

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
