### PR TITLE
[kv_transfer] Add LMCache KV offload connector for ATOM

### DIFF
--- a/atom/kv_transfer/disaggregation/aggregator.py
+++ b/atom/kv_transfer/disaggregation/aggregator.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 
-from atom.kv_transfer.disaggregation.types import KVConnectorOutput
+from atom.kv_transfer.disaggregation.types import KVConnectorOutput, ReqId
 
 logger = logging.getLogger("atom")
 
@@ -48,8 +48,10 @@ class KVOutputAggregator:
         if world_size <= 0:
             raise ValueError(f"world_size must be positive, got {world_size}")
         self._world_size = world_size
-        self._seen_sending: dict[str, set[int]] = {}
-        self._seen_recving: dict[str, set[int]] = {}
+        self._seen_sending: dict[ReqId, set[int]] = {}
+        self._seen_recving: dict[ReqId, set[int]] = {}
+        self._seen_recv_failed: dict[ReqId, set[int]] = {}
+        self._seen_saving: dict[ReqId, set[int]] = {}
 
     @property
     def world_size(self) -> int:
@@ -76,15 +78,33 @@ class KVOutputAggregator:
             if wo.finished_recving:
                 for rid in wo.finished_recving:
                     self._seen_recving.setdefault(rid, set()).add(worker_idx)
+            if wo.failed_recving:
+                for rid in wo.failed_recving:
+                    self._seen_recv_failed.setdefault(rid, set()).add(worker_idx)
+            if wo.finished_saving:
+                for rid in wo.finished_saving:
+                    self._seen_saving.setdefault(rid, set()).add(worker_idx)
 
         done_sending = {
             rid
             for rid, workers in self._seen_sending.items()
             if len(workers) >= self._world_size
         }
+        failed_recving = set()
+        recv_ids = set(self._seen_recving) | set(self._seen_recv_failed)
+        for rid in recv_ids:
+            done_workers = self._seen_recving.get(rid, set())
+            failed_workers = self._seen_recv_failed.get(rid, set())
+            if failed_workers and len(done_workers | failed_workers) >= self._world_size:
+                failed_recving.add(rid)
         done_recving = {
             rid
             for rid, workers in self._seen_recving.items()
+            if len(workers) >= self._world_size and rid not in failed_recving
+        }
+        done_saving = {
+            rid
+            for rid, workers in self._seen_saving.items()
             if len(workers) >= self._world_size
         }
 
@@ -92,18 +112,32 @@ class KVOutputAggregator:
             del self._seen_sending[rid]
         for rid in done_recving:
             del self._seen_recving[rid]
+            self._seen_recv_failed.pop(rid, None)
+        for rid in failed_recving:
+            self._seen_recving.pop(rid, None)
+            self._seen_recv_failed.pop(rid, None)
+        for rid in done_saving:
+            del self._seen_saving[rid]
 
         return KVConnectorOutput(
             finished_sending=done_sending,
             finished_recving=done_recving,
+            failed_recving=failed_recving,
+            finished_saving=done_saving,
         )
 
     def reset(self) -> None:
         """Clear all internal tracking state."""
         self._seen_sending.clear()
         self._seen_recving.clear()
+        self._seen_recv_failed.clear()
+        self._seen_saving.clear()
 
     @property
     def pending_count(self) -> tuple[int, int]:
         """Return ``(num_pending_sending, num_pending_recving)``."""
-        return len(self._seen_sending), len(self._seen_recving)
+        return (
+            len(self._seen_sending),
+            len(set(self._seen_recving) | set(self._seen_recv_failed))
+            + len(self._seen_saving),
+        )

--- a/atom/kv_transfer/disaggregation/aggregator.py
+++ b/atom/kv_transfer/disaggregation/aggregator.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 
 from atom.kv_transfer.disaggregation.types import KVConnectorOutput, ReqId
+from atom.kv_transfer.offload.trace import offload_trace
 
 logger = logging.getLogger("atom")
 
@@ -78,9 +79,23 @@ class KVOutputAggregator:
             if wo.finished_recving:
                 for rid in wo.finished_recving:
                     self._seen_recving.setdefault(rid, set()).add(worker_idx)
+                    offload_trace(
+                        "aggregator_worker_recv_done",
+                        worker=worker_idx,
+                        req=rid,
+                        seen=len(self._seen_recving[rid]),
+                        world=self._world_size,
+                    )
             if wo.failed_recving:
                 for rid in wo.failed_recving:
                     self._seen_recv_failed.setdefault(rid, set()).add(worker_idx)
+                    offload_trace(
+                        "aggregator_worker_recv_failed",
+                        worker=worker_idx,
+                        req=rid,
+                        seen=len(self._seen_recv_failed[rid]),
+                        world=self._world_size,
+                    )
             if wo.finished_saving:
                 for rid in wo.finished_saving:
                     self._seen_saving.setdefault(rid, set()).add(worker_idx)
@@ -118,6 +133,14 @@ class KVOutputAggregator:
             self._seen_recv_failed.pop(rid, None)
         for rid in done_saving:
             del self._seen_saving[rid]
