### PR TITLE
fix(v4): triton-3.6+ MoE SMEM OOM + empty-batch indexer prefill

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -762,6 +762,21 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 np.cumsum(n_committed_per_seq, dtype=np.int64),
             ]
         )
+        # Empty-batch guard: when no seq has committed K yet
+        # (`cu_committed_cpu[-1] == 0`, e.g. fresh prefill with prompt
+        # shorter than the CSA `ratio`), `cp_gather_indexer_k_quant_cache`
+        # would launch with grid.x = 0 and fail with HIP "invalid
+        # configuration argument". Bump the last cumsum by one so the
+        # kernel sees a single dummy row to gather (charged to the last
+        # seq's first cache block). Downstream readers
+        # (`fp8_mqa_logits` + `top_k_per_row_prefill`) honor per-token
+        # `cu_starts`/`cu_ends` derived from `cu_committed_gpu[:-1]` and
+        # `n_committed_per_seq`, both of which remain 0 — so the dummy
+        # row is never read and the output is `-1` sentinels everywhere,
+        # matching the all-empty semantics. Pure host-side scalar
+        # arithmetic on a value already host-synced two lines up; no new
+        # CG/torch.compile graph branch is introduced.
+        cu_committed_cpu[-1] = max(int(cu_committed_cpu[-1]), 1)
         total_committed = int(cu_committed_cpu[-1])
 
         # FP8 write-side slot_mapping (independent of `total_committed` —
@@ -771,15 +786,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         compress_slot_mapping_gpu = self._build_indexer_compress_slot_mapping(
             csa_compress_plan_cpu, scheduled_bs, k_per_block, ratio
         )
-
-        # All-empty batch: forward_batched short-circuits on
-        # `total_committed == 0` and returns -1; the FP8 read side is unused.
-        if total_committed == 0:
-            return {
-                "total_committed": 0,
-                "cu_committed_gpu": None,
-                "compress_slot_mapping_gpu": compress_slot_mapping_gpu,
-            }
 
         # batch_id_per_token + n_committed_csa: reuse the shared GPU
         # tensors set in `_attach_v4_per_fwd_meta` (which MUST run before

--- a/atom/model_ops/fused_moe_triton.py
+++ b/atom/model_ops/fused_moe_triton.py
@@ -18,7 +18,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import torch
+from contextlib import contextmanager
 from typing import Any
 import logging
 from math import prod
@@ -39,6 +41,45 @@ if has_triton_kernels():
             "version is compatible. Error: %s",
             e,
         )
+
+
+@contextmanager
+def _amd_smem_safe_tile():
+    """Cap matmul_ogs tile size on AMD CDNA4 to fit MI355X's 160 KiB LDS.
+
+    triton_kernels' AMD opt_flags has a special-case
+    `if cdna4 and block_m == 128: block_n = 512`, which makes BLOCK_M*BLOCK_N
+    = 64K FP32 entries — large enough that triton 3.6+/3.7+ spills the
+    accumulator into LDS and overflows the 160 KiB budget (observed 269 KiB
+    on V4-Pro FP8 MoE). triton 3.5 happened to keep more of the acc in
+    registers and slipped under the limit, hence the version-dependent OOM.
+
+    Pin block_n ≤ ATOM_TRITON_MOE_MAX_BLOCK_N (default 256) so BLOCK_M*BLOCK_N
+    stays at 32K. Default block_n in compute_block_nk is already capped at
+    256 except for that single cdna4 branch, so this only sidesteps the bad
+    path on gfx950.
+    """
+    if get_gfx() != "gfx950" or not has_triton_kernels():
+        yield
+        return
+    try:
+        from triton_kernels.matmul_ogs_details.opt_flags import (
+            update_opt_flags_constraints,
+            reset_opt_flags_constraints,
+        )
+    except ImportError:
+        yield
+        return
+    # Defaults chosen so BLOCK_M*BLOCK_N stays ≤ 16384 entries (64 KiB FP32
+    # acc), comfortably fitting MI355X's register file. Override via env if
+    # a future compiler/kernel update relaxes the budget.
+    block_m = int(os.getenv("ATOM_TRITON_MOE_BLOCK_M", "64"))
+    block_n = int(os.getenv("ATOM_TRITON_MOE_BLOCK_N", "256"))
+    update_opt_flags_constraints({"block_m": block_m, "block_n": block_n})
+    try:
+        yield
+    finally:
+        reset_opt_flags_constraints()
 
 
 def _swizzle_mxfp4(quant_tensor, scale):
@@ -241,16 +282,17 @@ def triton_kernel_fused_experts(
         dtype=hidden_states.dtype,
     )
 
