### PR TITLE
ci(docker-release): add ubuntu24.04/py3.12 base image option

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -11,6 +11,7 @@ on:
         default: "rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0"
         options:
           - rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0
+          - rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0
       atom_repo:
         description: "ATOM repo"
         default: "https://github.com/ROCm/ATOM.git"


### PR DESCRIPTION
Adds the ubuntu24.04/py3.12 base image to the `base_image` choice list, matching the prod naming convention used since 2026-04-23 (most recent prod tag: `atom0.1.3` on 2026-05-31).

## Why now

For today's paired release v0.1.4 + AITER v0.1.15 container build, the workflow needs to dispatch with the 24.04/py3.12 base to preserve continuity with `atom0.1.3`. Without this option, dispatch fails with HTTP 422.

## Risk

- Zero — this is a YAML-only additive change (adds one option to a choice list, default unchanged)
- Existing nightly cron continues to use the default 22.04/py3.10
- Only explicit `workflow_dispatch` callers can pick the new option

## Tracking

This is a band-aid for the paired-release pilot. Follow-up PR will codify a full prod-release mode (see proposal at https://github.com/sunway513/mygist/blob/main/writing-drafts/atom_release_cadence_proposal_v2_20260601_204500.md).
