### PR TITLE
[atom-sgl-accuracy] Modify sglang accuracy runner for mi355

### DIFF
--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -216,7 +216,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSV32_FP8_TP4",
@@ -225,7 +225,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSV32_FP8_TP4_DP4_EP4",
@@ -234,7 +234,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --data-parallel-size 4 --expert-parallel-size 4 --enable-dp-attention --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nMORI_SHMEM_MODE=ISOLATION\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSV32_FP8_TP8_DP8_EP8",
@@ -243,7 +243,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --data-parallel-size 8 --expert-parallel-size 8 --enable-dp-attention --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nMORI_SHMEM_MODE=ISOLATION\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP8_TP4_ONLINE_QUANT",
@@ -252,7 +252,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"mxfp4\",\"exclude_layer\":[\"model.layers.*.self_attn.*\",\"model.layers.61.*\",\"lm_head\"]}}'",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_KIMI_K26_MXFP4_TP4",
@@ -261,7 +261,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_KIMI_K26_MXFP4_TP8",
@@ -270,7 +270,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_QWEN35_35B_A3B_FP8_TP2",
@@ -279,7 +279,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 2 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.76,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_QWEN35_35B_A3B_TP2",
@@ -288,7 +288,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 2 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.83,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_QWEN35_397B_A17B_FP8_TP4",
@@ -297,7 +297,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 4 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.83,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_QWEN35_397B_A17B_FP8_TP8",
@@ -306,7 +306,7 @@ jobs:
                   "extra_args": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.83,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP8_TP8",
@@ -315,7 +315,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP4",
@@ -324,7 +324,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP4_DP4_EP4",
@@ -333,7 +333,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --expert-parallel-size 4 --data-parallel-size 4 --enable-dp-attention --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nMORI_SHMEM_MODE=ISOLATION\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP8_DP8_EP8",
@@ -342,7 +342,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --expert-parallel-size 8 --data-parallel-size 8 --enable-dp-attention --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nMORI_SHMEM_MODE=ISOLATION\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP8",
@@ -351,7 +351,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP8_MTP3",
@@ -360,7 +360,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache --speculative-draft-model-path SGLang/DeepSeek-R1-NextN --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --max-running-requests 256 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nSGLANG_ENABLE_SPEC_V2=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSR1_FP4_TP8_MTP1",
@@ -369,7 +369,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache --speculative-draft-model-path SGLang/DeepSeek-R1-NextN --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 --max-running-requests 256 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nSGLANG_ENABLE_SPEC_V2=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_DSV32_FP8_TP8",
@@ -378,7 +378,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
               {
                   "toggle_env": "RUN_GLM51_FP8_TP8",
@@ -387,7 +387,7 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models",
-                  "runner": "atom-mi355-8gpu-conductor-sgl-runner",
+                  "runner": "atom-plugin-acc-validation-runner",
               },
           ]
 

--- a/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
@@ -219,7 +219,9 @@ jobs:
           MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
           echo "Using model cache backend: ${MODEL_CACHE_DESC}"
 
-          printf '%s\n' "${{ matrix.model.env_vars }}" | sed 's/^[[:space:]]*//' > /tmp/oot_env_file.txt
+          OOT_ENV_FILE="${RUNNER_TEMP:-${GITHUB_WORKSPACE:-$PWD}}/oot_env_file.txt"
+          mkdir -p "$(dirname "${OOT_ENV_FILE}")"
+          printf '%s\n' "${{ matrix.model.env_vars }}" | sed 's/^[[:space:]]*//' > "${OOT_ENV_FILE}"
           CASE_KEY="${ISL}x${OSL}"
           CASE_ENV_VARS="$(
             CASE_ENV_VARS_BY_PAIR="${CASE_ENV_VARS_BY_PAIR:-null}" CASE_KEY="${CASE_KEY}" python3 - <<'PY'
@@ -238,7 +240,7 @@ jobs:
           PY
           )"
           if [[ -n "${CASE_ENV_VARS}" ]]; then
-            printf '%s\n' "${CASE_ENV_VARS}" >> /tmp/oot_env_file.txt
+            printf '%s\n' "${CASE_ENV_VARS}" >> "${OOT_ENV_FILE}"
           fi
 
           # Podman + crun: avoid "create keyring ... Disk quota exceeded" (kernel user-keyring
@@ -275,7 +277,7 @@ jobs:
             --security-opt seccomp=unconfined \
             --ulimit memlock=-1 \
             --ulimit stack=67108864 \
-            --env-file /tmp/oot_env_file.txt \
+            --env-file "${OOT_ENV_FILE}" \
             -e HF_TOKEN="${HF_TOKEN:-}" \
             --name "$CONTAINER_NAME" \
             --entrypoint /bin/bash \

--- a/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
@@ -197,6 +197,9 @@ jobs:
           elif [ -d "/data/models" ]; then
             MODEL_CACHE_MOUNT="-v /data/models:/models"
             MODEL_CACHE_DESC="/data/models (shared host path)"
+          elif [ -d "/mnt/raid0/pretrained_model" ]; then
+            MODEL_CACHE_MOUNT="-v /mnt/raid0/pretrained_model:/models"
+            MODEL_CACHE_DESC="/mnt/raid0/pretrained_model (shared host path)"
           else
             echo "No shared host model cache found; using container-local /models."
           fi


### PR DESCRIPTION
## Motivation
Modify sglang accuracy runner for mi355 from "atom-mi355-8gpu-conductor-sgl-runner" to "atom-plugin-acc-validation-runner", with the same as atom vllm benchmark.
