### PR TITLE
[plugin] enable online_quant for vllm-atom

### DIFF
--- a/atom/plugin/config.py
+++ b/atom/plugin/config.py
@@ -109,7 +109,36 @@ def _build_atom_speculative_config_from_vllm(vllm_spec_config: Any):
     )
 
 
-def _generate_atom_config_from_vllm_config(config: Any) -> PluginConfig:
+def _extract_vllm_online_quant_config(config: Any) -> Optional[dict]:
+    additional_config = getattr(config, "additional_config", None) or {}
+    if not isinstance(additional_config, dict):
+        raise ValueError(
+            "vLLM additional_config must be a dict when used with ATOM plugin "
+            f"settings, got {type(additional_config).__name__}."
+        )
+
+    atom_config = additional_config.get("atom")
+    if atom_config is not None:
+        if not isinstance(atom_config, dict):
+            raise ValueError(
+                'vLLM additional_config["atom"] must be a dict when provided, '
+                f"got {type(atom_config).__name__}."
+            )
+        online_quant_config = atom_config.get("online_quant_config")
+    else:
+        online_quant_config = additional_config.get("online_quant_config")
+
+    if online_quant_config is None:
+        return None
+    if not isinstance(online_quant_config, dict):
+        raise ValueError(
+            "ATOM vLLM online_quant_config must be a JSON object/dict, "
+            f"got {type(online_quant_config).__name__}."
+        )
+    return online_quant_config
+
+
+def _generate_atom_config_from_vllm_config(config: Any) -> Any:
     from atom.config import Config, CompilationConfig
 
     vllm_model_config = config.model_config
@@ -156,6 +185,11 @@ def _generate_atom_config_from_vllm_config(config: Any) -> PluginConfig:
     atom_speculative_config = _build_atom_speculative_config_from_vllm(
         getattr(config, "speculative_config", None)
     )
+    online_quant_config = _extract_vllm_online_quant_config(config)
+    if online_quant_config is not None:
+        logger.info(
+            "Using ATOM online quantization config from vLLM additional_config."
+        )
 
     return Config(
         model=vllm_model_config.model,
@@ -181,6 +215,7 @@ def _generate_atom_config_from_vllm_config(config: Any) -> PluginConfig:
         enable_dp_attention=False,
         plugin_config=plugin_config,
         speculative_config=atom_speculative_config,
+        online_quant_config=online_quant_config,
     )
 
 

--- a/docs/vllm_plugin_backend_guide.md
+++ b/docs/vllm_plugin_backend_guide.md
@@ -237,6 +237,15 @@ vllm serve ${model} \
     --no-enable-prefix-caching
 ```
 
+ATOM-specific plugin options should be passed through vLLM's official
+`--additional-config` argument. For example, to enable ATOM online
+quantization in plugin mode:
+
+```bash
+vllm serve ${model} \
+    --additional-config '{"atom": {"online_quant_config": {"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": "lm_head"}}}'
+```
+
 ATOM will log its activation at startup:
 
 ```

--- a/tests/plugin/test_plugin_config_translation.py
+++ b/tests/plugin/test_plugin_config_translation.py
@@ -49,6 +49,7 @@ def test_generate_from_vllm_translates_core_fields(monkeypatch):
         ),
         compilation_config=_Obj(mode=3),
         quant_config=_Obj(name="q"),
+        additional_config={},
     )
 
     cfg = plugin_config._generate_atom_config_from_vllm_config(vllm_cfg)
@@ -63,6 +64,89 @@ def test_generate_from_vllm_translates_core_fields(monkeypatch):
     assert cfg.plugin_config.is_plugin_mode is True
     assert cfg.plugin_config.is_vllm is True
     assert cfg.plugin_config.is_sglang is False
