### PR TITLE
[Triton] [Gluon] [GFX12] Support kv_buffer shuffled MLA

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -19,6 +19,13 @@ from aiter import (
 )
 from aiter.dist.parallel_state import get_dp_group
 from aiter.mla import mla_decode_fwd, mla_prefill_fwd
+from aiter.ops.triton.attention.mla import (
+    mla_decode_fwd as triton_shuffle_mla_decode_fwd,
+)
+from aiter.ops.triton.kv_cache import cat_and_cache_mla as triton_cat_and_cache_mla
+from aiter.ops.triton.fusions.fused_kv_cache import (
+    fused_qk_rope_cat_and_cache_mla as triton_fused_qk_rope_cat_and_cache_mla,
+)
 from aiter.ops.triton.gather_kv_b_proj import gather_kv_b_proj
 from atom.config import get_current_atom_config
 from atom.model_ops.linear import use_triton_gemm
@@ -44,6 +51,22 @@ fused_qk_rope_concat_and_cache_mla = mark_trace(
 )
 mla_prefill_fwd = mark_trace(mla_prefill_fwd, prefix="mla_prefill", torch_compile=False)
 mla_decode_fwd = mark_trace(mla_decode_fwd, prefix="mla_decode", torch_compile=False)
+
+# Shuffled-KV (block_size=64) Triton/Gluon MLA kernels, gated by
+# ATOM_USE_TRITON_MLA and ATOM_USE_TRITON_MLA_SHUFFLE_KV:. Write kernels mirror the aiter
+# concat_and_cache / fused_qk_rope_concat_and_cache_mla but store the cache in
+# the shuffled layout the shuffled decode kernel reads back.
+triton_shuffle_mla_decode_fwd = mark_trace(
+    triton_shuffle_mla_decode_fwd, prefix="mla_decode_shuffle", torch_compile=False
+)
+triton_cat_and_cache_mla = mark_trace(
+    triton_cat_and_cache_mla, prefix="kv_cache_shuffle", torch_compile=False
+)
+triton_fused_qk_rope_cat_and_cache_mla = mark_trace(
+    triton_fused_qk_rope_cat_and_cache_mla,
+    prefix="rope_and_kv_cache_shuffle",
+    torch_compile=False,
+)
 
 # torch.set_printoptions(threshold=10_000)
 
@@ -381,6 +404,8 @@ class MLAAttention(nn.Module):
             attn_metadata.cu_seqlens_k,
             k_full,
             v_full,
+            getattr(attn_metadata, "shuffle_kv_block_indptr", None),
+            getattr(attn_metadata, "shuffle_kv_block_indices", None),
         )
         output = flash_attn_varlen_func(
             q=prefill_q,
@@ -405,20 +430,41 @@ class MLAAttention(nn.Module):
         cu_seqlens_k: torch.Tensor,
         k_out: torch.Tensor,
         v_out: torch.Tensor,
+        shuffle_kv_block_indptr: Optional[torch.Tensor] = None,
+        shuffle_kv_block_indices: Optional[torch.Tensor] = None,
     ) -> None:
         weight = self.kv_b_proj.weight
