### PR TITLE
Fix benchmark summary Black formatting

### DIFF
--- a/.github/scripts/plugin_benchmark_summary.py
+++ b/.github/scripts/plugin_benchmark_summary.py
@@ -219,7 +219,9 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.matrix_json_file:
-        matrix_payload = json.loads(Path(args.matrix_json_file).read_text(encoding="utf-8"))
+        matrix_payload = json.loads(
+            Path(args.matrix_json_file).read_text(encoding="utf-8")
+        )
     elif args.matrix_json:
         matrix_payload = json.loads(args.matrix_json)
     else:


### PR DESCRIPTION
## Summary
- Fix Black formatting in `.github/scripts/plugin_benchmark_summary.py` introduced by PR #981.
- Keep the change scoped to the benchmark summary script so pre-checkin can pass on `main`.

## Test plan
- `python3 -m black --check /shared/amdgpu/home/hattie_wu_qle/ATOM/.github/scripts/plugin_benchmark_summary.py`
- `python3 -m py_compile /shared/amdgpu/home/hattie_wu_qle/ATOM/.github/scripts/plugin_benchmark_summary.py`

