### PR TITLE
feat(dp): PrefillDelayer + DP attn schedule optimize for dp and TBO

### DIFF
--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -17,7 +17,7 @@ from atom.config import Config, ParallelConfig
 from atom.model_engine.async_proc import AsyncIOProcManager
 from atom.model_engine.scheduler import Scheduler
 from atom.model_engine.sequence import Sequence, SequenceStatus, get_exit_sequence
-from atom.utils import init_exit_handler, make_zmq_socket
+from atom.utils import envs, init_exit_handler, make_zmq_socket
 from atom.utils.distributed.utils import (
     stateless_destroy_torch_distributed_process_group,
 )
@@ -394,27 +394,16 @@ class DPEngineCoreProc(EngineCore):
         self.engines_running = True
         self._shutting_down = False
 
-        if os.environ.get("ATOM_ENABLE_PREFILL_DELAYER", "1") == "1":
+        if envs.ATOM_ENABLE_PREFILL_DELAYER:
             from atom.model_engine.prefill_delayer import PrefillDelayer
 
-            dp_size = config.parallel_config.data_parallel_size
-            max_delay_passes = int(
-                os.environ.get("ATOM_PREFILL_DELAYER_MAX_DELAY_PASSES", "30")
-            )
-            max_delay_ms = float(
-                os.environ.get("ATOM_PREFILL_DELAYER_MAX_DELAY_MS", "5000")
-            )
-            watermark_env = os.environ.get(
-                "ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK", ""
-            )
-            watermark = None if watermark_env == "" else float(watermark_env)
             self.scheduler.set_prefill_delayer(
                 PrefillDelayer(
-                    dp_size=dp_size,
+                    dp_size=config.parallel_config.data_parallel_size,
                     cpu_group=self.dp_group,
-                    max_delay_passes=max_delay_passes,
-                    max_delay_ms=max_delay_ms,
-                    token_usage_low_watermark=watermark,
+                    max_delay_passes=envs.ATOM_PREFILL_DELAYER_MAX_DELAY_PASSES,
+                    max_delay_ms=envs.ATOM_PREFILL_DELAYER_MAX_DELAY_MS,
+                    token_usage_low_watermark=envs.ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK,
                 )
             )
 

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -3,6 +3,7 @@
 
 import enum
 import logging
+import os
 import pickle
 import queue
 import threading
@@ -393,6 +394,30 @@ class DPEngineCoreProc(EngineCore):
         self.engines_running = True
         self._shutting_down = False
 
+        if os.environ.get("ATOM_ENABLE_PREFILL_DELAYER", "1") == "1":
+            from atom.model_engine.prefill_delayer import PrefillDelayer
+
+            dp_size = config.parallel_config.data_parallel_size
+            max_delay_passes = int(
+                os.environ.get("ATOM_PREFILL_DELAYER_MAX_DELAY_PASSES", "30")
+            )
+            max_delay_ms = float(
+                os.environ.get("ATOM_PREFILL_DELAYER_MAX_DELAY_MS", "5000")
+            )
+            watermark_env = os.environ.get(
+                "ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK", ""
+            )
+            watermark = None if watermark_env == "" else float(watermark_env)
+            self.scheduler.set_prefill_delayer(
+                PrefillDelayer(
+                    dp_size=dp_size,
+                    cpu_group=self.dp_group,
+                    max_delay_passes=max_delay_passes,
+                    max_delay_ms=max_delay_ms,
+                    token_usage_low_watermark=watermark,
+                )
+            )
+
     def _init_data_parallel(self, config: Config):
         dp_rank = config.parallel_config.data_parallel_rank
         dp_size = config.parallel_config.data_parallel_size
@@ -404,6 +429,10 @@ class DPEngineCoreProc(EngineCore):
 
         self.dp_rank = dp_rank
         self.dp_group = config.parallel_config.stateless_init_dp_group()
+        # NOTE: PrefillDelayer attachment lives in __init__ (after
+        # super().__init__ creates self.scheduler) — not here. This
+        # function runs during super().__init__, before self.scheduler
+        # exists.
 
     def exit(self):
         super().exit()
@@ -414,24 +443,10 @@ class DPEngineCoreProc(EngineCore):
         shutdown = False
         while True:
             shutdown = shutdown or self.pull_and_process_input_queue()
-
-            local_is_prefill, local_num_tokens, local_num_reqs = (
-                self.scheduler.get_next_batch_info()
-            )
             local_unfinished = not self.scheduler.is_finished()
 
-            (
-                global_has_prefill,
-                global_max_tokens,
-                global_max_reqs,
-                global_has_unfinished,
-                global_shutdown,
-            ) = self._sync_dp_state(
-                local_is_prefill,
-                local_num_tokens,
-                local_num_reqs,
-                local_unfinished,
-                shutdown,
+            global_has_unfinished, global_shutdown = self._sync_dp_state(
+                local_unfinished, shutdown
             )
 
             if global_shutdown and not global_has_unfinished:
@@ -444,68 +459,26 @@ class DPEngineCoreProc(EngineCore):
                 self.engines_running = False
                 continue
 
-            if global_has_prefill and not local_is_prefill:
-                # We must do dummy prefill to sync here
-                # Since we want to split mori output in moe, we need to make dp all run prefill or all run decode
-                dummy_reqs = min(
-                    global_max_reqs, 2
-                )  # dummy reqs at 2: just enough for TBO agreement, avoid wasting compute.
-                logger.info(
-                    f"{self.label}: Running dummy prefill ({global_max_tokens} tokens, {dummy_reqs} reqs) "
-                    f"to sync with other DP ranks doing prefill"
-                )
-                self._execute_dummy_prefill(global_max_tokens, dummy_reqs)
-            else:
-                executed = self._process_engine_step()
-                if not executed:
-                    if global_has_prefill:
-                        # get_next_batch_info predicted prefill but schedule()
-                        # skipped it (e.g. WAITING_FOR_REMOTE_KVS).  Other DP
-                        # ranks already committed to dummy_prefill, so we must
-                        # match to keep the all-reduce in sync.
-                        logger.info(
-                            f"{self.label}: Predicted prefill was not scheduled, "
-                            f"falling back to dummy prefill ({global_max_tokens} "
-                            f"tokens) to stay in sync with other DP ranks"
-                        )
-                        self._execute_dummy_prefill(global_max_tokens)
-                    else:
-                        self._execute_dummy_batch()
+            executed = self._process_engine_step()
+            if not executed:
+                self._execute_dummy_batch()
 
             self.engines_running = global_has_unfinished
 
     def _execute_dummy_batch(self):
         return self.runner_mgr.call_func("dummy_execution", wait_out=True)
 
-    def _execute_dummy_prefill(self, num_tokens: int, num_reqs: int = 1):
-        return self.runner_mgr.call_func(
-            "dummy_prefill_execution", num_tokens, num_reqs, wait_out=True
-        )
-
     def _sync_dp_state(
         self,
-        local_is_prefill: bool,
-        local_num_tokens: int,
-        local_num_reqs: int,
         local_has_unfinished: bool,
         local_shutdown: bool = False,
-    ) -> tuple[bool, int, int, bool, bool]:
+    ) -> tuple[bool, bool]:
         if self._shutting_down:
-            return (
-                local_is_prefill,
-                local_num_tokens,
-                local_num_reqs,
-                local_has_unfinished,
-                True,
-            )
+            return local_has_unfinished, True
 
         try:
-            # Pack all state: [is_prefill, num_tokens, num_reqs, has_unfinished, shutdown]
             state_tensor = torch.tensor(
                 [
-                    1 if local_is_prefill else 0,
-                    local_num_tokens,
-                    local_num_reqs,
                     1 if local_has_unfinished else 0,
                     1 if local_shutdown else 0,
                 ],
@@ -515,29 +488,13 @@ class DPEngineCoreProc(EngineCore):
             torch.distributed.all_reduce(
                 state_tensor, op=torch.distributed.ReduceOp.MAX, group=self.dp_group
             )
-            global_has_prefill = state_tensor[0].item() == 1
-            global_max_tokens = state_tensor[1].item()
-            global_max_reqs = state_tensor[2].item()
-            global_has_unfinished = state_tensor[3].item() == 1
-            global_shutdown = state_tensor[4].item() == 1
-            return (
-                global_has_prefill,
-                global_max_tokens,
-                global_max_reqs,
-                global_has_unfinished,
-                global_shutdown,
-            )
+            global_has_unfinished = state_tensor[0].item() == 1
+            global_shutdown = state_tensor[1].item() == 1
+            return global_has_unfinished, global_shutdown
         except RuntimeError as e:
             logger.warning(f"{self.label}: _sync_dp_state failed: {e}")
-            # If sync fails, assume shutdown to prevent hang
             self._shutting_down = True
-            return (
-                local_is_prefill,
-                local_num_tokens,
-                local_num_reqs,
-                local_has_unfinished,
-                True,
-            )
+            return local_has_unfinished, True
 
     def _sync_shutdown_state(self, local_should_shutdown: bool) -> bool:
         try:

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -3,7 +3,6 @@
 
 import enum
 import logging
-import os
 import pickle
 import queue
 import threading

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1520,6 +1520,58 @@ class ModelRunner:
 
         return max_tokens_across_dp_cpu - num_tokens, num_tokens_across_dp
 
+    def _local_tbo_precompute(
+        self, batch, is_prefill: bool, num_scheduled_tokens: np.ndarray
+    ) -> tuple[bool, int, int]:
+        """Decide locally whether this rank could TBO-split into 2 ubatches,
+        and if so, what (ub0_tokens, ub1_tokens) the split would produce.
+
+        Returns (eligible, ub0_tokens, ub1_tokens). All zeros when ineligible.
+        These values are packed into the single DP all_reduce in
+        ``_preprocess`` so the collective decision (AND across ranks) and
+        ``UBatchWrapper`` 's per-ubatch token max (replaces a second
+        all_reduce) can both be derived from one round-trip.
+        """
+        if not self.config.enable_tbo:
+            return False, 0, 0
+        if is_prefill:
+            n_pref = batch.total_seqs_num_prefill
+            if n_pref < 2:
+                return False, 0, 0
+            # Mirror _split_prefill_balanced: pick boundary closest to
+            # total/2 so the packed value matches what
+            # maybe_create_ubatch_slices will produce post-decision.
+            toks = np.asarray(num_scheduled_tokens[:n_pref], dtype=np.int64)
+            total = int(toks.sum())
+            target = total // 2
+            cumsum = 0
+            split_idx = 1
+            for j in range(n_pref):
+                cumsum += int(toks[j])
+                if cumsum >= target:
+                    prev = cumsum - int(toks[j])
+                    if j > 0 and (target - prev) < (cumsum - target):
+                        split_idx = j
+                    else:
+                        split_idx = j + 1
+                    break
+            split_idx = max(1, min(split_idx, n_pref - 1))
+            ub0 = int(toks[:split_idx].sum())
+            ub1 = total - ub0
+            return True, ub0, ub1
+        # Decode path
+        if not self.config.enable_tbo_decode or batch.is_dummy_run:
+            return False, 0, 0
+        scheduled_bs = batch.total_seqs_num_decode
+        if scheduled_bs < 2:
+            return False, 0, 0
+        num_tokens = batch.total_tokens_num
+        tokens_per_req = num_tokens // scheduled_bs if scheduled_bs else 1
+        reqs_per_ub = scheduled_bs // 2
+        ub0 = reqs_per_ub * tokens_per_req
+        ub1 = num_tokens - ub0
+        return True, ub0, ub1
+
     def _maybe_create_tbo_slices(
         self,
         batch,
@@ -1527,24 +1579,17 @@ class ModelRunner:
         scheduled_bs,
         actual_num_tokens,
         num_scheduled_tokens,
-        reqs_across_dp,
+        tbo_collective_active: bool,
     ):
-        """Create TBO ubatch slices if conditions are met."""
-        if not self.config.enable_tbo:
-            return None
-        if not is_prefill and not self.config.enable_tbo_decode:
-            return None
-        if not is_prefill and batch.is_dummy_run:
+        """Create TBO ubatch slices when the collective DP decision is True.
+
+        With the packed-reduce path the eligibility (local + cross-DP AND)
+        is decided in ``_preprocess``; here we just realise the split.
+        """
+        if not tbo_collective_active:
             return None
 
         tbo_num_reqs = batch.total_seqs_num_prefill if is_prefill else scheduled_bs
-        if reqs_across_dp is not None:
-            can_tbo = int(torch.min(reqs_across_dp).item()) >= 2
-        else:
-            can_tbo = tbo_num_reqs >= 2
-        if not can_tbo:
-            return None
-
         ubatch_slices = maybe_create_ubatch_slices(
             num_reqs=tbo_num_reqs,
             num_tokens=actual_num_tokens,
@@ -1558,7 +1603,32 @@ class ModelRunner:
             )
         return ubatch_slices
 
-    def _preprocess(self, batch: ScheduledBatch):
+    def _preprocess(
+        self,
+        batch: ScheduledBatch,
+        num_scheduled_tokens: Optional[np.ndarray] = None,
+    ):
+        """Single packed DP all_reduce for token padding, prefill-fan-out,
+        and the cross-DP TBO decision.
+
+        Pre-Plan-B this method issued up to 3 separate all_reduces per
+        forward (``get_dp_padding`` / ``sync_dp_for_tbo`` + ``prefill_flag``
+        + a third one inside ``UBatchWrapper._compute_ub_graph_bs`` for
+        per-ubatch token sizes). Plan B packs every per-rank scalar into
+        one int32 tensor of length ``5 * dp_size`` so SUM-reduce is
+        sufficient (each rank writes only its own slots; other slots are
+        0). The fields derived from that single reduce:
+
+          slot 0 : num_input_tokens_per_rank  -> num_tokens_across_dp
+          slot 1 : is_prefill_per_rank        -> any_rank_has_prefill
+          slot 2 : tbo_eligible_per_rank      -> all_ranks_tbo_eligible (AND)
+          slot 3 : ub0_tokens_per_rank        -> ub_max_tokens_across_dp[0]
+          slot 4 : ub1_tokens_per_rank        -> ub_max_tokens_across_dp[1]
+
+        Returns a 6-tuple:
+          (num_input_tokens, num_tokens_across_dp, dp_uniform_decode,
+           max_tokens, tbo_collective_active, ub_max_tokens_across_dp)
+        """
         num_input_tokens = batch.total_tokens_num
         is_prefill = batch.total_tokens_num_prefill > 0
 
@@ -1566,55 +1636,65 @@ class ModelRunner:
         dp_rank = self.config.parallel_config.data_parallel_rank
 
         if dp_size <= 1:
-            return num_input_tokens, None, None, False, None
-
-        reqs_across_dp = None
-        if self.config.enable_tbo:
-            from atom.utils.tbo.ubatching import sync_dp_for_tbo
-
-            sync_reqs = (
-                batch.total_seqs_num_prefill
-                if is_prefill
-                else batch.total_seqs_num_decode
+            # Single-rank TBO decision can be taken without any all_reduce.
+            if num_scheduled_tokens is None:
+                num_scheduled_tokens = np.asarray(batch.num_scheduled_tokens)
+            eligible, _, _ = self._local_tbo_precompute(
+                batch, is_prefill, num_scheduled_tokens
             )
-            num_tokens_across_dp, reqs_across_dp = sync_dp_for_tbo(
-                dp_size,
-                dp_rank,
-                num_input_tokens,
-                sync_reqs,
-            )
-        else:
-            _, num_tokens_across_dp = self.get_dp_padding(num_input_tokens)
+            return num_input_tokens, None, False, None, eligible, None
 
-        max_tokens = int(torch.max(num_tokens_across_dp).item())
+        if num_scheduled_tokens is None:
+            num_scheduled_tokens = np.asarray(batch.num_scheduled_tokens)
+        local_tbo_eligible, local_ub0, local_ub1 = self._local_tbo_precompute(
+            batch, is_prefill, num_scheduled_tokens
+        )
 
-        # Sync is_prefill across DP ranks: if ANY rank has prefill, all go eager
-        prefill_flag = torch.tensor(
-            [1 if is_prefill else 0], dtype=torch.int32, device="cpu"
+        # Packed single all_reduce — 5 int32 slots per rank, SUM-reduce.
+        sync = torch.zeros(dp_size * 5, dtype=torch.int32, device="cpu")
+        sync[dp_rank] = num_input_tokens
+        sync[dp_size + dp_rank] = 1 if is_prefill else 0
+        sync[2 * dp_size + dp_rank] = 1 if local_tbo_eligible else 0
+        sync[3 * dp_size + dp_rank] = local_ub0
+        sync[4 * dp_size + dp_rank] = local_ub1
+        torch.distributed.all_reduce(sync, group=get_dp_group().cpu_group)
+
+        num_tokens_across_dp = sync[:dp_size]
+        any_rank_has_prefill = bool(sync[dp_size : 2 * dp_size].sum().item() > 0)
+        all_ranks_tbo_eligible = (
+            int(sync[2 * dp_size : 3 * dp_size].sum().item()) == dp_size
         )
-        torch.distributed.all_reduce(
-            prefill_flag,
-            op=torch.distributed.ReduceOp.MAX,
-            group=get_dp_group().cpu_group,
-        )
-        any_rank_has_prefill = prefill_flag.item() == 1
+        ub0_across_dp = sync[3 * dp_size : 4 * dp_size]
+        ub1_across_dp = sync[4 * dp_size : 5 * dp_size]
+
+        max_tokens = int(num_tokens_across_dp.max().item())
         # vLLM-style flag: True iff this step is safe for the fixed-size
         # CUDAGraph path across DP ranks (no rank doing prefill, or DP off).
         dp_uniform_decode = (not any_rank_has_prefill) or (
             not self.config.enable_dp_attention
         )
-
         if dp_uniform_decode:
             # CUDAGraph path: all ranks pad to same max for fixed-size all_gather
             num_input_tokens = max_tokens
         # else: variable-length path — each rank keeps its own token count
 
+        tbo_collective_active = self.config.enable_tbo and all_ranks_tbo_eligible
+        ub_max_tokens_across_dp = None
+        if tbo_collective_active:
+            # Cross-DP MAX per ubatch — replaces the second all_reduce that
+            # used to live in UBatchWrapper._compute_ub_graph_bs (prefill).
+            ub_max_tokens_across_dp = (
+                int(ub0_across_dp.max().item()),
+                int(ub1_across_dp.max().item()),
+            )
+
         return (
             num_input_tokens,
             num_tokens_across_dp,
-            reqs_across_dp,
             dp_uniform_decode,
             max_tokens,
+            tbo_collective_active,
+            ub_max_tokens_across_dp,
         )
 
     def prepare_inputs(self, batch: ScheduledBatch, input_ids: torch.Tensor = None):
@@ -1625,10 +1705,11 @@ class ModelRunner:
         (
             num_input_tokens,
             num_tokens_across_dp,
-            reqs_across_dp,
             dp_uniform_decode,
             max_tokens,
-        ) = self._preprocess(batch)
+            tbo_collective_active,
+            ub_max_tokens_across_dp,
+        ) = self._preprocess(batch, num_scheduled_tokens=num_scheduled_tokens)
         self.forward_vars["cu_seqlens_q"].np[1 : bs + 1] = cu_seqlens_q
         if not is_prefill:
             scheduled_bs = batch.total_seqs_num_decode
@@ -1684,7 +1765,7 @@ class ModelRunner:
             scheduled_bs if not is_prefill else 0,
             actual_num_tokens,
             num_scheduled_tokens,
-            reqs_across_dp,
+            tbo_collective_active,
         )
 
         set_forward_context(
@@ -1695,6 +1776,7 @@ class ModelRunner:
             num_tokens_across_dp=num_tokens_across_dp,
             spec_decode_metadata=spec_decode_metadata,
             ubatch_slices=ubatch_slices,
+            ub_max_tokens_across_dp=ub_max_tokens_across_dp,
         )
         return graph_bs
 

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -982,14 +982,7 @@ class ModelRunner:
             is_dummy_run=True,
         )
 