+
+        if done_recving or failed_recving or done_saving:
+            offload_trace(
+                "aggregator_done",
+                recv=sorted(done_recving),
+                failed=sorted(failed_recving),
+                saving=sorted(done_saving),
+            )
 
         return KVConnectorOutput(
             finished_sending=done_sending,

--- a/atom/kv_transfer/disaggregation/base.py
+++ b/atom/kv_transfer/disaggregation/base.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from atom.kv_transfer.disaggregation.types import ConnectorMetadata
+from atom.kv_transfer.disaggregation.types import ConnectorMetadata, KVConnectorOutput
 
 
 class KVConnectorBase(ABC):
@@ -48,8 +48,11 @@ class KVConnectorBase(ABC):
         ...
 
     @abstractmethod
-    def get_finished(self) -> tuple[set, set]:
-        """Return ``(done_sending, done_recving)`` request ID sets.
+    def get_finished(self) -> tuple[set, set] | KVConnectorOutput:
+        """Return transfer completion status.
+
+        Older connectors may return ``(done_sending, done_recving)``. Connectors
+        that need richer semantics can return :class:`KVConnectorOutput`.
 
         Called by the worker each engine step to report transfer status.
         """

--- a/atom/kv_transfer/disaggregation/factory.py
+++ b/atom/kv_transfer/disaggregation/factory.py
@@ -134,3 +134,12 @@ KVConnectorFactory.register(
     scheduler_module="atom.kv_transfer.disaggregation.mooncake.mooncake_connector",
     scheduler_class="MooncakeConnectorScheduler",
 )
+
+
+# ATOM standalone CPU/NVMe KV offload backend (registers "lmcache_offload").
+# Import is lightweight (offload/__init__ only records module paths as strings;
+# the connector module is imported lazily by create_connector when selected).
+try:
+    import atom.kv_transfer.offload  # noqa: F401,E402
+except Exception as _e:  # pragma: no cover - offload optional (needs lmcache)
+    logger.debug("lmcache_offload backend not registered: %s", _e)

--- a/atom/kv_transfer/disaggregation/types.py
+++ b/atom/kv_transfer/disaggregation/types.py
@@ -19,7 +19,7 @@ from typing import Any, Callable
 # ---------------------------------------------------------------------------
 
 EngineId = str
-ReqId = str
+ReqId = str | int
 TransferId = int
 
 # ---------------------------------------------------------------------------
@@ -59,22 +59,33 @@ class KVConnectorOutput:
     Attributes:
         finished_sending: Request IDs whose KV send completed on this worker.
         finished_recving: Request IDs whose KV receive completed on this worker.
+        failed_recving: Request IDs whose KV receive failed on this worker.
+        finished_saving: Request IDs whose local fire-and-forget save completed.
         expected_finished_count: How many finished notifications should be
             expected per request (used by the aggregator).
     """
 
-    finished_sending: set[str] = field(default_factory=set)
-    finished_recving: set[str] = field(default_factory=set)
+    finished_sending: set[ReqId] = field(default_factory=set)
+    finished_recving: set[ReqId] = field(default_factory=set)
+    failed_recving: set[ReqId] = field(default_factory=set)
+    finished_saving: set[ReqId] = field(default_factory=set)
     expected_finished_count: int = 0
 
     def is_empty(self) -> bool:
         """Return True if no transfers finished on this worker."""
-        return not self.finished_sending and not self.finished_recving
+        return (
+            not self.finished_sending
+            and not self.finished_recving
+            and not self.failed_recving
+            and not self.finished_saving
+        )
 
     def __repr__(self) -> str:
         return (
             f"KVConnectorOutput(sending={self.finished_sending}, "
-            f"recving={self.finished_recving})"
+            f"recving={self.finished_recving}, "
+            f"failed_recving={self.failed_recving}, "
+            f"finished_saving={self.finished_saving})"
         )
 
 

--- a/atom/kv_transfer/offload/__init__.py
+++ b/atom/kv_transfer/offload/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""ATOM standalone LMCache CPU/NVMe KV-offload connector.
+
+Registers the ``lmcache_offload`` backend with the shared KV connector factory.
+Enable via ``--kv-transfer-config '{"kv_connector":"lmcache_offload","kv_role":"offload"}'``
+plus LMCache env (``LMCACHE_LOCAL_CPU=True``, ``LMCACHE_MAX_LOCAL_CPU_SIZE``,
+``LMCACHE_CHUNK_SIZE=256``, optional ``LMCACHE_LOCAL_DISK`` for the NVMe L3 tier).
+"""
+
+from atom.kv_transfer.disaggregation.factory import KVConnectorFactory
+
+KVConnectorFactory.register(
+    "lmcache_offload",
+    worker_module="atom.kv_transfer.offload.connector",
+    worker_class="LMCacheOffloadConnector",
+    scheduler_module="atom.kv_transfer.offload.connector",
+    scheduler_class="LMCacheOffloadConnectorScheduler",
+)

--- a/atom/kv_transfer/offload/config.py
+++ b/atom/kv_transfer/offload/config.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Build the per-rank ``LMCacheEngineConfig`` + ``LMCacheMetadata`` for the
+ATOM standalone offload connector.
+
+LMCache is driven by ``LMCACHE_*`` env vars (``LMCACHE_LOCAL_CPU``,
+``LMCACHE_MAX_LOCAL_CPU_SIZE``, ``LMCACHE_CHUNK_SIZE``, ``LMCACHE_LOCAL_DISK``,
+``LMCACHE_MAX_LOCAL_DISK_SIZE`` …) exactly like the vLLM recipe. We additionally
+allow overrides via ``kv_transfer_config`` extras keyed ``lmcache.<field>`` and
+force ``use_gds=False`` (cufile GDS init hangs without NVMe-GDS hardware).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+
+
+def build_lmcache_config():
+    """Return an ``LMCacheEngineConfig`` from ``LMCACHE_*`` env + extras."""
+    from lmcache.v1.config import LMCacheEngineConfig
+
+    cfg = LMCacheEngineConfig.from_env()
+    # cufile GDS has no NVMe-GDS hardware here and hangs on init; force off.
+    if getattr(cfg, "use_gds", False):
+        try:
+            cfg.use_gds = False
+        except Exception:
+            pass
+    # TP>1 fix: only rank 0 serves/answers the ZMQ lookup. Without this the
+    # client queries all ranks and takes min() over results; we observed rank!=0
+    # engine.lookup returning 0 even though that rank stored the chunk
+    # (contains()=True) -> min(0, hit)=0 -> the scheduler never sees the hit and
+    # always recomputes. Our connector saves on ALL ranks in lockstep, so rank 0
+    # is authoritative for "is it offloaded?"; each rank still loads its own KV
+    # shard, and _do_load is all-or-nothing (re-prefills if a shard is missing).
+    try:
+        cfg.lookup_server_worker_ids = [0]
+    except Exception:
+        pass
+    return cfg
+
+
+def apply_extra_overrides(cfg, kv_transfer_config: dict[str, Any] | None) -> None:
+    """Apply ``{"lmcache.<field>": value}`` extras from kv_transfer_config."""
+    if not kv_transfer_config:
+        return
+    extra = kv_transfer_config.get("kv_connector_extra_config", kv_transfer_config)
+    for key, value in (extra or {}).items():
+        if isinstance(key, str) and key.startswith("lmcache."):
+            field = key[len("lmcache.") :]
+            if hasattr(cfg, field):
+                try:
+                    setattr(cfg, field, value)
+                except Exception:
+                    pass
+
+
+def build_lmcache_metadata(config, cfg, world_size: int, worker_id: int):
+    """Build ``LMCacheMetadata`` for this rank from ATOM ``config`` + LMCache cfg.
+
+    ``kv_shape`` follows LMCache's ``(num_layers, 2, chunk_size, num_kv_heads,
+    head_dim)`` convention. For our opaque BINARY-style storage the exact dims
+    are only used for key/shape bookkeeping (we override the byte layout in the
+    codec), but we fill them faithfully from hf_config so logging/keys are sane.
+    """
+    from aiter import dtypes
+    from lmcache.v1.metadata import LMCacheMetadata
+
+    hf = config.hf_config
+    num_layers = int(getattr(hf, "num_hidden_layers"))
+    num_kv_heads = int(getattr(hf, "num_key_value_heads", getattr(hf, "num_attention_heads")))
+    tp = int(getattr(config, "tensor_parallel_size", world_size) or 1)
+    num_kv_heads_local = max(1, num_kv_heads // tp)
+    head_dim = int(getattr(hf, "head_dim", 0) or (hf.hidden_size // hf.num_attention_heads))
+    kv_dtype = dtypes.d_dtypes[config.kv_cache_dtype]
+    model_name = str(getattr(config, "model", "atom-model"))
+
+    return LMCacheMetadata(
+        model_name=model_name,
+        world_size=world_size,
+        local_world_size=world_size,
+        worker_id=worker_id,
+        local_worker_id=worker_id,
+        kv_dtype=kv_dtype,
+        kv_shape=(num_layers, 2, int(cfg.chunk_size), num_kv_heads_local, head_dim),
+        use_mla=False,
+        chunk_size=int(cfg.chunk_size),
+        # Shared id so the scheduler's ZMQ LookupClient and each worker's
+        # LookupServer derive the SAME ipc socket path (get_zmq_rpc_path_lmcache).
+        engine_id="atom-offload",
+    )

--- a/atom/kv_transfer/offload/connector.py
+++ b/atom/kv_transfer/offload/connector.py
@@ -7,9 +7,11 @@ Design (see ../../../../PLAN_impl_lmcache_offload_v5.md + 005 LEARN notes):
 
 * **Reuse real LMCache as a storage tier only** — per-rank ``LMCacheEngine`` for its
   ``StorageManager`` (CPU LRU + NVMe L3) + ``ChunkedTokenDatabase`` (chunk-256 keys).
-  We bypass ``engine.store/retrieve`` (token-major GPU path can't represent AITER's
-  swizzle) and instead move **opaque per-block bytes** via :class:`ATOMKVByteCodec`
-  into pinned ``KV_2LTD``-as-uint8 ``MemoryObj``s.
+  We bypass ``engine.store/retrieve`` (its token-major GPU path can't represent ATOM's
+  x-packed KV storage layout — ``K=(nb,H,D//x,bs,x)``, see ``ATOMKVByteCodec`` docstring;
+  loosely "swizzle", but a persistent storage layout, not LDS bank-swizzle) and instead
+  move **opaque per-block bytes** via :class:`ATOMKVByteCodec` into pinned
+  ``KV_2LTD``-as-uint8 ``MemoryObj``s.
 * **Daemon-after-forward copies** — ``start_load_kv`` only ``submit``s to a single
   serial copy daemon (ThreadPoolExecutor max_workers=1) and returns immediately, so
   the worker RPC thread is free for ``forward``; completions are polled in
@@ -24,6 +26,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 
 import torch
@@ -32,6 +35,7 @@ from atom.kv_transfer.disaggregation.base import (
     KVConnectorBase,
     KVConnectorSchedulerBase,
 )
+from atom.kv_transfer.disaggregation.types import KVConnectorOutput, ReqId
 from atom.kv_transfer.offload import config as offcfg
 from atom.kv_transfer.offload.gpu_connector import ATOMKVByteCodec
 from atom.kv_transfer.offload.metadata import (
@@ -103,8 +107,10 @@ class LMCacheOffloadConnector(KVConnectorBase):
         )
         self._tls = threading.local()  # per-thread copy stream
         self._lock = threading.Lock()
-        self._done_load: set[str] = set()
-        self._done_save: set[str] = set()
+        self._done_load: set[ReqId] = set()
+        self._done_save: set[ReqId] = set()
+        self._failed_load: set[ReqId] = set()
+        self._load_active = threading.Event()
 
         self._engine = None
         self._sm = None
@@ -142,9 +148,9 @@ class LMCacheOffloadConnector(KVConnectorBase):
         def _logged_lookup(*a, **k):
             r = _orig_lookup(*a, **k)
             h = k.get("hashes")
-            logger.info("[ENGINE.LOOKUP] rank=%s lookup_id=%s nhashes=%s first3=%s -> %s",
-                        _rk, k.get("lookup_id"), (len(h) if h is not None else None),
-                        (list(h[:3]) if h else None), r)
+            logger.debug("[ENGINE.LOOKUP] rank=%s lookup_id=%s nhashes=%s first3=%s -> %s",
+                         _rk, k.get("lookup_id"), (len(h) if h is not None else None),
+                         (list(h[:3]) if h else None), r)
             return r
         self._engine.lookup = _logged_lookup
 
@@ -158,8 +164,9 @@ class LMCacheOffloadConnector(KVConnectorBase):
             logger.warning("LMCache offload: lookup server not started: %s", e)
 
         logger.info(
-            "LMCache offload worker rank=%d: bytes_per_block=%d chunk=%d save=%s load=%s",
-            rank, self._codec.bytes_per_block, self.chunk_size,
+            "LMCache offload worker rank=%d: bytes_per_block=%d chunk=%d "
+            "codec_layout=%s save=%s load=%s",
+            rank, self._codec.bytes_per_block, self.chunk_size, self._codec.layout,
             self._do_save, self._do_load,
         )
 
@@ -169,21 +176,41 @@ class LMCacheOffloadConnector(KVConnectorBase):
             return
         for req in metadata.requests:
             if req.load_spec is not None and self._do_load:
-                self._load_executor.submit(self._guard, self._do_load_req, req)
+                self._load_executor.submit(self._guard, "load", self._do_load_req, req)
             if req.save_spec is not None and self._do_save:
-                self._save_executor.submit(self._guard, self._do_save_req, req)
+                self._save_executor.submit(self._guard, "save", self._do_save_req, req)
 
-    def _guard(self, fn, req) -> None:
+    def _guard(self, kind: str, fn, req) -> None:
+        load_active = getattr(self, "_load_active", None)
+        if kind == "load" and load_active is None:
+            load_active = threading.Event()
+            self._load_active = load_active
+        if kind == "load":
+            load_active.set()
         try:
             fn(req)
         except Exception:
             logger.exception("LMCache offload: %s failed for %s", fn.__name__, req.req_id)
-            # Wake the seq anyway so it is not stuck parked; scheduler re-derives
-            # how much is actually cached (load) / proceeds (save).
+            if kind == "load":
+                self._lookup_unpin(req.req_id)
             with self._lock:
-                (self._done_load if fn is self._do_load_req else self._done_save).add(
-                    req.req_id
-                )
+                if kind == "load":
+                    self._failed_load.add(req.req_id)
+                else:
+                    # A failed save should not keep blocks pinned forever. The
+                    # request simply loses this offload opportunity.
+                    self._done_save.add(req.req_id)
+        finally:
+            if kind == "load":
+                load_active.clear()
+
+    def _lookup_unpin(self, req_id) -> None:
+        if getattr(self, "_engine", None) is None:
+            return
+        try:
+            self._engine.lookup_unpin([str(req_id)])  # LMCache pin keyed by str id
+        except Exception:
+            pass
 
     def _stream(self) -> torch.cuda.Stream:
         """A CUDA stream owned by the calling copy-daemon thread (lazily made)."""
@@ -193,49 +220,194 @@ class LMCacheOffloadConnector(KVConnectorBase):
             self._tls.stream = s
         return s
 
+    def _host_tmp(self, nbytes: int) -> torch.Tensor:
+        """Pinned CPU scratch buffer owned by the calling copy-daemon thread."""
+        buf = getattr(self._tls, "host_tmp", None)
+        if buf is None or int(buf.numel()) < int(nbytes):
+            try:
+                buf = torch.empty((int(nbytes),), dtype=torch.uint8, pin_memory=True)
+            except RuntimeError:
+                logger.warning(
+                    "LMCache offload: pinned host scratch allocation failed; "
+                    "falling back to pageable CPU memory",
+                    exc_info=True,
+                )
+                buf = torch.empty((int(nbytes),), dtype=torch.uint8)
+            self._tls.host_tmp = buf
+        return buf[: int(nbytes)]
+
+    def _pause_save_for_load(self, stream: torch.cuda.Stream) -> None:
+        """Let critical-path loads drain before fire-and-forget save copies."""
+        load_active = getattr(self, "_load_active", None)
+        if load_active is None or not load_active.is_set():
+            return
+        stream.synchronize()
+        while load_active.is_set():
+            time.sleep(0.001)
+
     def _block_ids(self, req: LMCacheReqMeta, start: int, end: int) -> list[int]:
         return req.block_ids[start // self.block_size : _cdiv(end, self.block_size)]
+
+    def _profile_enabled(self) -> bool:
+        return os.environ.get("OFFLOAD_PROFILE", "1").lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
 
     # -- copy daemon thread ----------------------------------------------
     def _do_load_req(self, req: LMCacheReqMeta) -> None:
         ls = req.load_spec
         assert ls is not None
         stream = self._stream()
-        hbm = (ls.hbm_cached_tokens // self.chunk_size) * self.chunk_size
+        hbm = int(ls.hbm_cached_tokens)
         toks = req.token_ids[: ls.lmcache_cached_tokens]
+        t_total0 = time.perf_counter()
+        if int(ls.lmcache_cached_tokens) <= hbm:
+            self._lookup_unpin(req.req_id)
+            with self._lock:
+                self._done_load.add(req.req_id)
+            return
         mask = torch.ones(len(toks), dtype=torch.bool)
         mask[:hbm] = False
+        t0 = time.perf_counter()
         chunks = list(self._tdb.process_tokens(torch.tensor(toks), mask=mask))
+        process_ms = (time.perf_counter() - t0) * 1000
         logger.debug("offload _do_load req=%s hbm=%d lmc=%d chunks=%d",
                      req.req_id, hbm, ls.lmcache_cached_tokens, len(chunks))
 
-        # All-or-nothing: a partial load would let attention read uninitialized
-        # blocks. If any chunk is gone (evicted between lookup and load), skip the
-        # whole load — the seq wakes and re-prefills the suffix (loaded 0).
+        # All-or-nothing above the HBM prefix: a partial load would let attention
+        # read uninitialized blocks, and a chunk that overlaps an HBM-cache hit
+        # could overwrite shared prefix-cache blocks. In either case the seq
+        # wakes and re-prefills from its HBM floor.
+        if not chunks:
+            logger.warning("LMCache offload: no loadable chunks req=%s; re-prefill",
+                           req.req_id)
+            self._lookup_unpin(req.req_id)
+            with self._lock:
+                self._failed_load.add(req.req_id)
+            return
+        for (s, _e, _key) in chunks:
+            if s < hbm:
+                logger.warning(
+                    "LMCache offload: chunk overlaps HBM prefix req=%s hbm=%d "
+                    "chunk_start=%d; re-prefill",
+                    req.req_id, hbm, s,
+                )
+                self._lookup_unpin(req.req_id)
+                with self._lock:
+                    self._failed_load.add(req.req_id)
+                return
+        contains_ms = 0.0
         for (_s, _e, key) in chunks:
+            t0 = time.perf_counter()
             if not self._sm.contains(key):
+                contains_ms += (time.perf_counter() - t0) * 1000
                 logger.warning("LMCache offload: load miss req=%s; re-prefill", req.req_id)
+                self._lookup_unpin(req.req_id)
                 with self._lock:
-                    self._done_load.add(req.req_id)
+                    self._failed_load.add(req.req_id)
                 return
+            contains_ms += (time.perf_counter() - t0) * 1000
 
-        for (s, e, key) in chunks:
-            mo = self._sm.get(key)
-            if mo is None:
-                with self._lock:
-                    self._done_load.add(req.req_id)
-                return
-            self._codec.host_to_gpu(mo.tensor, self._block_ids(req, s, e), stream)
+        loaded_objs = []
+        get_ms = 0.0
+        host_alloc_ms = 0.0
+        stitch_ms = 0.0
+        h2d_submit_ms = 0.0
+        sync_ms = 0.0
+        nblocks = 0
+        nbytes = 0
+        copy_calls = 0
+        chunk_bids: list[list[int]] = []
+        try:
+            for (s, e, key) in chunks:
+                t0 = time.perf_counter()
+                mo = self._sm.get(key)
+                get_ms += (time.perf_counter() - t0) * 1000
+                if mo is None:
+                    t0 = time.perf_counter()
+                    stream.synchronize()
+                    sync_ms += (time.perf_counter() - t0) * 1000
+                    for loaded_mo in loaded_objs:
+                        loaded_mo.ref_count_down()
+                    self._lookup_unpin(req.req_id)
+                    with self._lock:
+                        self._failed_load.add(req.req_id)
+                    return
+                loaded_objs.append(mo)
+                bids = self._block_ids(req, s, e)
+                chunk_bids.append(bids)
+                nblocks += len(bids)
+                nbytes += len(bids) * self._codec.bytes_per_block
+                if self._codec.layout != "segment_indexed":
+                    copy_calls += self._codec.copy_calls_for_block_ids(bids)
+                    t0 = time.perf_counter()
+                    self._codec.host_to_gpu(mo.tensor, bids, stream)
+                    h2d_submit_ms += (time.perf_counter() - t0) * 1000
+            if self._codec.layout == "segment_indexed":
+                all_bids = [bid for bids in chunk_bids for bid in bids]
+                copy_calls = self._codec.copy_calls_for_block_ids(all_bids)
+                t0 = time.perf_counter()
+                req_buf = self._host_tmp(nbytes)
+                host_alloc_ms += (time.perf_counter() - t0) * 1000
+                t0 = time.perf_counter()
+                self._codec.stitch_chunk_buffers(
+                    req_buf,
+                    [mo.tensor for mo in loaded_objs],
+                    [len(bids) for bids in chunk_bids],
+                )
+                stitch_ms += (time.perf_counter() - t0) * 1000
+                t0 = time.perf_counter()
+                self._codec.host_to_gpu(req_buf, all_bids, stream)
+                h2d_submit_ms += (time.perf_counter() - t0) * 1000
+            t0 = time.perf_counter()
+            stream.synchronize()
+            sync_ms += (time.perf_counter() - t0) * 1000
+        except Exception:
+            try:
+                t0 = time.perf_counter()
+                stream.synchronize()
+                sync_ms += (time.perf_counter() - t0) * 1000
+            finally:
+                for loaded_mo in loaded_objs:
+                    loaded_mo.ref_count_down()
+                self._lookup_unpin(req.req_id)
+            raise
+        for mo in loaded_objs:
             mo.ref_count_down()
-        stream.synchronize()
         # Release the lookup pin (taken by the scheduler's LookupClient.lookup)
         # now that the chunks are safely in GPU; lets the pool evict them later.
-        try:
-            self._engine.lookup_unpin([str(req.req_id)])  # LMCache pin keyed by str id
-        except Exception:
-            pass
+        self._lookup_unpin(req.req_id)
         with self._lock:
             self._done_load.add(req.req_id)
+        if self._profile_enabled():
+            total_ms = (time.perf_counter() - t_total0) * 1000
+            logger.info(
+                "[OFFLOAD-LOAD-PROF] rank=%s req=%s hbm=%d lmc=%d "
+                "chunks=%d blocks=%d bytes=%.3fGiB copy_calls=%d "
+                "layout=%s process_ms=%.2f contains_ms=%.2f get_ms=%.2f "
+                "host_alloc_ms=%.2f stitch_ms=%.2f h2d_submit_ms=%.2f "
+                "sync_ms=%.2f total_ms=%.2f",
+                getattr(self, "_rank", "?"),
+                req.req_id,
+                hbm,
+                ls.lmcache_cached_tokens,
+                len(chunks),
+                nblocks,
+                nbytes / 1024**3,
+                copy_calls,
+                self._codec.layout,
+                process_ms,
+                contains_ms,
+                get_ms,
+                host_alloc_ms,
+                stitch_ms,
+                h2d_submit_ms,
+                sync_ms,
+                total_ms,
+            )
         logger.info("offload _do_load DONE req=%s", req.req_id)
 
     def _do_save_req(self, req: LMCacheReqMeta) -> None:
@@ -253,48 +425,122 @@ class LMCacheOffloadConnector(KVConnectorBase):
                 self._done_save.add(req.req_id)
             return
 
+        t_total0 = time.perf_counter()
         mask = torch.ones(len(toks), dtype=torch.bool)
         mask[:skip] = False
+        t0 = time.perf_counter()
         chunks = list(self._tdb.process_tokens(torch.tensor(toks), mask=mask))
+        process_ms = (time.perf_counter() - t0) * 1000
 
         keys, objs, already = [], [], 0
-        for (s, e, key) in chunks:
-            if self._sm.contains(key):  # already offloaded → skip wasted D2H
-                already += 1
-                continue
-            bids = self._block_ids(req, s, e)
-            nbytes = len(bids) * self._codec.bytes_per_block
-            mo = self._sm.allocate(torch.Size((nbytes,)), torch.uint8,
-                                   fmt=MemoryFormat.KV_2LTD)
-            if mo is None:  # pool under pressure; stop here
-                break
-            # D2H on this thread's dedicated copy stream (off the compute stream).
-            self._codec.gpu_to_host(mo.tensor, bids, stream)
-            keys.append(key)
-            objs.append(mo)
+        put_started = False
+        contains_ms = 0.0
+        alloc_ms = 0.0
+        d2h_submit_ms = 0.0
+        sync_ms = 0.0
+        put_ms = 0.0
+        nblocks = 0
+        total_nbytes = 0
+        copy_calls = 0
+        try:
+            for (s, e, key) in chunks:
+                self._pause_save_for_load(stream)
+                t0 = time.perf_counter()
+                if self._sm.contains(key):  # already offloaded → skip wasted D2H
+                    contains_ms += (time.perf_counter() - t0) * 1000
+                    already += 1
+                    continue
+                contains_ms += (time.perf_counter() - t0) * 1000
+                bids = self._block_ids(req, s, e)
+                chunk_nbytes = len(bids) * self._codec.bytes_per_block
+                t0 = time.perf_counter()
+                mo = self._sm.allocate(torch.Size((chunk_nbytes,)), torch.uint8,
+                                       fmt=MemoryFormat.KV_2LTD)
+                alloc_ms += (time.perf_counter() - t0) * 1000
+                if mo is None:  # pool under pressure; stop here
+                    break
+                keys.append(key)
+                objs.append(mo)
+                nblocks += len(bids)
+                total_nbytes += chunk_nbytes
+                copy_calls += self._codec.copy_calls_for_block_ids(bids)
+                # D2H on this thread's dedicated copy stream (off the compute stream).
+                t0 = time.perf_counter()
+                self._codec.gpu_to_host(mo.tensor, bids, stream)
+                d2h_submit_ms += (time.perf_counter() - t0) * 1000
 
-        if keys:
-            stream.synchronize()  # stream-specific
-            self._sm.batched_put(keys, objs)
+            if keys:
+                t0 = time.perf_counter()
+                stream.synchronize()  # stream-specific
+                sync_ms += (time.perf_counter() - t0) * 1000
+                put_started = True
+                t0 = time.perf_counter()
+                self._sm.batched_put(keys, objs)
+                put_ms += (time.perf_counter() - t0) * 1000
+        except Exception:
+            if not put_started:
+                try:
+                    t0 = time.perf_counter()
+                    stream.synchronize()
+                    sync_ms += (time.perf_counter() - t0) * 1000
+                finally:
+                    for mo in objs:
+                        mo.ref_count_down()
+            raise
         with self._lock:
             self._done_save.add(req.req_id)
-        _kh = [getattr(k, "chunk_hash", None) for k in keys[:2]]
-        _contains = [bool(self._sm.contains(k)) for k in keys[:2]]
-        logger.info("[OFFLOAD-SAVE] rank=%s req=%s toks=%d chunks=%d stored=%d already=%d "
-                    "chunkhash2=%s contains=%s",
-                    self._rank, req.req_id, len(toks), len(chunks), len(keys),
-                    already, _kh, _contains)
+        if self._profile_enabled():
+            total_ms = (time.perf_counter() - t_total0) * 1000
+            logger.info(
+                "[OFFLOAD-SAVE-PROF] rank=%s req=%s toks=%d chunks=%d "
+                "stored=%d already=%d blocks=%d bytes=%.3fGiB copy_calls=%d "
+                "layout=%s process_ms=%.2f contains_ms=%.2f alloc_ms=%.2f "
+                "d2h_submit_ms=%.2f sync_ms=%.2f put_ms=%.2f total_ms=%.2f",
+                getattr(self, "_rank", "?"),
+                req.req_id,
+                len(toks),
+                len(chunks),
+                len(keys),
+                already,
+                nblocks,
+                total_nbytes / 1024**3,
+                copy_calls,
+                self._codec.layout,
+                process_ms,
+                contains_ms,
+                alloc_ms,
+                d2h_submit_ms,
+                sync_ms,
+                put_ms,
+                total_ms,
+            )
+        if logger.isEnabledFor(logging.DEBUG):
+            _kh = [getattr(k, "chunk_hash", None) for k in keys[:2]]
+            _contains = [bool(self._sm.contains(k)) for k in keys[:2]]
+            logger.debug("[OFFLOAD-SAVE] rank=%s req=%s toks=%d chunks=%d stored=%d already=%d "
+                         "chunkhash2=%s contains=%s",
+                         self._rank, req.req_id, len(toks), len(chunks), len(keys),
+                         already, _kh, _contains)
 
     # -- per-step (RPC thread, post-forward): poll completions ------------
-    def get_finished(self) -> tuple[set, set]:
-        # (finished_sending, finished_recving). Offload SAVES are fire-and-forget
-        # (they don't free blocks), so finished_sending is ALWAYS empty; only
-        # completed LOADS are reported, to wake parked seqs for suffix prefill.
+    def get_finished(self) -> KVConnectorOutput:
+        # Offload uses extended completion states:
+        # - finished_recving wakes successfully loaded requests.
+        # - failed_recving wakes them for recompute using already allocated blocks.
+        # - finished_saving releases blocks whose free was deferred during save.
         with self._lock:
             dl = set(self._done_load)
+            fl = set(self._failed_load)
+            ds = set(self._done_save)
             self._done_save.clear()
             self._done_load.clear()
-        return set(), dl
+            self._failed_load.clear()
+        return KVConnectorOutput(
+            finished_sending=set(),
+            finished_recving=dl,
+            failed_recving=fl,
+            finished_saving=ds,
+        )
 
     def get_finished_recv_blocks(self) -> list[int]:
         # Local CUDA copies are ordered by the copy stream + synchronize() before
@@ -329,6 +575,7 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
         # prefix is stored to LMCache once prefill computes it
         # (seq.prefix_hashes_published flips True), chunk by chunk.
         self._save_tracker: dict[str, list] = {}
+        self._save_inflight: set[str] = set()
         self._lookup_in_step: list[str] = []
 
         try:
@@ -353,27 +600,35 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
         except Exception:
             logger.exception("LMCache offload lookup failed for seq %s", seq.id)
             return 0, False
-        _lh = None
-        try:
-            tdb = getattr(self._lookup_client, "token_database", None)
-            if tdb is not None:
-                _lh = [k for (_s, _e, k) in list(
-                    tdb.process_tokens(token_ids, make_key=False))[:3]]
-        except Exception as e:
-            _lh = f"err:{e}"
-        logger.info("[OFFLOAD-LOOKUP] seq=%s num_prompt=%d hbm_cached=%d hit=%s lookuphash3=%s",
-                    seq.id, num_prompt, int(seq.num_cached_tokens), hit, _lh)
+        if logger.isEnabledFor(logging.DEBUG):
+            _lh = None
+            try:
+                tdb = getattr(self._lookup_client, "token_database", None)
+                if tdb is not None:
+                    _lh = [k for (_s, _e, k) in list(
+                        tdb.process_tokens(token_ids, make_key=False))[:3]]
+            except Exception as e:
+                _lh = f"err:{e}"
+            logger.debug("[OFFLOAD-LOOKUP] seq=%s num_prompt=%d hbm_cached=%d hit=%s lookuphash3=%s",
+                         seq.id, num_prompt, int(seq.num_cached_tokens), hit, _lh)
         if not hit:
             return 0, False
-        self._lookup_in_step.append(str(seq.id))
-        need = int(hit) - int(seq.num_cached_tokens)
-        if int(hit) == num_prompt:  # full-prompt hit → recompute last token
-            need -= 1
+        sid = str(seq.id)
+        hit = int(hit)
+        if hit == num_prompt:  # full-prompt hit → recompute last token
+            hit -= 1
+        need = hit - int(seq.num_cached_tokens)
         if need <= 0:
+            if self._lookup_client is not None:
+                try:
+                    self._lookup_client.clear_lookup_status(sid)
+                except Exception:
+                    pass
             return 0, False
-        self._load_specs[str(seq.id)] = LoadSpec(
+        self._lookup_in_step.append(sid)
+        self._load_specs[sid] = LoadSpec(
             hbm_cached_tokens=int(seq.num_cached_tokens),
-            lmcache_cached_tokens=int(hit),
+            lmcache_cached_tokens=hit,
             can_load=False,
         )
         return need, True  # True => park in WAITING_FOR_REMOTE_KVS
@@ -381,8 +636,8 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
     def update_state_after_alloc(self, seq) -> None:
         sid = str(seq.id)
         ls = self._load_specs.get(sid)
-        logger.info("[OFFLOAD-ALLOC] seq=%s ls_found=%s num_cached_now=%s",
-                    seq.id, ls is not None, int(getattr(seq, "num_cached_tokens", -1)))
+        logger.debug("[OFFLOAD-ALLOC] seq=%s ls_found=%s num_cached_now=%s",
+                     seq.id, ls is not None, int(getattr(seq, "num_cached_tokens", -1)))
         if ls is not None:
             ls.can_load = True
             self._reqs_need_recv[sid] = seq
@@ -397,12 +652,12 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
         self._lookup_in_step = []
 
         # Loads
-        logger.info("[OFFLOAD-BUILD] reqs_need_recv=%d", len(self._reqs_need_recv))
+        logger.debug("[OFFLOAD-BUILD] reqs_need_recv=%d", len(self._reqs_need_recv))
         for sid, seq in self._reqs_need_recv.items():
             ls = self._load_specs.pop(sid, None)
             if ls is None or not ls.can_load:
-                logger.info("[OFFLOAD-LOAD-SKIP] seq=%s ls=%s can_load=%s",
-                            sid, ls is not None, getattr(ls, "can_load", None))
+                logger.debug("[OFFLOAD-LOAD-SKIP] seq=%s ls=%s can_load=%s",
+                             sid, ls is not None, getattr(ls, "can_load", None))
                 continue
             # ★ Use the REAL HBM-cached count as the load floor.
             # get_num_new_matched_tokens runs BEFORE the prefix-cache match in
@@ -442,8 +697,8 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
             aligned = (int(seq.num_prompt_tokens) // chunk) * chunk
             if aligned <= saved:
                 continue
-            logger.info("[OFFLOAD-SAVE-EMIT] seq=%s num_prompt=%d aligned=%d saved=%d",
-                        seq.id, int(seq.num_prompt_tokens), aligned, saved)
+            logger.debug("[OFFLOAD-SAVE-EMIT] seq=%s num_prompt=%d aligned=%d saved=%d",
+                         seq.id, int(seq.num_prompt_tokens), aligned, saved)
             meta.add_request(LMCacheReqMeta(
                 req_id=seq.id,
                 token_ids=list(seq.token_ids[:aligned]),
@@ -451,8 +706,19 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
                 save_spec=SaveSpec(skip_leading_tokens=saved, can_save=True),
             ))
             entry[1] = aligned
+            self._save_inflight.add(sid)
         self._reqs_need_recv.clear()
         return meta
+
+    def should_defer_free(self, seq) -> bool:
+        return str(seq.id) in self._save_inflight
+
+    def save_finished(self, req_id) -> None:
+        self._save_inflight.discard(str(req_id))
+
+    def load_failed(self, req_id) -> None:
+        self._load_specs.pop(str(req_id), None)
+        self._reqs_need_recv.pop(str(req_id), None)
 
     def request_finished(self, seq) -> None:
         sid = str(seq.id)

--- a/atom/kv_transfer/offload/connector.py
+++ b/atom/kv_transfer/offload/connector.py
@@ -44,6 +44,7 @@ from atom.kv_transfer.offload.metadata import (
     LoadSpec,
     SaveSpec,
 )
+from atom.kv_transfer.offload.trace import offload_trace
 
 logger = logging.getLogger("atom")
 
@@ -111,6 +112,9 @@ class LMCacheOffloadConnector(KVConnectorBase):
         self._done_save: set[ReqId] = set()
         self._failed_load: set[ReqId] = set()
         self._load_active = threading.Event()
+        self._request_fastpath = os.environ.get(
+            "OFFLOAD_REQUEST_FASTPATH", "1"
+        ).lower() not in ("0", "false", "no", "off")
 
         self._engine = None
         self._sm = None
@@ -176,8 +180,24 @@ class LMCacheOffloadConnector(KVConnectorBase):
             return
         for req in metadata.requests:
             if req.load_spec is not None and self._do_load:
+                offload_trace(
+                    "worker_load_enqueue",
+                    rank=getattr(self, "_rank", "?"),
+                    req=req.req_id,
+                    hbm=req.load_spec.hbm_cached_tokens,
+                    lmc=req.load_spec.lmcache_cached_tokens,
+                    blocks=len(req.block_ids),
+                )
                 self._load_executor.submit(self._guard, "load", self._do_load_req, req)
             if req.save_spec is not None and self._do_save:
+                offload_trace(
+                    "worker_save_enqueue",
+                    rank=getattr(self, "_rank", "?"),
+                    req=req.req_id,
+                    skip=req.save_spec.skip_leading_tokens,
+                    toks=len(req.token_ids),
+                    blocks=len(req.block_ids),
+                )
                 self._save_executor.submit(self._guard, "save", self._do_save_req, req)
 
     def _guard(self, kind: str, fn, req) -> None:
@@ -212,12 +232,32 @@ class LMCacheOffloadConnector(KVConnectorBase):
         except Exception:
             pass
 
+    def _copy_device(self) -> torch.device | None:
+        codec = getattr(self, "_codec", None)
+        device = getattr(codec, "device", None)
+        if device is None:
+            return None
+        device = torch.device(device)
+        if device.type != "cuda":
+            return None
+        return device
+
     def _stream(self) -> torch.cuda.Stream:
-        """A CUDA stream owned by the calling copy-daemon thread (lazily made)."""
-        s = getattr(self._tls, "stream", None)
+        """A CUDA stream owned by the calling copy-daemon thread and device."""
+        device = self._copy_device()
+        key = str(device) if device is not None else "default"
+        streams = getattr(self._tls, "streams", None)
+        if streams is None:
+            streams = {}
+            self._tls.streams = streams
+        s = streams.get(key)
         if s is None:
-            s = torch.cuda.Stream()
-            self._tls.stream = s
+            if device is None:
+                s = torch.cuda.Stream()
+            else:
+                with torch.cuda.device(device):
+                    s = torch.cuda.Stream()
+            streams[key] = s
         return s
 
     def _host_tmp(self, nbytes: int) -> torch.Tensor:
@@ -256,19 +296,90 @@ class LMCacheOffloadConnector(KVConnectorBase):
             "off",
         )
 
+    def _request_fastpath_enabled(self) -> bool:
+        return (
+            bool(getattr(self, "_request_fastpath", False))
+            and self._codec is not None
+            and self._codec.layout == "segment_indexed"
+        )
+
+    def _request_level_key(self, chunks, token_count: int):
+        """Synthetic key for a whole-prefix segment-major object.
+
+        The normal LMCache chunk keys remain authoritative for lookup. This key
+        is an optional per-rank fast path for exact full-prefix reloads: it uses
+        the last chunk's prefix hash plus tags, so it cannot collide with normal
+        chunk entries and stays stable across scheduler/worker processes.
+        """
+        if not chunks:
+            return None
+        key = chunks[-1][2]
+        request_configs = dict(getattr(key, "request_configs", None) or {})
+        request_configs["lmcache.tag.atom_offload"] = "request"
+        request_configs["lmcache.tag.atom_offload_tokens"] = str(int(token_count))
+        request_configs["lmcache.tag.atom_offload_layout"] = str(
+            getattr(self._codec, "layout", "unknown")
+        )
+        return key.__class__(
+            model_name=key.model_name,
+            world_size=key.world_size,
+            worker_id=key.worker_id,
+            chunk_hash=key.chunk_hash,
+            dtype=key.dtype,
+            request_configs=request_configs,
+        )
+
     # -- copy daemon thread ----------------------------------------------
     def _do_load_req(self, req: LMCacheReqMeta) -> None:
         ls = req.load_spec
         assert ls is not None
-        stream = self._stream()
         hbm = int(ls.hbm_cached_tokens)
         toks = req.token_ids[: ls.lmcache_cached_tokens]
         t_total0 = time.perf_counter()
+        offload_trace(
+            "worker_load_start",
+            rank=getattr(self, "_rank", "?"),
+            req=req.req_id,
+            hbm=hbm,
+            lmc=ls.lmcache_cached_tokens,
+            toks=len(toks),
+            blocks=len(req.block_ids),
+        )
         if int(ls.lmcache_cached_tokens) <= hbm:
             self._lookup_unpin(req.req_id)
             with self._lock:
                 self._done_load.add(req.req_id)
+            offload_trace(
+                "worker_load_done",
+                rank=getattr(self, "_rank", "?"),
+                req=req.req_id,
+                status="hbm_only",
+                total_ms=f"{(time.perf_counter() - t_total0) * 1000:.2f}",
+            )
             return
+        chunk_size = int(self.chunk_size or 256)
+        if hbm % chunk_size != 0:
+            logger.warning(
+                "LMCache offload: HBM prefix is not chunk-aligned req=%s "
+                "hbm=%d chunk=%d; re-prefill",
+                req.req_id,
+                hbm,
+                chunk_size,
+            )
+            self._lookup_unpin(req.req_id)
+            with self._lock:
+                self._failed_load.add(req.req_id)
+            offload_trace(
+                "worker_load_done",
+                rank=getattr(self, "_rank", "?"),
+                req=req.req_id,
+                status="unaligned_hbm",
+                hbm=hbm,
+                chunk=chunk_size,
+                total_ms=f"{(time.perf_counter() - t_total0) * 1000:.2f}",
+            )
+            return
+        stream = self._stream()
         mask = torch.ones(len(toks), dtype=torch.bool)
         mask[:hbm] = False
         t0 = time.perf_counter()
@@ -287,6 +398,13 @@ class LMCacheOffloadConnector(KVConnectorBase):
             self._lookup_unpin(req.req_id)
             with self._lock:
                 self._failed_load.add(req.req_id)
+            offload_trace(
+                "worker_load_done",
+                rank=getattr(self, "_rank", "?"),
+                req=req.req_id,
+                status="no_chunks",
+                total_ms=f"{(time.perf_counter() - t_total0) * 1000:.2f}",
+            )
             return
         for (s, _e, _key) in chunks:
             if s < hbm:
@@ -298,19 +416,17 @@ class LMCacheOffloadConnector(KVConnectorBase):
                 self._lookup_unpin(req.req_id)
                 with self._lock:
                     self._failed_load.add(req.req_id)
+                offload_trace(
+                    "worker_load_done",
+                    rank=getattr(self, "_rank", "?"),
+                    req=req.req_id,
+                    status="overlap_hbm",
+                    hbm=hbm,
+                    chunk_start=s,
+                    total_ms=f"{(time.perf_counter() - t_total0) * 1000:.2f}",
+                )
                 return
         contains_ms = 0.0
-        for (_s, _e, key) in chunks:
-            t0 = time.perf_counter()
-            if not self._sm.contains(key):
-                contains_ms += (time.perf_counter() - t0) * 1000
-                logger.warning("LMCache offload: load miss req=%s; re-prefill", req.req_id)
-                self._lookup_unpin(req.req_id)
-                with self._lock:
-                    self._failed_load.add(req.req_id)
-                return
-            contains_ms += (time.perf_counter() - t0) * 1000
-
         loaded_objs = []
         get_ms = 0.0
         host_alloc_ms = 0.0
@@ -320,7 +436,102 @@ class LMCacheOffloadConnector(KVConnectorBase):
         nblocks = 0
         nbytes = 0
         copy_calls = 0
-        chunk_bids: list[list[int]] = []
+        chunk_bids: list[list[int]] = [
+            self._block_ids(req, s, e) for (s, e, _key) in chunks
+        ]
+        all_bids = [bid for bids in chunk_bids for bid in bids]
+        nblocks = len(all_bids)
+        nbytes = nblocks * self._codec.bytes_per_block
+
+        request_key = None
+        if hbm == 0 and self._request_fastpath_enabled():
+            request_key = self._request_level_key(chunks, len(toks))
+        if request_key is not None:
+            req_mo = None
+            t0 = time.perf_counter()
+            request_location = self._sm.contains(request_key)
+            contains_ms += (time.perf_counter() - t0) * 1000
+            if request_location:
+                try:
+                    t0 = time.perf_counter()
+                    req_mo = self._sm.get(request_key)
+                    get_ms += (time.perf_counter() - t0) * 1000
+                    if req_mo is not None:
+                        copy_calls = self._codec.copy_calls_for_block_ids(all_bids)
+                        t0 = time.perf_counter()
+                        self._codec.host_to_gpu(req_mo.tensor, all_bids, stream)
+                        h2d_submit_ms += (time.perf_counter() - t0) * 1000
+                        t0 = time.perf_counter()
+                        stream.synchronize()
+                        sync_ms += (time.perf_counter() - t0) * 1000
+                        self._lookup_unpin(req.req_id)
+                        with self._lock:
+                            self._done_load.add(req.req_id)
+                        total_ms = (time.perf_counter() - t_total0) * 1000
+                        offload_trace(
+                            "worker_load_done",
+                            rank=getattr(self, "_rank", "?"),
+                            req=req.req_id,
+                            status="ok_request",
+                            chunks=len(chunks),
+                            blocks=nblocks,
+                            bytes_gib=f"{nbytes / 1024**3:.3f}",
+                            stitch_ms=f"{stitch_ms:.2f}",
+                            h2d_submit_ms=f"{h2d_submit_ms:.2f}",
+                            sync_ms=f"{sync_ms:.2f}",
+                            total_ms=f"{total_ms:.2f}",
+                        )
+                        if self._profile_enabled():
+                            logger.info(
+                                "[OFFLOAD-LOAD-PROF] rank=%s req=%s hbm=%d lmc=%d "
+                                "chunks=%d blocks=%d bytes=%.3fGiB copy_calls=%d "
+                                "layout=%s fastpath=request process_ms=%.2f "
+                                "contains_ms=%.2f get_ms=%.2f host_alloc_ms=%.2f "
+                                "stitch_ms=%.2f h2d_submit_ms=%.2f sync_ms=%.2f "
+                                "total_ms=%.2f",
+                                getattr(self, "_rank", "?"),
+                                req.req_id,
+                                hbm,
+                                ls.lmcache_cached_tokens,
+                                len(chunks),
+                                nblocks,
+                                nbytes / 1024**3,
+                                copy_calls,
+                                self._codec.layout,
+                                process_ms,
+                                contains_ms,
+                                get_ms,
+                                host_alloc_ms,
+                                stitch_ms,
+                                h2d_submit_ms,
+                                sync_ms,
+                                total_ms,
+                            )
+                        logger.info("offload _do_load DONE req=%s", req.req_id)
+                        return
+                finally:
+                    if req_mo is not None:
+                        req_mo.ref_count_down()
+
+        for (_s, _e, key) in chunks:
+            t0 = time.perf_counter()
+            if not self._sm.contains(key):
+                contains_ms += (time.perf_counter() - t0) * 1000
+                logger.warning("LMCache offload: load miss req=%s; re-prefill", req.req_id)
+                self._lookup_unpin(req.req_id)
+                with self._lock:
+                    self._failed_load.add(req.req_id)
+                offload_trace(
+                    "worker_load_done",
+                    rank=getattr(self, "_rank", "?"),
+                    req=req.req_id,
+                    status="miss",
+                    chunks=len(chunks),
+                    total_ms=f"{(time.perf_counter() - t_total0) * 1000:.2f}",
+                )
+                return
+            contains_ms += (time.perf_counter() - t0) * 1000
+
         try:
             for (s, e, key) in chunks:
                 t0 = time.perf_counter()
@@ -335,19 +546,23 @@ class LMCacheOffloadConnector(KVConnectorBase):
                     self._lookup_unpin(req.req_id)
                     with self._lock:
                         self._failed_load.add(req.req_id)
+                    offload_trace(
+                        "worker_load_done",
+                        rank=getattr(self, "_rank", "?"),
+                        req=req.req_id,
+                        status="get_none",
+                        chunks=len(chunks),
+                        total_ms=f"{(time.perf_counter() - t_total0) * 1000:.2f}",
+                    )
                     return
                 loaded_objs.append(mo)
-                bids = self._block_ids(req, s, e)
-                chunk_bids.append(bids)
-                nblocks += len(bids)
-                nbytes += len(bids) * self._codec.bytes_per_block
+                bids = chunk_bids[len(loaded_objs) - 1]
                 if self._codec.layout != "segment_indexed":
                     copy_calls += self._codec.copy_calls_for_block_ids(bids)
                     t0 = time.perf_counter()
                     self._codec.host_to_gpu(mo.tensor, bids, stream)
                     h2d_submit_ms += (time.perf_counter() - t0) * 1000
             if self._codec.layout == "segment_indexed":
-                all_bids = [bid for bids in chunk_bids for bid in bids]
                 copy_calls = self._codec.copy_calls_for_block_ids(all_bids)
                 t0 = time.perf_counter()
                 req_buf = self._host_tmp(nbytes)
@@ -382,14 +597,27 @@ class LMCacheOffloadConnector(KVConnectorBase):
         self._lookup_unpin(req.req_id)
         with self._lock:
             self._done_load.add(req.req_id)
+        total_ms = (time.perf_counter() - t_total0) * 1000
+        offload_trace(
+            "worker_load_done",
+            rank=getattr(self, "_rank", "?"),
+            req=req.req_id,
+            status="ok",
+            chunks=len(chunks),
+            blocks=nblocks,
+            bytes_gib=f"{nbytes / 1024**3:.3f}",
+            stitch_ms=f"{stitch_ms:.2f}",
+            h2d_submit_ms=f"{h2d_submit_ms:.2f}",
+            sync_ms=f"{sync_ms:.2f}",
+            total_ms=f"{total_ms:.2f}",
+        )
         if self._profile_enabled():
-            total_ms = (time.perf_counter() - t_total0) * 1000
             logger.info(
                 "[OFFLOAD-LOAD-PROF] rank=%s req=%s hbm=%d lmc=%d "
                 "chunks=%d blocks=%d bytes=%.3fGiB copy_calls=%d "
-                "layout=%s process_ms=%.2f contains_ms=%.2f get_ms=%.2f "
-                "host_alloc_ms=%.2f stitch_ms=%.2f h2d_submit_ms=%.2f "
-                "sync_ms=%.2f total_ms=%.2f",
+                "layout=%s fastpath=chunk process_ms=%.2f contains_ms=%.2f "
+                "get_ms=%.2f host_alloc_ms=%.2f stitch_ms=%.2f "
+                "h2d_submit_ms=%.2f sync_ms=%.2f total_ms=%.2f",
                 getattr(self, "_rank", "?"),
                 req.req_id,
                 hbm,
@@ -423,9 +651,24 @@ class LMCacheOffloadConnector(KVConnectorBase):
         if skip >= len(toks):
             with self._lock:
                 self._done_save.add(req.req_id)
+            offload_trace(
+                "worker_save_done",
+                rank=getattr(self, "_rank", "?"),
+                req=req.req_id,
+                status="skip",
+                toks=len(toks),
+            )
             return
 
         t_total0 = time.perf_counter()
+        offload_trace(
+            "worker_save_start",
+            rank=getattr(self, "_rank", "?"),
+            req=req.req_id,
+            skip=skip,
+            toks=len(toks),
+            blocks=len(req.block_ids),
+        )
         mask = torch.ones(len(toks), dtype=torch.bool)
         mask[:skip] = False
         t0 = time.perf_counter()
@@ -433,15 +676,30 @@ class LMCacheOffloadConnector(KVConnectorBase):
         process_ms = (time.perf_counter() - t0) * 1000
 
         keys, objs, already = [], [], 0
+        request_key = None
+        request_obj = None
+        request_fastpath = "off"
+        if skip == 0 and self._request_fastpath_enabled() and chunks:
+            request_key = self._request_level_key(chunks, len(toks))
+            request_fastpath = "miss"
+            t0 = time.perf_counter()
+            if self._sm.contains(request_key):
+                request_key = None
+                request_fastpath = "hit"
+            contains_ms = (time.perf_counter() - t0) * 1000
+        else:
+            contains_ms = 0.0
         put_started = False
-        contains_ms = 0.0
         alloc_ms = 0.0
+        host_alloc_ms = 0.0
         d2h_submit_ms = 0.0
         sync_ms = 0.0
+        split_ms = 0.0
         put_ms = 0.0
         nblocks = 0
         total_nbytes = 0
         copy_calls = 0
+        chunk_bids: list[list[int]] = []
         try:
             for (s, e, key) in chunks:
                 self._pause_save_for_load(stream)
@@ -461,21 +719,64 @@ class LMCacheOffloadConnector(KVConnectorBase):
                     break
                 keys.append(key)
                 objs.append(mo)
+                chunk_bids.append(bids)
                 nblocks += len(bids)
                 total_nbytes += chunk_nbytes
-                copy_calls += self._codec.copy_calls_for_block_ids(bids)
-                # D2H on this thread's dedicated copy stream (off the compute stream).
-                t0 = time.perf_counter()
-                self._codec.gpu_to_host(mo.tensor, bids, stream)
-                d2h_submit_ms += (time.perf_counter() - t0) * 1000
+                if self._codec.layout != "segment_indexed":
+                    copy_calls += self._codec.copy_calls_for_block_ids(bids)
+                    # D2H on this thread's dedicated copy stream (off compute stream).
+                    t0 = time.perf_counter()
+                    self._codec.gpu_to_host(mo.tensor, bids, stream)
+                    d2h_submit_ms += (time.perf_counter() - t0) * 1000
 
             if keys:
+                if self._codec.layout == "segment_indexed":
+                    all_bids = [bid for bids in chunk_bids for bid in bids]
+                    copy_calls = self._codec.copy_calls_for_block_ids(all_bids)
+                    if request_key is not None and len(keys) == len(chunks):
+                        t0 = time.perf_counter()
+                        request_obj = self._sm.allocate(
+                            torch.Size((total_nbytes,)),
+                            torch.uint8,
+                            fmt=MemoryFormat.KV_2LTD,
+                        )
+                        alloc_ms += (time.perf_counter() - t0) * 1000
+                        if request_obj is not None:
+                            req_buf = request_obj.tensor
+                            request_fastpath = "stored"
+                        else:
+                            request_key = None
+                            request_fastpath = "alloc_failed"
+                    else:
+                        request_key = None
+                        if request_fastpath == "miss":
+                            request_fastpath = "partial_skip"
+                    if request_obj is None:
+                        t0 = time.perf_counter()
+                        req_buf = self._host_tmp(total_nbytes)
+                        host_alloc_ms += (time.perf_counter() - t0) * 1000
+                    t0 = time.perf_counter()
+                    self._codec.gpu_to_host(req_buf, all_bids, stream)
+                    d2h_submit_ms += (time.perf_counter() - t0) * 1000
                 t0 = time.perf_counter()
                 stream.synchronize()  # stream-specific
                 sync_ms += (time.perf_counter() - t0) * 1000
+                if self._codec.layout == "segment_indexed":
+                    t0 = time.perf_counter()
+                    self._codec.split_request_buffer(
+                        req_buf,
+                        [mo.tensor for mo in objs],
+                        [len(bids) for bids in chunk_bids],
+                    )
+                    split_ms += (time.perf_counter() - t0) * 1000
                 put_started = True
                 t0 = time.perf_counter()
-                self._sm.batched_put(keys, objs)
+                put_keys = list(keys)
+                put_objs = list(objs)
+                if request_key is not None and request_obj is not None:
+                    put_keys.append(request_key)
+                    put_objs.append(request_obj)
+                self._sm.batched_put(put_keys, put_objs)
                 put_ms += (time.perf_counter() - t0) * 1000
         except Exception:
             if not put_started:
@@ -484,18 +785,39 @@ class LMCacheOffloadConnector(KVConnectorBase):
                     stream.synchronize()
                     sync_ms += (time.perf_counter() - t0) * 1000
                 finally:
-                    for mo in objs:
+                    cleanup_objs = list(objs)
+                    if request_obj is not None:
+                        cleanup_objs.append(request_obj)
+                    for mo in cleanup_objs:
                         mo.ref_count_down()
             raise
         with self._lock:
             self._done_save.add(req.req_id)
+        total_ms = (time.perf_counter() - t_total0) * 1000
+        offload_trace(
+            "worker_save_done",
+            rank=getattr(self, "_rank", "?"),
+            req=req.req_id,
+            status="ok",
+            toks=len(toks),
+            chunks=len(chunks),
+            stored=len(keys),
+            blocks=nblocks,
+            bytes_gib=f"{total_nbytes / 1024**3:.3f}",
+            d2h_submit_ms=f"{d2h_submit_ms:.2f}",
+            sync_ms=f"{sync_ms:.2f}",
+            split_ms=f"{split_ms:.2f}",
+            request_fastpath=request_fastpath,
+            total_ms=f"{total_ms:.2f}",
+        )
         if self._profile_enabled():
-            total_ms = (time.perf_counter() - t_total0) * 1000
             logger.info(
                 "[OFFLOAD-SAVE-PROF] rank=%s req=%s toks=%d chunks=%d "
                 "stored=%d already=%d blocks=%d bytes=%.3fGiB copy_calls=%d "
-                "layout=%s process_ms=%.2f contains_ms=%.2f alloc_ms=%.2f "
-                "d2h_submit_ms=%.2f sync_ms=%.2f put_ms=%.2f total_ms=%.2f",
+                "layout=%s request_fastpath=%s process_ms=%.2f "
+                "contains_ms=%.2f alloc_ms=%.2f host_alloc_ms=%.2f "
+                "d2h_submit_ms=%.2f sync_ms=%.2f split_ms=%.2f "
+                "put_ms=%.2f total_ms=%.2f",
                 getattr(self, "_rank", "?"),
                 req.req_id,
                 len(toks),
@@ -506,11 +828,14 @@ class LMCacheOffloadConnector(KVConnectorBase):
                 total_nbytes / 1024**3,
                 copy_calls,
                 self._codec.layout,
+                request_fastpath,
                 process_ms,
                 contains_ms,
                 alloc_ms,
+                host_alloc_ms,
                 d2h_submit_ms,
                 sync_ms,
+                split_ms,
                 put_ms,
                 total_ms,
             )
@@ -535,6 +860,14 @@ class LMCacheOffloadConnector(KVConnectorBase):
             self._done_save.clear()
             self._done_load.clear()
             self._failed_load.clear()
+        if dl or fl or ds:
+            offload_trace(
+                "worker_get_finished",
+                rank=getattr(self, "_rank", "?"),
+                done_load=sorted(dl),
+                failed_load=sorted(fl),
+                done_save=sorted(ds),
+            )
         return KVConnectorOutput(
             finished_sending=set(),
             finished_recving=dl,
@@ -595,11 +928,25 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
             return 0, False
         num_prompt = seq.num_prompt_tokens
         token_ids = list(seq.token_ids[:num_prompt])
+        offload_trace(
+            "scheduler_lookup_start",
+            req=seq.id,
+            prompt=num_prompt,
+            hbm=seq.num_cached_tokens,
+        )
+        t_lookup0 = time.perf_counter()
         try:
             hit = self._lookup_client.lookup(token_ids, lookup_id=str(seq.id))
         except Exception:
             logger.exception("LMCache offload lookup failed for seq %s", seq.id)
+            offload_trace(
+                "scheduler_lookup_done",
+                req=seq.id,
+                status="exception",
+                lookup_ms=f"{(time.perf_counter() - t_lookup0) * 1000:.2f}",
+            )
             return 0, False
+        lookup_ms = (time.perf_counter() - t_lookup0) * 1000
         if logger.isEnabledFor(logging.DEBUG):
             _lh = None
             try:
@@ -612,6 +959,13 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
             logger.debug("[OFFLOAD-LOOKUP] seq=%s num_prompt=%d hbm_cached=%d hit=%s lookuphash3=%s",
                          seq.id, num_prompt, int(seq.num_cached_tokens), hit, _lh)
         if not hit:
+            offload_trace(
+                "scheduler_lookup_done",
+                req=seq.id,
+                status="miss",
+                hit=hit,
+                lookup_ms=f"{lookup_ms:.2f}",
+            )
             return 0, False
         sid = str(seq.id)
         hit = int(hit)
@@ -624,12 +978,29 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
                     self._lookup_client.clear_lookup_status(sid)
                 except Exception:
                     pass
+            offload_trace(
+                "scheduler_lookup_done",
+                req=seq.id,
+                status="hbm_satisfies",
+                hit=hit,
+                hbm=seq.num_cached_tokens,
+                lookup_ms=f"{lookup_ms:.2f}",
+            )
             return 0, False
         self._lookup_in_step.append(sid)
         self._load_specs[sid] = LoadSpec(
             hbm_cached_tokens=int(seq.num_cached_tokens),
             lmcache_cached_tokens=hit,
             can_load=False,
+        )
+        offload_trace(
+            "scheduler_lookup_done",
+            req=seq.id,
+            status="need_load",
+            hit=hit,
+            hbm=seq.num_cached_tokens,
+            need=need,
+            lookup_ms=f"{lookup_ms:.2f}",
         )
         return need, True  # True => park in WAITING_FOR_REMOTE_KVS
 
@@ -641,8 +1012,15 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
         if ls is not None:
             ls.can_load = True
             self._reqs_need_recv[sid] = seq
-        # Track for save; the prompt prefix is offloaded later, once prefill has
-        # actually computed it (checked via prefix_hashes_published in build).
+            offload_trace(
+                "scheduler_load_alloc_ready",
+                req=seq.id,
+                hbm=seq.num_cached_tokens,
+                lmc=ls.lmcache_cached_tokens,
+                blocks=len(seq.block_table),
+            )
+        # Track for save; build_connector_meta stores chunks once the scheduler's
+        # computed frontier (seq.num_cached_tokens) has advanced past them.
         if sid not in self._save_tracker:
             self._save_tracker[sid] = [seq, 0]
 
@@ -667,6 +1045,67 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
             # prefix-cache blocks (possibly shared with other seqs) -> output
             # corruption. So load only [hbm_cached, offload_hit).
             ls.hbm_cached_tokens = int(seq.num_cached_tokens)
+            if ls.hbm_cached_tokens >= int(ls.lmcache_cached_tokens):
+                seq.offload_loaded_tokens = int(seq.num_cached_tokens)
+                logger.info(
+                    "[OFFLOAD-LOAD-SKIP] seq=%s hbm_cached=%d lmc_cached=%d "
+                    "reason=hbm_satisfies_after_alloc",
+                    seq.id,
+                    ls.hbm_cached_tokens,
+                    ls.lmcache_cached_tokens,
+                )
+                offload_trace(
+                    "scheduler_load_hbm_satisfies_after_alloc",
+                    req=seq.id,
+                    hbm=ls.hbm_cached_tokens,
+                    lmc=ls.lmcache_cached_tokens,
+                    blocks=len(list(seq.block_table)),
+                )
+                # The request may already be parked in WAITING_FOR_REMOTE_KVS.
+                # Emit a no-op load so every worker reports finished_recving via
+                # the normal aggregation path instead of trying to complete it
+                # locally in the scheduler process.
+                meta.add_request(LMCacheReqMeta(
+                    req_id=seq.id,
+                    token_ids=list(seq.token_ids[: ls.lmcache_cached_tokens]),
+                    block_ids=list(seq.block_table),
+                    load_spec=ls,
+                ))
+                continue
+            chunk = self.chunk_size or 256
+            if ls.hbm_cached_tokens % chunk != 0:
+                seq.offload_loaded_tokens = int(seq.num_cached_tokens)
+                logger.info(
+                    "[OFFLOAD-LOAD-SKIP] seq=%s hbm_cached=%d lmc_cached=%d "
+                    "reason=unaligned_hbm chunk=%d",
+                    seq.id,
+                    ls.hbm_cached_tokens,
+                    ls.lmcache_cached_tokens,
+                    chunk,
+                )
+                offload_trace(
+                    "scheduler_load_unaligned_hbm",
+                    req=seq.id,
+                    hbm=ls.hbm_cached_tokens,
+                    lmc=ls.lmcache_cached_tokens,
+                    chunk=chunk,
+                    blocks=len(list(seq.block_table)),
+                )
+                # LMCache chunks can only be loaded from a chunk boundary. Do
+                # not round down and overwrite HBM prefix-cache blocks that may
+                # be shared with other requests; wake the parked request and let
+                # it continue prefill from the HBM floor.
+                meta.add_request(LMCacheReqMeta(
+                    req_id=seq.id,
+                    token_ids=list(seq.token_ids[: ls.hbm_cached_tokens]),
+                    block_ids=list(seq.block_table),
+                    load_spec=LoadSpec(
+                        hbm_cached_tokens=ls.hbm_cached_tokens,
+                        lmcache_cached_tokens=ls.hbm_cached_tokens,
+                        can_load=True,
+                    ),
+                ))
+                continue
             # num_cached after load = max(HBM, offload); never drop below HBM.
             seq.offload_loaded_tokens = max(
                 int(seq.num_cached_tokens), int(ls.lmcache_cached_tokens)
@@ -677,41 +1116,85 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
             logger.info("[OFFLOAD-LOAD-EMIT] seq=%s hbm_cached=%d lmc_cached=%d offload_loaded=%d nblocks=%d",
                         seq.id, ls.hbm_cached_tokens, ls.lmcache_cached_tokens,
                         seq.offload_loaded_tokens, len(list(seq.block_table)))
+            offload_trace(
+                "scheduler_load_emit",
+                req=seq.id,
+                hbm=ls.hbm_cached_tokens,
+                lmc=ls.lmcache_cached_tokens,
+                offload_loaded=seq.offload_loaded_tokens,
+                blocks=len(list(seq.block_table)),
+            )
             meta.add_request(LMCacheReqMeta(
                 req_id=seq.id,
                 token_ids=list(seq.token_ids[: ls.lmcache_cached_tokens]),
                 block_ids=list(seq.block_table),
                 load_spec=ls,
             ))
-        # Saves: store the prompt prefix once prefill has computed it. We detect
-        # "computed" via seq.prefix_hashes_published (set in postprocess after the
-        # prefill step), so the blocks we D2H are already written -- no race with
-        # forward. Persistent tracker: each chunk is stored once.
+        # Saves: store fully computed prompt chunks. Under scheduler-side
+        # chunked prefill, seq.num_cached_tokens advances after each prefill
+        # chunk's forward has completed; use it as the D2H-safe frontier.
         chunk = self.chunk_size or 256
         for sid, entry in self._save_tracker.items():
             seq, saved = entry
             if sid in self._reqs_need_recv:
                 continue  # loading this step; defer its save
-            if not getattr(seq, "prefix_hashes_published", False):
-                continue  # prefill not finished computing the prompt yet
-            aligned = (int(seq.num_prompt_tokens) // chunk) * chunk
+            if sid in self._save_inflight:
+                continue  # keep at most one save per request in flight
+            computed = min(
+                int(getattr(seq, "num_cached_tokens", 0)),
+                int(seq.num_prompt_tokens),
+            )
+            is_last_prefill = computed >= int(seq.num_prompt_tokens)
+            aligned = (computed // chunk) * chunk
             if aligned <= saved:
                 continue
-            logger.debug("[OFFLOAD-SAVE-EMIT] seq=%s num_prompt=%d aligned=%d saved=%d",
-                         seq.id, int(seq.num_prompt_tokens), aligned, saved)
+            logger.debug(
+                "[OFFLOAD-SAVE-EMIT] seq=%s computed=%d num_prompt=%d aligned=%d saved=%d",
+                seq.id,
+                computed,
+                int(seq.num_prompt_tokens),
+                aligned,
+                saved,
+            )
+            offload_trace(
+                "scheduler_save_emit",
+                req=seq.id,
+                prompt=seq.num_prompt_tokens,
+                computed=computed,
+                aligned=aligned,
+                saved=saved,
+                blocks=len(seq.block_table),
+            )
             meta.add_request(LMCacheReqMeta(
                 req_id=seq.id,
                 token_ids=list(seq.token_ids[:aligned]),
                 block_ids=list(seq.block_table),
                 save_spec=SaveSpec(skip_leading_tokens=saved, can_save=True),
+                is_last_prefill=is_last_prefill,
             ))
             entry[1] = aligned
             self._save_inflight.add(sid)
         self._reqs_need_recv.clear()
         return meta
 
+    def _save_frontier(self, seq) -> int:
+        chunk = self.chunk_size or 256
+        computed = min(
+            int(getattr(seq, "num_cached_tokens", 0)),
+            int(getattr(seq, "num_prompt_tokens", 0)),
+        )
+        return (computed // chunk) * chunk
+
+    def _has_pending_save(self, seq) -> bool:
+        sid = str(seq.id)
+        entry = self._save_tracker.get(sid)
+        if entry is None:
+            return False
+        return self._save_frontier(seq) > int(entry[1])
+
     def should_defer_free(self, seq) -> bool:
-        return str(seq.id) in self._save_inflight
+        sid = str(seq.id)
+        return sid in self._save_inflight or self._has_pending_save(seq)
 
     def save_finished(self, req_id) -> None:
         self._save_inflight.discard(str(req_id))
@@ -724,7 +1207,8 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
         sid = str(seq.id)
         self._load_specs.pop(sid, None)
         self._reqs_need_recv.pop(sid, None)
-        self._save_tracker.pop(sid, None)
+        if not self.should_defer_free(seq):
+            self._save_tracker.pop(sid, None)
         if self._lookup_client is not None:
             try:
                 self._lookup_client.clear_lookup_status(sid)

--- a/atom/kv_transfer/offload/connector.py
+++ b/atom/kv_transfer/offload/connector.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""ATOM standalone LMCache CPU/NVMe KV-offload connector.
+
+Design (see ../../../../PLAN_impl_lmcache_offload_v5.md + 005 LEARN notes):
+
+* **Reuse real LMCache as a storage tier only** — per-rank ``LMCacheEngine`` for its
+  ``StorageManager`` (CPU LRU + NVMe L3) + ``ChunkedTokenDatabase`` (chunk-256 keys).
+  We bypass ``engine.store/retrieve`` (token-major GPU path can't represent AITER's
+  swizzle) and instead move **opaque per-block bytes** via :class:`ATOMKVByteCodec`
+  into pinned ``KV_2LTD``-as-uint8 ``MemoryObj``s.
+* **Daemon-after-forward copies** — ``start_load_kv`` only ``submit``s to a single
+  serial copy daemon (ThreadPoolExecutor max_workers=1) and returns immediately, so
+  the worker RPC thread is free for ``forward``; completions are polled in
+  ``get_finished`` (called post-forward by ``async_proc_aggregation``). This is the
+  fix for 005's "load blocks/starves prefill" (corr(TTFT, prefill-conc)=0.773).
+* **Cross-process hit lookup** — scheduler (EngineCore process) queries worker hits
+  via LMCache's ZMQ ``LookupClient``/``LookupServer`` (no homegrown mirror).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import torch
+
+from atom.kv_transfer.disaggregation.base import (
+    KVConnectorBase,
+    KVConnectorSchedulerBase,
+)
+from atom.kv_transfer.offload import config as offcfg
+from atom.kv_transfer.offload.gpu_connector import ATOMKVByteCodec
+from atom.kv_transfer.offload.metadata import (
+    LMCacheOffloadMetadata,
+    LMCacheReqMeta,
+    LoadSpec,
+    SaveSpec,
+)
+
+logger = logging.getLogger("atom")
+
+
+def _cdiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+class _UnusedGPUConnector:
+    """Satisfies LMCacheEngineBuilder.get_or_create; never invoked (we do our own
+    byte-copy and never call engine.store/retrieve)."""
+
+    def to_gpu(self, *a, **k):
+        raise NotImplementedError
+
+    def from_gpu(self, *a, **k):
+        raise NotImplementedError
+
+    def batched_from_gpu(self, *a, **k):
+        raise NotImplementedError
+
+    def batched_to_gpu(self, *a, **k):
+        raise NotImplementedError
+
+    def get_shape(self, num_tokens):
+        return torch.Size((num_tokens,))
+
+
+# =====================================================================
+# Worker side
+# =====================================================================
+class LMCacheOffloadConnector(KVConnectorBase):
+    # Offload is a *consumer* from the scheduler's POV (it loads KV back). Saves
+    # are fire-and-forget on the worker and must NOT be reported as
+    # finished_sending (the scheduler frees blocks on finished_sending — a P/D
+    # producer semantic that would wrongly deallocate live offload blocks).
+    is_producer = False
+
+    def __init__(self, config) -> None:
+        self._config = config
+        kvc = getattr(config, "kv_transfer_config", {}) or {}
+        self.kv_role = kvc.get("kv_role", "offload")
+        self._do_save = self.kv_role in ("offload", "kv_both", "kv_producer")
+        self._do_load = self.kv_role in ("offload", "kv_both", "kv_consumer")
+        self.block_size = int(config.kv_cache_block_size)
+        self.chunk_size: int | None = None
+
+        # Copy daemons: keep GPU<->host copies off the RPC thread. SEPARATE
+        # executors for LOAD vs SAVE so a load (on the TTFT critical path — a
+        # parked seq is waiting for it) never queues behind a backlog of fire-
+        # and-forget saves (Phase 4 root cause: with one shared serial daemon, a
+        # reload sat behind ~N filler saves -> request hung well past timeout).
+        # Each worker thread gets its OWN CUDA stream (disjoint block_ids -> no
+        # write conflict). OFFLOAD_COPY_WORKERS tunes the SAVE pool only.
+        n_save_workers = int(os.environ.get("OFFLOAD_COPY_WORKERS", "1"))
+        self._load_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="lmc-offload-load"
+        )
+        self._save_executor = ThreadPoolExecutor(
+            max_workers=n_save_workers, thread_name_prefix="lmc-offload-save"
+        )
+        self._tls = threading.local()  # per-thread copy stream
+        self._lock = threading.Lock()
+        self._done_load: set[str] = set()
+        self._done_save: set[str] = set()
+
+        self._engine = None
+        self._sm = None
+        self._tdb = None
+        self._codec: ATOMKVByteCodec | None = None
+        self._lookup_server = None
+
+    # -- lifecycle --------------------------------------------------------
+    def register_kv_caches(self, kv_caches: dict, transfer_tensors=None) -> None:
+        from aiter.dist.parallel_state import get_tp_group
+        from lmcache.v1.cache_engine import LMCacheEngineBuilder
+
+        tp = get_tp_group()
+        rank, world = tp.rank_in_group, tp.world_size
+        self._rank = rank
+
+        cfg = offcfg.build_lmcache_config()
+        offcfg.apply_extra_overrides(cfg, getattr(self._config, "kv_transfer_config", None))
+        meta = offcfg.build_lmcache_metadata(self._config, cfg, world, rank)
+        self.chunk_size = int(cfg.chunk_size)
+
+        self._engine = LMCacheEngineBuilder.get_or_create(
+            f"atom-offload-{rank}", cfg, meta, _UnusedGPUConnector(),
+            lambda t, s: None, lambda o, s: o,
+        )
+        self._engine.post_init()
+        self._sm = self._engine.storage_manager
+        self._tdb = self._engine.token_database
+        self._codec = ATOMKVByteCodec(kv_caches)
+
+        # DEBUG: wrap engine.lookup to capture EVERY call (incl. the ones the ZMQ
+        # lookup_server makes on behalf of the scheduler) — args + result.
+        _orig_lookup = self._engine.lookup
+        _rk = rank
+        def _logged_lookup(*a, **k):
+            r = _orig_lookup(*a, **k)
+            h = k.get("hashes")
+            logger.info("[ENGINE.LOOKUP] rank=%s lookup_id=%s nhashes=%s first3=%s -> %s",
+                        _rk, k.get("lookup_id"), (len(h) if h is not None else None),
+                        (list(h[:3]) if h else None), r)
+            return r
+        self._engine.lookup = _logged_lookup
+
+        # ZMQ lookup server so the scheduler process can query our hit counts.
+        try:
+            from lmcache.v1.lookup_client.factory import LookupClientFactory
+            self._lookup_server = LookupClientFactory.create_lookup_server(
+                self._engine, meta
+            )
+        except Exception as e:  # lookup server optional for save-only smoke
+            logger.warning("LMCache offload: lookup server not started: %s", e)
+
+        logger.info(
+            "LMCache offload worker rank=%d: bytes_per_block=%d chunk=%d save=%s load=%s",
+            rank, self._codec.bytes_per_block, self.chunk_size,
+            self._do_save, self._do_load,
+        )
+
+    # -- per-step (RPC thread): only enqueue, never copy ------------------
+    def start_load_kv(self, metadata) -> None:
+        if not isinstance(metadata, LMCacheOffloadMetadata):
+            return
+        for req in metadata.requests:
+            if req.load_spec is not None and self._do_load:
+                self._load_executor.submit(self._guard, self._do_load_req, req)
+            if req.save_spec is not None and self._do_save:
+                self._save_executor.submit(self._guard, self._do_save_req, req)
+
+    def _guard(self, fn, req) -> None:
+        try:
+            fn(req)
+        except Exception:
+            logger.exception("LMCache offload: %s failed for %s", fn.__name__, req.req_id)
+            # Wake the seq anyway so it is not stuck parked; scheduler re-derives
+            # how much is actually cached (load) / proceeds (save).
+            with self._lock:
+                (self._done_load if fn is self._do_load_req else self._done_save).add(
+                    req.req_id
+                )
+
+    def _stream(self) -> torch.cuda.Stream:
+        """A CUDA stream owned by the calling copy-daemon thread (lazily made)."""
+        s = getattr(self._tls, "stream", None)
+        if s is None:
+            s = torch.cuda.Stream()
+            self._tls.stream = s
+        return s
+
+    def _block_ids(self, req: LMCacheReqMeta, start: int, end: int) -> list[int]:
+        return req.block_ids[start // self.block_size : _cdiv(end, self.block_size)]
+
+    # -- copy daemon thread ----------------------------------------------
+    def _do_load_req(self, req: LMCacheReqMeta) -> None:
+        ls = req.load_spec
+        assert ls is not None
+        stream = self._stream()
+        hbm = (ls.hbm_cached_tokens // self.chunk_size) * self.chunk_size
+        toks = req.token_ids[: ls.lmcache_cached_tokens]
+        mask = torch.ones(len(toks), dtype=torch.bool)
+        mask[:hbm] = False
+        chunks = list(self._tdb.process_tokens(torch.tensor(toks), mask=mask))
+        logger.debug("offload _do_load req=%s hbm=%d lmc=%d chunks=%d",
+                     req.req_id, hbm, ls.lmcache_cached_tokens, len(chunks))
+
+        # All-or-nothing: a partial load would let attention read uninitialized
+        # blocks. If any chunk is gone (evicted between lookup and load), skip the
+        # whole load — the seq wakes and re-prefills the suffix (loaded 0).
+        for (_s, _e, key) in chunks:
+            if not self._sm.contains(key):
+                logger.warning("LMCache offload: load miss req=%s; re-prefill", req.req_id)
+                with self._lock:
+                    self._done_load.add(req.req_id)
+                return
+
+        for (s, e, key) in chunks:
+            mo = self._sm.get(key)
+            if mo is None:
+                with self._lock:
+                    self._done_load.add(req.req_id)
+                return
+            self._codec.host_to_gpu(mo.tensor, self._block_ids(req, s, e), stream)
+            mo.ref_count_down()
+        stream.synchronize()
+        # Release the lookup pin (taken by the scheduler's LookupClient.lookup)
+        # now that the chunks are safely in GPU; lets the pool evict them later.
+        try:
+            self._engine.lookup_unpin([str(req.req_id)])  # LMCache pin keyed by str id
+        except Exception:
+            pass
+        with self._lock:
+            self._done_load.add(req.req_id)
+        logger.info("offload _do_load DONE req=%s", req.req_id)
+
+    def _do_save_req(self, req: LMCacheReqMeta) -> None:
+        from lmcache.v1.memory_management import MemoryFormat
+
+        ss = req.save_spec
+        assert ss is not None
+        stream = self._stream()
+        toks = req.token_ids
+        if not req.is_last_prefill:
+            toks = toks[: (len(toks) // self.chunk_size) * self.chunk_size]
+        skip = (ss.skip_leading_tokens // self.chunk_size) * self.chunk_size
+        if skip >= len(toks):
+            with self._lock:
+                self._done_save.add(req.req_id)
+            return
+
+        mask = torch.ones(len(toks), dtype=torch.bool)
+        mask[:skip] = False
+        chunks = list(self._tdb.process_tokens(torch.tensor(toks), mask=mask))
+
+        keys, objs, already = [], [], 0
+        for (s, e, key) in chunks:
+            if self._sm.contains(key):  # already offloaded → skip wasted D2H
+                already += 1
+                continue
+            bids = self._block_ids(req, s, e)
+            nbytes = len(bids) * self._codec.bytes_per_block
+            mo = self._sm.allocate(torch.Size((nbytes,)), torch.uint8,
+                                   fmt=MemoryFormat.KV_2LTD)
+            if mo is None:  # pool under pressure; stop here
+                break
+            # D2H on this thread's dedicated copy stream (off the compute stream).
+            self._codec.gpu_to_host(mo.tensor, bids, stream)
+            keys.append(key)
+            objs.append(mo)
+
+        if keys:
+            stream.synchronize()  # stream-specific
+            self._sm.batched_put(keys, objs)
+        with self._lock:
+            self._done_save.add(req.req_id)
+        _kh = [getattr(k, "chunk_hash", None) for k in keys[:2]]
+        _contains = [bool(self._sm.contains(k)) for k in keys[:2]]
+        logger.info("[OFFLOAD-SAVE] rank=%s req=%s toks=%d chunks=%d stored=%d already=%d "
+                    "chunkhash2=%s contains=%s",
+                    self._rank, req.req_id, len(toks), len(chunks), len(keys),
+                    already, _kh, _contains)
+
+    # -- per-step (RPC thread, post-forward): poll completions ------------
+    def get_finished(self) -> tuple[set, set]:
+        # (finished_sending, finished_recving). Offload SAVES are fire-and-forget
+        # (they don't free blocks), so finished_sending is ALWAYS empty; only
+        # completed LOADS are reported, to wake parked seqs for suffix prefill.
+        with self._lock:
+            dl = set(self._done_load)
+            self._done_save.clear()
+            self._done_load.clear()
+        return set(), dl
+
+    def get_finished_recv_blocks(self) -> list[int]:
+        # Local CUDA copies are ordered by the copy stream + synchronize() before
+        # we mark done; no RDMA-style GPU fence needed.
+        return []
+
+
+# =====================================================================
+# Scheduler side
+# =====================================================================
+class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
+    # Consumer semantics: finished_recving wakes parked seqs (the engine asserts
+    # `not is_producer` on that path). Offload never uses finished_sending.
+    is_producer = False
+    # Opt the scheduler into offload-wake (suffix prefill) instead of the P/D
+    # decode-jump in Scheduler.schedule(); see Scheduler._is_offload_connector.
+    is_offload = True
+
+    def __init__(self, config) -> None:
+        self._config = config
+        kvc = getattr(config, "kv_transfer_config", {}) or {}
+        self.kv_role = kvc.get("kv_role", "offload")
+        self.block_size = int(config.kv_cache_block_size)
+        self.chunk_size: int | None = None
+        self._lookup_client = None
+
+        # req_id -> LoadSpec (pending load decided at match time)
+        self._load_specs: dict[str, LoadSpec] = {}
+        # req_id -> Sequence (queued to recv this step)
+        self._reqs_need_recv: dict[str, object] = {}
+        # Persistent save tracker: sid -> [seq, saved_offset]. A seq's prompt
+        # prefix is stored to LMCache once prefill computes it
+        # (seq.prefix_hashes_published flips True), chunk by chunk.
+        self._save_tracker: dict[str, list] = {}
+        self._lookup_in_step: list[str] = []
+
+        try:
+            cfg = offcfg.build_lmcache_config()
+            offcfg.apply_extra_overrides(cfg, kvc)
+            self.chunk_size = int(cfg.chunk_size)
+            from lmcache.v1.lookup_client.factory import LookupClientFactory
+            world = int(getattr(config, "tensor_parallel_size", 1) or 1)
+            meta = offcfg.build_lmcache_metadata(config, cfg, world, 0)
+            self._lookup_client = LookupClientFactory.create_lookup_client(cfg, meta)
+        except Exception as e:
+            logger.warning("LMCache offload scheduler: lookup client unavailable: %s", e)
+
+    # -- match: how many extra tokens can come from CPU/NVMe -------------
+    def get_num_new_matched_tokens(self, seq) -> tuple[int, bool]:
+        if self._lookup_client is None:
+            return 0, False
+        num_prompt = seq.num_prompt_tokens
+        token_ids = list(seq.token_ids[:num_prompt])
+        try:
+            hit = self._lookup_client.lookup(token_ids, lookup_id=str(seq.id))
+        except Exception:
+            logger.exception("LMCache offload lookup failed for seq %s", seq.id)
+            return 0, False
+        _lh = None
+        try:
+            tdb = getattr(self._lookup_client, "token_database", None)
+            if tdb is not None:
+                _lh = [k for (_s, _e, k) in list(
+                    tdb.process_tokens(token_ids, make_key=False))[:3]]
+        except Exception as e:
+            _lh = f"err:{e}"
+        logger.info("[OFFLOAD-LOOKUP] seq=%s num_prompt=%d hbm_cached=%d hit=%s lookuphash3=%s",
+                    seq.id, num_prompt, int(seq.num_cached_tokens), hit, _lh)
+        if not hit:
+            return 0, False
+        self._lookup_in_step.append(str(seq.id))
+        need = int(hit) - int(seq.num_cached_tokens)
+        if int(hit) == num_prompt:  # full-prompt hit → recompute last token
+            need -= 1
+        if need <= 0:
+            return 0, False
+        self._load_specs[str(seq.id)] = LoadSpec(
+            hbm_cached_tokens=int(seq.num_cached_tokens),
+            lmcache_cached_tokens=int(hit),
+            can_load=False,
+        )
+        return need, True  # True => park in WAITING_FOR_REMOTE_KVS
+
+    def update_state_after_alloc(self, seq) -> None:
+        sid = str(seq.id)
+        ls = self._load_specs.get(sid)
+        logger.info("[OFFLOAD-ALLOC] seq=%s ls_found=%s num_cached_now=%s",
+                    seq.id, ls is not None, int(getattr(seq, "num_cached_tokens", -1)))
+        if ls is not None:
+            ls.can_load = True
+            self._reqs_need_recv[sid] = seq
+        # Track for save; the prompt prefix is offloaded later, once prefill has
+        # actually computed it (checked via prefix_hashes_published in build).
+        if sid not in self._save_tracker:
+            self._save_tracker[sid] = [seq, 0]
+
+    def build_connector_meta(self) -> LMCacheOffloadMetadata:
+        meta = LMCacheOffloadMetadata()
+        meta.lookup_requests_in_step = self._lookup_in_step
+        self._lookup_in_step = []
+
+        # Loads
+        logger.info("[OFFLOAD-BUILD] reqs_need_recv=%d", len(self._reqs_need_recv))
+        for sid, seq in self._reqs_need_recv.items():
+            ls = self._load_specs.pop(sid, None)
+            if ls is None or not ls.can_load:
+                logger.info("[OFFLOAD-LOAD-SKIP] seq=%s ls=%s can_load=%s",
+                            sid, ls is not None, getattr(ls, "can_load", None))
+                continue
+            # ★ Use the REAL HBM-cached count as the load floor.
+            # get_num_new_matched_tokens runs BEFORE the prefix-cache match in
+            # block_manager.allocate, so seq.num_cached_tokens was stale (often
+            # 0) when the LoadSpec was recorded. By now (post-allocate) it is the
+            # true HBM hit. Loading below this floor would overwrite HBM
+            # prefix-cache blocks (possibly shared with other seqs) -> output
+            # corruption. So load only [hbm_cached, offload_hit).
+            ls.hbm_cached_tokens = int(seq.num_cached_tokens)
+            # num_cached after load = max(HBM, offload); never drop below HBM.
+            seq.offload_loaded_tokens = max(
+                int(seq.num_cached_tokens), int(ls.lmcache_cached_tokens)
+            )
+            # req_id MUST be the raw seq.id (the type the scheduler compares
+            # against in _update_waiting_for_remote_kv); str(seq.id) is only for
+            # LMCache's lookup/pin API. A str here silently never wakes the seq.
+            logger.info("[OFFLOAD-LOAD-EMIT] seq=%s hbm_cached=%d lmc_cached=%d offload_loaded=%d nblocks=%d",
+                        seq.id, ls.hbm_cached_tokens, ls.lmcache_cached_tokens,
+                        seq.offload_loaded_tokens, len(list(seq.block_table)))
+            meta.add_request(LMCacheReqMeta(
+                req_id=seq.id,
+                token_ids=list(seq.token_ids[: ls.lmcache_cached_tokens]),
+                block_ids=list(seq.block_table),
+                load_spec=ls,
+            ))
+        # Saves: store the prompt prefix once prefill has computed it. We detect
+        # "computed" via seq.prefix_hashes_published (set in postprocess after the
+        # prefill step), so the blocks we D2H are already written -- no race with
+        # forward. Persistent tracker: each chunk is stored once.
+        chunk = self.chunk_size or 256
+        for sid, entry in self._save_tracker.items():
+            seq, saved = entry
+            if sid in self._reqs_need_recv:
+                continue  # loading this step; defer its save
+            if not getattr(seq, "prefix_hashes_published", False):
+                continue  # prefill not finished computing the prompt yet
+            aligned = (int(seq.num_prompt_tokens) // chunk) * chunk
+            if aligned <= saved:
+                continue
+            logger.info("[OFFLOAD-SAVE-EMIT] seq=%s num_prompt=%d aligned=%d saved=%d",
+                        seq.id, int(seq.num_prompt_tokens), aligned, saved)
+            meta.add_request(LMCacheReqMeta(
+                req_id=seq.id,
+                token_ids=list(seq.token_ids[:aligned]),
+                block_ids=list(seq.block_table),
+                save_spec=SaveSpec(skip_leading_tokens=saved, can_save=True),
+            ))
+            entry[1] = aligned
+        self._reqs_need_recv.clear()
+        return meta
+
+    def request_finished(self, seq) -> None:
+        sid = str(seq.id)
+        self._load_specs.pop(sid, None)
+        self._reqs_need_recv.pop(sid, None)
+        self._save_tracker.pop(sid, None)
+        if self._lookup_client is not None:
+            try:
+                self._lookup_client.clear_lookup_status(sid)
+            except Exception:
+                pass

--- a/atom/kv_transfer/offload/gpu_connector.py
+++ b/atom/kv_transfer/offload/gpu_connector.py
@@ -6,8 +6,13 @@ pinned host buffer (an LMCache ``MemoryObj``'s ``uint8`` tensor).
 
 Why a byte codec instead of an LMCache ``GPUConnectorInterface`` subclass:
 LMCache's ``engine.store/retrieve`` GPU path only emits token-major formats
-(``KV_2LTD`` etc.) via ``normalize_kv_and_discover_format``, which rejects
-AITER's swizzled K layout ``(nb, H, D//x, bs, x)`` and strided V ``(nb, H, D, bs)``.
+(``KV_2LTD`` etc.) via ``normalize_kv_and_discover_format``, which only accepts the
+clean NHD/HND family and rejects ATOM's **x-packed, head-major** K layout
+``(nb, H, D//x, bs, x)`` and strided V ``(nb, H, D, bs)`` (``x = 16 // elem``; verified
+``atom/model_ops/attentions/aiter_attention.py:488-502``). NB: this is a *persistent
+HBM storage layout*, NOT the transient LDS bank-conflict "swizzle"; we call it "swizzle"
+only as loose shorthand. It is also specific to this ATOM aiter path — stock vLLM's aiter
+FA backend (``rocm_aiter_fa``) uses the clean token-major ``(2,nb,bs,H,D)`` LMCache handles.
 We therefore bypass that path: we store **opaque per-block bytes** (byte-identical
 round-trip — the attention kernel reads back its own layout) and drive LMCache only
 as a storage tier (``StorageManager`` + ``ChunkedTokenDatabase``).
@@ -23,7 +28,13 @@ which is self-consistent for store and load (we never reinterpret it).
 
 from __future__ import annotations
 
+import logging
+import os
+import threading
+
 import torch
+
+logger = logging.getLogger("atom")
 
 
 class ATOMKVByteCodec:
@@ -61,6 +72,40 @@ class ATOMKVByteCodec:
             acc += nb
         self.bytes_per_block: int = acc
         self.num_blocks: int = int(self._segments[0].shape[0])
+        self.layout = os.environ.get("OFFLOAD_CODEC_LAYOUT", "block").lower()
+        if self.layout not in ("block", "segment", "segment_indexed"):
+            self.layout = "block"
+        self._tls = threading.local()
+        self._native_stitch = None
+        if (
+            self.layout == "segment_indexed"
+            and os.environ.get("OFFLOAD_NATIVE_STITCH", "0").lower()
+            not in ("0", "false", "no", "off")
+        ):
+            try:
+                from atom.kv_transfer.offload import native_stitch
+
+                native_stitch.load_extension()
+                self._native_stitch = native_stitch.stitch_chunk_buffers
+            except Exception:
+                logger.warning(
+                    "ATOMKVByteCodec: native stitch unavailable; using torch stitch",
+                    exc_info=True,
+                )
+
+    @property
+    def segments_per_block(self) -> int:
+        return len(self._segments)
+
+    def copy_calls_for_blocks(self, nblocks: int) -> int:
+        return int(nblocks) * len(self._segments)
+
+    def copy_calls_for_block_ids(self, block_ids: list[int]) -> int:
+        if self.layout == "block":
+            return self.copy_calls_for_blocks(len(block_ids))
+        if self.layout == "segment_indexed":
+            return len(self._segments) * 2
+        return len(self._segments) * len(list(self._contiguous_runs(block_ids)))
 
     # -- helpers ----------------------------------------------------------
     @staticmethod
@@ -73,6 +118,109 @@ class ATOMKVByteCodec:
             raise RuntimeError("ATOMKVByteCodec: block slice not contiguous")
         return blk.reshape(-1).view(torch.uint8)
 
+    @staticmethod
+    def _blocks_bytes_view(
+        seg: torch.Tensor,
+        block_id: int,
+        nblocks: int,
+    ) -> torch.Tensor:
+        """Flat ``uint8`` view of a contiguous block range (no copy)."""
+        blk = seg[block_id : block_id + nblocks]
+        if not blk.is_contiguous():
+            raise RuntimeError("ATOMKVByteCodec: block range not contiguous")
+        return blk.reshape(-1).view(torch.uint8)
+
+    @staticmethod
+    def _contiguous_runs(block_ids: list[int]):
+        """Yield ``(logical_start, physical_start, run_len)`` for increasing
+        physical block-id runs in logical order."""
+        if not block_ids:
+            return
+        logical_start = 0
+        physical_start = block_ids[0]
+        prev = block_ids[0]
+        run_len = 1
+        for logical_idx, bid in enumerate(block_ids[1:], start=1):
+            if bid == prev + 1:
+                prev = bid
+                run_len += 1
+                continue
+            yield logical_start, physical_start, run_len
+            logical_start = logical_idx
+            physical_start = bid
+            prev = bid
+            run_len = 1
+        yield logical_start, physical_start, run_len
+
+    def _segment_bases(self, nblocks: int) -> list[int]:
+        bases = []
+        acc = 0
+        for nb in self._seg_block_bytes:
+            bases.append(acc)
+            acc += nb * nblocks
+        return bases
+
+    def stitch_chunk_buffers(
+        self,
+        dst: torch.Tensor,
+        chunk_buffers: list[torch.Tensor],
+        chunk_block_counts: list[int],
+    ) -> None:
+        """CPU-side stitch from per-LMCache-chunk segment-major buffers into one
+        request-level segment-major buffer.
+
+        Each stored chunk is laid out as ``[seg0 chunk_blocks | seg1 ...]``. A
+        single request-level indexed H2D scatter expects
+        ``[seg0 all_blocks | seg1 all_blocks | ...]``.
+        """
+        if self._native_stitch is not None:
+            self._native_stitch(
+                dst,
+                chunk_buffers,
+                chunk_block_counts,
+                self._seg_block_bytes,
+            )
+            return
+        total_blocks = sum(chunk_block_counts)
+        dst_bases = self._segment_bases(total_blocks)
+        src_bases_by_chunk = [
+            self._segment_bases(nblocks) for nblocks in chunk_block_counts
+        ]
+        for seg_idx, (dst_base, nb) in enumerate(
+            zip(dst_bases, self._seg_block_bytes)
+        ):
+            parts = [
+                src[
+                    bases[seg_idx] : bases[seg_idx] + nblocks * nb
+                ]
+                for src, bases, nblocks in zip(
+                    chunk_buffers, src_bases_by_chunk, chunk_block_counts
+                )
+            ]
+            torch.cat(
+                parts,
+                out=dst[dst_base : dst_base + total_blocks * nb],
+            )
+
+    def _tmp_bytes(self, seg: torch.Tensor, nblocks: int) -> torch.Tensor:
+        elems = int(seg[0].numel()) * seg.element_size()
+        key = (str(seg.device), "uint8", elems, int(nblocks))
+        cache = getattr(self._tls, "tmp", None)
+        if cache is None:
+            cache = {}
+            self._tls.tmp = cache
+        tmp = cache.get(key)
+        if tmp is None:
+            tmp = torch.empty((nblocks, elems), dtype=torch.uint8, device=seg.device)
+            cache[key] = tmp
+        return tmp
+
+    @staticmethod
+    def _segment_bytes_matrix(seg: torch.Tensor) -> torch.Tensor:
+        if not seg.is_contiguous():
+            raise RuntimeError("ATOMKVByteCodec: segment tensor not contiguous")
+        return seg.reshape(seg.shape[0], -1).view(torch.uint8)
+
     # -- public API -------------------------------------------------------
     def gpu_to_host(
         self,
@@ -84,6 +232,36 @@ class ATOMKVByteCodec:
         pinned ``host_buf`` (uint8, length == len(block_ids) * bytes_per_block)."""
         ctx = torch.cuda.stream(stream) if stream is not None else _nullctx()
         with ctx:
