### PR TITLE
[Feat] Support GLM5 in SGLang plugin

### DIFF
--- a/atom/plugin/register.py
+++ b/atom/plugin/register.py
@@ -3,7 +3,7 @@ import logging
 from atom.models.qwen3 import Qwen3ForCausalLM
 from atom.models.qwen3_moe import Qwen3MoeForCausalLM
 from atom.models.glm4_moe import Glm4MoeForCausalLM
-from atom.models.deepseek_v2 import DeepseekV3ForCausalLM
+from atom.models.deepseek_v2 import DeepseekV3ForCausalLM, GlmMoeDsaForCausalLM
 from atom.models.minimax_m2 import MiniMaxM2ForCausalLM
 from atom.config import Config
 from atom.plugin.prepare import is_vllm, is_sglang
@@ -15,6 +15,7 @@ _ATOM_SUPPORTED_MODELS = {
     "Qwen3MoeForCausalLM": Qwen3MoeForCausalLM,
     "Glm4MoeForCausalLM": Glm4MoeForCausalLM,
     "DeepseekV3ForCausalLM": DeepseekV3ForCausalLM,
+    "GlmMoeDsaForCausalLM": GlmMoeDsaForCausalLM,
     "MiniMaxM2ForCausalLM": MiniMaxM2ForCausalLM,
 }
 

--- a/atom/plugin/sglang/prepare.py
+++ b/atom/plugin/sglang/prepare.py
@@ -8,6 +8,25 @@ from atom.plugin.prepare import _set_framework_backbone
 logger = logging.getLogger("atom")
 
 
+def _remap_quant_config_for_sglang_plugin(atom_config: Any, model_cls: type) -> None:
+    quant_config = getattr(atom_config, "quant_config", None)
+    if quant_config is None:
+        return
+
+    quant_config.remap_layer_name(
+        atom_config.hf_config,
+        packed_modules_mapping=getattr(model_cls, "packed_modules_mapping", {}),
+        weights_mapper=getattr(model_cls, "hf_to_atom_mapper", {}),
+        quant_exclude_name_mapping=getattr(
+            model_cls, "quant_exclude_name_mapping", {}
+        ),
+    )
+
+    default_excludes = getattr(model_cls, "quant_default_exclude_layers", [])
+    if default_excludes:
+        quant_config.apply_default_exclude_layers(default_excludes)
+
+
 def prepare_model(config: Any):
     """Prepare an ATOM model for SGLang plugin mode."""
     logger.info("Prepare model for plugin mode, the upper engine is sglang")
@@ -42,6 +61,8 @@ def prepare_model(config: Any):
     model_adapter = get_model_arch_spec(model_arch)
     if model_adapter.prepare_config is not None:
         model_adapter.prepare_config(atom_config, model_arch)
+    else:
+        _remap_quant_config_for_sglang_plugin(atom_config, model_cls)
 
     register_ops_to_sglang(atom_config=atom_config)
     set_attn_cls()

--- a/atom/plugin/sglang/prepare.py
+++ b/atom/plugin/sglang/prepare.py
@@ -17,9 +17,7 @@ def _remap_quant_config_for_sglang_plugin(atom_config: Any, model_cls: type) -> 
         atom_config.hf_config,
         packed_modules_mapping=getattr(model_cls, "packed_modules_mapping", {}),
         weights_mapper=getattr(model_cls, "hf_to_atom_mapper", {}),
