### PR TITLE
Fix vLLM plugin kv cache dtype auto parsing

### DIFF
--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -22,6 +22,17 @@ _CP_TOKENS_PER_ITER_ROCM = 32 * 1024
 disable_vllm_plugin_attention = envs.ATOM_DISABLE_VLLM_PLUGIN_ATTENTION
 
 
+def _get_aiter_kv_cache_dtype(config) -> torch.dtype:
+    kv_cache_dtype = config.cache_config.cache_dtype
+    if kv_cache_dtype == "auto":
+        kv_cache_dtype = "bf16"
+    elif kv_cache_dtype == "bfloat16":
+        kv_cache_dtype = "bf16"
+    elif kv_cache_dtype == "float16":
+        kv_cache_dtype = "fp16"
+    return dtypes.d_dtypes[kv_cache_dtype]
+
+
 @dataclass
 class AiterFlashAttentionPhaseMetadata:
     max_query_len: int
@@ -1299,7 +1310,7 @@ def create_mla_attn_metadata_builder_init_method(base_class):
             1,
             self.padded_num_attention_heads,
             torch.bfloat16,
-            dtypes.d_dtypes[config.cache_config.cache_dtype],
+            _get_aiter_kv_cache_dtype(config),
             is_sparse=False,  # TODO: support sparse
             fast_mode=True,
         )


### PR DESCRIPTION
## Summary
- Normalize vLLM `cache_config.cache_dtype` aliases before passing them to AITER metadata setup.
- Treat the default `auto` cache dtype as `bf16` so DeepSeek-V3.2 vLLM server startup does not fail dtype parsing when `--kv-cache-dtype` is omitted.

## Test plan
- `python3 -m py_compile atom/plugin/attention.py`

Made with [Cursor](https://cursor.com)