### PR TITLE
refactor: unify cudagraph-vs-eager dispatch via ForwardMode

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -45,6 +45,7 @@ from atom.utils.tbo import (
 from atom.utils.forward_context import (
     Context,
     DPMetadata,
+    ForwardMode,
     get_forward_context,
     reset_forward_context,
     set_forward_context,
@@ -1761,34 +1762,42 @@ class ModelRunner:
             ub_max_tokens_across_dp,
         ) = self._preprocess(batch, num_scheduled_tokens=num_scheduled_tokens)
         self.forward_vars["cu_seqlens_q"].np[1 : bs + 1] = cu_seqlens_q
+
+        forward_mode = ForwardMode.decide(
+            is_prefill=is_prefill,
+            total_seqs_num=batch.total_seqs_num,
+            scheduled_bs_decode=batch.total_seqs_num_decode,
+            num_input_tokens=num_input_tokens,
+            dp_uniform_decode=dp_uniform_decode,
+            enforce_eager=self.enforce_eager,
+            graph_bs=self.graph_bs,
+            mtp_step=(self.drafter.mtp_k + 1) if hasattr(self, "drafter") else 1,
+        )
+
         if not is_prefill:
             scheduled_bs = batch.total_seqs_num_decode
-            # num_pad, num_tokens_across_dp = self.get_dp_padding(scheduled_bs)
-            # padded_scheduled_bs = scheduled_bs + num_pad
-            # TODO rename num_input_tokens to actual bs in currrent rank?
-            padded_scheduled_bs = num_input_tokens
-            # for MTP, we need to divide by (mtp_k + 1) to get the actual batch size
-            if hasattr(self, "drafter"):
-                mtp_step = self.drafter.mtp_k + 1
-                padded_scheduled_bs = (padded_scheduled_bs + mtp_step - 1) // mtp_step
-            bs = (
-                padded_scheduled_bs
-                if self.enforce_eager
-                else next(
-                    (x for x in self.graph_bs if x >= padded_scheduled_bs),
-                    padded_scheduled_bs,
+            bs = forward_mode.effective_bs  # single source of truth
+            assert bs >= scheduled_bs, (
+                f"effective_bs={bs} < scheduled_bs={scheduled_bs}; "
+                f"ForwardMode.decide invariant violated"
+            )
+            # Only pad cu_seqlens_q out to the cudagraph capture size if we
+            # actually grew bs. Eager (bs == scheduled_bs) leaves the slice
+            # empty so no overwrite happens.
+            if bs > scheduled_bs:
+                self.forward_vars["cu_seqlens_q"].np[scheduled_bs + 1 : bs + 1] = (
+                    self.forward_vars["cu_seqlens_q"].np[scheduled_bs]
                 )
-            )
-            assert (
-                bs >= padded_scheduled_bs
-            ), f"current decode {padded_scheduled_bs=} > max graph_bs{bs}"
-            self.forward_vars["cu_seqlens_q"].np[scheduled_bs + 1 : bs + 1] = (
-                self.forward_vars["cu_seqlens_q"].np[scheduled_bs]
-            )
         attn_metadata, positions = self.attn_metadata_builder.build(batch=batch, bs=bs)
         context_bs = batch.total_seqs_num_prefill if is_prefill else scheduled_bs
 
-        graph_bs = num_input_tokens if is_prefill else bs
+        # MoE's pad_for_all_gather reads context.graph_bs to pad hidden_states
+        # before a cross-DP all_gather, so it must be unified across DP ranks
+        # under uniform decode (where pad path is taken). Use forward_mode's
+        # moe_pad_bs, which equals effective_bs except in the uniform-eager
+        # corner (enforce_eager / bs>graph_bs[-1]) where attention needs local
+        # but MoE pad needs the DP-unified padded_scheduled_bs.
+        graph_bs = num_input_tokens if is_prefill else forward_mode.moe_pad_bs
         context = Context(
             positions=positions,
             is_prefill=is_prefill,
@@ -1796,6 +1805,7 @@ class ModelRunner:
             batch_size=context_bs,
             graph_bs=graph_bs,
             dp_uniform_decode=dp_uniform_decode,
+            forward_mode=forward_mode,
         )
 
         actual_num_tokens = batch.total_tokens_num
@@ -1907,12 +1917,21 @@ class ModelRunner:
         is_prefill = context.is_prefill
         positions = context.positions
 
-        if (
-            is_prefill
-            or self.enforce_eager
-            or not context.dp_uniform_decode
-            or bs > self.graph_bs[-1]
-        ):
+        # Dispatch is owned by ForwardMode.decide() (called in prepare_inputs).
+        # Every run_model caller MUST go through prepare_inputs first, so
+        # forward_mode is always set here.
+        forward_mode = context.forward_mode
+        assert forward_mode is not None, (
+            "context.forward_mode is None; run_model invoked without going "
+            "through prepare_inputs. Add ForwardMode.decide() at the new "
+            "entry point instead of re-deriving the 4-OR dispatch here."
+        )
+
+        # Single canonical shape check; contract owned by ForwardMode, which
+        # internally short-circuits for prefill / cudagraph.
+        forward_mode.assert_shape_contract(input_ids, forward_context.attn_metadata)
+
+        if not forward_mode.use_cudagraph:
             # prefill, or decode forced eager (enforce_eager / DP peer
             # prefill / bs above the largest captured graph).
             if is_prefill:

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -160,6 +160,143 @@ class SpecDecodeMetadata:
     bonus_logits_indices: torch.Tensor
 
 
+@dataclass(frozen=True)
+class ForwardMode:
+    """Per-step dispatch decision: cudagraph vs eager + per-rank attention bs
+    + cross-DP MoE-pad bs.
+
+    Two distinct sizes because they answer different questions:
+      - ``effective_bs`` sizes per-rank attention tensors (slot_mapping /
+        cu_seqlens_q). Must match ``input_ids.shape[0]`` (= local real tokens)
+        in eager so aiter's ``t == t_slot`` invariant holds.
+      - ``moe_pad_bs`` sizes ``context.graph_bs`` which MoE's
+        ``pad_for_all_gather`` reads to pad ``hidden_states`` before the
+        cross-DP ``all_gather``. Must be identical on every DP rank or the
+        collective shape-mismatches. Only matters when uniform_decode (the
+        variable-length all_gatherv path doesn't read it).
+
+    Two are equal on the cudagraph path (captured shape is unified by
+    construction) and on the non-uniform path (collective is variable-length,
+    so MoE doesn't care). They diverge only in the uniform-decode + eager
+    fallback corner — ``--enforce-eager`` and ``padded > graph_bs[-1]``.
+    """
+
+    use_cudagraph: bool
+    effective_bs: int
+    moe_pad_bs: int
+    is_prefill: bool
+
+    @classmethod
+    def decide(
+        cls,
+        *,
+        is_prefill: bool,
+        total_seqs_num: int,
+        scheduled_bs_decode: int,
+        num_input_tokens: int,
+        dp_uniform_decode: bool,
+        enforce_eager: bool,
+        graph_bs: list[int],
+        mtp_step: int = 1,
+    ) -> "ForwardMode":
+        """Compute dispatch + effective_bs + moe_pad_bs. Any new force-eager
+        condition belongs here, not in caller-side checks."""
+        if is_prefill:
+            # Prefill is always eager. effective_bs is the sequence count;
+            # per-token sums are tracked separately via cu_seqlens_q.
+            # moe_pad_bs is unused on prefill (MoE pad only fires for decode).
+            return cls(
+                use_cudagraph=False,
+                effective_bs=total_seqs_num,
+                moe_pad_bs=total_seqs_num,
+                is_prefill=True,
+            )
+
+        # padded_scheduled_bs is unified across DP ranks in uniform mode
+        # (num_input_tokens = max_tokens, set in ModelRunner._preprocess);
+        # local-equivalent in non-uniform mode.
+        padded_scheduled_bs = (num_input_tokens + mtp_step - 1) // mtp_step
+
+        if not dp_uniform_decode:
+            # Non-uniform: MoE goes through all_gatherv (variable-length,
+            # per-rank sizes); pad_for_all_gather is NOT reached so moe_pad_bs
+            # is irrelevant. Keep both at local for consistency.
+            return cls(
+                use_cudagraph=False,
+                effective_bs=scheduled_bs_decode,
+                moe_pad_bs=scheduled_bs_decode,
+                is_prefill=False,
+            )
+
+        # From here on: dp_uniform_decode=True. MoE WILL go through
+        # pad_for_all_gather, so moe_pad_bs MUST be cross-rank unified.
+
+        if enforce_eager:
+            # --enforce-eager + uniform decode: attention input_ids is local
+            # real, so effective_bs = local; but MoE pad needs the unified
+            # padded_scheduled_bs.
+            return cls(
+                use_cudagraph=False,
+                effective_bs=scheduled_bs_decode,
+                moe_pad_bs=padded_scheduled_bs,
+                is_prefill=False,
+            )
+
+        if padded_scheduled_bs > graph_bs[-1]:
+            # Workload above the largest captured graph: eager fallback under
+            # uniform. Same split — attention local, MoE pad unified.
+            return cls(
+                use_cudagraph=False,
+                effective_bs=scheduled_bs_decode,
+                moe_pad_bs=padded_scheduled_bs,
+                is_prefill=False,
+            )
+
+        # CUDAGraph path: pick the smallest captured size that fits. Captured
+        # shape is unified by construction so attention and MoE pad agree.
+        eff = next(
+            (x for x in graph_bs if x >= padded_scheduled_bs),
+            padded_scheduled_bs,
+        )
+        return cls(
+            use_cudagraph=True,
+            effective_bs=eff,
+            moe_pad_bs=eff,
+            is_prefill=False,
+        )
+
+    @property
+    def attn_tensors_are_padded(self) -> bool:
+        """True iff per-token attention tensors carry padding this step
+        (cudagraph today; update if other padded layouts are added)."""
+        return self.use_cudagraph
+
+    def assert_shape_contract(
+        self,
+        input_ids: "torch.Tensor",
+        attn_metadata: "AttentionMetaData",
+    ) -> None:
+        """Validate ``input_ids`` / ``slot_mapping`` against this ForwardMode.
+
+        Skips prefill (variable-length) and cudagraph (graph-internal shape);
+        callers invoke unconditionally to keep dispatch decisions centralised.
+        """
+        if self.is_prefill or self.attn_tensors_are_padded:
+            return
+        max_q = attn_metadata.max_seqlen_q
+        expected = self.effective_bs * max_q
+        actual_in = input_ids.shape[0]
+        actual_slot = attn_metadata.slot_mapping.shape[0]
+        assert actual_in == expected, (
+            f"eager input_ids length {actual_in} != effective_bs*max_q="
+            f"{expected} ({self})"
+        )
+        assert actual_slot == expected, (
+            f"eager slot_mapping length {actual_slot} != effective_bs*max_q="
+            f"{expected} ({self}); attn_metadata_builder used a stale bs"
+        )
+
+
 @dataclass
 class Context:
     # This context is used to store the basic context of the forward.
@@ -173,6 +310,11 @@ class Context:
     # case is treated as True). Mirrors vLLM's `uniform_decode` flag and
     # gates DP-specific variable-length all_gather/scatter paths.
     dp_uniform_decode: bool = True
+    # Single source of truth for cudagraph vs eager dispatch + effective_bs.
+    # Set by prepare_inputs via ForwardMode.decide(). None only on legacy
+    # paths that haven't been routed through it (run_model falls back to
+    # the original four-OR derivation in that case for back-compat).
+    forward_mode: Optional[ForwardMode] = None
     # Optional flat token ids for the current forward. Read by callbacks
     # invoked inside Dynamo-opaque custom ops (e.g. V4 MoE hash routing)
     # that need the token ids but cannot receive them as a function arg
@@ -188,6 +330,7 @@ class Context:
         graph_bs: int = 0,
         is_draft: bool = False,
         dp_uniform_decode: bool = True,
+        forward_mode: Optional[ForwardMode] = None,
         input_ids: Optional[torch.Tensor] = None,
     ):
         self.positions = positions
@@ -197,6 +340,7 @@ class Context:
         self.graph_bs = graph_bs
         self.is_draft = is_draft
         self.dp_uniform_decode = dp_uniform_decode
+        self.forward_mode = forward_mode
         self.input_ids = input_ids
 
 


### PR DESCRIPTION
prepare_inputs and run_model used to each derive eager-vs-cudagraph from the same four-OR chain and drifted under PR #930's dp_uniform_decode path: prepare_inputs rounded bs up to the next captured graph size while run_model took the eager branch with local-real input_ids, leaving slot_mapping at the rounded length. Downstream this tripped aiter's fused_qk_rope_reshape_and_cache assert (t_slot=48 > t=33).

Introduce ForwardMode (frozen dataclass) owning the decision and its data:
- ForwardMode.decide() is the single rule (all four force-eager conditions live here).
- prepare_inputs uses effective_bs to size attn_metadata.
- run_model strict-asserts forward_mode is set, then dispatches off use_cudagraph.
- assert_shape_contract() guards the slot_mapping <-> input_ids invariant (skips prefill / cudagraph internally so callers stay decision-free).

## Motivation
Consolidate eager-vs-cudagraph dispatch and padding decisions into a single ForwardMode.


## Technical Details


## Test Plan

the same with ci on gpt-oss-120b

## Test Result

 flex-extract:0.8832       strict-extract: 0.3806 

## Submission Checklist

