### PR TITLE
[vLLM-ATOM] Support 64 heads for MLA under DP

### DIFF
--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -5,8 +5,9 @@ from dataclasses import dataclass
 
 import torch
 
-from aiter import get_mla_metadata_info_v1, get_mla_metadata_v1
+from aiter import dtypes, get_mla_metadata_info_v1, get_mla_metadata_v1
 from aiter.dist.parallel_state import get_dp_group, get_tp_group
+from aiter.jit.utils.chip_info import get_gfx
 from atom.model_ops.attention_mla import MLAAttention, _MLA_MIN_HEADS
 from atom.plugin.attention_mla import (
     disabled_mla_persistent_metadata,
@@ -687,6 +688,15 @@ class AiterMLADecodeMetadataForPluginMode(AiterMLACommonDecodeMetadataForPluginM
     attn_out_dtype: torch.dtype = torch.bfloat16
     # The max query output length: int
     max_qo_len: int | None = None
+    # The fold factor for handling mqa_ratio=64 in non-persistent mode
+    fold_factor: int | None = None
+    # Fold buffers for 64-head MLA workaround. These are populated at the
+    # fwd of the first MLA layer so they stay inside the cudagraph capture
+    # region, and then reused by subsequent layers
+    fold_kv_indptr: torch.Tensor | None = None
+    fold_kv_indices: torch.Tensor | None = None
+    fold_qo_indptr: torch.Tensor | None = None
+    fold_kv_last_page_len: torch.Tensor | None = None
 
 
 @dataclass
@@ -890,9 +900,12 @@ class vllmMLAAttentionMetadataBuilderMethods:
 
         # Disable persistent MLA in DP mode: pre-computed metadata buffers
         # are invalid when request counts vary across DP ranks each step.
-        if get_dp_group().world_size <= 1:
+        dp_enabled = get_dp_group().world_size > 1
+        if not dp_enabled:
             ctx_mla_ps = self._set_mla_persistent_worker_buffers(num_reqs, qo_indptr, 1)
             self.mla_persistent_metadata.update(ctx_mla_ps)
+
+        fold_factor = self._mla_fold_factor if self._mla_fold_enabled and dp_enabled and max_qo_len == 1 else None
 
         attn_metadata = AiterMLADecodeMetadataForPluginMode(
             block_table=block_table_tensor,
@@ -904,6 +917,7 @@ class vllmMLAAttentionMetadataBuilderMethods:
             dcp_tot_seq_lens=dcp_tot_seq_lens_device,
             max_qo_len=max_qo_len,
             attn_out_dtype=self.decode_attn_out_dtype,
+            fold_factor=fold_factor,
         )
 
         return attn_metadata
@@ -1312,6 +1326,20 @@ def create_mla_attn_metadata_builder_init_method(base_class):
                 device=self.device,
             ),
         }
+
+        # Workaround for the missing MLA fp8/fp8 nhead=64 qseqlen=1
+        # non-persistent kernel on gfx950. Leverage the pre-existing
+        # 16-head non-persistent kernels, folding the q/o tensors to
+        # 16 heads
+        self._mla_fold_enabled = (
+            self.padded_num_attention_heads in [64, 32]
+            and self.dtype_q == dtypes.fp8
+            and self.dtype_kv == dtypes.fp8
+            and get_gfx() == "gfx950"
+        )
+        self._mla_fold_factor = (
+            self.padded_num_attention_heads // 16 if self._mla_fold_enabled else 1
+        )
 
     return init_method_under_plugin_mode
 

--- a/atom/plugin/attention_mla.py
+++ b/atom/plugin/attention_mla.py
@@ -24,6 +24,9 @@ from atom.model_ops.linear import use_triton_gemm
 from atom.plugin.prepare import is_vllm
 from atom.utils import envs
 
+import triton
+import triton.language as tl
+
 
 import logging
 
