### PR TITLE
ci(docker-release): add rocm7.2.4 base option to release/v0.1.4 [release blocker]

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -13,6 +13,7 @@ on:
           - rocm/pytorch:latest
           - rocm/pytorch-nightly:latest
           - rocm/pytorch:rocm7.1.1_ubuntu24.04_py3.12_pytorch_release_2.10.0
+          - rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0
       atom_repo:
         description: "ATOM repo"
         default: "https://github.com/ROCm/ATOM.git"


### PR DESCRIPTION
Cherry-pick equivalent of #1117 onto release/v0.1.4. Adds `rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0` to the `base_image` choice list so v0.1.4 paired-release container build can dispatch successfully.

## Why merge to release/v0.1.4 (not main)

Dispatching from main runs the main-branch Dockerfile which now has an atomesh install step that requires `atom/mesh/` directory — but v0.1.4 (cut at 26f23a0b) doesn't include that directory. Run 27072389290 failed at step 16/16 with:

`/bin/sh: cd: can't cd to /app/ATOM/atom/mesh`

Solution: dispatch from release/v0.1.4 ref so workflow + Dockerfile both stay at v0.1.4 state. That requires the new base_image option to also exist on release/v0.1.4 — hence this PR.

## Risk

Zero — YAML-only additive (adds one option to choice list, default unchanged).