+
+
+def test_generate_from_vllm_reads_namespaced_online_quant_config(monkeypatch):
+    _patch_atom_config_module(monkeypatch)
+    online_quant_config = {
+        "global_quant_config": "ptpc_fp8",
+        "layer_quant_config": {"*expert*": "mxfp4"},
+        "exclude_layer": "lm_head",
+    }
+
+    vllm_cfg = _Obj(
+        model_config=_Obj(model="m1", max_model_len=4096),
+        scheduler_config=_Obj(max_num_batched_tokens=2048, max_num_seqs=8),
+        cache_config=_Obj(
+            gpu_memory_utilization=0.5,
+            block_size=16,
+            num_gpu_blocks=1024,
+            cache_dtype="auto",
+            enable_prefix_caching=True,
+        ),
+        parallel_config=_Obj(
+            rank=1, tensor_parallel_size=2, enable_expert_parallel=False
+        ),
+        compilation_config=_Obj(mode=3),
+        quant_config=_Obj(name="q"),
+        additional_config={"atom": {"online_quant_config": online_quant_config}},
+    )
+
+    cfg = plugin_config._generate_atom_config_from_vllm_config(vllm_cfg)
+
+    assert cfg.online_quant_config == online_quant_config
+
+
+def test_generate_from_vllm_reads_top_level_online_quant_config(monkeypatch):
+    _patch_atom_config_module(monkeypatch)
+    online_quant_config = {"global_quant_config": "ptpc_fp8"}
+
+    vllm_cfg = _Obj(
+        model_config=_Obj(model="m1", max_model_len=4096),
+        scheduler_config=_Obj(max_num_batched_tokens=2048, max_num_seqs=8),
+        cache_config=_Obj(
+            gpu_memory_utilization=0.5,
+            block_size=16,
+            num_gpu_blocks=1024,
+            cache_dtype="auto",
+            enable_prefix_caching=True,
+        ),
+        parallel_config=_Obj(
+            rank=1, tensor_parallel_size=2, enable_expert_parallel=False
+        ),
+        compilation_config=_Obj(mode=3),
+        quant_config=_Obj(name="q"),
+        additional_config={"online_quant_config": online_quant_config},
+    )
+
+    cfg = plugin_config._generate_atom_config_from_vllm_config(vllm_cfg)
+
+    assert cfg.online_quant_config == online_quant_config
+
+
+def test_generate_from_vllm_rejects_invalid_online_quant_config(monkeypatch):
+    _patch_atom_config_module(monkeypatch)
+
+    vllm_cfg = _Obj(
+        model_config=_Obj(model="m1", max_model_len=4096),
+        scheduler_config=_Obj(max_num_batched_tokens=2048, max_num_seqs=8),
+        cache_config=_Obj(
+            gpu_memory_utilization=0.5,
+            block_size=16,
+            num_gpu_blocks=1024,
+            cache_dtype="auto",
+            enable_prefix_caching=True,
+        ),
+        parallel_config=_Obj(
+            rank=1, tensor_parallel_size=2, enable_expert_parallel=False
+        ),
+        compilation_config=_Obj(mode=3),
+        quant_config=_Obj(name="q"),
+        additional_config={"atom": {"online_quant_config": "ptpc_fp8"}},
+    )
+
+    with pytest.raises(ValueError, match="online_quant_config"):
+        plugin_config._generate_atom_config_from_vllm_config(vllm_cfg)
 
 
 def test_generate_atom_config_requires_plugin_mode(monkeypatch):


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

```bash
model_path=/workspace/shared/data/amd_int/models/MiniMax-M2.5/
vllm serve $model_path \
    --host localhost \
    --port 8000 \
    --async-scheduling \
    --tensor-parallel-size 2 \
    --trust-remote-code \
    --gpu_memory_utilization 0.9 \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --kv-cache-dtype fp8 \
    --max-num-batched-tokens 16384 \
    --max-model-len 16384 \
    --additional-config '{"atom": {"online_quant_config": {"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "*.gate.*"]}}}' \
    --no-enable-prefix-caching
```

## Test Result
```bash
local-completions ({'model': '/workspace/shared/data/amd_int/models/MiniMax-M2.5/', 'base_url': 'http://localhost:8000/v1/completions', 'num_concurrent': 65, 'max_retries': 3, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 3, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9295|±  |0.0071|
|     |       |strict-match    |     3|exact_match|↑  |0.9272|±  |0.0072|
```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
