### PR TITLE
[draft] feat(eplb): add per-layer expert-load statistics monitor for EP path

### DIFF
--- a/atom/model_engine/engine_utility.py
+++ b/atom/model_engine/engine_utility.py
@@ -41,6 +41,7 @@ class EngineUtilityHandler:
         "stop_profile": "_handle_stop_profile",
         "get_mtp_stats": "_handle_get_mtp_stats",
         "get_mtp_statistics": "_handle_get_mtp_statistics",
+        "offline_eplb_rebalance": "_handle_offline_eplb_rebalance",
     }
 
     def __init__(
@@ -268,3 +269,11 @@ class EngineUtilityHandler:
         self.output_queue.put_nowait(
             ("UTILITY_RESPONSE", {"cmd": "get_mtp_statistics", "result": result})
         )
+
+    # ------------------------------------------------------------------
+    # EPLB expert-load statistics
+    # ------------------------------------------------------------------
+
+    def _handle_offline_eplb_rebalance(self, args: dict):
+        """Trigger a one-shot offline EPLB rebalance plan (fire-and-forget)."""
+        self.runner_mgr.call_func("trigger_offline_eplb_rebalance", wait_out=True)

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -264,6 +264,9 @@ class LLMEngine:
             },
         }
 
+    def offline_eplb_rebalance(self):
+        self.core_mgr.send_utility_command("offline_eplb_rebalance")
+
 
 class InputOutputProcessor:
 

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -26,6 +26,7 @@ from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
 from atom.model_loader.loader import load_model
 from atom.model_ops.rejection_sampler import RejectionSampler
 from atom.model_ops.sampler import SAMPLER_EPS, Sampler
+from atom.model_ops.eplb_stats import get_expert_load_monitor
 from atom.spec_decode.eagle import EagleProposer
 from atom.utils import (
     CpuGpuBuffer,
@@ -994,6 +995,11 @@ class ModelRunner:
             elapsed,
         )
         return {"trace_dir": self.profiler_dir, "elapsed": elapsed}
+
+    def trigger_offline_eplb_rebalance(self):
+        """Generate a one-shot offline EPLB rebalance plan from collected stats."""
+        get_expert_load_monitor().trigger_offline_rebalance(reason="utility_command")
+        return True
 
     def debug(self, *args: Any):
         if self.rank == 0:
@@ -2166,6 +2172,7 @@ class ModelRunner:
             hidden_states,
             needs_independent_noise=needs_independent_noise,
         )
+        get_expert_load_monitor().step(is_dummy_run=batch.is_dummy_run)
         reset_forward_context()
         return fwd_output
 