+            if self.layout == "segment_indexed":
+                idx = torch.tensor(
+                    block_ids, dtype=torch.long, device=self._segments[0].device
+                )
+                bases = self._segment_bases(len(block_ids))
+                for seg, base, nb in zip(
+                    self._segments, bases, self._seg_block_bytes
+                ):
+                    mat = self._segment_bytes_matrix(seg)
+                    tmp = self._tmp_bytes(seg, len(block_ids))
+                    torch.index_select(mat, 0, idx, out=tmp)
+                    host_buf[base : base + len(block_ids) * nb].copy_(
+                        tmp.reshape(-1), non_blocking=True
+                    )
+                return
+
+            if self.layout == "segment":
+                bases = self._segment_bases(len(block_ids))
+                runs = list(self._contiguous_runs(block_ids))
+                for seg, base, nb in zip(
+                    self._segments, bases, self._seg_block_bytes
+                ):
+                    for logical_start, physical_start, run_len in runs:
+                        src = self._blocks_bytes_view(seg, physical_start, run_len)
+                        dst = base + logical_start * nb
+                        host_buf[dst : dst + run_len * nb].copy_(
+                            src, non_blocking=True
+                        )
+                return
+
             for i, bid in enumerate(block_ids):
                 base = i * self.bytes_per_block
                 for seg, off, nb in zip(
@@ -102,6 +280,38 @@ class ATOMKVByteCodec:
         cache at ``block_ids`` (in-place into the real KV tensors)."""
         ctx = torch.cuda.stream(stream) if stream is not None else _nullctx()
         with ctx:
+            if self.layout == "segment_indexed":
+                idx = torch.tensor(
+                    block_ids, dtype=torch.long, device=self._segments[0].device
+                )
+                bases = self._segment_bases(len(block_ids))
+                for seg, base, nb in zip(
+                    self._segments, bases, self._seg_block_bytes
+                ):
+                    mat = self._segment_bytes_matrix(seg)
+                    tmp = self._tmp_bytes(seg, len(block_ids))
+                    tmp.copy_(
+                        host_buf[base : base + len(block_ids) * nb].reshape_as(tmp),
+                        non_blocking=True,
+                    )
+                    mat.index_copy_(0, idx, tmp)
+                return
+
+            if self.layout == "segment":
+                bases = self._segment_bases(len(block_ids))
+                runs = list(self._contiguous_runs(block_ids))
+                for seg, base, nb in zip(
+                    self._segments, bases, self._seg_block_bytes
+                ):
+                    for logical_start, physical_start, run_len in runs:
+                        dst = self._blocks_bytes_view(seg, physical_start, run_len)
+                        src = base + logical_start * nb
+                        dst.copy_(
+                            host_buf[src : src + run_len * nb],
+                            non_blocking=True,
+                        )
+                return
+
             for i, bid in enumerate(block_ids):
                 base = i * self.bytes_per_block
                 for seg, off, nb in zip(

--- a/atom/kv_transfer/offload/gpu_connector.py
+++ b/atom/kv_transfer/offload/gpu_connector.py
@@ -29,6 +29,7 @@ which is self-consistent for store and load (we never reinterpret it).
 from __future__ import annotations
 
 import logging
+import operator
 import os
 import threading
 
@@ -60,6 +61,19 @@ class ATOMKVByteCodec:
         if not self._segments:
             raise ValueError("ATOMKVByteCodec: no movable KV tensors registered")
 
+        first = self._segments[0]
+        self.num_blocks: int = int(first.shape[0])
+        self._device = first.device
+        for seg in self._segments:
+            if seg.device != self._device:
+                raise ValueError(
+                    "ATOMKVByteCodec: all KV tensors must be on the same device"
+                )
+            if int(seg.shape[0]) != self.num_blocks:
+                raise ValueError(
+                    "ATOMKVByteCodec: all KV tensors must have the same block count"
+                )
+
         # Bytes for one block of each segment (block is dim 0).
         self._seg_block_bytes: list[int] = [
             int(t[0].numel()) * t.element_size() for t in self._segments
@@ -71,12 +85,12 @@ class ATOMKVByteCodec:
             self._seg_off.append(acc)
             acc += nb
         self.bytes_per_block: int = acc
-        self.num_blocks: int = int(self._segments[0].shape[0])
         self.layout = os.environ.get("OFFLOAD_CODEC_LAYOUT", "block").lower()
         if self.layout not in ("block", "segment", "segment_indexed"):
             self.layout = "block"
         self._tls = threading.local()
         self._native_stitch = None
+        self._native_split = None
         if (
             self.layout == "segment_indexed"
             and os.environ.get("OFFLOAD_NATIVE_STITCH", "0").lower()
@@ -87,6 +101,7 @@ class ATOMKVByteCodec:
 
                 native_stitch.load_extension()
                 self._native_stitch = native_stitch.stitch_chunk_buffers
+                self._native_split = native_stitch.split_request_buffer
             except Exception:
                 logger.warning(
                     "ATOMKVByteCodec: native stitch unavailable; using torch stitch",
@@ -96,6 +111,10 @@ class ATOMKVByteCodec:
     @property
     def segments_per_block(self) -> int:
         return len(self._segments)
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
 
     def copy_calls_for_blocks(self, nblocks: int) -> int:
         return int(nblocks) * len(self._segments)
@@ -160,6 +179,38 @@ class ATOMKVByteCodec:
             acc += nb * nblocks
         return bases
 
+    def _device_ctx(self):
+        if self._device.type == "cuda":
+            return torch.cuda.device(self._device)
+        return _nullctx()
+
+    def _normalize_block_ids(self, block_ids: list[int]) -> list[int]:
+        try:
+            normalized = [operator.index(bid) for bid in block_ids]
+        except TypeError as exc:
+            raise ValueError("ATOMKVByteCodec: block_ids must be integers") from exc
+        if not normalized:
+            return normalized
+        min_bid = min(normalized)
+        max_bid = max(normalized)
+        if min_bid < 0 or max_bid >= self.num_blocks:
+            raise ValueError(
+                "ATOMKVByteCodec: block id out of range "
+                f"[0, {self.num_blocks}); min={min_bid} max={max_bid}"
+            )
+        return normalized
+
+    def _validate_host_buf(self, host_buf: torch.Tensor, nblocks: int) -> None:
+        if host_buf.dtype != torch.uint8:
+            raise TypeError("ATOMKVByteCodec: host_buf must be a uint8 tensor")
+        required = int(nblocks) * self.bytes_per_block
+        if int(host_buf.numel()) < required:
+            raise ValueError(
+                "ATOMKVByteCodec: host_buf is too small "
+                f"for {nblocks} blocks; need {required} bytes, "
+                f"got {int(host_buf.numel())}"
+            )
+
     def stitch_chunk_buffers(
         self,
         dst: torch.Tensor,
@@ -202,6 +253,53 @@ class ATOMKVByteCodec:
                 out=dst[dst_base : dst_base + total_blocks * nb],
             )
 
+    def split_request_buffer(
+        self,
+        src: torch.Tensor,
+        chunk_buffers: list[torch.Tensor],
+        chunk_block_counts: list[int],
+    ) -> None:
+        """CPU-side inverse of :meth:`stitch_chunk_buffers`.
+
+        ``src`` is one request-level segment-major buffer
+        ``[seg0 all_blocks | seg1 all_blocks | ...]``. Each destination chunk
+        receives its own segment-major slice
+        ``[seg0 chunk_blocks | seg1 chunk_blocks | ...]`` for LMCache storage.
+        """
+        if self._native_split is not None:
+            self._native_split(
+                src,
+                chunk_buffers,
+                chunk_block_counts,
+                self._seg_block_bytes,
+            )
+            return
+        total_blocks = sum(chunk_block_counts)
+        src_bases = self._segment_bases(total_blocks)
+        dst_bases_by_chunk = [
+            self._segment_bases(nblocks) for nblocks in chunk_block_counts
+        ]
+        for seg_idx, (src_base, nb) in enumerate(
+            zip(src_bases, self._seg_block_bytes)
+        ):
+            logical_block_start = 0
+            for dst, bases, nblocks in zip(
+                chunk_buffers, dst_bases_by_chunk, chunk_block_counts
+            ):
+                nbytes = nblocks * nb
+                if nbytes:
+                    dst[
+                        bases[seg_idx] : bases[seg_idx] + nbytes
+                    ].copy_(
+                        src[
+                            src_base
+                            + logical_block_start * nb : src_base
+                            + logical_block_start * nb
+                            + nbytes
+                        ]
+                    )
+                logical_block_start += nblocks
+
     def _tmp_bytes(self, seg: torch.Tensor, nblocks: int) -> torch.Tensor:
         elems = int(seg[0].numel()) * seg.element_size()
         key = (str(seg.device), "uint8", elems, int(nblocks))
@@ -230,45 +328,52 @@ class ATOMKVByteCodec:
     ) -> None:
         """D2H: gather ``block_ids`` from the paged GPU cache into the flat
         pinned ``host_buf`` (uint8, length == len(block_ids) * bytes_per_block)."""
-        ctx = torch.cuda.stream(stream) if stream is not None else _nullctx()
-        with ctx:
-            if self.layout == "segment_indexed":
-                idx = torch.tensor(
-                    block_ids, dtype=torch.long, device=self._segments[0].device
-                )
-                bases = self._segment_bases(len(block_ids))
-                for seg, base, nb in zip(
-                    self._segments, bases, self._seg_block_bytes
-                ):
-                    mat = self._segment_bytes_matrix(seg)
-                    tmp = self._tmp_bytes(seg, len(block_ids))
-                    torch.index_select(mat, 0, idx, out=tmp)
-                    host_buf[base : base + len(block_ids) * nb].copy_(
-                        tmp.reshape(-1), non_blocking=True
+        block_ids = self._normalize_block_ids(block_ids)
+        self._validate_host_buf(host_buf, len(block_ids))
+        if not block_ids:
+            return
+        with self._device_ctx():
+            stream_ctx = torch.cuda.stream(stream) if stream is not None else _nullctx()
+            with stream_ctx:
+                if self.layout == "segment_indexed":
+                    idx = torch.tensor(
+                        block_ids, dtype=torch.long, device=self._device
                     )
-                return
+                    bases = self._segment_bases(len(block_ids))
+                    for seg, base, nb in zip(
+                        self._segments, bases, self._seg_block_bytes
+                    ):
+                        mat = self._segment_bytes_matrix(seg)
+                        tmp = self._tmp_bytes(seg, len(block_ids))
+                        torch.index_select(mat, 0, idx, out=tmp)
+                        host_buf[base : base + len(block_ids) * nb].copy_(
+                            tmp.reshape(-1), non_blocking=True
+                        )
+                    return
 
-            if self.layout == "segment":
-                bases = self._segment_bases(len(block_ids))
-                runs = list(self._contiguous_runs(block_ids))
-                for seg, base, nb in zip(
-                    self._segments, bases, self._seg_block_bytes
-                ):
-                    for logical_start, physical_start, run_len in runs:
-                        src = self._blocks_bytes_view(seg, physical_start, run_len)
-                        dst = base + logical_start * nb
-                        host_buf[dst : dst + run_len * nb].copy_(
+                if self.layout == "segment":
+                    bases = self._segment_bases(len(block_ids))
+                    runs = list(self._contiguous_runs(block_ids))
+                    for seg, base, nb in zip(
+                        self._segments, bases, self._seg_block_bytes
+                    ):
+                        for logical_start, physical_start, run_len in runs:
+                            src = self._blocks_bytes_view(seg, physical_start, run_len)
+                            dst = base + logical_start * nb
+                            host_buf[dst : dst + run_len * nb].copy_(
+                                src, non_blocking=True
+                            )
+                    return
+
+                for i, bid in enumerate(block_ids):
+                    base = i * self.bytes_per_block
+                    for seg, off, nb in zip(
+                        self._segments, self._seg_off, self._seg_block_bytes
+                    ):
+                        src = self._block_bytes_view(seg, bid)
+                        host_buf[base + off : base + off + nb].copy_(
                             src, non_blocking=True
                         )
-                return
-
-            for i, bid in enumerate(block_ids):
-                base = i * self.bytes_per_block
-                for seg, off, nb in zip(
-                    self._segments, self._seg_off, self._seg_block_bytes
-                ):
-                    src = self._block_bytes_view(seg, bid)
-                    host_buf[base + off : base + off + nb].copy_(src, non_blocking=True)
 
     def host_to_gpu(
         self,
@@ -278,47 +383,55 @@ class ATOMKVByteCodec:
     ) -> None:
         """H2D: scatter the flat pinned ``host_buf`` back into the paged GPU
         cache at ``block_ids`` (in-place into the real KV tensors)."""
-        ctx = torch.cuda.stream(stream) if stream is not None else _nullctx()
-        with ctx:
-            if self.layout == "segment_indexed":
-                idx = torch.tensor(
-                    block_ids, dtype=torch.long, device=self._segments[0].device
-                )
-                bases = self._segment_bases(len(block_ids))
-                for seg, base, nb in zip(
-                    self._segments, bases, self._seg_block_bytes
-                ):
-                    mat = self._segment_bytes_matrix(seg)
-                    tmp = self._tmp_bytes(seg, len(block_ids))
-                    tmp.copy_(
-                        host_buf[base : base + len(block_ids) * nb].reshape_as(tmp),
-                        non_blocking=True,
+        block_ids = self._normalize_block_ids(block_ids)
+        self._validate_host_buf(host_buf, len(block_ids))
+        if not block_ids:
+            return
+        with self._device_ctx():
+            stream_ctx = torch.cuda.stream(stream) if stream is not None else _nullctx()
+            with stream_ctx:
+                if self.layout == "segment_indexed":
+                    idx = torch.tensor(
+                        block_ids, dtype=torch.long, device=self._device
                     )
-                    mat.index_copy_(0, idx, tmp)
-                return
-
-            if self.layout == "segment":
-                bases = self._segment_bases(len(block_ids))
-                runs = list(self._contiguous_runs(block_ids))
-                for seg, base, nb in zip(
-                    self._segments, bases, self._seg_block_bytes
-                ):
-                    for logical_start, physical_start, run_len in runs:
-                        dst = self._blocks_bytes_view(seg, physical_start, run_len)
-                        src = base + logical_start * nb
-                        dst.copy_(
-                            host_buf[src : src + run_len * nb],
+                    bases = self._segment_bases(len(block_ids))
+                    for seg, base, nb in zip(
+                        self._segments, bases, self._seg_block_bytes
+                    ):
+                        mat = self._segment_bytes_matrix(seg)
+                        tmp = self._tmp_bytes(seg, len(block_ids))
+                        tmp.copy_(
+                            host_buf[base : base + len(block_ids) * nb].reshape_as(tmp),
                             non_blocking=True,
                         )
-                return
+                        mat.index_copy_(0, idx, tmp)
+                    return
 
-            for i, bid in enumerate(block_ids):
-                base = i * self.bytes_per_block
-                for seg, off, nb in zip(
-                    self._segments, self._seg_off, self._seg_block_bytes
-                ):
-                    dst = self._block_bytes_view(seg, bid)
-                    dst.copy_(host_buf[base + off : base + off + nb], non_blocking=True)
+                if self.layout == "segment":
+                    bases = self._segment_bases(len(block_ids))
+                    runs = list(self._contiguous_runs(block_ids))
+                    for seg, base, nb in zip(
+                        self._segments, bases, self._seg_block_bytes
+                    ):
+                        for logical_start, physical_start, run_len in runs:
+                            dst = self._blocks_bytes_view(seg, physical_start, run_len)
+                            src = base + logical_start * nb
+                            dst.copy_(
+                                host_buf[src : src + run_len * nb],
+                                non_blocking=True,
+                            )
+                    return
+
+                for i, bid in enumerate(block_ids):
+                    base = i * self.bytes_per_block
+                    for seg, off, nb in zip(
+                        self._segments, self._seg_off, self._seg_block_bytes
+                    ):
+                        dst = self._block_bytes_view(seg, bid)
+                        dst.copy_(
+                            host_buf[base + off : base + off + nb],
+                            non_blocking=True,
+                        )
 
 
 class _nullctx:

--- a/atom/kv_transfer/offload/gpu_connector.py
+++ b/atom/kv_transfer/offload/gpu_connector.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""AITER-layout-aware byte codec between ATOM's paged GPU KV cache and a flat
+pinned host buffer (an LMCache ``MemoryObj``'s ``uint8`` tensor).
+
+Why a byte codec instead of an LMCache ``GPUConnectorInterface`` subclass:
+LMCache's ``engine.store/retrieve`` GPU path only emits token-major formats
+(``KV_2LTD`` etc.) via ``normalize_kv_and_discover_format``, which rejects
+AITER's swizzled K layout ``(nb, H, D//x, bs, x)`` and strided V ``(nb, H, D, bs)``.
+We therefore bypass that path: we store **opaque per-block bytes** (byte-identical
+round-trip — the attention kernel reads back its own layout) and drive LMCache only
+as a storage tier (``StorageManager`` + ``ChunkedTokenDatabase``).
+
+A whole *block* of any per-layer cache tensor (``t[block_id]``) is contiguous, so a
+block's KV is a set of contiguous byte slices: per layer K, V, and (fp8) k_scale,
+v_scale. The flat per-block layout in the host buffer is::
+
+    [ L0.K | L0.V | L0.kS | L0.vS | L1.K | L1.V | ... ]   (only present segments)
+
+which is self-consistent for store and load (we never reinterpret it).
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+class ATOMKVByteCodec:
+    """Per-block byte mover between paged GPU KV tensors and a flat host buffer."""
+
+    def __init__(self, kv_caches: dict) -> None:
+        """``kv_caches``: ordered ``{layer_name: KVCacheTensor}`` from
+        ``register_kv_caches``. We flatten every movable per-layer tensor (K, V,
+        and fp8 scales when present) into one ordered segment list. Each segment
+        is a GPU tensor shaped ``[num_blocks, ...]``; segment[block_id] is a
+        contiguous block slice we copy as raw bytes."""
+        self._segments: list[torch.Tensor] = []
+        for _name, kvt in kv_caches.items():
+            for t in (
+                getattr(kvt, "k_cache", None),
+                getattr(kvt, "v_cache", None),
+                getattr(kvt, "k_scale", None),
+                getattr(kvt, "v_scale", None),
+            ):
+                if t is not None and isinstance(t, torch.Tensor) and t.numel() > 0:
+                    self._segments.append(t)
+
+        if not self._segments:
+            raise ValueError("ATOMKVByteCodec: no movable KV tensors registered")
+
+        # Bytes for one block of each segment (block is dim 0).
+        self._seg_block_bytes: list[int] = [
+            int(t[0].numel()) * t.element_size() for t in self._segments
+        ]
+        # Byte offset of each segment within one block's flat record.
+        self._seg_off: list[int] = []
+        acc = 0
+        for nb in self._seg_block_bytes:
+            self._seg_off.append(acc)
+            acc += nb
+        self.bytes_per_block: int = acc
+        self.num_blocks: int = int(self._segments[0].shape[0])
+
+    # -- helpers ----------------------------------------------------------
+    @staticmethod
+    def _block_bytes_view(seg: torch.Tensor, block_id: int) -> torch.Tensor:
+        """Flat ``uint8`` view of one contiguous block slice (no copy)."""
+        blk = seg[block_id]
+        if not blk.is_contiguous():
+            # Block slices of the paged cache are contiguous in practice; guard
+            # anyway. A non-contiguous block would break in-place H2D, so fail loud.
+            raise RuntimeError("ATOMKVByteCodec: block slice not contiguous")
+        return blk.reshape(-1).view(torch.uint8)
+
+    # -- public API -------------------------------------------------------
+    def gpu_to_host(
+        self,
+        host_buf: torch.Tensor,
+        block_ids: list[int],
+        stream: torch.cuda.Stream | None = None,
+    ) -> None:
+        """D2H: gather ``block_ids`` from the paged GPU cache into the flat
+        pinned ``host_buf`` (uint8, length == len(block_ids) * bytes_per_block)."""
+        ctx = torch.cuda.stream(stream) if stream is not None else _nullctx()
+        with ctx:
+            for i, bid in enumerate(block_ids):
+                base = i * self.bytes_per_block
+                for seg, off, nb in zip(
+                    self._segments, self._seg_off, self._seg_block_bytes
+                ):
+                    src = self._block_bytes_view(seg, bid)
+                    host_buf[base + off : base + off + nb].copy_(src, non_blocking=True)
+
+    def host_to_gpu(
+        self,
+        host_buf: torch.Tensor,
+        block_ids: list[int],
+        stream: torch.cuda.Stream | None = None,
+    ) -> None:
+        """H2D: scatter the flat pinned ``host_buf`` back into the paged GPU
+        cache at ``block_ids`` (in-place into the real KV tensors)."""
+        ctx = torch.cuda.stream(stream) if stream is not None else _nullctx()
+        with ctx:
+            for i, bid in enumerate(block_ids):
+                base = i * self.bytes_per_block
+                for seg, off, nb in zip(
+                    self._segments, self._seg_off, self._seg_block_bytes
+                ):
+                    dst = self._block_bytes_view(seg, bid)
+                    dst.copy_(host_buf[base + off : base + off + nb], non_blocking=True)
+
+
+class _nullctx:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, *a):
+        return False

--- a/atom/kv_transfer/offload/metadata.py
+++ b/atom/kv_transfer/offload/metadata.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from atom.kv_transfer.disaggregation.types import ConnectorMetadata
+from atom.kv_transfer.disaggregation.types import ConnectorMetadata, ReqId
 
 
 @dataclass
@@ -45,7 +45,7 @@ class SaveSpec:
 class LMCacheReqMeta:
     """Everything the worker needs to load/save one request's KV this step."""
 
-    req_id: str
+    req_id: ReqId
     # Token ids covering the prefix being moved (used to derive chunk-256 keys via
     # LMCache's ChunkedTokenDatabase). For load: prompt[:lmcache_cached_tokens];
     # for save: computed token ids.

--- a/atom/kv_transfer/offload/metadata.py
+++ b/atom/kv_transfer/offload/metadata.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Per-request transfer descriptors for the LMCache CPU/NVMe offload connector.
+
+Ported (type-substituted) from vLLM's ``lmcache_integration/vllm_v1_adapter.py``
+(``LoadSpec`` / ``SaveSpec`` / ``RequestTracker`` / ``ReqMeta``) onto ATOM's
+``Sequence`` model. These travel from the scheduler-side connector to the
+worker-side connector inside :class:`LMCacheOffloadMetadata`, which subclasses
+ATOM's :class:`ConnectorMetadata` so the engine forwards it opaquely through
+``process_kvconnector_output`` → ``start_load_kv``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from atom.kv_transfer.disaggregation.types import ConnectorMetadata
+
+
+@dataclass
+class LoadSpec:
+    """How many tokens to load for a request, split HBM-cached vs LMCache-cached."""
+
+    # Tokens already resident in ATOM's HBM prefix cache (num_cached_tokens).
+    hbm_cached_tokens: int
+    # Total tokens LMCache can supply (>= hbm_cached_tokens). The load fills the
+    # gap [hbm_cached_tokens, lmcache_cached_tokens).
+    lmcache_cached_tokens: int
+    # Set True by update_state_after_alloc once blocks are reserved for the load.
+    can_load: bool = False
+
+
+@dataclass
+class SaveSpec:
+    """How many leading tokens of a request are already saved to LMCache."""
+
+    # Tokens at the prefix already persisted (skip these on the next store).
+    skip_leading_tokens: int
+    # Set False to suppress the store for this step (e.g. nothing new to save).
+    can_save: bool = True
+
+
+@dataclass
+class LMCacheReqMeta:
+    """Everything the worker needs to load/save one request's KV this step."""
+
+    req_id: str
+    # Token ids covering the prefix being moved (used to derive chunk-256 keys via
+    # LMCache's ChunkedTokenDatabase). For load: prompt[:lmcache_cached_tokens];
+    # for save: computed token ids.
+    token_ids: list[int]
+    # The sequence's GPU block table (logical block ids). A chunk spanning token
+    # range [start, end) maps to blocks block_ids[start // bs : ceil(end / bs)].
+    block_ids: list[int]
+    load_spec: LoadSpec | None = None
+    save_spec: SaveSpec | None = None
+    # True on the request's final prefill chunk (store the unaligned tail too).
+    is_last_prefill: bool = True
+
+
+class LMCacheOffloadMetadata(ConnectorMetadata):
+    """Connector metadata snapshot for one engine step.
+
+    Subclasses ATOM's :class:`ConnectorMetadata` (so it satisfies the
+    ``build_connector_meta() -> ConnectorMetadata`` contract and is forwarded
+    opaquely by the engine) while carrying the richer per-request offload
+    descriptors the worker consumes in ``start_load_kv``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.requests: list[LMCacheReqMeta] = []
+        # req_ids whose scheduler-side lookup pin should be released this step.
+        self.lookup_requests_in_step: list[str] = []
+
+    def add_request(self, meta: LMCacheReqMeta) -> None:
+        self.requests.append(meta)

--- a/atom/kv_transfer/offload/native_stitch.cpp
+++ b/atom/kv_transfer/offload/native_stitch.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#include <ATen/Parallel.h>
+#include <torch/extension.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+void stitch_chunk_buffers(
+    torch::Tensor dst,
+    std::vector<torch::Tensor> chunk_buffers,
+    std::vector<int64_t> chunk_block_counts,
+    std::vector<int64_t> seg_block_bytes) {
+  TORCH_CHECK(dst.device().is_cpu(), "dst must be a CPU tensor");
+  TORCH_CHECK(dst.dtype() == torch::kUInt8, "dst must be uint8");
+  TORCH_CHECK(dst.is_contiguous(), "dst must be contiguous");
+  TORCH_CHECK(
+      chunk_buffers.size() == chunk_block_counts.size(),
+      "chunk_buffers and chunk_block_counts size mismatch");
+
+  const int64_t nchunks = static_cast<int64_t>(chunk_buffers.size());
+  const int64_t nsegs = static_cast<int64_t>(seg_block_bytes.size());
+  int64_t total_blocks = 0;
+  for (int64_t nblocks : chunk_block_counts) {
+    TORCH_CHECK(nblocks >= 0, "chunk block count must be non-negative");
+    total_blocks += nblocks;
+  }
+
+  std::vector<int64_t> dst_bases(nsegs);
+  int64_t acc = 0;
+  for (int64_t seg = 0; seg < nsegs; ++seg) {
+    const int64_t nb = seg_block_bytes[seg];
+    TORCH_CHECK(nb >= 0, "segment byte count must be non-negative");
+    dst_bases[seg] = acc;
+    acc += nb * total_blocks;
+  }
+  TORCH_CHECK(dst.numel() >= acc, "dst is smaller than stitched output");
+
+  std::vector<const uint8_t*> src_ptrs(nchunks);
+  std::vector<int64_t> src_offsets(nchunks * nsegs);
+  for (int64_t c = 0; c < nchunks; ++c) {
+    const auto& src = chunk_buffers[c];
+    TORCH_CHECK(src.device().is_cpu(), "chunk buffer must be a CPU tensor");
+    TORCH_CHECK(src.dtype() == torch::kUInt8, "chunk buffer must be uint8");
+    TORCH_CHECK(src.is_contiguous(), "chunk buffer must be contiguous");
+    src_ptrs[c] = src.data_ptr<uint8_t>();
+
+    int64_t src_acc = 0;
+    const int64_t nblocks = chunk_block_counts[c];
+    for (int64_t seg = 0; seg < nsegs; ++seg) {
+      src_offsets[c * nsegs + seg] = src_acc;
+      src_acc += seg_block_bytes[seg] * nblocks;
+    }
+    TORCH_CHECK(src.numel() >= src_acc, "chunk buffer is smaller than expected");
+  }
+
+  auto* dst_ptr = dst.data_ptr<uint8_t>();
+  at::parallel_for(0, nsegs, 1, [&](int64_t begin, int64_t end) {
+    for (int64_t seg = begin; seg < end; ++seg) {
+      const int64_t nb = seg_block_bytes[seg];
+      int64_t logical_block_start = 0;
+      for (int64_t c = 0; c < nchunks; ++c) {
+        const int64_t nblocks = chunk_block_counts[c];
+        const int64_t nbytes = nblocks * nb;
+        if (nbytes > 0) {
+          std::memcpy(
+              dst_ptr + dst_bases[seg] + logical_block_start * nb,
+              src_ptrs[c] + src_offsets[c * nsegs + seg],
+              static_cast<size_t>(nbytes));
+        }
+        logical_block_start += nblocks;
+      }
+    }
+  });
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("stitch_chunk_buffers", &stitch_chunk_buffers);
+}

--- a/atom/kv_transfer/offload/native_stitch.cpp
+++ b/atom/kv_transfer/offload/native_stitch.cpp
@@ -76,6 +76,75 @@ void stitch_chunk_buffers(
   });
 }
 
+void split_request_buffer(
+    torch::Tensor src,
+    std::vector<torch::Tensor> chunk_buffers,
+    std::vector<int64_t> chunk_block_counts,
+    std::vector<int64_t> seg_block_bytes) {
+  TORCH_CHECK(src.device().is_cpu(), "src must be a CPU tensor");
+  TORCH_CHECK(src.dtype() == torch::kUInt8, "src must be uint8");
+  TORCH_CHECK(src.is_contiguous(), "src must be contiguous");
+  TORCH_CHECK(
+      chunk_buffers.size() == chunk_block_counts.size(),
+      "chunk_buffers and chunk_block_counts size mismatch");
+
+  const int64_t nchunks = static_cast<int64_t>(chunk_buffers.size());
+  const int64_t nsegs = static_cast<int64_t>(seg_block_bytes.size());
+  int64_t total_blocks = 0;
+  for (int64_t nblocks : chunk_block_counts) {
+    TORCH_CHECK(nblocks >= 0, "chunk block count must be non-negative");
+    total_blocks += nblocks;
+  }
+
+  std::vector<int64_t> src_bases(nsegs);
+  int64_t acc = 0;
+  for (int64_t seg = 0; seg < nsegs; ++seg) {
+    const int64_t nb = seg_block_bytes[seg];
+    TORCH_CHECK(nb >= 0, "segment byte count must be non-negative");
+    src_bases[seg] = acc;
+    acc += nb * total_blocks;
+  }
+  TORCH_CHECK(src.numel() >= acc, "src is smaller than split input");
+
+  std::vector<uint8_t*> dst_ptrs(nchunks);
+  std::vector<int64_t> dst_offsets(nchunks * nsegs);
+  for (int64_t c = 0; c < nchunks; ++c) {
+    auto& dst = chunk_buffers[c];
+    TORCH_CHECK(dst.device().is_cpu(), "chunk buffer must be a CPU tensor");
+    TORCH_CHECK(dst.dtype() == torch::kUInt8, "chunk buffer must be uint8");
+    TORCH_CHECK(dst.is_contiguous(), "chunk buffer must be contiguous");
+    dst_ptrs[c] = dst.data_ptr<uint8_t>();
+
+    int64_t dst_acc = 0;
+    const int64_t nblocks = chunk_block_counts[c];
+    for (int64_t seg = 0; seg < nsegs; ++seg) {
+      dst_offsets[c * nsegs + seg] = dst_acc;
+      dst_acc += seg_block_bytes[seg] * nblocks;
+    }
+    TORCH_CHECK(dst.numel() >= dst_acc, "chunk buffer is smaller than expected");
+  }
+
+  const auto* src_ptr = src.data_ptr<uint8_t>();
+  at::parallel_for(0, nsegs, 1, [&](int64_t begin, int64_t end) {
+    for (int64_t seg = begin; seg < end; ++seg) {
+      const int64_t nb = seg_block_bytes[seg];
+      int64_t logical_block_start = 0;
+      for (int64_t c = 0; c < nchunks; ++c) {
+        const int64_t nblocks = chunk_block_counts[c];
+        const int64_t nbytes = nblocks * nb;
+        if (nbytes > 0) {
+          std::memcpy(
+              dst_ptrs[c] + dst_offsets[c * nsegs + seg],
+              src_ptr + src_bases[seg] + logical_block_start * nb,
+              static_cast<size_t>(nbytes));
+        }
+        logical_block_start += nblocks;
+      }
+    }
+  });
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("stitch_chunk_buffers", &stitch_chunk_buffers);
+  m.def("split_request_buffer", &split_request_buffer);
 }

--- a/atom/kv_transfer/offload/native_stitch.py
+++ b/atom/kv_transfer/offload/native_stitch.py
@@ -42,3 +42,12 @@ def stitch_chunk_buffers(dst, chunk_buffers, chunk_block_counts, seg_block_bytes
         [int(x) for x in chunk_block_counts],
         [int(x) for x in seg_block_bytes],
     )
+
+
+def split_request_buffer(src, chunk_buffers, chunk_block_counts, seg_block_bytes) -> None:
+    _load_ext().split_request_buffer(
+        src,
+        chunk_buffers,
+        [int(x) for x in chunk_block_counts],
+        [int(x) for x in seg_block_bytes],
+    )

--- a/atom/kv_transfer/offload/native_stitch.py
+++ b/atom/kv_transfer/offload/native_stitch.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Optional native CPU stitch for LMCache chunk buffers.
+
+This is deliberately a small C++ CPU extension, not a HIP op: current profiles
+show H2D at tens of milliseconds, while Python/Torch host repacking takes more
+than a second for MiniMax-M2.5 32K.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from torch.utils.cpp_extension import load
+
+
+_EXT = None
+
+
+def _load_ext():
+    global _EXT
+    if _EXT is None:
+        src = Path(__file__).with_name("native_stitch.cpp")
+        _EXT = load(
+            name="atom_lmcache_native_stitch",
+            sources=[str(src)],
+            extra_cflags=["-O3"],
+            verbose=False,
+        )
+    return _EXT
+
+
+def load_extension() -> None:
+    _load_ext()
+
+
+def stitch_chunk_buffers(dst, chunk_buffers, chunk_block_counts, seg_block_bytes) -> None:
+    _load_ext().stitch_chunk_buffers(
+        dst,
+        chunk_buffers,
+        [int(x) for x in chunk_block_counts],
+        [int(x) for x in seg_block_bytes],
+    )

--- a/atom/kv_transfer/offload/trace.py
+++ b/atom/kv_transfer/offload/trace.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+logger = logging.getLogger("atom")
+_START = time.perf_counter()
+
+
+def offload_trace_enabled() -> bool:
+    return os.environ.get("OFFLOAD_TRACE_E2E", "0").lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def offload_trace(event: str, **fields) -> None:
+    if not offload_trace_enabled():
+        return
+    now = time.perf_counter()
+    parts = [f"{key}={value}" for key, value in fields.items()]
+    logger.info(
+        "[OFFLOAD-TRACE] t=%.6f dt_ms=%.3f event=%s %s",
+        now,
+        (now - _START) * 1000,
+        event,
+        " ".join(parts),
+    )

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -202,6 +202,7 @@ class EngineCore:
             self.output_queue.put_nowait(rejected)
 
         if result is None:
+            self._dispatch_idle_offload_work()
             if self.kv_transfer_enabled:
                 kvoutput = self.runner_mgr.call_func_with_aggregation(
                     "async_proc_aggregation"
@@ -212,6 +213,7 @@ class EngineCore:
 
         if scheduled_batch is None:
             logger.debug("%s: No sequences to schedule, skipping forward", self.label)
+            self._dispatch_idle_offload_work()
             if self.kv_transfer_enabled:
                 kvoutput = self.runner_mgr.call_func_with_aggregation(
                     "async_proc_aggregation"
@@ -267,6 +269,17 @@ class EngineCore:
         if finished_seqs:
             self.output_queue.put_nowait(finished_seqs)
         return True
+
+    def _dispatch_idle_offload_work(self) -> None:
+        if not self.kv_transfer_enabled:
+            return
+        connector = getattr(self.scheduler, "kv_connector", None)
+        if connector is None or not getattr(connector, "is_offload", False):
+            return
+        meta = connector.build_connector_meta()
+        if meta is None or not getattr(meta, "requests", None):
+            return
+        self.runner_mgr.call_func("process_kvconnector_output", meta)
 
     def pull_and_process_input_queue(self):
         recv_reqs = []

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2044,8 +2044,13 @@ class ModelRunner:
         """Collect finished send/recv status from the KV connector."""
         connector = get_kvconnector()
         if connector is None:
-            return KVConnectorOutput(finished_sending=[], finished_recving=[])
-        done_sending, done_recving = connector.get_finished()
+            return KVConnectorOutput()
+
+        finished = connector.get_finished()
+        if isinstance(finished, KVConnectorOutput):
+            return finished
+
+        done_sending, done_recving = finished
 
         return KVConnectorOutput(
             finished_sending=done_sending, finished_recving=done_recving

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -50,6 +50,7 @@ from atom.utils.forward_context import (
     set_forward_context,
     set_kv_cache_data,
 )
+from atom.kv_transfer.offload.trace import offload_trace
 from atom.utils.selector import get_attn_backend
 from torch.profiler import record_function
 
@@ -2009,6 +2010,15 @@ class ModelRunner:
 
     @torch.inference_mode()
     def forward(self, batch: ScheduledBatch) -> ScheduledBatchOutput:
+        t_forward0 = time.perf_counter()
+        offload_trace(
+            "runner_forward_start",
+            reqs=batch.req_ids,
+            prefill=batch.total_seqs_num_prefill,
+            decode=batch.total_seqs_num_decode,
+            tokens=batch.total_tokens_num,
+            cached=batch.num_cached_tokens,
+        )
         (
             input_ids,
             temperatures,
@@ -2029,6 +2039,15 @@ class ModelRunner:
             needs_independent_noise=needs_independent_noise,
         )
         reset_forward_context()
+        offload_trace(
+            "runner_forward_done",
+            reqs=batch.req_ids,
+            out_reqs=fwd_output.req_ids,
+            prefill=batch.total_seqs_num_prefill,
+            decode=batch.total_seqs_num_decode,
+            tokens=batch.total_tokens_num,
+            total_ms=f"{(time.perf_counter() - t_forward0) * 1000:.2f}",
+        )
         return fwd_output
 
     @torch.inference_mode()
@@ -2037,6 +2056,12 @@ class ModelRunner:
         if connector_meta_output is not None:
             connector = get_kvconnector()
             if connector is not None:
+                reqs = getattr(connector_meta_output, "requests", None)
+                offload_trace(
+                    "runner_connector_dispatch",
+                    requests=[r.req_id for r in reqs] if reqs is not None else None,
+                    nrequests=len(reqs) if reqs is not None else None,
+                )
                 connector.start_load_kv(connector_meta_output)
 
     @torch.inference_mode()
@@ -2048,6 +2073,19 @@ class ModelRunner:
 
         finished = connector.get_finished()
         if isinstance(finished, KVConnectorOutput):
+            if (
+                finished.finished_sending
+                or finished.finished_recving
+                or finished.failed_recving
+                or finished.finished_saving
+            ):
+                offload_trace(
+                    "runner_connector_finished",
+                    sending=sorted(finished.finished_sending or ()),
+                    recving=sorted(finished.finished_recving or ()),
+                    failed=sorted(finished.failed_recving or ()),
+                    saving=sorted(finished.finished_saving or ()),
+                )
             return finished
 
         done_sending, done_recving = finished

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -716,8 +716,42 @@ class Scheduler:
                     skipped_waiting_requests.append(seq)
                     continue
 
+            # OFFLOAD fresh-wake: a seq whose CPU/NVMe prefix just finished
+            # loading into its GPU blocks. Unlike P/D (which jumps straight to
+            # decode with an injected first token), offload must resume as a
+            # PREFILL of only the un-loaded SUFFIX: bump num_cached_tokens to the
+            # loaded count and fall through to admission WITHOUT re-matching or
+            # re-allocating (blocks were allocated for the whole seq before it
+            # parked). `offload_resume` also covers the case where a woken
+            # offload seq did not fit this step and was re-parked as plain
+            # WAITING -- it prevents re-running get_num_new_matched_tokens and,
+            # critically, re-calling block_manager.allocate() onto an already
+            # populated block_table (005's `assert not seq.block_table` crash).
+            is_offload = self._is_offload_connector()
+            if waiting_remote_to_waiting_ready and is_offload:
+                loaded = getattr(seq, "offload_loaded_tokens", None)
+                logger.debug(
+                    "[OFFLOAD-WAKE] seq %s: loaded=%s prev_cached=%d num_tokens=%d",
+                    seq.id, loaded, seq.num_cached_tokens, seq.num_tokens,
+                )
+                if loaded is not None and loaded > seq.num_cached_tokens:
+                    seq.num_cached_tokens = loaded
+                seq.offload_loaded = True
+                waiting_remote_to_waiting_ready = False  # not the P/D decode jump
+
+            offload_resume = (
+                is_offload
+                and getattr(seq, "offload_loaded", False)
+                and len(seq.block_table) > 0
+                and seq.num_cached_tokens > 0
+            )
+
             need_to_remove_to_load_kv_async_queue = False
-            if self.kv_connector is not None and not waiting_remote_to_waiting_ready:
+            if (
+                self.kv_connector is not None
+                and not waiting_remote_to_waiting_ready
+                and not offload_resume
+            ):
                 _ext_tokens, need_to_remove_to_load_kv_async_queue = (
                     self.kv_connector.get_num_new_matched_tokens(seq)
                 )
@@ -743,43 +777,53 @@ class Scheduler:
                 self.running.append(seq)
                 continue
 
-            # Probe cache hits FIRST so budget check sees the real
-            # (post-prefix-cache) remaining token count. `can_allocate`
-            # excludes the last block from cache hits (prefill must forward
-            # at least one block to produce logits), so num_new_tokens ≥ 1
-            # is guaranteed.
-            num_cached_blocks = self.block_manager.can_allocate(seq)
-            if num_cached_blocks < 0:
-                self.waiting.appendleft(seq)
-                break
-
-            num_new_tokens = (
-                seq.num_prompt_tokens
-                - num_cached_blocks * self.block_manager.block_size
-            )
-            budget_remaining = self.max_num_batched_tokens - num_batched_tokens
-            if self.enable_chunked_prefill:
-                chunk = min(num_new_tokens, budget_remaining)
+            if offload_resume:
+                # Blocks already held from the pre-park allocate; only re-check
+                # the batch budget. No re-match / re-allocate / re-park.
+                num_new_tokens = seq.num_prompt_tokens - seq.num_cached_tokens
+                budget_remaining = self.max_num_batched_tokens - num_batched_tokens
+                if self.enable_chunked_prefill:
+                    chunk = min(num_new_tokens, budget_remaining)
+                else:
+                    if num_new_tokens > budget_remaining and num_batched_tokens > 0:
+                        self.waiting.appendleft(seq)
+                        break
+                    chunk = num_new_tokens
             else:
-                if num_new_tokens > budget_remaining and num_batched_tokens > 0:
+                # Probe cache hits FIRST so budget check sees the real
+                # (post-prefix-cache) remaining token count.
+                num_cached_blocks = self.block_manager.can_allocate(seq)
+                if num_cached_blocks < 0:
                     self.waiting.appendleft(seq)
                     break
-                chunk = num_new_tokens
+
+                num_new_tokens = (
+                    seq.num_prompt_tokens
+                    - num_cached_blocks * self.block_manager.block_size
+                )
+                budget_remaining = self.max_num_batched_tokens - num_batched_tokens
+                if self.enable_chunked_prefill:
+                    chunk = min(num_new_tokens, budget_remaining)
+                else:
+                    if num_new_tokens > budget_remaining and num_batched_tokens > 0:
+                        self.waiting.appendleft(seq)
+                        break
+                    chunk = num_new_tokens
+
+                self.block_manager.allocate(seq, num_cached_blocks)
+
+                if self.kv_connector is not None:
+                    self.kv_connector.update_state_after_alloc(seq)
+
+                if need_to_remove_to_load_kv_async_queue:
+                    skipped_waiting_requests.append(seq)
+                    seq.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
+                    continue
+
             assert chunk > 0, (
                 f"chunk must be positive: {chunk=}, "
                 f"{num_new_tokens=}, {budget_remaining=}"
             )
-
-            self.block_manager.allocate(seq, num_cached_blocks)
-
-            if self.kv_connector is not None:
-                self.kv_connector.update_state_after_alloc(seq)
-
-            if need_to_remove_to_load_kv_async_queue:
-                skipped_waiting_requests.append(seq)
-                seq.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
-                continue
-
             if self.cache_stats:
                 self.cache_stats.update(seq.num_cached_tokens, seq.num_tokens)
             num_batched_tokens += chunk
@@ -1210,6 +1254,14 @@ class Scheduler:
                 self.block_manager.deallocate(seq)
             self.running.remove(seq)
         return finished_seqs
+
+    def _is_offload_connector(self) -> bool:
+        """True when the active KV connector is the CPU/NVMe offload backend.
+
+        Offload wakes a parked seq into a SUFFIX prefill (not the P/D decode
+        jump). Connectors set ``is_offload = True`` to opt into this path.
+        """
+        return getattr(self.kv_connector, "is_offload", False)
 
     def _update_waiting_for_remote_kv(self, seq: Sequence) -> bool:
         """Check whether a remote KV transfer for *seq* has completed.

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -428,6 +428,7 @@ class Scheduler:
 
         # KV transfer bookkeeping
         self.finished_recving_kv_req_ids: list[int] = []
+        self.failed_recving_kv_req_ids: list[int] = []
         self.deferred_free_blocks: dict[int, Sequence] = {}
 
         # Scheduling delay for batching efficiency
@@ -707,14 +708,24 @@ class Scheduler:
             # KV Transfer: skip request if still waiting for remote KVs
             waiting_remote_to_waiting_ready = False
             if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
-                waiting_remote_to_waiting_ready = self._update_waiting_for_remote_kv(
-                    seq
-                )
-                if waiting_remote_to_waiting_ready:
+                if self._pop_req_id(self.failed_recving_kv_req_ids, seq.id):
+                    if self.kv_connector is not None and hasattr(
+                        self.kv_connector, "load_failed"
+                    ):
+                        self.kv_connector.load_failed(seq.id)
                     seq.status = SequenceStatus.WAITING
+                    seq.offload_loaded = False
+                    seq.offload_loaded_tokens = seq.num_cached_tokens
+                    seq.offload_load_failed = True
                 else:
-                    skipped_waiting_requests.append(seq)
-                    continue
+                    waiting_remote_to_waiting_ready = self._update_waiting_for_remote_kv(
+                        seq
+                    )
+                    if waiting_remote_to_waiting_ready:
+                        seq.status = SequenceStatus.WAITING
+                    else:
+                        skipped_waiting_requests.append(seq)
+                        continue
 
             # OFFLOAD fresh-wake: a seq whose CPU/NVMe prefix just finished
             # loading into its GPU blocks. Unlike P/D (which jumps straight to
@@ -741,9 +752,11 @@ class Scheduler:
 
             offload_resume = (
                 is_offload
-                and getattr(seq, "offload_loaded", False)
+                and (
+                    getattr(seq, "offload_loaded", False)
+                    or getattr(seq, "offload_load_failed", False)
+                )
                 and len(seq.block_table) > 0
-                and seq.num_cached_tokens > 0
             )
 
             need_to_remove_to_load_kv_async_queue = False
@@ -1243,7 +1256,16 @@ class Scheduler:
                 self._partial_prefill_count -= 1
             if self.kv_connector is not None:
                 if not self.kv_connector.is_producer:
-                    self.block_manager.deallocate(seq)
+                    if hasattr(self.kv_connector, "should_defer_free") and (
+                        self.kv_connector.should_defer_free(seq)
+                    ):
+                        logger.debug(
+                            "Deferring block free for seq %s until KV save completes.",
+                            seq.id,
+                        )
+                        self.deferred_free_blocks[seq.id] = seq
+                    else:
+                        self.block_manager.deallocate(seq)
                 else:
                     logger.debug(
                         "Deferring block free for seq %s until KV send completes.",
@@ -1263,6 +1285,22 @@ class Scheduler:
         """
         return getattr(self.kv_connector, "is_offload", False)
 
+    @staticmethod
+    def _pop_req_id(req_ids: list, seq_id) -> bool:
+        candidates = (seq_id, str(seq_id))
+        for candidate in candidates:
+            if candidate in req_ids:
+                req_ids.remove(candidate)
+                return True
+        try:
+            int_id = int(seq_id)
+        except (TypeError, ValueError):
+            return False
+        if int_id in req_ids:
+            req_ids.remove(int_id)
+            return True
+        return False
+
     def _update_waiting_for_remote_kv(self, seq: Sequence) -> bool:
         """Check whether a remote KV transfer for *seq* has completed.
 
@@ -1271,10 +1309,9 @@ class Scheduler:
         scheduling step.  When ready, the sequence transitions back
         from ``WAITING_FOR_REMOTE_KVS`` to ``WAITING``.
         """
-        if seq.id not in self.finished_recving_kv_req_ids:
+        if not self._pop_req_id(self.finished_recving_kv_req_ids, seq.id):
             return False
 
-        self.finished_recving_kv_req_ids.remove(seq.id)
         logger.debug("KV transfer finished for seq %s, ready for scheduling.", seq.id)
         return True
 
@@ -1288,6 +1325,15 @@ class Scheduler:
         if kv_connector_output is None:
             return
 
+        def _pop_deferred(req_id):
+            seq = self.deferred_free_blocks.pop(req_id, None)
+            if seq is not None:
+                return seq
+            try:
+                return self.deferred_free_blocks.pop(int(req_id), None)
+            except (TypeError, ValueError):
+                return None
+
         for req_id in kv_connector_output.finished_recving or ():
             assert (
                 not self.kv_connector.is_producer
@@ -1295,15 +1341,36 @@ class Scheduler:
             logger.debug("Finished recving KV transfer for request %s", req_id)
             self.finished_recving_kv_req_ids.append(req_id)
 
+        for req_id in kv_connector_output.failed_recving or ():
+            assert (
+                not self.kv_connector.is_producer
+            ), "Only consumer should update failed KV recv status"
+            logger.warning("KV receive failed for request %s; falling back to prefill.", req_id)
+            self.failed_recving_kv_req_ids.append(req_id)
+
         for req_id in kv_connector_output.finished_sending or ():
             assert (
                 self.kv_connector.is_producer
             ), "Only producer should free blocks after sending KV"
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert (
-                req_id in self.deferred_free_blocks
-            ), f"req_id={req_id} not found in deferred_free_blocks"
-            self.block_manager.deallocate(self.deferred_free_blocks.pop(req_id))
+            seq = _pop_deferred(req_id)
+            assert seq is not None, f"req_id={req_id} not found in deferred_free_blocks"
+            self.block_manager.deallocate(seq)
+
+        for req_id in kv_connector_output.finished_saving or ():
+            if hasattr(self.kv_connector, "save_finished"):
+                self.kv_connector.save_finished(req_id)
+            seq = self.deferred_free_blocks.get(req_id)
+            if seq is None:
+                try:
+                    seq = self.deferred_free_blocks.get(int(req_id))
+                except (TypeError, ValueError):
+                    seq = None
+            if seq is not None and not (
+                hasattr(self.kv_connector, "should_defer_free")
+                and self.kv_connector.should_defer_free(seq)
+            ):
+                self.block_manager.deallocate(_pop_deferred(req_id))
 
     def get_request_counts(self) -> tuple[int, int]:
         """Returns (num_running_reqs, num_waiting_reqs)."""

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -29,6 +29,7 @@ from atom.kv_transfer.disaggregation import KVConnectorOutput
 from atom.model_engine.block_manager import BlockManager
 from atom.model_engine.request import RequestOutput
 from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
+from atom.kv_transfer.offload.trace import offload_trace
 
 logger = logging.getLogger("atom")
 
@@ -486,6 +487,8 @@ class Scheduler:
         entries) and check `can_allocate` + token-budget, mirroring the
         same checks the admission while-loop runs below.
         """
+        if self._partial_prefill_count > 0:
+            return True
         if not self.waiting:
             return False
         for i, seq in enumerate(self.waiting):
@@ -496,7 +499,10 @@ class Scheduler:
             if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
                 continue
             num_new_tokens = seq.num_tokens - seq.num_cached_tokens
-            if num_new_tokens > self.max_num_batched_tokens:
+            if (
+                not self.enable_chunked_prefill
+                and num_new_tokens > self.max_num_batched_tokens
+            ):
                 continue
             if self.block_manager.can_allocate(seq) < 0:
                 return False  # KV-pressured: definitely cannot prefill
@@ -709,6 +715,12 @@ class Scheduler:
             waiting_remote_to_waiting_ready = False
             if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
                 if self._pop_req_id(self.failed_recving_kv_req_ids, seq.id):
+                    offload_trace(
+                        "scheduler_load_failed_wake",
+                        req=seq.id,
+                        cached=seq.num_cached_tokens,
+                        prompt=seq.num_prompt_tokens,
+                    )
                     if self.kv_connector is not None and hasattr(
                         self.kv_connector, "load_failed"
                     ):
@@ -744,6 +756,13 @@ class Scheduler:
                 logger.debug(
                     "[OFFLOAD-WAKE] seq %s: loaded=%s prev_cached=%d num_tokens=%d",
                     seq.id, loaded, seq.num_cached_tokens, seq.num_tokens,
+                )
+                offload_trace(
+                    "scheduler_offload_wake",
+                    req=seq.id,
+                    loaded=loaded,
+                    prev_cached=seq.num_cached_tokens,
+                    prompt=seq.num_prompt_tokens,
                 )
                 if loaded is not None and loaded > seq.num_cached_tokens:
                     seq.num_cached_tokens = loaded
@@ -822,13 +841,28 @@ class Scheduler:
                         self.waiting.appendleft(seq)
                         break
                     chunk = num_new_tokens
-
+                t_alloc0 = time.perf_counter()
                 self.block_manager.allocate(seq, num_cached_blocks)
+                offload_trace(
+                    "scheduler_alloc_done",
+                    req=seq.id,
+                    cached_blocks=num_cached_blocks,
+                    cached_tokens=seq.num_cached_tokens,
+                    blocks=len(seq.block_table),
+                    alloc_ms=f"{(time.perf_counter() - t_alloc0) * 1000:.2f}",
+                )
 
                 if self.kv_connector is not None:
                     self.kv_connector.update_state_after_alloc(seq)
 
                 if need_to_remove_to_load_kv_async_queue:
+                    offload_trace(
+                        "scheduler_park_for_load",
+                        req=seq.id,
+                        cached=seq.num_cached_tokens,
+                        prompt=seq.num_prompt_tokens,
+                        blocks=len(seq.block_table),
+                    )
                     skipped_waiting_requests.append(seq)
                     seq.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
                     continue
@@ -837,15 +871,24 @@ class Scheduler:
                 f"chunk must be positive: {chunk=}, "
                 f"{num_new_tokens=}, {budget_remaining=}"
             )
+            num_seqs_prefill += 1
             if self.cache_stats:
                 self.cache_stats.update(seq.num_cached_tokens, seq.num_tokens)
             num_batched_tokens += chunk
-            num_seqs_prefill += 1
             seq.status = SequenceStatus.RUNNING
             seq.type = SequenceType.PREFILL
             self.running.append(seq)
             scheduled_seqs[seq.id] = seq
             num_scheduled_tokens.append(chunk)
+            offload_trace(
+                "scheduler_prefill_scheduled",
+                req=seq.id,
+                new_tokens=chunk,
+                cached=seq.num_cached_tokens,
+                prompt=seq.num_prompt_tokens,
+                offload_loaded=getattr(seq, "offload_loaded", False),
+                load_failed=getattr(seq, "offload_load_failed", False),
+            )
 
         if skipped_waiting_requests:
             logger.debug(
@@ -894,10 +937,14 @@ class Scheduler:
         num_new_tokens = self.mtp_k + 1
         remote_kv_blocks: set[int] = set()
         remote_kv_seq_blocks: dict[int, list[int]] = {}
+        skipped_partial_prefills: list[Sequence] = []
         while self.running and num_seqs_decode < self.max_num_seqs:
             if num_decode_tokens + tokens_per_decode_seq > self.max_num_batched_tokens:
                 break
             seq = self.running.popleft()
+            if seq.is_partial_prefill:
+                skipped_partial_prefills.append(seq)
+                continue
             while not self.block_manager.can_append(seq, num_new_tokens):
                 if self.running:
                     self.preempt(self.running.pop())
@@ -943,6 +990,8 @@ class Scheduler:
 
         if scheduled_seqs:
             self.running.extendleft(reversed(scheduled_seqs.values()))
+        if skipped_partial_prefills:
+            self.running.extendleft(reversed(skipped_partial_prefills))
 
         connector_meta_output = None
         if self.kv_connector is not None:
@@ -1076,10 +1125,11 @@ class Scheduler:
             # later in this loop, so they're not part of the prompt hash
             # chain — leaving them in would mint a stale partial-block hash.
             if not seq.prefix_hashes_published:
-                _num_new = seq.num_tokens - seq.num_cached_tokens
-                if need_placeholder:
-                    _num_new -= num_placeholder
-                self.block_manager.hash_blocks(seq, _num_new)
+                if batch is None:
+                    _num_new = seq.num_tokens - seq.num_cached_tokens
+                    if need_placeholder:
+                        _num_new -= num_placeholder
+                    self.block_manager.hash_blocks(seq, max(0, _num_new))
                 seq.prefix_hashes_published = True
             token_ids = prev_token_ids[idx]
             num_new_token = len(token_ids)
@@ -1255,6 +1305,8 @@ class Scheduler:
                 seq.is_partial_prefill = False
                 self._partial_prefill_count -= 1
             if self.kv_connector is not None:
+                if hasattr(self.kv_connector, "request_finished"):
+                    self.kv_connector.request_finished(seq)
                 if not self.kv_connector.is_producer:
                     if hasattr(self.kv_connector, "should_defer_free") and (
                         self.kv_connector.should_defer_free(seq)
@@ -1313,6 +1365,12 @@ class Scheduler:
             return False
 
         logger.debug("KV transfer finished for seq %s, ready for scheduling.", seq.id)
+        offload_trace(
+            "scheduler_recv_ready",
+            req=seq.id,
+            cached=getattr(seq, "num_cached_tokens", None),
+            prompt=getattr(seq, "num_prompt_tokens", None),
+        )
         return True
 
     def _update_from_kv_xfer_finished(self, kv_connector_output: KVConnectorOutput):
@@ -1339,6 +1397,7 @@ class Scheduler:
                 not self.kv_connector.is_producer
             ), "Only consumer should update recving KV status"
             logger.debug("Finished recving KV transfer for request %s", req_id)
+            offload_trace("scheduler_finished_recving", req=req_id)
             self.finished_recving_kv_req_ids.append(req_id)
 
         for req_id in kv_connector_output.failed_recving or ():
@@ -1346,6 +1405,7 @@ class Scheduler:
                 not self.kv_connector.is_producer
             ), "Only consumer should update failed KV recv status"
             logger.warning("KV receive failed for request %s; falling back to prefill.", req_id)
+            offload_trace("scheduler_failed_recving", req=req_id)
             self.failed_recving_kv_req_ids.append(req_id)
 
         for req_id in kv_connector_output.finished_sending or ():
@@ -1360,6 +1420,7 @@ class Scheduler:
         for req_id in kv_connector_output.finished_saving or ():
             if hasattr(self.kv_connector, "save_finished"):
                 self.kv_connector.save_finished(req_id)
+            offload_trace("scheduler_finished_saving", req=req_id)
             seq = self.deferred_free_blocks.get(req_id)
             if seq is None:
                 try:
@@ -1370,7 +1431,11 @@ class Scheduler:
                 hasattr(self.kv_connector, "should_defer_free")
                 and self.kv_connector.should_defer_free(seq)
             ):
