### PR TITLE
[atom-vllm benchmark] set 0 to random range ratio for vllm bench

### DIFF
--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -57,7 +57,7 @@
           "display": "gpt-oss-120b TP1 (AW)",
           "dashboard_model": "gpt-oss-120b-aw-tp1",
           "prefix": "gpt-oss-120b-aw-tp1",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 1 --gpu-memory-utilization 0.5 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nGPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT=1\nOOT_GPU_MEMORY_UTILIZATION=0.5"
         },
@@ -66,7 +66,7 @@
           "display": "gpt-oss-120b TP2 (AW)",
           "dashboard_model": "gpt-oss-120b-aw-tp2",
           "prefix": "gpt-oss-120b-aw-tp2",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 2 --gpu-memory-utilization 0.5 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nGPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT=1\nOOT_GPU_MEMORY_UTILIZATION=0.5"
         },
@@ -75,7 +75,7 @@
           "display": "gpt-oss-120b TP8 (AW)",
           "dashboard_model": "gpt-oss-120b-aw-tp8",
           "prefix": "gpt-oss-120b-aw-tp8",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 8 --gpu-memory-utilization 0.5 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nGPTOSS_USE_GENERIC_SWIGLU_MXFP4_LAYOUT=1\nOOT_GPU_MEMORY_UTILIZATION=0.5"
         }
@@ -149,7 +149,7 @@
           "display": "Kimi-K2.5-MXFP4 TP4 (AW)",
           "dashboard_model": "Kimi-K2.5-MXFP4-aw-tp4",
           "prefix": "kimi-k2-5-mxfp4-aw-tp4",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4"
         },
@@ -158,7 +158,7 @@
           "display": "Kimi-K2.5-MXFP4 TP8 (AW)",
           "dashboard_model": "Kimi-K2.5-MXFP4-aw-tp8",
           "prefix": "kimi-k2-5-mxfp4-aw-tp8",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4"
         }
@@ -247,7 +247,7 @@
           "display": "Qwen3-Next-80B-A3B-Instruct-FP8 TP1 (AW)",
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-aw-tp1",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-aw-tp1",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384",
           "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0"
         },
@@ -256,7 +256,7 @@
           "display": "Qwen3-Next-80B-A3B-Instruct-FP8 TP2 (AW)",
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-aw-tp2",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-aw-tp2",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 2 --max-num-batched-tokens 32768 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0"
         },
@@ -265,7 +265,7 @@
           "display": "Qwen3-Next-80B-A3B-Instruct-FP8 TP4 (AW)",
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-aw-tp4",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-aw-tp4",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 32768 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0"
         },
@@ -274,7 +274,7 @@
           "display": "Qwen3-Next-80B-A3B-Instruct-FP8-MTP TP1 (AW)",
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-mtp-tp1",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-mtp-tp1-aw",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
           "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0"
         },
@@ -283,7 +283,7 @@
           "display": "Qwen3-Next-80B-A3B-Instruct-FP8-MTP TP4 (AW)",
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-mtp-tp4",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-mtp-tp4-aw",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0"
         }
@@ -301,7 +301,7 @@
           "display": "DeepSeek-V3.2 FP8 TP4 (AW)",
           "dashboard_model": "DeepSeek-V3.2-FP8-aw-tp4",
           "prefix": "deepseek-v3-2-fp8-aw-tp4",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": ""
         },
@@ -310,7 +310,7 @@
           "display": "DeepSeek-V3.2 FP8 TP8 (AW)",
           "dashboard_model": "DeepSeek-V3.2-FP8-aw-tp8",
           "prefix": "deepseek-v3-2-fp8-aw-tp8",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": ""
         },
@@ -319,7 +319,7 @@
           "display": "DeepSeek-V3.2 FP8 MTP TP4 (AW)",
           "dashboard_model": "DeepSeek-V3.2-FP8-MTP-aw-tp4",
           "prefix": "deepseek-v3-2-fp8-mtp-aw-tp4",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
           "env_vars": ""
         }
@@ -337,7 +337,7 @@
           "display": "GLM-4.7-FP8 TP4 (AW)",
           "dashboard_model": "GLM-4.7-FP8-aw-tp4",
           "prefix": "glm-4-7-fp8-aw-tp4",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
@@ -346,7 +346,7 @@
           "display": "GLM-4.7-FP8 TP8 (AW)",
           "dashboard_model": "GLM-4.7-FP8-aw-tp8",
           "prefix": "glm-4-7-fp8-aw-tp8",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         }
@@ -364,7 +364,7 @@
           "display": "GLM-4.7-FP8 MTP TP4 (AW)",
           "dashboard_model": "GLM-4.7-FP8-mtp-aw-tp4",
           "prefix": "glm-4-7-fp8-mtp-aw-tp4",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
@@ -373,7 +373,7 @@
           "display": "GLM-4.7-FP8 MTP TP8 (AW)",
           "dashboard_model": "GLM-4.7-FP8-mtp-aw-tp8",
           "prefix": "glm-4-7-fp8-mtp-aw-tp8",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 8 --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         }
@@ -391,7 +391,7 @@
           "display": "MiniMax-M2.5 TP2 (AW)",
           "dashboard_model": "MiniMax-M2.5-aw-tp2",
           "prefix": "minimax-m2-5-aw-tp2",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 2 --kv-cache-dtype fp8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
@@ -400,7 +400,7 @@
           "display": "MiniMax-M2.5 TP4 (AW)",
           "dashboard_model": "MiniMax-M2.5-aw-tp4",
           "prefix": "minimax-m2-5-aw-tp4",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --kv-cache-dtype fp8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
@@ -409,7 +409,7 @@
           "display": "MiniMax-M2.5 TP8 (AW)",
           "dashboard_model": "MiniMax-M2.5-aw-tp8",
           "prefix": "minimax-m2-5-aw-tp8",
-          "bench_args": "--random-range-ratio 1",
+          "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 8 --kv-cache-dtype fp8 --max-num-batched-tokens 16384 --max-model-len 16384",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         }

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1139,7 +1139,7 @@ jobs:
                           aw_param = dict(param)
                           aw_param["input_length"] = input_length
                           aw_param["output_length"] = output_length
-                          aw_param["random_range_ratio"] = ""
+                          aw_param["random_range_ratio"] = "0.0"
                           base_params.append(aw_param)
 
                   variants = []
@@ -1309,7 +1309,7 @@ jobs:
           docker rmi atom_oot_base:ci || true
 
   benchmark:
-    name: OOT ${{ matrix.model.display }} ${{ matrix.params.input_length }}/${{ matrix.params.output_length }} c=${{ matrix.params.concurrency }}
+    name: ${{ contains(matrix.model.display, '(AW)') && format('OOT {0} all AW cases', matrix.model.display) || format('OOT {0} {1}/{2} c={3}', matrix.model.display, matrix.params.input_length, matrix.params.output_length, matrix.params.concurrency) }}
     needs: [resolve-atom-source, build-benchmark-matrix, build-oot-image]
     if: >-
       always()


### PR DESCRIPTION
## Motivation

Sync with branch dev_perf_0601. At the same time, resolve the error as below:

<img width="1202" height="404" alt="image" src="https://github.com/user-attachments/assets/a6013198-09b6-493a-9309-9841cf74ce82" />
