### PR TITLE
block_manager: defer hash registration, preserve cache on free-pool hits

### DIFF
--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -87,96 +87,121 @@ class BlockManager:
         self.free_block_ids.append(block_id)
         self.free_block_ids_set.add(block_id)
 
-    def can_allocate(self, seq: Sequence) -> bool:
+    def can_allocate(self, seq: Sequence) -> int:
+        """Return number of cache-hit blocks (>=0) if seq fits, else -1.
+
+        The hit count is the contiguous run of cache hits starting at the
+        prompt's first block. On the first miss we break: subsequent blocks
+        cannot match either (hash is chained, so a divergent token breaks the
+        chain for the rest of the prompt). The last block is never considered
+        for reuse — prefill must forward at least one block to produce
+        sampler logits, so it always comes from the free pool.
+
+        Caller (scheduler) passes the returned hit count to `allocate()`,
+        avoiding a second hash pass.
+        """
         # State cache (mamba / V4 compressor ring) has its own pre-allocated
         # tensor; admission only needs a free slot index, not extra paged
         # blocks. See `allocate()` for the budget reasoning.
-        per_req_cache_slot_ok = (not seq.has_per_req_cache) or len(
-            self.free_per_req_cache_groups
-        ) > 0
+        if seq.has_per_req_cache and not self.free_per_req_cache_groups:
+            return -1
         if not self.enable_prefix_caching:
-            return (
-                len(self.free_block_ids_set) >= seq.num_blocks and per_req_cache_slot_ok
-            )
-        # Dry-run: count how many blocks would be cache hits
+            if len(self.free_block_ids_set) < seq.num_blocks:
+                return -1
+            return 0
         h = -1
-        cache_miss = False
-        needed_free = 0
-        for i in range(seq.num_blocks):
+        num_cached_blocks = 0
+        num_new_blocks = seq.num_blocks
+        for i in range(seq.num_blocks - 1):
             token_ids = seq.block(i)
-            h = (
-                self.compute_hash(token_ids, h)
-                if len(token_ids) == self.block_size
-                else -1
-            )
+            h = self.compute_hash(token_ids, h)
             block_id = self.hash_to_block_id.get(h, -1)
             if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
-                cache_miss = True
-            # If the entire prompt would be cached, force the last full block
-            # to recompute so prefill has at least one token to forward and
-            # produce logits for the next-token sampler.
-            if (
-                not cache_miss
-                and i == seq.num_blocks - 1
-                and len(token_ids) == self.block_size
-            ):
-                cache_miss = True
-            if cache_miss:
-                needed_free += 1
-        return len(self.free_block_ids_set) >= needed_free and per_req_cache_slot_ok
+                break
+            num_cached_blocks += 1
+            # Hits on already-used blocks share refs; only free-pool hits
+            # consume a free slot (claimed inline in allocate()).
+            if block_id in self.used_block_ids:
+                num_new_blocks -= 1
+        if len(self.free_block_ids_set) < num_new_blocks:
+            return -1
+        return num_cached_blocks
 
-    def allocate(self, seq: Sequence):
+    def allocate(self, seq: Sequence, num_cached_blocks: int = 0):
+        """Allocate blocks for `seq`. `num_cached_blocks` is the hit count
+        returned by `can_allocate` (0 if caller didn't call it).
+
+        Hash registration is deferred to hash_blocks(), called from
+        scheduler.postprocess() once the forward has computed each block's
+        KV. This keeps the manager correct under future chunked-prefill
+        scheduling: a block spanning multiple steps must not be published as
+        a hash until fully filled.
+        """
         assert not seq.block_table
         h = -1
-        cache_miss = False
-
-        for i in range(seq.num_blocks):
+        for i in range(num_cached_blocks):
             token_ids = seq.block(i)
