### PR TITLE
[Feat]  Support layerwise shared expert fusion for all MoE models

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -796,6 +796,40 @@ class ParallelConfig:
         # self.data_parallel_master_port = get_open_port()
 
 
+def _normalize_moe_config_fields(
+    hf_config: PretrainedConfig,
+    model_path: Optional[str] = None,
+) -> None:
+    """Normalize common MoE config field names across model families."""
+    moe_config = getattr(hf_config, "text_config", hf_config)
+    updates: dict[str, Any] = {}
+
+    n_routed = getattr(
+        moe_config,
+        "n_routed_experts",
+        getattr(moe_config, "num_experts", None),
+    )
+    if n_routed is not None:
+        updates["n_routed_experts"] = n_routed
+
+    existing_n_shared = getattr(moe_config, "n_shared_experts", None)
+    if existing_n_shared is not None:
+        updates["n_shared_experts"] = existing_n_shared
+    elif n_routed is not None and model_path is not None:
+        from atom.models.utils import ckpt_shared_expert_count
+
+        n_shared = ckpt_shared_expert_count(model_path)
+        if n_shared > 0:
+            updates["n_shared_experts"] = n_shared
+
+    if not updates:
+        return
+
+    moe_config.update(updates)
+    if moe_config is not hf_config:
+        hf_config.update(updates)
+
+
 @dataclass
 class SpeculativeConfig:
     method: Optional[str] = ""
@@ -889,34 +923,6 @@ class SpeculativeConfig:
                 "num_nextn_predict_layers": n_predict,
                 "architectures": [arch],
             }
-            # Naming differs across families:
-            #   DeepSeek / GLM       → already have `n_routed_experts`
-            #   Qwen3.5 / Qwen3-Next → only carry `num_experts`
-            #   non-MoE / unknown    → leave unset (no MoE = no field)
-            n_routed = getattr(
-                hf_config,
-                "n_routed_experts",
-                getattr(hf_config, "num_experts", None),
-            )
-            if n_routed is not None:
-                updates["n_routed_experts"] = n_routed
-            # n_shared_experts: prefer the field's own value if it exists
-            # (DeepSeek / GLM ship it natively); else scan the checkpoint
-            # for `shared_expert` weights and use the parsed count (1 for
-            # the flat-block layout every released model uses). Leaving
-            # the field unset for ckpts without shared experts avoids
-            # fabricating a phantom shared block (e.g. R1 MTP eh_proj
-            # would otherwise pull a stale BF16 weight_scale).
-            existing_n_shared = getattr(hf_config, "n_shared_experts", None)
-            if existing_n_shared is not None:
-                updates["n_shared_experts"] = existing_n_shared
-            else:
-                from atom.models.utils import ckpt_shared_expert_count
-
-                n_shared = ckpt_shared_expert_count(model_path)
-                if n_shared > 0:
-                    updates["n_shared_experts"] = n_shared
-
             hf_config.update(updates)
 
         # MiMo-V2 has not MTP related information in HF config.json,
@@ -931,6 +937,7 @@ class SpeculativeConfig:
                 }
             )
 
+        _normalize_moe_config_fields(hf_config, model_path)
         logger.info(f"hf config is: {hf_config}")
 
     def __repr__(self) -> str:
@@ -1042,6 +1049,7 @@ class Config:
         )
         # Multimodal config (full config with vision_config) for vision encoder init
         self.multimodal_config = getattr(self.hf_config, "_multimodal_config", None)
+        _normalize_moe_config_fields(self.hf_config, self.model)
         # transformers 5+ exposes rope_parameters; <5 often only rope_scaling + rope_theta.
         # Synthesize when missing or None so GPT-OSS YaRN (rope_type in rope_scaling) is preserved.
         if getattr(self.hf_config, "rope_parameters", None) is None:

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -37,9 +37,10 @@ from atom.model_loader.weight_utils import (
     filter_duplicate_safetensors_files,
 )
 from atom.model_ops.base_config import QuantizeMethodBase
