### PR TITLE
[CI] Set HSA_NO_SCRATCH_RECLAIM=1 for Meta-Llama-3-8B-Instruct accuracy

### DIFF
--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -3,7 +3,7 @@
     "model_name": "Meta-Llama-3-8B-Instruct",
     "model_path": "meta-llama/Meta-Llama-3-8B-Instruct",
     "extraArgs": "--kv_cache_dtype fp8 --gpu-memory-utilization 0.3",
-    "env_vars": "",
+    "env_vars": "HSA_NO_SCRATCH_RECLAIM=1",
     "runner": "linux-atom-mi35x-1",
     "test_level": "pr",
     "accuracy_threshold": 0.73,


### PR DESCRIPTION
## Summary

- Adds `HSA_NO_SCRATCH_RECLAIM=1` to the `Meta-Llama-3-8B-Instruct` entry in `.github/benchmark/models_accuracy.json`, fixing the `Accuracy` job that has been failing on `linux-atom-mi35x-1`.
- Uses the existing per-model `env_vars` hook (already plumbed into `docker run --env-file` via `MODEL_ENV_VARS` in `atom-test.yaml`), same pattern as the two `Kimi-K2.5-MXFP4` entries.

## Root cause

Failing run: https://github.com/ROCm/ATOM/actions/runs/26366559969/job/77676472941

RCCL on the mi35x-1 runner (GPU firmware v14 + current HIP runtime) now fatal-exits at init if `HSA_NO_SCRATCH_RECLAIM=1` is not exported:

```
[FATAL ERROR]: HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid performance
degradation with the current HIP configuration.
(Runtime version:70253211, GPU Firmware version:14)
[FATAL ERROR]: Please set HSA_NO_SCRATCH_RECLAIM=1 and rerun.
```

That fault propagates as a NCCL `DistBackendError` at `torch.distributed.barrier()` inside `ModelRunner.allocate_kv_cache`, the runner subprocess exits 1, and `EngineCoreMgr` aborts with:

```
RuntimeError: Engine Core Mgr: Received unexpected SHUTDOWN signal from DP rank 0 during initialization
```

## Scope note

This patch only touches the Meta-Llama entry per request. Other jobs running on the same runner family with empty `env_vars` (e.g. `gpt-oss-120b`, `Llama-3.3-70B-Instruct-MXFP4-Preview`, several `atom-mi355-8gpu.predownload` entries) are likely to hit the same fatal once RCCL/firmware reach matching versions there — a follow-up to either fan this out per-model or bake `ENV HSA_NO_SCRATCH_RECLAIM=1` into the `rocm/atom-dev` image would be cleaner long term.

## Test plan

- [ ] Re-run the `Accuracy (Meta-Llama-3-8B-Instruct, ...)` job from this branch and confirm the server reaches `allocate_kv_cache` without the RCCL fatal, and `gsm8k flexible-extract >= 0.73`.