### PR TITLE
[mesh][ci] add atom-mesh ci

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -5,6 +5,7 @@ TYPE=${1:-launch}
 MODEL_PATH=${2:-meta-llama/Meta-Llama-3-8B-Instruct}
 EXTRA_ARGS=("${@:3}")
 ATOM_DOCKER_IMAGE=${ATOM_DOCKER_IMAGE:-}
+ATOM_SERVER_PORT=${ATOM_SERVER_PORT:-8000}
 
 
 if [ "$TYPE" == "launch" ]; then
@@ -33,7 +34,12 @@ if [ "$TYPE" == "launch" ]; then
   fi
 
   ATOM_SERVER_LOG="/tmp/atom_server.log"
-  PYTHONUNBUFFERED=1 $RTL_CMD python -m atom.entrypoints.openai_server --model "$MODEL_PATH" $PROFILER_ARGS "${EXTRA_ARGS[@]}" > "$ATOM_SERVER_LOG" 2>&1 &
+  if [ "${USE_ATOMESH_ENTRYPOINTS:-0}" == "1" ]; then
+    SERVER_PORT_ARGS=("--port" "$ATOM_SERVER_PORT")
+  else
+    SERVER_PORT_ARGS=("--server-port" "$ATOM_SERVER_PORT")
+  fi
+  PYTHONUNBUFFERED=1 $RTL_CMD python -m atom.entrypoints.openai_server --model "$MODEL_PATH" "${SERVER_PORT_ARGS[@]}" $PROFILER_ARGS "${EXTRA_ARGS[@]}" > "$ATOM_SERVER_LOG" 2>&1 &
   atom_server_pid=$!
   tail -f "$ATOM_SERVER_LOG" &
   _tail_launch_pid=$!
@@ -52,7 +58,7 @@ if [ "$TYPE" == "launch" ]; then
           tail -50 "$ATOM_SERVER_LOG" 2>/dev/null || true
           exit 1
       fi
-      if curl -sf http://localhost:8000/health -o /dev/null; then
+      if curl -sf "http://localhost:${ATOM_SERVER_PORT}/health" -o /dev/null; then
           echo "ATOM server HTTP endpoint is up."
           server_up=true
           break
@@ -79,7 +85,7 @@ if [ "$TYPE" == "launch" ]; then
           tail -50 "$ATOM_SERVER_LOG" 2>/dev/null || true
           exit 1
       fi
-      if curl -sf http://localhost:8000/v1/completions \
+      if curl -sf "http://localhost:${ATOM_SERVER_PORT}/v1/completions" \
           -H "Content-Type: application/json" \
           -d '{"model":"'"$MODEL_PATH"'","prompt":"hi","max_tokens":1}' \
           -o /dev/null --max-time 120; then
@@ -172,7 +178,7 @@ PY
   else
     echo "Using default lm-eval command."
     lm_eval --model local-completions \
-            --model_args "model=${MODEL_PATH},base_url=http://localhost:8000/v1/completions,num_concurrent=65,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
+            --model_args "model=${MODEL_PATH},base_url=http://localhost:${ATOM_SERVER_PORT}/v1/completions,num_concurrent=65,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
             --tasks gsm8k \
             --num_fewshot 3 \
             --output_path "${OUTPUT_PATH}" \
@@ -343,7 +349,7 @@ if [ "$TYPE" == "benchmark" ]; then
     echo "Profiling enabled via --profile flag"
   fi
   python -m atom.benchmarks.benchmark_serving \
-    --model=$MODEL_PATH --backend=vllm --base-url="http://localhost:8000" \
+    --model=$MODEL_PATH --backend=vllm --base-url="http://localhost:${ATOM_SERVER_PORT}" \
     --dataset-name=random \
     --random-input-len=$ISL --random-output-len=$OSL --random-range-ratio=$RANDOM_RANGE_RATIO \
     --max-concurrency=$CONC \

--- a/.github/workflows/atom-mesh-accuracy-validation.yaml
+++ b/.github/workflows/atom-mesh-accuracy-validation.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, Jasen/atom_mesh]  # Triggers on PRs targeting these branches
+    branches: [main]  # Triggers on PRs targeting `main`
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '**/*.md'

--- a/.github/workflows/atom-mesh-accuracy-validation.yaml
+++ b/.github/workflows/atom-mesh-accuracy-validation.yaml
@@ -334,6 +334,19 @@ jobs:
           RUN echo "=== ATOM version BEFORE uninstall ===" && pip show atom || true
           RUN pip uninstall -y atom
           RUN rm -rf /app/ATOM
+          ARG RUST_VERSION="1.94.0"
+          RUN if ! command -v cargo >/dev/null 2>&1; then \\
+                echo "=== Installing Rust toolchain for atom-mesh build ===" && \\
+                apt-get update && \\
+                apt --fix-broken install -y && \\
+                apt-get install -y --no-install-recommends curl build-essential pkg-config libssl-dev protobuf-compiler libprotobuf-dev && \\
+                rm -rf /var/lib/apt/lists/* && \\
+                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \\
+                  | sh -s -- -y --default-toolchain "\${RUST_VERSION}" --profile minimal && \\
+                . "\$HOME/.cargo/env" && \\
+                rustc --version && cargo --version; \\
+              fi
+          ENV PATH="/root/.cargo/bin:\$PATH"
           RUN git clone ${{ env.GITHUB_REPO_URL }} /app/ATOM && \\
               cd /app/ATOM && \\
               git checkout ${{ env.GITHUB_COMMIT_SHA }} && \\
@@ -450,6 +463,20 @@ jobs:
             pip install --timeout 60 --retries 10 -U 'lm-eval[api]'
             pip install --timeout 60 --retries 10 hf_transfer
             pip install --timeout 60 --retries 10 --upgrade 'pybind11>=3.0.1'
+            if ! command -v cargo >/dev/null 2>&1; then
+              echo '=== Installing Rust toolchain for atom-mesh build ==='
+              RUST_VERSION='1.94.0'
+              apt-get update
+              apt --fix-broken install -y
+              apt-get install -y --no-install-recommends curl build-essential pkg-config libssl-dev protobuf-compiler libprotobuf-dev
+              rm -rf /var/lib/apt/lists/*
+              curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+                | sh -s -- -y --default-toolchain \"\$RUST_VERSION\" --profile minimal
+              . \"\$HOME/.cargo/env\"
+            fi
+            export PATH=\"\$HOME/.cargo/bin:\$PATH\"
+            rustc --version
+            cargo --version
 
             echo '=== Installing ATOM ==='
             cd /workspace

--- a/.github/workflows/atom-mesh-accuracy-validation.yaml
+++ b/.github/workflows/atom-mesh-accuracy-validation.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]  # Triggers on PRs targeting `main`
+    branches: [main, Jasen/atom_mesh]  # Triggers on PRs targeting these branches
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '**/*.md'

