### PR TITLE
fix(spec_decode): support DP attention with MTP in Deepseek V4

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -953,9 +953,7 @@ class ModelRunner:
         if draft_bs is None:
             draft_bs = forward_context.context.graph_bs
         for i in range(self.drafter.mtp_k):
-            self.drafter._refresh_dp_metadata(
-                forward_context, hidden_states.shape[0]
-            )
+            self.drafter._refresh_dp_metadata(forward_context, hidden_states.shape[0])
             hidden_states = self.drafter.model(
                 input_ids=torch.zeros(
                     hidden_states.shape[0],

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -953,6 +953,9 @@ class ModelRunner:
         if draft_bs is None:
             draft_bs = forward_context.context.graph_bs
         for i in range(self.drafter.mtp_k):
+            self.drafter._refresh_dp_metadata(
+                forward_context, hidden_states.shape[0]
+            )
             hidden_states = self.drafter.model(
                 input_ids=torch.zeros(
                     hidden_states.shape[0],
@@ -975,7 +978,9 @@ class ModelRunner:
     def dummy_execution(self):
         """Execute dummy decode batch for DP synchronization."""
         # num_tokens_original = 1
-        mtp_factor = (self.drafter.mtp_k + 1) if hasattr(self, "drafter") else 1
+        has_drafter = hasattr(self, "drafter")
+        mtp_k = self.drafter.mtp_k if has_drafter else 0
+        mtp_factor = mtp_k + 1
         num_tokens_original = mtp_factor
 
         seq = Sequence([0] * num_tokens_original, block_size=self.block_size, id=-1)
@@ -983,6 +988,7 @@ class ModelRunner:
         seq.type = SequenceType.DECODE
         seq.block_table = [0]
 
+        spec_tokens = {seq.id: np.zeros(mtp_k, dtype=np.int32)} if mtp_k > 0 else None
         dummy_batch = ScheduledBatch(
             seqs={seq.id: seq},
             num_scheduled_tokens=np.array([num_tokens_original], dtype=np.int32),
@@ -991,6 +997,8 @@ class ModelRunner:
             total_seqs_num=1,
             total_seqs_num_decode=1,
             is_dummy_run=True,
+            num_spec_step=mtp_k,
+            scheduled_spec_decode_tokens=spec_tokens,
         )
 
         self.forward(dummy_batch)

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -11,7 +11,11 @@ from atom.config import CompilationLevel, Config, KVCacheTensor
 from atom.model_loader.loader import load_model
 from atom.utils import CpuGpuBuffer, resolve_obj_by_qualname
 from atom.utils import envs
-from atom.utils.forward_context import SpecDecodeMetadata, get_forward_context
+from atom.utils.forward_context import (
+    DPMetadata,
+    SpecDecodeMetadata,
+    get_forward_context,
+)
 from torch.profiler import record_function
 
 logger = logging.getLogger("atom")
@@ -313,6 +317,16 @@ class EagleProposer:
             "lm_head",
         )
 
+    def _refresh_dp_metadata(self, forward_context, num_local_tokens: int) -> None:
+        parallel_config = self.config.parallel_config
+        if parallel_config.data_parallel_size <= 1:
+            return
+        forward_context.context.dp_uniform_decode = False
+        forward_context.dp_metadata = DPMetadata.make(
+            parallel_config,
+            num_local_tokens,
+        )
+
     def propose(
         self,
         # [num_tokens]
@@ -376,6 +390,8 @@ class EagleProposer:
 
         for i in range(self.mtp_k):
             with record_function(f"draft[{i}/{self.mtp_k} bs={bs}]"):
+                # Re-sync DP token
+                self._refresh_dp_metadata(forward_context, input_ids.shape[0])
                 ret_hidden_states = self.model(
                     input_ids=input_ids,
                     positions=positions,


### PR DESCRIPTION
Refresh dp_metadata per draft step (force variable-length DP path) and add num_spec_step + scheduled_spec_decode_tokens to the dummy decode batch so DP+MTP runs stay in lockstep.

dp + ds v4 + mtp3:
8k1k:
```
32: 15216.91
64: 22374.76
128: 29604.59
256: 34000
512: 39157.95
```

1k/1k
```
32: 4281.97
64: 7375.24
128: 11296.76
```

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
