### PR TITLE
Add static LoRA adapter loading

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -895,6 +895,7 @@ class Config:
     torch_dtype: torch.dtype = field(init=False)
     speculative_config: Optional[SpeculativeConfig] = None
     kv_transfer_config: dict = field(default_factory=dict)
+    lora_modules: Optional[list[str]] = None
 
     enable_tbo: bool = False
     enable_tbo_decode: bool = False
@@ -1060,6 +1061,7 @@ class Config:
         factors.append(vllm_factors)
         factors.append(self.tensor_parallel_size)
         factors.append(self.enable_dp_attention)
+        factors.append(self.lora_modules)
 
         hash_str = hashlib.md5(
             str(factors).encode(), usedforsecurity=False

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -53,6 +53,7 @@ class EngineArgs:
     kv_transfer_config: str = "{}"
     draft_model: Optional[str] = None
     mark_trace: bool = False
+    lora_modules: Optional[List[str]] = None
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -218,6 +219,15 @@ class EngineArgs:
             "--mark-trace",
             action="store_true",
             help="Enable graph_marker nodes for tracing/profile instrumentation.",
+        )
+        parser.add_argument(
+            "--lora-modules",
+            nargs="*",
+            default=None,
+            help=(
+                "Static LoRA adapters to load at startup. Each entry may be "
+                "name=path or path. Loaded adapters are applied to every request."
+            ),
         )
 
         return parser

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -283,6 +283,12 @@ class EngineArgs:
             kwargs.pop("draft_model")
             kwargs["speculative_config"] = None
 
