### PR TITLE
fix: add kv_transfer_params support to /v1/chat/completions for PD di…

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -839,6 +839,7 @@ async def chat_completions(request: ChatCompletionRequest):
                     sampling_params,
                     request_id,
                     multimodal_data=stream_multimodal_data,
+                    kv_transfer_params=request.kv_transfer_params,
                 )
                 gen = stream_chat_response_fanout(
                     request_id,
@@ -855,6 +856,7 @@ async def chat_completions(request: ChatCompletionRequest):
                     sampling_params,
                     request_id,
                     multimodal_data=stream_multimodal_data,
+                    kv_transfer_params=request.kv_transfer_params,
                 )
                 gen = stream_chat_response(
                     request_id,
@@ -877,6 +879,7 @@ async def chat_completions(request: ChatCompletionRequest):
                 sampling_params,
                 request_id,
                 multimodal_data=multimodal_data,
+                kv_transfer_params=request.kv_transfer_params,
             )
             if not outputs:
                 raise RuntimeError("No output generated")
@@ -896,13 +899,23 @@ async def chat_completions(request: ChatCompletionRequest):
                 request_id, model_name, final_output["text"], final_output
             )
         elif effective_n > 1:
-            outputs = await generate_async_fanout(prompt, sampling_params, request_id)
+            outputs = await generate_async_fanout(
+                prompt,
+                sampling_params,
+                request_id,
+                kv_transfer_params=request.kv_transfer_params,
+            )
             if not outputs:
                 raise RuntimeError("No output generated")
             resp = build_chat_response_multi(request_id, model_name, outputs)
         else:
             final_output = None
-            async for output in generate_async(prompt, sampling_params, request_id):
+            async for output in generate_async(
+                prompt,
+                sampling_params,
+                request_id,
+                kv_transfer_params=request.kv_transfer_params,
+            ):
                 final_output = output
             if final_output is None:
                 raise RuntimeError("No output generated")

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -89,6 +89,8 @@ class ChatCompletionRequest(BaseModel):
     presence_penalty: Optional[float] = 0.0
     frequency_penalty: Optional[float] = 0.0
     n: Optional[int] = 1
+    # Optional KV-transfer metadata for P/D disaggregation.
+    kv_transfer_params: Optional[Dict[str, Any]] = None
 
     def get_messages(self) -> List[ChatMessage]:
         """Get messages from either 'messages' or 'prompt' field."""
@@ -133,6 +135,7 @@ class ChatCompletionResponse(BaseModel):
     model: str
     choices: List[Dict[str, Any]]
     usage: Dict[str, Any]
+    kv_transfer_params: Optional[Dict[str, Any]] = None
 
     model_config = ConfigDict(extra="allow")
 

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -83,10 +83,15 @@ async def stream_chat_response(
     # Send initial role chunk
     yield create_chat_chunk(request_id, model, delta={"role": "assistant"})
 
+    kv_transfer_params_value = None
+
     while True:
         chunk_data = await stream_queue.get()
         new_text = chunk_data["text"]
         num_tokens_output += len(chunk_data.get("token_ids", []))
+
+        if "kv_transfer_params" in chunk_data:
+            kv_transfer_params_value = chunk_data["kv_transfer_params"]
 
         # Phase 1: Process through reasoning filter
         segments = reasoning_filter.process(new_text)
@@ -155,6 +160,8 @@ async def stream_chat_response(
         "model": model,
         "usage": usage,
     }
+    if kv_transfer_params_value is not None:
+        usage_chunk["kv_transfer_params"] = kv_transfer_params_value
     yield f"data: {json.dumps(usage_chunk)}\n\n"
     yield STREAM_DONE_MESSAGE
 
@@ -194,7 +201,7 @@ def build_chat_response(
     final_output: Dict[str, Any],
 ) -> ChatCompletionResponse:
     """Build a non-streaming chat completion response (single choice)."""
-    return ChatCompletionResponse(
+    response = ChatCompletionResponse(
         id=request_id,
         created=int(time.time()),
         model=model,
@@ -209,6 +216,13 @@ def build_chat_response(
             "latency_s": round(final_output.get("latency", 0.0), 4),
         },
     )
+    if "kv_transfer_output_meta_info" in final_output:
+        response = response.model_copy(
+            update={
+                "kv_transfer_params": final_output["kv_transfer_output_meta_info"],
+            }
+        )
+    return response
 
 
 def build_chat_response_multi(
@@ -277,6 +291,7 @@ async def stream_chat_response_fanout(
     tool_parsers = [ToolCallStreamParser() for _ in range(n)]
     has_tool_calls = [False] * n
     finished = [False] * n
+    kv_transfer_params_value = None
 
     for i in range(n):
         yield create_chat_chunk(request_id, model, delta={"role": "assistant"}, index=i)
@@ -288,6 +303,9 @@ async def stream_chat_response_fanout(
             continue
         new_text = chunk_data["text"]
         num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
+
+        if "kv_transfer_params" in chunk_data:
+            kv_transfer_params_value = chunk_data["kv_transfer_params"]
 
         segments = reasoning_filters[idx].process(new_text)
         if chunk_data.get("finished", False):
@@ -368,5 +386,7 @@ async def stream_chat_response_fanout(
         "model": model,
         "usage": usage,
     }
+    if kv_transfer_params_value is not None:
+        usage_chunk["kv_transfer_params"] = kv_transfer_params_value
     yield f"data: {json.dumps(usage_chunk)}\n\n"
     yield STREAM_DONE_MESSAGE

--- a/tests/entrypoints/test_protocol.py
+++ b/tests/entrypoints/test_protocol.py
@@ -185,6 +185,22 @@ class TestChatCompletionRequest:
         )
         assert req.n == 4
 
+    def test_kv_transfer_params_parsed(self):
+        kv = {"transfer_id": "abc", "block_table": [1, 2, 3]}
+        req = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "kv_transfer_params": kv,
+            }
+        )
+        assert req.kv_transfer_params == kv
+
+    def test_kv_transfer_params_default_none(self):
+        req = ChatCompletionRequest(
+            messages=[ChatMessage(role="user", content="Hi")],
+        )
+        assert req.kv_transfer_params is None
+
     def test_multimodal_messages(self):
         """Request with multimodal content should parse correctly."""
         req = ChatCompletionRequest.model_validate(
@@ -250,6 +266,35 @@ class TestResponseModels:
         )
         assert resp.id == "chatcmpl-123"
         assert resp.choices[0]["message"]["content"] == "Hello!"
+
+    def test_chat_response_kv_transfer_params(self):
+        kv = {"transfer_id": "xfer-123", "block_table": [0, 1]}
+        resp = ChatCompletionResponse(
+            id="chatcmpl-456",
+            created=int(time.time()),
+            model="test-model",
+            choices=[
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hi"},
+                    "finish_reason": "stop",
+                }
+            ],
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            kv_transfer_params=kv,
+        )
+        dumped = resp.model_dump()
+        assert dumped["kv_transfer_params"] == kv
+
+    def test_chat_response_kv_transfer_params_absent(self):
+        resp = ChatCompletionResponse(
+            id="chatcmpl-789",
+            created=int(time.time()),
+            model="test-model",
+            choices=[],
+            usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        )
+        assert resp.kv_transfer_params is None
 
     def test_completion_response(self):
         resp = CompletionResponse(


### PR DESCRIPTION
…saggregation

The chat completions endpoint was missing kv_transfer_params passthrough, causing mesh router to fail with "response missing kv_transfer_params" when lm_eval uses local-chat-completions mode.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
