### PR TITLE
[atom-vllm CI] add fail and exit mechanism, change ci case from v4 pro to v4 flash and use tp4

### DIFF
--- a/.github/scripts/atom_oot_test.sh
+++ b/.github/scripts/atom_oot_test.sh
@@ -42,6 +42,13 @@ fi
 
 MAX_WAIT_RETRIES=${MAX_WAIT_RETRIES:-60}
 WAIT_INTERVAL_SEC=${WAIT_INTERVAL_SEC:-30}
+# Fatal server-log markers: if any appears while waiting for the server, abort
+# immediately instead of burning the full MAX_WAIT_RETRIES budget (which keeps the
+# GPU runner occupied long after init has already crashed). These are unambiguously
+# terminal — e.g. NCCL "unhandled cuda error" corrupts the CUDA context and never
+# recovers. The recoverable "tp_group_reuse failed ... will fall back" warning is
+# intentionally NOT matched. Override via FATAL_LOG_PATTERNS; set empty to disable.
+FATAL_LOG_PATTERNS=${FATAL_LOG_PATTERNS:-'unhandled cuda error|uncorrectable ECC|EngineCore[_ ][A-Za-z0-9]* died|Engine core proc.* died|EngineCore failed to start|Failed to initialize EngineCore'}
 VLLM_PORT=${VLLM_PORT:-8000}
 VLLM_HOST=${VLLM_HOST:-localhost}
 VLLM_PID_FILE=${VLLM_PID_FILE:-/tmp/vllm_oot.pid}
@@ -103,6 +110,13 @@ emit_new_vllm_logs() {
   LAST_VLLM_LOG_LINE=${current_line_count}
 }
 
+# Scan the server log for a fatal marker. Prints the first matching line and
+# returns 0 when a fatal error is present, 1 otherwise.
+detect_fatal_log() {
+  [[ -n "${FATAL_LOG_PATTERNS}" && -f "${VLLM_LOG_FILE}" ]] || return 1
+  grep -E -m1 "${FATAL_LOG_PATTERNS}" "${VLLM_LOG_FILE}" 2>/dev/null
+}
+
 wait_server_ready() {
   local model_name="$1"
   echo ""
@@ -115,6 +129,15 @@ wait_server_ready() {
     fi
 
     emit_new_vllm_logs
+
+    local fatal_line
+    if fatal_line=$(detect_fatal_log); then
+      echo "Detected fatal server error for ${model_name}; aborting wait early instead of retrying:"
+      echo "  ${fatal_line}"
+      emit_new_vllm_logs
+      tail -n 200 "${VLLM_LOG_FILE}" || true
+      return 1
+    fi
 
     if [[ -f "${VLLM_PID_FILE}" ]]; then
       local pid

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -241,16 +241,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - display_name: "DeepSeek-V4-Pro TP8"
-            model_name: "DeepSeek-V4-Pro"
-            model_path: "deepseek-ai/DeepSeek-V4-Pro"
-            extra_args: "--tensor-parallel-size 8 --gpu-memory-utilization 0.9 --max-num-seqs 512 --tokenizer-mode deepseek_v4"
+          - display_name: "DeepSeek-V4-Flash TP4"
+            model_name: "DeepSeek-V4-Flash"
+            model_path: "deepseek-ai/DeepSeek-V4-Flash"
+            extra_args: "--tensor-parallel-size 4 --gpu-memory-utilization 0.9 --max-num-seqs 512 --tokenizer-mode deepseek_v4"
             env_vars: |
               AITER_BF16_FP8_MOE_BOUND=0
               ATOM_MOE_GU_ITLV=1
             lm_eval_num_fewshot: 20
             accuracy_test_threshold: 0.94
-            runner: atom-mi355-8gpu.predownload
+            runner: linux-atom-mi35x-4
           - display_name: "gpt-oss-120b TP1"
             model_name: "gpt-oss-120b"
             model_path: "openai/gpt-oss-120b"

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -475,6 +475,13 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
+      - name: GPU preflight check
+        if: success()
+        timeout-minutes: 5
+        env:
+          GPU_PREFLIGHT_ALLOCATION_MB: "8"
+        run: bash .github/scripts/gpu_preflight_check.sh "$CONTAINER_NAME" docker
+
       - name: Download or refresh model if needed
         if: success()
         run: |
@@ -522,7 +529,7 @@ jobs:
 
       - name: Run OOT launch and gsm8k accuracy via script (ci mode)
         if: success()
-        timeout-minutes: 120
+        timeout-minutes: 45
         env:
           OOT_MODEL_NAME: ${{ matrix.model_name }}
           OOT_MODEL_PATH: ${{ matrix.model_path }}
@@ -530,7 +537,7 @@ jobs:
           OOT_CLIENT_COMMAND: ${{ matrix.client_command || '' }}
           OOT_ENV_VARS: ${{ matrix.env_vars }}
           LM_EVAL_NUM_FEWSHOT: ${{ matrix.lm_eval_num_fewshot }}
-          MAX_WAIT_RETRIES: "120"
+          MAX_WAIT_RETRIES: "40"
           STREAM_VLLM_LOGS: "1"
         run: |
           docker exec \


### PR DESCRIPTION
1. 对齐atom ci，增加preflight检测
2. 探测典型错误，比如之前hang住的nccl handle error，遇到就立马fail
3. 降低超时时间
4. v4 ci选择flash model，TP4和4卡机