### PR TITLE
feat(tbo):TBO optimization, token-midpoint prefill ubatch split in Deepseek v4

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1640,9 +1640,9 @@ class ModelRunner:
         num_tokens_across_dp = DPMetadata.num_tokens_across_dp(
             num_tokens, dp_size, dp_rank
         )
-        max_tokens_across_dp_cpu = torch.max(num_tokens_across_dp).item()
+        max_tokens_across_dp = int(torch.max(num_tokens_across_dp))
 
-        return max_tokens_across_dp_cpu - num_tokens, num_tokens_across_dp
+        return max_tokens_across_dp - num_tokens, num_tokens_across_dp
 
     def _maybe_create_tbo_slices(
         self,
@@ -1736,7 +1736,7 @@ class ModelRunner:
             require_uniform_mode=require_uniform_mode,
         )
 
-        max_tokens = int(sync.num_tokens_across_dp.max().item())
+        max_tokens = int(sync.num_tokens_across_dp.max())
         dp_uniform_decode = (not sync.any_rank_has_prefill) or (
             not self.config.enable_dp_attention
         )

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1720,6 +1720,11 @@ class ModelRunner:
                 None,
             )
 
+        # Mixed prefill+decode DP steps only deadlock under prefill
+        # token-split + TBO-decode
+        require_uniform_mode = (
+            self.config.enable_tbo_decode and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
+        )
         sync = sync_dp_for_tbo(
             dp_group=get_dp_group().cpu_group,
             dp_size=dp_size,
@@ -1728,6 +1733,7 @@ class ModelRunner:
             tbo_on=tbo_on,
             local_tbo_eligible=local_eligible,
             local_ub_tokens=(local_ub0, local_ub1),
+            require_uniform_mode=require_uniform_mode,
         )
 
         max_tokens = int(sync.num_tokens_across_dp.max().item())

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -422,7 +422,7 @@ class MLAAttention(nn.Module):
         if n == 1 or n % 500 == 0:
             logger.info(
                 "MLA chunked-prefill #%d: layer=%d num_chunks=%d "
-                "total_kv=%d cu_seqlens_q[-1]=%d",
+                "total_kv=%s cu_seqlens_q[-1]=%d",
                 n,
                 self.layer_num,
                 chunk_meta.num_chunks,

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -12,6 +12,7 @@ from atom.utils import CpuGpuBuffer
 from atom.utils.block_convert import kv_indices_generate_triton
 from atom.model_ops.attention_mha import PagedAttentionImpl
 from atom.utils.forward_context import AttentionMetaData, Context
+from atom.utils.tbo import TokenSplitPrefillState
 
 from .backends import AttentionBackend, CommonAttentionBuilder
 
@@ -54,9 +55,9 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         self._tbo_token_split = bool(
             config.enable_tbo and _envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
         )
-        self._tbo_prefill_block_tables = None
-        self._tbo_prefill_cu_tokens = None
-        self._tbo_prefill_num_cached = None
+        # Snapshot of the current prefill batch, set by
+        # `_stash_tbo_token_split_prefill_state`; None when not token-splitting.
+        self._tbo_prefill_state = None
         # `self.num_attention_heads` set by CommonAttentionBuilder.__init__.
         # For speculative decode (MTP), max_qlen = num_speculative_tokens + 1
         if (
@@ -559,29 +560,29 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             self._stash_tbo_token_split_prefill_state(batch)
         return attn_metadata, positions
 
+    # ================================================================
     # TBO PREFILL TOKEN-SPLIT (ATOM_TBO_PREFILL_TOKEN_SPLIT) — MHA path
+    # ================================================================
 
     def _stash_tbo_token_split_prefill_state(self, batch: ScheduledBatch):
-        """Snapshot full-batch paged block_tables / cu_tokens / num_cached so a
-        later micro-batch can rebuild the straddled request's cached prefix."""
-        self._tbo_prefill_block_tables = None
-        self._tbo_prefill_cu_tokens = None
-        self._tbo_prefill_num_cached = None
+        """Snapshot full-batch block_tables / cu_tokens / num_cached so a later
+        micro-batch can rebuild the straddled request's cached prefix."""
+        self._tbo_prefill_state = None
         if not batch.block_tables:
             return
         bs = batch.total_seqs_num_prefill
-        self._tbo_prefill_block_tables = [
-            np.asarray(bt, dtype=np.int32) for bt in batch.block_tables[:bs]
-        ]
-        self._tbo_prefill_cu_tokens = np.asarray(
-            self.model_runner.forward_vars["cu_seqlens_q"].np[: bs + 1],
-            dtype=np.int64,
-        ).copy()
         # Per-request prefix-cache hit length (tokens already in the paged cache
         # from previous steps). A straddled/ubatch request's FULL visible K is
         # num_cached + (its tokens in this ubatch), so the gather must include it.
-        self._tbo_prefill_num_cached = np.asarray(
-            batch.num_cached_tokens[:bs], dtype=np.int64
+        self._tbo_prefill_state = TokenSplitPrefillState(
+            block_tables=[
+                np.asarray(bt, dtype=np.int32) for bt in batch.block_tables[:bs]
+            ],
+            cu_tokens=np.asarray(
+                self.model_runner.forward_vars["cu_seqlens_q"].np[: bs + 1],
+                dtype=np.int64,
+            ).copy(),
+            num_cached=np.asarray(batch.num_cached_tokens[:bs], dtype=np.int64),
         )
 
     def build_ubatch_prefill_metadata(
@@ -604,10 +605,11 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         attention sees the tokens ubatch 0 wrote. No-op when not straddling."""
         from atom.utils.tbo import compute_straddle_split_info
 
-        block_tables_host = self._tbo_prefill_block_tables
-        cu_tokens = self._tbo_prefill_cu_tokens
-        if block_tables_host is None or cu_tokens is None:
+        state = self._tbo_prefill_state
+        if state is None:
             return
+        block_tables_host = state.block_tables
+        cu_tokens = state.cu_tokens
 
         info = compute_straddle_split_info(cu_tokens, ub_slice)
         if not info.is_straddling:
@@ -627,9 +629,8 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         # straddle prefix written by ubatch 0 (only req0) + this ubatch's new
         # tokens. Missing the num_cached term made the gather read from the
         # cached-prefix blocks instead of the freshly-written new blocks.
-        num_cached = self._tbo_prefill_num_cached
-        if num_cached is not None:
-            cached = num_cached[rs.start : rs.stop].astype(np.int64)
+        if state.num_cached is not None:
+            cached = state.num_cached[rs.start : rs.stop].astype(np.int64)
         else:
             cached = np.zeros(ub_num_reqs, dtype=np.int64)
         ctx_lens = cached + new_lens

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -49,14 +49,6 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         super().__init__(model_runner)
         config = model_runner.config
         hf_config = config.hf_config
-        # Token-midpoint TBO prefill split
-        from atom.utils import envs
-
-        self._tbo_token_split = bool(
-            config.enable_tbo and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
-        )
-        self._tbo_prefill_block_tables = None
-        self._tbo_prefill_cu_tokens = None
         # `self.num_attention_heads` set by CommonAttentionBuilder.__init__.
         # For speculative decode (MTP), max_qlen = num_speculative_tokens + 1
         if (
@@ -552,114 +544,6 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             slot_regions=[],
             num_blocks=runner.num_physical_kvcache_blocks,
         )
-
-    def prepare_prefill(self, batch: ScheduledBatch):
-        attn_metadata, positions = CommonAttentionBuilder.prepare_prefill(self, batch)
-        # Only the token-split TBO path needs the per-request block tables stashed
-        if self._tbo_token_split:
-            self._stash_tbo_prefill_block_tables(batch)
-        return attn_metadata, positions
-
-    def _stash_tbo_prefill_block_tables(self, batch: ScheduledBatch):
-        """Stash host-side per-request block tables + cumulative token offsets so
-        build_ubatch_prefill_metadata can expose a straddled request's first half
-        (already in the paged KV cache) as a cached prefix for ubatch 1."""
-        self._tbo_prefill_block_tables = None
-        self._tbo_prefill_cu_tokens = None
-        if not batch.block_tables:
-            return
-        bs = batch.total_seqs_num_prefill
-        self._tbo_prefill_block_tables = [
-            np.asarray(bt, dtype=np.int32) for bt in batch.block_tables[:bs]
-        ]
-        self._tbo_prefill_cu_tokens = np.asarray(
-            self.model_runner.forward_vars["cu_seqlens_q"].np[: bs + 1],
-            dtype=np.int64,
-        ).copy()
-
-    def build_ubatch_prefill_metadata(
-        self,
-        attn_metadata: AttentionMetaData,
-        ub_slice,
-        padded_bs: int,
-        ubatch_idx: int = 0,
-    ) -> AttentionMetaData:
-        """Split prefill metadata for MHA, handling token-midpoint straddle.
-
-        When the ubatch's first request is cut from a previous ubatch (its
-        token slice starts inside the request), expose the prior portion — already
-        written to the paged KV cache by the earlier ubatch on the same compute
-        stream — as a cached prefix so dense MHA attention can attend to it via
-        the existing `_gather_prefix_and_concat_kv` path.
-        """
-        del ubatch_idx
-        from atom.utils.tbo.ubatch_splitting import split_attn_metadata
-
-        ub_attn = split_attn_metadata(attn_metadata, ub_slice, padded_bs)
-
-        # Only set when token-split TBO is active (see prepare_prefill). For the
-        # request-boundary split or non-TBO this is None → plain split.
-        block_tables_host = self._tbo_prefill_block_tables
-        cu_tokens = self._tbo_prefill_cu_tokens
-        if block_tables_host is None or cu_tokens is None:
-            return ub_attn
-
-        rs = ub_slice.request_slice
-        ts = ub_slice.token_slice
-        first_req = rs.start
-        req_global_start = int(cu_tokens[first_req])
-        prefix_len = ts.start - req_global_start
-        if prefix_len <= 0:
-            return ub_attn  # not straddling
-
-        ub_num_reqs = rs.stop - rs.start
-        block_size = self.model_runner.block_size
-        device = self.device
-
-        # Per-request K length for the gather/attn: the straddled first request
-        # contributes prefix+new (full visible context up to its last token in
-        # this ubatch); every other request contributes only its own new tokens.
-        new_lens = (
-            cu_tokens[rs.start + 1 : rs.stop + 1] - cu_tokens[rs.start : rs.stop]
-        ).astype(np.int64)
-        # ub1's portion of the straddled request = (ts covers [ts.start, req_end))
-        # but its visible K starts at the request's position 0 (the prefix).
-        ctx_lens = new_lens.copy()
-        ctx_lens[0] = prefix_len + new_lens[0]
-        total_kv = int(ctx_lens.sum())
-
-        # Block tables: row 0 = the straddled request's full block list (covers
-        # the cached prefix + its new tokens); other rows = their own blocks.
-        max_blocks = max(
-            (
-                len(block_tables_host[first_req + i])
-                for i in range(ub_num_reqs)
-            ),
-            default=1,
-        )
-        bt = np.zeros((ub_num_reqs, max_blocks), dtype=np.int32)
-        for i in range(ub_num_reqs):
-            row = block_tables_host[first_req + i]
-            bt[i, : len(row)] = row
-
-        cu_k = np.zeros(ub_num_reqs + 1, dtype=np.int32)
-        np.cumsum(ctx_lens.astype(np.int32), out=cu_k[1:])
-
-        ub_attn.has_cached = True
-        ub_attn.total_kv = total_kv
-        ub_attn.context_lens = torch.from_numpy(
-            ctx_lens.astype(np.int32)
-        ).to(device, non_blocking=True)
-        ub_attn.block_tables = torch.from_numpy(bt).to(device, non_blocking=True)
-        ub_attn.cu_seqlens_k = torch.from_numpy(cu_k).to(device, non_blocking=True)
-        ub_attn.seq_starts = torch.zeros(
-            ub_num_reqs, dtype=torch.int32, device=device
-        )
-        ub_attn.num_cached_tokens = torch.from_numpy(
-            ctx_lens.astype(np.int32)
-        ).to(device, non_blocking=True)
-        ub_attn.max_seqlen_k = int(ctx_lens.max())
-        return ub_attn
 
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
         scheduled_bs = batch.total_seqs_num_decode

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -49,6 +49,14 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         super().__init__(model_runner)
         config = model_runner.config
         hf_config = config.hf_config
+        from atom.utils import envs as _envs
+
+        self._tbo_token_split = bool(
+            config.enable_tbo and _envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
+        )
+        self._tbo_prefill_block_tables = None
+        self._tbo_prefill_cu_tokens = None
+        self._tbo_prefill_num_cached = None
         # `self.num_attention_heads` set by CommonAttentionBuilder.__init__.
         # For speculative decode (MTP), max_qlen = num_speculative_tokens + 1
         if (
@@ -544,6 +552,104 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             slot_regions=[],
             num_blocks=runner.num_physical_kvcache_blocks,
         )
+
+    def prepare_prefill(self, batch: ScheduledBatch):
+        attn_metadata, positions = CommonAttentionBuilder.prepare_prefill(self, batch)
+        if self._tbo_token_split:
+            self._stash_tbo_prefill_block_tables(batch)
+        return attn_metadata, positions
+
+    def _stash_tbo_prefill_block_tables(self, batch: ScheduledBatch):
+        self._tbo_prefill_block_tables = None
+        self._tbo_prefill_cu_tokens = None
+        self._tbo_prefill_num_cached = None
+        if not batch.block_tables:
+            return
+        bs = batch.total_seqs_num_prefill
+        self._tbo_prefill_block_tables = [
+            np.asarray(bt, dtype=np.int32) for bt in batch.block_tables[:bs]
+        ]
+        self._tbo_prefill_cu_tokens = np.asarray(
+            self.model_runner.forward_vars["cu_seqlens_q"].np[: bs + 1],
+            dtype=np.int64,
+        ).copy()
+        # Per-request prefix-cache hit length (tokens already in the paged cache
+        # from previous steps). A straddled/ubatch request's FULL visible K is
+        # num_cached + (its tokens in this ubatch), so the gather must include it.
+        self._tbo_prefill_num_cached = np.asarray(
+            batch.num_cached_tokens[:bs], dtype=np.int64
+        )
+
+    def build_ubatch_prefill_metadata(
+        self,
+        attn_metadata: AttentionMetaData,
+        ub_slice,
+        padded_bs: int,
+        ubatch_idx: int = 0,
+    ) -> AttentionMetaData:
+        del ubatch_idx
+        from atom.utils.tbo.ubatch_splitting import split_attn_metadata
+
+        ub_attn = split_attn_metadata(attn_metadata, ub_slice, padded_bs)
+
+        block_tables_host = self._tbo_prefill_block_tables
+        cu_tokens = self._tbo_prefill_cu_tokens
+        if block_tables_host is None or cu_tokens is None:
+            return ub_attn
+
+        rs = ub_slice.request_slice
+        ts = ub_slice.token_slice
+        first_req = rs.start
+        req_global_start = int(cu_tokens[first_req])
+        prefix_len = ts.start - req_global_start
+        if prefix_len <= 0:
+            return ub_attn  # not straddling
+
+        ub_num_reqs = rs.stop - rs.start
+        device = self.device
+
+        new_lens = (
+            cu_tokens[rs.start + 1 : rs.stop + 1] - cu_tokens[rs.start : rs.stop]
+        ).astype(np.int64)
+        new_lens[0] -= prefix_len  # first request is the straddled one
+        # Visible K per request = prior-step prefix cache (num_cached) + the
+        # straddle prefix written by ubatch 0 (only req0) + this ubatch's new
+        # tokens. Missing the num_cached term made the gather read from the
+        # cached-prefix blocks instead of the freshly-written new blocks.
+        num_cached = self._tbo_prefill_num_cached
+        if num_cached is not None:
+            cached = num_cached[rs.start : rs.stop].astype(np.int64)
+        else:
+            cached = np.zeros(ub_num_reqs, dtype=np.int64)
+        ctx_lens = cached + new_lens
+        ctx_lens[0] += prefix_len
+        total_kv = int(ctx_lens.sum())
+
+        max_blocks = max(
+            (len(block_tables_host[first_req + i]) for i in range(ub_num_reqs)),
+            default=1,
+        )
+        bt = np.zeros((ub_num_reqs, max_blocks), dtype=np.int32)
+        for i in range(ub_num_reqs):
+            row = block_tables_host[first_req + i]
+            bt[i, : len(row)] = row
+
+        cu_k = np.zeros(ub_num_reqs + 1, dtype=np.int32)
+        np.cumsum(ctx_lens.astype(np.int32), out=cu_k[1:])
+
+        ub_attn.has_cached = True
+        ub_attn.total_kv = total_kv
+        ub_attn.context_lens = torch.from_numpy(ctx_lens.astype(np.int32)).to(
+            device, non_blocking=True
+        )
+        ub_attn.block_tables = torch.from_numpy(bt).to(device, non_blocking=True)
+        ub_attn.cu_seqlens_k = torch.from_numpy(cu_k).to(device, non_blocking=True)
+        ub_attn.seq_starts = torch.zeros(ub_num_reqs, dtype=torch.int32, device=device)
+        ub_attn.num_cached_tokens = torch.from_numpy(ctx_lens.astype(np.int32)).to(
+            device, non_blocking=True
+        )
+        ub_attn.max_seqlen_k = int(ctx_lens.max())
+        return ub_attn
 
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
         scheduled_bs = batch.total_seqs_num_decode

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -556,10 +556,14 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
     def prepare_prefill(self, batch: ScheduledBatch):
         attn_metadata, positions = CommonAttentionBuilder.prepare_prefill(self, batch)
         if self._tbo_token_split:
-            self._stash_tbo_prefill_block_tables(batch)
+            self._stash_tbo_token_split_prefill_state(batch)
         return attn_metadata, positions
 
-    def _stash_tbo_prefill_block_tables(self, batch: ScheduledBatch):
+    # TBO PREFILL TOKEN-SPLIT (ATOM_TBO_PREFILL_TOKEN_SPLIT) — MHA path
+
+    def _stash_tbo_token_split_prefill_state(self, batch: ScheduledBatch):
+        """Snapshot full-batch paged block_tables / cu_tokens / num_cached so a
+        later micro-batch can rebuild the straddled request's cached prefix."""
         self._tbo_prefill_block_tables = None
         self._tbo_prefill_cu_tokens = None
         self._tbo_prefill_num_cached = None
@@ -591,21 +595,28 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         from atom.utils.tbo.ubatch_splitting import split_attn_metadata
 
         ub_attn = split_attn_metadata(attn_metadata, ub_slice, padded_bs)
+        self._attach_tbo_token_split_straddle_prefix(ub_attn, ub_slice)
+        return ub_attn
+
+    def _attach_tbo_token_split_straddle_prefix(self, ub_attn, ub_slice):
+        """Re-attach the straddled request's already-cached first half as a
+        paged cached prefix (block_tables + context_lens) so ubatch 1's dense
+        attention sees the tokens ubatch 0 wrote. No-op when not straddling."""
+        from atom.utils.tbo import compute_straddle_split_info
 
         block_tables_host = self._tbo_prefill_block_tables
         cu_tokens = self._tbo_prefill_cu_tokens
         if block_tables_host is None or cu_tokens is None:
-            return ub_attn
+            return
+
+        info = compute_straddle_split_info(cu_tokens, ub_slice)
+        if not info.is_straddling:
+            return
 
         rs = ub_slice.request_slice
-        ts = ub_slice.token_slice
-        first_req = rs.start
-        req_global_start = int(cu_tokens[first_req])
-        prefix_len = ts.start - req_global_start
-        if prefix_len <= 0:
-            return ub_attn  # not straddling
-
-        ub_num_reqs = rs.stop - rs.start
+        first_req = info.first_req
+        ub_num_reqs = info.ub_num_reqs
+        prefix_len = info.prefix_len
         device = self.device
 
         new_lens = (
@@ -649,7 +660,6 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             device, non_blocking=True
         )
         ub_attn.max_seqlen_k = int(ctx_lens.max())
-        return ub_attn
 
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
         scheduled_bs = batch.total_seqs_num_decode

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -49,6 +49,14 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         super().__init__(model_runner)
         config = model_runner.config
         hf_config = config.hf_config
+        # Token-midpoint TBO prefill split
+        from atom.utils import envs
+
+        self._tbo_token_split = bool(
+            config.enable_tbo and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
+        )
+        self._tbo_prefill_block_tables = None
+        self._tbo_prefill_cu_tokens = None
         # `self.num_attention_heads` set by CommonAttentionBuilder.__init__.
         # For speculative decode (MTP), max_qlen = num_speculative_tokens + 1
         if (
@@ -544,6 +552,114 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             slot_regions=[],
             num_blocks=runner.num_physical_kvcache_blocks,
         )
+
+    def prepare_prefill(self, batch: ScheduledBatch):
+        attn_metadata, positions = CommonAttentionBuilder.prepare_prefill(self, batch)
+        # Only the token-split TBO path needs the per-request block tables stashed
+        if self._tbo_token_split:
+            self._stash_tbo_prefill_block_tables(batch)
+        return attn_metadata, positions
+
+    def _stash_tbo_prefill_block_tables(self, batch: ScheduledBatch):
+        """Stash host-side per-request block tables + cumulative token offsets so
+        build_ubatch_prefill_metadata can expose a straddled request's first half
+        (already in the paged KV cache) as a cached prefix for ubatch 1."""
+        self._tbo_prefill_block_tables = None
+        self._tbo_prefill_cu_tokens = None
+        if not batch.block_tables:
+            return
+        bs = batch.total_seqs_num_prefill
+        self._tbo_prefill_block_tables = [
+            np.asarray(bt, dtype=np.int32) for bt in batch.block_tables[:bs]
+        ]
+        self._tbo_prefill_cu_tokens = np.asarray(
+            self.model_runner.forward_vars["cu_seqlens_q"].np[: bs + 1],
+            dtype=np.int64,
+        ).copy()
+
+    def build_ubatch_prefill_metadata(
+        self,
+        attn_metadata: AttentionMetaData,
+        ub_slice,
+        padded_bs: int,
+        ubatch_idx: int = 0,
+    ) -> AttentionMetaData:
+        """Split prefill metadata for MHA, handling token-midpoint straddle.
+
+        When the ubatch's first request is cut from a previous ubatch (its
+        token slice starts inside the request), expose the prior portion — already
+        written to the paged KV cache by the earlier ubatch on the same compute
+        stream — as a cached prefix so dense MHA attention can attend to it via
+        the existing `_gather_prefix_and_concat_kv` path.
+        """
+        del ubatch_idx
+        from atom.utils.tbo.ubatch_splitting import split_attn_metadata
+
+        ub_attn = split_attn_metadata(attn_metadata, ub_slice, padded_bs)
+
+        # Only set when token-split TBO is active (see prepare_prefill). For the
+        # request-boundary split or non-TBO this is None → plain split.
+        block_tables_host = self._tbo_prefill_block_tables
+        cu_tokens = self._tbo_prefill_cu_tokens
+        if block_tables_host is None or cu_tokens is None:
+            return ub_attn
+
+        rs = ub_slice.request_slice
+        ts = ub_slice.token_slice
+        first_req = rs.start
+        req_global_start = int(cu_tokens[first_req])
+        prefix_len = ts.start - req_global_start
+        if prefix_len <= 0:
+            return ub_attn  # not straddling
+
+        ub_num_reqs = rs.stop - rs.start
+        block_size = self.model_runner.block_size
+        device = self.device
+
+        # Per-request K length for the gather/attn: the straddled first request
+        # contributes prefix+new (full visible context up to its last token in
+        # this ubatch); every other request contributes only its own new tokens.
+        new_lens = (
+            cu_tokens[rs.start + 1 : rs.stop + 1] - cu_tokens[rs.start : rs.stop]
+        ).astype(np.int64)
+        # ub1's portion of the straddled request = (ts covers [ts.start, req_end))
+        # but its visible K starts at the request's position 0 (the prefix).
+        ctx_lens = new_lens.copy()
+        ctx_lens[0] = prefix_len + new_lens[0]
+        total_kv = int(ctx_lens.sum())
+
+        # Block tables: row 0 = the straddled request's full block list (covers
+        # the cached prefix + its new tokens); other rows = their own blocks.
+        max_blocks = max(
+            (
+                len(block_tables_host[first_req + i])
+                for i in range(ub_num_reqs)
+            ),
+            default=1,
+        )
+        bt = np.zeros((ub_num_reqs, max_blocks), dtype=np.int32)
+        for i in range(ub_num_reqs):
+            row = block_tables_host[first_req + i]
+            bt[i, : len(row)] = row
+
+        cu_k = np.zeros(ub_num_reqs + 1, dtype=np.int32)
+        np.cumsum(ctx_lens.astype(np.int32), out=cu_k[1:])
+
+        ub_attn.has_cached = True
+        ub_attn.total_kv = total_kv
+        ub_attn.context_lens = torch.from_numpy(
+            ctx_lens.astype(np.int32)
+        ).to(device, non_blocking=True)
+        ub_attn.block_tables = torch.from_numpy(bt).to(device, non_blocking=True)
+        ub_attn.cu_seqlens_k = torch.from_numpy(cu_k).to(device, non_blocking=True)
+        ub_attn.seq_starts = torch.zeros(
+            ub_num_reqs, dtype=torch.int32, device=device
+        )
+        ub_attn.num_cached_tokens = torch.from_numpy(
+            ctx_lens.astype(np.int32)
+        ).to(device, non_blocking=True)
+        ub_attn.max_seqlen_k = int(ctx_lens.max())
+        return ub_attn
 
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
         scheduled_bs = batch.total_seqs_num_decode

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1390,27 +1390,31 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             )
 
         # ── Token-midpoint split straddle handling ──────────────────────
-        self._maybe_attach_straddle_prefix(attn_metadata, ub_attn, ub_slice)
+        self._attach_tbo_token_split_straddle_prefix(attn_metadata, ub_attn, ub_slice)
 
         return ub_attn
 
-    def _maybe_attach_straddle_prefix(self, attn_metadata, ub_attn, ub_slice):
+    # TBO PREFILL TOKEN-SPLIT (ATOM_TBO_PREFILL_TOKEN_SPLIT) — MLA path
+
+    def _attach_tbo_token_split_straddle_prefix(self, attn_metadata, ub_attn, ub_slice):
         """If this ubatch's first request is cut from a previous ubatch, attach
-        the prior portion's KV-cache slots as a single-chunk cached prefix so
-        dense MLA attention can see it (token-midpoint split correctness)."""
+        the prior portion's KV-cache slots as chunked cached prefixes so dense
+        MLA attention can see it (token-midpoint split correctness). No-op when
+        not straddling."""
+        from atom.utils.tbo import compute_straddle_split_info
+
         if self.k_chunk_workspace is None:
             return  # chunked workspace disabled → cannot serve a prefix
-        cu = attn_metadata.cu_seqlens_q
-        if cu is None:
-            return
-        rs = ub_slice.request_slice
-        ts = ub_slice.token_slice
-        first_req = rs.start
-        # Global token offset where this ubatch's first request actually began.
-        req_global_start = int(cu[first_req].item())
-        prefix_len = ts.start - req_global_start
-        if prefix_len <= 0:
+
+        cu_np = self.model_runner.forward_vars["cu_seqlens_q"].np
+        info = compute_straddle_split_info(cu_np, ub_slice)
+        if not info.is_straddling:
             return  # not straddling — first request starts at the slice edge
+
+        ts = ub_slice.token_slice
+        req_global_start = info.req_global_start
+        prefix_len = info.prefix_len
+        ub_num_reqs = info.ub_num_reqs
 
         slot_mapping = attn_metadata.slot_mapping
         if slot_mapping is None:
@@ -1420,7 +1424,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # the gather kv_indices directly.
         prefix_slots = slot_mapping[req_global_start : ts.start].to(torch.int32)
 
-        ub_num_reqs = rs.stop - rs.start
         device = prefix_slots.device
         # Only the first (straddled) request has a cached prefix; all other
         # requests in this ubatch contribute 0 cached tokens. Chunk the prefix
@@ -1449,8 +1452,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # total_kv = this ubatch's new tokens + the straddle prefix it now reads
         # from cache. Only referenced by the chunked-prefill debug log, but keep
         # it consistent to avoid a None in "%d" formatting.
-        ub_num_tokens = ts.stop - ts.start
-        ub_attn.total_kv = int(ub_num_tokens + prefix_len)
+        ub_attn.total_kv = int(info.ub_num_tokens + prefix_len)
         ub_attn.mla_chunk_meta = MLAChunkContextMetadata(
             kv_indptr=kv_indptr_list,
             kv_indices=kv_indices_list,

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1389,4 +1389,75 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 attn_metadata.sparse_kv_indptr[ts.start : ts.stop + 1] - base
             )
 
+        # ── Token-midpoint split straddle handling ──────────────────────
+        self._maybe_attach_straddle_prefix(attn_metadata, ub_attn, ub_slice)
+
         return ub_attn
+
+    def _maybe_attach_straddle_prefix(self, attn_metadata, ub_attn, ub_slice):
+        """If this ubatch's first request is cut from a previous ubatch, attach
+        the prior portion's KV-cache slots as a single-chunk cached prefix so
+        dense MLA attention can see it (token-midpoint split correctness)."""
+        if self.k_chunk_workspace is None:
+            return  # chunked workspace disabled → cannot serve a prefix
+        cu = attn_metadata.cu_seqlens_q
+        if cu is None:
+            return
+        rs = ub_slice.request_slice
+        ts = ub_slice.token_slice
+        first_req = rs.start
+        # Global token offset where this ubatch's first request actually began.
+        req_global_start = int(cu[first_req].item())
+        prefix_len = ts.start - req_global_start
+        if prefix_len <= 0:
+            return  # not straddling — first request starts at the slice edge
+
+        slot_mapping = attn_metadata.slot_mapping
+        if slot_mapping is None:
+            return
+        # Physical KV-cache slots of the straddled request's first half
+        # (written by the previous ubatch). MLA block_size==1, so slot ids are
+        # the gather kv_indices directly.
+        prefix_slots = slot_mapping[req_global_start : ts.start].to(torch.int32)
+
+        ub_num_reqs = rs.stop - rs.start
+        device = prefix_slots.device
+        # Only the first (straddled) request has a cached prefix; all other
+        # requests in this ubatch contribute 0 cached tokens. Chunk the prefix
+        # along the token axis so each chunk fits the k/v workspace
+        # (attn_prefill_chunk_size), mirroring _build_mla_chunk_meta.
+        chunk_size = self.attn_prefill_chunk_size
+        num_chunks = max(1, cdiv(prefix_len, chunk_size))
+        kv_indptr_list = []
+        kv_indices_list = []
+        total_tokens_list = []
+        max_seqlen_k_list = []
+        for c in range(num_chunks):
+            c_lo = c * chunk_size
+            c_hi = min(c_lo + chunk_size, prefix_len)
+            c_len = c_hi - c_lo
+            per_seq = torch.zeros(ub_num_reqs, dtype=torch.int32, device=device)
+            per_seq[0] = c_len
+            cu_k = torch.zeros(ub_num_reqs + 1, dtype=torch.int32, device=device)
+            torch.cumsum(per_seq, dim=0, out=cu_k[1:])
+            kv_indptr_list.append(cu_k)
+            kv_indices_list.append(prefix_slots[c_lo:c_hi])
+            total_tokens_list.append(int(c_len))
+            max_seqlen_k_list.append(int(c_len))
+
+        ub_attn.has_cached = True
+        # total_kv = this ubatch's new tokens + the straddle prefix it now reads
+        # from cache. Only referenced by the chunked-prefill debug log, but keep
+        # it consistent to avoid a None in "%d" formatting.
+        ub_num_tokens = ts.stop - ts.start
+        ub_attn.total_kv = int(ub_num_tokens + prefix_len)
+        ub_attn.mla_chunk_meta = MLAChunkContextMetadata(
+            kv_indptr=kv_indptr_list,
+            kv_indices=kv_indices_list,
+            cu_seqlens_k=kv_indptr_list,
+            total_tokens=total_tokens_list,
+            max_seqlen_k=max_seqlen_k_list,
+            num_chunks=num_chunks,
+            k_workspace=self.k_chunk_workspace,
+            v_workspace=self.v_chunk_workspace,
+        )

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1441,14 +1441,14 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             c_lo = c * chunk_size
             c_hi = min(c_lo + chunk_size, prefix_len)
             c_len = c_hi - c_lo
-            per_seq = torch.zeros(ub_num_reqs, dtype=torch.int32, device=device)
-            per_seq[0] = c_len
-            cu_k = torch.zeros(ub_num_reqs + 1, dtype=torch.int32, device=device)
-            torch.cumsum(per_seq, dim=0, out=cu_k[1:])
-            kv_indptr_list.append(cu_k)
+            cu = np.full(ub_num_reqs + 1, c_len, dtype=np.int32)
+            cu[0] = 0
+            kv_indptr_list.append(
+                torch.from_numpy(cu).pin_memory().to(device, non_blocking=True)
+            )
             kv_indices_list.append(prefix_slots[c_lo:c_hi])
-            total_tokens_list.append(int(c_len))
-            max_seqlen_k_list.append(int(c_len))
+            total_tokens_list.append(c_len)
+            max_seqlen_k_list.append(c_len)
 
         ub_attn.has_cached = True
         # total_kv = this ubatch's new tokens + the straddle prefix it now reads

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1394,7 +1394,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
         return ub_attn
 
+    # ================================================================
     # TBO PREFILL TOKEN-SPLIT (ATOM_TBO_PREFILL_TOKEN_SPLIT) — MLA path
+    # ================================================================
 
     def _attach_tbo_token_split_straddle_prefix(self, attn_metadata, ub_attn, ub_slice):
         """If this ubatch's first request is cut from a previous ubatch, attach

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1328,17 +1328,15 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         var = self.model_runner.forward_vars
         positions_np = np.asarray(var["positions"].np[ts.start : ts.stop])
         full_cu = var["cu_seqlens_q"].np
-        ub_cu = np.asarray(full_cu[rs.start : rs.stop + 1], dtype=np.int32).copy()
-        ub_cu -= ub_cu[0]
-
-        extend_lens_np = (ub_cu[1:] - ub_cu[:ub_num_reqs]).astype(np.int32)
-        # Slice the full batch's `var["context_lens"]` (populated by
-        # `super().prepare_prefill`) for this ubatch — mathematically equals
-        # `start_pos + extend_lens` but reads from the canonical source.
-        # `.copy()` so the swap-into-front below doesn't alias.
-        context_lens_np = np.asarray(
-            var["context_lens"].np[rs.start : rs.stop], dtype=np.int32
-        ).copy()
+        req_global_starts = full_cu[rs.start : rs.stop].astype(np.int64)
+        req_global_ends = full_cu[rs.start + 1 : rs.stop + 1].astype(np.int64)
+        clamped_starts = np.maximum(req_global_starts, ts.start)
+        clamped_ends = np.minimum(req_global_ends, ts.stop)
+        extend_lens_np = (clamped_ends - clamped_starts).astype(np.int32)
+        ub_cu = np.zeros(ub_num_reqs + 1, dtype=np.int32)
+        np.cumsum(extend_lens_np, dtype=np.int32, out=ub_cu[1:])
+        ub_start_pos_for_ctx = positions_np[ub_cu[:ub_num_reqs]].astype(np.int32)
+        context_lens_np = (ub_start_pos_for_ctx + extend_lens_np).astype(np.int32)
         from atom.model_ops.v4_kernels import make_compress_plans
 
         if self._unique_compress_ratios_overlap:
@@ -1408,6 +1406,25 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         finally:
             bt[:ub_num_reqs] = saved_bt
             var["context_lens"].np[:ub_num_reqs] = saved_ctx
+
+        # `split_attn_metadata` computed ub_attn.cu_seqlens_q/k from RAW request
+        # boundaries (orig_cu[rs] - base), which is WRONG for a straddling
+        # request under token-midpoint splits: it counts the request's FULL
+        # length instead of only the portion owned by this ubatch, so
+        # cu_seqlens_q[-1] > ub_num_tokens and any kernel indexing by it goes
+        # out of bounds (SIGABRT / GPU memory fault). Overwrite with the
+        # token-window-clamped `ub_cu` already computed above. For non-
+        # straddling splits these are identical, so this is a no-op there.
+        ub_cu_gpu = torch.from_numpy(
+            np.ascontiguousarray(ub_cu[: ub_num_reqs + 1], dtype=np.int32)
+        ).to(self.device, non_blocking=True)
+        ub_attn.cu_seqlens_q = ub_cu_gpu
+        if extend_lens_np.size > 0:
+            ub_attn.max_seqlen_q = int(extend_lens_np.max())
+        # cu_seqlens_k consistent with the clamped q lens (V4 prefill prefix KV
+        # is read via per-ratio kv_indices_prefix_* buffers, not cu_seqlens_k).
+        if ub_attn.cu_seqlens_k is not None:
+            ub_attn.cu_seqlens_k = ub_cu_gpu
 
         # Clone all GPU tensors that are views into shared CpuGpuBuffers.
         # Without this, building the next ubatch overwrites this ubatch's

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -217,7 +217,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         else float(os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK"))
     ),
     # --- TBO prefill ubatch splitting ---
-    # When "1", split prefill ubatches at the exact token midpoint 
+    # When "1", split prefill ubatches at the exact token midpoint
     "ATOM_TBO_PREFILL_TOKEN_SPLIT": lambda: (
         os.getenv("ATOM_TBO_PREFILL_TOKEN_SPLIT", "0") == "1"
     ),

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -217,9 +217,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
         else float(os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK"))
     ),
     # --- TBO prefill ubatch splitting ---
-    # When "1", split prefill ubatches at the exact token midpoint
+    # Split prefill ubatches at the exact token midpoint (vLLM-DBO style),
+    # cutting through a request if needed for perfectly balanced 50/50 ubatches.
+    # Default on; set "0" to fall back to the request-boundary balanced split.
     "ATOM_TBO_PREFILL_TOKEN_SPLIT": lambda: (
-        os.getenv("ATOM_TBO_PREFILL_TOKEN_SPLIT", "0") == "1"
+        os.getenv("ATOM_TBO_PREFILL_TOKEN_SPLIT", "1") == "1"
     ),
 }
 

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -216,6 +216,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK", "") == ""
         else float(os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK"))
     ),
+    # --- TBO prefill ubatch splitting ---
+    # When "1", split prefill ubatches at the exact token midpoint 
+    "ATOM_TBO_PREFILL_TOKEN_SPLIT": lambda: (
+        os.getenv("ATOM_TBO_PREFILL_TOKEN_SPLIT", "0") == "1"
+    ),
 }
 
 

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -283,6 +283,9 @@ class ForwardMode:
         """
         if self.is_prefill or self.attn_tensors_are_padded:
             return
+        # Dummy runs doesn't apply there.
+        if attn_metadata.slot_mapping is None:
+            return
         max_q = attn_metadata.max_seqlen_q
         expected = self.effective_bs * max_q
         actual_in = input_ids.shape[0]

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -283,9 +283,6 @@ class ForwardMode:
         """
         if self.is_prefill or self.attn_tensors_are_padded:
             return
