### PR TITLE
Fix MHA PA ASM metadata alignment

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2013,8 +2013,10 @@ class ModelRunner:
                 num_tokens = context.batch_size * max_q_len
                 hidden_states = self.forward_vars["outputs"][:num_tokens]
                 if graph_key in self.graph_aux_hidden:
+                    hidden_num_tokens = graph_bs * max_q_len
                     self._aux_hidden_states = [
-                        aux[:num_tokens] for aux in self.graph_aux_hidden[graph_key]
+                        aux[:hidden_num_tokens]
+                        for aux in self.graph_aux_hidden[graph_key]
                     ]
                 else:
                     self._aux_hidden_states = None

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2123,10 +2123,19 @@ class ModelRunner:
                 self.tokenID_processor.prev_token_ids = next_token_ids
                 # self.debug(f"{sampled_tokens=}")
                 # self.debug(f"{next_token_locs=}")
+                fctx = get_forward_context()
+                token_ids_len = batch.total_tokens_num
+                if (
+                    fctx.context.forward_mode is not None
+                    and fctx.context.forward_mode.use_cudagraph
+                ):
+                    token_ids_len = (
+                        fctx.context.graph_bs * fctx.attn_metadata.max_seqlen_q
+                    )
                 draft_token_ids = self.propose_draft_token_ids(
                     batch,
                     self.tokenID_processor.input_ids.gpu[
-                        1 : batch.total_tokens_num + 1
+                        1 : token_ids_len + 1
                     ],
                     hidden_states,
                     next_token_ids,

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -188,11 +188,10 @@ class PagedAttentionImpl(nn.Module):
         k_scale = kv_cache_data[f"layer_{self.layer_num}"].k_scale
         v_scale = kv_cache_data[f"layer_{self.layer_num}"].v_scale
 
-        # MTP MHA must go through triton/gluon; aiter ASM non-persistent path may have some unexpected behavior.
+        # Fall back to Triton/Gluon for layouts unsupported by AITer PA ASM.
         use_triton_attn = (
             self.sliding_window != -1
             or self.head_dim != 128
-            or self.num_heads == self.num_kv_heads
         )
         self.use_triton_attn = use_triton_attn
 

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -731,6 +731,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                 :sum_scheduled_tokens
             ]
 
+        total_position_tokens = bs * max_seqlen_q
         var["positions"].np[:sum_scheduled_tokens] = positions
         var["context_lens"].np[:scheduled_bs] = context_lens
         var["context_lens"].np[scheduled_bs:bs] = 0
@@ -779,7 +780,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         if mrope_positions is not None:
             positions = mrope_positions
         else:
