### PR TITLE
perf(deepseek_v4): use aiter silu_and_mul with in-kernel clamp

### DIFF
--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1720,18 +1720,25 @@ class Expert(nn.Module):
         x: torch.Tensor,  # [num_tokens, dim]
         weights: Optional[torch.Tensor] = None,  # [num_tokens, 1]  optional gate
     ) -> torch.Tensor:  # [num_tokens, dim]
+        from aiter import silu_and_mul as aiter_silu_and_mul
+
         dtype = x.dtype
-        # Single fused GEMM, then chunk(2) along last dim so TP-sharded per-rank
-        # output (inter_dim_per_tp * 2) is split correctly regardless of tp_size.
-        combined = self.gate_up_proj(x).float()  # [num_tokens, 2*inter_dim_per_tp]
-        gate, up = combined.chunk(2, dim=-1)  # each [num_tokens, inter_dim_per_tp]
-        if self.swiglu_limit > 0:
-            up = torch.clamp(up, min=-self.swiglu_limit, max=self.swiglu_limit)
-            gate = torch.clamp(gate, max=self.swiglu_limit)
-        x = F.silu(gate) * up  # [num_tokens, inter_dim_per_tp]
+        # Single fused GEMM. Layout is [gate | up] concat on last dim — matches
+        # aiter silu_and_mul's split([d, d], dim=-1) contract. The kernel does
+        # silu/clamp/mul in fp32 internally regardless of input dtype, so we
+        # feed the bf16 GEMM output directly.
+        combined = self.gate_up_proj(x)  # [num_tokens, 2*inter_dim_per_tp]
+        out = torch.empty(
+            (combined.shape[0], combined.shape[-1] // 2),
+            dtype=dtype,
+            device=combined.device,
+        )
+        # limit > 0 enables in-kernel clamp (gate≤limit, up∈[-limit,limit]) via
+        # ROCm v_med3_f32 — same semantics as the prior torch.clamp pair.
+        aiter_silu_and_mul(out, combined, self.swiglu_limit)
         if weights is not None:
-            x = weights * x
-        return self.w2(x.to(dtype))  # [num_tokens, dim]
+            out = weights.to(dtype) * out
+        return self.w2(out)  # [num_tokens, dim]
 
 
 class MoE(nn.Module):


### PR DESCRIPTION
## Summary

Replace the `chunk + double torch.clamp + F.silu * up` sequence in `Expert.forward`
(`atom/models/deepseek_v4.py`) with a single `aiter.silu_and_mul(out, combined, limit)`
call. The new `limit` parameter folds the `swiglu_limit` clamp (`gate <= limit`,
`up in [-limit, limit]`) into the kernel via the AMD `v_med3_f32` intrinsic, removing
several launch-bound ops on the per-token critical path.

## Dependency

Requires aiter PR [ROCm/aiter#3104](https://github.com/ROCm/aiter/pull/3104) (already
merged), which adds the `limit` argument and `HAS_LIMIT` compile-time specialization
to `silu_and_mul`. Without that aiter change the new third positional argument is
not accepted.

## Semantics

The aiter kernel does:

```
x, y = input.split([d, d], dim=-1)
if limit > 0:
    x = min(x, limit)
    y = clamp(y, -limit, limit)
out = silu(x) * y
```

This matches the previous Python sequence exactly:

- Layout `[gate | up]` on last dim matches `split([d, d], dim=-1)`.
- `gate` clamp is upper-bound only (`min(x, limit)` <-> `torch.clamp(gate, max=limit)`).
- `up` clamp is symmetric (`fmed3` <-> `torch.clamp(up, min=-limit, max=limit)`).
- `limit <= 0` skips the clamp branch (compile-time HAS_LIMIT=false fast path).

The kernel computes silu/clamp/mul in fp32 internally regardless of input dtype,
so the prior `.float()` upcast on the GEMM output is no longer needed.

## Test Plan

DeepSeek-V4-Pro, tp=8, `--level 0`, GSM8K `nshot=5`,
env: `AITER_BF16_FP8_MOE_BOUND=0` + `ATOM_MOE_GU_ITLV=1`:

| Run | flexible-extract | strict-match |
|---|---|---|
| 1 | 0.9515 (+/- 0.0059) | 0.9522 (+/- 0.0059) |
| 2 | 0.9522 (+/- 0.0059) | 0.9530 (+/- 0.0058) |

Matches the V4-Pro baseline (0.9522 / 0.9530) within 1 sigma stderr. No accuracy
regression on the aiter MoE + FP8 activation + GU-interleave path.

- [x] `ruff check atom/models/deepseek_v4.py` passes
- [x] GSM8K accuracy verified (two independent runs)
- [ ] CI smoke / accuracy job