### PR TITLE
[atom-sgl-benchmark] Debug benchmark timeout

### DIFF
--- a/.github/scripts/atom_sglang_test.sh
+++ b/.github/scripts/atom_sglang_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Usage:
+#   .github/scripts/atom_sglang_test.sh start
 #   .github/scripts/atom_sglang_test.sh launch
 #   .github/scripts/atom_sglang_test.sh accuracy
 #
@@ -28,8 +29,8 @@ set -euo pipefail
 #   LM_EVAL_NUM_CONCURRENT
 
 TYPE=${1:-launch}
-if [[ "${TYPE}" != "launch" && "${TYPE}" != "accuracy" ]]; then
-  echo "Invalid TYPE: ${TYPE}. Expected: launch or accuracy"
+if [[ "${TYPE}" != "start" && "${TYPE}" != "launch" && "${TYPE}" != "accuracy" ]]; then
+  echo "Invalid TYPE: ${TYPE}. Expected: start, launch, or accuracy"
   exit 2
 fi
 
@@ -144,6 +145,7 @@ stop_server() {
 }
 
 launch_server() {
+  local wait_for_ready="${1:-1}"
   local resolved_model_path
   resolved_model_path=$(resolve_model_path "${MODEL_PATH}")
 
@@ -210,7 +212,9 @@ PY
   echo $! > "${SGLANG_PID_FILE}"
   echo "Server PID: $(cat "${SGLANG_PID_FILE}")"
 
-  wait_server_ready
+  if [[ "${wait_for_ready}" == "1" ]]; then
+    wait_server_ready
+  fi
 }
 
 run_accuracy() {
@@ -330,7 +334,7 @@ PY
 }
 
 cleanup_on_exit() {
-  if [[ "${TYPE}" == "launch" && "${KEEP_SERVER_ALIVE_ON_EXIT}" == "1" ]]; then
+  if [[ "${TYPE}" == "start" || ( "${TYPE}" == "launch" && "${KEEP_SERVER_ALIVE_ON_EXIT}" == "1" ) ]]; then
     echo "Keeping SGLang server alive for follow-up steps."
     return 0
   fi
@@ -339,7 +343,9 @@ cleanup_on_exit() {
 
 trap 'cleanup_on_exit' EXIT
 
-if [[ "${TYPE}" == "launch" ]]; then
+if [[ "${TYPE}" == "start" ]]; then
+  launch_server "0"
+elif [[ "${TYPE}" == "launch" ]]; then
   launch_server
 else
   launch_server

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -955,7 +955,7 @@ jobs:
             if [[ "${WORKLOAD_LABEL}" == "SGLang-Mesh" && -n "${MESH_TP_SIZE}" ]]; then
               EFFECTIVE_SGLANG_EXTRA_ARGS="--tensor-parallel-size ${MESH_TP_SIZE} ${SGLANG_EXTRA_ARGS}"
             fi
-            $CONTAINER_ENGINE exec \
+            $CONTAINER_ENGINE exec -d \
               -e SGLANG_MODEL_NAME="${MODEL_NAME}" \
               -e SGLANG_MODEL_PATH="${SGLANG_RESOLVED_MODEL_PATH:-$MODEL_PATH}" \
               -e SGLANG_EXTRA_ARGS="${EFFECTIVE_SGLANG_EXTRA_ARGS}" \
@@ -964,8 +964,68 @@ jobs:
               -e KEEP_SERVER_ALIVE_ON_EXIT=1 \
               "$CONTAINER_NAME" bash -lc "
                 set -euo pipefail
-                bash .github/scripts/atom_sglang_test.sh launch
+                bash .github/scripts/atom_sglang_test.sh start
               "
+
+            last_sglang_log_line=0
+
+            emit_new_sglang_logs() {
+              if [ "${STREAM_SGLANG_LOGS}" != "1" ]; then
+                return 0
+              fi
+
+              current_line_count=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'if [ -f /tmp/atom_sglang.log ]; then wc -l < /tmp/atom_sglang.log; else echo 0; fi' 2>/dev/null || echo 0)
+              current_line_count=${current_line_count//$'\r'/}
+              if [ "${current_line_count:-0}" -le "${last_sglang_log_line}" ]; then
+                return 0
+              fi
+
+              echo ""
+              echo "========== New SGLang log output =========="
+              $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "sed -n '$((last_sglang_log_line + 1)),${current_line_count}p' /tmp/atom_sglang.log" || true
+              last_sglang_log_line=${current_line_count}
+            }
+
+            for ((i=1; i<=MAX_WAIT_RETRIES; i++)); do
+              if $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1'; then
+                emit_new_sglang_logs
+                echo "SGLang server is ready."
+                break
+              fi
+
+              emit_new_sglang_logs
+
+              server_status=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc '
+                if [ -f /tmp/atom_sglang.pid ]; then
+                  pid=$(cat /tmp/atom_sglang.pid)
+                  if kill -0 "$pid" 2>/dev/null; then
+                    echo running
+                  else
+                    echo dead
+                  fi
+                elif pgrep -f "sglang.launch_server" >/dev/null 2>&1; then
+                  echo running
+                else
+                  echo starting
+                fi
+              ' 2>/dev/null || echo unknown)
+
+              if [ "${server_status}" = "dead" ]; then
+                echo "SGLang server process exited before becoming ready."
+                $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'tail -n 200 /tmp/atom_sglang.log || true' || true
+                exit 1
+              fi
+
+              echo "Waiting for SGLang server... (${i}/${MAX_WAIT_RETRIES}; status=${server_status})"
+              sleep "${WAIT_INTERVAL_SEC:-30}"
+            done
+
+            if ! $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1'; then
+              echo "SGLang server did not become ready in time."
+              emit_new_sglang_logs
+              $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'tail -n 200 /tmp/atom_sglang.log || true' || true
+              exit 1
+            fi
 
             TRUST_REMOTE_CODE_ARG=""
             if [[ "${EFFECTIVE_SGLANG_EXTRA_ARGS}" == *"--trust-remote-code"* ]]; then


### PR DESCRIPTION
报错原因：
 podman exec 本身在等 container exec 的 exit 文件(vllm launch)时超时导致的255报错，即SGLang 的失败正好卡在 bash .github/scripts/atom_sglang_test.sh launch 这个长 exec。

解决思路：
atom_sglang_test.sh 增加 start 模式，让服务能后台启动后立即退出；
atom-sglang-benchmark.yaml 把 SGLang-ATOM 分支的长启动 exec 改成后台启动 + 外层轮询 ready。
 