### PR TITLE
[atom][M3]add gemma_norm + allreduce fusion

### DIFF
--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -13,7 +13,6 @@ from aiter import (
     rmsnorm2d_fwd_with_add,
 )
 from aiter.dist.communication_op import (
-    tensor_model_parallel_all_reduce,
     tensor_model_parallel_fused_allreduce_rmsnorm,
 )
 from aiter.dist.parallel_state import get_tensor_model_parallel_world_size
@@ -764,7 +763,13 @@ def fused_allreduce_gemma_rms_norm(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """MiniMax-M3 helper for delayed TP all-reduce followed by Gemma RMSNorm."""
     if get_tensor_model_parallel_world_size() > 1:
-        hidden_states = tensor_model_parallel_all_reduce(hidden_states)
+        return tensor_model_parallel_fused_allreduce_rmsnorm(
+            hidden_states.contiguous(),
+            residual,
+            norm.weight,
+            norm.variance_epsilon,
+            gemma_norm=True,
+        )
     return norm(hidden_states, residual)
 
 


### PR DESCRIPTION
## Motivation

add gemma_norm for atom M3 allreduce_norm fusion

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

m3 acc gsm8k test

## Test Result

```bash
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9439|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9447|±  |0.0063|
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
