### PR TITLE
[feature] Support deepseekv4 online quantization

### DIFF
--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -19,7 +19,7 @@ from aiter.ops.gated_rmsnorm_fp8_group_quant import gated_rmsnorm_fp8_group_quan
 from aiter.ops.triton.fused_add_rmsnorm_pad import fused_add_rmsnorm_pad
 from atom.config import QuantizationConfig
 from atom.model_ops.utils import atom_parameter
-from atom.quant_spec import LayerQuantConfig
+from atom.quant_spec import LayerQuantConfig, should_skip_online_quant
 from atom.utils.decorators import mark_trace
 from atom.utils import envs
 from torch import Tensor, nn
@@ -285,13 +285,8 @@ class RMSNorm(nn.Module):
             self.prefix, use_online_quant=True
         )
         online_quant_type = online_cfg.quant_type
-        if online_quant_type == QuantType.No:
-            return
-        # Already emitting the target scheme; avoid a redundant update.
-        if (
-            self.quant_type == online_quant_type
-            and self.params_dtype == online_cfg.quant_dtype
-        ):
+        # Skip if excluded (No) or already emitting the target scheme.
+        if should_skip_online_quant(self.quant_type, self.params_dtype, online_cfg):
             return
         # The fused RMSNorm+quant HIP kernel only emits these activation schemes.
         assert online_quant_type.value in _AITER_RMS_QUANT_TYPE_VALUES, (

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -227,6 +227,8 @@ class RMSNorm(nn.Module):
         self.fused_allreduce = fused_allreduce
         self.use_fused_quant = fused_quant
         self.tp_size = get_tensor_model_parallel_world_size()
+        self.quant_config = quant_config
+        self.prefix = prefix
 
         layer_quant_config = (
             LayerQuantConfig()
@@ -245,6 +247,72 @@ class RMSNorm(nn.Module):
             and quant_type.value == _QV_PER_1X128
             and envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
         )
+
+    def process_weights_after_loading(self):
+        """Post-load hook invoked by the model loader for every module.
+
+        RMSNorm has no weights to re-quantize, but when online quantization is
+        enabled the fused RMSNorm+quant activation scheme may need to follow the
+        downstream weight's online-quant target -- delegated to
+        ``online_quantize_activation``.
+        """
+        # Only the fused-quant path's output depends on `quant_type`; a plain
+        # RMSNorm emits BF16 regardless, so nothing to realign.
+        if self.use_fused_quant:
+            self.online_quantize_activation()
+
+    def online_quantize_activation(self):
+        """Realign the fused RMSNorm activation quant scheme with online quant.
+
+        The fused RMSNorm+quant path emits a quantized activation that a
+        downstream Linear consumes directly without re-quantizing (e.g.
+        DeepSeek-V4 ``q_norm`` -> ``attn.wq_b`` / ``indexer.wq_b``). The GEMM
+        interprets that activation's dtype/scale layout according to the
+        *weight*'s quant scheme. So when online quantization re-quantizes the
+        consumer's weight to a new scheme (e.g. mxfp4 = per_1x32 + fp4x2), the
+        activation emitted here MUST switch to the same scheme; otherwise the
+        per_1x32 GEMM bit-reinterprets a per_1x128 fp8 activation via
+        ``view(fp4x2)`` / ``view(e8m0)`` and produces garbage.
+
+        Mirrors ``LinearBase.online_quantize_weight``'s quant-state update, but
+        there is no weight to re-quantize here -- only the emitted activation
+        ``quant_type`` / ``params_dtype`` (and the derived scale layout).
+        """
+        if self.quant_config is None or not self.quant_config.online_quant:
+            return
+
+        online_cfg = self.quant_config.get_layer_quant_config(
+            self.prefix, use_online_quant=True
+        )
+        online_quant_type = online_cfg.quant_type
+        if online_quant_type == QuantType.No:
+            return
+        # Already emitting the target scheme; avoid a redundant update.
+        if (
+            self.quant_type == online_quant_type
+            and self.params_dtype == online_cfg.quant_dtype
+        ):
+            return
+        # The fused RMSNorm+quant HIP kernel only emits these activation schemes.
+        assert online_quant_type.value in _AITER_RMS_QUANT_TYPE_VALUES, (
+            f"Unsupported online activation quant for fused RMSNorm: "
+            f"type={online_quant_type}, dtype={online_cfg.quant_dtype} "
+            f"(layer={self.prefix})"
+        )
+
+        self.quant_type = online_quant_type
+        self.params_dtype = online_cfg.quant_dtype
+        self._aiter_transpose_scale = (
+            self.quant_type.value == _QV_PER_1X128
+            and envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
+        )
+        # Surfaced by the loader's online-quant report alongside Linear layers.
+        self._online_quant_info = {
+            "layer": self.prefix,
+            "quant_type": online_quant_type.name,
+            "quant_dtype": str(online_cfg.quant_dtype),
+            "kind": "rmsnorm_activation",
+        }
 
     @mark_trace(prefix="rmsnorm", torch_compile=True)
     def forward(

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -452,7 +452,14 @@ class LinearBase(nn.Module):
             self.prefix, use_online_quant=True
         )
         online_quant_type = online_layer_quant_config.quant_type
+        if online_quant_type == QuantType.No:
+            return
         online_quant_dtype = online_layer_quant_config.quant_dtype
+        if (
+            self.quant_type == online_quant_type
+            and self.params_dtype == online_quant_dtype
+        ):
+            return
         online_quant_func = get_hip_quant(online_quant_type)
         assert online_quant_dtype in [
             torch.float8_e4m3fn,

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -23,7 +23,7 @@ from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.tuned_gemm import tgemm
 from aiter.utility import fp4_utils
 from atom.config import QuantizationConfig, get_current_atom_config
-from atom.quant_spec import LayerQuantConfig
+from atom.quant_spec import LayerQuantConfig, should_skip_online_quant
 from atom.model_ops.utils import (
     atom_parameter,
     normalize_e4m3fn_to_e4m3fnuz,
@@ -452,12 +452,9 @@ class LinearBase(nn.Module):
             self.prefix, use_online_quant=True
         )
         online_quant_type = online_layer_quant_config.quant_type
-        if online_quant_type == QuantType.No:
-            return
         online_quant_dtype = online_layer_quant_config.quant_dtype
-        if (
-            self.quant_type == online_quant_type
-            and self.params_dtype == online_quant_dtype
+        if should_skip_online_quant(
+            self.quant_type, self.params_dtype, online_layer_quant_config
         ):
             return
         online_quant_func = get_hip_quant(online_quant_type)

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2208,10 +2208,18 @@ class FusedMoE(torch.nn.Module):
             self.layer_name, use_online_quant=True
         )
         online_quant_type = online_quant_config.quant_type
+        if online_quant_type == QuantType.No:
+            return
         online_quant_dtype = online_quant_config.quant_dtype
-        quant_func = get_hip_quant(online_quant_type)
 
         source_quant_type = self.layer_quant_config.quant_type
+        if (
+            source_quant_type == online_quant_type
+            and self.params_dtype == online_quant_dtype
+        ):
+            return
+
+        quant_func = get_hip_quant(online_quant_type)
         assert source_quant_type in (QuantType.No, QuantType.per_1x128), (
             f"Unsupported source quant_type for MoE online quantization: "
             f"{source_quant_type} (layer={self.layer_name})"

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -20,7 +20,7 @@ from atom.config import (
     get_current_atom_config,
 )
 from aiter.ops.flydsl.moe_common import GateMode
-from atom.quant_spec import LayerQuantConfig
+from atom.quant_spec import LayerQuantConfig, should_skip_online_quant
 from atom.model_loader.weight_utils import set_weight_attrs
 from atom.model_ops.base_config import QuantizeMethodBase
 from atom.model_ops.fused_moe.config import (
@@ -2208,14 +2208,10 @@ class FusedMoE(torch.nn.Module):
             self.layer_name, use_online_quant=True
         )
         online_quant_type = online_quant_config.quant_type
-        if online_quant_type == QuantType.No:
-            return
         online_quant_dtype = online_quant_config.quant_dtype
-
         source_quant_type = self.layer_quant_config.quant_type
-        if (
-            source_quant_type == online_quant_type
-            and self.params_dtype == online_quant_dtype
+        if should_skip_online_quant(
+            source_quant_type, self.params_dtype, online_quant_config
         ):
             return
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -459,12 +459,9 @@ def make_v4_quant_config(hf_config, model_path=None, online_quant_config=None):
         # V4-Flash-FP8 layout: wo_a is BF16 on disk — allocate as BF16 directly
         # so the loader receives matching dtype. Other SKUs let wo_a allocate
         # as FP8 + scale and DeepseekV4Attention dequants at load time.
-        if wo_a_is_bf16 and ".wo_a" in layer_name:
-            return no_spec
-        # NOTE: wo_a is FP8 on disk but used as BF16 in forward (aiter has no FP8
-        # grouped einsum). When online_quant is enabled, also keep wo_a BF16 so
+        # When online_quant is enabled, also keep wo_a BF16 so
         # the dequant→requant round-trip is skipped for this layer.
-        if use_online_quant and "attn.wo_a" in layer_name:
+        if ".wo_a" in layer_name and (wo_a_is_bf16 or use_online_quant):
             return no_spec
         return orig_lookup(
             layer_name,

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -367,7 +367,7 @@ def _wo_a_is_bf16_on_disk(model_path):
     return False
 
 
-def make_v4_quant_config(hf_config, model_path=None):
+def make_v4_quant_config(hf_config, model_path=None, online_quant_config=None):
     """Build a QuantizationConfig that knows V4's per-layer quant scheme.
 
     Two V4 SKUs supported:
@@ -391,9 +391,17 @@ def make_v4_quant_config(hf_config, model_path=None):
       - `Compressor.wkv` / `Compressor.wgate` / `indexer.weights_proj`: BF16
         (or fp32 internally; reference declares dtype= explicitly). Loaded raw.
       - All RMSNorm weights, attn_sink, hc_*: BF16/fp32 raw, no quant.
+
+    The optional ``online_quant_config`` is forwarded to the base
+    QuantizationConfig so V4 models can also be re-quantized at load time
+    (e.g. ``ptpc_fp8`` / ``mxfp4``). V4's hardcoded per-layer overrides
+    (FP4 routed experts, BF16 compressor / indexer.weights_proj) are
+    preserved on BOTH the source lookup AND the online lookup — returning
+    the same spec on the online path triggers the FusedMoE/Linear
+    ``source == online_target`` early-return so those layers stay untouched.
     """
 
-    base = QuantizationConfig(hf_config)
+    base = QuantizationConfig(hf_config, online_quant_config=online_quant_config)
 
     fp4_spec = LayerQuantConfig(quant_type=QuantType.per_1x32, quant_dtype=dtypes.fp4x2)
     # FP8 per-block 128x128 — V4-Flash-Base routed path.
@@ -427,12 +435,18 @@ def make_v4_quant_config(hf_config, model_path=None):
 
     orig_lookup = base.get_layer_quant_config
 
-    def overridden(layer_name, *, check_children=False):
+    def overridden(layer_name, use_online_quant=False, *, check_children=False):
         # Routed experts → SKU-detected (FP4 for V4-Pro, FP8-block for V4-Flash).
         # Match both per-expert prefix `layers.N.ffn.experts.M.w{1,2,3}` (used
         # by individual Linear lookups, with trailing `.M.w1`) AND the bare
         # `layers.N.ffn.experts` prefix (used by FusedMoE.__init__ when
         # constructing fused expert params — has NO trailing dot).
+        #
+        # V4 hardcoded specs apply on BOTH source AND online lookups. When
+        # online_quant is enabled, returning the source spec here means
+        # FusedMoE/Linear see `source == online_target` and skip the
+        # dequant→requant round-trip for these layers (which would either
+        # crash on the moe assert or further damage already-quantized weights).
         if ".ffn.experts" in layer_name:
             return routed_spec
         # BF16 / fp32 raw paths
@@ -447,7 +461,16 @@ def make_v4_quant_config(hf_config, model_path=None):
         # as FP8 + scale and DeepseekV4Attention dequants at load time.
         if wo_a_is_bf16 and ".wo_a" in layer_name:
             return no_spec
-        return orig_lookup(layer_name, check_children=check_children)
+        # NOTE: wo_a is FP8 on disk but used as BF16 in forward (aiter has no FP8
+        # grouped einsum). When online_quant is enabled, also keep wo_a BF16 so
+        # the dequant→requant round-trip is skipped for this layer.
+        if use_online_quant and "attn.wo_a" in layer_name:
+            return no_spec
+        return orig_lookup(
+            layer_name,
+            use_online_quant=use_online_quant,
+            check_children=check_children,
+        )
 
     base.get_layer_quant_config = overridden
     return base
@@ -2709,8 +2732,14 @@ class DeepseekV4ForCausalLM(nn.Module):
         # weight + scale params for real-checkpoint loading. When the HF
         # config lacks `quantization_config` (e.g. dummy / toy validation),
         # this still works — base spec is QuantType.No.
+        #
+        # Forward the engine-level `online_quant_config` (set via
+        # `--online_quant_config` CLI) so V4 weights can be re-quantized at
+        # load time. Without this, the engine flag is silently dropped on V4.
         self.args.quant_config = make_v4_quant_config(
-            self.hf_config, model_path=getattr(config, "model", None)
+            self.hf_config,
+            model_path=getattr(config, "model", None),
+            online_quant_config=getattr(config, "online_quant_config", None),
         )
         self.model = DeepseekV4Model(atom_config=config, args=self.args)
         # Tell ModelRunner to size the CG outputs buffer as

--- a/atom/models/deepseek_v4_mtp.py
+++ b/atom/models/deepseek_v4_mtp.py
@@ -213,7 +213,10 @@ class DeepseekV4MTP(nn.Module):
         self.atom_config = config
         self.hf_config = config.hf_config
         self.args = DeepseekV4Args.from_hf_config(self.hf_config)
-        self.args.quant_config = make_v4_quant_config(self.hf_config)
+        self.args.quant_config = make_v4_quant_config(
+            self.hf_config,
+            online_quant_config=getattr(config, "online_quant_config", None),
+        )
         self.model = DeepseekV4MTPModel(atom_config=config, args=self.args)
 
     def remap_mtp_weight_name(self, name: str) -> str | None:

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -47,6 +47,19 @@ class LayerQuantConfig:
         return cls(quant_type=QuantType.No, quant_dtype=dtype)
 
 
+def should_skip_online_quant(cur_type, cur_dtype, online_cfg) -> bool:
+    """Skip online re-quant when the layer is excluded (No) or already in target.
+
+    Shared by ``LinearBase.online_quantize_weight``, ``FusedMoE._online_quant``
+    and ``RMSNorm.online_quantize_activation``: re-quantizing is a no-op (and may
+    corrupt already-quantized weights) when the online target is ``No`` or the
+    layer already matches the target ``(quant_type, quant_dtype)``.
+    """
+    return online_cfg.quant_type == QuantType.No or (
+        cur_type == online_cfg.quant_type and cur_dtype == online_cfg.quant_dtype
+    )
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Structured parsed config
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION

1.make_v4_quant_config now takes online_quant_config and forwards it; both DeepseekV4ForCausalLM and MTP pass it. Before, the flag was silently dropped for V4.

2.Keep sensitive layers BF16. Compressor / indexer.weights_proj stay raw; wo_a stays BF16 even under online quant (aiter has no FP8 grouped einsum). The new QuantType.No → skip guard makes online quant actually honor this.

3.Quantize the norm layer. q_norm's fused output feeds wq_b directly, so its activation scheme must follow wq_b's online target — otherwise the GEMM misreads the bits (garbage, GSM8K→0). Added online_quantize_activation on RMSNorm, and dropped the old guard that pinned wq_b to the source scheme.

4.Harden linear/moe online quant. Skip early if the layer is excluded (No) or already in the target format — saves compute and avoids re-quantizing/corrupting the fp4 experts.

original 
```
ATOM_USE_TRITON_MOE=1 \
python -m atom.entrypoints.openai_server \
  --model /shareddata/deepseek-ai/DeepSeek-V4-Pro \
  --trust-remote-code \
  -tp 4 \
  --port 5679 \
  --server-port 7779


lm_eval   --model local-completions   --model_args "model=/shareddata/deepseek-ai/DeepSeek-V4-Pro,base_url=http://localhost:7779/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32"   --tasks gsm8k   --num_fewshot 5   --batch_size auto

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9462|±  |0.0062|
|     |       |strict-match    |     5|exact_match|↑  |0.9469|±  |0.0062|

```

Attn-shared expert ptpc fp8
```
HIP_VISIBLE_DEVICES=4,5,6,7 ATOM_USE_TRITON_MOE=1 python -m atom.entrypoints.openai_server   --model /shareddata/deepseek-ai/DeepSeek-V4-Pro   --trust-remote-code   --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "*.expert.*"]}'   -tp 4   --port 5678   --server-port 7778

lm_eval   --model local-completions   --model_args "model=/shareddata/deepseek-ai/DeepSeek-V4-Pro,base_url=http://localhost:7778/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32"   --tasks gsm8k   --num_fewshot 5   --batch_size auto

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9492|±  |0.0060|
|     |       |strict-match    |     5|exact_match|↑  |0.9484|±  |0.0061|


```