-        bs = self.prepare_inputs(dummy_batch)
-        self.forward_vars["input_ids"].gpu[:bs].zero_()
-        input_ids = self.forward_vars["input_ids"].gpu[:bs]
-
-        logits, hidden_states = self.run_model(input_ids)
-        self._run_dummy_drafter(hidden_states)
-
-        reset_forward_context()
+        self.forward(dummy_batch)
         logger.debug(
             f"{self.label}: dummy batch executed with {dummy_batch.total_tokens_num} tokens"
         )
@@ -1573,7 +1566,7 @@ class ModelRunner:
         dp_rank = self.config.parallel_config.data_parallel_rank
 
         if dp_size <= 1:
-            return num_input_tokens, None, None
+            return num_input_tokens, None, None, False, None
 
         reqs_across_dp = None
         if self.config.enable_tbo:
@@ -1593,15 +1586,49 @@ class ModelRunner:
         else:
             _, num_tokens_across_dp = self.get_dp_padding(num_input_tokens)
 
-        num_input_tokens = int(torch.max(num_tokens_across_dp).item())
-        return num_input_tokens, num_tokens_across_dp, reqs_across_dp
+        max_tokens = int(torch.max(num_tokens_across_dp).item())
+
+        # Sync is_prefill across DP ranks: if ANY rank has prefill, all go eager
+        prefill_flag = torch.tensor(
+            [1 if is_prefill else 0], dtype=torch.int32, device="cpu"
+        )
+        torch.distributed.all_reduce(
+            prefill_flag,
+            op=torch.distributed.ReduceOp.MAX,
+            group=get_dp_group().cpu_group,
+        )
+        any_rank_has_prefill = prefill_flag.item() == 1
+        # vLLM-style flag: True iff this step is safe for the fixed-size
+        # CUDAGraph path across DP ranks (no rank doing prefill, or DP off).
+        dp_uniform_decode = (not any_rank_has_prefill) or (
+            not self.config.enable_dp_attention
+        )
+
+        if dp_uniform_decode:
+            # CUDAGraph path: all ranks pad to same max for fixed-size all_gather
+            num_input_tokens = max_tokens
+        # else: variable-length path — each rank keeps its own token count
+
+        return (
+            num_input_tokens,
+            num_tokens_across_dp,
+            reqs_across_dp,
+            dp_uniform_decode,
+            max_tokens,
+        )
 
     def prepare_inputs(self, batch: ScheduledBatch, input_ids: torch.Tensor = None):
         is_prefill = batch.total_tokens_num_prefill > 0
         bs = batch.total_seqs_num
         num_scheduled_tokens = np.asarray(batch.num_scheduled_tokens)
         cu_seqlens_q, arange = self._get_cumsum_and_arange(num_scheduled_tokens)
-        num_input_tokens, num_tokens_across_dp, reqs_across_dp = self._preprocess(batch)
+        (
+            num_input_tokens,
+            num_tokens_across_dp,
+            reqs_across_dp,
+            dp_uniform_decode,
+            max_tokens,
+        ) = self._preprocess(batch)
         self.forward_vars["cu_seqlens_q"].np[1 : bs + 1] = cu_seqlens_q
         if not is_prefill:
             scheduled_bs = batch.total_seqs_num_decode
@@ -1620,7 +1647,6 @@ class ModelRunner:
                     (x for x in self.graph_bs if x >= padded_scheduled_bs),
                     padded_scheduled_bs,
                 )
-                # Use cudagraph and padding to batch_size, if bs > graph_bs, use eager mode
             )
             assert (
                 bs >= padded_scheduled_bs
@@ -1631,7 +1657,6 @@ class ModelRunner:
         attn_metadata, positions = self.attn_metadata_builder.build(batch=batch, bs=bs)
         context_bs = batch.total_seqs_num_prefill if is_prefill else scheduled_bs
 
-        # graph_bs should be batch size (number of sequences), not token count
         graph_bs = num_input_tokens if is_prefill else bs
         context = Context(
             positions=positions,
@@ -1639,7 +1664,9 @@ class ModelRunner:
             is_dummy_run=batch.is_dummy_run,
             batch_size=context_bs,
             graph_bs=graph_bs,
+            dp_uniform_decode=dp_uniform_decode,
         )
+
         actual_num_tokens = batch.total_tokens_num
 
         spec_decode_metadata = None
@@ -1748,9 +1775,18 @@ class ModelRunner:
         is_prefill = context.is_prefill
         positions = context.positions
 
-        if is_prefill or self.enforce_eager or bs > self.graph_bs[-1]:
-            # prefill[bs=1 tok=115 ctx=115]
-            label = f"prefill[bs={bs}" if is_prefill else f"eager_decode[bs={bs}"
+        if (
+            is_prefill
+            or self.enforce_eager
+            or not context.dp_uniform_decode
+            or bs > self.graph_bs[-1]
+        ):
+            # prefill, or decode forced eager (enforce_eager / DP peer
+            # prefill / bs above the largest captured graph).
+            if is_prefill:
+                label = f"prefill[bs={bs}"
+            else:
+                label = f"eager_decode[bs={bs}"
             if batch is not None:
                 ctx = batch.context_lens
                 if len(ctx) == 1:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1612,8 +1612,6 @@ class ModelRunner:
         )
 
         max_tokens = int(sync.num_tokens_across_dp.max().item())
-        # vLLM-style flag: True iff this step is safe for the fixed-size
-        # CUDAGraph path across DP ranks (no rank doing prefill, or DP off).
         dp_uniform_decode = (not sync.any_rank_has_prefill) or (
             not self.config.enable_dp_attention
         )

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -36,7 +36,12 @@ from atom.utils import (
 )
 from atom.kv_transfer.disaggregation import KVConnectorOutput
 from atom.utils.forward_context import get_kvconnector
