### PR TITLE
Add Responses API streaming support

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -37,7 +37,9 @@ from .protocol import (
     CompletionRequest,
     ModelCard,
     ModelList,
+    ResponsesRequest,
 )
+from .serving_responses import build_responses_response, stream_responses_response
 from .serving_chat import (
     build_chat_response,
     build_chat_response_multi,
@@ -826,6 +828,83 @@ async def completions(request: CompletionRequest):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Error in completions: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/v1/responses")
+async def responses(request: ResponsesRequest):
+    """Handle Responses API requests.
+
+    Implements a compatibility subset by mapping Responses input to ATOM's
+    existing chat-template generation path and wrapping streaming chunks in
+    Responses API SSE events.
+    """
+    global engine, tokenizer, model_name
+
+    validate_model(request.model)
+
+    try:
+        messages = request.to_chat_messages()
+
+        merged_kwargs = dict(default_chat_template_kwargs)
+        if request.chat_template_kwargs:
+            merged_kwargs.update(request.chat_template_kwargs)
+
+        prompt = apply_chat_template(
+            tokenizer,
+            custom_message_encoder,
+            [msg.to_template_dict() for msg in messages],
+            tools=request.tools,
+            **merged_kwargs,
+        )
+
+        sampling_params = _build_sampling_params(
+            temperature=request.temperature,
+            max_tokens=request.get_max_tokens(),
+            stop_strings=request.stop,
+            ignore_eos=request.ignore_eos,
+            top_k=request.top_k,
+            top_p=request.top_p,
+            n=1,
+        )
+
+        request_id = f"resp-{uuid.uuid4().hex}"
+        _log_request_event("request", request_id, request.model_dump())
+
+        if request.stream:
+            seq_id, stream_queue = await setup_streaming_request(
+                prompt, sampling_params, request_id
+            )
+            gen = stream_responses_response(
+                request_id,
+                model_name,
+                prompt,
+                stream_queue,
+                seq_id,
+                tokenizer,
+                cleanup_streaming_request,
+            )
+            return StreamingResponse(
+                _logged_stream(gen, request_id),
+                media_type="text/event-stream",
+            )
+
+        final_output = None
+        async for output in generate_async(prompt, sampling_params, request_id):
+            final_output = output
+        if final_output is None:
+            raise RuntimeError("No output generated")
+        resp = build_responses_response(
+            request_id, model_name, final_output["text"], final_output
+        )
+        _log_request_event("response", request_id, resp.model_dump())
+        return resp
+
+    except ValueError as e:
+        logger.error(f"Validation error in responses: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error in responses: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -72,6 +72,7 @@ _stream_queues: Dict[str, asyncio.Queue] = {}
 _seq_id_to_request_id: Dict[int, str] = {}
 _stream_loops: Dict[str, AbstractEventLoop] = {}
 _request_start_times: Dict[str, float] = {}
+_stream_decode_states: Dict[Tuple[str, int], Dict[str, Any]] = {}
 _request_logger: Optional[logging.Logger] = None
 
 
@@ -159,16 +160,64 @@ def _coerce_n(requested_n: Optional[int], temperature: Optional[float]) -> int:
     return n
 
 
+def _common_prefix_len(left: str, right: str) -> int:
+    """Return the character prefix shared by two decoded text snapshots."""
+    limit = min(len(left), len(right))
+    idx = 0
+    while idx < limit and left[idx] == right[idx]:
+        idx += 1
+    return idx
+
+
+def _decode_stream_delta(
+    state_key: Tuple[str, int],
+    new_token_ids: List[int],
+    finished: bool,
+) -> str:
+    """Decode streaming output with request-local token context.
+
+    The scheduler sends only newly generated token ids. Decoding that slice
+    directly can split byte-fallback or multi-token Unicode sequences and
+    emit U+FFFD. Keep cumulative token ids per stream and return only the
+    newly decoded suffix, similar to vLLM's incremental detokenizer.
+    """
+    global tokenizer
+
+    state = _stream_decode_states.setdefault(
+        state_key,
+        {"token_ids": [], "sent_text": ""},
+    )
+    state["token_ids"].extend(new_token_ids)
+
+    decoded_text = tokenizer.decode(state["token_ids"], skip_special_tokens=True)
+    sent_text = state["sent_text"]
+    if decoded_text.startswith(sent_text):
+        delta = decoded_text[len(sent_text) :]
+    else:
+        # Tokenizers may normalize whitespace around special tokens. Fall back
+        # to the changed suffix instead of replaying the entire decoded text.
+        prefix_len = _common_prefix_len(decoded_text, sent_text)
+        delta = decoded_text[prefix_len:]
+
+    if delta.endswith("\ufffd") and not finished:
+        return ""
+
+    state["sent_text"] = decoded_text
+    return delta
+
+
 def _send_stream_chunk_direct(
     request_output: RequestOutput,
     request_id: str,
     stream_queue: asyncio.Queue,
     loop: AbstractEventLoop,
 ) -> None:
-    """Send stream chunk directly to the queue."""
-    global tokenizer
-
-    new_text = tokenizer.decode(request_output.output_tokens, skip_special_tokens=True)
+    """Send a stream chunk decoded with cumulative token context."""
+    new_text = _decode_stream_delta(
+        (request_id, 0),
+        request_output.output_tokens,
+        request_output.finished,
+    )
     started_at = _request_start_times.get(request_id)
     chunk_data = {
         "text": new_text,
@@ -185,6 +234,7 @@ def _send_stream_chunk_direct(
 
 def _send_stream_chunk_tagged(
     request_output: RequestOutput,
+    request_id: str,
     sibling_index: int,
     stream_queue: asyncio.Queue,
     loop: AbstractEventLoop,
@@ -195,9 +245,11 @@ def _send_stream_chunk_tagged(
     queue so the merge-stream consumer in :mod:`serving_chat` /
     :mod:`serving_completion` can demultiplex by index.
     """
-    global tokenizer
-
-    new_text = tokenizer.decode(request_output.output_tokens, skip_special_tokens=True)
+    new_text = _decode_stream_delta(
+        (request_id, sibling_index),
+        request_output.output_tokens,
+        request_output.finished,
+    )
     chunk_data = {
         "text": new_text,
         "token_ids": request_output.output_tokens,
@@ -462,12 +514,14 @@ def cleanup_streaming_request(request_id: str, seq_id: int) -> None:
     dicts use ``dict.pop(..., None)`` so repeated removal is a no-op.
     """
     global engine, _stream_queues, _seq_id_to_request_id
-    global _stream_loops, _request_start_times
+    global _stream_loops, _request_start_times, _stream_decode_states
 
     _stream_queues.pop(request_id, None)
     _seq_id_to_request_id.pop(seq_id, None)
     _stream_loops.pop(request_id, None)
     _request_start_times.pop(request_id, None)
+    for key in [key for key in _stream_decode_states if key[0] == request_id]:
+        _stream_decode_states.pop(key, None)
     engine.io_processor.requests.pop(seq_id, None)
 
 
@@ -497,7 +551,9 @@ async def setup_streaming_request_fanout(
 
     def make_callback(idx: int):
         def _cb(request_output: RequestOutput) -> None:
-            _send_stream_chunk_tagged(request_output, idx, shared_queue, stream_loop)
+            _send_stream_chunk_tagged(
+                request_output, request_id, idx, shared_queue, stream_loop
+            )
 
         return _cb
 

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -920,7 +920,7 @@ async def responses(request: ResponsesRequest):
                 cleanup_streaming_request,
             )
             return StreamingResponse(
-                _logged_stream(gen, request_id),
+                _logged_stream_with_cleanup(gen, request_id, [seq_id]),
                 media_type="text/event-stream",
             )
 

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -74,8 +74,9 @@ _stream_queues: Dict[str, asyncio.Queue] = {}
 _seq_id_to_request_id: Dict[int, str] = {}
 _stream_loops: Dict[str, AbstractEventLoop] = {}
 _request_start_times: Dict[str, float] = {}
-_stream_decode_states: Dict[Tuple[str, int], Dict[str, Any]] = {}
+_stream_decode_states: Dict[str, Dict[int, Dict[str, Any]]] = {}
 _request_logger: Optional[logging.Logger] = None
+STREAM_DECODE_CONTEXT_TOKENS = 16
 
 
 # ============================================================================
@@ -108,6 +109,18 @@ async def _logged_stream(
             else:
                 _log_request_event("stream_done", request_id, None)
         yield chunk
+
+
+async def _logged_stream_with_cleanup(
+    gen: AsyncGenerator[str, None], request_id: str, seq_ids: List[int]
+) -> AsyncGenerator[str, None]:
+    """Log a stream and clean request state if the client disconnects."""
+    try:
+        async for chunk in _logged_stream(gen, request_id):
+            yield chunk
+    finally:
+        for seq_id in seq_ids:
+            cleanup_streaming_request(request_id, seq_id)
 
 
 # ============================================================================
@@ -180,31 +193,50 @@ def _decode_stream_delta(
 
     The scheduler sends only newly generated token ids. Decoding that slice
     directly can split byte-fallback or multi-token Unicode sequences and
-    emit U+FFFD. Keep cumulative token ids per stream and return only the
-    newly decoded suffix, similar to vLLM's incremental detokenizer.
+    emit U+FFFD. Keep per-stream token context and return only the newly
+    decoded suffix, similar to vLLM's incremental detokenizer.
     """
     global tokenizer
 
-    state = _stream_decode_states.setdefault(
-        state_key,
-        {"token_ids": [], "sent_text": ""},
+    request_id, sibling_index = state_key
+    states_for_request = _stream_decode_states.setdefault(request_id, {})
+    state = states_for_request.setdefault(
+        sibling_index,
+        {"token_ids": [], "sent_text": "", "context_start": 0, "context_text": ""},
     )
+    old_token_count = len(state["token_ids"])
     state["token_ids"].extend(new_token_ids)
 
-    decoded_text = tokenizer.decode(state["token_ids"], skip_special_tokens=True)
-    sent_text = state["sent_text"]
-    if decoded_text.startswith(sent_text):
-        delta = decoded_text[len(sent_text) :]
+    token_ids = state["token_ids"]
+    new_context_start = max(
+        0,
+        len(token_ids) - len(new_token_ids) - STREAM_DECODE_CONTEXT_TOKENS,
+    )
+    decoded_text = tokenizer.decode(
+        token_ids[new_context_start:], skip_special_tokens=True
+    )
+    if state["context_start"] == new_context_start:
+        sent_context_text = state["context_text"]
     else:
-        # Tokenizers may normalize whitespace around special tokens. Fall back
-        # to the changed suffix instead of replaying the entire decoded text.
-        prefix_len = _common_prefix_len(decoded_text, sent_text)
+        sent_context_text = tokenizer.decode(
+            token_ids[new_context_start:old_token_count],
+            skip_special_tokens=True,
+        )
+
+    if decoded_text.startswith(sent_context_text):
+        delta = decoded_text[len(sent_context_text) :]
+    else:
+        # Tokenizers may normalize text around the rolling context boundary.
+        # Fall back to the changed suffix instead of replaying the full text.
+        prefix_len = _common_prefix_len(decoded_text, sent_context_text)
         delta = decoded_text[prefix_len:]
 
     if delta.endswith("\ufffd") and not finished:
         return ""
 
-    state["sent_text"] = decoded_text
+    state["sent_text"] += delta
+    state["context_start"] = new_context_start
+    state["context_text"] = decoded_text
     return delta
 
 
@@ -522,8 +554,7 @@ def cleanup_streaming_request(request_id: str, seq_id: int) -> None:
     _seq_id_to_request_id.pop(seq_id, None)
     _stream_loops.pop(request_id, None)
     _request_start_times.pop(request_id, None)
-    for key in [key for key in _stream_decode_states if key[0] == request_id]:
-        _stream_decode_states.pop(key, None)
+    _stream_decode_states.pop(request_id, None)
     engine.io_processor.requests.pop(seq_id, None)
 
 
@@ -689,6 +720,7 @@ async def chat_completions(request: ChatCompletionRequest):
                     tokenizer,
                     cleanup_streaming_request,
                 )
+                cleanup_seq_ids = seq_ids
             else:
                 seq_id, stream_queue = await setup_streaming_request(
                     prompt, sampling_params, request_id
@@ -702,8 +734,9 @@ async def chat_completions(request: ChatCompletionRequest):
                     tokenizer,
                     cleanup_streaming_request,
                 )
+                cleanup_seq_ids = [seq_id]
             return StreamingResponse(
-                _logged_stream(gen, request_id),
+                _logged_stream_with_cleanup(gen, request_id, cleanup_seq_ids),
                 media_type="text/event-stream",
             )
 
@@ -774,6 +807,7 @@ async def completions(request: CompletionRequest):
                     tokenizer,
                     cleanup_streaming_request,
                 )
+                cleanup_seq_ids = seq_ids
             else:
                 seq_id, stream_queue = await setup_streaming_request(
                     request.prompt,
@@ -790,8 +824,9 @@ async def completions(request: CompletionRequest):
                     tokenizer,
                     cleanup_streaming_request,
                 )
+                cleanup_seq_ids = [seq_id]
             return StreamingResponse(
-                _logged_stream(gen, request_id),
+                _logged_stream_with_cleanup(gen, request_id, cleanup_seq_ids),
                 media_type="text/event-stream",
             )
 

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -3,6 +3,7 @@
 
 """Pydantic request/response models for the OpenAI-compatible API."""
 
+import json
 import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -48,6 +49,29 @@ class ChatMessage(BaseModel):
                 parts.append(part.get("text", ""))
         return "\n".join(parts)
 
+    @staticmethod
+    def _normalize_tool_calls(tool_calls: Any) -> Any:
+        """Decode OpenAI JSON-string tool arguments for chat templates."""
+        if not isinstance(tool_calls, list):
+            return tool_calls
+
+        normalized = []
+        for item in tool_calls:
+            if not isinstance(item, dict):
+                raise TypeError(f"tool_calls entries must be dicts, got {type(item)!r}")
+
+            call = dict(item)
+            function = dict(call.get("function") or {})
+            arguments = function.get("arguments")
+            if arguments:
+                if not isinstance(arguments, (dict, list)):
+                    function["arguments"] = json.loads(arguments)
+            else:
+                function["arguments"] = {}
+            call["function"] = function
+            normalized.append(call)
+        return normalized
+
     def to_template_dict(self) -> Dict[str, Any]:
         """Convert to dict for chat template, preserving tool-related fields.
 
@@ -59,7 +83,10 @@ class ChatMessage(BaseModel):
         extras = self.model_extra or {}
         for key in ("tool_calls", "tool_call_id", "name", "reasoning_content"):
             if key in extras:
-                d[key] = extras[key]
+                value = extras[key]
+                if key == "tool_calls":
+                    value = self._normalize_tool_calls(value)
+                d[key] = value
         return d
 
 

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -21,6 +21,7 @@ CHAT_COMPLETION_OBJECT = "chat.completion"
 CHAT_COMPLETION_CHUNK_OBJECT = "chat.completion.chunk"
 TEXT_COMPLETION_OBJECT = "text_completion"
 STREAM_DONE_MESSAGE = "data: [DONE]\n\n"
+RESPONSES_OBJECT = "response"
 
 
 # ============================================================================
@@ -146,6 +147,95 @@ class CompletionRequest(BaseModel):
     n: Optional[int] = 1
 
 
+class ResponsesRequest(BaseModel):
+    """Request model for the OpenAI Responses API.
+
+    This is a compatibility subset that maps Responses input onto ATOM's
+    existing chat-template and generation path.
+    """
+
+    model_config = {"extra": "allow"}
+
+    model: Optional[str] = None
+    input: Union[str, List[Any]]
+    instructions: Optional[str] = None
+    temperature: Optional[float] = DEFAULT_TEMPERATURE
+    top_k: Optional[int] = DEFAULT_TOP_K
+    top_p: Optional[float] = DEFAULT_TOP_P
+    max_output_tokens: Optional[int] = None
+    max_tokens: Optional[int] = None
+    stop: Optional[List[str]] = None
+    ignore_eos: Optional[bool] = False
+    stream: Optional[bool] = False
+    seed: Optional[int] = None
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
+    tools: Optional[List[Dict[str, Any]]] = None
+    tool_choice: Optional[Any] = None
+    store: Optional[bool] = False
+
+    def get_max_tokens(self) -> int:
+        """Return the output token budget using Responses naming first."""
+        if self.max_output_tokens is not None:
+            return self.max_output_tokens
+        if self.max_tokens is not None:
+            return self.max_tokens
+        return DEFAULT_MAX_TOKENS
+
+    @staticmethod
+    def _normalize_response_content(content: Any) -> Any:
+        """Map Responses content part names onto Chat Completions names."""
+        if not isinstance(content, list):
+            return content
+        parts: List[Any] = []
+        for part in content:
+            if not isinstance(part, dict):
+                parts.append(part)
+                continue
+            normalized = dict(part)
+            if normalized.get("type") in ("input_text", "output_text"):
+                normalized["type"] = "text"
+            parts.append(normalized)
+        return parts
+
+    def to_chat_messages(self) -> List[ChatMessage]:
+        """Convert Responses ``input`` into chat messages."""
+        messages: List[ChatMessage] = []
+        if self.instructions:
+            messages.append(ChatMessage(role="system", content=self.instructions))
+
+        if isinstance(self.input, str):
+            messages.append(ChatMessage(role="user", content=self.input))
+            return messages
+
+        for item in self.input:
+            if isinstance(item, ChatMessage):
+                messages.append(item)
+                continue
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                role = item.get("role")
+                content = item.get("content")
+                if item_type == "message" or role is not None:
+                    msg = dict(item)
+                    msg.pop("type", None)
+                    msg.setdefault("role", role or "user")
+                    msg["content"] = self._normalize_response_content(
+                        msg.get("content")
+                    )
+                    messages.append(ChatMessage.model_validate(msg))
+                elif item_type == "input_text":
+                    messages.append(ChatMessage(role="user", content=item.get("text", "")))
+                elif item_type == "output_text":
+                    messages.append(
+                        ChatMessage(role="assistant", content=item.get("text", ""))
+                    )
+                elif "text" in item:
+                    messages.append(ChatMessage(role="user", content=item.get("text", "")))
+        if not messages or all(m.role == "system" for m in messages):
+            raise ValueError("Responses input must contain at least one user or assistant message")
+        return messages
+
+
 # ============================================================================
 # Response Models
 # ============================================================================
@@ -197,3 +287,18 @@ class ErrorResponse(BaseModel):
     """OpenAI-format error response."""
 
     error: Dict[str, Any]
+
+
+class ResponsesResponse(BaseModel):
+    """Response model for /v1/responses."""
+
+    id: str
+    object: str = RESPONSES_OBJECT
+    created_at: int
+    status: str
+    model: str
+    output: List[Dict[str, Any]]
+    output_text: str
+    usage: Dict[str, Any]
+
+    model_config = ConfigDict(extra="allow")

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -245,15 +245,21 @@ class ResponsesRequest(BaseModel):
                     )
                     messages.append(ChatMessage.model_validate(msg))
                 elif item_type == "input_text":
-                    messages.append(ChatMessage(role="user", content=item.get("text", "")))
+                    messages.append(
+                        ChatMessage(role="user", content=item.get("text", ""))
+                    )
                 elif item_type == "output_text":
                     messages.append(
                         ChatMessage(role="assistant", content=item.get("text", ""))
                     )
                 elif "text" in item:
-                    messages.append(ChatMessage(role="user", content=item.get("text", "")))
+                    messages.append(
+                        ChatMessage(role="user", content=item.get("text", ""))
+                    )
         if not messages or all(m.role == "system" for m in messages):
-            raise ValueError("Responses input must contain at least one user or assistant message")
+            raise ValueError(
+                "Responses input must contain at least one user or assistant message"
+            )
         return messages
 
 

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -59,16 +59,37 @@ class ChatMessage(BaseModel):
         normalized = []
         for item in tool_calls:
             if not isinstance(item, dict):
-                raise TypeError(f"tool_calls entries must be dicts, got {type(item)!r}")
+                raise ValueError(
+                    f"tool_calls entries must be dicts, got {type(item)!r}"
+                )
 
             call = dict(item)
-            function = dict(call.get("function") or {})
+            function_value = call.get("function") or {}
+            if not isinstance(function_value, dict):
+                raise ValueError(
+                    f"tool_calls function must be a dict, got {type(function_value)!r}"
+                )
+
+            function = dict(function_value)
             arguments = function.get("arguments")
-            if arguments:
-                if not isinstance(arguments, (dict, list)):
-                    function["arguments"] = json.loads(arguments)
-            else:
+            if arguments is None or arguments == "":
                 function["arguments"] = {}
+            elif isinstance(arguments, str):
+                try:
+                    decoded_arguments = json.loads(arguments)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        "tool_calls function.arguments must be a valid JSON object"
+                    ) from exc
+                if not isinstance(decoded_arguments, dict):
+                    raise ValueError(
+                        "tool_calls function.arguments must decode to a JSON object"
+                    )
+                function["arguments"] = decoded_arguments
+            elif not isinstance(arguments, dict):
+                raise ValueError(
+                    "tool_calls function.arguments must be a dict or JSON object string"
+                )
             call["function"] = function
             normalized.append(call)
         return normalized

--- a/atom/entrypoints/openai/serving_responses.py
+++ b/atom/entrypoints/openai/serving_responses.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Responses API serving helpers.
+
+This implements a compatibility subset of OpenAI's Responses API on top of
+ATOM's existing chat-completions generation path. The streaming event names
+and payload shapes follow vLLM/OpenAI closely enough for SDK clients that
+consume text, reasoning, and function-call deltas.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+from .protocol import STREAM_DONE_MESSAGE, ResponsesResponse
+from .reasoning import ReasoningFilter, separate_reasoning
+from .tool_parser import ToolCallStreamParser, parse_tool_calls
+
+
+def _sse(event: Dict[str, Any]) -> str:
+    return f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+
+
+def _response_base(request_id: str, model: str, status: str = "in_progress") -> Dict[str, Any]:
+    return {
+        "id": request_id,
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": status,
+        "model": model,
+        "output": [],
+        "usage": None,
+    }
+
+
+def _event(event_type: str, request_id: str, model: str, **extra: Any) -> Dict[str, Any]:
+    event = {
+        "type": event_type,
+        "sequence_number": -1,
+        "response": _response_base(request_id, model),
+    }
+    event.update(extra)
+    return event
+
+
+def _completed_event(
+    request_id: str,
+    model: str,
+    output: List[Dict[str, Any]],
+    output_text: str,
+    usage: Dict[str, Any],
+) -> Dict[str, Any]:
+    response = _response_base(request_id, model, status="completed")
+    response["output"] = output
+    response["output_text"] = output_text
+    response["usage"] = usage
+    return {"type": "response.completed", "sequence_number": -1, "response": response}
+
+
+def _message_item(item_id: str, status: str, content: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+    return {
+        "id": item_id,
+        "type": "message",
+        "status": status,
+        "role": "assistant",
+        "content": content or [],
+    }
+
+
+def _reasoning_item(item_id: str, status: str, text: str = "") -> Dict[str, Any]:
+    return {
+        "id": item_id,
+        "type": "reasoning",
+        "status": status,
+        "summary": [],
+        "content": [{"type": "reasoning_text", "text": text}] if text else [],
+    }
+
+
+def _function_call_item(call_id: str, name: str, arguments: str, status: str) -> Dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function_call",
+        "status": status,
+        "call_id": call_id,
+        "name": name,
+        "arguments": arguments,
+    }
+
+
+class _ResponsesStreamState:
+    def __init__(self) -> None:
+        self.next_output_index = 0
+        self.message_output_index: Optional[int] = None
+        self.reasoning_output_index: Optional[int] = None
+        self.message_content_index = 0
+        self.reasoning_content_index = 0
+        self.message_item_id = ""
+        self.reasoning_item_id = ""
+        self.sent_message_item = False
+        self.sent_reasoning_item = False
+        self.content_text = ""
+        self.reasoning_text = ""
+        self.tool_calls: Dict[int, Dict[str, Any]] = {}
+
+    def ensure_message(self) -> List[Dict[str, Any]]:
+        if self.sent_message_item:
+            return []
+        self.sent_message_item = True
+        self.message_item_id = f"msg_{uuid.uuid4().hex}"
+        self.message_output_index = self.next_output_index
+        self.next_output_index += 1
+        return [
+            {
+                "type": "response.output_item.added",
+                "sequence_number": -1,
+                "output_index": self.message_output_index,
+                "item": _message_item(self.message_item_id, "in_progress"),
+            },
+            {
+                "type": "response.content_part.added",
+                "sequence_number": -1,
+                "output_index": self.message_output_index,
+                "item_id": self.message_item_id,
+                "content_index": self.message_content_index,
+                "part": {"type": "output_text", "text": "", "annotations": [], "logprobs": []},
+            },
+        ]
+
+    def ensure_reasoning(self) -> List[Dict[str, Any]]:
+        if self.sent_reasoning_item:
+            return []
+        self.sent_reasoning_item = True
+        self.reasoning_item_id = f"rs_{uuid.uuid4().hex}"
+        self.reasoning_output_index = self.next_output_index
+        self.next_output_index += 1
+        return [
+            {
+                "type": "response.output_item.added",
+                "sequence_number": -1,
+                "output_index": self.reasoning_output_index,
+                "item": _reasoning_item(self.reasoning_item_id, "in_progress"),
+            },
+            {
+                "type": "response.reasoning_part.added",
+                "sequence_number": -1,
+                "output_index": self.reasoning_output_index,
+                "item_id": self.reasoning_item_id,
+                "content_index": self.reasoning_content_index,
+                "part": {"type": "reasoning_text", "text": ""},
+            },
+        ]
+
+    def emit_content_delta(self, delta: str) -> List[Dict[str, Any]]:
+        events = self.ensure_message()
+        self.content_text += delta
+        events.append(
+            {
+                "type": "response.output_text.delta",
+                "sequence_number": -1,
+                "output_index": self.message_output_index,
+                "item_id": self.message_item_id,
+                "content_index": self.message_content_index,
+                "delta": delta,
+                "logprobs": [],
+            }
+        )
+        return events
+
+    def emit_reasoning_delta(self, delta: str) -> List[Dict[str, Any]]:
+        events = self.ensure_reasoning()
+        self.reasoning_text += delta
+        events.append(
+            {
+                "type": "response.reasoning_text.delta",
+                "sequence_number": -1,
+                "output_index": self.reasoning_output_index,
+                "item_id": self.reasoning_item_id,
+                "content_index": self.reasoning_content_index,
+                "delta": delta,
+            }
+        )
+        return events
+
+    def emit_tool_event(self, event_type: str, data: Any) -> List[Dict[str, Any]]:
+        if event_type == "tool_call_start":
+            idx = int(data.get("index", len(self.tool_calls)))
+            function = data.get("function", {})
+            call = {
+                "id": data.get("id") or f"call_{uuid.uuid4().hex[:8]}",
+                "name": function.get("name", ""),
+                "arguments": "",
+            }
+            self.tool_calls[idx] = call
+            output_index = self.next_output_index
+            self.next_output_index += 1
+            call["output_index"] = output_index
+            return [
+                {
+                    "type": "response.output_item.added",
+                    "sequence_number": -1,
+                    "output_index": output_index,
+                    "item": _function_call_item(call["id"], call["name"], "", "in_progress"),
+                }
+            ]
+        if event_type == "tool_call_args":
+            idx = int(data.get("index", 0))
+            call = self.tool_calls.setdefault(
+                idx,
+                {
+                    "id": f"call_{uuid.uuid4().hex[:8]}",
+                    "name": "",
+                    "arguments": "",
+                    "output_index": self.next_output_index,
+                },
+            )
+            if call["output_index"] == self.next_output_index:
+                self.next_output_index += 1
+            delta = (data.get("function") or {}).get("arguments", "")
+            call["arguments"] += delta
+            return [
+                {
+                    "type": "response.function_call_arguments.delta",
+                    "sequence_number": -1,
+                    "output_index": call["output_index"],
+                    "item_id": call["id"],
+                    "delta": delta,
+                }
+            ]
+        return []
+
+    def done_events(self) -> List[Dict[str, Any]]:
+        events: List[Dict[str, Any]] = []
+        if self.sent_reasoning_item:
+            events.append(
+                {
+                    "type": "response.reasoning_text.done",
+                    "sequence_number": -1,
+                    "output_index": self.reasoning_output_index,
+                    "item_id": self.reasoning_item_id,
+                    "content_index": self.reasoning_content_index,
+                    "text": self.reasoning_text,
+                }
+            )
+            events.append(
+                {
+                    "type": "response.output_item.done",
+                    "sequence_number": -1,
+                    "output_index": self.reasoning_output_index,
+                    "item": _reasoning_item(self.reasoning_item_id, "completed", self.reasoning_text),
+                }
+            )
+        if self.sent_message_item:
+            part = {
+                "type": "output_text",
+                "text": self.content_text,
+                "annotations": [],
+                "logprobs": [],
+            }
+            events.append(
+                {
+                    "type": "response.output_text.done",
+                    "sequence_number": -1,
+                    "output_index": self.message_output_index,
+                    "item_id": self.message_item_id,
+                    "content_index": self.message_content_index,
+                    "text": self.content_text,
+                }
+            )
+            events.append(
+                {
+                    "type": "response.content_part.done",
+                    "sequence_number": -1,
+                    "output_index": self.message_output_index,
+                    "item_id": self.message_item_id,
+                    "content_index": self.message_content_index,
+                    "part": part,
+                }
+            )
+            events.append(
+                {
+                    "type": "response.output_item.done",
+                    "sequence_number": -1,
+                    "output_index": self.message_output_index,
+                    "item": _message_item(self.message_item_id, "completed", [part]),
+                }
+            )
+        for idx, call in sorted(self.tool_calls.items()):
+            events.append(
+                {
+                    "type": "response.function_call_arguments.done",
+                    "sequence_number": -1,
+                    "output_index": call["output_index"],
+                    "item_id": call["id"],
+                    "arguments": call["arguments"],
+                }
+            )
+            events.append(
+                {
+                    "type": "response.output_item.done",
+                    "sequence_number": -1,
+                    "output_index": call["output_index"],
+                    "item": _function_call_item(
+                        call["id"], call["name"], call["arguments"], "completed"
+                    ),
+                }
+            )
+        return events
+
+    def output_items(self) -> List[Dict[str, Any]]:
+        indexed_items: List[tuple[int, Dict[str, Any]]] = []
+        if self.reasoning_text:
+            indexed_items.append(
+                (
+                    self.reasoning_output_index or 0,
+                    _reasoning_item(
+                        self.reasoning_item_id or f"rs_{uuid.uuid4().hex}",
+                        "completed",
+                        self.reasoning_text,
+                    ),
+                )
+            )
+        if self.content_text:
+            part = {"type": "output_text", "text": self.content_text, "annotations": [], "logprobs": []}
+            indexed_items.append(
+                (
+                    self.message_output_index or 0,
+                    _message_item(
+                        self.message_item_id or f"msg_{uuid.uuid4().hex}",
+                        "completed",
+                        [part],
+                    ),
+                )
+            )
+        for call in self.tool_calls.values():
+            indexed_items.append(
+                (
+                    call["output_index"],
+                    _function_call_item(call["id"], call["name"], call["arguments"], "completed"),
+                )
+            )
+        return [item for _, item in sorted(indexed_items, key=lambda entry: entry[0])]
+
+
+def build_responses_response(
+    request_id: str,
+    model: str,
+    raw_text: str,
+    final_output: Dict[str, Any],
+) -> ResponsesResponse:
+    reasoning_content, content_with_tools = separate_reasoning(raw_text)
+    content, tool_calls = parse_tool_calls(content_with_tools)
+    output: List[Dict[str, Any]] = []
+    if reasoning_content:
+        output.append(_reasoning_item(f"rs_{uuid.uuid4().hex}", "completed", reasoning_content))
+    if content:
+        part = {"type": "output_text", "text": content, "annotations": [], "logprobs": []}
+        output.append(_message_item(f"msg_{uuid.uuid4().hex}", "completed", [part]))
+    for tool_call in tool_calls:
+        output.append(
+            _function_call_item(
+                tool_call.id,
+                tool_call.function.get("name", ""),
+                tool_call.function.get("arguments", ""),
+                "completed",
+            )
+        )
+    return ResponsesResponse(
+        id=request_id,
+        created_at=int(time.time()),
+        status="completed",
+        model=model,
+        output=output,
+        output_text=content,
+        usage={
+            "input_tokens": final_output["num_tokens_input"],
+            "output_tokens": final_output["num_tokens_output"],
+            "total_tokens": final_output["num_tokens_input"] + final_output["num_tokens_output"],
+        },
+    )
+
+
+async def stream_responses_response(
+    request_id: str,
+    model: str,
+    prompt: str,
+    stream_queue: asyncio.Queue,
+    seq_id: int,
+    tokenizer,
+    cleanup_fn,
+) -> AsyncGenerator[str, None]:
+    num_tokens_input = len(tokenizer.encode(prompt))
+    num_tokens_output = 0
+    state = _ResponsesStreamState()
+    reasoning_filter = ReasoningFilter()
+    tool_parser = ToolCallStreamParser()
+
+    yield _sse(_event("response.created", request_id, model))
+    yield _sse(_event("response.in_progress", request_id, model))
+
+    while True:
+        chunk_data = await stream_queue.get()
+        new_text = chunk_data["text"]
+        num_tokens_output += len(chunk_data.get("token_ids", []))
+        segments = reasoning_filter.process(new_text)
+        if chunk_data.get("finished", False):
+            segments.extend(reasoning_filter.flush())
+
+        for field, text in segments:
+            if field == "reasoning_content" and text:
+                for event in state.emit_reasoning_delta(text):
+                    yield _sse(event)
+            elif field == "content" and text:
+                for event_type, data in tool_parser.process(text):
+                    if event_type == "content" and data:
+                        for event in state.emit_content_delta(data):
+                            yield _sse(event)
+                    elif event_type.startswith("tool_call"):
+                        for event in state.emit_tool_event(event_type, data):
+                            yield _sse(event)
+
+        if chunk_data.get("finished", False):
+            for event_type, data in tool_parser.flush():
+                if event_type == "content" and data:
+                    for event in state.emit_content_delta(data):
+                        yield _sse(event)
+                elif event_type.startswith("tool_call"):
+                    for event in state.emit_tool_event(event_type, data):
+                        yield _sse(event)
+            break
+
+    cleanup_fn(request_id, seq_id)
+
+    for event in state.done_events():
+        yield _sse(event)
+
+    usage = {
+        "input_tokens": num_tokens_input,
+        "output_tokens": num_tokens_output,
+        "total_tokens": num_tokens_input + num_tokens_output,
+    }
+    yield _sse(_completed_event(request_id, model, state.output_items(), state.content_text, usage))
+    yield STREAM_DONE_MESSAGE

--- a/atom/entrypoints/openai/serving_responses.py
+++ b/atom/entrypoints/openai/serving_responses.py
@@ -26,7 +26,9 @@ def _sse(event: Dict[str, Any]) -> str:
     return f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
 
 
-def _response_base(request_id: str, model: str, status: str = "in_progress") -> Dict[str, Any]:
+def _response_base(
+    request_id: str, model: str, status: str = "in_progress"
+) -> Dict[str, Any]:
     return {
         "id": request_id,
         "object": "response",
@@ -38,7 +40,9 @@ def _response_base(request_id: str, model: str, status: str = "in_progress") -> 
     }
 
 
-def _event(event_type: str, request_id: str, model: str, **extra: Any) -> Dict[str, Any]:
+def _event(
+    event_type: str, request_id: str, model: str, **extra: Any
+) -> Dict[str, Any]:
     event = {
         "type": event_type,
         "sequence_number": -1,
@@ -62,7 +66,11 @@ def _completed_event(
     return {"type": "response.completed", "sequence_number": -1, "response": response}
 
 
-def _message_item(item_id: str, status: str, content: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+def _message_item(
+    item_id: str,
+    status: str,
+    content: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
     return {
         "id": item_id,
         "type": "message",
@@ -82,7 +90,9 @@ def _reasoning_item(item_id: str, status: str, text: str = "") -> Dict[str, Any]
     }
 
 
-def _function_call_item(call_id: str, name: str, arguments: str, status: str) -> Dict[str, Any]:
+def _function_call_item(
+    call_id: str, name: str, arguments: str, status: str
+) -> Dict[str, Any]:
     return {
         "id": call_id,
         "type": "function_call",
@@ -128,7 +138,12 @@ class _ResponsesStreamState:
                 "output_index": self.message_output_index,
                 "item_id": self.message_item_id,
                 "content_index": self.message_content_index,
-                "part": {"type": "output_text", "text": "", "annotations": [], "logprobs": []},
+                "part": {
+                    "type": "output_text",
+                    "text": "",
+                    "annotations": [],
+                    "logprobs": [],
+                },
             },
         ]
 
@@ -205,7 +220,9 @@ class _ResponsesStreamState:
                     "type": "response.output_item.added",
                     "sequence_number": -1,
                     "output_index": output_index,
-                    "item": _function_call_item(call["id"], call["name"], "", "in_progress"),
+                    "item": _function_call_item(
+                        call["id"], call["name"], "", "in_progress"
+                    ),
                 }
             ]
         if event_type == "tool_call_args":
@@ -252,7 +269,11 @@ class _ResponsesStreamState:
                     "type": "response.output_item.done",
                     "sequence_number": -1,
                     "output_index": self.reasoning_output_index,
-                    "item": _reasoning_item(self.reasoning_item_id, "completed", self.reasoning_text),
+                    "item": _reasoning_item(
+                        self.reasoning_item_id,
+                        "completed",
+                        self.reasoning_text,
+                    ),
                 }
             )
         if self.sent_message_item:
@@ -326,7 +347,12 @@ class _ResponsesStreamState:
                 )
             )
         if self.content_text:
-            part = {"type": "output_text", "text": self.content_text, "annotations": [], "logprobs": []}
+            part = {
+                "type": "output_text",
+                "text": self.content_text,
+                "annotations": [],
+                "logprobs": [],
+            }
             indexed_items.append(
                 (
                     self.message_output_index or 0,
@@ -341,7 +367,9 @@ class _ResponsesStreamState:
             indexed_items.append(
                 (
                     call["output_index"],
-                    _function_call_item(call["id"], call["name"], call["arguments"], "completed"),
+                    _function_call_item(
+                        call["id"], call["name"], call["arguments"], "completed"
+                    ),
                 )
             )
         return [item for _, item in sorted(indexed_items, key=lambda entry: entry[0])]
@@ -357,9 +385,16 @@ def build_responses_response(
     content, tool_calls = parse_tool_calls(content_with_tools)
     output: List[Dict[str, Any]] = []
     if reasoning_content:
-        output.append(_reasoning_item(f"rs_{uuid.uuid4().hex}", "completed", reasoning_content))
+        output.append(
+            _reasoning_item(f"rs_{uuid.uuid4().hex}", "completed", reasoning_content)
+        )
     if content:
-        part = {"type": "output_text", "text": content, "annotations": [], "logprobs": []}
+        part = {
+            "type": "output_text",
+            "text": content,
+            "annotations": [],
+            "logprobs": [],
+        }
         output.append(_message_item(f"msg_{uuid.uuid4().hex}", "completed", [part]))
     for tool_call in tool_calls:
         output.append(
@@ -380,7 +415,8 @@ def build_responses_response(
         usage={
             "input_tokens": final_output["num_tokens_input"],
             "output_tokens": final_output["num_tokens_output"],
-            "total_tokens": final_output["num_tokens_input"] + final_output["num_tokens_output"],
+            "total_tokens": final_output["num_tokens_input"]
+            + final_output["num_tokens_output"],
         },
     )
 
@@ -444,5 +480,13 @@ async def stream_responses_response(
         "output_tokens": num_tokens_output,
         "total_tokens": num_tokens_input + num_tokens_output,
     }
-    yield _sse(_completed_event(request_id, model, state.output_items(), state.content_text, usage))
+    yield _sse(
+        _completed_event(
+            request_id,
+            model,
+            state.output_items(),
+            state.content_text,
+            usage,
+        )
+    )
     yield STREAM_DONE_MESSAGE

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -258,6 +258,26 @@ class InputOutputProcessor:
             if isinstance(prompt_or_tokens, str)
             else prompt_or_tokens
         )
+        prompt_len = len(tokens)
+        max_model_len = self.config.max_model_len
+        if max_model_len is not None and prompt_len > max_model_len:
+            raise ValueError(
+                f"Input has {prompt_len} tokens, which exceeds "
+                f"max_model_len={max_model_len}. Shorten the prompt or "
+                "restart the server with a larger --max-model-len."
+            )
+        max_tokens = max(0, int(getattr(sampling_params, "max_tokens", 0)))
+        if (
+            max_model_len is not None
+            and prompt_len + max_tokens > max_model_len
+        ):
+            raise ValueError(
+                f"Requested context length is {prompt_len + max_tokens} "
+                f"tokens ({prompt_len} input + {max_tokens} max output), "
+                f"which exceeds max_model_len={max_model_len}. Shorten the "
+                "prompt, lower max_tokens, or restart the server with a "
+                "larger --max-model-len."
+            )
 
         stop_token_sequences = []
         if sampling_params.stop_strings:

--- a/tests/entrypoints/test_api_server_helpers.py
+++ b/tests/entrypoints/test_api_server_helpers.py
@@ -165,3 +165,14 @@ class TestBuildSamplingParams:
                 ignore_eos=False,
                 n=0,
             )
+
+
+class TestResponsesRoute:
+    """The OpenAI Responses API route is registered."""
+
+    def test_responses_route_exists(self):
+        routes = {
+            (tuple(sorted(getattr(route, "methods", []) or [])), getattr(route, "path", ""))
+            for route in api_server.app.routes
+        }
+        assert (("POST",), "/v1/responses") in routes

--- a/tests/entrypoints/test_api_server_helpers.py
+++ b/tests/entrypoints/test_api_server_helpers.py
@@ -13,6 +13,7 @@ rather than block the rest of the suite.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 from types import SimpleNamespace
@@ -195,6 +196,29 @@ class TestStreamDecodeDelta:
         assert 11 not in fake_engine.io_processor.requests
         assert 12 in fake_engine.io_processor.requests
 
+    def test_logged_stream_with_cleanup_cleans_when_closed(self, monkeypatch):
+        async def run_stream():
+            async def source():
+                yield 'data: {"ok": true}\n\n'
+                await asyncio.Event().wait()
+
+            stream = api_server._logged_stream_with_cleanup(source(), "req-a", [11])
+            assert await anext(stream) == 'data: {"ok": true}\n\n'
+            await stream.aclose()
+
+        fake_engine = SimpleNamespace(
+            io_processor=SimpleNamespace(requests={11: "seq-a"})
+        )
+        monkeypatch.setattr(api_server, "engine", fake_engine)
+        api_server._stream_decode_states["req-a"] = {0: {}}
+        api_server._stream_queues["req-a"] = asyncio.Queue()
+
+        asyncio.run(run_stream())
+
+        assert "req-a" not in api_server._stream_decode_states
+        assert "req-a" not in api_server._stream_queues
+        assert 11 not in fake_engine.io_processor.requests
+
 
 class TestBuildSamplingParams:
     """``_build_sampling_params`` threads ``n`` into SamplingParams."""
@@ -234,7 +258,10 @@ class TestResponsesRoute:
 
     def test_responses_route_exists(self):
         routes = {
-            (tuple(sorted(getattr(route, "methods", []) or [])), getattr(route, "path", ""))
+            (
+                tuple(sorted(getattr(route, "methods", []) or [])),
+                getattr(route, "path", ""),
+            )
             for route in api_server.app.routes
         }
         assert (("POST",), "/v1/responses") in routes

--- a/tests/entrypoints/test_api_server_helpers.py
+++ b/tests/entrypoints/test_api_server_helpers.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import sys
 import types
+from types import SimpleNamespace
 
 import pytest
 
@@ -132,6 +133,67 @@ class TestCoerceN:
 
     def test_n_one_with_greedy_stays_one(self):
         assert api_server._coerce_n(1, 0.0) == 1
+
+
+class TestStreamDecodeDelta:
+    def setup_method(self):
+        api_server._stream_decode_states.clear()
+
+    def teardown_method(self):
+        api_server._stream_decode_states.clear()
+
+    def test_common_prefix_len(self):
+        assert api_server._common_prefix_len("abcdef", "abcXYZ") == 3
+        assert api_server._common_prefix_len("abc", "abc") == 3
+        assert api_server._common_prefix_len("abc", "xyz") == 0
+
+    def test_withholds_replacement_char_until_sequence_resolves(self, monkeypatch):
+        class FakeTokenizer:
+            def decode(self, token_ids, skip_special_tokens=True):
+                assert skip_special_tokens is True
+                token_ids = tuple(token_ids)
+                if token_ids == (1,):
+                    return "A"
+                if token_ids == (1, 2):
+                    return "A\ufffd"
+                if token_ids == (1, 2, 3):
+                    return "A\u00e9"
+                return "".join(str(token_id) for token_id in token_ids)
+
+        monkeypatch.setattr(api_server, "tokenizer", FakeTokenizer())
+
+        assert api_server._decode_stream_delta(("req", 0), [1], False) == "A"
+        assert api_server._decode_stream_delta(("req", 0), [2], False) == ""
+        assert api_server._decode_stream_delta(("req", 0), [3], True) == "\u00e9"
+
+    def test_keeps_decode_state_bucketed_by_request(self, monkeypatch):
+        class FakeTokenizer:
+            def decode(self, token_ids, skip_special_tokens=True):
+                return "".join(chr(ord("a") + token_id) for token_id in token_ids)
+
+        monkeypatch.setattr(api_server, "tokenizer", FakeTokenizer())
+
+        assert api_server._decode_stream_delta(("req-a", 0), [0], False) == "a"
+        assert api_server._decode_stream_delta(("req-a", 1), [1], False) == "b"
+        assert api_server._decode_stream_delta(("req-b", 0), [2], False) == "c"
+
+        assert set(api_server._stream_decode_states) == {"req-a", "req-b"}
+        assert set(api_server._stream_decode_states["req-a"]) == {0, 1}
+
+    def test_cleanup_removes_request_decode_bucket(self, monkeypatch):
+        api_server._stream_decode_states["req-a"] = {0: {}, 1: {}}
+        api_server._stream_decode_states["req-b"] = {0: {}}
+        fake_engine = SimpleNamespace(
+            io_processor=SimpleNamespace(requests={11: "seq-a", 12: "seq-b"})
+        )
+        monkeypatch.setattr(api_server, "engine", fake_engine)
+
+        api_server.cleanup_streaming_request("req-a", 11)
+
+        assert "req-a" not in api_server._stream_decode_states
+        assert "req-b" in api_server._stream_decode_states
+        assert 11 not in fake_engine.io_processor.requests
+        assert 12 in fake_engine.io_processor.requests
 
 
 class TestBuildSamplingParams:

--- a/tests/entrypoints/test_protocol.py
+++ b/tests/entrypoints/test_protocol.py
@@ -16,6 +16,8 @@ from atom.entrypoints.openai.protocol import (
     ErrorResponse,
     ModelCard,
     ModelList,
+    ResponsesRequest,
+    ResponsesResponse,
 )
 
 # ============================================================================
@@ -264,6 +266,51 @@ class TestCompletionRequest:
         assert req.n == 3
 
 
+class TestResponsesRequest:
+    """Tests for Responses API request compatibility model."""
+
+    def test_string_input_to_chat_messages(self):
+        req = ResponsesRequest(input="Hello", instructions="Be brief")
+        messages = req.to_chat_messages()
+        assert [m.role for m in messages] == ["system", "user"]
+        assert messages[1].content == "Hello"
+
+    def test_message_input_to_chat_messages(self):
+        req = ResponsesRequest.model_validate(
+            {
+                "input": [
+                    {"type": "message", "role": "user", "content": "Hi"},
+                    {"role": "assistant", "content": "Hello"},
+                ],
+                "max_output_tokens": 12,
+            }
+        )
+        messages = req.to_chat_messages()
+        assert [m.role for m in messages] == ["user", "assistant"]
+        assert req.get_max_tokens() == 12
+
+    def test_input_text_part_to_chat_message(self):
+        req = ResponsesRequest(input=[{"type": "input_text", "text": "Hi"}])
+        messages = req.to_chat_messages()
+        assert messages[0].role == "user"
+        assert messages[0].content == "Hi"
+
+    def test_message_content_parts_are_normalized(self):
+        req = ResponsesRequest.model_validate(
+            {
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Hi"}],
+                    }
+                ]
+            }
+        )
+        messages = req.to_chat_messages()
+        assert messages[0].get_content_text() == "Hi"
+
+
 # ============================================================================
 # Response Model Tests
 # ============================================================================
@@ -298,6 +345,20 @@ class TestResponseModels:
             usage={"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
         )
         assert resp.choices[0]["text"] == "world"
+
+    def test_responses_response(self):
+        resp = ResponsesResponse(
+            id="resp-123",
+            created_at=int(time.time()),
+            status="completed",
+            model="test-model",
+            output=[],
+            output_text="Hello",
+            usage={"input_tokens": 5, "output_tokens": 2, "total_tokens": 7},
+        )
+        assert resp.object == "response"
+        assert resp.output_text == "Hello"
+        assert resp.usage["total_tokens"] == 7
 
     def test_model_card(self):
         card = ModelCard(id="test-model")

--- a/tests/entrypoints/test_protocol.py
+++ b/tests/entrypoints/test_protocol.py
@@ -139,6 +139,54 @@ class TestChatMessage:
         d = msg.to_template_dict()
         assert d["tool_calls"][0]["function"]["arguments"] == {"cmd": "pwd"}
 
+    def test_to_template_dict_rejects_non_dict_tool_call_entry(self):
+        msg = ChatMessage.model_validate(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": ["not-a-dict"],
+            }
+        )
+
+        with pytest.raises(ValueError, match="tool_calls entries must be dicts"):
+            msg.to_template_dict()
+
+    def test_to_template_dict_rejects_non_object_tool_arguments(self):
+        msg = ChatMessage.model_validate(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {"name": "bad", "arguments": "[1, 2]"},
+                    }
+                ],
+            }
+        )
+
+        with pytest.raises(ValueError, match="must decode to a JSON object"):
+            msg.to_template_dict()
+
+    def test_to_template_dict_rejects_decoded_non_object_tool_arguments(self):
+        msg = ChatMessage.model_validate(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {"name": "bad", "arguments": ["x"]},
+                    }
+                ],
+            }
+        )
+
+        with pytest.raises(ValueError, match="must be a dict or JSON object string"):
+            msg.to_template_dict()
+
     def test_to_template_dict_tool_message(self):
         """Tool result message should preserve tool_call_id."""
         msg = ChatMessage.model_validate(

--- a/tests/entrypoints/test_protocol.py
+++ b/tests/entrypoints/test_protocol.py
@@ -98,6 +98,44 @@ class TestChatMessage:
         assert d["content"] == "I'll run that."
         assert len(d["tool_calls"]) == 1
         assert d["tool_calls"][0]["function"]["name"] == "exec"
+        assert d["tool_calls"][0]["function"]["arguments"] == {"cmd": "ls"}
+
+    def test_to_template_dict_with_empty_tool_call_arguments(self):
+        """Empty OpenAI tool arguments should be normalized to an object."""
+        msg = ChatMessage.model_validate(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {"name": "noop", "arguments": ""},
+                    }
+                ],
+            }
+        )
+        d = msg.to_template_dict()
+        assert d["content"] == ""
+        assert d["tool_calls"][0]["function"]["arguments"] == {}
+
+    def test_to_template_dict_with_decoded_tool_call_arguments(self):
+        """Already-decoded tool arguments should pass through unchanged."""
+        msg = ChatMessage.model_validate(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {"name": "exec", "arguments": {"cmd": "pwd"}},
+                    }
+                ],
+            }
+        )
+        d = msg.to_template_dict()
+        assert d["tool_calls"][0]["function"]["arguments"] == {"cmd": "pwd"}
 
     def test_to_template_dict_tool_message(self):
         """Tool result message should preserve tool_call_id."""

