### PR TITLE
[Triton] DSV4 replace einsum with Triton BMM

### DIFF
--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1884,7 +1884,7 @@ class DeepseekV4Attention(nn.Module):
             dtype=o.dtype,
             device=o.device,
         ).transpose(0, 1)
-        y = batched_gemm_bf16(o.transpose(0, 1), wo_a, y)
+        y = batched_gemm_bf16(o.transpose(0, 1), wo_a, YQ=y)
         x = self.wo_b(y.transpose(0, 1).flatten(1))
         return x
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -48,6 +48,7 @@ from aiter.ops.triton.fusions.fused_clamp_act_mul import (
     fused_clamp_act_mul,
 )
 from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
+from aiter.ops.triton.gemm.batched.batched_gemm_bf16 import batched_gemm_bf16
 from atom.config import (
     Config,
     LayerQuantConfig,
@@ -1876,8 +1877,15 @@ class DeepseekV4Attention(nn.Module):
         # ----- Grouped output LoRA (batched on the full flat tensor) -----
         o = o.view(num_tokens, self.n_local_groups, -1)
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-        o = torch.einsum("sgd,grd->sgr", o, wo_a)
-        x = self.wo_b(o.flatten(1))
+        y = torch.empty(
+            num_tokens,
+            self.n_local_groups,
+            self.o_lora_rank,
+            dtype=o.dtype,
+            device=o.device,
+        ).transpose(0, 1)
+        y = batched_gemm_bf16(o.transpose(0, 1), wo_a, y)
+        x = self.wo_b(y.transpose(0, 1).flatten(1))
         return x
 
     def _fill_csa_paged_compress(


### PR DESCRIPTION
The tunned config is at AITER PR: https://github.com/ROCm/aiter/pull/3822

**TLDR:**

GFX950 TP8 Flash:
1k1kconc1: 204-> 205 toks/s
1k1kconc64: 10122 -> 10110 toks/s (<0.1% should be noise)

GFX950 TP8 Pro:
1k1kconc1: 137 -> 138 toks/s
1k1kconc64: 4855 -> 4950 toks/s

GFX1250 TP1 Flash:
1k1kconc1: 108 -> 146 toks/s
1k1kconc64: 3316 -> 3956 toks/s


**Detail:**

GFX1250, DSV4-Flash, TP1

einsum:
```
============ Serving Benchmark Result ============
Successful requests:                     4         
Benchmark duration (s):                  68.67     
Total input tokens:                      3804      
Total generated tokens:                  3650      
Request throughput (req/s):              0.06      
Output token throughput (tok/s):         53.16     
Total Token throughput (tok/s):          108.56    
---------------Time to First Token----------------
Mean TTFT (ms):                          174.14    
Median TTFT (ms):                        176.35    
P99 TTFT (ms):                           178.23    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.64     
Median TPOT (ms):                        18.61     
P99 TPOT (ms):                           18.71     
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.62     
Median ITL (ms):                         18.56     
P99 ITL (ms):                            21.27     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          17165.68  
Median E2EL (ms):                        16982.13  
P99 E2EL (ms):                           19072.43  
==================================================

============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  142.02    
Total input tokens:                      236166    
Total generated tokens:                  234891    
Request throughput (req/s):              1.80      
Output token throughput (tok/s):         1653.97   
Total Token throughput (tok/s):          3316.93   
---------------Time to First Token----------------
Mean TTFT (ms):                          1190.33   
Median TTFT (ms):                        281.47    
P99 TTFT (ms):                           6298.33   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.43     
Median TPOT (ms):                        35.96     
P99 TPOT (ms):                           39.05     
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.45     
Median ITL (ms):                         27.72     
P99 ITL (ms):                            172.39    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          33712.90  
Median E2EL (ms):                        32984.94  
P99 E2EL (ms):                           42550.89  
==================================================
```

Tuned triton BMM
```
============ Serving Benchmark Result ============
Successful requests:                     4         
Benchmark duration (s):                  50.88     
Total input tokens:                      3804      
Total generated tokens:                  3650      
Request throughput (req/s):              0.08      
Output token throughput (tok/s):         71.74     
Total Token throughput (tok/s):          146.51    
---------------Time to First Token----------------
Mean TTFT (ms):                          164.75    
Median TTFT (ms):                        168.53    
P99 TTFT (ms):                           171.25    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          13.77     
Median TPOT (ms):                        13.77     
P99 TPOT (ms):                           13.89     
---------------Inter-token Latency----------------
Mean ITL (ms):                           13.76     
Median ITL (ms):                         13.64     
P99 ITL (ms):                            20.01     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          12718.34  
Median E2EL (ms):                        12602.44  
P99 E2EL (ms):                           14022.22  
==================================================

============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  119.07    
Total input tokens:                      236166    
Total generated tokens:                  234891    
Request throughput (req/s):              2.15      
Output token throughput (tok/s):         1972.73   
Total Token throughput (tok/s):          3956.16   
---------------Time to First Token----------------
Mean TTFT (ms):                          858.36    
Median TTFT (ms):                        207.14    
P99 TTFT (ms):                           4395.17   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.88     
Median TPOT (ms):                        30.53     
P99 TPOT (ms):                           33.18     
---------------Inter-token Latency----------------
Mean ITL (ms):                           29.89     
Median ITL (ms):                         24.02     
P99 ITL (ms):                            145.91    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          28286.96  
Median E2EL (ms):                        27832.29  
P99 E2EL (ms):                           35253.11  
==================================================
```


GFX950 TP8 Flash

einsum:
```
============ Serving Benchmark Result ============
Successful requests:                     4         
Benchmark duration (s):                  40.13     
Total input tokens:                      4096      
Total generated tokens:                  4096      
Request throughput (req/s):              0.10      
Output token throughput (tok/s):         102.06    
Total Token throughput (tok/s):          204.12    
---------------Time to First Token----------------
Mean TTFT (ms):                          98.58     
Median TTFT (ms):                        98.34     
P99 TTFT (ms):                           104.71    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.71      
Median TPOT (ms):                        9.71      
P99 TPOT (ms):                           9.74      
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.70      
Median ITL (ms):                         9.68      
P99 ITL (ms):                            14.35     
==================================================


============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  51.79     
Total input tokens:                      262144    
Total generated tokens:                  262144    
Request throughput (req/s):              4.94      
Output token throughput (tok/s):         5061.45   
Total Token throughput (tok/s):          10122.90  
---------------Time to First Token----------------
Mean TTFT (ms):                          647.56    
Median TTFT (ms):                        575.88    
P99 TTFT (ms):                           991.21    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.02     
Median TPOT (ms):                        12.02     
P99 TPOT (ms):                           12.51     
---------------Inter-token Latency----------------
Mean ITL (ms):                           12.01     
Median ITL (ms):                         11.68     
P99 ITL (ms):                            13.78     
==================================================
```

Tuned triton BMM
```

============ Serving Benchmark Result ============
Successful requests:                     4         
Benchmark duration (s):                  39.80     
Total input tokens:                      4096      
Total generated tokens:                  4096      
Request throughput (req/s):              0.10      
Output token throughput (tok/s):         102.91    
Total Token throughput (tok/s):          205.81    
---------------Time to First Token----------------
Mean TTFT (ms):                          95.89     
Median TTFT (ms):                        94.97     
P99 TTFT (ms):                           99.26     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.63      
Median TPOT (ms):                        9.63      
P99 TPOT (ms):                           9.64      
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.62      
Median ITL (ms):                         9.63      
P99 ITL (ms):                            10.26     
==================================================

============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  51.86     
Total input tokens:                      262144    
Total generated tokens:                  262144    
Request throughput (req/s):              4.94      
Output token throughput (tok/s):         5055.21   
Total Token throughput (tok/s):          10110.42  
---------------Time to First Token----------------
Mean TTFT (ms):                          660.24    
Median TTFT (ms):                        582.34    
P99 TTFT (ms):                           1015.17   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.02     
Median TPOT (ms):                        12.04     
P99 TPOT (ms):                           12.51     
---------------Inter-token Latency----------------
Mean ITL (ms):                           12.01     
Median ITL (ms):                         11.65     
P99 ITL (ms):                            13.35     
==================================================
```

GFX950 TP8 Pro

einsum:
```
============ Serving Benchmark Result ============
Successful requests:                     4         
Benchmark duration (s):                  59.46     
Total input tokens:                      4096      
Total generated tokens:                  4096      
Request throughput (req/s):              0.07      
Output token throughput (tok/s):         68.88     
Total Token throughput (tok/s):          137.76    
---------------Time to First Token----------------
Mean TTFT (ms):                          128.57    
Median TTFT (ms):                        127.57    
P99 TTFT (ms):                           131.70    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.41     
Median TPOT (ms):                        14.41     
P99 TPOT (ms):                           14.41     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.39     
Median ITL (ms):                         14.39     
P99 ITL (ms):                            14.96     
==================================================

============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  107.98    
Total input tokens:                      262144    
Total generated tokens:                  262144    
Request throughput (req/s):              2.37      
Output token throughput (tok/s):         2427.73   
Total Token throughput (tok/s):          4855.46   
---------------Time to First Token----------------
Mean TTFT (ms):                          1736.58   
Median TTFT (ms):                        1784.99   
P99 TTFT (ms):                           2856.96   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          24.68     
Median TPOT (ms):                        24.69     
P99 TPOT (ms):                           25.78     
---------------Inter-token Latency----------------
Mean ITL (ms):                           24.66     
Median ITL (ms):                         23.92     
P99 ITL (ms):                            25.17     
==================================================
```

Tunned triton BMM
```

============ Serving Benchmark Result ============
Successful requests:                     4         
Benchmark duration (s):                  59.10     
Total input tokens:                      4096      
Total generated tokens:                  4096      
Request throughput (req/s):              0.07      
Output token throughput (tok/s):         69.31     
Total Token throughput (tok/s):          138.62    
---------------Time to First Token----------------
Mean TTFT (ms):                          136.93    
Median TTFT (ms):                        137.53    
P99 TTFT (ms):                           140.09    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.31     
Median TPOT (ms):                        14.31     
P99 TPOT (ms):                           14.32     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.29     
Median ITL (ms):                         14.30     
P99 ITL (ms):                            14.90     
==================================================


============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  105.73    
Total input tokens:                      262144    
Total generated tokens:                  262144    
Request throughput (req/s):              2.42      
Output token throughput (tok/s):         2479.40   
Total Token throughput (tok/s):          4958.80   
---------------Time to First Token----------------
Mean TTFT (ms):                          1511.92   
Median TTFT (ms):                        1483.94   
P99 TTFT (ms):                           2422.36   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          24.35     
Median TPOT (ms):                        24.42     
P99 TPOT (ms):                           25.54     
---------------Inter-token Latency----------------
Mean ITL (ms):                           24.33     
Median ITL (ms):                         23.53     
P99 ITL (ms):                            24.95     
==================================================
```