+        lora_modules = kwargs.get("lora_modules")
+        if lora_modules is not None and len(lora_modules) == 0:
+            raise ValueError(
+                "--lora-modules requires at least one adapter path when provided"
+            )
+
         # --enable-tbo [prefill|all] → enable_tbo + enable_tbo_decode
         tbo_mode = kwargs.pop("enable_tbo", None)
         kwargs["enable_tbo"] = tbo_mode is not None

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -222,7 +222,7 @@ class EngineArgs:
         )
         parser.add_argument(
             "--lora-modules",
-            nargs="*",
+            nargs="+",
             default=None,
             help=(
                 "Static LoRA adapters to load at startup. Each entry may be "

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -24,6 +24,7 @@ from atom.config import Config, set_current_atom_config
 from atom.model_engine.scheduler import ScheduledBatch, ScheduledBatchOutput
 from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
 from atom.model_loader.loader import load_model
+from atom.model_loader.lora import apply_lora_adapters, validate_lora_adapters_supported
 from atom.model_ops.rejection_sampler import RejectionSampler
 from atom.model_ops.sampler import SAMPLER_EPS, Sampler
 from atom.spec_decode.eagle import EagleProposer
@@ -606,12 +607,22 @@ class ModelRunner:
         if hasattr(self.model, "load_fused_expert_weights"):
             fused_shared_expert_load_fn = self.model.load_fused_expert_weights
         torch.set_default_device(None)
+        validate_lora_adapters_supported(config.lora_modules)
         load_model(
             self.model,
             config.model,
             config.hf_config,
             config.load_dummy,
             load_fused_expert_weights_fn=fused_shared_expert_load_fn,
+        )
+        apply_lora_adapters(
+            self.model,
+            config.lora_modules,
+            packed_modules_mapping=getattr(
+                self.model,
+                "packed_modules_mapping",
+                getattr(model_class, "packed_modules_mapping", {}),
+            ),
         )
         logger.info(f"Model load done: {config.model}")
 

--- a/atom/model_loader/lora.py
+++ b/atom/model_loader/lora.py
@@ -1,0 +1,636 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+import json
+import logging
+import math
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from torch import nn
+
+logger = logging.getLogger("atom")
+
+_LORA_TENSOR_RE = re.compile(
+    r"^(?P<module>.+)\.lora_(?P<side>[AB])(?:\.[^.]+)?\.weight$"
+)
+_ROUTED_EXPERT_RE = re.compile(
+    r"^(?P<prefix>.+\.mlp)\.experts\.(?P<expert_id>\d+)\."
+    r"(?P<proj>gate_proj|up_proj|down_proj)$"
+)
+
+
+@dataclass(frozen=True)
+class LoRAModuleSpec:
+    name: str
+    path: str
+
+
+@dataclass(frozen=True)
+class LoRATensorPair:
+    module_name: str
+    lora_a: torch.Tensor
+    lora_b: torch.Tensor
+    scaling: float
+
+
+def parse_lora_module_entry(entry: str) -> LoRAModuleSpec:
+    """Parse a vLLM-style ``name=path`` LoRA module entry."""
+    if "=" in entry:
+        name, path = entry.split("=", 1)
+        name = name.strip()
+        path = path.strip()
+    else:
+        path = entry.strip()
+        name = Path(path).name
+    if not name:
+        raise ValueError(f"LoRA module entry has an empty name: {entry!r}")
+    if not path:
+        raise ValueError(f"LoRA module entry has an empty path: {entry!r}")
+    return LoRAModuleSpec(name=name, path=path)
+
+
+def _strip_peft_prefix(module_name: str) -> str:
+    while module_name.startswith("base_model.model."):
+        module_name = module_name[len("base_model.model.") :]
+    module_name = module_name.replace(".mlp.shared_expert.", ".mlp.shared_experts.")
+    return module_name
+
+
+def parse_lora_tensor_name(name: str) -> tuple[str, str] | None:
+    match = _LORA_TENSOR_RE.match(name)
+    if match is None:
+        return None
+    return _strip_peft_prefix(match.group("module")), match.group("side")
+
+
+def _find_adapter_weights(adapter_path: str) -> str:
+    weights_path = os.path.join(adapter_path, "adapter_model.safetensors")
+    if not os.path.isfile(weights_path):
+        raise FileNotFoundError(
+            "Static LoRA loading currently expects "
+            f"{weights_path}; adapter_model.bin is not supported."
+        )
+    return weights_path
+
+
+def _load_adapter_config(adapter_path: str) -> dict[str, Any]:
+    config_path = os.path.join(adapter_path, "adapter_config.json")
+    if not os.path.isfile(config_path):
+        raise FileNotFoundError(f"LoRA adapter config not found: {config_path}")
+    with open(config_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _pattern_value(
+    pattern: dict[str, Any] | None,
+    module_name: str,
+    default: Any,
+) -> Any:
+    if not pattern:
+        return default
+    candidates = [module_name]
+    parts = module_name.split(".")
+    candidates.extend(".".join(parts[i:]) for i in range(1, len(parts)))
+    for candidate in candidates:
+        if candidate in pattern:
+            return pattern[candidate]
+    return default
+
+
+def _lora_scaling(
+    adapter_config: dict[str, Any],
+    module_name: str,
+    rank: int,
+) -> float:
+    alpha_value = _pattern_value(adapter_config.get("alpha_pattern"), module_name, None)
+    if alpha_value is None:
+        alpha_value = adapter_config.get("lora_alpha", rank)
+    alpha = float(alpha_value)
+    if adapter_config.get("use_rslora", False):
+        return alpha / math.sqrt(rank)
+    return alpha / rank
+
+
+def load_lora_tensors(adapter_path: str) -> list[LoRATensorPair]:
+    adapter_config = _load_adapter_config(adapter_path)
+    weights_path = _find_adapter_weights(adapter_path)
+
+    tensors: dict[str, dict[str, torch.Tensor]] = {}
+    with safe_open(weights_path, framework="pt", device="cpu") as f:
+        for tensor_name in f.keys():
+            parsed = parse_lora_tensor_name(tensor_name)
+            if parsed is None:
+                continue
+            module_name, side = parsed
+            tensors.setdefault(module_name, {})[side] = f.get_tensor(tensor_name)
+
+    pairs: list[LoRATensorPair] = []
+    incomplete = []
+    for module_name, sides in sorted(tensors.items()):
+        if "A" not in sides or "B" not in sides:
+            incomplete.append(module_name)
+            continue
+        lora_a = sides["A"]
+        lora_b = sides["B"]
+        rank = int(lora_a.shape[0])
+        if lora_b.shape[1] != rank:
+            raise ValueError(
+                f"LoRA rank mismatch for {module_name}: "
+                f"A={tuple(lora_a.shape)} B={tuple(lora_b.shape)}"
+            )
+        expected_rank = int(
+            _pattern_value(
+                adapter_config.get("rank_pattern"),
+                module_name,
+                adapter_config.get("r", rank),
+            )
+        )
+        if expected_rank != rank:
+            raise ValueError(
+                f"LoRA rank config mismatch for {module_name}: "
+                f"config r={expected_rank}, tensor rank={rank}"
+            )
+        pairs.append(
+            LoRATensorPair(
+                module_name=module_name,
+                lora_a=lora_a,
+                lora_b=lora_b,
+                scaling=_lora_scaling(adapter_config, module_name, rank),
+            )
+        )
+
+    if incomplete:
+        raise ValueError(
+            "LoRA adapter has incomplete A/B tensor pairs for: "
+            + ", ".join(incomplete[:8])
+        )
+    if not pairs:
+        raise ValueError(f"No LoRA tensor pairs found in {weights_path}")
+    return pairs
+
+
+def iter_lora_tensor_module_names(adapter_path: str) -> list[str]:
+    weights_path = _find_adapter_weights(adapter_path)
+    module_names = set()
+    with safe_open(weights_path, framework="pt", device="cpu") as f:
+        for tensor_name in f.keys():
+            parsed = parse_lora_tensor_name(tensor_name)
+            if parsed is not None:
+                module_names.add(parsed[0])
+    return sorted(module_names)
+
+
+def validate_lora_adapters_supported(lora_modules: list[str] | None) -> None:
+    if not lora_modules:
+        return
+
+    for entry in lora_modules:
+        spec = parse_lora_module_entry(entry)
+        iter_lora_tensor_module_names(spec.path)
+
+
+def _endswith_module_name(module_name: str, suffix: str) -> bool:
+    return module_name == suffix or module_name.endswith(f".{suffix}")
+
+
+def resolve_lora_target(
+    module_name: str,
+    model_modules: dict[str, nn.Module],
+    packed_modules_mapping: dict[str, Any],
+) -> tuple[str, Any | None]:
+    if module_name in model_modules:
+        return module_name, None
+
+    for checkpoint_name, packed_value in packed_modules_mapping.items():
+        if not _endswith_module_name(module_name, checkpoint_name):
+            continue
+        if isinstance(packed_value, list):
+            raise ValueError(
+                f"Static LoRA does not support fused checkpoint adapter module "
+                f"{module_name!r} mapped through list packed_modules_mapping."
+            )
+        packed_name, shard_id = packed_value
+        target_name = module_name[: -len(checkpoint_name)] + packed_name
+        if target_name in model_modules:
+            return target_name, shard_id
+
+    if ".mlp.experts." in module_name:
+        raise NotImplementedError(
+            "Static LoRA does not support routed FusedMoE expert adapter "
+            f"modules yet: {module_name}"
+        )
+
+    raise KeyError(f"LoRA target module not found in model: {module_name}")
+
+
+def _slice_or_validate(
+    tensor: torch.Tensor,
+    dim: int,
+    start: int,
+    size: int,
+    what: str,
+) -> torch.Tensor:
+    if tensor.size(dim) == size:
+        return tensor
+    if start + size > tensor.size(dim):
+        raise ValueError(
+            f"LoRA tensor too small for {what}: shape={tuple(tensor.shape)}, "
+            f"dim={dim}, start={start}, size={size}"
+        )
+    return tensor.narrow(dim, start, size)
+
+
+def _qkv_output_slice(module: nn.Module, shard_id: str) -> tuple[int, int, int]:
+    has_q_gate = len(getattr(module, "output_partition_sizes", [])) == 4
+    q_size = module.num_heads * module.head_size
+    kv_size = module.num_kv_heads * module.head_size
+    if shard_id == "q":
+        shard_size = q_size
+        shard_offset = q_size if has_q_gate else 0
+        shard_rank = module.tp_rank
+    elif shard_id == "k":
+        shard_size = kv_size
+        shard_offset = q_size * 2 if has_q_gate else q_size
+        shard_rank = module.tp_rank // module.num_kv_head_replicas
+    elif shard_id == "v":
+        v_head_size = getattr(module, "v_head_size", module.head_size)
+        shard_size = module.num_kv_heads * v_head_size
+        shard_offset = q_size * 2 + kv_size if has_q_gate else q_size + kv_size
+        shard_rank = module.tp_rank // module.num_kv_head_replicas
+    else:
+        raise ValueError(f"Unsupported QKV LoRA shard id: {shard_id!r}")
+    return shard_offset, shard_rank * shard_size, shard_size
+
+
+def _slice_qkvg_q_lora_b(module: nn.Module, lora_b: torch.Tensor) -> torch.Tensor:
+    q_size = module.num_heads * module.head_size
+    shard_size = q_size * 2
+    lora_b = _slice_or_validate(
+        lora_b,
+        dim=0,
+        start=module.tp_rank * shard_size,
+        size=shard_size,
+        what="QKVG q+gate output shard",
+    )
+    deinterleave = getattr(module, "_deinterleave", None)
+    if deinterleave is None:
+        raise ValueError(
+            "Static LoRA cannot load QKVG q_proj adapters without a "
+            "_deinterleave helper on the target module."
+        )
+    lora_b = deinterleave(lora_b)
+    q_part = lora_b.narrow(0, 0, q_size)
+    gate_part = lora_b.narrow(0, q_size, q_size)
+    return torch.cat([gate_part, q_part], dim=0)
+
+
+def slice_lora_tensors_for_module(
+    module: nn.Module,
+    lora_a: torch.Tensor,
+    lora_b: torch.Tensor,
+    shard_id: Any | None,
+) -> tuple[torch.Tensor, torch.Tensor, int | None]:
+    tp_dim = getattr(module, "tp_dim", None)
+    tp_size = getattr(module, "tp_size", 1)
+    tp_rank = getattr(module, "tp_rank", 0)
+    output_offset = None
+
+    if tp_dim == 1:
+        local_in = module.input_size
+        lora_a = _slice_or_validate(
+            lora_a, dim=1, start=tp_rank * local_in, size=local_in, what="row input"
+        )
+    elif tp_dim == 0:
+        if shard_id is None:
+            local_out = module.output_size
+            lora_b = _slice_or_validate(
+                lora_b,
+                dim=0,
+                start=tp_rank * local_out,
+                size=local_out,
+                what="column output",
+            )
+        elif isinstance(shard_id, int):
+            full_sizes = module.output_sizes
+            local_out = full_sizes[shard_id] // tp_size
+            output_offset = sum(full_sizes[:shard_id]) // tp_size
+            lora_b = _slice_or_validate(
+                lora_b,
+                dim=0,
+                start=tp_rank * local_out,
+                size=local_out,
+                what=f"packed output shard {shard_id}",
+            )
+        elif isinstance(shard_id, str) and shard_id in {"q", "k", "v"}:
+            has_q_gate = len(getattr(module, "output_partition_sizes", [])) == 4
+            if shard_id == "q" and has_q_gate:
+                lora_b = _slice_qkvg_q_lora_b(module, lora_b)
+                output_offset = 0
+            else:
+                output_offset, start, shard_size = _qkv_output_slice(module, shard_id)
+                lora_b = _slice_or_validate(
+                    lora_b,
+                    dim=0,
+                    start=start,
+                    size=shard_size,
+                    what=f"QKV output shard {shard_id}",
+                )
+        else:
+            raise ValueError(
+                f"Unsupported LoRA shard id {shard_id!r} for {module.__class__}"
+            )
+    elif shard_id is not None:
+        if not isinstance(shard_id, int) or not hasattr(module, "output_sizes"):
+            raise ValueError(
+                f"Unsupported LoRA shard id {shard_id!r} for replicated module"
+            )
+        output_offset = sum(module.output_sizes[:shard_id])
+
+    return lora_a, lora_b, output_offset
+
+
+def _lora_dtype_for_module(module: nn.Module) -> torch.dtype:
+    weight = getattr(module, "weight", None)
+    dtype = getattr(weight, "dtype", None)
+    if dtype in (torch.float16, torch.bfloat16, torch.float32):
+        return dtype
+    return torch.bfloat16
+
+
+def _match_routed_expert(module_name: str) -> re.Match[str] | None:
+    return _ROUTED_EXPERT_RE.match(module_name)
+
+
+def _map_routed_expert_id(module: nn.Module, expert_id: int) -> int | None:
+    expert_map = getattr(module, "expert_map", None)
+    if expert_map is None:
+        return expert_id
+    if expert_id >= int(expert_map.numel()):
+        raise ValueError(
+            f"LoRA expert id {expert_id} is outside expert_map with "
+            f"{expert_map.numel()} entries"
+        )
+    local_id = int(expert_map[expert_id].item())
+    if local_id == -1:
+        return None
+    return local_id
+
+
+def _slice_routed_lora_delta(
+    module: nn.Module,
+    pair: LoRATensorPair,
+    proj: str,
+) -> torch.Tensor:
+    tp_rank = getattr(module, "tp_rank", 0)
+    local_intermediate = module.intermediate_size_per_partition
+    compute_dtype = torch.bfloat16
+    if proj in {"gate_proj", "up_proj"}:
+        lora_b = _slice_or_validate(
+            pair.lora_b,
+            dim=0,
+            start=tp_rank * local_intermediate,
+            size=local_intermediate,
+            what=f"routed expert {proj} output",
+        )
+        lora_a = pair.lora_a
+    else:
+        lora_a = _slice_or_validate(
+            pair.lora_a,
+            dim=1,
+            start=tp_rank * local_intermediate,
+            size=local_intermediate,
+            what="routed expert down_proj input",
+        )
+        lora_b = pair.lora_b
+    return (
+        lora_b.to(dtype=compute_dtype) @ lora_a.to(dtype=compute_dtype)
+    ) * pair.scaling
+
+
+def _dequantize_fp8_blocks(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    block_n: int,
+    block_k: int,
+) -> torch.Tensor:
+    out_dim, in_dim = weight.shape
+    if out_dim % block_n or in_dim % block_k:
+        raise ValueError(
+            f"FP8 MoE weight shape {tuple(weight.shape)} is not aligned to "
+            f"block shape ({block_n}, {block_k})"
+        )
+    expected_scale = (out_dim // block_n, in_dim // block_k)
+    if tuple(scale.shape) != expected_scale:
+        raise ValueError(
+            f"FP8 MoE scale shape {tuple(scale.shape)} does not match "
+            f"{expected_scale} for weight {tuple(weight.shape)}"
+        )
+    blocks = weight.float().reshape(
+        out_dim // block_n,
+        block_n,
+        in_dim // block_k,
+        block_k,
+    )
+    scale_blocks = scale.float().reshape(
+        out_dim // block_n,
+        1,
+        in_dim // block_k,
+        1,
+    )
+    return (blocks * scale_blocks).reshape(out_dim, in_dim)
+
+
+def _infer_fp8_block_shape(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    block_n: int,
+    block_k: int,
+) -> tuple[int, int]:
+    expected_scale = (weight.shape[0] // block_n, weight.shape[1] // block_k)
+    if block_n > 1 and block_k > 1 and tuple(scale.shape) == expected_scale:
+        return block_n, block_k
+    if weight.shape[0] % scale.shape[0] or weight.shape[1] % scale.shape[1]:
+        return block_n, block_k
+    return weight.shape[0] // scale.shape[0], weight.shape[1] // scale.shape[1]
+
+
+def _requantize_fp8_blocks_(
+    dst_weight: torch.Tensor,
+    dst_scale: torch.Tensor,
+    value: torch.Tensor,
+    block_n: int,
+    block_k: int,
+) -> None:
+    out_dim, in_dim = value.shape
+    blocks = value.float().reshape(
+        out_dim // block_n,
+        block_n,
+        in_dim // block_k,
+        block_k,
+    )
+    fp8_max = torch.finfo(dst_weight.dtype).max
+    scale = blocks.abs().amax(dim=(1, 3), keepdim=True).clamp(min=1e-8) / fp8_max
+    qweight = (blocks / scale).clamp(min=-fp8_max, max=fp8_max).to(dst_weight.dtype)
+    dst_weight.copy_(qweight.reshape(out_dim, in_dim))
+    dst_scale.copy_(scale.squeeze(3).squeeze(1).to(dst_scale.dtype))
+
+
+def _merge_delta_into_moe_weight_(
+    weight: torch.Tensor,
+    scale: torch.Tensor | None,
+    delta: torch.Tensor,
+    block_n: int,
+    block_k: int,
+) -> None:
+    if weight.dtype in (torch.float16, torch.bfloat16, torch.float32):
+        weight.add_(delta.to(device=weight.device, dtype=weight.dtype))
+        return
+
+    fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+    if weight.dtype not in fp8_dtypes or scale is None:
+        raise TypeError(
+            "Static routed expert LoRA supports floating-point MoE weights "
+            "and FP8 block-quantized MoE weights only"
+        )
+    block_n, block_k = _infer_fp8_block_shape(weight, scale, block_n, block_k)
+    merged = _dequantize_fp8_blocks(weight, scale, block_n, block_k)
+    merged.add_(delta.to(device=weight.device, dtype=merged.dtype))
+    _requantize_fp8_blocks_(weight, scale, merged, block_n, block_k)
+
+
+def _merge_routed_expert_lora(
+    module_name: str,
+    model_modules: dict[str, nn.Module],
+    pair: LoRATensorPair,
+    adapter_name: str,
+) -> bool:
+    match = _match_routed_expert(module_name)
+    if match is None:
+        return False
+
+    experts_name = f"{match.group('prefix')}.experts"
+    if experts_name not in model_modules:
+        raise KeyError(f"LoRA routed expert module not found: {experts_name}")
+    experts = model_modules[experts_name]
+    local_expert_id = _map_routed_expert_id(experts, int(match.group("expert_id")))
+    if local_expert_id is None:
+        return True
+
+    proj = match.group("proj")
+    delta = _slice_routed_lora_delta(experts, pair, proj)
+    quant_method = getattr(experts, "quant_method", None)
+    block_n = getattr(quant_method, "block_n", 1)
+    block_k = getattr(quant_method, "block_k", 1)
+
+    if proj in {"gate_proj", "up_proj"}:
+        shard_size = experts.intermediate_size_per_partition
+        start = 0 if proj == "gate_proj" else shard_size
+        weight = experts.w13_weight.data[local_expert_id, start : start + shard_size, :]
+        scale = getattr(experts, "w13_weight_scale", None)
+        scale_slice = None
+        if scale is not None and scale.dim() == 3:
+            if scale.shape[1] % 2:
+                raise ValueError(
+                    "FP8 MoE w13 scale rows must split evenly between gate "
+                    f"and up projections, got shape {tuple(scale.shape)}"
+                )
+            scale_rows_per_shard = scale.shape[1] // 2
+            scale_start = 0 if proj == "gate_proj" else scale_rows_per_shard
+            scale_end = scale_start + scale_rows_per_shard
+            scale_slice = scale.data[local_expert_id, scale_start:scale_end, :]
+        _merge_delta_into_moe_weight_(
+            weight,
+            scale_slice,
+            delta.to(weight.device),
+            block_n,
+            block_k,
+        )
+    else:
+        weight = experts.w2_weight.data[local_expert_id, :, :]
+        scale = getattr(experts, "w2_weight_scale", None)
+        scale_slice = None
+        if scale is not None and scale.dim() == 3:
+            scale_slice = scale.data[local_expert_id]
+        _merge_delta_into_moe_weight_(
+            weight,
+            scale_slice,
+            delta.to(weight.device),
+            block_n,
+            block_k,
+        )
+
+    logger.info(
+        "Merged static LoRA adapter %s into routed expert %s",
+        adapter_name,
+        module_name,
+    )
+    return True
+
+
+def apply_lora_adapters(
+    model: nn.Module,
+    lora_modules: list[str] | None,
+    packed_modules_mapping: dict[str, Any] | None = None,
+) -> None:
+    if not lora_modules:
+        return
+
+    model_modules = dict(model.named_modules())
+    packed_modules_mapping = packed_modules_mapping or {}
+    loaded_count = 0
+
+    for entry in lora_modules:
+        spec = parse_lora_module_entry(entry)
+        adapter_pairs = load_lora_tensors(spec.path)
+        logger.info(
+            "Loading static LoRA adapter %s from %s with %d tensor pairs",
+            spec.name,
+            spec.path,
+            len(adapter_pairs),
+        )
+        for pair in adapter_pairs:
+            if _merge_routed_expert_lora(
+                pair.module_name,
+                model_modules,
+                pair,
+                spec.name,
+            ):
+                loaded_count += 1
+                continue
+
+            target_name, shard_id = resolve_lora_target(
+                pair.module_name,
+                model_modules,
+                packed_modules_mapping,
+            )
+            target_module = model_modules[target_name]
+            add_lora_adapter = getattr(target_module, "add_lora_adapter", None)
+            if add_lora_adapter is None:
+                raise TypeError(
+                    f"LoRA target {target_name} does not support static LoRA"
+                )
+
+            lora_a, lora_b, output_offset = slice_lora_tensors_for_module(
+                target_module,
+                pair.lora_a,
+                pair.lora_b,
+                shard_id,
+            )
+            device = target_module.weight.device
+            dtype = _lora_dtype_for_module(target_module)
+            add_lora_adapter(
+                lora_a.to(device=device, dtype=dtype),
+                lora_b.to(device=device, dtype=dtype),
+                pair.scaling,
+                output_offset=output_offset,
+                adapter_name=spec.name,
+            )
+            loaded_count += 1
+
+    logger.info("Loaded %d static LoRA tensor pairs", loaded_count)

--- a/atom/model_loader/lora.py
+++ b/atom/model_loader/lora.py
@@ -138,6 +138,11 @@ def load_lora_tensors(adapter_path: str) -> list[LoRATensorPair]:
             continue
         lora_a = sides["A"]
         lora_b = sides["B"]
+        if lora_a.dim() != 2 or lora_b.dim() != 2:
+            raise ValueError(
+                f"LoRA tensors for {module_name} must be 2D, got "
+                f"A={tuple(lora_a.shape)} B={tuple(lora_b.shape)}"
+            )
         rank = int(lora_a.shape[0])
         if lora_b.shape[1] != rank:
             raise ValueError(
@@ -192,6 +197,7 @@ def validate_lora_adapters_supported(lora_modules: list[str] | None) -> None:
 
     for entry in lora_modules:
         spec = parse_lora_module_entry(entry)
+        _load_adapter_config(spec.path)
         iter_lora_tensor_module_names(spec.path)
 
 
@@ -290,6 +296,27 @@ def _slice_qkvg_q_lora_b(module: nn.Module, lora_b: torch.Tensor) -> torch.Tenso
     return torch.cat([gate_part, q_part], dim=0)
 
 
+def _validate_lora_output_shape(
+    module: nn.Module,
+    lora_b: torch.Tensor,
+    output_offset: int | None,
+) -> None:
+    if output_offset is None:
+        if lora_b.shape[0] != module.output_size:
+            raise ValueError(
+                f"LoRA B output mismatch for {module.__class__.__name__}: "
+                f"expected {module.output_size}, got {lora_b.shape[0]}"
+            )
+        return
+
+    if output_offset < 0 or output_offset + lora_b.shape[0] > module.output_size:
+        raise ValueError(
+            f"LoRA B output slice for {module.__class__.__name__} exceeds the "
+            f"module output size: offset={output_offset}, B={tuple(lora_b.shape)}, "
+            f"output_size={module.output_size}"
+        )
+
+
 def slice_lora_tensors_for_module(
     module: nn.Module,
     lora_a: torch.Tensor,
@@ -352,6 +379,7 @@ def slice_lora_tensors_for_module(
             )
         output_offset = sum(module.output_sizes[:shard_id])
 
+    _validate_lora_output_shape(module, lora_b, output_offset)
     return lora_a, lora_b, output_offset
 
 
@@ -509,10 +537,11 @@ def _merge_routed_expert_lora(
     model_modules: dict[str, nn.Module],
     pair: LoRATensorPair,
     adapter_name: str,
-) -> bool:
+) -> tuple[bool, bool]:
+    """Return (handled, merged) for routed expert LoRA modules."""
     match = _match_routed_expert(module_name)
     if match is None:
-        return False
+        return False, False
 
     experts_name = f"{match.group('prefix')}.experts"
     if experts_name not in model_modules:
@@ -520,7 +549,7 @@ def _merge_routed_expert_lora(
     experts = model_modules[experts_name]
     local_expert_id = _map_routed_expert_id(experts, int(match.group("expert_id")))
     if local_expert_id is None:
-        return True
+        return True, False
 
     proj = match.group("proj")
     delta = _slice_routed_lora_delta(experts, pair, proj)
@@ -565,12 +594,90 @@ def _merge_routed_expert_lora(
             block_k,
         )
 
-    logger.info(
+    logger.debug(
         "Merged static LoRA adapter %s into routed expert %s",
         adapter_name,
         module_name,
     )
-    return True
+    return True, True
+
+
+def _looks_like_vocab_parallel_head(module: nn.Module) -> bool:
+    return (
+        hasattr(module, "weight")
+        and hasattr(module, "num_embeddings_per_partition")
+        and hasattr(module, "vocab_start_idx")
+        and hasattr(module, "vocab_end_idx")
+    )
+
+
+def _slice_vocab_parallel_lora_b(
+    module: nn.Module,
+    lora_b: torch.Tensor,
+) -> torch.Tensor:
+    local_vocab = int(module.num_embeddings_per_partition)
+    if lora_b.shape[0] == local_vocab:
+        return lora_b
+    start = int(module.vocab_start_idx)
+    return _slice_or_validate(
+        lora_b,
+        dim=0,
+        start=start,
+        size=local_vocab,
+        what="vocab-parallel lm_head output",
+    )
+
+
+def _merge_vocab_parallel_lora_(
+    target_name: str,
+    module: nn.Module,
+    pair: LoRATensorPair,
+    adapter_name: str,
+) -> None:
+    weight = module.weight.data
+    if weight.dim() != 2:
+        raise ValueError(
+            f"LoRA target {target_name} weight must be 2D, got {tuple(weight.shape)}"
+        )
+    if pair.lora_a.dim() != 2 or pair.lora_b.dim() != 2:
+        raise ValueError(
+            f"LoRA tensors for {target_name} must be 2D, got "
+            f"A={tuple(pair.lora_a.shape)} B={tuple(pair.lora_b.shape)}"
+        )
+    if pair.lora_a.shape[0] != pair.lora_b.shape[1]:
+        raise ValueError(
+            f"LoRA rank mismatch for {target_name}: "
+            f"A={tuple(pair.lora_a.shape)} B={tuple(pair.lora_b.shape)}"
+        )
+    if pair.lora_a.shape[1] != weight.shape[1]:
+        raise ValueError(
+            f"LoRA A input mismatch for {target_name}: "
+            f"expected {weight.shape[1]}, got {pair.lora_a.shape[1]}"
+        )
+
+    lora_b = _slice_vocab_parallel_lora_b(module, pair.lora_b)
+    if lora_b.shape[0] != weight.shape[0]:
+        raise ValueError(
+            f"LoRA B output mismatch for {target_name}: "
+            f"expected {weight.shape[0]}, got {lora_b.shape[0]}"
+        )
+    if weight.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            "Static vocab-parallel LoRA supports floating-point lm_head "
+            f"weights only, got {weight.dtype}"
+        )
+
+    compute_dtype = _lora_dtype_for_module(module)
+    delta = (
+        lora_b.to(device=weight.device, dtype=compute_dtype)
+        @ pair.lora_a.to(device=weight.device, dtype=compute_dtype)
+    ) * pair.scaling
+    weight.add_(delta.to(dtype=weight.dtype))
+    logger.debug(
+        "Merged static LoRA adapter %s into vocab-parallel target %s",
+        adapter_name,
+        target_name,
+    )
 
 
 def apply_lora_adapters(
@@ -595,13 +702,15 @@ def apply_lora_adapters(
             len(adapter_pairs),
         )
         for pair in adapter_pairs:
-            if _merge_routed_expert_lora(
+            routed_handled, routed_merged = _merge_routed_expert_lora(
                 pair.module_name,
                 model_modules,
                 pair,
                 spec.name,
-            ):
-                loaded_count += 1
+            )
+            if routed_handled:
+                if routed_merged:
+                    loaded_count += 1
                 continue
 
             target_name, shard_id = resolve_lora_target(
@@ -612,6 +721,15 @@ def apply_lora_adapters(
             target_module = model_modules[target_name]
             add_lora_adapter = getattr(target_module, "add_lora_adapter", None)
             if add_lora_adapter is None:
+                if shard_id is None and _looks_like_vocab_parallel_head(target_module):
+                    _merge_vocab_parallel_lora_(
+                        target_name,
+                        target_module,
+                        pair,
+                        spec.name,
+                    )
+                    loaded_count += 1
+                    continue
                 raise TypeError(
                     f"LoRA target {target_name} does not support static LoRA"
                 )

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -311,6 +311,7 @@ class LinearBase(nn.Module):
             self.weight_scale.weight_loader = self.weight_loader
         self.need_normalize_e4m3fn_to_e4m3fnuz = params_dtype == torch.float8_e4m3fnuz
         self.quant_func = get_hip_quant(self.quant_type)
+        self._static_lora_adapters: list[tuple[str, str, float, int | None]] = []
 
     @staticmethod
     def weight_loader_process(
@@ -403,10 +404,72 @@ class LinearBase(nn.Module):
         if self.quant_type == QuantType.per_1x32:
             self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
 
+    def add_lora_adapter(
+        self,
+        lora_a: torch.Tensor,
+        lora_b: torch.Tensor,
+        scaling: float,
+        output_offset: int | None = None,
+        adapter_name: str = "",
+    ):
+        if lora_a.dim() != 2 or lora_b.dim() != 2:
+            raise ValueError(
+                f"LoRA tensors for {self.prefix} must be 2D, got "
+                f"A={tuple(lora_a.shape)} B={tuple(lora_b.shape)}"
+            )
+        if lora_a.shape[0] != lora_b.shape[1]:
+            raise ValueError(
+                f"LoRA rank mismatch for {self.prefix}: "
+                f"A={tuple(lora_a.shape)} B={tuple(lora_b.shape)}"
+            )
+        if lora_a.shape[1] != self.input_size:
+            raise ValueError(
+                f"LoRA A input mismatch for {self.prefix}: "
+                f"expected {self.input_size}, got {lora_a.shape[1]}"
+            )
+
+        idx = len(self._static_lora_adapters)
+        a_name = f"_static_lora_A_{idx}"
+        b_name = f"_static_lora_B_{idx}"
+        self.register_buffer(a_name, lora_a.contiguous(), persistent=False)
+        self.register_buffer(b_name, lora_b.contiguous(), persistent=False)
+        self._static_lora_adapters.append(
+            (a_name, b_name, float(scaling), output_offset)
+        )
+        logger.info(
+            "Loaded LoRA adapter %s for %s: A=%s B=%s scaling=%s output_offset=%s",
+            adapter_name or idx,
+            self.prefix,
+            tuple(lora_a.shape),
+            tuple(lora_b.shape),
+            scaling,
+            output_offset,
+        )
+
+    def _apply_static_lora(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        for a_name, b_name, scaling, output_offset in self._static_lora_adapters:
+            lora_a = getattr(self, a_name)
+            lora_b = getattr(self, b_name)
+            x_lora = x.to(dtype=lora_a.dtype)
+            delta = torch.matmul(torch.matmul(x_lora, lora_a.t()), lora_b.t())
+            delta = (delta * scaling).to(dtype=y.dtype)
+            if output_offset is None:
+                y.add_(delta)
+            else:
+                if delta.shape[-1] + output_offset > y.shape[-1]:
+                    raise ValueError(
+                        f"LoRA output slice for {self.prefix} exceeds output shape: "
+                        f"offset={output_offset}, delta={tuple(delta.shape)}, "
+                        f"output={tuple(y.shape)}"
+                    )
+                y.narrow(-1, output_offset, delta.shape[-1]).add_(delta)
+        return y
+
     @mark_trace
     def forward(
         self, x: torch.Tensor, x_scale: Optional[torch.Tensor] = None, otype=dtypes.bf16
     ) -> torch.Tensor:
+        lora_x = x if self._static_lora_adapters else None
         if self.quant_type.value == QuantType.No.value:
             y = tgemm.mm(
                 x,
@@ -492,6 +555,8 @@ class LinearBase(nn.Module):
                 )
                 if self.bias is not None:
                     y += self.bias
+        if lora_x is not None:
+            y = self._apply_static_lora(lora_x, y)
         if self.tp_dim == 1 and self.tp_size > 1 and self.reduce_results:
             y = get_tp_group().all_reduce(y, ca_fp8_quant=False)
         return y

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -312,6 +312,7 @@ class LinearBase(nn.Module):
         self.need_normalize_e4m3fn_to_e4m3fnuz = params_dtype == torch.float8_e4m3fnuz
         self.quant_func = get_hip_quant(self.quant_type)
         self._static_lora_adapters: list[tuple[str, str, float, int | None]] = []
+        self._static_lora_dtype: torch.dtype | None = None
 
     @staticmethod
     def weight_loader_process(
@@ -427,6 +428,30 @@ class LinearBase(nn.Module):
                 f"LoRA A input mismatch for {self.prefix}: "
                 f"expected {self.input_size}, got {lora_a.shape[1]}"
             )
+        if output_offset is None:
+            if lora_b.shape[0] != self.output_size:
+                raise ValueError(
+                    f"LoRA B output mismatch for {self.prefix}: "
+                    f"expected {self.output_size}, got {lora_b.shape[0]}"
+                )
+        elif output_offset < 0 or output_offset + lora_b.shape[0] > self.output_size:
+            raise ValueError(
+                f"LoRA B output slice for {self.prefix} exceeds output size: "
+                f"offset={output_offset}, B={tuple(lora_b.shape)}, "
+                f"output_size={self.output_size}"
+            )
+        if lora_a.dtype != lora_b.dtype:
+            raise ValueError(
+                f"Static LoRA tensors for {self.prefix} must share one dtype; "
+                f"got A={lora_a.dtype}, B={lora_b.dtype}"
+            )
+        if self._static_lora_dtype is None:
+            self._static_lora_dtype = lora_a.dtype
+        elif self._static_lora_dtype != lora_a.dtype:
+            raise ValueError(
+                f"Static LoRA adapters for {self.prefix} must share one dtype; "
+                f"got existing={self._static_lora_dtype}, new={lora_a.dtype}"
+            )
 
         idx = len(self._static_lora_adapters)
         a_name = f"_static_lora_A_{idx}"
@@ -436,7 +461,7 @@ class LinearBase(nn.Module):
         self._static_lora_adapters.append(
             (a_name, b_name, float(scaling), output_offset)
         )
-        logger.info(
+        logger.debug(
             "Loaded LoRA adapter %s for %s: A=%s B=%s scaling=%s output_offset=%s",
             adapter_name or idx,
             self.prefix,
@@ -447,10 +472,15 @@ class LinearBase(nn.Module):
         )
 
     def _apply_static_lora(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        if not self._static_lora_adapters:
+            return y
+
+        if self._static_lora_dtype is None:
+            raise ValueError(f"Static LoRA dtype missing for {self.prefix}")
+        x_lora = x.to(dtype=self._static_lora_dtype)
         for a_name, b_name, scaling, output_offset in self._static_lora_adapters:
             lora_a = getattr(self, a_name)
             lora_b = getattr(self, b_name)
-            x_lora = x.to(dtype=lora_a.dtype)
             delta = torch.matmul(torch.matmul(x_lora, lora_a.t()), lora_b.t())
             delta = (delta * scaling).to(dtype=y.dtype)
             if output_offset is None:

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -15,6 +15,9 @@ from atom.utils.custom_register import direct_register_custom_op
 def is_rocm_aiter_fusion_shared_expert_enabled() -> bool:
     config = get_current_atom_config()
 
+    if getattr(config, "lora_modules", None):
+        return False
+
     quant_config = config.quant_config
 
     # Resolve actual dtypes for shared experts vs routed experts.

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2714,6 +2714,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         "compressor.wgate": ("compressor.wkv_gate", 1),
         "shared_experts.w1": ("shared_experts.gate_up_proj", 0),
         "shared_experts.w3": ("shared_experts.gate_up_proj", 1),
+        "shared_experts.down_proj": ("shared_experts.w2", None),
     }
 
     def __init__(self, config: Config, prefix: str = "") -> None:

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -57,6 +57,7 @@ Defined in `atom/config.py`. The root dataclass that the engine consumes.
 | `enable_dp_attention` | `bool` | `False` | Enable data-parallel attention |
 | `torch_dtype` | `torch.dtype` | *(computed)* | Inferred from `hf_config.torch_dtype`; falls back to `torch.bfloat16` |
 | `speculative_config` | `Optional[SpeculativeConfig]` | `None` | Speculative decoding configuration (see Section 5) |
+| `lora_modules` | `Optional[list[str]]` | `None` | Static LoRA adapters loaded at startup and applied to every request |
 | `bos_token_id` | `int` | `-1` | Beginning-of-sequence token ID (`-1` = use model default) |
 | `eos_token_id` | `int` | `-1` | End-of-sequence token ID (`-1` = use model default) |
 | `stop_token_ids` | `list[int]` | `[]` | Additional stop token IDs; populated from `GenerationConfig.eos_token_id` during init |
@@ -340,6 +341,7 @@ all flags via `add_cli_args()` and converts them into a `Config` via
 | `--max-num-seqs` | | `int` | `512` | Maximum number of sequences to batch together |
 | `--gpu-memory-utilization` | | `float` | `0.9` | Fraction of GPU memory to use (0.0 -- 1.0) |
 | `--scheduler-delay-factor` | | `float` | `0.0` | Delay factor multiplied by previous prompt latency before scheduling next prompt |
+| `--lora-modules` | | `list[str]` | `None` | Static LoRA adapters loaded at startup; entries may be `name=path` or `path` and are applied to every request |
 
 **Example:**
 

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -64,3 +64,8 @@ class TestEngineArgsSpeculativeValidation:
             num_speculative_tokens=3,
         )
         assert kwargs["speculative_config"] is fake_spec_config
+
+    def test_lora_modules_pass_through_to_engine_kwargs(self):
+        args = EngineArgs(lora_modules=["adapter=/tmp/adapter"])
+        kwargs = args._get_engine_kwargs()
+        assert kwargs["lora_modules"] == ["adapter=/tmp/adapter"]

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -73,6 +73,12 @@ class TestEngineArgsSpeculativeValidation:
         kwargs = args._get_engine_kwargs()
         assert kwargs["lora_modules"] == ["adapter=/tmp/adapter"]
 
+    def test_empty_lora_modules_list_is_rejected(self):
+        args = EngineArgs(lora_modules=[])
+
+        with pytest.raises(ValueError, match="requires at least one adapter path"):
+            args._get_engine_kwargs()
+
     def test_lora_modules_cli_requires_at_least_one_adapter(self):
         parser = argparse.ArgumentParser()
         EngineArgs.add_cli_args(parser)

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MIT
 # Regression tests for speculative-config validation in EngineArgs._get_engine_kwargs.
 
+import argparse
 import sys
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 # conftest.py stubs atom.* and zmq before any atom imports are attempted,
 # but arg_utils.py imports LLMEngine from atom and CompilationConfig /
@@ -69,3 +72,13 @@ class TestEngineArgsSpeculativeValidation:
         args = EngineArgs(lora_modules=["adapter=/tmp/adapter"])
         kwargs = args._get_engine_kwargs()
         assert kwargs["lora_modules"] == ["adapter=/tmp/adapter"]
+
+    def test_lora_modules_cli_requires_at_least_one_adapter(self):
+        parser = argparse.ArgumentParser()
+        EngineArgs.add_cli_args(parser)
+
+        args = parser.parse_args(["--lora-modules", "adapter=/tmp/adapter"])
+        assert args.lora_modules == ["adapter=/tmp/adapter"]
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--lora-modules"])

--- a/tests/test_lora_loader.py
+++ b/tests/test_lora_loader.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: MIT
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from torch import nn
+
+from atom.model_loader.lora import (
+    _dequantize_fp8_blocks,
+    apply_lora_adapters,
+    load_lora_tensors,
+    parse_lora_module_entry,
+    parse_lora_tensor_name,
+    resolve_lora_target,
+    slice_lora_tensors_for_module,
+    validate_lora_adapters_supported,
+)
+
+
+class FakeLinear(nn.Module):
+    def __init__(
+        self,
+        input_size=4,
+        output_size=4,
+        tp_dim=None,
+        tp_rank=0,
+        tp_size=1,
+        output_sizes=None,
+    ):
+        super().__init__()
+        self.input_size = input_size
+        self.output_size = output_size
+        self.tp_dim = tp_dim
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.output_sizes = output_sizes or [output_size]
+        self.weight = nn.Parameter(
+            torch.empty(output_size, input_size, dtype=torch.bfloat16)
+        )
+        self.loaded_loras = []
+
+    def add_lora_adapter(self, lora_a, lora_b, scaling, output_offset=None, **kwargs):
+        self.loaded_loras.append((lora_a, lora_b, scaling, output_offset, kwargs))
+
+
+class FakeQKVLinear(FakeLinear):
+    def __init__(self):
+        super().__init__(input_size=3, output_size=4, tp_dim=0, tp_rank=1, tp_size=2)
+        self.num_heads = 2
+        self.head_size = 1
+        self.num_kv_heads = 1
+        self.v_head_size = 1
+        self.num_kv_head_replicas = 1
+        self.output_partition_sizes = [2, 1, 1]
+
+
+class FakeQKVGLinear(FakeQKVLinear):
+    def __init__(self):
+        super().__init__()
+        self.output_partition_sizes = [2, 2, 1, 1]
+
+    def _deinterleave(self, weight, head_stride=None):
+        hs = head_stride if head_stride is not None else self.head_size
+        return (
+            weight.view(self.num_heads, 2, hs, -1)
+            .transpose(0, 1)
+            .reshape(self.num_heads * 2 * hs, -1)
+        )
+
+
+class FakeFusedMoE(nn.Module):
+    def __init__(self, dtype=torch.bfloat16, tp_rank=1, tp_size=2):
+        super().__init__()
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.intermediate_size_per_partition = 2
+        self.expert_map = None
+        self.quant_method = None
+        self.w13_weight = nn.Parameter(
+            torch.zeros(2, 4, 3, dtype=dtype),
+            requires_grad=False,
+        )
+        self.w2_weight = nn.Parameter(
+            torch.zeros(2, 3, 2, dtype=dtype),
+            requires_grad=False,
+        )
+
+
+class FakeFp8BlockFusedMoE(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.tp_rank = 0
+        self.tp_size = 1
+        self.intermediate_size_per_partition = 2
+        self.expert_map = None
+        self.quant_method = object()
+        self.w13_weight = nn.Parameter(
+            torch.zeros(1, 4, 4).to(torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        self.w2_weight = nn.Parameter(
+            torch.zeros(1, 4, 2).to(torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        self.w13_weight_scale = nn.Parameter(
+            torch.ones(1, 2, 2),
+            requires_grad=False,
+        )
+        self.w2_weight_scale = nn.Parameter(
+            torch.ones(1, 2, 1),
+            requires_grad=False,
+        )
+
+
+def _write_adapter(path, tensors, r=2, alpha=4):
+    path.mkdir()
+    (path / "adapter_config.json").write_text(
+        json.dumps({"r": r, "lora_alpha": alpha, "target_modules": ["q_proj"]}),
+        encoding="utf-8",
+    )
+    save_file(tensors, path / "adapter_model.safetensors")
+
+
+def test_parse_lora_module_entry_supports_name_equals_path():
+    assert parse_lora_module_entry("adapter=/tmp/lora").name == "adapter"
+    assert parse_lora_module_entry("/tmp/my-lora").name == "my-lora"
+
+
+def test_parse_lora_tensor_name_strips_peft_prefix_and_default_slot():
+    parsed = parse_lora_tensor_name(
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_A.default.weight"
+    )
+    assert parsed == ("model.layers.0.self_attn.q_proj", "A")
+
+
+def test_lora_scaling_respects_zero_alpha_pattern(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    lora_a = torch.ones(2, 3)
+    lora_b = torch.ones(4, 2)
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.q_proj.lora_A.weight": lora_a,
+            "base_model.model.q_proj.lora_B.weight": lora_b,
+        },
+    )
+    config_path = adapter_path / "adapter_config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["alpha_pattern"] = {"q_proj": 0}
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    pairs = load_lora_tensors(str(adapter_path))
+
+    assert pairs[0].scaling == 0.0
+
+
+def test_slice_row_parallel_lora_shards_input_dim():
+    module = FakeLinear(input_size=3, output_size=2, tp_dim=1, tp_rank=1, tp_size=2)
+    lora_a = torch.arange(12, dtype=torch.float32).reshape(2, 6)
+    lora_b = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+
+    local_a, local_b, output_offset = slice_lora_tensors_for_module(
+        module, lora_a, lora_b, shard_id=None
+    )
+
+    assert torch.equal(local_a, lora_a[:, 3:6])
+    assert torch.equal(local_b, lora_b)
+    assert output_offset is None
+
+
+def test_slice_merged_column_lora_shards_output_dim():
+    module = FakeLinear(
+        input_size=3,
+        output_size=7,
+        tp_dim=0,
+        tp_rank=1,
+        tp_size=2,
+        output_sizes=[6, 8],
+    )
+    lora_a = torch.ones(1, 3)
+    lora_b = torch.arange(8, dtype=torch.float32).reshape(8, 1)
+
+    local_a, local_b, output_offset = slice_lora_tensors_for_module(
+        module, lora_a, lora_b, shard_id=1
+    )
+
+    assert torch.equal(local_a, lora_a)
+    assert torch.equal(local_b, lora_b[4:8])
+    assert output_offset == 3
+
+
+def test_apply_lora_adapters_loads_packed_qkv_adapter(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    lora_a = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    lora_b = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.q_proj.lora_A.weight": lora_a,
+            "base_model.model.q_proj.lora_B.weight": lora_b,
+        },
+    )
+    model = nn.Module()
+    model.qkv_proj = FakeQKVLinear()
+
+    apply_lora_adapters(
+        model,
+        [f"test={adapter_path}"],
+        packed_modules_mapping={"q_proj": ("qkv_proj", "q")},
+    )
+
+    loaded_a, loaded_b, scaling, output_offset, kwargs = model.qkv_proj.loaded_loras[0]
+    assert torch.equal(loaded_a.cpu(), lora_a.to(torch.bfloat16))
+    assert torch.equal(loaded_b.cpu(), lora_b[2:4].to(torch.bfloat16))
+    assert scaling == 2.0
+    assert output_offset == 0
+    assert kwargs["adapter_name"] == "test"
+
+
+def test_qkvg_q_lora_targets_q_slice_after_gate_slice():
+    module = FakeQKVGLinear()
+    lora_a = torch.ones(2, 3)
+    lora_b = torch.arange(16, dtype=torch.float32).reshape(8, 2)
+
+    _, local_b, output_offset = slice_lora_tensors_for_module(
+        module, lora_a, lora_b, shard_id="q"
+    )
+
+    assert torch.equal(
+        local_b,
+        torch.cat([lora_b[5:6], lora_b[7:8], lora_b[4:5], lora_b[6:7]], dim=0),
+    )
+    assert output_offset == 0
+
+
+def test_apply_lora_adapters_maps_glm_shared_expert_down_proj(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    lora_a = torch.arange(12, dtype=torch.float32).reshape(2, 6)
+    lora_b = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.model.layers.10.mlp.shared_experts.down_proj."
+            "lora_A.weight": lora_a,
+            "base_model.model.model.layers.10.mlp.shared_experts.down_proj."
+            "lora_B.weight": lora_b,
+        },
+    )
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.layers = nn.ModuleList(nn.Module() for _ in range(11))
+    model.model.layers[10].mlp = nn.Module()
+    model.model.layers[10].mlp.shared_experts = nn.Module()
+    model.model.layers[10].mlp.shared_experts.w2 = FakeLinear(
+        input_size=3,
+        output_size=4,
+        tp_dim=1,
+        tp_rank=1,
+        tp_size=2,
+    )
+
+    apply_lora_adapters(
+        model,
+        [f"test={adapter_path}"],
+        packed_modules_mapping={
+            "shared_experts.down_proj": ("shared_experts.w2", None)
+        },
+    )
+
+    loaded_a, loaded_b, scaling, output_offset, _ = (
+        model.model.layers[10].mlp.shared_experts.w2.loaded_loras[0]
+    )
+    assert torch.equal(loaded_a.cpu(), lora_a[:, 3:6].to(torch.bfloat16))
+    assert torch.equal(loaded_b.cpu(), lora_b.to(torch.bfloat16))
+    assert scaling == 2.0
+    assert output_offset is None
+
+
+def test_apply_lora_adapters_merges_routed_expert_lora_into_bf16_moe(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    gate_a = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    gate_b = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    down_a = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    down_b = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.model.layers.10.mlp.experts.1.gate_proj."
+            "lora_A.weight": gate_a,
+            "base_model.model.model.layers.10.mlp.experts.1.gate_proj."
+            "lora_B.weight": gate_b,
+            "base_model.model.model.layers.10.mlp.experts.1.down_proj."
+            "lora_A.weight": down_a,
+            "base_model.model.model.layers.10.mlp.experts.1.down_proj."
+            "lora_B.weight": down_b,
+        },
+    )
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.layers = nn.ModuleList(nn.Module() for _ in range(11))
+    model.model.layers[10].mlp = nn.Module()
+    model.model.layers[10].mlp.experts = FakeFusedMoE()
+
+    apply_lora_adapters(model, [f"test={adapter_path}"])
+
+    experts = model.model.layers[10].mlp.experts
+    assert torch.allclose(
+        experts.w13_weight[1, :2].float(),
+        (gate_b[2:4] @ gate_a * 2.0).bfloat16().float(),
+    )
+    assert torch.allclose(
+        experts.w2_weight[1].float(),
+        (down_b @ down_a[:, 2:4] * 2.0).bfloat16().float(),
+    )
+
+
+def test_apply_lora_adapters_merges_routed_expert_lora_into_fp8_block_moe(
+    tmp_path,
+):
+    adapter_path = tmp_path / "adapter"
+    lora_a = torch.ones(1, 4)
+    lora_b = torch.ones(2, 1)
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.model.layers.0.mlp.experts.0.gate_proj."
+            "lora_A.weight": lora_a,
+            "base_model.model.model.layers.0.mlp.experts.0.gate_proj."
+            "lora_B.weight": lora_b,
+            "base_model.model.model.layers.0.mlp.experts.0.up_proj."
+            "lora_A.weight": lora_a.clone(),
+            "base_model.model.model.layers.0.mlp.experts.0.up_proj."
+            "lora_B.weight": lora_b * 2,
+        },
+        r=1,
+        alpha=1,
+    )
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.layers = nn.ModuleList([nn.Module()])
+    model.model.layers[0].mlp = nn.Module()
+    model.model.layers[0].mlp.experts = FakeFp8BlockFusedMoE()
+
+    apply_lora_adapters(model, [f"test={adapter_path}"])
+
+    experts = model.model.layers[0].mlp.experts
+    dequant = _dequantize_fp8_blocks(
+        experts.w13_weight[0, :2],
+        experts.w13_weight_scale[0, :1],
+        block_n=2,
+        block_k=2,
+    )
+    assert torch.allclose(dequant, torch.ones(2, 4), atol=0.125)
+    dequant = _dequantize_fp8_blocks(
+        experts.w13_weight[0, 2:],
+        experts.w13_weight_scale[0, 1:],
+        block_n=2,
+        block_k=2,
+    )
+    assert torch.allclose(dequant, torch.full((2, 4), 2.0), atol=0.25)
+
+
+def test_resolve_lora_target_rejects_routed_fused_moe_experts():
+    with pytest.raises(NotImplementedError, match="routed FusedMoE expert"):
+        resolve_lora_target(
+            "model.layers.10.mlp.experts.0.down_proj",
+            {},
+            {},
+        )
+
+
+def test_validate_lora_adapters_accepts_routed_fused_moe_experts(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.model.layers.10.mlp.experts.0.down_proj."
+            "lora_A.weight": torch.ones(2, 3),
+            "base_model.model.model.layers.10.mlp.experts.0.down_proj."
+            "lora_B.weight": torch.ones(4, 2),
+        },
+    )
+
+    validate_lora_adapters_supported([f"user={adapter_path}"])

--- a/tests/test_lora_loader.py
+++ b/tests/test_lora_loader.py
@@ -114,6 +114,21 @@ class FakeFp8BlockFusedMoE(nn.Module):
         )
 
 
+class FakeParallelLMHead(nn.Module):
+    def __init__(self, tp_rank=1, tp_size=2):
+        super().__init__()
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.num_embeddings = 6
+        self.num_embeddings_per_partition = self.num_embeddings // self.tp_size
+        self.vocab_start_idx = self.num_embeddings_per_partition * self.tp_rank
+        self.vocab_end_idx = self.vocab_start_idx + self.num_embeddings_per_partition
+        self.weight = nn.Parameter(
+            torch.zeros(self.num_embeddings_per_partition, 4, dtype=torch.bfloat16),
+            requires_grad=False,
+        )
+
+
 def _write_adapter(path, tensors, r=2, alpha=4):
     path.mkdir()
     (path / "adapter_config.json").write_text(
@@ -154,6 +169,20 @@ def test_lora_scaling_respects_zero_alpha_pattern(tmp_path):
     pairs = load_lora_tensors(str(adapter_path))
 
     assert pairs[0].scaling == 0.0
+
+
+def test_load_lora_tensors_rejects_non_2d_tensors(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.q_proj.lora_A.weight": torch.ones(2, 3, 1),
+            "base_model.model.q_proj.lora_B.weight": torch.ones(4, 2),
+        },
+    )
+
+    with pytest.raises(ValueError, match="q_proj.*must be 2D"):
+        load_lora_tensors(str(adapter_path))
 
 
 def test_slice_row_parallel_lora_shards_input_dim():
@@ -217,6 +246,18 @@ def test_apply_lora_adapters_loads_packed_qkv_adapter(tmp_path):
     assert scaling == 2.0
     assert output_offset == 0
     assert kwargs["adapter_name"] == "test"
+
+
+def test_slice_lora_tensors_rejects_b_output_mismatch():
+    module = FakeLinear(input_size=3, output_size=4)
+
+    with pytest.raises(ValueError, match="LoRA B output mismatch"):
+        slice_lora_tensors_for_module(
+            module,
+            torch.ones(2, 3),
+            torch.ones(5, 2),
+            shard_id=None,
+        )
 
 
 def test_qkvg_q_lora_targets_q_slice_after_gate_slice():
@@ -362,6 +403,26 @@ def test_apply_lora_adapters_merges_routed_expert_lora_into_fp8_block_moe(
     assert torch.allclose(dequant, torch.full((2, 4), 2.0), atol=0.25)
 
 
+def test_apply_lora_adapters_merges_vocab_parallel_lm_head(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    lora_a = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    lora_b = torch.arange(12, dtype=torch.float32).reshape(6, 2)
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.lm_head.lora_A.weight": lora_a,
+            "base_model.model.lm_head.lora_B.weight": lora_b,
+        },
+    )
+    model = nn.Module()
+    model.lm_head = FakeParallelLMHead()
+
+    apply_lora_adapters(model, [f"test={adapter_path}"])
+
+    expected = (lora_b[3:6] @ lora_a * 2.0).to(torch.bfloat16)
+    assert torch.equal(model.lm_head.weight, expected)
+
+
 def test_resolve_lora_target_rejects_routed_fused_moe_experts():
     with pytest.raises(NotImplementedError, match="routed FusedMoE expert"):
         resolve_lora_target(
@@ -384,3 +445,62 @@ def test_validate_lora_adapters_accepts_routed_fused_moe_experts(tmp_path):
     )
 
     validate_lora_adapters_supported([f"user={adapter_path}"])
+
+
+def test_validate_lora_adapters_requires_config(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    adapter_path.mkdir()
+    save_file(
+        {
+            "base_model.model.q_proj.lora_A.weight": torch.ones(2, 3),
+            "base_model.model.q_proj.lora_B.weight": torch.ones(4, 2),
+        },
+        adapter_path / "adapter_model.safetensors",
+    )
+
+    with pytest.raises(FileNotFoundError, match="adapter_config.json"):
+        validate_lora_adapters_supported([f"user={adapter_path}"])
+
+
+def test_validate_lora_adapters_rejects_invalid_config_json(tmp_path):
+    adapter_path = tmp_path / "adapter"
+    adapter_path.mkdir()
+    save_file(
+        {
+            "base_model.model.q_proj.lora_A.weight": torch.ones(2, 3),
+            "base_model.model.q_proj.lora_B.weight": torch.ones(4, 2),
+        },
+        adapter_path / "adapter_model.safetensors",
+    )
+    (adapter_path / "adapter_config.json").write_text("{not json")
+
+    with pytest.raises(json.JSONDecodeError):
+        validate_lora_adapters_supported([f"user={adapter_path}"])
+
+
+def test_apply_lora_adapters_does_not_count_nonlocal_routed_experts(
+    tmp_path,
+    caplog,
+):
+    adapter_path = tmp_path / "adapter"
+    _write_adapter(
+        adapter_path,
+        {
+            "base_model.model.model.layers.0.mlp.experts.0.down_proj."
+            "lora_A.weight": torch.ones(2, 3),
+            "base_model.model.model.layers.0.mlp.experts.0.down_proj."
+            "lora_B.weight": torch.ones(4, 2),
+        },
+    )
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.layers = nn.ModuleList([nn.Module()])
+    model.model.layers[0].mlp = nn.Module()
+    experts = nn.Module()
+    experts.expert_map = torch.tensor([-1])
+    model.model.layers[0].mlp.experts = experts
+
+    with caplog.at_level("INFO", logger="atom"):
+        apply_lora_adapters(model, [f"test={adapter_path}"])
+
+    assert "Loaded 0 static LoRA tensor pairs" in caplog.text


### PR DESCRIPTION
## Summary
- add `--lora-modules` startup argument for PEFT-style LoRA adapters
- load `adapter_config.json` and `adapter_model.safetensors` without requiring `peft`
- apply static LoRA deltas in linear forward paths, including TP slicing for row, column, packed MergedColumn, and QKV modules

## Notes
- this is startup-static LoRA support: loaded adapters are applied to every request
- dynamic per-request adapter routing is intentionally not included

## Tests
- `python3 -m py_compile atom/model_loader/lora.py atom/model_ops/linear.py atom/model_engine/arg_utils.py atom/config.py atom/model_engine/model_runner.py`
- `python3 -m pytest -q tests/test_lora_loader.py tests/test_arg_utils_spec.py tests/test_quant_config.py`
- on amd in `rocm/atom-dev:latest`: same pytest target passed
- on amd: parsed cached user GLM LoRA adapter with 4533 tensor pairs and verified all 4533 pairs resolve through the static LoRA mapping smoke`