### PR TITLE
ci(sglang): add Kimi-K2 e2e accuracy + perf regression

### DIFF
--- a/.github/benchmark/sglang_benchmark_models.json
+++ b/.github/benchmark/sglang_benchmark_models.json
@@ -298,5 +298,29 @@
     "runner": "atom-mi355-8gpu-aac-runner",
     "nightly_group": "B",
     "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0"
+  },
+  {
+    "display": "Kimi-K2-Thinking-MXFP4 TP8",
+    "dashboard_model": "Kimi-K2-Thinking-MXFP4-tp8",
+    "source_path": "amd/Kimi-K2-Thinking-MXFP4",
+    "path": "amd/Kimi-K2-Thinking-MXFP4",
+    "prefix": "kimi-k2-thinking-mxfp4-tp8",
+    "extra_args": "--trust-remote-code --tensor-parallel-size 8",
+    "bench_args": "",
+    "runner": "atom-mi355-8gpu-aac-runner",
+    "nightly_group": "B",
+    "env_vars": "SGLANG_USE_AITER=1"
+  },
+  {
+    "display": "Kimi-K2.5-MXFP4 TP8",
+    "dashboard_model": "Kimi-K2.5-MXFP4-tp8",
+    "source_path": "amd/Kimi-K2.5-MXFP4",
+    "path": "amd/Kimi-K2.5-MXFP4",
+    "prefix": "kimi-k25-mxfp4-tp8",
+    "extra_args": "--trust-remote-code --tensor-parallel-size 8",
+    "bench_args": "",
+    "runner": "atom-mi355-8gpu-aac-runner",
+    "nightly_group": "B",
+    "env_vars": "SGLANG_USE_AITER=1"
   }
 ]

--- a/.github/runner-config.yml
+++ b/.github/runner-config.yml
@@ -21,3 +21,22 @@ runners:
   linux-atom-mi355-8:
     gpu_arch: MI355
     gpu_count: 8
+
+  atom-mi355-8gpu-oot-benchmark:
+    gpu_arch: MI355
+    gpu_count: 8
+
+  # mi35x pool schedules onto either MI350 or MI355 hardware.
+  # Reported as MI355; confirm with the devops-dashboard owner whether an
+  # MI35X heterogeneous-pool value is supported before relabeling.
+  linux-atom-mi35x-1:
+    gpu_arch: MI355
+    gpu_count: 1
+
+  linux-atom-mi35x-4:
+    gpu_arch: MI355
+    gpu_count: 4
+
+  linux-atom-mi35x-8:
+    gpu_arch: MI355
+    gpu_count: 8

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -35,8 +35,11 @@ on:
           - "deepseek-r1-fp4-tp8-mtp1 (1024x1024/8192x1024: [4,8,16,32,64])"
           - "qwen3-5-397b-a17b-fp8-tp4 (1024x1024/8192x1024: [4,8,16,32,64])"
           - "qwen3-5-397b-a17b-fp8-tp8 (1024x1024/8192x1024: [4,8,16,32,64])"
+          - "kimi-k2-thinking-mxfp4-tp8 (1024x1024/8192x1024: [4,8,16,32,64])"
+          - "kimi-k25-mxfp4-tp8 (1024x1024/8192x1024: [4,8,16,32,64])"
           - "all-deepseek (8 DeepSeek configs x 10 default params)"
           - "all-qwen (2 Qwen configs x 10 default params)"
+          - "all-kimi (2 Kimi configs x 10 default params)"
           - "all-oob (all SGLang-OOB configs x 10 default params)"
         default: "none (do not run SGLang-OOB models)"
       mesh_config_preset:
@@ -409,6 +412,8 @@ jobs:
                   return prefix.startswith("deepseek-")
               if preset == "all-qwen":
                   return prefix.startswith("qwen")
+              if preset == "all-kimi":
+                  return prefix.startswith("kimi-")
               return prefix == preset
 
           if event == "schedule":

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -229,6 +229,24 @@ jobs:
               ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0
             accuracy_test_threshold: 0.76
             runner: linux-atom-mi35x-4
