### PR TITLE
[chore][ci] MiMo-V2-Flash: recalibrate accuracy baseline to match what CI actually runs (3-shot)

### DIFF
--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -320,10 +320,10 @@
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "nightly",
-    "accuracy_threshold": 0.76,
+    "accuracy_threshold": 0.778,
     "accuracy_baseline": 0.79,
     "accuracy_baseline_model": "XiaomiMiMo/MiMo-V2-Flash",
-    "_baseline_note": "CI runs GSM8K 3-shot (atom_test.sh hardcodes --num_fewshot 3). Observed CI flexible-extract on the first stable run: base=0.8082 (run 26410931088, commit 24e4367b). Baseline 0.79 sits ~1.5pp below that to absorb run-to-run noise (stderr ±0.011); threshold 0.76 = ~2.5σ buffer below baseline. The original 0.8294 baseline was an out-of-band local 5-shot measurement that never matched what CI actually computes. tp pinned to 4 to match the MTP entry's setup (no separate base measurement)."
+    "_baseline_note": "CI runs GSM8K 3-shot (atom_test.sh hardcodes --num_fewshot 3). Observed CI flexible-extract on the first stable run: base=0.8082 (run 26410931088, commit 24e4367b). Baseline 0.79 sits ~1.5pp below that to absorb run-to-run noise (stderr ±0.011); threshold 0.778 leaves ~1.2pp headroom below baseline (~1.1σ), matching the headroom pattern in DeepSeek-R1 / Kimi-Eagle3 / MiniMax-M2.7 entries. The original 0.8294 baseline was an out-of-band local 5-shot measurement that never matched what CI actually computes. tp pinned to 4 to match the MTP entry's setup (no separate base measurement)."
   },
   {
     "model_name": "MiMo-V2-Flash MTP",
@@ -332,9 +332,9 @@
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "nightly",
-    "accuracy_threshold": 0.76,
+    "accuracy_threshold": 0.778,
     "accuracy_baseline": 0.79,
     "accuracy_baseline_model": "XiaomiMiMo/MiMo-V2-Flash",
-    "_baseline_note": "CI runs GSM8K 3-shot (atom_test.sh hardcodes --num_fewshot 3). Observed CI flexible-extract on the first stable run: MTP1=0.7983 (run 26410931088, commit 24e4367b); local reproduction with the fp8 + prefix-cache crash patches gave 0.8052. Baseline 0.79 sits just below the observed values to absorb run-to-run noise (stderr ±0.011); threshold 0.76 = ~2.5σ buffer below baseline. tp MUST be 4 and num-speculative-tokens MUST be 1: ATOM only constructs MTP layer 0 (matches vLLM _MIMO_V2_FLASH_NUM_MTP_LAYERS=1); driving more spec tokens would route through layers 1/2 whose KV is never populated and accept rate craters."
+    "_baseline_note": "CI runs GSM8K 3-shot (atom_test.sh hardcodes --num_fewshot 3). Observed CI flexible-extract on the first stable run: MTP1=0.7983 (run 26410931088, commit 24e4367b); local reproduction with the fp8 + prefix-cache crash patches gave 0.8052. Baseline 0.79 sits just below the observed values to absorb run-to-run noise (stderr ±0.011); threshold 0.778 leaves ~1.2pp headroom below baseline (~1.1σ), matching the headroom pattern in DeepSeek-R1 / Kimi-Eagle3 / MiniMax-M2.7 entries. tp MUST be 4 and num-speculative-tokens MUST be 1: ATOM only constructs MTP layer 0 (matches vLLM _MIMO_V2_FLASH_NUM_MTP_LAYERS=1); driving more spec tokens would route through layers 1/2 whose KV is never populated and accept rate craters."
   }
 ]

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -320,10 +320,10 @@
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "nightly",
-    "accuracy_threshold": 0.81,
-    "accuracy_baseline": 0.8294,
+    "accuracy_threshold": 0.76,
+    "accuracy_baseline": 0.79,
     "accuracy_baseline_model": "XiaomiMiMo/MiMo-V2-Flash",
