### PR TITLE
use ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM to enable non shuffle triton gemm

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -42,6 +42,20 @@ def use_triton_gemm() -> bool:
     return envs.ATOM_USE_TRITON_GEMM
 
 
+def use_fp4_triton_gemm() -> bool:
+    return envs.ATOM_USE_FP4_TRITON_GEMM
+
+
+if use_fp4_triton_gemm():
+    try:
+        from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4  # noqa: E402
+    except ImportError as e:
+        logger.warning(f"Triton FP4 GEMM not available: {e}")
+        gemm_afp4wfp4 = None
+else:
+    gemm_afp4wfp4 = None
+
+
 if use_triton_gemm():
     try:
         # from aiter.ops.triton.gemm_a8w8_blockscale import gemm_a8w8_blockscale_preshuffle as gemm_a8w8_blockscale_bpreshuffle_triton
@@ -98,14 +112,18 @@ def gemm_a4w4_quant(
     input_scale: torch.Tensor,
     output_size: int,
 ) -> torch.Tensor:
-    if gemm_afp4wfp4_preshuffle is None:
+    if params_dtype == dtypes.fp4x2 and use_fp4_triton_gemm():
+        if gemm_afp4wfp4 is None:
+            raise RuntimeError(
+                "ATOM_USE_FP4_TRITON_GEMM=1 requires aiter.ops.triton.gemm_afp4wfp4"
+            )
         if x_scale is None:
             quant_func = get_hip_quant(QuantType.per_1x32)
             x, x_scale = quant_func(
                 x,
                 quant_dtype=params_dtype,
                 scale=input_scale,
-                shuffle=True,
+                shuffle=False,
             )
         else:
             x_scale = x_scale.view(torch.float8_e8m0fnu)
@@ -122,14 +140,15 @@ def gemm_a4w4_quant(
             dtype=otype,
             device=x.device,
         )
-        y = gemm_a4w4(
-            x,
-            weight,
-            x_scale,
-            weight_scale,
+        y = gemm_afp4wfp4(
+            x.view(torch.uint8),
+            weight.view(torch.uint8),
+            x_scale.view(torch.uint8),
+            weight_scale.view(torch.uint8),
+            otype,
             y,
         )
-    else:
+    elif params_dtype == dtypes.fp4x2 and gemm_afp4wfp4_preshuffle is not None:
         m, k = x.view(-1, x.size(-1)).shape
 
         y = torch.empty(
@@ -168,6 +187,37 @@ def gemm_a4w4_quant(
                 weight_scale.shape[0] // MXFP4_QUANT_BLOCK_SIZE, -1
             ),
             y=y,
+        )
+    else:
+        if x_scale is None:
+            quant_func = get_hip_quant(QuantType.per_1x32)
+            x, x_scale = quant_func(
+                x,
+                quant_dtype=params_dtype,
+                scale=input_scale,
+                shuffle=True,
+            )
+        else:
+            x_scale = x_scale.view(torch.float8_e8m0fnu)
+            x = x.view(torch.float4_e2m1fn_x2)
+
+        m = x.view(-1, x.size(-1)).shape[0]
+        y = torch.empty(
+            (
+                (m + MXFP4_QUANT_BLOCK_SIZE - 1)
+                // MXFP4_QUANT_BLOCK_SIZE
+                * MXFP4_QUANT_BLOCK_SIZE,
+                output_size,
+            ),
+            dtype=otype,
+            device=x.device,
+        )
+        y = gemm_a4w4(
+            x,
+            weight,
+            x_scale,
+            weight_scale,
+            y,
         )
 
     return y[:m, ...]
@@ -504,21 +554,34 @@ class LinearBase(nn.Module):
             # quantized models must keep that tensor unshuffled here.
             if self.weight.dim() == 2:
                 shuffle_weights(self.weight)
+                if not use_fp4_triton_gemm():
+                    shuffle_weights(self.weight)
             # self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         else:
+            is_fp4_blockscale = (
+                self.quant_type == QuantType.per_1x32
+                and self.params_dtype == dtypes.fp4x2
+            )
             need_shuffle = (
                 self.quant_type == QuantType.per_Token
                 and self.params_dtype == dtypes.fp8
-            ) or self.quant_type == QuantType.per_1x32
+            ) or (
+                self.quant_type == QuantType.per_1x32
+                and (not is_fp4_blockscale or not use_fp4_triton_gemm())
+            )
             # per_1x128 only needs shuffle when using the preshuffle GEMM path
             if not need_shuffle and self.quant_type == QuantType.per_1x128:
                 need_shuffle = envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