--- a/.github/workflows/atom-mesh-accuracy-validation.yaml
+++ b/.github/workflows/atom-mesh-accuracy-validation.yaml
@@ -1,0 +1,712 @@
+name: ATOM Mesh Accuracy Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]  # Triggers on PRs targeting `main`
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  schedule:
+    # Nightly at 00:00 Beijing time (16:00 UTC)
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+    inputs:
+      aiter_branch:
+        description: 'ROCm/aiter branch to build inside the CI image'
+        required: false
+        default: 'main'
+        type: string
+
+concurrency:
+  # Keep scheduled main runs from blocking push-triggered validation.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  ATOM_BASE_IMAGE: rocm/atom-dev:latest
+  GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/ATOM.git' }}
+  GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
+  # workflow_dispatch: inputs.aiter_branch; otherwise main (matches previous default-branch shallow clone)
+  AITER_GIT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.aiter_branch || 'main' }}
+
+jobs:
+  check-signal:
+    if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
+    name: Check Pre Checkin Signal
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout ATOM repo
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: actions/checkout@v6
+
+      - name: Wait for Pre Checkin workflow
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: bash ./.github/scripts/check_signal.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_SHA: ${{ github.sha }}
+
+  download_aiter_wheel:
+    if: ${{ needs.check-signal.result == 'success' && (!github.event.pull_request || github.event.pull_request.draft == false) }}
+    needs: [check-signal]
+    name: Download aiter wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prefer latest main aiter wheel manifest and fallback to artifact
+        run: |
+          set -euo pipefail
+          echo "=== Trying latest main aiter wheel manifest from S3 first ==="
+
+          S3_MAIN_MANIFEST_URL="https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950/main/latest.json"
+          API_URL="https://api.github.com"
+          AUTH_HEADER="Authorization: token ${{ secrets.GITHUB_TOKEN }}"
+          AITER_TEST_WORKFLOW_ID=179476100
+
+          ARTIFACT_ID=""
+          ARTIFACT_NAME=""
+          ARTIFACT_RUN_ID=""
+          ARTIFACT_RUN_SHA=""
+          ARTIFACT_RUN_CREATED_AT=""
+
+          resolve_download_url() {
+            python3 -c 'import sys
+            from urllib.parse import quote, unquote, urlsplit, urlunsplit
+            parts = urlsplit(sys.argv[1])
+            encoded_path = "/".join(quote(unquote(segment), safe="") for segment in parts.path.split("/"))
+            print(urlunsplit((parts.scheme, parts.netloc, encoded_path, parts.query, parts.fragment)))' "$1"
+          }
+
+          find_latest_artifact() {
+            local runs_json artifact_json run_id
+
+            if [ -n "$ARTIFACT_ID" ] && [ "$ARTIFACT_ID" != "null" ]; then
+              return 0
+            fi
+
+            echo "=== Finding latest aiter-whl-* artifact from ROCm/aiter ==="
+            runs_json=$(curl -fsSL -H "$AUTH_HEADER" \
+              "$API_URL/repos/ROCm/aiter/actions/workflows/$AITER_TEST_WORKFLOW_ID/runs?per_page=100&branch=main&event=push")
+
+            for run_id in $(echo "$runs_json" | jq -r '.workflow_runs[].id'); do
+              artifact_json=$(curl -fsSL -H "$AUTH_HEADER" \
+                "$API_URL/repos/ROCm/aiter/actions/runs/$run_id/artifacts" \
+                | jq '[.artifacts[] | select(.name | startswith("aiter-whl-")) | select(.expired == false)] | sort_by(.created_at) | last')
+
+              if [ "$artifact_json" != "null" ] && [ -n "$artifact_json" ]; then
+                ARTIFACT_ID=$(echo "$artifact_json" | jq -r '.id')
+                ARTIFACT_NAME=$(echo "$artifact_json" | jq -r '.name')
+                ARTIFACT_RUN_ID="$run_id"
+                ARTIFACT_RUN_SHA=$(echo "$runs_json" | jq -r --arg run_id "$run_id" '.workflow_runs[] | select((.id | tostring) == $run_id) | .head_sha')
+                ARTIFACT_RUN_CREATED_AT=$(echo "$runs_json" | jq -r --arg run_id "$run_id" '.workflow_runs[] | select((.id | tostring) == $run_id) | .created_at')
+                echo "Found artifact in run $ARTIFACT_RUN_ID: $ARTIFACT_NAME (ID: $ARTIFACT_ID, SHA: $ARTIFACT_RUN_SHA)"
+                return 0
+              fi
+            done
+
+            return 1
+          }
+
+          download_from_s3_manifest() {
+            local manifest_file manifest_fetch_url manifest_branch manifest_timestamp manifest_commit wheel_name wheel_url resolved_wheel_url
+
+            mkdir -p aiter-whl
+            rm -f aiter-whl/amd_aiter*.whl
+
+            manifest_file=$(mktemp)
+            trap 'rm -f "$manifest_file"' RETURN
+            manifest_fetch_url="${S3_MAIN_MANIFEST_URL}?ts=$(date +%s)"
+            curl -fsSL -H "Cache-Control: no-cache" "$manifest_fetch_url" -o "$manifest_file" || return 1
+
+            manifest_branch=$(jq -r '.branch // empty' "$manifest_file")
+            manifest_timestamp=$(jq -r '.timestamp // empty' "$manifest_file")
+            manifest_commit=$(jq -r '.commit // empty' "$manifest_file")
+            wheel_name=$(jq -r '.wheel_name // empty' "$manifest_file")
+            wheel_url=$(jq -r '.wheel_url // empty' "$manifest_file")
+
+            if [ "$manifest_branch" != "main" ] || [ -z "$manifest_timestamp" ] || [ -z "$manifest_commit" ] || [ -z "$wheel_name" ] || [ -z "$wheel_url" ]; then
+              echo "Invalid latest main wheel manifest"
+              return 1
+            fi
+
+            if find_latest_artifact; then
+              if [ -n "$ARTIFACT_RUN_SHA" ] && [ "$manifest_commit" != "$ARTIFACT_RUN_SHA" ]; then
+                if [ -n "$ARTIFACT_RUN_CREATED_AT" ] && [[ "$manifest_timestamp" < "$ARTIFACT_RUN_CREATED_AT" ]]; then
+                  echo "Manifest commit $manifest_commit is older than latest artifact run $ARTIFACT_RUN_ID ($ARTIFACT_RUN_SHA); treating manifest as stale"
+                  return 1
+                fi
+                echo "Manifest commit $manifest_commit differs from latest artifact run $ARTIFACT_RUN_ID ($ARTIFACT_RUN_SHA), but manifest timestamp is not older"
+              fi
+            else
+              echo "No GitHub fallback artifact found while checking manifest freshness"
+            fi
+
+            resolved_wheel_url=$(resolve_download_url "$wheel_url")
+
+            echo "Selected latest main wheel manifest: $S3_MAIN_MANIFEST_URL"
+            echo "Manifest timestamp: $manifest_timestamp"
+            echo "Manifest commit: $manifest_commit"
+            echo "Manifest wheel: $wheel_name"
+            echo "Downloading manifest-selected wheel: $resolved_wheel_url"
+            curl -fsSL "$resolved_wheel_url" -o "aiter-whl/$wheel_name" || return 1
+            echo "Downloaded wheel from manifest: aiter-whl/$wheel_name"
+
+            rm -f "$manifest_file"
+            trap - RETURN
+          }
+
+          download_from_artifact() {
+            echo "=== Falling back to latest aiter-whl-* artifact from ROCm/aiter ==="
+            find_latest_artifact || {
+              echo "ERROR: No aiter-whl-* artifact found in recent Aiter Test runs"
+              return 1
+            }
+
+            mkdir -p aiter-whl
+            rm -f aiter-whl/amd_aiter*.whl
+            curl -fsSL -H "$AUTH_HEADER" \
+              "$API_URL/repos/ROCm/aiter/actions/artifacts/$ARTIFACT_ID/zip" \
+              -o aiter-whl.zip
+            unzip -o aiter-whl.zip -d aiter-whl
+            rm -f aiter-whl.zip
+          }
+
+          if download_from_s3_manifest; then
+            echo "Using wheel from S3 main manifest"
+          else
+            echo "Main wheel manifest download failed, falling back to GitHub artifact"
+            download_from_artifact
+          fi
+
+          AITER_WHL=$(ls -t aiter-whl/amd_aiter*.whl 2>/dev/null | head -1)
+          if [ -z "$AITER_WHL" ]; then
+            echo "ERROR: No amd_aiter wheel available after S3/artifact attempts"
+            ls -la aiter-whl/ || true
+            exit 1
+          fi
+
+          echo "Selected wheel: $AITER_WHL"
+
+      - name: Upload aiter wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: aiter-whl
+          path: aiter-whl/amd_aiter*.whl
+          retention-days: 7
+
+  load-test-models:
+    name: Load test model configs
+    runs-on: ubuntu-latest
+    outputs:
+      models_json: ${{ steps.load.outputs.models_json }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: load
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          python3 << 'PY'
+          import json, os
+          event = os.environ["EVENT_NAME"]
+          # pr → pr models only; push to main → pr+main; schedule/dispatch → all
+          level_map = {"schedule": "nightly", "workflow_dispatch": "nightly", "push": "main"}
+          current = level_map.get(event, "pr")
+          allowed = {"pr": {"pr"}, "main": {"pr", "main"}, "nightly": {"pr", "main", "nightly"}}[current]
+          models = json.load(open(".github/benchmark/models_accuracy.json", encoding="utf-8"))
+          filtered = [m for m in models if m.get("test_level", "nightly") in allowed]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"models_json={json.dumps(filtered)}\n")
+          print(f"Event={event} level={current}: {len(filtered)}/{len(models)} models")
+          print(f"{'Model':<45} {'Level':<10} {'Runner'}")
+          print("-" * 80)
+          for m in models:
+              enabled = "✓" if m in filtered else "·"
+              print(f"  {enabled} {m['model_name']:<43} {m.get('test_level','?'):<10} {m['runner']}")
+          PY
+
+  atom-mesh-test:
+    needs: [download_aiter_wheel, load-test-models]
+    name: Accuracy
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-test-models.outputs.models_json) }}
+    if: ${{ !github.event.pull_request || github.event.pull_request.draft == false }}
+    runs-on: ${{ matrix.runner }}
+
+    env:
+      CONTAINER_NAME: atom_mesh_test_${{ strategy.job-index }}
+
+    steps:
+      - name: Kill all Docker containers and clean up workspace
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: |
+          echo "=== Cleaning up containers on $(hostname) ==="
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "ls -la /workspace/ && find /workspace -mindepth 1 -delete" || true 
+
+      - name: Show Docker containers
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: docker ps -a
+
+      - name: Show ROCm memory usage
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: rocm-smi --showmemuse
+
+      - name: Show ROCm GPU processes
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: rocm-smi --showpidgpus
+
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+      
+      - name: Docker Login
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Resolve immutable native dashboard image
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if RESOLUTION_JSON="$(
+            python3 .github/scripts/resolve_atom_image.py \
+              --repository rocm/atom-dev \
+              --reference-tag latest \
+              --image-family native
+          )"; then
+            RESOLVED_ATOM_IMAGE="$(
+              RESOLUTION_JSON="${RESOLUTION_JSON}" python3 - <<'PY'
+          import json
+          import os
+
+          resolution = json.loads(os.environ["RESOLUTION_JSON"])
+          print(resolution["resolved_image"])
+          PY
+            )"
+            echo "Resolved native dashboard image: ${RESOLVED_ATOM_IMAGE}"
+          else
+            echo "::error::Failed to resolve ${ATOM_BASE_IMAGE} to an immutable reference for dashboard-uploading native runs."
+            exit 1
+          fi
+          echo "RESOLVED_ATOM_BASE_IMAGE=${RESOLVED_ATOM_IMAGE}" >> "$GITHUB_ENV"
+          echo "ATOM_DASHBOARD_DOCKER_IMAGE=${RESOLVED_ATOM_IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Pull immutable native dashboard image
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') }}
+        run: |
+          echo "Pulling immutable native dashboard image: ${RESOLVED_ATOM_BASE_IMAGE}"
+          docker pull "${RESOLVED_ATOM_BASE_IMAGE}"
+
+      - name: Generate Dockerfile for forked repo
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          cat <<EOF > Dockerfile.mod
+          FROM ${{ env.ATOM_BASE_NIGHTLY_IMAGE }}
+          RUN pip install -U lm-eval[api]
+          RUN pip show lm-eval || true
+          RUN pip install hf_transfer
+          RUN pip show hf_transfer || true
+          RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
+          RUN pip uninstall -y amd-aiter
+          RUN pip install --upgrade "pybind11>=3.0.1"
+          RUN pip show pybind11
+          RUN rm -rf /app/aiter-test
+          RUN git clone --depth 1 -b ${{ env.AITER_GIT_REF }} https://github.com/ROCm/aiter.git /app/aiter-test && \\
+              cd /app/aiter-test && \\
+              git submodule sync && git submodule update --init --recursive && \\
+              MAX_JOBS=64 PREBUILD_KERNELS=0 GPU_ARCHS=gfx950 python3 setup.py develop
+          RUN echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true
+          
+          RUN echo "=== ATOM version BEFORE uninstall ===" && pip show atom || true
+          RUN pip uninstall -y atom
+          RUN rm -rf /app/ATOM
+          RUN git clone ${{ env.GITHUB_REPO_URL }} /app/ATOM && \\
+              cd /app/ATOM && \\
+              git checkout ${{ env.GITHUB_COMMIT_SHA }} && \\
+              ATOM_MESH_BUILD=1 python -m pip install -e .
+
+          RUN echo "=== ATOM version AFTER installation ===" && pip show atom || true
+          EOF
+
+      - name: Download aiter wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: aiter-whl
+          path: /tmp/aiter-whl
+
+      - name: Set HF token for predownload runner
+        if: matrix.runner == 'atom-mi355-8gpu.predownload'
+        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> "$GITHUB_ENV"
+
+      - name: Start CI container
+        run: |
+          echo "Clean up containers..."
+          (docker ps -aq -f name="^${CONTAINER_NAME}$" | xargs -r docker stop) || true
+          (docker ps -aq -f name="^${CONTAINER_NAME}$" | xargs -r docker rm) || true
+
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+
+          if [ -d "/models" ]; then
+            MODEL_MOUNT="-v /models:/models"
+          else
+            echo "Warning: /models directory not found on runner; skipping /models mount and disabling model pre-download optimization."
+            MODEL_MOUNT=""
+          fi
+
+          # Write env_vars via env block (avoids expression injection)
+          printenv MODEL_ENV_VARS | grep -v '^$' > /tmp/env_file.txt || true
+
+          IMAGE_TAG="${RESOLVED_ATOM_BASE_IMAGE:-$ATOM_BASE_IMAGE}"
+          echo "Starting container with image: $IMAGE_TAG"
+          echo "Model-specific environment variables:"
+          cat /tmp/env_file.txt
+
+          PULL_FLAG=""
+          if [ -n "${RESOLVED_ATOM_BASE_IMAGE:-}" ]; then
+            PULL_FLAG=""
+          elif [ "${{ matrix.runner }}" = "atom-mi355-8gpu.predownload" ]; then
+            PULL_FLAG="--pull always"
+          fi
+
+          docker run -dt $PULL_FLAG --device=/dev/kfd $DEVICE_FLAG \
+          -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
+          $MODEL_MOUNT \
+          -w /workspace \
+          --ipc=host --group-add video \
+          --shm-size=16G \
+          --privileged \
+          --cap-add=SYS_PTRACE \
+          -e HF_TOKEN="${HF_TOKEN:-}" \
+          -e ATOM_DOCKER_IMAGE="${ATOM_DASHBOARD_DOCKER_IMAGE:-}" \
+          --env-file /tmp/env_file.txt \
+          --security-opt seccomp=unconfined \
+          --ulimit memlock=-1 \
+          --ulimit stack=67108864 \
+          -e ATOM_DISABLE_MMAP=true \
+          -v "${{ github.workspace }}:/workspace" \
+          -w /workspace \
+          --name "$CONTAINER_NAME" \
+          $IMAGE_TAG
+
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          MODEL_ENV_VARS: ${{ matrix.env_vars }}
+
+      - name: Check shm size
+        run: |
+          docker exec "$CONTAINER_NAME" df -h /dev/shm
+
+      - name: Collect GPU info (inside container)
+        id: gpu-info
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" docker "${{ matrix.runner }}"
+
+      - name: Install aiter from wheel
+        run: |
+          AITER_WHL=$(ls -t /tmp/aiter-whl/amd_aiter*.whl 2>/dev/null | head -1)
+          if [ -z "$AITER_WHL" ]; then
+            echo "ERROR: No amd_aiter wheel found"
+            ls -la /tmp/aiter-whl/
+            exit 1
+          fi
+
+          echo "=== Copying wheel into container ==="
+          WHL_NAME=$(basename "$AITER_WHL")
+          docker cp "$AITER_WHL" "$CONTAINER_NAME:/tmp/$WHL_NAME"
+
+          docker exec "$CONTAINER_NAME" bash -lc "
+            set -euo pipefail
+            echo '=== Uninstalling existing amd-aiter ==='
+            pip uninstall -y amd-aiter || true
+
+            echo '=== Installing amd-aiter from wheel ==='
+            pip install /tmp/$WHL_NAME
+
+            echo '=== Installed amd-aiter version ==='
+            pip show amd-aiter
+          "
+
+      - name: Install ATOM and dependencies
+        run: |
+          docker exec "$CONTAINER_NAME" bash -lc "
+            set -euo pipefail
+            pip install --timeout 60 --retries 10 -U 'lm-eval[api]'
+            pip install --timeout 60 --retries 10 hf_transfer
+            pip install --timeout 60 --retries 10 --upgrade 'pybind11>=3.0.1'
+
+            echo '=== Installing ATOM ==='
+            cd /workspace
+            git config --global --add safe.directory /workspace
+            ATOM_MESH_BUILD=1 python -m pip install -e .
+
+            echo '=== Installed package versions ==='
+            pip show amd-aiter | grep -E '^(Name|Version):'
+            pip show atom | grep -E '^(Name|Version):'
+            pip show triton | grep -E '^(Name|Version):'
+            pip show torch | grep -E '^(Name|Version):'
+          "
+
+      - name: Download models
+        timeout-minutes: 150
+        run: |
+          set -euo pipefail
+          if [ -d "/models" ]; then
+            model_dir="/models/${{ matrix.model_path }}"
+            echo "/models directory found, checking cache and lock-protected download for ${model_dir}"
+            if ! docker exec \
+              -e HF_TOKEN="${HF_TOKEN:-}" \
+              -e MODEL_ID="${{ matrix.model_path }}" \
+              -e TARGET_DIR="${model_dir}" \
+              -e MODEL_DOWNLOAD_TIMEOUT="${MODEL_DOWNLOAD_TIMEOUT}" \
+              -e MODEL_LOCK_WAIT_SECONDS="${MODEL_LOCK_WAIT_SECONDS}" \
+              -e MODEL_LOCK_POLL_INTERVAL="${MODEL_LOCK_POLL_INTERVAL}" \
+              -e MODEL_PROGRESS_INTERVAL="${MODEL_PROGRESS_INTERVAL}" \
+              "$CONTAINER_NAME" bash -lc 'bash /workspace/.github/scripts/download_model_with_lock.sh "$MODEL_ID" "$TARGET_DIR"'; then
+              echo "Model download failed for '${{ matrix.model_path }}'. Aborting."
+              exit 1
+            fi
+          else
+            echo "/models directory not found, skipping model download"
+          fi
+        env:
+          MODEL_DOWNLOAD_TIMEOUT: "30m"
+          MODEL_LOCK_WAIT_SECONDS: "1800"
+          MODEL_LOCK_POLL_INTERVAL: "30"
+          MODEL_PROGRESS_INTERVAL: "60"
+
+      - name: Run ATOM simple inference
+        # Skip simple inference; accuracy test already validates correctness
+        if: false
+        timeout-minutes: 30
+        run: |
+          # Run the inference and capture output
+          set -euo pipefail
+          
+          echo ""
+          echo "========== Running test =========="
+
+          if [ -d "/models" ]; then
+            model_path="/models/${{ matrix.model_path }}"
+          else
+            model_path="${{ matrix.model_path }}"
+          fi
+          echo "Model path: $model_path"
+          ls -la $model_path || true
+          # Print debug logs
+          echo "========= Runner debug logs ==============="
+          ps aux
+          rocm-smi --showmemuse
+          rocm-smi --showpids
+          docker ps -a
+          echo "========= End runner debug logs ==============="
+          docker exec "$CONTAINER_NAME" bash -lc "
+            set -euo pipefail
+            python3 -m atom.examples.simple_inference \
+              --model \"$model_path\" \
+              ${{ matrix.extraArgs }} \
+              --temperature 0 \
+            | grep -E '^Prompt: |^Completion:'
+          " > atom_test_output.txt
+          
+          echo ""
+          echo "========== Showing test output below =========="
+          cat atom_test_output.txt
+
+      - name: Compare output with golden outputs
+        if: false
+        timeout-minutes: 30
+        # TODO: skip for all test until it's fixed
+        run: |
+          echo "========== Comparing output with golden outputs =========="
+          if ! diff -u -B -w --strip-trailing-cr \
+            atom_test_output.txt \
+            ".github/workflows/golden_outputs/${{ matrix.model_name }}_golden_output.txt"; then
+            echo "Failed: Output does not match golden outputs."
+            exit 1
+          else
+            echo "Success: Output matches golden outputs."
+          fi
+      
+      - name: Run ATOM accuracy test
+        timeout-minutes: 30
+        env:
+          MODEL_EXTRA_ARGS: ${{ matrix.extraArgs }}
+          CLIENT_COMMAND: ${{ matrix.client_command || '' }}
+        run: |
+          set -euo pipefail
+          echo ""
+          echo "========== Launching ATOM server =========="
+          if [ -d "/models" ]; then
+            model_path="/models/${{ matrix.model_path }}"
+          else
+            model_path="${{ matrix.model_path }}"
+          fi
+          # Pipe via stdin so container bash parses shell quoting in extraArgs
+          # (e.g. single-quoted JSON in --default-chat-template-kwargs) naturally.
+          echo "USE_ATOMESH_ENTRYPOINTS=1 .github/scripts/atom_test.sh launch $model_path $MODEL_EXTRA_ARGS" | \
+            docker exec -i "$CONTAINER_NAME" bash -l
+          echo ""
+          echo "========== Running accuracy test =========="
+          docker exec \
+            -e CLIENT_COMMAND="${CLIENT_COMMAND}" \
+            -e GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
+            -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
+            -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
+            "$CONTAINER_NAME" bash -lc "
+            .github/scripts/atom_test.sh accuracy $model_path
+          " 2>&1 | tee atom_accuracy_output.txt
+      
+      - name: Dump server log
+        if: always()
+        run: |
+          docker exec "$CONTAINER_NAME" cat /tmp/atom_server.log 2>/dev/null || true
+
+      - name: Dump client log
+        if: always()
+        run: |
+          docker exec "$CONTAINER_NAME" cat /tmp/atom_client.log 2>/dev/null || true
+
+      - name: Check accuracy test results
+        if: success()
+        env:
+          MODEL_NAME: ${{ matrix.model_name }}
+        run: |
+          result_file=$(ls -1t accuracy_test_results/*.json 2>/dev/null | head -n 1)
+          if [ -z "$result_file" ] || [ ! -f "$result_file" ]; then
+              echo "ERROR: No results JSON file found in accuracy_test_results/"
+              exit 2
+          else
+              echo "RESULT_FILE: $result_file"
+          fi
+          flexible_extract_value=$(jq '.results.gsm8k["exact_match,flexible-extract"]' "$result_file")
+          echo "Flexible extract value: $flexible_extract_value"
+
+          # Read threshold from models_accuracy.json (via env var to avoid shell injection)
+          threshold=$(python3 -c "
+          import json, os
+          models = json.load(open('.github/benchmark/models_accuracy.json', encoding='utf-8'))
+          name = os.environ['MODEL_NAME']
+          t = next((m.get('accuracy_threshold', 0) for m in models if m['model_name'] == name), 0)
+          print(t)
+          ")
+          echo "Accuracy test threshold: $threshold"
+
+          result=$(awk -v val="$flexible_extract_value" -v threshold="$threshold" 'BEGIN {print (val < threshold) ? 1 : 0}')
+          if [ "$result" -eq 1 ]; then
+            echo "Accuracy test failed: $flexible_extract_value < $threshold"
+            exit 1
+          else
+            echo "Accuracy test passed: $flexible_extract_value >= $threshold"
+          fi
+
+      - name: Collect Test Summary
+        if: success()
+        env:
+          MODEL_NAME: ${{ matrix.model_name }}
+        run: |
+          # Read threshold and score for summary
+          threshold=$(python3 -c "
+          import json, os
+          models = json.load(open('.github/benchmark/models_accuracy.json', encoding='utf-8'))
+          name = os.environ['MODEL_NAME']
+          print(next((m.get('accuracy_threshold', 0) for m in models if m['model_name'] == name), 0))
+          ")
+          result_file=$(ls -1t accuracy_test_results/*.json 2>/dev/null | head -n 1)
+          score=$(jq '.results.gsm8k["exact_match,flexible-extract"]' "$result_file" 2>/dev/null || echo "N/A")
+
+          echo "Accuracy Test Summary for ${{ matrix.model_name }} (threshold: ${threshold}, score: ${score}):" >> $GITHUB_STEP_SUMMARY
+          awk '/\|Tasks\|Version\|/,/^$/ { if (NF > 0) print }' atom_accuracy_output.txt >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload output
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.model_name }}_atom_test_output.txt
+          path: atom_test_output.txt
+
+      - name: Upload accuracy results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: accuracy-${{ matrix.model_name }}
+          path: accuracy_test_results/*.json
+          if-no-files-found: ignore
+
+      - name: Clean Up
+        if: always()
+        run: |
+          # TODO: run a separate container for cleanup of the workspace due to permission issue to remove some pyc files under __pycache__ whose owners are root.
+          # We should use non-root user to run the test to avoid this issue.
+          set -x
+          echo "========== Cleaning up workspace =========="
+          if [[ ${{ matrix.runner }} == atom-mi355-8gpu.predownload ]]; then
+            docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "ls -la /workspace/ && find /workspace -mindepth 1 -delete" || true
+          fi
+          docker stop "$CONTAINER_NAME" || true
+          docker rm "$CONTAINER_NAME" || true
+          # Remove the pre-built image to free disk space on the runner
+          docker rmi "rocm/atom-dev:pre-build-${{ env.GITHUB_COMMIT_SHA }}" || true
+
+  # ---------- Push accuracy data to benchmark dashboard ----------
+  accuracy-dashboard:
+    name: Update accuracy dashboard
+    needs: [atom-mesh-test]
+    if: always() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Download accuracy artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/accuracy-results
+          pattern: accuracy-*
+
+      - name: List downloaded artifacts
+        run: |
+          echo "=== Downloaded accuracy artifacts ==="
+          find /tmp/accuracy-results -type f -name '*.json' | head -20 || echo "No JSON files found"
+
+      - name: Transform accuracy results for dashboard
+        run: |
+          python3 .github/scripts/accuracy_to_dashboard.py \
+            /tmp/accuracy-results \
+            --output accuracy-benchmark-input.json \
+            --models .github/benchmark/models_accuracy.json \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "=== Generated entries ==="
+          cat accuracy-benchmark-input.json
+
+      - name: Store accuracy result to dashboard
+        if: hashFiles('accuracy-benchmark-input.json') != ''
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: customBiggerIsBetter
+          output-file-path: accuracy-benchmark-input.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: benchmark-dashboard
+          auto-push: true
+          max-items-in-chart: 90
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/atom-mesh-accuracy-validation.yaml
+++ b/.github/workflows/atom-mesh-accuracy-validation.yaml
@@ -243,6 +243,8 @@ jobs:
 
     env:
       CONTAINER_NAME: atom_mesh_test_${{ strategy.job-index }}
+      USE_ATOMESH_ENTRYPOINTS: 1
+      ATOM_SERVER_PORT: 8000
 
     steps:
       - name: Kill all Docker containers and clean up workspace
@@ -409,6 +411,8 @@ jobs:
           --cap-add=SYS_PTRACE \
           -e HF_TOKEN="${HF_TOKEN:-}" \
           -e ATOM_DOCKER_IMAGE="${ATOM_DASHBOARD_DOCKER_IMAGE:-}" \
+          -e USE_ATOMESH_ENTRYPOINTS="${USE_ATOMESH_ENTRYPOINTS}" \
+          -e ATOM_SERVER_PORT="${ATOM_SERVER_PORT}" \
           --env-file /tmp/env_file.txt \
           --security-opt seccomp=unconfined \
           --ulimit memlock=-1 \
@@ -587,7 +591,7 @@ jobs:
           fi
           # Pipe via stdin so container bash parses shell quoting in extraArgs
           # (e.g. single-quoted JSON in --default-chat-template-kwargs) naturally.
-          echo "USE_ATOMESH_ENTRYPOINTS=1 .github/scripts/atom_test.sh launch $model_path $MODEL_EXTRA_ARGS" | \
+          echo ".github/scripts/atom_test.sh launch $model_path $MODEL_EXTRA_ARGS" | \
             docker exec -i "$CONTAINER_NAME" bash -l
           echo ""
           echo "========== Running accuracy test =========="

--- a/.github/workflows/atom-mesh-benchmark.yaml
+++ b/.github/workflows/atom-mesh-benchmark.yaml
@@ -178,6 +178,8 @@ jobs:
       CONC: ${{ matrix.config.concurrency }}
       RANDOM_RANGE_RATIO: ${{ matrix.config.random_range_ratio }}
       RESULT_FILENAME: ${{ matrix.model.prefix }}${{ matrix.model.suffix }}-${{ matrix.config.input_length }}-${{ matrix.config.output_length }}-${{ matrix.config.concurrency }}-${{ matrix.config.random_range_ratio }}
+      USE_ATOMESH_ENTRYPOINTS: 1
+      ATOM_SERVER_PORT: 8000
 
     steps:
       - name: Kill all Docker containers
@@ -220,6 +222,8 @@ jobs:
             -e ATOM_DISABLE_MMAP=true \
             -e ISL=${{ env.ISL }} -e OSL=${{ env.OSL }} \
             -e CONC=${{ env.CONC }} -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }} \
+            -e USE_ATOMESH_ENTRYPOINTS="${USE_ATOMESH_ENTRYPOINTS}" \
+            -e ATOM_SERVER_PORT="${ATOM_SERVER_PORT}" \
             -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
             -e ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
             --env-file /tmp/atom_benchmark_env.txt \
@@ -266,7 +270,7 @@ jobs:
           docker exec atom-mesh-benchmark bash -lc "set -euo pipefail
             ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
               ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
-              USE_ATOMESH_ENTRYPOINTS=1 .github/scripts/atom_test.sh launch $model_path ${{ env.ARGS }} ${{ inputs.extra_args || '' }}
+              .github/scripts/atom_test.sh launch $model_path ${{ env.ARGS }} ${{ inputs.extra_args || '' }}
             echo '========== Running benchmark =========='
             ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
               RESULT_FILENAME=${{ env.RESULT_FILENAME }} \
@@ -557,6 +561,9 @@ jobs:
         cell: ${{ fromJson(needs.generate-regression-matrix.outputs.matrix_json) }}
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.cell.runner }}
     timeout-minutes: 60
+    env:
+      USE_ATOMESH_ENTRYPOINTS: 1
+      ATOM_SERVER_PORT: 8000
     steps:
       - name: Kill all Docker containers
         run: |
@@ -593,6 +600,8 @@ jobs:
             --security-opt seccomp=unconfined \
             --ulimit memlock=-1 --ulimit stack=67108864 --pull always \
             -e ATOM_DISABLE_MMAP=true \
+            -e USE_ATOMESH_ENTRYPOINTS="${USE_ATOMESH_ENTRYPOINTS}" \
+            -e ATOM_SERVER_PORT="${ATOM_SERVER_PORT}" \
             --env-file /tmp/atom_regression_env.txt \
             --name atom-mesh-regression \
             ${{ inputs.image || 'rocm/atom-dev:latest' }}
@@ -621,7 +630,7 @@ jobs:
           # a literal newline).
           docker exec atom-mesh-regression bash -lc "set -euo pipefail
             ENABLE_TORCH_PROFILER=1 \
-            USE_ATOMESH_ENTRYPOINTS=1 .github/scripts/atom_test.sh launch $MODEL_DIR ${{ matrix.cell.server_args }}"
+            .github/scripts/atom_test.sh launch $MODEL_DIR ${{ matrix.cell.server_args }}"
 
       - name: Run regression configs with profiler
         run: |

--- a/.github/workflows/atom-mesh-benchmark.yaml
+++ b/.github/workflows/atom-mesh-benchmark.yaml
@@ -1,0 +1,907 @@
+name: ATOM Mesh Benchmark
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+on:
+  schedule:
+    # Nightly at 01:00 Beijing time (17:00 UTC)
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+    inputs:
+      deepseek-r1-0528:
+        description: "Benchmark DeepSeek-R1-0528 (+ MTP3)"
+        type: boolean
+        default: true
+      deepseek-v4-pro:
+        description: "Benchmark DeepSeek-V4-Pro"
+        type: boolean
+        default: true
+      glm-5-fp8:
+        description: "Benchmark GLM-5-FP8"
+        type: boolean
+        default: true
+      glm-5.1-fp4:
+        description: "Benchmark GLM-5.1-MXFP4"
+        type: boolean
+        default: true
+      deepseek-r1-0528-mxfp4:
+        description: "Benchmark DeepSeek-R1-0528 MXFP4 (+ MXFP4-MTP3)"
+        type: boolean
+        default: true
+      gpt-oss-120b:
+        description: "Benchmark gpt-oss-120b"
+        type: boolean
+        default: true
+      kimi-k25-mxfp4:
+        description: "Benchmark Kimi-K2.5-MXFP4"
+        type: boolean
+        default: true
+      MiniMax-M2.7:
+        description: "Benchmark MiniMax-M2.7 (+ MXFP4)"
+        type: boolean
+        default: true
+      qwen35-397b-fp8:
+        description: "Benchmark Qwen3.5-397B-A17B-FP8"
+        type: boolean
+        default: true
+      qwen35-397b-mxfp4:
+        description: "Benchmark Qwen3.5-397B-A17B-MXFP4"
+        type: boolean
+        default: true
+      llama-3-3-70b-instruct-mxfp4:
+        description: "Benchmark Llama-3.3-70B-Instruct-MXFP4"
+        type: boolean
+        default: true
+      extra_args:
+        description: "Extra arguments to pass to the ATOM server"
+        type: string
+      image:
+        description: "Image to use for the benchmark"
+        type: string
+        default: "rocm/atom-dev:latest"
+      runner:
+        description: "Optional runner label override for manual runs; leave empty to use model defaults"
+        type: string
+        default: ""
+      enable_profiler:
+        description: "Enable torch profiler to collect trace for performance debugging"
+        type: boolean
+        default: false
+      enable_rtl:
+        description: "Enable RTL (rocm-trace-lite) GPU kernel tracing for prefill/decode analysis"
+        type: boolean
+        default: false
+      param_lists:
+        description: |
+          "Benchmark parameter lists. 
+          Input as a single or multiple sets (comma-separated, semicolon between sets), 
+          format: input_length,output_length,concurrency,random_range_ratio.
+          Example (single set): 1024,1024,128,0.8
+          Example (multiple sets): 1024,1024,128,0.8;2048,1024,256,0.7"
+        type: string
+        default: "1024,1024,128,0.8"
+      atom_commit:
+        description: "ATOM commit SHA to checkout; leave empty to use the workflow ref"
+        type: string
+        default: ""
+
+jobs:
+  parse-param-lists:
+    name: Parse parameter lists
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_json: ${{ steps.parse-param-lists.outputs.matrix_json }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || github.ref }}
+
+      - name: Parse parameter lists
+        id: parse-param-lists
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Using nightly param lists from .github/benchmark/nightly_params.json"
+            # Expand grouped format (isl/osl + concurrency array) into flat matrix
+            MATRIX_JSON=$(jq -c '[.[] | . as $group | .concurrency[] | {input_length: $group.isl, output_length: $group.osl, concurrency: ., random_range_ratio: $group.random_range_ratio}]' .github/benchmark/nightly_params.json)
+          else
+            PARAM_LISTS="${{ inputs.param_lists || '1024,1024,128,0.8' }}"
+            echo "Using param_lists: ${PARAM_LISTS}"
+            IFS=';' read -ra SETS <<< "${PARAM_LISTS}"
+            MATRIX_JSON="["
+            SEP=""
+            for SET in "${SETS[@]}"; do
+              IFS=',' read -ra PARAMS <<< "$SET"
+              MATRIX_JSON="${MATRIX_JSON}${SEP}{\"input_length\":${PARAMS[0]},\"output_length\":${PARAMS[1]},\"concurrency\":${PARAMS[2]},\"random_range_ratio\":${PARAMS[3]}}"
+              SEP=","
+            done
+            MATRIX_JSON="${MATRIX_JSON}]"
+          fi
+          echo "Matrix JSON: ${MATRIX_JSON}"
+          echo "matrix_json=${MATRIX_JSON}" >> $GITHUB_OUTPUT
+
+  load-models:
+    name: Load model configs
+    runs-on: ubuntu-latest
+    outputs:
+      models_json: ${{ steps.load.outputs.models_json }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || github.ref }}
+      - id: load
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUTS_JSON: ${{ toJson(inputs) }}
+        run: |
+          python3 << 'PY'
+          import json, os
+          event = os.environ["EVENT_NAME"]
+          inputs = json.loads(os.environ.get("INPUTS_JSON", "{}"))
+          models = json.load(open(".github/benchmark/models.json", encoding="utf-8"))
+          if event == "schedule":
+              filtered = models
+          else:
+              filtered = [m for m in models if inputs.get(m["prefix"], True)]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"models_json={json.dumps(filtered)}\n")
+          print(f"Event={event}: {len(filtered)}/{len(models)} models enabled")
+          PY
+
+  benchmark:
+    name: ${{ matrix.model.display }} (isl=${{ matrix.config.input_length }} osl=${{ matrix.config.output_length }} c=${{ matrix.config.concurrency }})
+    needs: [parse-param-lists, load-models]
+    if: >-
+      !cancelled()
+      && needs.parse-param-lists.result == 'success'
+      && needs.load-models.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        model: ${{ fromJson(needs.load-models.outputs.models_json) }}
+        config: ${{ fromJson(needs.parse-param-lists.outputs.matrix_json) }}
+        exclude:
+          # Skip low-concurrency MTP runs to limit CI time
+          - model: { suffix: "-mtp3" }
+            config: { concurrency: 1 }
+          - model: { suffix: "-mtp3" }
+            config: { concurrency: 2 }
+
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.model.runner }}
+
+    env:
+      MODEL_PATH: ${{ matrix.model.path }}
+      ARGS: ${{ matrix.model.args }}
+      ISL: ${{ matrix.config.input_length }}
+      OSL: ${{ matrix.config.output_length }}
+      CONC: ${{ matrix.config.concurrency }}
+      RANDOM_RANGE_RATIO: ${{ matrix.config.random_range_ratio }}
+      RESULT_FILENAME: ${{ matrix.model.prefix }}${{ matrix.model.suffix }}-${{ matrix.config.input_length }}-${{ matrix.config.output_length }}-${{ matrix.config.concurrency }}-${{ matrix.config.random_range_ratio }}
+
+    steps:
+      - name: Kill all Docker containers
+        run: |
+          echo "=== Cleaning up containers on $(hostname) ==="
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "ls -la /workspace/ && find /workspace -mindepth 1 -delete" || true
+
+      - name: Show ROCm status (host)
+        run: docker ps -a && rocm-smi --showmemuse 2>/dev/null || true
+
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || github.ref }}
+
+      - name: Start CI container
+        run: |
+          docker ps -aq -f name=atom-mesh-benchmark | xargs -r docker stop | xargs -r docker rm
+          DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices 2>/dev/null || echo "--device /dev/dri")
+          MODEL_MOUNT=""
+          [ -d "/models" ] && MODEL_MOUNT="-v /models:/models"
+
+          # Write env_vars via env block (avoids expression injection — newlines
+          # in `matrix.model.env_vars` would otherwise break the host bash).
+          # Empty file when MODEL_ENV_VARS unset is fine — docker --env-file
+          # accepts it.
+          printenv MODEL_ENV_VARS 2>/dev/null | grep -v '^$' > /tmp/atom_benchmark_env.txt || true
+
+          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
+            -v "${GITHUB_WORKSPACE:-$PWD}":/workspace $MODEL_MOUNT \
+            -w /workspace --ipc=host --group-add video \
+            --shm-size=16G --privileged --cap-add=SYS_PTRACE \
+            -e HF_TOKEN="${HF_TOKEN:-}" \
+            --security-opt seccomp=unconfined \
+            --ulimit memlock=-1 --ulimit stack=67108864 --pull always \
+            -e ATOM_DISABLE_MMAP=true \
+            -e ISL=${{ env.ISL }} -e OSL=${{ env.OSL }} \
+            -e CONC=${{ env.CONC }} -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }} \
+            -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
+            -e ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
+            --env-file /tmp/atom_benchmark_env.txt \
+            --name atom-mesh-benchmark \
+            ${{ inputs.image || 'rocm/atom-dev:latest' }}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          MODEL_ENV_VARS: ${{ matrix.model.env_vars }}
+
+      - name: Collect GPU info (inside container)
+        id: gpu-info
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          RUNNER_HINT="${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.model.runner }}"
+          bash .github/scripts/collect_gpu_info.sh atom-mesh-benchmark docker "$RUNNER_HINT"
+          # Resolve latest → nightly_YYYYMMDDHHMMSS for dashboard display
+          DOCKER_IMAGE="${{ inputs.image || 'rocm/atom-dev:latest' }}"
+          if [ "$DOCKER_IMAGE" = "rocm/atom-dev:latest" ]; then
+            RESOLVED_IMAGE=""
+            if RESOLUTION_JSON="$(python3 .github/scripts/resolve_atom_image.py --repository rocm/atom-dev --reference-tag latest --image-family native 2>/dev/null)"; then
+              RESOLVED_IMAGE="$(echo "$RESOLUTION_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("resolved_image",""))')" || true
+            fi
+            DOCKER_IMAGE="${RESOLVED_IMAGE:-$DOCKER_IMAGE}"
+          fi
+          echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
+          echo "Docker: ${DOCKER_IMAGE}"
+
+      - name: Download models
+        run: |
+          if [ -d "/models" ]; then
+            docker exec -e HF_TOKEN=${{ secrets.AMD_HF_TOKEN }} atom-mesh-benchmark bash -lc \
+              "hf download ${{ env.MODEL_PATH }} --local-dir /models/${{ env.MODEL_PATH }}" || exit 1
+          fi
+
+      - name: Run benchmark
+        timeout-minutes: 60
+        run: |
+          set -euo pipefail
+          if [ -d "/models" ]; then model_path="/models/${{ env.MODEL_PATH }}"
+          else model_path="${{ env.MODEL_PATH }}"; fi
+
+          docker exec atom-mesh-benchmark bash -lc "set -euo pipefail
+            ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
+              ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
+              USE_ATOMESH_ENTRYPOINTS=1 .github/scripts/atom_test.sh launch $model_path ${{ env.ARGS }} ${{ inputs.extra_args || '' }}
+            echo '========== Running benchmark =========='
+            ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
+              RESULT_FILENAME=${{ env.RESULT_FILENAME }} \
+              SERVER_ARGS='${{ env.ARGS }}' \
+              BENCH_EXTRA_ARGS='${{ matrix.model.bench_args }}' \
+              .github/scripts/atom_test.sh benchmark $model_path
+          "
+
+      - name: Dump server log
+        if: always()
+        run: |
+          docker exec atom-mesh-benchmark cat /tmp/atom_server.log 2>/dev/null || true
+
+      - name: Dump client log
+        if: always()
+        run: |
+          docker exec atom-mesh-benchmark cat /tmp/atom_client.log 2>/dev/null || true
+
+      - name: Inject GPU metadata into benchmark result
+        run: |
+          docker exec \
+            -e GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
+            -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
+            -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
+            -e DOCKER_IMAGE="${{ steps.gpu-info.outputs.docker_image }}" \
+            -e RESULT_PATH="${{ env.RESULT_FILENAME }}.json" \
+            -e DISPLAY_NAME="${{ matrix.model.display }}" \
+            atom-mesh-benchmark python3 -c "
+          import json, os
+          p = os.environ['RESULT_PATH']
+          if not os.path.exists(p):
+              print(f'{p} not found, skipping GPU metadata injection')
+          else:
+              with open(p) as f:
+                  d = json.load(f)
+              d['gpu_name'] = os.environ.get('GPU_NAME', '')
+              d['gpu_vram_gb'] = int(os.environ.get('GPU_VRAM_GB') or 0)
+              d['rocm_version'] = os.environ.get('ROCM_VERSION', '')
+              d['docker_image'] = os.environ.get('DOCKER_IMAGE', '')
+              display_name = os.environ.get('DISPLAY_NAME', '')
+              if display_name:
+                  d['benchmark_model_name'] = display_name
+              with open(p, 'w') as f:
+                  json.dump(d, f, indent=2)
+          "
+
+      - name: Copy profiler traces
+        if: inputs.enable_profiler
+        run: docker cp atom-mesh-benchmark:/app/trace ./profiler-traces 2>/dev/null || true
+
+      - name: Upload profiler traces
+        if: inputs.enable_profiler
+        uses: actions/upload-artifact@v7
+        with:
+          name: profiler-traces-${{ env.RESULT_FILENAME }}
+          path: profiler-traces/
+
+      - name: Stop server and collect RTL traces
+        if: inputs.enable_rtl
+        run: |
+          docker exec atom-mesh-benchmark bash -lc \
+            "ENABLE_RTL_PROFILER=1 .github/scripts/atom_test.sh stop" || true
+          docker cp atom-mesh-benchmark:/app/rtl_traces ./rtl-traces 2>/dev/null || true
+
+      - name: Upload RTL traces
+        if: inputs.enable_rtl
+        uses: actions/upload-artifact@v7
+        with:
+          name: rtl-traces-${{ env.RESULT_FILENAME }}
+          path: rtl-traces/
+
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-${{ env.RESULT_FILENAME }}
+          path: ${{ env.RESULT_FILENAME }}.json
+
+      - name: Clean Up
+        if: always()
+        run: |
+          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged \
+            ${{ inputs.image || 'rocm/atom-dev:latest' }} bash -lc "rm -rf /workspace/atom/ /workspace/aiter/ /workspace/bench_serving/" || true
+          docker stop atom-mesh-benchmark || true
+          docker rm atom-mesh-benchmark || true
+
+  summarize-benchmark-result:
+    if: always()
+    name: Summarize benchmark result
+    needs: [benchmark]
+    runs-on: ubuntu-latest
+    outputs:
+      has_regression: ${{ steps.check-regression.outputs.has_regression }}
+    steps:
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || github.ref }}
+
+      - name: Download all benchmark results
+        uses: actions/download-artifact@v8
+        with:
+          pattern: 'benchmark-*'
+          merge-multiple: true
+          path: .
+
+      - name: Download baseline from previous nightly run
+        id: baseline
+        run: |
+          # Use the most recent completed nightly run (regardless of success/failure)
+          # because even failed runs have valid per-model benchmark artifacts.
+          # Only requiring --status=success misses baselines when any single job fails.
+          PREV_RUN_ID=$(gh run list \
+            --workflow="ATOM Mesh Benchmark" \
+            --branch=main \
+            --event=schedule \
+            --limit=5 \
+            --json databaseId,status \
+            --jq '[.[] | select(.status == "completed")][0].databaseId // empty')
+
+          if [ -n "$PREV_RUN_ID" ] && [ "$PREV_RUN_ID" != "${{ github.run_id }}" ]; then
+            echo "Downloading baseline from run #$PREV_RUN_ID"
+            mkdir -p /tmp/baseline
+            # Only download benchmark result artifacts (prefix: benchmark-),
+            # not profiler/regression traces which can be multi-GB.
+            gh run download "$PREV_RUN_ID" --dir /tmp/baseline --pattern 'benchmark-*' || echo "::warning::Failed to download baseline artifacts"
+            BASELINE_COUNT=$(find /tmp/baseline -name '*.json' | wc -l)
+            echo "Downloaded $BASELINE_COUNT baseline files"
+            echo "baseline_dir=/tmp/baseline" >> $GITHUB_OUTPUT
+          else
+            echo "No previous completed nightly run found"
+            echo "baseline_dir=" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: List all benchmark results
+        run: |
+          echo "=== Current results ==="
+          ls -la *.json 2>/dev/null || echo "No JSON files in current dir"
+          if [ -d "/tmp/baseline" ]; then
+            echo "=== Baseline results ==="
+            find /tmp/baseline -name '*.json' | head -20
+          fi
+
+      - name: Summarize benchmark result
+        id: check-regression
+        run: |
+          BASELINE_ARG=""
+          if [ -n "${{ steps.baseline.outputs.baseline_dir }}" ]; then
+            BASELINE_ARG="--baseline-dir ${{ steps.baseline.outputs.baseline_dir }}"
+          fi
+          .github/scripts/summarize.py . $BASELINE_ARG \
+            --output-json regression_report.json \
+            >> $GITHUB_STEP_SUMMARY || true
+
+          # Check if regression was detected (exit code 2)
+          if [ -f regression_report.json ]; then
+            REG_COUNT=$(python3 -c "import json; print(json.load(open('regression_report.json'))['regression_count'])")
+            if [ "$REG_COUNT" -gt 0 ]; then
+              echo "has_regression=true" >> $GITHUB_OUTPUT
+            else
+              echo "has_regression=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "has_regression=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload regression report
+        if: steps.check-regression.outputs.has_regression == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: regression-report
+          path: regression_report.json
+
+      - name: Transform results for benchmark dashboard
+        run: |
+          python3 .github/scripts/plugin_benchmark_to_dashboard.py \
+            . \
+            --output benchmark-action-input.json \
+            --default-backend ATOM-Mesh \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Store benchmark result to dashboard
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: customBiggerIsBetter
+          output-file-path: benchmark-action-input.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: benchmark-dashboard
+          auto-push: false
+          alert-threshold: "80%"
+          comment-on-alert: true
+          fail-on-alert: false
+          max-items-in-chart: 90
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy custom dashboard to gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          CURRENT_SHA=$(git rev-parse HEAD)
+          # Generate prefix→display name mapping from models.json
+          python3 -c "
+          import json
+          models = json.loads(open('.github/benchmark/models.json').read())
+          mapping = {}
+          for m in models:
+              display = m.get('display','')
+              path = m.get('path','')
+              suffix = m.get('suffix','')
+              if not display or not path: continue
+              hf_name = path.split('/')[-1].lower()
+              # HF path-derived key (old data used model_id last segment + optional suffix)
+              hf_key = hf_name + suffix.lower() if suffix else hf_name
+              mapping[hf_key] = display
+          with open('/tmp/dashboard_models_map.js','w') as f:
+              f.write('window.MODELS_DISPLAY_MAP = ' + json.dumps(mapping) + ';')
+          "
+          # Save dashboard assets before switching branches
+          cp .github/dashboard/index.html /tmp/dashboard_index.html
+          cp docs/assets/atom_logo.png /tmp/dashboard_logo.png
+          cp docs/assets/atom_logo_mini.png /tmp/dashboard_logo_mini.png
+          git fetch origin gh-pages
+          git checkout gh-pages
+          # Replace auto-generated index.html with custom dashboard + logo
+          cp /tmp/dashboard_index.html benchmark-dashboard/index.html
+          cp /tmp/dashboard_models_map.js benchmark-dashboard/models_map.js
+          cp /tmp/dashboard_logo.png benchmark-dashboard/atom_logo.png
+          cp /tmp/dashboard_logo_mini.png benchmark-dashboard/atom_logo_mini.png
+          git add benchmark-dashboard/
+          git diff --cached --quiet || git commit -m "Update benchmark data and dashboard"
+          git push origin gh-pages
+          git checkout "$CURRENT_SHA"
+
+  # ---------- Generate regression matrix (lightweight, ubuntu) ----------
+  generate-regression-matrix:
+    if: always() && needs.summarize-benchmark-result.outputs.has_regression == 'true'
+    name: Generate regression rerun matrix
+    needs: [summarize-benchmark-result]
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_json: ${{ steps.gen.outputs.matrix_json }}
+      has_matrix: ${{ steps.gen.outputs.has_matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || github.ref }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: regression-report
+
+      - name: Generate matrix from regression report
+        id: gen
+        run: |
+          python3 .github/scripts/regression_rerun.py \
+            regression_report.json \
+            .github/benchmark/models.json \
+            --output-matrix /tmp/matrix.json
+
+          if [ -s /tmp/matrix.json ] && [ "$(cat /tmp/matrix.json)" != "[]" ]; then
+            echo "matrix_json=$(cat /tmp/matrix.json)" >> $GITHUB_OUTPUT
+            echo "has_matrix=true" >> $GITHUB_OUTPUT
+            echo "=== Matrix cells ==="
+            python3 -c "
+          import json
+          cells = json.load(open('/tmp/matrix.json'))
+          for c in cells:
+              configs = json.loads(c['configs'])
+              print(f\"  {c['prefix']}: {len(configs)} config(s) on {c['runner']}\")
+          "
+          else
+            echo "matrix_json=[]" >> $GITHUB_OUTPUT
+            echo "has_matrix=false" >> $GITHUB_OUTPUT
+            echo "No regression configs generated"
+          fi
+
+  # ---------- Regression re-run (GPU, matrix by model) ----------
+  regression-rerun:
+    if: >-
+      !cancelled()
+      && needs.generate-regression-matrix.outputs.has_matrix == 'true'
+    name: Rerun ${{ matrix.cell.prefix }}
+    needs: [generate-regression-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        cell: ${{ fromJson(needs.generate-regression-matrix.outputs.matrix_json) }}
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.cell.runner }}
+    timeout-minutes: 60
+    steps:
+      - name: Kill all Docker containers
+        run: |
+          echo "=== Cleaning up containers on $(hostname) ==="
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "find /workspace -mindepth 1 -delete" || true
+
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || github.ref }}
+
+      - name: Docker Login
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Start CI container
+        run: |
+          DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices 2>/dev/null || echo "--device /dev/dri")
+          MODEL_MOUNT=""
+          [ -d "/models" ] && MODEL_MOUNT="-v /models:/models"
+
+          # Write env_vars via env block (avoids expression injection — newlines
+          # in `matrix.cell.env_vars` would otherwise break the host bash).
+          printenv CELL_ENV_VARS 2>/dev/null | grep -v '^$' > /tmp/atom_regression_env.txt || true
+
+          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
+            -v "${GITHUB_WORKSPACE:-$PWD}":/workspace $MODEL_MOUNT \
+            -w /workspace --ipc=host --group-add video \
+            --shm-size=16G --privileged --cap-add=SYS_PTRACE \
+            -e HF_TOKEN="${HF_TOKEN:-}" \
+            --security-opt seccomp=unconfined \
+            --ulimit memlock=-1 --ulimit stack=67108864 --pull always \
+            -e ATOM_DISABLE_MMAP=true \
+            --env-file /tmp/atom_regression_env.txt \
+            --name atom-mesh-regression \
+            ${{ inputs.image || 'rocm/atom-dev:latest' }}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          CELL_ENV_VARS: ${{ matrix.cell.env_vars }}
+
+      - name: Download model
+        run: |
+          if [ -d "/models" ]; then
+            echo "=== Downloading ${{ matrix.cell.model_path }} ==="
+            docker exec -e HF_TOKEN=${{ secrets.AMD_HF_TOKEN }} atom-mesh-regression bash -lc \
+              "hf download ${{ matrix.cell.model_path }} --local-dir /models/${{ matrix.cell.model_path }}" \
+              || echo "::warning::Failed to download ${{ matrix.cell.model_path }}, will use HF online"
+          fi
+
+      - name: Launch server
+        run: |
+          if [ -d "/models" ]; then MODEL_DIR="/models/${{ matrix.cell.model_path }}"
+          else MODEL_DIR="${{ matrix.cell.model_path }}"; fi
+
+          # cell.env_vars are already injected into the container env via
+          # --env-file in "Start CI container" — `docker exec` inherits them,
+          # so no need to re-prefix them on the command line (the previous
+          # inline form silently dropped the first var when env_vars contained
+          # a literal newline).
+          docker exec atom-mesh-regression bash -lc "set -euo pipefail
+            ENABLE_TORCH_PROFILER=1 \
+            USE_ATOMESH_ENTRYPOINTS=1 .github/scripts/atom_test.sh launch $MODEL_DIR ${{ matrix.cell.server_args }}"
+
+      - name: Run regression configs with profiler
+        run: |
+          set -uo pipefail  # no -e: allow per-config failure without aborting loop
+
+          if [ -d "/models" ]; then MODEL_DIR="/models/${{ matrix.cell.model_path }}"
+          else MODEL_DIR="${{ matrix.cell.model_path }}"; fi
+
+          FAIL_COUNT=0
+          TOTAL_COUNT=0
+
+          # Parse configs JSON into pipe-delimited lines for shell loop
+          echo '${{ matrix.cell.configs }}' | python3 -c "
+          import json, sys
+          for c in json.load(sys.stdin):
+              print('{isl}|{osl}|{conc}|{bench_args}|{prefix}'.format(**c))
+          " > /tmp/regression_configs.txt
+
+          while IFS='|' read -r ISL OSL CONC BENCH_ARGS PREFIX; do
+            TOTAL_COUNT=$((TOTAL_COUNT + 1))
+            TRACE_SUBDIR="${PREFIX}-${ISL}-${OSL}-${CONC}"
+
+            docker exec atom-mesh-regression bash -lc "mkdir -p /app/trace/$TRACE_SUBDIR"
+
+            # Record profiler stop count before benchmark (to detect new completions)
+            STOP_COUNT_BEFORE=$(docker exec atom-mesh-regression grep -c "Profiler stopped." /tmp/atom_server.log 2>/dev/null) || STOP_COUNT_BEFORE=0
+
+            echo "=== Profiling: $PREFIX ISL=$ISL OSL=$OSL CONC=$CONC ==="
+            if ! docker exec atom-mesh-regression bash -lc "
+              ${{ matrix.cell.env_vars }} \
+              ENABLE_TORCH_PROFILER=1 \
+              ISL=$ISL OSL=$OSL CONC=$CONC \
+              RANDOM_RANGE_RATIO=0.8 \
+              NUM_PROMPTS_OVERRIDE=$((CONC*2)) \
+              RESULT_FILENAME=regression-${PREFIX}-${ISL}-${OSL}-${CONC} \
+              BENCH_EXTRA_ARGS='$BENCH_ARGS' \
+              SERVER_ARGS='${{ matrix.cell.server_args }}' \
+              .github/scripts/atom_test.sh benchmark $MODEL_DIR"; then
+              echo "::warning::Benchmark failed for $PREFIX ISL=$ISL OSL=$OSL CONC=$CONC"
+              FAIL_COUNT=$((FAIL_COUNT + 1))
+              continue
+            fi
+
+            # Wait for engine core to finish exporting profiler trace (blocks inference)
+            # See .claude/plan/profiler-async-refactor.md for long-term fix
+            for i in $(seq 1 300); do
+              STOP_COUNT=$(docker exec atom-mesh-regression grep -c "Profiler stopped." /tmp/atom_server.log 2>/dev/null) || STOP_COUNT=0
+              [ "$STOP_COUNT" -gt "$STOP_COUNT_BEFORE" ] && echo "Profiler trace export done after ${i}s" && break
+              [ "$i" -eq 1 ] && echo "Waiting for profiler trace export..."
+              [ "$i" -eq 300 ] && echo "WARNING: Profiler did not finish after 300s, proceeding anyway"
+              sleep 1
+            done
+
+            # Move trace files into per-config subdir
+            docker exec atom-mesh-regression bash -lc "
+              for d in /app/trace/rank_*; do
+                [ -d \"\$d\" ] && mv \"\$d\" /app/trace/$TRACE_SUBDIR/ 2>/dev/null || true
+              done"
+          done < /tmp/regression_configs.txt
+
+          echo "=== Regression re-run complete: $((TOTAL_COUNT - FAIL_COUNT))/$TOTAL_COUNT succeeded ==="
+          if [ "$FAIL_COUNT" -gt 0 ]; then
+            echo "::warning::$FAIL_COUNT/$TOTAL_COUNT configs failed"
+          fi
+
+      - name: Stop server
+        if: always()
+        run: |
+          docker exec atom-mesh-regression bash -lc \
+            "TORCH_PROFILER_DIR=/app/trace .github/scripts/atom_test.sh stop" || true
+
+      - name: Copy profiler traces from container
+        id: copy-traces
+        if: always()
+        run: |
+          docker cp atom-mesh-regression:/app/trace ./regression-traces 2>/dev/null || echo "No traces found"
+          TRACE_COUNT=$(find ./regression-traces -type f \( -name "*.json.gz" -o -name "*.pt.trace.*" \) 2>/dev/null | wc -l | tr -d ' ')
+          echo "trace_count=$TRACE_COUNT" >> $GITHUB_OUTPUT
+          if [ "$TRACE_COUNT" -gt 0 ]; then
+            echo "Found $TRACE_COUNT trace files"
+            ls -lhR ./regression-traces/
+          else
+            echo "::warning::No trace files found in container — profiler may not have produced output"
+          fi
+
+      - name: Upload regression traces
+        if: always() && fromJSON(steps.copy-traces.outputs.trace_count) > 0
+        uses: actions/upload-artifact@v7
+        with:
+          name: regression-traces-${{ github.run_id }}-${{ matrix.cell.prefix }}
+          path: regression-traces/
+
+      - name: Upload regression results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: regression-results-${{ github.run_id }}-${{ matrix.cell.prefix }}
+          path: regression-*.json
+          if-no-files-found: ignore
+
+      - name: Clean Up
+        if: always()
+        run: |
+          docker stop atom-mesh-regression || true
+          docker rm atom-mesh-regression || true
+
+  # ---------- Collect regression traces from all matrix cells ----------
+  collect-regression-traces:
+    if: always() && needs.regression-rerun.result != 'skipped'
+    name: Collect regression traces
+    needs: [regression-rerun]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all regression trace artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: regression-traces-${{ github.run_id }}-*
+          merge-multiple: true
+          path: regression-traces/
+        continue-on-error: true
+
+      - name: Upload combined regression traces
+        uses: actions/upload-artifact@v7
+        with:
+          name: regression-traces-${{ github.run_id }}
+          path: regression-traces/
+          if-no-files-found: ignore
+
+  # ---------- Profiler analysis (lightweight, runs on regression OR manual profiler) ----------
+  profiler-analysis:
+    if: >-
+      always()
+      && (needs.collect-regression-traces.result != 'cancelled'
+          && needs.collect-regression-traces.result != 'skipped'
+          || inputs.enable_profiler == true)
+    name: Profiler trace analysis
+    needs: [benchmark, summarize-benchmark-result, generate-regression-matrix, regression-rerun, collect-regression-traces]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || github.ref }}
+
+      - name: Download regression traces
+        if: needs.collect-regression-traces.result == 'success'
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: regression-traces-${{ github.run_id }}
+          path: profiler-traces/
+
+      - name: Download benchmark profiler traces
+        if: needs.collect-regression-traces.result != 'success'
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: profiler-traces-*
+          merge-multiple: true
+          path: profiler-traces/
+
+      - name: Analyze traces
+        run: |
+          mkdir -p profiler-analysis
+          pip install -q openpyxl 2>/dev/null || true
+
+          # Find all config subdirectories containing rank_* dirs
+          # Structure: profiler-traces/<config-name>/rank_0/*.gz
+          CONFIG_DIRS=$(find profiler-traces -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true)
+          if [ -z "$CONFIG_DIRS" ]; then
+            echo "No config directories found in profiler-traces/"
+            ls -lhR profiler-traces/ 2>/dev/null || true
+            exit 0
+          fi
+
+          for config_dir in $CONFIG_DIRS; do
+            config=$(basename "$config_dir")
+            echo ""
+            echo "========== Config: $config =========="
+            mkdir -p "profiler-analysis/$config"
+
+            # Analyze rank_0 trace (representative for kernel breakdown + summary)
+            RANK0_TRACE=$(find "$config_dir/rank_0" -name "*.pt.trace.json.gz" ! -name "capture_graph_*" 2>/dev/null | sort | tail -1)
+            if [ -z "$RANK0_TRACE" ]; then
+              echo "No rank_0 trace found for $config, skipping"
+              continue
+            fi
+
+            echo "=== Analyzing: $RANK0_TRACE ==="
+            cd "profiler-analysis/$config"
+            python ../../tools/parse_trace.py "../../$RANK0_TRACE" --layer 3 2>&1 | tee analysis.log || true
+            python ../../tools/analyze_trace_summary.py "../../$RANK0_TRACE" \
+              --output performance_summary.md 2>&1 || true
+            if [ -f performance_summary.md ]; then
+              echo "=== Performance Summary ($config) ==="
+              cat performance_summary.md
+            fi
+            cd ../..
+          done
+          ls -laR profiler-analysis/ 2>/dev/null || true
+
+      - name: Upload analysis results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: profiler-analysis-${{ github.run_id }}
+          path: profiler-analysis/
+
+      - name: Download regression report
+        if: needs.summarize-benchmark-result.outputs.has_regression == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: regression-report
+        continue-on-error: true
+
+      - name: Create GitHub Issue for regression
+        if: needs.summarize-benchmark-result.outputs.has_regression == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let report;
+            try {
+              report = JSON.parse(fs.readFileSync('regression_report.json', 'utf8'));
+            } catch (e) {
+              console.log('No regression report found, skipping issue creation');
+              return;
+            }
+            if (!report.regressions || report.regressions.length === 0) return;
+
+            const regs = report.regressions.map(r => {
+              const throughput = r.metrics.output_throughput || {};
+              const tpot = r.metrics.mean_tpot_ms || {};
+              return `| ${r.model} | ${r.isl}/${r.osl} | ${r.conc} | ${throughput.current?.toFixed(1) || 'N/A'} | ${throughput.baseline?.toFixed(1) || 'N/A'} | ${throughput.pct?.toFixed(1) || 'N/A'}% | ${tpot.current?.toFixed(2) || 'N/A'} | ${tpot.baseline?.toFixed(2) || 'N/A'} | ${tpot.pct?.toFixed(1) || 'N/A'}% |`;
+            }).join('\n');
+
+            let summary = 'Summary not available';
+            try {
+              const dirs = fs.readdirSync('profiler-analysis').filter(d =>
+                fs.statSync(`profiler-analysis/${d}`).isDirectory());
+              for (const d of dirs) {
+                const p = `profiler-analysis/${d}/performance_summary.md`;
+                if (fs.existsSync(p)) { summary = fs.readFileSync(p, 'utf8'); break; }
+              }
+            } catch(e) { /* ignore */ }
+
+            const body = `## Performance Regression Detected
+
+            **Commit:** \`${context.sha.substring(0, 8)}\`
+            **Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
+            **Date:** ${report.timestamp}
+
+            ### Regressed Configurations
+
+            | Model | ISL/OSL | Conc | Tput (cur) | Tput (base) | Δ% | TPOT (cur) | TPOT (base) | Δ% |
+            |-------|---------|------|-----------|------------|-----|-----------|------------|-----|
+            ${regs}
+
+            ### Performance Summary
+
+            \`\`\`
+            ${summary}
+            \`\`\`
+
+            ### Profiler Traces
+
+            Download from [workflow artifacts](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).
+            Open in [Perfetto UI](https://ui.perfetto.dev/) or Chrome \`chrome://tracing\` for analysis.
+
+            ### Next Steps
+            1. Download \`profiler-analysis-${context.runId}\` artifact
+            2. Open trace files in Perfetto UI
+            3. Compare kernel durations against previous traces
+            4. Identify bottleneck changes
+            `.replace(/^            /gm, '');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Perf Regression] ${report.regressions.length} config(s) regressed @ ${context.sha.substring(0, 8)}`,
+              body: body,
+              labels: ['performance', 'regression']
+            });

--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main, Jasen/atom_mesh]  # Triggers on PRs targeting these branches
+    branches: [main]  # Triggers on PRs targeting `main`
     paths-ignore:
       - '**/*.md'
       - 'docs/**'

--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]  # Triggers on PRs targeting `main`
+    branches: [main, Jasen/atom_mesh]  # Triggers on PRs targeting these branches
     paths-ignore:
       - '**/*.md'
       - 'docs/**'

--- a/atom/entrypoints/atomesh/server.py
+++ b/atom/entrypoints/atomesh/server.py
@@ -95,13 +95,29 @@ def initialize_standalone_service(args: argparse.Namespace) -> Any:
     )
 
 
+def split_standalone_args(raw_args: list[str]) -> tuple[list[str], list[str]]:
+    """Keep mesh router --port from being consumed by EngineArgs.
+
+    EngineArgs also defines --port for internal engine communication. In
+    Atomesh standalone mode, the user-facing --port should configure the mesh
+    HTTP router, matching the Rust CLI behavior.
+    """
+    mesh_parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    mesh_parser.add_argument("--port")
+    mesh_args, engine_args = mesh_parser.parse_known_args(raw_args)
+    if mesh_args.port is None:
+        return engine_args, []
+    return engine_args, ["--port", mesh_args.port]
+
+
 def launch_atom_standalone(atomesh_runner: Any, raw_args: list[str]) -> None:
     from atom.model_engine.arg_utils import EngineArgs
 
     parser = argparse.ArgumentParser(description="ATOM Mesh Python interface")
     EngineArgs.add_cli_args(parser)
-    engine_args, mesh_args = parser.parse_known_args(raw_args)
-    parsed_args = atomesh_runner.parse_from(mesh_args)
+    engine_raw_args, mesh_port_args = split_standalone_args(raw_args)
+    engine_args, mesh_args = parser.parse_known_args(engine_raw_args)
+    parsed_args = atomesh_runner.parse_from(mesh_args + mesh_port_args)
     cli_args = parsed_args["cli_args"]
     initialize_engine(engine_args)
     standalone_service = initialize_standalone_service(engine_args)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -431,22 +431,20 @@ RUN cd /app/aiter-test && pip install -e . --no-build-isolation && \
 RUN pip install rocm-trace-lite && \
     rtl --version || true
 
-# ATOM: Python install (editable) + atom-mesh Rust binary
+# ATOM: Python package install (editable) with the atom-mesh build hook enabled.
 # CACHEBUST invalidates only this layer so parallel stages stay cached
 ARG CACHEBUST=1
 RUN git clone $ATOM_REPO /app/ATOM && \
     cd /app/ATOM && \
     git checkout $ATOM_COMMIT && \
-    pip install -e .
+    ATOM_MESH_BUILD=1 python -m pip install -e .
 RUN pip show atom || true
 
 RUN pip install --no-cache-dir msgpack msgspec quart
 
-# atom-mesh: build Rust binary, strip, install to /usr/local/bin
-RUN echo "========== Build atom-mesh ==========" && \
-    rustup update stable && rustup default stable && \
+# atom-mesh: install the binary produced by the ATOM package build hook to /usr/local/bin
+RUN echo "========== Install atom-mesh binary ==========" && \
     cd /app/ATOM/atom/mesh && \
-    cargo build --release && \
     strip target/release/atom-mesh && \
     cp target/release/atom-mesh /usr/local/bin/atom-mesh && \
     atom-mesh --version

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from importlib import import_module
 import runpy
 import subprocess
 from pathlib import Path
 
 from setuptools import setup
 from setuptools.command.build_py import build_py as _build_py
+
+_editable_wheel = import_module("setuptools.command.editable_wheel").editable_wheel
+_ATOM_MESH_BUILT = False
 
 
 def get_build_env(name: str):
@@ -14,23 +18,42 @@ def get_build_env(name: str):
     return runpy.run_path(str(envs_path))["environment_variables"][name]()
 
 
+def build_atom_mesh() -> None:
+    global _ATOM_MESH_BUILT
+
+    if not get_build_env("ATOM_MESH_BUILD"):
+        return
+    if _ATOM_MESH_BUILT:
+        return
+
+    root = Path(__file__).resolve().parent
+    mesh_dir = root / "atom" / "mesh"
+    print(f"Building atom-mesh from {mesh_dir}...", flush=True)
+    subprocess.run(
+        ["cargo", "build", "--release"],
+        cwd=mesh_dir,
+        check=True,
+        text=True,
+    )
+    _ATOM_MESH_BUILT = True
+
+
 class install_atom_mesh(_build_py):
     def run(self) -> None:
-        if get_build_env("ATOM_MESH_BUILD"):
-            root = Path(__file__).resolve().parent
-            mesh_dir = root / "atom" / "mesh"
-            print(f"Building atom-mesh from {mesh_dir}...")
-            subprocess.run(
-                ["cargo", "build", "--release"],
-                cwd=mesh_dir,
-                check=True,
-                text=True,
-            )
+        build_atom_mesh()
+        super().run()
 
+
+class editable_install_atom_mesh(_editable_wheel):
+    def run(self) -> None:
+        build_atom_mesh()
         super().run()
 
 
 setup(
     use_scm_version=True,
-    cmdclass={"build_py": install_atom_mesh},
+    cmdclass={
+        "build_py": install_atom_mesh,
+        "editable_wheel": editable_install_atom_mesh,
+    },
 )


### PR DESCRIPTION
Summary

- Updated ATOM package/Docker install flow to use ATOM_MESH_BUILD=1 so atom/mesh is built through the package install hook and libmesh.so is included for Atomesh Python entrypoints.
- Added dedicated Atomesh CI workflows based on existing ATOM validation flows:
    - atom-mesh-accuracy-validation.yaml
    - atom-mesh-benchmark.yaml
- The new Atomesh workflows keep the original ATOM test/benchmark settings intact, but launch the server via ATOM standalone mode using USE_ATOMESH_ENTRYPOINTS=1.