### PR TITLE
[atom-vllm-benchmark] Debug name 'AW_P0' is not defined

### DIFF
--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1168,7 +1168,7 @@ jobs:
                       continue
                   if pair in excluded_pairs:
                       continue
-                  if str(model.get("display", "")) in AWS_P0 and int(param["concurrency"]) in (128, 256, 512):
+                  if is_aws_p0_model and int(param["concurrency"]) in (128, 256, 512):
                       continue
                   include.append({"model": model, "params": param})
 


### PR DESCRIPTION
This PR to resolve the error as below:
<img width="487" height="174" alt="image" src="https://github.com/user-attachments/assets/05bc5200-f13c-40ec-b93c-c506da590a2f" />
