### PR TITLE
[Bugfix] Align the qknorm_fuse operator with the AITER API.

### DIFF
--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -156,16 +156,23 @@ def _fuse_qk_rmsnorm(
     k_nope: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Fuse q/k RMSNorm without quantizing q."""
-    from atom.models.deepseek_v2 import _fused_qk_rmsnorm
-
-    return _fused_qk_rmsnorm(
+    (q_normed, _), _, k_nope_normed, _ = _fuse_rmsnorm_quant(
         q,
         attn.q_a_layernorm.weight,
         attn.q_a_layernorm.eps,
         k_nope,
         attn.kv_a_layernorm.weight,
         attn.kv_a_layernorm.eps,
+        None,
+        dtype_quant=torch.bfloat16,
+        shuffle=False,
+        scale_shuffle_padding=False,
+        group_size=128,
+        quant_type=None,
+        output_unquantized_inp1=False,
+        transpose_scale=False,
     )
+    return q_normed, k_nope_normed
 
 
 def _prepare_weight_for_bmm(


### PR DESCRIPTION
## Motivation
fix Error:
<img width="916" height="387" alt="image" src="https://github.com/user-attachments/assets/fa1c253a-14a0-4241-b11e-6309f6dc4c86" />

Align the qknorm_fuse operator with the AITER API in sgl+ATOM.

## Command
```

model_path=/models/DeepSeek-R1-0528-MXFP4/
export PYTHONPATH=/workspace/dpsk-fp4/sglang/python:/workspace/dpsk-fp4/ATOM/ATOM_main/ATOM
export SGLANG_PROFILE_RECORD_SHAPES=1
export SGLANG_PROFILE_WITH_STACK=1
export SGLANG_TORCH_PROFILER_DIR=/workspace/dpsk-fp4/sglang/profile_log

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models

rm -rf logs/*

export SGLANG_ENABLE_TORCH_COMPILE=128

MAX_RUNNING_REQUESTS=24
export SGLANG_MORI_DISPATCH_DTYPE=bf16
export SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK=16384

python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --data-parallel-size 4 \
    --expert-parallel-size 4 \
    --enable-dp-attention \
    --kv-cache-dtype fp8_e4m3 \
    --attention-backend aiter \
    --mem-fraction-static 0.8 \
    --decode-log-interval 1000 \
    --chunked-prefill-size 65536 \
    --max-running-requests "${MAX_RUNNING_REQUESTS}" \
    --disable-radix-cache
```


## ACC
```
Generating test split: 100%|██████████| 1319/1319 [00:00<00:00, 310001.51 examples/s]
2026-05-18:07:15:15 INFO     [evaluator_utils:446] Selected tasks:
2026-05-18:07:15:15 INFO     [evaluator_utils:480] Task: gsm8k (gsm8k/gsm8k.yaml)
2026-05-18:07:15:15 INFO     [evaluator:314] gsm8k: Using gen_kwargs: {'until': ['Question:', '</s>', '<|im_end|>'], 'do_sample': False, 'temperature': 0.0}
2026-05-18:07:15:15 WARNING  [evaluator:333] Overwriting default num_fewshot of gsm8k from 5 to 3
2026-05-18:07:15:15 INFO     [api.task:312] Building contexts for gsm8k on rank 0...
100%|██████████| 1319/1319 [00:01<00:00, 1064.45it/s]
2026-05-18:07:15:16 INFO     [evaluator:585] Running generate_until requests
2026-05-18:07:15:16 INFO     [models.api_models:747] Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 100%|██████████| 1319/1319 [06:44<00:00,  3.26it/s]
2026-05-18:07:22:01 INFO     [loggers.evaluation_tracker:316] Output path not provided, skipping saving results aggregated
local-completions ({'model': '/models/DeepSeek-R1-0528/', 'base_url': 'http://localhost:8000/v1/completions', 'num_concurrent': 65, 'max_retries': 1, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 3, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9424|±  |0.0064|
|     |       |strict-match    |     3|exact_match|↑  |0.9371|±  |0.0067|
```