### PR TITLE
[mesh][envs] centralize Atomesh environment flags

### DIFF
--- a/atom/entrypoints/openai_server.py
+++ b/atom/entrypoints/openai_server.py
@@ -6,10 +6,9 @@
 Usage:
     python -m atom.entrypoints.openai_server --model <model> [options]
 """
+from atom.utils import envs
 
-import os
-
-if os.environ.get("USE_ATOMESH_ENTRYPOINTS") == "1":
+if envs.USE_ATOMESH_ENTRYPOINTS:
     from atom.entrypoints.atomesh.server import main
 else:
     from atom.entrypoints.openai.api_server import main

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -119,6 +119,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_RELAXED_MTP": lambda: (
         os.getenv("ATOM_ENABLE_RELAXED_MTP", "0").lower() == "1"
     ),
+    # --- Atomesh ---
+    # Build atom-mesh when installing ATOM from source.
+    "ATOM_MESH_BUILD": lambda: os.getenv("ATOM_MESH_BUILD", "0") == "1",
+    # Route the OpenAI-compatible server entrypoint through Atomesh.
+    "USE_ATOMESH_ENTRYPOINTS": lambda: (
+        os.getenv("USE_ATOMESH_ENTRYPOINTS", "0") == "1"
+    ),
     # --- Gradient Control ---
     # Enable gradient tracking on model parameters.  Default "0" (disabled)
     # is correct for inference; set to "1" only for training / fine-tuning.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+import runpy
 import subprocess
 from pathlib import Path
 
@@ -8,9 +8,15 @@ from setuptools import setup
 from setuptools.command.build_py import build_py as _build_py
 
 
+def get_build_env(name: str):
+    """Read build-time envs without importing the atom package."""
+    envs_path = Path(__file__).resolve().parent / "atom" / "utils" / "envs.py"
+    return runpy.run_path(str(envs_path))["environment_variables"][name]()
+
+
 class install_atom_mesh(_build_py):
     def run(self) -> None:
-        if os.environ.get("ATOM_MESH_BUILD") == "1":
+        if get_build_env("ATOM_MESH_BUILD"):
             root = Path(__file__).resolve().parent
             mesh_dir = root / "atom" / "mesh"
             print(f"Building atom-mesh from {mesh_dir}...")


### PR DESCRIPTION
Manage Atomesh entrypoint and mesh build toggles through `atom.utils.envs`.

