### PR TITLE
feat(sglang-plugin): enable true TP=8 for Kimi-K2.5

### DIFF
--- a/atom/models/kimi_k25.py
+++ b/atom/models/kimi_k25.py
@@ -70,6 +70,16 @@ class KimiK25ForCausalLM(nn.Module):
     def packed_modules_mapping(self):
         return self.language_model.packed_modules_mapping
 
+    @property
+    def model(self):
+        # Expose the inner DeepseekV2Model so the SGLang plugin wrapper can
+        # reach ``embed_tokens`` for embed/lm_head tying (ROCm/ATOM#1078).
+        return self.language_model.model
+
+    @property
+    def lm_head(self):
+        return self.language_model.lm_head
+
     # ---- forward / inference API ----
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -57,6 +57,7 @@ MODEL_ADAPTER_SPECS = {
     ),
     "KimiK25ForConditionalGeneration": SGLangModelAdapterSpec(
         install_adapters=_install_deepseek_mla_adapters,
+        uses_context_only_forward=True,
     ),
     "Qwen3MoeForCausalLM": SGLangModelAdapterSpec(),
     "Qwen3NextForCausalLM": SGLangModelAdapterSpec(


### PR DESCRIPTION
## Summary

Enables **true tensor-parallel-8** serving of **Kimi-K2.5** on the ATOM SGLang plugin (`--tensor-parallel-size 8`, **no** dp-attention), matching the dashboard's "Kimi-K2.5-MXFP4 TP8" configuration.

Builds on #1189 (which registered Kimi for the SGLang plugin so launches stop falling back to sglang's native model). With registration alone, a real TP=8 launch still failed at several points; this PR fixes them so Kimi behaves like the other DeepSeek-MLA plugin models (DeepseekV3 / GLM / MiniMax).

## Root cause chain (true TP=8) and fixes

1. **`forward()` got unexpected `forward_batch`** — `base_model_wrapper` calls the model forward with `forward_batch=...` unless the arch sets `uses_context_only_forward` (the batch is supplied via the bound `SGLangForwardBatchMetadata` context). Kimi's adapter spec omitted it.
   → `model_arch.py`: `uses_context_only_forward=True` for `KimiK25ForConditionalGeneration`.
2. **`'KimiK25ForCausalLM' object has no attribute 'lm_head'`** (and `model`) — the wrapper reaches `self.model.lm_head` / `self.model.model.embed_tokens` for logits and embed/head tying, but Kimi nests these under `self.language_model`.
   → `atom/models/kimi_k25.py`: add `model` and `lm_head` properties forwarding to the inner `DeepseekV2ForCausalLM`.

## Launch recipe for true TP=8 on gfx950 (MI355X)

- **BF16 KV cache** (do **not** pass `--kv-cache-dtype fp8_e4m3`). aiter's MLA decode kernel natively supports `nhead=8` (64 heads / TP8) on gfx950 **only when both q and kv are bf16**; fp8 KV falls through to `aiter/mla.py: assert nhead=8 ... not supported`.
- **`SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0`** — ATOM's collective buffers (~34 GB/GPU) drop free memory below sglang's 90% TP-memory-balance threshold at dist init, which otherwise raises.

Reference launch (sglang plugin, true TP=8):
```bash
export SGLANG_USE_AITER=1 AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
export SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0
python3 -m sglang.launch_server --model-path <Kimi-K2.5-MXFP4> \
  --tensor-parallel-size 8 --attention-backend aiter --trust-remote-code \
  --page-size 1 --disable-radix-cache      # BF16 KV (no --kv-cache-dtype fp8)
```

## Validation — MI355X (gfx950), Kimi-K2.5-MXFP4, true TP=8 (no dp-attention)

Loads, captures CUDA graphs, and serves correct output.

**Accuracy — gsm8k 3-shot:** flexible-extract **0.9424**, strict-match **0.9409** (dashboard baseline 0.93, threshold 0.92).

**Throughput — ISL/OSL 1024/1024:**

| Concurrency | Output tok/s | Total tok/s | Mean TTFT | Median TPOT |
|---|---|---|---|---|
| 1  | 104  | 208  | 103 ms | 9.5 ms |
| 8  | 712  | 1,423 | 206 ms | 11.0 ms |
| 32 | 2,060 | 4,120 | 516 ms | 15.0 ms |
| 64 | 3,166 (peak 3,456) | 6,333 | 835 ms | 19.4 ms |

Sanity: "The capital of France is" → "Paris…"; "17×23" → "391" (and 408, 425); coherent story generation.
