### PR TITLE
minimax-m3: support local_argmax_pack kernel

### DIFF
--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -9,8 +9,8 @@ import triton.language as tl
 from aiter.dist.communication_op import tensor_model_parallel_all_gather
 from aiter.dist.parallel_state import get_tp_group
 from aiter.jit.utils.torch_guard import torch_compile_guard
-from aiter.ops.triton.fusions.lm_head_argmax import local_argmax_pack
 
+from atom.model_ops.lm_head_argmax import lm_head_argmax_pack
 from atom.model_ops.utils import atom_parameter
 from atom.plugin import is_plugin_mode
 from atom.utils import envs
@@ -244,7 +244,7 @@ class ParallelLMHead(VocabParallelEmbedding):
             return logits.argmax(dim=-1)
         # Pack (val, idx) as fp32 — idx < 2^24 is exact — and all-gather only the
         # per-rank reductions ([N, 2]) instead of the full logits.
-        packed = local_argmax_pack(logits, self.vocab_start_idx)
+        packed = lm_head_argmax_pack(logits, self.vocab_start_idx)
         gathered = get_tp_group().all_gather(packed, dim=0).view(self.tp_size, -1, 2)
         winner = gathered[:, :, 0].argmax(dim=0)  # [N] winning rank (ties -> lowest)
         token = gathered[:, :, 1].gather(0, winner.unsqueeze(0)).squeeze(0)  # [N] fp32

--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -9,6 +9,7 @@ import triton.language as tl
 from aiter.dist.communication_op import tensor_model_parallel_all_gather
 from aiter.dist.parallel_state import get_tp_group
 from aiter.jit.utils.torch_guard import torch_compile_guard
+from aiter.ops.triton.fusions.lm_head_argmax import local_argmax_pack
 
 from atom.model_ops.utils import atom_parameter
 from atom.plugin import is_plugin_mode
@@ -241,12 +242,10 @@ class ParallelLMHead(VocabParallelEmbedding):
         logits = tgemm.mm(x, self.weight, self.bias)  # [N, vocab/tp]
         if self.tp_size <= 1:
             return logits.argmax(dim=-1)
-        local_max_val, local_idx = logits.max(dim=-1)  # [N], [N]
-        global_idx = local_idx + self.vocab_start_idx  # [N] global token id
         # Pack (val, idx) as fp32 — idx < 2^24 is exact — and all-gather only the
         # per-rank reductions ([N, 2]) instead of the full logits.
-        packed = torch.stack([local_max_val.float(), global_idx.float()], dim=-1)
+        packed = local_argmax_pack(logits, self.vocab_start_idx)
         gathered = get_tp_group().all_gather(packed, dim=0).view(self.tp_size, -1, 2)
         winner = gathered[:, :, 0].argmax(dim=0)  # [N] winning rank (ties -> lowest)
         token = gathered[:, :, 1].gather(0, winner.unsqueeze(0)).squeeze(0)  # [N] fp32
-        return token.to(local_idx.dtype)
+        return token.to(torch.long)

