### PR TITLE
[fix](attn): fix slot mapping in model runner v2

### DIFF
--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -225,6 +225,7 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
         # and the origin kv cache layout in fwd_args is not flash
 
         attn_metadata = attention_metadata
+        slot_mapping = attn_metadata.slot_mapping[: q.shape[0]]
 
         use_triton_attn = self.sliding_window != -1 or self.head_dim != 128
         # use_triton_attn = True
@@ -264,7 +265,7 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
                     v_cache=new_value_cache,
                     k_scale=k_scale,
                     v_scale=v_scale,
-                    slot_mapping=attn_metadata.slot_mapping,
+                    slot_mapping=slot_mapping,
                     kv_cache_dtype=self.kv_cache_dtype,
                 )
                 # Reshape q, k for attention: [T, num_heads, head_dim]
@@ -289,7 +290,7 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
                     pos_ids=position,
                     k_cache=new_key_cache,
                     v_cache=new_value_cache,
-                    slot_mapping=attn_metadata.slot_mapping,
+                    slot_mapping=slot_mapping,
                     kv_cache_dtype=(
                         "auto" if self.kv_cache_dtype == "bf16" else self.kv_cache_dtype
                     ),
@@ -305,7 +306,7 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
                 v,
                 new_key_cache,
                 new_value_cache,
-                attn_metadata.slot_mapping,
+                slot_mapping,
                 position,
                 self.rotary_emb.cos_cache,
                 self.rotary_emb.sin_cache,
@@ -342,7 +343,7 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
                     new_value_cache,
                     k_scale,
                     v_scale,
-                    attn_metadata.slot_mapping,
+                    slot_mapping,
                     asm_layout=asm_layout,
                 )
             else:
@@ -351,7 +352,7 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
                     v,
                     new_key_cache,
                     new_value_cache,
-                    attn_metadata.slot_mapping,
+                    slot_mapping,
                     kv_cache_dtype="auto",
                     k_scale=None,
                     v_scale=None,


### PR DESCRIPTION
## Motivation

this pr fixed slot mapping error when using `VLLM_USE_V2_MODEL_RUNNER=1` in vllm. the attn_metadata.slot_mapping will be paded in model runner v2, so we need slice the real shape in attention metadata. there is about 4% performance improvement in small model like gpt-oss-120b when using model runner v2.

## TEST

<img width="523" height="78" alt="image" src="https://github.com/user-attachments/assets/53844550-189a-4584-af4c-3e6e2e7bc05b" />
