### PR TITLE
ci(docker): install triton_kernels for ATOM_USE_TRITON_MOE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -310,7 +310,12 @@ RUN echo "========== [Parallel] Building Triton ==========" && \
     cd /triton-test && \
     pip install -r python/requirements.txt && \
     pip install filecheck && \
-    MAX_JOBS=64 pip --retries=10 --default-timeout=60 install .
+    MAX_JOBS=64 pip --retries=10 --default-timeout=60 install . && \
+    # Companion `triton_kernels` package (pure-Python). Required by ATOM when
+    # `ATOM_USE_TRITON_MOE=1` (e.g. DeepSeek-V4 launch path). Lives under
+    # python/triton_kernels in the same ROCm/triton checkout.
+    pip install ./python/triton_kernels && \
+    python -c "import triton_kernels; print(f'triton_kernels: {triton_kernels.__file__}')"
 
 # --------------------------------------------------------------------
 # Stage 4: Aiter — parallel
@@ -353,10 +358,15 @@ RUN DEBIAN_FRONTEND=noninteractive dpkg -i --force-all /tmp/rccl/*.deb && \
 
 # Triton: copy package from build stage into current venv
 # Use RUN --mount to avoid COPY glob issues, and preserve mori already in venv
+# Also copy the companion `triton_kernels` package (pure-Python, built in the
+# same stage) — required by ATOM_USE_TRITON_MOE=1 model paths.
 RUN --mount=from=build_triton,source=/opt/venv/lib/python3.12/site-packages,target=/triton-pkgs \
     cp -a /triton-pkgs/triton /opt/venv/lib/python3.12/site-packages/ && \
     cp -a /triton-pkgs/triton-*.dist-info /opt/venv/lib/python3.12/site-packages/ && \
-    pip show triton
+    cp -a /triton-pkgs/triton_kernels /opt/venv/lib/python3.12/site-packages/ && \
+    cp -a /triton-pkgs/triton_kernels-*.dist-info /opt/venv/lib/python3.12/site-packages/ && \
+    pip show triton triton_kernels && \
+    python -c "import triton, triton_kernels; print(f'triton {triton.__version__}; triton_kernels {triton_kernels.__file__}')"
 
 # Aiter: copy compiled source tree + re-register editable install
 # (pip install -e creates egg-link automatically, no need to COPY them)


### PR DESCRIPTION
## Summary

Install the companion `triton_kernels` package in the ATOM Docker base image so models that opt into the Triton MoE path (e.g. DeepSeek-V4 with `ATOM_USE_TRITON_MOE=1`) can import it.

`triton_kernels` is shipped as a sibling pure-Python package under `python/triton_kernels` in the same `ROCm/triton` checkout we already clone in the `build_triton` stage; it is not installed by `pip install .` of the main triton package and was therefore missing from images.

Without this change, launching V4-Pro fails at import:

```
ModuleNotFoundError: No module named 'triton_kernels'
```

(callers: `atom/model_ops/fused_moe_triton.py`, `atom/model_ops/moe.py:692-697`).

## Changes

- `build_triton` stage: `pip install ./python/triton_kernels` after the main triton install (pure-Python, no extra build deps).
- `atom_image` final stage: extend the existing `--mount=from=build_triton` cp block to also copy `triton_kernels/` and `triton_kernels-*.dist-info/` alongside `triton/`.
- Both stages get a `python -c "import triton_kernels; ..."` validation so the build fails early if the copy regresses.

## Derived stages — verified safe

- `atom_oot`: triton backup/restore globs only match `triton/` and `triton-*.dist-info`; `triton_kernels` (separate package) survives untouched.
- `atom_sglang`: reinstalls `triton==3.6.0`, does not touch `triton_kernels`.

## Test plan

- [ ] Local `docker build --target atom_image` reaches the new validation step and prints `triton_kernels: ...`.
- [ ] After build, `python -c "import triton_kernels; print(triton_kernels.__file__)"` resolves inside the image.
- [ ] Launch DeepSeek-V4-Pro with `ATOM_USE_TRITON_MOE=1` in the freshly built image — no `ModuleNotFoundError` and GSM8K-50 ≥ 0.94 (matches V4 baseline noted in PR #650).