### PR TITLE
fix: check slot_mapping none for dummy execution

### DIFF
--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -283,6 +283,12 @@ class ForwardMode:
         """
         if self.is_prefill or self.attn_tensors_are_padded:
             return
+        if (
+            input_ids is None
+            or attn_metadata is None
+            or attn_metadata.slot_mapping is None
+        ):
+            return
         max_q = attn_metadata.max_seqlen_q
         expected = self.effective_bs * max_q
         actual_in = input_ids.shape[0]


### PR DESCRIPTION
## Motivation

dummy execution has no slot_mapping in attn_metadata. Check None to early return.

## Technical Details



## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
