### PR TITLE
feat: fuse V4 decode SWA cache-write into qk_norm_rope_maybe_quant

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -99,15 +99,6 @@
       ]
     },
     {
-      "display": "GLM-5-FP8",
-      "path": "zai-org/GLM-5-FP8",
-      "prefix": "glm-5-fp8",
-      "runner": "atom-mi355-8gpu.predownload",
-      "env_vars": "",
-      "config": { "tp": 8, "kv_cache_dtype": "fp8" },
-      "variants": [{ "label": "", "suffix": "", "conc_max": 256 }]
-    },
-    {
       "display": "GLM-5.2-FP8",
       "path": "zai-org/GLM-5.2-FP8",
       "prefix": "glm-5-2-fp8",

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -18,10 +18,6 @@ on:
         description: "Benchmark DeepSeek-V4-Pro"
         type: boolean
         default: true
-      glm-5-fp8:
-        description: "Benchmark GLM-5-FP8"
-        type: boolean
-        default: true
       glm-5.1-fp4:
         description: "Benchmark GLM-5.1-MXFP4"
         type: boolean

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -121,14 +121,15 @@ class AttentionMetaData_DSV4(AttentionMetaData):
 
     # ----- Per-fwd hoisted (built in `_attach_v4_per_fwd_meta`) -----
     batch_id_per_token: Optional[torch.Tensor] = None
-    """[padded_T] int64 GPU — the SINGLE per-token mapping
-    (token_idx → seq_idx). int64 dtype is required by PyTorch fancy-index
-    (used in the indexer); triton kernels (swa_write, csa_translate_pack)
-    read int64 fine. Padded tail [T:padded_T] = -1 sentinel; consumer
-    kernels skip on `bid < 0`. All other per-token quantities resolved as
-    `per_seq_data[batch_id_per_token[t]]` — no [T] aliases of seq data."""
+    """[padded_T] int32 GPU — the SINGLE per-token mapping
+    (token_idx → seq_idx). int32 indices are accepted by PyTorch
+    advanced-indexing (used in the indexer); triton kernels (swa_write,
+    csa_translate_pack) and the fused flydsl SWA scatter read int32. Padded
+    tail [T:padded_T] = -1 sentinel; consumer kernels skip on `bid < 0`. All
+    other per-token quantities resolved as `per_seq_data[batch_id_per_token[t]]`
+    — no [T] aliases of seq data."""
     batch_id_per_token_cpu: Optional[Any] = None
-    """[T] int64 — CPU mirror of the unpadded batch_id slice. Built once in
+    """[T] int32 — CPU mirror of the unpadded batch_id slice. Built once in
     `_attach_v4_per_fwd_meta` (host-side `np.repeat`); reused by
     `_attach_v4_paged_decode_meta` for indptr fancy-index math. Avoids a
     duplicate `np.repeat` per fwd. None for prefill paths that don't go
@@ -849,7 +850,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         per-seq committed count and cumsums it on CPU.
 
         Reuses two shared GPU tensors also set by `_attach_v4_per_fwd_meta`:
-          - `attn_metadata.batch_id_per_token`        [padded_T] int64
+          - `attn_metadata.batch_id_per_token`        [padded_T] int32
           - `attn_metadata.n_committed_csa_per_seq`   [bs] int32
 
         DECODE fast path: returns a minimal dict with only
@@ -944,7 +945,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             "total_committed": total_committed,
             "cu_committed_gpu": cu_committed_gpu,
             "n_committed_per_seq_gpu": n_committed_per_seq_gpu,  # int32, [bs]
-            "batch_id_per_token_gpu": batch_id_per_token_gpu,  # int64, [total_tokens]
+            "batch_id_per_token_gpu": batch_id_per_token_gpu,  # int32, [total_tokens]
             # Prefill-only fields below — decode never consults them. NOT
             # in pre-allocated buffers (per-fwd derived); CG capture path
             # would see stale pointers, but the decode path doesn't touch
@@ -1509,9 +1510,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # re-running `np.repeat(arange, token_num_per_seq)` (saves ~10μs/fwd
         # at bs=1024 + one allocation).
         batch_id_unpadded_np = np.repeat(
-            np.arange(scheduled_bs, dtype=np.int64), token_num_per_seq
+            np.arange(scheduled_bs, dtype=np.int32), token_num_per_seq
         )
-        batch_id_per_token_np = np.full(padded_total_tokens, -1, dtype=np.int64)
+        batch_id_per_token_np = np.full(padded_total_tokens, -1, dtype=np.int32)
         batch_id_per_token_np[:total_tokens] = batch_id_unpadded_np
         attn_metadata.batch_id_per_token_cpu = batch_id_unpadded_np
 
@@ -1634,9 +1635,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # ----- Per-seq scalars (CPU numpy) -----
         # The single per-token mapping. Built once in `_attach_v4_per_fwd_meta`
         # — both the GPU staging tensor and the unpadded CPU mirror — so we
-        # just borrow both here. int64 (numpy fancy-index source dtype is
+        # just borrow both here. int32 (numpy fancy-index source dtype is
         # irrelevant; consumers below produce int32 outputs).
-        batch_id_per_token_np = attn_metadata.batch_id_per_token_cpu  # [T] int64
+        batch_id_per_token_np = attn_metadata.batch_id_per_token_cpu  # [T] int32
         batch_id_per_token_gpu = attn_metadata.batch_id_per_token
 
         # Read pre-computed `ctx // {4,128}` from attn_metadata — populated by
@@ -1933,9 +1934,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         if block_tables_gpu is None:
             block_tables_gpu = var["block_tables"].gpu[:scheduled_bs]
         state_slot_per_seq_gpu = attn_metadata.state_slot_mapping[:scheduled_bs]
-        # batch_id_per_token is int64 in storage (PyTorch fancy-index
-        # compatibility upstream); kernel uses tl.load which is dtype-agnostic
-        # but cast for safety + consistency.
+        # batch_id_per_token is int32 in storage (accepted by PyTorch
+        # advanced-indexing and the fused flydsl SWA scatter); the kernel uses
+        # tl.load which is dtype-agnostic.
         bid_per_token_gpu = attn_metadata.batch_id_per_token[:T]
 
         # ----- Allocate output buffers (exact sizes known from CPU totals) -----
@@ -2270,13 +2271,15 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # `_attach_v4_per_fwd_meta`.
         bufs["v4_n_committed_csa_per_seq"] = CpuGpuBuffer(bs, **i32)
         # Single per-token mapping shared across ALL V4 consumers:
-        #   - swa_write / csa_translate_pack (triton kernels, read int64 fine)
-        #   - _build_v4_indexer_meta (PyTorch fancy index, REQUIRES int64)
-        # int64 dtype satisfies the PyTorch constraint with one buffer rather
-        # than maintaining an int32 + int64 mirror. Sized to `mnbt`
-        # (worst-case prefill total tokens) since swa_write fires on prefill
-        # paths too. Phase B decode only uses [:T_dec] of this buffer.
-        bufs["v4_batch_id_per_token"] = CpuGpuBuffer(mnbt, **i64)
+        #   - swa_write / csa_translate_pack (triton kernels)
+        #   - _build_v4_indexer_meta (PyTorch fancy index — int32 indices are
+        #     accepted by torch advanced-indexing)
+        #   - the fused SWA scatter in qk_norm_rope_maybe_quant (flydsl kernel
+        #     loads it as int32; the MTP-draft path also supplies int32 via the
+        #     cu_seqlens_q slice, so int32 keeps both decode paths uniform).
+        # Sized to `mnbt` (worst-case prefill total tokens) since swa_write
+        # fires on prefill paths too. Phase B decode only uses [:T_dec].
+        bufs["v4_batch_id_per_token"] = CpuGpuBuffer(mnbt, **i32)
 
         # _build_v4_indexer_meta (CSA only — but allocate unconditionally;
         # never accessed when CSA layers are absent).

--- a/atom/model_ops/v4_kernels/qk_norm_rope_maybe_quant.py
+++ b/atom/model_ops/v4_kernels/qk_norm_rope_maybe_quant.py
@@ -35,6 +35,8 @@ import torch
 import triton
 import triton.language as tl
 
+from atom.model_ops.v4_kernels.state_writes import swa_write
+
 # Lazy-imported flydsl path (optional dependency). Set to None when flydsl
 # is unavailable; the dispatch in ``qk_norm_rope_maybe_quant`` will fall
 # back to the Triton kernel.
@@ -316,6 +318,12 @@ def qk_norm_rope_maybe_quant(
     eps: float,
     quant_q: bool = False,
     quant_k: bool = False,
+    swa_kv: Optional[torch.Tensor] = None,
+    state_slot_mapping: Optional[torch.Tensor] = None,
+    batch_id_per_token: Optional[torch.Tensor] = None,
+    swa_cu_seqlens_q: Optional[torch.Tensor] = None,
+    swa_cache_size: Optional[int] = None,
+    swa_write_per_batch: Optional[int] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """Fused per-token RMSNorm + GPT-J interleaved RoPE (+ optional FP8 quant).
 
@@ -333,6 +341,23 @@ def qk_norm_rope_maybe_quant(
         eps: RMSNorm epsilon.
         quant_q, quant_k: independently emit per-row FP8 + per-row fp32 scale.
             ``False`` keeps the bf16 output and returns ``None`` for that scale.
+        swa_kv: ``[num_slots, cache_size, D]`` bf16 SWA ring buffer. When
+            provided, the (bf16) KV row is also written into
+            ``swa_kv[slot, pos % cache_size, :]`` where
+            ``slot = state_slot_mapping[batch_id_per_token[t]]``. The flydsl
+            path fuses this into the qk_norm launch; the Triton fallback emits
+            a separate ``swa_write`` so both backends have identical side
+            effects. Decode-only (prefill writes its SWA tail post-attention).
+            BF16 only (requires ``quant_k=False``).
+        state_slot_mapping: ``[bs]`` int32 — per-seq SWA ring slot. Required
+            when ``swa_kv`` is set.
+        batch_id_per_token: ``[T]`` int64, ``-1`` on CG-pad tokens — token→seq
+            map for the fused (flydsl) SWA scatter. Required by the flydsl path.
+        swa_cu_seqlens_q: ``[bs+1]`` int — per-seq cumulative seqlens used by
+            the Triton-fallback ``swa_write``. Required only on the fallback
+            path when ``swa_kv`` is set.
+        swa_cache_size: SWA ring slot count (``swa_kv.shape[1]``); fallback only.
+        swa_write_per_batch: ``min(max_seqlen_q, cache_size)``; fallback only.
 
     Returns:
         ``(q_out, kv_out, q_scale_or_None, k_scale_or_None)``:
@@ -397,6 +422,10 @@ def qk_norm_rope_maybe_quant(
     # "auto" picks flydsl whenever the shape matches.
     # ------------------------------------------------------------------
     if _FLYDSL_AVAILABLE:
+        # When swa_kv is provided, the flydsl kernel additionally scatters the
+        # post-norm/rope KV row into swa_kv[slot, pos % cache_size, :] in the
+        # same launch (slot = state_slot_mapping[batch_id_per_token[t]]),
+        # replacing a separate swa_write launch. BF16 only (quant_k off).
         return flydsl_qk_norm_rope_quant(
             q,
             kv,
@@ -410,6 +439,9 @@ def qk_norm_rope_maybe_quant(
             quant=quant_q,
             q_out=q_out,
             kv_out=kv_out,
+            swa_kv=swa_kv,
+            state_slot_mapping=state_slot_mapping,
+            batch_id_per_token=batch_id_per_token,
         )
 
     q_scale = (
@@ -476,6 +508,32 @@ def qk_norm_rope_maybe_quant(
         num_warps=num_warps,
         waves_per_eu=1,
     )
+
+    # Triton fallback does not fuse the SWA cache-write — emit it as a separate
+    # launch so callers get identical side effects regardless of which kernel
+    # backend ran (the flydsl path fuses it above). Only fires when the caller
+    # requested it (swa_kv provided) AND supplied the fallback's cu_seqlens_q
+    # path args.
+    if swa_kv is not None:
+        if (
+            swa_cu_seqlens_q is None
+            or swa_cache_size is None
+            or swa_write_per_batch is None
+        ):
+            raise ValueError(
+                "swa_kv requested on the Triton fallback path requires "
+                "swa_cu_seqlens_q, swa_cache_size, and swa_write_per_batch"
+            )
+        swa_write(
+            kv_out,
+            positions,
+            swa_cu_seqlens_q,
+            state_slot_mapping,
+            swa_kv,
+            swa_cache_size,
+            swa_write_per_batch,
+        )
+
     return q_out, kv_out, q_scale, kv_scale
 
 

--- a/atom/model_ops/v4_kernels/qk_norm_rope_maybe_quant.py
+++ b/atom/model_ops/v4_kernels/qk_norm_rope_maybe_quant.py
@@ -351,7 +351,7 @@ def qk_norm_rope_maybe_quant(
             BF16 only (requires ``quant_k=False``).
         state_slot_mapping: ``[bs]`` int32 — per-seq SWA ring slot. Required
             when ``swa_kv`` is set.
-        batch_id_per_token: ``[T]`` int64, ``-1`` on CG-pad tokens — token→seq
+        batch_id_per_token: ``[T]`` int32, ``-1`` on CG-pad tokens — token→seq
             map for the fused (flydsl) SWA scatter. Required by the flydsl path.
         swa_cu_seqlens_q: ``[bs+1]`` int — per-seq cumulative seqlens used by
             the Triton-fallback ``swa_write``. Required only on the fallback

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1754,6 +1754,16 @@ class DeepseekV4Attention(nn.Module):
         # from 4 (1.12×) to 32k (1.04×); used for both decode and prefill.
         # Optional FP8 quant outputs left off — downstream sparse_attn /
         # swa_write are still bf16.
+        # Decode folds the SWA cache-write into qk_norm_rope_maybe_quant: the
+        # post-norm/rope KV row is written into swa_kv[slot, pos%cache, :]
+        # (slot = state_slot_mapping[batch_id_per_token[t]]). The flydsl path
+        # fuses it into the kernel launch; the Triton fallback emits a separate
+        # swa_write internally — either way the bridge owns the SWA write, so
+        # no backend dispatch is needed here. Prefill writes its in-chunk SWA
+        # tail after sparse_attn, so it passes swa_kv=None and never fuses.
+        # For decode, write_per_batch (= min(max_seqlen_q, cache_size)) >=
+        # tokens-per-seq, so the fused per-token scatter (gated on batch_id>=0)
+        # covers exactly the tokens the old standalone swa_write did.
         q_sa, kv, q_scale, kv_scale = qk_norm_rope_maybe_quant(
             q,
             kv_pre,
@@ -1767,19 +1777,15 @@ class DeepseekV4Attention(nn.Module):
             self.eps,
             quant_q=False,
             quant_k=False,
+            swa_kv=self.swa_kv if is_decode else None,
+            state_slot_mapping=state_slot_mapping if is_decode else None,
+            batch_id_per_token=attn_md.batch_id_per_token if is_decode else None,
+            swa_cu_seqlens_q=attn_md.cu_seqlens_q if is_decode else None,
+            swa_cache_size=cache_size if is_decode else None,
+            swa_write_per_batch=(
+                min(attn_md.max_seqlen_q, cache_size) if is_decode else None
+            ),
         )
-        if is_decode:
-            # SWA write per-token in decode (prefill writes after sparse_attn
-            # below so the in-chunk SWA tail is captured post-attention).
-            swa_write(
-                kv,
-                positions,
-                attn_md.cu_seqlens_q,
-                state_slot_mapping,
-                self.swa_kv,
-                cache_size,
-                min(attn_md.max_seqlen_q, cache_size),
-            )
         if _V4_USE_REF_QUANT:
             act_quant_inplace(kv[..., :-rd], 64, self.scale_fmt)
 

--- a/atom/plugin/sglang/deepseek_v4_bridge.py
+++ b/atom/plugin/sglang/deepseek_v4_bridge.py
@@ -515,7 +515,7 @@ class _V4SGLangDecodeGraphBuffers:
         self.state_slot = i32(s)
         self.n_csa = i32(s)
         self.n_hca = i32(s)
-        self.batch_id = CpuGpuBuffer(t, dtype=torch.int64, device=device)
+        self.batch_id = CpuGpuBuffer(t, dtype=torch.int32, device=device)
         self.block_tables = i32(s, self.max_blocks)
         self.indptr_swa = i32(t + 1)
         self.indptr_csa = i32(t + 1)
@@ -668,11 +668,11 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
 
     if total:
         pos_np = (seq_np[:total] - 1).astype(np.int32)
-        batch_np = np.arange(total, dtype=np.int64)
+        batch_np = np.arange(total, dtype=np.int32)
     else:
         pos_np = np.zeros(0, dtype=np.int32)
-        batch_np = np.zeros(0, dtype=np.int64)
-    batch_pad = np.full(t_pad, -1, dtype=np.int64)
+        batch_np = np.zeros(0, dtype=np.int32)
+    batch_pad = np.full(t_pad, -1, dtype=np.int32)
     if total:
         batch_pad[:total] = batch_np
 
@@ -794,7 +794,7 @@ def build_atom_v4_attention_metadata_from_sglang(
     if is_decode:
         lens = np.ones(num_reqs, dtype=np.int32)
         q_np = np.arange(num_reqs + 1, dtype=np.int32)
-        batch_np = np.arange(num_reqs, dtype=np.int64)
+        batch_np = np.arange(num_reqs, dtype=np.int32)
         pos_np = positions[:num_reqs].detach().cpu().numpy().astype(np.int32)
     else:
         extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
@@ -817,7 +817,7 @@ def build_atom_v4_attention_metadata_from_sglang(
         lens = extend_lens[:num_reqs].astype(np.int32)
         q_np = np.zeros(num_reqs + 1, dtype=np.int32)
         q_np[1:] = np.cumsum(lens, dtype=np.int32)
-        batch_np = np.repeat(np.arange(num_reqs, dtype=np.int64), lens)
+        batch_np = np.repeat(np.arange(num_reqs, dtype=np.int32), lens)
         pos_np = positions[: int(lens.sum())].detach().cpu().numpy().astype(np.int32)
 
     total = int(lens.sum())

--- a/atom/plugin/vllm/deepseek_v4_bridge.py
+++ b/atom/plugin/vllm/deepseek_v4_bridge.py
@@ -433,9 +433,10 @@ class _V4DecodeMetaBuffers:
         self.state_slot = i32(S)
         self.n_csa = i32(S)
         self.n_hca = i32(S)
-        # Per-token mapping (sized to padded token count). int64 to match the
-        # numpy fancy-index source and the kernel's batch_id dtype.
-        self.batch_id = CpuGpuBuffer(T, dtype=torch.int64, device=device)
+        # Per-token mapping (sized to padded token count). int32: accepted by
+        # torch advanced-indexing AND by the fused flydsl SWA scatter (which
+        # loads batch_id as int32); matches the in-tree model_runner path.
+        self.batch_id = CpuGpuBuffer(T, dtype=torch.int32, device=device)
         # Ragged cumsums (T + 1) and ragged index pools (worst-case per-token
         # slot counts): SWA = win, CSA = win + index_topk, HCA = win + hca.
         self.indptr_swa = i32(T + 1)
@@ -804,7 +805,7 @@ def build_atom_v4_attention_metadata(
     if seq_lens_cpu is None:
         seq_lens_cpu = common_attn_metadata.seq_lens.cpu()
     seq_np = seq_lens_cpu[:num_reqs].numpy().astype(np.int32)
-    batch_np = np.repeat(np.arange(num_reqs, dtype=np.int64), lens)
+    batch_np = np.repeat(np.arange(num_reqs, dtype=np.int32), lens)
     md = AttentionMetaData(
         cu_seqlens_q=common_attn_metadata.query_start_loc,
         cu_seqlens_k=common_attn_metadata.query_start_loc,


### PR DESCRIPTION
## Summary
- Thread the SWA ring scatter through the `qk_norm_rope_maybe_quant` bridge so the V4 **decode** path no longer launches a standalone `swa_write` per layer per step.
- When `swa_kv` is provided, the post-norm/rope KV row is written into `swa_kv[slot, pos % cache_size, :]` (`slot = state_slot_mapping[batch_id_per_token[t]]`) inside the same kernel.

## Details
- **flydsl path**: fuses the scatter into the qk_norm launch — no extra kernel, no `[T, D]` KV HBM round-trip — via the new `swa_kv` / `state_slot_mapping` / `batch_id_per_token` args on `flydsl_qk_norm_rope_quant`.
- **Triton fallback**: emits the existing `swa_write` as a separate launch (driven by `swa_cu_seqlens_q` + `state_slot_mapping`) so both backends have identical side effects.
- `deepseek_v4.py` decode deletes its standalone `swa_write` call and passes the SWA args through the bridge instead. **Prefill is unchanged** (still writes its in-chunk SWA tail via `swa_write` after `sparse_attn`). BF16 only.

## Dependency
- Requires the matching aiter change **ROCm/aiter#3776** for the flydsl fused-scatter kernel support. Without it, the bridge still works via the Triton fallback `swa_write`.

## Test plan
- [ ] Decode gsm8k accuracy unchanged vs main (SWA ring contents must match) — fused vs non-fused 5× A/B previously showed no regression (means within run-to-run noise).
- [x] aiter-side bit-exact unit test + 24-config cross-check vs the real `swa_write` (in ROCm/aiter#3776): all `max_diff=0`.