### PR TITLE
[atom-sgl] Modify the parallel strategy of DeepSeek-R1-0528-MXFP4-v2

### DIFF
--- a/.github/benchmark/sglang_benchmark_models.json
+++ b/.github/benchmark/sglang_benchmark_models.json
@@ -93,13 +93,13 @@
       "env_vars": "deepseek_dp_common"
     },
     {
-      "display": "DeepSeek-R1-0528-MXFP4 FP4 TP4 DP8 EP8",
-      "dashboard_model": "DeepSeek-R1-0528-MXFP4-tp4-dp8-ep8",
+      "display": "DeepSeek-R1-0528-MXFP4 FP4 TP8 DP8 EP8",
+      "dashboard_model": "DeepSeek-R1-0528-MXFP4-tp8-dp8-ep8",
       "workload_label": "SGLang-OOB",
       "source_path": "amd/DeepSeek-R1-0528-MXFP4-v2",
       "path": "amd/DeepSeek-R1-0528-MXFP4-v2",
-      "prefix": "deepseek-r1-fp4-tp4-dp8-ep8",
-      "extra_args": ["trust_remote_code", "--tensor-parallel-size 4 --expert-parallel-size 8 --data-parallel-size 8 --enable-dp-attention", "aiter_runtime"],
+      "prefix": "deepseek-r1-fp4-tp8-dp8-ep8",
+      "extra_args": ["trust_remote_code", "--tensor-parallel-size 8 --expert-parallel-size 8 --data-parallel-size 8 --enable-dp-attention", "aiter_runtime"],
       "bench_args": "",
       "runner": "atom-mi355-8gpu-aac-runner",
       "nightly_group": "A",

--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -132,9 +132,9 @@
     "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
   },
   {
-    "model_name": "DeepSeek-R1-FP4 TP4 DP8 EP8",
+    "model_name": "DeepSeek-R1-FP4 TP8 DP8 EP8",
     "model_path": "amd/DeepSeek-R1-0528-MXFP4-v2",
-    "extraArgs": "--trust-remote-code --tensor-parallel-size 4 --expert-parallel-size 8 --data-parallel-size 8 --enable-dp-attention --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
+    "extraArgs": "--trust-remote-code --tensor-parallel-size 8 --expert-parallel-size 8 --data-parallel-size 8 --enable-dp-attention --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
     "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nMORI_SHMEM_MODE=ISOLATION\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
     "runner": "linux-atom-mi35x-8",
     "test_level": "nightly",


### PR DESCRIPTION
## Motivation

Modify the parallel strategy of DeepSeek-R1-0528-MXFP4-v2 from 'TP4 DP8 EP8' to 'TP8 DP8 EP8' to resolve the error as below:
<img width="971" height="341" alt="image" src="https://github.com/user-attachments/assets/e69bcd90-618f-46c4-b94e-7ca5226c3c4a" />
