### PR TITLE
[atom-vllm plugin] cache metadata & tail-only fills in plugin decode build

### DIFF
--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -1932,14 +1932,21 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
         # be precomputed here. The kernel switches to the persistent
         # work-stealing path automatically when work_meta_data is non-None.
         #
-        # The work-split schedule is a deterministic function of the decode
-        # shape only: (num_tokens, padded_num_heads, per-request query lengths,
-        # per-request min(seq_len, topk_tokens)) -- topk_tokens, page_size and
-        # the qo layout are constant. Fingerprint those CPU-side and skip the
-        # get_mla_metadata_v1 launch when the schedule is unchanged. For
-        # steady-state long-context sparse decode (seq_len >= topk_tokens) the
-        # fingerprint is shape-determined, so the hit rate is ~100%; only the
-        # prefill / shape-change steps recompute.
+        # Pure-decode skip-cache: when every request has a single query token
+        # (max_query_len == 1, i.e. num_tokens == num_reqs) the work-split
+        # schedule is a deterministic function of the decode shape only --
+        # (num_tokens, padded_num_heads, per-request min(seq_len, topk_tokens));
+        # topk_tokens, page_size and the qo layout are constant. Fingerprint
+        # those CPU-side and skip the get_mla_metadata_v1 launch when unchanged.
+        # For steady-state long-context decode (seq_len >= topk_tokens) the
+        # fingerprint is shape-determined, so the hit rate is ~100%.
+        #
+        # For spec-decode / MTP batches (max_query_len > 1) the per-request
+        # clamped seq_len does NOT uniquely determine the per-token sparse
+        # schedule near the topk boundary (seq_len in [topk, topk + q_len)), so
+        # the cache is disabled there: we always recompute and invalidate the
+        # key, matching the pre-cache behaviour with no regression.
+        decode_only = int(common_attn_metadata.max_query_len) == 1
         num_reqs = common_attn_metadata.num_reqs
         seq_lens_cpu = getattr(common_attn_metadata, "seq_lens_cpu", None)
         if seq_lens_cpu is None:
@@ -1950,10 +1957,9 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
         metadata_key = (
             num_tokens,
             self.padded_num_heads,
-            seg_lengths.numpy().tobytes(),
             clamped_seq_lens.to(torch.int32).numpy().tobytes(),
         )
-        if metadata_key != self._prev_metadata_key:
+        if not (decode_only and metadata_key == self._prev_metadata_key):
             get_mla_metadata_v1(
                 qo_indptr,
                 paged_kv_indptr,
@@ -1975,7 +1981,9 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
                 dtype_q=_get_aiter_kv_cache_dtype(self.vllm_config),
                 dtype_kv=_get_aiter_kv_cache_dtype(self.vllm_config),
             )