--- a/tests/entrypoints/test_serving_responses.py
+++ b/tests/entrypoints/test_serving_responses.py
@@ -53,7 +53,12 @@ def test_stream_responses_response_emits_text_events_and_done_marker():
         queue = asyncio.Queue()
         await queue.put({"text": "Hello", "token_ids": [1], "finished": False})
         await queue.put(
-            {"text": " world", "token_ids": [2], "finished": True, "finish_reason": "stop"}
+            {
+                "text": " world",
+                "token_ids": [2],
+                "finished": True,
+                "finish_reason": "stop",
+            }
         )
         cleaned = []
 
@@ -84,7 +89,11 @@ def test_stream_responses_response_emits_text_events_and_done_marker():
     assert event_types[-1] == "[DONE]"
     assert cleaned == [("resp-stream", 42)]
 
-    completed = next(event for event in events if event != "[DONE]" and event["type"] == "response.completed")
+    completed = next(
+        event
+        for event in events
+        if event != "[DONE]" and event["type"] == "response.completed"
+    )
     assert completed["response"]["output_text"] == "Hello world"
     assert completed["response"]["usage"] == {
         "input_tokens": 2,
@@ -97,7 +106,11 @@ def test_stream_responses_response_keeps_reasoning_and_text_indices_stable():
     async def collect_events():
         queue = asyncio.Queue()
         await queue.put(
-            {"text": "<think>reason</think>answer", "token_ids": [1, 2], "finished": True}
+            {
+                "text": "<think>reason</think>answer",
+                "token_ids": [1, 2],
+                "finished": True,
+            }
         )
         return [
             _decode_sse_event(chunk)
@@ -113,10 +126,18 @@ def test_stream_responses_response_keeps_reasoning_and_text_indices_stable():
         ]
 
     events = [event for event in asyncio.run(collect_events()) if event != "[DONE]"]
-    reasoning_delta = next(event for event in events if event["type"] == "response.reasoning_text.delta")
-    reasoning_done = next(event for event in events if event["type"] == "response.reasoning_text.done")
-    text_delta = next(event for event in events if event["type"] == "response.output_text.delta")
-    text_done = next(event for event in events if event["type"] == "response.output_text.done")
+    reasoning_delta = next(
+        event for event in events if event["type"] == "response.reasoning_text.delta"
+    )
+    reasoning_done = next(
+        event for event in events if event["type"] == "response.reasoning_text.done"
+    )
+    text_delta = next(
+        event for event in events if event["type"] == "response.output_text.delta"
+    )
+    text_done = next(
+        event for event in events if event["type"] == "response.output_text.done"
+    )
 
     assert reasoning_delta["output_index"] == reasoning_done["output_index"]
     assert text_delta["output_index"] == text_done["output_index"]

--- a/tests/entrypoints/test_serving_responses.py
+++ b/tests/entrypoints/test_serving_responses.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for Responses API serving helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from atom.entrypoints.openai.serving_responses import (
+    build_responses_response,
+    stream_responses_response,
+)
+
+
+class _FakeTokenizer:
+    def encode(self, text: str):
+        return text.split()
+
+
+def _decode_sse_event(chunk: str):
+    assert chunk.startswith("data: ")
+    payload = chunk.removeprefix("data: ").strip()
+    if payload == "[DONE]":
+        return payload
+    return json.loads(payload)
+
+
+def test_build_responses_response_splits_reasoning_and_text():
+    response = build_responses_response(
+        "resp-test",
+        "test-model",
+        "<think>use arithmetic</think>2 + 3 = 5",
+        {"num_tokens_input": 4, "num_tokens_output": 6},
+    )
+
+    assert response.object == "response"
+    assert response.status == "completed"
+    assert response.output_text == "2 + 3 = 5"
+    assert response.usage == {
+        "input_tokens": 4,
+        "output_tokens": 6,
+        "total_tokens": 10,
+    }
+    assert [item["type"] for item in response.output] == ["reasoning", "message"]
+    assert response.output[0]["content"][0]["text"] == "use arithmetic"
+    assert response.output[1]["content"][0]["text"] == "2 + 3 = 5"
+
+
+def test_stream_responses_response_emits_text_events_and_done_marker():
+    async def collect_events():
+        queue = asyncio.Queue()
+        await queue.put({"text": "Hello", "token_ids": [1], "finished": False})
+        await queue.put(
+            {"text": " world", "token_ids": [2], "finished": True, "finish_reason": "stop"}
+        )
+        cleaned = []
+
+        def cleanup(request_id, seq_id):
+            cleaned.append((request_id, seq_id))
+
+        return [
+            _decode_sse_event(chunk)
+            async for chunk in stream_responses_response(
+                "resp-stream",
+                "test-model",
+                "hello prompt",
+                queue,
+                42,
+                _FakeTokenizer(),
+                cleanup,
+            )
+        ], cleaned
+
+    events, cleaned = asyncio.run(collect_events())
+    event_types = [event if event == "[DONE]" else event["type"] for event in events]
+
+    assert event_types[:2] == ["response.created", "response.in_progress"]
+    assert "response.output_item.added" in event_types
+    assert event_types.count("response.output_text.delta") >= 1
+    assert "response.output_text.done" in event_types
+    assert "response.completed" in event_types
+    assert event_types[-1] == "[DONE]"
+    assert cleaned == [("resp-stream", 42)]
+
+    completed = next(event for event in events if event != "[DONE]" and event["type"] == "response.completed")
+    assert completed["response"]["output_text"] == "Hello world"
+    assert completed["response"]["usage"] == {
+        "input_tokens": 2,
+        "output_tokens": 2,
+        "total_tokens": 4,
+    }
+
+
+def test_stream_responses_response_keeps_reasoning_and_text_indices_stable():
+    async def collect_events():
+        queue = asyncio.Queue()
+        await queue.put(
+            {"text": "<think>reason</think>answer", "token_ids": [1, 2], "finished": True}
+        )
+        return [
+            _decode_sse_event(chunk)
+            async for chunk in stream_responses_response(
+                "resp-indices",
+                "test-model",
+                "prompt",
+                queue,
+                7,
+                _FakeTokenizer(),
+                lambda _request_id, _seq_id: None,
+            )
+        ]
+
+    events = [event for event in asyncio.run(collect_events()) if event != "[DONE]"]
+    reasoning_delta = next(event for event in events if event["type"] == "response.reasoning_text.delta")
+    reasoning_done = next(event for event in events if event["type"] == "response.reasoning_text.done")
+    text_delta = next(event for event in events if event["type"] == "response.output_text.delta")
+    text_done = next(event for event in events if event["type"] == "response.output_text.done")
+
+    assert reasoning_delta["output_index"] == reasoning_done["output_index"]
+    assert text_delta["output_index"] == text_done["output_index"]
+    assert reasoning_delta["output_index"] != text_delta["output_index"]

--- a/tests/test_io_processor_fanout.py
+++ b/tests/test_io_processor_fanout.py
@@ -48,6 +48,7 @@ def _reset_sequence_counter():
 def _make_processor() -> InputOutputProcessor:
     proc = InputOutputProcessor.__new__(InputOutputProcessor)
     proc.config = MagicMock()
+    proc.config.max_model_len = None
     tokenizer = MagicMock()
     tokenizer.encode = MagicMock(side_effect=lambda s, **_: list(range(len(s))))
     proc.tokenizer = tokenizer
@@ -140,3 +141,17 @@ class TestPreprocessFanout:
             stream_callback=cb,
         )
         assert all(s.stream_callback is cb for s in seqs)