-    matmul_ogs(
-        hidden_states,
-        w1,
-        w1_bias,
-        routing_data,
-        gather_indx=gather_indx,
-        precision_config=w13_precision_config,
-        gammas=gammas if apply_router_weight_on_input else None,
-        y=raw_intermediate,
-    )
+    with _amd_smem_safe_tile():
+        matmul_ogs(
+            hidden_states,
+            w1,
+            w1_bias,
+            routing_data,
+            gather_indx=gather_indx,
+            precision_config=w13_precision_config,
+            gammas=gammas if apply_router_weight_on_input else None,
+            y=raw_intermediate,
+        )
 
     # Standard SiLU/SwiGLU activation: silu(gate) * up
     # With optional swiglu_limit clamping (V4: limit=10.0)
@@ -262,16 +304,17 @@ def triton_kernel_fused_experts(
         up = up.clamp(-swiglu_limit, swiglu_limit)
     intermediate_cache[0] = torch.nn.functional.silu(gate) * up
 
-    matmul_ogs(
-        intermediate_cache.view(M * topk, half_N),
-        w2,
-        w2_bias,
-        routing_data,
-        scatter_indx=scatter_indx,
-        precision_config=w2_precision_config,
-        gammas=None if apply_router_weight_on_input else gammas,
-        y=output_tensor,
-    )
+    with _amd_smem_safe_tile():
+        matmul_ogs(
+            intermediate_cache.view(M * topk, half_N),
+            w2,
+            w2_bias,
+            routing_data,
+            scatter_indx=scatter_indx,
+            precision_config=w2_precision_config,
+            gammas=None if apply_router_weight_on_input else gammas,
+            y=output_tensor,
+        )
 
     output_tensor = output_tensor.view(M, K)
     return output_tensor


### PR DESCRIPTION
## Summary

Two CI failures surfaced after #703 unblocked the V4-Pro accuracy step.

### 1. Triton MoE SMEM OOM on AMD CDNA4 (triton 3.6+)

`triton_kernels.matmul_ogs_details.opt_flags_amd` has a CDNA4 special case:

\`\`\`python
if get_cdna_version() == 4 and block_m == 128:
    block_n = 512
\`\`\`

Producing BLOCK_M*BLOCK_N = 64K FP32 acc entries. triton 3.6+/3.7+ spills the accumulator to LDS more aggressively than 3.5, exceeding MI355X's 160 KiB LDS budget (observed **269 KiB required** vs **163 KiB hardware limit** on V4-Pro FP8 MoE).

**Fix**: wrap matmul_ogs calls with a CDNA4-only context manager that pins \`block_m=64\` / \`block_n=256\` (BLOCK_M*BLOCK_N = 16K, fits comfortably). Tunable via \`ATOM_TRITON_MOE_BLOCK_{M,N}\` env vars. Other GPU families and triton ≤3.5 paths are unaffected.

### 2. \`cp_gather_indexer_k_quant_cache\` HIP \"invalid configuration argument\"

When the indexer prefill builder produces \`cu_committed_cpu[-1] == 0\` (fresh prefill with prompt shorter than the CSA \`ratio\`), the kernel grid:

\`\`\`cpp
dim3((num_tokens + BLOCK_Y_SIZE - 1) / BLOCK_Y_SIZE, ...)
\`\`\`

becomes \`grid.x = 0\` and the HIP launcher rejects it.

**Fix**: clamp \`cu_committed_cpu[-1]\` to ≥1 in \`_build_v4_indexer_meta\`. The dummy +1 row gets gathered from the last seq's first cache block but is never read downstream — \`fp8_mqa_logits\` and \`top_k_per_row_prefill\` honor per-token \`cu_starts\`/\`cu_ends\` derived from \`cu_committed_gpu[:-1]\` and \`n_committed_per_seq\`, which both remain 0. Output stays all -1 sentinels, matching the all-empty semantics.

This is pure host-side scalar arithmetic on a value already host-synced (\`int(cu_committed_cpu[-1])\`); no new CG/torch.compile graph branch is introduced.

## Local Verification

triton 3.7.0+amd.rocm7.1.0 (closest to CI's 3.6.0+rocm7.2.3, both reproduce the OOM):

- DeepSeek-V4-Pro server starts successfully (no SMEM OOM)
- 1-token \"Hi\" curl returns successfully (was crashing pre-fix)
- GSM8K-50 fewshot=5 = **0.94** (matches pre-#703 baseline 0.92~0.96)

## Test plan

- [ ] Re-run V4-Pro accuracy CI step
- [ ] Verify other AMD CDNA4 MoE workloads (gpt-oss-120b, Kimi-K2.5) regress at most by perf, not correctness