### PR TITLE
[atom-sgl-benchmark] Parallelize SGLang GPU benchmarks and unify container run flags

### DIFF
--- a/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
@@ -1,0 +1,300 @@
+name: ATOM SGLang accuracy validation GPU shard (internal)
+
+on:
+  workflow_call:
+    inputs:
+      shard_suffix:
+        description: "Short id for container names (e.g. mi355, mi308)"
+        required: true
+        type: string
+      model_matrix_json:
+        description: 'JSON {"include":[{model_name, model_path, ...}, ...]} for this runner shard'
+        required: true
+        type: string
+      sglang_image_tag:
+        required: true
+        type: string
+      upload_accuracy_artifact:
+        description: "Whether to upload accuracy-* artifacts for the dashboard job"
+        required: true
+        type: boolean
+
+jobs:
+  sglang-model-accuracy:
+    name: SGLANG Model Accuracy (${{ matrix.model_name }})
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.model_matrix_json) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 240
+    permissions:
+      actions: read
+      contents: write
+    env:
+      CONTAINER_NAME: atom_sglang_validation_${{ inputs.shard_suffix }}_${{ strategy.job-index }}
+      SGLANG_IMAGE_TAG: ${{ inputs.sglang_image_tag }}
+    steps:
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+
+      - name: Docker Login
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Set HF_TOKEN
+        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> "$GITHUB_ENV"
+            
+      - name: Print runner user and Docker diagnostics
+        run: |
+          echo "=== Docker diagnostics ==="
+          echo "PATH=${PATH}"
+          echo "whoami=$(whoami)"
+          echo "id=$(id)"
+          echo "DOCKER_HOST=${DOCKER_HOST:-<unset>}"
+          echo "docker path: $(command -v docker || true)"
+          ls -l /var/run/docker.sock || true
+          stat -c '%U %G %a %n' /var/run/docker.sock || true
+          echo "docker version:"
+          docker version || true
+          echo "docker info:"
+          docker info || true
+          echo "=== End Docker diagnostics ==="
+        
+      - name: Pull SGLANG image
+        run: |
+          docker pull "${SGLANG_IMAGE_TAG}"
+
+      - name: Prepare model cache mount
+        run: |
+          MODEL_CACHE_ROOT="/mnt/raid0/pretrained_model"
+          MODEL_CACHE_MOUNT=""
+          MODEL_CACHE_DESC="container-local ${MODEL_CACHE_ROOT} (no host cache mount)"
+
+          if [ -d "$(dirname "${MODEL_CACHE_ROOT}")" ]; then
+            mkdir -p "${MODEL_CACHE_ROOT}"
+            MODEL_CACHE_MOUNT="-v ${MODEL_CACHE_ROOT}:${MODEL_CACHE_ROOT}"
+            MODEL_CACHE_DESC="${MODEL_CACHE_ROOT} (host mount)"
+          else
+            echo "Warning: $(dirname "${MODEL_CACHE_ROOT}") directory not found on runner; using container-local ${MODEL_CACHE_ROOT}."
+          fi
+
+          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
+          echo "MODEL_CACHE_ROOT=${MODEL_CACHE_ROOT}" >> "$GITHUB_ENV"
+          echo "MODEL_CACHE_MOUNT=${MODEL_CACHE_MOUNT}" >> "$GITHUB_ENV"
+          echo "MODEL_CACHE_DESC=${MODEL_CACHE_DESC}" >> "$GITHUB_ENV"
+
+      #- name: Clean up old containers
+      #  run: |
+      #    containers=$(docker ps -q)
+      #    if [ -n "$containers" ]; then
+      #      docker kill $containers || true
+      #    fi
+      #    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+      - name: Start validation container
+        run: |
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+
+          MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
+          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
+
+          cat > /tmp/sglang_env_file.txt << 'EOF'
+          ${{ matrix.env_vars }}
+          EOF
+
+          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
+            -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
+            $MODEL_MOUNT \
+            -w /workspace \
+            --ipc=host --group-add video \
+            --shm-size=16G \
+            --privileged \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            --ulimit memlock=-1 \
+            --ulimit stack=67108864 \
+            --env-file /tmp/sglang_env_file.txt \
+            -e HF_TOKEN="${HF_TOKEN:-}" \
+            -e HF_HOME="${MODEL_CACHE_ROOT}/.cache/huggingface" \
+            -e HUGGINGFACE_HUB_CACHE="${MODEL_CACHE_ROOT}/.cache/huggingface/hub" \
+            -e TRANSFORMERS_CACHE="${MODEL_CACHE_ROOT}/.cache/huggingface/transformers" \
+            --name "$CONTAINER_NAME" \
+            "${SGLANG_IMAGE_TAG}"
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Collect GPU info (inside container)
+        id: gpu-info
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" docker "${{ matrix.runner }}"
+
+      - name: Download model if needed
+        run: |
+          set -euo pipefail
+          model_dir="${MODEL_CACHE_ROOT}/${{ matrix.model_path }}"
+          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
+            lock_suffix="$(printf '%s' "${{ matrix.model_path }}" | tr '/:@' '___')"
+            if ! docker exec \
+              -e HF_TOKEN="${HF_TOKEN:-}" \
+              -e MODEL_CACHE_ROOT="${MODEL_CACHE_ROOT}" \
+              -e MODEL_PATH="${{ matrix.model_path }}" \
+              -e MODEL_DIR="$model_dir" \
+              -e RUNNER_NAME="${{ matrix.runner }}" \
+              -e LOCK_SUFFIX="$lock_suffix" \
+              "$CONTAINER_NAME" \
+              bash -lc '
+                set -euo pipefail
+                completion_flag="$MODEL_DIR/.download-complete"
+                use_model_lock="true"
+
+                if [ "$RUNNER_NAME" = "atom-mi355-8gpu.predownload" ]; then
+                  use_model_lock="false"
+                fi
+
+                download_model() {
+                  if [ -f "$MODEL_DIR/config.json" ]; then
+                    echo "Model directory exists without a completion marker under ${MODEL_DIR}; validating download"
+                  else
+                    echo "Model not found under ${MODEL_DIR}; downloading model"
+                  fi
+
+                  rm -f "$completion_flag"
+                  hf download "$MODEL_PATH" --local-dir "$MODEL_DIR"
+                  touch "$completion_flag"
+                }
+
+                if [ -f "$completion_flag" ]; then
+                  echo "Model already exists under ${MODEL_DIR}; skip download"
+                elif [ "$use_model_lock" != "true" ]; then
+                  echo "Baremetal runner ${RUNNER_NAME} detected; skipping shared model download lock"
+                  download_model
+                else
+                  lock_dir="${MODEL_CACHE_ROOT}/.cache/atom-download-locks"
+                  mkdir -p "$lock_dir"
+                  lock_file="$lock_dir/${LOCK_SUFFIX}.lock"
+                  exec 9>"$lock_file"
+                  echo "Waiting for model download lock: $lock_file"
+                  if ! flock -w 7200 9; then
+                    echo "Timed out waiting for model download lock: $lock_file"
+                    exit 1
+                  fi
+
+                  if [ -f "$completion_flag" ]; then
+                    echo "Model became available under ${MODEL_DIR} while waiting for the lock; skip download"
+                  else
+                    download_model
+                  fi
+                fi
+              '; then
+              echo "Model download failed for '${{ matrix.model_path }}'. Aborting."
+              exit 1
+            fi
+          else
+            echo "${MODEL_CACHE_ROOT} directory not mounted; skipping model download"
+          fi
+
+      - name: Resolve SGLANG model path
+        if: success()
+        run: |
+          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
+            echo "SGLANG_RESOLVED_MODEL_PATH=${MODEL_CACHE_ROOT}/${{ matrix.model_path }}" >> "$GITHUB_ENV"
+            echo "Using mounted model path: ${MODEL_CACHE_ROOT}/${{ matrix.model_path }}"
+          else
+            echo "SGLANG_RESOLVED_MODEL_PATH=${{ matrix.model_path }}" >> "$GITHUB_ENV"
+            echo "Using model id: ${{ matrix.model_path }}"
+          fi
+
+      - name: Run SGLANG launch and gsm8k accuracy via script (full mode)
+        timeout-minutes: 120
+        env:
+          SGLANG_MODEL_NAME: ${{ matrix.model_name }}
+          SGLANG_MODEL_PATH: ${{ matrix.model_path }}
+          SGLANG_EXTRA_ARGS: ${{ matrix.extra_args }}
+          SGLANG_ENV_VARS: ${{ matrix.env_vars }}
+          MAX_WAIT_RETRIES: "120"
+          STREAM_SGLANG_LOGS: "1"
+          LM_EVAL_TASK: "gsm8k"
+        run: |
+          docker exec \
+            -e SGLANG_MODEL_NAME="${SGLANG_MODEL_NAME}" \
+            -e SGLANG_MODEL_PATH="${SGLANG_RESOLVED_MODEL_PATH:-$SGLANG_MODEL_PATH}" \
+            -e SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS}" \
+            -e SGLANG_ENV_VARS="${SGLANG_ENV_VARS}" \
+            -e SGLANG_DOCKER_IMAGE="${SGLANG_IMAGE_TAG}" \
+            -e GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
+            -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
+            -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
+            -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
+            -e STREAM_SGLANG_LOGS="${STREAM_SGLANG_LOGS}" \
+            -e LM_EVAL_TASK="${LM_EVAL_TASK}" \
+            "$CONTAINER_NAME" bash -lc "
+              set -euo pipefail
+              bash .github/scripts/atom_sglang_test.sh accuracy
+            "
+
+      - name: Check SGLANG accuracy test results
+        if: success()
+        run: |
+          docker cp "$CONTAINER_NAME":/tmp/atom_sglang_accuracy_results ./atom_sglang_accuracy_results || true
+          result_file=$(ls -1t atom_sglang_accuracy_results/*.json 2>/dev/null | head -n 1)
+          if [ -z "$result_file" ] || [ ! -f "$result_file" ]; then
+            echo "ERROR: No results JSON file found in atom_sglang_accuracy_results/"
+            exit 2
+          fi
+
+          echo "RESULT_FILE: $result_file"
+          flexible_extract_value=$(jq '.results.gsm8k["exact_match,flexible-extract"]' "$result_file")
+          echo "Flexible extract value: $flexible_extract_value"
+          echo "Accuracy test threshold: ${{ matrix.accuracy_test_threshold }}"
+
+          result=$(awk -v val="$flexible_extract_value" -v threshold="${{ matrix.accuracy_test_threshold }}" 'BEGIN {print (val < threshold) ? 1 : 0}')
+          if [ "$result" -eq 1 ]; then
+            echo "Accuracy test failed: Flexible extract value $flexible_extract_value is less than threshold ${{ matrix.accuracy_test_threshold }}."
+            exit 1
+          else
+            echo "Accuracy test passed: Flexible extract value $flexible_extract_value is greater than or equal to threshold ${{ matrix.accuracy_test_threshold }}."
+            exit 0
+          fi
+
+      - name: Collect summary
+        if: success()
+        run: |
+          echo "SGLANG gsm8k summary for ${{ matrix.model_name }}:" >> $GITHUB_STEP_SUMMARY
+          docker exec "$CONTAINER_NAME" bash -lc "awk '/\|Tasks\|Version\|/,/^$/ { if (NF > 0) print }' /tmp/atom_sglang_accuracy_output.txt" >> $GITHUB_STEP_SUMMARY || true
+
+      - name: Collect artifacts
+        if: always()
+        run: |
+          docker cp "$CONTAINER_NAME":/tmp/atom_sglang.log ./atom_sglang.log || true
+          docker cp "$CONTAINER_NAME":/tmp/atom_sglang_accuracy_output.txt ./atom_sglang_accuracy_output.txt || true
+          docker cp "$CONTAINER_NAME":/tmp/atom_sglang_accuracy_results ./atom_sglang_accuracy_results || true
+
+      - name: Upload model artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sglang-validation-${{ matrix.model_name }}-${{ github.run_id }}
+          path: |
+            atom_sglang.log
+            atom_sglang_accuracy_output.txt
+            atom_sglang_accuracy_results
+
+      - name: Upload accuracy results for dashboard
+        if: ${{ always() && inputs.upload_accuracy_artifact }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: accuracy-${{ matrix.model_name }}
+          path: atom_sglang_accuracy_results/*.json
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker exec "$CONTAINER_NAME" bash -lc "if [ -f /tmp/atom_sglang.pid ]; then kill \$(cat /tmp/atom_sglang.pid) || true; fi" || true
+          docker stop "$CONTAINER_NAME" || true
+          docker rm "$CONTAINER_NAME" || true
+          docker rmi "${SGLANG_IMAGE_TAG}" || true
+

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -9,11 +9,6 @@ on:
     # from") as the ATOM branch selector, so users do not need to type branch
     # names.
     inputs:
-      run_dsr1_fp8_tp4:
-        description: "DeepSeek-R1-FP8 TP4"
-        required: false
-        type: boolean
-        default: false
       run_dsv32_fp8_tp4:
         description: "DeepSeek-V3.2-FP8 TP4"
         required: false
@@ -21,6 +16,11 @@ on:
         default: false
       run_dsv32_fp8_tp4_dp4_ep4:
         description: "DeepSeek-V3.2-FP8 TP4 DP4 EP4"
+        required: false
+        type: boolean
+        default: false
+      run_dsv32_fp8_tp8:
+        description: "DeepSeek-V3.2-FP8 TP8"
         required: false
         type: boolean
         default: false
@@ -64,6 +64,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_dsr1_fp8_tp4:
+        description: "DeepSeek-R1-FP8 TP4"
+        required: false
+        type: boolean
+        default: false
       run_dsr1_fp8_tp8:
         description: "DeepSeek-R1-FP8 TP8"
         required: false
@@ -99,38 +104,13 @@ on:
         required: false
         type: boolean
         default: false
-      run_dsv32_fp8_tp8:
-        description: "DeepSeek-V3.2-FP8 TP8"
-        required: false
-        type: boolean
-        default: false
       run_glm51_fp8_tp8:
         description: "GLM-5.1-FP8 TP8"
         required: false
         type: boolean
         default: false
-      run_mi308_qwen35_397b_a17b_fp8_tp4:
-        description: "MI308 Qwen3.5-397B-A17B-FP8 TP4"
-        required: false
-        type: boolean
-        default: false
-      run_mi308_qwen35_397b_a17b_fp8_tp8:
-        description: "MI308 Qwen3.5-397B-A17B-FP8 TP8"
-        required: false
-        type: boolean
-        default: false
-      run_mi308_qwen35_35b_a3b_fp8_tp1:
-        description: "MI308 Qwen3.5-35B-A3B-FP8 TP1"
-        required: false
-        type: boolean
-        default: false
-      run_mi308_qwen3_32b_fp8_tp1:
-        description: "MI308 Qwen3-32B-FP8 TP1"
-        required: false
-        type: boolean
-        default: false
-      run_mi308_qwen3_32b_fp8_tp8:
-        description: "MI308 Qwen3-32B-FP8 TP8"
+      run_mi308_all:
+        description: "Run all MI308 gsm8k accuracy cases (Qwen on atom-mi308-8gpu-plugins-benchmark)"
         required: false
         type: boolean
         default: false
@@ -166,6 +146,10 @@ jobs:
       sglang_image_tag: ${{ steps.meta.outputs.sglang_image_tag }}
       cleanup_temp_image: ${{ steps.meta.outputs.cleanup_temp_image }}
       model_matrix: ${{ steps.meta.outputs.model_matrix }}
+      model_matrix_mi355: ${{ steps.meta.outputs.model_matrix_mi355 }}
+      model_matrix_mi308: ${{ steps.meta.outputs.model_matrix_mi308 }}
+      has_model_cells_mi355: ${{ steps.meta.outputs.has_model_cells_mi355 }}
+      has_model_cells_mi308: ${{ steps.meta.outputs.has_model_cells_mi308 }}
     steps:
       - name: Checkout selected ATOM branch
         uses: actions/checkout@v6
@@ -203,11 +187,7 @@ jobs:
           RUN_DSR1_FP4_TP8_MTP1: ${{ inputs.run_dsr1_fp4_tp8_mtp1 }}
           RUN_DSV32_FP8_TP8: ${{ inputs.run_dsv32_fp8_tp8 }}
           RUN_GLM51_FP8_TP8: ${{ inputs.run_glm51_fp8_tp8 }}
-          RUN_MI308_QWEN35_397B_A17B_FP8_TP4: ${{ inputs.run_mi308_qwen35_397b_a17b_fp8_tp4 }}
-          RUN_MI308_QWEN35_397B_A17B_FP8_TP8: ${{ inputs.run_mi308_qwen35_397b_a17b_fp8_tp8 }}
-          RUN_MI308_QWEN35_35B_A3B_FP8_TP1: ${{ inputs.run_mi308_qwen35_35b_a3b_fp8_tp1 }}
-          RUN_MI308_QWEN3_32B_FP8_TP1: ${{ inputs.run_mi308_qwen3_32b_fp8_tp1 }}
-          RUN_MI308_QWEN3_32B_FP8_TP8: ${{ inputs.run_mi308_qwen3_32b_fp8_tp8 }}
+          RUN_MI308_ALL: ${{ inputs.run_mi308_all }}
           REBUILD_ATOM_BASE_FROM_DOCKERFILE: ${{ inputs.rebuild_atom_base_from_dockerfile }}
         run: |
           set -euo pipefail
@@ -220,6 +200,7 @@ jobs:
           import sys
 
           event = os.environ["GITHUB_EVENT_NAME"]
+          run_mi308_all = os.environ.get("RUN_MI308_ALL", "").lower() == "true"
           models = [
               {
                   "toggle_env": "RUN_DSR1_FP8_TP4",
@@ -403,9 +384,9 @@ jobs:
               },
           ]
 
+          # MI308 gsm8k accuracy: nightly schedule only (no workflow_dispatch inputs; GitHub limits 25 inputs).
           mi308_models = [
               {
-                  "toggle_env": "RUN_MI308_QWEN35_397B_A17B_FP8_TP4",
                   "model_name": "MI308 Qwen3.5-397B-A17B-FP8 TP4",
                   "model_path": "Qwen/Qwen3.5-397B-A17B-FP8",
                   "extra_args": "--tensor-parallel-size 4 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
@@ -414,7 +395,6 @@ jobs:
                   "runner": "atom-mi308-8gpu-plugins-benchmark",
               },
               {
-                  "toggle_env": "RUN_MI308_QWEN35_397B_A17B_FP8_TP8",
                   "model_name": "MI308 Qwen3.5-397B-A17B-FP8 TP8",
                   "model_path": "Qwen/Qwen3.5-397B-A17B-FP8",
                   "extra_args": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
@@ -423,7 +403,6 @@ jobs:
                   "runner": "atom-mi308-8gpu-plugins-benchmark",
               },
               {
-                  "toggle_env": "RUN_MI308_QWEN35_35B_A3B_FP8_TP1",
                   "model_name": "MI308 Qwen3.5-35B-A3B-FP8 TP1",
                   "model_path": "Qwen/Qwen3.5-35B-A3B-FP8",
                   "extra_args": "--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
@@ -432,7 +411,6 @@ jobs:
                   "runner": "atom-mi308-8gpu-plugins-benchmark",
               },
               {
-                  "toggle_env": "RUN_MI308_QWEN3_32B_FP8_TP1",
                   "model_name": "MI308 Qwen3-32B-FP8 TP1",
                   "model_path": "Qwen/Qwen3-32B-FP8",
                   "extra_args": "--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
@@ -441,7 +419,6 @@ jobs:
                   "runner": "atom-mi308-8gpu-plugins-benchmark",
               },
               {
-                  "toggle_env": "RUN_MI308_QWEN3_32B_FP8_TP8",
                   "model_name": "MI308 Qwen3-32B-FP8 TP8",
                   "model_path": "Qwen/Qwen3-32B-FP8",
                   "extra_args": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
@@ -454,7 +431,12 @@ jobs:
 
           selected = []
           for model in models:
-              enabled = event != "workflow_dispatch" or os.environ.get(model["toggle_env"], "").lower() == "true"
+              toggle = model.get("toggle_env")
+              if toggle is None:
+                  # MI308-only rows: nightly schedule, or manual when run_mi308_all is checked.
+                  enabled = (event != "workflow_dispatch") or run_mi308_all
+              else:
+                  enabled = event != "workflow_dispatch" or os.environ.get(toggle, "").lower() == "true"
               if enabled:
                   selected.append({k: v for k, v in model.items() if k != "toggle_env"})
 
@@ -462,7 +444,21 @@ jobs:
               print("No models selected for manual run.", file=sys.stderr)
               sys.exit(1)
 
-          print(f"model_matrix={json.dumps({'include': selected})}")
+          def is_mi308_row(row):
+              return "mi308" in str(row.get("runner", ""))
+
+          sel355 = [r for r in selected if not is_mi308_row(r)]
+          sel308 = [r for r in selected if is_mi308_row(r)]
+          sep = (",", ":")
+          full = json.dumps({"include": selected}, separators=sep)
+          j355 = json.dumps({"include": sel355}, separators=sep)
+          j308 = json.dumps({"include": sel308}, separators=sep)
+
+          print(f"model_matrix={full}")
+          print(f"model_matrix_mi355={j355}")
+          print(f"model_matrix_mi308={j308}")
+          print("has_model_cells_mi355=" + ("true" if sel355 else "false"))
+          print("has_model_cells_mi308=" + ("true" if sel308 else "false"))
           PY
 
           REBUILD_FROM_DOCKERFILE="${REBUILD_ATOM_BASE_FROM_DOCKERFILE:-false}"
@@ -622,288 +618,45 @@ jobs:
             fi
           done
 
-  sglang-model-accuracy:
-    name: SGLANG Model Accuracy (${{ matrix.model_name }})
+  sglang-model-accuracy-mi355:
+    name: SGLANG Model Accuracy (MI355 / non-MI308 runners)
     needs: [prepare-sglang-image]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.prepare-sglang-image.outputs.model_matrix) }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 240
+    if: >-
+      always()
+      && needs.prepare-sglang-image.result == 'success'
+      && needs.prepare-sglang-image.outputs.has_model_cells_mi355 == 'true'
     permissions:
       actions: read
       contents: write
-    env:
-      CONTAINER_NAME: atom_sglang_validation_${{ strategy.job-index }}
-      SGLANG_IMAGE_TAG: ${{ needs.prepare-sglang-image.outputs.sglang_image_tag }}
-    steps:
-      - name: Checkout ATOM repo
-        uses: actions/checkout@v6
+    uses: ./.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+    secrets: inherit
+    with:
+      shard_suffix: mi355
+      model_matrix_json: ${{ needs.prepare-sglang-image.outputs.model_matrix_mi355 }}
+      sglang_image_tag: ${{ needs.prepare-sglang-image.outputs.sglang_image_tag }}
+      upload_accuracy_artifact: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard) }}
 
-      - name: Docker Login
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-      - name: Set HF_TOKEN
-        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> "$GITHUB_ENV"
-            
-      - name: Print runner user and Docker diagnostics
-        run: |
-          echo "=== Docker diagnostics ==="
-          echo "PATH=${PATH}"
-          echo "whoami=$(whoami)"
-          echo "id=$(id)"
-          echo "DOCKER_HOST=${DOCKER_HOST:-<unset>}"
-          echo "docker path: $(command -v docker || true)"
-          ls -l /var/run/docker.sock || true
-          stat -c '%U %G %a %n' /var/run/docker.sock || true
-          echo "docker version:"
-          docker version || true
-          echo "docker info:"
-          docker info || true
-          echo "=== End Docker diagnostics ==="
-        
-      - name: Pull SGLANG image
-        run: |
-          docker pull "${SGLANG_IMAGE_TAG}"
-
-      - name: Prepare model cache mount
-        run: |
-          MODEL_CACHE_ROOT="/mnt/raid0/pretrained_model"
-          MODEL_CACHE_MOUNT=""
-          MODEL_CACHE_DESC="container-local ${MODEL_CACHE_ROOT} (no host cache mount)"
-
-          if [ -d "$(dirname "${MODEL_CACHE_ROOT}")" ]; then
-            mkdir -p "${MODEL_CACHE_ROOT}"
-            MODEL_CACHE_MOUNT="-v ${MODEL_CACHE_ROOT}:${MODEL_CACHE_ROOT}"
-            MODEL_CACHE_DESC="${MODEL_CACHE_ROOT} (host mount)"
-          else
-            echo "Warning: $(dirname "${MODEL_CACHE_ROOT}") directory not found on runner; using container-local ${MODEL_CACHE_ROOT}."
-          fi
-
-          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
-          echo "MODEL_CACHE_ROOT=${MODEL_CACHE_ROOT}" >> "$GITHUB_ENV"
-          echo "MODEL_CACHE_MOUNT=${MODEL_CACHE_MOUNT}" >> "$GITHUB_ENV"
-          echo "MODEL_CACHE_DESC=${MODEL_CACHE_DESC}" >> "$GITHUB_ENV"
-
-      #- name: Clean up old containers
-      #  run: |
-      #    containers=$(docker ps -q)
-      #    if [ -n "$containers" ]; then
-      #      docker kill $containers || true
-      #    fi
-      #    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
-
-      - name: Start validation container
-        run: |
-          if [ -f "/etc/podinfo/gha-render-devices" ]; then
-            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
-          else
-            DEVICE_FLAG="--device /dev/dri"
-          fi
-
-          MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
-          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
-
-          cat > /tmp/sglang_env_file.txt << 'EOF'
-          ${{ matrix.env_vars }}
-          EOF
-
-          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
-            -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
-            $MODEL_MOUNT \
-            -w /workspace \
-            --ipc=host --group-add video \
-            --shm-size=16G \
-            --privileged \
-            --cap-add=SYS_PTRACE \
-            --security-opt seccomp=unconfined \
-            --ulimit memlock=-1 \
-            --ulimit stack=67108864 \
-            --env-file /tmp/sglang_env_file.txt \
-            -e HF_TOKEN="${HF_TOKEN:-}" \
-            -e HF_HOME="${MODEL_CACHE_ROOT}/.cache/huggingface" \
-            -e HUGGINGFACE_HUB_CACHE="${MODEL_CACHE_ROOT}/.cache/huggingface/hub" \
-            -e TRANSFORMERS_CACHE="${MODEL_CACHE_ROOT}/.cache/huggingface/transformers" \
-            --name "$CONTAINER_NAME" \
-            "${SGLANG_IMAGE_TAG}"
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Collect GPU info (inside container)
-        id: gpu-info
-        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" docker "${{ matrix.runner }}"
-
-      - name: Download model if needed
-        run: |
-          set -euo pipefail
-          model_dir="${MODEL_CACHE_ROOT}/${{ matrix.model_path }}"
-          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
-            lock_suffix="$(printf '%s' "${{ matrix.model_path }}" | tr '/:@' '___')"
-            if ! docker exec \
-              -e HF_TOKEN="${HF_TOKEN:-}" \
-              -e MODEL_CACHE_ROOT="${MODEL_CACHE_ROOT}" \
-              -e MODEL_PATH="${{ matrix.model_path }}" \
-              -e MODEL_DIR="$model_dir" \
-              -e RUNNER_NAME="${{ matrix.runner }}" \
-              -e LOCK_SUFFIX="$lock_suffix" \
-              "$CONTAINER_NAME" \
-              bash -lc '
-                set -euo pipefail
-                completion_flag="$MODEL_DIR/.download-complete"
-                use_model_lock="true"
-
-                if [ "$RUNNER_NAME" = "atom-mi355-8gpu.predownload" ]; then
-                  use_model_lock="false"
-                fi
-
-                download_model() {
-                  if [ -f "$MODEL_DIR/config.json" ]; then
-                    echo "Model directory exists without a completion marker under ${MODEL_DIR}; validating download"
-                  else
-                    echo "Model not found under ${MODEL_DIR}; downloading model"
-                  fi
-
-                  rm -f "$completion_flag"
-                  hf download "$MODEL_PATH" --local-dir "$MODEL_DIR"
-                  touch "$completion_flag"
-                }
-
-                if [ -f "$completion_flag" ]; then
-                  echo "Model already exists under ${MODEL_DIR}; skip download"
-                elif [ "$use_model_lock" != "true" ]; then
-                  echo "Baremetal runner ${RUNNER_NAME} detected; skipping shared model download lock"
-                  download_model
-                else
-                  lock_dir="${MODEL_CACHE_ROOT}/.cache/atom-download-locks"
-                  mkdir -p "$lock_dir"
-                  lock_file="$lock_dir/${LOCK_SUFFIX}.lock"
-                  exec 9>"$lock_file"
-                  echo "Waiting for model download lock: $lock_file"
-                  if ! flock -w 7200 9; then
-                    echo "Timed out waiting for model download lock: $lock_file"
-                    exit 1
-                  fi
-
-                  if [ -f "$completion_flag" ]; then
-                    echo "Model became available under ${MODEL_DIR} while waiting for the lock; skip download"
-                  else
-                    download_model
-                  fi
-                fi
-              '; then
-              echo "Model download failed for '${{ matrix.model_path }}'. Aborting."
-              exit 1
-            fi
-          else
-            echo "${MODEL_CACHE_ROOT} directory not mounted; skipping model download"
-          fi
-
-      - name: Resolve SGLANG model path
-        if: success()
-        run: |
-          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
-            echo "SGLANG_RESOLVED_MODEL_PATH=${MODEL_CACHE_ROOT}/${{ matrix.model_path }}" >> "$GITHUB_ENV"
-            echo "Using mounted model path: ${MODEL_CACHE_ROOT}/${{ matrix.model_path }}"
-          else
-            echo "SGLANG_RESOLVED_MODEL_PATH=${{ matrix.model_path }}" >> "$GITHUB_ENV"
-            echo "Using model id: ${{ matrix.model_path }}"
-          fi
-
-      - name: Run SGLANG launch and gsm8k accuracy via script (full mode)
-        timeout-minutes: 120
-        env:
-          SGLANG_MODEL_NAME: ${{ matrix.model_name }}
-          SGLANG_MODEL_PATH: ${{ matrix.model_path }}
-          SGLANG_EXTRA_ARGS: ${{ matrix.extra_args }}
-          SGLANG_ENV_VARS: ${{ matrix.env_vars }}
-          MAX_WAIT_RETRIES: "120"
-          STREAM_SGLANG_LOGS: "1"
-          LM_EVAL_TASK: "gsm8k"
-        run: |
-          docker exec \
-            -e SGLANG_MODEL_NAME="${SGLANG_MODEL_NAME}" \
-            -e SGLANG_MODEL_PATH="${SGLANG_RESOLVED_MODEL_PATH:-$SGLANG_MODEL_PATH}" \
-            -e SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS}" \
-            -e SGLANG_ENV_VARS="${SGLANG_ENV_VARS}" \
-            -e SGLANG_DOCKER_IMAGE="${SGLANG_IMAGE_TAG}" \
-            -e GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
-            -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
-            -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
-            -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
-            -e STREAM_SGLANG_LOGS="${STREAM_SGLANG_LOGS}" \
-            -e LM_EVAL_TASK="${LM_EVAL_TASK}" \
-            "$CONTAINER_NAME" bash -lc "
-              set -euo pipefail
-              bash .github/scripts/atom_sglang_test.sh accuracy
-            "
-
-      - name: Check SGLANG accuracy test results
-        if: success()
-        run: |
-          docker cp "$CONTAINER_NAME":/tmp/atom_sglang_accuracy_results ./atom_sglang_accuracy_results || true
-          result_file=$(ls -1t atom_sglang_accuracy_results/*.json 2>/dev/null | head -n 1)
-          if [ -z "$result_file" ] || [ ! -f "$result_file" ]; then
-            echo "ERROR: No results JSON file found in atom_sglang_accuracy_results/"
-            exit 2
-          fi
-
-          echo "RESULT_FILE: $result_file"
-          flexible_extract_value=$(jq '.results.gsm8k["exact_match,flexible-extract"]' "$result_file")
-          echo "Flexible extract value: $flexible_extract_value"
-          echo "Accuracy test threshold: ${{ matrix.accuracy_test_threshold }}"
-
-          result=$(awk -v val="$flexible_extract_value" -v threshold="${{ matrix.accuracy_test_threshold }}" 'BEGIN {print (val < threshold) ? 1 : 0}')
-          if [ "$result" -eq 1 ]; then
-            echo "Accuracy test failed: Flexible extract value $flexible_extract_value is less than threshold ${{ matrix.accuracy_test_threshold }}."
-            exit 1
-          else
-            echo "Accuracy test passed: Flexible extract value $flexible_extract_value is greater than or equal to threshold ${{ matrix.accuracy_test_threshold }}."
-            exit 0
-          fi
-
-      - name: Collect summary
-        if: success()
-        run: |
-          echo "SGLANG gsm8k summary for ${{ matrix.model_name }}:" >> $GITHUB_STEP_SUMMARY
-          docker exec "$CONTAINER_NAME" bash -lc "awk '/\|Tasks\|Version\|/,/^$/ { if (NF > 0) print }' /tmp/atom_sglang_accuracy_output.txt" >> $GITHUB_STEP_SUMMARY || true
-
-      - name: Collect artifacts
-        if: always()
-        run: |
-          docker cp "$CONTAINER_NAME":/tmp/atom_sglang.log ./atom_sglang.log || true
-          docker cp "$CONTAINER_NAME":/tmp/atom_sglang_accuracy_output.txt ./atom_sglang_accuracy_output.txt || true
-          docker cp "$CONTAINER_NAME":/tmp/atom_sglang_accuracy_results ./atom_sglang_accuracy_results || true
-
-      - name: Upload model artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: sglang-validation-${{ matrix.model_name }}-${{ github.run_id }}
-          path: |
-            atom_sglang.log
-            atom_sglang_accuracy_output.txt
-            atom_sglang_accuracy_results
-
-      - name: Upload accuracy results for dashboard
-        if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard)) }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: accuracy-${{ matrix.model_name }}
-          path: atom_sglang_accuracy_results/*.json
-          if-no-files-found: ignore
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker exec "$CONTAINER_NAME" bash -lc "if [ -f /tmp/atom_sglang.pid ]; then kill \$(cat /tmp/atom_sglang.pid) || true; fi" || true
-          docker stop "$CONTAINER_NAME" || true
-          docker rm "$CONTAINER_NAME" || true
-          docker rmi "${SGLANG_IMAGE_TAG}" || true
+  sglang-model-accuracy-mi308:
+    name: SGLANG Model Accuracy (MI308 runners)
+    needs: [prepare-sglang-image]
+    if: >-
+      always()
+      && needs.prepare-sglang-image.result == 'success'
+      && needs.prepare-sglang-image.outputs.has_model_cells_mi308 == 'true'
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+    secrets: inherit
+    with:
+      shard_suffix: mi308
+      model_matrix_json: ${{ needs.prepare-sglang-image.outputs.model_matrix_mi308 }}
+      sglang_image_tag: ${{ needs.prepare-sglang-image.outputs.sglang_image_tag }}
+      upload_accuracy_artifact: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard) }}
 
   accuracy-dashboard:
     name: Update SGLANG accuracy dashboard
-    needs: [sglang-model-accuracy]
+    needs: [sglang-model-accuracy-mi355, sglang-model-accuracy-mi308]
     if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard)) }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
@@ -1,0 +1,653 @@
+name: ATOM SGLang benchmark GPU shard (internal)
+
+on:
+  workflow_call:
+    inputs:
+      shard_suffix:
+        description: "Short id for container names (e.g. mi355, mi308)"
+        required: true
+        type: string
+      benchmark_matrix_json:
+        description: 'JSON object {"include":[{model,params},...]} for this hardware shard only'
+        required: true
+        type: string
+      mesh_server_mode:
+        required: true
+        type: string
+      atom_repository:
+        required: true
+        type: string
+      atom_ref:
+        required: true
+        type: string
+      workload_label:
+        required: true
+        type: string
+      prebuilt_sglang_image:
+        required: true
+        type: string
+      sglang_image_source:
+        required: true
+        type: string
+      selected_sglang_ref:
+        required: true
+        type: string
+      selected_sglang_version:
+        required: true
+        type: string
+      publish_to_dashboard:
+        required: true
+        type: string
+      upload_to_custom_dashboard:
+        required: true
+        type: string
+      sglang_image_tag:
+        required: true
+        type: string
+      atom_source_sha_for_checkout:
+        required: true
+        type: string
+
+jobs:
+  benchmark:
+    name: SGLang ${{ matrix.model.display }} ${{ matrix.params.input_length }}/${{ matrix.params.output_length }} c=${{ matrix.params.concurrency }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.benchmark_matrix_json) }}
+    runs-on: ${{ matrix.model.runner }}
+    timeout-minutes: 240
+    permissions:
+      actions: read
+      contents: write
+    env:
+      MODEL_NAME: ${{ matrix.model.display }}
+      DASHBOARD_MODEL_NAME: ${{ matrix.model.dashboard_model || '' }}
+      MODEL_SOURCE_PATH: ${{ matrix.model.source_path || matrix.model.path }}
+      MODEL_PATH: ${{ matrix.model.path || matrix.model.source_path }}
+      SGLANG_EXTRA_ARGS: ${{ matrix.model.extra_args }}
+      BENCH_EXTRA_ARGS: ${{ matrix.model.bench_args }}
+      MESH_SERVER_MODE: ${{ inputs.mesh_server_mode }}
+      MESH_SPEC_MODE: ${{ matrix.model.mesh_spec_mode || 'none' }}
+      MESH_TP_SIZE: ${{ matrix.model.tp_size || '' }}
+      MESH_DP_SIZE: ${{ matrix.model.dp_size || '' }}
+      MESH_EP_SIZE: ${{ matrix.model.ep_size || '' }}
+      CASE_EXTRA_ARGS_BY_PAIR: ${{ toJson(matrix.model.case_extra_args_by_pair) }}
+      CASE_ENV_VARS_BY_PAIR: ${{ toJson(matrix.model.case_env_vars_by_pair) }}
+      RESULT_PREFIX: ${{ matrix.model.prefix }}
+      ISL: ${{ matrix.params.input_length }}
+      OSL: ${{ matrix.params.output_length }}
+      CONC: ${{ matrix.params.concurrency }}
+      RANDOM_RANGE_RATIO: ${{ matrix.params.random_range_ratio }}
+      RESULT_FILENAME: ${{ matrix.model.prefix }}-${{ matrix.params.input_length }}-${{ matrix.params.output_length }}-${{ matrix.params.concurrency }}-${{ matrix.params.random_range_ratio }}
+      WORKLOAD_LABEL: ${{ matrix.model.workload_label || inputs.workload_label }}
+      CONTAINER_NAME: atom_sglang_benchmark_${{ inputs.shard_suffix }}_${{ strategy.job-index }}
+      CONTAINER_RESULT_DIR: /tmp/sglang-benchmark-results
+      CONTAINER_BENCH_SERVING_DIR: /tmp/sglang-benchmark/bench_serving
+      SGLANG_IMAGE_TAG: ${{ inputs.sglang_image_tag }}
+      SGLANG_IMAGE_SOURCE: ${{ inputs.sglang_image_source }}
+      BENCH_SERVING_REPO_URL: https://github.com/kimbochen/bench_serving.git
+      ATOM_SOURCE_REPOSITORY: ${{ inputs.atom_repository }}
+      ATOM_SOURCE_REF: ${{ inputs.atom_ref }}
+      SGLANG_REF_USED: ${{ inputs.selected_sglang_ref }}
+      SGLANG_VERSION_USED: ${{ inputs.selected_sglang_version }}
+      PUBLISH_TO_DASHBOARD: ${{ inputs.publish_to_dashboard }}
+      UPLOAD_TO_CUSTOM_DASHBOARD: ${{ inputs.upload_to_custom_dashboard }}
+    steps:
+      - name: Detect container engine
+        run: |
+          if command -v podman > /dev/null 2>&1; then
+            echo "CONTAINER_ENGINE=podman" >> "$GITHUB_ENV"
+            echo "Container engine: podman"
+          elif docker info > /dev/null 2>&1; then
+            echo "CONTAINER_ENGINE=docker" >> "$GITHUB_ENV"
+            echo "Container engine: docker"
+          else
+            echo "ERROR: Neither docker nor podman is available on this runner."
+            exit 1
+          fi
+
+      #- name: Clean up containers and workspace
+      #  run: |
+      #    echo "=== Cleaning up containers on $(hostname) ==="
+      #    containers=$($CONTAINER_ENGINE ps -q)
+      #    if [ -n "$containers" ]; then
+      #      $CONTAINER_ENGINE kill $containers || true
+      #    fi
+      #    $CONTAINER_ENGINE rm -f "$CONTAINER_NAME" 2>/dev/null || true
+      #    $CONTAINER_ENGINE run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged docker.io/rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
+
+      - name: Checkout benchmark ATOM source
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.ATOM_SOURCE_REPOSITORY }}
+          ref: ${{ inputs.atom_source_sha_for_checkout }}
+          fetch-depth: 1
+
+      - name: Record benchmark source revision
+        run: |
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          echo "ATOM_SOURCE_SHA=${SOURCE_SHA}" >> "$GITHUB_ENV"
+          echo "Benchmarking ${ATOM_SOURCE_REPOSITORY}@${ATOM_SOURCE_REF} (${SOURCE_SHA}) with ${SGLANG_IMAGE_SOURCE} image ${SGLANG_IMAGE_TAG}"
+
+      - name: Container Engine Login
+        run: |
+          set -euo pipefail
+          IMG="${SGLANG_IMAGE_TAG}"
+          if [[ "${IMG}" != */* ]]; then
+            IMG="docker.io/library/${IMG}"
+          else
+            reg="${IMG%%/*}"
+            if [[ "${reg}" != *.* && "${reg}" != localhost* && "${reg}" != *:* ]]; then
+              IMG="docker.io/${IMG}"
+            fi
+          fi
+          echo "SGLANG_IMAGE_REF=${IMG}" >> "$GITHUB_ENV"
+          REG="${IMG%%/*}"
+          echo "Logging in to registry: ${REG}"
+          echo "${{ secrets.DOCKER_PASSWORD }}" | $CONTAINER_ENGINE login "$REG" -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Set HF_TOKEN
+        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> "$GITHUB_ENV"
+
+      - name: Pull SGLang benchmark image
+        run: |
+          set -euo pipefail
+          IMG="${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}"
+          if [[ -z "${IMG}" ]]; then
+            echo "ERROR: SGLang image reference is empty."
+            exit 1
+          fi
+          echo "Pulling SGLang benchmark image: ${IMG} (workflow tag: ${SGLANG_IMAGE_TAG})"
+          pull_ok=false
+          for attempt in 1 2 3; do
+            echo "Pull attempt ${attempt}/3: ${IMG}"
+            if $CONTAINER_ENGINE pull "${IMG}"; then
+              pull_ok=true
+              break
+            fi
+            sleep $((attempt * 10))
+          done
+
+          if [[ "${pull_ok}" != "true" && "${CONTAINER_ENGINE}" == "podman" ]]; then
+            echo "Plain podman pull failed; retrying with docker transport."
+            if $CONTAINER_ENGINE pull "docker://${IMG}"; then
+              pull_ok=true
+            fi
+          fi
+
+          if [[ "${pull_ok}" != "true" ]]; then
+            echo "ERROR: Failed to pull SGLang benchmark image: ${IMG}"
+            exit 1
+          fi
+
+      - name: Prepare model cache mount
+        run: |
+          MODEL_CACHE_MOUNT=""
+          MODEL_CACHE_DESC="container-local /models (no host cache mount)"
+          if [ -d "/it-share/models" ]; then
+            MODEL_CACHE_MOUNT="-v /it-share/models:/models"
+            MODEL_CACHE_DESC="/it-share/models (shared host path)"
+          elif [ -d "/models" ]; then
+            MODEL_CACHE_MOUNT="-v /models:/models"
+            MODEL_CACHE_DESC="/models (shared host path)"
+          elif [ -d "/data/models" ]; then
+            MODEL_CACHE_MOUNT="-v /data/models:/models"
+            MODEL_CACHE_DESC="/data/models (shared host path)"
+          else
+            echo "No shared host model cache found; using container-local /models."
+          fi
+
+          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
+          echo "MODEL_CACHE_MOUNT=${MODEL_CACHE_MOUNT}" >> "$GITHUB_ENV"
+          echo "MODEL_CACHE_DESC=${MODEL_CACHE_DESC}" >> "$GITHUB_ENV"
+
+      - name: Start SGLang benchmark container
+        run: |
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri"
+          fi
+
+          MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
+          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
+
+          printf '%s\n' "${{ matrix.model.env_vars }}" | sed 's/^[[:space:]]*//' > /tmp/oot_env_file.txt
+          CASE_KEY="${ISL}x${OSL}"
+          CASE_ENV_VARS="$(
+            CASE_ENV_VARS_BY_PAIR="${CASE_ENV_VARS_BY_PAIR:-null}" CASE_KEY="${CASE_KEY}" python3 - <<'PY'
+          import json
+          import os
+
+          raw = os.environ.get("CASE_ENV_VARS_BY_PAIR") or "null"
+          try:
+              mapping = json.loads(raw)
+          except json.JSONDecodeError:
+              mapping = None
+          if isinstance(mapping, dict):
+              value = mapping.get(os.environ["CASE_KEY"], "")
+              if value:
+                  print(value)
+          PY
+          )"
+          if [[ -n "${CASE_ENV_VARS}" ]]; then
+            printf '%s\n' "${CASE_ENV_VARS}" >> /tmp/oot_env_file.txt
+          fi
+
+          # Podman + crun: avoid "create keyring ... Disk quota exceeded" (kernel user-keyring
+          # quota on shared runners). Docker ignores CONTAINERS_CONF_OVERRIDE; Podman reads it.
+          ATOM_SGLANG_PODMAN_CONF=""
+          if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
+            ATOM_SGLANG_PODMAN_CONF="$(mktemp "${TMPDIR:-/tmp}/atom-sglang-containers-conf.XXXXXX")"
+            printf '%s\n' '[containers]' 'keyring=false' > "${ATOM_SGLANG_PODMAN_CONF}"
+            _atom_sglang_prev_exit_body="$(trap -p EXIT | sed -nE "s/^trap -- '(.*)' EXIT$/\1/p" || true)"
+            cleanup_atom_podman_conf() {
+              rm -f "${ATOM_SGLANG_PODMAN_CONF:-}"
+              if [[ -n "${_atom_sglang_prev_exit_body:-}" ]]; then
+                eval "${_atom_sglang_prev_exit_body}"
+              fi
+            }
+            trap cleanup_atom_podman_conf EXIT
+          fi
+
+          container_engine_run() {
+            if [[ "${CONTAINER_ENGINE}" != "podman" ]]; then
+              "${CONTAINER_ENGINE}" "$@"
+              return
+            fi
+            CONTAINERS_CONF_OVERRIDE="${ATOM_SGLANG_PODMAN_CONF}" "${CONTAINER_ENGINE}" "$@"
+          }
+
+          container_engine_run run -dt --device=/dev/kfd $DEVICE_FLAG \
+            -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
+            $MODEL_MOUNT \
+            -w /workspace \
+            --ipc=host --group-add keep-groups \
+            --privileged \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            --ulimit memlock=-1 \
+            --ulimit stack=67108864 \
+            --env-file /tmp/oot_env_file.txt \
+            -e HF_TOKEN="${HF_TOKEN:-}" \
+            --name "$CONTAINER_NAME" \
+            --entrypoint /bin/bash \
+            "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}" \
+            -lc 'trap "exit 0" TERM INT; sleep infinity & wait'
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Collect GPU info (inside container)
+        id: gpu-info
+        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" "$CONTAINER_ENGINE" "${{ matrix.model.runner }}"
+
+      - name: Download model if needed
+        run: |
+          model_dir="${MODEL_PATH}"
+          if [[ "${model_dir}" = /models/* ]]; then
+            model_dir="/models/${model_dir#/models/}"
+          elif [[ "${model_dir}" = /it-share/models/* ]]; then
+            model_dir="/models/${model_dir#/it-share/models/}"
+          elif [[ "${model_dir}" = /data/models/* ]]; then
+            model_dir="/models/${model_dir#/data/models/}"
+          elif [[ "${model_dir}" != /* ]]; then
+            model_dir="/models/${model_dir}"
+          fi
+          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
+            echo "/models directory found, downloading model to ${model_dir}"
+            if ! $CONTAINER_ENGINE exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "hf download \"${MODEL_SOURCE_PATH}\" --local-dir \"$model_dir\""; then
+              echo "Model download failed for '${MODEL_SOURCE_PATH}'. Aborting."
+              exit 1
+            fi
+          else
+            echo "/models directory not mounted; skipping model download"
+          fi
+
+      - name: Resolve SGLang model path
+        run: |
+          model_dir="${MODEL_PATH}"
+          if [[ "${model_dir}" = /models/* ]]; then
+            model_dir="/models/${model_dir#/models/}"
+          elif [[ "${model_dir}" = /it-share/models/* ]]; then
+            model_dir="/models/${model_dir#/it-share/models/}"
+          elif [[ "${model_dir}" = /data/models/* ]]; then
+            model_dir="/models/${model_dir#/data/models/}"
+          elif [[ "${model_dir}" != /* ]]; then
+            model_dir="/models/${model_dir}"
+          fi
+          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
+            echo "SGLANG_RESOLVED_MODEL_PATH=${model_dir}" >> "$GITHUB_ENV"
+            echo "Using mounted model path: ${model_dir}"
+          else
+            echo "SGLANG_RESOLVED_MODEL_PATH=${MODEL_SOURCE_PATH}" >> "$GITHUB_ENV"
+            echo "Using model id: ${MODEL_SOURCE_PATH}"
+          fi
+
+      - name: Prepare SGLang benchmark runner in container
+        run: |
+          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "
+            set -euo pipefail
+            rm -rf \"${CONTAINER_BENCH_SERVING_DIR%/bench_serving}\"
+            mkdir -p \"${CONTAINER_BENCH_SERVING_DIR%/bench_serving}\"
+            git clone --depth 1 \"${BENCH_SERVING_REPO_URL}\" \"${CONTAINER_BENCH_SERVING_DIR}\"
+            test -f \"${CONTAINER_BENCH_SERVING_DIR}/benchmark_serving.py\"
+          "
+
+      - name: Run SGLang benchmark
+        timeout-minutes: 240
+        env:
+          MAX_WAIT_RETRIES: "120"
+          STREAM_SGLANG_LOGS: "1"
+        run: |
+          set -euo pipefail
+          echo "=== Benchmark config: ${MODEL_NAME} ISL=${ISL} OSL=${OSL} CONC=${CONC} RANDOM_RANGE_RATIO=${RANDOM_RANGE_RATIO} ==="
+          EFFECTIVE_BENCHMARK_RUNNER="sglang_atom"
+          EFFECTIVE_SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS}"
+          CASE_KEY="${ISL}x${OSL}"
+          CASE_EXTRA_ARGS="$(
+            CASE_EXTRA_ARGS_BY_PAIR="${CASE_EXTRA_ARGS_BY_PAIR:-null}" CASE_KEY="${CASE_KEY}" python3 - <<'PY'
+          import json
+          import os
+
+          raw = os.environ.get("CASE_EXTRA_ARGS_BY_PAIR") or "null"
+          try:
+              mapping = json.loads(raw)
+          except json.JSONDecodeError:
+              mapping = None
+          if isinstance(mapping, dict):
+              value = mapping.get(os.environ["CASE_KEY"], "")
+              if value:
+                  print(value)
+          PY
+          )"
+          if [[ -n "${CASE_EXTRA_ARGS}" ]]; then
+            EFFECTIVE_SGLANG_EXTRA_ARGS="${EFFECTIVE_SGLANG_EXTRA_ARGS} ${CASE_EXTRA_ARGS}"
+          fi
+          BENCH_NUM_PROMPTS="$(( CONC * 10 ))"
+          BENCH_NUM_WARMUPS="$(( 2 * CONC ))"
+          if [[ "${WORKLOAD_LABEL}" == "SGLang-Mesh" && "${MESH_DP_SIZE:-1}" -gt 1 && "${MESH_EP_SIZE:-1}" -gt 1 ]]; then
+            BENCH_NUM_PROMPTS="$(( CONC * 3 ))"
+            BENCH_NUM_WARMUPS="${CONC}"
+          fi
+          if [[ "${WORKLOAD_LABEL}" == "SGLang-Mesh" && "${MESH_SERVER_MODE}" == "sglang-mori" ]]; then
+            case "${SGLANG_IMAGE_TAG}" in
+              lmsysorg/sglang-rocm*|docker.io/lmsysorg/sglang-rocm*) ;;
+              *)
+                echo "ERROR: mesh_server_mode=sglang-mori requires docker_image to start with lmsysorg/sglang-rocm."
+                echo "Current image: ${SGLANG_IMAGE_TAG}"
+                exit 1
+                ;;
+            esac
+            EFFECTIVE_BENCHMARK_RUNNER="mori_sglang_mesh"
+            $CONTAINER_ENGINE exec \
+              -e MODEL="${SGLANG_RESOLVED_MODEL_PATH:-$MODEL_PATH}" \
+              -e SGLANG_MODEL_NAME="${MODEL_NAME}" \
+              -e TP="${MESH_TP_SIZE}" \
+              -e DP_SIZE="${MESH_DP_SIZE:-1}" \
+              -e EP_SIZE="${MESH_EP_SIZE:-1}" \
+              -e CONC="${CONC}" \
+              -e ISL="${ISL}" \
+              -e OSL="${OSL}" \
+              -e RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO}" \
+              -e RESULT_FILENAME="${RESULT_FILENAME}" \
+              -e RESULT_DIR="${CONTAINER_RESULT_DIR}" \
+              -e BENCH_SERVING_DIR="${CONTAINER_BENCH_SERVING_DIR}" \
+              -e SERVER_EXTRA_ARGS="${EFFECTIVE_SGLANG_EXTRA_ARGS}" \
+              -e BENCH_EXTRA_ARGS="${BENCH_EXTRA_ARGS}" \
+              -e SPEC_MODE="${MESH_SPEC_MODE}" \
+              -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
+              -e STREAM_SGLANG_LOGS="${STREAM_SGLANG_LOGS}" \
+              "$CONTAINER_NAME" bash -lc "
+                set -euo pipefail
+                bash .github/scripts/atom_sglang_mesh_benchmark.sh
+              "
+          else
+            if [[ "${WORKLOAD_LABEL}" == "SGLang-Mesh" && -n "${MESH_TP_SIZE}" ]]; then
+              EFFECTIVE_SGLANG_EXTRA_ARGS="--tensor-parallel-size ${MESH_TP_SIZE} ${EFFECTIVE_SGLANG_EXTRA_ARGS}"
+            fi
+            $CONTAINER_ENGINE exec -d \
+              -e SGLANG_MODEL_NAME="${MODEL_NAME}" \
+              -e SGLANG_MODEL_PATH="${SGLANG_RESOLVED_MODEL_PATH:-$MODEL_PATH}" \
+              -e SGLANG_EXTRA_ARGS="${EFFECTIVE_SGLANG_EXTRA_ARGS}" \
+              -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
+              -e STREAM_SGLANG_LOGS="${STREAM_SGLANG_LOGS}" \
+              -e KEEP_SERVER_ALIVE_ON_EXIT=1 \
+              "$CONTAINER_NAME" bash -lc "
+                set -euo pipefail
+                bash .github/scripts/atom_sglang_test.sh start
+              "
+
+            last_sglang_log_line=0
+
+            emit_new_sglang_logs() {
+              if [ "${STREAM_SGLANG_LOGS}" != "1" ]; then
+                return 0
+              fi
+
+              current_line_count=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'if [ -f /tmp/atom_sglang.log ]; then wc -l < /tmp/atom_sglang.log; else echo 0; fi' 2>/dev/null || echo 0)
+              current_line_count=${current_line_count//$'\r'/}
+              if [ "${current_line_count:-0}" -le "${last_sglang_log_line}" ]; then
+                return 0
+              fi
+
+              echo ""
+              echo "========== New SGLang log output =========="
+              $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "sed -n '$((last_sglang_log_line + 1)),${current_line_count}p' /tmp/atom_sglang.log" || true
+              last_sglang_log_line=${current_line_count}
+            }
+
+            for ((i=1; i<=MAX_WAIT_RETRIES; i++)); do
+              if $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1'; then
+                emit_new_sglang_logs
+                echo "SGLang server is ready."
+                break
+              fi
+
+              emit_new_sglang_logs
+
+              server_status=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc '
+                if [ -f /tmp/atom_sglang.pid ]; then
+                  pid=$(cat /tmp/atom_sglang.pid)
+                  if kill -0 "$pid" 2>/dev/null; then
+                    echo running
+                  else
+                    echo dead
+                  fi
+                elif pgrep -f "sglang.launch_server" >/dev/null 2>&1; then
+                  echo running
+                else
+                  echo starting
+                fi
+              ' 2>/dev/null || echo unknown)
+
+              if [ "${server_status}" = "dead" ]; then
+                echo "SGLang server process exited before becoming ready."
+                $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'tail -n 200 /tmp/atom_sglang.log || true' || true
+                exit 1
+              fi
+
+              echo "Waiting for SGLang server... (${i}/${MAX_WAIT_RETRIES}; status=${server_status})"
+              sleep "${WAIT_INTERVAL_SEC:-30}"
+            done
+
+            if ! $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1'; then
+              echo "SGLang server did not become ready in time."
+              emit_new_sglang_logs
+              $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'tail -n 200 /tmp/atom_sglang.log || true' || true
+              exit 1
+            fi
+
+            TRUST_REMOTE_CODE_ARG=""
+            if [[ "${EFFECTIVE_SGLANG_EXTRA_ARGS}" == *"--trust-remote-code"* ]]; then
+              TRUST_REMOTE_CODE_ARG="--trust-remote-code"
+            fi
+
+            $CONTAINER_ENGINE exec \
+              -e ISL="${ISL}" \
+              -e OSL="${OSL}" \
+              -e CONC="${CONC}" \
+              -e RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO}" \
+              -e RESULT_FILENAME="${RESULT_FILENAME}" \
+              -e BENCH_EXTRA_ARGS="${BENCH_EXTRA_ARGS}" \
+              "$CONTAINER_NAME" bash -lc "
+                set -euo pipefail
+                rm -rf \"${CONTAINER_RESULT_DIR}\"
+                mkdir -p \"${CONTAINER_RESULT_DIR}\"
+                PYTHONDONTWRITEBYTECODE=1 python \"${CONTAINER_BENCH_SERVING_DIR}/benchmark_serving.py\" \
+                  --model=\"${SGLANG_RESOLVED_MODEL_PATH:-$MODEL_PATH}\" \
+                  --backend=sglang \
+                  --base-url=http://127.0.0.1:8000 \
+                  --dataset-name=random \
+                  --random-input-len=\"${ISL}\" \
+                  --random-output-len=\"${OSL}\" \
+                  --random-range-ratio \"${RANDOM_RANGE_RATIO}\" \
+                  --num-prompts=\"${BENCH_NUM_PROMPTS}\" \
+                  --max-concurrency=\"${CONC}\" \
+                  ${TRUST_REMOTE_CODE_ARG} \
+                  --num-warmups=\"${BENCH_NUM_WARMUPS}\" \
+                  --request-rate=inf \
+                  --ignore-eos \
+                  --save-result \
+                  --percentile-metrics=\"ttft,tpot,itl,e2el\" \
+                  --result-dir=\"${CONTAINER_RESULT_DIR}\" \
+                  --result-filename=\"${RESULT_FILENAME}.json\" \
+                  ${BENCH_EXTRA_ARGS:-}
+              "
+          fi
+
+          $CONTAINER_ENGINE exec -i \
+            -e RESULT_PATH="${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" \
+            -e ISL="${ISL}" \
+            -e OSL="${OSL}" \
+            -e EXTRA_ARGS_TEXT="${EFFECTIVE_SGLANG_EXTRA_ARGS}" \
+            -e DASHBOARD_MODEL_NAME="${DASHBOARD_MODEL_NAME}" \
+            -e ATOM_SOURCE_REPOSITORY="${ATOM_SOURCE_REPOSITORY}" \
+            -e ATOM_SOURCE_REF="${ATOM_SOURCE_REF}" \
+            -e ATOM_SOURCE_SHA="${ATOM_SOURCE_SHA}" \
+            -e SGLANG_REF_USED="${SGLANG_REF_USED}" \
+            -e SGLANG_VERSION_USED="${SGLANG_VERSION_USED}" \
+            -e SGLANG_IMAGE_SOURCE="${SGLANG_IMAGE_SOURCE}" \
+            -e SGLANG_IMAGE_TAG_USED="${SGLANG_IMAGE_TAG}" \
+            -e PUBLISH_TO_DASHBOARD="${PUBLISH_TO_DASHBOARD}" \
+            -e UPLOAD_TO_CUSTOM_DASHBOARD="${UPLOAD_TO_CUSTOM_DASHBOARD}" \
+            -e WORKLOAD_LABEL="${WORKLOAD_LABEL}" \
+            -e BENCHMARK_RUNNER="${EFFECTIVE_BENCHMARK_RUNNER}" \
+            -e MESH_SERVER_MODE="${MESH_SERVER_MODE}" \
+            -e MESH_SPEC_MODE="${MESH_SPEC_MODE}" \
+            -e MESH_TP_SIZE="${MESH_TP_SIZE}" \
+            -e MESH_DP_SIZE="${MESH_DP_SIZE}" \
+            -e MESH_EP_SIZE="${MESH_EP_SIZE}" \
+            "$CONTAINER_NAME" python3 - <<'PY'
+          import json
+          import os
+          import re
+
+          result_path = os.environ["RESULT_PATH"]
+          with open(result_path, encoding="utf-8") as f:
+              data = json.load(f)
+
+          data["random_input_len"] = int(os.environ["ISL"])
+          data["random_output_len"] = int(os.environ["OSL"])
+          workload_label = os.environ.get("WORKLOAD_LABEL") or "SGLang-OOB"
+          data["workload_label"] = workload_label
+          data["benchmark_backend"] = workload_label
+          data["dashboard_backend"] = "ATOM-SGLang"
+
+          display_name = os.environ.get("DASHBOARD_MODEL_NAME", "")
+          if display_name:
+              data["benchmark_model_name"] = display_name
+
+          extra_args_text = os.environ.get("EXTRA_ARGS_TEXT", "")
+          tp_match = re.search(
+              r"(?:--tensor-parallel-size|--tp-size|--tp|(?:^|\s)-tp)\s+(\d+)",
+              extra_args_text,
+          )
+          if tp_match:
+              data["tensor_parallel_size"] = int(tp_match.group(1))
+          elif os.environ.get("MESH_TP_SIZE"):
+              data["tensor_parallel_size"] = int(os.environ["MESH_TP_SIZE"])
+          dp_match = re.search(
+              r"(?:--data-parallel-size|--dp-size|--dp|(?:^|\s)-dp)\s+(\d+)",
+              extra_args_text,
+          )
+          if dp_match:
+              data["data_parallel_size"] = int(dp_match.group(1))
+          elif os.environ.get("MESH_DP_SIZE"):
+              data["data_parallel_size"] = int(os.environ["MESH_DP_SIZE"])
+          ep_match = re.search(r"(?:--expert-parallel-size|--ep-size)\s+(\d+)", extra_args_text)
+          if ep_match:
+              data["expert_parallel_size"] = int(ep_match.group(1))
+          elif os.environ.get("MESH_EP_SIZE"):
+              data["expert_parallel_size"] = int(os.environ["MESH_EP_SIZE"])
+          data["enable_dp_attention"] = "--enable-dp-attention" in extra_args_text
+          data["benchmark_runner"] = os.environ.get("BENCHMARK_RUNNER", "")
+          data["mesh_server_mode"] = os.environ.get("MESH_SERVER_MODE", "")
+          data["spec_mode"] = os.environ.get("MESH_SPEC_MODE", "")
+
+          data["atom_source_repository"] = os.environ.get("ATOM_SOURCE_REPOSITORY", "")
+          data["atom_source_ref"] = os.environ.get("ATOM_SOURCE_REF", "")
+          data["atom_source_sha"] = os.environ.get("ATOM_SOURCE_SHA", "")
+          data["sglang_ref"] = os.environ.get("SGLANG_REF_USED", "")
+          data["sglang_version"] = os.environ.get("SGLANG_VERSION_USED", "")
+          data["sglang_image_source"] = os.environ.get("SGLANG_IMAGE_SOURCE", "")
+          data["sglang_image_tag"] = os.environ.get("SGLANG_IMAGE_TAG_USED", "")
+          data["dashboard_publish_allowed"] = (
+              os.environ.get("PUBLISH_TO_DASHBOARD", "false").lower() == "true"
+              and workload_label != "SGLang-Mesh"
+          )
+          data["custom_dashboard_publish_allowed"] = (
+              os.environ.get("UPLOAD_TO_CUSTOM_DASHBOARD", "false").lower() == "true"
+          )
+
+          with open(result_path, "w", encoding="utf-8") as f:
+              json.dump(data, f, indent=2)
+          PY
+
+          $CONTAINER_ENGINE cp "${CONTAINER_NAME}:${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" "./${RESULT_FILENAME}.json"
+
+      - name: Inject GPU metadata into benchmark results
+        run: |
+          shopt -s nullglob
+          for f in "${RESULT_PREFIX}"-*.json; do
+            GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
+            GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
+            ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
+            RESULT_PATH="$f" \
+            python3 -c "
+          import json, os
+          p = os.environ['RESULT_PATH']
+          with open(p) as f:
+              d = json.load(f)
+          d['gpu_name'] = os.environ.get('GPU_NAME', '')
+          d['gpu_vram_gb'] = int(os.environ.get('GPU_VRAM_GB') or 0)
+          d['rocm_version'] = os.environ.get('ROCM_VERSION', '')
+          with open(p, 'w') as f:
+              json.dump(d, f, indent=2)
+          "
+          done
+
+      - name: Collect benchmark result
+        run: |
+          if [ ! -f "${RESULT_FILENAME}.json" ]; then
+            echo "ERROR: Benchmark result file ${RESULT_FILENAME}.json was not generated for ${MODEL_NAME}."
+            exit 1
+          fi
+
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@v7
+        with:
+          name: sglang-benchmark-${{ env.RESULT_FILENAME }}
+          path: ${{ env.RESULT_FILENAME }}.json
+
+      - name: Clean up SGLang benchmark container
+        if: always()
+        run: |
+          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "if [ -f /tmp/atom_sglang.pid ]; then kill \$(cat /tmp/atom_sglang.pid) || true; fi" || true
+          $CONTAINER_ENGINE stop "$CONTAINER_NAME" || true
+          $CONTAINER_ENGINE rm "$CONTAINER_NAME" || true
+          if [[ "${SGLANG_IMAGE_SOURCE}" == "rebuild" ]]; then
+            $CONTAINER_ENGINE rmi "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}" || true
+          else
+            echo "Keeping prebuilt SGLang image cached on runner: ${SGLANG_IMAGE_TAG}"
+          fi
+

--- a/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
@@ -95,14 +95,18 @@ jobs:
     steps:
       - name: Detect container engine
         run: |
-          if command -v podman > /dev/null 2>&1; then
+          set -euo pipefail
+          # Prefer podman when usable + --group-add keep-groups; otherwise docker + --group-add video.
+          if command -v podman > /dev/null 2>&1 && podman info > /dev/null 2>&1; then
             echo "CONTAINER_ENGINE=podman" >> "$GITHUB_ENV"
-            echo "Container engine: podman"
+            echo "CONTAINER_GROUP_ADD=--group-add keep-groups" >> "$GITHUB_ENV"
+            echo "Container engine: podman (--group-add keep-groups)"
           elif docker info > /dev/null 2>&1; then
             echo "CONTAINER_ENGINE=docker" >> "$GITHUB_ENV"
-            echo "Container engine: docker"
+            echo "CONTAINER_GROUP_ADD=--group-add video" >> "$GITHUB_ENV"
+            echo "Container engine: docker (--group-add video)"
           else
-            echo "ERROR: Neither docker nor podman is available on this runner."
+            echo "ERROR: Neither a working podman nor docker is available on this runner."
             exit 1
           fi
 
@@ -262,7 +266,7 @@ jobs:
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
-            --ipc=host --group-add keep-groups \
+            --ipc=host ${CONTAINER_GROUP_ADD} \
             --privileged \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -602,7 +602,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       benchmark_matrix: ${{ steps.build.outputs.benchmark_matrix }}
+      benchmark_matrix_mi355: ${{ steps.build.outputs.benchmark_matrix_mi355 }}
+      benchmark_matrix_mi308: ${{ steps.build.outputs.benchmark_matrix_mi308 }}
       has_benchmark_cells: ${{ steps.build.outputs.has_benchmark_cells }}
+      has_benchmark_cells_mi355: ${{ steps.build.outputs.has_benchmark_cells_mi355 }}
+      has_benchmark_cells_mi308: ${{ steps.build.outputs.has_benchmark_cells_mi308 }}
     steps:
       - name: Combine models and params
         id: build
@@ -610,9 +614,10 @@ jobs:
           MODELS_JSON: ${{ needs.load-models.outputs.models_json }}
           PARAMS_JSON: ${{ needs.parse-param-lists.outputs.matrix_json }}
         run: |
-          BENCHMARK_MATRIX="$(python3 - <<'PY'
+          python3 - <<'PY'
           import json
           import os
+          import sys
 
           models = json.loads(os.environ["MODELS_JSON"])
           params = json.loads(os.environ["PARAMS_JSON"])
@@ -657,20 +662,35 @@ jobs:
                       continue
                   if supported_concurrency_values and int(param["concurrency"]) not in supported_concurrency_values:
                       continue
-                  
+
                   include.append({"model": model, "params": param})
 
-          print(json.dumps({"include": include}))
+          def is_mi308_row(row):
+              return "mi308" in str(row["model"].get("runner", ""))
+
+          mi308_rows = [row for row in include if is_mi308_row(row)]
+          mi355_rows = [row for row in include if not is_mi308_row(row)]
+
+          sep = (",", ":")
+          full = json.dumps({"include": include}, separators=sep)
+          j355 = json.dumps({"include": mi355_rows}, separators=sep)
+          j308 = json.dumps({"include": mi308_rows}, separators=sep)
+
+          gh_out = os.environ["GITHUB_OUTPUT"]
+          with open(gh_out, "a", encoding="utf-8") as fh:
+              fh.write(f"benchmark_matrix={full}\n")
+              fh.write(f"benchmark_matrix_mi355={j355}\n")
+              fh.write(f"benchmark_matrix_mi308={j308}\n")
+              fh.write("has_benchmark_cells=" + ("false" if not include else "true") + "\n")
+              fh.write("has_benchmark_cells_mi355=" + ("false" if not mi355_rows else "true") + "\n")
+              fh.write("has_benchmark_cells_mi308=" + ("false" if not mi308_rows else "true") + "\n")
+
+          if not include:
+              print("No eligible benchmark cases remain after model-specific parameter filtering.", file=sys.stderr)
+          else:
+              print(f"Benchmark matrix (full): {full}", file=sys.stderr)
+              print(f"MI355 shard cells: {len(mi355_rows)}, MI308 shard cells: {len(mi308_rows)}", file=sys.stderr)
           PY
-          )"
-          echo "benchmark_matrix=${BENCHMARK_MATRIX}" >> "$GITHUB_OUTPUT"
-          if [ "${BENCHMARK_MATRIX}" = '{"include":[]}' ]; then
-            echo "has_benchmark_cells=false" >> "$GITHUB_OUTPUT"
-            echo "No eligible benchmark cases remain after model-specific parameter filtering."
-          else
-            echo "has_benchmark_cells=true" >> "$GITHUB_OUTPUT"
-            echo "Benchmark matrix: ${BENCHMARK_MATRIX}"
-          fi
 
   build-sglang-image:
     name: Build custom SGLang benchmark image
@@ -779,614 +799,65 @@ jobs:
           docker rmi "${{ steps.image-meta.outputs.sglang_image_tag }}" || true
           docker rmi atom_sglang_base:ci || true
 
-  benchmark:
-    name: SGLang ${{ matrix.model.display }} ${{ matrix.params.input_length }}/${{ matrix.params.output_length }} c=${{ matrix.params.concurrency }}
+  benchmark-mi355:
+    name: SGLang benchmark (MI355 / non-MI308 runners)
     needs: [resolve-atom-source, build-benchmark-matrix, build-sglang-image]
     if: >-
       always()
       && needs.resolve-atom-source.result == 'success'
       && needs.build-benchmark-matrix.result == 'success'
       && (needs.build-sglang-image.result == 'success' || needs.build-sglang-image.result == 'skipped')
-      && needs.build-benchmark-matrix.outputs.has_benchmark_cells == 'true'
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.build-benchmark-matrix.outputs.benchmark_matrix) }}
-    runs-on: ${{ matrix.model.runner }}
-    timeout-minutes: 240
+      && needs.build-benchmark-matrix.outputs.has_benchmark_cells_mi355 == 'true'
     permissions:
       actions: read
       contents: write
-    env:
-      MODEL_NAME: ${{ matrix.model.display }}
-      DASHBOARD_MODEL_NAME: ${{ matrix.model.dashboard_model || '' }}
-      MODEL_SOURCE_PATH: ${{ matrix.model.source_path || matrix.model.path }}
-      MODEL_PATH: ${{ matrix.model.path || matrix.model.source_path }}
-      SGLANG_EXTRA_ARGS: ${{ matrix.model.extra_args }}
-      BENCH_EXTRA_ARGS: ${{ matrix.model.bench_args }}
-      MESH_SERVER_MODE: ${{ inputs.mesh_server_mode || 'sglang-atom' }}
-      MESH_SPEC_MODE: ${{ matrix.model.mesh_spec_mode || 'none' }}
-      MESH_TP_SIZE: ${{ matrix.model.tp_size || '' }}
-      MESH_DP_SIZE: ${{ matrix.model.dp_size || '' }}
-      MESH_EP_SIZE: ${{ matrix.model.ep_size || '' }}
-      CASE_EXTRA_ARGS_BY_PAIR: ${{ toJson(matrix.model.case_extra_args_by_pair) }}
-      CASE_ENV_VARS_BY_PAIR: ${{ toJson(matrix.model.case_env_vars_by_pair) }}
-      RESULT_PREFIX: ${{ matrix.model.prefix }}
-      ISL: ${{ matrix.params.input_length }}
-      OSL: ${{ matrix.params.output_length }}
-      CONC: ${{ matrix.params.concurrency }}
-      RANDOM_RANGE_RATIO: ${{ matrix.params.random_range_ratio }}
-      RESULT_FILENAME: ${{ matrix.model.prefix }}-${{ matrix.params.input_length }}-${{ matrix.params.output_length }}-${{ matrix.params.concurrency }}-${{ matrix.params.random_range_ratio }}
-      WORKLOAD_LABEL: ${{ matrix.model.workload_label || needs.resolve-atom-source.outputs.workload_label }}
-      CONTAINER_NAME: atom_sglang_benchmark_${{ strategy.job-index }}
-      CONTAINER_RESULT_DIR: /tmp/sglang-benchmark-results
-      CONTAINER_BENCH_SERVING_DIR: /tmp/sglang-benchmark/bench_serving
-      SGLANG_IMAGE_TAG: ${{ needs.build-sglang-image.outputs.sglang_image_tag || needs.resolve-atom-source.outputs.prebuilt_sglang_image }}
-      SGLANG_IMAGE_SOURCE: ${{ needs.resolve-atom-source.outputs.sglang_image_source }}
-      BENCH_SERVING_REPO_URL: https://github.com/kimbochen/bench_serving.git
-      ATOM_SOURCE_REPOSITORY: ${{ needs.resolve-atom-source.outputs.atom_repository }}
-      ATOM_SOURCE_REF: ${{ needs.resolve-atom-source.outputs.atom_ref }}
-      SGLANG_REF_USED: ${{ needs.resolve-atom-source.outputs.selected_sglang_ref }}
-      SGLANG_VERSION_USED: ${{ needs.resolve-atom-source.outputs.selected_sglang_version }}
-      PUBLISH_TO_DASHBOARD: ${{ needs.resolve-atom-source.outputs.publish_to_dashboard }}
-      UPLOAD_TO_CUSTOM_DASHBOARD: ${{ needs.resolve-atom-source.outputs.upload_to_custom_dashboard }}
-    steps:
-      - name: Detect container engine
-        run: |
-          if command -v podman > /dev/null 2>&1; then
-            echo "CONTAINER_ENGINE=podman" >> "$GITHUB_ENV"
-            echo "Container engine: podman"
-          elif docker info > /dev/null 2>&1; then
-            echo "CONTAINER_ENGINE=docker" >> "$GITHUB_ENV"
-            echo "Container engine: docker"
-          else
-            echo "ERROR: Neither docker nor podman is available on this runner."
-            exit 1
-          fi
+    uses: ./.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
+    secrets: inherit
+    with:
+      shard_suffix: mi355
+      benchmark_matrix_json: ${{ needs.build-benchmark-matrix.outputs.benchmark_matrix_mi355 }}
+      mesh_server_mode: ${{ inputs.mesh_server_mode || 'sglang-atom' }}
+      atom_repository: ${{ needs.resolve-atom-source.outputs.atom_repository }}
+      atom_ref: ${{ needs.resolve-atom-source.outputs.atom_ref }}
+      workload_label: ${{ needs.resolve-atom-source.outputs.workload_label }}
+      prebuilt_sglang_image: ${{ needs.resolve-atom-source.outputs.prebuilt_sglang_image }}
+      sglang_image_source: ${{ needs.resolve-atom-source.outputs.sglang_image_source }}
+      selected_sglang_ref: ${{ needs.resolve-atom-source.outputs.selected_sglang_ref }}
+      selected_sglang_version: ${{ needs.resolve-atom-source.outputs.selected_sglang_version }}
+      publish_to_dashboard: ${{ needs.resolve-atom-source.outputs.publish_to_dashboard }}
+      upload_to_custom_dashboard: ${{ needs.resolve-atom-source.outputs.upload_to_custom_dashboard }}
+      sglang_image_tag: ${{ needs.build-sglang-image.outputs.sglang_image_tag || needs.resolve-atom-source.outputs.prebuilt_sglang_image }}
+      atom_source_sha_for_checkout: ${{ needs.build-sglang-image.outputs.atom_source_sha || github.sha }}
 
-      #- name: Clean up containers and workspace
-      #  run: |
-      #    echo "=== Cleaning up containers on $(hostname) ==="
-      #    containers=$($CONTAINER_ENGINE ps -q)
-      #    if [ -n "$containers" ]; then
-      #      $CONTAINER_ENGINE kill $containers || true
-      #    fi
-      #    $CONTAINER_ENGINE rm -f "$CONTAINER_NAME" 2>/dev/null || true
-      #    $CONTAINER_ENGINE run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged docker.io/rocm/pytorch:latest bash -lc "shopt -s dotglob && ls -la /workspace/ && rm -rf /workspace/*" || true
-
-      - name: Checkout benchmark ATOM source
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.ATOM_SOURCE_REPOSITORY }}
-          ref: ${{ needs.build-sglang-image.outputs.atom_source_sha || github.sha }}
-          fetch-depth: 1
-
-      - name: Record benchmark source revision
-        run: |
-          SOURCE_SHA="$(git rev-parse HEAD)"
-          echo "ATOM_SOURCE_SHA=${SOURCE_SHA}" >> "$GITHUB_ENV"
-          echo "Benchmarking ${ATOM_SOURCE_REPOSITORY}@${ATOM_SOURCE_REF} (${SOURCE_SHA}) with ${SGLANG_IMAGE_SOURCE} image ${SGLANG_IMAGE_TAG}"
-
-      - name: Container Engine Login
-        run: |
-          set -euo pipefail
-          IMG="${SGLANG_IMAGE_TAG}"
-          if [[ "${IMG}" != */* ]]; then
-            IMG="docker.io/library/${IMG}"
-          else
-            reg="${IMG%%/*}"
-            if [[ "${reg}" != *.* && "${reg}" != localhost* && "${reg}" != *:* ]]; then
-              IMG="docker.io/${IMG}"
-            fi
-          fi
-          echo "SGLANG_IMAGE_REF=${IMG}" >> "$GITHUB_ENV"
-          REG="${IMG%%/*}"
-          echo "Logging in to registry: ${REG}"
-          echo "${{ secrets.DOCKER_PASSWORD }}" | $CONTAINER_ENGINE login "$REG" -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-
-      - name: Set HF_TOKEN
-        run: echo "HF_TOKEN=${HF_TOKEN:-${{ secrets.AMD_HF_TOKEN }}}" >> "$GITHUB_ENV"
-
-      - name: Pull SGLang benchmark image
-        run: |
-          set -euo pipefail
-          IMG="${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}"
-          if [[ -z "${IMG}" ]]; then
-            echo "ERROR: SGLang image reference is empty."
-            exit 1
-          fi
-          echo "Pulling SGLang benchmark image: ${IMG} (workflow tag: ${SGLANG_IMAGE_TAG})"
-          pull_ok=false
-          for attempt in 1 2 3; do
-            echo "Pull attempt ${attempt}/3: ${IMG}"
-            if $CONTAINER_ENGINE pull "${IMG}"; then
-              pull_ok=true
-              break
-            fi
-            sleep $((attempt * 10))
-          done
-
-          if [[ "${pull_ok}" != "true" && "${CONTAINER_ENGINE}" == "podman" ]]; then
-            echo "Plain podman pull failed; retrying with docker transport."
-            if $CONTAINER_ENGINE pull "docker://${IMG}"; then
-              pull_ok=true
-            fi
-          fi
-
-          if [[ "${pull_ok}" != "true" ]]; then
-            echo "ERROR: Failed to pull SGLang benchmark image: ${IMG}"
-            exit 1
-          fi
-
-      - name: Prepare model cache mount
-        run: |
-          MODEL_CACHE_MOUNT=""
-          MODEL_CACHE_DESC="container-local /models (no host cache mount)"
-          if [ -d "/it-share/models" ]; then
-            MODEL_CACHE_MOUNT="-v /it-share/models:/models"
-            MODEL_CACHE_DESC="/it-share/models (shared host path)"
-          elif [ -d "/models" ]; then
-            MODEL_CACHE_MOUNT="-v /models:/models"
-            MODEL_CACHE_DESC="/models (shared host path)"
-          elif [ -d "/data/models" ]; then
-            MODEL_CACHE_MOUNT="-v /data/models:/models"
-            MODEL_CACHE_DESC="/data/models (shared host path)"
-          else
-            echo "No shared host model cache found; using container-local /models."
-          fi
-
-          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
-          echo "MODEL_CACHE_MOUNT=${MODEL_CACHE_MOUNT}" >> "$GITHUB_ENV"
-          echo "MODEL_CACHE_DESC=${MODEL_CACHE_DESC}" >> "$GITHUB_ENV"
-
-      - name: Start SGLang benchmark container
-        run: |
-          if [ -f "/etc/podinfo/gha-render-devices" ]; then
-            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
-          else
-            DEVICE_FLAG="--device /dev/dri"
-          fi
-
-          MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
-          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
-
-          printf '%s\n' "${{ matrix.model.env_vars }}" | sed 's/^[[:space:]]*//' > /tmp/oot_env_file.txt
-          CASE_KEY="${ISL}x${OSL}"
-          CASE_ENV_VARS="$(
-            CASE_ENV_VARS_BY_PAIR="${CASE_ENV_VARS_BY_PAIR:-null}" CASE_KEY="${CASE_KEY}" python3 - <<'PY'
-          import json
-          import os
-
-          raw = os.environ.get("CASE_ENV_VARS_BY_PAIR") or "null"
-          try:
-              mapping = json.loads(raw)
-          except json.JSONDecodeError:
-              mapping = None
-          if isinstance(mapping, dict):
-              value = mapping.get(os.environ["CASE_KEY"], "")
-              if value:
-                  print(value)
-          PY
-          )"
-          if [[ -n "${CASE_ENV_VARS}" ]]; then
-            printf '%s\n' "${CASE_ENV_VARS}" >> /tmp/oot_env_file.txt
-          fi
-
-          # Podman + crun: avoid "create keyring ... Disk quota exceeded" (kernel user-keyring
-          # quota on shared runners). Docker ignores CONTAINERS_CONF_OVERRIDE; Podman reads it.
-          ATOM_SGLANG_PODMAN_CONF=""
-          if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
-            ATOM_SGLANG_PODMAN_CONF="$(mktemp "${TMPDIR:-/tmp}/atom-sglang-containers-conf.XXXXXX")"
-            printf '%s\n' '[containers]' 'keyring=false' > "${ATOM_SGLANG_PODMAN_CONF}"
-            _atom_sglang_prev_exit_body="$(trap -p EXIT | sed -nE "s/^trap -- '(.*)' EXIT$/\1/p" || true)"
-            cleanup_atom_podman_conf() {
-              rm -f "${ATOM_SGLANG_PODMAN_CONF:-}"
-              if [[ -n "${_atom_sglang_prev_exit_body:-}" ]]; then
-                eval "${_atom_sglang_prev_exit_body}"
-              fi
-            }
-            trap cleanup_atom_podman_conf EXIT
-          fi
-
-          container_engine_run() {
-            if [[ "${CONTAINER_ENGINE}" != "podman" ]]; then
-              "${CONTAINER_ENGINE}" "$@"
-              return
-            fi
-            CONTAINERS_CONF_OVERRIDE="${ATOM_SGLANG_PODMAN_CONF}" "${CONTAINER_ENGINE}" "$@"
-          }
-
-          container_engine_run run -dt --device=/dev/kfd $DEVICE_FLAG \
-            -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
-            $MODEL_MOUNT \
-            -w /workspace \
-            --ipc=host --group-add keep-groups \
-            --privileged \
-            --cap-add=SYS_PTRACE \
-            --security-opt seccomp=unconfined \
-            --ulimit memlock=-1 \
-            --ulimit stack=67108864 \
-            --env-file /tmp/oot_env_file.txt \
-            -e HF_TOKEN="${HF_TOKEN:-}" \
-            --name "$CONTAINER_NAME" \
-            --entrypoint /bin/bash \
-            "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}" \
-            -lc 'trap "exit 0" TERM INT; sleep infinity & wait'
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Collect GPU info (inside container)
-        id: gpu-info
-        run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" "$CONTAINER_ENGINE" "${{ matrix.model.runner }}"
-
-      - name: Download model if needed
-        run: |
-          model_dir="${MODEL_PATH}"
-          if [[ "${model_dir}" = /models/* ]]; then
-            model_dir="/models/${model_dir#/models/}"
-          elif [[ "${model_dir}" = /it-share/models/* ]]; then
-            model_dir="/models/${model_dir#/it-share/models/}"
-          elif [[ "${model_dir}" = /data/models/* ]]; then
-            model_dir="/models/${model_dir#/data/models/}"
-          elif [[ "${model_dir}" != /* ]]; then
-            model_dir="/models/${model_dir}"
-          fi
-          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
-            echo "/models directory found, downloading model to ${model_dir}"
-            if ! $CONTAINER_ENGINE exec -e HF_TOKEN="${HF_TOKEN:-}" "$CONTAINER_NAME" bash -lc "hf download \"${MODEL_SOURCE_PATH}\" --local-dir \"$model_dir\""; then
-              echo "Model download failed for '${MODEL_SOURCE_PATH}'. Aborting."
-              exit 1
-            fi
-          else
-            echo "/models directory not mounted; skipping model download"
-          fi
-
-      - name: Resolve SGLang model path
-        run: |
-          model_dir="${MODEL_PATH}"
-          if [[ "${model_dir}" = /models/* ]]; then
-            model_dir="/models/${model_dir#/models/}"
-          elif [[ "${model_dir}" = /it-share/models/* ]]; then
-            model_dir="/models/${model_dir#/it-share/models/}"
-          elif [[ "${model_dir}" = /data/models/* ]]; then
-            model_dir="/models/${model_dir#/data/models/}"
-          elif [[ "${model_dir}" != /* ]]; then
-            model_dir="/models/${model_dir}"
-          fi
-          if [ -n "${MODEL_CACHE_MOUNT}" ]; then
-            echo "SGLANG_RESOLVED_MODEL_PATH=${model_dir}" >> "$GITHUB_ENV"
-            echo "Using mounted model path: ${model_dir}"
-          else
-            echo "SGLANG_RESOLVED_MODEL_PATH=${MODEL_SOURCE_PATH}" >> "$GITHUB_ENV"
-            echo "Using model id: ${MODEL_SOURCE_PATH}"
-          fi
-
-      - name: Prepare SGLang benchmark runner in container
-        run: |
-          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "
-            set -euo pipefail
-            rm -rf \"${CONTAINER_BENCH_SERVING_DIR%/bench_serving}\"
-            mkdir -p \"${CONTAINER_BENCH_SERVING_DIR%/bench_serving}\"
-            git clone --depth 1 \"${BENCH_SERVING_REPO_URL}\" \"${CONTAINER_BENCH_SERVING_DIR}\"
-            test -f \"${CONTAINER_BENCH_SERVING_DIR}/benchmark_serving.py\"
-          "
-
-      - name: Run SGLang benchmark
-        timeout-minutes: 240
-        env:
-          MAX_WAIT_RETRIES: "120"
-          STREAM_SGLANG_LOGS: "1"
-        run: |
-          set -euo pipefail
-          echo "=== Benchmark config: ${MODEL_NAME} ISL=${ISL} OSL=${OSL} CONC=${CONC} RANDOM_RANGE_RATIO=${RANDOM_RANGE_RATIO} ==="
-          EFFECTIVE_BENCHMARK_RUNNER="sglang_atom"
-          EFFECTIVE_SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS}"
-          CASE_KEY="${ISL}x${OSL}"
-          CASE_EXTRA_ARGS="$(
-            CASE_EXTRA_ARGS_BY_PAIR="${CASE_EXTRA_ARGS_BY_PAIR:-null}" CASE_KEY="${CASE_KEY}" python3 - <<'PY'
-          import json
-          import os
-
-          raw = os.environ.get("CASE_EXTRA_ARGS_BY_PAIR") or "null"
-          try:
-              mapping = json.loads(raw)
-          except json.JSONDecodeError:
-              mapping = None
-          if isinstance(mapping, dict):
-              value = mapping.get(os.environ["CASE_KEY"], "")
-              if value:
-                  print(value)
-          PY
-          )"
-          if [[ -n "${CASE_EXTRA_ARGS}" ]]; then
-            EFFECTIVE_SGLANG_EXTRA_ARGS="${EFFECTIVE_SGLANG_EXTRA_ARGS} ${CASE_EXTRA_ARGS}"
-          fi
-          BENCH_NUM_PROMPTS="$(( CONC * 10 ))"
-          BENCH_NUM_WARMUPS="$(( 2 * CONC ))"
-          if [[ "${WORKLOAD_LABEL}" == "SGLang-Mesh" && "${MESH_DP_SIZE:-1}" -gt 1 && "${MESH_EP_SIZE:-1}" -gt 1 ]]; then
-            BENCH_NUM_PROMPTS="$(( CONC * 3 ))"
-            BENCH_NUM_WARMUPS="${CONC}"
-          fi
-          if [[ "${WORKLOAD_LABEL}" == "SGLang-Mesh" && "${MESH_SERVER_MODE}" == "sglang-mori" ]]; then
-            case "${SGLANG_IMAGE_TAG}" in
-              lmsysorg/sglang-rocm*|docker.io/lmsysorg/sglang-rocm*) ;;
-              *)
-                echo "ERROR: mesh_server_mode=sglang-mori requires docker_image to start with lmsysorg/sglang-rocm."
-                echo "Current image: ${SGLANG_IMAGE_TAG}"
-                exit 1
-                ;;
-            esac
-            EFFECTIVE_BENCHMARK_RUNNER="mori_sglang_mesh"
-            $CONTAINER_ENGINE exec \
-              -e MODEL="${SGLANG_RESOLVED_MODEL_PATH:-$MODEL_PATH}" \
-              -e SGLANG_MODEL_NAME="${MODEL_NAME}" \
-              -e TP="${MESH_TP_SIZE}" \
-              -e DP_SIZE="${MESH_DP_SIZE:-1}" \
-              -e EP_SIZE="${MESH_EP_SIZE:-1}" \
-              -e CONC="${CONC}" \
-              -e ISL="${ISL}" \
-              -e OSL="${OSL}" \
-              -e RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO}" \
-              -e RESULT_FILENAME="${RESULT_FILENAME}" \
-              -e RESULT_DIR="${CONTAINER_RESULT_DIR}" \
-              -e BENCH_SERVING_DIR="${CONTAINER_BENCH_SERVING_DIR}" \
-              -e SERVER_EXTRA_ARGS="${EFFECTIVE_SGLANG_EXTRA_ARGS}" \
-              -e BENCH_EXTRA_ARGS="${BENCH_EXTRA_ARGS}" \
-              -e SPEC_MODE="${MESH_SPEC_MODE}" \
-              -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
-              -e STREAM_SGLANG_LOGS="${STREAM_SGLANG_LOGS}" \
-              "$CONTAINER_NAME" bash -lc "
-                set -euo pipefail
-                bash .github/scripts/atom_sglang_mesh_benchmark.sh
-              "
-          else
-            if [[ "${WORKLOAD_LABEL}" == "SGLang-Mesh" && -n "${MESH_TP_SIZE}" ]]; then
-              EFFECTIVE_SGLANG_EXTRA_ARGS="--tensor-parallel-size ${MESH_TP_SIZE} ${EFFECTIVE_SGLANG_EXTRA_ARGS}"
-            fi
-            $CONTAINER_ENGINE exec -d \
-              -e SGLANG_MODEL_NAME="${MODEL_NAME}" \
-              -e SGLANG_MODEL_PATH="${SGLANG_RESOLVED_MODEL_PATH:-$MODEL_PATH}" \
-              -e SGLANG_EXTRA_ARGS="${EFFECTIVE_SGLANG_EXTRA_ARGS}" \
-              -e MAX_WAIT_RETRIES="${MAX_WAIT_RETRIES}" \
-              -e STREAM_SGLANG_LOGS="${STREAM_SGLANG_LOGS}" \
-              -e KEEP_SERVER_ALIVE_ON_EXIT=1 \
-              "$CONTAINER_NAME" bash -lc "
-                set -euo pipefail
-                bash .github/scripts/atom_sglang_test.sh start
-              "
-
-            last_sglang_log_line=0
-
-            emit_new_sglang_logs() {
-              if [ "${STREAM_SGLANG_LOGS}" != "1" ]; then
-                return 0
-              fi
-
-              current_line_count=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'if [ -f /tmp/atom_sglang.log ]; then wc -l < /tmp/atom_sglang.log; else echo 0; fi' 2>/dev/null || echo 0)
-              current_line_count=${current_line_count//$'\r'/}
-              if [ "${current_line_count:-0}" -le "${last_sglang_log_line}" ]; then
-                return 0
-              fi
-
-              echo ""
-              echo "========== New SGLang log output =========="
-              $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "sed -n '$((last_sglang_log_line + 1)),${current_line_count}p' /tmp/atom_sglang.log" || true
-              last_sglang_log_line=${current_line_count}
-            }
-
-            for ((i=1; i<=MAX_WAIT_RETRIES; i++)); do
-              if $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1'; then
-                emit_new_sglang_logs
-                echo "SGLang server is ready."
-                break
-              fi
-
-              emit_new_sglang_logs
-
-              server_status=$($CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc '
-                if [ -f /tmp/atom_sglang.pid ]; then
-                  pid=$(cat /tmp/atom_sglang.pid)
-                  if kill -0 "$pid" 2>/dev/null; then
-                    echo running
-                  else
-                    echo dead
-                  fi
-                elif pgrep -f "sglang.launch_server" >/dev/null 2>&1; then
-                  echo running
-                else
-                  echo starting
-                fi
-              ' 2>/dev/null || echo unknown)
-
-              if [ "${server_status}" = "dead" ]; then
-                echo "SGLang server process exited before becoming ready."
-                $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'tail -n 200 /tmp/atom_sglang.log || true' || true
-                exit 1
-              fi
-
-              echo "Waiting for SGLang server... (${i}/${MAX_WAIT_RETRIES}; status=${server_status})"
-              sleep "${WAIT_INTERVAL_SEC:-30}"
-            done
-
-            if ! $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'curl -fsS http://127.0.0.1:8000/v1/models >/dev/null 2>&1'; then
-              echo "SGLang server did not become ready in time."
-              emit_new_sglang_logs
-              $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc 'tail -n 200 /tmp/atom_sglang.log || true' || true
-              exit 1
-            fi
-
-            TRUST_REMOTE_CODE_ARG=""
-            if [[ "${EFFECTIVE_SGLANG_EXTRA_ARGS}" == *"--trust-remote-code"* ]]; then
-              TRUST_REMOTE_CODE_ARG="--trust-remote-code"
-            fi
-
-            $CONTAINER_ENGINE exec \
-              -e ISL="${ISL}" \
-              -e OSL="${OSL}" \
-              -e CONC="${CONC}" \
-              -e RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO}" \
-              -e RESULT_FILENAME="${RESULT_FILENAME}" \
-              -e BENCH_EXTRA_ARGS="${BENCH_EXTRA_ARGS}" \
-              "$CONTAINER_NAME" bash -lc "
-                set -euo pipefail
-                rm -rf \"${CONTAINER_RESULT_DIR}\"
-                mkdir -p \"${CONTAINER_RESULT_DIR}\"
-                PYTHONDONTWRITEBYTECODE=1 python \"${CONTAINER_BENCH_SERVING_DIR}/benchmark_serving.py\" \
-                  --model=\"${SGLANG_RESOLVED_MODEL_PATH:-$MODEL_PATH}\" \
-                  --backend=sglang \
-                  --base-url=http://127.0.0.1:8000 \
-                  --dataset-name=random \
-                  --random-input-len=\"${ISL}\" \
-                  --random-output-len=\"${OSL}\" \
-                  --random-range-ratio \"${RANDOM_RANGE_RATIO}\" \
-                  --num-prompts=\"${BENCH_NUM_PROMPTS}\" \
-                  --max-concurrency=\"${CONC}\" \
-                  ${TRUST_REMOTE_CODE_ARG} \
-                  --num-warmups=\"${BENCH_NUM_WARMUPS}\" \
-                  --request-rate=inf \
-                  --ignore-eos \
-                  --save-result \
-                  --percentile-metrics=\"ttft,tpot,itl,e2el\" \
-                  --result-dir=\"${CONTAINER_RESULT_DIR}\" \
-                  --result-filename=\"${RESULT_FILENAME}.json\" \
-                  ${BENCH_EXTRA_ARGS:-}
-              "
-          fi
-
-          $CONTAINER_ENGINE exec -i \
-            -e RESULT_PATH="${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" \
-            -e ISL="${ISL}" \
-            -e OSL="${OSL}" \
-            -e EXTRA_ARGS_TEXT="${EFFECTIVE_SGLANG_EXTRA_ARGS}" \
-            -e DASHBOARD_MODEL_NAME="${DASHBOARD_MODEL_NAME}" \
-            -e ATOM_SOURCE_REPOSITORY="${ATOM_SOURCE_REPOSITORY}" \
-            -e ATOM_SOURCE_REF="${ATOM_SOURCE_REF}" \
-            -e ATOM_SOURCE_SHA="${ATOM_SOURCE_SHA}" \
-            -e SGLANG_REF_USED="${SGLANG_REF_USED}" \
-            -e SGLANG_VERSION_USED="${SGLANG_VERSION_USED}" \
-            -e SGLANG_IMAGE_SOURCE="${SGLANG_IMAGE_SOURCE}" \
-            -e SGLANG_IMAGE_TAG_USED="${SGLANG_IMAGE_TAG}" \
-            -e PUBLISH_TO_DASHBOARD="${PUBLISH_TO_DASHBOARD}" \
-            -e UPLOAD_TO_CUSTOM_DASHBOARD="${UPLOAD_TO_CUSTOM_DASHBOARD}" \
-            -e WORKLOAD_LABEL="${WORKLOAD_LABEL}" \
-            -e BENCHMARK_RUNNER="${EFFECTIVE_BENCHMARK_RUNNER}" \
-            -e MESH_SERVER_MODE="${MESH_SERVER_MODE}" \
-            -e MESH_SPEC_MODE="${MESH_SPEC_MODE}" \
-            -e MESH_TP_SIZE="${MESH_TP_SIZE}" \
-            -e MESH_DP_SIZE="${MESH_DP_SIZE}" \
-            -e MESH_EP_SIZE="${MESH_EP_SIZE}" \
-            "$CONTAINER_NAME" python3 - <<'PY'
-          import json
-          import os
-          import re
-
-          result_path = os.environ["RESULT_PATH"]
-          with open(result_path, encoding="utf-8") as f:
-              data = json.load(f)
-
-          data["random_input_len"] = int(os.environ["ISL"])
-          data["random_output_len"] = int(os.environ["OSL"])
-          workload_label = os.environ.get("WORKLOAD_LABEL") or "SGLang-OOB"
-          data["workload_label"] = workload_label
-          data["benchmark_backend"] = workload_label
-          data["dashboard_backend"] = "ATOM-SGLang"
-
-          display_name = os.environ.get("DASHBOARD_MODEL_NAME", "")
-          if display_name:
-              data["benchmark_model_name"] = display_name
-
-          extra_args_text = os.environ.get("EXTRA_ARGS_TEXT", "")
-          tp_match = re.search(
-              r"(?:--tensor-parallel-size|--tp-size|--tp|(?:^|\s)-tp)\s+(\d+)",
-              extra_args_text,
-          )
-          if tp_match:
-              data["tensor_parallel_size"] = int(tp_match.group(1))
-          elif os.environ.get("MESH_TP_SIZE"):
-              data["tensor_parallel_size"] = int(os.environ["MESH_TP_SIZE"])
-          dp_match = re.search(
-              r"(?:--data-parallel-size|--dp-size|--dp|(?:^|\s)-dp)\s+(\d+)",
-              extra_args_text,
-          )
-          if dp_match:
-              data["data_parallel_size"] = int(dp_match.group(1))
-          elif os.environ.get("MESH_DP_SIZE"):
-              data["data_parallel_size"] = int(os.environ["MESH_DP_SIZE"])
-          ep_match = re.search(r"(?:--expert-parallel-size|--ep-size)\s+(\d+)", extra_args_text)
-          if ep_match:
-              data["expert_parallel_size"] = int(ep_match.group(1))
-          elif os.environ.get("MESH_EP_SIZE"):
-              data["expert_parallel_size"] = int(os.environ["MESH_EP_SIZE"])
-          data["enable_dp_attention"] = "--enable-dp-attention" in extra_args_text
-          data["benchmark_runner"] = os.environ.get("BENCHMARK_RUNNER", "")
-          data["mesh_server_mode"] = os.environ.get("MESH_SERVER_MODE", "")
-          data["spec_mode"] = os.environ.get("MESH_SPEC_MODE", "")
-
-          data["atom_source_repository"] = os.environ.get("ATOM_SOURCE_REPOSITORY", "")
-          data["atom_source_ref"] = os.environ.get("ATOM_SOURCE_REF", "")
-          data["atom_source_sha"] = os.environ.get("ATOM_SOURCE_SHA", "")
-          data["sglang_ref"] = os.environ.get("SGLANG_REF_USED", "")
-          data["sglang_version"] = os.environ.get("SGLANG_VERSION_USED", "")
-          data["sglang_image_source"] = os.environ.get("SGLANG_IMAGE_SOURCE", "")
-          data["sglang_image_tag"] = os.environ.get("SGLANG_IMAGE_TAG_USED", "")
-          data["dashboard_publish_allowed"] = (
-              os.environ.get("PUBLISH_TO_DASHBOARD", "false").lower() == "true"
-              and workload_label != "SGLang-Mesh"
-          )
-          data["custom_dashboard_publish_allowed"] = (
-              os.environ.get("UPLOAD_TO_CUSTOM_DASHBOARD", "false").lower() == "true"
-          )
-
-          with open(result_path, "w", encoding="utf-8") as f:
-              json.dump(data, f, indent=2)
-          PY
-
-          $CONTAINER_ENGINE cp "${CONTAINER_NAME}:${CONTAINER_RESULT_DIR}/${RESULT_FILENAME}.json" "./${RESULT_FILENAME}.json"
-
-      - name: Inject GPU metadata into benchmark results
-        run: |
-          shopt -s nullglob
-          for f in "${RESULT_PREFIX}"-*.json; do
-            GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
-            GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
-            ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
-            RESULT_PATH="$f" \
-            python3 -c "
-          import json, os
-          p = os.environ['RESULT_PATH']
-          with open(p) as f:
-              d = json.load(f)
-          d['gpu_name'] = os.environ.get('GPU_NAME', '')
-          d['gpu_vram_gb'] = int(os.environ.get('GPU_VRAM_GB') or 0)
-          d['rocm_version'] = os.environ.get('ROCM_VERSION', '')
-          with open(p, 'w') as f:
-              json.dump(d, f, indent=2)
-          "
-          done
-
-      - name: Collect benchmark result
-        run: |
-          if [ ! -f "${RESULT_FILENAME}.json" ]; then
-            echo "ERROR: Benchmark result file ${RESULT_FILENAME}.json was not generated for ${MODEL_NAME}."
-            exit 1
-          fi
-
-      - name: Upload benchmark result
-        uses: actions/upload-artifact@v7
-        with:
-          name: sglang-benchmark-${{ env.RESULT_FILENAME }}
-          path: ${{ env.RESULT_FILENAME }}.json
-
-      - name: Clean up SGLang benchmark container
-        if: always()
-        run: |
-          $CONTAINER_ENGINE exec "$CONTAINER_NAME" bash -lc "if [ -f /tmp/atom_sglang.pid ]; then kill \$(cat /tmp/atom_sglang.pid) || true; fi" || true
-          $CONTAINER_ENGINE stop "$CONTAINER_NAME" || true
-          $CONTAINER_ENGINE rm "$CONTAINER_NAME" || true
-          if [[ "${SGLANG_IMAGE_SOURCE}" == "rebuild" ]]; then
-            $CONTAINER_ENGINE rmi "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}" || true
-          else
-            echo "Keeping prebuilt SGLang image cached on runner: ${SGLANG_IMAGE_TAG}"
-          fi
+  benchmark-mi308:
+    name: SGLang benchmark (MI308 runners)
+    needs: [resolve-atom-source, build-benchmark-matrix, build-sglang-image]
+    if: >-
+      always()
+      && needs.resolve-atom-source.result == 'success'
+      && needs.build-benchmark-matrix.result == 'success'
+      && (needs.build-sglang-image.result == 'success' || needs.build-sglang-image.result == 'skipped')
+      && needs.build-benchmark-matrix.outputs.has_benchmark_cells_mi308 == 'true'
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
+    secrets: inherit
+    with:
+      shard_suffix: mi308
+      benchmark_matrix_json: ${{ needs.build-benchmark-matrix.outputs.benchmark_matrix_mi308 }}
+      mesh_server_mode: ${{ inputs.mesh_server_mode || 'sglang-atom' }}
+      atom_repository: ${{ needs.resolve-atom-source.outputs.atom_repository }}
+      atom_ref: ${{ needs.resolve-atom-source.outputs.atom_ref }}
+      workload_label: ${{ needs.resolve-atom-source.outputs.workload_label }}
+      prebuilt_sglang_image: ${{ needs.resolve-atom-source.outputs.prebuilt_sglang_image }}
+      sglang_image_source: ${{ needs.resolve-atom-source.outputs.sglang_image_source }}
+      selected_sglang_ref: ${{ needs.resolve-atom-source.outputs.selected_sglang_ref }}
+      selected_sglang_version: ${{ needs.resolve-atom-source.outputs.selected_sglang_version }}
+      publish_to_dashboard: ${{ needs.resolve-atom-source.outputs.publish_to_dashboard }}
+      upload_to_custom_dashboard: ${{ needs.resolve-atom-source.outputs.upload_to_custom_dashboard }}
+      sglang_image_tag: ${{ needs.build-sglang-image.outputs.sglang_image_tag || needs.resolve-atom-source.outputs.prebuilt_sglang_image }}
+      atom_source_sha_for_checkout: ${{ needs.build-sglang-image.outputs.atom_source_sha || github.sha }}
 
   summarize-benchmark-result:
     if: >-
@@ -1395,7 +866,7 @@ jobs:
       && needs.build-benchmark-matrix.result == 'success'
       && needs.build-benchmark-matrix.outputs.has_benchmark_cells == 'true'
     name: Summarize SGLang benchmark result
-    needs: [resolve-atom-source, build-benchmark-matrix, benchmark]
+    needs: [resolve-atom-source, build-benchmark-matrix, benchmark-mi355, benchmark-mi308]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ATOM repo

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -275,51 +275,6 @@ jobs:
               ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0
             accuracy_test_threshold: 0.76
             runner: linux-atom-mi35x-4
-          - model_name: "MI308 Qwen3.5-397B-A17B-FP8 TP4"
-            model_path: "Qwen/Qwen3.5-397B-A17B-FP8"
-            extra_args: "--tensor-parallel-size 4 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache"
-            env_vars: |
-              SGLANG_DEFAULT_SERVER_ARGS=
-              SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
-              ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0
-            accuracy_test_threshold: 0.83
-            runner: atom-mi308-8gpu-plugins-benchmark
-          - model_name: "MI308 Qwen3.5-397B-A17B-FP8 TP8"
-            model_path: "Qwen/Qwen3.5-397B-A17B-FP8"
-            extra_args: "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache"
-            env_vars: |
-              SGLANG_DEFAULT_SERVER_ARGS=
-              SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
-              ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0
-            accuracy_test_threshold: 0.83
-            runner: atom-mi308-8gpu-plugins-benchmark
-          - model_name: "MI308 Qwen3.5-35B-A3B-FP8 TP1"
-            model_path: "Qwen/Qwen3.5-35B-A3B-FP8"
-            extra_args: "--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache"
-            env_vars: |
-              SGLANG_DEFAULT_SERVER_ARGS=
-              SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
-              ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0
-            accuracy_test_threshold: 0.76
-            runner: atom-mi308-8gpu-plugins-benchmark
-          - model_name: "MI308 Qwen3-32B-FP8 TP1"
-            model_path: "Qwen/Qwen3-32B-FP8"
-            extra_args: "--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache"
-            env_vars: |
-              SGLANG_DEFAULT_SERVER_ARGS=
-              SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
-              ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0
-            accuracy_test_threshold: 0.8
-            runner: atom-mi308-8gpu-plugins-benchmark
-          - model_name: "MI308 Qwen3-32B-FP8 TP8"
-            model_path: "Qwen/Qwen3-32B-FP8"
-            extra_args: "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache"
-            env_vars: |
-              SGLANG_DEFAULT_SERVER_ARGS=
-              SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
-              ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0
-            accuracy_test_threshold: 0.8
-            runner: atom-mi308-8gpu-plugins-benchmark
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     env:
@@ -327,54 +282,8 @@ jobs:
       AITER_ARTIFACT_ID: ${{ needs.download_aiter_wheel.outputs.aiter_artifact_id }}
 
     steps:
-      - name: Ensure Python 3.10+ (install portable 3.10 if needed)
-        if: matrix.runner == 'atom-mi308-8gpu-plugins-benchmark'
-        id: ensure_python
-        shell: bash
-        run: |
-          if command -v python3 >/dev/null 2>&1 && python3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"; then
-            echo "Using $(command -v python3): $(python3 --version)"
-            echo "need_install=false" >> "$GITHUB_OUTPUT"
-          else
-            if command -v python3 >/dev/null 2>&1; then
-              echo "python3 is below 3.10: $(python3 --version 2>&1)"
-            else
-              echo "python3 not found on PATH; will install portable CPython 3.10"
-            fi
-            echo "need_install=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      # setup-python has no build for Alibaba Cloud Linux / unknown OS on many self-hosted runners.
-      # Portable glibc CPython from python-build-standalone (3.10.13 @ tag 20231002; satisfies >=3.10).
-      - name: Install portable CPython 3.10 (self-hosted)
-        if: matrix.runner == 'atom-mi308-8gpu-plugins-benchmark' && steps.ensure_python.outputs.need_install == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG='20231002'
-          PYVER='3.10.13'
-          case "$(uname -m)" in
-            x86_64) triple='x86_64-unknown-linux-gnu' ;;
-            aarch64) triple='aarch64-unknown-linux-gnu' ;;
-            *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
-          esac
-          tarball="cpython-${PYVER}+${TAG}-${triple}-install_only.tar.gz"
-          base="${RUNNER_TOOL_CACHE:-${HOME}/.cache/atom-ci}/portable-python/${PYVER}-${TAG}-${triple}"
-          pybin="${base}/python/bin"
-          if [ ! -x "${pybin}/python3" ]; then
-            echo "Downloading ${tarball}..."
-            rm -rf "${base}"
-            mkdir -p "${base}"
-            curl -fsSL "https://github.com/astral-sh/python-build-standalone/releases/download/${TAG}/${tarball}" -o "/tmp/${tarball}"
-            tar -xzf "/tmp/${tarball}" -C "${base}"
-            rm -f "/tmp/${tarball}"
-          fi
-          echo "${pybin}" >> "$GITHUB_PATH"
-          command -v python3
-          python3 --version
-
       - name: Clean up containers and workspace
-        if: contains(fromJSON('["atom-mi355-8gpu.predownload","atom-mi308-8gpu-plugins-benchmark"]'), matrix.runner)
+        if: contains(fromJSON('["atom-mi355-8gpu.predownload"]'), matrix.runner)
         run: |
           echo "=== Cleaning up containers on $(hostname) ==="
           containers=$(docker ps -q)


### PR DESCRIPTION
## Summary

### SGLang benchmark

- 将 GPU benchmark 拆成两个并行的 workflow_call（benchmark-mi355 / benchmark-mi308），对应不同 runner 池，缩短 MI355 与 MI308 互相等待的时间。

- 抽取可复用工作流 atom-sglang-benchmark-gpu-shard.yaml，矩阵分片通过 runner 是否包含 mi308 划分；summarize 仍使用完整的 benchmark_matrix 作为预期 case 列表。

- 分片容器名增加 shard_suffix，避免极端情况下容器名冲突。

### 容器引擎与 GPU 组（SGLang shard ）

- 检测逻辑：若本机 podman 可用（podman info 成功）则使用 podman，并加 --group-add keep-groups；否则在 docker 可用时使用 docker，并加 --group-add video。

- docker run / podman run 通过环境变量 CONTAINER_GROUP_ADD 注入上述参数，与 --ipc=host 组合使用。

### SGLang  accuracy

- 修复 workflow_dispatch 超过 25 个 inputs 的校验错误：去掉 5 个逐条 MI308 勾选；MI308 模型改为 无 toggle_env，默认仅 schedule 全量；仍通过矩阵拆分并行。

- 与 benchmark 类似：在 prepare-sglang-image 中输出 model_matrix_mi355 / model_matrix_mi308 及 has_model_cells_*，用两个 workflow_call 并行跑 sglang-model-accuracy-mi355 / sglang-model-accuracy-mi308；accuracy-dashboard 的 needs 改为依赖上述两个 job。

- 新增 workflow_dispatch 输入 run_mi308_all：手动勾选时 一次性跑齐全部 MI308 gsm8k case（与 nightly 行为对齐，且不增加 5 个独立 boolean）。

### SGLang CI

- 去掉MI308的case。

