### PR TITLE
perf(v4): tune sparse_attn_v4_paged_decode for MI355 (+19.3% geomean)

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -142,23 +142,26 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     # overrides it. Below buffers are populated only when state is DECODE
     # (built by `_attach_v4_paged_decode_meta`).
     kv_indices_swa: Optional[torch.Tensor] = None
-    """[T*win] int32 GPU — flat paged offsets into `unified_kv` for SWA path."""
+    """[swa_indptr[T]] int32 GPU — ragged-packed paged offsets into `unified_kv`
+    for the SWA path (per-token length `min(positions[t]+1, win)`)."""
     kv_indices_csa: Optional[torch.Tensor] = None
     """[csa_indptr[T]] int32 GPU — packed paged offsets for CSA layers
-    (window prefix + per-token compress entries via csa_translate_pack)."""
+    (CSA topk compress at slice head + SWA window prefix at tail; topk section
+    filled per-layer by csa_translate_pack)."""
     kv_indices_hca: Optional[torch.Tensor] = None
     """[hca_indptr[T]] int32 GPU — packed paged offsets for HCA layers
-    (window prefix + n_committed_hca compress entries; layer-invariant)."""
+    (HCA compress at slice head + SWA window prefix at tail; layer-invariant)."""
     kv_indptr_swa: Optional[torch.Tensor] = None
-    """[padded_T+1] int32 GPU — uniform stride `win` cumsum;
-    `[T+1:padded_T+1]` = T*win (last value repeated → kv_len=0 sentinel)."""
+    """[padded_T+1] int32 GPU — ragged cumsum of per-token SWA length
+    `min(positions[t]+1, win)`. Padded tail repeats last value → kv_len=0
+    sentinel for CG-padded slots."""
     kv_indptr_csa: Optional[torch.Tensor] = None
     """[padded_T+1] int32 GPU — packed cumsum of per-token CSA kv_len
-    (= `win + min(n_committed_csa[bid], index_topk)`).
+    (= `min(positions[t]+1, win) + min(n_committed_csa[bid], index_topk)`).
     Padded tail = last value."""
     kv_indptr_hca: Optional[torch.Tensor] = None
     """[padded_T+1] int32 GPU — packed cumsum of per-token HCA kv_len
-    (= `win + n_committed_hca[bid]`). Padded tail = last value."""
+    (= `min(positions[t]+1, win) + n_committed_hca[bid]`). Padded tail = last value."""
     swa_pages: int = 0
     """Boundary in `unified_kv`: index < swa_pages → SWA region; index >=
     swa_pages → compress region. Equal to
