### PR TITLE
[MoE] adapt to triton_kernels matmul_ogs -> matmul rename

### DIFF
--- a/atom/model_ops/fused_moe_triton.py
+++ b/atom/model_ops/fused_moe_triton.py
@@ -18,9 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import torch
-from contextlib import contextmanager
 from typing import Any
 import logging
 from math import prod
@@ -38,12 +36,21 @@ logger = logging.getLogger("atom")
 if has_triton_kernels():
     try:
         import triton_kernels.swiglu
-        from triton_kernels.matmul_ogs import (
-            FnSpecs,
-            FusedActivation,
-            PrecisionConfig,
-            matmul_ogs,
-        )
+
+        try:
+            from triton_kernels.matmul import (
+                FnSpecs,
+                FusedActivation,
+                PrecisionConfig,
+                matmul as matmul_ogs,
+            )
+        except ImportError:
+            from triton_kernels.matmul_ogs import (
+                FnSpecs,
+                FusedActivation,
+                PrecisionConfig,
+                matmul_ogs,
+            )
         from triton_kernels.routing import routing
     except (AttributeError, ImportError) as e:
         logger.error(
@@ -51,45 +58,6 @@ if has_triton_kernels():
             "version is compatible. Error: %s",
             e,
         )
-
-
-@contextmanager
-def _amd_smem_safe_tile():
-    """Cap matmul_ogs tile size on AMD CDNA4 to fit MI355X's 160 KiB LDS.
-
-    triton_kernels' AMD opt_flags has a special-case
-    `if cdna4 and block_m == 128: block_n = 512`, which makes BLOCK_M*BLOCK_N
-    = 64K FP32 entries — large enough that triton 3.6+/3.7+ spills the
-    accumulator into LDS and overflows the 160 KiB budget (observed 269 KiB
-    on V4-Pro FP8 MoE). triton 3.5 happened to keep more of the acc in
-    registers and slipped under the limit, hence the version-dependent OOM.
-
-    Pin block_n ≤ ATOM_TRITON_MOE_MAX_BLOCK_N (default 256) so BLOCK_M*BLOCK_N
-    stays at 32K. Default block_n in compute_block_nk is already capped at
-    256 except for that single cdna4 branch, so this only sidesteps the bad
-    path on gfx950.
-    """
-    if get_gfx() != "gfx950" or not has_triton_kernels():
-        yield
-        return
-    try:
-        from triton_kernels.matmul_ogs_details.opt_flags import (
-            update_opt_flags_constraints,
-            reset_opt_flags_constraints,
-        )
-    except ImportError:
-        yield
-        return
-    # Defaults chosen so BLOCK_M*BLOCK_N stays ≤ 16384 entries (64 KiB FP32
-    # acc), comfortably fitting MI355X's register file. Override via env if
-    # a future compiler/kernel update relaxes the budget.
-    block_m = int(os.getenv("ATOM_TRITON_MOE_BLOCK_M", "32"))
-    block_n = int(os.getenv("ATOM_TRITON_MOE_BLOCK_N", "256"))
-    update_opt_flags_constraints({"block_m": block_m, "block_n": block_n})
-    try:
-        yield
-    finally:
-        reset_opt_flags_constraints()
 
 
 def _swizzle_mxfp4(quant_tensor, scale):
@@ -342,57 +310,56 @@ def triton_kernel_fused_experts(
         dtype=hidden_states.dtype,
     )
 
