### PR TITLE
[Fix] Limit static FP4 linear kv_b_proj post-processing

### DIFF
--- a/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
+++ b/atom/plugin/sglang/attention_backend/sgl_attention_mla.py
@@ -988,6 +988,19 @@ def forward_sgl_plugin_mode(
 
 
 # Weight post-processing: decomposed into sub-functions
+def _is_static_quark_mxfp4_kv_b_proj(kv_b_proj) -> bool:
+    layer_quant_config = getattr(kv_b_proj, "layer_quant_config", None)
+    return (
+        getattr(kv_b_proj, "weight", None) is not None
+        and kv_b_proj.weight.dim() == 2
+        and layer_quant_config is not None
+        and layer_quant_config.quant_method == "quark"
+        and layer_quant_config.quant_dtype == dtypes.fp4x2
+        and getattr(layer_quant_config.quant_type, "name", None) == "per_1x32"
+        and getattr(kv_b_proj, "source_quant_dtype", None) is None
+    )
+
+
 def _read_kv_b_proj_weight(attn: DeepseekV2MLAAttention) -> torch.Tensor:
     """Read kv_b_proj weight, handling AWQ and fnuz dtypes."""
     if hasattr(attn.kv_b_proj, "qweight"):
@@ -1002,14 +1015,7 @@ def _read_kv_b_proj_weight(attn: DeepseekV2MLAAttention) -> torch.Tensor:
             attn.kv_b_proj.qzeros,
         ).T
     else:
-        layer_quant_config = getattr(attn.kv_b_proj, "layer_quant_config", None)
-        is_quark_static_mxfp4 = (
-            layer_quant_config is not None
-            and layer_quant_config.quant_method == "quark"
-            and layer_quant_config.quant_dtype == dtypes.fp4x2
-            and getattr(layer_quant_config.quant_type, "name", None) == "per_1x32"
-        )
-        if is_quark_static_mxfp4:
+        if _is_static_quark_mxfp4_kv_b_proj(attn.kv_b_proj):
             w = getattr(
                 attn.kv_b_proj,
                 "_mxfp4_unshuffled_weight",
@@ -1253,7 +1259,9 @@ def process_mla_kv_b_proj_after_loading(attn: DeepseekV2MLAAttention) -> None:
     Orchestrates reading, quantization handling, and splitting of
     kv_b_proj into absorbed w_kc / w_vc weights.
     """
-    if not getattr(attn.kv_b_proj, "_sgl_mxfp4_process_done", False):
+    if _is_static_quark_mxfp4_kv_b_proj(attn.kv_b_proj) and not getattr(
+        attn.kv_b_proj, "_sgl_mxfp4_process_done", False
+    ):
         attn.kv_b_proj.process_weights_after_loading()
 
     w = _read_kv_b_proj_weight(attn)
@@ -1288,16 +1296,7 @@ def _patch_kv_b_proj_for_sglang_mxfp4(attn: DeepseekV2MLAAttention) -> None:
         if getattr(kv_b_proj, "_sgl_mxfp4_process_done", False):
             return
 
-        layer_quant_config = getattr(kv_b_proj, "layer_quant_config", None)
-        is_quark_static_mxfp4 = (
-            kv_b_proj.weight.dim() == 2
-            and layer_quant_config is not None
-            and layer_quant_config.quant_method == "quark"
-            and layer_quant_config.quant_dtype == dtypes.fp4x2
-            and getattr(layer_quant_config.quant_type, "name", None) == "per_1x32"
-            and getattr(kv_b_proj, "source_quant_dtype", None) is None
-        )
-        if is_quark_static_mxfp4:
+        if _is_static_quark_mxfp4_kv_b_proj(kv_b_proj):
             kv_b_proj._mxfp4_unshuffled_weight = kv_b_proj.weight.detach().clone()
             kv_b_proj._mxfp4_unshuffled_weight_scale = (
                 kv_b_proj.weight_scale.detach().clone()


### PR DESCRIPTION
## Motivation

Fix a DeepSeek-R1-0528 and DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 accuracy regression in the SGLang ATOM plugin path. The regression was introduced when kv_b_proj.process_weights_after_loading() started running eagerly before SGLang MLA splits kv_b_proj into w_kc and w_vc, which caused BF16/source-quantized weights to be quantized and shuffled before the split.


## Technical Details

Restrict the eager kv_b_proj post-processing path to static Quark FP4 linear weights only. This preserves the intended MXFP4 handling while keeping BF16/source-quantized DeepSeek-R1 weights in their original layout until SGLang MLA finishes reading and splitting them.

## Test Result

before：
<img width="1195" height="135" alt="image" src="https://github.com/user-attachments/assets/d4054c3c-4cf0-4279-bcd1-8f70c0afa9f5" />

after：
<img width="1210" height="149" alt="image" src="https://github.com/user-attachments/assets/bd24d641-037a-4fdd-892d-46a65a801c21" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
