### PR TITLE
feat(server): add Anthropic Messages API endpoint (/v1/messages)

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -816,12 +816,29 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             temperature=request.temperature or 1.0,
             max_tokens=request.max_tokens,
             stop_strings=request.stop_sequences,
-            top_k=request.top_k,
-            top_p=request.top_p,
+            ignore_eos=False,
+            top_k=request.top_k if request.top_k is not None else -1,
+            top_p=request.top_p if request.top_p is not None else 1.0,
         )
 
         request_id = uuid.uuid4().hex[:24]
         input_tokens = len(tokenizer.encode(prompt))
+
+        max_ctx = getattr(engine, "max_model_len", None)
+        if max_ctx is None:
+            try:
+                max_ctx = engine.config.max_model_len
+            except AttributeError:
+                max_ctx = 16384
+        headroom = min(request.max_tokens, max_ctx // 2)
+        max_input = max_ctx - headroom
+        if input_tokens > max_input:
+            logger.warning(
+                f"Prompt too long ({input_tokens} > {max_input}), truncating"
+            )
+            token_ids = tokenizer.encode(prompt)[:max_input]
+            prompt = tokenizer.decode(token_ids, skip_special_tokens=False)
+            input_tokens = max_input
 
         if request.stream:
             # Streaming response
@@ -834,6 +851,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 from .tool_parser import ToolCallStreamParser
 
                 reasoning_filter = ReasoningFilter()
+                if prompt.rstrip().endswith("<think>"):
+                    reasoning_filter.state = 1
                 tool_parser = ToolCallStreamParser()
                 block_index = 0
                 started_text = False
@@ -871,78 +890,97 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                 )
                             else:
                                 # Phase 2: Tool call detection on content
-                                tool_parser.process(text)
-                                content_text = tool_parser.get_content()
-                                tool_calls = tool_parser.get_tool_calls()
-
-                                if content_text:
-                                    if started_thinking and not started_text:
+                                events = tool_parser.process(text)
+                                for etype, edata in events:
+                                    if etype == "content":
+                                        if started_thinking and not started_text:
+                                            yield stream_content_block_stop(
+                                                block_index
+                                            )
+                                            block_index += 1
+                                        if not started_text:
+                                            yield stream_content_block_start(
+                                                block_index, "text"
+                                            )
+                                            started_text = True
+                                        yield stream_content_block_delta(
+                                            block_index, edata, "text"
+                                        )
+                                    elif etype == "tool_call_start":
+                                        has_tool_calls = True
+                                        stop_reason = "tool_use"
+                                        if started_text:
+                                            yield stream_content_block_stop(
+                                                block_index
+                                            )
+                                            block_index += 1
+                                            started_text = False
+                                        elif started_thinking:
+                                            yield stream_content_block_stop(
+                                                block_index
+                                            )
+                                            block_index += 1
+                                            started_thinking = False
+                                        fn = edata.get("function", {})
+                                        yield stream_content_block_start(
+                                            block_index,
+                                            "tool_use",
+                                            tool_use_id=edata.get("id", ""),
+                                            tool_name=fn.get("name", ""),
+                                        )
+                                    elif etype == "tool_call_args":
+                                        fn = edata.get("function", {})
+                                        yield stream_content_block_delta(
+                                            block_index,
+                                            fn.get("arguments", ""),
+                                            "tool_use",
+                                        )
+                                    elif etype == "tool_call_end":
                                         yield stream_content_block_stop(block_index)
                                         block_index += 1
+
+                        if finished:
+                            # Flush remaining tool call events
+                            for etype, edata in tool_parser.flush():
+                                if etype == "content":
                                     if not started_text:
+                                        if started_thinking:
+                                            yield stream_content_block_stop(
+                                                block_index
+                                            )
+                                            block_index += 1
+                                            started_thinking = False
                                         yield stream_content_block_start(
                                             block_index, "text"
                                         )
                                         started_text = True
                                     yield stream_content_block_delta(
-                                        block_index, content_text, "text"
+                                        block_index, edata, "text"
                                     )
-
-                                if tool_calls:
+                                elif etype == "tool_call_start":
                                     has_tool_calls = True
                                     stop_reason = "tool_use"
-                                    # Close text block if open
                                     if started_text:
-                                        yield stream_content_block_stop(block_index)
+                                        yield stream_content_block_stop(
+                                            block_index
+                                        )
                                         block_index += 1
                                         started_text = False
-                                    elif started_thinking and not started_text:
-                                        yield stream_content_block_stop(block_index)
-                                        block_index += 1
-                                        started_thinking = False
-                                    for tc in tool_calls:
-                                        args = tc.function.get("arguments", "{}")
-                                        yield stream_content_block_start(
-                                            block_index,
-                                            "tool_use",
-                                            tool_use_id=tc.id,
-                                            tool_name=tc.function.get("name", ""),
-                                        )
-                                        yield stream_content_block_delta(
-                                            block_index,
-                                            json.dumps(args),
-                                            "tool_use",
-                                        )
-                                        yield stream_content_block_stop(block_index)
-                                        block_index += 1
-
-                        if finished:
-                            # Flush remaining tool calls
-                            remaining = tool_parser.flush()
-                            if remaining:
-                                has_tool_calls = True
-                                stop_reason = "tool_use"
-                                if started_text:
-                                    yield stream_content_block_stop(block_index)
-                                    block_index += 1
-                                    started_text = False
-                                for tc in remaining:
-                                    args = (
-                                        tc.function.get("arguments", "{}")
-                                        if False
-                                        else {}
-                                    )
+                                    fn = edata.get("function", {})
                                     yield stream_content_block_start(
                                         block_index,
                                         "tool_use",
-                                        tool_use_id=tc.id,
-                                        tool_name=tc.function.get("name", ""),
+                                        tool_use_id=edata.get("id", ""),
+                                        tool_name=fn.get("name", ""),
                                     )
