### PR TITLE
[Fix] fix fused shared+routed MoE accuracy on DeepSeek-V4-Flash-Base

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -288,7 +288,17 @@ def load_model(
     load_fused_expert_weights_fn=None,
 ):
     def have_shared_expert(name):
-        maybe_matching_list = ["mlp.shared_experts.", "mlp.shared_expert."]
+        # Match both `mlp.` (GLM4, Qwen, ...) and `ffn.` (DeepSeek-V4) module
+        # naming. The matched substring is replaced by the caller with
+        # `<prefix>experts.{n_routed}.` so the shared expert lands in the fused
+        # MoE buffer's extra slot. Returning the full prefix (incl. mlp./ffn.)
+        # lets the rewrite preserve the module-naming style.
+        maybe_matching_list = [
+            "mlp.shared_experts.",
+            "mlp.shared_expert.",
+            "ffn.shared_experts.",
+            "ffn.shared_expert.",
+        ]
         for maybe_matching_name in maybe_matching_list:
             if maybe_matching_name in name:
                 return maybe_matching_name
@@ -430,14 +440,25 @@ def load_model(
             if (
                 is_rocm_aiter_fusion_shared_expert_enabled()
                 and maybe_matching_name is not None
+                # When the model keeps shared experts unfused (e.g. V4-Pro with
+                # FP4 routed vs FP8 shared, or DP + mori all2all), do NOT rewrite
+                # the shared weights into the fused slot — they must load into the
+                # standalone Expert module. Stays True for models without this
+                # attr (GLM4 etc.) so their fused-shared path is unchanged.
+                and not getattr(model, "disable_fused_shared_loading", False)
             ):
+                # Preserve the module-naming prefix (mlp. / ffn.) so the rewritten
+                # name matches this model's routed-expert param naming.
+                module_prefix = maybe_matching_name.split("shared_expert", 1)[0]
                 name = name.replace(
                     maybe_matching_name,
-                    f"mlp.experts.{hf_config.n_routed_experts}.",
+                    f"{module_prefix}experts.{hf_config.n_routed_experts}.",
                 )
             for k in packed_modules_mapping:
                 # We handle the experts below in expert_params_mapping
-                if "mlp.experts." in name and name not in params_dict:
+                if (
+                    "mlp.experts." in name or "ffn.experts." in name
+                ) and name not in params_dict:
                     continue
                 if k in name:
                     packed_value = packed_modules_mapping[k]

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2974,15 +2974,47 @@ class FusedMoE(torch.nn.Module):
 
                 topk_ids = topk_ids.to(torch.int32)
             elif scoring_func == "sqrtsoftplus":
-                # # DeepSeek-V4 routing: sqrt(softplus(scores)) + bias for selection;
-                # # weights gathered from the unbiased sqrt(softplus(.)) values.
+                # DeepSeek-V4 routing: sqrt(softplus(scores)) + bias for selection;
+                # weights gathered from the unbiased sqrt(softplus(.)) values.
                 tokens_num = router_logits.shape[0]
-                topk_ids = torch.empty(
-                    tokens_num, top_k, dtype=torch.int32, device=router_logits.device
+                fuse_shared = (
+                    is_rocm_aiter_fusion_shared_expert_enabled()
+                    and num_fused_shared_experts > 0
                 )
-                topk_weights = torch.empty(
-                    tokens_num, top_k, dtype=torch.float32, device=router_logits.device
-                )
+                if fuse_shared:
+                    import atom.model_ops.topK as _topK_mod
+
+                    assert _topK_mod.aiter_topK_meta_data is not None, (
+                        "AITER topK meta data is not initialized. "
+                        "Please ensure that init_aiter_topK_meta_data is called "
+                        "before this function."
+                    )
+                    total_topk_weights, total_topk_ids = _topK_mod.aiter_topK_meta_data
+                    assert total_topk_weights.shape[0] >= tokens_num
+                    n_extra = total_topk_ids.shape[1] - top_k
+                    topk_ids, _ = torch.split(
+                        total_topk_ids[:tokens_num],
+                        [top_k, n_extra],
+                        dim=1,
+                    )
+                    topk_weights, _ = torch.split(
+                        total_topk_weights[:tokens_num],
+                        [top_k, n_extra],
+                        dim=1,
+                    )
+                else:
+                    topk_ids = torch.empty(
+                        tokens_num,
+                        top_k,
+                        dtype=torch.int32,
+                        device=router_logits.device,
+                    )
+                    topk_weights = torch.empty(
+                        tokens_num,
+                        top_k,
+                        dtype=torch.float32,
+                        device=router_logits.device,
+                    )
                 topk_gating(
                     topk_weights,
                     topk_ids,
@@ -2992,6 +3024,11 @@ class FusedMoE(torch.nn.Module):
                     routed_scaling_factor,
                     score_func="sqrtsoftplus",
                 )
+                if fuse_shared:
+                    # Switch from the stride-7 routed view back to the full
+                    # 7-col buffer (routed + shared cols) for the fused kernel.
+                    topk_weights = total_topk_weights[:tokens_num]
+                    topk_ids = total_topk_ids[:tokens_num]
             else:
                 raise ValueError(
                     f"Unsupported scoring function for non-grouped topk: {scoring_func}"

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2070,29 +2070,13 @@ class MoE(nn.Module):
         shared_spec = qc.get_layer_quant_config(f"{prefix}.shared_experts")
         routed_dtype = routed_spec.quant_dtype
         shared_dtype = shared_spec.quant_dtype
-        # aiter's fused shared+routed kernel is broken on gfx942 with FP8
-        # per-block routed experts (V4-Flash-Base on MI308 produces garbage
-        # output unless we run shared and routed as 2 separate kernels). Auto-
-        # disable in that combination; explicit env override always wins.
-        env_override = os.environ.get("ATOM_V4_DISABLE_FUSED_SHARED")
-        if env_override is not None:
-            disable_fused = env_override == "1"
-        else:
-            try:
-                from aiter.jit.utils.chip_info import get_gfx
-
-                gfx = get_gfx() or ""
-            except Exception:
-                gfx = ""
-            disable_fused = (
-                gfx.startswith("gfx94")
-                and routed_spec.quant_type == QuantType.per_1x128
-                and routed_dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
-            )
+        # Fuse shared expert into the routed MoE kernel whenever physically
+        # possible. Falls back to a standalone Expert module only when fusion is
+        # infeasible: routed/shared quant dtypes differ (V4-Pro: FP4 routed vs
+        # FP8 shared) or aiter fusion is unavailable (e.g. DP + mori all2all).
         self._fuse_shared_into_routed = (
             routed_dtype == shared_dtype
             and is_rocm_aiter_fusion_shared_expert_enabled()
-            and not disable_fused
         )
         moe_cfg = SimpleNamespace(
             routed_scaling_factor=self.routed_scaling_factor,
@@ -2213,6 +2197,32 @@ class MoE(nn.Module):
                 dim=-1, keepdim=True
             ).clamp_min(1e-20)
         topk_weights = topk_weights * self.routed_scaling_factor
+
+        # Fused shared expert: the custom_routing_function path in
+        # `select_experts` (moe.py:3055) returns early and bypasses the
+        # sqrtsoftplus fused-shared branch (moe.py:3108). Without this block the
+        # returned topk_ids are [N, top_k] with ids in 0..n_routed-1 only — the
+        # shared expert (slot n_routed_experts) never appears, so moe_sorting
+        # assigns it no tokens and its contribution (≈40% of the layer output)
+        # is silently dropped. Replicate the shared-col append: write the routed
+        # weights/ids into the first `top_k` columns of the global topK buffer
+        # and return the full [N, top_k + n_shared] view (last cols pre-filled
+        # with shared id = n_routed_experts and weight = shared_experts_score).
+        num_fused_shared = getattr(self.experts, "num_fused_shared_experts", 0)
+        if num_fused_shared > 0:
+            import atom.model_ops.topK as _topK_mod
+
+            assert _topK_mod.aiter_topK_meta_data is not None, (
+                "AITER topK meta data is not initialized. "
+                "init_aiter_topK_meta_data must run before hash-layer routing."
+            )
+            total_topk_weights, total_topk_ids = _topK_mod.aiter_topK_meta_data
+            n_tokens = topk_ids.shape[0]
+            assert total_topk_weights.shape[0] >= n_tokens
+            total_topk_ids[:n_tokens, :topk] = topk_ids
+            total_topk_weights[:n_tokens, :topk] = topk_weights
+            return total_topk_weights[:n_tokens], total_topk_ids[:n_tokens]
+
         return topk_weights, topk_ids
 
     def routed_expert_forward(
@@ -2709,6 +2719,18 @@ class DeepseekV4ForCausalLM(nn.Module):
         # the un-reduced mHC residual stack [N, hc, dim].
         self.extra_output_dims: tuple[int, ...] = (self.args.hc_mult,)
 
+    @property
+    def disable_fused_shared_loading(self) -> bool:
+        """True when shared experts are NOT fused into the routed MoE kernel, so
+        the weight loader must keep `ffn.shared_experts.*` on the standalone
+        Expert module instead of rewriting them into the fused slot. Read from
+        the actual built MoE layers so it always agrees with model structure.
+        """
+        for m in self.model.modules():
+            if m.__class__.__name__ == "MoE":
+                return not getattr(m, "_fuse_shared_into_routed", True)
+        return False
+
     def forward(
         self,
         input_ids: torch.Tensor,  # [num_tokens] int
@@ -2748,12 +2770,31 @@ class DeepseekV4ForCausalLM(nn.Module):
 
         V4 expert weights on disk are named `ffn.experts.{e}.w{1,2,3}`. Pass
         these as the gate/down/up names to FusedMoE.make_expert_params_mapping.
+
+        When fused shared expert is enabled, FusedMoE allocates one extra expert
+        slot (id = n_routed_experts) for the shared expert. Include it in the
+        mapping so the loader can dispatch `ffn.shared_experts.w*` (rewritten to
+        `ffn.experts.{n_routed_experts}.w*` by the loader) into that slot.
+        Otherwise the shared expert weights are dropped and slot N stays
+        uninitialized -> garbage MoE output.
         """
+        # Whether the shared expert is fused into the routed buffer is decided
+        # per-MoE-layer (`_fuse_shared_into_routed`). Read the ACTUAL allocated
+        # buffer state from a real MoE layer instead of the global
+        # `is_rocm_aiter_fusion_shared_expert_enabled()` — otherwise when fusion
+        # is disabled (buffer=256) the mapping would emit 257 entries and
+        # mis-load expert weights -> garbage.
+        num_fused_shared = 0
+        for _m in self.model.modules():
+            if _m.__class__.__name__ == "FusedMoE":
+                num_fused_shared = getattr(_m, "num_fused_shared_experts", 0)
+                break
+        num_experts = self.args.n_routed_experts + num_fused_shared
         return FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="w1",
             ckpt_down_proj_name="w2",
             ckpt_up_proj_name="w3",
-            num_experts=self.args.n_routed_experts,
+            num_experts=num_experts,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/recipes/DeepSeek-V4.md
+++ b/recipes/DeepSeek-V4.md
@@ -49,15 +49,13 @@ python -m atom.entrypoints.openai_server \
 
 Override knobs (escape hatches, normally not needed):
 
-- **`ATOM_V4_ROUTED_QUANT={fp4,fp8_block}`** — forces the routed-expert path. Useful for debugging or when the auto-detection picks the wrong scheme. `fp8` and `fp8_per_block` are valid aliases for `fp8_block`.
-- **`ATOM_V4_DISABLE_FUSED_SHARED=1`** — disables the aiter fused shared+routed expert kernel. On V4-Flash-Base both routed and shared experts are FP8 (matching dtype), so the framework auto-enables fusion. If you hit numerical instabilities or kernel issues on a specific GPU, set this to 1 to keep them as 2 separate kernels.
 - **`ATOM_USE_TRITON_MOE=1`** — `gfx942` defaults to Triton MoE automatically (no need to set), but it doesn't hurt to set explicitly. Required on `gfx950` for V4-Pro (see V4-Pro section above).
 
 #### Auto-detection logic
 
 The routed-expert quant spec is resolved in this priority order (see [`_detect_v4_routed_quant_spec`](../atom/models/deepseek_v4.py)):
 
-1. **`ATOM_V4_ROUTED_QUANT` env override** — explicit forcing.
+1. **HF config `expert_dtype`** — if `config.json` declares `expert_dtype` (e.g. `"fp8"` / `"fp4"`), use it directly.
 2. **Parser-derived layer spec** — if the ckpt's `quantization_config.layer_quant_config` (Quark) or global config (compressed-tensors / generic) directly produces a per-layer spec for `ffn.experts.*.w*`, that wins.
 3. **Heuristic from `quant_method` / `fmt`** — strings containing `fp8` → FP8 block; `fp4` / `mxfp4` → FP4.
 4. **V4-Pro fallback** — historical default.


### PR DESCRIPTION
## Motivation

Fix fused shared+routed MoE accuracy issue on DeepSeek-V4-Flash-Base on both MI355 and MI308, which mentioned in https://github.com/ROCm/ATOM/pull/996 (PR996 uses WA with non-fused shared+routed MoE).

## Technical Details

+ deepseek_v4.py — add  the shared expert in `_hash_topk` (hash layers L0–2 previously returned [N, top_k] without the shared id, dropping the shared expert); 
remove ATOM_V4_DISABLE_FUSED_SHARED so fused is the default, auto-falling back to non-fused only for V4-Pro (FP4/FP8 mismatch) and DP+mori.
+ moe.py — add the shared expert in the `sqrtsoftplus` branch.
+ loader.py — `have_shared_expert` matches V4's ffn. naming (previously was mlp. only, so V4 shared weights were dropped); rewrite preserves the module prefix so GLM4 etc. are unaffected.


## Test Result

GSM8K (V4-Flash-Base, TP8, MI355): 
+ Fused shared+routed MoE

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9014|±  |0.0082|
|     |       |strict-match    |     5|exact_match|↑  |0.8969|±  |0.0084|

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
