### PR TITLE
[refactor] Unify engine utility command dispatch into EngineUtilityHandler

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1065,10 +1065,11 @@ async def stop_profile():
     """Stop profiling the engine."""
     global engine
     try:
-        engine.stop_profile()
+        traces = engine.stop_profile()
         return {
             "status": "success",
             "message": "Profiling stopped. Trace files generated.",
+            "traces": traces,
         }
     except Exception as e:
         logger.error(f"Failed to stop profiling: {e}", exc_info=True)

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -14,7 +14,7 @@ import torch
 import zmq
 from atom.config import Config, ParallelConfig
 from atom.model_engine.async_proc import AsyncIOProcManager
-from atom.rollout.engine_utility import EngineUtilityHandler
+from atom.model_engine.engine_utility import EngineUtilityHandler
 from atom.model_engine.scheduler import Scheduler
 from atom.model_engine.sequence import Sequence, SequenceStatus, get_exit_sequence
 from atom.utils import envs, init_exit_handler, make_zmq_socket
@@ -145,7 +145,10 @@ class EngineCore:
             )
 
         self.utility_handler = EngineUtilityHandler(
-            self.runner_mgr, self.output_queue, label=self.label
+            self.runner_mgr,
+            self.output_queue,
+            label=self.label,
+            scheduler=self.scheduler,
         )
 
         self._send_ready_signal()
@@ -364,23 +367,10 @@ class EngineCore:
                         )
                         self.input_queue.put_nowait(reqs)
                     elif request_type == EngineCoreRequestType.UTILITY:
-                        # Put utility commands into queue for processing in busy_loop
-                        # This ensures all runner_mgr.call_func() calls happen in the same thread
                         cmd = reqs.get("cmd") if isinstance(reqs, dict) else None
                         logger.debug(f"{self.label}: input get UTILITY command: {cmd}")
-                        if cmd == "start_profile":
-                            self.start_profiler()
-                        elif cmd == "stop_profile":
-                            self.stop_profiler()
-                        elif cmd == "get_mtp_stats":
-                            self.print_mtp_statistics()
-                        elif cmd == "get_mtp_statistics":
-                            response = {"cmd": cmd, "result": self.get_mtp_statistics()}
-                            self.output_queue.put_nowait(("UTILITY_RESPONSE", response))
-                        else:
-                            # Queue command for processing in busy_loop (main thread)
-                            self.utility_queue.put_nowait((cmd, reqs))
-                            self._has_pending_utility = True
+                        self.utility_queue.put_nowait((cmd, reqs))
+                        self._has_pending_utility = True
                     elif request_type == EngineCoreRequestType.SHUTDOWN:
                         logger.debug(f"{self.label}: input get {request_type}")
                         self.input_queue.put_nowait([get_exit_sequence()])
@@ -437,33 +427,6 @@ class EngineCore:
                         f"{self.label}: output send {EngineCoreRequestType.SHUTDOWN}"
                     )
                     break
-
-    def start_profiler(self):
-        if self.profile_enbaled:
-            self.runner_mgr.call_func("start_profiler", wait_out=True)
-
-    def stop_profiler(self):
-        if self.profile_enbaled:
-            logger.info("Profiler stopping...")
-            t0 = time.monotonic()
-            self.runner_mgr.call_func("stop_profiler", wait_out=True)
-            logger.info("Profiler stopped in %.1fs", time.monotonic() - t0)
-
-    def print_mtp_statistics(self):
-        if self.scheduler.spec_stats is not None:
-            self.scheduler.spec_stats._log()
-        else:
-            logger.info(
-                "\n[MTP Stats] No MTP statistics available (MTP not enabled or no tokens processed)\n"
-            )
-
-    def get_mtp_statistics(self):
-        if self.scheduler.spec_stats is None:
-            return {"enabled": False}
-
-        stats = self.scheduler.spec_stats.get_statistics()
-        stats["enabled"] = True
-        return stats
 
 
 class DPEngineCoreProc(EngineCore):

--- a/atom/model_engine/engine_utility.py
+++ b/atom/model_engine/engine_utility.py
@@ -8,17 +8,24 @@ logger = logging.getLogger("atom")
 
 
 class EngineUtilityHandler:
-    """Handles utility commands dispatched by EngineCore.
+    """Centralised handler for all utility commands dispatched by EngineCore.
+
+    Covers weight management, memory lifecycle, profiling, MTP statistics,
+    and TorchSpec hidden-state extraction.  Every command is registered in
+    ``_UTILITY_HANDLERS`` and executed in the main busy-loop thread so that
+    ``runner_mgr.call_func`` calls are serialized.
 
     Parameters
     ----------
     runner_mgr : AsyncIOProcManager
         The model-runner process manager used to execute ``call_func``.
     output_queue : queue.Queue
