### PR TITLE
[Feat] Support input_rmsnorm_quant & qknorm_quant fused for Atom dpsk v2 model

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -389,41 +389,18 @@ class MLAAttention(nn.Module):
         k_out: torch.Tensor,
         v_out: torch.Tensor,
     ) -> None:
-        if self.kv_b_proj.weight.dtype != dtypes.fp4x2:
-            gather_kv_b_proj(
-                kv_cache,
-                self._k_scale,
-                kv_indptr,
-                kv_indices,
-                cu_seqlens_k,
-                self.kv_b_proj.weight,
-                self.kv_b_proj.weight_scale,
-                k_out,
-                v_out,
-                weight_preshuffle=getattr(self.kv_b_proj.weight, "is_shuffled", False),
-            )
-            return
-
-        flat_cache = kv_cache.view(-1, self.kv_lora_rank + self.qk_rope_head_dim)
-        # ``kv_indices`` is a reusable workspace; only the current k/v output
-        # length is valid for this call.
-        valid_indices = kv_indices[: k_out.shape[0]]
-        cached = flat_cache.index_select(0, valid_indices).to(self.dtype)
-        if self.kv_cache_dtype == "fp8" and self._k_scale is not None:
-            cached = cached * self._k_scale.to(device=cached.device, dtype=cached.dtype)
-
-        kv_c_normed = cached[:, : self.kv_lora_rank]
-        k_rope = cached[:, self.kv_lora_rank :]
-        kv_nope = self.kv_b_proj(kv_c_normed).view(
-            -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
+        gather_kv_b_proj(
+            kv_cache,
+            self._k_scale,
+            kv_indptr,
+            kv_indices,
+            cu_seqlens_k,
+            self.kv_b_proj.weight,
+            self.kv_b_proj.weight_scale,
+            k_out,
+            v_out,
+            weight_preshuffle=getattr(self.kv_b_proj.weight, "is_shuffled", False),
         )
-        k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-        k = torch.cat(
-            (k_nope, k_rope.unsqueeze(1).expand(-1, self.num_heads, -1)),
-            dim=-1,
-        )
-        k_out[: k.shape[0]].copy_(k)
-        v_out[: v.shape[0]].copy_(v)
 
     def _forward_prefill_cached_chunked(
         self,

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -69,6 +69,23 @@ def is_rocm_aiter_fp4bmm_enabled() -> bool:
     return envs.ATOM_USE_TRITON_MXFP4_BMM
 
 
+def _maybe_view_mxfp4_weight_for_gather(
+    kv_b_proj: nn.Module, weight: torch.Tensor
+) -> torch.Tensor:
+    fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    if fp4_dtype is None or weight.dtype != torch.uint8:
+        return weight
+
+    layer_quant_config = getattr(kv_b_proj, "layer_quant_config", None)
+    is_mxfp4 = getattr(kv_b_proj, "params_dtype", None) == dtypes.fp4x2 or (
+        layer_quant_config is not None
+        and getattr(layer_quant_config, "quant_dtype", None) == dtypes.fp4x2
+    )
+    if is_mxfp4:
+        return weight.view(fp4_dtype)
+    return weight
+
+
 if is_rocm_aiter_fp4bmm_enabled():
     # from aiter.ops.triton.batched_gemm_afp4wfp4_pre_quant import  batched_gemm_afp4wfp4_pre_quant
     from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
@@ -389,17 +406,18 @@ class MLAAttention(nn.Module):
         k_out: torch.Tensor,
         v_out: torch.Tensor,
     ) -> None:
+        weight = self.kv_b_proj.weight
         gather_kv_b_proj(
             kv_cache,
             self._k_scale,
             kv_indptr,
             kv_indices,
             cu_seqlens_k,
-            self.kv_b_proj.weight,
-            self.kv_b_proj.weight_scale,
+            _maybe_view_mxfp4_weight_for_gather(self.kv_b_proj, weight),
+            getattr(self.kv_b_proj, "weight_scale", None),
             k_out,
             v_out,
-            weight_preshuffle=getattr(self.kv_b_proj.weight, "is_shuffled", False),
+            weight_preshuffle=getattr(weight, "is_shuffled", False),
         )
 
     def _forward_prefill_cached_chunked(

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -407,7 +407,7 @@ class MLAAttention(nn.Module):
         flat_cache = kv_cache.view(-1, self.kv_lora_rank + self.qk_rope_head_dim)
         # ``kv_indices`` is a reusable workspace; only the current k/v output
         # length is valid for this call.
-        valid_indices = kv_indices[: k_out.shape[0]].to(torch.long)
+        valid_indices = kv_indices[: k_out.shape[0]]
         cached = flat_cache.index_select(0, valid_indices).to(self.dtype)
         if self.kv_cache_dtype == "fp8" and self._k_scale is not None:
             cached = cached * self._k_scale.to(device=cached.device, dtype=cached.dtype)

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -357,17 +357,13 @@ class MLAAttention(nn.Module):
             device=prefill_q.device,
             dtype=self.dtype,
         )
-        gather_kv_b_proj(
+        self._gather_cached_kv_b_proj(
             kv_cache,
-            self._k_scale,
             attn_metadata.kv_indptr,
             attn_metadata.kv_indices,
             attn_metadata.cu_seqlens_k,
-            self.kv_b_proj.weight,
-            self.kv_b_proj.weight_scale,
             k_full,
             v_full,
-            weight_preshuffle=getattr(self.kv_b_proj.weight, "is_shuffled", False),
         )
         output = flash_attn_varlen_func(
             q=prefill_q,
@@ -383,6 +379,51 @@ class MLAAttention(nn.Module):
             causal=True,
         )
         return self.o_proj(output.flatten(start_dim=-2))
+
+    def _gather_cached_kv_b_proj(
+        self,
+        kv_cache: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        k_out: torch.Tensor,
+        v_out: torch.Tensor,
+    ) -> None:
+        if self.kv_b_proj.weight.dtype != dtypes.fp4x2:
+            gather_kv_b_proj(
+                kv_cache,
+                self._k_scale,
+                kv_indptr,
+                kv_indices,
+                cu_seqlens_k,
+                self.kv_b_proj.weight,
+                self.kv_b_proj.weight_scale,
+                k_out,
+                v_out,
+                weight_preshuffle=getattr(self.kv_b_proj.weight, "is_shuffled", False),
+            )
+            return
+
+        flat_cache = kv_cache.view(-1, self.kv_lora_rank + self.qk_rope_head_dim)
+        # ``kv_indices`` is a reusable workspace; only the current k/v output
+        # length is valid for this call.
+        valid_indices = kv_indices[: k_out.shape[0]].to(torch.long)
+        cached = flat_cache.index_select(0, valid_indices).to(self.dtype)
+        if self.kv_cache_dtype == "fp8" and self._k_scale is not None:
+            cached = cached * self._k_scale.to(device=cached.device, dtype=cached.dtype)
+
+        kv_c_normed = cached[:, : self.kv_lora_rank]
+        k_rope = cached[:, self.kv_lora_rank :]
+        kv_nope = self.kv_b_proj(kv_c_normed).view(
+            -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
+        )
+        k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+        k = torch.cat(
+            (k_nope, k_rope.unsqueeze(1).expand(-1, self.num_heads, -1)),
+            dim=-1,
+        )
+        k_out[: k.shape[0]].copy_(k)
+        v_out[: v.shape[0]].copy_(v)
 
     def _forward_prefill_cached_chunked(
         self,
@@ -403,9 +444,9 @@ class MLAAttention(nn.Module):
 
         Step 1 — new-tokens self-attention (causal). New k/v come from
         kv_b_proj on the input latent kv_c_normed; cu_seqlens_k = cu_seqlens_q.
-        Step 2 — per chunk c of the cached prefix: gather_kv_b_proj into the
-        shared workspace, flash_attn(causal=False, return_lse), merge into a
-        running (chunked_out, chunked_lse).
+        Step 2 — per chunk c of the cached prefix: gather expanded K/V into
+        the shared workspace, flash_attn(causal=False, return_lse), merge
+        into a running (chunked_out, chunked_lse).
         Step 3 — final merge of (chunked_out, chunked_lse) with (new_out,
         new_lse). The cached prefix is the "prefix" side (smaller token
         positions), new tokens are the "suffix".
@@ -429,8 +470,6 @@ class MLAAttention(nn.Module):
                 attn_metadata.total_kv,
                 int(attn_metadata.cu_seqlens_q[-1].item()),
             )
-
-        weight_preshuffle = getattr(self.kv_b_proj.weight, "is_shuffled", False)
 
         # Step 1: new-tokens self-attn via kv_b_proj on the latent.
         if k_rope_new.dim() == 2:
@@ -470,17 +509,13 @@ class MLAAttention(nn.Module):
                 continue
             k_chunk = k_workspace[:n_tok]
             v_chunk = v_workspace[:n_tok]
-            gather_kv_b_proj(
+            self._gather_cached_kv_b_proj(
                 kv_cache,
-                self._k_scale,
                 chunk_meta.kv_indptr[c],
                 chunk_meta.kv_indices[c],
                 chunk_meta.cu_seqlens_k[c],
-                self.kv_b_proj.weight,
-                self.kv_b_proj.weight_scale,
                 k_chunk,
                 v_chunk,
-                weight_preshuffle=weight_preshuffle,
             )
             suf_out, suf_lse = flash_attn_varlen_func(
                 q=prefill_q,

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -137,31 +137,30 @@ _FP8_DTYPES = tuple(
 )
 
 
-def _allow_ds_v2_non_triton_fp4_input_norm_quant(
+def _enable_non_triton_global_mxfp4_input_norm_quant(
     config: PretrainedConfig,
+    quant_config: Optional[QuantizationConfig],
+    quant_dtype: Optional[torch.dtype],
+    is_mtp_block: bool,
 ) -> bool:
-    model_type = str(getattr(config, "model_type", "") or "").lower()
-    architectures = getattr(config, "architectures", None) or []
-    architecture_names = {str(arch) for arch in architectures if arch}
-    architecture_text = " ".join(architecture_names).lower()
-
-    # This is only for the PR-added non-Triton FP4 input RMSNorm quant path.
-    # Wrappers that reuse DeepSeek-V2/MLA should keep the original path unless
-    # Triton GEMM is explicitly enabled, which was the pre-existing gate.
-    if model_type in {"glm_moe_dsa", "kimi_k2", "kimi_k25"}:
+    if (
+        is_mtp_block
+        or quant_dtype != dtypes.fp4x2
+        or quant_config is None
+        or quant_config.quant_method != "quark"
+        or quant_config.quant_dtype != dtypes.fp4x2
+        or quant_config.layer_pattern_specs
+    ):
         return False
-    if any(name in architecture_text for name in ("glm", "kimi", "qwen", "gpt")):
-        return False
-
-    if architecture_names:
-        return bool(
-            architecture_names
-            & {
-                "DeepseekV2ForCausalLM",
-                "DeepseekV3ForCausalLM",
-            }
-        )
-    return model_type in {"deepseek_v2", "deepseek_v3", "deepseek_v32", "deepseek_v4"}
+    architectures = set(getattr(config, "architectures", None) or [])
+    return bool(
+        architectures & {"DeepseekV2ForCausalLM", "DeepseekV3ForCausalLM"}
+    ) or str(getattr(config, "model_type", "")).lower() in {
+        "deepseek_v2",
+        "deepseek_v3",
+        "deepseek_v32",
+        "deepseek_v4",
+    }
 
 
 def _supports_fused_indexer_kernel_config(config: PretrainedConfig) -> bool:
@@ -275,17 +274,6 @@ def _mxfp4_activation_quant_layout(num_tokens: int) -> Tuple[bool, bool]:
         should_shuffle = num_tokens >= MXFP4_QUANT_BLOCK_SIZE
         return should_shuffle, should_shuffle
     return True, True
-
-
-def _is_global_mxfp4_without_layer_overrides(
-    quant_config: Optional[QuantizationConfig],
-) -> bool:
-    return (
-        quant_config is not None
-        and quant_config.quant_method == "quark"
-        and quant_config.quant_dtype == dtypes.fp4x2
-        and not quant_config.layer_pattern_specs
-    )
 
 
 def _fused_rms_fp8_quant_fake(
@@ -1929,56 +1917,33 @@ class DeepseekV2MLAAttention(nn.Module):
                 )
                 # fuse q_c norm + kv_c norm + quant of hidden_states_or_q_c
                 if self.fuse_qknorm_quant or self.fuse_qknorm:
-                    use_asm_fp4_q_b_proj = (
-                        self.quant_dtype == dtypes.fp4x2 and not use_triton_gemm()
-                    )
-                    if use_asm_fp4_q_b_proj:
+                    q_shuffle = False
+                    q_scale_shuffle_padding = False
+                    if self.quant_dtype == dtypes.fp4x2 and not use_triton_gemm():
                         q_shuffle, q_scale_shuffle_padding = (
                             _mxfp4_activation_quant_layout(q_c.shape[0])
                         )
-                        (
-                            (hidden_states_or_q_c, hidden_states_or_q_c_scale),
-                            _,
-                            kv_c_normed,
-                            _,
-                        ) = _fuse_rmsnorm_quant(
-                            q_c,
-                            self.q_a_layernorm.weight,
-                            self.q_a_layernorm.eps,
-                            kv_c,
-                            self.kv_a_layernorm.weight,
-                            self.kv_a_layernorm.eps,
-                            None,
-                            dtype_quant=self.quant_dtype,
-                            shuffle=q_shuffle,
-                            scale_shuffle_padding=q_scale_shuffle_padding,
-                            group_size=128,
-                            quant_type=self.qknorm_quant_type,
-                            output_unquantized_inp1=False,
-                            transpose_scale=True,
-                        )
-                    else:
-                        (
-                            (hidden_states_or_q_c, hidden_states_or_q_c_scale),
-                            _,
-                            kv_c_normed,
-                            _,
-                        ) = _fuse_rmsnorm_quant(
-                            q_c,
-                            self.q_a_layernorm.weight,
-                            self.q_a_layernorm.eps,
-                            kv_c,
-                            self.kv_a_layernorm.weight,
-                            self.kv_a_layernorm.eps,
-                            None,
-                            dtype_quant=self.quant_dtype,
-                            shuffle=False,
-                            scale_shuffle_padding=False,
-                            group_size=128,
-                            quant_type=self.qknorm_quant_type,
-                            output_unquantized_inp1=False,
-                            transpose_scale=True,
-                        )
+                    (
+                        (hidden_states_or_q_c, hidden_states_or_q_c_scale),
+                        _,
+                        kv_c_normed,
+                        _,
+                    ) = _fuse_rmsnorm_quant(
+                        q_c,
+                        self.q_a_layernorm.weight,
+                        self.q_a_layernorm.eps,
+                        kv_c,
+                        self.kv_a_layernorm.weight,
+                        self.kv_a_layernorm.eps,
+                        None,
+                        dtype_quant=self.quant_dtype,
+                        shuffle=q_shuffle,
+                        scale_shuffle_padding=q_scale_shuffle_padding,
+                        group_size=128,
+                        quant_type=self.qknorm_quant_type,
+                        output_unquantized_inp1=False,
+                        transpose_scale=True,
+                    )
                 else:
                     hidden_states_or_q_c = self.q_a_layernorm(q_c)
         else:
@@ -2071,10 +2036,11 @@ class DeepseekV2DecoderLayer(nn.Module):
             )
             enable_fp4_input_norm_quant = self.quant_dtype == dtypes.fp4x2 and (
                 use_triton_gemm()
-                or (
-                    not is_mtp_block
-                    and _allow_ds_v2_non_triton_fp4_input_norm_quant(config)
-                    and _is_global_mxfp4_without_layer_overrides(quant_config)
+                or _enable_non_triton_global_mxfp4_input_norm_quant(
+                    config,
+                    quant_config,
+                    self.quant_dtype,
+                    is_mtp_block,
                 )
             )
             if enable_fp8_input_norm_quant or enable_fp4_input_norm_quant:

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -137,6 +137,33 @@ _FP8_DTYPES = tuple(
 )
 
 
+def _allow_ds_v2_non_triton_fp4_input_norm_quant(
+    config: PretrainedConfig,
+) -> bool:
+    model_type = str(getattr(config, "model_type", "") or "").lower()
+    architectures = getattr(config, "architectures", None) or []
+    architecture_names = {str(arch) for arch in architectures if arch}
+    architecture_text = " ".join(architecture_names).lower()
+
+    # This is only for the PR-added non-Triton FP4 input RMSNorm quant path.
+    # Wrappers that reuse DeepSeek-V2/MLA should keep the original path unless
+    # Triton GEMM is explicitly enabled, which was the pre-existing gate.
+    if model_type in {"glm_moe_dsa", "kimi_k2", "kimi_k25"}:
+        return False
+    if any(name in architecture_text for name in ("glm", "kimi", "qwen", "gpt")):
+        return False
+
+    if architecture_names:
+        return bool(
+            architecture_names
+            & {
+                "DeepseekV2ForCausalLM",
+                "DeepseekV3ForCausalLM",
+            }
+        )
+    return model_type in {"deepseek_v2", "deepseek_v3", "deepseek_v32", "deepseek_v4"}
+
+
 def _supports_fused_indexer_kernel_config(config: PretrainedConfig) -> bool:
     if not hasattr(config, "index_topk"):
         return False
@@ -2042,12 +2069,12 @@ class DeepseekV2DecoderLayer(nn.Module):
             enable_fp8_input_norm_quant = (
                 self.quant_dtype == dtypes.fp8 and use_triton_gemm()
             )
-            enable_fp4_input_norm_quant = (
-                self.quant_dtype == dtypes.fp4x2
-                and not is_mtp_block
-                and (
-                    use_triton_gemm()
-                    or _is_global_mxfp4_without_layer_overrides(quant_config)
+            enable_fp4_input_norm_quant = self.quant_dtype == dtypes.fp4x2 and (
+                use_triton_gemm()
+                or (
+                    not is_mtp_block
+                    and _allow_ds_v2_non_triton_fp4_input_norm_quant(config)
+                    and _is_global_mxfp4_without_layer_overrides(quant_config)
                 )
             )
             if enable_fp8_input_norm_quant or enable_fp4_input_norm_quant:

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -68,6 +68,7 @@ from atom.model_ops.linear import (
     MergedReplicatedLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    use_fp4_non_shuffle_triton_gemm,
     use_triton_gemm,
 )
 from atom.model_ops.moe import FusedMoE
@@ -219,8 +220,12 @@ def _fuse_rmsnorm_fp4_quant_fake(
 
     scale_n_valid = (n1 + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE
 
-    scale_m = ((m + 255) // 256) * 256
-    scale_n = ((scale_n_valid + 7) // 8) * 8
+    if scale_shuffle_padding:
+        scale_m = ((m + 255) // 256) * 256
+        scale_n = ((scale_n_valid + 7) // 8) * 8
+    else:
+        scale_m = m
+        scale_n = scale_n_valid
 
     out1_bs = torch.empty((scale_m, scale_n), dtype=torch.uint8, device=x1.device)
 
@@ -234,6 +239,26 @@ def _fuse_rmsnorm_fp4_quant_fake(
 
     out1_unquantized = None
     return out1_quantized, out1_bs, out1_unquantized, out2, out_res1
+
+
+def _mxfp4_activation_quant_layout(num_tokens: int) -> Tuple[bool, bool]:
+    if use_fp4_non_shuffle_triton_gemm():
+        return False, False
+    if use_triton_gemm():
+        should_shuffle = num_tokens >= MXFP4_QUANT_BLOCK_SIZE
+        return should_shuffle, should_shuffle
+    return True, True
+
+
+def _is_global_mxfp4_without_layer_overrides(
+    quant_config: Optional[QuantizationConfig],
+) -> bool:
+    return (
+        quant_config is not None
+        and quant_config.quant_method == "quark"
+        and quant_config.quant_dtype == dtypes.fp4x2
+        and not quant_config.layer_pattern_specs
+    )
 
 
 def _fused_rms_fp8_quant_fake(
@@ -299,10 +324,6 @@ def _fuse_rmsnorm_fp4_quant(
     torch.Tensor,
     torch.Tensor,
 ]:
-    m = x1.shape[0]
-
-    shuffle_bool = shuffle and (m >= MXFP4_QUANT_BLOCK_SIZE)
-
     (out1_quantized, out1_bs), _out1_unquantized, out2, out_res1 = (
         fused_rms_mxfp4_quant(
             x1=x1,
@@ -312,7 +333,7 @@ def _fuse_rmsnorm_fp4_quant(
             x2_weight=x2_weight,
             x2_epsilon=0.0 if x2_epsilon is None else x2_epsilon,
             res1=res1,
-            shuffle=shuffle_bool,
+            shuffle=shuffle,
             scale_shuffle_padding=scale_shuffle_padding,
             output_unquantized_inp1=output_unquantized_inp1,
         )
@@ -461,8 +482,12 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant_fp4_fake(
     device = hidden_states_quant.device
     q_c = torch.empty((M, q_lora_rank // 2), dtype=torch.uint8, device=device)
     scale_n_valid = (q_lora_rank + MXFP4_QUANT_BLOCK_SIZE - 1) // MXFP4_QUANT_BLOCK_SIZE
-    scale_m = ((M + 255) // 256) * 256
-    scale_n = ((scale_n_valid + 7) // 8) * 8
+    if scale_shuffle_padding:
+        scale_m = ((M + 255) // 256) * 256
+        scale_n = ((scale_n_valid + 7) // 8) * 8
+    else:
+        scale_m = M
+        scale_n = scale_n_valid
     q_c_scale = torch.empty((scale_m, scale_n), dtype=torch.uint8, device=device)
     kv_c_normed = torch.empty((M, kv_lora_rank), dtype=torch.bfloat16, device=device)
     k_pe = torch.empty(
@@ -1877,27 +1902,56 @@ class DeepseekV2MLAAttention(nn.Module):
                 )
                 # fuse q_c norm + kv_c norm + quant of hidden_states_or_q_c
                 if self.fuse_qknorm_quant or self.fuse_qknorm:
-                    (
-                        (hidden_states_or_q_c, hidden_states_or_q_c_scale),
-                        _,
-                        kv_c_normed,
-                        _,
-                    ) = _fuse_rmsnorm_quant(
-                        q_c,
-                        self.q_a_layernorm.weight,
-                        self.q_a_layernorm.eps,
-                        kv_c,
-                        self.kv_a_layernorm.weight,
-                        self.kv_a_layernorm.eps,
-                        None,
-                        dtype_quant=self.quant_dtype,
-                        shuffle=False,
-                        scale_shuffle_padding=False,
-                        group_size=128,
-                        quant_type=self.qknorm_quant_type,
-                        output_unquantized_inp1=False,
-                        transpose_scale=True,
+                    use_asm_fp4_q_b_proj = (
+                        self.quant_dtype == dtypes.fp4x2 and not use_triton_gemm()
                     )
+                    if use_asm_fp4_q_b_proj:
+                        q_shuffle, q_scale_shuffle_padding = (
+                            _mxfp4_activation_quant_layout(q_c.shape[0])
+                        )
+                        (
+                            (hidden_states_or_q_c, hidden_states_or_q_c_scale),
+                            _,
+                            kv_c_normed,
+                            _,
+                        ) = _fuse_rmsnorm_quant(
+                            q_c,
+                            self.q_a_layernorm.weight,
+                            self.q_a_layernorm.eps,
+                            kv_c,
+                            self.kv_a_layernorm.weight,
+                            self.kv_a_layernorm.eps,
+                            None,
+                            dtype_quant=self.quant_dtype,
+                            shuffle=q_shuffle,
+                            scale_shuffle_padding=q_scale_shuffle_padding,
+                            group_size=128,
+                            quant_type=self.qknorm_quant_type,
+                            output_unquantized_inp1=False,
+                            transpose_scale=True,
+                        )
+                    else:
+                        (
+                            (hidden_states_or_q_c, hidden_states_or_q_c_scale),
+                            _,
+                            kv_c_normed,
+                            _,
+                        ) = _fuse_rmsnorm_quant(
+                            q_c,
+                            self.q_a_layernorm.weight,
+                            self.q_a_layernorm.eps,
+                            kv_c,
+                            self.kv_a_layernorm.weight,
+                            self.kv_a_layernorm.eps,
+                            None,
+                            dtype_quant=self.quant_dtype,
+                            shuffle=False,
+                            scale_shuffle_padding=False,
+                            group_size=128,
+                            quant_type=self.qknorm_quant_type,
+                            output_unquantized_inp1=False,
+                            transpose_scale=True,
+                        )
                 else:
                     hidden_states_or_q_c = self.q_a_layernorm(q_c)
         else:
@@ -1965,7 +2019,9 @@ class DeepseekV2DecoderLayer(nn.Module):
             use_indexer_wk_weights_proj_fusion=use_indexer_wk_weights_proj_fusion,
         )
 
-        # When ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION is turned on self.fuse_input_norm_quant is turned on only if use_triton_gemm and (FP8 or FP4),
+        # Keep input RMSNorm quant fusion narrow: the legacy FP8/FP4 path uses
+        # Triton GEMM, while the non-Triton FP4 path is only enabled for the
+        # pure global MXFP4 DeepSeek v2 checkpoint layout.
         # Because AR_RMS and RMS_Quant cannot co-exist for input_layernorm, this block of codes ensures 3 things when ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION is turned on:
         #   1. RMS_Quant fusion is only used for input_layernorm
         #   2. The reduce_results variable is re-enabled for feed forward layers (MOE and MLP), because AR_RMS is now disabled in the beginning of the next layer
@@ -1983,9 +2039,18 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.fuse_input_norm_quant = False
         self.fuse_ar_input_norm = ENABLE_ALLREDUCE_RMSNORM_FUSION
         if quant_config is not None and ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION:
-            if (
-                self.quant_dtype == dtypes.fp8 or self.quant_dtype == dtypes.fp4x2
-            ) and use_triton_gemm():
+            enable_fp8_input_norm_quant = (
+                self.quant_dtype == dtypes.fp8 and use_triton_gemm()
+            )
+            enable_fp4_input_norm_quant = (
+                self.quant_dtype == dtypes.fp4x2
+                and not is_mtp_block
+                and (
+                    use_triton_gemm()
+                    or _is_global_mxfp4_without_layer_overrides(quant_config)
+                )
+            )
+            if enable_fp8_input_norm_quant or enable_fp4_input_norm_quant:
                 self.fuse_input_norm_quant = True
                 if self.fuse_ar_input_norm:
                     self.fuse_ar_input_norm = False
@@ -1993,11 +2058,6 @@ class DeepseekV2DecoderLayer(nn.Module):
                         logger.info(
                             "Warning: Because ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION is turned on, AR + RMS fusion is turned off for input_layernorm and reduce_results is re-enabled for first k dense layer down_proj"
                         )
-            else:
-                if layer_idx == 0:
-                    logger.info(
-                        "Info: Because ATOM_USE_TRITON_GEMM is not turned on in DeepSeek-R1, ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION is turned off automatically"
-                    )
 
         if (
             config.n_routed_experts is not None
@@ -2048,6 +2108,13 @@ class DeepseekV2DecoderLayer(nn.Module):
             assert self.quant_dtype is not None
             weight = self.input_layernorm.weight
             eps = self.input_layernorm.eps
+            if self.quant_dtype == dtypes.fp4x2:
+                shuffle_input_norm_quant, scale_shuffle_padding = (
+                    _mxfp4_activation_quant_layout(hidden_states.shape[0])
+                )
+            else:
+                shuffle_input_norm_quant = True
+                scale_shuffle_padding = True
             if residual is None:
                 residual = hidden_states
                 (hidden_states_quant, hidden_states_quant_scale), _, _, _ = (
@@ -2060,8 +2127,8 @@ class DeepseekV2DecoderLayer(nn.Module):
                         None,
                         None,
                         dtype_quant=self.quant_dtype,
-                        shuffle=True,
-                        scale_shuffle_padding=True,
+                        shuffle=shuffle_input_norm_quant,
+                        scale_shuffle_padding=scale_shuffle_padding,
                         group_size=128,
                         quant_type=self.input_norm_quant_type,
                         output_unquantized_inp1=False,
@@ -2079,8 +2146,8 @@ class DeepseekV2DecoderLayer(nn.Module):
                         None,
                         residual,
                         dtype_quant=self.quant_dtype,
-                        shuffle=True,
-                        scale_shuffle_padding=True,
+                        shuffle=shuffle_input_norm_quant,
+                        scale_shuffle_padding=scale_shuffle_padding,
                         group_size=128,
                         quant_type=self.input_norm_quant_type,
                         output_unquantized_inp1=False,

--- a/atom/plugin/sglang/models/deepseek_mla_forward.py
+++ b/atom/plugin/sglang/models/deepseek_mla_forward.py
@@ -21,7 +21,10 @@ from atom.model_ops.base_attention import Attention
 from atom.model_ops.attention_mla import (
     dynamic_per_batched_tensor_quant,
 )
-from atom.models.deepseek_v2 import _fuse_rmsnorm_quant
+from atom.models.deepseek_v2 import (
+    _fuse_rmsnorm_quant,
+    _mxfp4_activation_quant_layout,
+)
 from atom.models.utils import maybe_prefix
 
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
@@ -179,6 +182,12 @@ def _fuse_qk_rmsnorm_and_q_quant(
 ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
     """Fuse q/k RMSNorm and q quant using ATOM's DeepSeek-V2 path."""
 
+    if getattr(attn, "quant_dtype", None) == dtypes.fp4x2:
+        q_shuffle, q_scale_shuffle_padding = _mxfp4_activation_quant_layout(q.shape[0])
+    else:
+        q_shuffle = False
+        q_scale_shuffle_padding = False
+
     (q_quantized, q_scale), q_normed, k_nope_normed, _ = _fuse_rmsnorm_quant(
         q,
         attn.q_a_layernorm.weight,
@@ -188,51 +197,14 @@ def _fuse_qk_rmsnorm_and_q_quant(
         attn.kv_a_layernorm.eps,
         None,
         dtype_quant=attn.quant_dtype,
-        shuffle=False,
-        scale_shuffle_padding=False,
+        shuffle=q_shuffle,
+        scale_shuffle_padding=q_scale_shuffle_padding,
         group_size=128,
         quant_type=_linear_quant_type_value(attn.q_b_proj),
         output_unquantized_inp1=output_unquantized_q,
         transpose_scale=True,
     )
     return q_quantized, q_scale, q_normed, k_nope_normed
-
-
-def _q_b_proj_mxfp4_raw_scale(
-    attn: DeepseekV2MLAAttention,
-    q: torch.Tensor,
-    q_scale: torch.Tensor,
-) -> torch.Tensor:
-    """Run q_b_proj with native SGLang-style raw MXFP4 activation scales."""
-
-    raw_weight = getattr(attn.q_b_proj, "_mxfp4_unshuffled_weight", None)
-    raw_weight_scale = getattr(attn.q_b_proj, "_mxfp4_unshuffled_weight_scale", None)
-    bias = getattr(attn.q_b_proj, "bias", None)
-    if (
-        gemm_afp4wfp4 is not None
-        and raw_weight is not None
-        and raw_weight_scale is not None
-        and bias is None
-    ):
-        q_2d = q.view(-1, q.size(-1))
-        y = torch.empty(
-            q_2d.shape[0],
-            raw_weight.shape[0],
-            device=q.device,
-            dtype=torch.bfloat16,
-        )
-        gemm_afp4wfp4(
-            q_2d.view(torch.uint8),
-            raw_weight.view(torch.uint8),
-            q_scale.view(torch.uint8),
-            raw_weight_scale.view(torch.uint8),
-            torch.bfloat16,
-            y,
-        )
-        return y
-
-    q_scale = fp4_utils.e8m0_shuffle(q_scale.view(torch.float8_e8m0fnu))
-    return _unwrap_linear_output(attn.q_b_proj(q, q_scale))
 
 
 def _q_b_proj_with_optional_scale(
@@ -243,7 +215,7 @@ def _q_b_proj_with_optional_scale(
     if q_scale is None:
         return _unwrap_linear_output(attn.q_b_proj(q))
     if getattr(attn, "quant_dtype", None) == dtypes.fp4x2:
-        return _q_b_proj_mxfp4_raw_scale(attn, q, q_scale)
+        return _unwrap_linear_output(attn.q_b_proj(q, q_scale))
     return _unwrap_linear_output(attn.q_b_proj(q, q_scale))
 
 


### PR DESCRIPTION
## Motivation

Enable DeepSeek V2 FP4 input_rmsnorm_quant and qknorm_quant fusion in ATOM across both Triton and non-Triton GEMM paths. This reduces separate RMSNorm + quant kernel launches while keeping FP4 activation scale layouts and cached KV projection paths correct.

## Technical Details

- Enable qknorm quant fusion for FP8/FP4 without requiring Triton GEMM.
- Route FP4 qknorm and input RMSNorm quant through fused RMSNorm+MXFP4 quant kernels.
- Select the correct MXFP4 activation/scale layout for preshuffle Triton, non-shuffle Triton, and ASM GEMM paths.
- Add FP4-safe cached KV projection gather fallback for MLA attention.
- Align the SGLang MLA prepare path with the native ATOM qknorm quant fusion behavior.

## Test Plan

server:
```
#!/bin/bash
# export ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
export ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION=1

rm -rf /root/.cache/ /tmp/torchinductor_root
model_path=/shared/data/amd_int/models/deepseek-ai/DeepSeek-R1-0528-MXFP4-v2
python -m atom.entrypoints.openai_server \
    --model $model_path \
    --host localhost \
    --server-port 8000 \
    --tensor-parallel-size 8 \
    --kv_cache_dtype fp8 \
    --gpu-memory-utilization 0.8 \
    --no-enable_prefix_caching
```

client:
```
#!/bin/bash
set -euo pipefail
 
addr=localhost
port=8000
url=http://${addr}:${port}/v1/completions
 
model_path="/shared/data/amd_int/models/deepseek-ai/DeepSeek-R1-0528-MXFP4-v2"
num_concurrent="${LM_EVAL_CONCURRENT:-16}"
max_gen_toks="${LM_EVAL_MAX_GEN_TOKS:-512}"


lm_eval --model local-completions \
    --model_args "{\"base_url\": \"${url}\", \"model\": \"${model_path}\", \"num_concurrent\": ${num_concurrent}, \"max_retries\": 1, \"max_gen_toks\": ${max_gen_toks}, \"tokenized_requests\": false}" \
    --tasks gsm8k \
    --batch_size auto \
    --num_fewshot 5 \
    --trust_remote_code \
```

## Test Result
For preshuffle FP4 gemm kernel:
<img width="1326" height="95" alt="image" src="https://github.com/user-attachments/assets/e6ecda2c-3465-4e44-b6b6-c007c85b6ecf" />

For non-preshuffle FP4 gemm kernel:
**export ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM=1**
<img width="1330" height="110" alt="image" src="https://github.com/user-attachments/assets/0928250b-e901-421c-9682-d747d561c745" />

**Accuracy:**

| Backend | Model | NON_SHUFFLE=0 | NON_SHUFFLE=1 | Delta |
|---|---|---:|---:|---:|
| atom | DeepSeek-R1-0528-MXFP4-v2 | 0.9515 | 0.9522 | +0.0030 |
| atom | DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 | 0.9507 | 0.9553 | +0.0046 |
| atom | DeepSeek-R1-0528 | 0.9629 | 0.9629 | +0.0000 |

**Performance:**
- TP8 , kv_cache_dtype=fp8, ISL/OSL: 1024/1024, num-prompts = concurrency * 3, random-range-ratio=1.0
- FP4 v2 non-shuffle improves output throughput over FP4 v2 shuffle by about +5.2% at concurrency 1, +5.9% at concurrency 4, +7.7% at concurrency 16, and +31.7% at concurrency 64.
- FP4 v2 non-shuffle is the **highest-throughput** case at each concurrency, and it achieves a **1~5%** uplift compared to FP4 MTP/MoEFP4.

| Model / case | Layout | Concurrency | Req/s | Output tok/s | Total tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Mean E2E (ms) |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| DeepSeek-R1-0528-MXFP4-v2 | shuffle | 1 | 0.1379 | 141.26 | 282.52 | 169.60 | 6.92 | 7248.41 |
| DeepSeek-R1-0528-MXFP4-v2 | shuffle | 4 | 0.4619 | 473.00 | 946.00 | 188.88 | 8.28 | 8657.74 |
| DeepSeek-R1-0528-MXFP4-v2 | shuffle | 16 | 1.4642 | 1499.33 | 2998.67 | 347.36 | 10.34 | 10923.26 |
| DeepSeek-R1-0528-MXFP4-v2 | shuffle | 64 | 3.1151 | 3189.91 | 6379.82 | 1520.45 | 18.59 | 20533.20 |
| DeepSeek-R1-0528-MXFP4-v2 | non-shuffle | 1 | 0.1452 | 148.64 | **297.27** | 186.53 | 6.55 | 6888.42 |
| DeepSeek-R1-0528-MXFP4-v2 | non-shuffle | 4 | 0.4890 | 500.75 | **1001.50** | 196.84 | 7.80 | 8178.54 |
| DeepSeek-R1-0528-MXFP4-v2 | non-shuffle | 16 | 1.5763 | 1614.17 | **3228.35** | 352.69 | 9.57 | 10145.80 |
| DeepSeek-R1-0528-MXFP4-v2 | non-shuffle | 64 | 4.1022 | 4200.68 | **8401.37** | 1176.36 | 14.09 | 15589.67 |
| DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 | default | 1 | 0.1371 | 140.36 | 280.73 | 283.31 | 6.85 | 7294.43 |
| DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 | default | 4 | 0.4912 | 503.02 | 1006.04 | 240.14 | 7.72 | 8140.87 |
| DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 | default | 16 | 1.5307 | 1567.41 | 3134.81 | 418.36 | 9.80 | 10448.54 |
| DeepSeek-R1-0528-MXFP4-MTP-MoEFP4 | default | 64 | 4.0664 | 4163.95 | 8327.91 | 1474.78 | 13.93 | 15727.16 |
| DeepSeek-R1-0528 | FP8 | 1 | 0.1001 | 102.53 | 205.06 | 106.57 | 9.66 | 9986.10 |
| DeepSeek-R1-0528 | FP8 | 4 | 0.3748 | 383.82 | 767.64 | 168.82 | 10.26 | 10669.92 |
| DeepSeek-R1-0528 | FP8 | 16 | 1.2198 | 1249.11 | 2498.22 | 431.64 | 12.40 | 13112.44 |
| DeepSeek-R1-0528 | FP8 | 64 | 3.1166 | 3191.41 | 6382.82 | 1078.79 | 19.01 | 20523.59 |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