+            if self.weight.dim() == 2 and is_fp4_blockscale:
+                self._maybe_preserve_unshuffled_mxfp4_attention_proj()
             if need_shuffle:
                 if self.weight.dim() == 2:
                     shuffle_weights(self.weight)
                 # self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         # shuffle weight scale once so no reshuffling for every gemm
-        if self.quant_type == QuantType.per_1x32:
+        if self.quant_type == QuantType.per_1x32 and (
+            self.params_dtype != dtypes.fp4x2 or not use_fp4_triton_gemm()
+        ):
             self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
 
     @mark_trace

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -563,10 +563,8 @@ class LinearBase(nn.Module):
             # Only quantized 2D GEMM weights use aiter's preshuffle layout.
             # Qwen3-Next/Qwen3.5 GDN conv1d expands its weight to 3D, so FP8/blocked
             # quantized models must keep that tensor unshuffled here.
-            if self.weight.dim() == 2:
+            if self.weight.dim() == 2 and not use_fp4_non_shuffle_triton_gemm():
                 shuffle_weights(self.weight)
-                if not use_fp4_non_shuffle_triton_gemm():
-                    shuffle_weights(self.weight)
             # self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         else:
             is_fp4_blockscale = (
@@ -583,8 +581,6 @@ class LinearBase(nn.Module):
             # per_1x128 only needs shuffle when using the preshuffle GEMM path
             if not need_shuffle and self.quant_type == QuantType.per_1x128:
                 need_shuffle = envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
-            if self.weight.dim() == 2 and is_fp4_blockscale:
-                self._maybe_preserve_unshuffled_mxfp4_attention_proj()
             if need_shuffle:
                 if self.weight.dim() == 2:
                     shuffle_weights(self.weight)

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -42,11 +42,11 @@ def use_triton_gemm() -> bool:
     return envs.ATOM_USE_TRITON_GEMM
 
 
-def use_fp4_triton_gemm() -> bool:
-    return envs.ATOM_USE_FP4_TRITON_GEMM
+def use_fp4_non_shuffle_triton_gemm() -> bool:
+    return envs.ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM
 
 
-if use_fp4_triton_gemm():
+if use_fp4_non_shuffle_triton_gemm():
     try:
         from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4  # noqa: E402
     except ImportError as e:
@@ -112,10 +112,12 @@ def gemm_a4w4_quant(
     input_scale: torch.Tensor,
     output_size: int,
 ) -> torch.Tensor:
-    if params_dtype == dtypes.fp4x2 and use_fp4_triton_gemm():
+    # Non-shuffle FP4 Triton path: keep x/weight/scale in the original MXFP4
+    # layout and call the non-preshuffled gemm_afp4wfp4 kernel.
+    if params_dtype == dtypes.fp4x2 and use_fp4_non_shuffle_triton_gemm():
         if gemm_afp4wfp4 is None:
             raise RuntimeError(
-                "ATOM_USE_FP4_TRITON_GEMM=1 requires aiter.ops.triton.gemm_afp4wfp4"
+                "ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM=1 requires aiter.ops.triton.gemm_afp4wfp4"
             )
         if x_scale is None:
             quant_func = get_hip_quant(QuantType.per_1x32)
@@ -148,7 +150,14 @@ def gemm_a4w4_quant(
             otype,
             y,
         )
-    elif params_dtype == dtypes.fp4x2 and gemm_afp4wfp4_preshuffle is not None:
+    # Preshuffle FP4 Triton path: used when ATOM_USE_TRITON_GEMM is enabled
+    # and the non-shuffle path is disabled. This expects preshuffled weights.
+    elif (
+        params_dtype == dtypes.fp4x2
+        and use_triton_gemm()
+        and not use_fp4_non_shuffle_triton_gemm()
+        and gemm_afp4wfp4_preshuffle is not None
+    ):
         m, k = x.view(-1, x.size(-1)).shape
 
         y = torch.empty(
@@ -188,6 +197,8 @@ def gemm_a4w4_quant(
             ),
             y=y,
         )
+    # Default AITER path: quantize/shuffle into the layout expected by gemm_a4w4
+    # and use the backend ASM implementation.
     else:
         if x_scale is None:
             quant_func = get_hip_quant(QuantType.per_1x32)
@@ -554,7 +565,7 @@ class LinearBase(nn.Module):
             # quantized models must keep that tensor unshuffled here.
             if self.weight.dim() == 2:
                 shuffle_weights(self.weight)
-                if not use_fp4_triton_gemm():
+                if not use_fp4_non_shuffle_triton_gemm():
                     shuffle_weights(self.weight)
             # self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         else:
@@ -567,7 +578,7 @@ class LinearBase(nn.Module):
                 and self.params_dtype == dtypes.fp8
             ) or (
                 self.quant_type == QuantType.per_1x32
-                and (not is_fp4_blockscale or not use_fp4_triton_gemm())
+                and (not is_fp4_blockscale or not use_fp4_non_shuffle_triton_gemm())
             )
             # per_1x128 only needs shuffle when using the preshuffle GEMM path
             if not need_shuffle and self.quant_type == QuantType.per_1x128:
@@ -580,7 +591,7 @@ class LinearBase(nn.Module):
                 # self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
         # shuffle weight scale once so no reshuffling for every gemm
         if self.quant_type == QuantType.per_1x32 and (
-            self.params_dtype != dtypes.fp4x2 or not use_fp4_triton_gemm()
+            self.params_dtype != dtypes.fp4x2 or not use_fp4_non_shuffle_triton_gemm()
         ):
             self.weight_scale.data = fp4_utils.e8m0_shuffle(self.weight_scale.data)
 

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -128,6 +128,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE": lambda: (
         os.getenv("ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE", "1") == "1"
     ),
+    "ATOM_USE_FP4_TRITON_GEMM": lambda: (
+        os.getenv("ATOM_USE_FP4_TRITON_GEMM", "0") == "1"
+    ),
     # --- V4 Attention Backend Refactor (PR-A: kill .item(), unlock CUDAGraph) ---
     # `legacy` (default) keeps the per-seq Python dispatch loop with .item()
     # syncs in deepseek_v4.py. `new` routes through V4AttentionBackend with

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -128,8 +128,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE": lambda: (
         os.getenv("ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE", "1") == "1"
     ),
-    "ATOM_USE_FP4_TRITON_GEMM": lambda: (
-        os.getenv("ATOM_USE_FP4_TRITON_GEMM", "0") == "1"
+    "ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM": lambda: (
+        os.getenv("ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM", "0") == "1"
     ),
     # --- V4 Attention Backend Refactor (PR-A: kill .item(), unlock CUDAGraph) ---
     # `legacy` (default) keeps the per-seq Python dispatch loop with .item()

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -37,6 +37,7 @@ This document describes the environment variables used in the ATOM project.
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | **ATOM_USE_TRITON_GEMM** | bool | 0 (false) | If set to `1`, use AITER Triton FP4 weight preshuffled GEMM. Otherwise use AITER ASM FP4 weight preshuffled GEMM. |
+| **ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM** | bool | 0 (false) | If set to `1`, use AITER Triton FP4 GEMM with non-shuffled weights. Takes precedence over the FP4 preshuffled GEMM path selected by `ATOM_USE_TRITON_GEMM`. |
 | **ATOM_USE_TRITON_MXFP4_BMM** | bool | 0 (false) | If set to `1`, use FP4 BMM in MLA attention module. |
 
 ---


### PR DESCRIPTION
## Motivation
As shown below, atom use preshuffled asm gemm as default path for fp4 gemm path while mori-sglang using non-shuffle gemm for better performance, plus, triton preshuffle fp4 gemm got a worse perf:
<img width="1758" height="511" alt="image" src="https://github.com/user-attachments/assets/0cb56179-397d-4efe-b35a-c7bb0552d324" />

<img width="1315" height="362" alt="image" src="https://github.com/user-attachments/assets/55d1a7a4-7c05-4cdd-9d3d-cf581fb71738" />
Hence, this pr add a flag `ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM=1` to control whether to use triton non-shuffle fp4 gemm to imporve decode(small bs) cases' perf.

## Test Plan

benchmark + gsm8k

## Test Result

https://github.com/ROCm/ATOM/actions/runs/26651782340 for benchmark test:
<img width="1788" height="200" alt="image" src="https://github.com/user-attachments/assets/9e8b3073-7eba-4ea3-a4f8-eb297cddaed2" />

<img width="533" height="91" alt="image" src="https://github.com/user-attachments/assets/6e1972bd-1660-484d-a53b-d3f4a1f7c5fc" />
for accuracy test


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
