### PR TITLE
[Feat] remove copy for dpsk v2 model

### DIFF
--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -48,6 +48,9 @@ from sglang.srt.models.deepseek_common.utils import (
 from sglang.srt.layers.quantization.rocm_mxfp4_utils import (
     batched_gemm_afp4wfp4_pre_quant,
 )
+from aiter.ops.triton.batched_gemm_afp4wfp4_pre_quant import (
+    batched_gemm_a16wfp4,
+)
 from aiter.ops.triton.batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant import (
     batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant,
 )
@@ -336,6 +339,26 @@ def mla_v_up_proj(
     effective_weight_scale = (
         weight_scale_k if weight_scale_k is not None else weight_scale
     )
+    if _is_hip and _use_aiter_gfx95 and weight.dtype == torch.uint8:
+        x = inp.transpose(0, 1)
+        out = torch.empty(
+            (inp.shape[0], attn.num_local_heads * out_dim),
+            device=inp.device,
+            dtype=torch.bfloat16,
+        )
+        out_3d = out.view(inp.shape[0], attn.num_local_heads, out_dim)
+        batched_gemm_a16wfp4(
+            x,
+            weight.transpose(-2, -1),
+            weight_scale_k.transpose(-2, -1),
+            dtype=torch.bfloat16,
+            y=out_3d,
+            transpose_bm=True,
+            prequant=True,
+            y_scale=None,
+        )
+        return out
+
     if _is_hip and (
         (_use_aiter_gfx95 and weight.dtype == torch.float8_e4m3fn)
         or (get_is_capture_mode() and weight.dtype == torch.float8_e4m3fnuz)


### PR DESCRIPTION
## Motivation

Improve DeepSeek V2 MLA decode performance in SGLang plugin mode by avoiding an extra copy in the MXFP4 v-up projection path on ROCm/GFX95.

## Technical Details

This commit adds a ROCm/GFX95 MXFP4 fast path in sgl_attention_mla.py using AITER batched_gemm_a16wfp4. It writes GEMM output directly into the flattened o_proj input buffer, while keeping existing FP8 and fallback paths unchanged.


## Test Result

**before：**
<img width="687" height="70" alt="image" src="https://github.com/user-attachments/assets/3b53d5aa-81ef-4178-8957-288b80815270" />

**after：**
<img width="660" height="44" alt="image" src="https://github.com/user-attachments/assets/13351a36-30ae-4335-ac3f-757e4c1911e3" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
