### PR TITLE
[codex] DeepSeek FP4 MTP decode safeguards and MLA hooks

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -308,7 +308,12 @@ class tokenIDProcessor:
                 total_tokens_prefill : total_tokens_prefill + total_tokens_decode
             ]
             if self.use_spec:
+                tokens_per_seq = self.num_spec_tokens + 1
+                token_ids = token_ids.reshape(
+                    batch.total_seqs_num_decode, tokens_per_seq
+                )
                 token_ids[:, 1:] = batch.scheduled_spec_decode_tokens
+                token_ids = token_ids.reshape(-1)
 
             self.input_ids.np[:total_tokens_decode] = token_ids
             return self.input_ids.copy_to_gpu(total_tokens_decode)
@@ -325,10 +330,14 @@ class tokenIDProcessor:
             tokens_per_seq = self.num_spec_tokens + 1
             num_deferred_tokens = num_deferred_seqs * tokens_per_seq
             num_new_tokens = num_new_seqs * tokens_per_seq
+            decode_token_rows = scheduled_tokens[
+                total_tokens_prefill : total_tokens_prefill + total_tokens_decode
+            ].reshape(batch.total_seqs_num_decode, tokens_per_seq)
         else:
             tokens_per_seq = 1
             num_deferred_tokens = num_deferred_seqs
             num_new_tokens = num_new_seqs
+            decode_token_rows = None
 
         # Receive and map bonus_list to current batch order
         self.num_rejected = batch.num_rejected
@@ -421,28 +430,32 @@ class tokenIDProcessor:
                         num_new_tokens : num_new_tokens + num_deferred_tokens
                     ] = gathered_tokens
                 if num_new_tokens > 0:
-                    token_ids = scheduled_tokens[
-                        total_tokens_prefill : total_tokens_prefill + num_new_tokens
-                    ].reshape(num_new_seqs, tokens_per_seq)
                     if self.use_spec:
+                        token_ids = decode_token_rows[new_curr_indices].copy()
                         token_ids[:, 1:] = batch.scheduled_spec_decode_tokens[
-                            :num_new_seqs
+                            new_curr_indices
                         ]
+                    else:
+                        token_ids = scheduled_tokens[
+                            total_tokens_prefill : total_tokens_prefill + num_new_tokens
+                        ].reshape(num_new_seqs, tokens_per_seq)
                     self.input_ids.np[:num_new_tokens] = token_ids.flatten()
                     self.input_ids.copy_to_gpu(num_new_tokens)
             else:
                 # Layout: [deferred | new] - deferred at front, new is from previous finished prefill and waiting for decode
                 if num_new_tokens > 0:
-                    new_token_ids = scheduled_tokens[new_curr_indices].reshape(
-                        num_new_seqs, tokens_per_seq
-                    )
                     if self.use_spec:
+                        new_token_ids = decode_token_rows[new_curr_indices].copy()
                         # MTP mode: combine scheduled_tokens and draft_tokens
                         # For new_decode_front=False, use new_curr_indices to get the right sequences
                         draft_tokens = batch.scheduled_spec_decode_tokens[
                             new_curr_indices
                         ]
                         new_token_ids[:, 1:] = draft_tokens
+                    else:
+                        new_token_ids = scheduled_tokens[new_curr_indices].reshape(
+                            num_new_seqs, tokens_per_seq
+                        )
                     self.input_ids.np[:num_new_tokens] = new_token_ids.flatten()
                     self.input_ids.gpu[
                         num_deferred_tokens : num_deferred_tokens + num_new_tokens
@@ -1577,6 +1590,7 @@ class ModelRunner:
                 num_scheduled_tokens[:scheduled_bs],
                 cu_seqlens_q[:scheduled_bs],
                 input_ids,
+                batch.completion_lens[:scheduled_bs],
             )
 
         ubatch_slices = self._maybe_create_tbo_slices(
@@ -1669,7 +1683,8 @@ class ModelRunner:
         self,
         input_ids: torch.Tensor,
         batch: Optional[ScheduledBatch] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        skip_logits: bool = False,
+    ) -> tuple[Optional[torch.Tensor], torch.Tensor]:
         forward_context = get_forward_context()
         context = forward_context.context
         bs = context.batch_size
@@ -1696,7 +1711,7 @@ class ModelRunner:
                 else:
                     hidden_states = model_output
                     self._aux_hidden_states = None
-                logits = self.model.compute_logits(hidden_states)
+                logits = None if skip_logits else self.model.compute_logits(hidden_states)
         else:
             # decode[bs=128 tok=128 d=128]  or  decode[bs=128 tok=128 p=2 d=126 spec=3]
             label = f"decode[bs={bs}"
@@ -1723,15 +1738,67 @@ class ModelRunner:
                     self._aux_hidden_states = None
                 if self.logits_in_graph:
                     logits = self.graph_logits[graph_key][:num_tokens]
+                elif skip_logits:
+                    logits = None
                 else:
                     logits = self.model.compute_logits(hidden_states)
 
         return logits, hidden_states
 
