### PR TITLE
Add DeepSeek-V3.2 fused indexer path

### DIFF
--- a/atom/model_ops/v4_kernels/indexer_weights.py
+++ b/atom/model_ops/v4_kernels/indexer_weights.py
@@ -14,11 +14,6 @@ def _scale_indexer_weights_kernel(
     q_scale_ptr,  # [T, H, 1] fp32, flattened as [T * H]
     out_ptr,  # [T, H] fp32
     n_elements,
-    n_cols: tl.constexpr,
-    weights_stride_t: tl.constexpr,
-    weights_stride_h: tl.constexpr,
-    q_scale_stride_t: tl.constexpr,
-    q_scale_stride_h: tl.constexpr,
     weights_scale: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
@@ -26,17 +21,8 @@ def _scale_indexer_weights_kernel(
     offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements
 
-    rows = offsets // n_cols
-    cols = offsets % n_cols
-    weights_offsets = rows * weights_stride_t + cols * weights_stride_h
-    q_scale_offsets = rows * q_scale_stride_t + cols * q_scale_stride_h
-
-    weights = tl.load(weights_ptr + weights_offsets, mask=mask, other=0.0).to(
-        tl.float32
-    )
-    q_scale = tl.load(q_scale_ptr + q_scale_offsets, mask=mask, other=0.0).to(
-        tl.float32
-    )
+    weights = tl.load(weights_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    q_scale = tl.load(q_scale_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
     tl.store(out_ptr + offsets, weights * q_scale * weights_scale, mask=mask)
 
 
@@ -52,13 +38,12 @@ def scale_indexer_weights(
         weights.size(0),
         weights.size(1),
         1,
-    ), (
-        f"q_scale shape {tuple(q_scale.shape)} incompatible with weights "
-        f"{tuple(weights.shape)}"
-    )
+    ), f"q_scale shape {tuple(q_scale.shape)} incompatible with weights {tuple(weights.shape)}"
+    assert weights.is_contiguous(), "weights must be contiguous"
+    assert q_scale.is_contiguous(), "q_scale must be contiguous"
 
     n_elements = weights.numel()
-    out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+    out = torch.empty_like(weights, dtype=torch.float32)
     if n_elements == 0:
         return out
 
@@ -68,11 +53,6 @@ def scale_indexer_weights(
         q_scale,
         out,
         n_elements,
-        weights.size(1),
-        weights.stride(0),
-        weights.stride(1),
-        q_scale.stride(0),
-        q_scale.stride(1),
         weights_scale,
         BLOCK_SIZE=block_size,
     )

--- a/atom/model_ops/v4_kernels/indexer_weights.py
+++ b/atom/model_ops/v4_kernels/indexer_weights.py
@@ -6,7 +6,6 @@
 import torch
 import triton
 import triton.language as tl
-from aiter import dtypes
 
 
 @triton.jit
@@ -78,77 +77,3 @@ def scale_indexer_weights(
         BLOCK_SIZE=block_size,
     )
     return out
-
-
-@triton.jit
-def _quant_indexer_q_and_scale_weights_kernel(
-    q_ptr,  # [T * H, D] bf16/fp16/fp32
-    weights_ptr,  # [T, H] bf16/fp32
-    q_out_ptr,  # [T, H, D] fp8
-    weights_out_ptr,  # [T, H] fp32
-    n_heads: tl.constexpr,
-    q_stride_m: tl.constexpr,
-    q_stride_d: tl.constexpr,
-    weights_stride_t: tl.constexpr,
-    weights_stride_h: tl.constexpr,
-    weights_scale: tl.constexpr,
-    fp8_max: tl.constexpr,
-    BLOCK_D: tl.constexpr,
-):
-    row = tl.program_id(0)
-    offs_d = tl.arange(0, BLOCK_D)
-
-    q = tl.load(q_ptr + row * q_stride_m + offs_d * q_stride_d).to(tl.float32)
-    amax = tl.max(tl.abs(q), axis=0)
-    scale = tl.maximum(amax, 1.0e-10) / fp8_max
-    q_fp8 = tl.clamp(q / scale, -fp8_max, fp8_max).to(q_out_ptr.dtype.element_ty)
-    tl.store(q_out_ptr + row * BLOCK_D + offs_d, q_fp8)
-
-    token = row // n_heads
-    head = row % n_heads
-    weights = tl.load(
-        weights_ptr + token * weights_stride_t + head * weights_stride_h,
-    ).to(tl.float32)
-    tl.store(weights_out_ptr + row, weights * scale * weights_scale)
-
-
-def quant_indexer_q_and_scale_weights(
-    q: torch.Tensor,
-    weights: torch.Tensor,
-    weights_scale: float,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Quantize Indexer q and fold q_scale into weights in one Triton launch."""
-    assert q.dim() == 2, f"q must be [T * H, D], got {tuple(q.shape)}"
-    assert weights.dim() == 2, f"weights must be [T, H], got {tuple(weights.shape)}"
-    n_tokens, n_heads = weights.shape
-    head_dim = q.size(1)
-    assert q.size(0) == n_tokens * n_heads, (
-        f"q rows {q.size(0)} incompatible with weights shape {tuple(weights.shape)}"
-    )
-    assert head_dim == 128, f"only head_dim=128 is supported, got {head_dim}"
-
-    q_fp8 = torch.empty(
-        (n_tokens, n_heads, head_dim),
-        dtype=dtypes.fp8,
-        device=q.device,
-    )
-    weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-    if q.numel() == 0:
-        return q_fp8, weights_out
-
-    grid = (q.size(0),)
-    _quant_indexer_q_and_scale_weights_kernel[grid](
-        q,
-        weights,
-        q_fp8,
-        weights_out,
-        n_heads,
-        q.stride(0),
-        q.stride(1),
-        weights.stride(0),
-        weights.stride(1),
-        weights_scale,
-        torch.finfo(dtypes.fp8).max,
-        BLOCK_D=head_dim,
-    )
-    return q_fp8, weights_out

--- a/atom/model_ops/v4_kernels/indexer_weights.py
+++ b/atom/model_ops/v4_kernels/indexer_weights.py
@@ -6,6 +6,7 @@
 import torch
 import triton
 import triton.language as tl
+from aiter import dtypes
 
 
 @triton.jit
@@ -14,6 +15,11 @@ def _scale_indexer_weights_kernel(
     q_scale_ptr,  # [T, H, 1] fp32, flattened as [T * H]
     out_ptr,  # [T, H] fp32
     n_elements,
+    n_cols: tl.constexpr,
+    weights_stride_t: tl.constexpr,
+    weights_stride_h: tl.constexpr,
+    q_scale_stride_t: tl.constexpr,
+    q_scale_stride_h: tl.constexpr,
     weights_scale: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
@@ -21,8 +27,17 @@ def _scale_indexer_weights_kernel(
     offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements
 
-    weights = tl.load(weights_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
-    q_scale = tl.load(q_scale_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    rows = offsets // n_cols
+    cols = offsets % n_cols
+    weights_offsets = rows * weights_stride_t + cols * weights_stride_h
+    q_scale_offsets = rows * q_scale_stride_t + cols * q_scale_stride_h
+
+    weights = tl.load(weights_ptr + weights_offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    q_scale = tl.load(q_scale_ptr + q_scale_offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
     tl.store(out_ptr + offsets, weights * q_scale * weights_scale, mask=mask)
 
 
@@ -38,12 +53,13 @@ def scale_indexer_weights(
         weights.size(0),
         weights.size(1),
         1,
-    ), f"q_scale shape {tuple(q_scale.shape)} incompatible with weights {tuple(weights.shape)}"
-    assert weights.is_contiguous(), "weights must be contiguous"
-    assert q_scale.is_contiguous(), "q_scale must be contiguous"
+    ), (
+        f"q_scale shape {tuple(q_scale.shape)} incompatible with weights "
+        f"{tuple(weights.shape)}"
+    )
 
     n_elements = weights.numel()
-    out = torch.empty_like(weights, dtype=torch.float32)
+    out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
     if n_elements == 0:
         return out
 
@@ -53,7 +69,86 @@ def scale_indexer_weights(
         q_scale,
         out,
         n_elements,
+        weights.size(1),
+        weights.stride(0),
+        weights.stride(1),
+        q_scale.stride(0),
+        q_scale.stride(1),
         weights_scale,
         BLOCK_SIZE=block_size,
     )
     return out
+
+
+@triton.jit
+def _quant_indexer_q_and_scale_weights_kernel(
+    q_ptr,  # [T * H, D] bf16/fp16/fp32
+    weights_ptr,  # [T, H] bf16/fp32
+    q_out_ptr,  # [T, H, D] fp8
+    weights_out_ptr,  # [T, H] fp32
+    n_heads: tl.constexpr,
+    q_stride_m: tl.constexpr,
+    q_stride_d: tl.constexpr,
+    weights_stride_t: tl.constexpr,
+    weights_stride_h: tl.constexpr,
+    weights_scale: tl.constexpr,
+    fp8_max: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offs_d = tl.arange(0, BLOCK_D)
+
+    q = tl.load(q_ptr + row * q_stride_m + offs_d * q_stride_d).to(tl.float32)
+    amax = tl.max(tl.abs(q), axis=0)
+    scale = tl.maximum(amax, 1.0e-10) / fp8_max
+    q_fp8 = tl.clamp(q / scale, -fp8_max, fp8_max).to(q_out_ptr.dtype.element_ty)
+    tl.store(q_out_ptr + row * BLOCK_D + offs_d, q_fp8)
+
+    token = row // n_heads
+    head = row % n_heads
+    weights = tl.load(
+        weights_ptr + token * weights_stride_t + head * weights_stride_h,
+    ).to(tl.float32)
+    tl.store(weights_out_ptr + row, weights * scale * weights_scale)
+
+
+def quant_indexer_q_and_scale_weights(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    weights_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize Indexer q and fold q_scale into weights in one Triton launch."""
+    assert q.dim() == 2, f"q must be [T * H, D], got {tuple(q.shape)}"
+    assert weights.dim() == 2, f"weights must be [T, H], got {tuple(weights.shape)}"
+    n_tokens, n_heads = weights.shape
+    head_dim = q.size(1)
+    assert q.size(0) == n_tokens * n_heads, (
+        f"q rows {q.size(0)} incompatible with weights shape {tuple(weights.shape)}"
+    )
+    assert head_dim == 128, f"only head_dim=128 is supported, got {head_dim}"
+
+    q_fp8 = torch.empty(
+        (n_tokens, n_heads, head_dim),
+        dtype=dtypes.fp8,
+        device=q.device,
+    )
+    weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+    if q.numel() == 0:
+        return q_fp8, weights_out
+
+    grid = (q.size(0),)
+    _quant_indexer_q_and_scale_weights_kernel[grid](
+        q,
+        weights,
+        q_fp8,
+        weights_out,
+        n_heads,
+        q.stride(0),
+        q.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        weights_scale,
+        torch.finfo(dtypes.fp8).max,
+        BLOCK_D=head_dim,
+    )
+    return q_fp8, weights_out

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -130,6 +130,28 @@ _FP8_DTYPES = tuple(
 )
 
 
+def _can_fuse_indexer_wk_quant_config(wk_quant_config) -> bool:
+    if wk_quant_config.quant_type == QuantType.No:
+        return True
+    return wk_quant_config.quant_dtype == dtypes.fp8
+
+
+def _iter_indexer_prefixes(
+    config: PretrainedConfig,
+    model_prefix: str,
+) -> list[str]:
+    attn_module_list_cfg = getattr(config, "attn_module_list_cfg", None)
+    if isinstance(attn_module_list_cfg, (list, tuple)):
+        prefixes = [
+            f"{model_prefix}.layers.{layer_idx}.self_attn.indexer"
+            for layer_idx, layer_cfg in enumerate(attn_module_list_cfg)
+            if isinstance(layer_cfg, dict) and layer_cfg.get("attn_index") is not None
+        ]
+        if prefixes:
+            return prefixes
+    return [f"{model_prefix}.layers.0.self_attn.indexer"]
+
+
 def _can_fuse_indexer_wk_weights_proj(
     config: PretrainedConfig,
     quant_config: Optional[QuantizationConfig],
@@ -141,9 +163,18 @@ def _can_fuse_indexer_wk_weights_proj(
         return True
 
     wk_quant_config = quant_config.get_layer_quant_config(f"{indexer_prefix}.wk")
-    if wk_quant_config.quant_type == QuantType.No:
-        return True
-    return wk_quant_config.quant_dtype == dtypes.fp8
+    return _can_fuse_indexer_wk_quant_config(wk_quant_config)
+
+
+def _can_fuse_model_indexer_wk_weights_proj(
+    config: PretrainedConfig,
+    quant_config: Optional[QuantizationConfig],
+    model_prefix: str,
+) -> bool:
+    return all(
+        _can_fuse_indexer_wk_weights_proj(config, quant_config, indexer_prefix)
+        for indexer_prefix in _iter_indexer_prefixes(config, model_prefix)
+    )
 
 
 def _fuse_rmsnorm_fp4_quant_fake(
@@ -750,7 +781,6 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant(
 
 
 class DeepseekV2MLP(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,
@@ -778,8 +808,7 @@ class DeepseekV2MLP(nn.Module):
         )
         if hidden_act != "silu":
             raise ValueError(
-                f"Unsupported activation: {hidden_act}. "
-                "Only silu is supported for now."
+                f"Unsupported activation: {hidden_act}. Only silu is supported for now."
             )
         self.act_fn = SiluAndMul()
 
@@ -791,7 +820,6 @@ class DeepseekV2MLP(nn.Module):
 
 
 class DeepseekV2MoE(nn.Module):
-
     def __init__(
         self,
         config: PretrainedConfig,
@@ -936,12 +964,12 @@ class DeepseekV2MoE(nn.Module):
         return final_hidden_states
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        assert (
-            hidden_states.dim() == 2
-        ), f"Expected hidden_states to be 2D (seq_len, hidden_dim), but got {hidden_states.dim()}D, with shape {hidden_states.shape}"
-        assert (
-            hidden_states.shape[1] == self.experts.hidden_size
-        ), f"Hidden states dimension {hidden_states.shape[1]} does not match expected {self.experts.hidden_size}"
+        assert hidden_states.dim() == 2, (
+            f"Expected hidden_states to be 2D (seq_len, hidden_dim), but got {hidden_states.dim()}D, with shape {hidden_states.shape}"
+        )
+        assert hidden_states.shape[1] == self.experts.hidden_size, (
+            f"Hidden states dimension {hidden_states.shape[1]} does not match expected {self.experts.hidden_size}"
+        )
 
         if self._use_dual_stream:
             return torch.ops.aiter.maybe_dual_stream_forward(hidden_states, self.prefix)
@@ -960,7 +988,6 @@ def yarn_get_mscale(scale: float = 1, mscale: float = 1) -> float:
 
 @DeepseekV32IndexerCacheDecoratorForPluginMode
 class DeepseekV32IndexerCache(nn.Module):
-
     def __init__(
         self, head_dim: int, dtype: torch.dtype, prefix: str, cache_config: str
     ):
@@ -976,7 +1003,7 @@ def sparse_attn_indexer(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
     kv_cache: torch.Tensor,
-    q_fp8: torch.Tensor,
+    q_input: torch.Tensor,
     k: torch.Tensor,
     weights: torch.Tensor,
     quant_block_size: int,
@@ -1004,7 +1031,7 @@ def sparse_attn_indexer(
     # Skip for dummy runs to avoid corrupting KV cache
     if forward_context.context.is_dummy_run:
         # dummy runner
-        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+        return torch.zeros_like(weights, dtype=torch.float32)
     # For MTP verify decode, max_seqlen_q > 1 so total decode tokens = batch_size * max_seqlen_q
     num_decode_tokens = (
         context.batch_size * attn_metadata.max_seqlen_q if not context.is_prefill else 0
@@ -1012,13 +1039,13 @@ def sparse_attn_indexer(
     runner_block_size = get_current_atom_config().kv_cache_block_size
     kv_cache = kv_cache.view(-1, runner_block_size, kv_cache.shape[-1])
     if use_qk_rope_cache_fusion:
-        q = q_fp8
-        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+        q_bf16 = q_input
+        q_fp8 = torch.empty_like(q_bf16, dtype=dtypes.fp8)
         weights_out = torch.empty(
             weights.shape, device=weights.device, dtype=torch.float32
         )
         indexer_qk_rope_quant_and_cache(
-            q,
+            q_bf16,
             q_fp8,
             weights,
             weights_out,
@@ -1039,6 +1066,7 @@ def sparse_attn_indexer(
         )
         weights = weights_out
     else:
+        q_fp8 = q_input
         indexer_k_quant_and_cache(
             k,
             kv_cache,
@@ -1151,7 +1179,7 @@ def sparse_attn_indexer_fake(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
     kv_cache: torch.Tensor,
-    q_fp8: torch.Tensor,
+    q_input: torch.Tensor,
     k: torch.Tensor,
     weights: torch.Tensor,
     quant_block_size: int,
@@ -1236,7 +1264,7 @@ class IndexerWkWeightsProjLinear(MergedReplicatedLinear):
         # during loading and is not consumed in forward.
         self.weight_scale = atom_parameter(
             torch.empty(
-                (max(1, (head_dim + 127) // 128), (hidden_size + 127) // 128),
+                ((head_dim + 127) // 128, (hidden_size + 127) // 128),
                 dtype=torch.float32,
             )
         )
@@ -1264,7 +1292,7 @@ class IndexerWkWeightsProjLinear(MergedReplicatedLinear):
         if param is self.weight_scale:
             if loaded_shard_id == 0:
                 param.weight_loader_process(param.data, loaded_weight)
-                self._wk_pending_scale = loaded_weight
+                self._wk_pending_scale = param.data.detach().clone()
                 self._maybe_load_pending_wk()
             return
 
@@ -1273,7 +1301,7 @@ class IndexerWkWeightsProjLinear(MergedReplicatedLinear):
             and loaded_shard_id == 0
             and loaded_weight.dtype in _FP8_DTYPES
         ):
-            self._wk_pending_weight = loaded_weight
+            self._wk_pending_weight = loaded_weight.detach().clone()
             self._maybe_load_pending_wk()
             return
 
@@ -1297,7 +1325,6 @@ class IndexerWkWeightsProjLinear(MergedReplicatedLinear):
 
 @IndexerDecoratorForPluginMode
 class Indexer(nn.Module):
-
     def __init__(
         self,
         atom_config: Config,
@@ -1472,6 +1499,7 @@ class DeepseekV2MLAAttention(nn.Module):
         prefix: str = "",
         layer_num: int = 0,
         topk_indices_buffer: Optional[torch.Tensor] = None,
+        use_indexer_wk_weights_proj_fusion: Optional[bool] = None,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -1644,10 +1672,14 @@ class DeepseekV2MLAAttention(nn.Module):
                 base_quant_config,
                 cache_config,
                 topk_indices_buffer,
-                _can_fuse_indexer_wk_weights_proj(
-                    config,
-                    model_quant_config,
-                    f"{prefix}.indexer",
+                (
+                    _can_fuse_indexer_wk_weights_proj(
+                        config,
+                        model_quant_config,
+                        f"{prefix}.indexer",
+                    )
+                    if use_indexer_wk_weights_proj_fusion is None
+                    else use_indexer_wk_weights_proj_fusion
                 ),
                 f"{prefix}.indexer",
             )
@@ -1796,7 +1828,6 @@ class DeepseekV2MLAAttention(nn.Module):
 
 
 class DeepseekV2DecoderLayer(nn.Module):
-
     def __init__(
         self,
         config: PretrainedConfig,
@@ -1807,6 +1838,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         layer_num: int = 0,
         is_mtp_block: bool = False,
         alt_stream: Optional[torch.cuda.Stream] = None,
+        use_indexer_wk_weights_proj_fusion: Optional[bool] = None,
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -1831,6 +1863,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             prefix=f"{prefix}.self_attn",
             layer_num=layer_num,
             topk_indices_buffer=topk_indices_buffer,
+            use_indexer_wk_weights_proj_fusion=use_indexer_wk_weights_proj_fusion,
         )
 
         # When ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION is turned on self.fuse_input_norm_quant is turned on only if use_triton_gemm and (FP8 or FP4),
@@ -2002,6 +2035,7 @@ class DeepseekV2Model(nn.Module):
         atom_config: Config,
         prefix: str = "",
         layer_type: type[nn.Module] = DeepseekV2DecoderLayer,
+        use_indexer_wk_weights_proj_fusion: Optional[bool] = None,
     ):
         super().__init__()
 
@@ -2046,6 +2080,7 @@ class DeepseekV2Model(nn.Module):
                 quant_config=quant_config,
                 layer_num=layer_num,
                 alt_stream=_alt_stream,
+                use_indexer_wk_weights_proj_fusion=use_indexer_wk_weights_proj_fusion,
             ),
             prefix=f"{prefix}.layers",
             layer_num_offset=0,
@@ -2126,7 +2161,6 @@ class DeepseekV2Model(nn.Module):
 
 
 class DeepseekV2ForCausalLM(nn.Module):
-
     def __init__(
         self,
         atom_config: Config,
@@ -2140,10 +2174,10 @@ class DeepseekV2ForCausalLM(nn.Module):
         self.quant_config = quant_config
 
         model_prefix = maybe_prefix(prefix, "model")
-        use_indexer_wk_weights_proj_fusion = _can_fuse_indexer_wk_weights_proj(
+        use_indexer_wk_weights_proj_fusion = _can_fuse_model_indexer_wk_weights_proj(
             config,
             quant_config,
-            f"{model_prefix}.layers.0.self_attn.indexer",
+            model_prefix,
         )
         if hasattr(config, "q_lora_rank") and config.q_lora_rank is not None:
             self.packed_modules_mapping = {
@@ -2169,6 +2203,7 @@ class DeepseekV2ForCausalLM(nn.Module):
             atom_config=atom_config,
             prefix=model_prefix,
             layer_type=layer_type,
+            use_indexer_wk_weights_proj_fusion=use_indexer_wk_weights_proj_fusion,
         )
         if get_pp_group().is_last_rank:
             self.lm_head = ParallelLMHead(
@@ -2248,10 +2283,10 @@ class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
     """GLM 5.0 MoE (structurally similar to DeepSeek v3.2). Reuses DeepseekV2 implementation."""
 
     # GLM-5's HF quant config uses `indexers_proj` in modules_to_not_convert, but
-    # the ATOM module path is fused as `indexer.wk_weights_proj`.  Declaring the
-    # mapping here keeps the translation co-located with the model and out of config.py.
+    # the unfused ATOM module path is `indexer.weights_proj`.  Keep that path
+    # excluded so FP4/MXFP4 fallback does not quantize the BF16 projection.
     quant_exclude_name_mapping: dict[str, str] = {
         # HF quant config uses "indexers_proj" but the ATOM module path is
-        # "indexer.wk_weights_proj".  str.replace translates each exclude entry.
-        "indexers_proj": "indexer.wk_weights_proj",
+        # "indexer.weights_proj".  str.replace translates each exclude entry.
+        "indexers_proj": "indexer.weights_proj",
     }

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -35,6 +35,9 @@ from aiter import (
     gemm_a8w8_blockscale_bpreshuffle,
     get_hip_quant,
     indexer_k_quant_and_cache,
+    indexer_k_norm_rope_quant_and_cache,
+    indexer_qk_rope_quant_and_cache,
+    rope_cached_positions_fwd_inplace,
     top_k_per_row_decode,
     top_k_per_row_prefill,
 )
@@ -66,6 +69,10 @@ from atom.model_ops.linear import (
 from atom.model_ops.moe import FusedMoE
 from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.model_ops.utils import MXFP4_QUANT_BLOCK_SIZE, atom_parameter
+from atom.model_ops.v4_kernels.indexer_weights import (
+    quant_indexer_q_and_scale_weights,
+    scale_indexer_weights,
+)
 from atom.models.utils import (
     IntermediateTensors,
     PPMissingLayer,
@@ -116,6 +123,17 @@ ENABLE_DS_QKNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_QKNORM_QUANT_FUSION
 ENABLE_DS_QKNORM_FUSION = envs.ATOM_ENABLE_DS_QKNORM_FUSION
 ENABLE_ALLREDUCE_RMSNORM_FUSION = envs.ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION
 ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION
+ENABLE_DS_INDEXER_Q_QUANT_FUSION = envs.ATOM_ENABLE_DS_INDEXER_Q_QUANT_FUSION
+ENABLE_DS_INDEXER_K_CACHE_FUSION = envs.ATOM_ENABLE_DS_INDEXER_K_CACHE_FUSION
+ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION = envs.ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
+_FP8_DTYPES = tuple(
+    dtype
+    for dtype in (
+        getattr(torch, "float8_e4m3fn", None),
+        getattr(torch, "float8_e4m3fnuz", None),
+    )
+    if dtype is not None
+)
 
 
 def _fuse_rmsnorm_fp4_quant_fake(
@@ -395,6 +413,47 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant_fp4_fake(
         device=device,
     )[..., :qk_rope_head_dim]
     return q_c, q_c_scale, kv_c_normed, k_pe
+
+
+def _indexer_q_rope_inplace_fake(
+    q_pe: torch.Tensor,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    return q_pe
+
+
+def _indexer_q_rope_inplace(
+    q_pe: torch.Tensor,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    num_tokens = positions.numel()
+    q_view = q_pe.view(1, num_tokens, -1, q_pe.shape[-1])
+    position_view = positions.view(1, num_tokens)
+    rotate_style = 0 if is_neox_style else 1
+    rope_cached_positions_fwd_inplace(
+        q_view,
+        cos_cache,
+        sin_cache,
+        position_view,
+        rotate_style,
+        True,
+        False,
+    )
+    return q_pe
+
+
+direct_register_custom_op(
+    op_name="indexer_q_rope_inplace",
+    op_func=_indexer_q_rope_inplace,
+    mutates_args=["q_pe"],
+    fake_impl=_indexer_q_rope_inplace_fake,
+)
 
 
 def _fuse_qkv_a_proj_reduce_rmsnorm_quant_fp8_fake(
@@ -958,6 +1017,15 @@ def sparse_attn_indexer(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor,
+    fuse_qk_rope_quant_cache: bool,
+    fuse_k_norm_rope_cache: bool,
+    k_norm_weight: torch.Tensor,
+    k_norm_bias: torch.Tensor,
+    k_norm_eps: float,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    weights_scale: float,
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
     forward_context = get_forward_context()
@@ -967,6 +1035,8 @@ def sparse_attn_indexer(
     # Skip for dummy runs to avoid corrupting KV cache
     if forward_context.context.is_dummy_run:
         # dummy runner
+        if fuse_qk_rope_quant_cache:
+            return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
         return weights
     # For MTP verify decode, max_seqlen_q > 1 so total decode tokens = batch_size * max_seqlen_q
     num_decode_tokens = (
@@ -974,14 +1044,56 @@ def sparse_attn_indexer(
     )
     runner_block_size = get_current_atom_config().kv_cache_block_size
     kv_cache = kv_cache.view(-1, runner_block_size, kv_cache.shape[-1])
-    indexer_k_quant_and_cache(
-        k,
-        kv_cache,
-        slot_mapping,
-        quant_block_size,
-        scale_fmt,
-        preshuffle=True,
-    )
+    if fuse_qk_rope_quant_cache:
+        q = q_fp8
+        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+        weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+        indexer_qk_rope_quant_and_cache(
+            q,
+            q_fp8,
+            weights,
+            weights_out,
+            k,
+            kv_cache,
+            slot_mapping,
+            k_norm_weight,
+            k_norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            k_norm_eps,
+            quant_block_size,
+            scale_fmt,
+            weights_scale,
+            preshuffle=True,
+            is_neox=True,
+        )
+        weights = weights_out
+    elif fuse_k_norm_rope_cache:
+        indexer_k_norm_rope_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            k_norm_weight,
+            k_norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            k_norm_eps,
+            quant_block_size,
+            scale_fmt,
+            preshuffle=True,
+            is_neox=True,
+        )
+    else:
+        indexer_k_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            quant_block_size,
+            scale_fmt,
+            preshuffle=True,
+        )
     if context.is_prefill:
         if attn_metadata.max_seqlen_k <= topk_indices_buffer.shape[1]:
             return weights
@@ -1096,6 +1208,15 @@ def sparse_attn_indexer_fake(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor,
+    fuse_qk_rope_quant_cache: bool,
+    fuse_k_norm_rope_cache: bool,
+    k_norm_weight: torch.Tensor,
+    k_norm_bias: torch.Tensor,
+    k_norm_eps: float,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    weights_scale: float,
 ) -> torch.Tensor:
     # profile run
     # NOTE(Chen): create the max possible flattened_kv. So that
@@ -1105,6 +1226,8 @@ def sparse_attn_indexer_fake(
     )
     _k_fp8 = _flattened_kv[..., :head_dim].view(torch.float8_e4m3fn).contiguous()
     _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
+    if fuse_qk_rope_quant_cache:
+        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
     return weights
 
 
@@ -1114,6 +1237,111 @@ direct_register_custom_op(
     mutates_args=["topk_indices_buffer"],
     fake_impl=sparse_attn_indexer_fake,
 )
+
+
+def _dequant_fp8_block_to_bf16(
+    weight_fp8: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = 128,
+) -> torch.Tensor:
+    """Dequantize block-scaled FP8 weights to BF16 for BF16-only fused GEMMs."""
+    out_dim, in_dim = weight_fp8.shape
+    if out_dim % block_size != 0 or in_dim % block_size != 0:
+        raise ValueError(
+            "FP8 block dequant expects dimensions divisible by "
+            f"{block_size}, got {tuple(weight_fp8.shape)}"
+        )
+    weight = (
+        weight_fp8.unflatten(0, (-1, block_size))
+        .unflatten(-1, (-1, block_size))
+        .float()
+    )
+    scale = scale.float()
+    return (weight * scale[:, None, :, None]).flatten(2, 3).flatten(0, 1).bfloat16()
+
+
+class IndexerWkWeightsProjLinear(MergedReplicatedLinear):
+    """Fused Indexer wk + weights projection with FP8 wk load support."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_dim: int,
+        n_head: int,
+        prefix: str = "",
+    ):
+        self._wk_pending_weight: Optional[torch.Tensor] = None
+        self._wk_pending_scale: Optional[torch.Tensor] = None
+        self._wk_loaded = False
+        super().__init__(
+            hidden_size,
+            [head_dim, n_head],
+            bias=False,
+            quant_config=None,
+            prefix=prefix,
+        )
+        # Checkpoints may store indexer.wk as FP8 plus weight_scale_inv.  The
+        # fused GEMM runs in BF16, so this parameter only receives the scale
+        # during loading and is not consumed in forward.
+        self.weight_scale = atom_parameter(
+            torch.empty(
+                (max(1, (head_dim + 127) // 128), (hidden_size + 127) // 128),
+                dtype=torch.float32,
+            )
+        )
+        self.weight_scale.weight_loader_process = self.weight_loader_process
+        self.weight_scale.weight_loader = self.weight_loader
+
+    def _maybe_load_pending_wk(self) -> None:
+        if self._wk_pending_weight is None or self._wk_pending_scale is None:
+            return
+        wk_weight = _dequant_fp8_block_to_bf16(
+            self._wk_pending_weight,
+            self._wk_pending_scale,
+        )
+        super().weight_loader(self.weight, wk_weight, 0)
+        self._wk_pending_weight = None
+        self._wk_pending_scale = None
+        self._wk_loaded = True
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: Optional[int] = None,
+    ):
+        if param is self.weight_scale:
+            if loaded_shard_id == 0:
+                param.weight_loader_process(param.data, loaded_weight)
+                self._wk_pending_scale = loaded_weight
+                self._maybe_load_pending_wk()
+            return
+
+        if (
+            param is self.weight
+            and loaded_shard_id == 0
+            and loaded_weight.dtype in _FP8_DTYPES
+        ):
+            self._wk_pending_weight = loaded_weight
+            self._maybe_load_pending_wk()
+            return
+
+        if param is self.weight and loaded_shard_id == 0:
+            self._wk_pending_weight = None
+            self._wk_pending_scale = None
+            self._wk_loaded = True
+
+        super().weight_loader(param, loaded_weight, loaded_shard_id)
+
+    def process_weights_after_loading(self):
+        if self._wk_pending_weight is not None or (
+            self._wk_pending_scale is not None and not self._wk_loaded
+        ):
+            raise RuntimeError(
+                "Incomplete FP8 indexer.wk load: both weight and weight_scale "
+                "are required before building wk_weights_proj."
+            )
+        super().process_weights_after_loading()
 
 
 @IndexerDecoratorForPluginMode
@@ -1147,25 +1375,33 @@ class Indexer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.wq_b",
         )
-        self.wk = ReplicatedLinear(
+        self.wk_weights_proj = IndexerWkWeightsProjLinear(
             hidden_size,
             self.head_dim,
-            bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.wk",
+            self.n_head,
+            prefix=f"{prefix}.wk_weights_proj",
         )
         self.k_norm = LayerNorm(self.head_dim, eps=1e-6)
-        self.weights_proj = ReplicatedLinear(
-            hidden_size,
-            self.n_head,
-            quant_config=None,
-            prefix=f"{prefix}.weights_proj",
-        )
         self.softmax_scale = self.head_dim**-0.5
+        self._weights_scale = self.softmax_scale * self.n_head**-0.5
 
         self.scale_fmt = "ue8m0"
         self.quant_func = get_hip_quant(QuantType.per_1x128)
         self.quant_block_size = 128  # TODO: get from config
+        self.fuse_q_quant_weights = (
+            ENABLE_DS_INDEXER_Q_QUANT_FUSION
+            and self.head_dim == self.quant_block_size
+        )
+        self.fuse_k_norm_rope_cache = (
+            ENABLE_DS_INDEXER_K_CACHE_FUSION
+            and self.head_dim == self.quant_block_size
+            and self.rope_dim == self.head_dim // 2
+        )
+        self.fuse_qk_rope_quant_cache = (
+            ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
+            and self.fuse_q_quant_weights
+            and self.fuse_k_norm_rope_cache
+        )
         self.topk_indices_buffer = topk_indices_buffer
 
         # TODO (zyongye) change dim to fp8 later to (self.head_dim + 4)
@@ -1192,30 +1428,49 @@ class Indexer(nn.Module):
     ) -> torch.Tensor:
         q = self.wq_b(qr, qr_scale)
         q = q.view(-1, self.n_head, self.head_dim)
-        q_pe, q_nope = torch.split(
-            q, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
-        )
+        q_pe = q[..., : self.rope_dim]
 
-        k = self.wk(hidden_states)
-        k = self.k_norm(k)
-        k_pe, k_nope = torch.split(
-            k, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
+        k, weights = torch.split(
+            self.wk_weights_proj(hidden_states),
+            [self.head_dim, self.n_head],
+            dim=-1,
         )
-
-        q_pe, k_pe = rotary_emb(positions, q_pe, k_pe)
+        if self.fuse_qk_rope_quant_cache:
+            # q RoPE/quant and k cache write are fused inside sparse_attn_indexer,
+            # where the runtime cache slot mapping is available.
+            pass
+        elif self.fuse_k_norm_rope_cache:
+            q_pe = torch.ops.aiter.indexer_q_rope_inplace(
+                q_pe,
+                positions,
+                rotary_emb.cos_cache,
+                rotary_emb.sin_cache,
+                rotary_emb.is_neox_style,
+            )
+        else:
+            k = self.k_norm(k)
+            k_pe = k[..., : self.rope_dim]
+            q_pe, k_pe = rotary_emb(positions, q_pe, k_pe)
 
         # we only quant q here since k quant is fused with cache insertion
-        q = q.view(-1, self.head_dim)
+        if self.fuse_qk_rope_quant_cache:
+            q_fp8 = q
+        else:
+            q = q.view(-1, self.head_dim)
 
-        q_fp8, q_scale = self.quant_func(q, quant_dtype=dtypes.fp8)
-        q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
-        q_scale = q_scale.view(-1, self.n_head, 1)
-
-        weights = self.weights_proj(hidden_states)
-        weights = (
-            weights.unsqueeze(-1) * q_scale * self.softmax_scale * self.n_head**-0.5
-        )
-        weights = weights.squeeze(-1)
+        if self.fuse_qk_rope_quant_cache:
+            pass
+        elif self.fuse_q_quant_weights:
+            q_fp8, weights = quant_indexer_q_and_scale_weights(
+                q,
+                weights,
+                self._weights_scale,
+            )
+        else:
+            q_fp8, q_scale = self.quant_func(q, quant_dtype=dtypes.fp8)
+            q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
+            q_scale = q_scale.view(-1, self.n_head, 1)
+            weights = scale_indexer_weights(weights, q_scale, self._weights_scale)
 
         return self.sparse_attn_indexer_impl(
             hidden_states,
@@ -1231,6 +1486,15 @@ class Indexer(nn.Module):
             self.max_model_len,
             self.max_total_seq_len,
             self.topk_indices_buffer,
+            self.fuse_qk_rope_quant_cache,
+            self.fuse_k_norm_rope_cache,
+            self.k_norm.weight,
+            self.k_norm.bias,
+            self.k_norm.eps,
+            positions,
+            rotary_emb.cos_cache,
+            rotary_emb.sin_cache,
+            self._weights_scale,
         )
 
 
@@ -1925,11 +2189,15 @@ class DeepseekV2ForCausalLM(nn.Module):
                 "kv_a_proj_with_mqa": ("fused_qkv_a_proj", 1),
                 "gate_proj": ("gate_up_proj", 0),
                 "up_proj": ("gate_up_proj", 1),
+                "indexer.wk": ("indexer.wk_weights_proj", 0),
+                "indexer.weights_proj": ("indexer.wk_weights_proj", 1),
             }
         else:
             self.packed_modules_mapping = {
                 "gate_proj": ("gate_up_proj", 0),
                 "up_proj": ("gate_up_proj", 1),
+                "indexer.wk": ("indexer.wk_weights_proj", 0),
+                "indexer.weights_proj": ("indexer.wk_weights_proj", 1),
             }
 
         self.model = DeepseekV2Model(
@@ -2003,19 +2271,22 @@ class DeepseekV2ForCausalLM(nn.Module):
 
 
 class DeepseekV3ForCausalLM(DeepseekV2ForCausalLM):
-    # DeepSeek-V3.2's indexer weights_proj are not quantized, but they are not listed in
-    # model's quant exclude mapping. So we add it to quant_default_exclude_layers.
-    quant_default_exclude_layers: list[str] = ["*.indexer.weights_proj"]
+    # DeepSeek-V3.2's indexer weights projection is BF16.  Keep the original
+    # checkpoint path and the fused ATOM path excluded from default quantization.
+    quant_default_exclude_layers: list[str] = [
+        "*.indexer.weights_proj",
+        "*.indexer.wk_weights_proj",
+    ]
 
 
 class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
     """GLM 5.0 MoE (structurally similar to DeepSeek v3.2). Reuses DeepseekV2 implementation."""
 
     # GLM-5's HF quant config uses `indexers_proj` in modules_to_not_convert, but
-    # the ATOM module path is `indexer.weights_proj`.  Declaring the mapping here
-    # keeps the translation co-located with the model and out of config.py.
+    # the ATOM module path is fused as `indexer.wk_weights_proj`.  Declaring the
+    # mapping here keeps the translation co-located with the model and out of config.py.
     quant_exclude_name_mapping: dict[str, str] = {
         # HF quant config uses "indexers_proj" but the ATOM module path is
-        # "indexer.weights_proj".  str.replace translates each exclude entry.
-        "indexers_proj": "indexer.weights_proj",
+        # "indexer.wk_weights_proj".  str.replace translates each exclude entry.
+        "indexers_proj": "indexer.wk_weights_proj",
     }

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1026,6 +1026,7 @@ def sparse_attn_indexer(
     cos_cache: torch.Tensor,
     sin_cache: torch.Tensor,
     weights_scale: float,
+    is_neox_style: bool,
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
     forward_context = get_forward_context()
@@ -1066,7 +1067,7 @@ def sparse_attn_indexer(
             scale_fmt,
             weights_scale,
             preshuffle=True,
-            is_neox=True,
+            is_neox=is_neox_style,
         )
         weights = weights_out
     elif fuse_k_norm_rope_cache:
@@ -1083,7 +1084,7 @@ def sparse_attn_indexer(
             quant_block_size,
             scale_fmt,
             preshuffle=True,
-            is_neox=True,
+            is_neox=is_neox_style,
         )
     else:
         indexer_k_quant_and_cache(
@@ -1217,6 +1218,7 @@ def sparse_attn_indexer_fake(
     cos_cache: torch.Tensor,
     sin_cache: torch.Tensor,
     weights_scale: float,
+    is_neox_style: bool,
 ) -> torch.Tensor:
     # profile run
     # NOTE(Chen): create the max possible flattened_kv. So that
@@ -1495,6 +1497,7 @@ class Indexer(nn.Module):
             rotary_emb.cos_cache,
             rotary_emb.sin_cache,
             self._weights_scale,
+            rotary_emb.is_neox_style,
         )
 
 

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -34,10 +34,7 @@ from aiter import (
     fused_qk_rmsnorm,
     gemm_a8w8_blockscale_bpreshuffle,
     get_hip_quant,
-    indexer_k_quant_and_cache,
-    indexer_k_norm_rope_quant_and_cache,
     indexer_qk_rope_quant_and_cache,
-    rope_cached_positions_fwd_inplace,
     top_k_per_row_decode,
     top_k_per_row_prefill,
 )
@@ -69,10 +66,6 @@ from atom.model_ops.linear import (
 from atom.model_ops.moe import FusedMoE
 from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.model_ops.utils import MXFP4_QUANT_BLOCK_SIZE, atom_parameter
-from atom.model_ops.v4_kernels.indexer_weights import (
-    quant_indexer_q_and_scale_weights,
-    scale_indexer_weights,
-)
 from atom.models.utils import (
     IntermediateTensors,
     PPMissingLayer,
@@ -123,9 +116,6 @@ ENABLE_DS_QKNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_QKNORM_QUANT_FUSION
 ENABLE_DS_QKNORM_FUSION = envs.ATOM_ENABLE_DS_QKNORM_FUSION
 ENABLE_ALLREDUCE_RMSNORM_FUSION = envs.ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION
 ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION
-ENABLE_DS_INDEXER_Q_QUANT_FUSION = envs.ATOM_ENABLE_DS_INDEXER_Q_QUANT_FUSION
-ENABLE_DS_INDEXER_K_CACHE_FUSION = envs.ATOM_ENABLE_DS_INDEXER_K_CACHE_FUSION
-ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION = envs.ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
 _FP8_DTYPES = tuple(
     dtype
     for dtype in (
@@ -413,47 +403,6 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant_fp4_fake(
         device=device,
     )[..., :qk_rope_head_dim]
     return q_c, q_c_scale, kv_c_normed, k_pe
-
-
-def _indexer_q_rope_inplace_fake(
-    q_pe: torch.Tensor,
-    positions: torch.Tensor,
-    cos_cache: torch.Tensor,
-    sin_cache: torch.Tensor,
-    is_neox_style: bool,
-) -> torch.Tensor:
-    return q_pe
-
-
-def _indexer_q_rope_inplace(
-    q_pe: torch.Tensor,
-    positions: torch.Tensor,
-    cos_cache: torch.Tensor,
-    sin_cache: torch.Tensor,
-    is_neox_style: bool,
-) -> torch.Tensor:
-    num_tokens = positions.numel()
-    q_view = q_pe.view(1, num_tokens, -1, q_pe.shape[-1])
-    position_view = positions.view(1, num_tokens)
-    rotate_style = 0 if is_neox_style else 1
-    rope_cached_positions_fwd_inplace(
-        q_view,
-        cos_cache,
-        sin_cache,
-        position_view,
-        rotate_style,
-        True,
-        False,
-    )
-    return q_pe
-
-
-direct_register_custom_op(
-    op_name="indexer_q_rope_inplace",
-    op_func=_indexer_q_rope_inplace,
-    mutates_args=["q_pe"],
-    fake_impl=_indexer_q_rope_inplace_fake,
-)
 
 
 def _fuse_qkv_a_proj_reduce_rmsnorm_quant_fp8_fake(
@@ -1017,8 +966,6 @@ def sparse_attn_indexer(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor,
-    fuse_qk_rope_quant_cache: bool,
-    fuse_k_norm_rope_cache: bool,
     k_norm_weight: torch.Tensor,
     k_norm_bias: torch.Tensor,
     k_norm_eps: float,
@@ -1036,65 +983,37 @@ def sparse_attn_indexer(
     # Skip for dummy runs to avoid corrupting KV cache
     if forward_context.context.is_dummy_run:
         # dummy runner
-        if fuse_qk_rope_quant_cache:
-            return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-        return weights
+        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
     # For MTP verify decode, max_seqlen_q > 1 so total decode tokens = batch_size * max_seqlen_q
     num_decode_tokens = (
         context.batch_size * attn_metadata.max_seqlen_q if not context.is_prefill else 0
     )
     runner_block_size = get_current_atom_config().kv_cache_block_size
     kv_cache = kv_cache.view(-1, runner_block_size, kv_cache.shape[-1])
-    if fuse_qk_rope_quant_cache:
-        q = q_fp8
-        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
-        weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-        indexer_qk_rope_quant_and_cache(
-            q,
-            q_fp8,
-            weights,
-            weights_out,
-            k,
-            kv_cache,
-            slot_mapping,
-            k_norm_weight,
-            k_norm_bias,
-            positions,
-            cos_cache,
-            sin_cache,
-            k_norm_eps,
-            quant_block_size,
-            scale_fmt,
-            weights_scale,
-            preshuffle=True,
-            is_neox=is_neox_style,
-        )
-        weights = weights_out
-    elif fuse_k_norm_rope_cache:
-        indexer_k_norm_rope_quant_and_cache(
-            k,
-            kv_cache,
-            slot_mapping,
-            k_norm_weight,
-            k_norm_bias,
-            positions,
-            cos_cache,
-            sin_cache,
-            k_norm_eps,
-            quant_block_size,
-            scale_fmt,
-            preshuffle=True,
-            is_neox=is_neox_style,
-        )
-    else:
-        indexer_k_quant_and_cache(
-            k,
-            kv_cache,
-            slot_mapping,
-            quant_block_size,
-            scale_fmt,
-            preshuffle=True,
-        )
+    q = q_fp8
+    q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+    weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+    indexer_qk_rope_quant_and_cache(
+        q,
+        q_fp8,
+        weights,
+        weights_out,
+        k,
+        kv_cache,
+        slot_mapping,
+        k_norm_weight,
+        k_norm_bias,
+        positions,
+        cos_cache,
+        sin_cache,
+        k_norm_eps,
+        quant_block_size,
+        scale_fmt,
+        weights_scale,
+        preshuffle=True,
+        is_neox=is_neox_style,
+    )
+    weights = weights_out
     if context.is_prefill:
         if attn_metadata.max_seqlen_k <= topk_indices_buffer.shape[1]:
             return weights
@@ -1209,8 +1128,6 @@ def sparse_attn_indexer_fake(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor,
-    fuse_qk_rope_quant_cache: bool,
-    fuse_k_norm_rope_cache: bool,
     k_norm_weight: torch.Tensor,
     k_norm_bias: torch.Tensor,
     k_norm_eps: float,
@@ -1228,9 +1145,7 @@ def sparse_attn_indexer_fake(
     )
     _k_fp8 = _flattened_kv[..., :head_dim].view(torch.float8_e4m3fn).contiguous()
     _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
-    if fuse_qk_rope_quant_cache:
-        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-    return weights
+    return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
 
 
 direct_register_custom_op(
@@ -1388,22 +1303,13 @@ class Indexer(nn.Module):
         self._weights_scale = self.softmax_scale * self.n_head**-0.5
 
         self.scale_fmt = "ue8m0"
-        self.quant_func = get_hip_quant(QuantType.per_1x128)
         self.quant_block_size = 128  # TODO: get from config
-        self.fuse_q_quant_weights = (
-            ENABLE_DS_INDEXER_Q_QUANT_FUSION
-            and self.head_dim == self.quant_block_size
-        )
-        self.fuse_k_norm_rope_cache = (
-            ENABLE_DS_INDEXER_K_CACHE_FUSION
-            and self.head_dim == self.quant_block_size
-            and self.rope_dim == self.head_dim // 2
-        )
-        self.fuse_qk_rope_quant_cache = (
-            ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
-            and self.fuse_q_quant_weights
-            and self.fuse_k_norm_rope_cache
-        )
+        if self.head_dim != self.quant_block_size or self.rope_dim != self.head_dim // 2:
+            raise ValueError(
+                "DeepSeek-V3.2 fused indexer requires "
+                f"head_dim={self.quant_block_size} and rope_dim={self.head_dim // 2}, "
+                f"got head_dim={self.head_dim}, rope_dim={self.rope_dim}"
+            )
         self.topk_indices_buffer = topk_indices_buffer
 
         # TODO (zyongye) change dim to fp8 later to (self.head_dim + 4)
@@ -1430,55 +1336,18 @@ class Indexer(nn.Module):
     ) -> torch.Tensor:
         q = self.wq_b(qr, qr_scale)
         q = q.view(-1, self.n_head, self.head_dim)
-        q_pe = q[..., : self.rope_dim]
 
         k, weights = torch.split(
             self.wk_weights_proj(hidden_states),
             [self.head_dim, self.n_head],
             dim=-1,
         )
-        if self.fuse_qk_rope_quant_cache:
-            # q RoPE/quant and k cache write are fused inside sparse_attn_indexer,
-            # where the runtime cache slot mapping is available.
-            pass
-        elif self.fuse_k_norm_rope_cache:
-            q_pe = torch.ops.aiter.indexer_q_rope_inplace(
-                q_pe,
-                positions,
-                rotary_emb.cos_cache,
-                rotary_emb.sin_cache,
-                rotary_emb.is_neox_style,
-            )
-        else:
-            k = self.k_norm(k)
-            k_pe = k[..., : self.rope_dim]
-            q_pe, k_pe = rotary_emb(positions, q_pe, k_pe)
-
-        # we only quant q here since k quant is fused with cache insertion
-        if self.fuse_qk_rope_quant_cache:
-            q_fp8 = q
-        else:
-            q = q.view(-1, self.head_dim)
-
-        if self.fuse_qk_rope_quant_cache:
-            pass
-        elif self.fuse_q_quant_weights:
-            q_fp8, weights = quant_indexer_q_and_scale_weights(
-                q,
-                weights,
-                self._weights_scale,
-            )
-        else:
-            q_fp8, q_scale = self.quant_func(q, quant_dtype=dtypes.fp8)
-            q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
-            q_scale = q_scale.view(-1, self.n_head, 1)
-            weights = scale_indexer_weights(weights, q_scale, self._weights_scale)
 
         return self.sparse_attn_indexer_impl(
             hidden_states,
             self.k_cache.prefix,
             self.k_cache.kv_cache[0],
-            q_fp8,
+            q,
             k,
             weights,
             self.quant_block_size,
@@ -1488,8 +1357,6 @@ class Indexer(nn.Module):
             self.max_model_len,
             self.max_total_seq_len,
             self.topk_indices_buffer,
-            self.fuse_qk_rope_quant_cache,
-            self.fuse_k_norm_rope_cache,
             self.k_norm.weight,
             self.k_norm.bias,
             self.k_norm.eps,

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1247,8 +1247,11 @@ class IndexerWkWeightsProjLinear(MergedReplicatedLinear):
     def _maybe_load_pending_wk(self) -> None:
         if self._wk_pending_weight is None or self._wk_pending_scale is None:
             return
+        wk_weight_fp8 = self._wk_pending_weight
+        if wk_weight_fp8.device != self._wk_pending_scale.device:
+            wk_weight_fp8 = wk_weight_fp8.to(self._wk_pending_scale.device)
         wk_weight = _dequant_fp8_block_to_bf16(
-            self._wk_pending_weight,
+            wk_weight_fp8,
             self._wk_pending_scale,
         )
         super().weight_loader(self.weight, wk_weight, 0)

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -130,51 +130,24 @@ _FP8_DTYPES = tuple(
 )
 
 
-def _can_fuse_indexer_wk_quant_config(wk_quant_config) -> bool:
-    if wk_quant_config.quant_type == QuantType.No:
-        return True
-    return wk_quant_config.quant_dtype == dtypes.fp8
-
-
-def _iter_indexer_prefixes(
-    config: PretrainedConfig,
-    model_prefix: str,
-) -> list[str]:
-    attn_module_list_cfg = getattr(config, "attn_module_list_cfg", None)
-    if isinstance(attn_module_list_cfg, (list, tuple)):
-        prefixes = [
-            f"{model_prefix}.layers.{layer_idx}.self_attn.indexer"
-            for layer_idx, layer_cfg in enumerate(attn_module_list_cfg)
-            if isinstance(layer_cfg, dict) and layer_cfg.get("attn_index") is not None
-        ]
-        if prefixes:
-            return prefixes
-    return [f"{model_prefix}.layers.0.self_attn.indexer"]
-
-
 def _can_fuse_indexer_wk_weights_proj(
     config: PretrainedConfig,
     quant_config: Optional[QuantizationConfig],
-    indexer_prefix: str,
+    indexer_prefixes: list[str],
 ) -> bool:
     if not hasattr(config, "index_topk"):
         return False
     if quant_config is None:
         return True
 
-    wk_quant_config = quant_config.get_layer_quant_config(f"{indexer_prefix}.wk")
-    return _can_fuse_indexer_wk_quant_config(wk_quant_config)
-
-
-def _can_fuse_model_indexer_wk_weights_proj(
-    config: PretrainedConfig,
-    quant_config: Optional[QuantizationConfig],
-    model_prefix: str,
-) -> bool:
-    return all(
-        _can_fuse_indexer_wk_weights_proj(config, quant_config, indexer_prefix)
-        for indexer_prefix in _iter_indexer_prefixes(config, model_prefix)
-    )
+    for indexer_prefix in indexer_prefixes:
+        wk_quant_config = quant_config.get_layer_quant_config(f"{indexer_prefix}.wk")
+        if (
+            wk_quant_config.quant_type != QuantType.No
+            and wk_quant_config.quant_dtype != dtypes.fp8
+        ):
+            return False
+    return True
 
 
 def _fuse_rmsnorm_fp4_quant_fake(
@@ -1676,7 +1649,7 @@ class DeepseekV2MLAAttention(nn.Module):
                     _can_fuse_indexer_wk_weights_proj(
                         config,
                         model_quant_config,
-                        f"{prefix}.indexer",
+                        [f"{prefix}.indexer"],
                     )
                     if use_indexer_wk_weights_proj_fusion is None
                     else use_indexer_wk_weights_proj_fusion
@@ -2174,10 +2147,21 @@ class DeepseekV2ForCausalLM(nn.Module):
         self.quant_config = quant_config
 
         model_prefix = maybe_prefix(prefix, "model")
-        use_indexer_wk_weights_proj_fusion = _can_fuse_model_indexer_wk_weights_proj(
+        attn_module_list_cfg = getattr(config, "attn_module_list_cfg", None)
+        indexer_prefixes = []
+        if isinstance(attn_module_list_cfg, (list, tuple)):
+            indexer_prefixes = [
+                f"{model_prefix}.layers.{layer_idx}.self_attn.indexer"
+                for layer_idx, layer_cfg in enumerate(attn_module_list_cfg)
+                if isinstance(layer_cfg, dict)
+                and layer_cfg.get("attn_index") is not None
+            ]
+        if not indexer_prefixes:
+            indexer_prefixes = [f"{model_prefix}.layers.0.self_attn.indexer"]
+        use_indexer_wk_weights_proj_fusion = _can_fuse_indexer_wk_weights_proj(
             config,
             quant_config,
-            model_prefix,
+            indexer_prefixes,
         )
         if hasattr(config, "q_lora_rank") and config.q_lora_rank is not None:
             self.packed_modules_mapping = {

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -964,12 +964,12 @@ class DeepseekV2MoE(nn.Module):
         return final_hidden_states
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        assert hidden_states.dim() == 2, (
-            f"Expected hidden_states to be 2D (seq_len, hidden_dim), but got {hidden_states.dim()}D, with shape {hidden_states.shape}"
-        )
-        assert hidden_states.shape[1] == self.experts.hidden_size, (
-            f"Hidden states dimension {hidden_states.shape[1]} does not match expected {self.experts.hidden_size}"
-        )
+        assert (
+            hidden_states.dim() == 2
+        ), f"Expected hidden_states to be 2D (seq_len, hidden_dim), but got {hidden_states.dim()}D, with shape {hidden_states.shape}"
+        assert (
+            hidden_states.shape[1] == self.experts.hidden_size
+        ), f"Hidden states dimension {hidden_states.shape[1]} does not match expected {self.experts.hidden_size}"
 
         if self._use_dual_stream:
             return torch.ops.aiter.maybe_dual_stream_forward(hidden_states, self.prefix)

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -130,6 +130,22 @@ _FP8_DTYPES = tuple(
 )
 
 
+def _can_fuse_indexer_wk_weights_proj(
+    config: PretrainedConfig,
+    quant_config: Optional[QuantizationConfig],
+    indexer_prefix: str,
+) -> bool:
+    if not hasattr(config, "index_topk"):
+        return False
+    if quant_config is None:
+        return True
+
+    wk_quant_config = quant_config.get_layer_quant_config(f"{indexer_prefix}.wk")
+    if wk_quant_config.quant_type == QuantType.No:
+        return True
+    return wk_quant_config.quant_dtype == dtypes.fp8
+
+
 def _fuse_rmsnorm_fp4_quant_fake(
     x1: torch.Tensor,
     x1_weight: torch.Tensor,
@@ -1291,6 +1307,7 @@ class Indexer(nn.Module):
         quant_config: Optional[QuantizationConfig],
         cache_config: str,
         topk_indices_buffer: Optional[torch.Tensor],
+        use_wk_weights_proj_fusion: bool = True,
         prefix: str = "",
     ):
         super().__init__()
@@ -1310,12 +1327,28 @@ class Indexer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.wq_b",
         )
-        self.wk_weights_proj = IndexerWkWeightsProjLinear(
-            hidden_size,
-            self.head_dim,
-            self.n_head,
-            prefix=f"{prefix}.wk_weights_proj",
-        )
+        self.use_wk_weights_proj_fusion = use_wk_weights_proj_fusion
+        if self.use_wk_weights_proj_fusion:
+            self.wk_weights_proj = IndexerWkWeightsProjLinear(
+                hidden_size,
+                self.head_dim,
+                self.n_head,
+                prefix=f"{prefix}.wk_weights_proj",
+            )
+        else:
+            self.wk = ReplicatedLinear(
+                hidden_size,
+                self.head_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.wk",
+            )
+            self.weights_proj = ReplicatedLinear(
+                hidden_size,
+                self.n_head,
+                quant_config=None,
+                prefix=f"{prefix}.weights_proj",
+            )
         self.k_norm = LayerNorm(self.head_dim, eps=1e-6)
         self.softmax_scale = self.head_dim**-0.5
         self._weights_scale = self.softmax_scale * self.n_head**-0.5
@@ -1355,11 +1388,15 @@ class Indexer(nn.Module):
         q = self.wq_b(qr, qr_scale)
         q = q.view(-1, self.n_head, self.head_dim)
 
-        k, weights = torch.split(
-            self.wk_weights_proj(hidden_states),
-            [self.head_dim, self.n_head],
-            dim=-1,
-        )
+        if self.use_wk_weights_proj_fusion:
+            k, weights = torch.split(
+                self.wk_weights_proj(hidden_states),
+                [self.head_dim, self.n_head],
+                dim=-1,
+            )
+        else:
+            k = self.wk(hidden_states)
+            weights = self.weights_proj(hidden_states)
         k = k.contiguous()
         weights = weights.contiguous()
 
@@ -1445,6 +1482,7 @@ class DeepseekV2MLAAttention(nn.Module):
 
         self.q_lora_rank = q_lora_rank
         self.kv_lora_rank = kv_lora_rank
+        model_quant_config = quant_config
 
         self.num_heads = num_heads
         tp_size = get_tensor_model_parallel_world_size()
@@ -1606,6 +1644,11 @@ class DeepseekV2MLAAttention(nn.Module):
                 base_quant_config,
                 cache_config,
                 topk_indices_buffer,
+                _can_fuse_indexer_wk_weights_proj(
+                    config,
+                    model_quant_config,
+                    f"{prefix}.indexer",
+                ),
                 f"{prefix}.indexer",
             )
         else:
@@ -2096,26 +2139,35 @@ class DeepseekV2ForCausalLM(nn.Module):
         self.config = config
         self.quant_config = quant_config
 
+        model_prefix = maybe_prefix(prefix, "model")
+        use_indexer_wk_weights_proj_fusion = _can_fuse_indexer_wk_weights_proj(
+            config,
+            quant_config,
+            f"{model_prefix}.layers.0.self_attn.indexer",
+        )
         if hasattr(config, "q_lora_rank") and config.q_lora_rank is not None:
             self.packed_modules_mapping = {
                 "q_a_proj": ("fused_qkv_a_proj", 0),
                 "kv_a_proj_with_mqa": ("fused_qkv_a_proj", 1),
                 "gate_proj": ("gate_up_proj", 0),
                 "up_proj": ("gate_up_proj", 1),
-                "indexer.wk": ("indexer.wk_weights_proj", 0),
-                "indexer.weights_proj": ("indexer.wk_weights_proj", 1),
             }
         else:
             self.packed_modules_mapping = {
                 "gate_proj": ("gate_up_proj", 0),
                 "up_proj": ("gate_up_proj", 1),
-                "indexer.wk": ("indexer.wk_weights_proj", 0),
-                "indexer.weights_proj": ("indexer.wk_weights_proj", 1),
             }
+        if use_indexer_wk_weights_proj_fusion:
+            self.packed_modules_mapping.update(
+                {
+                    "indexer.wk": ("indexer.wk_weights_proj", 0),
+                    "indexer.weights_proj": ("indexer.wk_weights_proj", 1),
+                }
+            )
 
         self.model = DeepseekV2Model(
             atom_config=atom_config,
-            prefix=maybe_prefix(prefix, "model"),
+            prefix=model_prefix,
             layer_type=layer_type,
         )
         if get_pp_group().is_last_rank:

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -34,6 +34,7 @@ from aiter import (
     fused_qk_rmsnorm,
     gemm_a8w8_blockscale_bpreshuffle,
     get_hip_quant,
+    indexer_k_quant_and_cache,
     indexer_qk_rope_quant_and_cache,
     top_k_per_row_decode,
     top_k_per_row_prefill,
@@ -116,6 +117,9 @@ ENABLE_DS_QKNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_QKNORM_QUANT_FUSION
 ENABLE_DS_QKNORM_FUSION = envs.ATOM_ENABLE_DS_QKNORM_FUSION
 ENABLE_ALLREDUCE_RMSNORM_FUSION = envs.ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION
 ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION
+ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION = (
+    envs.ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
+)
 _FP8_DTYPES = tuple(
     dtype
     for dtype in (
@@ -974,6 +978,7 @@ def sparse_attn_indexer(
     sin_cache: torch.Tensor,
     weights_scale: float,
     is_neox_style: bool,
+    use_qk_rope_cache_fusion: bool,
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
     forward_context = get_forward_context()
@@ -990,30 +995,42 @@ def sparse_attn_indexer(
     )
     runner_block_size = get_current_atom_config().kv_cache_block_size
     kv_cache = kv_cache.view(-1, runner_block_size, kv_cache.shape[-1])
-    q = q_fp8
-    q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
-    weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-    indexer_qk_rope_quant_and_cache(
-        q,
-        q_fp8,
-        weights,
-        weights_out,
-        k,
-        kv_cache,
-        slot_mapping,
-        k_norm_weight,
-        k_norm_bias,
-        positions,
-        cos_cache,
-        sin_cache,
-        k_norm_eps,
-        quant_block_size,
-        scale_fmt,
-        weights_scale,
-        preshuffle=True,
-        is_neox=is_neox_style,
-    )
-    weights = weights_out
+    if use_qk_rope_cache_fusion:
+        q = q_fp8
+        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+        weights_out = torch.empty(
+            weights.shape, device=weights.device, dtype=torch.float32
+        )
+        indexer_qk_rope_quant_and_cache(
+            q,
+            q_fp8,
+            weights,
+            weights_out,
+            k,
+            kv_cache,
+            slot_mapping,
+            k_norm_weight,
+            k_norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            k_norm_eps,
+            quant_block_size,
+            scale_fmt,
+            weights_scale,
+            preshuffle=True,
+            is_neox=is_neox_style,
+        )
+        weights = weights_out
+    else:
+        indexer_k_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            quant_block_size,
+            scale_fmt,
+            preshuffle=True,
+        )
     if context.is_prefill:
         if attn_metadata.max_seqlen_k <= topk_indices_buffer.shape[1]:
             return weights
@@ -1136,6 +1153,7 @@ def sparse_attn_indexer_fake(
     sin_cache: torch.Tensor,
     weights_scale: float,
     is_neox_style: bool,
+    use_qk_rope_cache_fusion: bool,
 ) -> torch.Tensor:
     # profile run
     # NOTE(Chen): create the max possible flattened_kv. So that
@@ -1303,13 +1321,13 @@ class Indexer(nn.Module):
         self._weights_scale = self.softmax_scale * self.n_head**-0.5
 
         self.scale_fmt = "ue8m0"
+        self.quant_func = get_hip_quant(QuantType.per_1x128)
         self.quant_block_size = 128  # TODO: get from config
-        if self.head_dim != self.quant_block_size or self.rope_dim != self.head_dim // 2:
-            raise ValueError(
-                "DeepSeek-V3.2 fused indexer requires "
-                f"head_dim={self.quant_block_size} and rope_dim={self.head_dim // 2}, "
-                f"got head_dim={self.head_dim}, rope_dim={self.rope_dim}"
-            )
+        self.use_qk_rope_cache_fusion = (
+            ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
+            and self.head_dim == self.quant_block_size
+            and self.rope_dim == self.head_dim // 2
+        )
         self.topk_indices_buffer = topk_indices_buffer
 
         # TODO (zyongye) change dim to fp8 later to (self.head_dim + 4)
@@ -1342,12 +1360,36 @@ class Indexer(nn.Module):
             [self.head_dim, self.n_head],
             dim=-1,
         )
+        k = k.contiguous()
+        weights = weights.contiguous()
+
+        if not self.use_qk_rope_cache_fusion:
+            q_pe, _ = torch.split(
+                q, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
+            )
+            k = self.k_norm(k)
+            k_pe, _ = torch.split(
+                k, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
+            )
+            q_pe, k_pe = rotary_emb(positions, q_pe, k_pe)
+            q[..., : self.rope_dim] = q_pe
+            k[..., : self.rope_dim] = k_pe
+
+            q = q.view(-1, self.head_dim)
+            q_fp8, q_scale = self.quant_func(q, quant_dtype=dtypes.fp8)
+            q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
+            q_scale = q_scale.view(-1, self.n_head, 1)
+            weights = (weights.unsqueeze(-1) * q_scale * self._weights_scale).squeeze(
+                -1
+            )
+        else:
+            q_fp8 = q
 
         return self.sparse_attn_indexer_impl(
             hidden_states,
             self.k_cache.prefix,
             self.k_cache.kv_cache[0],
-            q,
+            q_fp8,
             k,
             weights,
             self.quant_block_size,
@@ -1365,6 +1407,7 @@ class Indexer(nn.Module):
             rotary_emb.sin_cache,
             self._weights_scale,
             rotary_emb.is_neox_style,
+            self.use_qk_rope_cache_fusion,
         )
 
 

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -135,8 +135,6 @@ def _can_fuse_indexer_wk_weights_proj(
     quant_config: Optional[QuantizationConfig],
     indexer_prefixes: list[str],
 ) -> bool:
-    if not ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION:
-        return False
     if not hasattr(config, "index_topk"):
         return False
     if quant_config is None:

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -130,12 +130,23 @@ _FP8_DTYPES = tuple(
 )
 
 
+def _supports_fused_indexer_kernel_config(config: PretrainedConfig) -> bool:
+    if not hasattr(config, "index_topk"):
+        return False
+    if getattr(config, "model_type", None) == "glm_moe_dsa":
+        return False
+    return (
+        getattr(config, "index_head_dim", None) == 128
+        and getattr(config, "qk_rope_head_dim", None) == 64
+    )
+
+
 def _can_fuse_indexer_wk_weights_proj(
     config: PretrainedConfig,
     quant_config: Optional[QuantizationConfig],
     indexer_prefixes: list[str],
 ) -> bool:
-    if not hasattr(config, "index_topk"):
+    if not _supports_fused_indexer_kernel_config(config):
         return False
     if quant_config is None:
         return True
@@ -1365,6 +1376,7 @@ class Indexer(nn.Module):
         self.quant_block_size = 128  # TODO: get from config
         self.use_qk_rope_cache_fusion = (
             ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
+            and _supports_fused_indexer_kernel_config(config)
             and self.head_dim == self.quant_block_size
             and self.rope_dim == self.head_dim // 2
         )

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -135,6 +135,8 @@ def _can_fuse_indexer_wk_weights_proj(
     quant_config: Optional[QuantizationConfig],
     indexer_prefixes: list[str],
 ) -> bool:
+    if not ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION:
+        return False
     if not hasattr(config, "index_topk"):
         return False
     if quant_config is None:
@@ -1296,6 +1298,10 @@ class IndexerWkWeightsProjLinear(MergedReplicatedLinear):
                 "Incomplete FP8 indexer.wk load: both weight and weight_scale "
                 "are required before building wk_weights_proj."
             )
+        if not self._wk_loaded:
+            raise RuntimeError(
+                "Missing indexer.wk load before building wk_weights_proj."
+            )
         super().process_weights_after_loading()
 
 
@@ -1412,8 +1418,6 @@ class Indexer(nn.Module):
                 k, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
             )
             q_pe, k_pe = rotary_emb(positions, q_pe, k_pe)
-            q[..., : self.rope_dim] = q_pe
-            k[..., : self.rope_dim] = k_pe
 
             q = q.view(-1, self.head_dim)
             q_fp8, q_scale = self.quant_func(q, quant_dtype=dtypes.fp8)
@@ -1422,14 +1426,15 @@ class Indexer(nn.Module):
             weights = (weights.unsqueeze(-1) * q_scale * self._weights_scale).squeeze(
                 -1
             )
+            q_input = q_fp8
         else:
-            q_fp8 = q
+            q_input = q
 
         return self.sparse_attn_indexer_impl(
             hidden_states,
             self.k_cache.prefix,
             self.k_cache.kv_cache[0],
-            q_fp8,
+            q_input,
             k,
             weights,
             self.quant_block_size,

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -25,8 +25,6 @@ from aiter import (
     fused_qk_rope_concat_and_cache_mla,
     cp_gather_indexer_k_quant_cache,
     dtypes,
-    indexer_k_quant_and_cache,
-    indexer_k_norm_rope_quant_and_cache,
     indexer_qk_rope_quant_and_cache,
     top_k_per_row_decode,
     top_k_per_row_prefill,
@@ -570,8 +568,6 @@ def sparse_attn_indexer_plugin_mode(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor,
-    fuse_qk_rope_quant_cache: bool,
-    fuse_k_norm_rope_cache: bool,
     k_norm_weight: torch.Tensor,
     k_norm_bias: torch.Tensor,
     k_norm_eps: float,
@@ -596,18 +592,12 @@ def sparse_attn_indexer_plugin_mode(
     # During profile/dummy run the metadata dict may not contain
     # our layer or may be None.
     if attn_metadata_dict is None:
-        if fuse_qk_rope_quant_cache:
-            return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-        return weights
+        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
     if k_cache_prefix not in attn_metadata_dict:
-        if fuse_qk_rope_quant_cache:
-            return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-        return weights
+        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
     layer_meta = attn_metadata_dict[k_cache_prefix]
     if layer_meta is None:
-        if fuse_qk_rope_quant_cache:
-            return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-        return weights
+        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
 
     # In plugin mode, plugin_metadata is vllmDeepseekV32IndexerMetadata from
     # AiterMLASparseIndexerMetadataBuilder.
@@ -620,56 +610,30 @@ def sparse_attn_indexer_plugin_mode(
     kv_block_size = kv_cache.shape[1]
     preshuffle_cache = kv_block_size != 1
 
-    if fuse_qk_rope_quant_cache:
-        q = q_fp8
-        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
-        weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-        indexer_qk_rope_quant_and_cache(
-            q,
-            q_fp8,
-            weights,
-            weights_out,
-            k,
-            kv_cache,
-            slot_mapping,
-            k_norm_weight,
-            k_norm_bias,
-            positions,
-            cos_cache,
-            sin_cache,
-            k_norm_eps,
-            quant_block_size,
-            scale_fmt,
-            weights_scale,
-            preshuffle=preshuffle_cache,
-            is_neox=is_neox_style,
-        )
-        weights = weights_out
-    elif fuse_k_norm_rope_cache:
-        indexer_k_norm_rope_quant_and_cache(
-            k,
-            kv_cache,
-            slot_mapping,
-            k_norm_weight,
-            k_norm_bias,
-            positions,
-            cos_cache,
-            sin_cache,
-            k_norm_eps,
-            quant_block_size,
-            scale_fmt,
-            preshuffle=preshuffle_cache,
-            is_neox=is_neox_style,
-        )
-    else:
-        indexer_k_quant_and_cache(
-            k,
-            kv_cache,
-            slot_mapping,
-            quant_block_size,
-            scale_fmt,
-            preshuffle=preshuffle_cache,
-        )
+    q = q_fp8
+    q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+    weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+    indexer_qk_rope_quant_and_cache(
+        q,
+        q_fp8,
+        weights,
+        weights_out,
+        k,
+        kv_cache,
+        slot_mapping,
+        k_norm_weight,
+        k_norm_bias,
+        positions,
+        cos_cache,
+        sin_cache,
+        k_norm_eps,
+        quant_block_size,
+        scale_fmt,
+        weights_scale,
+        preshuffle=preshuffle_cache,
+        is_neox=is_neox_style,
+    )
+    weights = weights_out
 
     topk_indices_buffer[: hidden_states.shape[0]] = -1
     # topk_indices_buffer[: num_actual_tokens] = -1
@@ -808,8 +772,6 @@ def sparse_attn_indexer_fake(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor,
-    fuse_qk_rope_quant_cache: bool,
-    fuse_k_norm_rope_cache: bool,
     k_norm_weight: torch.Tensor,
     k_norm_bias: torch.Tensor,
     k_norm_eps: float,
@@ -827,9 +789,7 @@ def sparse_attn_indexer_fake(
     )
     _k_fp8 = _flattened_kv[..., :head_dim].view(torch.float8_e4m3fn).contiguous()
     _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
-    if fuse_qk_rope_quant_cache:
-        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-    return weights
+    return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
 
 
 direct_register_custom_op(

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -558,7 +558,7 @@ def sparse_attn_indexer_plugin_mode(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
     kv_cache: torch.Tensor,
-    q_fp8: torch.Tensor,
+    q_input: torch.Tensor,
     k: torch.Tensor,
     weights: torch.Tensor,
     quant_block_size: int,
@@ -593,12 +593,12 @@ def sparse_attn_indexer_plugin_mode(
     # During profile/dummy run the metadata dict may not contain
     # our layer or may be None.
     if attn_metadata_dict is None:
-        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+        return torch.zeros_like(weights, dtype=torch.float32)
     if k_cache_prefix not in attn_metadata_dict:
-        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+        return torch.zeros_like(weights, dtype=torch.float32)
     layer_meta = attn_metadata_dict[k_cache_prefix]
     if layer_meta is None:
-        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+        return torch.zeros_like(weights, dtype=torch.float32)
 
     # In plugin mode, plugin_metadata is vllmDeepseekV32IndexerMetadata from
     # AiterMLASparseIndexerMetadataBuilder.
@@ -612,13 +612,13 @@ def sparse_attn_indexer_plugin_mode(
     preshuffle_cache = kv_block_size != 1
 
     if use_qk_rope_cache_fusion:
-        q = q_fp8
-        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+        q_bf16 = q_input
+        q_fp8 = torch.empty_like(q_bf16, dtype=dtypes.fp8)
         weights_out = torch.empty(
             weights.shape, device=weights.device, dtype=torch.float32
         )
         indexer_qk_rope_quant_and_cache(
-            q,
+            q_bf16,
             q_fp8,
             weights,
             weights_out,
@@ -639,6 +639,7 @@ def sparse_attn_indexer_plugin_mode(
         )
         weights = weights_out
     else:
+        q_fp8 = q_input
         indexer_k_quant_and_cache(
             k,
             kv_cache,
@@ -775,7 +776,7 @@ def sparse_attn_indexer_fake(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
     kv_cache: torch.Tensor,
-    q_fp8: torch.Tensor,
+    q_input: torch.Tensor,
     k: torch.Tensor,
     weights: torch.Tensor,
     quant_block_size: int,

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -28,7 +28,6 @@ from aiter import (
     indexer_k_quant_and_cache,
     indexer_qk_rope_quant_and_cache,
     top_k_per_row_decode,
-    top_k_per_row_prefill,
 )
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -25,6 +25,7 @@ from aiter import (
     fused_qk_rope_concat_and_cache_mla,
     cp_gather_indexer_k_quant_cache,
     dtypes,
+    indexer_k_quant_and_cache,
     indexer_qk_rope_quant_and_cache,
     top_k_per_row_decode,
     top_k_per_row_prefill,
@@ -576,6 +577,7 @@ def sparse_attn_indexer_plugin_mode(
     sin_cache: torch.Tensor,
     weights_scale: float,
     is_neox_style: bool,
+    use_qk_rope_cache_fusion: bool,
 ) -> torch.Tensor:
     try:
         from vllm.forward_context import (
@@ -610,30 +612,42 @@ def sparse_attn_indexer_plugin_mode(
     kv_block_size = kv_cache.shape[1]
     preshuffle_cache = kv_block_size != 1
 
-    q = q_fp8
-    q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
-    weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
-    indexer_qk_rope_quant_and_cache(
-        q,
-        q_fp8,
-        weights,
-        weights_out,
-        k,
-        kv_cache,
-        slot_mapping,
-        k_norm_weight,
-        k_norm_bias,
-        positions,
-        cos_cache,
-        sin_cache,
-        k_norm_eps,
-        quant_block_size,
-        scale_fmt,
-        weights_scale,
-        preshuffle=preshuffle_cache,
-        is_neox=is_neox_style,
-    )
-    weights = weights_out
+    if use_qk_rope_cache_fusion:
+        q = q_fp8
+        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+        weights_out = torch.empty(
+            weights.shape, device=weights.device, dtype=torch.float32
+        )
+        indexer_qk_rope_quant_and_cache(
+            q,
+            q_fp8,
+            weights,
+            weights_out,
+            k,
+            kv_cache,
+            slot_mapping,
+            k_norm_weight,
+            k_norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            k_norm_eps,
+            quant_block_size,
+            scale_fmt,
+            weights_scale,
+            preshuffle=preshuffle_cache,
+            is_neox=is_neox_style,
+        )
+        weights = weights_out
+    else:
+        indexer_k_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            quant_block_size,
+            scale_fmt,
+            preshuffle=preshuffle_cache,
+        )
 
     topk_indices_buffer[: hidden_states.shape[0]] = -1
     # topk_indices_buffer[: num_actual_tokens] = -1
@@ -780,6 +794,7 @@ def sparse_attn_indexer_fake(
     sin_cache: torch.Tensor,
     weights_scale: float,
     is_neox_style: bool,
+    use_qk_rope_cache_fusion: bool,
 ) -> torch.Tensor:
     # profile run
     # NOTE(Chen): create the max possible flattened_kv. So that

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -26,6 +26,8 @@ from aiter import (
     cp_gather_indexer_k_quant_cache,
     dtypes,
     indexer_k_quant_and_cache,
+    indexer_k_norm_rope_quant_and_cache,
+    indexer_qk_rope_quant_and_cache,
     top_k_per_row_decode,
     top_k_per_row_prefill,
 )
@@ -568,6 +570,15 @@ def sparse_attn_indexer_plugin_mode(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor,
+    fuse_qk_rope_quant_cache: bool,
+    fuse_k_norm_rope_cache: bool,
+    k_norm_weight: torch.Tensor,
+    k_norm_bias: torch.Tensor,
+    k_norm_eps: float,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    weights_scale: float,
 ) -> torch.Tensor:
     try:
         from vllm.forward_context import (
@@ -584,11 +595,17 @@ def sparse_attn_indexer_plugin_mode(
     # During profile/dummy run the metadata dict may not contain
     # our layer or may be None.
     if attn_metadata_dict is None:
+        if fuse_qk_rope_quant_cache:
+            return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
         return weights
     if k_cache_prefix not in attn_metadata_dict:
+        if fuse_qk_rope_quant_cache:
+            return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
         return weights
     layer_meta = attn_metadata_dict[k_cache_prefix]
     if layer_meta is None:
+        if fuse_qk_rope_quant_cache:
+            return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
         return weights
 
     # In plugin mode, plugin_metadata is vllmDeepseekV32IndexerMetadata from
@@ -602,14 +619,56 @@ def sparse_attn_indexer_plugin_mode(
     kv_block_size = kv_cache.shape[1]
     preshuffle_cache = kv_block_size != 1
 
-    indexer_k_quant_and_cache(
-        k,
-        kv_cache,
-        slot_mapping,
-        quant_block_size,
-        scale_fmt,
-        preshuffle=preshuffle_cache,
-    )
+    if fuse_qk_rope_quant_cache:
+        q = q_fp8
+        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+        weights_out = torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
+        indexer_qk_rope_quant_and_cache(
+            q,
+            q_fp8,
+            weights,
+            weights_out,
+            k,
+            kv_cache,
+            slot_mapping,
+            k_norm_weight,
+            k_norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            k_norm_eps,
+            quant_block_size,
+            scale_fmt,
+            weights_scale,
+            preshuffle=preshuffle_cache,
+            is_neox=True,
+        )
+        weights = weights_out
+    elif fuse_k_norm_rope_cache:
+        indexer_k_norm_rope_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            k_norm_weight,
+            k_norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            k_norm_eps,
+            quant_block_size,
+            scale_fmt,
+            preshuffle=preshuffle_cache,
+            is_neox=True,
+        )
+    else:
+        indexer_k_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            quant_block_size,
+            scale_fmt,
+            preshuffle=preshuffle_cache,
+        )
 
     topk_indices_buffer[: hidden_states.shape[0]] = -1
     # topk_indices_buffer[: num_actual_tokens] = -1
@@ -748,6 +807,15 @@ def sparse_attn_indexer_fake(
     max_model_len: int,
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor,
+    fuse_qk_rope_quant_cache: bool,
+    fuse_k_norm_rope_cache: bool,
+    k_norm_weight: torch.Tensor,
+    k_norm_bias: torch.Tensor,
+    k_norm_eps: float,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    weights_scale: float,
 ) -> torch.Tensor:
     # profile run
     # NOTE(Chen): create the max possible flattened_kv. So that
@@ -757,6 +825,8 @@ def sparse_attn_indexer_fake(
     )
     _k_fp8 = _flattened_kv[..., :head_dim].view(torch.float8_e4m3fn).contiguous()
     _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
+    if fuse_qk_rope_quant_cache:
+        return torch.empty(weights.shape, device=weights.device, dtype=torch.float32)
     return weights
 
 

--- a/atom/plugin/attention_mla_sparse.py
+++ b/atom/plugin/attention_mla_sparse.py
@@ -579,6 +579,7 @@ def sparse_attn_indexer_plugin_mode(
     cos_cache: torch.Tensor,
     sin_cache: torch.Tensor,
     weights_scale: float,
+    is_neox_style: bool,
 ) -> torch.Tensor:
     try:
         from vllm.forward_context import (
@@ -641,7 +642,7 @@ def sparse_attn_indexer_plugin_mode(
             scale_fmt,
             weights_scale,
             preshuffle=preshuffle_cache,
-            is_neox=True,
+            is_neox=is_neox_style,
         )
         weights = weights_out
     elif fuse_k_norm_rope_cache:
@@ -658,7 +659,7 @@ def sparse_attn_indexer_plugin_mode(
             quant_block_size,
             scale_fmt,
             preshuffle=preshuffle_cache,
-            is_neox=True,
+            is_neox=is_neox_style,
         )
     else:
         indexer_k_quant_and_cache(
@@ -816,6 +817,7 @@ def sparse_attn_indexer_fake(
     cos_cache: torch.Tensor,
     sin_cache: torch.Tensor,
     weights_scale: float,
+    is_neox_style: bool,
 ) -> torch.Tensor:
     # profile run
     # NOTE(Chen): create the max possible flattened_kv. So that

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -50,15 +50,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_DS_QKNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_DS_QKNORM_FUSION", "1") == "1"
     ),
-    "ATOM_ENABLE_DS_INDEXER_Q_QUANT_FUSION": lambda: (
-        os.getenv("ATOM_ENABLE_DS_INDEXER_Q_QUANT_FUSION", "1") == "1"
-    ),
-    "ATOM_ENABLE_DS_INDEXER_K_CACHE_FUSION": lambda: (
-        os.getenv("ATOM_ENABLE_DS_INDEXER_K_CACHE_FUSION", "1") == "1"
-    ),
-    "ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION": lambda: (
-        os.getenv("ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION", "1") == "1"
-    ),
     "ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION", "1") == "1"
     ),

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -76,8 +76,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Use a thread pool for weight loading instead of main-process sequential I/O.
     # Set to 0 to disable if the thread pool causes hangs (e.g. on gfx1250).
-    "ATOM_LOADER_USE_THREADPOOL": lambda: os.getenv("ATOM_LOADER_USE_THREADPOOL", "1")
-    == "1",
+    "ATOM_LOADER_USE_THREADPOOL": lambda: (
+        os.getenv("ATOM_LOADER_USE_THREADPOOL", "1") == "1"
+    ),
     # --- Attention Backend ---
     # Use unified_attention (flash-style) for MHA paged/prefill attention instead
     # of pa_decode_gluon. Set to 1 to enable the unified_attention path.
@@ -111,10 +112,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_REQUIRES_GRAD": lambda: os.getenv("ATOM_REQUIRES_GRAD", "0") == "1",
     # --- Bpreshuffle for weight ---
     # Preshuffle weight.  Default "1" (enabled)
-    "ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE": lambda: os.getenv(
-        "ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE", "1"
-    )
-    == "1",
+    "ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE": lambda: (
+        os.getenv("ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE", "1") == "1"
+    ),
     # --- V4 Attention Backend Refactor (PR-A: kill .item(), unlock CUDAGraph) ---
     # `legacy` (default) keeps the per-seq Python dispatch loop with .item()
     # syncs in deepseek_v4.py. `new` routes through V4AttentionBackend with

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -50,6 +50,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_DS_QKNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_DS_QKNORM_FUSION", "1") == "1"
     ),
+    "ATOM_ENABLE_DS_INDEXER_Q_QUANT_FUSION": lambda: (
+        os.getenv("ATOM_ENABLE_DS_INDEXER_Q_QUANT_FUSION", "1") == "1"
+    ),
+    "ATOM_ENABLE_DS_INDEXER_K_CACHE_FUSION": lambda: (
+        os.getenv("ATOM_ENABLE_DS_INDEXER_K_CACHE_FUSION", "1") == "1"
+    ),
+    "ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION": lambda: (
+        os.getenv("ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION", "1") == "1"
+    ),
     "ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION", "1") == "1"
     ),

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -50,6 +50,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_DS_QKNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_DS_QKNORM_FUSION", "1") == "1"
     ),
+    "ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION": lambda: (
+        os.getenv("ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION", "1") == "1"
+    ),
     "ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION", "1") == "1"
     ),


### PR DESCRIPTION
## Summary
- Fuse DeepSeek-V3.2 indexer `wk` and `weights_proj` when the checkpoint layout is compatible, including FP8 block-scale `wk` load support.
- Add the fused indexer Q RoPE + Q quant + weight scaling + K norm/RoPE/cache path, guarded by `ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION` and enabled by default.
- Preserve fallback behavior when the env is disabled, when the fused kernel shape constraints are not met, or when `indexer.wk` uses an unsupported weight dtype such as FP4/MXFP4.
- Route sparse indexer plugin mode through the same fused/fallback selection.

## Performance Validation
Environment:
- Model: `/shared/data/amd_int/models/DeepSeek-V3.2`
- Hardware: MI355, TP=4
- Benchmark: ISL=1000, OSL=100, `NUM=10*CON`, warmups=`4*CON`
- Baseline: same ATOM/AITER branch with `ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION=0`
- Fused: default path with `ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION=1`
- AITER JIT cache was cleared before validation
- Logs: `/workdir/my_test/results/indexer_refusion_repro_20260514_120947`

| CON | Baseline output tok/s | Fused output tok/s | Output delta | Baseline total tok/s | Fused total tok/s | Total speedup | Total delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 191.42 | 202.15 | +5.6% | 2105.61 | 2223.67 | 1.056x | +5.6% |
| 8 | 324.49 | 342.91 | +5.7% | 3569.41 | 3772.00 | 1.057x | +5.7% |
| 16 | 465.05 | 481.38 | +3.5% | 5115.58 | 5295.15 | 1.035x | +3.5% |


## Accuracy Validation
`gsm8k`, 3-shot, fused path enabled:

| Filter | exact_match | Stderr |
| --- | ---: | ---: |
| flexible-extract | 0.9462 | 0.0062 |
| strict-match | 0.9469 | 0.0062 |

No material accuracy regression was observed in this run.

## Test plan
- `git diff --check` passed for ATOM changes.
- `python3 -m py_compile atom/models/deepseek_v2.py atom/plugin/attention_mla_sparse.py atom/utils/envs.py` passed.
- AITER `indexer_qk_rope_quant_and_cache` JIT compiled and ran during local validation.
- Re-ran performance validation for CON=4/8/16 with the env-controlled fallback and fused paths.
- Re-ran `gsm8k` 3-shot accuracy with the fused path enabled.

## Notes
- Companion AITER kernel PR: https://github.com/ROCm/aiter/pull/3185

Made with [Cursor](https://cursor.com)