### PR TITLE
Add NUMA-aware CPU/memory binding for PD Single Node optimization

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -65,7 +65,7 @@
           "label": "DPA TBO",
           "suffix": "-dpa-tbo",
           "extra_args": "--enable-dp-attention --enable-tbo",
-          "env_vars": "GPU_MAX_HW_QUEUES=5\nATOM_CPU_AFFINITY=1",
+          "env_vars": "GPU_MAX_HW_QUEUES=5\nATOM_NUMA_BIND=1",
           "conc_min": 256,
           "conc_max": 1024
         },

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -22,6 +22,10 @@ on:
         description: "Benchmark GLM-5.1-MXFP4"
         type: boolean
         default: true
+      glm-5-2-fp8:
+        description: "Benchmark GLM-5.2-FP8"
+        type: boolean
+        default: true
       deepseek-r1-0528-mxfp4:
         description: "Benchmark DeepSeek-R1-0528 MXFP4 (+ MXFP4-MTP3)"
         type: boolean

--- a/atom/model_engine/async_proc.py
+++ b/atom/model_engine/async_proc.py
@@ -15,7 +15,6 @@ This module provides:
 
 import logging
 import multiprocessing
-import os
 import pickle
 import queue
 import threading
@@ -35,6 +34,7 @@ from atom.utils import (
     resolve_obj_by_qualname,
     shutdown_all_processes,
 )
+from atom.utils.numa_utils import numa_bind_to_node
 
 logger = logging.getLogger("atom")
 
@@ -71,29 +71,20 @@ class AsyncIOProc:
         *args,
         **kwargs,
     ):
-        # Per-rank CPU/NUMA pinning. Must run before any large allocation so
-        # Linux first-touch places memory on the local NUMA node (implicit
-        # membind without libnuma). Gated by env so baseline/pinned A/B is free.
-        # The global GPU index is dp_rank * tp_size + tp_rank (see
-        # engine_core_mgr GPU assignment); the `rank` arg is only the TP-local
-        # rank, which is always 0 under DP-attention (tp_size == 1 per engine).
-        if os.environ.get("ATOM_CPU_AFFINITY", "0") == "1":
-            try:
-                cfg = args[0]
-                tp_size = cfg.tensor_parallel_size
-                dp_size = cfg.parallel_config.data_parallel_size
-                dp_rank = cfg.parallel_config.data_parallel_rank
-                world = dp_size * tp_size
-                gpu = dp_rank * tp_size + rank
-                per = os.cpu_count() // world
-                lo = gpu * per
-                os.sched_setaffinity(0, set(range(lo, lo + per)))
-                logger.info(
-                    f"AsyncIOProc({label}): gpu={gpu}/{world} "
-                    f"pinned to cores {lo}-{lo + per - 1}"
-                )
-            except Exception as e:
-                logger.warning(f"AsyncIOProc({label}): CPU affinity skipped: {e}")
+        # NUMA-local CPU/memory pinning (see atom.utils.numa_utils).
+        # Auto-detects the GPU's local node by default; gated by
+        # ATOM_NUMA_BIND. Must run before any large allocation / native
+        # (mooncake) thread spawn so the mask is inherited by child threads and
+        # first-touch lands memory locally. The global GPU index is
+        # dp_rank*tp_size+tp_rank (engine_core_mgr GPU assignment).
+        try:
+            cfg = args[0]
+            gpu = (
+                cfg.parallel_config.data_parallel_rank * cfg.tensor_parallel_size + rank
+            )
+            numa_bind_to_node(gpu, label)
+        except Exception as e:
+            logger.warning(f"AsyncIOProc({label}): NUMA bind skipped: {e}")
         self.label = f"AsyncIOProc({label})"
         self.io_addrs = io_addrs
         self.io_queues = queue.Queue(), queue.Queue()

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -230,6 +230,20 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_TBO_PREFILL_TOKEN_SPLIT": lambda: (
         os.getenv("ATOM_TBO_PREFILL_TOKEN_SPLIT", "1") == "1"
     ),