-            self._prev_metadata_key = metadata_key
+            # Only remember the key when it fully determines the schedule;
+            # invalidate for MTP/spec batches so the next decode step recomputes.
+            self._prev_metadata_key = metadata_key if decode_only else None
 
         attn_metadata_for_plugin_mode = AiterMLASparseMetadataForPluginMode(
             num_reqs=common_attn_metadata.num_reqs,

--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -1875,11 +1875,29 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
         req_id_per_token = torch.repeat_interleave(
             torch.arange(seg_lengths.shape[0], dtype=torch.int32), seg_lengths
         )
-        # Zero-fill for cudagraphs
-        self.req_id_per_token_buffer.fill_(0)
-        self.paged_kv_indices.fill_(0)
-        self.paged_kv_indptr.fill_(0)
-        self.req_id_per_token_buffer[: req_id_per_token.shape[0]].copy_(
+        # Shrink-tail-only zeroing instead of three full-buffer fill_(0) every
+        # step (the buffers are persistent across decode steps and zeros-init):
+        #   - req_id_per_token_buffer / paged_kv_indices: the kernel only reads
+        #     the ranges defined by paged_kv_indptr / num_tokens, so entries
+        #     past the new extent are never read; we only need to re-zero the
+        #     tail left over from a previous, larger batch.
+        #   - paged_kv_indptr: index 0 stays 0 (never written by the cumsum
+        #     below, which starts at index 1) and indices >= 1 are fully
+        #     rewritten by the cumsum + scalar broadcast, so its fill_(0) is
+        #     redundant and dropped entirely.
+        new_req_extent = int(req_id_per_token.shape[0])
+        new_indices_extent = num_tokens * self.topk_tokens
+        if self._prev_req_extent > new_req_extent:
+            self.req_id_per_token_buffer[new_req_extent : self._prev_req_extent].fill_(
+                0
+            )
+        if self._prev_indices_extent > new_indices_extent:
+            self.paged_kv_indices[new_indices_extent : self._prev_indices_extent].fill_(
+                0
+            )
+        self._prev_req_extent = new_req_extent
+        self._prev_indices_extent = new_indices_extent
+        self.req_id_per_token_buffer[:new_req_extent].copy_(
             req_id_per_token, non_blocking=True
         )
         query_lens = (
@@ -1913,27 +1931,51 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
         # treated as its own batch entry), so persistent metadata can always
         # be precomputed here. The kernel switches to the persistent
         # work-stealing path automatically when work_meta_data is non-None.
-        get_mla_metadata_v1(
-            qo_indptr,
-            paged_kv_indptr,
-            paged_kv_last_page_len,
+        #
+        # The work-split schedule is a deterministic function of the decode
+        # shape only: (num_tokens, padded_num_heads, per-request query lengths,
+        # per-request min(seq_len, topk_tokens)) -- topk_tokens, page_size and
+        # the qo layout are constant. Fingerprint those CPU-side and skip the
+        # get_mla_metadata_v1 launch when the schedule is unchanged. For
+        # steady-state long-context sparse decode (seq_len >= topk_tokens) the
+        # fingerprint is shape-determined, so the hit rate is ~100%; only the
+        # prefill / shape-change steps recompute.
+        num_reqs = common_attn_metadata.num_reqs
+        seq_lens_cpu = getattr(common_attn_metadata, "seq_lens_cpu", None)
+        if seq_lens_cpu is None:
+            seq_lens_cpu = getattr(common_attn_metadata, "_seq_lens_cpu", None)
+        if seq_lens_cpu is None:
+            seq_lens_cpu = seq_lens.cpu()
+        clamped_seq_lens = torch.clamp(seq_lens_cpu[:num_reqs], max=self.topk_tokens)
+        metadata_key = (
+            num_tokens,
             self.padded_num_heads,
-            1,
-            True,
-            self._mla_work_meta_data,
-            self._mla_work_info_set,
-            self._mla_work_indptr,
-            self._mla_reduce_indptr,
-            self._mla_reduce_final_map,
-            self._mla_reduce_partial_map,
-            page_size=1,
-            kv_granularity=16,
-            max_seqlen_qo=1,
-            uni_seqlen_qo=1,
-            fast_mode=True,
-            dtype_q=_get_aiter_kv_cache_dtype(self.vllm_config),
-            dtype_kv=_get_aiter_kv_cache_dtype(self.vllm_config),
+            seg_lengths.numpy().tobytes(),
+            clamped_seq_lens.to(torch.int32).numpy().tobytes(),
         )
+        if metadata_key != self._prev_metadata_key:
+            get_mla_metadata_v1(
+                qo_indptr,
+                paged_kv_indptr,
+                paged_kv_last_page_len,
+                self.padded_num_heads,
+                1,
+                True,
+                self._mla_work_meta_data,
+                self._mla_work_info_set,
+                self._mla_work_indptr,
+                self._mla_reduce_indptr,
+                self._mla_reduce_final_map,
+                self._mla_reduce_partial_map,
+                page_size=1,
+                kv_granularity=16,
+                max_seqlen_qo=1,
+                uni_seqlen_qo=1,
+                fast_mode=True,
+                dtype_q=_get_aiter_kv_cache_dtype(self.vllm_config),
+                dtype_kv=_get_aiter_kv_cache_dtype(self.vllm_config),
+            )
+            self._prev_metadata_key = metadata_key
 
         attn_metadata_for_plugin_mode = AiterMLASparseMetadataForPluginMode(
             num_reqs=common_attn_metadata.num_reqs,
@@ -2410,7 +2452,10 @@ def create_mla_sparse_attn_metadata_builder_init_method(base_class):
             (1, 1), dtype=torch.int32, device=self.device
         )
 
-        self.req_id_per_token_buffer = torch.empty(
+        # zeros (not empty) so the shrink-tail fast path in build() can assume
+        # entries past the current extent are already 0 without a full-buffer
+        # fill_(0) every step.
+        self.req_id_per_token_buffer = torch.zeros(
             (max_num_batched_tokens,),
             dtype=torch.int32,
             device=device,
@@ -2511,6 +2556,14 @@ def create_mla_sparse_attn_metadata_builder_init_method(base_class):
             dtype=reduce_partial_map_type,
             device=device,
         )
+
+        # ----- Decode-orchestration caches (see build()) -----
+        # Track the previously-written extents of the persistent buffers so we
+        # only re-zero the shrink tail, and fingerprint the get_mla_metadata_v1
+        # inputs so we can skip recomputing an identical work-split schedule.
+        self._prev_req_extent = 0
+        self._prev_indices_extent = 0
+        self._prev_metadata_key = None
 
     return init_method_under_plugin_mode
 

--- a/atom/plugin/attention.py
+++ b/atom/plugin/attention.py
@@ -1932,34 +1932,43 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
         # be precomputed here. The kernel switches to the persistent
         # work-stealing path automatically when work_meta_data is non-None.
         #
-        # Pure-decode skip-cache: when every request has a single query token
-        # (max_query_len == 1, i.e. num_tokens == num_reqs) the work-split
-        # schedule is a deterministic function of the decode shape only --
-        # (num_tokens, padded_num_heads, per-request min(seq_len, topk_tokens));
-        # topk_tokens, page_size and the qo layout are constant. Fingerprint
-        # those CPU-side and skip the get_mla_metadata_v1 launch when unchanged.
-        # For steady-state long-context decode (seq_len >= topk_tokens) the
-        # fingerprint is shape-determined, so the hit rate is ~100%.
+        # Pure-decode skip-cache: only valid when every request contributes
+        # exactly one query token. max_query_len == 1 alone is NOT enough --
+        # it allows empty/padded request slots (q_len == 0), where
+        # num_actual_tokens < num_reqs and the per-token sparse stream no longer
+        # lines up with the per-request clamped seq_lens used as the key. We
+        # therefore also require num_tokens == num_reqs; together they imply
+        # exactly one token per request, so clamped_seq_lens[:num_reqs] IS the
+        # per-token sparse stream and the work-split schedule is a deterministic
+        # function of (num_tokens, padded_num_heads, per-request
+        # min(seq_len, topk_tokens)) -- topk_tokens, page_size and the qo layout
+        # are constant. Fingerprint those CPU-side and skip the launch when
+        # unchanged; for long-context decode (seq_len >= topk_tokens) the key is
+        # shape-determined, so the hit rate is ~100%.
         #
-        # For spec-decode / MTP batches (max_query_len > 1) the per-request
-        # clamped seq_len does NOT uniquely determine the per-token sparse
-        # schedule near the topk boundary (seq_len in [topk, topk + q_len)), so
-        # the cache is disabled there: we always recompute and invalidate the
-        # key, matching the pre-cache behaviour with no regression.
-        decode_only = int(common_attn_metadata.max_query_len) == 1
+        # MTP/spec or padded batches always recompute and invalidate the key.
+        # The fingerprint is only built on the cacheable path, so the slow path
+        # adds no extra CPU work.
         num_reqs = common_attn_metadata.num_reqs
-        seq_lens_cpu = getattr(common_attn_metadata, "seq_lens_cpu", None)
-        if seq_lens_cpu is None:
-            seq_lens_cpu = getattr(common_attn_metadata, "_seq_lens_cpu", None)
-        if seq_lens_cpu is None:
-            seq_lens_cpu = seq_lens.cpu()
-        clamped_seq_lens = torch.clamp(seq_lens_cpu[:num_reqs], max=self.topk_tokens)
-        metadata_key = (
-            num_tokens,
-            self.padded_num_heads,
-            clamped_seq_lens.to(torch.int32).numpy().tobytes(),
+        decode_only = (
+            int(common_attn_metadata.max_query_len) == 1 and num_tokens == num_reqs
         )
-        if not (decode_only and metadata_key == self._prev_metadata_key):
+        metadata_key = None
+        if decode_only:
+            seq_lens_cpu = getattr(common_attn_metadata, "seq_lens_cpu", None)
+            if seq_lens_cpu is None:
+                seq_lens_cpu = getattr(common_attn_metadata, "_seq_lens_cpu", None)
+            if seq_lens_cpu is None:
+                seq_lens_cpu = seq_lens.cpu()
+            clamped_seq_lens = torch.clamp(
+                seq_lens_cpu[:num_reqs], max=self.topk_tokens
+            )
+            metadata_key = (
+                num_tokens,
+                self.padded_num_heads,
+                clamped_seq_lens.to(torch.int32).numpy().tobytes(),
+            )
+        if metadata_key is None or metadata_key != self._prev_metadata_key:
             get_mla_metadata_v1(
                 qo_indptr,
                 paged_kv_indptr,
@@ -1981,9 +1990,10 @@ class vllmMLASparseAttentionMetadataBuilderMethods:
                 dtype_q=_get_aiter_kv_cache_dtype(self.vllm_config),
                 dtype_kv=_get_aiter_kv_cache_dtype(self.vllm_config),
             )
-            # Only remember the key when it fully determines the schedule;
-            # invalidate for MTP/spec batches so the next decode step recomputes.
-            self._prev_metadata_key = metadata_key if decode_only else None
+            # metadata_key is the exact fingerprint on the cacheable path and
+            # None for MTP/spec/padded batches -- storing it as-is records a
+            # hittable key on decode and invalidates the cache otherwise.
+            self._prev_metadata_key = metadata_key
 
         attn_metadata_for_plugin_mode = AiterMLASparseMetadataForPluginMode(
             num_reqs=common_attn_metadata.num_reqs,


### PR DESCRIPTION

Case | Accuracy | Threshold | Pass
-- | -- | -- | --
DeepSeek-V3.2-FP8 TP4 | 0.947688 | 0.93 | True
DeepSeek-V3.2-FP8 MTP TP4 | 0.944655 | 0.93 | True

2-4% perf gain for 5k/500, 10k/1000, con8 16

| ISL | OSL | Conc | TTFT target/baseline ms | TTFT ratio | TPOT target/baseline ms | TPOT ratio | Total tok/s target/baseline | Total tok/s ratio | failed target/baseline |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1000 | 100 | 4 | 269.63/260.54 | 0.9663 | 14.19/14.29 | 1.0066 | 2625.58/2625.38 | 1.0001 | 0/0 |
| 1000 | 100 | 8 | 425.86/438.95 | 1.0307 | 16.50/16.88 | 1.0229 | 4269.53/4167.80 | 1.0244 | 0/0 |
| 1000 | 100 | 16 | 782.70/835.18 | 1.0670 | 22.66/22.35 | 0.9861 | 5806.32/5771.31 | 1.0061 | 0/0 |
| 5000 | 500 | 4 | 1146.58/1152.35 | 1.0050 | 14.95/15.44 | 1.0325 | 2555.17/2483.52 | 1.0289 | 0/0 |
| 5000 | 500 | 8 | 1821.79/1846.18 | 1.0134 | 18.73/19.30 | 1.0304 | 3938.53/3832.68 | 1.0276 | 0/0 |
| 5000 | 500 | 16 | 2917.78/3039.43 | 1.0417 | 27.20/27.76 | 1.0207 | 5334.46/5206.90 | 1.0245 | 0/0 |
| 10000 | 1000 | 4 | 2093.86/2105.33 | 1.0055 | 15.40/16.18 | 1.0507 | 2517.34/2408.36 | 1.0452 | 0/0 |
| 10000 | 1000 | 8 | 3450.08/3477.70 | 1.0080 | 19.67/20.55 | 1.0448 | 3808.43/3664.45 | 1.0393 | 0/0 |
| 10000 | 1000 | 16 | 4662.69/4806.10 | 1.0308 | 29.49/30.12 | 1.0216 | 5156.50/5041.31 | 1.0228 | 0/0 |