### PR TITLE
[ATOM-vLLM-Nightly] Debug ATOM-vLLM-Nightly timeout

### DIFF
--- a/.github/scripts/atom_oot_test.sh
+++ b/.github/scripts/atom_oot_test.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 # Usage:
+#   .github/scripts/atom_oot_test.sh start <mode> [model_name]
 #   .github/scripts/atom_oot_test.sh launch <mode> [model_name]
+#   .github/scripts/atom_oot_test.sh client <mode> [model_name]
 #   .github/scripts/atom_oot_test.sh accuracy <mode> [model_name]
 #
 # Alternatively, pass a single model explicitly through environment variables:
@@ -12,8 +14,10 @@ set -euo pipefail
 #   LM_EVAL_NUM_FEWSHOT
 #
 # TYPE:
+#   start    - launch vLLM server in the background and return immediately
 #   launch   - launch vLLM server and wait until ready
-#   accuracy - run gsm8k accuracy test and save result JSON
+#   client   - run gsm8k accuracy against an existing server
+#   accuracy - launch server, run gsm8k accuracy, and save result JSON
 #
 # MODE:
 #   ci    - workflow-provided OOT CI model entry
@@ -26,8 +30,8 @@ TYPE=${1:-launch}
 MODE=${2:-ci}
 SELECTED_MODEL=${3:-}
 
-if [[ "$TYPE" != "launch" && "$TYPE" != "accuracy" ]]; then
-  echo "Invalid TYPE: $TYPE. Expected: launch or accuracy"
+if [[ "$TYPE" != "start" && "$TYPE" != "launch" && "$TYPE" != "client" && "$TYPE" != "accuracy" ]]; then
+  echo "Invalid TYPE: $TYPE. Expected: start, launch, client, or accuracy"
   exit 2
 fi
 
