### PR TITLE
ci(benchmark): raise benchmark drain MAX_MIN 30→60 and step timeout 60→80

### DIFF
--- a/.github/scripts/atom_test.sh
+++ b/.github/scripts/atom_test.sh
@@ -410,7 +410,11 @@ if [ "$TYPE" == "benchmark" ]; then
 
   echo "========== Supervising benchmark with wait_infer_drain.sh =========="
   # See accuracy block above for STUCK_POLLS=18 rationale.
-  bash scripts/wait_infer_drain.sh 8000 30 10 "$ATOM_CLIENT_LOG" 18
+  # MAX_MIN=60: high-concurrency long-context runs (e.g. DP-attention 8k/1k
+  # c=1024 with num_prompts=conc*10) take ~48 min wall (warmup + 10240 reqs);
+  # 30 min cut them off mid-run (drain exit 4). Real hangs/faults still
+  # surface fast via STUCK_POLLS / fault detection, not MAX_MIN.
+  bash scripts/wait_infer_drain.sh 8000 60 10 "$ATOM_CLIENT_LOG" 18
   DRAIN_RC=$?
   if [ "$DRAIN_RC" -ne 0 ]; then
     echo "wait_infer_drain.sh exit=$DRAIN_RC — killing benchmark pgid $CLIENT_PID"

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -316,7 +316,7 @@ jobs:
           MODEL_PROGRESS_INTERVAL: "60"
 
       - name: Run benchmark
-        timeout-minutes: 60
+        timeout-minutes: 80
         run: |
           set -euo pipefail
           if [ -d "/models" ]; then model_path="/models/${{ env.MODEL_PATH }}"


### PR DESCRIPTION
## Problem

The new **DeepSeek-V4-Pro DP (isl=8192 osl=1024 c=1024)** benchmark job fails at *Run benchmark* with `Process completed with exit code 4` — `wait_infer_drain.sh`'s MAX_MIN timeout, **not** an OOM, hang, or crash. ([failing run](https://github.com/ROCm/ATOM/actions/runs/26719406873/job/78743686417))

At c=1024 the benchmark runs `num_prompts = conc * 10 = 10240`. For 8k/1k that is:
- ~14 min warmup (2048 warmup reqs × 8k prefill at c=1024)
- ~34 min measured run (10 waves of 1024 prompts, steady ~3:20/wave)
- **~48 min total wall**

The benchmark drain's `MAX_MIN=30` cut it off at ~40% (`outputs=3071`, drain `[t=1800s]`) while the server was healthy and still progressing → exit 4.

## Fix

- `.github/scripts/atom_test.sh`: benchmark drain `MAX_MIN` **30 → 60**
- `.github/workflows/atom-benchmark.yaml`: *Run benchmark* step `timeout-minutes` **60 → 80**

(`80 > server-start + 60` so the GitHub step ceiling never pre-empts the drain.)

## Why this is safe
- Fast jobs are unaffected — drain exits when the client finishes, well before MAX_MIN.
- Genuine hangs/faults still surface quickly: STUCK_POLLS=18 (3 min no-progress → exit 1) and fault detection (≤10 s → exit 2). MAX_MIN is only the last-resort ceiling for *slow-but-progressing* runs.
- The **accuracy** drain (`MAX_MIN=30`) is left unchanged.

## Note
Complements #986 (which adds the c=512/1024 DP-attention points at util 0.85). Without this, the c=1024 8k/1k point times out.