### PR TITLE
[fea](qwen): support model runner v2 on qwen-next (#1249)

### DIFF
--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -253,7 +253,7 @@
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-tp1-met",
           "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384",
-          "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1"
+          "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1\nVLLM_USE_V2_MODEL_RUNNER=1"
         },
         {
           "tp_size": 4,
@@ -271,7 +271,7 @@
           "prefix": "qwen3-next-80b-a3b-instruct-fp8-aw-tp1",
           "bench_args": "",
           "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384",
-          "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1"
+          "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nGATED_DELTA_RULE_TRITON_AUTOTUNE=1\nVLLM_USE_V2_MODEL_RUNNER=1"
         },
         {
           "tp_size": 2,

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -497,7 +497,7 @@ jobs:
                   "model_path": "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8",
                   "extra_args": "--tensor-parallel-size 1",
                   "accuracy_test_threshold": 0.81,
-                  "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0",
+                  "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nVLLM_USE_V2_MODEL_RUNNER=1",
                   "runner": "atom-plugin-acc-validation-runner",
               },
               {
@@ -803,7 +803,7 @@ jobs:
           BENCHMARK_OVERRIDES = {
               "Qwen3-Next-80B-A3B-Instruct-FP8 TP1": {
                   "extra_args": "--trust-remote-code --tensor-parallel-size 1 --max-num-batched-tokens 32768 --max-model-len 16384",
-                  "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0",
+                  "env_vars": "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nATOM_USE_CUSTOM_ALL_GATHER=0\nATOM_USE_FLYDSL_GDR=1\nATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0\nVLLM_USE_V2_MODEL_RUNNER=1",
               },
               "Qwen3-Next-80B-A3B-Instruct-FP8 TP2": {
                   "extra_args": "--trust-remote-code --tensor-parallel-size 2 --max-num-batched-tokens 32768 --max-model-len 16384",

--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -468,6 +468,19 @@ class AiterMhaMetadataBuilderForVllm(AttentionMetadataBuilder):
         self.positions = CpuGpuBuffer(max_num_batched_tokens, **i64_kwargs)
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
 
+    @staticmethod
+    def _get_seq_lens_cpu(common_attn_metadata):
+        import vllm.envs as vllm_envs
+
+        if (
+            vllm_envs.VLLM_USE_V2_MODEL_RUNNER is True
+            and hasattr(common_attn_metadata, "seq_lens_cpu_upper_bound")
+            and common_attn_metadata.seq_lens_cpu_upper_bound is not None
+        ):
+            return common_attn_metadata.seq_lens_cpu_upper_bound
+
+        return common_attn_metadata.seq_lens.cpu()
+
     def build(
         self,
         common_prefix_len: int = 0,
@@ -478,6 +491,8 @@ class AiterMhaMetadataBuilderForVllm(AttentionMetadataBuilder):
             raise ValueError("ATOM does not support cascade attention yet")
 
         from vllm.v1.attention.backends.utils import split_decodes_prefills_and_extends
+
+        seq_lens = self._get_seq_lens_cpu(common_attn_metadata)
 
         # decode_threshold tracks reorder_batch_threshold so MTP/EAGLE
         # multi-token verification (query_len > 1) routes through decode.
@@ -500,10 +515,6 @@ class AiterMhaMetadataBuilderForVllm(AttentionMetadataBuilder):
         decode_only = num_decodes > 0 and num_extends == 0 and num_prefills == 0
         mixed = not (prefill_only or decode_only)
 
-        # common_attn_metadata._seq_lens_cpu is equal to common_attn_metadata.seq_lens.cpu(),
-        # but using seq_lens.cpu() can get the better performance in low concurrency.
-        # seq_lens = common_attn_metadata._seq_lens_cpu
-        seq_lens = common_attn_metadata.seq_lens.cpu()
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
 
         query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]

--- a/atom/plugin/vllm/mamba_hybrid_patch.py
+++ b/atom/plugin/vllm/mamba_hybrid_patch.py
@@ -1,0 +1,67 @@
+import functools
+import inspect
+import logging
+import threading
+
+logger = logging.getLogger("atom")
+
+_TLS = threading.local()
+
+
+def apply_mamba_hybrid_seq_lens_patch() -> None:
+    """Patch vLLM mamba-hybrid metadata wiring for seq_lens_cpu_upper_bound."""
+    import vllm.envs as vllm_envs
+
+    if vllm_envs.VLLM_USE_V2_MODEL_RUNNER is not True:
+        return
+
+    try:
+        from vllm.v1.worker.gpu.model_states import mamba_hybrid
+    except ImportError:
+        return
+
+    original_build_attn_metadata = mamba_hybrid.build_attn_metadata
+    original_prepare_attn = mamba_hybrid.MambaHybridModelState.prepare_attn
+
+    if getattr(original_prepare_attn, "_atom_seq_lens_upper_bound_patched", False):
+        return
+
+    try:
+        sig = inspect.signature(original_build_attn_metadata)
+    except (TypeError, ValueError):
+        return
+    if "seq_lens_cpu_upper_bound" not in sig.parameters:
+        return
+
+    @functools.wraps(original_build_attn_metadata)
+    def wrapped_build_attn_metadata(*args, **kwargs):
+        if kwargs.get("seq_lens_cpu_upper_bound") is None:
+            seq_lens_cpu_upper_bound = getattr(_TLS, "seq_lens_cpu_upper_bound", None)
+            if seq_lens_cpu_upper_bound is not None:
+                kwargs["seq_lens_cpu_upper_bound"] = seq_lens_cpu_upper_bound
+        return original_build_attn_metadata(*args, **kwargs)
+
+    @functools.wraps(original_prepare_attn)
+    def wrapped_prepare_attn(self, input_batch, *args, **kwargs):
+        previous = getattr(_TLS, "seq_lens_cpu_upper_bound", None)
+        _TLS.seq_lens_cpu_upper_bound = getattr(
+            input_batch, "seq_lens_cpu_upper_bound", None
+        )
+        try:
+            return original_prepare_attn(self, input_batch, *args, **kwargs)
+        finally:
+            if previous is None:
+                try:
+                    delattr(_TLS, "seq_lens_cpu_upper_bound")
+                except AttributeError:
+                    pass
+            else:
+                _TLS.seq_lens_cpu_upper_bound = previous
+
+    setattr(wrapped_prepare_attn, "_atom_seq_lens_upper_bound_patched", True)
+    mamba_hybrid.build_attn_metadata = wrapped_build_attn_metadata
+    mamba_hybrid.MambaHybridModelState.prepare_attn = wrapped_prepare_attn
+    logger.info(
+        "ATOM plugin: patched vLLM mamba-hybrid attention metadata to "
+        "forward seq_lens_cpu_upper_bound."
+    )

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -133,6 +133,15 @@ def register_model() -> None:
     # isolation, so extend that allow-list before MTP/Eagle proposal runs.
     apply_vllm_spec_decode_patch()
 
+    # vLLM mamba-hybrid state builds seq_lens_cpu_upper_bound on CPU, but
+    # some versions do not pass it into CommonAttentionMetadata. ATOM MHA
+    # metadata consumes that CPU tensor to avoid a GPU->CPU sync.
+    from atom.plugin.vllm.mamba_hybrid_patch import (
+        apply_mamba_hybrid_seq_lens_patch,
+    )
+
+    apply_mamba_hybrid_seq_lens_patch()
+
     # Patch vLLM graph_capture to also enter aiter's ca_comm.capture(),
     # avoiding hipMemcpyAsync in fused_allreduce_rmsnorm when model uses aiter collectives
     from atom.plugin.vllm.graph_capture_patch import apply_graph_capture_patch


### PR DESCRIPTION
## Motivation

This PR supports model runner v2 on qwen-next, vllm model runner v2 improves the performance on the small model.