-                self.block_manager.deallocate(_pop_deferred(req_id))
+                seq = _pop_deferred(req_id)
+                if seq is not None and hasattr(self.kv_connector, "request_finished"):
+                    self.kv_connector.request_finished(seq)
+                if seq is not None:
+                    self.block_manager.deallocate(seq)
 
     def get_request_counts(self) -> tuple[int, int]:
         """Returns (num_running_reqs, num_waiting_reqs)."""
@@ -1392,7 +1457,7 @@ class Scheduler:
     def get_next_batch_info(self) -> tuple[bool, int, int]:
         # Check for partial prefills in running (chunked prefill resume)
         for seq in self.running:
-            if seq.num_cached_tokens < seq.num_prompt_tokens:
+            if seq.is_partial_prefill:
                 remaining = seq.num_prompt_tokens - seq.num_cached_tokens
                 chunk = min(remaining, self.max_num_batched_tokens)
                 return (True, chunk, 1)
@@ -1409,6 +1474,8 @@ class Scheduler:
             total_tokens = 0
             for seq in eligible_waiting:
                 tokens = seq.num_tokens - seq.num_cached_tokens
+                if self.enable_chunked_prefill:
+                    tokens = min(tokens, self.max_num_batched_tokens - total_tokens)
                 if total_tokens + tokens > self.max_num_batched_tokens:
                     break
                 if num_reqs >= self.max_num_seqs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 
 import importlib
 import importlib.util
