### PR TITLE
ci(accuracy): set Qwen3.5-35B-A3B TP2 baseline to 0.85

### DIFF
--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -237,9 +237,9 @@
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "nightly",
     "accuracy_threshold": 0.83,
-    "accuracy_baseline": null,
+    "accuracy_baseline": 0.85,
     "accuracy_baseline_model": "Qwen/Qwen3.5-35B-A3B",
-    "_baseline_note": "Threshold referenced from the sglang nightly entry for the same model; refresh after first CI measurement."
+    "_baseline_note": "Mean of first 4 valid CI runs (0.8226 / 0.8529 / 0.8620 / 0.8628). Threshold 0.83 from sglang nightly retained."
   },
   {
     "model_name": "Qwen3.5-397B-A17B-FP8",

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -230,16 +230,16 @@
     "_baseline_note": "CI uses 3-shot, not comparable to HF 5-shot baseline"
   },
   {
-    "model_name": "Qwen3.5-397B-A17B",
-    "model_path": "Qwen/Qwen3.5-397B-A17B",
-    "extraArgs": "--kv_cache_dtype fp8 -tp 8",
+    "model_name": "Qwen3.5-35B-A3B TP2",
+    "model_path": "Qwen/Qwen3.5-35B-A3B",
+    "extraArgs": "--kv_cache_dtype fp8 -tp 2",
     "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "nightly",
-    "accuracy_threshold": 0.85,
-    "accuracy_baseline": 0.9538,
-    "accuracy_baseline_model": "Qwen3.5-397B-A17B-FP8",
-    "_baseline_note": "BF16 weight, TP8. Placeholder threshold/baseline copied from FP8 entry; refresh after first CI measurement."
+    "accuracy_threshold": 0.83,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "Qwen/Qwen3.5-35B-A3B",
+    "_baseline_note": "Threshold referenced from the sglang nightly entry for the same model; refresh after first CI measurement."
   },
   {
     "model_name": "Qwen3.5-397B-A17B-FP8",


### PR DESCRIPTION
## Summary
Follow-up to #893. `accuracy_baseline` was left `null` pending first CI measurement.

Mean of first 4 valid nightly runs after #893 merged: **0.85** (0.8226 / 0.8529 / 0.8620 / 0.8628). Threshold 0.83 unchanged.

## Test plan
- [ ] Next nightly run reports baseline 0.85 in dashboard