### PR TITLE
[fix][acc][sgl-atom] fix accuracy of fp8 attn weights model using ptpc quant recipe

### DIFF
--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -27,6 +27,7 @@ from atom.model_ops.attention_mla import (
     fused_qk_rope_concat_and_cache_mla,
 )
 from atom.models.utils import maybe_prefix
+from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
 
 # sglang imports
 from sglang.srt.layers.communicator import AttentionInputs, get_attn_tp_context
@@ -129,7 +130,6 @@ def _fuse_qk_rmsnorm_and_q_quant(
     output_unquantized_q: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
     """Fuse q/k RMSNorm and q quant using ATOM's DeepSeek-V2 path."""
-    from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
 
     (q_quantized, q_scale), q_normed, k_nope_normed, _ = _fuse_rmsnorm_quant(
         q,
@@ -645,7 +645,6 @@ def forward_sgl_mha_prepare(
     hidden_states: torch.Tensor,
     **model_kwargs,
 ) -> SglMhaPrepareResult:
-    from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
 
     forward_batch = model_kwargs.get("forward_batch", None)
     if forward_batch is None:

--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 import torch
 from aiter import dtypes
 from aiter.dist.parallel_state import get_tensor_model_parallel_world_size, get_tp_group
-from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
 from atom.model_ops.base_attention import Attention
 from atom.model_ops.attention_mla import (
     dynamic_per_batched_tensor_quant,
@@ -117,6 +116,11 @@ def _unwrap_linear_output(output: Any) -> torch.Tensor:
     return output
 
 
+def _linear_quant_type_value(linear: Any) -> Optional[int]:
+    quant_type = getattr(linear, "quant_type", None)
+    return None if quant_type is None else getattr(quant_type, "value", quant_type)
+
+
 def _fuse_qk_rmsnorm_and_q_quant(
     attn: DeepseekV2MLAAttention,
     q: torch.Tensor,
@@ -139,6 +143,7 @@ def _fuse_qk_rmsnorm_and_q_quant(
         shuffle=False,
         scale_shuffle_padding=False,
         group_size=128,
+        quant_type=_linear_quant_type_value(attn.q_b_proj),
         output_unquantized_inp1=output_unquantized_q,
         transpose_scale=True,
     )
@@ -640,6 +645,8 @@ def forward_sgl_mha_prepare(
     hidden_states: torch.Tensor,
     **model_kwargs,
 ) -> SglMhaPrepareResult:
+    from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
+
     forward_batch = model_kwargs.get("forward_batch", None)
     if forward_batch is None:
         raise RuntimeError("forward_batch is required in forward_sgl_mha_prepare")
@@ -681,16 +688,17 @@ def forward_sgl_mha_prepare(
             )
 
         if _use_aiter_gfx95 and attn.q_b_proj.weight.dtype == torch.float8_e4m3fn:
-            (q, q_scale), _, _, _ = fused_rms_fp8_group_quant(
+            (q, q_scale), _, _, _ = _fuse_rmsnorm_quant(
                 q,
                 attn.q_a_layernorm.weight,
                 attn.q_a_layernorm.eps,
                 None,
                 None,
                 None,
-                group_size=128,
-                dtype_quant=torch.float8_e4m3fn,
                 res1=None,
+                dtype_quant=torch.float8_e4m3fn,
+                group_size=128,
+                quant_type=_linear_quant_type_value(attn.q_b_proj),
                 output_unquantized_inp1=False,
                 transpose_scale=True,
             )
@@ -715,16 +723,17 @@ def forward_sgl_mha_prepare(
     latent_cache = latent_cache.unsqueeze(1)
 
     if _use_aiter_gfx95 and attn.kv_b_proj.weight.dtype == torch.float8_e4m3fn:
-        (kv_a_quanted, kv_a_quanted_scale), kv_a, _, _ = fused_rms_fp8_group_quant(
+        (kv_a_quanted, kv_a_quanted_scale), kv_a, _, _ = _fuse_rmsnorm_quant(
             kv_a,
             attn.kv_a_layernorm.weight,
             attn.kv_a_layernorm.eps,
             None,
             None,
             None,
-            group_size=128,
-            dtype_quant=torch.float8_e4m3fn,
             res1=None,
+            dtype_quant=torch.float8_e4m3fn,
+            group_size=128,
+            quant_type=_linear_quant_type_value(attn.kv_b_proj),
             output_unquantized_inp1=True,
             transpose_scale=True,
         )


### PR DESCRIPTION
## Motivation

Align with #670
The quark models, [amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4](https://huggingface.co/amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4) has fp8 weight linear layers in attn and adopt ptpc quant recipe. But current code in ATOM forces block scale quant in _fuse_rmsnorm_quant. This pr fixed this issue.

## Technical Details
_fuse_rmsnorm_quant should select correct quant type based on the quant config/recipe. For per-token quant, a new kernel: fused_qk_rmsnorm_per_token_quant is added in aiter.

## Test Plan
The gsm8k dataset accuracy is validated with this pr on [amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4](https://huggingface.co/amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4) with sglang-ATOM.

## Test Result
### Main branch:
#### amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 TP4
**SGLang-ATOM**:
```bash
local-completions ({'model': '/shared/data/amd_int/models/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4', 'base_url': 'http://localhost:8013/v1/completions', 'num_concurrent': 65, 'max_retries': 1, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 3, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.8544|±  |0.0097|
|     |       |strict-match    |     3|exact_match|↑  |0.8400|±  |0.0101|
```

### This PR:
#### amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 TP4
**SGLang-ATOM**:
```bash
llocal-completions ({'model': '/shared/data/amd_int/models/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4', 'base_url': 'http://localhost:8013/v1/completions', 'num_concurrent': 65, 'max_retries': 1, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 3, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9340|±  |0.0068|
|     |       |strict-match    |     3|exact_match|↑  |0.9303|±  |0.0070|
```

For model amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4, acc increase from 0.85 to 0.93
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
