### PR TITLE
[MiniMax-M3] optimize sparse vLLM metadata for improved performance of vllm-atom

### DIFF
--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -434,9 +434,11 @@ class MinimaxM3SparseMetadata:
 
 
 class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
-    # MiniMax-M3 sparse attention owns dynamic index/topk/cache state that must
-    # be refreshed outside full cudagraph capture.
-    _cudagraph_support = AttentionCGSupport.NEVER
+    # Only uniform single-token decode is safe to capture. Prefill/mixed batches
+    # still use build(), where variable query lengths and CPU-side max reduction
+    # are allowed. The decode kernels consume per-step seq_lens/block_table from
+    # vLLM's fixed metadata buffers and keep their grids shape-constant.
+    _cudagraph_support = AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
     reorder_batch_threshold = 1
 
     def __init__(
@@ -450,6 +452,7 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
         del model_runner
         super().__init__(kv_cache_spec, layer_names, config, device)
         logger.info("init MinimaxM3SparseAttentionMetadataBuilder")
+        from atom.model_ops.minimax_m3.sparse_attn import SPARSE_BLOCK_SIZE
         from vllm.config import VllmConfig
 
         assert isinstance(config, VllmConfig)
@@ -458,6 +461,14 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
         self.cache_config = config.cache_config
         self.scheduler_config = config.scheduler_config
         self.block_size = kv_cache_spec.block_size
+        if self.block_size != SPARSE_BLOCK_SIZE:
+            raise ValueError(
+                f"MiniMax-M3 sparse block size must be {SPARSE_BLOCK_SIZE}."
+            )
+        max_num_batched_tokens = self.scheduler_config.max_num_batched_tokens
+        self.prefill_qo_indptr = torch.arange(
+            max_num_batched_tokens + 1, dtype=torch.int32, device=device
+        )
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
 
     def build(
@@ -471,7 +482,11 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
             raise ValueError("ATOM does not support cascade attention yet")
         assert common_attn_metadata is not None
 
-        from atom.model_ops.minimax_m3.sparse_attn import SPARSE_BLOCK_SIZE
+        # Plain decode can have many concurrent requests; each request contributes
+        # exactly one query token, so max_query_len stays 1.
+        if common_attn_metadata.max_query_len == 1:
+            return self._build_uniform_decode_metadata(common_attn_metadata)
+
         from vllm.v1.attention.backends.utils import (
             split_decodes_prefills_and_extends,
         )
@@ -513,30 +528,9 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
             context_lens = common_attn_metadata.compute_num_computed_tokens()[
                 prefill_start:prefill_stop
             ]
-            seq_lens_cpu = getattr(
-                common_attn_metadata, "seq_lens_cpu_upper_bound", None
-            )
-            if seq_lens_cpu is None:
-                seq_lens_cpu = getattr(common_attn_metadata, "_seq_lens_cpu", None)
-            if seq_lens_cpu is None:
-                seq_lens_cpu = seq_lens.cpu()
-            prefill_max_seq_len = int(
-                seq_lens_cpu[prefill_start:prefill_stop].max().item()
-            )
-            query_lens_cpu = (
-                common_attn_metadata.query_start_loc_cpu[1:]
-                - common_attn_metadata.query_start_loc_cpu[:-1]
-            )
-            prefill_max_query_len = max(
-                1, int(query_lens_cpu[prefill_start:prefill_stop].max().item())
-            )
-            if self.block_size != SPARSE_BLOCK_SIZE:
-                raise ValueError(
-                    f"MiniMax-M3 sparse block size must be {SPARSE_BLOCK_SIZE}."
-                )
-            qo_indptr = torch.arange(
-                num_prefill_tokens + 1, dtype=torch.int32, device=seq_lens.device
-            )
+            prefill_max_seq_len = common_attn_metadata.max_seq_len
+            prefill_max_query_len = common_attn_metadata.max_query_len
+            qo_indptr = self.prefill_qo_indptr[: num_prefill_tokens + 1]
             prefill_metadata = MinimaxM3SparsePrefillMetadata(
                 qo_indptr=qo_indptr,
                 cu_seqlens_q=prefill_query_start,
@@ -549,17 +543,10 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
 
         decode_metadata: MinimaxM3SparseDecodeMetadata | None = None
         if num_decodes > 0:
-            query_lens_cpu = (
-                common_attn_metadata.query_start_loc_cpu[1:]
-                - common_attn_metadata.query_start_loc_cpu[:-1]
-            )
-            decode_max_query_len = max(
-                1, int(query_lens_cpu[:num_decodes].max().item())
-            )
             decode_metadata = MinimaxM3SparseDecodeMetadata(
                 seq_lens=seq_lens[:num_decodes],
                 block_table=block_table[:num_decodes],
-                max_query_len=decode_max_query_len,
+                max_query_len=self.reorder_batch_threshold,
             )
 
         return MinimaxM3SparseMetadata(
@@ -577,10 +564,36 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
             decode=decode_metadata,
         )
 
-    def build_for_cudagraph_capture(self, common_attn_metadata=None):
-        return self.build(
-            common_prefix_len=0, common_attn_metadata=common_attn_metadata
+    def _build_uniform_decode_metadata(self, common_attn_metadata):
+        assert common_attn_metadata is not None
+
+        num_reqs = common_attn_metadata.num_reqs
+        num_tokens = common_attn_metadata.num_actual_tokens
+        seq_lens = common_attn_metadata.seq_lens
+        block_table = common_attn_metadata.block_table_tensor
+
+        decode_metadata = MinimaxM3SparseDecodeMetadata(
+            seq_lens=seq_lens[:num_reqs],
+            block_table=block_table[:num_reqs],
+            max_query_len=1,
         )
+        return MinimaxM3SparseMetadata(
+            seq_lens=seq_lens,
+            max_seq_len=common_attn_metadata.max_seq_len,
+            slot_mapping=common_attn_metadata.slot_mapping,
+            num_actual_tokens=num_tokens,
+            num_decodes=num_reqs,
+            num_decode_tokens=num_tokens,
+            num_prefills=0,
+            num_prefill_tokens=0,
+            block_table=block_table,
+            max_query_len=1,
+            prefill=None,
+            decode=decode_metadata,
+        )
+
+    def build_for_cudagraph_capture(self, common_attn_metadata=None):
+        return self._build_uniform_decode_metadata(common_attn_metadata)
 
 
 # vLLM metadata builders

--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -482,11 +482,6 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
             raise ValueError("ATOM does not support cascade attention yet")
         assert common_attn_metadata is not None
 
-        # Plain decode can have many concurrent requests; each request contributes
-        # exactly one query token, so max_query_len stays 1.
-        if common_attn_metadata.max_query_len == 1:
-            return self._build_uniform_decode_metadata(common_attn_metadata)
-
         from vllm.v1.attention.backends.utils import (
             split_decodes_prefills_and_extends,
         )
@@ -502,6 +497,13 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
             common_attn_metadata=common_attn_metadata,
             decode_threshold=getattr(self, "reorder_batch_threshold", 1) or 1,
         )
+
+        # Plain decode has max_query_len == 1, while MTP/spec decode verifies
+        # num_spec+1 tokens per request. Both should use the decode path, but only
+        # when the split says there are no prefill/extend requests in the batch.
+        if num_decodes > 0 and num_extends == 0 and num_prefills == 0:
+            return self._build_uniform_decode_metadata(common_attn_metadata)
+
         num_tokens = common_attn_metadata.num_actual_tokens
         num_prefills_total = num_extends + num_prefills
         num_prefill_tokens = num_tokens - num_decode_tokens
@@ -569,13 +571,14 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
 
         num_reqs = common_attn_metadata.num_reqs
         num_tokens = common_attn_metadata.num_actual_tokens
+        max_query_len = common_attn_metadata.max_query_len
         seq_lens = common_attn_metadata.seq_lens
         block_table = common_attn_metadata.block_table_tensor
 
         decode_metadata = MinimaxM3SparseDecodeMetadata(
             seq_lens=seq_lens[:num_reqs],
             block_table=block_table[:num_reqs],
-            max_query_len=1,
+            max_query_len=max_query_len,
         )
         return MinimaxM3SparseMetadata(
             seq_lens=seq_lens,
@@ -587,7 +590,7 @@ class MinimaxM3SparseAttentionMetadataBuilder(AttentionMetadataBuilder):
             num_prefills=0,
             num_prefill_tokens=0,
             block_table=block_table,
-            max_query_len=1,
+            max_query_len=max_query_len,
             prefill=None,
             decode=decode_metadata,
         )

--- a/atom/plugin/vllm/attention/minimax_m3_attnetion.py
+++ b/atom/plugin/vllm/attention/minimax_m3_attnetion.py
@@ -34,6 +34,8 @@ from atom.utils import mark_spliting_op
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 
+_MINIMAX_M3_TOPK_CACHE_STATE: dict = {}
+
 
 def minimax_m3_sparse_attention_fake(
     qkv: torch.Tensor,
@@ -167,7 +169,6 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
             use_mla,
             quant_config,
             index_rotary_emb,
-            sparse_layer_ordinal,
             impl_cls,
             kwargs,
         )
@@ -221,8 +222,7 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
         self.init_blocks = init_blocks
         self.local_blocks = local_blocks
         self.skip_index_topk = skip_index_topk
-        self._cached_topk: tuple | None = None
-        self._cached_topk_key: tuple | None = None
+        self.sparse_layer_ordinal = sparse_layer_ordinal
 
         if self.head_dim != 128:
             raise ValueError("MiniMax-M3 sparse attention requires head_dim == 128.")
@@ -443,15 +443,28 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
             self.local_blocks,
         )
 
+    @staticmethod
+    def _topk_cache_state():
+        return _MINIMAX_M3_TOPK_CACHE_STATE
+
     def _load_cached_topk(self, key: tuple):
-        if self.skip_index_topk and self._cached_topk_key == key:
-            return self._cached_topk
+        if not self.skip_index_topk:
+            return None
+        phase = key[0]
+        entry = self._topk_cache_state().get(phase)
+        if entry is not None and entry.get("key") == key:
+            return entry["value"]
+        raise RuntimeError("MiniMax-M3 topk cache miss on a skip-index layer")
         return None
 
     def _store_cached_topk(self, key: tuple, topk_idx) -> None:
-        if self.skip_index_topk:
-            self._cached_topk_key = key
-            self._cached_topk = topk_idx
+        phase = key[0]
+        self._topk_cache_state()[phase] = {
+            "key": key,
+            "value": topk_idx,
+            "layer_num": self.layer_num,
+            "sparse_layer_ordinal": self.sparse_layer_ordinal,
+        }
 
     def _decode_topk(
         self,
@@ -506,7 +519,11 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
         index_prefill_md = (
             index_metadata.prefill if index_metadata is not None else prefill_md
         )
-        return minimax_m3_index_topk(
+        key = self._topk_cache_key("prefill", index_q[start:stop], index_prefill_md)
+        cached = self._load_cached_topk(key)
+        if cached is not None:
+            return cached
+        topk_idx = minimax_m3_index_topk(
             index_q[start:stop].view(-1, self.num_idx_heads, self.index_head_dim),
             self.index_cache_layer.kv_cache,
             index_prefill_md.block_table,
@@ -522,6 +539,8 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
             self.scale,
             emit_sparse_block_table=True,
         )
+        self._store_cached_topk(key, topk_idx)
+        return topk_idx
 
     def _run_decode_sparse_attention(
         self,

--- a/atom/plugin/vllm/attention/minimax_m3_attnetion.py
+++ b/atom/plugin/vllm/attention/minimax_m3_attnetion.py
@@ -378,7 +378,7 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
         positions: torch.Tensor,
         main_metadata,
         index_metadata,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, object, object]:
         from atom.models.minimax_m3 import _minimax_m3_cos_sin_cache
 
         if self.kv_cache.numel() == 0 or self.index_cache_layer.kv_cache.numel() == 0:
@@ -386,6 +386,10 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
             return (
                 qkv.new_zeros((num_tokens, self.q_size)),
                 qkv.new_zeros((num_tokens, self.index_q_size)),
+                self.kv_cache,
+                self.kv_cache,
+                None,
+                None,
             )
 
         qkv = qkv.contiguous()
@@ -424,7 +428,7 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
             v_scale=v_scale if self.kv_cache_dtype == "fp8" else None,
             asm_layout=True,
         )
-        return q_out, index_q
+        return q_out, index_q, k_cache, v_cache, k_scale, v_scale
 
     def _topk_cache_key(self, phase: str, index_q: torch.Tensor, metadata) -> tuple:
         return (
@@ -609,14 +613,15 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
         query: torch.Tensor,
         index_q: torch.Tensor,
         output: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        k_scale,
+        v_scale,
         main_metadata,
         index_metadata,
     ) -> torch.Tensor:
         q = query.view(-1, self.num_heads, self.head_dim)
         out = output.view(-1, self.num_heads, self.head_dim)
-        k_cache, v_cache, k_scale, v_scale = (
-            self._page16_shuffle_cache_for_sparse_kernel()
-        )
         self._run_decode_sparse_attention(
             q,
             index_q,
@@ -662,16 +667,22 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
         self._validate_bound_sparse_state(main_metadata, index_metadata)
         if self.kv_cache.numel() == 0 or self.index_cache_layer.kv_cache.numel() == 0:
             return output.fill_(0)
-        q_actual, index_q = self._insert_qkv_and_index(
-            qkv[:actual_tokens],
-            positions[:actual_tokens],
-            main_metadata,
-            index_metadata,
+        q_actual, index_q, k_cache, v_cache, k_scale, v_scale = (
+            self._insert_qkv_and_index(
+                qkv[:actual_tokens],
+                positions[:actual_tokens],
+                main_metadata,
+                index_metadata,
+            )
         )
         output[:actual_tokens] = self._run_sparse_attention(
             q_actual,
             index_q,
             output[:actual_tokens],
+            k_cache,
+            v_cache,
+            k_scale,
+            v_scale,
             main_metadata,
             index_metadata,
         )

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -45,6 +45,12 @@ class MiniMaxM3Config(PretrainedConfig):
     """Minimal local config shim for MiniMax-M3 VL checkpoints."""
 
     model_type = "minimax_m3_vl"
+    text_config_override_attrs = {
+        "use_index_cache",
+        "index_topk_freq",
+        "index_topk_pattern",
+        "index_skip_topk_offset",
+    }
 
     def __init__(
         self,
@@ -60,6 +66,14 @@ class MiniMaxM3Config(PretrainedConfig):
         self.hidden_size = getattr(text_config, "hidden_size", None)
 
         super().__init__(**kwargs)
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name not in self.text_config_override_attrs:
+            return
+        text_config = self.__dict__.get("text_config")
+        if text_config is not None and text_config is not self:
+            setattr(text_config, name, value)
 
 
 def _set_plugin_mode() -> None:

--- a/recipes/atom_vllm/MiniMax-M3.md
+++ b/recipes/atom_vllm/MiniMax-M3.md
@@ -42,6 +42,7 @@ vllm serve "${MODEL}" \
     --no-enable-prefix-caching \
     --language-model-only \
     --no-trust-remote-code \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --additional-config '{"online_quant_config": {"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}}' \
     --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}'
 ```
@@ -67,6 +68,7 @@ vllm serve "${MODEL}" \
     --no-enable-prefix-caching \
     --language-model-only \
     --no-trust-remote-code \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
     --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}'
 ```
 

--- a/recipes/atom_vllm/MiniMax-M3.md
+++ b/recipes/atom_vllm/MiniMax-M3.md
@@ -26,7 +26,7 @@ checkpoint path or the corresponding model id for `MODEL`.
 MODEL=/path/to/MiniMax-M3-MXFP8
 TP=4
 PORT=8001
-
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
 vllm serve "${MODEL}" \
     --dtype auto \
     --load-format auto \
@@ -52,7 +52,7 @@ config:
 
 ```bash
 MODEL=/path/to/MiniMax-M3-MXFP4
-
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
 vllm serve "${MODEL}" \
     --dtype auto \
     --load-format auto \


### PR DESCRIPTION
## Motivation

Improve MiniMax-M3 sparse attention performance in the vLLM plugin path by reducing per-step metadata overhead and enabling CUDA Graph capture for the uniform single-token decode path.

## Technical Details

- Marked `MinimaxM3SparseAttentionMetadataBuilder` as `UNIFORM_SINGLE_TOKEN_DECODE` instead of disabling CUDA Graph support entirely.
- Added a decode-only metadata fast path for `max_query_len == 1`, avoiding decode/prefill splitting and CPU-side max reductions for plain decode batches.
- Reused preallocated `qo_indptr` for prefill metadata and replaced exact CPU-side max calculations with existing common metadata upper bounds.
- Moved MiniMax-M3 sparse block-size validation to builder initialization.
- Reused page-16 KV cache views between sparse KV/index insertion and sparse attention execution to avoid duplicate view setup.
- support index cache of vLLM-ATOM

## Test Plan

- Launch MiniMax-M3 vLLM service with ATOM adapters enabled with index cache.
- Run GSM8K accuracy validation:
  - MIXFP8
  - MIXFP4
  - MIXFP8 + kv_fp8
  - MIXFP4 + kv_fp8
 - Performance Test
```
MODEL=/shared/data/amd_int/models/MiniMax-M3-MXFP8
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
vllm serve "$MODEL" \
    --dtype auto \
    --load-format auto \
    --host localhost \
    --port 8001 \
    --tensor-parallel-size 4 \
    --gpu-memory-utilization 0.85 \
    --max-model-len 32768 \
    --max-num-batched-tokens 32768 \
    --block-size 128 \
    --no-async-scheduling \
    --kv-cache-dtype fp8 \
    --no-enable-prefix-caching \
    --language-model-only \
    --no-trust-remote-code \
    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
    --additional-config '{"online_quant_config": {"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}}' \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    2>&1 | tee log_m3_mxfp8_vllm.log
```

```
MODEL=/shared/data/amd_int/models/MiniMax-M3-MXFP4
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
vllm serve "$MODEL" \
    --dtype auto \
    --load-format auto\
    --host localhost \
    --port 8001 \
    --tensor-parallel-size 4 \
    --gpu-memory-utilization 0.85 \
    --max-model-len 32768 \
    --max-num-batched-tokens 32768 \
    --block-size 128 \
    --kv-cache-dtype fp8 \
    --no-enable-prefix-caching \
    --language-model-only \
    --no-trust-remote-code \
    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    2>&1 | tee log_m3_mxfp4_vllm_0625.log
```

## Test Result
### GSM8K accuracy
**MIXFP4** 
<img width="1304" height="278" alt="image" src="https://github.com/user-attachments/assets/a4372595-0dc6-413d-9c67-4a3c366f61b9" />

**MIXFP4-kv_fp8** 
<img width="1179" height="249" alt="image" src="https://github.com/user-attachments/assets/07500946-92c0-4020-84bd-877ac4fb9f56" />

**MIXFP8** 
<img width="1171" height="326" alt="image" src="https://github.com/user-attachments/assets/92f6da35-8941-4e31-bc70-b8f07a23f5f3" />

**MIXFP8-kv_fp8** 
<img width="1086" height="242" alt="image" src="https://github.com/user-attachments/assets/bb83dc95-97eb-40be-beb5-3f648e422300" />


### Performance 
**MIXFP4-8192-1024-16**
<img width="531" height="486" alt="image" src="https://github.com/user-attachments/assets/03dcb714-ace1-4e7b-becc-7603a087d6b5" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.