### PR TITLE
ci(benchmark): DP-attention up to c=1024 at util 0.85 (suffix -dpa)

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -33,9 +33,9 @@
     "display": "DeepSeek-V4-Pro DP",
     "path": "deepseek-ai/DeepSeek-V4-Pro",
     "prefix": "deepseek-v4-pro",
-    "args": "--kv_cache_dtype fp8 -tp 8 --enable-dp-attention",
+    "args": "--kv_cache_dtype fp8 -tp 8 --enable-dp-attention --gpu-memory-utilization 0.85",
     "bench_args": "",
-    "suffix": "-dp",
+    "suffix": "-dpa",
     "runner": "atom-mi355-8gpu.predownload",
     "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1"
   },

--- a/.github/benchmark/nightly_params.json
+++ b/.github/benchmark/nightly_params.json
@@ -2,13 +2,13 @@
   {
     "isl": 1024,
     "osl": 1024,
-    "concurrency": [4, 8, 16, 32, 64, 128, 256],
+    "concurrency": [4, 8, 16, 32, 64, 128, 256, 512, 1024],
     "random_range_ratio": 0.8
   },
   {
     "isl": 8192,
     "osl": 1024,
-    "concurrency": [4, 8, 16, 32, 64, 128, 256],
+    "concurrency": [4, 8, 16, 32, 64, 128, 256, 512, 1024],
     "random_range_ratio": 0.8
   }
 ]

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -185,14 +185,25 @@ jobs:
           - model: { suffix: "-mtp3" }
             config: { concurrency: 2 }
           # Skip low-concurrency DP-attention runs (only run c>=64)
-          - model: { suffix: "-dp" }
+          - model: { suffix: "-dpa" }
+            config: { concurrency: 2 }
+          - model: { suffix: "-dpa" }
             config: { concurrency: 4 }
-          - model: { suffix: "-dp" }
+          - model: { suffix: "-dpa" }
             config: { concurrency: 8 }
-          - model: { suffix: "-dp" }
+          - model: { suffix: "-dpa" }
             config: { concurrency: 16 }
-          - model: { suffix: "-dp" }
+          - model: { suffix: "-dpa" }
             config: { concurrency: 32 }
+          # High-concurrency (512/1024) only for DP-attention; cap others at 256
+          - model: { suffix: "" }
+            config: { concurrency: 512 }
+          - model: { suffix: "" }
+            config: { concurrency: 1024 }
+          - model: { suffix: "-mtp3" }
+            config: { concurrency: 512 }
+          - model: { suffix: "-mtp3" }
+            config: { concurrency: 1024 }
 
     runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.model.runner }}
 


### PR DESCRIPTION
## Summary

Extend the DeepSeek-V4-Pro **DP-attention** benchmark to high concurrency, scoped so only the DP-attention model runs the new points.

### Changes
- **`.github/benchmark/models.json`** — `DeepSeek-V4-Pro DP` entry:
  - add `--gpu-memory-utilization 0.85`
  - rename `suffix` `-dp` → **`-dpa`** (result filenames become `deepseek-v4-pro-dpa-...`)
- **`.github/benchmark/nightly_params.json`** — add `512, 1024` to the concurrency sweep for both `1024/1024` and `8192/1024`.
- **`.github/workflows/atom-benchmark.yaml`**:
  - update existing low-concurrency DP excludes to the new `-dpa` suffix
  - add excludes so `c=512` and `c=1024` run **only** for DP-attention (excluded for `suffix: ""` and `suffix: "-mtp3"`, i.e. all 16 other models)

### Why util 0.85
DP-attention gathers all 8 DP ranks' tokens into each rank's MoE; the FlyDSL stage-2 reduce-mode scratch (`token_num × topk × model_dim`) peaks at ~10 GiB during prefill (bounded by `max_num_batched_tokens × 8`, independent of concurrency). At util 0.9 there is no headroom for that transient and the server OOMs (`HSA_STATUS_ERROR_OUT_OF_RESOURCES` / `torch.OutOfMemoryError`). util 0.85 frees ~14 GiB and was verified stable.

### Verification (DeepSeek-V4-Pro, util 0.85, dp-attention)
- 1k/1k c=1024: **22,925 tok/s**, 2048/2048 OK, 0 OOM
- 8k/1k c=256: **27,140 tok/s**, 2560/2560 OK, 0 OOM
- KV headroom at c=1024 8k/1k: 128 seqs/rank → 9216/44003 blocks (21%); default `max_num_seqs=256` suffices (1024 ÷ 8 ranks = 128/rank)

### Effect
- DP-attention (`-dpa`): runs c=64/128/256/**512/1024** at both 1k/1k and 8k/1k, util 0.85
- All other 16 models: unchanged, capped at c≤256