### PR TITLE
perf(v4): rewrite sparse paged_decode (split-K + FUSED) + add optional fp8 (1x64) KV path

### DIFF
--- a/atom/model_ops/v4_kernels/paged_decode.py
+++ b/atom/model_ops/v4_kernels/paged_decode.py
@@ -22,52 +22,170 @@ Caller contract:
   attn_sink:        [H] per-head learnable softmax-denom bias (V4 specific).
   softmax_scale:    float.
 
-Per-token K loop iterates exactly `kv_indptr[t+1] - kv_indptr[t]`
-slots (rounded up to BLOCK_K granularity for the partial last block) — short
-seqs do not pay for long-seq worst-case work. CUDAGraph-compatible: the trip
-count is loaded from `kv_indptr` at replay, kernel binary stays
-unchanged across batches.
-
 Returns:
   out: [N, H, D] same dtype as q.
 
-Numerics: standard online-softmax with attention sink as a virtual K.
-Bit-exact against the PyTorch reference (`_sparse_attn_ragged_torch`)
-when invoked with the same per-token gather indices.
+Numerics: online-softmax in log2 domain (exp2 with qk_scale = softmax_scale *
+LOG2E), with attention sink folded as a virtual K. Bit-close to the PyTorch
+reference (``_sparse_attn_ragged_torch``) within fp32-accumulation tolerance.
+
+Architecture:
+  - Small T (T * ceil(H/block_h) < ~1.7×CU): split-K + reduce-kernel path.
+    Split kernel emits (m, l, acc) fp32 partials; reduce combines splits and
+    folds attn_sink.
+  - Large T: single-pass FUSED kernel that does softmax + sink + write in one
+    shot (no partial-buffer alloc, no second kernel launch).
+
+CUDAGraph-safe: kv_splits and tile config depend only on capture-time
+shapes (``T``, ``H``); the kernels' early-return / segment-mask logic is
+driven by ``kv_indptr`` values, which are runtime data but don't affect
+the captured launch sequence.
 """
 
+from __future__ import annotations
+
+import functools
 import os
 
 import torch
 import triton
 import triton.language as tl
 
+from aiter.ops.triton.utils.device_info import get_num_sms
+
 from atom.model_ops.sparse_attn_v4 import _sparse_attn_ragged_torch
+
+LOG2E = 1.4426950408889634  # log2(e); folded into qk_scale so softmax can use exp2.
+_MAX_KV_SPLITS = 64  # Hard cap on kv_splits (see _kv_splits_heuristic).
+
+
+@functools.lru_cache(maxsize=1)
+def _cu_count() -> int:
+    """Compute-unit count of the active GPU, queried once via aiter.
+
+    Wrapped in ``lru_cache`` so the first decode call pays the device-property
+    lookup and all subsequent calls hit the cache — important inside a hot
+    decode loop and CUDAGraph capture (no data-dependent host work).
+    """
+    return get_num_sms()
+
+
+# ---------------------------------------------------------------------------
+# Heuristics — pure-Python, capture-time deterministic.
+# ---------------------------------------------------------------------------
+
+
+def _kernel_config(block_h: int) -> tuple[int, int, int]:
+    """Pick (BLOCK_K, num_warps, num_stages) without autotune.
+
+    Depends ONLY on ``block_h`` (a function of H, capture-time shape) so the
+    config is identical between CUDAGraph capture and replay regardless of
+    per-token K. In production ``kv_indices.shape[0]`` is a padded bucket
+    whose value is unrelated to the true per-token kv_len, so any heuristic
+    that reads it would mis-tune at capture time.
+
+    Derived from autotune statistics over ~150 shapes on MI355:
+      - BLOCK_K=16 dominated (~78% of best configs for D=512); D=512 has
+        enough load width that wider K tiles spill regs more than they buy.
+      - num_warps tracks BLOCK_H: a 64-head tile needs 8 warps to keep all
+        MFMA lanes fed; a 16-head tile peaks at 4 warps before going idle.
+      - num_stages=2 is the safe default — deeper pipelining (3) helps only
+        when the K loop has many iterations; we cannot know per-token K at
+        capture time, so the conservative pick avoids regressing short-K.
+    """
+    block_k = 16
+    num_warps = 4 if block_h <= 16 else 8
+    num_stages = 2
+    return block_k, num_warps, num_stages
+
+
+def _prev_pow2(n: int) -> int:
+    """Largest power of two ≤ ``n``. For n < 1 returns 1."""
+    if n < 1:
+        return 1
+    return 1 << (n.bit_length() - 1)
+
+
+def _kv_splits_heuristic(
+    T: int,
+    H: int,
+    block_h: int,
+    num_cu: int | None = None,
+    target_wg_per_cu: float = 2.0,
+    max_kv_splits: int = _MAX_KV_SPLITS,
+) -> int:
+    """Pick KV_SPLITS to fill the GPU. CUDAGraph-safe: depends ONLY on
+    capture-time scalars (``T``, ``H``, ``block_h``). Never reads any
+    tensor value or shape — production callers must not assume kv_indices
+    layout encodes per-token kv_len.
+
+    Split-K trades a single-kernel pass for (split, reduce) two-kernel +
+    partial-buffer allocation. The trade is worth it when the base grid
+    ``T * ceil(H/block_h)`` underfills the device.
+
+      base_ctas  = T * ceil(H / block_h)
+      target_wg  = target_wg_per_cu * num_cu     (≈ 1.7x to hide load-imbalance)
+      if base_ctas >= target_wg:  splits = 1     (grid already saturates GPU)
+      else:                       splits = prev_pow2(min(target_wg/base_ctas,
+                                                          max_kv_splits))
+
+    ``max_kv_splits`` (default 64) caps the number of split-kernel CTAs per
+    token. Higher values would buy more parallelism for bs=1 long-ctx, but
+    when per-token K is short most splits fall-through and the launch
+    overhead dominates. 64 is the sweet spot for MI300/MI355.
+
+    Rounded DOWN to a power of two — rounding up over-splits when
+    splits_to_fill isn't already pow2 (e.g. T=2 → 258 → 512 doubles the wg
+    count past target, halves per-split work → 4× slowdown on bs=2 ctx=16384).
+    """
+    if num_cu is None:
+        num_cu = _cu_count()
+    target_wg = max(1, int(target_wg_per_cu * num_cu))
+    head_blocks = max(1, (H + block_h - 1) // block_h)
+    base_ctas = max(1, T * head_blocks)
+    if base_ctas >= target_wg:
+        return 1
+
+    splits_to_fill = max(1, target_wg // base_ctas)
+    return _prev_pow2(min(splits_to_fill, max_kv_splits))
+
+
+# ---------------------------------------------------------------------------
+# Kernels.
+# ---------------------------------------------------------------------------
 
 
 @triton.jit
-def _sparse_attn_v4_paged_decode_kernel(
+def _paged_decode_fused_kernel(
     q_ptr,  # [N, H, D]
     unified_kv_ptr,  # [total_pages, D]
     kv_indices_ptr,  # [total_indices] int32
     kv_indptr_ptr,  # [N+1] int32
     attn_sink_ptr,  # [H]
     out_ptr,  # [N, H, D]
-    q_stride_t: tl.constexpr,
-    q_stride_h: tl.constexpr,
-    q_stride_d: tl.constexpr,
-    kv_stride_n: tl.constexpr,
-    kv_stride_d: tl.constexpr,
-    out_stride_t: tl.constexpr,
-    out_stride_h: tl.constexpr,
-    out_stride_d: tl.constexpr,
+    q_stride_t,
+    q_stride_h,
+    q_stride_d,
+    kv_stride_n,
+    kv_stride_d,
+    out_stride_t,
+    out_stride_h,
+    out_stride_d,
+    qk_scale,  # = softmax_scale * LOG2E
+    log2e,  # = LOG2E, to lift natural-log sink into log2 domain
     H: tl.constexpr,
     D: tl.constexpr,
-    softmax_scale: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_D: tl.constexpr,
     BLOCK_K: tl.constexpr,
 ):
+    """Single-pass online-softmax with sink folded inline — fast path for
+    cases where ``kv_splits = 1`` (base grid already saturates the GPU). Skips
+    the partial-buffer alloc + reduce-kernel launch that the 2-kernel
+    split-K path needs.
+
+    Grid: ``(N, ceil(H / BLOCK_H))``. One CTA owns one token and one head-tile.
+    """
     t = tl.program_id(0)
     pid_h = tl.program_id(1)
 
@@ -84,20 +202,20 @@ def _sparse_attn_v4_paged_decode_kernel(
         mask=h_mask[:, None] & d_mask[None, :],
         other=0.0,
     )
+
     kv_start = tl.load(kv_indptr_ptr + t)
     kv_end = tl.load(kv_indptr_ptr + t + 1)
     kv_len = kv_end - kv_start
+    num_tiles = tl.cdiv(kv_len, BLOCK_K)
 
     neg_large = -3.4028234663852886e38
     m_i = tl.full((BLOCK_H,), neg_large, dtype=tl.float32)
     l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
     acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
 
-    # Runtime trip count: each token iterates ceil(kv_len / BLOCK_K) blocks —
-    # short seqs do not pay for long-seq worst-case work. The last block needs
-    # `k_pos < kv_len` masking for the partial tail.
     k_offs = tl.arange(0, BLOCK_K)
-    for k_start in tl.range(0, kv_len, BLOCK_K):
+    for j in tl.range(0, num_tiles):
+        k_start = j * BLOCK_K
         k_pos = k_start + k_offs
         in_range = k_pos < kv_len
         slot = tl.load(
@@ -115,13 +233,13 @@ def _sparse_attn_v4_paged_decode_kernel(
             other=0.0,
         )
 
-        scores = tl.dot(q, tl.trans(kv)) * softmax_scale
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
         scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
 
         m_block = tl.max(scores, axis=1)
         m_new = tl.maximum(m_i, m_block)
-        alpha = tl.exp(m_i - m_new)
-        p = tl.exp(scores - m_new[:, None])
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
         p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
         l_new = l_i * alpha + tl.sum(p, axis=1)
 
@@ -129,21 +247,274 @@ def _sparse_attn_v4_paged_decode_kernel(
         m_i = m_new
         l_i = l_new
 
-    sink = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(tl.float32)
+    # Fold attn_sink as a virtual K of weight 1. sink is a natural-log bias;
+    # multiply by log2e so it lives in the same log2 domain as our online m_i.
+    sink_raw = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(
+        tl.float32
+    )
+    sink = sink_raw * log2e
     m_final = tl.maximum(m_i, sink)
-    alpha = tl.exp(m_i - m_final)
-    l_final = l_i * alpha + tl.exp(sink - m_final)
+    alpha_kv = tl.exp2(m_i - m_final)
+    alpha_sink = tl.exp2(sink - m_final)
+    l_final = l_i * alpha_kv + alpha_sink
 
     denom = tl.maximum(l_final, 1.0e-30)
-    out = tl.where(l_final[:, None] > 0.0, (acc * alpha[:, None]) / denom[:, None], 0.0)
+    out = tl.where(
+        l_final[:, None] > 0.0, (acc * alpha_kv[:, None]) / denom[:, None], 0.0
+    )
     tl.store(
         out_ptr
         + t * out_stride_t
         + h_offs[:, None] * out_stride_h
         + d_offs[None, :] * out_stride_d,
-        out,
+        out.to(out_ptr.dtype.element_ty),
         mask=h_mask[:, None] & d_mask[None, :],
     )
+
+
+@triton.jit
+def _paged_decode_split_kernel(
+    q_ptr,  # [N, H, D]
+    unified_kv_ptr,  # [total_pages, D]
+    kv_indices_ptr,  # [total_indices] int32
+    kv_indptr_ptr,  # [N+1] int32
+    m_partial_ptr,  # [N, KV_SPLITS, H_padded] fp32
+    l_partial_ptr,  # [N, KV_SPLITS, H_padded] fp32
+    acc_partial_ptr,  # [N, KV_SPLITS, H_padded, D] fp32
+    q_stride_t,
+    q_stride_h,
+    q_stride_d,
+    kv_stride_n,
+    kv_stride_d,
+    mp_stride_t,
+    mp_stride_k,
+    mp_stride_h,
+    lp_stride_t,
+    lp_stride_k,
+    lp_stride_h,
+    ap_stride_t,
+    ap_stride_k,
+    ap_stride_h,
+    ap_stride_d,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    KV_SPLITS: tl.constexpr,
+    qk_scale,  # = softmax_scale * LOG2E
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """3D split-K + exp2-softmax sparse paged-decode. Grid: (N, ceil(H/BLOCK_H), KV_SPLITS).
+
+    Emits pre-sink (m, l, acc) partials in fp32. The reduce kernel folds
+    ``attn_sink`` and combines splits.
+    """
+    t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    pid_k = tl.program_id(2)
+
+    h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    d_offs = tl.arange(0, BLOCK_D)
+    h_mask = h_offs < H
+    d_mask = d_offs < D
+
+    q = tl.load(
+        q_ptr
+        + t * q_stride_t
+        + h_offs[:, None] * q_stride_h
+        + d_offs[None, :] * q_stride_d,
+        mask=h_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    )
+
+    kv_start = tl.load(kv_indptr_ptr + t)
+    kv_end = tl.load(kv_indptr_ptr + t + 1)
+    kv_len = kv_end - kv_start
+
+    # tiles_per_segment pattern from aiter's kernel_unified_attention_3d:
+    # KV_SPLITS is constexpr; tiles_per_segment derived at runtime. Splits
+    # whose tile range is past kv_len early-return WITHOUT writing — the
+    # reduce kernel uses the same constexpr BLOCK_K/KV_SPLITS to compute
+    # ``act_num_segments = cdiv(kv_len, tiles_per_segment * BLOCK_K)`` and
+    # masks unwritten slots out of its load. This saves a per-empty-split
+    # write of BLOCK_H*BLOCK_D fp32 (16 KB at BLOCK_H=16, BLOCK_D=512) which
+    # dominated short-K + many-splits cases.
+    tiles_per_segment = tl.cdiv(kv_len, KV_SPLITS * BLOCK_K)
+    if pid_k * tiles_per_segment * BLOCK_K >= kv_len:
+        return
+    num_tiles = tl.cdiv(kv_len, BLOCK_K)
+    tile_start = pid_k * tiles_per_segment
+    tile_end = tl.minimum((pid_k + 1) * tiles_per_segment, num_tiles)
+
+    neg_large = -3.4028234663852886e38
+    m_i = tl.full((BLOCK_H,), neg_large, dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
+
+    k_offs = tl.arange(0, BLOCK_K)
+    for j in tl.range(tile_start, tile_end):
+        k_start = j * BLOCK_K
+        k_pos = k_start + k_offs
+        in_range = k_pos < kv_len
+        slot = tl.load(
+            kv_indices_ptr + kv_start + k_pos,
+            mask=in_range,
+            other=-1,
+        )
+        valid = in_range & (slot >= 0)
+
+        kv = tl.load(
+            unified_kv_ptr
+            + slot[:, None] * kv_stride_n
+            + d_offs[None, :] * kv_stride_d,
+            mask=valid[:, None] & d_mask[None, :],
+            other=0.0,
+        )
+
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
+
+        m_block = tl.max(scores, axis=1)
+        m_new = tl.maximum(m_i, m_block)
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
+        l_new = l_i * alpha + tl.sum(p, axis=1)
+
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+        l_i = l_new
+
+    m_base = t * mp_stride_t + pid_k * mp_stride_k
+    tl.store(m_partial_ptr + m_base + h_offs * mp_stride_h, m_i, mask=h_mask)
+    l_base = t * lp_stride_t + pid_k * lp_stride_k
+    tl.store(l_partial_ptr + l_base + h_offs * lp_stride_h, l_i, mask=h_mask)
+    a_base = t * ap_stride_t + pid_k * ap_stride_k
+    tl.store(
+        acc_partial_ptr
+        + a_base
+        + h_offs[:, None] * ap_stride_h
+        + d_offs[None, :] * ap_stride_d,
+        acc,
+        mask=h_mask[:, None] & d_mask[None, :],
+    )
+
+
+@triton.jit
+def _paged_decode_reduce_kernel(
+    m_partial_ptr,  # [N, KV_SPLITS, H_padded] fp32
+    l_partial_ptr,  # [N, KV_SPLITS, H_padded] fp32
+    acc_partial_ptr,  # [N, KV_SPLITS, H_padded, D] fp32
+    attn_sink_ptr,  # [H]
+    kv_indptr_ptr,  # [N+1] int32
+    out_ptr,  # [N, H, D]
+    mp_stride_t,
+    mp_stride_k,
+    mp_stride_h,
+    lp_stride_t,
+    lp_stride_k,
+    lp_stride_h,
+    ap_stride_t,
+    ap_stride_k,
+    ap_stride_h,
+    ap_stride_d,
+    out_stride_t,
+    out_stride_h,
+    out_stride_d,
+    log2e,  # = LOG2E, used to convert natural-log sink → log2 domain
+    H: tl.constexpr,
+    D: tl.constexpr,
+    KV_SPLITS: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Combine KV_SPLITS partials, fold attn_sink, write final output.
+
+    Splits that early-returned never wrote their slot. We re-derive the same
+    ``tiles_per_segment`` the split kernel used (BLOCK_K is constexpr and
+    matches across kernels), compute ``act_num_segments`` from kv_len, and
+    mask out unwritten slots with ``other=-inf`` (for m) / 0 (for l, acc).
+    Sink is a natural-log bias; we multiply by ``log2e`` before folding.
+    """
+    t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    d_offs = tl.arange(0, BLOCK_D)
+    k_offs = tl.arange(0, KV_SPLITS)
+    h_mask = h_offs < H
+    d_mask = d_offs < D
+
+    neg_large = -3.4028234663852886e38
+
+    kv_start = tl.load(kv_indptr_ptr + t)
+    kv_end = tl.load(kv_indptr_ptr + t + 1)
+    kv_len = kv_end - kv_start
+    tiles_per_segment = tl.cdiv(kv_len, KV_SPLITS * BLOCK_K)
+    # Only segments [0, act_num_segments) were written by the split kernel.
+    act_num_segments = tl.cdiv(kv_len, tl.maximum(tiles_per_segment, 1) * BLOCK_K)
+    segm_mask = k_offs < act_num_segments
+
+    m_p = tl.load(
+        m_partial_ptr
+        + t * mp_stride_t
+        + k_offs[:, None] * mp_stride_k
+        + h_offs[None, :] * mp_stride_h,
+        mask=segm_mask[:, None] & h_mask[None, :],
+        other=neg_large,
+    )  # [KV_SPLITS, BLOCK_H]
+    l_p = tl.load(
+        l_partial_ptr
+        + t * lp_stride_t
+        + k_offs[:, None] * lp_stride_k
+        + h_offs[None, :] * lp_stride_h,
+        mask=segm_mask[:, None] & h_mask[None, :],
+        other=0.0,
+    )  # [KV_SPLITS, BLOCK_H]
+    a_p = tl.load(
+        acc_partial_ptr
+        + t * ap_stride_t
+        + k_offs[:, None, None] * ap_stride_k
+        + h_offs[None, :, None] * ap_stride_h
+        + d_offs[None, None, :] * ap_stride_d,
+        mask=segm_mask[:, None, None] & h_mask[None, :, None] & d_mask[None, None, :],
+        other=0.0,
+    )  # [KV_SPLITS, BLOCK_H, BLOCK_D]
+
+    # Combine splits in log2 domain.
+    m_max = tl.max(m_p, axis=0)  # [BLOCK_H]
+    alpha_split = tl.exp2(m_p - m_max[None, :])  # [KV_SPLITS, BLOCK_H]
+    l_combined = tl.sum(l_p * alpha_split, axis=0)
+    acc_combined = tl.sum(a_p * alpha_split[:, :, None], axis=0)
+
+    # Sink is a natural-log bias on the softmax denom. Multiply by LOG2E so
+    # comparisons live in the same log2 domain as the split outputs.
+    sink_raw = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(
+        tl.float32
+    )
+    sink = sink_raw * log2e
+    m_final = tl.maximum(m_max, sink)
+    alpha_kv = tl.exp2(m_max - m_final)
+    alpha_sink = tl.exp2(sink - m_final)
+    l_final = l_combined * alpha_kv + alpha_sink
+    acc_final = acc_combined * alpha_kv[:, None]
+
+    denom = tl.maximum(l_final, 1.0e-30)
+    out = tl.where(l_final[:, None] > 0.0, acc_final / denom[:, None], 0.0)
+    tl.store(
+        out_ptr
+        + t * out_stride_t
+        + h_offs[:, None] * out_stride_h
+        + d_offs[None, :] * out_stride_d,
+        out.to(out_ptr.dtype.element_ty),
+        mask=h_mask[:, None] & d_mask[None, :],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wrapper.
+# ---------------------------------------------------------------------------
 
 
 def _sparse_attn_v4_paged_decode_triton(
@@ -153,7 +524,13 @@ def _sparse_attn_v4_paged_decode_triton(
     kv_indptr: torch.Tensor,
     attn_sink: torch.Tensor,
     softmax_scale: float,
+    block_h: int | None = None,
+    kv_splits: int | None = None,
 ) -> torch.Tensor:
+    """V4 sparse decode Triton implementation: split-K with FUSED fast path,
+    exp2 softmax, CG-safe heuristic. ``block_h`` and ``kv_splits`` are
+    escape hatches for benchmarks; production callers pass neither.
+    """
     if not q.is_cuda:
         raise RuntimeError(
             "Triton sparse_attn_v4_paged_decode requires CUDA/HIP tensors"
@@ -172,31 +549,134 @@ def _sparse_attn_v4_paged_decode_triton(
     kv_indices = kv_indices.to(torch.int32).contiguous()
     kv_indptr = kv_indptr.to(torch.int32).contiguous()
 
-    block_h = 16  # AMD MFMA min tile
+    if block_h is None:
+        block_h = triton.next_power_of_2(min(H, 64))
+    else:
+        block_h = triton.next_power_of_2(block_h)
+    block_h = max(block_h, 16)  # AMD MFMA min tile
+
+    n_head_blocks = (H + block_h - 1) // block_h
+    h_padded = n_head_blocks * block_h
     block_d = triton.next_power_of_2(D)
-    block_k = 16 if D >= 256 else 32
-    _sparse_attn_v4_paged_decode_kernel[(T, triton.cdiv(H, block_h))](
+
+    if kv_splits is None:
+        kv_splits = _kv_splits_heuristic(T, H, block_h)
+
+    qk_scale = float(softmax_scale) * LOG2E
+    block_k, num_warps, num_stages = _kernel_config(block_h)
+
+    # Fast path: when the base grid (T * n_head_blocks) already saturates the
+    # GPU, kv_splits=1 and a single-pass fused kernel beats split+reduce by
+    # skipping the partial-buffer alloc and the second kernel launch.
+    if kv_splits == 1:
+        grid_fused = (T, n_head_blocks)
+        _paged_decode_fused_kernel[grid_fused](
+            q,
+            unified_kv,
+            kv_indices,
+            kv_indptr,
+            attn_sink,
+            out,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            unified_kv.stride(0),
+            unified_kv.stride(1),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            qk_scale,
+            LOG2E,
+            H,
+            D,
+            BLOCK_H=block_h,
+            BLOCK_D=block_d,
+            BLOCK_K=block_k,
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        return out
+
+    # Split-K path: split kernel writes (m, l, acc) partials in log2 domain;
+    # reduce kernel combines them, folds attn_sink, writes final output.
+    # Empty splits early-return without writing — reduce masks them out using
+    # the same constexpr BLOCK_K to derive ``act_num_segments``.
+    m_partial = torch.empty(
+        (T, kv_splits, h_padded), dtype=torch.float32, device=q.device
+    )
+    l_partial = torch.empty_like(m_partial)
+    acc_partial = torch.empty(
+        (T, kv_splits, h_padded, D), dtype=torch.float32, device=q.device
+    )
+
+    grid_split = (T, n_head_blocks, kv_splits)
+    _paged_decode_split_kernel[grid_split](
         q,
         unified_kv,
         kv_indices,
         kv_indptr,
-        attn_sink,
-        out,
+        m_partial,
+        l_partial,
+        acc_partial,
         q.stride(0),
         q.stride(1),
         q.stride(2),
         unified_kv.stride(0),
         unified_kv.stride(1),
-        out.stride(0),
-        out.stride(1),
-        out.stride(2),
+        m_partial.stride(0),
+        m_partial.stride(1),
+        m_partial.stride(2),
+        l_partial.stride(0),
+        l_partial.stride(1),
+        l_partial.stride(2),
+        acc_partial.stride(0),
+        acc_partial.stride(1),
+        acc_partial.stride(2),
+        acc_partial.stride(3),
         H,
         D,
-        float(softmax_scale),
+        kv_splits,
+        qk_scale,
         BLOCK_H=block_h,
         BLOCK_D=block_d,
         BLOCK_K=block_k,
-        num_warps=8,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    # Reduce: one CTA per (token, head). Per-head fan-out hides launch latency
+    # on small per-rank H (TP=8 → H ∈ {8, 16}); for large H we accept the extra
+    # CTAs since the reduce work is tiny.
+    block_h_reduce = 1
+    grid_reduce = (T, (H + block_h_reduce - 1) // block_h_reduce)
+    _paged_decode_reduce_kernel[grid_reduce](
+        m_partial,
+        l_partial,
+        acc_partial,
+        attn_sink,
+        kv_indptr,
+        out,
+        m_partial.stride(0),
+        m_partial.stride(1),
+        m_partial.stride(2),
+        l_partial.stride(0),
+        l_partial.stride(1),
+        l_partial.stride(2),
+        acc_partial.stride(0),
+        acc_partial.stride(1),
+        acc_partial.stride(2),
+        acc_partial.stride(3),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        LOG2E,
+        H,
+        D,
+        kv_splits,
+        BLOCK_H=block_h_reduce,
+        BLOCK_D=block_d,
+        BLOCK_K=block_k,
+        num_warps=4,
     )
     return out
 

--- a/atom/model_ops/v4_kernels/paged_decode.py
+++ b/atom/model_ops/v4_kernels/paged_decode.py
@@ -58,6 +58,20 @@ from atom.model_ops.sparse_attn_v4 import _sparse_attn_ragged_torch
 LOG2E = 1.4426950408889634  # log2(e); folded into qk_scale so softmax can use exp2.
 _MAX_KV_SPLITS = 64  # Hard cap on kv_splits (see _kv_splits_heuristic).
 
+# FP8 KV cache (1xGROUP_SIZE block-scale quantization).
+#
+# Storage: unified_kv[total_pages, D] in e4m3fnuz + kv_scales[total_pages,
+# D // GROUP_SIZE] in fp32. Per-slot, D is split into NUM_GROUPS chunks of
+# GROUP_SIZE elements; each chunk shares one fp32 scale.
+# Dequant in-kernel: kv_bf16 = kv_fp8.to(fp32) * scale[d // GROUP_SIZE], cast
+# back to q.dtype before the second dot.
+#
+# GROUP_SIZE=64 matches the user's 1x64 quant spec. V4-Pro: D=512 → 8 scales
+# per slot, 4 bytes each → +6.25% storage on top of the fp8 pool (vs the
+# halving from bf16→fp8 = 2× saving — net ~46% read bandwidth reduction).
+_FP8_GROUP_SIZE = 64
+_FP8_DTYPE = torch.float8_e4m3fnuz
+
 
 @functools.lru_cache(maxsize=1)
 def _cu_count() -> int:
@@ -158,7 +172,8 @@ def _kv_splits_heuristic(
 @triton.jit
 def _paged_decode_fused_kernel(
     q_ptr,  # [N, H, D]
-    unified_kv_ptr,  # [total_pages, D]
+    unified_kv_ptr,  # [total_pages, D] bf16/fp16, or fp8 when QUANT_KV
+    kv_scales_ptr,  # [total_pages, NUM_GROUPS] fp32 when QUANT_KV (dummy otherwise)
     kv_indices_ptr,  # [total_indices] int32
     kv_indptr_ptr,  # [N+1] int32
     attn_sink_ptr,  # [H]
@@ -168,6 +183,7 @@ def _paged_decode_fused_kernel(
     q_stride_d,
     kv_stride_n,
     kv_stride_d,
+    ks_stride_n,  # row stride of kv_scales (groups are contiguous, stride=1)
     out_stride_t,
     out_stride_h,
     out_stride_d,
@@ -178,6 +194,9 @@ def _paged_decode_fused_kernel(
     BLOCK_H: tl.constexpr,
     BLOCK_D: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    QUANT_KV: tl.constexpr,  # True → dequant fp8 KV via kv_scales
+    GROUP_SIZE: tl.constexpr,  # scale block width along D (e.g. 64)
+    NUM_GROUPS: tl.constexpr,  # D // GROUP_SIZE (constexpr; D % GROUP_SIZE == 0)
 ):
     """Single-pass online-softmax with sink folded inline — fast path for
     cases where ``kv_splits = 1`` (base grid already saturates the GPU). Skips
@@ -214,6 +233,11 @@ def _paged_decode_fused_kernel(
     acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
 
     k_offs = tl.arange(0, BLOCK_K)
+    if QUANT_KV:
+        # Compile-time per-D-element group index: d_offs // GROUP_SIZE has
+        # NUM_GROUPS distinct values; redundant scale loads at the same
+        # address are coalesced through L1, no per-element scalar issue.
+        g_idx_per_d = d_offs // GROUP_SIZE
     for j in tl.range(0, num_tiles):
         k_start = j * BLOCK_K
         k_pos = k_start + k_offs
@@ -225,13 +249,28 @@ def _paged_decode_fused_kernel(
         )
         valid = in_range & (slot >= 0)
 
-        kv = tl.load(
+        kv_raw = tl.load(
             unified_kv_ptr
             + slot[:, None] * kv_stride_n
             + d_offs[None, :] * kv_stride_d,
             mask=valid[:, None] & d_mask[None, :],
             other=0.0,
         )
+        if QUANT_KV:
+            # 1xGROUP_SIZE block-scale dequant via direct broadcast load —
+            # avoids the explicit reshape + 3D intermediate that pinned
+            # too many bf16 tiles in flight at once. The masked load with
+            # d_offs // GROUP_SIZE as the column index produces a virtual
+            # [BLOCK_K, BLOCK_D] scales tile but in IR is a coalesced
+            # NUM_GROUPS-wide load per row.
+            scales_full = tl.load(
+                kv_scales_ptr + slot[:, None] * ks_stride_n + g_idx_per_d[None, :],
+                mask=valid[:, None] & d_mask[None, :],
+                other=0.0,
+            ).to(q.dtype)
+            kv = kv_raw.to(q.dtype) * scales_full
+        else:
+            kv = kv_raw
 
         scores = tl.dot(q, tl.trans(kv)) * qk_scale
         scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
@@ -275,7 +314,8 @@ def _paged_decode_fused_kernel(
 @triton.jit
 def _paged_decode_split_kernel(
     q_ptr,  # [N, H, D]
-    unified_kv_ptr,  # [total_pages, D]
+    unified_kv_ptr,  # [total_pages, D] bf16/fp16, or fp8 when QUANT_KV
+    kv_scales_ptr,  # [total_pages, NUM_GROUPS] fp32 when QUANT_KV (dummy otherwise)
     kv_indices_ptr,  # [total_indices] int32
     kv_indptr_ptr,  # [N+1] int32
     m_partial_ptr,  # [N, KV_SPLITS, H_padded] fp32
@@ -286,6 +326,7 @@ def _paged_decode_split_kernel(
     q_stride_d,
     kv_stride_n,
     kv_stride_d,
+    ks_stride_n,  # row stride of kv_scales (groups are contiguous, stride=1)
     mp_stride_t,
     mp_stride_k,
     mp_stride_h,
@@ -303,6 +344,9 @@ def _paged_decode_split_kernel(
     BLOCK_H: tl.constexpr,
     BLOCK_D: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    QUANT_KV: tl.constexpr,  # True → dequant fp8 KV via kv_scales
+    GROUP_SIZE: tl.constexpr,  # scale block width along D (e.g. 64)
+    NUM_GROUPS: tl.constexpr,  # D // GROUP_SIZE
 ):
     """3D split-K + exp2-softmax sparse paged-decode. Grid: (N, ceil(H/BLOCK_H), KV_SPLITS).
 
@@ -352,6 +396,8 @@ def _paged_decode_split_kernel(
     acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
 
     k_offs = tl.arange(0, BLOCK_K)
+    if QUANT_KV:
+        g_idx_per_d = d_offs // GROUP_SIZE
     for j in tl.range(tile_start, tile_end):
         k_start = j * BLOCK_K
         k_pos = k_start + k_offs
@@ -363,13 +409,22 @@ def _paged_decode_split_kernel(
         )
         valid = in_range & (slot >= 0)
 
-        kv = tl.load(
+        kv_raw = tl.load(
             unified_kv_ptr
             + slot[:, None] * kv_stride_n
             + d_offs[None, :] * kv_stride_d,
             mask=valid[:, None] & d_mask[None, :],
             other=0.0,
         )
+        if QUANT_KV:
+            scales_full = tl.load(
+                kv_scales_ptr + slot[:, None] * ks_stride_n + g_idx_per_d[None, :],
+                mask=valid[:, None] & d_mask[None, :],
+                other=0.0,
+            ).to(q.dtype)
+            kv = kv_raw.to(q.dtype) * scales_full
+        else:
+            kv = kv_raw
 
         scores = tl.dot(q, tl.trans(kv)) * qk_scale
         scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
@@ -524,12 +579,19 @@ def _sparse_attn_v4_paged_decode_triton(
     kv_indptr: torch.Tensor,
     attn_sink: torch.Tensor,
     softmax_scale: float,
+    kv_scales: torch.Tensor | None = None,
     block_h: int | None = None,
     kv_splits: int | None = None,
+    block_k: int | None = None,
 ) -> torch.Tensor:
     """V4 sparse decode Triton implementation: split-K with FUSED fast path,
     exp2 softmax, CG-safe heuristic. ``block_h`` and ``kv_splits`` are
     escape hatches for benchmarks; production callers pass neither.
+
+    When ``kv_scales`` is provided, ``unified_kv`` must be e4m3fnuz and
+    ``kv_scales`` must be ``[total_pages, D // GROUP_SIZE]`` fp32 — 1xGROUP_SIZE
+    block-scale quantization. Dequant happens in-kernel; the dot still runs
+    in q.dtype.
     """
     if not q.is_cuda:
         raise RuntimeError(
@@ -539,10 +601,34 @@ def _sparse_attn_v4_paged_decode_triton(
         raise RuntimeError(
             f"sparse_attn_v4_paged_decode expects fp16/bf16 q, got {q.dtype}"
         )
-    if unified_kv.dtype != q.dtype:
-        raise RuntimeError(
-            f"unified_kv dtype mismatch: kv={unified_kv.dtype}, q={q.dtype}"
-        )
+
+    quant_kv = kv_scales is not None
+    if quant_kv:
+        if unified_kv.dtype != _FP8_DTYPE:
+            raise RuntimeError(
+                f"kv_scales supplied but unified_kv is {unified_kv.dtype}, "
+                f"expected {_FP8_DTYPE}"
+            )
+        if kv_scales.dtype != torch.float32:
+            raise RuntimeError(f"kv_scales must be fp32, got {kv_scales.dtype}")
+        D_check = unified_kv.shape[-1]
+        if D_check % _FP8_GROUP_SIZE != 0:
+            raise RuntimeError(
+                f"D={D_check} must be divisible by GROUP_SIZE={_FP8_GROUP_SIZE}"
+            )
+        expected_g = D_check // _FP8_GROUP_SIZE
+        if kv_scales.shape != (unified_kv.shape[0], expected_g):
+            raise RuntimeError(
+                f"kv_scales shape {tuple(kv_scales.shape)} does not match "
+                f"expected ({unified_kv.shape[0]}, {expected_g})"
+            )
+        if kv_scales.stride(-1) != 1:
+            kv_scales = kv_scales.contiguous()
+    else:
+        if unified_kv.dtype != q.dtype:
+            raise RuntimeError(
+                f"unified_kv dtype mismatch: kv={unified_kv.dtype}, q={q.dtype}"
+            )
 
     T, H, D = q.shape
     out = torch.empty_like(q)
@@ -563,7 +649,27 @@ def _sparse_attn_v4_paged_decode_triton(
         kv_splits = _kv_splits_heuristic(T, H, block_h)
 
     qk_scale = float(softmax_scale) * LOG2E
-    block_k, num_warps, num_stages = _kernel_config(block_h)
+    _bk, num_warps, num_stages = _kernel_config(block_h)
+    if block_k is None:
+        # fp8 dequant inflates per-tile ALU work ~4×; a wider K tile amortizes
+        # the per-tile dequant cost (scale load + cast + multiply) over more
+        # MFMA work. Empirically BLOCK_K=32 wins ~20% over BLOCK_K=16 on fp8
+        # (bs=512 ctx=4096: 3000µs → 2300µs) without hurting bf16.
+        block_k = 32 if quant_kv else _bk
+
+    # Kernel reads (kv_scales_ptr, ks_stride_n) only when QUANT_KV — supply a
+    # dummy 1-element fp32 tensor on the bf16 path so the launch signature
+    # stays uniform (avoids a separate JIT specialization per call).
+    if quant_kv:
+        kv_scales_arg = kv_scales
+        ks_stride_n_arg = kv_scales.stride(0)
+        num_groups_arg = D // _FP8_GROUP_SIZE
+    else:
+        kv_scales_arg = q.new_empty(1, dtype=torch.float32)
+        ks_stride_n_arg = 1
+        # NUM_GROUPS still needs a constexpr value (unused at compile time
+        # because the QUANT_KV=False branch elides the dequant code).
+        num_groups_arg = 1
 
     # Fast path: when the base grid (T * n_head_blocks) already saturates the
     # GPU, kv_splits=1 and a single-pass fused kernel beats split+reduce by
@@ -573,6 +679,7 @@ def _sparse_attn_v4_paged_decode_triton(
         _paged_decode_fused_kernel[grid_fused](
             q,
             unified_kv,
+            kv_scales_arg,
             kv_indices,
             kv_indptr,
             attn_sink,
@@ -582,6 +689,7 @@ def _sparse_attn_v4_paged_decode_triton(
             q.stride(2),
             unified_kv.stride(0),
             unified_kv.stride(1),
+            ks_stride_n_arg,
             out.stride(0),
             out.stride(1),
             out.stride(2),
@@ -592,6 +700,9 @@ def _sparse_attn_v4_paged_decode_triton(
             BLOCK_H=block_h,
             BLOCK_D=block_d,
             BLOCK_K=block_k,
+            QUANT_KV=quant_kv,
+            GROUP_SIZE=_FP8_GROUP_SIZE,
+            NUM_GROUPS=num_groups_arg,
             num_warps=num_warps,
             num_stages=num_stages,
         )
@@ -613,6 +724,7 @@ def _sparse_attn_v4_paged_decode_triton(
     _paged_decode_split_kernel[grid_split](
         q,
         unified_kv,
+        kv_scales_arg,
         kv_indices,
         kv_indptr,
         m_partial,
@@ -623,6 +735,7 @@ def _sparse_attn_v4_paged_decode_triton(
         q.stride(2),
         unified_kv.stride(0),
         unified_kv.stride(1),
+        ks_stride_n_arg,
         m_partial.stride(0),
         m_partial.stride(1),
         m_partial.stride(2),
@@ -640,6 +753,9 @@ def _sparse_attn_v4_paged_decode_triton(
         BLOCK_H=block_h,
         BLOCK_D=block_d,
         BLOCK_K=block_k,
+        QUANT_KV=quant_kv,
+        GROUP_SIZE=_FP8_GROUP_SIZE,
+        NUM_GROUPS=num_groups_arg,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -688,13 +804,28 @@ def sparse_attn_v4_paged_decode_reference(
     kv_indptr: torch.Tensor,
     attn_sink: torch.Tensor,
     softmax_scale: float,
+    kv_scales: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Pure-torch reference. Materialises per-token KV via gather and reuses
     `_sparse_attn_ragged_torch`. Slow but correct — for unit tests / dump-bisect.
 
     Uses the longest per-token span as the K dimension for the dense
-    `topk_idxs` tensor; shorter spans are tail-padded with `-1`.
+    `topk_idxs` tensor; shorter spans are tail-padded with `-1`. When
+    ``kv_scales`` is given, dequantizes unified_kv (fp8) → q.dtype up front
+    via per-slot 1xGROUP_SIZE block-scale multiply.
     """
+    if kv_scales is not None:
+        # Dequant the whole pool once — only the gather sees a real tensor,
+        # so this is just a reference path; not optimized.
+        total_pages, D = unified_kv.shape
+        num_groups = D // _FP8_GROUP_SIZE
+        kv_fp32 = unified_kv.to(torch.float32)
+        scales_expanded = (
+            kv_scales.view(total_pages, num_groups, 1)
+            .expand(total_pages, num_groups, _FP8_GROUP_SIZE)
+            .reshape(total_pages, D)
+        )
+        unified_kv = (kv_fp32 * scales_expanded).to(q.dtype)
     T = q.size(0)
     indptr = kv_indptr.to(torch.int64)
     spans = (indptr[1:] - indptr[:T]).clamp(min=0)
@@ -717,8 +848,13 @@ def sparse_attn_v4_paged_decode(
     kv_indptr: torch.Tensor,
     attn_sink: torch.Tensor,
     softmax_scale: float,
+    kv_scales: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """V4 decode sparse attention over a unified KV pool with paged indices."""
+    """V4 decode sparse attention over a unified KV pool with paged indices.
+
+    When ``kv_scales`` is provided, ``unified_kv`` must be fp8 (e4m3fnuz) and
+    will be dequantized in-kernel using 1xGROUP_SIZE (default 64) block scales.
+    """
     if os.environ.get("ATOM_USE_TRITON_ATTN", "1") == "1":
         return _sparse_attn_v4_paged_decode_triton(
             q,
@@ -727,6 +863,7 @@ def sparse_attn_v4_paged_decode(
             kv_indptr,
             attn_sink,
             softmax_scale,
+            kv_scales=kv_scales,
         )
     return sparse_attn_v4_paged_decode_reference(
         q,
@@ -735,4 +872,5 @@ def sparse_attn_v4_paged_decode(
         kv_indptr,
         attn_sink,
         softmax_scale,
+        kv_scales=kv_scales,
     )


### PR DESCRIPTION
## Summary

Two commits on top of `main` for V4-Pro sparse paged decode (`atom/model_ops/v4_kernels/paged_decode.py`):

1. **`perf(v4): rewrite sparse paged_decode with split-K + FUSED fast path`** (9bdb4b15)
   - Replace the single `_sparse_attn_v4_paged_decode_kernel` with a 3-kernel architecture (FUSED single-pass + SPLIT/REDUCE two-pass + dispatcher) inspired by aiter `pa_decode_sparse` and the SGL DSA decode kernel.
   - Online-softmax moves to log2 domain (`exp2` + `qk_scale = softmax_scale * LOG2E`) — fewer ALU ops per K tile.
   - Heuristic picks FUSED when `T * ceil(H/block_h) ≥ target_wg_per_cu × num_cu` (base grid already saturates the GPU), SPLIT+REDUCE otherwise. Both branches are pure shape-driven (no tensor-value reads) → CUDAGraph-safe.
   - `_kv_splits_heuristic` rounds down to prev-pow-2, caps at `MAX_KV_SPLITS=64`. CU count queried via `aiter.ops.triton.utils.device_info.get_num_sms()` (lru_cached).
   - Pure perf change — bf16 ABI unchanged.

2. **`feat(v4): add fp8 (1x64 block-scale) KV path to sparse paged_decode`** (09b4fd06)
   - Opt-in via new `kv_scales` kwarg on `sparse_attn_v4_paged_decode` / `_sparse_attn_v4_paged_decode_triton` / reference.
   - When set, `unified_kv` must be `float8_e4m3fnuz` and `kv_scales` must be `[total_pages, D//64]` fp32. Kernel dequantizes in-register before the dot; output stays in q.dtype.
   - Backwards-compatible: `kv_scales=None` defaults to today's bf16 path with zero structural change (`QUANT_KV` is a constexpr that elides the dequant code).
   - V4 production integration (allocating fp8 `unified_kv`, plumbing scales through `swa_write` / `Compressor.forward` / dispatch / `paged_prefill`) is a separate PR.

## Test plan

- [x] **Accuracy — 240-case bf16↔fp8 sweep**: `v4_pro_{tp8,tp4,full} × bs ∈ {1..512} × mtp ∈ {0,3} × ctx ∈ {128,1k,4k,16k}`. Every case matches bf16 reference within tolerance (`err_quant_% == 0` across all 240). Full table at `/app/logs_claude/pa_decode_fp8/full_matrix.md`.
- [x] **GSM8K MTP3 V4-Pro accuracy — 3 trials**: `0.9500 / 0.9477 / 0.9507` (mean 0.9495). Compared to 3-trial `main` baseline `0.9447 / 0.9469 / 0.9507` (mean 0.9474), difference +0.0020 with `|t| ≈ 1.03` — within natural lm_eval noise (1σ ≈ 0.006 on 1319 samples).
- [x] **Bandwidth bench**: bf16 path hits 5-6 TB/s (~70-75% of MI355X HBM peak 8 TB/s) on large shapes — within practical ceiling. fp8 path is correct but ALU-bound (~500 GB/s) due to per-tile 8K dequant multiplies that 1x64 blockscale demands; ratio fp8/bf16 ranges 1.35-7.16× slower across the sweep. Designed as a memory-saving option (~46% less HBM for `unified_kv`), not a latency optimization.
- [ ] CI