### PR TITLE
[atom-sgl-nightly] Update SGLANG accuracy runner

### DIFF
--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -136,7 +136,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 4",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
-                  "runner": "linux-atom-mi35x-4",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_QWEN35_35B_A3B_FP8_TP2",
@@ -145,7 +145,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 2 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.76,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
-                  "runner": "linux-atom-mi35x-4",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_QWEN35_35B_A3B_TP2",
@@ -154,7 +154,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 2 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.83,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
-                  "runner": "linux-atom-mi35x-4",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_QWEN35_397B_A17B_FP8_TP4",
@@ -163,7 +163,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 4 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.83,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
-                  "runner": "linux-atom-mi35x-4",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_QWEN35_397B_A17B_FP8_TP8",
@@ -172,7 +172,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.83,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
-                  "runner": "linux-atom-mi35x-8",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP8_TP8",
@@ -181,7 +181,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 8",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
-                  "runner": "linux-atom-mi35x-8",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP4",
@@ -190,7 +190,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 4",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
-                  "runner": "linux-atom-mi35x-4",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP4_DP4_EP4",
@@ -199,7 +199,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --data-parallel-size 4 --expert-parallel-size 4 --enable-dp-attention --kv-cache-dtype fp8_e4m3 --attention-backend aiter --mem-fraction-static 0.8 --decode-log-interval 1000 --chunked-prefill-size 65536 --max-running-requests 24 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nMORI_SHMEM_MODE=ISOLATION\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=128\nSGLANG_MORI_DISPATCH_DTYPE=bf16\nSGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK=16384",
-                  "runner": "linux-atom-mi35x-8",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP8",
@@ -208,7 +208,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 8",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1",
-                  "runner": "linux-atom-mi35x-8",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP8_MTP3",
@@ -217,7 +217,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 8 --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --max-running-requests 256 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_ENABLE_SPEC_V2=1",
-                  "runner": "linux-atom-mi35x-8",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP8_MTP1",
@@ -226,7 +226,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 8 --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 --max-running-requests 256 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_ENABLE_SPEC_V2=1",
-                  "runner": "linux-atom-mi35x-8",
+                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
               },
           ]
 


### PR DESCRIPTION
## Motivation
Update sglang nightly runner from "linux-atom-mi35x-4/8" to "atom-mi355-8gpu-conductor-sgl-runner".