### PR TITLE
remove unnecessary fp8 scale for vllm plugin

### DIFF
--- a/atom/plugin/vllm/attention/layer_mla.py
+++ b/atom/plugin/vllm/attention/layer_mla.py
@@ -1193,14 +1193,17 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                 group_size=128,
                 transpose_bm=True,
             )
-
+        if fp8_attention:
+            q_out_dtype = current_platform.fp8_dtype()
+        else:
+            q_out_dtype = ql_nope.dtype
         q_out = torch.empty(
             (
                 ql_nope.shape[0],
                 self.num_heads,
                 self.kv_lora_rank + self.qk_rope_head_dim,
             ),
-            dtype=ql_nope.dtype,
+            dtype=q_out_dtype,
             device=ql_nope.device,
         )
         if kv_cache.numel() > 0:
@@ -1226,15 +1229,6 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
         if self.head_repeat_factor > 1:
             q_out = q_out.repeat_interleave(self.head_repeat_factor, dim=1)
 
-        if fp8_attention:
-            from vllm import _custom_ops as ops
-
-            # Reshape to 2D for scaled_fp8_quant, then restore
-            q_flat, _ = ops.scaled_fp8_quant(
-                q_out.reshape(q_out.shape[0], -1),
-                self._q_scale,
-            )
-            q_out = q_flat.reshape(q_out.shape)
         attn_out = self._forward_sparse_bf16_kv(q_out, kv_cache, attn_metadata)
 
         # V up-projection


### PR DESCRIPTION
## Motivation
Remove unnecessary fp8 quant in vllm plugin
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
before
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  219.32    
Total input tokens:                      1280000   
Total generated tokens:                  128000    
Request throughput (req/s):              0.58      
Output token throughput (tok/s):         583.61    
Peak output token throughput (tok/s):    928.00    
Peak concurrent requests:                25.00     
Total token throughput (tok/s):          6419.71   
---------------Time to First Token----------------
Mean TTFT (ms):                          3593.61   
Median TTFT (ms):                        4100.17   
P99 TTFT (ms):                           7945.96   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          23.84     
Median TPOT (ms):                        23.80     
P99 TPOT (ms):                           27.26     
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.84     
Median ITL (ms):                         19.36     
P99 ITL (ms):                            21.24     
==================================================
```

after
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  214.74    
Total input tokens:                      1280000   
Total generated tokens:                  128000    
Request throughput (req/s):              0.60      
Output token throughput (tok/s):         596.07    
Peak output token throughput (tok/s):    944.00    
Peak concurrent requests:                26.00     
Total token throughput (tok/s):          6556.80   
---------------Time to First Token----------------
Mean TTFT (ms):                          3452.21   
Median TTFT (ms):                        3790.46   
P99 TTFT (ms):                           7691.69   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          23.40     
Median TPOT (ms):                        23.11     
P99 TPOT (ms):                           26.50     
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.40     
Median ITL (ms):                         19.01     
P99 ITL (ms):                            20.86     
==================================================
```
acc
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9515|±  |0.0059|
|     |       |strict-match    |    20|exact_match|↑  |0.9515|±  |0.0059|
```
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
