### PR TITLE
kv_transfer: add OFFLOAD subsystem + LMCacheOffloadConnector for standalone

### DIFF
--- a/atom/kv_transfer/disaggregation/__init__.py
+++ b/atom/kv_transfer/disaggregation/__init__.py
@@ -11,6 +11,7 @@ rather than reaching into submodules directly.
 from atom.kv_transfer.disaggregation.aggregator import KVOutputAggregator
 from atom.kv_transfer.disaggregation.base import (
     KVConnectorBase,
+    KVConnectorRole,
     KVConnectorSchedulerBase,
 )
 from atom.kv_transfer.disaggregation.factory import KVConnectorFactory
@@ -22,6 +23,7 @@ from atom.kv_transfer.disaggregation.types import (
 
 __all__ = [
     "KVConnectorBase",
+    "KVConnectorRole",
     "KVConnectorSchedulerBase",
     "KVConnectorFactory",
     "KVConnectorOutput",

--- a/atom/kv_transfer/disaggregation/aggregator.py
+++ b/atom/kv_transfer/disaggregation/aggregator.py
@@ -50,6 +50,9 @@ class KVOutputAggregator:
         self._world_size = world_size
         self._seen_sending: dict[str, set[int]] = {}
         self._seen_recving: dict[str, set[int]] = {}
+        # ``failed_recving`` uses any-rank-emit semantics (see aggregate
+        # docstring), so it doesn't need per-rank set tracking — we only
+        # need to suppress duplicate emissions within the same step.
 
     @property
     def world_size(self) -> int:
@@ -64,7 +67,10 @@ class KVOutputAggregator:
 
         Returns:
             A new :class:`KVConnectorOutput` containing only request IDs
-            that have been reported as finished by **all** workers.
+            that have been reported as finished by **all** workers, plus
+            any request IDs that **any** worker reported as failed (load
+            failures must propagate immediately — if even one TP shard is
+            missing KV, the request cannot forward correctly).
         """
         if not worker_outputs:
             return KVConnectorOutput()
@@ -88,6 +94,18 @@ class KVOutputAggregator:
             if len(workers) >= self._world_size
         }
 
+        # failed_recving: any-rank-emit. If rank R can't load its KV
+        # shard, the whole TP forward for that req is wrong even if the
+        # other ranks succeeded — emit immediately and drop any pending
+        # finished_recving tracking for the same req so the same req
+        # isn't both "failed" and "succeeded" in the scheduler's view.
+        failed_recving: set[str] = set()
+        for wo in worker_outputs:
+            if wo.failed_recving:
+                failed_recving.update(wo.failed_recving)
+        for rid in failed_recving:
+            self._seen_recving.pop(rid, None)
+
         for rid in done_sending:
             del self._seen_sending[rid]
         for rid in done_recving:
@@ -96,6 +114,7 @@ class KVOutputAggregator:
         return KVConnectorOutput(
             finished_sending=done_sending,
             finished_recving=done_recving,
+            failed_recving=failed_recving,
         )
 
     def reset(self) -> None:

--- a/atom/kv_transfer/disaggregation/base.py
+++ b/atom/kv_transfer/disaggregation/base.py
@@ -19,15 +19,32 @@ Two roles are defined:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Any
 
 from atom.kv_transfer.disaggregation.types import ConnectorMetadata
+
+
+class KVConnectorRole(str, Enum):
+    """Concrete role a connector plays inside the engine.
+
+    PD connectors (Mooncake/MoRIIO) historically routed via ``is_producer``;
+    that binary still works and the default ``PD_PRODUCER`` value is just a
+    placeholder for them. Offload connectors (CPU/NVMe-backed L2/L3 store)
+    set ``role = OFFLOAD`` so the scheduler can skip producer/consumer-only
+    invariants that only make sense for cross-node KV transfer.
+    """
+
+    PD_PRODUCER = "pd_producer"  # prefill node in P/D disaggregation
+    PD_CONSUMER = "pd_consumer"  # decode node in P/D disaggregation
+    OFFLOAD = "offload"  # local second/third-tier store
 
 
 class KVConnectorBase(ABC):
     """Worker-side KV connector interface (one instance per TP rank)."""
 
     is_producer: bool
+    role: KVConnectorRole = KVConnectorRole.PD_PRODUCER
 
     @abstractmethod
     def register_kv_caches(
@@ -69,6 +86,7 @@ class KVConnectorSchedulerBase(ABC):
     """Scheduler-side KV connector interface."""
 
     is_producer: bool
+    role: KVConnectorRole = KVConnectorRole.PD_PRODUCER
 
     @abstractmethod
     def get_num_new_matched_tokens(self, seq: Any) -> tuple[int, bool]:

--- a/atom/kv_transfer/disaggregation/types.py
+++ b/atom/kv_transfer/disaggregation/types.py
@@ -59,22 +59,35 @@ class KVConnectorOutput:
     Attributes:
         finished_sending: Request IDs whose KV send completed on this worker.
         finished_recving: Request IDs whose KV receive completed on this worker.
+        failed_recving: Request IDs whose KV receive was attempted but could
+            not be satisfied (e.g. an OFFLOAD pool eviction between the
+            scheduler-side optimistic lookup and the worker-side load).
+            The scheduler must drop its mirror state for these requests
+            and re-prefill them; leaving them in WAITING_FOR_REMOTE_KVS
+            with uninitialized GPU blocks would let attention read garbage
+            KV and corrupt generation.
         expected_finished_count: How many finished notifications should be
             expected per request (used by the aggregator).
     """
 
     finished_sending: set[str] = field(default_factory=set)
     finished_recving: set[str] = field(default_factory=set)
+    failed_recving: set[str] = field(default_factory=set)
     expected_finished_count: int = 0
 
     def is_empty(self) -> bool:
         """Return True if no transfers finished on this worker."""
-        return not self.finished_sending and not self.finished_recving
+        return (
+            not self.finished_sending
+            and not self.finished_recving
+            and not self.failed_recving
+        )
 
     def __repr__(self) -> str:
         return (
             f"KVConnectorOutput(sending={self.finished_sending}, "
-            f"recving={self.finished_recving})"
+            f"recving={self.finished_recving}, "
+            f"failed_recving={self.failed_recving})"
         )
 
 

--- a/atom/kv_transfer/offload/README.md
+++ b/atom/kv_transfer/offload/README.md
@@ -1,0 +1,98 @@
+# Local KV Cache Offload (CPU DRAM / NVMe)
+
+This module adds a *local* second/third-tier KV cache to ATOM's standalone
+serving stack — CPU DRAM as L2, optional NVMe as L3, sitting behind the HBM
+paged prefix cache. It's the standalone-mode counterpart to the
+[ATOM-as-vLLM-plugin + LMCache recipe](../../../recipes/atom_vllm/LMCache-KV-Cache-Offload.md):
+that path borrows vLLM's `KVConnectorV1` so LMCache plugs into vLLM, but
+leaves ATOM standalone without any offload story. This module fills that
+gap.
+
+## When to use
+
+Same workload profile as the plugin-mode recipe:
+
+* Multi-turn / agentic serving where conversations reuse 90–97 % of their
+  prefix across turns (Claude Code, Cursor, Devin-style agents).
+* Long prompts (20K–150K tokens), short outputs.
+* Many concurrent users contending for HBM KV cache.
+
+Low-concurrency setups whose working set already fits in HBM should stay on
+ATOM's native prefix cache — offload adds D2H/H2D copy overhead that's not
+amortized when there's no eviction pressure.
+
+## Architecture
+
+```
++-----------------------------+
+|   Scheduler (PD-style hooks)|
+|  get_num_new_matched_tokens |  --> OffloadConnectorScheduler.lookup_external_hits
+|  update_state_after_alloc   |  --> OffloadConnectorScheduler.queue_load
+|  postprocess (hash_blocks)  |  --> OffloadConnectorScheduler.queue_save
+|  build_connector_meta       |  --> OffloadConnectorMetadata
++-----------------------------+
+              |
+              | ScheduledBatch.connector_meta_output
+              v
++-----------------------------+
+|         EngineCore          |
+|  process_kvconnector_output |
++-----------------------------+
+              |
+              v
++------- worker (per TP rank) -----+
+| OffloadConnector.start_load_kv   |  --> H2D loads + D2H saves
+| OffloadConnector.get_finished    |  --> (done_saving, done_loading)
++----------------------------------+
+              |
+              v   KVConnectorOutput aggregated across ranks
+              |   via KVOutputAggregator (already wired by engine_core)
+              v
++-----------------------------+
+| Scheduler._update_from_     |
+| kv_xfer_finished            |  --> finished_recving wakes
+|                             |      WAITING_FOR_REMOTE_KVS seqs
++-----------------------------+
+```
+
+Key differences from the existing `atom/kv_transfer/disaggregation/` path:
+
+| Concern | PD disaggregation | OFFLOAD |
+|---|---|---|
+| Store location | Remote node (RDMA via Mooncake/MoRIIO) | Local CPU DRAM / NVMe |
+| Transfer protocol | RDMA push (producer) or pull (consumer) | HIP `memcpy` / pinned buffers |
+| Block free policy | Producer defers free until send completes | Free immediately; save is independent D2H copy |
+| `KVConnectorRole` | `PD_PRODUCER` / `PD_CONSUMER` | `OFFLOAD` |
+| Per-block hash key | Anchored by sequence id + remote tag | `BlockManager.compute_hash` (same as in-HBM prefix cache) |
+| Metadata shape | `ConnectorMetadata` with `remote_host`/`port` | `OffloadConnectorMetadata` with `block_ids`/`hashes` only |
+
+The scheduler's role split is preserved (`get_num_new_matched_tokens`,
+`update_state_after_alloc`, `build_connector_meta`, `request_finished`,
+`_update_from_kv_xfer_finished`), so adding offload doesn't introduce a
+second scheduling path — only branching on `KVConnectorRole`.
+
+## Implementations
+
+* `atom.kv_transfer.offload.lmcache.LMCacheOffloadConnector` — wraps
+  [LMCache](https://github.com/LMCache/LMCache) (built from source with
+  `BUILD_WITH_HIP=1` so its HIP `c_ops` backend is used for KV transfer).
+  Bypasses LMCache's `LMCacheConnectorV1` to avoid pulling in vLLM type
+  dependencies — talks directly to the engine-level API + `lmcache.c_ops`.
+
+## Cache key consistency
+
+The OFFLOAD connector uses the *same* xxhash64 chain that ATOM's HBM
+prefix cache uses (`BlockManager.compute_hash`), so HBM hits and offload
+hits live in the same hash space. The scheduler-side lookup order:
+
+1. `BlockManager.can_allocate(seq)` — HBM hit, no copy required.
+2. On miss, `OffloadConnectorScheduler.lookup_external_hits` — CPU/NVMe
+   hit triggers H2D.
+3. On double miss, real prefill runs; finalized blocks are queued for
+   save via `queue_save` after `hash_blocks` publishes their hash.
+
+This means TP workers must produce identical hash chains for identical
+prompts. The xxhash chain is deterministic, but `PYTHONHASHSEED=0` is
+still required at engine start to avoid Python-level hash randomization
+leaking into any auxiliary data structure the connector may use; the
+LMCache connector enforces this at `__init__`.

--- a/atom/kv_transfer/offload/README.md
+++ b/atom/kv_transfer/offload/README.md
@@ -61,7 +61,7 @@ Key differences from the existing `atom/kv_transfer/disaggregation/` path:
 |---|---|---|
 | Store location | Remote node (RDMA via Mooncake/MoRIIO) | Local CPU DRAM / NVMe |
 | Transfer protocol | RDMA push (producer) or pull (consumer) | HIP `memcpy` / pinned buffers |
-| Block free policy | Producer defers free until send completes | Free immediately; save is independent D2H copy |
+| Block free policy | Producer defers free until send completes | Defer only while an async D2H save is pending |
 | `KVConnectorRole` | `PD_PRODUCER` / `PD_CONSUMER` | `OFFLOAD` |
 | Per-block hash key | Anchored by sequence id + remote tag | `BlockManager.compute_hash` (same as in-HBM prefix cache) |
 | Metadata shape | `ConnectorMetadata` with `remote_host`/`port` | `OffloadConnectorMetadata` with `block_ids`/`hashes` only |
@@ -70,6 +70,31 @@ The scheduler's role split is preserved (`get_num_new_matched_tokens`,
 `update_state_after_alloc`, `build_connector_meta`, `request_finished`,
 `_update_from_kv_xfer_finished`), so adding offload doesn't introduce a
 second scheduling path — only branching on `KVConnectorRole`.
+
+## Save completion and block free
+
+`queue_save(request_id, published)` only records scheduler-side metadata.
+The actual D2H save starts later on each worker when
+`EngineCore.process_kvconnector_output` dispatches the
+`OffloadConnectorMetadata` snapshot to `LMCacheOffloadConnector.start_load_kv`.
+
+The worker judges save completion with a CUDA event:
+
+1. `start_load_kv` enqueues `dst.copy_(src, non_blocking=True)` on the
+   connector's copy stream.
+2. After all K/V layer copies for a request are enqueued, it records
+   `torch.cuda.Event()` on that stream and stores `(req_id, "save", evt)`.
+3. `get_finished()` polls the event via `evt.query()`. Completed save
+   events become `done_save`.
+4. `ModelRunner.async_proc_aggregation()` returns `done_save` as
+   `KVConnectorOutput.finished_sending`.
+5. `Scheduler._update_from_kv_xfer_finished()` treats offload
+   `finished_sending` as the point where a pending save is complete and
+   any deferred GPU blocks may be returned to `BlockManager`.
+
+This means a finished request with no queued offload save still frees its
+blocks immediately, but a request with a pending async D2H save keeps its
+source GPU blocks alive until `finished_sending` arrives.
 
 ## Implementations
 

--- a/atom/kv_transfer/offload/__init__.py
+++ b/atom/kv_transfer/offload/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Local KV-cache offload (CPU DRAM / NVMe) for ATOM standalone serving.
+
+Importing this package registers all built-in offload backends with the
+shared :class:`atom.kv_transfer.disaggregation.factory.KVConnectorFactory`
+so they can be selected via ``--kv-transfer-config '{"kv_connector": ...}'``
+on the command line. See the package README for the data flow and the
+``LMCacheOffloadConnector`` recipe for end-to-end setup.
+"""
+
+from atom.kv_transfer.offload.base import (
+    OffloadConnectorBase,
+    OffloadConnectorSchedulerBase,
+)
+from atom.kv_transfer.offload.types import (
+    OffloadConnectorMetadata,
+    OffloadReqMeta,
+)
+
+__all__ = [
+    "OffloadConnectorBase",
+    "OffloadConnectorSchedulerBase",
+    "OffloadConnectorMetadata",
+    "OffloadReqMeta",
+]
+
+# Backend registrations happen here so a bare `import atom.kv_transfer.offload`
+# arms every built-in. The concrete lmcache module isn't imported eagerly
+# (avoids pulling lmcache at engine start if offload is not in use); the
+# factory uses the module string and lazy-imports on instantiation.
+from atom.kv_transfer.disaggregation.factory import KVConnectorFactory
+
+KVConnectorFactory.register(
+    "lmcache_offload",
+    worker_module="atom.kv_transfer.offload.lmcache.lmcache_connector",
+    worker_class="LMCacheOffloadConnector",
+    scheduler_module="atom.kv_transfer.offload.lmcache.lmcache_connector",
+    scheduler_class="LMCacheOffloadConnectorScheduler",
+)

--- a/atom/kv_transfer/offload/base.py
+++ b/atom/kv_transfer/offload/base.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Abstract base classes for KV-cache offload connectors.
+
+OFFLOAD connectors plug into the same engine hooks as PD-disaggregation
+connectors (KVConnectorFactory registry, scheduler-side metadata, worker-
+side per-step dispatch) but represent a *local* L2/L3 store (CPU DRAM,
+NVMe) instead of a remote prefill/decode peer. See the package README for
+the full data flow.
+
+Worker-side (one per TP rank): owns the external store, issues D2H copies
+on save and H2D copies on load.
+
+Scheduler-side: looks up external-store hits during prefill admission,
+queues blocks for save after BlockManager publishes new hashes, packages
+both into per-step metadata.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any
+
+from atom.kv_transfer.disaggregation.base import (
+    KVConnectorBase,
+    KVConnectorRole,
+    KVConnectorSchedulerBase,
+)
+from atom.kv_transfer.offload.types import OffloadConnectorMetadata
+
+if TYPE_CHECKING:
+    from atom.model_engine.sequence import Sequence
+
+
+class OffloadConnectorBase(KVConnectorBase):
+    """Worker-side interface for a local KV-offload backend."""
+
+    role = KVConnectorRole.OFFLOAD
+    # OFFLOAD connectors are neither PD producer nor consumer; this field
+    # is kept for back-compat with code paths still gating on the binary,
+    # but the scheduler routes via `role` for offload-specific behavior.
+    is_producer = False
+
+    @abstractmethod
+    def start_load_kv(self, metadata: OffloadConnectorMetadata) -> None:
+        """Issue async H2D copies for pending loads, async D2H for pending
+        saves. Called once per engine step on each worker. The single entry
+        point matches the existing PD dispatch (``process_kvconnector_output``
+        in EngineCore) so no new IPC channel is required.
+        """
+        ...
+
+    @abstractmethod
+    def get_finished(self) -> tuple[set[str], set[str]]:
+        """Return ``(done_saving, done_loading)`` request IDs since the last
+        call. ``done_loading`` IDs propagate back to the scheduler so seqs
+        waiting in ``WAITING_FOR_REMOTE_KVS`` can resume.
+        """
+        ...
+
+
+class OffloadConnectorSchedulerBase(KVConnectorSchedulerBase):
+    """Scheduler-side interface for a local KV-offload backend."""
+
+    role = KVConnectorRole.OFFLOAD
+    is_producer = False
+
+    def bind_block_manager(self, block_manager: Any) -> None:
+        """Give the connector a reference to the engine's BlockManager.
+
+        Default impl stashes it as ``self.block_manager``. Override only if
+        a connector needs to register listeners or precompute geometry.
+        Called by ``Scheduler.__init__`` after both objects exist.
+        """
+        self.block_manager = block_manager
+
+    @abstractmethod
+    def lookup_external_hits(self, seq: "Sequence", block_hashes: list[int]) -> int:
+        """Return the number of leading blocks of ``block_hashes`` that are
+        present in the external store. ``block_hashes`` is the
+        ``BlockManager.compute_hash`` chain for ``seq``'s prompt blocks.
+
+        The scheduler calls this from ``get_num_new_matched_tokens`` after
+        the in-HBM prefix-cache check has run; a positive return value
+        causes the seq to be marked ``WAITING_FOR_REMOTE_KVS`` until the
+        worker's load completes.
+        """
+        ...
+
+    @abstractmethod
+    def queue_save(self, request_id: str, published: list[tuple[int, int]]) -> None:
+        """Enqueue freshly-finalized blocks for D2H save.
+
+        Called by the scheduler from ``postprocess`` after
+        ``BlockManager.hash_blocks`` returns the list of
+        ``(block_id, hash)`` pairs newly published this step.
+        Implementations may skip blocks already known to the external store
+        (no-op if the connector tracks its own index).
+        """
+        ...
+
+    @abstractmethod
+    def queue_load(
+        self, request_id: str, block_ids: list[int], block_hashes: list[int]
+    ) -> None:
+        """Enqueue blocks to be hydrated from the external store into the
+        given GPU paged-block slots. Called by the scheduler from
+        ``update_state_after_alloc`` once BlockManager has assigned
+        destination slot ids.
+        """
+        ...
+
+    @abstractmethod
+    def build_connector_meta(self) -> OffloadConnectorMetadata | None:
+        """Drain accumulated save/load queues into a per-step metadata
+        snapshot for dispatch to workers. Returning ``None`` (or an empty
+        metadata) signals no work for this step.
+        """
+        ...

--- a/atom/kv_transfer/offload/base.py
+++ b/atom/kv_transfer/offload/base.py
@@ -60,6 +60,19 @@ class OffloadConnectorBase(KVConnectorBase):
         """
         ...
 
