### PR TITLE
[Perf][vLLM-ATOM] Optimize Sparse MLA in vLLM-ATOM

### DIFF
--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -284,7 +284,7 @@
           "dashboard_model": "DeepSeek-V3.2-FP8-aw-tp4",
           "prefix": "deepseek-v3-2-fp8-aw-tp4",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --kv-cache-dtype auto --block-size 1 --max-num-batched-tokens 16384 --max-model-len 16384",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --kv-cache-dtype auto --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4"
         },
         {
@@ -293,7 +293,7 @@
           "dashboard_model": "DeepSeek-V3.2-FP8-aw-tp8",
           "prefix": "deepseek-v3-2-fp8-aw-tp8",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --block-size 1 --max-num-batched-tokens 16384 --max-model-len 16384",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4"
         }
       ]

--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -139,7 +139,7 @@
   {
     "model_name": "DeepSeek-V3.2-FP8 TP8",
     "model_path": "deepseek-ai/DeepSeek-V3.2",
-    "extraArgs": "--tensor-parallel-size 8 --block-size 1",
+    "extraArgs": "--tensor-parallel-size 8",
     "env_vars": "",
     "runner": "linux-atom-mi35x-8",
     "test_level": "nightly",

--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -1752,6 +1752,15 @@ class AiterMLASparseMetadataForPluginMode:
     block_size: int = 1
     topk_tokens: int = 2048
 
+    # Persistent MLA metadata (only populated when persistent mode is enabled,
+    # i.e. when the aiter sparse decode kernel supports work-stealing splits).
+    work_meta_data: torch.Tensor | None = None
+    work_indptr: torch.Tensor | None = None
+    work_info_set: torch.Tensor | None = None
+    reduce_indptr: torch.Tensor | None = None
+    reduce_final_map: torch.Tensor | None = None
+    reduce_partial_map: torch.Tensor | None = None
+
 
 class vllmMLASparseAttentionMetadataBuilderMethods:
     def __init__(self):
@@ -1799,6 +1808,31 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
         paged_kv_indices = self.paged_kv_indices[: num_tokens * self.topk_tokens]
         paged_kv_indptr = self.paged_kv_indptr[: num_tokens + 1]
 
+        # ----- Compute persistent MLA metadata -----
+        # The aiter sparse decode kernel uses qseqlen=1 (each query token is
+        # treated as its own batch entry), so persistent metadata can always
+        # be precomputed here. The kernel switches to the persistent
+        # work-stealing path automatically when work_meta_data is non-None.
+        get_mla_metadata_v1(
+            qo_indptr,
+            paged_kv_indptr,
+            paged_kv_last_page_len,
+            self.padded_num_heads,
+            1,
+            True,
+            self._mla_work_meta_data,
+            self._mla_work_info_set,
+            self._mla_work_indptr,
+            self._mla_reduce_indptr,
+            self._mla_reduce_final_map,
+            self._mla_reduce_partial_map,
+            page_size=1,
+            kv_granularity=16,
+            max_seqlen_qo=1,
+            uni_seqlen_qo=1,
+            fast_mode=True,
+        )
+
         attn_metadata_for_plugin_mode = AiterMLASparseMetadataForPluginMode(
             num_reqs=common_attn_metadata.num_reqs,
             max_query_len=common_attn_metadata.max_query_len,
@@ -1816,6 +1850,12 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
             paged_kv_last_page_len=paged_kv_last_page_len,
             paged_kv_indices=paged_kv_indices,
             paged_kv_indptr=paged_kv_indptr,
+            work_meta_data=self._mla_work_meta_data,
+            work_indptr=self._mla_work_indptr,
+            work_info_set=self._mla_work_info_set,
+            reduce_indptr=self._mla_reduce_indptr,
+            reduce_final_map=self._mla_reduce_final_map,
+            reduce_partial_map=self._mla_reduce_partial_map,
         )
 
         attn_metadata = AttentionMetaData(
@@ -2273,6 +2313,52 @@ def create_mla_sparse_attn_metadata_builder_init_method(base_class):
         )
         self.paged_kv_indptr = torch.zeros(
             [max_num_batched_tokens + 1], dtype=torch.int32, device=device
+        )
+
+        # ----- Persistent MLA metadata buffers -----
+        # The aiter sparse decode kernel supports a "persistent" path that
+        # uses precomputed work-splitting metadata for better load balancing
+        # across CUs. Mirrors the approach used in rocm_aiter_mla.py.
+        #
+        # In the sparse case each query token is its own "batch" entry in the
+        # qo_indptr (qo_indptr = [0, 1, 2, ..., num_tokens]) and max_qo_len=1.
+        # We pad get_mla_metadata_info_v1's batch_size to max_num_batched_tokens
+        # so the buffers are large enough for any decode shape we might see.
+        (
+            (work_meta_data_size, work_meta_data_type),
+            (work_indptr_size, work_indptr_type),
+            (work_info_set_size, work_info_set_type),
+            (reduce_indptr_size, reduce_indptr_type),
+            (reduce_final_map_size, reduce_final_map_type),
+            (reduce_partial_map_size, reduce_partial_map_type),
+        ) = get_mla_metadata_info_v1(
+            max_num_batched_tokens,
+            1,
+            self.padded_num_heads,
+            torch.bfloat16,
+            dtypes.d_dtypes[config.cache_config.cache_dtype],
+            is_sparse=True,
+            fast_mode=True,
+        )
+        self._mla_work_meta_data = torch.empty(
+            work_meta_data_size, dtype=work_meta_data_type, device=device
+        )
+        self._mla_work_indptr = torch.empty(
+            work_indptr_size, dtype=work_indptr_type, device=device
+        )
+        self._mla_work_info_set = torch.empty(
+            work_info_set_size, dtype=work_info_set_type, device=device
+        )
+        self._mla_reduce_indptr = torch.empty(
+            reduce_indptr_size, dtype=reduce_indptr_type, device=device
+        )
+        self._mla_reduce_final_map = torch.empty(
+            reduce_final_map_size, dtype=reduce_final_map_type, device=device
+        )
+        self._mla_reduce_partial_map = torch.empty(
+            reduce_partial_map_size,
+            dtype=reduce_partial_map_type,
+            device=device,
         )
 
     return init_method_under_plugin_mode

--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -1747,7 +1747,7 @@ class AiterMLASparseMetadataForPluginMode:
     paged_kv_last_page_len: torch.Tensor
     paged_kv_indices: torch.Tensor
     paged_kv_indptr: torch.Tensor
-    paged_kv_indptr_rest: torch.Tensor
+    attn_out_dtype: torch.dtype
 
     block_size: int = 1
     topk_tokens: int = 2048
@@ -1769,18 +1769,35 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
         )
         # Zero-fill for cudagraphs
         self.req_id_per_token_buffer.fill_(0)
