### PR TITLE
minimax ops: support qknorm+allreduce+rope+group_quant+cache_shuffle_write fusion pattern

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -139,6 +139,18 @@ class PagedAttentionImpl(nn.Module):
         )
         self.use_triton_attn = use_triton_attn
 
+        if getattr(self, "_skip_next_kv_cache_write", False):
+            self._skip_next_kv_cache_write = False
+            self.per_token_quant = True
+            self._cache_format = "SHUFFLE"
+            if attn_metadata.has_cached:
+                q, k, v, k_cache, v_cache, k_scale, v_scale = (
+                    self._gather_prefix_and_concat_kv(
+                        q, k, v, k_cache, v_cache, k_scale, v_scale, attn_metadata
+                    )
+                )
+            return q, k, v, k_cache, v_cache, k_scale, v_scale
+
         if (
             self.rotary_emb is not None
             and self.q_norm is not None

--- a/atom/models/minimax_m2.py
+++ b/atom/models/minimax_m2.py
@@ -26,6 +26,7 @@ from atom.models.utils import (
     make_layers,
     maybe_prefix,
 )
+from atom.plugin.prepare import is_vllm
 from atom.utils import envs
 from atom.utils.decorators import support_torch_compile
 from atom.utils.forward_context import get_forward_context
@@ -182,6 +183,12 @@ class MiniMaxM2Attention(nn.Module):
         )
         self.rotary_dim = rotary_dim
         self.kv_cache_dtype = kv_cache_dtype
+        self.delegate_qknorm_rope_to_vllm = (
+            is_vllm()
+            and self.use_qk_norm
+            and self.tp_size > 1
+            and self.kv_cache_dtype == "fp8"
+        )
         cos = self.rotary_emb.cos_cache.squeeze(-2).squeeze(-2)
         sin = self.rotary_emb.sin_cache.squeeze(-2).squeeze(-2)
         self.register_buffer(
@@ -215,7 +222,9 @@ class MiniMaxM2Attention(nn.Module):
             kv_cache_dtype=kv_cache_dtype,
             layer_num=layer_num,
             use_mla=False,
-            rotary_emb=None,
+            rotary_emb=self.rotary_emb if self.delegate_qknorm_rope_to_vllm else None,
+            q_norm=self.q_norm if self.delegate_qknorm_rope_to_vllm else None,
+            k_norm=self.k_norm if self.delegate_qknorm_rope_to_vllm else None,
             prefix=f"{prefix}.attn",
         )
 
@@ -239,7 +248,11 @@ class MiniMaxM2Attention(nn.Module):
     ) -> torch.Tensor:
         qkv = self.qkv_proj(hidden_states)
 
-        if self.use_qk_norm:
+        if self.delegate_qknorm_rope_to_vllm:
+            q, k, v = torch.split(
+                qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1
+            )
+        elif self.use_qk_norm:
             # TP-aware RMSNorm: all-reduce variance across TP ranks so
             # normalization uses the global variance (over 6144/1024 dims)
             # rather than per-rank variance (768/128 dims).

--- a/atom/models/minimax_m2.py
+++ b/atom/models/minimax_m2.py
@@ -248,14 +248,18 @@ class MiniMaxM2Attention(nn.Module):
                 if cos_sin_cache.dtype != qkv.dtype or cos_sin_cache.device != qkv.device:
                     cos_sin_cache = cos_sin_cache.to(device=qkv.device, dtype=qkv.dtype)
                 fwd_ctx = get_forward_context()
+                fwd_context = getattr(fwd_ctx, "context", None)
+                kv_cache_data = getattr(fwd_ctx, "kv_cache_data", None)
                 use_fused_cache_quant = (
                     self.kv_cache_dtype == "fp8"
                     and hasattr(self.attn, "impl")
-                    and not fwd_ctx.context.is_dummy_run
-                    and f"layer_{self.layer_num}" in fwd_ctx.kv_cache_data
+                    and fwd_context is not None
+                    and not fwd_context.is_dummy_run
+                    and kv_cache_data is not None
+                    and f"layer_{self.layer_num}" in kv_cache_data
                 )
                 if use_fused_cache_quant:
