### PR TITLE
[MiniMax-M3] use fused_qknorm_idxrqknorm

### DIFF
--- a/atom/models/minimax_m3.py
+++ b/atom/models/minimax_m3.py
@@ -94,7 +94,7 @@ def _can_use_fused_minimax_m3_attention_preproc(
     *weights: torch.Tensor,
 ) -> bool:
     return (
-        hasattr(aiter, "fused_minimax_m3_qknorm_rope_kv_insert")
+        hasattr(aiter, "fused_qknorm_idxrqknorm")
         and qkv.dim() == 2
         and qkv.is_cuda
         and qkv.dtype in (torch.float16, torch.bfloat16)
@@ -416,7 +416,7 @@ class MiniMaxM3Attention(nn.Module):
                 (qkv.shape[0], self.q_size), dtype=qkv.dtype, device=qkv.device
             )
             cos_sin_cache = _minimax_m3_cos_sin_cache(self.rotary_emb, qkv.dtype)
-            aiter.fused_minimax_m3_qknorm_rope_kv_insert(
+            aiter.fused_qknorm_idxrqknorm(
                 qkv,
                 self.q_norm.weight,
                 self.k_norm.weight,
@@ -700,7 +700,7 @@ class MiniMaxM3SparseAttention(nn.Module):
                 (qkv.shape[0], self.index_q_size), dtype=qkv.dtype, device=qkv.device
             )
             cos_sin_cache = _minimax_m3_cos_sin_cache(self.rotary_emb, qkv.dtype)
-            aiter.fused_minimax_m3_qknorm_rope_kv_insert(
+            aiter.fused_qknorm_idxrqknorm(
                 qkv,
                 self.q_norm.weight,
                 self.k_norm.weight,


### PR DESCRIPTION
aiter main upstreamed the MiniMax-M3 fused qk-norm + rope + kv-insert op as `fused_qknorm_idxrqknorm` (PR #3754) with a byte-identical signature; the old M3_mi355 name `fused_minimax_m3_qknorm_rope_kv_insert` does not exist on aiter main. The hasattr() capability gate therefore failed and ATOM silently fell back to the unfused qk-norm path.

Rename all 3 references (the capability check + both call sites) so ATOM uses the fused kernel when running against aiter main. Pure rename — call arguments unchanged. Applies to both bf16 and FP4 M3 (attention preprocessing).
