### PR TITLE
[Triton] add fused_routing_from_topk switch

### DIFF
--- a/atom/model_ops/fused_moe_triton.py
+++ b/atom/model_ops/fused_moe_triton.py
@@ -25,6 +25,9 @@ from typing import Any
 import logging
 from math import prod
 from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.triton.fused_routing_from_topk import (
+    fused_routing_from_topk as _aiter_fused_routing_from_topk,
+)
 from atom.model_ops.utils import has_triton_kernels
 
 logger = logging.getLogger("atom")
@@ -106,6 +109,58 @@ def _swizzle_mxfp4(quant_tensor, scale):
     )
     scale = convert_layout(wrap_torch_tensor(scale), scale_layout, **scale_layout_opts)
     return quant_tensor, InFlexData(), scale
+
+
+def fused_routing_from_topk_triton(topk_weights, topk_ids, n_expts_tot):
+    """Build matmul_ogs routing data via the AITER fused-routing kernel.
+
+    Thin bridge over ``aiter.ops.triton.fused_routing_from_topk``: invokes
+    the single-CTA counting-sort kernel for small NK and packages the
+    resulting indices into the ``RoutingData`` / ``GatherIndx`` /
+    ``ScatterIndx`` structures consumed by
+    ``triton_kernels.matmul_ogs``. For ``NK = n_tokens * n_expts_act``
+    above the kernel's single-CTA budget (prefill-shaped inputs), falls
+    back to the multi-kernel ``routing_from_topk`` reference defined
+    below — that path does the per-row sort + global stable argsort in
+    plain torch and is correctness-stable at any NK.
+
+    Equivalence vs reference: the fused kernel skips the per-row sort,
+    so ``topk_indx`` / ``gate_indx`` differ at intra-expert ordering.
+    ``hist`` and the per-(token, expert, weight) bucket assignments
+    match exactly; ``matmul_ogs`` is commutative over per-expert slices
+    so the MoE output is unchanged (up to FP non-associativity).
+    """
+    if not has_triton_kernels():
+        return routing_from_topk(topk_weights, topk_ids, n_expts_tot)
+
+    n_tokens, n_expts_act = topk_weights.shape
+    n_gates_pad = n_tokens * n_expts_act
+
+    if n_gates_pad > 4096:
+        # Single-CTA design exceeded; fall back rather than degrading
+        # silently. Typically only hit during prefill.
+        return routing_from_topk(topk_weights, topk_ids, n_expts_tot)
+
+    hist, topk_indx, gate_indx, gate_scal = _aiter_fused_routing_from_topk(
+        topk_weights, topk_ids, n_expts_tot
+    )
+
+    # Package as the matmul_ogs routing data structures.
+    from triton_kernels.routing import (
+        RoutingData,
+        GatherIndx,
+        ScatterIndx,
+        compute_expt_data,
+    )
+
+    gather_indx = GatherIndx(src_indx=topk_indx, dst_indx=gate_indx)
+    scatter_indx = ScatterIndx(src_indx=gate_indx, dst_indx=topk_indx)
+    expt_data = compute_expt_data(hist, n_expts_tot, n_gates_pad)
+
+    routing_data = RoutingData(
+        gate_scal, hist, n_expts_tot, n_expts_act, expt_data
+    )
+    return routing_data, gather_indx, scatter_indx
 
 
 def routing_from_topk(topk_weights, topk_ids, n_expts_tot):

--- a/atom/model_ops/fused_moe_triton.py
+++ b/atom/model_ops/fused_moe_triton.py
@@ -157,9 +157,7 @@ def fused_routing_from_topk_triton(topk_weights, topk_ids, n_expts_tot):
     scatter_indx = ScatterIndx(src_indx=gate_indx, dst_indx=topk_indx)
     expt_data = compute_expt_data(hist, n_expts_tot, n_gates_pad)
 
-    routing_data = RoutingData(
-        gate_scal, hist, n_expts_tot, n_expts_act, expt_data
-    )
+    routing_data = RoutingData(gate_scal, hist, n_expts_tot, n_expts_act, expt_data)
     return routing_data, gather_indx, scatter_indx
 
 

