### PR TITLE
disable prefix caching in MiniMax-M3 FP4 and EAGLE3 recipe scripts

### DIFF
--- a/recipes/MiniMax-M3.md
+++ b/recipes/MiniMax-M3.md
@@ -116,7 +116,8 @@ python -m atom.entrypoints.openai_server \
   --block-size 128 \
   --max-model-len 32768 \
   --max-num-seqs 128 \
-  --max-num-batched-tokens 32768 2>&1 | tee "${run_name}-server.log"
+  --max-num-batched-tokens 32768 \
+  --no-enable_prefix_caching 2>&1 | tee "${run_name}-server.log"
 ```
 
 ### Accuracy Test
@@ -238,6 +239,7 @@ python -m atom.entrypoints.openai_server \
   --max-model-len 32768 \
   --max-num-seqs 128 \
   --max-num-batched-tokens 32768 \
+  --no-enable_prefix_caching \
   --method eagle3 \
   --draft-model "$draft_path" \
   --num-speculative-tokens 3 2>&1 | tee m3-mxfp4-eagle3-server.log


### PR DESCRIPTION
The BF16 script already had --no-enable_prefix_caching; add the same flag to the MXFP4 and EAGLE3 server commands for consistency.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
