### PR TITLE
ci(accuracy): switch Qwen3.5 BF16 nightly from 397B to 35B-A3B

### DIFF
--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -230,16 +230,16 @@
     "_baseline_note": "CI uses 3-shot, not comparable to HF 5-shot baseline"
   },
   {
-    "model_name": "Qwen3.5-397B-A17B",
-    "model_path": "Qwen/Qwen3.5-397B-A17B",
-    "extraArgs": "--kv_cache_dtype fp8 -tp 8",
+    "model_name": "Qwen3.5-35B-A3B TP2",
+    "model_path": "Qwen/Qwen3.5-35B-A3B",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 2",
     "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "nightly",
-    "accuracy_threshold": 0.85,
-    "accuracy_baseline": 0.9538,
-    "accuracy_baseline_model": "Qwen3.5-397B-A17B-FP8",
-    "_baseline_note": "BF16 weight, TP8. Placeholder threshold/baseline copied from FP8 entry; refresh after first CI measurement."
+    "accuracy_threshold": 0.83,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "Qwen/Qwen3.5-35B-A3B",
+    "_baseline_note": "Threshold referenced from the sglang nightly entry for the same model; refresh after first CI measurement."
   },
   {
     "model_name": "Qwen3.5-397B-A17B-FP8",


### PR DESCRIPTION


## Motivation

397B BF16 keeps timing out the 30-min server-launch step. Switch to Qwen3.5-35B-A3B BF16 TP2 (aligned with sglang nightly). Threshold 0.83 referenced from sglang; baseline refreshed after first CI run.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