-        The EngineCore output queue, used by ``_handle_update_weights_shm``
-        to push ``UTILITY_RESPONSE`` messages back to ``CoreManager``.
+        The EngineCore output queue for pushing ``UTILITY_RESPONSE`` messages
+        back to ``CoreManager``.
     label : str, optional
         Label used in log messages (default ``"Engine Core"``).
+    scheduler : Scheduler, optional
+        The scheduler instance, needed by MTP statistics handlers.
     """
 
     # Utility command name  ->  handler method name
@@ -30,12 +37,19 @@ class EngineUtilityHandler:
         "resume_memory": "_handle_resume_memory",
         "clear_kv_cache": "_handle_clear_kv_cache",
         "configure_hidden_states": "_handle_configure_hidden_states",
+        "start_profile": "_handle_start_profile",
+        "stop_profile": "_handle_stop_profile",
+        "get_mtp_stats": "_handle_get_mtp_stats",
+        "get_mtp_statistics": "_handle_get_mtp_statistics",
     }
 
-    def __init__(self, runner_mgr, output_queue, label: str = "Engine Core"):
+    def __init__(
+        self, runner_mgr, output_queue, label: str = "Engine Core", scheduler=None
+    ):
         self.runner_mgr = runner_mgr
         self.output_queue = output_queue
         self.label = label
+        self.scheduler = scheduler
 
     def process_queue(self, utility_queue, engine):
         """Drain *utility_queue* and execute each command.
@@ -118,7 +132,8 @@ class EngineUtilityHandler:
         After all ModelRunners finish, a UTILITY_RESPONSE is pushed onto the
         output_queue so that the caller (LLMEngine) can synchronise.
 
