### PR TITLE
[FIX] fix configurable bpreshuffle option, disable it's effect on moe

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1336,15 +1336,12 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
             layer.w13_weight_scale = atom_parameter(max_w13_scales)
 
         # Shuffle weights for asm moe (moved from inference to load time for better performance).
-        if (
-            w13.dtype
-            in [
-                torch.int8,
-                torch.uint8,
-                torch.float8_e4m3fnuz,
-                torch.float8_e4m3fn,
-            ]
-        ):
+        if w13.dtype in [
+            torch.int8,
+            torch.uint8,
+            torch.float8_e4m3fnuz,
+            torch.float8_e4m3fn,
+        ]:
             from aiter.ops.shuffle import shuffle_weight
 
             w13.data = shuffle_weight(w13.data)
@@ -2818,15 +2815,6 @@ class FusedMoE(torch.nn.Module):
             f"ep_size={self.ep_size}, "
             f"reduce_results={self.reduce_results}, "
             f"renormalize={self.renormalize}, "
-            f"use_grouped_topk={self.use_grouped_topk}"
-        )
-
-        if self.use_grouped_topk:
-            s += f", num_expert_group={self.num_expert_group}, topk_group={self.topk_group}"  # noqa: E501
-
-        s += f", scoring_func='{self.scoring_func}', activation='{self.activation}'"  # noqa: E501
-
-        return s
             f"use_grouped_topk={self.use_grouped_topk}"
         )
 

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1336,11 +1336,6 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
             layer.w13_weight_scale = atom_parameter(max_w13_scales)
 
         # Shuffle weights for asm moe (moved from inference to load time for better performance).
-        # For per_1x128 blockscale (block_quant), only shuffle when the preshuffle GEMM
-        # path is enabled — the non-preshuffle kernel expects the un-shuffled layout.
-        skip_shuffle_for_block = (
-            self.block_quant and not envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
-        )
         if (
             w13.dtype
             in [
@@ -1349,7 +1344,6 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
                 torch.float8_e4m3fnuz,
                 torch.float8_e4m3fn,
             ]
-            and not skip_shuffle_for_block
         ):
             from aiter.ops.shuffle import shuffle_weight
 
@@ -1660,11 +1654,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w2_weight = atom_parameter(layer.w2_weight.data)
             layer.w2_weight_scale = atom_parameter(layer.w2_weight_scale.data)
 
-        # per_1x128 blockscale MoE only needs weight bpreshuffle when the
-        # preshuffle GEMM path is enabled. Skip it to match the non-preshuffle
-        # kernel's expected weight layout.
-        if envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE:
-            shuffle_weights(layer.w13_weight, layer.w2_weight)
+        shuffle_weights(layer.w13_weight, layer.w2_weight)
 
     def _process_channel_quant(self, layer: nn.Module) -> None:
         """PTPTC"""
@@ -2828,6 +2818,15 @@ class FusedMoE(torch.nn.Module):
             f"ep_size={self.ep_size}, "
             f"reduce_results={self.reduce_results}, "
             f"renormalize={self.renormalize}, "
+            f"use_grouped_topk={self.use_grouped_topk}"
+        )
+
+        if self.use_grouped_topk:
+            s += f", num_expert_group={self.num_expert_group}, topk_group={self.topk_group}"  # noqa: E501
+
+        s += f", scoring_func='{self.scoring_func}', activation='{self.activation}'"  # noqa: E501
+
+        return s
             f"use_grouped_topk={self.use_grouped_topk}"
         )
 


### PR DESCRIPTION
## Motivation
moe select shuffle path all the time no matter if we shuffle weight in post_weight_loading_process. This fix accuracy of disable bpreshuffle weight.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