-            h = (
-                self.compute_hash(token_ids, h)
-                if len(token_ids) == self.block_size
-                else -1
-            )
-            block_id = (
-                self.hash_to_block_id.get(h, -1) if self.enable_prefix_caching else -1
-            )
-            if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
-                cache_miss = True
-            # If the entire prompt would be cached, force the last full block
-            # to recompute so prefill has at least one token to forward and
-            # produce logits for the next-token sampler. Must mirror the same
-            # condition in can_allocate() so the block budget agrees.
-            if (
-                not cache_miss
-                and i == seq.num_blocks - 1
-                and len(token_ids) == self.block_size
-            ):
-                cache_miss = True
-            if cache_miss:
-                block_id = self._pop_free_block()
-                block = self._allocate_block(block_id)
+            h = self.compute_hash(token_ids, h)
+            block_id = self.hash_to_block_id[h]
+            block = self.blocks[block_id]
+            if block_id in self.used_block_ids:
+                block.ref_count += 1
             else:
-                seq.num_cached_tokens += self.block_size
-                if block_id in self.used_block_ids:
-                    block = self.blocks[block_id]
-                    block.ref_count += 1
-                else:
-                    block = self._allocate_block(block_id)
-            if h != -1:
-                block.update(h, token_ids)
-                self.hash_to_block_id[h] = block_id
+                # Cache hit on a block sitting in the free pool. Claim WITHOUT
+                # _allocate_block(), because _allocate_block calls reset()
+                # which clears block.hash / block.token_ids and evicts
+                # hash_to_block_id[h] — i.e. every cache-hit reuse would
+                # destroy the cache entry, making subsequent identical
+                # requests miss until this seq's prefill finishes and
+                # re-registers the hash.
+                assert block.ref_count == 0
+                block.ref_count = 1
+                self.free_block_ids_set.discard(block_id)
+                self.used_block_ids.add(block_id)
             seq.block_table.append(block_id)
+        # Remaining blocks (including the always-fresh last block) come from
+        # the free pool. Hash is registered later by hash_blocks().
+        for _ in range(num_cached_blocks, seq.num_blocks):
+            block_id = self._pop_free_block()
+            self._allocate_block(block_id)
+            seq.block_table.append(block_id)
+        seq.num_cached_tokens = num_cached_blocks * self.block_size
 
         # Per-request cache: claim one slot index from the pre-allocated
         # state tensor (e.g. GDN mamba_k_cache, V4 compressor state + SWA
         # ring). The state tensor's memory was already excluded from
-        # `num_kvcache_blocks` in ModelRunner._compute_kv_budget() — see
-        # `available_for_pool = available_for_kv - per_req_cache_tensor_bytes`
-        # — so admitting a seq adds no further paged-block cost. The slot
-        # cap (`free_per_req_cache_groups` size = `max_num_seqs`) is the
-        # sole admission bound for state cache.
+        # `num_kvcache_blocks` in ModelRunner._compute_kv_budget(), so
+        # admitting a seq adds no further paged-block cost. The slot cap
+        # (`free_per_req_cache_groups` size = `max_num_seqs`) is the sole
+        # admission bound for state cache.
         if seq.has_per_req_cache:
             seq.per_req_cache_group = self.free_per_req_cache_groups.pop()
+
+    def hash_blocks(self, seq: Sequence, num_new_tokens: int) -> None:
+        """Register hashes for blocks finalized by the most recent step.
+
+        Called from scheduler.postprocess() after the forward completes, so a
+        block's hash is only published once its KV is actually computed. The
+        `[start, end)` range covers blocks fully filled by this step:
+          start = first block whose first token was at num_cached_tokens
+          end   = first block not yet fully filled (excludes the partial one)
+        Caller passes `num_new_tokens` = tokens forwarded in this step. For
+        single-shot prefill that's `seq.num_tokens - seq.num_cached_tokens`;
+        chunked prefill will pass the per-chunk count.
+        """
+        if not self.enable_prefix_caching:
+            return
+        start = seq.num_cached_tokens // self.block_size
+        end = (seq.num_cached_tokens + num_new_tokens) // self.block_size
+        if start >= end:
+            return
+        h = self.blocks[seq.block_table[start - 1]].hash if start > 0 else -1
+        for i in range(start, end):
+            block = self.blocks[seq.block_table[i]]
+            token_ids = seq.block(i)
+            h = self.compute_hash(token_ids, h)
+            block.update(h, token_ids)
+            self.hash_to_block_id[h] = block.block_id
 
     def deallocate(self, seq: Sequence):
         for block_id in reversed(seq.block_table):

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -604,14 +604,15 @@ class Scheduler:
                 continue
 
             num_new_tokens = seq.num_tokens - seq.num_cached_tokens