-                    kv_cache = fwd_ctx.kv_cache_data[f"layer_{self.layer_num}"]
+                    kv_cache = kv_cache_data[f"layer_{self.layer_num}"]
                     k_cache = kv_cache.k_cache
                     v_cache = kv_cache.v_cache
                     k_scale = kv_cache.k_scale

--- a/atom/models/minimax_m2.py
+++ b/atom/models/minimax_m2.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 import torch
 from aiter.dist.communication_op import (
     tensor_model_parallel_all_reduce,
-    tensor_model_parallel_fused_qknorm_allreduce,
+    tensor_model_parallel_fused_qknorm_allreduce_rope,
 )
 from aiter.dist.parallel_state import (
     get_pp_group,
@@ -178,6 +178,14 @@ class MiniMaxM2Attention(nn.Module):
             base=rope_theta,
             rope_scaling=rope_scaling,
         )
+        self.rotary_dim = rotary_dim
+        cos = self.rotary_emb.cos_cache.squeeze(-2).squeeze(-2)
+        sin = self.rotary_emb.sin_cache.squeeze(-2).squeeze(-2)
+        self.register_buffer(
+            "qknorm_rope_cos_sin_cache",
+            torch.cat([cos, sin], dim=-1).contiguous(),
+            persistent=False,
+        )
 
         self.use_qk_norm = use_qk_norm
         if self.use_qk_norm:
@@ -204,7 +212,7 @@ class MiniMaxM2Attention(nn.Module):
             kv_cache_dtype=kv_cache_dtype,
             layer_num=layer_num,
             use_mla=False,
-            rotary_emb=self.rotary_emb,
+            rotary_emb=None,
             prefix=f"{prefix}.attn",
         )
 
@@ -233,8 +241,18 @@ class MiniMaxM2Attention(nn.Module):
             # normalization uses the global variance (over 6144/1024 dims)
             # rather than per-rank variance (768/128 dims).
             if self.tp_size > 1:
-                q, k, v = tensor_model_parallel_fused_qknorm_allreduce(
-                    qkv, self.q_norm.weight, self.k_norm.weight, self.rms_norm_eps
+                cos_sin_cache = self.qknorm_rope_cos_sin_cache
+                if cos_sin_cache.dtype != qkv.dtype or cos_sin_cache.device != qkv.device:
+                    cos_sin_cache = cos_sin_cache.to(device=qkv.device, dtype=qkv.dtype)
+                q, k, v = tensor_model_parallel_fused_qknorm_allreduce_rope(
+                    qkv,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    cos_sin_cache,
+                    positions,
+                    self.head_dim,
+                    self.rotary_dim,
+                    self.rms_norm_eps,
                 )
             else:
                 q, k, v = torch.split(
@@ -255,10 +273,12 @@ class MiniMaxM2Attention(nn.Module):
                 k = (
                     k * torch.rsqrt(k_var + self.rms_norm_eps) * self.k_norm.weight
                 ).to(orig_dtype)
+                q, k = self.rotary_emb(positions, q, k)
         else:
             q, k, v = torch.split(
                 qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1
             )
+            q, k = self.rotary_emb(positions, q, k)
 
         attn_output = self.attn(
             query=q, key=k, value=v, positions=positions, q_scale=None, qkv=qkv

--- a/atom/models/minimax_m2.py
+++ b/atom/models/minimax_m2.py
@@ -4,6 +4,7 @@ import torch
 from aiter.dist.communication_op import (
     tensor_model_parallel_all_reduce,
     tensor_model_parallel_fused_qknorm_allreduce_rope,
+    tensor_model_parallel_fused_qknorm_allreduce_rope_cache_quant,
 )
 from aiter.dist.parallel_state import (
     get_pp_group,
@@ -27,6 +28,7 @@ from atom.models.utils import (
 )
 from atom.utils import envs
 from atom.utils.decorators import support_torch_compile
+from atom.utils.forward_context import get_forward_context
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -179,6 +181,7 @@ class MiniMaxM2Attention(nn.Module):
             rope_scaling=rope_scaling,
         )
         self.rotary_dim = rotary_dim
+        self.kv_cache_dtype = kv_cache_dtype
         cos = self.rotary_emb.cos_cache.squeeze(-2).squeeze(-2)
         sin = self.rotary_emb.sin_cache.squeeze(-2).squeeze(-2)
         self.register_buffer(
@@ -244,16 +247,64 @@ class MiniMaxM2Attention(nn.Module):
                 cos_sin_cache = self.qknorm_rope_cos_sin_cache
                 if cos_sin_cache.dtype != qkv.dtype or cos_sin_cache.device != qkv.device:
                     cos_sin_cache = cos_sin_cache.to(device=qkv.device, dtype=qkv.dtype)
-                q, k, v = tensor_model_parallel_fused_qknorm_allreduce_rope(
-                    qkv,
-                    self.q_norm.weight,
-                    self.k_norm.weight,
-                    cos_sin_cache,
-                    positions,
-                    self.head_dim,
-                    self.rotary_dim,
-                    self.rms_norm_eps,
+                fwd_ctx = get_forward_context()
+                use_fused_cache_quant = (
+                    self.kv_cache_dtype == "fp8"
+                    and hasattr(self.attn, "impl")
+                    and not fwd_ctx.context.is_dummy_run
+                    and f"layer_{self.layer_num}" in fwd_ctx.kv_cache_data
                 )
+                if use_fused_cache_quant:
+                    kv_cache = fwd_ctx.kv_cache_data[f"layer_{self.layer_num}"]
+                    k_cache = kv_cache.k_cache
+                    v_cache = kv_cache.v_cache
+                    k_scale = kv_cache.k_scale
+                    v_scale = kv_cache.v_scale
+                    if k_scale is not None and v_scale is not None:
+                        x = 16 // k_cache.element_size()
+                        if k_cache.dim() == 5 and v_cache.dim() == 4:
+                            n, nh, hd, bs = v_cache.shape
+                            v_cache = v_cache.view(n, nh, bs // x, hd, x)
+                        q, k, v = (
+                            tensor_model_parallel_fused_qknorm_allreduce_rope_cache_quant(
+                                qkv,
+                                self.q_norm.weight,
+                                self.k_norm.weight,
+                                cos_sin_cache,
+                                positions,
+                                k_cache,
+                                v_cache,
+                                k_scale,
+                                v_scale,
+                                fwd_ctx.attn_metadata.slot_mapping,
+                                self.head_dim,
+                                self.rotary_dim,
+                                self.rms_norm_eps,
+                            )
+                        )
+                        self.attn.impl._skip_next_kv_cache_write = True
+                    else:
+                        q, k, v = tensor_model_parallel_fused_qknorm_allreduce_rope(
+                            qkv,
+                            self.q_norm.weight,
+                            self.k_norm.weight,
+                            cos_sin_cache,
+                            positions,
+                            self.head_dim,
+                            self.rotary_dim,
+                            self.rms_norm_eps,
+                        )
+                else:
+                    q, k, v = tensor_model_parallel_fused_qknorm_allreduce_rope(
+                        qkv,
+                        self.q_norm.weight,
+                        self.k_norm.weight,
+                        cos_sin_cache,
+                        positions,
+                        self.head_dim,
+                        self.rotary_dim,
+                        self.rms_norm_eps,
+                    )
             else:
                 q, k, v = torch.split(
                     qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1

--- a/atom/models/minimax_m2.py
+++ b/atom/models/minimax_m2.py
@@ -183,12 +183,6 @@ class MiniMaxM2Attention(nn.Module):
         )
         self.rotary_dim = rotary_dim
         self.kv_cache_dtype = kv_cache_dtype
-        self.delegate_qknorm_rope_to_vllm = (
-            is_vllm()
-            and self.use_qk_norm
-            and self.tp_size > 1
-            and self.kv_cache_dtype == "fp8"
-        )
         cos = self.rotary_emb.cos_cache.squeeze(-2).squeeze(-2)
         sin = self.rotary_emb.sin_cache.squeeze(-2).squeeze(-2)
         self.register_buffer(
@@ -213,6 +207,13 @@ class MiniMaxM2Attention(nn.Module):
                 self.k_norm.weight.weight_loader = self._make_tp_norm_loader(
                     self.total_num_kv_heads * self.head_dim
                 )
+
+        self.delegate_qknorm_rope_to_vllm = (
+            is_vllm()
+            and self.use_qk_norm
+            and self.tp_size > 1
+            and self.kv_cache_dtype == "fp8"
+        )
 
         self.attn = Attention(
             self.num_heads,

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -139,6 +139,20 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
             per_layer_sliding_window if per_layer_sliding_window is not None else -1
         )
         self.rotary_emb = rotary_emb
+        if rotary_emb is not None and hasattr(rotary_emb, "cos_cache"):
+            cos = rotary_emb.cos_cache.squeeze(-2).squeeze(-2)
+            sin = rotary_emb.sin_cache.squeeze(-2).squeeze(-2)
+            self.register_buffer(
+                "qknorm_rope_cos_sin_cache",
+                torch.cat([cos, sin], dim=-1).contiguous(),
+                persistent=False,
+            )
+        else:
+            self.register_buffer(
+                "qknorm_rope_cos_sin_cache",
+                None,
+                persistent=False,
+            )
         self.q_norm = q_norm
         self.k_norm = k_norm
         self.use_flash_layout = False
@@ -297,7 +311,11 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
                     and v_scale is not None
                     and get_tensor_model_parallel_world_size() > 1
                 ):
-                    cos_sin_cache = self.rotary_emb.cos_sin_cache
+                    cos_sin_cache = self.qknorm_rope_cos_sin_cache
+                    if cos_sin_cache is None:
+                        raise RuntimeError(
+                            "MiniMax M2 fused qknorm rope cache requires packed cos/sin cache"
+                        )
                     if (
                         cos_sin_cache.dtype != qkv.dtype
                         or cos_sin_cache.device != qkv.device

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -3,6 +3,10 @@ from typing import TYPE_CHECKING, Optional
 import aiter
 import torch
 from aiter import dtypes, fused_qk_norm_rope_cache_quant_shuffle
+from aiter.dist.communication_op import (
+    tensor_model_parallel_fused_qknorm_allreduce_rope_cache_quant,
+)
+from aiter.dist.parallel_state import get_tensor_model_parallel_world_size
 from aiter.ops.triton.fused_kv_cache import fused_qk_rope_reshape_and_cache
 from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
 from atom.config import get_current_atom_config
@@ -285,6 +289,44 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
                 k = k.view(-1, self.num_kv_heads, self.head_dim)
                 v = v.view(-1, self.num_kv_heads, self.head_dim)
             else:
+                if (
+                    self.model_type == "minimax_m2"
+                    and qkv is not None
+                    and self.kv_cache_dtype == "fp8"
+                    and k_scale is not None
+                    and v_scale is not None
+                    and get_tensor_model_parallel_world_size() > 1
+                ):
+                    cos_sin_cache = self.rotary_emb.cos_sin_cache
+                    if (
+                        cos_sin_cache.dtype != qkv.dtype
+                        or cos_sin_cache.device != qkv.device
+                    ):
+                        cos_sin_cache = cos_sin_cache.to(
+                            device=qkv.device, dtype=qkv.dtype
+                        )
+                    q_flat, k_flat, v_flat = (
+                        tensor_model_parallel_fused_qknorm_allreduce_rope_cache_quant(
+                            qkv,
+                            self.q_norm.weight,
+                            self.k_norm.weight,
+                            cos_sin_cache,
+                            position,
+                            new_key_cache,
+                            new_value_cache,
+                            k_scale,
+                            v_scale,
+                            slot_mapping,
+                            self.head_dim,
+                            cos_sin_cache.shape[-1],
+                            self.q_norm.eps,
+                        )
+                    )
+                    q = q_flat.view(-1, self.num_heads, self.head_dim)
+                    k = k_flat.view(-1, self.num_kv_heads, self.head_dim)
+                    v = v_flat.view(-1, self.num_kv_heads, self.head_dim)
+                    return q, k, v, k_cache, v_cache, k_scale, v_scale
+
                 # Standard RMSNorm — use existing aiter kernel
                 fused_qk_norm_rope_cache_quant_shuffle(
                     q=q,


### PR DESCRIPTION
<img width="2125" height="181" alt="image" src="https://github.com/user-attachments/assets/c5dfffb2-19c4-45f4-addb-1ad574810fb7" />

before

```
============ Serving Benchmark Result ============
Successful requests:                     160       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  47.50     
Total input tokens:                      165228    
Total generated tokens:                  16305     
Request throughput (req/s):              3.37      
Output token throughput (tok/s):         343.29    
Peak output token throughput (tok/s):    398.00    
Peak concurrent requests:                24.00     
Total token throughput (tok/s):          3822.02   
---------------Time to First Token----------------
Mean TTFT (ms):                          163.77    
Median TTFT (ms):                        133.15    
P99 TTFT (ms):                           457.19    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          41.30     
Median TPOT (ms):                        41.36     
P99 TPOT (ms):                           42.60     
---------------Inter-token Latency----------------
Mean ITL (ms):                           41.35     
Median ITL (ms):                         40.15     
P99 ITL (ms):                            54.48     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          4336.29   
Median E2EL (ms):                        4407.73   
P99 E2EL (ms):                           7409.44   
==================================================
```

after fuse rope

```
============ Serving Benchmark Result ============
Successful requests:                     160       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  46.05     
Total input tokens:                      165228    
Total generated tokens:                  16305     
Request throughput (req/s):              3.47      
Output token throughput (tok/s):         354.07    
Peak output token throughput (tok/s):    414.00    
Peak concurrent requests:                24.00     
Total token throughput (tok/s):          3942.05   
---------------Time to First Token----------------
Mean TTFT (ms):                          163.79    
Median TTFT (ms):                        128.96    
P99 TTFT (ms):                           482.48    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          40.02     
Median TPOT (ms):                        40.05     
P99 TPOT (ms):                           41.43     
---------------Inter-token Latency----------------
Mean ITL (ms):                           40.05     
Median ITL (ms):                         38.55     
P99 ITL (ms):                            56.34     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          4204.90   
Median E2EL (ms):                        4274.42   
P99 E2EL (ms):                           7166.39   
==================================================
```

after fuse rope+quant_cache

```
============ Serving Benchmark Result ============
Successful requests:                     160       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  45.03     
Total input tokens:                      165228    
Total generated tokens:                  16305     
Request throughput (req/s):              3.55      
Output token throughput (tok/s):         362.09    
Peak output token throughput (tok/s):    430.00    
Peak concurrent requests:                22.00     
Total token throughput (tok/s):          4031.38   
---------------Time to First Token----------------
Mean TTFT (ms):                          157.37    
Median TTFT (ms):                        127.17    
P99 TTFT (ms):                           439.09    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          39.18     
Median TPOT (ms):                        39.19     
P99 TPOT (ms):                           41.15     
---------------Inter-token Latency----------------
Mean ITL (ms):                           39.19     
Median ITL (ms):                         37.56     
P99 ITL (ms):                            57.74     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          4112.10   
Median E2EL (ms):                        4171.64   
P99 E2EL (ms):                           7001.18   
==================================================
```

acc

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9310|±  |0.0070|
|     |       |strict-match    |     3|exact_match|↑  |0.9272|±  |0.0072|
```
