### PR TITLE
add m3 mxfp8 support

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -309,6 +309,7 @@ class QuantizationConfig:
             "",
             "fp8",
             "mxfp4",
+            "mxfp8",
         ]:
             self.online_quant = True
             online_parser = get_quant_parser("online_quant")

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -32,7 +32,7 @@ from atom.model_ops.utils import (
 )
 from atom.utils import envs
 from atom.utils.decorators import mark_trace
-from atom.quantization.quark.utils import weight_dequant_fp8
+from atom.quantization.quark.utils import weight_dequant_fp8, weight_dequant_mxfp8
 from torch import nn
 
 logger = logging.getLogger("atom")
@@ -456,6 +456,14 @@ class LinearBase(nn.Module):
         """Gather sharded weight from all TP ranks to reconstruct the full unpartitioned weight."""
         if self.tp_size <= 1 or self.tp_dim is None:
             return weight
+        # NCCL cannot all_gather E8M0 scales (MXFP8 source); gather the raw
+        # bytes as uint8 and reinterpret afterwards. The gather only moves
+        # bytes, so this is bit-exact.
+        if weight.dtype == dtypes.fp8_e8m0:
+            gathered = get_tp_group().all_gather(
+                weight.view(torch.uint8), dim=self.tp_dim
+            )
+            return gathered.view(dtypes.fp8_e8m0)
         return get_tp_group().all_gather(weight, dim=self.tp_dim)
 
     def _shard_quantized_weight(self, q_weight, weight_scale):
@@ -508,7 +516,11 @@ class LinearBase(nn.Module):
             f"Unsupported online quant: "
             f"dtype={online_quant_dtype}, type={online_quant_type}"
         )
