### PR TITLE
fix: support DeepSeek-V4-Flash-FP8 on gfx942 device

### DIFF
--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -353,7 +353,10 @@ def _wo_a_is_bf16_on_disk(model_path):
 
         with safe_open(os.path.join(model_path, wmap[probe]), framework="pt") as h:
             w = h.get_slice(probe)
-            if w.dtype == torch.bfloat16:
+            w_dtype = (
+                w.get_dtype() if hasattr(w, "get_dtype") else getattr(w, "dtype", None)
+            )
+            if w_dtype in (torch.bfloat16, "BF16"):
                 return True  # BF16 weight; no scale needed regardless of index
             if not scale_present_in_idx:
                 return False


### PR DESCRIPTION
## Motivation

To support DeepSeek-V4-Flash-FP8 on gfx942 device
model source:https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Flash-Base/summary

In pr996，I changed get_tensor to get_slice per PR comments to avoid loading the entire tensor just to check its dtype. However, the object returned by get_slice lacks a .dtype attribute, causing _wo_a_is_bf16_on_disk to incorrectly return False. This led to Flash-FP8 allocating BF16 wo_a weights as FP8, resulting in corrupted weight data and zero accuracy.


## Test Plan

```bash
HF_ENDPOINT=https://hf-mirror.com lm_eval --model local-completions \
  --model_args model=/DeepSeek-V4-Flash-FP8,base_url=http://localhost:9677/v1/completions,num_concurrent=16,max_retries=3,tokenized_requests=False \
  --tasks gsm8k --num_fewshot 5
```

## Test Result

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.95|±  | 0.006|
|     |       |strict-match    |     5|exact_match|↑  | 0.95|±  | 0.006|