### PR TITLE
[sgl-atom][Feat] enable Kimi-K2.6-MXFP4 in sgl atom

### DIFF
--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -24,6 +24,30 @@
     "_baseline_note": "Online quant coverage based on the DeepSeek-R1-FP8 TP4 SGLang accuracy validation target for gsm8k."
   },
   {
+    "model_name": "Kimi-K2.6-MXFP4 TP4",
+    "model_path": "amd/Kimi-K2.6-MXFP4",
+    "extraArgs": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --page-size 1 --disable-radix-cache",
+    "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+    "runner": "linux-atom-mi35x-4",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.91,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "amd/Kimi-K2.6-MXFP4",
+    "_baseline_note": "HF model card reports Kimi-K2.6-MXFP4 GSM8K flexible-extract=0.9325; threshold leaves headroom for SGLang CI noise."
+  },
+  {
+    "model_name": "Kimi-K2.6-MXFP4 TP8",
+    "model_path": "amd/Kimi-K2.6-MXFP4",
+    "extraArgs": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --page-size 1 --disable-radix-cache",
+    "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+    "runner": "linux-atom-mi35x-8",
+    "test_level": "nightly",
+    "accuracy_threshold": 0.91,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "amd/Kimi-K2.6-MXFP4",
+    "_baseline_note": "TP8 coverage for the Kimi-K2.6-MXFP4 SGLang accuracy validation target for gsm8k."
+  },
+  {
     "model_name": "Qwen3.5-35B-A3B-FP8 TP2",
     "model_path": "Qwen/Qwen3.5-35B-A3B-FP8",
     "extraArgs": "--tensor-parallel-size 2 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -19,6 +19,16 @@ on:
         required: false
         type: boolean
         default: false
+      run_kimi_k26_mxfp4_tp4:
+        description: "Kimi-K2.6-MXFP4 TP4"
+        required: false
+        type: boolean
+        default: false
+      run_kimi_k26_mxfp4_tp8:
+        description: "Kimi-K2.6-MXFP4 TP8"
+        required: false
+        type: boolean
+        default: false
       run_qwen35_35b_a3b_fp8_tp2:
         description: "Qwen3.5-35B-A3B-FP8 TP2"
         required: false
@@ -140,6 +150,8 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           RUN_DSR1_FP8_TP4: ${{ inputs.run_dsr1_fp8_tp4 }}
           RUN_DSR1_FP8_TP4_ONLINE_QUANT: ${{ inputs.run_dsr1_fp8_tp4_online_quant }}
+          RUN_KIMI_K26_MXFP4_TP4: ${{ inputs.run_kimi_k26_mxfp4_tp4 }}
+          RUN_KIMI_K26_MXFP4_TP8: ${{ inputs.run_kimi_k26_mxfp4_tp8 }}
           RUN_QWEN35_35B_A3B_FP8_TP2: ${{ inputs.run_qwen35_35b_a3b_fp8_tp2 }}
           RUN_QWEN35_35B_A3B_TP2: ${{ inputs.run_qwen35_35b_a3b_tp2 }}
           RUN_QWEN35_397B_A17B_FP8_TP4: ${{ inputs.run_qwen35_397b_a17b_fp8_tp4 }}
@@ -184,6 +196,24 @@ jobs:
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
                   "runner": "linux-atom-mi35x-4",
+              },
+              {
+                  "toggle_env": "RUN_KIMI_K26_MXFP4_TP4",
+                  "model_name": "Kimi-K2.6-MXFP4 TP4",
+                  "model_path": "amd/Kimi-K2.6-MXFP4",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --page-size 1 --disable-radix-cache",
+                  "accuracy_test_threshold": 0.91,
+                  "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+                  "runner": "linux-atom-mi35x-4",
+              },
+              {
+                  "toggle_env": "RUN_KIMI_K26_MXFP4_TP8",
+                  "model_name": "Kimi-K2.6-MXFP4 TP8",
+                  "model_path": "amd/Kimi-K2.6-MXFP4",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --page-size 1 --disable-radix-cache",
+                  "accuracy_test_threshold": 0.91,
+                  "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+                  "runner": "linux-atom-mi35x-8",
               },
               {
                   "toggle_env": "RUN_QWEN35_35B_A3B_FP8_TP2",

--- a/atom/plugin/sglang/attention_backend/full_attention/full_attention_backend.py
+++ b/atom/plugin/sglang/attention_backend/full_attention/full_attention_backend.py
@@ -2212,6 +2212,38 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
     def _call_mla_decode_fwd(self, q, k_buffer, o, layer):
         """Common mla_decode_fwd invocation shared across decode/extend paths."""
         md = self.forward_metadata
+        head_repeat_factor = getattr(self, "head_repeat_factor", 1)
+        if head_repeat_factor > 1:
+            q_in = q.repeat_interleave(head_repeat_factor, dim=1)
+            o_padded = q.new_empty(
+                (q.shape[0], self.num_head_padded, layer.v_head_dim),
+                dtype=self.input_dtype,
+            )
+            mla_decode_fwd(
+                q_in,
+                k_buffer.view(-1, 1, 1, layer.qk_head_dim),
+                o_padded,
+                md.qo_indptr,
+                md.kv_indptr,
+                md.kv_indices,
+                md.kv_last_page_len,
+                md.max_q_len,
+                sm_scale=layer.scaling,
+                logit_cap=layer.logit_cap,
+                work_meta_data=md.work_metadata,
+                work_indptr=md.work_indptr,
+                work_info_set=md.work_info_set,
+                reduce_indptr=md.reduce_indptr,
+                reduce_final_map=md.reduce_final_map,
+                reduce_partial_map=md.reduce_partial_map,
+                q_scale=layer.k_scale,
+                kv_scale=layer.k_scale,
+                intra_batch_mode=_sglang_aiter.intra_batch_mode,
+                num_kv_splits=md.num_kv_splits,
+            )
+            o.copy_(o_padded[:, ::head_repeat_factor, :])
+            return
+
         mla_decode_fwd(
             q,
             k_buffer.view(-1, 1, 1, layer.qk_head_dim),

--- a/atom/plugin/sglang/models/kimi_k25.py
+++ b/atom/plugin/sglang/models/kimi_k25.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+import torch
+from torch import nn
+
+from atom.model_loader.loader import WeightsMapper, load_model_in_plugin_mode
+from atom.plugin.sglang.runtime import (
+    SGLangForwardBatchMetadata,
+    SGLangPluginRuntime,
+    plugin_runtime_scope,
+)
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.kimi_k25 import (
+    KimiK25ForConditionalGeneration as _SglangKimiK25ForConditionalGeneration,
+)
+from sglang.srt.utils import LazyValue
+
+_KIMI_K25_PACKED_MODULES_MAPPING = {
+    "q_a_proj": ("fused_qkv_a_proj", 0),
+    "kv_a_proj_with_mqa": ("fused_qkv_a_proj", 1),
+    "gate_proj": ("gate_up_proj", 0),
+    "up_proj": ("gate_up_proj", 1),
+}
+
+_KIMI_K25_QUANT_EXCLUDE_NAME_MAPPING = {
+    "language_model.model.": "model.",
+    "language_model.lm_head": "lm_head",
+}
+
+_KIMI_K25_HF_TO_ATOM_MAPPER = WeightsMapper(
+    orig_to_new_substr={
+        "mm_projector.proj.0": "mm_projector.linear_1",
+        "mm_projector.proj.2": "mm_projector.linear_2",
+    },
+    orig_to_new_prefix={
+        # Kimi checkpoints seen in the wild use both nested and flattened
+        # language-model prefixes. Keep all of them pointed at the SGLang-style
+        # wrapper slots backed by the ATOM text model.
+        "model.language_model.": "language_model.model.",
+        "language_model.layers.": "language_model.model.layers.",
+        "lm_head.": "language_model.lm_head.",
+    },
+)
+
+
+def remap_kimi_k25_quant_config_for_sglang_plugin(
+    atom_config: Any, model_arch: str
+) -> None:
+    del model_arch
+    quant_config = getattr(atom_config, "quant_config", None)
+    if quant_config is None:
+        return
+
+    quant_config.remap_layer_name(
+        atom_config.hf_config,
+        packed_modules_mapping=dict(_KIMI_K25_PACKED_MODULES_MAPPING),
+        weights_mapper=_KIMI_K25_HF_TO_ATOM_MAPPER,
+        quant_exclude_name_mapping=_KIMI_K25_QUANT_EXCLUDE_NAME_MAPPING,
+    )
+
+
+class _AtomKimiK25LanguageModelAdapter(nn.Module):
+    """Expose ATOM's Kimi text model through SGLang's language-model API."""
+
+    def __init__(
+        self,
+        atom_lm: nn.Module,
+        quant_config: Optional[QuantizationConfig] = None,
+    ) -> None:
+        super().__init__()
+        self.pp_group = get_pp_group()
+        self.atom_config = atom_lm.atom_config
+        self.config = atom_lm.config
+        self.quant_config = quant_config or self.atom_config.quant_config
+
+        atom_text_lm = atom_lm.language_model
+        atom_text_lm.atom_config = self.atom_config
+        self.model = atom_text_lm.model
+        self.lm_head = atom_text_lm.lm_head
+        self.make_empty_intermediate_tensors = atom_lm.make_empty_intermediate_tensors
+        self.packed_modules_mapping = atom_text_lm.packed_modules_mapping
+        self._routed_experts_weights_of_layer = LazyValue(
+            lambda: {
+                layer_id: layer.mlp.get_moe_weights()
+                for layer_id, layer in enumerate(self.model.layers)
+                if hasattr(getattr(layer, "mlp", None), "get_moe_weights")
+            }
+        )
+        self.logits_processor = LogitsProcessor(
+            self.config,
+            skip_all_gather=bool(self.atom_config.enable_dp_attention),
+        )
+        self.__dict__["_atom_lm"] = atom_lm
+
+        from atom.plugin.sglang.models.deepseek_mla import setup_deepseek_for_sglang
+
+        with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
+            setup_deepseek_for_sglang(atom_text_lm)
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    @property
+    def start_layer(self) -> int:
+        return self.model.start_layer
+
+    @property
+    def end_layer(self) -> int:
+        return self.model.end_layer
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self._atom_lm.get_expert_mapping()
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor],
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        **model_kwargs: Any,
+    ):
+        with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
+            with SGLangPluginRuntime(
+                atom_config=self.atom_config,
+                forward_batch=forward_batch,
+                positions=positions,
+                input_ids=input_ids,
+                input_embeds=input_embeds,
+            ) as runtime:
+                metadata = SGLangForwardBatchMetadata.build(
+                    runtime.forward_batch,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                    save_kv_cache=model_kwargs.get("save_kv_cache"),
+                )
+                intermediate_tensors = (
+                    SGLangForwardBatchMetadata.to_intermediate_tensors(
+                        pp_proxy_tensors,
+                        metadata,
+                    )
+                )
+                with SGLangForwardBatchMetadata.bind(metadata):
+                    hidden_states = self._atom_lm(
+                        input_ids=runtime.input_ids,
+                        positions=runtime.positions,
+                        intermediate_tensors=intermediate_tensors,
+                        inputs_embeds=runtime.input_embeds,
+                    )
+                hidden_states = runtime.trim_output(hidden_states)
+
+                if self.pp_group.is_last_rank:
+                    return self.logits_processor(
+                        runtime.input_ids,
+                        hidden_states,
+                        self.lm_head,
+                        runtime.forward_batch,
+                    )
+                return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        # The outer Kimi wrapper owns loading so vision/projector weights are
+        # loaded together with the ATOM text backbone.
+        del weights
+        return set()
+
+    def get_embed_and_head(self):
+        return self.model.embed_tokens.weight, self.lm_head.weight
+
+    def set_embed_and_head(self, embed, head):
+        del self.model.embed_tokens.weight
+        del self.lm_head.weight
+        self.model.embed_tokens.weight = embed
+        self.lm_head.weight = head
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+    def set_embed(self, embed):
+        del self.model.embed_tokens.weight
+        self.model.embed_tokens.weight = embed
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+
+class KimiK25ForConditionalGeneration(_SglangKimiK25ForConditionalGeneration):
+    hf_to_atom_mapper = _KIMI_K25_HF_TO_ATOM_MAPPER
+    packed_modules_mapping = _KIMI_K25_PACKED_MODULES_MAPPING
+
+    def __init__(
+        self,
+        config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        **kwargs: Any,
+    ) -> None:
+        from atom.plugin.sglang.prepare import prepare_model
+
+        with plugin_runtime_scope(framework="sglang"):
+            atom_lm = prepare_model(config=config)
+
+        original_language_model_cls = (
+            _SglangKimiK25ForConditionalGeneration.__init__.__globals__[
+                "DeepseekV3ForCausalLM"
+            ]
+        )
+        _SglangKimiK25ForConditionalGeneration.__init__.__globals__[
+            "DeepseekV3ForCausalLM"
+        ] = lambda *args, **kwargs: _AtomKimiK25LanguageModelAdapter(
+            atom_lm,
+            quant_config=quant_config,
+        )
+        try:
+            super().__init__(
+                config=config,
+                quant_config=quant_config,
+                prefix=prefix,
+                **kwargs,
+            )
+        finally:
+            _SglangKimiK25ForConditionalGeneration.__init__.__globals__[
+                "DeepseekV3ForCausalLM"
+            ] = original_language_model_cls
+
+        self.atom_config = atom_lm.atom_config
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+        self.packed_modules_mapping = self.language_model.packed_modules_mapping
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.language_model.get_expert_mapping()
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        del weights
+        with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
+            return load_model_in_plugin_mode(
+                model=self,
+                config=self.atom_config,
+                prefix="",
+                weights_mapper=self.hf_to_atom_mapper,
+            )
+
+
+EntryClass = [KimiK25ForConditionalGeneration]

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -40,6 +40,14 @@ def _prepare_minimax_m2_config(atom_config: Any, model_arch: str) -> None:
     )
 
 
