### PR TITLE
ci: skip ATOM Test for plugin-only PRs

### DIFF
--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -4,11 +4,12 @@ on:
   pull_request:
     branches: [main]  # Triggers on PRs targeting `main`
     types: [opened, synchronize, reopened, ready_for_review, closed]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
+    paths:
+      - 'atom/plugin/**'
+      - '!atom/plugin/vllm/**'
+      - 'atom/plugin/sglang/**'
+      - '.github/workflows/atom-sglang-*.yaml'
+      - '.github/benchmark/sglang_models_accuracy.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
       - 'atom/plugin/vllm/**'
       - '.github/workflows/atom-vllm-*.yaml'
-      - '.github/benchmark/sglang_models_accuracy.json'
+      - '.github/benchmark/oot_models_accuracy.json'
       - 'LICENSE'
       - '.gitignore'
 

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches: [main]  # Triggers on PRs targeting `main`
     types: [opened, synchronize, reopened, ready_for_review, closed]
-    paths:
-      - 'atom/plugin/**'
-      - '!atom/plugin/vllm/**'
-      - 'atom/plugin/sglang/**'
-      - '.github/workflows/atom-sglang-*.yaml'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'atom/plugin/vllm/**'
+      - '.github/workflows/atom-vllm-*.yaml'
       - '.github/benchmark/sglang_models_accuracy.json'
+      - 'LICENSE'
+      - '.gitignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - 'atom/plugin/**'
       - 'LICENSE'
       - '.gitignore'
   schedule:

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -10,6 +10,10 @@ on:
       - '**/*.md'
       - 'docs/**'
       - 'atom/plugin/**'
+      - '.github/workflows/atom-vllm-*.yaml'
+      - '.github/workflows/atom-sglang-*.yaml'
+      - '.github/benchmark/oot_models_accuracy.json'
+      - '.github/benchmark/sglang_models_accuracy.json'
       - 'LICENSE'
       - '.gitignore'
   schedule:

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches: [main]  # Triggers on PRs targeting `main`
     types: [opened, synchronize, reopened, ready_for_review, closed]
-    paths:
-      - 'atom/plugin/**'
-      - '!atom/plugin/sglang/**'
-      - 'atom/plugin/vllm/**'
-      - '.github/workflows/atom-vllm-*.yaml'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'atom/plugin/sglang/**'
+      - '.github/workflows/atom-sglang-*.yaml'
       - '.github/benchmark/oot_models_accuracy.json'
+      - 'LICENSE'
+      - '.gitignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -4,11 +4,12 @@ on:
   pull_request:
     branches: [main]  # Triggers on PRs targeting `main`
     types: [opened, synchronize, reopened, ready_for_review, closed]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
+    paths:
+      - 'atom/plugin/**'
+      - '!atom/plugin/sglang/**'
+      - 'atom/plugin/vllm/**'
+      - '.github/workflows/atom-vllm-*.yaml'
+      - '.github/benchmark/oot_models_accuracy.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
       - 'atom/plugin/sglang/**'
       - '.github/workflows/atom-sglang-*.yaml'
-      - '.github/benchmark/oot_models_accuracy.json'
+      - '.github/benchmark/sglang_models_accuracy.json'
       - 'LICENSE'
       - '.gitignore'
 


### PR DESCRIPTION
## Summary
- Skip native `ATOM Test` for plugin-only and plugin-test-only PRs.
- Route plugin-only PRs to the targeted plugin test workflow: SGLang-only changes run SGLang, vLLM-only changes run vLLM, and shared `atom/plugin` changes run both.
- Preserve full PR coverage for all other changes by letting native, vLLM, and SGLang tests all run when a PR includes any non-special path.

## Routing
- `atom/plugin/sglang/**` only -> `ATOM SGLang Test` only.
- `atom/plugin/vllm/**` only -> `ATOM vLLM Test` only.
- shared `atom/plugin/**` only -> `ATOM vLLM Test` and `ATOM SGLang Test`.
- `atom-sglang-*` workflow or `sglang_models_accuracy.json` only -> `ATOM SGLang Test` only.
- `atom-vllm-*` workflow or `oot_models_accuracy.json` only -> `ATOM vLLM Test` only.
- Any mixed or other code path -> full native + vLLM + SGLang test coverage.

## Test plan
- Ran `git diff --check`.
- Simulated representative `paths-ignore` cases locally for SGLang-only, vLLM-only, shared plugin, special workflow/config, and mixed/full-run changes.