### PR TITLE
ci(atom_test): supervise client with wait_infer_drain.sh to kill hung jobs early

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -168,16 +168,53 @@ PY
     done
 
     echo "Using custom lm-eval command from client_command: ${CLIENT_COMMAND}"
-    "${CLIENT_COMMAND_ARGS[@]}" 2>&1 | tee "$ATOM_CLIENT_LOG"
+    # Background the client + tee pipeline in its own process group so
+    # wait_infer_drain.sh can supervise the engine in the foreground and we
+    # can SIGTERM the whole group on hang/fault. `set -m` (job control)
+    # gives each backgrounded pipeline its own pgid == $!.
+    set -m
+    ( "${CLIENT_COMMAND_ARGS[@]}" 2>&1 | tee "$ATOM_CLIENT_LOG" ) &
+    CLIENT_PID=$!
+    set +m
   else
     echo "Using default lm-eval command."
-    lm_eval --model local-completions \
-            --model_args "model=${MODEL_PATH},base_url=http://localhost:8000/v1/completions,num_concurrent=65,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
-            --tasks gsm8k \
-            --num_fewshot 3 \
-            --output_path "${OUTPUT_PATH}" \
-            2>&1 | tee "$ATOM_CLIENT_LOG"
+    set -m
+    (
+      lm_eval --model local-completions \
+              --model_args "model=${MODEL_PATH},base_url=http://localhost:8000/v1/completions,num_concurrent=65,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
+              --tasks gsm8k \
+              --num_fewshot 3 \
+              --output_path "${OUTPUT_PATH}" \
+              2>&1 | tee "$ATOM_CLIENT_LOG"
+    ) &
+    CLIENT_PID=$!
+    set +m
   fi