+import importlib.machinery
 import sys
 import os
 import types
@@ -58,6 +59,16 @@ _atom_config.Config = _StubConfig
 _atom_config.KVCacheTensor = _StubKVCacheTensor
 _atom_config.ParallelConfig = _StubParallelConfig
 sys.modules["atom.config"] = _atom_config
+
+# ── 3b. Stub forward_context; Scheduler only needs get_kvconnector in tests ──
+
+_forward_context = types.ModuleType("atom.utils.forward_context")
+_forward_context.__package__ = "atom.utils"
+_forward_context.__spec__ = importlib.machinery.ModuleSpec(
+    "atom.utils.forward_context", loader=None
+)
+_forward_context.get_kvconnector = lambda *args, **kwargs: None
+sys.modules["atom.utils.forward_context"] = _forward_context
 
 # ── 4. Stub zmq / zmq.asyncio if not installed ────────────────────────────
 
@@ -116,6 +127,7 @@ class MockConfig:
             kv_cache_block_size=4,
             num_kvcache_blocks=10,
             enable_prefix_caching=False,
+            enable_chunked_prefill=True,
             max_num_seqs=4,
             max_num_batched_tokens=64,
             max_model_len=64,
@@ -124,7 +136,6 @@ class MockConfig:
             stop_token_ids=[],
             scheduler_delay_factor=0.0,
             speculative_config=None,
