### PR TITLE
atom mesh atom backend intergrate

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -786,6 +786,19 @@ async def health():
     return {"status": "ok"}
 
 
+@app.get("/kv_transfer_info")
+async def kv_transfer_info():
+    global engine
+    cfg = engine.config
+    kv_cfg = cfg.kv_transfer_config or {}
+    return {
+        "tp_size": cfg.tensor_parallel_size,
+        "dp_size": cfg.parallel_config.data_parallel_size,
+        "kv_role": kv_cfg.get("kv_role"),
+        "handshake_port": kv_cfg.get("handshake_port", 6301),
+    }
+
+
 @app.post("/start_profile")
 async def start_profile():
     """Start profiling the engine."""

--- a/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
+++ b/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
@@ -109,6 +109,7 @@ class MooncakeConnectorScheduler(KVConnectorSchedulerBase):
             kv_transfer_config.get("kv_role", "kv_producer") == "kv_producer"
         )
         self.handshake_port = get_open_port()
+        self.base_handshake_port = kv_transfer_config.get("handshake_port", 6301)
         self.engine_id = "None"
         self.tp_size = config.tensor_parallel_size
         self.dp_size = config.parallel_config.data_parallel_size
@@ -211,6 +212,7 @@ class MooncakeConnectorScheduler(KVConnectorSchedulerBase):
             "remote_engine_id": self.engine_id,
             "remote_host": self.host_ip,
             "remote_port": self.handshake_port,
+            "remote_handshake_port": self.base_handshake_port,
             "tp_size": self.tp_size,
             "dp_rank": self.dp_rank,
             "transfer_id": seq.id,

--- a/atom/kv_transfer/disaggregation/moriio/moriio_connector.py
+++ b/atom/kv_transfer/disaggregation/moriio/moriio_connector.py
@@ -953,6 +953,9 @@ class MoRIIOConnectorScheduler(KVConnectorSchedulerBase):
             kv_transfer_config.get("kv_role", "kv_producer") == "kv_producer"
         )
         self.handshake_port = get_open_port()
+        self.base_handshake_port = kv_transfer_config.get(
+            "handshake_port", MoRIIOConstants.DEFAULT_HANDSHAKE_PORT
+        )
         self.engine_id = "None"
         self.tp_size = config.tensor_parallel_size
         self.dp_size = config.parallel_config.data_parallel_size
@@ -1049,6 +1052,7 @@ class MoRIIOConnectorScheduler(KVConnectorSchedulerBase):
             "remote_engine_id": self.engine_id,
             "remote_host": self.host_ip,
             "remote_port": self.handshake_port,
+            "remote_handshake_port": self.base_handshake_port,
             "tp_size": self.tp_size,
             "dp_rank": self.dp_rank,
             "transfer_id": seq.id,

