### PR TITLE
Add HIP MLA reduce kernel dispatch logic

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -41,6 +41,8 @@ from aiter.ops.triton.batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched
     batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant as _aiter_triton_fp8_bmm,
 )
 
+from aiter.mla_v_up_proj import mla_reduce_decode
+
 concat_and_cache_mla = mark_trace(
     concat_and_cache_mla, prefix="kv_cache", torch_compile=False
 )
@@ -816,26 +818,51 @@ class MLAAttention(nn.Module):
                 reduce_final_map = attn_metadata.reduce_final_map
                 reduce_partial_map = attn_metadata.reduce_partial_map
 
-            mla_decode_fwd(
-                q,
-                kv_buffer.view(-1, 1, 1, q.shape[-1]),
-                o,
-                paged_cu_seqlens_q,
-                paged_kv_indptr,
-                paged_kv_indices,
-                paged_kv_last_page_lens,
-                max_q_len,
-                num_kv_splits=16,
-                sm_scale=self.scale,
-                work_meta_data=work_meta_data,
-                work_indptr=work_indptr,
-                work_info_set=work_info_set,
-                reduce_indptr=reduce_indptr,
-                reduce_final_map=reduce_final_map,
-                reduce_partial_map=reduce_partial_map,
-                q_scale=self._q_scale,
-                kv_scale=self._k_scale,
-            )
+            reduced = None
+            if (
+                envs.ATOM_ENABLE_HIP_MLA_REDUCE
+                and is_rocm_aiter_fp4bmm_enabled()
+                and self.padded_num_heads == 16
+            ):
+                reduced = mla_reduce_decode(
+                    q,
+                    kv_buffer,
+                    o,
+                    cu_seqlens_q=paged_cu_seqlens_q,
+                    kv_indptr=paged_kv_indptr,
+                    kv_indices=paged_kv_indices,
+                    kv_last_page_lens=paged_kv_last_page_lens,
+                    max_seqlen_q=max_q_len,
+                    scale=self.scale,
+                    q_scale=self._q_scale,
+                    k_scale=self._k_scale,
+                    kv_lora_rank=self.kv_lora_rank,
+                    v_head_dim=self.v_head_dim,
+                )
+
+            if reduced is not None:
+                o = reduced
+            else:
+                mla_decode_fwd(
+                    q,
+                    kv_buffer.view(-1, 1, 1, q.shape[-1]),
+                    o,
+                    paged_cu_seqlens_q,
+                    paged_kv_indptr,
+                    paged_kv_indices,
+                    paged_kv_last_page_lens,
+                    max_q_len,
+                    num_kv_splits=16,
+                    sm_scale=self.scale,
+                    work_meta_data=work_meta_data,
+                    work_indptr=work_indptr,
+                    work_info_set=work_info_set,
+                    reduce_indptr=reduce_indptr,
+                    reduce_final_map=reduce_final_map,
+                    reduce_partial_map=reduce_partial_map,
+                    q_scale=self._q_scale,
+                    kv_scale=self._k_scale,
+                )
 
         if self.head_repeat_factor > 1:
             o = o[:, :: self.head_repeat_factor, :].contiguous()

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -71,6 +71,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_SILU_MUL_QUANT": lambda: (
         os.getenv("ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_SILU_MUL_QUANT", "1") == "1"
     ),
+    "ATOM_ENABLE_HIP_MLA_REDUCE": lambda: (
+        os.getenv("ATOM_ENABLE_HIP_MLA_REDUCE", "1") == "1"
+    ),
     # --- Profiling & Logging ---
     "ATOM_TORCH_PROFILER_DIR": lambda: os.getenv("ATOM_TORCH_PROFILER_DIR", None),
     "ATOM_PROFILER_MORE": lambda: os.getenv("ATOM_PROFILER_MORE", "0") == "1",


### PR DESCRIPTION
Add HIP MLA reduce kernel dispatch logic. Rely on https://github.com/ROCm/aiter/pull/3468.

## Performance Result

- E2E (rocprof, Kimi K2.5, conc128): the decode reduce drops from **7997 ns**
  (stock `kn_mla_reduce_v1_ps`) to **6176 ns** (ours), ~1.3×.
- Microbench (conc64, plain TP4, H=16 / K=512): stock `mla_reduce_v1` ~4.7 µs →
  ours (adaptive) ~2.5 µs, ~1.9×. Correctness checked bit-faithful against a
  torch reference (atol/rtol 2e-2).