--- a/atom/model_ops/eplb_stats.py
+++ b/atom/model_ops/eplb_stats.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+
+import torch
+
+from atom.utils import envs
+
+logger = logging.getLogger("atom")
+
+
+@dataclass
+class _LayerExpertLoadState:
+    expert_load_pass: torch.Tensor
+    expert_load_window: torch.Tensor
+    window_step: int = 0
+
+
+class ExpertLoadMonitor:
+    """Lightweight EPLB-style expert-load monitor for ATOM EP path.
+
+    This monitor tracks per-layer, per-expert token counts in two tensors:
+    - ``expert_load_pass``: load accumulated in current pass window.
+    - ``expert_load_window``: ring buffer of recent pass windows.
+
+    The implementation intentionally keeps scope narrow:
+    - per-rank statistics only (no cross-rank all-reduce yet),
+    - collection wired to MORI dispatch output (dispatch_recv_token_num).
+    """
+
+    def __init__(self) -> None:
+        self._enabled = envs.ATOM_ENABLE_EPLB_LOAD_STATS
+        self._window_size = max(1, envs.ATOM_EPLB_LOAD_WINDOW_SIZE)
+        self._log_interval = max(1, envs.ATOM_EPLB_LOG_INTERVAL)
+        self._offline_rebalance_after_steps = max(
+            0, envs.ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS
+        )
+        self._states: dict[str, _LayerExpertLoadState] = {}
+        self._steps = 0
+        self._real_steps = 0
+        self._offline_rebalance_done = False
+        self._lock = threading.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def record_expert_load_pass(
+        self, layer_name: str | None, dispatch_recv_token_num: torch.Tensor
+    ) -> None:
+        if not self._enabled or layer_name is None:
+            return
+        if dispatch_recv_token_num.numel() == 0:
+            return
+
+        # Keep counting on the source device to avoid per-step D2H copies.
+        # We only normalize dtype/shape here.
+        counts = (
+            dispatch_recv_token_num.detach()
+            .to(dtype=torch.int64)
+            .reshape(-1)
+            .contiguous()
+        )
+
+        with self._lock:
+            state = self._states.get(layer_name)
+            if state is None:
+                pass_tensor = torch.zeros_like(counts, dtype=torch.int64)
+                window = torch.zeros(
+                    (self._window_size, counts.numel()),
+                    dtype=torch.int64,
+                    device=counts.device,
+                )
+                state = _LayerExpertLoadState(
+                    expert_load_pass=pass_tensor,
+                    expert_load_window=window,
+                )
+                self._states[layer_name] = state
+            elif (
+                state.expert_load_pass.numel() != counts.numel()
+                or state.expert_load_pass.device != counts.device
+            ):
+                # Defensive reset for shape changes caused by model swap/reinit.
+                logger.warning(
+                    "EPLB monitor reset for layer=%s due to expert-size/device change "
+                    "(size %d -> %d, device %s -> %s).",
+                    layer_name,
+                    state.expert_load_pass.numel(),
+                    counts.numel(),
+                    state.expert_load_pass.device,
+                    counts.device,
+                )
+                state.expert_load_pass = torch.zeros_like(counts, dtype=torch.int64)
+                state.expert_load_window = torch.zeros(
+                    (self._window_size, counts.numel()),
+                    dtype=torch.int64,
+                    device=counts.device,
+                )
+                state.window_step = 0
+
+            state.expert_load_pass.add_(counts)
+
+    def step(self, *, is_dummy_run: bool = False) -> None:
+        if not self._enabled:
+            return
+        with self._lock:
+            if not self._states:
+                return
+            self._steps += 1
+            if is_dummy_run:
+                # Drop any load collected during dummy/warmup forwards so it
+                # never leaks into the next real step's statistics.
+                for state in self._states.values():
+                    state.expert_load_pass.zero_()
+                return
+
+            self._real_steps += 1
+            should_log = (self._real_steps % self._log_interval) == 0
+
+            for layer_name, state in self._states.items():
+                state.expert_load_window[state.window_step].copy_(state.expert_load_pass)
+
+                if should_log:
+                    load = state.expert_load_pass
+                    avg_tokens = load.float().mean().item()
+                    max_tokens = load.max().item()
+                    balancedness = (avg_tokens / max_tokens) if max_tokens > 0 else 0.0
+                    logger.info(
+                        "EPLB load stats layer=%s step=%d avg_tokens=%.2f "
+                        "max_tokens=%d balancedness=%.4f",
+                        layer_name,
+                        self._real_steps,
+                        avg_tokens,
+                        int(max_tokens),
+                        balancedness,
+                    )
+
+                state.expert_load_pass.zero_()
+                state.window_step += 1
+                if state.window_step >= self._window_size:
+                    state.window_step = 0
+
+            if (
+                not self._offline_rebalance_done
+                and self._offline_rebalance_after_steps > 0
+                and self._real_steps >= self._offline_rebalance_after_steps
+            ):
+                self._offline_rebalance_done = True
+                self._log_offline_rebalance_plan()
+
+    def trigger_offline_rebalance(self, reason: str = "manual") -> None:
+        if not self._enabled:
+            logger.info(
+                "EPLB offline rebalance trigger skipped: load stats monitor is disabled."
+            )
+            return
+        with self._lock:
+            self._log_offline_rebalance_plan(reason=reason)
+
+    def _log_offline_rebalance_plan(self, reason: str = "auto") -> None:
+        logger.info(
+            "EPLB offline rebalance planning trigger (%s) at step=%d real_step=%d.",
+            reason,
+            self._steps,
+            self._real_steps,
+        )
+        for layer_name, state in self._states.items():
+            window_sum = state.expert_load_window.sum(dim=0)
+            if window_sum.numel() == 0:
+                continue
+            top_k = min(8, window_sum.numel())
+            top_vals, top_idx = torch.topk(window_sum, k=top_k, largest=True, sorted=True)
+            bottom_vals, bottom_idx = torch.topk(
+                window_sum, k=top_k, largest=False, sorted=True
+            )
+            avg_tokens = window_sum.float().mean().item()
+            max_tokens = window_sum.max().item()
+            balancedness = (avg_tokens / max_tokens) if max_tokens > 0 else 0.0
+            logger.info(
+                "EPLB offline plan layer=%s avg_tokens=%.2f max_tokens=%d "
+                "balancedness=%.4f hot_experts=%s cold_experts=%s",
+                layer_name,
+                avg_tokens,
+                int(max_tokens),
+                balancedness,
+                list(zip(top_idx.tolist(), top_vals.tolist())),
+                list(zip(bottom_idx.tolist(), bottom_vals.tolist())),
+            )
+        logger.info(
+            "EPLB offline plan generated. Note: automatic expert weight remap/transfer "
+            "is not applied in this pass."
+        )
+
+
+_EXPERT_LOAD_MONITOR = ExpertLoadMonitor()
+
+
+def get_expert_load_monitor() -> ExpertLoadMonitor:
+    return _EXPERT_LOAD_MONITOR

