### PR TITLE
merge build sparse block into topk and enable fp8 kv cache

### DIFF
--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -514,6 +514,30 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                 device="cuda",
             )
             tensors["_minimax_m3_sparse_cache_next"] = 0
+            # fp8 ASM path: per-token dequant scales for the page-16 SHUFFLE main
+            # KV cache, written by fused_qknorm_idxrqknorm /
+            # reshape_and_cache_with_pertoken_quant and read by gluon. Allocated
+            # page-128 here ([num_128_blocks, num_kv_heads, 128]); build_kv_cache_tensor
+            # binds a zero-copy page-16 view ([num_128_blocks*8, nkv, 16]) per layer so
+            # the row stride (16) matches the SHUFFLE page the kernel/gluon index with.
+            # Allocated only for fp8.
+            if config.kv_cache_dtype == "fp8":
+                tensors["minimax_m3_k_scale"] = torch.zeros(
+                    hf_config.num_hidden_layers,
+                    runner.num_physical_kvcache_blocks,
+                    num_kv_heads,
+                    runner.physical_block_size,
+                    dtype=dtypes.fp32,
+                    device="cuda",
+                )
+                tensors["minimax_m3_v_scale"] = torch.zeros(
+                    hf_config.num_hidden_layers,
+                    runner.num_physical_kvcache_blocks,
+                    num_kv_heads,
+                    runner.physical_block_size,
+                    dtype=dtypes.fp32,
+                    device="cuda",
+                )
         return tensors
 
     def build_kv_cache_tensor(self, layer_id: int, module):
@@ -539,12 +563,42 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             module.index_cache = runner.minimax_m3_index_cache[sparse_idx]
             key_cache, value_cache = module.kv_cache.unbind(1)
             module.max_model_len = config.max_model_len
+            # fp8 ASM path: bind this layer's per-token dequant scale slices
+            # (written by the fp8 KV insert, read by gluon). bf16 -> None.
+            k_scale = v_scale = None
+            if config.kv_cache_dtype == "fp8":
+                from atom.model_ops.minimax_m3.sparse_attn import (
+                    ASM_PAGE_SIZE,
+                    PAGES_PER_SPARSE_BLOCK,
+                )
+
+                # The scale buffer is allocated page-128 ([num_128_blocks, nkv, 128]),
+                # but the fp8 write kernel (fused_qknorm_idxrqknorm) and the gluon
+                # reader both index it in the page-16 SHUFFLE layout that mirrors the
+                # main KV cache: [num_128_blocks * 8, nkv, 16]. 128 == 8 * 16, so this
+                # is a pure zero-copy reinterpretation of the same contiguous bytes —
+                # the row stride becomes 16 (== the SHUFFLE page) so a page-16 block id
+                # lands on the right scale. Without this view, gluon multiplies a
+                # page-16 block id by the page-128 row stride (128) and reads scales
+                # 8x out of position, corrupting fp8 attention once blocks are reused.
+                k_scale = runner.minimax_m3_k_scale[layer_id].view(
+                    runner.num_physical_kvcache_blocks * PAGES_PER_SPARSE_BLOCK,
+                    module.num_kv_heads,
+                    ASM_PAGE_SIZE,
+                )
+                v_scale = runner.minimax_m3_v_scale[layer_id].view(
+                    runner.num_physical_kvcache_blocks * PAGES_PER_SPARSE_BLOCK,
+                    module.num_kv_heads,
+                    ASM_PAGE_SIZE,
+                )
+            module.k_scale = k_scale
+            module.v_scale = v_scale
             return KVCacheTensor(
                 layer_num=layer_id,
                 k_cache=key_cache,
                 v_cache=value_cache,
-                k_scale=None,
-                v_scale=None,
+                k_scale=k_scale,
+                v_scale=v_scale,
             )
 
         if not (

--- a/atom/model_ops/minimax_m3/index_topk.py
+++ b/atom/model_ops/minimax_m3/index_topk.py
@@ -25,6 +25,10 @@ except ModuleNotFoundError:
 
 # One sparse block == one KV page.
 SPARSE_BLOCK_SIZE = 128
+# Physical 16-pages per logical 128-block for the page-16 SHUFFLE ASM/gluon cache
+# (must match sparse_attn.PAGES_PER_SPARSE_BLOCK). Used by the fused block-table
+# emission in the topk kernels.
+PAGES_PER_SPARSE_BLOCK = 8
 
 
 # ---------------------------------------------------------------------------
@@ -199,10 +203,18 @@ def _topk_index_kernel(
     stride_ti_h,
     stride_ti_n,
     stride_ti_t,
+    # --- fused sparse block-table emission (ASM/gluon prefill path) ---
+    block_table_ptr,  # [batch, max_blocks] int32 logical 128-granularity (or dummy)
+    sparse_bt_ptr,  # out: [total_q, topk*pages_per_block] int32 (or dummy)
+    sparse_ctx_ptr,  # out: [total_q] int32 (or dummy)
+    stride_bt_b,
+    stride_sbt_n,
     BLOCK_SIZE_K: tl.constexpr,
     BLOCK_SIZE_T: tl.constexpr,
     MASK_INIT: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
+    pages_per_block: tl.constexpr,  # 16-pages per sparse block (8)
+    EMIT_SPARSE_BT: tl.constexpr,  # fuse compaction iff True (num_idx_heads==1)
 ):
     tl.static_assert(BLOCK_SIZE_K > BLOCK_SIZE_T)
     pid_q = tl.program_id(0)
@@ -281,6 +293,48 @@ def _topk_index_kernel(
     valid_mask = off_t < valid_blocks
     topk_idx = tl.where(store_mask & valid_mask, topk_idx, -1)
     tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty), mask=store_mask)
