### PR TITLE
feat: chunked prefill toggle + auto-disable for DeepSeek-V4

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1125,6 +1125,19 @@ class Config:
                     "(SWA buffer is not cacheable); disabling automatically."
                 )
                 self.enable_prefix_caching = False
+            # V4's MHC compress-attention / SWA per-request state assumes the whole
+            # prompt is processed in one forward; chunked prefill splits a request
+            # across batches and leaves that per-request state inconsistent, so
+            # disable chunked prefill too.
+            if self.enable_chunked_prefill:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "DeepSeek-V4 does not support chunked prefill "
+                    "(per-request SWA/compress state is not chunk-safe); "
+                    "disabling automatically."
+                )
+                self.enable_chunked_prefill = False
 
     def compute_hash(self) -> str:
         """

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -39,6 +39,7 @@ class EngineArgs:
     max_model_len: Optional[int] = None
     max_num_batched_tokens: int = 16384
     attn_prefill_chunk_size: int = 16384
+    enable_chunked_prefill: bool = True
     scheduler_delay_factor: float = 0.0
     max_num_seqs: int = 512
     gpu_memory_utilization: float = 0.9
@@ -198,6 +199,14 @@ class EngineArgs:
                 "MLA chunked-prefill budget in tokens. Default uses "
                 "max_num_batched_tokens."
             ),
+        )
+        parser.add_argument(
+            "--enable_chunked_prefill",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Enable chunked prefill (default: enabled). "
+            "Use --no-enable_chunked_prefill to disable. "
+            "Note: DeepSeek-V4 auto-disables this (unsupported).",
         )
         parser.add_argument(
             "--max-num-seqs",

--- a/scripts/run_debug_agent.sh
+++ b/scripts/run_debug_agent.sh
@@ -36,6 +36,11 @@
 
 set -uo pipefail
 
+# Resolve script dir to an ABSOLUTE path before any `cd` below. The launch step
+# cd's into $DEBUG_DIR for code-object dumps, so a relative dirname would break
+# the path to the sibling launcher scripts.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 MODE="server"
 if [ "${1:-}" = "--simple" ]; then
   MODE="simple"
@@ -71,7 +76,6 @@ export ROCM_DEBUG_AGENT_OPTIONS="--save-code-objects"
 export AITER_LOG_LEVEL="${AITER_LOG_LEVEL:-WARNING}"
 
 # 5) launch (model-specific env like ATOM_USE_TRITON_MOE must come from caller)
-SCRIPT_DIR="$(dirname "$0")"
 if [ "$MODE" = "server" ]; then
   exec bash "$SCRIPT_DIR/start_atom_server.sh" \
     "$MODEL" "$TP" "$PORT" "$@"


### PR DESCRIPTION
## Summary

Two independent changes:

### 1. `--enable_chunked_prefill` toggle + DeepSeek-V4 auto-disable
- Add explicit `--enable_chunked_prefill` / `--no-enable_chunked_prefill` CLI flag (default **enabled**), backed by `EngineArgs.enable_chunked_prefill`.
- **DeepSeek-V4 auto-disables chunked prefill**: its MHC compress-attention / SWA per-request state assumes the whole prompt is processed in one forward pass. Chunked prefill splits a request across batches and leaves that per-request state inconsistent. `Config` now logs a warning and forces it off for V4.

### 2. `run_debug_agent.sh` launcher path fix
- `SCRIPT_DIR` was computed with a relative `dirname "$0"` **after** the script had already `cd`'d into `$DEBUG_DIR` (for `--save-code-objects` dumps), so the sibling `start_atom_server.sh` / `start_simple_inference.sh` failed with "No such file or directory".
- Now resolved to an absolute path via `BASH_SOURCE` **before** the `cd`.

## Test plan
- [x] `ruff check` clean on changed Python files
- [x] `black --check` reports both `.py` files already formatted
- [x] `run_debug_agent.sh` launches correctly after fix (verified: V4-Pro server came up under rocm-debug-agent and ran a full benchmark)
- [ ] Verify V4 server start logs the chunked-prefill auto-disable warning
- [ ] Verify `--no-enable_chunked_prefill` disables it on a non-V4 model