### PR TITLE
perf(deepseek_v4): zero-copy wo_a — torch.bmm(out=non_contig) eliminates BF16 direct_copy

### DIFF
--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1839,10 +1839,32 @@ class DeepseekV4Attention(nn.Module):
         # contribution carried in by the value-side RoPE of the KV entries.
         self.rotary_emb.inverse(positions, o[..., -rd:])
         # ----- Grouped output LoRA (batched on the full flat tensor) -----
+        # Pre-allocate wo_b's input as `(num_tokens, n_local_groups * o_lora_rank)`
+        # row-major contiguous, then view it as `(g, s, r)` and pass that view as
+        # `out=` to `torch.bmm`. hipBLAS strided-batched GEMM writes via the given
+        # strides directly into the underlying flat `(s, g·r)` buffer — no copy.
+        #
+        # The previous `torch.einsum("sgd,grd->sgr", ...).flatten(1)` path
+        # produced a non-contig `(s, g, r)` (lazy permute after bmm), and the
+        # `flatten(1)` then forced a `.contiguous()` — launching one extra
+        # `direct_copy_kernel_cuda<BFloat16>` per layer per forward. Same
+        # underlying hipBLAS Tensile BMM kernel runs in both paths; we just
+        # eliminate the post-copy.
         o = o.view(num_tokens, self.n_local_groups, -1)
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-        o = torch.einsum("sgd,grd->sgr", o, wo_a)
-        x = self.wo_b(o.flatten(1))
+        wo_b_in = torch.empty(
+            num_tokens,
+            self.n_local_groups * self.o_lora_rank,
+            dtype=o.dtype,
+            device=o.device,
+        )
+        wo_b_in_view = wo_b_in.view(
+            num_tokens, self.n_local_groups, self.o_lora_rank
+        ).transpose(0, 1)
+        # bmm wants (B, M, K) @ (B, K, N) → (B, M, N). Both inputs as non-contig
+        # views are fine (hipBLAS uses our strides); no .contiguous() forced.
+        torch.bmm(o.transpose(0, 1), wo_a.transpose(1, 2), out=wo_b_in_view)
+        x = self.wo_b(wo_b_in)
         return x
 
     def _fill_csa_paged_compress(


### PR DESCRIPTION
Replaces #676 (62 commits behind main).

## Summary

Eliminate one extra device-side kernel from `DeepseekV4Attention.forward`'s wo_a path. **Same hipBLAS Tensile BMM kernel as main**, no precision change, no quant change. Touches one file: `atom/models/deepseek_v4.py`. Net diff: +24 / −1 lines.

## What changes

```python
# before
o = torch.einsum("sgd,grd->sgr", o, wo_a)
x = self.wo_b(o.flatten(1))

# after
wo_b_in = torch.empty(num_tokens, n_local_groups * o_lora_rank, dtype=o.dtype, device=o.device)
wo_b_in_view = wo_b_in.view(num_tokens, n_local_groups, o_lora_rank).transpose(0, 1)
torch.bmm(o.transpose(0, 1), wo_a.transpose(1, 2), out=wo_b_in_view)
x = self.wo_b(wo_b_in)
```

Pre-allocate wo_b's input as `(s, g·r)` row-major contig and pass it as a `(g, s, r)` view to `torch.bmm` via `out=`. hipBLAS strided-batched GEMM writes via the given strides directly into the underlying flat buffer in `(s, g, r)` row-major order; `wo_b(...)` sees an already-contig `(s, g·r)` view with no `.contiguous()` copy.

## Why this exists

The previous einsum path produced a non-contig `(s, g, r)` output (lazy permute after bmm), and `o.flatten(1)` was forced to call `.contiguous()`, launching one extra `direct_copy_kernel_cuda<BFloat16>` per layer per forward. Found via tune profile inspection of the o_proj region.

## Measured

On MI355X with DSv4-Pro shapes (s=256, g=2, r=1024, d=128), profiling each path in isolation:

```
EINSUM PATH (current main):
  ×5  Cijk_Alik_Bljk_BBS_BH_…_MT64x32x64       ← hipBLAS BMM
  ×5  direct_copy_kernel_cuda<…BFloat16…>       ⚠️ EXTRA COPY

ZERO-COPY PATH (this PR):
  ×5  Cijk_Alik_Bljk_BBS_BH_…_MT64x32x64       ← same hipBLAS BMM
  (no copy kernel)

Max abs diff:  0.000000  (same dtype, same kernel, same math)

Per-layer wall:    einsum 21.81 us  →  zero-copy 20.40 us  (−1.40 us, −6.4%)
× 30 layers per forward step:                              (−42 us)
```

## Why neither FP8 nor Triton BF16

A previous iteration (and PR #676) replaced this path with FP8 BMM, then with Triton BF16 BMM. Both rejected:

| | FP8 BMM | Triton BF16 BMM | torch.bmm zero-copy (this PR) |
|---|---|---|---|
| Eliminates BF16 copy | ✓ | ✓ | ✓ |
| Memory saved | ~4MB / layer (~0.005% of HBM) | 0 | 0 |
| Single-op kernel speed at B=2 | 1.5-2× slower than rocBLAS | +15% slower than hipBLAS (measured) | matches hipBLAS (same kernel) |
| Precision | per-block-scale → scalar (needs lm_eval gate) | identical to main | identical to main |
| Risk surface | quant + compute + layout all change | layout + kernel backend change | layout only |

`torch.bmm(out=non_contig)` keeps the existing hipBLAS Tensile BMM (small-shape tuned for MI355X) and uses its strided-batched output capability — neither precision risk nor kernel-backend risk.

## Test plan

- [x] Kernel-level: confirmed direct_copy disappears, numerical match (max diff 0.0), and **measured −6.4% per-layer wall time on MI355X**
- [ ] CI: simple_inference + lm_eval gates (no precision change expected)
- [ ] Full TPOT benchmark on 8×MI355X via CI dashboard