+    def get_failed_load(self) -> set[str]:
+        """Return request IDs whose load attempt could not be satisfied
+        since the last call (e.g. the optimistic scheduler-side mirror
+        said HIT but the worker's pool no longer has the block).
+
+        Default: empty set. Backends that may evict between scheduler
+        lookup and worker load (FIFO/LRU pools) MUST override and surface
+        the failed req_ids here, otherwise the scheduler will leave the
+        request in ``WAITING_FOR_REMOTE_KVS`` with uninitialized GPU
+        blocks and attention will read garbage KV.
+        """
+        return set()
+
 
 class OffloadConnectorSchedulerBase(KVConnectorSchedulerBase):
     """Scheduler-side interface for a local KV-offload backend."""
@@ -119,3 +132,19 @@ class OffloadConnectorSchedulerBase(KVConnectorSchedulerBase):
         metadata) signals no work for this step.
         """
         ...
+
+    def handle_failed_load(self, request_id: str) -> list[int]:
+        """Called by the scheduler when the worker reports a load failure
+        for ``request_id`` (pool eviction between the optimistic mirror
+        lookup and the actual H2D copy). The scheduler-side connector
+        must drop any mirror entries for the request's external hashes
+        so a future lookup does not re-hit the same stale entries, and
+        must clear any per-request stash that ``update_state_after_alloc``
+        populated.
+
+        Returns the list of hashes that were evicted from the mirror —
+        for logging only.
+
+        Default: no-op (PD and OFFLOAD-with-no-eviction backends).
+        """
+        return []

--- a/atom/kv_transfer/offload/lmcache/__init__.py
+++ b/atom/kv_transfer/offload/lmcache/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""LMCache-backed offload connector.
+
+Loaded lazily via the KVConnectorFactory registry entry in
+``atom.kv_transfer.offload.__init__``. Importing this submodule directly
+also works (and forces lmcache + c_ops to be imported at process start).
+"""
+
+from atom.kv_transfer.offload.lmcache.lmcache_connector import (
+    LMCacheOffloadConnector,
+    LMCacheOffloadConnectorScheduler,
+)
+
+__all__ = [
+    "LMCacheOffloadConnector",
+    "LMCacheOffloadConnectorScheduler",
+]

--- a/atom/kv_transfer/offload/lmcache/lmcache_connector.py
+++ b/atom/kv_transfer/offload/lmcache/lmcache_connector.py
@@ -2,28 +2,29 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 """
-LMCache-backed local KV cache offload for ATOM standalone serving.
+Per-rank CPU offload backend for ATOM standalone serving.
 
-Talks directly to ``lmcache.c_ops`` (the HIP-built transfer kernels) rather
-than going through ``lmcache.integration.vllm.vllm_v1_adapter`` — that path
-pulls vllm types into the import graph, which we want to avoid for the
-standalone build. ATOM owns the hash-to-CPU-slot index; LMCache provides
-the pinned-memory allocator and the H2D/D2H block-transfer kernel.
-
-Layout (M3 first commit — transfer kernels stubbed, see TODOs):
+Owns a single contiguous pinned CPU pool, allocated via
+``lmcache.c_ops.alloc_pinned_ptr`` — direct ``cudaHostRegister`` on raw
+``malloc()``-ed memory, bypassing PyTorch's pinned host allocator and its
+power-of-two bucket rounding. ATOM's per-layer K/V tensors use AITER
+swizzled layouts (K: ``(NB, NH, HD/x, BS, x)``, V: ``(NB, NH, HD, BS)``)
+that match none of LMCache's ``GPUKVFormat`` enums, so D2H/H2D copies stay
+on byte-view ``dst.copy_(src, non_blocking=True)`` over a dedicated copy
+stream rather than ``lmcache.c_ops.multi_layer_kv_transfer``.
 
 * Worker side: pinned CPU pool of N slots × sizeof(one paged block × all
   layers, K and V). ``register_kv_caches`` learns the per-layer geometry
   and (re)sizes the pool. ``start_load_kv`` is the single per-step entry
   the EngineCore dispatches to (matches the existing PD path).
-* Scheduler side: an *optimistic* mirror of the worker's index — entries
-  appear when the scheduler queues a save, are removed if the worker
-  reports a failed load. Stale mirror entries are safe: a load miss just
-  triggers re-prefill, never wrong KV.
+* Scheduler side: an *optimistic* mirror of the worker's index. Entries
+  appear when the scheduler queues a save; when the worker can't satisfy
+  a load (pool eviction), it reports the request via ``get_finished``'s
+  third return value ``failed_load`` and the scheduler drops the mirror
+  entry plus re-prefills the request.
 
-NVMe (L3) tier and proper LRU eviction are deferred to M5; the first cut
-uses a fixed-size FIFO pool. The known-good ``lmcache.engine.LMCacheEngine``
-wrapper is the natural upgrade path once we want disk-tier and metrics.
+NVMe (L3) tier, real LRU eviction (vs FIFO), and full LMCacheEngine
+integration are deferred — see ``atom_lmcache_integration_plan.md``.
 """
 
 from __future__ import annotations
@@ -141,11 +142,15 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
         self._v_uint8_views: list[Any] = []
 
         # CPU pool — allocated lazily in register_kv_caches once geometry
-        # is known. The pool is a single pinned uint8 tensor of size
-        # `num_slots * bytes_per_block`; slot `s` occupies bytes
+        # is known. The pool is a single contiguous pinned byte buffer of
+        # size `num_slots * bytes_per_block` allocated via
+        # ``c_ops.alloc_pinned_ptr`` (cudaHostRegister on raw malloc);
+        # ``self._cpu_pool`` is a ``torch.frombuffer`` uint8 view over the
+        # same memory, so ``dst.copy_(src, non_blocking=True)`` and offset
+        # slicing keep working unchanged. Slot ``s`` occupies bytes
         # [s * bytes_per_block : (s+1) * bytes_per_block].
-        self._cpu_pool: Any = None  # torch.Tensor, dtype=uint8, pin_memory=True
-        self._cpu_pool_base_ptr: int = 0
+        self._cpu_pool: Any = None  # torch.Tensor view, dtype=uint8
+        self._cpu_pool_base_ptr: int = 0  # raw ptr from c_ops, freed in close()
         self._cpu_pool_total_bytes: int = 0
         self._num_slots: int = 0
         # Hash -> slot index. OrderedDict so we can FIFO-evict on overflow.
@@ -165,6 +170,13 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
         # Per-step completion tracking (request_id sets).
         self._done_saving: set[str] = set()
         self._done_loading: set[str] = set()