-        gather_kv_b_proj(
-            kv_cache,
-            self._k_scale,
-            kv_indptr,
-            kv_indices,
-            cu_seqlens_k,
-            _maybe_view_mxfp4_weight_for_gather(self.kv_b_proj, weight),
-            getattr(self.kv_b_proj, "weight_scale", None),
-            k_out,
-            v_out,
-            weight_preshuffle=getattr(weight, "is_shuffled", False),
-        )
+        if envs.ATOM_USE_TRITON_MLA and envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV:
+            # Shuffled KV: read the block_size-shuffled cache with block-granular
+            # CSR indices built by the metadata builder. cu_seqlens_k stays the
+            # token-granular context cumsum (output token positions).
+            kv_buffer = self._shuffled_kv_view(kv_cache)
+            gather_kv_b_proj(
+                kv_buffer.squeeze(1),  # [num_blocks, block_size, kv_lora+rope]
+                self._k_scale,
+                shuffle_kv_block_indptr,
+                shuffle_kv_block_indices,
+                cu_seqlens_k,
+                _maybe_view_mxfp4_weight_for_gather(self.kv_b_proj, weight),
+                getattr(self.kv_b_proj, "weight_scale", None),
+                k_out,
+                v_out,
+                weight_preshuffle=getattr(self.kv_b_proj.weight, "is_shuffled", False),
+                shuffled_kv_cache=True,
+            )
+        else:
+            gather_kv_b_proj(
+                kv_cache,
+                self._k_scale,
+                kv_indptr,
+                kv_indices,
+                cu_seqlens_k,
+                _maybe_view_mxfp4_weight_for_gather(self.kv_b_proj, weight),
+                getattr(self.kv_b_proj, "weight_scale", None),
+                k_out,
+                v_out,
+                weight_preshuffle=getattr(weight, "is_shuffled", False),
+            )
 
     def _forward_prefill_cached_chunked(
         self,
@@ -511,6 +557,16 @@ class MLAAttention(nn.Module):
                 chunk_meta.cu_seqlens_k[c],
                 k_chunk,
                 v_chunk,
+                shuffle_kv_block_indptr=(
+                    chunk_meta.shuffle_kv_block_indptr[c]
+                    if chunk_meta.shuffle_kv_block_indptr is not None
+                    else None
+                ),
+                shuffle_kv_block_indices=(
+                    chunk_meta.shuffle_kv_block_indices[c]
+                    if chunk_meta.shuffle_kv_block_indices is not None
+                    else None
+                ),
             )
             suf_out, suf_lse = flash_attn_varlen_func(
                 q=prefill_q,
@@ -739,6 +795,27 @@ class MLAAttention(nn.Module):
 
         return self._v_up_proj_and_o_proj(o)
 
+    def _shuffled_kv_view(self, kv_cache: torch.Tensor):
+        """View the flat ``[num_token_slots, 1, d]`` MLA cache as the
+        ``[num_blocks, num_kv_heads=1, block_size, d]`` shuffled layout the
+        block_size=64 Triton/Gluon MLA kernels read and write.
+
+        This is a pure view: ``num_token_slots == num_blocks * block_size`` by
+        construction (block_ratio == kv_cache_block_size), and the per-block
+        ``block_size * d`` region is contiguous, which is all the shuffled
+        kernels require (they compute their own within-block byte offsets).
+        """
+        if not hasattr(self, "_shuffle_block_size_cached"):
+            self._shuffle_block_size_cached = int(
+                get_current_atom_config().kv_cache_block_size
+            )
+        block_size = self._shuffle_block_size_cached
+        d = self.kv_lora_rank + self.qk_rope_head_dim
+        num_token_slots = kv_cache.shape[0]
+        num_blocks = num_token_slots // block_size
+        # [num_token_slots, 1, d] -> [num_blocks, block_size, d] -> [.., 1, ..]
+        return kv_cache.view(num_blocks, block_size, d).unsqueeze(1)
+
     def _forward_decode(
         self,
         q: torch.Tensor,
@@ -760,7 +837,28 @@ class MLAAttention(nn.Module):
             device=q.device,
         )
 
-        if hasattr(attn_metadata, "triton_block_table"):
+        if envs.ATOM_USE_TRITON_MLA and envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV:
+            # Shuffled block_size=64 Triton/Gluon MLA decode kernel.
+            kv_buffer = self._shuffled_kv_view(kv_c_and_k_pe_cache)
+            triton_shuffle_mla_decode_fwd(
+                q,  # [num_tokens, num_query_heads, kv_lora_rank + qk_rope_head_dim]
+                kv_buffer,  # [num_blocks, 1, block_size, kv_lora_rank + qk_rope_head_dim]
+                o,
+                attn_metadata.cu_seqlens_q,
+                attn_metadata.context_lens,  # seqused_k
+                int(attn_metadata.max_seqlen_k),  # max_seqlen_kv
+                attn_metadata.block_tables,  # [bs, max_num_blocks_per_seq] (logical)
+                self.scale,
+                self.kv_lora_rank,
+                self.qk_rope_head_dim,
+                True,  # causal
+                # q is bf16 (the shuffled fused write does not quantize q), so
+                # no q de-scale; kv carries its own per-tensor scale.
+                None,  # q_descale
+                self._k_scale,  # kv_descale
+                shuffled_kv_cache=True,
+            )
+        elif hasattr(attn_metadata, "triton_block_table"):
             from aiter.ops.triton.attention.mla_decode import decode_attention_fwd
 
             k_buffer = kv_c_and_k_pe_cache.unsqueeze(2)
@@ -898,16 +996,31 @@ class MLAAttention(nn.Module):
             self.rotary_emb(positions, prefill_q_pe, k_rope)
 
             if kv_cache.numel() > 0:
-                concat_and_cache_mla(
-                    k_nope,
-                    k_rope.squeeze(1),
-                    kv_cache,
-                    attn_metadata.slot_mapping.flatten(),
-                    kv_cache_dtype=self.kv_cache_dtype,
-                    scale=self._k_scale,
-                )
+                if envs.ATOM_USE_TRITON_MLA and envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV:
+                    shuffled_cache = self._shuffled_kv_view(kv_cache)
+                    triton_cat_and_cache_mla(
+                        k_nope.view(-1, self.num_kv_heads, self.kv_lora_rank),
+                        k_rope.view(-1, self.num_kv_heads, self.qk_rope_head_dim),
+                        shuffled_cache,
+                        attn_metadata.slot_mapping.flatten(),
+                        self._k_scale,
+                        apply_scale=True,
+                        shuffled_kv_cache=True,
+                    )
+                else:
+                    concat_and_cache_mla(
+                        k_nope,
+                        k_rope.squeeze(1),
+                        kv_cache,
+                        attn_metadata.slot_mapping.flatten(),
+                        kv_cache_dtype=self.kv_cache_dtype,
+                        scale=self._k_scale,
+                    )
 
             if attn_metadata.has_cached:
+                # Shuffled KV: the builder nulls mla_chunk_meta, so cached-prefix
+                # prefill always takes the single-pass gather (which is shuffle
+                # aware). The chunked path stays on the plain layout.
                 chunk_meta = getattr(attn_metadata, "mla_chunk_meta", None)
                 if chunk_meta is not None:
                     output = self._forward_prefill_cached_chunked(
@@ -934,24 +1047,46 @@ class MLAAttention(nn.Module):
                 device=q_nope.device,
             )
             if kv_cache.numel() > 0:
-                fused_qk_rope_concat_and_cache_mla(
-                    q_nope,
-                    q_rope,
-                    k_nope,
-                    k_rope,
-                    kv_cache.view(
-                        kv_cache.shape[0], -1, self.kv_lora_rank + self.qk_rope_head_dim
-                    ),
-                    q_out,
-                    attn_metadata.slot_mapping,
-                    self._k_scale,
-                    self._q_scale,
-                    positions,
-                    self.rotary_emb.cos_cache,
-                    self.rotary_emb.sin_cache,
-                    is_neox=self.rotary_emb.is_neox_style,
-                    is_nope_first=True,
-                )
+                if envs.ATOM_USE_TRITON_MLA and envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV:
+                    shuffled_cache = self._shuffled_kv_view(kv_cache)
+                    triton_fused_qk_rope_cat_and_cache_mla(
+                        q_nope,
+                        q_rope,
+                        k_nope.view(-1, self.num_kv_heads, self.kv_lora_rank),
+                        k_rope.view(-1, self.num_kv_heads, self.qk_rope_head_dim),
+                        shuffled_cache,
+                        attn_metadata.slot_mapping,
+                        positions,
+                        self.rotary_emb.cos_cache,
+                        self.rotary_emb.sin_cache,
+                        self._k_scale,
+                        self.rotary_emb.is_neox_style,
+                        num_decode_toks_for_zeros=0,
+                        apply_scale=True,
+                        q_out=q_out,
+                        shuffled_kv_cache=True,
+                    )
+                else:
+                    fused_qk_rope_concat_and_cache_mla(
+                        q_nope,
+                        q_rope,
+                        k_nope,
+                        k_rope,
+                        kv_cache.view(
+                            kv_cache.shape[0],
+                            -1,
+                            self.kv_lora_rank + self.qk_rope_head_dim,
+                        ),
+                        q_out,
+                        attn_metadata.slot_mapping,
+                        self._k_scale,
+                        self._q_scale,
+                        positions,
+                        self.rotary_emb.cos_cache,
+                        self.rotary_emb.sin_cache,
+                        is_neox=self.rotary_emb.is_neox_style,
+                        is_nope_first=True,
+                    )
                 # q_out = self.fused_kv_bmm(q, q_scale, k_nope, k_rope, positions, kv_cache, attn_metadata)
 
             if context.is_prefill:

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Type
 
 import numpy as np
 import torch
+from atom.utils import envs
 from aiter import (
     decode_update_mla_metadata_v1,
     dtypes,
@@ -54,6 +55,10 @@ class MLAChunkContextMetadata:
     num_chunks: int
     k_workspace: torch.Tensor
     v_workspace: torch.Tensor
+    # Block-granular CSR per chunk for the shuffled-KV gather (block_size=64
+    # blocks instead of token slots). None for the plain token-slot layout.
+    shuffle_kv_block_indptr: Optional[List[torch.Tensor]] = None
+    shuffle_kv_block_indices: Optional[List[torch.Tensor]] = None
 
 
 def cdiv(a, b):
@@ -77,6 +82,12 @@ class AiterMLABackend(AttentionBackend):
 class AiterMLAMetadataBuilder(CommonAttentionBuilder):
     def __init__(self, model_runner):
         self.block_size = 1
+        if envs.ATOM_USE_TRITON_MLA and envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV:
+            assert model_runner.block_size == 64, (
+                f"ATOM_USE_TRITON_MLA=1 and ATOM_USE_TRITON_MLA_SHUFFLE_KV=1 expects --block-size 64 "
+                f"for {model_runner.kv_cache_dtype} KV cache, "
+                f"got --block-size {model_runner.block_size}"
+            )
         CommonAttentionBuilder.__init__(self, model_runner)
         config = model_runner.config
         hf_config = config.hf_config

--- a/atom/model_ops/attentions/triton_mla.py
+++ b/atom/model_ops/attentions/triton_mla.py
@@ -2,15 +2,16 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import logging
-from typing import Type
+from typing import List, Type
 
 import torch
 from aiter.ops.triton.attention.mla_decode import csr_to_dense_block_table
 from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_ops.attention_mla import MLAAttention
+from atom.utils import envs
 from atom.utils.forward_context import AttentionMetaData
 
-from .aiter_mla import AiterMLAMetadataBuilder
+from .aiter_mla import AiterMLAMetadataBuilder, MLAChunkContextMetadata
 from .backends import AttentionBackend
 
 logger = logging.getLogger("atom")
@@ -89,6 +90,134 @@ class TritonMLAMetadataBuilder(AiterMLAMetadataBuilder):
         attn_metadata.triton_lse = var["triton_lse"][:scheduled_bs]
 
         return attn_metadata, positions
+
+    def prepare_prefill(self, batch: ScheduledBatch):
+        attn_metadata, positions = super().prepare_prefill(batch)
+
+        if envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV and attn_metadata.has_cached:
+            # The shuffled cached-prefix gather (gather_kv_b_proj with
+            # shuffled_kv_cache=True) reads block_size-token blocks, so it needs
+            # block-granular CSR indices (logical block ids) instead of the
+            # token-granular kv_indices used by the plain layout. Build them from
+            # the full per-seq context (cached + just-written new tokens).
+            bs = batch.total_seqs_num_prefill
+            block_size = self.model_runner.block_size
+            # All GPU: derive block counts from the (already on-device) full
+            # context lengths and pack the dense logical block table — populated
+            # by super().prepare_prefill for has_cached — into CSR via a masked
+            # select (row-major == per-seq CSR order).
+            var = self.model_runner.forward_vars
+            ctx = attn_metadata.context_lens[:bs]  # int32 [bs], full context
+            block_counts = (ctx + (block_size - 1)) // block_size  # [bs]
+
+            indptr = torch.zeros(bs + 1, dtype=torch.int32, device=self.device)
+            indptr[1:] = torch.cumsum(block_counts, dim=0).to(torch.int32)
+
+            block_tables = var["block_tables"].gpu[:bs]  # [bs, max_blocks] logical
+            col = torch.arange(block_tables.shape[1], device=self.device)
+            mask = col[None, :] < block_counts[:, None]
+            indices = block_tables[mask].to(torch.int32)
+
+            attn_metadata.shuffle_kv_block_indptr = indptr
+            attn_metadata.shuffle_kv_block_indices = indices
+            # If super() decided to chunk the cached prefix (total_kv >
+            # attn_prefill_chunk_size), rebuild block-aligned chunk metadata so
+            # the per-chunk gather can read the shuffled blocks. Otherwise the
+            # single-pass gather above is used (mla_chunk_meta stays None).
+            if (
+                hasattr(attn_metadata, "mla_chunk_meta")
+                and attn_metadata.mla_chunk_meta is not None
+            ):
+                attn_metadata.mla_chunk_meta = self._build_mla_chunk_meta_shuffle(
+                    attn_metadata, bs
+                )
+
+        return attn_metadata, positions
+
+    def _build_mla_chunk_meta_shuffle(self, attn_metadata, bs: int):
+        """Block-aligned variant of ``_build_mla_chunk_meta`` for the shuffled
+        KV layout.
+
+        The shuffled gather reads whole ``block_size``-token blocks, so chunks
+        are split along the *block* axis (≤ ``attn_prefill_chunk_size //
+        block_size`` blocks per chunk) rather than the token axis. Each chunk
+        carries block-granular CSR (``shuffle_kv_block_indptr/indices``) plus
+        token-granular ``cu_seqlens_k`` (output positions / flash_attn lens).
+
+        Built entirely on-device from the GPU ``num_cached_tokens`` and the
+        dense logical block table (populated by super().prepare_prefill).
+        """
+        device = self.device
+        block_size = self.model_runner.block_size
+        chunk_blocks = max(1, self.attn_prefill_chunk_size // block_size)
+
+        cached = attn_metadata.num_cached_tokens[:bs].to(torch.int64)  # [bs]
+        per_seq_blocks = (cached + (block_size - 1)) // block_size  # [bs]
+        total_blocks = int(per_seq_blocks.sum().item())
+        if total_blocks == 0:
+            return None
+        num_chunks = (total_blocks + chunk_blocks - 1) // chunk_blocks
+
+        # Global logical block list in per-seq CSR order (leading cached blocks
+        # of each seq), via a masked select on the dense block table.
+        block_tables = self.model_runner.forward_vars["block_tables"].gpu[:bs]
+        col = torch.arange(block_tables.shape[1], device=device)
+        global_blocks = block_tables[col[None, :] < per_seq_blocks[:, None]].to(
+            torch.int32
+        )  # [total_blocks]
+        blk_offsets = torch.zeros(bs + 1, dtype=torch.int64, device=device)
+        blk_offsets[1:] = torch.cumsum(per_seq_blocks, dim=0)
+
+        blk_indptr_list: List[torch.Tensor] = []
+        blk_indices_list: List[torch.Tensor] = []
+        cu_seqlens_k_list: List[torch.Tensor] = []
+        chunk_total_tokens: List[torch.Tensor] = []
+        chunk_max_seqlen_k: List[torch.Tensor] = []
+
+        for c in range(num_chunks):
+            gb_start = c * chunk_blocks
+            gb_end = min(gb_start + chunk_blocks, total_blocks)
+            # Per-seq local block range covered by this chunk.
+            seq_lo = blk_offsets[:bs].clamp(gb_start, gb_end)
+            seq_hi = blk_offsets[1 : bs + 1].clamp(gb_start, gb_end)
+            per_seq_chunk_blocks = (seq_hi - seq_lo).to(torch.int32)
+            local_lo = seq_lo - blk_offsets[:bs]  # first local block in chunk
+            local_hi = seq_hi - blk_offsets[:bs]  # last+1 local block in chunk
+            # Token count: full blocks * block_size, clamped to cached_len for
+            # the seq's final (partial) block.
+            per_seq_chunk_tokens = (
+                (torch.minimum(local_hi * block_size, cached) - local_lo * block_size)
+                .clamp_min(0)
+                .to(torch.int32)
+            )
+
+            blk_indptr = torch.zeros(bs + 1, dtype=torch.int32, device=device)
+            blk_indptr[1:] = torch.cumsum(per_seq_chunk_blocks, dim=0)
+            cu_k = torch.zeros(bs + 1, dtype=torch.int32, device=device)
+            cu_k[1:] = torch.cumsum(per_seq_chunk_tokens, dim=0)
+
+            blk_indptr_list.append(blk_indptr)
+            blk_indices_list.append(global_blocks[gb_start:gb_end])
+            cu_seqlens_k_list.append(cu_k)
+            chunk_total_tokens.append(cu_k[-1])
+            chunk_max_seqlen_k.append(per_seq_chunk_tokens.max())
+
+        # Single host sync for the python-int scalars the forward consumes.
+        total_tokens_list = torch.stack(chunk_total_tokens).tolist()
+        max_seqlen_k_list = torch.stack(chunk_max_seqlen_k).tolist()
+
+        return MLAChunkContextMetadata(
+            kv_indptr=blk_indptr_list,  # unused by shuffle gather; kept for parity
+            kv_indices=blk_indices_list,
+            cu_seqlens_k=cu_seqlens_k_list,
+            total_tokens=total_tokens_list,
+            max_seqlen_k=max_seqlen_k_list,
+            num_chunks=num_chunks,
+            k_workspace=self.k_chunk_workspace,
+            v_workspace=self.v_chunk_workspace,
+            shuffle_kv_block_indptr=blk_indptr_list,
+            shuffle_kv_block_indices=blk_indices_list,
+        )
 
     def build_for_cudagraph_capture(self, bs: int) -> AttentionMetaData:
         attn_metadata, context = super().build_for_cudagraph_capture(bs)

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -34,6 +34,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("ATOM_USE_TRITON_MXFP4_BMM", "0") == "1"
     ),
     "ATOM_USE_TRITON_MLA": lambda: os.getenv("ATOM_USE_TRITON_MLA", "0") == "1",
+    # Use the block_size=64 *shuffled* KV-cache Triton/Gluon MLA kernels
+    # (aiter.ops.triton.attention.mla.mla_decode_fwd + the shuffled cat/cache
+    # write kernels) instead of the SGLang-style page_size=1 decode path.
+    # Requires ATOM_USE_TRITON_MLA=1 (selects TritonMLABackend).
+    "ATOM_USE_TRITON_MLA_SHUFFLE_KV": lambda: (
+        os.getenv("ATOM_USE_TRITON_MLA_SHUFFLE_KV", "0") == "1"
+    ),
     "ATOM_USE_TRITON_MOE": lambda: os.getenv("ATOM_USE_TRITON_MOE", "0") == "1",
     # --- Kernel Fusion Toggles ---
     # fused_compress_attn: switch between Triton (default historical) and a


### PR DESCRIPTION
This PR depends on https://github.com/ROCm/aiter/pull/3688

This PR does the following:

when `ATOM_USE_TRITON_MLA=1` and `ATOM_USE_TRITON_MLA_SHUFFLE_KV=1`, the kv_buffer will be view as blocked kv_buffer, in which block_size is required to be fixed to `64`, this triggers AITER Gluon MLA `mla_decode_fwd` and it uses TDM loads on gfx1250. This PR supports either prefix caching `--no-enable_prefix_caching` or either chunked prefill `--no-enable_chunked_prefill` being on or off

It uses the AITER Triton/Gluon `cat_and_cache_mla` and `fused_qk_rope_cat_and_cache_mla` in order to support shuffled kv_buffer layout flushing