### PR TITLE
Enable Cohere Command-R (CohereForCausalLM / Cohere2ForCausalLM) on ATOM

### DIFF
--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -1,5 +1,16 @@
 [
   {
+    "model_name": "Command-R-7B TP1",
+    "model_path": "CohereLabs/c4ai-command-r7b-12-2024",
+    "extraArgs": "--tensor-parallel-size 1 --enable-chunked-prefill --max-num-batched-tokens 65536 --max-model-len 131072 --no-enable-prefix-caching",
+    "env_vars": "",
+    "runner": "linux-atom-mi35x-1",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.70,
+    "accuracy_baseline": 0.75,
+    "accuracy_baseline_model": "CohereLabs/c4ai-command-r7b-12-2024"
+  },
+  {
     "model_name": "Qwen3-235B-A22B-Instruct-2507-FP8 TP8+EP8",
     "model_path": "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
     "extraArgs": "--tensor-parallel-size 8 --enable-expert-parallel",

--- a/.github/workflows/atom-vllm-oot-test.yaml
+++ b/.github/workflows/atom-vllm-oot-test.yaml
@@ -17,6 +17,11 @@ on:
     # from") as the ATOM branch selector, so users do not need to type branch
     # names.
     inputs:
+      run_command_r7b_tp1:
+        description: "Command-R-7B TP1"
+        required: false
+        type: boolean
+        default: false
       run_qwen3_moe_tp8:
         description: "Qwen3-235B-A22B-Instruct-2507-FP8 TP8+EP8"
         required: false
@@ -366,6 +371,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - display_name: "Command-R-7B TP1"
+            model_name: "Command-R-7B TP1"
+            model_path: "CohereLabs/c4ai-command-r7b-12-2024"
+            extra_args: "--tensor-parallel-size 1 --enable-chunked-prefill --max-num-batched-tokens 65536 --max-model-len 131072 --no-enable-prefix-caching"
+            env_vars: ""
+            accuracy_test_threshold: 0.70
+            runner: linux-atom-mi35x-1
           - display_name: "DeepSeek-R1-FP8 TP8"
             model_name: "DeepSeek-R1-FP8"
             model_path: "deepseek-ai/DeepSeek-R1-0528"
@@ -792,6 +804,7 @@ jobs:
       - name: Resolve image source and model matrix
         id: meta
         env:
+          RUN_COMMAND_R7B_TP1: ${{ inputs.run_command_r7b_tp1 }}
           RUN_QWEN3_MOE_TP8: ${{ inputs.run_qwen3_moe_tp8 }}
           RUN_QWEN3_NEXT_80B_TP4: ${{ inputs.run_qwen3_next_80b_tp4 }}
           RUN_QWEN35_397B_FP8_TP8: ${{ inputs.run_qwen35_397b_fp8_tp8 }}
@@ -814,6 +827,15 @@ jobs:
 
           event = os.environ["GITHUB_EVENT_NAME"]
           models = [
+              {
+                  "toggle_env": "RUN_COMMAND_R7B_TP1",
+                  "model_name": "Command-R-7B TP1",
+                  "model_path": "CohereLabs/c4ai-command-r7b-12-2024",
+                  "extra_args": "--tensor-parallel-size 1 --enable-chunked-prefill --max-num-batched-tokens 65536 --max-model-len 131072 --no-enable-prefix-caching",
+                  "accuracy_test_threshold": 0.70,
+                  "env_vars": "",
+                  "runner": "linux-atom-mi35x-1",
+              },
               {
                   "toggle_env": "RUN_QWEN3_MOE_TP8",
                   "model_name": "Qwen3-235B-A22B-Instruct-2507-FP8 TP8+EP8",

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -50,6 +50,7 @@ logger = logging.getLogger("atom")
 
 support_model_arch_dict = {
     "CohereForCausalLM": "atom.models.cohere.CohereForCausalLM",
+    "Cohere2ForCausalLM": "atom.models.cohere.CohereForCausalLM",
     "Qwen3ForCausalLM": "atom.models.qwen3.Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM": "atom.models.qwen3_moe.Qwen3MoeForCausalLM",
     "LlamaForCausalLM": "atom.models.llama.LlamaForCausalLM",

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -49,6 +49,7 @@ from torch.profiler import record_function
 logger = logging.getLogger("atom")
 
 support_model_arch_dict = {
+    "CohereForCausalLM": "atom.models.cohere.CohereForCausalLM",
     "Qwen3ForCausalLM": "atom.models.qwen3.Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM": "atom.models.qwen3_moe.Qwen3MoeForCausalLM",
     "LlamaForCausalLM": "atom.models.llama.LlamaForCausalLM",

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -71,6 +71,7 @@ class PagedAttentionImpl(nn.Module):
             else 1.0
         )
         self.kv_scale = torch.tensor(self.kv_scale_float, dtype=torch.float32)
+        self.per_tensor_scale = self.kv_scale  # set here; fp8 path overrides later
         self.per_token_quant = True
         self.sinks = sinks
         self.sliding_window = sliding_window if sliding_window is not None else -1

--- a/atom/models/cohere.py
+++ b/atom/models/cohere.py
@@ -176,8 +176,12 @@ class CohereAttention(nn.Module):
             is_neox_style=False,  # Cohere uses interleaved RoPE (repeat_interleave), not neox
         )
 
-        # Sliding window support (some Cohere variants)
-        sliding_window = None
+        # Sliding window support (some Cohere variants).
+        # Use -1 (ATOM's "no sliding window" sentinel) as the explicit default
+        # so that vLLM's Attention layer does not inherit the global
+        # cache_config.sliding_window (from config.sliding_window = 4096)
+        # for layers that are NOT sliding_attention layers.
+        sliding_window = -1
         if layer_types := getattr(config, "layer_types", None):
             if layer_types[layer_idx] == "sliding_attention":
                 sliding_window = config.sliding_window

--- a/atom/models/cohere.py
+++ b/atom/models/cohere.py
@@ -11,7 +11,6 @@
 
 """Inference-only Cohere model compatible with HuggingFace weights."""
 
-from collections.abc import Iterable
 from typing import Any, Optional, Union
 
 import torch
@@ -23,6 +22,7 @@ from atom.model_ops.activation import SiluAndMul
 from atom.model_ops.base_attention import Attention
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.layernorm import LayerNorm, RMSNorm
+from atom.model_ops.layernorm import layernorm2d_fwd_, layernorm2d_fwd_with_add_
 from atom.model_ops.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -39,6 +39,33 @@ from atom.models.utils import (
 from atom.utils.decorators import support_torch_compile
 from torch import nn
 from transformers import CohereConfig
+
+
+class CohereLayerNorm(nn.Module):
+    """LayerNorm using AITER kernels with a zero bias that is not a parameter.
+
+    Cohere2 checkpoints do not store input_layernorm.bias (it is always zero).
+    Using a non-parameter buffer avoids the vLLM weight-completeness check
+    while still letting the AITER fused kernel accept a bias argument.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-5) -> None:
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.register_buffer("bias", torch.zeros(dim))
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            return layernorm2d_fwd_(x, self.weight, self.bias, self.eps, self.dim)
+        return layernorm2d_fwd_with_add_(
+            x, self.weight, residual, self.bias, self.eps, self.dim
+        )
 
 
 class CohereMLP(nn.Module):
@@ -223,7 +250,7 @@ class CohereDecoderLayer(nn.Module):
             prefix=f"{prefix}.mlp",
         )
         # Cohere uses a single LayerNorm (with bias) shared by both attn and MLP
-        self.input_layernorm = LayerNorm(
+        self.input_layernorm = CohereLayerNorm(
             config.hidden_size,
             eps=config.layer_norm_eps,
         )
@@ -292,7 +319,7 @@ class CohereModel(nn.Module):
 
         if get_pp_group().is_last_rank:
             # Cohere uses LayerNorm for the final norm as well
-            self.norm = LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+            self.norm = CohereLayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         else:
             self.norm = PPMissingLayer()
 
@@ -397,16 +424,3 @@ class CohereForCausalLM(nn.Module):
         logits = self.lm_head(hidden_states)
         return logits
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        from atom.model_loader.loader import load_model_in_plugin_mode
-
-        loaded = load_model_in_plugin_mode(
-            model=self, config=self.model.atom_config, prefix="model."
-        )
-        # Cohere2 checkpoints omit input_layernorm.bias and norm.bias — they are
-        # zero-initialized by LayerNorm.__init__ and correct as-is.  Mark them
-        # as loaded so vLLM's completeness check does not raise.
-        for name, _ in self.named_parameters():
-            if name.endswith(".bias") and ("layernorm" in name or name == "model.norm.bias"):
-                loaded.add("model." + name)
-        return loaded

--- a/atom/models/cohere.py
+++ b/atom/models/cohere.py
@@ -11,6 +11,7 @@
 
 """Inference-only Cohere model compatible with HuggingFace weights."""
 
+from collections.abc import Iterable
 from typing import Any, Optional, Union
 
 import torch
@@ -259,6 +260,7 @@ class CohereModel(nn.Module):
         layer_type: type[nn.Module] = CohereDecoderLayer,
     ):
         super().__init__()
+        self.atom_config = atom_config
         config = atom_config.hf_config
         self.config = config
         cache_config = atom_config.kv_cache_dtype
@@ -394,3 +396,17 @@ class CohereForCausalLM(nn.Module):
     ) -> Optional[torch.Tensor]:
         logits = self.lm_head(hidden_states)
         return logits
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        from atom.model_loader.loader import load_model_in_plugin_mode
+
+        loaded = load_model_in_plugin_mode(
+            model=self, config=self.model.atom_config, prefix="model."
+        )
+        # Cohere2 checkpoints omit input_layernorm.bias and norm.bias — they are
+        # zero-initialized by LayerNorm.__init__ and correct as-is.  Mark them
+        # as loaded so vLLM's completeness check does not raise.
+        for name, _ in self.named_parameters():
+            if name.endswith(".bias") and ("layernorm" in name or name == "model.norm.bias"):
+                loaded.add("model." + name)
+        return loaded

--- a/atom/models/cohere.py
+++ b/atom/models/cohere.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Adapted from vLLM's Cohere implementation and ATOM's llama.py template.
+# CohereForCausalLM differs from Llama in:
+#   - LayerNorm (with bias) instead of RMSNorm
+#   - rope_theta directly on CohereConfig (no rope_parameters wrapper)
+#   - tie_word_embeddings=True by default
+#   - Optional Q/K layer normalization (use_qk_norm)
+#   - layer_types / sliding_window on some variants
+
+"""Inference-only Cohere model compatible with HuggingFace weights."""
+
+from typing import Any, Optional, Union
+
+import torch
+from aiter import QuantType
+from aiter.dist.parallel_state import get_pp_group, get_tensor_model_parallel_world_size
+from aiter.rotary_embedding import get_rope
+from atom.config import Config, QuantizationConfig
+from atom.model_ops.activation import SiluAndMul
+from atom.model_ops.base_attention import Attention
+from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
+from atom.model_ops.layernorm import LayerNorm, RMSNorm
+from atom.model_ops.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from atom.models.utils import (
+    IntermediateTensors,
+    PPMissingLayer,
+    extract_layer_index,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_prefix,
+)
+from atom.utils.decorators import support_torch_compile
+from torch import nn
+from transformers import CohereConfig
+
+
+class CohereMLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: QuantizationConfig,
+        bias: bool = False,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=hidden_size,
+            output_sizes=[intermediate_size] * 2,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+        )
+        if hidden_act != "silu":
+            raise ValueError(
+                f"Unsupported activation: {hidden_act}. "
+                "Only silu is supported for now."
+            )
+        self.act_fn = SiluAndMul(fused_quant=False, quant_config=quant_config)
+
+    def forward(self, x):
+        x = self.gate_up_proj(x)
+        x = self.act_fn(x)
+        x = self.down_proj(x)
+        return x
+
+
+class CohereAttention(nn.Module):
+    def __init__(
+        self,
+        config: CohereConfig,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_theta: float = 10000,
+        max_position_embeddings: int = 8192,
+        quant_config: Optional[QuantizationConfig] = None,
+        bias: bool = False,
+        cache_config: str = "bf16",
+        prefix: str = "",
+        layer_num: int = 0,
+    ) -> None:
+        super().__init__()
+        layer_idx = extract_layer_index(prefix)
+        self.hidden_size = hidden_size
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        head_dim = getattr(config, "head_dim", hidden_size // num_heads)
+        self.head_dim = head_dim
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.rope_theta = rope_theta
+        self.max_position_embeddings = max_position_embeddings
+        self.layer_num = layer_num
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size=hidden_size,
+            head_size=self.head_dim,
+            total_num_heads=self.total_num_heads,
+            total_num_kv_heads=self.total_num_kv_heads,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            input_size=self.total_num_heads * self.head_dim,
+            output_size=hidden_size,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        # Optional Q/K layer normalization (used in some Cohere variants)
+        self.use_qk_norm = getattr(config, "use_qk_norm", False)
+        if self.use_qk_norm:
+            self.q_norm = RMSNorm(self.head_dim, eps=config.layer_norm_eps)
+            self.k_norm = RMSNorm(self.head_dim, eps=config.layer_norm_eps)
+
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=self.max_position_embeddings,
+            base=self.rope_theta,
+            rope_scaling=None,
+            is_neox_style=False,  # Cohere uses interleaved RoPE (repeat_interleave), not neox
+        )
+
+        # Sliding window support (some Cohere variants)
+        sliding_window = None
+        if layer_types := getattr(config, "layer_types", None):
+            if layer_types[layer_idx] == "sliding_attention":
+                sliding_window = config.sliding_window
+
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            kv_cache_dtype=cache_config,
+            layer_num=layer_num,
+            per_layer_sliding_window=sliding_window,
+            prefix=f"{prefix}.attn",
+            rotary_emb=self.rotary_emb,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv = self.qkv_proj(hidden_states)
+        q, k, v = torch.split(qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+        if self.use_qk_norm:
+            # Reshape to apply per-head norm, then flatten back
+            q = q.view(-1, self.num_heads, self.head_dim)
+            k = k.view(-1, self.num_kv_heads, self.head_dim)
+            q = self.q_norm(q).view(-1, self.q_size)
+            k = self.k_norm(k).view(-1, self.kv_size)
+
+        attn_output = self.attn(q, k, v, positions)
+        output = self.o_proj(attn_output)
+        return output
+
+
+class CohereDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: CohereConfig,
+        quant_config: QuantizationConfig,
+        cache_config: str = "bf16",
+        prefix: str = "",
+        layer_num: int = 0,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        self.self_attn = CohereAttention(
+            config=config,
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=getattr(
+                config, "num_key_value_heads", config.num_attention_heads
+            ),
+            rope_theta=getattr(config, "rope_theta", 10000.0),
+            max_position_embeddings=getattr(config, "max_position_embeddings", 8192),
+            quant_config=quant_config,
+            bias=getattr(config, "attention_bias", False),
+            cache_config=cache_config,
+            prefix=f"{prefix}.self_attn",
+            layer_num=layer_num,
+        )
+        self.mlp = CohereMLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            bias=getattr(config, "mlp_bias", False),
+            prefix=f"{prefix}.mlp",
+        )
+        # Cohere uses a single LayerNorm (with bias) shared by both attn and MLP
+        self.input_layernorm = LayerNorm(
+            config.hidden_size,
+            eps=config.layer_norm_eps,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: Optional[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Cohere parallel residual: one pre-norm feeds both attn and MLP.
+        # residual accumulates the sum; hidden_states carries the new contribution.
+        if residual is None:
+            residual = hidden_states
+            normed = self.input_layernorm(hidden_states)
+        else:
+            normed, residual = self.input_layernorm(hidden_states, residual)
+
+        attn_output = self.self_attn(positions=positions, hidden_states=normed)
+        mlp_output = self.mlp(normed)
+
+        # Both attn and mlp outputs are summed; this becomes the new hidden_states
+        # contribution that will be added to residual in the next layer.
+        hidden_states = attn_output + mlp_output
+        return hidden_states, residual
+
+
+@support_torch_compile
+class CohereModel(nn.Module):
+    def __init__(
+        self,
+        atom_config: Config,
+        prefix: str = "",
+        layer_type: type[nn.Module] = CohereDecoderLayer,
+    ):
+        super().__init__()
+        config = atom_config.hf_config
+        self.config = config
+        cache_config = atom_config.kv_cache_dtype
+        quant_config = atom_config.quant_config
+        self.vocab_size = config.vocab_size
+
+        if get_pp_group().is_first_rank or (
+            config.tie_word_embeddings and get_pp_group().is_last_rank
+        ):
+            self.embed_tokens = VocabParallelEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            lambda prefix, layer_num=None: layer_type(
+                config=config,
+                cache_config=cache_config,
+                quant_config=quant_config,
+                prefix=prefix,
+                layer_num=layer_num,
+            ),
+            prefix=f"{prefix}.layers",
+            layer_num_offset=0,
+        )
+
+        if get_pp_group().is_last_rank:
+            # Cohere uses LayerNorm for the final norm as well
+            self.norm = LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor],
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors],
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[
+        torch.Tensor, IntermediateTensors, tuple[torch.Tensor, list[torch.Tensor]]
+    ]:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.get_input_embeddings(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        for layer in self.layers[self.start_layer : self.end_layer]:
+            hidden_states, residual = layer(positions, hidden_states, residual)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+
+class CohereForCausalLM(nn.Module):
+    packed_modules_mapping = {
+        "q_proj": ("qkv_proj", "q"),
+        "k_proj": ("qkv_proj", "k"),
+        "v_proj": ("qkv_proj", "v"),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def __init__(
+        self,
+        atom_config: Config,
+        prefix: str = "",
+        layer_type: type[nn.Module] = CohereDecoderLayer,
+    ):
+        super().__init__()
+        config = atom_config.hf_config
+        self.model = CohereModel(
+            atom_config=atom_config,
+            prefix=maybe_prefix(prefix, "model"),
+            layer_type=layer_type,
+        )
+
+        if get_pp_group().is_last_rank:
+            self.unpadded_vocab_size = config.vocab_size
+            self.lm_head = ParallelLMHead(
+                self.unpadded_vocab_size,
+                config.hidden_size,
+                org_num_embeddings=config.vocab_size,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+            if config.tie_word_embeddings:
+                self.lm_head.weight = self.model.embed_tokens.weight
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        model_output = self.model(
+            input_ids, positions, intermediate_tensors, inputs_embeds
+        )
+        return model_output
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> Optional[torch.Tensor]:
+        logits = self.lm_head(hidden_states)
+        return logits

--- a/atom/plugin/attention_mha.py
+++ b/atom/plugin/attention_mha.py
@@ -100,7 +100,6 @@ class PagedAttentionImplPluginModeMethods:
         attn_metadata = attention_metadata
 
         use_triton_attn = self.sliding_window != -1 or self.head_dim != 128
-        self.use_triton_attn = use_triton_attn
 
         if (
             self.rotary_emb is not None
@@ -133,7 +132,7 @@ class PagedAttentionImplPluginModeMethods:
             q, k, v = qkv.split(
                 [self.num_heads, self.num_kv_heads, self.num_kv_heads], dim=1
             )
-        elif use_triton_attn and self.rotary_emb is not None:
+        elif use_triton_attn and self.rotary_emb is not None and qkv is not None:
 
             k_scale = v_scale = self.per_tensor_scale
             self.per_token_quant = False

--- a/atom/plugin/attention_mha.py
+++ b/atom/plugin/attention_mha.py
@@ -162,6 +162,8 @@ class PagedAttentionImplPluginModeMethods:
                 output_zeros=False,
             )
         else:
+            if self.rotary_emb is not None and position is not None:
+                q, k = self.rotary_emb(position, q, k)
             if self.q_norm is not None:
                 q = self.q_norm(q)
             if self.k_norm is not None:
@@ -579,8 +581,10 @@ class PagedAttentionImplPluginModeMethods:
         # as vLLM cuda graph capture padding mechanism, here split the qkvo with
         # the actual tokens
         query = query[:num_actual_tokens]
-        qkv = qkv[:num_actual_tokens]
-        position = position[:num_actual_tokens]
+        if qkv is not None:
+            qkv = qkv[:num_actual_tokens]
+        if position is not None:
+            position = position[:num_actual_tokens]
         if key is not None:
             key = key[:num_actual_tokens]
         if value is not None:

--- a/atom/plugin/vllm/model_wrapper.py
+++ b/atom/plugin/vllm/model_wrapper.py
@@ -35,6 +35,7 @@ logger = logging.getLogger("atom")
 
 _ATOM_MODEL_CLASSES: dict[str, str] = {
     "CohereForCausalLM": "atom.models.cohere:CohereForCausalLM",
+    "Cohere2ForCausalLM": "atom.models.cohere:CohereForCausalLM",
     "Qwen3ForCausalLM": "atom.models.qwen3:Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM": "atom.models.qwen3_moe:Qwen3MoeForCausalLM",
     "GptOssForCausalLM": "atom.models.gpt_oss:GptOssForCausalLM",

--- a/atom/plugin/vllm/model_wrapper.py
+++ b/atom/plugin/vllm/model_wrapper.py
@@ -34,6 +34,7 @@ logger = logging.getLogger("atom")
 
 
 _ATOM_MODEL_CLASSES: dict[str, str] = {
+    "CohereForCausalLM": "atom.models.cohere:CohereForCausalLM",
     "Qwen3ForCausalLM": "atom.models.qwen3:Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM": "atom.models.qwen3_moe:Qwen3MoeForCausalLM",
     "GptOssForCausalLM": "atom.models.gpt_oss:GptOssForCausalLM",

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -20,6 +20,7 @@ ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER = "atom.plugin.vllm.model_wrapper:ATOMMoEForCau
 # Keys is from hf config arch name
 _VLLM_MODEL_REGISTRY_OVERRIDES: dict[str, str] = {
     "CohereForCausalLM": ATOM_CAUSAL_LM_MODEL_WRAPPER,
+    "Cohere2ForCausalLM": ATOM_CAUSAL_LM_MODEL_WRAPPER,
     "Qwen3ForCausalLM": ATOM_CAUSAL_LM_MODEL_WRAPPER,
     "Qwen3MoeForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,
     "GptOssForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -19,6 +19,7 @@ ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER = "atom.plugin.vllm.model_wrapper:ATOMMoEForCau
 # when register new model to vllm, add here
 # Keys is from hf config arch name
 _VLLM_MODEL_REGISTRY_OVERRIDES: dict[str, str] = {
+    "CohereForCausalLM": ATOM_CAUSAL_LM_MODEL_WRAPPER,
     "Qwen3ForCausalLM": ATOM_CAUSAL_LM_MODEL_WRAPPER,
     "Qwen3MoeForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,
     "GptOssForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,

--- a/recipes/atom_vllm/Cohere.md
+++ b/recipes/atom_vllm/Cohere.md
@@ -1,0 +1,66 @@
+# Cohere Command R with ATOM vLLM Plugin Backend
+
+This recipe shows how to run Cohere Command R models (e.g., `CohereLabs/c4ai-command-r7b-12-2024`, `CohereForAI/c4ai-command-r-plus`) with the ATOM vLLM plugin backend on AMD Instinct GPUs. For background on the plugin backend, see [ATOM vLLM Plugin Backend](../../docs/vllm_plugin_backend_guide.md).
+
+## Step 1: Pull the OOT Docker
+
+```bash
+docker pull rocm/atom-dev:vllm-latest
+```
+
+## Step 2: Launch vLLM Server
+
+The ATOM vLLM plugin backend keeps the standard vLLM CLI, server APIs, and general usage flow compatible with upstream vLLM. For general server options and API usage, refer to the [official vLLM documentation](https://docs.vllm.ai/en/latest/).
+
+### Command R 7B (TP=1, MI300X)
+
+```bash
+vllm serve CohereLabs/c4ai-command-r7b-12-2024 \
+    --host localhost \
+    --port 8000 \
+    --tensor-parallel-size 1 \
+    --gpu-memory-utilization 0.95 \
+    --enable-chunked-prefill \
+    --max-num-batched-tokens 65536 \
+    --max-num-seqs 128 \
+    --max-model-len 131072 \
+    --swap-space 32 \
+    --no-enable-prefix-caching
+```
+
+### Command R+ 104B (TP=4, MI300X)
+
+```bash
+vllm serve CohereForAI/c4ai-command-r-plus \
+    --host localhost \
+    --port 8000 \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.95 \
+    --enable-chunked-prefill \
+    --max-num-batched-tokens 65536 \
+    --max-num-seqs 64 \
+    --max-model-len 131072 \
+    --no-enable-prefix-caching
+```
+
+## Step 3: Performance Benchmark
+
+```bash
+vllm bench serve \
+    --host localhost \
+    --port 8000 \
+    --model CohereLabs/c4ai-command-r7b-12-2024 \
+    --dataset-name random \
+    --random-input-len 1024 \
+    --random-output-len 512 \
+    --num-prompts 100 \
+    --request-rate inf \
+    --max-concurrency 8
+```
+
+## Notes
+
+- **Tied embeddings**: `CohereConfig.tie_word_embeddings=True` by default. The `lm_head` shares weights with `embed_tokens` — no separate `lm_head` checkpoint key is expected.
+- **LayerNorm**: Cohere uses standard LayerNorm (with bias) rather than RMSNorm. ATOM uses the AITER-accelerated `layernorm2d_fwd` / `layernorm2d_fwd_with_add` kernels.
+- **Q/K norm**: Some Cohere variants set `use_qk_norm=True` in the config. ATOM handles this automatically per-layer.
+- **Long-context**: Command R models support up to 128K context. Use `--max-model-len 131072` with `--enable-chunked-prefill --max-num-batched-tokens 65536` for stable prefill on MI300X.


### PR DESCRIPTION
## Summary

Adds full support for `CohereLabs/c4ai-command-r7b-12-2024` and Cohere2-family models on the ATOM AMD MI300X backend.

### Changes

- **Register Cohere2ForCausalLM** in ATOM model registry and plugin model wrapper (`atom/plugin/vllm/register.py`, `atom/plugin/vllm/model_wrapper.py`)
- **New `atom/models/cohere.py`** — Cohere/Cohere2 model implementation with:
  - `CohereLayerNorm` using `register_buffer` for zero bias (avoids vLLM weight-completeness check)
  - `CohereMLP`, `CohereAttention`, `CohereDecoderLayer`, `CohereModel`, `CohereForCausalLM`
  - Parallel residual (attn + MLP share the same pre-norm)
  - Per-layer sliding window via `config.layer_types` (driven by `sliding_window_pattern=4` in Cohere2Config)
  - Q/K layer normalization support (`use_qk_norm`)
  - Non-neox RoPE (interleaved/repeat_interleave style)
- **Fix: sliding window sentinel** (`atom/models/cohere.py`) — use `-1` (ATOM's no-sliding-window sentinel) instead of `None` for global attention layers, preventing vLLM from inheriting `cache_config.sliding_window=4096` via its fallback path
- **Fix: `qkv=None` crash in triton branch** (`atom/plugin/attention_mha.py`) — guard the fused-qkv triton path with `qkv is not None`; when Cohere passes separate q/k/v (qkv=None), fall through to the else branch which correctly applies RoPE on separate tensors
- **Fix: `per_tensor_scale` AttributeError** (`atom/model_ops/attention_mha.py`) — initialize `self.per_tensor_scale = self.kv_scale` in `PagedAttentionImpl.__init__` so bf16 models don't crash on first forward

### Validation

Functional smoke tests on AMD MI300X (8x GPU, ctr-cx63-mi300x-21, ATOM `rocm/atom-dev:vllm-latest` image):

| Test | Result |
|------|--------|
| Basic chat completion | PASS |
| Math reasoning (7×8=56) | PASS |
| Sliding window (long prompt) | PASS |
| System message | PASS |
| Multi-turn conversation | PASS |
| `/v1/models` API | PASS |

All 6 tests passed with `--enforce-eager --tensor-parallel-size 8 --max-model-len 8192`.