### PR TITLE
fix(docker,recipes): remove dev-branch defaults and correct image tags

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -306,7 +306,7 @@ RUN pip install --upgrade setuptools_scm
 RUN echo "========== [Parallel] Building Aiter ==========" && \
     git clone $AITER_REPO /app/aiter-test && \
     cd /app/aiter-test && \
-    git checkout -f $AITER_COMMIT && \
+    git checkout $AITER_COMMIT && \
     git submodule sync && git submodule update --init --recursive && \
     pip install -r requirements.txt && \
     MAX_JOBS=$MAX_JOBS PREBUILD_KERNELS=$PREBUILD_KERNELS \
@@ -317,7 +317,7 @@ RUN echo "========== [Parallel] Building Aiter ==========" && \
 # --------------------------------------------------------------------
 FROM base AS atom_image
 ARG ATOM_REPO="https://github.com/ROCm/ATOM.git"
-ARG ATOM_COMMIT="Jasen/atom_mesh"
+ARG ATOM_COMMIT="HEAD"
 
 # pip packages (lm-eval is lightweight, install directly)
 RUN pip install lm-eval[api]

--- a/recipes/mesh/multi-node-atom.md
+++ b/recipes/mesh/multi-node-atom.md
@@ -14,7 +14,7 @@ Two-node Prefill-Decode disaggregation using the ATOM native inference engine an
 On both nodes:
 
 ```bash
-docker pull rocm/atom-dev:sglang-latest
+docker pull rocm/atom-dev:latest
 ```
 
 ## Step 2: Start Docker Containers
@@ -31,7 +31,7 @@ docker run -d --name atom_mesh \
     --shm-size 128G \
     -v /mnt:/mnt \
     -v /it-share:/it-share \
-    rocm/atom-dev:sglang-latest sleep infinity
+    rocm/atom-dev:latest sleep infinity
 ```
 
 ## Step 3: Start Prefill Server (Node 1)


### PR DESCRIPTION
- Reset ATOM_COMMIT default from personal branch to HEAD
- Remove -f flag from aiter git checkout (unnecessary in Docker build)
- Fix multi-node-atom recipe to use rocm/atom-dev:latest instead of sglang-latest

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
