### PR TITLE
ci(vllm): enable Kimi-K2.5-MXFP4 TP8 accuracy job on MI350X runner

### DIFF
--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -105,14 +105,14 @@
   {
     "model_name": "Kimi-K2.5-MXFP4 TP8",
     "model_path": "amd/Kimi-K2.5-MXFP4",
-    "extraArgs": "--tensor-parallel-size 8",
-    "env_vars": "",
-    "runner": "linux-atom-mi35x-8",
+    "extraArgs": "--tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384",
+    "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4",
+    "runner": "linux-aiter-do-mi350x-8",
     "test_level": "nightly",
     "accuracy_threshold": 0.92,
-    "accuracy_baseline": 0.93,
+    "accuracy_baseline": 0.9409,
     "accuracy_baseline_model": "amd/Kimi-K2.5-MXFP4",
-    "_baseline_note": "Reference value from recipes/atom_vllm/Kimi-K2.5.md"
+    "_baseline_note": "Verified on MI355X 2026-05-30: vllm serve TP8 (atom-dev:vllm-latest, aiter ef114b0d4) gsm8k flexible-extract 0.9409. Ref recipes/atom_vllm/Kimi-K2.5.md"
   },
   {
     "model_name": "MiniMax-M2.7 TP2",

--- a/.github/runner-config.yml
+++ b/.github/runner-config.yml
@@ -21,3 +21,20 @@ runners:
   linux-atom-mi355-8:
     gpu_arch: MI355
     gpu_count: 8
+
+  # AITER devops MI350X runner pool (used by the vLLM Kimi-K2.5 CI job)
+  linux-aiter-do-mi350x-1:
+    gpu_arch: MI350X
+    gpu_count: 1
+
+  linux-aiter-do-mi350x-2:
+    gpu_arch: MI350X
+    gpu_count: 2
+
+  linux-aiter-do-mi350x-4:
+    gpu_arch: MI350X
+    gpu_count: 4
+
+  linux-aiter-do-mi350x-8:
+    gpu_arch: MI350X
+    gpu_count: 8

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -224,6 +224,18 @@ jobs:
             env_vars: ""
             accuracy_test_threshold: 0.90
             runner: linux-atom-mi35x-4
+          # Verified on MI355X 2026-05-30: vllm serve TP8 (atom-dev:vllm-latest,
+          # aiter ef114b0d4) -> gsm8k flexible-extract 0.9409, matching the
+          # amd/Kimi-K2.5-MXFP4 reference baseline. Default OOT serve args
+          # (async-scheduling, fastsafetensors, FULL_AND_PIECEWISE cudagraph,
+          # kv-cache fp8, no prefix caching) match the verified config.
+          - display_name: "Kimi-K2.5-MXFP4 TP8"
+            model_name: "Kimi-K2.5-MXFP4"
+            model_path: "amd/Kimi-K2.5-MXFP4"
+            extra_args: "--tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384"
+            env_vars: "AITER_QUICK_REDUCE_QUANTIZATION=INT4"
+            accuracy_test_threshold: 0.92
+            runner: linux-aiter-do-mi350x-8
           - display_name: "Qwen3.5-35B-A3B-FP8 TP2"
             model_name: "Qwen3.5-35B-A3B-FP8"
             model_path: "Qwen/Qwen3.5-35B-A3B-FP8"


### PR DESCRIPTION
## What
Enables the **vLLM Kimi-K2.5-MXFP4 TP8 accuracy job** in CI on the new **`linux-aiter-do-mi350x-8`** runner, using a config verified end-to-end on real hardware.

## Verification (the basis for this PR)
Ran on **MI355X (gfx950)**, 2026-05-30, image `rocm/atom-dev:vllm-latest` (vllm `0.19.1.dev0+g2a69949bd`, **aiter `ef114b0d4`**), `vllm serve` TP8:

- Sanity: "The capital of China is" → " Beijing. Beijing is a municipality directly under the central government of China..."
- **gsm8k 3-shot flexible-extract: 0.9409** (strict-match 0.9386) — lands exactly on the `amd/Kimi-K2.5-MXFP4` reference baseline, well above the 0.92 threshold
- Perf (TP8, ISL/OSL 1024/1024): c=4 → 473.6 tok/s @ TPOT 8.30 ms ... c=64 → 3557 tok/s @ TPOT 17.36 ms (ahead of dashboard reference)

The default OOT serve args in `.github/scripts/atom_oot_test.sh` (`--async-scheduling --load-format fastsafetensors --compilation-config FULL_AND_PIECEWISE --kv-cache-dtype fp8 --no-enable-prefix-caching`) are identical to the verified recipe, so the matrix entry only carries TP size + capacity flags + the quick-allreduce env.

## Changes
1. **`atom-vllm-test.yaml`** — add `Kimi-K2.5-MXFP4 TP8` to the PR-gating accuracy matrix on `linux-aiter-do-mi350x-8` (threshold 0.92).
2. **`oot_models_accuracy.json`** — point the nightly Kimi-K2.5 entry at the same runner, refresh `accuracy_baseline` to the verified **0.9409**, add the verified `extraArgs` / `env_vars`.
3. **`runner-config.yml`** — document the `linux-aiter-do-mi350x-{1,2,4,8}` pool (gpu_arch MI350X) for the devops dashboard.

## Notes for reviewers
- TP8 chosen because that's what was verified; the 4-GPU runner (`linux-aiter-do-mi350x-4`) is available too if you prefer a TP4 gate.
- The `linux-aiter-do-mi350x-8` runner must have `amd/Kimi-K2.5-MXFP4` available under `/models` (the model is 521 GB; CI download is impractical). Please confirm the mount/pre-cache on that pool.
- Scope is **Kimi-K2.5 only** (the variant verified). Kimi-K2-Thinking is left on its existing runner — its weights weren't on the test node, so it wasn't verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
