### PR TITLE
[torch compile] generate the compile cache exclude the pseudo file

### DIFF
--- a/atom/utils/backends.py
+++ b/atom/utils/backends.py
@@ -575,9 +575,13 @@ class VllmBackend:
             hash_content = []
             for filepath in forward_code_files:
                 hash_content.append(filepath)
-                if filepath == "<string>" or filepath == "<frozen os>":
-                    # This means the function was dynamically generated, with
-                    # e.g. exec() or frozen os module. We can't actually check these.
+                # The file, start with '<', is usually the python temp file
+                # maintained by the python interpreter. It has pseudo filepath
+                # and will be recorded in the forward_code_files as the code
+                # has been traced by Dynamo during the compilation.
+                # Here is computing the hash of the code from the compiled files,
+                # but exclude the pseudo-path files
+                if filepath.startswith("<"):
                     continue
                 with open(filepath) as f:
                     hash_content.append(f.read())


### PR DESCRIPTION
Fix the below issue https://github.com/ROCm/ATOM/actions/runs/26775378095/job/78925569060#step:8:256
```
  File "/opt/venv/lib/python3.12/site-packages/torch/_dynamo/output_graph.py", line 2437, in _call_user_compiler
    raise BackendCompilerFailed(
  File "/opt/venv/lib/python3.12/site-packages/torch/_dynamo/output_graph.py", line 2412, in _call_user_compiler
    compiled_fn = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/_dynamo/repro/after_dynamo.py", line 156, in __call__
    compiled_gm = compiler_fn(gm, example_inputs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/__init__.py", line 2509, in __call__
    return self.compiler_fn(model_, inputs_, **self.kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/atom/utils/backends.py", line 582, in __call__
    with open(filepath) as f:
         ^^^^^^^^^^^^^^
torch._dynamo.exc.BackendCompilerFailed: backend='<atom.utils.backends.VllmBackend object at 0x702542ce7f80>' raised:
FileNotFoundError: [Errno 2] No such file or directory: '<frozen posixpath>'
```

**Why we have this issue?**
The PR https://github.com/ROCm/ATOM/commit/e3c97b9d5d4a172f761971805a55e15987631bac changed the QK-norm dispatch in MiniMax forward, and the `tensor_model_parallel_fused_qknorm_allreduce` will be compiled during the profiler run. Both atom and atom-vllm compile the model in this phase. The pseudo file <frozen posixpath> will be recorded as Dynamo traced through it when calling importlib. Previously this file could not be compiled as the prefill token is usually 16k during profile run, but for now this function will be compiled as the condition has been removed
```
            self.vllm_config.compilation_config.traced_files.add(
                self.original_code_object.co_filename
            )
```
For computing the hash code of the compiled graph, the pseudo file should be totally skipped as it has no real location and remains no change