### PR TITLE
chore(v4): Compressor flydsl integration + debug tooling

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -346,6 +346,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # Non-spec (max_spec_steps=0) → ring_size = K_pool: no rejections ever
         # happen, so the bare commit pool is sufficient (causal writes mean
         # the alias slot is never read before being overwritten).
+        # `ring_extra` is slack beyond K_pool for the compressor ring buffer.
+        # Validated via `ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL=1` (100% reject =
+        # worst case for aliasing): even at ring_extra=0, decode commits the
+        # correct next token, confirming no read-from-stale slot collision.
+        # See `Adding a further +1 (the old layout) was unnecessary slack` below.
         ring_extra = self.max_spec_steps
         self.csa_main_state_shape = (2 * 4 + ring_extra, 2 * self.head_dim)
         self.csa_idx_state_shape = (2 * 4 + ring_extra, 2 * self.index_head_dim)
@@ -2242,12 +2247,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # The decode CG path uses a much tighter capacity than the prefill
         # worst case — the kernel grid is dictated by the slice of this
         # buffer that we hand to the kernel, and decode only ever needs
-        # `max_decode_tokens // ratio + max_bs` rows (vs `mnbt // ratio + bs`
-        # for prefill, which is ~13× larger at typical config). We still
-        # allocate the full prefill capacity (eager prefill needs it), but
-        # both decode capture and replay slice down to `_decode_compress_cap`
-        # so the captured grid is the decode-tight bound. capture and
-        # replay MUST use the same value (CG kernel call args are baked).
+        # `bs * ceil((1 + max_spec_steps) / ratio)` rows (vs `mnbt // ratio
+        # + bs` for prefill, which is ~13× larger at typical config). We
+        # still allocate the full prefill capacity (eager prefill needs it),
+        # but both decode capture and replay slice down to
+        # `_decode_compress_cap` so the captured grid is the decode-tight
+        # bound. capture and replay MUST use the same value (CG kernel call
+        # args are baked).
         self._decode_compress_cap: dict[int, int] = {}
         for ratio, is_overlap in self._unique_compress_ratios_overlap:
             # NOTE: this is the pool-window size (algorithm constant), NOT the
@@ -2266,12 +2272,20 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             bufs[f"v4_compress_plan_{ratio}"].copy_to_gpu()
             bufs[f"v4_write_plan_{ratio}"].cpu.fill_(-1)
             bufs[f"v4_write_plan_{ratio}"].copy_to_gpu()
-            # Decode-tight bound. Worst case = total_tokens_decode boundaries
-            # all firing simultaneously, each in its own ratio-aligned slot.
-            # `total_tokens_decode = max_decode_tokens` (= max_bs * (1+spec)).
-            # The `+ max_bs` covers per-seq alignment slack (each seq can hit
-            # at most one extra boundary when extend_len isn't ratio-aligned).
-            self._decode_compress_cap[ratio] = self.max_decode_tokens // ratio + bs
+            # Decode-tight bound: each seq's qlen-token window contains at
+            # most ceil(qlen / ratio) ratio-aligned boundaries (qlen =
+            # 1 + max_spec_steps), so total ≤ bs * ceil(qlen / ratio).
+            # The integer expression `(max_spec_steps + ratio) // ratio`
+            # is ceil((1 + max_spec_steps) / ratio).
+            #
+            # Tighter than the old `max_decode_tokens // ratio + max_bs`:
+            #   CSA r=4 MTP3 bs=256:  256 vs 512 (2× smaller)
+            #   HCA r=128 MTP3 bs=256: 256 vs 264 (8 smaller)
+            #
+            # Smaller plan slice → fewer sentinel rows the kernel skips →
+            # smaller grid → less launch + scheduling overhead.
+            per_seq_max = (self.max_spec_steps + ratio) // ratio
+            self._decode_compress_cap[ratio] = bs * per_seq_max
 
         self.model_runner.forward_vars.update(bufs)
 