-            positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
+            positions = var["positions"].copy_to_gpu(total_position_tokens)
         if self.model_runner.config.enable_tbo_decode and bs >= 2:
             self._prepare_ubatch_decode(
                 scheduled_bs,

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -933,6 +933,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         var["slot_mapping"].np[: bs * max_seqlen_q] = -1
         if not batch.is_dummy_run:
             var["slot_mapping"].np[:sum_scheduled_tokens] = slot_mapping
+        total_position_tokens = bs * max_seqlen_q
         var["positions"].np[:sum_scheduled_tokens] = positions
         var["context_lens"].np[:scheduled_bs] = context_lens
         var["context_lens"].np[scheduled_bs:bs] = 0
@@ -1036,7 +1037,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
         is_sparse_mtp = self.is_sparse and max_seqlen_q > 1
         # metadata copies on main_stream
-        positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
+        positions = var["positions"].copy_to_gpu(total_position_tokens)
         ctx.update({el: var[el].copy_to_gpu(num) for el, num in vars_for_metadata})
 
         if is_sparse_mtp:

--- a/atom/models/eagle3_llama.py
+++ b/atom/models/eagle3_llama.py
@@ -334,6 +334,21 @@ class Eagle3LlamaModel(nn.Module):
         compute_logits() is norm-aware, so EagleProposer only sees one tensor.
         """
         embeds = self.embed_tokens(input_ids)
+        if hidden_states.shape[0] > embeds.shape[0]:
+            pad_tokens = hidden_states.shape[0] - embeds.shape[0]
+            embeds = torch.cat(
+                [embeds, embeds.new_zeros((pad_tokens, embeds.shape[1]))], dim=0
+            )
+            if positions.ndim == 1:
+                positions = torch.cat(
+                    [positions, positions.new_zeros((pad_tokens,))], dim=0
+                )
+            else:
+                pad_shape = list(positions.shape)
+                pad_shape[-1] = pad_tokens
+                positions = torch.cat(
+                    [positions, positions.new_zeros(pad_shape)], dim=-1
+                )
         hidden_states = self.midlayer(positions, embeds, hidden_states)
         return self.norm(hidden_states) if self.norm_output else hidden_states
 

--- a/atom/models/eagle3_llama.py
+++ b/atom/models/eagle3_llama.py
@@ -334,21 +334,6 @@ class Eagle3LlamaModel(nn.Module):
         compute_logits() is norm-aware, so EagleProposer only sees one tensor.
         """
         embeds = self.embed_tokens(input_ids)
-        if hidden_states.shape[0] > embeds.shape[0]:
-            pad_tokens = hidden_states.shape[0] - embeds.shape[0]
-            embeds = torch.cat(
-                [embeds, embeds.new_zeros((pad_tokens, embeds.shape[1]))], dim=0
-            )
-            if positions.ndim == 1:
-                positions = torch.cat(
-                    [positions, positions.new_zeros((pad_tokens,))], dim=0
-                )
-            else:
-                pad_shape = list(positions.shape)
-                pad_shape[-1] = pad_tokens
-                positions = torch.cat(
-                    [positions, positions.new_zeros(pad_shape)], dim=-1
-                )
         hidden_states = self.midlayer(positions, embeds, hidden_states)
         return self.norm(hidden_states) if self.norm_output else hidden_states
 

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -384,21 +384,20 @@ class EagleProposer:
         # Eaale3 only support mha currently
         draft_uses_mha = hasattr(self.runner, "eagle3_draft_builder")
 
-        # Eagle3 MHA reuses target metadata, but the target may be MLA.  Keep
-        # write slots sized to this draft pass, and when prefix cache is active
-        # restore logical block ids: MLA prefill expands block_tables by
-        # block_ratio for its physical block_size=1 pool, while the draft MHA
-        # cache is indexed by runner.block_size blocks.
-        if draft_uses_mha:
-            attn_metadata.slot_mapping = var["slot_mapping"].gpu[: len(input_ids)]
-            attn_metadata.block_tables = var["block_tables"].gpu[:bs]
-
         # Backends that expose flat per-seq kv_indices/kv_indptr (MLA, MHA)
         # wire them through eagle's mid-step block; V4 has block_tables +
         # context_lens instead (its v4_kv_indices_{swa,csa,hca} are per-token
         # non-equivalent). Hoisted out of the loop so the value is bound for
         # every iteration (used at i>=1 too, even though i==0 sets it).
         has_flat_kv = "kv_indices" in var
+
+        # Target cudagraph replay may pass graph-sized Q into the Eagle3 draft.
+        # Match slot/block metadata to the graph-padded draft shape.
+        if draft_uses_mha:
+            attn_metadata.slot_mapping = var["slot_mapping"].gpu[
+                : context.graph_bs * attn_metadata.max_seqlen_q
+            ]
+            attn_metadata.block_tables = var["block_tables"].gpu[: context.graph_bs]
 
         for i in range(self.mtp_k):
             with record_function(f"draft[{i}/{self.mtp_k} bs={bs}]"):

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -392,12 +392,20 @@ class EagleProposer:
         has_flat_kv = "kv_indices" in var
 
         # Target cudagraph replay may pass graph-sized Q into the Eagle3 draft.
-        # Match slot/block metadata to the graph-padded draft shape.
+        # Match slot/block metadata to the graph-padded draft shape only on
+        # that path; prefill/eager decode keep active-sized draft inputs.
+        use_graph_padded_draft = (
+            context.forward_mode is not None and context.forward_mode.use_cudagraph
+        )
         if draft_uses_mha:
-            attn_metadata.slot_mapping = var["slot_mapping"].gpu[
-                : context.graph_bs * attn_metadata.max_seqlen_q
-            ]
-            attn_metadata.block_tables = var["block_tables"].gpu[: context.graph_bs]
+            slot_len = (
+                context.graph_bs * attn_metadata.max_seqlen_q
+                if use_graph_padded_draft
+                else len(input_ids)
+            )
+            block_len = context.graph_bs if use_graph_padded_draft else bs
+            attn_metadata.slot_mapping = var["slot_mapping"].gpu[:slot_len]
+            attn_metadata.block_tables = var["block_tables"].gpu[:block_len]
 
         for i in range(self.mtp_k):
             with record_function(f"draft[{i}/{self.mtp_k} bs={bs}]"):


### PR DESCRIPTION
## Summary
- allow head_dim=128 MHA decode to dispatch to AITer PA ASM when no sliding window is used
- align context_lens and cu_seqlens_q with active block_tables rows before calling pa_fwd_asm
- fail fast if PA ASM metadata is shorter than the active block table batch

## Testing
- python3 -m py_compile ATOM/atom/model_ops/attention_mha.py
- end-to-end lm_eval GSM8K with ATOM server + eagle3, num_concurrent=64: completed 1319 requests without PA_ASM_SYNC_FAIL, illegal memory access, traceback, or server death
- GSM8K result: flexible-extract exact_match 0.8560 +/- 0.0097; strict-match exact_match 0.8491 +/- 0.0099
