### PR TITLE
[feat](pad): remove pad kernel in gpt-oss

### DIFF
--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -253,10 +253,19 @@ class RMSNorm(nn.Module):
         residual: torch.Tensor | None = None,
         x_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        if self.x_pad_to_multiple > 0:
+        if self.fused_allreduce and self.tp_size > 1:
             assert (
-                not self.fused_allreduce
-            ), "fused_allreduce_rmsnorm is not supported with rms_norm padding!"
+                residual is not None
+            ), "fused_allreduce_rmsnorm requires residual input!"
+            x, residual = tensor_model_parallel_fused_allreduce_rmsnorm(
+                x,
+                residual,
+                self.weight,
+                self.eps,
+                x_pad_to_multiple=self.x_pad_to_multiple,
+            )
+            return x, residual
+        if self.x_pad_to_multiple > 0:
             if residual is None:
                 x = fused_rmsnorm_pad_(x, self.weight, self.eps, self.x_pad_to_multiple)
                 return x
@@ -265,18 +274,6 @@ class RMSNorm(nn.Module):
                     x, self.weight, self.eps, residual, self.x_pad_to_multiple
                 )
                 return x, residual
-        if self.fused_allreduce and self.tp_size > 1:
-            assert (
-                residual is not None
-            ), "fused_allreduce_rmsnorm requires residual input!"
-            # tensor_model_parallel_fused_allreduce_rmsnorm does not support non-contiguous input
-            x, residual = tensor_model_parallel_fused_allreduce_rmsnorm(
-                x.contiguous(),
-                residual,
-                self.weight,
-                self.eps,
-            )
-            return x, residual
         else:
             if x_scale is not None and self.use_fused_quant:
                 import aiter as rocm_aiter

--- a/atom/models/gpt_oss.py
+++ b/atom/models/gpt_oss.py
@@ -21,7 +21,6 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
-import torch.nn.functional as F
 from aiter import ActivationType
 from aiter.dist.communication_op import (
     tensor_model_parallel_all_gather,
@@ -226,8 +225,9 @@ class MLPBlock(torch.nn.Module):
         )
         # Detect MXFP4 MoE GEMM padding requirement from the quant method.
         # When hidden_size is not aligned to 256, MXFP4 weights are padded
-        # and the kernel expects padded input. We handle padding here instead
-        # of in the layernorm, so the layernorm can use fused AllReduce.
+        # and the kernel expects padded input. The padded activation now comes
+        # from post_attention_layernorm so we can verify kernel-side padding
+        # without an extra model-level F.pad here.
         if hasattr(self.experts.quant_method, "hidden_pad"):
             self.moe_hidden_pad = self.experts.quant_method.hidden_pad
         else:
@@ -241,17 +241,17 @@ class MLPBlock(torch.nn.Module):
 
         g = self.router(x[..., : self.hidden_size])
 
-        # Pad input for MXFP4 MoE GEMM alignment if needed
-        if self.moe_hidden_pad > 0 and self.tp_size > 1:
-            x = F.pad(x, (0, self.moe_hidden_pad))
-
         x = self.experts(hidden_states=x, router_logits=g)
 
         if self.tp_size > 1 and not ENABLE_ALLREDUCE_RMSNORM_FUSION:
             x = tensor_model_parallel_all_reduce(x)
 
-        # Remove padding from output
-        if self.moe_hidden_pad > 0:
+        # Keep the padded tail for the next fused AR+RMSNorm when fusion is
+        # enabled so the downstream kernel can consume the contiguous 3072-wide
+        # MoE output directly and slice internally.
+        if self.moe_hidden_pad > 0 and (
+            self.tp_size <= 1 or not ENABLE_ALLREDUCE_RMSNORM_FUSION
+        ):
             x = x[:, : self.hidden_size]
 
         if self.is_sequence_parallel:
@@ -292,13 +292,13 @@ class TransformerBlock(torch.nn.Module):
             fused_allreduce=ENABLE_ALLREDUCE_RMSNORM_FUSION and layer_num > 0,
         )
         # Fuse o_proj AllReduce into post_attention_layernorm.
-        # Padding for MXFP4 MoE GEMM alignment is now handled inside MLPBlock,
-        # so this layernorm no longer needs x_pad_to_multiple.
+        # Keep MXFP4 MoE alignment padding in the RMSNorm kernel path so model
+        # code does not add a separate F.pad before the MoE block.
         self.post_attention_layernorm = RMSNorm(
             config.hidden_size,
             eps=1e-5,
             fused_allreduce=ENABLE_ALLREDUCE_RMSNORM_FUSION and self.tp_size > 1,
-            x_pad_to_multiple=0 if self.tp_size > 1 else 256,
+            x_pad_to_multiple=256,
         )
 
     def forward(


### PR DESCRIPTION
## Motivation

This PR removes pad kernels before moe and slice kernel after moe in TP2 mode. Please merge this PR after https://github.com/ROCm/aiter/pull/3265/changes.

## TEST
<img width="512" height="74" alt="image" src="https://github.com/user-attachments/assets/55cf7889-62cd-4665-9c23-1dcb7d9360a5" />

## Perf

before: 4.50ms
<img width="518" height="270" alt="image" src="https://github.com/user-attachments/assets/487957d3-ee2a-4281-b89c-f5a05211073c" />

after: 4.11ms
<img width="463" height="310" alt="image" src="https://github.com/user-attachments/assets/0ec06be9-2fa4-4d42-88ee-6cc8e3c6c148" />