-        quant_exclude_name_mapping=getattr(
-            model_cls, "quant_exclude_name_mapping", {}
-        ),
+        quant_exclude_name_mapping=getattr(model_cls, "quant_exclude_name_mapping", {}),
     )
 
     default_excludes = getattr(model_cls, "quant_default_exclude_layers", [])

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -36,6 +36,9 @@ MODEL_ADAPTER_SPECS = {
     "DeepseekV3ForCausalLM": SGLangModelAdapterSpec(
         install_adapters=_install_deepseek_mla_adapters,
     ),
+    "GlmMoeDsaForCausalLM": SGLangModelAdapterSpec(
+        install_adapters=_install_deepseek_mla_adapters,
+    ),
     "Qwen3MoeForCausalLM": SGLangModelAdapterSpec(),
     "Qwen3NextForCausalLM": SGLangModelAdapterSpec(
         wrapper_binds_gdn_context=True,
@@ -55,6 +58,7 @@ MODEL_ARCH_SPECS = {
     key: MODEL_ADAPTER_SPECS[key]
     for key in (
         "DeepseekV3ForCausalLM",
+        "GlmMoeDsaForCausalLM",
         "Qwen3MoeForCausalLM",
         "Qwen3NextForCausalLM",
     )

--- a/recipes/atom_sglang/DeepSeek-V3.2.md
+++ b/recipes/atom_sglang/DeepSeek-V3.2.md
@@ -1,0 +1,119 @@
+# DeepSeek-V3.2 with ATOM SGLang Backend
+
+This recipe shows how to run `deepseek-ai/DeepSeek-V3.2` with the SGLang-ATOM backend. For background on the SGLang-ATOM integration, see [Introduce ATOM as external model package of SGLang](https://github.com/ROCm/ATOM/issues/359).
+
+## Step 1: Pull the SGLang-ATOM Docker
+
+```bash
+docker pull rocm/atom-dev:sglang-latest
+```
+
+Launch a container from this image and run the remaining commands inside the container.
+
+## Step 2: Launch SGLang-ATOM Server
+
+The SGLang-ATOM backend keeps the standard SGLang CLI, server APIs, and general usage flow compatible with upstream SGLang. For general server options and API usage, users can refer to the [official SGLang documentation](https://docs.sglang.ai/).
+
+Before launching the server, export the SGLang-ATOM settings used by the benchmark workflow:
+
+```bash
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
+export SGLANG_AITER_FP8_PREFILL_ATTN=0
+export SGLANG_USE_AITER=1
+export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
+# Introduce ATOM as external model package of SGLang
+export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
+export SGLANG_ENABLE_TORCH_COMPILE=1
+```
+
+### DeepSeek-V3.2 with BF16 KV Cache (TP=4)
+
+```bash
+TP=4
+
+TORCHINDUCTOR_COMPILE_THREADS=128 \
+python3 -m sglang.launch_server \
+    --model-path deepseek-ai/DeepSeek-V3.2 \
+    --host localhost \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size "${TP}" \
+    --attention-backend aiter \
+    --mem-fraction-static 0.8 \
+    --disable-radix-cache
+```
+
+### DeepSeek-V3.2 with FP8 KV Cache (TP=4)
+
+```bash
+TP=4
+
+TORCHINDUCTOR_COMPILE_THREADS=128 \
+python3 -m sglang.launch_server \
+    --model-path deepseek-ai/DeepSeek-V3.2 \
+    --host localhost \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size "${TP}" \
+    --attention-backend aiter \
+    --kv-cache-dtype fp8_e4m3 \
+    --mem-fraction-static 0.8 \
+    --disable-radix-cache
+```
+
+For an 8-GPU run, set `TP=8` and expose the target GPUs with `CUDA_VISIBLE_DEVICES`.
+
+## Step 3: Performance Benchmark
+
+The SGLang benchmark workflow uses the `bench_serving` client for performance benchmarking.
+
+```bash
+git clone --depth 1 https://github.com/kimbochen/bench_serving.git /tmp/bench_serving
+
+ISL=8192
+OSL=1024
+CONC=64
+RANDOM_RANGE_RATIO=0.8
+RESULT_DIR=./benchmark-results
+RESULT_FILENAME=deepseek-v3.2-sglang-tp${TP}-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}.json
+
+python3 /tmp/bench_serving/benchmark_serving.py \
+    --model=deepseek-ai/DeepSeek-V3.2 \
+    --backend=sglang \
+    --base-url=http://127.0.0.1:8000 \
+    --dataset-name=random \
+    --random-input-len="${ISL}" \
+    --random-output-len="${OSL}" \
+    --random-range-ratio "${RANDOM_RANGE_RATIO}" \
+    --num-prompts="$(( CONC * 10 ))" \
+    --max-concurrency="${CONC}" \
+    --trust-remote-code \
+    --num-warmups="$(( 2 * CONC ))" \
+    --request-rate=inf \
+    --ignore-eos \
+    --save-result \
+    --percentile-metrics="ttft,tpot,itl,e2el" \
+    --result-dir="${RESULT_DIR}" \
+    --result-filename="${RESULT_FILENAME}"
+```
+
+### Optional: Enable Profiling
+
+If you want to collect profiling trace, set the SGLang profiling environment variables before launching the server, and add `--profile` to the benchmark client command.
+
+```bash
+export SGLANG_PROFILE_RECORD_SHAPES=1
+export SGLANG_PROFILE_WITH_STACK=1
+export SGLANG_TORCH_PROFILER_DIR=./profile_sglang/
+```
+
+Then append `--profile` to the `benchmark_serving.py` command in Step 3.
+
+## Step 4: Accuracy Validation
+
+```bash
+lm_eval --model local-completions \
+        --model_args model=deepseek-ai/DeepSeek-V3.2,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=1,max_gen_toks=512,tokenized_requests=False,trust_remote_code=True \
+        --tasks gsm8k \
+        --num_fewshot 5
+```

--- a/recipes/atom_sglang/GLM-5.md
+++ b/recipes/atom_sglang/GLM-5.md
@@ -1,0 +1,106 @@
+# GLM-5 with ATOM SGLang Backend
+
+This recipe shows how to run `zai-org/GLM-5-FP8` with the SGLang-ATOM backend. GLM-5 uses sparse MLA and is architecturally similar to DeepSeek-V3.2; in the SGLang-ATOM plugin it is exposed through `GlmMoeDsaForCausalLM`.
+
+## Step 1: Pull the SGLang-ATOM Docker
+
+```bash
+docker pull rocm/atom-dev:sglang-latest
+```
+
+Launch a container from this image and run the remaining commands inside the container.
+
+## Step 2: Launch SGLang-ATOM Server
+
+The SGLang-ATOM backend keeps the standard SGLang CLI, server APIs, and general usage flow compatible with upstream SGLang. For general server options and API usage, users can refer to the [official SGLang documentation](https://docs.sglang.ai/).
+
+Before launching the server, export the SGLang-ATOM settings used by the benchmark workflow:
+
+```bash
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
+export SGLANG_AITER_FP8_PREFILL_ATTN=0
+export SGLANG_USE_AITER=1
+export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
+# Introduce ATOM as external model package of SGLang
+export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
+export SGLANG_ENABLE_TORCH_COMPILE=1
+```
+
+### GLM-5 FP8 (TP=4)
+
+```bash
+TP=4
+PORT=9000
+
+TORCHINDUCTOR_COMPILE_THREADS=128 \
+python3 -m sglang.launch_server \
+    --model-path zai-org/GLM-5-FP8 \
+    --host localhost \
+    --port "${PORT}" \
+    --trust-remote-code \
+    --tensor-parallel-size "${TP}" \
+    --attention-backend aiter \
+    --kv-cache-dtype fp8_e4m3 \
+    --mem-fraction-static 0.8 \
+    --page-size 1 \
+    --disable-radix-cache \
+```
+
+For an 8-GPU run, set `TP=8` and expose the target GPUs with `CUDA_VISIBLE_DEVICES`.
+
+## Step 3: Performance Benchmark
+
+The SGLang benchmark workflow uses the `bench_serving` client for performance benchmarking.
+
+```bash
+git clone --depth 1 https://github.com/kimbochen/bench_serving.git /tmp/bench_serving
+
+ISL=1024
+OSL=1024
+CONC=64
+RANDOM_RANGE_RATIO=1.0
+RESULT_DIR=./benchmark-results
+RESULT_FILENAME=glm-5-sglang-tp${TP}-${ISL}-${OSL}-${CONC}-${RANDOM_RANGE_RATIO}.json
+
+python3 /tmp/bench_serving/benchmark_serving.py \
+    --model=zai-org/GLM-5-FP8 \
+    --backend=sglang \
+    --base-url=http://127.0.0.1:${PORT} \
+    --dataset-name=random \
+    --random-input-len="${ISL}" \
+    --random-output-len="${OSL}" \
+    --random-range-ratio "${RANDOM_RANGE_RATIO}" \
+    --num-prompts="$(( CONC * 10 ))" \
+    --max-concurrency="${CONC}" \
+    --trust-remote-code \
+    --num-warmups="$(( 2 * CONC ))" \
+    --request-rate=inf \
+    --ignore-eos \
+    --save-result \
+    --percentile-metrics="ttft,tpot,itl,e2el" \
+    --result-dir="${RESULT_DIR}" \
+    --result-filename="${RESULT_FILENAME}"
+```
+
+### Optional: Enable Profiling
+
+If you want to collect profiling trace, set the SGLang profiling environment variables before launching the server, and add `--profile` to the benchmark client command.
+
+```bash
+export SGLANG_PROFILE_RECORD_SHAPES=1
+export SGLANG_PROFILE_WITH_STACK=1
+export SGLANG_TORCH_PROFILER_DIR=./profile_sglang/
+```
+
+Then append `--profile` to the `benchmark_serving.py` command in Step 3.
+
+## Step 4: Accuracy Validation
+
+The sparse MLA mechanism contains an indexer that selects the top-k tokens it deems most relevant for each query from the KV cache. To evaluate this path, use requests with context longer than the selected top-k window when possible.
+
+```bash
+lm_eval --model local-completions \
+        --model_args model=zai-org/GLM-5-FP8,base_url=http://localhost:${PORT}/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True \
+        --tasks gsm8k \
+        --num_fewshot 20
+```

--- a/tests/plugin/test_sglang_model_wrapper.py
+++ b/tests/plugin/test_sglang_model_wrapper.py
@@ -213,6 +213,30 @@ def test_deepseek_wrapper_sets_and_clears_forward_batch_context(monkeypatch):
     assert module.get_current_forward_batch() is None
 
 
+def test_glm_dsa_wrapper_is_registered_with_deepseek_adapter(monkeypatch):
+    """GLM5 should be discoverable by SGLang and reuse the DeepSeek MLA adapter."""
+    fake_model = MagicMock(return_value="hidden_states")
+    fake_model.lm_head = object()
+    setup_hook = MagicMock()
+
+    module, patcher = _import_wrapper_module(
+        monkeypatch,
+        fake_model,
+        is_last_rank=False,
+        setup_hook=setup_hook,
+    )
+    try:
+        wrapper = module.GlmMoeDsaForCausalLM(
+            _Obj(vocab_size=154880, architectures=["GlmMoeDsaForCausalLM"])
+        )
+    finally:
+        patcher.stop()
+
+    assert wrapper.model is fake_model
+    assert module.GlmMoeDsaForCausalLM in module.EntryClass
+    setup_hook.assert_called_once_with(fake_model)
+
+
 def test_deepseek_wrapper_resets_forward_batch_context_on_exception(monkeypatch):
     """DeepSeek ContextVar should not leak across failed forwards."""
     fake_model = MagicMock(side_effect=RuntimeError("boom"))

--- a/tests/plugin/test_sglang_prepare_hooks.py
+++ b/tests/plugin/test_sglang_prepare_hooks.py
@@ -67,6 +67,7 @@ def _reset_framework_state():
         "Qwen3_5MoeForConditionalGeneration",
         "Qwen3NextForCausalLM",
         "DeepseekV3ForCausalLM",
+        "GlmMoeDsaForCausalLM",
         "Qwen3MoeForCausalLM",
     ),
 )

--- a/tests/plugin/test_sglang_prepare_model.py
+++ b/tests/plugin/test_sglang_prepare_model.py
@@ -124,6 +124,58 @@ def test_prepare_model_sglang_happy_path():
     assert result is fake_model
 
 
+def test_prepare_model_remaps_quant_config_for_generic_wrapper():
+    fake_quant_config = MagicMock()
+    fake_atom_config = _Obj(
+        hf_config=_Obj(model_type="glm_moe_dsa"),
+        plugin_config=_Obj(is_plugin_mode=True),
+        quant_config=fake_quant_config,
+    )
+    fake_model = MagicMock(name="FakeGlmModel")
+    fake_model_cls = MagicMock(return_value=fake_model)
+    fake_model_cls.packed_modules_mapping = {"gate_proj": ("gate_up_proj", 0)}
+    fake_model_cls.hf_to_atom_mapper = object()
+    fake_model_cls.quant_exclude_name_mapping = {
+        "indexers_proj": "indexer.weights_proj",
+    }
+    fake_model_cls.quant_default_exclude_layers = ["*.indexer.weights_proj"]
+
+    fake_register = _make_fake_register_module(
+        model_dict={"GlmMoeDsaForCausalLM": fake_model_cls}
+    )
+    fake_runtime = _make_fake_runtime_module()
+    fake_config_mod = MagicMock()
+    fake_config_mod.generate_atom_config_for_plugin_mode = MagicMock(
+        return_value=fake_atom_config
+    )
+
+    with patch.dict(
+        sys.modules,
+        {
+            "atom.plugin.register": fake_register,
+            "atom.plugin.config": fake_config_mod,
+            "atom.plugin.sglang.runtime": fake_runtime,
+            "atom.plugin.sglang.graph_capture_patch": MagicMock(
+                apply_graph_capture_patch=MagicMock()
+            ),
+        },
+    ):
+        config = _Obj(architectures=["GlmMoeDsaForCausalLM"])
+        result = sglang_prepare.prepare_model(config=config)
+
+    fake_quant_config.remap_layer_name.assert_called_once_with(
+        fake_atom_config.hf_config,
+        packed_modules_mapping=fake_model_cls.packed_modules_mapping,
+        weights_mapper=fake_model_cls.hf_to_atom_mapper,
+        quant_exclude_name_mapping=fake_model_cls.quant_exclude_name_mapping,
+    )
+    fake_quant_config.apply_default_exclude_layers.assert_called_once_with(
+        fake_model_cls.quant_default_exclude_layers
+    )
+    fake_model_cls.assert_called_once_with(atom_config=fake_atom_config)
+    assert result is fake_model
+
+
 def test_prepare_model_selects_sglang_dict_for_deepseek_v2():
     """Verify that sglang engine uses _ATOM_SUPPORTED_MODELS (has DeepSeekV2)."""
     fake_atom_config = _Obj(plugin_config=_Obj(is_plugin_mode=True))

--- a/tests/plugin/test_sglang_register.py
+++ b/tests/plugin/test_sglang_register.py
@@ -345,6 +345,9 @@ def test_register_custom_attention_uses_aiter_name():
     fake_modules["atom.models.deepseek_v2"].DeepseekV3ForCausalLM = type(
         "DeepseekV3ForCausalLM", (), {}
     )
+    fake_modules["atom.models.deepseek_v2"].GlmMoeDsaForCausalLM = type(
+        "GlmMoeDsaForCausalLM", (), {}
+    )
     fake_modules["atom.models.minimax_m2"].MiniMaxM2ForCausalLM = type(
         "MiniMaxM2ForCausalLM", (), {}
     )


### PR DESCRIPTION
## Motivation

Add SGLang-ATOM recipe coverage for DeepSeek-V3.2 and GLM-5 so users can launch, benchmark, and validate these sparse MLA models with the plugin backend more easily.

## Technical Details
- Added recipes/atom_sglang/DeepSeek-V3.2.md with SGLang-ATOM Docker setup, required environment variables, BF16/FP8 KV cache launch examples, benchmark command, profiling notes, and GSM8K validation.
- Added recipes/atom_sglang/GLM-5.md with GLM-5 FP8 launch settings aligned with the SGLang plugin path, including AITER backend flags, FP8 KV cache, chunked prefill limits, benchmark command, profiling notes, and accuracy validation.
- Support GLM-5 SGLang plugin, add GLM5 architecture registration, preparation hooks, and related tests.

## Test Plan
**server:**
```
export SGLANG_USE_AITER=1
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1

model_path=/shared/data/amd_int/models/GLM-5-FP8

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models

TORCHINDUCTOR_COMPILE_THREADS=128 python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 9000 \
    --trust-remote-code \
    --tp-size 4 \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.85 \
    --page-size 1 \
    --disable-radix-cache \
    --attention-backend aiter \
    --max-running-requests 128 \
    --chunked-prefill-size 16384 \
    --max-prefill-tokens 16384 \
```

## Test Result
**accuracy:**
<img width="780" height="122" alt="image" src="https://github.com/user-attachments/assets/c29ae33c-8d5c-47e0-a352-d9db7d053c5a" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
