### PR TITLE
[sgl][benchmark] update sglang benchmark schedule

### DIFF
--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -8,7 +8,7 @@ on:
   schedule:
     # Nightly at 23:00 Beijing time (15:00 UTC).
     - cron: '0 15 * * 1,3'  # Mon/Wed: SGLang-OOB DeepSeek group A, 6 models x 10 params = 60 cases
-    - cron: '0 15 * * 2,4'  # Tue/Thu: SGLang-OOB group B, 2 DeepSeek MTP + 2 Qwen models, 4 x 10 params = 40 cases
+    - cron: '0 15 * * 2,4'  # Tue/Thu: SGLang-OOB DeepSeek MTP group B, 2 models x 10 params = 20 cases
     - cron: '0 15 * * 5'    # Fri: SGLang-OOB all, 10 models x 10 params = 100 cases
     - cron: '0 15 * * 6'  # Sat: SGLang-Mesh all, 8 configs = 62 cases
   workflow_dispatch:
@@ -417,8 +417,14 @@ jobs:
                   selected_group = "A-DEEPSEEK"
                   selected = [m for m in models if m.get("nightly_group", "A") == "A" and matches_workload(m)]
               elif schedule_cron == "0 15 * * 2,4":
-                  selected_group = "B-QWEN35"
-                  selected = [m for m in models if m.get("nightly_group") == "B" and matches_workload(m)]
+                  selected_group = "B-DEEPSEEK-MTP"
+                  selected = [
+                      m
+                      for m in models
+                      if m.get("nightly_group") == "B"
+                      and matches_workload(m)
+                      and str(m.get("prefix", "")).startswith("deepseek-")
+                  ]
               elif schedule_cron == "0 15 * * 5":
                   selected_group = "C-ALL"
                   selected = [m for m in models if matches_workload(m)]


### PR DESCRIPTION
## Motivation
Nightly Schedule change from 

| Cron | Time | Mode | Cases |
| --- | --- | --- | --- |
| `0 15 * * 1,3` | 周一/周三北京时间 23:00 | `SGLang-OOB` DeepSeek group A | 60 cases |
| `0 15 * * 2,4` | 周二/周四北京时间 23:00 | **`SGLang-OOB` group B，包含 DeepSeek MTP + Qwen** | 40 cases |
| `0 15 * * 5` | 周五北京时间 23:00 | `SGLang-OOB` all | 100 cases |
| `0 15 * * 6` | 周六北京时间 23:00 | `SGLang-Mesh` all | 62 cases |

to

| Cron | Time | Mode | Cases |
| --- | --- | --- | --- |
| `0 15 * * 1,3` | 周一/周三北京时间 23:00 | `SGLang-OOB` DeepSeek group A | 60 cases |
| `0 15 * * 2,4` | 周二/周四北京时间 23:00 | **`SGLang-OOB` DeepSeek MTP group B** | 20 cases |
| `0 15 * * 5` | 周五北京时间 23:00 | `SGLang-OOB` all | 100 cases |
| `0 15 * * 6` | 周六北京时间 23:00 | `SGLang-Mesh` all | 62 cases |

to save benchmark time.

-------

Q: 如果周一这60个case没跑完怎么办？

A: 周一触发出来的 60 个 matrix jobs 如果有些一直在等 runner，它们仍然属于周一这个 run，会继续等机器/继续跑，直到 GitHub Actions 或 runner 层面把它们取消、超时，或者它们实际跑完。
周二的定时 run 也会被触发，但 workflow 顶层有 concurrency：
```
group: ${{ github.workflow }}-${{ github.repository }}-${{ github.ref_name }}
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```
对 main 分支的定时任务来说，cancel-in-progress=false，所以周二不会主动取消周一正在进行的 run。通常会等同一个 concurrency group 里的前一个 run 完成后再开始。
LLM-Booster 上传也是按整次 workflow run 的 summarize job 做的，不是每个 case 跑完就单独上传。summarize-benchmark-result 依赖整个 benchmark matrix job，所以如果周一还有 case 在排队，summary 不会开始，LLM-Booster 也不会先上传部分结果。
等周一这次 run 最终进入完成态后：
那它会把周一 run 里成功的 case 上传到 LLM-Booster。如果某些 case 最终被取消/超时/没产出 JSON，就不会上传那些 case，只上传成功产出的结果。