### PR TITLE
[atom-sgl-accuracy] Fix SGLang accuracy result parsing without jq for MI308

### DIFF
--- a/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
@@ -252,7 +252,15 @@ jobs:
           fi
 
           echo "RESULT_FILE: $result_file"
-          flexible_extract_value=$(jq '.results.gsm8k["exact_match,flexible-extract"]' "$result_file")
+          flexible_extract_value=$(python3 - "$result_file" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as f:
+              data = json.load(f)
+          print(data["results"]["gsm8k"]["exact_match,flexible-extract"])
+          PY
+          )
           echo "Flexible extract value: $flexible_extract_value"
           echo "Accuracy test threshold: ${{ matrix.accuracy_test_threshold }}"
 


### PR DESCRIPTION
## Summary

- Replace `jq` usage in the SGLang accuracy result check with Python JSON parsing.
- Avoid `exit 127` failures on MI308 self-hosted runners where `jq` may not be installed.

## Test plan

- Verified the updated workflow YAML has no linter errors.
- Expected behavior: accuracy validation now reads `results.gsm8k["exact_match,flexible-extract"]` via `python3` and continues to compare against the configured threshold.