### PR TITLE
[bugfix] Fix/mtp entry proj quant bf16 mismatch

### DIFF
--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -288,5 +288,29 @@
     "accuracy_baseline": 0.9401,
     "accuracy_baseline_model": "MiniMaxAI/MiniMax-M2.5",
     "_baseline_note": "HF: amd/MiniMax-M2.5-MXFP4 card shows MXFP4=0.9256, baseline=0.9401"
+  },
+  {
+    "model_name": "MiMo-V2-Flash",
+    "model_path": "XiaomiMiMo/MiMo-V2-Flash",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 4 --trust-remote-code --gpu-memory-utilization 0.8",
+    "env_vars": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.81,
+    "accuracy_baseline": 0.8294,
+    "accuracy_baseline_model": "XiaomiMiMo/MiMo-V2-Flash",
+    "_baseline_note": "CI measured GSM8K 5-shot flexible-extract = 0.8294 (±0.0104) under MTP1 greedy decoding (see MiMo-V2-Flash MTP entry); base-only number is identical because MTP only proposes speculative drafts that the target verifies. tp pinned to 4 to match the MTP entry's setup (no separate base measurement)."
+  },
+  {
+    "model_name": "MiMo-V2-Flash MTP",
+    "model_path": "XiaomiMiMo/MiMo-V2-Flash",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 4 --trust-remote-code --gpu-memory-utilization 0.8 --method mtp --num-speculative-tokens 1",
+    "env_vars": "",
+    "runner": "atom-mi355-8gpu.predownload",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.81,
+    "accuracy_baseline": 0.8294,
+    "accuracy_baseline_model": "XiaomiMiMo/MiMo-V2-Flash",
+    "_baseline_note": "CI measured GSM8K 5-shot flexible-extract = 0.8294 (±0.0104) on FP8 KV + MTP1. tp MUST be 4 and num-speculative-tokens MUST be 1: ATOM only constructs MTP layer 0 (matches vLLM _MIMO_V2_FLASH_NUM_MTP_LAYERS=1); driving more spec tokens would route through layers 1/2 whose KV is never populated and accept rate craters."
   }
 ]

--- a/atom/config.py
+++ b/atom/config.py
@@ -806,10 +806,26 @@ class SpeculativeConfig:
                 "num_nextn_predict_layers": n_predict,
                 "architectures": [arch],
             }
-            # Qwen3.5 MTP needs expert counts for MoE layer construction
-            if hf_config.model_type == "qwen3_5_mtp":
+            # Naming differs across families:
+            #   DeepSeek / GLM       → already have `n_routed_experts`
+            #   Qwen3.5 / Qwen3-Next → only carry `num_experts`
+            #   non-MoE / unknown    → leave unset (no MoE = no field)
+            n_routed = getattr(
+                hf_config,
+                "n_routed_experts",
+                getattr(hf_config, "num_experts", None),
+            )
+            if n_routed is not None:
+                updates["n_routed_experts"] = n_routed
+            # n_shared_experts: prefer the field's own value if it exists
+            # (DeepSeek / GLM ship it natively); else, if this looks like
+            # a MoE model (n_routed_experts was synthesized > 0), default
+            # to 1; else leave it unset (non-MoE).
+            existing_n_shared = getattr(hf_config, "n_shared_experts", None)
+            if existing_n_shared is not None:
+                updates["n_shared_experts"] = existing_n_shared
+            elif updates.get("n_routed_experts"):
                 updates["n_shared_experts"] = 1
-                updates["n_routed_experts"] = getattr(hf_config, "num_experts", 0)
 
             hf_config.update(updates)
 

--- a/atom/config.py
+++ b/atom/config.py
@@ -754,7 +754,7 @@ class SpeculativeConfig:
         # For multimodal models, extract text_config
         if hasattr(self.draft_model_hf_config, "text_config"):
             self.draft_model_hf_config = self.draft_model_hf_config.text_config
-        self.hf_config_override(self.draft_model_hf_config)
+        self.hf_config_override(self.draft_model_hf_config, self.model)
 
         if self.method == "eagle3":
             if getattr(self.draft_model_hf_config, "kv_lora_rank", None):
@@ -778,7 +778,9 @@ class SpeculativeConfig:
                 self.use_aux_hidden_state = True
 
     @staticmethod
-    def hf_config_override(hf_config: PretrainedConfig) -> None:
+    def hf_config_override(
+        hf_config: PretrainedConfig, model_path: Optional[str] = None
+    ) -> None:
         # Eagle3 architecture mapping (architecture-level, not model_type)
         arch = (getattr(hf_config, "architectures", None) or [""])[0]
         if arch == "LlamaForCausalLMEagle3":
@@ -818,14 +820,21 @@ class SpeculativeConfig:
             if n_routed is not None:
                 updates["n_routed_experts"] = n_routed
             # n_shared_experts: prefer the field's own value if it exists
-            # (DeepSeek / GLM ship it natively); else, if this looks like
-            # a MoE model (n_routed_experts was synthesized > 0), default
-            # to 1; else leave it unset (non-MoE).
+            # (DeepSeek / GLM ship it natively); else scan the checkpoint
+            # for `shared_expert` weights and use the parsed count (1 for
+            # the flat-block layout every released model uses). Leaving
+            # the field unset for ckpts without shared experts avoids
+            # fabricating a phantom shared block (e.g. R1 MTP eh_proj
+            # would otherwise pull a stale BF16 weight_scale).
             existing_n_shared = getattr(hf_config, "n_shared_experts", None)
             if existing_n_shared is not None:
                 updates["n_shared_experts"] = existing_n_shared
-            elif updates.get("n_routed_experts"):
-                updates["n_shared_experts"] = 1
+            else:
+                from atom.models.utils import ckpt_shared_expert_count
+
+                n_shared = ckpt_shared_expert_count(model_path)
+                if n_shared > 0:
+                    updates["n_shared_experts"] = n_shared
 
             hf_config.update(updates)
 

--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -17,7 +17,7 @@ from atom.utils.decorators import support_torch_compile
 from transformers import DeepseekV2Config, DeepseekV3Config, PretrainedConfig
 
 from .deepseek_v2 import DeepseekV2DecoderLayer
-from .utils import maybe_prefix
+from .utils import ckpt_has_tensor_suffix, maybe_prefix
 
 
 class SharedHead(nn.Module):
@@ -176,6 +176,20 @@ class DeepSeekMTP(nn.Module):
     def __init__(self, atom_config: Config, prefix: str = ""):
         super().__init__()
         self.config = atom_config.hf_config
