### PR TITLE
fix(sglang-plugin): register Kimi-K2.5 for the SGLang plugin path (#1078)

### DIFF
--- a/atom/plugin/register.py
+++ b/atom/plugin/register.py
@@ -25,12 +25,20 @@ if is_sglang():
         Qwen3_5ForCausalLM,
         Qwen3_5MoeForCausalLM,
     )
+    from atom.models.kimi_k25 import KimiK25ForCausalLM
 
     _ATOM_SUPPORTED_MODELS.update(
         {
             "Qwen3NextForCausalLM": Qwen3NextForCausalLM,
             "Qwen3_5ForConditionalGeneration": Qwen3_5ForCausalLM,
             "Qwen3_5MoeForConditionalGeneration": Qwen3_5MoeForCausalLM,
+            # ROCm/ATOM#1078: route Kimi-K2.x through ATOM's quant-aware model
+            # path (KimiK25ForCausalLM -> DeepseekV2ForCausalLM). The standalone
+            # engine already registers this in atom/model_engine/model_runner.py;
+            # the SGLang plugin path was missing it, so launches fell back to
+            # sglang's native model and failed weight loading on the excluded
+            # (BF16) attention projections.
+            "KimiK25ForConditionalGeneration": KimiK25ForCausalLM,
         }
     )
 

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -39,6 +39,9 @@ MODEL_ADAPTER_SPECS = {
     "GlmMoeDsaForCausalLM": SGLangModelAdapterSpec(
         install_adapters=_install_deepseek_mla_adapters,
     ),
+    "KimiK25ForConditionalGeneration": SGLangModelAdapterSpec(
+        install_adapters=_install_deepseek_mla_adapters,
+    ),
     "Qwen3MoeForCausalLM": SGLangModelAdapterSpec(),
     "Qwen3NextForCausalLM": SGLangModelAdapterSpec(
         wrapper_binds_gdn_context=True,
@@ -59,6 +62,7 @@ MODEL_ARCH_SPECS = {
     for key in (
         "DeepseekV3ForCausalLM",
         "GlmMoeDsaForCausalLM",
+        "KimiK25ForConditionalGeneration",
         "Qwen3MoeForCausalLM",
         "Qwen3NextForCausalLM",
     )


### PR DESCRIPTION
## Summary

Fixes #1078 — `atom+sglang` could not launch **Kimi-K2.x** (`KimiK25ForConditionalGeneration`).

Kimi was registered for ATOM's **standalone** engine (`atom/model_engine/model_runner.py:72`) but **not** for the **SGLang plugin** path. So launching with `SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models` fell back to sglang's *native* Kimi model, which MXFP4-packs the attention projections that the checkpoint keeps in **BF16** (everything under `quantization_config.exclude`: `q_a_proj`, `q_b_proj`, `kv_a_proj_with_mqa`, `kv_b_proj`, `o_proj`, `mlp.gate`, `lm_head`). Weight loading then failed with:

```
File ".../sglang/srt/layers/linear.py", line 269, in weight_loader
    assert param.size() == loaded_weight.size()
AssertionError
```

## Root cause

- The native sglang Quark path quantizes attention projections that should stay BF16, because (a) the wrapped model builds its nested LM with `prefix=""` so the `language_model.`-prefixed `exclude` entries don't match, and (b) `fused_qkv_a_proj_with_mqa` isn't mapped to its excluded constituents at quant-config snapshot time.
- ATOM's own model path **already handles both** via `KimiK25ForCausalLM.quant_exclude_name_mapping` (`language_model.model.` → `model.`) and `DeepseekV2ForCausalLM`'s `_is_excluded` + `fused_qkv_a_proj` construction. It was simply never wired into the plugin registry.

## Fix

Route Kimi through ATOM's quant-aware model path (`KimiK25ForCausalLM` → `DeepseekV2ForCausalLM`):

- **`atom/plugin/register.py`** — register `KimiK25ForConditionalGeneration` → `KimiK25ForCausalLM` in the SGLang `_ATOM_SUPPORTED_MODELS`.
- **`atom/plugin/sglang/runtime/model_arch.py`** — add a `MODEL_ADAPTER_SPECS` entry (DeepSeek-MLA adapters) and include it in `MODEL_ARCH_SPECS` so `base_model_wrapper` generates the SGLang `EntryClass`. Kimi's ATOM backbone is text-only, so the generic causal-LM wrapper is sufficient — no custom multimodal wrapper (à la `qwen3_5.py`) is required.

## TP=8 launch recipe (also part of #1078)

The aiter MLA-metadata kernel (`get_mla_metadata_v1`) requires `#heads % 16 == 0 && #heads >= 16`. Kimi has 64 attention heads, so a pure TP=8 split (64/8 = **8** heads/rank) is unsupported with `--attention-backend aiter`. Launch TP=8 with **DP-attention** so attention keeps 16 heads/rank:

```bash
python3 -m sglang.launch_server \
  --model-path /path/Kimi-K2.x-MXFP4 \
  --tensor-parallel-size 8 --enable-dp-attention --dp-size 2 \
  --attention-backend aiter --trust-remote-code \
  --kv-cache-dtype fp8_e4m3 --page-size 1 --disable-radix-cache
# env: SGLANG_USE_AITER=1, SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
```
(`--dp-size 8` → attention_tp=1 / 64-head simulated path currently aborts during cuda-graph capture in aiter — tracked separately.)

## Validation (MI355X, gfx950 — Kimi-K2.5-MXFP4, architecturally identical to K2.6)

- **Root cause + correctness** verified end-to-end on the equivalent native-sglang path with the Quark exclusion corrected: model loads at TP=8, coherent output, **gsm8k 3-shot = 0.634 flexible / 0.596 strict**, perf sweep 76→3041 tok/s (c1→c64). (The ~63% reflects w4a4 MXFP4 + INT4 quick-reduce + fp8-KV quantization, not a correctness defect.)
- **This plugin change**: confirmed sglang now routes Kimi to ATOM and engages ATOM's own weight pipeline (`atom/model_ops/linear.py`, `atom/model_ops/moe.py`). Full plugin-path serving validation is pending — the shared MI355X node was occupied by another TP=8 job and OOM'd the run before it finished loading. I'll update this PR with plugin-path gsm8k/perf once the node frees up.

## Notes

- Scope: SGLang plugin path (text-only backbone), matching #1078. vLLM already has `atom/plugin/vllm/models/kimi_k25.py`.