--- a/atom/kv_transfer/disaggregation/types.py
+++ b/atom/kv_transfer/disaggregation/types.py
@@ -122,11 +122,11 @@ class ConnectorMetadata:
         """Construct a :class:`ReqMeta` from raw transfer parameters."""
         return ReqMeta(
             local_block_ids=local_block_ids,
-            remote_block_ids=kv_transfer_params["remote_block_ids"],
-            remote_engine_id=kv_transfer_params["remote_engine_id"],
-            remote_host=kv_transfer_params["remote_host"],
-            remote_port=kv_transfer_params["remote_port"],
-            remote_handshake_port=kv_transfer_params["remote_handshake_port"],
+            remote_block_ids=kv_transfer_params.get("remote_block_ids"),
+            remote_engine_id=kv_transfer_params.get("remote_engine_id"),
+            remote_host=kv_transfer_params.get("remote_host"),
+            remote_port=kv_transfer_params.get("remote_port"),
+            remote_handshake_port=kv_transfer_params.get("remote_handshake_port"),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
             remote_dp_rank=kv_transfer_params.get("remote_dp_rank", 0),
             tp_size=(

--- a/atom/mesh/src/cliargs.rs
+++ b/atom/mesh/src/cliargs.rs
@@ -109,6 +109,8 @@ pub enum Backend {
     Sglang,
     #[value(name = "vllm")]
     Vllm,
+    #[value(name = "atom")]
+    Atom,
 }
 
 impl std::fmt::Display for Backend {
@@ -116,6 +118,7 @@ impl std::fmt::Display for Backend {
         match self {
             Backend::Sglang => write!(f, "sglang"),
             Backend::Vllm => write!(f, "vllm"),
+            Backend::Atom => write!(f, "atom"),
         }
     }
 }
@@ -125,6 +128,7 @@ impl From<Backend> for BackendType {
         match b {
             Backend::Sglang => BackendType::Sglang,
             Backend::Vllm => BackendType::Vllm,
+            Backend::Atom => BackendType::Atom,
         }
     }
 }
@@ -136,6 +140,7 @@ impl std::str::FromStr for Backend {
         match value {
             "sglang" => Ok(Self::Sglang),
             "vllm" => Ok(Self::Vllm),
+            "atom" => Ok(Self::Atom),
             other => Err(format!("unsupported backend: {other}")),
         }
     }

--- a/atom/mesh/src/config/types.rs
+++ b/atom/mesh/src/config/types.rs
@@ -12,6 +12,8 @@ pub enum BackendType {
     Sglang,
     #[serde(rename = "vllm")]
     Vllm,
+    #[serde(rename = "atom")]
+    Atom,
 }
 
 /// Main router configuration

--- a/atom/mesh/src/core/placement/backend/atom.rs
+++ b/atom/mesh/src/core/placement/backend/atom.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use super::super::types::AdapterError;
+use super::{BackendAdapter, PairCtx};
+use crate::core::Worker;
+
+#[derive(Default)]
+pub struct AtomPrefillInfo {
+    pub tp_sizes: HashMap<String, usize>,
+}
+
+impl std::fmt::Debug for AtomPrefillInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AtomPrefillInfo")
+            .field("prefill_count", &self.tp_sizes.len())
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct AtomAdapter {
+    pub prefill_info: Arc<AtomPrefillInfo>,
+}
+
+impl AtomAdapter {
+    pub fn new(prefill_info: Arc<AtomPrefillInfo>) -> Self {
+        Self { prefill_info }
+    }
+
+    /// Add the two fields that ATOM's prefill response omits but the decode side requires
+    /// (mooncake_connector kv_transfer_params_output drops remote_dp_size/remote_tp_size;
+    /// decode's ReqMeta reads them, defaulting to 1 — wrong for multi-DP clusters).
+    pub fn enrich_decode_kv(&self, kv: &mut Value, ctx: &PairCtx) -> Result<(), AdapterError> {
+        let ctx = downcast(ctx)?;
+        let obj = kv.as_object_mut().ok_or(AdapterError::BodyNotObject)?;
+        let tp_size = self
+            .prefill_info
+            .tp_sizes
+            .get(&ctx.prefill_url)
+            .copied()
+            .ok_or_else(|| AdapterError::TpSizeMissing {
+                prefill_url: ctx.prefill_url.clone(),
+            })?;
+        obj.insert("remote_dp_size".to_string(), json!(ctx.prefill_dp_size));
+        obj.insert("remote_tp_size".to_string(), json!(tp_size));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AtomPairCtx {
+    pub transfer_id: String,
+    pub prefill_url: String,
+    pub prefill_dp_size: usize,
+}
+
+fn downcast(ctx: &PairCtx) -> Result<&AtomPairCtx, AdapterError> {
+    ctx.downcast_ref::<AtomPairCtx>()
+        .ok_or(AdapterError::CtxTypeMismatch)
+}
+
+impl BackendAdapter for AtomAdapter {
+    fn prepare_pair(
+        &self,
+        prefill: &dyn Worker,
+        _decode: &dyn Worker,
+    ) -> Result<PairCtx, AdapterError> {
+        Ok(Box::new(AtomPairCtx {
+            transfer_id: format!("xfer-{}", Uuid::new_v4()),
+            prefill_url: prefill.url().to_string(),
+            prefill_dp_size: prefill.dp_size().unwrap_or(1),
+        }))
+    }
+
+    fn inject_prefill_fields(&self, body: &mut Value, ctx: &PairCtx) -> Result<(), AdapterError> {
+        downcast(ctx)?;
+        let obj = body.as_object_mut().ok_or(AdapterError::BodyNotObject)?;
+        obj.insert(
+            "kv_transfer_params".to_string(),
+            json!({
+                "do_remote_decode": true,
+                "do_remote_prefill": false,
+            }),
+        );
+        obj.insert("stream".to_string(), Value::Bool(false));
+        obj.insert("max_tokens".to_string(), json!(1));
+        if obj.contains_key("max_completion_tokens") {
+            obj.insert("max_completion_tokens".to_string(), json!(1));
+        }
+        obj.remove("stream_options");
+        Ok(())
+    }
+
+    /// No-op: the kv_transfer_params for decode comes from the prefill response,
+    /// not from a static ctx. Mesh injects it in execute_atom_relay after enriching.
+    fn inject_decode_fields(&self, _body: &mut Value, ctx: &PairCtx) -> Result<(), AdapterError> {
+        downcast(ctx)?;
+        Ok(())
+    }
+
+    fn inject_batch_prefill_fields(
+        &self,
+        body: &mut Value,
+        ctx: &PairCtx,
+        batch_size: usize,
+    ) -> Result<(), AdapterError> {
+        debug_assert_eq!(batch_size, 1, "ATOM Mooncake fires per-request");
+        self.inject_prefill_fields(body, ctx)
+    }
+
+    fn correlation_id(&self, ctx: &PairCtx) -> Option<String> {
+        downcast(ctx).ok().map(|c| c.transfer_id.clone())
+    }
+}

--- a/atom/mesh/src/core/placement/backend/mod.rs
+++ b/atom/mesh/src/core/placement/backend/mod.rs
@@ -1,3 +1,4 @@
+pub mod atom;
 pub mod sglang;
 pub mod vllm;
 

--- a/atom/mesh/src/core/placement/tests.rs
+++ b/atom/mesh/src/core/placement/tests.rs
@@ -1342,6 +1342,196 @@ mod e_adapter {
     }
 }
 
+mod f_atom_adapter {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use serde_json::{json, Value};
+
+    use super::super::backend::atom::{AtomAdapter, AtomPairCtx, AtomPrefillInfo};
+    use super::super::backend::BackendAdapter;
+    use super::super::test_support::*;
+    use super::super::types::AdapterError;
+
+    fn atom_info_with(prefill_url: &str, tp_size: usize) -> Arc<AtomPrefillInfo> {
+        let mut tp_sizes = HashMap::new();
+        tp_sizes.insert(prefill_url.to_string(), tp_size);
+        Arc::new(AtomPrefillInfo { tp_sizes })
+    }
+
+    fn atom_pair_for(
+        prefill_url: &str,
+        tp_size: usize,
+    ) -> (AtomAdapter, super::super::backend::PairCtx) {
+        let prefill = make_prefill_http(prefill_url, "m", None);
+        let decode = make_decode_http("http://decode:8000", "m");
+        let adapter = AtomAdapter::new(atom_info_with(prefill_url, tp_size));
+        let ctx = adapter
+            .prepare_pair(prefill.as_ref(), decode.as_ref())
+            .expect("prepare_pair");
+        (adapter, ctx)
+    }
+
+    #[test]
+    fn test_atom_inject_prefill_writes_kv_and_force_prefill() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut body = json!({
+            "prompt": "hi",
+            "stream": true,
+            "max_tokens": 256,
+            "max_completion_tokens": 100,
+        });
+        adapter.inject_prefill_fields(&mut body, &ctx).unwrap();
+        let obj = body.as_object().unwrap();
+        let kv = &obj["kv_transfer_params"];
+        assert_eq!(kv["do_remote_decode"], json!(true));
+        assert_eq!(kv["do_remote_prefill"], json!(false));
+        assert_eq!(obj["stream"], json!(false));
+        assert_eq!(obj["max_tokens"], json!(1));
+        assert_eq!(obj["max_completion_tokens"], json!(1));
+    }
+
+    #[test]
+    fn test_atom_inject_prefill_removes_stream_options() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut body = json!({
+            "prompt": "hi",
+            "stream_options": {"include_usage": true},
+        });
+        adapter.inject_prefill_fields(&mut body, &ctx).unwrap();
+        assert!(!body.as_object().unwrap().contains_key("stream_options"));
+    }
+
+    #[test]
+    fn test_atom_inject_prefill_does_not_add_max_completion_tokens() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut body = json!({"prompt": "hi"});
+        adapter.inject_prefill_fields(&mut body, &ctx).unwrap();
+        let obj = body.as_object().unwrap();
+        assert!(!obj.contains_key("max_completion_tokens"));
+        assert_eq!(obj["max_tokens"], json!(1));
+    }
+
+    #[test]
+    fn test_atom_inject_decode_is_noop() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut body = json!({"prompt": "hi", "kv_transfer_params": {"x": 1}});
+        let before = body.clone();
+        adapter.inject_decode_fields(&mut body, &ctx).unwrap();
+        assert_eq!(body, before);
+    }
+
+    #[test]
+    fn test_atom_inject_prefill_on_non_object_returns_body_not_object() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut body = json!([1, 2, 3]);
+        let before = body.clone();
+        let err = adapter.inject_prefill_fields(&mut body, &ctx).unwrap_err();
+        assert_eq!(err, AdapterError::BodyNotObject);
+        assert_eq!(body, before);
+    }
+
+    #[test]
+    fn test_atom_inject_batch_equals_single_for_batch_one() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut a = json!({"prompt": "hi"});
+        let mut b = json!({"prompt": "hi"});
+        adapter.inject_prefill_fields(&mut a, &ctx).unwrap();
+        adapter
+            .inject_batch_prefill_fields(&mut b, &ctx, 1)
+            .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_atom_correlation_id_matches_ctx_transfer_id() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let cid = adapter.correlation_id(&ctx).unwrap();
+        let downcast = ctx
+            .downcast_ref::<AtomPairCtx>()
+            .expect("downcast atom ctx");
+        assert!(cid.starts_with("xfer-"));
+        assert_eq!(cid, downcast.transfer_id);
+    }
+
+    #[test]
+    fn test_atom_prepare_pair_captures_default_dp_size_one() {
+        let (_adapter, ctx) = atom_pair_for("http://p:8000", 4);
+        let c = ctx.downcast_ref::<AtomPairCtx>().unwrap();
+        assert_eq!(c.prefill_url, "http://p:8000");
+        assert_eq!(c.prefill_dp_size, 1);
+    }
+
+    #[test]
+    fn test_atom_enrich_decode_kv_single_dp() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut kv = json!({
+            "do_remote_prefill": true,
+            "do_remote_decode": false,
+            "remote_block_ids": [0, 1, 2],
+            "remote_engine_id": "10.24.112.168:6301",
+            "transfer_id": 42,
+        });
+        adapter.enrich_decode_kv(&mut kv, &ctx).unwrap();
+        assert_eq!(kv["remote_dp_size"], json!(1));
+        assert_eq!(kv["remote_tp_size"], json!(8));
+        assert_eq!(kv["transfer_id"], json!(42));
+    }
+
+    #[test]
+    fn test_atom_enrich_decode_kv_multi_dp() {
+        let info = atom_info_with("http://p:8000", 8);
+        let adapter = AtomAdapter::new(info);
+        let ctx: super::super::backend::PairCtx = Box::new(AtomPairCtx {
+            transfer_id: "xfer-test".to_string(),
+            prefill_url: "http://p:8000".to_string(),
+            prefill_dp_size: 4,
+        });
+        let mut kv = json!({});
+        adapter.enrich_decode_kv(&mut kv, &ctx).unwrap();
+        assert_eq!(kv["remote_dp_size"], json!(4));
+        assert_eq!(kv["remote_tp_size"], json!(8));
+    }
+
+    #[test]
+    fn test_atom_enrich_decode_kv_missing_tp_size_errors() {
+        let info = atom_info_with("http://other:8000", 8);
+        let adapter = AtomAdapter::new(info);
+        let ctx: super::super::backend::PairCtx = Box::new(AtomPairCtx {
+            transfer_id: "x".to_string(),
+            prefill_url: "http://unknown:8000".to_string(),
+            prefill_dp_size: 1,
+        });
+        let mut kv = json!({});
+        let err = adapter.enrich_decode_kv(&mut kv, &ctx).unwrap_err();
+        assert_eq!(
+            err,
+            AdapterError::TpSizeMissing {
+                prefill_url: "http://unknown:8000".to_string()
+            }
+        );
+        assert_eq!(kv, json!({}));
+    }
+
+    #[test]
+    fn test_atom_enrich_decode_kv_non_object_errors() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut kv = json!("not-an-object");
+        let err = adapter.enrich_decode_kv(&mut kv, &ctx).unwrap_err();
+        assert_eq!(err, AdapterError::BodyNotObject);
+    }
+
+    #[test]
+    fn test_atom_enrich_decode_kv_wrong_ctx_errors() {
+        let info = atom_info_with("http://p:8000", 8);
+        let adapter = AtomAdapter::new(info);
+        let wrong: super::super::backend::PairCtx = Box::new(42u32);
+        let mut kv = json!({});
+        let err = adapter.enrich_decode_kv(&mut kv, &wrong).unwrap_err();
+        assert_eq!(err, AdapterError::CtxTypeMismatch);
+    }
+}
+
 mod g_error {
     use std::sync::Arc;
 

--- a/atom/mesh/src/core/placement/types.rs
+++ b/atom/mesh/src/core/placement/types.rs
@@ -59,6 +59,8 @@ pub enum AdapterError {
     BootstrapAddrMissing { prefill_url: String },
     #[error("engine_id missing for prefill {prefill_url} dp_rank {dp_rank}")]
     EngineIdMissing { prefill_url: String, dp_rank: usize },
+    #[error("tp_size missing for prefill {prefill_url}")]
+    TpSizeMissing { prefill_url: String },
     #[error("PairCtx type does not match adapter")]
     CtxTypeMismatch,
 }

--- a/atom/mesh/src/core/steps/worker/local/discover_metadata.rs
+++ b/atom/mesh/src/core/steps/worker/local/discover_metadata.rs
@@ -348,7 +348,7 @@ impl StepExecutor<LocalWorkerWorkflowData> for DiscoverMetadataStep {
                     BackendType::Sglang => {
                         discover_http_sglang(&config.url, config.api_key.as_deref()).await
                     }
-                    BackendType::Vllm => {
+                    BackendType::Vllm | BackendType::Atom => {
                         discover_http_openai(&config.url, config.api_key.as_deref()).await
                     }
                 };

--- a/atom/mesh/src/routers/http_pd_router.rs
+++ b/atom/mesh/src/routers/http_pd_router.rs
@@ -21,6 +21,7 @@ use crate::{
         is_retryable_status,
         placement::{
             backend::{
+                atom::{AtomAdapter, AtomPrefillInfo},
                 sglang::SglangAdapter,
                 vllm::{VllmAdapter, VllmPrefillInfo},
                 BackendAdapter, PairCtx,
@@ -70,6 +71,8 @@ pub struct PDRouter {
     pub backend: BackendType,
     pub planner: Arc<dyn PdPlanner>,
     pub adapter: Arc<dyn BackendAdapter>,
+    /// Set when backend == Atom. enrich_decode_kv is ATOM-specific and not on the trait.
+    atom_adapter: Option<Arc<AtomAdapter>>,
 }
 
 impl std::fmt::Debug for PDRouter {
@@ -170,12 +173,20 @@ impl PDRouter {
         let policy_registry = Arc::clone(&ctx.policy_registry);
         let client = ctx.client.clone();
 
+        let mut atom_adapter: Option<Arc<AtomAdapter>> = None;
         let adapter: Arc<dyn BackendAdapter> = match backend {
             BackendType::Sglang => Arc::new(SglangAdapter),
             BackendType::Vllm => {
                 let info =
                     Arc::new(Self::fetch_vllm_prefill_info(&worker_registry, &client).await?);
                 Arc::new(VllmAdapter::new(info))
+            }
+            BackendType::Atom => {
+                let info =
+                    Arc::new(Self::fetch_atom_prefill_info(&worker_registry, &client).await?);
+                let a = Arc::new(AtomAdapter::new(info));
+                atom_adapter = Some(a.clone());
+                a
             }
         };
 
@@ -192,6 +203,7 @@ impl PDRouter {
             backend,
             planner,
             adapter,
+            atom_adapter,
         })
     }
 
@@ -292,6 +304,52 @@ impl PDRouter {
         })
     }
 
+    async fn fetch_atom_prefill_info(
+        worker_registry: &WorkerRegistry,
+        client: &Client,
+    ) -> Result<AtomPrefillInfo, String> {
+        let prefill_workers = worker_registry.get_prefill_workers();
+        if prefill_workers.is_empty() {
+            return Err("ATOM PD mode requires at least one prefill worker".to_string());
+        }
+
+        let mut tp_sizes = HashMap::new();
+        for worker in &prefill_workers {
+            let worker_url = worker.url().to_string();
+            let info_url = format!("{}/kv_transfer_info", worker_url);
+
+            info!("Querying ATOM prefill kv_transfer_info: {}", info_url);
+            let resp = client
+                .get(&info_url)
+                .send()
+                .await
+                .map_err(|e| format!("GET {} failed: {}", info_url, e))?;
+            if !resp.status().is_success() {
+                return Err(format!("{} returned {}", info_url, resp.status()));
+            }
+            let data: Value = resp
+                .json()
+                .await
+                .map_err(|e| format!("Parse {} response: {}", info_url, e))?;
+
+            let tp = data
+                .get("tp_size")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| format!("Missing tp_size in {} response", info_url))?
+                as usize;
+            let kv_role = data.get("kv_role").and_then(|v| v.as_str());
+            if kv_role != Some("kv_producer") {
+                return Err(format!(
+                    "{} is not a prefill (kv_role={:?}, expected kv_producer)",
+                    worker_url, kv_role
+                ));
+            }
+            info!("ATOM prefill {} tp_size={}", worker_url, tp);
+            tp_sizes.insert(worker_url, tp);
+        }
+        Ok(AtomPrefillInfo { tp_sizes })
+    }
+
     fn handle_serialization_error(error: impl std::fmt::Display) -> Response {
         error!("Failed to serialize request error={}", error);
         error::internal_error("serialization_failed", "Failed to serialize request")
@@ -340,6 +398,10 @@ impl PDRouter {
             }
             BackendType::Vllm => {
                 self.execute_vllm_mooncake(headers, original_request, context)
+                    .await
+            }
+            BackendType::Atom => {
+                self.execute_atom_relay(headers, original_request, context)
                     .await
             }
         }
@@ -650,6 +712,341 @@ impl PDRouter {
                 }
                 Err(e) => {
                     error!("Failed to read vLLM decode response: {}", e);
+                    error::internal_error("read_response_failed", "Failed to read response")
+                }
+            }
+        }
+    }
+
+    /// ATOM Mooncake mode: P must run first and return kv_transfer_params; mesh
+    /// enriches them with remote_dp_size/remote_tp_size, then forwards to D.
+    /// Decode's response is streamed (or buffered) back to the client.
+    async fn execute_atom_relay<T: Serialize + Clone>(
+        &self,
+        headers: Option<&HeaderMap>,
+        original_request: &T,
+        context: PDRequestContext<'_>,
+    ) -> Response {
+        let start_time = Instant::now();
+
+        let route = context.route;
+        let model = context.model_id.unwrap_or(UNKNOWN_MODEL_ID);
+        let endpoint = route_to_endpoint(route);
+
+        Metrics::record_router_request(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_PD,
+            metrics_labels::CONNECTION_HTTP,
+            model,
+            endpoint,
+            bool_to_static_str(context.is_stream),
+        );
+
+        let shared_request = Arc::new(original_request.clone());
+        let response = RetryExecutor::execute_response_with_retry(
+            &self.retry_config,
+            {
+                move |attempt: u32| {
+                    let shared_request = Arc::clone(&shared_request);
+                    let context = context.clone();
+                    async move {
+                        let (prefill, decode, ctx) = match self.plan_pd_pair(&context).await {
+                            Ok(t) => t,
+                            Err(resp) => return resp,
+                        };
+
+                        debug!(
+                            "ATOM PD retry attempt {} prefill={} decode={}",
+                            attempt,
+                            prefill.url(),
+                            decode.url()
+                        );
+
+                        let mut prefill_request_json =
+                            match serde_json::to_value(shared_request.as_ref()) {
+                                Ok(v) => v,
+                                Err(e) => return Self::handle_serialization_error(e),
+                            };
+                        let mut decode_request_json = prefill_request_json.clone();
+                        if let Err(e) = self
+                            .adapter
+                            .inject_prefill_fields(&mut prefill_request_json, &ctx)
+                        {
+                            return Self::handle_serialization_error(e);
+                        }
+                        if let Err(e) = self
+                            .adapter
+                            .inject_decode_fields(&mut decode_request_json, &ctx)
+                        {
+                            return Self::handle_serialization_error(e);
+                        }
+                        let correlation_id = self.adapter.correlation_id(&ctx);
+
+                        self.dispatch_atom_relay_internal(
+                            headers,
+                            prefill_request_json,
+                            decode_request_json,
+                            context,
+                            Arc::clone(&prefill),
+                            Arc::clone(&decode),
+                            ctx,
+                            start_time,
+                            correlation_id,
+                        )
+                        .await
+                    }
+                }
+            },
+            |res, _attempt| is_retryable_status(res.status()),
+            |delay, attempt| {
+                Metrics::record_worker_retry(metrics_labels::WORKER_PREFILL, endpoint);
+                Metrics::record_worker_retry(metrics_labels::WORKER_DECODE, endpoint);
+                Metrics::record_worker_retry_backoff(attempt, delay);
+            },
+            || {
+                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_PREFILL, endpoint);
+                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_DECODE, endpoint);
+            },
+        )
+        .await;
+
+        let duration = start_time.elapsed();
+        if response.status().is_success() {
+            Metrics::record_router_duration(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_PD,
+                metrics_labels::CONNECTION_HTTP,
+                model,
+                endpoint,
+                duration,
+            );
+        } else if !is_retryable_status(response.status()) {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_PD,
+                metrics_labels::CONNECTION_HTTP,
+                model,
+                endpoint,
+                error_type_from_status(response.status()),
+            );
+        }
+
+        response
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch_atom_relay_internal(
+        &self,
+        headers: Option<&HeaderMap>,
+        prefill_request_json: Value,
+        mut decode_request_json: Value,
+        context: PDRequestContext<'_>,
+        prefill: Arc<dyn Worker>,
+        decode: Arc<dyn Worker>,
+        ctx: PairCtx,
+        _start_time: Instant,
+        correlation_id: Option<String>,
+    ) -> Response {
+        let _prefill_guard =
+            (!context.is_stream).then(|| WorkerLoadGuard::new(prefill.clone(), headers));
+        let _decode_guard =
+            (!context.is_stream).then(|| WorkerLoadGuard::new(decode.clone(), headers));
+
+        events::RequestPDSentEvent {
+            prefill_url: prefill.url(),
+            decode_url: decode.url(),
+        }
+        .emit();
+
+        let prefill_post = self.build_post_with_headers(
+            &self.client,
+            prefill.url(),
+            context.route,
+            &prefill_request_json,
+            headers,
+            false,
+        );
+        let correlation_for_log = correlation_id
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let prefill_result = prefill_post.send().await;
+        let prefill_resp = match prefill_result {
+            Ok(r) => r,
+            Err(e) => {
+                error!(
+                    "ATOM prefill {} request_id={} failed: {}",
+                    prefill.url(),
+                    correlation_for_log,
+                    e
+                );
+                prefill.record_outcome(false);
+                return error::bad_gateway(
+                    "prefill_server_error",
+                    format!("Prefill server error: {}", e),
+                );
+            }
+        };
+
+        let prefill_status = prefill_resp.status();
+        prefill.record_outcome(prefill_status.is_success());
+        if !prefill_status.is_success() {
+            let body_text = prefill_resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable>".to_string());
+            error!(
+                "ATOM prefill {} request_id={} status={} body={}",
+                prefill.url(),
+                correlation_for_log,
+                prefill_status,
+                body_text
+            );
+            let code = StatusCode::from_u16(prefill_status.as_u16())
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            return error::create_error(
+                code,
+                "prefill_error",
+                format!("Prefill server error ({}): {}", prefill_status, body_text),
+            );
+        }
+
+        let prefill_body: Value = match prefill_resp.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                error!(
+                    "ATOM prefill {} request_id={} response parse failed: {}",
+                    prefill.url(),
+                    correlation_for_log,
+                    e
+                );
+                return error::bad_gateway(
+                    "prefill_parse_error",
+                    format!("Prefill response parse error: {}", e),
+                );
+            }
+        };
+
+        let mut kv_params = match prefill_body.get("kv_transfer_params").cloned() {
+            Some(v) => v,
+            None => {
+                error!(
+                    "ATOM prefill {} request_id={} response missing kv_transfer_params",
+                    prefill.url(),
+                    correlation_for_log
+                );
+                return error::bad_gateway(
+                    "prefill_missing_kv_transfer_params",
+                    "Prefill response missing kv_transfer_params",
+                );
+            }
+        };
+
+        let atom_adapter = match self.atom_adapter.as_ref() {
+            Some(a) => a,
+            None => {
+                error!("atom_adapter is None but backend == Atom — programming error");
+                return error::internal_error(
+                    "atom_adapter_missing",
+                    "Internal: ATOM adapter not initialized",
+                );
+            }
+        };
+        if let Err(e) = atom_adapter.enrich_decode_kv(&mut kv_params, &ctx) {
+            error!(
+                "ATOM enrich_decode_kv failed for prefill {} request_id={}: {}",
+                prefill.url(),
+                correlation_for_log,
+                e
+            );
+            return error::internal_error(
+                "enrich_decode_kv_failed",
+                format!("Failed to enrich decode kv: {}", e),
+            );
+        }
+
+        let decode_obj = match decode_request_json.as_object_mut() {
+            Some(o) => o,
+            None => {
+                return error::internal_error(
+                    "decode_body_not_object",
+                    "Decode request body must be a JSON object",
+                );
+            }
+        };
+        decode_obj.insert("kv_transfer_params".to_string(), kv_params);
+
+        let decode_post = self.build_post_with_headers(
+            &self.client,
+            decode.url(),
+            context.route,
+            &decode_request_json,
+            headers,
+            false,
+        );
+        let decode_result = decode_post.send().await;
+        events::RequestReceivedEvent {}.emit();
+
+        let res = match decode_result {
+            Ok(r) => r,
+            Err(e) => {
+                error!(
+                    decode_url = %decode.url(),
+                    error = %e,
+                    "ATOM decode request failed"
+                );
+                decode.record_outcome(false);
+                return error::bad_gateway(
+                    "decode_server_error",
+                    format!("Decode server error: {}", e),
+                );
+            }
+        };
+
+        let status = StatusCode::from_u16(res.status().as_u16())
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let not_error = status.is_success() || status.is_client_error();
+        decode.record_outcome(not_error);
+
+        if !status.is_success() {
+            error!(
+                "ATOM decode {} returned error status={}",
+                decode.url(),
+                status
+            );
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_DECODE,
+                metrics_labels::CONNECTION_HTTP,
+                error_type_from_status(status),
+            );
+            return self
+                .handle_decode_error_response(res, &context, prefill, decode)
+                .await;
+        }
+
+        if context.is_stream {
+            let response_headers = header_utils::preserve_response_headers(res.headers());
+            self.create_streaming_response(
+                res.bytes_stream(),
+                status,
+                None,
+                false,
+                None,
+                Some(response_headers),
+                prefill,
+                decode,
+            )
+        } else {
+            let response_headers = header_utils::preserve_response_headers(res.headers());
+            match res.bytes().await {
+                Ok(decode_body) => {
+                    let mut response = Response::new(Body::from(decode_body));
+                    *response.status_mut() = status;
+                    *response.headers_mut() = response_headers;
+                    response
+                }
+                Err(e) => {
+                    error!("Failed to read ATOM decode response: {}", e);
                     error::internal_error("read_response_failed", "Failed to read response")
                 }
             }
@@ -1569,6 +1966,7 @@ mod tests {
             backend: BackendType::Sglang,
             planner,
             adapter,
+            atom_adapter: None,
         }
     }
 

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -36,6 +36,7 @@ class LLMEngine:
         config_kwargs = {k: v for k, v in kwargs.items() if k in config_fields}
         data_parallel_size = kwargs.get("data_parallel_size", 1)
         config = Config(model, **config_kwargs)
