### PR TITLE
[vLLM-ATOM] Pass fp8 dtype to sparse MLA metadata

### DIFF
--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -1873,6 +1873,8 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
             max_seqlen_qo=1,
             uni_seqlen_qo=1,
             fast_mode=True,
+            dtype_q=_get_aiter_kv_cache_dtype(self.vllm_config),
+            dtype_kv=_get_aiter_kv_cache_dtype(self.vllm_config),
         )
 
         attn_metadata_for_plugin_mode = AiterMLASparseMetadataForPluginMode(
@@ -2393,7 +2395,7 @@ def create_mla_sparse_attn_metadata_builder_init_method(base_class):
             max_num_batched_tokens,
             1,
             self.padded_num_heads,
-            torch.bfloat16,
+            _get_aiter_kv_cache_dtype(config),
             _get_aiter_kv_cache_dtype(config),
             is_sparse=True,
             fast_mode=True,


### PR DESCRIPTION
## Summary
- Pass the configured AITER KV cache dtype into sparse MLA metadata generation in plugin mode.
- Size persistent sparse MLA metadata buffers with the real KV cache dtype instead of hard-coding bf16 for the query dtype.
- This keeps ATOM plugin metadata dispatch aligned with AITER's fp8 sparse MLA folded decode path.

## Problem
DeepSeek V3.2 with TP4 and `--kv-cache-dtype fp8` uses 32 local query heads. AITER's fast persistent sparse MLA decode path does not natively handle `fp8/fp8, nhead=32, q_len=1`; it folds the work into two 16-head query groups to keep a single kernel launch.

Before this change, the ATOM plugin did not consistently pass the configured dtype into AITER metadata setup. That could make metadata sizing or dispatch disagree with the actual fp8 decode path, especially for dtype-sensitive folded metadata.

## Why This Fix Is Reasonable
The actual attention kernel already sees the real tensor dtypes. This change makes the metadata builder use the same dtype information, so buffer allocation and AITER metadata generation follow the same fp8 path as decode. The companion AITER change fixes the folded sparse batch mapping itself; this ATOM change ensures the plugin selects and sizes that metadata path correctly.

## Accuracy Validation
GSM8K was run with `my_test/test_accuracy.sh` using 20-shot local completions on DeepSeek V3.2 with `--kv-cache-dtype fp8`.

Before the root-cause fix, TP4 fp8 sparse MLA showed severe accuracy degradation. After this ATOM change plus the companion AITER metadata fix:

- TP4 fp8 KV: flexible-extract exact_match = 0.9507 +/- 0.0060
- TP4 fp8 KV: strict-match exact_match = 0.9500 +/- 0.0060
- TP8 fp8 KV: flexible-extract exact_match = 0.9530 +/- 0.0058
- TP8 fp8 KV: strict-match exact_match = 0.9522 +/- 0.0059

TP8 is included as a guardrail. It has 16 local heads and therefore uses the native sparse MLA fast path rather than the TP4 32-head folded path.

## Test Plan
- `git diff --check`
- DeepSeek V3.2 TP4 + `--kv-cache-dtype fp8`, GSM8K 20-shot accuracy
- DeepSeek V3.2 TP8 + `--kv-cache-dtype fp8`, GSM8K 20-shot accuracy

Made with [Cursor](https://cursor.com)