-        NOTE: This is the **only** handler that writes to ``output_queue``.
+        After completion, a ``UTILITY_RESPONSE`` is pushed so the caller
+        (LLMEngine) can synchronise.
         """
         shm_name = args.get("shm_name", "")
         bucket_meta = args.get("bucket_meta", {})
@@ -208,4 +223,48 @@ class EngineUtilityHandler:
         )
         self.output_queue.put_nowait(
             ("UTILITY_RESPONSE", {"cmd": "configure_hidden_states", "result": result})
+        )
+
+    # ------------------------------------------------------------------
+    # Profiler
+    # ------------------------------------------------------------------
+
+    def _handle_start_profile(self, args: dict):
+        result = self.runner_mgr.call_func("start_profiler", wait_out=True)
+        logger.info(f"{self.label}: profiler started")
+        self.output_queue.put_nowait(
+            ("UTILITY_RESPONSE", {"cmd": "start_profile", "result": result})
+        )
+
+    def _handle_stop_profile(self, args: dict):
+        logger.info(f"{self.label}: stopping profiler...")
+        result = self.runner_mgr.call_func("stop_profiler", wait_out=True)
+        logger.info(f"{self.label}: profiler stopped, result={result}")
+        self.output_queue.put_nowait(
+            ("UTILITY_RESPONSE", {"cmd": "stop_profile", "result": result})
+        )
+
+    # ------------------------------------------------------------------
+    # MTP statistics
+    # ------------------------------------------------------------------
+
+    def _handle_get_mtp_stats(self, args: dict):
+        """Print MTP statistics to log (fire-and-forget)."""
+        if self.scheduler is not None and self.scheduler.spec_stats is not None:
+            self.scheduler.spec_stats._log()
+        else:
+            logger.info(
+                "\n[MTP Stats] No MTP statistics available "
+                "(MTP not enabled or no tokens processed)\n"
+            )
+
+    def _handle_get_mtp_statistics(self, args: dict):
+        """Return structured MTP statistics via UTILITY_RESPONSE."""
+        if self.scheduler is None or self.scheduler.spec_stats is None:
+            result = {"enabled": False}
+        else:
+            result = self.scheduler.spec_stats.get_statistics()
+            result["enabled"] = True
+        self.output_queue.put_nowait(
+            ("UTILITY_RESPONSE", {"cmd": "get_mtp_statistics", "result": result})
         )

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -206,11 +206,12 @@ class LLMEngine:
         return outputs
 
     def start_profile(self):
-        self.core_mgr.send_utility_command("start_profile")
+        self.core_mgr.broadcast_utility_command_sync("start_profile")
         logger.info("Profiling started")
 
-    def stop_profile(self):
-        self.core_mgr.send_utility_command("stop_profile")
+    def stop_profile(self) -> List[Dict[str, Any]]:
+        responses = self.core_mgr.broadcast_utility_command_sync("stop_profile")
+        return [resp.get("result", {}) for resp in responses]
 
     def print_mtp_statistics(self):
         self.core_mgr.send_utility_command("get_mtp_stats")

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -971,9 +971,13 @@ class ModelRunner:
         return True
 
     def stop_profiler(self):
-        """Stop profiling for this rank."""
+        """Stop profiling for this rank.
+
+        Returns a dict with ``trace_dir`` and ``elapsed`` so the caller
+        can report where the trace was written.
+        """
         if self.profiler is None:
-            return True
+            return {"trace_dir": self.profiler_dir, "elapsed": 0.0}
         t0 = time.monotonic()
         logger.info("Rank %d: stopping profiler...", self.rank)
         try:
@@ -982,12 +986,13 @@ class ModelRunner:
             logger.exception("Rank %d: profiler stop failed", self.rank)
         finally:
             self.profiler = None
+        elapsed = round(time.monotonic() - t0, 1)
         logger.info(
             "Rank %d: profiler stop completed in %.1fs",
             self.rank,
-            time.monotonic() - t0,
+            elapsed,
         )
-        return True
+        return {"trace_dir": self.profiler_dir, "elapsed": elapsed}
 
     def debug(self, *args: Any):
         if self.rank == 0:

--- a/atom/rollout/__init__.py
+++ b/atom/rollout/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 from atom.rollout.weight_sync import load_weights_via_shm, load_weights_via_ipc
-from atom.rollout.engine_utility import EngineUtilityHandler
+from atom.model_engine.engine_utility import EngineUtilityHandler
 from atom.rollout.weight_updater import WeightUpdaterMixin
 from atom.rollout.memory_manager import MemoryManagerMixin
 


### PR DESCRIPTION
## Summary

Unify all engine utility command dispatch into `EngineUtilityHandler`.

Previously, utility commands were split across two locations:
- **`engine_core.py` input thread** — `start_profile`, `stop_profile`, `get_mtp_stats`, `get_mtp_statistics` handled inline via ad-hoc if/elif
- **`EngineUtilityHandler`** (in `atom/rollout/`) — weight updates, memory lifecycle, KV cache, hidden states

This PR consolidates everything into a single dispatch-dict handler and moves it to its proper home in `atom/model_engine/`.

## Changes

- **Move `EngineUtilityHandler`** from `atom/rollout/engine_utility.py` to `atom/model_engine/engine_utility.py`
- **Add 4 handlers** to unified dispatch: `start_profile`, `stop_profile`, `get_mtp_stats`, `get_mtp_statistics`
- **Simplify `engine_core.py`**: remove inline if/elif chain and standalone methods; all commands go through `utility_queue` → handler
- **`stop_profile` returns trace info**: `ModelRunner.stop_profiler()` now returns `{trace_dir, elapsed}` instead of `True`; `/stop_profile` endpoint includes this in response
- **Thread safety**: profiler/MTP commands now run in the main busy-loop thread (serialized with other utility commands) instead of the input thread

## Unified Command Inventory

| Command | Response | Description |
|---------|----------|-------------|
| `start_profile` | `UTILITY_RESPONSE` | Start torch profiler on all model runners |
| `stop_profile` | `UTILITY_RESPONSE` (trace_dir + elapsed) | Stop profiler, return trace metadata |
| `get_mtp_stats` | fire-and-forget (prints to log) | Print MTP statistics to server log |
| `get_mtp_statistics` | `UTILITY_RESPONSE` | Return structured MTP statistics JSON |
| `update_weights` | none | Direct weight update |
| `update_weights_shm` | `UTILITY_RESPONSE` | Shared-memory weight update |
| `update_weights_ipc` | `UTILITY_RESPONSE` | CUDA IPC weight update |
| `release_memory` | `UTILITY_RESPONSE` | Offload weights/KV cache (sleep) |
| `resume_memory` | `UTILITY_RESPONSE` | Restore weights/KV cache (wake) |
| `clear_kv_cache` | `UTILITY_RESPONSE` | Zero KV cache blocks |
| `configure_hidden_states` | `UTILITY_RESPONSE` | Configure TorchSpec hidden states extraction |

## API Changes

`/stop_profile` response now includes trace metadata:

```json
{
  "status": "success",
  "message": "Profiling stopped. Trace files generated.",
  "traces": [{"trace_dir": "/path/to/traces", "elapsed": 3.2}]
}
```

All other HTTP endpoints unchanged.

## Changed Files

| File | Change |
|------|--------|
| `atom/model_engine/engine_utility.py` | New location; add profiler + MTP handlers; accept `scheduler` param |
| `atom/rollout/engine_utility.py` | Removed (old location) |
| `atom/rollout/__init__.py` | Re-export from new location |
| `atom/model_engine/engine_core.py` | Remove inline dispatch + standalone methods; pass scheduler to handler |
| `atom/model_engine/model_runner.py` | `stop_profiler()` returns `{trace_dir, elapsed}` |
| `atom/model_engine/llm_engine.py` | `start_profile`/`stop_profile` use `broadcast_utility_command_sync` |
| `atom/entrypoints/openai/api_server.py` | `/stop_profile` returns trace info |