--- a/atom/model_ops/fused_moe/mori_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_prepare_finalize.py
@@ -9,6 +9,7 @@ import torch
 
 import atom.model_ops.fused_moe.modular_kernel as mk
 from atom.model_ops.fused_moe.config import FusedMoEQuantConfig
+from atom.model_ops.eplb_stats import get_expert_load_monitor
 from atom.utils.forward_context import get_forward_context
 from aiter import QuantType, dtypes
 
@@ -129,6 +130,7 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         self.quant_dtype = quant_dtype
         self._is_async = is_async
         self._low_latency = low_latency
+        self.layer_name: str | None = None
 
     @property
     def activation_format(self) -> mk.FusedMoEActivationFormat:
@@ -159,6 +161,14 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         if context.is_prefill:
             return 128, 16
         return 64, 4
+
+    def set_layer_name(self, layer_name: str) -> None:
+        self.layer_name = layer_name
+
+    def _record_expert_load_pass(self, dispatch_recv_token_num: torch.Tensor) -> None:
+        get_expert_load_monitor().record_expert_load_pass(
+            self.layer_name, dispatch_recv_token_num
+        )
 
     # ---- Synchronous (non-TBO) path ----
 
@@ -204,6 +214,7 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         ) = self._sync_mori_op.dispatch(
             a1, topk_weights, scale, topk_ids, block_num, warp_per_block
         )