--- a/atom/model_ops/lm_head_argmax.py
+++ b/atom/model_ops/lm_head_argmax.py
@@ -1,0 +1,79 @@
+import torch
+import triton
+import triton.language as tl
+
+from aiter.jit.utils.torch_guard import torch_compile_guard
+
+_MAX_BLOCK_M = 131072
+
+
+@triton.jit
+def _lm_head_argmax_pack_kernel(
+    logits_ptr,
+    packed_ptr,
+    vocab_start_idx,
+    N: tl.constexpr,
+    M: tl.constexpr,
+    stride_logits_n: tl.constexpr,
+    stride_logits_m: tl.constexpr,
+    stride_packed_n: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_M)
+    mask = offs < M
+    vals = tl.load(
+        logits_ptr + row * stride_logits_n + offs * stride_logits_m,
+        mask=mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+
+    max_val = tl.max(vals, axis=0)
+    idxs = offs.to(tl.int64)
+    masked_idxs = tl.where((vals == max_val) & mask, idxs, idxs + BLOCK_M)
+    local_idx = tl.min(masked_idxs, axis=0)
+    global_idx = local_idx + vocab_start_idx
+
+    tl.store(packed_ptr + row * stride_packed_n, max_val)
+    tl.store(packed_ptr + row * stride_packed_n + 1, global_idx.to(tl.float32))
+
+
+def _lm_head_argmax_pack_fake(
+    logits: torch.Tensor,
+    vocab_start_idx: int,
+) -> torch.Tensor:
+    return torch.empty((logits.shape[0], 2), dtype=torch.float32, device=logits.device)
+
+
+@torch_compile_guard(gen_fake=_lm_head_argmax_pack_fake)
+def lm_head_argmax_pack(logits: torch.Tensor, vocab_start_idx: int) -> torch.Tensor:
+    """Reduce local LM-head logits and pack (max_val, global_idx) as fp32."""
+    if logits.dim() != 2:
+        raise ValueError("lm_head_argmax_pack expects a 2-D logits tensor")
+
+    N, M = logits.shape
+    if N == 0:
+        return torch.empty((0, 2), dtype=torch.float32, device=logits.device)
+    if M > _MAX_BLOCK_M:
+        local_max_val, local_idx = logits.max(dim=-1)
+        global_idx = local_idx + vocab_start_idx
+        return torch.stack([local_max_val.float(), global_idx.float()], dim=-1)
+
+    packed = torch.empty((N, 2), dtype=torch.float32, device=logits.device)
+    block_m = triton.next_power_of_2(M)
+    num_warps = 8 if block_m >= 2048 else 4
+
+    _lm_head_argmax_pack_kernel[(N,)](
+        logits,
+        packed,
+        vocab_start_idx,
+        N=N,
+        M=M,
+        stride_logits_n=logits.stride(0),
+        stride_logits_m=logits.stride(1),
+        stride_packed_n=packed.stride(0),
+        BLOCK_M=block_m,
+        num_warps=num_warps,
+        num_stages=2,
+    )
+    return packed

--- a/atom/model_ops/lm_head_argmax.py
+++ b/atom/model_ops/lm_head_argmax.py
@@ -5,6 +5,8 @@ import triton.language as tl
 from aiter.jit.utils.torch_guard import torch_compile_guard
 
 _MAX_BLOCK_M = 131072
+# One program reduces one row, so small row counts underutilize the GPU.
+_MIN_ROWS_FOR_FUSED_ARGMAX = 16
 
 
 @triton.jit
@@ -12,7 +14,6 @@ def _lm_head_argmax_pack_kernel(
     logits_ptr,
     packed_ptr,
     vocab_start_idx,
-    N: tl.constexpr,
     M: tl.constexpr,
     stride_logits_n: tl.constexpr,
     stride_logits_m: tl.constexpr,
@@ -45,6 +46,15 @@ def _lm_head_argmax_pack_fake(
     return torch.empty((logits.shape[0], 2), dtype=torch.float32, device=logits.device)
 
 
+def _torch_lm_head_argmax_pack(
+    logits: torch.Tensor,
+    vocab_start_idx: int,
+) -> torch.Tensor:
+    local_max_val, local_idx = logits.max(dim=-1)
+    global_idx = local_idx + vocab_start_idx
+    return torch.stack([local_max_val.float(), global_idx.float()], dim=-1)
+
+
 @torch_compile_guard(gen_fake=_lm_head_argmax_pack_fake)
 def lm_head_argmax_pack(logits: torch.Tensor, vocab_start_idx: int) -> torch.Tensor:
     """Reduce local LM-head logits and pack (max_val, global_idx) as fp32."""
@@ -54,10 +64,8 @@ def lm_head_argmax_pack(logits: torch.Tensor, vocab_start_idx: int) -> torch.Ten
     N, M = logits.shape
     if N == 0:
         return torch.empty((0, 2), dtype=torch.float32, device=logits.device)
-    if M > _MAX_BLOCK_M:
-        local_max_val, local_idx = logits.max(dim=-1)
-        global_idx = local_idx + vocab_start_idx
-        return torch.stack([local_max_val.float(), global_idx.float()], dim=-1)
+    if N < _MIN_ROWS_FOR_FUSED_ARGMAX or M > _MAX_BLOCK_M:
+        return _torch_lm_head_argmax_pack(logits, vocab_start_idx)
 
     packed = torch.empty((N, 2), dtype=torch.float32, device=logits.device)
     block_m = triton.next_power_of_2(M)
@@ -67,7 +75,6 @@ def lm_head_argmax_pack(logits: torch.Tensor, vocab_start_idx: int) -> torch.Ten
         logits,
         packed,
         vocab_start_idx,
-        N=N,
         M=M,
         stride_logits_n=logits.stride(0),
         stride_logits_m=logits.stride(1),

--- a/tests/test_lm_head_argmax.py
+++ b/tests/test_lm_head_argmax.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+from atom.model_ops.lm_head_argmax import lm_head_argmax_pack
+
+
+def _torch_lm_head_argmax_pack(
+    logits: torch.Tensor,
+    vocab_start_idx: int,
+) -> torch.Tensor:
+    local_max_val, local_idx = logits.max(dim=-1)
+    global_idx = local_idx + vocab_start_idx
+    return torch.stack([local_max_val.float(), global_idx.float()], dim=-1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("shape", [(1, 8), (7, 1024), (16, 8192)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_lm_head_argmax_pack(shape, dtype):
+    torch.manual_seed(0)
+    logits = torch.randn(shape, dtype=dtype, device="cuda")
+    vocab_start_idx = 32000
+
+    expected = _torch_lm_head_argmax_pack(logits, vocab_start_idx)
+    actual = lm_head_argmax_pack(logits, vocab_start_idx)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_lm_head_argmax_pack_tie_breaks_lowest_global_idx():
+    logits = torch.tensor(
+        [[1.0, 3.0, 3.0, 2.0], [5.0, 5.0, 4.0, 5.0]],
+        dtype=torch.float32,
+        device="cuda",
+    )
+    vocab_start_idx = 128
+
+    actual = lm_head_argmax_pack(logits, vocab_start_idx)
+    expected = _torch_lm_head_argmax_pack(logits, vocab_start_idx)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)


### PR DESCRIPTION
## EAGLE3-MXFP8 MCC16 TP4

before

```
============ Serving Benchmark Result ============
Successful requests:                     160       
Benchmark duration (s):                  110.81    
Total input tokens:                      1176661   
Total generated tokens:                  146666    
Request throughput (req/s):              1.44      
Output token throughput (tok/s):         1323.61   
Total Token throughput (tok/s):          11942.56  
---------------Time to First Token----------------
Mean TTFT (ms):                          444.80    
Median TTFT (ms):                        251.79    
P99 TTFT (ms):                           2481.41   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.27     
Median TPOT (ms):                        10.07     
P99 TPOT (ms):                           21.25     
---------------Inter-token Latency----------------
Mean ITL (ms):                           28.02     
Median ITL (ms):                         22.17     
P99 ITL (ms):                            142.14    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          10712.54  
Median E2EL (ms):                        9649.88   
P99 E2EL (ms):                           19700.18  
==================================================
```

after

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9553|±  |0.0057|
|     |       |strict-match    |     5|exact_match|↑  |0.9560|±  |0.0056|
```

```
============ Serving Benchmark Result ============
Successful requests:                     160       
Benchmark duration (s):                  110.45    
Total input tokens:                      1176661   
Total generated tokens:                  146661    
Request throughput (req/s):              1.45      
Output token throughput (tok/s):         1327.88   
Total Token throughput (tok/s):          11981.49  
---------------Time to First Token----------------
Mean TTFT (ms):                          454.20    
Median TTFT (ms):                        252.83    
P99 TTFT (ms):                           2472.35   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.31     
Median TPOT (ms):                        10.12     
P99 TPOT (ms):                           21.22     
---------------Inter-token Latency----------------
Mean ITL (ms):                           27.97     
Median ITL (ms):                         22.18     
P99 ITL (ms):                            142.95    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          10783.63  
Median E2EL (ms):                        9684.85   
P99 E2EL (ms):                           20114.89  
==================================================
```
