### PR TITLE
ci: reuse locked model downloader for benchmark

### DIFF
--- a/.github/scripts/download_model_with_lock.sh
+++ b/.github/scripts/download_model_with_lock.sh
@@ -293,18 +293,28 @@ start_progress_reporter
   export MODEL_ID REMOTE_REVISION STAGING_DIR
   timeout --signal=TERM --kill-after=5m "${MODEL_DOWNLOAD_TIMEOUT}" python3 - <<'PY'
 import os
+import sys
 
-from huggingface_hub import snapshot_download
-
+model_id = os.environ["MODEL_ID"]
 revision = os.environ.get("REMOTE_REVISION") or None
 token = os.environ.get("HF_TOKEN") or None
 
-snapshot_download(
-    repo_id=os.environ["MODEL_ID"],
-    revision=revision,
-    local_dir=os.environ["STAGING_DIR"],
-    token=token,
-)
+try:
+    from huggingface_hub import snapshot_download
+
+    snapshot_download(
+        repo_id=model_id,
+        revision=revision,
+        local_dir=os.environ["STAGING_DIR"],
+        token=token,
+    )
+except Exception as exc:
+    print(
+        f"Failed to download model '{model_id}'"
+        f" at revision '{revision or 'default'}': {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 PY
 ) &
 DOWNLOAD_PID="$!"

--- a/.github/scripts/download_model_with_lock.sh
+++ b/.github/scripts/download_model_with_lock.sh
@@ -46,14 +46,14 @@ print_dir_snapshot() {
   local size
   local file_count
   size="$(du -sh "${dir}" 2>/dev/null | awk '{print $1}')"
-  file_count="$(find "${dir}" -type f 2>/dev/null | wc -l | tr -d ' ')"
-  log "Directory snapshot for ${dir}: size=${size:-0} files=${file_count:-0}"
-  find "${dir}" -maxdepth 2 -type f 2>/dev/null | sort | head -20 | sed 's/^/[model-download]   /' || true
+  file_count="$(find "${dir}" \( -type f -o -type l \) 2>/dev/null | wc -l | tr -d ' ')"
+  log "Directory snapshot for ${dir}: size=${size:-0} files_or_links=${file_count:-0}"
+  find "${dir}" -maxdepth 2 \( -type f -o -type l \) 2>/dev/null | sort | head -20 | sed 's/^/[model-download]   /' || true
 }
 
 has_model_payload() {
   local dir="$1"
-  find "${dir}" -type f \
+  find "${dir}" \( -type f -o -type l \) \
     ! -name 'config.json' \
     ! -name '.atom_download_complete' \
     ! -name '.download-complete' \

--- a/.github/scripts/download_model_with_lock.sh
+++ b/.github/scripts/download_model_with_lock.sh
@@ -290,13 +290,22 @@ start_progress_reporter
 
 (
   export HF_HUB_ENABLE_HF_TRANSFER=1
-  if [ -n "${REMOTE_REVISION}" ]; then
-    timeout --signal=TERM --kill-after=5m "${MODEL_DOWNLOAD_TIMEOUT}" \
-      hf download "${MODEL_ID}" --revision "${REMOTE_REVISION}" --local-dir "${STAGING_DIR}"
-  else
-    timeout --signal=TERM --kill-after=5m "${MODEL_DOWNLOAD_TIMEOUT}" \
-      hf download "${MODEL_ID}" --local-dir "${STAGING_DIR}"
-  fi
+  export MODEL_ID REMOTE_REVISION STAGING_DIR
+  timeout --signal=TERM --kill-after=5m "${MODEL_DOWNLOAD_TIMEOUT}" python3 - <<'PY'
+import os
+
+from huggingface_hub import snapshot_download
+
+revision = os.environ.get("REMOTE_REVISION") or None
+token = os.environ.get("HF_TOKEN") or None
+
+snapshot_download(
+    repo_id=os.environ["MODEL_ID"],
+    revision=revision,
+    local_dir=os.environ["STAGING_DIR"],
+    token=token,
+)
+PY
 ) &
 DOWNLOAD_PID="$!"
 wait "${DOWNLOAD_PID}"

--- a/.github/scripts/download_model_with_lock.sh
+++ b/.github/scripts/download_model_with_lock.sh
@@ -306,6 +306,7 @@ try:
         repo_id=model_id,
         revision=revision,
         local_dir=os.environ["STAGING_DIR"],
+        local_dir_use_symlinks=False,
         token=token,
     )
 except Exception as exc:

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -250,11 +250,33 @@ jobs:
           echo "Docker: ${DOCKER_IMAGE}"
 
       - name: Download models
+        timeout-minutes: 150
         run: |
+          set -euo pipefail
           if [ -d "/models" ]; then
