### PR TITLE
Make profile stop timeout configurable with ATOM_PROFILER_TIMEOUT

### DIFF
--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -13,6 +13,7 @@ from atom.model_engine.engine_core_mgr import CoreManager
 from atom.model_engine.multimodal import get_mrope_input_positions
 from atom.model_engine.sequence import Sequence
 from atom.sampling_params import SamplingParams
+from atom.utils import envs
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
 logger = logging.getLogger("atom")
@@ -211,7 +212,9 @@ class LLMEngine:
         logger.info("Profiling started")
 
     def stop_profile(self) -> List[Dict[str, Any]]:
-        responses = self.core_mgr.broadcast_utility_command_sync("stop_profile")
+        responses = self.core_mgr.broadcast_utility_command_sync(
+            "stop_profile", timeout=envs.ATOM_PROFILER_TIMEOUT
+        )
         return [resp.get("result", {}) for resp in responses]
 
     def print_mtp_statistics(self):

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -85,6 +85,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # --- Profiling & Logging ---
     "ATOM_TORCH_PROFILER_DIR": lambda: os.getenv("ATOM_TORCH_PROFILER_DIR", None),
     "ATOM_PROFILER_MORE": lambda: os.getenv("ATOM_PROFILER_MORE", "0") == "1",
+    "ATOM_PROFILER_TIMEOUT": lambda: float(os.getenv("ATOM_PROFILER_TIMEOUT", "300")),
     "ATOM_LOG_MORE": lambda: int(os.getenv("ATOM_LOG_MORE", "0")) != 0,
     # RTL (rocm-trace-lite) GPU kernel tracing — set to output directory to enable.
     # When set, the server launch is wrapped with `rtl trace` to collect per-kernel

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -361,6 +361,7 @@ the programmatic API.
 | `--torch-profiler-dir <dir>` | CLI arg to set the trace output directory |
 | `ATOM_TORCH_PROFILER_DIR` env var | Sets the default `torch_profiler_dir` in `Config` |
 | `ATOM_PROFILER_MORE=1` env var | Enables detailed profiling: `record_shapes`, `with_stack`, `profile_memory` |
+| `ATOM_PROFILER_TIMEOUT=<seconds>` env var | Overrides the `stop_profile` timeout; default is 300 seconds |
 
 When a profiler directory is configured, each worker saves traces to a
 rank-specific subdirectory:
@@ -387,6 +388,7 @@ curl -s -S -X POST http://127.0.0.1:8000/stop_profile
 
 The server must be started with `--torch-profiler-dir` or with
 `ATOM_TORCH_PROFILER_DIR` set for these endpoints to produce traces.
+For large traces, set `ATOM_PROFILER_TIMEOUT` higher before starting the server.
 
 ### 5.3 Programmatic Profiling
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -21,6 +21,7 @@ _ATOM_ENV_VARS = [
     "ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_SILU_MUL_QUANT",
     "ATOM_TORCH_PROFILER_DIR",
     "ATOM_PROFILER_MORE",
+    "ATOM_PROFILER_TIMEOUT",
     "ATOM_LOG_MORE",
     "ATOM_DISABLE_MMAP",
     "ATOM_DISABLE_VLLM_PLUGIN",
@@ -73,6 +74,9 @@ class TestEnvsDefaults:
     def test_profiler_more_default(self):
         assert _get_envs().ATOM_PROFILER_MORE is False
 
+    def test_profiler_timeout_default(self):
+        assert _get_envs().ATOM_PROFILER_TIMEOUT == 300.0
+
     def test_log_more_default(self):
         assert _get_envs().ATOM_LOG_MORE is False
 
@@ -111,6 +115,10 @@ class TestEnvsOverrides:
     def test_profiler_more_enabled(self, monkeypatch):
         monkeypatch.setenv("ATOM_PROFILER_MORE", "1")
         assert _get_envs().ATOM_PROFILER_MORE is True
+
+    def test_profiler_timeout_override(self, monkeypatch):
+        monkeypatch.setenv("ATOM_PROFILER_TIMEOUT", "900")
+        assert _get_envs().ATOM_PROFILER_TIMEOUT == 900.0
 
     def test_log_more_enabled(self, monkeypatch):
         monkeypatch.setenv("ATOM_LOG_MORE", "1")


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Large profile dumps can take longer than the existing 300s `stop_profile` timeout, causing the request to fail before traces finish flushing.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Adds `ATOM_PROFILER_TIMEOUT` to override the `stop_profile` utility command timeout while preserving the existing 300s default. The override is scoped to `LLMEngine.stop_profile()` and documented in the serving benchmarking guide.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ran focused env-var tests and syntax checks for the changed files.

## Test Result

<!-- Briefly summarize test outcomes. -->
- `python3 -m py_compile atom/model_engine/llm_engine.py atom/utils/envs.py tests/test_envs.py`
- `python -m pytest tests/test_envs.py -k profiler_timeout`
Result: `2 passed, 29 deselected`.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