@@ -187,13 +190,14 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     needed.
     """
     skip_prefix_len_csa: Optional[torch.Tensor] = None
-    """[padded_T] int32 GPU — per-token write offset for csa_translate_pack
-    within the per-token prefix region. Decode path: filled with
-    `window_size` (full SWA prefix occupies the head of each region).
-    Prefill path: equals `prefix_swa_count_per_token[t]` — 0 for pure
-    prefill (no prior chunk), or the `< chunk_start` portion of the SWA
-    window for chunked prefill. CG-padded tail slots: 0 (kernel bails on
-    `bid<0` so the value is irrelevant)."""
+    """[padded_T] int32 GPU — per-token SWA prefix length within each token's
+    region. Decode path: filled with `window_size`; csa_translate_pack uses it
+    to recover the CSA topk length (`valid_k = slice_len - skip`) and writes
+    the topk section at the slice head (SWA prefix occupies the tail). Prefill
+    path: equals `prefix_swa_count_per_token[t]` — 0 for pure prefill (no prior
+    chunk), or the `< chunk_start` portion of the SWA window for chunked
+    prefill (prefill keeps the SWA prefix at the head). CG-padded tail slots:
+    0 (kernel bails on `bid<0` so the value is irrelevant)."""
 
     # ----- Prefill-only paged-prefill index buffers (set in `_build_paged_prefill_meta`) -----
     # Two-source paged_prefill kernel reads:
@@ -1564,17 +1568,18 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         Writes into stable forward_vars buffers (attn_metadata fields are
         the V4-namespaced counterparts on `AttentionMetaData_DSV4`):
           - kv_indices_swa : per-token SWA paged offsets, ragged-packed
-          - kv_indices_csa : SWA prefix written here; CSA compress section
-                             left UNINITIALIZED — V4Attention.forward fills
-                             it per-layer via csa_translate_pack (Phase C)
-          - kv_indices_hca : SWA prefix + HCA compress section, both fully
-                             written (HCA is layer-invariant)
+          - kv_indices_csa : SWA prefix at slice TAIL; CSA compress section
+                             (slice head) left UNINITIALIZED — V4Attention.
+                             forward fills it per-layer via csa_translate_pack
+                             (Phase C)
+          - kv_indices_hca : HCA compress section (head) + SWA prefix (tail),
+                             both fully written (HCA is layer-invariant)
           - kv_indptr_{swa,csa,hca} : 3 ragged cumsums. Padded tail repeats
                              last value → kv_len=0 sentinel for CG-padded slots.
-          - skip_prefix_len_csa : per-token actual_swa_count (offset where
-                             csa_translate_pack starts writing CSA topk
-                             within each token's region). Matches prefill
-                             semantics (where it equals prefix_swa_count[t]).
+          - skip_prefix_len_csa : per-token SWA prefix length (the tail
+                             segment); csa_translate_pack uses it to recover
+                             the CSA topk length valid_k = slice_len - skip.
+                             Decode derives it inline from positions.
 
         Reuses (built earlier in `_attach_v4_per_fwd_meta`):
           - batch_id_per_token : single per-token mapping (with -1 sentinel)
@@ -1701,19 +1706,15 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             entry_offsets = np.arange(total_hca_entries, dtype=np.int32) - np.repeat(
                 cu_n_h[:T], n_h_per_token
             )
-            # HCA compress section starts at `actual_swa_count[t]` (was `win`
-            # under the old uniform layout) — ragged-packed offset matches
-            # what the kernel writes for the SWA prefix segment.
-            write_pos = (
-                hca_indptr_np[token_indices]
-                + actual_swa_count_np[token_indices]
-                + entry_offsets
-            )
+            # HCA compress section occupies the slice HEAD (offset 0); the SWA
+            # prefix segment sits at the tail, written below by
+            # write_v4_paged_decode_indices.
+            write_pos = hca_indptr_np[token_indices] + entry_offsets
             bid_expanded = batch_id_per_token_np[token_indices]
             hca_indices_np[write_pos] = (
                 swa_pages + block_tables_np_full[bid_expanded, entry_offsets]
             ).astype(np.int32)
-        # Stage to GPU (HCA compress tail; window prefix scattered below).
+        # Stage to GPU (HCA compress section at head; SWA prefix scattered below).
         hca_indices_gpu = self._stage("v4_kv_indices_hca", hca_indices_np)
 
         # ----- Write SWA / CSA / HCA window-prefix paged offsets (1 kernel) -----

--- a/atom/model_ops/v4_kernels/csa_translate_pack.py
+++ b/atom/model_ops/v4_kernels/csa_translate_pack.py
@@ -27,17 +27,17 @@ two-source paged_prefill layout:
   - pure prefill:     skip = 0                 (no SWA history in `unified_kv`)
   - chunked prefill:  skip = prior_swa_count   (variable per-token)
 
-Correctness equivalence with the prior path:
+Correctness:
   - paged_decode reads `kv_indices_csa[indptr[t] : indptr[t+1]]` whose length
-    is exactly `skip_prefix_len_per_token[t] + valid_k[t]`. The fused kernel
-    writes only `[skip[t], skip[t]+valid_k[t])`, where `valid_k[t]` is
-    recovered as `indptr[t+1] - indptr[t] - skip[t]` (CPU builder packs
-    exactly this much per token). The tail `[valid_k, index_topk)` of
-    `topk_local` is uninitialized garbage from aiter's `top_k_per_row_*`
-    (which only writes `[0, valid_k)` and does NOT fill -1) — the
-    `k_offs < valid_k` mask is the sole correctness barrier; do not rely
-    on a `topk >= 0` check. CG-padded slots (batch_id=-1) bail in the
-    kernel preamble.
+    is exactly `skip_prefix_len_per_token[t] + valid_k[t]`. This kernel writes
+    the CSA topk section at the slice HEAD `[indptr[t], indptr[t]+valid_k[t])`,
+    where `valid_k[t]` is recovered as `indptr[t+1] - indptr[t] - skip[t]`
+    (CPU builder packs exactly this much per token); the SWA prefix (length
+    `skip[t]`) occupies the tail, written by `write_v4_paged_decode_indices`.
+    The tail `[valid_k, index_topk)` of `topk_local` is uninitialized garbage
+    from aiter's `top_k_per_row_*` (writes only `[0, valid_k)`), so the
+    `k_offs < valid_k` mask is the sole correctness barrier. CG-padded slots
+    (batch_id=-1) bail in the kernel preamble.
 """
 
 from typing import Optional
