### PR TITLE
[atom-vllm] enable DeepSeek V3.2 quick reduce envs

### DIFF
--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -303,7 +303,7 @@
           "prefix": "deepseek-v3-2-fp8-aw-tp4",
           "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384",
-          "env_vars": ""
+          "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0"
         },
         {
           "tp_size": 8,
@@ -312,7 +312,7 @@
           "prefix": "deepseek-v3-2-fp8-aw-tp8",
           "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384",
-          "env_vars": ""
+          "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0"
         },
         {
           "tp_size": 4,

--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -152,7 +152,7 @@
     "model_name": "DeepSeek-V3.2-FP8 TP8",
     "model_path": "deepseek-ai/DeepSeek-V3.2",
     "extraArgs": "--tensor-parallel-size 8",
-    "env_vars": "",
+    "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
     "runner": "linux-atom-mi35x-8",
     "test_level": "nightly",
     "accuracy_threshold": 0.93,

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -597,7 +597,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384",
                   "lm_eval_num_fewshot": 20,
                   "accuracy_test_threshold": 0.93,
-                  "env_vars": "",
+                  "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
                   "runner": "atom-plugin-acc-validation-runner",
               },
               {
@@ -607,7 +607,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 8",
                   "lm_eval_num_fewshot": 20,
                   "accuracy_test_threshold": 0.93,
-                  "env_vars": "",
+                  "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
                   "runner": "atom-plugin-acc-validation-runner",
               },
               {
@@ -775,11 +775,11 @@ jobs:
               },
               "DeepSeek-V3.2-FP8 TP4": {
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384",
-                  "env_vars": "",
+                  "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
               },
               "DeepSeek-V3.2-FP8 TP8": {
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --max-num-batched-tokens 16384 --max-model-len 16384",
-                  "env_vars": "",
+                  "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
               },
               "DeepSeek-V3.2-FP8 MTP TP4": {
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",

--- a/recipes/atom_vllm/DeepSeek-V3.2.md
+++ b/recipes/atom_vllm/DeepSeek-V3.2.md
@@ -14,6 +14,8 @@ The vLLM-ATOM plugin backend keeps the standard vLLM CLI, server APIs, and gener
 
 ```bash
 TP=4
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
+export AITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0
 
 vllm serve deepseek-ai/DeepSeek-V3.2 \
     --host localhost \

--- a/recipes/atom_vllm/DeepSeek-V3.2.md
+++ b/recipes/atom_vllm/DeepSeek-V3.2.md
@@ -75,3 +75,20 @@ vllm bench serve \
     --save-result \
     --percentile-metrics ttft,tpot,itl,e2el
 ```
+
+### Optional: Enable Profiling
+If you want to collect profiling trace, you can use the same API as default vLLM to add `--profiler-config "$profiler_config"` to the `vllm serve` command above.
+
+```bash
+profiler_config=$(printf '{"profiler":"torch","torch_profiler_dir":"%s","torch_profiler_with_stack":true,"torch_profiler_record_shapes":true}' \
+    "${your-profiler-dir}")
+```
+
+## Step 4: Accuracy Validation
+
+```bash
+lm_eval --model local-completions \
+        --model_args model=deepseek-ai/DeepSeek-V3.2,base_url=http://localhost:8000/v1/completions,num_concurrent=16,max_retries=3,tokenized_requests=False \
+        --tasks gsm8k \
+        --num_fewshot 20
+```


### PR DESCRIPTION
## Motivation

add int4 quick reduce for deepseek v3.2。

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

accuracy:

<img width="940" height="147" alt="image" src="https://github.com/user-attachments/assets/c9f6a6c8-2cfb-4763-aa95-9386d154a57b" />


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