-        assert self.quant_type in [QuantType.No, QuantType.per_1x128], (
+        assert self.quant_type in [
+            QuantType.No,
+            QuantType.per_1x128,
+            QuantType.per_1x32,
+        ], (
             f"Unsupported source quant_type for online quantization: "
             f"{self.quant_type} (layer={self.prefix})"
         )
@@ -546,6 +558,9 @@ class LinearBase(nn.Module):
         if self.quant_type == QuantType.per_1x128:
             # dequant per block fp8
             weight = weight_dequant_fp8(weight, weight_scale)
+        elif self.quant_type == QuantType.per_1x32:
+            # dequant MXFP8 (FP8 elements + 1x32 E8M0 shared scale)
+            weight = weight_dequant_mxfp8(weight, weight_scale)
         q_weight, weight_scale = online_quant_func(
             weight, quant_dtype=online_quant_dtype
         )

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -266,48 +266,6 @@ def gemm_a8w8_blockscale_preshuffle_impl(
     return y
 
 
-def _is_fp8_dtype(dtype: torch.dtype) -> bool:
-    fp8_dtypes = {
-        d
-        for d in (
-            getattr(torch, "float8_e4m3fn", None),
-            getattr(torch, "float8_e4m3fnuz", None),
-            getattr(torch, "float8_e5m2", None),
-            getattr(torch, "float8_e5m2fnuz", None),
-            dtypes.fp8,
-        )
-        if d is not None
-    }
-    return dtype in fp8_dtypes
-
-
-def _dequantize_fp8_1x32_weight(
-    weight: torch.Tensor,
-    weight_scale: torch.Tensor,
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    """Materialize MXFP8 1x32 weights for the BF16 dense-GEMM fallback."""
-    if weight_scale is None:
-        raise RuntimeError("per_1x32 fp8 GEMM fallback requires weight_scale")
-    scale = weight_scale.contiguous()
-    # MiniMax-M3 stores MXFP8 scales as e8m0 bytes. Reinterpret uint8 storage
-    # before converting to the fallback compute dtype.
-    if scale.dtype == torch.uint8:
-        scale = scale.view(dtypes.fp8_e8m0)
-    if weight.shape[-1] % 32 == 0:
-        return (
-            (
-                weight.to(dtype).view(*weight.shape[:-1], weight.shape[-1] // 32, 32)
-                * scale.to(dtype).unsqueeze(-1)
-            )
-            .reshape_as(weight)
-            .contiguous()
-        )
-    scale = scale.to(dtype).repeat_interleave(32, dim=-1)
-    scale = scale[..., : weight.shape[-1]]
-    return (weight.to(dtype) * scale).contiguous()
-
-
 class LinearBase(nn.Module):
     def __init__(
         self,
@@ -610,20 +568,6 @@ class LinearBase(nn.Module):
             self.weight.data, self.weight_scale.data, _ = normalize_e4m3fn_to_e4m3fnuz(
                 self.weight.data, self.weight_scale.data
             )
-        if self.quant_type == QuantType.per_1x32 and _is_fp8_dtype(self.params_dtype):
-            fallback_dtype = get_current_atom_config().torch_dtype
-            self.weight = atom_parameter(
-                _dequantize_fp8_1x32_weight(
-                    self.weight.data,
-                    self.weight_scale.data,
-                    fallback_dtype,
-                )
-            )
-            self.register_parameter("weight_scale", None)
-            self.quant_type = QuantType.No
-            self.params_dtype = fallback_dtype
-            self.quant_func = get_hip_quant(QuantType.No)
-            return
         if (
             self.source_quant_dtype == torch.bfloat16
             and self.quant_type == QuantType.per_1x32

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -266,6 +266,48 @@ def gemm_a8w8_blockscale_preshuffle_impl(
     return y
 
 
+def _is_fp8_dtype(dtype: torch.dtype) -> bool:
+    fp8_dtypes = {
+        d
+        for d in (
+            getattr(torch, "float8_e4m3fn", None),
+            getattr(torch, "float8_e4m3fnuz", None),
+            getattr(torch, "float8_e5m2", None),
+            getattr(torch, "float8_e5m2fnuz", None),
+            dtypes.fp8,
+        )
+        if d is not None
+    }
+    return dtype in fp8_dtypes
+
+
+def _dequantize_fp8_1x32_weight(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Materialize MXFP8 1x32 weights for the BF16 dense-GEMM fallback."""
+    if weight_scale is None:
+        raise RuntimeError("per_1x32 fp8 GEMM fallback requires weight_scale")
+    scale = weight_scale.contiguous()
+    # MiniMax-M3 stores MXFP8 scales as e8m0 bytes. Reinterpret uint8 storage
+    # before converting to the fallback compute dtype.
+    if scale.dtype == torch.uint8:
+        scale = scale.view(dtypes.fp8_e8m0)
+    if weight.shape[-1] % 32 == 0:
+        return (
+            (
+                weight.to(dtype).view(*weight.shape[:-1], weight.shape[-1] // 32, 32)
+                * scale.to(dtype).unsqueeze(-1)
+            )
+            .reshape_as(weight)
+            .contiguous()
+        )
+    scale = scale.to(dtype).repeat_interleave(32, dim=-1)
+    scale = scale[..., : weight.shape[-1]]
+    return (weight.to(dtype) * scale).contiguous()
+
+
 class LinearBase(nn.Module):
     def __init__(
         self,
@@ -553,6 +595,20 @@ class LinearBase(nn.Module):
             self.weight.data, self.weight_scale.data, _ = normalize_e4m3fn_to_e4m3fnuz(
                 self.weight.data, self.weight_scale.data
             )
+        if self.quant_type == QuantType.per_1x32 and _is_fp8_dtype(self.params_dtype):
+            fallback_dtype = get_current_atom_config().torch_dtype
+            self.weight = atom_parameter(
+                _dequantize_fp8_1x32_weight(
+                    self.weight.data,
+                    self.weight_scale.data,
+                    fallback_dtype,
+                )
+            )
+            self.register_parameter("weight_scale", None)
+            self.quant_type = QuantType.No
+            self.params_dtype = fallback_dtype
+            self.quant_func = get_hip_quant(QuantType.No)
+            return
         if (
             self.source_quant_dtype == torch.bfloat16
             and self.quant_type == QuantType.per_1x32

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -52,7 +52,7 @@ from atom.model_ops.utils import (
 )
 from atom.plugin.vllm.moe import FusedMoEDecoratorForPluginMode
 from atom.quant_spec import LayerQuantConfig, should_skip_online_quant
-from atom.quantization.quark.utils import weight_dequant_fp8
+from atom.quantization.quark.utils import weight_dequant_fp8, weight_dequant_mxfp8
 from atom.utils import envs
 from atom.utils.custom_register import direct_register_custom_op
 from atom.utils.decorators import mark_trace
@@ -2511,11 +2511,24 @@ class FusedMoE(torch.nn.Module):
             return
 
         quant_func = get_hip_quant(online_quant_type)
-        assert source_quant_type in (QuantType.No, QuantType.per_1x128), (
+        assert source_quant_type in (
+            QuantType.No,
+            QuantType.per_1x128,
+            QuantType.per_1x32,
+        ), (
             f"Unsupported source quant_type for MoE online quantization: "
             f"{source_quant_type} (layer={self.layer_name})"
         )
-        need_dequant = source_quant_type == QuantType.per_1x128
+        need_dequant = source_quant_type in (
+            QuantType.per_1x128,
+            QuantType.per_1x32,
+        )
+
+        def _dequant_func(w: torch.Tensor, sc: torch.Tensor) -> torch.Tensor:
+            # per_1x128 -> deepseek-style square-block FP8; per_1x32 -> MXFP8.
+            if source_quant_type == QuantType.per_1x32:
+                return weight_dequant_mxfp8(w.contiguous(), sc.contiguous())
+            return weight_dequant_fp8(w.contiguous(), sc.contiguous())
 
         # Determine whether each weight needs all_gather to match offline quantization.
         # w13 (column parallel): (E, (2*intermediate/tp, hidden)) — TP dim 0
@@ -2572,13 +2585,13 @@ class FusedMoE(torch.nn.Module):
             if need_dequant:
                 w13_scale = old_w13_scale[expert_id]
                 s1_size = w13_scale.shape[0] // 2
-                w1_bf16 = weight_dequant_fp8(
-                    w13_local[:w1_size].contiguous(),
-                    w13_scale[:s1_size].contiguous(),
+                w1_bf16 = _dequant_func(
+                    w13_local[:w1_size],
+                    w13_scale[:s1_size],
                 )
-                w3_bf16 = weight_dequant_fp8(
-                    w13_local[w1_size:].contiguous(),
-                    w13_scale[s1_size:].contiguous(),
+                w3_bf16 = _dequant_func(
+                    w13_local[w1_size:],
+                    w13_scale[s1_size:],
                 )
             else:
                 w1_bf16 = w13_local[:w1_size]
@@ -2615,9 +2628,9 @@ class FusedMoE(torch.nn.Module):
             # w2 ptpc_fp8 [e, m, n]->[e, m, n//tp]->[e, m, 1]
             w2_local = old_w2_data[expert_id]
             if need_dequant:
-                w2_local = weight_dequant_fp8(
-                    w2_local.contiguous(),
-                    old_w2_scale[expert_id].contiguous(),
+                w2_local = _dequant_func(
+                    w2_local,
+                    old_w2_scale[expert_id],
                 )
             if need_gather_w2:
                 w2_full = tp_group.all_gather(w2_local, dim=1)

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1395,9 +1395,6 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
         layer.hidden_size = hidden_size
         layer.intermediate_size_per_partition = intermediate_size_per_partition
 
-        # Override to FP8 dtype
-        params_dtype = torch.float8_e4m3fn
-
         # Check block alignment for block quantization
         if self.block_quant:
             tp_size = get_tp_group().world_size
@@ -1777,8 +1774,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         **extra_weight_attrs,
     ):
         self.num_experts = num_experts
-        # TODO hard code for now
-        params_dtype = torch.float8_e4m3fn
         intermediate_size_for_weight = intermediate_size_per_partition
 
         if self.block_quant:

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1776,8 +1776,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
+        self.num_experts = num_experts
         # TODO hard code for now
         params_dtype = torch.float8_e4m3fn
+        intermediate_size_for_weight = intermediate_size_per_partition
 
         if self.block_quant:
             if self.quant_type == QuantType.per_1x128:
@@ -1804,28 +1806,42 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     f"{intermediate_size_per_partition} is not divisible by "
                     f"weight quantization block_k = {block_k}."
                 )
+            if self.quant_type == QuantType.per_1x32:
+                # aiter's GU-interleaved MXFP8 scale shuffle packs 8 scale
+                # columns, i.e. 256 weight columns for 1x32 scales. TP8 on
+                # MiniMax-M3 has local intermediate=384, so pad to 512.
+                scale_pack_k = block_k * 8
+                intermediate_size_for_weight = (
+                    (intermediate_size_per_partition + scale_pack_k - 1)
+                    // scale_pack_k
+                    * scale_pack_k
+                )
 
         # WEIGHTS
         w13_weight = atom_parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                2 * intermediate_size_for_weight,
                 hidden_size,
                 dtype=params_dtype,
             )
         )
         layer.register_parameter("w13_weight", w13_weight)
+        if self.quant_type == QuantType.per_1x32:
+            w13_weight.data.view(torch.uint8).zero_()
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w2_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 hidden_size,
-                intermediate_size_per_partition,
+                intermediate_size_for_weight,
                 dtype=params_dtype,
             )
         )
         layer.register_parameter("w2_weight", w2_weight)
+        if self.quant_type == QuantType.per_1x32:
+            w2_weight.data.view(torch.uint8).zero_()
         set_weight_attrs(w2_weight, extra_weight_attrs)
 
         # WEIGHT_SCALES
@@ -1835,7 +1851,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             w13_weight_scale = atom_parameter(
                 torch.ones(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    2 * intermediate_size_for_weight,
                     dtype=torch.float32,
                 )
             )
@@ -1847,20 +1863,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         elif self.block_quant:
             scale_shape_w13 = (
                 num_experts,
-                2 * ((intermediate_size_per_partition + block_n - 1) // block_n),
+                2 * ((intermediate_size_for_weight + block_n - 1) // block_n),
                 (hidden_size + block_k - 1) // block_k,
             )
             scale_shape_w2 = (
                 num_experts,
                 (hidden_size + block_n - 1) // block_n,
-                (intermediate_size_per_partition + block_k - 1) // block_k,
+                (intermediate_size_for_weight + block_k - 1) // block_k,
             )
-            w13_weight_scale = atom_parameter(
-                torch.ones(scale_shape_w13, dtype=torch.float32)
-            )
-            w2_weight_scale = atom_parameter(
-                torch.ones(scale_shape_w2, dtype=torch.float32)
-            )
+            # MXFP8 checkpoints store 1x32 scales as e8m0 bytes. Keep the
+            # existing float32 initialization for the original 1x128 path.
+            if self.quant_type == QuantType.per_1x32:
+                w13_scale_data = torch.empty(scale_shape_w13, dtype=dtypes.fp8_e8m0)
+                w2_scale_data = torch.empty(scale_shape_w2, dtype=dtypes.fp8_e8m0)
+                w13_scale_data.view(torch.uint8).zero_()
+                w2_scale_data.view(torch.uint8).zero_()
+            else:
+                w13_scale_data = torch.ones(scale_shape_w13, dtype=torch.float32)
+                w2_scale_data = torch.ones(scale_shape_w2, dtype=torch.float32)
+            w13_weight_scale = atom_parameter(w13_scale_data)
+            w2_weight_scale = atom_parameter(w2_scale_data)
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
             layer.register_parameter("w2_weight_scale", w2_weight_scale)
             assert self.quant_config.is_dynamic
@@ -1930,6 +1952,47 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w13_weight_scale = atom_parameter(layer.w13_weight_scale.data)
             layer.w2_weight = atom_parameter(layer.w2_weight.data)
             layer.w2_weight_scale = atom_parameter(layer.w2_weight_scale.data)
+
+        if self.quant_type == QuantType.per_1x32:
+            # aiter's MXFP8 MoE kernels consume the same gate/up interleaved
+            # layout used by their 1x32 shuffle helpers. Keep this branch
+            # isolated so the existing 1x128 FP8 path still uses shuffle_weights.
+            layer.w13_weight.data = shuffle_weight(
+                layer.w13_weight,
+                is_guinterleave=True,
+                gate_up=True,
+            )
+            layer.w2_weight.data = shuffle_weight(
+                layer.w2_weight,
+                is_guinterleave=True,
+                gate_up=False,
+            )
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
+
+            w13_scale_2d = layer.w13_weight_scale.reshape(
+                -1, layer.w13_weight_scale.shape[-1]
+            )
+            w2_scale_2d = layer.w2_weight_scale.reshape(
+                -1, layer.w2_weight_scale.shape[-1]
+            )
+            layer.w13_weight_scale = atom_parameter(
+                moe_shuffle_scale(
+                    w13_scale_2d,
+                    self.num_experts,
+                    is_guinterleave=True,
+                    gate_up=True,
+                )
+            )
+            layer.w2_weight_scale = atom_parameter(
+                moe_shuffle_scale(
+                    w2_scale_2d,
+                    self.num_experts,
+                    is_guinterleave=True,
+                    gate_up=False,
+                )
+            )
+            return
 
         shuffle_weights(layer.w13_weight, layer.w2_weight)
 
@@ -2057,7 +2120,17 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             num_fused_shared_experts=layer.num_fused_shared_experts,
             routed_scaling_factor=layer.routed_scaling_factor,
         )
-        moe_extra_args = {"swiglu_limit": getattr(layer, "swiglu_limit", 0.0)}
+        # Match the 1x32 preshuffled layout above; other FP8 quant modes keep
+        # the historical separated gate/up layout.
+        gate_mode = (
+            GateMode.INTERLEAVE.value
+            if self.quant_type == QuantType.per_1x32
+            else GateMode.SEPARATED.value
+        )
+        moe_extra_args = {
+            "gate_mode": gate_mode,
+            "swiglu_limit": getattr(layer, "swiglu_limit", 0.0),
+        }
         if self.quant_type == QuantType.per_Tensor or self.fused_experts is None:
             return torch.ops.aiter.rocm_aiter_fused_moe(
                 x,

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -320,6 +320,14 @@ class GenericParser(QuantConfigParser):
             QuantType.per_1x128,
         ):
             quant_type = QuantType.per_1x32
+        # Mxfp8 ``[1, K]`` block to per_1x32.
+        weight_block_size = hf_quant_config.get("weight_block_size")
+        if (
+            isinstance(weight_block_size, (list, tuple))
+            and len(weight_block_size) == 2
+            and weight_block_size[0] == 1
+        ):
+            quant_type = QuantType.per_1x32
         is_dynamic = hf_quant_config.get("is_dynamic", True)
         # Each quantizer uses a different key for excluded layers:
         # Quark -> "exclude", compressed-tensors -> "ignore",

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -372,6 +372,27 @@ class GenericParser(QuantConfigParser):
         return torch.bfloat16
 
     def _infer_qtype(self, cfg: dict, config_str: str) -> QuantType:
+        # Prefer explicit HF/compressed-tensors block size over text heuristics
+        # so MXFP8 1x32 and blockscale 1x128/128x128 are not conflated.
+        if "weight_block_size" in cfg:
+            wbs = cfg.get("weight_block_size")
+            if wbs is None:
+                return QuantType.per_Tensor
+            if isinstance(wbs, (list, tuple)) and len(wbs) >= 2:
+                try:
+                    m, n = int(wbs[0]), int(wbs[1])
+                except (TypeError, ValueError):
+                    m = n = None
+                if (m, n) == (1, 128):
+                    return QuantType.per_1x128
+                if (m, n) == (128, 128):
+                    # per_128x128 enum has no consumers in linear.py / GEMM dispatch yet;
+                    # the per_1x128 path already allocates a (out//128, in//128)
+                    # scale grid which is exactly the (128, 128) block layout.
+                    return QuantType.per_1x128
+                if (m, n) == (1, 32):
+                    return QuantType.per_1x32
+                return QuantType.per_1x128
         # Check explicit fields
         for key in ("quant_type", "quantization_type", "scheme"):
             val = cfg.get(key)
@@ -393,24 +414,6 @@ class GenericParser(QuantConfigParser):
                         mapped = _QSCHEME_TO_QUANT_TYPE.get(f"per_{strategy}")
                     if mapped is not None:
                         return mapped
-        # Honor weight_block_size explicitly: a present-but-null value (Mistral
-        # FP8 native checkpoints) means per-tensor, not blockwise.
-        if "weight_block_size" in cfg:
-            wbs = cfg.get("weight_block_size")
-            if wbs is None:
-                return QuantType.per_Tensor
-            if isinstance(wbs, (list, tuple)) and len(wbs) >= 2:
-                m, n = int(wbs[0]), int(wbs[1])
-                if (m, n) == (1, 128):
-                    return QuantType.per_1x128
-                if (m, n) == (128, 128):
-                    # per_128x128 enum has no consumers in linear.py / GEMM dispatch yet;
-                    # the per_1x128 path already allocates a (out//128, in//128)
-                    # scale grid which is exactly the (128, 128) block layout.
-                    return QuantType.per_1x128
-                if (m, n) == (1, 32):
-                    return QuantType.per_1x32
-                return QuantType.per_1x128
         # Fall back to regex heuristics on full config string
         for pattern, qtype in self._QTYPE_PATTERNS.items():
             if re.search(pattern, config_str):

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -106,8 +106,7 @@ _E8M0_DTYPE = getattr(torch, "float8_e8m0fnu", None)
 def weight_dequant_mxfp8(
     x: torch.Tensor, s: torch.Tensor, block_size: int = 32
 ) -> torch.Tensor:
-    """Dequantize an MXFP8 weight to the default float dtype.
-    """
+    """Dequantize an MXFP8 weight to the default float dtype."""
     assert x.dim() == 2 and s.dim() == 2, "Input tensors must have 2 dimensions"
     M, K = x.shape
     assert K % block_size == 0, f"K={K} not divisible by block_size={block_size}"

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -97,3 +97,31 @@ def weight_dequant_fp8(
 
     _weight_dequant_kernel[grid](x, s, y, M, N, BLOCK_SIZE=block_size)
     return y
+
+
+# Optional E8M0 dtype: only available on newer torch builds.
+_E8M0_DTYPE = getattr(torch, "float8_e8m0fnu", None)
+
+
+def weight_dequant_mxfp8(
+    x: torch.Tensor, s: torch.Tensor, block_size: int = 32
+) -> torch.Tensor:
+    """Dequantize an MXFP8 weight to the default float dtype.
+    """
+    assert x.dim() == 2 and s.dim() == 2, "Input tensors must have 2 dimensions"
+    M, K = x.shape
+    assert K % block_size == 0, f"K={K} not divisible by block_size={block_size}"
+    n_blocks = K // block_size
+    assert s.shape == (M, n_blocks), f"scale shape {tuple(s.shape)} != {(M, n_blocks)}"
+
+    if _E8M0_DTYPE is not None and s.dtype == _E8M0_DTYPE:
+        # E8M0 dtype decodes straight to the 2**(e-127) multiplier.
+        scale = s.to(torch.float32)
+    else:
+        # Raw E8M0 integer codes stored as uint8 / float.
+        scale = torch.exp2(s.to(torch.float32) - 127.0)
+
+    out_dtype = torch.get_default_dtype()
+    y = x.to(torch.float32).reshape(M, n_blocks, block_size)
+    y = y * scale.unsqueeze(-1)
+    return y.reshape(M, K).to(out_dtype)

--- a/recipes/MiniMax-M3.md
+++ b/recipes/MiniMax-M3.md
@@ -1,4 +1,4 @@
-# MiniMax-M3 MXFP4 Usage Guide
+# MiniMax-M3 MXFP4/MXFP8 Usage Guide
 
 [MiniMax-M3-MXFP4](https://huggingface.co/amd/MiniMax-M3-MXFP4) and [MiniMax-M3-MXFP8](https://huggingface.co/MiniMaxAI/MiniMax-M3-MXFP8) are supported by the native ATOM OpenAI-compatible server path.
 
@@ -10,13 +10,9 @@ Pull the latest development image:
 docker pull rocm/atom-dev:latest
 ```
 
-## MXFP4/MXFP8 on 4xMI355 GPUs
+## MXFP4 on 4xMI355 GPUs
 
 ### Launching Server
-
-MXFP4 and MXFP8 use the same launch path.  Set
-`model_path=MiniMaxAI/MiniMax-M3-MXFP8 run_name=m3-mxfp8` to run the MXFP8
-checkpoint.
 
 ```bash
 model_path=${model_path:-amd/MiniMax-M3-MXFP4}
@@ -36,6 +32,34 @@ python -m atom.entrypoints.openai_server \
   --max-num-batched-tokens 32768 \
   --no-enable_prefix_caching 2>&1 | tee "${run_name}-server.log"
 ```
+
+## MXFP8 on 4xMI355 GPUs
+
+### Launching Server
+
+For the MXFP8 model, online quant is used to convert the linear weights in attention module and first 3 dense MLP layers to PTPC FP8 format, which are originally equipped with 1*32 block scale.
+The MoE weights keep unchanged. Check **--online_quant_config** in the script below for more details.
+
+```bash
+model_path=${model_path:-MiniMaxAI/MiniMax-M3-MXFP8}
+run_name=${run_name:-m3-mxfp8}
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
+export ATOM_FORCE_ATTN_TRITON=1
+
+python -m atom.entrypoints.openai_server \
+  --model "$model_path" \
+  --tensor-parallel-size 4 \
+  --server-port 8000 \
+  --trust-remote-code \
+  --gpu-memory-utilization 0.8 \
+  --block-size 128 \
+  --max-model-len 32768 \
+  --max-num-seqs 128 \
+  --max-num-batched-tokens 32768 \
+  --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
+  --no-enable_prefix_caching 2>&1 | tee "${run_name}-server.log"
+```
+
 
 ### Accuracy Test
 
@@ -72,7 +96,7 @@ Validated MXFP8 GSM8K result:
 local-chat-completions ({'model': 'MiniMaxAI/MiniMax-M3-MXFP8', 'base_url': 'http://127.0.0.1:8000/v1/chat/completions', 'num_concurrent': 32, 'max_gen_toks': 16384}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 65
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
 |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
-|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9469|±  |0.0062|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9484|±  |0.0061|
 |     |       |strict-match    |     5|exact_match|↑  |0.9477|±  |0.0061|
 ```
 

--- a/recipes/MiniMax-M3.md
+++ b/recipes/MiniMax-M3.md
@@ -1,7 +1,6 @@
 # MiniMax-M3 MXFP4 Usage Guide
 
-[MiniMax-M3-MXFP4](https://huggingface.co/amd/MiniMax-M3-MXFP4) is supported by
-the native ATOM OpenAI-compatible server path.
+[MiniMax-M3-MXFP4](https://huggingface.co/amd/MiniMax-M3-MXFP4) and [MiniMax-M3-MXFP8](https://huggingface.co/MiniMaxAI/MiniMax-M3-MXFP8) are supported by the native ATOM OpenAI-compatible server path.
 
 ## Preparing Environment
 
@@ -11,9 +10,13 @@ Pull the latest development image:
 docker pull rocm/atom-dev:latest
 ```
 
-## MXFP4 on 4xMI355 GPUs
+## MXFP4/MXFP8 on 4xMI355 GPUs
 
 ### Launching Server
+
+MXFP4 and MXFP8 use the same launch path.  Set
+`model_path=MiniMaxAI/MiniMax-M3-MXFP8 run_name=m3-mxfp8` to run the MXFP8
+checkpoint.
 
 ```bash
 model_path=${model_path:-amd/MiniMax-M3-MXFP4}
@@ -63,6 +66,16 @@ local-chat-completions ({'model': 'amd/MiniMax-M3-MXFP4', 'base_url': 'http://12
 |     |       |strict-match    |     5|exact_match|↑  |0.9371|±  |0.0067|
 ```
 
+Validated MXFP8 GSM8K result:
+
+```text
+local-chat-completions ({'model': 'MiniMaxAI/MiniMax-M3-MXFP8', 'base_url': 'http://127.0.0.1:8000/v1/chat/completions', 'num_concurrent': 32, 'max_gen_toks': 16384}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 65
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9469|±  |0.0062|
+|     |       |strict-match    |     5|exact_match|↑  |0.9477|±  |0.0061|
+```
+
 ### Serving Benchmark
 
 The following script can be used to benchmark online serving throughput and
@@ -99,3 +112,13 @@ Reference MXFP4 results from the validated run on 4xMI355 GPUs:
 | 16 | 160 | 114.35 | 383.04 | 2200.03 | 11.73 | 12.84 | 1280.47 | 11555.95 |
 | 32 | 320 | 163.86 | 512.32 | 4477.16 | 16.74 | 19.12 | 1807.32 | 16161.65 |
 | 64 | 640 | 242.49 | 831.98 | 8566.28 | 25.00 | 29.83 | 2432.75 | 21928.25 |
+
+Reference MXFP8 results from the validated run on 4xMI355 GPUs:
+
+| CONC | Requests | Duration (s) | Mean TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | P99 TPOT (ms) | Output tok/s | Total tok/s |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 4 | 40 | 82.00 | 268.02 | 564.13 | 8.43 | 8.66 | 448.82 | 4034.60 |
+| 8 | 80 | 103.52 | 323.33 | 1284.59 | 10.67 | 11.31 | 715.51 | 6364.77 |
+| 16 | 160 | 143.25 | 414.95 | 2411.41 | 14.80 | 16.44 | 1022.17 | 9224.81 |
+| 32 | 320 | 208.34 | 565.02 | 4936.02 | 21.42 | 24.16 | 1421.47 | 12711.25 |
+| 64 | 640 | 305.81 | 893.93 | 9610.43 | 31.69 | 37.31 | 1929.04 | 17387.94 |


### PR DESCRIPTION
## Motivation
Use online quant to convert the linear weights in attention module and first 3 dense MLP layers to PTPC FP8 format, which are originally equipped with 1*32 block scale.
The MoE weights keep unchanged. Check **--online_quant_config** in the script below for more details.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

```bash
model_path=${model_path:-/workspace/shared/data/amd_int/models/MiniMax-M3-MXFP8}
run_name=${run_name:-m3-mxfp8}

export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export ATOM_FORCE_ATTN_TRITON=1

python -m atom.entrypoints.openai_server \
  --model "$model_path" \
  --tensor-parallel-size 4 \
  --server-port 8000 \
  --trust-remote-code \
  --gpu-memory-utilization 0.8 \
  --block-size 128 \
  --max-model-len 32768 \
  --max-num-seqs 128 \
  --max-num-batched-tokens 32768 \
  --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
  --no-enable_prefix_caching 2>&1 | tee "logs/${run_name}-server.log"
```

## Test Result

<img width="1297" height="216" alt="image" src="https://github.com/user-attachments/assets/477e0d26-5fd7-4b3a-a61b-8155b31cc6de" />

FP8 gemm have been called for attn linears:
<img width="2039" height="207" alt="image" src="https://github.com/user-attachments/assets/4ffe8cd6-978c-4c16-8d2d-c5ec2e13fb9f" />


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
