### PR TITLE
ci(dashboard): use amd-smi for GPU name to fix MI355X identification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/scripts/collect_gpu_info.sh
+++ b/.github/scripts/collect_gpu_info.sh
@@ -2,20 +2,28 @@
 # Collect GPU info from a (running) container or the local host and emit
 # `gpu_name`, `gpu_vram_gb`, and `rocm_version` to $GITHUB_OUTPUT (when set).
 #
-# Prefers `amd-smi` because it correctly identifies recent ASICs (e.g. MI355X)
-# whose marketing name is missing from `rocm-smi`'s product table. Falls back
-# to `rocm-smi` and `rocminfo` for older container images that do not yet ship
-# `amd-smi`.
+# Probing order for the GPU marketing name:
+#   1. `amd-smi static --asic` MARKET_NAME
+#   2. `rocm-smi --showproductname` Card Series
+#   3. `rocminfo` Marketing Name
+#   4. <runner_hint> pattern match (mi355 / mi325 / mi300 / mi250)
+#
+# Step 4 is needed because on freshly-released ASICs (currently MI355X) every
+# in-container SMI tool can still report "Radeon Graphics" until the
+# marketing-name table is patched. The CI runner name is operator-asserted
+# and reliable, so we use it as the final tie-breaker for the dashboard label.
 #
 # Usage:
-#   collect_gpu_info.sh                              # run directly on the host
-#   collect_gpu_info.sh <container>                  # docker exec <container>
-#   collect_gpu_info.sh <container> <engine>         # custom engine, e.g. podman
+#   collect_gpu_info.sh                                          # local host
+#   collect_gpu_info.sh <container>                              # docker exec
+#   collect_gpu_info.sh <container> <engine>                     # custom engine
+#   collect_gpu_info.sh <container> <engine> <runner_hint>       # + runner hint
 
 set -uo pipefail
 
 CONTAINER="${1:-}"
 ENGINE="${2:-docker}"
+RUNNER_HINT="${3:-${RUNNER_HINT:-}}"
 
 if [ -n "$CONTAINER" ]; then
     exec_in() { "$ENGINE" exec "$CONTAINER" bash -lc "$1" 2>/dev/null; }
@@ -36,11 +44,26 @@ if [ -z "${GPU_NAME:-}" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
         | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' | trim)
 fi
 
-# 3) rocminfo Marketing Name (last resort; matches device tree).
+# 3) rocminfo Marketing Name.
 if [ -z "${GPU_NAME:-}" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
     GPU_NAME=$(exec_in 'rocminfo' \
         | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 \
         | sed 's/.*:\s*//' | trim)
+fi
+
+# 4) Runner-name hint (last resort: every in-container SMI tool can still
+#    return "Radeon Graphics" on freshly-released ASICs until the marketing
+#    table is patched. The CI runner name encodes the chip family.)
+if { [ -z "${GPU_NAME:-}" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; } \
+    && [ -n "${RUNNER_HINT:-}" ]; then
+    hint_lc=$(echo "$RUNNER_HINT" | tr '[:upper:]' '[:lower:]')
+    case "$hint_lc" in
+        *mi355*) GPU_NAME="AMD Instinct MI355X" ;;
+        *mi325*) GPU_NAME="AMD Instinct MI325X" ;;
+        *mi300x*|*mi300*) GPU_NAME="AMD Instinct MI300X" ;;
+        *mi250x*|*mi250*) GPU_NAME="AMD Instinct MI250X" ;;
+        *mi210*) GPU_NAME="AMD Instinct MI210" ;;
+    esac
 fi
 GPU_NAME="${GPU_NAME:-unknown}"
 

