### PR TITLE
[atom-vllm benchmark] Fix actions/artifact@v8 → v7 in benchmark workflows

### DIFF
--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1149,7 +1149,7 @@ jobs:
           printf '%s' '${{ steps.build.outputs.benchmark_matrix }}' > benchmark_matrix.json
 
       - name: Upload benchmark matrix payload
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: oot-benchmark-matrix
           path: benchmark_matrix.json


### PR DESCRIPTION
actions/upload-artifact@v8 and actions/download-artifact@v8 do not exist, causing "Build OOT benchmark matrix" to fail immediately on resolve (e.g. run 26220767113).  Downgrade all occurrences back to @v7 in both atom-benchmark.yaml and atom-vllm-benchmark.yaml.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
