### PR TITLE
[vLLM Plugin] Upgrade vLLM version to v0.21.0

### DIFF
--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -175,6 +175,10 @@ class vllmAiterAttentionBackendMethods:
     def is_mla(cls) -> bool:
         return False
 
+    @classmethod
+    def is_ssm(cls) -> bool:
+        return False
+
     @staticmethod
     def get_required_kv_cache_layout():
         return None
@@ -1418,6 +1422,10 @@ class vllmAiterMLABackendMethods:
     def is_mla(cls) -> bool:
         return True
 
+    @classmethod
+    def is_ssm(cls) -> bool:
+        return False
+
     @staticmethod
     def get_required_kv_cache_layout():
         return None
@@ -2089,6 +2097,10 @@ class vllmAiterMLASparseBackendMethods:
     @classmethod
     def is_sparse(cls) -> bool:
         return True
+
+    @classmethod
+    def is_ssm(cls) -> bool:
+        return False
 
     @staticmethod
     def get_required_kv_cache_layout():

--- a/atom/plugin/vllm/mla_patch.py
+++ b/atom/plugin/vllm/mla_patch.py
@@ -4,6 +4,72 @@ from dataclasses import replace
 import torch
 from atom.plugin.vllm.platform import disable_vllm_plugin_attention
 