+          - model_name: "Kimi-K2-Thinking-MXFP4 TP8"
+            model_path: "amd/Kimi-K2-Thinking-MXFP4"
+            extra_args: "--tensor-parallel-size 8 --trust-remote-code"
+            env_vars: |
+              SGLANG_USE_AITER=1
+            # NOTE: initial threshold mirrors vLLM-OOT Kimi-K2-Thinking baseline (0.90);
+            # recalibrate from the first green SGLang run.
+            accuracy_test_threshold: 0.90
+            runner: linux-atom-mi35x-8
+          - model_name: "Kimi-K2.5-MXFP4 TP8"
+            model_path: "amd/Kimi-K2.5-MXFP4"
+            extra_args: "--tensor-parallel-size 8 --trust-remote-code"
+            env_vars: |
+              SGLANG_USE_AITER=1
+            # NOTE: initial threshold mirrors vLLM Kimi-K2.5 baseline (0.93 -> 0.92 margin);
+            # recalibrate from the first green SGLang run.
+            accuracy_test_threshold: 0.92
+            runner: linux-atom-mi35x-8
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     env:


### PR DESCRIPTION
## What

Adds **Kimi-K2** end-to-end regression coverage to the **SGLang** backend (both accuracy and performance), reaching parity with the Kimi coverage that already exists for vLLM.

## Why

KimiK2 was already covered on every vLLM lane (in-tree accuracy/perf and OOT accuracy/perf) but **had zero coverage on SGLang** — neither the accuracy matrix nor the perf catalog contained any Kimi entry. This closes that gap.

## Coverage before vs after

| Lane | Before | After |
|---|---|---|
| vLLM in-tree accuracy | Kimi-K2.5-MXFP4 | (unchanged) |
| vLLM in-tree perf | Kimi-K2.5-MXFP4 | (unchanged) |
| vLLM OOT accuracy | K2-Thinking + K2.5 TP8 | (unchanged) |
| vLLM OOT perf | K2-Thinking/K2.5 TP4+TP8 | (unchanged) |
| **SGLang accuracy** | none | **+ K2-Thinking-MXFP4 TP8, K2.5-MXFP4 TP8** |
| **SGLang perf** | none | **+ K2-Thinking-MXFP4 TP8, K2.5-MXFP4 TP8** |

## Changes

1. `.github/workflows/atom-sglang-test.yaml` — two Kimi cases added to the accuracy `matrix.include` (TP8, `linux-atom-mi35x-8`, `SGLANG_USE_AITER=1`).
2. `.github/benchmark/sglang_benchmark_models.json` — two Kimi perf cases (`nightly_group: B`, `atom-mi355-8gpu-aac-runner`). Group B keeps them out of the daily group-A sweep; they run in the Friday `C-ALL` full sweep and on manual dispatch.
3. `.github/workflows/atom-sglang-benchmark.yaml` — `kimi-k2-thinking-mxfp4-tp8`, `kimi-k25-mxfp4-tp8` and an `all-kimi` option added to the `oob_model_preset` dropdown + selector logic.
4. `.github/runner-config.yml` — documents the runner labels actually in use but previously missing from the GPU-arch map: `atom-mi355-8gpu-oot-benchmark` and the `linux-atom-mi35x-{1,4,8}` family.

## Open items for reviewers (draft)

- **Accuracy thresholds need calibration.** `0.90` (K2-Thinking) and `0.92` (K2.5) are mirrored from the vLLM baselines as placeholders. Please recalibrate from the first green SGLang run.
- **Model paths / flags.** Using `amd/Kimi-K2-Thinking-MXFP4` and `amd/Kimi-K2.5-MXFP4` with `--tensor-parallel-size 8 --trust-remote-code` + `SGLANG_USE_AITER=1`. Confirm these are the intended SGLang serving args (DeepSeek entries also set `SGLANG_AITER_FP8_PREFILL_ATTN=0` / fusion flags — Kimi MXFP4 may want different env).
- **`mi35x` GPU-arch label.** The `linux-atom-mi35x-*` pool schedules onto MI350 **or** MI355. I mapped it to `MI355` with a comment; confirm whether the devops-dashboard supports an `MI35X` heterogeneous-pool value before relabeling.

> Draft — opening for review of approach/config before enabling on real runners.
