### PR TITLE
[fix](gpt-oss): change gpu utilization for large lenth

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -83,7 +83,7 @@
     "display": "gpt-oss-120b",
     "path": "openai/gpt-oss-120b",
     "prefix": "gpt-oss-120b",
-    "args": "--kv_cache_dtype fp8 --gpu-memory-utilization 0.5",
+    "args": "--kv_cache_dtype fp8 --gpu-memory-utilization 0.9",
     "bench_args": "",
     "suffix": "",
     "runner": "atom-mi355-8gpu.predownload",

--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -49,7 +49,7 @@
           "prefix": "gpt-oss-120b-met",
           "dashboard_model": "gpt-oss-120b-tp1",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --gpu-memory-utilization 0.5 --max-num-batched-tokens 16384 --max-model-len 16384",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --gpu-memory-utilization 0.8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
         {
@@ -58,7 +58,7 @@
           "dashboard_model": "gpt-oss-120b-aw-tp1",
           "prefix": "gpt-oss-120b-aw-tp1",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 16384 --max-model-len 16384",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --gpu-memory-utilization 0.8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
         {
@@ -67,7 +67,7 @@
           "dashboard_model": "gpt-oss-120b-aw-tp2",
           "prefix": "gpt-oss-120b-aw-tp2",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 2 --gpu-memory-utilization 0.5 --max-num-batched-tokens 16384 --max-model-len 16384",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 2 --gpu-memory-utilization 0.8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
         {
@@ -76,7 +76,7 @@
           "dashboard_model": "gpt-oss-120b-aw-tp8",
           "prefix": "gpt-oss-120b-aw-tp8",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --gpu-memory-utilization 0.5 --max-num-batched-tokens 16384 --max-model-len 16384",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --gpu-memory-utilization 0.8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         }
       ]


### PR DESCRIPTION
## Motivation

This PR changed the --gpu-memory-utilization args to 0.9 for atom and 0.8 for vllm-atom. because large lenth and concurrency for gpt-oss such as 10k1k 256 conc need more kvcache.