+try:
+    from vllm.v1.attention.backends.mla.prefill.base import MLAPrefillBackend
+except Exception:  # pragma: no cover - imported only when vLLM is available
+    MLAPrefillBackend = object
+
+
+class ATOMPluginMLAPrefillBackend(MLAPrefillBackend):
+    """Placeholder backend for ATOM MLA plugin mode.
+
+    vLLM 0.21.0 introduced a mandatory MLA prefill backend selector during
+    `MLAAttention` initialization. ATOM's plugin-mode MLA path already owns
+    prefill execution inside `forward_impl_plugin_mode`, so the upstream
+    prefill backend must not be selected for ATOM's custom MLA backend.
+    """
+
+    @staticmethod
+    def get_name() -> str:
+        return "ATOM_PLUGIN_MLA_PREFILL"
+
+    def prepare_metadata(self, prefill_metadata) -> None:
+        self._prefill_metadata = prefill_metadata
+
+    def run_prefill_new_tokens(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        return_softmax_lse: bool,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        raise RuntimeError(
+            "ATOM MLA plugin mode handles prefill inside "
+            "forward_impl_plugin_mode; vLLM's standalone MLA prefill backend "
+            "must not be called."
+        )
+
+    def run_prefill_context_chunk(
+        self,
+        chunk_idx: int,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise RuntimeError(
+            "ATOM MLA plugin mode handles chunked prefill inside "
+            "forward_impl_plugin_mode; vLLM's standalone MLA prefill backend "
+            "must not be called."
+        )
+
+
+def select_mla_prefill_backend_for_plugin(vllm_config, default_selector):
+    """Bridge vLLM's MLA prefill selector to ATOM's plugin-owned prefill path."""
+
+    if disable_vllm_plugin_attention:
+        return default_selector(vllm_config)
+
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    static_forward_context = getattr(compilation_config, "static_forward_context", None)
+    if static_forward_context:
+        current_layer = next(reversed(static_forward_context.values()))
+        attn_backend = getattr(current_layer, "attn_backend", None)
+        backend_name = getattr(attn_backend, "get_name", lambda: None)()
+        if isinstance(backend_name, str) and backend_name.startswith("CUSTOM"):
+            return ATOMPluginMLAPrefillBackend
+
+    return default_selector(vllm_config)
+
 
 def set_default_quant_scales(
     layer: torch.nn.Module, register_buffer: bool = False
@@ -62,6 +128,23 @@ def _patch_vllm_mla_attention_process_weights_after_loading(mla_attention_cls) -
     mla_attention_cls.process_weights_after_loading = _process_weights_after_loading
 
 
+def _patch_vllm_mla_prefill_backend_selector(mla_attention_cls) -> None:
+    module_globals = mla_attention_cls.__init__.__globals__
+    orig_selector = module_globals.get("get_mla_prefill_backend")
+    if orig_selector is None:
+        return
+
+    if getattr(orig_selector, "_atom_mla_prefill_selector_patched", False):
+        return
+
+    @functools.wraps(orig_selector)
+    def _selector(vllm_config):
+        return select_mla_prefill_backend_for_plugin(vllm_config, orig_selector)
+
+    setattr(_selector, "_atom_mla_prefill_selector_patched", True)
+    module_globals["get_mla_prefill_backend"] = _selector
+
+
 def _patch_vllm_mla_attention_forward_impl(mla_attention_cls) -> None:
     """
     We patch the forward_impl method is to make qk rope and kv cache update
@@ -82,6 +165,7 @@ def _patch_vllm_mla_attention_forward_impl(mla_attention_cls) -> None:
         output: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
+        **kwargs,
     ) -> torch.Tensor:
         if disable_vllm_plugin_attention:
             return orig_forward_impl(
@@ -94,6 +178,7 @@ def _patch_vllm_mla_attention_forward_impl(mla_attention_cls) -> None:
                 output=output,
                 output_scale=output_scale,
                 output_block_scale=output_block_scale,
+                **kwargs,
             )
 
         if hasattr(self.impl, "forward_impl_plugin_mode"):
@@ -117,6 +202,7 @@ def _patch_vllm_mla_attention_forward_impl(mla_attention_cls) -> None:
             output=output,
             output_scale=output_scale,
             output_block_scale=output_block_scale,
+            **kwargs,
         )
 
     setattr(_forward_impl, "_atom_mla_forward_impl_patched", True)
@@ -165,6 +251,7 @@ def patch_vllm_mla_attention() -> None:
     except ImportError:
         from vllm.model_executor.layers.attention import MLAAttention
 
+    _patch_vllm_mla_prefill_backend_selector(MLAAttention)
     _patch_vllm_mla_attention_get_kv_cache_spec(MLAAttention)
     _patch_vllm_mla_attention_process_weights_after_loading(MLAAttention)
     _patch_vllm_mla_attention_forward_impl(MLAAttention)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,11 +109,15 @@ RUN echo "========== [OOT 7/7] Install vLLM runtime dependencies ==========" && 
     cd /app/vllm && \
     "${VENV_PYTHON}" -m pip uninstall -y vllm || true && \
     "${VENV_PYTHON}" -m pip install /tmp/vllm-wheels/*.whl && \
-    "${VENV_PYTHON}" -m pip install uvloop && \
+    "${VENV_PYTHON}" -m pip install \
+      uvloop \
+      "botocore>=1.43.7,<1.44.0" \
+      "s3transfer>=0.17.0,<0.18.0" && \
     if [ "${INSTALL_LM_EVAL}" = "1" ]; then "${VENV_PYTHON}" -m pip install "lm-eval[api]"; else echo "Skip lm-eval install"; fi && \
     if [ "${INSTALL_FASTSAFETENSORS}" = "1" ]; then "${VENV_PYTHON}" -m pip install "git+https://github.com/foundation-model-stack/fastsafetensors.git"; else echo "Skip fastsafetensors install"; fi && \
+    "${VENV_PYTHON}" -c "import boto3, botocore, s3transfer; print(f'boto3: {boto3.__version__}'); print(f'botocore: {botocore.__version__}'); print(f's3transfer: {s3transfer.__version__}')" && \
     "${VENV_PYTHON}" -c "import glob, os, torch; print(f'torch.version.hip: {torch.version.hip}'); print(f'torch.version.cuda: {torch.version.cuda}'); torch_lib_dir=os.path.join(os.path.dirname(torch.__file__), 'lib'); print(f'torch lib dir: {torch_lib_dir}'); print(f'libtorch_hip candidates: {glob.glob(os.path.join(torch_lib_dir, \"libtorch_hip.so*\"))}'); assert torch.version.hip is not None, 'Torch is not ROCm build (torch.version.hip is None).'" && \
-    "${VENV_PYTHON}" -m pip show vllm torch triton torchvision torchaudio amdsmi amd-aiter atom mori || true
+    "${VENV_PYTHON}" -m pip show vllm boto3 botocore s3transfer torch triton torchvision torchaudio amdsmi amd-aiter atom mori || true
 
 RUN echo "========== [VLLM-ATOM] Validate vision/audio wheels ==========" && \
     "${VENV_PYTHON}" -c "import torch, torchvision, torchaudio; from torchvision.transforms import InterpolationMode; from transformers.models.auto.image_processing_auto import get_image_processor_config; print(f'torch: {torch.__version__}'); print(f'torchvision: {torchvision.__version__}'); print(f'torchaudio: {torchaudio.__version__}'); print(f'InterpolationMode: {InterpolationMode.BILINEAR}'); print(f'get_image_processor_config: {get_image_processor_config.__name__}')"


### PR DESCRIPTION
## Motivation

This PR upgrades vLLM version to v0.21.0.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Need to test the following cases:

- [x] DeepSeek-R1 FP8 TP8
- [x] GLM-5.1-FP8 TP8
- [ ] Qwen3.5-397B-A17B-FP8 TP4
- [ ] gpt-oss-120b TP2
- [ ] MiniMax-M2.5 TP4
- [ ] Kimi-K2.5-MXFP4 TP4

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist


