### PR TITLE
[fix](gpt-oss): fix quark quantized model in moe bias

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -756,7 +756,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         if layer.has_bias:
             w13_bias = atom_parameter(
-                torch.empty(
+                torch.zeros(
                     num_experts,
                     2 * intermediate_size_per_partition_after_pad,
                     dtype=torch.bfloat16,
@@ -793,7 +793,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         if layer.has_bias:
             w2_bias = atom_parameter(
-                torch.empty(
+                torch.zeros(
                     num_experts,
                     hidden_size,
                     dtype=torch.bfloat16,


### PR DESCRIPTION
## Motivation

This PR fixed the padding error in quantized gpt_oss. the quantized gpt-oss-120b is from quark team(https://huggingface.co/amd/gpt-oss-120b-moe-ori-attn-ptpc), it only quantized gemm weights in attention with PTPC methods. the bias in moe are padding, using empty tensor will introduce dirty data, so use zero bias data.

<img width="524" height="89" alt="image" src="https://github.com/user-attachments/assets/6e41364e-498b-4fa7-8108-810f5c5d236e" />