-            enable_chunked_prefill=False,
         )
         defaults.update(overrides)
         for k, v in defaults.items():

--- a/tests/test_lmcache_offload_connector.py
+++ b/tests/test_lmcache_offload_connector.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+import threading
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    import torch  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["torch"] = types.ModuleType("torch")
+
+from atom.kv_transfer.disaggregation import KVConnectorOutput, KVOutputAggregator
+from atom.kv_transfer.offload.connector import (
+    LMCacheOffloadConnector,
+    LMCacheOffloadConnectorScheduler,
+)
+from atom.kv_transfer.offload.gpu_connector import ATOMKVByteCodec
+from atom.model_engine.scheduler import Scheduler
+
+
+class _LookupClient:
+    def __init__(self, hit: int) -> None:
+        self.hit = hit
+
+    def lookup(self, token_ids, lookup_id):
+        return self.hit
+
+
+def _scheduler() -> LMCacheOffloadConnectorScheduler:
+    sched = LMCacheOffloadConnectorScheduler.__new__(LMCacheOffloadConnectorScheduler)
+    sched._config = SimpleNamespace()
+    sched.kv_role = "offload"
+    sched.block_size = 4
+    sched.chunk_size = 4
+    sched._lookup_client = _LookupClient(hit=0)
+    sched._load_specs = {}
+    sched._reqs_need_recv = {}
+    sched._save_tracker = {}
+    sched._save_inflight = set()
+    sched._lookup_in_step = []
+    return sched
+
+
+@pytest.mark.parametrize("layout", ["segment", "segment_indexed"])
+def test_segment_major_codec_roundtrip_noncontiguous_blocks(monkeypatch, layout):
+    import torch
+    if not hasattr(torch, "arange"):
+        pytest.skip("real torch is unavailable")
+
+    monkeypatch.setenv("OFFLOAD_CODEC_LAYOUT", layout)
+
+    original = {
+        "l0": SimpleNamespace(
+            k_cache=torch.arange(8 * 2 * 3, dtype=torch.uint8).reshape(8, 2, 3),
+            v_cache=(torch.arange(8 * 4, dtype=torch.uint8).reshape(8, 4) + 51),
+            k_scale=torch.arange(8, dtype=torch.uint8).reshape(8, 1) + 101,
+            v_scale=torch.arange(8, dtype=torch.uint8).reshape(8, 1) + 151,
+        ),
+        "l1": SimpleNamespace(
+            k_cache=(torch.arange(8 * 3, dtype=torch.uint8).reshape(8, 3) + 201),
+            v_cache=(torch.arange(8 * 2, dtype=torch.uint8).reshape(8, 2) + 31),
+            k_scale=None,
+            v_scale=None,
+        ),
+    }
+    kv_caches = {
+        name: SimpleNamespace(
+            k_cache=layer.k_cache.clone(),
+            v_cache=layer.v_cache.clone(),
+            k_scale=layer.k_scale.clone() if layer.k_scale is not None else None,
+            v_scale=layer.v_scale.clone() if layer.v_scale is not None else None,
+        )
+        for name, layer in original.items()
+    }
+
+    codec = ATOMKVByteCodec(kv_caches)
+    block_ids = [1, 2, 4, 6, 7]
+    host = torch.empty(len(block_ids) * codec.bytes_per_block, dtype=torch.uint8)
+
+    codec.gpu_to_host(host, block_ids)
+    expected_calls = codec.segments_per_block * (3 if layout == "segment" else 2)
+    assert codec.copy_calls_for_block_ids(block_ids) == expected_calls
+
+    for layer in kv_caches.values():
+        layer.k_cache.zero_()
+        layer.v_cache.zero_()
+        if layer.k_scale is not None:
+            layer.k_scale.zero_()
+        if layer.v_scale is not None:
+            layer.v_scale.zero_()
+
+    codec.host_to_gpu(host, block_ids)
+
+    for name, layer in kv_caches.items():
+        src = original[name]
+        for bid in block_ids:
+            assert torch.equal(layer.k_cache[bid], src.k_cache[bid])
+            assert torch.equal(layer.v_cache[bid], src.v_cache[bid])
+            if layer.k_scale is not None:
+                assert torch.equal(layer.k_scale[bid], src.k_scale[bid])
+            if layer.v_scale is not None:
+                assert torch.equal(layer.v_scale[bid], src.v_scale[bid])
+
+
+def test_segment_indexed_stitches_chunk_buffers(monkeypatch):
+    import torch
+    if not hasattr(torch, "arange"):
+        pytest.skip("real torch is unavailable")
+
+    monkeypatch.setenv("OFFLOAD_CODEC_LAYOUT", "segment_indexed")
+    kv_caches = {
+        "l0": SimpleNamespace(
+            k_cache=torch.arange(8 * 2 * 3, dtype=torch.uint8).reshape(8, 2, 3),
+            v_cache=(torch.arange(8 * 4, dtype=torch.uint8).reshape(8, 4) + 51),
+            k_scale=torch.arange(8, dtype=torch.uint8).reshape(8, 1) + 101,
+            v_scale=torch.arange(8, dtype=torch.uint8).reshape(8, 1) + 151,
+        ),
+        "l1": SimpleNamespace(
+            k_cache=(torch.arange(8 * 3, dtype=torch.uint8).reshape(8, 3) + 201),
+            v_cache=(torch.arange(8 * 2, dtype=torch.uint8).reshape(8, 2) + 31),
+            k_scale=None,
+            v_scale=None,
+        ),
+    }
+    codec = ATOMKVByteCodec(kv_caches)
+    chunks = [[1, 2], [4], [6, 7]]
+    flat_ids = [bid for bids in chunks for bid in bids]
+    direct = torch.empty(len(flat_ids) * codec.bytes_per_block, dtype=torch.uint8)
+    codec.gpu_to_host(direct, flat_ids)
+
+    chunk_buffers = []
+    for bids in chunks:
+        host = torch.empty(len(bids) * codec.bytes_per_block, dtype=torch.uint8)
+        codec.gpu_to_host(host, bids)
+        chunk_buffers.append(host)
+
+    stitched = torch.empty_like(direct)
+    codec.stitch_chunk_buffers(stitched, chunk_buffers, [len(b) for b in chunks])
+
+    assert torch.equal(stitched, direct)
+
+
+def test_full_prompt_hit_is_clamped_before_load_spec():
+    sched = _scheduler()
+    sched._lookup_client = _LookupClient(hit=8)
+    seq = SimpleNamespace(
+        id=123,
+        num_prompt_tokens=8,
+        token_ids=list(range(8)),
+        num_cached_tokens=0,
+    )
+
+    need, should_park = sched.get_num_new_matched_tokens(seq)
+
+    assert need == 7
+    assert should_park is True
+    assert sched._load_specs[str(seq.id)].lmcache_cached_tokens == 7
+
+
+def test_load_exception_is_reported_as_failed_recving():
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._lock = threading.Lock()
+    conn._done_load = set()
+    conn._done_save = set()
+    conn._failed_load = set()
+    req = SimpleNamespace(req_id=42)
+
+    def boom(_req):
+        raise RuntimeError("load failed")
+
+    conn._guard("load", boom, req)
+
+    assert conn._done_load == set()
+    assert conn._failed_load == {42}
+
+
+def test_aggregator_emits_failed_recving_if_any_worker_failed():
+    agg = KVOutputAggregator(world_size=2)
+
+    result = agg.aggregate(
+        [
+            KVConnectorOutput(finished_recving={77}),
+            KVConnectorOutput(failed_recving={77}),
+        ]
+    )
+
+    assert result.finished_recving == set()
+    assert result.failed_recving == {77}
+
+
+def test_aggregator_failure_overrides_late_success():
+    agg = KVOutputAggregator(world_size=2)
+
+    result = agg.aggregate(
+        [
+            KVConnectorOutput(finished_recving={77}, failed_recving={77}),
+            KVConnectorOutput(finished_recving={77}),
+        ]
+    )
+
+    assert result.finished_recving == set()
+    assert result.failed_recving == {77}
+    assert agg.pending_count == (0, 0)
+
+
+def test_save_inflight_defers_free_until_save_finishes():
+    sched = _scheduler()
+    seq = SimpleNamespace(
+        id=9,
+        token_ids=list(range(8)),
+        block_table=[3, 4],
+        num_prompt_tokens=8,
+        prefix_hashes_published=True,
+    )
+    sched._save_tracker[str(seq.id)] = [seq, 0]
+
+    meta = sched.build_connector_meta()
+
+    assert len(meta.requests) == 1
+    assert meta.requests[0].save_spec is not None
+    assert sched.should_defer_free(seq) is True
+
+    sched.save_finished(seq.id)
+
+    assert sched.should_defer_free(seq) is False
+
+
+def test_finished_saving_releases_deferred_free_with_string_req_id():
+    class _BlockManager:
+        def __init__(self) -> None:
+            self.deallocated = []
+
+        def deallocate(self, seq) -> None:
+            self.deallocated.append(seq.id)
+
+    class _Connector:
+        is_producer = False
+
+        def __init__(self) -> None:
+            self.inflight = {"9"}
+
+        def save_finished(self, req_id) -> None:
+            self.inflight.discard(str(req_id))
+
+        def should_defer_free(self, seq) -> bool:
+            return str(seq.id) in self.inflight
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.block_manager = _BlockManager()
+    sched.kv_connector = _Connector()
+    seq = SimpleNamespace(id=9)
+    sched.deferred_free_blocks = {seq.id: seq}
+
+    sched._update_from_kv_xfer_finished(KVConnectorOutput(finished_saving={"9"}))
+
+    assert sched.block_manager.deallocated == [9]
+    assert sched.deferred_free_blocks == {}
+
+
+def test_finished_recv_matches_string_req_id():
+    sched = Scheduler.__new__(Scheduler)
+    sched.finished_recving_kv_req_ids = ["123"]
+
+    assert sched._update_waiting_for_remote_kv(SimpleNamespace(id=123)) is True
+    assert sched.finished_recving_kv_req_ids == []

