### PR TITLE
fix(minimax): restore qkv<=256 shape guard + harden compile-cache frozen-path guard

### DIFF
--- a/atom/models/minimax_m2.py
+++ b/atom/models/minimax_m2.py
@@ -233,7 +233,7 @@ class MiniMaxM2Attention(nn.Module):
             # TP-aware RMSNorm: all-reduce variance across TP ranks so
             # normalization uses the global variance (over 6144/1024 dims)
             # rather than per-rank variance (768/128 dims).
-            if self.tp_size > 1:
+            if qkv.shape[0] <= 256 and self.tp_size > 1:
                 q, k, v = tensor_model_parallel_fused_qknorm_allreduce(
                     qkv, self.q_norm.weight, self.k_norm.weight, self.rms_norm_eps
                 )

--- a/atom/utils/backends.py
+++ b/atom/utils/backends.py
@@ -575,9 +575,9 @@ class VllmBackend:
             hash_content = []
             for filepath in forward_code_files:
                 hash_content.append(filepath)
-                if filepath == "<string>" or filepath == "<frozen os>":
-                    # This means the function was dynamically generated, with
-                    # e.g. exec() or frozen os module. We can't actually check these.
+                if filepath == "<string>" or not os.path.exists(filepath):
+                    # Dynamically generated (exec()) or frozen stdlib module
+                    # (<frozen os>, <frozen posixpath>, ...): no readable source.
                     continue
                 with open(filepath) as f:
                     hash_content.append(f.read())


### PR DESCRIPTION
## Summary
MiniMax-M2.5 hard-fails at engine init under torch.compile at TP>1 on `main` (and the v0.1.5 release line). Two surgical fixes. Companion of #1299 (release/v0.1.5).

## Root cause
- `#999` ("Remove qkv 256 tok limitation") dropped the `qkv.shape[0] <= 256` guard in `MiniMaxM2Attention.forward`. The fused custom collective `tensor_model_parallel_fused_qknorm_allreduce` then runs unconditionally at TP>1 inside the compiled forward → top-level graph break → re-enters `VllmBackend` → `AssertionError: VllmBackend can only be called once`. The revert lives only on the v0.1.4 line; `main` carries the un-reverted change.
- The compile-cache hash guard in `backends.py` only skipped `"<string>"`/`"<frozen os>"`; a traced `"<frozen posixpath>"` reached `open()` → `FileNotFoundError` → `BackendCompilerFailed`.

## Changes
1. `atom/models/minimax_m2.py` — restore `qkv.shape[0] <= 256 and` guard on the fused qknorm-allreduce path; non-fused `else` already handles larger token counts.
2. `atom/utils/backends.py` — generic `not os.path.exists(filepath)` instead of enumerated frozen-path special-cases.

## Validation
mi355-gpu-15, GSM8K 3-shot flexible-extract: MiniMax-M2.5 **3/3 mean 0.929** (was hard-failing); DSR1 0.952 / GLM5 0.947 / Kimi 0.940 / Qwen3 mean 0.871 unaffected.