### PR TITLE
[sgl-atom][Feat] Enable online quant in sgl-atom

### DIFF
--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -12,6 +12,18 @@
     "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
   },
   {
+    "model_name": "DeepSeek-R1-FP8 TP4 Online Quant",
+    "model_path": "deepseek-ai/DeepSeek-R1-0528",
+    "extraArgs": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"mxfp4\",\"exclude_layer\":[\"model.layers.*.self_attn.*\",\"model.layers.61.*\",\"lm_head\"]}}'",
+    "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+    "runner": "linux-atom-mi35x-4",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.91,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "deepseek-ai/DeepSeek-R1-0528",
+    "_baseline_note": "Online quant coverage based on the DeepSeek-R1-FP8 TP4 SGLang accuracy validation target for gsm8k."
+  },
+  {
     "model_name": "Qwen3.5-35B-A3B-FP8 TP2",
     "model_path": "Qwen/Qwen3.5-35B-A3B-FP8",
     "extraArgs": "--tensor-parallel-size 2 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -14,6 +14,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_dsr1_fp8_tp4_online_quant:
+        description: "DeepSeek-R1-FP8 TP4 Online Quant"
+        required: false
+        type: boolean
+        default: false
       run_qwen35_35b_a3b_fp8_tp2:
         description: "Qwen3.5-35B-A3B-FP8 TP2"
         required: false
@@ -134,6 +139,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           RUN_DSR1_FP8_TP4: ${{ inputs.run_dsr1_fp8_tp4 }}
+          RUN_DSR1_FP8_TP4_ONLINE_QUANT: ${{ inputs.run_dsr1_fp8_tp4_online_quant }}
           RUN_QWEN35_35B_A3B_FP8_TP2: ${{ inputs.run_qwen35_35b_a3b_fp8_tp2 }}
           RUN_QWEN35_35B_A3B_TP2: ${{ inputs.run_qwen35_35b_a3b_tp2 }}
           RUN_QWEN35_397B_A17B_FP8_TP4: ${{ inputs.run_qwen35_397b_a17b_fp8_tp4 }}
@@ -166,6 +172,15 @@ jobs:
                   "model_name": "DeepSeek-R1-FP8 TP4",
                   "model_path": "deepseek-ai/DeepSeek-R1-0528",
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
+                  "accuracy_test_threshold": 0.91,
+                  "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+                  "runner": "linux-atom-mi35x-4",
+              },
+              {
+                  "toggle_env": "RUN_DSR1_FP8_TP4_ONLINE_QUANT",
+                  "model_name": "DeepSeek-R1-FP8 TP4 Online Quant",
+                  "model_path": "deepseek-ai/DeepSeek-R1-0528",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"mxfp4\",\"exclude_layer\":[\"model.layers.*.self_attn.*\",\"model.layers.61.*\",\"lm_head\"]}}'",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
                   "runner": "linux-atom-mi35x-4",

--- a/atom/plugin/config.py
+++ b/atom/plugin/config.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from typing import Any, Optional
 from dataclasses import dataclass
 
@@ -214,6 +215,14 @@ def _generate_atom_config_from_sglang_config(config: Any):
             "server arguments."
         )
 
+    sglang_model_loader_extra_config = json.loads(
+        getattr(server_args, "model_loader_extra_config", None) or "{}"
+    )
+    online_quant_config = sglang_model_loader_extra_config.pop(
+        "online_quant_config", None
+    )
+    server_args.model_loader_extra_config = json.dumps(sglang_model_loader_extra_config)
+
     sgl_model_config = SglangModelConfig.from_server_args(server_args)
     sgl_model_opt_config = ModelOptConfig(
         quant=server_args.modelopt_quant,
@@ -332,6 +341,7 @@ def _generate_atom_config_from_sglang_config(config: Any):
         master_addr=None,
         enable_dp_attention=server_args.enable_dp_attention,
         plugin_config=plugin_config,
+        online_quant_config=online_quant_config,
     )
 
 

--- a/atom/plugin/sglang/runtime/__init__.py
+++ b/atom/plugin/sglang/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Runtime utilities for ATOM's SGLang plugin integration."""
 
