### PR TITLE
[atom-vllm benchmark MTP] refine benchmark command for atom-vllm MTP case

### DIFF
--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -297,7 +297,7 @@
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-mtp-tp1",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-mtp-tp1-aw",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --performance-mode throughput --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --performance-mode throughput --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
           "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1"
         },
         {
@@ -306,7 +306,7 @@
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-mtp-tp4",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-mtp-tp4-aw",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --performance-mode throughput --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --performance-mode throughput --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1"
         }
       ]
@@ -405,7 +405,7 @@
           "dashboard_model": "GLM-4.7-FP8-mtp-aw-tp4",
           "prefix": "glm-4-7-fp8-mtp-aw-tp4",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --performance-mode throughput --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --performance-mode throughput --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
         {
@@ -414,7 +414,7 @@
           "dashboard_model": "GLM-4.7-FP8-mtp-aw-tp8",
           "prefix": "glm-4-7-fp8-mtp-aw-tp8",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --performance-mode throughput --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --performance-mode throughput --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         }
       ]

--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -297,7 +297,7 @@
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-mtp-tp1",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-mtp-tp1-aw",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --performance-mode throughput --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
           "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1"
         },
         {
@@ -306,7 +306,7 @@
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-mtp-tp4",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-mtp-tp4-aw",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --performance-mode throughput --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1"
         }
       ]
@@ -405,7 +405,7 @@
           "dashboard_model": "GLM-4.7-FP8-mtp-aw-tp4",
           "prefix": "glm-4-7-fp8-mtp-aw-tp4",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --performance-mode throughput --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
         {
@@ -414,7 +414,7 @@
           "dashboard_model": "GLM-4.7-FP8-mtp-aw-tp8",
           "prefix": "glm-4-7-fp8-mtp-aw-tp8",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --performance-mode throughput --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         }
       ]

--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -297,7 +297,7 @@
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-mtp-tp1",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-mtp-tp1-aw",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --performance-mode throughput --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
           "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1"
         },
         {
@@ -306,7 +306,7 @@
           "dashboard_model": "Qwen3-Next-80B-A3B-Instruct-FP8-mtp-tp4",
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-mtp-tp4-aw",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --performance-mode throughput --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1"
         }
       ]
@@ -342,7 +342,7 @@
           "dashboard_model": "DeepSeek-V3.2-FP8-MTP-aw-tp4",
           "prefix": "deepseek-v3-2-fp8-mtp-aw-tp4",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --performance-mode throughput --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}' --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\", \"rejection_sample_method\": \"synthetic\", \"synthetic_acceptance_rates\": [0.9,0.8,0.6]}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}' --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\", \"rejection_sample_method\": \"synthetic\", \"synthetic_acceptance_rates\": [0.9,0.8,0.6]}'",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0"
         }
       ]
@@ -405,7 +405,7 @@
           "dashboard_model": "GLM-4.7-FP8-mtp-aw-tp4",
           "prefix": "glm-4-7-fp8-mtp-aw-tp4",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --performance-mode throughput --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         },
         {
@@ -414,7 +414,7 @@
           "dashboard_model": "GLM-4.7-FP8-mtp-aw-tp8",
           "prefix": "glm-4-7-fp8-mtp-aw-tp8",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --performance-mode throughput --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 8 --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1"
         }
       ]

--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -342,8 +342,8 @@
           "dashboard_model": "DeepSeek-V3.2-FP8-MTP-aw-tp4",
           "prefix": "deepseek-v3-2-fp8-mtp-aw-tp4",
           "bench_args": "",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
-          "env_vars": ""
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --performance-mode throughput --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}' --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\", \"rejection_sample_method\": \"synthetic\", \"synthetic_acceptance_rates\": [0.9,0.8,0.6]}'",
+          "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0"
         }
       ]
     },

--- a/.github/scripts/atom_oot_test.sh
+++ b/.github/scripts/atom_oot_test.sh
@@ -146,6 +146,70 @@ stop_server() {
   fi
 }
 