+        # Per-step load failures (request had a pool miss between the
+        # scheduler's optimistic lookup and the worker's hash_to_slot
+        # check). Drained by get_failed_load and surfaced to the
+        # scheduler in KVConnectorOutput.failed_recving so the request
+        # can be re-prefilled instead of running attention against an
+        # uninitialized GPU block.
+        self._failed_load: set[str] = set()
 
         logger.info(
             "LMCacheOffloadConnector initialized (rank-local pool=%.2f GB, "
@@ -228,9 +240,7 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
             else:
                 k_bytes = (k.numel() // k.shape[0]) * k.element_size()
                 v_bytes = (
-                    (v.numel() // v.shape[0]) * v.element_size()
-                    if v.numel() > 0
-                    else 0
+                    (v.numel() // v.shape[0]) * v.element_size() if v.numel() > 0 else 0
                 )
             self._k_bytes_per_layer.append(k_bytes)
             self._v_bytes_per_layer.append(v_bytes)
@@ -251,19 +261,40 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
 
         self._num_slots = max(1, self.cpu_bytes_per_rank // self.bytes_per_block)
         self._cpu_pool_total_bytes = self._num_slots * self.bytes_per_block
-        # Plain pinned uint8 tensor; bypasses c_ops.alloc_pinned_ptr so the
-        # storage participates in PyTorch's normal lifetime management. The
-        # c_ops alloc is reserved for the M5 NUMA-aware LMCacheEngine pool.
-        # TODO: Avoid one huge pinned allocation for very large CPU KV caches.
-        # PyTorch's pinned host allocator may round large requests up to the
-        # next power-of-two bucket (e.g. ~100 GB -> 128 GB), causing surprising
-        # RSS/locked-memory pressure. Replace this with a segmented pool or
-        # power-of-two-aware planner before recommending multi-hundred-GB
-        # offload capacity.
-        self._cpu_pool = torch.empty(
-            self._cpu_pool_total_bytes, dtype=torch.uint8, pin_memory=True
+        # Allocate via lmcache.c_ops: a raw malloc() + cudaHostRegister on
+        # exactly self._cpu_pool_total_bytes bytes. This avoids PyTorch's
+        # pinned host allocator (which buckets large requests to the next
+        # power of two and would lock ~128 GB to satisfy a ~100 GB pool).
+        # We then wrap the raw pointer in a uint8 torch.Tensor view so
+        # ``dst.copy_(src, non_blocking=True)`` works unchanged. Lifetime:
+        # the buffer is freed in close()/__del__ via c_ops.free_pinned_ptr;
+        # torch.frombuffer does not own the memory.
+        import ctypes
+
+        from lmcache import c_ops
+
+        # c_ops wants an int device id for cudaHostRegister's flags lookup.
+        # A real torch.Tensor.device is a torch.device with int .index; fake
+        # tensors in tests use a string ("cuda:0"). Fall back to 0 if we
+        # can't extract a usable int — the registration works fine on any
+        # device, the id is only a hint to the driver.
+        view_device = self._k_uint8_views[0].device if self._k_uint8_views else None
+        device_id = getattr(view_device, "index", None)
+        if not isinstance(device_id, int):
+            device_id = 0
+        self._cpu_pool_base_ptr = int(
+            c_ops.alloc_pinned_ptr(self._cpu_pool_total_bytes, device_id)
         )
-        self._cpu_pool_base_ptr = self._cpu_pool.data_ptr()
+        if self._cpu_pool_base_ptr == 0:
+            raise RuntimeError(
+                "c_ops.alloc_pinned_ptr returned NULL — out of pinnable "
+                "host memory? Try lowering kv_transfer_config.cpu_bytes / "
+                "cpu_bytes_per_rank."
+            )
+        buf = (ctypes.c_uint8 * self._cpu_pool_total_bytes).from_address(
+            self._cpu_pool_base_ptr
+        )
+        self._cpu_pool = torch.frombuffer(buf, dtype=torch.uint8)
         self._free_slots = list(range(self._num_slots))
         first_layer_name = next(iter(kv_caches.keys()))
         logger.info(
@@ -394,20 +425,30 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
             )
             with torch.cuda.stream(self._copy_stream):
                 for req_id, meta in metadata.reqs_to_load.items():
-                    missed = 0
+                    # Pre-scan: if ANY block in this req's chain is no longer
+                    # in the worker pool (FIFO-evicted between the scheduler's
+                    # optimistic lookup and now), the whole request fails the
+                    # load. We do NOT enqueue partial H2D copies — the
+                    # corresponding GPU blocks would still be uninitialized
+                    # for the missed positions and attention would read
+                    # garbage. Instead surface req_id in self._failed_load
+                    # so the scheduler drops the mirror entry and re-prefills.
+                    missing_hashes = [
+                        h for h in meta.block_hashes if self.hash_to_slot.get(h, -1) < 0
+                    ]
+                    if missing_hashes:
+                        logger.warning(
+                            "LMCacheOffload: load FAILED for req=%s — "
+                            "%d/%d blocks evicted from CPU pool; re-prefill "
+                            "via scheduler failed_recving.",
+                            req_id,
+                            len(missing_hashes),
+                            len(meta.block_hashes),
+                        )
+                        self._failed_load.add(req_id)
+                        continue
                     for block_id, h in zip(meta.block_ids, meta.block_hashes):
-                        slot = self.hash_to_slot.get(h, -1)
-                        if slot < 0:
-                            # Optimistic mirror said HIT, worker doesn't
-                            # have it (likely FIFO-evicted). Leave the
-                            # paged block uninitialized — the scheduler
-                            # will see this seq finish with wrong KV; in
-                            # practice this only happens if the pool is
-                            # sized too small for the working set. TODO:
-                            # surface miss back so scheduler can drop the
-                            # mirror entry and trigger re-prefill.
-                            missed += 1
-                            continue
+                        slot = self.hash_to_slot[h]
                         cpu_offset = slot * self.bytes_per_block
                         for layer_idx in range(self.num_layers):
                             k_view = self._k_uint8_views[layer_idx]
@@ -429,30 +470,16 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
                                 ]
                                 dst_v.copy_(src_v, non_blocking=True)
                                 cpu_offset += v_bytes
-                    if missed:
-                        logger.warning(
-                            "LMCacheOffload: %d/%d H2D load misses for "
-                            "req=%s (pool eviction; expect wrong KV)",
-                            missed,
-                            len(meta.block_ids),
-                            req_id,
-                        )
                     evt = torch.cuda.Event()
                     evt.record(self._copy_stream)
                     self._pending.append((req_id, "load", evt))
-            # The compute stream must wait for the H2D loads to finish
-            # before reading those paged blocks for attention. Insert the
-            # reverse barrier so the next forward sees fully-loaded KV.
-            # TODO: Align with vLLM SimpleCPUOffload's async-load model.
-            # The scheduler already parks load-hit requests in
-            # WAITING_FOR_REMOTE_KVS and wakes them via finished_recving, so
-            # the request that needs this H2D load should not participate in
-            # the current forward batch. This stream-wide wait is a conservative
-            # batch-level fence and can unnecessarily block unrelated forward
-            # work on the current stream. Prefer relying on per-load CUDA
-            # events + next-step scheduling once the load lifecycle is fully
-            # validated.
-            torch.cuda.current_stream(device).wait_stream(self._copy_stream)
+            # No reverse barrier here: the request that needs this H2D
+            # load is parked in WAITING_FOR_REMOTE_KVS and only re-enters
+            # the next forward batch after get_finished() reports its
+            # load event done (via finished_recving). The current batch
+            # never reads load-target GPU blocks, so a stream-wide fence
+            # would only block unrelated forward work. Per-load CUDA
+            # events + next-step scheduling is the correctness contract.
 
     def get_finished(self) -> tuple[set[str], set[str]]:
         """Drain completed CUDA events into the done sets, then return
@@ -474,6 +501,34 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
         self._done_saving = set()
         self._done_loading = set()
         return done_save, done_load
+
+    def get_failed_load(self) -> set[str]:
+        """Drain accumulated load-failures and return; called by the
+        worker once per step right after ``get_finished``."""
+        failed = self._failed_load
+        self._failed_load = set()
+        return failed
+
+    def close(self) -> None:
+        """Release the cudaHostRegister'd CPU pool. Safe to call twice.
+
+        Drop the torch view first so the pool's refcount goes to zero
+        before unpinning the underlying buffer — otherwise PyTorch could
+        access freed pinned memory during gc.
+        """
+        if self._cpu_pool is not None:
+            self._cpu_pool = None
+        if self._cpu_pool_base_ptr:
+            from lmcache import c_ops
+
+            c_ops.free_pinned_ptr(self._cpu_pool_base_ptr)
+            self._cpu_pool_base_ptr = 0
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001 — destructors must not raise
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -507,6 +562,13 @@ class LMCacheOffloadConnectorScheduler(OffloadConnectorSchedulerBase):
         # Per-seq stash between get_num_new_matched_tokens and
         # update_state_after_alloc, keyed by `id(seq)`.
         self._external_match_stash: dict[int, list[int]] = {}
+        # Per-request memory of the external hashes that were queued for
+        # load via update_state_after_alloc, keyed by str(seq.id). Used by
+        # handle_failed_load to drop the corresponding mirror entries
+        # when the worker reports the load could not be satisfied.
+        # Cleared on successful finished_recving (in request_finished) or
+        # on handle_failed_load.
+        self._external_hashes_by_req: dict[str, list[int]] = {}
         logger.info(
             "LMCacheOffloadConnectorScheduler initialized (chunk_size=%d)",
             self.chunk_size,
@@ -603,9 +665,13 @@ class LMCacheOffloadConnectorScheduler(OffloadConnectorSchedulerBase):
                 seq.num_blocks,
             )
             return
-        self._pending_load[str(seq.id)] = OffloadReqMeta(
+        req_id = str(seq.id)
+        self._pending_load[req_id] = OffloadReqMeta(
             block_ids=dest_block_ids, block_hashes=external_hashes
         )
+        # Remember the hashes so handle_failed_load can drop them from
+        # the mirror if the worker can't satisfy this load.
+        self._external_hashes_by_req[req_id] = list(external_hashes)
 
     def lookup_external_hits(self, seq: "Sequence", block_hashes: list[int]) -> int:
         """Return the longest prefix of ``block_hashes`` known to the
@@ -661,7 +727,23 @@ class LMCacheOffloadConnectorScheduler(OffloadConnectorSchedulerBase):
         return meta
 
     def request_finished(self, seq: "Sequence") -> None:
-        # No-op for OFFLOAD: hash_blocks already queued saves block-by-block
-        # during postprocess. The scheduler defers block free while any queued
-        # async save for this request is still pending.
-        return
+        # OFFLOAD: hash_blocks already queued saves block-by-block during
+        # postprocess; the scheduler defers block free while any queued
+        # async save for this request is still pending. Drop any
+        # outstanding load-recovery stash for this req — the load either
+        # succeeded (req moved out of WAITING_FOR_REMOTE_KVS) or failed
+        # and was already handled via handle_failed_load.
+        self._external_hashes_by_req.pop(str(seq.id), None)
+
+    def handle_failed_load(self, request_id: str) -> list[int]:
+        """Worker reported the H2D load for ``request_id`` could not be
+        satisfied (pool eviction). Drop the corresponding mirror entries
+        so a future ``get_num_new_matched_tokens`` does not re-hit the
+        same stale hashes, and clear the per-request stash.
+
+        Returns the evicted hashes for logging.
+        """
+        hashes = self._external_hashes_by_req.pop(request_id, [])
+        for h in hashes:
+            self.saved_hashes.discard(h)
+        return hashes

--- a/atom/kv_transfer/offload/lmcache/lmcache_connector.py
+++ b/atom/kv_transfer/offload/lmcache/lmcache_connector.py
@@ -1,0 +1,643 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+LMCache-backed local KV cache offload for ATOM standalone serving.
+
+Talks directly to ``lmcache.c_ops`` (the HIP-built transfer kernels) rather
+than going through ``lmcache.integration.vllm.vllm_v1_adapter`` — that path
+pulls vllm types into the import graph, which we want to avoid for the
+standalone build. ATOM owns the hash-to-CPU-slot index; LMCache provides
+the pinned-memory allocator and the H2D/D2H block-transfer kernel.
+
+Layout (M3 first commit — transfer kernels stubbed, see TODOs):
+
+* Worker side: pinned CPU pool of N slots × sizeof(one paged block × all
+  layers, K and V). ``register_kv_caches`` learns the per-layer geometry
+  and (re)sizes the pool. ``start_load_kv`` is the single per-step entry
+  the EngineCore dispatches to (matches the existing PD path).
+* Scheduler side: an *optimistic* mirror of the worker's index — entries
+  appear when the scheduler queues a save, are removed if the worker
+  reports a failed load. Stale mirror entries are safe: a load miss just
+  triggers re-prefill, never wrong KV.
+
+NVMe (L3) tier and proper LRU eviction are deferred to M5; the first cut
+uses a fixed-size FIFO pool. The known-good ``lmcache.engine.LMCacheEngine``
+wrapper is the natural upgrade path once we want disk-tier and metrics.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any
+
+from atom.kv_transfer.offload.base import (
+    OffloadConnectorBase,
+    OffloadConnectorSchedulerBase,
+)
+from atom.kv_transfer.offload.types import (
+    OffloadConnectorMetadata,
+    OffloadReqMeta,
+)
+
+if TYPE_CHECKING:
+    from atom.config import Config
+    from atom.model_engine.sequence import Sequence
+
+logger = logging.getLogger("atom")
+
+# Sentinel returned by lookup when nothing is queued — keep distinct from
+# integer slot ids (which are >= 0).
+_NO_SLOT = -1
+
+
+def _check_environment() -> None:
+    """Fail fast on misconfigurations that silently corrupt cache keys or
+    fall back to a slow Python backend."""
+    if os.environ.get("PYTHONHASHSEED") != "0":
+        raise RuntimeError(
+            "LMCacheOffloadConnector requires PYTHONHASHSEED=0. "
+            "Without it, TP-rank Python dict hashing diverges and the "
+            "scheduler-side cache index disagrees with workers."
+        )
+    try:
+        import lmcache  # noqa: F401
+        from lmcache import c_ops  # noqa: F401
+    except ImportError as e:
+        raise RuntimeError(
+            "lmcache or lmcache.c_ops failed to import. Build LMCache from "
+            "source with BUILD_WITH_HIP=1 — the PyPI wheel ships CUDA "
+            "binaries that do not work on ROCm. See "
+            "atom/kv_transfer/offload/README.md."
+        ) from e
+    # `lmcache.c_ops` exists iff the HIP/CUDA native extension built; the
+    # Python fallback (`lmcache.python_ops_fallback`) is orders of magnitude
+    # slower and must not be used for serving.
+    backend_mod = getattr(__import__("lmcache"), "_backend_module", None)
+    if backend_mod is not None and "c_ops" not in str(backend_mod):
+        raise RuntimeError(
+            f"LMCache fell back to Python backend {backend_mod!r}. Rebuild "
+            "with BUILD_WITH_HIP=1 — see offload README."
+        )
+
+
+def _kv_transfer_extra(config: "Config") -> dict[str, Any]:
+    """Extract the ``kv_transfer_config`` dict regardless of how it was
+    supplied (dataclass with ``.get_from_extra_config`` vs plain dict via
+    --kv-transfer-config JSON)."""
+    cfg = getattr(config, "kv_transfer_config", None)
+    if cfg is None:
+        return {}
+    if isinstance(cfg, dict):
+        return cfg
+    return getattr(cfg, "extra_config", None) or {}
+
+
+# ---------------------------------------------------------------------------
+# Worker side
+# ---------------------------------------------------------------------------
+
+
+class LMCacheOffloadConnector(OffloadConnectorBase):
+    """Per-TP-rank LMCache offload backend."""
+
+    def __init__(self, config: "Config") -> None:
+        _check_environment()
+        extra = _kv_transfer_extra(config)
+        # Per-rank CPU pool size. ``cpu_bytes`` is server-wide and split
+        # across TP ranks below; ``cpu_bytes_per_rank`` overrides if set
+        # (matches the SimpleCPUOffloadConnector vocabulary).
+        world = max(1, getattr(config, "tensor_parallel_size", 1))
+        cpu_bytes = int(extra.get("cpu_bytes", 8 * (1024**3)))
+        self.cpu_bytes_per_rank = int(
+            extra.get("cpu_bytes_per_rank", cpu_bytes // world)
+        )
+        self.disk_path = extra.get("disk_path", None)  # M5
+        if self.disk_path:
+            logger.warning(
+                "LMCacheOffloadConnector: disk_path=%r set but NVMe tier "
+                "is not implemented yet (M5). Ignoring.",
+                self.disk_path,
+            )
+
+        # KV cache geometry filled in by register_kv_caches.
+        self.kv_caches: dict[str, Any] | None = None
+        self.num_layers: int = 0
+        # Per layer: K block size in bytes + V block size in bytes. Each
+        # K (resp. V) block is contiguous in GPU memory at offset
+        # `block_id * bytes_per_block_per_layer_k` (resp. _v) into the
+        # tensor's storage; the AITER-specific swizzled layout doesn't
+        # affect byte-level offsets within a block.
+        self._k_bytes_per_layer: list[int] = []
+        self._v_bytes_per_layer: list[int] = []
+        self.bytes_per_block: int = 0  # K + V across all layers
+
+        # Flat byte views used for the copies — keyed by layer index.
+        # Built once at register_kv_caches and reused per copy.
+        self._k_uint8_views: list[Any] = []  # torch.Tensor of dtype=uint8
+        self._v_uint8_views: list[Any] = []
+
+        # CPU pool — allocated lazily in register_kv_caches once geometry
+        # is known. The pool is a single pinned uint8 tensor of size
+        # `num_slots * bytes_per_block`; slot `s` occupies bytes
+        # [s * bytes_per_block : (s+1) * bytes_per_block].
+        self._cpu_pool: Any = None  # torch.Tensor, dtype=uint8, pin_memory=True
+        self._cpu_pool_base_ptr: int = 0
+        self._cpu_pool_total_bytes: int = 0
+        self._num_slots: int = 0
+        # Hash -> slot index. OrderedDict so we can FIFO-evict on overflow.
+        # (Real LRU comes with the LMCacheEngine wrapper in M5.)
+        self.hash_to_slot: OrderedDict[int, int] = OrderedDict()
+        self._free_slots: list[int] = []
+
+        # Dedicated CUDA stream for D2H/H2D transfers — overlaps with the
+        # compute stream's next-step work. Lazily created on first use so
+        # we don't bind to a specific device at __init__ (rank may not be
+        # initialized yet on the scheduler process).
+        self._copy_stream: Any = None  # torch.cuda.Stream
+        # Per-step pending completions: list of (req_id, kind, event).
+        # kind in {"save", "load"}. Drained in get_finished.
+        self._pending: list[tuple[str, str, Any]] = []
+
+        # Per-step completion tracking (request_id sets).
+        self._done_saving: set[str] = set()
+        self._done_loading: set[str] = set()
+
+        logger.info(
+            "LMCacheOffloadConnector initialized (rank-local pool=%.2f GB, "
+            "disk_path=%s)",
+            self.cpu_bytes_per_rank / (1024**3),
+            self.disk_path,
+        )
+
+    # ------------------------------------------------------------------ #
+    # KVConnectorBase methods
+    # ------------------------------------------------------------------ #
+
+    def register_kv_caches(
+        self, kv_caches: dict[str, Any], transfer_tensors: Any = None
+    ) -> None:
+        """Capture per-layer KV tensor geometry and allocate the CPU pool.
+
+        ATOM's per-layer K and V tensors don't match any of LMCache's
+        ``GPUKVFormat`` variants (AITER swizzles K as
+        ``(NB, NH, HD/x, BS, x)`` and V as ``(NB, NH, HD, BS)``), so we
+        bypass ``c_ops.multi_layer_block_kv_transfer`` and do byte-level
+        async copies via ``torch.Tensor.copy_(non_blocking=True)``. The
+        underlying storage of each block is contiguous (allocated by
+        ``torch.zeros``), so byte views with reinterpret-cast strides
+        work fine — only the within-block layout is unusual.
+        """
+        import torch
+
+        self.kv_caches = kv_caches
+        self.num_layers = len(kv_caches)
+        if self.num_layers == 0:
+            logger.warning(
+                "register_kv_caches received empty kv_caches; offload disabled."
+            )
+            return
+
+        self._k_bytes_per_layer = []
+        self._v_bytes_per_layer = []
+        self._k_uint8_views = []
+        self._v_uint8_views = []
+        bytes_per_block = 0
+        for name, kvt in kv_caches.items():
+            k = kvt.k_cache
+            v = kvt.v_cache
+            if not k.is_cuda or not k.is_contiguous():
+                logger.warning(
+                    "Layer %s K cache not on CUDA or non-contiguous "
+                    "(device=%s, contig=%s); offload disabled.",
+                    name,
+                    k.device,
+                    k.is_contiguous(),
+                )
+                self._num_slots = 0
+                return
+            k_bytes = (k.numel() // k.shape[0]) * k.element_size()
+            v_bytes = (
+                (v.numel() // v.shape[0]) * v.element_size()
+                if v is not None and v.numel() > 0
+                else 0
+            )
+            self._k_bytes_per_layer.append(k_bytes)
+            self._v_bytes_per_layer.append(v_bytes)
+            # Flatten then reinterpret as bytes so block_id offsets are
+            # byte-linear: `flat[bid * k_bytes : (bid+1) * k_bytes]`.
+            # `.view(-1)` requires contiguity (checked above).
+            self._k_uint8_views.append(k.view(-1).view(torch.uint8))
+            self._v_uint8_views.append(
+                v.view(-1).view(torch.uint8) if v_bytes > 0 else None
+            )
+            bytes_per_block += k_bytes + v_bytes
+
+        self.bytes_per_block = bytes_per_block
+        if self.bytes_per_block == 0:
+            logger.warning("bytes_per_block == 0; offload disabled.")
+            self._num_slots = 0
+            return
+
+        self._num_slots = max(1, self.cpu_bytes_per_rank // self.bytes_per_block)
+        self._cpu_pool_total_bytes = self._num_slots * self.bytes_per_block
+        # Plain pinned uint8 tensor; bypasses c_ops.alloc_pinned_ptr so the
+        # storage participates in PyTorch's normal lifetime management. The
+        # c_ops alloc is reserved for the M5 NUMA-aware LMCacheEngine pool.
+        self._cpu_pool = torch.empty(
+            self._cpu_pool_total_bytes, dtype=torch.uint8, pin_memory=True
+        )
+        self._cpu_pool_base_ptr = self._cpu_pool.data_ptr()
+        self._free_slots = list(range(self._num_slots))
+        first_layer_name = next(iter(kv_caches.keys()))
+        logger.info(
+            "LMCacheOffload: %d slots × %d bytes (pool=%.2f GB, "
+            "num_layers=%d, bytes/block=%d, first_layer=%s, k_bytes[0]=%d, "
+            "v_bytes[0]=%d)",
+            self._num_slots,
+            self.bytes_per_block,
+            self._cpu_pool_total_bytes / (1024**3),
+            self.num_layers,
+            self.bytes_per_block,
+            first_layer_name,
+            self._k_bytes_per_layer[0],
+            self._v_bytes_per_layer[0],
+        )
+
+    def _ensure_copy_stream(self, device):
+        """Lazy-create the copy stream on the GPU device of the first
+        registered KV layer. Workers initialize cuda after engine setup,
+        so we can't bind in __init__.
+        """
+        import torch
+
+        if self._copy_stream is None:
+            self._copy_stream = torch.cuda.Stream(device=device)
+
+    def start_load_kv(self, metadata: OffloadConnectorMetadata) -> None:
+        """Issue async D2H saves for this step.
+
+        Per save block:
+          1. Claim a CPU slot (FIFO-evict if pool full).
+          2. For each layer, copy K bytes then V bytes from the GPU paged
+             block into the slot's region of the pinned CPU pool, using
+             ``torch.copy_(non_blocking=True)`` on a dedicated CUDA stream.
+          3. After all per-req copies, record a CUDA event on the stream
+             and stash ``(req_id, "save", event)``. ``get_finished`` polls
+             events and reports completed req_ids.
+
+        Loads remain stubbed (loads metadata always empty in this commit —
+        ``LMCacheOffloadConnectorScheduler.get_num_new_matched_tokens``
+        returns 0). Enabled in the follow-up alongside BlockManager
+        binding so HBM hits aren't double-counted.
+        """
+        import torch
+
+        if metadata is None or metadata.is_empty():
+            return
+        if self._num_slots == 0 or self._cpu_pool is None:
+            logger.warning(
+                "LMCacheOffload start_load_kv before pool init "
+                "(saves=%d, loads=%d) — dropping.",
+                len(metadata.reqs_to_save),
+                len(metadata.reqs_to_load),
+            )
+            self._done_saving.update(metadata.reqs_to_save.keys())
+            self._done_loading.update(metadata.reqs_to_load.keys())
+            return
+
+        # All layers live on the same device; sample the first.
+        device = self._k_uint8_views[0].device
+        self._ensure_copy_stream(device)
+        # Make our copy stream wait for whatever produced the K/V (the
+        # default compute stream that ran the forward pass). Without this
+        # sync the D2H reads can race with the still-in-flight attention
+        # write of the same paged block.
+        self._copy_stream.wait_stream(torch.cuda.current_stream(device))
+
+        total_save_blocks = sum(
+            len(m.block_ids) for m in metadata.reqs_to_save.values()
+        )
+        if total_save_blocks:
+            logger.debug(
+                "LMCacheOffload start_load_kv: saves=%d blocks across %d reqs (pool %d/%d slots in use)",
+                total_save_blocks,
+                len(metadata.reqs_to_save),
+                len(self.hash_to_slot),
+                self._num_slots,
+            )
+        with torch.cuda.stream(self._copy_stream):
+            for req_id, meta in metadata.reqs_to_save.items():
+                for block_id, h in zip(meta.block_ids, meta.block_hashes):
+                    # Slot claim (skip if already cached — same hash chain
+                    # re-published is a no-op).
+                    if h in self.hash_to_slot:
+                        continue
+                    if not self._free_slots:
+                        evict_hash, evict_slot = self.hash_to_slot.popitem(last=False)
+                        self._free_slots.append(evict_slot)
+                    slot = self._free_slots.pop(0)
+                    self.hash_to_slot[h] = slot
+                    # Per-layer K then V copy into the slot's byte region.
+                    cpu_offset = slot * self.bytes_per_block
+                    for layer_idx in range(self.num_layers):
+                        k_view = self._k_uint8_views[layer_idx]
+                        k_bytes = self._k_bytes_per_layer[layer_idx]
+                        v_view = self._v_uint8_views[layer_idx]
+                        v_bytes = self._v_bytes_per_layer[layer_idx]
+                        # K block: flat byte view of k_cache[block_id].
+                        src_k = k_view[block_id * k_bytes : (block_id + 1) * k_bytes]
+                        dst_k = self._cpu_pool[cpu_offset : cpu_offset + k_bytes]
+                        dst_k.copy_(src_k, non_blocking=True)
+                        cpu_offset += k_bytes
+                        if v_bytes > 0:
+                            src_v = v_view[
+                                block_id * v_bytes : (block_id + 1) * v_bytes
+                            ]
+                            dst_v = self._cpu_pool[cpu_offset : cpu_offset + v_bytes]
+                            dst_v.copy_(src_v, non_blocking=True)
+                            cpu_offset += v_bytes
+                # One event per request — coarser than per-block but the
+                # scheduler granularity is per-request anyway.
+                evt = torch.cuda.Event()
+                evt.record(self._copy_stream)
+                self._pending.append((req_id, "save", evt))
+
+        # H2D loads — issued on the same stream after the saves above so
+        # any save→load same-step ordering is respected naturally.
+        if metadata.reqs_to_load:
+            total_load_blocks = sum(
+                len(m.block_ids) for m in metadata.reqs_to_load.values()
+            )
+            logger.debug(
+                "LMCacheOffload start_load_kv: loads=%d blocks across %d reqs (pool %d/%d slots in use)",
+                total_load_blocks,
+                len(metadata.reqs_to_load),
+                len(self.hash_to_slot),
+                self._num_slots,
+            )
+            with torch.cuda.stream(self._copy_stream):
+                for req_id, meta in metadata.reqs_to_load.items():
+                    missed = 0
+                    for block_id, h in zip(meta.block_ids, meta.block_hashes):
+                        slot = self.hash_to_slot.get(h, -1)
+                        if slot < 0:
+                            # Optimistic mirror said HIT, worker doesn't
+                            # have it (likely FIFO-evicted). Leave the
+                            # paged block uninitialized — the scheduler
+                            # will see this seq finish with wrong KV; in
+                            # practice this only happens if the pool is
+                            # sized too small for the working set. TODO:
+                            # surface miss back so scheduler can drop the
+                            # mirror entry and trigger re-prefill.
+                            missed += 1
+                            continue
+                        cpu_offset = slot * self.bytes_per_block
+                        for layer_idx in range(self.num_layers):
+                            k_view = self._k_uint8_views[layer_idx]
+                            k_bytes = self._k_bytes_per_layer[layer_idx]
+                            v_view = self._v_uint8_views[layer_idx]
+                            v_bytes = self._v_bytes_per_layer[layer_idx]
+                            dst_k = k_view[
+                                block_id * k_bytes : (block_id + 1) * k_bytes
+                            ]
+                            src_k = self._cpu_pool[cpu_offset : cpu_offset + k_bytes]
+                            dst_k.copy_(src_k, non_blocking=True)
+                            cpu_offset += k_bytes
+                            if v_bytes > 0:
+                                dst_v = v_view[
+                                    block_id * v_bytes : (block_id + 1) * v_bytes
+                                ]
+                                src_v = self._cpu_pool[
+                                    cpu_offset : cpu_offset + v_bytes
+                                ]
+                                dst_v.copy_(src_v, non_blocking=True)
+                                cpu_offset += v_bytes
+                    if missed:
+                        logger.warning(
+                            "LMCacheOffload: %d/%d H2D load misses for "
+                            "req=%s (pool eviction; expect wrong KV)",
+                            missed,
+                            len(meta.block_ids),
+                            req_id,
+                        )
+                    evt = torch.cuda.Event()
+                    evt.record(self._copy_stream)
+                    self._pending.append((req_id, "load", evt))
+            # The compute stream must wait for the H2D loads to finish
+            # before reading those paged blocks for attention. Insert the
+            # reverse barrier so the next forward sees fully-loaded KV.
+            torch.cuda.current_stream(device).wait_stream(self._copy_stream)
+
+    def get_finished(self) -> tuple[set[str], set[str]]:
+        """Drain completed CUDA events into the done sets, then return
+        them (and clear).
+        """
+        if self._pending:
+            still_pending: list[tuple[str, str, Any]] = []
+            for req_id, kind, evt in self._pending:
+                if evt.query():
+                    if kind == "save":
+                        self._done_saving.add(req_id)
+                    else:
+                        self._done_loading.add(req_id)
+                else:
+                    still_pending.append((req_id, kind, evt))
+            self._pending = still_pending
+        done_save = self._done_saving
+        done_load = self._done_loading
+        self._done_saving = set()
+        self._done_loading = set()
+        return done_save, done_load
+
+
+# ---------------------------------------------------------------------------
+# Scheduler side
+# ---------------------------------------------------------------------------
+
+
+class LMCacheOffloadConnectorScheduler(OffloadConnectorSchedulerBase):
+    """Scheduler-side companion of :class:`LMCacheOffloadConnector`.
+
+    Maintains an *optimistic* set of block hashes that have been queued for
+    save. A `queue_save` immediately marks the hash as available; if a
+    subsequent load actually misses on the worker, the connector reports it
+    via :meth:`OffloadConnectorBase.get_finished` and we evict from the
+    mirror.
+    """
+
+    def __init__(self, config: "Config") -> None:
+        _check_environment()
+        extra = _kv_transfer_extra(config)
+        self.chunk_size = int(extra.get("chunk_size", 256))
+        # Optimistic mirror — set of block hashes the worker is believed
+        # to have. Bounded only by total prefill block count across the
+        # run; trimmed as worker reports load misses.
+        self.saved_hashes: set[int] = set()
+        # Per-step accumulator drained by build_connector_meta.
+        self._pending_save: dict[str, OffloadReqMeta] = {}
+        self._pending_load: dict[str, OffloadReqMeta] = {}
+        # Set by Scheduler.__init__ via bind_block_manager.
+        self.block_manager: Any = None
+        # Per-seq stash between get_num_new_matched_tokens and
+        # update_state_after_alloc, keyed by `id(seq)`.
+        self._external_match_stash: dict[int, list[int]] = {}
+        logger.info(
+            "LMCacheOffloadConnectorScheduler initialized (chunk_size=%d)",
+            self.chunk_size,
+        )
+
+    # ------------------------------------------------------------------ #
+    # KVConnectorSchedulerBase methods (PD-style names; OFFLOAD semantics)
+    # ------------------------------------------------------------------ #
+
+    def get_num_new_matched_tokens(self, seq: "Sequence") -> tuple[int, bool]:
+        """Return ``(tokens_in_external_store, async_load_required)``.
+
+        Walks the seq's prompt hash chain (same xxhash chain as
+        ``BlockManager.compute_hash``) and finds the longest *contiguous*
+        prefix where either:
+
+        * The block is an HBM prefix-cache hit (already free, no work), OR
+        * The block is in the external store (needs H2D load).
+
+        Returns the count of *external-only* tokens (HBM hits subtracted)
+        plus ``async=True`` so the scheduler parks the seq in
+        ``WAITING_FOR_REMOTE_KVS`` until the worker confirms the load.
+
+        Returns ``(0, False)`` if the connector isn't ready (no block
+        manager bound, no external hits, etc.).
+        """
+        if self.block_manager is None or seq.num_blocks <= 1:
+            return 0, False
+        if not self.block_manager.enable_prefix_caching:
+            # No prefix cache means no HBM dedup possible AND no hash
+            # chain — fall through to plain prefill.
+            return 0, False
+        from atom.model_engine.block_manager import BlockManager
+
+        h = -1
+        external_hashes: list[int] = []
+        n_hbm = 0
+        n_ext = 0
+        # Same loop bound as BlockManager.can_allocate: skip the last
+        # block (always allocated fresh; prefill needs to forward at
+        # least one block for sampler logits).
+        state = "hbm"
+        for i in range(seq.num_blocks - 1):
+            token_ids = seq.block(i)
+            h = BlockManager.compute_hash(token_ids, h)
+            if state == "hbm":
+                hit_bid = self.block_manager.hash_to_block_id.get(h, -1)
+                if hit_bid != -1 and (
+                    self.block_manager.blocks[hit_bid].token_ids == token_ids
+                ):
+                    n_hbm += 1
+                    continue
+                state = "ext"
+            # state == "ext"
+            if h in self.saved_hashes:
+                n_ext += 1
+                external_hashes.append(h)
+            else:
+                break  # chain broke; nothing after this can hit either
+
+        if n_ext == 0:
+            return 0, False
+        # Stash for update_state_after_alloc to consume.
+        self._external_match_stash[id(seq)] = external_hashes
+        return n_ext * seq.block_size, True
+
+    def update_state_after_alloc(self, seq: "Sequence") -> None:
+        """Enqueue the H2D load tasks for the external-prefix slots
+        BlockManager just allocated.
+
+        BlockManager.allocate has already laid out ``seq.block_table``:
+        first ``n_hbm`` entries are HBM-cached blocks (reused), the rest
+        are fresh slots from the free pool. External-store loads target
+        ``seq.block_table[n_hbm : n_hbm + n_ext]`` — the freshly-allocated
+        slots that correspond to the external-only prefix prefix.
+        """
+        stashed = self._external_match_stash.pop(id(seq), None)
+        if stashed is None:
+            return
+        external_hashes = stashed
+        n_ext = len(external_hashes)
+        n_hbm = seq.num_cached_blocks
+        dest_block_ids = list(seq.block_table[n_hbm : n_hbm + n_ext])
+        if len(dest_block_ids) != n_ext:
+            # block_table is shorter than expected (allocation deviated
+            # from what we predicted). Skip the load — seq will fall back
+            # to full prefill of those blocks; correctness preserved.
+            logger.warning(
+                "LMCacheOffload: dest_block_ids len %d != n_ext %d "
+                "(n_hbm=%d, num_blocks=%d) — skipping load",
+                len(dest_block_ids),
+                n_ext,
+                n_hbm,
+                seq.num_blocks,
+            )
+            return
+        self._pending_load[str(seq.id)] = OffloadReqMeta(
+            block_ids=dest_block_ids, block_hashes=external_hashes
+        )
+
+    def lookup_external_hits(self, seq: "Sequence", block_hashes: list[int]) -> int:
+        """Return the longest prefix of ``block_hashes`` known to the
+        optimistic mirror. Bounded by the chain rule — stop at first miss.
+
+        Currently unused: :meth:`get_num_new_matched_tokens` returns 0 in
+        this first commit (load path disabled until BlockManager binding
+        and real c_ops H2D land in the follow-up). Keeping the method
+        implemented makes the class instantiable and primes the lookup
+        logic for that commit.
+        """
+        n = 0
+        for h in block_hashes:
+            if h in self.saved_hashes:
+                n += 1
+            else:
+                break
+        return n
+
+    def queue_save(self, request_id: str, published: list[tuple[int, int]]) -> None:
+        if not published:
+            return
+        block_ids = [bid for bid, _ in published]
+        block_hashes = [h for _, h in published]
+        # Mark optimistically saved so subsequent lookups find it.
+        self.saved_hashes.update(block_hashes)
+        # Accumulate; one request may publish across multiple steps.
+        meta = self._pending_save.setdefault(request_id, OffloadReqMeta())
+        meta.block_ids.extend(block_ids)
+        meta.block_hashes.extend(block_hashes)
+        logger.debug(
+            "LMCacheOffload queue_save req=%s n_new=%d total_mirror=%d",
+            request_id,
+            len(published),
+            len(self.saved_hashes),
+        )
+
+    def queue_load(
+        self, request_id: str, block_ids: list[int], block_hashes: list[int]
+    ) -> None:
+        self._pending_load[request_id] = OffloadReqMeta(
+            block_ids=list(block_ids), block_hashes=list(block_hashes)
+        )
+
+    def build_connector_meta(self) -> OffloadConnectorMetadata | None:
+        if not self._pending_save and not self._pending_load:
+            return None
+        meta = OffloadConnectorMetadata()
+        meta.reqs_to_save = self._pending_save
+        meta.reqs_to_load = self._pending_load
+        self._pending_save = {}
+        self._pending_load = {}
+        return meta
+
+    def request_finished(self, seq: "Sequence") -> None:
+        # No-op for OFFLOAD: hash_blocks already queued saves block-by-block
+        # during postprocess. Block free is immediate (handled by scheduler).
+        return

--- a/atom/kv_transfer/offload/lmcache/lmcache_connector.py
+++ b/atom/kv_transfer/offload/lmcache/lmcache_connector.py
@@ -125,6 +125,7 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
         # KV cache geometry filled in by register_kv_caches.
         self.kv_caches: dict[str, Any] | None = None
         self.num_layers: int = 0
+        self.block_size = int(getattr(config, "kv_cache_block_size", 1))
         # Per layer: K block size in bytes + V block size in bytes. Each
         # K (resp. V) block is contiguous in GPU memory at offset
         # `block_id * bytes_per_block_per_layer_k` (resp. _v) into the
@@ -218,12 +219,19 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
                 )
                 self._num_slots = 0
                 return
-            k_bytes = (k.numel() // k.shape[0]) * k.element_size()
-            v_bytes = (
-                (v.numel() // v.shape[0]) * v.element_size()
-                if v is not None and v.numel() > 0
-                else 0
-            )
+            if v is None:
+                # MLA registers a token-major K-only cache shaped like
+                # [num_blocks * block_size, 1, hidden]. A logical paged block
+                # spans block_size consecutive token rows.
+                k_bytes = self.block_size * k.stride(0) * k.element_size()
+                v_bytes = 0
+            else:
+                k_bytes = (k.numel() // k.shape[0]) * k.element_size()
+                v_bytes = (
+                    (v.numel() // v.shape[0]) * v.element_size()
+                    if v.numel() > 0
+                    else 0
+                )
             self._k_bytes_per_layer.append(k_bytes)
             self._v_bytes_per_layer.append(v_bytes)
             # Flatten then reinterpret as bytes so block_id offsets are
@@ -246,6 +254,12 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
         # Plain pinned uint8 tensor; bypasses c_ops.alloc_pinned_ptr so the
         # storage participates in PyTorch's normal lifetime management. The
         # c_ops alloc is reserved for the M5 NUMA-aware LMCacheEngine pool.
+        # TODO: Avoid one huge pinned allocation for very large CPU KV caches.
+        # PyTorch's pinned host allocator may round large requests up to the
+        # next power-of-two bucket (e.g. ~100 GB -> 128 GB), causing surprising
+        # RSS/locked-memory pressure. Replace this with a segmented pool or
+        # power-of-two-aware planner before recommending multi-hundred-GB
+        # offload capacity.
         self._cpu_pool = torch.empty(
             self._cpu_pool_total_bytes, dtype=torch.uint8, pin_memory=True
         )
@@ -429,6 +443,15 @@ class LMCacheOffloadConnector(OffloadConnectorBase):
             # The compute stream must wait for the H2D loads to finish
             # before reading those paged blocks for attention. Insert the
             # reverse barrier so the next forward sees fully-loaded KV.
+            # TODO: Align with vLLM SimpleCPUOffload's async-load model.
+            # The scheduler already parks load-hit requests in
+            # WAITING_FOR_REMOTE_KVS and wakes them via finished_recving, so
+            # the request that needs this H2D load should not participate in
+            # the current forward batch. This stream-wide wait is a conservative
+            # batch-level fence and can unnecessarily block unrelated forward
+            # work on the current stream. Prefer relying on per-load CUDA
+            # events + next-step scheduling once the load lifecycle is fully
+            # validated.
             torch.cuda.current_stream(device).wait_stream(self._copy_stream)
 
     def get_finished(self) -> tuple[set[str], set[str]]:
@@ -639,5 +662,6 @@ class LMCacheOffloadConnectorScheduler(OffloadConnectorSchedulerBase):
 
     def request_finished(self, seq: "Sequence") -> None:
         # No-op for OFFLOAD: hash_blocks already queued saves block-by-block
-        # during postprocess. Block free is immediate (handled by scheduler).
+        # during postprocess. The scheduler defers block free while any queued
+        # async save for this request is still pending.
         return

--- a/atom/kv_transfer/offload/types.py
+++ b/atom/kv_transfer/offload/types.py
@@ -11,11 +11,11 @@ connectors in two key ways:
 * No remote engine. Saves/loads are local D2H/H2D copies, so transfer
   metadata carries only local ``(block_id, hash)`` pairs — no host/port
   or remote-engine identifiers.
-* No block-ownership transfer at request finish. The source GPU blocks
-  remain owned by the BlockManager; the offload connector's save is an
-  independent D2H copy that may complete before or after the block is
-  freed. Consequently the scheduler skips its PD producer "defer free"
-  behavior for OFFLOAD connectors (see ``Scheduler._connector_defers_free``).
+* No remote block-ownership transfer at request finish. The source GPU
+  blocks remain owned by the BlockManager, but an async D2H save still
+  needs those blocks to remain valid until the worker reports
+  ``finished_sending``. The scheduler therefore defers freeing only for
+  OFFLOAD requests with pending saves.
 """
 
 from __future__ import annotations

--- a/atom/kv_transfer/offload/types.py
+++ b/atom/kv_transfer/offload/types.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Type definitions for the local KV-offload subsystem.
+
+OFFLOAD connectors maintain a second/third-tier KV store (CPU DRAM, NVMe)
+behind the engine's HBM paged KV cache. They differ from PD-disaggregation
+connectors in two key ways:
+
+* No remote engine. Saves/loads are local D2H/H2D copies, so transfer
+  metadata carries only local ``(block_id, hash)`` pairs — no host/port
+  or remote-engine identifiers.
+* No block-ownership transfer at request finish. The source GPU blocks
+  remain owned by the BlockManager; the offload connector's save is an
+  independent D2H copy that may complete before or after the block is
+  freed. Consequently the scheduler skips its PD producer "defer free"
+  behavior for OFFLOAD connectors (see ``Scheduler._connector_defers_free``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from atom.kv_transfer.disaggregation.types import ReqId
+
+
+@dataclass
+class OffloadReqMeta:
+    """Per-request metadata for one offload operation (save or load).
+
+    A *save* and a *load* use the same dataclass: for save, ``block_ids``
+    are GPU paged-block slot ids holding KV the connector should copy out;
+    for load, ``block_ids`` are GPU paged-block slot ids the connector
+    should fill from the external store. ``block_hashes`` is the prefix-
+    cache hash chain produced by ``BlockManager.compute_hash``, used as the
+    cache key in the external store.
+    """
+
+    block_ids: list[int] = field(default_factory=list)
+    block_hashes: list[int] = field(default_factory=list)
+
+
+class OffloadConnectorMetadata:
+    """Snapshot of pending offload operations, passed scheduler -> worker.
+
+    Mirrors :class:`atom.kv_transfer.disaggregation.types.ConnectorMetadata`
+    so the engine-core dispatch path (``process_kvconnector_output``) can
+    handle both flavors interchangeably; only the field types differ.
+    """
+
+    def __init__(self) -> None:
+        self.reqs_to_save: dict[ReqId, OffloadReqMeta] = {}
+        self.reqs_to_load: dict[ReqId, OffloadReqMeta] = {}
+
+    def is_empty(self) -> bool:
+        return not self.reqs_to_save and not self.reqs_to_load
+
+    def __repr__(self) -> str:
+        return (
+            f"OffloadConnectorMetadata(saves={len(self.reqs_to_save)}, "
+            f"loads={len(self.reqs_to_load)})"
+        )

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -177,7 +177,7 @@ class BlockManager:
         if seq.has_per_req_cache:
             seq.per_req_cache_group = self.free_per_req_cache_groups.pop()
 
-    def hash_blocks(self, seq: Sequence, num_new_tokens: int) -> None:
+    def hash_blocks(self, seq: Sequence, num_new_tokens: int) -> list[tuple[int, int]]:
         """Register hashes for blocks finalized by the most recent step.
 
         Called from scheduler.postprocess() after the forward completes, so a
@@ -188,20 +188,28 @@ class BlockManager:
         Caller passes `num_new_tokens` = tokens forwarded in this step. For
         single-shot prefill that's `seq.num_tokens - seq.num_cached_tokens`;
         chunked prefill will pass the per-chunk count.
+
+        Returns a list of `(block_id, block_hash)` pairs newly published by
+        this call (in finalization order). Offload connectors consume this
+        to enqueue D2H saves for the freshly-computed blocks. Empty when
+        prefix caching is disabled or no full block crossed the boundary.
         """
         if not self.enable_prefix_caching:
-            return
+            return []
         start = seq.num_cached_tokens // self.block_size
         end = (seq.num_cached_tokens + num_new_tokens) // self.block_size
         if start >= end:
-            return
+            return []
         h = self.blocks[seq.block_table[start - 1]].hash if start > 0 else -1
+        published: list[tuple[int, int]] = []
         for i in range(start, end):
             block = self.blocks[seq.block_table[i]]
             token_ids = seq.block(i)
             h = self.compute_hash(token_ids, h)
             block.update(h, token_ids)
             self.hash_to_block_id[h] = block.block_id
+            published.append((block.block_id, h))
+        return published
 
     def deallocate(self, seq: Sequence):
         for block_id in reversed(seq.block_table):

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1946,14 +1946,30 @@ class ModelRunner:
 
     @torch.inference_mode()
     def async_proc_aggregation(self) -> KVConnectorOutput:
-        """Collect finished send/recv status from the KV connector."""
+        """Collect finished send/recv status from the KV connector.
+
+        For OFFLOAD connectors with a may-evict pool (FIFO/LRU), also
+        drain ``get_failed_load`` so the scheduler can drop its
+        optimistic mirror entry and re-prefill the request rather than
+        running attention against an uninitialized GPU block.
+        """
         connector = get_kvconnector()
         if connector is None:
             return KVConnectorOutput(finished_sending=[], finished_recving=[])
         done_sending, done_recving = connector.get_finished()
+        # PD connectors don't implement get_failed_load; the base method
+        # returns set() by default so this is safe to call unconditionally
+        # on anything routed here.
+        failed_recving = (
+            connector.get_failed_load()
+            if hasattr(connector, "get_failed_load")
+            else set()
+        )
 
         return KVConnectorOutput(
-            finished_sending=done_sending, finished_recving=done_recving
+            finished_sending=done_sending,
+            finished_recving=done_recving,
+            failed_recving=failed_recving,
         )
 
     def propose_draft_token_ids(

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -414,6 +414,16 @@ class Scheduler:
 
         self.kv_connector = get_kvconnector("scheduler", config)
 
+        # Hand the connector a BlockManager reference so OFFLOAD connectors
+        # can de-duplicate external-store hits against the in-HBM prefix
+        # cache (HBM hits are free; only the residual external-only prefix
+        # needs an H2D load). PD connectors don't need it and ignore the
+        # default bind via `KVConnectorSchedulerBase`'s no-op.
+        if self.kv_connector is not None and hasattr(
+            self.kv_connector, "bind_block_manager"
+        ):
+            self.kv_connector.bind_block_manager(self.block_manager)
+
     def is_finished(self):
         # `_rejected` must be considered too: if a batch of seqs is all
         # oversized, schedule() moves them straight from `waiting` to
@@ -794,10 +804,49 @@ class Scheduler:
             # chunked-prefill scheduling where one block may span multiple
             # steps. Must run before any seq state update so num_cached_tokens
             # and block_table still reflect the pre-step view.
-            if seq.type == SequenceType.PREFILL:
-                self.block_manager.hash_blocks(
-                    seq, seq.num_tokens - seq.num_cached_tokens
-                )
+            #
+            # Gate is `len(seq.output_tokens) == 0`, not `seq.type == PREFILL`,
+            # because ModelRunner runs in deferred-output mode (sampled tokens
+            # surface one engine step late, see tokenIDProcessor.is_deferred_out).
+            # In deferred mode, the prefill step's fwd_output is empty (no
+            # idx for the seq), and by the time its output IS processed the
+            # next step's schedule has already flipped seq.type to DECODE —
+            # so the old PREFILL gate never fired and hashes were never
+            # published. `len(output_tokens) == 0` is true exactly at the
+            # first postprocess that has an idx for the seq, in both modes.
+            if not seq.prefix_hashes_published:
+                # The prefill's KV is now fully written in HBM (its output
+                # has surfaced — `idx` is not None this step). Compute the
+                # count of prompt tokens that the prefill forward filled:
+                # `seq.num_tokens` at this point still reflects the prompt
+                # length plus any placeholder tokens that were appended at
+                # the end of the prefill-step postprocess (under
+                # `need_placeholder` below). Placeholder KV is computed in
+                # the *current* decode step, not the prefill, and the
+                # placeholder tokens themselves are about to be overwritten
+                # with the real sampled prefill output later in this loop —
+                # so they're NOT part of the prompt's hash chain. Subtract
+                # them to keep the published-block range to "fully-prompt"
+                # blocks only.
+                _num_new = seq.num_tokens - seq.num_cached_tokens
+                if need_placeholder:
+                    _num_new -= num_placeholder
+                published = self.block_manager.hash_blocks(seq, _num_new)
+                seq.prefix_hashes_published = True
+                if published:
+                    logger.debug(
+                        "Prefix hashes published for seq=%s: %d blocks (num_new=%d, cached=%d)",
+                        seq.id,
+                        len(published),
+                        _num_new,
+                        seq.num_cached_tokens,
+                    )
+                # For OFFLOAD connectors, every freshly-published block is
+                # a candidate for D2H save. The connector dedupes against
+                # its own external-store index; the scheduler just forwards
+                # the (block_id, hash) pairs the BlockManager just minted.
+                if published and self._connector_is_offload():
+                    self.kv_connector.queue_save(str(seq.id), published)
             token_ids = prev_token_ids[idx]
             num_new_token = len(token_ids)
             if is_deferred_out or self.use_spec:
@@ -968,16 +1017,15 @@ class Scheduler:
                     # )
         for seq in finished_seqs:
             logger.debug("Freeing blocks for finished seq %s", seq.id)
-            if self.kv_connector is not None:
-                if not self.kv_connector.is_producer:
-                    self.block_manager.deallocate(seq)
-                else:
-                    logger.debug(
-                        "Deferring block free for seq %s until KV send completes.",
-                        seq.id,
-                    )
-                    self.deferred_free_blocks[seq.id] = seq
+            if self.kv_connector is not None and self._connector_defers_free():
+                logger.debug(
+                    "Deferring block free for seq %s until KV send completes.",
+                    seq.id,
+                )
+                self.deferred_free_blocks[seq.id] = seq
             else:
+                # No connector, OFFLOAD connector (saves are in-place D2H —
+                # blocks freed immediately), or a non-producer PD connector.
                 self.block_manager.deallocate(seq)
             self.running.remove(seq)
         return finished_seqs
@@ -1000,21 +1048,30 @@ class Scheduler:
     def _update_from_kv_xfer_finished(self, kv_connector_output: KVConnectorOutput):
         """Reconcile scheduler state with completed KV transfers.
 
-        * ``finished_recving``: marks requests as ready for decode scheduling.
-        * ``finished_sending``: releases deferred block allocations on the
-          producer side.
+        * ``finished_recving``: marks requests as ready for decode scheduling
+          (PD decode consumer) or as loaded from external store (OFFLOAD).
+        * ``finished_sending``: releases deferred block allocations on the PD
+          producer side, or is purely informational for OFFLOAD (saves are
+          D2H copies; the source blocks were already freed at finish time).
         """
         if kv_connector_output is None:
             return
 
+        is_offload = self._connector_is_offload()
         for req_id in kv_connector_output.finished_recving or ():
             assert (
-                not self.kv_connector.is_producer
-            ), "Only consumer should update recving KV status"
+                is_offload or not self.kv_connector.is_producer
+            ), "Only consumer or offload connector should update recving KV status"
             logger.debug("Finished recving KV transfer for request %s", req_id)
             self.finished_recving_kv_req_ids.append(req_id)
 
         for req_id in kv_connector_output.finished_sending or ():
+            if is_offload:
+                logger.debug(
+                    "Offload save completed for request %s (informational)",
+                    req_id,
+                )
+                continue
             assert (
                 self.kv_connector.is_producer
             ), "Only producer should free blocks after sending KV"
@@ -1023,6 +1080,32 @@ class Scheduler:
                 req_id in self.deferred_free_blocks
             ), f"req_id={req_id} not found in deferred_free_blocks"
             self.block_manager.deallocate(self.deferred_free_blocks.pop(req_id))
+
+    def _connector_role(self):
+        """Return the connector's role, or None if no connector is wired."""
+        if self.kv_connector is None:
+            return None
+        # Lazy import to avoid pulling kv_transfer at module import time.
+        from atom.kv_transfer.disaggregation.base import KVConnectorRole
+
+        return getattr(self.kv_connector, "role", KVConnectorRole.PD_PRODUCER)
+
+    def _connector_is_offload(self) -> bool:
+        from atom.kv_transfer.disaggregation.base import KVConnectorRole
+
+        return self._connector_role() == KVConnectorRole.OFFLOAD
+
+    def _connector_defers_free(self) -> bool:
+        """True if the connector takes over block lifetime after request
+        finish (PD producer transferring KV to the decode node). OFFLOAD
+        connectors do NOT defer — their D2H save is independent of the
+        source block's GPU lifetime, so finished_seqs can free immediately.
+        """
+        return (
+            self.kv_connector is not None
+            and not self._connector_is_offload()
+            and self.kv_connector.is_producer
+        )
 
     def get_request_counts(self) -> tuple[int, int]:
         """Returns (num_running_reqs, num_waiting_reqs)."""

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -388,7 +388,8 @@ class Scheduler:
 
         # KV transfer bookkeeping
         self.finished_recving_kv_req_ids: list[int] = []
-        self.deferred_free_blocks: dict[int, Sequence] = {}
+        self.deferred_free_blocks: dict[int | str, Sequence] = {}
+        self.offload_pending_save_req_ids: set[str] = set()
 
         # Scheduling delay for batching efficiency
         self.prev_time = 0.0
@@ -846,7 +847,9 @@ class Scheduler:
                 # its own external-store index; the scheduler just forwards
                 # the (block_id, hash) pairs the BlockManager just minted.
                 if published and self._connector_is_offload():
-                    self.kv_connector.queue_save(str(seq.id), published)
+                    req_id = self._normalize_req_id(seq.id)
+                    self.kv_connector.queue_save(req_id, published)
+                    self.offload_pending_save_req_ids.add(req_id)
             token_ids = prev_token_ids[idx]
             num_new_token = len(token_ids)
             if is_deferred_out or self.use_spec:
@@ -1023,9 +1026,16 @@ class Scheduler:
                     seq.id,
                 )
                 self.deferred_free_blocks[seq.id] = seq
+            elif self.kv_connector is not None and self._offload_save_pending(seq.id):
+                logger.debug(
+                    "Deferring block free for offload seq %s until D2H save completes.",
+                    seq.id,
+                )
+                self.deferred_free_blocks[self._normalize_req_id(seq.id)] = seq
             else:
-                # No connector, OFFLOAD connector (saves are in-place D2H —
-                # blocks freed immediately), or a non-producer PD connector.
+                # No connector, no pending OFFLOAD save, or a non-producer PD
+                # connector. OFFLOAD saves that are still in-flight defer free
+                # above so their source GPU blocks cannot be reused early.
                 self.block_manager.deallocate(seq)
             self.running.remove(seq)
         return finished_seqs
@@ -1051,8 +1061,8 @@ class Scheduler:
         * ``finished_recving``: marks requests as ready for decode scheduling
           (PD decode consumer) or as loaded from external store (OFFLOAD).
         * ``finished_sending``: releases deferred block allocations on the PD
-          producer side, or is purely informational for OFFLOAD (saves are
-          D2H copies; the source blocks were already freed at finish time).
+          producer side and for OFFLOAD requests whose async D2H saves kept
+          source GPU blocks alive after request finish.
         """
         if kv_connector_output is None:
             return
@@ -1068,9 +1078,17 @@ class Scheduler:
         for req_id in kv_connector_output.finished_sending or ():
             if is_offload:
                 logger.debug(
-                    "Offload save completed for request %s (informational)",
+                    "Offload save completed for request %s",
                     req_id,
                 )
+                self.offload_pending_save_req_ids.discard(
+                    self._normalize_req_id(req_id)
+                )
+                deferred_seq = self.deferred_free_blocks.pop(
+                    self._normalize_req_id(req_id), None
+                )
+                if deferred_seq is not None:
+                    self.block_manager.deallocate(deferred_seq)
                 continue
             assert (
                 self.kv_connector.is_producer
@@ -1098,13 +1116,22 @@ class Scheduler:
     def _connector_defers_free(self) -> bool:
         """True if the connector takes over block lifetime after request
         finish (PD producer transferring KV to the decode node). OFFLOAD
-        connectors do NOT defer — their D2H save is independent of the
-        source block's GPU lifetime, so finished_seqs can free immediately.
+        connectors defer only when a request has an in-flight D2H save.
         """
         return (
             self.kv_connector is not None
             and not self._connector_is_offload()
             and self.kv_connector.is_producer
+        )
+
+    @staticmethod
+    def _normalize_req_id(req_id) -> str:
+        return str(req_id)
+
+    def _offload_save_pending(self, req_id) -> bool:
+        return (
+            self._connector_is_offload()
+            and self._normalize_req_id(req_id) in self.offload_pending_save_req_ids
         )
 
     def get_request_counts(self) -> tuple[int, int]:

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -304,7 +304,7 @@ class ScheduledBatch:
         self.total_seqs_num_decode = total_seqs_num_decode
 
         self.connector_meta_output = connector_meta_output
-        self.finished_recving_kv_req_ids: list[int] = []
+        self.finished_recving_kv_req_ids: list[str] = []
 
         self.is_dummy_run = is_dummy_run
         self.num_spec_step = num_spec_step
@@ -387,7 +387,7 @@ class Scheduler:
         self._rejected: list[Sequence] = []
 
         # KV transfer bookkeeping
-        self.finished_recving_kv_req_ids: list[int] = []
+        self.finished_recving_kv_req_ids: list[str] = []
         self.deferred_free_blocks: dict[int | str, Sequence] = {}
         self.offload_pending_save_req_ids: set[str] = set()
 
@@ -1048,10 +1048,11 @@ class Scheduler:
         scheduling step.  When ready, the sequence transitions back
         from ``WAITING_FOR_REMOTE_KVS`` to ``WAITING``.
         """
-        if seq.id not in self.finished_recving_kv_req_ids:
+        req_id_norm = self._normalize_req_id(seq.id)
+        if req_id_norm not in self.finished_recving_kv_req_ids:
             return False
 
-        self.finished_recving_kv_req_ids.remove(seq.id)
+        self.finished_recving_kv_req_ids.remove(req_id_norm)
         logger.debug("KV transfer finished for seq %s, ready for scheduling.", seq.id)
         return True
 
@@ -1060,6 +1061,13 @@ class Scheduler:
 
         * ``finished_recving``: marks requests as ready for decode scheduling
           (PD decode consumer) or as loaded from external store (OFFLOAD).
+        * ``failed_recving`` (OFFLOAD-only): worker reported the H2D load
+          could not be satisfied (pool eviction between scheduler-side
+          optimistic mirror lookup and the actual copy). Drop the mirror
+          entries, release the over-allocated GPU blocks, and put the
+          request back in WAITING for a plain re-prefill. Without this,
+          the request would forward against an uninitialized GPU block
+          and attention would read garbage KV.
         * ``finished_sending``: releases deferred block allocations on the PD
           producer side and for OFFLOAD requests whose async D2H saves kept
           source GPU blocks alive after request finish.
@@ -1073,7 +1081,11 @@ class Scheduler:
                 is_offload or not self.kv_connector.is_producer
             ), "Only consumer or offload connector should update recving KV status"
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            self.finished_recving_kv_req_ids.append(req_id)
+            self.finished_recving_kv_req_ids.append(self._normalize_req_id(req_id))
+
+        for req_id in kv_connector_output.failed_recving or ():
+            assert is_offload, "failed_recving is only produced by OFFLOAD connectors"
+            self._recover_failed_offload_load(req_id)
 
         for req_id in kv_connector_output.finished_sending or ():
             if is_offload:
@@ -1132,6 +1144,58 @@ class Scheduler:
         return (
             self._connector_is_offload()
             and self._normalize_req_id(req_id) in self.offload_pending_save_req_ids
+        )
+
+    def _recover_failed_offload_load(self, req_id: str) -> None:
+        """Handle ``failed_recving`` for an OFFLOAD request.
+
+        The worker reported it could not satisfy the H2D load (FIFO
+        eviction in the CPU pool). Three things must happen, in order:
+
+        1. Drop the scheduler-side mirror entries for the request's
+           external hashes so the next ``get_num_new_matched_tokens`` for
+           the same prompt won't re-hit the same stale entries and loop
+           through the failure path again.
+        2. Find the seq parked in ``WAITING_FOR_REMOTE_KVS`` and free
+           its allocated GPU blocks (HBM-prefix + external destinations).
+           ``BlockManager.deallocate`` clears ``block_table`` and resets
+           ``num_cached_tokens`` so the next scheduling pass treats the
+           seq as a fresh waiter.
+        3. Flip its status back to ``WAITING``; ``num_computed_tokens``
+           and ``block_table`` are already 0 / empty after step 2.
+
+        First-pass behavior: even the still-valid HBM prefix hits get
+        thrown away (deallocate is whole-seq). The next scheduling pass
+        will re-discover them via the HBM prefix-cache lookup, so
+        correctness is preserved; only the HBM-rediscovery cost is paid.
+        """
+        evicted = self.kv_connector.handle_failed_load(self._normalize_req_id(req_id))
+        # Locate the seq. failed_recving carries str req_id; seq.id is int.
+        target = next(
+            (
+                seq
+                for seq in self.waiting
+                if self._normalize_req_id(seq.id) == self._normalize_req_id(req_id)
+                and seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS
+            ),
+            None,
+        )
+        if target is None:
+            logger.warning(
+                "OFFLOAD load failed for req=%s but no matching "
+                "WAITING_FOR_REMOTE_KVS seq found (already moved on or "
+                "evicted). Dropped %d mirror entries; nothing else to do.",
+                req_id,
+                len(evicted),
+            )
+            return
+        self.block_manager.deallocate(target)
+        target.status = SequenceStatus.WAITING
+        logger.warning(
+            "OFFLOAD load failed for req=%s: dropped %d mirror entries, "
+            "released GPU blocks, re-queued for plain prefill.",
+            req_id,
+            len(evicted),
         )
 
     def get_request_counts(self) -> tuple[int, int]:

--- a/atom/model_engine/sequence.py
+++ b/atom/model_engine/sequence.py
@@ -78,6 +78,15 @@ class Sequence:
         self.stop_strings = sampling_params.stop_strings
         self.stop_token_sequences = stop_token_sequences or []
         self.is_first_decode = False
+        # Set to True by Scheduler.postprocess after BlockManager.hash_blocks
+        # has registered the prompt blocks for prefix caching. The trigger has
+        # to be per-seq because in deferred-output mode the prefill step's
+        # postprocess has no fwd_output entry for the seq (idx is None) — the
+        # prefill output surfaces one step later, at which point seq.type has
+        # already been flipped to DECODE and placeholder tokens have been
+        # appended. A simple seq.type / len(output_tokens) gate would never
+        # fire for the prefill blocks.
+        self.prefix_hashes_published = False
         # stream callback
         self.stream_callback = stream_callback
         self.output_tokens = []  # cache for newly generate tokens

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -491,6 +491,16 @@ def get_kvconnector(role: str = "worker", config: Optional[Config] = None) -> An
     if not (hasattr(config, "kv_transfer_config") and config.kv_transfer_config):
         return _global_kvconnector
 
+    # Ensure non-disagg backend packages have registered with the factory.
+    # `atom.kv_transfer.disaggregation` registers moriio/mooncake at import
+    # time (it's imported via the KVConnectorFactory module below), but
+    # offload backends (lmcache_offload, etc.) live under a sibling package
+    # and only register if explicitly imported. Doing it here (lazy, idem-
+    # potent) keeps the engine startup path agnostic of the chosen backend.
+    import importlib
+
+    importlib.import_module("atom.kv_transfer.offload")
+
     if role == "worker":
         from aiter.dist.parallel_state import get_tp_group
 

--- a/docs/kv_offload_guide.md
+++ b/docs/kv_offload_guide.md
@@ -56,9 +56,8 @@ overhead with no return. Keep it off in that regime.
 │  _update_from_kv_xfer_finished(out):◄─────┘    │
 │   ├─ finished_recving → WAITING_FOR_REMOTE_KVS │
 │   │   transitions back to WAITING              │
-│   └─ finished_sending → informational (no      │
-│       deferred-free; D2H is independent of     │
-│       the GPU block's lifetime)                │
+│   └─ finished_sending → clear pending save     │
+│       and release deferred GPU blocks          │
 └────────────────┬───────────────────────────────┘
                  │ ScheduledBatch.connector_meta_output
                  ▼
@@ -256,6 +255,37 @@ copy stream with the next-step compute stream via `wait_stream` —
 the only thing missing is intra-step overlap with the same forward's
 attention layers.
 
+## Save completion and block lifetime
+
+OFFLOAD saves are asynchronous D2H copies, so the scheduler must not
+return a finished request's GPU KV blocks to `BlockManager` until the
+worker has confirmed the save completed.
+
+The completion signal is a CUDA event recorded by the worker-side
+connector after all K/V block bytes for a request have been enqueued:
+
+1. `LMCacheOffloadConnector.start_load_kv()` issues `dst.copy_(src,
+   non_blocking=True)` on the dedicated copy stream.
+2. It records `torch.cuda.Event()` on that same stream and stores
+   `(req_id, "save", event)` in `_pending`.
+3. Each engine step calls `ModelRunner.async_proc_aggregation()`, which
+   calls `connector.get_finished()`.
+4. `get_finished()` polls each event with `evt.query()`. If the event
+   has completed and `kind == "save"`, the request id is returned in
+   `done_save`.
+5. `ModelRunner.async_proc_aggregation()` maps `done_save` to
+   `KVConnectorOutput.finished_sending`.
+6. `EngineCore` forwards that output to
+   `Scheduler._update_from_kv_xfer_finished()`.
+7. For `KVConnectorRole.OFFLOAD`, the scheduler removes the request id
+   from `offload_pending_save_req_ids`; if the finished sequence was
+   waiting in `deferred_free_blocks`, it finally calls
+   `block_manager.deallocate(seq)`.
+
+This matches the same lifetime invariant vLLM relies on: a paged GPU KV
+block may be reused only after the connector has either finished saving
+it or otherwise holds an extra reference preventing allocator reuse.
+
 ## Files
 
 | Path                                                       | What                                                |
@@ -267,10 +297,10 @@ attention layers.
 | `atom/kv_transfer/offload/lmcache/lmcache_connector.py`    | Concrete `LMCacheOffloadConnector` (worker + scheduler) |
 | `atom/kv_transfer/offload/README.md`                       | Module-local overview (this guide is the user-facing one) |
 | `atom/model_engine/block_manager.py`                       | `hash_blocks` returns the published `(bid, h)` list |
-| `atom/model_engine/scheduler.py`                           | Role-aware dispatch helpers + OFFLOAD queue_save hook + `bind_block_manager` |
+| `atom/model_engine/scheduler.py`                           | Role-aware dispatch helpers + OFFLOAD queue_save hook + pending-save deferred free |
 | `atom/model_engine/sequence.py`                            | `Sequence.prefix_hashes_published` flag             |
 | `atom/utils/forward_context.py`                            | Lazy `import atom.kv_transfer.offload` so factory registers in worker subprocesses |
-| `tests/test_offload_connector.py`                          | 17 cases: factory wiring, save-queue + mirror, lookup HBM-vs-external dedup, update_state_after_alloc, worker pool, env checks |
+| `tests/test_offload_connector.py`                          | Covers factory wiring, save-queue + mirror, block lifetime, lookup HBM-vs-external dedup, update_state_after_alloc, worker pool, env checks |
 
 ## Known limitations
 

--- a/docs/kv_offload_guide.md
+++ b/docs/kv_offload_guide.md
@@ -1,0 +1,298 @@
+# KV Cache Offload (CPU DRAM) — ATOM Standalone
+
+This guide covers the OFFLOAD connector subsystem at
+`atom/kv_transfer/offload/`, which adds a CPU-DRAM second-tier KV cache
+to **ATOM standalone serving**
+(`python -m atom.entrypoints.openai_server`). The first-tier HBM prefix
+cache (driven by `BlockManager`) stays in place; the OFFLOAD connector
+sits behind it and remembers blocks that have already aged out of HBM,
+so a repeat request can H2D-load them instead of re-running prefill.
+
+If you came from the
+[LMCache plugin recipe](../recipes/atom_vllm/LMCache-KV-Cache-Offload.md):
+that one is for **ATOM-as-vLLM-plugin** mode, where vLLM owns the
+`KVConnectorV1` interface and LMCache plugs into vLLM — ATOM itself
+doesn't participate in offload. **This guide is the standalone-mode
+counterpart**, and the two paths can coexist (a deployment can pick
+either form without affecting the other).
+
+## When to enable
+
+OFFLOAD pays off when **HBM eviction pressure is real**:
+
+- Multi-turn / agentic serving where conversations reuse 90 %+ of their
+  prefix across turns (Claude Code, Cursor, Devin-style agents).
+- Long prompts (20K–150K tokens), short outputs.
+- Many concurrent users contending for the HBM KV pool.
+
+If your working set already fits in HBM, the in-engine prefix cache
+alone serves every hit for free. Adding OFFLOAD then only adds D2H copy
+overhead with no return. Keep it off in that regime.
+
+## Architecture
+
+```
+┌────────── Scheduler (engine process) ──────────┐
+│  schedule():                                   │
+│   ├─ get_num_new_matched_tokens(seq) ─────┐    │
+│   │   • walk BlockManager.compute_hash    │    │
+│   │     chain for the prompt              │    │
+│   │   • count HBM hits (free)             │    │
+│   │   • then count OFFLOAD hits (mirror)  │    │
+│   │   • return external-only token count  │    │
+│   ├─ BlockManager.can_allocate / allocate │    │
+│   └─ update_state_after_alloc(seq) ───────┤    │
+│       • queue H2D load for fresh slots    │    │
+│         beyond the HBM-hit prefix         │    │
+│                                           │    │
+│  postprocess(...):                        │    │
+│   ├─ if not seq.prefix_hashes_published:  │    │  scheduler-side
+│   │    published = hash_blocks(seq, n)    │    │  connector
+│   │    queue_save(req_id, published) ─────┼──→ LMCacheOffloadConnectorScheduler
+│   │                                       │    │  • saved_hashes (mirror)
+│   ├─ append/stream/free                   │    │  • _pending_save / _pending_load
+│   └─ build_connector_meta() ──────────────┼──→ build_connector_meta()
+│                                           │    │  returns OffloadConnectorMetadata
+│  _update_from_kv_xfer_finished(out):◄─────┘    │
+│   ├─ finished_recving → WAITING_FOR_REMOTE_KVS │
+│   │   transitions back to WAITING              │
+│   └─ finished_sending → informational (no      │
+│       deferred-free; D2H is independent of     │
+│       the GPU block's lifetime)                │
+└────────────────┬───────────────────────────────┘
+                 │ ScheduledBatch.connector_meta_output
+                 ▼
+        EngineCore.process_kvconnector_output
+                 │  (IPC to each TP worker)
+                 ▼
+┌────────── Worker (per TP rank) ────────────────┐
+│  LMCacheOffloadConnector                       │
+│   • register_kv_caches → alloc pinned CPU pool │
+│     (cpu_bytes_per_rank / bytes_per_block      │
+│      slots), capture per-layer K and V tensor  │
+│     handles                                    │
+│   • start_load_kv(meta):                       │
+│       copy_stream.wait_stream(compute) ────── ensures D2H reads only
+│       for save block:                          after the prefill's
+│         for layer in 0..L:                     attention write has
+│           gpu_block.bytes ─copy_→ cpu_pool     landed in HBM
+│       for load block:                          (no race on prefill KV)
+│         for layer in 0..L:
+│           cpu_pool ─copy_→ gpu_block.bytes
+│       compute.wait_stream(copy_stream) ─────── ensures the next forward
+│       record CUDA event per request            sees fully-loaded KV
+│   • get_finished() → poll events → return     │
+│     (done_save, done_load) request id sets    │
+│   • hash_to_slot: dict (worker truth)          │
+│                                                │
+│  KVOutputAggregator (existing, reused from PD) │
+│   • aggregate per-rank KVConnectorOutput,      │
+│     vote, return to scheduler                  │
+└────────────────────────────────────────────────┘
+```
+
+The factory registry, ConnectorMetadata flow, and EngineCore dispatch
+are the same machinery used by the existing `disaggregation/`
+Mooncake/MoRIIO PD connectors. OFFLOAD is differentiated by a new
+`KVConnectorRole` enum on the shared base — see the role table in
+[`base.py`](../atom/kv_transfer/disaggregation/base.py).
+
+## Quickstart
+
+```bash
+# Inside the container with ATOM + LMCache (BUILD_WITH_HIP=1) installed
+export PYTHONHASHSEED=0   # mandatory — TP-rank hash consistency
+export AITER_LOG_LEVEL=WARNING
+
+python -m atom.entrypoints.openai_server \
+  --model <model_path> --kv_cache_dtype fp8 -tp <N> --trust-remote-code \
+  --gpu-memory-utilization 0.78 \
+  --kv-transfer-config '{
+      "kv_connector": "lmcache_offload",
+      "kv_role":      "offload",
+      "cpu_bytes":    17179869184
+  }'
+```
+
+You should see, once per worker rank at startup:
+
+```
+LMCacheOffloadConnector initialized (rank-local pool=8.00 GB, ...)
+LMCacheOffload: 8456 slots × 1015808 bytes (pool=8.00 GB, num_layers=62, ...)
+```
+
+…and once in the scheduler process:
+
+```
+LMCacheOffloadConnectorScheduler initialized (chunk_size=256)
+```
+
+Health-check + a sample completion:
+
+```bash
+curl --noproxy '*' -s http://127.0.0.1:8000/health
+curl --noproxy '*' -s http://127.0.0.1:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<model_path>","prompt":"...","max_tokens":8,"temperature":0}'
+```
+
+Run the same prompt twice; the second time the scheduler log should
+show an HBM hit (the OFFLOAD save fires too but HBM serves the request
+without needing an H2D):
+
+```
+Scheduled prefill batch: 1 reqs, 300 new tokens (cached: [0],   new: [300]), req_ids: (0,)
+Scheduled prefill batch: 1 reqs,  12 new tokens (cached: [288], new: [12]),  req_ids: (1,)
+```
+
+## Configuration
+
+All knobs live in the `kv-transfer-config` JSON (dict in code).
+
+| Key                    | Default                | Meaning                                                                 |
+|------------------------|------------------------|-------------------------------------------------------------------------|
+| `kv_connector`         | required               | Set to `"lmcache_offload"` to select this backend                        |
+| `kv_role`              | `"offload"`            | Free-form label, future-reserved for sub-modes                          |
+| `cpu_bytes`            | `8 * 1024**3` (8 GiB)  | **Server-wide** CPU pool budget; split evenly across TP ranks           |
+| `cpu_bytes_per_rank`   | `cpu_bytes / TP`       | Explicit per-rank override (use when split is not even)                 |
+| `chunk_size`           | `256`                  | Reserved for the future LMCacheEngine wrapper; ignored in this impl     |
+| `disk_path`            | unset                  | Reserved for the future NVMe (L3) tier; currently warns + ignores       |
+
+Geometry of one slot (filled at `register_kv_caches`):
+
+- `bytes_per_block = Σ layers (sizeof(K block) + sizeof(V block))`
+- `num_slots = cpu_bytes_per_rank // bytes_per_block`
+
+So if you size `cpu_bytes` to N times the in-HBM block budget, you can
+keep roughly N working sets warm in CPU. Typical: 1–4× of the HBM
+pool for prefix-heavy workloads.
+
+## Operational requirements
+
+1. **`PYTHONHASHSEED=0` is mandatory.** Without it, TP-rank Python dict
+   hashing diverges and the scheduler's optimistic mirror disagrees
+   with the workers. The connector `__init__` raises a `RuntimeError`
+   if the env var is unset or set to anything else.
+
+2. **LMCache must be the HIP-built `c_ops` backend.** The PyPI wheel
+   ships CUDA-linked binaries that don't load on ROCm. Build from
+   source:
+
+   ```bash
+   git clone --depth 1 https://github.com/LMCache/LMCache.git /tmp/LMCache
+   cd /tmp/LMCache
+   BUILD_WITH_HIP=1 pip install -e . --no-build-isolation --no-deps
+   pip install aiofile aiofiles blake3 msgspec sortedcontainers redis pyzmq \
+               prometheus_client numba nvtx httptools setuptools_scm 'numpy<=2.2.6'
+   ```
+
+   Verify: `python -c "import lmcache" 2>&1 | grep backend` should show
+   `Using backend: lmcache.c_ops`. The connector `__init__` rejects
+   `lmcache.python_ops_fallback`.
+
+3. **Enable ATOM's prefix cache** (default on). OFFLOAD piggybacks on
+   the same xxhash64 block-hash chain that `BlockManager` already
+   computes. Disabling prefix caching disables OFFLOAD too.
+
+4. **Don't share the pool across processes.** Each TP rank allocates
+   its own pinned CPU pool; sizing assumes per-rank ownership.
+
+## Cache key consistency
+
+OFFLOAD uses `BlockManager.compute_hash` (xxhash64 chain) as the cache
+key, so HBM hits and OFFLOAD hits live in the same hash space. The
+scheduler lookup order in `get_num_new_matched_tokens`:
+
+1. **HBM** — `BlockManager.hash_to_block_id` (free if hit; no H2D
+   needed).
+2. **OFFLOAD** — connector's `saved_hashes` mirror (H2D from CPU pool
+   if hit).
+3. **Re-prefill** the residual on a miss.
+
+The chain stops at the first OFFLOAD miss because xxhash chains
+forward — a hash mismatch on block N means blocks N+1, N+2, … have
+different content downstream too. This matches the in-HBM behavior of
+`BlockManager.can_allocate`.
+
+## A latent ATOM bug also fixed
+
+This change includes a one-line behavioral fix for ATOM's in-HBM prefix
+cache when running in deferred-output mode (the only mode currently
+used —`tokenIDProcessor.is_deferred_out` is hard-coded `True`).
+
+The old hash-publish gate was `seq.type == SequenceType.PREFILL`. In
+deferred mode this never fires for the prefill step's seq, because the
+prefill output surfaces one engine step later than the prefill forward,
+and by then the next-step `schedule()` has flipped `seq.type` to
+`DECODE`. The result: `BlockManager.hash_to_block_id` was never
+populated for prompt blocks, and the HBM prefix cache was a silent
+no-op (every request reported `cached:[0]` regardless).
+
+The new gate uses a per-seq `Sequence.prefix_hashes_published` flag
+that fires exactly once per seq at the first postprocess where `idx`
+is not `None`, in both deferred and non-deferred modes. Side effect:
+ATOM's existing HBM prefix cache now actually works in default
+deployment — same-prefix requests show `cached:[288]` (or whatever the
+chain count is) and TTFT drops accordingly, independent of whether
+OFFLOAD is enabled.
+
+If for any reason you want the old gate back, set the per-seq flag to
+`True` immediately after `Sequence.__init__` — the gate becomes a
+permanent no-op.
+
+## Layer-by-layer vs batched
+
+The current implementation is **batch-level**: one `start_load_kv`
+call per engine step, with per-layer copy loops inside. CUDA events
+are recorded once per request, not per layer. This keeps the
+implementation small and avoids touching `AiterBackend` /
+`AiterMLABackend`.
+
+Layer-pipelined save/load (analogous to vLLM's
+`wait_for_layer_load` / `save_kv_layer` hooks) is **not** done here.
+It's a worthwhile follow-up if a benchmark shows D2H/H2D on the
+critical path, but the current impl already overlaps the per-step
+copy stream with the next-step compute stream via `wait_stream` —
+the only thing missing is intra-step overlap with the same forward's
+attention layers.
+
+## Files
+
+| Path                                                       | What                                                |
+|------------------------------------------------------------|-----------------------------------------------------|
+| `atom/kv_transfer/disaggregation/base.py`                  | Adds `KVConnectorRole` enum + `role` class attr     |
+| `atom/kv_transfer/offload/base.py`                         | `OffloadConnectorBase` + `OffloadConnectorSchedulerBase` |
+| `atom/kv_transfer/offload/types.py`                        | `OffloadReqMeta` + `OffloadConnectorMetadata`       |
+| `atom/kv_transfer/offload/__init__.py`                     | Re-exports + factory registration                   |
+| `atom/kv_transfer/offload/lmcache/lmcache_connector.py`    | Concrete `LMCacheOffloadConnector` (worker + scheduler) |
+| `atom/kv_transfer/offload/README.md`                       | Module-local overview (this guide is the user-facing one) |
+| `atom/model_engine/block_manager.py`                       | `hash_blocks` returns the published `(bid, h)` list |
+| `atom/model_engine/scheduler.py`                           | Role-aware dispatch helpers + OFFLOAD queue_save hook + `bind_block_manager` |
+| `atom/model_engine/sequence.py`                            | `Sequence.prefix_hashes_published` flag             |
+| `atom/utils/forward_context.py`                            | Lazy `import atom.kv_transfer.offload` so factory registers in worker subprocesses |
+| `tests/test_offload_connector.py`                          | 17 cases: factory wiring, save-queue + mirror, lookup HBM-vs-external dedup, update_state_after_alloc, worker pool, env checks |
+
+## Known limitations
+
+- **NVMe (L3) tier** not implemented. `disk_path` accepted but warns
+  and ignores. Slated for a follow-up via the LMCacheEngine wrapper.
+- **Optimistic-mirror eviction races.** If the worker FIFO-evicts a
+  slot between save and load, a subsequent load lookup reports
+  done-with-empty-block (logged as `WARN: %d/%d H2D load misses`).
+  Mitigation: size `cpu_bytes` comfortably above the working set;
+  surface the miss back to the scheduler in a follow-up.
+- **No per-layer pipelining** (see Layer-by-layer vs batched above).
+- **`get_finished` is per-request**, not per-block. Coarser than the
+  vLLM equivalent; matches the scheduler's per-request
+  `WAITING_FOR_REMOTE_KVS` granularity.
+
+## Related guides
+
+- [`docs/vllm_plugin_backend_guide.md`](vllm_plugin_backend_guide.md) —
+  the ATOM-as-vLLM-plugin counterpart deployment form
+- [`docs/scheduling_kv_cache_guide.md`](scheduling_kv_cache_guide.md) —
+  BlockManager + scheduler internals this connector hooks into
+- [`atom/kv_transfer/disaggregation/README.md`](../atom/kv_transfer/disaggregation/README.md) —
+  PD-disaggregation (Mooncake/MoRIIO), the sibling connector family
+- [`recipes/atom_vllm/LMCache-KV-Cache-Offload.md`](../recipes/atom_vllm/LMCache-KV-Cache-Offload.md) —
+  the plugin-mode LMCache recipe this guide complements

--- a/tests/test_kv_aggregator.py
+++ b/tests/test_kv_aggregator.py
@@ -143,15 +143,79 @@ class TestKVConnectorOutput:
         out = KVConnectorOutput()
         assert out.finished_sending == set()
         assert out.finished_recving == set()
+        assert out.failed_recving == set()
         assert out.expected_finished_count == 0
 
     def test_is_empty(self):
         assert KVConnectorOutput().is_empty()
         assert not KVConnectorOutput(finished_sending={"x"}).is_empty()
         assert not KVConnectorOutput(finished_recving={"x"}).is_empty()
+        assert not KVConnectorOutput(failed_recving={"x"}).is_empty()
 
     def test_repr(self):
-        out = KVConnectorOutput(finished_sending={"a"}, finished_recving={"b"})
+        out = KVConnectorOutput(
+            finished_sending={"a"},
+            finished_recving={"b"},
+            failed_recving={"c"},
+        )
         r = repr(out)
         assert "sending" in r
         assert "recving" in r
+        assert "failed_recving" in r
+
+
+class TestAggregateFailedRecving:
+    """OFFLOAD load failures must propagate to the scheduler as soon as
+    *any* TP rank reports them, not after every rank reports — even one
+    missing KV shard means the request can't TP-forward correctly."""
+
+    def test_single_rank_failure_emits_immediately(self):
+        agg = KVOutputAggregator(world_size=4)
+        outputs = [
+            KVConnectorOutput(failed_recving={"r_evicted"}),
+            KVConnectorOutput(),
+            KVConnectorOutput(),
+            KVConnectorOutput(),
+        ]
+        result = agg.aggregate(outputs)
+        assert result.failed_recving == {"r_evicted"}
+        # Aggregator state must be clean; we don't track failed by-rank.
+        assert agg.pending_count == (0, 0)
+
+    def test_failure_displaces_partial_finished_recving(self):
+        """If a req shows up as finished on some ranks but failed on
+        another, the failure wins: drop the partial finished-recving
+        tracking so the same req can't later be reported as 'done'."""
+        agg = KVOutputAggregator(world_size=4)
+        outputs = [
+            KVConnectorOutput(finished_recving={"r1"}),  # rank 0 done
+            KVConnectorOutput(finished_recving={"r1"}),  # rank 1 done
+            KVConnectorOutput(failed_recving={"r1"}),  # rank 2 failed
+            KVConnectorOutput(),  # rank 3 silent
+        ]
+        result = agg.aggregate(outputs)
+        assert result.failed_recving == {"r1"}
+        assert result.finished_recving == set()
+        # After the failure displacement no per-req state should remain.
+        assert agg.pending_count == (0, 0)
+
+    def test_dedup_within_step(self):
+        """Multiple ranks reporting the same failed req in one step
+        should emit the req once."""
+        agg = KVOutputAggregator(world_size=4)
+        outputs = [KVConnectorOutput(failed_recving={"rA"})] * 3 + [KVConnectorOutput()]
+        result = agg.aggregate(outputs)
+        assert result.failed_recving == {"rA"}
+
+    def test_failure_does_not_affect_other_reqs(self):
+        agg = KVOutputAggregator(world_size=2)
+        outputs = [
+            KVConnectorOutput(
+                finished_sending={"good"},
+                failed_recving={"bad"},
+            ),
+            KVConnectorOutput(finished_sending={"good"}),
+        ]
+        result = agg.aggregate(outputs)
+        assert result.failed_recving == {"bad"}
+        assert result.finished_sending == {"good"}

--- a/tests/test_offload_connector.py
+++ b/tests/test_offload_connector.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: MIT
+# Tests for atom/kv_transfer/offload/* — focused on the OFFLOAD admission
+# and load-queue path. GPU-dependent round-trip behavior is exercised by
+# ad-hoc scripts (see project/005-kvcache-offload notes) since the CI
+# environment mocks torch.cuda.
+
+import os
+
+import pytest
+
+# Connector __init__ enforces this, and it must be set before the module
+# is imported (tests inherit the env from pytest's own process).
+os.environ.setdefault("PYTHONHASHSEED", "0")
+
+from atom.kv_transfer.disaggregation.base import KVConnectorRole
+from atom.kv_transfer.disaggregation.factory import KVConnectorFactory
+from atom.kv_transfer.offload import (  # noqa: F401  (registers factory entry)
+    OffloadConnectorBase,
+    OffloadConnectorMetadata,
+    OffloadConnectorSchedulerBase,
+    OffloadReqMeta,
+)
+from atom.kv_transfer.offload.lmcache.lmcache_connector import (
+    LMCacheOffloadConnector,
+    LMCacheOffloadConnectorScheduler,
+)
+from atom.model_engine.block_manager import BlockManager
+from conftest import MockConfig
+
+_OFFLOAD_CFG = MockConfig(
+    kv_transfer_config={
+        "kv_connector": "lmcache_offload",
+        "kv_role": "offload",
+        "cpu_bytes": 1024 * 1024 * 64,
+    },
+    tensor_parallel_size=1,
+    enable_prefix_caching=True,
+)
+
+
+# ── Factory wiring ────────────────────────────────────────────────────────
+
+
+class TestFactoryRegistration:
+    def test_lmcache_offload_registered(self):
+        assert "lmcache_offload" in KVConnectorFactory._registry
+
+    def test_worker_role_is_offload(self):
+        w = KVConnectorFactory.create_connector(_OFFLOAD_CFG, role="worker")
+        assert isinstance(w, LMCacheOffloadConnector)
+        assert w.role == KVConnectorRole.OFFLOAD
+        assert w.is_producer is False  # OFFLOAD is neither PD producer nor consumer
+
+    def test_scheduler_role_is_offload(self):
+        s = KVConnectorFactory.create_connector(_OFFLOAD_CFG, role="scheduler")
+        assert isinstance(s, LMCacheOffloadConnectorScheduler)
+        assert s.role == KVConnectorRole.OFFLOAD
+
+
+# ── Scheduler-side: queue_save + mirror ───────────────────────────────────
+
+
+class TestSchedulerSaveQueue:
+    def test_queue_save_populates_mirror(self):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.queue_save("r1", [(11, 0xABCD), (12, 0xBCDE)])
+        assert s.saved_hashes == {0xABCD, 0xBCDE}
+        assert "r1" in s._pending_save
+        assert s._pending_save["r1"].block_hashes == [0xABCD, 0xBCDE]
+
+    def test_queue_save_multi_step_accumulates(self):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.queue_save("r1", [(11, 0xAAA)])
+        s.queue_save("r1", [(12, 0xBBB)])
+        assert s._pending_save["r1"].block_ids == [11, 12]
+        assert s._pending_save["r1"].block_hashes == [0xAAA, 0xBBB]
+
+    def test_queue_save_empty_is_noop(self):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.queue_save("r1", [])
+        assert s.saved_hashes == set()
+        assert s._pending_save == {}
+
+    def test_build_connector_meta_drains(self):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.queue_save("r1", [(11, 0xAAA)])
+        meta1 = s.build_connector_meta()
+        assert meta1 is not None
+        assert "r1" in meta1.reqs_to_save
+        meta2 = s.build_connector_meta()
+        assert meta2 is None  # drained
+
+
+# ── Scheduler-side: lookup + admission path ───────────────────────────────
+
+
+def _seq_with_prompt(seq_factory, token_ids, block_size=4):
+    return seq_factory(token_ids, block_size=block_size)
+
+
+class TestSchedulerLookup:
+    def test_lookup_external_hits_chain_prefix(self):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.saved_hashes = {1, 2, 3}
+        # Longest matching prefix from [1, 2, 99, 3]: [1, 2] then break.
+        assert s.lookup_external_hits(None, [1, 2, 99, 3]) == 2
+        assert s.lookup_external_hits(None, [1, 2, 3]) == 3
+        assert s.lookup_external_hits(None, [99, 1]) == 0
+
+    def test_get_num_new_matched_tokens_no_block_manager(self, seq_factory):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        seq = _seq_with_prompt(seq_factory, [1, 2, 3, 4, 5, 6, 7, 8])
+        n_tok, async_load = s.get_num_new_matched_tokens(seq)
+        assert (n_tok, async_load) == (0, False)
+
+    def test_get_num_new_matched_tokens_no_external_hits(
+        self, block_manager_prefix, seq_factory
+    ):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.bind_block_manager(block_manager_prefix)
+        # block_size=4 by MockConfig default; 3 blocks of distinct content.
+        seq = _seq_with_prompt(
+            seq_factory, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+        )
+        n_tok, async_load = s.get_num_new_matched_tokens(seq)
+        assert (n_tok, async_load) == (0, False)
+
+    def test_get_num_new_matched_tokens_external_after_eviction(
+        self, block_manager_prefix, seq_factory
+    ):
+        """Simulate: prior request published 2 blocks to HBM + OFFLOAD.
+        HBM then evicted them (manually clear hash_to_block_id) but
+        OFFLOAD mirror retained them. New same-prefix request should see
+        2 blocks worth of external hits.
+        """
+        bm = block_manager_prefix
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.bind_block_manager(bm)
+
+        # 3-block prompt; last block is never considered by can_allocate
+        # so only first 2 blocks are eligible for prefix-cache reuse.
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]  # 12 tokens / bs=4 → 3 blocks
+        h1 = BlockManager.compute_hash([1, 2, 3, 4])
+        h2 = BlockManager.compute_hash([5, 6, 7, 8], prefix=h1)
+        # OFFLOAD mirror has both (as if a prior request had saved them).
+        s.saved_hashes = {h1, h2}
+        # HBM is empty (simulates eviction).
+        assert h1 not in bm.hash_to_block_id
+
+        seq = _seq_with_prompt(seq_factory, tokens)
+        n_tok, async_load = s.get_num_new_matched_tokens(seq)
+        # 2 external blocks × block_size=4 = 8 tokens.
+        assert async_load is True
+        assert n_tok == 8
+        # Stash should hold the 2 hashes for update_state_after_alloc.
+        stashed = s._external_match_stash[id(seq)]
+        assert stashed == [h1, h2]
+
+    def test_get_num_new_matched_tokens_hbm_takes_precedence(
+        self, block_manager_prefix, seq_factory
+    ):
+        """If HBM has the first block and OFFLOAD has both, we should
+        report only the residual (block 2) as external — block 1 is free
+        in HBM, no need to H2D it.
+        """
+        bm = block_manager_prefix
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.bind_block_manager(bm)
+
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        h1 = BlockManager.compute_hash([1, 2, 3, 4])
+        h2 = BlockManager.compute_hash([5, 6, 7, 8], prefix=h1)
+
+        # Seed HBM with block 1 only — use a dummy seq to allocate +
+        # hash, then mimic the post-publish state.
+        warmup_seq = _seq_with_prompt(seq_factory, [1, 2, 3, 4, 5, 6, 7, 8])
+        bm.allocate(warmup_seq)
+        bm.hash_blocks(warmup_seq, warmup_seq.num_tokens)
+        # Confirm both block hashes are in HBM now (block 0 and 1, since
+        # hash_blocks skips the last partial — but this seq has 2 full
+        # blocks; the "last is never considered for reuse" rule lives in
+        # can_allocate, not hash_blocks).
+        assert h1 in bm.hash_to_block_id
+
+        # OFFLOAD mirror has h2 too (from a hypothetical earlier save).
+        s.saved_hashes = {h1, h2}
+        # Simulate eviction of block 2 only (clear h2 from HBM).
+        if h2 in bm.hash_to_block_id:
+            del bm.hash_to_block_id[h2]
+
+        new_seq = _seq_with_prompt(seq_factory, tokens)
+        n_tok, async_load = s.get_num_new_matched_tokens(new_seq)
+        # Block 1 = HBM hit (free), block 2 = external (needs load) → 4 tokens.
+        assert async_load is True
+        assert n_tok == 4
+
+
+# ── Scheduler-side: update_state_after_alloc → load queue ────────────────
+
+
+class TestSchedulerLoadQueue:
+    def test_update_state_after_alloc_queues_load(
+        self, block_manager_prefix, seq_factory
+    ):
+        bm = block_manager_prefix
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.bind_block_manager(bm)
+
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        h1 = BlockManager.compute_hash([1, 2, 3, 4])
+        h2 = BlockManager.compute_hash([5, 6, 7, 8], prefix=h1)
+        s.saved_hashes = {h1, h2}
+
+        seq = _seq_with_prompt(seq_factory, tokens)
+        n_tok, async_load = s.get_num_new_matched_tokens(seq)
+        assert async_load and n_tok == 8
+
+        # Mimic admission: BlockManager allocates fresh blocks for all
+        # 3 prompt blocks (HBM was empty).
+        bm.allocate(seq)
+        s.update_state_after_alloc(seq)
+
+        assert str(seq.id) in s._pending_load
+        meta = s._pending_load[str(seq.id)]
+        assert meta.block_hashes == [h1, h2]
+        # dest_block_ids are seq.block_table[n_hbm : n_hbm + n_ext]; n_hbm=0
+        # here so the first 2 fresh slots.
+        assert meta.block_ids == list(seq.block_table[:2])
+
+    def test_no_stash_after_alloc_is_noop(self, block_manager_prefix, seq_factory):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.bind_block_manager(block_manager_prefix)
+        seq = _seq_with_prompt(seq_factory, [1, 2, 3, 4])
+        s.update_state_after_alloc(seq)  # never went through lookup
+        assert s._pending_load == {}
+
+
+# ── Worker-side: pool sizing + degenerate paths ──────────────────────────
+
+
+class TestWorkerPool:
+    def test_environment_check_rejects_bad_pythonhashseed(self, monkeypatch):
+        monkeypatch.setenv("PYTHONHASHSEED", "42")
+        with pytest.raises(RuntimeError, match="PYTHONHASHSEED"):
+            LMCacheOffloadConnector(_OFFLOAD_CFG)
+
+    def test_start_load_kv_before_pool_init_drops(self):
+        w = LMCacheOffloadConnector(_OFFLOAD_CFG)
+        # register_kv_caches never called — pool is empty.
+        assert w._num_slots == 0
+        meta = OffloadConnectorMetadata()
+        meta.reqs_to_save["rX"] = OffloadReqMeta(block_ids=[1], block_hashes=[0xAAA])
+        meta.reqs_to_load["rY"] = OffloadReqMeta(block_ids=[2], block_hashes=[0xBBB])
+        w.start_load_kv(meta)
+        done_save, done_load = w.get_finished()
+        # Both reported as done so the scheduler doesn't stall, but no
+        # GPU motion happened.
+        assert done_save == {"rX"}
+        assert done_load == {"rY"}
+
+    def test_start_load_kv_empty_metadata_noop(self):
+        w = LMCacheOffloadConnector(_OFFLOAD_CFG)
+        w.start_load_kv(None)
+        w.start_load_kv(OffloadConnectorMetadata())
+        done_save, done_load = w.get_finished()
+        assert done_save == set() and done_load == set()

--- a/tests/test_offload_connector.py
+++ b/tests/test_offload_connector.py
@@ -5,6 +5,10 @@
 # environment mocks torch.cuda.
 
 import os
+import importlib.util
+import sys
+import types
+from collections import deque
 
 import pytest
 
@@ -24,7 +28,10 @@ from atom.kv_transfer.offload.lmcache.lmcache_connector import (
     LMCacheOffloadConnector,
     LMCacheOffloadConnectorScheduler,
 )
+from atom.kv_transfer.disaggregation.types import KVConnectorOutput
 from atom.model_engine.block_manager import BlockManager
+from atom.model_engine.scheduler import ScheduledBatchOutput, Scheduler
+from atom.model_engine.sequence import SequenceStatus
 from conftest import MockConfig
 
 _OFFLOAD_CFG = MockConfig(
@@ -36,6 +43,25 @@ _OFFLOAD_CFG = MockConfig(
     tensor_parallel_size=1,
     enable_prefix_caching=True,
 )
+
+
+@pytest.fixture(autouse=True)
+def stub_lmcache_and_torch(monkeypatch):
+    """Keep offload unit tests independent of optional GPU/runtime deps."""
+    if importlib.util.find_spec("lmcache") is None:
+        fake_lmcache = types.SimpleNamespace(
+            c_ops=object(), _backend_module="lmcache.c_ops"
+        )
+        monkeypatch.setitem(sys.modules, "lmcache", fake_lmcache)
+
+    if importlib.util.find_spec("torch") is None:
+        fake_torch = types.SimpleNamespace(
+            uint8=object(),
+            empty=lambda num_bytes, dtype, pin_memory: types.SimpleNamespace(
+                data_ptr=lambda: 0
+            ),
+        )
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
 
 
 # ── Factory wiring ────────────────────────────────────────────────────────
@@ -91,11 +117,126 @@ class TestSchedulerSaveQueue:
         assert meta2 is None  # drained
 
 
+class TestSchedulerOffloadBlockLifetime:
+    def test_finished_seq_with_pending_offload_save_defers_block_free(self, seq_factory):
+        scheduler = _scheduler_with_offload_connector()
+        seq = _seq_with_prompt(seq_factory, [10, 11, 12, 13, 14, 15, 16, 17])
+        scheduler.block_manager.allocate(seq)
+        seq.status = SequenceStatus.RUNNING
+        scheduler.running.append(seq)
+
+        fwd_output = ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[(scheduler.eos_token_id,)],
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
+        )
+
+        finished = scheduler.postprocess([seq], fwd_output)
+
+        assert finished == [seq]
+        assert str(seq.id) in scheduler.offload_pending_save_req_ids
+        assert str(seq.id) in scheduler.deferred_free_blocks
+        assert seq.block_table
+
+    def test_offload_save_completion_releases_deferred_blocks(self, seq_factory):
+        scheduler = _scheduler_with_offload_connector()
+        seq = _seq_with_prompt(seq_factory, [10, 11, 12, 13, 14, 15, 16, 17])
+        scheduler.block_manager.allocate(seq)
+        seq.status = SequenceStatus.RUNNING
+        scheduler.running.append(seq)
+
+        fwd_output = ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[(scheduler.eos_token_id,)],
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
+        )
+        scheduler.postprocess([seq], fwd_output)
+
+        scheduler._update_from_kv_xfer_finished(
+            KVConnectorOutput(finished_sending={str(seq.id)})
+        )
+
+        assert str(seq.id) not in scheduler.offload_pending_save_req_ids
+        assert seq.id not in scheduler.deferred_free_blocks
+        assert seq.block_table == []
+
+    def test_finished_seq_without_offload_save_frees_immediately(self, seq_factory):
+        scheduler = _scheduler_with_offload_connector()
+        seq = _seq_with_prompt(seq_factory, [10, 11, 12])
+        scheduler.block_manager.allocate(seq)
+        seq.status = SequenceStatus.RUNNING
+        scheduler.running.append(seq)
+
+        fwd_output = ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[(scheduler.eos_token_id,)],
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
+        )
+
+        scheduler.postprocess([seq], fwd_output)
+
+        assert str(seq.id) not in scheduler.offload_pending_save_req_ids
+        assert seq.id not in scheduler.deferred_free_blocks
+        assert seq.block_table == []
+
+    def test_offload_save_completion_before_finish_allows_immediate_free(
+        self, seq_factory
+    ):
+        scheduler = _scheduler_with_offload_connector()
+        seq = _seq_with_prompt(seq_factory, [10, 11, 12, 13, 14, 15, 16, 17])
+        scheduler.block_manager.allocate(seq)
+        scheduler.kv_connector.queue_save(str(seq.id), [(seq.block_table[0], 0xAAA)])
+        scheduler.offload_pending_save_req_ids.add(str(seq.id))
+
+        scheduler._update_from_kv_xfer_finished(
+            KVConnectorOutput(finished_sending={str(seq.id)})
+        )
+
+        seq.prefix_hashes_published = True
+        seq.status = SequenceStatus.RUNNING
+        scheduler.running.append(seq)
+        fwd_output = ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[(scheduler.eos_token_id,)],
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
+        )
+        scheduler.postprocess([seq], fwd_output)
+
+        assert str(seq.id) not in scheduler.offload_pending_save_req_ids
+        assert seq.id not in scheduler.deferred_free_blocks
+        assert seq.block_table == []
+
+
 # ── Scheduler-side: lookup + admission path ───────────────────────────────
 
 
 def _seq_with_prompt(seq_factory, token_ids, block_size=4):
     return seq_factory(token_ids, block_size=block_size)
+
+
+def _scheduler_with_offload_connector():
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.block_manager = BlockManager(_OFFLOAD_CFG)
+    scheduler.running = deque()
+    scheduler.eos_token_id = _OFFLOAD_CFG.eos_token_id
+    scheduler.stop_token_ids = _OFFLOAD_CFG.stop_token_ids
+    scheduler.use_spec = False
+    scheduler.mtp_k = 0
+    scheduler.spec_stats = None
+    scheduler.deferred_free_blocks = {}
+    scheduler.offload_pending_save_req_ids = set()
+    scheduler.finished_recving_kv_req_ids = []
+    scheduler.kv_connector = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+    scheduler.kv_connector.bind_block_manager(scheduler.block_manager)
+    return scheduler
 
 
 class TestSchedulerLookup:
@@ -264,3 +405,70 @@ class TestWorkerPool:
         w.start_load_kv(OffloadConnectorMetadata())
         done_save, done_load = w.get_finished()
         assert done_save == set() and done_load == set()
+
+    def test_register_kv_caches_mla_uses_block_bytes(self, monkeypatch):
+        """MLA k_cache is token-major: [num_blocks * block_size, 1, 576].
+
+        Offload slots must copy one logical paged block, not one token row.
+        """
+
+        class FakeTensor:
+            is_cuda = True
+
+            def __init__(
+                self,
+                shape=(8, 1, 576),
+                stride=(576, 576, 1),
+                element_size=2,
+            ):
+                self.shape = shape
+                self._stride = stride
+                self._element_size = element_size
+                self.device = "cuda:0"
+
+            def is_contiguous(self):
+                return True
+
+            def numel(self):
+                n = 1
+                for dim in self.shape:
+                    n *= dim
+                return n
+
+            def element_size(self):
+                return self._element_size
+
+            def stride(self, dim):
+                return self._stride[dim]
+
+            def view(self, *args):
+                return self
+
+            def data_ptr(self):
+                return 0xCAFE
+
+        class FakeKV:
+            k_cache = FakeTensor()
+            v_cache = None
+
+        class FakeCPUPool(FakeTensor):
+            def __init__(self, num_bytes):
+                super().__init__(shape=(num_bytes,), stride=(1,), element_size=1)
+
+        fake_torch = types.SimpleNamespace(
+            uint8=object(),
+            empty=lambda num_bytes, dtype, pin_memory: FakeCPUPool(num_bytes),
+        )
+        fake_lmcache = types.SimpleNamespace(
+            c_ops=object(), _backend_module="lmcache.c_ops"
+        )
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+        monkeypatch.setitem(sys.modules, "lmcache", fake_lmcache)
+
+        w = LMCacheOffloadConnector(_OFFLOAD_CFG)
+        w.register_kv_caches({"layer0": FakeKV()})
+
+        # block_size=4, row bytes=576 * bf16(2) => one MLA block is 4608 bytes.
+        assert w._k_bytes_per_layer == [4 * 576 * 2]
+        assert w._v_bytes_per_layer == [0]
+        assert w.bytes_per_block == 4 * 576 * 2

--- a/tests/test_offload_connector.py
+++ b/tests/test_offload_connector.py
@@ -8,7 +8,7 @@ import os
 import importlib.util
 import sys
 import types
-from collections import deque
+from collections import OrderedDict, deque
 
 import pytest
 
@@ -45,20 +45,47 @@ _OFFLOAD_CFG = MockConfig(
 )
 
 
+def _fake_lmcache_namespace() -> types.SimpleNamespace:
+    """Stub ``lmcache`` module that satisfies the connector's
+    ``_check_environment`` import probe plus the ``c_ops`` calls that
+    ``register_kv_caches`` and ``close`` make: ``alloc_pinned_ptr`` and
+    ``free_pinned_ptr``. Returned ptrs are bytearray ``id()`` so each call
+    is unique and ``int(...)`` cast succeeds.
+    """
+    fake_allocs: dict[int, bytearray] = {}
+
+    def alloc_pinned_ptr(size: int, device_id: int = 0) -> int:
+        buf = bytearray(int(size))
+        ptr = id(buf)
+        fake_allocs[ptr] = buf
+        return ptr
+
+    def free_pinned_ptr(ptr: int) -> None:
+        fake_allocs.pop(int(ptr), None)
+
+    return types.SimpleNamespace(
+        c_ops=types.SimpleNamespace(
+            alloc_pinned_ptr=alloc_pinned_ptr,
+            free_pinned_ptr=free_pinned_ptr,
+        ),
+        _backend_module="lmcache.c_ops",
+    )
+
+
 @pytest.fixture(autouse=True)
 def stub_lmcache_and_torch(monkeypatch):
     """Keep offload unit tests independent of optional GPU/runtime deps."""
     if importlib.util.find_spec("lmcache") is None:
-        fake_lmcache = types.SimpleNamespace(
-            c_ops=object(), _backend_module="lmcache.c_ops"
-        )
-        monkeypatch.setitem(sys.modules, "lmcache", fake_lmcache)
+        monkeypatch.setitem(sys.modules, "lmcache", _fake_lmcache_namespace())
 
     if importlib.util.find_spec("torch") is None:
         fake_torch = types.SimpleNamespace(
             uint8=object(),
             empty=lambda num_bytes, dtype, pin_memory: types.SimpleNamespace(
                 data_ptr=lambda: 0
+            ),
+            frombuffer=lambda buf, dtype: types.SimpleNamespace(
+                data_ptr=lambda: id(buf)
             ),
         )
         monkeypatch.setitem(sys.modules, "torch", fake_torch)
@@ -118,7 +145,9 @@ class TestSchedulerSaveQueue:
 
 
 class TestSchedulerOffloadBlockLifetime:
-    def test_finished_seq_with_pending_offload_save_defers_block_free(self, seq_factory):
+    def test_finished_seq_with_pending_offload_save_defers_block_free(
+        self, seq_factory
+    ):
         scheduler = _scheduler_with_offload_connector()
         seq = _seq_with_prompt(seq_factory, [10, 11, 12, 13, 14, 15, 16, 17])
         scheduler.block_manager.allocate(seq)
@@ -226,6 +255,7 @@ def _scheduler_with_offload_connector():
     scheduler = Scheduler.__new__(Scheduler)
     scheduler.block_manager = BlockManager(_OFFLOAD_CFG)
     scheduler.running = deque()
+    scheduler.waiting = deque()
     scheduler.eos_token_id = _OFFLOAD_CFG.eos_token_id
     scheduler.stop_token_ids = _OFFLOAD_CFG.stop_token_ids
     scheduler.use_spec = False
@@ -458,12 +488,10 @@ class TestWorkerPool:
         fake_torch = types.SimpleNamespace(
             uint8=object(),
             empty=lambda num_bytes, dtype, pin_memory: FakeCPUPool(num_bytes),
-        )
-        fake_lmcache = types.SimpleNamespace(
-            c_ops=object(), _backend_module="lmcache.c_ops"
+            frombuffer=lambda buf, dtype: FakeCPUPool(len(buf)),
         )
         monkeypatch.setitem(sys.modules, "torch", fake_torch)
-        monkeypatch.setitem(sys.modules, "lmcache", fake_lmcache)
+        monkeypatch.setitem(sys.modules, "lmcache", _fake_lmcache_namespace())
 
         w = LMCacheOffloadConnector(_OFFLOAD_CFG)
         w.register_kv_caches({"layer0": FakeKV()})
@@ -472,3 +500,240 @@ class TestWorkerPool:
         assert w._k_bytes_per_layer == [4 * 576 * 2]
         assert w._v_bytes_per_layer == [0]
         assert w.bytes_per_block == 4 * 576 * 2
+
+
+# ── §2.6: load-miss surfaces as failed_load (no silent wrong-KV) ─────────
+
+
+class TestFailedLoadSurfacing:
+    """OFFLOAD §2.6 — the worker must NOT silently let a load-miss leave
+    paged blocks uninitialized; it must report the req via
+    ``get_failed_load``, the scheduler-side handler must drop the mirror
+    entry, and ``_recover_failed_offload_load`` must free GPU blocks and
+    re-queue the seq for plain prefill.
+    """
+
+    def test_get_failed_load_returns_empty_by_default(self):
+        w = LMCacheOffloadConnector(_OFFLOAD_CFG)
+        assert w.get_failed_load() == set()
+
+    def test_get_failed_load_drains_each_call(self):
+        w = LMCacheOffloadConnector(_OFFLOAD_CFG)
+        w._failed_load = {"r1", "r2"}
+        assert w.get_failed_load() == {"r1", "r2"}
+        # Subsequent call returns empty — set was drained.
+        assert w.get_failed_load() == set()
+
+    def test_start_load_kv_miss_marks_failed_and_skips_enqueue(self):
+        """When a req's load hash isn't in hash_to_slot at worker time,
+        the req must go into _failed_load and NO load event should be
+        appended to _pending. The current step's _pending should only
+        contain events for the reqs the worker could fully satisfy."""
+        w = LMCacheOffloadConnector(_OFFLOAD_CFG)
+
+        # Set up minimal worker state without going through register_kv_caches
+        # so we don't need a real CUDA stream — start_load_kv early-outs
+        # on _num_slots == 0, so flip those flags to bypass that guard.
+        w._num_slots = 4
+
+        # Fake byte-view tensors so the per-block slicing doesn't blow up.
+        # __getitem__ returns self so dst[slice].copy_(src) works.
+        class _FakeView:
+            device = "cuda:0"
+
+            def __getitem__(self, _slc):
+                return self
+
+            def copy_(self, _src, non_blocking=False):
+                return self
+
+        fake_pool = _FakeView()
+        w._cpu_pool = fake_pool
+        w.hash_to_slot = OrderedDict({0x111: 0})  # only 0x111 is "in pool"
+        w._k_uint8_views = [_FakeView()]
+        w.num_layers = 1
+        w.bytes_per_block = 1
+        w._k_bytes_per_layer = [1]
+        w._v_bytes_per_layer = [0]
+        w._v_uint8_views = [None]
+
+        # Avoid real CUDA — patch the bits start_load_kv touches.
+        class _FakeStream:
+            def wait_stream(self, _other):
+                return None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        class _FakeEvent:
+            def record(self, _stream):
+                return None
+
+            def query(self):
+                return True
+
+        w._copy_stream = _FakeStream()
+        w._ensure_copy_stream = lambda _device: None
+
+        import sys
+        import types as _types
+
+        fake_cuda = _types.SimpleNamespace(
+            current_stream=lambda _dev: _FakeStream(),
+            stream=lambda _s: _FakeStream(),
+            Event=lambda: _FakeEvent(),
+        )
+        torch_mod = sys.modules["torch"]
+        # SimpleNamespace doesn't accept arbitrary attribute assignment
+        # the way patching does, but works for setattr.
+        setattr(torch_mod, "cuda", fake_cuda)
+
+        # rA: chain hits — fully satisfied
+        # rB: chain misses (0x222 not in pool) — must fail entirely
+        meta = OffloadConnectorMetadata()
+        meta.reqs_to_load = {
+            "rA": OffloadReqMeta(block_ids=[10], block_hashes=[0x111]),
+            "rB": OffloadReqMeta(block_ids=[20, 21], block_hashes=[0x111, 0x222]),
+        }
+
+        w.start_load_kv(meta)
+
+        # rA load event was enqueued; rB was not (any block miss fails req)
+        load_event_reqs = [rid for rid, kind, _ in w._pending if kind == "load"]
+        assert load_event_reqs == ["rA"]
+        assert w._failed_load == {"rB"}
+
+    def test_scheduler_handle_failed_load_drops_mirror_and_stash(self):
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.saved_hashes = {0xAAA, 0xBBB, 0xCCC}
+        s._external_hashes_by_req["r99"] = [0xAAA, 0xBBB]
+
+        evicted = s.handle_failed_load("r99")
+
+        assert evicted == [0xAAA, 0xBBB]
+        # 0xAAA/0xBBB dropped, 0xCCC untouched (different req's hashes).
+        assert s.saved_hashes == {0xCCC}
+        assert "r99" not in s._external_hashes_by_req
+        # Idempotent: second call returns empty, no double-drop.
+        assert s.handle_failed_load("r99") == []
+
+    def test_update_state_after_alloc_records_external_hashes(
+        self, block_manager_prefix, seq_factory
+    ):
+        """After update_state_after_alloc the per-req external hashes
+        must be remembered so handle_failed_load can drop them later."""
+        bm = block_manager_prefix
+        s = LMCacheOffloadConnectorScheduler(_OFFLOAD_CFG)
+        s.bind_block_manager(bm)
+
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        h1 = BlockManager.compute_hash([1, 2, 3, 4])
+        h2 = BlockManager.compute_hash([5, 6, 7, 8], prefix=h1)
+        s.saved_hashes = {h1, h2}
+
+        seq = _seq_with_prompt(seq_factory, tokens)
+        n_tok, async_load = s.get_num_new_matched_tokens(seq)
+        assert async_load and n_tok == 8
+        bm.allocate(seq)
+        s.update_state_after_alloc(seq)
+
+        # The connector remembers what to evict on failure.
+        assert s._external_hashes_by_req[str(seq.id)] == [h1, h2]
+        # handle_failed_load drops them.
+        evicted = s.handle_failed_load(str(seq.id))
+        assert set(evicted) == {h1, h2}
+        assert h1 not in s.saved_hashes and h2 not in s.saved_hashes
+
+
+class TestSchedulerRecoverFailedOffloadLoad:
+    """End-to-end §2.6 recovery: scheduler sees ``failed_recving`` for a
+    seq parked in WAITING_FOR_REMOTE_KVS and must:
+      1. Free its allocated GPU blocks
+      2. Flip it back to WAITING (so the next scheduling pass treats it
+         as a fresh waiter)
+      3. Drop the corresponding mirror hashes from the connector
+    """
+
+    def test_recover_failed_load_releases_blocks_and_reverts_status(self, seq_factory):
+        scheduler = _scheduler_with_offload_connector()
+        bm = scheduler.block_manager
+        s = scheduler.kv_connector
+
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        h1 = BlockManager.compute_hash([1, 2, 3, 4])
+        h2 = BlockManager.compute_hash([5, 6, 7, 8], prefix=h1)
+        s.saved_hashes = {h1, h2, 0xCAFE}
+
+        seq = _seq_with_prompt(seq_factory, tokens)
+        # Drive through the admission path so block_table is laid out and
+        # the connector stash is populated, then park the seq in
+        # WAITING_FOR_REMOTE_KVS (the scheduler does this in its main loop).
+        n_tok, async_load = s.get_num_new_matched_tokens(seq)
+        assert async_load and n_tok == 8
+        bm.allocate(seq)
+        s.update_state_after_alloc(seq)
+        seq.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
+        scheduler.waiting.append(seq)
+
+        # Sanity precondition.
+        assert seq.block_table  # blocks allocated
+        assert str(seq.id) in s._external_hashes_by_req
+
+        # Worker reports the load failed.
+        scheduler._update_from_kv_xfer_finished(
+            KVConnectorOutput(failed_recving={str(seq.id)})
+        )
+
+        # The seq's blocks are freed and status flipped back to WAITING.
+        assert seq.block_table == []
+        assert seq.num_cached_tokens == 0
+        assert seq.status == SequenceStatus.WAITING
+        # The mirror dropped h1/h2 but kept the unrelated 0xCAFE entry.
+        assert h1 not in s.saved_hashes
+        assert h2 not in s.saved_hashes
+        assert 0xCAFE in s.saved_hashes
+        # Per-req stash cleared.
+        assert str(seq.id) not in s._external_hashes_by_req
+
+    def test_recover_failed_load_missing_seq_is_safe(self, seq_factory):
+        """A failure report after the seq has already moved on (e.g. an
+        out-of-band recovery) must not raise — log and move on."""
+        scheduler = _scheduler_with_offload_connector()
+        # No matching seq in waiting; just call directly.
+        scheduler._update_from_kv_xfer_finished(
+            KVConnectorOutput(failed_recving={"99999"})
+        )
+        # No exception, no state mutation.
+        assert scheduler.waiting == deque()
+
+
+class TestSchedulerOffloadWakeFromOffloadHit:
+    """§2.6-adjacent regression: scheduler's wake-from-WAITING_FOR_REMOTE_KVS
+    path used to compare seq.id (int) against finished_recving_kv_req_ids
+    (which OFFLOAD pushes as str(seq.id)). The mismatch silently kept the
+    seq parked forever — visible only when an OFFLOAD load is the FIRST
+    thing to wake a seq (HBM-evicted prefix, no PD producer in the mix).
+    Normalize both sides to str via _normalize_req_id."""
+
+    def test_finished_recving_str_id_unparks_int_seq_id(self, seq_factory):
+        scheduler = _scheduler_with_offload_connector()
+        seq = _seq_with_prompt(seq_factory, [10, 11, 12, 13])
+        scheduler.block_manager.allocate(seq)
+        seq.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
+        scheduler.waiting.append(seq)
+
+        # Worker reports str(seq.id) per connector convention.
+        scheduler._update_from_kv_xfer_finished(
+            KVConnectorOutput(finished_recving={str(seq.id)})
+        )
+
+        # The bookkeeping list must hold the normalized form, AND the
+        # int-keyed lookup in _update_waiting_for_remote_kv must succeed.
+        assert str(seq.id) in scheduler.finished_recving_kv_req_ids
+        unparked = scheduler._update_waiting_for_remote_kv(seq)
+        assert unparked is True
+        # And the entry is consumed.
+        assert str(seq.id) not in scheduler.finished_recving_kv_req_ids


### PR DESCRIPTION
## Summary

Adds a CPU-DRAM second-tier KV cache to **ATOM standalone serving** (`python -m atom.entrypoints.openai_server`), filling the gap left by the existing [ATOM-as-vLLM-plugin + LMCache recipe (#890)](https://github.com/ROCm/ATOM/commit/db136a4) where ATOM itself does not participate in offload — vLLM owns the `KVConnectorV1` interface and LMCache plugs into vLLM. This PR keeps that recipe intact and adds a parallel path that works in standalone mode.

New module `atom/kv_transfer/offload/` is a sibling of the existing `disaggregation/` (Mooncake/MoRIIO PD), sharing the same `KVConnectorFactory` registry, `ConnectorMetadata` flow, `KVOutputAggregator`, scheduler-side hook points, and EngineCore dispatch path. Differences captured by a new `KVConnectorRole` enum (`PD_PRODUCER` / `PD_CONSUMER` / `OFFLOAD`) on the shared base; the scheduler routes producer/consumer-only invariants past OFFLOAD via three helpers and keeps PD behavior byte-for-byte unchanged.

Concrete impl `LMCacheOffloadConnector` talks directly to `lmcache.c_ops` (HIP-built pinned-memory allocator), bypassing `lmcache.integration.vllm.vllm_v1_adapter` so the import graph stays vllm-free. D2H/H2D goes through `torch.copy_(non_blocking=True)` on a dedicated CUDA stream — none of LMCache's `GPUKVFormat` variants matches ATOM's per-layer K shape `(NB, NH, HD/x, BS, x)` (AITER swizzled) + separate V `(NB, NH, HD, BS)`, so a byte-level copy via flat reinterpret-cast ranges is the layout-agnostic correct minimum.

User guide: [`docs/kv_offload_guide.md`](https://github.com/ROCm/ATOM/blob/feature/standalone-kv-offload-lmcache-squashed/docs/kv_offload_guide.md).

## Side effect — a real pre-existing ATOM bug fixed

The hash-publish gate in `Scheduler.postprocess` moves off `seq.type == SequenceType.PREFILL` to a new per-seq `Sequence.prefix_hashes_published` flag. The old gate was effectively dead under deferred-output mode (`tokenIDProcessor.is_deferred_out` is hard-coded `True`): the prefill-step postprocess sees the seq with `idx=None` and skips it; the next-step postprocess sees the prefill's output but `seq.type` has been flipped to `DECODE`. **Result: `BlockManager.hash_to_block_id` was never populated for prompt blocks, and ATOM's HBM prefix cache was a silent no-op (every request reported `cached:[0]` regardless of repeat prefix).**

Confirmed on MiniMax-M2.5 TP=2 — same-prefix repeat requests now hit `cached:[288]` instead of `cached:[0]`, TTFT drops ~45% (138 ms → 75 ms) **independent of whether OFFLOAD is enabled**.

## How to enable

```bash
python -m atom.entrypoints.openai_server \
  --model <model> --kv_cache_dtype fp8 -tp N --trust-remote-code \
  --gpu-memory-utilization 0.78 \
  --kv-transfer-config '{"kv_connector":"lmcache_offload","kv_role":"offload","cpu_bytes":17179869184}'
```

Requires `PYTHONHASHSEED=0` and an LMCache built from source with `BUILD_WITH_HIP=1`. See guide.

## Test plan

- [x] `tests/test_offload_connector.py` (new, 17 cases) — factory wiring, save-queue + mirror, lookup HBM-vs-OFFLOAD admission de-dup, `update_state_after_alloc` → `_pending_load` wiring, worker pool sizing, `PYTHONHASHSEED` check, "before pool init" graceful drop
- [x] `tests/test_scheduler.py` + `tests/test_block_manager.py` — 60/60 pass, PD path unchanged
- [x] Live verification on MiniMax-M2.5 (456B MoE, FP8) TP=2 on 2× MI300X:
  - 5 distinct prompts in one prefill batch (1380 new tokens) — no crash, TTFT ~150 ms
  - Same-prefix repeat × 3 — TTFT 138 → 75 ms, scheduler shows `cached:[288] new:[12]`
  - Output bit-identical (temperature=0)
- [ ] Full kv-cache-tester agentic trace replay vs db136a4 baseline numbers — left as follow-up (kv-cache-tester repo not checked out in this environment)
- [ ] Layer-pipelined save/load — left as follow-up (current impl is batch-level; enable if benchmark shows D2H on the critical path)

## Files

| Area | Path | Note |
|---|---|---|
| Framework (shared) | `atom/kv_transfer/disaggregation/base.py` | `KVConnectorRole` enum + `role` attr |
| New module | `atom/kv_transfer/offload/{base,types,__init__,README}.py(md)` | abstract base + types + factory registration |
| Concrete impl | `atom/kv_transfer/offload/lmcache/lmcache_connector.py` | worker + scheduler classes |
| Engine wiring | `atom/model_engine/scheduler.py` | role-aware dispatch + OFFLOAD queue_save hook + `bind_block_manager` |
| Engine wiring | `atom/model_engine/block_manager.py` | `hash_blocks` returns published `(bid, h)` list |
| Engine wiring | `atom/model_engine/sequence.py` | `prefix_hashes_published` flag |
| Engine wiring | `atom/utils/forward_context.py` | lazy import for factory registration in worker subprocesses |
| User guide | `docs/kv_offload_guide.md` | architecture, quickstart, knobs, limitations |
| Tests | `tests/test_offload_connector.py` | 17 cases |

🤖 Generated with [Claude Code](https://claude.com/claude-code) — AI-assisted; human submitter (yhl-amd) has reviewed every changed line and run the test plan above.