### PR TITLE
refactor(deepseek_v4): switch MoE routing to topk_gating

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Callable, List, Optional, Tuple
 
 import torch
-from aiter import ActivationType, QuantType, dtypes, get_hip_quant, topk_softplus
+from aiter import ActivationType, QuantType, dtypes, get_hip_quant, topk_gating
 from aiter.dist.parallel_state import get_dp_group, get_tp_group
 from aiter.fused_moe import fused_moe
 from aiter.jit.utils.chip_info import get_gfx
@@ -2664,13 +2664,14 @@ class FusedMoE(torch.nn.Module):
                 topk_weights = torch.empty(
                     tokens_num, top_k, dtype=torch.float32, device=router_logits.device
                 )
-                topk_softplus(
+                topk_gating(
                     topk_weights,
                     topk_ids,
                     router_logits,
                     e_score_correction_bias,
                     renormalize,
                     routed_scaling_factor,
+                    score_func="sqrtsoftplus",
                 )
             else:
                 raise ValueError(

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1972,9 +1972,7 @@ class MoE(nn.Module):
         `forward_context.context.input_ids` before each forward, and
         `_hash_topk` (FusedMoE's custom_routing_function) reads it there.
         """
-        router_logits = self.gate(
-            x, otype=torch.float32
-        )  # [num_tokens, n_routed_experts]
+        router_logits = self.gate(x)  # [num_tokens, n_routed_experts]
         return self.experts(hidden_states=x, router_logits=router_logits)
 
     def combine_outputs(


### PR DESCRIPTION
Update DeepSeek V4 MoE routing to call aiter topk_gating with explicit sqrtsoftplus scoring, and remove the forced fp32 cast on gate output so the router logits path follows the model default dtype behavior.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
