### PR TITLE
Route GPT-OSS full prefill to sink ASM

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -7,6 +7,7 @@ import aiter
 import torch
 from aiter import fused_qk_norm_rope_cache_quant_shuffle
 from aiter.ops.triton.fused_kv_cache import fused_qk_rope_reshape_and_cache
+from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
 from aiter.ops.triton.unified_attention import unified_attention
 from atom.config import get_current_atom_config
@@ -85,6 +86,51 @@ class PagedAttentionImpl(nn.Module):
 
         self.supports_quant_query_input = False
 
+    def _can_use_prefill_sink_asm(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        fwd_ctx: ForwardContext,
+    ) -> bool:
+        if not self.use_flash_layout:
+            return False
+        attn_metadata = fwd_ctx.attn_metadata
+        if attn_metadata is None:
+            return False
+        if get_gfx() != "gfx1250":
+            return False
+        if (
+            q.dtype != torch.bfloat16
+            or k.dtype != torch.bfloat16
+            or v.dtype != torch.bfloat16
+        ):
+            return False
+        if (
+            self.head_dim != 64
+            or q.shape[-1] != 64
+            or k.shape[-1] != 64
+            or v.shape[-1] != 64
+        ):
+            return False
+        if self.sinks is None:
+            return False
+        if self.sliding_window != -1 or self.alibi_slopes is not None:
+            return False
+        if getattr(attn_metadata, "dropout_p", 0.0) != 0.0:
+            return False
+        if getattr(attn_metadata, "has_cached", False):
+            return False
+        if attn_metadata.cu_seqlens_q is None or attn_metadata.cu_seqlens_k is None:
+            return False
+        if attn_metadata.max_seqlen_q != attn_metadata.max_seqlen_k:
+            return False
+        if q.shape[0] != k.shape[0] or k.shape[0] != v.shape[0]:
+            return False
+        if q.shape[1] % k.shape[1] != 0:
+            return False
+        return True
+
     def forward_impl(
         self,
         q: torch.Tensor,
@@ -112,7 +158,7 @@ class PagedAttentionImpl(nn.Module):
             q, k, v, qkv, position, fwd_ctx
         )
 
-        attn_impl = self.dispatch_backend(fwd_ctx)
+        attn_impl = self.dispatch_backend(fwd_ctx, q, k, v)
 
         o = attn_impl(q, k, v, k_cache, v_cache, k_scale, v_scale, fwd_ctx)
 
@@ -637,11 +683,19 @@ class PagedAttentionImpl(nn.Module):
 
         return o
 
-    def dispatch_backend(self, fwd_ctx: ForwardContext):
+    def dispatch_backend(
+        self,
+        fwd_ctx: ForwardContext,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ):
 
         ctx = fwd_ctx.context
 
         if ctx.is_prefill:
+            if self._can_use_prefill_sink_asm(q, k, v, fwd_ctx):
+                return self.prefill_attention
             if self.use_flash_layout:
                 return self.prefill_attention_triton
             return self.prefill_attention

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -18,6 +18,7 @@ from aiter import (
     get_hip_quant,
 )
 from aiter.dist.parallel_state import get_dp_group
+from aiter.jit.utils.chip_info import get_gfx
 from aiter.mla import mla_decode_fwd, mla_prefill_fwd
 from aiter.ops.triton.gather_kv_b_proj import gather_kv_b_proj
 from atom.config import get_current_atom_config
@@ -584,7 +585,10 @@ class MLAAttention(nn.Module):
             elif (
                 fused_gemm_a8w8_blockscale_preshuffle_split_cat is not None
                 and weight.dtype == dtypes.fp8
+                and get_gfx() != "gfx1250"
             ):  # FP8 GEMM + split + cat
+                # gfx1250: this fused kernel is unadapted (requires
+                # GROUP_K == BLOCK_SIZE_K); fall through to the non-fused path.
                 weight_shuffled = weight.reshape(
                     weight.shape[0] // 16, weight.shape[1] * 16
                 )


### PR DESCRIPTION
Review-only PR. This routes GPT-OSS full-attention prefill on gfx1250/bf16/head_dim=64/sink/no-SWA/no cached prefix to AITER flash_attn_varlen_func so it can hit the sink varlen ASM path. SWA layers and decode/PA decode are intentionally untouched. Commit: da777e9464b10ae2d66c9f03620e0737440cbc20