### PR TITLE
mla: chunked-prefix prefill path to bound has_cached workspace

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -932,6 +932,7 @@ class Config:
     model: str
     trust_remote_code: bool = False
     max_num_batched_tokens: int = 16384
+    max_num_scheduled_tokens: int = 16384
     scheduler_delay_factor: float = 0.0
     max_num_seqs: int = 512
     max_model_len: int | None = None

--- a/atom/config.py
+++ b/atom/config.py
@@ -932,7 +932,7 @@ class Config:
     model: str
     trust_remote_code: bool = False
     max_num_batched_tokens: int = 16384
-    max_num_scheduled_tokens: int = 16384
+    mla_prefill_chunk_size: int = 16384
     scheduler_delay_factor: float = 0.0
     max_num_seqs: int = 512
     max_model_len: int | None = None

--- a/atom/config.py
+++ b/atom/config.py
@@ -932,7 +932,7 @@ class Config:
     model: str
     trust_remote_code: bool = False
     max_num_batched_tokens: int = 16384
-    mla_prefill_chunk_size: int = 16384
+    attn_prefill_chunk_size: int = 16384
     scheduler_delay_factor: float = 0.0
     max_num_seqs: int = 512
     max_model_len: int | None = None

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -38,7 +38,7 @@ class EngineArgs:
     block_size: int = 16
     max_model_len: Optional[int] = None
     max_num_batched_tokens: int = 16384
-    max_num_scheduled_tokens: int = 16384
+    mla_prefill_chunk_size: int = 16384
     scheduler_delay_factor: float = 0.0
     max_num_seqs: int = 512
     gpu_memory_utilization: float = 0.9
