### PR TITLE
fix(attn): enable PA ASM for MHA decode

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -188,12 +188,8 @@ class PagedAttentionImpl(nn.Module):
         k_scale = kv_cache_data[f"layer_{self.layer_num}"].k_scale
         v_scale = kv_cache_data[f"layer_{self.layer_num}"].v_scale
 
-        # MTP MHA must go through triton/gluon; aiter ASM non-persistent path may have some unexpected behavior.
-        use_triton_attn = (
-            self.sliding_window != -1
-            or self.head_dim != 128
-            or self.num_heads == self.num_kv_heads
-        )
+        # Fall back to Triton/Gluon for layouts unsupported by AITer PA ASM.
+        use_triton_attn = self.sliding_window != -1 or self.head_dim != 128
         self.use_triton_attn = use_triton_attn
 
         if (


### PR DESCRIPTION
## Summary
- Let MHA decode use AITer PA ASM when the layout is otherwise supported.
- Keep Triton/Gluon fallback for sliding-window attention and unsupported head_dim.

## Notes
This is paired with ROCm/aiter#3782, which fixes the MTP PA ASM launch batch when graph metadata is padded but Q/block_tables are active-sized.

## Testing
Using docker.io/rocm/atom-dev:latest with the paired aiter fix:
- Synchronous repro: AMD_SERIALIZE_KERNEL=3 HIP_LAUNCH_BLOCKING=1, GSM8K limit=256, NUM_CONCURRENT=128: pass.
- Full GSM8K, NUM_CONCURRENT=128: pass, strict exact_match=0.8628, flexible exact_match=0.8643.
- Final MTP stats in server log: Accepted/Total Draft tokens=86863/165000, Acceptance rate=52.64%, Average toks/fwd=2.58.
