### PR TITLE
Fix the benchmark workflow issue in vLLM-ATOM

### DIFF
--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1139,8 +1139,10 @@ jobs:
           fi
 
       - name: Persist benchmark matrix payload
+        env:
+          BENCHMARK_MATRIX: ${{ steps.build.outputs.benchmark_matrix }}
         run: |
-          printf '%s' '${{ steps.build.outputs.benchmark_matrix }}' > benchmark_matrix.json
+          printf '%s' "${BENCHMARK_MATRIX}" > benchmark_matrix.json
 
       - name: Upload benchmark matrix payload
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Motivation

Fix the issue in this action https://github.com/ROCm/ATOM/actions/runs/26322028797/job/77561479509

The vLLM-ATOM benchmark summary job can fail when generating the final summary table if the benchmark matrix JSON contains shell-sensitive characters, such as single quotes inside `extra_args`.

In the failing run, `plugin_benchmark_summary.py` failed at `json.loads(matrix_json_text)` because `benchmark_matrix.json` was written with broken quoting and became invalid JSON.

## Technical Details

Update the `Persist benchmark matrix payload` step to pass `steps.build.outputs.benchmark_matrix` through an environment variable before writing it to `benchmark_matrix.json`.

This avoids embedding the full JSON payload directly inside a single-quoted shell string, which can be broken by model arguments such as:

```bash
--default-chat-template-kwargs '{"enable_thinking":false}'
