### PR TITLE
[fix](moe): fix fused shared expert in qwen3.5-fp4

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -38,10 +38,7 @@ from atom.model_loader.weight_utils import (
 )
 from atom.model_ops.base_config import QuantizeMethodBase
 from atom.model_ops.moe import FusedMoEMethodBase
-from atom.model_ops.topK import (
-    is_rocm_aiter_fusion_shared_expert_enabled,
-    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
-)
+from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from aiter.dist.parallel_state import get_tp_group
 
 from atom.plugin.prepare import is_sglang
@@ -305,25 +302,6 @@ def load_model(
                 return maybe_matching_name
         return None
 
-    def should_fuse_shared_expert_weight(name: str, matching_name: str) -> bool:
-        layer_prefix = name.split(matching_name, 1)[0]
-        module_prefix = matching_name.split("shared_expert", 1)[0]
-        shared_expert_prefix = layer_prefix + matching_name.rstrip(".")
-        routed_expert_prefix = layer_prefix + f"{module_prefix}experts"
-        model_quant_config = getattr(getattr(model, "args", None), "quant_config", None)
-        if model_quant_config is None:
-            model_quant_config = getattr(model, "quant_config", None)
-        if model_quant_config is not None:
-            return is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
-                model_quant_config,
-                shared_expert_prefix=shared_expert_prefix,
-                routed_expert_prefix=routed_expert_prefix,
-            )
-        return is_rocm_aiter_fusion_shared_expert_enabled(
-            shared_expert_prefix=shared_expert_prefix,
-            routed_expert_prefix=routed_expert_prefix,
-        )
-
     def extract_expert_target_and_id(name: str) -> Tuple[str, int] | None:
         """Extract fused parameter name and expert id from expert checkpoint name.
         like 'model.layers.10.mlp.experts.100.w2_bias' -> model.layers.10.mlp.experts.w2_bias and 100
@@ -465,7 +443,7 @@ def load_model(
                 # standalone Expert module. Stays True for models without this
                 # attr (GLM4 etc.) so their fused-shared path is unchanged.
                 and not getattr(model, "disable_fused_shared_loading", False)
-                and should_fuse_shared_expert_weight(name, maybe_matching_name)
+                and is_rocm_aiter_fusion_shared_expert_enabled()
             ):
                 # Preserve the module-naming prefix (mlp. / ffn.) so the rewritten
                 # name matches this model's routed-expert param naming.

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -38,7 +38,10 @@ from atom.model_loader.weight_utils import (
 )
 from atom.model_ops.base_config import QuantizeMethodBase
 from atom.model_ops.moe import FusedMoEMethodBase
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
+from atom.model_ops.topK import (
+    is_rocm_aiter_fusion_shared_expert_enabled,
+    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
+)
 from aiter.dist.parallel_state import get_tp_group
 
 from atom.plugin.prepare import is_sglang
@@ -302,6 +305,26 @@ def load_model(
                 return maybe_matching_name
         return None
 
+    def should_fuse_shared_expert_weight(name: str, matching_name: str) -> bool:
+        layer_prefix = name.split(matching_name, 1)[0]
+        module_prefix = matching_name.split("shared_expert", 1)[0]
+        shared_expert_prefix = layer_prefix + matching_name.rstrip(".")
+        routed_expert_prefix = layer_prefix + f"{module_prefix}experts"
+        model_quant_config = getattr(getattr(model, "args", None), "quant_config", None)
+        if model_quant_config is None:
+            model_quant_config = getattr(model, "quant_config", None)
+        if model_quant_config is not None:
+            return is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+                model_quant_config,
+                shared_expert_prefix=shared_expert_prefix,
+                routed_expert_prefix=routed_expert_prefix,
+            )
+        return is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+            None,
+            shared_expert_prefix=shared_expert_prefix,
+            routed_expert_prefix=routed_expert_prefix,
+        )
+
     def extract_expert_target_and_id(name: str) -> Tuple[str, int] | None:
         """Extract fused parameter name and expert id from expert checkpoint name.
         like 'model.layers.10.mlp.experts.100.w2_bias' -> model.layers.10.mlp.experts.w2_bias and 100
@@ -443,7 +466,7 @@ def load_model(
                 # standalone Expert module. Stays True for models without this
                 # attr (GLM4 etc.) so their fused-shared path is unchanged.
                 and not getattr(model, "disable_fused_shared_loading", False)
-                and is_rocm_aiter_fusion_shared_expert_enabled()
+                and should_fuse_shared_expert_weight(name, maybe_matching_name)
             ):
                 # Preserve the module-naming prefix (mlp. / ffn.) so the rewritten
                 # name matches this model's routed-expert param naming.

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -38,7 +38,7 @@ from atom.model_ops.fused_moe.mori_prepare_finalize import MoriPrepareAndFinaliz
 from atom.model_ops.topK import (
     init_aiter_topK_meta_data,
     is_rocm_aiter_fuse_routed_scaling_factor,
-    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
+    is_rocm_aiter_fusion_shared_expert_enabled,
 )
 from atom.model_ops.topK import rocm_aiter_grouped_topk as grouped_topk
 from atom.model_ops.topK import rocm_aiter_topk_softmax as fused_topk
