### PR TITLE
[atom-sgl-benchmark] debug sgl benchmark disk quota exceeded

### DIFF
--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -849,7 +849,9 @@ jobs:
             --env-file /tmp/oot_env_file.txt \
             -e HF_TOKEN="${HF_TOKEN:-}" \
             --name "$CONTAINER_NAME" \
-            "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}"
+            --entrypoint /bin/bash \
+            "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}" \
+            -lc 'trap "exit 0" TERM INT; sleep infinity & wait'
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 


### PR DESCRIPTION
**问题:** OCI runtime error: crun: create keyring `4a680378ec67ce28745fd4e0c2a3c83529f20daab02475ae95b9821090df7cc5`: Disk quota exceeded.
<img width="1245" height="206" alt="image" src="https://github.com/user-attachments/assets/41d7c766-c9c9-4117-8cad-cad9506cc5b4" />

**方法：**

容器启动需要显式 --entrypoint /bin/bash ... sleep infinity