-            docker exec -e HF_TOKEN=${{ secrets.AMD_HF_TOKEN }} atom-benchmark bash -lc \
-              "hf download ${{ env.MODEL_PATH }} --local-dir /models/${{ env.MODEL_PATH }}" || exit 1
+            model_dir="/models/${MODEL_PATH}"
+            echo "/models directory found, checking cache and lock-protected download for ${model_dir}"
+            if ! docker exec \
+              -e HF_TOKEN="${HF_TOKEN:-}" \
+              -e MODEL_ID="${MODEL_PATH}" \
+              -e TARGET_DIR="${model_dir}" \
+              -e MODEL_DOWNLOAD_TIMEOUT="${MODEL_DOWNLOAD_TIMEOUT}" \
+              -e MODEL_LOCK_WAIT_SECONDS="${MODEL_LOCK_WAIT_SECONDS}" \
+              -e MODEL_LOCK_POLL_INTERVAL="${MODEL_LOCK_POLL_INTERVAL}" \
+              -e MODEL_PROGRESS_INTERVAL="${MODEL_PROGRESS_INTERVAL}" \
+              atom-benchmark bash -lc 'bash /workspace/.github/scripts/download_model_with_lock.sh "$MODEL_ID" "$TARGET_DIR"'; then
+              echo "Model download failed for '${MODEL_PATH}'. Aborting."
+              exit 1
+            fi
+          else
+            echo "/models directory not found, skipping model download"
           fi
+        env:
+          HF_TOKEN: ${{ secrets.AMD_HF_TOKEN }}
+          MODEL_DOWNLOAD_TIMEOUT: "30m"
+          MODEL_LOCK_WAIT_SECONDS: "1800"
+          MODEL_LOCK_POLL_INTERVAL: "30"
+          MODEL_PROGRESS_INTERVAL: "60"
 
       - name: Run benchmark
         timeout-minutes: 60
@@ -601,13 +623,32 @@ jobs:
           CELL_ENV_VARS: ${{ matrix.cell.env_vars }}
 
       - name: Download model
+        timeout-minutes: 150
         run: |
+          set -euo pipefail
           if [ -d "/models" ]; then
-            echo "=== Downloading ${{ matrix.cell.model_path }} ==="
-            docker exec -e HF_TOKEN=${{ secrets.AMD_HF_TOKEN }} atom-regression bash -lc \
-              "hf download ${{ matrix.cell.model_path }} --local-dir /models/${{ matrix.cell.model_path }}" \
-              || echo "::warning::Failed to download ${{ matrix.cell.model_path }}, will use HF online"
+            model_dir="/models/${{ matrix.cell.model_path }}"
+            echo "/models directory found, checking cache and lock-protected download for ${model_dir}"
+            if ! docker exec \
+              -e HF_TOKEN="${HF_TOKEN:-}" \
+              -e MODEL_ID="${{ matrix.cell.model_path }}" \
+              -e TARGET_DIR="${model_dir}" \
+              -e MODEL_DOWNLOAD_TIMEOUT="${MODEL_DOWNLOAD_TIMEOUT}" \
+              -e MODEL_LOCK_WAIT_SECONDS="${MODEL_LOCK_WAIT_SECONDS}" \
+              -e MODEL_LOCK_POLL_INTERVAL="${MODEL_LOCK_POLL_INTERVAL}" \
+              -e MODEL_PROGRESS_INTERVAL="${MODEL_PROGRESS_INTERVAL}" \
+              atom-regression bash -lc 'bash /workspace/.github/scripts/download_model_with_lock.sh "$MODEL_ID" "$TARGET_DIR"'; then
+              echo "::warning::Failed to download ${{ matrix.cell.model_path }}, will use HF online"
+            fi
+          else
+            echo "/models directory not found, skipping model download"
           fi
+        env:
+          HF_TOKEN: ${{ secrets.AMD_HF_TOKEN }}
+          MODEL_DOWNLOAD_TIMEOUT: "30m"
+          MODEL_LOCK_WAIT_SECONDS: "1800"
+          MODEL_LOCK_POLL_INTERVAL: "30"
+          MODEL_PROGRESS_INTERVAL: "60"
 
       - name: Launch server
         run: |


### PR DESCRIPTION
## Summary
- Route ATOM Benchmark model downloads through the shared lock-protected downloader used by ATOM Test.
- Use `huggingface_hub.snapshot_download` inside the downloader to avoid `hf download` CLI exit handling failures after successful downloads.
- Apply the same downloader path to benchmark regression reruns while preserving their existing fallback behavior.

## Test plan
- `bash -n .github/scripts/download_model_with_lock.sh`
- Parsed `.github/workflows/atom-benchmark.yaml` with PyYAML
- Smoke-tested cached-model path for `.github/scripts/download_model_with_lock.sh`
- `git diff --check`