### PR TITLE
[fix][attn] MiMo-V2-Flash fp8 + prefix cache crash in _gather_prefix_and_concat_kv

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -338,6 +338,12 @@ class PagedAttentionImpl(nn.Module):
                 use_shuffle = True
                 k_cache_gather = k_cache
                 v_cache_gather = v_cache.view(n, nh, block_size // x, head_dim, x)
+            elif v_cache.dim() == 5:
+                # MiMo-V2-Flash per-layer allocator (aiter_attention.py:461) emits
+                # v_cache natively as 5D SHUFFLE [n, nh, bs//x, hd, x]; pass through.
+                use_shuffle = True
+                k_cache_gather = k_cache
+                v_cache_gather = v_cache
             else:
                 # fused_qk_rope_reshape_and_cache: V [n, nh, hd, bs] -> NHD
                 use_shuffle = False

--- a/atom/model_ops/base_attention.py
+++ b/atom/model_ops/base_attention.py
@@ -55,7 +55,10 @@ def cp_mha_gather_cache_kernel(
 ):
     token_id = tl.program_id(0)
     head_id = tl.program_id(1)
+    # BLOCK_SIZE is rounded up to next pow2 at the call site (tl.arange requires
+    # pow2); col_mask guards stores/loads when head_size is non-pow2 (e.g. MiMo SWA=192).
     col_offsets = tl.arange(0, BLOCK_SIZE)
+    col_mask = col_offsets < head_size
 
     key_ptr_offset = key_ptr + token_id * head_size * num_heads + head_id * head_size
     value_ptr_offset = (
@@ -87,8 +90,8 @@ def cp_mha_gather_cache_kernel(
             + slot_id * num_heads * head_size
             + head_id * head_size
         )
-        k_reg = tl.load(key_cache_ptr_offset + col_offsets)
-        v_reg = tl.load(value_cache_ptr_offset + col_offsets)
+        k_reg = tl.load(key_cache_ptr_offset + col_offsets, mask=col_mask)
+        v_reg = tl.load(value_cache_ptr_offset + col_offsets, mask=col_mask)
         if DEQUANT:
             if PER_TOKEN_QUANT:
                 scale_offset = (
@@ -102,8 +105,8 @@ def cp_mha_gather_cache_kernel(
                 v_scale = tl.load(v_scale_ptr)
             k_reg = k_reg.to(tl.float32) * k_scale
             v_reg = v_reg.to(tl.float32) * v_scale
-        tl.store(key_ptr_offset + col_offsets, k_reg)
-        tl.store(value_ptr_offset + col_offsets, v_reg)
+        tl.store(key_ptr_offset + col_offsets, k_reg, mask=col_mask)
+        tl.store(value_ptr_offset + col_offsets, v_reg, mask=col_mask)
 
     elif CACHE_FORMAT == "SHUFFLE":
         # for kv cache layout as
@@ -124,8 +127,8 @@ def cp_mha_gather_cache_kernel(
         )
         k_reg_offset = col_offsets // x * PAGE_SIZE * x + col_offsets % x
         v_reg_offset = col_offsets * x
-        k_reg = tl.load(key_cache_ptr_offset + k_reg_offset)
-        v_reg = tl.load(value_cache_ptr_offset + v_reg_offset)
+        k_reg = tl.load(key_cache_ptr_offset + k_reg_offset, mask=col_mask)
+        v_reg = tl.load(value_cache_ptr_offset + v_reg_offset, mask=col_mask)
         if DEQUANT:
             if PER_TOKEN_QUANT:
                 scale_offset = (
@@ -139,8 +142,8 @@ def cp_mha_gather_cache_kernel(
                 v_scale = tl.load(v_scale_ptr)
             k_reg = k_reg.to(tl.float32) * k_scale
             v_reg = v_reg.to(tl.float32) * v_scale
-        tl.store(key_ptr_offset + col_offsets, k_reg)
-        tl.store(value_ptr_offset + col_offsets, v_reg)
+        tl.store(key_ptr_offset + col_offsets, k_reg, mask=col_mask)
+        tl.store(value_ptr_offset + col_offsets, v_reg, mask=col_mask)
 
 
 def cp_mha_gather_cache(
@@ -211,7 +214,7 @@ def cp_mha_gather_cache(
         PER_TOKEN_QUANT=per_token_quant,
         PAGE_SIZE=page_size,
         CACHE_FORMAT=kv_cache_layout,
-        BLOCK_SIZE=head_dim,
+        BLOCK_SIZE=triton.next_power_of_2(head_dim),
     )
 
 


### PR DESCRIPTION
## Summary

Two related bugs in the chunked-prefill cached-KV gather path that crash MiMo-V2-Flash whenever prefix caching hits. Each bug masks the next, so they have to be fixed together.

**Repro:** `python -m atom.entrypoints.openai_server --model XiaomiMiMo/MiMo-V2-Flash --kv_cache_dtype fp8 -tp 4 --trust-remote-code --method mtp` (per `recipes/MiMo-V2-Flash.md`), then any multi-request workload that shares a prefix — e.g. `lm_eval --tasks gsm8k --num_fewshot 5` at conc=64. Single short prompts skip the path because `has_cached=False`.

### Bug 1: `_gather_prefix_and_concat_kv` (`atom/model_ops/attention_mha.py`)

The `v_cache` dimension dispatch only covers 4D-storage-viewed-into-5D-SHUFFLE and 4D-NHD. MiMo-V2-Flash uses a per-layer KV allocator (`atom/model_ops/attentions/aiter_attention.py:461`) that emits `v_cache` **natively as 5D SHUFFLE** `[n, nh, bs//x, hd, x]` (other models share a 4D pool that `build_kv_cache_tensor` views into 5D on demand). The 5D-native case falls through to the 4D-NHD branch and hits `v_cache.permute(0, 3, 1, 2)`, which on a 5D tensor raises:

```
RuntimeError: permute(sparse_coo): number of dimensions in the tensor input does
not match the length of the desired ordering of dimensions
i.e. input.dim() = 5 is not equal to len(dims) = 4
```

(The `sparse_coo` label in the message is just the dispatcher fallback name — the tensor is dense, the failure is the dim mismatch.)

**Fix:** add an `elif v_cache.dim() == 5` branch that passes the tensor through unchanged, since downstream `cp_mha_gather_cache` already expects the SHUFFLE layout.

### Bug 2: `cp_mha_gather_cache_kernel` (`atom/model_ops/base_attention.py`)

Once Bug 1 is fixed the kernel itself is reached with MiMo SWA `head_dim=192`, and the `BLOCK_SIZE=head_dim` constexpr trips:

```
triton.compiler.errors.CompilationError: at 26:18:
    col_offsets = tl.arange(0, BLOCK_SIZE)
                  ^
arange's range must be a power of 2
```

**Fix:** round `BLOCK_SIZE` up to `triton.next_power_of_2(head_dim)` at the call site and add `col_mask = col_offsets < head_size` to all four `tl.load` / `tl.store` calls (NHD + SHUFFLE branches).

**Subtlety:** do NOT pass `other=0` on the masked loads — Triton converts the int32 literal to the cache element type, which under fp8_e4nv raises `AssertionError: cannot cast int32[constexpr[256]] to <['256'], fp8e4nv>`. Mask-only is safe because the matching `tl.store` is also masked, so the garbage loaded into the lanes `[head_size .. BLOCK_SIZE)` is never written.

## Verification

MiMo-V2-Flash TP4 fp8 KV + MTP (`--method mtp`, `num-spec-tokens=1`), `lm_eval --tasks gsm8k --num_fewshot 5` conc=64:

| config | gsm8k flex-extract | gsm8k strict-match |
|---|---|---|
| prefix-cache OFF (baseline) | 0.8378 ± 0.0102 | 0.8317 ± 0.0103 |
| **patched + prefix-cache ON** | **0.8431 ± 0.0100** | **0.8317 ± 0.0103** |
| `recipes/MiMo-V2-Flash.md` reference | 0.8279 ± 0.0104 | 0.8211 ± 0.0106 |

All three configs agree within stderr. MTP acceptance rate ~84.6% (unaffected by the change).

## Risk / Blast radius

Non-MiMo paths are untouched:

- The new `elif v_cache.dim() == 5` branch only fires when the allocator returns a 5D tensor, which today is only the MiMo per-layer path (`is_mimo_v2()` branch in `aiter_attention.py:447`).
- The kernel changes are mask-only and a no-op for `head_dim` that is already a power of 2 — `tl.arange(0, head_dim)` for `head_dim ∈ {64, 128, 256}` rounds to itself, and the mask is uniformly true.

## Test plan

- [x] Repro the original crash on `main` (HEAD `eddde64f`) with the recipe command and `lm_eval gsm8k`.
- [x] Verify `--no-enable_prefix_caching` workaround completes and matches recipe accuracy → localizes the bug to `_gather_prefix_and_concat_kv`.
- [x] Apply patches, rerun the same `lm_eval` with prefix caching on; no crash, accuracy matches OFF baseline within stderr.
- [ ] Reviewer-side smoke on a non-MiMo model (DeepSeek-V3 / Qwen3-Next) to confirm the shared 4D `kv_cache[1, layer_id].view(...)` path is unaffected. Theoretically yes, but a 5-min `simple_inference` would lock it in.
- [ ] `atom benchmark_serving` prefix-cache on/off TTFT/TPOT delta on MiMo-V2-Flash for the perf regression record.