### PR TITLE
perf(deepseek_v4): unified aiter rmsnorm_quant + q_norm/wkv_gate fuses

### DIFF
--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -190,13 +190,11 @@ jobs:
           MODEL_MOUNT=""
           [ -d "/models" ] && MODEL_MOUNT="-v /models:/models"
 
-          # Build env var flags from model config
-          ENV_FLAGS=""
-          if [ -n "${{ matrix.model.env_vars }}" ]; then
-            for ev in ${{ matrix.model.env_vars }}; do
-              ENV_FLAGS="$ENV_FLAGS -e $ev"
-            done
-          fi
+          # Write env_vars via env block (avoids expression injection — newlines
+          # in `matrix.model.env_vars` would otherwise break the host bash).
+          # Empty file when MODEL_ENV_VARS unset is fine — docker --env-file
+          # accepts it.
+          printenv MODEL_ENV_VARS 2>/dev/null | grep -v '^$' > /tmp/atom_benchmark_env.txt || true
 
           docker run -dt --device=/dev/kfd $DEVICE_FLAG \
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace $MODEL_MOUNT \
@@ -210,11 +208,12 @@ jobs:
             -e CONC=${{ env.CONC }} -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }} \
             -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
             -e ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
-            $ENV_FLAGS \
+            --env-file /tmp/atom_benchmark_env.txt \
             --name atom-benchmark \
             ${{ inputs.image || 'rocm/atom-dev:latest' }}
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          MODEL_ENV_VARS: ${{ matrix.model.env_vars }}
 
       - name: Collect GPU info (inside container)
         id: gpu-info
@@ -559,13 +558,9 @@ jobs:
           MODEL_MOUNT=""
           [ -d "/models" ] && MODEL_MOUNT="-v /models:/models"
 
-          # Build env var flags from model config
-          ENV_FLAGS=""
-          if [ -n "${{ matrix.cell.env_vars }}" ]; then
-            for ev in ${{ matrix.cell.env_vars }}; do
-              ENV_FLAGS="$ENV_FLAGS -e $ev"
-            done
-          fi
+          # Write env_vars via env block (avoids expression injection — newlines
+          # in `matrix.cell.env_vars` would otherwise break the host bash).
+          printenv CELL_ENV_VARS 2>/dev/null | grep -v '^$' > /tmp/atom_regression_env.txt || true
 
           docker run -dt --device=/dev/kfd $DEVICE_FLAG \
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace $MODEL_MOUNT \
@@ -575,11 +570,12 @@ jobs:
             --security-opt seccomp=unconfined \
             --ulimit memlock=-1 --ulimit stack=67108864 --pull always \
             -e ATOM_DISABLE_MMAP=true \
-            $ENV_FLAGS \
+            --env-file /tmp/atom_regression_env.txt \
             --name atom-regression \
             ${{ inputs.image || 'rocm/atom-dev:latest' }}
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          CELL_ENV_VARS: ${{ matrix.cell.env_vars }}
 
       - name: Download model
         run: |
@@ -595,8 +591,12 @@ jobs:
           if [ -d "/models" ]; then MODEL_DIR="/models/${{ matrix.cell.model_path }}"
           else MODEL_DIR="${{ matrix.cell.model_path }}"; fi
 
+          # cell.env_vars are already injected into the container env via
+          # --env-file in "Start CI container" — `docker exec` inherits them,
+          # so no need to re-prefix them on the command line (the previous
+          # inline form silently dropped the first var when env_vars contained
+          # a literal newline).
           docker exec atom-regression bash -lc "set -euo pipefail
