### PR TITLE
[atom-vllm recipe] set max num seqs to 512 as upper limit with 0.9 gpu mem utilization

### DIFF
--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -53,7 +53,7 @@
             "8192x1024"
           ],
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --gpu-memory-utilization 0.8 --tokenizer-mode deepseek_v4",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --gpu-memory-utilization 0.9 --max-num-seqs 512 --tokenizer-mode deepseek_v4",
           "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1"
         }
       ]

--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -151,7 +151,7 @@
   {
     "model_name": "DeepSeek-V4-Pro TP8",
     "model_path": "deepseek-ai/DeepSeek-V4-Pro",
-    "extraArgs": "--tensor-parallel-size 8 --gpu-memory-utilization 0.8 --tokenizer-mode deepseek_v4",
+    "extraArgs": "--tensor-parallel-size 8 --gpu-memory-utilization 0.9 --max-num-seqs 512 --tokenizer-mode deepseek_v4",
     "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1",
     "runner": "linux-atom-mi35x-8",
     "test_level": "nightly",

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -616,7 +616,7 @@ jobs:
                   "toggle_env": "RUN_DSV4_PRO_TP8",
                   "model_name": "DeepSeek-V4-Pro TP8",
                   "model_path": "deepseek-ai/DeepSeek-V4-Pro",
-                  "extra_args": "--tensor-parallel-size 8 --gpu-memory-utilization 0.8 --tokenizer-mode deepseek_v4",
+                  "extra_args": "--tensor-parallel-size 8 --gpu-memory-utilization 0.9 --max-num-seqs 512 --tokenizer-mode deepseek_v4",
                   "lm_eval_num_fewshot": 20,
                   "accuracy_test_threshold": 0.94,
                   "env_vars": "AITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1",

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -237,7 +237,7 @@ jobs:
           - display_name: "DeepSeek-V4-Pro TP8"
             model_name: "DeepSeek-V4-Pro"
             model_path: "deepseek-ai/DeepSeek-V4-Pro"
-            extra_args: "--tensor-parallel-size 8 --gpu-memory-utilization 0.8 --tokenizer-mode deepseek_v4"
+            extra_args: "--tensor-parallel-size 8 --gpu-memory-utilization 0.9 --max-num-seqs 512 --tokenizer-mode deepseek_v4"
             env_vars: |
               AITER_BF16_FP8_MOE_BOUND=0
               ATOM_MOE_GU_ITLV=1

--- a/recipes/atom_vllm/DeepSeek-V4.md
+++ b/recipes/atom_vllm/DeepSeek-V4.md
@@ -29,7 +29,8 @@ vllm serve "${MODEL}" \
     --tensor-parallel-size "${TP}" \
     --distributed-executor-backend mp \
     --trust-remote-code \
-    --gpu-memory-utilization 0.8 \
+    --gpu-memory-utilization 0.9 \
+    --max-num-seqs 512 \
     --tokenizer-mode deepseek_v4 \
     --async-scheduling \
     --no-enable-prefix-caching \
@@ -39,6 +40,7 @@ vllm serve "${MODEL}" \
 Notes:
 - `ATOM_USE_TRITON_MOE=1` enables the Triton MoE path used by this configuration.
 - `--tokenizer-mode deepseek_v4` selects the DeepSeek-V4 tokenizer mode required by the vLLM-ATOM adapter.
+- Keep `--max-num-seqs` at or below `512` for this configuration; larger values may OOM.
 - The command above serves on port `8001`; update the accuracy command below if you change the port.
 - The profiler writes torch traces to `./vllm_profile`. Remove `--profiler-config` if profiling is not needed.
 


### PR DESCRIPTION
# PR Description: Cap DeepSeek V4 max_num_seqs at 512 for high memory utilization

## Summary

This PR caps DeepSeek V4 atom-vLLM `max_num_seqs` at `512` when running with high GPU memory utilization.

The goal is to avoid vLLM's large-GPU default `max_num_seqs=1024`, which causes ATOM DeepSeek V4 to allocate a large amount of per-request persistent state outside vLLM's KV cache accounting.

## Motivation

On MI355, vLLM reports about `287.98 GiB` per GPU. When `--max-num-seqs` is not explicitly set, vLLM's OpenAI server defaults to `1024` on large GPUs.

For DeepSeek V4, ATOM sizes its persistent state by `max_num_seqs`:

```python
num_slots = max(1, int(vllm_config.scheduler_config.max_num_seqs))
```

With `max_num_seqs=1024`, ATOM allocates about `17.85 GiB` of extra persistent state per rank, mostly HCA compressor state. This memory is not included in vLLM's `determine_available_memory()` KV cache budget.

At `gpu_memory_utilization=0.9`, this leaves only about `6.7 GiB` free after ATOM proxy cache binding, which is too little for real lmeval runtime allocations and can lead to OOM / HSA out-of-resources.

## Memory Comparison

Measured on 8x AMD MI355 with DeepSeek-V4-Pro, TP=8, `FULL_AND_PIECEWISE` cudagraph mode preserved.

| Metric | util=0.8, default max seqs | util=0.9, default max seqs | util=0.9, `--max-num-seqs 512` |
|---|---:|---:|---:|
| Effective `max_num_seqs` / `num_slots` | 1024 | 1024 | 512 |
| GPU total memory | 287.98 GiB | 287.98 GiB | 287.98 GiB |
| Initial free memory | 281.60 GiB | 281.60 GiB | 281.60 GiB |
| vLLM requested memory | 230.39 GiB | 259.19 GiB | 259.19 GiB |
| vLLM available KV memory | 82.38 GiB | 111.18 GiB | 112.26 GiB |
| GPU KV cache tokens | 171,008 | 230,912 | 458,368 |
| Proxy KV blocks (`block_size=128`) | 1,336 | 1,804 | 3,581 |
| Proxy KV tensor bytes | 82.33 GiB | 111.16 GiB | 112.25 GiB |
| Proxy page bytes | 63.10 MiB | 63.10 MiB | 32.10 MiB |
| Free before ATOM proxy bind | ~53.5 GiB | ~24.6 GiB | ~23.7 GiB |
| ATOM extra state total | 17.85 GiB | 17.85 GiB | 8.93 GiB |
| ATOM CSA state | 1.88 GiB | 1.88 GiB | 0.94 GiB |
| ATOM HCA state | 15.50 GiB | 15.50 GiB | 7.75 GiB |
| ATOM indexer state | 0.47 GiB | 0.47 GiB | 0.23 GiB |
| Free after ATOM proxy bind | ~35.5 GiB | ~6.7 GiB | ~14.7 GiB |
| Graph capture reported memory | 17.05 GiB | 17.05 GiB | 8.00 GiB |

Lowering `max_num_seqs` from `1024` to `512` reduces ATOM's untracked per-slot state from `17.85 GiB` to `8.93 GiB`, recovering about `8.9 GiB` of GPU headroom per rank.

## Accuracy and Runtime Validation

Ran full GSM8K lmeval with:

- `gpu_memory_utilization=0.9`
- `--max-num-seqs 512`
- `--max-num-batched-tokens 16384`
- `FULL_AND_PIECEWISE` cudagraph mode
- `num_concurrent=65`
- `num_fewshot=20`

Result:

| Metric | Value |
|---|---:|
| lmeval exit code | 0 |
| OOM / HSA out-of-resources in server log | no |
| Peak logged running requests | 65 |
| Peak logged GPU KV cache usage | 56.5% |
| GSM8K flexible exact match | 0.1918 +/- 0.0108 |
| GSM8K strict exact match | 0.1531 +/- 0.0099 |

## Conclusion

Capping DeepSeek V4 `max_num_seqs` at `512` is a practical default for `gpu_memory_utilization=0.9`: it preserves the high vLLM KV cache budget while reducing ATOM's untracked per-slot state enough to complete full GSM8K lmeval without OOM.
