### PR TITLE
[fix](gpt-oss): remove VLLM_USE_V2_MODEL_RUNNER for 128 conc

### DIFF
--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -50,7 +50,7 @@
           "dashboard_model": "gpt-oss-120b-tp1",
           "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 1 --gpu-memory-utilization 0.8 --max-num-batched-tokens 16384 --max-model-len 16384",
-          "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nVLLM_ROCM_USE_AITER=1\nVLLM_USE_V2_MODEL_RUNNER=1"
+          "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nVLLM_ROCM_USE_AITER=1"
         },
         {
           "tp_size": 1,
@@ -59,7 +59,7 @@
           "prefix": "gpt-oss-120b-aw-tp1",
           "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 1 --gpu-memory-utilization 0.8 --max-num-batched-tokens 16384 --max-model-len 16384",
-          "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nVLLM_ROCM_USE_AITER=1\nVLLM_USE_V2_MODEL_RUNNER=1"
+          "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nVLLM_ROCM_USE_AITER=1"
         },
         {
           "tp_size": 2,

--- a/recipes/atom_vllm/GPT-OSS.md
+++ b/recipes/atom_vllm/GPT-OSS.md
@@ -17,7 +17,6 @@ GPT-OSS-120B is a single-GPU model, so `--tensor-parallel-size` defaults to 1 an
 ```bash
 ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1 \
 VLLM_ROCM_USE_AITER=1 \
-VLLM_USE_V2_MODEL_RUNNER=1 \
 vllm serve openai/gpt-oss-120b \
     --host localhost \
     --port 8000 \


### PR DESCRIPTION
## Motivation

enable VLLM_USE_V2_MODEL_RUNNER=1 will hang in 1k100 128 conc.