### PR TITLE
fix(dp): route DP all_gather through custom AR to survive CUDAGraph capture

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -204,7 +204,11 @@ def pad_for_all_gather(x: torch.Tensor):
 
 def all_gather_with_padding(x: torch.Tensor):
     padded_x, original_batch_size = pad_for_all_gather(x)
-    gathered_hidden_states = get_dp_group().all_gather(padded_x, dim=0)
+    # use_custom=True routes through CA IPC (outplace_all_gather). Default
+    # use_custom=False falls back to torch.distributed.all_gather_into_tensor
+    # (NCCL), whose WorkNCCL end-event recorded inside CUDAGraph capture is
+    # later queried by the watchdog thread -> hipErrorCapturedEvent crash.
+    gathered_hidden_states = get_dp_group().all_gather(padded_x, use_custom=True, dim=0)
     return gathered_hidden_states, original_batch_size
 
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2018,7 +2018,10 @@ class MoE(nn.Module):
 
                 ids_2d = ids.unsqueeze(-1)
                 ids_2d, _ = pad_for_all_gather(ids_2d)
-                ids_2d = _get_dp_group().all_gather(ids_2d, dim=0)
+                # use_custom=True: avoid NCCL all_gather recording an event
+                # inside CUDAGraph capture (watchdog would later query it and
+                # trigger hipErrorCapturedEvent).
+                ids_2d = _get_dp_group().all_gather(ids_2d, use_custom=True, dim=0)
                 ids = ids_2d[:num_tokens].flatten()
             ids = ids.clamp(0, self.gate.tid2eid.shape[0] - 1)
         topk_ids = self.gate.tid2eid[ids].to(torch.int32)  # [N, topk]

--- a/scripts/wait_server_ready.sh
+++ b/scripts/wait_server_ready.sh
@@ -29,6 +29,14 @@ for ((i=1; i<=ITERS; i++)); do
     sleep "$POLL"
     READY=$(curl -s -m 3 "http://localhost:${PORT}/v1/models" 2>/dev/null | head -c 60)
     if [ -f "$LOG_FILE" ]; then
+        # Detect truncation/recreation: if current size < snapshot, the file
+        # was rewritten (e.g. start_atom_server.sh `tee` truncates). Reset
+        # offset to 0 so we scan the new content.
+        CUR_BYTES=$(stat -c %s "$LOG_FILE" 2>/dev/null || echo 0)
+        if [ "$CUR_BYTES" -lt "$LOG_START_BYTES" ]; then
+            echo "[t=$((i*POLL))s] log truncated (cur=$CUR_BYTES < snapshot=$LOG_START_BYTES), scanning from offset 0"
+            LOG_START_BYTES=0
+        fi
         ERR=$(tail -c "+$((LOG_START_BYTES + 1))" "$LOG_FILE" 2>/dev/null \
             | grep -c "cluster_dims\|InductorError\|SHUTDOWN signal\|proc died")
     else


### PR DESCRIPTION
## Summary
\`enable_dp_attention\` with hipgraph capture (default \`--level 0\` path on DeepSeek-V4-Pro) crashed mid-capture with:

\`\`\`
HIP error: operation not permitted on an event last recorded in a capturing stream (hipErrorCapturedEvent)
[c10d::ProcessGroupNCCL::Watchdog::runLoop -> WorkNCCL::isCompleted -> finishedGPUExecutionInternal]
\`\`\`

The watchdog calls \`hipEventQuery\` on a WorkNCCL end-event that was recorded INSIDE a CUDAGraph capturing stream — HIP rejects this.

## Root cause
Both decode-path DP gathers default to \`use_custom=False\`, falling through to \`torch.distributed.all_gather_into_tensor\` (NCCL). The counterpart \`reduce_scatter_with_unpadding\` already used \`use_custom=True\` (custom AR IPC path, which is graph-capture safe).

## Changes

| File | Change |
|---|---|
| \`atom/model_ops/moe.py\` | \`all_gather_with_padding\` now passes \`use_custom=True\` for hidden_states + router_logits gather (bf16) before fused MoE. |
| \`atom/models/deepseek_v4.py\` | DeepSeek-V4-Pro hash-gate \`_hash_topk\` now passes \`use_custom=True\` for input-id gather (int32) before \`tid2eid\` lookup. **Requires** companion aiter PR [ROCm/aiter#3375](https://github.com/ROCm/aiter/pull/3375) which adds int-dtype view-cast to \`custom_all_gather\`. |
| \`scripts/wait_server_ready.sh\` | Detect log truncation between polls (\`start_atom_server.sh\` truncates \`atom_server.log\` via \`tee\`) and rescan from offset 0 so startup errors aren't missed. |

## Test plan
- [x] Server: \`/data/DeepSeek-V4-Pro\` tp=8 \`--enable-dp-attention --level 0\` → READY at ~125s (was crashing during decode bs=128/256 capture)
- [x] Benchmark 1k/1k c=128 PMULT=2 (256 reqs): 5325 tok/s Total throughput, TPOT 42ms
- [x] GSM8K 3-shot: flexible-extract **0.9538** ± 0.0058, strict-match 0.9530 (no regression vs baseline)
- [x] Kineto trace cleanly exported (8 ranks × ~150 MB \`.gz\`)
- [ ] DP+EP / DP+TBO paths (orthogonal, not exercised here)

## Companion PR
- aiter: https://github.com/ROCm/aiter/pull/3375 — un-shadows C++ \`reduce_scatter\` and accepts int dtypes in \`custom_all_gather\`. Required for the deepseek_v4.py hunk to work; without it the int32 hash-gate gather hits \`custom allreduce only supports float32, float16 and bfloat16\`.