+        self.paged_kv_indices.fill_(0)
+        self.paged_kv_indptr.fill_(0)
         self.req_id_per_token_buffer[: req_id_per_token.shape[0]].copy_(
             req_id_per_token, non_blocking=True
         )
-        self.paged_kv_indices.fill_(0)
-        self.paged_kv_indptr.fill_(0)
+        query_lens = (
+            common_attn_metadata.query_start_loc[1:]
+            - common_attn_metadata.query_start_loc[:-1]
+        )
+        seq_lens = common_attn_metadata.seq_lens
+
+        from atom.plugin.attention_mla_sparse import generate_sparse_seqlen_triton
+        sparse_seqlen = generate_sparse_seqlen_triton(
+            query_lens,
+            seq_lens,
+            common_attn_metadata.query_start_loc,
+            self.topk_tokens,
+            num_tokens,
+            common_attn_metadata.max_query_len,
+        )
+
+        torch.cumsum(sparse_seqlen, dim=0, out=self.paged_kv_indptr[1 : num_tokens + 1])
+        self.paged_kv_indptr[num_tokens + 1 :].fill_(self.paged_kv_indptr[num_tokens])
 
         req_id_per_token = self.req_id_per_token_buffer[:num_tokens]
         qo_indptr = self.qo_indptr[: num_tokens + 1]
         paged_kv_last_page_len = self.paged_kv_last_page_len[:num_tokens]
         paged_kv_indices = self.paged_kv_indices[: num_tokens * self.topk_tokens]
         paged_kv_indptr = self.paged_kv_indptr[: num_tokens + 1]