+        self.config = config
         self.tokenizer = tokenizer or _load_tokenizer(
             config.model, config.trust_remote_code
         )


### PR DESCRIPTION
# Add `--backend atom` to atom-mesh router

  Routes PD-disaggregated requests to ATOM-native servers. Mesh learns each
  prefill's topology via a new `/kv_transfer_info` HTTP endpoint, awaits the
  prefill response, and forwards `kv_transfer_params` to decode.

  ## Changes

  - **`7d53515e`** — `BackendType::Atom`, `AtomAdapter`, `execute_atom_relay`
    in atom-mesh + `/kv_transfer_info` endpoint on ATOM server (13 unit tests)
  - **`d0bb85df`** — Python fixes to make the connectors work without legacy
    `proxy.py`:
    - `LLMEngine.config` exposed (endpoint needed it)
    - `base_handshake_port` added to scheduler classes
    - `remote_handshake_port` added to producer output
    - `_build_req_meta` uses `.get()` for fields proxy.py used to inject

  ## Test plan

  End-to-end on 2× MI300X (g42 prefill + g44 decode), DeepSeek-R1 MXFP4
  1P TP8 + 1D TP8, mooncake connector.

  **Smoke** — `"The capital of France is"` → `" Paris. It is located in..."` (latency 367 ms).

  **GSM8K** (1319 samples, 3-shot)

  | Metric | Score | Threshold |
  |---|---:|---:|
  | flexible-extract | 0.938 ± 0.007 | 0.93 ✅ |
  | strict-match | 0.936 ± 0.007 | — |

  **Perf sweep** (ISL=8192, OSL=1024, ratio=0.8) — matches vllm + mooncake reference:

  | CONC | TTFT (ms) | TPOT (ms) | tput (tok/s) | vllm ref |
  |---:|---:|---:|---:|---:|
  | 1  | 321 | 7.3  | 131  | ~135  |
  | 2  | 331 | 7.6  | 250  | ~256  |
  | 4  | 370 | 8.3  | 449  | ~457  |
  | 8  | 437 | 9.3  | 806  | ~805  |
  | 16 | 504 | 10.5 | 1392 | ~1358 |

  ## Notes

  - Pass `"kv_connector":"mooncake"` in `--kv-transfer-config` (default is `moriio`).
  - The `atom_sglang_mesh` image needs `pip install msgpack msgspec quart`.