### PR TITLE
fix: warmup uses full token budget for DP

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1056,7 +1056,11 @@ class ModelRunner:
             self.config.max_num_batched_tokens,
             self.config.max_model_len,
         )
-        warmup_max_tokens = max_num_batched_tokens
+        dp_size = get_dp_group().world_size
+        if self.config.enable_dp_attention:
+            warmup_max_tokens = max_num_batched_tokens
+        else:
+            warmup_max_tokens = max_num_batched_tokens // dp_size
 
         num_seqs = min(warmup_max_tokens // max_model_len, self.config.max_num_seqs)
 
@@ -1066,8 +1070,8 @@ class ModelRunner:
             if seq_len == 0:
                 seq_len = 1
             logger.warning(
-                f"{self.label}: warmup_max_tokens={warmup_max_tokens} (=max_num_batched_tokens) "
-                f"< max_model_len={max_model_len}. "
+                f"{self.label}: dp_size={dp_size}, dp_attn={self.config.enable_dp_attention}, "
+                f"warmup_max_tokens={warmup_max_tokens} < max_model_len={max_model_len}. "
                 f"Using {num_seqs} seq with length {seq_len} for warmup."
             )
         else:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1056,8 +1056,7 @@ class ModelRunner:
             self.config.max_num_batched_tokens,
             self.config.max_model_len,
         )
-        dp_size = get_dp_group().world_size
-        warmup_max_tokens = max_num_batched_tokens // dp_size
+        warmup_max_tokens = max_num_batched_tokens
 
         num_seqs = min(warmup_max_tokens // max_model_len, self.config.max_num_seqs)
 
@@ -1067,7 +1066,8 @@ class ModelRunner:
             if seq_len == 0:
                 seq_len = 1
             logger.warning(
-                f"{self.label}: DP size={dp_size} too large, warmup_max_tokens={warmup_max_tokens} < max_model_len={max_model_len}. "
+                f"{self.label}: warmup_max_tokens={warmup_max_tokens} (=max_num_batched_tokens) "
+                f"< max_model_len={max_model_len}. "
                 f"Using {num_seqs} seq with length {seq_len} for warmup."
             )
         else:


### PR DESCRIPTION
Warmup now uses the full `max_num_batched_tokens` instead of dividing by `dp_size`. Under DP attention each rank's MoE sees up to `dp_size * local_tokens` after the all-gather, so warmup must exercise the full token budget to capture the true peak activation / CUDA-graph footprint; dividing by dp_size under-sized warmup and let decode OOM later. Also updated the warning message accordingly.