### PR TITLE
fix: convert weight scale shape[N, K/128]  to [ceil(N/128), ceil(K/128)]

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -92,6 +92,44 @@ def divide(numerator, denominator):
     return numerator // denominator
 
 
+def quantize_weight_to_fp8_128x128_blockscale(weight, quant_dtype):
+    """Quantize a 2D weight to FP8 with 128x128 block scales.
+
+    Returns:
+        q_weight: quantized weight with the same shape as input ``weight``.
+        scale: per-block scale with shape ``(ceil(N/128), ceil(K/128))``.
+    """
+    assert weight.dim() == 2, f"expected 2D weight, got shape={tuple(weight.shape)}"
+
+    w = weight.to(torch.float32).contiguous()
+    n, k = w.shape
+    n_blocks = (n + 127) // 128
+    k_blocks = (k + 127) // 128
+    n_padded = n_blocks * 128
+    k_padded = k_blocks * 128
+
+    if n_padded != n or k_padded != k:
+        w = torch.nn.functional.pad(w, (0, k_padded - k, 0, n_padded - n))
+
+    w_blocks = w.view(n_blocks, 128, k_blocks, 128).permute(0, 2, 1, 3).contiguous()
+
+    finfo = torch.finfo(quant_dtype)
+    block_amax = w_blocks.abs().amax(dim=(2, 3))
+    scale = (block_amax / finfo.max).clamp_min(torch.finfo(torch.float32).tiny)
+
+    q_blocks = torch.clamp(
+        w_blocks / scale.unsqueeze(-1).unsqueeze(-1), min=finfo.min, max=finfo.max
+    ).to(quant_dtype)
+
+    q_weight = (
+        q_blocks.permute(0, 2, 1, 3)
+        .contiguous()
+        .view(n_padded, k_padded)[:n, :k]
+        .contiguous()
+    )
+    return q_weight, scale.contiguous()
+
+
 def gemm_a4w4_quant_fake(
     x: torch.Tensor,
     x_scale: torch.Tensor,
@@ -473,6 +511,7 @@ class LinearBase(nn.Module):
 
         assert online_quant_dtype in [
             torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
             torch.float4_e2m1fn_x2,
         ], (
             f"Unsupported online quant: "
@@ -540,6 +579,7 @@ class LinearBase(nn.Module):
         self.quant_func = get_hip_quant(online_quant_type)
         self.need_normalize_e4m3fn_to_e4m3fnuz = (
             online_quant_dtype == torch.float8_e4m3fnuz
+            and q_weight.dtype != torch.float8_e4m3fnuz
         )
         self._online_quant_info = {
             "layer": self.prefix,

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -218,8 +218,9 @@ class QuarkOnlineParser(QuantConfigParser):
         if not isinstance(online_quant_config, dict):
             raise TypeError("online_quant_config must be a dict parsed from JSON.")
 
-        SCHEME_MAP = {
+        scheme_map = {
             "ptpc": QuantType.per_Token,
+            "per_block": QuantType.per_1x128,
         }
 
         def _parse_online_quant_format(quant_format_str: str) -> LayerQuantConfig:
@@ -231,10 +232,14 @@ class QuarkOnlineParser(QuantConfigParser):
                 quant_type = QuantType.per_1x32
                 dtype_str = quant_format_str[2:]
             else:
-                parts = quant_format_str.split("_", 1)
-                if len(parts) == 2 and parts[0] in SCHEME_MAP:
-                    quant_type = SCHEME_MAP[parts[0]]
-                    dtype_str = parts[1]
+                matched_scheme = None
+                for scheme in sorted(scheme_map, key=len, reverse=True):
+                    if quant_format_str.startswith(scheme + "_"):
+                        matched_scheme = scheme
+                        break
+                if matched_scheme is not None:
+                    quant_type = scheme_map[matched_scheme]
+                    dtype_str = quant_format_str[len(matched_scheme) + 1 :]
                 else:
                     raise ValueError(
                         f"Unsupported online quant format: '{quant_format_str}'. "


### PR DESCRIPTION
## Motivation

  per_block_fp8 online quantization in ATOM can produce degenerate generation (all-f outputs or immediate EOS) because the weight-scale layout emitted by the online quant path does not match the layout expected by the existing linear FP8 blockscale GEMM backend.

## Technical Details

 In LinearBase.online_quantize_weight for online_quant_type == QuantType.per_1x128, we no longer
  use the generic per-group quant output directly (weight_scale shaped like [N, K/128]). Instead,
  we explicitly quantize weights into 128x128 blockscale format and emit:

  - q_weight: shape [N, K] (same logical weight shape),
  - weight_scale: shape [ceil(N/128), ceil(K/128)].

  This aligns online-quantized weights with the current linear compute path
  (gemm_a8w8_blockscale*), which consumes 128x128 block scales.

Additional fix included:
  Added float8_e4m3fnuz compatibility in online quant dtype checks and avoided redundant normalize
  marking when quant output is already fnuz (relevant on gfx942).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
