### PR TITLE
refactor(mesh): rename atom-mesh to atomesh for brand alignment

### DIFF
--- a/atom/entrypoints/atomesh/server.py
+++ b/atom/entrypoints/atomesh/server.py
@@ -1,4 +1,4 @@
-"""Python entrypoint for running ATOM Mesh with a Python-owned engine.
+"""Python entrypoint for running Atomesh with a Python-owned engine.
 
 This module intentionally mirrors the engine/tokenizer initialization used by
 ``atom.entrypoints.openai.api_server``. The Rust side receives the already
@@ -77,7 +77,7 @@ def print_version(verbose: bool = False) -> None:
         )
         print(version_fn())
     except Exception:
-        print("ATOM Mesh Python interface")
+        print("Atomesh Python interface")
 
 
 def initialize_engine(args: argparse.Namespace) -> tuple[Any, Any]:
@@ -151,7 +151,7 @@ def parse_standalone_args(raw_args: list[str]) -> StandaloneArgs:
     from atom.model_engine.arg_utils import EngineArgs
 
     parser = argparse.ArgumentParser(
-        description="ATOM Mesh Python interface",
+        description="Atomesh Python interface",
         allow_abbrev=False,
     )
     EngineArgs.add_cli_args(parser)

--- a/atom/mesh/Cargo.toml
+++ b/atom/mesh/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "atom-mesh"
+name = "atomesh"
 version = "0.1.0"
 edition = "2021"
 
@@ -15,7 +15,7 @@ name = "mesh"
 crate-type = ["rlib", "cdylib"]
 
 [[bin]]
-name = "atom-mesh"
+name = "atomesh"
 path = "src/main.rs"
 
 [dependencies]

--- a/atom/mesh/README.md
+++ b/atom/mesh/README.md
@@ -1,8 +1,8 @@
-# ATOM Mesh
+# Atomesh
 
 High-performance model routing gateway for **PD (Prefill–Decode) disaggregated** LLM serving. It routes inference across heterogeneous worker fleets with cache-aware load balancing, a gRPC pipeline that keeps tokenization in Rust, and built-in reliability primitives.
 
-ATOM Mesh can also run in an **ATOM standalone** mode. In this mode, Python owns the ATOM engine, tokenizer, and OpenAI-compatible serving semantics, while Rust Mesh provides the HTTP server, request routing, lifecycle management, observability, and PyO3 bridge. This allows the same Mesh serving layer to support both distributed worker routing and a single-process ATOM deployment path.
+Atomesh can also run in an **ATOM standalone** mode. In this mode, Python owns the ATOM engine, tokenizer, and OpenAI-compatible serving semantics, while Atomesh provides the HTTP server, request routing, lifecycle management, observability, and PyO3 bridge. This allows the same Atomesh serving layer to support both distributed worker routing and a single-process ATOM deployment path.
 
 ## Features
 
@@ -53,9 +53,9 @@ Artifacts: `target/release/atomesh`, `target/release/libmesh.so`.
 
 ### Build during ATOM package install
 
-ATOM package installation does not build Mesh by default. To compile Mesh during
+ATOM package installation does not build Atomesh by default. To compile Atomesh during
 package installation and include `libmesh.so` in the installed package, enable
-the Mesh build hook:
+the Atomesh build hook:
 
 ```bash
 ATOM_MESH_BUILD=1 python -m pip install .
@@ -87,14 +87,14 @@ USE_ATOMESH_ENTRYPOINTS=1 python -m atom.entrypoints.openai_server \
 ```
 
 Do not pass `mesh-only` for standalone mode. The `mesh-only` subcommand is only
-used when the Python entrypoint should run Mesh as a router for external
+used when the Python entrypoint should run Atomesh as a router for external
 workers.
 
 
 ### Regular HTTP routing
 
 Routing mode can be started through either the Rust binary or the Python
-entrypoint. For the Python entrypoint, `mesh-only` selects Mesh routing;
+entrypoint. For the Python entrypoint, `mesh-only` selects Atomesh routing;
 without `mesh-only`, it defaults to ATOM standalone mode.
 
 ```bash
@@ -231,4 +231,4 @@ Clients send `Authorization: Bearer <key>`. Workers declared on the CLI inherit 
 
 ## Acknowledgments and upstream
 
-[**sgl-model-gateway**](https://github.com/sgl-project/sglang/tree/main/sgl-model-gateway) remains an excellent reference for disaggregated model routing and high-throughput serving. ATOM Mesh acknowledges that work as useful inspiration, but has since been substantially reworked into an independent serving layer for the **ATOM** stack and **AMD** hardware. Its routing, scheduling, runtime integration, and performance-sensitive paths are designed around AMD accelerator deployments and ATOM-specific serving requirements.
+[**sgl-model-gateway**](https://github.com/sgl-project/sglang/tree/main/sgl-model-gateway) remains an excellent reference for disaggregated model routing and high-throughput serving. Atomesh acknowledges that work as useful inspiration, but has since been substantially reworked into an independent serving layer for the **ATOM** stack and **AMD** hardware. Its routing, scheduling, runtime integration, and performance-sensitive paths are designed around AMD accelerator deployments and ATOM-specific serving requirements.

--- a/atom/mesh/README.md
+++ b/atom/mesh/README.md
@@ -49,7 +49,7 @@ cargo build
 cargo build --release
 ```
 
-Artifacts: `target/release/atom-mesh`, `target/release/libmesh.so`.
+Artifacts: `target/release/atomesh`, `target/release/libmesh.so`.
 
 ### Build during ATOM package install
 
@@ -98,7 +98,7 @@ entrypoint. For the Python entrypoint, `mesh-only` selects Mesh routing;
 without `mesh-only`, it defaults to ATOM standalone mode.
 
 ```bash
-./target/release/atom-mesh launch \
+./target/release/atomesh launch \
   --worker-urls http://worker1:8000 http://worker2:8000 \
   --policy cache_aware
 
@@ -110,7 +110,7 @@ USE_ATOMESH_ENTRYPOINTS=1 python -m atom.entrypoints.openai_server mesh-only \
 ### Prefill / decode disaggregation
 
 ```bash
-./target/release/atom-mesh launch --pd-disaggregation \
+./target/release/atomesh launch --pd-disaggregation \
   --prefill http://prefill1:30001 9001 \
   --prefill http://prefill2:30002 \
   --decode http://decode1:30011 \