@@ -2067,16 +2067,7 @@ class FusedMoE(torch.nn.Module):
         self.global_num_experts = num_experts
         self.shared_expert_scoring_func = shared_expert_scoring_func
 
-        if shared_expert_prefix is None and prefix.endswith(".experts"):
-            shared_expert_prefix = prefix[: -len(".experts")] + ".shared_experts"
-
-        fuse_shared_experts = (
-            is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
-                quant_config,
-                shared_expert_prefix=shared_expert_prefix,
-                routed_expert_prefix=prefix,
-            )
-        )
+        fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
         self.num_fused_shared_experts = (
             config.n_shared_experts
             if config is not None

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -38,7 +38,7 @@ from atom.model_ops.fused_moe.mori_prepare_finalize import MoriPrepareAndFinaliz
 from atom.model_ops.topK import (
     init_aiter_topK_meta_data,
     is_rocm_aiter_fuse_routed_scaling_factor,
-    is_rocm_aiter_fusion_shared_expert_enabled,
+    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
 )
 from atom.model_ops.topK import rocm_aiter_grouped_topk as grouped_topk
 from atom.model_ops.topK import rocm_aiter_topk_softmax as fused_topk
@@ -2067,7 +2067,16 @@ class FusedMoE(torch.nn.Module):
         self.global_num_experts = num_experts
         self.shared_expert_scoring_func = shared_expert_scoring_func
 
-        fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+        if shared_expert_prefix is None and prefix.endswith(".experts"):
+            shared_expert_prefix = prefix[: -len(".experts")] + ".shared_experts"
+
+        fuse_shared_experts = (
+            is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+                quant_config,
+                shared_expert_prefix=shared_expert_prefix,
+                routed_expert_prefix=prefix,
+            )
+        )
         self.num_fused_shared_experts = (
             config.n_shared_experts
             if config is not None

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -137,7 +137,8 @@ def rocm_aiter_topk_softmax_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    if num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -172,7 +173,7 @@ def rocm_aiter_topk_softmax_impl(
         fused_shared_experts_for_kernel,
         fused_shared_experts_scoring_func,
     )
-    if num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -206,7 +207,8 @@ def rocm_aiter_biased_grouped_topk_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    if num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -237,7 +239,7 @@ def rocm_aiter_biased_grouped_topk_impl(
         need_renorm,
         routed_scaling_factor,
     )
-    if num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -254,7 +256,8 @@ def rocm_aiter_biased_grouped_topk_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     token = gating_output.shape[0]
     device = gating_output.device
-    if num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -285,7 +288,7 @@ def rocm_aiter_biased_grouped_topk_fake(
     else:
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
-    if num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -307,7 +310,8 @@ def rocm_aiter_grouped_topk_impl(
 
     token = gating_output.shape[0]
     device = gating_output.device
-    if num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -338,7 +342,7 @@ def rocm_aiter_grouped_topk_impl(
         scoring_func,
         routed_scaling_factor,
     )
-    if num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 
@@ -357,7 +361,8 @@ def rocm_aiter_grouped_topk_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     token = gating_output.shape[0]
     device = gating_output.device
-    if num_fused_shared_experts > 0:
+    fuse_shared_experts = is_rocm_aiter_fusion_shared_expert_enabled()
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         assert aiter_topK_meta_data is not None, (
             "AITER topK meta data is not initialized. "
             "Please ensure that init_aiter_topK_meta_data is called before this function."
@@ -388,7 +393,7 @@ def rocm_aiter_grouped_topk_fake(
     else:
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
-    if num_fused_shared_experts > 0:
+    if fuse_shared_experts and num_fused_shared_experts > 0:
         return total_topk_weights, total_topk_ids
     return topk_weights, topk_ids
 

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -25,7 +25,14 @@ def is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
         return False
 
     if quant_config is not None and shared_expert_prefix is not None:
-        shared_spec = quant_config.get_layer_quant_config(shared_expert_prefix)
+        # shared_expert_prefix points at the shared expert module, while quant
+        # exclude entries are usually leaf weights under that module
+        # (e.g. shared_expert.down_proj).  Match children here; otherwise a
+        # BF16 shared expert can be mistaken for the global routed expert dtype.
+        shared_spec = quant_config.get_layer_quant_config(
+            shared_expert_prefix,
+            check_children=True,
+        )
         routed_spec = (
             quant_config.get_layer_quant_config(routed_expert_prefix)
             if routed_expert_prefix is not None

--- a/atom/models/qwen3_5.py
+++ b/atom/models/qwen3_5.py
@@ -7,6 +7,7 @@ from torch import nn
 
 from atom.config import QuantizationConfig, Config
 
+from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.model_ops.utils import atom_parameter
 from atom.utils.decorators import support_torch_compile
 
@@ -532,7 +533,11 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.n_routed_experts
-            + (self.config.n_shared_experts or 0),
+            + (
+                self.config.n_shared_experts
+                if is_rocm_aiter_fusion_shared_expert_enabled()
+                else 0
+            ),
         )
 
 

--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -201,16 +201,9 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             quant_config=None,
             prefix=f"{prefix}.gate",
         )
-        self.is_rocm_aiter_fusion_shared_expert_enabled = (
-            is_rocm_aiter_fusion_shared_expert_enabled(
-                shared_expert_prefix=f"{prefix}.shared_expert",
-                routed_expert_prefix=f"{prefix}.experts",
-            )
-        )
-
         if (
             config.shared_expert_intermediate_size > 0
-            and not self.is_rocm_aiter_fusion_shared_expert_enabled
+            and not is_rocm_aiter_fusion_shared_expert_enabled()
         ):
             # When shared expert fusion is disabled (e.g. MXFP4 where shared
             # experts are BF16 while routed experts are FP4), run the shared
@@ -240,11 +233,10 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             use_grouped_topk=False,
             has_bias=False,
             shared_expert_scoring_func=(
-                "sigmoid" if self.is_rocm_aiter_fusion_shared_expert_enabled else None
+                "sigmoid" if self.shared_expert is None else None
             ),
             prefix=f"{prefix}.experts",
             config=config,
-            shared_expert_prefix=f"{prefix}.shared_expert",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -255,14 +247,14 @@ class Qwen3NextSparseMoeBlock(nn.Module):
 
         # router_logits: (num_tokens, n_experts + 1)
         logits = self.gate(hidden_states)
-        if not self.is_rocm_aiter_fusion_shared_expert_enabled:
+        if not is_rocm_aiter_fusion_shared_expert_enabled():
             router_logits = logits[:, : self.n_routed_experts]
         else:
             router_logits = logits
         routed_output = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )
-        if not self.is_rocm_aiter_fusion_shared_expert_enabled:
+        if not is_rocm_aiter_fusion_shared_expert_enabled():
             shared_output = self.shared_expert(hidden_states)
             # Apply shared expert gate: the merged gate output contains
             # [routed_logits, shared_expert_gate_logits], extract the tail

--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -32,7 +32,9 @@ from atom.model_ops.linear import (
     RowParallelLinear,
 )  # noqa: F401
 from atom.model_ops.moe import FusedMoE
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
+from atom.model_ops.topK import (
+    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
+)
 from atom.model_ops.utils import atom_parameter
 from atom.models.utils import (
     IntermediateTensors,
@@ -201,9 +203,17 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             quant_config=None,
             prefix=f"{prefix}.gate",
         )
+        self.is_rocm_aiter_fusion_shared_expert_enabled = (
+            is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+                quant_config,
+                shared_expert_prefix=f"{prefix}.shared_expert",
+                routed_expert_prefix=f"{prefix}.experts",
+            )
+        )
+
         if (
             config.shared_expert_intermediate_size > 0
-            and not is_rocm_aiter_fusion_shared_expert_enabled()
+            and not self.is_rocm_aiter_fusion_shared_expert_enabled
         ):
             # When shared expert fusion is disabled (e.g. MXFP4 where shared
             # experts are BF16 while routed experts are FP4), run the shared
@@ -233,10 +243,11 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             use_grouped_topk=False,
             has_bias=False,
             shared_expert_scoring_func=(
-                "sigmoid" if self.shared_expert is None else None
+                "sigmoid" if self.is_rocm_aiter_fusion_shared_expert_enabled else None
             ),
             prefix=f"{prefix}.experts",
             config=config,
+            shared_expert_prefix=f"{prefix}.shared_expert",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -247,14 +258,14 @@ class Qwen3NextSparseMoeBlock(nn.Module):
 
         # router_logits: (num_tokens, n_experts + 1)
         logits = self.gate(hidden_states)
-        if not is_rocm_aiter_fusion_shared_expert_enabled():
+        if not self.is_rocm_aiter_fusion_shared_expert_enabled:
             router_logits = logits[:, : self.n_routed_experts]
         else:
             router_logits = logits
         routed_output = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )
-        if not is_rocm_aiter_fusion_shared_expert_enabled():
+        if not self.is_rocm_aiter_fusion_shared_expert_enabled:
             shared_output = self.shared_expert(hidden_states)
             # Apply shared expert gate: the merged gate output contains
             # [routed_logits, shared_expert_gate_logits], extract the tail


### PR DESCRIPTION
## Motivation

Fix a Qwen3.5-397B-A17B-MXFP4 accuracy regression introduced by shared expert fusion changes. In this case, shared expert fusion was disabled in the runtime path, but the weight loader still rewrote shared expert checkpoint weights into the fused MoE expert slot. This made the loaded weights inconsistent with the execution path and caused GSM8K accuracy to drop near zero.

This change keeps shared expert weight remapping behind the same runtime fusion gate used by MoE/topK execution, so Qwen3.5 MXFP4 loads shared expert weights through the standalone path when fusion is disabled. Validation on Qwen3.5-397B-A17B-MXFP4 recovers exact_match,flexible-extract above the required threshold.

## TEST

<img width="513" height="72" alt="image" src="https://github.com/user-attachments/assets/7873a1c8-57d4-4822-81cd-aa34c6b19da6" />

