### PR TITLE
Add benchmark commit override input

### DIFF
--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -10,6 +10,14 @@ on:
     - cron: '0 17 * * *'
   workflow_dispatch:
     inputs:
+      atom_branch:
+        description: "ATOM branch to checkout; leave empty to use the workflow ref"
+        type: string
+        default: ""
+      atom_commit:
+        description: "ATOM commit SHA to checkout; overrides atom_branch when set"
+        type: string
+        default: ""
       deepseek-r1-0528:
         description: "Benchmark DeepSeek-R1-0528 (+ MTP3)"
         type: boolean
@@ -87,6 +95,8 @@ jobs:
       matrix_json: ${{ steps.parse-param-lists.outputs.matrix_json }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
 
       - name: Parse parameter lists
         id: parse-param-lists
@@ -118,6 +128,8 @@ jobs:
       models_json: ${{ steps.load.outputs.models_json }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
       - id: load
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -182,6 +194,8 @@ jobs:
 
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
 
       - name: Start CI container
         run: |
@@ -345,6 +359,8 @@ jobs:
     steps:
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
 
       - name: Download all benchmark results
         uses: actions/download-artifact@v8
@@ -493,6 +509,8 @@ jobs:
       has_matrix: ${{ steps.gen.outputs.has_matrix }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -548,6 +566,8 @@ jobs:
 
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
 
       - name: Docker Login
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -740,6 +760,8 @@ jobs:
     steps:
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
 
       - name: Download regression traces
         if: needs.collect-regression-traces.result == 'success'

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -10,14 +10,6 @@ on:
     - cron: '0 17 * * *'
   workflow_dispatch:
     inputs:
-      atom_branch:
-        description: "ATOM branch to checkout; leave empty to use the workflow ref"
-        type: string
-        default: ""
-      atom_commit:
-        description: "ATOM commit SHA to checkout; overrides atom_branch when set"
-        type: string
-        default: ""
       deepseek-r1-0528:
         description: "Benchmark DeepSeek-R1-0528 (+ MTP3)"
         type: boolean
@@ -86,6 +78,10 @@ on:
           Example (multiple sets): 1024,1024,128,0.8;2048,1024,256,0.7"
         type: string
         default: "1024,1024,128,0.8"
+      atom_commit:
+        description: "ATOM commit SHA to checkout; leave empty to use the workflow ref"
+        type: string
+        default: ""
 
 jobs:
   parse-param-lists:
@@ -96,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
+          ref: ${{ inputs.atom_commit || github.ref }}
 
       - name: Parse parameter lists
         id: parse-param-lists
@@ -129,7 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
+          ref: ${{ inputs.atom_commit || github.ref }}
       - id: load
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -195,7 +191,7 @@ jobs:
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
+          ref: ${{ inputs.atom_commit || github.ref }}
 
       - name: Start CI container
         run: |
@@ -360,7 +356,7 @@ jobs:
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
+          ref: ${{ inputs.atom_commit || github.ref }}
 
       - name: Download all benchmark results
         uses: actions/download-artifact@v8
@@ -510,7 +506,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
+          ref: ${{ inputs.atom_commit || github.ref }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -567,7 +563,7 @@ jobs:
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
+          ref: ${{ inputs.atom_commit || github.ref }}
 
       - name: Docker Login
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -761,7 +757,7 @@ jobs:
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.atom_commit || inputs.atom_branch || github.ref }}
+          ref: ${{ inputs.atom_commit || github.ref }}
 
       - name: Download regression traces
         if: needs.collect-regression-traces.result == 'success'


### PR DESCRIPTION
## Summary
- Add an optional `atom_commit` input to the ATOM benchmark workflow for manual runs.
- Use the provided commit SHA for all repository checkout steps, falling back to the workflow ref when it is empty.

## Test plan
- Parsed `.github/workflows/atom-benchmark.yaml` locally with PyYAML.
- Not run: full benchmark workflow, since it requires GPU runners and manual model selection.


Made with [Cursor](https://cursor.com)