### PR TITLE
Fix DSV4 MTP shared expert loading

### DIFF
--- a/atom/models/deepseek_v4_mtp.py
+++ b/atom/models/deepseek_v4_mtp.py
@@ -227,15 +227,28 @@ class DeepseekV4MTP(nn.Module):
         """
         return name if "mtp." in name else None
 
+    @property
+    def disable_fused_shared_loading(self) -> bool:
+        """True when MTP shared experts are standalone, not fused into FusedMoE."""
+        for m in self.model.modules():
+            if m.__class__.__name__ == "MoE":
+                return not getattr(m, "_fuse_shared_into_routed", True)
+        return False
+
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         """FusedMoE expert param mapping for MTPBlock's MoE layer. Same
         ckpt convention as the target (`ffn.experts.{e}.w{1,2,3}`).
         """
+        num_fused_shared = 0
+        for m in self.model.modules():
+            if m.__class__.__name__ == "FusedMoE":
+                num_fused_shared = getattr(m, "num_fused_shared_experts", 0)
+                break
         return FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="w1",
             ckpt_down_proj_name="w2",
             ckpt_up_proj_name="w3",
-            num_experts=self.args.n_routed_experts,
+            num_experts=self.args.n_routed_experts + num_fused_shared,
         )
 
     def forward(


### PR DESCRIPTION
## Summary
- prevent DSV4 MTP standalone shared expert weights from being rewritten into routed expert slots
- include fused shared experts in the MTP expert mapping when shared experts are actually fused

## Root cause
PR #1076 broadened loader matching to include `ffn.shared_experts.*`. The target DSV4 model disables fused-shared loading when shared experts are standalone, but `DeepseekV4MTP` did not expose the same signal. As a result, MTP shared expert checkpoint tensors were rewritten to `ffn.experts.{n_routed_experts}.*`, silently dropped, and the draft model accept rate collapsed.

## Validation
- `python3 -m py_compile atom/models/deepseek_v4_mtp.py atom/model_loader/loader.py atom/models/deepseek_v4.py`
- `git diff --check`
- Docker checkpoint loader smoke against `/data/amd_int/models/deepseek-ai/DeepSeek-V4-Pro`: MTP shared expert tensors load into standalone params; no missing or silently dropped MTP shared expert tensors
- 100-sample GSM8K smoke, 3-shot, MTP3: flexible-extract `0.97`, strict-match `0.88`; final smoke MTP stats `Average toks/fwd: 2.94`, `Acceptance rate: 64.52%`