### PR TITLE
deepseek v4 fp8_einsum enable

### DIFF
--- a/atom/model_ops/quant_v4.py
+++ b/atom/model_ops/quant_v4.py
@@ -228,6 +228,51 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
 
 
 # ---------------------------------------------------------------------------
+# Packed-UE8M0 helpers (DeepGEMM SM100 ABI, used by aiter fp8_einsum kernel).
+#
+# The flydsl fp8_einsum kernel consumes its block scales as INT32 tensors
+# where each i32 holds 4 consecutive UE8M0 bytes (little-endian) along the
+# K-axis. These helpers mirror those in op_tests/test_fp8_einsum.py so the
+# V4 weight-loading hook and the parity test can share one implementation.
+# ---------------------------------------------------------------------------
+
+
+def fp32_to_ue8m0_byte(scale_f32: torch.Tensor) -> torch.Tensor:
+    """fp32 scale → UE8M0 biased-exp byte (round-up to next power of 2).
+
+    Byte ``b`` represents ``2 ** (b - 127)``. Clamped to ``[0, 254]``.
+    Returns int32 (one byte per element, zero-extended).
+    """
+    s = scale_f32.clamp_min(2.0**-126).float()
+    m, e = torch.frexp(s)
+    e = e.to(torch.int32)
+    is_pow2 = m == 0.5
+    byte = torch.where(is_pow2, e - 1 + 127, e + 127)
+    return byte.clamp(0, 254).to(torch.int32)
+
+
+def pack_ue8m0_bytes_to_i32(bytes_along_k: torch.Tensor) -> torch.Tensor:
+    """Pack 4 UE8M0 bytes along the last dim into one little-endian i32.
+
+    Input shape ``... × (4N)`` → output shape ``... × N``. Input must be
+    int32 (one byte per element, low 8 bits used).
+    """
+    *lead, nk = bytes_along_k.shape
+    assert nk % 4 == 0, f"trailing dim {nk} must be divisible by 4"
+    b = bytes_along_k.to(torch.int32).reshape(*lead, nk // 4, 4)
+    return (
+        (
+            (b[..., 0] & 0xFF)
+            | ((b[..., 1] & 0xFF) << 8)
+            | ((b[..., 2] & 0xFF) << 16)
+            | ((b[..., 3] & 0xFF) << 24)
+        )
+        .contiguous()
+        .to(torch.int32)
+    )
+
+
+# ---------------------------------------------------------------------------
 # Self-test (run as `python -m atom.model_ops.quant_v4`)
 # ---------------------------------------------------------------------------
 

--- a/atom/model_ops/v4_kernels/inverse_rope.py
+++ b/atom/model_ops/v4_kernels/inverse_rope.py
@@ -6,6 +6,15 @@
 Replaces the two-step `freqs_for_positions` + `_apply_rotary_emb(inverse=True)`
 with a single kernel that indexes the cos/sin cache by positions and does the
 inverse rotation in-place. GPT-J (interleaved) style only.
+
+Two modes:
+  - quant_out=False (default): pure inverse RoPE, in-place BF16 write to `x`.
+    Used by `_V4RoPE.inverse`.
+  - quant_out=True: fused inverse RoPE + per-D128 amax + UE8M0-rounded scale +
+    FP8 e4m3 cast + packed-i32 scale write. Used by `DeepseekV4Attention.
+    forward_impl` when feeding the wo_a grouped LoRA via the flydsl
+    fp8_einsum kernel. The quant axis groups heads into `n_groups` chunks of
+    `n_heads_per_group * head_dim = d_per_group` columns each.
 """
 
 import torch
@@ -13,6 +22,9 @@ import triton
 import triton.language as tl
 
 
+# ---------------------------------------------------------------------------
+# Mode A: pure inverse RoPE (rope slice only). Unchanged from PR1.
+# ---------------------------------------------------------------------------
 @triton.jit
 def _inverse_rope_gptj_kernel(
     x_ptr,
@@ -69,37 +81,301 @@ def _inverse_rope_gptj_kernel(
     tl.store(x_ptr + x_offs, out, mask=x_mask)
 
 
+# ---------------------------------------------------------------------------
+# Ported from vLLM's `_fused_inv_rope_fp8_quant_per_head`
+# (vllm/models/deepseek_v4/common/ops/fused_inv_rope_fp8_quant.py).
+#
+# Key structural wins adopted from vLLM:
+#   - Grid = (n_heads, cdiv(S, BLOCK_S)) → one program per (head, token-tile),
+#     each handling ONE head's CHUNKS_PER_HEAD D128 blocks. Massively more
+#     workgroups than the old (n_groups, cdiv(S,32)) grid (which serialized
+#     all 32 D128 chunks of a group in one WG → ~8 WGs at small B).
+#   - No tl.gather / tl.flip: inverse RoPE via the `offsets ^ 1` partner-load
+#     trick + even/odd tl.where. Much cheaper than the gather+flip path.
+#
+# Kept from OUR kernel (so output is BIT-IDENTICAL → true drop-in):
+#   - Separate cos/sin caches `[max_pos, 1, 1, rope_dim//2]` with the
+#     reuse_freqs_front_part `// 2` indexing (NOT vLLM's fused cos||sin cache).
+#   - UE8M0 byte = round-UP via `(bits + 0x007FFFFF) & 0xFF800000) >> 23`,
+#     clamp [0, 254], scale floor 2^-126 — matches host `fp32_to_ue8m0_byte`
+#     and the C++ reference (vLLM's `exp2(ceil(log2))` differs on ~64% of
+#     inputs, so we do NOT use it).
+#   - Output layout: y_fp8 [S, n_groups, d_per_group] row-major; sx int32
+#     [S, n_groups, d_per_group//512] with 4 UE8M0 bytes packed LE per i32.
+# ---------------------------------------------------------------------------
+# Grid = (num_tokens, n_groups * heads_per_group): ONE program per
+# (token, head), each handling that head's CHUNKS_PER_HEAD D128 blocks. This
+# vLLM-derived layout (vllm fused_inv_rope_fp8_quant) beats the prior
+# (n_heads, cdiv(S, BLOCK_S)) token-tiled grid by ~1.6-1.9× at prefill on
+# gfx950 (MI355X): the flat per-head HEAD_DIM load is fully coalesced and
+# carries far less register/ALU pressure than the old 2D [BLOCK_S, HEAD_DIM]
+# tile, so the kernel stops being VALU-issue-bound (measured VALUBusy 79% →
+# memory-streaming) at large S. num_warps=1 (one wavefront issues the whole
+# head row; extra warps only add scheduling overhead). No @triton.autotune —
+# the grid is a pure function of (tokens, heads), so it is CUDA-graph-capture
+# safe and spike-free with no per-batch search.
+#
+# RoPE math runs in FP32 (matches vLLM). This is NOT byte-identical to the
+# older BF16-rope kernel — ~0.8% of fp8 bytes differ by ≤1 UE8M0 ULP — but
+# stays well within fp8 e4m3 tolerance (≈6% per-element ULP); the downstream
+# fp8_einsum consumer is unaffected (see op_tests/test_inverse_rope_quant.py
+# and test_v4_fp8_wo_a.py). FP32 rope removes the BF16 pack/unpack overhead
+# that was the remaining gap to vLLM's kernel.
+
+
+@triton.jit
+def _inverse_rope_quant_kernel(
+    x_ptr,  # bf16 [S, n_heads, head_dim]
+    y_ptr,  # fp8  [S, G, d_per_group]
+    s_ptr,  # i32  [S, G, d_per_group // 512]
+    cos_ptr,  # bf16 [max_pos, 1, 1, rd//2]
+    sin_ptr,
+    pos_ptr,  # i32/i64 [S]
+    stride_x_s,
+    stride_x_h,
+    stride_x_d,
+    stride_y_s,
+    stride_y_g,
+    stride_y_d,
+    stride_s_s,
+    stride_s_g,
+    stride_s_d,
+    stride_cos_s,
+    stride_cos_d,
+    S,
+    HEAD_DIM: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    N_HEADS_PER_GROUP: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,  # 128
+    PACK4: tl.constexpr,  # 4 (UE8M0 bytes per i32)
+    FP8_MAX: tl.constexpr,  # 448.0
+):
+    # One program per (token, head). Grid = (num_tokens, n_heads).
+    # int64 ids: stride math overflows int32 past S=32768 (IMA).
+    pid_s = tl.program_id(0).to(tl.int64)  # token
+    pid_h = tl.program_id(1).to(tl.int64)  # global head in [0, n_heads)
+
+    head_in_group = pid_h % N_HEADS_PER_GROUP
+    pid_g = pid_h // N_HEADS_PER_GROUP
+
+    CHUNKS_PER_HEAD: tl.constexpr = HEAD_DIM // GROUP_SIZE  # 4 at V4-Pro
+    # Where this head's D128 chunks land within the group's d_per_group axis.
+    qb_start = head_in_group * CHUNKS_PER_HEAD  # first D128 idx of this head
+
+    pos = tl.load(pos_ptr + pid_s)
+
+    # Whole-head column offsets [HEAD_DIM]; rope lives in the tail.
+    d_offs = tl.arange(0, HEAD_DIM)
+    rope_abs_start = NOPE_DIM  # rope occupies [NOPE_DIM, HEAD_DIM)
+    is_rope = d_offs >= rope_abs_start  # [HEAD_DIM]
+    rope_local = d_offs - rope_abs_start  # valid where is_rope
+
+    # Flat per-(token, head) load of the whole head row: [HEAD_DIM]. Fully
+    # coalesced (contiguous along d). RoPE math in FP32 (vLLM-style) — load is
+    # bf16, immediately upcast. Not byte-identical to the old BF16-rope kernel
+    # (~0.8% of fp8 bytes differ by ≤1 ULP), but within fp8 tolerance.
+    base = x_ptr + pid_s * stride_x_s + pid_h * stride_x_h
+    x = tl.load(base + d_offs * stride_x_d).to(tl.float32)  # [HEAD_DIM] fp32
+
+    # Partner element for the interleaved (GPT-J) rope pair: index ^ 1.
+    x_partner = tl.load(base + (d_offs ^ 1) * stride_x_d, mask=is_rope, other=0.0).to(
+        tl.float32
+    )
+
+    # cos/sin gathered by the rope-pair index (reuse_freqs_front_part: //2).
+    # cos cache is [max_pos, 1, 1, rd//2]; index = rope_local // 2.
+    cs_idx = tl.maximum(rope_local >> 1, 0)  # [HEAD_DIM]
+    cos_addr = pos * stride_cos_s + cs_idx * stride_cos_d
+    cos_v = tl.load(cos_ptr + cos_addr, mask=is_rope, other=1.0)
+    sin_v = tl.load(sin_ptr + cos_addr, mask=is_rope, other=0.0)
+
+    # Inverse (transpose) GPT-J rotation in FP32: even lanes x*cos + partner*sin,
+    # odd lanes x*cos - partner*sin. Applied only on rope cols.
+    is_even = (rope_local & 1) == 0  # [HEAD_DIM]
+    x_add = x * cos_v + x_partner * sin_v
+    x_sub = x * cos_v - x_partner * sin_v
+    rotated = tl.where(is_even, x_add, x_sub)
+    x = tl.where(is_rope, rotated, x)  # [HEAD_DIM] fp32
+
+    # Per-D128-block amax over the head's CHUNKS_PER_HEAD chunks.
+    x_blk = tl.reshape(x, (CHUNKS_PER_HEAD, GROUP_SIZE))
+    amax = tl.max(tl.abs(x_blk), axis=1)  # [CHUNKS_PER_HEAD]
+
+    # UE8M0 byte via the bit-trick round-up: ((bits + 0x7FFFFF) & 0xFF800000)
+    # >> 23, clamp [0,254]. Matches the DeepGEMM host reference. The pow2 scale
+    # is reconstructed from the byte so the consumer's dequant is bit-exact.
+    scale_f32 = amax * (1.0 / FP8_MAX)
+    scale_f32 = tl.maximum(scale_f32, 1.1754944e-38)  # 2^-126 floor
+    bits_u = scale_f32.to(tl.uint32, bitcast=True)
+    byte_u = (
+        (bits_u + tl.full([], 0x007FFFFF, tl.uint32))
+        & tl.full([], 0xFF800000, tl.uint32)
+    ) >> 23
+    byte = tl.minimum(tl.maximum(byte_u.to(tl.int32), 0), 254)  # [CHUNKS_PER_HEAD]
+    s_pow2 = (byte.to(tl.uint32) << 23).to(tl.float32, bitcast=True)
+
+    # Quantize: divide each col by its block's pow2 scale, clamp, fp8 cast.
+    s_pow2_exp = tl.reshape(
+        tl.broadcast_to(
+            tl.reshape(s_pow2, (CHUNKS_PER_HEAD, 1)),
+            (CHUNKS_PER_HEAD, GROUP_SIZE),
+        ),
+        (HEAD_DIM,),
+    )
+    q = x / s_pow2_exp
+    q = tl.minimum(tl.maximum(q, -FP8_MAX), FP8_MAX)
+    q_fp8 = q.to(tl.float8e4nv)
+
+    # Store fp8 head into y at (s, g, qb_start*GROUP_SIZE + d_offs).
+    y_d0 = qb_start * GROUP_SIZE
+    y_offs = pid_s * stride_y_s + pid_g * stride_y_g + (y_d0 + d_offs) * stride_y_d
+    tl.store(y_ptr + y_offs, q_fp8)
+
+    # Pack scale bytes into one i32 word. Each i32 covers PACK4 consecutive D128
+    # blocks (= 512 cols). When CHUNKS_PER_HEAD == PACK4 (V4-Pro: 4 == 4) each
+    # head's blocks map to EXACTLY ONE word (qb_start is a multiple of PACK4,
+    # so word = qb_start // PACK4 = head_in_group and lanes are 0..PACK4-1).
+    # No cross-head word sharing → a single packed store per head, no atomics.
+    tl.static_assert(
+        CHUNKS_PER_HEAD == PACK4,
+        "packed-scale store assumes CHUNKS_PER_HEAD == PACK4 (one word/head)",
+    )
+    lane_shift = tl.arange(0, CHUNKS_PER_HEAD) * 8  # [CHUNKS]
+    packed = tl.sum((byte & 0xFF) << lane_shift)  # scalar i32
+    word = qb_start // PACK4  # == head_in_group
+    s_addr = pid_s * stride_s_s + pid_g * stride_s_g + word * stride_s_d
+    tl.store(s_ptr + s_addr, packed)
+
+
 def inverse_rope_inplace(
     x: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
     positions: torch.Tensor,
-) -> None:
+    *,
+    quant_out: bool = False,
+    n_groups: int | None = None,
+    nope_dim: int | None = None,
+):
     """In-place inverse RoPE (GPT-J style) on the rope slice of attention output.
 
     Args:
-        x: ``[num_tokens, n_heads, rotary_dim]`` bf16 — typically ``o[..., -rd:]``.
+        x: ``[num_tokens, n_heads, head_dim]`` bf16 — typically ``o`` (full
+           head_dim including nope+rope) when ``quant_out=True``, or just the
+           rope slice ``o[..., -rd:]`` when ``quant_out=False``.
         cos: ``[max_seq_len, 1, 1, rotary_dim // 2]`` bf16 cache.
         sin: ``[max_seq_len, 1, 1, rotary_dim // 2]`` bf16 cache.
         positions: ``[num_tokens]`` int — per-token position ids.
+        quant_out: when True, returns ``(y_fp8, sx_i32)`` quantized output
+                   suitable as direct input to ``fp8_einsum``. ``x`` is
+                   read-only in this mode.
+        n_groups: when ``quant_out=True``, number of head-groups to fold the
+                  ``n_heads`` axis into. Must divide ``n_heads`` evenly.
+                  ``d_per_group = (n_heads // n_groups) * head_dim``.
+        nope_dim: when ``quant_out=True``, size of the leading nope slice in
+                  each head. Defaults to ``head_dim - cos.shape[-1] * 2``
+                  (rope-slice = full rotary_dim, nope = remainder).
+
+    Returns:
+        ``None`` when ``quant_out=False``.
+        ``(y_fp8, sx_i32)`` when ``quant_out=True``:
+          - ``y_fp8``: ``[num_tokens, n_groups, d_per_group]`` float8_e4m3fn
+          - ``sx_i32``: ``[num_tokens, n_groups, d_per_group // 512]`` int32
+                       (4 UE8M0 bytes packed little-endian per i32).
     """
-    S, H, rd = x.shape
-    BLOCK_RD = triton.next_power_of_2(rd)
-    BLOCK_S = 32
-    grid = (H, triton.cdiv(S, BLOCK_S))
-    _inverse_rope_gptj_kernel[grid](
+    if not quant_out:
+        S, H, rd = x.shape
+        BLOCK_RD = triton.next_power_of_2(rd)
+        BLOCK_S = 32
+        grid = (H, triton.cdiv(S, BLOCK_S))
+        _inverse_rope_gptj_kernel[grid](
+            x,
+            cos,
+            sin,
+            positions,
+            x.stride(0),
+            x.stride(1),
+            x.stride(2),
+            cos.stride(0),
+            cos.stride(3),
+            S,
+            BLOCK_S=BLOCK_S,
+            BLOCK_RD=BLOCK_RD,
+            BLOCK_RD_HALF=BLOCK_RD // 2,
+            num_warps=4,
+        )
+        return None
+
+    # quant_out=True path: full head_dim input, fused per-D128 UE8M0 + fp8 cast.
+    assert n_groups is not None, "n_groups required when quant_out=True"
+    S, H, head_dim = x.shape
+    assert H % n_groups == 0, f"n_heads={H} must be divisible by n_groups={n_groups}"
+    n_heads_per_group = H // n_groups
+    d_per_group = n_heads_per_group * head_dim
+    GROUP_SIZE = 128
+    PACK4 = 4
+    assert (
+        d_per_group % (GROUP_SIZE * PACK4) == 0
+    ), f"d_per_group={d_per_group} must be divisible by {GROUP_SIZE * PACK4}"
+    # cos.shape[-1] = rotary_dim // 2 (reuse_freqs_front_part layout)
+    rope_dim = cos.shape[-1] * 2
+    if nope_dim is None:
+        nope_dim = head_dim - rope_dim
+    assert (
+        nope_dim + rope_dim == head_dim
+    ), f"nope_dim={nope_dim} + rope_dim={rope_dim} != head_dim={head_dim}"
+    assert (
+        head_dim % GROUP_SIZE == 0
+    ), f"head_dim={head_dim} must be multiple of {GROUP_SIZE}"
+    assert (
+        rope_dim <= GROUP_SIZE
+    ), f"rope_dim={rope_dim} must be <= {GROUP_SIZE} (one rope D128 chunk)"
+
+    device = x.device
+    y = torch.empty(S, n_groups, d_per_group, dtype=torch.float8_e4m3fn, device=device)
+    sx = torch.empty(
+        S,
+        n_groups,
+        d_per_group // (GROUP_SIZE * PACK4),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    # Grid = (S, n_heads): ONE program per (token, head). Each program loads
+    # that head's flat HEAD_DIM row (fully coalesced) and writes its
+    # CHUNKS_PER_HEAD D128 blocks + one packed scale word. Pure function of
+    # (tokens, heads) → CUDA-graph-capture safe, no @triton.autotune, no
+    # per-batch search spike. num_warps=1: a single wavefront issues the head
+    # row; extra warps only add scheduling overhead.
+    n_heads = n_groups * n_heads_per_group
+    grid = (S, n_heads)
+    _inverse_rope_quant_kernel[grid](
         x,
+        y,
+        sx,
         cos,
         sin,
         positions,
         x.stride(0),
         x.stride(1),
         x.stride(2),
+        y.stride(0),
+        y.stride(1),
+        y.stride(2),
+        sx.stride(0),
+        sx.stride(1),
+        sx.stride(2),
         cos.stride(0),
         cos.stride(3),
         S,
-        BLOCK_S=BLOCK_S,
-        BLOCK_RD=BLOCK_RD,
-        BLOCK_RD_HALF=BLOCK_RD // 2,
-        num_warps=4,
+        HEAD_DIM=head_dim,
+        NOPE_DIM=nope_dim,
+        ROPE_DIM=rope_dim,
+        N_HEADS_PER_GROUP=n_heads_per_group,
+        GROUP_SIZE=GROUP_SIZE,
+        PACK4=PACK4,
+        FP8_MAX=448.0,
+        num_warps=1,
     )
+    return y, sx

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -44,6 +44,9 @@ from aiter.dist.communication_op import (
 from aiter.dist.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
+from aiter.jit.utils.torch_guard import torch_compile_guard
+from aiter.ops.flydsl.kernels.fp8_einsum import fp8_einsum
+from aiter.ops.shuffle import shuffle_weight
 from aiter.ops.topk import top_k_per_row_decode, top_k_per_row_prefill
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 from aiter.ops.triton.fusions.fused_clamp_act_mul import (
@@ -76,6 +79,12 @@ from atom.model_ops.linear import (
 )
 from atom.model_ops.moe import FusedMoE
 from atom.model_ops.quant_v4 import act_quant_inplace
+from aiter import rope_rotate_activation
+from atom.model_ops.quant_v4 import (
+    act_quant_inplace,
+    fp32_to_ue8m0_byte,
+    pack_ue8m0_bytes_to_i32,
+)
 from atom.model_ops.sparse_attn_v4 import (
     hc_split_sinkhorn,
 )
@@ -157,6 +166,11 @@ _V4_FORCE_UE8M0_QUANT = os.environ.get("V4_FORCE_UE8M0_QUANT", "0") == "1"
 _V4_USE_REF_QUANT = os.environ.get("V4_USE_REF_QUANT", "0") == "1"
 # Fused-kernel switches. Default off; flip via env to A/B against the eager path.
 _V4_USE_TRITON_FUSION = os.environ.get("ATOM_V4_USE_TRITON_FUSION", "0") == "1"
+# When on, the wo_a grouped LoRA is computed by the flydsl fp8_einsum kernel
+# instead of the BF16 torch.einsum. Activation quant is fused into the
+# inverse-RoPE Triton kernel (single launch). Requires `tp_size == 1` at V4-Pro
+# until per-TP shapes are added to the fp8_einsum autotune table.
+_V4_USE_FP8_WO_A = os.environ.get("ATOM_V4_USE_FP8_WO_A", "0") == "1"
 ENABLE_DS_QKNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_QKNORM_QUANT_FUSION
 
 
@@ -1501,8 +1515,11 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{p}.wq_b",
         )
         self.kv_norm = RMSNorm(self.head_dim, self.eps)
-        # wo_a: grouped LoRA — V4QuantConfig forces this BF16 even though disk is FP8.
-        # The grouped einsum (`bsgd,grd->bsgr`) needs BF16 weights; aiter has no FP8 einsum.
+        # wo_a: grouped LoRA. Disk is FP8 + 128x128 block scale. The weight is
+        # allocated FP8 here; process_weights_after_loading then either dequants
+        # it to BF16 for the plain `torch.einsum` path (default), or — when
+        # `ATOM_V4_USE_FP8_WO_A=1` — repacks it into the flydsl `fp8_einsum`
+        # layout (`wo_a_y_pre` / `wo_a_sy_i32`) and drops the BF16 copy.
         self.wo_a = ColumnParallelLinear(
             self.n_heads * self.head_dim // self.n_groups,
             self.n_groups * args.o_lora_rank,
@@ -1601,53 +1618,86 @@ class DeepseekV4Attention(nn.Module):
         atom_config.compilation_config.static_forward_context[self.layer_name] = self
 
     def process_weights_after_loading(self) -> None:
-        """Dequant wo_a (FP8 + e8m0 block scale) → BF16 in place.
+        """Convert wo_a (FP8 + e8m0 block scale) into the layout the grouped
+        LoRA expects.
 
-        Called by ATOM's standard loader (atom.model_loader.loader.load_model)
-        after all weights are filled. wo_a is allocated as FP8 ColumnParallelLinear
-        so both `.weight` (FP8) and `.weight_scale` (e8m0 block scale) load
-        correctly via the standard FP8 path. We then dequant to BF16 because
-        forward needs `wo_a.weight` as BF16 for the grouped LoRA einsum
-        (`bsgd,grd->bsgr`); aiter has no FP8 grouped einsum.
+        Two modes, switched by `_V4_USE_FP8_WO_A`:
 
-        Idempotent: if wo_a.weight is already BF16 (e.g. dequant was applied
-        elsewhere), this is a no-op.
+        - Default (BF16 only): dequant FP8 → BF16 in place. forward_impl runs
+          the grouped LoRA as a plain BF16 `torch.einsum`.
+
+        - FP8 mode (env `ATOM_V4_USE_FP8_WO_A=1`): keep ONLY the FP8
+          representation — preshuffled FP8 weight `wo_a_y_pre` + packed-UE8M0
+          i32 scale `wo_a_sy_i32` (the flydsl `fp8_einsum` ABI). Activation
+          quant is fused into `inverse_rope_inplace(quant_out=True)`.
+          forward_impl always runs the grouped LoRA via `fp8_einsum`; no BF16
+          weight is built and there is no per-forward dispatch.
+
+        Idempotent: if wo_a.weight has already been converted (BF16 with
+        scale dropped, or `wo_a_y_pre` already bound), this is a no-op.
         """
         w = self.wo_a.weight
+        # Idempotency guards: skip if already converted (FP8 repack done, or
+        # weight already dequanted to BF16), or if there's nothing to convert.
+        if hasattr(self, "wo_a_y_pre"):
+            return
         if w.dtype == torch.bfloat16:
-            return  # already dequanted
+            return
         scale = getattr(self.wo_a, "weight_scale", None)
-        if w.dtype not in (torch.float8_e4m3fn, torch.float8_e4m3fnuz) or scale is None:
-            return  # nothing to do
-        # Dequant: w (FP8 [out, in]) × scale (e8m0 [out/128, in/128]) → BF16
-        bf16 = _dequant_fp8_block_to_bf16(
-            w.data, scale.data.to(torch.float32), block=128
+        if w.dtype != torch.float8_e4m3fn or scale is None:
+            return
+
+        # Disk layout for wo_a: FP8 e4m3 weight [G*R, K] + per-128x128 block
+        # scale. The ATOM loader (model_ops/linear.py:per_1x128) materializes
+        # the scale as fp32, so `scale.data` here is fp32, not native UE8M0.
+        G = self.n_local_groups
+        R = self.o_lora_rank
+        K = w.shape[1]  # d_per_group
+        scale_f32 = scale.data.float()
+
+        if not _V4_USE_FP8_WO_A:
+            # Default BF16-only mode: dequant FP8 → BF16, drop the scale, and
+            # make the subsequent LinearBase post-load a no-op (see CRITICAL
+            # below). forward_impl runs the grouped LoRA as a plain BF16
+            # `torch.einsum` over `self.wo_a.weight`.
+            self.wo_a.weight = atom_parameter(
+                _dequant_fp8_block_to_bf16(w.data, scale_f32, block=128)
+            )
+            if hasattr(self.wo_a, "weight_scale"):
+                delattr(self.wo_a, "weight_scale")
+            # CRITICAL: prevent LinearBase.process_weights_after_loading from
+            # `shuffle_weights(self.weight)` on the now-BF16 wo_a. That shuffle
+            # is for the FP8 CK GEMM layout; applying it to a plain BF16 matrix
+            # consumed by `torch.einsum` corrupts it (rows permuted within 16x16
+            # blocks). load_model iterates parent-first (this hook runs BEFORE
+            # the child wo_a Linear's shuffle), so overriding quant_type here
+            # makes that subsequent post-load a no-op for wo_a.
+            self.wo_a.quant_type = QuantType.No
+            return
+
+        # ----- FP8 mode: keep ONLY the FP8 representation. -----
+        assert w.shape[0] == G * R, f"wo_a.weight rows {w.shape[0]} != G*R = {G*R}"
+        assert scale.shape == (G * R // 128, K // 128), (
+            f"wo_a.weight_scale shape {tuple(scale.shape)} != "
+            f"{(G * R // 128, K // 128)}"
         )
-        # Replace the weight tensor with BF16, drop the scale param so future
-        # loads / introspection don't try to use a stale FP8 scale.
-        self.wo_a.weight = atom_parameter(bf16)
-        try:
+        # fp8_einsum inputs: preshuffled FP8 weight + packed-UE8M0 i32 scale.
+        #   y_pre  : shuffle_weight((G, R, K), layout=(16, 32))
+        #   sy_i32 : fp32 scale → UE8M0 byte (round-up pow2) → pack 4/LE per i32
+        self.wo_a_y_pre = shuffle_weight(
+            w.data.view(G, R, K).contiguous(), layout=(16, 32)
+        ).contiguous()
+        self.wo_a_sy_i32 = pack_ue8m0_bytes_to_i32(
+            fp32_to_ue8m0_byte(scale_f32.view(G, R // 128, K // 128))
+        )
+        # Free the original FP8 weight + scale; leave an empty placeholder so
+        # anything introspecting wo_a.weight still gets a sane dtype.
+        self.wo_a.weight = atom_parameter(
+            torch.empty(0, dtype=torch.float8_e4m3fn, device=w.device)
+        )
+        if hasattr(self.wo_a, "weight_scale"):
             delattr(self.wo_a, "weight_scale")
-        except AttributeError:
-            pass
-        # CRITICAL: prevent LinearBase.process_weights_after_loading from
-        # `shuffle_weights(self.weight)` on the now-BF16 wo_a. That shuffle
-        # is for the FP8 CK GEMM layout; applying it to a plain BF16 matrix
-        # consumed by `torch.einsum` corrupts the layout (rows get permuted
-        # within 16×16 blocks, only rows aligned to the block boundaries
-        # stay in place). Iteration order in load_model is parent-first
-        # (DeepseekV4Attention before its child wo_a Linear), so our hook
-        # runs BEFORE the shuffle — overriding `quant_type` here makes the
-        # subsequent LinearBase post-load a no-op for wo_a.
-        #
-        # TODO(perf): replace dequant-to-BF16 + einsum with FP8 batched BMM
-        # (same path as MLA's `_v_up_proj_and_o_proj`). Steps:
-        #   1. Dequant FP8 per-128-block → BF16 (this code)
-        #   2. Reshape to [n_local_groups, o_lora_rank, d_per_group]
-        #   3. Requant via dynamic_per_batched_tensor_quant → FP8 + scalar scale
-        #   4. Forward: _aiter_triton_fp8_bmm(o, W_OA, W_OA_scale, group_size=128)
-        # This avoids the dequant + einsum overhead and reuses the proven MLA
-        # batched-FP8 kernel. See attention_mla.py:211 for reference.
+        # Same no-op-the-child-shuffle rationale as the BF16 branch's CRITICAL note.
         self.wo_a.quant_type = QuantType.No
         self.wo_a.need_normalize_e4m3fn_to_e4m3fnuz = False
 
@@ -1901,11 +1951,40 @@ class DeepseekV4Attention(nn.Module):
 
         # Inverse RoPE on output's rope dims to remove absolute-position
         # contribution carried in by the value-side RoPE of the KV entries.
-        self.rotary_emb.inverse(positions, o[..., -rd:])
         # ----- Grouped output LoRA (batched on the full flat tensor) -----
-        o = o.view(num_tokens, self.n_local_groups, -1)
-        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-        o = torch.einsum("sgd,grd->sgr", o, wo_a)
+        # When the env flag is on, process_weights_after_loading keeps ONLY the
+        # repacked FP8 weights (`wo_a_y_pre` / `wo_a_sy_i32`), so the grouped
+        # LoRA always runs via `fp8_einsum` regardless of batch size.
+
+        if _V4_USE_FP8_WO_A:
+            # FP8 path. One launch: inverse RoPE on the rope tail of each head +
+            # per-D128 amax → UE8M0 → FP8 e4m3 cast + packed-i32 scale write.
+            # Output layout matches fp8_einsum's X-operand ABI.
+            o_fp8, o_sx = inverse_rope_inplace(
+                o,
+                self.rotary_emb.cos_cache,
+                self.rotary_emb.sin_cache,
+                positions,
+                quant_out=True,
+                n_groups=self.n_local_groups,
+            )  # o_fp8 [S, G, d_per_group], o_sx [S, G, d_per_group/512]
+
+            z_fp8, sz = fp8_einsum(
+                o_fp8,
+                self.wo_a_y_pre,
+                o_sx,
+                self.wo_a_sy_i32,
+                out_dtype=torch.float8_e4m3fn,
+                transpose_scale=True,
+            )  # z_fp8 [S, G, o_lora_rank], sz [...]
+            x_fp8 = z_fp8.view(num_tokens, -1)  # [S, G*o_lora_rank]
+            x_scale = sz.view(-1, num_tokens).transpose(0, 1)
+            return self.wo_b(x_fp8, x_scale=x_scale)
+        else:
+            self.rotary_emb.inverse(positions, o[..., -rd:])
+            o = o.view(num_tokens, self.n_local_groups, -1)
+            wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+            o = torch.einsum("sgd,grd->sgr", o, wo_a)
         x = self.wo_b(o.flatten(1))
         return x
 


### PR DESCRIPTION
# Motivation
depends on https://github.com/ROCm/aiter/pull/3614
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->


<!-- Explain the changes along with any relevant GitHub links. -->

# Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

# Test Result
for small conc like 8, basically same:
PR
```
============ Serving Benchmark Result ============
Successful requests:                     64        
Failed requests:                         0         
Maximum request concurrency:             64        
Benchmark duration (s):                  18.61     
Total input tokens:                      65536     
Total generated tokens:                  65536     
Request throughput (req/s):              3.44      
Output token throughput (tok/s):         3522.40   
Peak output token throughput (tok/s):    4055.00   
Peak concurrent requests:                64.00     
Total token throughput (tok/s):          7044.80   
---------------Time to First Token----------------
Mean TTFT (ms):                          887.00    
Median TTFT (ms):                        752.65    
P99 TTFT (ms):                           1357.04   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.31     
Median TPOT (ms):                        17.44     
P99 TPOT (ms):                           17.83     
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.30     
Median ITL (ms):                         17.04     
P99 ITL (ms):                            18.15     
==================================================
```

before
```
============ Serving Benchmark Result ============
Successful requests:                     64        
Failed requests:                         0         
Maximum request concurrency:             64        
Benchmark duration (s):                  19.14     
Total input tokens:                      65536     
Total generated tokens:                  65536     
Request throughput (req/s):              3.34      
Output token throughput (tok/s):         3423.32   
Peak output token throughput (tok/s):    4288.00   
Peak concurrent requests:                64.00     
Total token throughput (tok/s):          6846.64   
---------------Time to First Token----------------
Mean TTFT (ms):                          961.97    
Median TTFT (ms):                        831.00    
P99 TTFT (ms):                           1434.64   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.76     
Median TPOT (ms):                        17.89     
P99 TPOT (ms):                           18.28     
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.75     
Median ITL (ms):                         17.38     
P99 ITL (ms):                            18.95     
==================================================
```


acc test:
v4-flash
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9469|±  |0.0062|
|     |       |strict-match    |     5|exact_match|↑  |0.9447|±  |0.0063|
```
v4-pro
```
local-completions ({'model': '/workspace/shared/data/amd_int/models/deepseek-ai/DeepSeek-V4-Pro', 'base_url': 'http://localhost:30000/v1/completions', 'num_concurrent': 65, 'max_retries': 3, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9538|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.9538|±  |0.0058|
```

<!-- Briefly summarize test outcomes. -->

# Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