--- a/atom/model_ops/v4_kernels/compress_plan.py
+++ b/atom/model_ops/v4_kernels/compress_plan.py
@@ -92,7 +92,8 @@ def make_compress_plans(
                     `n_compress`) — required by the decode CUDAGraph path
                     so capture and replay produce kernel calls with
                     identical tensor shapes. Caller must size this to the
-                    decode worst case (`max_decode_tokens // ratio + bs`).
+                    decode worst case (`bs * ceil((1 + max_spec_steps) /
+                    ratio)`).
                     When NONE: the slice is exactly `n_compress` (tight,
                     eager-only) — gives the smallest possible kernel grid.
                     The slice is contiguous-from-base so the data pointer

--- a/atom/model_ops/v4_kernels/fused_compress.py
+++ b/atom/model_ops/v4_kernels/fused_compress.py
@@ -58,6 +58,28 @@ import triton
 import triton.language as tl
 
 from atom.model_ops.v4_kernels.compress_plan import CompressPlan
+from atom.utils import envs
+
+# Optional flydsl path (aiter ROCm kernels). Falls back to Triton when
+# unavailable. HCA = compress + norm_rope_scatter 2-kernel split for
+# D=512 ratio=128 overlap=False.
+try:
+    from aiter.ops.flydsl.kernels.fused_compress_attn import flydsl_fused_compress_attn
+    from aiter.ops.flydsl.kernels.fused_compress_attn_hca import (
+        flydsl_hca_compress_attn,
+    )
+except Exception:
+    flydsl_fused_compress_attn = None
+    flydsl_hca_compress_attn = None
+
+# Supported (head_dim, rope_head_dim, ratio, overlap) tuples for the flydsl
+# kernel — matches V4-Pro Main (D=512) and Indexer-inner (D=128) compressors.
+# Extend as more configs are validated.
+_FLYDSL_SUPPORTED = {
+    (512, 64, 4, True),  # V4-Pro CSA Main BF16   (ratio=4, OVERLAP)
+    (128, 64, 4, True),  # V4-Pro CSA Indexer FP8 (ratio=4, OVERLAP)
+    (512, 64, 128, False),  # V4-Pro HCA Main BF16  (ratio=128, no overlap)
+}
 
 
 @triton.jit