@@ -100,8 +100,11 @@ def _csa_translate_pack_kernel(
         skip = tl.load(skip_prefix_len_per_token_ptr + pid_t)
     indptr_t = tl.load(kv_indptr_csa_ptr + pid_t)
     indptr_t1 = tl.load(kv_indptr_csa_ptr + pid_t + 1)
-    write_base = indptr_t + skip
-    valid_k = indptr_t1 - write_base  # = (skip + valid_k) - skip
+    # CSA topk section occupies the slice HEAD; the SWA prefix (length `skip`)
+    # sits at the tail, written by write_v4_paged_decode_indices. valid_k =
+    # slice_len - skip is unchanged; only write_base moves to the head.
+    write_base = indptr_t
+    valid_k = indptr_t1 - indptr_t - skip
 
     k_offs = pid_kb * BLOCK_K + tl.arange(0, BLOCK_K)
     in_range = k_offs < valid_k
@@ -173,18 +176,19 @@ def csa_translate_pack(
                                    recovered as `indptr[t+1] - indptr[t] - skip[t]`.
       batch_id_per_token:          [T] int32 — token → seq, sentinel -1 for
                                    CG-padded slots.
-      skip_prefix_len_per_token:   [T] int32 OR None — per-token write offset
-                                   within `kv_indices_csa[indptr[t] : indptr[t+1]]`
-                                   where the CSA section starts. Pass None
-                                   with `window_size > 0` to derive skip
-                                   inline as `min(positions[t]+1, window_size)`
+      skip_prefix_len_per_token:   [T] int32 OR None — per-token SWA prefix
+                                   length (the tail segment of each token's
+                                   slice); used only to recover
+                                   `valid_k = slice_len - skip`. Pass None
+                                   with `window_size > 0` to derive it inline
+                                   as `min(positions[t]+1, window_size)`
                                    (decode shortcut). Pure prefill passes a
                                    zero buffer; chunked prefill passes
                                    `prior_swa_count_per_token`.
       kv_indices_csa:              [total_indices] int32 — destination buffer;
-                                   this kernel writes the CSA section
-                                   `[indptr[t]+skip[t],
-                                     indptr[t]+skip[t]+valid_k[t])`.
+                                   this kernel writes the CSA topk section at
+                                   the slice head
+                                   `[indptr[t], indptr[t]+valid_k[t])`.
       swa_pages:                   SWA region size — `num_slots * window_size`,
                                    fixed at CG capture time. Keyword-only.
       csa_block_capacity:          `block_size // ratio = 128 // 4 = 32`
@@ -281,8 +285,9 @@ def csa_translate_pack_reference(
             continue
         pos = int(poses[t].item())
         skip_t = min(pos + 1, window_size) if inline_skip else int(skips[t].item())
-        base = int(indptr[t].item()) + skip_t
-        valid_k = int(indptr[t + 1].item()) - base
+        # CSA topk at slice HEAD (matches kernel); SWA prefix (len skip_t) at tail.
+        base = int(indptr[t].item())
+        valid_k = int(indptr[t + 1].item()) - base - skip_t
         if valid_k <= 0:
             continue
         topk = topk_local[t, :valid_k].to(torch.int64)

--- a/atom/model_ops/v4_kernels/paged_decode.py
+++ b/atom/model_ops/v4_kernels/paged_decode.py
@@ -600,8 +600,14 @@ def _paged_decode_reduce_kernel(
     l_final = l_combined * alpha_kv + alpha_sink
 
     denom = tl.maximum(l_final, 1.0e-30)
-    scale = tl.where(l_final > 0.0, alpha_kv / denom, 0.0)
-    out = acc_combined * scale
+    # Direct divide (acc*alpha_kv)/denom, matching the single-CTA reference.
+    # The prior `acc * (alpha_kv/denom)` precomputed a reciprocal-scaled scalar
+    # (~1 extra ulp per element). Under split-K that per-kv_splits rounding
+    # diverges across batch shapes (T) and, via MTP greedy spec-acceptance,
+    # flips tokens — breaking MTP losslessness. The D-chunked multi-CTA layout
+    # (perf) is untouched; only the final normalize arithmetic changes.
+    acc_final = acc_combined * alpha_kv
+    out = tl.where(l_final > 0.0, acc_final / denom, 0.0)
 
     tl.store(
         out_ptr + t * out_stride_t + h * out_stride_h + d_offs * out_stride_d,

--- a/atom/model_ops/v4_kernels/paged_decode.py
+++ b/atom/model_ops/v4_kernels/paged_decode.py
@@ -17,7 +17,11 @@ Caller contract:
   kv_indices: [total_indices] int32 — per-token slot lists, flat.
     Per-token entries live in
     `kv_indices[kv_indptr[t] : kv_indptr[t+1]]`.
-    `-1` entries are skipped (sentinel for unused tail).
+    **All entries MUST be valid slot ids in [0, unified_kv.shape[0]).**
+    The production decode index builder (``write_v4_paged_decode_indices``)
+    emits ragged-packed indices with no sentinels; CG-padded tokens get
+    a zero-length slice via ``indptr[t+1] == indptr[t]``. The kernel no
+    longer carries a per-iter ``slot >= 0`` sentinel check.
   kv_indptr:  [N+1] int32 — true prefix sum (variable per-token len).
   attn_sink:        [H] per-head learnable softmax-denom bias (V4 specific).
   softmax_scale:    float.
@@ -50,9 +54,7 @@ import os
 import torch
 import triton
 import triton.language as tl
-
 from aiter.ops.triton.utils.device_info import get_num_sms
-
 from atom.model_ops.sparse_attn_v4 import _sparse_attn_ragged_torch
 
 LOG2E = 1.4426950408889634  # log2(e); folded into qk_scale so softmax can use exp2.
@@ -101,14 +103,22 @@ def _kernel_config(block_h: int) -> tuple[int, int, int]:
     Derived from autotune statistics over ~150 shapes on MI355:
       - BLOCK_K=16 dominated (~78% of best configs for D=512); D=512 has
         enough load width that wider K tiles spill regs more than they buy.
-      - num_warps tracks BLOCK_H: a 64-head tile needs 8 warps to keep all
-        MFMA lanes fed; a 16-head tile peaks at 4 warps before going idle.
+      - num_warps:
+          block_h ≤ 32 → 4 warps; block_h ≥ 64 → 8 warps.
+        Pre-v11 the threshold was 16, which gave H=32 nw=8 — that was a
+        regression worth +30% geomean (max +57%) on H=32 across all T,
+        from a Phase-1 fine-tune sweep on top of v05+v09. With block_h=32
+        the MFMA tile is 32×16×D; 4 waves (256 threads) is the sweet
+        spot for AMD wave64 register budget. 8 warps over-distribute and
+        leave each warp with too little MFMA to amortize pipeline fill.
+        block_h=64 still wants 8 warps (one wave per row tile is too
+        little ILP).
       - num_stages=2 is the safe default — deeper pipelining (3) helps only
         when the K loop has many iterations; we cannot know per-token K at
         capture time, so the conservative pick avoids regressing short-K.
     """
     block_k = 16
-    num_warps = 4 if block_h <= 16 else 8
+    num_warps = 4 if block_h <= 32 else 8
     num_stages = 2
     return block_k, num_warps, num_stages
 
@@ -238,16 +248,20 @@ def _paged_decode_fused_kernel(
         # NUM_GROUPS distinct values; redundant scale loads at the same
         # address are coalesced through L1, no per-element scalar issue.
         g_idx_per_d = d_offs // GROUP_SIZE
-    for j in tl.range(0, num_tiles):
+    # num_stages=3 on the inner K loop overrides the launch-time default
+    # (2) for this loop only. Deeper SW pipeline keeps 2 in-flight KV
+    # gathers (vs 1 with stages=2) while the current MFMA runs — better
+    # hides AMD HBM gather latency on D=512. Cost: ~1 extra KV tile
+    # (BLOCK_K*BLOCK_D*2 = 16KB at bf16) staged in regs/LDS per CTA.
+    for j in tl.range(0, num_tiles, num_stages=3):
         k_start = j * BLOCK_K
         k_pos = k_start + k_offs
-        in_range = k_pos < kv_len
+        valid = k_pos < kv_len  # in_range; no sentinel check (see contract)
         slot = tl.load(
             kv_indices_ptr + kv_start + k_pos,
-            mask=in_range,
-            other=-1,
+            mask=valid,
+            other=0,  # any in-bounds slot; the read is masked out below
         )
-        valid = in_range & (slot >= 0)
 
         kv_raw = tl.load(
             unified_kv_ptr
@@ -273,13 +287,19 @@ def _paged_decode_fused_kernel(
             kv = kv_raw
 
         scores = tl.dot(q, tl.trans(kv)) * qk_scale
-        scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
+        # K: drop h_mask from the per-iter where. In V4-Pro every realistic
+        # (H, BLOCK_H) pair has H % BLOCK_H == 0 → h_mask is statically
+        # all-True, but the runtime ``h_offs < H`` compare prevents Triton
+        # from constant-folding. Masking only on ``valid`` is sufficient:
+        # ``neg_large`` on invalid k positions makes exp2(scores - m) ≈ 0
+        # in the subsequent dot, and the masked store at the end gates
+        # invalid h rows from polluting the output.
+        scores = tl.where(valid[None, :], scores, neg_large)
 
         m_block = tl.max(scores, axis=1)
         m_new = tl.maximum(m_i, m_block)
         alpha = tl.exp2(m_i - m_new)
         p = tl.exp2(scores - m_new[:, None])
-        p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
         l_new = l_i * alpha + tl.sum(p, axis=1)
 
         acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
@@ -398,16 +418,16 @@ def _paged_decode_split_kernel(
     k_offs = tl.arange(0, BLOCK_K)
     if QUANT_KV:
         g_idx_per_d = d_offs // GROUP_SIZE
-    for j in tl.range(tile_start, tile_end):
+    # num_stages=3 (see fused kernel comment for rationale).
+    for j in tl.range(tile_start, tile_end, num_stages=3):
         k_start = j * BLOCK_K
         k_pos = k_start + k_offs
-        in_range = k_pos < kv_len
+        valid = k_pos < kv_len  # in_range; no sentinel check (see contract)
         slot = tl.load(
             kv_indices_ptr + kv_start + k_pos,
-            mask=in_range,
-            other=-1,
+            mask=valid,
+            other=0,  # any in-bounds slot; masked out below
         )
-        valid = in_range & (slot >= 0)
 
         kv_raw = tl.load(
             unified_kv_ptr
@@ -427,13 +447,13 @@ def _paged_decode_split_kernel(
             kv = kv_raw
 
         scores = tl.dot(q, tl.trans(kv)) * qk_scale
-        scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
+        # K (same as fused kernel): drop h_mask from per-iter where.
+        scores = tl.where(valid[None, :], scores, neg_large)
 
         m_block = tl.max(scores, axis=1)
         m_new = tl.maximum(m_i, m_block)
         alpha = tl.exp2(m_i - m_new)
         p = tl.exp2(scores - m_new[:, None])
-        p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
         l_new = l_i * alpha + tl.sum(p, axis=1)
 
         acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
@@ -480,25 +500,43 @@ def _paged_decode_reduce_kernel(
     H: tl.constexpr,
     D: tl.constexpr,
     KV_SPLITS: tl.constexpr,
-    BLOCK_H: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    D_CHUNK: tl.constexpr,
     BLOCK_K: tl.constexpr,
 ):
-    """Combine KV_SPLITS partials, fold attn_sink, write final output.
+    """2D-tile reduce: combine KV_SPLITS partials, fold attn_sink, write
+    final output. Grid: ``(T, H, ceil(D / D_CHUNK))`` — one CTA owns one
+    (token, single-head, D-chunk) tuple.
 
-    Splits that early-returned never wrote their slot. We re-derive the same
-    ``tiles_per_segment`` the split kernel used (BLOCK_K is constexpr and
-    matches across kernels), compute ``act_num_segments`` from kv_len, and
-    mask out unwritten slots with ``other=-inf`` (for m) / 0 (for l, acc).
-    Sink is a natural-log bias; we multiply by ``log2e`` before folding.
+    Rewrite of the prior 3D-load reduce inspired by:
+      - aiter ``_fwd_kernel_stage2`` (mla_decode_rope.py): scalar control
+        flow + one D-tile per CTA, online accumulation across splits.
+      - AKO4X ``hybrid_2d_reduce`` (B200 reference, +3.37x): merged 2D
+        tile load ``[KV_SPLITS, D_CHUNK]`` replaces strided 3D access.
+
+    Why this wins on MI355 split path (T ≤ ~256, kv_splits > 1):
+
+    1. **2D tile fits registers**. The old 3D load tile
+       ``[KV_SPLITS=64, BLOCK_H=1, BLOCK_D=512]`` = 32K fp32 = 128 KB —
+       didn't fit in registers, spilled to LDS, and used a strided 3D
+       address compute. New ``[KV_SPLITS, D_CHUNK]`` = 64×64×4 = 16 KB
+       fits one wave's VGPR with headroom.
+    2. **D-chunked grid widens occupancy**. Old grid was ``(T, H)`` —
+       e.g. T=1 H=16 → 16 CTAs into 256 CUs (6% occupancy). New grid
+       ``(T, H, D/D_CHUNK)`` → 16 × (512/64) = 128 CTAs at T=1 H=16
+       (50% occupancy). Reduce was the latency bottleneck at small T.
+    3. **Scalar control flow for sink fold**. Sink computation needs
+       (m_max, l_combined) which only depend on (t, h) — same value
+       across all dc programs for the same (t, h). They recompute it
+       redundantly but it's a tiny scalar reduce; cheaper than passing
+       through LDS.
     """
     t = tl.program_id(0)
-    pid_h = tl.program_id(1)
+    h = tl.program_id(1)
+    dc = tl.program_id(2)
 
-    h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
-    d_offs = tl.arange(0, BLOCK_D)
+    d_offs = dc * D_CHUNK + tl.arange(0, D_CHUNK)
     k_offs = tl.arange(0, KV_SPLITS)
-    h_mask = h_offs < H
     d_mask = d_offs < D
 
     neg_large = -3.4028234663852886e38
@@ -506,64 +544,69 @@ def _paged_decode_reduce_kernel(
     kv_start = tl.load(kv_indptr_ptr + t)
     kv_end = tl.load(kv_indptr_ptr + t + 1)
     kv_len = kv_end - kv_start
+    # CTA-level early return for empty tokens (CUDAGraph padding, or any
+    # caller-supplied zero-length slice). Split kernel skipped these without
+    # writing partials → partial buffers hold garbage; the segm_mask path
+    # below would still mask it correctly but consumes the masked-load BW
+    # and the sink-fold arithmetic. Skipping the whole CTA also halves the
+    # reduce-kernel cost on mixed-kv batches with many padded tokens.
+    if kv_len == 0:
+        out_off = t * out_stride_t + h * out_stride_h + d_offs * out_stride_d
+        tl.store(
+            out_ptr + out_off,
+            tl.zeros([D_CHUNK], dtype=out_ptr.dtype.element_ty),
+            mask=d_mask,
+        )
+        return
     tiles_per_segment = tl.cdiv(kv_len, KV_SPLITS * BLOCK_K)
-    # Only segments [0, act_num_segments) were written by the split kernel.
     act_num_segments = tl.cdiv(kv_len, tl.maximum(tiles_per_segment, 1) * BLOCK_K)
     segm_mask = k_offs < act_num_segments
 
+    # 1D loads for (m, l) along splits — single head h.
     m_p = tl.load(
-        m_partial_ptr
-        + t * mp_stride_t
-        + k_offs[:, None] * mp_stride_k
-        + h_offs[None, :] * mp_stride_h,
-        mask=segm_mask[:, None] & h_mask[None, :],
+        m_partial_ptr + t * mp_stride_t + k_offs * mp_stride_k + h * mp_stride_h,
+        mask=segm_mask,
         other=neg_large,
-    )  # [KV_SPLITS, BLOCK_H]
+    )  # [KV_SPLITS]
     l_p = tl.load(
-        l_partial_ptr
-        + t * lp_stride_t
-        + k_offs[:, None] * lp_stride_k
-        + h_offs[None, :] * lp_stride_h,
-        mask=segm_mask[:, None] & h_mask[None, :],
+        l_partial_ptr + t * lp_stride_t + k_offs * lp_stride_k + h * lp_stride_h,
+        mask=segm_mask,
         other=0.0,
-    )  # [KV_SPLITS, BLOCK_H]
+    )  # [KV_SPLITS]
+
+    # 2D-tile load for acc partials — the key change vs old 3D-strided load.
     a_p = tl.load(
         acc_partial_ptr
         + t * ap_stride_t
-        + k_offs[:, None, None] * ap_stride_k
-        + h_offs[None, :, None] * ap_stride_h
-        + d_offs[None, None, :] * ap_stride_d,
-        mask=segm_mask[:, None, None] & h_mask[None, :, None] & d_mask[None, None, :],
+        + k_offs[:, None] * ap_stride_k
+        + h * ap_stride_h
+        + d_offs[None, :] * ap_stride_d,
+        mask=segm_mask[:, None] & d_mask[None, :],
         other=0.0,
-    )  # [KV_SPLITS, BLOCK_H, BLOCK_D]
+    )  # [KV_SPLITS, D_CHUNK]
 
-    # Combine splits in log2 domain.
-    m_max = tl.max(m_p, axis=0)  # [BLOCK_H]
-    alpha_split = tl.exp2(m_p - m_max[None, :])  # [KV_SPLITS, BLOCK_H]
-    l_combined = tl.sum(l_p * alpha_split, axis=0)
-    acc_combined = tl.sum(a_p * alpha_split[:, :, None], axis=0)
+    # Combine across splits.
+    m_max = tl.max(m_p, axis=0)  # scalar
+    alpha_split = tl.exp2(m_p - m_max)  # [KV_SPLITS]
+    l_combined = tl.sum(l_p * alpha_split, axis=0)  # scalar
+    acc_combined = tl.sum(a_p * alpha_split[:, None], axis=0)  # [D_CHUNK]
 
-    # Sink is a natural-log bias on the softmax denom. Multiply by LOG2E so
-    # comparisons live in the same log2 domain as the split outputs.
-    sink_raw = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(
-        tl.float32
-    )
+    # Fold attn_sink (recomputed across dc — scalar work, negligible).
+    sink_raw = tl.load(attn_sink_ptr + h).to(tl.float32)
     sink = sink_raw * log2e
     m_final = tl.maximum(m_max, sink)
     alpha_kv = tl.exp2(m_max - m_final)
     alpha_sink = tl.exp2(sink - m_final)
     l_final = l_combined * alpha_kv + alpha_sink
-    acc_final = acc_combined * alpha_kv[:, None]
 
     denom = tl.maximum(l_final, 1.0e-30)
-    out = tl.where(l_final[:, None] > 0.0, acc_final / denom[:, None], 0.0)
+    scale = tl.where(l_final > 0.0, alpha_kv / denom, 0.0)
+    out = acc_combined * scale
+
     tl.store(
-        out_ptr
-        + t * out_stride_t
-        + h_offs[:, None] * out_stride_h
-        + d_offs[None, :] * out_stride_d,
+        out_ptr + t * out_stride_t + h * out_stride_h + d_offs * out_stride_d,
         out.to(out_ptr.dtype.element_ty),
-        mask=h_mask[:, None] & d_mask[None, :],
+        mask=d_mask,
     )
 
 
@@ -632,8 +675,6 @@ def _sparse_attn_v4_paged_decode_triton(
 
     T, H, D = q.shape
     out = torch.empty_like(q)
-    kv_indices = kv_indices.to(torch.int32).contiguous()
-    kv_indptr = kv_indptr.to(torch.int32).contiguous()
 
     if block_h is None:
         block_h = triton.next_power_of_2(min(H, 64))
@@ -760,11 +801,25 @@ def _sparse_attn_v4_paged_decode_triton(
         num_stages=num_stages,
     )
 
-    # Reduce: one CTA per (token, head). Per-head fan-out hides launch latency
-    # on small per-rank H (TP=8 → H ∈ {8, 16}); for large H we accept the extra
-    # CTAs since the reduce work is tiny.
-    block_h_reduce = 1
-    grid_reduce = (T, (H + block_h_reduce - 1) // block_h_reduce)
+    # 2D-tile reduce: grid = (T, H, ceil(D/D_CHUNK)). One CTA per
+    # (token, single-head, D-chunk). Adaptive D_CHUNK based on whether the
+    # base reduce grid (T*H) already saturates the GPU:
+    #   - large T*H (≥ 2*num_CU=512 on MI355): the grid is already at or
+    #     above the launch target; further D-splitting just over-fragments
+    #     (T=128 H=128 with D_CHUNK=64 → 131K CTAs → 2× slowdown). Use
+    #     D_CHUNK = block_d (1 d-block per CTA, grid = T*H).
+    #   - small T*H: D-split widens the grid to fill CUs at small-T
+    #     latency-critical decode. The 2D tile [KV_SPLITS, D_CHUNK] should
+    #     stay ≤ 16 KB fp32 to fit registers.
+    base_grid_t_h = T * H
+    target_reduce_wg = 2 * _cu_count()
+    if base_grid_t_h >= target_reduce_wg:
+        d_chunk = block_d
+    else:
+        d_chunks_needed = max(1, target_reduce_wg // base_grid_t_h)
+        d_chunks_needed = min(d_chunks_needed, block_d // 32)
+        d_chunk = max(32, triton.next_power_of_2(block_d // d_chunks_needed))
+    grid_reduce = (T, H, (D + d_chunk - 1) // d_chunk)
     _paged_decode_reduce_kernel[grid_reduce](
         m_partial,
         l_partial,
@@ -789,8 +844,8 @@ def _sparse_attn_v4_paged_decode_triton(
         H,
         D,
         kv_splits,
-        BLOCK_H=block_h_reduce,
         BLOCK_D=block_d,
+        D_CHUNK=d_chunk,
         BLOCK_K=block_k,
         num_warps=4,
     )

--- a/atom/model_ops/v4_kernels/paged_decode_indices.py
+++ b/atom/model_ops/v4_kernels/paged_decode_indices.py
@@ -5,32 +5,16 @@
 prefix paged offsets into the three ragged-packed destination buffers
 (`kv_indices_swa` / `kv_indices_csa` / `kv_indices_hca`).
 
-Replaces the prior chain (numpy `_build_window_topk_np` + `index_copy_`):
+The ring-index formula `ring = (pos - win + 1 + w) % cs` is computed inline
+inside the kernel from `positions[t]` — no `[T, win]` window_topk staging
+buffer, no separate CPU build + H2D copy.
 
-    window_topk_np = _build_window_topk_np(positions, win, cs)  # [T, win]
-    swa_paged_2d = torch.where(window_topk >= 0, slot * cs + topk, -1)
-    swa_paged_flat = swa_paged_2d.reshape(-1)
-    swa_indices_gpu[:T*win].copy_(swa_paged_flat)
-    csa_indices_gpu.index_copy_(0, csa_win_pos, swa_paged_flat)
-    hca_indices_gpu.index_copy_(0, hca_win_pos, swa_paged_flat)
-
-Two simplifications vs the prior implementation (see plan
-`sequential-noodling-turing.md` for details):
-
-1. The ring-index formula `ring = (pos - win + 1 + w) % cs` is computed
-   inline inside the kernel from `positions[t]`. The `[T, win]`
-   `window_topk` intermediate buffer (mnbt·win·4 = 4 MB at typical config)
-   is gone; no separate CPU build + H2D copy.
-2. The destination layout is now ragged-packed (same as prefill): each
-   token's SWA prefix segment has length `n = min(positions[t]+1, win)`
-   (NOT a fixed `win` padded with `-1` sentinels). The caller's
-   `swa_indptr` / `csa_indptr` / `hca_indptr` reflect this ragged sizing.
-
-Bytewise correctness: for tokens with `position >= win-1` (all `n == win`),
-the output is identical to the prior implementation. For shorter
-positions, the prior layout wrote `(win - n)` leading `-1` entries that
-the sparse-attention kernel masked out; the new layout omits those slots
-entirely, saving sparse-attn loop iterations.
+Layout: ragged-packed. Each token's slice holds an SWA prefix of length
+`n = min(positions[t]+1, win)` plus a per-buffer compress section; the
+`swa_indptr` / `csa_indptr` / `hca_indptr` cumsums reflect this ragged
+sizing. Within each token's slice the SWA prefix is written at the TAIL
+(`[indptr[t+1] - n, indptr[t+1])`) and the compress section (CSA topk /
+HCA committed) occupies the head.
 
 Caller contract:
 - Grid = T (one program per token).
@@ -41,9 +25,10 @@ Caller contract:
   where `n_compress[t]` is 0 for SWA, `min(n_committed_csa, index_topk)`
   for CSA, `n_committed_hca` for HCA.
 - `swa_indices` / `csa_indices` / `hca_indices` capacity ≥ corresponding
-  indptr[T]; this kernel only writes the SWA-prefix segment
-  `[indptr[t], indptr[t] + n)` per token. The compress-tail is filled
-  elsewhere (HCA: numpy fill in caller, CSA: `csa_translate_pack` per layer).
+  indptr[T]; this kernel only writes the SWA-prefix segment at the slice
+  tail `[indptr[t+1] - n, indptr[t+1])` per token. The compress section is
+  filled elsewhere (HCA: numpy fill in caller, CSA: `csa_translate_pack`
+  per layer).
 """
 
 import torch
@@ -67,22 +52,24 @@ def _v4_paged_decode_indices_kernel(
     BLOCK_N: tl.constexpr,  # next_pow2(win)
 ):
     """One program per token. Writes `n = min(positions[t]+1, win)` paged
-    offsets to the SWA prefix segment of each of SWA/CSA/HCA index buffers.
+    offsets to the SWA prefix segment, placed at the TAIL of each token's
+    slice in the SWA/CSA/HCA index buffers (the compress section occupies
+    the head).
 
     For token `t`:
         bid = batch_id_per_token[t]                  # bail if -1 (CG pad)
         slot = state_slot_per_seq[bid]
         pos = positions[t]
         n = min(pos + 1, win)
-        # Old -1 sentinels were at the leading `win - n` cols; reparameterize
-        # to skip them: i in [0, n) → abs_pos = pos - n + 1 + i ∈ [0, pos].
+        # i in [0, n) → abs_pos = pos - n + 1 + i ∈ [0, pos]; written at the
+        # slice tail (indptr[t+1] - n) so the compress section fills the head.
         for i in range(n):
             abs_pos = pos - n + 1 + i
             ring = abs_pos % cs
             paged = slot * cs + ring
-            swa_indices[swa_indptr[t] + i] = paged
-            csa_indices[csa_indptr[t] + i] = paged
-            hca_indices[hca_indptr[t] + i] = paged
+            swa_indices[swa_indptr[t+1] - n + i] = paged
+            csa_indices[csa_indptr[t+1] - n + i] = paged
+            hca_indices[hca_indptr[t+1] - n + i] = paged
     """
     t = tl.program_id(0)
     bid = tl.load(batch_id_per_token_ptr + t)
@@ -94,9 +81,12 @@ def _v4_paged_decode_indices_kernel(
     # `n` = actual valid SWA prefix count. Cast to match `win` (compile-time
     # int) — pos is i32/i64 from positions buffer.
     n = tl.minimum(pos + 1, win)
-    swa_base = tl.load(swa_indptr_ptr + t)
-    csa_base = tl.load(csa_indptr_ptr + t)
-    hca_base = tl.load(hca_indptr_ptr + t)
+    # SWA prefix segment lives at the TAIL of each token's slice (compress
+    # section fills the head). Write base = slice END (indptr[t+1]) - n. For
+    # the SWA buffer (compress=0) end-n == indptr[t], same as a head write.
+    swa_end = tl.load(swa_indptr_ptr + t + 1)
+    csa_end = tl.load(csa_indptr_ptr + t + 1)
+    hca_end = tl.load(hca_indptr_ptr + t + 1)
 
     i = tl.arange(0, BLOCK_N)
     mask = i < n
@@ -104,9 +94,9 @@ def _v4_paged_decode_indices_kernel(
     ring_idx = abs_pos % cs
     paged = slot * cs + ring_idx
 
-    tl.store(swa_indices_ptr + swa_base + i, paged, mask=mask)
-    tl.store(csa_indices_ptr + csa_base + i, paged, mask=mask)
-    tl.store(hca_indices_ptr + hca_base + i, paged, mask=mask)
+    tl.store(swa_indices_ptr + swa_end - n + i, paged, mask=mask)
+    tl.store(csa_indices_ptr + csa_end - n + i, paged, mask=mask)
+    tl.store(hca_indices_ptr + hca_end - n + i, paged, mask=mask)
 
 
 def write_v4_paged_decode_indices(
@@ -145,13 +135,14 @@ def write_v4_paged_decode_indices(
                                    prefix + HCA committed per token).
       swa_indices:         [>=swa_indptr[T]] int32 OUT — fully written by
                                    this kernel (no other source).
-      csa_indices:         [>=csa_indptr[T]] int32 OUT — window-prefix
-                                   `[csa_indptr[t], +n)` written here; CSA
-                                   topk tail filled per-layer by
-                                   `csa_translate_pack`.
+      csa_indices:         [>=csa_indptr[T]] int32 OUT — SWA prefix written
+                                   here at the slice tail
+                                   `[csa_indptr[t+1] - n, csa_indptr[t+1])`;
+                                   CSA topk section (slice head) filled
+                                   per-layer by `csa_translate_pack`.
       hca_indices:         [>=hca_indptr[T]] int32 OUT — same semantics; HCA
-                                   compress tail filled in the caller via
-                                   numpy fill.
+                                   compress section (slice head) filled in the
+                                   caller via numpy fill.
       T:                   int — number of real tokens (grid size).
       win:                 int — SWA window size (typically 128 for V4-Pro).
       cs:                  int — `win_with_spec = window_size + max_spec_steps`,
@@ -227,9 +218,10 @@ def write_v4_paged_decode_indices_reference(
         abs_pos = p - n + 1 + i_arr  # [n]
         ring = abs_pos % cs
         paged = (s * cs + ring).to(torch.int32)
-        swa_base = int(swa_indptr[t].item())
-        csa_base = int(csa_indptr[t].item())
-        hca_base = int(hca_indptr[t].item())
-        swa_indices[swa_base : swa_base + n] = paged
-        csa_indices[csa_base : csa_base + n] = paged
-        hca_indices[hca_base : hca_base + n] = paged
+        # SWA prefix segment at the slice TAIL (compress section fills the head).
+        swa_end = int(swa_indptr[t + 1].item())
+        csa_end = int(csa_indptr[t + 1].item())
+        hca_end = int(hca_indptr[t + 1].item())
+        swa_indices[swa_end - n : swa_end] = paged
+        csa_indices[csa_end - n : csa_end] = paged
+        hca_indices[hca_end - n : hca_end] = paged


### PR DESCRIPTION
## Summary

Five-step incremental tune of `sparse_attn_v4_paged_decode` on MI355X
(gfx950, CDNA4) — **+19.3% geomean** across the 256-shape (T × H × kv_len)
decode grid; **H=32 +50.2%** (the previously stuck hot path).

| step | what | cum vs base |
| ---- | ---- | ----------- |
| 03 | drop redundant `tl.where(h_mask, ...)` in inner loop | +1.0% |
| 04 | drop `slot >= 0` sentinel check; tighten caller contract to ragged-packed (no sentinels) | +3.7% |
| 05 | `num_stages=3` on inner K loop (hides AMD HBM gather latency on D=512) | +8.8% |
| 09 | rewrite `_paged_decode_reduce_kernel`: 3D-strided single-CTA-per-(t,h) → 2D-tile multi-CTA D-chunked with adaptive heuristic (refs: aiter `_fwd_kernel_stage2`, AKO4X `hybrid_2d_reduce`) | +12.1% |
| 11 | (a) reduce kv_len==0 CTA-level early return; (b) `num_warps = 4 if block_h <= 32 else 8` (was `<= 16`); +30% on H=32 | **+19.3%** |

All changes capture-time deterministic (CUDAGraph safe).

### Per-H cumulative speedup
```
H= 16   +9.0%
H= 32  +50.2%   ← previously stuck hot path
H= 64  +10.8%
H=128  +11.7%
```

### Per-T cumulative speedup
```
T=    1   +13.1%
T=   16    +9.7%
T=   64   +14.4%
T=  128   +18.7%
T=  256   +22.4%
T=  512   +23.5%
T= 1024   +24.7%
T= 2048   +25.8%
```

Best win: 2.110x (T=128 H=64 kv=128). Worst: 0.945x (small-T noise).

## Method

Each step gated on **geomean > +0.5% AND no shape regresses > 5%**. Three
intermediate experiments rejected (`06` num_stages=4 LDS cliff, `07`
block_h=8 superseded by `05`, `08` D-chunked acc neutral, `10` partial
buffer layout swap H=64 -12%). Full journal at
`/app/logs_claude/aaa_kenel_opt/`.

The v11 num_warps threshold flip (+30% on H=32) demonstrates the AKO4X
*"structural-change invalidates parameter sweeps"* lesson: pre-v05 the
sweep ruled out `nw=4 for H=32`, but after the inner-loop pipelining
(v05) and reduce-kernel rewrite (v09) the optimum shifted. Phase-1
single-axis re-sweep (8 overrides × 256 shapes, ~2h) found it.

## Test plan

- [x] 256-shape bf16 sweep vs PyTorch reference: 256/256 pass (atol=rtol=5e-3)
- [x] fp8 QUANT_KV path (`e4m3fnuz`): 6/6 spot checks pass
- [x] Mixed-kv-len batches (4 scenarios × 8 cells): 32/32 pass
- [x] Edge cases (kv boundary, kv_len=0 padding token): 20/20 pass
- [x] Perf regression sweep: see numbers above
- [x] CUDAGraph compatibility: heuristics depend only on capture-time
      shapes; never read per-token kv_len
- [ ] End-to-end lm_eval (DeepSeek V4) — recommend reviewer run before
      land if available

## Notes on mixed-kv-len

V4-Pro SWA path (uniform window=128) is a strict win. CSA/HCA paths
with normal length spread (2-4×) are net positive. A bimodal-extreme
(~64× spread) at T=256 H=32 + fused-path is the one edge regression
(-11 to -18%); rare in production. See journal `11_nw4_for_blockh32/config.md`
for full analysis.