+# Scrape MTP/speculative-decode acceptance from the live vLLM /metrics endpoint
+# and store overall + per-position acceptance into the result JSON. Must be
+# called while the server is still running. No-op for non-speculative runs
+# (the spec_decode counters are absent). The workflow's "Check OOT MTP
+# acceptance rate" step reads these values to gate against regressions —
+# gsm8k accuracy alone cannot, since spec decoding is lossless w.r.t. the
+# target model and a broken draft head only craters acceptance/throughput.
+record_mtp_acceptance() {
+  local result_file="$1"
+  local metrics_file="/tmp/oot_spec_metrics.txt"
+
+  if ! curl -fsS "http://127.0.0.1:${VLLM_PORT}/metrics" -o "${metrics_file}" 2>/dev/null; then
+    echo "MTP acceptance: /metrics not reachable (skipping)."
+    return 0
+  fi
+
+  RESULT_FILE="${result_file}" METRICS_FILE="${metrics_file}" python3 - <<'PY'
+import json, os, re
+
+with open(os.environ["METRICS_FILE"], encoding="utf-8", errors="replace") as f:
+    metrics = f.read()
+
+def sum_counter(name):
+    # Sum a Prometheus counter across all label series; tolerate the `_total`
+    # suffix and optional `{labels}`. Anchored so e.g. num_accepted_tokens does
+    # not also match num_accepted_tokens_per_pos.
+    pat = rf'^{re.escape(name)}(?:_total)?(?:\{{[^}}]*\}})?\s+([0-9eE+.\-]+)\s*$'
+    vals = [float(m.group(1)) for m in re.finditer(pat, metrics, re.M)]
+    return sum(vals) if vals else None
+
+accepted = sum_counter("vllm:spec_decode_num_accepted_tokens")
+draft_tokens = sum_counter("vllm:spec_decode_num_draft_tokens")
+num_drafts = sum_counter("vllm:spec_decode_num_drafts")
+
+per_pos_counts = {}
+for m in re.finditer(
+    r'vllm:spec_decode_num_accepted_tokens_per_pos(?:_total)?\{([^}]*)\}\s+([0-9eE+.\-]+)',
+    metrics,
+):
+    pm = re.search(r'position="(\d+)"', m.group(1))
+    if pm:
+        i = int(pm.group(1))
+        per_pos_counts[i] = per_pos_counts.get(i, 0.0) + float(m.group(2))
+
+if not draft_tokens:
+    print("MTP acceptance: no spec-decode metrics found (non-MTP run).")
+else:
+    overall = accepted / draft_tokens
+    per_pos = []
+    if num_drafts and per_pos_counts:
+        per_pos = [per_pos_counts[i] / num_drafts for i in sorted(per_pos_counts)]
+    rf = os.environ["RESULT_FILE"]
+    with open(rf, encoding="utf-8") as f:
+        data = json.load(f)
+    meta = data.setdefault("atom_ci_metadata", {})
+    meta["mtp_acceptance_overall"] = overall
+    meta["mtp_per_pos_acceptance"] = per_pos
+    with open(rf, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    print("MTP acceptance overall: %.4f, per-position: %s" % (
+        overall, ", ".join("%.4f" % r for r in per_pos) if per_pos else "n/a"))
+PY
+}
+
 launch_one_model() {
   local model_name="$1"
   local model_path="$2"
@@ -386,6 +450,9 @@ print(data["results"]["gsm8k"]["exact_match,flexible-extract"])
 PY
 )
   fi
+
+  # Capture MTP acceptance from /metrics while the server is still alive.
+  record_mtp_acceptance "${result_file}"
 
   echo "Result file: ${result_file}"
   echo "Flexible extract value: ${value}"

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -490,8 +490,10 @@ jobs:
                   "toggle_env": "RUN_QWEN3_NEXT_80B_MTP_TP1",
                   "model_name": "Qwen3-Next-80B-A3B-Instruct-FP8-MTP TP1",
                   "model_path": "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8",
-                  "extra_args": "--tensor-parallel-size 1 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
+                  "extra_args": "--tensor-parallel-size 1 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
                   "accuracy_test_threshold": 0.80,
+                  "mtp_accept_threshold": 0.74,
+                  "mtp_per_pos_threshold": "0.88,0.76,0.59",
                   "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0",
                   "runner": "atom-plugin-acc-validation-runner",
               },
@@ -499,8 +501,10 @@ jobs:
                   "toggle_env": "RUN_QWEN3_NEXT_80B_MTP_TP4",
                   "model_name": "Qwen3-Next-80B-A3B-Instruct-FP8-MTP TP4",
                   "model_path": "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8",
-                  "extra_args": "--tensor-parallel-size 4 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
+                  "extra_args": "--tensor-parallel-size 4 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
                   "accuracy_test_threshold": 0.80,
