### PR TITLE
fix: [gpt-oss] keep weight layout  gugu for triton

### DIFF
--- a/atom/models/gpt_oss.py
+++ b/atom/models/gpt_oss.py
@@ -234,7 +234,11 @@ class MLPBlock(torch.nn.Module):
             self.moe_hidden_pad = 0
 
     def process_weights_after_loading(self):
-        _interleave_swiglu_weights(self.experts)
+        # The aiter path expects the CONCAT [g|u] layout produced by
+        # _interleave_swiglu_weights (matching shuffle_weight's default
+        # is_guinterleave=False). Only run the conversion for that path.
+        if not self.experts.quant_method.use_triton:
+            _interleave_swiglu_weights(self.experts)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         num_tokens = x.shape[0]


### PR DESCRIPTION
## Motivation
  gpt-oss precision on MI308X was 0 on gsm8k. Root cause:
  `MLPBlock.process_weights_after_loading` unconditionally ran
  `_interleave_swiglu_weights`, which converts the on-disk INTERLEAVED
  `[g0,u0,g1,u1,...]` gpt-oss weights into the CONCAT `[g|u]` 
  layout expected by the aiter path (`shuffle_weight` with `is_guinterleave=False`).

## Technical Details

Gate `_interleave_swiglu_weights` on `not self.experts.quant_method.use_triton`,
  so the conversion only runs for the aiter consumer that needs CONCAT
  `[g|u]`. The triton consumer keeps the on-disk INTERLEAVED layout intact.

## Test Plan

**Same as ci for gpt-oss-120b:**
  python -m atom.entrypoints.openai_server
    --model /data/models/gpt-oss-120b
    --kv_cache_dtype fp8 --gpu-memory-utilization 0.5 --server-port 8000

  lm_eval --model local-chat-completions --apply_chat_template
    --model_args 'model=...,base_url=http://localhost:8000/v1/chat/completions,
                  num_concurrent=65,max_retries=3,max_gen_toks=2048,
                  tokenized_requests=False,trust_remote_code=True'
    --tasks gsm8k --num_fewshot 3

## Test Result

MI308:
 GPT-OSS-120b    │ flexible: 0.8954   │strict: 0.1873

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