-from atom.model_ops.moe import (
-    FusedMoEMethodBase,
+from atom.model_ops.moe import FusedMoEMethodBase
+from atom.model_ops.topK import (
     is_rocm_aiter_fusion_shared_expert_enabled,
+    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
 )
 from aiter.dist.parallel_state import get_tp_group
 
@@ -309,6 +310,15 @@ def load_model(
         module_prefix = matching_name.split("shared_expert", 1)[0]
         shared_expert_prefix = layer_prefix + matching_name.rstrip(".")
         routed_expert_prefix = layer_prefix + f"{module_prefix}experts"
+        model_quant_config = getattr(getattr(model, "args", None), "quant_config", None)
+        if model_quant_config is None:
+            model_quant_config = getattr(model, "quant_config", None)
+        if model_quant_config is not None:
+            return is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+                model_quant_config,
+                shared_expert_prefix=shared_expert_prefix,
+                routed_expert_prefix=routed_expert_prefix,
+            )
         return is_rocm_aiter_fusion_shared_expert_enabled(
             shared_expert_prefix=shared_expert_prefix,
             routed_expert_prefix=routed_expert_prefix,

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -304,6 +304,25 @@ def load_model(
                 return maybe_matching_name
         return None
 
+    is_deepseek = any(
+        "deepseek" in str(architecture).lower()
+        for architecture in getattr(hf_config, "architectures", []) or []
+    )
+
+    def should_fuse_shared_expert_weight(name: str, matching_name: str) -> bool:
+        if not is_deepseek:
+            return is_rocm_aiter_fusion_shared_expert_enabled()
+        # Added specifically to support shared expert fusion for
+        # DeepSeek-R1-0528-MXFP4-v2, whose shared/routed dtypes can differ
+        # by layer. Keep other models on the legacy global remap gate.
+        layer_prefix = name.split(matching_name, 1)[0]
+        shared_expert_prefix = layer_prefix + matching_name.rstrip(".")
+        routed_expert_prefix = layer_prefix + "mlp.experts"
+        return is_rocm_aiter_fusion_shared_expert_enabled(
+            shared_expert_prefix=shared_expert_prefix,
+            routed_expert_prefix=routed_expert_prefix,
+        )
+
     def extract_expert_target_and_id(name: str) -> Tuple[str, int] | None:
         """Extract fused parameter name and expert id from expert checkpoint name.
         like 'model.layers.10.mlp.experts.100.w2_bias' -> model.layers.10.mlp.experts.w2_bias and 100
@@ -438,14 +457,14 @@ def load_model(
                 continue
             maybe_matching_name = have_shared_expert(name)
             if (
-                is_rocm_aiter_fusion_shared_expert_enabled()
-                and maybe_matching_name is not None
+                maybe_matching_name is not None
                 # When the model keeps shared experts unfused (e.g. V4-Pro with
                 # FP4 routed vs FP8 shared, or DP + mori all2all), do NOT rewrite
                 # the shared weights into the fused slot — they must load into the
                 # standalone Expert module. Stays True for models without this
                 # attr (GLM4 etc.) so their fused-shared path is unchanged.
                 and not getattr(model, "disable_fused_shared_loading", False)
+                and should_fuse_shared_expert_weight(name, maybe_matching_name)
             ):
                 # Preserve the module-naming prefix (mlp. / ffn.) so the rewritten
                 # name matches this model's routed-expert param naming.

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -304,20 +304,11 @@ def load_model(
                 return maybe_matching_name
         return None
 
-    is_deepseek = any(
-        "deepseek" in str(architecture).lower()
-        for architecture in getattr(hf_config, "architectures", []) or []
-    )
-
     def should_fuse_shared_expert_weight(name: str, matching_name: str) -> bool:
-        if not is_deepseek:
-            return is_rocm_aiter_fusion_shared_expert_enabled()
-        # Added specifically to support shared expert fusion for
-        # DeepSeek-R1-0528-MXFP4-v2, whose shared/routed dtypes can differ
-        # by layer. Keep other models on the legacy global remap gate.
         layer_prefix = name.split(matching_name, 1)[0]
+        module_prefix = matching_name.split("shared_expert", 1)[0]
         shared_expert_prefix = layer_prefix + matching_name.rstrip(".")
-        routed_expert_prefix = layer_prefix + "mlp.experts"
+        routed_expert_prefix = layer_prefix + f"{module_prefix}experts"
         return is_rocm_aiter_fusion_shared_expert_enabled(
             shared_expert_prefix=shared_expert_prefix,
             routed_expert_prefix=routed_expert_prefix,

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2022,6 +2022,7 @@ class FusedMoE(torch.nn.Module):
         activation: ActivationType = ActivationType.Silu,
         shared_expert_scoring_func: Optional[str] = None,
         config: Optional[PretrainedConfig] = None,
+        shared_expert_prefix: Optional[str] = None,
     ):
         super().__init__()
         self.prefix = prefix
@@ -2062,25 +2063,13 @@ class FusedMoE(torch.nn.Module):
         self.global_num_experts = num_experts
         self.shared_expert_scoring_func = shared_expert_scoring_func
 
-        is_deepseek = any(
-            "deepseek" in str(architecture).lower()
-            for architecture in getattr(config, "architectures", []) or []
+        if shared_expert_prefix is None and prefix.endswith(".experts"):
+            shared_expert_prefix = prefix[: -len(".experts")] + ".shared_experts"
+
+        fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled(
+            shared_expert_prefix=shared_expert_prefix,
+            routed_expert_prefix=prefix,
         )
-        if is_deepseek:
-            # Added specifically to support shared expert fusion for
-            # DeepSeek-R1-0528-MXFP4-v2, whose shared/routed dtypes can differ
-            # by layer. Keep other models on the legacy global gate.
-            shared_expert_prefix = (
-                prefix[: -len(".experts")] + ".shared_experts"
-                if prefix.endswith(".experts")
-                else None
-            )
-            fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled(
-                shared_expert_prefix=shared_expert_prefix,
-                routed_expert_prefix=prefix,
-            )
-        else:
-            fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
         self.num_fused_shared_experts = (
             config.n_shared_experts
             if config is not None
@@ -2999,10 +2988,7 @@ class FusedMoE(torch.nn.Module):
                 # DeepSeek-V4 routing: sqrt(softplus(scores)) + bias for selection;
                 # weights gathered from the unbiased sqrt(softplus(.)) values.
                 tokens_num = router_logits.shape[0]
-                fuse_shared = (
-                    is_rocm_aiter_fusion_shared_expert_enabled()
-                    and num_fused_shared_experts > 0
-                )
+                fuse_shared = num_fused_shared_experts > 0
                 if fuse_shared:
                     import atom.model_ops.topK as _topK_mod
 

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -38,7 +38,6 @@ from atom.model_ops.fused_moe.mori_prepare_finalize import MoriPrepareAndFinaliz
 from atom.model_ops.topK import (
     init_aiter_topK_meta_data,
     is_rocm_aiter_fuse_routed_scaling_factor,
-    is_rocm_aiter_fusion_shared_expert_enabled,
     is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
 )
 from atom.model_ops.topK import rocm_aiter_grouped_topk as grouped_topk
@@ -2067,10 +2066,12 @@ class FusedMoE(torch.nn.Module):
         if shared_expert_prefix is None and prefix.endswith(".experts"):
             shared_expert_prefix = prefix[: -len(".experts")] + ".shared_experts"
 
-        fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
-            quant_config,
-            shared_expert_prefix=shared_expert_prefix,
-            routed_expert_prefix=prefix,
+        fuse_shared_experts = (
+            is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+                quant_config,
+                shared_expert_prefix=shared_expert_prefix,
+                routed_expert_prefix=prefix,
+            )
         )
         self.num_fused_shared_experts = (
             config.n_shared_experts

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2062,7 +2062,25 @@ class FusedMoE(torch.nn.Module):
         self.global_num_experts = num_experts
         self.shared_expert_scoring_func = shared_expert_scoring_func
 
-        fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+        is_deepseek = any(
+            "deepseek" in str(architecture).lower()
+            for architecture in getattr(config, "architectures", []) or []
+        )
+        if is_deepseek:
+            # Added specifically to support shared expert fusion for
+            # DeepSeek-R1-0528-MXFP4-v2, whose shared/routed dtypes can differ
+            # by layer. Keep other models on the legacy global gate.
+            shared_expert_prefix = (
+                prefix[: -len(".experts")] + ".shared_experts"
+                if prefix.endswith(".experts")
+                else None
+            )
+            fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled(
+                shared_expert_prefix=shared_expert_prefix,
+                routed_expert_prefix=prefix,
+            )
+        else:
+            fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
         self.num_fused_shared_experts = (
             config.n_shared_experts
             if config is not None

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -39,6 +39,7 @@ from atom.model_ops.topK import (
     init_aiter_topK_meta_data,
     is_rocm_aiter_fuse_routed_scaling_factor,
     is_rocm_aiter_fusion_shared_expert_enabled,
+    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
 )
 from atom.model_ops.topK import rocm_aiter_grouped_topk as grouped_topk
 from atom.model_ops.topK import rocm_aiter_topk_softmax as fused_topk
@@ -2066,7 +2067,8 @@ class FusedMoE(torch.nn.Module):
         if shared_expert_prefix is None and prefix.endswith(".experts"):
             shared_expert_prefix = prefix[: -len(".experts")] + ".shared_experts"
 
-        fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled(
+        fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+            quant_config,
             shared_expert_prefix=shared_expert_prefix,
             routed_expert_prefix=prefix,
         )

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -11,14 +11,14 @@ from atom.model_ops.utils import _has_module
 from atom.utils.custom_register import direct_register_custom_op
 
 
-@torch_compile_guard()
-def is_rocm_aiter_fusion_shared_expert_enabled(
+def is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+    quant_config,
     shared_expert_prefix: Optional[str] = None,
     routed_expert_prefix: Optional[str] = None,
 ) -> bool:
     config = get_current_atom_config()
-
-    quant_config = config.quant_config
+    if quant_config is None:
+        quant_config = config.quant_config
 
     dp_size = config.parallel_config.data_parallel_size
     if dp_size > 1 and _has_module("mori") and config.enable_dp_attention:
@@ -57,6 +57,19 @@ def is_rocm_aiter_fusion_shared_expert_enabled(
             break
 
     return True
+
+
+@torch_compile_guard()
+def is_rocm_aiter_fusion_shared_expert_enabled(
+    shared_expert_prefix: Optional[str] = None,
+    routed_expert_prefix: Optional[str] = None,
+) -> bool:
+    config = get_current_atom_config()
+    return is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+        config.quant_config,
+        shared_expert_prefix=shared_expert_prefix,
+        routed_expert_prefix=routed_expert_prefix,
+    )
 
 
 def is_rocm_aiter_fuse_routed_scaling_factor():

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -12,10 +12,26 @@ from atom.utils.custom_register import direct_register_custom_op
 
 
 @torch_compile_guard()
-def is_rocm_aiter_fusion_shared_expert_enabled() -> bool:
+def is_rocm_aiter_fusion_shared_expert_enabled(
+    shared_expert_prefix: Optional[str] = None,
+    routed_expert_prefix: Optional[str] = None,
+) -> bool:
     config = get_current_atom_config()
 
     quant_config = config.quant_config
+
+    dp_size = config.parallel_config.data_parallel_size
+    if dp_size > 1 and _has_module("mori") and config.enable_dp_attention:
+        return False
+
+    if quant_config is not None and shared_expert_prefix is not None:
+        shared_spec = quant_config.get_layer_quant_config(shared_expert_prefix)
+        routed_spec = (
+            quant_config.get_layer_quant_config(routed_expert_prefix)
+            if routed_expert_prefix is not None
+            else quant_config
+        )
+        return shared_spec.quant_dtype == routed_spec.quant_dtype
 
     # Resolve actual dtypes for shared experts vs routed experts.
     # Find a representative shared expert entry from the exclude list to
@@ -36,9 +52,6 @@ def is_rocm_aiter_fusion_shared_expert_enabled() -> bool:
                 return False
             break
 
-    dp_size = config.parallel_config.data_parallel_size
-    if dp_size > 1 and _has_module("mori") and config.enable_dp_attention:
-        return False
     return True
 
 
@@ -107,8 +120,7 @@ def rocm_aiter_topk_softmax_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -143,7 +155,7 @@ def rocm_aiter_topk_softmax_impl(
         fused_shared_experts_for_kernel,
         fused_shared_experts_scoring_func,
     )
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -177,8 +189,7 @@ def rocm_aiter_biased_grouped_topk_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -209,7 +220,7 @@ def rocm_aiter_biased_grouped_topk_impl(
         need_renorm,
         routed_scaling_factor,
     )
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -226,8 +237,7 @@ def rocm_aiter_biased_grouped_topk_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     token = gating_output.shape[0]
     device = gating_output.device
-    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -258,7 +268,7 @@ def rocm_aiter_biased_grouped_topk_fake(
     else:
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -280,8 +290,7 @@ def rocm_aiter_grouped_topk_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -312,7 +321,7 @@ def rocm_aiter_grouped_topk_impl(
         scoring_func,
         routed_scaling_factor,
     )
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -331,8 +340,7 @@ def rocm_aiter_grouped_topk_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     token = gating_output.shape[0]
     device = gating_output.device
-    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -363,7 +371,7 @@ def rocm_aiter_grouped_topk_fake(
     else:
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
-    if fuse_shared_experts and num_fused_shared_experts > 0:
+    if num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -31,7 +31,11 @@ def is_rocm_aiter_fusion_shared_expert_enabled(
             if routed_expert_prefix is not None
             else quant_config
         )
-        return shared_spec.quant_dtype == routed_spec.quant_dtype
+        return (
+            shared_spec.quant_dtype == routed_spec.quant_dtype
+            and shared_spec.quant_type == routed_spec.quant_type
+            and shared_spec.is_dynamic == routed_spec.is_dynamic
+        )
 
     # Resolve actual dtypes for shared experts vs routed experts.
     # Find a representative shared expert entry from the exclude list to

--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -10,7 +10,6 @@ from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.layernorm import RMSNorm
 from atom.model_ops.linear import ReplicatedLinear
 from atom.model_ops.moe import FusedMoE
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.models.utils import IntermediateTensors
 
 from atom.utils.decorators import support_torch_compile
@@ -268,11 +267,7 @@ class DeepSeekMTP(nn.Module):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.n_routed_experts
-            + (
-                self.config.n_shared_experts
-                if is_rocm_aiter_fusion_shared_expert_enabled()
-                else 0
-            ),
+            + (self.config.n_shared_experts or 0),
         )
 
 

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -870,9 +870,15 @@ class DeepseekV2MoE(nn.Module):
         self._use_dual_stream = False
         self.alt_stream = alt_stream
         self.prefix = prefix
+        self.is_rocm_aiter_fusion_shared_expert_enabled = (
+            is_rocm_aiter_fusion_shared_expert_enabled(
+                shared_expert_prefix=f"{prefix}.shared_experts",
+                routed_expert_prefix=f"{prefix}.experts",
+            )
+        )
 
         if config.n_shared_experts is not None:
-            if not is_rocm_aiter_fusion_shared_expert_enabled():
+            if not self.is_rocm_aiter_fusion_shared_expert_enabled:
                 tbo_active = get_current_atom_config().enable_tbo
                 if envs.ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD > 0 and not tbo_active:
                     self._use_dual_stream = True
@@ -945,7 +951,7 @@ class DeepseekV2MoE(nn.Module):
         shared_output = None
         if (
             self.n_shared_experts is not None
-            and not is_rocm_aiter_fusion_shared_expert_enabled()
+            and not self.is_rocm_aiter_fusion_shared_expert_enabled
         ):
             shared_output = self.shared_experts(hidden_states)
 
@@ -2207,11 +2213,7 @@ class DeepseekV2Model(nn.Module):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.n_routed_experts
-            + (
-                self.config.n_shared_experts
-                if is_rocm_aiter_fusion_shared_expert_enabled()
-                else 0
-            ),
+            + (self.config.n_shared_experts or 0),
         )
 
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2062,24 +2062,9 @@ class MoE(nn.Module):
             # attribute mutation across the compile boundary, so stashing on
             # `self.foo` from inside forward is a no-op at runtime.
         assert args.n_shared_experts == 1
-        # aiter can fuse shared expert into the routed FusedMoE kernel ONLY
-        # when shared and routed have the same quant dtype.
-        # `is_rocm_aiter_fusion_shared_expert_enabled` compares shared vs
-        # GLOBAL (=base dtype), but V4-Pro has routed=FP4 (per-layer override
-        # for `.ffn.experts`) and shared=FP8 (=global). The function returns
-        # True for V4 because shared matches global, missing the routed-shared
-        # mismatch. Direct comparison: get routed and shared specs and compare.
-        routed_spec = qc.get_layer_quant_config(f"{prefix}.experts")
-        shared_spec = qc.get_layer_quant_config(f"{prefix}.shared_experts")
-        routed_dtype = routed_spec.quant_dtype
-        shared_dtype = shared_spec.quant_dtype
-        # Fuse shared expert into the routed MoE kernel whenever physically
-        # possible. Falls back to a standalone Expert module only when fusion is
-        # infeasible: routed/shared quant dtypes differ (V4-Pro: FP4 routed vs
-        # FP8 shared) or aiter fusion is unavailable (e.g. DP + mori all2all).
-        self._fuse_shared_into_routed = (
-            routed_dtype == shared_dtype
-            and is_rocm_aiter_fusion_shared_expert_enabled()
+        self._fuse_shared_into_routed = is_rocm_aiter_fusion_shared_expert_enabled(
+            shared_expert_prefix=f"{prefix}.shared_experts",
+            routed_expert_prefix=f"{prefix}.experts",
         )
         moe_cfg = SimpleNamespace(
             routed_scaling_factor=self.routed_scaling_factor,
@@ -2100,6 +2085,7 @@ class MoE(nn.Module):
             scoring_func=args.score_func,  # "sqrtsoftplus"
             e_score_correction_bias=getattr(self.gate, "e_score_correction_bias", None),
             config=moe_cfg,
+            shared_expert_prefix=f"{prefix}.shared_experts",
         )
         self.experts.swiglu_limit = args.swiglu_limit
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -79,7 +79,6 @@ from atom.model_ops.sparse_attn_v4 import (
     hc_split_sinkhorn,
 )
 from atom.model_ops.topK import (
-    is_rocm_aiter_fusion_shared_expert_enabled,
     is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
 )
 from atom.model_ops.triton_rmsnorm_nw import rmsnorm_nw

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -78,7 +78,10 @@ from atom.model_ops.quant_v4 import act_quant_inplace
 from atom.model_ops.sparse_attn_v4 import (
     hc_split_sinkhorn,
 )
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
+from atom.model_ops.topK import (
+    is_rocm_aiter_fusion_shared_expert_enabled,
+    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
+)
 from atom.model_ops.triton_rmsnorm_nw import rmsnorm_nw
 from atom.model_ops.utils import atom_parameter
 from atom.model_ops.v4_kernels import (
@@ -2062,9 +2065,12 @@ class MoE(nn.Module):
             # attribute mutation across the compile boundary, so stashing on
             # `self.foo` from inside forward is a no-op at runtime.
         assert args.n_shared_experts == 1
-        self._fuse_shared_into_routed = is_rocm_aiter_fusion_shared_expert_enabled(
-            shared_expert_prefix=f"{prefix}.shared_experts",
-            routed_expert_prefix=f"{prefix}.experts",
+        self._fuse_shared_into_routed = (
+            is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+                qc,
+                shared_expert_prefix=f"{prefix}.shared_experts",
+                routed_expert_prefix=f"{prefix}.experts",
+            )
         )
         moe_cfg = SimpleNamespace(
             routed_scaling_factor=self.routed_scaling_factor,

--- a/atom/models/deepseek_v4_mtp.py
+++ b/atom/models/deepseek_v4_mtp.py
@@ -227,15 +227,28 @@ class DeepseekV4MTP(nn.Module):
         """
         return name if "mtp." in name else None
 
+    @property
+    def disable_fused_shared_loading(self) -> bool:
+        """True when MTP shared experts are standalone, not fused into FusedMoE."""
+        for m in self.model.modules():
+            if m.__class__.__name__ == "MoE":
+                return not getattr(m, "_fuse_shared_into_routed", True)
+        return False
+
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         """FusedMoE expert param mapping for MTPBlock's MoE layer. Same
         ckpt convention as the target (`ffn.experts.{e}.w{1,2,3}`).
         """
+        num_fused_shared = 0
+        for m in self.model.modules():
+            if m.__class__.__name__ == "FusedMoE":
+                num_fused_shared = getattr(m, "num_fused_shared_experts", 0)
+                break
         return FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="w1",
             ckpt_down_proj_name="w2",
             ckpt_up_proj_name="w3",
-            num_experts=self.args.n_routed_experts,
+            num_experts=self.args.n_routed_experts + num_fused_shared,
         )
 
     def forward(

--- a/atom/models/glm4_moe.py
+++ b/atom/models/glm4_moe.py
@@ -116,6 +116,12 @@ class Glm4MoE(nn.Module):
         self.gate.e_score_correction_bias = atom_parameter(
             torch.empty(config.n_routed_experts, dtype=torch.float32)
         )
+        self.is_rocm_aiter_fusion_shared_expert_enabled = (
+            is_rocm_aiter_fusion_shared_expert_enabled(
+                shared_expert_prefix=f"{prefix}.shared_experts",
+                routed_expert_prefix=f"{prefix}.experts",
+            )
+        )
 
         self.n_redundant_experts = 0
         self.n_logical_experts = self.n_routed_experts
@@ -128,7 +134,7 @@ class Glm4MoE(nn.Module):
         )
 
         if config.n_shared_experts is not None:
-            if not is_rocm_aiter_fusion_shared_expert_enabled():
+            if not self.is_rocm_aiter_fusion_shared_expert_enabled:
                 # Only create separate shared_experts module when fusion is disabled
                 intermediate_size = (
                     config.moe_intermediate_size * config.n_shared_experts
@@ -162,6 +168,7 @@ class Glm4MoE(nn.Module):
             e_score_correction_bias=self.gate.e_score_correction_bias,
             has_bias=getattr(config, "moe_ffn_bias", False),
             config=config,
+            shared_expert_prefix=f"{prefix}.shared_experts",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -172,7 +179,7 @@ class Glm4MoE(nn.Module):
         router_logits = self.gate(hidden_states.to(dtype=torch.float32))
         if (
             self.n_shared_experts is not None
-            and not is_rocm_aiter_fusion_shared_expert_enabled()
+            and not self.is_rocm_aiter_fusion_shared_expert_enabled
         ):
             shared_output = self.shared_experts(hidden_states)
         final_hidden_states = self.experts(
@@ -184,7 +191,7 @@ class Glm4MoE(nn.Module):
 
         if (
             self.shared_experts is not None
-            and not is_rocm_aiter_fusion_shared_expert_enabled()
+            and not self.is_rocm_aiter_fusion_shared_expert_enabled
         ):
             final_hidden_states = final_hidden_states + shared_output
 
@@ -513,19 +520,12 @@ class Glm4MoeModel(nn.Module):
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        # When fusion is enabled, FusedMoE adds shared expert internally
-        # so we need to include it in the mapping as well
-        num_experts = self.config.n_routed_experts
-        if (
-            is_rocm_aiter_fusion_shared_expert_enabled()
-            and self.config.n_shared_experts
-        ):
-            num_experts += self.config.n_shared_experts
         return FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=num_experts,
+            num_experts=self.config.n_routed_experts
+            + (self.config.n_shared_experts or 0),
         )
 
 

--- a/atom/models/glm4_moe_mtp.py
+++ b/atom/models/glm4_moe_mtp.py
@@ -6,7 +6,6 @@ from atom.config import Config, QuantizationConfig
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.layernorm import RMSNorm
 from atom.model_ops.moe import FusedMoE
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.models.utils import IntermediateTensors
 from atom.utils.decorators import support_torch_compile
 from transformers import PretrainedConfig
@@ -191,15 +190,10 @@ class Glm4MoeMTP(nn.Module):
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        num_experts = self.config.n_routed_experts
-        if (
-            is_rocm_aiter_fusion_shared_expert_enabled()
-            and self.config.n_shared_experts
-        ):
-            num_experts += self.config.n_shared_experts
         return FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=num_experts,
+            num_experts=self.config.n_routed_experts
+            + (self.config.n_shared_experts or 0),
         )

--- a/atom/models/qwen3_5.py
+++ b/atom/models/qwen3_5.py
@@ -7,7 +7,6 @@ from torch import nn
 
 from atom.config import QuantizationConfig, Config
 
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.model_ops.utils import atom_parameter
 from atom.utils.decorators import support_torch_compile
 
@@ -533,11 +532,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.n_routed_experts
-            + (
-                self.config.n_shared_experts
-                if is_rocm_aiter_fusion_shared_expert_enabled()
-                else 0
-            ),
+            + (self.config.n_shared_experts or 0),
         )
 
 

--- a/atom/models/qwen3_5_mtp.py
+++ b/atom/models/qwen3_5_mtp.py
@@ -11,7 +11,6 @@ from atom.config import Config
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.linear import ColumnParallelLinear
 from atom.model_ops.moe import FusedMoE
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.models.qwen3_5 import (
     Qwen3_5DecoderLayer,
     Qwen3_5RMSNorm,
@@ -204,9 +203,5 @@ class Qwen3_5MTP(nn.Module):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.n_routed_experts
-            + (
-                self.config.n_shared_experts
-                if is_rocm_aiter_fusion_shared_expert_enabled()
-                else 0
-            ),
+            + (self.config.n_shared_experts or 0),
         )

--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -201,10 +201,16 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             quant_config=None,
             prefix=f"{prefix}.gate",
         )