+        self._record_expert_load_pass(dispatch_recv_token_num)
 
         expert_tokens_meta = mk.ExpertTokensMetadata(
             expert_num_tokens=dispatch_recv_token_num, expert_num_tokens_cpu=None
@@ -299,6 +310,7 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             mori_op.dispatch_recv()
 
         def receiver() -> mk.PrepareResultType:
+            self._record_expert_load_pass(dispatch_recv_token_num)
             expert_tokens_meta = mk.ExpertTokensMetadata(
                 expert_num_tokens=dispatch_recv_token_num,
                 expert_num_tokens_cpu=None,
@@ -346,6 +358,7 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         tbo_switch_to_compute_sync()
 
         def receiver() -> mk.PrepareResultType:
+            self._record_expert_load_pass(dispatch_recv_token_num)
             expert_tokens_meta = mk.ExpertTokensMetadata(
                 expert_num_tokens=dispatch_recv_token_num,
                 expert_num_tokens_cpu=None,

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -486,6 +486,10 @@ class FusedMoEMethodBase(QuantizeMethodBase):
             # logger.debug(
             #     "%s for %s(%s)", prepare_finalize.__class__.__name__, self, id(self)
             # )
+            if hasattr(prepare_finalize, "set_layer_name") and hasattr(
+                layer, "layer_name"
+            ):
+                prepare_finalize.set_layer_name(layer.layer_name)
             assert self.topk_indices_dtype is None
             assert (
                 self.fused_experts is None

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -116,6 +116,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD": lambda: int(
         os.getenv("ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD", "1024")
     ),
+    # EPLB-style per-layer expert-load statistics collection (ATOM local monitor).
+    "ATOM_ENABLE_EPLB_LOAD_STATS": lambda: (
+        os.getenv("ATOM_ENABLE_EPLB_LOAD_STATS", "0") == "1"
+    ),
+    "ATOM_EPLB_LOAD_WINDOW_SIZE": lambda: int(
+        os.getenv("ATOM_EPLB_LOAD_WINDOW_SIZE", "100")
+    ),
+    "ATOM_EPLB_LOG_INTERVAL": lambda: int(os.getenv("ATOM_EPLB_LOG_INTERVAL", "50")),
+    # Trigger one offline EPLB rebalance planning pass after N forward steps.
+    # 0 disables auto trigger.
+    "ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS": lambda: int(
+        os.getenv("ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS", "0")
+    ),
     # Gate/Up interleave mode for MoE weight preshuffle and kernel gate_mode.
     # "0" (default) = SEPARATED layout; "1" = INTERLEAVE layout.
     "ATOM_MOE_GU_ITLV": lambda: os.getenv("ATOM_MOE_GU_ITLV", "0") == "1",

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -58,6 +58,10 @@ This document describes the environment variables used in the ATOM project.
 | **ATOM_ENABLE_DS_QKNORM_FUSION** | bool | 1 (true) | If set to `1`, use the fused Q/K RMSNorm path (`fused_qk_rmsnorm`) in the DeepSeek MLA attention module when Q-LoRA is enabled and QK norm+quant fusion is not used. If set to `0`, apply separate RMSNorm for the Q and KV branches instead. |
 | **ATOM_ENABLE_DS_QKNORM_QUANT_FUSION** | bool | 1 (true) | If set to `1`, fuse QK norm with quantization in MLA attention module. |
 | **ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD** | int | 1024 | Upper bound on MoE token count (`num_tokens` in the MoE forward) for using the dual-stream path: shared experts on a secondary CUDA stream while routed experts run on the default stream. If `num_tokens` exceeds this value, that forward uses single-stream MoE instead. Set to `0` to disable dual-stream setup entirely (no alt stream, no `maybe_dual_stream_forward` registration). |
+| **ATOM_ENABLE_EPLB_LOAD_STATS** | bool | 0 (false) | If set to `1`, enable EPLB-style local expert-load statistics collection for the MORI EP dispatch path. |
+| **ATOM_EPLB_LOAD_WINDOW_SIZE** | int | 100 | Ring-buffer length (number of steps) for per-layer expert-load windows when `ATOM_ENABLE_EPLB_LOAD_STATS=1`. |
+| **ATOM_EPLB_LOG_INTERVAL** | int | 50 | Log interval (in forward steps) for per-layer `avg_tokens`, `max_tokens`, and `balancedness`. |
+| **ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS** | int | 0 (disabled) | If `> 0`, trigger a one-shot offline EPLB rebalance planning pass after this many **real** forward steps (dummy/warmup batches are excluded). Current implementation generates and logs the plan only (no automatic weight remap). |
 
 ### Qwen3-MoE style
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -26,6 +26,10 @@ _ATOM_ENV_VARS = [
     "ATOM_DISABLE_VLLM_PLUGIN",
     "ATOM_USE_CUSTOM_ALL_GATHER",
     "ATOM_ENABLE_RELAXED_MTP",
+    "ATOM_ENABLE_EPLB_LOAD_STATS",
+    "ATOM_EPLB_LOAD_WINDOW_SIZE",
+    "ATOM_EPLB_LOG_INTERVAL",
+    "ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS",
 ]
 
 
@@ -88,6 +92,18 @@ class TestEnvsDefaults:
     def test_atom_enable_gdn_decode_lossy_fast_default(self):
         assert _get_envs().ATOM_ENABLE_GDN_DECODE_LOSSY_FAST is False
 
+    def test_eplb_load_stats_default(self):
+        assert _get_envs().ATOM_ENABLE_EPLB_LOAD_STATS is False
+
+    def test_eplb_window_size_default(self):
+        assert _get_envs().ATOM_EPLB_LOAD_WINDOW_SIZE == 100
+
+    def test_eplb_log_interval_default(self):
+        assert _get_envs().ATOM_EPLB_LOG_INTERVAL == 50
+
+    def test_eplb_offline_after_steps_default(self):
+        assert _get_envs().ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS == 0
+
     def test_unknown_attr_raises(self):
         with pytest.raises(AttributeError):
             _ = _get_envs().ATOM_NONEXISTENT_VAR
@@ -139,6 +155,22 @@ class TestEnvsOverrides:
     def test_atom_enable_gdn_decode_lossy_fast_enabled(self, monkeypatch):
         monkeypatch.setenv("ATOM_ENABLE_GDN_DECODE_LOSSY_FAST", "1")
         assert _get_envs().ATOM_ENABLE_GDN_DECODE_LOSSY_FAST is True
+
+    def test_eplb_load_stats_enabled(self, monkeypatch):
+        monkeypatch.setenv("ATOM_ENABLE_EPLB_LOAD_STATS", "1")
+        assert _get_envs().ATOM_ENABLE_EPLB_LOAD_STATS is True
+
+    def test_eplb_window_size_override(self, monkeypatch):
+        monkeypatch.setenv("ATOM_EPLB_LOAD_WINDOW_SIZE", "16")
+        assert _get_envs().ATOM_EPLB_LOAD_WINDOW_SIZE == 16
+
+    def test_eplb_log_interval_override(self, monkeypatch):
+        monkeypatch.setenv("ATOM_EPLB_LOG_INTERVAL", "9")
+        assert _get_envs().ATOM_EPLB_LOG_INTERVAL == 9
+
+    def test_eplb_offline_after_steps_override(self, monkeypatch):
+        monkeypatch.setenv("ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS", "25")
+        assert _get_envs().ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS == 25
 
 
 class TestIsSet:

--- a/tests/test_eplb_stats.py
+++ b/tests/test_eplb_stats.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+
+import importlib
+
+import torch
+
+
+def _reload_eplb_stats_module():
+    import atom.model_ops.eplb_stats as eplb_stats
+
+    return importlib.reload(eplb_stats)
+
+
+def test_record_and_step_updates_window_and_clears_pass(monkeypatch):
+    monkeypatch.setenv("ATOM_ENABLE_EPLB_LOAD_STATS", "1")
+    monkeypatch.setenv("ATOM_EPLB_LOAD_WINDOW_SIZE", "3")
+    monkeypatch.setenv("ATOM_EPLB_LOG_INTERVAL", "1000")
+    monkeypatch.setenv("ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS", "0")
+
+    eplb_stats = _reload_eplb_stats_module()
+    monitor = eplb_stats.ExpertLoadMonitor()
+
+    monitor.record_expert_load_pass("layer0", torch.tensor([2, 3], dtype=torch.int32))
+    monitor.record_expert_load_pass("layer0", torch.tensor([1, 1], dtype=torch.int32))
+    monitor.step()
+
+    state = monitor._states["layer0"]  # internal state is expected in this unit test
+    assert state.expert_load_window[0].tolist() == [3, 4]
+    assert state.expert_load_pass.tolist() == [0, 0]
+    assert state.window_step == 1
+
+
+def test_auto_offline_rebalance_trigger_once(monkeypatch, caplog):
+    monkeypatch.setenv("ATOM_ENABLE_EPLB_LOAD_STATS", "1")
+    monkeypatch.setenv("ATOM_EPLB_LOAD_WINDOW_SIZE", "4")
+    monkeypatch.setenv("ATOM_EPLB_LOG_INTERVAL", "1000")
+    monkeypatch.setenv("ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS", "2")
+
+    eplb_stats = _reload_eplb_stats_module()
+    monitor = eplb_stats.ExpertLoadMonitor()
+
+    caplog.set_level("INFO", logger="atom")
+    monitor.record_expert_load_pass("layerA", torch.tensor([1, 0, 2]))
+    monitor.step()
+    monitor.record_expert_load_pass("layerA", torch.tensor([2, 1, 0]))
+    monitor.step()
+    # One extra step should not emit the planning trigger again.
+    monitor.record_expert_load_pass("layerA", torch.tensor([0, 1, 1]))
+    monitor.step()
+
+    trigger_logs = [
+        r.message
+        for r in caplog.records
+        if "offline rebalance planning trigger" in r.message
+    ]
+    assert len(trigger_logs) == 1
+    assert monitor._offline_rebalance_done is True
+
+
+def test_dummy_steps_are_excluded_from_auto_trigger(monkeypatch, caplog):
+    monkeypatch.setenv("ATOM_ENABLE_EPLB_LOAD_STATS", "1")
+    monkeypatch.setenv("ATOM_EPLB_LOAD_WINDOW_SIZE", "4")
+    monkeypatch.setenv("ATOM_EPLB_LOG_INTERVAL", "1000")
+    monkeypatch.setenv("ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS", "2")
+
+    eplb_stats = _reload_eplb_stats_module()
+    monitor = eplb_stats.ExpertLoadMonitor()
+
+    caplog.set_level("INFO", logger="atom")
+    monitor.record_expert_load_pass("layerA", torch.tensor([1, 0, 2]))
+    monitor.step(is_dummy_run=True)
+    monitor.record_expert_load_pass("layerA", torch.tensor([2, 1, 0]))
+    monitor.step(is_dummy_run=False)
+    monitor.record_expert_load_pass("layerA", torch.tensor([0, 1, 1]))
+    monitor.step(is_dummy_run=False)
+
+    trigger_logs = [
+        r.message
+        for r in caplog.records
+        if "offline rebalance planning trigger" in r.message
+    ]
+    assert len(trigger_logs) == 1
+    assert "real_step=2" in trigger_logs[0]
+    assert monitor._offline_rebalance_done is True
+
+
+def test_dummy_step_clears_pass_load_instead_of_leaking(monkeypatch):
+    monkeypatch.setenv("ATOM_ENABLE_EPLB_LOAD_STATS", "1")
+    monkeypatch.setenv("ATOM_EPLB_LOAD_WINDOW_SIZE", "3")
+    monkeypatch.setenv("ATOM_EPLB_LOG_INTERVAL", "1000")
+    monkeypatch.setenv("ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS", "0")
+
+    eplb_stats = _reload_eplb_stats_module()
+    monitor = eplb_stats.ExpertLoadMonitor()
+
+    monitor.record_expert_load_pass("layerA", torch.tensor([10, 0, 0]))
+    monitor.step(is_dummy_run=True)
+
+    monitor.record_expert_load_pass("layerA", torch.tensor([1, 2, 3]))
+    monitor.step(is_dummy_run=False)
+
+    state = monitor._states["layerA"]
+    # If dummy pass leaked, this would become [11, 2, 3].
+    assert state.expert_load_window[0].tolist() == [1, 2, 3]
+    assert state.expert_load_pass.tolist() == [0, 0, 0]
+
+
+def test_manual_offline_rebalance_trigger_sends_plan_log(monkeypatch, caplog):
+    monkeypatch.setenv("ATOM_ENABLE_EPLB_LOAD_STATS", "1")
+    monkeypatch.setenv("ATOM_EPLB_LOAD_WINDOW_SIZE", "2")
+    monkeypatch.setenv("ATOM_EPLB_LOG_INTERVAL", "1000")
+    monkeypatch.setenv("ATOM_EPLB_OFFLINE_REBALANCE_AFTER_STEPS", "0")
+
+    eplb_stats = _reload_eplb_stats_module()
+    monitor = eplb_stats.ExpertLoadMonitor()
+
+    monitor.record_expert_load_pass("layerB", torch.tensor([3, 1, 0]))
+    monitor.step()
+
+    caplog.set_level("INFO", logger="atom")
+    monitor.trigger_offline_rebalance(reason="test")
+    assert any(
+        "offline rebalance planning trigger (test)" in r.message for r in caplog.records
+    )
+    assert any("offline plan layer=layerB" in r.message for r in caplog.records)

--- a/tests/test_llm_engine_eplb.py
+++ b/tests/test_llm_engine_eplb.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+
+from unittest.mock import MagicMock
+
+from atom.model_engine.llm_engine import LLMEngine
+
+
+def test_offline_eplb_rebalance_sends_utility_command():
+    engine = LLMEngine.__new__(LLMEngine)
+    engine.core_mgr = MagicMock()
+
+    engine.offline_eplb_rebalance()
+
+    engine.core_mgr.send_utility_command.assert_called_once_with(
+        "offline_eplb_rebalance"
+    )
+


### PR DESCRIPTION
Collect per-layer, per-expert token counts from the MORI EP dispatch output (dispatch_recv_token_num) into a windowed ExpertLoadMonitor. Logs avg/max/balancedness and can emit a one-shot offline rebalance plan (hot/cold experts) via the offline_eplb_rebalance utility command.

Scope is statistics only: per-rank, no cross-rank all-reduce, and no actual expert weight remap/transfer yet. All gated behind ATOM_ENABLE_EPLB_LOAD_STATS (default off).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