-from atom.utils.tbo import UBatchWrapper, maybe_create_ubatch_slices
+from atom.utils.tbo import (
+    UBatchWrapper,
+    local_tbo_precompute,
+    maybe_create_ubatch_slices,
+    sync_dp_for_tbo,
+)
 from atom.utils.forward_context import (
     Context,
     DPMetadata,
@@ -1520,58 +1525,6 @@ class ModelRunner:
 
         return max_tokens_across_dp_cpu - num_tokens, num_tokens_across_dp
 
-    def _local_tbo_precompute(
-        self, batch, is_prefill: bool, num_scheduled_tokens: np.ndarray
-    ) -> tuple[bool, int, int]:
-        """Decide locally whether this rank could TBO-split into 2 ubatches,
-        and if so, what (ub0_tokens, ub1_tokens) the split would produce.
-
-        Returns (eligible, ub0_tokens, ub1_tokens). All zeros when ineligible.
-        These values are packed into the single DP all_reduce in
-        ``_preprocess`` so the collective decision (AND across ranks) and
-        ``UBatchWrapper`` 's per-ubatch token max (replaces a second
-        all_reduce) can both be derived from one round-trip.
-        """
-        if not self.config.enable_tbo:
-            return False, 0, 0
-        if is_prefill:
-            n_pref = batch.total_seqs_num_prefill
-            if n_pref < 2:
-                return False, 0, 0
-            # Mirror _split_prefill_balanced: pick boundary closest to
-            # total/2 so the packed value matches what
-            # maybe_create_ubatch_slices will produce post-decision.
-            toks = np.asarray(num_scheduled_tokens[:n_pref], dtype=np.int64)
-            total = int(toks.sum())
-            target = total // 2
-            cumsum = 0
-            split_idx = 1
-            for j in range(n_pref):
-                cumsum += int(toks[j])
-                if cumsum >= target:
-                    prev = cumsum - int(toks[j])
-                    if j > 0 and (target - prev) < (cumsum - target):
-                        split_idx = j
-                    else:
-                        split_idx = j + 1
-                    break
-            split_idx = max(1, min(split_idx, n_pref - 1))
-            ub0 = int(toks[:split_idx].sum())
-            ub1 = total - ub0
-            return True, ub0, ub1
-        # Decode path
-        if not self.config.enable_tbo_decode or batch.is_dummy_run:
-            return False, 0, 0
-        scheduled_bs = batch.total_seqs_num_decode
-        if scheduled_bs < 2:
-            return False, 0, 0
-        num_tokens = batch.total_tokens_num
-        tokens_per_req = num_tokens // scheduled_bs if scheduled_bs else 1
-        reqs_per_ub = scheduled_bs // 2
-        ub0 = reqs_per_ub * tokens_per_req
-        ub1 = num_tokens - ub0
-        return True, ub0, ub1
-
     def _maybe_create_tbo_slices(
         self,
         batch,
@@ -1608,93 +1561,63 @@ class ModelRunner:
         batch: ScheduledBatch,
         num_scheduled_tokens: Optional[np.ndarray] = None,
     ):
-        """Single packed DP all_reduce for token padding, prefill-fan-out,
-        and the cross-DP TBO decision.
+        """Per-step DP sync: token padding, prefill fan-out, TBO decision.
 
-        Pre-Plan-B this method issued up to 3 separate all_reduces per
-        forward (``get_dp_padding`` / ``sync_dp_for_tbo`` + ``prefill_flag``
-        + a third one inside ``UBatchWrapper._compute_ub_graph_bs`` for
-        per-ubatch token sizes). Plan B packs every per-rank scalar into
-        one int32 tensor of length ``5 * dp_size`` so SUM-reduce is
-        sufficient (each rank writes only its own slots; other slots are
-        0). The fields derived from that single reduce:
+        Thin wrapper over :func:`atom.utils.tbo.sync_dp_for_tbo` (the
+        actual collective) and :func:`atom.utils.tbo.local_tbo_precompute`
+        (the rank-local TBO eligibility / per-ubatch token split).
 
-          slot 0 : num_input_tokens_per_rank  -> num_tokens_across_dp
-          slot 1 : is_prefill_per_rank        -> any_rank_has_prefill
-          slot 2 : tbo_eligible_per_rank      -> all_ranks_tbo_eligible (AND)
-          slot 3 : ub0_tokens_per_rank        -> ub_max_tokens_across_dp[0]
-          slot 4 : ub1_tokens_per_rank        -> ub_max_tokens_across_dp[1]
-
-        Returns a 6-tuple:
-          (num_input_tokens, num_tokens_across_dp, dp_uniform_decode,
-           max_tokens, tbo_collective_active, ub_max_tokens_across_dp)
+        Returns:
+            (num_input_tokens, num_tokens_across_dp, dp_uniform_decode,
+             max_tokens, tbo_collective_active, ub_max_tokens_across_dp)
         """
         num_input_tokens = batch.total_tokens_num
         is_prefill = batch.total_tokens_num_prefill > 0
-
+        tbo_on = self.config.enable_tbo
         dp_size = self.config.parallel_config.data_parallel_size
-        dp_rank = self.config.parallel_config.data_parallel_rank
 
-        if dp_size <= 1:
-            # Single-rank TBO decision can be taken without any all_reduce.
+        # Rank-local TBO precompute (needed for both dp==1 fast path and
+        # the cross-DP packed gather below).
+        local_eligible, local_ub0, local_ub1 = False, 0, 0
+        if tbo_on:
             if num_scheduled_tokens is None:
                 num_scheduled_tokens = np.asarray(batch.num_scheduled_tokens)
-            eligible, _, _ = self._local_tbo_precompute(
-                batch, is_prefill, num_scheduled_tokens
+            local_eligible, local_ub0, local_ub1 = local_tbo_precompute(
+                self.config, batch, is_prefill, num_scheduled_tokens
             )
-            return num_input_tokens, None, False, None, eligible, None
 
-        if num_scheduled_tokens is None:
-            num_scheduled_tokens = np.asarray(batch.num_scheduled_tokens)
-        local_tbo_eligible, local_ub0, local_ub1 = self._local_tbo_precompute(
-            batch, is_prefill, num_scheduled_tokens
+        if dp_size <= 1:
+            # Single-rank: TBO decision is purely local; no collective needed.
+            return num_input_tokens, None, False, None, local_eligible, None
+
+        sync = sync_dp_for_tbo(
+            dp_group=get_dp_group().cpu_group,
+            dp_size=dp_size,
+            num_input_tokens=num_input_tokens,
+            is_prefill=is_prefill,
+            tbo_on=tbo_on,
+            local_tbo_eligible=local_eligible,
+            local_ub_tokens=(local_ub0, local_ub1),
         )
 
-        # Packed single all_reduce — 5 int32 slots per rank, SUM-reduce.
-        sync = torch.zeros(dp_size * 5, dtype=torch.int32, device="cpu")
-        sync[dp_rank] = num_input_tokens
-        sync[dp_size + dp_rank] = 1 if is_prefill else 0
-        sync[2 * dp_size + dp_rank] = 1 if local_tbo_eligible else 0
-        sync[3 * dp_size + dp_rank] = local_ub0
-        sync[4 * dp_size + dp_rank] = local_ub1
-        torch.distributed.all_reduce(sync, group=get_dp_group().cpu_group)
-
-        num_tokens_across_dp = sync[:dp_size]
-        any_rank_has_prefill = bool(sync[dp_size : 2 * dp_size].sum().item() > 0)
-        all_ranks_tbo_eligible = (
-            int(sync[2 * dp_size : 3 * dp_size].sum().item()) == dp_size
-        )
-        ub0_across_dp = sync[3 * dp_size : 4 * dp_size]
-        ub1_across_dp = sync[4 * dp_size : 5 * dp_size]
-
-        max_tokens = int(num_tokens_across_dp.max().item())
+        max_tokens = int(sync.num_tokens_across_dp.max().item())
         # vLLM-style flag: True iff this step is safe for the fixed-size
         # CUDAGraph path across DP ranks (no rank doing prefill, or DP off).
-        dp_uniform_decode = (not any_rank_has_prefill) or (
+        dp_uniform_decode = (not sync.any_rank_has_prefill) or (
             not self.config.enable_dp_attention
         )
         if dp_uniform_decode:
-            # CUDAGraph path: all ranks pad to same max for fixed-size all_gather
+            # CUDAGraph path: all ranks pad to the same max for fixed-size all_gather.
             num_input_tokens = max_tokens
-        # else: variable-length path — each rank keeps its own token count
-
-        tbo_collective_active = self.config.enable_tbo and all_ranks_tbo_eligible
-        ub_max_tokens_across_dp = None
-        if tbo_collective_active:
-            # Cross-DP MAX per ubatch — replaces the second all_reduce that
-            # used to live in UBatchWrapper._compute_ub_graph_bs (prefill).
-            ub_max_tokens_across_dp = (
-                int(ub0_across_dp.max().item()),
-                int(ub1_across_dp.max().item()),
-            )
+        # else: variable-length path — each rank keeps its own token count.
 
         return (
             num_input_tokens,
-            num_tokens_across_dp,
+            sync.num_tokens_across_dp,
             dp_uniform_decode,
             max_tokens,
-            tbo_collective_active,
-            ub_max_tokens_across_dp,
+            sync.tbo_collective_active,
+            sync.ub_max_tokens_across_dp,
         )
 
     def prepare_inputs(self, batch: ScheduledBatch, input_ids: torch.Tensor = None):

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1588,7 +1588,18 @@ class ModelRunner:
 
         if dp_size <= 1:
             # Single-rank: TBO decision is purely local; no collective needed.
-            return num_input_tokens, None, False, None, local_eligible, None
+            # dp_uniform_decode=True mirrors the DP-disabled case in the
+            # multi-rank branch (`not enable_dp_attention` => True) and the
+            # Context default — otherwise single-GPU/TP-only decode would
+            # be forced into eager and lose the CUDAGraph decode path.
+            return (
+                num_input_tokens,
+                None,
+                True,
+                num_input_tokens,
+                local_eligible,
+                None,
+            )
 
         sync = sync_dp_for_tbo(
             dp_group=get_dp_group().cpu_group,

--- a/atom/model_engine/prefill_delayer.py
+++ b/atom/model_engine/prefill_delayer.py
@@ -1,0 +1,249 @@
+"""
+PrefillDelayer — cross-DP-rank prefill alignment for ATOM.
+
+Direct port of SGLang's PrefillDelayer (refactored form, post #16269), keeping
+the "mixed prefillable status → delay" core that fixes our 1k/1k workload's
+~81% pad_waste during prefill forwards.
+
+Mechanism (per scheduler tick):
+  1. Each DP rank reports its local state via cpu all_gather:
+       (local_prefillable, watermark_force_allow)
+  2. Compute `prefillable_status` ∈ {all, none, mixed}:
+       - "all"   → every rank has a new prefill ready  → allow (8-way aligned)
+       - "none"  → no rank has any prefill             → allow (vacuous)
+       - "mixed" → only some ranks have prefill ready  → DELAY
+  3. In "mixed", refuse the prefill (return False from `should_allow_prefill`)
+     for up to `max_delay_passes` consecutive ticks (default 30, ≈ 255ms at
+     8.5ms/decode-tick) OR `max_delay_ms` wall-clock (default 5000ms),
+     whichever comes first. After timeout, force-allow to bound worst-case
+     TTFT.
+  4. Safety valve: if local KV-cache usage drops below
+     `token_usage_low_watermark`, the rank reports "force_allow" and the
+     delayer falls through immediately (the GPU is idling, don't delay).
+
+Why this fixes our problem:
+  Today (no delayer) — when 1 rank has a new prefill and 7 have decodes,
+  ATOM runs eager forward NOW. MoE all_to_all is bottlenecked by the
+  prefill rank's ~1000 tokens, costing all 8 ranks ~118ms (a1.log: 81.7%
+  pad_waste, 67% of wall in moe.gather). 57 such mixed forwards = 6.7s.
+  With delayer — the prefilling rank waits up to 255ms for sibling ranks'
+  waiting queues to also gain prefills, then all 8 ranks do prefill
+  simultaneously (balanced all_to_all). 57 mixed forwards → ~8 aligned
+  forwards × ~140ms = 1.1s. Expected: ~5.6s saved per request burst.
+
+What's intentionally NOT ported from SGL (HEAD):
+  - prometheus / observability hooks (ATOM has dp_timing instead)
+  - NCCL gather path (ATOM's dp_group is gloo cpu_group; sufficient)
+  - TBO / hisparse / dllm / spec interactions (N/A)
+  - `queue_min_ratio` adaptive trigger (added 2026-05; defer until baseline)
+  - `slot_condition` (max_running_requests - global_running_bs check):
+        ATOM steady-state running_bs ≈ 16 vs max_num_seqs ≈ 256+, condition
+        never true → omitted to keep code simple
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_DEBUG = os.environ.get("ATOM_PREFILL_DELAYER_DEBUG", "0") == "1"
+
+
+class PrefillDelayer:
+    __slots__ = (
+        "dp_size",
+        "cpu_group",
+        "max_delay_passes",
+        "max_delay_ms",
+        "token_usage_low_watermark",
+        "_reduce_buf",
+        "_delayed_count",
+        "_delay_start_ts",
+        "_skip_first",
+        "_stat_allow",
+        "_stat_delay",
+        "_stat_timeout",
+        "_stat_watermark",
+        "_stat_log_every",
+    )
+
+    def __init__(
+        self,
+        dp_size: int,
+        cpu_group,
+        max_delay_passes: int = 30,
+        token_usage_low_watermark: Optional[float] = None,
+        max_delay_ms: float = 5000.0,
+    ):
+        self.dp_size = dp_size
+        self.cpu_group = cpu_group
+        self.max_delay_passes = max_delay_passes
+        self.max_delay_ms = max_delay_ms
+        self.token_usage_low_watermark = token_usage_low_watermark
+
+        # 3-slot MAX-reduce buffer (gloo-friendly; mirrors the proven
+        # `_sync_dp_state` all_reduce path in engine_core.py rather than
+        # relying on all_gather_into_tensor — the stateless gloo group's
+        # docstring warns broadcast-like ops are unreliable, and the
+        # initial hang we saw with all_gather_into_tensor was consistent
+        # with this caveat).
+        #
+        # Encoding:
+        #   slot 0 = local_prefillable          (MAX → "any rank prefillable")
+        #   slot 1 = local_force                (MAX → "any rank forces allow")
+        #   slot 2 = NOT local_prefillable      (MAX → "any rank lacks prefill")
+        # Then prefillable_status:
+        #   any_prefillable AND any_not_prefillable → "mixed"
+        #   any_prefillable AND NOT any_not_prefillable → "all"
+        #   NOT any_prefillable → "none"
+        # Single all_reduce, 3 int64s on cpu — negligible overhead.
+        self._reduce_buf = torch.zeros(3, dtype=torch.int64, device="cpu")
+
+        self._delayed_count: int = 0
+        self._delay_start_ts: float = 0.0
+        # Skip first negotiation: during warmup / first burst we want
+        # decode batch_size to grow as fast as possible. Mirrors SGL
+        # PR #19836 (`skip_first_delayer`).
+        self._skip_first: bool = True
+
+        # Aggregate counters for periodic logging
+        self._stat_allow = 0
+        self._stat_delay = 0
+        self._stat_timeout = 0
+        self._stat_watermark = 0
+        self._stat_log_every = int(
+            os.environ.get("ATOM_PREFILL_DELAYER_LOG_EVERY", "1000")
+        )
+
+        logger.info(
+            f"PrefillDelayer initialized: dp_size={dp_size} "
+            f"max_delay_passes={max_delay_passes} "
+            f"max_delay_ms={max_delay_ms} "
+            f"watermark={token_usage_low_watermark}"
+        )
+
+    def should_allow_prefill(
+        self,
+        local_prefillable: bool,
+        token_usage: float,
+    ) -> bool:
+        """
+        Returns True iff this rank is allowed to admit new prefills this tick.
+
+        Args:
+            local_prefillable: this rank has at least one new prefill ready
+                (i.e. self.waiting non-empty and admission would succeed).
+            token_usage: fraction of KV cache blocks currently in use
+                (used_blocks / total_blocks ∈ [0, 1]). Used by the
+                low-watermark safety valve.
+        """
+        # Local "force allow" if KV cache is underutilized — don't delay
+        # when GPU is starving. Only meaningful if this rank actually has
+        # a prefill to push through (otherwise force_allow is a no-op).
+        force = False
+        if (
+            self.token_usage_low_watermark is not None
+            and local_prefillable
+            and token_usage < self.token_usage_low_watermark
+        ):
+            force = True
+
+        # Cross-DP MAX-reduce: 3 booleans encoded as int64.
+        self._reduce_buf[0] = 1 if local_prefillable else 0
+        self._reduce_buf[1] = 1 if force else 0
+        self._reduce_buf[2] = 0 if local_prefillable else 1
+        torch.distributed.all_reduce(
+            self._reduce_buf,
+            op=torch.distributed.ReduceOp.MAX,
+            group=self.cpu_group,
+        )
+        any_prefillable = int(self._reduce_buf[0].item()) > 0
+        force_max = int(self._reduce_buf[1].item())
+        any_not_prefillable = int(self._reduce_buf[2].item()) > 0
+
+        # Derive 3-way status: all / none / mixed.
+        prefillable_max = 1 if any_prefillable else 0
+        prefillable_min = 0 if any_not_prefillable else 1
+
+        # Watermark short-circuit: ANY rank below the watermark forces all
+        # ranks to allow this tick. Without this the delayer can stall a
+        # rank with a fresh prefill while the cluster is underloaded.
+        if force_max > 0:
+            self._stat_watermark += 1
+            self._reset_delay()
+            self._maybe_log()
+            return True
+
+        # Skip first call to maximize initial decode batch size build-up.
+        if self._skip_first:
+            self._skip_first = False
+            self._reset_delay()
+            self._stat_allow += 1
+            self._maybe_log()
+            return True
+
+        # status = "all" or "none" → no skew, just allow
+        if prefillable_min == prefillable_max:
+            self._reset_delay()
+            self._stat_allow += 1
+            self._maybe_log()
+            return True
+
+        # status = "mixed" → delay if still within budget
+        if self._delayed_count == 0:
+            self._delay_start_ts = time.perf_counter()
+        elapsed_ms = (time.perf_counter() - self._delay_start_ts) * 1000.0
+
+        if (
+            self._delayed_count < self.max_delay_passes
+            and elapsed_ms < self.max_delay_ms
+        ):
+            self._delayed_count += 1
+            self._stat_delay += 1
+            if _DEBUG:
+                logger.info(
+                    f"[PrefillDelayer] DELAY: count={self._delayed_count} "
+                    f"elapsed={elapsed_ms:.1f}ms "
+                    f"any_prefillable={any_prefillable} "
+                    f"any_not_prefillable={any_not_prefillable}"
+                )
+            self._maybe_log()
+            return False
+
+        # Timed out — force allow to bound worst-case TTFT
+        self._stat_timeout += 1
+        if _DEBUG:
+            logger.info(
+                f"[PrefillDelayer] TIMEOUT: count={self._delayed_count} "
+                f"elapsed={elapsed_ms:.1f}ms force-allow"
+            )
+        self._reset_delay()
+        self._maybe_log()
+        return True
+
+    def _reset_delay(self):
+        self._delayed_count = 0
+        self._delay_start_ts = 0.0
+
+    def _maybe_log(self):
+        total = (
+            self._stat_allow
+            + self._stat_delay
+            + self._stat_timeout
+            + self._stat_watermark
+        )
+        if self._stat_log_every <= 0 or total == 0:
+            return
+        if total % self._stat_log_every == 0:
+            logger.info(
+                f"[PrefillDelayer stats] total={total} "
+                f"allow={self._stat_allow} delay={self._stat_delay} "
+                f"timeout={self._stat_timeout} watermark={self._stat_watermark} "
+                f"(delay_rate={self._stat_delay/total:.2%})"
+            )

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -502,7 +502,7 @@ class Scheduler:
             num_new_tokens = seq.num_tokens - seq.num_cached_tokens
             if num_new_tokens > self.max_num_batched_tokens:
                 continue
-            if not self.block_manager.can_allocate(seq):
+            if self.block_manager.can_allocate(seq) < 0:
                 return False  # KV-pressured: definitely cannot prefill
             return True
         return False

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -490,8 +490,6 @@ class Scheduler:
         """
         if not self.waiting:
             return False
-        # Bounded peek: in practice the head is admissible or not; we
-        # cap at 4 to avoid pathological O(queue) work per tick.
         for i, seq in enumerate(self.waiting):
             if i >= 4:
                 break

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -18,7 +18,6 @@ This module provides:
 from __future__ import annotations
 
 import logging
-import os
 import time
 from collections import deque
 from typing import Optional
@@ -32,15 +31,6 @@ from atom.model_engine.request import RequestOutput
 from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
 
 logger = logging.getLogger("atom")
-
-# Chunked-prefill threshold (in tokens). 0 = disabled (legacy single-shot
-# prefill). When set, each forward admits at most `threshold` *new* prompt
-# tokens per prefill seq, and an in-flight chunked prefill seq is given
-# absolute priority over both decode and new-prefill admission so that no
-# more than ONE prefill seq is half-finished at any time. Steps remain
-# pure-prefill or pure-decode (no mixed batches) to preserve the
-# attention/MoE/DP-sync invariants the rest of the stack relies on.
-_LONG_PREFILL_THRESHOLD = int(os.environ.get("ATOM_LONG_PREFILL_THRESHOLD", "0"))
 
 
 class SpecStats:
@@ -236,19 +226,7 @@ class ScheduledBatch:
         scheduled_spec_decode_tokens: dict[int, np.ndarray] | None = None,
         remote_kv_block_ids: list[int] | None = None,
         remote_kv_seq_blocks: dict[int, list[int]] | None = None,
-        chunked_overrides: dict[int, tuple[int, int]] | None = None,
     ):
-        """
-        chunked_overrides: per-seq override for (effective_context_len,
-        effective_cached_tokens) when a prefill seq is being run as a chunk
-        rather than the full prompt. Lets prepare_prefill see the seq as if
-        its prompt were `effective_context_len` long with `effective_cached`
-        tokens already in KV, so seqlen_q = ctx - cached = chunk_size and
-        positions = range(cached, ctx) line up with the new tokens of this
-        chunk only. Block tables (allocated for the full prompt at chunk 0)
-        and num_blocks are reused as-is — the unwritten blocks for future
-        chunks just sit unfilled until those chunks run.
-        """
         if scheduled_spec_decode_tokens is None:
             scheduled_spec_decode_tokens = {}
         self.remote_kv_block_ids = remote_kv_block_ids or []
@@ -266,18 +244,9 @@ class ScheduledBatch:
         self.temperatures = np.asarray(
             [seq.temperature for seq in seqs.values()], dtype=np.float32
         )
-        # Effective context length per seq. For a chunked prefill seq, this
-        # is the cumulative token count *after* this chunk completes
-        # (= num_computed_tokens_after_chunk), NOT the full prompt length.
-        # That makes seqlen_q = context_len - num_cached = chunk_size in
-        # prepare_prefill without touching that function.
-        _ctx = []
-        for _sid, _seq in seqs.items():
-            if chunked_overrides and _sid in chunked_overrides:
-                _ctx.append(chunked_overrides[_sid][0])
-            else:
-                _ctx.append(_seq.num_tokens)
-        self.context_lens = np.asarray(_ctx, dtype=np.int32)
+        self.context_lens = np.asarray(
+            [_seq.num_tokens for _seq in seqs.values()], dtype=np.int32
+        )
         self.num_rejected = np.asarray(
             [seq.num_rejected for seq in seqs.values()], dtype=np.int32
         )
@@ -319,28 +288,10 @@ class ScheduledBatch:
         self.block_tables = [
             seq.block_table for seq in seqs.values() if seq.block_table
         ]
-        # last_block_num_tokens must match effective context_len so the
-        # prepare_prefill slot_mapping loop ends on the right partial block.
-        _lbnt = []
-        for i, (_sid, _seq) in enumerate(seqs.items()):
-            eff = int(self.context_lens[i])
-            if chunked_overrides and _sid in chunked_overrides:
-                bs = _seq.block_size
-                nblk = (eff + bs - 1) // bs
-                _lbnt.append(eff - (nblk - 1) * bs)
-            else:
-                _lbnt.append(_seq.last_block_num_tokens)
-        self.last_block_num_tokens = _lbnt
-        # num_cached_tokens override: for a chunked prefill seq, the "cached"
-        # half is everything already computed in previous chunks. prepare_prefill
-        # uses this to start `positions` at this chunk's first token.
-        _nct = []
-        for _sid, _seq in seqs.items():
-            if chunked_overrides and _sid in chunked_overrides:
-                _nct.append(chunked_overrides[_sid][1])
-            else:
-                _nct.append(_seq.num_cached_tokens)
-        self.num_cached_tokens = _nct
+        self.last_block_num_tokens = [
+            _seq.last_block_num_tokens for _seq in seqs.values()
+        ]
+        self.num_cached_tokens = [_seq.num_cached_tokens for _seq in seqs.values()]
 
         # Total number of tokens scheduled for all requests.
         self.total_tokens_num = total_tokens_num
@@ -656,70 +607,6 @@ class Scheduler:
         if not self.running and not self.waiting:
             return None
 
-        threshold = _LONG_PREFILL_THRESHOLD
-        block_size = self.block_manager.block_size
-        if threshold > 0 and threshold % block_size != 0:
-            # Align down so chunk boundaries land on block boundaries
-            # (prepare_prefill's slot_mapping loop iterates whole blocks).
-            threshold = max(block_size, (threshold // block_size) * block_size)
-        chunked_overrides: dict[int, tuple[int, int]] = {}
-
-        if threshold > 0:
-            in_flight_seq = next(
-                (
-                    s
-                    for s in self.running
-                    if s.type == SequenceType.PREFILL and not s.is_prefill_done
-                ),
-                None,
-            )
-            if in_flight_seq is not None:
-                seq = in_flight_seq
-                remaining = seq.num_prompt_tokens - seq.num_computed_tokens
-                avail = self.max_num_batched_tokens
-                chunk = min(remaining, threshold, avail)
-                # Final chunk may be non-aligned; intermediate chunks must
-                # be a multiple of block_size so blocks fill exactly.
-                if chunk < remaining and chunk >= block_size:
-                    chunk = (chunk // block_size) * block_size
-                assert chunk > 0, (
-                    f"chunked prefill produced empty chunk for seq {seq.id} "
-                    f"(remaining={remaining} threshold={threshold} avail={avail})"
-                )
-                chunk_start = seq.num_computed_tokens
-                chunk_end = chunk_start + chunk
-                chunked_overrides[seq.id] = (chunk_end, chunk_start)
-                seq.num_computed_tokens = chunk_end
-                if chunk_end >= seq.num_prompt_tokens:
-                    seq.is_prefill_done = True
-                scheduled_seqs[seq.id] = seq
-                num_scheduled_tokens.append(chunk)
-                num_seqs_prefill = 1
-                num_batched_tokens = chunk
-                total_tokens_num_prefill = chunk
-                logger.info(
-                    f"Scheduled prefill CHUNK: seq {seq.id} "
-                    f"chunk=[{chunk_start},{chunk_end}) of {seq.num_prompt_tokens}, "
-                    f"done={seq.is_prefill_done}"
-                )
-                self.prev_prompt = True
-                connector_meta_output = None
-                if self.kv_connector is not None:
-                    connector_meta_output = self.kv_connector.build_connector_meta()
-                return (
-                    ScheduledBatch(
-                        seqs=scheduled_seqs,
-                        num_scheduled_tokens=num_scheduled_tokens,
-                        total_tokens_num=total_tokens_num_prefill,
-                        total_tokens_num_prefill=total_tokens_num_prefill,
-                        total_seqs_num=num_seqs_prefill,
-                        total_seqs_num_prefill=num_seqs_prefill,
-                        connector_meta_output=connector_meta_output,
-                        chunked_overrides=chunked_overrides,
-                    ),
-                    scheduled_seqs,
-                )
-
         # --- Prefill scheduling --- (gated by `_delayer_allows_prefill`
         # computed at the very top of schedule() to keep the cross-DP
         # collective aligned across all early-return paths)
@@ -808,34 +695,12 @@ class Scheduler:
             num_new_tokens = seq.num_tokens - seq.num_cached_tokens
             if self.cache_stats:
                 self.cache_stats.update(seq.num_cached_tokens, seq.num_tokens)
-            # Chunked prefill: first chunk only. Final chunk may be smaller.
-            # Block-aligned cap unless this *is* the final chunk.
-            if threshold > 0:
-                chunk = min(num_new_tokens, threshold)
-                if chunk < num_new_tokens and chunk >= block_size:
-                    chunk = (chunk // block_size) * block_size
-                chunk = max(chunk, 1)  # never empty
-                chunk_start = seq.num_cached_tokens
-                chunk_end = chunk_start + chunk
-                chunked_overrides[seq.id] = (chunk_end, chunk_start)
-                seq.num_computed_tokens = chunk_end
-                seq.is_prefill_done = chunk_end >= seq.num_prompt_tokens
-                num_new_tokens = chunk
-            else:
-                # Legacy: prefill completes in one shot.
-                seq.num_computed_tokens = seq.num_tokens
-                seq.is_prefill_done = True
             num_batched_tokens += num_new_tokens
             seq.status = SequenceStatus.RUNNING
             seq.type = SequenceType.PREFILL
             self.running.append(seq)
             scheduled_seqs[seq.id] = seq
             num_scheduled_tokens.append(num_new_tokens)
-
-            # Chunked mode: only admit one new prefill per step (the first
-            # chunk must monopolize the next step's chunk continuation).
-            if threshold > 0:
-                break
 
         if skipped_waiting_requests:
             logger.debug(
@@ -869,7 +734,6 @@ class Scheduler:
                     total_seqs_num=num_seqs_prefill,
                     total_seqs_num_prefill=num_seqs_prefill,
                     connector_meta_output=connector_meta_output,
-                    chunked_overrides=chunked_overrides,
                 ),
                 scheduled_seqs,
             )
@@ -961,11 +825,6 @@ class Scheduler:
         seq.num_bonus_tokens = 0
         seq.spec_token_ids = np.array([], dtype=np.int32)
         seq.is_first_decode = False
-        # Reset chunked-prefill bookkeeping so the re-admitted seq restarts
-        # prefill from scratch (block_manager.allocate() at re-admission
-        # will refresh num_cached_tokens from prefix-cache hits).
-        seq.num_computed_tokens = 0
-        seq.is_prefill_done = False
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
 
@@ -1000,10 +859,8 @@ class Scheduler:
             # Register prefix-cache hashes for blocks the prefill step just
             # finalized. Deferred from BlockManager.allocate() so a hash is
             # only published after the block's KV has actually been computed
-            # by the forward — keeps the block manager correct under future
-            # chunked-prefill scheduling where one block may span multiple
-            # steps. Must run before any seq state update so num_cached_tokens
-            # and block_table still reflect the pre-step view.
+            # by the forward. Must run before any seq state update so
+            # num_cached_tokens and block_table still reflect the pre-step view.
             if seq.type == SequenceType.PREFILL:
                 self.block_manager.hash_blocks(
                     seq, seq.num_tokens - seq.num_cached_tokens

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -18,6 +18,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections import deque
 from typing import Optional
@@ -31,6 +32,15 @@ from atom.model_engine.request import RequestOutput
 from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
 
 logger = logging.getLogger("atom")
+
+# Chunked-prefill threshold (in tokens). 0 = disabled (legacy single-shot
+# prefill). When set, each forward admits at most `threshold` *new* prompt
+# tokens per prefill seq, and an in-flight chunked prefill seq is given
+# absolute priority over both decode and new-prefill admission so that no
+# more than ONE prefill seq is half-finished at any time. Steps remain
+# pure-prefill or pure-decode (no mixed batches) to preserve the
+# attention/MoE/DP-sync invariants the rest of the stack relies on.
+_LONG_PREFILL_THRESHOLD = int(os.environ.get("ATOM_LONG_PREFILL_THRESHOLD", "0"))
 
 
 class SpecStats:
@@ -226,7 +236,19 @@ class ScheduledBatch:
         scheduled_spec_decode_tokens: dict[int, np.ndarray] | None = None,
         remote_kv_block_ids: list[int] | None = None,
         remote_kv_seq_blocks: dict[int, list[int]] | None = None,
+        chunked_overrides: dict[int, tuple[int, int]] | None = None,
     ):
+        """
+        chunked_overrides: per-seq override for (effective_context_len,
+        effective_cached_tokens) when a prefill seq is being run as a chunk
+        rather than the full prompt. Lets prepare_prefill see the seq as if
+        its prompt were `effective_context_len` long with `effective_cached`
+        tokens already in KV, so seqlen_q = ctx - cached = chunk_size and
+        positions = range(cached, ctx) line up with the new tokens of this
+        chunk only. Block tables (allocated for the full prompt at chunk 0)
+        and num_blocks are reused as-is — the unwritten blocks for future
+        chunks just sit unfilled until those chunks run.
+        """
         if scheduled_spec_decode_tokens is None:
             scheduled_spec_decode_tokens = {}
         self.remote_kv_block_ids = remote_kv_block_ids or []
@@ -244,9 +266,18 @@ class ScheduledBatch:
         self.temperatures = np.asarray(
             [seq.temperature for seq in seqs.values()], dtype=np.float32
         )
-        self.context_lens = np.asarray(
-            [seq.num_tokens for seq in seqs.values()], dtype=np.int32
-        )
+        # Effective context length per seq. For a chunked prefill seq, this
+        # is the cumulative token count *after* this chunk completes
+        # (= num_computed_tokens_after_chunk), NOT the full prompt length.
+        # That makes seqlen_q = context_len - num_cached = chunk_size in
+        # prepare_prefill without touching that function.
+        _ctx = []
+        for _sid, _seq in seqs.items():
+            if chunked_overrides and _sid in chunked_overrides:
+                _ctx.append(chunked_overrides[_sid][0])
+            else:
+                _ctx.append(_seq.num_tokens)
+        self.context_lens = np.asarray(_ctx, dtype=np.int32)
         self.num_rejected = np.asarray(
             [seq.num_rejected for seq in seqs.values()], dtype=np.int32
         )
@@ -288,10 +319,28 @@ class ScheduledBatch:
         self.block_tables = [
             seq.block_table for seq in seqs.values() if seq.block_table
         ]
-        self.last_block_num_tokens = [
-            seq.last_block_num_tokens for seq in seqs.values()
-        ]
-        self.num_cached_tokens = [seq.num_cached_tokens for seq in seqs.values()]
+        # last_block_num_tokens must match effective context_len so the
+        # prepare_prefill slot_mapping loop ends on the right partial block.
+        _lbnt = []
+        for i, (_sid, _seq) in enumerate(seqs.items()):
+            eff = int(self.context_lens[i])
+            if chunked_overrides and _sid in chunked_overrides:
+                bs = _seq.block_size
+                nblk = (eff + bs - 1) // bs
+                _lbnt.append(eff - (nblk - 1) * bs)
+            else:
+                _lbnt.append(_seq.last_block_num_tokens)
+        self.last_block_num_tokens = _lbnt
+        # num_cached_tokens override: for a chunked prefill seq, the "cached"
+        # half is everything already computed in previous chunks. prepare_prefill
+        # uses this to start `positions` at this chunk's first token.
+        _nct = []
+        for _sid, _seq in seqs.items():
+            if chunked_overrides and _sid in chunked_overrides:
+                _nct.append(chunked_overrides[_sid][1])
+            else:
+                _nct.append(_seq.num_cached_tokens)
+        self.num_cached_tokens = _nct
 
         # Total number of tokens scheduled for all requests.
         self.total_tokens_num = total_tokens_num
@@ -413,6 +462,63 @@ class Scheduler:
         from atom.utils.forward_context import get_kvconnector
 
         self.kv_connector = get_kvconnector("scheduler", config)
+
+        # Cross-DP prefill alignment. Set by DPEngineCoreProc after
+        # dp_group is available. See `prefill_delayer.py` for rationale.
+        from atom.model_engine.prefill_delayer import PrefillDelayer
+
+        self.prefill_delayer: Optional[PrefillDelayer] = None
+
+    def set_prefill_delayer(self, delayer) -> None:
+        self.prefill_delayer = delayer
+
+    def _can_admit_head_prefill(self) -> bool:
+        """Match SGL's `local_prefillable=True` semantics: report True iff
+        this rank would *actually* admit a new prefill this tick.
+
+        Just having `self.waiting` non-empty is too coarse — during a
+        concurrent-burst workload (e.g. 1k/1k @ high concurrency) every
+        DP rank has a full waiting queue, so `bool(self.waiting)` is
+        ALWAYS True on all ranks → status="all" → delayer never engages.
+        But only the 1-2 ranks with free KV blocks actually admit a
+        prefill that tick; the other 6-7 ranks decode. That's the real
+        "mixed" we need to delay.
+
+        We peek the front of `waiting` (skipping a few unschedulable
+        entries) and check `can_allocate` + token-budget, mirroring the
+        same checks the admission while-loop runs below.
+        """
+        if not self.waiting:
+            return False
+        # Bounded peek: in practice the head is admissible or not; we
+        # cap at 4 to avoid pathological O(queue) work per tick.
+        for i, seq in enumerate(self.waiting):
+            if i >= 4:
+                break
+            if self._unschedulable_reason(seq) is not None:
+                continue
+            if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
+                continue
+            num_new_tokens = seq.num_tokens - seq.num_cached_tokens
+            if num_new_tokens > self.max_num_batched_tokens:
+                continue
+            if not self.block_manager.can_allocate(seq):
+                return False  # KV-pressured: definitely cannot prefill
+            return True
+        return False
+
+    def _kv_usage(self) -> float:
+        """Fraction of KV-cache blocks currently in use ∈ [0, 1].
+
+        Used as the `token_usage` signal for PrefillDelayer's low-watermark
+        safety valve. Derived from BlockManager bookkeeping; cheap (no
+        traversal of seq tables).
+        """
+        bm = self.block_manager
+        total = len(bm.blocks)
+        if total <= 0:
+            return 0.0
+        return len(bm.used_block_ids) / total
 
     def is_finished(self):
         # `_rejected` must be considered too: if a batch of seqs is all
@@ -541,11 +647,89 @@ class Scheduler:
         num_scheduled_tokens: list[int] = []
         scheduled_spec_decode_tokens: dict[int, np.ndarray] = {}
 
+        # ─── Cross-DP prefill alignment (PrefillDelayer) ───────────────
+        _delayer_allows_prefill = True
+        if self.prefill_delayer is not None:
+            _delayer_allows_prefill = self.prefill_delayer.should_allow_prefill(
+                local_prefillable=self._can_admit_head_prefill(),
+                token_usage=self._kv_usage(),
+            )
+
         if not self.running and not self.waiting:
             return None
 
-        # --- Prefill scheduling ---
-        while self.waiting and num_seqs_prefill < self.max_num_seqs:
+        threshold = _LONG_PREFILL_THRESHOLD
+        block_size = self.block_manager.block_size
+        if threshold > 0 and threshold % block_size != 0:
+            # Align down so chunk boundaries land on block boundaries
+            # (prepare_prefill's slot_mapping loop iterates whole blocks).
+            threshold = max(block_size, (threshold // block_size) * block_size)
+        chunked_overrides: dict[int, tuple[int, int]] = {}
+
+        if threshold > 0:
+            in_flight_seq = next(
+                (
+                    s
+                    for s in self.running
+                    if s.type == SequenceType.PREFILL and not s.is_prefill_done
+                ),
+                None,
+            )
+            if in_flight_seq is not None:
+                seq = in_flight_seq
+                remaining = seq.num_prompt_tokens - seq.num_computed_tokens
+                avail = self.max_num_batched_tokens
+                chunk = min(remaining, threshold, avail)
+                # Final chunk may be non-aligned; intermediate chunks must
+                # be a multiple of block_size so blocks fill exactly.
+                if chunk < remaining and chunk >= block_size:
+                    chunk = (chunk // block_size) * block_size
+                assert chunk > 0, (
+                    f"chunked prefill produced empty chunk for seq {seq.id} "
+                    f"(remaining={remaining} threshold={threshold} avail={avail})"
+                )
+                chunk_start = seq.num_computed_tokens
+                chunk_end = chunk_start + chunk
+                chunked_overrides[seq.id] = (chunk_end, chunk_start)
+                seq.num_computed_tokens = chunk_end
+                if chunk_end >= seq.num_prompt_tokens:
+                    seq.is_prefill_done = True
+                scheduled_seqs[seq.id] = seq
+                num_scheduled_tokens.append(chunk)
+                num_seqs_prefill = 1
+                num_batched_tokens = chunk
+                total_tokens_num_prefill = chunk
+                logger.info(
+                    f"Scheduled prefill CHUNK: seq {seq.id} "
+                    f"chunk=[{chunk_start},{chunk_end}) of {seq.num_prompt_tokens}, "
+                    f"done={seq.is_prefill_done}"
+                )
+                self.prev_prompt = True
+                connector_meta_output = None
+                if self.kv_connector is not None:
+                    connector_meta_output = self.kv_connector.build_connector_meta()
+                return (
+                    ScheduledBatch(
+                        seqs=scheduled_seqs,
+                        num_scheduled_tokens=num_scheduled_tokens,
+                        total_tokens_num=total_tokens_num_prefill,
+                        total_tokens_num_prefill=total_tokens_num_prefill,
+                        total_seqs_num=num_seqs_prefill,
+                        total_seqs_num_prefill=num_seqs_prefill,
+                        connector_meta_output=connector_meta_output,
+                        chunked_overrides=chunked_overrides,
+                    ),
+                    scheduled_seqs,
+                )
+
+        # --- Prefill scheduling --- (gated by `_delayer_allows_prefill`
+        # computed at the very top of schedule() to keep the cross-DP
+        # collective aligned across all early-return paths)
+        while (
+            _delayer_allows_prefill
+            and self.waiting
+            and num_seqs_prefill < self.max_num_seqs
+        ):
             seq = self.waiting.popleft()
 
             # Drop seqs the static-capacity check at submit-time flagged as
@@ -626,12 +810,34 @@ class Scheduler:
             num_new_tokens = seq.num_tokens - seq.num_cached_tokens
             if self.cache_stats:
                 self.cache_stats.update(seq.num_cached_tokens, seq.num_tokens)
+            # Chunked prefill: first chunk only. Final chunk may be smaller.
+            # Block-aligned cap unless this *is* the final chunk.
+            if threshold > 0:
+                chunk = min(num_new_tokens, threshold)
+                if chunk < num_new_tokens and chunk >= block_size:
+                    chunk = (chunk // block_size) * block_size
+                chunk = max(chunk, 1)  # never empty
+                chunk_start = seq.num_cached_tokens
+                chunk_end = chunk_start + chunk
+                chunked_overrides[seq.id] = (chunk_end, chunk_start)
+                seq.num_computed_tokens = chunk_end
+                seq.is_prefill_done = chunk_end >= seq.num_prompt_tokens
+                num_new_tokens = chunk
+            else:
+                # Legacy: prefill completes in one shot.
+                seq.num_computed_tokens = seq.num_tokens
+                seq.is_prefill_done = True
             num_batched_tokens += num_new_tokens
             seq.status = SequenceStatus.RUNNING
             seq.type = SequenceType.PREFILL
             self.running.append(seq)
             scheduled_seqs[seq.id] = seq
             num_scheduled_tokens.append(num_new_tokens)
+
+            # Chunked mode: only admit one new prefill per step (the first
+            # chunk must monopolize the next step's chunk continuation).
+            if threshold > 0:
+                break
 
         if skipped_waiting_requests:
             logger.debug(
@@ -665,6 +871,7 @@ class Scheduler:
                     total_seqs_num=num_seqs_prefill,
                     total_seqs_num_prefill=num_seqs_prefill,
                     connector_meta_output=connector_meta_output,
+                    chunked_overrides=chunked_overrides,
                 ),
                 scheduled_seqs,
             )
@@ -756,6 +963,11 @@ class Scheduler:
         seq.num_bonus_tokens = 0
         seq.spec_token_ids = np.array([], dtype=np.int32)
         seq.is_first_decode = False
+        # Reset chunked-prefill bookkeeping so the re-admitted seq restarts
+        # prefill from scratch (block_manager.allocate() at re-admission
+        # will refresh num_cached_tokens from prefix-cache hits).
+        seq.num_computed_tokens = 0
+        seq.is_prefill_done = False
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
 

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1337,10 +1337,12 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         attn_metadata: AttentionMetaData,
         ub_slice,
         padded_bs: int,
+        ubatch_idx: int = 0,
     ) -> AttentionMetaData:
         """
         Split prefill AttentionMetaData for MLA.
         """
+        del ubatch_idx  # MLA has no per-ubatch pooled buffers to disambiguate
         from atom.utils.tbo.ubatch_splitting import split_attn_metadata
 
         ub_attn = split_attn_metadata(attn_metadata, ub_slice, padded_bs)

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -370,7 +370,9 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         attn_metadata: AttentionMetaData,
         ub_slice: UBatchSlice,
         padded_bs: int,
+        ubatch_idx: int = 0,
     ) -> AttentionMetaData:
+        del ubatch_idx  # only used by builders with per-ubatch plan buffers
         return split_attn_metadata(attn_metadata, ub_slice, padded_bs)
 
     def build(self, batch: ScheduledBatch, bs: int):

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1273,11 +1273,44 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
         return attn_metadata, positions
 
+    def _get_ubatch_compress_plan_buffers(
+        self, ubatch_idx: int
+    ) -> dict[int, dict[str, "CpuGpuBuffer"]]:
+
+        if not hasattr(self, "_ubatch_compress_plan_buffers"):
+            self._ubatch_compress_plan_buffers: dict[
+                int, dict[int, dict[str, CpuGpuBuffer]]
+            ] = {}
+        cached = self._ubatch_compress_plan_buffers.get(ubatch_idx)
+        if cached is not None:
+            return cached
+
+        var = self.model_runner.forward_vars
+        pool: dict[int, dict[str, CpuGpuBuffer]] = {}
+        for ratio, _ in self._unique_compress_ratios_overlap:
+            tmpl_c = var[f"v4_compress_plan_{ratio}"]
+            tmpl_w = var[f"v4_write_plan_{ratio}"]
+            buf_c = CpuGpuBuffer(
+                *tmpl_c.cpu.shape, dtype=tmpl_c.cpu.dtype, device=tmpl_c.gpu.device
+            )
+            buf_w = CpuGpuBuffer(
+                *tmpl_w.cpu.shape, dtype=tmpl_w.cpu.dtype, device=tmpl_w.gpu.device
+            )
+            # Sentinel-fill so any unused tail rows behave like the main pool.
+            buf_c.cpu.fill_(-1)
+            buf_c.copy_to_gpu()
+            buf_w.cpu.fill_(-1)
+            buf_w.copy_to_gpu()
+            pool[ratio] = {"compress": buf_c, "write": buf_w}
+        self._ubatch_compress_plan_buffers[ubatch_idx] = pool
+        return pool
+
     def build_ubatch_prefill_metadata(
         self,
         attn_metadata: AttentionMetaData,
         ub_slice,
         padded_bs: int,
+        ubatch_idx: int = 0,
     ) -> AttentionMetaData_DSV4:
         """Split prefill AttentionMetaData for V4 TBO micro-batches."""
         from atom.utils.tbo.ubatch_splitting import split_attn_metadata
@@ -1310,17 +1343,19 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         context_lens_np = np.asarray(
             var["context_lens"].np[rs.start : rs.stop], dtype=np.int32
         ).copy()
-        device = src.state_slot_mapping.device
-
         from atom.model_ops.v4_kernels import make_compress_plans
 
         if self._unique_compress_ratios_overlap:
+            # Per-ubatch plan buffers — sharing the main pool would let
+            # ubatch 1's CPU build overwrite ubatch 0's before ubatch 0
+            # launches its compressor kernel. TBO prefill is eager-only,
+            # so `decode_capacity_per_ratio=None` (tight n_compress slice).
+            ub_plan_buffers = self._get_ubatch_compress_plan_buffers(ubatch_idx)
             ub_attn.compress_plans = make_compress_plans(
                 np.ascontiguousarray(extend_lens_np, dtype=np.int32),
                 np.ascontiguousarray(context_lens_np, dtype=np.int32),
                 self._unique_compress_ratios_overlap,
-                device,
-                plan_buffers=None,
+                plan_buffers=ub_plan_buffers,
                 decode_capacity_per_ratio=None,
             )
         else:
@@ -1356,6 +1391,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
             # start_pos = position of first token of each seq in this ubatch.
             ub_start_pos_per_seq_np = positions_np[ub_cu[:ub_num_reqs]]
+            ub_positions_gpu = var["positions"].gpu[ts.start : ts.stop]
+            ub_block_tables_gpu = var["block_tables"].gpu[rs.start : rs.stop]
+            ub_cu_q_per_seq_gpu = torch.from_numpy(
+                np.ascontiguousarray(ub_cu[:ub_num_reqs], dtype=np.int32)
+            ).to(self.device, non_blocking=True)
             self._build_paged_prefill_meta(
                 ub_attn,
                 positions_np,
@@ -1365,6 +1405,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 ub_attn.state_slot_mapping_cpu,
                 ub_num_reqs,
                 ub_num_tokens,
+                positions_gpu=ub_positions_gpu,
+                cu_q_per_seq_gpu=ub_cu_q_per_seq_gpu,
+                block_tables_gpu=ub_block_tables_gpu,
             )
         finally:
             bt[:ub_num_reqs] = saved_bt
@@ -1740,6 +1783,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         state_slot_mapping_cpu: np.ndarray,
         scheduled_bs: int,
         total_tokens: int,
+        *,
+        positions_gpu: Optional[torch.Tensor] = None,
+        cu_q_per_seq_gpu: Optional[torch.Tensor] = None,
+        block_tables_gpu: Optional[torch.Tensor] = None,
     ) -> None:
         """Build per-fwd index buffers consumed by sparse_attn_v4_paged_prefill.
 
@@ -1869,10 +1916,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # the kernel was designed/tested against int32 (downstream paged
         # offsets stored in int32 buffers; int32 throughout avoids mixed-
         # dtype Triton arithmetic that can silently truncate).
-        positions_gpu = var["positions"].gpu[:T]
-        cu_q_per_seq_gpu = var["cu_seqlens_q"].gpu[:scheduled_bs]
+        if positions_gpu is None:
+            positions_gpu = var["positions"].gpu[:T]
+        if cu_q_per_seq_gpu is None:
+            cu_q_per_seq_gpu = var["cu_seqlens_q"].gpu[:scheduled_bs]
+        if block_tables_gpu is None:
+            block_tables_gpu = var["block_tables"].gpu[:scheduled_bs]
         state_slot_per_seq_gpu = attn_metadata.state_slot_mapping[:scheduled_bs]
-        block_tables_gpu = var["block_tables"].gpu[:scheduled_bs]
         # batch_id_per_token is int64 in storage (PyTorch fancy-index
         # compatibility upstream); kernel uses tl.load which is dtype-agnostic
         # but cast for safety + consistency.

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -225,6 +225,14 @@ def reduce_scatter_with_unpadding(
     return scattered_output
 
 
+def all_gatherv(x: torch.Tensor, sizes: list[int], group) -> torch.Tensor:
+    return group.device_communicator.all_gatherv(x, dim=0, sizes=list(sizes))
+
+
+def reduce_scatterv(x: torch.Tensor, sizes: list[int], group) -> torch.Tensor:
+    return group.device_communicator.reduce_scatterv(x, dim=0, sizes=list(sizes))
+
+
 @torch_compile_guard()
 def get_max_tokens_across_dispatchers(input: torch.Tensor) -> int:
     return input.item()
@@ -2028,8 +2036,6 @@ class FusedMoE(torch.nn.Module):
         self.e_score_correction_bias = e_score_correction_bias
         self.activation = activation
 
-        self.use_chunked = get_dp_group().world_size > 1
-
         moe = FusedMoEConfig(
             num_experts=self.global_num_experts,
             experts_per_token=self.top_k,
@@ -2912,6 +2918,7 @@ class FusedMoE(torch.nn.Module):
         # 2. DP attention + EP mori Moe
         # 3. DP attention + TP All_gahter/reduce Moe
         original_hidden_size = None
+        sizes = None
         # Use all_gather/reduce_scatter when DP > 1 but not using mori all2all kernels
         use_dp_gather_scatter = (
             self.dp_size > 1
@@ -2919,6 +2926,10 @@ class FusedMoE(torch.nn.Module):
             and get_current_atom_config().enable_dp_attention
         )
         if use_dp_gather_scatter:
+            ctx = get_forward_context()
+            dp_group = get_dp_group()
+            dp_variable_len = not ctx.context.dp_uniform_decode
+
             from atom.utils.tbo.ubatching import tbo_active
 
             _tbo = tbo_active()
@@ -2930,8 +2941,32 @@ class FusedMoE(torch.nn.Module):
                 )
 
                 tbo_yield_and_switch_from_compute_to_comm()
-            hidden_states, original_hidden_size = all_gather_with_padding(hidden_states)
-            router_logits, _ = all_gather_with_padding(router_logits)
+
+            if dp_variable_len:
+                sizes = ctx.dp_metadata.get_sizes_across_dp()
+                original_hidden_size = hidden_states.shape[0]
+                _h_dim = hidden_states.shape[-1]
+                _r_dim = router_logits.shape[-1]
+                _r_dtype = router_logits.dtype
+                _r_for_gather = (
+                    router_logits
+                    if _r_dtype == hidden_states.dtype
+                    else router_logits.to(hidden_states.dtype)
+                )
+                _combined = torch.cat([hidden_states, _r_for_gather], dim=-1)
+                _combined = all_gatherv(_combined, sizes, dp_group)
+                hidden_states, router_logits = _combined.split([_h_dim, _r_dim], dim=-1)
+                hidden_states = hidden_states.contiguous()
+                if router_logits.dtype != _r_dtype:
+                    router_logits = router_logits.to(_r_dtype)
+                else:
+                    router_logits = router_logits.contiguous()
+            else:
+                hidden_states, original_hidden_size = all_gather_with_padding(
+                    hidden_states
+                )
+                router_logits, _ = all_gather_with_padding(router_logits)
+
             if _tbo:
                 tbo_switch_to_compute_sync()
 
@@ -2959,9 +2994,14 @@ class FusedMoE(torch.nn.Module):
         if use_dp_gather_scatter:
             if _tbo:
                 tbo_yield_and_switch_from_compute_to_comm()
-            final_hidden_states = reduce_scatter_with_unpadding(
-                final_hidden_states, original_hidden_size
-            )
+            if dp_variable_len:
+                final_hidden_states = reduce_scatterv(
+                    final_hidden_states, sizes, dp_group
+                )
+            else:
+                final_hidden_states = reduce_scatter_with_unpadding(
+                    final_hidden_states, original_hidden_size
+                )
             if _tbo:
                 tbo_yield_and_switch_from_comm_to_compute()
 
@@ -2975,10 +3015,9 @@ class FusedMoE(torch.nn.Module):
 
     def forward_impl(self, hidden_states: torch.Tensor, router_logits: torch.Tensor):
         assert self.quant_method is not None
-        # cuda graph not supported forward with combine and dispatch
-        if self.use_chunked:
+
+        if get_dp_group().world_size > 1:
             return self.forward_impl_graph(hidden_states, router_logits)
-            # return self.forward_impl_chunked(hidden_states, router_logits)
 
         dp_group = get_dp_group()
         if dp_group.world_size > 1:

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -233,6 +233,55 @@ def reduce_scatterv(x: torch.Tensor, sizes: list[int], group) -> torch.Tensor:
     return group.device_communicator.reduce_scatterv(x, dim=0, sizes=list(sizes))
 
 
+def dp_gather_hidden_and_router(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    dp_eager_mode: bool,
+    ctx,
+    dp_group,
+):
+    """All-gather ``hidden_states`` + ``router_logits`` across DP ranks.
+
+    - **Eager (variable-length) mode**: per-rank token counts may differ, so
+      we ``all_gatherv`` with per-rank sizes. Both tensors are concatenated
+      along the last dim and gathered in a single collective to avoid the
+      cost of two separate rounds (caller splits them back out).
+    - **Uniform mode** (DP-decode-only / CUDAGraph path): every rank has the
+      same token count, so a plain padded ``all_gather`` per tensor is
+      enough.
+
+    Returns ``(hidden_states, router_logits, original_hidden_size, sizes)``;
+    ``sizes`` is non-None only in eager mode (needed later for
+    ``reduce_scatterv``).
+    """
+    if dp_eager_mode:
+        sizes = ctx.dp_metadata.get_sizes_across_dp()
+        original_hidden_size = hidden_states.shape[0]
+        h_dim = hidden_states.shape[-1]
+        r_dim = router_logits.shape[-1]
+        r_dtype = router_logits.dtype
+        # Cast router_logits to hidden_states.dtype for the single fused
+        # gather; cast back after split. (all_gatherv requires uniform dtype.)
+        r_for_gather = (
+            router_logits
+            if r_dtype == hidden_states.dtype
+            else router_logits.to(hidden_states.dtype)
+        )
+        combined = torch.cat([hidden_states, r_for_gather], dim=-1)
+        combined = all_gatherv(combined, sizes, dp_group)
+        hidden_states, router_logits = combined.split([h_dim, r_dim], dim=-1)
+        hidden_states = hidden_states.contiguous()
+        if router_logits.dtype != r_dtype:
+            router_logits = router_logits.to(r_dtype)
+        else:
+            router_logits = router_logits.contiguous()
+        return hidden_states, router_logits, original_hidden_size, sizes
+
+    hidden_states, original_hidden_size = all_gather_with_padding(hidden_states)
+    router_logits, _ = all_gather_with_padding(router_logits)
+    return hidden_states, router_logits, original_hidden_size, None
+
+
 @torch_compile_guard()
 def get_max_tokens_across_dispatchers(input: torch.Tensor) -> int:
     return input.item()
@@ -2928,7 +2977,7 @@ class FusedMoE(torch.nn.Module):
         if use_dp_gather_scatter:
             ctx = get_forward_context()
             dp_group = get_dp_group()
-            dp_variable_len = not ctx.context.dp_uniform_decode
+            dp_eager_mode = not ctx.context.dp_uniform_decode
 
             from atom.utils.tbo.ubatching import tbo_active
 
@@ -2942,30 +2991,14 @@ class FusedMoE(torch.nn.Module):
 
                 tbo_yield_and_switch_from_compute_to_comm()
 
-            if dp_variable_len:
-                sizes = ctx.dp_metadata.get_sizes_across_dp()
-                original_hidden_size = hidden_states.shape[0]
-                _h_dim = hidden_states.shape[-1]
-                _r_dim = router_logits.shape[-1]
-                _r_dtype = router_logits.dtype
-                _r_for_gather = (
-                    router_logits
-                    if _r_dtype == hidden_states.dtype
-                    else router_logits.to(hidden_states.dtype)
-                )
-                _combined = torch.cat([hidden_states, _r_for_gather], dim=-1)
-                _combined = all_gatherv(_combined, sizes, dp_group)
-                hidden_states, router_logits = _combined.split([_h_dim, _r_dim], dim=-1)
-                hidden_states = hidden_states.contiguous()
-                if router_logits.dtype != _r_dtype:
-                    router_logits = router_logits.to(_r_dtype)
-                else:
-                    router_logits = router_logits.contiguous()
-            else:
-                hidden_states, original_hidden_size = all_gather_with_padding(
-                    hidden_states
-                )
-                router_logits, _ = all_gather_with_padding(router_logits)
+            (
+                hidden_states,
+                router_logits,
+                original_hidden_size,
+                sizes,
+            ) = dp_gather_hidden_and_router(
+                hidden_states, router_logits, dp_eager_mode, ctx, dp_group
+            )
 
             if _tbo:
                 tbo_switch_to_compute_sync()
@@ -2994,7 +3027,7 @@ class FusedMoE(torch.nn.Module):
         if use_dp_gather_scatter:
             if _tbo:
                 tbo_yield_and_switch_from_compute_to_comm()
-            if dp_variable_len:
+            if dp_eager_mode:
                 final_hidden_states = reduce_scatterv(
                     final_hidden_states, sizes, dp_group
                 )

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2003,10 +2003,10 @@ class MoE(nn.Module):
             from aiter.dist.parallel_state import get_dp_group as _get_dp_group
 
             ctx = get_forward_context()
-            dp_variable_len = (
+            dp_eager_mode = (
                 not ctx.context.dp_uniform_decode
             ) and ctx.dp_metadata is not None
-            if dp_variable_len:
+            if dp_eager_mode:
                 from atom.model_ops.moe import all_gatherv
 
                 sizes = ctx.dp_metadata.get_sizes_across_dp()

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2000,14 +2000,26 @@ class MoE(nn.Module):
         # input_ids to match.
         num_tokens = gating_output.shape[0]
         if ids.shape[0] < num_tokens:
-            from atom.model_ops.moe import pad_for_all_gather
+            from aiter.dist.parallel_state import get_dp_group as _get_dp_group
 
-            ids_2d = ids.unsqueeze(-1)
-            ids_2d, _ = pad_for_all_gather(ids_2d)
-            from aiter.dist.parallel_state import get_dp_group
+            ctx = get_forward_context()
+            dp_variable_len = (
+                not ctx.context.dp_uniform_decode
+            ) and ctx.dp_metadata is not None
+            if dp_variable_len:
+                from atom.model_ops.moe import all_gatherv
 
-            ids_2d = get_dp_group().all_gather(ids_2d, dim=0)
-            ids = ids_2d[:num_tokens].flatten()
+                sizes = ctx.dp_metadata.get_sizes_across_dp()
+                ids_2d = ids.unsqueeze(-1)
+                ids_2d = all_gatherv(ids_2d, sizes, _get_dp_group())
+                ids = ids_2d.flatten()
+            else:
+                from atom.model_ops.moe import pad_for_all_gather
+
+                ids_2d = ids.unsqueeze(-1)
+                ids_2d, _ = pad_for_all_gather(ids_2d)
+                ids_2d = _get_dp_group().all_gather(ids_2d, dim=0)
+                ids = ids_2d[:num_tokens].flatten()
             ids = ids.clamp(0, self.gate.tid2eid.shape[0] - 1)
         topk_ids = self.gate.tid2eid[ids].to(torch.int32)  # [N, topk]
         scores = torch.nn.functional.softplus(gating_output.float()).sqrt()
@@ -2509,7 +2521,8 @@ class DeepseekV4ForCausalLM(nn.Module):
         # it here (rather than in ModelRunner) means any caller of
         # `model.forward` — production runner, warmup, benchmarks — gets
         # correct hash routing without a separate setup step.
-        get_forward_context().context.input_ids = input_ids
+        ctx = get_forward_context()
+        ctx.context.input_ids = input_ids
         return self.model(input_ids, positions)
 
     def compute_logits(

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -170,6 +170,27 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL": lambda: (
         os.getenv("ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL", "0") == "1"
     ),
+    # --- PrefillDelayer (cross-DP prefill alignment) ---
+    # Master switch; default on. Set "0" to disable construction.
+    "ATOM_ENABLE_PREFILL_DELAYER": lambda: (
+        os.getenv("ATOM_ENABLE_PREFILL_DELAYER", "1") == "1"
+    ),
+    # Max consecutive scheduler passes the delayer is allowed to suppress
+    # prefill admission while waiting for cross-DP alignment.
+    "ATOM_PREFILL_DELAYER_MAX_DELAY_PASSES": lambda: int(
+        os.getenv("ATOM_PREFILL_DELAYER_MAX_DELAY_PASSES", "30")
+    ),
+    # Wall-clock cap (milliseconds) on a single delay window.
+    "ATOM_PREFILL_DELAYER_MAX_DELAY_MS": lambda: float(
+        os.getenv("ATOM_PREFILL_DELAYER_MAX_DELAY_MS", "5000")
+    ),
+    # Optional KV-usage low watermark below which delaying is allowed.
+    # Empty string => None (use PrefillDelayer's internal default).
+    "ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK": lambda: (
+        None
+        if os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK", "") == ""
+        else float(os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK"))
+    ),
 }
 
 

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -375,6 +375,13 @@ class ForwardContext:
 
     ubatch_slices: Optional[list[Any]] = None
 
+    # Cross-DP MAX of per-ubatch token counts, precomputed in
+    # ``ModelRunner._preprocess`` and propagated here so
+    # ``UBatchWrapper._compute_ub_graph_bs`` no longer needs its own
+    # per-ubatch all_reduce. Shape: tuple of length N == len(ubatch_slices).
+    # None when DP is off or when TBO is not active this step.
+    ub_max_tokens_across_dp: Optional[tuple] = None
+
     # Cached current_stream() captured at set_forward_context() time, so
     # downstream code (V4 attention / MoE / metadata builder) doesn't have
     # to query torch.cuda.current_stream() repeatedly during a forward —
@@ -439,6 +446,7 @@ def set_forward_context(
     spec_decode_metadata: Optional[SpecDecodeMetadata] = None,
     ubatch_slices: Optional[list[Any]] = None,
     in_hipgraph: bool = False,
+    ub_max_tokens_across_dp: Optional[tuple] = None,
 ) -> None:
     global _forward_context
     dp_metadata: Optional[DPMetadata] = None
@@ -458,6 +466,7 @@ def set_forward_context(
         dp_metadata=dp_metadata,
         spec_decode_metadata=spec_decode_metadata,
         ubatch_slices=ubatch_slices,
+        ub_max_tokens_across_dp=ub_max_tokens_across_dp,
         main_stream=(torch.cuda.current_stream() if _CUDA_AVAILABLE else None),
         in_hipgraph=in_hipgraph,
     )  # _forward_context.attn_metadata = attn_metadata

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -147,6 +147,11 @@ class DPMetadata:
     def get_chunk_sizes_across_dp_rank(self) -> Optional[list[int]]:
         return self.local_sizes
 
+    def get_sizes_across_dp(self) -> list[int]:
+        """Per-rank token counts derived from cumulative tensor."""
+        cu = self.cu_tokens_across_dp_cpu
+        return [(cu[i] - (cu[i - 1] if i > 0 else 0)).item() for i in range(len(cu))]
+
 
 @dataclass
 class SpecDecodeMetadata:
@@ -167,6 +172,10 @@ class Context:
     batch_size: int = 0
     graph_bs: int = 0
     is_draft: bool = False
+    # True iff all DP ranks are running pure decode this step (DP-disabled
+    # case is treated as True). Mirrors vLLM's `uniform_decode` flag and
+    # gates DP-specific variable-length all_gather/scatter paths.
+    dp_uniform_decode: bool = True
     # Optional flat token ids for the current forward. Read by callbacks
     # invoked inside Dynamo-opaque custom ops (e.g. V4 MoE hash routing)
     # that need the token ids but cannot receive them as a function arg
@@ -181,6 +190,7 @@ class Context:
         batch_size: int = 0,
         graph_bs: int = 0,
         is_draft: bool = False,
+        dp_uniform_decode: bool = True,
         input_ids: Optional[torch.Tensor] = None,
     ):
         self.positions = positions
@@ -189,6 +199,7 @@ class Context:
         self.batch_size = batch_size
         self.graph_bs = graph_bs
         self.is_draft = is_draft
+        self.dp_uniform_decode = dp_uniform_decode
         self.input_ids = input_ids
 
 

--- a/atom/utils/tbo/__init__.py
+++ b/atom/utils/tbo/__init__.py
@@ -8,7 +8,10 @@ from .ubatch_splitting import (
 )
 from .ubatch_wrapper import UBatchWrapper
 from .ubatching import (
+    DPSyncResult,
     TBOContext,
+    local_tbo_precompute,
+    sync_dp_for_tbo,
     tbo_overlap_enabled,
     make_tbo_contexts,
     tbo_enabled,
@@ -27,9 +30,12 @@ from .ubatching import (
 )
 
 __all__ = [
+    "DPSyncResult",
     "TBOContext",
     "UBatchSlice",
     "UBatchWrapper",
+    "local_tbo_precompute",
+    "sync_dp_for_tbo",
     "tbo_overlap_enabled",
     "make_tbo_contexts",
     "maybe_create_ubatch_slices",

--- a/atom/utils/tbo/ubatch_wrapper.py
+++ b/atom/utils/tbo/ubatch_wrapper.py
@@ -23,13 +23,6 @@ from .ubatching import make_tbo_contexts
 logger = logging.getLogger("atom")
 
 
-def _get_dp_group_handle():
-    """Return the torch.distributed process group for DP."""
-    from aiter.dist.parallel_state import get_dp_group
-
-    return get_dp_group().device_group
-
-
 @dataclass
 class TBOGraphData:
     """Stores a captured CUDAGraph alongside objects that must stay alive."""
@@ -64,6 +57,54 @@ class UBatchWrapper(nn.Module):
 
     def forward(self, input_ids: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
         ctx = get_forward_context()
+        # Hit-rate counters: split by prefill / decode to diagnose whether
+        # the collective TBO decision is firing where we expect.
+        is_prefill = ctx.context.is_prefill
+        if ctx.ubatch_slices is None:
+            if is_prefill:
+                self._n_skip_prefill = getattr(self, "_n_skip_prefill", 0) + 1
+            else:
+                self._n_skip_decode = getattr(self, "_n_skip_decode", 0) + 1
+        else:
+            if is_prefill:
+                self._n_used_prefill = getattr(self, "_n_used_prefill", 0) + 1
+            else:
+                self._n_used_decode = getattr(self, "_n_used_decode", 0) + 1
+        total = (
+            getattr(self, "_n_skip_prefill", 0)
+            + getattr(self, "_n_skip_decode", 0)
+            + getattr(self, "_n_used_prefill", 0)
+            + getattr(self, "_n_used_decode", 0)
+        )
+        # Log on (a) the very first TBO hit so we know it actually fired,
+        # (b) every 50 fwds thereafter. Prefill-only TBO can total way less
+        # than 200 fwds across a whole benchmark, so the old `% 200 == 0`
+        # gate could silently never fire.
+        first_hit = ctx.ubatch_slices is not None and (
+            getattr(self, "_n_used_prefill", 0) + getattr(self, "_n_used_decode", 0)
+        ) == 1
+        if first_hit or total % 50 == 0:
+            logger.info(
+                "[TBO] used_p=%d skip_p=%d used_d=%d skip_d=%d (hit_p=%.1f%% hit_d=%.1f%%)",
+                getattr(self, "_n_used_prefill", 0),
+                getattr(self, "_n_skip_prefill", 0),
+                getattr(self, "_n_used_decode", 0),
+                getattr(self, "_n_skip_decode", 0),
+                100.0
+                * getattr(self, "_n_used_prefill", 0)
+                / max(
+                    1,
+                    getattr(self, "_n_used_prefill", 0)
+                    + getattr(self, "_n_skip_prefill", 0),
+                ),
+                100.0
+                * getattr(self, "_n_used_decode", 0)
+                / max(
+                    1,
+                    getattr(self, "_n_used_decode", 0)
+                    + getattr(self, "_n_skip_decode", 0),
+                ),
+            )
         if ctx.ubatch_slices is None:
             return self.model(input_ids, positions)
         return self._run_ubatches(input_ids, positions, ctx)
@@ -114,12 +155,21 @@ class UBatchWrapper(nn.Module):
                 ub_graph_bs=ub_graph_bs_list[i],
             )
             forward_contexts.append(ub_ctx)
-            ub_inputs.append(
-                (
-                    input_ids[ub_slice.token_slice],
-                    positions[ub_slice.token_slice],
-                )
+            ub_token_slice = (
+                input_ids[ub_slice.token_slice],
+                positions[ub_slice.token_slice],
             )
+            # Empty ubatch would return immediately, leaving the partner
+            # wedged at its next yield (see TBOContext.__exit__ comment).
+            # The new partner.done short-circuit covers this case too, but
+            # an empty ubatch is always a metadata bug upstream — assert
+            # loudly rather than silently waste a TBO split.
+            assert ub_token_slice[0].numel() > 0, (
+                f"ubatch {i} produced an empty token slice "
+                f"(ts={ub_slice.token_slice}, rs={ub_slice.request_slice}); "
+                "check _local_tbo_precompute / maybe_create_ubatch_slices."
+            )
+            ub_inputs.append(ub_token_slice)
 
         tbo_ctxs = make_tbo_contexts(
             num_micro_batches=N,
@@ -148,9 +198,14 @@ class UBatchWrapper(nn.Module):
                     model_output = self.model(ub_input_ids, ub_positions)
                 results.append((idx, model_output))
             except Exception as e:
-                import traceback
-
-                traceback.print_exc()
+                # `logger.exception` captures the full traceback to the atom
+                # logger (which goes to stderr + log file); previously the
+                # bare `traceback.print_exc()` could be drowned by other
+                # stderr output across 8 worker procs. The partner thread
+                # is now unblocked via TBOContext.partner.done (set in
+                # __exit__) so the main thread's `t.join()` will return
+                # promptly and re-raise this `errors[idx]`.
+                logger.exception("[TBO] ubatch %d crashed: %s", idx, e)
                 errors[idx] = e
 
         # Clear thread-local forward context so threads don't inherit it
@@ -326,23 +381,24 @@ class UBatchWrapper(nn.Module):
         device: torch.device,
     ) -> list[int]:
         """
-        For prefill (eager only): all_reduce(MAX) per-ubatch token counts
+        For prefill (eager only): use cross-DP per-ubatch token MAX that
+            ``ModelRunner._preprocess`` already packed into the single DP
+            all_reduce (``ctx.ub_max_tokens_across_dp``). Falls back to
+            local sizes when DP is off / value not precomputed.
         For decode: padded_bs * dp_size.
         """
         if ctx.context.is_prefill:
+            if (
+                dp_size > 1
+                and ctx.ub_max_tokens_across_dp is not None
+                and len(ctx.ub_max_tokens_across_dp) == N
+            ):
+                # Precomputed via the packed DP reduce — no extra all_reduce.
+                return list(ctx.ub_max_tokens_across_dp)
             ub_sizes = []
             for ub_slice in ctx.ubatch_slices:
                 ub_num_tokens = ub_slice.token_slice.stop - ub_slice.token_slice.start
                 ub_sizes.append(ub_num_tokens)
-
-            if dp_size > 1:
-                sizes_t = torch.tensor(ub_sizes, device=device, dtype=torch.int64)
-                torch.distributed.all_reduce(
-                    sizes_t,
-                    op=torch.distributed.ReduceOp.MAX,
-                    group=_get_dp_group_handle(),
-                )
-                return sizes_t.tolist()
             return ub_sizes
         else:
             result = []
@@ -371,6 +427,7 @@ class UBatchWrapper(nn.Module):
                 ctx.attn_metadata,
                 ub_slice,
                 padded_bs,
+                ubatch_idx=ubatch_idx,
             )
         else:
             attn_bs = actual_num_reqs if actual_num_reqs is not None else padded_bs
@@ -404,6 +461,18 @@ class UBatchWrapper(nn.Module):
             dp_metadata=ctx.dp_metadata,  # shared across ubatches
             spec_decode_metadata=None,  # not supported with TBO
             ubatch_slices=None,  # prevent recursion
+            # Propagate parent's cached current_stream so downstream code
+            # (V4 dual-stream MoE / attention compressor / etc.) that reads
+            # `get_forward_context().main_stream` sees a real Stream rather
+            # than None. Without this the per-ubatch ForwardContext picks up
+            # the dataclass default (None) and the first `wait_stream(None)`
+            # crashes with `AttributeError: 'NoneType' has no record_event`.
+            # The TBO worker thread switches stream via TBOContext, so we
+            # use the parent's stream here (= the original compute stream),
+            # which is also the stream the worker resumes on after each
+            # comm→compute switch.
+            main_stream=ctx.main_stream,
+            in_hipgraph=ctx.in_hipgraph,
         )
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/atom/utils/tbo/ubatch_wrapper.py
+++ b/atom/utils/tbo/ubatch_wrapper.py
@@ -465,16 +465,6 @@ class UBatchWrapper(nn.Module):
             dp_metadata=ctx.dp_metadata,  # shared across ubatches
             spec_decode_metadata=None,  # not supported with TBO
             ubatch_slices=None,  # prevent recursion
-            # Propagate parent's cached current_stream so downstream code
-            # (V4 dual-stream MoE / attention compressor / etc.) that reads
-            # `get_forward_context().main_stream` sees a real Stream rather
-            # than None. Without this the per-ubatch ForwardContext picks up
-            # the dataclass default (None) and the first `wait_stream(None)`
-            # crashes with `AttributeError: 'NoneType' has no record_event`.
-            # The TBO worker thread switches stream via TBOContext, so we
-            # use the parent's stream here (= the original compute stream),
-            # which is also the stream the worker resumes on after each
-            # comm→compute switch.
             main_stream=ctx.main_stream,
             in_hipgraph=ctx.in_hipgraph,
         )

--- a/atom/utils/tbo/ubatch_wrapper.py
+++ b/atom/utils/tbo/ubatch_wrapper.py
@@ -80,9 +80,13 @@ class UBatchWrapper(nn.Module):
         # (b) every 50 fwds thereafter. Prefill-only TBO can total way less
         # than 200 fwds across a whole benchmark, so the old `% 200 == 0`
         # gate could silently never fire.
-        first_hit = ctx.ubatch_slices is not None and (
-            getattr(self, "_n_used_prefill", 0) + getattr(self, "_n_used_decode", 0)
-        ) == 1
+        first_hit = (
+            ctx.ubatch_slices is not None
+            and (
+                getattr(self, "_n_used_prefill", 0) + getattr(self, "_n_used_decode", 0)
+            )
+            == 1
+        )
         if first_hit or total % 50 == 0:
             logger.info(
                 "[TBO] used_p=%d skip_p=%d used_d=%d skip_d=%d (hit_p=%.1f%% hit_d=%.1f%%)",
@@ -167,7 +171,7 @@ class UBatchWrapper(nn.Module):
             assert ub_token_slice[0].numel() > 0, (
                 f"ubatch {i} produced an empty token slice "
                 f"(ts={ub_slice.token_slice}, rs={ub_slice.request_slice}); "
-                "check _local_tbo_precompute / maybe_create_ubatch_slices."
+                "check local_tbo_precompute / maybe_create_ubatch_slices."
             )
             ub_inputs.append(ub_token_slice)
 

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -20,26 +20,11 @@ def tbo_enabled() -> bool:
     return getattr(config, "enable_tbo", False)
 
 
-def sync_dp_for_tbo(
-    dp_size: int,
-    dp_rank: int,
-    num_input_tokens: int,
-    num_reqs: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Sync token counts and request counts across DP ranks in one all_reduce.
-
-    Returns (num_tokens_across_dp, reqs_across_dp).
-    reqs_across_dp is used to decide TBO on/off (min_reqs >= 2).
-    """
-    import torch.distributed as dist
-    from aiter.dist.parallel_state import get_dp_group
-
-    # Layout: [tokens_r0, ..., tokens_rN, reqs_r0, ..., reqs_rN]
-    sync_tensor = torch.zeros(dp_size * 2, device="cpu", dtype=torch.int32)
-    sync_tensor[dp_rank] = num_input_tokens
-    sync_tensor[dp_size + dp_rank] = num_reqs
-    dist.all_reduce(sync_tensor, group=get_dp_group().cpu_group)
-    return sync_tensor[:dp_size], sync_tensor[dp_size:]
+# NOTE: ``sync_dp_for_tbo`` was removed. The DP TBO-eligibility / token-count
+# synchronisation has been folded into the packed single all_reduce in
+# ``ModelRunner._preprocess`` (see Plan B). Two callers used to issue it
+# every step (one for tokens+reqs, one for the per-ubatch token MAX in
+# ``UBatchWrapper``); both are now derived from the packed reduce.
 
 
 _THREAD_ID_TO_CONTEXT: dict[int, int] = {}
@@ -86,6 +71,12 @@ class TBOContext:
         self.gpu_compute_done_event = gpu_compute_done_event
         self.current_stream = compute_stream
         self.recv_hook: Optional[Callable] = None
+        # Set True when this ubatch's model.forward returns (or raises).
+        # Partner thread checks this in `_cpu_yield` so it doesn't sleep
+        # forever if we exited (cleanly or via exception) ahead of it.
+        self.done: bool = False
+        # Filled by `make_tbo_contexts` — points to the OTHER ubatch's ctx.
+        self.partner: Optional["TBOContext"] = None
 
     # -- context manager protocol ----------------------------------------
 
@@ -110,6 +101,14 @@ class TBOContext:
         _CURRENT_CONTEXTS[self.ubatch_id] = None
         del _THREAD_ID_TO_CONTEXT[threading.get_ident()]
         self.maybe_run_recv_hook()
+        # Mark this ubatch done BEFORE the final signal so that if the partner
+        # is racing into its next `_cpu_yield` between our signal and its wait,
+        # it observes `partner.done == True` and skips the wait instead of
+        # sleeping forever. Without this, any asymmetry (e.g. partner exits
+        # mid-forward via exception) leaves the survivor wedged on the next
+        # yield: the dead partner only signals exactly once from __exit__,
+        # but the survivor still has ≥1 yield left to do.
+        self.done = True
         # No CPU-blocking synchronize — GPU ordering is handled by
         # torch.Event record/wait in switch_to_comm_sync / switch_to_compute_sync.
         self.cpu_signal_event.set()
@@ -158,8 +157,19 @@ class TBOContext:
     # -- CPU yield (ping-pong) -------------------------------------------
 
     def _cpu_yield(self):
-        """Wake the next thread and sleep until woken."""
+        """Wake the next thread and sleep until woken.
+
+        If the partner ubatch has already finished (cleanly or via exception
+        — see `__exit__` above), there is nobody to wake us, so we must not
+        block. Returning immediately here lets the survivor finish its
+        remaining yields and exit normally, so the main thread's `t.join()`
+        can complete and any captured `errors[idx]` can be raised.
+        """
         self.cpu_signal_event.set()
+        if self.partner is not None and self.partner.done:
+            self.cpu_wait_event.clear()
+            self._restore_context()
+            return
         self.cpu_wait_event.wait()
         self.cpu_wait_event.clear()
         self._restore_context()
@@ -297,5 +307,13 @@ def make_tbo_contexts(
             gpu_compute_done_event=gpu_compute_done_events[i],
         )
         ctxs.append(ctx)
+
+    # Link each ctx to its neighbour in the ping-pong ring so that `_cpu_yield`
+    # can short-circuit when the partner has exited. For N=2 (the only case
+    # we run today) `partner` is just the other ctx. For N>2 we point at the
+    # NEXT ctx (the one whose `cpu_wait_event` is our `cpu_signal_event`'s
+    # target) — that's the only one whose `done` flag can leave us wedged.
+    for i, ctx in enumerate(ctxs):
+        ctx.partner = ctxs[(i + 1) % num_micro_batches]
 
     return ctxs

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -2,8 +2,10 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import threading
+from dataclasses import dataclass
 from typing import Callable, Optional
 
+import numpy as np
 import torch
 
 from atom.config import get_current_atom_config
@@ -20,11 +22,142 @@ def tbo_enabled() -> bool:
     return getattr(config, "enable_tbo", False)
 
 
-# NOTE: ``sync_dp_for_tbo`` was removed. The DP TBO-eligibility / token-count
-# synchronisation has been folded into the packed single all_reduce in
-# ``ModelRunner._preprocess`` (see Plan B). Two callers used to issue it
-# every step (one for tokens+reqs, one for the per-ubatch token MAX in
-# ``UBatchWrapper``); both are now derived from the packed reduce.
+# =====================================================================
+# DP-side TBO helpers (formerly ModelRunner._local_tbo_precompute and
+# the inline sync block inside ModelRunner._preprocess).
+# =====================================================================
+
+
+def local_tbo_precompute(
+    config,
+    batch,
+    is_prefill: bool,
+    num_scheduled_tokens: np.ndarray,
+) -> tuple[bool, int, int]:
+    """Decide locally whether this rank could TBO-split into 2 ubatches,
+    and if so what (ub0_tokens, ub1_tokens) the split would produce.
+
+    Returns ``(eligible, ub0_tokens, ub1_tokens)``. All zeros when
+    ineligible. The eligibility bit is later AND-reduced across DP ranks
+    by :func:`sync_dp_for_tbo`; the ub0/ub1 counts are MAX-reduced so
+    every rank picks the same per-ubatch CUDAGraph buffer size.
+    """
+    if not config.enable_tbo:
+        return False, 0, 0
+    if is_prefill:
+        n_pref = batch.total_seqs_num_prefill
+        if n_pref < 2:
+            return False, 0, 0
+        # Mirror _split_prefill_balanced: pick boundary closest to total/2
+        # so the packed value matches what maybe_create_ubatch_slices will
+        # produce post-decision.
+        toks = np.asarray(num_scheduled_tokens[:n_pref], dtype=np.int64)
+        total = int(toks.sum())
+        target = total // 2
+        cumsum = 0
+        split_idx = 1
+        for j in range(n_pref):
+            cumsum += int(toks[j])
+            if cumsum >= target:
+                prev = cumsum - int(toks[j])
+                if j > 0 and (target - prev) < (cumsum - target):
+                    split_idx = j
+                else:
+                    split_idx = j + 1
+                break
+        split_idx = max(1, min(split_idx, n_pref - 1))
+        ub0 = int(toks[:split_idx].sum())
+        ub1 = total - ub0
+        return True, ub0, ub1
+    # Decode path
+    if not config.enable_tbo_decode or batch.is_dummy_run:
+        return False, 0, 0
+    scheduled_bs = batch.total_seqs_num_decode
+    if scheduled_bs < 2:
+        return False, 0, 0
+    num_tokens = batch.total_tokens_num
+    tokens_per_req = num_tokens // scheduled_bs if scheduled_bs else 1
+    reqs_per_ub = scheduled_bs // 2
+    ub0 = reqs_per_ub * tokens_per_req
+    ub1 = num_tokens - ub0
+    return True, ub0, ub1
+
+
+@dataclass
+class DPSyncResult:
+    """Output of :func:`sync_dp_for_tbo`."""
+
+    # [dp_size] int32 CPU tensor — each rank's input token count.
+    num_tokens_across_dp: torch.Tensor
+    # True iff ANY rank has at least one prefill seq this step.
+    any_rank_has_prefill: bool
+    # True iff TBO is on AND every rank reported local_tbo_eligible.
+    tbo_collective_active: bool
+    # (ub0_max, ub1_max) across DP — only set when tbo_collective_active.
+    ub_max_tokens_across_dp: Optional[tuple[int, int]]
+
+
+def sync_dp_for_tbo(
+    *,
+    dp_group,
+    dp_size: int,
+    num_input_tokens: int,
+    is_prefill: bool,
+    tbo_on: bool,
+    local_tbo_eligible: bool = False,
+    local_ub_tokens: tuple[int, int] = (0, 0),
+) -> DPSyncResult:
+    """Single packed DP all_gather over the per-rank scalars needed to
+    decide DP padding, the prefill fan-out, and the cross-DP TBO gate.
+
+    Pre-Plan-B this required up to 3 separate all_reduces per step
+    (``get_dp_padding`` / ``sync_dp_for_tbo`` / a third inside
+    ``UBatchWrapper``). Now one all_gather of ``n_fields`` int32 values
+    per rank suffices. When TBO is off only the first 2 fields are
+    exchanged (saves 60 % payload + skips :func:`local_tbo_precompute`
+    at the call site).
+
+    Layout (``sync`` is ``[n_fields, dp_size]``):
+
+      row 0 : num_input_tokens         -> num_tokens_across_dp
+      row 1 : is_prefill (0/1)         -> any_rank_has_prefill (OR)
+      row 2 : tbo_eligible (0/1)       -> tbo_collective_active (AND)   [TBO only]
+      row 3 : ub0_tokens               -> ub_max_tokens_across_dp[0]    [TBO only]
+      row 4 : ub1_tokens               -> ub_max_tokens_across_dp[1]    [TBO only]
+    """
+    n_fields = 5 if tbo_on else 2
+    local = torch.zeros(n_fields, dtype=torch.int32, device="cpu")
+    local[0] = num_input_tokens
+    local[1] = 1 if is_prefill else 0
+    if tbo_on:
+        local[2] = 1 if local_tbo_eligible else 0
+        local[3] = local_ub_tokens[0]
+        local[4] = local_ub_tokens[1]
+
+    gathered = [
+        torch.empty(n_fields, dtype=torch.int32, device="cpu") for _ in range(dp_size)
+    ]
+    torch.distributed.all_gather(gathered, local, group=dp_group)
+    sync = torch.stack(gathered, dim=1)  # [n_fields, dp_size]
+
+    num_tokens_across_dp = sync[0]
+    any_rank_has_prefill = bool(sync[1].any().item())
+    tbo_collective_active = False
+    ub_max_tokens_across_dp: Optional[tuple[int, int]] = None
+    if tbo_on:
+        tbo_collective_active = bool(sync[2].all().item())
+        if tbo_collective_active:
+            ub_max_tokens_across_dp = (
+                int(sync[3].max().item()),
+                int(sync[4].max().item()),
+            )
+
+    return DPSyncResult(
+        num_tokens_across_dp=num_tokens_across_dp,
+        any_rank_has_prefill=any_rank_has_prefill,
+        tbo_collective_active=tbo_collective_active,
+        ub_max_tokens_across_dp=ub_max_tokens_across_dp,
+    )
 
 
 _THREAD_ID_TO_CONTEXT: dict[int, int] = {}


### PR DESCRIPTION
1 PrefillDelayer — cross-DP prefill admission gate
2 Drop "dummy prefill" workaround; just go eager when any DP rank has prefill
3 enable TBO on current dp

Deepseek v4:  dp
1k/1k
bs 128: 5535.92/8=687.5
bs 256:  9687.44/8=1210

8k/1k:
bs 128: 16717.39/8=2089
bs 246: 24663/8=3082
