### PR TITLE
[Feat] enable sgl+atom mtp + dp atten

### DIFF
--- a/atom/plugin/sglang/models/deepseek_nextn_wrapper.py
+++ b/atom/plugin/sglang/models/deepseek_nextn_wrapper.py
@@ -24,8 +24,11 @@ from atom.plugin.sglang.attention_backend.sgl_attention_mla import (
 )
 from atom.plugin.sglang.models.base_model_wrapper import (
     _current_forward_batch,
+    _is_dummy_forward,
+    _materialize_atom_dummy_forward,
     _reset_sglang_forward_context,
     _set_sglang_forward_context,
+    _trim_hidden_states_for_output,
     plugin_runtime_scope,
 )
 
@@ -42,6 +45,15 @@ def _replace_weight(module: nn.Module, attr_name: str, weight) -> None:
     if hasattr(module, attr_name):
         delattr(module, attr_name)
     setattr(module, attr_name, weight)
+
+
+def _materialize_dummy_hidden_states(
+    hidden_states: torch.Tensor,
+    *,
+    length: int,
+) -> torch.Tensor:
+    shape = (length, *hidden_states.shape[1:])
+    return hidden_states.new_zeros(shape)
 
 
 def _set_runtime_layer_id(layer_module: nn.Module, layer_id: int) -> None:
@@ -159,20 +171,54 @@ class DeepseekV3ForCausalLMNextN(nn.Module):
             raise ValueError("DeepSeek MTP draft forward requires speculative info")
 
         with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
-            token = _current_forward_batch.set(forward_batch)
+            if _is_dummy_forward(forward_batch):
+                (
+                    model_input_ids,
+                    model_positions,
+                    model_input_embeds,
+                    model_forward_batch,
+                ) = _materialize_atom_dummy_forward(
+                    input_ids,
+                    positions,
+                    input_embeds,
+                    forward_batch,
+                )
+                model_hidden_states = _materialize_dummy_hidden_states(
+                    forward_batch.spec_info.hidden_states,
+                    length=int(model_positions.shape[0]),
+                )
+            else:
+                (
+                    model_input_ids,
+                    model_positions,
+                    model_input_embeds,
+                    model_forward_batch,
+                ) = (
+                    input_ids,
+                    positions,
+                    input_embeds,
+                    forward_batch,
+                )
+                model_hidden_states = forward_batch.spec_info.hidden_states
+
+            token = _current_forward_batch.set(model_forward_batch)
             try:
-                _set_sglang_forward_context(self.atom_config, forward_batch, positions)
+                _set_sglang_forward_context(
+                    self.atom_config, model_forward_batch, model_positions
+                )
                 hidden_states = self.model(
-                    input_ids=input_ids,
-                    positions=positions,
-                    hidden_states=forward_batch.spec_info.hidden_states,
-                    inputs_embeds=input_embeds,
+                    input_ids=model_input_ids,
+                    positions=model_positions,
+                    hidden_states=model_hidden_states,
+                    inputs_embeds=model_input_embeds,
                 )
             finally:
                 _reset_sglang_forward_context()
                 _current_forward_batch.reset(token)
 
             if self.pp_group.is_last_rank:
+                if _is_dummy_forward(forward_batch):
+                    hidden_states = _trim_hidden_states_for_output(hidden_states, 0)
                 return self.logits_processor(
                     input_ids,
                     hidden_states,


### PR DESCRIPTION
## Motivation

enable sgl+atom mtp + dp atten.  add _materialize_atom_dummy_forward in draft model as well.

## Command
```
# export CUDA_VISIBLE_DEVICES=0,1,2,3
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION=0
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models

export MORI_SHMEM_MODE=ISOLATION

# export CUDA_VISIBLE_DEVICES=0,1,2,3
export CUDA_VISIBLE_DEVICES=4,5,6,7

MTP=${MTP:-1}
SPECULATIVE_NUM_DRAFT_TOKENS=${SPECULATIVE_NUM_DRAFT_TOKENS:-$((MTP + 1))}

model_path=/models/deepseek-ai/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4/
# export PYTHONPATH=/workspace/dpsk-fp4/sglang/python:/workspace/dpsk-fp4/ATOM/ATOM_zejun/ATOM
export PYTHONPATH=/workspace/dpsk-fp4/sglang/python:/workspace/dpsk-fp4/ATOM/ATOM_main/ATOM
export ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD=0


TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --expert-parallel-size 4 \
    --data-parallel-size 4 \
    --enable-dp-attention \
    --attention-backend aiter \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.8 \
    --page-size 1 \
    --disable-radix-cache \
    --speculative-algorithm NEXTN \
    --speculative-num-steps "${MTP}" \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens "${SPECULATIVE_NUM_DRAFT_TOKENS}" \
    --max-running-requests 256 \
    --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256 > log-dpsk-fp4-mtp.log 2>&1
```

## ACC
```
2026-05-26:07:55:28 INFO     [models.api_models:747] Tokenized requests are disabled. Context + generation length is not checked.
Requesting API: 100%|██████████| 1319/1319 [03:37<00:00,  6.07it/s]
2026-05-26:07:59:07 INFO     [loggers.evaluation_tracker:316] Output path not provided, skipping saving results aggregated
local-completions ({'model': '/models/deepseek-ai/DeepSeek-R1-0528-MXFP4/', 'base_url': 'http://localhost:9000/v1/completions', 'num_concurrent': 65, 'max_retries': 1, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 3, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9439|±  |0.0063|
|     |       |strict-match    |     3|exact_match|↑  |0.9409|±  |0.0065|
```