### PR TITLE
[Fix] Support online quantization for vllm plugin mode

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -734,7 +734,7 @@ def load_model(
         logger.info("Weight post-processing started (includes online quantization)")
     pp_start = time.perf_counter()
 
-    for _, module in model.named_modules():
+    for module_name, module in model.named_modules():
         if hasattr(module, "process_weights_after_loading"):
             module.process_weights_after_loading()
         quant_method = getattr(module, "quant_method", None)
@@ -745,6 +745,17 @@ def load_model(
             quant_method.process_weights_after_loading(module)
         if isinstance(quant_method, FusedMoEMethodBase):
             quant_method.init_prepare_finalize(module)
+
+        # Online quantization creates new params (e.g. weight_scale) that are
+        # not present in the source checkpoint. Record them as "loaded" so the
+        # plugin host's strict weight tracking (e.g. vLLM's default loader)
+        # does not flag them as uninitialized.
+        if getattr(module, "_online_quant_info", None) is not None:
+            for param_name, _ in module.named_parameters(recurse=False):
+                full_name = (
+                    f"{module_name}.{param_name}" if module_name else param_name
+                )
+                loaded_weights_record.add(prefix + full_name)
 
     if has_online_quant:
         pp_elapsed = time.perf_counter() - pp_start

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -752,9 +752,7 @@ def load_model(
         # does not flag them as uninitialized.
         if getattr(module, "_online_quant_info", None) is not None:
             for param_name, _ in module.named_parameters(recurse=False):
-                full_name = (
-                    f"{module_name}.{param_name}" if module_name else param_name
-                )
+                full_name = f"{module_name}.{param_name}" if module_name else param_name
                 loaded_weights_record.add(prefix + full_name)
 
     if has_online_quant:

--- a/atom/plugin/config.py
+++ b/atom/plugin/config.py
@@ -181,6 +181,9 @@ def _generate_atom_config_from_vllm_config(config: Any) -> PluginConfig:
         enable_dp_attention=False,
         plugin_config=plugin_config,
         speculative_config=atom_speculative_config,
+        online_quant_config=(getattr(config, "additional_config", None) or {}).get(
+            "online_quant_config"
+        ),
     )
 
 

--- a/docs/online_quantization_guide.md
+++ b/docs/online_quantization_guide.md
@@ -177,6 +177,36 @@ the `--online_quant_config` JSON.
 
 ---
 
+## 3.5 Plugin mode (`vllm serve`)
+
+In the [vLLM out-of-tree plugin backend](vllm_plugin_backend_guide.md) you launch
+with `vllm serve`, whose CLI does not understand ATOM's `--online_quant_config`
+flag. Instead, pass the **same JSON object** through vLLM's official plugin
+escape hatch `--additional-config`, under the `online_quant_config` key. ATOM
+reads it during the vLLM→ATOM config translation and routes it through the
+identical load-time quantization path (`process_weights_after_loading`),
+including the `online_quant_info_*.json` dump described in § 4.
+
+```bash
+vllm serve deepseek-ai/DeepSeek-R1-0528 \
+  --tensor-parallel-size 8 \
+  --trust-remote-code \
+  --no-enable-prefix-caching \
+  --additional-config '{"online_quant_config": {
+    "global_quant_config": "ptpc_fp8",
+    "layer_quant_config": {"*expert*": "mxfp4"},
+    "exclude_layer": ["lm_head", "*.gate.*"]
+  }}'
+```
+
+The schema, target formats, pattern semantics, and resolution order are
+identical to the `--online_quant_config` flag documented in § 2. Omitting it
+leaves weights at their source precision. As with the standalone flag, online
+quantization only activates when the source checkpoint's `quant_method` is
+unquantized or per-block FP8 (see § 1).
+
+---
+
 ## 4. Verifying the result
 
 When online quantization runs, rank 0 writes

--- a/docs/vllm_plugin_backend_guide.md
+++ b/docs/vllm_plugin_backend_guide.md
@@ -293,3 +293,16 @@ export ATOM_DISABLE_VLLM_PLUGIN=1
 |---|---|---|---|
 | `ATOM_DISABLE_VLLM_PLUGIN` | bool | `0` (false) | Set to `1` to disable the entire ATOM vLLM plugin (platform + model registration). vLLM runs in pure ROCm mode. |
 | `ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION` | bool | `0` (false) | Enable QK-norm + RoPE + cache + quant fusion in attention. Recommended for Qwen3-MoE models. |
+
+### Online quantization
+
+Online (load-time) quantization is supported in plugin mode. Since `vllm serve`
+cannot take ATOM's `--online_quant_config` CLI flag, pass the same JSON through
+vLLM's `--additional-config` under the `online_quant_config` key:
+
+```bash
+vllm serve <model> ... \
+    --additional-config '{"online_quant_config": {"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": ["lm_head", "*.gate.*"]}}'
+```
+
+See the [online quantization guide](online_quantization_guide.md#35-plugin-mode-vllm-serve) for the full schema.

--- a/tests/plugin/test_plugin_config_translation.py
+++ b/tests/plugin/test_plugin_config_translation.py
@@ -65,6 +65,49 @@ def test_generate_from_vllm_translates_core_fields(monkeypatch):
     assert cfg.plugin_config.is_sglang is False
 
 
+def _vllm_cfg(additional_config=None):
+    return _Obj(
+        model_config=_Obj(model="m1", max_model_len=4096),
+        scheduler_config=_Obj(max_num_batched_tokens=2048, max_num_seqs=8),
+        cache_config=_Obj(
+            gpu_memory_utilization=0.5,
+            block_size=16,
+            num_gpu_blocks=1024,
+            cache_dtype="auto",
+            enable_prefix_caching=True,
+        ),
+        parallel_config=_Obj(
+            rank=1, tensor_parallel_size=2, enable_expert_parallel=False
+        ),
+        compilation_config=_Obj(mode=3),
+        quant_config=_Obj(name="q"),
+        additional_config=additional_config if additional_config is not None else {},
+    )
+
+
+def test_online_quant_config_unset_is_none(monkeypatch):
+    _patch_atom_config_module(monkeypatch)
+
+    cfg = plugin_config._generate_atom_config_from_vllm_config(_vllm_cfg())
+
+    assert cfg.online_quant_config is None
+
+
+def test_online_quant_config_from_additional_config(monkeypatch):
+    _patch_atom_config_module(monkeypatch)
+
+    oqc = {
+        "global_quant_config": "ptpc_fp8",
+        "layer_quant_config": {"*expert*": "mxfp4"},
+        "exclude_layer": ["lm_head", "*.gate.*"],
+    }
+    cfg = plugin_config._generate_atom_config_from_vllm_config(
+        _vllm_cfg({"online_quant_config": oqc})
+    )
+
+    assert cfg.online_quant_config == oqc
+
+
 def test_generate_atom_config_requires_plugin_mode(monkeypatch):
     import atom.plugin.config as config_module
     import atom.plugin as plugin_module


### PR DESCRIPTION
Doc: https://github.com/ROCm/ATOM/blob/main/docs/online_quantization_guide.md
as title
offline: amd/Qwen3-235B-A22B-Instruct-2507-MXFP4
online: Qwen/Qwen3-235B-A22B-Instruct-2507 -mxfp4 online quantization

ttft | ttft | tpot | tpot | gsm8k | gsm8k
-- | -- | -- | -- | -- | --
offline | online | offline | online | offline | online
477.32 | 476.81 | 27.94 | 28.01 | 0.8976 | 0.8939


**online quant:**
```
export ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1
export VLLM_ROCM_USE_AITER=1
export HIP_VISIBLE_DEVICES=4,5,6,7
vllm serve /shareddata/Qwen/Qwen3-235B-A22B-Instruct-2507 \
    --host localhost \
    --port 8000 \
    --gpu-memory-utilization 0.45  \
    --async-scheduling \
    --load-format fastsafetensors \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --no-enable-prefix-caching \
    --additional-config '{"online_quant_config": {"global_quant_config": "mxfp4", "exclude_layer": ["lm_head", "*.gate.*"]}}'
lm_eval --model local-completions \
    --model_args model=/shareddata/Qwen/Qwen3-235B-A22B-Instruct-2507,base_url=http://localhost:8000/v1/completions,num_concurrent=32,max_retries=3,tokenized_requests=False \
    --tasks gsm8k \
    --num_fewshot 5 \
    --batch_size auto


vllm bench serve \
  --backend vllm \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/completions \
  --model /shareddata/Qwen/Qwen3-235B-A22B-Instruct-2507  \
  --dataset-name random \
  --random-input-len 1024 \
  --random-output-len 1024 \
  --random-range-ratio 0.8 \
  --num-prompts 1024 \
  --max-concurrency 128 \
  --trust_remote_code \
  --num-warmups 128 \
  --request-rate inf \
  --ignore-eos \
  --disable-tqdm \
  --save-result \
  --percentile-metrics ttft,tpot,itl,e2el \
  --result-dir /tmp/oot-benchmark-results \
  --result-filename deepseek-r1-fp8-met-1024-1024-128-0.8.json

```
**offline quant:**
```
export ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1
export VLLM_ROCM_USE_AITER=1
export HIP_VISIBLE_DEVICES=4,5,6,7
vllm serve /shareddata/amd/Qwen3-235B-A22B-Instruct-2507-MXFP4 \
    --host localhost \
    --port 8000 \
    --gpu-memory-utilization 0.45  \
    --async-scheduling \
    --load-format fastsafetensors \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --no-enable-prefix-caching


lm_eval --model local-completions \
    --model_args model=//shareddata/amd/Qwen3-235B-A22B-Instruct-2507-MXFP4,base_url=http://localhost:8000/v1/completions,num_concurrent=32,max_retries=3,tokenized_requests=False \
    --tasks gsm8k \
    --num_fewshot 5 \
    --batch_size auto

vllm bench serve \
  --backend vllm \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/completions \
  --model /shareddata/amd/Qwen3-235B-A22B-Instruct-2507-MXFP4 \
  --dataset-name random \
  --random-input-len 1024 \
  --random-output-len 1024 \
  --random-range-ratio 0.8 \
  --num-prompts 1024 \
  --max-concurrency 128 \
  --trust_remote_code \
  --num-warmups 128 \
  --request-rate inf \
  --ignore-eos \
  --disable-tqdm \
  --save-result \
  --percentile-metrics ttft,tpot,itl,e2el \
  --result-dir /tmp/oot-benchmark-results \
  --result-filename deepseek-r1-fp8-met-1024-1024-128-0.8.json


```