+from atom.plugin.sglang.runtime.load_config_patch import apply_load_config_patch
 from atom.plugin.sglang.runtime.context import (
     SGLangForwardBatchMetadata,
     bind_current_forward_batch,
@@ -14,7 +15,10 @@ from atom.plugin.sglang.runtime.model_arch import (
     get_model_arch_spec,
 )
 
+apply_load_config_patch()
+
 __all__ = [
+    "apply_load_config_patch",
     "MODEL_ADAPTER_SPECS",
     "MODEL_ARCH_SPECS",
     "SGLangForwardBatchMetadata",

--- a/atom/plugin/sglang/runtime/load_config_patch.py
+++ b/atom/plugin/sglang/runtime/load_config_patch.py
@@ -1,0 +1,33 @@
+"""Patch SGLang LoadConfig for ATOM-only model loader extras.
+
+ATOM reuses SGLang's ``--model-loader-extra-config`` to receive plugin-only
+options such as ``online_quant_config``. SGLang parses the same JSON into
+``LoadConfig.model_loader_extra_config`` and later passes it to its default
+model loader, whose validation rejects keys it does not own. Without this
+patch, a valid ATOM online-quant config fails before ATOM can consume it.
+
+The ATOM config translation reads and stores ``online_quant_config`` earlier in
+the plugin setup path, so this runtime patch only removes the ATOM-private key
+from SGLang's loader-facing copy after ``LoadConfig.__post_init__`` has parsed
+the JSON string into a dict.
+"""
+
+from __future__ import annotations
+
+
+def apply_load_config_patch() -> None:
+    from sglang.srt.configs.load_config import LoadConfig
+
+    if getattr(LoadConfig, "_atom_online_quant_patch", False):
+        return
+
+    original_post_init = LoadConfig.__post_init__
+
+    def patched_post_init(self):
+        original_post_init(self)
+        extra_config = self.model_loader_extra_config or {}
+        if isinstance(extra_config, dict):
+            extra_config.pop("online_quant_config", None)
+
+    LoadConfig.__post_init__ = patched_post_init
+    LoadConfig._atom_online_quant_patch = True


### PR DESCRIPTION
## Motivation

Enable online quant in sgl-atom.

## Command
```
model_path=/models/deepseek-ai/DeepSeek-R1-0528
model_loader_extra_config='{"online_quant_config":{"global_quant_config":"mxfp4","exclude_layer":["model.layers.*.self_attn.*","model.layers.61.*","lm_head"]}}'

export SGLANG_PROFILE_RECORD_SHAPES=1
export SGLANG_PROFILE_WITH_STACK=1
export SGLANG_TORCH_PROFILER_DIR=./profile_log/
 
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
export SGLANG_ENABLE_TORCH_COMPILE=1


TORCHINDUCTOR_COMPILE_THREADS=128 python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --mem-fraction-static 0.85 \
    --disable-radix-cache \
    --attention-backend aiter \
    --kv-cache-dtype fp8_e4m3 \
    --model-loader-extra-config "$model_loader_extra_config" \
    --chunked-prefill-size 65536 \
    --page-size 1
```


## ACC
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9447|±  |0.0063|
|     |       |strict-match    |     3|exact_match|↑  |0.9424|±  |0.0064|
```


## Performance
before online quant:
```
============ Serving Benchmark Result ============
Successful requests:                     48        
Benchmark duration (s):                  15.76     
Total input tokens:                      49152     
Total generated tokens:                  12288     
Request throughput (req/s):              3.05      
Output token throughput (tok/s):         779.93    
Total Token throughput (tok/s):          3899.67   
---------------Time to First Token----------------
Mean TTFT (ms):                          613.95    
Median TTFT (ms):                        638.07    
P99 TTFT (ms):                           816.11    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.17     
Median TPOT (ms):                        18.29     
P99 TPOT (ms):                           19.96     
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.17     
Median ITL (ms):                         17.92     
P99 ITL (ms):                            18.68     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          5247.82   
Median E2EL (ms):                        5264.05   
P99 E2EL (ms):                           5304.73   
==================================================
```


after online quant:
```
============ Serving Benchmark Result ============
Successful requests:                     48        
Benchmark duration (s):                  12.08     
Total input tokens:                      49152     
Total generated tokens:                  12288     
Request throughput (req/s):              3.97      
Output token throughput (tok/s):         1017.25   
Total Token throughput (tok/s):          5086.25   
---------------Time to First Token----------------
Mean TTFT (ms):                          699.72    
Median TTFT (ms):                        546.88    
P99 TTFT (ms):                           1129.34   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          13.03     
Median TPOT (ms):                        13.00     
P99 TPOT (ms):                           14.23     
---------------Inter-token Latency----------------
Mean ITL (ms):                           13.03     
Median ITL (ms):                         13.02     
P99 ITL (ms):                            13.53     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          4022.42   
Median E2EL (ms):                        3828.52   
P99 E2EL (ms):                           4443.61   
==================================================
```