--- a/tests/test_lmcache_offload_connector.py
+++ b/tests/test_lmcache_offload_connector.py
@@ -20,6 +20,7 @@ from atom.kv_transfer.offload.connector import (
     LMCacheOffloadConnector,
     LMCacheOffloadConnectorScheduler,
 )
+from atom.kv_transfer.offload import connector as offload_connector_mod
 from atom.kv_transfer.offload.gpu_connector import ATOMKVByteCodec
 from atom.model_engine.scheduler import Scheduler
 
@@ -27,9 +28,13 @@ from atom.model_engine.scheduler import Scheduler
 class _LookupClient:
     def __init__(self, hit: int) -> None:
         self.hit = hit
+        self.cleared = []
 
     def lookup(self, token_ids, lookup_id):
         return self.hit
+
+    def clear_lookup_status(self, lookup_id):
+        self.cleared.append(lookup_id)
 
 
 def _scheduler() -> LMCacheOffloadConnectorScheduler:
@@ -44,6 +49,8 @@ def _scheduler() -> LMCacheOffloadConnectorScheduler:
     sched._save_tracker = {}
     sched._save_inflight = set()
     sched._lookup_in_step = []
+    sched._lock = threading.Lock()
+    sched._done_load = set()
     return sched
 
 
@@ -145,6 +152,104 @@ def test_segment_indexed_stitches_chunk_buffers(monkeypatch):
 
     assert torch.equal(stitched, direct)
 