+                  "mtp_accept_threshold": 0.74,
+                  "mtp_per_pos_threshold": "0.88,0.76,0.59",
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0",
                   "runner": "atom-plugin-acc-validation-runner",
               },
@@ -646,10 +650,12 @@ jobs:
                   "toggle_env": "RUN_DSV32_FP8_MTP_TP4",
                   "model_name": "DeepSeek-V3.2-FP8 MTP TP4",
                   "model_path": "deepseek-ai/DeepSeek-V3.2",
-                  "extra_args": "--tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
+                  "extra_args": "--tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}' --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
                   "lm_eval_num_fewshot": 20,
                   "accuracy_test_threshold": 0.93,
-                  "env_vars": "",
+                  "mtp_accept_threshold": 0.60,
+                  "mtp_per_pos_threshold": "0.89,0.62,0.28",
+                  "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
                   "runner": "atom-plugin-acc-validation-runner",
               },
               {
@@ -734,6 +740,8 @@ jobs:
                   "model_path": "zai-org/GLM-4.7-FP8",
                   "extra_args": "--tensor-parallel-size 4 --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
                   "accuracy_test_threshold": 0.92,
+                  "mtp_accept_threshold": 0.74,
+                  "mtp_per_pos_threshold": "0.91,0.58",
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
                   "runner": "atom-plugin-acc-validation-runner",
               },
@@ -743,6 +751,8 @@ jobs:
                   "model_path": "zai-org/GLM-4.7-FP8",
                   "extra_args": "--tensor-parallel-size 8 --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
                   "accuracy_test_threshold": 0.92,
+                  "mtp_accept_threshold": 0.74,
+                  "mtp_per_pos_threshold": "0.91,0.58",
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
                   "runner": "atom-plugin-acc-validation-runner",
               },
@@ -772,11 +782,11 @@ jobs:
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0",
               },
               "Qwen3-Next-80B-A3B-Instruct-FP8-MTP TP1": {
-                  "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
                   "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0",
               },
               "Qwen3-Next-80B-A3B-Instruct-FP8-MTP TP4": {
-                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":1, \"method\": \"mtp\"}'",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 32768 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0",
               },
               "Qwen3.5-397B-A17B-FP8 TP4": {
@@ -824,8 +834,8 @@ jobs:
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
               },
               "DeepSeek-V3.2-FP8 MTP TP4": {
-                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
-                  "env_vars": "",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}' --speculative-config '{\"num_speculative_tokens\":3, \"method\": \"mtp\"}'",
+                  "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
               },
               "DeepSeek-V3.2-FP8 PTPC TP4": {
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --max-model-len 16384 --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}'",
@@ -1692,6 +1702,64 @@ jobs:
             echo "Accuracy test passed: Flexible extract value $flexible_extract_value is greater than or equal to threshold ${{ matrix.accuracy_test_threshold }}."
             exit 0
           fi