+
+    # --- fused sparse block-table build (per-query-token causal compaction) ---
+    # Mirrors _build_sparse_block_table_prefill_kernel over the in-register
+    # selection. Only the first index head emits (ASM/gluon needs num_idx_heads
+    # == 1). Token absolute pos p = prefix_len + pid_q (sample_interval == 1);
+    # causal self-block = p // block_size, length p + 1.
+    if EMIT_SPARSE_BT and pid_h == 0:
+        p = prefix_len + pid_q * sample_interval
+        self_blk = p // block_size
+        causal_len = p + 1
+        bt_blk = tl.where(off_t < topk, topk_idx, -1)
+        # causal: drop any selected block above the self-block (defensive; the
+        # indexer already caps selection at valid_blocks == self_blk + 1).
+        bt_valid = (bt_blk >= 0) & (bt_blk <= self_blk)
+        bt_is_tail = bt_valid & (bt_blk == self_blk)
+        bt_is_full = bt_valid & (bt_blk < self_blk)
+        bt_n_full = tl.sum(bt_is_full.to(tl.int32), axis=0)
+        bt_n_valid = tl.sum(bt_valid.to(tl.int32), axis=0)
+        bt_earlier_full = tl.cumsum(bt_is_full.to(tl.int32), axis=0) - bt_is_full.to(
+            tl.int32
+        )
+        bt_slot = tl.where(bt_is_full, bt_earlier_full, bt_n_full)  # tail -> n_full
+
+        bt_row = block_table_ptr + pid_b * stride_bt_b
+        bt_logical_page = tl.load(bt_row + bt_blk, mask=bt_valid, other=0).to(tl.int32)
+        bt_base_phys = bt_logical_page * pages_per_block
+        bt_dst_base = bt_slot * pages_per_block
+
+        sbt_row = sparse_bt_ptr + (block_start + pid_q) * stride_sbt_n
+        for pj in range(pages_per_block):
+            tl.store(sbt_row + bt_dst_base + pj, bt_base_phys + pj, mask=bt_valid)
+        bt_n_used = bt_n_valid * pages_per_block
+        off_w = tl.arange(0, BLOCK_SIZE_T * pages_per_block)
+        tl.store(sbt_row + off_w, tl.zeros_like(off_w), mask=off_w >= bt_n_used)
+
+        bt_tail_tokens = causal_len - self_blk * block_size
+        bt_has_tail = tl.sum(bt_is_tail.to(tl.int32), axis=0) > 0
+        bt_ctx = bt_n_full * block_size + tl.where(bt_has_tail, bt_tail_tokens, 0)
+        bt_ctx = tl.where(
+            bt_has_tail, bt_ctx, tl.minimum(bt_n_valid * block_size, causal_len)
+        )
+        tl.store(sparse_ctx_ptr + (block_start + pid_q), bt_ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -531,9 +585,17 @@ def _topk_index_merge_kernel(
     stride_tif_h,
     stride_tif_b,
     stride_tif_t,
+    # --- fused sparse block-table emission (ASM/gluon decode path) ---
+    block_table_ptr,  # [batch, max_blocks] int32 logical 128-granularity (or dummy)
+    sparse_bt_ptr,  # out: [batch, topk*pages_per_block] int32 (or dummy)
+    sparse_ctx_ptr,  # out: [batch] int32 (or dummy)
+    stride_bt_b,
+    stride_sbt_b,
     NUM_TOPK_CHUNKS: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
     BLOCK_SIZE_T: tl.constexpr,
+    pages_per_block: tl.constexpr,  # 16-pages per sparse block (8)
+    EMIT_SPARSE_BT: tl.constexpr,  # fuse compaction iff True (num_idx_heads==1)
 ):
     pid_b = tl.program_id(0)
     pid_h = tl.program_id(1)
@@ -595,6 +657,44 @@ def _topk_index_merge_kernel(
         tif_ptrs, topk_idx_final.to(ti_final_ptr.dtype.element_ty), mask=store_mask
     )
 
+    # --- fused sparse block-table build (per-request decode compaction) ---
+    # Mirrors _build_sparse_block_table_kernel over the in-register selection,
+    # avoiding a second kernel launch + topk_idx HBM round-trip. Only the first
+    # index head emits (ASM/gluon path requires num_idx_heads == 1).
+    if EMIT_SPARSE_BT and pid_h == 0:
+        last_blk = (seq_len - 1) // block_size
+        bt_blk = tl.where(off_t < topk, topk_idx_final, -1)
+        bt_valid = bt_blk >= 0
+        bt_is_tail = bt_valid & (bt_blk == last_blk)
+        bt_is_full = bt_valid & (bt_blk != last_blk)
+        bt_n_full = tl.sum(bt_is_full.to(tl.int32), axis=0)
+        bt_n_valid = tl.sum(bt_valid.to(tl.int32), axis=0)
+        bt_earlier_full = tl.cumsum(bt_is_full.to(tl.int32), axis=0) - bt_is_full.to(
+            tl.int32
+        )
+        bt_slot = tl.where(bt_is_full, bt_earlier_full, bt_n_full)  # tail -> n_full
+
+        bt_row = block_table_ptr + pid_b * stride_bt_b
+        bt_logical_page = tl.load(bt_row + bt_blk, mask=bt_valid, other=0).to(tl.int32)
+        bt_base_phys = bt_logical_page * pages_per_block
+        bt_dst_base = bt_slot * pages_per_block
+
+        sbt_row = sparse_bt_ptr + pid_b * stride_sbt_b
+        # write valid slots -> their pages; unused tail -> 0 (in-bounds page id).
+        for pj in range(pages_per_block):
+            tl.store(sbt_row + bt_dst_base + pj, bt_base_phys + pj, mask=bt_valid)
+        bt_n_used = bt_n_valid * pages_per_block
+        off_w = tl.arange(0, BLOCK_SIZE_T * pages_per_block)
+        tl.store(sbt_row + off_w, tl.zeros_like(off_w), mask=off_w >= bt_n_used)
+
+        bt_tail_tokens = seq_len - last_blk * block_size
+        bt_has_tail = tl.sum(bt_is_tail.to(tl.int32), axis=0) > 0
+        bt_ctx = bt_n_full * block_size + tl.where(bt_has_tail, bt_tail_tokens, 0)
+        bt_ctx = tl.where(
+            bt_has_tail, bt_ctx, tl.minimum(bt_n_valid * block_size, seq_len)
+        )
+        tl.store(sparse_ctx_ptr + pid_b, bt_ctx)
+
 
 # ---------------------------------------------------------------------------
 # Python wrappers
@@ -614,12 +714,19 @@ def minimax_m3_index_topk(
     local_blocks: int,
     num_kv_heads: int,
     sm_scale: float,
-) -> torch.Tensor:
+    emit_sparse_block_table: bool = False,
+):
     """Index block-score + top-k selection. block_size_q == 1 (per-token).
 
     Returns topk_idx [num_kv_heads, total_q, topk] of 0-indexed block ids
     (right-padded with -1). M3 has num_idx_heads == num_kv_heads, so the
     per-index-head top-k maps 1:1 to kv heads (no index-head reduction needed).
+
+    When ``emit_sparse_block_table`` is True (requires num_idx_heads == 1), the
+    topk kernel ALSO fuses the per-query-token page-16 SHUFFLE block-table
+    compaction and returns ``(topk_idx, sparse_bt [total_q, topk*8], sparse_ctx
+    [total_q])`` ready for the ASM prefill kernel -- saving a separate build
+    launch + topk_idx HBM round-trip.
     """
     total_q, num_idx_heads, head_dim = idx_q.shape
     assert (
@@ -665,6 +772,20 @@ def minimax_m3_index_topk(
         dtype=torch.int32,
         device=idx_q.device,
     )
+    emit = emit_sparse_block_table and num_idx_heads == 1
+    if emit:
+        sparse_bt = torch.empty(
+            (total_q, topk * PAGES_PER_SPARSE_BLOCK),
+            dtype=torch.int32,
+            device=idx_q.device,
+        )
+        sparse_ctx = torch.empty((total_q,), dtype=torch.int32, device=idx_q.device)
+        sbt_arg, sctx_arg = sparse_bt, sparse_ctx
+        bt_stride0, sbt_stride0 = block_table.stride(0), sparse_bt.stride(0)
+    else:
+        sbt_arg = torch.empty(1, dtype=torch.int32, device=idx_q.device)
+        sctx_arg = torch.empty(1, dtype=torch.int32, device=idx_q.device)
+        bt_stride0, sbt_stride0 = 0, 0
     # block_size_q == 1 -> query blocks coincide with query tokens.
     grid_topk = (max_query_len, batch, num_idx_heads)
     _topk_index_kernel[grid_topk](
@@ -684,9 +805,18 @@ def minimax_m3_index_topk(
         topk_idx.stride(0),
         topk_idx.stride(1),
         topk_idx.stride(2),
+        block_table,
+        sbt_arg,
+        sctx_arg,
+        bt_stride0,
+        sbt_stride0,
         MASK_INIT=False,
         MASK_LOCAL=False,
+        pages_per_block=PAGES_PER_SPARSE_BLOCK,
+        EMIT_SPARSE_BT=emit,
     )
+    if emit:
+        return topk_idx, sparse_bt, sparse_ctx
     return topk_idx
 
 
@@ -702,10 +832,17 @@ def minimax_m3_index_topk_decode(
     local_blocks: int,
     num_kv_heads: int,
     sm_scale: float,
-) -> torch.Tensor:
+    emit_sparse_block_table: bool = False,
+):
     """Decode index block-score + top-k, both split-K (cudagraph-safe).
 
     Returns topk_idx [num_kv_heads, batch, topk] (0-indexed block ids, -1 pad).
+
+    When ``emit_sparse_block_table`` is True (requires num_idx_heads == 1), the
+    merge kernel ALSO fuses the page-16 SHUFFLE block-table compaction and returns
+    ``(topk_idx, sparse_bt [batch, topk*8], sparse_ctx [batch])`` ready for the
+    ASM/gluon decode kernel -- saving a separate build launch + topk_idx HBM
+    round-trip.
     """
     total_q, num_idx_heads, head_dim = idx_q.shape
     assert (
@@ -804,6 +941,21 @@ def minimax_m3_index_topk_decode(
         topk_idx_partial.stride(2),
         topk_idx_partial.stride(3),
     )
+    emit = emit_sparse_block_table and num_idx_heads == 1
+    if emit:
+        sparse_bt = torch.empty(
+            (batch, topk * PAGES_PER_SPARSE_BLOCK),
+            dtype=torch.int32,
+            device=idx_q.device,
+        )
+        sparse_ctx = torch.empty((batch,), dtype=torch.int32, device=idx_q.device)
+        sbt_arg, sctx_arg = sparse_bt, sparse_ctx
+        bt_stride0, sbt_stride0 = block_table.stride(0), sparse_bt.stride(0)
+    else:
+        # dummy 1-elem tensors so the kernel always has valid pointers.
+        sbt_arg = torch.empty(1, dtype=torch.int32, device=idx_q.device)
+        sctx_arg = torch.empty(1, dtype=torch.int32, device=idx_q.device)
+        bt_stride0, sbt_stride0 = 0, 0
     _topk_index_merge_kernel[(batch, num_idx_heads)](
         topk_score_partial,
         topk_idx_partial,
@@ -822,6 +974,15 @@ def minimax_m3_index_topk_decode(
         topk_idx.stride(0),
         topk_idx.stride(1),
         topk_idx.stride(2),
+        block_table,
+        sbt_arg,
+        sctx_arg,
+        bt_stride0,
+        sbt_stride0,
         NUM_TOPK_CHUNKS=num_topk_chunks,
+        pages_per_block=PAGES_PER_SPARSE_BLOCK,
+        EMIT_SPARSE_BT=emit,
     )
+    if emit:
+        return topk_idx, sparse_bt, sparse_ctx
     return topk_idx

--- a/atom/model_ops/minimax_m3/sparse_attn.py
+++ b/atom/model_ops/minimax_m3/sparse_attn.py
@@ -19,6 +19,7 @@ leaves the prefill kernels (which parallelize over the query dim) idle.
 from dataclasses import dataclass
 
 import numpy as np
+import aiter
 import torch
 
 try:
@@ -1112,7 +1113,13 @@ def minimax_m3_sparse_attn_decode_asm(
     temporary_output = torch.empty(
         *intermediate_shape, head_size, dtype=q.dtype, device=q.device
     )
-    compute_type = torch.bfloat16  # bf16 KV cache (k/v_scale = None)
+    # fp8 KV cache -> fp8 compute_type + per-token scales; bf16 otherwise.
+    is_fp8 = _is_fp8_kv_cache_tensor(k_cache)
+    compute_type = aiter.dtypes.fp8 if is_fp8 else torch.bfloat16
+    # gluon wants per-token scale as [num_blocks, num_kv_heads, kv_block_size, 1];
+    # the M3 scale tensor is [num_phys_blocks, num_kv_heads, physical_block_size].
+    gluon_k_scale = k_scale.unsqueeze(-1) if (is_fp8 and k_scale is not None) else None
+    gluon_v_scale = v_scale.unsqueeze(-1) if (is_fp8 and v_scale is not None) else None
     run_pa_decode_gluon(
         output=output,
         q=q,
@@ -1126,8 +1133,8 @@ def minimax_m3_sparse_attn_decode_asm(
         context_partition_size=context_partition_size,
         compute_type=compute_type,
         q_scale=None,
-        k_scale=k_scale,
-        v_scale=v_scale,
+        k_scale=gluon_k_scale,
+        v_scale=gluon_v_scale,
         exp_sums=exp_sums,
         max_logits=max_logits,
         temporary_output=temporary_output,
@@ -1299,8 +1306,6 @@ def minimax_m3_sparse_attn_prefill_asm(
     that don't populate it), derive it on-device, SYNC-FREE, via searchsorted /
     arange (no .item(), no GPU repeat_interleave).
     """
-    from atom.model_ops.base_attention import run_pa_fwd_asm
-
     assert num_kv_heads == 1, (
         "minimax_m3_sparse_attn_prefill_asm requires per-rank num_kv_heads == 1;"
         f" got {num_kv_heads}."
@@ -1327,16 +1332,85 @@ def minimax_m3_sparse_attn_prefill_asm(
         sparse_bt, sparse_ctx = minimax_m3_build_sparse_block_table_prefill(
             topk_idx, block_table, query_req_id, query_abs_pos
         )
-    run_pa_fwd_asm(
+
+    _run_prefill_fp8_gluon(
+        q,
+        k_cache,
+        v_cache,
+        sparse_bt,
+        sparse_ctx,
+        num_kv_heads,
+        sm_scale,
+        output,
+        k_scale,
+        v_scale,
+    )
+
+
+
+@torch.no_grad()
+def _run_prefill_fp8_gluon(
+    q: torch.Tensor,  # [total_q, num_heads, head_dim==128]
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    sparse_bt: torch.Tensor,  # [total_q, topk*8] int32 (per-token 16-page table)
+    sparse_ctx: torch.Tensor,  # [total_q] int32 (per-token causal ctx)
+    num_kv_heads: int,
+    sm_scale: float,
+    output: torch.Tensor,  # [total_q, num_heads, head_dim]
+    k_scale: torch.Tensor | None,
+    v_scale: torch.Tensor | None,
+) -> None:
+    """fp8 prefill via the Gluon split-KV decode kernel (per-token-as-decode).
+
+    Each of the ``total_q`` query tokens is treated as an independent length-1
+    "sequence" with its own sparse 16-page block_table + causal context_len --
+    identical setup to ``minimax_m3_sparse_attn_decode_asm``, just with
+    ``num_seqs == total_q``. This avoids the pa_fwd_asm maskless-fp8 NaN bug at
+    the 256-token boundary (see caller).
+    """
+    from atom.model_ops.base_attention import run_pa_decode_gluon
+    from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
+
+    num_seqs, num_q_heads_total, head_size = q.shape
+    query_group_size = num_q_heads_total // num_kv_heads
+    max_context_partition_num = get_recommended_splits(num_seqs, num_kv_heads)
+    context_partition_size = 256
+    intermediate_shape = (
+        num_seqs,
+        num_kv_heads,
+        max_context_partition_num,
+        query_group_size,
+    )
+    exp_sums = torch.empty(intermediate_shape, dtype=torch.float32, device=q.device)
+    max_logits = torch.empty(intermediate_shape, dtype=torch.float32, device=q.device)
+    temporary_output = torch.empty(
+        *intermediate_shape, head_size, dtype=q.dtype, device=q.device
+    )
+    # gluon wants per-token scale as [num_blocks, num_kv_heads, kv_block_size, 1];
+    # the M3 scale tensor is [num_phys_blocks, num_kv_heads, physical_block_size].
+    gluon_k_scale = k_scale.unsqueeze(-1) if k_scale is not None else None
+    gluon_v_scale = v_scale.unsqueeze(-1) if v_scale is not None else None
+    run_pa_decode_gluon(
+        output=output,
         q=q,
         k_cache=k_cache,
         v_cache=v_cache,
-        block_tables=sparse_bt,
         context_lens=sparse_ctx,
-        k_scale=k_scale,
-        v_scale=v_scale,
-        out=output,
-        qo_indptr=qo_indptr,
-        max_qlen=1,
-        high_precision=0,
+        block_tables=sparse_bt,
+        softmax_scale=sm_scale,
+        max_seqlen_q=1,
+        max_context_partition_num=max_context_partition_num,
+        context_partition_size=context_partition_size,
+        compute_type=aiter.dtypes.fp8,
+        q_scale=None,
+        k_scale=gluon_k_scale,
+        v_scale=gluon_v_scale,
+        exp_sums=exp_sums,
+        max_logits=max_logits,
+        temporary_output=temporary_output,
+        alibi_slopes=None,
+        sinks=None,
+        sliding_window=-1,
+        ps=True,
     )

--- a/atom/model_ops/minimax_m3/sparse_attn.py
+++ b/atom/model_ops/minimax_m3/sparse_attn.py
@@ -983,9 +983,17 @@ def _build_sparse_block_table_kernel(
     base_phys = logical_page * pages_per_block  # [BLOCK_SIZE_T]
     dst_base = slot * pages_per_block  # [BLOCK_SIZE_T]
 
+    # Write EVERY destination slot so the output buffer can be torch.empty (no
+    # memset): valid selected blocks -> their physical pages; all remaining slots
+    # (padding beyond n_valid, or BLOCK_SIZE_T > max_topk) -> 0 (an in-bounds page
+    # id; masked out by context_lens at attention time). Avoids the per-call
+    # torch.zeros memset that dominates at low concurrency.
     for j in range(pages_per_block):
-        write_mask = valid & (dst_base + j < BLOCK_SIZE_T * pages_per_block)
-        tl.store(sbt_row + dst_base + j, base_phys + j, mask=write_mask)
+        tl.store(sbt_row + dst_base + j, base_phys + j, mask=valid)
+    # zero the unused tail [n_valid*pages_per_block : width).
+    n_used = n_valid * pages_per_block
+    off_w = tl.arange(0, BLOCK_SIZE_T * pages_per_block)
+    tl.store(sbt_row + off_w, tl.zeros_like(off_w), mask=off_w >= n_used)
 
     # true valid token count: full blocks contribute 128 each, tail the remainder.
     tail_tokens = seq_len - last_blk * sm_block_size
@@ -1016,8 +1024,11 @@ def minimax_m3_build_sparse_block_table(
     batch = topk_idx.shape[1]
     topk = topk_idx.shape[-1]
     width = topk * PAGES_PER_SPARSE_BLOCK
-    sparse_bt = torch.zeros((batch, width), dtype=torch.int32, device=topk_idx.device)
-    sparse_ctx = torch.zeros((batch,), dtype=torch.int32, device=topk_idx.device)
+    # Both buffers are FULLY written by the kernel (sparse_bt: every slot incl.
+    # padding -> 0; sparse_ctx: one entry per program), so torch.empty is safe and
+    # skips the per-call memset that hurts low-concurrency decode.
+    sparse_bt = torch.empty((batch, width), dtype=torch.int32, device=topk_idx.device)
+    sparse_ctx = torch.empty((batch,), dtype=torch.int32, device=topk_idx.device)
     _build_sparse_block_table_kernel[(batch,)](
         topk_idx,
         block_table,
@@ -1050,6 +1061,8 @@ def minimax_m3_sparse_attn_decode_asm(
     output: torch.Tensor,  # [batch, num_heads, head_dim]
     k_scale: torch.Tensor | None = None,
     v_scale: torch.Tensor | None = None,
+    sparse_bt: torch.Tensor | None = None,  # prebuilt (fused topk) -> skip build
+    sparse_ctx: torch.Tensor | None = None,
 ) -> None:
     """Block-sparse decode attention via the AITER Gluon paged-attention kernel.
 
@@ -1060,6 +1073,9 @@ def minimax_m3_sparse_attn_decode_asm(
     split-KV (flash-decoding) implementation is more efficient than the monolithic
     ASM kernel at low concurrency (few decode sequences), where it parallelizes
     over KV partitions to keep the GPU busy.
+
+    If ``sparse_bt`` / ``sparse_ctx`` are provided (built fused inside the topk
+    merge kernel), the standalone compaction launch is skipped.
 
     Requires per-rank num_kv_heads == 1 (the indexer top-k is per-kv-head; one
     shared block_table cannot express per-kv-head selection) and head_dim == 128.
@@ -1073,9 +1089,10 @@ def minimax_m3_sparse_attn_decode_asm(
     )
     assert q.shape[-1] == 128, "Gluon paged-attention requires head_dim == 128."
 
-    sparse_bt, sparse_ctx = minimax_m3_build_sparse_block_table(
-        topk_idx, block_table, seq_lens
-    )
+    if sparse_bt is None or sparse_ctx is None:
+        sparse_bt, sparse_ctx = minimax_m3_build_sparse_block_table(
+            topk_idx, block_table, seq_lens
+        )
 
     # Gluon split-KV decode setup (mirrors the standard MHA path in
     # attention_mha.py::paged_attention_triton). q is [batch, num_heads, 128];
@@ -1183,9 +1200,14 @@ def _build_sparse_block_table_prefill_kernel(
     base_phys = logical_page * pages_per_block
     dst_base = slot * pages_per_block
 
+    # Write EVERY destination slot so the output buffer can be torch.empty (no
+    # memset): valid selected blocks -> their physical pages; the unused tail ->
+    # 0 (in-bounds page id, masked out by context_lens at attention time).
     for j in range(pages_per_block):
-        write_mask = valid & (dst_base + j < BLOCK_SIZE_T * pages_per_block)
-        tl.store(sbt_row + dst_base + j, base_phys + j, mask=write_mask)
+        tl.store(sbt_row + dst_base + j, base_phys + j, mask=valid)
+    n_used = n_valid * pages_per_block
+    off_w = tl.arange(0, BLOCK_SIZE_T * pages_per_block)
+    tl.store(sbt_row + off_w, tl.zeros_like(off_w), mask=off_w >= n_used)
 
     # full blocks contribute 128 each; tail (self-block) contributes p%128 + 1.
     tail_tokens = causal_len - self_blk * sm_block_size
@@ -1218,8 +1240,10 @@ def minimax_m3_build_sparse_block_table_prefill(
     device = topk_idx.device
 
     width = topk * PAGES_PER_SPARSE_BLOCK
-    sparse_bt = torch.zeros((total_q, width), dtype=torch.int32, device=device)
-    sparse_ctx = torch.zeros((total_q,), dtype=torch.int32, device=device)
+    # Fully written by the kernel (every slot incl. padding -> 0; one ctx per
+    # program), so torch.empty is safe and skips the per-call memset.
+    sparse_bt = torch.empty((total_q, width), dtype=torch.int32, device=device)
+    sparse_ctx = torch.empty((total_q,), dtype=torch.int32, device=device)
     _build_sparse_block_table_prefill_kernel[(total_q,)](
         topk_idx,
         block_table,
@@ -1260,6 +1284,8 @@ def minimax_m3_sparse_attn_prefill_asm(
     v_scale: torch.Tensor | None = None,
     cu_seqlens_q: torch.Tensor | None = None,  # [batch+1] int32, for the fallback
     prefix_lens: torch.Tensor | None = None,  # [batch] int32, for the fallback
+    sparse_bt: torch.Tensor | None = None,  # prebuilt (fused topk) -> skip build
+    sparse_ctx: torch.Tensor | None = None,
 ) -> None:
     """Block-sparse PREFILL via AITER ASM pa_fwd_asm, per-token-as-decode.
 
@@ -1283,23 +1309,24 @@ def minimax_m3_sparse_attn_prefill_asm(
 
     total_q = q.shape[0]
     device = q.device
-    if query_req_id is None or query_abs_pos is None:
-        # Sync-free on-device derivation: req_id[n] = #(cu_seqlens_q[1:] <= n),
-        # abs_pos[n] = prefix_lens[req] + (n - cu_seqlens_q[req]).
-        assert cu_seqlens_q is not None and prefix_lens is not None
-        pos = torch.arange(total_q, dtype=torch.int32, device=device)
-        query_req_id = torch.searchsorted(
-            cu_seqlens_q[1:].contiguous(), pos, right=True
-        ).to(torch.int32)
-        query_abs_pos = (
-            prefix_lens[query_req_id] + (pos - cu_seqlens_q[query_req_id])
-        ).to(torch.int32)
     if qo_indptr is None:
         qo_indptr = torch.arange(total_q + 1, dtype=torch.int32, device=device)
 
-    sparse_bt, sparse_ctx = minimax_m3_build_sparse_block_table_prefill(
-        topk_idx, block_table, query_req_id, query_abs_pos
-    )
+    if sparse_bt is None or sparse_ctx is None:
+        if query_req_id is None or query_abs_pos is None:
+            # Sync-free on-device derivation: req_id[n] = #(cu_seqlens_q[1:] <= n),
+            # abs_pos[n] = prefix_lens[req] + (n - cu_seqlens_q[req]).
+            assert cu_seqlens_q is not None and prefix_lens is not None
+            pos = torch.arange(total_q, dtype=torch.int32, device=device)
+            query_req_id = torch.searchsorted(
+                cu_seqlens_q[1:].contiguous(), pos, right=True
+            ).to(torch.int32)
+            query_abs_pos = (
+                prefix_lens[query_req_id] + (pos - cu_seqlens_q[query_req_id])
+            ).to(torch.int32)
+        sparse_bt, sparse_ctx = minimax_m3_build_sparse_block_table_prefill(
+            topk_idx, block_table, query_req_id, query_abs_pos
+        )
     run_pa_fwd_asm(
         q=q,
         k_cache=k_cache,

--- a/atom/models/minimax_m3.py
+++ b/atom/models/minimax_m3.py
@@ -658,18 +658,33 @@ class MiniMaxM3SparseAttention(nn.Module):
             self._ensure_asm_shuffle_views()
             if self.kv_cache_k.numel() == 0:
                 return
-            # Page-16 SHUFFLE write for the ASM decode path.
-            aiter.reshape_and_cache(
-                k.view(-1, self.num_kv_heads, self.head_dim),
-                v.view(-1, self.num_kv_heads, self.head_dim),
-                self.kv_cache_k,
-                self.kv_cache_v,
-                slot_mapping,
-                kv_cache_dtype="auto",
-                k_scale=None,
-                v_scale=None,
-                asm_layout=True,
-            )
+            if self.kv_cache_dtype == "fp8":
+                # Page-16 SHUFFLE fp8 write with per-token dynamic quant; writes
+                # per-token dequant scales into self.k_scale/self.v_scale
+                # ([num_phys_blocks, num_kv_heads, physical_block_size]).
+                aiter.reshape_and_cache_with_pertoken_quant(
+                    k.view(-1, self.num_kv_heads, self.head_dim),
+                    v.view(-1, self.num_kv_heads, self.head_dim),
+                    self.kv_cache_k,
+                    self.kv_cache_v,
+                    self.k_scale,
+                    self.v_scale,
+                    slot_mapping,
+                    asm_layout=True,
+                )
+            else:
+                # Page-16 SHUFFLE bf16 write for the ASM decode path.
+                aiter.reshape_and_cache(
+                    k.view(-1, self.num_kv_heads, self.head_dim),
+                    v.view(-1, self.num_kv_heads, self.head_dim),
+                    self.kv_cache_k,
+                    self.kv_cache_v,
+                    slot_mapping,
+                    kv_cache_dtype="auto",
+                    k_scale=None,
+                    v_scale=None,
+                    asm_layout=True,
+                )
         else:
             if self.kv_cache.numel() == 0:
                 return
@@ -891,6 +906,10 @@ class MiniMaxM3SparseAttention(nn.Module):
                 kv_cache_dtype = (
                     "auto" if self.kv_cache_dtype == "bf16" else self.kv_cache_dtype
                 )
+                # fp8: the fused op computes per-token dynamic quant and writes the
+                # per-token dequant scales into self.k_scale/self.v_scale (output).
+                fused_k_scale = self.k_scale if self.kv_cache_dtype == "fp8" else None
+                fused_v_scale = self.v_scale if self.kv_cache_dtype == "fp8" else None
                 aiter.fused_qknorm_idxrqknorm(
                     qkv,
                     self.q_norm.weight,
@@ -913,8 +932,8 @@ class MiniMaxM3SparseAttention(nn.Module):
                     index_q,
                     sparse_metadata.slot_mapping,
                     kv_cache_dtype=kv_cache_dtype,
-                    k_scale=None,
-                    v_scale=None,
+                    k_scale=fused_k_scale,
+                    v_scale=fused_v_scale,
                     asm_layout=True,
                 )
             else:

--- a/atom/models/minimax_m3.py
+++ b/atom/models/minimax_m3.py
@@ -45,7 +45,6 @@ from atom.model_ops.minimax_m3.moe import (
 )
 from atom.model_ops.minimax_m3.sparse_attn import (
     SPARSE_BLOCK_SIZE,
-    minimax_m3_fused_qknorm_rope_kv_insert_shuffle,
     minimax_m3_sparse_attn,
     minimax_m3_sparse_attn_decode,
     minimax_m3_sparse_attn_decode_asm,
@@ -94,11 +93,13 @@ def _rope_theta(config: PretrainedConfig) -> float:
 
 def _can_use_fused_minimax_m3_attention_preproc(
     qkv: torch.Tensor,
+    use_asm_pa: bool,
     rotary_emb: nn.Module,
     *weights: torch.Tensor,
 ) -> bool:
     return (
         hasattr(aiter, "fused_qknorm_idxrqknorm")
+        or use_asm_pa
         and qkv.dim() == 2
         and qkv.is_cuda
         and qkv.dtype in (torch.float16, torch.bfloat16)
@@ -453,16 +454,17 @@ class MiniMaxM3Attention(nn.Module):
                 self.num_kv_heads,
                 self.rotary_emb.rotary_dim,
                 self.q_norm.variance_epsilon,
-                None,
-                None,
-                0,
-                None,
-                None,
-                None,
-                0,
-                q,
-                None,
-                None,
+                None,  # index_q_norm_weight
+                None,  # index_k_norm_weight
+                0,  # num_index_heads
+                None,  # slot_mapping
+                None,  # kv_cache_k
+                None,  # kv_cache_v
+                None,  # index_cache
+                0,  # block_size
+                q,  # q_out
+                None,  # index_q_out
+                None,  # index_slot_mapping
             )
             _, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
             attn_output = self.attn(q, k, v)
@@ -707,7 +709,10 @@ class MiniMaxM3SparseAttention(nn.Module):
         # prepare_prefill built. Either way it is correct to read directly here.
         prefix_lens = prefill_metadata.context_lens
         block_tables = prefill_metadata.block_table
-        topk_idx = minimax_m3_index_topk(
+        # Fuse the sparse block-table build into the topk kernel for the ASM
+        # prefill path (num_kv_heads == 1), saving a build launch + round-trip.
+        fuse_bt = self._use_asm_pa and self.num_kv_heads == 1
+        topk_out = minimax_m3_index_topk(
             index_q,
             self.index_cache,
             block_tables,
@@ -721,7 +726,12 @@ class MiniMaxM3SparseAttention(nn.Module):
             self.local_blocks,
             self.num_kv_heads,
             self.scaling,
+            emit_sparse_block_table=fuse_bt,
         )
+        if fuse_bt:
+            topk_idx, sparse_bt, sparse_ctx = topk_out
+        else:
+            topk_idx, sparse_bt, sparse_ctx = topk_out, None, None
         output = torch.empty_like(q)
         if self._use_asm_pa:
             minimax_m3_sparse_attn_prefill_asm(
@@ -745,6 +755,8 @@ class MiniMaxM3SparseAttention(nn.Module):
                 # of asserting / reading frozen metadata.
                 cu_seqlens_q=cu_seqlens_q,
                 prefix_lens=prefix_lens,
+                sparse_bt=sparse_bt,
+                sparse_ctx=sparse_ctx,
             )
         else:
             minimax_m3_sparse_attn(
@@ -770,7 +782,11 @@ class MiniMaxM3SparseAttention(nn.Module):
     ) -> torch.Tensor:
         decode_metadata = sparse_metadata.decode
         assert decode_metadata is not None
-        topk_idx = minimax_m3_index_topk_decode(
+        # When using ASM/gluon decode (num_kv_heads == 1), fuse the sparse
+        # block-table build into the topk merge kernel (returns sparse_bt/ctx),
+        # saving a separate build launch + topk_idx round-trip.
+        fuse_bt = self._use_asm_pa and self.num_kv_heads == 1
+        topk_out = minimax_m3_index_topk_decode(
             index_q,
             self.index_cache,
             decode_metadata.block_table,
@@ -781,7 +797,12 @@ class MiniMaxM3SparseAttention(nn.Module):
             self.local_blocks,
             self.num_kv_heads,
             self.scaling,
+            emit_sparse_block_table=fuse_bt,
         )
+        if fuse_bt:
+            topk_idx, sparse_bt, sparse_ctx = topk_out
+        else:
+            topk_idx, sparse_bt, sparse_ctx = topk_out, None, None
         output = torch.empty_like(q)
         if self._use_asm_pa:
             if self.num_kv_heads != 1:
@@ -802,6 +823,8 @@ class MiniMaxM3SparseAttention(nn.Module):
                 output,
                 k_scale=self.k_scale,
                 v_scale=self.v_scale,
+                sparse_bt=sparse_bt,
+                sparse_ctx=sparse_ctx,
             )
         else:
             minimax_m3_sparse_attn_decode(
@@ -845,6 +868,7 @@ class MiniMaxM3SparseAttention(nn.Module):
             sparse_metadata = attn_metadata
         if _can_use_fused_minimax_m3_attention_preproc(
             qkv,
+            self._use_asm_pa,
             self.rotary_emb,
             self.q_norm.weight,
             self.k_norm.weight,
@@ -860,9 +884,14 @@ class MiniMaxM3SparseAttention(nn.Module):
             )
             cos_sin_cache = _minimax_m3_cos_sin_cache(self.rotary_emb, qkv)
             if self._use_asm_pa:
-                # Triton fallback that writes the main KV cache in page-16
-                # SHUFFLE layout (the aiter fused kernel writes plain page-128).
-                minimax_m3_fused_qknorm_rope_kv_insert_shuffle(
+                # Fused aiter CUDA kernel writing the main KV cache in page-16
+                # SHUFFLE layout (asm_layout=True), matching the page-16 SHUFFLE
+                # K/V views. ~2-4x faster than the Triton shuffle writer; block_size
+                # is the SHUFFLE page (16 == kv_cache_k.shape[3]), not 128.
+                kv_cache_dtype = (
+                    "auto" if self.kv_cache_dtype == "bf16" else self.kv_cache_dtype
+                )
+                aiter.fused_qknorm_idxrqknorm(
                     qkv,
                     self.q_norm.weight,
                     self.k_norm.weight,
@@ -879,11 +908,23 @@ class MiniMaxM3SparseAttention(nn.Module):
                     self.kv_cache_k,
                     self.kv_cache_v,
                     self.index_cache,
+                    self.kv_cache_k.shape[3],  # SHUFFLE page size (== ASM_PAGE_SIZE)
                     q,
                     index_q,
-                    self.idx_head_dim,
+                    sparse_metadata.slot_mapping,
+                    kv_cache_dtype=kv_cache_dtype,
+                    k_scale=None,
+                    v_scale=None,
+                    asm_layout=True,
                 )
             else:
+                # page-128 path: the op takes separate K/V caches. Pass the
+                # key/value slices of the fused [N, 2, block_size, nkv, hd] cache
+                # (zero-copy views); asm_layout=False selects page-128 addressing.
+                key_cache, value_cache = self.kv_cache.unbind(1)
+                kv_cache_dtype = (
+                    "auto" if self.kv_cache_dtype == "bf16" else self.kv_cache_dtype
+                )
                 aiter.fused_qknorm_idxrqknorm(
                     qkv,
                     self.q_norm.weight,
@@ -898,15 +939,17 @@ class MiniMaxM3SparseAttention(nn.Module):
                     self.index_k_norm.weight,
                     self.num_idx_heads,
                     sparse_metadata.slot_mapping,
-                    self.kv_cache,
+                    key_cache,
+                    value_cache,
                     self.index_cache,
                     self.kv_cache.shape[2],
                     q,
                     index_q,
                     sparse_metadata.slot_mapping,
-                    self.kv_cache_dtype,
-                    None,
-                    None,
+                    kv_cache_dtype=kv_cache_dtype,
+                    k_scale=None,
+                    v_scale=None,
+                    asm_layout=False,
                 )
             q = q.view(-1, self.num_heads, self.head_dim)
             index_q = index_q.view(-1, self.num_idx_heads, self.idx_head_dim)
@@ -916,47 +959,47 @@ class MiniMaxM3SparseAttention(nn.Module):
                 output = self._run_decode_sparse(q, index_q, sparse_metadata)
             return output.view(-1, self.q_size)
 
-        q, k, v, index_q, index_k = qkv.split(
-            [
-                self.q_size,
-                self.kv_size,
-                self.kv_size,
-                self.index_q_size,
-                self.idx_head_dim,
-            ],
-            dim=-1,
-        )
-        q, k = _minimax_m3_gemma_qk_norm(
-            q,
-            k,
-            self.q_norm,
-            self.k_norm,
-            self.num_heads,
-            self.num_kv_heads,
-            self.head_dim,
-        )
-        q, k = self.rotary_emb(positions, q, k)
+        # q, k, v, index_q, index_k = qkv.split(
+        #     [
+        #         self.q_size,
+        #         self.kv_size,
+        #         self.kv_size,
+        #         self.index_q_size,
+        #         self.idx_head_dim,
+        #     ],
+        #     dim=-1,
+        # )
+        # q, k = _minimax_m3_gemma_qk_norm(
+        #     q,
+        #     k,
+        #     self.q_norm,
+        #     self.k_norm,
+        #     self.num_heads,
+        #     self.num_kv_heads,
+        #     self.head_dim,
+        # )
+        # q, k = self.rotary_emb(positions, q, k)
 
-        index_q, index_k = _minimax_m3_gemma_qk_norm(
-            index_q,
-            index_k,
-            self.index_q_norm,
-            self.index_k_norm,
-            self.num_idx_heads,
-            1,
-            self.idx_head_dim,
-        )
-        index_q, index_k = self.index_rotary_emb(positions, index_q, index_k)
+        # index_q, index_k = _minimax_m3_gemma_qk_norm(
+        #     index_q,
+        #     index_k,
+        #     self.index_q_norm,
+        #     self.index_k_norm,
+        #     self.num_idx_heads,
+        #     1,
+        #     self.idx_head_dim,
+        # )
+        # index_q, index_k = self.index_rotary_emb(positions, index_q, index_k)
 
-        self._insert_kv(k, v, index_k, sparse_metadata.slot_mapping)
+        # self._insert_kv(k, v, index_k, sparse_metadata.slot_mapping)
 
-        q = q.view(-1, self.num_heads, self.head_dim)
-        index_q = index_q.view(-1, self.num_idx_heads, self.idx_head_dim)
-        if getattr(sparse_metadata, "num_prefills", 0) > 0:
-            output = self._run_prefill_sparse(q, index_q, sparse_metadata)
-        else:
-            output = self._run_decode_sparse(q, index_q, sparse_metadata)
-        return output.view(-1, self.q_size)
+        # q = q.view(-1, self.num_heads, self.head_dim)
+        # index_q = index_q.view(-1, self.num_idx_heads, self.idx_head_dim)
+        # if getattr(sparse_metadata, "num_prefills", 0) > 0:
+        #     output = self._run_prefill_sparse(q, index_q, sparse_metadata)
+        # else:
+        #     output = self._run_decode_sparse(q, index_q, sparse_metadata)
+        # return output.view(-1, self.q_size)
 
 
 class MiniMaxM3DecoderLayer(nn.Module):


### PR DESCRIPTION
## Motivation

deps:
https://github.com/ROCm/aiter/pull/3795

launch script:
```
export AITER_LOG_LEVEL=WARNING ATOM_M3_SPARSE_USE_ASM_PA=1 HIP_VISIBLE_DEVICES=4,5,6,7
python -m atom.entrypoints.openai_server --model /workspace/shared/data/amd_int/models/MiniMax-M3-MXFP4 \
  -tp 4 --server-port 8013 --trust-remote-code --gpu-memory-utilization 0.8 --block-size 128 --no-enable_prefix_caching \
  --max-num-batched-tokens 32768 --max-model-len 32768 --max-num-seqs 128
```

accuracy: 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9393|±  |0.0066|
|     |       |strict-match    |     5|exact_match|↑  |0.9401|±  |0.0065|
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
before:
```
============ Serving Benchmark Result ============
Successful requests:                     640       
Failed requests:                         0         
Maximum request concurrency:             64        
Benchmark duration (s):                  331.70    
Total input tokens:                      5419318   
Total generated tokens:                  657257    
Request throughput (req/s):              1.93      
Output token throughput (tok/s):         1981.47   
Peak output token throughput (tok/s):    4864.00   
Peak concurrent requests:                73.00     
Total token throughput (tok/s):          18319.41  
---------------Time to First Token----------------
Mean TTFT (ms):                          1121.23   
Median TTFT (ms):                        418.59    
P99 TTFT (ms):                           14163.40  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.37     
Median TPOT (ms):                        30.77     
P99 TPOT (ms):                           46.36     
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.06     
Median ITL (ms):                         15.50     
P99 ITL (ms):                            376.82    
==================================================
```

after:
```
============ Serving Benchmark Result ============
Successful requests:                     640       
Failed requests:                         0         
Maximum request concurrency:             64        
Benchmark duration (s):                  320.99    
Total input tokens:                      5419318   
Total generated tokens:                  657257    
Request throughput (req/s):              1.99      
Output token throughput (tok/s):         2047.58   
Peak output token throughput (tok/s):    4800.00   
Peak concurrent requests:                69.00     
Total token throughput (tok/s):          18930.65  
---------------Time to First Token----------------
Mean TTFT (ms):                          1042.35   
Median TTFT (ms):                        382.99    
P99 TTFT (ms):                           12908.83  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.29     
Median TPOT (ms):                        29.69     
P99 TPOT (ms):                           39.90     
---------------Inter-token Latency----------------
Mean ITL (ms):                           29.05     
Median ITL (ms):                         15.70     
P99 ITL (ms):                            334.21    
==================================================
```

launch script with fp8 kv cache:
```
export AITER_LOG_LEVEL=WARNING ATOM_M3_SPARSE_USE_ASM_PA=1 HIP_VISIBLE_DEVICES=4,5,6,7
python -m atom.entrypoints.openai_server --model /workspace/shared/data/amd_int/models/MiniMax-M3-MXFP4 \
  -tp 4 --server-port 8013 --trust-remote-code --gpu-memory-utilization 0.8 --block-size 128 --no-enable_prefix_caching \
  --max-num-batched-tokens 32768 --max-model-len 32768 --max-num-seqs 128 --kv_cache_dtype fp8
```

acc with fp8 kv cache
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9439|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9447|±  |0.0063|
```
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
