### PR TITLE
[atom-vllm-benchmark] Add host network to start container

### DIFF
--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -1588,7 +1588,9 @@ jobs:
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
-            --ipc=host --group-add video \
+            --ipc=host \
+            --network=host \
+            --group-add video \
             --privileged \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \


### PR DESCRIPTION
## Motivation

Add --network=host for container to resolve the error as below:
<img width="1212" height="203" alt="image" src="https://github.com/user-attachments/assets/32029e01-30bf-4566-a758-3edca394d59f" />
