### PR TITLE
fix(mesh): map producer dp_rank to remote_dp_rank in enrich_decode_kv

### DIFF
--- a/atom/mesh/src/core/placement/backend/atom.rs
+++ b/atom/mesh/src/core/placement/backend/atom.rs
@@ -31,9 +31,9 @@ impl AtomAdapter {
         Self { prefill_info }
     }
 
-    /// Add the two fields that ATOM's prefill response omits but the decode side requires
-    /// (mooncake_connector kv_transfer_params_output drops remote_dp_size/remote_tp_size;
-    /// decode's ReqMeta reads them, defaulting to 1 — wrong for multi-DP clusters).
+    /// Fill in fields the prefill response omits but decode's ReqMeta needs:
+    /// remote_dp_size/remote_tp_size, and remote_dp_rank (renamed from the
+    /// prefill's `dp_rank`). Mirrors proxy.py.
     pub fn enrich_decode_kv(&self, kv: &mut Value, ctx: &PairCtx) -> Result<(), AdapterError> {
         let ctx = downcast(ctx)?;
         let obj = kv.as_object_mut().ok_or(AdapterError::BodyNotObject)?;
@@ -47,6 +47,10 @@ impl AtomAdapter {
             })?;
         obj.insert("remote_dp_size".to_string(), json!(ctx.prefill_dp_size));
         obj.insert("remote_tp_size".to_string(), json!(tp_size));
+        // Only a numeric rank; else leave unset so decode defaults to 0.
+        if let Some(dp_rank) = obj.get("dp_rank").filter(|v| v.is_number()).cloned() {
+            obj.insert("remote_dp_rank".to_string(), dp_rank);
+        }
         Ok(())
     }
 }

--- a/atom/mesh/src/core/placement/tests.rs
+++ b/atom/mesh/src/core/placement/tests.rs
@@ -1494,6 +1494,42 @@ mod f_atom_adapter {
     }
 
     #[test]
+    fn test_atom_enrich_decode_kv_maps_dp_rank_to_remote_dp_rank() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut kv = json!({
+            "do_remote_prefill": true,
+            "dp_rank": 3,
+            "transfer_id": 7,
+        });
+        adapter.enrich_decode_kv(&mut kv, &ctx).unwrap();
+        // The owning producer DP rank must be propagated so the decode side
+        // sends its write_request to the correct side-channel port.
+        assert_eq!(kv["remote_dp_rank"], json!(3));
+        assert_eq!(kv["remote_dp_size"], json!(1));
+        assert_eq!(kv["remote_tp_size"], json!(8));
+    }
+
+    #[test]
+    fn test_atom_enrich_decode_kv_no_dp_rank_leaves_remote_dp_rank_unset() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut kv = json!({ "transfer_id": 1 });
+        adapter.enrich_decode_kv(&mut kv, &ctx).unwrap();
+        // Absent dp_rank: decode's ReqMeta default (0) applies, matching the
+        // single-DP case; we must not invent a rank.
+        assert!(kv.get("remote_dp_rank").is_none());
+    }
+
+    #[test]
+    fn test_atom_enrich_decode_kv_null_dp_rank_leaves_remote_dp_rank_unset() {
+        let (adapter, ctx) = atom_pair_for("http://p:8000", 8);
+        let mut kv = json!({ "dp_rank": serde_json::Value::Null });
+        adapter.enrich_decode_kv(&mut kv, &ctx).unwrap();
+        // A null dp_rank must not be propagated: decode would default to 0,
+        // whereas copying null verbatim would crash its integer port math.
+        assert!(kv.get("remote_dp_rank").is_none());
+    }
+
+    #[test]
     fn test_atom_enrich_decode_kv_missing_tp_size_errors() {
         let info = atom_info_with("http://other:8000", 8);
         let adapter = AtomAdapter::new(info);


### PR DESCRIPTION
In multi-DP PD disaggregation the decode side must send each mooncake write_request to the producer DP rank that prefilled the request (each rank binds its own side channel at base_handshake_port + dp_rank). The producer reports its owning rank under key dp_rank, but decode's ReqMeta reads remote_dp_rank (default 0). enrich_decode_kv only injected remote_dp_size/remote_tp_size, so every write_request went to producer rank 0; prefills served by any other rank timed out, KV never arrived, decode requests piled up in WAITING_FOR_REMOTE_KVS and the DP+EP engine coredumped. Mirror proxy.py by copying dp_rank to remote_dp_rank, guarded to only propagate a numeric value.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