-    with _amd_smem_safe_tile():
-        if activation == ActivationType.Swiglu:
-            # SwiGLU (GPT OSS): fused activation with interleaved [gate, up] layout
-            act = FusedActivation(
-                FnSpecs("swiglu", triton_kernels.swiglu.swiglu_fn, ("alpha", "limit")),
-                (swiglu_alpha, swiglu_limit),
-                2,
-            )
-            matmul_ogs(
-                hidden_states,
-                w1,
-                w1_bias,
-                routing_data,
-                gather_indx=gather_indx,
-                precision_config=w13_precision_config,
-                gammas=gammas if apply_router_weight_on_input else None,
-                fused_activation=act,
-                y=intermediate_cache,
-            )
-        else:
-            # SiLU (DeepSeek): concatenated [gate | up] layout, manual activation
-            raw_intermediate = matmul_ogs(
-                hidden_states,
-                w1,
-                w1_bias,
-                routing_data,
-                gather_indx=gather_indx,
-                precision_config=w13_precision_config,
-                gammas=gammas if apply_router_weight_on_input else None,
-            )
-            raw_2d = raw_intermediate.view(M * topk, N)
-            intermediate_cache = intermediate_cache.view(M * topk, half_N)
-            fused_clamp_act_mul(
-                raw_2d,
-                out=intermediate_cache,
-                swiglu_limit=swiglu_limit,
-                activation="silu",
-                dtype_quant=None,
-            )
-            intermediate_cache = intermediate_cache.view(batch_dim, M * topk, half_N)
-
-        matmul_ogs(
-            intermediate_cache.view(M * topk, half_N),
-            w2,
-            w2_bias,
-            routing_data,
-            scatter_indx=scatter_indx,
-            precision_config=w2_precision_config,
-            gammas=None if apply_router_weight_on_input else gammas,
-            y=output_tensor,
+    if activation == ActivationType.Swiglu:
+        # SwiGLU (GPT OSS): fused activation with interleaved [gate, up] layout
+        act = FusedActivation(
+            FnSpecs("swiglu", triton_kernels.swiglu.swiglu_fn, ("alpha", "limit")),
+            (swiglu_alpha, swiglu_limit),
+            2,
         )
+        matmul_ogs(
+            hidden_states,
+            w1,
+            w1_bias,
+            routing_data,
+            gather_indx=gather_indx,
+            precision_config=w13_precision_config,
+            gammas=gammas if apply_router_weight_on_input else None,
+            fused_activation=act,
+            y=intermediate_cache,
+        )
+    else:
+        # SiLU (DeepSeek): concatenated [gate | up] layout, manual activation
+        raw_intermediate = matmul_ogs(
+            hidden_states,
+            w1,
+            w1_bias,
+            routing_data,
+            gather_indx=gather_indx,
+            precision_config=w13_precision_config,
+            gammas=gammas if apply_router_weight_on_input else None,
+        )
+        raw_2d = raw_intermediate.view(M * topk, N)
+        intermediate_cache = intermediate_cache.view(M * topk, half_N)
+        fused_clamp_act_mul(
+            raw_2d,
+            out=intermediate_cache,
+            swiglu_limit=swiglu_limit,
+            activation="silu",
+            dtype_quant=None,
+        )
+        intermediate_cache = intermediate_cache.view(batch_dim, M * topk, half_N)
+
+    matmul_ogs(
+        intermediate_cache.view(M * topk, half_N),
+        w2,
+        w2_bias,
+        routing_data,
+        scatter_indx=scatter_indx,
+        precision_config=w2_precision_config,
+        gammas=None if apply_router_weight_on_input else gammas,
+        y=output_tensor,
+    )
 
     output_tensor = output_tensor.view(M, K)
     return output_tensor

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -892,8 +892,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             return
 
         if self.use_triton:
+            import dataclasses
+
             from atom.model_ops.fused_moe_triton import _swizzle_mxfp4
-            from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
+
+            try:
+                from triton_kernels.matmul import FlexCtx, PrecisionConfig
+            except ImportError:
+                from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 
             w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(
                 layer.w13_weight.view(torch.uint8),
@@ -904,12 +910,23 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 layer.w2_weight_scale,
             )
 
-            self.w13_precision_config = PrecisionConfig(
-                weight_scale=w13_scale, flex_ctx=FlexCtx(rhs_data=w13_flex)
-            )
-            self.w2_precision_config = PrecisionConfig(
-                weight_scale=w2_scale, flex_ctx=FlexCtx(rhs_data=w2_flex)
-            )
+            _pc_field_names = {f.name for f in dataclasses.fields(PrecisionConfig)}
+
+            def _build_precision_config(scale, flex):
+                kwargs = {"flex_ctx": FlexCtx(rhs_data=flex)}
+                if "weight_scale" in _pc_field_names:
+                    kwargs["weight_scale"] = scale
+                else:
+                    # New triton_kernels API renamed `weight_scale` → `b_mx_scale`
+                    # and now requires the microblock size to be set explicitly.
+                    from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE
+
+                    kwargs["b_mx_scale"] = scale
+                    kwargs["b_microblock_size"] = int(MXFP_BLOCK_SIZE)
+                return PrecisionConfig(**kwargs)
+
+            self.w13_precision_config = _build_precision_config(w13_scale, w13_flex)
+            self.w2_precision_config = _build_precision_config(w2_scale, w2_flex)
             del layer.w13_weight
             del layer.w2_weight
             del layer.w13_weight_scale


### PR DESCRIPTION
## Motivation

Fix DeepseekV4 accuracy error. https://github.com/ROCm/triton-internal/issues/1823?reload=1?reload=1

## Technical Details

Upstream triton_kernels merged the `matmul_ogs` module into `matmul` and the `matmul_ogs_details` package into `matmul_details`. The `PrecisionConfig` dataclass was also reshaped: `weight_scale` is now `b_mx_scale`, and setting it requires `b_microblock_size` to be provided explicitly (enforced by an assert in the new `matmul()`).

- fused_moe_triton: try importing `FnSpecs / FusedActivation / PrecisionConfig / matmul` from `triton_kernels.matmul` first, fall back to the old `triton_kernels.matmul_ogs` path. Alias `matmul as matmul_ogs` so existing call sites stay unchanged.
- moe (Mxfp4MoEMethod.process_weights_after_loading): same dual-path import for `FlexCtx / PrecisionConfig`; detect the kwarg name via `dataclasses.fields` so the old `weight_scale=...` path keeps working while the new API takes `b_mx_scale=...` and `b_microblock_size=...`.
- Drop the `_amd_smem_safe_tile` workaround that pinned block_m / block_n on gfx950: the underlying LDS-spill is no longer reproducible against current triton / triton_kernels.

## Test Plan

ATOM Test

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
