### PR TITLE
fix(ci): select aiter wheel by Python version from S3 manifest

### DIFF
--- a/.github/workflows/atom-mmstar-ci.yaml
+++ b/.github/workflows/atom-mmstar-ci.yaml
@@ -23,6 +23,7 @@ concurrency:
 
 env:
   ATOM_BASE_IMAGE: rocm/atom-dev:latest
+  ATOM_PYTHON_TAG: "cp310"
 
 jobs:
   prepare-mmstar-matrix:
@@ -138,11 +139,22 @@ jobs:
           manifest_file="$(mktemp)"
           curl -fsSL -H "Cache-Control: no-cache" "${manifest_url}" -o "${manifest_file}"
 
-          wheel_url="$(jq -r '.wheel_url // empty' "${manifest_file}")"
-          wheel_name="$(jq -r '.wheel_name // empty' "${manifest_file}")"
+          wheel_name="$(jq -r ".wheels.${ATOM_PYTHON_TAG}.wheel_name // empty" "${manifest_file}")"
+          wheel_url="$(jq -r ".wheels.${ATOM_PYTHON_TAG}.wheel_url // empty" "${manifest_file}")"
+          if [ -n "${wheel_name}" ] && [ -n "${wheel_url}" ]; then
+            echo "Selected ${ATOM_PYTHON_TAG} wheel from versioned manifest"
+          else
+            wheel_name="$(jq -r '.wheel_name // empty' "${manifest_file}")"
+            wheel_url="$(jq -r '.wheel_url // empty' "${manifest_file}")"
+            echo "Versioned manifest not available, using top-level wheel fields"
+          fi
           if [ -z "${wheel_url}" ] || [ -z "${wheel_name}" ]; then
             echo "Invalid aiter wheel manifest:"
             cat "${manifest_file}"
+            exit 1
+          fi
+          if [[ "${wheel_name}" == *cp* ]] && [[ "${wheel_name}" != *${ATOM_PYTHON_TAG}* ]]; then
+            echo "ERROR: wheel ${wheel_name} does not match target Python ${ATOM_PYTHON_TAG}"
             exit 1
           fi
 

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   ATOM_BASE_NIGHTLY_IMAGE: rocm/atom-dev:latest
+  ATOM_PYTHON_TAG: "cp310"
   SGLANG_IMAGE_CACHE_KEEP: "3"
   GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/ATOM.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
@@ -118,11 +119,24 @@ jobs:
             manifest_branch=$(jq -r '.branch // empty' "$manifest_file")
             manifest_timestamp=$(jq -r '.timestamp // empty' "$manifest_file")
             manifest_commit=$(jq -r '.commit // empty' "$manifest_file")
-            wheel_name=$(jq -r '.wheel_name // empty' "$manifest_file")
-            wheel_url=$(jq -r '.wheel_url // empty' "$manifest_file")
+
+            wheel_name=$(jq -r ".wheels.${ATOM_PYTHON_TAG}.wheel_name // empty" "$manifest_file")
+            wheel_url=$(jq -r ".wheels.${ATOM_PYTHON_TAG}.wheel_url // empty" "$manifest_file")
+            if [ -n "$wheel_name" ] && [ -n "$wheel_url" ]; then
+              echo "Selected ${ATOM_PYTHON_TAG} wheel from versioned manifest"
+            else
+              wheel_name=$(jq -r '.wheel_name // empty' "$manifest_file")
+              wheel_url=$(jq -r '.wheel_url // empty' "$manifest_file")
+              echo "Versioned manifest not available, using top-level wheel fields"
+            fi
 
             if [ "$manifest_branch" != "main" ] || [ -z "$manifest_timestamp" ] || [ -z "$manifest_commit" ] || [ -z "$wheel_name" ] || [ -z "$wheel_url" ]; then
               echo "Invalid latest main wheel manifest"
+              return 1
+            fi
+
+            if [[ "$wheel_name" == *cp* ]] && [[ "$wheel_name" != *${ATOM_PYTHON_TAG}* ]]; then
+              echo "WARNING: wheel $wheel_name does not match target Python ${ATOM_PYTHON_TAG}"
               return 1
             fi
 

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -34,6 +34,7 @@ concurrency:
 
 env:
   ATOM_BASE_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.atom_base_image || 'rocm/atom-dev:latest' }}
+  ATOM_PYTHON_TAG: "cp310"
   GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/ATOM.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
   # workflow_dispatch: inputs.aiter_branch; otherwise main (matches previous default-branch shallow clone)
@@ -133,11 +134,24 @@ jobs:
             manifest_branch=$(jq -r '.branch // empty' "$manifest_file")
             manifest_timestamp=$(jq -r '.timestamp // empty' "$manifest_file")
             manifest_commit=$(jq -r '.commit // empty' "$manifest_file")
