### PR TITLE
given a8w8 gemm a zero bias input to avoid dynamic allock in aiter side

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -202,7 +202,9 @@ def gemm_a8w8_blockscale_preshuffle_impl(
             x, weight_shuffled, x_scale, w_scale, dtype
         )
     else:
-        y = gemm_a8w8_blockscale_bpreshuffle(x, weight, x_scale, w_scale, zero_bias_buf, dtype=dtype)
+        y = gemm_a8w8_blockscale_bpreshuffle(
+            x, weight, x_scale, w_scale, dtype=dtype, zero_bias_buf=zero_bias_buf
+        )
     return y
 
 
@@ -295,10 +297,13 @@ class LinearBase(nn.Module):
                         dtype=dtypes.fp32,
                     )
                 )
-                self.zero_bias_buf = None
-                if envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE and gemm_a8w8_blockscale_bpreshuffle_triton is None:
-                    self.zero_bias_buf = atom_parameter(
-                        torch.zeros(self.output_size, dtype=dtypes.fp32)
+                self.register_buffer("zero_bias_buf", None, persistent=False)
+                if (
+                    envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
+                    and gemm_a8w8_blockscale_bpreshuffle_triton is None
+                ):
+                    self.zero_bias_buf = torch.zeros(
+                        self.output_size, dtype=dtypes.fp32
                     )
             elif quant_type == QuantType.per_1x32:
                 self.weight_scale = atom_parameter(

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -178,6 +178,7 @@ def gemm_a8w8_blockscale_preshuffle_fake(
     weight: torch.Tensor,
     x_scale: torch.Tensor,
     w_scale: torch.Tensor,
+    zero_bias_buf: Optional[torch.Tensor] = None,
     dtype: torch.dtype = torch.bfloat16,
     prefix: str = "",
 ) -> torch.Tensor:
@@ -191,6 +192,7 @@ def gemm_a8w8_blockscale_preshuffle_impl(
     weight: torch.Tensor,
     x_scale: torch.Tensor,
     w_scale: torch.Tensor,
+    zero_bias_buf: Optional[torch.Tensor] = None,
     dtype: torch.dtype = torch.bfloat16,
     prefix: str = "",
 ) -> torch.Tensor:
@@ -200,7 +202,7 @@ def gemm_a8w8_blockscale_preshuffle_impl(
             x, weight_shuffled, x_scale, w_scale, dtype
         )
     else:
-        y = gemm_a8w8_blockscale_bpreshuffle(x, weight, x_scale, w_scale, dtype)
+        y = gemm_a8w8_blockscale_bpreshuffle(x, weight, x_scale, w_scale, zero_bias_buf, dtype=dtype)
     return y
 
 
@@ -293,6 +295,11 @@ class LinearBase(nn.Module):
                         dtype=dtypes.fp32,
                     )
                 )
+                self.zero_bias_buf = None
+                if envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE and gemm_a8w8_blockscale_bpreshuffle_triton is None:
+                    self.zero_bias_buf = atom_parameter(
+                        torch.zeros(self.output_size, dtype=dtypes.fp32)
+                    )
             elif quant_type == QuantType.per_1x32:
                 self.weight_scale = atom_parameter(
                     torch.empty(
@@ -584,6 +591,7 @@ class LinearBase(nn.Module):
                         self.weight,
                         x_scale,
                         self.weight_scale,
+                        self.zero_bias_buf,
                         dtype=otype,
                         prefix=self.prefix,
                     )


### PR DESCRIPTION
## Motivation

With https://github.com/ROCm/aiter/pull/3386， we can pre-allocate a zero bias to avoid dynamic alloc zero tensor for a better performance.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