@@ -146,6 +150,7 @@ launch_one_model() {
   local model_name="$1"
   local model_path="$2"
   local extra_args="$3"
+  local wait_for_ready="${4:-1}"
   local -a extra_arg_array=()
 
   local resolved_model_path
@@ -203,7 +208,9 @@ PY
   echo $! > "${VLLM_PID_FILE}"
   echo "Server PID: $(cat "${VLLM_PID_FILE}")"
 
-  wait_server_ready "${model_name}"
+  if [[ "${wait_for_ready}" == "1" ]]; then
+    wait_server_ready "${model_name}"
+  fi
 }
 
 accuracy_one_model() {
@@ -396,8 +403,18 @@ run_for_models() {
     fi
     matched=1
 
+    if [[ "${action}" == "start" ]]; then
+      launch_one_model "${model_name}" "${model_path}" "${extra_args}" "0"
+      break
+    fi
+
     if [[ "${action}" == "launch" ]]; then
       launch_one_model "${model_name}" "${model_path}" "${extra_args}"
+      break
+    fi
+
+    if [[ "${action}" == "client" ]]; then
+      accuracy_one_model "${model_name}" "${model_path}" "${extra_args}" "${client_command}"
       break
     fi
 
@@ -414,7 +431,7 @@ run_for_models() {
 }
 
 cleanup_on_exit() {
-  if [[ "${TYPE}" == "launch" && "${KEEP_SERVER_ALIVE_ON_EXIT}" == "1" ]]; then
+  if [[ "${TYPE}" == "start" || ( "${TYPE}" == "launch" && "${KEEP_SERVER_ALIVE_ON_EXIT}" == "1" ) ]]; then
     echo "Keeping vLLM server alive for follow-up steps."
     return 0
   fi
@@ -423,8 +440,12 @@ cleanup_on_exit() {
 
 trap 'cleanup_on_exit' EXIT
 
-if [[ "${TYPE}" == "launch" ]]; then
+if [[ "${TYPE}" == "start" ]]; then
+  run_for_models "start"
+elif [[ "${TYPE}" == "launch" ]]; then
   run_for_models "launch"
+elif [[ "${TYPE}" == "client" ]]; then
+  run_for_models "client"
 else
   run_for_models "accuracy"
 fi

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -25,7 +25,7 @@ on:
           - Qwen3.5-397B-A17B-FP8 TP4
           - Qwen3.5-397B-A17B TP8
           - Qwen3.5-397B-A17B-MXFP4 TP4
-          - Meta-Llama-3.1-405B-Instruct-FP8/ TP8
+          - Meta-Llama-3.1-405B-Instruct-FP8 TP8
           - Llama-3.1-8B-Instruct TP1
           - Kimi-K2-Thinking-MXFP4 TP4
           - Kimi-K2-Thinking-MXFP4 TP8
@@ -62,7 +62,7 @@ on:
           - Qwen3.5-397B-A17B-FP8 TP4
           - Qwen3.5-397B-A17B TP8
           - Qwen3.5-397B-A17B-MXFP4 TP4
-          - Meta-Llama-3.1-405B-Instruct-FP8/ TP8
+          - Meta-Llama-3.1-405B-Instruct-FP8 TP8
           - Llama-3.1-8B-Instruct TP1
           - Kimi-K2-Thinking-MXFP4 TP4
           - Kimi-K2-Thinking-MXFP4 TP8
@@ -99,7 +99,7 @@ on:
           - Qwen3.5-397B-A17B-FP8 TP4
           - Qwen3.5-397B-A17B TP8
           - Qwen3.5-397B-A17B-MXFP4 TP4
-          - Meta-Llama-3.1-405B-Instruct-FP8/ TP8
+          - Meta-Llama-3.1-405B-Instruct-FP8 TP8
           - Llama-3.1-8B-Instruct TP1
           - Kimi-K2-Thinking-MXFP4 TP4
           - Kimi-K2-Thinking-MXFP4 TP8
@@ -136,7 +136,7 @@ on:
           - Qwen3.5-397B-A17B-FP8 TP4
           - Qwen3.5-397B-A17B TP8
           - Qwen3.5-397B-A17B-MXFP4 TP4
-          - Meta-Llama-3.1-405B-Instruct-FP8/ TP8
+          - Meta-Llama-3.1-405B-Instruct-FP8 TP8
           - Llama-3.1-8B-Instruct TP1
           - Kimi-K2-Thinking-MXFP4 TP4
           - Kimi-K2-Thinking-MXFP4 TP8
@@ -173,7 +173,7 @@ on:
           - Qwen3.5-397B-A17B-FP8 TP4
           - Qwen3.5-397B-A17B TP8
           - Qwen3.5-397B-A17B-MXFP4 TP4
-          - Meta-Llama-3.1-405B-Instruct-FP8/ TP8
+          - Meta-Llama-3.1-405B-Instruct-FP8 TP8
           - Llama-3.1-8B-Instruct TP1
           - Kimi-K2-Thinking-MXFP4 TP4
           - Kimi-K2-Thinking-MXFP4 TP8
@@ -210,7 +210,7 @@ on:
           - Qwen3.5-397B-A17B-FP8 TP4
           - Qwen3.5-397B-A17B TP8
           - Qwen3.5-397B-A17B-MXFP4 TP4
-          - Meta-Llama-3.1-405B-Instruct-FP8/ TP8
+          - Meta-Llama-3.1-405B-Instruct-FP8 TP8
           - Llama-3.1-8B-Instruct TP1
           - Kimi-K2-Thinking-MXFP4 TP4
           - Kimi-K2-Thinking-MXFP4 TP8
@@ -247,7 +247,7 @@ on:
           - Qwen3.5-397B-A17B-FP8 TP4
           - Qwen3.5-397B-A17B TP8
           - Qwen3.5-397B-A17B-MXFP4 TP4
-          - Meta-Llama-3.1-405B-Instruct-FP8/ TP8
+          - Meta-Llama-3.1-405B-Instruct-FP8 TP8
           - Llama-3.1-8B-Instruct TP1
           - Kimi-K2-Thinking-MXFP4 TP4
           - Kimi-K2-Thinking-MXFP4 TP8
@@ -284,7 +284,7 @@ on:
           - Qwen3.5-397B-A17B-FP8 TP4
           - Qwen3.5-397B-A17B TP8
           - Qwen3.5-397B-A17B-MXFP4 TP4
-          - Meta-Llama-3.1-405B-Instruct-FP8/ TP8
+          - Meta-Llama-3.1-405B-Instruct-FP8 TP8
           - Llama-3.1-8B-Instruct TP1
           - Kimi-K2-Thinking-MXFP4 TP4
           - Kimi-K2-Thinking-MXFP4 TP8
@@ -520,7 +520,7 @@ jobs:
               },
               {
                   "toggle_env": "RUN_LLAMA405_FP8_TP8",
-                  "model_name": "Meta-Llama-3.1-405B-Instruct-FP8/ TP8",
+                  "model_name": "Meta-Llama-3.1-405B-Instruct-FP8 TP8",
                   "model_path": "Meta-Llama-3.1-405B-Instruct-FP8/",
                   "extra_args": "--tensor-parallel-size 8 --load-format safetensors --allow-deprecated-quantization",
                   "accuracy_test_threshold": 0.93,
@@ -1453,25 +1453,6 @@ jobs:
             echo "Using model id: ${{ matrix.model_path }}"
           fi
 
-      - name: Prepare OOT artifact names
-        id: artifact-names
-        if: ${{ steps.validation-window.outputs.should_run == 'true' }}
-        env:
-          OOT_MODEL_NAME: ${{ matrix.model_name }}
-        run: |
-          safe_model_name=$(python3 - <<'PY'
-          import os
-          import re
-
-          name = os.environ["OOT_MODEL_NAME"]
-          safe = re.sub(r'["*:<>?\\|/\r\n]+', '_', name).strip()
-          safe = re.sub(r'\s+', ' ', safe)
-          print(safe or 'model')
-          PY
-          )
-          echo "safe_model_name=${safe_model_name}" >> "$GITHUB_OUTPUT"
-          echo "OOT_SAFE_MODEL_NAME=${safe_model_name}" >> "$GITHUB_ENV"
-
       - name: Start OOT accuracy server
         if: ${{ steps.validation-window.outputs.should_run == 'true' }}
         timeout-minutes: 10
@@ -1625,7 +1606,7 @@ jobs:
         if: ${{ always() && steps.validation-window.outputs.should_run == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: oot-validation-${{ steps.artifact-names.outputs.safe_model_name }}-${{ github.run_id }}
+          name: oot-validation-${{ matrix.model_name }}-${{ github.run_id }}
           path: |
             vllm_oot.log
             oot_accuracy_client.log
@@ -1640,7 +1621,7 @@ jobs:
         if: ${{ always() && steps.validation-window.outputs.should_run == 'true' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard)) }}
         uses: actions/upload-artifact@v7
         with:
-          name: accuracy-${{ steps.artifact-names.outputs.safe_model_name }}
+          name: accuracy-${{ matrix.model_name }}
           path: oot_accuracy_results/*.json
           if-no-files-found: ignore
 

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -1453,18 +1453,121 @@ jobs:
             echo "Using model id: ${{ matrix.model_path }}"
           fi
 
-      - name: Run OOT launch and gsm8k accuracy via script (full mode)
+      - name: Prepare OOT artifact names
+        id: artifact-names
         if: ${{ steps.validation-window.outputs.should_run == 'true' }}
+        env:
+          OOT_MODEL_NAME: ${{ matrix.model_name }}
+        run: |
+          safe_model_name=$(python3 - <<'PY'
+          import os
+          import re
+
+          name = os.environ["OOT_MODEL_NAME"]
+          safe = re.sub(r'["*:<>?\\|/\r\n]+', '_', name).strip()
+          safe = re.sub(r'\s+', ' ', safe)
+          print(safe or 'model')
+          PY
+          )
+          echo "safe_model_name=${safe_model_name}" >> "$GITHUB_OUTPUT"
+          echo "OOT_SAFE_MODEL_NAME=${safe_model_name}" >> "$GITHUB_ENV"
+
+      - name: Start OOT accuracy server
+        if: ${{ steps.validation-window.outputs.should_run == 'true' }}
+        timeout-minutes: 10
+        env:
+          OOT_MODEL_NAME: ${{ matrix.model_name }}
+          OOT_MODEL_PATH: ${{ matrix.model_path }}
+          OOT_EXTRA_ARGS: ${{ matrix.extra_args }}
+        run: |
+          $CONTAINER_ENGINE exec -d \
+            -e OOT_MODEL_NAME="${OOT_MODEL_NAME}" \
+            -e OOT_MODEL_PATH="${OOT_RESOLVED_MODEL_PATH:-$OOT_MODEL_PATH}" \
+            -e OOT_EXTRA_ARGS="${OOT_EXTRA_ARGS}" \
+            "$CONTAINER_NAME" bash -lc "
+              set -euo pipefail
+              bash .github/scripts/atom_oot_test.sh start full
+            "
+
+      - name: Wait for OOT accuracy server
+        if: ${{ steps.validation-window.outputs.should_run == 'true' && success() }}
         timeout-minutes: 120
+        env:
+          MAX_WAIT_RETRIES: "120"
+          WAIT_INTERVAL_SEC: "30"
+          STREAM_VLLM_LOGS: "1"
+        run: |
+          last_vllm_log_line=0
+
+          emit_new_vllm_logs() {
+            if [ "${STREAM_VLLM_LOGS}" != "1" ]; then
+              return 0
+            fi
+
+            current_line_count=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'if [ -f /tmp/vllm_oot.log ]; then wc -l < /tmp/vllm_oot.log; else echo 0; fi' 2>/dev/null || echo 0)
+            current_line_count=${current_line_count//$'\r'/}
+            if [ "${current_line_count:-0}" -le "${last_vllm_log_line}" ]; then
+              return 0
+            fi
+
+            echo ""
+            echo "========== New vLLM log output =========="
+            $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "sed -n '$((last_vllm_log_line + 1)),${current_line_count}p' /tmp/vllm_oot.log" || true
+            last_vllm_log_line=${current_line_count}
+          }
+
+          for ((i=1; i<=MAX_WAIT_RETRIES; i++)); do
+            if $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1'; then
+              emit_new_vllm_logs
+              echo "vLLM server is ready."
+              exit 0
+            fi
+
+            emit_new_vllm_logs
+
+            server_status=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc '
+              if [ -f /tmp/vllm_oot.pid ]; then
+                pid=$(cat /tmp/vllm_oot.pid)
+                if kill -0 "$pid" 2>/dev/null; then
+                  echo running
+                else
+                  echo dead
+                fi
+              elif pgrep -f "vllm serve" >/dev/null 2>&1; then
+                echo running
+              else
+                echo starting
+              fi
+            ' 2>/dev/null || echo unknown)
+
+            if [ "${server_status}" = "dead" ]; then
+              echo "vLLM server process exited before becoming ready."
+              $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'tail -n 200 /tmp/vllm_oot.log || true' || true
+              exit 1
+            fi
+
+            echo "Waiting for vLLM server... (${i}/${MAX_WAIT_RETRIES}; status=${server_status})"
+            sleep "${WAIT_INTERVAL_SEC}"
+          done
+
+          echo "vLLM server did not become ready in time."
+          emit_new_vllm_logs
+          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'tail -n 200 /tmp/vllm_oot.log || true' || true
+          exit 1
+
+      - name: Run OOT gsm8k accuracy client
+        id: run_accuracy_client
+        if: ${{ steps.validation-window.outputs.should_run == 'true' && success() }}
+        timeout-minutes: 120
+        continue-on-error: true
         env:
           OOT_MODEL_NAME: ${{ matrix.model_name }}
           OOT_MODEL_PATH: ${{ matrix.model_path }}
           OOT_EXTRA_ARGS: ${{ matrix.extra_args }}
           OOT_CLIENT_COMMAND: ${{ matrix.client_command || '' }}
           LM_EVAL_NUM_FEWSHOT: ${{ matrix.lm_eval_num_fewshot }}
-          MAX_WAIT_RETRIES: "120"
-          STREAM_VLLM_LOGS: "1"
         run: |
+          set -o pipefail
           $CONTAINER_ENGINE exec \
             -e OOT_MODEL_NAME="${OOT_MODEL_NAME}" \
             -e OOT_MODEL_PATH="${OOT_RESOLVED_MODEL_PATH:-$OOT_MODEL_PATH}" \
@@ -1475,15 +1578,13 @@ jobs:
             -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
             -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
             -e LM_EVAL_NUM_FEWSHOT="${LM_EVAL_NUM_FEWSHOT}" \
-            -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
-            -e STREAM_VLLM_LOGS="${STREAM_VLLM_LOGS}" \
             "$CONTAINER_NAME" bash -lc "
               set -euo pipefail
-              bash .github/scripts/atom_oot_test.sh accuracy full
-            "
+              bash .github/scripts/atom_oot_test.sh client full
+            " 2>&1 | tee ./oot_accuracy_client.log
 
       - name: Check OOT accuracy test results
-        if: ${{ steps.validation-window.outputs.should_run == 'true' && success() }}
+        if: ${{ steps.validation-window.outputs.should_run == 'true' && success() && steps.run_accuracy_client.outcome == 'success' }}
         run: |
           $CONTAINER_ENGINE cp "$CONTAINER_NAME":/tmp/oot_accuracy_results ./oot_accuracy_results || true
           result_file=$(ls -1t oot_accuracy_results/*.json 2>/dev/null | head -n 1)
@@ -1518,22 +1619,28 @@ jobs:
           $CONTAINER_ENGINE cp "$CONTAINER_NAME":/tmp/vllm_oot.log ./vllm_oot.log || true
           $CONTAINER_ENGINE cp "$CONTAINER_NAME":/tmp/oot_accuracy_output.txt ./oot_accuracy_output.txt || true
           $CONTAINER_ENGINE cp "$CONTAINER_NAME":/tmp/oot_accuracy_results ./oot_accuracy_results || true
+          if [ ! -f ./oot_accuracy_client.log ]; then : > ./oot_accuracy_client.log; fi
 
       - name: Upload model artifacts
         if: ${{ always() && steps.validation-window.outputs.should_run == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: oot-validation-${{ matrix.model_name }}-${{ github.run_id }}
+          name: oot-validation-${{ steps.artifact-names.outputs.safe_model_name }}-${{ github.run_id }}
           path: |
             vllm_oot.log
+            oot_accuracy_client.log
             oot_accuracy_output.txt
             oot_accuracy_results
+
+      - name: Fail if OOT accuracy client failed
+        if: ${{ always() && steps.validation-window.outputs.should_run == 'true' && steps.run_accuracy_client.outcome == 'failure' }}
+        run: exit 1
 
       - name: Upload accuracy results for dashboard
         if: ${{ always() && steps.validation-window.outputs.should_run == 'true' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard)) }}
         uses: actions/upload-artifact@v7
         with:
-          name: accuracy-${{ matrix.model_name }}
+          name: accuracy-${{ steps.artifact-names.outputs.safe_model_name }}
           path: oot_accuracy_results/*.json
           if-no-files-found: ignore
 


### PR DESCRIPTION
## Motivation

解决vllm nightly中遇到的timeout问题:
<img width="1272" height="200" alt="image" src="https://github.com/user-attachments/assets/356933e8-1492-4068-b6d9-dc88970cde57" />

问题出现原因：
不是简单的GitHub step timeout, 是foreground podman exec 等待容器内命令退出时触发了podman自己的exit-file watchdog。

解决思路：
当前 workflow/script 的结构上，新增一个“只启动 vLLM 并立即返回”的脚本入口，然后 workflow 在 host 侧用短 podman exec 轮询 readiness。

具体解决方法：

1. atom_oot_test.sh 新增 start 类型：只 nohup vllm serve ... &、写 /tmp/vllm_oot.pid，然后立刻退出；
2. workflow 用："bash .github/scripts/atom_oot_test.sh start full"
3. workflow 在 host 侧轮询；
4. ready 后再用短生命周期 podman exec 跑 client full