### PR TITLE
ci(accuracy): set Qwen3.5-35B-A3B TP2 baseline to 0.85

### DIFF
--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -237,9 +237,9 @@
     "runner": "atom-mi355-8gpu.predownload",
     "test_level": "nightly",
     "accuracy_threshold": 0.83,
-    "accuracy_baseline": null,
+    "accuracy_baseline": 0.85,
     "accuracy_baseline_model": "Qwen/Qwen3.5-35B-A3B",
-    "_baseline_note": "Threshold referenced from the sglang nightly entry for the same model; refresh after first CI measurement."
+    "_baseline_note": "Mean of first 4 valid CI runs (0.8226 / 0.8529 / 0.8620 / 0.8628). Threshold 0.83 from sglang nightly retained."
   },
   {
     "model_name": "Qwen3.5-397B-A17B-FP8",


### PR DESCRIPTION
## Summary
Follow-up to #893. `accuracy_baseline` was left `null` pending first CI measurement.

Mean of first 4 valid nightly runs after #893 merged: **0.85** (0.8226 / 0.8529 / 0.8620 / 0.8628). Threshold 0.83 unchanged.

## Test plan
- [ ] Next nightly run reports baseline 0.85 in dashboard