+                                elif etype == "tool_call_args":
+                                    fn = edata.get("function", {})
                                     yield stream_content_block_delta(
                                         block_index,
-                                        json.dumps(args),
+                                        fn.get("arguments", ""),
                                         "tool_use",
                                     )
+                                elif etype == "tool_call_end":
                                     yield stream_content_block_stop(block_index)
                                     block_index += 1
 
@@ -958,7 +996,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             yield stream_message_stop()
                             break
                 finally:
-                    cleanup_streaming_request(seq_id)
+                    cleanup_streaming_request(request_id, seq_id)
 
             return StreamingResponse(
                 generate_anthropic_stream(),

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -44,6 +44,17 @@ from .serving_chat import (
     stream_chat_response,
     stream_chat_response_fanout,
 )
+from .serving_anthropic import (
+    AnthropicMessagesRequest,
+    anthropic_to_openai_messages,
+    build_anthropic_response,
+    stream_content_block_delta,
+    stream_content_block_start,
+    stream_content_block_stop,
+    stream_message_delta,
+    stream_message_start,
+    stream_message_stop,
+)
 from .serving_completion import (
     build_completion_response,
     build_completion_response_multi,
@@ -771,6 +782,227 @@ async def completions(request: CompletionRequest):
     except Exception as e:
         logger.error(f"Error in completions: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/v1/messages")
+async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Request):
+    """Handle Anthropic Messages API requests.
+
+    Translates Anthropic format to OpenAI format internally, runs inference,
+    and returns Anthropic-formatted responses. Enables Claude Code and other
+    Anthropic-compatible tools to use ATOM as a backend.
+    """
+    global engine, tokenizer, model_name
+
+    try:
+        # Convert Anthropic messages to OpenAI format
+        openai_messages = anthropic_to_openai_messages(request.messages, request.system)
+
+        # Apply chat template
+        from .protocol import ChatMessage
+
+        messages = [ChatMessage(**m) for m in openai_messages]
+
+        merged_kwargs = dict(default_chat_template_kwargs)
+        prompt = apply_chat_template(
+            tokenizer,
+            custom_message_encoder,
+            [msg.to_template_dict() for msg in messages],
+            tools=None,
+            **merged_kwargs,
+        )
+
+        sampling_params = _build_sampling_params(
+            temperature=request.temperature or 1.0,
+            max_tokens=request.max_tokens,
+            stop_strings=request.stop_sequences,
+            top_k=request.top_k,
+            top_p=request.top_p,
+        )
+
+        request_id = uuid.uuid4().hex[:24]
+        input_tokens = len(tokenizer.encode(prompt))
+
+        if request.stream:
+            # Streaming response
+            seq_id, stream_queue = await setup_streaming_request(
+                prompt, sampling_params, request_id
+            )
+
+            async def generate_anthropic_stream():
+                from .reasoning import ReasoningFilter
+                from .tool_parser import ToolCallStreamParser
+
+                reasoning_filter = ReasoningFilter()
+                tool_parser = ToolCallStreamParser()
+                block_index = 0
+                started_text = False
+                started_thinking = False
+                has_tool_calls = False
+                output_tokens = 0
+                stop_reason = "end_turn"
+
+                yield stream_message_start(request_id, model_name, input_tokens)
+
+                try:
+                    while True:
+                        chunk_data = await stream_queue.get()
+                        new_text = chunk_data["text"]
+                        output_tokens += len(chunk_data.get("token_ids", []))
+                        finished = chunk_data.get("finished", False)
+
+                        # Phase 1: Reasoning filter
+                        segments = reasoning_filter.process(new_text)
+                        if finished:
+                            segments.extend(reasoning_filter.flush())
+
+                        for field, text in segments:
+                            if not text:
+                                continue
+
+                            if field == "reasoning_content":
+                                if not started_thinking:
+                                    yield stream_content_block_start(
+                                        block_index, "thinking"
+                                    )
+                                    started_thinking = True
+                                yield stream_content_block_delta(
+                                    block_index, text, "thinking"
+                                )
+                            else:
+                                # Phase 2: Tool call detection on content
+                                tool_parser.process(text)
+                                content_text = tool_parser.get_content()
+                                tool_calls = tool_parser.get_tool_calls()
+
+                                if content_text:
+                                    if started_thinking and not started_text:
+                                        yield stream_content_block_stop(block_index)
+                                        block_index += 1
+                                    if not started_text:
+                                        yield stream_content_block_start(
+                                            block_index, "text"
+                                        )
+                                        started_text = True
+                                    yield stream_content_block_delta(
+                                        block_index, content_text, "text"
+                                    )
+
+                                if tool_calls:
+                                    has_tool_calls = True
+                                    stop_reason = "tool_use"
+                                    # Close text block if open
+                                    if started_text:
+                                        yield stream_content_block_stop(block_index)
+                                        block_index += 1
+                                        started_text = False
+                                    elif started_thinking and not started_text:
+                                        yield stream_content_block_stop(block_index)
+                                        block_index += 1
+                                        started_thinking = False
+                                    for tc in tool_calls:
+                                        args = tc.function.get("arguments", "{}")
+                                        yield stream_content_block_start(
+                                            block_index,
+                                            "tool_use",
+                                            tool_use_id=tc.id,
+                                            tool_name=tc.function.get("name", ""),
+                                        )
+                                        yield stream_content_block_delta(
+                                            block_index,
+                                            json.dumps(args),
+                                            "tool_use",
+                                        )
+                                        yield stream_content_block_stop(block_index)
+                                        block_index += 1
+
+                        if finished:
+                            # Flush remaining tool calls
+                            remaining = tool_parser.flush()
+                            if remaining:
+                                has_tool_calls = True
+                                stop_reason = "tool_use"
+                                if started_text:
+                                    yield stream_content_block_stop(block_index)
+                                    block_index += 1
+                                    started_text = False
+                                for tc in remaining:
+                                    args = (
+                                        tc.function.get("arguments", "{}")
+                                        if False
+                                        else {}
+                                    )
+                                    yield stream_content_block_start(
+                                        block_index,
+                                        "tool_use",
+                                        tool_use_id=tc.id,
+                                        tool_name=tc.function.get("name", ""),
+                                    )
+                                    yield stream_content_block_delta(
+                                        block_index,
+                                        json.dumps(args),
+                                        "tool_use",
+                                    )
+                                    yield stream_content_block_stop(block_index)
+                                    block_index += 1
+
+                            if not started_text and not has_tool_calls:
+                                if started_thinking:
+                                    yield stream_content_block_stop(block_index)
+                                    block_index += 1
+                                yield stream_content_block_start(block_index, "text")
+                                started_text = True
+                            if started_text:
+                                yield stream_content_block_stop(block_index)
+                            yield stream_message_delta(stop_reason, output_tokens)
+                            yield stream_message_stop()
+                            break
+                finally:
+                    cleanup_streaming_request(seq_id)
+
+            return StreamingResponse(
+                generate_anthropic_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "anthropic-version": "2023-06-01",
+                    "x-request-id": request_id,
+                },
+            )
+
+        # Non-streaming response
+        from .reasoning import separate_reasoning
+        from .tool_parser import parse_tool_calls
+
+        final_output = None
+        async for output in generate_async(prompt, sampling_params, request_id):
+            final_output = output
+        if final_output is None:
+            raise RuntimeError("No output generated")
+
+        raw_text = final_output["text"]
+        reasoning_content, content_with_tools = separate_reasoning(raw_text)
+        content_text, tool_calls = parse_tool_calls(content_with_tools)
+        output_tokens = len(tokenizer.encode(raw_text))
+
+        return build_anthropic_response(
+            request_id=request_id,
+            model=model_name,
+            content_text=content_text,
+            reasoning_content=reasoning_content,
+            tool_calls=tool_calls if tool_calls else None,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+
+    except Exception as e:
+        logger.error(f"Error in anthropic_messages: {e}", exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={
+                "type": "error",
+                "error": {"type": "api_error", "message": str(e)},
+            },
+        )
 
 
 @app.get("/v1/models")

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -47,6 +47,7 @@ from .serving_chat import (
 from .serving_anthropic import (
     AnthropicMessagesRequest,
     anthropic_to_openai_messages,
+    anthropic_to_openai_tools,
     build_anthropic_response,
     stream_content_block_delta,
     stream_content_block_start,
@@ -803,12 +804,14 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
         messages = [ChatMessage(**m) for m in openai_messages]
 
+        openai_tools = anthropic_to_openai_tools(request.tools)
+
         merged_kwargs = dict(default_chat_template_kwargs)
         prompt = apply_chat_template(
             tokenizer,
             custom_message_encoder,
             [msg.to_template_dict() for msg in messages],
-            tools=None,
+            tools=openai_tools,
             **merged_kwargs,
         )
 

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -47,7 +47,6 @@ from .serving_chat import (
 from .serving_anthropic import (
     AnthropicMessagesRequest,
     anthropic_to_openai_messages,
-    anthropic_to_openai_tools,
     build_anthropic_response,
     stream_content_block_delta,
     stream_content_block_start,
@@ -55,6 +54,7 @@ from .serving_anthropic import (
     stream_message_delta,
     stream_message_start,
     stream_message_stop,
+    stream_signature_delta,
 )
 from .serving_completion import (
     build_completion_response,
@@ -804,14 +804,12 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
         messages = [ChatMessage(**m) for m in openai_messages]
 
-        openai_tools = anthropic_to_openai_tools(request.tools)
-
         merged_kwargs = dict(default_chat_template_kwargs)
         prompt = apply_chat_template(
             tokenizer,
             custom_message_encoder,
             [msg.to_template_dict() for msg in messages],
-            tools=openai_tools,
+            tools=None,
             **merged_kwargs,
         )
 
@@ -833,7 +831,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 max_ctx = engine.config.max_model_len
             except AttributeError:
                 max_ctx = 16384
-        headroom = min(request.max_tokens, max_ctx // 2)
+        headroom = min(request.max_tokens, max_ctx // 4)
         max_input = max_ctx - headroom
         if input_tokens > max_input:
             logger.warning(
@@ -883,23 +881,15 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                 continue
 
                             if field == "reasoning_content":
-                                if not started_thinking:
-                                    yield stream_content_block_start(
-                                        block_index, "thinking"
-                                    )
-                                    started_thinking = True
-                                yield stream_content_block_delta(
-                                    block_index, text, "thinking"
-                                )
+                                pass
                             else:
                                 # Phase 2: Tool call detection on content
                                 events = tool_parser.process(text)
                                 for etype, edata in events:
                                     if etype == "content":
                                         if started_thinking and not started_text:
-                                            yield stream_content_block_stop(
-                                                block_index
-                                            )
+                                            yield stream_signature_delta(block_index)
+                                            yield stream_content_block_stop(block_index)
                                             block_index += 1
                                         if not started_text:
                                             yield stream_content_block_start(
@@ -913,15 +903,12 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                         has_tool_calls = True
                                         stop_reason = "tool_use"
                                         if started_text:
-                                            yield stream_content_block_stop(
-                                                block_index
-                                            )
+                                            yield stream_content_block_stop(block_index)
                                             block_index += 1
                                             started_text = False
                                         elif started_thinking:
-                                            yield stream_content_block_stop(
-                                                block_index
-                                            )
+                                            yield stream_signature_delta(block_index)
+                                            yield stream_content_block_stop(block_index)
                                             block_index += 1
                                             started_thinking = False
                                         fn = edata.get("function", {})
@@ -948,9 +935,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                 if etype == "content":
                                     if not started_text:
                                         if started_thinking:
-                                            yield stream_content_block_stop(
-                                                block_index
-                                            )
+                                            yield stream_signature_delta(block_index)
+                                            yield stream_content_block_stop(block_index)
                                             block_index += 1
                                             started_thinking = False
                                         yield stream_content_block_start(
@@ -964,9 +950,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                     has_tool_calls = True
                                     stop_reason = "tool_use"
                                     if started_text:
-                                        yield stream_content_block_stop(
-                                            block_index
-                                        )
+                                        yield stream_content_block_stop(block_index)
                                         block_index += 1
                                         started_text = False
                                     fn = edata.get("function", {})
@@ -989,6 +973,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
                             if not started_text and not has_tool_calls:
                                 if started_thinking:
+                                    yield stream_signature_delta(block_index)
                                     yield stream_content_block_stop(block_index)
                                     block_index += 1
                                 yield stream_content_block_start(block_index, "text")

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -110,11 +110,10 @@ class ReasoningFilter:
                 self.buf = ""
                 if after:
                     results.extend(self._process_content(after))
-            elif len(self.buf) > 7 and "<" not in self.buf:
-                # No <think> tag found — emit as content. For models that
-                # don't emit <think> (MiniMax), streaming reasoning separation
-                # requires buffering the entire response, which is impractical.
-                # Non-streaming path handles this correctly via separate_reasoning().
+            elif len(self.buf) > 100 and "<" not in self.buf:
+                # No think tags found after significant buffering — emit as
+                # content. Uses a large threshold to give models time to emit
+                # </think> when the chat template injected <think>.
                 results.append(("content", self.buf))
                 self.buf = ""
 

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Anthropic Messages API adapter for ATOM.
+
+Translates Anthropic /v1/messages requests to ATOM's internal format and
+converts responses back to Anthropic format. Enables Claude Code and other
+Anthropic-compatible tools to use ATOM as a backend.
+"""
+
+import json
+import logging
+from typing import Any, List, Optional
+
+from pydantic import BaseModel
+
+logger = logging.getLogger("atom")
+
+
+# ── Anthropic Request Schema ───────────────────────────────────────────
+
+
+class AnthropicContentBlock(BaseModel):
+    type: str
+    text: Optional[str] = None
+    # tool_use fields
+    id: Optional[str] = None
+    name: Optional[str] = None
+    input: Optional[Any] = None
+    # tool_result fields
+    tool_use_id: Optional[str] = None
+    content: Optional[Any] = None
+
+
+class AnthropicMessage(BaseModel):
+    role: str
+    content: Any  # str or list[AnthropicContentBlock]
+
+
+class AnthropicMessagesRequest(BaseModel):
+    model: str
+    messages: List[AnthropicMessage]
+    max_tokens: int = 4096
+    system: Optional[Any] = None  # str or list
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    stream: bool = False
+    stop_sequences: Optional[List[str]] = None
+    tools: Optional[List[dict]] = None
+    tool_choice: Optional[Any] = None
+    metadata: Optional[dict] = None
+
+
+# ── Format Conversion ──────────────────────────────────────────────────
+
+
+def anthropic_to_openai_messages(
+    messages: List[AnthropicMessage],
+    system: Optional[Any] = None,
+) -> List[dict]:
+    """Convert Anthropic messages to OpenAI format."""
+    result = []
+
+    # System message
+    if system:
+        if isinstance(system, str):
+            result.append({"role": "system", "content": system})
+        elif isinstance(system, list):
+            text_parts = [b["text"] for b in system if b.get("type") == "text"]
+            result.append({"role": "system", "content": "\n".join(text_parts)})
+
+    for msg in messages:
+        role = msg.role
+        content = msg.content
+
+        if role == "assistant":
+            if isinstance(content, str):
+                result.append({"role": "assistant", "content": content})
+            elif isinstance(content, list):
+                text_parts = []
+                tool_calls = []
+                for block in content:
+                    if isinstance(block, dict):
+                        if block.get("type") == "text":
+                            text_parts.append(block["text"])
+                        elif block.get("type") == "tool_use":
+                            tool_calls.append(
+                                {
+                                    "id": block["id"],
+                                    "type": "function",
+                                    "function": {
+                                        "name": block["name"],
+                                        "arguments": json.dumps(block.get("input", {})),
+                                    },
+                                }
+                            )
+                entry = {"role": "assistant", "content": "\n".join(text_parts) or None}
+                if tool_calls:
+                    entry["tool_calls"] = tool_calls
+                result.append(entry)
+
+        elif role == "user":
+            if isinstance(content, str):
+                result.append({"role": "user", "content": content})
+            elif isinstance(content, list):
+                text_parts = []
+                tool_results = []
+                for block in content:
+                    if isinstance(block, dict):
+                        if block.get("type") == "text":
+                            text_parts.append(block["text"])
+                        elif block.get("type") == "tool_result":
+                            tool_content = block.get("content", "")
+                            if isinstance(tool_content, list):
+                                tool_content = "\n".join(
+                                    b.get("text", "")
+                                    for b in tool_content
+                                    if isinstance(b, dict) and b.get("type") == "text"
+                                )
+                            tool_results.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": block["tool_use_id"],
+                                    "content": str(tool_content),
+                                }
+                            )
+                if text_parts:
+                    result.append({"role": "user", "content": "\n".join(text_parts)})
+                result.extend(tool_results)
+        else:
+            result.append({"role": role, "content": str(content) if content else ""})
+
+    return result
+
+
+def anthropic_to_openai_tools(tools: Optional[List[dict]]) -> Optional[List[dict]]:
+    """Convert Anthropic tool definitions to OpenAI format."""
+    if not tools:
+        return None
+    result = []
+    for tool in tools:
+        result.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": tool.get("input_schema", {}),
+                },
+            }
+        )
+    return result
+
+
+# ── Response Construction ──────────────────────────────────────────────
+
+
+def build_anthropic_response(
+    request_id: str,
+    model: str,
+    content_text: str,
+    reasoning_content: Optional[str] = None,
+    tool_calls: Optional[list] = None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    stop_reason: str = "end_turn",
+) -> dict:
+    """Build Anthropic Messages API response.
+
+    Args:
+        tool_calls: List of ToolCall objects (from tool_parser.parse_tool_calls).
+            Each has .name, .arguments (dict), .call_id.
+    """
+    content = []
+
+    if reasoning_content:
+        content.append(
+            {
+                "type": "thinking",
+                "thinking": reasoning_content,
+            }
+        )
+
+    if content_text:
+        content.append(
+            {
+                "type": "text",
+                "text": content_text,
+            }
+        )
+
+    if tool_calls:
+        stop_reason = "tool_use"
+        for tc in tool_calls:
+            # ToolCall has .id, .function["name"], .function["arguments"]
+            func = tc.function if isinstance(tc.function, dict) else {}
+            args_str = func.get("arguments", "{}")
+            try:
+                args = json.loads(args_str) if isinstance(args_str, str) else args_str
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+            content.append(
+                {
+                    "type": "tool_use",
+                    "id": tc.id,
+                    "name": func.get("name", ""),
+                    "input": args,
+                }
+            )
+
+    # Ensure at least one content block
+    if not content:
+        content.append({"type": "text", "text": ""})
+
+    return {
+        "id": f"msg_{request_id}",
+        "type": "message",
+        "role": "assistant",
+        "content": content,
+        "model": model,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        },
+    }
+
+
+# ── Streaming ──────────────────────────────────────────────────────────
+
+
+def format_sse(event: str, data: Any) -> str:
+    """Format a server-sent event."""
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+def stream_message_start(request_id: str, model: str, input_tokens: int = 0) -> str:
+    return format_sse(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": f"msg_{request_id}",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": model,
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+            },
+        },
+    )
+
+
+def stream_content_block_start(
+    index: int,
+    block_type: str = "text",
+    tool_use_id: str = "",
+    tool_name: str = "",
+) -> str:
+    if block_type == "thinking":
+        block = {"type": "thinking", "thinking": ""}
+    elif block_type == "tool_use":
+        block = {
+            "type": "tool_use",
+            "id": tool_use_id,
+            "name": tool_name,
+            "input": {},
+        }
+    else:
+        block = {"type": "text", "text": ""}
+    return format_sse(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": index,
+            "content_block": block,
+        },
+    )
+
+
+def stream_content_block_delta(index: int, text: str, block_type: str = "text") -> str:
+    if block_type == "thinking":
+        delta = {"type": "thinking_delta", "thinking": text}
+    elif block_type == "tool_use":
+        delta = {"type": "input_json_delta", "partial_json": text}
+    else:
+        delta = {"type": "text_delta", "text": text}
+    return format_sse(
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": delta,
+        },
+    )
+
+
+def stream_content_block_stop(index: int) -> str:
+    return format_sse(
+        "content_block_stop",
+        {
+            "type": "content_block_stop",
+            "index": index,
+        },
+    )
+
+
+def stream_message_delta(stop_reason: str = "end_turn", output_tokens: int = 0) -> str:
+    return format_sse(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+            "usage": {"output_tokens": output_tokens},
+        },
+    )
+
+
+def stream_message_stop() -> str:
+    return format_sse("message_stop", {"type": "message_stop"})

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -67,8 +67,15 @@ def anthropic_to_openai_messages(
         if isinstance(system, str):
             result.append({"role": "system", "content": system})
         elif isinstance(system, list):
-            text_parts = [b["text"] for b in system if b.get("type") == "text"]
-            result.append({"role": "system", "content": "\n".join(text_parts)})
+            text_parts = []
+            for b in system:
+                if b.get("type") == "text":
+                    text = b["text"]
+                    if text.startswith("x-anthropic-billing-header"):
+                        continue
+                    text_parts.append(text)
+            if text_parts:
+                result.append({"role": "system", "content": "\n".join(text_parts)})
 
     for msg in messages:
         role = msg.role

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -224,6 +224,8 @@ def build_anthropic_response(
         "usage": {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
         },
     }
 
@@ -249,7 +251,12 @@ def stream_message_start(request_id: str, model: str, input_tokens: int = 0) -> 
                 "model": model,
                 "stop_reason": None,
                 "stop_sequence": None,
-                "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
             },
         },
     )

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -175,10 +175,16 @@ def build_anthropic_response(
     content = []
 
     if reasoning_content:
+        import base64
+        import hashlib
+        import os
+
+        sig = base64.b64encode(hashlib.sha256(os.urandom(32)).digest()).decode()
         content.append(
             {
                 "type": "thinking",
                 "thinking": reasoning_content,
+                "signature": sig,
             }
         )
 
@@ -269,7 +275,7 @@ def stream_content_block_start(
     tool_name: str = "",
 ) -> str:
     if block_type == "thinking":
-        block = {"type": "thinking", "thinking": ""}
+        block = {"type": "thinking", "thinking": "", "signature": ""}
     elif block_type == "tool_use":
         block = {
             "type": "tool_use",
@@ -302,6 +308,23 @@ def stream_content_block_delta(index: int, text: str, block_type: str = "text") 
             "type": "content_block_delta",
             "index": index,
             "delta": delta,
+        },
+    )
+
+
+def stream_signature_delta(index: int) -> str:
+    """Emit a signature_delta for thinking blocks (required by Claude Code)."""
+    import base64
+    import hashlib
+    import os
+
+    dummy_sig = base64.b64encode(hashlib.sha256(os.urandom(32)).digest()).decode()
+    return format_sse(
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"type": "signature_delta", "signature": dummy_sig},
         },
     )
 

--- a/atom/entrypoints/openai/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser.py
@@ -17,7 +17,6 @@ OpenAI format:
 """
 
 import re
-import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
 
@@ -81,11 +80,12 @@ def _parse_tool_call_entries(section_text: str) -> List[ToolCall]:
     )
     for match in pattern.finditer(section_text):
         name = match.group(1)
-        _index = match.group(2)  # noqa: F841 (captured but not used in ID generation)
+        index = match.group(2)
         arguments = match.group(3).strip()
+        tool_id = f"functions.{name}:{index}"
         tool_calls.append(
             ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
+                id=tool_id,
                 type="function",
                 function={"name": name, "arguments": arguments},
             )
@@ -171,13 +171,13 @@ class ToolCallStreamParser:
             index = int(match.group(2))
             arguments = match.group(3).strip()
 
-            call_id = f"call_{uuid.uuid4().hex[:8]}"
+            tool_id = f"functions.{name}:{index}"
             results.append(
                 (
                     "tool_call_start",
                     {
                         "index": index,
-                        "id": call_id,
+                        "id": tool_id,
                         "type": "function",
                         "function": {"name": name, "arguments": ""},
                     },

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -446,3 +446,23 @@ class TestAnthropicMessagesRequest:
         assert req.stream is True
         assert req.stop_sequences == ["STOP"]
         assert len(req.tools) == 1
+
+    def test_attribution_header_stripped(self):
+        system = [
+            {"type": "text", "text": "x-anthropic-billing-header: abc123"},
+            {"type": "text", "text": "You are helpful."},
+        ]
+        msgs = [AnthropicMessage(role="user", content="Hi")]
+        result = anthropic_to_openai_messages(msgs, system=system)
+        assert result[0]["role"] == "system"
+        assert "x-anthropic-billing-header" not in result[0]["content"]
+        assert "You are helpful." in result[0]["content"]
+
+    def test_attribution_header_only_system(self):
+        system = [
+            {"type": "text", "text": "x-anthropic-billing-header: xyz"},
+        ]
+        msgs = [AnthropicMessage(role="user", content="Hi")]
+        result = anthropic_to_openai_messages(msgs, system=system)
+        # No system message when all blocks are attribution headers
+        assert result[0]["role"] == "user"

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for Anthropic Messages API endpoint adapter.
+
+Tests the format translation layer (serving_anthropic.py) without
+requiring a running GPU server — uses unit tests on the conversion
+functions and response builders.
+"""
+
+import json
+
+
+from atom.entrypoints.openai.serving_anthropic import (
+    AnthropicMessage,
+    AnthropicMessagesRequest,
+    anthropic_to_openai_messages,
+    anthropic_to_openai_tools,
+    build_anthropic_response,
+    format_sse,
+    stream_content_block_delta,
+    stream_content_block_start,
+    stream_content_block_stop,
+    stream_message_delta,
+    stream_message_start,
+    stream_message_stop,
+)
+
+# ============================================================================
+# Message Conversion Tests
+# ============================================================================
+
+
+class TestAnthropicToOpenAIMessages:
+    def test_simple_user_message(self):
+        msgs = [AnthropicMessage(role="user", content="Hello")]
+        result = anthropic_to_openai_messages(msgs)
+        assert len(result) == 1
+        assert result[0] == {"role": "user", "content": "Hello"}
+
+    def test_system_string(self):
+        msgs = [AnthropicMessage(role="user", content="Hi")]
+        result = anthropic_to_openai_messages(msgs, system="You are helpful.")
+        assert len(result) == 2
+        assert result[0] == {"role": "system", "content": "You are helpful."}
+        assert result[1]["role"] == "user"
+
+    def test_system_content_blocks(self):
+        system = [
+            {"type": "text", "text": "You are helpful."},
+            {"type": "text", "text": "Be concise."},
+        ]
+        msgs = [AnthropicMessage(role="user", content="Hi")]
+        result = anthropic_to_openai_messages(msgs, system=system)
+        assert result[0]["role"] == "system"
+        assert "You are helpful." in result[0]["content"]
+        assert "Be concise." in result[0]["content"]
+
+    def test_user_content_blocks(self):
+        msgs = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    {"type": "text", "text": "Part 1."},
+                    {"type": "text", "text": "Part 2."},
+                ],
+            )
+        ]
+        result = anthropic_to_openai_messages(msgs)
+        assert result[0]["content"] == "Part 1.\nPart 2."
+
+    def test_assistant_string(self):
+        msgs = [
+            AnthropicMessage(role="user", content="Hi"),
+            AnthropicMessage(role="assistant", content="Hello!"),
+        ]
+        result = anthropic_to_openai_messages(msgs)
+        assert result[1] == {"role": "assistant", "content": "Hello!"}
+
+    def test_assistant_with_tool_use(self):
+        msgs = [
+            AnthropicMessage(
+                role="assistant",
+                content=[
+                    {"type": "text", "text": "Let me check."},
+                    {
+                        "type": "tool_use",
+                        "id": "call_123",
+                        "name": "get_weather",
+                        "input": {"city": "NYC"},
+                    },
+                ],
+            )
+        ]
+        result = anthropic_to_openai_messages(msgs)
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "Let me check."
+        assert len(result[0]["tool_calls"]) == 1
+        tc = result[0]["tool_calls"][0]
+        assert tc["id"] == "call_123"
+        assert tc["function"]["name"] == "get_weather"
+        assert json.loads(tc["function"]["arguments"]) == {"city": "NYC"}
+
+    def test_tool_result_in_user_message(self):
+        msgs = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_123",
+                        "content": "72°F, sunny",
+                    }
+                ],
+            )
+        ]
+        result = anthropic_to_openai_messages(msgs)
+        assert result[0]["role"] == "tool"
+        assert result[0]["tool_call_id"] == "call_123"
+        assert result[0]["content"] == "72°F, sunny"
+
+    def test_tool_result_with_content_blocks(self):
+        msgs = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_456",
+                        "content": [
+                            {"type": "text", "text": "Result line 1"},
+                            {"type": "text", "text": "Result line 2"},
+                        ],
+                    }
+                ],
+            )
+        ]
+        result = anthropic_to_openai_messages(msgs)
+        assert result[0]["role"] == "tool"
+        assert "Result line 1" in result[0]["content"]
+        assert "Result line 2" in result[0]["content"]
+
+    def test_multi_turn_conversation(self):
+        msgs = [
+            AnthropicMessage(role="user", content="What's the weather?"),
+            AnthropicMessage(
+                role="assistant",
+                content=[
+                    {"type": "text", "text": "Let me check."},
+                    {
+                        "type": "tool_use",
+                        "id": "call_1",
+                        "name": "get_weather",
+                        "input": {"city": "NYC"},
+                    },
+                ],
+            ),
+            AnthropicMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "72°F",
+                    }
+                ],
+            ),
+            AnthropicMessage(role="assistant", content="It's 72°F in NYC."),
+            AnthropicMessage(role="user", content="Thanks!"),
+        ]
+        result = anthropic_to_openai_messages(msgs, system="Weather bot")
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+        assert result[2]["role"] == "assistant"
+        assert "tool_calls" in result[2]
+        assert result[3]["role"] == "tool"
+        assert result[4]["role"] == "assistant"
+        assert result[5]["role"] == "user"
+
+
+# ============================================================================
+# Tool Definition Conversion Tests
+# ============================================================================
+
+
+class TestAnthropicToOpenAITools:
+    def test_none_tools(self):
+        assert anthropic_to_openai_tools(None) is None
+
+    def test_empty_tools(self):
+        assert anthropic_to_openai_tools([]) is None
+
+    def test_single_tool(self):
+        tools = [
+            {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        ]
+        result = anthropic_to_openai_tools(tools)
+        assert len(result) == 1
+        assert result[0]["type"] == "function"
+        assert result[0]["function"]["name"] == "get_weather"
+        assert result[0]["function"]["description"] == "Get weather for a city"
+        assert "city" in result[0]["function"]["parameters"]["properties"]
+
+    def test_multiple_tools(self):
+        tools = [
+            {"name": "tool_a", "description": "A", "input_schema": {}},
+            {"name": "tool_b", "description": "B", "input_schema": {}},
+        ]
+        result = anthropic_to_openai_tools(tools)
+        assert len(result) == 2
+        assert result[0]["function"]["name"] == "tool_a"
+        assert result[1]["function"]["name"] == "tool_b"
+
+
+# ============================================================================
+# Response Building Tests
+# ============================================================================
+
+
+class TestBuildAnthropicResponse:
+    def test_basic_response(self):
+        resp = build_anthropic_response(
+            request_id="test123",
+            model="test-model",
+            content_text="Hello!",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        assert resp["type"] == "message"
+        assert resp["role"] == "assistant"
+        assert resp["model"] == "test-model"
+        assert resp["id"] == "msg_test123"
+        assert len(resp["content"]) == 1
+        assert resp["content"][0]["type"] == "text"
+        assert resp["content"][0]["text"] == "Hello!"
+        assert resp["usage"]["input_tokens"] == 10
+        assert resp["usage"]["output_tokens"] == 5
+        assert resp["stop_reason"] == "end_turn"
+
+    def test_response_with_reasoning(self):
+        resp = build_anthropic_response(
+            request_id="test456",
+            model="test-model",
+            content_text="The answer is 42.",
+            reasoning_content="Let me think about this...",
+            input_tokens=20,
+            output_tokens=15,
+        )
+        assert len(resp["content"]) == 2
+        assert resp["content"][0]["type"] == "thinking"
+        assert resp["content"][0]["thinking"] == "Let me think about this..."
+        assert resp["content"][1]["type"] == "text"
+        assert resp["content"][1]["text"] == "The answer is 42."
+
+    def test_response_no_reasoning(self):
+        resp = build_anthropic_response(
+            request_id="test789",
+            model="m",
+            content_text="Direct answer.",
+        )
+        assert len(resp["content"]) == 1
+        assert resp["content"][0]["type"] == "text"
+
+    def test_response_with_tool_calls(self):
+        from atom.entrypoints.openai.tool_parser import ToolCall
+
+        tc = ToolCall(
+            id="call_0",
+            type="function",
+            function={"name": "read_file", "arguments": '{"path": "/tmp/foo.py"}'},
+        )
+        resp = build_anthropic_response(
+            request_id="test_tc",
+            model="m",
+            content_text="Let me read that file.",
+            tool_calls=[tc],
+        )
+        assert resp["stop_reason"] == "tool_use"
+        types = [b["type"] for b in resp["content"]]
+        assert "text" in types
+        assert "tool_use" in types
+        tool_block = [b for b in resp["content"] if b["type"] == "tool_use"][0]
+        assert tool_block["name"] == "read_file"
+        assert tool_block["input"] == {"path": "/tmp/foo.py"}
+        assert tool_block["id"] == "call_0"
+
+    def test_response_with_reasoning_and_tool_calls(self):
+        from atom.entrypoints.openai.tool_parser import ToolCall
+
+        tc = ToolCall(
+            id="call_1",
+            type="function",
+            function={"name": "bash", "arguments": '{"command": "ls"}'},
+        )
+        resp = build_anthropic_response(
+            request_id="test_rtc",
+            model="m",
+            content_text="I'll run a command.",
+            reasoning_content="The user wants to list files.",
+            tool_calls=[tc],
+        )
+        types = [b["type"] for b in resp["content"]]
+        assert types == ["thinking", "text", "tool_use"]
+        assert resp["stop_reason"] == "tool_use"
+
+    def test_response_empty_content_with_tool_call(self):
+        from atom.entrypoints.openai.tool_parser import ToolCall
+
+        tc = ToolCall(
+            id="call_2",
+            type="function",
+            function={"name": "bash", "arguments": '{"command": "pwd"}'},
+        )
+        resp = build_anthropic_response(
+            request_id="test_empty",
+            model="m",
+            content_text="",
+            tool_calls=[tc],
+        )
+        types = [b["type"] for b in resp["content"]]
+        assert "tool_use" in types
+        assert resp["stop_reason"] == "tool_use"
+
+
+# ============================================================================
+# SSE Streaming Format Tests
+# ============================================================================
+
+
+class TestSSEFormatting:
+    def test_format_sse(self):
+        result = format_sse("test_event", {"key": "value"})
+        assert result.startswith("event: test_event\n")
+        assert "data: " in result
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["key"] == "value"
+
+    def test_message_start(self):
+        result = stream_message_start("req1", "model1", 50)
+        assert "event: message_start" in result
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["type"] == "message_start"
+        assert data["message"]["role"] == "assistant"
+        assert data["message"]["model"] == "model1"
+        assert data["message"]["usage"]["input_tokens"] == 50
+
+    def test_content_block_start_tool_use(self):
+        result = stream_content_block_start(
+            2, "tool_use", tool_use_id="toolu_123", tool_name="read_file"
+        )
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["content_block"]["type"] == "tool_use"
+        assert data["content_block"]["id"] == "toolu_123"
+        assert data["content_block"]["name"] == "read_file"
+        assert data["index"] == 2
+
+    def test_content_block_delta_tool_use(self):
+        result = stream_content_block_delta(2, '{"path": "/foo"}', "tool_use")
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["delta"]["type"] == "input_json_delta"
+        assert data["delta"]["partial_json"] == '{"path": "/foo"}'
+
+    def test_content_block_start_text(self):
+        result = stream_content_block_start(0, "text")
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["type"] == "content_block_start"
+        assert data["index"] == 0
+        assert data["content_block"]["type"] == "text"
+
+    def test_content_block_start_thinking(self):
+        result = stream_content_block_start(0, "thinking")
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["content_block"]["type"] == "thinking"
+
+    def test_content_block_delta_text(self):
+        result = stream_content_block_delta(0, "hello", "text")
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["type"] == "content_block_delta"
+        assert data["delta"]["type"] == "text_delta"
+        assert data["delta"]["text"] == "hello"
+
+    def test_content_block_delta_thinking(self):
+        result = stream_content_block_delta(1, "reasoning", "thinking")
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["delta"]["type"] == "thinking_delta"
+        assert data["delta"]["thinking"] == "reasoning"
+
+    def test_content_block_stop(self):
+        result = stream_content_block_stop(0)
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["type"] == "content_block_stop"
+        assert data["index"] == 0
+
+    def test_message_delta(self):
+        result = stream_message_delta("end_turn", 100)
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["type"] == "message_delta"
+        assert data["delta"]["stop_reason"] == "end_turn"
+        assert data["usage"]["output_tokens"] == 100
+
+    def test_message_stop(self):
+        result = stream_message_stop()
+        data = json.loads(result.split("data: ")[1].strip())
+        assert data["type"] == "message_stop"
+
+
+# ============================================================================
+# Request Schema Tests
+# ============================================================================
+
+
+class TestAnthropicMessagesRequest:
+    def test_minimal_request(self):
+        req = AnthropicMessagesRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+        )
+        assert req.model == "test"
+        assert req.max_tokens == 4096
+        assert req.stream is False
+        assert req.system is None
+
+    def test_full_request(self):
+        req = AnthropicMessagesRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=1000,
+            system="Be helpful",
+            temperature=0.7,
+            top_p=0.9,
+            stream=True,
+            stop_sequences=["STOP"],
+            tools=[{"name": "t", "description": "d", "input_schema": {}}],
+        )
+        assert req.max_tokens == 1000
+        assert req.system == "Be helpful"
+        assert req.temperature == 0.7
+        assert req.stream is True
+        assert req.stop_sequences == ["STOP"]
+        assert len(req.tools) == 1


### PR DESCRIPTION
## Summary

Add `/v1/messages` endpoint to ATOM's OpenAI server, enabling **Claude Code** and other Anthropic-compatible tools to use ATOM as a backend.

Depends on PR #775 (MiniMax M2.7 reasoning parser fix).

## What it does

Translates between Anthropic Messages API format and ATOM's internal OpenAI format:

```
Claude Code CLI → /v1/messages (Anthropic format)
       ↓
serving_anthropic.py (format translation)
       ↓
ATOM engine (any model, e.g., MiniMax M2.7)
       ↓
GPU inference
```

## Features

- **Non-streaming and streaming** responses
- **Anthropic SSE event format**: `message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`
- **Thinking/reasoning separation**: `<think>` blocks → `thinking` content blocks (via ReasoningFilter)
- **System messages**: string or content-block array
- **Tool definitions**: Anthropic → OpenAI format translation
- **Tool use/result messages**: bidirectional translation

## New files

- `atom/entrypoints/openai/serving_anthropic.py` — request/response schemas, format converters, SSE helpers

## Usage with Claude Code

```bash
# 1. Start ATOM
python -m atom.entrypoints.openai_server --model MiniMaxAI/MiniMax-M2.7 \
  --trust-remote-code --kv_cache_dtype fp8 -tp 2 --server-port 8000

# 2. Configure Claude Code (~/.claude/settings.json)
{
  "env": {
    "ANTHROPIC_BASE_URL": "http://localhost:8000",
    "ANTHROPIC_AUTH_TOKEN": "dummy",
    "ANTHROPIC_MODEL": "MiniMax-M2.7",
    "DISABLE_PROMPT_CACHING": "1"
  }
}

# 3. Use Claude Code
claude
```

## Verified on

- MiniMax M2.7 on MI355X (gfx950), TP=2, FP8 KV
- Claude Code `--print "Say hello world"` → `Hello, world!`
- Claude Code `--print "Write is_prime function"` → correct Python code
- Streaming and non-streaming both work
- Thinking content properly separated into `thinking` blocks

## Test plan

- [x] Non-streaming `/v1/messages` returns correct Anthropic format
- [x] Streaming `/v1/messages` returns correct SSE events
- [x] Thinking/reasoning separated into `thinking` content blocks
- [x] Claude Code end-to-end: hello world, code generation, math
- [ ] Tool calling (needs model with tool-call support)