### PR TITLE
add m3 mxfp8 support

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -266,6 +266,48 @@ def gemm_a8w8_blockscale_preshuffle_impl(
     return y
 
 
+def _is_fp8_dtype(dtype: torch.dtype) -> bool:
+    fp8_dtypes = {
+        d
+        for d in (
+            getattr(torch, "float8_e4m3fn", None),
+            getattr(torch, "float8_e4m3fnuz", None),
+            getattr(torch, "float8_e5m2", None),
+            getattr(torch, "float8_e5m2fnuz", None),
+            dtypes.fp8,
+        )
+        if d is not None
+    }
+    return dtype in fp8_dtypes
+
+
+def _dequantize_fp8_1x32_weight(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Materialize MXFP8 1x32 weights for the BF16 dense-GEMM fallback."""
+    if weight_scale is None:
+        raise RuntimeError("per_1x32 fp8 GEMM fallback requires weight_scale")
+    scale = weight_scale.contiguous()
+    # MiniMax-M3 stores MXFP8 scales as e8m0 bytes. Reinterpret uint8 storage
+    # before converting to the fallback compute dtype.
+    if scale.dtype == torch.uint8:
+        scale = scale.view(dtypes.fp8_e8m0)
+    if weight.shape[-1] % 32 == 0:
+        return (
+            (
+                weight.to(dtype).view(*weight.shape[:-1], weight.shape[-1] // 32, 32)
+                * scale.to(dtype).unsqueeze(-1)
+            )
+            .reshape_as(weight)
+            .contiguous()
+        )
+    scale = scale.to(dtype).repeat_interleave(32, dim=-1)
+    scale = scale[..., : weight.shape[-1]]
+    return (weight.to(dtype) * scale).contiguous()
+
+
 class LinearBase(nn.Module):
     def __init__(
         self,
@@ -553,6 +595,20 @@ class LinearBase(nn.Module):
             self.weight.data, self.weight_scale.data, _ = normalize_e4m3fn_to_e4m3fnuz(
                 self.weight.data, self.weight_scale.data
             )
+        if self.quant_type == QuantType.per_1x32 and _is_fp8_dtype(self.params_dtype):
+            fallback_dtype = get_current_atom_config().torch_dtype
+            self.weight = atom_parameter(
+                _dequantize_fp8_1x32_weight(
+                    self.weight.data,
+                    self.weight_scale.data,
+                    fallback_dtype,
+                )
+            )
+            self.register_parameter("weight_scale", None)
+            self.quant_type = QuantType.No
+            self.params_dtype = fallback_dtype
+            self.quant_func = get_hip_quant(QuantType.No)
+            return
         if (
             self.source_quant_dtype == torch.bfloat16
             and self.quant_type == QuantType.per_1x32

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1776,8 +1776,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
+        self.num_experts = num_experts
         # TODO hard code for now
         params_dtype = torch.float8_e4m3fn
+        intermediate_size_for_weight = intermediate_size_per_partition
 
         if self.block_quant:
             if self.quant_type == QuantType.per_1x128:
@@ -1804,28 +1806,42 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     f"{intermediate_size_per_partition} is not divisible by "
                     f"weight quantization block_k = {block_k}."
                 )
+            if self.quant_type == QuantType.per_1x32:
+                # aiter's GU-interleaved MXFP8 scale shuffle packs 8 scale
+                # columns, i.e. 256 weight columns for 1x32 scales. TP8 on
+                # MiniMax-M3 has local intermediate=384, so pad to 512.
+                scale_pack_k = block_k * 8
+                intermediate_size_for_weight = (
+                    (intermediate_size_per_partition + scale_pack_k - 1)
+                    // scale_pack_k
+                    * scale_pack_k
+                )
 
         # WEIGHTS
         w13_weight = atom_parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                2 * intermediate_size_for_weight,
                 hidden_size,
                 dtype=params_dtype,
             )
         )
         layer.register_parameter("w13_weight", w13_weight)
+        if self.quant_type == QuantType.per_1x32:
+            w13_weight.data.view(torch.uint8).zero_()
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w2_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 hidden_size,
-                intermediate_size_per_partition,
+                intermediate_size_for_weight,
                 dtype=params_dtype,
             )
         )
         layer.register_parameter("w2_weight", w2_weight)
+        if self.quant_type == QuantType.per_1x32:
+            w2_weight.data.view(torch.uint8).zero_()
         set_weight_attrs(w2_weight, extra_weight_attrs)
 
         # WEIGHT_SCALES
@@ -1835,7 +1851,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             w13_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    2 * intermediate_size_for_weight,
                     dtype=torch.float32,
                 )
             )
@@ -1847,20 +1863,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         elif self.block_quant:
             scale_shape_w13 = (
                 num_experts,
-                2 * ((intermediate_size_per_partition + block_n - 1) // block_n),
+                2 * ((intermediate_size_for_weight + block_n - 1) // block_n),
                 (hidden_size + block_k - 1) // block_k,
             )
             scale_shape_w2 = (
                 num_experts,
                 (hidden_size + block_n - 1) // block_n,
-                (intermediate_size_per_partition + block_k - 1) // block_k,
+                (intermediate_size_for_weight + block_k - 1) // block_k,
             )
-            w13_weight_scale = atom_parameter(
-                torch.ones(scale_shape_w13, dtype=torch.float32)
-            )
-            w2_weight_scale = atom_parameter(
-                torch.ones(scale_shape_w2, dtype=torch.float32)
-            )
+            # MXFP8 checkpoints store 1x32 scales as e8m0 bytes. Keep the
+            # existing float32 initialization for the original 1x128 path.
+            if self.quant_type == QuantType.per_1x32:
+                w13_scale_data = torch.empty(scale_shape_w13, dtype=dtypes.fp8_e8m0)
+                w2_scale_data = torch.empty(scale_shape_w2, dtype=dtypes.fp8_e8m0)
+                w13_scale_data.view(torch.uint8).zero_()
+                w2_scale_data.view(torch.uint8).zero_()
+            else:
+                w13_scale_data = torch.ones(scale_shape_w13, dtype=torch.float32)
+                w2_scale_data = torch.ones(scale_shape_w2, dtype=torch.float32)
+            w13_weight_scale = atom_parameter(w13_scale_data)
+            w2_weight_scale = atom_parameter(w2_scale_data)
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
             assert self.quant_config.is_dynamic
@@ -1930,6 +1952,47 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w13_weight_scale = atom_parameter(layer.w13_weight_scale.data)
             layer.w2_weight = atom_parameter(layer.w2_weight.data)
             layer.w2_weight_scale = atom_parameter(layer.w2_weight_scale.data)
+
+        if self.quant_type == QuantType.per_1x32:
+            # aiter's MXFP8 MoE kernels consume the same gate/up interleaved
+            # layout used by their 1x32 shuffle helpers. Keep this branch
+            # isolated so the existing 1x128 FP8 path still uses shuffle_weights.
+            layer.w13_weight.data = shuffle_weight(
+                layer.w13_weight,
+                is_guinterleave=True,
+                gate_up=True,
+            )
+            layer.w2_weight.data = shuffle_weight(
+                layer.w2_weight,
+                is_guinterleave=True,
+                gate_up=False,
+            )
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
+
+            w13_scale_2d = layer.w13_weight_scale.reshape(
+                -1, layer.w13_weight_scale.shape[-1]
+            )
+            w2_scale_2d = layer.w2_weight_scale.reshape(
+                -1, layer.w2_weight_scale.shape[-1]
+            )
+            layer.w13_weight_scale = atom_parameter(
+                moe_shuffle_scale(
+                    w13_scale_2d,
+                    self.num_experts,
+                    is_guinterleave=True,
+                    gate_up=True,
+                )
+            )
+            layer.w2_weight_scale = atom_parameter(
+                moe_shuffle_scale(
+                    w2_scale_2d,
+                    self.num_experts,
+                    is_guinterleave=True,
+                    gate_up=False,
+                )
+            )
+            return
 
         shuffle_weights(layer.w13_weight, layer.w2_weight)
 
@@ -2057,7 +2120,17 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             num_fused_shared_experts=layer.num_fused_shared_experts,
             routed_scaling_factor=layer.routed_scaling_factor,
         )
-        moe_extra_args = {"swiglu_limit": getattr(layer, "swiglu_limit", 0.0)}
+        # Match the 1x32 preshuffled layout above; other FP8 quant modes keep
+        # the historical separated gate/up layout.
+        gate_mode = (
+            GateMode.INTERLEAVE.value
+            if self.quant_type == QuantType.per_1x32
+            else GateMode.SEPARATED.value
+        )
+        moe_extra_args = {
+            "gate_mode": gate_mode,
+            "swiglu_limit": getattr(layer, "swiglu_limit", 0.0),
+        }
         if self.quant_type == QuantType.per_Tensor or self.fused_experts is None:
             return torch.ops.aiter.rocm_aiter_fused_moe(
                 x,

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -372,6 +372,27 @@ class GenericParser(QuantConfigParser):
         return torch.bfloat16
 
     def _infer_qtype(self, cfg: dict, config_str: str) -> QuantType:
+        # Prefer explicit HF/compressed-tensors block size over text heuristics
+        # so MXFP8 1x32 and blockscale 1x128/128x128 are not conflated.
+        if "weight_block_size" in cfg:
+            wbs = cfg.get("weight_block_size")
+            if wbs is None:
+                return QuantType.per_Tensor
+            if isinstance(wbs, (list, tuple)) and len(wbs) >= 2:
+                try:
+                    m, n = int(wbs[0]), int(wbs[1])
+                except (TypeError, ValueError):
+                    m = n = None
+                if (m, n) == (1, 128):
+                    return QuantType.per_1x128
+                if (m, n) == (128, 128):
+                    # per_128x128 enum has no consumers in linear.py / GEMM dispatch yet;
+                    # the per_1x128 path already allocates a (out//128, in//128)
+                    # scale grid which is exactly the (128, 128) block layout.
+                    return QuantType.per_1x128
+                if (m, n) == (1, 32):
+                    return QuantType.per_1x32
+                return QuantType.per_1x128
         # Check explicit fields
         for key in ("quant_type", "quantization_type", "scheme"):
             val = cfg.get(key)
@@ -393,24 +414,6 @@ class GenericParser(QuantConfigParser):
                         mapped = _QSCHEME_TO_QUANT_TYPE.get(f"per_{strategy}")
                     if mapped is not None:
                         return mapped
-        # Honor weight_block_size explicitly: a present-but-null value (Mistral
-        # FP8 native checkpoints) means per-tensor, not blockwise.
-        if "weight_block_size" in cfg:
-            wbs = cfg.get("weight_block_size")
-            if wbs is None:
-                return QuantType.per_Tensor
-            if isinstance(wbs, (list, tuple)) and len(wbs) >= 2:
-                m, n = int(wbs[0]), int(wbs[1])
-                if (m, n) == (1, 128):
-                    return QuantType.per_1x128
-                if (m, n) == (128, 128):
-                    # per_128x128 enum has no consumers in linear.py / GEMM dispatch yet;
-                    # the per_1x128 path already allocates a (out//128, in//128)
-                    # scale grid which is exactly the (128, 128) block layout.
-                    return QuantType.per_1x128
-                if (m, n) == (1, 32):
-                    return QuantType.per_1x32
-                return QuantType.per_1x128
         # Fall back to regex heuristics on full config string
         for pattern, qtype in self._QTYPE_PATTERNS.items():
             if re.search(pattern, config_str):

--- a/recipes/MiniMax-M3.md
+++ b/recipes/MiniMax-M3.md
@@ -1,7 +1,6 @@
 # MiniMax-M3 MXFP4 Usage Guide
 
-[MiniMax-M3-MXFP4](https://huggingface.co/amd/MiniMax-M3-MXFP4) is supported by
-the native ATOM OpenAI-compatible server path.
+[MiniMax-M3-MXFP4](https://huggingface.co/amd/MiniMax-M3-MXFP4) and [MiniMax-M3-MXFP8](https://huggingface.co/MiniMaxAI/MiniMax-M3-MXFP8) are supported by the native ATOM OpenAI-compatible server path.
 
 ## Preparing Environment
 
@@ -11,9 +10,13 @@ Pull the latest development image:
 docker pull rocm/atom-dev:latest
 ```
 
-## MXFP4 on 4xMI355 GPUs
+## MXFP4/MXFP8 on 4xMI355 GPUs
 
 ### Launching Server
+
+MXFP4 and MXFP8 use the same launch path.  Set
+`model_path=MiniMaxAI/MiniMax-M3-MXFP8 run_name=m3-mxfp8` to run the MXFP8
+checkpoint.
 
 ```bash
 model_path=${model_path:-amd/MiniMax-M3-MXFP4}
@@ -63,6 +66,16 @@ local-chat-completions ({'model': 'amd/MiniMax-M3-MXFP4', 'base_url': 'http://12
 |     |       |strict-match    |     5|exact_match|↑  |0.9371|±  |0.0067|
 ```
 
+Validated MXFP8 GSM8K result:
+
+```text
+local-chat-completions ({'model': 'MiniMaxAI/MiniMax-M3-MXFP8', 'base_url': 'http://127.0.0.1:8000/v1/chat/completions', 'num_concurrent': 32, 'max_gen_toks': 16384}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 65
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9469|±  |0.0062|
+|     |       |strict-match    |     5|exact_match|↑  |0.9477|±  |0.0061|
+```
+
 ### Serving Benchmark
 
 The following script can be used to benchmark online serving throughput and
@@ -99,3 +112,13 @@ Reference MXFP4 results from the validated run on 4xMI355 GPUs:
 | 16 | 160 | 114.35 | 383.04 | 2200.03 | 11.73 | 12.84 | 1280.47 | 11555.95 |
 | 32 | 320 | 163.86 | 512.32 | 4477.16 | 16.74 | 19.12 | 1807.32 | 16161.65 |
 | 64 | 640 | 242.49 | 831.98 | 8566.28 | 25.00 | 29.83 | 2432.75 | 21928.25 |
+
+Reference MXFP8 results from the validated run on 4xMI355 GPUs:
+
+| CONC | Requests | Duration (s) | Mean TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | P99 TPOT (ms) | Output tok/s | Total tok/s |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 4 | 40 | 82.00 | 268.02 | 564.13 | 8.43 | 8.66 | 448.82 | 4034.60 |
+| 8 | 80 | 103.52 | 323.33 | 1284.59 | 10.67 | 11.31 | 715.51 | 6364.77 |
+| 16 | 160 | 143.25 | 414.95 | 2411.41 | 14.80 | 16.44 | 1022.17 | 9224.81 |
+| 32 | 320 | 208.34 | 565.02 | 4936.02 | 21.42 | 24.16 | 1421.47 | 12711.25 |
+| 64 | 640 | 305.81 | 893.93 | 9610.43 | 31.69 | 37.31 | 1929.04 | 17387.94 |


### PR DESCRIPTION
## Motivation

Enable minimax-m3 mxfp8 path。

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
```
export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3}"
# unset HIP_VISIBLE_DEVICES
# unset ROCR_VISIBLE_DEVICES
# export ATOM_PROFILER_MORE=1
export ATOM_FORCE_ATTN_TRITON=1
export AITER_QUICK_REDUCE_QUANTIZATION=INT4

python -m atom.entrypoints.openai_server \
  --model /shared/data/amd_int/models/MiniMax-M3-MXFP8 \
  --tensor-parallel-size 4 \
  --server-port 8005 \
  --trust-remote-code \
  --gpu-memory-utilization 0.8 \
  --block-size 128 \
  --max-model-len 32768 \
  --max-num-seqs 128 \
  --max-num-batched-tokens 32768 2>&1 | tee m3-mxfp4-server.log
```
```

served_model="${served_model:-/shared/data/amd_int/models/MiniMax-M3-MXFP8}"

model_path="${served_model}"
BS=65

lm_eval \
  --model local-chat-completions \
  --model_args "model=$model_path,base_url=http://127.0.0.1:8005/v1/chat/completions,num_concurrent=32,max_gen_toks=16384" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size "${BS}" \
  --apply_chat_template \
  --fewshot_as_multiturn 2>&1 | tee m3-mxfp4-bs65-accuracy.log
```

## Test Result

<img width="2385" height="233" alt="image" src="https://github.com/user-attachments/assets/39a9d49b-8057-4827-b8a7-ffc41335d545" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
