### PR TITLE
Handle unreadable traced files in compile cache

### DIFF
--- a/atom/utils/backends.py
+++ b/atom/utils/backends.py
@@ -582,12 +582,15 @@ class VllmBackend:
             hash_content = []
             for filepath in forward_code_files:
                 hash_content.append(filepath)
-                if filepath == "<string>" or filepath == "<frozen os>":
+                if filepath == "<string>" or filepath.startswith("<frozen "):
                     # This means the function was dynamically generated, with
-                    # e.g. exec() or frozen os module. We can't actually check these.
+                    # e.g. exec() or a frozen stdlib module. We can't actually check these.
                     continue
-                with open(filepath) as f:
-                    hash_content.append(f.read())
+                try:
+                    with open(filepath) as f:
+                        hash_content.append(f.read())
+                except (OSError, UnicodeDecodeError):
+                    logger.warning("Failed to read traced file %s", filepath)
             import hashlib
 
             code_hash = hashlib.md5(


### PR DESCRIPTION
## Summary
- Skip Torch Dynamo virtual traced files such as `<frozen posixpath>` when computing the ATOM compile cache hash.
- Warn and continue when a traced file cannot be read, preventing vLLM server startup from failing during compile cache setup.

## Test plan
- `python3 -m py_compile /shared/amdgpu/home/xiaobing_zhang_qle/hattie/ATOM/atom/utils/backends.py`
- Cursor linter check for `atom/utils/backends.py`


Made with [Cursor](https://cursor.com)