-            wheel_name=$(jq -r '.wheel_name // empty' "$manifest_file")
-            wheel_url=$(jq -r '.wheel_url // empty' "$manifest_file")
+
+            wheel_name=$(jq -r ".wheels.${ATOM_PYTHON_TAG}.wheel_name // empty" "$manifest_file")
+            wheel_url=$(jq -r ".wheels.${ATOM_PYTHON_TAG}.wheel_url // empty" "$manifest_file")
+            if [ -n "$wheel_name" ] && [ -n "$wheel_url" ]; then
+              echo "Selected ${ATOM_PYTHON_TAG} wheel from versioned manifest"
+            else
+              wheel_name=$(jq -r '.wheel_name // empty' "$manifest_file")
+              wheel_url=$(jq -r '.wheel_url // empty' "$manifest_file")
+              echo "Versioned manifest not available, using top-level wheel fields"
+            fi
 
             if [ "$manifest_branch" != "main" ] || [ -z "$manifest_timestamp" ] || [ -z "$manifest_commit" ] || [ -z "$wheel_name" ] || [ -z "$wheel_url" ]; then
               echo "Invalid latest main wheel manifest"
+              return 1
+            fi
+
+            if [[ "$wheel_name" == *cp* ]] && [[ "$wheel_name" != *${ATOM_PYTHON_TAG}* ]]; then
+              echo "WARNING: wheel $wheel_name does not match target Python ${ATOM_PYTHON_TAG}"
               return 1
             fi
 

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   ATOM_BASE_NIGHTLY_IMAGE: rocm/atom-dev:latest
+  ATOM_PYTHON_TAG: "cp310"
   OOT_IMAGE_CACHE_KEEP: "3"
   GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/ATOM.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
@@ -119,11 +120,24 @@ jobs:
             manifest_branch=$(jq -r '.branch // empty' "$manifest_file")
             manifest_timestamp=$(jq -r '.timestamp // empty' "$manifest_file")
             manifest_commit=$(jq -r '.commit // empty' "$manifest_file")
-            wheel_name=$(jq -r '.wheel_name // empty' "$manifest_file")
-            wheel_url=$(jq -r '.wheel_url // empty' "$manifest_file")
+
+            wheel_name=$(jq -r ".wheels.${ATOM_PYTHON_TAG}.wheel_name // empty" "$manifest_file")
+            wheel_url=$(jq -r ".wheels.${ATOM_PYTHON_TAG}.wheel_url // empty" "$manifest_file")
+            if [ -n "$wheel_name" ] && [ -n "$wheel_url" ]; then
+              echo "Selected ${ATOM_PYTHON_TAG} wheel from versioned manifest"
+            else
+              wheel_name=$(jq -r '.wheel_name // empty' "$manifest_file")
+              wheel_url=$(jq -r '.wheel_url // empty' "$manifest_file")
+              echo "Versioned manifest not available, using top-level wheel fields"
+            fi
 
             if [ "$manifest_branch" != "main" ] || [ -z "$manifest_timestamp" ] || [ -z "$manifest_commit" ] || [ -z "$wheel_name" ] || [ -z "$wheel_url" ]; then
               echo "Invalid latest main wheel manifest"
+              return 1
+            fi
+
+            if [[ "$wheel_name" == *cp* ]] && [[ "$wheel_name" != *${ATOM_PYTHON_TAG}* ]]; then
+              echo "WARNING: wheel $wheel_name does not match target Python ${ATOM_PYTHON_TAG}"
               return 1
             fi
 

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -8,9 +8,9 @@ on:
       base_image:
         description: "Base Docker image for ATOM build"
         type: choice
-        default: "rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0"
+        default: "rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0"
         options:
-          - rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0
+          - rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
       atom_repo:
         description: "ATOM repo"
         default: "https://github.com/ROCm/ATOM.git"
@@ -84,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - ${{ inputs.base_image || 'rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0' }}
+          - ${{ inputs.base_image || 'rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0' }}
 
     env:
       ATOM_REPO: "https://github.com/ROCm/ATOM.git"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Default base images
-ARG BASE_IMAGE="rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0"
+ARG BASE_IMAGE="rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0"
 ARG OOT_BASE_IMAGE="rocm/atom-dev:latest"
 ARG SGLANG_BASE_IMAGE="rocm/atom-dev:latest"
 ARG GPU_ARCH="gfx942;gfx950"


### PR DESCRIPTION
The aiter CI now builds wheels with rocm/pytorch:latest which has upgraded to Python 3.12, but the ATOM base image (rocm/atom-dev:latest) still uses Python 3.10. pip install of a cp312 wheel into a cp310 container fails.

Add ATOM_PYTHON_TAG env var (cp310) to all 4 CI workflows and modify the S3 manifest parsing to prefer the versioned `wheels.<tag>` field with fallback to the legacy top-level fields for backward compatibility. A post-download validation rejects wheels that don't match the target Python version.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