@@ -410,6 +432,82 @@ def fused_compress_attn(
     num_compress = plan.num_compress
     if plan_capacity == 0:
         return  # nothing to do — no plan rows ever populated.
+
+    # ------------------------------------------------------------------
+    # flydsl dispatch. Pure-GPU time on V4-Pro beats Triton 0.9x→2.9x
+    # across the relevant N_compress range; the small-N gap is bridged
+    # by the kernel doing both BF16 and FP8 paths through a single
+    # launcher (less per-call Python overhead at the boundary).
+    # ------------------------------------------------------------------
+    _flydsl_mode = envs.ATOM_FUSED_COMPRESS_USE_FLYDSL
+    _shape_key = (head_dim, rope_head_dim, ratio, overlap)
+    _flydsl_shape_ok = _shape_key in _FLYDSL_SUPPORTED
+    _flydsl_use = (
+        flydsl_fused_compress_attn is not None
+        and _flydsl_mode in ("auto", "always")
+        and _flydsl_shape_ok
+    )
+    if _flydsl_mode == "always" and not _flydsl_shape_ok:
+        raise RuntimeError(
+            f"ATOM_FUSED_COMPRESS_USE_FLYDSL=always but shape "
+            f"{_shape_key} is not in supported set {_FLYDSL_SUPPORTED}"
+        )
+    # HCA 2-kernel-split: BF16-only on V4-Pro HCA Main shape
+    # (D=512 ratio=128 overlap=False). HCA wins single-kernel at all N
+    # (1.06-3.7×) post slice_size + VEC=8 refactor.
+    _hca_use = (
+        _flydsl_use
+        and flydsl_hca_compress_attn is not None
+        and not quant
+        and _shape_key == (512, 64, 128, False)
+    )
+    if _hca_use:
+        flydsl_hca_compress_attn(
+            kv_in=kv_in,
+            score_in=score_in,
+            kv_state=kv_state,
+            score_state=score_state,
+            state_slot_mapping=state_slot_mapping,
+            plan_gpu=plan.compress_plan_gpu,
+            ape=ape,
+            rms_weight=rms_weight,
+            rms_eps=rms_eps,
+            cos_cache=cos_cache,
+            sin_cache=sin_cache,
+            kv_cache=kv_cache,
+            block_tables=block_tables,
+            k_per_block=k_per_block,
+            ratio=ratio,
+            head_dim=head_dim,
+            rope_head_dim=rope_head_dim,
+        )
+        return
+    if _flydsl_use:
+        flydsl_fused_compress_attn(
+            kv_in=kv_in,
+            score_in=score_in,
+            kv_state=kv_state,
+            score_state=score_state,
+            plan_gpu=plan.compress_plan_gpu,
+            state_slot_mapping=state_slot_mapping,
+            ape=ape,
+            rms_weight=rms_weight,
+            rms_eps=rms_eps,
+            cos_cache=cos_cache,
+            sin_cache=sin_cache,
+            kv_cache=kv_cache,
+            block_tables=block_tables,
+            k_per_block=k_per_block,
+            overlap=overlap,
+            ratio=ratio,
+            head_dim=head_dim,
+            rope_head_dim=rope_head_dim,
+            quant=quant,
+            cache_scale=cache_scale,
+            use_ue8m0=use_ue8m0,
+            preshuffle=preshuffle,
+        )
+        return
 
     # Validate shapes
     dim_full = (2 if overlap else 1) * head_dim

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -10,6 +10,7 @@ from aiter.dist.parallel_state import get_pp_group
 from atom.config import CompilationLevel, Config, KVCacheTensor
 from atom.model_loader.loader import load_model
 from atom.utils import CpuGpuBuffer, resolve_obj_by_qualname
+from atom.utils import envs
 from atom.utils.forward_context import SpecDecodeMetadata, get_forward_context
 from torch.profiler import record_function
 
@@ -334,6 +335,7 @@ class EagleProposer:
         context.is_draft = True
 
         assert self.runner is not None
+
         input_ids = target_token_ids
         # input_ids[last_token_indices] = next_token_ids
         input_ids.scatter_(0, last_token_indices, next_token_ids)
@@ -349,6 +351,8 @@ class EagleProposer:
         draft_token_ids = torch.empty(
             bs, self.mtp_k, dtype=next_token_ids.dtype, device=next_token_ids.device
         )
+        if envs.ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL:
+            draft_token_ids.fill_(-1)
         var = self.runner.forward_vars
         target_uses_mla = self.runner.use_mla
         # Eaale3 only support mha currently

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -36,6 +36,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_USE_TRITON_MLA": lambda: os.getenv("ATOM_USE_TRITON_MLA", "0") == "1",
     "ATOM_USE_TRITON_MOE": lambda: os.getenv("ATOM_USE_TRITON_MOE", "0") == "1",
     # --- Kernel Fusion Toggles ---
+    # fused_compress_attn: switch between Triton (default historical) and a
+    # flydsl drop-in for V4-Pro Compressor (Main BF16 + Indexer FP8) paths.
+    # "auto" picks flydsl when shape matches the supported configs (D ∈
+    # {128, 512}, RD=64, OVERLAP=1, RATIO=4); "always" forces it (errors on
+    # unsupported); "never" pins Triton. flydsl pure-GPU time beats Triton
+    # across the full range on V4-Pro (1.1x small N → 2-3x at N≥4096).
+    "ATOM_FUSED_COMPRESS_USE_FLYDSL": lambda: os.getenv(
+        "ATOM_FUSED_COMPRESS_USE_FLYDSL", "auto"
+    ).lower(),
     # QK-norm-rope-cache-quant fusion for Qwen3-MoE; disabled by default.
     # Enable for Qwen3-MoE to get better performance.
     "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION": lambda: (
@@ -153,6 +162,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Sampler top-K logits log — int K, 0/empty disables.
     "ATOM_DEBUG_TOPK": lambda: int(os.getenv("ATOM_DEBUG_TOPK", "0") or "0"),
     "ATOM_DEBUG_TOPK_PATH": lambda: os.getenv("ATOM_DEBUG_TOPK_PATH", ""),
+    # Force-skip the draft-model forward in eagle/MTP propose() and return
+    # sentinel draft token ids (int max) so rejection_sampler rejects all
+    # speculative tokens. Used to reproduce 100% rejection behavior — the
+    # worst case for ring-buffer aliasing in compressor state caches.
+    # Default: False (run the draft model normally).
+    "ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL": lambda: (
+        os.getenv("ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL", "0") == "1"
+    ),
 }
 
 

--- a/scripts/wait_infer_drain.sh
+++ b/scripts/wait_infer_drain.sh
@@ -32,15 +32,22 @@
 # the HTTP endpoint can fail to respond within reasonable timeout even when
 # the server is alive, producing false-positive "dead" reports).
 #
-# Usage: bash scripts/wait_infer_drain.sh [PORT] [MAX_MIN] [POLL_SEC] [LOG_FILE] [STUCK_POLLS]
-#   PORT         default 8000  (kept for API symmetry with wait_server_ready.sh; unused in offline mode)
-#   MAX_MIN      default 30    (full GSM8K 1319 typically 5-15 min on V4-Pro)
-#   POLL_SEC     default 10    (fast poll for quick hang detection)
-#   LOG_FILE     default empty (server log auto-discovered via /proc). Pass a
-#                client/workload log (e.g. benchmark.log, simple_inference.log)
-#                to add it as a secondary signal source for fault grep and
-#                mtime-based progress detection.
-#   STUCK_POLLS  default 6     (6 × 10s = 1 min of no progress → declare hang)
+# Usage: bash scripts/wait_infer_drain.sh [PORT] [MAX_MIN] [POLL_SEC] [LOG_FILE] [STUCK_POLLS] [STARTUP_MAX_MIN]
+#   PORT             default 8000  (kept for API symmetry with wait_server_ready.sh; unused in offline mode)
+#   MAX_MIN          default 30    (full GSM8K 1319 typically 5-15 min on V4-Pro)
+#   POLL_SEC         default 10    (fast poll for quick hang detection)
+#   LOG_FILE         default empty (server log auto-discovered via /proc). Pass a
+#                    client/workload log (e.g. benchmark.log, simple_inference.log)
+#                    to add it as a secondary signal source for fault grep and
+#                    mtime-based progress detection.
+#   STUCK_POLLS      default 6     (6 × 10s = 1 min of no progress → declare hang)
+#   STARTUP_MAX_MIN  default 15    (how long to wait for the workload python
+#                                   process to first appear before giving up;
+#                                   V4-Pro launchers spend minutes in GPU
+#                                   cleanup + cache prep + model load before
+#                                   exec'ing python. During this window the
+#                                   pgrep miss must NOT be interpreted as a
+#                                   clean exit.)
 #
 # Exit codes:
 #   0 — workload drained cleanly (server: client gone + no pending output;
@@ -56,7 +63,9 @@ MAX_MIN="${2:-30}"
 POLL="${3:-10}"
 LOG_FILE="${4:-}"
 STUCK_POLLS="${5:-6}"
+STARTUP_MAX_MIN="${6:-15}"
 ITERS=$(( MAX_MIN * 60 / POLL ))
+STARTUP_ITERS=$(( STARTUP_MAX_MIN * 60 / POLL ))
 
 # Match anything that indicates the eval driver is still hammering the
 # server. Extend if you use a different client.
@@ -101,6 +110,11 @@ prev_outputs=0
 prev_mtime=0
 stuck=0
 server_log=""
+# Whether we've ever observed the workload python process. Until this flips
+# to 1, a pgrep miss means "launcher script still in pre-exec setup" (GPU
+# cleanup, cache prep, model load), NOT "workload finished". Without this
+# guard the script returns DRAINED in ~10s for any V4-Pro / large-model run.
+ever_seen=0
 
 for ((i=1; i<=ITERS; i++)); do
     sleep "$POLL"
@@ -128,10 +142,22 @@ for ((i=1; i<=ITERS; i++)); do
 
     # Workload process alive? Only by process presence — no curl (HTTP can
     # false-negative under heavy load).
-    if ! pgrep -f "$SERVER_PATTERN" >/dev/null 2>&1; then
-        # No fault grep matched above + process gone = clean exit (drain).
-        # Covers both stop_atom_server (server mode) and simple_inference
-        # finishing its prompts (offline mode).
+    if pgrep -f "$SERVER_PATTERN" >/dev/null 2>&1; then
+        ever_seen=1
+    else
+        if [ "$ever_seen" -eq 0 ]; then
+            # Launcher script still in pre-exec setup (GPU cleanup, cache prep,
+            # initial model load). Don't mistake "not started yet" for "drained".
+            if [ "$i" -ge "$STARTUP_ITERS" ]; then
+                echo "[t=$((i*POLL))s] workload python never appeared in ${STARTUP_MAX_MIN} min — giving up (exit 4)"
+                exit 4
+            fi
+            echo "[t=$((i*POLL))s] waiting for workload python to exec (startup ${i}/${STARTUP_ITERS})"
+            continue
+        fi
+        # Process was seen, now gone, no fault → clean drain. Covers both
+        # stop_atom_server (server mode) and simple_inference finishing its
+        # prompts (offline mode).
         echo "[t=$((i*POLL))s] workload process exited cleanly — DRAINED"
         exit 0
     fi


### PR DESCRIPTION
## Summary

Bundles V4 Compressor flydsl integration with a couple of supporting debug/tooling changes from a prior session into one PR. Independent of the sparse paged_decode rewrite (#936).

### Compressor flydsl integration
- `atom/model_ops/v4_kernels/fused_compress.py`: wire optional flydsl drop-in (`flydsl_fused_compress_attn` + `flydsl_hca_compress_attn`) for V4-Pro Compressor Main BF16 + Indexer FP8. Triton fallback when the shape doesn't match a validated config (head_dim ∈ {128, 512}, rope_head_dim=64, overlap=1, ratio=4).
- `atom/utils/envs.py`: `ATOM_FUSED_COMPRESS_USE_FLYDSL` ∈ {`auto`, `always`, `never`}. `auto` (default) picks flydsl when shape supports it; `never` pins Triton; `always` errors on unsupported.
- `atom/model_ops/attentions/deepseek_v4_attn.py` + `atom/model_ops/v4_kernels/compress_plan.py`: comment/docstring updates for the decode-tight compress plan capacity formula `bs * ceil((1 + max_spec_steps) / ratio)` and the `ring_extra` slack rationale (validated via `ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL=1`).

### Debug + tooling
- `atom/spec_decode/eagle.py` + `atom/utils/envs.py`: add `ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL` toggle. `EagleProposer.propose()` short-circuits the draft model forward and returns canned `draft_token_ids` → forces 100% rejection. Used to validate that Compressor ring slack is sufficient even in the worst aliasing case.
- `scripts/wait_infer_drain.sh`: add optional `STARTUP_MAX_MIN` positional arg (default `MAX_MIN`) so callers can give a long startup budget without inflating the per-iter hang threshold.

## Test plan

- [x] **GSM8K MTP3 V4-Pro accuracy — 3 trials** with flydsl Compressor enabled (default `auto`): `0.9469 / 0.9462 / 0.9484` (mean 0.9472). Compared to 3-trial `main` baseline `0.9447 / 0.9469 / 0.9507` (mean 0.9474). Difference −0.0003, `|t| ≈ 0.14` — statistically indistinguishable.
- [x] `ATOM_FUSED_COMPRESS_USE_FLYDSL=never` falls back cleanly to Triton (exercised during the base-config baseline runs).
- [ ] CI