### PR TITLE
add vllm' impl for vk layout and make it support o buffer

### DIFF
--- a/atom/model_ops/fla_ops/chunk.py
+++ b/atom/model_ops/fla_ops/chunk.py
@@ -257,12 +257,12 @@ def chunk_gated_delta_rule(
             f"chunk_gated_delta_rule: o.shape {tuple(o.shape)} != v.shape "
             f"{tuple(v.shape)}"
         )
-        assert o.dtype == v.dtype, (
-            f"chunk_gated_delta_rule: o.dtype {o.dtype} != v.dtype {v.dtype}"
-        )
-        assert o.is_contiguous(), (
-            "chunk_gated_delta_rule: caller-provided o must be contiguous"
-        )
+        assert (
+            o.dtype == v.dtype
+        ), f"chunk_gated_delta_rule: o.dtype {o.dtype} != v.dtype {v.dtype}"
+        assert (
+            o.is_contiguous()
+        ), "chunk_gated_delta_rule: caller-provided o must be contiguous"
     o, final_state = ChunkGatedDeltaRuleFunction.apply(
         q,
         k,

--- a/atom/model_ops/fla_ops/chunk_delta_h_vk.py
+++ b/atom/model_ops/fla_ops/chunk_delta_h_vk.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+
+import torch
+
+# Adapted for ATOM: original used `from vllm.triton_utils import tl, triton`,
+# which couples to vLLM internals. ATOM uses plain triton imports throughout
+# (see existing chunk_delta_h.py, chunk_o.py, etc. for the same pattern).
+import triton
+import triton.language as tl
+
+from .index import prepare_chunk_indices, prepare_chunk_offsets
+from .op import exp
+from .utils import use_cuda_graph
+
+NUM_WARPS = [2, 4, 8, 16]
+
+
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "USE_GK": lambda args: args["gk"] is not None,
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+        for BV in [32, 64]
+    ],
+    key=["H", "K", "V", "BT"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_vk(
+    k,
+    v,
+    w,
+    v_new,
+    g,
+    gk,
+    h,
+    h0,
+    ht,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    SAVE_NEW_VALUE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        boh = i_n * NT
+
+    # [BV, BK]
+    b_h1 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 64:
+        b_h2 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 128:
+        b_h3 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 192:
+        b_h4 = tl.zeros([BV, 64], dtype=tl.float32)
+
+    # calculate offset
+    h += ((boh * H + i_h) * V * K).to(tl.int64)
+    v += ((bos * H + i_h) * V).to(tl.int64)
+    k += ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
+    w += ((bos * H + i_h) * K).to(tl.int64)
+    if SAVE_NEW_VALUE:
+        v_new += ((bos * H + i_h) * V).to(tl.int64)
+    stride_v = H * V
+    stride_h = H * V * K
+    stride_k = Hg * K
+    stride_w = H * K
+    if USE_INITIAL_STATE:
+        h0 = h0 + i_nh * V * K
+    if STORE_FINAL_STATE:
+        ht = ht + i_nh * V * K
+
+    # load initial state
+    if USE_INITIAL_STATE:
+        p_h0_1 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        if K > 64:
+            p_h0_2 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+            )
+            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+        if K > 128:
+            p_h0_3 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+            )
+            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+        if K > 192:
+            p_h0_4 = tl.make_block_ptr(
+                h0, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+            )
+            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+
+    # main recurrence
+    for i_t in range(NT):
+        p_h1 = tl.make_block_ptr(
+            h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
+        )
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_h2 = tl.make_block_ptr(
+                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+            )
+            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+        if K > 128:
+            p_h3 = tl.make_block_ptr(
+                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+            )
+            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+        if K > 192:
+            p_h4 = tl.make_block_ptr(
+                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+            )
+            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+
+        p_w = tl.make_block_ptr(
+            w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+        )
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        b_v = tl.dot(b_w, tl.trans(b_h1).to(b_w.dtype))
+        if K > 64:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, tl.trans(b_h2).to(b_w.dtype))
+        if K > 128:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, tl.trans(b_h3).to(b_w.dtype))
+        if K > 192:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, tl.trans(b_h4).to(b_w.dtype))
+        p_v = tl.make_block_ptr(
+            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+
+        if SAVE_NEW_VALUE:
+            p_v = tl.make_block_ptr(
+                v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            )
+            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+
+        last_idx = min((i_t + 1) * BT, T) - 1
+        if USE_G:
+            m_t = (i_t * BT + tl.arange(0, BT)) < T
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+            p_g = tl.make_block_ptr(
+                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+            )
+            b_g = tl.load(p_g, boundary_check=(0,))
+            b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
+            b_g_last = exp(b_g_last)
+            b_h1 *= b_g_last
+            if K > 64:
+                b_h2 *= b_g_last
+            if K > 128:
+                b_h3 *= b_g_last
+            if K > 192:
+                b_h4 *= b_g_last
+
+        if USE_GK:
+            o_k1 = tl.arange(0, 64)
+            b_gk_last1 = tl.load(
+                gk + (bos + last_idx) * H * K + i_h * K + o_k1,
+                mask=(o_k1 < K),
+                other=0.0,
+            )
+            b_h1 *= exp(b_gk_last1)[None, :]
+            if K > 64:
+                o_k2 = 64 + o_k1
+                b_gk_last2 = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k2,
+                    mask=(o_k2 < K),
+                    other=0.0,
+                )
+                b_h2 *= exp(b_gk_last2)[None, :]
+            if K > 128:
+                o_k3 = 128 + o_k1
+                b_gk_last3 = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k3,
+                    mask=(o_k3 < K),
+                    other=0.0,
+                )
+                b_h3 *= exp(b_gk_last3)[None, :]
+            if K > 192:
+                o_k4 = 192 + o_k1
+                b_gk_last4 = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k4,
+                    mask=(o_k4 < K),
+                    other=0.0,
+                )
+                b_h4 *= exp(b_gk_last4)[None, :]
+        b_v = b_v.to(k.dtype.element_ty)
+
+        p_k = tl.make_block_ptr(
+            k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_h1 += tl.trans(tl.dot(b_k, b_v))
+        if K > 64:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h2 += tl.trans(tl.dot(b_k, b_v))
+        if K > 128:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h3 += tl.trans(tl.dot(b_k, b_v))
+        if K > 192:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h4 += tl.trans(tl.dot(b_k, b_v))
+    # epilogue
+    if STORE_FINAL_STATE:
+        p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+            )
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 128:
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+            )
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 192:
+            p_ht = tl.make_block_ptr(
+                ht, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+            )
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_gated_delta_rule_fwd_h_vk(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
+    save_new_value: bool = True,
+    cu_seqlens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # This kernel is slightly different from fla to support Q/K with different head numbers.
+    # In fla, Q/K always have the same head number, so Hg is always equal to H.
+    B, T, Hg, K, V = *k.shape, u.shape[-1]
+    H = u.shape[-2]
+    BT = chunk_size
+
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, chunk_size)
+        if cu_seqlens is not None
+        else None
+    )
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    if cu_seqlens is None:
+        N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
+    else:
+        N, NT, chunk_offsets = (
+            len(cu_seqlens) - 1,
+            len(chunk_indices),
+            prepare_chunk_offsets(cu_seqlens, BT),
+        )
+    assert K <= 256, "current kernel does not support head dimension larger than 256."
+
+    h = k.new_empty(B, NT, H, V, K)
+    final_state = (
+        k.new_empty(N, H, V, K, dtype=torch.float32) if output_final_state else None
+    )
+
+    v_new = torch.empty_like(u) if save_new_value else None
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), N * H)
+
+    chunk_gated_delta_rule_fwd_kernel_h_blockdim64_vk[grid](
+        k=k,
+        v=u,
+        w=w,
+        v_new=v_new,
+        g=g,
+        gk=gk,
+        h=h,
+        h0=initial_state,
+        ht=final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return h, v_new, final_state

--- a/atom/model_ops/fla_ops/chunk_fused.py
+++ b/atom/model_ops/fla_ops/chunk_fused.py
@@ -24,6 +24,7 @@ Scope (Phase 1):
 
 Correctness reference: vllm.model_executor.layers.fla.ops.chunk_gated_delta_rule
 """
+
 from __future__ import annotations
 
 import torch
@@ -33,13 +34,11 @@ import triton.language as tl
 
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
-from .index import prepare_chunk_indices, prepare_chunk_offsets
 from .l2norm import l2norm_fwd
 from .op import exp
 from .solve_tril import solve_tril
 from .utils import use_cuda_graph
 from .wy_fast import recompute_w_u_fwd
-
 
 # ---------------------------------------------------------------------------
 # Fused Phase-1 kernel: h-recurrence (vk layout) + per-chunk o-GEMM.
@@ -93,18 +92,18 @@ NUM_WARPS = [2, 4]
 @triton.jit(do_not_specialize=["T"])
 def chunk_fused_fwd_kernel_vk(
     # --- inputs (all needed by the recurrence) ---
-    q,           # [B, T, Hg, K]
-    k,           # [B, T, Hg, K]
-    u,           # [B, T, H,  V]  — the "new v" from recompute_w_u
-    w,           # [B, T, H,  K]  — the "corrected k weight" from recompute_w_u
-    g,           # [B, T, H]      — cumulative log-decay
-    h0,          # [N, H, V, K] fp32 or None
+    q,  # [B, T, Hg, K]
+    k,  # [B, T, Hg, K]
+    u,  # [B, T, H,  V]  — the "new v" from recompute_w_u
+    w,  # [B, T, H,  K]  — the "corrected k weight" from recompute_w_u
+    g,  # [B, T, H]      — cumulative log-decay
+    h0,  # [N, H, V, K] fp32 or None
     # --- outputs ---
-    ht,          # [N, H, V, K] fp32 or None  (final recurrent state)
-    o,           # [B, T, H, V] — the chunk-attention output (same dtype as q)
+    ht,  # [N, H, V, K] fp32 or None  (final recurrent state)
+    o,  # [B, T, H, V] — the chunk-attention output (same dtype as q)
     # --- ragged-batch metadata ---
     cu_seqlens,  # [N+1] int32 or None
-    scale,       # 1/sqrt(K), runtime scalar
+    scale,  # 1/sqrt(K), runtime scalar
     # --- compile-time shapes ---
     T,
     H: tl.constexpr,
@@ -268,9 +267,7 @@ def chunk_fused_fwd_kernel_vk(
         # Apply chunk-relative gating to the inter-chunk attn output and the
         # intra-chunk A. (Identical to chunk_fwd_kernel_o.)
         if USE_G:
-            p_g = tl.make_block_ptr(
-                g_p, (T,), (stride_g,), (i_t * BT,), (BT,), (0,)
-            )
+            p_g = tl.make_block_ptr(g_p, (T,), (stride_g,), (i_t * BT,), (BT,), (0,))
             b_g = tl.load(p_g, boundary_check=(0,))
             b_o = b_o * exp(b_g)[:, None]
             b_A = b_A * exp(b_g[:, None] - b_g[None, :])
@@ -375,9 +372,7 @@ def chunk_fused_fwd_kernel_vk(
     # ----- epilogue: write final recurrent state -----
     if STORE_FINAL_STATE:
         ht_p = ht + (i_n * H + i_h) * V * K
-        p_ht1 = tl.make_block_ptr(
-            ht_p, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
-        )
+        p_ht1 = tl.make_block_ptr(ht_p, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
         tl.store(p_ht1, b_h1.to(p_ht1.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:
             p_ht2 = tl.make_block_ptr(
@@ -428,9 +423,7 @@ def chunk_gated_delta_rule_fused(
         "Use bfloat16 / float16; chunk_gated_delta_rule_fused does not "
         "support fp32 inputs."
     )
-    assert beta.dim() == 3, (
-        f"beta must be [B, T, H]; got shape {tuple(beta.shape)}"
-    )
+    assert beta.dim() == 3, f"beta must be [B, T, H]; got shape {tuple(beta.shape)}"
 
     if cu_seqlens is not None:
         assert q.shape[0] == 1, (
@@ -478,9 +471,9 @@ def chunk_gated_delta_rule_fused(
     H = v.shape[-2]
     V = v.shape[-1]
     BT = 64  # algorithmic chunk size (must match the prologue's chunk_size)
-    assert K <= 256, (
-        f"chunk_fused: K must be <= 256 (got {K}); kernel only has 4 K-tiles."
-    )
+    assert (
+        K <= 256
+    ), f"chunk_fused: K must be <= 256 (got {K}); kernel only has 4 K-tiles."
 
     # N (# sequences) is already computed above based on cu_seqlens vs B.
 

--- a/atom/model_ops/fla_ops/chunk_fused.py
+++ b/atom/model_ops/fla_ops/chunk_fused.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Fused single-kernel chunked Gated DeltaNet forward — Phase 1.
+
+This file implements a fused version of the FLA-style chunked Gated DeltaNet
+prefill that combines the h-recurrence (chunk_delta_h kernel) with the o-GEMM
+(chunk_o kernel) into ONE Triton kernel. Intermediate per-chunk hidden
+states (the `h` tensor of shape [B, NT, H, V, K]) never get materialized in
+HBM — they live entirely in registers across the chunk loop.
+
+Scope (Phase 1):
+    * Prologue kernels (l2norm, cumsum, KKT, solve_tril, recompute_w_u) are
+      reused unchanged from atom.model_ops.fla_ops.* — they produce per-chunk
+      artifacts (g_cum, w, u) that the fused kernel consumes. Fusing those is
+      a later phase.
+    * State layout is fixed to vLLM's "[V, K]"-per-head convention so the
+      output `final_state` can be written directly into ssm_state without a
+      transpose. ATOM's [K, V] layout is not supported here.
+    * Output buffer `o` is always allocated inside the wrapper. No inplace
+      `o=` parameter — callers write into their target buffer themselves
+      (matches the modeling-code pattern that existed before the inplace
+      experiment).
+
+Correctness reference: vllm.model_executor.layers.fla.ops.chunk_gated_delta_rule
+"""
+from __future__ import annotations
+
+import torch
+
+import triton
+import triton.language as tl
+
+from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from .cumsum import chunk_local_cumsum
+from .index import prepare_chunk_indices, prepare_chunk_offsets
+from .l2norm import l2norm_fwd
+from .op import exp
+from .solve_tril import solve_tril
+from .utils import use_cuda_graph
+from .wy_fast import recompute_w_u_fwd
+
+
+# ---------------------------------------------------------------------------
+# Fused Phase-1 kernel: h-recurrence (vk layout) + per-chunk o-GEMM.
+#
+# This kernel is a port of the existing
+# chunk_gated_delta_rule_fwd_kernel_h_blockdim64_vk (in chunk_delta_h.py)
+# with the body of chunk_fwd_kernel_o (in chunk_o.py) inlined immediately
+# AFTER each chunk's h-update — using the b_h1..b_h4 register tiles that
+# would otherwise have been spilled to HBM as `h[c]`.
+#
+# Grid: (cdiv(V, BV), N * H)  — one program per (sequence, head, V-block).
+# Each program walks the sequence's NT chunks sequentially because the
+# h-recurrence is causal.
+# ---------------------------------------------------------------------------
+
+NUM_WARPS = [2, 4]
+
+
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in NUM_WARPS
+        for num_stages in [2, 3, 4]
+        # BV=8, 16 added for long-sequence grid occupancy on small-H models.
+        # At T=8192, H=16, BV=32 gives only V/BV * H = 4 * 16 = 64 programs
+        # (~21% of MI300X CUs); BV=16 doubles that, BV=8 quadruples it. Triton
+        # autotunes per (H, K, V, BT) so short-T shapes naturally pick larger
+        # BV for better register efficiency while long-T shapes pick smaller
+        # BV for grid parallelism.
+        for BV in [8, 16, 32, 64]
+    ],
+    # Include T in the autotune key: the per-program work (chunk loop count
+    # NT = cdiv(T, BT)) is proportional to T, and the best BV depends on T.
+    # Short-T wants larger BV for register efficiency; long-T wants smaller
+    # BV for grid occupancy (e.g., at T=8192, H=16 with BV=32 we have only
+    # 64 programs — under 25% of MI300X CUs; BV=8 gets 256 programs, ~84%).
+    # Without T in the key, Triton picks one config at first call (often a
+    # tiny test shape) and reuses it for all later T, which catastrophically
+    # underperforms on long sequences.
+    key=["H", "K", "V", "BT", "T"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_fused_fwd_kernel_vk(
+    # --- inputs (all needed by the recurrence) ---
+    q,           # [B, T, Hg, K]
+    k,           # [B, T, Hg, K]
+    u,           # [B, T, H,  V]  — the "new v" from recompute_w_u
+    w,           # [B, T, H,  K]  — the "corrected k weight" from recompute_w_u
+    g,           # [B, T, H]      — cumulative log-decay
+    h0,          # [N, H, V, K] fp32 or None
+    # --- outputs ---
+    ht,          # [N, H, V, K] fp32 or None  (final recurrent state)
+    o,           # [B, T, H, V] — the chunk-attention output (same dtype as q)
+    # --- ragged-batch metadata ---
+    cu_seqlens,  # [N+1] int32 or None
+    scale,       # 1/sqrt(K), runtime scalar
+    # --- compile-time shapes ---
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    # --- heuristic flags ---
+    USE_G: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    # Grid axes: (V-block, N * H)
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    i_hg = i_h // (H // Hg)  # GQA: map v-head -> k-head
+
+    if IS_VARLEN:
+        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        bos = i_n * T
+        eos = bos + T
+        NT = tl.cdiv(T, BT)
+
+    # --- per-head register tiles for the recurrent state S_h ∈ [V, K] ---
+    # Stored vLLM-style as [BV, K], split across 4 K-tiles of width 64.
+    b_h1 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 64:
+        b_h2 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 128:
+        b_h3 = tl.zeros([BV, 64], dtype=tl.float32)
+    if K > 192:
+        b_h4 = tl.zeros([BV, 64], dtype=tl.float32)
+
+    # --- base pointer offsets (per-head, per-sequence) ---
+    # Layout: q,k are [B, T, Hg, K]; u,o are [B, T, H, V]; w is [B, T, H, K];
+    # g is [B, T, H]. We pre-shift each pointer to the start of this head/sequence.
+    q_p = q + (bos * Hg + i_hg) * K
+    k_p = k + (bos * Hg + i_hg) * K
+    u_p = u + (bos * H + i_h) * V
+    w_p = w + (bos * H + i_h) * K
+    o_p = o + (bos * H + i_h) * V
+    g_p = g + bos * H + i_h
+    stride_q = Hg * K
+    stride_k = Hg * K
+    stride_u = H * V
+    stride_w = H * K
+    stride_o = H * V
+    stride_g = H
+
+    if USE_INITIAL_STATE:
+        h0_p = h0 + (i_n * H + i_h) * V * K
+        p_h0_1 = tl.make_block_ptr(
+            h0_p, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
+        )
+        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        if K > 64:
+            p_h0_2 = tl.make_block_ptr(
+                h0_p, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+            )
+            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+        if K > 128:
+            p_h0_3 = tl.make_block_ptr(
+                h0_p, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+            )
+            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+        if K > 192:
+            p_h0_4 = tl.make_block_ptr(
+                h0_p, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+            )
+            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+
+    # ----- main chunk loop -----
+    # Each chunk runs the recurrence step (kernel 5 work) and emits its
+    # contribution to o (kernel 6 work) using b_h_{1..4} already in registers.
+    for i_t in range(NT):
+        # === o-GEMM for this chunk ===
+        # Build b_o ∈ [BT, BV] = Q_c · S_BV_prev^T   (the inter-chunk piece,
+        # i.e. the prior state's contribution to the new attention output).
+        # The recurrence below will then update S_BV with the chunk's K, V.
+        #
+        # vLLM's o kernel iterates K-blocks of [BK=64, BV] of h; here we have
+        # the full h_BV[V_block, K] = (b_h1 | b_h2 | b_h3 | b_h4) in registers.
+        # b_o += dot(b_q_k, b_h_k.T) for each K-tile k.
+        b_o = tl.zeros([BT, BV], dtype=tl.float32)
+        b_A = tl.zeros([BT, BT], dtype=tl.float32)
+
+        # Downcast b_h to the input dtype BEFORE the o-emit dot so that the
+        # numerical regime matches vLLM upstream's chunk_fwd_kernel_o, which
+        # loads `h` from HBM as bf16 (it does `tl.dot(b_q, tl.trans(b_h))`
+        # where b_h is the bf16-loaded tile). The order matters: cast first,
+        # THEN trans, so the cast happens in [BV, K]-tile shape and trans is
+        # a pure metadata op on bf16 values — exactly mirroring "store as
+        # bf16 then load and trans" in the unfused pipeline.
+        b_h1_bf = b_h1.to(q_p.dtype.element_ty)
+        b_h1_q = tl.trans(b_h1_bf)
+        if K > 64:
+            b_h2_bf = b_h2.to(q_p.dtype.element_ty)
+            b_h2_q = tl.trans(b_h2_bf)
+        if K > 128:
+            b_h3_bf = b_h3.to(q_p.dtype.element_ty)
+            b_h3_q = tl.trans(b_h3_bf)
+        if K > 192:
+            b_h4_bf = b_h4.to(q_p.dtype.element_ty)
+            b_h4_q = tl.trans(b_h4_bf)
+
+        # K-tile 1
+        p_q1 = tl.make_block_ptr(
+            q_p, (T, K), (stride_q, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+        )
+        # b_k as (K, T) so that dot(b_q, b_k) -> [BT, BT].
+        p_k1 = tl.make_block_ptr(
+            k_p, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
+        )
+        b_q1 = tl.load(p_q1, boundary_check=(0, 1))
+        b_k1 = tl.load(p_k1, boundary_check=(0, 1))
+        # b_h1_q is [64, BV] in input dtype — fold into b_o ∈ [BT, BV] via
+        # b_q1 @ b_h1_q which is [BT, 64] @ [64, BV] = [BT, BV].
+        b_o += tl.dot(b_q1, b_h1_q)
+        b_A += tl.dot(b_q1, b_k1)
+
+        if K > 64:
+            p_q2 = tl.make_block_ptr(
+                q_p, (T, K), (stride_q, 1), (i_t * BT, 64), (BT, 64), (1, 0)
+            )
+            p_k2 = tl.make_block_ptr(
+                k_p, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
+            )
+            b_q2 = tl.load(p_q2, boundary_check=(0, 1))
+            b_k2 = tl.load(p_k2, boundary_check=(0, 1))
+            b_o += tl.dot(b_q2, b_h2_q)
+            b_A += tl.dot(b_q2, b_k2)
+        if K > 128:
+            p_q3 = tl.make_block_ptr(
+                q_p, (T, K), (stride_q, 1), (i_t * BT, 128), (BT, 64), (1, 0)
+            )
+            p_k3 = tl.make_block_ptr(
+                k_p, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
+            )
+            b_q3 = tl.load(p_q3, boundary_check=(0, 1))
+            b_k3 = tl.load(p_k3, boundary_check=(0, 1))
+            b_o += tl.dot(b_q3, b_h3_q)
+            b_A += tl.dot(b_q3, b_k3)
+        if K > 192:
+            p_q4 = tl.make_block_ptr(
+                q_p, (T, K), (stride_q, 1), (i_t * BT, 192), (BT, 64), (1, 0)
+            )
+            p_k4 = tl.make_block_ptr(
+                k_p, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
+            )
+            b_q4 = tl.load(p_q4, boundary_check=(0, 1))
+            b_k4 = tl.load(p_k4, boundary_check=(0, 1))
+            b_o += tl.dot(b_q4, b_h4_q)
+            b_A += tl.dot(b_q4, b_k4)
+
+        # Apply chunk-relative gating to the inter-chunk attn output and the
+        # intra-chunk A. (Identical to chunk_fwd_kernel_o.)
+        if USE_G:
+            p_g = tl.make_block_ptr(
+                g_p, (T,), (stride_g,), (i_t * BT,), (BT,), (0,)
+            )
+            b_g = tl.load(p_g, boundary_check=(0,))
+            b_o = b_o * exp(b_g)[:, None]
+            b_A = b_A * exp(b_g[:, None] - b_g[None, :])
+
+        # Causal mask on A (lower-tri inside the chunk, zero outside).
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+        b_A = tl.where(m_A, b_A, 0)
+
+        # Load the chunk's "new v" (u) — it's the post-correction value the
+        # recurrence and the o-write both consume. We pre-load it BEFORE
+        # running the recurrence so we use the same bytes for both: the
+        # o-emit needs u for the intra-chunk piece, the recurrence needs
+        # the (g-decayed, gated) version for b_h.
+        p_u = tl.make_block_ptr(
+            u_p, (T, V), (stride_u, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        b_u = tl.load(p_u, boundary_check=(0, 1))
+
+        # Compose o_c: inter-chunk + intra-chunk causal, both scaled by 1/sqrt(K).
+        b_o = b_o * scale + tl.dot(b_A.to(b_u.dtype), b_u) * scale
+
+        # Write the chunk's output to HBM.
+        p_o = tl.make_block_ptr(
+            o_p, (T, V), (stride_o, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+        # === recurrence step: update S_BV ===
+        # The mathematics matches chunk_gated_delta_rule_fwd_kernel_h_blockdim64_vk:
+        #   1. b_v_new = u - w @ S_BV^T          (post-delta-correction value)
+        #   2. b_v_new *= exp(g_last - g)        (per-token gate)
+        #   3. b_h *= exp(g_last)                (per-chunk gate on prior state)
+        #   4. b_h += k_c^T @ b_v_new            (rank-BT update)
+        # Step 1: load w-chunk for each K-tile and accumulate b_v ∈ [BT, BV].
+        p_w1 = tl.make_block_ptr(
+            w_p, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+        )
+        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
+        # b_h1 is [BV, 64]; w_chunk is [BT, 64]; want b_v ∈ [BT, BV] =
+        # b_w @ b_h.T = [BT, 64] @ [64, BV].
+        b_v = tl.dot(b_w1, tl.trans(b_h1).to(b_w1.dtype))
+        if K > 64:
+            p_w2 = tl.make_block_ptr(
+                w_p, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
+            )
+            b_w2 = tl.load(p_w2, boundary_check=(0, 1))
+            b_v += tl.dot(b_w2, tl.trans(b_h2).to(b_w2.dtype))
+        if K > 128:
+            p_w3 = tl.make_block_ptr(
+                w_p, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
+            )
+            b_w3 = tl.load(p_w3, boundary_check=(0, 1))
+            b_v += tl.dot(b_w3, tl.trans(b_h3).to(b_w3.dtype))
+        if K > 192:
+            p_w4 = tl.make_block_ptr(
+                w_p, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
+            )
+            b_w4 = tl.load(p_w4, boundary_check=(0, 1))
+            b_v += tl.dot(b_w4, tl.trans(b_h4).to(b_w4.dtype))
+
+        # b_v ← b_u - (w @ S^T)   — the corrected delta value
+        b_v = b_u - b_v
+
+        # Apply per-token gating to the corrected value (Step 2) and scale
+        # the carried-over state by the chunk's last gate (Step 3).
+        last_idx = min((i_t + 1) * BT, T) - 1
+        if USE_G:
+            # Reload g for this chunk; same b_g as we computed for o above
+            # — but we let the compiler decide whether to re-load or reuse.
+            # (Triton can CSE this when the inputs are constant.)
+            p_g_recur = tl.make_block_ptr(
+                g_p, (T,), (stride_g,), (i_t * BT,), (BT,), (0,)
+            )
+            b_g_recur = tl.load(p_g_recur, boundary_check=(0,))
+            b_g_last = tl.load(g_p + last_idx * stride_g)
+            mask_chunk = (i_t * BT + tl.arange(0, BT)) < T
+            b_v = b_v * tl.where(mask_chunk, exp(b_g_last - b_g_recur), 0)[:, None]
+            scale_last = exp(b_g_last)
+            b_h1 *= scale_last
+            if K > 64:
+                b_h2 *= scale_last
+            if K > 128:
+                b_h3 *= scale_last
+            if K > 192:
+                b_h4 *= scale_last
+
+        # Step 4: rank-BT update — b_h += b_k^T @ b_v_new for each K-tile.
+        b_v_t = b_v.to(k_p.dtype.element_ty)
+        # b_k1 already loaded above (in the o-GEMM step); reuse it.
+        # b_k1 has shape [64, BT]; b_v_t has shape [BT, BV]; result is [64, BV].
+        # We want to add into b_h1 ∈ [BV, 64], so transpose: trans([64, BV]) = [BV, 64].
+        b_h1 += tl.trans(tl.dot(b_k1, b_v_t))
+        if K > 64:
+            b_h2 += tl.trans(tl.dot(b_k2, b_v_t))
+        if K > 128:
+            b_h3 += tl.trans(tl.dot(b_k3, b_v_t))
+        if K > 192:
+            b_h4 += tl.trans(tl.dot(b_k4, b_v_t))
+
+    # ----- epilogue: write final recurrent state -----
+    if STORE_FINAL_STATE:
+        ht_p = ht + (i_n * H + i_h) * V * K
+        p_ht1 = tl.make_block_ptr(
+            ht_p, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
+        )
+        tl.store(p_ht1, b_h1.to(p_ht1.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_ht2 = tl.make_block_ptr(
+                ht_p, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+            )
+            tl.store(p_ht2, b_h2.to(p_ht2.dtype.element_ty), boundary_check=(0, 1))
+        if K > 128:
+            p_ht3 = tl.make_block_ptr(
+                ht_p, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+            )
+            tl.store(p_ht3, b_h3.to(p_ht3.dtype.element_ty), boundary_check=(0, 1))
+        if K > 192:
+            p_ht4 = tl.make_block_ptr(
+                ht_p, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+            )
+            tl.store(p_ht4, b_h4.to(p_ht4.dtype.element_ty), boundary_check=(0, 1))
+
+
+# ---------------------------------------------------------------------------
+# Host wrapper
+# ---------------------------------------------------------------------------
+
+
+def chunk_gated_delta_rule_fused(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Fused chunked Gated DeltaNet forward — Phase 1.
+
+    Reuses the existing prologue kernels (l2norm, cumsum, KKT, solve_tril,
+    recompute_w_u) and fuses the h-recurrence + o-GEMM into a single kernel
+    that keeps the chunk-state `b_h` in registers across chunks.
+
+    Inputs / outputs match the FLA reference contract; see module docstring
+    for scope notes.
+    """
+    # --- input validation (mirrors the FLA reference's checks) ---
+    assert q.dtype == k.dtype == v.dtype, "q/k/v must share dtype"
+    assert q.dtype != torch.float32, (
+        "Use bfloat16 / float16; chunk_gated_delta_rule_fused does not "
+        "support fp32 inputs."
+    )
+    assert beta.dim() == 3, (
+        f"beta must be [B, T, H]; got shape {tuple(beta.shape)}"
+    )
+
+    if cu_seqlens is not None:
+        assert q.shape[0] == 1, (
+            f"cu_seqlens requires batch=1 (got B={q.shape[0]}); flatten "
+            f"variable-length inputs before calling."
+        )
+        N = cu_seqlens.numel() - 1
+        if initial_state is not None:
+            assert initial_state.shape[0] == N, (
+                f"initial_state.shape[0]={initial_state.shape[0]} != "
+                f"len(cu_seqlens)-1={N}"
+            )
+    else:
+        N = q.shape[0]
+
+    # --- optional in-kernel l2norm on q, k ---
+    if use_qk_l2norm_in_kernel:
+        q = l2norm_fwd(q)
+        k = l2norm_fwd(k)
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    # --- prologue (reused unchanged from the existing 7-kernel path) ---
+    g_cum = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k, beta=beta, g=g_cum, cu_seqlens=cu_seqlens, output_dtype=torch.float32
+    )
+    A = solve_tril(A=A, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
+    w, u = recompute_w_u_fwd(
+        k=k, v=v, beta=beta, A=A, g_cumsum=g_cum, cu_seqlens=cu_seqlens
+    )
+
+    # --- output buffers ---
+    # o is [B, T, H_v, V], same dtype as q (matches FLA reference).
+    o = torch.empty_like(v)
+    final_state = (
+        k.new_empty(N, v.shape[-2], v.shape[-1], k.shape[-1], dtype=torch.float32)
+        if output_final_state
+        else None
+    )
+
+    # --- launch the fused kernel ---
+    B, T, Hg, K = q.shape
+    H = v.shape[-2]
+    V = v.shape[-1]
+    BT = 64  # algorithmic chunk size (must match the prologue's chunk_size)
+    assert K <= 256, (
+        f"chunk_fused: K must be <= 256 (got {K}); kernel only has 4 K-tiles."
+    )
+
+    # N (# sequences) is already computed above based on cu_seqlens vs B.
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), N * H)
+
+    chunk_fused_fwd_kernel_vk[grid](
+        q=q,
+        k=k,
+        u=u,
+        w=w,
+        g=g_cum,
+        h0=initial_state,
+        ht=final_state,
+        o=o,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return o, final_state

--- a/atom/model_ops/fla_ops/chunk_o.py
+++ b/atom/model_ops/fla_ops/chunk_o.py
@@ -178,8 +178,7 @@ def chunk_fwd_o(
             f"v.shape {tuple(v.shape)}"
         )
         assert o.dtype == v.dtype, (
-            f"chunk_fwd_o: caller-provided o.dtype {o.dtype} != v.dtype "
-            f"{v.dtype}"
+            f"chunk_fwd_o: caller-provided o.dtype {o.dtype} != v.dtype " f"{v.dtype}"
         )
         assert o.is_contiguous(), (
             "chunk_fwd_o: caller-provided o must be contiguous (kernel "

--- a/atom/model_ops/fla_ops/chunk_o_vk.py
+++ b/atom/model_ops/fla_ops/chunk_o_vk.py
@@ -12,6 +12,9 @@
 
 import torch
 
+# Adapted for ATOM: replaced `from vllm.triton_utils import tl, triton`
+# with plain triton imports (consistent with the existing ATOM-vendored
+# FLA files).
 import triton
 import triton.language as tl
 
@@ -40,7 +43,7 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
     key=["H", "K", "V", "BT"],
 )
 @triton.jit(do_not_specialize=["T"])
-def chunk_fwd_kernel_o(
+def chunk_fwd_kernel_o_vk(
     q,
     k,
     v,
@@ -86,7 +89,7 @@ def chunk_fwd_kernel_o(
     k += (bos * Hg + i_h // (H // Hg)) * K
     v += (bos * H + i_h) * V
     o += (bos * H + i_h) * V
-    h += (i_tg * H + i_h).to(tl.int64) * K * V
+    h += (i_tg * H + i_h).to(tl.int64) * V * K
 
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
@@ -99,17 +102,17 @@ def chunk_fwd_kernel_o(
             k, (K, T), (1, Hg * K), (i_k * BK, i_t * BT), (BK, BT), (0, 1)
         )
         p_h = tl.make_block_ptr(
-            h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+            h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
         )
         # [BT, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
         # [BK, BT]
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        # [BK, BV]
+        # [BV, BK]
         b_h = tl.load(p_h, boundary_check=(0, 1))
 
         # [BT, BK] @ [BK, BV] -> [BT, BV]
-        b_o += tl.dot(b_q, b_h)
+        b_o += tl.dot(b_q, tl.trans(b_h))
         # [BT, BK] @ [BK, BT] -> [BT, BT]
         b_A += tl.dot(b_q, b_k)
 
@@ -139,14 +142,14 @@ def chunk_fwd_kernel_o(
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
-def chunk_fwd_o(
+def chunk_fwd_o_vk(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
     h: torch.Tensor,
     g: torch.Tensor | None = None,  # cumsum of log decay
     scale: float | None = None,
-    cu_seqlens: torch.LongTensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
     chunk_size: int = 64,
     o: torch.Tensor | None = None,
 ) -> torch.Tensor:
@@ -155,10 +158,10 @@ def chunk_fwd_o(
     If ``o`` is provided, the kernel writes into it inplace and ``o`` is
     returned. The caller's buffer MUST match ``v``'s shape and dtype and
     be contiguous — the Triton kernel assumes stride ``(H * V, 1)`` along
-    ``(T, V)`` for a ``[B, T, H, V]`` layout. The public chunk_gated_delta_rule
-    entry point asserts these contracts before .apply() (so input_guard's
-    silent .contiguous() clone can't defeat them); we re-assert here as a
-    defense-in-depth backstop for any caller that bypasses the public API.
+    ``(T, V)`` for a ``[B, T, H, V]`` layout. Mismatches are rejected so
+    that a non-contiguous view (which would otherwise be silently replaced
+    by ``input_guard``'s ``.contiguous()`` copy upstream) cannot result
+    in a write to the wrong buffer.
     """
     B, T, Hg, K, V = *q.shape, v.shape[-1]
     H = v.shape[-2]
@@ -174,22 +177,22 @@ def chunk_fwd_o(
         o = torch.empty_like(v)
     else:
         assert o.shape == v.shape, (
-            f"chunk_fwd_o: caller-provided o.shape {tuple(o.shape)} != "
+            f"chunk_fwd_o_vk: caller-provided o.shape {tuple(o.shape)} != "
             f"v.shape {tuple(v.shape)}"
         )
         assert o.dtype == v.dtype, (
-            f"chunk_fwd_o: caller-provided o.dtype {o.dtype} != v.dtype "
+            f"chunk_fwd_o_vk: caller-provided o.dtype {o.dtype} != v.dtype "
             f"{v.dtype}"
         )
         assert o.is_contiguous(), (
-            "chunk_fwd_o: caller-provided o must be contiguous (kernel "
+            "chunk_fwd_o_vk: caller-provided o must be contiguous (kernel "
             "assumes stride (H*V, 1) on the (T, V) plane)"
         )
 
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), NT, B * H)
 
-    chunk_fwd_kernel_o[grid](
+    chunk_fwd_kernel_o_vk[grid](
         q,
         k,
         v,

--- a/atom/model_ops/fla_ops/chunk_vk.py
+++ b/atom/model_ops/fla_ops/chunk_vk.py
@@ -10,10 +10,16 @@
 import warnings
 
 import torch
-from einops import rearrange
 
-from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
-from .chunk_o import chunk_fwd_o
+# vk variant of chunk_gated_delta_rule. Ported verbatim from vLLM upstream
+# (vllm.model_executor.layers.fla.ops.chunk). Differs from ATOM's existing
+# chunk.py only in the per-head [V, K] (vk) state layout vs ATOM's existing
+# [K, V] (kv) layout. The prologue kernels (cumsum, KKT, solve_tril,
+# recompute_w_u, l2norm) are layout-agnostic and shared with the kv path.
+# Only chunk_delta_h and chunk_o have layout-sensitive code, so we import
+# the vk variants of those two.
+from .chunk_delta_h_vk import chunk_gated_delta_rule_fwd_h_vk
+from .chunk_o_vk import chunk_fwd_o_vk
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
 from .l2norm import l2norm_fwd
@@ -22,7 +28,8 @@ from .utils import SUPPRESS_LEVEL, input_guard
 from .wy_fast import recompute_w_u_fwd
 
 
-def chunk_gated_delta_rule_fwd(
+
+def chunk_gated_delta_rule_fwd_vk(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -31,9 +38,13 @@ def chunk_gated_delta_rule_fwd(
     scale: float,
     initial_state: torch.Tensor,
     output_final_state: bool,
-    cu_seqlens: torch.LongTensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
     o: torch.Tensor | None = None,
 ):
+    """ATOM-native vk prefill: K1-K6 all run as separate Triton kernels.
+
+    See `chunk_gated_delta_rule_fwd_vk_flydsl` for the flydsl-K5 variant.
+    """
     g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
     # obtain WY representation. u is actually the new v.
     A = chunk_scaled_dot_kkt_fwd(
@@ -48,7 +59,7 @@ def chunk_gated_delta_rule_fwd(
         g_cumsum=g,
         cu_seqlens=cu_seqlens,
     )
-    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h_vk(
         k=k,
         w=w,
         u=u,
@@ -57,7 +68,7 @@ def chunk_gated_delta_rule_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
     )
-    o = chunk_fwd_o(
+    o = chunk_fwd_o_vk(
         q=q,
         k=k,
         v=v_new,
@@ -73,7 +84,7 @@ def chunk_gated_delta_rule_fwd(
         return g, o, A, final_state, w, h, v_new
 
 
-class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+class ChunkGatedDeltaRuleFunctionVk(torch.autograd.Function):
     @staticmethod
     @input_guard
     @torch.amp.custom_fwd(device_type="cuda")
@@ -87,7 +98,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         scale: float,
         initial_state: torch.Tensor,
         output_final_state: bool,
-        cu_seqlens: torch.LongTensor | None = None,
+        cu_seqlens: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = False,
         o: torch.Tensor | None = None,
     ):
@@ -95,10 +106,11 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             q = l2norm_fwd(q)
             k = l2norm_fwd(k)
 
-        # NOTE: input_guard calls .contiguous() on every Tensor arg including
-        # o. The public chunk_gated_delta_rule entry point pre-asserts o is
-        # contiguous before .apply() so this can't silently clone.
-        g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
+        # NOTE: input_guard calls .contiguous() on every Tensor arg including o.
+        # For our intended caller (a contiguous output buffer) that is a no-op
+        # and returns the same storage, so the inplace contract is preserved.
+        # chunk_fwd_o_vk asserts contiguity again as a backstop.
+        g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd_vk(
             q=q,
             k=k,
             v=v,
@@ -120,7 +132,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
 
 
 @torch.compiler.disable
-def chunk_gated_delta_rule(
+def chunk_gated_delta_rule_vk(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -129,44 +141,39 @@ def chunk_gated_delta_rule(
     scale: float = None,
     initial_state: torch.Tensor = None,
     output_final_state: bool = False,
-    cu_seqlens: torch.LongTensor | None = None,
-    head_first: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     o: torch.Tensor | None = None,
 ):
     r"""
     Args:
         q (torch.Tensor):
-            queries of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+            Queries of shape `[B, T, H, K]`.
         k (torch.Tensor):
-            keys of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+            Keys of shape `[B, T, H, K]`.
         v (torch.Tensor):
-            values of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+            Values of shape `[B, T, H, V]`.
         g (torch.Tensor):
-            (forget) gating tensor (in log space!) of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+            (forget) Gating tensor (in log space!) of shape `[B, T, H]`.
         beta (torch.Tensor):
-            betas of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+            Betas of shape `[B, T, H]`.
         scale (Optional[int]):
             Scale factor for the RetNet attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
         initial_state (Optional[torch.Tensor]):
-            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            Initial state of shape `[N, H, V, K]` for `N` input sequences.
             For equal-length input sequences, `N` equals the batch size `B`.
             Default: `None`.
         output_final_state (Optional[bool]):
-            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
-        cu_seqlens (torch.LongTensor):
+            Whether to output the final state of shape `[N, H, V, K]`. Default: `False`.
+        cu_seqlens (torch.Tensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
-        head_first (Optional[bool]):
-            Whether the inputs are in the head-first format, which is not supported for variable-length inputs.
-            Default: `False`.
-
     Returns:
         o (torch.Tensor):
-            Outputs of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+            Outputs of shape `[B, T, H, V]`.
         final_state (torch.Tensor):
-            Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+            Final state of shape `[N, H, V, K]` if `output_final_state=True` else `None`.
 
     Examples::
         >>> import torch
@@ -180,7 +187,7 @@ def chunk_gated_delta_rule(
         >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
         >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
         >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
-        >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
+        >>> h0 = torch.randn(B, H, V, K, dtype=torch.bfloat16, device='cuda')
         >>> o, ht = chunk_gated_delta_rule(
             q, k, v, g, beta,
             initial_state=h0,
@@ -189,7 +196,7 @@ def chunk_gated_delta_rule(
         # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
         >>> q, k, v, beta, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta, g))
         # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
-        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.int32)
         >>> o_var, ht_var = chunk_gated_delta_rule(
             q, k, v, g, beta,
             initial_state=h0,
@@ -198,38 +205,14 @@ def chunk_gated_delta_rule(
         )
     """
     assert q.dtype == k.dtype == v.dtype
-    assert (
-        q.dtype != torch.float32
-    ), "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
-    assert (
-        len(beta.shape) == 3
-    ), "beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
-
-    if o is not None and head_first:
-        # head_first=True + o= would route the kernel output through a
-        # rearrange("b t h ... -> b h t ...") below, producing a
-        # non-contiguous view of the caller's storage and silently
-        # breaking the inplace contract. Reject up front BEFORE the
-        # existing head_first DeprecationWarning so callers see the more
-        # specific error.
-        raise NotImplementedError(
-            "chunk_gated_delta_rule(o=...) does not support head_first=True"
-        )
-
-    if head_first:
-        raise DeprecationWarning(
-            "head_first is deprecated and will be removed in a future version. "
-            "Please use head_first=False for now instead.",
-            stacklevel=2,
-        )
-        q, k, v, beta, g = map(
-            lambda x: rearrange(x, "b h t ... -> b t h ..."), (q, k, v, beta, g)
-        )
-    if not head_first and q.shape[1] < q.shape[2]:
+    assert q.dtype != torch.float32, (
+        "ChunkGatedDeltaRuleFunctionVk does not support float32. Please use bfloat16."
+    )
+    assert len(beta.shape) == 3, "beta must be of shape [B, T, H]."
+    if q.shape[1] < q.shape[2]:
         warnings.warn(
             f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
             "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
-            "when head_first=False was specified. "
             "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
             stacklevel=2,
         )
@@ -247,23 +230,51 @@ def chunk_gated_delta_rule(
     if scale is None:
         scale = k.shape[-1] ** -0.5
     if o is not None:
-        # Pre-check contiguity HERE — input_guard inside
-        # ChunkGatedDeltaRuleFunction.forward will call .contiguous() on
+        # Pre-check the inplace contract HERE — input_guard inside
+        # ChunkGatedDeltaRuleFunctionVk.forward will call .contiguous() on
         # every Tensor arg including o, silently cloning a non-contiguous
-        # caller buffer and writing the kernel output into the clone
-        # instead of the caller's storage. Asserting before .apply() is
-        # the only place where we can catch that loudly.
+        # caller buffer and writing the kernel output into the clone instead
+        # of the caller's storage. Asserting here, before .apply(), is the
+        # only place where we can catch that misuse loudly.
         assert o.shape == v.shape, (
-            f"chunk_gated_delta_rule: o.shape {tuple(o.shape)} != v.shape "
+            f"chunk_gated_delta_rule_vk: o.shape {tuple(o.shape)} != v.shape "
             f"{tuple(v.shape)}"
         )
         assert o.dtype == v.dtype, (
-            f"chunk_gated_delta_rule: o.dtype {o.dtype} != v.dtype {v.dtype}"
+            f"chunk_gated_delta_rule_vk: o.dtype {o.dtype} != v.dtype {v.dtype}"
         )
         assert o.is_contiguous(), (
-            "chunk_gated_delta_rule: caller-provided o must be contiguous"
+            "chunk_gated_delta_rule_vk: caller-provided o must be contiguous"
         )
-    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+
+    # Optional: dispatch to aiter's end-to-end flydsl prefill pipeline
+    # (K1+K2 fused, K3+K4 fused, K5 flydsl, K6 chunk_fwd_o_opt_vk).
+    # Enabled via ATOM_USE_FLYDSL_GDR_PREFILL=1 and only when the aiter
+    # flydsl-prefill package is importable. We dispatch HERE (not inside
+    # the autograd Function) because flydsl_gdr_prefill is a complete
+    # pipeline that handles l2norm and contiguity itself — bypassing
+    # input_guard and the autograd machinery is cleaner than threading
+    # the dispatch through them. The inplace o= contract is forwarded
+    # directly to aiter's flydsl_gdr_prefill via its `o=` parameter
+    # (which threads into chunk_fwd_o_opt_vk via the same mechanism).
+    from atom.utils import envs
+
+    if False and _HAS_FLYDSL_GDR_PREFILL:
+        return flydsl_gdr_prefill(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            cu_seqlens=cu_seqlens,
+            o=o,
+        )
+
+    o, final_state = ChunkGatedDeltaRuleFunctionVk.apply(
         q,
         k,
         v,
@@ -276,6 +287,4 @@ def chunk_gated_delta_rule(
         use_qk_l2norm_in_kernel,
         o,
     )
-    if head_first:
-        o = rearrange(o, "b t h ... -> b h t ...")
     return o, final_state

--- a/atom/model_ops/fla_ops/chunk_vk.py
+++ b/atom/model_ops/fla_ops/chunk_vk.py
@@ -28,7 +28,6 @@ from .utils import SUPPRESS_LEVEL, input_guard
 from .wy_fast import recompute_w_u_fwd
 
 
-
 def chunk_gated_delta_rule_fwd_vk(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -205,9 +204,9 @@ def chunk_gated_delta_rule_vk(
         )
     """
     assert q.dtype == k.dtype == v.dtype
-    assert q.dtype != torch.float32, (
-        "ChunkGatedDeltaRuleFunctionVk does not support float32. Please use bfloat16."
-    )
+    assert (
+        q.dtype != torch.float32
+    ), "ChunkGatedDeltaRuleFunctionVk does not support float32. Please use bfloat16."
     assert len(beta.shape) == 3, "beta must be of shape [B, T, H]."
     if q.shape[1] < q.shape[2]:
         warnings.warn(
@@ -240,12 +239,12 @@ def chunk_gated_delta_rule_vk(
             f"chunk_gated_delta_rule_vk: o.shape {tuple(o.shape)} != v.shape "
             f"{tuple(v.shape)}"
         )
-        assert o.dtype == v.dtype, (
-            f"chunk_gated_delta_rule_vk: o.dtype {o.dtype} != v.dtype {v.dtype}"
-        )
-        assert o.is_contiguous(), (
-            "chunk_gated_delta_rule_vk: caller-provided o must be contiguous"
-        )
+        assert (
+            o.dtype == v.dtype
+        ), f"chunk_gated_delta_rule_vk: o.dtype {o.dtype} != v.dtype {v.dtype}"
+        assert (
+            o.is_contiguous()
+        ), "chunk_gated_delta_rule_vk: caller-provided o must be contiguous"
 
     # Optional: dispatch to aiter's end-to-end flydsl prefill pipeline
     # (K1+K2 fused, K3+K4 fused, K5 flydsl, K6 chunk_fwd_o_opt_vk).
@@ -257,22 +256,7 @@ def chunk_gated_delta_rule_vk(
     # the dispatch through them. The inplace o= contract is forwarded
     # directly to aiter's flydsl_gdr_prefill via its `o=` parameter
     # (which threads into chunk_fwd_o_opt_vk via the same mechanism).
-    from atom.utils import envs
 
-    if False and _HAS_FLYDSL_GDR_PREFILL:
-        return flydsl_gdr_prefill(
-            q=q,
-            k=k,
-            v=v,
-            g=g,
-            beta=beta,
-            scale=scale,
-            initial_state=initial_state,
-            output_final_state=output_final_state,
-            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-            cu_seqlens=cu_seqlens,
-            o=o,
-        )
 
     o, final_state = ChunkGatedDeltaRuleFunctionVk.apply(
         q,

--- a/atom/model_ops/fla_ops/chunk_vk.py
+++ b/atom/model_ops/fla_ops/chunk_vk.py
@@ -257,7 +257,6 @@ def chunk_gated_delta_rule_vk(
     # directly to aiter's flydsl_gdr_prefill via its `o=` parameter
     # (which threads into chunk_fwd_o_opt_vk via the same mechanism).
 
-
     o, final_state = ChunkGatedDeltaRuleFunctionVk.apply(
         q,
         k,

--- a/atom/plugin/vllm/attention_backend/attention_gdn.py
+++ b/atom/plugin/vllm/attention_backend/attention_gdn.py
@@ -34,7 +34,6 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 #     escape hatch (e.g. for A/B layout experiments). Selecting it on the
 #     plugin path will corrupt the prefill→decode ssm_state round-trip.
 from atom.model_ops.fla_ops.chunk_vk import chunk_gated_delta_rule_vk
-from atom.model_ops.fla_ops.chunk import chunk_gated_delta_rule as _chunk_gated_delta_rule_kv
 from atom.model_ops.fla_ops.fused_sigmoid_gating import (
     fused_sigmoid_gating_delta_rule_update,
 )
@@ -65,11 +64,7 @@ class ChunkGatedDeltaRule(nn.Module):
     def __init__(self, use_vk_layout: bool = True) -> None:
         super().__init__()
         self.use_vk_layout = use_vk_layout
-        self._fla_chunk_gated_delta_rule = (
-            chunk_gated_delta_rule_vk
-            if use_vk_layout
-            else _chunk_gated_delta_rule_kv
-        )
+        self._fla_chunk_gated_delta_rule = chunk_gated_delta_rule_vk
 
     def forward(
         self,

--- a/atom/plugin/vllm/attention_backend/attention_gdn.py
+++ b/atom/plugin/vllm/attention_backend/attention_gdn.py
@@ -16,9 +16,25 @@ from vllm.forward_context import get_forward_context
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
-from vllm.model_executor.layers.fla.ops import (
-    chunk_gated_delta_rule as fla_chunk_gated_delta_rule,
-)
+# Two prefill kernel options, selected per-instance via use_vk_layout:
+#
+#   * vk (default for the plugin path): ATOM-vendored verbatim port of
+#     vllm.model_executor.layers.fla.ops.chunk. Writes ssm_state as
+#     `[N, H, V, K]` per slot — matches the layout vLLM allocates via
+#     MambaStateShapeCalculator.gated_delta_net_state_shape and the layout
+#     that this file's decode kernels (fused_sigmoid_gating_delta_rule_update,
+#     flydsl_gdr_decode) read. Bit-exact agreement with vLLM upstream
+#     verified by tests/test_chunk_gated_delta_rule_vk.py.
+#
+#   * kv: ATOM's original chunk_gated_delta_rule in chunk.py. Writes
+#     ssm_state as `[N, H, K, V]` per slot. Used by the non-plugin
+#     ATOM-native GDN backend, which pairs it with its kv-layout decode
+#     kernel `fused_recurrent_gated_delta_rule`. NOT compatible with the
+#     plugin path's decode kernels — included here as a developer-only
+#     escape hatch (e.g. for A/B layout experiments). Selecting it on the
+#     plugin path will corrupt the prefill→decode ssm_state round-trip.
+from atom.model_ops.fla_ops.chunk_vk import chunk_gated_delta_rule_vk
+from atom.model_ops.fla_ops.chunk import chunk_gated_delta_rule as _chunk_gated_delta_rule_kv
 from atom.model_ops.fla_ops.fused_sigmoid_gating import (
     fused_sigmoid_gating_delta_rule_update,
 )
@@ -38,8 +54,22 @@ except ImportError:
 
 
 class ChunkGatedDeltaRule(nn.Module):
-    def __init__(self) -> None:
+    """Prefill kernel wrapper.
+
+    The choice between vk- and kv-layout chunk kernels is resolved at
+    construction time so .forward stays branch-free. See the module-level
+    import comment for the layout semantics and the constraint that the
+    plugin path's decode kernels are vk-only.
+    """
+
+    def __init__(self, use_vk_layout: bool = True) -> None:
         super().__init__()
+        self.use_vk_layout = use_vk_layout
+        self._fla_chunk_gated_delta_rule = (
+            chunk_gated_delta_rule_vk
+            if use_vk_layout
+            else _chunk_gated_delta_rule_kv
+        )
 
     def forward(
         self,
@@ -52,8 +82,9 @@ class ChunkGatedDeltaRule(nn.Module):
         output_final_state: bool,
         cu_seqlens: torch.LongTensor | None = None,
         use_qk_l2norm_in_kernel: bool = True,
+        o: torch.Tensor | None = None,
     ):
-        return fla_chunk_gated_delta_rule(
+        return self._fla_chunk_gated_delta_rule(
             q=q,
             k=k,
             v=v,
@@ -63,6 +94,7 @@ class ChunkGatedDeltaRule(nn.Module):
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            o=o,
         )
 
 
@@ -159,8 +191,20 @@ class GatedDeltaNet(nn.Module):
         conv1d,
         activation,
         layer_num: int = 0,
+        use_vk_layout: bool = True,
         **kwargs,
     ):
+        """
+        Args:
+            use_vk_layout: When True (default), prefill writes ssm_state in
+                vLLM's `[V, K]`-per-head layout — required for this file's
+                decode kernels (fused_sigmoid_gating_delta_rule_update,
+                flydsl_gdr_decode) to read it correctly. The vLLM ssm_state
+                allocator (MambaStateShapeCalculator.gated_delta_net_state_shape)
+                also uses this layout. Set False ONLY for developer
+                experiments — the plugin path's decode kernels are vk-only,
+                so kv prefill would corrupt the prefill→decode round-trip.
+        """
         super().__init__()
         self.layer_num = layer_num
 
@@ -176,7 +220,10 @@ class GatedDeltaNet(nn.Module):
         self.num_v_heads = num_v_heads
         self.head_k_dim = head_k_dim
         self.head_v_dim = head_v_dim
-        self.chunk_gated_delta_rule = ChunkGatedDeltaRule()
+        self.use_vk_layout = use_vk_layout
+        self.chunk_gated_delta_rule = ChunkGatedDeltaRule(
+            use_vk_layout=use_vk_layout
+        )
 
     def rearrange_mixed_qkv(self, mixed_qkv):
         if mixed_qkv is None:
@@ -368,6 +415,18 @@ class GatedDeltaNet(nn.Module):
         if attn_metadata.num_prefills > 0:
             initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
             initial_state[~has_initial_state, ...] = 0
+            # When spec_sequence_masks is None, T_nonspec == num_actual_tokens
+            # and core_attn_out[:num_actual_tokens] is contiguous, so the
+            # prefill kernel can write its output directly into that slice —
+            # saves a `core_attn_out_non_spec.squeeze(0)` copy per layer per
+            # prefill step. With spec decode active, mixed_qkv was index_select'd
+            # by non_spec_token_indx so T_nonspec < num_actual_tokens and the
+            # merge below (index_copy_) needs a separately-allocated buffer to
+            # scatter back to the correct slot positions — fall back to o=None.
+            if spec_sequence_masks is None:
+                o_buf = core_attn_out[:num_actual_tokens].unsqueeze(0)
+            else:
+                o_buf = None
             (
                 core_attn_out_non_spec,
                 last_recurrent_state,
@@ -381,18 +440,16 @@ class GatedDeltaNet(nn.Module):
                 output_final_state=True,
                 cu_seqlens=non_spec_query_start_loc,
                 use_qk_l2norm_in_kernel=True,
+                o=o_buf,
             )
             # Init cache
             ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(
                 ssm_state.dtype
             )
-            # Only write directly when there are no spec tokens. With spec
-            # decode active, mixed_qkv was index_select'd by non_spec_token_indx
-            # so core_attn_out_non_spec has fewer rows than num_actual_tokens.
-            # The merge below (index_copy_) handles the scatter back to the
-            # correct slot positions.
-            if spec_sequence_masks is None:
-                core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
+            # When spec_sequence_masks is None the kernel already wrote into
+            # core_attn_out via o_buf — no copy needed here. With spec decode,
+            # core_attn_out_non_spec is a separate alloc and the merge below
+            # scatters it via index_copy_.
         elif attn_metadata.num_decodes > 0:
             o = core_attn_out[: attn_metadata.num_decode_tokens]
             if USE_FLYDSL_GDR:
@@ -402,8 +459,8 @@ class GatedDeltaNet(nn.Module):
                     query=query_non_spec,
                     key=key_non_spec,
                     value=value_non_spec,
-                    a=a,
-                    b=b,
+                    a=a.unsqueeze(1),
+                    b=b.unsqueeze(1),
                     dt_bias=self.dt_bias,
                     A_log=self.A_log,
                     indices=non_spec_state_indices_tensor,

--- a/atom/plugin/vllm/attention_backend/attention_gdn.py
+++ b/atom/plugin/vllm/attention_backend/attention_gdn.py
@@ -16,6 +16,7 @@ from vllm.forward_context import get_forward_context
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+
 # Two prefill kernel options, selected per-instance via use_vk_layout:
 #
 #   * vk (default for the plugin path): ATOM-vendored verbatim port of
@@ -216,9 +217,7 @@ class GatedDeltaNet(nn.Module):
         self.head_k_dim = head_k_dim
         self.head_v_dim = head_v_dim
         self.use_vk_layout = use_vk_layout
-        self.chunk_gated_delta_rule = ChunkGatedDeltaRule(
-            use_vk_layout=use_vk_layout
-        )
+        self.chunk_gated_delta_rule = ChunkGatedDeltaRule(use_vk_layout=use_vk_layout)
 
     def rearrange_mixed_qkv(self, mixed_qkv):
         if mixed_qkv is None:

--- a/atom/plugin/vllm/attention_backend/gdn_attn.py
+++ b/atom/plugin/vllm/attention_backend/gdn_attn.py
@@ -6,28 +6,6 @@ from typing import Type
 from atom.plugin.vllm.attention_backend.attention_gdn import GatedDeltaNet
 
 
-class _PluginGatedDeltaNet(GatedDeltaNet):
-    """Plugin-path GatedDeltaNet with vk layout hard-wired on.
-
-    vLLM's attention-backend protocol resolves `get_impl_cls()` to a class
-    and then constructs it with its own argument list — it doesn't accept
-    pre-bound kwargs from us. To express the plugin-path constraint that
-    ssm_state must be written in vk (`[V, K]`-per-head) layout — required
-    by the decode kernels this path uses (fused_sigmoid_gating_delta_rule_update
-    and flydsl_gdr_decode) — we subclass GatedDeltaNet and force the flag
-    in __init__ regardless of what vLLM passes through **kwargs.
-
-    See atom/plugin/vllm/attention_backend/attention_gdn.py for the
-    layout semantics and why kv layout would corrupt this path.
-    """
-
-    def __init__(self, *args, **kwargs):
-        # Force vk regardless of caller. Drop any caller-supplied value to
-        # avoid silent override.
-        kwargs.pop("use_vk_layout", None)
-        super().__init__(*args, use_vk_layout=True, **kwargs)
-
-
 class GDNAttentionBackend:
     @staticmethod
     def get_name() -> str:
@@ -35,4 +13,4 @@ class GDNAttentionBackend:
 
     @staticmethod
     def get_impl_cls() -> Type["GatedDeltaNet"]:
-        return _PluginGatedDeltaNet
+        return GatedDeltaNet

--- a/atom/plugin/vllm/attention_backend/gdn_attn.py
+++ b/atom/plugin/vllm/attention_backend/gdn_attn.py
@@ -6,6 +6,28 @@ from typing import Type
 from atom.plugin.vllm.attention_backend.attention_gdn import GatedDeltaNet
 
 
+class _PluginGatedDeltaNet(GatedDeltaNet):
+    """Plugin-path GatedDeltaNet with vk layout hard-wired on.
+
+    vLLM's attention-backend protocol resolves `get_impl_cls()` to a class
+    and then constructs it with its own argument list — it doesn't accept
+    pre-bound kwargs from us. To express the plugin-path constraint that
+    ssm_state must be written in vk (`[V, K]`-per-head) layout — required
+    by the decode kernels this path uses (fused_sigmoid_gating_delta_rule_update
+    and flydsl_gdr_decode) — we subclass GatedDeltaNet and force the flag
+    in __init__ regardless of what vLLM passes through **kwargs.
+
+    See atom/plugin/vllm/attention_backend/attention_gdn.py for the
+    layout semantics and why kv layout would corrupt this path.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Force vk regardless of caller. Drop any caller-supplied value to
+        # avoid silent override.
+        kwargs.pop("use_vk_layout", None)
+        super().__init__(*args, use_vk_layout=True, **kwargs)
+
+
 class GDNAttentionBackend:
     @staticmethod
     def get_name() -> str:
@@ -13,4 +35,4 @@ class GDNAttentionBackend:
 
     @staticmethod
     def get_impl_cls() -> Type["GatedDeltaNet"]:
-        return GatedDeltaNet
+        return _PluginGatedDeltaNet


### PR DESCRIPTION
## Motivation
Port the vllm's vk layout prefill chunk gated delta rule into atom, and make it support output buffer for inplace write

w/o inplace write o:
isl/osl: 10000/1000 c16
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  84.07     
Total input tokens:                      1280000   
Total generated tokens:                  128000    
Request throughput (req/s):              1.52      
Output token throughput (tok/s):         1522.57   
Peak output token throughput (tok/s):    1956.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          16748.22  
---------------Time to First Token----------------
Mean TTFT (ms):                          1223.61   
Median TTFT (ms):                        1190.04   
P99 TTFT (ms):                           2062.04   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.29      
Median TPOT (ms):                        9.22      
P99 TPOT (ms):                           10.48     
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.31      
Median ITL (ms):                         8.46      
P99 ITL (ms):                            9.63      
==================================================
```
w inplace write o:
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  79.60     
Total input tokens:                      1280000   
Total generated tokens:                  128000    
Request throughput (req/s):              1.61      
Output token throughput (tok/s):         1608.08   
Peak output token throughput (tok/s):    2128.00   
Peak concurrent requests:                31.00     
Total token throughput (tok/s):          17688.87  
---------------Time to First Token----------------
Mean TTFT (ms):                          1172.53   
Median TTFT (ms):                        1295.18   
P99 TTFT (ms):                           2063.27   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          8.77      
Median TPOT (ms):                        8.70      
P99 TPOT (ms):                           9.85      
---------------Inter-token Latency----------------
Mean ITL (ms):                           8.79      
Median ITL (ms):                         7.95      
P99 ITL (ms):                            9.05      
==================================================

```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
