### PR TITLE
fix: black-format plugin_benchmark_summary.py to unblock Pre Checkin Signal

### DIFF
--- a/.github/scripts/plugin_benchmark_summary.py
+++ b/.github/scripts/plugin_benchmark_summary.py
@@ -219,7 +219,9 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.matrix_json_file:
-        matrix_payload = json.loads(Path(args.matrix_json_file).read_text(encoding="utf-8"))
+        matrix_payload = json.loads(
+            Path(args.matrix_json_file).read_text(encoding="utf-8")
+        )
     elif args.matrix_json:
         matrix_payload = json.loads(args.matrix_json)
     else:


### PR DESCRIPTION
## Problem

Commit 73e4383 (#981) introduced a line in `.github/scripts/plugin_benchmark_summary.py` that exceeds Black's line length:

```python
matrix_payload = json.loads(Path(args.matrix_json_file).read_text(encoding="utf-8"))
```

This makes **Check Code Style with Black** (`psf/black@stable`) fail with `1 file would be reformatted`. The **Check Pre Checkin Signal** gate (`.github/scripts/check_signal.sh`) depends on the Black job, so it also fails (`Pre Checkin did not pass (conclusion: failure)`, exit 78).

## Fix

Reformat the single offending line with Black — the only change, purely formatting:

```python
matrix_payload = json.loads(
    Path(args.matrix_json_file).read_text(encoding="utf-8")
)
```

## Verification
- [x] `black --check .github/scripts/plugin_benchmark_summary.py` → passes
- [x] `ruff check .github/scripts/plugin_benchmark_summary.py` → All checks passed
- [x] Diff is formatting-only (one statement wrapped), no behavior change