### PR TITLE
support swiglu a4w4 moe

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -837,16 +837,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer):
-        bias_dtype = (
-            self.moe.in_dtype
-            if layer.activation == ActivationType.Swiglu
-            and self.quant_type == QuantType.per_1x32
-            else torch.float32
-        )
         if layer.w13_bias is not None:
-            layer.w13_bias.data = layer.w13_bias.data.to(bias_dtype)
+            layer.w13_bias.data = layer.w13_bias.data.to(torch.float32)
         if layer.w2_bias is not None:
-            layer.w2_bias.data = layer.w2_bias.data.to(bias_dtype)
+            layer.w2_bias.data = layer.w2_bias.data.to(torch.float32)
 
         if os.environ.get("ATOM_V4_TORCH_MOE"):
             return

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -70,10 +70,7 @@ def _shuffle_generic_mxfp4_weight_scale(
     if scale.ndim < 2:
         return fp4_utils.e8m0_shuffle(scale)
     # Generic preshuffle packs the combined [expert, row] axis, not experts alone.
-    rows = 1
-    for dim in scale.shape[:-1]:
-        rows *= dim
-    return fp4_utils.e8m0_shuffle(scale.reshape(rows, scale.shape[-1])).reshape(
+    return fp4_utils.e8m0_shuffle(scale.reshape(-1, scale.shape[-1])).reshape(
         scale.shape
     )
 
@@ -921,15 +918,12 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         # quark method for moe, split it out?
         elif self.quant_method == "quark":
             shuffle_weights(layer.w13_weight, layer.w2_weight)
-            s0, s1, _ = layer.w13_weight_scale.shape
-            w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
-            w13_weight_scale = fp4_utils.e8m0_shuffle(w13_weight_scale)
-            layer.w13_weight_scale.data = w13_weight_scale.view(s0, s1, -1)
-
-            s0, s1, _ = layer.w2_weight_scale.shape
-            w2_weight_scale = layer.w2_weight_scale.view(s0 * s1, -1)
-            w2_weight_scale = fp4_utils.e8m0_shuffle(w2_weight_scale)
-            layer.w2_weight_scale.data = w2_weight_scale.view(s0, s1, -1)
+            layer.w13_weight_scale.data = _shuffle_generic_mxfp4_weight_scale(
+                layer.w13_weight_scale
+            )
+            layer.w2_weight_scale.data = _shuffle_generic_mxfp4_weight_scale(
+                layer.w2_weight_scale
+            )
             return
         else:
             shuffle_weights(layer.w13_weight, layer.w2_weight)

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -59,7 +59,7 @@ from atom.plugin.moe import FusedMoEDecoratorForPluginMode
 
 
 def _use_generic_swiglu_mxfp4_layout() -> bool:
-    return os.environ.get("GPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT", "1") == "1"
+    return os.environ.get("GPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT", "0") == "1"
 
 
 def _shuffle_generic_mxfp4_weight_scale(

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -58,6 +58,26 @@ from transformers import PretrainedConfig
 from atom.plugin.moe import FusedMoEDecoratorForPluginMode
 
 
+def _use_generic_swiglu_mxfp4_layout() -> bool:
+    return os.environ.get("GPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT", "1") == "1"
+
+
+def _shuffle_generic_mxfp4_weight_scale(
+    scale: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    if scale is None:
+        return None
+    if scale.ndim < 2:
+        return fp4_utils.e8m0_shuffle(scale)
+    # Generic preshuffle packs the combined [expert, row] axis, not experts alone.
+    rows = 1
+    for dim in scale.shape[:-1]:
+        rows *= dim
+    return fp4_utils.e8m0_shuffle(scale.reshape(rows, scale.shape[-1])).reshape(
+        scale.shape
+    )
+
+
 class FusedMoeWeightScaleSupported(Enum):
     """Supported quantization strategies for MoE weight scales."""
 
@@ -817,10 +837,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer):
+        bias_dtype = (
+            self.moe.in_dtype
+            if layer.activation == ActivationType.Swiglu
+            and self.quant_type == QuantType.per_1x32
+            else torch.float32
+        )
         if layer.w13_bias is not None:
-            layer.w13_bias.data = layer.w13_bias.data.to(torch.float32)
+            layer.w13_bias.data = layer.w13_bias.data.to(bias_dtype)
         if layer.w2_bias is not None:
-            layer.w2_bias.data = layer.w2_bias.data.to(torch.float32)
+            layer.w2_bias.data = layer.w2_bias.data.to(bias_dtype)
 
         if os.environ.get("ATOM_V4_TORCH_MOE"):
             return
@@ -868,24 +894,35 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 .contiguous()
                 .view(e, n, -1)
             )
-            layer.w13_weight.data = shuffle_weight_a16w4(layer.w13_weight, 16, True)
-            shuffled_w13_scale = shuffle_scale_a16w4(
-                layer.w13_weight_scale.view(-1, layer.w13_weight_scale.shape[-1]),
-                self.num_experts,
-                True,
-            )
-            layer.w2_weight.data = shuffle_weight_a16w4(layer.w2_weight, 16, False)
-            shuffled_w2_scale = shuffle_scale_a16w4(
-                layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
-                self.num_experts,
-                False,
-            )
             if layer.w13_bias is not None:
                 layer.w13_bias.data = (
                     layer.w13_bias.data.view(-1, n // 2, 2)
                     .permute(0, 2, 1)
                     .contiguous()
                     .view(-1, n)
+                )
+
+            if _use_generic_swiglu_mxfp4_layout():
+                # New GPT-OSS A4W4 Swiglu path: use the same generic preshuffle
+                # layout for bf16 and fp4x2 activations.
+                shuffle_weights(layer.w13_weight, layer.w2_weight)
+                shuffled_w13_scale, shuffled_w2_scale = (
+                    _shuffle_generic_mxfp4_weight_scale(layer.w13_weight_scale),
+                    _shuffle_generic_mxfp4_weight_scale(layer.w2_weight_scale),
+                )
+            else:
+                # Legacy path: keep the original A16W4-style Swiglu layout.
+                layer.w13_weight.data = shuffle_weight_a16w4(layer.w13_weight, 16, True)
+                shuffled_w13_scale = shuffle_scale_a16w4(
+                    layer.w13_weight_scale.view(-1, layer.w13_weight_scale.shape[-1]),
+                    self.num_experts,
+                    True,
+                )
+                layer.w2_weight.data = shuffle_weight_a16w4(layer.w2_weight, 16, False)
+                shuffled_w2_scale = shuffle_scale_a16w4(
+                    layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
+                    self.num_experts,
+                    False,
                 )
         # quark method for moe, split it out?
         elif self.quant_method == "quark":


### PR DESCRIPTION
## Motivation
Add ATOM-side support for GPT-OSS SwiGLU A4W4/MXFP4 MoE weight layout selection.
The AITER PR for GPT-OSS SwiGLU MoE supports both the legacy A16W4-style layout and a generic MXFP4 preshuffled layout. ATOM needs to prepare GPT-OSS MoE weights/scales in the matching layout before dispatching into AITER.
## Technical Details
- Add `GPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT` switch in ATOM.
  - Default is off (`0`) to preserve the original/legacy path.
  - Set to `1` to use the new generic MXFP4 layout.
- Add generic MXFP4 scale shuffle helper.
  - Handles scale tensors by flattening the combined `[expert, row]` axes before `e8m0_shuffle`.
  - Restores the original scale shape after shuffling.
- Update GPT-OSS MXFP4 SwiGLU weight loading path.
  - Legacy mode keeps the original A16W4-style `shuffle_weight_a16w4` / `shuffle_scale_a16w4` path.
  - Generic mode uses `shuffle_weights(...)` for `w13/w2` and the new generic scale shuffle helper.

## Test Plan
- Validate legacy/default path:
  - Run without setting `GPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT`.
  - Confirm original GPT-OSS SwiGLU MXFP4 behavior is preserved.
- Validate generic path:
  - Run with `GPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT=1`.
  - Confirm ATOM prepares weights/scales in the generic MXFP4 layout expected by AITER.
- Run GPT-OSS MoE accuracy/performance smoke tests through the ATOM/vLLM benchmark path.
## Notes
This PR only changes ATOM-side weight/scale/bias preparation. The kernel dispatch and tuned GPT-OSS FlyDSL/CK-Tile behavior are handled in the corresponding AITER PR.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