+        self.is_rocm_aiter_fusion_shared_expert_enabled = (
+            is_rocm_aiter_fusion_shared_expert_enabled(
+                shared_expert_prefix=f"{prefix}.shared_expert",
+                routed_expert_prefix=f"{prefix}.experts",
+            )
+        )
 
         if (
             config.shared_expert_intermediate_size > 0
-            and not is_rocm_aiter_fusion_shared_expert_enabled()
+            and not self.is_rocm_aiter_fusion_shared_expert_enabled
         ):
             # When shared expert fusion is disabled (e.g. MXFP4 where shared
             # experts are BF16 while routed experts are FP4), run the shared
@@ -234,10 +240,11 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             use_grouped_topk=False,
             has_bias=False,
             shared_expert_scoring_func=(
-                "sigmoid" if self.shared_expert is None else None
+                "sigmoid" if self.is_rocm_aiter_fusion_shared_expert_enabled else None
             ),
             prefix=f"{prefix}.experts",
             config=config,
+            shared_expert_prefix=f"{prefix}.shared_expert",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -248,14 +255,14 @@ class Qwen3NextSparseMoeBlock(nn.Module):
 
         # router_logits: (num_tokens, n_experts + 1)
         logits = self.gate(hidden_states)
-        if not is_rocm_aiter_fusion_shared_expert_enabled():
+        if not self.is_rocm_aiter_fusion_shared_expert_enabled:
             router_logits = logits[:, : self.n_routed_experts]
         else:
             router_logits = logits
         routed_output = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )
-        if not is_rocm_aiter_fusion_shared_expert_enabled():
+        if not self.is_rocm_aiter_fusion_shared_expert_enabled:
             shared_output = self.shared_expert(hidden_states)
             # Apply shared expert gate: the merged gate output contains
             # [routed_logits, shared_expert_gate_logits], extract the tail
@@ -962,12 +969,7 @@ class Qwen3NextModel(nn.Module):
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts
-            + (
-                self.config.n_shared_experts
-                if is_rocm_aiter_fusion_shared_expert_enabled()
-                else 0
-            ),
+            num_experts=self.config.n_routed_experts + self.config.n_shared_experts,
         )
 
 

--- a/atom/models/qwen3_next_mtp.py
+++ b/atom/models/qwen3_next_mtp.py
@@ -169,19 +169,14 @@ class Qwen3NextMTP(nn.Module):
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
-        # Mirror target's get_expert_mapping: when shared-expert fusion is on,
-        # the loader rewrites `mlp.shared_expert.*` to `mlp.experts.{N}.*`
-        # (where N == n_routed_experts), so the expert_mapping must include
-        # an extra slot for that fused shared-expert. Without this, MTP's
-        # shared_expert weights get silently dropped during loading.
-        from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
-
+        # Mirror target's get_expert_mapping: the loader may rewrite
+        # `mlp.shared_expert.*` to `mlp.experts.{N}.*` per layer, so the
+        # mapping must always include the extra shared-expert slot.
         n_routed = getattr(self.config, "n_routed_experts", self.config.num_experts)
         n_shared = getattr(self.config, "n_shared_experts", 1)
         return FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=n_routed