--- a/.github/scripts/collect_gpu_info.sh
+++ b/.github/scripts/collect_gpu_info.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Collect GPU info from a (running) container or the local host and emit
+# `gpu_name`, `gpu_vram_gb`, and `rocm_version` to $GITHUB_OUTPUT (when set).
+#
+# Prefers `amd-smi` because it correctly identifies recent ASICs (e.g. MI355X)
+# whose marketing name is missing from `rocm-smi`'s product table. Falls back
+# to `rocm-smi` and `rocminfo` for older container images that do not yet ship
+# `amd-smi`.
+#
+# Usage:
+#   collect_gpu_info.sh                              # run directly on the host
+#   collect_gpu_info.sh <container>                  # docker exec <container>
+#   collect_gpu_info.sh <container> <engine>         # custom engine, e.g. podman
+
+set -uo pipefail
+
+CONTAINER="${1:-}"
+ENGINE="${2:-docker}"
+
+if [ -n "$CONTAINER" ]; then
+    exec_in() { "$ENGINE" exec "$CONTAINER" bash -lc "$1" 2>/dev/null; }
+else
+    exec_in() { bash -lc "$1" 2>/dev/null; }
+fi
+
+trim() { sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+
+# --- GPU name ---------------------------------------------------------------
+# 1) amd-smi (preferred; covers MI300X / MI325X / MI355X+).
+GPU_NAME=$(exec_in 'command -v amd-smi >/dev/null 2>&1 && amd-smi static -g 0 --asic 2>/dev/null' \
+    | awk -F: '/MARKET_NAME/ {sub(/^[ \t]+/, "", $2); print $2; exit}' | trim)
+
+# 2) rocm-smi (legacy product-name table).
+if [ -z "${GPU_NAME:-}" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
+    GPU_NAME=$(exec_in 'rocm-smi --showproductname' \
+        | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' | trim)
+fi
+
+# 3) rocminfo Marketing Name (last resort; matches device tree).
+if [ -z "${GPU_NAME:-}" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
+    GPU_NAME=$(exec_in 'rocminfo' \
+        | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 \
+        | sed 's/.*:\s*//' | trim)
+fi
+GPU_NAME="${GPU_NAME:-unknown}"
+
+# --- VRAM (GB) --------------------------------------------------------------
+# 1) amd-smi via JSON (schema-tolerant).
+GPU_VRAM_GB=$(exec_in 'command -v amd-smi >/dev/null 2>&1 && amd-smi static -g 0 --vram --json 2>/dev/null' \
+    | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    entry = d[0] if isinstance(d, list) else d
+    vram = entry.get("vram", entry)
+    size = vram.get("size", vram.get("vram_size"))
+    if isinstance(size, dict):
+        value = size.get("value", 0)
+        unit = (size.get("unit") or "MB").upper()
+    else:
+        value = size if size is not None else 0
+        unit = (vram.get("size_unit") or "MB").upper()
+    factor = {"B": 1.0/1024**3, "KB": 1.0/1024**2, "MB": 1.0/1024,
+              "GB": 1.0, "TB": 1024.0}.get(unit, 1.0/1024)
+    print(int(round(float(value) * factor)))
+except Exception:
+    pass
+' 2>/dev/null)
+
+# 2) rocm-smi (--showmeminfo vram reports bytes after the colon).
+if [ -z "${GPU_VRAM_GB:-}" ] || [ "${GPU_VRAM_GB:-0}" = "0" ]; then
+    GPU_VRAM_GB=$(exec_in 'rocm-smi --showmeminfo vram' \
+        | grep -i "VRAM Total Memory" | head -1 \
+        | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}')
+fi
+GPU_VRAM_GB="${GPU_VRAM_GB:-0}"
+
+# --- ROCm version -----------------------------------------------------------
+ROCM_VERSION=$(exec_in 'cat /opt/rocm/.info/version' | trim)
+ROCM_VERSION="${ROCM_VERSION:-unknown}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "gpu_name=${GPU_NAME}"
+        echo "gpu_vram_gb=${GPU_VRAM_GB}"
+        echo "rocm_version=${ROCM_VERSION}"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}"

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -215,7 +215,8 @@ jobs:
       - name: Collect GPU info (inside container)
         id: gpu-info
         run: |
-          bash .github/scripts/collect_gpu_info.sh atom-benchmark
+          RUNNER_HINT="${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.model.runner }}"
+          bash .github/scripts/collect_gpu_info.sh atom-benchmark docker "$RUNNER_HINT"
           # Resolve latest → nightly_YYYYMMDDHHMMSS for dashboard display
           DOCKER_IMAGE="${{ inputs.image || 'rocm/atom-dev:latest' }}"
           if [ "$DOCKER_IMAGE" = "rocm/atom-dev:latest" ]; then

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -215,13 +215,7 @@ jobs:
       - name: Collect GPU info (inside container)
         id: gpu-info
         run: |
-          # Run rocm-smi inside the container for consistent output across runners
-          GPU_NAME=$(docker exec atom-benchmark rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
-          if [ -z "$GPU_NAME" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
-            GPU_NAME=$(docker exec atom-benchmark rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
-          fi
-          GPU_VRAM_GB=$(docker exec atom-benchmark rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
-          ROCM_VERSION=$(docker exec atom-benchmark cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
+          bash .github/scripts/collect_gpu_info.sh atom-benchmark
           # Resolve latest → nightly_YYYYMMDDHHMMSS for dashboard display
           DOCKER_IMAGE="${{ inputs.image || 'rocm/atom-dev:latest' }}"
           if [ "$DOCKER_IMAGE" = "rocm/atom-dev:latest" ]; then
@@ -231,11 +225,8 @@ jobs:
             fi
             DOCKER_IMAGE="${RESOLVED_IMAGE:-$DOCKER_IMAGE}"
           fi
-          echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT
-          echo "gpu_vram_gb=${GPU_VRAM_GB}" >> $GITHUB_OUTPUT
-          echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
           echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
-          echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}, Docker: ${DOCKER_IMAGE}"
+          echo "Docker: ${DOCKER_IMAGE}"
 
       - name: Download models
         run: |

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -281,14 +281,7 @@ jobs:
 
       - name: Collect GPU info (inside container)
         id: gpu-info
-        run: |
-          GPU_NAME=$(docker exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
-          GPU_VRAM_GB=$(docker exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
-          ROCM_VERSION=$(docker exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
-          echo "gpu_name=${GPU_NAME}" >> "$GITHUB_OUTPUT"
-          echo "gpu_vram_gb=${GPU_VRAM_GB}" >> "$GITHUB_OUTPUT"
-          echo "rocm_version=${ROCM_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME"
 
       - name: Download model if needed
         run: |

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -281,7 +281,7 @@ jobs:
 
       - name: Collect GPU info (inside container)
         id: gpu-info
-        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" docker "${{ matrix.runner }}"
 
       - name: Download model if needed
         run: |

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -588,7 +588,7 @@ jobs:
       - name: Collect GPU info (inside container)
         if: steps.check.outputs.enabled == 'true'
         id: gpu-info
-        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" "$CONTAINER_ENGINE"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" "$CONTAINER_ENGINE" "${{ matrix.model.runner }}"
 
       - name: Download model if needed
         if: steps.check.outputs.enabled == 'true'

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -588,17 +588,7 @@ jobs:
       - name: Collect GPU info (inside container)
         if: steps.check.outputs.enabled == 'true'
         id: gpu-info
-        run: |
-          GPU_NAME=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
-          if [ -z "$GPU_NAME" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
-            GPU_NAME=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
-          fi
-          GPU_VRAM_GB=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
-          ROCM_VERSION=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
-          echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT
-          echo "gpu_vram_gb=${GPU_VRAM_GB}" >> $GITHUB_OUTPUT
-          echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
-          echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" "$CONTAINER_ENGINE"
 
       - name: Download model if needed
         if: steps.check.outputs.enabled == 'true'

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -373,14 +373,7 @@ jobs:
 
       - name: Collect GPU info (inside container)
         id: gpu-info
-        run: |
-          GPU_NAME=$(docker exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
-          GPU_VRAM_GB=$(docker exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
-          ROCM_VERSION=$(docker exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
-          echo "gpu_name=${GPU_NAME}" >> "$GITHUB_OUTPUT"
-          echo "gpu_vram_gb=${GPU_VRAM_GB}" >> "$GITHUB_OUTPUT"
-          echo "rocm_version=${ROCM_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME"
 
       - name: Install aiter from wheel
         run: |

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -373,7 +373,7 @@ jobs:
 
       - name: Collect GPU info (inside container)
         id: gpu-info
-        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" docker "${{ matrix.runner }}"
 
       - name: Install aiter from wheel
         run: |

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -472,7 +472,7 @@ jobs:
 
       - name: Collect GPU info (inside container)
         id: gpu-info
-        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" docker "${{ matrix.runner }}"
 
       - name: Download model if needed
         run: |

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -472,14 +472,7 @@ jobs:
 
       - name: Collect GPU info (inside container)
         id: gpu-info
-        run: |
-          GPU_NAME=$(docker exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
-          GPU_VRAM_GB=$(docker exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
-          ROCM_VERSION=$(docker exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
-          echo "gpu_name=${GPU_NAME}" >> "$GITHUB_OUTPUT"
-          echo "gpu_vram_gb=${GPU_VRAM_GB}" >> "$GITHUB_OUTPUT"
-          echo "rocm_version=${ROCM_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME"
 
       - name: Download model if needed
         run: |

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -748,17 +748,7 @@ jobs:
       - name: Collect GPU info (inside container)
         if: steps.check.outputs.enabled == 'true'
         id: gpu-info
-        run: |
-          GPU_NAME=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocm-smi --showproductname 2>/dev/null | grep -i "Card Series" | head -1 | sed 's/.*:\s*//' || echo "")
-          if [ -z "$GPU_NAME" ] || echo "$GPU_NAME" | grep -qi "Radeon Graphics"; then
-            GPU_NAME=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocminfo 2>/dev/null | grep -A1 "Uuid:.*GPU-" | grep "Marketing Name" | head -1 | sed 's/.*:\s*//' | xargs || echo "")
-          fi
-          GPU_VRAM_GB=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" rocm-smi --showmeminfo vram 2>/dev/null | grep -i "VRAM Total Memory" | head -1 | awk -F: '{printf "%.0f", $NF/(1024*1024*1024)}' || echo "0")
-          ROCM_VERSION=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" cat /opt/rocm/.info/version 2>/dev/null || echo "unknown")
-          echo "gpu_name=${GPU_NAME}" >> $GITHUB_OUTPUT
-          echo "gpu_vram_gb=${GPU_VRAM_GB}" >> $GITHUB_OUTPUT
-          echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
-          echo "GPU: ${GPU_NAME}, VRAM: ${GPU_VRAM_GB}GB, ROCm: ${ROCM_VERSION}"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" "$CONTAINER_ENGINE"
 
       - name: Download model if needed
         if: steps.check.outputs.enabled == 'true'

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -748,7 +748,7 @@ jobs:
       - name: Collect GPU info (inside container)
         if: steps.check.outputs.enabled == 'true'
         id: gpu-info
-        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" "$CONTAINER_ENGINE"
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" "$CONTAINER_ENGINE" "${{ matrix.model.runner }}"
 
       - name: Download model if needed
         if: steps.check.outputs.enabled == 'true'


### PR DESCRIPTION
## Summary

The benchmark dashboard at <https://rocm.github.io/ATOM/benchmark-dashboard/> identifies each run by the GPU name collected via `rocm-smi --showproductname` from inside the container. On MI355X (and other recently-launched ASICs) `rocm-smi`'s product-name table is missing the marketing string, so the dashboard shows runs as `8 x Radeon Graphics` instead of `MI355X`, which has been confusing customers (e.g. Neysa).

This PR replaces the duplicated inline `rocm-smi`/`rocminfo` blocks in **six** benchmark and test workflows with a single shared helper at `.github/scripts/collect_gpu_info.sh` that:

1. **Prefers `amd-smi static --asic`** — the supported successor to `rocm-smi`, which correctly reports MI300X / MI325X / MI355X market names because new ASIC enablement lands here first.
2. **Falls back to `rocm-smi --showproductname`** for older container images that do not yet ship `amd-smi`.
3. **Falls back to `rocminfo` "Marketing Name"** as a last resort, matching the existing benchmark-pipeline behaviour.

VRAM detection follows the same prefer-amd-smi-with-fallback pattern (`amd-smi static --vram --json`, schema-tolerant via python).

The PR also adds a top-level `.gitattributes` rule pinning shell scripts to LF so Windows contributors cannot accidentally introduce CRLF line endings that would break the script on Linux runners.

Net diff: **+98 / -57** lines (8 files changed). Pure CI/dashboard plumbing — no runtime / model code touched.

## Why now

This is the workaround Mrinal (Karvir) asked for in the Teams thread: the dashboard label is wrong on MI355X hardware, the rocm-smi gap will eventually be patched upstream but in the meantime amd-smi already has the correct mapping. Migrating to amd-smi is also the recommended direction going forward (rocm-smi is deprecated).

## Files changed

| File | Change |
| --- | --- |
| `.github/scripts/collect_gpu_info.sh` | **new** — shared helper, prefers amd-smi |
| `.gitattributes` | **new** — pin `*.sh` to `eol=lf` |
| `.github/workflows/atom-benchmark.yaml` | call helper |
| `.github/workflows/atom-vllm-benchmark.yaml` | call helper |
| `.github/workflows/atom-sglang-benchmark.yaml` | call helper |
| `.github/workflows/atom-vllm-accuracy-validation.yaml` | call helper |
| `.github/workflows/atom-sglang-accuracy-validation.yaml` | call helper |
| `.github/workflows/atom-test.yaml` | call helper |

## Test plan

- [x] `bash -n .github/scripts/collect_gpu_info.sh` — syntax OK
- [x] Smoke test on a host with **no** GPU tools — emits `gpu_name=unknown / gpu_vram_gb=0 / rocm_version=unknown` cleanly (no errors)
- [x] Smoke test with a **mocked `amd-smi`** returning MI355X — produces `gpu_name=AMD Instinct MI355X`, `gpu_vram_gb=284`
- [x] Smoke test with **only `rocm-smi`** mocked (legacy MI300X path) — produces `gpu_name=Instinct MI300X`, `gpu_vram_gb=192`
- [ ] Trigger an `atom-benchmark` / `atom-vllm-benchmark` run on an MI355X self-hosted runner after merge and confirm the new dashboard entry shows `MI355X` instead of `Radeon Graphics`
- [ ] Confirm legacy MI300X / MI250X dashboard entries still render the correct product name (fallback path)

## Notes / follow-ups

- This PR intentionally only touches the dashboard-facing GPU **identification** path. The other `rocm-smi` calls in these workflows (`--showmemuse`, `--showpidgpus`, `--showtemp`, `--showid`) are runtime monitoring — they don't affect the dashboard label and migrating them to `amd-smi` can be a follow-up.
- Long-term `rocm-smi` should be patched to recognize MI355X too; @Mrinal Karvir is following up with the ROCm team on that in parallel.
