### PR TITLE
[fix](plugin): remove qkv arg in vllm-atom

### DIFF
--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -722,7 +722,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         2. Core attention (custom op)
         3. Output projection
         """
-        num_tokens = hidden_states.size(0)
 
         # ============================================================
         # Part 1: Input Projection

--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -11,7 +11,6 @@ from atom.plugin.prepare import is_vllm, is_sglang
 from atom.utils import CpuGpuBuffer, envs
 from atom.utils.block_convert import kv_indices_generate_triton
 from atom.config import get_current_atom_config
-
 from atom.utils.forward_context import Context, AttentionMetaData
 from atom.model_ops.attention_mha import PagedAttentionImpl
 from atom.model_ops.attention_mla import MLAAttention, _MLA_MIN_HEADS
@@ -2316,13 +2315,16 @@ def unified_attention_with_output_base_for_plugin_mode(
         return self.o_proj(output)
     else:
         self = atom_config.compilation_config.static_forward_context[layer_name]
+
         # here is the standard vllm attention impl interface
         # when using fusion, we need to pass the qkv and positions through the q,k,v
         # [watch out] accept_output_buffer must be False for plugin mode
         # because we don't want vllm to manipulate the q k v and output buffer
         # ATOM needs to handle all of the buffer here
+        # Positions for compiled unified_attention are provided via vLLM ForwardContext
+        # (atom_positions) in ATOMModelBase.forward, not via this Python arg.
         if envs.ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION:
-            output = self.attn(q, positions, qkv)
+            output = self.attn(q, k, v)
         else:
             # calculate the q and k with rotary embedding
             if self.rotary_emb is not None:

--- a/atom/plugin/attention_mha.py
+++ b/atom/plugin/attention_mha.py
@@ -116,10 +116,10 @@ class PagedAttentionImplPluginModeMethods:
                 v = v.view(-1, kv_size)
 
                 q, k = triton_fused_norm_rope_cache(
-                    q=q,
-                    k=k,
-                    v=v,
-                    position=position,
+                    q,
+                    k,
+                    v,
+                    position,
                     q_norm=self.q_norm,
                     k_norm=self.k_norm,
                     rotary_emb=self.rotary_emb,

--- a/atom/plugin/attention_mha.py
+++ b/atom/plugin/attention_mha.py
@@ -12,6 +12,7 @@ from aiter import dtypes, fused_qk_norm_rope_cache_quant_shuffle
 from aiter.ops.triton.fused_kv_cache import fused_qk_rope_reshape_and_cache
 from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
 from typing import TYPE_CHECKING, Optional
+from atom.config import get_current_atom_config
 from atom.utils import envs
 from atom.model_ops.base_attention import cp_mha_gather_cache
 
@@ -108,17 +109,17 @@ class PagedAttentionImplPluginModeMethods:
                     triton_fused_norm_rope_cache,
                 )
 
-                # qkv is a packed [q, k, v] tensor — split
                 q_size = self.num_heads * self.head_dim
                 kv_size = self.num_kv_heads * self.head_dim
-                q_raw, k_raw, v_raw = torch.split(
-                    qkv, [q_size, kv_size, kv_size], dim=-1
-                )
+                q = q.view(-1, q_size)
+                k = k.view(-1, kv_size)
+                v = v.view(-1, kv_size)
+
                 q, k = triton_fused_norm_rope_cache(
-                    q_raw,
-                    k_raw,
-                    v_raw,
-                    position,
+                    q=q,
+                    k=k,
+                    v=v,
+                    position=position,
                     q_norm=self.q_norm,
                     k_norm=self.k_norm,
                     rotary_emb=self.rotary_emb,
@@ -135,11 +136,13 @@ class PagedAttentionImplPluginModeMethods:
                 # Reshape q, k for attention: [T, num_heads, head_dim]
                 q = q.view(-1, self.num_heads, self.head_dim)
                 k = k.view(-1, self.num_kv_heads, self.head_dim)
-                v = v_raw.view(-1, self.num_kv_heads, self.head_dim)
+                v = v.view(-1, self.num_kv_heads, self.head_dim)
             else:
                 # Standard RMSNorm — use existing aiter kernel
                 fused_qk_norm_rope_cache_quant_shuffle(
-                    qkv,
+                    q=q,
+                    k=k,
+                    v=v,
                     num_heads_q=self.num_heads,
                     num_heads_k=self.num_kv_heads,
                     num_heads_v=self.num_kv_heads,
@@ -159,18 +162,9 @@ class PagedAttentionImplPluginModeMethods:
                     k_scale=k_scale,
                     v_scale=v_scale,
                 )
-
-                qkv = qkv.view(qkv.shape[0], -1, self.head_dim)
-                q, k, v = qkv.split(
-                    [self.num_heads, self.num_kv_heads, self.num_kv_heads], dim=1
-                )
         elif use_triton_attn and self.rotary_emb is not None:
             k_scale = v_scale = self.per_tensor_scale
             self.per_token_quant = False
-            qkv = qkv.view(qkv.shape[0], -1, self.head_dim)
-            q, k, v = qkv.split(
-                [self.num_heads, self.num_kv_heads, self.num_kv_heads], dim=1
-            )
             q, k, _k_cache, _v_cache = fused_qk_rope_reshape_and_cache(
                 q,
                 k,
@@ -566,19 +560,22 @@ class PagedAttentionImplPluginModeMethods:
         if attn_metadata is None:
             return output.fill_(0)
 
-        # When using the fusion path (ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION),
-        # positions and qkv tuple are smuggled through k, v args.
-        if ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION:
-            assert (
-                position is None
-            ), "position should be None because it is passed through k"
+        # vLLM's compiled unified_attention custom op does not pass positions into
+        # impl.forward. ATOMModelBase stashes them on vLLM ForwardContext as
+        # additional_kwargs["atom_positions"] (see atom/plugin/vllm/model_wrapper.py).
+        if position is None:
+            from vllm.forward_context import (
+                get_forward_context as get_vllm_forward_context,
+                is_forward_context_available,
+            )
 
-            position = key
-            qkv = value  # packed [q, k, v] tensor
-            q_size = self.num_heads * self.head_dim
-            kv_size = self.num_kv_heads * self.head_dim
-            query, key, value = torch.split(qkv, [q_size, kv_size, kv_size], dim=-1)
-
+            if is_forward_context_available():
+                position = get_vllm_forward_context().additional_kwargs.get(
+                    "atom_positions"
+                )
+        if position is None:
+            sfc = get_current_atom_config().compilation_config.static_forward_context
+            position = sfc.get("positions")
         query = query.view(-1, self.num_heads, self.head_dim)
         key = key.view(-1, self.num_kv_heads, self.head_dim)
         value = value.view(-1, self.num_kv_heads, self.head_dim)


### PR DESCRIPTION
## Motivation

This PR fixed a RoPE/fusion mismatch in vLLM plugin mode: the compiled unified_attention op only passes Q/K/V (no positions), so impl.forward always saw position=None. Positions are actually stored on vLLM’s ForwardContext as additional_kwargs["atom_positions"] by ATOMModelBase.forward. The code had been writing to ATOM’s separate forward context, so fused kernels got wrong or missing pos_ids and failed with “Number of tokens in position_ids must match activations.”

## TEST

qwen-235B
<img width="516" height="82" alt="image" src="https://github.com/user-attachments/assets/85dffc85-5244-43a4-9aee-cf012f608b64" />

gpt-oss
<img width="517" height="75" alt="image" src="https://github.com/user-attachments/assets/1787318c-14ed-40ee-b5d8-35b9b92241c2" />