+
+        # Several MTP checkpoints (DeepSeek R1/V3/V3.2 FP8 + the Quark mixed
+        # MXFP4/FP8 variants) store eh_proj as BF16 with no weight_scale even
+        # though their HF quantization_config does not list eh_proj in the
+        # exclude set. Without this guard ReplicatedLinear is built with the
+        # global FP8/MXFP4 spec, the BF16 weight is cast into the FP8 slot
+        # against an uninitialized weight_scale, and MTP accept rate collapses.
+        # GLM-FP8 ckpts already list eh_proj explicitly (this becomes a no-op);
+        # GLM-5.1-MXFP4 truly quantizes eh_proj and ships weight_scale on disk
+        # so the check below leaves the global spec in effect.
+        if atom_config.quant_config is not None and not ckpt_has_tensor_suffix(
+            atom_config.model, "eh_proj.weight_scale"
+        ):
+            atom_config.quant_config.apply_default_exclude_layers(["*.eh_proj"])
 
         if hasattr(self.config, "q_lora_rank") and self.config.q_lora_rank is not None:
             self.packed_modules_mapping = {

--- a/atom/models/mimo_v2_flash_mtp.py
+++ b/atom/models/mimo_v2_flash_mtp.py
@@ -11,7 +11,7 @@ from atom.config import Config
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.layernorm import RMSNorm
 from atom.model_ops.linear import ReplicatedLinear
-from atom.models.utils import IntermediateTensors, maybe_prefix
+from atom.models.utils import IntermediateTensors, ckpt_has_tensor_suffix, maybe_prefix
 from atom.utils.decorators import support_torch_compile
 
 from .mimo_v2_flash import MiMoV2Attention, MiMoV2MLP
@@ -220,6 +220,40 @@ class MiMoV2FlashMTP(nn.Module):
         super().__init__()
         self.config = atom_config.hf_config
         self._draft_hf_config = atom_config.speculative_config.draft_model_hf_config
+        num_spec = atom_config.speculative_config.num_speculative_tokens
+        assert num_spec == 1, (
+            f"MiMo-V2-Flash MTP only supports --num-speculative-tokens=1 now "
+            f"(got {num_spec})."
+        )
+
+        # See deepseek_mtp.DeepSeekMTP for the full rationale: MTP eh_proj is
+        # commonly stored as BF16 with no weight_scale even when the model's
+        # global quant_config is FP8/MXFP4. Skip quantization for eh_proj only
+        # when the checkpoint actually has no scale tensor for it.
+        if atom_config.quant_config is not None and not ckpt_has_tensor_suffix(
+            atom_config.model, "eh_proj.weight_scale"
+        ):
+            atom_config.quant_config.apply_default_exclude_layers(["*.eh_proj"])
+        # MiMo additionally keeps every self_attn.o_proj as BF16. Its HF
+        # `ignored_layers` covers all 48 base-model o_proj entries but
+        # forgets the MTP-layer ones (model.mtp.layers.0..2.self_attn.o_proj).
+        # Without this exclude, MTP o_proj falls back to the global FP8 spec,
+        # weight_scale stays at torch.empty junk memory, and accept rate
+        # collapses — same corruption chain as the eh_proj case above.
+        # Detect from disk: if the ckpt has no o_proj.weight_scale[_inv] for
+        # any layer, exclude *.self_attn.o_proj globally (HF entries dedup).
+        if (
+            atom_config.quant_config is not None
+            and not ckpt_has_tensor_suffix(
+                atom_config.model, "self_attn.o_proj.weight_scale_inv"
+            )
+            and not ckpt_has_tensor_suffix(
+                atom_config.model, "self_attn.o_proj.weight_scale"
+            )
+        ):
+            atom_config.quant_config.apply_default_exclude_layers(
+                ["*.self_attn.o_proj"]
+            )
 
         self.model = MiMoV2FlashMultiTokenPredictor(
             atom_config=atom_config, prefix=maybe_prefix(prefix, "model")

--- a/atom/models/qwen3_next_mtp.py
+++ b/atom/models/qwen3_next_mtp.py
@@ -43,6 +43,7 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
             self.config.hidden_size,
             bias=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.fc",
         )
 
         self.layers = torch.nn.ModuleList(
@@ -107,6 +108,8 @@ class Qwen3NextMTP(nn.Module):
         "v_proj": ("qkv_proj", "v"),
         "gate_proj": ("gate_up_proj", 0),
         "up_proj": ("gate_up_proj", 1),
+        ".gate.": (".gate.", 0),
+        "shared_expert_gate": ("gate", 1),
     }
     weights_mapping = {"mtp.": "model."}
 

--- a/atom/models/utils.py
+++ b/atom/models/utils.py
@@ -241,6 +241,66 @@ def maybe_prefix(prefix: str, name: str) -> str:
     return name if not prefix else f"{prefix}.{name}"
 
 
+def ckpt_has_tensor_suffix(model_path: str, suffix: str) -> bool:
+    """Return True if the checkpoint at ``model_path`` contains a tensor whose
+    key ends with ``suffix``.
+
+    Used by MTP modules to decide whether the entry projection (eh_proj/fc) is
+    actually quantized on disk: when the HF quantization_config's exclude list
+    is incomplete, falling back to the global quant spec creates an
+    uninitialized weight_scale that silently corrupts inference. Checking the
+    safetensors index for a sibling ``*.weight_scale`` is the only reliable
+    signal.
+    """
+    import glob
+    import json
+    import os
+
+    if not model_path or not os.path.isdir(model_path):
+        logger.warning(
+            "ckpt_has_tensor_suffix: model_path %r is not a directory; "
+            "assuming suffix %r is absent",
+            model_path,
+            suffix,
+        )
+        return False
+
+    index_files = glob.glob(os.path.join(model_path, "*.safetensors.index.json"))
+    if index_files:
+        try:
+            with open(index_files[0]) as f:
+                weight_map = json.load(f)["weight_map"]
+        except (OSError, json.JSONDecodeError, KeyError) as e:
+            logger.warning(
+                "ckpt_has_tensor_suffix: failed to read %s (%s); "
+                "assuming suffix %r is absent",
+                index_files[0],
+                e,
+                suffix,
+            )
+            return False
+        return any(k.endswith(suffix) for k in weight_map)
+
+    safetensors_files = glob.glob(os.path.join(model_path, "*.safetensors"))
+    if safetensors_files:
+        try:
+            from safetensors import safe_open
+
+            with safe_open(safetensors_files[0], framework="pt") as sf:
+                return any(k.endswith(suffix) for k in sf.keys())
+        except Exception as e:
+            logger.warning(
+                "ckpt_has_tensor_suffix: failed to read %s (%s); "
+                "assuming suffix %r is absent",
+                safetensors_files[0],
+                e,
+                suffix,
+            )
+            return False
+
+    return False
+
+
 def cast_overflow_tensors(
     tensors: torch.Tensor,
     offset: float = 1000,

--- a/atom/models/utils.py
+++ b/atom/models/utils.py
@@ -301,6 +301,74 @@ def ckpt_has_tensor_suffix(model_path: str, suffix: str) -> bool:
     return False
 
 
+def ckpt_shared_expert_count(model_path: str | None) -> int:
+    """Return the number of shared experts present in the local checkpoint.
+
+    0 means no `shared_expert` weights were found. 1 covers the flat-block
+    layout used by every MTP checkpoint shipped today (a single shared block
+    written without a numeric index, e.g. `...mlp.shared_experts.gate_proj`).
+    A value >1 is parsed from indexed keys (e.g. `shared_experts.0.`,
+    `shared_experts.1.`) and emits a warning, since no released model uses
+    that layout — the path exists to surface a mismatch instead of silently
+    loading the wrong count.
+
+    Used by SpeculativeConfig to synthesize n_shared_experts when the HF
+    config doesn't carry it. Non-local paths or unreadable indexes return 0
+    (leaving the field unset, safer than fabricating one).
+    """
+    import glob
+    import json
+    import os
+    import re
+
+    if not model_path or not os.path.isdir(model_path):
+        return 0
+
+    keys: list[str] | None = None
+    index_files = glob.glob(os.path.join(model_path, "*.safetensors.index.json"))
+    if index_files:
+        try:
+            with open(index_files[0]) as f:
+                keys = list(json.load(f)["weight_map"].keys())
+        except (OSError, json.JSONDecodeError, KeyError):
+            return 0
+    else:
+        safetensors_files = glob.glob(os.path.join(model_path, "*.safetensors"))
+        if safetensors_files:
+            try:
+                from safetensors import safe_open
+
+                with safe_open(safetensors_files[0], framework="pt") as sf:
+                    keys = list(sf.keys())
+            except Exception:
+                return 0
+
+    if not keys:
+        return 0
+
+    shared_keys = [k for k in keys if "shared_expert" in k]
+    if not shared_keys:
+        return 0
+
+    indexed = re.compile(r"shared_experts?\.(\d+)\.")
+    max_idx = -1
+    for k in shared_keys:
+        m = indexed.search(k)
+        if m:
+            max_idx = max(max_idx, int(m.group(1)))
+    if max_idx >= 0:
+        count = max_idx + 1
+        logger.warning(
+            "Checkpoint at %r carries indexed shared_experts (parsed "
+            "n_shared_experts=%d). This layout is unprecedented in shipped "
+            "models; verify against the model definition before trusting it.",
+            model_path,
+            count,
+        )
+        return count
+    return 1
+
+
 def cast_overflow_tensors(
     tensors: torch.Tensor,
     offset: float = 1000,


### PR DESCRIPTION
# MTP entry-projection BF16/quant-mismatch bugfix writeup

This document records the silent corruption modes that had to be fixed for MTP speculative decoding to actually work in ATOM, plus one MiMo-specific runtime guardrail. **Bug A** — entry-projection (`eh_proj` / `fc`) BF16 quant mismatch — affects DeepSeek and MiMo (1 root cause, same mechanism, fixed once in shared helper). **Bug B** — Qwen3-Next-FP8 MTP total failure — **3 independent root causes stacked**, all must be fixed for accept rate to recover. **Bug C** — MiMo-specific extras: a sibling BF16 fallback on `self_attn.o_proj`, plus a single-step (`num_speculative_tokens=1`) constraint enforced by assert because ATOM does not yet implement multi-step MTP for MiMo's architecture. All fixes live on branch `fix/mtp-entry-proj-quant-bf16-mismatch`.

## 1. TL;DR

| Item | Content |
|---|---|
| **Failure modes** | **Bug A** — entry-projection (`eh_proj` / `fc`) BF16 quant mismatch (1 root cause: FP8 ReplicatedLinear + uninitialized weight_scale; affects DeepSeek and MiMo)<br>**Bug B** — Qwen3-Next-FP8 MTP completely broken (3 stacked root causes, see §3.3)<br>**Bug C** — MiMo MTP additionally has the same BF16 fallback on `self_attn.o_proj`, and only the single-step path (`mtp_k=1`) is implemented in ATOM (see §3.4) |
| **Affected versions** | Bug A: after commit `5d34e9e`; Bug B's 3 root causes have all been present historically; Bug C: present since MiMo MTP was introduced |
| **Affected ckpts** | DeepSeek R1 / R1-0528 / V3 / V3.2 FP8 releases (Bug A); all Qwen3-Next FP8 releases (Bug B); MiMo-V2-Flash MTP (Bug A on `eh_proj` + Bug C on `self_attn.o_proj` and the `mtp_k=1` constraint) |
| **Symptom** | Server starts cleanly, weight loading reports no errors, inference does not crash, single-prompt completions look semantically correct — but **MTP accept rate collapses to ~0%**, speculative decoding is completely dead. For Bug C's `--num-speculative-tokens > 1` case on MiMo, startup now fails fast with an explicit `AssertionError` instead of producing garbage. |
| **Detection** | Boot openai_server with `--method mtp`, run a smoke client, watch `[MTP Stats]` for `Acceptance rate`. Full commands in §2.1. (`tools/repro_hidden_gap.py` does **not** exercise the MTP drafter — it is under-testing for MTP fixes.) |
| **Fix commits** | `bb64c26` Qwen3-Next MTP (Bug B, 3 root causes squashed: §3.3.1 generalize `hf_config_override` synthesis of `n_routed_experts/n_shared_experts`; §3.3.2 add `prefix=` to `fc`; §3.3.3 copy `shared_expert_gate` into `packed_modules_mapping`)<br>`4addad3` DeepSeek MTP (Bug A on DeepSeek — adds the `ckpt_has_tensor_suffix` helper + ckpt-introspection-driven exclude on `eh_proj`; see §6.2)<br>`0ee5d87` MiMo MTP (Bug A reuse on MiMo `eh_proj` + Bug C on `self_attn.o_proj` + `num_speculative_tokens == 1` assert; see §6.3) |

## 2. Symptom

What an operator actually sees:

- `python -m atom.entrypoints.openai_server ...` boots normally
- `curl /health` returns OK
- `rocm-smi --showmemuse` shows GPU memory used (weights are loaded)
- Single-prompt completions **look** correct (the base model path is unaffected)
- But `lm_eval` accept-rate metrics show MTP accept ≈ 0% — speculative decoding is functionally disabled, and end-to-end throughput is *worse* than just turning MTP off (extra MTP forward cost, zero benefit)

This is the hardest failure mode to diagnose **because nothing throws**:

- Dtype conversion "succeeds" (FP8 saturates / truncates out-of-range values without raising)
- Shape checks "pass" (shapes match)
- `weight_scale` is a legitimate `nn.Parameter`, just full of `torch.empty`-allocated junk memory
- The AITER GEMM kernel has no way to know what value the scale "should" have

The only reliable signal is the end-to-end accept-rate metric.

### 2.1 Reproduction

> ⚠️ `tools/repro_hidden_gap.py` only diffs base-model MLA hidden states; it **does not exercise the MTP drafter or the shared-expert path** and is under-testing for MTP fixes. Any MTP fix must run the full e2e flow below.

**Minimum sanity check** (no GPU needed — verifies the ckpt-introspection helper):

```python
from atom.models.utils import ckpt_has_tensor_suffix
assert not ckpt_has_tensor_suffix("/data/amd_int/models/DeepSeek-R1-0528", "eh_proj.weight_scale")
assert     ckpt_has_tensor_suffix("/data/amd_int/models/GLM-5.1-MXFP4",   "eh_proj.weight_scale")
```

**Full e2e** (requires GPU):

```bash
# Required: clear compile cache (CLAUDE.md "Critical Rules")
rm -rf /root/.cache/atom/*

# Qwen3-Next-FP8 (Bug B primary target, TP=4)
HIP_VISIBLE_DEVICES=4,5,6,7 AITER_LOG_LEVEL=WARNING \
  python -m atom.entrypoints.openai_server \
    --model /data/amd_int/models/Qwen3-Next-80B-A3B-Instruct-FP8 \
    --kv_cache_dtype fp8 -tp 4 --method mtp \
  > server.log 2>&1 &

# DeepSeek-R1-0528 (Bug A primary target, TP=8)
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 AITER_LOG_LEVEL=WARNING \
  python -m atom.entrypoints.openai_server \
    --model /data/amd_int/models/DeepSeek-R1-0528 \
    --kv_cache_dtype fp8 -tp 8 --method mtp \
  > server.log 2>&1 &
```

**Mandatory post-startup check**: `server.log` must have no `load_model` warnings:

```bash
grep -E "load_model:.*(NOT loaded|silently dropped)" server.log
# Any match means an unloaded / silently-dropped tensor is still there → accept rate will be 0%
```

**Trigger MTP stats** (in-repo [`repro_main_logs/smoke.py`](../repro_main_logs/smoke.py): 32 prompts × 384 max_tokens concurrent, ~1 minute):

```bash
python repro_main_logs/smoke.py /data/amd_int/models/Qwen3-Next-80B-A3B-Instruct-FP8
```

**Read the verdict**: `server.log` will print at the end:

```
[atom HH:MM:SS] [MTP Stats] Average toks/fwd: <X>, Accepted/Total Draft tokens: <a>/<b>,
                            Acceptance rate: <Y>%, Accepted tokens distribution: {...}
```

| Signal | Pre-fix (broken) | Post-fix (good) |
|---|---|---|
| `load_model: NOT loaded` warning | present | **must be absent** |
| `load_model: silently dropped` warning | present | **must be absent** |
| `Average toks/fwd` | 1.00 | > 1.0 (typically 1.5–2.0) |
| `Acceptance rate` | 0.00% | > 50% (typically 60–80%) |

For CI gating, run the `lm_eval` MTP accept-rate metrics (see `/ci-pr-guide`) — broader coverage than the 32-prompt smoke.

## 3. Root cause analysis

### 3.1 The shared corruption chain

The core of both bugs: a `ReplicatedLinear` / `ColumnParallelLinear` is incorrectly constructed as a quantized FP8 layer, but the on-disk checkpoint provides BF16 with no scale. Once on this path the corruption is identical:

**Construction** ([`atom/model_ops/linear.py:206-313`](../atom/model_ops/linear.py#L206-L313)):

```python
layer_quant_config = quant_config.get_layer_quant_config(prefix)  # falls through to global FP8 spec
quant_type = layer_quant_config.quant_type                        # = per_1x128
params_dtype = layer_quant_config.quant_dtype                     # = fp8
self.weight = atom_parameter(torch.empty((out, in), dtype=fp8))   # FP8 slot
self.weight_scale = atom_parameter(                                # uninitialized scale
    torch.empty((out//128, in//128), dtype=fp32)
)
```

**Loading** ([`atom/model_ops/linear.py:316-343`](../atom/model_ops/linear.py#L316-L343)):

```python
def weight_loader_process(param, loaded_weight, ...):
    if param.data.dtype != loaded_weight.dtype:                   # fp8 vs bf16
        if param.data.element_size() == loaded_weight.element_size():
            ...
        else:
            loaded_weight = loaded_weight.to(param.data.dtype)    # ← silent cast to FP8
```

The bf16 weight from the ckpt is `.to(fp8)`-cast directly into the FP8 slot — values |x| > 448 are truncated/saturated, and the per-block scale information that should accompany an FP8 weight is permanently lost. Meanwhile `weight_scale` is never visited by the loader (the ckpt has no corresponding key), so it **keeps the `torch.empty(...)` junk-memory values**.

**Forward** ([`atom/model_ops/linear.py:462-481`](../atom/model_ops/linear.py#L462-L481)):

```python
y = gemm_a8w8_blockscale(x, self.weight, x_scale, self.weight_scale, dtype=otype)
                                                  # ↑ GEMM with junk scale → garbage output
```

Garbage output → MTP's first-step prediction is wrong → accept rate ≈ 0%.

The entire path raises no exception. The two bugs differ only in **why** the layer ended up constructed as FP8 in the first place.

### 3.2 Bug A: entry-projection (`eh_proj`) missing from HF exclude list (DeepSeek + MiMo)

**Affects**: DeepSeek R1 / R1-0528 / V3 / V3.2 FP8 (primary case, drives the helper design) and MiMo-V2-Flash MTP (same mechanism, reused via the same helper). MiMo additionally has a sibling issue on `self_attn.o_proj` documented as Bug C in §3.4.

**Trigger**: DeepSeek R1 / R1-0528 / V3 / V3.2 FP8 ckpts have `eh_proj` stored as bf16 with no `weight_scale`, but their HF `quantization_config.modules_to_not_convert` field **does not list eh_proj at all**.

```text
ckpt: model.layers.61.eh_proj.weight    bf16  shape=(7168, 14336)
ckpt: model.layers.61.eh_proj.weight_scale  ← does not exist
HF quantization_config.modules_to_not_convert: [...] ← no "eh_proj" entry
```

**Trigger chain**: commit `5d34e9e` changed [`atom/models/deepseek_mtp.py:58-64`](../atom/models/deepseek_mtp.py#L58-L64) so that `eh_proj` is now constructed with `quant_config=atom_config.quant_config` (instead of being hard-coded BF16). `LinearBase.__init__` queries `exclude_layers` with prefix `model.layers.61.eh_proj` → no match → falls back to global FP8 spec → triggers the §3.1 corruption chain.

**Why it wasn't caught earlier**: before commit `5d34e9e` this layer was hard-coded to BF16 without consulting `quant_config`, so the bug did not exist. It was introduced as a regression in that refactor.

> **e2e validation status**: For this round we couldn't free 8 GPUs (GPU[3] held 270 GB of orphan VRAM), so the R1-0528 primary target was not run end-to-end on this host. MiMo-V2-Flash MTP was loaded end-to-end and its `eh_proj` exclude path was verified by the disappearance of the corresponding `load_model: NOT loaded` warning (see §3.4 for the broader MiMo verification). The fix mechanism (`ckpt_has_tensor_suffix` + `apply_default_exclude_layers`) shares the same LinearBase exclude path as §3.3.2; helper behaviour is verified by the §2.1 unit assert.

### 3.3 Bug B: Qwen3-Next-FP8 MTP completely broken (3 stacked root causes)

What end-to-end openai_server + `--method mtp` actually exposed: the ~0% MTP accept rate on Qwen3-Next-80B-A3B-Instruct-FP8 is the result of **three independent root causes stacked on top of each other**. Only one of them (§3.3.2) is related to the entry-projection quant story; the other two are a startup-time AttributeError and a weight-name-mapping omission, neither of which has anything to do with quantization but each of which is independently sufficient to flatten accept rate to 0%. **The three fixes are not substitutes for each other** — drop any one and accept rate collapses again (ablation experiment in §3.3.4).

In discovery / blocking order:

#### 3.3.1 Startup blocker — `hf_config_override` doesn't synthesize `n_routed_experts` for Qwen3-Next

**Symptom**: during MTP drafter loading (the `spec_decode=True` path), `atom/model_loader/loader.py:384` accesses `hf_config.n_routed_experts` directly:

```python
name = name.replace(
    maybe_matching_name,
    f"mlp.experts.{hf_config.n_routed_experts}.",
)
```

Observed stack:

```
File "atom/model_engine/model_runner.py", line 630
    self.drafter.load_model(self.model)         ← MTP drafter
File "atom/spec_decode/eagle.py", line 252, in load_model
    loaded = load_model(...)
File "atom/model_loader/loader.py", line 384, in load_model
    f"mlp.experts.{hf_config.n_routed_experts}.",
AttributeError: 'Qwen3NextConfig' object has no attribute 'n_routed_experts'
```

**Root cause**: HF config field naming differs across families —

| Family | Field for routed-expert count |
|---|---|
| DeepSeek V3/R1/V3.2, GLM-* | `n_routed_experts` ✓ native |
| Qwen3.5 / Qwen3-Next | `num_experts` (**no `n_routed_experts`**) |

ATOM's `SpeculativeConfig.hf_config_override` ([`atom/config.py:780-814`](../atom/config.py#L780-L814)) only synthesized `n_routed_experts = num_experts` for `qwen3_5_mtp`. **It missed `qwen3_next_mtp`**. So Qwen3-Next's drafter hf_config never received the field, and loader.py:384 raised AttributeError → EngineCore SHUTDOWN.

> Why base-model load doesn't crash: [`atom/models/qwen3_next.py:942`](../atom/models/qwen3_next.py#L942) does `self.config.n_routed_experts = self.config.num_experts` as a side effect inside `Qwen3NextModel.__init__`. Base-model construction runs before base-model load, so the side effect populates the field in time. `Qwen3NextMTP.__init__` does not have the equivalent side effect, so the drafter load is not rescued.

**Fix** (commit `bb64c26`, [`atom/config.py:809-826`](../atom/config.py#L809-L826)): generalize the synthesis in `hf_config_override` into a family-agnostic priority chain:

```python
# n_routed_experts: prefer existing → fallback to num_experts → leave unset
n_routed = getattr(
    hf_config,
    "n_routed_experts",
    getattr(hf_config, "num_experts", None),
)
if n_routed is not None:
    updates["n_routed_experts"] = n_routed

# n_shared_experts: prefer existing → default to 1 if MoE → otherwise leave unset
existing_n_shared = getattr(hf_config, "n_shared_experts", None)
if existing_n_shared is not None:
    updates["n_shared_experts"] = existing_n_shared
elif updates.get("n_routed_experts"):
    updates["n_shared_experts"] = 1
```

Behaviour matrix (verified):

| ckpt | `n_routed_experts` | `n_shared_experts` | Source |
|---|---|---|---|
| Qwen3-Next-80B-FP8 | 512 | 1 | both newly synthesized |
| Qwen3.5-35B-FP8 | 256 | 1 | both newly synthesized |
| DeepSeek-R1-0528 | 256 | 1 | both preserved from native config |
| GLM-5.1-FP8 | 256 | 1 | both preserved from native config |
| Hypothetical: neither field present | **unset** | **unset** | non-MoE not polluted |

**Role**: until this is fixed the server cannot even start, so it is the prerequisite for the other two root causes.

> Note: an earlier draft of the fix added a defensive `getattr(..., 0)` at `loader.py:384` as well. We later judged that redundant — once `hf_config_override` does the right thing this line can no longer AttributeError, and a 0 fallback would have silently rewritten the shared-expert weight to `mlp.experts.0.<key>`, corrupting routed expert #0. Not kept.

#### 3.3.2 The quant path — MTP `fc` constructed without `prefix=`

**Trigger**: Qwen3-Next/Qwen3.5 also store `mtp.fc.weight` as bf16 with no scale. **But** their HF `quantization_config` does correctly list `mtp.fc` in `modules_to_not_convert` — so in principle the exclude system should work.

The Qwen3.5 version [`atom/models/qwen3_5_mtp.py:45-51`](../atom/models/qwen3_5_mtp.py#L45-L51) does this right:

```python
self.fc = ColumnParallelLinear(
    self.config.hidden_size * 2,
    self.config.hidden_size,
    bias=False,
    quant_config=quant_config,
    prefix=f"{prefix}.fc",      # ← key
)
```

The outer `prefix` is `"mtp"`, so internally the lookup is `get_layer_quant_config("mtp.fc")` → matches the HF `mtp.fc` entry → returns `LayerQuantConfig(quant_type=No, quant_dtype=bf16)` → BF16 path ✓.

But [`atom/models/qwen3_next_mtp.py:41-46`](../atom/models/qwen3_next_mtp.py#L41-L46) (pre-fix) was missing the `prefix=` kwarg:

```python
self.fc = ColumnParallelLinear(
    self.config.hidden_size * 2,
    self.config.hidden_size,
    bias=False,
    quant_config=quant_config,
    # ← missing prefix=f"{prefix}.fc"
)
```

`ColumnParallelLinear` defaults to `prefix=""`. `_is_excluded("")` doesn't match the HF entry `"mtp.fc"` — neither equality, nor prefix, nor fnmatch ([`atom/config.py:387-412`](../atom/config.py#L387-L412)) — so the layer falls back to global FP8 → §3.1 corruption chain. **This is the only one of the three root causes that is actually about entry-projection quantization.**

**Fix** (part of commit `bb64c26`): one line — `prefix=f"{prefix}.fc"`. The pattern is already correct in `qwen3_5_mtp.py:50`.

**Difference vs Bug A**:

- Bug A is **a configuration omission** — HF metadata never said eh_proj should not be quantized; ATOM has to supply the default exclude.
- Bug B / §3.3.2 is **an ATOM bug** — HF metadata did say it; ATOM just failed to pass the right query key.

#### 3.3.3 Parallel corruption — `Qwen3NextMTP.packed_modules_mapping` missing two entries

**Trigger**: with §3.3.1 + §3.3.2 fixed, the server starts cleanly and `fc.weight_scale` is no longer junk memory — but MTP accept rate is still ~0%. The `load_model` warnings now contain:

```
1 checkpoint tensors were silently dropped because the rewritten name has no matching model parameter.
First 1 (orig_ckpt_name → rewritten_name):
  [('mtp.layers.0.mlp.shared_expert_gate.weight',
    'model.layers.0.mlp.shared_expert_gate.weight')]
```

`mtp.layers.0.mlp.shared_expert_gate.weight` gets renamed via `weights_mapping = {"mtp.": "model."}` to `model.layers.0.mlp.shared_expert_gate.weight`. There's no parameter by that name in the model — because in the base model `Qwen3NextForCausalLM`, `shared_expert_gate` and `.gate.` are packed into shard 1 of a fused `gate` parameter:

```python
# atom/models/qwen3_next.py:1022-1030
class Qwen3NextForCausalLM(nn.Module):
    packed_modules_mapping = {
        ...
        ".gate.": (".gate.", 0),
        "shared_expert_gate": ("gate", 1),
    }
```

`Qwen3NextMTP.packed_modules_mapping` (`atom/models/qwen3_next_mtp.py:105-111`) was missing both entries. The loader can't find a packing rule, can't find a direct param, and silently drops the tensor — the MTP shared-expert gate stays at its `torch.empty` random initialization, which is by itself enough to flatten accept rate to 0%. **This has nothing to do with entry-projection quantization; it's purely a name-mapping omission.**

**Fix** (part of commit `bb64c26`): copy the entries from the base model:

```diff
 packed_modules_mapping = {
     "q_proj": ("qkv_proj", "q"),
     "k_proj": ("qkv_proj", "k"),
     "v_proj": ("qkv_proj", "v"),
     "gate_proj": ("gate_up_proj", 0),
     "up_proj": ("gate_up_proj", 1),
+    ".gate.": (".gate.", 0),
+    "shared_expert_gate": ("gate", 1),
 }
```

#### 3.3.4 e2e ablation — fixes are non-substitutable (Qwen3-Next-80B-A3B-Instruct-FP8, TP=4, MI355X×4)

| Configuration | `NOT loaded` warning | `silently dropped` warning | MTP accept | avg toks/fwd | 32×384 smoke |
|---|---|---|---|---|---|
| main (`679422d`) | `model.fc.weight_scale` | `mtp.layers.0.mlp.shared_expert_gate.weight` | 0.00% (0/11000) | 1.00 | 69.8s / 172 tok/s |
| §3.3.2 fc prefix fix only | gone ✓ | still present | 0.00% (0/11000) | 1.00 | 42.4s / 273 tok/s |
| §3.3.1 + §3.3.2 + §3.3.3 all fixes (i.e. commit `bb64c26`) | gone ✓ | gone ✓ | **60.14%** (4210/7000) | **1.60** | **20.3s / 604 tok/s** (3.5×) |
| All fixes **then revert §3.3.2 prefix=** | `model.fc.weight_scale` reappears | gone ✓ | **0.05% (6/11000)** | 1.00 | 46.2s / 251 tok/s |

The last row is an ablation experiment (not committed): keep §3.3.3's `shared_expert_gate` fix but deliberately revert §3.3.2's `prefix=` line. Accept rate immediately collapses to ~0%. This makes it concrete that the two fixes **cannot substitute for each other** — they patch two independent corruption channels, and when both are present neither alone is enough.

> §3.3.1 is implicit in this table — the "main" row showing 0% (rather than a startup crash) was only possible because §3.3.1's `hf_config_override` synthesis was applied first (an early experiment without it crashed with `AttributeError: 'Qwen3NextConfig' object has no attribute 'n_routed_experts'` and never even reached MTP load). Commit `bb64c26` packages all three fixes together, so cherry-picking that one commit covers all three root causes.

In-repo reproduction artifacts:

- `repro_main_logs/SUMMARY.md` — full three-configuration side-by-side
- `repro_main_logs/qwen3_next_main_server.log`, `repro_fix_logs/qwen3_next_fix_server.log`, `repro_fix2_logs/server.log` — full server stdout/stderr for the three configurations
- `repro_main_logs/smoke.py` — 32×384 concurrent `/v1/completions` client

### 3.4 Bug C: MiMo MTP additional issues (`self_attn.o_proj` BF16 + single-step constraint)

Surfaced when running end-to-end `openai_server --method mtp` on `MiMo-V2-Flash`. Two findings on top of Bug A's `eh_proj` reuse.

#### 3.4.1 `self_attn.o_proj` BF16 fallback (sibling of Bug A, different layer)

**Trigger**: MiMo's checkpoint stores every `self_attn.o_proj` as BF16 with no `weight_scale` across all 51 layers (48 base + 3 MTP). Its HF `quantization_config.ignored_layers` correctly lists all 48 base-model entries (`model.layers.0..47.self_attn.o_proj`) but **forgets the 3 MTP-layer entries** (`model.mtp.layers.0..2.self_attn.o_proj`). Without an exclude for those, MTP `o_proj` is constructed as an FP8 `ReplicatedLinear` with uninitialized `weight_scale` — same §3.1 corruption chain as Bug A on `eh_proj`.

**Pre-fix signal**: `server.log` emits `load_model: NOT loaded: model.mtp_block.self_attn.o_proj.weight_scale at layer 48` (and analogous warnings for the other MTP layers if all 3 were constructed).

**Fix** (commit `0ee5d87`, [`atom/models/mimo_v2_flash_mtp.py`](../atom/models/mimo_v2_flash_mtp.py)): mirror the Bug A fix shape — scan the ckpt for `*.self_attn.o_proj.weight_scale[_inv]`; if absent, call `apply_default_exclude_layers(["*.self_attn.o_proj"])`. HF's existing 48 base-layer entries deduplicate harmlessly. Both probes are needed because Quark uses `weight_scale_inv` while HF/compressed-tensors use `weight_scale`.

**Why this couldn't be folded into Bug A's helper**: `ckpt_has_tensor_suffix` is generic and reused as-is. What's MiMo-specific is the *decision* to also exclude `*.self_attn.o_proj` — DeepSeek's o_proj is correctly listed in HF metadata, so this exclude would be a no-op there but adds a class of layers ATOM has to special-case for MiMo. Keeping it in the MiMo file (not the shared helper or `quant_spec.py`) preserves the principle that "the entry projection's quantization disagrees with the rest of the model" is MTP-domain knowledge owned by the MTP class (§7).

#### 3.4.2 Runtime constraint — only `mtp_k = 1` is implemented

**Trigger**: MiMo-V2-Flash ships 3 trained MTP layers (multi-head independent — each layer has its own KV state). Driving all 3 to the paper accept rate (2.8–3.6 toks/fwd, 80%+ step-1/2 accept) requires sglang's per-layer extend-mode decode + per-layer KV pools — a refactor ATOM does not have today. With ATOM's single-token decode loop only writing one slot per layer per propose, layer `i`'s KV develops gaps at slots that step `j` (`j != i`) wrote, and step-1/2 accept rate craters to ~40% regardless of any prefill-side fix (verified with both naive same-input prefill and full sglang-style per-layer rotation).

**Mitigation** (commit `0ee5d87`): assert in `MiMoV2FlashMTP.__init__`:

```python
num_spec = atom_config.speculative_config.num_speculative_tokens
assert num_spec == 1, (
    f"MiMo-V2-Flash MTP only supports --num-speculative-tokens=1 now "
    f"(got {num_spec})."
)
```

Effect: passing `--num-speculative-tokens 2` (or higher) on MiMo now produces a clear startup error instead of a silent ~0% accept rate later. This aligns with vLLM's `_MIMO_V2_FLASH_NUM_MTP_LAYERS = 1` choice.

**Note on `num_mtp_layers`**: the `MiMoV2FlashMultiTokenPredictor.__init__` line is left as the original `getattr(config, "num_nextn_predict_layers", 1)`. MiMo's BASE `hf_config` does not define this field, so the default of 1 fires naturally and matches the assert above. The architectural cap is enforced by the assert at the outer class; the predictor itself is otherwise untouched.

#### 3.4.3 Verification (TP=8 on `/data/amd_int/models/MiMo-V2-Flash`)

| Signal | Pre-fix | Post-fix (commit `0ee5d87`) |
|---|---|---|
| `load_model: NOT loaded` (eh_proj weight_scale at layer 48) | present | absent ✓ (fixed by Bug A reuse) |
| `load_model: NOT loaded` (o_proj weight_scale at layer 48) | present | absent ✓ (fixed by §3.4.1) |
| `--num-speculative-tokens 2` startup | crashes mid-decode with confusing error | clean `AssertionError` at startup ✓ |
| `--num-speculative-tokens 1` end-to-end | accept ≈ 0% | still accept ≈ 0% (see note below) |

> **End-to-end accept rate caveat**: post-fix MiMo MTP still shows ~0% accept rate. This is **not** an MTP issue — the MiMo BASE model alone (server started without `--method mtp`) also produces incoherent output ("The capital of France is" → " 1,1); ,,,,,..."). MiMo base support in ATOM has at least one further unidentified issue outside the entry-projection quant scope. The fixes in commit `0ee5d87` are still correct for what they cover (verified by the disappearance of all `load_model` warnings on the layers we keep), they just can't be observed end-to-end until the base-model issue is also resolved.

## 4. Background

### 4.1 What the MTP entry projection is

MTP attaches a mini transformer block after the base model to predict the "next-next token". Each MTP layer takes two `H`-dim inputs: `inputs_embeds` (the embedding of the next teacher-forcing token) and `previous_hidden_states` (the base model's last hidden state). The two are concatenated along the last dim into a `2H` vector and passed through a `Linear(2H -> H)` projection before the rest of the MTP transformer block. That projection is the "entry projection":

| Model family | File | Projection name | Placement |
|---|---|---|---|
| DeepSeek V3 / R1 / V3.2 / GLM-* | `atom/models/deepseek_mtp.py` | `eh_proj` | Inside each `DeepSeekMultiTokenPredictorLayer` (one per MTP layer) |
| MiMo-V2-Flash | `atom/models/mimo_v2_flash_mtp.py` | `eh_proj` | Inside each `MiMoV2FlashMTPPredictorLayer` |
| Qwen3-Next | `atom/models/qwen3_next_mtp.py` | `fc` | At the top of `Qwen3NextMultiTokenPredictor` (shared across MTP layers) |
| Qwen3.5 / Qwen3.5-MoE | `atom/models/qwen3_5_mtp.py` | `fc` | At the top of `Qwen3_5MultiTokenPredictor` (shared) |

The forward path is structurally identical across families; DeepSeek's `eh_proj` and Qwen's `fc` play the same role.

### 4.2 Why this layer typically stays BF16

Across nearly every MTP ckpt observed, the entry projection is kept in BF16 — the only exception is GLM-5.1-MXFP4. Reasons cited across model cards:

- It bridges two semantically different feature spaces (token embedding vs. hidden state) and is precision-sensitive.
- It's small (`2H × H`); compared to the MoE expert weights, the memory/compute saved by quantizing it is negligible.
- Empirically, quantizing it sends MTP accept rate through the floor (which is exactly the bug reported here).

### 4.3 Where each `quant_method` puts its exclude list

Different `quant_method` values use different field names to declare "do not quantize this layer". ATOM normalizes them in [`atom/quant_spec.py`](../atom/quant_spec.py):

| `quant_method` | Field with exclude entries |
|---|---|
| `fp8` (HF / TransformersV2) | `quantization_config.modules_to_not_convert` |
| `quark` | `quantization_config.exclude` |
| `compressed-tensors` | `quantization_config.ignore` |
| `gpt-oss`-style | `quantization_config.ignored_layers` |

`atom/quant_spec.py:226-232` (`GenericParser`) and `atom/quant_spec.py:165-185` (`QuarkParser`) feed all of these into `QuantizationConfig.exclude_layers`. At construction time, `LinearBase` calls `quant_config.get_layer_quant_config(prefix)` against this list ([`atom/config.py:305-328`](../atom/config.py#L305-L328)); a miss falls through to the global spec.

## 5. Per-checkpoint state matrix

Numbers and dtypes were verified by direct safetensors inspection on `/data/amd_int/models/*`. `H` = hidden_size, `N` = base layer count, `MTP` = number of nextn predict layers.

| Checkpoint | quant_method | H, N, MTP | HF declares entry-proj exclude? | On-disk entry-proj weight | Has `*.weight_scale`? | Pre-fix status | Post-fix status |
|---|---|---|---|---|---|---|---|
| DeepSeek-R1 / R1-0528 / V3 / V3.2 | `fp8` | 7168, 61, 1 | ❌ no | `model.layers.61.eh_proj.weight` bf16 (7168, 14336) | ❌ | 🔴 silent ~0% accept | ✅ ckpt-introspection adds exclude → BF16 |
| DeepSeek-R1-0528-MoE-MXFP4-Attn-MTP-PTPC-FP8 | `quark` | 7168, 61, 1 | ✅ `model.layers.61.eh_proj` | bf16 (7168, 14336) | ❌ | ✅ already correct via Quark `exclude` | ✅ unchanged (dedup no-op) |
| GLM-5-FP8 / GLM-5.1-FP8 | `fp8` | 6144, 78, 1 | ✅ `model.layers.78.eh_proj` | bf16 (6144, 12288) | ❌ | ✅ already correct via HF `modules_to_not_convert` | ✅ unchanged (dedup no-op) |
| GLM-4.7-FP8 | `compressed-tensors` | 5120, 92, 1 | ✅ `model.layers.92.eh_proj` (in `ignore`) | bf16 (5120, 10240) | ❌ | ✅ already correct via compressed-tensors `ignore` | ✅ unchanged (dedup no-op) |
| GLM-5.1-MXFP4 | `quark` | 6144, 78, 1 | ❌ no (**correct** — it IS quantized) | uint8 (6144, 6144) packed fp4x2 | ✅ | ✅ correctly quantized | ✅ unchanged (introspection sees scale → no exclude added) |
| Qwen3-Next-80B-A3B-Instruct-FP8 | `fp8` | 2048, 48, 1 | ✅ `mtp.fc` | `mtp.fc.weight` bf16 (2048, 4096) | ❌ | 🔴 silent ~0% accept (missing prefix=) | ✅ prefix passed → HF exclude hits |
| Qwen3.5-35B-A3B-FP8 | `fp8` | 2048, 40, 1 | ✅ `mtp.fc` | bf16 (2048, 4096) | ❌ | ✅ already correct | ✅ unchanged |
| Qwen3.5-397B-A17B-FP8 / -MXFP4 | `fp8` / `quark` | 4096, 60, 1 | ✅ `mtp.fc` | bf16 (4096, 8192) | ❌ | ✅ already correct | ✅ unchanged |
| MiMo-V2-Flash MTP | `fp8` | (verified locally) | ❌ no for `eh_proj`; ❌ partial for `self_attn.o_proj` (HF lists 48 base layers, omits the 3 MTP-layer entries) | `eh_proj.weight` bf16; every `self_attn.o_proj.weight` bf16 (51 layers) | ❌ for both | 🔴 silent ~0% accept on `eh_proj` (Bug A) + on MTP `o_proj` (Bug C / §3.4.1); `--num-speculative-tokens > 1` silently produced garbage | ✅ ckpt-introspection adds excludes for both `*.eh_proj` and `*.self_attn.o_proj`; assert blocks `mtp_k > 1` at startup |

A few takeaways from the matrix:

- Except for GLM-5.1-MXFP4, every observed entry-projection weight is BF16 with no scale. "The ckpt actually quantizes it" is the rare case.
- The on-disk shape's last dim is always `2H`; first dim is always `H`.
- Whether HF/quark/compressed-tensors metadata declares the exclude is **inconsistent across model families** — DeepSeek FP8 omits it, GLM lists it, Qwen lists it. New ckpts cannot be trusted via metadata alone; the **only authoritative signal is the presence (or absence) of `*.weight_scale` on disk**.

## 6. The fix

Branch `fix/mtp-entry-proj-quant-bf16-mismatch` carries 3 fix commits, grouped by which bug they address:

| Bug | Commit | Files | Change |
|---|---|---|---|
| B (Qwen3-Next-FP8 — three root causes squashed) | `bb64c26` | `atom/config.py`, `atom/models/qwen3_next_mtp.py` | §3.3.1 generalize `hf_config_override` synthesis of `n_routed_experts/n_shared_experts` + §3.3.2 add `prefix=f"{prefix}.fc"` to `fc` + §3.3.3 copy `.gate. / shared_expert_gate` into `packed_modules_mapping` (see §6.1) |
| A (DeepSeek `eh_proj` quant mismatch) | `4addad3` | `atom/models/utils.py`, `deepseek_mtp.py` | Add `ckpt_has_tensor_suffix` helper; DeepSeek `eh_proj` consults the ckpt to decide whether to add an exclude (see §6.2) |
| A reuse + C (MiMo `eh_proj` + `self_attn.o_proj` BF16 + single-step assert) | `0ee5d87` | `atom/models/mimo_v2_flash_mtp.py` | Reuse the same helper for MiMo `eh_proj`; add a parallel exclude probe for `self_attn.o_proj`; assert `num_speculative_tokens == 1` (see §6.3) |

§3.3.1 / §3.3.2 / §3.3.3 are already detailed in §3.3, and §3.4 covers Bug C. §6.1 / §6.2 / §6.3 below only note why the fixes are bundled the way they are and what each commit's blast radius is.

### 6.1 Commit `bb64c26`: Qwen3-Next MTP three root causes (Bug B / §3.3.1-3)

The three changes touch three different mechanisms (`SpeculativeConfig`, `LinearBase`'s prefix lookup key, and `packed_modules_mapping`), but **all three are required end-to-end** — the §3.3.4 ablation table's last row proves: keeping §3.3.3 but reverting §3.3.2 immediately collapses accept rate to ~0%. All three root causes touch only the Qwen3-Next-MTP path; zero impact on other models:

- The `atom/config.py` change in `hf_config_override` uses a 3-step priority chain ("native first → fallback → leave unset") so DeepSeek/GLM's existing `n_routed_experts=256` is preserved (see the 4-row behaviour table in §3.3.1).
- `atom/models/qwen3_next_mtp.py:46` adds `prefix=f"{prefix}.fc"`, matching the existing pattern in `qwen3_5_mtp.py:50`.
- `atom/models/qwen3_next_mtp.py:111-112` adds `.gate.` and `shared_expert_gate` to `packed_modules_mapping`, matching the base `Qwen3NextForCausalLM.packed_modules_mapping`.

Bundled into a single commit because the three root causes are **all-or-nothing** for Bug B; splitting would mislead reviewers into thinking any individual fix could rescue the path on its own.

### 6.2 Commit `4addad3`: DeepSeek `eh_proj` ckpt introspection (Bug A on DeepSeek)

New helper in `atom/models/utils.py`:

```python
def ckpt_has_tensor_suffix(model_path: str, suffix: str) -> bool:
    """Return True if the ckpt at model_path contains a tensor whose key
    ends with `suffix`. On any I/O / JSON / shape error, log a warning
    and return False."""
```

It scans `*.safetensors.index.json` (or, for single-file ckpts, the safetensors metadata directly) for a key matching the requested suffix. Read failures (`OSError` / `json.JSONDecodeError` / `KeyError` / no safetensors files) log a warning and return `False` — the safer default, because if the ckpt actually IS quantized then the BF16 `ReplicatedLinear` will fail loudly at weight load on a dtype/shape mismatch.

`DeepSeekMTP.__init__` ([`atom/models/deepseek_mtp.py:189-192`](../atom/models/deepseek_mtp.py#L189-L192)) calls it for `eh_proj.weight_scale` at construction time. When the suffix is missing, it calls `quant_config.apply_default_exclude_layers(["*.eh_proj"])`; subsequently `get_layer_quant_config("...eh_proj")` returns `LayerQuantConfig(quant_type=No, quant_dtype=bf16)` and the BF16 path is taken.

Properties:

- DeepSeek R1/V3/V3.2 FP8: missing exclude is supplied → fix.
- GLM-FP8 / DeepSeek-Quark: HF/quark already declare the exclude, `apply_default_exclude_layers` deduplicates → no-op.
- GLM-5.1-MXFP4: ckpt has the scale → introspection returns `True` → no exclude added → MXFP4 path preserved.
- BF16-base models (no quant_config): the global spec is already `quant_type=No`, so the appended exclude is never consulted.

The helper is generic — MiMo reuses it as-is in commit `0ee5d87` (see §6.3) for both `eh_proj` and `self_attn.o_proj` introspection. Keeping the helper in this commit (and not in MiMo's) reflects the discovery order: DeepSeek was the primary case that drove the helper design.

### 6.3 Commit `0ee5d87`: MiMo `eh_proj` + `self_attn.o_proj` exclude + single-step assert (Bug A reuse + Bug C)

Three changes, all confined to [`atom/models/mimo_v2_flash_mtp.py`](../atom/models/mimo_v2_flash_mtp.py) (no shared-helper or config.py changes):

1. **`eh_proj` exclude** — same shape as the DeepSeek call in §6.2, just on the MiMo construction path. Reuses `ckpt_has_tensor_suffix` from `atom/models/utils.py`.
2. **`self_attn.o_proj` exclude** — probe the ckpt for either `self_attn.o_proj.weight_scale_inv` (Quark layout) or `self_attn.o_proj.weight_scale` (HF / compressed-tensors layout); if neither exists, call `apply_default_exclude_layers(["*.self_attn.o_proj"])`. HF's existing 48 base-layer entries deduplicate harmlessly. See §3.4.1.
3. **`num_speculative_tokens == 1` assert** — placed at the top of `MiMoV2FlashMTP.__init__` so misconfiguration fails fast at startup. See §3.4.2.

Bundled into a single commit because all three are MiMo-specific startup-time guardrails on the same construction path; splitting would create three commits that each touch the same 30-line region of the same file.

Blast radius: only models routing through `MiMoV2FlashMTP`. DeepSeek / Qwen / GLM paths are untouched. The `num_mtp_layers` line inside `MiMoV2FlashMultiTokenPredictor` is intentionally left as the original `getattr(config, "num_nextn_predict_layers", 1)` upstream code (see §3.4.2 note) — the assert at the outer class is the load-bearing guarantee, and the `getattr` happens to fall back to `1` for MiMo because BASE `hf_config` does not define the field.

## 7. Design trade-off: why fix at MTP construction rather than at weight loading

The loader **can** notice the dtype mismatch (`weight_loader_process` at `atom/model_ops/linear.py:316-343` sees `param.dtype=fp8` vs `loaded.dtype=bf16`), but it is the wrong place to fix this. Reasons in order of weight:

### 7.1 By load time it's "too late" for a clean repair

By the time the weight loader is invoked, the layer is already constructed:

- `self.weight` is allocated with FP8 dtype (`atom/model_ops/linear.py:259`)
- `self.weight_scale` is registered as an `nn.Parameter` (`atom/model_ops/linear.py:286-293`)
- `self.quant_type` is frozen as an instance attribute = FP8 (`atom/model_ops/linear.py:266`)
- The forward GEMM dispatch keys off `self.quant_type.value` (`atom/model_ops/linear.py:462-481`)

Repairing this at load time means doing `nn.Module` surgery: remove the `weight_scale` attribute, reallocate `weight` as BF16, change `quant_type=No`, clear `quant_func`, and switch the forward GEMM dispatch. If the layer has already been captured by `@support_torch_compile`, things get worse.

### 7.2 The weight loader has a "single tensor" view

Each loader callback only sees "this one tensor about to be written into this one parameter". The fact that "this layer was supposed to have a `weight_scale` but no one ever showed up to load it" can only be determined **after the entire load completes** (by checking against the visited-parameter set), at which point the layer is long since frozen.

### 7.3 The dtype-cast branch isn't a bug, it's a feature

`atom/model_ops/linear.py:332-333`'s `loaded_weight.to(param.data.dtype)` cannot simply be tightened to "raise on mismatch" — it's load-bearing for legitimate cases:

- The `source_quant_dtype=torch.bfloat16` runtime requantization path (`atom/model_ops/linear.py:372-389`): on-disk BF16, run-time requantize to MXFP4 — that's a legitimate dtype mismatch by design.
- Various fp16 ↔ bf16 cross-loading scenarios (`atom/model_ops/linear.py:327-329` handles them explicitly).

Adding "raise if FP8 param receives BF16 input" would damage these legitimate paths.

### 7.4 Fixing it at load time would still need the same ckpt introspection

The most reliable signal for "this layer should be quantized but has no scale on disk" is still "scan the ckpt for `*.weight_scale`" — the exact thing `ckpt_has_tensor_suffix` does. Pushing the decision from "before construction" to "after the load" doesn't avoid the introspection; it just makes it more expensive. The recovery options are still nn.Module surgery or loud-fail-and-restart. **Doing it earlier is cheaper**: one disk read of the index file (milliseconds) lets us pick the right `params_dtype` and decide whether to register `weight_scale`, so the layer is constructed correctly from the start.

### 7.5 Compromise: a post-load sanity assert as backstop (not done, future follow-up)

Even with the construction-time fix in place, a post-load sweep that verifies "every quant layer's `weight_scale` has been visited by some weight loader" and loud-fails otherwise would protect against future bugs in the same family. This is an independent, model-agnostic robustness improvement that **does not replace** the construction-time ckpt introspection — it's just an additional safety net. The current fix does not implement it.

### Summary

The loader can detect the issue, but its only options are "after-the-fact surgery" or "after-the-fact failure". The surgery is complex and risks fighting torch.compile; the post-hoc failure is poor UX. **Doing the same ckpt introspection earlier — before construction — uses the same information more cheaply and lands on a correct layer the first time.** The MTP class is the natural boundary at which to apply this signal: "the entry projection's quantization disagrees with the rest of the model" is MTP domain knowledge, not something `LinearBase` should special-case.
