### PR TITLE
fix(v4-ci): unblock nightly Docker test + V4-Pro accuracy step

### DIFF
--- a/atom/examples/simple_inference.py
+++ b/atom/examples/simple_inference.py
@@ -45,7 +45,7 @@ def main():
         "1+2+3=?",
         "如何在一个月内增肌10公斤",
         "+".join([f"{i}-{i+1}" for i in range(1000)]) + "=? 最后结果是什么",
-        "+".join([f"{i}+{i+1}" for i in range(3000)]) + "=? 最后结果是什么",
+        "+".join([f"{i}+{i+1}" for i in range(1500)]) + "=? 最后结果是什么",
     ]
     args = parser.parse_args()
     # Generate power of 2 sizes for CUDA graph: [1, 2, 4, 8, ...]

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -12,10 +12,20 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import safetensors
+import safetensors.torch
 import torch
 from torch import nn
 from tqdm import tqdm
 from transformers import AutoConfig
+
+# safetensors<=0.7.0 ships a Python `_TYPES` dict missing the `F8_E8M0`
+# (MX scale) entry, even though both torch and the safetensors-rust binary
+# support it. The mmap'd `safe_open` path goes through Rust and works, but
+# the `safetensors.torch.load(bytes)` path used when `ATOM_DISABLE_MMAP=true`
+# raises `KeyError: 'F8_E8M0'` on DeepSeek-V4-Pro shards. Register the
+# missing dtype string so both paths behave identically.
+if "F8_E8M0" not in safetensors.torch._TYPES and hasattr(torch, "float8_e8m0fnu"):
+    safetensors.torch._TYPES["F8_E8M0"] = torch.float8_e8m0fnu
 
 from atom.utils import envs
 from transformers.utils import SAFE_WEIGHTS_INDEX_NAME


### PR DESCRIPTION
## Summary

Two hotfixes for CI regressions exposed after the V4-Pro PR1 merge (#650):

### 1. Nightly Docker Release — `simple_inference` long prompt overflows block_tables
The new arithmetic stress prompt (3000 terms ≈ 16k tokens) added in c3ec204c crashed the Docker test (\`atom-release\` runs Llama-3-8B-Instruct):

```
ValueError: could not broadcast input array from shape (1005,) into shape (512,)
  at atom/model_ops/attentions/backends.py:249 (prepare_block_tables)
```

Llama-3-8B's `max_model_len=8192` → `block_tables` buffer dim = `8192 / 16 = 512`. The 16k-token seq passes the prefill scheduler (`max_num_batched_tokens=16384` ≥ 16016) but its KV needs ~1000 blocks > 512. **Fix**: shrink the prompt to 1500 terms (~7k tokens, 438 blocks → 74-block margin).

Locally reproduced with `gpt-oss-120b -tp 1 --max-model-len 8192`.

### 2. V4-Pro per-PR accuracy step — `safetensors==0.7.0` missing F8_E8M0
The new V4-Pro accuracy entry (also c3ec204c) failed at model load:

```
KeyError: 'F8_E8M0'
  at safetensors/torch.py:427 (_getdtype)
```

V4-Pro shards contain MX scale tensors with `F8_E8M0` dtype. Both `torch.float8_e8m0fnu` and the safetensors-rust binary support it, but the Python `_TYPES` dict in `safetensors==0.7.0` (latest pinned in CI) is missing the mapping. The mmap path (`safe_open + get_tensor`) goes through Rust and works fine, but the `ATOM_DISABLE_MMAP=true` path (set by atom-test.yaml's container env) calls `safetensors.torch.load(bytes)` which fails the dict lookup.

**Fix**: monkey-patch the missing mapping at loader import time. No-op when safetensors ships the entry natively.

End-to-end verified locally: previously crashed at shard 2/64; with patch, all 10000 scanned tensors load (4951 are F8_E8M0).

## Test plan

- [x] Local repro: `gpt-oss-120b --max-model-len 8192` → simple_inference crashes on the old 3000-term prompt with the same `(1005,) → (512,)` error
- [x] Local F8_E8M0 repro: `safetensors.torch.load(bytes)` on a V4-Pro shard → `KeyError: 'F8_E8M0'`
- [x] Local F8_E8M0 fix verified: same call path now loads 2337 tensors per shard cleanly via the loader's `disable_mmap=True` branch
- [ ] Wait for CI to re-run nightly Docker + V4-Pro accuracy after merge