-        paged_kv_indptr_rest = self.paged_kv_indptr[num_tokens + 1 :]
 
         attn_metadata_for_plugin_mode = AiterMLASparseMetadataForPluginMode(
             num_reqs=common_attn_metadata.num_reqs,
@@ -1793,12 +1810,12 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
             block_table=common_attn_metadata.block_table_tensor,
             req_id_per_token=req_id_per_token,
             block_size=self.kv_cache_spec.block_size,
+            attn_out_dtype=self.model_dtype,
             topk_tokens=self.topk_tokens,
             qo_indptr=qo_indptr,
             paged_kv_last_page_len=paged_kv_last_page_len,
             paged_kv_indices=paged_kv_indices,
             paged_kv_indptr=paged_kv_indptr,
-            paged_kv_indptr_rest=paged_kv_indptr_rest,
         )
 
         attn_metadata = AttentionMetaData(
@@ -2066,14 +2083,12 @@ class vllmAiterMLASparseBackendMethods:
 
     @staticmethod
     def get_supported_kernel_block_sizes():
-        return [1]
+        return [1, 64]
 
     @classmethod
     def get_preferred_block_size(cls, default_block_size: int) -> int:
-        # ATOM's sparse MLA plugin path assumes kernel/page block size == 1
-        # throughout metadata construction and KV-cache indexing, so force that
-        # value when vLLM 0.19 negotiates the backend-specific cache block size.
-        return 1
+        # Prefer block_size == 64 so the indexer's preshuffled path is taken
+        return 64
 
     @staticmethod
     def get_kv_cache_shape(
@@ -2219,6 +2234,7 @@ def create_mla_sparse_attn_metadata_builder_init_method(base_class):
 
         self.vllm_config = config
         self.model_config = config.model_config
+        self.model_dtype = self.model_config.dtype
         self.kv_cache_spec = kv_cache_spec
         self.device = device
         max_num_batched_tokens = config.scheduler_config.max_num_batched_tokens
@@ -2228,9 +2244,6 @@ def create_mla_sparse_attn_metadata_builder_init_method(base_class):
         self.padded_num_heads = max(self.num_heads, _MLA_MIN_HEADS)
         self.mla_dims = get_mla_dims(self.model_config)
         self.topk_tokens = config.model_config.hf_config.index_topk
-        self.topk_tokens_tensor = torch.tensor(
-            [self.topk_tokens], device=device, dtype=torch.int32
-        )
         self.max_model_len_tensor = torch.tensor(
             [self.model_config.max_model_len], device=device, dtype=torch.int32
         )

--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -1790,6 +1790,7 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
         seq_lens = common_attn_metadata.seq_lens
 
         from atom.plugin.attention_mla_sparse import generate_sparse_seqlen_triton
+
         sparse_seqlen = generate_sparse_seqlen_triton(
             query_lens,
             seq_lens,

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -132,9 +132,9 @@ def triton_convert_req_index_to_global_index(
     assert block_table.dtype == torch.int32
     assert token_indices.dtype == torch.int32
     assert token_indices.shape[1] == NUM_TOPK_TOKENS
-    assert NUM_TOPK_TOKENS % BLOCK_N == 0, (
-        f"NUM_TOPK_TOKENS ({NUM_TOPK_TOKENS}) must be divisible byBLOCK_N ({BLOCK_N})"
-    )
+    assert (
+        NUM_TOPK_TOKENS % BLOCK_N == 0
+    ), f"NUM_TOPK_TOKENS ({NUM_TOPK_TOKENS}) must be divisible byBLOCK_N ({BLOCK_N})"
     # print("req_id: ", req_id, flush=True)
     num_tokens = req_id.shape[0]
     _, max_num_blocks_per_req = block_table.shape
@@ -483,9 +483,7 @@ class MLASparseAttentionImplPluginModeMethods:
                 layer._q_scale,
             )
             q_out = q_flat.reshape(q_out.shape)
-        attn_out = self._forward_sparse_mla(
-            q_out, kv_cache, attn_metadata, layer
-        )
+        attn_out = self._forward_sparse_mla(q_out, kv_cache, attn_metadata, layer)
 
         # V up-projection
         self._v_up_proj(attn_out, out=output[:num_actual_toks])

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -302,9 +302,6 @@ class MLASparseAttentionImplPluginModeMethods:
 
         kv_buffer = kv_cache.unsqueeze(2)
 
-        # TODO: Currently, persistent mode has memory access issues when input context is long
-        # in fp8 kv cache settings, so it is not used for now.
-        # Re-enable persistent mode when the issue is fixed.
         mla_decode_fwd(
             q,
             kv_buffer.view(-1, 1, 1, q.shape[-1]),
@@ -318,6 +315,12 @@ class MLASparseAttentionImplPluginModeMethods:
             q_scale=layer._q_scale,
             kv_scale=layer._k_scale,
             page_size=1,
+            work_meta_data=sparse_meta.work_meta_data,
+            work_indptr=sparse_meta.work_indptr,
+            work_info_set=sparse_meta.work_info_set,
+            reduce_indptr=sparse_meta.reduce_indptr,
+            reduce_final_map=sparse_meta.reduce_final_map,
+            reduce_partial_map=sparse_meta.reduce_partial_map,
         )
 
         if self.head_repeat_factor > 1:

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -47,6 +47,188 @@ logger = logging.getLogger("atom")
 
 
 @triton.jit
+def _convert_req_index_to_global_index_kernel(
+    req_id_ptr,  # int32 [num_tokens]
+    block_table_ptr,  # int32 [num_requests, max_num_blocks_per_req]
+    token_indices_ptr,  # int32 [num_tokens, NUM_TOPK_TOKENS]
+    cu_seqlens_ptr,  # int32 [num_tokens + 1]
+    out_ptr,  # int32 [num_tokens, NUM_TOPK_TOKENS]
+    # shapes (compile-time where possible)
+    max_num_blocks_per_req: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_N: tl.constexpr,  # tile width along columns
+    # strides (in elements)
+    bt_stride0,
+    bt_stride1,
+    ti_stride0,
+    ti_stride1,
+):
+    # program_id(0) -> token_id (row)
+    # program_id(1) -> tile index along columns
+    token_id = tl.program_id(0)
+    tile_id = tl.program_id(1)
+
+    # Each program covers BLOCK_N consecutive columns
+    indice_id = tile_id * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    # Load request id for this token (no mask: grid is exact)
+    req = tl.load(req_id_ptr + token_id)
+
+    # Load cumulative sequence lengths to get starting index of this request
+    seq_start = tl.load(cu_seqlens_ptr + token_id)
+    seq_end = tl.load(cu_seqlens_ptr + token_id + 1)
+
+    if tile_id * BLOCK_N + seq_start >= seq_end:
+        return
+
+    # Load token indices for this tile
+    ti_ptr = token_indices_ptr + token_id * ti_stride0 + indice_id * ti_stride1
+    tok = tl.load(ti_ptr)  # int32
+
+    # Only token == -1 should propagate as -1
+    is_invalid_tok = tok < 0
+
+    # Compute block id and in-block offset
+    block_id = tok // BLOCK_SIZE
+    inblock_off = tok % BLOCK_SIZE
+
+    # Guard block_table access
+    valid_block = (block_id < max_num_blocks_per_req) & (block_id >= 0)
+    bt_ptr = block_table_ptr + req * bt_stride0 + block_id * bt_stride1
+    base = tl.load(bt_ptr, mask=valid_block, other=0)
+
+    # # If token == -1 OR block_id OOB, output 0; else base * BLOCK_SIZE + offset
+    out_val = tl.where(
+        is_invalid_tok | (~valid_block), 0, base * BLOCK_SIZE + inblock_off
+    )
+    out_ptr_ij = out_ptr + seq_start + indice_id
+    out_ptr_ij_mask = (seq_start + indice_id) < seq_end
+
+    # store the results with mask
+    tl.store(out_ptr_ij, out_val, mask=out_ptr_ij_mask)
+
+
+def triton_convert_req_index_to_global_index(
+    req_id: torch.Tensor,  # int32 [num_tokens]
+    block_table: torch.Tensor,  # int32 [num_requests, max_num_blocks_per_req]
+    token_indices: torch.Tensor,  # int32 [num_tokens, NUM_TOPK_TOKENS]
+    cu_seqlens: torch.Tensor,  # int32 [num_tokens + 1]
+    paged_kv_indices: torch.Tensor,  # int32 [num_tokens * topk] out_buffer
+    BLOCK_SIZE: int = 64,
+    NUM_TOPK_TOKENS: int = 2048,
+    BLOCK_N: int = 128,  # tile width along columns
+):
+    """
+    out[token_id, indice_id] =
+        block_table[req_id[token_id],
+            token_indices[token_id, indice_id] // BLOCK_SIZE] * BLOCK_SIZE
+        + token_indices[token_id, indice_id] % BLOCK_SIZE
+
+    Only when token_indices[token_id, indice_id] == -1 do we output -1.
+    For safety, we also output -1 if the derived block_id would be
+        out-of-bounds.
+    """
+    assert req_id.dtype == torch.int32
+    assert block_table.dtype == torch.int32
+    assert token_indices.dtype == torch.int32
+    assert token_indices.shape[1] == NUM_TOPK_TOKENS
+    assert NUM_TOPK_TOKENS % BLOCK_N == 0, (
+        f"NUM_TOPK_TOKENS ({NUM_TOPK_TOKENS}) must be divisible byBLOCK_N ({BLOCK_N})"
+    )
+    # print("req_id: ", req_id, flush=True)
+    num_tokens = req_id.shape[0]
+    _, max_num_blocks_per_req = block_table.shape
+    tiles_per_row = NUM_TOPK_TOKENS // BLOCK_N
+
+    # Ensure contiguous tensors on the same device
+    req_id_c = req_id.contiguous()
+    block_table_c = block_table.contiguous()
+    token_indices_c = token_indices.contiguous()
+
+    # Strides in elements
+    bt_stride0, bt_stride1 = block_table_c.stride()
+    ti_stride0, ti_stride1 = token_indices_c.stride()
+
+    # Exact 2D grid: tokens × column tiles
+    grid = (num_tokens, tiles_per_row)
+
+    _convert_req_index_to_global_index_kernel[grid](
+        req_id_c,
+        block_table_c,
+        token_indices_c,
+        cu_seqlens,
+        paged_kv_indices,
+        # shapes / constexprs
+        max_num_blocks_per_req,
+        BLOCK_SIZE,
+        BLOCK_N,
+        # strides
+        bt_stride0,
+        bt_stride1,
+        ti_stride0,
+        ti_stride1,
+    )
+    return
+
+
+@triton.jit
+def generate_sparse_seqlen_kernel(
+    seq_len_ptr,  # [num_seq]
+    cu_query_lens_ptr,  # [num_seq]
+    out_ptr,  # [num_query_tokens]
+    topk_token: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    seq_id = tl.program_id(0)
+    query_offset = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    query_start = tl.load(cu_query_lens_ptr + seq_id)
+    query_end = tl.load(cu_query_lens_ptr + seq_id + 1)
+    if query_start + tl.program_id(1) * BLOCK_SIZE > query_end:
+        return
+    query_len = query_end - query_start
+    query_mask = query_offset + query_start < query_end
+    seq_len = tl.load(seq_len_ptr + seq_id)
+    # Just return since the out_ptr is zero initialized.
+    if seq_len == 0:
+        return
+    context_start_point = seq_len - query_len
+    sparse_seqlen = context_start_point + query_offset
+    sparse_seqlen_masked = tl.where(
+        sparse_seqlen + 1 < topk_token, sparse_seqlen + 1, topk_token
+    )
+    tl.store(
+        out_ptr + query_start + query_offset, sparse_seqlen_masked, mask=query_mask
+    )
+
+
+def generate_sparse_seqlen_triton(
+    query_lens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    cu_query_lens: torch.Tensor,
+    topk_token: int,
+    num_tokens: int,
+    max_query_len: int,
+):
+    num_seqs = query_lens.size(0)
+    # zero initialize the tensor to make sure invalid positions will be zero
+    out = torch.zeros([num_tokens], dtype=torch.int32, device=query_lens.device)
+    block_size = 64
+    num_block_per_row = triton.cdiv(max_query_len, block_size)
+    grid = (
+        num_seqs,
+        num_block_per_row,
+    )
+    generate_sparse_seqlen_kernel[grid](
+        seq_lens,
+        cu_query_lens,
+        out,
+        topk_token,
+        block_size,
+    )
+    return out
+
+
+@triton.jit
 def fetch_id_to_ragged_kernel(
     in_tensor_ptr,  # [num_seq, topk]
     cumsum_ptr,  # [num_seq + 1]
@@ -101,11 +283,10 @@ class MLASparseAttentionImplPluginModeMethods:
             "It is only used as a method container for the decorator."
         )
 
-    def _forward_sparse_bf16_kv(
+    def _forward_sparse_mla(
         self,
         q: torch.Tensor,  # [sq, heads, d_qk]
         kv_cache: torch.Tensor,  # [blocks, heads, d_qk]
-        topk_indices_global: torch.Tensor,  # [sq, topk]
         attn_metadata,
         layer,
     ) -> torch.Tensor:
@@ -115,18 +296,8 @@ class MLASparseAttentionImplPluginModeMethods:
         output = torch.empty(
             [num_tokens, self.padded_num_heads, self.kv_lora_rank],
             # dtype=q.dtype,
-            dtype=torch.bfloat16,
+            dtype=sparse_meta.attn_out_dtype,
             device=q.device,
-        )
-
-        seq_len = (topk_indices_global != -1).sum(dim=-1)
-        torch.cumsum(seq_len, dim=0, out=sparse_meta.paged_kv_indptr[1:])
-        sparse_meta.paged_kv_indptr_rest.fill_(sparse_meta.paged_kv_indptr[-1])
-        fetch_id_to_ragged_triton(
-            topk_indices_global,
-            sparse_meta.paged_kv_indptr,
-            sparse_meta.paged_kv_indices,
-            sparse_meta.topk_tokens,
         )
 
         kv_buffer = kv_cache.unsqueeze(2)
@@ -288,22 +459,15 @@ class MLASparseAttentionImplPluginModeMethods:
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        try:
-            from vllm.v1.attention.backends.mla.sparse_utils import (
-                triton_convert_req_index_to_global_index,
-            )
-        except ImportError:
-            from vllm.v1.attention.backends.mla.flashmla_sparse import (
-                triton_convert_req_index_to_global_index,
-            )
-
         req_id_i32 = sparse_meta.req_id_per_token.to(dtype=torch.int32)
         block_table_i32 = sparse_meta.block_table.to(dtype=torch.int32)
         topk_indices_i32 = topk_indices.to(dtype=torch.int32)
-        topk_indices_global = triton_convert_req_index_to_global_index(
-            req_id_i32,  # sparse_meta.req_id_per_token,
-            block_table_i32,  # sparse_meta.block_table,
-            topk_indices_i32,  # topk_indices,
+        triton_convert_req_index_to_global_index(
+            req_id_i32,
+            block_table_i32,
+            topk_indices_i32,
+            sparse_meta.paged_kv_indptr,
+            sparse_meta.paged_kv_indices,
             BLOCK_SIZE=sparse_meta.block_size,
             NUM_TOPK_TOKENS=sparse_meta.topk_tokens,
         )
@@ -316,8 +480,8 @@ class MLASparseAttentionImplPluginModeMethods:
                 layer._q_scale,
             )
             q_out = q_flat.reshape(q_out.shape)
-        attn_out = self._forward_sparse_bf16_kv(
-            q_out, kv_cache, topk_indices_global, attn_metadata, layer
+        attn_out = self._forward_sparse_mla(
+            q_out, kv_cache, attn_metadata, layer
         )
 
         # V up-projection
@@ -355,13 +519,13 @@ def MLASparseAttentionImplDecoratorForPluginMode(cls):
     Decorator that injects sparse MLA methods into the MLAAttentionImpl class.
     Applied alongside the regular MLAAttentionImplDecoratorForPluginMode.
 
-    Injects forward_impl_sparse_plugin_mode and _forward_sparse_bf16_kv.
+    Injects forward_impl_sparse_plugin_mode and _forward_sparse_mla.
     The patched forward_impl in register.py calls forward_impl_plugin_mode,
     which dispatches to forward_impl_sparse_plugin_mode when topk_indices_buffer
     is set.
     """
     sparse_method_names = [
-        "_forward_sparse_bf16_kv",
+        "_forward_sparse_mla",
         "forward_impl_sparse_plugin_mode",
     ]
 
@@ -434,6 +598,8 @@ def sparse_attn_indexer_plugin_mode(
     has_decode = indexer_meta.num_decodes > 0
     has_prefill = indexer_meta.num_prefills > 0
     num_decode_tokens = indexer_meta.num_decode_tokens
+    kv_block_size = kv_cache.shape[1]
+    preshuffle_cache = kv_block_size != 1
 
     indexer_k_quant_and_cache(
         k,
@@ -441,6 +607,7 @@ def sparse_attn_indexer_plugin_mode(
         slot_mapping,
         quant_block_size,
         scale_fmt,
+        preshuffle=preshuffle_cache,
     )
 
     topk_indices_buffer[: hidden_states.shape[0]] = -1
@@ -465,6 +632,7 @@ def sparse_attn_indexer_plugin_mode(
                 k_scale.view(dtypes.fp8),
                 chunk.block_table,
                 chunk.cu_seq_lens,
+                preshuffle=preshuffle_cache,
             )
 
             logits = fp8_mqa_logits(
@@ -530,6 +698,10 @@ def sparse_attn_indexer_plugin_mode(
             decode_metadata.seq_lens,
             decode_metadata.block_table,
             max_model_len,
+            ChunkK=256,
+            Preshuffle=preshuffle_cache,
+            KVBlockSize=kv_block_size,
+            WavePerEU=2,
         )
 
         num_rows = logits.shape[0]
@@ -616,8 +788,15 @@ def IndexerDecoratorForPluginMode(cls):
 def _deepseek_v32_indexer_get_kv_cache_spec(self, vllm_config):
     from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
+    # Use the negotiated cache_config.block_size so the indexer cache and the
+    # main MLA cache share a single block_size. With a uniform block_size,
+    # vLLM groups the two layer types via `UniformTypeKVCacheSpecs.from_specs`
+    # and allocates a separate KVCacheTensor per layer sized to its own
+    # page_size_bytes (576B/token MLA vs 132B/token indexer); otherwise the
+    # smaller indexer page does not divide the MLA page and
+    # `unify_kv_cache_spec_page_size` raises NotImplementedError.
     return MLAAttentionSpec(
-        block_size=1,  # block_size = 1 for indexer on ROCm
+        block_size=vllm_config.cache_config.block_size,
         num_kv_heads=1,
         head_size=self.head_dim,
         dtype=self.dtype,

--- a/recipes/atom_vllm/GLM-5.md
+++ b/recipes/atom_vllm/GLM-5.md
@@ -23,8 +23,7 @@ vllm serve zai-org/GLM-5-FP8 \
     --gpu_memory_utilization 0.9 \
     --async-scheduling \
     --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
-    --no-enable-prefix-caching \
-    --block-size 1
+    --no-enable-prefix-caching
 ```
 
 ## Step 3: Performance Benchmark


### PR DESCRIPTION
## Motivation
This PR adds optimization for sparse MLA in vLLM-ATOM.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
- Enable preshuffled indexer cache and add block_size 64
- Use persistent mla and add respective workspace buffers
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Accuracy test with lm_eval on MI355X

Model: deepseek-ai/DeepSeek-V3.2

Server command:
```
ATOM_DISABLE_VLLM_PLUGIN=0 \
ATOM_DISABLE_VLLM_PLUGIN_ATTENTION=0 \
VLLM_ROCM_USE_AITER=1 \
vllm serve deepseek-ai/DeepSeek-V3.2 \
  -tp 8 \
  --gpu-memory-utilization 0.8 \
  --no-enable-prefix-caching \
  --disable-uvicorn-access-log \
  --trust-remote-code \
  --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
  --kv-cache-dtype fp8
```

lm_eval command
```
lm_eval --model local-completions   --model_args model=deepseek-ai/DeepSeek-V3.2,base_url=http://localhost:8000/v1/completions,num_concurrent=64,tokenized_requests=False  --tasks gsm8k --num_fewshot 20
```

Benchmark command
```
vllm bench serve --model deepseek-ai/DeepSeek-V3.2 --port 8000 --dataset-name random --random-input-len 1024 --random-output-len 1024 --max-concurrency $CONC --num-prompts $(( CONC * 10 )) --ignore-eos --temperature 0
```

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
lm_eval

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|           
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|                                                                                                                                   
|gsm8k|      3|flexible-extract|    20|exact_match|_  |0.9500|_  |0.0060|   
|     |       |strict-match    |    20|exact_match|_  |0.9484|_  |0.0061|

Performance on MI355X, TP8
ISL/OSL | Concurrency | KV Cache | PR req/s | Main req/s | PR over Main (req/s) | PR Total tok/s | Main Total tok/s | PR over Main (tok/s)
-- | -- | -- | -- | -- | -- | -- | -- | --
1k/1k | 64 | fp8 | 2.50 | 2.17 | +15.21% | 5123.55 | 4440.94 | +15.37%
1k/1k | 128 | fp8 | 4.06 | 3.47 | +17.00% | 8320.14 | 7103.16 | +17.13%
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
