### PR TITLE
V4-Pro: paged prefill/decode meta hot-path + MTP3 direct-kernel + recipe refresh

### DIFF
--- a/.claude/skills/atom-patterns/SKILL.md
+++ b/.claude/skills/atom-patterns/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: atom-patterns
 description: Coding patterns and architecture index for the ATOM LLM inference engine
-version: 1.1.0
-source: local-git-analysis
+version: 1.2.0
+scope: ATOM repo on AMD ROCm
+last_updated: 2026-05-20
 ---
 
 # ATOM Patterns
@@ -28,12 +29,9 @@ atom/
 │   ├── attention_mla.py       # MLA attention (DeepSeek)
 │   ├── attention_mha.py       # Standard MHA attention
 │   └── paged_attention.py     # Paged attention backend
-├── models/                    # Model implementations
-│   ├── deepseek_v2.py         # DeepSeek V3/V3.2/GLM-5 (shared)
-│   ├── deepseek_v4.py         # DeepSeek V4 (HC, sparse attn, FP4 MoE)
-│   ├── deepseek_mtp.py        # DeepSeek MTP (speculative)
-│   ├── llama.py               # Llama family
-│   └── qwen3*.py              # Qwen3 variants
+├── models/                    # Model implementations (one file per family;
+│                              # `*_mtp.py` for MTP / speculative variants —
+│                              # run `ls atom/models/` for the current set)
 ├── spec_decode/
 │   └── eagle.py               # MTP proposer (speculative decoding)
 ├── plugin/                    # vLLM/SGLang plugin adapters