+    # --- NUMA binding ---
+    # Master switch: pin each GPU worker to its GPU-local NUMA node's CPU cores
+    # and preferred memory. Default off so baseline/pinned A/B stays clean.
+    "ATOM_NUMA_BIND": lambda: os.getenv("ATOM_NUMA_BIND", "0") == "1",
+    # Auto-detect the GPU->NUMA-node mapping (amdsmi first, sysfs fallback).
+    # Default on, so `ATOM_NUMA_BIND=1` alone is zero-config.
+    "ATOM_AUTO_NUMA_BIND": lambda: os.getenv("ATOM_AUTO_NUMA_BIND", "1") == "1",
+    # Explicit per-global-rank node ids (comma separated), overriding auto, e.g.
+    # ATOM_NUMA_NODE="0,0,0,0,1,1,1,1". A single value applies to all ranks.
+    "ATOM_NUMA_NODE": lambda: os.getenv("ATOM_NUMA_NODE", ""),
+    # Raise instead of warn when binding fails.
+    "ATOM_CRASH_ON_NUMA_BIND_FAILURE": lambda: (
+        os.getenv("ATOM_CRASH_ON_NUMA_BIND_FAILURE", "0") == "1"
+    ),
 }
 
 

--- a/atom/utils/numa_utils.py
+++ b/atom/utils/numa_utils.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""NUMA binding for GPU worker processes.
+
+Pin each GPU worker to the CPU cores and preferred memory of its GPU's local
+NUMA node. The GPU->node mapping is auto-detected (``amdsmi`` -- the ROCm analog
+of NVML -- with a sysfs fallback) so the operator needs no per-machine config;
+an explicit per-rank node list can override it.
+
+Public entry point: :func:`numa_bind_to_node`, called once at worker start.
+Knobs live in :mod:`atom.utils.envs` (``ATOM_NUMA_BIND``, ``ATOM_AUTO_NUMA_BIND``,
+``ATOM_NUMA_NODE``, ``ATOM_CRASH_ON_NUMA_BIND_FAILURE``).
+"""
+
+import ctypes
+import glob
+import logging
+import os
+
+from atom.utils import envs
+
+logger = logging.getLogger("atom")
+
+
+def _parse_cpulist(s: str) -> set[int]:
+    """Parse a sysfs cpulist string (e.g. ``"0-63,128-191"``) into a set."""
+    out: set[int] = set()
+    for part in s.strip().split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            a, b = part.split("-")
+            out.update(range(int(a), int(b) + 1))
+        else:
+            out.add(int(part))
+    return out
+
+
+def _node_cpus(node: int) -> set[int]:
+    """CPUs belonging to NUMA ``node`` (kernel-reported, no topology guessing)."""
+    with open(f"/sys/devices/system/node/node{node}/cpulist") as f:
+        return _parse_cpulist(f.read())
+
+
+def _physical_index(gpu_id: int) -> int:
+    """Map a logical GPU id to the physical index, honoring *_VISIBLE_DEVICES.
+
+    System tools (amdsmi) and sysfs enumerate every physical GPU regardless of
+    the visible-device mask, so a logical worker id must be translated back to
+    the physical device it actually drives.
+    """
+    visible = os.environ.get("HIP_VISIBLE_DEVICES") or os.environ.get(
+        "CUDA_VISIBLE_DEVICES"
+    )
+    if not visible:
+        return gpu_id
+    vis = [int(x) for x in visible.split(",") if x.strip() != ""]
+    return vis[gpu_id] if gpu_id < len(vis) else gpu_id
+
+
+def _query_node_amdsmi(gpu_id: int) -> int | None:
+    """Physical GPU -> NUMA node via amdsmi (ROCm analog of NVML affinity)."""
+    try:
+        import amdsmi
+    except Exception:
+        return None
+    phys = _physical_index(gpu_id)
+    try:
+        amdsmi.amdsmi_init()
+        try:
+            handles = amdsmi.amdsmi_get_processor_handles()
+            if phys >= len(handles):
+                return None
+            node = int(amdsmi.amdsmi_topo_get_numa_node_number(handles[phys]))
+            return node if node >= 0 else None
+        finally:
+            amdsmi.amdsmi_shut_down()
+    except Exception as e:
+        logger.debug(f"amdsmi NUMA query failed for gpu {gpu_id}: {e}")
+        return None
+
+
+def _query_node_sysfs(gpu_id: int) -> int | None:
+    """Fallback: physical GPU -> node via DRM cards sorted by PCI BDF.
+
+    Assumes ROCm enumerates GPUs in PCI-BDF order, which a non-identity
+    *_VISIBLE_DEVICES permutation can break -- so this is only used when amdsmi
+    is unavailable. Prefer the explicit ``ATOM_NUMA_NODE`` list on such setups.
+    """
+    phys = _physical_index(gpu_id)
+    cards: list[tuple[str, int]] = []
+    for dev in glob.glob("/sys/class/drm/card*/device"):
+        nn = os.path.join(dev, "numa_node")
+        if not os.path.exists(nn):
+            continue
+        bdf = os.path.basename(os.path.realpath(dev))
+        with open(nn) as f:
+            cards.append((bdf, int(f.read())))
+    cards.sort()
+    if phys >= len(cards):
+        return None
+    node = cards[phys][1]
+    return node if node >= 0 else None
+
+
+def _resolve_node(gpu_id: int) -> int | None:
+    """Explicit ``ATOM_NUMA_NODE`` wins; else auto-detect (amdsmi -> sysfs)."""
+    explicit = [x for x in envs.ATOM_NUMA_NODE.split(",") if x.strip() != ""]
+    if explicit:
+        idx = gpu_id if gpu_id < len(explicit) else len(explicit) - 1
+        return int(explicit[idx])
+    if not envs.ATOM_AUTO_NUMA_BIND:
+        return None
+    node = _query_node_amdsmi(gpu_id)
+    if node is None:
+        node = _query_node_sysfs(gpu_id)
+    return node
+
+
+def _set_preferred_memory(node: int) -> None:
+    """Best-effort memory binding via libnuma ``numa_set_preferred``.
+
+    If libnuma is absent, first-touch on the pinned CPUs still lands memory on
+    the local node, so this is an optimization, not a requirement.
+    """
+    try:
+        libnuma = ctypes.CDLL("libnuma.so.1")
+        if libnuma.numa_available() < 0:
+            return
+        libnuma.numa_set_preferred(ctypes.c_int(node))
+    except Exception as e:
+        logger.debug(f"numa_set_preferred({node}) skipped: {e}")
+
+
+def numa_bind_to_node(gpu_id: int, label: str = "") -> None:
+    """Bind the current process to its GPU's NUMA-local cores and memory.
+
+    No-op unless ``ATOM_NUMA_BIND`` is enabled. Must run before any large
+    allocation / native (e.g. mooncake RDMA) thread spawn so the affinity mask
+    is inherited by child threads and Linux first-touch places memory on the
+    node. The node's CPUs are intersected with the current affinity so an
+    existing container cpuset is respected. On failure it warns (and raises only
+    if ``ATOM_CRASH_ON_NUMA_BIND_FAILURE``).
+    """
+    if not envs.ATOM_NUMA_BIND:
+        return
+    tag = f" ({label})" if label else ""
+    try:
+        node = _resolve_node(gpu_id)
+        if node is None or node < 0:
+            raise RuntimeError(f"could not resolve NUMA node for gpu {gpu_id}")
+        cpus = _node_cpus(node) & os.sched_getaffinity(0)
+        if not cpus:
+            raise RuntimeError(
+                f"NUMA node {node} has no CPUs allowed by the current affinity"
+            )
+        os.sched_setaffinity(0, cpus)
+        _set_preferred_memory(node)
+        logger.info(f"NUMA bind{tag}: gpu={gpu_id} -> node {node} ({len(cpus)} cores)")
+    except Exception as e:
+        msg = (
+            f"NUMA bind{tag} failed for gpu {gpu_id}: {e}. In docker add "
+            f"--cap-add SYS_NICE, or set ATOM_NUMA_NODE explicitly."
+        )
+        if envs.ATOM_CRASH_ON_NUMA_BIND_FAILURE:
+            raise RuntimeError(msg) from e
+        logger.warning(msg)

--- a/recipes/pd_disaggregation_guide.md
+++ b/recipes/pd_disaggregation_guide.md
@@ -215,6 +215,163 @@ V4-specific env vars:
 
 ---
 
+## Single-Node PD: NUMA Binding
+
+When prefill and decode run on the **same** node — each a separate process pinned
+to a GPU subset via `HIP_VISIBLE_DEVICES` — bind every worker's CPU threads
+(especially mooncake's native RDMA threads) and its memory to the GPU's **local
+NUMA node**. On a 2-socket box this removes the cross-socket GPU launch bubbles
+that otherwise dominate prefill.
+
+### Mechanism
+
+`ATOM_NUMA_BIND` runs at the top of `AsyncIOProc.__init__` — before any large
+allocation or native (mooncake) thread spawn — calling `sched_setaffinity` +
+libnuma `numa_set_preferred`. Child threads inherit the mask and Linux
+first-touch lands memory on the local node. See `atom/utils/numa_utils.py` and
+`atom/model_engine/async_proc.py`. This replaces hand-rolled `taskset` / the old
+NUMA-blind `ATOM_CPU_AFFINITY` linear slice.
+
+### Env vars
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ATOM_NUMA_BIND` | `0` (off) | Master switch; `=1` enables binding |
+| `ATOM_NUMA_NODE` | empty (auto) | Explicit node id(s); empty = auto-detect (amdsmi → sysfs) |
+| `ATOM_AUTO_NUMA_BIND` | `1` | Auto-detect toggle (rarely changed) |
+| `ATOM_CRASH_ON_NUMA_BIND_FAILURE` | `0` | Raise instead of warn on bind failure |
+
+### Check the topology first
+
+```bash
+# GPU -> NUMA node (amdsmi if present, else sysfs)
+for d in /sys/class/drm/card*/device; do
+  [ -e "$d/numa_node" ] && echo "$(basename $(realpath $d)) node=$(cat $d/numa_node)"
+done | sort
+# cpus per node
+for n in /sys/devices/system/node/node*/cpulist; do echo "$n: $(cat $n)"; done
+```
+
+Example (2-socket, 8-GPU box): physical GPU 0–3 → node 0, 4–7 → node 1.
+
+### Per-process configuration
+
+Set a single node id per process (it broadcasts to all `tp` ranks in that
+process):
+
+| Process | `HIP_VISIBLE_DEVICES` | node | Config |
+|---|---|---|---|
+| prefill #1 | `0,1` | 0 | `ATOM_NUMA_BIND=1 ATOM_NUMA_NODE="0"` |
+| prefill #2 | `2,3` | 0 | `ATOM_NUMA_BIND=1 ATOM_NUMA_NODE="0"` |
+| decode #1 | `4,5` | 1 | `ATOM_NUMA_BIND=1 ATOM_NUMA_NODE="1"` |
+| decode #2 | `6,7` | 1 | `ATOM_NUMA_BIND=1 ATOM_NUMA_NODE="1"` |
+
+```bash
+export ATOM_NUMA_BIND=1
+export ATOM_NUMA_NODE="0"          # node of this process's GPUs
+export HIP_VISIBLE_DEVICES=0,1
+python -m atom.entrypoints.openai_server ... -tp 2 ...
+```
+
+### Full launch scripts (1P1D example)
+
+Set `NODE_IP` to this node's address. Prefill is the `kv_producer`, decode the
+`kv_consumer`; they coordinate through mooncake on the shared `handshake_port`.
+
+**Prefill (GPU 0,1 → node 0):**
+
+```bash
+export NODE_IP=<this-node-ip>
+
+export ATOM_NUMA_BIND=1
+export ATOM_NUMA_NODE="0"
+export ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1
+export HIP_VISIBLE_DEVICES=0,1
+export PYTHONUNBUFFERED=1
+export ATOM_HOST_IP=${NODE_IP}
+export LD_LIBRARY_PATH=/opt/venv/lib/python3.10/site-packages/mooncake:/opt/rocm/lib:${LD_LIBRARY_PATH:-}
+export ATOM_DISABLE_MMAP=true
+rm -rf /root/.cache/atom/* 2>/dev/null || true
+
+python3 -m atom.entrypoints.openai_server \
+    --model /data/models/MiniMax-M2.7/ \
+    --host 0.0.0.0 --server-port 8030 \
+    --trust-remote-code \
+    -tp 2 \
+    --port 8006 \
+    --kv_cache_dtype fp8 \
+    --gpu-memory-utilization 0.75 \
+    --torch-profiler-dir /it-share/lirzhang/trace/prefill \
+    --kv-transfer-config '{"kv_role":"kv_producer","kv_connector":"mooncake","proxy_ip":"'"${NODE_IP}"'","handshake_port":6301}'
+```
+
+**Decode (GPU 4,5 → node 1):**
+
+```bash
+export NODE_IP=<this-node-ip>
+
+export ATOM_NUMA_BIND=1
+export ATOM_NUMA_NODE="1"
+export ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1
+export HIP_VISIBLE_DEVICES=4,5
+export PYTHONUNBUFFERED=1
+export ATOM_HOST_IP=${NODE_IP}
+export LD_LIBRARY_PATH=/opt/venv/lib/python3.10/site-packages/mooncake:/opt/rocm/lib:${LD_LIBRARY_PATH:-}
+export ATOM_DISABLE_MMAP=true
+rm -rf /root/.cache/atom/* 2>/dev/null || true
+
+python3 -m atom.entrypoints.openai_server \
+    --model /data/models/MiniMax-M2.7/ \
+    --host 0.0.0.0 --server-port 8031 \
+    --trust-remote-code \
+    -tp 2 \
+    --port 8007 \
+    --kv_cache_dtype fp8 \
+    --gpu-memory-utilization 0.75 \
+    --torch-profiler-dir /it-share/lirzhang/trace/decode \
+    --kv-transfer-config '{"kv_role":"kv_consumer","kv_connector":"mooncake","proxy_ip":"'"${NODE_IP}"'","handshake_port":6302,"http_port":8041}'
+```
+
+> Each process pins to the NUMA node local to its GPUs (`0,1`/`2,3` → node 0;
+> `4,5`/`6,7` → node 1). For a 2P1D / 1P2D mesh, bump every deterministic id
+> (`server-port`, `--port`, `handshake_port`, `http_port`) per extra process so
+> they don't collide.
+
+### Indexing rule (important under HIP_VISIBLE_DEVICES masking)
+
+- **auto** (no `ATOM_NUMA_NODE`): resolves through `_physical_index()`, mapping
+  the process-local rank back to the real physical GPU via `HIP_VISIBLE_DEVICES`
+  before querying its node. Masking is handled correctly — **prefer auto when
+  amdsmi is available; it is portable and zero-config.**
+- **explicit** `ATOM_NUMA_NODE`: does **not** go through `_physical_index`; it is
+  indexed by **process-local rank** (`0..tp-1`). Write the node(s) of the GPUs
+  visible to *this* process, in local-rank order. A single value applies to all
+  ranks — convenient when a process's GPUs are all on one node.
+
+> If amdsmi is not installed, auto falls back to a sysfs scan (works when ROCm
+> enumerates GPUs in PCI-BDF order). When the node layout is fixed and known,
+> explicit `ATOM_NUMA_NODE` is the most deterministic choice.
+
+### Verify
+
+Each process logs one line per worker:
+
+```
+NUMA bind (ModelRunner0/2): gpu=0 -> node 0 (64 cores)
+```
+
+`tp2` → 2 lines with the expected node ids. A failure logs
+`NUMA bind ... failed ...` — in Docker add `--cap-add SYS_NICE`, or set
+`ATOM_NUMA_NODE` explicitly.
+
+### CI / portability
+
+When the target topology is unknown (e.g. a CI runner), set **only**
+`ATOM_NUMA_BIND=1` and let auto-detect pick the node per machine — do not
+hardcode `ATOM_NUMA_NODE`.
+
+---
+
 ## Accuracy Validation
 
 ### DeepSeek-R1


### PR DESCRIPTION
## Motivation
When PD in single node, prefill/decode rank will bind across NUMA and cause large bubble in communication.

---
pd prefill rank:
**export ATOM_NUMA_BIND=1
export ATOM_NUMA_NODE="0"**

```
export ATOM_NUMA_BIND=1
export ATOM_NUMA_NODE="0"
export ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1
export HIP_VISIBLE_DEVICES=0,1
export PYTHONUNBUFFERED=1
export ATOM_HOST_IP=10.24.112.178
export LD_LIBRARY_PATH=/opt/venv/lib/python3.10/site-packages/mooncake:/opt/rocm/lib:${LD_LIBRARY_PATH:-}
export ATOM_DISABLE_MMAP=true
rm -rf /root/.cache/atom/* 2>/dev/null || true

python3 -m atom.entrypoints.openai_server \
    --model /data/models/MiniMax-M2.7/ \
    --host 0.0.0.0 --server-port 8030 \
    --trust-remote-code \
    -tp 2 \
    --port 8006 \
    --kv_cache_dtype fp8 \
    --gpu-memory-utilization 0.75 \
    --torch-profiler-dir /it-share/lirzhang/trace/prefill \
    --kv-transfer-config '{"kv_role":"kv_producer","kv_connector":"mooncake","proxy_ip":"xxxxxxx","handshake_port":6301}'
```

decode rank:
**export ATOM_NUMA_BIND=1
export ATOM_NUMA_NODE="1"**

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