-    "_baseline_note": "CI measured GSM8K 5-shot flexible-extract = 0.8294 (±0.0104) under MTP1 greedy decoding (see MiMo-V2-Flash MTP entry); base-only number is identical because MTP only proposes speculative drafts that the target verifies. tp pinned to 4 to match the MTP entry's setup (no separate base measurement)."
+    "_baseline_note": "CI runs GSM8K 3-shot (atom_test.sh hardcodes --num_fewshot 3). Observed CI flexible-extract on the first stable run: base=0.8082 (run 26410931088, commit 24e4367b). Baseline 0.79 sits ~1.5pp below that to absorb run-to-run noise (stderr ±0.011); threshold 0.76 = ~2.5σ buffer below baseline. The original 0.8294 baseline was an out-of-band local 5-shot measurement that never matched what CI actually computes. tp pinned to 4 to match the MTP entry's setup (no separate base measurement)."
   },
   {
     "model_name": "MiMo-V2-Flash MTP",
@@ -332,9 +332,9 @@
     "env_vars": "",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "nightly",
-    "accuracy_threshold": 0.81,
-    "accuracy_baseline": 0.8294,
+    "accuracy_threshold": 0.76,
+    "accuracy_baseline": 0.79,
     "accuracy_baseline_model": "XiaomiMiMo/MiMo-V2-Flash",
-    "_baseline_note": "CI measured GSM8K 5-shot flexible-extract = 0.8294 (±0.0104) on FP8 KV + MTP1. tp MUST be 4 and num-speculative-tokens MUST be 1: ATOM only constructs MTP layer 0 (matches vLLM _MIMO_V2_FLASH_NUM_MTP_LAYERS=1); driving more spec tokens would route through layers 1/2 whose KV is never populated and accept rate craters."
+    "_baseline_note": "CI runs GSM8K 3-shot (atom_test.sh hardcodes --num_fewshot 3). Observed CI flexible-extract on the first stable run: MTP1=0.7983 (run 26410931088, commit 24e4367b); local reproduction with the fp8 + prefix-cache crash patches gave 0.8052. Baseline 0.79 sits just below the observed values to absorb run-to-run noise (stderr ±0.011); threshold 0.76 = ~2.5σ buffer below baseline. tp MUST be 4 and num-speculative-tokens MUST be 1: ATOM only constructs MTP layer 0 (matches vLLM _MIMO_V2_FLASH_NUM_MTP_LAYERS=1); driving more spec tokens would route through layers 1/2 whose KV is never populated and accept rate craters."
   }
 ]


### PR DESCRIPTION
## Summary

Both MiMo entries in `.github/benchmark/models_accuracy.json` claim:

```
"_baseline_note": "CI measured GSM8K 5-shot flexible-extract = 0.8294 (±0.0104) …"
"accuracy_baseline":  0.8294
"accuracy_threshold": 0.81
```

But CI invokes `lm_eval` with `--num_fewshot 3` ([`atom_test.sh:177`](https://github.com/ROCm/ATOM/blob/main/.github/scripts/atom_test.sh#L177)), hardcoded since the gsm8k accuracy step was first added in #73 (`eeaccd67`). The 5-shot 0.8294 number therefore never described what the CI job was measuring — it was an out-of-band local measurement carried over by mistake when the MiMo entries were added in #755.

## Observed consequence

The first nightly run that survived long enough to produce a number — commit `24e4367b`, 2026-05-25, [run 26410931088](https://github.com/ROCm/ATOM/actions/runs/26410931088) — reported:

| metric | value | vs threshold 0.81 | vs baseline 0.8294 |
|---|---|---|---|
| flex-extract base | 0.8082 ± 0.0109 | below | -2.1pp |
| flex-extract MTP1 | 0.7983 ± 0.0111 | below | -3.1pp |

Both lit the dashboard red for what is actually expected 3-shot behavior, not a regression.

## Change

| field | old | new |
|---|---|---|
| `accuracy_baseline` | 0.8294 | **0.79** |
| `accuracy_threshold` | 0.81 | **0.76** |
| `_baseline_note` | mentions 5-shot, baseline only | rewritten — 3-shot, cites run id, calls out the old 5-shot drift |

- **0.79** sits just below the observed values (CI MTP1 0.7983, local repro of MTP1 with the fp8+prefix-cache crash patches 0.8052) so future noise rarely undershoots.
- **0.76** is ~2.5σ below baseline (single-run stderr ±0.011). Matches the headroom pattern already used by the GLM-5/Qwen3 entries in this file that note `"CI uses 3-shot, not comparable to HF 5-shot baseline"`.
- The note now explicitly cites `atom_test.sh:177`, the run id, and flags the prior 5-shot 0.8294 value as out-of-band — so the same drift doesn't recur if someone tunes the baseline later.

## Scope

JSON-only change. No CI script change in this PR — the `--num_fewshot 3` invocation is what every prior MiMo CI ran on, the baseline just needs to match it.

## Related

- #910 (open) — fixes the crash that prevented every MiMo nightly between 2026-05-13 and 2026-05-24 from producing any number. With #910 applied locally I get MTP1=0.8052 ± 0.011 on 3-shot, matching the CI run that did complete.

## Test plan

- [x] `python3 -m json.tool < .github/benchmark/models_accuracy.json` passes (JSON valid).
- [x] Reviewer-side: next nightly under main with these threshold/baseline values should report PASS on both MiMo entries.