### PR TITLE
[minimax_m3] gate AR+RMSNorm fusion on ATOM_ENABLE_ALLREDUCE_RMSNORM_…

### DIFF
--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -761,8 +761,18 @@ def fused_allreduce_gemma_rms_norm(
     residual: torch.Tensor,
     norm: GemmaRMSNorm,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """MiniMax-M3 helper for delayed TP all-reduce followed by Gemma RMSNorm."""
-    if get_tensor_model_parallel_world_size() > 1:
+    """MiniMax-M3 helper for delayed TP all-reduce followed by Gemma RMSNorm.
+
+    Gated by ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION (default on): when enabled and
+    TP>1, the upstream RowParallel linear skips its all-reduce and this op fuses
+    all-reduce + residual-add + Gemma RMSNorm. When disabled, the linear does its
+    own all-reduce and this falls back to a plain residual-add + Gemma RMSNorm
+    (so the reduce_results and fusion toggles MUST move together).
+    """
+    if (
+        get_tensor_model_parallel_world_size() > 1
+        and envs.ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION
+    ):
         return tensor_model_parallel_fused_allreduce_rmsnorm(
             hidden_states.contiguous(),
             residual,

--- a/atom/models/minimax_m3.py
+++ b/atom/models/minimax_m3.py
@@ -165,6 +165,14 @@ def _minimax_m3_gemma_qk_norm(
     )
 
 
+# When on (default), the RowParallel o_proj / down_proj / MoE skip their own
+# all-reduce and the following Gemma RMSNorm fuses all-reduce + residual-add +
+# norm (fused_allreduce_gemma_rms_norm). Set ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION=0
+# to disable: linears all-reduce themselves and the norm runs unfused. Both sides
+# read this same flag so they always move together.
+ENABLE_ALLREDUCE_RMSNORM_FUSION = envs.ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION
+
+
 class MiniMaxM3MLP(nn.Module):
     def __init__(
         self,
@@ -297,7 +305,7 @@ class MiniMaxM3MoE(nn.Module):
                 hidden_size=config.hidden_size,
                 intermediate_size=config.intermediate_size,
                 params_dtype=params_dtype,
-                reduce_results=False,
+                reduce_results=not ENABLE_ALLREDUCE_RMSNORM_FUSION,
                 renormalize=True,
                 activation=ActivationType.Swiglu,
                 scoring_func=getattr(config, "scoring_func", "sigmoid"),
@@ -322,7 +330,7 @@ class MiniMaxM3MoE(nn.Module):
                 config=config,
                 intermediate_size=config.intermediate_size * config.n_shared_experts,
                 quant_config=quant_config,
-                reduce_results=False,
+                reduce_results=not ENABLE_ALLREDUCE_RMSNORM_FUSION,
                 prefix=f"{prefix}.shared_experts",
             )
 
@@ -388,7 +396,7 @@ class MiniMaxM3Attention(nn.Module):
             self.total_num_heads * self.head_dim,
             self.hidden_size,
             bias=False,
-            reduce_results=False,
+            reduce_results=not ENABLE_ALLREDUCE_RMSNORM_FUSION,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
         )
@@ -546,7 +554,7 @@ class MiniMaxM3SparseAttention(nn.Module):
             self.total_num_heads * self.head_dim,
             self.hidden_size,
             bias=False,
-            reduce_results=False,
+            reduce_results=not ENABLE_ALLREDUCE_RMSNORM_FUSION,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
         )
@@ -1164,7 +1172,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 config=config,
                 intermediate_size=config.dense_intermediate_size,
                 quant_config=quant_config,
-                reduce_results=False,
+                reduce_results=not ENABLE_ALLREDUCE_RMSNORM_FUSION,
                 prefix=f"{prefix}.mlp",
             )
 


### PR DESCRIPTION
…FUSION

Previously M3's target-model fusion was hardcoded on (fused_allreduce_gemma_rms_norm fused all-reduce + residual-add + Gemma RMSNorm whenever TP>1), ignoring the ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION env that the draft / deepseek_v2 / glm4_moe already honor — so the env couldn't disable M3's fusion for A/B testing.

Make both halves of the fusion move together under the flag (default on):
- layernorm.py fused_allreduce_gemma_rms_norm: also require envs.ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION; when off it returns a plain residual-add + Gemma RMSNorm (expects an already-all-reduced input).
- minimax_m3.py: the RowParallel o_proj (dense + sparse attn), MoE experts, shared_experts and dense MLP down_proj now use reduce_results=not ENABLE_ALLREDUCE_RMSNORM_FUSION, so when the env is off they do their own all-reduce and the norm runs unfused.

Default (=1) is byte-equivalent to before. Set ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION=0 to disable M3 target fusion (linears all-reduce, norm unfused).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