+            num_cached_blocks = self.block_manager.can_allocate(seq)
             if (
                 num_batched_tokens + num_new_tokens > self.max_num_batched_tokens
-                or not self.block_manager.can_allocate(seq)
+                or num_cached_blocks < 0
             ):
                 self.waiting.appendleft(seq)
                 break
 
-            self.block_manager.allocate(seq)
+            self.block_manager.allocate(seq, num_cached_blocks)
 
             if self.kv_connector is not None:
                 self.kv_connector.update_state_after_alloc(seq)
@@ -786,6 +787,17 @@ class Scheduler:
             idx = fwd_output.get_idx(seq.id)
             if idx is None:
                 continue
+            # Register prefix-cache hashes for blocks the prefill step just
+            # finalized. Deferred from BlockManager.allocate() so a hash is
+            # only published after the block's KV has actually been computed
+            # by the forward — keeps the block manager correct under future
+            # chunked-prefill scheduling where one block may span multiple
+            # steps. Must run before any seq state update so num_cached_tokens
+            # and block_table still reflect the pre-step view.
+            if seq.type == SequenceType.PREFILL:
+                self.block_manager.hash_blocks(
+                    seq, seq.num_tokens - seq.num_cached_tokens
+                )
             token_ids = prev_token_ids[idx]
             num_new_token = len(token_ids)
             if is_deferred_out or self.use_spec:

--- a/tests/test_block_manager.py
+++ b/tests/test_block_manager.py
@@ -34,7 +34,7 @@ class TestComputeHash:
 class TestCanAllocate:
     def test_can_allocate_when_free(self, block_manager, seq_factory):
         seq = seq_factory([1, 2, 3, 4])
-        assert block_manager.can_allocate(seq)
+        assert block_manager.can_allocate(seq) >= 0
 
     def test_cannot_allocate_when_full(self, seq_factory):
         cfg = MockConfig(num_kvcache_blocks=1, kv_cache_block_size=4)
@@ -42,11 +42,11 @@ class TestCanAllocate:
         s1 = seq_factory([1, 2, 3, 4])
         bm.allocate(s1)
         s2 = seq_factory([5, 6, 7, 8])
-        assert not bm.can_allocate(s2)
+        assert bm.can_allocate(s2) < 0
 
     def test_can_allocate_multi_block(self, block_manager, seq_factory):
         seq = seq_factory([1, 2, 3, 4, 5])
-        assert block_manager.can_allocate(seq)
+        assert block_manager.can_allocate(seq) >= 0
 
 
 # ── allocate / deallocate ──────────────────────────────────────────────────
@@ -81,10 +81,10 @@ class TestAllocateDeallocate:
             others.append(s)
         # Full — can't allocate more
         probe = seq_factory([100, 101, 102, 103])
-        assert not block_manager.can_allocate(probe)
+        assert block_manager.can_allocate(probe) < 0
         # Deallocate one → can allocate again
         block_manager.deallocate(s1)
-        assert block_manager.can_allocate(probe)
+        assert block_manager.can_allocate(probe) >= 0
 
 
 # ── Prefix caching ────────────────────────────────────────────────────────
@@ -94,10 +94,12 @@ class TestPrefixCaching:
     def test_prefix_cache_hit(self, block_manager_prefix, seq_factory):
         s1 = seq_factory([1, 2, 3, 4, 5, 6, 7, 8])
         block_manager_prefix.allocate(s1)