+
+  # Supervise: drain detects engine fault (exit 2 in <=10s), engine hang
+  # (exit 1 in <=60s), clean completion (exit 0 when client gone + no
+  # pending output), or timeout (exit 4 at MAX_MIN). Without this the
+  # accuracy step burns the full `timeout-minutes` whenever an aiter
+  # kernel asserts mid-prefill or a GPU faults — lm_eval just keeps
+  # retrying against a dead engine for 30 min.
+  echo "========== Supervising client with wait_infer_drain.sh =========="
+  bash scripts/wait_infer_drain.sh 8000 30 10 "$ATOM_CLIENT_LOG"
+  DRAIN_RC=$?
+  if [ "$DRAIN_RC" -ne 0 ]; then
+    echo "wait_infer_drain.sh exit=$DRAIN_RC — killing client pgid $CLIENT_PID"
+    # `kill -- -PGID` signals the whole group (set -m made CLIENT_PID == pgid).
+    # Negative target requires `--` separator so bash doesn't parse it as a flag.
+    kill -TERM -- -"$CLIENT_PID" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do
+      kill -0 "$CLIENT_PID" 2>/dev/null || break
+      sleep 1
+    done
+    kill -KILL -- -"$CLIENT_PID" 2>/dev/null || true
+    wait "$CLIENT_PID" 2>/dev/null || true
+    exit "$DRAIN_RC"
+  fi
+  # Drain clean: client should be near-done. Reap exit status.
+  wait "$CLIENT_PID" || true
 
   RESULT_FILENAME=$(
     python3 - <<PY
@@ -342,19 +379,44 @@ if [ "$TYPE" == "benchmark" ]; then
     PROFILE_ARG="--profile"
     echo "Profiling enabled via --profile flag"
   fi
-  python -m atom.benchmarks.benchmark_serving \
-    --model=$MODEL_PATH --backend=vllm --base-url="http://localhost:8000" \
-    --dataset-name=random \
-    --random-input-len=$ISL --random-output-len=$OSL --random-range-ratio=$RANDOM_RANGE_RATIO \
-    --max-concurrency=$CONC \
-    --num-prompts=${NUM_PROMPTS_OVERRIDE:-$(( $CONC * 10 ))} \
-    --trust-remote-code \
-    --num-warmups=$(( $CONC * 2 )) \
-    --request-rate=inf --ignore-eos \
-    --save-result --percentile-metrics="ttft,tpot,itl,e2el" \
-    --result-dir=. --result-filename=${RESULT_FILENAME}.json \
-    $PROFILE_ARG ${BENCH_EXTRA_ARGS:-} \
-    2>&1 | tee "$ATOM_CLIENT_LOG"
+  # Background the benchmark + tee pipeline in its own process group so
+  # wait_infer_drain.sh can supervise the engine in the foreground and
+  # SIGTERM the whole group on hang/fault. Same pattern as the accuracy
+  # block — see comments there.
+  set -m
+  (
+    python -m atom.benchmarks.benchmark_serving \
+      --model=$MODEL_PATH --backend=vllm --base-url="http://localhost:8000" \
+      --dataset-name=random \
+      --random-input-len=$ISL --random-output-len=$OSL --random-range-ratio=$RANDOM_RANGE_RATIO \
+      --max-concurrency=$CONC \
+      --num-prompts=${NUM_PROMPTS_OVERRIDE:-$(( $CONC * 10 ))} \
+      --trust-remote-code \
+      --num-warmups=$(( $CONC * 2 )) \
+      --request-rate=inf --ignore-eos \
+      --save-result --percentile-metrics="ttft,tpot,itl,e2el" \
+      --result-dir=. --result-filename=${RESULT_FILENAME}.json \
+      $PROFILE_ARG ${BENCH_EXTRA_ARGS:-} \
+      2>&1 | tee "$ATOM_CLIENT_LOG"
+  ) &
+  CLIENT_PID=$!
+  set +m
+
+  echo "========== Supervising benchmark with wait_infer_drain.sh =========="
+  bash scripts/wait_infer_drain.sh 8000 30 10 "$ATOM_CLIENT_LOG"
+  DRAIN_RC=$?
+  if [ "$DRAIN_RC" -ne 0 ]; then
+    echo "wait_infer_drain.sh exit=$DRAIN_RC — killing benchmark pgid $CLIENT_PID"
+    kill -TERM -- -"$CLIENT_PID" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do
+      kill -0 "$CLIENT_PID" 2>/dev/null || break
+      sleep 1
+    done
+    kill -KILL -- -"$CLIENT_PID" 2>/dev/null || true
+    wait "$CLIENT_PID" 2>/dev/null || true
+    exit "$DRAIN_RC"
+  fi
+  wait "$CLIENT_PID" || true
 
   # Inject ISL/OSL into result JSON for summary table
   if [ -f "${RESULT_FILENAME}.json" ]; then


### PR DESCRIPTION
## Problem
CI accuracy/benchmark jobs burn the full \`timeout-minutes: 30\` when an aiter kernel asserts mid-prefill, a worker SIGABRTs (\`exitcode=-6\`), or the GPU faults. \`lm_eval\` / \`benchmark_serving\` happily retries against a dead engine for 30 min, holding the GPU runner hostage.

Concrete example: https://github.com/ROCm/ATOM/actions/runs/26561974986/job/78247211277 — V4-Pro accuracy job was stuck because a worker died with \`mono-tile requires M divisible by B_M=128; got M=15856\` (aiter dispatcher routing M=15856 to a 128-aligned mono kernel), but the CI step kept running until the 30-min hard cap.

## Fix
Wrap the client (\`lm_eval\` / custom \`CLIENT_COMMAND\` / \`benchmark_serving\`) in a backgrounded subshell with its own process group (\`set -m\` so \`\$!\` == pgid), then run \`scripts/wait_infer_drain.sh\` in the foreground as the step's gating process.

Drain exits early on:
- **exit 1**: engine hang — no \"Engine Core: output send\" in server log for 60s while a client is still active
- **exit 2**: GPU fault / ASSERT_TRAP / \`proc died unexpectedly\` / \`Memory access fault by GPU\` (~10s detection)
- **exit 4**: \`MAX_MIN\` (30) elapsed without resolution
- **exit 0**: clean drain (client gone + no pending engine output)

On non-zero exit, SIGTERM the whole client process group, escalate to SIGKILL after 5s, then propagate drain's exit code → CI step fails immediately instead of waiting out the YAML \`timeout-minutes\`.

## Affected files
- \`.github/scripts/atom_test.sh\` — \`accuracy\` block (lines 175-217) and \`benchmark\` block (lines 386-419) both get the same supervise pattern. \`launch\` / \`stop\` blocks unchanged.

## What stays the same
- \`/tmp/atom_client.log\` content is unchanged (\`tee\` target unchanged)
- \`accuracy_test_results/*.json\` unchanged
- \`Dump server log\` / \`Dump client log\` / \`Check accuracy test results\` / \`Collect Test Summary\` steps unaffected
- \`Collect Test Summary\`'s \`awk '/\\|Tasks\\|Version\\|/,/^\$/ { ... }' atom_accuracy_output.txt\` extractor still works — drain status lines start with \`[\` and contain no pipe characters, so they don't break the range pattern

## What changes in CI output
\`atom_accuracy_output.txt\` (the host-side capture of the docker exec stdout) now interleaves drain progress lines like:

\`\`\`
========== Supervising client with wait_infer_drain.sh ==========
[t=10s] server log auto-discovered: /tmp/atom_server.log
[t=10s] outputs=27 (+27) mtime+10s clients=1 stuck=0/6
[t=20s] outputs=112 (+85) mtime+10s clients=1 stuck=0/6
...
Engine DRAINED (client gone + no pending output)
\`\`\`

These are useful diagnostic context when a job fails — you can see immediately at which second the engine stopped emitting output, vs the previous behavior where you only had a 30-min-later timeout with no breadcrumbs.

## Test plan
- [ ] Trigger a fresh Pre-Checkin run; accuracy + benchmark jobs should complete with no change in pass/fail outcome
- [ ] Manually validate hang detection: temporarily inject a \`sleep 999\` into a worker to simulate hang, confirm the job fails in ~70s instead of 30 min
- [ ] Validate fault detection: same with a deliberate \`AITER_CHECK\` failure