### PR TITLE
Change model cache mount for AAC machine

### DIFF
--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -1274,9 +1274,9 @@ jobs:
         run: |
           MODEL_CACHE_MOUNT=""
           MODEL_CACHE_DESC="container-local /models (no host cache mount)"
-          if [ -d "/shared/data/amd_int/models" ]; then
-            MODEL_CACHE_MOUNT="-v /shared/data/amd_int/models:/models"
-            MODEL_CACHE_DESC="/shared/data/amd_int/models (shared host path)"
+          if [ -d "/shared/data/WRH/models" ]; then
+            MODEL_CACHE_MOUNT="-v /shared/data/WRH/models:/models"
+            MODEL_CACHE_DESC="/shared/data/WRH/models (shared host path)"
           elif [ -d "/it-share/models" ]; then
             MODEL_CACHE_MOUNT="-v /it-share/models:/models"
             MODEL_CACHE_DESC="/it-share/models (shared host path)"


### PR DESCRIPTION
## Motivation

Modify model cache mount from '/shared/data/amd_int/models' to '/shared/data/WRH/models', because we don't have write permission for  '/shared/data/amd_int/models' . And '/shared/data/WRH/models' is a symlink target for  '/shared/data/amd_int/models' .