@@ -131,7 +131,7 @@ Prefill entries may include an optional bootstrap port (e.g. for Mooncake KV cac
 ### gRPC routing
 
 ```bash
-./target/release/atom-mesh launch \
+./target/release/atomesh launch \
   --worker-urls grpc://worker1:31001 grpc://worker2:31002 \
   --tokenizer-path /path/to/tokenizer.json \
   --reasoning-parser deepseek-r1 \
@@ -220,7 +220,7 @@ Structured logging via `tracing`, optional file sink (`--log-dir`), and log leve
 Optional API key protection for router endpoints:
 
 ```bash
-./target/release/atom-mesh launch --api-key "your-secret-key" \
+./target/release/atomesh launch --api-key "your-secret-key" \
   --worker-urls http://worker1:8000 http://worker2:8000
 
 USE_ATOMESH_ENTRYPOINTS=1 python -m atom.entrypoints.openai_server mesh-only --api-key "your-secret-key" \

--- a/atom/mesh/build.rs
+++ b/atom/mesh/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 const DEFAULT_VERSION: &str = "0.0.0";
-const DEFAULT_PROJECT_NAME: &str = "atom-mesh";
+const DEFAULT_PROJECT_NAME: &str = "atomesh";
 
 /// Set a compile-time environment variable with the ATOM_MESH_ prefix
 macro_rules! set_env {

--- a/atom/mesh/mocker/Cargo.toml
+++ b/atom/mesh/mocker/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "atom-mesh-mocker"
+name = "atomesh-mocker"
 version = "0.1.0"
 edition = "2021"
 
@@ -12,7 +12,7 @@ name = "atomesh-mocker"
 path = "main.rs"
 
 [dependencies]
-mesh = { package = "atom-mesh", path = ".." }
+mesh = { package = "atomesh", path = ".." }
 axum = { version = "0.8.6", features = ["macros", "ws", "tracing"] }
 clap = { version = "4", features = ["derive", "env"] }
 data-connector = "=1.0.0"

--- a/atom/mesh/mocker/README.md
+++ b/atom/mesh/mocker/README.md
@@ -39,7 +39,7 @@ Workers bind to `base-port + worker_index`. For example, `--base-port 30010 --wo
 Start Atomesh and point it at the virtual worker URL:
 
 ```bash
-cd ATOM/atom/mesh && ./target/debug/atom-mesh \
+cd ATOM/atom/mesh && ./target/debug/atomesh \
   --host 127.0.0.1 \
   --port 30000 \
   --worker http://127.0.0.1:30010

--- a/atom/mesh/scripts/README.md
+++ b/atom/mesh/scripts/README.md
@@ -90,7 +90,7 @@ The script waits for both prefill and decode servers to be ready before starting
 | `DECODE_PORT` | `8020` | Decode server port |
 | `ROUTER_PORT` | `8000` | Router listening port |
 | `POLICY` | `random` | Routing policy |
-| `MESH_BIN` | `/usr/local/bin/atom-mesh` | Path to atom-mesh binary |
+| `MESH_BIN` | `/usr/local/bin/atomesh` | Path to atomesh binary |
 | `WAIT_TIMEOUT` | `900` | Timeout waiting for prefill/decode (seconds) |
 
 ## 5. Verify
@@ -202,7 +202,7 @@ SBATCH directives (edit in script if your cluster differs):
 └── <MMDD>_ds_fp8_1p_tp4_1d_tp8_<jobid>/
     ├── prefill/prefill.log               # sglang prefill server
     ├── decode/decode.log                 # sglang decode server
-    ├── router/                           # atom-mesh router
+    ├── router/                           # atomesh router
     ├── gsm8k/<timestamp>_gsm8k/          # lm_eval GSM8K results (if enabled)
     ├── bench/pd-mesh-<isl>-<osl>-<conc>-<ratio>.json
     └── scripts/                          # generated in-container scripts

--- a/atom/mesh/scripts/README.md
+++ b/atom/mesh/scripts/README.md
@@ -1,6 +1,6 @@
-# ATOM Mesh PD Disaggregation Scripts
+# Atomesh PD Disaggregation Scripts
 
-End-to-end guide for building, deploying, and benchmarking the ATOM Mesh prefill-decode (PD) disaggregation setup.
+End-to-end guide for building, deploying, and benchmarking the Atomesh prefill-decode (PD) disaggregation setup.
 
 ## Prerequisites
 

--- a/atom/mesh/scripts/atom_sgl_mesh_xpyd.sh
+++ b/atom/mesh/scripts/atom_sgl_mesh_xpyd.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 #   DECODE_BOOTSTRAP_BASE=9098
 #
 # Optional serving env:
-#   ROUTER_PORT=8000  POLICY=random  MESH_BIN=/usr/local/bin/atom-mesh
+#   ROUTER_PORT=8000  POLICY=random  MESH_BIN=/usr/local/bin/atomesh
 #   MEM_FRACTION=0.85  KV_CACHE_DTYPE=fp8_e4m3
 #   MAX_RUNNING_REQUESTS=128
 #   CUDA_GRAPH_BS_START=1  CUDA_GRAPH_BS_END=64
@@ -64,7 +64,7 @@ CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-64}"
 IB_DEVICE="${IB_DEVICE:-$(detect_ib_devices)}"
 POLICY="${POLICY:-random}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-900}"
 LOG_DIR="${LOG_DIR:-/workspace/logs}"
 CLEANUP_EXISTING="${CLEANUP_EXISTING:-0}"
@@ -316,7 +316,7 @@ main() {
     mkdir -p "${LOG_DIR}"
 
     if [[ "${CLEANUP_EXISTING}" == "1" ]]; then
-        echo "[cleanup] stopping existing sglang and atom-mesh processes"
+        echo "[cleanup] stopping existing sglang and atomesh processes"
         pkill -f 'python3 -m sglang.launch_server' || true
         pkill -f "${MESH_BIN} launch" || true
         sleep 3

--- a/atom/mesh/scripts/atom_sgl_mesh_xpyd.sh
+++ b/atom/mesh/scripts/atom_sgl_mesh_xpyd.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Launch ATOM Mesh SGLang PD disaggregation on a single node.
+# Launch Atomesh SGLang PD disaggregation on a single node.
 #
 # Required env:
 #   MODEL_PATH      - model path

--- a/atom/mesh/scripts/docker_start.sh
+++ b/atom/mesh/scripts/docker_start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Start the atom-mesh Docker container.
+# Start the atomesh Docker container.
 #
 # Optional env (with defaults):
 #   CONTAINER=atom_sglang_mesh

--- a/atom/mesh/scripts/docker_start_vllm.sh
+++ b/atom/mesh/scripts/docker_start_vllm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Start the atom-mesh vLLM Docker container.
+# Start the atomesh vLLM Docker container.
 #
 # Optional env (with defaults):
 #   CONTAINER=atom_vllm_mesh

--- a/atom/mesh/scripts/ds_fp4_1p_tp4_2d_tp8_atom_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp4_2d_tp8_atom_slurm.sh
@@ -13,10 +13,10 @@
 #SBATCH --output=/it-share/yajizhan/slurm_logs/ds_fp4_atom_1p_tp4_2d_tp8-%j.out
 #SBATCH --error=/it-share/yajizhan/slurm_logs/ds_fp4_atom_1p_tp4_2d_tp8-%j.err
 #
-# 1P+2D PD-disaggregated benchmark for ATOM native server + atom-mesh router.
+# 1P+2D PD-disaggregated benchmark for ATOM native server + atomesh router.
 #   - prefill: ATOM kv_producer, TP=4 (uses GPUs 0-3, other 4 idle)
 #   - decode:  ATOM kv_consumer, TP=8 (2 instances, each on its own node)
-#   - router:  atom-mesh launch --backend atom (no bootstrap port)
+#   - router:  atomesh launch --backend atom (no bootstrap port)
 #   - KV transfer: Mooncake RDMA (atom/kv_transfer/disaggregation/mooncake)
 #
 # Mesh router learns each prefill's tp_size/dp_size/kv_role by GETing
@@ -288,7 +288,7 @@ IFS=',' read -ra CONCS <<< "${CONC_LIST}"
 
 for ISL in "${ISLS[@]}"; do
     for CONC in "${CONCS[@]}"; do
-        RESULT_FILENAME="pd-atom-mesh-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}"
+        RESULT_FILENAME="pd-atomesh-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}"
         echo ""
         echo "========================================="
         echo "[bench] ISL=${ISL} OSL=${OSL} CONC=${CONC}"
@@ -325,7 +325,7 @@ from pathlib import Path
 import json
 
 result_dir = Path('${RESULT_DIR}')
-json_files = sorted(result_dir.glob('pd-atom-mesh-*.json'))
+json_files = sorted(result_dir.glob('pd-atomesh-*.json'))
 if not json_files:
     print('No result files found')
     exit(0)
@@ -363,7 +363,7 @@ for script in "${LOG_ROOT}"/scripts/*.sh; do
         -e "s|\${MODEL_PATH}|${MODEL_PATH}|g" \
         -e "s|\${KV_CACHE_DTYPE}|${KV_CACHE_DTYPE}|g" \
         -e "s|\${BLOCK_SIZE}|${BLOCK_SIZE}|g" \
-        -e "s|\${MESH_BIN}|/usr/local/bin/atom-mesh|g" \
+        -e "s|\${MESH_BIN}|/usr/local/bin/atomesh|g" \
         -e "s|\${PREFILL_GPU_IDS}|${PREFILL_GPU_IDS}|g" \
         -e "s|\${DECODE_GPU_IDS}|${DECODE_GPU_IDS}|g" \
         -e "s|\${EXTRA_SERVER_ARGS}|${EXTRA_SERVER_ARGS}|g" \
@@ -390,7 +390,7 @@ cleanup() {
             docker logs '${CONTAINER}' > '${LOG_ROOT}/docker_\$(hostname).log' 2>&1 || true
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             pkill -9 -f 'atom.entrypoints.openai_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     wait
@@ -534,7 +534,7 @@ verify_kv_info decode-2  "$DECODE_NODE_2"  "$DECODE_IP_2"  "$DECODE_PORT"  kv_co
 
 # ======================== 4. start router (detached) ========================
 echo ""
-echo "[router] launching atom-mesh on ${PREFILL_NODE}"
+echo "[router] launching atomesh on ${PREFILL_NODE}"
 srun --nodelist="$PREFILL_NODE" --nodes=1 --ntasks=1 bash -lc "
     docker exec -d '${CONTAINER}' bash '${LOG_ROOT}/scripts/router.sh'
 "

--- a/atom/mesh/scripts/ds_fp4_1p_tp4_2d_tp8_sglang_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp4_2d_tp8_sglang_slurm.sh
@@ -46,7 +46,7 @@ MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-256}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-256}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 
 ISL_LIST="${ISL_LIST:-8192}"
 OSL="${OSL:-1024}"
@@ -93,7 +93,7 @@ fi
 
 # ======================== pre-cleanup ========================
 # Force-stop ALL running docker containers on every node before starting fresh.
-# This ensures no residual sglang/atom-mesh processes are holding GPU memory
+# This ensures no residual sglang/atomesh processes are holding GPU memory
 # or ports from previous runs (e.g. when `scancel` killed the sbatch shell
 # without propagating into the containers).
 echo "=== pre-cleanup: force-stopping all docker containers on all nodes ==="
@@ -464,7 +464,7 @@ cleanup() {
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             # Belt-and-suspenders: kill any orphaned GPU processes from this run
             pkill -9 -f 'sglang.launch_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     # Wait for all cleanup sruns (with a timeout)

--- a/atom/mesh/scripts/ds_fp4_1p_tp4_2d_tp8_vllm_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp4_2d_tp8_vllm_slurm.sh
@@ -45,7 +45,7 @@ MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-16384}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-16384}"
 LOAD_FORMAT="${LOAD_FORMAT:-fastsafetensors}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 ENFORCE_EAGER="${ENFORCE_EAGER:-}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-256}"
@@ -435,7 +435,7 @@ cleanup() {
             docker logs '${CONTAINER}' > '${LOG_ROOT}/docker_\$(hostname).log' 2>&1 || true
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             pkill -9 -f 'vllm.entrypoints' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     wait

--- a/atom/mesh/scripts/ds_fp4_1p_tp8_1d_tp8_atom_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp8_1d_tp8_atom_slurm.sh
@@ -13,10 +13,10 @@
 #SBATCH --output=/it-share/yajizhan/slurm_logs/ds_fp4_atom_1p_tp8_1d_tp8-%j.out
 #SBATCH --error=/it-share/yajizhan/slurm_logs/ds_fp4_atom_1p_tp8_1d_tp8-%j.err
 #
-# 1P+1D PD-disaggregated benchmark for ATOM native server + atom-mesh router.
+# 1P+1D PD-disaggregated benchmark for ATOM native server + atomesh router.
 #   - prefill: ATOM kv_producer, TP=8
 #   - decode:  ATOM kv_consumer, TP=8
-#   - router:  atom-mesh launch --backend atom (no bootstrap port)
+#   - router:  atomesh launch --backend atom (no bootstrap port)
 #   - KV transfer: Mooncake RDMA (atom/kv_transfer/disaggregation/mooncake)
 #
 # Mesh router learns each prefill's tp_size/dp_size/kv_role by GETing
@@ -275,7 +275,7 @@ IFS=',' read -ra CONCS <<< "${CONC_LIST}"
 
 for ISL in "${ISLS[@]}"; do
     for CONC in "${CONCS[@]}"; do
-        RESULT_FILENAME="pd-atom-mesh-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}"
+        RESULT_FILENAME="pd-atomesh-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}"
         echo ""
         echo "========================================="
         echo "[bench] ISL=${ISL} OSL=${OSL} CONC=${CONC}"
@@ -314,7 +314,7 @@ from pathlib import Path
 import json
 
 result_dir = Path('${RESULT_DIR}')
-json_files = sorted(result_dir.glob('pd-atom-mesh-*.json'))
+json_files = sorted(result_dir.glob('pd-atomesh-*.json'))
 if not json_files:
     print('No result files found')
     exit(0)
@@ -351,7 +351,7 @@ for script in "${LOG_ROOT}"/scripts/*.sh; do
         -e "s|\${MODEL_PATH}|${MODEL_PATH}|g" \
         -e "s|\${KV_CACHE_DTYPE}|${KV_CACHE_DTYPE}|g" \
         -e "s|\${BLOCK_SIZE}|${BLOCK_SIZE}|g" \
-        -e "s|\${MESH_BIN}|/usr/local/bin/atom-mesh|g" \
+        -e "s|\${MESH_BIN}|/usr/local/bin/atomesh|g" \
         -e "s|\${PREFILL_GPU_IDS}|${PREFILL_GPU_IDS}|g" \
         -e "s|\${DECODE_GPU_IDS}|${DECODE_GPU_IDS}|g" \
         -e "s|\${EXTRA_SERVER_ARGS}|${EXTRA_SERVER_ARGS}|g" \
@@ -378,7 +378,7 @@ cleanup() {
             docker logs '${CONTAINER}' > '${LOG_ROOT}/docker_\$(hostname).log' 2>&1 || true
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             pkill -9 -f 'atom.entrypoints.openai_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     wait
@@ -515,7 +515,7 @@ verify_kv_info decode  "$DECODE_NODE"  "$DECODE_IP"  "$DECODE_PORT"  kv_consumer
 
 # ======================== 4. start router (detached) ========================
 echo ""
-echo "[router] launching atom-mesh on ${PREFILL_NODE}"
+echo "[router] launching atomesh on ${PREFILL_NODE}"
 srun --nodelist="$PREFILL_NODE" --nodes=1 --ntasks=1 bash -lc "
     docker exec -d '${CONTAINER}' bash '${LOG_ROOT}/scripts/router.sh'
 "

--- a/atom/mesh/scripts/ds_fp4_1p_tp8_1d_tp8_sglang_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp8_1d_tp8_sglang_slurm.sh
@@ -44,7 +44,7 @@ MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-128}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-256}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 
 ISL_LIST="${ISL_LIST:-8192}"
 OSL="${OSL:-1024}"
@@ -89,7 +89,7 @@ fi
 
 # ======================== pre-cleanup ========================
 # Force-stop ALL running docker containers on both nodes before starting fresh.
-# This ensures no residual sglang/atom-mesh processes are holding GPU memory
+# This ensures no residual sglang/atomesh processes are holding GPU memory
 # or ports from previous runs (e.g. when `scancel` killed the sbatch shell
 # without propagating into the containers).
 echo "=== pre-cleanup: force-stopping all docker containers on both nodes ==="
@@ -443,7 +443,7 @@ cleanup() {
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             # Belt-and-suspenders: kill any orphaned GPU processes from this run
             pkill -9 -f 'sglang.launch_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     # Wait for both cleanup sruns (with a timeout)

--- a/atom/mesh/scripts/ds_fp4_1p_tp8_1d_tp8_vllm_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp8_1d_tp8_vllm_slurm.sh
@@ -44,7 +44,7 @@ MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-16384}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-16384}"
 LOAD_FORMAT="${LOAD_FORMAT:-fastsafetensors}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 ENFORCE_EAGER="${ENFORCE_EAGER:-}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-256}"
@@ -418,7 +418,7 @@ cleanup() {
             docker logs '${CONTAINER}' > '${LOG_ROOT}/docker_\$(hostname).log' 2>&1 || true
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             pkill -9 -f 'vllm.entrypoints' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     wait

--- a/atom/mesh/scripts/ds_fp4_1p_tp8_2d_tp8_atom_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp8_2d_tp8_atom_slurm.sh
@@ -13,10 +13,10 @@
 #SBATCH --output=/it-share/yajizhan/slurm_logs/ds_fp4_atom_1p_tp8_2d_tp8-%j.out
 #SBATCH --error=/it-share/yajizhan/slurm_logs/ds_fp4_atom_1p_tp8_2d_tp8-%j.err
 #
-# 1P+2D PD-disaggregated benchmark for ATOM native server + atom-mesh router.
+# 1P+2D PD-disaggregated benchmark for ATOM native server + atomesh router.
 #   - prefill: ATOM kv_producer, TP=8
 #   - decode:  ATOM kv_consumer, TP=8 (2 instances, each on its own node)
-#   - router:  atom-mesh launch --backend atom (no bootstrap port)
+#   - router:  atomesh launch --backend atom (no bootstrap port)
 #   - KV transfer: Mooncake RDMA (atom/kv_transfer/disaggregation/mooncake)
 #
 # Mesh router learns each prefill's tp_size/dp_size/kv_role by GETing
@@ -294,7 +294,7 @@ IFS=',' read -ra CONCS <<< "${CONC_LIST}"
 
 for ISL in "${ISLS[@]}"; do
     for CONC in "${CONCS[@]}"; do
-        RESULT_FILENAME="pd-atom-mesh-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}"
+        RESULT_FILENAME="pd-atomesh-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}"
         echo ""
         echo "========================================="
         echo "[bench] ISL=${ISL} OSL=${OSL} CONC=${CONC}"
@@ -333,7 +333,7 @@ from pathlib import Path
 import json
 
 result_dir = Path('${RESULT_DIR}')
-json_files = sorted(result_dir.glob('pd-atom-mesh-*.json'))
+json_files = sorted(result_dir.glob('pd-atomesh-*.json'))
 if not json_files:
     print('No result files found')
     exit(0)
@@ -371,7 +371,7 @@ for script in "${LOG_ROOT}"/scripts/*.sh; do
         -e "s|\${MODEL_PATH}|${MODEL_PATH}|g" \
         -e "s|\${KV_CACHE_DTYPE}|${KV_CACHE_DTYPE}|g" \
         -e "s|\${BLOCK_SIZE}|${BLOCK_SIZE}|g" \
-        -e "s|\${MESH_BIN}|/usr/local/bin/atom-mesh|g" \
+        -e "s|\${MESH_BIN}|/usr/local/bin/atomesh|g" \
         -e "s|\${PREFILL_GPU_IDS}|${PREFILL_GPU_IDS}|g" \
         -e "s|\${DECODE_GPU_IDS}|${DECODE_GPU_IDS}|g" \
         -e "s|\${EXTRA_SERVER_ARGS}|${EXTRA_SERVER_ARGS}|g" \
@@ -398,7 +398,7 @@ cleanup() {
             docker logs '${CONTAINER}' > '${LOG_ROOT}/docker_\$(hostname).log' 2>&1 || true
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             pkill -9 -f 'atom.entrypoints.openai_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     wait
@@ -543,7 +543,7 @@ verify_kv_info decode-2  "$DECODE_NODE_2"  "$DECODE_IP_2"  "$DECODE_PORT"  kv_co
 
 # ======================== 4. start router (detached) ========================
 echo ""
-echo "[router] launching atom-mesh on ${PREFILL_NODE}"
+echo "[router] launching atomesh on ${PREFILL_NODE}"
 srun --nodelist="$PREFILL_NODE" --nodes=1 --ntasks=1 bash -lc "
     docker exec -d '${CONTAINER}' bash '${LOG_ROOT}/scripts/router.sh'
 "

--- a/atom/mesh/scripts/ds_fp4_1p_tp8_2d_tp8_sglang_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp8_2d_tp8_sglang_slurm.sh
@@ -45,7 +45,7 @@ MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-256}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-256}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 
 ISL_LIST="${ISL_LIST:-8192}"
 OSL="${OSL:-1024}"
@@ -92,7 +92,7 @@ fi
 
 # ======================== pre-cleanup ========================
 # Force-stop ALL running docker containers on every node before starting fresh.
-# This ensures no residual sglang/atom-mesh processes are holding GPU memory
+# This ensures no residual sglang/atomesh processes are holding GPU memory
 # or ports from previous runs (e.g. when `scancel` killed the sbatch shell
 # without propagating into the containers).
 echo "=== pre-cleanup: force-stopping all docker containers on all nodes ==="
@@ -463,7 +463,7 @@ cleanup() {
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             # Belt-and-suspenders: kill any orphaned GPU processes from this run
             pkill -9 -f 'sglang.launch_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     # Wait for all cleanup sruns (with a timeout)

--- a/atom/mesh/scripts/ds_fp4_1p_tp8_2d_tp8_vllm_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_1p_tp8_2d_tp8_vllm_slurm.sh
@@ -45,7 +45,7 @@ MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-16384}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-16384}"
 LOAD_FORMAT="${LOAD_FORMAT:-fastsafetensors}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 ENFORCE_EAGER="${ENFORCE_EAGER:-}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-256}"
@@ -435,7 +435,7 @@ cleanup() {
             docker logs '${CONTAINER}' > '${LOG_ROOT}/docker_\$(hostname).log' 2>&1 || true
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             pkill -9 -f 'vllm.entrypoints' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     wait

--- a/atom/mesh/scripts/ds_fp4_2p_dp8ep8_1d_dp8ep8_atom_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_2p_dp8ep8_1d_dp8ep8_atom_slurm.sh
@@ -13,11 +13,11 @@
 #SBATCH --output=/it-share/yajizhan/slurm_logs/ds_fp4_atom_2p_dp8ep8_1d_dp8ep8-%j.out
 #SBATCH --error=/it-share/yajizhan/slurm_logs/ds_fp4_atom_2p_dp8ep8_1d_dp8ep8-%j.err
 #
-# 2P+1D PD-disaggregated benchmark for ATOM native server + atom-mesh router.
+# 2P+1D PD-disaggregated benchmark for ATOM native server + atomesh router.
 #   prefill0: ATOM kv_producer, TP=1, DP=8, EP=8 (1 node)
 #   prefill1: ATOM kv_producer, TP=1, DP=8, EP=8 (1 node)
 #   decode:   ATOM kv_consumer, TP=1, DP=8, EP=8 (1 node)
-#   router:   atom-mesh launch --backend atom (no bootstrap port)
+#   router:   atomesh launch --backend atom (no bootstrap port)
 #   KV transfer: Mooncake RDMA (atom/kv_transfer/disaggregation/mooncake)
 #
 # Mesh router learns each prefill's tp_size/dp_size/kv_role by GETing
@@ -55,7 +55,7 @@ BLOCK_SIZE="${BLOCK_SIZE:-16}"
 PREFILL_MAX_NUM_SEQS="${PREFILL_MAX_NUM_SEQS:-4096}"
 DECODE_MAX_NUM_SEQS="${DECODE_MAX_NUM_SEQS:-4096}"
 EXTRA_SERVER_ARGS="${EXTRA_SERVER_ARGS:-}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 
 MORI_DISPATCH_DTYPE="${MORI_DISPATCH_DTYPE:-bf16}"
 MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK="${MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK:-16384}"
@@ -315,7 +315,7 @@ IFS=',' read -ra CONCS <<< "${CONC_LIST}"
 
 for ISL in "\${ISLS[@]}"; do
     for CONC in "\${CONCS[@]}"; do
-        RESULT_FILENAME="pd-atom-mesh-dp8ep8-\${ISL}-${OSL}-\${CONC}-${RANDOM_RANGE_RATIO}"
+        RESULT_FILENAME="pd-atomesh-dp8ep8-\${ISL}-${OSL}-\${CONC}-${RANDOM_RANGE_RATIO}"
         echo ""
         echo "========================================="
         echo "[bench] ISL=\${ISL} OSL=${OSL} CONC=\${CONC}"
@@ -352,7 +352,7 @@ from pathlib import Path
 import json
 
 result_dir = Path('\${RESULT_DIR}')
-json_files = sorted(result_dir.glob('pd-atom-mesh-dp8ep8-*.json'))
+json_files = sorted(result_dir.glob('pd-atomesh-dp8ep8-*.json'))
 if not json_files:
     print('No result files found')
     exit(0)
@@ -388,7 +388,7 @@ cleanup() {
             docker logs '${CONTAINER}' > '${LOG_ROOT}/docker_\$(hostname).log' 2>&1 || true
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             pkill -9 -f 'atom.entrypoints.openai_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     wait
@@ -534,7 +534,7 @@ verify_kv_info decode    "$DECODE_NODE"    "$DECODE_IP"    "$DECODE_PORT"   kv_c
 
 # ======================== 4. start router (detached) ========================
 echo ""
-echo "[router] launching atom-mesh on ${PREFILL_NODE_0}"
+echo "[router] launching atomesh on ${PREFILL_NODE_0}"
 srun --nodelist="$PREFILL_NODE_0" --nodes=1 --ntasks=1 bash -lc "
     docker exec -d '${CONTAINER}' bash '${LOG_ROOT}/scripts/router.sh'
 "

--- a/atom/mesh/scripts/ds_fp4_2p_dp8ep8_1d_dp8ep8_sglang_slurm.sh
+++ b/atom/mesh/scripts/ds_fp4_2p_dp8ep8_1d_dp8ep8_sglang_slurm.sh
@@ -56,7 +56,7 @@ PREFILL_CHUNKED_PREFILL_SIZE="${PREFILL_CHUNKED_PREFILL_SIZE:-65536}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-160}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 
 MORI_DISPATCH_DTYPE="${MORI_DISPATCH_DTYPE:-bf16}"
 MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK="${MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK:-16384}"
@@ -423,7 +423,7 @@ cleanup() {
             docker logs '${CONTAINER}' > '${LOG_ROOT}/docker_\$(hostname).log' 2>&1 || true
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             pkill -9 -f 'sglang.launch_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     wait

--- a/atom/mesh/scripts/ds_fp8_1p_tp4_1d_tp8_slurm.sh
+++ b/atom/mesh/scripts/ds_fp8_1p_tp4_1d_tp8_slurm.sh
@@ -45,7 +45,7 @@ MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-128}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-64}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 
 ISL_LIST="${ISL_LIST:-8192}"
 OSL="${OSL:-1024}"
@@ -90,7 +90,7 @@ fi
 
 # ======================== pre-cleanup ========================
 # Force-stop ALL running docker containers on both nodes before starting fresh.
-# This ensures no residual sglang/atom-mesh processes are holding GPU memory
+# This ensures no residual sglang/atomesh processes are holding GPU memory
 # or ports from previous runs (e.g. when `scancel` killed the sbatch shell
 # without propagating into the containers).
 echo "=== pre-cleanup: force-stopping all docker containers on both nodes ==="
@@ -445,7 +445,7 @@ cleanup() {
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             # Belt-and-suspenders: kill any orphaned GPU processes from this run
             pkill -9 -f 'sglang.launch_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     # Wait for both cleanup sruns (with a timeout)

--- a/atom/mesh/scripts/ds_fp8_1p_tp8_1d_tp8_slurm.sh
+++ b/atom/mesh/scripts/ds_fp8_1p_tp8_1d_tp8_slurm.sh
@@ -45,7 +45,7 @@ MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-128}"
 CUDA_GRAPH_BS_START="${CUDA_GRAPH_BS_START:-1}"
 CUDA_GRAPH_BS_END="${CUDA_GRAPH_BS_END:-256}"
 IB_DEVICE="${IB_DEVICE:-rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 
 ISL_LIST="${ISL_LIST:-8192}"
 OSL="${OSL:-1024}"
@@ -90,7 +90,7 @@ fi
 
 # ======================== pre-cleanup ========================
 # Force-stop ALL running docker containers on both nodes before starting fresh.
-# This ensures no residual sglang/atom-mesh processes are holding GPU memory
+# This ensures no residual sglang/atomesh processes are holding GPU memory
 # or ports from previous runs (e.g. when `scancel` killed the sbatch shell
 # without propagating into the containers).
 echo "=== pre-cleanup: force-stopping all docker containers on both nodes ==="
@@ -445,7 +445,7 @@ cleanup() {
             docker rm -f '${CONTAINER}' >/dev/null 2>&1 || true
             # Belt-and-suspenders: kill any orphaned GPU processes from this run
             pkill -9 -f 'sglang.launch_server' 2>/dev/null || true
-            pkill -9 -f 'atom-mesh' 2>/dev/null || true
+            pkill -9 -f 'atomesh' 2>/dev/null || true
         " &
     done
     # Wait for both cleanup sruns (with a timeout)

--- a/atom/mesh/scripts/start_router.sh
+++ b/atom/mesh/scripts/start_router.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Launch the atom-mesh router. Run this script inside the container.
+# Launch the atomesh router. Run this script inside the container.
 #
 # Required env:
 #   PREFILL_IP      - prefill node IP
@@ -10,7 +10,7 @@ set -euo pipefail
 # Optional env (with defaults):
 #   PREFILL_PORT=8010  DECODE_PORT=8020  ROUTER_PORT=8000
 #   BOOTSTRAP_PORT=8998  POLICY=random
-#   MESH_BIN=/usr/local/bin/atom-mesh  WAIT_TIMEOUT=900
+#   MESH_BIN=/usr/local/bin/atomesh  WAIT_TIMEOUT=900
 
 : "${PREFILL_IP:?}"
 : "${DECODE_IP:?}"
@@ -20,7 +20,7 @@ DECODE_PORT="${DECODE_PORT:-8020}"
 ROUTER_PORT="${ROUTER_PORT:-8000}"
 BOOTSTRAP_PORT="${BOOTSTRAP_PORT:-8998}"
 POLICY="${POLICY:-random}"
-MESH_BIN="${MESH_BIN:-/usr/local/bin/atom-mesh}"
+MESH_BIN="${MESH_BIN:-/usr/local/bin/atomesh}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-900}"
 
 echo "[router] prefill=${PREFILL_IP}:${PREFILL_PORT} decode=${DECODE_IP}:${DECODE_PORT} router=0.0.0.0:${ROUTER_PORT}"

--- a/atom/mesh/src/cliargs.rs
+++ b/atom/mesh/src/cliargs.rs
@@ -155,7 +155,7 @@ ATOM Mesh - Rust-based inference gateway
 
 Usage:
   mesh launch [OPTIONS]       Launch router (short command)
-  atom-mesh launch [OPTIONS]  Launch router (full name)
+  atomesh launch [OPTIONS]  Launch router (full name)
 
 Examples:
   # Regular mode

--- a/atom/mesh/src/cliargs.rs
+++ b/atom/mesh/src/cliargs.rs
@@ -148,10 +148,10 @@ impl std::str::FromStr for Backend {
 
 #[derive(Parser, Debug)]
 #[command(name = "mesh")]
-#[command(about = "ATOM Mesh - High-performance inference gateway")]
+#[command(about = "Atomesh - High-performance inference gateway")]
 #[command(args_conflicts_with_subcommands = true)]
 #[command(long_about = r#"
-ATOM Mesh - Rust-based inference gateway
+Atomesh - Rust-based inference gateway
 
 Usage:
   mesh launch [OPTIONS]       Launch router (short command)

--- a/atom/mesh/src/core/mod.rs
+++ b/atom/mesh/src/core/mod.rs
@@ -1,4 +1,4 @@
-//! Core abstractions for ATOM Mesh
+//! Core abstractions for Atomesh
 //!
 //! This module contains the fundamental types and traits used throughout the router:
 //! - Worker trait and implementations

--- a/atom/mesh/src/main.rs
+++ b/atom/mesh/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => cli.router_args,
     };
 
-    println!("ATOM Mesh starting...");
+    println!("Atomesh starting...");
     println!("Host: {}:{}", cli_args.host, cli_args.port);
     let mode_str = if cli_args.pd_disaggregation {
         "PD Disaggregated".to_string()

--- a/atom/mesh/src/policies/mod.rs
+++ b/atom/mesh/src/policies/mod.rs
@@ -1,4 +1,4 @@
-//! Load balancing policies for ATOM Mesh
+//! Load balancing policies for Atomesh
 //!
 //! This module provides a unified abstraction for routing policies that work
 //! across both regular and prefill-decode (PD) routing modes.

--- a/atom/mesh/src/python.rs
+++ b/atom/mesh/src/python.rs
@@ -80,7 +80,7 @@ fn startup_runtime(server_config: ServerConfig) -> PyResult<()> {
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to create runtime: {e}")))?;
     tokio_runtime
         .block_on(async move { server::startup(server_config).await })
-        .map_err(|e| PyRuntimeError::new_err(format!("ATOM mesh exited with error: {e}")))
+        .map_err(|e| PyRuntimeError::new_err(format!("Atomesh exited with error: {e}")))
 }
 
 fn build_server_config(

--- a/atom/mesh/tests/README.md
+++ b/atom/mesh/tests/README.md
@@ -93,22 +93,22 @@ Contract tests that verify serialization/deserialization behavior of protocol ty
 
 ```bash
 # Run all mesh tests
-cargo test -p atom-mesh
+cargo test -p atomesh
 
 # Run local quick checks used during harness development
-cargo test -p atom-mesh --lib
-cargo test -p atom-mesh --test spec_test
+cargo test -p atomesh --lib
+cargo test -p atomesh --test spec_test
 
 # Run a specific test module
-cargo test -p atom-mesh --test api_tests
-cargo test -p atom-mesh --test routing_tests
-cargo test -p atom-mesh --test reliability_tests
-cargo test -p atom-mesh --test security_tests
-cargo test -p atom-mesh --test spec_test
+cargo test -p atomesh --test api_tests
+cargo test -p atomesh --test routing_tests
+cargo test -p atomesh --test reliability_tests
+cargo test -p atomesh --test security_tests
+cargo test -p atomesh --test spec_test
 
 # Run a specific test by name
-cargo test -p atom-mesh test_list_workers
+cargo test -p atomesh test_list_workers
 
 # Run with output
-cargo test -p atom-mesh -- --nocapture
+cargo test -p atomesh -- --nocapture
 ```

--- a/atom/mesh/tests/run_atomesh_harness_test.sh
+++ b/atom/mesh/tests/run_atomesh_harness_test.sh
@@ -54,11 +54,11 @@ print_summary() {
 
 TEST_COMMANDS=(
     # Metrics subsystem unit tests.
-    "cargo test -p atom-mesh --lib observability::metrics"
+    "cargo test -p atomesh --lib observability::metrics"
     # Worker /engine_metrics aggregation integration tests.
-    "cargo test -p atom-mesh --test metrics_aggregator_test -- --nocapture"
+    "cargo test -p atomesh --test metrics_aggregator_test -- --nocapture"
     # End-to-end Atomesh harness API test.
-    "cargo test -p atom-mesh --test api_tests -- --nocapture --test-threads=1"
+    "cargo test -p atomesh --test api_tests -- --nocapture --test-threads=1"
 )
 
 for test_command in "${TEST_COMMANDS[@]}"; do

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -120,7 +120,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("ATOM_ENABLE_RELAXED_MTP", "0").lower() == "1"
     ),
     # --- Atomesh ---
-    # Build atom-mesh when installing ATOM from source.
+    # Build atomesh when installing ATOM from source.
     "ATOM_MESH_BUILD": lambda: os.getenv("ATOM_MESH_BUILD", "0") == "1",
     # Route the OpenAI-compatible server entrypoint through Atomesh.
     "USE_ATOMESH_ENTRYPOINTS": lambda: (

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -435,7 +435,7 @@ RUN cd /app/aiter-test && pip install -e . --no-build-isolation && \
 RUN pip install rocm-trace-lite && \
     rtl --version || true
 
-# ATOM: Python package install (editable) with the atom-mesh build hook enabled.
+# ATOM: Python package install (editable) with the atomesh build hook enabled.
 # CACHEBUST invalidates only this layer so parallel stages stay cached
 ARG CACHEBUST=1
 RUN git clone $ATOM_REPO /app/ATOM && \
@@ -446,11 +446,11 @@ RUN pip show atom || true
 
 RUN pip install --no-cache-dir msgpack msgspec quart
 
-# atom-mesh: install the binary produced by the ATOM package build hook to /usr/local/bin
-RUN echo "========== Install atom-mesh binary ==========" && \
+# atomesh: install the binary produced by the ATOM package build hook to /usr/local/bin
+RUN echo "========== Install atomesh binary ==========" && \
     cd /app/ATOM/atom/mesh && \
-    strip target/release/atom-mesh && \
-    cp target/release/atom-mesh /usr/local/bin/atom-mesh && \
-    atom-mesh --version
+    strip target/release/atomesh && \
+    cp target/release/atomesh /usr/local/bin/atomesh && \
+    atomesh --version
 
 CMD ["/bin/bash"]

--- a/recipes/mesh/multi-node-atom.md
+++ b/recipes/mesh/multi-node-atom.md
@@ -22,7 +22,7 @@ docker pull rocm/atom-dev:latest
 On **each node**, start a container:
 
 ```bash
-docker run -d --name atom_mesh \
+docker run -d --name atomesh \
     --network host --ipc host --privileged \
     --device /dev/kfd --device /dev/dri \
     --group-add video \
@@ -38,7 +38,7 @@ docker run -d --name atom_mesh \
 Enter the container on the prefill node:
 
 ```bash
-docker exec -it atom_mesh bash
+docker exec -it atomesh bash
 ```
 
 Find the node IP and launch:
@@ -80,7 +80,7 @@ Key parameters:
 Enter the container on the decode node:
 
 ```bash
-docker exec -it atom_mesh bash
+docker exec -it atomesh bash
 ```
 
 ```bash

--- a/recipes/mesh/multi-node-atom.md
+++ b/recipes/mesh/multi-node-atom.md
@@ -1,6 +1,6 @@
 # Multi-Node PD Disaggregation with ATOM Native Backend
 
-Two-node Prefill-Decode disaggregation using the ATOM native inference engine and atom-mesh router for DeepSeek-V4-Pro. KV cache transfer via Mooncake RDMA.
+Two-node Prefill-Decode disaggregation using the ATOM native inference engine and atomesh router for DeepSeek-V4-Pro. KV cache transfer via Mooncake RDMA.
 
 ## Prerequisites
 
@@ -130,7 +130,7 @@ curl -s http://<DECODE_IP>:8020/kv_transfer_info | python3 -m json.tool
 Inside the prefill node container:
 
 ```bash
-atom-mesh launch \
+atomesh launch \
     --host 0.0.0.0 --port 8000 \
     --pd-disaggregation \
     --prefill "http://${PREFILL_IP}:8010" \

--- a/recipes/mesh/multi-node-sglang.md
+++ b/recipes/mesh/multi-node-sglang.md
@@ -1,6 +1,6 @@
 # Multi-Node PD Disaggregation with SGLang Backend
 
-Two-node Prefill-Decode disaggregation using the SGLang-ATOM backend and atom-mesh router. KV cache transfer via Mooncake RDMA.
+Two-node Prefill-Decode disaggregation using the SGLang-ATOM backend and atomesh router. KV cache transfer via Mooncake RDMA.
 
 ## Prerequisites
 
@@ -139,7 +139,7 @@ Wait for both gRPC servers to become healthy, then launch the router:
 ```bash
 export HF_HUB_CACHE=/mnt/hf_hub_cache
 
-atom-mesh launch \
+atomesh launch \
     --host 0.0.0.0 --port 8000 \
     --pd-disaggregation \
     --prefill "grpc://${PREFILL_IP}:8010" 8998 \

--- a/recipes/mesh/multi-node-sglang.md
+++ b/recipes/mesh/multi-node-sglang.md
@@ -22,7 +22,7 @@ docker pull rocm/atom-dev:sglang-latest
 On **each node**, start a container:
 
 ```bash
-docker run -d --name atom_mesh \
+docker run -d --name atomesh \
     --network host --ipc host --privileged \
     --device /dev/kfd --device /dev/dri \
     --group-add video \
@@ -39,7 +39,7 @@ docker run -d --name atom_mesh \
 Enter the container on the prefill node:
 
 ```bash
-docker exec -it atom_mesh bash
+docker exec -it atomesh bash
 ```
 
 Find the node IP and launch:
@@ -88,7 +88,7 @@ Key parameters:
 Enter the container on the decode node:
 
 ```bash
-docker exec -it atom_mesh bash
+docker exec -it atomesh bash
 ```
 
 ```bash

--- a/recipes/mesh/multi-node-vllm.md
+++ b/recipes/mesh/multi-node-vllm.md
@@ -1,6 +1,6 @@
 # Multi-Node PD Disaggregation with vLLM Backend
 
-Two-node Prefill-Decode disaggregation using the vLLM backend with MooncakeConnector and atom-mesh router.
+Two-node Prefill-Decode disaggregation using the vLLM backend with MooncakeConnector and atomesh router.
 
 ## Prerequisites
 
@@ -115,7 +115,7 @@ Key differences from prefill:
 Wait for both servers to report ready (`/v1/models` returns 200), then launch the router:
 
 ```bash
-atom-mesh launch \
+atomesh launch \
     --host 0.0.0.0 --port 8000 \
     --pd-disaggregation \
     --prefill "http://${PREFILL_IP}:8010" 8998 \

--- a/recipes/mesh/multi-node-vllm.md
+++ b/recipes/mesh/multi-node-vllm.md
@@ -22,7 +22,7 @@ docker pull rocm/atom-dev:vllm-latest
 On **each node**, start a container:
 
 ```bash
-docker run -d --name atom_mesh \
+docker run -d --name atomesh \
     --network host --ipc host --privileged \
     --device /dev/kfd --device /dev/dri \
     --group-add video \
@@ -39,7 +39,7 @@ docker run -d --name atom_mesh \
 Enter the container on the prefill node:
 
 ```bash
-docker exec -it atom_mesh bash
+docker exec -it atomesh bash
 ```
 
 ```bash
@@ -79,7 +79,7 @@ For eager mode (debugging), replace the `--async-scheduling --compilation-config
 Enter the container on the decode node:
 
 ```bash
-docker exec -it atom_mesh bash
+docker exec -it atomesh bash
 ```
 
 ```bash

--- a/recipes/mesh/single-node-sglang.md
+++ b/recipes/mesh/single-node-sglang.md
@@ -17,7 +17,7 @@ docker pull rocm/atom-dev:sglang-latest
 ## Step 2: Start Docker Container
 
 ```bash
-docker run -d --name atom_mesh \
+docker run -d --name atomesh \
     --network host --ipc host --privileged \
     --device /dev/kfd --device /dev/dri \
     --group-add video \
@@ -30,7 +30,7 @@ docker run -d --name atom_mesh \
 Enter the container:
 
 ```bash
-docker exec -it atom_mesh bash
+docker exec -it atomesh bash
 ```
 
 ## Step 3: Start Prefill Server

--- a/recipes/mesh/single-node-sglang.md
+++ b/recipes/mesh/single-node-sglang.md
@@ -1,6 +1,6 @@
 # Single-Node PD Disaggregation with SGLang Backend
 
-Prefill-Decode disaggregation on a single machine using the SGLang backend and atom-mesh router. Split GPUs between prefill and decode instances (xPyD topology).
+Prefill-Decode disaggregation on a single machine using the SGLang backend and atomesh router. Split GPUs between prefill and decode instances (xPyD topology).
 
 ## Prerequisites
 
@@ -123,7 +123,7 @@ Key differences from prefill:
 Wait for both servers to report ready, then launch the router:
 
 ```bash
-atom-mesh launch \
+atomesh launch \
     --host 0.0.0.0 --port 8000 \
     --pd-disaggregation \
     --prefill "http://${NODE_IP}:8010" 8998 \

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 from setuptools.command.build_py import build_py as _build_py
 
 _editable_wheel = import_module("setuptools.command.editable_wheel").editable_wheel
-_ATOM_MESH_BUILT = False
+_ATOMESH_BUILT = False
 
 
 def get_build_env(name: str):
@@ -18,42 +18,42 @@ def get_build_env(name: str):
     return runpy.run_path(str(envs_path))["environment_variables"][name]()
 
 
-def build_atom_mesh() -> None:
-    global _ATOM_MESH_BUILT
+def build_atomesh() -> None:
+    global _ATOMESH_BUILT
 
     if not get_build_env("ATOM_MESH_BUILD"):
         return
-    if _ATOM_MESH_BUILT:
+    if _ATOMESH_BUILT:
         return
 
     root = Path(__file__).resolve().parent
     mesh_dir = root / "atom" / "mesh"
-    print(f"Building atom-mesh from {mesh_dir}...", flush=True)
+    print(f"Building atomesh from {mesh_dir}...", flush=True)
     subprocess.run(
         ["cargo", "build", "--release"],
         cwd=mesh_dir,
         check=True,
         text=True,
     )
-    _ATOM_MESH_BUILT = True
+    _ATOMESH_BUILT = True
 
 
-class install_atom_mesh(_build_py):
+class install_atomesh(_build_py):
     def run(self) -> None:
-        build_atom_mesh()
+        build_atomesh()
         super().run()
 
 
-class editable_install_atom_mesh(_editable_wheel):
+class editable_install_atomesh(_editable_wheel):
     def run(self) -> None:
-        build_atom_mesh()
+        build_atomesh()
         super().run()
 
 
 setup(
     use_scm_version=True,
     cmdclass={
-        "build_py": install_atom_mesh,
-        "editable_wheel": editable_install_atom_mesh,
+        "build_py": install_atomesh,
+        "editable_wheel": editable_install_atomesh,
     },
 )


### PR DESCRIPTION
The product brand is "Atomesh" (no hyphen). Rename the Rust crate, binary, Python build hooks, Dockerfile references, shell scripts, recipes, and documentation from "atom-mesh" to "atomesh".

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
