### PR TITLE
Add atom Qwen3.5 multimodal 

### DIFF
--- a/.github/scripts/atom_mmstar_ci.sh
+++ b/.github/scripts/atom_mmstar_ci.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_PATH="${MODEL_PATH:-/models/Qwen/Qwen3.5-35B-A3B-FP8}"
+ATOM_PORT="${ATOM_PORT:-8000}"
+RESULT_DIR="${RESULT_DIR:-/tmp/atom_mmstar_results}"
+LIMIT="${LIMIT:-}"
+MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-8192}"
+NUM_CONCURRENT="${NUM_CONCURRENT:-64}"
+TIMEOUT="${TIMEOUT:-900}"
+MMSTAR_THRESHOLD="${MMSTAR_THRESHOLD:-0.72}"
+SERVER_READY_RETRIES="${SERVER_READY_RETRIES:-90}"
+SERVER_READY_INTERVAL="${SERVER_READY_INTERVAL:-30}"
+SERVER_LOG="${SERVER_LOG:-/tmp/atom_mmstar_server.log}"
+CLIENT_LOG="${CLIENT_LOG:-/tmp/atom_mmstar_client.log}"
+EXTRA_SERVER_ARGS="${EXTRA_SERVER_ARGS:-}"
+
+SERVER_PID=""
+
+cleanup() {
+  if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "=== MMStar CI configuration ==="
+echo "MODEL_PATH=${MODEL_PATH}"
+echo "ATOM_PORT=${ATOM_PORT}"
+echo "RESULT_DIR=${RESULT_DIR}"
+echo "LIMIT=${LIMIT}"
+echo "MAX_NEW_TOKENS=${MAX_NEW_TOKENS}"
+echo "NUM_CONCURRENT=${NUM_CONCURRENT}"
+echo "MMSTAR_THRESHOLD=${MMSTAR_THRESHOLD}"
+
+mkdir -p "${RESULT_DIR}"
+rm -f "${SERVER_LOG}" "${CLIENT_LOG}"
+
+echo "=== Installed package versions ==="
+python3 - <<'PY'
+import importlib.metadata as md
+
+for name in ("torch", "torchvision", "torchaudio", "transformers", "accelerate", "vllm", "lmms-eval", "atom"):
+    try:
+        version = md.version(name)
+    except md.PackageNotFoundError:
+        version = "<not-installed>"
+    print(f"{name}=={version}")
+PY
+
+echo "=== Launching ATOM OpenAI server ==="
+read -r -a extra_server_args <<< "${EXTRA_SERVER_ARGS}"
+PYTHONUNBUFFERED=1 python3 -m atom.entrypoints.openai_server \
+  --model "${MODEL_PATH}" \
+  --server-port "${ATOM_PORT}" \
+  --no-enable_prefix_caching \
+  "${extra_server_args[@]}" \
+  > "${SERVER_LOG}" 2>&1 &
+SERVER_PID=$!
+
+for ((i=1; i<=SERVER_READY_RETRIES; i++)); do
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo "ATOM server exited before becoming ready." >&2
+    tail -200 "${SERVER_LOG}" || true
+    exit 1
+  fi
+
+  if curl -fsS "http://127.0.0.1:${ATOM_PORT}/health" >/dev/null 2>&1; then
+    echo "ATOM server health endpoint is ready."
+    break
+  fi
+
+  if (( i == SERVER_READY_RETRIES )); then
+    echo "ATOM server did not become ready in time." >&2
+    tail -200 "${SERVER_LOG}" || true
+    exit 1
+  fi
+
+  echo "Waiting for ATOM server... (${i}/${SERVER_READY_RETRIES})"
+  sleep "${SERVER_READY_INTERVAL}"
+done
+
+echo "=== Running lmms-eval MMStar ==="
+lmms_eval_args=(
+  --model openai \
+  --model_args "model=${MODEL_PATH},base_url=http://127.0.0.1:${ATOM_PORT}/v1,api_key=EMPTY,timeout=${TIMEOUT},max_retries=3,num_concurrent=${NUM_CONCURRENT},max_size_in_mb=50" \
+  --tasks mmstar \
+  --batch_size 1 \
+  --process_with_media \
+  --gen_kwargs "temperature=0,max_new_tokens=${MAX_NEW_TOKENS}" \
+  --log_samples \
+  --log_samples_suffix atom_mmstar_ci \
+  --output_path "${RESULT_DIR}"
+)
+if [[ -n "${LIMIT}" ]]; then
+  lmms_eval_args+=(--limit "${LIMIT}")
+fi
+
+python3 -m lmms_eval "${lmms_eval_args[@]}" 2>&1 | tee "${CLIENT_LOG}"
+
+echo "=== Checking MMStar score ==="
+RESULT_DIR="${RESULT_DIR}" MMSTAR_THRESHOLD="${MMSTAR_THRESHOLD}" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+result_dir = Path(os.environ["RESULT_DIR"])
+threshold = float(os.environ["MMSTAR_THRESHOLD"])
+json_files = sorted(result_dir.rglob("*.json"), key=lambda path: path.stat().st_mtime_ns)
+if not json_files:
+    raise SystemExit(f"No lmms-eval result JSON found under {result_dir}")
+
+result_file = json_files[-1]
+with result_file.open(encoding="utf-8") as handle:
+    data = json.load(handle)
+
+metrics = data["results"]["mmstar"]
+if "average" in metrics:
+    score = float(metrics["average"])
+elif "average,none" in metrics:
+    score = float(metrics["average,none"])
+else:
+    raise SystemExit(f"Could not find MMStar average in {result_file}; keys={sorted(metrics)}")
+
+print(f"Result file: {result_file}")
+print(f"MMStar average: {score:.4f}")
+print(f"Threshold: {threshold:.4f}")
+if score < threshold:
+    raise SystemExit(f"MMStar score {score:.4f} is below threshold {threshold:.4f}")
+PY
+
+echo "MMStar CI check passed."

--- a/.github/scripts/install_lmms_eval_no_deps.sh
+++ b/.github/scripts/install_lmms_eval_no_deps.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LMMS_EVAL_REF="${LMMS_EVAL_REF:-4510f3e9c04be1952b71caea331822e6ddf73d2f}"
+LMMS_EVAL_REPO="${LMMS_EVAL_REPO:-https://github.com/EvolvingLMMs-Lab/lmms-eval.git}"
+LMMS_EVAL_SRC_DIR="${LMMS_EVAL_SRC_DIR:-/opt/lmms-eval}"
+
+snapshot_protected_versions() {
+  python3 - <<'PY'
+import importlib.metadata as md
+
+for name in ("torch", "torchvision", "torchaudio", "transformers", "vllm"):
+    try:
+        version = md.version(name)
+    except md.PackageNotFoundError:
+        version = "<not-installed>"
+    print(f"{name}=={version}")
+PY
+}
+
+before="$(mktemp)"
+after="$(mktemp)"
+trap 'rm -f "${before}" "${after}"' EXIT
+
+echo "=== Protected package versions before lmms-eval install ==="
+snapshot_protected_versions | tee "${before}"
+
+echo "=== Installing lmms-eval from source with --no-deps ==="
+echo "LMMS_EVAL_REPO=${LMMS_EVAL_REPO}"
+echo "LMMS_EVAL_REF=${LMMS_EVAL_REF}"
+echo "LMMS_EVAL_SRC_DIR=${LMMS_EVAL_SRC_DIR}"
+if [[ -d "${LMMS_EVAL_SRC_DIR}/.git" ]]; then
+  git -C "${LMMS_EVAL_SRC_DIR}" fetch --all --tags
+else
+  rm -rf "${LMMS_EVAL_SRC_DIR}"
+  git clone "${LMMS_EVAL_REPO}" "${LMMS_EVAL_SRC_DIR}"
+fi
+git -C "${LMMS_EVAL_SRC_DIR}" checkout "${LMMS_EVAL_REF}"
+python3 -m pip install --no-deps --force-reinstall -e "${LMMS_EVAL_SRC_DIR}"
+
+# Install only lmms-eval runtime dependencies that are safe to add without
+# letting pip resolve/upgrade the ROCm torch stack. Keep torch, torchvision,
+# torchaudio, transformers, vllm, numpy, and triton out of this list.
+echo "=== Installing lmms-eval helper packages with --no-deps ==="
+python3 -m pip install --no-deps \
+  "accelerate>=0.29.1" \
+  "av<16.0.0" \
+  "datasets>=2.19.0" \
+  "evaluate>=0.4.0" \
+  "jsonlines" \
+  "aiohttp" \
+  "numexpr" \
+  "peft>=0.2.0" \
+  "pybind11>=2.6.2" \
+  "pytablewriter" \
+  "sacrebleu>=1.5.0" \
+  "scikit-learn>=0.24.1" \
+  "timm" \
+  "einops" \
+  "ftfy" \
+  "openai" \
+  "httpx>=0.23.3" \
+  "httpcore" \
+  "h11" \
+  "anyio" \
+  "sniffio" \
+  "distro" \
+  "jiter" \
+  "certifi" \
+  "idna" \
+  "typing-extensions" \
+  "opencv-python-headless" \
+  "hf-transfer" \
+  "nltk" \
+  "sentencepiece" \
+  "yt-dlp" \
+  "pycocoevalcap" \
+  "tqdm-multiprocess" \
+  "transformers-stream-generator" \
+  "zstandard" \
+  "pillow" \
+  "pyyaml" \
+  "sympy" \
+  "latex2sympy2" \
+  "mpmath" \
+  "Jinja2" \
+  "openpyxl" \
+  "loguru" \
+  "tenacity>=8.3.0" \
+  "math-verify" \
+  "wandb==0.25.0" \
+  "tqdm>4" \
+  "tiktoken" \
+  "pydantic" \
+  "pydantic-core" \
+  "annotated-types>=0.6.0" \
+  "typing-inspection>=0.4.2" \
+  "packaging" \
+  "pre-commit" \
+  "zss" \
+  "protobuf" \
+  "python-dotenv" \
+  "qwen-vl-utils>=0.0.14" \
+  "decord"
+
+# Let pip resolve this small pure-Python client stack. Installing these with
+# --no-deps is brittle because openai/pydantic/httpx add runtime dependencies
+# such as sniffio, pydantic-core, and typing-inspection.
+echo "=== Installing OpenAI client helper dependencies ==="
+python3 -m pip install \
+  "openai" \
+  "httpx>=0.23.3" \
+  "pydantic" \
+  "tqdm>4" \
+  "tenacity>=8.3.0"
+
+echo "=== Protected package versions after lmms-eval install ==="
+snapshot_protected_versions | tee "${after}"
+
+if ! diff -u "${before}" "${after}"; then
+  echo "ERROR: lmms-eval installation changed protected package versions." >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+from pathlib import Path
+import importlib.metadata as md
+import anyio
+import httpx
+import lmms_eval
+import openai
+import pydantic
+import sniffio
+import tenacity
+import tqdm
+from lmms_eval.models.chat.openai import OpenAICompatible
+
+root = Path(lmms_eval.__file__).resolve().parent
+template = root / "tasks" / "prismm_bench" / "_default_template_yaml"
+if not template.exists():
+    raise SystemExit(f"ERROR: missing lmms-eval task template: {template}")
+print(f"Verified lmms-eval source install: {root}")
+print(f"Verified lmms-eval OpenAI backend import: {OpenAICompatible.__name__}")
+print(
+    "Verified OpenAI backend dependencies: "
+    f"openai={md.version('openai')}, httpx={md.version('httpx')}, "
+    f"anyio={md.version('anyio')}, sniffio={md.version('sniffio')}, "
+    f"pydantic={md.version('pydantic')}, tqdm={md.version('tqdm')}, "
+    f"tenacity={md.version('tenacity')}"
+)
+PY
+
+echo "lmms-eval install verified: protected package versions are unchanged."

--- a/.github/workflows/atom-mmstar-ci.yaml
+++ b/.github/workflows/atom-mmstar-ci.yaml
@@ -1,0 +1,295 @@
+name: ATOM Test
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
+  schedule:
+    # Daily at 03:00 Beijing time (19:00 UTC on the previous day).
+    - cron: "0 19 * * *"
+  workflow_dispatch:
+    # Manual runs use GitHub Actions' built-in branch dropdown ("Use workflow
+    # from") as the ATOM branch selector.
+    inputs:
+      run_qwen35_35b_a3b_fp8:
+        description: "Qwen3.5-35B-A3B-FP8 MMStar"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  # Keep scheduled main runs from blocking branch/PR validation.
+  group: ATOM-MMStar-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  ATOM_BASE_IMAGE: rocm/atom-dev:latest
+
+jobs:
+  prepare-mmstar-matrix:
+    name: Prepare MMStar model matrix
+    runs-on: ubuntu-latest
+    outputs:
+      model_matrix: ${{ steps.matrix.outputs.model_matrix }}
+    steps:
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+
+      - name: Resolve model matrix
+        id: matrix
+        env:
+          RUN_QWEN35_35B_A3B_FP8: ${{ inputs.run_qwen35_35b_a3b_fp8 }}
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          import sys
+
+          event = os.environ["GITHUB_EVENT_NAME"]
+          models = [
+              {
+                  "toggle_env": "RUN_QWEN35_35B_A3B_FP8",
+                  "model_name": "Qwen3.5-35B-A3B-FP8 MMStar",
+                  "model_path": "Qwen/Qwen3.5-35B-A3B-FP8",
+                  "extra_args": "--no-enable_prefix_caching",
+                  "env_vars": "",
+                  "runner": "linux-atom-mi35x-1",
+                  "mmstar_limit": "",
+                  "mmstar_threshold": 0.72,
+                  "max_new_tokens": 8192,
+              },
+          ]
+
+          selected = []
+          for model in models:
+              enabled = event != "workflow_dispatch" or os.environ.get(model["toggle_env"], "").lower() == "true"
+              if enabled:
+                  selected.append({k: v for k, v in model.items() if k != "toggle_env"})
+
+          if event == "workflow_dispatch" and not selected:
+              print("No models selected for manual MMStar run.", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"model_matrix={json.dumps({'include': selected})}")
+          PY
+
+  mmstar-model-accuracy:
+    name: MMStar Accuracy (${{ matrix.model_name }})
+    needs: [prepare-mmstar-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare-mmstar-matrix.outputs.model_matrix) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 240
+    env:
+      CONTAINER_NAME: atom_mmstar_validation_${{ strategy.job-index }}
+    steps:
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+
+      - name: Docker Login
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Set HF_TOKEN
+        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> "$GITHUB_ENV"
+
+      - name: Prepare model cache mount
+        run: |
+          MODEL_CACHE_MOUNT=""
+          MODEL_CACHE_DESC="container-local /models (no host cache mount)"
+
+          if [ -d "/models" ]; then
+            MODEL_CACHE_MOUNT="-v /models:/models"
+            MODEL_CACHE_DESC="/models (host mount)"
+          else
+            echo "Warning: /models directory not found on runner; using container-local /models."
+          fi
+
+          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
+          echo "MODEL_CACHE_MOUNT=${MODEL_CACHE_MOUNT}" >> "$GITHUB_ENV"
+          echo "MODEL_CACHE_DESC=${MODEL_CACHE_DESC}" >> "$GITHUB_ENV"
+
+      - name: Clean up old containers
+        run: |
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+          docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+      - name: Download latest aiter wheel
+        run: |
+          set -euo pipefail
+          mkdir -p aiter-whl
+          rm -f aiter-whl/amd_aiter*.whl
+
+          manifest_url="https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950/main/latest.json?ts=$(date +%s)"
+          manifest_file="$(mktemp)"
+          curl -fsSL -H "Cache-Control: no-cache" "${manifest_url}" -o "${manifest_file}"
+
+          wheel_url="$(jq -r '.wheel_url // empty' "${manifest_file}")"
+          wheel_name="$(jq -r '.wheel_name // empty' "${manifest_file}")"
+          if [ -z "${wheel_url}" ] || [ -z "${wheel_name}" ]; then
+            echo "Invalid aiter wheel manifest:"
+            cat "${manifest_file}"
+            exit 1
+          fi
+
+          python3 -c 'import sys; from urllib.parse import quote, unquote, urlsplit, urlunsplit; parts = urlsplit(sys.argv[1]); encoded_path = "/".join(quote(unquote(segment), safe="") for segment in parts.path.split("/")); print(urlunsplit((parts.scheme, parts.netloc, encoded_path, parts.query, parts.fragment)))' "${wheel_url}" > /tmp/aiter_wheel_url.txt
+          resolved_wheel_url="$(cat /tmp/aiter_wheel_url.txt)"
+          echo "Downloading aiter wheel: ${wheel_name}"
+          curl -fsSL "${resolved_wheel_url}" -o "aiter-whl/${wheel_name}"
+
+      - name: Start validation container
+        run: |
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+
+          MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
+          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
+
+          cat > /tmp/mmstar_env_file.txt << 'EOF'
+          ${{ matrix.env_vars }}
+          EOF
+
+          docker pull "${ATOM_BASE_IMAGE}"
+          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
+            -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
+            $MODEL_MOUNT \
+            -w /workspace \
+            --ipc=host --group-add video \
+            --shm-size=16G \
+            --privileged \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            --ulimit memlock=-1 \
+            --ulimit stack=67108864 \
+            --env-file /tmp/mmstar_env_file.txt \
+            -e HF_TOKEN="${HF_TOKEN:-}" \
+            --name "$CONTAINER_NAME" \
+            "${ATOM_BASE_IMAGE}"
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install aiter wheel
+        run: |
+          AITER_WHL="$(ls -t aiter-whl/amd_aiter*.whl 2>/dev/null | head -1)"
+          if [ -z "${AITER_WHL}" ]; then
+            echo "ERROR: No amd_aiter wheel found under aiter-whl/"
+            exit 1
+          fi
+          WHL_NAME="$(basename "${AITER_WHL}")"
+          docker cp "${AITER_WHL}" "$CONTAINER_NAME:/tmp/${WHL_NAME}"
+          docker exec "$CONTAINER_NAME" bash -lc "
+            set -euo pipefail
+            python3 -m pip uninstall -y amd-aiter || true
+            python3 -m pip install --no-deps /tmp/${WHL_NAME}
+            python3 -m pip show amd-aiter
+          "
+
+      - name: Install ATOM without dependency resolution
+        run: |
+          docker exec "$CONTAINER_NAME" bash -lc '
+            set -euo pipefail
+            cd /workspace
+            git config --global --add safe.directory /workspace
+            python3 -m pip uninstall -y atom || true
+            python3 -m pip install -e . --no-deps
+            python3 -m pip show atom
+          '
+
+      - name: Install lmms-eval without changing torch stack
+        run: |
+          docker exec "$CONTAINER_NAME" bash -lc '
+            set -euo pipefail
+            cd /workspace
+            bash .github/scripts/install_lmms_eval_no_deps.sh
+          '
+
+      - name: Download model if needed
+        timeout-minutes: 150
+        run: |
+          set -euo pipefail
+          model_dir="/models/${{ matrix.model_path }}"
+          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
+            if ! docker exec \
+              -e HF_TOKEN="${HF_TOKEN:-}" \
+              -e MODEL_ID="${{ matrix.model_path }}" \
+              -e TARGET_DIR="${model_dir}" \
+              -e MODEL_DOWNLOAD_TIMEOUT="${MODEL_DOWNLOAD_TIMEOUT}" \
+              -e MODEL_LOCK_WAIT_SECONDS="${MODEL_LOCK_WAIT_SECONDS}" \
+              -e MODEL_LOCK_POLL_INTERVAL="${MODEL_LOCK_POLL_INTERVAL}" \
+              -e MODEL_PROGRESS_INTERVAL="${MODEL_PROGRESS_INTERVAL}" \
+              "$CONTAINER_NAME" \
+              bash -lc 'bash /workspace/.github/scripts/download_model_with_lock.sh "$MODEL_ID" "$TARGET_DIR"'; then
+              echo "Model download failed for '${{ matrix.model_path }}'. Aborting."
+              exit 1
+            fi
+            echo "MMSTAR_RESOLVED_MODEL_PATH=${model_dir}" >> "$GITHUB_ENV"
+          else
+            echo "/models directory not mounted; using model id/path directly"
+            echo "MMSTAR_RESOLVED_MODEL_PATH=${{ matrix.model_path }}" >> "$GITHUB_ENV"
+          fi
+        env:
+          MODEL_DOWNLOAD_TIMEOUT: "3h"
+          MODEL_LOCK_WAIT_SECONDS: "7200"
+          MODEL_LOCK_POLL_INTERVAL: "30"
+          MODEL_PROGRESS_INTERVAL: "60"
+
+      - name: Run MMStar accuracy
+        timeout-minutes: 180
+        env:
+          MMSTAR_LIMIT: ${{ matrix.mmstar_limit }}
+          MMSTAR_THRESHOLD: ${{ matrix.mmstar_threshold }}
+          MAX_NEW_TOKENS: ${{ matrix.max_new_tokens }}
+          EXTRA_SERVER_ARGS: ${{ matrix.extra_args }}
+        run: |
+          docker exec \
+            -e MODEL_PATH="${MMSTAR_RESOLVED_MODEL_PATH}" \
+            -e LIMIT="${MMSTAR_LIMIT}" \
+            -e MAX_NEW_TOKENS="${MAX_NEW_TOKENS}" \
+            -e MMSTAR_THRESHOLD="${MMSTAR_THRESHOLD}" \
+            -e EXTRA_SERVER_ARGS="${EXTRA_SERVER_ARGS}" \
+            -e RESULT_DIR="/tmp/atom_mmstar_results" \
+            "$CONTAINER_NAME" \
+            bash -lc 'bash /workspace/.github/scripts/atom_mmstar_ci.sh'
+
+      - name: Collect summary
+        if: success()
+        run: |
+          echo "MMStar summary for ${{ matrix.model_name }}:" >> "$GITHUB_STEP_SUMMARY"
+          docker exec "$CONTAINER_NAME" bash -lc "awk '/\|Tasks\|Filter\|/,/^$/ { if (NF > 0) print }' /tmp/atom_mmstar_client.log" >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Collect artifacts
+        if: always()
+        run: |
+          docker cp "$CONTAINER_NAME":/tmp/atom_mmstar_server.log ./atom_mmstar_server.log || true
+          docker cp "$CONTAINER_NAME":/tmp/atom_mmstar_client.log ./atom_mmstar_client.log || true
+          docker cp "$CONTAINER_NAME":/tmp/atom_mmstar_results ./atom_mmstar_results || true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mmstar-validation-${{ matrix.model_name }}-${{ github.run_id }}
+          path: |
+            atom_mmstar_server.log
+            atom_mmstar_client.log
+            atom_mmstar_results
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop "$CONTAINER_NAME" || true
+          docker rm "$CONTAINER_NAME" || true

--- a/atom/config.py
+++ b/atom/config.py
@@ -636,6 +636,16 @@ def get_hf_config(model: str, trust_remote_code: bool = False) -> PretrainedConf
         for field in ("bos_token_id", "eos_token_id", "pad_token_id"):
             if getattr(hf_config, field, None) is None and field in config_dict:
                 setattr(hf_config, field, config_dict[field])
+        if not hasattr(hf_config, "text_config"):
+            hf_config.text_config = hf_config
+        # Store full multimodal config (with vision_config) for vision encoder init
+        try:
+            full_config = AutoConfig.from_pretrained(
+                model, trust_remote_code=trust_remote_code
+            )
+            hf_config._multimodal_config = full_config
+        except Exception:
+            hf_config._multimodal_config = None
         return hf_config
 
     if model_type in _CONFIG_REGISTRY:
@@ -994,6 +1004,8 @@ class Config:
         self.hf_config = get_hf_config(
             self.model, trust_remote_code=self.trust_remote_code
         )
+        # Multimodal config (full config with vision_config) for vision encoder init
+        self.multimodal_config = getattr(self.hf_config, "_multimodal_config", None)
         # transformers 5+ exposes rope_parameters; <5 often only rope_scaling + rope_theta.
         # Synthesize when missing or None so GPT-OSS YaRN (rope_type in rope_scaling) is preserved.
         if getattr(self.hf_config, "rope_parameters", None) is None:

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -14,9 +14,13 @@ Usage:
 
 import argparse
 import asyncio
+import base64
+import binascii
+import io
 import json
 import logging
 import time
+import urllib.request
 import uuid
 from asyncio import AbstractEventLoop
 from contextlib import asynccontextmanager
@@ -29,7 +33,8 @@ from atom.model_engine.llm_engine import _load_tokenizer
 from atom.model_engine.request import RequestOutput
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from transformers import AutoTokenizer
+from PIL import Image
+from transformers import AutoProcessor, AutoTokenizer
 
 from .chat_encoders import apply_chat_template, load_custom_message_encoder
 from .protocol import (
@@ -65,6 +70,7 @@ DEFAULT_PORT = 8000
 
 engine = None
 tokenizer: Optional[AutoTokenizer] = None
+processor: Optional[Any] = None
 model_name: str = ""
 default_chat_template_kwargs: Dict[str, Any] = {}
 custom_message_encoder: Optional[Any] = None
@@ -157,6 +163,115 @@ def _coerce_n(requested_n: Optional[int], temperature: Optional[float]) -> int:
         )
         n = 1
     return n
+
+
+def _has_multimodal_content(messages: List[Any]) -> bool:
+    for message in messages:
+        content = getattr(message, "content", None)
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in {"image", "image_url"}:
+                return True
+    return False
+
+
+def _load_image_from_url(url: str) -> Image.Image:
+    if url.startswith("data:"):
+        try:
+            _, encoded = url.split(",", 1)
+            image_bytes = base64.b64decode(encoded, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise ValueError("Invalid base64 data URL for image_url") from exc
+        return Image.open(io.BytesIO(image_bytes)).convert("RGB")
+
+    if url.startswith(("http://", "https://")):
+        with urllib.request.urlopen(url, timeout=30) as response:
+            image_bytes = response.read()
+        return Image.open(io.BytesIO(image_bytes)).convert("RGB")
+
+    if url.startswith("file://"):
+        url = url[len("file://") :]
+    return Image.open(url).convert("RGB")
+
+
+def _get_multimodal_processor():
+    global processor, model_name
+    if processor is None:
+        logger.info(f"Loading multimodal processor from {model_name}...")
+        processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True)
+    return processor
+
+
+def _prepare_multimodal_inputs(
+    messages: List[Any],
+    chat_template_kwargs: Dict[str, Any],
+) -> Tuple[List[int], Dict[str, Any]]:
+    mm_processor = _get_multimodal_processor()
+    processor_messages: List[Dict[str, Any]] = []
+    images: List[Image.Image] = []
+
+    for message in messages:
+        content = getattr(message, "content", None)
+        if isinstance(content, str) or content is None:
+            processor_messages.append({"role": message.role, "content": content or ""})
+            continue
+
+        image_parts: List[Dict[str, Any]] = []
+        text_parts: List[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type")
+            if part_type == "text":
+                text_parts.append(part.get("text", ""))
+            elif part_type == "image_url":
+                image_url = part.get("image_url", {})
+                url = image_url.get("url") if isinstance(image_url, dict) else None
+                if not url:
+                    raise ValueError(
+                        "image_url content part must include image_url.url"
+                    )
+                image = _load_image_from_url(url)
+                images.append(image)
+                image_parts.append({"type": "image", "image": image})
+            elif part_type == "image":
+                url = part.get("image")
+                if not isinstance(url, str):
+                    raise ValueError(
+                        "image content part must include an image URL/path"
+                    )
+                image = _load_image_from_url(url)
+                images.append(image)
+                image_parts.append({"type": "image", "image": image})
+
+        # Qwen3.5's template reliably emits <|image_pad|> when image entries
+        # precede the text, matching the native offline multimodal example.
+        parts = image_parts
+        if text_parts:
+            parts.append({"type": "text", "text": "\n".join(text_parts)})
+        processor_messages.append({"role": message.role, "content": parts})
+
+    if not images:
+        raise ValueError("Multimodal request did not contain any images")
+
+    template_kwargs = dict(chat_template_kwargs)
+    template_kwargs.pop("tokenize", None)
+    template_kwargs.pop("add_generation_prompt", None)
+    text = mm_processor.apply_chat_template(
+        processor_messages,
+        tokenize=False,
+        add_generation_prompt=True,
+        **template_kwargs,
+    )
+    if images and "<|image_pad|>" not in text:
+        raise ValueError("Multimodal chat template did not emit image placeholders")
+    inputs = mm_processor(text=[text], images=images, return_tensors="pt")
+    multimodal_data = {
+        "pixel_values": inputs["pixel_values"],
+        "image_grid_thw": inputs["image_grid_thw"],
+    }
+    return inputs["input_ids"][0].tolist(), multimodal_data
 
 
 def _send_stream_chunk_direct(
@@ -299,6 +414,86 @@ async def generate_async(
     yield response
 
 
+async def generate_async_multimodal(
+    token_ids: List[int],
+    multimodal_data: Dict[str, Any],
+    sampling_params: SamplingParams,
+    request_id: str,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    """Generate text asynchronously for one multimodal request."""
+    global engine, tokenizer
+
+    token_queue: asyncio.Queue = asyncio.Queue()
+    loop = asyncio.get_running_loop()
+
+    started_at = time.time()
+    first_token_at: Optional[float] = None
+    last_token_at: Optional[float] = None
+    all_token_ids: List[int] = []
+    finish_reason: Optional[str] = None
+    seq = None
+
+    def completion_callback(request_output: RequestOutput):
+        now = time.time()
+        loop.call_soon_threadsafe(
+            token_queue.put_nowait,
+            {
+                "token_ids": request_output.output_tokens,
+                "finished": request_output.finished,
+                "finish_reason": request_output.finish_reason,
+                "ts": now,
+            },
+        )
+
+    def do_preprocess():
+        return engine.io_processor.preprocess(
+            token_ids,
+            sampling_params,
+            stream_callback=completion_callback,
+            multimodal_data=multimodal_data,
+        )
+
+    seq = await loop.run_in_executor(None, do_preprocess)
+    engine.core_mgr.add_request([seq])
+
+    while True:
+        item = await token_queue.get()
+        token_ids_out = item.get("token_ids") or []
+        if token_ids_out:
+            if first_token_at is None:
+                first_token_at = item.get("ts", time.time())
+            last_token_at = item.get("ts", time.time())
+            all_token_ids.extend(token_ids_out)
+        if item.get("finished", False):
+            finish_reason = item.get("finish_reason")
+            break
+
+    text = tokenizer.decode(all_token_ids, skip_special_tokens=True)
+    num_tokens_output = len(all_token_ids)
+    finished_at = time.time()
+    ttft = (first_token_at - started_at) if first_token_at is not None else 0.0
+    tpot = (
+        (last_token_at - first_token_at) / (num_tokens_output - 1)
+        if first_token_at is not None
+        and last_token_at is not None
+        and num_tokens_output > 1
+        else 0.0
+    )
+
+    yield {
+        "text": text,
+        "token_ids": all_token_ids,
+        "finish_reason": finish_reason,
+        "num_tokens_input": (
+            seq.num_prompt_tokens if seq is not None else len(token_ids)
+        ),
+        "num_tokens_output": num_tokens_output,
+        "ttft": ttft,
+        "tpot": tpot,
+        "latency": finished_at - started_at,
+    }
+
+
 async def generate_async_fanout(
     prompt: str,
     sampling_params: SamplingParams,
@@ -406,7 +601,12 @@ async def generate_async_fanout(
 
 def validate_model(requested_model: Optional[str]) -> None:
     """Validate that the requested model matches the server's model."""
-    if requested_model is not None and requested_model != model_name:
+    if requested_model is None:
+        return
+
+    normalized_requested = requested_model.rstrip("/")
+    normalized_served = model_name.rstrip("/")
+    if normalized_requested != normalized_served:
         raise HTTPException(
             status_code=400,
             detail=f"Requested model '{requested_model}' does not match "
@@ -593,14 +793,6 @@ async def chat_completions(request: ChatCompletionRequest):
         if request.chat_template_kwargs:
             merged_kwargs.update(request.chat_template_kwargs)
 
-        prompt = apply_chat_template(
-            tokenizer,
-            custom_message_encoder,
-            [msg.to_template_dict() for msg in messages],
-            tools=request.tools,
-            **merged_kwargs,
-        )
-
         effective_n = _coerce_n(request.n, request.temperature)
         sampling_params = _build_sampling_params(
             temperature=request.temperature,
@@ -615,6 +807,25 @@ async def chat_completions(request: ChatCompletionRequest):
         request_id = f"chatcmpl-{uuid.uuid4().hex}"
 
         _log_request_event("request", request_id, request.model_dump())
+
+        is_multimodal = _has_multimodal_content(messages)
+        if is_multimodal:
+            if request.stream:
+                raise ValueError("Streaming multimodal chat is not supported yet")
+            if effective_n > 1:
+                raise ValueError("Multimodal chat currently supports n=1 only")
+            token_ids, multimodal_data = _prepare_multimodal_inputs(
+                messages,
+                merged_kwargs,
+            )
+        else:
+            prompt = apply_chat_template(
+                tokenizer,
+                custom_message_encoder,
+                [msg.to_template_dict() for msg in messages],
+                tools=request.tools,
+                **merged_kwargs,
+            )
 
         # Streaming
         if request.stream:
@@ -650,7 +861,21 @@ async def chat_completions(request: ChatCompletionRequest):
             )
 
         # Non-streaming
-        if effective_n > 1:
+        if is_multimodal:
+            final_output = None
+            async for output in generate_async_multimodal(
+                token_ids,
+                multimodal_data,
+                sampling_params,
+                request_id,
+            ):
+                final_output = output
+            if final_output is None:
+                raise RuntimeError("No output generated")
+            resp = build_chat_response(
+                request_id, model_name, final_output["text"], final_output
+            )
+        elif effective_n > 1:
             outputs = await generate_async_fanout(prompt, sampling_params, request_id)
             if not outputs:
                 raise RuntimeError("No output generated")

--- a/atom/examples/multimodal_inference.py
+++ b/atom/examples/multimodal_inference.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+import argparse
+import json
+
+from PIL import Image
+from transformers import AutoProcessor
+
+from atom import SamplingParams
+from atom.model_engine.arg_utils import EngineArgs
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawTextHelpFormatter,
+    description=(
+        "Generic image+text multimodal offline inference using the native ATOM engine.\n"
+        "The current ATOM multimodal path is validated with Qwen3.5 models, but\n"
+        "the script itself only relies on the model's Hugging Face processor and\n"
+        "chat template."
+    ),
+)
+
+EngineArgs.add_cli_args(parser)
+
+parser.add_argument(
+    "--image",
+    type=str,
+    action="append",
+    required=True,
+    help="Path to an input image file. Repeat for multi-image prompts.",
+)
+parser.add_argument(
+    "--prompt",
+    type=str,
+    default="Describe this image in detail.",
+    help="Text prompt to accompany the image",
+)
+parser.add_argument(
+    "--temperature", type=float, default=0.6, help="Temperature for sampling"
+)
+parser.add_argument(
+    "--max-tokens", type=int, default=512, help="Max tokens to generate"
+)
+parser.add_argument(
+    "--chat-template-kwargs",
+    type=str,
+    default="{}",
+    help="JSON kwargs passed to processor.apply_chat_template, e.g. '{\"enable_thinking\": false}'",
+)
+
+
+def main():
+    args = parser.parse_args()
+    chat_template_kwargs = json.loads(args.chat_template_kwargs)
+
+    # Force eager mode and single-batch cudagraph sizes for simplicity
+    args.cudagraph_capture_sizes = "[1]"
+
+    # Load processor (handles media preprocessing and chat template)
+    processor = AutoProcessor.from_pretrained(args.model, trust_remote_code=True)
+
+    images = [Image.open(path).convert("RGB") for path in args.image]
+
+    # Build chat messages. Image parts intentionally precede text so Qwen-style
+    # templates emit image placeholders in the same order as the media tensors.
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                *({"type": "image", "image": image} for image in images),
+                {"type": "text", "text": args.prompt},
+            ],
+        }
+    ]
+
+    # Apply chat template to get text with image placeholders.
+    text = processor.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+        **chat_template_kwargs,
+    )
+    print(f"Formatted prompt (first 500 chars): {text[:500]}")
+
+    # Process text + images to get input_ids, pixel_values, image_grid_thw.
+    inputs = processor(
+        text=[text],
+        images=images,
+        return_tensors="pt",
+    )
+
+    input_ids = inputs["input_ids"][0].tolist()
+    print(f"Input token count: {len(input_ids)}")
+
+    # Build multimodal data dict
+    multimodal_data = {
+        "pixel_values": inputs["pixel_values"],
+        "image_grid_thw": inputs["image_grid_thw"],
+    }
+
+    print(f"pixel_values shape: {multimodal_data['pixel_values'].shape}")
+    print(f"image_grid_thw: {multimodal_data['image_grid_thw']}")
+
+    # Create engine
+    engine_args = EngineArgs.from_cli_args(args)
+    llm = engine_args.create_engine()
+
+    sampling_params = SamplingParams(
+        temperature=args.temperature, max_tokens=args.max_tokens
+    )
+
+    # Run multimodal generation
+    print("\nStarting multimodal inference...")
+    outputs = llm.generate_multimodal(
+        [input_ids],
+        sampling_params,
+        [multimodal_data],
+    )
+
+    # Print results
+    for output in outputs:
+        print("\n" + "=" * 70)
+        print(f"Generated text:\n{output['text']}")
+        print(f"\nInput tokens: {output['num_tokens_input']}")
+        print(f"Output tokens: {output['num_tokens_output']}")
+        print(f"Latency: {output['latency']:.2f}s")
+        print(f"TTFT: {output['ttft']:.3f}s")
+        print(f"TPOT: {output['tpot']:.3f}s")
+        print(f"Finish reason: {output['finish_reason']}")
+        print("=" * 70)
+
+    llm.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Union
 
 from atom.config import Config
 from atom.model_engine.engine_core_mgr import CoreManager
+from atom.model_engine.multimodal import get_mrope_input_positions
 from atom.model_engine.sequence import Sequence
 from atom.sampling_params import SamplingParams
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
@@ -80,6 +81,7 @@ class LLMEngine:
         prompt_or_tokens_list: List[Union[str, List[int]]],
         sampling_params_list: SamplingParams | List[SamplingParams],
         stream_callback=None,
+        multimodal_data_list: List[dict] | None = None,
     ):
         # if sampling params is not list, use it for all prompts
         if not isinstance(sampling_params_list, list):
@@ -106,12 +108,29 @@ class LLMEngine:
         else:
             stream_callback_iter = itertools.repeat(None)
 
+        # Handle multimodal data
+        if multimodal_data_list is not None:
+            if len(prompt_or_tokens_list) != len(multimodal_data_list):
+                raise ValueError(
+                    f"number of elements in prompt_or_tokens_list and multimodal_data_list is different: "
+                    f"{len(prompt_or_tokens_list)=} vs {len(multimodal_data_list)=}"
+                )
+            mm_data_iter = multimodal_data_list
+        else:
+            mm_data_iter = itertools.repeat(None)
+
         reqs = []
-        for prompt, sampling_param, callback in zip(
-            prompt_or_tokens_list, sampling_params_iter, stream_callback_iter
+        for prompt, sampling_param, callback, mm_data in zip(
+            prompt_or_tokens_list,
+            sampling_params_iter,
+            stream_callback_iter,
+            mm_data_iter,
         ):
             req = self.io_processor.preprocess(
-                prompt, sampling_param, stream_callback=callback
+                prompt,
+                sampling_param,
+                stream_callback=callback,
+                multimodal_data=mm_data,
             )
             reqs.append(req)
         self.core_mgr.add_request(reqs)
@@ -133,6 +152,30 @@ class LLMEngine:
         self.core_mgr._rr_counter = 0
 
         self.add_request(prompts, sampling_params)
+        outputs = {}
+        while not self.is_finished() and (
+            self.core_mgr.is_alive() or self.core_mgr.is_rest()
+        ):
+            seqs = self.step()
+            outs = self.io_processor.postprocess(seqs)
+            outputs.update(outs)
+
+        outputs = [outputs[seq_id] for seq_id in sorted(outputs)]
+        return outputs
+
+    def generate_multimodal(
+        self,
+        token_ids_list: list[list[int]],
+        sampling_params: SamplingParams | list[SamplingParams],
+        multimodal_data_list: list[dict],
+    ) -> list[dict]:
+        """Generate completions for multimodal inputs (token IDs + vision data)."""
+        self.core_mgr._rr_counter = 0
+        self.add_request(
+            token_ids_list,
+            sampling_params,
+            multimodal_data_list=multimodal_data_list,
+        )
         outputs = {}
         while not self.is_finished() and (
             self.core_mgr.is_alive() or self.core_mgr.is_rest()
@@ -204,6 +247,7 @@ class InputOutputProcessor:
         sampling_params: SamplingParams,
         stream_callback=None,
         kv_transfer_params=None,
+        multimodal_data=None,
     ):
         """responsible for:
         1) Tokenize
@@ -223,6 +267,7 @@ class InputOutputProcessor:
             sampling_params,
             stream_callback=stream_callback,
             kv_transfer_params=kv_transfer_params,
+            multimodal_data=multimodal_data,
         )
         return seqs[0]
 
@@ -233,6 +278,7 @@ class InputOutputProcessor:
         stream_callback=None,
         stream_callbacks: Optional[List] = None,
         kv_transfer_params=None,
+        multimodal_data=None,
         parent_request_id: Optional[str] = None,
     ) -> List[Sequence]:
         """Tokenize once and materialize ``sampling_params.n`` Sequences.
@@ -258,6 +304,14 @@ class InputOutputProcessor:
             if isinstance(prompt_or_tokens, str)
             else prompt_or_tokens
         )
+        mrope_positions = None
+        mrope_position_delta = 0
+        if multimodal_data is not None:
+            mrope_positions, mrope_position_delta = get_mrope_input_positions(
+                self.config,
+                tokens,
+                multimodal_data,
+            )
 
         stop_token_sequences = []
         if sampling_params.stop_strings:
@@ -290,6 +344,9 @@ class InputOutputProcessor:
                 num_draft_tokens=self.num_speculative_tokens,
                 has_per_req_cache=self.has_per_req_cache,
                 kv_transfer_params=kv_transfer_params,
+                multimodal_data=multimodal_data,
+                mrope_positions=mrope_positions,
+                mrope_position_delta=mrope_position_delta,
                 needs_independent_noise=(n > 1),
                 parent_request_id=parent_request_id,
                 sibling_index=i,

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -62,8 +62,8 @@ support_model_arch_dict = {
     "GlmMoeDsaForCausalLM": "atom.models.deepseek_v2.GlmMoeDsaForCausalLM",
     "Glm4MoeForCausalLM": "atom.models.glm4_moe.Glm4MoeForCausalLM",
     "Qwen3NextForCausalLM": "atom.models.qwen3_next.Qwen3NextForCausalLM",
-    "Qwen3_5ForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5ForConditionalGenerationTextOnly",
-    "Qwen3_5MoeForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5MoeForConditionalGenerationTextOnly",
+    "Qwen3_5ForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5MultimodalModel",
+    "Qwen3_5MoeForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5MoeMultimodalModel",
     "KimiK25ForConditionalGeneration": "atom.models.kimi_k25.KimiK25ForCausalLM",
     "MiniMaxM2ForCausalLM": "atom.models.minimax_m2.MiniMaxM2ForCausalLM",
     "MiMoV2FlashForCausalLM": "atom.models.mimo_v2_flash.MiMoV2FlashForCausalLM",
@@ -517,6 +517,8 @@ class ModelRunner:
         self.use_mla = self.is_deepseek_mla()
         self.use_gdn = self.is_qwen_next()
         self.use_v4 = self.is_deepseek_v4()
+        rope_parameters = getattr(self.hf_text_config, "rope_parameters", None) or {}
+        self.use_mrope = "mrope_section" in rope_parameters
         self.is_deepseek_v32 = (
             hasattr(hf_config, "index_topk") if self.use_mla else False
         )
@@ -1116,6 +1118,10 @@ class ModelRunner:
                 dtype=hidden_type,
             ),
         }
+        if self.use_mrope:
+            self.forward_vars["mrope_positions"] = CpuGpuBuffer(
+                3, self.max_num_batched_tokens, **i64_kwargs
+            )
         if hasattr(self, "drafter"):
             self.forward_vars["mtp_k"] = self.drafter.mtp_k
             self.forward_vars["num_accepted_tokens"] = CpuGpuBuffer(
@@ -1131,6 +1137,11 @@ class ModelRunner:
         else:
             assert self.world_size % hf_config.num_key_value_heads == 0
             return 1
+
+    def _mrope_positions_view(self, num_tokens: int) -> torch.Tensor:
+        return self.forward_vars["mrope_positions"].gpu.as_strided(
+            (3, num_tokens), (num_tokens, 1)
+        )
 
     def _get_total_num_layers(self):
         """Return total layer count including draft (MTP) layers.
@@ -1762,7 +1773,37 @@ class ModelRunner:
                 label += f" tok={batch.total_tokens_num} ctx={ctx_str}"
             label += "]"
             with record_function(label):
-                model_output = self.model(input_ids, positions)
+                # Handle multimodal prefill: compute vision embeddings and merge
+                inputs_embeds = None
+                if (
+                    is_prefill
+                    and hasattr(self.model, "get_vision_embeddings")
+                    and batch is not None
+                    and hasattr(batch, "multimodal_data")
+                    and batch.multimodal_data
+                ):
+                    mm_data_values = list(batch.multimodal_data.values())
+                    pixel_values = torch.cat(
+                        [mm_data["pixel_values"] for mm_data in mm_data_values], dim=0
+                    ).to(device=self.device, dtype=self.config.torch_dtype)
+                    grid_thw = torch.cat(
+                        [mm_data["image_grid_thw"] for mm_data in mm_data_values],
+                        dim=0,
+                    ).to(device=self.device)
+                    vision_embeds = self.model.get_vision_embeddings(
+                        pixel_values, grid_thw
+                    )
+                    text_embeds = self.model.embed_input_ids(input_ids)
+                    inputs_embeds = self.model.merge_multimodal_embeddings(
+                        input_ids, text_embeds, vision_embeds
+                    )
+
+                if inputs_embeds is None:
+                    model_output = self.model(input_ids, positions)
+                else:
+                    model_output = self.model(
+                        input_ids, positions, inputs_embeds=inputs_embeds
+                    )
                 if self.use_aux_hidden_state_outputs:
                     hidden_states, self._aux_hidden_states = model_output
                 else:
@@ -2059,10 +2100,15 @@ class ModelRunner:
                 self.forward_vars["positions"].np[:num_tokens] = (
                     np.arange(num_tokens, dtype=np.int64) % max_q_len
                 )
-
                 attn_metadata, context = (
                     self.attn_metadata_builder.build_for_cudagraph_capture(bs=bs)
                 )
+                if self.use_mrope:
+                    mrope_positions = self._mrope_positions_view(num_tokens)
+                    mrope_positions.copy_(
+                        positions[:num_tokens].unsqueeze(0).expand(3, -1)
+                    )
+                    context.positions = mrope_positions
                 num_pad, num_tokens_across_dp = self.get_dp_padding(num_tokens)
                 num_tokens += num_pad
                 # Create ubatch slices for TBO capture (need >= 2 requests)
@@ -2084,8 +2130,14 @@ class ModelRunner:
                 )
 
                 # Warmup
+                model_positions = (
+                    self._mrope_positions_view(num_tokens)
+                    if self.use_mrope
+                    else positions[:num_tokens]
+                )
                 model_output = self.model(
-                    input_ids[:num_tokens], positions[:num_tokens]
+                    input_ids[:num_tokens],
+                    model_positions,
                 )
                 if self.use_aux_hidden_state_outputs:
                     outputs[:num_tokens] = model_output[0]
@@ -2113,9 +2165,15 @@ class ModelRunner:
                     else:
                         # Standard single-stream capture
                         graph = torch.cuda.CUDAGraph()
+                        model_positions = (
+                            self._mrope_positions_view(num_tokens)
+                            if self.use_mrope
+                            else positions[:num_tokens]
+                        )
                         with torch.cuda.graph(graph, self.graph_pool, stream=gc.stream):
                             model_output = self.model(
-                                input_ids[:num_tokens], positions[:num_tokens]
+                                input_ids[:num_tokens],
+                                model_positions,
                             )
                             if self.use_aux_hidden_state_outputs:
                                 outputs[:num_tokens] = model_output[0]

--- a/atom/model_engine/multimodal.py
+++ b/atom/model_engine/multimodal.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+import numpy as np
+
+from atom.config import Config
+from atom.utils import resolve_obj_by_qualname
+
+_MULTIMODAL_ARCH_TO_MODEL: dict[str, str] = {
+    "Qwen3_5ForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5MultimodalModel",
+    "Qwen3_5MoeForConditionalGeneration": (
+        "atom.models.qwen3_5.Qwen3_5MoeMultimodalModel"
+    ),
+}
+
+
+def get_mrope_input_positions(
+    atom_config: Config,
+    input_tokens: list[int],
+    multimodal_data: dict,
+) -> tuple[np.ndarray | None, int]:
+    """Return request-level MRoPE positions via the model's MRoPE interface."""
+
+    architectures = getattr(atom_config.hf_config, "architectures", None) or []
+    if not architectures:
+        return None, 0
+
+    model_qualname = _MULTIMODAL_ARCH_TO_MODEL.get(architectures[0])
+    if model_qualname is None:
+        return None, 0
+
+    model_cls = resolve_obj_by_qualname(model_qualname)
+    mrope_getter = getattr(model_cls, "get_mrope_input_positions", None)
+    if mrope_getter is None:
+        return None, 0
+
+    return mrope_getter(atom_config, input_tokens, multimodal_data)

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -271,6 +271,17 @@ class ScheduledBatch:
         self.is_first_decode_without_local_prefill = [
             seq.is_first_decode for seq in seqs.values()
         ]
+        self.mrope_positions_by_req = {
+            seq.id: seq.mrope_positions
+            for seq in seqs.values()
+            if getattr(seq, "mrope_positions", None) is not None
+        }
+        self.mrope_position_deltas = {
+            seq.id: getattr(seq, "mrope_position_delta", 0)
+            for seq in seqs.values()
+            if getattr(seq, "mrope_positions", None) is not None
+        }
+        self.has_mrope = bool(self.mrope_positions_by_req)
 
         offs = self.context_lens - self.num_rejected - self.num_scheduled_tokens
         self.scheduled_tokens = np.empty(total_tokens_num, dtype=np.int32)
@@ -308,6 +319,14 @@ class ScheduledBatch:
 
         self.is_dummy_run = is_dummy_run
         self.num_spec_step = num_spec_step
+
+        # Collect multimodal data from prefill sequences
+        self.multimodal_data = {}
+        for seq in seqs.values():
+            if getattr(seq, "multimodal_data", None) is not None:
+                self.multimodal_data[seq.id] = seq.multimodal_data
+                # Clear after first use to avoid re-sending on decode steps
+                seq.multimodal_data = None
 
         # logger.info(f"{[el for el in scheduled_spec_decode_tokens.keys()]=}")
         # logger.info(f"{self.num_scheduled_tokens=}")

--- a/atom/model_engine/sequence.py
+++ b/atom/model_engine/sequence.py
@@ -47,6 +47,9 @@ class Sequence:
         needs_independent_noise: bool = False,
         parent_request_id: Optional[str] = None,
         sibling_index: int = 0,
+        multimodal_data: Optional[dict] = None,
+        mrope_positions: Optional[np.ndarray] = None,
+        mrope_position_delta: int = 0,
     ):
         self.block_size = block_size
         self.id = id or next(Sequence.counter)
@@ -61,6 +64,9 @@ class Sequence:
         # Triggers BlockManager to allocate a per-req cache slot in
         # allocate() / free it in deallocate().
         self.has_per_req_cache = has_per_req_cache
+        self.multimodal_data = multimodal_data
+        self.mrope_positions = mrope_positions
+        self.mrope_position_delta = mrope_position_delta
         self.num_tokens = len(self.token_ids)
         self.num_prompt_tokens = len(token_ids)
         self.num_rejected = 0

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -316,6 +316,14 @@ def load_model(
     # it is only used in plugin mode for vllm
     loaded_weights_record: set[str] = set()
 
+    # Auto-detect weight mapper from model if not provided explicitly
+    if weights_mapper is None:
+        model_mapper = getattr(model, "hf_to_atom_mapper", None)
+        if isinstance(model_mapper, dict):
+            weights_mapper = WeightsMapper(orig_to_new_prefix=model_mapper)
+        elif isinstance(model_mapper, WeightsMapper):
+            weights_mapper = model_mapper
+
     packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
     weights_mapping = getattr(model, "weights_mapping", {})
     skip_weight_prefixes = getattr(model, "skip_weight_prefixes", [])

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -649,7 +649,13 @@ class AiterAttentionMetadataBuilder:
             min_seqlen_q=min_seqlen_q,
             **ctx,
         )
-        positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
+        mrope_positions = self._build_mrope_decode_positions(
+            batch, context_lens, max_seqlen_q
+        )
+        if mrope_positions is not None:
+            positions = mrope_positions
+        else:
+            positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
         if self.model_runner.config.enable_tbo_decode and bs >= 2:
             self._prepare_ubatch_decode(
                 scheduled_bs,

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Type, TypeVar
 if TYPE_CHECKING:
     from atom.kv_transfer.disaggregation.types import KVTransferTensors
 
+import numpy as np
 import torch
 from aiter.dist.parallel_state import get_tp_group
 from atom.model_engine.scheduler import ScheduledBatch
@@ -265,6 +266,71 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
             block_tables[i] = 0
             block_tables[i, : len(block_table)] = block_table
 
+    def _mrope_cpu_view(self, num_tokens: int) -> np.ndarray:
+        return (
+            self.model_runner.forward_vars["mrope_positions"]
+            .np.reshape(-1)[: 3 * num_tokens]
+            .reshape(3, num_tokens)
+        )
+
+    def _copy_mrope_to_gpu(self, num_tokens: int) -> torch.Tensor:
+        buf = self.model_runner.forward_vars["mrope_positions"]
+        buf.gpu.reshape(-1)[: 3 * num_tokens].copy_(
+            buf.cpu.reshape(-1)[: 3 * num_tokens], non_blocking=True
+        )
+        return self.model_runner._mrope_positions_view(num_tokens)
+
+    def _build_mrope_prefill_positions(
+        self, batch: ScheduledBatch
+    ) -> torch.Tensor | None:
+        if not getattr(self.model_runner, "use_mrope", False):
+            return None
+
+        total_tokens = batch.total_tokens_num_prefill
+        positions = self._mrope_cpu_view(total_tokens)
+        offset = 0
+        for req_id, seqlen, cached_seqlen in zip(
+            batch.req_ids, batch.context_lens, batch.num_cached_tokens
+        ):
+            num_tokens = int(seqlen) - int(cached_seqlen)
+            mrope_positions = batch.mrope_positions_by_req.get(req_id)
+            if mrope_positions is None:
+                positions[:, offset : offset + num_tokens] = np.arange(
+                    cached_seqlen, seqlen, dtype=np.int64
+                )[None, :]
+            else:
+                positions[:, offset : offset + num_tokens] = mrope_positions[
+                    :, cached_seqlen:seqlen
+                ]
+            offset += num_tokens
+
+        return self._copy_mrope_to_gpu(total_tokens)
+
+    def _build_mrope_decode_positions(
+        self,
+        batch: ScheduledBatch,
+        context_lens: np.ndarray,
+        max_seqlen_q: int,
+    ) -> torch.Tensor | None:
+        if not getattr(self.model_runner, "use_mrope", False):
+            return None
+
+        total_tokens = batch.total_tokens_num_decode
+        positions = self._mrope_cpu_view(total_tokens)
+        offset = 0
+        for req_id, context_len in zip(batch.req_ids, context_lens):
+            start = int(context_len) - max_seqlen_q
+            stop = int(context_len)
+            delta = batch.mrope_position_deltas.get(req_id)
+            if delta is None:
+                base = np.arange(start, stop, dtype=np.int64)
+            else:
+                base = np.arange(start + int(delta), stop + int(delta), dtype=np.int64)
+            positions[:, offset : offset + max_seqlen_q] = base[None, :]
+            offset += max_seqlen_q
+
+        return self._copy_mrope_to_gpu(total_tokens)
+
     def prepare_prefill(self, batch: ScheduledBatch):
         bs = batch.total_seqs_num_prefill
         sum_scheduled_tokens = batch.total_tokens_num_prefill
@@ -361,7 +427,11 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
             state=AttnState.PREFILL_PREFIX if has_cached else AttnState.PREFILL_NATIVE,
             **ctx,
         )
-        positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
+        mrope_positions = self._build_mrope_prefill_positions(batch)
+        if mrope_positions is not None:
+            positions = mrope_positions
+        else:
+            positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
 
         return attn_metadata, positions
 

--- a/atom/models/qwen3_5.py
+++ b/atom/models/qwen3_5.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 
+import numpy as np
 import torch
 from torch import nn
 
@@ -53,6 +54,65 @@ if is_vllm():
 def get_qwen3_5_text_config(atom_config: Config):
     hf_config = atom_config.hf_config
     return hf_config.text_config if hasattr(hf_config, "text_config") else hf_config
+
+
+def build_qwen3_5_mrope_input_positions(
+    input_tokens: list[int],
+    image_grid_thw,
+    video_grid_thw,
+    image_token_id: int,
+    video_token_id: int,
+    vision_start_token_id: int,
+    vision_end_token_id: int,
+    spatial_merge_size: int,
+) -> tuple[np.ndarray, int]:
+    """Build request-level Qwen3.5-VL MRoPE positions for prompt tokens."""
+    from aiter.rotary_embedding import MRotaryEmbedding
+
+    positions, delta = MRotaryEmbedding.get_input_positions(
+        input_tokens,
+        image_grid_thw,
+        video_grid_thw if video_grid_thw is not None else [],
+        image_token_id,
+        video_token_id,
+        vision_start_token_id,
+        vision_end_token_id,
+        spatial_merge_size,
+    )
+    return np.asarray(positions, dtype=np.int64), int(delta)
+
+
+def _get_qwen3_5_mrope_input_positions(
+    atom_config: Config,
+    input_tokens: list[int],
+    multimodal_data: dict,
+) -> tuple[np.ndarray | None, int]:
+    """Return Qwen3.5 request-level MRoPE positions when applicable."""
+
+    multimodal_config = atom_config.multimodal_config
+    if multimodal_config is None:
+        return None, 0
+
+    model_type = getattr(multimodal_config, "model_type", None)
+    if model_type not in {"qwen3_5", "qwen3_5_moe"}:
+        return None, 0
+
+    vision_config = getattr(multimodal_config, "vision_config", None)
+    if vision_config is None or "image_grid_thw" not in multimodal_data:
+        return None, 0
+
+    return build_qwen3_5_mrope_input_positions(
+        input_tokens,
+        multimodal_data.get("image_grid_thw"),
+        multimodal_data.get("video_grid_thw"),
+        image_token_id=getattr(multimodal_config, "image_token_id", 248056),
+        video_token_id=getattr(multimodal_config, "video_token_id", 248057),
+        vision_start_token_id=getattr(
+            multimodal_config, "vision_start_token_id", 248053
+        ),
+        vision_end_token_id=getattr(multimodal_config, "vision_end_token_id", 248054),
+        spatial_merge_size=getattr(vision_config, "spatial_merge_size", 2),
+    )
 
 
 # Qwen3.5 MoE models have some checkpoints where expert weights are fused together in BF16 format, so we need special handling to load those weights into our per-expert parameters.
@@ -372,7 +432,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
         "input_ids": 0,
         # positions is of shape (3, seq_len) if mrope is enabled for qwen2-vl,
         # otherwise (seq_len, ).
-        "positions": -1,
+        "positions": [0, -1],
         "intermediate_tensors": 0,
         "inputs_embeds": 0,
     }