+        block_manager_prefix.hash_blocks(s1, s1.num_tokens - s1.num_cached_tokens)
         block_manager_prefix.deallocate(s1)
 
         s2 = seq_factory([1, 2, 3, 4, 9, 10, 11, 12])
-        block_manager_prefix.allocate(s2)
+        n = block_manager_prefix.can_allocate(s2)
+        block_manager_prefix.allocate(s2, n)
         assert s2.num_cached_tokens == 4
 
     def test_prefix_cache_miss_different_tokens(
@@ -180,22 +182,27 @@ class TestMayAppend:
 
 class TestCanAllocateWithPrefixCaching:
     def test_can_allocate_accounts_for_cache_hits(self, seq_factory):
-        """With 3 blocks total, allocate 2-block seq, deallocate, then a new
-        2-block seq sharing block 1 should need only 1 free block."""
+        """can_allocate must charge BOTH the cache-miss block AND the
+        cache-hit-on-free-pool block to the free-block budget, because the
+        cached block still has to be claimed out of free_block_ids_set."""
         cfg = MockConfig(
-            num_kvcache_blocks=3, kv_cache_block_size=4, enable_prefix_caching=True
+            num_kvcache_blocks=4, kv_cache_block_size=4, enable_prefix_caching=True
         )
         bm = BlockManager(cfg)
         s1 = seq_factory([1, 2, 3, 4, 5, 6, 7, 8])
         bm.allocate(s1)
+        bm.hash_blocks(s1, s1.num_tokens - s1.num_cached_tokens)
         bm.deallocate(s1)  # blocks freed, hashes retained
 
-        # Use up 2 of the 3 free blocks
+        # Use up 2 of the 4 free blocks with non-overlapping tokens
         filler = seq_factory([50, 51, 52, 53, 60, 61, 62, 63])
         bm.allocate(filler)
-        # Only 1 free block left; s2 needs 2 blocks but first is cached
+        # 2 free blocks left. s2 needs 2 blocks (1 cached + 1 fresh): exactly fits.
         s2 = seq_factory([1, 2, 3, 4, 9, 10, 11, 12])
-        assert bm.can_allocate(s2)
+        n = bm.can_allocate(s2)
+        assert n == 1
+        bm.allocate(s2, n)
+        assert s2.num_cached_tokens == 4
 
     def test_can_allocate_no_false_positive(self, seq_factory):
         """can_allocate should return False when even with cache hits
@@ -208,7 +215,7 @@ class TestCanAllocateWithPrefixCaching:
         bm.allocate(s1)
         # 0 free blocks; new seq shares prefix but needs 1 new block
         s2 = seq_factory([1, 2, 3, 4, 9, 10, 11, 12])
-        assert not bm.can_allocate(s2)
+        assert bm.can_allocate(s2) < 0
 
 
 # ── Hash table cleanup ───────────────────────────────────────────────────
@@ -224,12 +231,14 @@ class TestHashTableCleanup:
         bm = BlockManager(cfg)
         s1 = seq_factory([1, 2, 3, 4, 5, 6, 7, 8])
         bm.allocate(s1)
+        bm.hash_blocks(s1, s1.num_tokens - s1.num_cached_tokens)
         h1 = bm.blocks[s1.block_table[0]].hash
         bm.deallocate(s1)
 
         # Allocate with completely different tokens — should overwrite blocks
         s2 = seq_factory([90, 91, 92, 93, 94, 95, 96, 97])
         bm.allocate(s2)
+        bm.hash_blocks(s2, s2.num_tokens - s2.num_cached_tokens)
         # Old hash should no longer point to a valid block
         assert bm.hash_to_block_id.get(h1) != s2.block_table[0]
 
@@ -242,8 +251,9 @@ class TestHashTableCleanup:
         for i in range(20):
             tokens = list(range(i * 4, i * 4 + 4))
             seq = seq_factory(tokens)
-            if bm.can_allocate(seq):
-                bm.allocate(seq)
+            n = bm.can_allocate(seq)
+            if n >= 0:
+                bm.allocate(seq, n)
                 bm.deallocate(seq)
         assert len(bm.hash_to_block_id) <= cfg.num_kvcache_blocks
 
@@ -296,6 +306,7 @@ class TestPrefixCachingPreemption:
         bm = BlockManager(cfg)
         s1 = seq_factory([1, 2, 3, 4, 5, 6, 7, 8])
         bm.allocate(s1)
+        bm.hash_blocks(s1, s1.num_tokens - s1.num_cached_tokens)
         # Simulate preemption
         bm.deallocate(s1)
         assert s1.num_cached_tokens == 0
@@ -304,7 +315,8 @@ class TestPrefixCachingPreemption:
         # Re-allocate — first block is a cache hit; the last full block is
         # force-recomputed so prefill has at least one token to forward.
         s1_retry = seq_factory([1, 2, 3, 4, 5, 6, 7, 8])
-        bm.allocate(s1_retry)
+        n = bm.can_allocate(s1_retry)
+        bm.allocate(s1_retry, n)
         assert s1_retry.num_cached_tokens == 4
 
 

--- a/tests/test_per_req_cache_decoupling.py
+++ b/tests/test_per_req_cache_decoupling.py
@@ -92,7 +92,7 @@ class TestBlockManagerPerReqCacheSlots:
         """can_allocate must check KV blocks AND per-req cache slots."""
         bm = BlockManager(per_req_cache_config(num_kvcache_blocks=100))
         seq = stateful_seq([1, 2, 3, 4])
-        assert bm.can_allocate(seq) is True
+        assert bm.can_allocate(seq) >= 0
 
     def test_can_allocate_fails_not_enough_blocks(self):
         """Not enough free blocks for KV + per-req cache equiv."""
@@ -106,7 +106,7 @@ class TestBlockManagerPerReqCacheSlots:
         seq1 = stateful_seq([1, 2, 3, 4])
         bm.allocate(seq1)
         seq2 = stateful_seq([5, 6, 7, 8])
-        assert bm.can_allocate(seq2) is False
+        assert bm.can_allocate(seq2) < 0
 
     def test_plain_seq_ignores_per_req_cache(self):
         """Stateless sequence should not consume per-req cache slots."""
@@ -165,13 +165,13 @@ class TestBlockManagerPerReqCacheSlots:
         bm.allocate(long_seq)
         # 20 - 4 = 16 free blocks
         # stateful seq needs 1 KV + 5 equiv = 6 blocks
-        assert bm.can_allocate(stateful_seq([1, 2, 3, 4]))
+        assert bm.can_allocate(stateful_seq([1, 2, 3, 4])) >= 0
         s1 = stateful_seq([1, 2, 3, 4])
         bm.allocate(s1)  # 16 - 6 = 10 free
         s2 = stateful_seq([1, 2, 3, 4])
         bm.allocate(s2)  # 10 - 6 = 4 free
         s3 = stateful_seq([1, 2, 3, 4])
-        assert bm.can_allocate(s3) is False  # 4 < 6
+        assert bm.can_allocate(s3) < 0  # 4 < 6
 
 
 # ── Sequence: per_req_cache_group field ──────────────────────────────────────


### PR DESCRIPTION
Two bugs ported from nano-vllm + a control-flow refactor:

1. Cache-hit-on-free-pool no longer calls _allocate_block (which would reset() the block and evict its hash entry — destroying the cache for everyone). Inline-claim preserves block.hash / token_ids.

2. can_allocate now correctly charges free-pool cache hits to the budget. Previously over-reported capacity, letting allocate() race past and assert "No free blocks available" mid-loop.

3. Hash registration moved out of allocate() into hash_blocks(), called from scheduler.postprocess() after the forward computes KV. Required for chunked prefill: a block spanning multiple steps must not publish a hash until fully filled.

API cleanup (nano-vllm style): can_allocate returns hit count (>=0) or -1; allocate(seq, num_cached_blocks) consumes that count directly. Eliminates the cache_miss flag and the "force last block recompute" hack — the loop is range(num_blocks - 1) and the last block naturally falls into the fresh-pop path.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