+    split_buffers = [torch.empty_like(buf) for buf in chunk_buffers]
+    codec.split_request_buffer(stitched, split_buffers, [len(b) for b in chunks])
+    for actual, expected in zip(split_buffers, chunk_buffers):
+        assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize("layout", ["block", "segment", "segment_indexed"])
+@pytest.mark.parametrize("method_name", ["gpu_to_host", "host_to_gpu"])
+def test_codec_rejects_invalid_block_ids_before_copy(monkeypatch, layout, method_name):
+    import torch
+    if not hasattr(torch, "arange"):
+        pytest.skip("real torch is unavailable")
+
+    monkeypatch.setenv("OFFLOAD_CODEC_LAYOUT", layout)
+    kv_caches = {
+        "l0": SimpleNamespace(
+            k_cache=torch.arange(4 * 2, dtype=torch.uint8).reshape(4, 2),
+            v_cache=torch.arange(4 * 2, dtype=torch.uint8).reshape(4, 2),
+            k_scale=None,
+            v_scale=None,
+        ),
+    }
+    codec = ATOMKVByteCodec(kv_caches)
+    host = torch.empty(2 * codec.bytes_per_block, dtype=torch.uint8)
+    method = getattr(codec, method_name)
+
+    with pytest.raises(ValueError, match="block id out of range"):
+        method(host, [0, 4])
+
+    with pytest.raises(ValueError, match="block id out of range"):
+        method(host, [-1])
+
+
+def test_codec_rejects_short_host_buffer(monkeypatch):
+    import torch
+    if not hasattr(torch, "arange"):
+        pytest.skip("real torch is unavailable")
+
+    monkeypatch.setenv("OFFLOAD_CODEC_LAYOUT", "segment_indexed")
+    kv_caches = {
+        "l0": SimpleNamespace(
+            k_cache=torch.arange(4 * 2, dtype=torch.uint8).reshape(4, 2),
+            v_cache=torch.arange(4 * 2, dtype=torch.uint8).reshape(4, 2),
+            k_scale=None,
+            v_scale=None,
+        ),
+    }
+    codec = ATOMKVByteCodec(kv_caches)
+    host = torch.empty(codec.bytes_per_block - 1, dtype=torch.uint8)
+
+    with pytest.raises(ValueError, match="host_buf is too small"):
+        codec.gpu_to_host(host, [0])
+
+
+def test_copy_stream_is_cached_per_codec_device(monkeypatch):
+    import torch
+    if not hasattr(torch, "device") or not hasattr(torch, "cuda"):
+        pytest.skip("torch cuda API is unavailable")
+
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._tls = threading.local()
+    conn._codec = SimpleNamespace(device=torch.device("cuda:1"))
+    active_devices = []
+    created_on = []
+
+    class _FakeDeviceCtx:
+        def __init__(self, device) -> None:
+            self.device = str(device)
+
+        def __enter__(self):
+            active_devices.append(self.device)
+            return None
+
+        def __exit__(self, *args):
+            active_devices.pop()
+            return False
+
+    class _FakeStream:
+        def __init__(self) -> None:
+            created_on.append(active_devices[-1] if active_devices else "default")
+
+    monkeypatch.setattr(
+        offload_connector_mod.torch.cuda,
+        "device",
+        lambda device: _FakeDeviceCtx(device),
+    )
+    monkeypatch.setattr(offload_connector_mod.torch.cuda, "Stream", _FakeStream)
+
+    rank1_stream = conn._stream()
+    assert conn._stream() is rank1_stream
+    assert created_on == ["cuda:1"]
+
+    conn._codec = SimpleNamespace(device=torch.device("cuda:0"))
+    rank0_stream = conn._stream()
+
+    assert rank0_stream is not rank1_stream
+    assert created_on == ["cuda:1", "cuda:0"]
+
 
 def test_full_prompt_hit_is_clamped_before_load_spec():
     sched = _scheduler()
@@ -161,6 +266,121 @@ def test_full_prompt_hit_is_clamped_before_load_spec():
     assert need == 7
     assert should_park is True
     assert sched._load_specs[str(seq.id)].lmcache_cached_tokens == 7
+
+
+def test_load_is_skipped_if_hbm_satisfies_after_allocation():
+    sched = _scheduler()
+    lookup = _LookupClient(hit=8)
+    sched._lookup_client = lookup
+    seq = SimpleNamespace(
+        id=321,
+        num_prompt_tokens=12,
+        token_ids=list(range(12)),
+        num_cached_tokens=0,
+        block_table=[1, 2, 3],
+    )
+
+    need, should_park = sched.get_num_new_matched_tokens(seq)
+    assert need == 8
+    assert should_park is True
+
+    # Prefix-cache allocation can discover a larger HBM hit than the lookup-time
+    # snapshot. In that case the scheduler still emits a no-op load so the
+    # normal worker aggregation path can wake the parked seq.
+    seq.num_cached_tokens = 8
+    sched.update_state_after_alloc(seq)
+    meta = sched.build_connector_meta()
+
+    assert len(meta.requests) == 1
+    req = meta.requests[0]
+    assert req.req_id == 321
+    assert req.token_ids == list(range(8))
+    assert req.block_ids == [1, 2, 3]
+    assert req.load_spec.hbm_cached_tokens == 8
+    assert req.load_spec.lmcache_cached_tokens == 8
+    assert seq.offload_loaded_tokens == 8
+    assert lookup.cleared == []
+
+
+def test_load_is_skipped_if_hbm_floor_is_not_chunk_aligned():
+    sched = _scheduler()
+    lookup = _LookupClient(hit=12)
+    sched._lookup_client = lookup
+    seq = SimpleNamespace(
+        id=654,
+        num_prompt_tokens=16,
+        token_ids=list(range(16)),
+        num_cached_tokens=0,
+        block_table=[1, 2, 3, 4],
+    )
+
+    need, should_park = sched.get_num_new_matched_tokens(seq)
+    assert need == 12
+    assert should_park is True
+
+    # HBM prefix cache can return block-size granularity, while LMCache chunks
+    # are larger. Loading from a non-chunk boundary would either overlap shared
+    # HBM blocks or leave a gap, so the scheduler wakes the seq with a no-op
+    # load and lets suffix prefill continue from the HBM floor.
+    seq.num_cached_tokens = 6
+    sched.update_state_after_alloc(seq)
+    meta = sched.build_connector_meta()
+
+    assert len(meta.requests) == 1
+    req = meta.requests[0]
+    assert req.req_id == 654
+    assert req.token_ids == list(range(6))
+    assert req.block_ids == [1, 2, 3, 4]
+    assert req.load_spec.hbm_cached_tokens == 6
+    assert req.load_spec.lmcache_cached_tokens == 6
+    assert seq.offload_loaded_tokens == 6
+
+
+def test_worker_completes_noop_load_when_hbm_satisfies():
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._lock = threading.Lock()
+    conn._done_load = set()
+    conn._failed_load = set()
+    conn._done_save = set()
+    conn._engine = SimpleNamespace(unpinned=[])
+    conn._engine.lookup_unpin = lambda ids: conn._engine.unpinned.extend(ids)
+
+    req = SimpleNamespace(
+        req_id=321,
+        token_ids=list(range(8)),
+        block_ids=[1, 2, 3],
+        load_spec=SimpleNamespace(hbm_cached_tokens=8, lmcache_cached_tokens=8),
+    )
+
+    conn._do_load_req(req)
+
+    assert conn._done_load == {321}
+    assert conn._failed_load == set()
+    assert conn._engine.unpinned == ["321"]
+
+
+def test_worker_reports_unaligned_hbm_load_as_failed_without_exception():
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._lock = threading.Lock()
+    conn._done_load = set()
+    conn._failed_load = set()
+    conn._done_save = set()
+    conn.chunk_size = 4
+    conn._engine = SimpleNamespace(unpinned=[])
+    conn._engine.lookup_unpin = lambda ids: conn._engine.unpinned.extend(ids)
+
+    req = SimpleNamespace(
+        req_id=654,
+        token_ids=list(range(12)),
+        block_ids=[1, 2, 3],
+        load_spec=SimpleNamespace(hbm_cached_tokens=6, lmcache_cached_tokens=12),
+    )
+
+    conn._do_load_req(req)
+
+    assert conn._done_load == set()
+    assert conn._failed_load == {654}
+    assert conn._engine.unpinned == ["654"]
 
 
 def test_load_exception_is_reported_as_failed_recving():
@@ -216,6 +436,7 @@ def test_save_inflight_defers_free_until_save_finishes():
         token_ids=list(range(8)),
         block_table=[3, 4],
         num_prompt_tokens=8,
+        num_cached_tokens=8,
         prefix_hashes_published=True,
     )
     sched._save_tracker[str(seq.id)] = [seq, 0]
@@ -229,6 +450,40 @@ def test_save_inflight_defers_free_until_save_finishes():
     sched.save_finished(seq.id)
 
     assert sched.should_defer_free(seq) is False
+
+
+def test_chunked_prefill_save_uses_computed_frontier_and_serializes_inflight():
+    sched = _scheduler()
+    seq = SimpleNamespace(
+        id=10,
+        token_ids=list(range(12)),
+        block_table=[3, 4, 5],
+        num_prompt_tokens=12,
+        num_cached_tokens=8,
+        is_partial_prefill=True,
+    )
+    sched._save_tracker[str(seq.id)] = [seq, 0]
+
+    meta1 = sched.build_connector_meta()
+
+    assert len(meta1.requests) == 1
+    assert len(meta1.requests[0].token_ids) == 8
+    assert meta1.requests[0].save_spec.skip_leading_tokens == 0
+    assert meta1.requests[0].is_last_prefill is False
+    assert sched.should_defer_free(seq) is True
+
+    seq.num_cached_tokens = 12
+    seq.is_partial_prefill = False
+    meta2 = sched.build_connector_meta()
+    assert len(meta2.requests) == 0
+
+    sched.save_finished(seq.id)
+    meta3 = sched.build_connector_meta()
+
+    assert len(meta3.requests) == 1
+    assert len(meta3.requests[0].token_ids) == 12
+    assert meta3.requests[0].save_spec.skip_leading_tokens == 8
+    assert meta3.requests[0].is_last_prefill is True
 
 
 def test_finished_saving_releases_deferred_free_with_string_req_id():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -98,6 +98,42 @@ class TestSchedule:
         assert batch.total_tokens_num_prefill == 6
         assert list(batch.num_scheduled_tokens) == [4, 2]
 
+    def test_chunked_prefill_splits_prompt_across_steps(self, seq_factory):
+        sched = Scheduler(
+            MockConfig(
+                max_num_batched_tokens=6,
+                num_kvcache_blocks=100,
+                kv_cache_block_size=4,
+                enable_chunked_prefill=True,
+            )
+        )
+        seq = seq_factory(list(range(10)))
+        sched.add(seq)
+
+        batch1, _ = sched.schedule()
+        assert batch1.total_tokens_num_prefill == 6
+        assert list(batch1.scheduled_tokens) == list(range(6))
+        assert list(batch1.num_cached_tokens) == [0]
+
+        sched.postprocess(
+            list(sched.running),
+            ScheduledBatchOutput(
+                req_ids=[],
+                token_ids=[],
+                num_rejected=None,
+                num_bonus=None,
+                draft_token_ids=None,
+            ),
+            batch=batch1,
+        )
+        assert seq.is_partial_prefill is True
+        assert seq.num_cached_tokens == 6
+
+        batch2, _ = sched.schedule()
+        assert batch2.total_tokens_num_prefill == 4
+        assert list(batch2.scheduled_tokens) == list(range(6, 10))
+        assert list(batch2.num_cached_tokens) == [6]
+
     def test_prefill_respects_block_availability(self, seq_factory):
         sched = Scheduler(MockConfig(num_kvcache_blocks=1, kv_cache_block_size=4))
         sched.add(seq_factory([1, 2, 3, 4]))  # 1 block


### PR DESCRIPTION
## Summary
- Add the standalone LMCache CPU/NVMe KV offload connector, metadata/config plumbing, and ATOM byte-codec storage path.
- Add async save/load copy paths, segment-indexed stitch/split fast paths, request-level reload fast path, validation, profiling, and optional trace logging.
- Integrate offload wake/failure handling with scheduler chunked prefill and add regression coverage for connector, codec, save/load, and scheduler behavior.

## Test Report
- PASS: `git diff --check`
- PASS: `python3 -m py_compile atom/config.py atom/kv_transfer/disaggregation/aggregator.py atom/kv_transfer/offload/connector.py atom/kv_transfer/offload/gpu_connector.py atom/kv_transfer/offload/native_stitch.py atom/kv_transfer/offload/trace.py atom/model_engine/engine_core.py atom/model_engine/model_runner.py atom/model_engine/scheduler.py atom/model_engine/sequence.py atom/model_ops/attentions/backends.py tests/conftest.py tests/test_lmcache_offload_connector.py tests/test_scheduler.py`
- PASS: `python3 -m pytest -q tests/test_lmcache_offload_connector.py tests/test_scheduler.py` -> `42 passed, 11 skipped in 0.17s`
- BLOCKED: `python3 -m pytest -q` fails during collection in the current local environment because required test dependencies/modules are unavailable (`pydantic`, `torch`, `msgpack`, `atom.kv_transfer.disaggregation.kv_transfer_engine`) and one existing import path reports `atom.plugin.is_vllm` unavailable; no test body ran before collection stopped.

## Base
- Rebased on `origin/main` at `9f9e97b`.
