### PR TITLE
[atom-vllm bench] Remove explicit temperature from vLLM bench commands

### DIFF
--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1537,10 +1537,10 @@ jobs:
                     --random-input-len=\"${ISL}\" \
                     --random-output-len=\"${OSL}\" \
                     --random-range-ratio \"${RANDOM_RANGE_RATIO}\" \
-                    --num-prompts=\"$(( CONC * 8 ))\" \
+                    --num-prompts=\"$(( CONC * 10 ))\" \
                     --max-concurrency=\"${CONC}\" \
                     ${TRUST_REMOTE_CODE_ARG} \
-                    --num-warmups=\"${CONC}\" \
+                    --num-warmups=\"$(( 2 * CONC ))\" \
                     --request-rate=inf \
                     --ignore-eos \
                     --save-result \

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1570,7 +1570,6 @@ jobs:
                     --random-input-len \"${ISL}\" \
                     --random-output-len \"${OSL}\" \
                     ${RANDOM_RANGE_RATIO:+--random-range-ratio \"${RANDOM_RANGE_RATIO}\"} \
-                    --temperature 0.0 \
                     --num-prompts \"$(( CONC * 10 ))\" \
                     --max-concurrency \"${CONC}\" \
                     ${TRUST_REMOTE_CODE_ARG} \

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1537,10 +1537,10 @@ jobs:
                     --random-input-len=\"${ISL}\" \
                     --random-output-len=\"${OSL}\" \
                     --random-range-ratio \"${RANDOM_RANGE_RATIO}\" \
-                    --num-prompts=\"$(( CONC * 10 ))\" \
+                    --num-prompts=\"$(( CONC * 8 ))\" \
                     --max-concurrency=\"${CONC}\" \
                     ${TRUST_REMOTE_CODE_ARG} \
-                    --num-warmups=\"$(( 2 * CONC ))\" \
+                    --num-warmups=\"${CONC}\" \
                     --request-rate=inf \
                     --ignore-eos \
                     --save-result \
@@ -1570,10 +1570,10 @@ jobs:
                     --random-input-len \"${ISL}\" \
                     --random-output-len \"${OSL}\" \
                     ${RANDOM_RANGE_RATIO:+--random-range-ratio \"${RANDOM_RANGE_RATIO}\"} \
-                    --num-prompts \"$(( CONC * 10 ))\" \
+                    --num-prompts \"$(( CONC * 8 ))\" \
                     --max-concurrency \"${CONC}\" \
                     ${TRUST_REMOTE_CODE_ARG} \
-                    --num-warmups \"$(( 2 * CONC ))\" \
+                    --num-warmups \"${CONC}\" \
                     --request-rate inf \
                     --ignore-eos \
                     --disable-tqdm \

--- a/recipes/atom_vllm/DeepSeek-V3.2.md
+++ b/recipes/atom_vllm/DeepSeek-V3.2.md
@@ -48,7 +48,6 @@ vllm bench serve \
     --dataset-name random \
     --random-input-len 1000 \
     --random-output-len 100 \
-    --temperature 0.0 \
     --max-concurrency 4 \
     --num-prompts 40 \
     --trust_remote_code \

--- a/recipes/atom_vllm/GLM-4.md
+++ b/recipes/atom_vllm/GLM-4.md
@@ -61,7 +61,6 @@ vllm bench serve \
     --dataset-name random \
     --random-input-len 1000 \
     --random-output-len 100 \
-    --temperature 0.0 \
     --max-concurrency 4 \
     --num-prompts 40 \
     --trust_remote_code \

--- a/recipes/atom_vllm/GPT-OSS.md
+++ b/recipes/atom_vllm/GPT-OSS.md
@@ -41,7 +41,6 @@ vllm bench serve \
     --dataset-name random \
     --random-input-len 1000 \
     --random-output-len 100 \
-    --temperature 0.0 \
     --max-concurrency 4 \
     --num-prompts 40 \
     --trust_remote_code \

--- a/recipes/atom_vllm/Kimi-K2.5.md
+++ b/recipes/atom_vllm/Kimi-K2.5.md
@@ -130,7 +130,6 @@ vllm bench serve \
     --dataset-name random \
     --random-input-len 1000 \
     --random-output-len 100 \
-    --temperature 0.0 \
     --max-concurrency 4 \
     --num-prompts 40 \
     --trust_remote_code \

--- a/recipes/atom_vllm/MiniMax-M2.5.md
+++ b/recipes/atom_vllm/MiniMax-M2.5.md
@@ -47,7 +47,6 @@ vllm bench serve \
     --dataset-name random \
     --random-input-len 1000 \
     --random-output-len 100 \
-    --temperature 0.0 \
     --max-concurrency 4 \
     --num-prompts 40 \
     --trust_remote_code \

--- a/recipes/atom_vllm/Qwen3Next.md
+++ b/recipes/atom_vllm/Qwen3Next.md
@@ -70,7 +70,6 @@ vllm bench serve \
     --dataset-name random \
     --random-input-len 1000 \
     --random-output-len 100 \
-    --temperature 0.0 \
     --max-concurrency 4 \
     --num-prompts 40 \
     --trust_remote_code \


### PR DESCRIPTION
Delete temperature value and use default one