@@ -559,6 +619,8 @@ class Qwen3_5ForConditionalGenerationTextOnly(nn.Module):
         inputs_embeds: torch.Tensor | None = None,
         **_: object,
     ):
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
         return self.language_model(
             input_ids, positions, intermediate_tensors, inputs_embeds
         )
@@ -618,6 +680,147 @@ class Qwen3_5MoeForConditionalGenerationTextOnly(
         Returns:
             True if weights were loaded successfully
         """
+        return load_fused_expert_weights(
+            original_name,
+            name,
+            params_dict,
+            loaded_weight,
+            shard_id,
+            num_experts,
+        )
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.language_model.get_expert_mapping()
+
+
+class _Qwen3_5MultimodalBase(nn.Module):
+    packed_modules_mapping = (
+        Qwen3_5ForConditionalGenerationTextOnly.packed_modules_mapping.copy()
+    )
+
+    # Weight name mapping: checkpoint -> native ATOM module names.
+    hf_to_atom_mapper = {
+        "model.visual.": "visual.",
+        "lm_head.": "language_model.lm_head.",
+        "model.language_model.": "language_model.model.",
+    }
+
+    # Remap quant exclude layer names from checkpoint format to native names.
+    quant_exclude_name_mapping = {
+        "model.visual.": "visual.",
+        "lm_head.": "language_model.lm_head.",
+        "model.language_model.": "language_model.model.",
+    }
+
+    language_model_cls = Qwen3_5ForCausalLM
+
+    @staticmethod
+    def get_mrope_input_positions(
+        atom_config: Config,
+        input_tokens: list[int],
+        multimodal_data: dict,
+    ) -> tuple[np.ndarray | None, int]:
+        return _get_qwen3_5_mrope_input_positions(
+            atom_config, input_tokens, multimodal_data
+        )
+
+    def __init__(self, atom_config: Config, prefix: str = ""):
+        super().__init__()
+        from atom.models.qwen3_5_vl import Qwen3VisionTransformer
+
+        self.config = atom_config.hf_config
+        multimodal_config = atom_config.multimodal_config
+        if multimodal_config is None:
+            raise ValueError("Qwen3.5 multimodal models require multimodal_config")
+
+        self._prepare_text_config(atom_config)
+        self.visual = Qwen3VisionTransformer(
+            multimodal_config.vision_config,
+            norm_eps=getattr(multimodal_config, "rms_norm_eps", 1e-6),
+        )
+        self.language_model = self.language_model_cls(
+            atom_config=atom_config,
+            prefix=maybe_prefix("", "language_model"),
+        )
+        self.image_token_id = getattr(multimodal_config, "image_token_id", 248056)
+        self.video_token_id = getattr(multimodal_config, "video_token_id", 248057)
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+
+    def _prepare_text_config(self, atom_config: Config) -> None:
+        pass
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.language_model.model.get_input_embeddings(input_ids)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.language_model.embed_input_ids(input_ids)
+
+    def get_vision_embeddings(
+        self, pixel_values: torch.Tensor, grid_thw: torch.Tensor
+    ) -> torch.Tensor:
+        return self.visual(pixel_values, grid_thw)
+
+    def merge_multimodal_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+        vision_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        mask = input_ids == self.image_token_id
+        inputs_embeds[mask] = vision_embeds.to(inputs_embeds.dtype)
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **_: object,
+    ):
+        # Keep the compiled language model on the inputs_embeds path so vision
+        # embeddings are not dropped after text-only warmup.
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+        return self.language_model(
+            input_ids, positions, intermediate_tensors, inputs_embeds
+        )
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.language_model.compute_logits(hidden_states)
+
+
+class Qwen3_5MultimodalModel(_Qwen3_5MultimodalBase):
+    pass
+
+
+class Qwen3_5MoeMultimodalModel(_Qwen3_5MultimodalBase):
+    language_model_cls = Qwen3_5MoeForCausalLM
+
+    def _prepare_text_config(self, atom_config: Config) -> None:
+        text_config = atom_config.hf_config.text_config
+        if not hasattr(text_config, "n_shared_experts"):
+            text_config.n_shared_experts = 1
+        if not hasattr(text_config, "n_routed_experts"):
+            text_config.n_routed_experts = text_config.num_experts
+
+    def detect_fused_expert_format(self, weight_name: str) -> bool:
+        return detect_fused_expert_format(weight_name)
+
+    def get_fused_expert_mapping(self) -> list[tuple[str, str, str]]:
+        return get_fused_expert_mapping()
+
+    def load_fused_expert_weights(
+        self,
+        original_name: str,
+        name: str,
+        params_dict: dict,
+        loaded_weight: torch.Tensor,
+        shard_id: str,
+        num_experts: int,
+    ) -> bool:
         return load_fused_expert_weights(
             original_name,
             name,

--- a/atom/models/qwen3_5_vl.py
+++ b/atom/models/qwen3_5_vl.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Native Qwen3.5 Vision Encoder for ATOM.
+
+Pure PyTorch implementation (no vLLM dependencies) of the Qwen3 VisionTransformer.
+Uses F.scaled_dot_product_attention for the vision self-attention blocks.
+"""
+
+from functools import lru_cache
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Qwen3VisionPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        patch_size: int = 16,
+        temporal_patch_size: int = 2,
+        in_channels: int = 3,
+        hidden_size: int = 1152,
+    ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.hidden_size = hidden_size
+
+        kernel_size = (temporal_patch_size, patch_size, patch_size)
+        self.proj = nn.Conv3d(
+            in_channels,
+            hidden_size,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=True,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [L, C * temporal_patch_size * patch_size * patch_size]
+        L, C = x.shape
+        x = x.view(L, -1, self.temporal_patch_size, self.patch_size, self.patch_size)
+        x = self.proj(x).view(L, self.hidden_size)
+        return x
+
+
+class Qwen3VisionMLP(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        bias: bool = True,
+        act_fn=F.silu,
+    ):
+        super().__init__()
+        self.linear_fc1 = nn.Linear(in_features, hidden_features, bias=bias)
+        self.linear_fc2 = nn.Linear(hidden_features, in_features, bias=bias)
+        self.act_fn = act_fn
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+
+
+class Qwen3VisionAttention(nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+
+        # Combined QKV projection (matching checkpoint weight name "attn.qkv")
+        self.qkv = nn.Linear(embed_dim, embed_dim * 3, bias=True)
+        self.proj = nn.Linear(embed_dim, embed_dim, bias=True)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        rotary_pos_emb_cos: torch.Tensor,
+        rotary_pos_emb_sin: torch.Tensor,
+    ) -> torch.Tensor:
+        # x: [seq_len, 1, embed_dim] (the VisionBlock adds a batch dim)
+        seq_len = x.shape[0]
+        batch = x.shape[1] if x.dim() == 3 else 1
+        x_2d = x.view(seq_len, self.embed_dim)
+
+        qkv = self.qkv(x_2d)
+        qkv = qkv.view(seq_len, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv[:, 0], qkv[:, 1], qkv[:, 2]
+
+        # Apply rotary embeddings
+        q = self._apply_rotary_emb(q, rotary_pos_emb_cos, rotary_pos_emb_sin)
+        k = self._apply_rotary_emb(k, rotary_pos_emb_cos, rotary_pos_emb_sin)
+
+        # Reshape for SDPA: [batch, heads, seq_len, head_dim]
+        q = q.unsqueeze(0).transpose(1, 2)  # [1, num_heads, seq_len, head_dim]
+        k = k.unsqueeze(0).transpose(1, 2)
+        v = v.unsqueeze(0).transpose(1, 2)
+
+        out = F.scaled_dot_product_attention(q, k, v)
+        out = out.transpose(1, 2).reshape(seq_len, self.embed_dim)
+        out = self.proj(out)
+        return out.view(seq_len, batch, self.embed_dim)
+
+    @staticmethod
+    def _apply_rotary_emb(
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> torch.Tensor:
+        # x: [seq_len, num_heads, head_dim]
+        # cos, sin: [seq_len, head_dim]
+        # Use rotate_half style matching HF's apply_rotary_pos_emb_vision
+        orig_dtype = x.dtype
+        x = x.float()
+        cos = cos.unsqueeze(-2).float()  # [seq_len, 1, head_dim]
+        sin = sin.unsqueeze(-2).float()  # [seq_len, 1, head_dim]
+        # rotate_half: [-x2, x1] where x1 = x[..., :dim//2], x2 = x[..., dim//2:]
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        x_rotated = torch.cat((-x2, x1), dim=-1)
+        out = (x * cos) + (x_rotated * sin)
+        return out.to(orig_dtype)
+
+
+class Qwen3VisionBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        act_fn=F.silu,
+        norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim, eps=norm_eps)
+        self.norm2 = nn.LayerNorm(dim, eps=norm_eps)
+        self.attn = Qwen3VisionAttention(embed_dim=dim, num_heads=num_heads)
+        self.mlp = Qwen3VisionMLP(dim, mlp_hidden_dim, act_fn=act_fn, bias=True)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        rotary_pos_emb_cos: torch.Tensor,
+        rotary_pos_emb_sin: torch.Tensor,
+    ) -> torch.Tensor:
+        x = x + self.attn(
+            self.norm1(x),
+            rotary_pos_emb_cos=rotary_pos_emb_cos,
+            rotary_pos_emb_sin=rotary_pos_emb_sin,
+        )
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class Qwen3VisionPatchMerger(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        context_dim: int,
+        spatial_merge_size: int = 2,
+        norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        self.norm = nn.LayerNorm(context_dim, eps=norm_eps)
+        self.linear_fc1 = nn.Linear(self.hidden_size, self.hidden_size, bias=True)
+        self.act_fn = nn.GELU()
+        self.linear_fc2 = nn.Linear(self.hidden_size, d_model, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [seq_len, 1, context_dim]
+        x = self.norm(x).view(-1, self.hidden_size)
+        x = self.linear_fc1(x)
+        x = self.act_fn(x)
+        x = self.linear_fc2(x)
+        return x
+
+
+class Qwen3VisionTransformer(nn.Module):
+    def __init__(
+        self,
+        vision_config,
+        norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.hidden_size = vision_config.hidden_size
+        self.num_heads = vision_config.num_heads
+        self.num_position_embeddings = vision_config.num_position_embeddings
+        self.patch_size = vision_config.patch_size
+        self.spatial_merge_size = vision_config.spatial_merge_size
+        self.spatial_merge_unit = self.spatial_merge_size**2
+        self.temporal_patch_size = vision_config.temporal_patch_size
+        self.deepstack_visual_indexes = getattr(
+            vision_config, "deepstack_visual_indexes", []
+        )
+        self.num_grid_per_side = int(self.num_position_embeddings**0.5)
+
+        self.patch_embed = Qwen3VisionPatchEmbed(
+            patch_size=self.patch_size,
+            temporal_patch_size=self.temporal_patch_size,
+            in_channels=vision_config.in_channels,
+            hidden_size=self.hidden_size,
+        )
+
+        self.pos_embed = nn.Embedding(self.num_position_embeddings, self.hidden_size)
+
+        head_dim = self.hidden_size // self.num_heads
+        self.head_dim = head_dim
+        self.rotary_dim = head_dim  # full rotation by default
+
+        act_fn_map = {
+            "gelu_pytorch_tanh": lambda x: F.gelu(x, approximate="tanh"),
+            "silu": F.silu,
+            "gelu": F.gelu,
+        }
+        act_fn = act_fn_map.get(getattr(vision_config, "hidden_act", "silu"), F.silu)
+
+        self.blocks = nn.ModuleList(
+            [
+                Qwen3VisionBlock(
+                    dim=self.hidden_size,
+                    num_heads=self.num_heads,
+                    mlp_hidden_dim=vision_config.intermediate_size,
+                    act_fn=act_fn,
+                    norm_eps=norm_eps,
+                )
+                for _ in range(vision_config.depth)
+            ]
+        )
+
+        self.merger = Qwen3VisionPatchMerger(
+            d_model=vision_config.out_hidden_size,
+            context_dim=self.hidden_size,
+            spatial_merge_size=self.spatial_merge_size,
+            norm_eps=norm_eps,
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    @staticmethod
+    @lru_cache(maxsize=1024)
+    def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
+        hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
+        h_div = h // spatial_merge_size
+        w_div = w // spatial_merge_size
+        hpos_ids = hpos_ids.reshape(
+            h_div, spatial_merge_size, w_div, spatial_merge_size
+        )
+        hpos_ids = hpos_ids.transpose(0, 2, 1, 3).flatten()
+
+        wpos_ids = np.broadcast_to(np.arange(w).reshape(1, w), (h, w))
+        wpos_ids = wpos_ids.reshape(
+            h_div, spatial_merge_size, w_div, spatial_merge_size
+        )
+        wpos_ids = wpos_ids.transpose(0, 2, 1, 3).flatten()
+
+        return torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))
+
+    def _compute_rotary_emb(self, grid_thw: list[list[int]]):
+        """Compute rotary position embeddings for the vision encoder.
+
+        Matches HuggingFace Qwen3_5MoeVisionModel.rot_pos_emb:
+        - Uses head_dim // 2 as the rotary dimension (head_dim // 4 frequencies)
+        - Concatenates h and w frequency tables → head_dim // 2
+        - Doubles: cat((emb, emb)) → head_dim
+        - Returns (cos, sin) each of shape (seq_len, head_dim)
+        """
+        max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+
+        # Rotary dim is head_dim // 2 (matching HF's VisionRotaryEmbedding(head_dim // 2))
+        rotary_dim = self.head_dim // 2
+        inv_freq = 1.0 / (
+            10000.0
+            ** (torch.arange(0, rotary_dim, 2, dtype=torch.float32) / rotary_dim)
+        )
+        positions = torch.arange(max_grid_size, dtype=torch.float32)
+        freq_table = torch.outer(positions, inv_freq)  # (max_hw, head_dim // 4)
+
+        # Build position IDs for each image/frame
+        pos_ids = []
+        for t, h, w in grid_thw:
+            ids = self.rot_pos_ids(h, w, self.spatial_merge_size)
+            if t > 1:
+                ids = ids.repeat(t, 1)
+            pos_ids.append(ids)
+        pos_ids = torch.cat(pos_ids, dim=0)  # [total_patches, 2] (CPU)
+
+        # Index into freq table: (seq_len, 2, head_dim // 4) → flatten → (seq_len, head_dim // 2)
+        embeddings = freq_table[pos_ids]  # (seq_len, 2, head_dim // 4)
+        embeddings = embeddings.flatten(1)  # (seq_len, head_dim // 2)
+
+        # Double the embeddings: cat((emb, emb)) → (seq_len, head_dim)
+        emb = torch.cat((embeddings, embeddings), dim=-1)
+        cos = emb.cos().to(self.device, dtype=self.dtype)
+        sin = emb.sin().to(self.device, dtype=self.dtype)
+
+        return cos, sin
+
+    def _compute_pos_embed(self, grid_thw: list[list[int]]) -> torch.Tensor:
+        """Compute interpolated position embeddings."""
+        num_grid_per_side = self.num_grid_per_side
+        m_size = self.spatial_merge_size
+        hidden_dim = self.pos_embed.embedding_dim
+
+        outputs = []
+        for t, h, w in grid_thw:
+            h_idxs = torch.linspace(
+                0, num_grid_per_side - 1, h, dtype=torch.float32, device=self.device
+            )
+            w_idxs = torch.linspace(
+                0, num_grid_per_side - 1, w, dtype=torch.float32, device=self.device
+            )
+
+            h_floor = h_idxs.to(torch.long)
+            w_floor = w_idxs.to(torch.long)
+            h_ceil = torch.clamp(h_floor + 1, max=num_grid_per_side - 1)
+            w_ceil = torch.clamp(w_floor + 1, max=num_grid_per_side - 1)
+
+            dh = h_idxs - h_floor
+            dw = w_idxs - w_floor
+
+            dh_grid, dw_grid = torch.meshgrid(dh, dw, indexing="ij")
+            h_floor_grid, w_floor_grid = torch.meshgrid(h_floor, w_floor, indexing="ij")
+            h_ceil_grid, w_ceil_grid = torch.meshgrid(h_ceil, w_ceil, indexing="ij")
+
+            w11 = dh_grid * dw_grid
+            w10 = dh_grid - w11
+            w01 = dw_grid - w11
+            w00 = 1 - dh_grid - w01
+
+            h_grid = torch.stack([h_floor_grid, h_floor_grid, h_ceil_grid, h_ceil_grid])
+            w_grid = torch.stack([w_floor_grid, w_ceil_grid, w_floor_grid, w_ceil_grid])
+            h_grid_idx = h_grid * num_grid_per_side
+
+            indices = (h_grid_idx + w_grid).reshape(4, -1)
+            weights = torch.stack([w00, w01, w10, w11], dim=0).reshape(4, -1, 1)
+            weights = weights.to(dtype=self.dtype)
+
+            embeds = self.pos_embed(indices)
+            embeds *= weights
+            combined = embeds.sum(dim=0)
+
+            combined = combined.reshape(
+                h // m_size, m_size, w // m_size, m_size, hidden_dim
+            )
+            combined = combined.permute(0, 2, 1, 3, 4).reshape(1, -1, hidden_dim)
+            repeated = combined.expand(t, -1, -1).reshape(-1, hidden_dim)
+            outputs.append(repeated)
+
+        return torch.cat(outputs, dim=0)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Args:
+            x: pixel_values tensor [total_patches, C*temporal*patch*patch]
+            grid_thw: tensor of shape [num_images, 3] with (t, h, w) for each image
+        Returns:
+            image embeddings [num_merged_patches, out_hidden_size]
+        """
+        hidden_states = x.to(device=self.device, dtype=self.dtype, non_blocking=True)
+        hidden_states = self.patch_embed(hidden_states)
+
+        if isinstance(grid_thw, torch.Tensor):
+            grid_thw_list = grid_thw.tolist()
+        else:
+            grid_thw_list = grid_thw
+
+        # Position embeddings
+        pos_embeds = self._compute_pos_embed(grid_thw_list)
+        hidden_states = hidden_states + pos_embeds
+
+        # Add batch dim for attention blocks
+        hidden_states = hidden_states.unsqueeze(1)
+
+        # Rotary position embeddings
+        rotary_cos, rotary_sin = self._compute_rotary_emb(grid_thw_list)
+
+        for blk in self.blocks:
+            hidden_states = blk(
+                hidden_states,
+                rotary_pos_emb_cos=rotary_cos,
+                rotary_pos_emb_sin=rotary_sin,
+            )
+
+        hidden_states = self.merger(hidden_states)
+        return hidden_states

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -48,7 +48,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # QK-norm-rope-cache-quant fusion for Qwen3-MoE; disabled by default.
     # Enable for Qwen3-MoE to get better performance.
     "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION": lambda: (
-        os.getenv("ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION", "1") == "1"
+        os.getenv("ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION", "0") == "1"
     ),
     "ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION", "1") == "1"

--- a/recipes/Qwen3.5_multimodel.md
+++ b/recipes/Qwen3.5_multimodel.md
@@ -1,0 +1,137 @@
+# Qwen3.5 Multimodal Usage Guide
+
+[Qwen3.5-35B-A3B-FP8](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-FP8) is a multimodal Mixture-of-Experts (MoE) model from the Qwen3.5 family. ATOM supports the native Qwen3.5 multimodal path, including Hugging Face processor/chat-template preprocessing, the vision encoder, and Qwen3.5 MRoPE positions for language-model attention.
+
+## Preparing environment
+
+Pull the latest docker from https://hub.docker.com/r/rocm/atom/ :
+```bash
+docker pull rocm/atom:latest
+```
+All the operations below will be executed inside the container.
+
+## Launching server
+
+### Serving on 1xMI355X GPU
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model Qwen/Qwen3.5-35B-A3B-FP8 \
+  --server-port 8000 \
+  --no-enable_prefix_caching
+```
+
+For single-GPU testing on a multi-GPU node, pin the server to one GPU:
+
+```bash
+HIP_VISIBLE_DEVICES=0 python -m atom.entrypoints.openai_server \
+  --model Qwen/Qwen3.5-35B-A3B-FP8 \
+  --server-port 8000 \
+  --no-enable_prefix_caching
+```
+
+Tips on server configuration:
+- Use `--no-enable_prefix_caching` for multimodal requests.
+- ATOM has built-in support for `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration`.
+- Qwen3.5 multimodal models use MRoPE positions on the language-model side. Text-only and non-MRoPE models still use one-dimensional positions.
+- Set `AITER_LOG_LEVEL=WARNING` before starting to suppress aiter kernel log noise.
+- Use `HIP_VISIBLE_DEVICES` to run independent tests on different GPUs.
+
+## Image request
+
+Send an OpenAI-compatible image request to the server:
+
+```bash
+IMAGE_BASE64=$(base64 -w 0 /app/image.png)
+
+curl -X POST "http://localhost:8000/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3.5-35B-A3B-FP8",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Describe this image in detail."
+          },
+          {
+            "type": "image_url",
+            "image_url": {
+              "url": "data:image/png;base64,'"$IMAGE_BASE64"'"
+            }
+          }
+        ]
+      }
+    ],
+    "max_tokens": 1024,
+    "temperature": 0,
+    "top_p": 1,
+    "stream": false
+  }' | python3 -m json.tool
+```
+
+For offline image-to-text inference, use the multimodal example:
+
+```bash
+python /app/ATOM/atom/examples/multimodal_inference.py \
+  --model Qwen/Qwen3.5-35B-A3B-FP8 \
+  --image /app/image.png \
+  --prompt "Describe this image in detail." \
+  --temperature 0 \
+  --max-tokens 1024 \
+  -tp 1
+```
+
+## Multimodal accuracy test
+
+Install `lmms-eval` first. The commands below install `lmms-eval` with `--no-deps`, then install only the runtime packages used by the multimodal evaluators to avoid upgrading the ROCm PyTorch stack:
+
+```bash
+python3 -m pip install --no-deps --force-reinstall \
+  "git+https://github.com/EvolvingLMMs-Lab/lmms-eval.git"
+
+python3 -m pip install --no-deps \
+  "accelerate>=0.29.1" "av<16.0.0" "datasets>=2.19.0" "evaluate>=0.4.0" \
+  "jsonlines" "aiohttp" "numexpr" "peft>=0.2.0" "pybind11>=2.6.2" \
+  "pytablewriter" "sacrebleu>=1.5.0" "scikit-learn>=0.24.1" "timm" \
+  "einops" "ftfy" "openai" "opencv-python-headless" "hf-transfer" "nltk" \
+  "sentencepiece" "yt-dlp" "pycocoevalcap" "tqdm-multiprocess" \
+  "transformers-stream-generator" "zstandard" "pillow" "pyyaml" "sympy" \
+  "latex2sympy2" "mpmath" "Jinja2" "openpyxl" "loguru" "math-verify" \
+  "wandb==0.25.0" "tiktoken" "pydantic" "packaging" "pre-commit" "zss" \
+  "protobuf" "python-dotenv" "qwen-vl-utils>=0.0.14" "decord"
+```
+
+### MMStar
+
+```bash
+OPENAI_API_KEY=EMPTY \
+PYTHONPATH="${LMMS_EVAL_PATH:-/app/lmms-eval}${PYTHONPATH:+:${PYTHONPATH}}" \
+python -m lmms_eval \
+  --model openai \
+  --model_args "model=Qwen/Qwen3.5-35B-A3B-FP8,base_url=http://127.0.0.1:8000/v1,api_key=EMPTY,timeout=900,max_retries=3,num_concurrent=64,max_size_in_mb=50" \
+  --tasks mmstar \
+  --batch_size 1 \
+  --process_with_media \
+  --gen_kwargs "temperature=0,max_new_tokens=8192" \
+  --log_samples \
+  --output_path /tmp/atom_qwen35_mmstar
+```
+
+### MMMU validation
+
+```bash
+OPENAI_API_KEY=EMPTY \
+PYTHONPATH="${LMMS_EVAL_PATH:-/app/lmms-eval}${PYTHONPATH:+:${PYTHONPATH}}" \
+python -m lmms_eval \
+  --model openai \
+  --model_args "model=Qwen/Qwen3.5-35B-A3B-FP8,base_url=http://127.0.0.1:8000/v1,api_key=EMPTY,timeout=900,max_retries=3,num_concurrent=16,max_size_in_mb=50" \
+  --tasks mmmu_val \
+  --batch_size 1 \
+  --process_with_media \
+  --gen_kwargs "temperature=0,max_new_tokens=8192" \
+  --log_samples \
+  --output_path /tmp/atom_qwen35_mmmu_val
+```


### PR DESCRIPTION
1. Add native Qwen3.5 multimodal support, including the vision encoder, multimodal embedding merge path, and OpenAI-compatible image chat completions.
2. Add a generic offline multimodal inference example for image + text prompts.
3. Add full MMStar CI coverage for Qwen3.5-35B-A3B-FP8, with protected lmms-eval installation that does not change the ROCm torch stack.