@@ -73,10 +71,11 @@ support_model_arch_dict = {
 
 ### Model Reuse Relationships
 
-- `deepseek_v2.py` ← DeepSeek V3, V3.2, GLM-5
-- `deepseek_v4.py` ← DeepSeek V4 (standalone, uses HC + sparse attn)
-- `deepseek_mtp.py` ← DeepSeek MTP models
-- `qwen3_5_mtp.py` ← Qwen3.5 MTP (hybrid GDN + full attention)
+One model file often serves multiple HuggingFace `model_type`s when their architecture is identical or a strict subset. The mapping lives in `atom/model_engine/model_runner.py:support_model_arch_dict` — that's the authoritative source. Common patterns:
+
+- A shared base file covers a family of closely-related releases (e.g. DeepSeek V3 / V3.2 / GLM-5 all dispatch to one `deepseek_v2.py`).
+- A standalone file when the architecture diverges enough that sharing causes branching everywhere (e.g. DeepSeek V4's hot-cold sparse attention + FP4 MoE).
+- An `_mtp.py` companion when the spec-decode head differs from the base model.
 
 ### TP Parallel Linear Pattern
 
@@ -129,21 +128,11 @@ MoE pattern: FusedMoE + shared_experts both use `reduce_results=False`, parent d
 
 ## Environment Variables
 
-All defined in `atom/utils/envs.py` as lazy lambdas:
-
-```python
-"ATOM_USE_TRITON_GEMM": lambda: os.getenv("ATOM_USE_TRITON_GEMM", "0") == "1",
-```
-
-Key vars:
-- `AITER_LOG_LEVEL=WARNING` — suppress kernel log flooding
-- `ATOM_USE_TRITON_MOE=1` — triton MoE for V4
-- `ATOM_V4_TORCH_MOE=1` — torch fallback MoE for V4
-- `ATOM_V4_DIAG=1` — V4 diagnostic prints
+Authoritative list: `atom/utils/envs.py` (all `ATOM_*` defined as lazy lambdas). To read what an env var does, grep the file for its name — the lambda and the call site comment describe the behavior. Required per-model env vars are listed in `.github/benchmark/models.json` and `.github/benchmark/models_accuracy.json`.
 
 ## CI/CD
 
-- Accuracy tests: `.github/benchmark/models_accuracy.json` (model matrix)
-- Benchmark: `.github/benchmark/models.json`
-- Dashboard: `.github/dashboard/index.html` (gh-pages)
-- Docker: `docker login --password-stdin`, `checkout@v6`, `upload-artifact@v7`
+- Accuracy tests: `.github/benchmark/models_accuracy.json` (model matrix, thresholds, baselines).
+- Benchmark: `.github/benchmark/models.json` (server args, bench args, runner pinning).
+- Dashboard: `.github/dashboard/index.html` (gh-pages).
+- Workflows + action versions: `.github/workflows/*.yaml` is the source of truth (action versions pinned per workflow).

--- a/.claude/skills/capture-trace/SKILL.md
+++ b/.claude/skills/capture-trace/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: capture-trace
 description: Capture a PyTorch profiler / kineto trace from a running ATOM server for a short benchmark window. Use when the user asks for "a trace", "profiler trace", "GPU trace", or "抓 trace" for performance investigation — what kernels ran, what's on the critical path, what's slow. Do NOT use for crashes (use debug-agent-locate-kernel) or numerical bugs (use dump-bisect-debug).
-version: 1.1.0
+version: 1.2.0
 scope: ATOM on AMD ROCm (PyTorch kineto profiler, per-rank `*.pt.trace.json.gz`)
-last_updated: 2026-05-17
+last_updated: 2026-05-20
 ---
 
 ## When to use
@@ -159,18 +159,10 @@ Searching by these tags is far more reliable than searching by kernel name (whic
 - Default `=0` (kernel names + durations only — enough for 95% of investigations)
 - `=1` only when you specifically need shapes or Python stacks AND you've kept the window short (≤ 5 seconds of bench traffic, ≤ `CONC * 1` prompts)
 
-## Common model configs
+## Looking up model configs
 
-| Model | Path | TP | Server `EXTRA_ARGS` | Bench notes |
-|---|---|---|---|---|
-| DeepSeek-V4-Pro | `/data/DeepSeek-V4-Pro` | 8 | `--level 0` (CG not yet enabled) | tokenizer has no chat template — do NOT pass `--use-chat-template` |
-| DeepSeek-V4-Pro MTP1 | `/data/DeepSeek-V4-Pro` | 8 | `--level 0 --method mtp --num-speculative-tokens 1` | same — no chat template |
-| DeepSeek-R1-0528 | `/data/DeepSeek-R1-0528` | 8 | | |
-| DeepSeek-R1-0528 MTP3 | `/data/DeepSeek-R1-0528` | 8 | `--method mtp --num-speculative-tokens 3` | `--use-chat-template` REQUIRED on bench |
-| DeepSeek FP4 MTP3 | `/data/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4` | 8 | `--method mtp --num-speculative-tokens 3` | `--use-chat-template` REQUIRED |
-| GLM-5 FP8 | `/data/GLM-5-FP8` | 8 | | |
-| gpt-oss-120b | `/data/openai/gpt-oss-120b` | 1 | drop `-tp` | |
-| Kimi-K2.5-MXFP4 | `/data/Kimi-K2.5-MXFP4` | 4 | `--trust-remote-code` + `HSA_NO_SCRATCH_RECLAIM=1` env | |
+- **Server launch args + env vars**: `.github/benchmark/models.json` (CI source of truth).
+- **Does this model need `--use-chat-template` on the bench?** Inspect the model's `tokenizer_config.json` — if it has a non-null `chat_template` field, pass `--use-chat-template`; otherwise the bench will tokenize the raw prompt directly.
 
 ## Anti-patterns
 
@@ -179,27 +171,7 @@ Searching by these tags is far more reliable than searching by kernel name (whic
 - **Trusting the `.gz` size to decide if the export finished.** Use `.gz exists AND no orphan .json`. The exporter writes `.json` first, then gzips + unlinks; a leftover `.json` means it crashed mid-export.
 - **Forgetting `--use-chat-template` on MTP DeepSeek-R1 benchmarks.** Tokenizer mismatch silently degrades accuracy — the trace will look fine but the workload is wrong.
 - **Adding `--mark-trace` or `ENABLE_TORCH_PROFILER=1`.** Neither is needed — `--torch-profiler-dir` on the server + `PROFILE=1` on the bench is the complete handshake. The extras either no-op or interfere.
-- **Profiling under `--level 3` for V4-Pro right now.** V4-Pro Inductor + autotune hits a `cluster_dims` bug on AMD — start with `--level 0` until CG support lands.
-
-## Real example — May 17 2026
-
-Captured an MTP-1 vs no-MTP V4-Pro trace at `1024/1024/c=64`, 64 prompts each, to compare whether `_hash_topk` uses the fused `aiter::topk_softplus` kernel or the native `softplus + sqrt` chain:
-
-```bash
-mkdir -p /app/logs_claude/traces/v4_mtp1
-bash /app/ATOM/scripts/start_atom_server.sh /data/DeepSeek-V4-Pro 8 8000 \
-  --level 0 --method mtp --num-speculative-tokens 1 \
-  --torch-profiler-dir /app/logs_claude/traces/v4_mtp1
-bash /app/ATOM/scripts/run_benchmark.sh /data/DeepSeek-V4-Pro 8000 1024 1024 64 1 1
-# (wait loop on .gz / .json — see Step 3)
-zcat /app/logs_claude/traces/v4_mtp1/rank_0/*.gz | python3 -c "..."
-```
-
-Finding: 12,938 `aiter::topk_softplus` calls (the `elif scoring_func == 'sqrtsoftplus'`
-branch in `moe.py:2637` IS taken) plus 12,658 native `softplus_kernel` calls
-(from `_hash_topk` in `deepseek_v4.py:1982` — the first 3 hash layers don't go
-through the fused path). Trace files: `/app/logs_claude/traces/v4_mtp1/` and
-`/app/logs_claude/traces/v4_nomtp/`.
+- **Profiling V4-Pro under default `--level 3`.** V4-Pro Inductor + autotune hits a `cluster_dims` bug on AMD — pass `--level 0` until that bug is fixed.
 
 ## Cross-references
 

--- a/.claude/skills/debug-agent-locate-kernel/SKILL.md
+++ b/.claude/skills/debug-agent-locate-kernel/SKILL.md
@@ -1,10 +1,21 @@
 ---
 name: debug-agent-locate-kernel
-description: Use rocm-debug-agent to identify which GPU kernel is faulting/hanging when ATOM server hits a HIP memory access fault, MEMORY_VIOLATION, or silent infinite loop. The agent dumps wave registers, faulting PC, and (with --save-code-objects) the disassembled code object so you can name the exact kernel and trace it back to the Python call site. Use when: server crashes with "Memory access fault by GPU node-N", server hangs with GPU at 100% but no token output, or you need to identify a kernel asserting `s_trap`. Do NOT use for: numerical bugs (use dump-bisect-debug), compile errors, OOM.
-version: 1.0.0
-scope: ATOM on AMD ROCm (debug-agent at /opt/rocm/lib/librocm-debug-agent.so.2)
-last_updated: 2026-05-14
+description: Identify which GPU kernel is faulting/hanging in ATOM via rocm-debug-agent (for faults/asserts) or rocgdb (for silent livelocks). debug-agent dumps wave registers + faulting PC + (with --save-code-objects) disassembled code object on memory faults / ASSERT_TRAP. rocgdb attaches to a live process and lists in-flight `info dispatches` + HSA `info queues` — works when the kernel isn't faulting but just stuck (e.g. atomic-counter deadlock). Use when: server crashes with "Memory access fault by GPU node-N", server hangs with GPU at 100% but no token output, kernel asserting `s_trap`, or `HIP_LAUNCH_BLOCKING=1` makes a hang vanish. Do NOT use for: numerical bugs (use dump-bisect-debug), compile errors, OOM.
+version: 1.2.0
+scope: ATOM on AMD ROCm (debug-agent at /opt/rocm/lib/librocm-debug-agent.so.2; rocgdb at /opt/rocm/bin/rocgdb)
+last_updated: 2026-05-20
 ---
+
+## Tool selection: debug-agent vs rocgdb
+
+| Symptom | Use first |
+|---------|-----------|
+| `Memory access fault by GPU node-N` / `MEMORY_VIOLATION` / `ASSERT_TRAP` in log | **debug-agent** — only it dumps wave regs + faulting PC + code-object disassembly |
+| Silent livelock (GPU 100%, no fault, no log output) | **rocgdb** — debug-agent never fires (no trap event); rocgdb's `info dispatches` lists in-flight kernels directly |
+| `HIP_LAUNCH_BLOCKING=1` makes hang disappear (async race) | **rocgdb first** to name the stuck kernel(s); debug-agent only if you need wave-level detail later |
+| Need disassembly / per-lane register values | **debug-agent** (rocgdb doesn't go to that depth on AMD) |
+
+**The two tools cannot be combined.** debug-agent loads `HSA_TOOLS_LIB=librocm-debug-agent.so.2` which occupies the HSA debugger hook — rocgdb attached to the same process reports "No queues / No dispatches are currently active" because the agent has the slot. To use rocgdb, launch the server with **plain** `start_atom_server.sh` (no `run_debug_agent.sh` wrapper).
 
 ## When to use
 
@@ -21,12 +32,13 @@ Do NOT use this skill for: precision bugs (use [[dump-bisect-debug]]), build/com
 ## Required tools (verify before starting)
 
 ```bash
-ls /opt/rocm/lib/librocm-debug-agent.so.2     # the agent itself
+ls /opt/rocm/lib/librocm-debug-agent.so.2     # debug-agent (fault path)
+ls /opt/rocm/bin/rocgdb                       # rocgdb (livelock path)
 ls /opt/rocm/llvm/bin/llvm-objdump            # for disassembling code objects
-which py-spy && py-spy --version              # for stack traces of stuck workers
+which py-spy && py-spy --version              # Python stacks of stuck workers
 ```
 
-If any missing: install `rocm-debug-agent`, `llvm`, `pip install py-spy`. Stop here if not available.
+If any missing: install `rocm-debug-agent`, `rocgdb`, `llvm`, `pip install py-spy`. Stop here if not available.
 
 ## Critical pre-flight
 
@@ -154,6 +166,95 @@ Per [[atom-patterns]] / DeepSeek V4 guidance, do not ship `cuda.synchronize()` w
 | Per-fwd kernel reads stale forward_vars from prior fwd | Switch H2D path off `prep_stream` to default stream (matches ATOM `prepare_mtp_decode` v2 pattern). |
 | Cross-rank inconsistency causes one rank to OOB | Ensure all ranks see identical batch shapes before launching kernel; check `cu_seqlens_q` / `state_slot_mapping` parity. |
 
+## rocgdb workflow (for silent livelocks — when debug-agent gives no wave dump)
+
+debug-agent only fires on `MEMORY_VIOLATION` / `ASSERT_TRAP` etc. — for a **silent livelock** (GPU stuck at 100% with no kernel making progress, no fault, no log), it sits idle and gives you nothing. rocgdb fills that gap: attached to a live worker, it can enumerate in-flight HSA dispatches and queue head/tail pointers, naming the stuck kernel directly.
+
+### Pre-flight (rocgdb only)
+
+```bash
+which rocgdb                                          # /opt/rocm/bin/rocgdb
+rocgdb --version | head -3                            # confirm GNU gdb 16.x rocm-rel
+```
+
+The "Symbol PySlice_Type has different size" warnings on attach are benign — Python symbol size mismatch between rocgdb's bundled Python and the venv. Wave-debug commands still work.
+
+### Step R1: Launch WITHOUT debug-agent
+
+Use plain `start_atom_server.sh` — **NOT** `run_debug_agent.sh`. debug-agent's `HSA_TOOLS_LIB` occupies the HSA debugger hook and rocgdb will report "No agents / No dispatches / No queues are currently active" because the agent has the slot. Run only ONE of the two tools at a time on the same process.
+
+```bash
+bash scripts/stop_atom_server.sh
+<MODEL_ENV> bash scripts/start_atom_server.sh <MODEL> <TP> <PORT> <EXTRA_ARGS...> &
+bash scripts/wait_server_ready.sh <PORT> 10 5 /app/logs_claude/atom_server.log
+<run workload that triggers the hang>
+```
+
+### Step R2: Pick the right worker PID (NOT the dispatcher)
+
+ATOM at TP=N has 1 `openai_server` + 1 spawn dispatcher + N spawn workers. Only the **workers** hold GPU queues — attaching to the dispatcher returns "No dispatches" (it has no GPU work).
+
+```bash
+# Process tree: dispatcher has PPID = openai_server; workers have PPID = dispatcher
+ps -ef | grep spawn_main | grep -v grep
+# Workers' PPID equals the dispatcher PID and they sit ~99% CPU during forward;
+# the dispatcher itself shows lower CPU. Pick any worker.
+WORKER_PID=<one of the worker PIDs>
+```
+
+### Step R3: Dump GPU state non-interactively
+
+```bash
+cat > /tmp/rocgdb_cmds.txt <<'EOF'
+set pagination off
+set confirm off
+set logging file /app/logs_claude/rocgdb_dump.txt
+set logging overwrite on
+set logging on
+echo === info agents ===\n
+info agents
+echo \n=== info dispatches ===\n
+info dispatches
+echo \n=== info queues ===\n
+info queues
+echo \n=== main thread bt ===\n
+bt 30
+detach
+quit
+EOF
+timeout 90 rocgdb -p $WORKER_PID -x /tmp/rocgdb_cmds.txt -batch
+```
+
+`detach` (not just `quit`) is required or the worker stays SIGSTOP'd after rocgdb exits — kills your repro and leaves zombies.
+
+### Step R4: Read the dump
+
+`/app/logs_claude/rocgdb_dump.txt` contains four sections:
+
+| Section | What to read |
+|---------|--------------|
+| `info agents` | One row per GPU (8 for TP=8). Confirms rocgdb sees the HSA runtime. If empty → debug-agent is still loaded, restart without it. |
+| `info dispatches` | **The smoking gun.** Each in-flight kernel: dispatch ID, grid, workgroup, fence, demangled kernel name. Two-or-more dispatches active = concurrent streams. |
+| `info queues` | HSA queue table with `Read` and `Write` pointers per queue. `Write > Read` = packets pending; queue is stalled if the head dispatch never completes. Type DMA queues handle memcpy, HSA queues handle kernel launches. |
+| `bt` | Python main thread's C stack. Look for `hipMemcpyAsync → memcpy_and_sync → _local_scalar_dense_cuda` to confirm `.item()` is blocked waiting for GPU. |
+
+### Step R5: Cross-reference kernel name → source
+
+The demangled name in `info dispatches` is the AITER (or PyTorch) kernel symbol. For AITER ASM-precompiled kernels, grep the kernel name across `aiter/aiter/ops/` to find the Python wrapper, then check whatever singleton workspace / semaphore the wrapper allocates — that is the most common shared resource a cross-stream race fights over.
+
+### Step R6: Tell-tale of the shared-workspace deadlock class
+
+**Two or more `_clean`-suffixed dispatches on different queues, each with `Fence: B|Aa|Ra` (full memory fence)** = the classic shared-workspace race. Split-K GEMMs use a reduction phase that atomic-increments a counter in a per-process workspace; if that workspace is a singleton (e.g. `@functools.lru_cache(maxsize=1)` over device only) and two splitk kernels run concurrently on different streams, their counters interleave → neither hits its expected count → both deadlock.
+
+Fix shape (general): make the workspace cache stream-keyed (e.g. `lru_cache` over `(device, stream_id)`) so each stream gets its own counter. Workaround shape: serialize the streams (`current_stream.wait_stream(other_stream)`) — masks the bug for one workload but resurfaces on a larger one; not shippable per [[atom-patterns]].
+
+### rocgdb anti-patterns
+
+- **Don't attach to the dispatcher** (PPID = openai_server). It has no GPU queues; you'll get "No dispatches" and waste 90s on the timeout.
+- **Don't combine debug-agent + rocgdb on the same process**. The debug-agent's HSA tool hook shadows rocgdb's queue/dispatch visibility — you'll see agents but no dispatches.
+- **Don't run rocgdb interactively** when the worker is in HSA wait — it can take 30+ seconds to attach, and an accidental `^C` SIGSTOPs the worker permanently. Use `-x scriptfile -batch` with `detach` before `quit`.
+- **Don't trust `info threads`' Python frame names** — rocgdb's Python integration doesn't speak the venv ABI. Use `py-spy dump --pid $WORKER_PID` in parallel for the Python-side stack.
+
 ## Recovery checklist (after agent run)
 
 1. `bash scripts/stop_atom_server.sh` — agent leaves zombie KFD entries; if you skip, next launch OOMs at NCCL barrier.
@@ -170,26 +271,12 @@ Per [[atom-patterns]] / DeepSeek V4 guidance, do not ship `cuda.synchronize()` w
 - **Don't leave `--save-code-objects` on for routine runs** — each run dumps ~500 MB. Only enable for the bisect run.
 - **Don't add `torch.cuda.synchronize()` "fixes" and ship** — they mask the race for one workload and surface a worse hang (livelock) on a larger one. Find the allocator/stream root cause.
 
-## Real example (May 14 2026 — V4-Pro MTP-3 prefill hang)
-
-**Symptom**: `Memory access fault by GPU node-N` on all 8 ranks within 1s of "Scheduled prefill batch: 19 reqs, 9573 tokens". `HIP_LAUNCH_BLOCKING=1` and `ATOM_DUMP_SWA_WRITE=1` (which inserts `.cpu()` sync) both eliminated it.
-
-**Workflow**:
-1. Step 1-2: ran `run_debug_agent.sh`, grep `"stopped, reason"` → got `ASSERT_TRAP` in `at::native::index_copy_kernel_impl<OpaqueType<4>>`.
-2. Step 4: disassembled code object → confirmed `s_trap 2` followed by `s_endpgm` → PyTorch `CUDA_KERNEL_ASSERT` failed (bound check on index_copy).
-3. Step 5: grep'd ATOM source for `index_copy_` of int32 dtype → only csa/hca calls in `deepseek_v4_attn.py:1505-1506`.
-4. Step 6: bisected — neither alone trapped, both together did. Added `torch.cuda.synchronize()` between → small workload passed, GSM8K (1319 reqs) eventually livelocked at 1281, py-spy showed all ranks stuck in the synchronize call → confirmed root cause is allocator churn from transient tensors (`csa_win_pos`/`hca_win_pos`/`swa_paged_flat` built via `torch.where`/`arange`/`.reshape`/`.to(int64)`).
-5. Real fix (in progress): replace 3 sequential `index_copy_` + transient tensor construction with a single Triton kernel reading only persistent forward_vars buffers.
-
-Wave dumps and code objects from this run: `/app/logs_claude/atom_server.log` (line 419+), `/app/logs_claude/debug_run/`, `/app/logs_claude/fault.s`.
-
 ## Sample wave dump (what to expect in atom_server.log)
 
-Trimmed real example from the May 14 2026 V4-Pro MTP-3 run. Key fields are the
-mangled function name in `kernel_code_entry=...`, the `stopped, reason: ...`
-tag, the `code object: memory://<pid>#offset=<hex>&size=<bytes>` line that
-points at the saved file, and the `=> <pc>: <instruction>` arrow showing the
-faulting PC. Vector registers (only v0/v1/v6 shown — full dump prints v0..v15
+Trimmed example. Key fields are the mangled function name in `kernel_code_entry=...`,
+the `stopped, reason: ...` tag, the `code object: memory://<pid>#offset=<hex>&size=<bytes>`
+line that points at the saved file, and the `=> <pc>: <instruction>` arrow showing
+the faulting PC. Vector registers (only v0/v1/v6 shown — full dump prints v0..v15
 and beyond) often reveal address / index values that pin down the operand.
 
 ```

--- a/.claude/skills/dump-bisect-debug/SKILL.md
+++ b/.claude/skills/dump-bisect-debug/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: dump-bisect-debug
 description: Locate forward numerical bugs by dumping intermediate tensors from a target implementation and a known-good reference, then bisecting layer by layer. Also covers batch-invariance bisect (the same token at any batch position should produce a bitwise-identical output, per DeepSeek V4 paper §3.3). Use when "the output is wrong but I don't know where" — model produces gibberish, degenerates, or picks the wrong token, but code review reveals nothing.
-version: 3.0.0
+version: 3.1.0
 scope: ATOM (generalizable to any PyTorch forward debug)
-last_updated: 2026-04-30  # add Phase 8 batch invariance + atom/utils/debug_helper infra
+last_updated: 2026-05-20
 ---
 
 ## ATOM built-in infrastructure (v3.0+ — read first)
@@ -292,10 +292,7 @@ print(cos_max(out_C2, ref_dump))
 2. **Re-run the forward dump and verify cos**: confirm the fix is real and the sub-stage cos actually improved.
 3. **Run e2e and look at token output**: from rambling → coherent output → byte-equal vs ref.
 4. **Multiple bugs may need fixing**: one fix is often not enough (e.g. fixing V4 attention still leaves FFN wrong) → continue bisecting the next one.
-5. **Fix isolation revert** ★ Once all fixes pass, **revert each one in turn** to identify the critical ones (this is core principle #6):
-   - V4 case: reverting `linear.py` (Bug 8) showed Bug 9+10 alone were enough to output `"6"`.
-   - Bug 8 was just fine-tuning (byte-equal vs ref) and had a perf cost.
-   - This step decides the PR split granularity (critical fixes merge immediately; fine-tuning fixes can wait).
+5. **Fix isolation revert** ★ Once all fixes pass, **revert each one in turn** to identify the critical ones (this is core principle #6). A fix may be "fine-tuning" (byte-equal vs ref but other fixes alone already produce correct output) and carry a perf cost — those can ship separately or wait. This step decides PR split granularity: critical fixes merge immediately; fine-tuning fixes can wait.
 
 ### Phase 8: Batch-invariance bisect (DeepSeek V4 paper §3.3)
 
@@ -374,15 +371,14 @@ Set `ATOM_FWD_DUMP_ONE_SHOT=0` so each call writes its own file (`layer{LL}_{Cls
 | Layer 1+ attn cos explodes (0.97) | Hash routing / sqrtsoftplus cascades small upstream drift. |
 | Whole model cos ≈ 0.999 yet final logits diverge | Edge-confidence token + sampling noise. |
 
-**Example** (Bug 11, V4 batch=4 prompt P3 answers `"15"`):
-- Single prompt: 100% answers `"6"`. Batch=4: 40% flip to `"15"`.
-- E1 4×P3 + temp=0.0: slot 0/1/3 → `"6"`, slot 2 → `"1+2+"` (different).
-- Layer 0 attn cos 0.99988 (near identical) → MoE 0.998 (10× amplification) → layer 1 attn 0.97 (cascaded).
-- Full write-up: `/app/logs_claude/deepseek_v4/notes/21_bug11_isolation.md`.
+**Diagnostic pattern** — when batch=N flips a token that single-prompt gets right:
+- E1 with 4× the same prompt at temp=0.0 shows slots disagreeing (e.g. slot 2 produces different tokens than 0/1/3).
+- Layer 0 attention cos = 0.99988 (near identical) → MoE 0.998 (10× amplification) → layer 1 attention 0.97 (cascaded).
+- The single-step cos drop is in the GEMM / MoE reduction, not the model code.
 
 **Fix direction**:
-- Cannot be fixed at the ATOM layer — needs aiter to ship batch-invariant kernels (DeepGEMM-style + dual-kernel attention).
-- Short term: document as a known limitation; only the single-prompt and high-confidence batch paths are guaranteed correct.
+- Not fixable at the ATOM layer — needs aiter to ship batch-invariant kernels (DeepGEMM-style + dual-kernel attention).
+- Mitigation: document as a known limitation; only single-prompt and high-confidence batch paths are guaranteed correct.
 
 ## Common root-cause categories (by frequency)
 

--- a/.claude/skills/run-atom-workload/SKILL.md
+++ b/.claude/skills/run-atom-workload/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: run-atom-workload
 description: Run any ATOM workload — accuracy eval (GSM8K via lm_eval), performance benchmark, concurrency sweep, offline simple_inference, or fault repro under rocm-debug-agent. Use when the user asks to "test accuracy", "测精度", "跑 GSM8K", "跑 benchmark", "test performance", "run sweep", "repro the fault", "测一下 MTP1 精度", "跑 simple_inference" — anything that drives an ATOM workload. Encodes the canonical flow (stop → start → workload-in-shell-bg → wait_infer_drain → stop) and the model-family env vars. Same pattern works for both server-based workloads (lm_eval / benchmark client) and offline simple_inference. Do NOT use for profiling traces (use capture-trace).
-version: 1.2.0
+version: 1.6.0
 scope: ATOM on AMD ROCm; `scripts/` orchestration scripts under repo root
-last_updated: 2026-05-18
+last_updated: 2026-05-21
 ---
 
 ## Path convention
@@ -18,18 +18,20 @@ or `cd` to the repo first.
 
 ## Why this skill exists
 
-Every blocking ATOM workload follows the same 4-step shape: **stop → start → workload-in-bg → wait_infer_drain → stop**. The scripts in `scripts/` are orchestration-grade — chain them via **separate Bash tool calls**, not wrappers, not `&&`.
+Every blocking ATOM workload follows the same 5-step shape: **stop → start → verify-ready → workload-in-bg → wait_infer_drain → stop**. The scripts in `scripts/` are orchestration-grade — chain them via **separate Bash tool calls**, not wrappers, not `&&`.
 
 Past failure modes this skill prevents (collected from many sessions):
 
 1. **Writing wrapper scripts in `/app/logs_claude/`** — `start_atom_server.sh` etc. ARE the orchestration layer. Wrapping them is pure noise. The dozens of `run_*.sh` / `start_*_safe.sh` files in `/app/logs_claude/` are session debris — **do not mimic them**.
 2. **Chaining all steps with `&&` into one long command** — the user has explicitly forbidden this. Each step gets its own Bash tool call so logs are separate, errors abort cleanly, and the user can interrupt at any boundary.
-3. **Double-backgrounding the server** — `start_atom_server.sh` already forks python in background internally and polls ready. Adding `&` after `start_atom_server.sh` is wrong; it blocks until ready or fail.
+3. **Foregrounding `start_atom_server.sh`** — its inline ready-poll caps at **120 iterations × `sleep 1` = 120s** with no failure exit, so any model that takes >2min to cold-start (V4-Pro takes 5–10min) lets the script return success while the server is still loading. Step 3 then launches against a not-yet-ready server. Fix: background it with `&`, use step 2.5 as the real foreground ready gate.
 4. **Skipping `wait_infer_drain.sh`** — without it, GPU faults take the whole timeout to surface, and hangs go undetected. `wait_infer_drain.sh` exits in ~10s on fault and ~1min on hang, with tail-log attached.
 5. **Using `curl /health` for liveness** — under heavy load it can false-negative. The flow uses `/v1/models` (start script) and `pgrep` + Engine Core marker (drain script).
 6. **Forgetting model-family env vars** — V4-Pro silently regresses on accuracy without `AITER_BF16_FP8_MOE_BOUND=0 ATOM_MOE_GU_ITLV=1`. Pinned in the table below.
 7. **Skipping drain for offline simple_inference** — `wait_infer_drain.sh` supports offline mode (process-exit detection + fault scan). Without it you lose early fault visibility.
-8. **Passing the wrong LOG_FILE to drain** — historically callers had to know which log carries the "Engine Core: output send" marker. v1.2 of drain auto-discovers the server log via `/proc/<pid>/fd/1`, so the user LOG_FILE is now only a **secondary** signal (fault scan + mtime progress for clients with tqdm output). Pass any log you want extra coverage on, or pass nothing — drain still works.
+8. **Passing the wrong LOG_FILE to drain** — `wait_infer_drain.sh` auto-discovers the server log via `/proc/<pid>/fd/1`; the user-supplied LOG_FILE is a **secondary** signal (fault scan + mtime progress for clients with tqdm output). Pass any log you want extra coverage on, or pass nothing — drain still works.
+9. **Trusting `start_atom_server.sh` exit alone** — same root cause as failure 3. Background step 2 with `&` and use **step 2.5 `wait_server_ready.sh` as the mandatory foreground ready gate** with a real (15min) timeout. If 2.5 fails, abort to step 5 — do **not** launch workload.
+10. **Writing a custom monitor loop to "catch the hang at the right moment"** for rocgdb / py-spy attach — `wait_infer_drain.sh` exit=1 IS that moment: workers are still alive in livelock state, GPU queues still loaded, the next call is your attach. Self-written `for i in ...; sleep 10; grep -c "output send" ...` loops always misjudge the heuristic (drain's STUCK_POLLS check is tuned across hundreds of runs; yours isn't), waste a turn re-deriving it, and leak past the user-forbidden "no ad-hoc orchestration" rule. Use drain → on exit=1 attach rocgdb (see step 4.5) → step 5.
 
 ## Backgrounding mechanism — shell `&`, NOT claude task
 
@@ -49,9 +51,11 @@ bash scripts/wait_infer_drain.sh 30000 30 10
 
 The Bash invocation for step 3 returns the instant `&` is processed (`bash -c 'cmd &'` exits as soon as cmd is backgrounded). Step 4 then runs as the next Bash call and blocks on drain.
 
-## Canonical 4-step flow
+## Canonical 5-step flow
 
 Run each step as a **separate Bash tool call**. Never chain with `&&`.
+
+Step order: **1 stop → 2 start → 2.5 verify-ready → 3 workload `&` → 4 drain → 4.5 (optional) hang inspection → 5 stop**.
 
 ### Step 1 — clean GPU (always)
 
@@ -63,18 +67,18 @@ Idempotent. SIGTERM → SIGKILL → force-kill GPU PIDs, waits ≤60s for VRAM=0
 
 ### Step 2 — start workload host (blocks until ready / completion)
 
-**Server-based workloads** (GSM8K / benchmark / sweep / fault repro):
+**Server-based workloads** (GSM8K / benchmark / sweep / fault repro): **background with shell `&`**, then use step 2.5 as the real ready gate.
 
 ```bash
-<MODEL_ENV_VARS> bash scripts/start_atom_server.sh <MODEL_PATH> <TP> <PORT> <EXTRA_ARGS...>
+<MODEL_ENV_VARS> bash scripts/start_atom_server.sh <MODEL_PATH> <TP> <PORT> <EXTRA_ARGS...> &
 ```
 
-- Self-contained: forks python in background internally, polls `/v1/models` + GPU VRAM, returns when ready or 1 on fail
-- **Do NOT** add `&` — the script self-backgrounds python and waits for ready
-- **Do NOT** chain `wait_server_ready.sh` after — already inlined inside start script
+- **MUST end with `&`** so the Bash tool returns immediately and step 2.5 can do the real foreground wait
+- The script forks python in background and runs a best-effort inline poll, but that poll caps at 120s and falls through to exit-0 without raising — for any model that takes >2min to load, the inline poll's outcome is meaningless
+- Step 2.5 is the source of truth for ready/fail
 - Log: hard-coded `/app/logs_claude/atom_server.log` (`LOG_FILE` env is NOT respected by this script). Drain auto-discovers it via `/proc/<pid>/fd/1` regardless of path
 
-**Offline workload** (simple_inference): step 2 is fused with step 3, see below.
+**Offline workload** (simple_inference): steps 2 and 2.5 are skipped — workload runs offline; jump to step 3.
 
 Model-family env vars (set as `VAR=val VAR=val bash ...` prefix):
 
@@ -85,6 +89,24 @@ Model-family env vars (set as `VAR=val VAR=val bash ...` prefix):
 | Kimi-K2.5-MXFP4 | `HSA_NO_SCRATCH_RECLAIM=1 AITER_LOG_LEVEL=WARNING` | `--kv_cache_dtype fp8 --trust-remote-code` (tp=4) |
 
 MTP add-on (any supporting model): append `--method mtp --num-speculative-tokens N` to EXTRA_ARGS. V4-Pro: keep `--level 0`.
+
+### Step 2.5 — verify server ready (MANDATORY for server-based workloads)
+
+```bash
+bash scripts/wait_server_ready.sh <PORT> <MAX_MIN> <POLL_SEC> /app/logs_claude/atom_server.log
+```
+
+Typical: `bash scripts/wait_server_ready.sh 30000 15 5 /app/logs_claude/atom_server.log`.
+
+- Polls `/v1/models` and grep-watches the server log for startup errors (`cluster_dims`, `InductorError`, `SHUTDOWN`, `proc died`, `AssertionError`)
+- Exit 0 → server ready, proceed to step 3
+- Exit non-zero → **abort to step 5** (`stop_atom_server.sh`). Do NOT launch step 3
+- `MAX_MIN`: V4-Pro cold start ~5–10min; use 15 to be safe. Smaller models: 5–8
+- Set Bash tool timeout to ≥ `MAX_MIN × 60 × 1000` ms (e.g. `900000` for 15min) so the tool doesn't kill the poll prematurely
+
+Why mandatory: step 2 was backgrounded with `&`, so its exit code is meaningless to us — we deliberately ignored it. Step 2.5 is the **one and only** clean gate — its exit code, blocking behavior, and tail-on-fail are all visible to the operator. Without it, step 3 may launch against a dead or not-yet-ready server (lm_eval just sits in its own retry loop and hides the failure).
+
+Skip step 2.5 for: offline simple_inference (no server), debug-agent fault repro (the fault IS the goal).
 
 ### Step 3 — launch workload in shell background (`&`)
 
@@ -121,7 +143,7 @@ bash scripts/wait_infer_drain.sh PORT MAX_MIN POLL_SEC [LOG_FILE] [STUCK_POLLS]
 
 Defaults: PORT=8000, MAX_MIN=30, POLL_SEC=10, LOG_FILE=empty (server log auto-discovered via `/proc/<pid>/fd/1`), STUCK_POLLS=6.
 
-`LOG_FILE` is **optional** in v1.2+. The drain script discovers the server log itself from the running `atom.entrypoints` process. Pass an additional client/workload log only if you want:
+`LOG_FILE` is **optional**. The drain script discovers the server log itself from the running `atom.entrypoints` process. Pass an additional client/workload log only if you want:
 - Extra fault grep coverage (drain scans both)
 - Mtime-based progress detection for client tools that write tqdm to a file (benchmark, simple_inference)
 
@@ -134,7 +156,7 @@ How drain decides (auto-detects server vs offline by `SERVER_PATTERN` pgrep):
 - **Server only**: no progress (engine output count flat + caller LOG_FILE mtime flat) AND client still running for STUCK_POLLS × POLL_SEC ≈ 1min → exit 1 (hang)
 - **Either mode**: MAX_MIN elapsed without resolution → exit 4
 
-If exit ≠ 0: read the printed tail, then run step 5 regardless.
+If exit ≠ 0: read the printed tail. If exit=1 (hang) and you want to inspect the stuck GPU state, do step 4.5 BEFORE step 5 (step 5 kills the workers and destroys the evidence). Otherwise run step 5 regardless.
 
 Typical wait windows:
 - GSM8K (1319 samples): MAX_MIN=30 plenty for V4-Pro
@@ -142,6 +164,33 @@ Typical wait windows:
 - Sweep (8 conc points): MAX_MIN=60
 - Simple_inference (default ~10 prompts): MAX_MIN=15 plenty
 - Fault repro: MAX_MIN=10 (fault should land within first request)
+
+### Step 4.5 — hang inspection (optional, only when drain exit=1)
+
+Trigger: step 4 returned exit=1 (HANG detected) AND you want to know which kernel / Python frame is stuck.
+
+`wait_infer_drain.sh exit=1` means the engine stopped emitting "output send" for STUCK_POLLS×POLL_SEC seconds while the benchmark client is still alive. At that instant:
+
+- Server process is alive (`pgrep atom.entrypoints` returns)
+- Worker spawn_main processes are alive (`ps -ef | grep spawn_main`)
+- GPU queues still hold the stuck dispatches
+- HSA debugger hook is FREE (you launched with plain `start_atom_server.sh`, not `run_debug_agent.sh`)
+
+This is the unique window to attach **rocgdb** or **py-spy** before step 5 destroys the evidence. After step 5 all workers are SIGKILL'd and `info dispatches` returns "No dispatches" — too late.
+
+Use the **[[debug-agent-locate-kernel]]** skill for the rocgdb workflow:
+- Step R2 in that skill: pick a worker PID (`ps -ef | grep spawn_main`, PPID = dispatcher, NOT the openai_server)
+- Step R3: `rocgdb -p $WORKER_PID -x cmdfile -batch` with `detach` before `quit`
+- Step R4-R6: read `info dispatches` / `info queues` from the dump
+
+Quick py-spy companion (for the Python-side stack on the same worker):
+```bash
+py-spy dump --pid $WORKER_PID 2>&1 | tee /app/logs_claude/pyspy_${WORKER_PID}.txt
+```
+
+**Hard rule**: do NOT replace step 4 with a self-written `for/while` polling loop just to "time the attach better". Drain's exit=1 IS the attach moment. See failure mode 10.
+
+After inspection completes, proceed to step 5.
 
 ### Step 5 — teardown (always)
 
@@ -166,11 +215,9 @@ grep -E "^Generated|^Output|tokens/s" /app/logs_claude/simple_inference.log
 
 GSM8K format: `|gsm8k|3|flexible-extract|3|exact_match|↑|0.XXXX|±|0.00XX|` — flexible-extract is the headline number, ±value is the noise band. Anything within 1σ of baseline = no regression.
 
-## V4-Pro accuracy baselines (current, 3-shot, no `--limit`)
+## Reading baselines
 
-- Non-MTP: ~0.9545 ± 0.0057
-- MTP-1: ~0.9492 ± 0.006
-- MTP-3: see `feedback_v4_cg_mtp_status_deadlock.md` — currently hangs on high-concurrency GSM8K
+Per-model accuracy baselines and thresholds live in `.github/benchmark/models_accuracy.json` (CI is the source of truth). For one-off comparison, run the same `(model, fewshot)` pair locally and diff against the CI threshold in that file.
 
 ## Hard rules (do not violate)
 
@@ -180,32 +227,39 @@ GSM8K format: `|gsm8k|3|flexible-extract|3|exact_match|↑|0.XXXX|±|0.00XX|` �
 4. **Drain auto-discovers server log via `/proc/<pid>/fd/1`** — you no longer need to know or pass the canonical server log path. Pass a client log only as supplementary signal.
 5. **Always step 5 (`stop_atom_server.sh`)**, even after a fault, even for offline workloads.
 6. **Never use `curl /health`** to verify ready — only `/v1/models` (already inlined in start script).
-7. **No extra `&`, `wait_server_ready.sh`, `LOG_FILE=` env on `start_atom_server.sh`** — start script self-backgrounds, self-polls, hard-codes log path.
+7. **No `LOG_FILE=` env on `start_atom_server.sh`** — log path is hard-coded.
+8. **Step 2 (`start_atom_server.sh`) MUST end with shell `&`.** Foregrounding it is a trap: its inline ready-poll caps at 120s and falls through to exit-0 without raising — for V4-Pro and other slow-starting models the script silently returns success while the server is still loading. See failure mode 3.
+9. **Step 2.5 (`wait_server_ready.sh`) is MANDATORY for server-based workloads.** Run it as a separate foreground Bash tool call after step 2. If it exits non-zero, abort to step 5; do not launch step 3.
+10. **Step 4 (`wait_infer_drain.sh`) is the ONLY hang detector.** Never replace it with a custom `for/sleep/grep` monitor loop, even if your goal is to attach rocgdb / py-spy at hang time — drain's exit=1 IS the attach moment (workers still alive, GPU queues still loaded). Step 4.5 covers the inspection workflow. See failure mode 10.
 
 ## Reference: each script in one line
 
 | Script | What it does | Step | Blocks? |
 |---|---|---|---|
 | `stop_atom_server.sh` | Kill all atom + multiproc children, wait for VRAM=0 | 1, 5 | Yes ≤60s |
-| `start_atom_server.sh MODEL TP PORT [ARGS...]` | Clean GPU, fork python in bg, poll ready | 2 (server) | Yes, until ready or fail |
+| `start_atom_server.sh MODEL TP PORT [ARGS...]` | Clean GPU, fork python in bg, best-effort 120s ready poll (must wrap with `&` — step 2.5 is the real gate) | 2 (server) | Self-blocks ≤120s but unreliable as gate |
 | `start_simple_inference.sh MODEL TP [ARGS...]` | Offline inference (no server, runs prompts) — wrap with `&` for drain | 3 (offline) | Blocks unless `&` |
 | `run_gsm8k_eval.sh MODEL PORT FEWSHOT` | lm_eval local-completions GSM8K — wrap with `&` for drain | 3 (server) | Blocks unless `&` |
 | `run_benchmark.sh MODEL PORT ISL OSL CONC [PMULT] [PROF]` | Single perf point — wrap with `&` for drain | 3 (server) | Blocks unless `&` |
 | `run_benchmark_sweep.sh MODEL PORT ISL OSL "CONCs"` | Loop run_benchmark — wrap with `&` for drain | 3 (server) | Blocks unless `&` |
 | `wait_infer_drain.sh PORT MAX_MIN POLL [LOG] [STUCK]` | Monitor workload for drain / hang / fault (auto-discovers server log) | 4 | Yes, until exit code |
-| `wait_server_ready.sh PORT MAX_MIN POLL LOG` | Standalone ready poller (rarely needed; start script self-polls) | (debug) | Yes |
+| `wait_server_ready.sh PORT MAX_MIN POLL LOG` | Mandatory ready-gate after start; polls `/v1/models` + greps log for startup errors | 2.5 (server) | Yes, until ready or fail |
 | `run_debug_agent.sh [--simple] MODEL TP [PORT] [ARGS...]` | Server (or simple_inference) under rocm-debug-agent — fault repro | 2 (replaces start) | Yes, until ready or fault |
 
-## Worked example: V4-Pro MTP1 GSM8K accuracy
+## Worked example: V4-Pro MTP3 GSM8K accuracy
 
 ```
 # Step 1
 bash scripts/stop_atom_server.sh
 
-# Step 2
+# Step 2 — note trailing `&` (REQUIRED — see Hard rule 8)
 AITER_BF16_FP8_MOE_BOUND=0 ATOM_MOE_GU_ITLV=1 AITER_LOG_LEVEL=WARNING \
   bash scripts/start_atom_server.sh /data/DeepSeek-V4-Pro 8 30000 \
-  --kv_cache_dtype fp8 --method mtp --num-speculative-tokens 1 --level 0
+  --kv_cache_dtype fp8 --method mtp --num-speculative-tokens 3 --level 0 &
+
+# Step 2.5 — MANDATORY foreground ready gate. Bash tool timeout ≥ 900000ms.
+# Abort to step 5 on non-zero exit.
+bash scripts/wait_server_ready.sh 30000 15 5 /app/logs_claude/atom_server.log
 
 # Step 3 — note trailing `&`
 bash scripts/run_gsm8k_eval.sh /data/DeepSeek-V4-Pro 30000 3 &

--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -20,12 +20,12 @@
     "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1"
   },
   {
-    "display": "DeepSeek-V4-Pro MTP1",
+    "display": "DeepSeek-V4-Pro MTP3",
     "path": "deepseek-ai/DeepSeek-V4-Pro",
     "prefix": "deepseek-v4-pro",
-    "args": "--kv_cache_dtype fp8 -tp 8 --method mtp --num-speculative-tokens 1",
+    "args": "--kv_cache_dtype fp8 -tp 8 --method mtp --num-speculative-tokens 3",
     "bench_args": "--use-chat-template",
-    "suffix": "-mtp1",
+    "suffix": "-mtp3",
     "runner": "atom-mi355-8gpu.predownload",
     "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1"
   },

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -38,14 +38,14 @@
   {
     "model_name": "DeepSeek-V4-Pro MTP",
     "model_path": "deepseek-ai/DeepSeek-V4-Pro",
-    "extraArgs": "--kv_cache_dtype fp8 -tp 8 --method mtp --num-speculative-tokens 1",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 8 --method mtp --num-speculative-tokens 3",
     "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "pr",
     "accuracy_threshold": 0.92,
     "accuracy_baseline": 0.96,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-V4-Pro",
-    "_baseline_note": "Same base model as DeepSeek-V4-Pro FP8 (MTP-1: 1 speculative token)"
+    "_baseline_note": "Same base model as DeepSeek-V4-Pro FP8 (MTP-3: 3 speculative tokens). Local full-eval (1319 samples, 3-shot) flexible-extract = 0.9560 ± 0.0056."
   },
   {
     "model_name": "DeepSeek-R1-0528 MTP",

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -30,7 +30,7 @@
     "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "pr",
-    "accuracy_threshold": 0.92,
+    "accuracy_threshold": 0.94,
     "accuracy_baseline": 0.96,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-V4-Pro",
     "_baseline_note": "Local 4-run average GSM8K-100 3-shot flexible-extract = 0.96 (runs: 0.96/0.98/0.96/0.94, stderr ~0.024). ATOM_USE_TRITON_MOE=1 is required — without it accuracy drops to ~0.6. Threshold set 4pp below local baseline to absorb full-eval (1319 samples) noise; refresh after first CI measurement."
@@ -42,7 +42,7 @@
     "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "pr",
-    "accuracy_threshold": 0.92,
+    "accuracy_threshold": 0.94,
     "accuracy_baseline": 0.96,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-V4-Pro",
     "_baseline_note": "Same base model as DeepSeek-V4-Pro FP8 (MTP-3: 3 speculative tokens). Local full-eval (1319 samples, 3-shot) flexible-extract = 0.9560 ± 0.0056."

--- a/.github/scripts/resolve_atom_image.py
+++ b/.github/scripts/resolve_atom_image.py
@@ -15,7 +15,9 @@ digest is known, it returns a digest-pinned floating reference instead.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -118,9 +120,21 @@ def get_registry_token(repository: str) -> str:
             "scope": f"repository:{repository}:pull",
         }
     )
+    # Use Docker Hub credentials when available to raise the unauthenticated
+    # rate limit (100 pulls / 6h per IP) to the authenticated quota (200 / 6h
+    # per account, billed against the user instead of the shared runner IP).
+    # Falls back to anonymous when secrets are absent (e.g. fork PR runs).
+    headers = {"User-Agent": USER_AGENT}
+    docker_user = os.environ.get("DOCKER_USERNAME")
+    docker_pass = os.environ.get("DOCKER_PASSWORD")
+    if docker_user and docker_pass:
+        creds = base64.b64encode(
+            f"{docker_user}:{docker_pass}".encode("utf-8")
+        ).decode("ascii")
+        headers["Authorization"] = f"Basic {creds}"
     body, _ = http_request(
         f"{AUTH_URL}?{query}",
-        headers={"User-Agent": USER_AGENT},
+        headers=headers,
     )
     payload = json.loads(body.decode("utf-8"))
     token = payload.get("token")

--- a/.github/scripts/resolve_atom_image.py
+++ b/.github/scripts/resolve_atom_image.py
@@ -128,9 +128,9 @@ def get_registry_token(repository: str) -> str:
     docker_user = os.environ.get("DOCKER_USERNAME")
     docker_pass = os.environ.get("DOCKER_PASSWORD")
     if docker_user and docker_pass:
-        creds = base64.b64encode(
-            f"{docker_user}:{docker_pass}".encode("utf-8")
-        ).decode("ascii")
+        creds = base64.b64encode(f"{docker_user}:{docker_pass}".encode("utf-8")).decode(
+            "ascii"
+        )
         headers["Authorization"] = f"Basic {creds}"
     body, _ = http_request(
         f"{AUTH_URL}?{query}",

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -231,6 +231,9 @@ jobs:
 
       - name: Collect GPU info (inside container)
         id: gpu-info
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           RUNNER_HINT="${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.model.runner }}"
           bash .github/scripts/collect_gpu_info.sh atom-benchmark docker "$RUNNER_HINT"

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -104,6 +104,8 @@ jobs:
       - name: Resolve image source and model matrix
         id: meta
         env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           RUN_DSR1_FP8_TP4: ${{ inputs.run_dsr1_fp8_tp4 }}
           RUN_QWEN35_35B_A3B_FP8_TP2: ${{ inputs.run_qwen35_35b_a3b_fp8_tp2 }}
           RUN_QWEN35_35B_A3B_TP2: ${{ inputs.run_qwen35_35b_a3b_tp2 }}

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -90,6 +90,8 @@ jobs:
       - name: Resolve benchmark source
         id: resolve
         env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           INPUT_SGLANG_IMAGE: ${{ inputs.sglang_image || '' }}
           INPUT_PUBLISH_TO_DASHBOARD: ${{ inputs.publish_to_dashboard }}
         run: |

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -277,6 +277,9 @@ jobs:
 
       - name: Resolve immutable native dashboard image
         if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           set -euo pipefail
           if RESOLUTION_JSON="$(

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -360,6 +360,8 @@ jobs:
           MODEL_SLOT_7: ${{ inputs.model_slot_7 || 'none' }}
           MODEL_SLOT_8: ${{ inputs.model_slot_8 || 'none' }}
           GITHUB_TOKEN: ${{ github.token }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           INPUT_OOT_IMAGE: ${{ inputs.oot_image || '' }}
         run: |
           set -euo pipefail

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -476,6 +476,8 @@ jobs:
       - name: Resolve benchmark source
         id: resolve
         env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           INPUT_OOT_IMAGE: ${{ inputs.oot_image || '' }}
           INPUT_PUBLISH_TO_DASHBOARD: ${{ inputs.publish_to_dashboard }}
           INPUT_UPLOAD_TO_CUSTOM_DASHBOARD: ${{ inputs.upload_to_custom_dashboard }}

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -41,22 +41,17 @@ class BlockManager:
         self.used_block_ids: set[int] = set()
         self.enable_prefix_caching = config.enable_prefix_caching
 
-        # Per-request cache: per-request slot pool + equiv-block accounting.
-        # Used by attention types that maintain stateful per-request buffers
-        # outside the paged KV pool — currently GDN recurrent state, future
-        # DeepseekV4 ring buffer + compressor state. See
-        # AttentionMetadataBuilder.compute_per_req_cache_bytes() for details.
+        # Per-request cache slot pool. Used by attention types with a
+        # stateful per-request buffer (GDN recurrent state, V4 compressor
+        # state). The backing tensor is pre-allocated by ModelRunner sized
+        # to max_num_seqs and excluded from `num_kvcache_blocks` at sizing
+        # time, so admission only needs a free slot index from this list.
         # Each slot group contains slots_per_req() contiguous tensor indices
         # (1 for stateless / + num_spec for spec-decoding-aware variants).
-        self.per_req_cache_equiv_blocks: int = getattr(
-            config, "per_req_cache_equiv_blocks", 0
-        )
         num_per_req_cache_groups: int = getattr(config, "num_per_req_cache_groups", 0)
         self.free_per_req_cache_groups: list[int] = list(
             range(num_per_req_cache_groups)
         )
-        # seq_id → list of accounting block_ids (memory bookkeeping only)
-        self.per_req_cache_accounting: dict[int, list[int]] = {}
 
     @classmethod
     def compute_hash(cls, token_ids: list[int], prefix: int = -1):
@@ -93,16 +88,15 @@ class BlockManager:
         self.free_block_ids_set.add(block_id)
 
     def can_allocate(self, seq: Sequence) -> bool:
-        per_req_cache_cost = (
-            self.per_req_cache_equiv_blocks if seq.has_per_req_cache else 0
-        )
+        # State cache (mamba / V4 compressor ring) has its own pre-allocated
+        # tensor; admission only needs a free slot index, not extra paged
+        # blocks. See `allocate()` for the budget reasoning.
         per_req_cache_slot_ok = (not seq.has_per_req_cache) or len(
             self.free_per_req_cache_groups
         ) > 0
         if not self.enable_prefix_caching:
             return (
-                len(self.free_block_ids_set) >= seq.num_blocks + per_req_cache_cost
-                and per_req_cache_slot_ok
+                len(self.free_block_ids_set) >= seq.num_blocks and per_req_cache_slot_ok
             )
         # Dry-run: count how many blocks would be cache hits
         h = -1
@@ -129,10 +123,7 @@ class BlockManager:
                 cache_miss = True
             if cache_miss:
                 needed_free += 1
-        return (
-            len(self.free_block_ids_set) >= needed_free + per_req_cache_cost
-            and per_req_cache_slot_ok
-        )
+        return len(self.free_block_ids_set) >= needed_free and per_req_cache_slot_ok
 
     def allocate(self, seq: Sequence):
         assert not seq.block_table
@@ -176,16 +167,15 @@ class BlockManager:
                 self.hash_to_block_id[h] = block_id
             seq.block_table.append(block_id)
 
-        # Per-request cache: allocate equiv blocks (memory accounting) +
-        # one slot index from the per-req cache pool. Slot indexes into
-        # ModelRunner's per-req cache tensors (e.g. mamba_k_cache for GDN).
+        # Per-request cache: claim one slot index from the pre-allocated
+        # state tensor (e.g. GDN mamba_k_cache, V4 compressor state + SWA
+        # ring). The state tensor's memory was already excluded from
+        # `num_kvcache_blocks` in ModelRunner._compute_kv_budget() — see
+        # `available_for_pool = available_for_kv - per_req_cache_tensor_bytes`
+        # — so admitting a seq adds no further paged-block cost. The slot
+        # cap (`free_per_req_cache_groups` size = `max_num_seqs`) is the
+        # sole admission bound for state cache.
         if seq.has_per_req_cache:
-            accounting_blocks = []
-            for _ in range(self.per_req_cache_equiv_blocks):
-                block_id = self._pop_free_block()
-                self._allocate_block(block_id)
-                accounting_blocks.append(block_id)
-            self.per_req_cache_accounting[seq.id] = accounting_blocks
             seq.per_req_cache_group = self.free_per_req_cache_groups.pop()
 
     def deallocate(self, seq: Sequence):
@@ -197,10 +187,6 @@ class BlockManager:
         seq.num_cached_tokens = 0
         seq.block_table.clear()
         if seq.has_per_req_cache and seq.per_req_cache_group >= 0:
-            for block_id in self.per_req_cache_accounting.pop(seq.id, []):
-                block = self.blocks[block_id]
-                block.ref_count = 0  # accounting blocks bypass ref-counting
-                self._deallocate_block(block_id)
             self.free_per_req_cache_groups.append(seq.per_req_cache_group)
             seq.per_req_cache_group = -1
 

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1281,6 +1281,39 @@ class ModelRunner:
                 f"pool_blocks={num_kvcache_blocks}"
             )
 
+        # Concurrent-capacity table: at each context-length percentage of
+        # max_model_len, how many requests can simultaneously hold their
+        # KV in the pool. Per-req block usage = ceil(ctx_len/block_size);
+        # per-req state cache is in its own pre-allocated tensor (already
+        # excluded from `num_kvcache_blocks` at sizing time), so it adds
+        # no per-block cost. Concurrency is also capped by
+        # max_per_req_cache_slots (state buffer slot count).
+        max_model_len = config.max_model_len
+        cap = (
+            max_per_req_cache_slots if per_req_cache_bytes > 0 else config.max_num_seqs
+        )
+        pct_lines = []
+        for pct in (10, 30, 50, 70, 90, 100):
+            ctx = max(1, max_model_len * pct // 100)
+            blocks_per_req = math.ceil(ctx / self.block_size)
+            block_bound = (
+                num_kvcache_blocks // blocks_per_req if blocks_per_req > 0 else 0
+            )
+            max_conc = min(cap, block_bound) if cap > 0 else block_bound
+            bound_label = (
+                "slots" if cap > 0 and max_conc == cap < block_bound else "blocks"
+            )
+            pct_lines.append(
+                f"  {pct:>3}% ({ctx:>7} tok): {blocks_per_req:>6} blk/req "
+                f"→ max_concurrent={max_conc:<5} (bound by {bound_label})"
+            )
+        logger.info(
+            f"Concurrent capacity vs context length "
+            f"(max_model_len={max_model_len}, block_size={self.block_size}, "
+            f"max_slots={cap}, pool_blocks={num_kvcache_blocks}):\n"
+            + "\n".join(pct_lines)
+        )
+
         assert num_kvcache_blocks > 0, (
             f"Not enough memory for KV cache with block size({self.block_size}). "
             f"At least 1 block ({block_bytes / (1 << 20):.2f}MB) is required, "
@@ -1717,7 +1750,7 @@ class ModelRunner:
 
         if is_prefill or self.enforce_eager or bs > self.graph_bs[-1]:
             # prefill[bs=1 tok=115 ctx=115]
-            label = f"prefill[bs={bs}"
+            label = f"prefill[bs={bs}" if is_prefill else f"eager_decode[bs={bs}"
             if batch is not None:
                 ctx = batch.context_lens
                 if len(ctx) == 1:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -154,18 +154,28 @@ class tokenIDProcessor:
         #   prev acc decode have 0 rej, 1 bonus
         #   prev rej decode have 1 rej, 0 bonus
         # It is clear that only rejected number is not sufficient for all status tracking, bonus number is also needed.
-        self.send_to_cpu_async(num_rejected, self.rejected_tokens_cpu, data_ready)
-        self.send_to_cpu_async(num_bonus, self.bonus_tokens_cpu, data_ready)
+        # Single Event for both copies (vs. per-tensor send_to_cpu_async) so the
+        # consumer pops one queue entry and synchronizes once instead of twice.
+        copy_done = torch.cuda.Event()
+        with torch.cuda.stream(self.async_copy_stream):
+            data_ready.wait(stream=self.async_copy_stream)
+            cpu_num_rejected = num_rejected.to("cpu", non_blocking=True)
+            cpu_num_bonus = num_bonus.to("cpu", non_blocking=True)
+            copy_done.record(self.async_copy_stream)
+        self.pending_mtp_status_copies.append(
+            (cpu_num_rejected, cpu_num_bonus, copy_done)
+        )
 
     def recv_mtp_status_async(
         self,
     ) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
-        if not self.rejected_tokens_cpu:
+        if not self.pending_mtp_status_copies:
             return None, None
-        return (
-            self.recv_async_output(self.rejected_tokens_cpu).numpy(),
-            self.recv_async_output(self.bonus_tokens_cpu).numpy(),
+        cpu_num_rejected, cpu_num_bonus, copy_done = self.pending_mtp_status_copies.pop(
+            0
         )
+        copy_done.synchronize()
+        return cpu_num_rejected.numpy(), cpu_num_bonus.numpy()
 
     def clean(self):
         self.token_ids_cpu: list[torch.Tensor] = []
@@ -176,8 +186,12 @@ class tokenIDProcessor:
         self.pre_num_decode_token_per_seq = 1
         self.draft_token_ids: Optional[torch.Tensor] = None
         self.draft_token_ids_cpu: list[torch.Tensor] = []
-        self.rejected_tokens_cpu: list[torch.Tensor] = []
-        self.bonus_tokens_cpu: list[torch.Tensor] = []
+        # Queue of (cpu_num_rejected, cpu_num_bonus, copy_done_event) — async
+        # D2H copies fired by send_mtp_status_to_cpu_async, drained by
+        # recv_mtp_status_async after the event syncs.
+        self.pending_mtp_status_copies: list[
+            tuple[torch.Tensor, torch.Tensor, torch.cuda.Event]
+        ] = []
         self.mapped_bonus_list: Optional[list[int]] = (
             None  # Mapped to current batch order
         )

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -472,15 +472,13 @@ class Scheduler:
                 f"or shorten the prompt."
             )
         bm = self.block_manager
-        per_req_cost = bm.per_req_cache_equiv_blocks if seq.has_per_req_cache else 0
         total_blocks = len(bm.blocks)
-        if seq.num_blocks + per_req_cost > total_blocks:
+        if seq.num_blocks > total_blocks:
             return (
-                f"needs {seq.num_blocks + per_req_cost} KV blocks "
-                f"({seq.num_blocks} for {num_tokens} input tokens + "
-                f"{per_req_cost} for per-req cache) > total pool blocks="
-                f"{total_blocks}. Reduce prompt length, lower --max-num-seqs, "
-                f"or raise --gpu-memory-utilization."
+                f"needs {seq.num_blocks} KV blocks for {num_tokens} input tokens "
+                f"> total pool blocks={total_blocks}. Reduce prompt length or "
+                f"raise --gpu-memory-utilization. (Per-req state cache lives in "
+                f"its own pre-allocated tensor and does not consume pool blocks.)"
             )
         return None
 
@@ -499,16 +497,23 @@ class Scheduler:
             logger.warning("Request %s will never be scheduled: %s", seq.id, reason)
             return
         bm = self.block_manager
-        if (
-            seq.has_per_req_cache
-            and not bm.free_per_req_cache_groups
-            and not bm.per_req_cache_accounting
-        ):
-            logger.warning(
-                "Request %s will never be scheduled: needs per-req cache slot "
-                "but no slots were allocated (max_num_seqs=0 for this model type).",
-                seq.id,
-            )
+        # No slots ever allocated (max_num_seqs=0 effectively) AND no slots
+        # currently in use → seq with has_per_req_cache=True can never enter.
+        # We check the slot list length below; without the accounting dict we
+        # infer "no slots ever existed" from `num_per_req_cache_groups == 0`,
+        # exposed via the free list at init time (slot ids 0..N-1).
+        if seq.has_per_req_cache and len(bm.free_per_req_cache_groups) == 0:
+            # All slots are currently in-use OR no slots were ever created.
+            # The schedule loop handles "currently full" by waiting; only
+            # warn for the permanent "never created" case, identified by
+            # `num_per_req_cache_groups` being 0 in the config.
+            if getattr(self.config, "num_per_req_cache_groups", 0) == 0:
+                logger.warning(
+                    "Request %s will never be scheduled: needs per-req cache "
+                    "slot but no slots were allocated (max_num_seqs=0 for "
+                    "this model type).",
+                    seq.id,
+                )
 
     def take_rejected(self) -> list[Sequence]:
         """Pop and return any seqs the prefill scheduler dropped because
@@ -784,8 +789,13 @@ class Scheduler:
             token_ids = prev_token_ids[idx]
             num_new_token = len(token_ids)
             if is_deferred_out or self.use_spec:
-                num_rejected = fwd_output.num_rejected[idx]
-                num_bonus = fwd_output.num_bonus[idx]
+                # int() casts strip the np.int32 wrapper coming out of
+                # fwd_output's np.ndarray indexing. Without these, the values
+                # propagate into seq.num_rejected / seq.num_bonus_tokens, then
+                # into seq.num_tokens via `preempt()`'s `-= mtp_k + num_rejected`,
+                # contaminating downstream logs and arithmetic with np.int32.
+                num_rejected = int(fwd_output.num_rejected[idx])
+                num_bonus = int(fwd_output.num_bonus[idx])
                 offset = 0 if (num_new_token + num_rejected) == 1 else self.mtp_k
                 # Align stats with vLLM: only count steps that actually ran
                 # speculation (drafts proposed and validated). Skip the

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -441,6 +441,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         bs: int,
         max_seqlen_q: int,
         max_seqlen_k: int,
+        positions: torch.Tensor,  # [total_tokens] int32
         only_update: bool = False,
         num_reject_tokens: torch.Tensor = None,
     ):

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -14,7 +14,7 @@ from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_ops.attention_mla import MLAModules
 from atom.utils import CpuGpuBuffer
 from atom.utils.tbo.ubatch_splitting import UBatchSlice, split_attn_metadata
-from atom.utils.forward_context import AttentionMetaData
+from atom.utils.forward_context import AttentionMetaData, AttnState
 from torch import nn
 
 logger = logging.getLogger("atom")
@@ -348,19 +348,22 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         total_kv = total_tokens if has_cached else sum_scheduled_tokens
         attn_metadata = AttentionMetaData(
             cu_seqlens_k=cu_seqlens_k.cuda(non_blocking=True),
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_k=max_seqlen_k,
-            min_seqlen_q=min_seqlen_q,
+            # Cast to python int — numpy.int32 leaks in via batch.context_lens
+            # (numpy array) and breaks downstream Triton kernel constexpr
+            # binding (`tl.minimum` rejects numpy scalars).
+            max_seqlen_q=int(max_seqlen_q),
+            max_seqlen_k=int(max_seqlen_k),
+            min_seqlen_q=int(min_seqlen_q),
             dropout_p=dropout_p,
             has_cached=has_cached,
-            total_kv=total_kv,
+            total_kv=int(total_kv),
             num_cached_tokens=num_cached_tokens,
+            state=AttnState.PREFILL_PREFIX if has_cached else AttnState.PREFILL_NATIVE,
             **ctx,
         )
         positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
 
         return attn_metadata, positions
-        # return var["positions"].copy_to_gpu(sum_scheduled_tokens)
 
     def build_ubatch_prefill_metadata(
         self,

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -39,6 +39,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type, cast
 
+
 import numpy as np
 import torch
 from aiter import dtypes
@@ -52,6 +53,7 @@ from atom.model_ops.v4_kernels import write_v4_paged_decode_indices
 from atom.utils import CpuGpuBuffer
 from atom.utils.forward_context import (
     AttentionMetaData,
+    AttnState,
     Context,
     get_forward_context,
 )
@@ -137,10 +139,10 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     """dict[ratio:int -> CompressPlan] — packed plan tensors per
     compress_ratio (4=CSA, 128=HCA)."""
 
-    # ----- Phase B paged-decode metadata (set when is_pure_decode == True) -----
-    is_pure_decode: bool = False
-    """uniform tokens-per-seq AND no fresh prefill (doc §7.4) — gates the
-    paged-decode dispatch in V4Attention.forward."""
+    # ----- Phase B paged-decode metadata (set when state is DECODE) -----
+    # `state` lives on the base AttentionMetaData; every V4 `prepare_*` path
+    # overrides it. Below buffers are populated only when state is DECODE
+    # (built by `_attach_v4_paged_decode_meta`).
     kv_indices_swa: Optional[torch.Tensor] = None
     """[T*win] int32 GPU — flat paged offsets into `unified_kv` for SWA path."""
     kv_indices_csa: Optional[torch.Tensor] = None
@@ -314,6 +316,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         self.index_head_dim = getattr(hf, "index_head_dim", 128)
         self.window_size = getattr(hf, "sliding_window", 128)
         self.index_topk = getattr(hf, "index_topk", 1024)
+        # MTP-portion of compress_ratios. `prepare_mtp_decode`'s direct-kernel
+        # fast path only handles SWA (ratio=0) draft layers; non-zero ratios
+        # would also need n_committed_{csa,hca} + HCA compress tail rebuilt.
+        # V4-Pro currently ships all-zero MTP ratios; assert keeps future
+        # configs honest.
+        n_main = int(getattr(hf, "num_hidden_layers", len(ratios)))
+        self._n_main_layers = n_main
+        self._mtp_layers_are_swa_only = all(r == 0 for r in ratios[n_main:])
         # `deepgemm_fp8_paged_mqa_logits` decode-path output column count
         # = max compressed K positions per seq. CSA ratio=4 is the
         # max-density ratio (1 indexer slot per 4 source tokens).
@@ -947,83 +957,116 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         bs: int,
         max_seqlen_q: int,
         max_seqlen_k: int,
+        positions: torch.Tensor,  # [bs] int — eagle's current draft-step positions
         only_update: bool = False,
-        num_reject_tokens: torch.Tensor = None,
+        num_reject_tokens: Optional[torch.Tensor] = None,
     ):
         """Per-draft-step V4 region metadata rebuild for 1-token-per-seq shape.
 
-        Called by EagleProposer.propose at mid-step iters (i < mtp_k - 1).
-        Eagle has already bumped attn_metadata.context_lens GPU by +1 and
-        max_seqlen_k by +1 before calling us. We mirror the +1 on CPU (zero
-        D2H: structural invariant of eagle's loop) and rebuild
-        v4_kv_indices_{swa,csa,hca}, batch_id_per_token, n_committed_csa_per_seq,
-        indexer meta, and compress_plans.
+        Called by EagleProposer.propose at mid-step iters. Eagle has already
+        updated GPU state before this call:
+          - ``attn_metadata.context_lens`` (GPU view of
+            ``var["context_lens"].gpu``): rolled-back by ``prepare_decode``
+            and bumped by eagle (`eagle.py:443`). Already the correct
+            per-seq KV length for this draft step — DO NOT subtract
+            num_reject_tokens (would double-rollback).
+          - ``var["cu_seqlens_q"].gpu[:bs+1]``: set to ``arange(bs+1)``
+            (`eagle.py:430`) for the 1-tok-per-seq shape.
+        Eagle does NOT update the CPU mirrors (``var["..."].np``), so the
+        CPU-numpy path of ``_attach_v4_per_fwd_meta`` /
+        ``_attach_v4_paged_decode_meta`` would see stale values from verify.
+        This routine bypasses both helpers and rebuilds the only buffers
+        an SWA-only MTP layer actually consumes by calling
+        ``write_v4_paged_decode_indices`` directly with GPU-computed
+        indptrs. No D2H, no CPU mirror touch.
 
-        ``only_update`` / ``num_reject_tokens`` are MLA-specific (no V4
-        analog — V4 has no incremental-update kernel and the ctx rollback
-        is already applied at the top of prepare_decode for the verify
-        shape). Ignored.
+        Restricted to SWA-only MTP layers (compress_ratio == 0); asserted at
+        builder init via ``self._mtp_layers_are_swa_only``. ``only_update``
+        / ``num_reject_tokens`` are MLA-specific knobs and are ignored — V4
+        handles rollback once in ``prepare_decode``.
         """
-        # `max_per_req_cache_slots` is set inside `model_runner.get_num_blocks`,
-        # which runs AFTER `warmup_model`. The full per-fwd meta rebuild below
-        # eventually reads it via `_attach_v4_paged_decode_meta`, so during
-        # warmup (attr unset) we no-op — warmup discards draft output anyway,
-        # and the verify-shape attn_metadata from the main forward stays valid
-        # for the rest of eagle.propose.
+        # `max_per_req_cache_slots` is set inside `model_runner.get_num_blocks`
+        # AFTER `warmup_model`. During warmup we no-op — warmup discards
+        # draft output anyway, and the verify-shape attn_metadata stays valid.
         if not getattr(self.model_runner, "max_per_req_cache_slots", 0):
             return {}
+        assert self._mtp_layers_are_swa_only, (
+            "prepare_mtp_decode fast path only supports SWA-only MTP layers "
+            f"(compress_ratio==0); got compress_ratios[mtp]="
+            f"{self.compress_ratios[self._n_main_layers:]}"
+        )
 
         var = self.model_runner.forward_vars
-        attn_metadata = get_forward_context().attn_metadata
-
-        # 1. CPU mirror of eagle's GPU `context_lens[:bs] += 1` bump. Zero
-        #    D2H: we know the offset by construction (+1 per call).
-        var["context_lens"].np[:bs] += 1
-        context_lens_np = var["context_lens"].np[:bs]
-
-        # 2. 1-token-per-seq shape: positions = ctx-1, cu_seqlens_q = arange.
-        positions_np = (context_lens_np - 1).astype(np.int32)
-        cu_seqlens_q_np = np.arange(bs + 1, dtype=np.int32)
-        var["positions"].np[:bs] = positions_np
-        var["cu_seqlens_q"].np[: bs + 1] = cu_seqlens_q_np
-
-        # 3. H2D staging. context_lens already on GPU (eagle bumped it);
-        # CPU is now mirrored.
-        positions_gpu = var["positions"].copy_to_gpu(bs)
-        var["cu_seqlens_q"].copy_to_gpu(bs + 1)
-
-        # 4. CPU numpy: extend_lens (=1 per seq).
-        extend_lens_np = np.ones(bs, dtype=np.int32)
-
-        # 5. Rebuild V4 region metadata via existing helpers (numpy + H2D,
-        #    no D2H — `_build_compress_plans` only triggers `.cpu()` when
-        #    given torch tensors; we pass numpy below).
-        self._attach_v4_per_fwd_meta(
-            attn_metadata,
-            cu_seqlens_q_np,
-            extend_lens_np,  # = np.ones(bs) — MTP draft step is 1 token per seq
-            state_slot_mapping_cpu=attn_metadata.state_slot_mapping_cpu,
-            scheduled_bs=bs,
-            total_tokens=bs,
-            padded_bs=bs,
-            max_q_len=1,
+        attn_metadata = cast(
+            AttentionMetaData_DSV4, get_forward_context().attn_metadata
         )
-        self._attach_v4_indexer_meta(
-            attn_metadata,
-            scheduled_bs=bs,
-            total_tokens=bs,
-            positions_gpu=positions_gpu,
+        # Pre-populated by the verify-forward `prepare_decode` and kept alive
+        # across eagle.propose; assert for the static checker.
+        assert attn_metadata.context_lens is not None
+        assert attn_metadata.state_slot_mapping is not None
+        win = self.window_size  # SWA prefix max per token
+        cs = self.win_with_spec  # SWA ring stride = win + max_spec_steps
+
+        # ----- GPU-side SWA indptr math (no CPU numpy, no D2H) -----
+        # ctx_gpu is already correct (rolled-back by prepare_decode + bumped
+        # by eagle). int32 in the source buffer; keep dtype throughout.
+        # Only SWA is computed; CSA/HCA indices are unused by SWA-only MTP
+        # (asserted above) and will be fully rebuilt by the next verify-fwd's
+        # `prepare_decode`.
+        actual_swa = torch.clamp(positions + 1, max=win)
+
+        swa_indptr = var["v4_kv_indptr_swa"].gpu[: bs + 1]
+        # positions/actual_swa are int64 (eagle's positions buffer); cast to
+        # int32 inside cumsum to match swa_indptr's int32 storage.
+        torch.cumsum(actual_swa, dim=0, dtype=torch.int32, out=swa_indptr[1:])
+
+        # batch_id_per_token: 1-tok-per-seq → arange(bs). Eagle already
+        # populated cu_seqlens_q as arange(bs+1) (eagle.py:430), so its
+        # [:bs] slice IS [0,1,...,bs-1] — exactly the per-token batch id.
+        # No extra alloc / arange kernel.
+        assert attn_metadata.cu_seqlens_q is not None
+        batch_id_per_token = attn_metadata.cu_seqlens_q[:bs]
+
+        # ----- Kernel: write SWA prefix paged offsets -----
+        # `write_v4_paged_decode_indices` writes to swa/csa/hca indices in
+        # one pass. For SWA-only MTP we alias csa/hca slots to swa so the
+        # kernel writes the same value three times to swa_indices_buf —
+        # redundant ~bs*win stores (~8 KB at V4-Pro bs=64, win=128), saves
+        # building two extra unused indptr buffers.
+        swa_indices_buf = var["v4_kv_indices_swa"].gpu
+        write_v4_paged_decode_indices(
+            state_slot_per_seq=attn_metadata.state_slot_mapping,
+            batch_id_per_token=batch_id_per_token,
+            positions=positions,
+            swa_indptr=swa_indptr,
+            csa_indptr=swa_indptr,
+            hca_indptr=swa_indptr,
+            swa_indices=swa_indices_buf,
+            csa_indices=swa_indices_buf,
+            hca_indices=swa_indices_buf,
+            T=bs,
+            win=win,
+            cs=cs,
         )
 
-        # 6. Compress plans for state-ring write of each new draft token.
-        attn_metadata.compress_plans = self._build_compress_plans(
-            extend_lens_np,
-            context_lens_np,
-            for_decode_cg=True,
-        )
+        # ----- Publish on attn_metadata for V4Attention.forward -----
+        # MTP layer is ratio=0 → reads kv_indices_swa + kv_indptr_swa only.
+        # kv_indices_{csa,hca} / kv_indptr_{csa,hca} are left at whatever
+        # prepare_decode populated for the verify shape; downstream V4
+        # decode kernel only touches them when ratio != 0.
+        attn_metadata.state = AttnState.DECODE
+        attn_metadata.max_seqlen_q = 1
+        attn_metadata.kv_indices_swa = swa_indices_buf
+        attn_metadata.kv_indptr_swa = swa_indptr
+        attn_metadata.batch_id_per_token = batch_id_per_token
 
-        # All updates done in-place on attn_metadata; eagle's
-        # `for k, v in workinfos.items(): __dict__[k] = v` loop is a no-op.
+        # NOT rebuilt (unused by SWA-only MTP layer; would block a future
+        # CSA/HCA MTP layer — assert at top guards):
+        #   - n_committed_{csa,hca}_per_seq{,_cpu} (compressor/HCA tail math)
+        #   - skip_prefix_len_csa (csa_translate_pack per-layer write)
+        #   - compress_plans (Compressor — only present when ratio != 0)
+        #   - HCA compress tail in kv_indices_hca
+        #   - v4 indexer meta (Indexer — only present when ratio == 4)
         return {}
 
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
@@ -1114,7 +1157,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             num_cached_tokens=None,
             block_tables=block_tables_gpu,
             context_lens=context_lens_gpu,
-            is_pure_decode=True,
+            state=AttnState.DECODE,
         )
         attn_metadata.state_slot_mapping = state_slot_gpu
         attn_metadata.state_slot_mapping_cpu = state_slot_np
@@ -1156,11 +1199,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # fields with defaults; the parent dataclass is non-slotted.
         base_md.__class__ = AttentionMetaData_DSV4
         attn_metadata = cast(AttentionMetaData_DSV4, base_md)
-        # Prefill is by definition not pure decode (fresh-prefill seqs have
-        # start_pos == 0). Class-promotion via __class__ doesn't run the
-        # dataclass __init__, so V4-specific defaults aren't applied — set
-        # explicitly.
-        attn_metadata.is_pure_decode = False
+        # state defaults to PREFILL_NATIVE (set by `backends.build()` after
+        # this returns); `_build_paged_prefill_meta` upgrades to
+        # PREFILL_PREFIX if any seq has chunk_start > 0 (chunked prefill).
         scheduled_bs = batch.total_seqs_num_prefill
         if attn_metadata.block_tables is None:
             attn_metadata.block_tables = self._populate_block_tables(
@@ -1393,24 +1434,22 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         cu_seqlens_q_arr = np.asarray(
             cu_seqlens_q_np[: scheduled_bs + 1], dtype=np.int32
         )
-        # is_pure_decode is set by the caller at AttentionMetaData_DSV4
-        # construction time (single source of truth — prepare_decode /
-        # prepare_prefill / build_for_cudagraph_capture each know their
-        # own semantics). Consumed for: padded_total_tokens (CG bucket vs
-        # eager-tight) and by `_attach_v4_paged_decode_meta` for the
-        # index-buffer skip.
-        is_pure_decode = attn_metadata.is_pure_decode
+        # state is set by the caller at AttentionMetaData_DSV4 construction
+        # time (single source of truth — prepare_decode / prepare_prefill /
+        # prepare_mtp_decode / build_for_cudagraph_capture each set it).
+        # Consumed here for padded_total_tokens sizing.
+        is_pure_decode = attn_metadata.state is AttnState.DECODE
 
         # padded_total_tokens: CG-captured decode/MTP pads to the fixed
         # bucket `padded_bs * (1+max_spec_steps)` so the per-token
         # `batch_id_per_token` buffer has a stable shape across captures.
-        # Non-pure-decode (prefill / mixed / fresh-prefill) is eager and
-        # uses `total_tokens` exactly — no wasted padding (a long prefill
+        # Prefill states (PREFILL_NATIVE / PREFILL_PREFIX) are eager and
+        # use `total_tokens` exactly — no wasted padding (a long prefill
         # chunk doesn't need to be padded up to a bucket that doesn't
         # exist for it).
         if is_pure_decode:
             assert padded_bs is not None and max_q_len is not None, (
-                "is_pure_decode requires padded_bs + max_q_len from caller "
+                "DECODE state requires padded_bs + max_q_len from caller "
                 "(CG bucket size — fixed at capture)"
             )
             padded_total_tokens = int(padded_bs) * int(max_q_len)
@@ -1514,23 +1553,21 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                                the caller; consumed by the index-write kernel
                                + CPU-side actual_swa_count cumsum here)
 
-        Skipped when not is_pure_decode (prefill, mixed, fresh-prefill). The
-        Phase-B fields (kv_indices_*, kv_indptr_*, swa_pages) stay at their
-        dataclass defaults (None / 0) for non-decode batches; downstream
-        consumers gate on `is_pure_decode`.
+        Skipped when state is not DECODE. The Phase-B fields
+        (kv_indices_*, kv_indptr_*, swa_pages) stay at their dataclass
+        defaults for prefill batches; downstream V4Attention.forward branches
+        on state and reads prefill-mode buffers (kv_indices_prefix_*) instead.
         """
         if scheduled_bs == 0 or total_tokens == 0:
             return  # fields stay at dataclass defaults
 
-        if not attn_metadata.is_pure_decode:
-            return  # caller already marked non-decode; nothing to build
+        if attn_metadata.state is not AttnState.DECODE:
+            return  # prefill: only kv_indices_prefix_* are built downstream
 
         if len(state_slot_mapping_cpu) < scheduled_bs:
-            # Warmup / dummy_run carve-out: caller asserted pure_decode but
-            # state_slot_mapping is incomplete. Flip the flag so downstream
-            # consumers (V4Attention.forward) take the non-decode codepath
-            # instead of dereferencing the unbuilt kv_indices_* buffers.
-            attn_metadata.is_pure_decode = False
+            # Defensive carve-out: caller asserted DECODE but
+            # state_slot_mapping is incomplete. Flip state to PREFILL_NATIVE.
+            attn_metadata.state = AttnState.PREFILL_NATIVE
             return
 
         var = self.model_runner.forward_vars
@@ -2117,7 +2154,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             num_cached_tokens=None,
             block_tables=block_tables_gpu,
             context_lens=context_lens_gpu,
-            is_pure_decode=True,
+            state=AttnState.DECODE,
         )
         attn_metadata.state_slot_mapping = state_slot_gpu
         attn_metadata.state_slot_mapping_cpu = state_slot_np

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -49,7 +49,10 @@ from atom.model_ops.attentions.backends import (
     AttentionMetadataBuilder,
     CommonAttentionBuilder,
 )
-from atom.model_ops.v4_kernels import write_v4_paged_decode_indices
+from atom.model_ops.v4_kernels import (
+    write_v4_paged_decode_indices,
+    write_v4_paged_prefill_indices,
+)
 from atom.utils import CpuGpuBuffer
 from atom.utils.forward_context import (
     AttentionMetaData,
@@ -112,9 +115,10 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     """[bs] int32 GPU — per-seq state cache slot. Shared by swa_write +
     Compressor + paged-decode kernels (looked up via batch_id_per_token)."""
     n_committed_csa_per_seq: Optional[torch.Tensor] = None
-    """[bs] int32 GPU — `ctx_len // 4`. Consumed by csa_translate_pack
-    (kernel masks `(k < n_committed) & (k < index_topk)` — clamp lives in
-    kernel, not builder) AND by the indexer (cast to long inline)."""
+    """[bs] int32 GPU — RAW `ctx_len // 4` per-seq committed count. Consumed
+    by the indexer (cast to long inline) AND by csa_translate_pack
+    (kernel derives per-token valid_k inline from this + positions +
+    index_topk; no separate per-token tensor needed)."""
 
     # ----- Per-fwd hoisted (built in `_attach_v4_per_fwd_meta`) -----
     batch_id_per_token: Optional[torch.Tensor] = None
@@ -229,33 +233,6 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     (same `kv` shared by all 3 ratios; one builder pass)."""
     kv_indptr_extend: Optional[torch.Tensor] = None
     """[total_tokens + 1] int32 GPU — packed cumsum of `extend_count`."""
-
-
-# ---------------------------------------------------------------------------
-# Builder-local helpers (private). Used by `_build_paged_prefill_meta` and
-# `_attach_v4_per_fwd_meta` for ragged-segment index math + per-token
-# sliding-window topk index generation. Live here (not in the model file)
-# because their only callers are inside this builder.
-# ---------------------------------------------------------------------------
-
-
-def _segment_indices(
-    seq_ids: np.ndarray, lens: np.ndarray
-) -> tuple[np.ndarray, np.ndarray]:
-    """For ragged segments (one per `seq_ids[i]` of length `lens[i]`), return
-    flat (per-row seq id, per-row local position) arrays of total length
-    `sum(lens)`.
-    """
-    total = int(lens.sum())
-    if total == 0:
-        return (
-            np.empty(0, dtype=np.int32),
-            np.empty(0, dtype=np.int32),
-        )
-    token_seq_ids = np.repeat(seq_ids.astype(np.int32), lens)
-    cum = np.concatenate(([0], np.cumsum(lens, dtype=np.int32)[:-1]))
-    local_pos = np.arange(total, dtype=np.int32) - np.repeat(cum, lens)
-    return token_seq_ids, local_pos
 
 
 class DeepseekV4Backend(AttentionBackend):
@@ -395,11 +372,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # `np[:n] = arr; copy_to_gpu(n)` pattern instead of per-call
         # `torch.as_tensor(arr)` allocations.
         self._alloc_v4_metadata_buffers()
-
-        # Grow-on-demand pinned buffer for prefill index H2D.
-        self._prefill_staging_cap = 0
-        self._prefill_staging_pinned: Optional[torch.Tensor] = None
-        self._prefill_staging_gpu: Optional[torch.Tensor] = None
 
     @property
     def prep_stream(self):
@@ -1594,24 +1566,33 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         n_committed_hca_per_seq = attn_metadata.n_committed_hca_per_seq_cpu
 
         # ----- 3 indptr cumsums (CPU numpy, ragged) -----
-        # Per-token kv_len = actual_swa_count + n_compress. CSA length is
-        # clamped to index_topk because csa_translate_pack only writes that
-        # many rows per seq (kernel mask `(k < n_committed) & (k < index_topk)`);
-        # the host-side clamp here just keeps the indices buffer correctly
-        # sized — the staged GPU n_committed_csa stays raw.
+        # Per-token kv_len = actual_swa_count + n_compress. CSA length now
+        # matches Indexer's per-row visibility exactly (= csa_translate_pack
+        # kernel's per-token valid_k formula), so buffer reserves only the
+        # cells the kernel actually writes — no `-1` sentinel pre-fill, no
+        # over-allocation for tokens with per-row visibility < seq-level
+        # n_csa (which happens for early tokens in chunked-prefill verify
+        # batches and MTP draft mid-iters).
         index_topk = self.index_topk
-        n_committed_csa_clamped_per_token = np.minimum(
-            n_committed_csa_per_seq[batch_id_per_token_np], index_topk
-        )
+        positions_np_view = var["positions"].np[:T]
         n_committed_hca_per_token = n_committed_hca_per_seq[batch_id_per_token_np]
 
         # actual_swa_count[t] = min(positions[t]+1, win). Matches the kernel's
         # inline `n = tl.minimum(pos+1, win)` so SWA-prefix segment sizes line
         # up perfectly. `var["positions"]` is the int64 CpuGpuBuffer populated
         # + H2D-copied by the caller (prepare_decode / build_for_cudagraph_capture).
-        actual_swa_count_np = np.minimum(var["positions"].np[:T] + 1, win).astype(
-            np.int32
-        )
+        actual_swa_count_np = np.minimum(positions_np_view + 1, win).astype(np.int32)
+        # csa_valid_k_per_token = min((pos+1)//4, n_committed_csa[bid], index_topk)
+        # — mirrors `_attach_v4_indexer_meta`'s `visible_end_gpu` and the
+        # `csa_translate_pack` kernel's inline computation, so buffer size ↔
+        # kernel-writes match exactly.
+        csa_valid_k_per_token = np.minimum(
+            np.minimum(
+                (positions_np_view + 1) // 4,
+                n_committed_csa_per_seq[batch_id_per_token_np],
+            ),
+            index_topk,
+        ).astype(np.int32)
 
         # CG-padding-aware T_for_indptr: indptr buffer must size to the
         # captured kernel grid (= padded_total_tokens) so padded slots see
@@ -1630,8 +1611,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         swa_indptr_np[1 : T + 1] = np.cumsum(actual_swa_count_np, dtype=np.int32)
         if T_pad > T:
             swa_indptr_np[T + 1 :].fill(int(swa_indptr_np[T]))
-        # CSA: ragged, per-token len = actual_swa_count + min(n_csa, index_topk)
-        csa_per_tok = actual_swa_count_np + n_committed_csa_clamped_per_token
+        # CSA: ragged, per-token len = actual_swa_count + csa_valid_k_per_token
+        csa_per_tok = actual_swa_count_np + csa_valid_k_per_token
         csa_indptr_np = np.zeros(T_pad + 1, dtype=np.int32)
         csa_indptr_np[1 : T + 1] = np.cumsum(csa_per_tok, dtype=np.int32)
         if T_pad > T:
@@ -1789,195 +1770,145 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # (max_per_req_cache_slots not set yet, unified_kv is a 1-page
         # placeholder). V4Attention.forward detects `is_dummy_run` and
         # short-circuits the sparse_attn dispatch entirely, so we don't need
-        # valid prefix/extend indices during warmup. Skip the CPU work too.
+        # valid prefix/extend indices during warmup.
         num_slots = getattr(self.model_runner, "max_per_req_cache_slots", 0)
         if num_slots == 0:
             return
         swa_pages = num_slots * cs
-        var = self.model_runner.forward_vars  # used for block_tables + plan buffers
+        var = self.model_runner.forward_vars
 
-        # ----- Per-token quantities (CPU numpy) -----
-        # cu_seqlens_q_arr still needed below (ext_cu_q gather);
-        # token_num_per_seq is now passed in by caller — no longer re-derived.
-        # All quantities here fit in int32: positions ≤ max_model_len ≪ 2^31,
-        # counts (win, index_topk) are small, cumsums bounded by T·max_per_tok
-        # ≈ 18M. Keeping int32 throughout avoids needless widen/narrow churn.
-        cu_seqlens_q_arr = np.asarray(
-            cu_seqlens_q_np[: scheduled_bs + 1], dtype=np.int32
-        )
-        token_num_per_seq = np.asarray(token_num_per_seq, dtype=np.int32)
-        chunk_start_per_seq = np.asarray(
+        # ----- CPU numpy: per-token counts + indptrs -----
+        # Same formulas as the old _segment_indices/scatter chain, just without
+        # the segment-expansion + scatter steps — those are now done by the
+        # GPU kernel below. numpy.cumsum gives us indptr totals for free
+        # (no D2H sync needed to size output buffers).
+        chunk_start_per_seq_np = np.asarray(
             start_pos_per_seq_np[:scheduled_bs], dtype=np.int32
         )
-        # batch_id_per_token_np mirrors what _attach_v4_per_fwd_meta computed
-        # but we need a CPU copy for the cumsum / segment math below. CPU-only
-        # — the GPU copy (int64 for PyTorch fancy index) is staged separately.
+        token_num_per_seq = np.asarray(token_num_per_seq, dtype=np.int32)
         batch_id_per_token_np = np.repeat(
             np.arange(scheduled_bs, dtype=np.int32), token_num_per_seq
         )  # [T] int32
         positions_arr = np.asarray(positions_np[:T], dtype=np.int32)
-        token_pos_in_chunk = (
-            positions_arr - chunk_start_per_seq[batch_id_per_token_np]
-        )  # [T] int32
-        # SWA window low bound (clamped at 0); used to derive prefix_swa_count
-        # AND the absolute global positions inside the prefix SWA section.
-        swa_window_low_global = np.maximum(0, positions_arr - win + 1)  # [T] int32
+        chunk_start_pt = chunk_start_per_seq_np[batch_id_per_token_np]
+        token_pos_in_chunk = positions_arr - chunk_start_pt
+        swa_low = np.maximum(positions_arr - win + 1, 0)
 
         extend_count_np = np.minimum(token_pos_in_chunk + 1, win).astype(np.int32)
-        prefix_swa_count_np = np.maximum(
-            0, chunk_start_per_seq[batch_id_per_token_np] - swa_window_low_global
-        ).astype(np.int32)
-
-        # Read pre-computed `ctx // {4,128}` from attn_metadata — populated by
-        # `_attach_v4_per_fwd_meta` (always runs first). int32.
+        prefix_swa_count_np = np.maximum(chunk_start_pt - swa_low, 0).astype(np.int32)
         n_committed_csa_per_seq_np = attn_metadata.n_committed_csa_per_seq_cpu
         n_committed_hca_per_seq_np = attn_metadata.n_committed_hca_per_seq_cpu
-        n_csa_per_token = np.minimum(
-            n_committed_csa_per_seq_np[batch_id_per_token_np], index_topk
-        )  # [T] int32 — clamped because csa_translate_pack writes at most
-        #   index_topk per token (kernel mask `(k < n) & (k < index_topk)`)
-        n_hca_per_token = n_committed_hca_per_seq_np[batch_id_per_token_np]  # [T] int32
-
-        # ----- indptr cumsums (CPU) -----
-        # All output int32 directly (downstream H2D stages int32 GPU buffers).
-        prefix_swa_indptr_np = np.zeros(T + 1, dtype=np.int32)
-        prefix_swa_indptr_np[1:] = np.cumsum(prefix_swa_count_np, dtype=np.int32)
-        prefix_csa_indptr_np = np.zeros(T + 1, dtype=np.int32)
-        prefix_csa_indptr_np[1:] = np.cumsum(
-            prefix_swa_count_np + n_csa_per_token, dtype=np.int32
-        )
-        prefix_hca_indptr_np = np.zeros(T + 1, dtype=np.int32)
-        prefix_hca_indptr_np[1:] = np.cumsum(
-            prefix_swa_count_np + n_hca_per_token, dtype=np.int32
-        )
-        extend_indptr_np = np.zeros(T + 1, dtype=np.int32)
-        extend_indptr_np[1:] = np.cumsum(extend_count_np, dtype=np.int32)
-
-        # ----- Extend kv_indices (in `kv` tensor): per-token rows -----
-        # extend window for token t: kv rows
-        # `[cu_seqlens_q[bid] + (token_pos_in_chunk[t] - extend_count[t] + 1
-        #   ... cu_seqlens_q[bid] + token_pos_in_chunk[t]]`. Build via segment
-        # expansion.
-        ext_seg_tok, ext_seg_k = _segment_indices(
-            np.arange(T, dtype=np.int32), extend_count_np
-        )
-        # Pre-gather per-token vars for the segment positions (vectorised).
-        ext_cu_q = cu_seqlens_q_arr[:scheduled_bs][batch_id_per_token_np]  # [T] int32
-        ext_indices_np = (
-            ext_cu_q[ext_seg_tok]
-            + (
-                token_pos_in_chunk[ext_seg_tok]
-                - extend_count_np[ext_seg_tok]
-                + 1
-                + ext_seg_k
-            )
+        # Per-token CSA valid_k = Indexer's per-row visibility, matching
+        # `_attach_v4_indexer_meta`'s `visible_end_gpu` formula and the
+        # `csa_translate_pack` kernel's inline computation. Buffer size ↔
+        # kernel-writes match exactly, so no `-1` sentinel pre-fill is needed.
+        csa_valid_k_per_token_np = np.minimum(
+            np.minimum(
+                (positions_arr + 1) // 4,
+                n_committed_csa_per_seq_np[batch_id_per_token_np],
+            ),
+            index_topk,
         ).astype(np.int32)
-
-        # ----- Prefix SWA paged offsets -----
-        # For each token's prefix SWA segment: positions
-        # `[swa_window_low_global[t] + k for k in range(prefix_swa_count[t])]`,
-        # paged into `unified_kv` SWA region:
-        #   paged = state_slot[bid] * cs + (global_pos % cs)
-        # where cs = win_with_spec (per-slot ring size). MUST match the same
-        # stride/modulo used by `swa_write` and the decode-path
-        # `_attach_v4_paged_decode_meta`, otherwise prefill prefix reads would
-        # land in the wrong slot once MTP makes cs > win.
-        swa_seg_tok, swa_seg_k = _segment_indices(
-            np.arange(T, dtype=np.int32), prefix_swa_count_np
+        n_hca_per_token_np = n_committed_hca_per_seq_np[batch_id_per_token_np].astype(
+            np.int32
         )
-        state_slot_arr = np.asarray(
-            state_slot_mapping_cpu[:scheduled_bs], dtype=np.int32
+
+        # 4 indptrs on CPU; last element = total (no D2H to size buffers).
+        ext_indptr_np = np.zeros(T + 1, dtype=np.int32)
+        ext_indptr_np[1:] = np.cumsum(extend_count_np, dtype=np.int32)
+        swa_indptr_np = np.zeros(T + 1, dtype=np.int32)
+        swa_indptr_np[1:] = np.cumsum(prefix_swa_count_np, dtype=np.int32)
+        csa_indptr_np = np.zeros(T + 1, dtype=np.int32)
+        csa_indptr_np[1:] = np.cumsum(
+            prefix_swa_count_np + csa_valid_k_per_token_np, dtype=np.int32
         )
-        prefix_swa_global_pos = (
-            swa_window_low_global[swa_seg_tok] + swa_seg_k
-        )  # [sum prefix_swa_count] int32
-        prefix_swa_paged_np = (
-            state_slot_arr[batch_id_per_token_np[swa_seg_tok]] * cs
-            + (prefix_swa_global_pos % cs)
-        ).astype(np.int32)
-
-        # ----- HCA compress paged offsets (layer-invariant, fully built here) -----
-        # Per token, HCA section is `[block_tables[bid, k] for k in range(n_hca[bid])]`
-        # mapped to `swa_pages + phys` (HCA block_capacity = 1).
-        block_tables_np = var["block_tables"].np[:scheduled_bs]
-        hca_seg_tok, hca_seg_k = _segment_indices(
-            np.arange(T, dtype=np.int32), n_hca_per_token
+        hca_indptr_np = np.zeros(T + 1, dtype=np.int32)
+        hca_indptr_np[1:] = np.cumsum(
+            prefix_swa_count_np + n_hca_per_token_np, dtype=np.int32
         )
-        hca_phys = block_tables_np[
-            batch_id_per_token_np[hca_seg_tok], hca_seg_k
-        ]  # [sum n_hca] int32
-        hca_compress_paged_np = (swa_pages + hca_phys).astype(np.int32)
+        ext_total = int(ext_indptr_np[T])
+        swa_total = int(swa_indptr_np[T])
+        csa_total = int(csa_indptr_np[T])
+        hca_total = int(hca_indptr_np[T])
 
-        # ----- Assemble flat prefix buffers (vectorised, no Python per-token loop) -----
-        # Each per-token segment is laid out as [SWA_prefix..., compress...].
-        # Dense (SWA only): buffer == `prefix_swa_paged_np` directly (no compress).
-        # CSA / HCA: scatter SWA segments into [indptr[t], indptr[t]+swa_n[t])
-        # and compress segments into [indptr[t]+swa_n[t], indptr[t]+swa_n[t]+comp_n[t]).
-        # Both scatter dst positions derived from `_segment_indices` output:
-        #   for SWA segment i (token = swa_seg_tok[i], col = swa_seg_k[i]):
-        #     dst = prefix_*_indptr[token] + col
-        #   for compress segment j (token = comp_seg_tok[j], col = comp_seg_k[j]):
-        #     dst = prefix_*_indptr[token] + prefix_swa_count[token] + col
-        prefix_csa_total = int(prefix_csa_indptr_np[T])
-        prefix_hca_total = int(prefix_hca_indptr_np[T])
-
-        # Dense prefix buffer = SWA only, already in per-token cumsum order
-        # (since _segment_indices walks tokens in order and emits cols 0..n-1).
-        kv_indices_prefix_swa_np = prefix_swa_paged_np  # alias
-
-        # CSA prefix buffer: SWA section scattered, CSA section pre-filled -1
-        # (csa_translate_pack writes valid entries per-layer; -1 sentinel keeps
-        # unfilled tail slots safe — paged_prefill kernel skips slot < 0).
-        kv_indices_prefix_csa_np = np.full(prefix_csa_total, -1, dtype=np.int32)
-        if prefix_swa_paged_np.size > 0:
-            csa_swa_dst = prefix_csa_indptr_np[swa_seg_tok] + swa_seg_k
-            kv_indices_prefix_csa_np[csa_swa_dst] = prefix_swa_paged_np
-
-        # HCA prefix buffer: SWA section + HCA all-committed section, both
-        # scattered via segment indices (no Python per-token loop).
-        kv_indices_prefix_hca_np = np.empty(prefix_hca_total, dtype=np.int32)
-        if prefix_swa_paged_np.size > 0:
-            hca_swa_dst = prefix_hca_indptr_np[swa_seg_tok] + swa_seg_k
-            kv_indices_prefix_hca_np[hca_swa_dst] = prefix_swa_paged_np
-        if hca_compress_paged_np.size > 0:
-            hca_comp_dst = (
-                prefix_hca_indptr_np[hca_seg_tok]
-                + prefix_swa_count_np[hca_seg_tok]
-                + hca_seg_k
-            )
-            kv_indices_prefix_hca_np[hca_comp_dst] = hca_compress_paged_np
-
-        # ----- Single pinned H2D for all prefill index arrays -----
-        # Pack int32 arrays into one contiguous pinned buffer, one H2D copy
-        # (truly non_blocking on pinned memory), then slice out views.
-        fields = [
-            ("kv_indices_extend", ext_indices_np),
-            ("kv_indptr_extend", extend_indptr_np),
-            ("kv_indices_prefix_swa", kv_indices_prefix_swa_np),
-            ("kv_indptr_prefix_swa", prefix_swa_indptr_np),
-            ("kv_indices_prefix_csa", kv_indices_prefix_csa_np),
-            ("kv_indptr_prefix_csa", prefix_csa_indptr_np),
-            ("kv_indices_prefix_hca", kv_indices_prefix_hca_np),
-            ("kv_indptr_prefix_hca", prefix_hca_indptr_np),
-            ("skip_prefix_len_csa", prefix_swa_count_np),
-        ]
-        total = sum(arr.shape[0] for _, arr in fields)
-        self._ensure_prefill_staging(total)
-        pinned_np = self._prefill_staging_pinned.numpy()
-        off = 0
-        for _, arr in fields:
-            n = arr.shape[0]
-            pinned_np[off : off + n] = arr
-            off += n
-        self._prefill_staging_gpu[:total].copy_(
-            self._prefill_staging_pinned[:total], non_blocking=True
+        # ----- H2D: 4 indptrs + 2 per-seq scalars -----
+        # All non-blocking; bounded by `total ≤ T*max_per_tok`.
+        chunk_start_per_seq_gpu = torch.from_numpy(chunk_start_per_seq_np).to(
+            device, non_blocking=True
         )
-        g = self._prefill_staging_gpu
-        off = 0
-        for name, arr in fields:
-            n = arr.shape[0]
-            setattr(attn_metadata, name, g[off : off + n])
-            off += n
+        n_committed_hca_per_seq_gpu = torch.from_numpy(
+            np.asarray(n_committed_hca_per_seq_np[:scheduled_bs], dtype=np.int32)
+        ).to(device, non_blocking=True)
+        ext_indptr = torch.from_numpy(ext_indptr_np).to(device, non_blocking=True)
+        swa_indptr = torch.from_numpy(swa_indptr_np).to(device, non_blocking=True)
+        csa_indptr = torch.from_numpy(csa_indptr_np).to(device, non_blocking=True)
+        hca_indptr = torch.from_numpy(hca_indptr_np).to(device, non_blocking=True)
+
+        # Reuse already-on-GPU tensors (populated upstream).
+        # Cast positions to int32: production var["positions"] is int64 but
+        # the kernel was designed/tested against int32 (downstream paged
+        # offsets stored in int32 buffers; int32 throughout avoids mixed-
+        # dtype Triton arithmetic that can silently truncate).
+        positions_gpu = var["positions"].gpu[:T].to(torch.int32)
+        cu_q_per_seq_gpu = var["cu_seqlens_q"].gpu[:scheduled_bs]
+        state_slot_per_seq_gpu = attn_metadata.state_slot_mapping[:scheduled_bs]
+        block_tables_gpu = var["block_tables"].gpu[:scheduled_bs]
+        # batch_id_per_token is int64 in storage (PyTorch fancy-index
+        # compatibility upstream); kernel uses tl.load which is dtype-agnostic
+        # but cast for safety + consistency.
+        bid_per_token_gpu = attn_metadata.batch_id_per_token[:T].to(torch.int32)
+
+        # ----- Allocate output buffers (exact sizes known from CPU totals) -----
+        ext_indices = torch.empty(max(ext_total, 1), dtype=torch.int32, device=device)
+        swa_indices = torch.empty(max(swa_total, 1), dtype=torch.int32, device=device)
+        csa_indices = torch.empty(max(csa_total, 1), dtype=torch.int32, device=device)
+        hca_indices = torch.empty(max(hca_total, 1), dtype=torch.int32, device=device)
+        # NB: no `csa_indices.fill_(-1)` — per-token CSA reservation now
+        # matches Indexer visibility exactly (csa_valid_k_per_token), so
+        # csa_translate_pack writes every reserved cell.
+
+        # ----- Single Triton kernel: scatter SWA-prefix / extend / HCA-compress -----
+        write_v4_paged_prefill_indices(
+            positions=positions_gpu,
+            bid_per_token=bid_per_token_gpu,
+            chunk_start_per_seq=chunk_start_per_seq_gpu,
+            cu_seqlens_q_per_seq=cu_q_per_seq_gpu,
+            state_slot_per_seq=state_slot_per_seq_gpu,
+            n_committed_hca_per_seq=n_committed_hca_per_seq_gpu,
+            block_tables=block_tables_gpu,
+            extend_indptr=ext_indptr,
+            prefix_swa_indptr=swa_indptr,
+            prefix_csa_indptr=csa_indptr,
+            prefix_hca_indptr=hca_indptr,
+            extend_indices=ext_indices,
+            prefix_swa_indices=swa_indices,
+            prefix_csa_indices=csa_indices,
+            prefix_hca_indices=hca_indices,
+            T=T,
+            win=win,
+            cs=cs,
+            swa_pages=swa_pages,
+        )
+
+        # ----- skip_prefix_len_csa: per-token CSA section write offset -----
+        # csa_translate_pack consumes this as offset within
+        # `kv_indices_prefix_csa[indptr[t]:indptr[t+1]]` where the CSA topk
+        # section starts (after the SWA prefix segment). Matches the per-token
+        # prefix_swa_count vector we just computed on CPU.
+        skip_csa_gpu = torch.from_numpy(prefix_swa_count_np).to(
+            device, non_blocking=True
+        )
+
+        # ----- Publish on attn_metadata -----
+        attn_metadata.kv_indices_extend = ext_indices[:ext_total]
+        attn_metadata.kv_indptr_extend = ext_indptr
+        attn_metadata.kv_indices_prefix_swa = swa_indices[:swa_total]
+        attn_metadata.kv_indptr_prefix_swa = swa_indptr
+        attn_metadata.kv_indices_prefix_csa = csa_indices[:csa_total]
+        attn_metadata.kv_indptr_prefix_csa = csa_indptr
+        attn_metadata.kv_indices_prefix_hca = hca_indices[:hca_total]
+        attn_metadata.kv_indptr_prefix_hca = hca_indptr
+        attn_metadata.skip_prefix_len_csa = skip_csa_gpu
         attn_metadata.swa_pages = swa_pages
 
     def _build_compress_plans(
@@ -2352,19 +2283,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
         buf.np[:n] = arr
         return buf.copy_to_gpu(n)
-
-    def _ensure_prefill_staging(self, n: int) -> None:
-        """Grow the pinned + GPU staging buffer pair to hold at least `n` int32 elements."""
-        if self._prefill_staging_cap >= n:
-            return
-        new_cap = max(n, self._prefill_staging_cap * 2, 1 << 20)
-        self._prefill_staging_pinned = torch.empty(
-            new_cap, dtype=torch.int32, pin_memory=True
-        )
-        self._prefill_staging_gpu = torch.empty(
-            new_cap, dtype=torch.int32, device=self.device
-        )
-        self._prefill_staging_cap = new_cap
 
     @staticmethod
     def _numel(shape: tuple) -> int:

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -128,6 +128,12 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     read int64 fine. Padded tail [T:padded_T] = -1 sentinel; consumer
     kernels skip on `bid < 0`. All other per-token quantities resolved as
     `per_seq_data[batch_id_per_token[t]]` — no [T] aliases of seq data."""
+    batch_id_per_token_cpu: Optional[Any] = None
+    """[T] int64 — CPU mirror of the unpadded batch_id slice. Built once in
+    `_attach_v4_per_fwd_meta` (host-side `np.repeat`); reused by
+    `_attach_v4_paged_decode_meta` for indptr fancy-index math. Avoids a
+    duplicate `np.repeat` per fwd. None for prefill paths that don't go
+    through paged_decode_meta (it's only consumed there)."""
     swa_write_indices: Optional[torch.Tensor] = None
     """[W] int64 GPU — src row id into per-fwd KV for swa_write.
     `[0:num_write]` = real (last `win` tokens per seq); trailing entries
@@ -843,6 +849,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
           - `attn_metadata.batch_id_per_token`        [padded_T] int64
           - `attn_metadata.n_committed_csa_per_seq`   [bs] int32
 
+        DECODE fast path: returns a minimal dict with only
+        `n_committed_per_seq_gpu` (the single field `_score_topk_decode`
+        reads). The cumsum + H2D + per-token GPU derivations below are all
+        prefill-only — `deepgemm_fp8_paged_mqa_logits` + `top_k_per_row_decode`
+        operate directly on paged KV via `n_committed_per_seq_gpu`, never on
+        the packed-cumsum / per-token `cu_starts/cu_ends` layout.
+
         The FP8 indexer K-cache write happens inside `fused_compress_attn`
         (the unified Indexer-inner Compressor path) via the same block_tables
         that CSA Main uses; no separate slot_mapping is built here.
@@ -852,6 +865,20 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # invariants as `_attach_v4_per_fwd_meta` — guaranteed by every
         # prepare_*/CG-capture path).
         bs = scheduled_bs
+
+        # DECODE short-circuit: the only field `_score_topk_decode` consumes is
+        # `n_committed_per_seq_gpu`, which is the same tensor as
+        # `attn_metadata.n_committed_csa_per_seq` (already staged by
+        # `_attach_v4_per_fwd_meta`). The prefill-only derivations below
+        # (CPU cumsum + H2D for `cu_committed_gpu`; 7 GPU launches for
+        # `seq_base`/`visible_end`/`cu_ends`) feed `_score_topk_prefill` only
+        # (cp_gather + fp8_mqa_logits + per-row prefill top-k), so they are
+        # dead work on the decode hot path. ~50μs / fwd saved at bs=1024.
+        if attn_metadata.state is AttnState.DECODE:
+            return {
+                "n_committed_per_seq_gpu": attn_metadata.n_committed_csa_per_seq,
+            }
+
         ratio = 4  # CSA — also referenced by `visible_end_gpu` below
         n_committed_per_seq = attn_metadata.n_committed_csa_per_seq_cpu[:bs]
         cu_committed_cpu = np.concatenate(
@@ -1138,7 +1165,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         padded_bs = int(bs)
         self._attach_v4_per_fwd_meta(
             attn_metadata,
-            cu_seqlens_q_np,
             extend_lens_np,  # = np.full(scheduled_bs, max_seqlen_q) for decode
             state_slot_np,
             scheduled_bs,
@@ -1218,7 +1244,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # reuse the shared GPU tensors (batch_id_per_token, n_committed_csa).
         self._attach_v4_per_fwd_meta(
             attn_metadata,
-            cu_seqlens_q_np,
             extend_lens_np,  # = cu_seqlens_q[1:] - cu_seqlens_q[:bs]
             attn_metadata.state_slot_mapping_cpu,
             scheduled_bs,
@@ -1313,7 +1338,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
             self._attach_v4_per_fwd_meta(
                 ub_attn,
-                ub_cu,
                 extend_lens_np,  # ubatch's per-seq token counts
                 ub_attn.state_slot_mapping_cpu,
                 ub_num_reqs,
@@ -1365,7 +1389,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
     def _attach_v4_per_fwd_meta(
         self,
         attn_metadata: AttentionMetaData_DSV4,
-        cu_seqlens_q_np,
         token_num_per_seq,
         state_slot_mapping_cpu,
         scheduled_bs: int,
@@ -1397,15 +1420,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         (model_runner.warmup_model:1003-1011, _populate_state_slot_mapping
         zeros-fill); CG capture uses graph_bs >= 1 too.
         """
-        win = self.window_size
-
-        # cu_seqlens_q_arr still needed for write_starts/write_ends below;
-        # token_num_per_seq is now passed in by caller (== batch.num_scheduled_tokens
-        # for prepare_decode/prefill, np.ones for MTP draft, etc.) — no longer
-        # re-derived from cu_seqlens_q here.
-        cu_seqlens_q_arr = np.asarray(
-            cu_seqlens_q_np[: scheduled_bs + 1], dtype=np.int32
-        )
         # state is set by the caller at AttentionMetaData_DSV4 construction
         # time (single source of truth — prepare_decode / prepare_prefill /
         # prepare_mtp_decode / build_for_cudagraph_capture each set it).
@@ -1431,10 +1445,17 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         var = self.model_runner.forward_vars
 
         # ---- CPU numpy work (all on main thread) ----
-        batch_id_per_token_np = np.full(padded_total_tokens, -1, dtype=np.int64)
-        batch_id_per_token_np[:total_tokens] = np.repeat(
+        # Build the unpadded mapping once; the padded GPU staging buffer wraps
+        # it (head = real, tail = -1 sentinel). Stash the unpadded slice on
+        # attn_metadata so `_attach_v4_paged_decode_meta` reuses it instead of
+        # re-running `np.repeat(arange, token_num_per_seq)` (saves ~10μs/fwd
+        # at bs=1024 + one allocation).
+        batch_id_unpadded_np = np.repeat(
             np.arange(scheduled_bs, dtype=np.int64), token_num_per_seq
         )
+        batch_id_per_token_np = np.full(padded_total_tokens, -1, dtype=np.int64)
+        batch_id_per_token_np[:total_tokens] = batch_id_unpadded_np
+        attn_metadata.batch_id_per_token_cpu = batch_id_unpadded_np
 
         # context_lens is int32 on the buffer; keep dtype through divide so
         # n_committed_{csa,hca} stay int32 (max value ~max_model_len // 4 ≪ 2^31).
@@ -1553,11 +1574,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         # ----- Per-seq scalars (CPU numpy) -----
         # The single per-token mapping. Built once in `_attach_v4_per_fwd_meta`
-        # (so swa_write / indexer can also consume it). Pull the GPU view from
-        # attn_metadata; recompute the np copy here only for cumsum math below.
-        batch_id_per_token_np = np.repeat(
-            np.arange(scheduled_bs, dtype=np.int32), token_num_per_seq
-        )  # [T] int32 — host copy for indptr cumsums
+        # — both the GPU staging tensor and the unpadded CPU mirror — so we
+        # just borrow both here. int64 (numpy fancy-index source dtype is
+        # irrelevant; consumers below produce int32 outputs).
+        batch_id_per_token_np = attn_metadata.batch_id_per_token_cpu  # [T] int64
         batch_id_per_token_gpu = attn_metadata.batch_id_per_token
 
         # Read pre-computed `ctx // {4,128}` from attn_metadata — populated by
@@ -1684,15 +1704,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             cs=cs,
         )
 
-        # ----- skip_prefix_len_csa: per-token actual SWA-prefix length -----
-        # csa_translate_pack consumes this as the offset within each token's
-        # `kv_indices_csa` region where the CSA topk section starts (after
-        # the SWA prefix segment). Decode + prefill now share this semantics
-        # (was `win` in decode, `prefix_swa_count[t]` in prefill).
-        skip_csa_buf = var["v4_skip_prefix_len_csa"]
-        skip_csa_buf.np[:T] = actual_swa_count_np
-        skip_csa_buf.np[T:T_pad].fill(0)
-        skip_csa_gpu = skip_csa_buf.copy_to_gpu(T_pad)
+        # `skip_prefix_len_csa` is no longer materialized on the decode path —
+        # `csa_translate_pack` is invoked with `window_size = self.window_size`
+        # so the kernel derives `skip = min(positions[t]+1, win)` inline,
+        # which is identical to the value we used to write here
+        # (`actual_swa_count_np`). Saves a CPU write + H2D per fwd. The
+        # `v4_skip_prefix_len_csa` forward_var is retained for the (unrelated)
+        # prefill path where skip depends on `chunk_start` and cannot be
+        # derived from positions alone.
 
         # ----- Stash on attn_metadata for V4Attention.forward consumption -----
         # batch_id_per_token + n_committed_csa_per_seq already set in
@@ -1707,7 +1726,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         attn_metadata.kv_indptr_swa = swa_indptr_gpu
         attn_metadata.kv_indptr_csa = csa_indptr_gpu
         attn_metadata.kv_indptr_hca = hca_indptr_gpu
-        attn_metadata.skip_prefix_len_csa = skip_csa_gpu
         attn_metadata.swa_pages = swa_pages
 
     def _build_paged_prefill_meta(
@@ -2101,7 +2119,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # builder can reuse the shared per-fwd GPU tensors.
         self._attach_v4_per_fwd_meta(
             attn_metadata,
-            cu_seqlens_q_np,
             extend_lens_np,  # = np.full(bs, max_q_len) — synthetic uniform decode batch
             attn_metadata.state_slot_mapping_cpu,
             bs,

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -336,20 +336,28 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
 
         # Compressor state shape: [ring_size, coff * head_dim], fp32.
-        # ring_size = K_pool + (max_spec_steps + 1), where K_pool = coff * ratio.
-        # The extra (max_spec_steps + 1) slots prevent reject K/V written to the
-        # ring in round R from being borrow-read by the round-R+1 re-commit of
-        # the same boundary (slot index = pos % ring_size). With ring_size =
-        # K_pool the slot of pos P+K_pool aliases the slot of pos P, so a
-        # rejected K_{P+K_pool} written in R overwrites the K_P that R+1's
-        # commit pool window [P..P+K_pool-1] still needs. Bumping by one
-        # verify window's worth of positions decouples the two.
-        # CSA: ratio=4, overlap=True  → K_pool=8;  spec ring_size=8 + (mtp_k+1)
-        # HCA: ratio=128, overlap=False → K_pool=128; spec ring_size=128+(mtp_k+1)
-        # Non-spec (max_spec_steps=0) → ring_size = K_pool + 1 (effectively
-        # equivalent to old K_pool layout for correctness; one extra slot is
-        # the algebraic minimum and trivial in memory).
-        ring_extra = self.max_spec_steps + 1
+        # ring_size = K_pool + max_spec_steps, where K_pool = coff * ratio.
+        #
+        # Per spec round we write up to (1 + max_spec_steps) consecutive token
+        # positions; if some draft tokens are rejected, round R+1 re-commits
+        # those slots starting from a later offset. The aliasing concern is:
+        # at round R+1, while we read the K_pool committed entries that R+1's
+        # attention needs, can a position R already wrote (and we'd be about
+        # to overwrite) collide with one of those reads?
+        #
+        # Slot index = (compressed_K_id) % ring_size, where
+        # compressed_K_id = pos // ratio. Round R+1 reads
+        # `K_pool` consecutive ids ending at its own commit head; round R's
+        # rejected writes sit `<= max_spec_steps` ids beyond that head. With
+        # `ring_size = K_pool + max_spec_steps`, R's stale ids are guaranteed
+        # to fall outside R+1's K_pool-wide read window — no collision.
+        # Adding a further +1 (the old layout) was unnecessary slack.
+        # CSA: ratio=4, overlap=True  → K_pool=8;  ring_size=8 + mtp_k
+        # HCA: ratio=128, overlap=False → K_pool=128; ring_size=128 + mtp_k
+        # Non-spec (max_spec_steps=0) → ring_size = K_pool: no rejections ever
+        # happen, so the bare commit pool is sufficient (causal writes mean
+        # the alias slot is never read before being overwritten).
+        ring_extra = self.max_spec_steps
         self.csa_main_state_shape = (2 * 4 + ring_extra, 2 * self.head_dim)
         self.csa_idx_state_shape = (2 * 4 + ring_extra, 2 * self.index_head_dim)
         self.hca_main_state_shape = (128 + ring_extra, self.head_dim)

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -134,17 +134,6 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     `_attach_v4_paged_decode_meta` for indptr fancy-index math. Avoids a
     duplicate `np.repeat` per fwd. None for prefill paths that don't go
     through paged_decode_meta (it's only consumed there)."""
-    swa_write_indices: Optional[torch.Tensor] = None
-    """[W] int64 GPU — src row id into per-fwd KV for swa_write.
-    `[0:num_write]` = real (last `win` tokens per seq); trailing entries
-    `[num_write:W]` = -1 sentinel (only present on decode/MTP CG paths
-    where `W = padded_bs * (1 + max_spec_steps)`; prefill is eager and
-    uses `W = num_write` exactly, no padding). `None` for warmup / empty fwd.
-
-    NOTE: kept only for the aiter `fused_qk_norm_rope_swa_write` path
-    (num_tokens <= 64). Standalone `swa_write` (num_tokens > 64) now derives
-    `src_id` from `cu_seqlens_q` + `token_num_per_seq` directly inside the
-    kernel — eliminates the DMA-tear race on this shared GPU buffer."""
     compress_plans: Optional[Dict[int, Any]] = None
     """dict[ratio:int -> CompressPlan] — packed plan tensors per
     compress_ratio (4=CSA, 128=HCA)."""

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -127,7 +127,12 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     `[0:num_write]` = real (last `win` tokens per seq); trailing entries
     `[num_write:W]` = -1 sentinel (only present on decode/MTP CG paths
     where `W = padded_bs * (1 + max_spec_steps)`; prefill is eager and
-    uses `W = num_write` exactly, no padding). `None` for warmup / empty fwd."""
+    uses `W = num_write` exactly, no padding). `None` for warmup / empty fwd.
+
+    NOTE: kept only for the aiter `fused_qk_norm_rope_swa_write` path
+    (num_tokens <= 64). Standalone `swa_write` (num_tokens > 64) now derives
+    `src_id` from `cu_seqlens_q` + `token_num_per_seq` directly inside the
+    kernel — eliminates the DMA-tear race on this shared GPU buffer."""
     compress_plans: Optional[Dict[int, Any]] = None
     """dict[ratio:int -> CompressPlan] — packed plan tensors per
     compress_ratio (4=CSA, 128=HCA)."""
@@ -1333,8 +1338,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             ub_attn.batch_id_per_token = ub_attn.batch_id_per_token.clone()
         if ub_attn.n_committed_csa_per_seq is not None:
             ub_attn.n_committed_csa_per_seq = ub_attn.n_committed_csa_per_seq.clone()
-        if ub_attn.swa_write_indices is not None:
-            ub_attn.swa_write_indices = ub_attn.swa_write_indices.clone()
         if ub_attn.indexer_meta is not None:
             im = ub_attn.indexer_meta
             if im.get("cu_committed_gpu") is not None:
@@ -1365,17 +1368,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         them once per fwd saves ~64 redundant constructions for V4-Pro.
 
         Sets:
-          - `attn_metadata.swa_write_indices`: [W] int64 row ids into
-            per-token KV. Real entries are the last `win` tokens per seq.
-            For decode/MTP (CG-captured): `W = padded_bs * (1 + max_spec_steps)`,
-            trailing entries `[num_write:W]` get -1 sentinel so the fixed
-            grid is CUDAGraph-safe. For prefill (eager, no CG):
-            `W = num_write` exactly — no padding, no wasted grid programs
-            (long-prefill chunks would otherwise launch up to ~64× more
-            programs that all bail on `src_id < 0`).
           - `attn_metadata.batch_id_per_token`: [padded_T] int32 batch id
-            per token (single per-token mapping; consumed by `swa_write`,
-            Phase B/C/E paged-decode kernels, and the indexer).
+            per token (single per-token mapping; consumed by the Phase B/C/E
+            paged-decode kernels and the indexer). `swa_write` no longer
+            depends on this — it derives `src_id` from `cu_seqlens_q` inline.
           - `attn_metadata.n_committed_csa_per_seq`: [bs] int32 per-seq
             `ctx_len // 4` (shared by csa_translate_pack + indexer; kernels
             do their own `min(., index_topk)` clamp via mask).
@@ -1401,17 +1397,17 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # construction time (single source of truth — prepare_decode /
         # prepare_prefill / build_for_cudagraph_capture each know their
         # own semantics). Consumed for: padded_total_tokens (CG bucket vs
-        # eager-tight), arange shortcut (write_indices), SWA grid bucketing,
-        # and by `_attach_v4_paged_decode_meta` for the index-buffer skip.
+        # eager-tight) and by `_attach_v4_paged_decode_meta` for the
+        # index-buffer skip.
         is_pure_decode = attn_metadata.is_pure_decode
 
         # padded_total_tokens: CG-captured decode/MTP pads to the fixed
-        # bucket `padded_bs * (1+max_spec_steps)` so per-token buffers
-        # (batch_id_per_token, swa_write_indices) have a stable shape across
-        # captures. Non-pure-decode (prefill / mixed / fresh-prefill) is
-        # eager and uses `total_tokens` exactly — no wasted padding (a long
-        # prefill chunk doesn't need to be padded up to a bucket that
-        # doesn't exist for it).
+        # bucket `padded_bs * (1+max_spec_steps)` so the per-token
+        # `batch_id_per_token` buffer has a stable shape across captures.
+        # Non-pure-decode (prefill / mixed / fresh-prefill) is eager and
+        # uses `total_tokens` exactly — no wasted padding (a long prefill
+        # chunk doesn't need to be padded up to a bucket that doesn't
+        # exist for it).
         if is_pure_decode:
             assert padded_bs is not None and max_q_len is not None, (
                 "is_pure_decode requires padded_bs + max_q_len from caller "
@@ -1439,33 +1435,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         n_committed_hca_per_seq_np = ctx_per_seq_np // 128
         attn_metadata.n_committed_csa_per_seq_cpu = n_committed_csa_per_seq_np
         attn_metadata.n_committed_hca_per_seq_cpu = n_committed_hca_per_seq_np
-
-        # Build write_indices for the SWA-write kernel.
-        # is_pure_decode ⇒ source is `self._swa_iota` (static GPU tensor) +
-        #   GPU fill_(-1) tail. No CPU numpy needed; `num_write = total_tokens`,
-        #   `swa_write_grid = padded_total_tokens` (CG bucket).
-        # else ⇒ per-seq concat tail (filter `last win tokens per seq`).
-        #   Built as a fresh local numpy (NOT into the shared pinned
-        #   `wi_buf.np`, which would race with the next fwd's rewrite during
-        #   in-flight DMA). `swa_write_grid = num_write` (tight, no padding —
-        #   prefill is eager).
-        if is_pure_decode:
-            write_indices_np = None
-            num_write = total_tokens
-            swa_write_grid = padded_total_tokens
-        else:
-            write_starts = cu_seqlens_q_arr[:scheduled_bs] + np.maximum(
-                0, token_num_per_seq - win
-            )
-            write_ends = cu_seqlens_q_arr[1:]
-            write_indices_np = np.concatenate(
-                [
-                    np.arange(s, e, dtype=np.int64)
-                    for s, e in zip(write_starts, write_ends)
-                ]
-            )
-            num_write = int(write_indices_np.shape[0])
-            swa_write_grid = num_write
 
         # ---- Stage all buffers to GPU ----
         # window_topk used to be CPU-built here ([T, win] of ring indices with
@@ -1496,29 +1465,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.n_committed_csa_per_seq = n_csa_buf.copy_to_gpu(padded_bs)
         else:
             attn_metadata.n_committed_csa_per_seq = n_csa_buf.copy_to_gpu(scheduled_bs)
-        # Race-free write into the shared `v4_meta_swa_write_indices` GPU
-        # buffer (stable pointer → CG-capture-safe). Bypasses `_stage`
-        # because `_stage`'s `buf.np[:n] = arr; copy_to_gpu(non_blocking=True)`
-        # pattern uses the shared pinned alias as the H2D source — the next
-        # fwd's CPU rewrite of `buf.np` can land mid-DMA and tear the GPU
-        # contents, producing torn `src_id` values that exceed `kv.shape[0]`
-        # and MEMORY_VIOLATION the `tl.load(kv_ptr + src_id * ...)` in
-        # `_swa_write_kernel`.
-        wi_gpu = var["v4_meta_swa_write_indices"].gpu
-        assert swa_write_grid <= wi_gpu.shape[0], (
-            f"v4_meta_swa_write_indices too small: need {swa_write_grid}, "
-            f"have {wi_gpu.shape[0]}"
-        )
-        if is_pure_decode:
-            if num_write > 0:
-                wi_gpu[:num_write].copy_(self._swa_iota[:num_write])
-            if num_write < swa_write_grid:
-                wi_gpu[num_write:swa_write_grid].fill_(-1)
-        elif num_write > 0:
-            wi_buf = var["v4_meta_swa_write_indices"]
-            wi_buf.np[:num_write] = write_indices_np
-            wi_gpu[:num_write].copy_(wi_buf.cpu[:num_write], non_blocking=True)
-        attn_metadata.swa_write_indices = wi_gpu[:swa_write_grid]
 
         self._attach_v4_paged_decode_meta(
             attn_metadata=attn_metadata,
@@ -2250,18 +2196,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # exposes that GPU view to all downstream consumers (no second
         # H2D-staged copy).
         bufs["v4_meta_state_slot_groups"] = CpuGpuBuffer(bs, **i32)
-        # swa_write_indices: tight bound = `max_bs * window_size`. Universal
-        # worst-case across paths — prefill compact write is `sum(min(num_i,
-        # win)) ≤ bs * win`; decode/MTP CG is `bs * (1+max_spec_steps) ≤
-        # bs * win` (since `1+max_spec_steps ≪ win`). Legacy `mnbt` sizing
-        # was over-padded to the prefill total-token worst case.
-        bufs["v4_meta_swa_write_indices"] = CpuGpuBuffer(bs * win, **i64)
-        # Static GPU iota used by `_attach_v4_per_fwd_meta` for the
-        # is_pure_decode arange shortcut. Pre-allocated once so the per-fwd
-        # write into `v4_meta_swa_write_indices` is a pure GPU-to-GPU copy
-        # (no CPU intermediate → no pinned-buffer H2D race) and the source
-        # pointer stays stable for CUDAGraph capture.
-        self._swa_iota = torch.arange(bs * win, dtype=torch.int64, device=self.device)
 
         # Phase B: paged-decode index buffers (consumed by Phase C/E).
         # Sized to worst-case decode shape `T = max_bs * (1 + max_spec_steps)`

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1875,14 +1875,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # the kernel was designed/tested against int32 (downstream paged
         # offsets stored in int32 buffers; int32 throughout avoids mixed-
         # dtype Triton arithmetic that can silently truncate).
-        positions_gpu = var["positions"].gpu[:T].to(torch.int32)
+        positions_gpu = var["positions"].gpu[:T]
         cu_q_per_seq_gpu = var["cu_seqlens_q"].gpu[:scheduled_bs]
         state_slot_per_seq_gpu = attn_metadata.state_slot_mapping[:scheduled_bs]
         block_tables_gpu = var["block_tables"].gpu[:scheduled_bs]
         # batch_id_per_token is int64 in storage (PyTorch fancy-index
         # compatibility upstream); kernel uses tl.load which is dtype-agnostic
         # but cast for safety + consistency.
-        bid_per_token_gpu = attn_metadata.batch_id_per_token[:T].to(torch.int32)
+        bid_per_token_gpu = attn_metadata.batch_id_per_token[:T]
 
         # ----- Allocate output buffers (exact sizes known from CPU totals) -----
         ext_indices = torch.empty(max(ext_total, 1), dtype=torch.int32, device=device)
@@ -2262,8 +2262,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         self._decode_compress_cap: dict[int, int] = {}
         for ratio, is_overlap in self._unique_compress_ratios_overlap:
             # NOTE: this is the pool-window size (algorithm constant), NOT the
-            # state ring buffer size. The ring buffer is now K_pool + max_spec_steps + 1
-            # to avoid R+1 re-commit borrow-reads (see csa_main_state_shape comment),
+            # state ring buffer size. The ring buffer is K_pool + max_spec_steps
+            # (see csa_main_state_shape comment for the slot-aliasing argument),
             # but write_plan still emits ≤ K_pool rows per seq per fwd because
             # `write_starts = max(0, context_lens - K_pool)` in make_compress_plans.
             K_pool = (2 if is_overlap else 1) * ratio

--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -526,6 +526,7 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
         bs: int,
         max_seqlen_q: int,
         max_seqlen_k: int,
+        positions: torch.Tensor,  # [total_tokens] int32
         only_update: bool = False,
         num_reject_tokens=None,
     ):

--- a/atom/model_ops/v4_kernels/__init__.py
+++ b/atom/model_ops/v4_kernels/__init__.py
@@ -35,6 +35,10 @@ from atom.model_ops.v4_kernels.paged_decode_indices import (
     write_v4_paged_decode_indices,
     write_v4_paged_decode_indices_reference,
 )
+from atom.model_ops.v4_kernels.paged_prefill_indices import (
+    write_v4_paged_prefill_indices,
+    write_v4_paged_prefill_indices_reference,
+)
 from atom.model_ops.v4_kernels.state_writes import update_compressor_states, swa_write
 
 __all__ = [
@@ -54,4 +58,6 @@ __all__ = [
     "scale_indexer_weights",
     "write_v4_paged_decode_indices",
     "write_v4_paged_decode_indices_reference",
+    "write_v4_paged_prefill_indices",
+    "write_v4_paged_prefill_indices_reference",
 ]

--- a/atom/model_ops/v4_kernels/compress_plan.py
+++ b/atom/model_ops/v4_kernels/compress_plan.py
@@ -10,15 +10,19 @@ Each plan slot is a 16-byte struct of 4 int32 fields:
   - batch_id:   sequence index (→ state_slot_mapping[batch_id], block_table[batch_id])
   - position:   absolute token position (→ RoPE)
   - window_len: number of leading K-loop iterations that read from state cache
-                instead of the ragged input. K = STATE_SIZE = (1+overlap)*ratio.
+                instead of the ragged input. K = K_pool = (1+overlap)*ratio
+                (pool window size — the algorithm constant; distinct from
+                STATE_SIZE = K_pool + max_spec_steps which is just the ring
+                modulus widened by spec slack).
 
 Two plan tensors are produced per `compress_ratio`:
   - compress_plan: rows for tokens whose `(position+1) % ratio == 0`
                    (= compression boundaries). One row per fused-compress kernel
                    program. Grid = `num_compress`.
   - write_plan:    rows for tokens whose `position` falls in the per-seq
-                   "last STATE_SIZE positions" window. One row per
-                   `update_compressor_states` kernel program. Grid = `num_write`.
+                   "last K_pool positions" window (the only entries the
+                   downstream compressor forward will actually read). One row
+                   per `update_compressor_states` kernel program. Grid = `num_write`.
 
 Caller (per-seq loop) gets `cu_compress_cpu` for slicing the kernel's flat
 output `[num_compress, head_dim]` back to per-seq chunks.

--- a/atom/model_ops/v4_kernels/csa_translate_pack.py
+++ b/atom/model_ops/v4_kernels/csa_translate_pack.py
@@ -47,7 +47,8 @@ import triton.language as tl
 def _csa_translate_pack_kernel(
     topk_local_ptr,  # [T, index_topk] int32 — indexer raw output
     block_tables_ptr,  # [bs, mnbps] int32 — page table
-    n_committed_csa_per_seq_ptr,  # [bs] int32 — per-seq valid count
+    n_committed_csa_per_seq_ptr,  # [bs] int32 — RAW per-seq committed count
+    positions_ptr,  # [T] int — global token positions
     kv_indptr_csa_ptr,  # [T+1] int32 — packed cumsum (per-token)
     batch_id_per_token_ptr,  # [T] int32 — token → seq, sentinel -1
     skip_prefix_len_per_token_ptr,  # [T] int32 — per-token write offset
@@ -56,6 +57,7 @@ def _csa_translate_pack_kernel(
     mnbps,  # i32 — max blocks per seq, runtime int
     index_topk: tl.constexpr,
     csa_block_capacity: tl.constexpr,
+    ratio: tl.constexpr,  # = 4 for CSA (compress ratio used for visibility)
     BLOCK_K: tl.constexpr,
 ):
     pid_t = tl.program_id(0)
@@ -67,10 +69,19 @@ def _csa_translate_pack_kernel(
     if bid < 0:
         return
 
-    valid_k = tl.load(n_committed_csa_per_seq_ptr + bid)
+    # Per-token valid_k = Indexer's per-row visibility = the count of
+    # valid (>=0) topk_local cells per row. Matches the formula in
+    # `_attach_v4_indexer_meta`. The n_csa_seq clamp is defensive — V4
+    # prepare_* paths enforce `pos < ctx_total` so it usually matches
+    # `(pos+1)//ratio`, but keeping the explicit clamp tracks Indexer's
+    # `visible_end` exactly and protects against edge cases in CG-warmup /
+    # MTP-verify rollback paths where positions and ctx may drift slightly.
+    pos = tl.load(positions_ptr + pid_t)
+    n_csa_seq = tl.load(n_committed_csa_per_seq_ptr + bid)
+    valid_k = tl.minimum(tl.minimum((pos + 1) // ratio, n_csa_seq), index_topk)
 
     k_offs = pid_kb * BLOCK_K + tl.arange(0, BLOCK_K)
-    in_range = (k_offs < valid_k) & (k_offs < index_topk)
+    in_range = k_offs < valid_k
 
     topk = tl.load(
         topk_local_ptr + pid_t * index_topk + k_offs,
@@ -109,6 +120,7 @@ def csa_translate_pack(
     topk_local: torch.Tensor,
     block_tables: torch.Tensor,
     n_committed_csa_per_seq: torch.Tensor,
+    positions: torch.Tensor,
     kv_indptr_csa: torch.Tensor,
     batch_id_per_token: torch.Tensor,
     skip_prefix_len_per_token: torch.Tensor,
@@ -116,23 +128,30 @@ def csa_translate_pack(
     *,
     swa_pages: int,
     csa_block_capacity: int,
+    ratio: int = 4,
 ) -> None:
     """Fused topk translate + packed write into `kv_indices_csa` (in-place).
 
+    The kernel computes per-token CSA `valid_k` inline as
+    ``min((positions[t]+1)//ratio, n_committed_csa[bid], index_topk)``,
+    matching Indexer's per-row visibility (cu_ends - cu_starts in
+    ``_attach_v4_indexer_meta``). Caller's CSA indptr MUST reserve exactly
+    this many cells per token — then csa_translate_pack writes every
+    reserved cell and no `-1` sentinel pre-fill is needed.
+
     Args:
       topk_local:                  [T, index_topk] int32 — indexer's seq-local
-                                   row indices; tails may carry -1 sentinels
-                                   (kernel-native; we skip writes on those).
+                                   row indices. Leading `valid_k[t]` cells are
+                                   always >= 0 (Indexer filled them); trailing
+                                   cells are -1 but never read because
+                                   `k_offs < valid_k` filters them out.
       block_tables:                [bs, mnbps] int32 — logical block → physical.
       n_committed_csa_per_seq:     [bs] int32 — RAW per-seq committed count
-                                   (`ctx_len // 4`). The kernel clamps
-                                   internally via
-                                   `(k < valid_k) & (k < index_topk)` mask;
-                                   callers MUST pass the raw value (NOT
-                                   pre-clamped to index_topk), since the
-                                   indexer also reads this same buffer and
-                                   needs the raw count. Indexed by
-                                   `batch_id_per_token[t]`.
+                                   (`ctx_len // ratio`); clamps per-token
+                                   `valid_k` to seq-level (defensive).
+      positions:                   [T] int — global token positions; combined
+                                   with `n_committed_csa_per_seq` and
+                                   `index_topk` to derive per-token valid_k.
       kv_indptr_csa:               [T+1] int32 — per-token packed cumsum
                                    (CG-padded: tail repeats last value
                                    → kv_len=0).
@@ -140,19 +159,22 @@ def csa_translate_pack(
                                    CG-padded slots.
       skip_prefix_len_per_token:   [T] int32 — per-token write offset within
                                    `kv_indices_csa[indptr[t] : indptr[t+1]]`
-                                   the CSA section starts at. Decode passes
+                                   where the CSA section starts. Decode passes
                                    `[window_size, ...]` (full SWA prefix);
                                    pure prefill passes 0; chunked prefill
                                    passes `prior_swa_count_per_token`.
       kv_indices_csa:              [total_indices] int32 — destination buffer;
                                    this kernel writes the CSA section
                                    `[indptr[t]+skip[t],
-                                     indptr[t]+skip[t]+min(valid_k, index_topk))`.
+                                     indptr[t]+skip[t]+valid_k[t])`.
       swa_pages:                   SWA region size — `num_slots * window_size`,
                                    fixed at CG capture time. Keyword-only.
       csa_block_capacity:          `block_size // ratio = 128 // 4 = 32`
                                    (constexpr; triton can strength-reduce
                                    // and %). Keyword-only.
+      ratio:                       Compression ratio (= 4 for CSA). Used in
+                                   the per-token visibility formula
+                                   `(positions[t]+1)//ratio`. Keyword-only.
     """
     T, index_topk = topk_local.shape
     if T == 0:
@@ -169,6 +191,8 @@ def csa_translate_pack(
             "skip_prefix_len_per_token.numel()="
             f"{skip_prefix_len_per_token.numel()} < T={T}"
         )
+    if positions.numel() < T:
+        raise ValueError(f"positions.numel()={positions.numel()} < T={T}")
     mnbps = block_tables.size(1)
 
     BLOCK_K = min(64, triton.next_power_of_2(index_topk))
@@ -177,6 +201,7 @@ def csa_translate_pack(
         topk_local,
         block_tables,
         n_committed_csa_per_seq,
+        positions,
         kv_indptr_csa,
         batch_id_per_token,
         skip_prefix_len_per_token,
@@ -185,6 +210,7 @@ def csa_translate_pack(
         mnbps,
         index_topk=index_topk,
         csa_block_capacity=csa_block_capacity,
+        ratio=ratio,
         BLOCK_K=BLOCK_K,
     )
 
@@ -193,6 +219,7 @@ def csa_translate_pack_reference(
     topk_local: torch.Tensor,
     block_tables: torch.Tensor,
     n_committed_csa_per_seq: torch.Tensor,
+    positions: torch.Tensor,
     kv_indptr_csa: torch.Tensor,
     batch_id_per_token: torch.Tensor,
     skip_prefix_len_per_token: torch.Tensor,
@@ -200,18 +227,15 @@ def csa_translate_pack_reference(
     *,
     swa_pages: int,
     csa_block_capacity: int,
+    ratio: int = 4,
 ) -> None:
-    """Pure-torch reference. Mirrors the original PyTorch chain + packed write.
-
-    Same contract as `csa_translate_pack`: `n_committed_csa_per_seq` is the
-    raw per-seq count; this reference also clamps via `min(n, index_topk)`
-    to match the kernel's mask behavior. Negative `topk_local` entries
-    (kernel-native -1 sentinels) are skipped to mirror the kernel's
-    `topk >= 0` write mask.
+    """Pure-torch reference. Mirrors the kernel — derives per-token valid_k
+    inline from positions + n_committed_csa_per_seq + index_topk.
     """
     T, index_topk = topk_local.shape
     indptr = kv_indptr_csa.to(torch.int64)
     counts = n_committed_csa_per_seq.to(torch.int64)
+    poses = positions.to(torch.int64)
     bids = batch_id_per_token.to(torch.int64)
     skips = skip_prefix_len_per_token.to(torch.int64)
     mnbps = block_tables.size(1)
@@ -219,19 +243,18 @@ def csa_translate_pack_reference(
         bid = int(bids[t].item())
         if bid < 0:
             continue
-        # Mirror kernel's `(k < valid_k) & (k < index_topk)` clamp.
-        n = min(int(counts[bid].item()), index_topk)
-        if n == 0:
+        pos = int(poses[t].item())
+        n_csa_seq = int(counts[bid].item())
+        n = min((pos + 1) // ratio, n_csa_seq, index_topk)
+        if n <= 0:
             continue
         topk = topk_local[t, :n].to(torch.int64)
-        valid = topk >= 0  # mirror kernel's per-cell `topk >= 0` write mask
+        valid = topk >= 0  # defensive; with per-token valid_k all should be >= 0
         blk_idx = (topk // csa_block_capacity).clamp(0, mnbps - 1)
         slot = topk % csa_block_capacity
         phys = block_tables[bid, blk_idx].to(torch.int64)
         paged = swa_pages + phys * csa_block_capacity + slot
         base = int(indptr[t].item()) + int(skips[t].item())
-        # Scatter only at cells where valid; cells with topk<0 keep their
-        # prior value (matches the kernel's masked tl.store).
         for k in range(n):
             if bool(valid[k].item()):
                 kv_indices_csa[base + k] = int(paged[k].item())

--- a/atom/model_ops/v4_kernels/csa_translate_pack.py
+++ b/atom/model_ops/v4_kernels/csa_translate_pack.py
@@ -29,14 +29,18 @@ two-source paged_prefill layout:
 
 Correctness equivalence with the prior path:
   - paged_decode reads `kv_indices_csa[indptr[t] : indptr[t+1]]` whose length
-    is exactly `skip_prefix_len_per_token[t] + n_committed_csa[bid]`. The
-    fused kernel writes only `[0, valid_k)` (mask
-    `(k < valid_k) & (k < index_topk)`); the tail `[valid_k, index_topk)` is
-    never read downstream, so no `-1` fill is needed. CG-padded slots
-    (batch_id=-1) bail in the kernel preamble. Indexer raw output may
-    contain -1 in tail cols (kernel-native sentinel) — those cells are
-    masked off via `(topk >= 0)` so we never write a garbage paged offset.
+    is exactly `skip_prefix_len_per_token[t] + valid_k[t]`. The fused kernel
+    writes only `[skip[t], skip[t]+valid_k[t])`, where `valid_k[t]` is
+    recovered as `indptr[t+1] - indptr[t] - skip[t]` (CPU builder packs
+    exactly this much per token). The tail `[valid_k, index_topk)` of
+    `topk_local` is uninitialized garbage from aiter's `top_k_per_row_*`
+    (which only writes `[0, valid_k)` and does NOT fill -1) — the
+    `k_offs < valid_k` mask is the sole correctness barrier; do not rely
+    on a `topk >= 0` check. CG-padded slots (batch_id=-1) bail in the
+    kernel preamble.
 """
+
+from typing import Optional
 
 import torch
 import triton
@@ -47,18 +51,18 @@ import triton.language as tl
 def _csa_translate_pack_kernel(
     topk_local_ptr,  # [T, index_topk] int32 — indexer raw output
     block_tables_ptr,  # [bs, mnbps] int32 — page table
-    n_committed_csa_per_seq_ptr,  # [bs] int32 — RAW per-seq committed count
-    positions_ptr,  # [T] int — global token positions
-    kv_indptr_csa_ptr,  # [T+1] int32 — packed cumsum (per-token)
+    positions_ptr,  # [T] int — global token positions (only read under INLINE_SKIP_FROM_POS)
+    kv_indptr_csa_ptr,  # [T+1] int32 — packed cumsum; per-token valid_k = indptr[t+1]-indptr[t]-skip[t]
     batch_id_per_token_ptr,  # [T] int32 — token → seq, sentinel -1
-    skip_prefix_len_per_token_ptr,  # [T] int32 — per-token write offset
+    skip_prefix_len_per_token_ptr,  # [T] int32 — per-token write offset; ignored when INLINE_SKIP_FROM_POS
     kv_indices_csa_ptr,  # [total_indices] int32 — destination
     swa_pages,  # i32 — SWA region size, runtime int
     mnbps,  # i32 — max blocks per seq, runtime int
     index_topk: tl.constexpr,
     csa_block_capacity: tl.constexpr,
-    ratio: tl.constexpr,  # = 4 for CSA (compress ratio used for visibility)
     BLOCK_K: tl.constexpr,
+    INLINE_SKIP_FROM_POS: tl.constexpr,  # True → skip = min(pos+1, WINDOW_SIZE) (decode); False → load from buffer (prefill)
+    WINDOW_SIZE: tl.constexpr,  # SWA window; only used under INLINE_SKIP_FROM_POS
 ):
     pid_t = tl.program_id(0)
     pid_kb = tl.program_id(1)
@@ -69,16 +73,35 @@ def _csa_translate_pack_kernel(
     if bid < 0:
         return
 
-    # Per-token valid_k = Indexer's per-row visibility = the count of
-    # valid (>=0) topk_local cells per row. Matches the formula in
-    # `_attach_v4_indexer_meta`. The n_csa_seq clamp is defensive — V4
-    # prepare_* paths enforce `pos < ctx_total` so it usually matches
-    # `(pos+1)//ratio`, but keeping the explicit clamp tracks Indexer's
-    # `visible_end` exactly and protects against edge cases in CG-warmup /
-    # MTP-verify rollback paths where positions and ctx may drift slightly.
-    pos = tl.load(positions_ptr + pid_t)
-    n_csa_seq = tl.load(n_committed_csa_per_seq_ptr + bid)
-    valid_k = tl.minimum(tl.minimum((pos + 1) // ratio, n_csa_seq), index_topk)
+    # Per-token valid_k is derived from the indptr delta we already need to
+    # load anyway:
+    #   kv_indptr_csa[t+1] - kv_indptr_csa[t] = skip[t] + valid_k[t]
+    # (CPU builder packs `(prefix_swa_count_or_actual_swa) + csa_valid_k`
+    # per token — see `_attach_v4_paged_decode_meta` / `_build_paged_prefill_meta`).
+    # Reading the delta replaces the previous chain
+    # `min(min((pos+1)//ratio, n_csa_seq), index_topk)` — eliminates the
+    # `n_csa_seq` load and the `(pos+1)//ratio` compute, and stays
+    # CORRECT under the aiter `top_k_per_row_*` contract which only writes
+    # `[0, min(k, row_length))` (the tail is uninitialized garbage from
+    # `torch.empty`, never -1 — aiter tests confirm via `compare_topk_results`
+    # checking only the head). The `k_offs < valid_k` mask remains the
+    # primary correctness barrier; `topk >= 0` is dropped as it was never
+    # a reliable filter for the uninitialized tail.
+    if INLINE_SKIP_FROM_POS:
+        # Decode: skip = `actual_swa_count[t]` = min(positions[t]+1, win).
+        # Derived inline so the caller can omit the per-token CPU write +
+        # H2D of `v4_skip_prefix_len_csa`. Matches the value the prefill
+        # path stores per token, except chunked prefill where skip depends
+        # on `chunk_start` (not derivable from pos alone) — that path keeps
+        # INLINE_SKIP_FROM_POS=False and loads from the buffer.
+        pos = tl.load(positions_ptr + pid_t)
+        skip = tl.minimum(pos + 1, WINDOW_SIZE)
+    else:
+        skip = tl.load(skip_prefix_len_per_token_ptr + pid_t)
+    indptr_t = tl.load(kv_indptr_csa_ptr + pid_t)
+    indptr_t1 = tl.load(kv_indptr_csa_ptr + pid_t + 1)
+    write_base = indptr_t + skip
+    valid_k = indptr_t1 - write_base  # = (skip + valid_k) - skip
 
     k_offs = pid_kb * BLOCK_K + tl.arange(0, BLOCK_K)
     in_range = k_offs < valid_k
@@ -88,11 +111,6 @@ def _csa_translate_pack_kernel(
         mask=in_range,
         other=0,
     )
-    # Indexer's raw seq-local output uses -1 as the kernel-native sentinel
-    # for tail cols where no candidate was selected (per-token visibility
-    # cap < n_committed_csa[seq]). Skip writes for negative entries so we
-    # don't translate a garbage row into a paged offset.
-    valid_topk = in_range & (topk >= 0)
 
     # Translate seq-local row → physical paged offset.
     blk_idx = topk // csa_block_capacity
@@ -102,67 +120,67 @@ def _csa_translate_pack_kernel(
     blk_safe = tl.minimum(tl.maximum(blk_idx, 0), mnbps - 1)
     phys = tl.load(
         block_tables_ptr + bid * mnbps + blk_safe,
-        mask=valid_topk,
+        mask=in_range,
         other=0,
     )
     paged = swa_pages + phys * csa_block_capacity + slot
-
-    skip = tl.load(skip_prefix_len_per_token_ptr + pid_t)
-    write_base = tl.load(kv_indptr_csa_ptr + pid_t) + skip
     tl.store(
         kv_indices_csa_ptr + write_base + k_offs,
         paged,
-        mask=valid_topk,
+        mask=in_range,
     )
 
 
 def csa_translate_pack(
     topk_local: torch.Tensor,
     block_tables: torch.Tensor,
-    n_committed_csa_per_seq: torch.Tensor,
     positions: torch.Tensor,
     kv_indptr_csa: torch.Tensor,
     batch_id_per_token: torch.Tensor,
-    skip_prefix_len_per_token: torch.Tensor,
+    skip_prefix_len_per_token: Optional[torch.Tensor],
     kv_indices_csa: torch.Tensor,
     *,
     swa_pages: int,
     csa_block_capacity: int,
-    ratio: int = 4,
+    window_size: int = 0,
 ) -> None:
     """Fused topk translate + packed write into `kv_indices_csa` (in-place).
 
-    The kernel computes per-token CSA `valid_k` inline as
-    ``min((positions[t]+1)//ratio, n_committed_csa[bid], index_topk)``,
-    matching Indexer's per-row visibility (cu_ends - cu_starts in
-    ``_attach_v4_indexer_meta``). Caller's CSA indptr MUST reserve exactly
-    this many cells per token — then csa_translate_pack writes every
-    reserved cell and no `-1` sentinel pre-fill is needed.
+    Per-token `valid_k` is recovered from `kv_indptr_csa[t+1] - kv_indptr_csa[t]
+    - skip[t]`, which equals the Indexer's per-row visibility
+    (`min((pos+1)//ratio, n_committed_csa[bid], index_topk)`) by construction
+    of the CPU-side indptr builders (see `_attach_v4_paged_decode_meta`,
+    `_build_paged_prefill_meta`). aiter's `top_k_per_row_*` writes only
+    `[0, valid_k)` and leaves the tail UNINITIALIZED (`torch.empty`, no
+    `-1` fill), so the explicit `k_offs < valid_k` mask is what keeps the
+    kernel correct — the previous `topk >= 0` check would NOT have been a
+    reliable filter for the garbage tail.
 
     Args:
       topk_local:                  [T, index_topk] int32 — indexer's seq-local
-                                   row indices. Leading `valid_k[t]` cells are
-                                   always >= 0 (Indexer filled them); trailing
-                                   cells are -1 but never read because
-                                   `k_offs < valid_k` filters them out.
+                                   row indices. Cells `[0, valid_k[t])` are
+                                   the kernel-written results; `[valid_k[t],
+                                   index_topk)` is uninitialized garbage and
+                                   never read.
       block_tables:                [bs, mnbps] int32 — logical block → physical.
-      n_committed_csa_per_seq:     [bs] int32 — RAW per-seq committed count
-                                   (`ctx_len // ratio`); clamps per-token
-                                   `valid_k` to seq-level (defensive).
-      positions:                   [T] int — global token positions; combined
-                                   with `n_committed_csa_per_seq` and
-                                   `index_topk` to derive per-token valid_k.
+      positions:                   [T] int — global token positions; used only
+                                   under `window_size > 0` (inline skip
+                                   derivation, decode path).
       kv_indptr_csa:               [T+1] int32 — per-token packed cumsum
                                    (CG-padded: tail repeats last value
-                                   → kv_len=0).
+                                   → kv_len=0). The kernel reads both
+                                   `[t]` and `[t+1]` so `valid_k[t]` is
+                                   recovered as `indptr[t+1] - indptr[t] - skip[t]`.
       batch_id_per_token:          [T] int32 — token → seq, sentinel -1 for
                                    CG-padded slots.
-      skip_prefix_len_per_token:   [T] int32 — per-token write offset within
-                                   `kv_indices_csa[indptr[t] : indptr[t+1]]`
-                                   where the CSA section starts. Decode passes
-                                   `[window_size, ...]` (full SWA prefix);
-                                   pure prefill passes 0; chunked prefill
-                                   passes `prior_swa_count_per_token`.
+      skip_prefix_len_per_token:   [T] int32 OR None — per-token write offset
+                                   within `kv_indices_csa[indptr[t] : indptr[t+1]]`
+                                   where the CSA section starts. Pass None
+                                   with `window_size > 0` to derive skip
+                                   inline as `min(positions[t]+1, window_size)`
+                                   (decode shortcut). Pure prefill passes a
+                                   zero buffer; chunked prefill passes
+                                   `prior_swa_count_per_token`.
       kv_indices_csa:              [total_indices] int32 — destination buffer;
                                    this kernel writes the CSA section
                                    `[indptr[t]+skip[t],
@@ -172,21 +190,25 @@ def csa_translate_pack(
       csa_block_capacity:          `block_size // ratio = 128 // 4 = 32`
                                    (constexpr; triton can strength-reduce
                                    // and %). Keyword-only.
-      ratio:                       Compression ratio (= 4 for CSA). Used in
-                                   the per-token visibility formula
-                                   `(positions[t]+1)//ratio`. Keyword-only.
+      window_size:                 SWA window. When > 0 the kernel computes
+                                   per-token skip inline (decode shortcut);
+                                   when 0 the per-token buffer is loaded.
+                                   Keyword-only.
     """
     T, index_topk = topk_local.shape
     if T == 0:
         return
 
+    inline_skip = window_size > 0
+    if not inline_skip and skip_prefix_len_per_token is None:
+        raise ValueError("skip_prefix_len_per_token is required when window_size == 0")
     if kv_indptr_csa.numel() < T + 1:
         raise ValueError(f"kv_indptr_csa.numel()={kv_indptr_csa.numel()} < T+1={T + 1}")
     if batch_id_per_token.numel() < T:
         raise ValueError(
             f"batch_id_per_token.numel()={batch_id_per_token.numel()} < T={T}"
         )
-    if skip_prefix_len_per_token.numel() < T:
+    if not inline_skip and skip_prefix_len_per_token.numel() < T:
         raise ValueError(
             "skip_prefix_len_per_token.numel()="
             f"{skip_prefix_len_per_token.numel()} < T={T}"
@@ -195,66 +217,78 @@ def csa_translate_pack(
         raise ValueError(f"positions.numel()={positions.numel()} < T={T}")
     mnbps = block_tables.size(1)
 
+    # Triton requires a concrete pointer even when the buffer is unused under
+    # an INLINE_SKIP_FROM_POS=True constexpr branch. Reuse positions as a
+    # dummy — same dtype family (int), valid GPU pointer, never read.
+    skip_ptr = (
+        skip_prefix_len_per_token
+        if skip_prefix_len_per_token is not None
+        else positions
+    )
+
     BLOCK_K = min(64, triton.next_power_of_2(index_topk))
     grid = (T, triton.cdiv(index_topk, BLOCK_K))
     _csa_translate_pack_kernel[grid](
         topk_local,
         block_tables,
-        n_committed_csa_per_seq,
         positions,
         kv_indptr_csa,
         batch_id_per_token,
-        skip_prefix_len_per_token,
+        skip_ptr,
         kv_indices_csa,
         swa_pages,
         mnbps,
         index_topk=index_topk,
         csa_block_capacity=csa_block_capacity,
-        ratio=ratio,
         BLOCK_K=BLOCK_K,
+        INLINE_SKIP_FROM_POS=inline_skip,
+        WINDOW_SIZE=window_size,
     )
 
 
 def csa_translate_pack_reference(
     topk_local: torch.Tensor,
     block_tables: torch.Tensor,
-    n_committed_csa_per_seq: torch.Tensor,
     positions: torch.Tensor,
     kv_indptr_csa: torch.Tensor,
     batch_id_per_token: torch.Tensor,
-    skip_prefix_len_per_token: torch.Tensor,
+    skip_prefix_len_per_token: Optional[torch.Tensor],
     kv_indices_csa: torch.Tensor,
     *,
     swa_pages: int,
     csa_block_capacity: int,
-    ratio: int = 4,
+    window_size: int = 0,
 ) -> None:
     """Pure-torch reference. Mirrors the kernel — derives per-token valid_k
-    inline from positions + n_committed_csa_per_seq + index_topk.
+    inline from the `kv_indptr_csa` delta minus skip. When `window_size > 0`,
+    derives per-token skip inline as `min(positions[t]+1, window_size)` and
+    ignores `skip_prefix_len_per_token` (which may be None).
     """
-    T, index_topk = topk_local.shape
+    T, _ = topk_local.shape
     indptr = kv_indptr_csa.to(torch.int64)
-    counts = n_committed_csa_per_seq.to(torch.int64)
     poses = positions.to(torch.int64)
     bids = batch_id_per_token.to(torch.int64)
-    skips = skip_prefix_len_per_token.to(torch.int64)
+    inline_skip = window_size > 0
+    skips = (
+        skip_prefix_len_per_token.to(torch.int64)
+        if (not inline_skip and skip_prefix_len_per_token is not None)
+        else None
+    )
     mnbps = block_tables.size(1)
     for t in range(T):
         bid = int(bids[t].item())
         if bid < 0:
             continue
         pos = int(poses[t].item())
-        n_csa_seq = int(counts[bid].item())
-        n = min((pos + 1) // ratio, n_csa_seq, index_topk)
-        if n <= 0:
+        skip_t = min(pos + 1, window_size) if inline_skip else int(skips[t].item())
+        base = int(indptr[t].item()) + skip_t
+        valid_k = int(indptr[t + 1].item()) - base
+        if valid_k <= 0:
             continue
-        topk = topk_local[t, :n].to(torch.int64)
-        valid = topk >= 0  # defensive; with per-token valid_k all should be >= 0
+        topk = topk_local[t, :valid_k].to(torch.int64)
         blk_idx = (topk // csa_block_capacity).clamp(0, mnbps - 1)
         slot = topk % csa_block_capacity
         phys = block_tables[bid, blk_idx].to(torch.int64)
         paged = swa_pages + phys * csa_block_capacity + slot
-        base = int(indptr[t].item()) + int(skips[t].item())
-        for k in range(n):
-            if bool(valid[k].item()):
-                kv_indices_csa[base + k] = int(paged[k].item())
+        for k in range(valid_k):
+            kv_indices_csa[base + k] = int(paged[k].item())

--- a/atom/model_ops/v4_kernels/fused_compress.py
+++ b/atom/model_ops/v4_kernels/fused_compress.py
@@ -104,8 +104,9 @@ def _fused_compress_attn_kernel(
     OVERLAP: tl.constexpr,
     RATIO: tl.constexpr,
     STATE_SIZE: tl.constexpr,  # ring buffer modulo = kv_state.shape[1] (≥ K_pool;
-    #   for spec decode is K_pool + max_spec_steps + 1 to avoid R+1 re-commit
-    #   borrow-reads of prior round's reject K/V; for non-spec decode is K_pool)
+    #   spec decode: K_pool + max_spec_steps so R's rejected writes fall outside
+    #   R+1's K_pool-wide read window; non-spec decode: K_pool exactly — no
+    #   rejection ever happens and causal writes preclude any read-before-overwrite)
     K: tl.constexpr,  # pool-window reduce dim (= 2*RATIO if OVERLAP else RATIO);
     #   ≤ STATE_SIZE; used for `s = position - K + 1 + k_static` loop bound
     HAS_BLOCK_TABLE: tl.constexpr,
@@ -415,7 +416,7 @@ def fused_compress_attn(
     K_pool = (2 if overlap else 1) * ratio  # pool window size (algorithm-defined)
     state_size = kv_state.shape[
         1
-    ]  # ring buffer modulo (≥ K_pool; spec path enlarges to K_pool + max_spec_steps + 1)
+    ]  # ring buffer modulo (≥ K_pool; V4-Pro: K_pool + max_spec_steps spec / K_pool non-spec)
     assert (
         kv_in.dim() == 2 and kv_in.shape[1] == dim_full
     ), f"kv_in {kv_in.shape}, expected [*, {dim_full}]"

--- a/atom/model_ops/v4_kernels/paged_prefill.py
+++ b/atom/model_ops/v4_kernels/paged_prefill.py
@@ -44,11 +44,19 @@ Numerics: identical online-softmax + sink finalization to
 (then equivalent to a decode call with the same prefix indices).
 """
 
-import os
-
 import torch
 import triton
 import triton.language as tl
+
+from atom.utils import envs
+
+try:
+    from aiter.ops.pa_sparse_prefill_opus import pa_sparse_prefill_opus
+
+    _HAS_OPUS = True
+except ImportError:
+    pa_sparse_prefill_opus = None
+    _HAS_OPUS = False
 
 
 @triton.jit
@@ -361,7 +369,10 @@ def sparse_attn_v4_paged_prefill(
     Returns:
       out: [T, H, D] same dtype as q.
     """
-    if os.environ.get("ATOM_USE_TRITON_ATTN", "1") == "1":
+    # Backend selection: OPUS (gfx950) is the default; set
+    # `ATOM_FORCE_ATTN_TRITON=1` to fall back to the Triton kernel. When the
+    # OPUS module isn't importable on this build, we silently use Triton.
+    if envs.ATOM_FORCE_ATTN_TRITON or not _HAS_OPUS:
         return _sparse_attn_v4_paged_prefill_triton(
             q,
             unified_kv,
@@ -373,7 +384,7 @@ def sparse_attn_v4_paged_prefill(
             attn_sink,
             softmax_scale,
         )
-    return sparse_attn_v4_paged_prefill_reference(
+    return pa_sparse_prefill_opus(
         q,
         unified_kv,
         kv_indices_prefix,

--- a/atom/model_ops/v4_kernels/paged_prefill_indices.py
+++ b/atom/model_ops/v4_kernels/paged_prefill_indices.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""V4 paged-prefill index scatter — single Triton kernel writes the four
+per-fwd index buffers consumed by `sparse_attn_v4_paged_prefill`:
+
+  - ``kv_indices_extend``       : per-fwd `kv` tensor row indices for the
+                                  in-chunk SWA tail (one shared buffer).
+  - ``kv_indices_prefix_swa``   : Dense path — SWA prior-chunk paged offsets
+                                  into `unified_kv`.
+  - ``kv_indices_prefix_csa``   : CSA path — SWA prefix segment written here;
+                                  CSA topk tail kept at ``-1`` (filled per
+                                  layer by ``csa_translate_pack``).
+  - ``kv_indices_prefix_hca``   : HCA path — SWA prefix segment + HCA
+                                  all-committed compress section, both fully
+                                  written.
+
+Replaces the CPU numpy build in
+``DeepseekV4AttentionMetadataBuilder._build_paged_prefill_meta`` (per-fwd
+`_segment_indices` + cumsum + scatter chain + pinned H2D). The kernel runs
+entirely on GPU and is invoked AFTER the caller has computed the four
+indptrs via ``torch.cumsum`` (also on GPU).
+
+Caller responsibilities (no copies done here):
+  - Pre-fill ``prefix_csa_indices`` with ``-1`` (e.g. ``tensor.fill_(-1)``).
+    The kernel writes only the SWA prefix segment; the CSA topk tail must
+    stay at the ``-1`` sentinel until ``csa_translate_pack`` fills it per
+    layer. (HCA / Dense buffers are fully written by this kernel.)
+  - Compute and stage the four indptr buffers and the per-seq scalar inputs.
+
+Per-token quantities (kernel-computed from inputs; mirror the formulas in
+``_build_paged_prefill_meta``):
+  token_pos_in_chunk[t] = positions[t] - chunk_start[bid]
+  swa_low[t]            = max(positions[t] - win + 1, 0)
+  extend_count[t]       = min(token_pos_in_chunk[t] + 1, win)
+  prefix_swa_count[t]   = max(chunk_start[bid] - swa_low[t], 0)
+
+Per-token paged offset for SWA prefix entries (matches the stride/modulo
+used by `swa_write` and `_attach_v4_paged_decode_meta`):
+  paged[t,k] = state_slot[bid] * cs + ((swa_low[t] + k) % cs)
+"""
+
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _v4_paged_prefill_indices_kernel(
+    # Per-token inputs.
+    positions_ptr,  # [T] int — global token position
+    bid_per_token_ptr,  # [T] int — batch id per token (==`np.repeat(arange(bs), tnps)`)
+    # Per-seq inputs (indexed by bid).
+    chunk_start_per_seq_ptr,  # [bs] int — current chunk's absolute start position
+    cu_seqlens_q_per_seq_ptr,  # [bs] int — per-seq prefix sum start in per-fwd kv tensor
+    state_slot_per_seq_ptr,  # [bs] int — per-seq SWA ring slot
+    n_committed_hca_per_seq_ptr,  # [bs] int — per-seq HCA compress entry count
+    block_tables_ptr,  # [bs, MAX_BLOCKS] int — per-seq paged block ids
+    bt_stride_bs,  # bytes between block_tables rows
+    # Indptrs (already cumsum'd by caller, all length [T+1]).
+    extend_indptr_ptr,
+    prefix_swa_indptr_ptr,
+    prefix_csa_indptr_ptr,
+    prefix_hca_indptr_ptr,
+    # Output buffers.
+    extend_indices_ptr,
+    prefix_swa_indices_ptr,
+    prefix_csa_indices_ptr,
+    prefix_hca_indices_ptr,
+    # Constants.
+    win: tl.constexpr,
+    cs,  # win_with_spec — SWA ring stride (NOT constexpr because varies w/ mtp_k)
+    swa_pages,  # state_slot count * cs — boundary into HCA compress section
+    BLOCK_N: tl.constexpr,  # next_pow2(win) — covers SWA prefix and extend segments
+):
+    """One program per token. Writes four per-token segments:
+
+    - extend         : ``[extend_indptr[t], extend_indptr[t]+extend_count[t])``
+    - prefix SWA     : ``[*_swa_indptr[t], *_swa_indptr[t]+prefix_swa_count[t])``
+                        in all three of swa / csa / hca prefix buffers
+    - HCA compress   : ``[prefix_hca_indptr[t]+prefix_swa_count[t], +n_hca[bid])``
+                        in prefix_hca_indices
+
+    Per-token bounded segments (extend, SWA prefix) fit in one ``BLOCK_N``
+    vector. HCA compress can be up to ``max_model_len // 128`` per token
+    (e.g. 8192 at V4-Pro 1M ctx) — looped in ``BLOCK_N`` chunks.
+    """
+    t = tl.program_id(0)
+
+    bid = tl.load(bid_per_token_ptr + t)
+    pos = tl.load(positions_ptr + t)
+    chunk_start = tl.load(chunk_start_per_seq_ptr + bid)
+    cu_q = tl.load(cu_seqlens_q_per_seq_ptr + bid)
+    state_slot = tl.load(state_slot_per_seq_ptr + bid)
+    n_hca = tl.load(n_committed_hca_per_seq_ptr + bid)
+
+    # Per-token derived quantities (single-pass arithmetic).
+    token_pos_in_chunk = pos - chunk_start
+    swa_low = tl.maximum(pos - win + 1, 0)
+    extend_count = tl.minimum(token_pos_in_chunk + 1, win)
+    prefix_swa_count = tl.maximum(chunk_start - swa_low, 0)
+
+    i = tl.arange(0, BLOCK_N)
+
+    # ---- Extend kv_indices: rows in per-fwd kv tensor ----
+    # row = cu_q + token_pos_in_chunk - extend_count + 1 + k, k in [0, extend_count)
+    ext_base = tl.load(extend_indptr_ptr + t)
+    ext_mask = i < extend_count
+    ext_start_row = cu_q + token_pos_in_chunk - extend_count + 1
+    tl.store(extend_indices_ptr + ext_base + i, ext_start_row + i, mask=ext_mask)
+
+    # ---- SWA prefix paged offsets: written to all three prefix buffers ----
+    # paged = state_slot * cs + ((swa_low + k) % cs), k in [0, prefix_swa_count)
+    swa_base_swa = tl.load(prefix_swa_indptr_ptr + t)
+    swa_base_csa = tl.load(prefix_csa_indptr_ptr + t)
+    swa_base_hca = tl.load(prefix_hca_indptr_ptr + t)
+    swa_mask = i < prefix_swa_count
+    global_pos = swa_low + i
+    ring_idx = global_pos - (global_pos // cs) * cs  # global_pos % cs
+    paged = state_slot * cs + ring_idx
+    tl.store(prefix_swa_indices_ptr + swa_base_swa + i, paged, mask=swa_mask)
+    tl.store(prefix_csa_indices_ptr + swa_base_csa + i, paged, mask=swa_mask)
+    tl.store(prefix_hca_indices_ptr + swa_base_hca + i, paged, mask=swa_mask)
+
+    # ---- HCA compress section: block_tables[bid, k] for k in [0, n_hca) ----
+    # Written at offset prefix_swa_count past the SWA prefix segment in HCA buffer.
+    hca_dst_base = swa_base_hca + prefix_swa_count
+    # block_tables row stride is `bt_stride_bs` int32 elements (== max_num_blocks_per_seq).
+    bt_row_base = bid * bt_stride_bs
+    for j in tl.range(0, n_hca, BLOCK_N):
+        k = j + i
+        hca_mask = k < n_hca
+        bt = tl.load(block_tables_ptr + bt_row_base + k, mask=hca_mask, other=0)
+        tl.store(
+            prefix_hca_indices_ptr + hca_dst_base + k,
+            swa_pages + bt,
+            mask=hca_mask,
+        )
+
+
+def write_v4_paged_prefill_indices(
+    *,
+    positions: torch.Tensor,
+    bid_per_token: torch.Tensor,
+    chunk_start_per_seq: torch.Tensor,
+    cu_seqlens_q_per_seq: torch.Tensor,
+    state_slot_per_seq: torch.Tensor,
+    n_committed_hca_per_seq: torch.Tensor,
+    block_tables: torch.Tensor,
+    extend_indptr: torch.Tensor,
+    prefix_swa_indptr: torch.Tensor,
+    prefix_csa_indptr: torch.Tensor,
+    prefix_hca_indptr: torch.Tensor,
+    extend_indices: torch.Tensor,
+    prefix_swa_indices: torch.Tensor,
+    prefix_csa_indices: torch.Tensor,
+    prefix_hca_indices: torch.Tensor,
+    T: int,
+    win: int,
+    cs: int,
+    swa_pages: int,
+) -> None:
+    """One-shot GPU build of the V4 paged-prefill index buffers.
+
+    Replaces the CPU numpy build in
+    ``DeepseekV4AttentionMetadataBuilder._build_paged_prefill_meta`` (the
+    `_segment_indices` + scatter chain). All inputs/outputs are GPU tensors;
+    no D2H, no allocator churn beyond the persistent buffers the caller owns.
+
+    Caller is responsible for:
+      1. Pre-filling ``prefix_csa_indices`` with ``-1`` so the CSA topk
+         tail stays sentinel-marked until ``csa_translate_pack`` fills it
+         per layer. (Use ``prefix_csa_indices[:csa_total].fill_(-1)``.)
+      2. Computing the four indptr cumsums (e.g. via ``torch.cumsum`` over
+         the per-token count vectors).
+      3. Computing ``bid_per_token`` (e.g.
+         ``torch.repeat_interleave(arange(bs), token_num_per_seq)``).
+
+    Per-seq inputs MUST be indexed by ``bid_per_token`` (the kernel reads
+    ``chunk_start_per_seq[bid_per_token[t]]`` etc. inline — no per-token
+    pre-gather needed by the caller).
+
+    Args (all GPU tensors):
+      positions:                 ``[T]``    int — global token positions.
+      bid_per_token:             ``[T]``    int — batch id per token.
+      chunk_start_per_seq:       ``[bs]``   int — per-seq chunk start.
+      cu_seqlens_q_per_seq:      ``[bs]``   int — per-seq cu_seqlens_q[bid]
+                                            (NOT the full ``[bs+1]`` cumsum
+                                            — caller passes the leading
+                                            ``bs`` entries).
+      state_slot_per_seq:        ``[bs]``   int — per-seq SWA ring slot.
+      n_committed_hca_per_seq:   ``[bs]``   int — per-seq HCA compress count.
+      block_tables:              ``[bs, mnbs]`` int — per-seq paged blocks.
+      extend_indptr:             ``[T+1]``  int.
+      prefix_swa_indptr:         ``[T+1]``  int.
+      prefix_csa_indptr:         ``[T+1]``  int.
+      prefix_hca_indptr:         ``[T+1]``  int.
+      extend_indices:            ``[ext_total]`` int OUT — fully written.
+      prefix_swa_indices:        ``[swa_total]`` int OUT — fully written.
+      prefix_csa_indices:        ``[csa_total]`` int OUT — SWA prefix
+                                  segment written here; CSA topk tail
+                                  PRESERVED (caller pre-fills -1).
+      prefix_hca_indices:        ``[hca_total]`` int OUT — fully written.
+      T:                         int — token count (grid size).
+      win:                       int — SWA window size (per-token SWA cap).
+      cs:                        int — ``win + max_spec_steps`` (ring stride
+                                  and modulo for paged offset).
+      swa_pages:                 int — ``num_slots * cs`` boundary in unified_kv.
+    """
+    if T == 0:
+        return
+    assert positions.dim() == 1 and positions.shape[0] >= T
+    assert bid_per_token.dim() == 1 and bid_per_token.shape[0] >= T
+    assert chunk_start_per_seq.dim() == 1
+    assert cu_seqlens_q_per_seq.dim() == 1
+    assert state_slot_per_seq.dim() == 1
+    assert n_committed_hca_per_seq.dim() == 1
+    assert block_tables.dim() == 2
+    for idp in (extend_indptr, prefix_swa_indptr, prefix_csa_indptr, prefix_hca_indptr):
+        assert idp.dim() == 1 and idp.shape[0] >= T + 1
+    for idx in (
+        extend_indices,
+        prefix_swa_indices,
+        prefix_csa_indices,
+        prefix_hca_indices,
+    ):
+        assert idx.dim() == 1
+
+    BLOCK_N = triton.next_power_of_2(win)
+    _v4_paged_prefill_indices_kernel[(T,)](
+        positions,
+        bid_per_token,
+        chunk_start_per_seq,
+        cu_seqlens_q_per_seq,
+        state_slot_per_seq,
+        n_committed_hca_per_seq,
+        block_tables,
+        block_tables.stride(0),
+        extend_indptr,
+        prefix_swa_indptr,
+        prefix_csa_indptr,
+        prefix_hca_indptr,
+        extend_indices,
+        prefix_swa_indices,
+        prefix_csa_indices,
+        prefix_hca_indices,
+        win=win,
+        cs=cs,
+        swa_pages=swa_pages,
+        BLOCK_N=BLOCK_N,
+    )
+
+
+def write_v4_paged_prefill_indices_reference(
+    *,
+    positions: torch.Tensor,
+    bid_per_token: torch.Tensor,
+    chunk_start_per_seq: torch.Tensor,
+    cu_seqlens_q_per_seq: torch.Tensor,
+    state_slot_per_seq: torch.Tensor,
+    n_committed_hca_per_seq: torch.Tensor,
+    block_tables: torch.Tensor,
+    extend_indptr: torch.Tensor,
+    prefix_swa_indptr: torch.Tensor,
+    prefix_csa_indptr: torch.Tensor,
+    prefix_hca_indptr: torch.Tensor,
+    extend_indices: torch.Tensor,
+    prefix_swa_indices: torch.Tensor,
+    prefix_csa_indices: torch.Tensor,
+    prefix_hca_indices: torch.Tensor,
+    T: int,
+    win: int,
+    cs: int,
+    swa_pages: int,
+) -> None:
+    """Pure-Python equivalent of ``write_v4_paged_prefill_indices``.
+    Per-token Python loop — slow but readable; used for unit-test bit-exact
+    verification against the Triton kernel and dump-bisect debugging.
+
+    Same caller contract: ``prefix_csa_indices`` must be pre-filled with
+    ``-1`` for the CSA topk tail to stay sentinel-marked.
+    """
+    if T == 0:
+        return
+    bid_cpu = bid_per_token[:T].cpu().tolist()
+    pos_cpu = positions[:T].cpu().tolist()
+    cs_per_seq_cpu = chunk_start_per_seq.cpu().tolist()
+    cu_q_cpu = cu_seqlens_q_per_seq.cpu().tolist()
+    state_slot_cpu = state_slot_per_seq.cpu().tolist()
+    n_hca_cpu = n_committed_hca_per_seq.cpu().tolist()
+    block_tables_cpu = block_tables.cpu()
+    ext_indptr_cpu = extend_indptr.cpu().tolist()
+    swa_indptr_cpu = prefix_swa_indptr.cpu().tolist()
+    csa_indptr_cpu = prefix_csa_indptr.cpu().tolist()
+    hca_indptr_cpu = prefix_hca_indptr.cpu().tolist()
+    device = extend_indices.device
+
+    for t in range(T):
+        bid = bid_cpu[t]
+        pos = pos_cpu[t]
+        chunk_start = cs_per_seq_cpu[bid]
+        cu_q = cu_q_cpu[bid]
+        state_slot = state_slot_cpu[bid]
+        n_hca = n_hca_cpu[bid]
+
+        token_pos_in_chunk = pos - chunk_start
+        swa_low = max(pos - win + 1, 0)
+        extend_count = min(token_pos_in_chunk + 1, win)
+        prefix_swa_count = max(chunk_start - swa_low, 0)
+
+        # Extend
+        ext_base = ext_indptr_cpu[t]
+        ext_start_row = cu_q + token_pos_in_chunk - extend_count + 1
+        ext_rows = torch.arange(
+            ext_start_row,
+            ext_start_row + extend_count,
+            device=device,
+            dtype=extend_indices.dtype,
+        )
+        extend_indices[ext_base : ext_base + extend_count] = ext_rows
+
+        # SWA prefix (written to swa / csa / hca prefix buffers)
+        sb_swa = swa_indptr_cpu[t]
+        sb_csa = csa_indptr_cpu[t]
+        sb_hca = hca_indptr_cpu[t]
+        if prefix_swa_count > 0:
+            global_pos = torch.arange(
+                swa_low,
+                swa_low + prefix_swa_count,
+                device=device,
+                dtype=prefix_swa_indices.dtype,
+            )
+            paged = state_slot * cs + (global_pos % cs)
+            prefix_swa_indices[sb_swa : sb_swa + prefix_swa_count] = paged
+            prefix_csa_indices[sb_csa : sb_csa + prefix_swa_count] = paged
+            prefix_hca_indices[sb_hca : sb_hca + prefix_swa_count] = paged
+
+        # HCA compress
+        if n_hca > 0:
+            bt = block_tables_cpu[bid, :n_hca].to(device).to(prefix_hca_indices.dtype)
+            hca_dst = sb_hca + prefix_swa_count
+            prefix_hca_indices[hca_dst : hca_dst + n_hca] = swa_pages + bt

--- a/atom/model_ops/v4_kernels/paged_prefill_indices.py
+++ b/atom/model_ops/v4_kernels/paged_prefill_indices.py
@@ -40,7 +40,6 @@ used by `swa_write` and `_attach_v4_paged_decode_meta`):
   paged[t,k] = state_slot[bid] * cs + ((swa_low[t] + k) % cs)
 """
 
-
 import torch
 import triton
 import triton.language as tl

--- a/atom/model_ops/v4_kernels/state_writes.py
+++ b/atom/model_ops/v4_kernels/state_writes.py
@@ -8,17 +8,14 @@ Inputs are flat batched tensors; per-token slot/position lookups happen
 inside the kernel — no `.item()` syncs.
 
 Currently implemented:
-- `swa_write`: writes `swa_kv[state_slot_per_seq[batch_id_per_token[t]],
-  positions[t] % cache_size, :] = kv[t, :]` for each src row id `t` selected
-  by `write_indices`. The kernel does ALL gathers (kv row, position, batch
-  id, state slot) itself — caller passes only stable forward_vars buffers
-  (full `kv`, full `positions`, full `batch_id_per_token`, per-seq
-  `state_slot`). Race-free for long prefill via the `write_indices` filter
-  (only the last `cache_size` tokens per seq selected); CUDAGraph-safe via
-  sentinel skip (`write_indices[pid] < 0` → bail). `cache_size` is
-  `window_size + max_spec_steps` — for non-MTP this reduces to `window_size`
-  (no behavioral change); for MTP-k draft tokens get their own ring slots
-  separate from the verified token's slot.
+- `swa_write`: writes the LAST `min(tok_n_b, write_per_batch)` tokens of
+  every seq `b ∈ [0, bs)` into `swa_kv[state_slot_per_seq[b],
+  positions[src] % cache_size, :] = kv[src, :]`. `src_id` is derived inside
+  the kernel from `cu_seqlens_q + row_in_batch` — no shared per-token
+  `write_indices` GPU buffer (which had a DMA-tear race when the next fwd's
+  CPU rewrite landed mid-H2D). `cache_size = window_size + max_spec_steps`
+  — for non-MTP this reduces to `window_size`; for MTP-k draft tokens get
+  their own ring slots separate from the verified token's slot.
 - `update_compressor_states`: unified in-place update of Compressor's
   per-request `kv_state` + `score_state` ring buffers, covering both prefill
   (B-side overlap context + tail) and decode (every token at `pos % STATE_SIZE`
@@ -32,23 +29,26 @@ Currently implemented:
 
 Caller contract (`swa_write`):
 - `kv`                  [T, head_dim] flat — full per-fwd KV (forward_vars).
-- `write_indices`       [W] int — src row ids into `kv` / `positions` /
-                        `batch_id_per_token`. Sentinel = -1 → kernel skips.
-                        For long prefill (`seqlen > cache_size`) builder
-                        pre-filters to the last `cache_size` rows per seq to
-                        avoid `pos % cache_size` collisions. For decode/MTP
-                        every row is written.
 - `positions`           [T] int — full positions buffer (forward_vars).
-- `batch_id_per_token`  [T] int — Phase-B `v4_batch_id_per_token` mapping;
-                        kernel does `state_slot_per_seq[batch_id]` for the
-                        per-seq state-cache slot. Single per-token mapping
-                        principle (no per-token slot alias).
+- `cu_seqlens_q`        [bs+1] int — per-fwd cumulative seqlens (so
+                        seq `i` covers token rows `[cu_seqlens_q[i], cu_seqlens_q[i+1])`
+                        in `kv` / `positions`). Per-seq token count is
+                        derived inside the kernel as `cu_seqlens_q[i+1] -
+                        cu_seqlens_q[i]`.
 - `state_slot_per_seq`  [bs] int — `state_slot_mapping_gpu_i32`.
 - `swa_kv`              [num_slots, cache_size, head_dim] in-place buffer.
 - `cache_size`          int ring-slot count = `window_size + max_spec_steps`
                         (e.g. 128 + 0 = 128 non-MTP; 128 + 1 = 129 MTP-1).
+- `write_per_batch`     int — max tokens to write per seq this fwd
+                        (= `min(max_q_len, cache_size)`). Used as Triton
+                        `constexpr` for grid sizing.
 
-Grid = `write_indices.shape[0]`; each program processes one src row id.
+Grid = `(bs, write_per_batch)`; each program writes one (seq, row-in-seq)
+token. Per-seq actual count is `min(token_num_per_seq[bs], write_per_batch)`;
+threads whose `row_in_batch >= actual_count` bail. The kernel derives
+`src_id = cu_seqlens_q[i+1] - actual_count + row_in_batch` — selects the
+LAST `actual_count` tokens of seq `i` in `kv` / `positions`, no shared
+GPU index buffer needed (no DMA race window).
 """
 
 import torch
@@ -59,30 +59,41 @@ import triton.language as tl
 @triton.jit
 def _swa_write_kernel(
     kv_ptr,  # [T, head_dim]
-    write_indices_ptr,  # [W] int — src row id; sentinel=-1 → skip
     positions_ptr,  # [T] int — full positions
-    batch_id_per_token_ptr,  # [T] int — v4_batch_id_per_token
+    cu_seqlens_q_ptr,  # [bs+1] int — per-seq cumulative seqlens
     state_slot_per_seq_ptr,  # [bs] int — state_slot_mapping_gpu_i32
     swa_kv_ptr,  # [num_slots, cache_size, head_dim]
     swa_kv_slot_stride,  # = cache_size * head_dim
     swa_kv_pos_stride,  # = head_dim
     head_dim,
     cache_size,
+    WRITE_PER_BATCH: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
-    """One program per write_indices entry. Sentinel skip via write_indices < 0.
+    """2D grid `(bs, WRITE_PER_BATCH)`. Program `(b, r)` writes the `r`-th
+    of the last-N tokens of seq `b`, where `N = min(tok_n_b, WRITE_PER_BATCH)`
+    and `tok_n_b = cu_seqlens_q[b+1] - cu_seqlens_q[b]`. Threads with
+    `r >= N` bail.
 
-    Reads kv row + position + batch_id by indirection through `write_indices`,
-    then looks up state slot via `state_slot_per_seq[batch_id]`. All four
-    source tensors are stable forward_vars buffers; no captured-region alloc.
+    `src_id = cu_seqlens_q[b+1] - N + r` — selects directly from `kv` /
+    `positions` with NO shared GPU index buffer (no DMA race window).
     """
-    pid = tl.program_id(0)
-    src_id = tl.load(write_indices_ptr + pid)
-    if src_id < 0:
+    batch_idx = tl.program_id(0)
+    row_in_batch = tl.program_id(1)
+
+    cu_start = tl.load(cu_seqlens_q_ptr + batch_idx)
+    cu_end = tl.load(cu_seqlens_q_ptr + batch_idx + 1)
+    tok_n = cu_end - cu_start
+    if tok_n <= 0:
         return
+    write_n = tl.minimum(tok_n, WRITE_PER_BATCH)
+    if row_in_batch >= write_n:
+        return
+
+    src_id = cu_end - write_n + row_in_batch
+
+    slot = tl.load(state_slot_per_seq_ptr + batch_idx)
     pos = tl.load(positions_ptr + src_id)
-    bid = tl.load(batch_id_per_token_ptr + src_id)
-    slot = tl.load(state_slot_per_seq_ptr + bid)
     ring_idx = pos % cache_size
 
     d_offsets = tl.arange(0, BLOCK_D)
@@ -103,101 +114,105 @@ def _swa_write_kernel(
 
 def swa_write(
     kv: torch.Tensor,
-    write_indices: torch.Tensor,
     positions: torch.Tensor,
-    batch_id_per_token: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
     state_slot_per_seq: torch.Tensor,
     swa_kv: torch.Tensor,
     cache_size: int,
+    write_per_batch: int,
 ) -> None:
-    """In-place write
-    `swa_kv[state_slot_per_seq[bid], pos % cache_size, :] = kv[r, :]` for
-    each `r = write_indices[pid]` (skip pid where `write_indices[pid] < 0`).
+    """In-place write `swa_kv[state_slot_per_seq[b], pos % cache_size, :] = kv[r, :]`
+    for the last `min(tok_n_b, write_per_batch)` tokens of every seq
+    `b ∈ [0, bs)` this fwd, where `tok_n_b = cu_seqlens_q[b+1] - cu_seqlens_q[b]`.
+    `bs = state_slot_per_seq.shape[0]`.
 
-    Per-token quantities (`pos`, `bid`) are gathered inside the kernel via
-    `positions[r]` / `batch_id_per_token[r]`; per-seq `state_slot_per_seq`
-    is looked up via `bid`. Caller passes only stable forward_vars buffers
-    (no captured-region alloc, no per-token slot alias).
+    The kernel derives `r` from `cu_seqlens_q` diff inside the kernel,
+    eliminating the prior `write_indices` GPU staging buffer (which had a DMA
+    tearing race when its CPU mirror was rewritten by the next fwd before
+    the H2D for the current fwd had completed; see `_swa_write_kernel` doc).
 
     Args:
-        kv: [T, head_dim] full per-fwd KV (BF16). Stable buffer (slice or alias).
-        write_indices: [W] int — src row ids to write. Sentinel=-1 skipped.
-            `W` may be `total_tokens` (decode/MTP, every row real) or
-            `num_write` (long-prefill compact) or padded with -1 trailing
-            sentinels (CG fixed-grid).
-        positions: [T] int — full forward_vars["positions"].
-        batch_id_per_token: [T] int — v4_batch_id_per_token mapping.
-        state_slot_per_seq: [bs] int — per-seq state cache slot.
-        swa_kv: [num_slots, cache_size, head_dim] in-place ring buffer.
+        kv: [T, head_dim] per-fwd KV (BF16). `T = cu_seqlens_q[bs]`.
+        positions: [T'] int — full forward_vars["positions"] (`T' >= T`).
+        cu_seqlens_q: [bs+1] int — exact size (`bs == state_slot_per_seq.shape[0]`).
+        state_slot_per_seq: [bs] int — per-seq state cache slot. Its
+            `shape[0]` is the grid X dim and source-of-truth for `bs`.
+        swa_kv: [num_slots, cache_size, head_dim] ring buffer.
         cache_size: ring-slot count = `window_size + max_spec_steps`.
-            For non-MTP this equals `window_size` and the kernel is bytewise
-            identical to the pre-MTP behavior.
+        write_per_batch: `min(max_q_len, cache_size)` — max tokens written
+            per seq this fwd (grid y dim, kernel `constexpr`).
     """
     assert kv.dim() == 2, f"kv must be [T, D], got {kv.shape}"
-    assert write_indices.dim() == 1
     assert positions.dim() == 1
-    assert batch_id_per_token.dim() == 1
     assert state_slot_per_seq.dim() == 1
+    bs = state_slot_per_seq.shape[0]
+    assert cu_seqlens_q.dim() == 1 and cu_seqlens_q.shape[0] >= bs + 1
     assert swa_kv.dim() == 3, f"swa_kv must be [S, C, D], got {swa_kv.shape}"
     T, head_dim = kv.shape
     assert positions.shape[0] >= T, f"positions {positions.shape[0]} < kv T={T}"
-    assert (
-        batch_id_per_token.shape[0] >= T
-    ), f"batch_id_per_token {batch_id_per_token.shape[0]} < kv T={T}"
     assert (
         swa_kv.shape[1] == cache_size
     ), f"swa_kv ring dim {swa_kv.shape[1]} != cache_size {cache_size}"
     assert swa_kv.shape[2] == head_dim
     assert kv.is_contiguous() and swa_kv.is_contiguous()
-
-    W = write_indices.shape[0]
-    if W == 0:
-        return
+    assert (
+        bs > 0 and write_per_batch > 0
+    ), f"bs={bs}, write_per_batch={write_per_batch} must be positive"
 
     # head_dim is small (e.g. 64-128 for V4 SWA layer), so a single Triton
     # block per token covers it. Round up to the next power of two for tl.
     BLOCK_D = triton.next_power_of_2(head_dim)
-    grid = (W,)
+    grid = (bs, write_per_batch)
 
     _swa_write_kernel[grid](
         kv,
-        write_indices,
         positions,
-        batch_id_per_token,
+        cu_seqlens_q,
         state_slot_per_seq,
         swa_kv,
         swa_kv.stride(0),
         swa_kv.stride(1),
         head_dim,
         cache_size,
+        WRITE_PER_BATCH=write_per_batch,
         BLOCK_D=BLOCK_D,
     )
 
 
 def swa_write_reference(
     kv: torch.Tensor,
-    write_indices: torch.Tensor,
     positions: torch.Tensor,
-    batch_id_per_token: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
     state_slot_per_seq: torch.Tensor,
     swa_kv: torch.Tensor,
     cache_size: int,
+    write_per_batch: int,
 ) -> None:
     """Pure-PyTorch reference equivalent of `swa_write`. For tests / dump-bisect.
 
-    Mirrors the kernel: filter sentinel rows, gather kv/positions/batch_id by
-    write_indices, look up state slot via batch_id, ring-buffer write.
+    Mirrors the kernel: for each seq `b ∈ [0, bs)`
+    (`bs = state_slot_per_seq.shape[0]`), take the last
+    `min(cu_seqlens_q[b+1] - cu_seqlens_q[b], write_per_batch)` rows of `kv`
+    for that seq (via `cu_seqlens_q[b+1] - N + arange(N)`), look up state
+    slot, ring write.
     """
-    keep = write_indices >= 0
-    src_ids = write_indices[keep].long()
-    if src_ids.numel() == 0:
-        return
-    src_kv = kv[src_ids]
-    src_pos = positions[src_ids]
-    bids = batch_id_per_token[src_ids].long()
-    slots = state_slot_per_seq[bids].long()
-    ring_idx = src_pos % cache_size
-    swa_kv[slots, ring_idx] = src_kv
+    bs = state_slot_per_seq.shape[0]
+    cu_cpu = cu_seqlens_q[: bs + 1].tolist()
+    for b in range(bs):
+        cu_start = int(cu_cpu[b])
+        cu_end = int(cu_cpu[b + 1])
+        tok_n = cu_end - cu_start
+        write_n = min(tok_n, write_per_batch)
+        if write_n <= 0:
+            continue
+        src_ids = torch.arange(
+            cu_end - write_n, cu_end, dtype=torch.long, device=kv.device
+        )
+        src_kv = kv[src_ids]
+        src_pos = positions[src_ids]
+        slot = int(state_slot_per_seq[b].item())
+        ring_idx = src_pos % cache_size
+        swa_kv[slot, ring_idx] = src_kv
 
 
 # === Unified Compressor state save (plan path) ==========================

--- a/atom/model_ops/v4_kernels/state_writes.py
+++ b/atom/model_ops/v4_kernels/state_writes.py
@@ -250,7 +250,9 @@ def _update_compressor_states_kernel(
     score_state_slot_stride,
     score_state_pos_stride,
     dim,
-    STATE_SIZE: tl.constexpr,  # = 2*RATIO if OVERLAP else RATIO
+    STATE_SIZE: tl.constexpr,  # ring buffer modulo = kv_state.shape[1] (≥ K_pool;
+    #   V4-Pro spec decode: K_pool + max_spec_steps to keep R's rejected writes
+    #   out of R+1's read window; non-spec or pre-spec models: exactly K_pool)
     OVERLAP: tl.constexpr,
     RATIO: tl.constexpr,
     BLOCK_D: tl.constexpr,
@@ -320,20 +322,25 @@ def update_compressor_states(
     overlap: bool,
 ) -> None:
     """In-place update of Compressor's per-request `kv_state`/`score_state`
-    ring buffer (size `2*ratio` for overlap CSA, `ratio` for HCA), driven by
-    a SGLang-style packed `write_plan`.
+    ring buffer (size ≥ `K_pool = (1+overlap)*ratio`; V4-Pro widens to
+    `K_pool + max_spec_steps` for spec decode, keeps `K_pool` for non-spec),
+    driven by a SGLang-style packed `write_plan`.
 
     The plan is pre-filtered on the host to include only tokens whose
-    `position` falls in the per-seq "last STATE_SIZE absolute positions"
-    window — the kernel writes unconditionally, no in-kernel mask.
+    `position` falls in the per-seq "last K_pool absolute positions" window
+    (`write_starts = max(0, context_lens - K_pool)` in `make_compress_plans`)
+    — the kernel writes unconditionally, no in-kernel mask. Note that the
+    write window is K_pool, NOT STATE_SIZE; the extra STATE_SIZE - K_pool
+    slots exist purely as aliasing slack for spec rollback (see
+    `csa_main_state_shape` comment in `deepseek_v4_attn.py`).
 
     Args:
       kv:           [N, dim] flat batched KV (typically fp32 or bf16, cast inside).
       score:        [N, dim] flat batched score (NOT pre-added with ape;
                     kernel fuses ape addition).
       ape:          [ratio, dim] absolute position embedding.
-      kv_state:     [num_slots, S, dim] in-place ring buffer.
-                    S = 2*ratio if overlap else ratio.
+      kv_state:     [num_slots, S, dim] in-place ring buffer. S ≥ K_pool;
+                    V4-Pro: S = K_pool + max_spec_steps.
       score_state:  same shape as kv_state.
       write_plan:   [num_write, 4] int32 — packed (ragged_id, batch_id,
                     position, _); each row = one token to write.

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -819,11 +819,13 @@ class Compressor(nn.Module):
         # valid tensor; afterwards `DeepseekV4AttentionMetadataBuilder.
         # build_kv_cache_tensor` setattr-replaces these attributes with
         # views of the per-request cache pool whose second dim is the real
-        # ring_size = coff*ratio + max_spec_steps + 1 (spec) or coff*ratio
-        # (non-spec). The 1-slot init buffers (≈9 MB total across all layers)
-        # are GC'd once replaced before any real kernel call, so the
-        # placeholder's smaller second dim never actually flows through the
-        # kernel's `state_size >= K_pool` assertion.
+        # ring_size = K_pool + max_spec_steps where K_pool = coff * ratio
+        # (non-spec collapses to K_pool since max_spec_steps == 0; causal
+        # writes guarantee no read-before-overwrite alias). The 1-slot init
+        # buffers (≈9 MB total across all layers) are GC'd once replaced
+        # before any real kernel call, so the placeholder's smaller second
+        # dim never actually flows through the kernel's
+        # `state_size >= K_pool` assertion.
         self.register_buffer(
             "kv_state",
             torch.zeros(

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1885,22 +1885,31 @@ class DeepseekV4Attention(nn.Module):
         if attn_md.state is AttnState.DECODE:
             kv_indptr = attn_md.kv_indptr_csa
             kv_indices = attn_md.kv_indices_csa
+            # Decode: skip = `actual_swa_count[t]` = min(pos+1, win) — derived
+            # inline by the kernel, so the per-token buffer + its CPU build +
+            # H2D in `_attach_v4_paged_decode_meta` are skipped.
+            skip_buf = None
+            window_size = self.window_size
         else:
             kv_indptr = attn_md.kv_indptr_prefix_csa
             kv_indices = attn_md.kv_indices_prefix_csa
+            # Prefill: skip = `prefix_swa_count[t]` (chunked-prefill: depends
+            # on `chunk_start[bid]`, not derivable from `positions[t]` alone)
+            # — kernel loads from the per-token buffer.
+            skip_buf = attn_md.skip_prefix_len_csa
+            window_size = 0
 
         csa_translate_pack(
             topk_local_raw,
             attn_md.block_tables,
-            attn_md.n_committed_csa_per_seq,
             positions,
             kv_indptr,
             attn_md.batch_id_per_token,
-            attn_md.skip_prefix_len_csa,
+            skip_buf,
             kv_indices,
             swa_pages=attn_md.swa_pages,
             csa_block_capacity=csa_block_capacity,
-            ratio=4,
+            window_size=window_size,
         )
 
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -658,22 +658,29 @@ class _V4RoPE(nn.Module):
         self.beta_fast = beta_fast
         self.beta_slow = beta_slow
         self.dtype = dtype
-        # Cos/sin caches are fetched lazily on first forward via the
-        # device-keyed `_build_cos_sin_cache`; this lets all 62 layers share
-        # one cache per (rope params, device) instead of registering 62
-        # buffers that .to() would each clone onto GPU.
-
-    def _caches(self, device: torch.device) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _build_cos_sin_cache(
-            self.rotary_dim,
-            self.max_seq_len,
-            self.base,
-            self.factor,
-            self.original_seq_len,
-            self.beta_fast,
-            self.beta_slow,
-            self.dtype,
-            device,
+        # Build cos/sin caches at __init__ via the lru_cached `_build_cos_sin_cache`
+        # and store as plain attributes — NOT `register_buffer`. ATOM wraps model
+        # construction in `torch.set_default_device(self.device)`, so the lru_cache
+        # builds directly on the current GPU device and is shared across all 62
+        # layers with the same rope params (V4 has only 3 distinct sets:
+        # HCA/CSA/Dense). Plain-attribute storage skips PyTorch's per-buffer
+        # `.to()` machinery, which would clone each layer's reference into a
+        # separate GPU tensor (62 × 256 MiB ≈ 16 GiB at V4-Pro's
+        # max_position_embeddings=1M — verified OOM if we register_buffer).
+        # Tradeoff vs aiter/sglang/vllm: those engines accept the per-layer
+        # clone because their target models have much smaller max-pos; V4's 1M
+        # context window makes dedup essential. Forward path still does zero
+        # cache lookups — only attribute reads.
+        self.cos_cache, self.sin_cache = _build_cos_sin_cache(
+            rotary_dim,
+            max_seq_len,
+            base,
+            factor,
+            original_seq_len,
+            beta_fast,
+            beta_slow,
+            dtype,
+            torch.empty(0).device,
         )
 
     def freqs_for_positions(self, positions: torch.Tensor) -> torch.Tensor:
@@ -682,9 +689,8 @@ class _V4RoPE(nn.Module):
         Used by the attention output's inverse RoPE step.
         Returns: complex64 [num_tokens, rotary_dim // 2].
         """
-        cos_cache, sin_cache = self._caches(positions.device)
-        cos = cos_cache.index_select(0, positions).squeeze(-2).squeeze(-2).float()
-        sin = sin_cache.index_select(0, positions).squeeze(-2).squeeze(-2).float()
+        cos = self.cos_cache.index_select(0, positions).squeeze(-2).squeeze(-2).float()
+        sin = self.sin_cache.index_select(0, positions).squeeze(-2).squeeze(-2).float()
         return torch.complex(cos, sin)
 
     def forward(
@@ -695,7 +701,6 @@ class _V4RoPE(nn.Module):
     ) -> None:
         """In-place RoPE on `query` (and `key` if given). All inputs are the
         rope-slice only (`head_size == rotary_dim`)."""
-        cos, sin = self._caches(query.device)
         # rotate_style=1 → GPT-J / interleaved (matches V4's view_as_complex).
         rotate_style = 1
         num_tokens = positions.numel()
@@ -703,8 +708,8 @@ class _V4RoPE(nn.Module):
             aiter.rope_cached_positions_2c_fwd_inplace(
                 query.view(1, num_tokens, -1, self.rotary_dim),
                 key.view(1, num_tokens, -1, self.rotary_dim),
-                cos,
-                sin,
+                self.cos_cache,
+                self.sin_cache,
                 positions.view(1, num_tokens),
                 rotate_style,
                 reuse_freqs_front_part=True,
@@ -713,8 +718,8 @@ class _V4RoPE(nn.Module):
         else:
             aiter.rope_cached_positions_fwd_inplace(
                 query.view(1, num_tokens, -1, self.rotary_dim),
-                cos,
-                sin,
+                self.cos_cache,
+                self.sin_cache,
                 positions.view(1, num_tokens),
                 rotate_style,
                 reuse_freqs_front_part=True,
@@ -726,8 +731,7 @@ class _V4RoPE(nn.Module):
 
         ``x`` must be the rope-slice only (last dim == rotary_dim).
         """
-        cos, sin = self._caches(x.device)
-        inverse_rope_inplace(x, cos, sin, positions)
+        inverse_rope_inplace(x, self.cos_cache, self.sin_cache, positions)
 
 
 # ---------------------------------------------------------------------------
@@ -906,7 +910,7 @@ class Compressor(nn.Module):
         # PREVIOUS-fwd. `update_compressor_states` overwrites them with this
         # fwd's data for the NEXT fwd's overlap — must run AFTER the fused
         # kernel.
-        cos_cache, sin_cache = self.rotary_emb._caches(x.device)
+        cos_cache, sin_cache = self.rotary_emb.cos_cache, self.rotary_emb.sin_cache
         # Quant path triggers when the bound cache is FP8 (Indexer-inner).
         # `self.cache_scale` is bound alongside `self.kv_cache` by the V4
         # builder when the cache is FP8 (strided fp32 view of the per-block
@@ -1078,8 +1082,9 @@ class Indexer(nn.Module):
         )
         # self.rotary_emb(positions, q[..., -rd:])
         # q = rotate_activation(q)
-        cos, sin = self.rotary_emb._caches(q.device)
-        rope_rotate_activation(q, q, cos, sin, positions, rd)
+        rope_rotate_activation(
+            q, q, self.rotary_emb.cos_cache, self.rotary_emb.sin_cache, positions, rd
+        )
 
         # FP8 quant Q (still online — Q is recomputed each fwd, no cache).
         # `_fp8_quant_func` / `_weights_scale` precomputed in __init__.
@@ -1558,34 +1563,57 @@ class DeepseekV4Attention(nn.Module):
         # batched-FP8 kernel. See attention_mla.py:211 for reference.
         self.wo_a.quant_type = QuantType.No
 
-    def _launch_compressors_async(self, x, plan, state_slot_mapping, block_tables):
+    def maybe_compressors_async(
+        self, x, plan, state_slot_mapping, block_tables
+    ) -> bool:
         """Fire Compressor(s) on side streams, return immediately.
 
         Main Compressor → alt_stream (CSA + HCA).
         Indexer Compressor → compress_stream (CSA only).
         Waits resolve instantly: side streams ~25us, main Q/KV chain ~87us."""
-        current_stream = get_forward_context().main_stream
-        if self.compressor is not None and self.alt_stream is not None:
-            self.alt_stream.wait_stream(current_stream)
-        if self.indexer is not None and self.compress_stream is not None:
-            self.compress_stream.wait_stream(current_stream)
+        fc = get_forward_context()
+        current_stream = fc.main_stream
+        use_async_compress = self._use_async_compress and fc.in_hipgraph
+        has_compressor = self.compressor is not None
+        has_indexer = self.indexer is not None
+        if use_async_compress:
+            if has_compressor:
+                self.alt_stream.wait_stream(current_stream)
+            if has_indexer:
+                self.compress_stream.wait_stream(current_stream)
 
-        if self.compressor is not None and self.alt_stream is not None:
-            with torch.cuda.stream(self.alt_stream):
+            if has_compressor:
+                with torch.cuda.stream(self.alt_stream):
+                    self.compressor(
+                        x,
+                        plan=plan,
+                        state_slot_mapping=state_slot_mapping,
+                        block_tables=block_tables,
+                    )
+            if has_indexer:
+                with torch.cuda.stream(self.compress_stream):
+                    self.indexer.compressor(
+                        x,
+                        plan=plan,
+                        state_slot_mapping=state_slot_mapping,
+                        block_tables=block_tables,
+                    )
+        else:
+            if has_compressor:
                 self.compressor(
                     x,
                     plan=plan,
                     state_slot_mapping=state_slot_mapping,
                     block_tables=block_tables,
                 )
-        if self.indexer is not None and self.compress_stream is not None:
-            with torch.cuda.stream(self.compress_stream):
+            if has_indexer:
                 self.indexer.compressor(
                     x,
                     plan=plan,
                     state_slot_mapping=state_slot_mapping,
                     block_tables=block_tables,
                 )
+        return use_async_compress
 
     def forward(
         self,
@@ -1616,38 +1644,15 @@ class DeepseekV4Attention(nn.Module):
         # with a zero output of the correct shape; downstream layers compile
         # on a real fwd. swa_write / Compressor / Indexer are also skipped to
         # avoid touching unbound state caches.
-        if get_forward_context().context.is_dummy_run:
+        fc = get_forward_context()
+        if fc.context.is_dummy_run:
+            return torch.zeros_like(x)
+        if os.environ.get("ATOM_V4_BYPASS_ATTN") == "1":
             return torch.zeros_like(x)
         num_tokens = x.size(0)
-        # Async-compress (alt_stream main Compressor + compress_stream
-        # indexer.compressor) is only safe inside CUDAGraph capture: graph
-        # records the fork-join edges and replay re-uses the same stream
-        # layout. In eager mode the side-stream launches accumulate across
-        # 60 layers and deadlock the hipStream queue when the first splitk
-        # GEMM kernel allocates its workspace — verified hang on both
-        # small (~800-token) and large (>2k-token) prefill batches in
-        # eager. Replay does not re-execute this Python code so the flag
-        # doesn't matter then.
-        use_async_compress = (
-            self._use_async_compress and get_forward_context().in_hipgraph
-        )
-        # SWA ring-slot count per req (= window_size + max_spec_steps for
-        # MTP-aware cache). Sourced from the bound cache to avoid threading
-        # `max_spec_steps` through V4Args; for non-MTP this equals
-        # `self.window_size`. Used as the modulo in `swa_write` (and matches
-        # the per-row case_c modulo in window_topk).
         cache_size = self.swa_kv.shape[1]
         ratio = self.compress_ratio
         rd = self.rope_head_dim
-
-        # Idempotent one-time plumb of rotary_emb into compressor / indexer
-        # (and the indexer's inner compressor). `rotary_emb` is set by the
-        # owning layer after __init__, so this can't move into __init__.
-        if self.compress_ratio and self.compressor.rotary_emb is None:
-            self.compressor.rotary_emb = self.rotary_emb
-            if self.indexer is not None:
-                self.indexer.rotary_emb = self.rotary_emb
-                self.indexer.compressor.rotary_emb = self.rotary_emb
 
         # ===== Per-fwd metadata (built once in prepare_prefill/decode). =====
         # All per-fwd state read once. Production prepare_decode/prefill
@@ -1655,12 +1660,12 @@ class DeepseekV4Attention(nn.Module):
         # (`_populate_state_slot_mapping` falls back to slot 0).
         # Cast to V4 typed metadata so V4-specific attribute access (v4_*,
         # compress_plans, swa_write_indices, ...) is well-typed for pyright.
-        attn_md = cast("AttentionMetaData_DSV4", get_forward_context().attn_metadata)
+        attn_md = cast("AttentionMetaData_DSV4", fc.attn_metadata)
         compress_plans = attn_md.compress_plans
-        swa_write_indices = attn_md.swa_write_indices
         v4_batch_id_per_token = attn_md.batch_id_per_token
         block_tables_gpu = attn_md.block_tables
         state_slot_mapping = attn_md.state_slot_mapping
+        plan_for_layer = compress_plans[ratio] if ratio else None
 
         # ----- Batched ops on full flat tensors -----
         # `_V4_FORCE_UE8M0_QUANT` (module-level): round-trip x/qr to ue8m0-FP8
@@ -1670,20 +1675,10 @@ class DeepseekV4Attention(nn.Module):
             x = x.clone()
             act_quant_inplace(x, 128, "ue8m0")
 
-        attn_md = cast("AttentionMetaData_DSV4", get_forward_context().attn_metadata)
-        compress_plans = attn_md.compress_plans
-        swa_write_indices = attn_md.swa_write_indices
-        v4_batch_id_per_token = attn_md.batch_id_per_token
-        block_tables_gpu = attn_md.block_tables
-        state_slot_mapping = attn_md.state_slot_mapping
-        plan_for_layer = compress_plans[ratio] if ratio else None
-
         # ===== Triple-stream: Q/KV path + both Compressors in parallel =====
-        current_stream = get_forward_context().main_stream
-        if use_async_compress:
-            self._launch_compressors_async(
-                x, plan_for_layer, state_slot_mapping, block_tables_gpu
-            )
+        use_async_compress = self.maybe_compressors_async(
+            x, plan_for_layer, state_slot_mapping, block_tables_gpu
+        )
 
         # ----- Q/KV projections (main stream) -----
         qkv_a = self.wqkv_a(x)
@@ -1699,17 +1694,7 @@ class DeepseekV4Attention(nn.Module):
             # kernel. KV RMSNorm stays out (kernel doesn't apply weighted norm
             # to kv); the standalone swa_write below is gated off when this
             # path runs since the kernel already wrote the window slots.
-            cos_cache, sin_cache = self.rotary_emb._caches(x.device)
-            if swa_write_indices is not None:
-                write_indices = swa_write_indices
-                batch_id = v4_batch_id_per_token
-                slot_map = state_slot_mapping
-                swa_kv_buf = self.swa_kv
-            else:
-                write_indices = None
-                batch_id = None
-                slot_map = None
-                swa_kv_buf = None
+            cos_cache, sin_cache = self.rotary_emb.cos_cache, self.rotary_emb.sin_cache
             q = fused_qk_norm_rope_swa_write(
                 q,
                 kv_pre,
@@ -1722,10 +1707,10 @@ class DeepseekV4Attention(nn.Module):
                 self.kv_norm.weight,
                 self.eps,
                 cache_size,
-                swa_write_indices=write_indices,
-                batch_id_per_token=batch_id,
-                state_slot_mapping=slot_map,
-                swa_kv=swa_kv_buf,
+                swa_write_indices=swa_write_indices,
+                batch_id_per_token=v4_batch_id_per_token,
+                state_slot_mapping=state_slot_mapping,
+                swa_kv=self.swa_kv,
             )
         else:
             # Flat q_flat is [num_tokens, n_local_heads * head_dim]; DualRMSNorm
@@ -1740,26 +1725,15 @@ class DeepseekV4Attention(nn.Module):
         if _V4_USE_REF_QUANT:
             act_quant_inplace(kv[..., :-rd], 64, self.scale_fmt)
 
-        # ===== Compressor + Indexer =====
-        if not use_async_compress:
+        # HCA
+        if use_async_compress:
+            current_stream = fc.main_stream
             if self.compressor is not None:
-                self.compressor(
-                    x,
-                    plan=plan_for_layer,
-                    state_slot_mapping=state_slot_mapping,
-                    block_tables=block_tables_gpu,
-                )
-                if self.indexer is not None:
-                    self.indexer.compressor(
-                        x,
-                        plan=plan_for_layer,
-                        state_slot_mapping=state_slot_mapping,
-                        block_tables=block_tables_gpu,
-                    )
-        if self.indexer is not None:
-            if use_async_compress:
-                current_stream.wait_stream(self.compress_stream)
                 current_stream.wait_stream(self.alt_stream)
+            if self.indexer is not None:
+                current_stream.wait_stream(self.compress_stream)
+        # ===== Compressor + Indexer =====
+        if self.indexer is not None:
             indexer_topk_batched = self.indexer.forward_batched(
                 x_full=x,
                 qr_full=qr,
@@ -1772,8 +1746,6 @@ class DeepseekV4Attention(nn.Module):
             #   - prefill buffer `kv_indices_prefix_csa` (otherwise)
             # `_fill_csa_paged_compress` dispatches internally on is_pure_decode.
             self._fill_csa_paged_compress(attn_md, indexer_topk_batched, num_tokens)
-        elif use_async_compress:
-            current_stream.wait_stream(self.alt_stream)
 
         # ===== Sparse attention dispatch =====
         # Two paths over the unified KV pool. The order of `swa_write` vs
@@ -1800,12 +1772,12 @@ class DeepseekV4Attention(nn.Module):
             if not self.use_fuse_qk_norm_rope_swa_write:
                 swa_write(
                     kv,
-                    swa_write_indices,
                     positions,
-                    v4_batch_id_per_token,
+                    attn_md.cu_seqlens_q,
                     state_slot_mapping,
                     self.swa_kv,
                     cache_size,
+                    min(attn_md.max_seqlen_q, cache_size),
                 )
             if ratio == 0:
                 kv_indices = attn_md.kv_indices_swa
@@ -1853,12 +1825,12 @@ class DeepseekV4Attention(nn.Module):
             # ring slots `pos % cache_size` for positions in this chunk's tail).
             swa_write(
                 kv,
-                swa_write_indices,
                 positions,
-                v4_batch_id_per_token,
+                attn_md.cu_seqlens_q,
                 state_slot_mapping,
                 self.swa_kv,
                 cache_size,
+                min(attn_md.max_seqlen_q, cache_size),
             )
 
         # Inverse RoPE on output's rope dims to remove absolute-position

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -147,7 +147,6 @@ def _fused_qk_norm_rope_swa_write_fake(
     kv_weight: torch.Tensor,
     eps: float,
     win: int,
-    swa_write_indices: Optional[torch.Tensor] = None,
     batch_id_per_token: Optional[torch.Tensor] = None,
     state_slot_mapping: Optional[torch.Tensor] = None,
     swa_kv: Optional[torch.Tensor] = None,
@@ -173,18 +172,16 @@ def fused_qk_norm_rope_swa_write(
     kv_weight: torch.Tensor,
     eps: float,
     win: int,
-    swa_write_indices: Optional[torch.Tensor] = None,
     batch_id_per_token: Optional[torch.Tensor] = None,
     state_slot_mapping: Optional[torch.Tensor] = None,
     swa_kv: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Fused wq_b GEMM (a8w8 1x128 blockscale) + per-head RMSNorm-nw + RoPE on
-    q/kv tail (+ SWA write) in a single triton kernel.
+    q/kv tail in a single triton kernel.
 
     `kv` must already be kv_norm-applied; the kernel does not weight-norm kv.
-    `kv` is RoPE-mutated in place. When all SWA tensors are provided, the
-    kernel also writes the windowed kv into `swa_kv`; the caller must then
-    skip the standalone `swa_write` for those rows.
+    `kv` is RoPE-mutated in place. SWA write is not performed here — callers
+    that need it must invoke the standalone `swa_write` after this call.
     """
     num_tokens = q.shape[0]
     if num_tokens <= 64:
@@ -207,7 +204,7 @@ def fused_qk_norm_rope_swa_write(
             q_out=q_out,
             is_neox=False,
             dtype=torch.bfloat16,
-            write_indices=swa_write_indices,
+            write_indices=None,
             batch_id_per_token=batch_id_per_token,
             state_slot_mapping=state_slot_mapping,
             swa_kv=swa_kv,
@@ -227,16 +224,6 @@ def fused_qk_norm_rope_swa_write(
             reuse_freqs_front_part=True,
             nope_first=False,
         )
-        if swa_write_indices is not None:
-            swa_write(
-                kv,
-                swa_write_indices,
-                positions,
-                batch_id_per_token,
-                state_slot_mapping,
-                swa_kv,
-                win,
-            )
     return q_out
 
 
@@ -1661,7 +1648,7 @@ class DeepseekV4Attention(nn.Module):
         # always populates these; warmup goes through the same path
         # (`_populate_state_slot_mapping` falls back to slot 0).
         # Cast to V4 typed metadata so V4-specific attribute access (v4_*,
-        # compress_plans, swa_write_indices, ...) is well-typed for pyright.
+        # compress_plans, ...) is well-typed for pyright.
         attn_md = cast("AttentionMetaData_DSV4", fc.attn_metadata)
         compress_plans = attn_md.compress_plans
         v4_batch_id_per_token = attn_md.batch_id_per_token
@@ -1710,7 +1697,6 @@ class DeepseekV4Attention(nn.Module):
                 self.kv_norm.weight,
                 self.eps,
                 cache_size,
-                swa_write_indices=swa_write_indices,
                 batch_id_per_token=v4_batch_id_per_token,
                 state_slot_mapping=state_slot_mapping,
                 swa_kv=self.swa_kv,

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1723,6 +1723,16 @@ class DeepseekV4Attention(nn.Module):
             # q [S, H, D] / kv [S, head_dim] — rotary_emb internally unsqueezes
             # to (1, num_tokens, ...) for aiter's per-position rope kernel.
             self.rotary_emb(positions, q[..., -rd:], kv[..., -rd:])
+            if is_decode:
+                swa_write(
+                    kv,
+                    positions,
+                    attn_md.cu_seqlens_q,
+                    state_slot_mapping,
+                    self.swa_kv,
+                    cache_size,
+                    min(attn_md.max_seqlen_q, cache_size),
+                )
         if _V4_USE_REF_QUANT:
             act_quant_inplace(kv[..., :-rd], 64, self.scale_fmt)
 
@@ -1743,43 +1753,22 @@ class DeepseekV4Attention(nn.Module):
             )
             # Translate seq-local topk → physical paged offsets and write into
             # the CSA section of either:
-            #   - decode buffer `kv_indices_csa` (is_pure_decode)
+            #   - decode buffer `kv_indices_csa` (state is DECODE)
             #   - prefill buffer `kv_indices_prefix_csa` (otherwise)
-            # `_fill_csa_paged_compress` dispatches internally on is_pure_decode.
-            self._fill_csa_paged_compress(attn_md, indexer_topk_batched, num_tokens)
+            # `_fill_csa_paged_compress` dispatches internally on state.
+            self._fill_csa_paged_compress(
+                attn_md, indexer_topk_batched, positions, num_tokens
+            )
 
         # ===== Sparse attention dispatch =====
-        # Two paths over the unified KV pool. The order of `swa_write` vs
-        # `sparse_attn` differs because the two kernels read SWA differently:
-        #
-        # decode (is_pure_decode==True):
-        #   `paged_decode` reads SWA from `unified_kv` ring slot
-        #   `pos % cache_size`. The current decode token's K must be present
-        #   in the ring before attn fires, otherwise the token can't see its
-        #   own K. So:
-        #     swa_write → paged_decode
-        #
-        # prefill / mixed (is_pure_decode==False):
-        #   `paged_prefill` reads in-chunk K from per-fwd `kv` tensor (extend
-        #   region) and prior-chunk K from `unified_kv` ring (prefix region).
-        #   `swa_write` writes the LAST `cache_size` tokens of THIS fwd into
-        #   ring slots `pos % cache_size`, which OVERLAP with prior-chunk
-        #   slots that the prefix SWA region wants to read (chunked prefill):
-        #     paged_prefill → swa_write
-        #   Pure prefill (chunk_start==0) has prefix_swa_count==0 so no prior
-        #   ring read; swa_write order is irrelevant in that subcase.
+        # Decode SWA write fires upstream of this dispatch — either inside
+        # `fused_qk_norm_rope_swa_write` (fused path above) or via the
+        # explicit `swa_write` call in the non-fused `else` branch — so
+        # `paged_decode` always sees the current token's K in the ring.
+        # Prefill does NOT call swa_write from this layer (prior-chunk K is
+        # read from `unified_kv` ring via the kv_indices_prefix_swa region).
         q_sa = q.contiguous()
         if is_decode:
-            if not self.use_fuse_qk_norm_rope_swa_write:
-                swa_write(
-                    kv,
-                    positions,
-                    attn_md.cu_seqlens_q,
-                    state_slot_mapping,
-                    self.swa_kv,
-                    cache_size,
-                    min(attn_md.max_seqlen_q, cache_size),
-                )
             if ratio == 0:
                 kv_indices = attn_md.kv_indices_swa
                 kv_indptr = attn_md.kv_indptr_swa
@@ -1850,6 +1839,7 @@ class DeepseekV4Attention(nn.Module):
         self,
         attn_md,
         topk_local_raw: torch.Tensor,
+        positions: torch.Tensor,
         total_tokens: int,
     ) -> None:
         """Per-CSA-layer: translate indexer raw `topk_in_seq` → physical paged
@@ -1857,8 +1847,8 @@ class DeepseekV4Attention(nn.Module):
         active prefix buffer.
 
         Dispatch:
-          - is_pure_decode → write into decode buffer `kv_indices_csa`,
-                             skip = `window_size` (full SWA prefix per token)
+          - state is DECODE → write into decode buffer `kv_indices_csa`,
+                              skip = `window_size` (full SWA prefix per token)
           - prefill / mixed → write into prefill buffer `kv_indices_prefix_csa`,
                               skip = per-token `prefix_swa_count[t]`
 
@@ -1871,14 +1861,19 @@ class DeepseekV4Attention(nn.Module):
 
         Fully fused into one triton kernel — no [T, index_topk] intermediates,
         no PyTorch fancy index. CG sentinel (batch_id=-1) and OOB clamp are
-        handled in-kernel; downstream paged_decode/paged_prefill kernels
-        strict-slice via `kv_indptr*`, so tail cols beyond `valid_k` are never
-        read and need no `-1` fill (CSA section was -1 pre-filled by builder).
+        handled in-kernel. The kernel derives per-token `valid_k` inline from
+        `(positions[t]+1)//ratio` clamped by `n_committed_csa[bid]` and
+        `index_topk`, matching Indexer's per-row visibility — so every
+        reserved CSA cell gets written and no `-1` sentinel pre-fill is needed.
 
         Args:
           topk_local_raw: [total_tokens, index_topk] int32 — RAW seq-local
-            output of `Indexer.forward_batched` (negative tails are sentinels;
-            csa_translate_pack skips them via `topk >= 0` write mask).
+            output of `Indexer.forward_batched`. The leading `valid_k[t]`
+            cells are always >= 0; trailing cells are -1 sentinels never
+            read by csa_translate_pack (filtered by `k_offs < valid_k`).
+          positions: [total_tokens] int — global token positions; forwarded
+            to csa_translate_pack so the kernel can compute per-token
+            `valid_k` inline.
         """
         # csa_block_capacity = block_size // ratio = 128 // 4 = 32.
         # Derived from constants (not `compressor.kv_cache.size(1)`) because
@@ -1898,12 +1893,14 @@ class DeepseekV4Attention(nn.Module):
             topk_local_raw,
             attn_md.block_tables,
             attn_md.n_committed_csa_per_seq,
+            positions,
             kv_indptr,
             attn_md.batch_id_per_token,
             attn_md.skip_prefix_len_csa,
             kv_indices,
             swa_pages=attn_md.swa_pages,
             csa_block_capacity=csa_block_capacity,
+            ratio=4,
         )
 
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -96,7 +96,7 @@ from atom.model_ops.v4_kernels import (
     swa_write,
     update_compressor_states,
 )
-from atom.utils.forward_context import get_forward_context
+from atom.utils.forward_context import AttnState, get_forward_context
 from atom.utils.decorators import support_torch_compile
 
 # ---------------------------------------------------------------------------
@@ -1688,7 +1688,8 @@ class DeepseekV4Attention(nn.Module):
         ), "_V4_FORCE_UE8M0_QUANT incompatible with fused q_norm quant (qr is already FP8)"
         qr, qr_scale = self.q_norm(q_lora)
         q = self.wq_b(qr, x_scale=qr_scale)
-        if attn_md.is_pure_decode and self.use_fuse_qk_norm_rope_swa_write:
+        is_decode = attn_md.state is AttnState.DECODE
+        if is_decode and self.use_fuse_qk_norm_rope_swa_write:
             # Fused: wq_b GEMM (a8w8 1x128 blockscale) + per-head RMSNorm-nw
             # + RoPE on q tail + RoPE on kv tail (+ SWA write) in one triton
             # kernel. KV RMSNorm stays out (kernel doesn't apply weighted norm
@@ -1768,7 +1769,7 @@ class DeepseekV4Attention(nn.Module):
         #   Pure prefill (chunk_start==0) has prefix_swa_count==0 so no prior
         #   ring read; swa_write order is irrelevant in that subcase.
         q_sa = q.contiguous()
-        if attn_md.is_pure_decode:
+        if is_decode:
             if not self.use_fuse_qk_norm_rope_swa_write:
                 swa_write(
                     kv,
@@ -1806,9 +1807,11 @@ class DeepseekV4Attention(nn.Module):
             elif ratio == 4:
                 kv_indices_prefix = attn_md.kv_indices_prefix_csa
                 kv_indptr_prefix = attn_md.kv_indptr_prefix_csa
-            else:  # ratio == 128
+            elif ratio == 128:
                 kv_indices_prefix = attn_md.kv_indices_prefix_hca
                 kv_indptr_prefix = attn_md.kv_indptr_prefix_hca
+            else:
+                raise ValueError(f"Unsupported compress_ratio {ratio}")
             o = sparse_attn_v4_paged_prefill(
                 q_sa,
                 self.unified_kv,
@@ -1884,7 +1887,7 @@ class DeepseekV4Attention(nn.Module):
         # warmup batches). Equivalent post-bind: `compressor.kv_cache.size(1)`.
         csa_block_capacity = _V4_BLOCK_SIZE // 4
 
-        if attn_md.is_pure_decode:
+        if attn_md.state is AttnState.DECODE:
             kv_indptr = attn_md.kv_indptr_csa
             kv_indices = attn_md.kv_indices_csa
         else:

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -456,9 +456,6 @@ class EagleProposer:
                         attn_metadata.__dict__[k] = v
                     if has_flat_kv:
                         # MLA/MHA path: slot derived from flat kv_indices.
-                        # V4 doesn't expose flat kv_indices and its kernels
-                        # don't read attn_metadata.slot_mapping (state-ring +
-                        # swa_write_indices instead), so the update is skipped.
                         slot_mapping[:] = kv_indices[kv_indptr[1 : bs + 1] - 1]
 
                     input_ids = new_draft_ids

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -441,6 +441,7 @@ class EagleProposer:
                     # Update context_lens for each draft step (needed by both
                     # MHA attention and MLA+sparse indexer)
                     attn_metadata.context_lens[:bs] += 1
+                    positions += 1
                     workinfos = self.runner.attn_metadata_builder.prepare_mtp_decode(
                         bs,
                         (
@@ -449,6 +450,7 @@ class EagleProposer:
                             else i0_max_seqlen_q
                         ),
                         attn_metadata.max_seqlen_k,
+                        positions,
                         only_update=do_attn_metadata_update,
                         num_reject_tokens=num_reject_tokens if i == 0 else None,
                     )
@@ -459,7 +461,6 @@ class EagleProposer:
                         slot_mapping[:] = kv_indices[kv_indptr[1 : bs + 1] - 1]
 
                     input_ids = new_draft_ids
-                    positions += 1
                     if ret_hidden_prenorm is not None:
                         hidden_states = (
                             torch.index_select(

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -83,6 +83,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use unified_attention (flash-style) for MHA paged/prefill attention instead
     # of pa_decode_gluon. Set to 1 to enable the unified_attention path.
     "ATOM_USE_UNIFIED_ATTN": lambda: os.getenv("ATOM_USE_UNIFIED_ATTN", "0") == "1",
+    # Force the Triton path for V4 sparse-paged-prefill attention; default backend
+    # is aiter's OPUS kernel (gfx950 fast path). Set to 1 to fall back to Triton
+    # (e.g. for debugging or on non-gfx950 builds).
+    "ATOM_FORCE_ATTN_TRITON": lambda: (os.getenv("ATOM_FORCE_ATTN_TRITON", "0") == "1"),
     # --- Plugin Mode ---
     "ATOM_DISABLE_VLLM_PLUGIN": lambda: (
         os.getenv("ATOM_DISABLE_VLLM_PLUGIN", "0").lower() == "1"

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -5,6 +5,7 @@ import logging
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
 
 import numpy as np
@@ -13,6 +14,29 @@ from atom.config import Config, KVCacheTensor, ParallelConfig
 
 if TYPE_CHECKING:
     from atom.plugin.attention import MetadataForPluginMode
+
+
+class AttnState(Enum):
+    """Attention dispatch state — controls which kv-indices buffers are built
+    and which forward branch fires.
+
+    Backends that distinguish only "decode vs prefill" can treat any
+    ``PREFILL_*`` value as prefill. Backends with chunked-prefill awareness
+    (e.g. V4) further distinguish ``PREFILL_NATIVE`` from ``PREFILL_PREFIX``.
+
+    - ``DECODE``: 1+K tokens/seq uniformly (decode + spec). Per-token decode
+      kv-indices buffers are valid; prefill prefix buffers may be stale.
+    - ``PREFILL_NATIVE``: fresh prefill — every seq starts at position 0 in
+      this fwd. No prior-chunk KV history to read; the prefix region is
+      empty per token.
+    - ``PREFILL_PREFIX``: chunked prefill — at least one seq has
+      ``chunk_start > 0`` and therefore reads its prior chunk's KV from
+      the paged history (e.g. V4 SWA ring via ``kv_indices_prefix_swa``).
+    """
+
+    DECODE = "decode"
+    PREFILL_NATIVE = "prefill_native"
+    PREFILL_PREFIX = "prefill_prefix"
 
 
 def _compute_chunked_local_num_tokens(
@@ -182,6 +206,13 @@ class AttentionMetaData:
     block_tables: Optional[torch.Tensor] = None
     dropout_p: float = 0.0
 
+    state: AttnState = AttnState.PREFILL_NATIVE
+    """One of `DECODE / PREFILL_NATIVE / PREFILL_PREFIX` — controls which
+    kv-indices buffers downstream forward branches read. Default is
+    `PREFILL_NATIVE`; every `prepare_*` path overrides explicitly.
+    Backends that don't need the NATIVE/PREFIX distinction can treat
+    `any PREFILL_*` as prefill. See ``AttnState`` for full semantics."""
+
     kv_indptr: Optional[torch.Tensor] = None
     kv_indices: Optional[torch.Tensor] = None
     kv_last_page_lens: Optional[torch.Tensor] = None
@@ -216,6 +247,7 @@ class AttentionMetaData:
         context_lens: Optional[torch.Tensor] = None,
         block_tables: Optional[torch.Tensor] = None,
         dropout_p: float = 0.0,
+        state: AttnState = AttnState.PREFILL_NATIVE,
         kv_indptr: Optional[torch.Tensor] = None,
         kv_indices: Optional[torch.Tensor] = None,
         kv_last_page_lens: Optional[torch.Tensor] = None,
@@ -249,6 +281,7 @@ class AttentionMetaData:
         self.context_lens = context_lens
         self.block_tables = block_tables
         self.dropout_p = dropout_p
+        self.state = state
         self.kv_indptr = kv_indptr
         self.kv_indices = kv_indices
         self.kv_last_page_lens = kv_last_page_lens

--- a/recipes/DeepSeek-V4.md
+++ b/recipes/DeepSeek-V4.md
@@ -115,24 +115,40 @@ python -m atom.benchmarks.benchmark_serving \
 ```
 
 Performance on 8xMI355X GPUs with the following environment:
-- Date measured: 2026-05-07.
+- Date measured: 2026-05-23.
 - Docker image: rocm/atom:latest.
-- ATOM: main branch (commit 33c54649).
+- ATOM: `feat/v4-swa-write-tok-n-guard-opus-default` branch (commit bf9b133e).
 - `ATOM_USE_TRITON_MOE=1`, `--kv_cache_dtype fp8`.
 
 The numbers below are a snapshot. For the latest data tracked across commits, see [rocm.github.io/ATOM/benchmark-dashboard](https://rocm.github.io/ATOM/benchmark-dashboard/).
 
-### FP8 (TP8, FP8 KV Cache)
+### FP8 (TP8, FP8 KV Cache) — no MTP
 
 | ISL  | OSL  | Concurrency | Num Prompts | Output Throughput (tok/s) | Total Throughput (tok/s) | Mean TPOT (ms) |
 | ---- | ---- | ----------- | ----------- | ------------------------- | ------------------------ | -------------- |
-| 1024 | 1024 | 4           | 40          | 111.03                    | 222.06                   | 35.67          |
-| 1024 | 1024 | 8           | 80          | 196.19                    | 392.39                   | 40.25          |
-| 1024 | 1024 | 16          | 160         | 369.79                    | 739.59                   | 42.36          |
-| 1024 | 1024 | 32          | 320         | 660.31                    | 1320.62                  | 46.85          |
-| 1024 | 1024 | 64          | 640         | 1138.68                   | 2277.37                  | 53.64          |
-| 1024 | 1024 | 128         | 1280        | 1888.45                   | 3776.90                  | 63.41          |
-| 1024 | 1024 | 256         | 2560        | 2926.71                   | 5853.41                  | 79.66          |
+| 1024 | 1024 | 4           | 40          | 195.31                    | 392.53                   | 19.66          |
+| 1024 | 1024 | 8           | 80          | 367.43                    | 732.14                   | 21.09          |
+| 1024 | 1024 | 16          | 160         | 668.02                    | 1343.15                  | 23.19          |
+| 1024 | 1024 | 32          | 320         | 1145.71                   | 2287.81                  | 26.90          |
+| 1024 | 1024 | 64          | 640         | 1808.69                   | 3618.19                  | 33.96          |
+| 1024 | 1024 | 128         | 1280        | 2847.24                   | 5700.73                  | 43.26          |
+| 1024 | 1024 | 256         | 2560        | 4289.93                   | 8575.71                  | 57.55          |
+
+### FP8 (TP8, FP8 KV Cache) — MTP-3
+
+Add `--method mtp --num-speculative-tokens 3` to the server launch. MTP-3
+trades a small amount of memory for ~1.5–2× lower TPOT and ~1.3–1.5×
+higher total throughput at the same concurrency.
+
+| ISL  | OSL  | Concurrency | Num Prompts | Output Throughput (tok/s) | Total Throughput (tok/s) | Mean TPOT (ms) |
+| ---- | ---- | ----------- | ----------- | ------------------------- | ------------------------ | -------------- |
+| 1024 | 1024 | 4           | 40          | 528.46                    | 1061.26                  | 7.25           |
+| 1024 | 1024 | 8           | 80          | 907.09                    | 1806.44                  | 8.17           |
+| 1024 | 1024 | 16          | 160         | 1391.13                   | 2795.02                  | 10.95          |
+| 1024 | 1024 | 32          | 320         | 2159.04                   | 4308.13                  | 14.01          |
+| 1024 | 1024 | 64          | 640         | 3222.33                   | 6441.40                  | 18.75          |
+| 1024 | 1024 | 128         | 1280        | 4376.29                   | 8755.90                  | 27.77          |
+| 1024 | 1024 | 256         | 2560        | 5701.20                   | 11388.96                 | 43.06          |
 
 Here are the steps to reinstall ATOM/AITER in the docker, if you are trying to verify with other specific commits:
 ```bash
@@ -163,7 +179,18 @@ lm_eval \
   --num_fewshot 5
 ```
 
-Reference accuracy on 8xMI355X GPUs (FP8, FP8 KV Cache, `ATOM_USE_TRITON_MOE=1`):
+Reference accuracy on 8xMI355X GPUs (FP8, FP8 KV Cache, `ATOM_USE_TRITON_MOE=1`,
+measured 2026-05-23 at commit bf9b133e):
+
+**no MTP**:
+```
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9553|±  |0.0057|
+|     |       |strict-match    |     5|exact_match|↑  |0.9560|±  |0.0056|
+```
+
+**MTP-3** (`--method mtp --num-speculative-tokens 3`, average acceptance ≈ 64.5%):
 ```
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
 |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|

--- a/scripts/run_benchmark_sweep.sh
+++ b/scripts/run_benchmark_sweep.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
-# Run benchmark across multiple concurrency levels
+# Run benchmark across multiple concurrency levels.
+#
+# Per-step output: each concurrency saves a copy of `/app/logs_claude/benchmark.log`
+# (which `run_benchmark.sh` always overwrites) under
+# `$SWEEP_DIR/c<CONC>.log`. SWEEP_DIR defaults to a timestamped subdir of
+# `/app/logs_claude/sweeps/`; override via the SWEEP_DIR env var to bucket
+# multiple sweeps under a stable name.
+#
+# Final summary table is printed to stdout AND saved to `$SWEEP_DIR/summary.txt`.
+#
 # Usage: bash run_benchmark_sweep.sh MODEL PORT ISL OSL [CONC_LIST]
 #
 # Examples:
 #   bash run_benchmark_sweep.sh /data/Kimi-K2.5-MXFP4 8000 1024 1024
 #   bash run_benchmark_sweep.sh /data/Kimi-K2.5-MXFP4 8000 1024 1024 "4 8 16 32 64 128"
 #   bash run_benchmark_sweep.sh /data/DeepSeek-R1-0528 8000 1024 1024 "1 2 4 8 16 32 64 128 256"
+#   SWEEP_DIR=/app/logs_claude/sweeps/v4-pro-noMTP \
+#     bash run_benchmark_sweep.sh /data/DeepSeek-V4-Pro 30000 1024 1024 "4 8 16 32 64 128 256"
 
 set -uo pipefail
 
@@ -15,12 +26,17 @@ ISL="${3:-1024}"
 OSL="${4:-1024}"
 CONC_LIST="${5:-4 8 16 32 64 128}"
 
+SWEEP_DIR="${SWEEP_DIR:-/app/logs_claude/sweeps/$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$SWEEP_DIR"
+SUMMARY="$SWEEP_DIR/summary.txt"
+
 echo "========================================"
 echo " Benchmark Sweep"
 echo "========================================"
 echo " Model:     $MODEL"
 echo " ISL/OSL:   ${ISL}/${OSL}"
 echo " Conc:      $CONC_LIST"
+echo " Output:    $SWEEP_DIR"
 echo "========================================"
 
 for CONC in $CONC_LIST; do
@@ -29,7 +45,24 @@ for CONC in $CONC_LIST; do
   echo "=== CONC=$CONC ==="
   echo "================================================================"
   bash /app/ATOM/scripts/run_benchmark.sh "$MODEL" "$PORT" "$ISL" "$OSL" "$CONC"
+  # Preserve per-step result before the next iteration overwrites it.
+  cp -f /app/logs_claude/benchmark.log "$SWEEP_DIR/c${CONC}.log"
 done
+
+# Compose summary table: one row per concurrency.
+{
+  printf "%-12s %-25s %-25s %-15s\n" \
+    "Concurrency" "Output Throughput(tok/s)" "Total Throughput(tok/s)" "Mean TPOT(ms)"
+  for CONC in $CONC_LIST; do
+    LOG="$SWEEP_DIR/c${CONC}.log"
+    OUT_TP=$(grep "Output token throughput" "$LOG" 2>/dev/null | awk '{print $NF}')
+    TOT_TP=$(grep "Total Token throughput" "$LOG" 2>/dev/null | awk '{print $NF}')
+    TPOT=$(grep "Mean TPOT" "$LOG" 2>/dev/null | awk '{print $NF}')
+    printf "%-12s %-25s %-25s %-15s\n" \
+      "$CONC" "${OUT_TP:--}" "${TOT_TP:--}" "${TPOT:--}"
+  done
+} | tee "$SUMMARY"
 
 echo ""
 echo "=== Sweep complete ==="
+echo "Per-step logs + summary: $SWEEP_DIR"


### PR DESCRIPTION
## Summary

End-to-end V4-Pro perf & MTP3 robustness pass on top of `main`. Six commits, grouped by theme:

- **Meta-build hot path (prefill + decode)** — `b17c8d85`, `72a4f690`: GPU-side prefill meta + per-token CSA visible_end; decode meta build moved to direct kernel, csa_translate_pack cleanup. Removes per-step CPU sync from the hot path.
- **MTP3 direct-kernel decode** — `28561a66`: new `AttnState` enum + `prepare_mtp_decode` direct kernel path so MTP3 doesn't fall back through the generic prefill builder.
- **Compressor state ring tightening** — `bf9b133e`: drop redundant `+1` slack in `ring_extra`; ring is now `K_pool + max_spec_steps` exactly (collapses to `K_pool` when spec is off). Audited all producers/consumers (state_writes, fused_compress, swa_write, decode/prefill_indices) — all use dynamic buffer shape, no hardcoded `+1` assumption. CI threshold tightened accordingly.
- **swa_write tok_n guard** — `c1da4e97`: fix OOB writes when `tok_n` exceeds the per-slot SWA ring on opus-default path.
- **Docs + tooling** — `5bf4e114`: recipe perf/accuracy refresh @ bf9b133e (2026-05-23 measurements, no-MTP and MTP-3 split tables); ring_extra docstring cleanup across 5 files; `run_benchmark_sweep.sh` saves per-conc logs + summary table (prior version overwrote `benchmark.log` between conc steps).

Diff: ~1.6k inserts / 1k deletes across 34 files. No new dependencies.

## Accuracy verification (GSM8K, V4-Pro FP8, bf9b133e + tip)

5-shot:

| config | flexible-extract | strict-match |
|---|---|---|
| no-MTP | 0.9515 ±0.0059 | 0.9522 ±0.0059 |
| MTP-1  | 0.9492 ±0.006  | 0.9500 ±0.006  |
| MTP-3  | 0.9530 ±0.0058 | 0.9538 ±0.0058 |

3-shot (CI parity):

| config | flexible-extract | strict-match |
|---|---|---|
| no-MTP | 0.9492 ±0.006 | 0.9500 ±0.006 |
| MTP-1  | 0.9507 ±0.006 | 0.9507 ±0.006 |
| MTP-3  | 0.9492 ±0.006 | 0.9507 ±0.006 |

All three configs within 1σ noise band; MTP-1/MTP-3 vs no-MTP shows no regression.

## Perf (TP8, ISL/OSL=1024/1024, total tok/s)

| conc | no-MTP | MTP-3 | speedup |
|---|---|---|---|
| 4   | 393   | 1061  | 2.70× |
| 32  | 2288  | 4308  | 1.88× |
| 128 | 5701  | 8756  | 1.54× |
| 256 | 8576  | 11389 | 1.33× |

Full tables in `recipes/DeepSeek-V4.md`.

## Test plan

- [x] GSM8K 3-shot + 5-shot, no-MTP / MTP-1 / MTP-3, all within 1σ baseline
- [x] Benchmark sweep c=[4,8,16,32,64,128,256] for both no-MTP and MTP-3
- [x] `recipes/DeepSeek-V4.md` perf + accuracy tables refreshed
- [x] ring_extra audit: all kernel producers/consumers use dynamic shape
- [ ] CI: atom-test
- [ ] CI: atom-vllm-accuracy-validation
- [ ] CI: atom-benchmark