### PR TITLE
fix(minimax): restore qkv<=256 shape guard + harden compile-cache frozen-path guard (v0.1.5)

### DIFF
--- a/atom/models/minimax_m2.py
+++ b/atom/models/minimax_m2.py
@@ -233,7 +233,7 @@ class MiniMaxM2Attention(nn.Module):
             # TP-aware RMSNorm: all-reduce variance across TP ranks so
             # normalization uses the global variance (over 6144/1024 dims)
             # rather than per-rank variance (768/128 dims).
-            if self.tp_size > 1:
+            if qkv.shape[0] <= 256 and self.tp_size > 1:
                 q, k, v = tensor_model_parallel_fused_qknorm_allreduce(
                     qkv, self.q_norm.weight, self.k_norm.weight, self.rms_norm_eps
                 )

--- a/atom/utils/backends.py
+++ b/atom/utils/backends.py
@@ -575,9 +575,9 @@ class VllmBackend:
             hash_content = []
             for filepath in forward_code_files:
                 hash_content.append(filepath)
-                if filepath == "<string>" or filepath == "<frozen os>":
-                    # This means the function was dynamically generated, with
-                    # e.g. exec() or frozen os module. We can't actually check these.
+                if filepath == "<string>" or not os.path.exists(filepath):
+                    # Dynamically generated (exec()) or frozen stdlib module
+                    # (<frozen os>, <frozen posixpath>, ...): no readable source.
                     continue
                 with open(filepath) as f:
                     hash_content.append(f.read())

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,6 +96,7 @@ RUN echo "========== [OOT 7/7] Install vLLM runtime dependencies ==========" && 
       "s3transfer>=0.17.0,<0.18.0" && \
     if [ "${INSTALL_LM_EVAL}" = "1" ]; then "${VENV_PYTHON}" -m pip install "lm-eval[api]"; else echo "Skip lm-eval install"; fi && \
     if [ "${INSTALL_FASTSAFETENSORS}" = "1" ]; then "${VENV_PYTHON}" -m pip install "git+https://github.com/foundation-model-stack/fastsafetensors.git"; else echo "Skip fastsafetensors install"; fi && \
+    "${VENV_PYTHON}" -m pip install 'fastapi>=0.115,<0.137' && \
     "${VENV_PYTHON}" -c "import boto3, botocore, s3transfer; print(f'boto3: {boto3.__version__}'); print(f'botocore: {botocore.__version__}'); print(f's3transfer: {s3transfer.__version__}')" && \
     "${VENV_PYTHON}" -c "import glob, os, torch; print(f'torch.version.hip: {torch.version.hip}'); print(f'torch.version.cuda: {torch.version.cuda}'); torch_lib_dir=os.path.join(os.path.dirname(torch.__file__), 'lib'); print(f'torch lib dir: {torch_lib_dir}'); print(f'libtorch_hip candidates: {glob.glob(os.path.join(torch_lib_dir, \"libtorch_hip.so*\"))}'); assert torch.version.hip is not None, 'Torch is not ROCm build (torch.version.hip is None).'" && \
     "${VENV_PYTHON}" -m pip show vllm torch triton torchvision torchaudio amdsmi amd-aiter atom amd-mori-nightly || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "a lightweight vLLM implementation built from scratch"
 requires-python = ">=3.10"
 dynamic = ["version"]
-dependencies = ["pybind11", "transformers==5.2.0", "zmq", "msgspec", "xxhash", "fastapi", "psutil", "protobuf", "uvicorn", "aiohttp", "datasets", "openpyxl", "tqdm"]
+dependencies = ["pybind11", "transformers==5.2.0", "zmq", "msgspec", "xxhash", "fastapi>=0.115,<0.137", "psutil", "protobuf", "uvicorn", "aiohttp", "datasets", "openpyxl", "tqdm"]
 
 [project.urls]
 Homepage = "https://github.com/ROCm/ATOM"


### PR DESCRIPTION
## Summary
Two surgical fixes required for **MiniMax-M2.5** to serve under torch.compile at TP>1 on the v0.1.5 (c0a1242b) line. Without them the server hard-fails at engine init. Found while validating the **AITER v0.1.16 + ATOM v0.1.5 paired release**.

## Root cause
- `release/v0.1.5` forked off the **un-reverted** `#999` ("Remove qkv 256 tok limitation"), which dropped the `qkv.shape[0] <= 256` guard in `MiniMaxM2Attention.forward`. The fused custom collective `tensor_model_parallel_fused_qknorm_allreduce` then runs unconditionally at TP>1 inside the compiled forward → top-level graph break → re-enters `VllmBackend` → `AssertionError: VllmBackend can only be called once`.
- The compile-cache hash guard in `backends.py` only skipped `"<string>"` and `"<frozen os>"`, so a traced `"<frozen posixpath>"` reached `open()` → `FileNotFoundError` → `BackendCompilerFailed`.

## Changes
1. `atom/models/minimax_m2.py` — restore `qkv.shape[0] <= 256 and` guard on the fused qknorm-allreduce path (carries the revert of #999). The `else` branch already handles the non-fused path for larger token counts.
2. `atom/utils/backends.py` — replace the enumerated frozen-path special-cases with a generic `not os.path.exists(filepath)` check.

## Validation
mi355-gpu-15, ATOM c0a1242b + aiter 0.1.16, GSM8K 3-shot flexible-extract:
- MiniMax-M2.5: **3/3 mean 0.929** (was hard-failing at init)
- DSR1 0.952 / GLM5 0.947 / Kimi 0.940 / Qwen3 mean 0.871 — unaffected

## Note
`main` is on the same un-reverted line and has both bugs; a parallel PR to `main` will follow.