### PR TITLE
workflow: avoid ARG_MAX failure in benchmark summary step

### DIFF
--- a/.github/scripts/plugin_benchmark_summary.py
+++ b/.github/scripts/plugin_benchmark_summary.py
@@ -193,8 +193,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--matrix-json",
-        required=True,
+        default=None,
         help="Benchmark matrix JSON from the workflow",
+    )
+    parser.add_argument(
+        "--matrix-json-file",
+        default=None,
+        help="Path to a file containing benchmark matrix JSON",
     )
     parser.add_argument(
         "--run-url",
@@ -213,7 +218,15 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    matrix_payload = json.loads(args.matrix_json)
+    matrix_json_text = None
+    if args.matrix_json_file:
+        matrix_json_text = Path(args.matrix_json_file).read_text(encoding="utf-8")
+    elif args.matrix_json:
+        matrix_json_text = args.matrix_json
+    else:
+        raise ValueError("Either --matrix-json or --matrix-json-file must be provided")
+
+    matrix_payload = json.loads(matrix_json_text)
     rows = _build_rows(Path(args.result_dir), matrix_payload)
 
     _print_markdown_table(rows, args.run_url, args.title)

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1144,6 +1144,16 @@ jobs:
             echo "Benchmark matrix: ${BENCHMARK_MATRIX}"
           fi
 
+      - name: Persist benchmark matrix payload
+        run: |
+          printf '%s' '${{ steps.build.outputs.benchmark_matrix }}' > benchmark_matrix.json
+
+      - name: Upload benchmark matrix payload
+        uses: actions/upload-artifact@v8
+        with:
+          name: oot-benchmark-matrix
+          path: benchmark_matrix.json
+
   build-oot-image:
     name: Build custom OOT benchmark image
     needs: [resolve-atom-source, build-benchmark-matrix]
@@ -1850,6 +1860,12 @@ jobs:
           echo "downloaded_count=${#json_files[@]}" >> "$GITHUB_OUTPUT"
           printf 'Downloaded %s benchmark result files\n' "${#json_files[@]}"
 
+      - name: Download benchmark matrix payload
+        uses: actions/download-artifact@v8
+        with:
+          name: oot-benchmark-matrix
+          path: .
+
       - name: Note summary behavior
         run: |
           printf '### Summary mode\nResults from `%s@%s` using `%s` OOT image mode are shown below as a workflow summary table.\n- Benchmark client: `%s`\n- Upload to dashboard: `%s`\n- Upload to custom dashboard: `%s`\n' \
@@ -1878,12 +1894,11 @@ jobs:
 
       - name: Generate OOT benchmark summary table
         env:
-          BENCHMARK_MATRIX: ${{ needs.build-benchmark-matrix.outputs.benchmark_matrix }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/scripts/plugin_benchmark_summary.py \
             --result-dir . \
-            --matrix-json "${BENCHMARK_MATRIX}" \
+            --matrix-json-file benchmark_matrix.json \
             --run-url "${RUN_URL}" \
             --output-json oot_benchmark_summary.json \
             --title "ATOM-vLLM Benchmark Summary" \


### PR DESCRIPTION
Summary
This PR fixes a workflow reliability issue in ATOM vLLM Benchmark where the summary job can fail before execution with:

Argument list too long

Root cause: the workflow passes a very large BENCHMARK_MATRIX JSON as an env var / CLI argument (--matrix-json "${BENCHMARK_MATRIX}") in summarize-benchmark-result. For large matrices, this exceeds process argument/environment size limits (ARG_MAX), so the step fails to start and all downstream dashboard publishing steps are skipped.

What Changed
Updated .github/workflows/atom-vllm-benchmark.yaml

Persist benchmark matrix to benchmark_matrix.json
Upload it as artifact oot-benchmark-matrix in build-benchmark-matrix
Download the artifact in summarize-benchmark-result
Switch summary script invocation from:
--matrix-json "${BENCHMARK_MATRIX}"
to --matrix-json-file benchmark_matrix.json
Updated .github/scripts/plugin_benchmark_summary.py

Added --matrix-json-file input
Kept backward compatibility with existing --matrix-json
Uses file input when provided, falls back to inline JSON otherwise
Why This Fix
Avoids ARG_MAX/env-size overflows for large benchmark matrices
Keeps behavior unchanged for summary generation and downstream publish logic
Preserves compatibility for any existing callers still using --matrix-json
Validation
Python syntax check passed for .github/scripts/plugin_benchmark_summary.py
The fix directly addresses the failing run pattern seen in benchmark summary startup failures
No change to benchmark result semantics; only matrix transport path is changed
Impact
Prevents summary-stage startup failure in large scheduled runs
Allows downstream steps (including LLM-Booster dashboard publish) to proceed when benchmark artifacts are available