### PR TITLE
[fix][moe] DeepSeek V4+ EP: pass correct expert_mask and register as buffer

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1031,7 +1031,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 layer.w2_weight,
                 topk_weights,
                 topk_ids,
-                expert_mask=expert_map,
+                expert_mask=layer.expert_mask,
                 activation=activation,
                 quant_type=self.quant_type,
                 w1_scale=layer.w13_weight_scale,
@@ -1947,6 +1947,8 @@ class FusedMoE(torch.nn.Module):
             tp_size, dp_size, atom_config
         )
         self.global_num_experts = num_experts
+        self.register_buffer("expert_map", None, persistent=False)
+        self.register_buffer("expert_mask", None, persistent=False)
         if self.use_ep:
             self.local_num_experts, self.expert_map = determine_expert_map(
                 ep_size=self.ep_size,
@@ -1955,7 +1957,6 @@ class FusedMoE(torch.nn.Module):
             )
         else:
             self.local_num_experts = self.global_num_experts
-            self.expert_map = None
         self.top_k = top_k
         self.global_num_experts = num_experts
         self.shared_expert_scoring_func = shared_expert_scoring_func
@@ -1973,11 +1974,11 @@ class FusedMoE(torch.nn.Module):
             if config is not None and atom_config.torch_dtype != torch.float16
             else 1.0
         )
-        self.expert_mask = None
         if self.use_ep:
             expert_mask = torch.ones(
                 (self.global_num_experts + self.num_fused_shared_experts + 1,),
                 dtype=torch.int32,
+                device=self.expert_map.device,
             )
             expert_mask[-1] = 0
             expert_mask[: self.global_num_experts] = self.expert_map > -1


### PR DESCRIPTION
## Summary
This PR #875 can fix triton moe, and now we fixed flydsl related moe

Two related fixes for `FusedMoE` under expert-parallel (EP) routing with the `Mxfp4MoEMethod` dispatch — required to run DeepSeek V4-Pro with `--enable-expert-parallel`


## Bugs fixed

1. `Mxfp4MoEMethod.apply`: wrong argument value passed to `aiter.fused_moe`

`aiter.fused_moe` expects a **binary (0/1) `expert_mask`**, not the index-style `expert_map` (which carries `-1` sentinels for non-local experts).

Before:
```python
expert_mask=expert_map,   # values like [0, 1, 2, 3, -1, -1, ...]
```
Under EP the kernel uses `mask[i] == 1` internally, so any local expert with id ≠ 1 was incorrectly skipped, and non-local entries (`-1`) hit undefined comparisons. Output was essentially garbage / near-zero.

After:
```python
expert_mask=layer.expert_mask,   # values like [1, 1, 1, 1, 0, 0, ...]
```



 2. `FusedMoE.__init__`: `expert_map` / `expert_mask` not migrated to GPU