+def _prepare_kimi_k25_config(atom_config: Any, model_arch: str) -> None:
+    from atom.plugin.sglang.models.kimi_k25 import (
+        remap_kimi_k25_quant_config_for_sglang_plugin,
+    )
+
+    remap_kimi_k25_quant_config_for_sglang_plugin(atom_config, model_arch)
+
+
 def _install_deepseek_mla_adapters(model: Any) -> None:
     from atom.plugin.sglang.models.deepseek_mla import setup_deepseek_for_sglang
 
@@ -56,6 +64,7 @@ MODEL_ADAPTER_SPECS = {
         uses_context_only_forward=True,
     ),
     "KimiK25ForConditionalGeneration": SGLangModelAdapterSpec(
+        prepare_config=_prepare_kimi_k25_config,
         install_adapters=_install_deepseek_mla_adapters,
     ),
     "Qwen3MoeForCausalLM": SGLangModelAdapterSpec(),
@@ -82,7 +91,6 @@ MODEL_ARCH_SPECS = {
     for key in (
         "DeepseekV3ForCausalLM",
         "GlmMoeDsaForCausalLM",
-        "KimiK25ForConditionalGeneration",
         "Qwen3MoeForCausalLM",
         "Qwen3NextForCausalLM",
         "MiniMaxM2ForCausalLM",


### PR DESCRIPTION
## Motivation

enable Kimi-K2.6-MXFP4 in sgl atom

## Command
TP4:
```
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
export SGLANG_ENABLE_TORCH_COMPILE=1

TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path /models/Kimi-K2.6-MXFP4/ \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --attention-backend aiter \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.8 \
    --page-size 1 \
    --disable-radix-cache > log-kimi.log 2>&1
```

TP8:
```
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export SGLANG_USE_AITER=1
export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
export SGLANG_ENABLE_TORCH_COMPILE=1

TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path /models/Kimi-K2.6-MXFP4/ \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size 8 \
    --attention-backend aiter \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.8 \
    --page-size 1 \
    --disable-radix-cache > log-kimi.log 2>&1
```

## ACC
TP4:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.934|±  |0.0068|
|     |       |strict-match    |     3|exact_match|↑  |0.934|±  |0.0068|
```

TP8:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9371|±  |0.0067|
|     |       |strict-match    |     3|exact_match|↑  |0.9371|±  |0.0067|
```