+
+    def test_fanout_rejects_prompt_longer_than_max_model_len(self):
+        proc = _make_processor()
+        proc.config.max_model_len = 4
+
+        with pytest.raises(ValueError, match="exceeds max_model_len=4"):
+            proc.preprocess_fanout("hello", SamplingParams(n=1, max_tokens=0))
+
+    def test_fanout_rejects_prompt_plus_generation_past_max_model_len(self):
+        proc = _make_processor()
+        proc.config.max_model_len = 8
+
+        with pytest.raises(ValueError, match="which exceeds max_model_len=8"):
+            proc.preprocess_fanout("hello", SamplingParams(n=1, max_tokens=4))


### PR DESCRIPTION
## Summary

This PR adds a compatibility subset of the OpenAI Responses API to ATOM's OpenAI-compatible entrypoint.

Changes included:
- normalize OpenAI tool-call history arguments before chat-template rendering
- make streaming decode use token context to avoid replacement characters on split UTF-8/token boundaries
- reject prompts that exceed `max_model_len` before scheduling
- add `POST /v1/responses` with non-streaming and SSE streaming support
- emit Responses-style events for text, reasoning, and function-call argument streams
- add focused protocol, route, and streaming-helper tests

The Responses implementation maps Responses `input` onto the existing ATOM chat-template/generation path. It supports string/message inputs, `instructions`, `max_output_tokens`, sampling fields, tools passed into the template, and text/reasoning/function-call stream event shapes. It does not implement persisted response retrieval by id.

## Tests

- `PYTHONPYCACHEPREFIX=/tmp/atom-pr-pycache python3 -m py_compile atom/entrypoints/openai/protocol.py atom/entrypoints/openai/api_server.py atom/entrypoints/openai/serving_responses.py tests/entrypoints/test_protocol.py tests/entrypoints/test_api_server_helpers.py tests/entrypoints/test_serving_responses.py`
- `PYTHONPATH=/tmp/atom-pr-responses python3 -m pytest -q tests/entrypoints/test_protocol.py tests/entrypoints/test_api_server_helpers.py tests/entrypoints/test_serving_responses.py` -> `47 passed`
- Remote MI300X smoke on `amd` with GLM-5.1 qabf16 model:
  - direct `/v1/responses` non-stream returned HTTP 200 with `output_text="5"`
  - direct `/v1/responses` streaming emitted `response.output_text.delta`, `response.completed`, and `[DONE]`
  - Caddy -> capture proxy -> ATOM `/v1/responses` streaming emitted the same event sequence

Remote smoke artifact directory: `/data2/amd_profiling/results/responses_api_smoke_20260516T101112Z/`.
