### PR TITLE
fix: enable TBO compute/comm overlap in Deepseek V4 and fix mooncake gather hang for PD prefill

### DIFF
--- a/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
+++ b/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
@@ -1058,6 +1058,10 @@ class MooncakeConnector(KVConnectorBase):
         if self._gather_slot is not None and consumer_staging_addr:
             producer_pool_idx = self._acquire_staging_slot()
             self._gather_slot(src_slot, producer_pool_idx)
+            # Synchronize on the gather kernel before NIC starts reading the
+            # staging buffer. Without this, the RDMA can race the still-in-flight
+            # gather kernel on TBO prefill (page fault under high concurrency).
+            torch.cuda.current_stream().synchronize()
             slot_src.append(
                 self._staging_base_addr + producer_pool_idx * self._staging_slot_bytes
             )

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, Optional, Tuple, cast
 if TYPE_CHECKING:
     from atom.model_ops.attentions.deepseek_v4_attn import AttentionMetaData_DSV4
 
+import threading
+
 import aiter
 import torch
 import torch.nn.functional as F
@@ -101,6 +103,34 @@ from atom.utils.forward_context import AttnState, get_forward_context
 from torch import nn
 
 logger = logging.getLogger(__name__)
+
+# Per-device auxiliary stream for TBO-adjacent collectives (DP input_ids
+# all-gather hoisted into DeepseekV4ForCausalLM.forward, MoE combine_outputs
+# TP all-reduce). Submitting these on a dedicated stream keeps the main
+# compute lane free of nccl interleaving so it can hardware-overlap with
+# TBO's own comm_stream.
+_TBO_COMM_STREAM: dict = {}
+_TBO_COMM_STREAM_LOCK = threading.Lock()
+
+
+def _run_on_tbo_comm_stream(fn, *args, **kwargs):
+    # Without TBO there is no second compute/comm stream to overlap with,
+    # so the side-stream hop only adds event/sync overhead. Run inline.
+    if not get_current_atom_config().enable_tbo:
+        return fn(*args, **kwargs)
+    device = torch.cuda.current_device()
+    with _TBO_COMM_STREAM_LOCK:
+        side = _TBO_COMM_STREAM.get(device)
+        if side is None:
+            side = torch.cuda.Stream(device=device)
+            _TBO_COMM_STREAM[device] = side
+    main = torch.cuda.current_stream()
+    side.wait_stream(main)
+    with torch.cuda.stream(side):
+        result = fn(*args, **kwargs)
+    main.wait_stream(side)
+    return result
+
 
 # ---------------------------------------------------------------------------
 # Classical KV cache scatter / gather helpers (PR3-pre2c-B).
@@ -2294,7 +2324,7 @@ class MoE(nn.Module):
         if shared is not None:
             routed = routed + shared
         if self.tp_size > 1:
-            routed = tensor_model_parallel_all_reduce(routed)
+            routed = _run_on_tbo_comm_stream(tensor_model_parallel_all_reduce, routed)
         return routed
 
     def single_stream_moe_forward(
@@ -2809,7 +2839,11 @@ class DeepseekV4ForCausalLM(nn.Module):
             # gate sees DP-gathered gating_output, so gather ids to match. This
             # runs for every forward, including each TBO ubatch, which invokes
             # this same forward with its own local slice + ubatch context.
-            ctx.context.input_ids = MoE._gather_ids_for_dp(input_ids.flatten(), ctx)
+            # Route through the routing-side stream so the all-gather does not
+            # serialize behind the main compute stream during TBO ping-pong.
+            ctx.context.input_ids = _run_on_tbo_comm_stream(
+                MoE._gather_ids_for_dp, input_ids.flatten(), ctx
+            )
         else:
             ctx.context.input_ids = input_ids
         return self.model(input_ids, positions)


### PR DESCRIPTION
## Summary

Two fixes for DeepSeek-V4-Pro PD-disaggregation prefill with `--enable-tbo`:

1. Enable real compute/comm overlap.

2. Fix mooncake gather hang under high-concurrency TBO prefill.

## Trace results

DeepSeek-V4-Pro, TP=8, `--enable-dp-attention --enable-tbo`, c=256, ISL=8192:

| | TBO NCCL overlap with compute |
|---|---|
| before | 3.8 % |
| after  | 91.7 % |
<img width="1122" height="609" alt="image" src="https://github.com/user-attachments/assets/7a8e34b3-7c4b-4280-b5a4-abf85872065c" />


## Test plan

- [x] PD prefill bench (c=256, ISL=8192, OSL=1024) runs to completion without hang
- [x] Trace shows 91.7 % of TBO NCCL overlapping with compute on the new node
- [x] CI: existing model accuracy tests