@@ -137,6 +140,75 @@ def reorg_kvcache(
     assert reorganized_k_pe.shape[0] == sum_seq_len
     assert max_seq_len_check == max_seq_len
     return reorganized_kv_c_normed, reorganized_k_pe
+
+
+@triton.jit
+def mla_fold_kv_metadata_kernel(
+    paged_kv_indptr_ptr,   # [num_reqs + 1]   int32
+    paged_kv_indices_ptr,  # [>= paged_kv_indptr[-1]]  int32
+    fold_kv_indptr_ptr,    # [num_reqs * FOLD_FACTOR + 1]  int32, entry [0] pre-zeroed
+    fold_kv_indices_ptr,   # [>= FOLD_FACTOR * paged_kv_indptr[-1] + TAIL_PADDING] int32
+    FOLD_FACTOR: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Build folded kv metadata for the MLA nhead=64 -> nhead=16 workaround.
+    Each original batch's KV-index segment is replicated FOLD_FACTOR times
+    back-to-back in `fold_kv_indices`, and `fold_kv_indptr` gets the matching
+    expanded indptr.
+    """
+    orig_batch = tl.program_id(0)
+    fold_idx = tl.program_id(1)
+
+    seq_start = tl.load(paged_kv_indptr_ptr + orig_batch)
+    seq_end = tl.load(paged_kv_indptr_ptr + orig_batch + 1)
+    seq_len = seq_end - seq_start
+
+    # Each (orig_batch, fold_idx) program writes its one indptr entry.
+    # Entry 0 of fold_kv_indptr stays at its pre-init zero.
+    out_indptr_idx = orig_batch * FOLD_FACTOR + fold_idx + 1
+    out_indptr_val = FOLD_FACTOR * seq_start + (fold_idx + 1) * seq_len
+    tl.store(fold_kv_indptr_ptr + out_indptr_idx, out_indptr_val)
+
+    # Copy the KV-index segment for synthetic batch (orig_batch, fold_idx).
+    dst_start = FOLD_FACTOR * seq_start + fold_idx * seq_len
+
+    for offset_start in range(0, seq_len, BLOCK_SIZE):
+        offsets = offset_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < seq_len
+        src = tl.load(paged_kv_indices_ptr + seq_start + offsets, mask=mask)
+        tl.store(fold_kv_indices_ptr + dst_start + offsets, src, mask=mask)
+
+
+def mla_fold_kv_metadata_triton(
+    paged_kv_indptr,
+    paged_kv_indices,
+    fold_kv_indptr,
+    fold_kv_indices,
+    fold_factor,
+    num_reqs,
+):
+    """Populate `fold_kv_indptr` and `fold_kv_indices` in-place for the
+    MLA nhead-fold workaround. All input/output tensors must already be
+    allocated; this kernel only writes.
+    Args:
+        paged_kv_indptr: [num_reqs+1] int32, the original kv indptr.
+        paged_kv_indices: [paged_kv_indptr[-1]] int32, original kv indices.
+        fold_kv_indptr: [num_reqs*fold_factor + 1] int32, output indptr.
+        fold_kv_indices: [fold_factor * paged_kv_indptr[-1]] int32.
+        fold_factor: integer fold factor (e.g. 4 for nhead 64 → 16).
+        num_reqs: number of decode requests (size of `paged_kv_indptr` - 1).
+    """
+    if num_reqs == 0:
+        return
+    grid = (num_reqs, fold_factor)
+    mla_fold_kv_metadata_kernel[grid](
+        paged_kv_indptr,
+        paged_kv_indices,
+        fold_kv_indptr,
+        fold_kv_indices,
+        FOLD_FACTOR=fold_factor,
+        BLOCK_SIZE=256,
+    )
 
 
 class MLAAttentionImplPluginModeMethods:
@@ -612,14 +684,73 @@ class MLAAttentionImplPluginModeMethods:
         paged_kv_indptr = attn_metadata.plugin_metadata.decode.paged_kv_indptr
         paged_kv_indices = attn_metadata.plugin_metadata.decode.paged_kv_indices
 
+        qo_indptr = attn_metadata.plugin_metadata.decode.qo_indptr
+        paged_kv_last_page_len = (
+            attn_metadata.plugin_metadata.decode.paged_kv_last_page_len
+        )
+        
+        fold_factor = attn_metadata.plugin_metadata.decode.fold_factor
+        do_fold = fold_factor is not None and fold_factor > 1
+        if do_fold:
+            decode_md = attn_metadata.plugin_metadata.decode
+            if decode_md.fold_kv_indptr is None:
+                num_reqs = paged_kv_indptr.shape[0] - 1
+                new_bs = num_reqs * fold_factor
+                # Capture-time worst-case seq_len per request - vLLM's
+                # dummy_run uses max_model_len, so this sets an upper bound
+                # for the buffer length that's preserved at replay (the
+                # captured allocation has this exact size).
+                max_seq_len = attn_metadata.plugin_metadata.max_seq_len
+                fold_kv_indices_len = (
+                    num_reqs * max_seq_len * fold_factor
+                )
+
+                new_kv_indptr = torch.zeros(
+                    new_bs + 1, dtype=torch.int32, device=q.device
+                )
+                new_kv_indices = torch.empty(
+                    fold_kv_indices_len, dtype=torch.int32, device=q.device
+                )
+                new_qo_indptr = torch.arange(
+                    new_bs + 1, dtype=torch.int32, device=q.device
+                )
+                new_kv_last_page_lens = torch.ones(
+                    new_bs, dtype=torch.int32, device=q.device
+                )
+
+                mla_fold_kv_metadata_triton(
+                    paged_kv_indptr,
+                    paged_kv_indices,
+                    new_kv_indptr,
+                    new_kv_indices,
+                    fold_factor=fold_factor,
+                    num_reqs=num_reqs,
+                )
+
+                decode_md.fold_kv_indptr = new_kv_indptr
+                decode_md.fold_kv_indices = new_kv_indices
+                decode_md.fold_qo_indptr = new_qo_indptr
+                decode_md.fold_kv_last_page_len = new_kv_last_page_lens
+
+            paged_kv_indptr = decode_md.fold_kv_indptr
+            paged_kv_indices = decode_md.fold_kv_indices
+            qo_indptr = decode_md.fold_qo_indptr
+            paged_kv_last_page_len = decode_md.fold_kv_last_page_len
+
+            ori_total_s, ori_nhead = q.shape[0], q.shape[1]
+            new_nhead = ori_nhead // fold_factor
+            new_total_s = ori_total_s * fold_factor
+            q = q.view(new_total_s, new_nhead, -1)
+            o = o.view(new_total_s, new_nhead, -1)
+
         mla_decode_fwd(
             q,
             kv_buffer.view(-1, 1, 1, q.shape[-1]),
             o,
-            attn_metadata.plugin_metadata.decode.qo_indptr,
+            qo_indptr,
             paged_kv_indptr,
             paged_kv_indices,
-            attn_metadata.plugin_metadata.decode.paged_kv_last_page_len,
+            paged_kv_last_page_len,
             attn_metadata.plugin_metadata.decode.max_qo_len,
             sm_scale=self.scale,
             work_meta_data=work_meta_data,
@@ -631,6 +762,8 @@ class MLAAttentionImplPluginModeMethods:
             q_scale=layer._q_scale,
             kv_scale=layer._k_scale,
         )
+        if do_fold:
+            o = o.view(ori_total_s, ori_nhead, -1)
         if self.head_repeat_factor > 1:
             o = o[:, :: self.head_repeat_factor, :]
         return o, None

--- a/atom/plugin/vllm/models/kimi_k25.py
+++ b/atom/plugin/vllm/models/kimi_k25.py
@@ -57,6 +57,12 @@ class KimiK25Model(DeepseekV2Model):
         else:
             self.embed_tokens = PPMissingLayer()
 
+        self.alt_stream: Optional[torch.cuda.Stream] = None
+        if getattr(config, "n_shared_experts", None) is not None:
+            self.alt_stream = torch.cuda.Stream()
+
+        _alt_stream = self.alt_stream
+
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
             lambda prefix, layer_num=None: DeepseekV2DecoderLayer(
@@ -66,6 +72,7 @@ class KimiK25Model(DeepseekV2Model):
                 cache_config=cache_config,
                 quant_config=quant_config,
                 layer_num=layer_num,
+                alt_stream=_alt_stream,
             ),
             prefix=f"{prefix}.layers",
             layer_num_offset=0,


### PR DESCRIPTION
## Motivation
When DP>1, MLA goes through the non-persistent path, but aiter currently lacks a non-persistent kernel that handles the 64-head fp8 attention workload on gfx950, making models like Kimi-K2 fail to launch. This PR works around this by folding the 64-head workloads to 16 heads so that this can be handled by existing kernels.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
This PR adds support for DP to Kimi-K2 by folding query and output tensors into 16 heads. The expansion of the related arguments is performed at the first layer of each forward so that they can be reused at the subsequent layers while staying in the cudagraph pool.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
lm_eval with gsm8k on MI355X

Model: amd/Kimi-K2.5-MXFP4-AttnFP8, DP8+EP

Server:
```
AITER_QUICK_REDUCE_QUANTIZATION=INT4 \
vllm serve amd/Kimi-K2.5-MXFP4-AttnFP8 \
    --host localhost \
    --port 8000 \
    --async-scheduling \
    --data-parallel-size 8 \
    --enable-expert-parallel \
    --trust-remote-code \
    --gpu_memory_utilization 0.9 \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --kv-cache-dtype fp8 \
    --no-enable-prefix-caching
```

lm_eval
```
lm_eval --model local-completions --model_args model=amd/Kimi-K2.5-MXFP4-AttnFP8,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True --tasks gsm8k --num_fewshot 5
```
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|_  |0.9378|_  |0.0067|
|     |       |strict-match    |     5|exact_match|_  |0.9378|_  |0.0067|
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
