### PR TITLE
feat: fuse indexer Q fp8 quant into rope_rotate_activation

### DIFF
--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -32,7 +32,6 @@ import torch.nn.functional as F
 from aiter import (
     cp_gather_indexer_k_quant_cache,
     dtypes,
-    get_hip_quant,
     rope_rotate_activation,
 )
 from aiter import silu_and_mul as aiter_silu_and_mul
@@ -1085,7 +1084,10 @@ class Indexer(nn.Module):
         )
         self.softmax_scale = self.head_dim**-0.5
         # Init-time hoists out of `forward_batched`'s hot path.
-        self._fp8_quant_func = get_hip_quant(QuantType.per_1x128)
+        # FP8 Q quant is fused into `rope_rotate_activation` (per_1x128 over
+        # head_dim); `group_size` is the per-1xN block. head_dim is the index
+        # head dim (128), so there is exactly one scale per (token, head).
+        self._q_quant_group = self.head_dim
         self._weights_scale = self.softmax_scale * self.n_heads**-0.5
         # `deepgemm_fp8_paged_mqa_logits` decode-path output column count:
         # one indexer slot per `compress_ratio` source tokens.
@@ -1157,16 +1159,28 @@ class Indexer(nn.Module):
         q = self.wq_b(qr_full, x_scale=qr_full_scale).view(
             total_tokens, self.n_heads, self.head_dim
         )
-        # self.rotary_emb(positions, q[..., -rd:])
-        # q = rotate_activation(q)
-        rope_rotate_activation(
-            q, q, self.rotary_emb.cos_cache, self.rotary_emb.sin_cache, positions, rd
+        # RoPE + Hadamard-rotate + FP8 quant fused in one kernel. Q is online
+        # (recomputed each fwd, no cache); the bf16 rotated Q is never read back,
+        # so it is quantized in place of being materialized. `out_scale` carries
+        # the per-(token, head) fp8 block scale (head_dim == group => one/row).
+        # `_weights_scale` precomputed in __init__.
+        # self.rotary_emb(positions, q[..., -rd:]); q = rotate_activation(q)
+        q_fp8 = torch.empty_like(q, dtype=dtypes.fp8)
+        q_scale = torch.empty(
+            (total_tokens * self.n_heads, self.head_dim // self._q_quant_group),
+            dtype=dtypes.fp32,
+            device=q.device,
         )
-
-        # FP8 quant Q (still online — Q is recomputed each fwd, no cache).
-        # `_fp8_quant_func` / `_weights_scale` precomputed in __init__.
-        q_2d = q.view(-1, self.head_dim)
-        q_fp8, q_scale = self._fp8_quant_func(q_2d, quant_dtype=dtypes.fp8)
+        rope_rotate_activation(
+            q_fp8,
+            q,
+            self.rotary_emb.cos_cache,
+            self.rotary_emb.sin_cache,
+            positions,
+            rd,
+            out_scale=q_scale,
+            group_size=self._q_quant_group,
+        )
         q_fp8 = q_fp8.view(total_tokens, self.n_heads, self.head_dim)
         q_scale = q_scale.view(total_tokens, self.n_heads, 1)
 


### PR DESCRIPTION
## Summary

Replace the two-step indexer Q preparation in `Indexer.forward_batched`:
- **Before:** bf16 `rope_rotate_activation` (RoPE + Hadamard-rotate, in place) **then** a separate `get_hip_quant(QuantType.per_1x128)` fp8 quant.
- **After:** a single fused `rope_rotate_activation(out_scale=, group_size=)` call that does RoPE + Hadamard-rotate **and** writes fp8-quantized Q plus its per-(token, head) block scale in one kernel.

The bf16 rotated Q is never read back, so quantizing it in-kernel avoids materializing the intermediate. `group_size = head_dim` (128) ⇒ exactly one scale per (token, head). The fused kernel's fp8 quant matches `dynamic_per_group_scaled_quant_kernel`.

## Dependency

Requires the aiter-side fused fp8 `rope_rotate_activation` (RQ_FP8 path in `csrc/kernels/dsv4_rotate_quant.cu`, with its quant strictly aligned to `dynamic_per_group_scaled_quant_kernel`) and the `out_scale`/`group_size` binding. Merge after the corresponding aiter version is available.

## Test plan

DeepSeek-V4-Pro, tp=8, `--kv_cache_dtype fp8 --level 0`:

- **Accuracy (GSM8K, lm_eval):**
  - 3-shot: 0.9530 / 0.9553 / 0.9568 (with index cache); 0.9530 (no index cache, 10-shot)
  - 10-shot: 0.9568 ± 0.0056
  - Baseline 0.9522 ± 0.0059 — within noise, **no regression**
- **Performance (conc 16, ISL/OSL 1024/1024):** Total throughput 1644 tok/s, Mean TPOT 18.9 ms — on par with the pre-change baseline (1634 tok/s).
- ruff + black clean; no residual `_fp8_quant_func` / `get_hip_quant` references in the model.