### PR TITLE
[MoE] Align generic MXFP4 shuffle layout

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -14,7 +14,6 @@ from aiter.fused_moe import fused_moe
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.ops.shuffle import shuffle_weight, shuffle_scale
-from aiter.utility import fp4_utils
 from atom.config import (
     Config,
     QuantizationConfig,
@@ -859,46 +858,34 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_weight_scale = None
             return
 
-        elif self.quant_method == "quark" or not self.is_guinterleave:
-            shuffle_weights(layer.w13_weight, layer.w2_weight)
-            s0, s1, _ = layer.w13_weight_scale.shape
-            w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
-            w13_weight_scale = fp4_utils.e8m0_shuffle(w13_weight_scale)
-            layer.w13_weight_scale.data = w13_weight_scale.view(s0, s1, -1)
+        # shuffle weight
+        layer.w13_weight.data = shuffle_weight(
+            layer.w13_weight,
+            is_guinterleave=self.is_guinterleave,
+            gate_up=True,
+        )
+        layer.w2_weight.data = shuffle_weight(
+            layer.w2_weight,
+            is_guinterleave=self.is_guinterleave,
+            gate_up=False,
+        )
+        layer.w13_weight.is_shuffled = True
+        layer.w2_weight.is_shuffled = True
 
-            s0, s1, _ = layer.w2_weight_scale.shape
-            w2_weight_scale = layer.w2_weight_scale.view(s0 * s1, -1)
-            w2_weight_scale = fp4_utils.e8m0_shuffle(w2_weight_scale)
-            layer.w2_weight_scale.data = w2_weight_scale.view(s0, s1, -1)
-            return
-        else:
-            # self.is_guinterleave is True
-            layer.w13_weight.data = shuffle_weight(
-                layer.w13_weight,
-                is_guinterleave=True,
-                gate_up=True,
-            )
-            layer.w2_weight.data = shuffle_weight(
-                layer.w2_weight,
-                is_guinterleave=True,
-                gate_up=False,
-            )
-            layer.w13_weight.is_shuffled = True
-            layer.w2_weight.is_shuffled = True
-            shuffled_w13_scale = shuffle_scale(
-                layer.w13_weight_scale.reshape(-1, layer.w13_weight_scale.shape[-1]),
-                self.num_experts,
-                True,
-                True,
-            )
-            shuffled_w2_scale = shuffle_scale(
-                layer.w2_weight_scale.reshape(-1, layer.w2_weight_scale.shape[-1]),
-                self.num_experts,
-                True,
-                False,
-            )
-            layer.w13_weight_scale = atom_parameter(shuffled_w13_scale)
-            layer.w2_weight_scale = atom_parameter(shuffled_w2_scale)
+        # shuffle scale
+        w13_scale_2d = layer.w13_weight_scale.reshape(
+            -1, layer.w13_weight_scale.shape[-1]
+        )
+        w2_scale_2d = layer.w2_weight_scale.reshape(-1, layer.w2_weight_scale.shape[-1])
+
+        shuffled_w13_scale = shuffle_scale(
+            w13_scale_2d, self.num_experts, self.is_guinterleave, True
+        )
+        shuffled_w2_scale = shuffle_scale(
+            w2_scale_2d, self.num_experts, self.is_guinterleave, False
+        )
+        layer.w13_weight_scale = atom_parameter(shuffled_w13_scale)
+        layer.w2_weight_scale = atom_parameter(shuffled_w2_scale)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -883,6 +883,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 is_guinterleave=True,
                 gate_up=False,
             )
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
             shuffled_w13_scale = shuffle_scale(
                 layer.w13_weight_scale.reshape(-1, layer.w13_weight_scale.shape[-1]),
                 self.num_experts,

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -859,8 +859,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_weight_scale = None
             return
 
-        # quark method for moe, split it out?
-        elif self.quant_method == "quark":
+        elif self.quant_method == "quark" or not self.is_guinterleave:
             shuffle_weights(layer.w13_weight, layer.w2_weight)
             s0, s1, _ = layer.w13_weight_scale.shape
             w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
@@ -873,39 +872,31 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_weight_scale.data = w2_weight_scale.view(s0, s1, -1)
             return
         else:
-            # shuffle weight
+            # self.is_guinterleave is True
             layer.w13_weight.data = shuffle_weight(
                 layer.w13_weight,
-                is_guinterleave=self.is_guinterleave,
+                is_guinterleave=True,
                 gate_up=True,
             )
             layer.w2_weight.data = shuffle_weight(
                 layer.w2_weight,
-                is_guinterleave=self.is_guinterleave,
+                is_guinterleave=True,
                 gate_up=False,
             )
-
-            # shuffle scale
-            if self.is_guinterleave:
-                w13_scale_2d = layer.w13_weight_scale.view(
-                    -1, layer.w13_weight_scale.shape[-1]
-                )
-                w2_scale_2d = layer.w2_weight_scale.view(
-                    -1, layer.w2_weight_scale.shape[-1]
-                )
-            else:
-                w13_scale_2d = layer.w13_weight_scale.view(self.num_experts, -1)
-                w2_scale_2d = layer.w2_weight_scale.view(self.num_experts, -1)
-
             shuffled_w13_scale = shuffle_scale(
-                w13_scale_2d, self.num_experts, self.is_guinterleave, True
+                layer.w13_weight_scale.reshape(-1, layer.w13_weight_scale.shape[-1]),
+                self.num_experts,
+                True,
+                True,
             )
             shuffled_w2_scale = shuffle_scale(
-                w2_scale_2d, self.num_experts, self.is_guinterleave, False
+                layer.w2_weight_scale.reshape(-1, layer.w2_weight_scale.shape[-1]),
+                self.num_experts,
+                True,
+                False,
             )
-
-        layer.w13_weight_scale = atom_parameter(shuffled_w13_scale)
-        layer.w2_weight_scale = atom_parameter(shuffled_w2_scale)
+            layer.w13_weight_scale = atom_parameter(shuffled_w13_scale)
+            layer.w2_weight_scale = atom_parameter(shuffled_w2_scale)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module


### PR DESCRIPTION
## Summary
- Use the shared separated-layout `shuffle_weights` path for non-interleaved MXFP4 MoE weights.
- Keep the interleaved MXFP4 weight and scale shuffle path explicit.
- Mark shuffled MXFP4 weights with `is_shuffled` so AITER runtime config selection can distinguish the actual layout.
- Align ATOM's generic MXFP4 layout with AITER `GateMode.SEPARATED` expectations.

## Test plan
- Validated together with the AITER Swiglu MXFP4 path:
- `podman exec zxb_vllm_gptoss bash -lc 'cd /workdir/aiter_main && HIP_VISIBLE_DEVICES=1 FLYDSL_RUNTIME_CACHE_DIR=/tmp/flydsl_pr3123_test_fp4 AITER_CONFIG_FMOE=/workdir/aiter_main/aiter/configs/model_configs/gptoss_fp4_tuned_fmoe.csv python3 -m op_tests.test_moe_2stage --no-legacy'`
- `podman exec zxb_vllm_gptoss bash -lc 'cd /workdir/aiter_main && HIP_VISIBLE_DEVICES=1 FLYDSL_RUNTIME_CACHE_DIR=/tmp/flydsl_pr3123_test_fp8fp4 AITER_CONFIG_FMOE=/workdir/aiter_main/aiter/configs/model_configs/gptoss_fp8fp4_tuned_fmoe.csv python3 -m op_tests.test_moe_2stage --no-legacy'`
- `podman exec zxb_vllm_gptoss bash -lc 'cd /workdir/aiter_main && HIP_VISIBLE_DEVICES=1 FLYDSL_RUNTIME_CACHE_DIR=/tmp/flydsl_pr3123_test_legacy python3 -m op_tests.test_moe_2stage --no-flydsl-csv -t 1024 -dim 3072,3072 -e 128 -k 4 -q 4 -a swiglu -s f -p t -hip 0,0'`

## Test result
- GPT-OSS FP4 tuned MoE CSV: passed 8 strict cases.
- GPT-OSS FP8/FP4 tuned MoE CSV: passed 7 strict cases.
- Legacy Swiglu MXFP4 target case: passed.

Made with [Cursor](https://cursor.com)