-            + (n_shared if is_rocm_aiter_fusion_shared_expert_enabled() else 0),
+            num_experts=n_routed + (n_shared or 0),
         )


### PR DESCRIPTION
## Motivation
In DeepSeek-R1-0528-MXFP4-v2, layer 61 has a situation where shared experts and routed experts are of different types, while the other layers still have the same type. The original is_rocm_aiter_fusion_shared_expert_enabled() function will cause all layers to skip shared expert fusion. This PR enables shared expert fusion for the compatible layers in DeepSeek-R1-0528-MXFP4-v2. For other models, the original behavior is preserved to ensure compatibility.

## Command

```
export CUDA_VISIBLE_DEVICES=0,1,2,3

export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1

model_path=/models/deepseek-ai/DeepSeek-R1-0528-MXFP4-v2

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
 
TORCHINDUCTOR_COMPILE_THREADS=128 python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --mem-fraction-static 0.9 \
    --disable-radix-cache \
    --attention-backend aiter \
    --kv-cache-dtype fp8_e4m3 \
    --max-running-requests 128
```

```
export CUDA_VISIBLE_DEVICES=0,1,2,3

export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1

export MORI_SHMEM_MODE=ISOLATION

model_path=/models/deepseek-ai/DeepSeek-R1-0528-MXFP4-v2

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
 
TORCHINDUCTOR_COMPILE_THREADS=128 python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --data-parallel-size 4 \
    --expert-parallel-size 4 \
    --enable-dp-attention \
    --mem-fraction-static 0.9 \
    --disable-radix-cache \
    --attention-backend aiter \
    --kv-cache-dtype fp8_e4m3 \
    --max-running-requests 128
```


## Performance
before:
<img width="999" height="530" alt="image" src="https://github.com/user-attachments/assets/145c7cec-feb2-4b35-9eea-b301a87bd88d" />
The shared expert is not fused into the MoE.

after:
<img width="1018" height="516" alt="image" src="https://github.com/user-attachments/assets/211c06ba-ec52-43dd-9f22-c0d6ff534e26" />
The shared expert is fused into the MoE.