--- a/atom/model_ops/fused_moe_triton.py
+++ b/atom/model_ops/fused_moe_triton.py
@@ -25,7 +25,7 @@ from typing import Any
 import logging
 from math import prod
 from aiter.jit.utils.chip_info import get_gfx
-from aiter.ops.triton.fused_routing_from_topk import (
+from aiter.ops.triton.fusions.fused_routing_from_topk import (
     fused_routing_from_topk as _aiter_fused_routing_from_topk,
 )
 from atom.model_ops.utils import has_triton_kernels

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -946,7 +946,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             from atom.model_ops.fused_moe_triton import (
                 triton_kernel_moe_forward,
                 triton_kernel_fused_experts,
-                routing_from_topk,
                 fused_routing_from_topk_triton,
             )
 

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -947,6 +947,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 triton_kernel_moe_forward,
                 triton_kernel_fused_experts,
                 routing_from_topk,
+                fused_routing_from_topk_triton,
             )
 
             # Check if the model needs custom routing that triton routing()
@@ -981,7 +982,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 if global_num_experts > 0:
                     n_expts_tot = global_num_experts
 
-                routing_data, gather_idx, scatter_idx = routing_from_topk(
+                routing_data, gather_idx, scatter_idx = fused_routing_from_topk_triton(
                     topk_weights, topk_ids, n_expts_tot
                 )
 


### PR DESCRIPTION
This PR depends on https://github.com/ROCm/aiter/pull/3096

The inter-decode-layer "bubbles" are due to poorly captured multi-stream trace, in which the MOE path is not correctly captured, the topk routing is within that path and it's composed of +10 small torch kernel. This contributes to the ~275 us "bubble" seen in the trace:
<img width="1283" height="344" alt="image" src="https://github.com/user-attachments/assets/6476dfe5-94d3-4544-a43e-969bdb47b237" />

after fusing all those ops into a single triton fused kernel, the gap closes down to ~160 us:
<img width="1946" height="390" alt="image" src="https://github.com/user-attachments/assets/fb6be1f0-7d03-402b-bd6f-a06630b012c0" />

lm_eval with fused topk
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  | 0.96|±  |0.0197|
|     |       |strict-match    |     3|exact_match|↑  | 0.96|±  |0.0197|
```

+15% total token throughput end-to-end

baseline
```
Maximum request concurrency: 64
============ Serving Benchmark Result ============
Successful requests:                     512       
Benchmark duration (s):                  209.11    
Total input tokens:                      524288    
Total generated tokens:                  524288    
Request throughput (req/s):              2.45      
Output token throughput (tok/s):         2507.24   
Total Token throughput (tok/s):          5014.49   
---------------Time to First Token----------------
Mean TTFT (ms):                          1109.65   
Median TTFT (ms):                        1088.55   
P99 TTFT (ms):                           1956.70   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          24.46     
Median TPOT (ms):                        24.40     
P99 TPOT (ms):                           25.40     
---------------Inter-token Latency----------------
Mean ITL (ms):                           24.43     
Median ITL (ms):                         23.98     
P99 ITL (ms):                            26.45     
==================================================
```

fused topk
```
Maximum request concurrency: 64
============ Serving Benchmark Result ============
Successful requests:                     512       
Benchmark duration (s):                  181.92    
Total input tokens:                      524288    
Total generated tokens:                  524288    
Request throughput (req/s):              2.81      
Output token throughput (tok/s):         2881.92   
Total Token throughput (tok/s):          5763.84   
---------------Time to First Token----------------
Mean TTFT (ms):                          1072.04   
Median TTFT (ms):                        1103.72   
P99 TTFT (ms):                           1811.84   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.17     
Median TPOT (ms):                        21.17     
P99 TPOT (ms):                           22.36     
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.15     
Median ITL (ms):                         20.57     
P99 ITL (ms):                            23.65     
==================================================
```