@@ -191,7 +191,7 @@ class EngineArgs:
             help="Maximum number of tokens to batch together in async engine",
         )
         parser.add_argument(
-            "--max-num-scheduled-tokens",
+            "--mla-prefill-chunk-size",
             type=int,
             default=16384,
             help=(

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -38,6 +38,7 @@ class EngineArgs:
     block_size: int = 16
     max_model_len: Optional[int] = None
     max_num_batched_tokens: int = 16384
+    max_num_scheduled_tokens: int = 16384
     scheduler_delay_factor: float = 0.0
     max_num_seqs: int = 512
     gpu_memory_utilization: float = 0.9
@@ -188,6 +189,15 @@ class EngineArgs:
             type=int,
             default=16384,
             help="Maximum number of tokens to batch together in async engine",
+        )
+        parser.add_argument(
+            "--max-num-scheduled-tokens",
+            type=int,
+            default=16384,
+            help=(
+                "MLA chunked-prefill budget in tokens. Default uses "
+                "max_num_batched_tokens."
+            ),
         )
         parser.add_argument(
             "--max-num-seqs",

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -38,7 +38,7 @@ class EngineArgs:
     block_size: int = 16
     max_model_len: Optional[int] = None
     max_num_batched_tokens: int = 16384
-    mla_prefill_chunk_size: int = 16384
+    attn_prefill_chunk_size: int = 16384
     scheduler_delay_factor: float = 0.0
     max_num_seqs: int = 512
     gpu_memory_utilization: float = 0.9
@@ -191,7 +191,7 @@ class EngineArgs:
             help="Maximum number of tokens to batch together in async engine",
         )
         parser.add_argument(
-            "--mla-prefill-chunk-size",
+            "--attn-prefill-chunk-size",
             type=int,
             default=16384,
             help=(

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -337,6 +337,202 @@ class MLAAttention(nn.Module):
 
         return result
 
+    def _forward_prefill_cached_single_pass(
+        self,
+        prefill_q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: AttentionMetaData,
+    ) -> torch.Tensor:
+        """Legacy single-pass path: gather the full cached+new context into
+        k_full / v_full and run one flash_attn. OOMs on long contexts (peak
+        ≈ total_kv × heads × (qk_dim + v_dim) × dtype)."""
+        k_full = torch.empty(
+            (
+                attn_metadata.total_kv,
+                self.num_heads,
+                self.qk_nope_head_dim + self.qk_rope_head_dim,
+            ),
+            device=prefill_q.device,
+            dtype=self.dtype,
+        )
+        v_full = torch.empty(
+            (attn_metadata.total_kv, self.num_heads, self.v_head_dim),
+            device=prefill_q.device,
+            dtype=self.dtype,
+        )
+        gather_kv_b_proj(
+            kv_cache,
+            self._k_scale,
+            attn_metadata.kv_indptr,
+            attn_metadata.kv_indices,
+            attn_metadata.cu_seqlens_k,
+            self.kv_b_proj.weight,
+            self.kv_b_proj.weight_scale,
+            k_full,
+            v_full,
+            weight_preshuffle=getattr(self.kv_b_proj.weight, "is_shuffled", False),
+        )
+        output = flash_attn_varlen_func(
+            q=prefill_q,
+            k=k_full,
+            v=v_full,
+            cu_seqlens_q=attn_metadata.cu_seqlens_q,
+            cu_seqlens_k=attn_metadata.cu_seqlens_k,
+            max_seqlen_q=attn_metadata.max_seqlen_q,
+            max_seqlen_k=attn_metadata.max_seqlen_k,
+            min_seqlen_q=attn_metadata.min_seqlen_q,
+            dropout_p=attn_metadata.dropout_p,
+            softmax_scale=self.scale,
+            causal=True,
+        )
+        return self.o_proj(output.flatten(start_dim=-2))
+
+    def _forward_prefill_cached_chunked(
+        self,
+        prefill_q: torch.Tensor,
+        kv_c_normed_new: torch.Tensor,
+        k_rope_new: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: AttentionMetaData,
+        chunk_meta,
+    ) -> torch.Tensor:
+        """Chunked prefill for the has_cached branch.
+
+        Pattern (mirrors atom/plugin/attention_mha.py:extend_forward): the
+        cached prefix and the new tokens are attended separately and merged
+        via softmax-LSE recombination. This bounds peak memory to
+        ``CHUNK_TOKENS × heads × (qk_dim + v_dim)``, independent of context
+        length.
+
+        Step 1 — new-tokens self-attention (causal). New k/v come from
+        kv_b_proj on the input latent kv_c_normed; cu_seqlens_k = cu_seqlens_q.
+        Step 2 — per chunk c of the cached prefix: gather_kv_b_proj into the
+        shared workspace, flash_attn(causal=False, return_lse), merge into a
+        running (chunked_out, chunked_lse).
+        Step 3 — final merge of (chunked_out, chunked_lse) with (new_out,
+        new_lse). The cached prefix is the "prefix" side (smaller token
+        positions), new tokens are the "suffix".
+        """
+        from atom.model_ops.attentions.triton_merge_attn_states import merge_attn_states
+
+        # Trigger counter: log first hit + every 500th to confirm the chunked
+        # path is actually exercised (not silently bypassed when
+        # has_cached=True but cached prefix < CHUNK_TOKENS for every seq).
+        # Counter is class-level so all layers/instances share a single count.
+        n = MLAAttention._chunked_prefill_calls = (
+            getattr(MLAAttention, "_chunked_prefill_calls", 0) + 1
+        )
+        if n == 1 or n % 500 == 0:
+            logger.info(
+                "MLA chunked-prefill #%d: layer=%d num_chunks=%d "
+                "total_kv=%d cu_seqlens_q[-1]=%d",
+                n,
+                self.layer_num,
+                chunk_meta.num_chunks,
+                attn_metadata.total_kv,
+                int(attn_metadata.cu_seqlens_q[-1].item()),
+            )
+
+        weight_preshuffle = getattr(self.kv_b_proj.weight, "is_shuffled", False)
+
+        # Step 1: new-tokens self-attn via kv_b_proj on the latent.
+        if k_rope_new.dim() == 2:
+            k_rope_new = k_rope_new.unsqueeze(1)
+        kv_nope_new = self.kv_b_proj(kv_c_normed_new).view(
+            -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
+        )
+        k_nope_new, v_new = kv_nope_new.split(
+            [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+        )
+        k_new = torch.cat(
+            (k_nope_new, k_rope_new.expand((*k_nope_new.shape[:-1], -1))), dim=-1
+        )
+        new_out, new_lse = flash_attn_varlen_func(
+            q=prefill_q,
+            k=k_new,
+            v=v_new,
+            cu_seqlens_q=attn_metadata.cu_seqlens_q,
+            cu_seqlens_k=attn_metadata.cu_seqlens_q,
+            max_seqlen_q=attn_metadata.max_seqlen_q,
+            max_seqlen_k=attn_metadata.max_seqlen_q,
+            min_seqlen_q=attn_metadata.min_seqlen_q,
+            dropout_p=attn_metadata.dropout_p,
+            softmax_scale=self.scale,
+            causal=True,
+            return_lse=True,
+        )
+
+        # Step 2: chunked cached-prefix attention.
+        k_workspace = chunk_meta.k_workspace
+        v_workspace = chunk_meta.v_workspace
+        chunked_out: Optional[torch.Tensor] = None
+        chunked_lse: Optional[torch.Tensor] = None
+        for c in range(chunk_meta.num_chunks):
+            n_tok = chunk_meta.total_tokens[c]
+            if n_tok == 0:
+                continue
+            k_chunk = k_workspace[:n_tok]
+            v_chunk = v_workspace[:n_tok]
+            gather_kv_b_proj(
+                kv_cache,
+                self._k_scale,
+                chunk_meta.kv_indptr[c],
+                chunk_meta.kv_indices[c],
+                chunk_meta.cu_seqlens_k[c],
+                self.kv_b_proj.weight,
+                self.kv_b_proj.weight_scale,
+                k_chunk,
+                v_chunk,
+                weight_preshuffle=weight_preshuffle,
+            )
+            suf_out, suf_lse = flash_attn_varlen_func(
+                q=prefill_q,
+                k=k_chunk,
+                v=v_chunk,
+                cu_seqlens_q=attn_metadata.cu_seqlens_q,
+                cu_seqlens_k=chunk_meta.cu_seqlens_k[c],
+                max_seqlen_q=attn_metadata.max_seqlen_q,
+                max_seqlen_k=chunk_meta.max_seqlen_k[c],
+                min_seqlen_q=attn_metadata.min_seqlen_q,
+                dropout_p=attn_metadata.dropout_p,
+                softmax_scale=self.scale,
+                causal=False,
+                return_lse=True,
+            )
+            if chunked_out is None:
+                chunked_out = suf_out
+                chunked_lse = suf_lse
+            else:
+                tmp_out = torch.empty_like(new_out)
+                tmp_lse = torch.empty_like(new_lse)
+                merge_attn_states(
+                    output=tmp_out,
+                    output_lse=tmp_lse,
+                    prefix_output=chunked_out,
+                    prefix_lse=chunked_lse,
+                    suffix_output=suf_out,
+                    suffix_lse=suf_lse,
+                )
+                chunked_out = tmp_out
+                chunked_lse = tmp_lse
+
+        # Step 3: merge cached prefix (prefix) with new tokens (suffix).
+        # If every seq happened to have zero cached tokens this iter, fall
+        # back to the new-only output (should not happen since has_cached
+        # implies ≥1 seq has cached_len > 0).
+        if chunked_out is None:
+            output = new_out
+        else:
+            output = torch.empty_like(new_out)
+            merge_attn_states(
+                output=output,
+                prefix_output=chunked_out,
+                prefix_lse=chunked_lse,
+                suffix_output=new_out,
+                suffix_lse=new_lse,
+            )
+        return self.o_proj(output.flatten(start_dim=-2))
+
     def _forward_prefill_mha(
         self,
         q: torch.Tensor,
@@ -715,55 +911,15 @@ class MLAAttention(nn.Module):
                 )
 
             if attn_metadata.has_cached:
-                # k_full/v_full are used for attention compute; gather_kv_b_proj reads
-                # fp8 from cache and dequantizes internally, so output must be model dtype
-                k_full = torch.empty(
-                    (
-                        attn_metadata.total_kv,
-                        self.num_heads,
-                        self.qk_nope_head_dim + self.qk_rope_head_dim,
-                    ),
-                    device=q.device,
-                    dtype=self.dtype,
-                )
-                v_full = torch.empty(
-                    (
-                        attn_metadata.total_kv,
-                        self.num_heads,
-                        self.v_head_dim,
-                    ),
-                    device=q.device,
-                    dtype=self.dtype,
-                )
-
-                gather_kv_b_proj(
-                    kv_cache,
-                    self._k_scale,
-                    attn_metadata.kv_indptr,
-                    attn_metadata.kv_indices,
-                    attn_metadata.cu_seqlens_k,
-                    self.kv_b_proj.weight,
-                    self.kv_b_proj.weight_scale,
-                    k_full,
-                    v_full,
-                    weight_preshuffle=getattr(
-                        self.kv_b_proj.weight, "is_shuffled", False
-                    ),
-                )
-                output = flash_attn_varlen_func(
-                    q=prefill_q,
-                    k=k_full,
-                    v=v_full,
-                    cu_seqlens_q=attn_metadata.cu_seqlens_q,
-                    cu_seqlens_k=attn_metadata.cu_seqlens_k,
-                    max_seqlen_q=attn_metadata.max_seqlen_q,
-                    max_seqlen_k=attn_metadata.max_seqlen_k,
-                    min_seqlen_q=attn_metadata.min_seqlen_q,
-                    dropout_p=attn_metadata.dropout_p,
-                    softmax_scale=self.scale,
-                    causal=True,
-                )
-                output = self.o_proj(output.flatten(start_dim=-2))
+                chunk_meta = getattr(attn_metadata, "mla_chunk_meta", None)
+                if chunk_meta is not None:
+                    output = self._forward_prefill_cached_chunked(
+                        prefill_q, k_nope, k_rope, kv_cache, attn_metadata, chunk_meta
+                    )
+                else:
+                    output = self._forward_prefill_cached_single_pass(
+                        prefill_q, kv_cache, attn_metadata
+                    )
             else:
                 output = self._forward_prefill_mha(
                     prefill_q, k_nope, k_rope, kv_cache, attn_metadata

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -36,7 +36,7 @@ class MLAChunkContextMetadata:
     """Per-chunk slices of the cached prefix for chunked MLA prefill.
 
     Built host-side in `AiterMLAMetadataBuilder.prepare_prefill` when the
-    cached prefix exceeds `config.max_num_scheduled_tokens`. The forward iterates
+    cached prefix exceeds `config.mla_prefill_chunk_size`. The forward iterates
     these chunks instead of materializing the full `total_kv × heads × dim`
     k/v tensors (which OOM on long contexts).
 
@@ -211,20 +211,20 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         self.model_runner.forward_vars.update(mla_metadata)
 
         # Chunked-context workspaces for the prefill has_cached path. Sized
-        # to config.max_num_scheduled_tokens (defaults to max_num_batched_tokens)
+        # to config.mla_prefill_chunk_size (defaults to max_num_batched_tokens)
         # so peak memory is bounded regardless of total context length.
         # Allocated outside any per-step scope so a single buffer is shared
         # across all chunks and layers.
-        self.max_num_scheduled_tokens = config.max_num_scheduled_tokens
+        self.mla_prefill_chunk_size = config.mla_prefill_chunk_size
         self.k_chunk_workspace: Optional[torch.Tensor] = None
         self.v_chunk_workspace: Optional[torch.Tensor] = None
-        if self.max_num_scheduled_tokens > 0:
+        if self.mla_prefill_chunk_size > 0:
             qk_head_dim = hf_config.qk_nope_head_dim + hf_config.qk_rope_head_dim
             v_head_dim = hf_config.v_head_dim
             model_dtype = config.torch_dtype
             self.k_chunk_workspace = torch.empty(
                 (
-                    self.max_num_scheduled_tokens,
+                    self.mla_prefill_chunk_size,
                     self.num_attention_heads,
                     qk_head_dim,
                 ),
@@ -233,7 +233,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             )
             self.v_chunk_workspace = torch.empty(
                 (
-                    self.max_num_scheduled_tokens,
+                    self.mla_prefill_chunk_size,
                     self.num_attention_heads,
                     v_head_dim,
                 ),
@@ -790,9 +790,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # forward (self-attention via kv_b_proj), so chunks span only the
             # cached prefix.
             if (
-                self.max_num_scheduled_tokens > 0
+                self.mla_prefill_chunk_size > 0
                 and attn_metadata.has_cached
-                and attn_metadata.total_kv > self.max_num_scheduled_tokens
+                and attn_metadata.total_kv > self.mla_prefill_chunk_size
             ):
                 attn_metadata.mla_chunk_meta = self._build_mla_chunk_meta(batch, bs)
 
@@ -805,7 +805,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         """Build per-chunk slices of the cached prefix.
 
         Chunks the cached-prefix tokens along the GLOBAL token axis (not the
-        per-seq axis). Per-chunk total token count ≤ `max_num_scheduled_tokens`,
+        per-seq axis). Per-chunk total token count ≤ `mla_prefill_chunk_size`,
         which is what the k/v workspace is sized for. Each chunk c contains a
         contiguous slice of the concatenated per-seq slot list; per-seq
         contributions to chunk c are the intersection of seq i's slot range
@@ -815,7 +815,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         flash_attn returns lse=-inf which merge_attn_states handles correctly
         (the prefix output for that seq is preserved unchanged).
         """
-        chunk_size = self.max_num_scheduled_tokens
+        chunk_size = self.mla_prefill_chunk_size
         runner_bs = self.model_runner.block_size
 
         cached_lens = np.asarray(batch.num_cached_tokens[:bs], dtype=np.int64)

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -26,6 +26,10 @@ from atom.utils.block_convert import (
 )
 from atom.utils.forward_context import AttentionMetaData, Context
 
+from .backends import AttentionBackend, CommonAttentionBuilder
+
+logger = logging.getLogger("atom")
+
 
 @dataclass
 class MLAChunkContextMetadata:
@@ -57,11 +61,6 @@ class MLAChunkContextMetadata:
     v_workspace: torch.Tensor
 
 
-from .backends import AttentionBackend, CommonAttentionBuilder
-
-logger = logging.getLogger("atom")
-
-
 def cdiv(a, b):
     return (a + b - 1) // b
 
@@ -85,7 +84,6 @@ class AiterMLABackend(AttentionBackend):
     default_base_class=CommonAttentionBuilder
 )
 class AiterMLAMetadataBuilder(CommonAttentionBuilder):
-
     def __init__(self, model_runner):
         self.block_size = 1
         CommonAttentionBuilder.__init__(self, model_runner)

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -2,7 +2,8 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import logging
-from typing import Type
+from dataclasses import dataclass
+from typing import List, Optional, Type
 
 import numpy as np
 import torch
@@ -24,6 +25,37 @@ from atom.utils.block_convert import (
     kv_indices_generate_triton,
 )
 from atom.utils.forward_context import AttentionMetaData, Context
+
+
+@dataclass
+class MLAChunkContextMetadata:
+    """Per-chunk slices of the cached prefix for chunked MLA prefill.
+
+    Built host-side in `AiterMLAMetadataBuilder.prepare_prefill` when the
+    cached prefix exceeds `config.max_num_scheduled_tokens`. The forward iterates
+    these chunks instead of materializing the full `total_kv × heads × dim`
+    k/v tensors (which OOM on long contexts).
+
+    Each list entry [c] holds the chunk-c data:
+      kv_indptr[c]:   [bs+1] cumulative chunk-local block range per seq
+      kv_indices[c]:  [sum_chunk_blocks] physical block ids for this chunk
+      cu_seqlens_k[c]: [bs+1] cumulative chunk-local token counts per seq
+      total_tokens[c]: int — sum of per-seq chunk lengths
+      max_seqlen_k[c]: int — max per-seq chunk length
+
+    `k_workspace` / `v_workspace` are shared across chunks (overwritten each
+    iteration); only `[:total_tokens[c]]` is valid for chunk c.
+    """
+
+    kv_indptr: List[torch.Tensor]
+    kv_indices: List[torch.Tensor]
+    cu_seqlens_k: List[torch.Tensor]
+    total_tokens: List[int]
+    max_seqlen_k: List[int]
+    num_chunks: int
+    k_workspace: torch.Tensor
+    v_workspace: torch.Tensor
+
 
 from .backends import AttentionBackend, CommonAttentionBuilder
 
@@ -179,6 +211,49 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             )
 
         self.model_runner.forward_vars.update(mla_metadata)
+
+        # Chunked-context workspaces for the prefill has_cached path. Sized
+        # to config.max_num_scheduled_tokens (defaults to max_num_batched_tokens)
+        # so peak memory is bounded regardless of total context length.
+        # Allocated outside any per-step scope so a single buffer is shared
+        # across all chunks and layers.
+        self.max_num_scheduled_tokens = config.max_num_scheduled_tokens
+        self.k_chunk_workspace: Optional[torch.Tensor] = None
+        self.v_chunk_workspace: Optional[torch.Tensor] = None
+        if self.max_num_scheduled_tokens > 0:
+            qk_head_dim = hf_config.qk_nope_head_dim + hf_config.qk_rope_head_dim
+            v_head_dim = hf_config.v_head_dim
+            model_dtype = config.torch_dtype
+            self.k_chunk_workspace = torch.empty(
+                (
+                    self.max_num_scheduled_tokens,
+                    self.num_attention_heads,
+                    qk_head_dim,
+                ),
+                dtype=model_dtype,
+                device=self.device,
+            )
+            self.v_chunk_workspace = torch.empty(
+                (
+                    self.max_num_scheduled_tokens,
+                    self.num_attention_heads,
+                    v_head_dim,
+                ),
+                dtype=model_dtype,
+                device=self.device,
+            )
+            mib = (
+                self.k_chunk_workspace.numel() * self.k_chunk_workspace.element_size()
+                + self.v_chunk_workspace.numel() * self.v_chunk_workspace.element_size()
+            ) / (1024 * 1024)
+            logger.info(
+                "Allocated MLA chunked-prefill workspaces: "
+                "k%s v%s (%.1f MiB total, dtype=%s)",
+                tuple(self.k_chunk_workspace.shape),
+                tuple(self.v_chunk_workspace.shape),
+                mib,
+                model_dtype,
+            )
 
         if self.is_sparse:
             self._token_to_seq_idxs_gpu = torch.zeros(
@@ -711,8 +786,109 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 attn_metadata.max_seqlen_k,
             )
 
+            # Build chunked-context metadata when enabled AND the cached
+            # prefix is large enough to risk OOM in the single-pass path.
+            # The non-cached new-tokens portion is handled separately by the
+            # forward (self-attention via kv_b_proj), so chunks span only the
+            # cached prefix.
+            if (
+                self.max_num_scheduled_tokens > 0
+                and attn_metadata.has_cached
+                and attn_metadata.total_kv > self.max_num_scheduled_tokens
+            ):
+                attn_metadata.mla_chunk_meta = self._build_mla_chunk_meta(batch, bs)
+
         attn_metadata.dtype_q = self.dtype_q
         return attn_metadata, positions
+
+    def _build_mla_chunk_meta(
+        self, batch: ScheduledBatch, bs: int
+    ) -> Optional[MLAChunkContextMetadata]:
+        """Build per-chunk slices of the cached prefix.
+
+        Chunks the cached-prefix tokens along the GLOBAL token axis (not the
+        per-seq axis). Per-chunk total token count ≤ `max_num_scheduled_tokens`,
+        which is what the k/v workspace is sized for. Each chunk c contains a
+        contiguous slice of the concatenated per-seq slot list; per-seq
+        contributions to chunk c are the intersection of seq i's slot range
+        with [c*K, (c+1)*K).
+
+        Seqs with 0 contribution to a chunk emit empty k for that seq —
+        flash_attn returns lse=-inf which merge_attn_states handles correctly
+        (the prefix output for that seq is preserved unchanged).
+        """
+        chunk_size = self.max_num_scheduled_tokens
+        runner_bs = self.model_runner.block_size
+
+        cached_lens = np.asarray(batch.num_cached_tokens[:bs], dtype=np.int64)
+        total_cached = int(cached_lens.sum())
+        if total_cached == 0:
+            return None
+        num_chunks = (total_cached + chunk_size - 1) // chunk_size
+
+        # Per-seq absolute slot id for every cached token, in seq order, then
+        # concatenated into a single global slot array of length total_cached.
+        per_seq_slots: List[np.ndarray] = []
+        for i in range(bs):
+            cached_len = int(cached_lens[i])
+            if cached_len == 0:
+                per_seq_slots.append(np.empty(0, dtype=np.int32))
+                continue
+            block_ids = np.asarray(batch.block_tables[i], dtype=np.int64)
+            needed_blocks = (cached_len + runner_bs - 1) // runner_bs
+            block_ids = block_ids[:needed_blocks]
+            base = block_ids[:, None] * runner_bs
+            offsets = np.arange(runner_bs, dtype=np.int64)[None, :]
+            slots = (base + offsets).reshape(-1)[:cached_len].astype(np.int32)
+            per_seq_slots.append(slots)
+        global_slots = (
+            np.concatenate(per_seq_slots) if bs > 0 else np.empty(0, np.int32)
+        )
+        seq_offsets = np.zeros(bs + 1, dtype=np.int64)
+        np.cumsum(cached_lens, out=seq_offsets[1:])
+
+        kv_indptr_list: List[torch.Tensor] = []
+        kv_indices_list: List[torch.Tensor] = []
+        cu_seqlens_k_list: List[torch.Tensor] = []
+        total_tokens_list: List[int] = []
+        max_seqlen_k_list: List[int] = []
+
+        for c in range(num_chunks):
+            g_start = c * chunk_size
+            g_end = min(g_start + chunk_size, total_cached)
+            # Per-seq contribution: intersect [seq_offsets[i], seq_offsets[i+1])
+            # with [g_start, g_end).
+            seq_lo = np.maximum(seq_offsets[:bs], g_start)
+            seq_hi = np.minimum(seq_offsets[1 : bs + 1], g_end)
+            per_seq_chunk_lens = np.maximum(seq_hi - seq_lo, 0).astype(np.int32)
+            chunk_indices = global_slots[g_start:g_end].astype(np.int32, copy=False)
+            cu = np.zeros(bs + 1, dtype=np.int32)
+            np.cumsum(per_seq_chunk_lens, out=cu[1:])
+            total_tokens = int(cu[-1])
+            # cu doubles as gather_kv_b_proj kv_indptr (block_size=1 → block
+            # indptr == token indptr) and flash_attn cu_seqlens_k.
+            kv_indptr_list.append(
+                torch.from_numpy(cu).pin_memory().to(self.device, non_blocking=True)
+            )
+            kv_indices_list.append(
+                torch.from_numpy(chunk_indices)
+                .pin_memory()
+                .to(self.device, non_blocking=True)
+            )
+            cu_seqlens_k_list.append(kv_indptr_list[-1])  # same tensor
+            total_tokens_list.append(total_tokens)
+            max_seqlen_k_list.append(int(per_seq_chunk_lens.max(initial=0)))
+
+        return MLAChunkContextMetadata(
+            kv_indptr=kv_indptr_list,
+            kv_indices=kv_indices_list,
+            cu_seqlens_k=cu_seqlens_k_list,
+            total_tokens=total_tokens_list,
+            max_seqlen_k=max_seqlen_k_list,
+            num_chunks=num_chunks,
+            k_workspace=self.k_chunk_workspace,
+            v_workspace=self.v_chunk_workspace,
+        )
 
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
         scheduled_bs = batch.total_seqs_num_decode

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -36,7 +36,7 @@ class MLAChunkContextMetadata:
     """Per-chunk slices of the cached prefix for chunked MLA prefill.
 
     Built host-side in `AiterMLAMetadataBuilder.prepare_prefill` when the
-    cached prefix exceeds `config.mla_prefill_chunk_size`. The forward iterates
+    cached prefix exceeds `config.attn_prefill_chunk_size`. The forward iterates
     these chunks instead of materializing the full `total_kv × heads × dim`
     k/v tensors (which OOM on long contexts).
 
@@ -211,20 +211,20 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         self.model_runner.forward_vars.update(mla_metadata)
 
         # Chunked-context workspaces for the prefill has_cached path. Sized
-        # to config.mla_prefill_chunk_size (defaults to max_num_batched_tokens)
+        # to config.attn_prefill_chunk_size (defaults to max_num_batched_tokens)
         # so peak memory is bounded regardless of total context length.
         # Allocated outside any per-step scope so a single buffer is shared
         # across all chunks and layers.
-        self.mla_prefill_chunk_size = config.mla_prefill_chunk_size
+        self.attn_prefill_chunk_size = config.attn_prefill_chunk_size
         self.k_chunk_workspace: Optional[torch.Tensor] = None
         self.v_chunk_workspace: Optional[torch.Tensor] = None
-        if self.mla_prefill_chunk_size > 0:
+        if self.attn_prefill_chunk_size > 0:
             qk_head_dim = hf_config.qk_nope_head_dim + hf_config.qk_rope_head_dim
             v_head_dim = hf_config.v_head_dim
             model_dtype = config.torch_dtype
             self.k_chunk_workspace = torch.empty(
                 (
-                    self.mla_prefill_chunk_size,
+                    self.attn_prefill_chunk_size,
                     self.num_attention_heads,
                     qk_head_dim,
                 ),
@@ -233,7 +233,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             )
             self.v_chunk_workspace = torch.empty(
                 (
-                    self.mla_prefill_chunk_size,
+                    self.attn_prefill_chunk_size,
                     self.num_attention_heads,
                     v_head_dim,
                 ),
@@ -790,9 +790,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # forward (self-attention via kv_b_proj), so chunks span only the
             # cached prefix.
             if (
-                self.mla_prefill_chunk_size > 0
+                self.attn_prefill_chunk_size > 0
                 and attn_metadata.has_cached
-                and attn_metadata.total_kv > self.mla_prefill_chunk_size
+                and attn_metadata.total_kv > self.attn_prefill_chunk_size
             ):
                 attn_metadata.mla_chunk_meta = self._build_mla_chunk_meta(batch, bs)
 
@@ -805,7 +805,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         """Build per-chunk slices of the cached prefix.
 
         Chunks the cached-prefix tokens along the GLOBAL token axis (not the
-        per-seq axis). Per-chunk total token count ≤ `mla_prefill_chunk_size`,
+        per-seq axis). Per-chunk total token count ≤ `attn_prefill_chunk_size`,
         which is what the k/v workspace is sized for. Each chunk c contains a
         contiguous slice of the concatenated per-seq slot list; per-seq
         contributions to chunk c are the intersection of seq i's slot range
@@ -815,7 +815,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         flash_attn returns lse=-inf which merge_attn_states handles correctly
         (the prefix output for that seq is preserved unchanged).
         """
-        chunk_size = self.mla_prefill_chunk_size
+        chunk_size = self.attn_prefill_chunk_size
         runner_bs = self.model_runner.block_size
 
         cached_lens = np.asarray(batch.num_cached_tokens[:bs], dtype=np.int64)

--- a/atom/model_ops/attentions/triton_merge_attn_states.py
+++ b/atom/model_ops/attentions/triton_merge_attn_states.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import triton
+import triton.language as tl
+
+import aiter
+
+float8_info = torch.finfo(aiter.dtypes.fp8)
+
+
+# Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
+# can be used to combine partial attention results (in the split-KV case)
+def merge_attn_states(
+    output: torch.Tensor,
+    prefix_output: torch.Tensor,
+    prefix_lse: torch.Tensor,
+    suffix_output: torch.Tensor,
+    suffix_lse: torch.Tensor,
+    output_lse: torch.Tensor | None = None,
+    prefill_tokens_with_context: int | None = None,
+    output_scale: torch.Tensor | None = None,
+) -> None:
+    num_tokens = output.shape[0]
+    num_query_heads = output.shape[1]
+    head_size = output.shape[2]
+    padded_head_size = triton.next_power_of_2(head_size)
+    # We assume the output stride on num_head is not always as same as the
+    # `suffix_output` and `prefix_output`, as them might be padded by the
+    # attention backend.
+    prefix_head_stride = prefix_output.stride(1)
+    output_head_stride = output.stride(1)
+
+    # If prefill_tokens_with_context is None, all tokens should use prefix context
+    if prefill_tokens_with_context is None:
+        prefill_tokens_with_context = num_tokens
+
+    # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
+    merge_attn_states_kernel[(num_tokens, num_query_heads)](
+        output,
+        output_lse,
+        prefix_output,
+        prefix_lse,
+        suffix_output,
+        suffix_lse,
+        prefix_head_stride,
+        output_head_stride,
+        output_scale,
+        head_size,
+        padded_head_size,
+        output_lse is not None,
+        prefill_tokens_with_context,
+        output_scale is not None,
+    )
+
+
+@triton.jit
+def merge_attn_states_kernel(
+    output,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    output_lse,  # [NUM_HEADS, NUM_TOKENS]
+    prefix_output,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    prefix_lse,  # [NUM_HEADS, NUM_TOKENS]
+    suffix_output,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    suffix_lse,  # [NUM_HEADS, NUM_TOKENS]
+    prefix_head_stride,
+    output_head_stride,
+    output_scale,  # scale tensor or None
+    HEAD_SIZE: tl.constexpr,
+    PADDED_HEAD_SIZE: tl.constexpr,
+    OUTPUT_LSE: tl.constexpr,
+    prefill_tokens_with_context: tl.constexpr,
+    USE_FP8: tl.constexpr,
+    FP8_MIN: tl.constexpr = float8_info.min,
+    FP8_MAX: tl.constexpr = float8_info.max,
+):
+    token_idx = tl.program_id(0)
+    num_tokens = tl.num_programs(0)
+    head_idx = tl.program_id(1)
+    num_heads = tl.num_programs(1)
+
+    prefix_mask = token_idx < prefill_tokens_with_context
+
+    head_arange = tl.arange(0, PADDED_HEAD_SIZE)
+    head_mask = head_arange < HEAD_SIZE
+
+    # For tokens without context (token_idx >= prefill_tokens_with_context),
+    # directly copy from suffix_output
+    if not prefix_mask:
+        s_lse = tl.load(suffix_lse + head_idx * num_tokens + token_idx)
+        if OUTPUT_LSE:
+            tl.store(output_lse + head_idx * num_tokens + token_idx, s_lse)
+
+        s_out = tl.load(
+            suffix_output
+            + token_idx * num_heads * prefix_head_stride
+            + head_idx * prefix_head_stride
+            + head_arange,
+            mask=head_mask,
+        )
+
+        if USE_FP8:
+            s_out = s_out * (1.0 / tl.load(output_scale))
+            s_out = tl.clamp(s_out, FP8_MIN, FP8_MAX)
+            s_out = s_out.to(output.dtype.element_ty)
+
+        tl.store(
+            output
+            + token_idx * num_heads * output_head_stride
+            + head_idx * output_head_stride
+            + head_arange,
+            s_out,
+            mask=head_mask,
+        )
+        return
+
+    # For tokens with context (token_idx < prefill_tokens_with_context),
+    # perform normal merge operation
+    p_lse = tl.load(prefix_lse + head_idx * num_tokens + token_idx)
+    s_lse = tl.load(suffix_lse + head_idx * num_tokens + token_idx)
+
+    # FA2 and FA3 have different behavior for when the sum-exp is 0, this namely
+    # arises with 0 len seqlens. FA3 returns -inf here while FA2 returns inf.
+    # If we see an inf assume FA2 and convert inf to -inf for consistency
+    # and correctness. Inf generally doesn't make sense in this context outside
+    # of undefined-behavior/FA2-case, so I think this a safe assumption.
+    p_lse = float("-inf") if p_lse == float("inf") else p_lse
+    s_lse = float("-inf") if s_lse == float("inf") else s_lse
+
+    max_lse = tl.maximum(p_lse, s_lse)
+    p_lse = p_lse - max_lse
+    s_lse = s_lse - max_lse
+    # Will reuse precomputed Exp values for scale factor computation.
+    p_se = tl.exp(p_lse)
+    s_se = tl.exp(s_lse)
+    out_se = p_se + s_se
+
+    if OUTPUT_LSE:
+        out_lse = tl.log(out_se) + max_lse
+        tl.store(output_lse + head_idx * num_tokens + token_idx, out_lse)
+
+    p_out = tl.load(
+        prefix_output
+        + token_idx * num_heads * prefix_head_stride
+        + head_idx * prefix_head_stride
+        + head_arange,
+        mask=head_mask,
+    )
+    s_out = tl.load(
+        suffix_output
+        + token_idx * num_heads * prefix_head_stride
+        + head_idx * prefix_head_stride
+        + head_arange,
+        mask=head_mask,
+    )
+
+    # NOTE(woosuk): Be careful with the numerical stability.
+    # We should compute the scale first, and then multiply it with the output.
+    # Do not multiply the output with tl.exp(p_lse) or tl.exp(s_lse) directly.
+    p_scale = p_se / out_se
+    s_scale = s_se / out_se
+    out = p_out * p_scale + s_out * s_scale
+
+    if USE_FP8:
+        out = out * (1.0 / tl.load(output_scale))
+        out = tl.clamp(out, FP8_MIN, FP8_MAX)
+        out = out.to(output.dtype.element_ty)
+
+    tl.store(
+        output
+        + token_idx * num_heads * output_head_stride
+        + head_idx * output_head_stride
+        + head_arange,
+        out,
+        mask=head_mask,
+    )


### PR DESCRIPTION
The legacy MLA prefill has_cached branch materializes k_full / v_full of shape (total_kv, num_heads, head_dim), OOMing on long contexts. Add a chunked path that bins cached-prefix tokens along the global token axis into chunks of <= max_num_scheduled_tokens (defaults to max_num_batched_tokens), gathers + attends per chunk into a shared workspace, and merges partial outputs via softmax-LSE recombination (merge_attn_states, ported from vLLM).

Peak workspace is bounded to CHUNK_TOKENS * heads * (qk_dim + v_dim) instead of total_kv * heads * dim. Single-pass path remains available via --max-num-scheduled-tokens 0 for A/B comparison.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
