### PR TITLE
[atom-vllm-benchmark] Align GPT-OSS warmups with AW models

### DIFF
--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1744,9 +1744,6 @@ jobs:
                   "
               else
                 NUM_WARMUPS="${CONC}"
-                if [[ "${MODEL_NAME}" == gpt-oss-120b* ]]; then
-                  NUM_WARMUPS="$(( CONC * 8 ))"
-                fi
                 $CONTAINER_ENGINE exec \
                   -e ISL="${ISL}" \
                   -e OSL="${OSL}" \

--- a/recipes/atom_vllm/GPT-OSS.md
+++ b/recipes/atom_vllm/GPT-OSS.md
@@ -51,7 +51,7 @@ vllm bench serve \
     --num-prompts "$(( CONC * 8 ))" \
     --max-concurrency "${CONC}" \
     --trust_remote_code \
-    --num-warmups "$(( CONC * 8 ))" \
+    --num-warmups "${CONC}" \
     --request-rate inf \
     --ignore-eos \
     --disable-tqdm \


### PR DESCRIPTION
## Summary
- Remove the GPT-OSS-specific `8 * CONC` warmup override in the AW vLLM benchmark workflow.
- Update the GPT-OSS vLLM recipe so `--num-warmups` matches the shared AW setting of `${CONC}`.

## Test plan
- Parsed `.github/workflows/atom-vllm-benchmark.yaml` with PyYAML.
- Searched for remaining GPT-OSS warmup special cases and found none.
- Read lints for the edited workflow and recipe files.

Made with [Cursor](https://cursor.com)