+
+      - name: Check OOT MTP acceptance rate
+        if: ${{ steps.validation-window.outputs.should_run == 'true' && success() && steps.run_accuracy_client.outcome == 'success' && matrix.mtp_accept_threshold != '' }}
+        env:
+          MTP_ACCEPT_THRESHOLD: ${{ matrix.mtp_accept_threshold }}
+          MTP_PER_POS_THRESHOLD: ${{ matrix.mtp_per_pos_threshold }}
+        run: |
+          # MTP acceptance is recorded into the result JSON by atom_oot_test.sh
+          # (scraped from the live vLLM /metrics endpoint during the gsm8k run).
+          # gsm8k accuracy alone CANNOT guard MTP: speculative decoding is loss-
+          # less w.r.t. the target model, so a broken draft head leaves accuracy
+          # unchanged and only craters acceptance/throughput. This step is the
+          # only gate that catches an MTP regression. Uses jq+awk (no python on
+          # the host runner), mirroring the gsm8k accuracy check above.
+          result_file=$(ls -1t oot_accuracy_results/*.json 2>/dev/null | head -n 1)
+          if [ -z "$result_file" ] || [ ! -f "$result_file" ]; then
+            echo "ERROR: No results JSON file found for MTP acceptance check."
+            exit 2
+          fi
+          echo "RESULT_FILE: $result_file"
+
+          overall=$(jq -r '.atom_ci_metadata.mtp_acceptance_overall // empty' "$result_file")
+          if [ -z "$overall" ]; then
+            echo "ERROR: mtp_acceptance_overall missing — spec-decode /metrics were not captured during the run. Treating as a failure."
+            exit 1
+          fi
+
+          fail=0
+          echo "MTP overall acceptance: $overall (threshold ${MTP_ACCEPT_THRESHOLD})"
+          if awk -v v="$overall" -v t="${MTP_ACCEPT_THRESHOLD}" 'BEGIN {exit !(v < t)}'; then
+            echo "FAIL: overall acceptance $overall < threshold ${MTP_ACCEPT_THRESHOLD}"
+            fail=1
+          fi
+
+          if [ -n "${MTP_PER_POS_THRESHOLD}" ]; then
+            IFS=',' read -ra pos_thresholds <<< "${MTP_PER_POS_THRESHOLD}"
+            idx=0
+            for th in "${pos_thresholds[@]}"; do
+              p=$(jq -r ".atom_ci_metadata.mtp_per_pos_acceptance[$idx] // empty" "$result_file")
+              if [ -z "$p" ]; then
+                echo "FAIL: position $idx acceptance missing (expected >= $th)"
+                fail=1
+              else
+                echo "MTP position $idx acceptance: $p (threshold $th)"
+                if awk -v v="$p" -v t="$th" 'BEGIN {exit !(v < t)}'; then
+                  echo "FAIL: position $idx acceptance $p < threshold $th"
+                  fail=1
+                fi
+              fi
+              idx=$((idx + 1))
+            done
+          fi
+
+          if [ "$fail" -eq 1 ]; then
+            echo "MTP acceptance gate FAILED."
+            exit 1
+          fi
+          echo "MTP acceptance gate PASSED."
 
       - name: Collect summary
         if: ${{ steps.validation-window.outputs.should_run == 'true' && success() }}

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -732,7 +732,7 @@ jobs:
                   "toggle_env": "RUN_GLM4_7_FP8_MTP_TP4",
                   "model_name": "GLM-4.7-FP8 MTP TP4",
                   "model_path": "zai-org/GLM-4.7-FP8",
-                  "extra_args": "--tensor-parallel-size 4 --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
+                  "extra_args": "--tensor-parallel-size 4 --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
                   "accuracy_test_threshold": 0.92,
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
                   "runner": "atom-plugin-acc-validation-runner",
@@ -741,7 +741,7 @@ jobs:
                   "toggle_env": "RUN_GLM4_7_FP8_MTP_TP8",
                   "model_name": "GLM-4.7-FP8 MTP TP8",
                   "model_path": "zai-org/GLM-4.7-FP8",
-                  "extra_args": "--tensor-parallel-size 8 --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
+                  "extra_args": "--tensor-parallel-size 8 --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
                   "accuracy_test_threshold": 0.92,
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
                   "runner": "atom-plugin-acc-validation-runner",
@@ -860,11 +860,11 @@ jobs:
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_GLUON_PA_DECODE=1",
               },
               "GLM-4.7-FP8 MTP TP4": {
-                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
               },
               "GLM-4.7-FP8 MTP TP8": {
-                  "extra_args": "--trust-remote-code --tensor-parallel-size 8 --speculative-config.method mtp --speculative-config.num_speculative_tokens 1",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 8 --speculative-config.method mtp --speculative-config.num_speculative_tokens 2",
                   "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1",
               },
               "GLM-5.1-FP8 TP8": {

--- a/atom/models/glm4_moe_mtp.py
+++ b/atom/models/glm4_moe_mtp.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
+from aiter.dist.communication_op import tensor_model_parallel_all_reduce
+from aiter.dist.parallel_state import get_tp_group
 from atom.config import Config, QuantizationConfig
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.layernorm import RMSNorm
@@ -12,7 +14,11 @@ from transformers import PretrainedConfig
 
 from .deepseek_mtp import rewrite_spec_layer_name
 
-from .glm4_moe import Glm4MoeDecoderLayer, get_spec_layer_idx_from_weight_name
+from .glm4_moe import (
+    ENABLE_ALLREDUCE_RMSNORM_FUSION,
+    Glm4MoeDecoderLayer,
+    get_spec_layer_idx_from_weight_name,
+)
 from .utils import maybe_prefix
 
 
@@ -57,6 +63,8 @@ class Glm4MoeMultiTokenPredictorLayer(nn.Module):
             prefix=prefix,
         )
 
+        self.tp_size = get_tp_group().world_size
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -77,6 +85,17 @@ class Glm4MoeMultiTokenPredictorLayer(nn.Module):
         hidden_states, residual = self.mtp_block(
             positions=positions, hidden_states=hidden_states, residual=None
         )
+        # When allreduce+RMSNorm fusion is on, Glm4MoeDecoderLayer leaves its
+        # final MoE down_proj output as an un-reduced TP partial sum, deferring
+        # the all-reduce to the *next* layer's fused input_layernorm. The MTP
+        # block is the last layer, so there is no next layer to complete it --
+        # we must reduce explicitly here (mirrors DeepSeek/MiMo MTP). When the
+        # fusion is off the MoE already reduced internally, so adding one here
+        # would double-reduce; hence the gate. No extra communication is
+        # introduced versus a correct fused path (the reduce is required either
+        # way), so performance is preserved.
+        if ENABLE_ALLREDUCE_RMSNORM_FUSION and self.tp_size > 1:
+            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
         hidden_states = residual + hidden_states
         return hidden_states
 


### PR DESCRIPTION
For deepseekv3.2(TP4) MTP, add indexer cache, quick allreduce, MTP3 and synthetic accept mode(0.9 0.8 0.6)
| Metric | Value |
| --- | ---: |
| Accuracy | 0.9476876421531463 |
| Accept ratio | 0.9393 0.6789 0.3387 |

| Concurrency | Base tok/s/GPU | Optimized tok/s/GPU | Speedup | Base Mean TPOT | Optimized Mean TPOT | TPOT Reduction |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 353.72 | 900.22 | 2.55x | 27.72 ms | 9.68 ms | 65.1% |
| 16 | 862.81 | 2035.56 | 2.36x | 46.36 ms | 17.08 ms | 63.2% |
| 64 | 1883.57 | 3585.51 | 1.90x | 83.10 ms | 38.32 ms | 53.9% |
| 256 | 2777.17 | 4620.39 | 1.66x | 227.59 ms | 126.61 ms | 44.4% |

<img width="381" height="187" alt="image" src="https://github.com/user-attachments/assets/6d029426-1e14-4a90-b6fd-e0fe99891c22" />

For qwen3next(TP1) MTP, add MTP3
| Metric | Value |
| --- | ---: |
| Accuracy | 0.8188021228203184 |
| Accept ratio | 0.9323 0.8153 0.6440 |

| Concurrency | Completed | Failed | Total tok/s | Output tok/s | Interactivity tok/s/user | Mean TTFT ms | Mean TPOT ms | Mean E2EL ms | Speedup vs previous real MTP |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 32 | 0 | 8220.13 | 747.28 | 186.82 | 177.22 | 3.51 | 524.99 | 1.27x |
| 16 | 128 | 0 | 17282.28 | 1571.12 | 98.19 | 212.95 | 7.82 | 987.19 | 1.19x |
| 64 | 512 | 0 | 35889.35 | 3262.67 | 50.98 | 384.14 | 15.36 | 1904.56 | 1.20x |
| 256 | 2048 | 0 | 58380.21 | 5307.29 | 20.73 | 765.85 | 40.18 | 4743.28 | 1.10x |

<img width="376" height="189" alt="image" src="https://github.com/user-attachments/assets/ab7b31f0-6dc6-48b3-bb53-f0b03e5cd98c" />

For glm4.7(TP4) MTP(1), add MTP2 and fix acc bug
| metric | value |
|---|---:|
| GSM8K exact_match, flexible-extract | 0.943897 |
| MTP acceptance, overall | 79.8443% |
| MTP acceptance, pos0 | 96.5146% |
| MTP acceptance, pos1 | 63.1750% |

| concurrency | completed | total tok/s | total tok/s/GPU | output tok/s | mean TTFT ms | mean TPOT ms | mean E2EL ms | accept avg | pos0 | pos1 |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 32 | 2922.36 | 730.59 | 265.67 | 186.16 | 12.85 | 1458.49 | 58.02% | 79.82% | 36.22% |
| 16 | 128 | 7897.79 | 1974.45 | 717.98 | 262.23 | 19.32 | 2174.46 | 57.26% | 79.10% | 35.41% |
| 64 | 512 | 14830.35 | 3707.59 | 1348.21 | 571.22 | 41.10 | 4640.05 | 58.10% | 79.70% | 36.50% |
| 256 | 2048 | 22638.43 | 5659.61 | 2058.04 | 1408.95 | 109.92 | 12291.40 | 57.24% | 79.14% | 35.33% |

<img width="361" height="148" alt="image" src="https://github.com/user-attachments/assets/1a4775c6-02b8-42e4-9c55-1c47e284276f" />
