### PR TITLE
CI: extend aiter wheel artifact retention

### DIFF
--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -192,7 +192,7 @@ jobs:
         with:
           name: aiter-whl
           path: aiter-whl/amd_aiter*.whl
-          retention-days: 1
+          retention-days: 7
 
   atom-sglang-accuracy:
     needs: [check-signal, download_aiter_wheel]

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -199,7 +199,7 @@ jobs:
         with:
           name: aiter-whl
           path: aiter-whl/amd_aiter*.whl
-          retention-days: 1
+          retention-days: 7
 
   load-test-models:
     name: Load test model configs

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -192,7 +192,7 @@ jobs:
         with:
           name: aiter-whl
           path: aiter-whl/amd_aiter*.whl
-          retention-days: 1
+          retention-days: 7
 
   atom-vllm-oot:
     needs: [check-signal, download_aiter_wheel]


### PR DESCRIPTION
## Summary
- Extend the `aiter-whl` artifact retention from 1 day to 7 days in ATOM accuracy workflows.
- Apply the same retention window to the ATOM, SGLang, and vLLM test workflows so reruns after a day can still download the wheel artifact.

## Test plan
- Verified the workflow diff only updates `retention-days` for `aiter-whl` uploads.
- Ran `git diff --check`.