+    def _can_use_tp_greedy_argmax_no_gather(
+        self,
+        batch: ScheduledBatch,
+        top_ks: torch.Tensor | None,
+        top_ps: torch.Tensor | None,
+        all_greedy: bool,
+    ) -> bool:
+        if not envs.ATOM_TP_GREEDY_ARGMAX_NO_GATHER:
+            return False
+        if get_tp_group().world_size <= 1:
+            return False
+        if not all_greedy or top_ks is not None or top_ps is not None:
+            return False
+        if batch.total_seqs_num_prefill > 0 or batch.num_spec_step <= 0:
+            return False
+        if self.enforce_eager:
+            return False
+        if getattr(envs, "ATOM_ENABLE_MTP_DIAGNOSTICS", False) or getattr(
+            envs,
+            "ATOM_MTP_DRAFT_TOPK_DIAGNOSTICS",
+            False,
+        ):
+            return False
+        return True
+
+    def _tp_global_argmax_from_hidden(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = hidden_states.contiguous()
+        local_logits = self.model.lm_head.forward_local(hidden_states)
+        local_vals, local_ids = torch.max(local_logits, dim=-1)
+        local_ids = local_ids.to(torch.int64) + int(self.model.lm_head.vocab_start_idx)
+
+        local_pack = torch.stack(
+            (local_vals.to(torch.float32), local_ids.to(torch.float32)),
+            dim=0,
+        ).contiguous()
+        tp_group = get_tp_group()
+        all_pack = tp_group.all_gather(
+            local_pack,
+            # The normal lm-head path gathers logits along the vocab dimension.
+            # This shortcut gathers a tiny (value, token_id) packet along dim=0;
+            # use the standard distributed path to avoid custom all-gather layout
+            # differences across AITER versions.
+            use_custom=False,
+            dim=0,
+        )
+        all_vals = all_pack[0::2, :]
+        all_ids = all_pack[1::2, :]
+        winner = all_vals.argmax(dim=0).view(1, -1)
+        return all_ids.gather(0, winner).view(-1).to(torch.int32).contiguous()
+
     def postprocess(
         self,
         batch: ScheduledBatch,
-        logits: torch.Tensor,
+        logits: Optional[torch.Tensor],
         temperatures: torch.Tensor,
         top_ks: torch.Tensor | None,
         top_ps: torch.Tensor | None,
@@ -1754,34 +1821,58 @@ class ModelRunner:
             num_reject_tokens = self.tokenID_processor.default_num_rejected_tokens[:bs]
             next_token_locs = num_reject_tokens
         else:
-            assert logits is not None
             bonus_logits_indices = spec_decode_metadata.bonus_logits_indices
             target_logits_indices = spec_decode_metadata.target_logits_indices
 
-            bonus_logits = torch.index_select(logits, 0, bonus_logits_indices)
-            target_logits = torch.index_select(logits, 0, target_logits_indices)
-            bonus_token_ids = self.sampler(
-                logits=bonus_logits,
-                temperatures=temperatures,
-                top_ks=top_ks,
-                top_ps=top_ps,
-                all_greedy=all_greedy,
-                needs_independent_noise=needs_independent_noise,
-            )
-            # Validate shapes match expectations
-            if target_logits.shape[0] != len(spec_decode_metadata.draft_token_ids):
-                raise ValueError(
-                    f"Shape mismatch: target_logits.shape[0]={target_logits.shape[0]} "
-                    f"but len(draft_token_ids)={len(spec_decode_metadata.draft_token_ids)}. "
-                    f"target_logits_indices shape={spec_decode_metadata.target_logits_indices.shape}, "
-                    f"logits.shape[0]={logits.shape[0]}"
+            if logits is None:
+                bonus_hidden = torch.index_select(hidden_states, 0, bonus_logits_indices)
+                if spec_decode_metadata.blind_accept_no_argmax:
+                    bonus_token_ids = self._tp_global_argmax_from_hidden(bonus_hidden)
+                    target_argmax = (
+                        spec_decode_metadata.draft_token_ids.to(torch.int32).contiguous()
+                    )
+                else:
+                    target_hidden = torch.index_select(
+                        hidden_states, 0, target_logits_indices
+                    )
+                    combined_argmax = self._tp_global_argmax_from_hidden(
+                        torch.cat((bonus_hidden, target_hidden), dim=0)
+                    )
+                    bonus_rows = bonus_hidden.shape[0]
+                    bonus_token_ids = combined_argmax[:bonus_rows]
+                    target_argmax = combined_argmax[bonus_rows:]
+                sampled_tokens, num_bonus_tokens = (
+                    self.rejection_sampler.forward_argmax_only(
+                        spec_decode_metadata,
+                        target_argmax,
+                        bonus_token_ids,
+                    )
                 )
+            else:
+                bonus_logits = torch.index_select(logits, 0, bonus_logits_indices)
+                target_logits = torch.index_select(logits, 0, target_logits_indices)
+                bonus_token_ids = self.sampler(
+                    logits=bonus_logits,
+                    temperatures=temperatures,
+                    top_ks=top_ks,
+                    top_ps=top_ps,
+                    all_greedy=all_greedy,
+                    needs_independent_noise=needs_independent_noise,
+                )
+                # Validate shapes match expectations
+                if target_logits.shape[0] != len(spec_decode_metadata.draft_token_ids):
+                    raise ValueError(
+                        f"Shape mismatch: target_logits.shape[0]={target_logits.shape[0]} "
+                        f"but len(draft_token_ids)={len(spec_decode_metadata.draft_token_ids)}. "
+                        f"target_logits_indices shape={spec_decode_metadata.target_logits_indices.shape}, "
+                        f"logits.shape[0]={logits.shape[0]}"
+                    )
 
-            sampled_tokens, num_bonus_tokens = self.rejection_sampler.forward(
-                spec_decode_metadata,
-                target_logits,
-                bonus_token_ids,
-            )
+                sampled_tokens, num_bonus_tokens = self.rejection_sampler.forward(
+                    spec_decode_metadata,
+                    target_logits,
+                    bonus_token_ids,
+                )
             num_reject_tokens = self.drafter.mtp_k - num_bonus_tokens
             next_token_locs = num_bonus_tokens
 
@@ -1850,7 +1941,17 @@ class ModelRunner:
             all_greedy,
             needs_independent_noise,
         ) = self.prepare_model(batch)
-        logits, hidden_states = self.run_model(input_ids, batch)
+        skip_logits = self._can_use_tp_greedy_argmax_no_gather(
+            batch,
+            top_ks,
+            top_ps,
+            all_greedy,
+        )
+        logits, hidden_states = self.run_model(
+            input_ids,
+            batch,
+            skip_logits=skip_logits,
+        )
         fwd_output = self.postprocess(
             batch,
             logits,
@@ -1910,6 +2011,7 @@ class ModelRunner:
             next_token_ids=next_token_ids,
             last_token_indices=last_token_indices,
             aux_hidden_states=self._aux_hidden_states,
+            completion_token_counts=batch.completion_lens[: batch.total_seqs_num],
         )
         return self.tokenID_processor.prepare_draft_ids(batch, draft_token)
 

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -243,6 +243,9 @@ class ScheduledBatch:
         self.context_lens = np.asarray(
             [seq.num_tokens for seq in seqs.values()], dtype=np.int32
         )
+        self.completion_lens = np.asarray(
+            [seq.num_completion_tokens for seq in seqs.values()], dtype=np.int32
+        )
         self.num_rejected = np.asarray(
             [seq.num_rejected for seq in seqs.values()], dtype=np.int32
         )
@@ -635,11 +638,26 @@ class Scheduler:
         # Real token count = seq.num_tokens - mtp_k - num_rejected
         # (same formula as postprocess line: num_tokens = seq.num_tokens - self.mtp_k - num_rejected)
         if self.mtp_k > 0:
-            strip = self.mtp_k + seq.num_rejected
+            requested_strip = self.mtp_k + seq.num_rejected
+            max_strip = max(
+                0,
+                min(seq.num_tokens, len(seq.token_ids)) - seq.num_prompt_tokens,
+            )
+            strip = min(requested_strip, max_strip)
             if strip > 0:
                 del seq.token_ids[-strip:]
-                del seq.output_tokens[-strip:]
                 seq.num_tokens -= strip
+            if seq.num_tokens > len(seq.token_ids):
+                seq.num_tokens = len(seq.token_ids)
+            if seq.num_tokens < seq.num_prompt_tokens:
+                seq.num_tokens = seq.num_prompt_tokens
+            expected_output_len = max(0, seq.num_tokens - seq.num_prompt_tokens)
+            if len(seq.output_tokens) > expected_output_len:
+                del seq.output_tokens[expected_output_len:]
+            if seq.token_ids:
+                seq.last_token = seq.token_ids[
+                    min(seq.num_tokens, len(seq.token_ids)) - 1
+                ]
         seq.num_rejected = 0
         seq.num_bonus_tokens = 0
         seq.spec_token_ids = np.array([], dtype=np.int32)

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -16,6 +16,8 @@ from aiter import (
     flash_attn_varlen_func,
     fused_qk_rope_concat_and_cache_mla,
     get_hip_quant,
+    mla_decode_stage1_asm_fwd,
+    mla_reduce_v1,
 )
 from aiter.dist.parallel_state import get_dp_group
 from aiter.mla import mla_decode_fwd, mla_prefill_fwd
@@ -55,6 +57,44 @@ mla_decode_fwd = mark_trace(mla_decode_fwd, prefix="mla_decode", torch_compile=F
 logger = logging.getLogger("atom")
 
 _MLA_MIN_HEADS = 16  # AITER MLA kernels require at least 16 attention heads
+_MLA_DIRECT_SCRATCH_CACHE = {}
+_MLA_DIRECT_SCRATCH_LOGGED = False
+
+
+def _device_index(device: torch.device) -> int:
+    if device.type == "cpu":
+        return -1
+    if device.index is None:
+        return torch.cuda.current_device() if torch.cuda.is_available() else -1
+    return int(device.index)
+
+
+def _mla_direct_stage1_reduce_scratch(
+    *,
+    partial_tiles: int,
+    max_seqlen_q: int,
+    num_heads: int,
+    kv_lora_rank: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    global _MLA_DIRECT_SCRATCH_LOGGED
+    device_key = _device_index(device)
+    logits_shape = (partial_tiles * max_seqlen_q, 1, num_heads, kv_lora_rank)
+    attn_lse_shape = (partial_tiles * max_seqlen_q, 1, num_heads, 1)
+    logits_key = (device_key, "logits", logits_shape, torch.float32)
+    attn_lse_key = (device_key, "attn_lse", attn_lse_shape, torch.float32)
+    logits = _MLA_DIRECT_SCRATCH_CACHE.get(logits_key)
+    if logits is None:
+        logits = torch.empty(logits_shape, dtype=torch.float32, device=device)
+        _MLA_DIRECT_SCRATCH_CACHE[logits_key] = logits
+    attn_lse = _MLA_DIRECT_SCRATCH_CACHE.get(attn_lse_key)
+    if attn_lse is None:
+        attn_lse = torch.empty(attn_lse_shape, dtype=torch.float32, device=device)
+        _MLA_DIRECT_SCRATCH_CACHE[attn_lse_key] = attn_lse
+    if not _MLA_DIRECT_SCRATCH_LOGGED:
+        _MLA_DIRECT_SCRATCH_LOGGED = True
+        logger.info("ATOM MLA direct stage1+reduce scratch cache enabled")
+    return logits, attn_lse
 
 if use_triton_gemm():
     try:
@@ -645,26 +685,83 @@ class MLAAttention(nn.Module):
                 reduce_final_map = attn_metadata.reduce_final_map
                 reduce_partial_map = attn_metadata.reduce_partial_map
 
-            mla_decode_fwd(
-                q,
-                kv_buffer.view(-1, 1, 1, q.shape[-1]),
-                o,
-                paged_cu_seqlens_q,
-                paged_kv_indptr,
-                paged_kv_indices,
-                paged_kv_last_page_lens,
-                max_q_len,
-                num_kv_splits=16,
-                sm_scale=self.scale,
-                work_meta_data=work_meta_data,
-                work_indptr=work_indptr,
-                work_info_set=work_info_set,
-                reduce_indptr=reduce_indptr,
-                reduce_final_map=reduce_final_map,
-                reduce_partial_map=reduce_partial_map,
-                q_scale=self._q_scale,
-                kv_scale=self._k_scale,
+            request_batch = int(paged_cu_seqlens_q.numel() - 1)
+            use_direct_stage1_reduce = (
+                envs.ATOM_MLA_DIRECT_STAGE1_REDUCE
+                and self.kv_cache_dtype.startswith("fp8")
+                and use_persistent_mode
+                and work_meta_data is not None
+                and work_indptr is not None
+                and work_info_set is not None
+                and reduce_indptr is not None
+                and reduce_final_map is not None
+                and reduce_partial_map is not None
+                and max_q_len == 4
+                and self.padded_num_heads == 32
+                and self.num_kv_heads == 1
+                and request_batch <= envs.ATOM_MLA_DIRECT_STAGE1_REDUCE_MAX_BATCH
             )
+            if use_direct_stage1_reduce:
+                logits, attn_lse = _mla_direct_stage1_reduce_scratch(
+                    partial_tiles=int(reduce_partial_map.numel()),
+                    max_seqlen_q=max_q_len,
+                    num_heads=self.padded_num_heads,
+                    kv_lora_rank=self.kv_lora_rank,
+                    device=q.device,
+                )
+                mla_decode_stage1_asm_fwd(
+                    q,
+                    kv_buffer.view(-1, 1, 1, q.shape[-1]),
+                    paged_cu_seqlens_q,
+                    paged_kv_indptr,
+                    paged_kv_indices,
+                    paged_kv_last_page_lens,
+                    None,
+                    work_meta_data,
+                    work_indptr,
+                    work_info_set,
+                    max_q_len,
+                    1,
+                    1,
+                    self.scale,
+                    logits,
+                    attn_lse,
+                    o,
+                    None,
+                    self._q_scale,
+                    self._k_scale,
+                )
+                mla_reduce_v1(
+                    logits,
+                    attn_lse,
+                    reduce_indptr,
+                    reduce_final_map,
+                    reduce_partial_map,
+                    max_q_len,
+                    o,
+                    None,
+                )
+            else:
+                mla_decode_fwd(
+                    q,
+                    kv_buffer.view(-1, 1, 1, q.shape[-1]),
+                    o,
+                    paged_cu_seqlens_q,
+                    paged_kv_indptr,
+                    paged_kv_indices,
+                    paged_kv_last_page_lens,
+                    max_q_len,
+                    num_kv_splits=envs.ATOM_MLA_MAX_SPLIT_PER_BATCH,
+                    sm_scale=self.scale,
+                    work_meta_data=work_meta_data,
+                    work_indptr=work_indptr,
+                    work_info_set=work_info_set,
+                    reduce_indptr=reduce_indptr,
+                    reduce_final_map=reduce_final_map,
+                    reduce_partial_map=reduce_partial_map,
+                    q_scale=self._q_scale,
+                    kv_scale=self._k_scale,
+                )
 
         if self.head_repeat_factor > 1:
             o = o[:, :: self.head_repeat_factor, :].contiguous()

--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -190,3 +190,6 @@ class ParallelLMHead(VocabParallelEmbedding):
             # dist.gather(logits, all_logits, 0)
             # logits = torch.cat(all_logits, -1) if self.tp_rank == 0 else None
         return logits
+
+    def forward_local(self, x: torch.Tensor):
+        return tgemm.mm(x, self.weight, self.bias)

--- a/atom/model_ops/rejection_sampler.py
+++ b/atom/model_ops/rejection_sampler.py
@@ -38,6 +38,36 @@ class RejectionSampler(nn.Module):
                 f"{expected_num_tokens} (len(draft_token_ids)), but got {target_logits.shape[0]}"
             )
 
+        if metadata.blind_accept_no_argmax:
+            output_token_ids, num_bonus_tokens = rejection_sample_argmax_only(
+                metadata.draft_token_ids,
+                metadata.num_spec_steps,
+                metadata.cu_num_draft_tokens,
+                metadata.draft_token_ids.to(torch.int32).contiguous(),
+                bonus_token_ids,
+            )
+            return output_token_ids, num_bonus_tokens
+        if metadata.partial_blind_accept_no_argmax:
+            strict_row_mask = metadata.partial_blind_strict_row_mask
+            if strict_row_mask is None:
+                raise ValueError(
+                    "partial_blind_accept_no_argmax requires "
+                    "partial_blind_strict_row_mask"
+                )
+            target_argmax = target_logits.argmax(dim=-1).to(torch.int32).contiguous()
+            relaxed_row_mask = ~strict_row_mask
+            target_argmax[relaxed_row_mask] = metadata.draft_token_ids[
+                relaxed_row_mask
+            ].to(torch.int32)
+            output_token_ids, num_bonus_tokens = rejection_sample_argmax_only(
+                metadata.draft_token_ids,
+                metadata.num_spec_steps,
+                metadata.cu_num_draft_tokens,
+                target_argmax,
+                bonus_token_ids,
+            )
+            return output_token_ids, num_bonus_tokens
+
         output_token_ids = rejection_sample(
             metadata.draft_token_ids,
             # metadata.num_draft_tokens_np,
@@ -48,6 +78,26 @@ class RejectionSampler(nn.Module):
             bonus_token_ids,
         )
         return output_token_ids
+
+    def forward_argmax_only(
+        self,
+        metadata: SpecDecodeMetadata,
+        target_argmax: torch.Tensor,
+        bonus_token_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        expected_num_tokens = len(metadata.draft_token_ids)
+        if target_argmax.shape[0] != expected_num_tokens:
+            raise ValueError(
+                f"target_argmax shape mismatch: expected first dimension to be "
+                f"{expected_num_tokens} (len(draft_token_ids)), but got {target_argmax.shape[0]}"
+            )
+        return rejection_sample_argmax_only(
+            metadata.draft_token_ids,
+            metadata.num_spec_steps,
+            metadata.cu_num_draft_tokens,
+            target_argmax.to(torch.int32).contiguous(),
+            bonus_token_ids.to(torch.int32).contiguous(),
+        )
 
 
 def rejection_sample(
@@ -124,6 +174,41 @@ def rejection_sample(
             num_warps=1,
         )
 
+    return output_token_ids, num_bonus_tokens
+
+
+def rejection_sample_argmax_only(
+    draft_token_ids: torch.Tensor,
+    num_spec_steps: int,
+    cu_num_draft_tokens: torch.Tensor,
+    target_argmax: torch.Tensor,
+    bonus_token_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert draft_token_ids.ndim == 1
+    assert cu_num_draft_tokens.ndim == 1
+    assert target_argmax.ndim == 1
+    assert draft_token_ids.is_contiguous()
+    assert target_argmax.is_contiguous()
+    assert target_argmax.shape[0] == draft_token_ids.shape[0]
+
+    batch_size = len(cu_num_draft_tokens)
+    device = target_argmax.device
+    output_token_ids = torch.empty(
+        (batch_size, num_spec_steps + 1),
+        dtype=torch.int32,
+        device=device,
+    )
+    num_bonus_tokens = torch.empty(batch_size, dtype=torch.int32, device=device)
+    rejection_greedy_sample_kernel[(batch_size,)](
+        output_token_ids,
+        num_bonus_tokens,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        target_argmax,
+        bonus_token_ids,
+        num_spec_steps,
+        num_warps=1,
+    )
     return output_token_ids, num_bonus_tokens
 
 

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -9,7 +9,7 @@ from aiter import dtypes
 from aiter.dist.parallel_state import get_pp_group
 from atom.config import CompilationLevel, Config, KVCacheTensor
 from atom.model_loader.loader import load_model
-from atom.utils import CpuGpuBuffer, resolve_obj_by_qualname
+from atom.utils import CpuGpuBuffer, envs, resolve_obj_by_qualname
 from atom.utils.forward_context import SpecDecodeMetadata, get_forward_context
 from torch.profiler import record_function
 
@@ -212,6 +212,79 @@ class EagleProposer:
         self.cu_num_draft_tokens = CpuGpuBuffer(max_bs, **i32_kwargs)
         self.target_logits_indices = CpuGpuBuffer(max_bs * self.mtp_k, **i64_kwargs)
         self.bonus_logits_indices = CpuGpuBuffer(max_bs, **i64_kwargs)
+        self.completion_token_counts = CpuGpuBuffer(max_bs, **i32_kwargs)
+        self.partial_blind_strict_row_mask = CpuGpuBuffer(
+            max_bs * self.mtp_k,
+            dtype=torch.bool,
+            device=self.device,
+        )
+
+    def _try_tail_cheap_propose(
+        self,
+        *,
+        next_token_ids: torch.Tensor,
+        completion_token_counts: Optional[np.ndarray],
+    ) -> Optional[torch.Tensor]:
+        min_tokens = envs.ATOM_MTP_TAIL_CHEAP_DRAFT_MIN_COMPLETION_TOKENS
+        if min_tokens <= 0 or completion_token_counts is None:
+            return None
+        if next_token_ids.numel() == 0:
+            return None
+        counts = completion_token_counts[: next_token_ids.shape[0]]
+        if counts.shape[0] != next_token_ids.shape[0] or not np.all(counts >= min_tokens):
+            return None
+        mode = envs.ATOM_MTP_TAIL_CHEAP_DRAFT_MODE
+        if mode != "repeat_next":
+            raise ValueError(
+                "ATOM_MTP_TAIL_CHEAP_DRAFT_MODE must be repeat_next for this "
+                "C4 upstream replay patch"
+            )
+        return next_token_ids.view(-1, 1).expand(-1, self.mtp_k).contiguous()
+
+    @staticmethod
+    def _draft_topk_select_positions() -> Optional[set[int]]:
+        raw_positions = envs.ATOM_MTP_DRAFT_TOPK_SELECT_POSITIONS.strip()
+        if not raw_positions or raw_positions.lower() in ("*", "all"):
+            return None
+        positions: set[int] = set()
+        for raw_pos in raw_positions.split(","):
+            raw_pos = raw_pos.strip()
+            if not raw_pos:
+                continue
+            pos = int(raw_pos)
+            if pos <= 0:
+                raise ValueError(
+                    "ATOM_MTP_DRAFT_TOPK_SELECT_POSITIONS is 1-based and "
+                    f"received {pos}"
+                )
+            positions.add(pos)
+        return positions
+
+    def _select_draft_ids_from_logits(
+        self,
+        logits: torch.Tensor,
+        draft_step_idx: int,
+    ) -> torch.Tensor:
+        if not envs.ATOM_MTP_DRAFT_TOPK_SELECT:
+            return logits.argmax(dim=-1)
+
+        positions = self._draft_topk_select_positions()
+        draft_pos = draft_step_idx + 1
+        if positions is not None and draft_pos not in positions:
+            return logits.argmax(dim=-1)
+
+        rank = envs.ATOM_MTP_DRAFT_TOPK_SELECT_RANK
+        if rank <= 1:
+            return logits.argmax(dim=-1)
+
+        select_k = max(envs.ATOM_MTP_DRAFT_TOPK_SELECT_K, rank)
+        select_k = min(select_k, logits.shape[-1])
+        topk_vals, topk_ids = torch.topk(logits, select_k, dim=-1)
+        base_ids = topk_ids[:, 0]
+        alt_ids = topk_ids[:, rank - 1]
+        gap = topk_vals[:, 0] - topk_vals[:, rank - 1]
+        use_alt = gap <= envs.ATOM_MTP_DRAFT_TOPK_SELECT_GAP
+        return torch.where(use_alt, alt_ids, base_ids)
 
     @staticmethod
     def _share_if_not_loaded(
@@ -315,6 +388,7 @@ class EagleProposer:
         next_token_ids: torch.Tensor,
         last_token_indices: torch.Tensor,
         aux_hidden_states: Optional[list[torch.Tensor]] = None,
+        completion_token_counts: Optional[np.ndarray] = None,
     ) -> torch.Tensor:
 
         forward_context = get_forward_context()
@@ -339,6 +413,12 @@ class EagleProposer:
         draft_token_ids = torch.empty(
             bs, self.mtp_k, dtype=next_token_ids.dtype, device=next_token_ids.device
         )
+        cheap_draft_token_ids = self._try_tail_cheap_propose(
+            next_token_ids=next_token_ids,
+            completion_token_counts=completion_token_counts,
+        )
+        if cheap_draft_token_ids is not None:
+            return cheap_draft_token_ids
         var = self.runner.forward_vars
         target_uses_mla = self.runner.use_mla
         # Eaale3 only support mha currently
@@ -376,7 +456,7 @@ class EagleProposer:
                     else ret_hidden_states
                 )
                 logits = self.model.compute_logits(sample_hidden_states)
-                new_draft_ids = logits.argmax(dim=-1)
+                new_draft_ids = self._select_draft_ids_from_logits(logits, i)
                 draft_token_ids[:, i] = new_draft_ids
 
                 if i < self.mtp_k - 1:
@@ -485,6 +565,7 @@ class EagleProposer:
         num_sampled_tokens: np.ndarray,
         cu_num_sampled_tokens: np.ndarray,
         input_ids: torch.Tensor,
+        completion_token_counts=None,
     ) -> SpecDecodeMetadata:
         scheduled_bs = len(num_sampled_tokens)
         sum_drafted_tokens = self.mtp_k * scheduled_bs
@@ -520,6 +601,36 @@ class EagleProposer:
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
         draft_token_ids = torch.index_select(input_ids[1:], 0, target_logits_indices)
+        completion_token_counts_gpu = None
+        blind_accept_no_argmax = False
+        partial_blind_accept_no_argmax = False
+        partial_blind_strict_row_mask = None
+        if completion_token_counts is not None:
+            self.completion_token_counts.np[:scheduled_bs] = completion_token_counts[
+                :scheduled_bs
+            ]
+            completion_token_counts_gpu = self.completion_token_counts.copy_to_gpu(
+                scheduled_bs
+            )
+            min_tokens = envs.ATOM_MTP_BLIND_ACCEPT_NO_ARGMAX_MIN_COMPLETION_TOKENS
+            if min_tokens > 0 and scheduled_bs > 0:
+                tail_ready = completion_token_counts[:scheduled_bs] >= min_tokens
+                blind_accept_no_argmax = bool(np.all(tail_ready))
+                if (
+                    envs.ATOM_MTP_PARTIAL_BLIND_ACCEPT_NO_ARGMAX
+                    and not blind_accept_no_argmax
+                    and bool(np.any(tail_ready))
+                ):
+                    strict_row_mask = np.repeat(~tail_ready, self.mtp_k)
+                    self.partial_blind_strict_row_mask.np[
+                        :sum_drafted_tokens
+                    ] = strict_row_mask
+                    partial_blind_strict_row_mask = (
+                        self.partial_blind_strict_row_mask.copy_to_gpu(
+                            sum_drafted_tokens
+                        )
+                    )
+                    partial_blind_accept_no_argmax = True
 
         metadata = SpecDecodeMetadata(
             draft_token_ids=draft_token_ids,
@@ -528,5 +639,9 @@ class EagleProposer:
             cu_num_draft_tokens=cu_num_draft_tokens,
             target_logits_indices=target_logits_indices,
             bonus_logits_indices=bonus_logits_indices,
+            completion_token_counts=completion_token_counts_gpu,
+            blind_accept_no_argmax=blind_accept_no_argmax,
+            partial_blind_accept_no_argmax=partial_blind_accept_no_argmax,
+            partial_blind_strict_row_mask=partial_blind_strict_row_mask,
         )
         return metadata

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -102,6 +102,51 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_RELAXED_MTP": lambda: (
         os.getenv("ATOM_ENABLE_RELAXED_MTP", "0").lower() == "1"
     ),
+    "ATOM_MTP_TAIL_CHEAP_DRAFT_MIN_COMPLETION_TOKENS": lambda: int(
+        os.getenv("ATOM_MTP_TAIL_CHEAP_DRAFT_MIN_COMPLETION_TOKENS", "0")
+    ),
+    "ATOM_MTP_TAIL_CHEAP_DRAFT_MODE": lambda: os.getenv(
+        "ATOM_MTP_TAIL_CHEAP_DRAFT_MODE", "repeat_next"
+    ),
+    "ATOM_MTP_BLIND_ACCEPT_NO_ARGMAX_MIN_COMPLETION_TOKENS": lambda: int(
+        os.getenv("ATOM_MTP_BLIND_ACCEPT_NO_ARGMAX_MIN_COMPLETION_TOKENS", "0")
+    ),
+    "ATOM_MTP_PARTIAL_BLIND_ACCEPT_NO_ARGMAX": lambda: (
+        os.getenv("ATOM_MTP_PARTIAL_BLIND_ACCEPT_NO_ARGMAX", "0") == "1"
+    ),
+    # Exact proposal reranking experiment. This only changes draft proposals;
+    # the target verifier still accepts/rejects normally.
+    "ATOM_MTP_DRAFT_TOPK_SELECT": lambda: (
+        os.getenv("ATOM_MTP_DRAFT_TOPK_SELECT", "0") == "1"
+    ),
+    "ATOM_MTP_DRAFT_TOPK_SELECT_K": lambda: int(
+        os.getenv("ATOM_MTP_DRAFT_TOPK_SELECT_K", "2")
+    ),
+    "ATOM_MTP_DRAFT_TOPK_SELECT_RANK": lambda: int(
+        os.getenv("ATOM_MTP_DRAFT_TOPK_SELECT_RANK", "2")
+    ),
+    "ATOM_MTP_DRAFT_TOPK_SELECT_GAP": lambda: float(
+        os.getenv("ATOM_MTP_DRAFT_TOPK_SELECT_GAP", "0.0")
+    ),
+    "ATOM_MTP_DRAFT_TOPK_SELECT_POSITIONS": lambda: os.getenv(
+        "ATOM_MTP_DRAFT_TOPK_SELECT_POSITIONS", ""
+    ),
+    # Opt-in exact TP decode fast path: for all-greedy speculative decode,
+    # compute distributed argmax token ids from local lm_head shards instead of
+    # all-gathering full vocab logits.
+    "ATOM_TP_GREEDY_ARGMAX_NO_GATHER": lambda: (
+        os.getenv("ATOM_TP_GREEDY_ARGMAX_NO_GATHER", "0") == "1"
+    ),
+    # --- MLA decode experiments ---
+    "ATOM_MLA_MAX_SPLIT_PER_BATCH": lambda: int(
+        os.getenv("ATOM_MLA_MAX_SPLIT_PER_BATCH", "16")
+    ),
+    "ATOM_MLA_DIRECT_STAGE1_REDUCE": lambda: (
+        os.getenv("ATOM_MLA_DIRECT_STAGE1_REDUCE", "0") == "1"
+    ),
+    "ATOM_MLA_DIRECT_STAGE1_REDUCE_MAX_BATCH": lambda: int(
+        os.getenv("ATOM_MLA_DIRECT_STAGE1_REDUCE_MAX_BATCH", "32")
+    ),
     # --- Gradient Control ---
     # Enable gradient tracking on model parameters.  Default "0" (disabled)
     # is correct for inference; set to "1" only for training / fine-tuning.

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -132,6 +132,10 @@ class SpecDecodeMetadata:
     cu_num_draft_tokens: torch.Tensor
     target_logits_indices: torch.Tensor
     bonus_logits_indices: torch.Tensor
+    completion_token_counts: Optional[torch.Tensor] = None
+    blind_accept_no_argmax: bool = False
+    partial_blind_accept_no_argmax: bool = False
+    partial_blind_strict_row_mask: Optional[torch.Tensor] = None
 
 
 @dataclass


### PR DESCRIPTION
# ATOM PR Draft

## Title

DeepSeek FP4 MTP decode safeguards and guarded small-batch MLA path

## Summary

This PR contains DeepSeek R1 FP4 + MTP changes developed for the AMD MI355X finals environment. The patch focuses on correctness-preserving decode improvements and guarded experiment surfaces:

- Clamp MTP token rollback during preemption so speculative cleanup cannot corrupt prompt/output state.
- Add a guarded small-batch MLA stage1+reduce path for `q_len=4`, `qh32`, `gqa32`, FP8 KV decode.
- Make MLA split count configurable through an env var instead of hard-coding it.
- Add an opt-in exact TP greedy argmax path that avoids gathering full vocabulary logits in all-greedy decode.
- Add default-off MTP proposal/diagnostic envs for future exact-verifier experimentation.

## Motivation

DeepSeek R1 FP4 with MTP spends substantial time in decode attention/MoE and MTP verifier plumbing. The competition workload uses fixed `8192/1024` random prompts at `CONC=4,32,128`, so safe decode-path improvements are valuable, but GSM8K correctness must remain intact.

The submitted leaderboard runs using this stack passed GSM8K at all three concurrencies.

## Implementation Notes

- `atom/model_engine/scheduler.py`: clamp speculative rollback and keep sequence token counts consistent after preemption.
- `atom/model_ops/attention_mla.py`: add guarded direct AITER `mla_decode_stage1_asm_fwd` + `mla_reduce_v1` path and scratch cache.
- `atom/model_engine/model_runner.py`: support optional `skip_logits` path for exact greedy argmax from hidden states.
- `atom/model_ops/embed_head.py`: expose local LM-head projection for TP-local argmax.
- `atom/model_ops/rejection_sampler.py`: add argmax-only verifier path for exact greedy speculative acceptance.
- `atom/spec_decode/eagle.py` and `atom/utils/forward_context.py`: carry optional completion counts and speculative metadata.
- `atom/utils/envs.py`: add guarded env vars, all default-off except existing behavior-compatible defaults.

## Rule / Correctness Notes

- MTP remains enabled.
- The submitted runs keep tail-cheap and blind/no-argmax behavior disabled.
- The top-k draft selector is exact-verifier-compatible and default-off.
- The TP greedy no-gather path is default-off in the submitted configuration.

## Validation

Submitted leaderboard results:

| CONC | TP | GSM8K | Tok/s/GPU | Interactivity | Median E2E |
|---:|---:|---:|---:|---:|---:|
| 4 | 4 | 0.9378 | 1233.04 | 138.94 | 7.876s |
| 32 | 4 | 0.9363 | 3121.65 | 43.41 | 24.719s |
| 128 | 8 | 0.9378 | 3613.33 | 24.48 | 42.890s |

Known limitation: these submitted numbers are accuracy-safe but do not clear all DeepSeek performance gates.