-        # Dummy runs doesn't apply there.
-        if attn_metadata.slot_mapping is None:
-            return
         max_q = attn_metadata.max_seqlen_q
         expected = self.effective_bs * max_q
         actual_in = input_ids.shape[0]

--- a/atom/utils/tbo/__init__.py
+++ b/atom/utils/tbo/__init__.py
@@ -3,6 +3,7 @@
 
 from .prefill_token_split import (
     StraddleSplitInfo,
+    TokenSplitPrefillState,
     compute_straddle_split_info,
 )
 from .ubatch_splitting import (
@@ -37,6 +38,7 @@ __all__ = [
     "DPSyncResult",
     "StraddleSplitInfo",
     "TBOContext",
+    "TokenSplitPrefillState",
     "UBatchSlice",
     "UBatchWrapper",
     "compute_straddle_split_info",

--- a/atom/utils/tbo/__init__.py
+++ b/atom/utils/tbo/__init__.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+from .prefill_token_split import (
+    StraddleSplitInfo,
+    compute_straddle_split_info,
+)
 from .ubatch_splitting import (
     UBatchSlice,
     maybe_create_ubatch_slices,
@@ -31,9 +35,11 @@ from .ubatching import (
 
 __all__ = [
     "DPSyncResult",
+    "StraddleSplitInfo",
     "TBOContext",
     "UBatchSlice",
     "UBatchWrapper",
+    "compute_straddle_split_info",
     "local_tbo_precompute",
     "sync_dp_for_tbo",
     "tbo_overlap_enabled",

--- a/atom/utils/tbo/prefill_token_split.py
+++ b/atom/utils/tbo/prefill_token_split.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+TBO prefill token-split — shared straddle geometry.
+=====================================================================
+
+This module backs the ``ATOM_TBO_PREFILL_TOKEN_SPLIT`` path: when TBO splits
+a prefill batch at the exact *token* midpoint (rather than on a request
+boundary), the cut can land **inside a single request**. The request is then
+processed across two micro-batches:
+
+    req R, tokens [0 ............ M ............ L)
+                  |---- ubatch 0 ----|--- ubatch 1 ---|
+                         (prefix)          (this ubatch)
+
+"""
+
+from dataclasses import dataclass
+
+__all__ = ["StraddleSplitInfo", "compute_straddle_split_info"]
+
+
+@dataclass
+class StraddleSplitInfo:
+    """Geometry of a token-midpoint prefill cut for one micro-batch.
+
+    Attributes:
+        is_straddling: True iff this ubatch's first request was cut from a
+            previous ubatch (i.e. ``prefix_len > 0``). When False the ubatch
+            starts on a clean request boundary and no prefix attach is needed.
+        first_req: Index (into the full prefill batch) of this ubatch's first
+            request — the only request that can carry a straddle prefix.
+        ub_num_reqs: Number of requests in this ubatch.
+        ub_num_tokens: Number of *new* tokens in this ubatch.
+        prefix_len: Tokens of ``first_req`` already processed (and KV-cached)
+            by the previous ubatch. Zero when not straddling.
+        req_global_start: Global token offset where ``first_req`` began.
+    """
+
+    is_straddling: bool
+    first_req: int
+    ub_num_reqs: int
+    ub_num_tokens: int
+    prefix_len: int
+    req_global_start: int
+
+
+def compute_straddle_split_info(cu_tokens, ub_slice) -> StraddleSplitInfo:
+    """Compute the token-midpoint straddle geometry for one micro-batch.
+
+    Args:
+        cu_tokens: Exclusive-prefix cumulative q-seqlens over the full prefill
+            batch (``cu_tokens[i]`` = global first-token offset of request i).
+            Accepts a numpy array or any indexable of ints.
+        ub_slice: The :class:`UBatchSlice` describing this micro-batch's
+            request/token spans.
+
+    Returns:
+        A :class:`StraddleSplitInfo`. Check ``.is_straddling`` first; the other
+        fields are always populated but only meaningful when straddling.
+    """
+    rs = ub_slice.request_slice
+    ts = ub_slice.token_slice
+    first_req = rs.start
+    req_global_start = int(cu_tokens[first_req])
+    prefix_len = ts.start - req_global_start
+    return StraddleSplitInfo(
+        is_straddling=prefix_len > 0,
+        first_req=first_req,
+        ub_num_reqs=rs.stop - rs.start,
+        ub_num_tokens=ts.stop - ts.start,
+        prefix_len=int(prefix_len),
+        req_global_start=req_global_start,
+    )

--- a/atom/utils/tbo/prefill_token_split.py
+++ b/atom/utils/tbo/prefill_token_split.py
@@ -17,8 +17,22 @@ processed across two micro-batches:
 """
 
 from dataclasses import dataclass
+from typing import Optional
 
-__all__ = ["StraddleSplitInfo", "compute_straddle_split_info"]
+import numpy as np
+
+__all__ = [
+    "StraddleSplitInfo",
+    "TokenSplitPrefillState",
+    "compute_straddle_split_info",
+]
+
+
+@dataclass
+class TokenSplitPrefillState:
+    block_tables: list
+    cu_tokens: np.ndarray
+    num_cached: Optional[np.ndarray]
 
 
 @dataclass

--- a/atom/utils/tbo/ubatch_splitting.py
+++ b/atom/utils/tbo/ubatch_splitting.py
@@ -46,9 +46,7 @@ def maybe_create_ubatch_slices(
     # even with a single request (bs=1) — only require that there are at
     # least `num_ubatches` tokens to go around. The request-boundary path
     # below still needs num_reqs >= num_ubatches.
-    token_split = (
-        num_scheduled_tokens is not None and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
-    )
+    token_split = num_scheduled_tokens is not None and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
     if not token_split and num_reqs < num_ubatches:
         return None
 
@@ -152,9 +150,7 @@ def _split_prefill_token_midpoint(
     num_ubatches: int,
     max_tokens_per_ubatch: Optional[int],
 ) -> Optional[list[UBatchSlice]]:
-    """split prefill at the exact token midpoint.
-
-    """
+    """split prefill at the exact token midpoint."""
     toks = np.asarray(num_scheduled_tokens[:num_reqs], dtype=np.int64)
     total_tokens = int(toks.sum())
     # Exclusive-prefix cumulative token offsets: cu[i] = first token of req i.
@@ -162,9 +158,7 @@ def _split_prefill_token_midpoint(
     np.cumsum(toks, out=cu[1:])
 
     # Token split points at exact fractions of the total.
-    split_points = [
-        (total_tokens * i) // num_ubatches for i in range(1, num_ubatches)
-    ]
+    split_points = [(total_tokens * i) // num_ubatches for i in range(1, num_ubatches)]
 
     slices: list[UBatchSlice] = []
     tok_start = 0

--- a/atom/utils/tbo/ubatch_splitting.py
+++ b/atom/utils/tbo/ubatch_splitting.py
@@ -14,6 +14,34 @@ from atom.utils.forward_context import AttentionMetaData
 logger = logging.getLogger("atom")
 
 
+def _token_split_supported() -> bool:
+    """Whether the active attention backend can serve a straddled request's
+    first half from the paged KV cache, which the token-midpoint split requires.
+
+    Only MLA (DeepSeek-R1 / V2 / V3) and DeepSeek-V4 are supported today; dense
+    MHA backends (e.g. GPT-OSS) fall back to the request-boundary split. Remove
+    this gate once MHA straddle gather is fixed.
+    """
+    try:
+        from atom.config import get_current_atom_config
+
+        hf = get_current_atom_config().hf_config
+        model_type = getattr(hf, "model_type", "") or ""
+        arches = getattr(hf, "architectures", None) or []
+        is_v4 = any("DeepseekV4" in str(a) for a in arches)
+        is_mla = model_type in (
+            "deepseek_v2",
+            "deepseek_v3",
+            "deepseek_mtp",
+            "kimi_k2",
+            "glm_moe_dsa",
+        )
+        return bool(is_v4 or is_mla)
+    except Exception:
+        # If we can't determine the backend, be safe: no token-split.
+        return False
+
+
 @dataclass
 class UBatchSlice:
     """Describes which portion of a batch belongs to a micro-batch."""
@@ -46,7 +74,11 @@ def maybe_create_ubatch_slices(
     # even with a single request (bs=1) — only require that there are at
     # least `num_ubatches` tokens to go around. The request-boundary path
     # below still needs num_reqs >= num_ubatches.
-    token_split = num_scheduled_tokens is not None and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
+    token_split = (
+        num_scheduled_tokens is not None
+        and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
+        and _token_split_supported()
+    )
     if not token_split and num_reqs < num_ubatches:
         return None
 

--- a/atom/utils/tbo/ubatch_splitting.py
+++ b/atom/utils/tbo/ubatch_splitting.py
@@ -5,8 +5,10 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
+import numpy as np
 import torch
 
+from atom.utils import envs
 from atom.utils.forward_context import AttentionMetaData
 
 logger = logging.getLogger("atom")
@@ -40,11 +42,27 @@ def maybe_create_ubatch_slices(
     if num_ubatches <= 1:
         return None
 
-    if num_reqs < num_ubatches:
+    # Token-midpoint prefill split can cut *inside* a request, so it works
+    # even with a single request (bs=1) — only require that there are at
+    # least `num_ubatches` tokens to go around. The request-boundary path
+    # below still needs num_reqs >= num_ubatches.
+    token_split = (
+        num_scheduled_tokens is not None and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
+    )
+    if not token_split and num_reqs < num_ubatches:
         return None
 
     if num_scheduled_tokens is not None:
         # Prefill: token-balanced split
+        if token_split:
+            if num_tokens < num_ubatches:
+                return None
+            return _split_prefill_token_midpoint(
+                num_reqs,
+                num_scheduled_tokens,
+                num_ubatches,
+                max_tokens_per_ubatch,
+            )
         return _split_prefill_balanced(
             num_reqs,
             num_scheduled_tokens,
@@ -128,6 +146,59 @@ def _split_prefill_balanced(
     ]
 
 
+def _split_prefill_token_midpoint(
+    num_reqs: int,
+    num_scheduled_tokens: list[int],
+    num_ubatches: int,
+    max_tokens_per_ubatch: Optional[int],
+) -> Optional[list[UBatchSlice]]:
+    """split prefill at the exact token midpoint.
+
+    """
+    toks = np.asarray(num_scheduled_tokens[:num_reqs], dtype=np.int64)
+    total_tokens = int(toks.sum())
+    # Exclusive-prefix cumulative token offsets: cu[i] = first token of req i.
+    cu = np.zeros(num_reqs + 1, dtype=np.int64)
+    np.cumsum(toks, out=cu[1:])
+
+    # Token split points at exact fractions of the total.
+    split_points = [
+        (total_tokens * i) // num_ubatches for i in range(1, num_ubatches)
+    ]
+
+    slices: list[UBatchSlice] = []
+    tok_start = 0
+    for tok_end in split_points + [total_tokens]:
+        if tok_end <= tok_start:
+            # Degenerate (e.g. total_tokens < num_ubatches) — bail out and
+            # let the caller fall back to no-split.
+            return None
+        # Requests overlapping [tok_start, tok_end):
+        #   first req = the one containing tok_start
+        #   last req  = the one containing tok_end - 1
+        req_start = int(np.searchsorted(cu, tok_start, side="right") - 1)
+        req_stop = int(np.searchsorted(cu, tok_end - 1, side="right"))
+        slices.append(
+            UBatchSlice(
+                request_slice=slice(req_start, req_stop),
+                token_slice=slice(tok_start, tok_end),
+            )
+        )
+        tok_start = tok_end
+
+    if max_tokens_per_ubatch is not None:
+        for s in slices:
+            if (s.token_slice.stop - s.token_slice.start) > max_tokens_per_ubatch:
+                logger.info(
+                    "[TBO] token-midpoint split rejected: ubatch tokens "
+                    "exceed buffer %s",
+                    max_tokens_per_ubatch,
+                )
+                return None
+
+    return slices
+
+
 def split_attn_metadata(
     attn_metadata: AttentionMetaData,
     ub_slice: UBatchSlice,
@@ -140,13 +211,13 @@ def split_attn_metadata(
     req_end = rs.stop
     ub_num_reqs = req_end - req_start
 
-    # cu_seqlens_q: need to re-base so it starts from 0
     ub_cu_seqlens_q = None
     if attn_metadata.cu_seqlens_q is not None:
         orig_cu = attn_metadata.cu_seqlens_q
-        # Take [req_start : req_end + 1] and subtract the base offset
-        base_offset = orig_cu[req_start]
-        ub_cu_seqlens_q = orig_cu[req_start : req_end + 1] - base_offset
+        seg = orig_cu[req_start : req_end + 1]
+        # clamp absolute token offsets to [ts.start, ts.stop], then re-base
+        clamped = torch.clamp(seg, min=ts.start, max=ts.stop)
+        ub_cu_seqlens_q = clamped - clamped[0]
         # Pad remaining entries up to padded_bs + 1
         if padded_bs > ub_num_reqs:
             last_val = ub_cu_seqlens_q[-1]
@@ -272,8 +343,12 @@ def split_attn_metadata(
     ub_cu_seqlens_k = None
     if attn_metadata.cu_seqlens_k is not None:
         orig_cu_k = attn_metadata.cu_seqlens_k
-        base_offset_k = orig_cu_k[req_start]
-        ub_cu_seqlens_k = orig_cu_k[req_start : req_end + 1] - base_offset_k
+        seg_k = orig_cu_k[req_start : req_end + 1]
+        if not getattr(attn_metadata, "has_cached", False):
+            clamped_k = torch.clamp(seg_k, min=ts.start, max=ts.stop)
+            ub_cu_seqlens_k = clamped_k - clamped_k[0]
+        else:
+            ub_cu_seqlens_k = seg_k - seg_k[0]
         if padded_bs > ub_num_reqs:
             last_val = ub_cu_seqlens_k[-1]
             pad_size = padded_bs - ub_num_reqs

--- a/atom/utils/tbo/ubatch_splitting.py
+++ b/atom/utils/tbo/ubatch_splitting.py
@@ -14,34 +14,6 @@ from atom.utils.forward_context import AttentionMetaData
 logger = logging.getLogger("atom")
 
 
-def _token_split_supported() -> bool:
-    """Whether the active attention backend can serve a straddled request's
-    first half from the paged KV cache, which the token-midpoint split requires.
-
-    Only MLA (DeepSeek-R1 / V2 / V3) and DeepSeek-V4 are supported today; dense
-    MHA backends (e.g. GPT-OSS) fall back to the request-boundary split. Remove
-    this gate once MHA straddle gather is fixed.
-    """
-    try:
-        from atom.config import get_current_atom_config
-
-        hf = get_current_atom_config().hf_config
-        model_type = getattr(hf, "model_type", "") or ""
-        arches = getattr(hf, "architectures", None) or []
-        is_v4 = any("DeepseekV4" in str(a) for a in arches)
-        is_mla = model_type in (
-            "deepseek_v2",
-            "deepseek_v3",
-            "deepseek_mtp",
-            "kimi_k2",
-            "glm_moe_dsa",
-        )
-        return bool(is_v4 or is_mla)
-    except Exception:
-        # If we can't determine the backend, be safe: no token-split.
-        return False
-
-
 @dataclass
 class UBatchSlice:
     """Describes which portion of a batch belongs to a micro-batch."""
@@ -74,11 +46,7 @@ def maybe_create_ubatch_slices(
     # even with a single request (bs=1) — only require that there are at
     # least `num_ubatches` tokens to go around. The request-boundary path
     # below still needs num_reqs >= num_ubatches.
-    token_split = (
-        num_scheduled_tokens is not None
-        and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
-        and _token_split_supported()
-    )
+    token_split = num_scheduled_tokens is not None and envs.ATOM_TBO_PREFILL_TOKEN_SPLIT
     if not token_split and num_reqs < num_ubatches:
         return None
 

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -46,6 +46,23 @@ def local_tbo_precompute(
         return False, 0, 0
     if is_prefill:
         n_pref = batch.total_seqs_num_prefill
+        # token-midpoint split: cut at exact total//2 even
+        # inside a request, so bs==1 can still split. MUST mirror
+        # `_split_prefill_token_midpoint` in ubatch_splitting.py exactly, or
+        # the cross-DP MAX-reduced ub0/ub1 will disagree with the realised
+        # slices → all_gather size mismatch → RCCL hang.
+        from atom.utils import envs
+
+        if envs.ATOM_TBO_PREFILL_TOKEN_SPLIT:
+            if n_pref < 1:
+                return False, 0, 0
+            toks = np.asarray(num_scheduled_tokens[:n_pref], dtype=np.int64)
+            total = int(toks.sum())
+            if total < 2:
+                return False, 0, 0
+            ub0 = total // 2
+            ub1 = total - ub0
+            return True, ub0, ub1
         if n_pref < 2:
             return False, 0, 0
         # Mirror _split_prefill_balanced: pick boundary closest to total/2

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -125,6 +125,7 @@ def sync_dp_for_tbo(
     tbo_on: bool,
     local_tbo_eligible: bool = False,
     local_ub_tokens: tuple[int, int] = (0, 0),
+    require_uniform_mode: bool = False,
 ) -> DPSyncResult:
     """Single packed DP all_gather over the per-rank scalars needed to
     decide DP padding, the prefill fan-out, and the cross-DP TBO gate.
@@ -165,6 +166,12 @@ def sync_dp_for_tbo(
     ub_max_tokens_across_dp: Optional[tuple[int, int]] = None
     if tbo_on:
         tbo_collective_active = bool(sync[2].all().item())
+        # Mixed-mode guard — only needed when `require_uniform_mode` is set
+        # (i.e. prefill token-split + TBO decode, see call site).
+        if tbo_collective_active and require_uniform_mode:
+            prefill_rank_count = int(sync[1].sum().item())
+            uniform_mode = prefill_rank_count == 0 or prefill_rank_count == dp_size
+            tbo_collective_active = uniform_mode
         if tbo_collective_active:
             ub_max_tokens_across_dp = (
                 int(sync[3].max().item()),

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -161,21 +161,21 @@ def sync_dp_for_tbo(
     sync = torch.stack(gathered, dim=1)  # [n_fields, dp_size]
 
     num_tokens_across_dp = sync[0]
-    any_rank_has_prefill = bool(sync[1].any().item())
+    any_rank_has_prefill = bool(sync[1].any())
     tbo_collective_active = False
     ub_max_tokens_across_dp: Optional[tuple[int, int]] = None
     if tbo_on:
-        tbo_collective_active = bool(sync[2].all().item())
+        tbo_collective_active = bool(sync[2].all())
         # Mixed-mode guard — only needed when `require_uniform_mode` is set
         # (i.e. prefill token-split + TBO decode, see call site).
         if tbo_collective_active and require_uniform_mode:
-            prefill_rank_count = int(sync[1].sum().item())
+            prefill_rank_count = int(sync[1].sum())
             uniform_mode = prefill_rank_count == 0 or prefill_rank_count == dp_size
             tbo_collective_active = uniform_mode
         if tbo_collective_active:
             ub_max_tokens_across_dp = (
-                int(sync[3].max().item()),
-                int(sync[4].max().item()),
+                int(sync[3].max()),
+                int(sync[4].max()),
             )
 
     return DPSyncResult(

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -52,8 +52,11 @@ def local_tbo_precompute(
         # the cross-DP MAX-reduced ub0/ub1 will disagree with the realised
         # slices → all_gather size mismatch → RCCL hang.
         from atom.utils import envs
+        from atom.utils.tbo.ubatch_splitting import _token_split_supported
 
-        if envs.ATOM_TBO_PREFILL_TOKEN_SPLIT:
+        # MUST mirror maybe_create_ubatch_slices' gating exactly, or the
+        # cross-DP MAX-reduced ub0/ub1 disagree with the realised slices → hang.
+        if envs.ATOM_TBO_PREFILL_TOKEN_SPLIT and _token_split_supported():
             if n_pref < 1:
                 return False, 0, 0
             toks = np.asarray(num_scheduled_tokens[:n_pref], dtype=np.int64)

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -52,11 +52,10 @@ def local_tbo_precompute(
         # the cross-DP MAX-reduced ub0/ub1 will disagree with the realised
         # slices → all_gather size mismatch → RCCL hang.
         from atom.utils import envs
-        from atom.utils.tbo.ubatch_splitting import _token_split_supported
 
         # MUST mirror maybe_create_ubatch_slices' gating exactly, or the
         # cross-DP MAX-reduced ub0/ub1 disagree with the realised slices → hang.
-        if envs.ATOM_TBO_PREFILL_TOKEN_SPLIT and _token_split_supported():
+        if envs.ATOM_TBO_PREFILL_TOKEN_SPLIT:
             if n_pref < 1:
                 return False, 0, 0
             toks = np.asarray(num_scheduled_tokens[:n_pref], dtype=np.int64)


### PR DESCRIPTION
Add atom tbo split token to split prefill ubatches at the exact token midpoint, cutting through a request if the midpoint falls inside one. Guarantees perfectly balanced 50/50 ubatches under length jitter, where the request-boundary split can leave up to ~20% imbalance.

previous TBO:
[bs=3 tok=16384 ctx=[7003, 7620, 2453]]  -> TBO will get [7003] and [7620, 2453] two ubatch

after:
[bs=3 tok=16384 ctx=[7003, 7620, 2453]]  -> TBO will get [8196] and [8196] two ubatch

### split token to prefill ubatches in TBO has supported default and validate on Deepseek V4, R1, gpt-oss




### Performance (DeepSeek-V4-Pro, DP=8, ratio 0.8, in=8192 out=1024)
Deepseek V4
TOKEN_SPLIT + TBO + DP vs DP:

  | batch-size | Total Token throughput (tok/s) | improvement |
  |------------|-------------------------------:|------------:|
  | 256        | 28,199.95                      | +4.2%       |
  | 512        | 35,957.06                      | +6.4%       |
  | 1024       | 49,033.16                      | +15.1%      |
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