-            ${{ matrix.cell.env_vars }} \
             ENABLE_TORCH_PROFILER=1 \
             .github/scripts/atom_test.sh launch $MODEL_DIR ${{ matrix.cell.server_args }}"
 

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -119,51 +119,93 @@ def fused_add_rmsnorm_pad_(
     return fused_add_rmsnorm_pad(x, weight, epsilon, res, x_pad_to_multiple)
 
 
-def mxfp4_rms_quant_fuse_fake(
+# ---------------------------------------------------------------------------
+# Aiter dynamic RMSNorm + quant — single dispatch covering per_1x32 (MXFP4),
+# per_1x128 (FP8 block), and per_Token (FP8). All three reach
+# aiter.{rmsnorm_quant, add_rmsnorm_quant} (HIP) which both normalizes and
+# emits a freshly-computed scale, so callers must have x_scale=None
+# (static-scale FP8 stays on its own branch). Per-quant params (out_dtype,
+# scale shape, group_size, shuffle_scale) are derived from quant_type_value
+# inside the fake helper so torch.compile's schema infer sees a single,
+# stable signature.
+#
+# `mutates_args=[]` keeps torch.compile from functionalizing the out-buffers
+# — same pattern as the legacy mxfp4 fuse helper.
+# ---------------------------------------------------------------------------
+
+_QV_PER_1X32 = QuantType.per_1x32.value
+_QV_PER_1X128 = QuantType.per_1x128.value
+_QV_PER_TOKEN = QuantType.per_Token.value
+_AITER_RMS_QUANT_TYPE_VALUES = frozenset({_QV_PER_1X32, _QV_PER_1X128, _QV_PER_TOKEN})
+
+
+def _aiter_rms_quant_fake(
     x: torch.Tensor,
     weight: torch.Tensor,
     eps: float,
-    shuffle: bool = False,
+    quant_type_value: int,
+    transpose_scale: bool,
     res1: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    from aiter.utility.dtypes import fp8
+
     M, N = x.shape
-    out = torch.empty((M, N // 2), dtype=torch.float4_e2m1fn_x2, device=x.device)
-    MXFP4_QUANT_BLOCK_SIZE = 32
-    SCALE_N_valid = (N + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE
-    use_scale_shuffle_padding = shuffle
-    if use_scale_shuffle_padding:
-        SCALE_M = ((M + 255) // 256) * 256
-        SCALE_N = ((SCALE_N_valid + 7) // 8) * 8
-    else:
-        SCALE_M = M
-        SCALE_N = SCALE_N_valid
-    scale = torch.empty(
-        (SCALE_M, SCALE_N),
-        dtype=torch.float8_e8m0fnu,
-        device=x.device,
-    )
-    out_res1 = None
-    if res1 is not None:
-        out_res1 = torch.empty_like(res1)
+    if quant_type_value == _QV_PER_1X32:
+        # MXFP4: out=(M, N/2) fp4x2; scale=(⌈M/256⌉*256, ⌈⌈N/32⌉/8⌉*8) UE8M0
+        # bytes (kernel writes one uint8 per group; passing fp8_e8m0fnu
+        # directly yields the matching byte layout — no fp32 view).
+        out = torch.empty((M, N // 2), dtype=torch.float4_e2m1fn_x2, device=x.device)
+        scale_m = ((M + 255) // 256) * 256
+        scale_n = ((((N + 31) // 32) + 7) // 8) * 8
+        scale = torch.empty(
+            (scale_m, scale_n), dtype=torch.float8_e8m0fnu, device=x.device
+        )
+    elif quant_type_value == _QV_PER_1X128:
+        # FP8 per-block: scale=(M, ⌈N/128⌉) fp32. Preshuffle GEMM expects
+        # column-major; allocate (num_groups, M) row-major then view as
+        # (M, num_groups). Matches GemmaRMSNorm._forward_fused_fp8.
+        out = torch.empty((M, N), dtype=fp8, device=x.device)
+        num_groups = N // 128
+        if transpose_scale:
+            scale = torch.empty(
+                (num_groups, M), dtype=torch.float32, device=x.device
+            ).view(M, num_groups)
+        else:
+            scale = torch.empty((M, num_groups), dtype=torch.float32, device=x.device)
+    else:  # _QV_PER_TOKEN
+        out = torch.empty((M, N), dtype=fp8, device=x.device)
+        scale = torch.empty((M, 1), dtype=torch.float32, device=x.device)
+    out_res1 = torch.empty_like(res1) if res1 is not None else None
     return (out, scale, out_res1)
 
 
-# It's important to use mutates_args=[] to avoid functionized_v2 op generation
-@torch_compile_guard(gen_fake=mxfp4_rms_quant_fuse_fake, mutates_args=[])
-def mxfp4_rms_quant_fuse(
+@torch_compile_guard(gen_fake=_aiter_rms_quant_fake, mutates_args=[])
+def _aiter_rms_quant(
     x: torch.Tensor,
     weight: torch.Tensor,
     eps: float,
-    shuffle: bool = False,
+    quant_type_value: int,
+    transpose_scale: bool,
     res1: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    from aiter.ops.triton.fused_mxfp4_quant import fused_rms_mxfp4_quant
+    from aiter import add_rmsnorm_quant, rmsnorm_quant
 
-    (x_quant, x_scale), _, _, residual_out = fused_rms_mxfp4_quant(
-        x, weight, eps, shuffle=shuffle, res1=res1
+    out, scale, out_res1 = _aiter_rms_quant_fake(
+        x, weight, eps, quant_type_value, transpose_scale, res1
     )
-
-    return x_quant, x_scale, residual_out
+    if quant_type_value == _QV_PER_1X32:
+        group_size, shuffle = 32, True
+    elif quant_type_value == _QV_PER_1X128:
+        group_size, shuffle = 128, transpose_scale
+    else:  # _QV_PER_TOKEN
+        group_size, shuffle = 0, False
+    if res1 is None:
+        rmsnorm_quant(out, x, scale, weight, eps, group_size, shuffle)
+    else:
+        add_rmsnorm_quant(
+            out, x, res1, out_res1, scale, weight, eps, group_size, shuffle
+        )
+    return out, scale, out_res1
 
 
 class RMSNorm(nn.Module):
@@ -195,6 +237,14 @@ class RMSNorm(nn.Module):
         params_dtype = layer_quant_config.quant_dtype
         self.quant_type = quant_type
         self.params_dtype = params_dtype
+        # transpose_scale (column-major scale) only applies to per_1x128 with
+        # the preshuffle GEMM consumer; resolve the env once at init time so
+        # forward sees a hot static bool instead of an env lookup per call.
+        self._aiter_transpose_scale = (
+            fused_quant
+            and quant_type.value == _QV_PER_1X128
+            and envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
+        )
 
     @mark_trace(prefix="rmsnorm", torch_compile=True)
     def forward(
@@ -263,19 +313,24 @@ class RMSNorm(nn.Module):
                         res1=residual,
                     )
                     return (x, x_scale), residual
-            elif self.use_fused_quant and (
-                x_scale is None and self.quant_type.value == QuantType.per_1x32.value
+            elif (
+                self.use_fused_quant
+                and x_scale is None
+                and self.quant_type.value in _AITER_RMS_QUANT_TYPE_VALUES
             ):
+                # Dynamic-scale fused RMSNorm + quant via aiter HIP kernels.
+                # Static FP8 (x_scale provided) stays on the branch above.
+                x, x_scale, residual_out = _aiter_rms_quant(
+                    x,
+                    self.weight,
+                    self.eps,
+                    self.quant_type.value,
+                    self._aiter_transpose_scale,
+                    residual,
+                )
                 if residual is None:
-                    x, x_scale, _ = mxfp4_rms_quant_fuse(
-                        x, self.weight, self.eps, shuffle=True
-                    )
                     return x, x_scale
-                else:
-                    x, x_scale, residual = mxfp4_rms_quant_fuse(
-                        x, self.weight, self.eps, shuffle=True, res1=residual
-                    )
-                    return (x, x_scale), residual
+                return (x, x_scale), residual_out
             else:
                 if residual is None:
                     # return rmsnorm2d_fwd(x, self.weight, self.eps).view(ori_shape)

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -769,12 +769,14 @@ class Compressor(nn.Module):
         d = self.head_dim
         rd = self.rope_head_dim
 
-        # Single fused BF16 GEMM via tgemm; otype=fp32 keeps softmax-pool
-        # accumulator in fp32. torch.split returns zero-copy strided views;
-        # downstream kernels (fused_compress_attn, update_compressor_states)
-        # accept strided kv/score (only inner stride must be 1).
+        # Single fused BF16 GEMM via tgemm. (Probing whether dropping the
+        # otype=fp32 upcast — relying on fused_compress_attn's internal fp32
+        # accumulator instead — is accuracy-neutral.) torch.split returns
+        # zero-copy strided views; downstream kernels (fused_compress_attn,
+        # update_compressor_states) accept strided kv/score (only inner
+        # stride must be 1).
         coff_d = (1 + overlap) * d
-        combined = self.wkv_gate(x, otype=torch.float32)
+        combined = self.wkv_gate(x)
         kv, score = torch.split(combined, [coff_d, coff_d], dim=-1)
 
         # ====== Unified fused kernel path (CSA + Indexer) ======
@@ -920,8 +922,11 @@ class Indexer(nn.Module):
     def forward_batched(
         self,
         x_full: torch.Tensor,  # [total_tokens, dim]
-        qr_full: torch.Tensor,  # [total_tokens, q_lora_rank]
+        qr_full: torch.Tensor,  # [total_tokens, q_lora_rank] — fp8 when qr_full_scale given
         positions: torch.Tensor,  # [total_tokens]
+        qr_full_scale: Optional[
+            torch.Tensor
+        ] = None,  # per_1x128 scale paired with qr_full
     ) -> torch.Tensor:
         """Q proj + RoPE + FP8-quant + weights compute (have module state),
         then dispatch to `torch.ops.aiter.indexer_score_topk`, which calls
@@ -946,7 +951,9 @@ class Indexer(nn.Module):
         # Q proj + RoPE + rotate (batched). rotary_emb internally reshapes
         # to (1, num_tokens, -1, rotary_dim) so the input doesn't need an
         # explicit batch dim. rotate_activation is last-dim-only.
-        q = self.wq_b(qr_full).view(total_tokens, self.n_heads, self.head_dim)
+        q = self.wq_b(qr_full, x_scale=qr_full_scale).view(
+            total_tokens, self.n_heads, self.head_dim
+        )
         # self.rotary_emb(positions, q[..., -rd:])
         # q = rotate_activation(q)
         cos, sin = self.rotary_emb._caches(q.device)
@@ -1235,7 +1242,16 @@ class DeepseekV4Attention(nn.Module):
             quant_config=qc,
             prefix=f"{p}.wqkv_a",
         )
-        self.q_norm = RMSNorm(self.q_lora_rank, self.eps)
+        # Fuse q_norm + per_1x128 FP8 quant: kernel emits (qr_fp8, qr_scale)
+        # in one launch, both wq_b consumers (outer ColumnParallel + Indexer
+        # ReplicatedLinear) skip their own input quant.
+        self.q_norm = RMSNorm(
+            self.q_lora_rank,
+            self.eps,
+            fused_quant=True,
+            quant_config=qc,
+            prefix=f"{p}.q_norm",
+        )
         # q_norm2: per-head Q normalization. The checkpoint has no
         # `q_norm2.weight` entry, so the module is constructed with
         # `weight=None` (no learnable Parameter) — `DualRMSNorm` reads the
@@ -1451,15 +1467,17 @@ class DeepseekV4Attention(nn.Module):
         # Single fused FP8 GEMM for [wq_a; wkv]; torch.split returns zero-copy views.
         qkv_a = self.wqkv_a(x)
         q_lora, kv_pre = torch.split(qkv_a, [self.q_lora_rank, self.head_dim], dim=-1)
-        qr = self.q_norm(q_lora)  # [num_tokens, q_lora_rank]  shared with Indexer
-        if _V4_FORCE_UE8M0_QUANT:
-            qr = qr.clone()
-            act_quant_inplace(qr, 128, "ue8m0")
+        # q_norm is fused-quant: returns (qr_fp8, qr_scale) — shared by
+        # outer wq_b and Indexer.wq_b, both per_1x128 FP8 GEMMs.
+        assert (
+            not _V4_FORCE_UE8M0_QUANT
+        ), "_V4_FORCE_UE8M0_QUANT incompatible with fused q_norm quant (qr is already FP8)"
+        qr, qr_scale = self.q_norm(q_lora)
         # Flat q_flat is [num_tokens, n_local_heads * head_dim]; DualRMSNorm
         # views internally to per-head shape and returns flat. Single Triton
         # launch fuses per-head Q RMSNorm (weightless) + KV RMSNorm (both
         # head_dim=128), replacing the prior `_rmsnorm_nw + kv_norm` pair.
-        q_flat = self.wq_b(qr)
+        q_flat = self.wq_b(qr, x_scale=qr_scale)
         q_flat, kv = self.qk_norm(q_flat, kv_pre)
         q = q_flat.view(num_tokens, self.n_local_heads, self.head_dim)
         # q [S, H, D] / kv [S, head_dim] — rotary_emb internally unsqueezes
@@ -1513,6 +1531,7 @@ class DeepseekV4Attention(nn.Module):
             indexer_topk_batched = self.indexer.forward_batched(
                 x_full=x,
                 qr_full=qr,
+                qr_full_scale=qr_scale,
                 positions=positions,
             )  # raw seq-local [T, index_topk] int32, -1 sentinels in tail cols
             # Translate seq-local topk → physical paged offsets and write into


### PR DESCRIPTION
## Summary

Three related changes that together cut input-quant overhead on V4-Pro
attention:

1. **`atom/model_ops/layernorm.py`** — single dispatch covering all dynamic
   quant types (`per_1x32`, `per_1x128`, `per_Token`).
2. **`atom/models/deepseek_v4.py`** — fuse `q_norm` with `wq_b` input quant,
   plus drop the `otype=fp32` upcast on `wkv_gate`.
3. **`.github/workflows/atom-benchmark.yaml`** — fix `env_vars` expression
   injection bug (CI for V4-Pro currently fails with bash `syntax error
   near unexpected token` because multi-line JSON values get inlined into
   a `for` loop).

## 1. Unified `aiter.rmsnorm_quant` dispatch

Replaces the mxfp4-only triton wrapper (`mxfp4_rms_quant_fuse`) with a single
helper that calls `aiter.{rmsnorm_quant, add_rmsnorm_quant}` (HIP) and
dispatches on `quant_type`:

| QuantType | aiter params |
|---|---|
| `per_1x32` (MXFP4) | `out=fp4x2`, `group_size=32`, `shuffle_scale=True`; scale held as `fp8_e8m0fnu` (no fp32 view) |
| `per_1x128` (FP8 block) | `out=fp8`, `group_size=128`, `shuffle_scale=ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE` |
| `per_Token` (FP8) | `out=fp8`, `group_size=0`, `shuffle_scale=False` |

`_aiter_transpose_scale` is resolved once at `RMSNorm.__init__` so forward
sees a hot static bool instead of an env lookup per call. The legacy
`mxfp4_rms_quant_fuse` is removed (no remaining callers).

## 2. V4 q_norm fuse + wkv_gate dtype

- **q_norm + per_1x128 FP8 quant fused into one launch.** The output
  `(qr_fp8, qr_scale)` is shared by both the outer `wq_b` (ColumnParallel)
  and the Indexer's `wq_b` (ReplicatedLinear) — saves two redundant input
  quants per layer.
- **`wkv_gate` no longer requests `otype=fp32`.** `fused_compress_attn`
  and `update_compressor_states` both upcast inputs internally
  (`tl.load(...).to(tl.float32)`); the persistent `kv_state`/`score_state`
  ring buffers stay fp32, so accumulator precision is unchanged. This
  halves the (kv, score) intermediate buffer bandwidth.

## 3. CI workflow `env_vars` injection fix

`.github/benchmark/models.json` ships values like
`""env_vars"": ""AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1""`. Inlining
that string into a host-side `for ev in ${{ matrix.model.env_vars }}` made
the host bash see a literal newline mid-list:

`````
for ev in AITER_BF16_FP8_MOE_BOUND=0
ATOM_MOE_GU_ITLV=1; do
`````

→ `syntax error near unexpected token ATOM_MOE_GU_ITLV=1` (see
[failing job](https://github.com/ROCm/ATOM/actions/runs/25607119907/job/75170862075)).

Both ""Start CI container"" blocks now use the env-block + `docker --env-file`
pattern (same as `atom-test.yaml`). The third site — the regression
""Launch server"" step — had a silent variant of the same bug (the first
env var was treated as a standalone no-op assignment); the redundant
inline prefix is dropped because the vars are already in the container env
after `docker run --env-file`.

## Test Plan

DeepSeek-V4-Pro, tp=8, `--level 0`, GSM8K nshot=5,
env: `AITER_BF16_FP8_MOE_BOUND=0` + `ATOM_MOE_GU_ITLV=1`:

| Run | flexible-extract | strict-match |
|---|---|---|
| baseline | 0.9522 ±0.0059 | 0.9530 ±0.0058 |
| + `rmsnorm_quant` refactor | 0.9507 ±0.0060 | 0.9515 ±0.0059 |
| + `q_norm` fuse | 0.9538 ±0.0058 | 0.9538 ±0.0058 |
| **+ drop `wkv_gate` fp32 (this PR)** | **0.9583 ±0.0055** | **0.9591 ±0.0055** |

All within ±1σ stderr of baseline; no regression.

1024/1024 c=64 perf delta from the q_norm fuse alone:

| Metric | Before | After | Δ |
|---|---|---|---|
| Total token throughput | 2735.80 tok/s | 2813.00 tok/s | +2.8% |
| Median TPOT | 41.28 ms | 38.83 ms | -5.9% |
| Mean TTFT | 1896.65 ms | 1882.00 ms | -0.8% |

- [x] `ruff check atom/model_ops/layernorm.py atom/models/deepseek_v4.py` passes
- [x] YAML parse passes for `atom-benchmark.yaml`
- [x] GSM8K accuracy verified (no regression)
- [x] 1024/1024 c=64 microbench shows TPOT improvement
- [ ] CI smoke / accuracy job