### PR TITLE
fix(v4): drop redundant cu_seqlens_q refill in attention metadata builder

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -39,7 +39,6 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type, cast
 
-
 import numpy as np
 import torch
 from aiter import dtypes
@@ -595,11 +594,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         standard MHA path uses.
         """
         # Local imports to avoid circular dependency at module load time.
-        from atom.models.deepseek_v4 import (
-            Compressor as _V4Compressor,
-            DeepseekV4Attention as _V4Attention,
-            Indexer as _V4Indexer,
-        )
+        from atom.models.deepseek_v4 import Compressor as _V4Compressor
+        from atom.models.deepseek_v4 import DeepseekV4Attention as _V4Attention
+        from atom.models.deepseek_v4 import Indexer as _V4Indexer
 
         runner = self.model_runner
         num_slots = self.model_runner.max_per_req_cache_slots
@@ -1104,11 +1101,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         var["positions"].np[:sum_scheduled_tokens] = positions_np
 
-        cu_seqlens_q_np = np.arange(
-            0, (scheduled_bs + 1) * max_seqlen_q, max_seqlen_q, dtype=np.int32
-        )
-        var["cu_seqlens_q"].np[: scheduled_bs + 1] = cu_seqlens_q_np
-
         var["context_lens"].np[:scheduled_bs] = context_lens_np
 
         # Inline block_tables CPU fill (H2D deferred to prep_stream).
@@ -1130,7 +1122,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         prep_stream.wait_stream(current_stream)
         with torch.cuda.stream(prep_stream):
             positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
-            cu_seqlens_q_gpu = var["cu_seqlens_q"].copy_to_gpu(scheduled_bs + 1)
+            cu_seqlens_q_gpu = var["cu_seqlens_q"].copy_to_gpu(bs + 1)
             context_lens_gpu = var["context_lens"].copy_to_gpu(scheduled_bs)
             block_tables_gpu = var["block_tables"].copy_to_gpu(scheduled_bs)
             state_slot_gpu = ss_buf.copy_to_gpu(scheduled_bs)


### PR DESCRIPTION
## Summary

`cu_seqlens_q` is already populated in `ModelRunner` as a variable-length prefix sum over `num_scheduled_tokens`, with the `[scheduled_bs+1 : bs+1]` tail padded to the boundary value (for cudagraph padding slots):

- `model_runner.py:1670` — `cu_seqlens_q.np[1:bs+1] = <prefix sum>`
- `model_runner.py:1692-1693` — pad `[scheduled_bs+1 : bs+1]` to the boundary value
- `model_runner.py:2160` — copies `bs+1` entries

The DeepseekV4 attention metadata builder was **re-filling** `cu_seqlens_q` with a uniform `np.arange` sized `scheduled_bs+1`, overwriting ModelRunner's correct variable-length values with a stale uniform fill, and copying only `scheduled_bs+1` entries.

## Changes

- Remove the redundant `np.arange` refill of `cu_seqlens_q` in `DeepseekV4AttentionMetadataBuilder` — let ModelRunner's fill stand.
- Copy `bs+1` entries (was `scheduled_bs+1`) so the GPU buffer matches the range ModelRunner populates (including the padded tail).
- Minor: split a grouped local import into per-line imports (isort).

## Test plan

- [x] `black --check` + `ruff check` on the changed file
- [x] DeepSeek-V4-Pro GSM8K (5-shot) = **0.9507** flexible / 0.9500 strict — no attention regression
- [x] DeepSeek-V4-Pro 1k/1k/128c benchmark runs clean