### PR TITLE
[Bugfix] eagle: fix MTP draft warmup crash on mrope-config target models

### DIFF
--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -428,7 +428,14 @@ class EagleProposer:
                             kv_indptr[1 : bs + 1] -= torch.cumsum(
                                 num_reject_tokens, dim=0
                             )
-                        positions = torch.gather(positions, 0, last_token_indices)
+                        # Index along the last dim so this works for both
+                        # 1D text positions [num_tokens] and 2D mrope
+                        # positions [3, num_tokens] (Qwen3.5 sets
+                        # `mrope_section` in `rope_parameters`, which flips
+                        # `use_mrope=True` and makes context.positions 2D).
+                        # `torch.gather` requires input.ndim == index.ndim
+                        # and crashes on the 2D case during MTP warmup.
+                        positions = positions[..., last_token_indices]
                         context.is_prefill = False
 
                     # update metadata


### PR DESCRIPTION
## Summary

Fix `RuntimeError: Index tensor must have the same number of dimensions as input tensor` raised from `EagleProposer.propose` during MTP draft warmup whenever the target model's HF config carries `mrope_section` in `rope_parameters` (e.g. Qwen3.5-397B-A17B-FP8).

`atom/spec_decode/eagle.py` previously did:

```python
positions = torch.gather(positions, 0, last_token_indices)
```

`torch.gather` requires `input.ndim == index.ndim`. After #831 (mrope path), `context.positions` becomes 2D `[3, num_tokens]` for any model whose rope config contains `mrope_section`, while `last_token_indices` stays 1D `[bs]` → ndim mismatch → crash on MTP warmup.

Fix: switch to ellipsis indexing, which produces the same shape semantics for both 1D and 2D positions.

```python
positions = positions[..., last_token_indices]
```

| `positions.shape`  | `last_token_indices.shape` | result shape | works? |
|---|---|---|---|
| `[num_tokens]`     | `[bs]`                     | `[bs]`       | ✅ (same as before) |
| `[3, num_tokens]`  | `[bs]`                     | `[3, bs]`    | ✅ (mrope) |

Identical to the pre-#254 form (`positions[last_token_indices]`) on 1D inputs.

## Failing CI

https://github.com/ROCm/ATOM/actions/runs/26529268074/job/78141372143

Affected jobs (Qwen3.5-397B-A17B-FP8 MTP3, schedule on 378715d8):

- `Qwen3.5-397B-A17B-FP8 MTP3 (isl=1024 osl=1024 c=4)`
- `Qwen3.5-397B-A17B-FP8 MTP3 (isl=1024 osl=1024 c=8)`
- `Qwen3.5-397B-A17B-FP8 MTP3 (isl=1024 osl=1024 c=16)`
- … (rest cancelled after the first three failed)

Stack trace from the server log:

```
File "/workspace/atom/spec_decode/eagle.py", line 431, in propose
    positions = torch.gather(positions, 0, last_token_indices)
RuntimeError: Index tensor must have the same number of dimensions as input tensor
```

Last green schedule for the same job: 2026-05-22 (`4181e4249`). First red: 2026-05-24 (`d55a233ae`). DeepSeek-V4-Pro MTP3 keeps passing because V4 targets don't opt into mrope.

## Test plan

- [ ] Bench `Qwen3.5-397B-A17B-FP8 MTP3` ISL=1024 OSL=1024 c=4 — server reaches ready, no warmup crash
- [ ] Bench `DeepSeek-V4-Pro MTP3` ISL=1024 OSL=1024 c=4 — no regression (1D path is bit-identical)
- [ ] (Optional) full nightly atom-benchmark MTP matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)