### PR TITLE
[Fix] Fix the incorrect layerwise-share-expert-fusion

### DIFF
--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -25,11 +25,17 @@ def is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
         return False
 
     if quant_config is not None and shared_expert_prefix is not None:
-        shared_spec = quant_config.get_layer_quant_config(shared_expert_prefix)
+        shared_spec = quant_config.get_layer_quant_config(
+            shared_expert_prefix,
+            check_children=True,
+        )
         routed_spec = (
-            quant_config.get_layer_quant_config(routed_expert_prefix)
+            quant_config.get_layer_quant_config(
+                routed_expert_prefix,
+                check_children=True,
+            )
             if routed_expert_prefix is not None
-            else quant_config
+            else quant_config.global_quant_config
         )
         return (
             shared_spec.quant_dtype == routed_spec.quant_dtype


### PR DESCRIPTION
## Motivation

Fix the incorrect fusion caused by not checking the module children type when determining the quantization type in layerwise share expert fusion.

