### PR TITLE
feat(deepseek_v4): 1. use rope_rotate_activation instead of rotary_em…

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Callable, List, Optional, Tuple
 
 import torch
-from aiter import ActivationType, QuantType, dtypes, get_hip_quant
+from aiter import ActivationType, QuantType, dtypes, get_hip_quant, topk_softplus
 from aiter.dist.parallel_state import get_dp_group, get_tp_group
 from aiter.fused_moe import fused_moe
 from aiter.jit.utils.chip_info import get_gfx
@@ -2637,32 +2637,23 @@ class FusedMoE(torch.nn.Module):
 
                 topk_ids = topk_ids.to(torch.int32)
             elif scoring_func == "sqrtsoftplus":
-                # DeepSeek-V4 routing: sqrt(softplus(scores)) + bias for selection;
-                # weights gathered from the unbiased sqrt(softplus(.)) values.
-                routing_weights = torch.nn.functional.softplus(
-                    router_logits.float()
-                ).sqrt()
-                scores_for_choice = routing_weights
-                if e_score_correction_bias is not None:
-                    scores_for_choice = scores_for_choice + e_score_correction_bias
-
-                topk_ids = torch.topk(
-                    scores_for_choice, top_k, dim=-1, sorted=False
-                ).indices
-                topk_weights = routing_weights.gather(dim=-1, index=topk_ids)
-
-                if renormalize:
-                    topk_weights = topk_weights / topk_weights.sum(
-                        dim=-1, keepdim=True
-                    ).clamp_min(1e-20)
-                # Match reference Gate.forward (deepseek_v4 inference/model.py:583):
-                # `weights *= route_scale` is applied for every non-softmax routing
-                # path. The hash routing path (`_hash_topk`) already does this
-                # internally; do it here for the sqrtsoftplus topk path so callers
-                # don't need to re-scale.
-                topk_weights = topk_weights * routed_scaling_factor
-
-                topk_ids = topk_ids.to(torch.int32)
+                # # DeepSeek-V4 routing: sqrt(softplus(scores)) + bias for selection;
+                # # weights gathered from the unbiased sqrt(softplus(.)) values.
+                tokens_num = router_logits.shape[0]
+                topk_ids = torch.empty(
+                    tokens_num, top_k, dtype=torch.int32, device=router_logits.device
+                )
+                topk_weights = torch.empty(
+                    tokens_num, top_k, dtype=torch.float32, device=router_logits.device
+                )
+                topk_softplus(
+                    topk_weights,
+                    topk_ids,
+                    router_logits,
+                    e_score_correction_bias,
+                    renormalize,
+                    routed_scaling_factor,
+                )
             else:
                 raise ValueError(
                     f"Unsupported scoring function for non-grouped topk: {scoring_func}"

--- a/atom/model_ops/v4_kernels/__init__.py
+++ b/atom/model_ops/v4_kernels/__init__.py
@@ -21,6 +21,7 @@ from atom.model_ops.v4_kernels.fused_compress import (
     fused_compress_attn,
     fused_compress_attn_reference,
 )
+from atom.model_ops.v4_kernels.indexer_weights import scale_indexer_weights
 from atom.model_ops.v4_kernels.paged_decode import (
     sparse_attn_v4_paged_decode,
     sparse_attn_v4_paged_decode_reference,
@@ -46,4 +47,5 @@ __all__ = [
     "CompressPlan",
     "make_compress_plans",
     "inverse_rope_inplace",
+    "scale_indexer_weights",
 ]

--- a/atom/model_ops/v4_kernels/indexer_weights.py
+++ b/atom/model_ops/v4_kernels/indexer_weights.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Small Indexer helper kernels."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _scale_indexer_weights_kernel(
+    weights_ptr,  # [T, H] fp32/bf16
+    q_scale_ptr,  # [T, H, 1] fp32, flattened as [T * H]
+    out_ptr,  # [T, H] fp32
+    n_elements,
+    weights_scale: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    weights = tl.load(weights_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    q_scale = tl.load(q_scale_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr + offsets, weights * q_scale * weights_scale, mask=mask)
+
+
+def scale_indexer_weights(
+    weights: torch.Tensor,
+    q_scale: torch.Tensor,
+    weights_scale: float,
+    block_size: int = 1024,
+) -> torch.Tensor:
+    """Apply `weights * q_scale.squeeze(-1) * weights_scale` in one Triton launch."""
+    assert weights.dim() == 2, f"weights must be [T, H], got {tuple(weights.shape)}"
+    assert q_scale.shape == (
+        weights.size(0),
+        weights.size(1),
+        1,
+    ), f"q_scale shape {tuple(q_scale.shape)} incompatible with weights {tuple(weights.shape)}"
+    assert weights.is_contiguous(), "weights must be contiguous"
+    assert q_scale.is_contiguous(), "q_scale must be contiguous"
+
+    n_elements = weights.numel()
+    out = torch.empty_like(weights, dtype=torch.float32)
+    if n_elements == 0:
+        return out
+
+    grid = (triton.cdiv(n_elements, block_size),)
+    _scale_indexer_weights_kernel[grid](
+        weights,
+        q_scale,
+        out,
+        n_elements,
+        weights_scale,
+        BLOCK_SIZE=block_size,
+    )
+    return out

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -60,6 +60,7 @@ from atom.model_ops.linear import (
 )
 from atom.model_ops.moe import FusedMoE
 from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
+from aiter import rope_rotate_activation
 from atom.model_ops.quant_v4 import (
     act_quant_inplace,
     rotate_activation,
@@ -81,6 +82,7 @@ from atom.model_ops.v4_kernels import (
     csa_translate_pack,
     fused_compress_attn,
     inverse_rope_inplace,
+    scale_indexer_weights,
     sparse_attn_v4_paged_decode,
     sparse_attn_v4_paged_prefill,
     swa_write,
@@ -910,8 +912,10 @@ class Indexer(nn.Module):
         # to (1, num_tokens, -1, rotary_dim) so the input doesn't need an
         # explicit batch dim. rotate_activation is last-dim-only.
         q = self.wq_b(qr_full).view(total_tokens, self.n_heads, self.head_dim)
-        self.rotary_emb(positions, q[..., -rd:])
-        q = rotate_activation(q)
+        # self.rotary_emb(positions, q[..., -rd:])
+        # q = rotate_activation(q)
+        cos, sin = self.rotary_emb._caches(q.device)
+        rope_rotate_activation(q, q, cos, sin, positions, rd)
 
         # FP8 quant Q (still online — Q is recomputed each fwd, no cache).
         # `_fp8_quant_func` / `_weights_scale` precomputed in __init__.
@@ -924,7 +928,7 @@ class Indexer(nn.Module):
         # weights_proj is BF16 but auto-promotes to fp32 via fp32 q_scale,
         # so no explicit `.float()` cast needed.
         weights = self.weights_proj(x_full)
-        weights = (weights.unsqueeze(-1) * q_scale * self._weights_scale).squeeze(-1)
+        weights = scale_indexer_weights(weights, q_scale, self._weights_scale)
 
         return torch.ops.aiter.indexer_score_topk(
             q_fp8, weights, self.prefix, self.index_topk
@@ -1832,7 +1836,7 @@ class MoE(nn.Module):
         `forward_context.context.input_ids` before each forward, and
         `_hash_topk` (FusedMoE's custom_routing_function) reads it there.
         """
-        router_logits = self.gate(x)  # [num_tokens, n_routed_experts]
+        router_logits = self.gate(x, otype=torch.float32)  # [num_tokens, n_routed_experts]
         return self.experts(hidden_states=x, router_logits=router_logits)
 
     def combine_outputs(
@@ -2125,13 +2129,8 @@ class ParallelHead(nn.Module):
         """Reduce mHC residual `[num_tokens, hc, dim]` → `[num_tokens, dim]`
         via Sigmoid-gated weighted sum (vs Block.hc_pre's Sinkhorn variant).
         """
-        dtype = x.dtype
-        x_flat = x.flatten(-2)  # [num_tokens, hc*dim]
-        x_normed = _rmsnorm_nw(x_flat, self.norm_eps, x_flat.shape[-1])
-        mixes = F.linear(x_normed.float(), hc_fn)  # [num_tokens, hc]
-        pre = torch.sigmoid(mixes * hc_scale + hc_base) + self.hc_eps
-        y = torch.sum(pre.unsqueeze(-1) * x, dim=-2)  # [num_tokens, dim]
-        return y.to(dtype)
+        _, _, y = aiter.mhc_pre(x, hc_fn, hc_scale, hc_base, self.norm_eps, self.hc_eps, sinkhorn_repeat=0)
+        return y
 
     def forward(
         self,


### PR DESCRIPTION
1. use rope_rotate_activation instead of rotary_emb + rotate_activation;  related aiter pr https://github.com/ROCm/aiter/pull/3035
2. use topk_softplus fused kernel; related aiter pr https://github.com/ROCm/aiter/pull/2995
3. use mhc_pre in hc_head; related aiter pr https://github.com/ROCm/aiter/pull/3044
4. add scale_indexer_weights