### PR TITLE
Triton GEMM Integration

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -38,6 +38,7 @@ from aiter.ops.triton.kv_cache import cat_and_cache_mla as triton_cat_and_cache_
 from aiter.ops.triton.fusions.fused_kv_cache import (
     fused_qk_rope_cat_and_cache_mla as triton_fused_qk_rope_cat_and_cache_mla,
 )
+from aiter.ops.shuffle import shuffle_weight
 from aiter.ops.triton.gather_kv_b_proj import gather_kv_b_proj
 from atom.config import get_current_atom_config
 from atom.model_ops.linear import use_triton_gemm
@@ -758,8 +759,17 @@ class MLAAttention(nn.Module):
                 fused_gemm_a8w8_blockscale_preshuffle_split_cat is not None
                 and weight.dtype == dtypes.fp8
             ):  # FP8 GEMM + split + cat
-                weight_shuffled = weight.reshape(
-                    weight.shape[0] // 16, weight.shape[1] * 16
+                # The preshuffle split-cat GEMM consumes a 16x16-shuffled weight.
+                # When ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE is enabled the loader
+                # already shuffled kv_b_proj.weight, so only reshape. Otherwise the
+                # weight is still in its raw (unshuffled) layout, so shuffle it here
+                # before the GEMM to keep the PRESHUFFLE=0 + triton path correct.
+                if envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE and use_triton_gemm() and envs.ATOM_USE_TRITON_MLA:
+                    weight_for_gemm = weight
+                else:
+                    weight_for_gemm = shuffle_weight(weight, layout=(16, 16))
+                weight_shuffled = weight_for_gemm.reshape(
+                    weight_for_gemm.shape[0] // 16, weight_for_gemm.shape[1] * 16
                 )
 
                 output_dtype = kv_c_normed.dtype

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -38,7 +38,6 @@ from aiter.ops.triton.kv_cache import cat_and_cache_mla as triton_cat_and_cache_
 from aiter.ops.triton.fusions.fused_kv_cache import (
     fused_qk_rope_cat_and_cache_mla as triton_fused_qk_rope_cat_and_cache_mla,
 )
-from aiter.ops.shuffle import shuffle_weight
 from aiter.ops.triton.gather_kv_b_proj import gather_kv_b_proj
 from atom.config import get_current_atom_config
 from atom.model_ops.linear import use_triton_gemm
@@ -759,17 +758,8 @@ class MLAAttention(nn.Module):
                 fused_gemm_a8w8_blockscale_preshuffle_split_cat is not None
                 and weight.dtype == dtypes.fp8
             ):  # FP8 GEMM + split + cat
-                # The preshuffle split-cat GEMM consumes a 16x16-shuffled weight.
-                # When ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE is enabled the loader
-                # already shuffled kv_b_proj.weight, so only reshape. Otherwise the
-                # weight is still in its raw (unshuffled) layout, so shuffle it here
-                # before the GEMM to keep the PRESHUFFLE=0 + triton path correct.
-                if envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE and use_triton_gemm() and envs.ATOM_USE_TRITON_MLA:
-                    weight_for_gemm = weight
-                else:
-                    weight_for_gemm = shuffle_weight(weight, layout=(16, 16))
-                weight_shuffled = weight_for_gemm.reshape(
-                    weight_for_gemm.shape[0] // 16, weight_for_gemm.shape[1] * 16
+                weight_shuffled = weight.reshape(
+                    weight.shape[0] // 16, weight.shape[1] * 16
                 )
 
                 output_dtype = kv_c_normed.dtype

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -78,10 +78,31 @@ if use_triton_gemm():
     except ImportError as e:
         logger.warning(f"Triton w8a8 GEMM not available: {e}")
         gemm_a8w8_blockscale_bpreshuffle_triton = None
+
+    # Plain (non-preshuffle) Triton blockscale GEMM. Consumes an unshuffled
+    # (N, K) weight with row-major x_scale (M, scale_k) and w_scale
+    # (scale_n, scale_k) -- the same layout the non-preshuffle path produces.
+    try:
+        from aiter.ops.triton.gemm.basic.gemm_a8w8_blockscale import (
+            gemm_a8w8_blockscale as gemm_a8w8_blockscale_triton,
+        )  # noqa: E402
+    except ImportError as e:
+        logger.warning(f"Triton w8a8 blockscale GEMM not available: {e}")
+        gemm_a8w8_blockscale_triton = None
+
+    # Per-tensor / per-token a8w8 (per-row activation x per-column weight scale).
+    try:
+        from aiter.ops.triton.gemm.basic.gemm_a8w8 import (
+            gemm_a8w8 as gemm_a8w8_triton,
+        )  # noqa: E402
+    except ImportError as e:
+        logger.warning(f"Triton a8w8 GEMM not available: {e}")
+        gemm_a8w8_triton = None
 else:
     gemm_afp4wfp4_preshuffle = None
     gemm_a8w8_blockscale_bpreshuffle_triton = None
-
+    gemm_a8w8_blockscale_triton = None
+    gemm_a8w8_triton = None
 from atom.model_ops.utils import MXFP4_QUANT_BLOCK_SIZE  # noqa
 
 
@@ -268,6 +289,31 @@ def gemm_a8w8_blockscale_preshuffle_impl(
     else:
         y = gemm_a8w8_blockscale_bpreshuffle(x, weight, x_scale, w_scale, dtype)
     return y
+
+
+def gemm_a8w8_blockscale_triton_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    return torch.empty((*x.shape[:-1], weight.shape[0]), dtype=dtype, device=x.device)
+
+
+@mark_trace(torch_compile=False)
+@torch_compile_guard(gen_fake=gemm_a8w8_blockscale_triton_fake, mutates_args=[])
+def gemm_a8w8_blockscale_triton_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    # Wrap the raw Triton launcher in a custom-op boundary so Dynamo treats it
+    # as opaque (otherwise tracing into the Triton kernel launch causes a graph
+    # break that splits the compiled model into >1 graph).
+    return gemm_a8w8_blockscale_triton(x, weight, x_scale, w_scale, dtype)
 
 
 def gemm_a8w8_per_tensor_fake(
@@ -732,13 +778,22 @@ class LinearBase(nn.Module):
                         prefix=self.prefix,
                     )
                 else:
-                    y = gemm_a8w8_blockscale(
-                        x,
-                        self.weight,
-                        x_scale,
-                        self.weight_scale,
-                        dtype=otype,
-                    )
+                    if use_triton_gemm() and gemm_a8w8_blockscale_triton is not None:
+                        y = gemm_a8w8_blockscale_triton_impl(
+                            x,
+                            self.weight,
+                            x_scale,
+                            self.weight_scale,
+                            dtype=otype,
+                        )
+                    else:
+                        y = gemm_a8w8_blockscale(
+                            x,
+                            self.weight,
+                            x_scale,
+                            self.weight_scale,
+                            dtype=otype,
+                        )
                 if self.bias is not None:
                     y += self.bias
             elif self.quant_type.value == QuantType.per_1x32.value:

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -19,7 +19,6 @@ from aiter import (
 
 # import torch.distributed as dist
 from aiter.dist.parallel_state import get_tp_group
-from aiter.ops.shuffle import shuffle_weight
 from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.tuned_gemm import tgemm
 from aiter.utility import fp4_utils
@@ -45,25 +44,6 @@ logger = logging.getLogger("atom")
 
 def use_triton_gemm() -> bool:
     return envs.ATOM_USE_TRITON_GEMM
-
-
-def maybe_shuffle_weight_for_preshuffle_gemm(weight: torch.Tensor) -> torch.Tensor:
-    """Return a 16x16-shuffled copy of *weight* for the non-preshuffle triton path.
-
-    Preshuffle blockscale GEMMs (``gemm_a8w8_blockscale_(b)preshuffle``,
-    ``gemm_a16w8_blockscale_preshuffle``) require a 16x16-shuffled weight. With
-    ``ATOM_USE_TRITON_GEMM=1`` and ``ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0`` the
-    loader keeps blockscale weights in their raw ``(N, K)`` layout (so the generic
-    dense linears can use the non-preshuffle triton kernel). Model code that still
-    calls a preshuffle kernel on such a weight (e.g. DeepSeek ``qkv_a_proj``) must
-    shuffle it at the call site; this helper centralizes that under the triton flag.
-
-    When PRESHUFFLE is enabled the loader has already shuffled the weight, so this
-    is a no-op (re-shuffling would corrupt it). ``weight_scale`` needs no shuffle.
-    """
-    if use_triton_gemm() and not envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE:
-        return shuffle_weight(weight, layout=(16, 16))
-    return weight
 
 
 def use_fp4_non_shuffle_triton_gemm() -> bool:
@@ -375,6 +355,45 @@ def gemm_a8w8_per_tensor_impl(
     )
 
 
+def gemm_a8w8_per_token_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    return torch.empty((*x.shape[:-1], weight.shape[0]), dtype=dtype, device=x.device)
+
+
+@mark_trace(torch_compile=False)
+@torch_compile_guard(gen_fake=gemm_a8w8_per_token_fake, mutates_args=[])
+def gemm_a8w8_per_token_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    # The triton a8w8 kernel natively applies a per-row (activation) and
+    # per-column (weight) scale -- exactly per-token-per-channel. The scales are
+    # already (M, 1) / (N, 1); flatten them to the (M,) / (N,) vectors the kernel
+    # expects. Unlike the AITER bpreshuffle path this consumes the unshuffled
+    # (N, K) weight, so the loader must skip the per_Token weight shuffle when
+    # use_triton_gemm() is enabled (see process_weights_after_loading).
+    x_scale_vec = x_scale.reshape(-1).to(torch.float32).contiguous()
+    w_scale_vec = w_scale.reshape(-1).to(torch.float32).contiguous()
+    return gemm_a8w8_triton(
+        x,
+        weight,
+        x_scale_vec,
+        w_scale_vec,
+        bias=bias,
+        dtype=dtype,
+    )
+
+
 class LinearBase(nn.Module):
     def __init__(
         self,
@@ -585,6 +604,7 @@ class LinearBase(nn.Module):
         )
         assert self.quant_type in [
             QuantType.No,
+            QuantType.per_Tensor,
             QuantType.per_1x128,
             QuantType.per_1x32,
         ], (
@@ -628,6 +648,19 @@ class LinearBase(nn.Module):
         elif self.quant_type == QuantType.per_1x32:
             # dequant MXFP8 (FP8 elements + 1x32 E8M0 shared scale)
             weight = weight_dequant_mxfp8(weight, weight_scale)
+        elif self.quant_type == QuantType.per_Tensor:
+            # dequant per-tensor fp8: weight (N, K) * per-partition scalar scale.
+            # Merged layers (qkv/gate_up) carry one scale per output partition.
+            w = weight.to(torch.float32)
+            ws = weight_scale.reshape(-1)
+            if ws.numel() <= 1:
+                w = w * ws.reshape(())
+            else:
+                off = 0
+                for i, sz in enumerate(self.output_partition_sizes):
+                    w[off : off + sz] = w[off : off + sz] * ws[i]
+                    off += sz
+            weight = w.to(get_current_atom_config().torch_dtype)
 
         q_weight, weight_scale = quant_weight_online(
             weight, online_quant_type, online_quant_dtype
@@ -646,6 +679,15 @@ class LinearBase(nn.Module):
         self.need_normalize_e4m3fn_to_e4m3fnuz = (
             online_quant_dtype == torch.float8_e4m3fnuz
         )
+        # A dynamic online target (e.g. ptpc per_Token) quantizes activations at
+        # runtime. Drop any static input_scale inherited from a static per_Tensor
+        # source, otherwise the per-token quant kernel rejects it
+        # ("unsupported: static per token quant").
+        if (
+            online_layer_quant_config.is_dynamic
+            and getattr(self, "input_scale", None) is not None
+        ):
+            self.input_scale = None
         self._online_quant_info = {
             "layer": self.prefix,
             "quant_type": online_quant_type.name,
@@ -704,6 +746,9 @@ class LinearBase(nn.Module):
             need_shuffle = (
                 self.quant_type == QuantType.per_Token
                 and self.params_dtype == dtypes.fp8
+                # The triton a8w8 per_Token GEMM consumes the unshuffled (N, K)
+                # weight; only the AITER bpreshuffle fallback needs the shuffle.
+                and not (use_triton_gemm() and gemm_a8w8_triton is not None)
             ) or (
                 self.quant_type == QuantType.per_1x32
                 and (not is_fp4_blockscale or not use_fp4_non_shuffle_triton_gemm())
@@ -711,6 +756,15 @@ class LinearBase(nn.Module):
             # per_1x128 only needs shuffle when using the preshuffle GEMM path
             if not need_shuffle and self.quant_type == QuantType.per_1x128:
                 need_shuffle = envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
+                # Modules whose fused forward calls a *preshuffle* blockscale GEMM
+                # directly (e.g. DeepSeek fused qkv_a_proj) need the 16x16-shuffled
+                # weight even under the non-preshuffle path
+                # (ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0). Shuffle once here at
+                # load time instead of per-forward.
+                if not envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE and getattr(
+                    self, "needs_preshuffled_weight", False
+                ):
+                    need_shuffle = True
             if need_shuffle:
                 if self.weight.dim() == 2:
                     shuffle_weights(self.weight)
@@ -775,6 +829,16 @@ class LinearBase(nn.Module):
                         x_scale,
                         self.weight_scale,
                         self.bias,
+                        dtype=otype,
+                    )
+                elif use_triton_gemm() and gemm_a8w8_triton is not None:
+                    # Triton a8w8 per-token-per-channel GEMM (unshuffled weight).
+                    y = gemm_a8w8_per_token_impl(
+                        x,
+                        self.weight,
+                        x_scale,
+                        self.weight_scale,
+                        bias=self.bias,
                         dtype=otype,
                     )
                 else:

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -19,6 +19,7 @@ from aiter import (
 
 # import torch.distributed as dist
 from aiter.dist.parallel_state import get_tp_group
+from aiter.ops.shuffle import shuffle_weight
 from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.tuned_gemm import tgemm
 from aiter.utility import fp4_utils
@@ -44,6 +45,25 @@ logger = logging.getLogger("atom")
 
 def use_triton_gemm() -> bool:
     return envs.ATOM_USE_TRITON_GEMM
+
+
+def maybe_shuffle_weight_for_preshuffle_gemm(weight: torch.Tensor) -> torch.Tensor:
+    """Return a 16x16-shuffled copy of *weight* for the non-preshuffle triton path.
+
+    Preshuffle blockscale GEMMs (``gemm_a8w8_blockscale_(b)preshuffle``,
+    ``gemm_a16w8_blockscale_preshuffle``) require a 16x16-shuffled weight. With
+    ``ATOM_USE_TRITON_GEMM=1`` and ``ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0`` the
+    loader keeps blockscale weights in their raw ``(N, K)`` layout (so the generic
+    dense linears can use the non-preshuffle triton kernel). Model code that still
+    calls a preshuffle kernel on such a weight (e.g. DeepSeek ``qkv_a_proj``) must
+    shuffle it at the call site; this helper centralizes that under the triton flag.
+
+    When PRESHUFFLE is enabled the loader has already shuffled the weight, so this
+    is a no-op (re-shuffling would corrupt it). ``weight_scale`` needs no shuffle.
+    """
+    if use_triton_gemm() and not envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE:
+        return shuffle_weight(weight, layout=(16, 16))
+    return weight
 
 
 def use_fp4_non_shuffle_triton_gemm() -> bool:

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -270,6 +270,45 @@ def gemm_a8w8_blockscale_preshuffle_impl(
     return y
 
 
+def gemm_a8w8_per_tensor_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    return torch.empty((*x.shape[:-1], weight.shape[0]), dtype=dtype, device=x.device)
+
+
+@mark_trace(torch_compile=False)
+@torch_compile_guard(gen_fake=gemm_a8w8_per_tensor_fake, mutates_args=[])
+def gemm_a8w8_per_tensor_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    # The triton a8w8 kernel applies a per-row (activation) and per-column
+    # (weight) scale. Per-tensor quantization produces a single scalar scale
+    # for each operand, so broadcast them into the (M,) / (N,) vectors the
+    # kernel expects before launching.
+    M = x.shape[0]
+    N = weight.shape[0]
+    x_scale_vec = x_scale.reshape(-1)[:1].to(torch.float32).expand(M).contiguous()
+    w_scale_vec = w_scale.reshape(-1)[:1].to(torch.float32).expand(N).contiguous()
+    return gemm_a8w8_triton(
+        x,
+        weight,
+        x_scale_vec,
+        w_scale_vec,
+        bias=bias,
+        dtype=dtype,
+    )
+
+
 class LinearBase(nn.Module):
     def __init__(
         self,
@@ -644,14 +683,24 @@ class LinearBase(nn.Module):
                         scale=getattr(self, "input_scale", None),
                     )
             if self.quant_type.value == QuantType.per_Tensor.value:
-                y = tgemm.mm(
-                    x,
-                    self.weight,
-                    self.bias,
-                    otype=otype,
-                    scale_a=x_scale,
-                    scale_b=self.weight_scale,
-                )
+                if use_triton_gemm() and gemm_a8w8_triton is not None:
+                    y = gemm_a8w8_per_tensor_impl(
+                        x,
+                        self.weight,
+                        x_scale,
+                        self.weight_scale,
+                        bias=self.bias,
+                        dtype=otype,
+                    )
+                else:
+                    y = tgemm.mm(
+                        x,
+                        self.weight,
+                        self.bias,
+                        otype=otype,
+                        scale_a=x_scale,
+                        scale_b=self.weight_scale,
+                    )
             elif self.quant_type.value == QuantType.per_Token.value:
                 if self.params_dtype == dtypes.i8:
                     y = gemm_a8w8(

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -68,7 +68,6 @@ from atom.model_ops.linear import (
     MergedReplicatedLinear,
     ReplicatedLinear,
     RowParallelLinear,
-    maybe_shuffle_weight_for_preshuffle_gemm,
     use_fp4_non_shuffle_triton_gemm,
     use_triton_gemm,
 )
@@ -725,11 +724,11 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant_fp8(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     M = hidden_states_quant.shape[0]
 
-    # This fused path always calls aiter's *preshuffle* blockscale GEMMs, which
-    # need a 16x16-shuffled weight. Under the non-preshuffle triton path the
-    # loader leaves fused_qkv_a_proj.weight unshuffled, so shuffle it here.
-    # (Flag-gated logic lives in linear.maybe_shuffle_weight_for_preshuffle_gemm.)
-    weight_qkv_a_proj = maybe_shuffle_weight_for_preshuffle_gemm(weight_qkv_a_proj)
+    # NOTE: this fused path always calls aiter's *preshuffle* blockscale GEMMs,
+    # which require a 16x16-shuffled weight. fused_qkv_a_proj is flagged with
+    # needs_preshuffled_weight=True so the loader shuffles it once even under the
+    # non-preshuffle path (ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0) -- see
+    # LinearBase.process_weights_after_loading.
 
     if hidden_states_quant_scale is None:
         if M <= 32:
@@ -1752,6 +1751,11 @@ class DeepseekV2MLAAttention(nn.Module):
                 source_quant_dtype=source_quant_dtype,
                 prefix=f"{prefix}.fused_qkv_a_proj",
             )
+            # The fused qkv_a_proj forward calls *preshuffle* blockscale GEMMs, so
+            # its weight must be 16x16-shuffled even when the global non-preshuffle
+            # path (ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0) is selected. The loader
+            # honors this flag in LinearBase.process_weights_after_loading.
+            self.fused_qkv_a_proj.needs_preshuffled_weight = True
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = ColumnParallelLinear(
                 q_lora_rank,

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -68,6 +68,7 @@ from atom.model_ops.linear import (
     MergedReplicatedLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    maybe_shuffle_weight_for_preshuffle_gemm,
     use_fp4_non_shuffle_triton_gemm,
     use_triton_gemm,
 )
@@ -723,6 +724,12 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant_fp8(
     transpose_scale: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     M = hidden_states_quant.shape[0]
+
+    # This fused path always calls aiter's *preshuffle* blockscale GEMMs, which
+    # need a 16x16-shuffled weight. Under the non-preshuffle triton path the
+    # loader leaves fused_qkv_a_proj.weight unshuffled, so shuffle it here.
+    # (Flag-gated logic lives in linear.maybe_shuffle_weight_for_preshuffle_gemm.)
+    weight_qkv_a_proj = maybe_shuffle_weight_for_preshuffle_gemm(weight_qkv_a_proj)
 
     if hidden_states_quant_scale is None:
         if M <= 32:

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -328,7 +328,12 @@ class GenericParser(QuantConfigParser):
             and weight_block_size[0] == 1
         ):
             quant_type = QuantType.per_1x32
-        is_dynamic = hf_quant_config.get("is_dynamic", True)
+        # `activation_scheme: static` ships precomputed input_scales in the
+        # checkpoint, so the activation quant is NOT dynamic (load the scales);
+        # `dynamic` (or unspecified) quantizes activations at runtime.
+        act_scheme = (hf_quant_config.get("activation_scheme") or "").lower()
+        default_dynamic = False if act_scheme == "static" else True
+        is_dynamic = hf_quant_config.get("is_dynamic", default_dynamic)
         # Each quantizer uses a different key for excluded layers:
         # Quark -> "exclude", compressed-tensors -> "ignore",
         # gpt-oss/HF transformers -> "modules_to_not_convert",
@@ -426,4 +431,15 @@ class GenericParser(QuantConfigParser):
         for pattern, qtype in self._QTYPE_PATTERNS.items():
             if re.search(pattern, config_str):
                 return qtype
+        # Bare compressed-tensors / vLLM fp8 (no weight_block_size, no config_groups,
+        # no explicit scheme/strategy) — e.g. Llama-3.1-8B-Instruct-FP8-KV with
+        # {"quant_method":"fp8","activation_scheme":"static"}. `activation_scheme`
+        # distinguishes per-tensor (static) from per-token (dynamic); default fp8 to
+        # per_Tensor so the weight/input scales actually get applied.
+        quant_method = (cfg.get("quant_method") or "").lower()
+        if quant_method in ("fp8", "float8") or re.search(r"fp8|float8", config_str):
+            act_scheme = (cfg.get("activation_scheme") or "").lower()
+            return (
+                QuantType.per_Token if act_scheme == "dynamic" else QuantType.per_Tensor
+            )
         return QuantType.No


### PR DESCRIPTION
## Motivation

Triton GEMM Integration for linear a8w8 blockscale/tensor scale/token scale GEMMs

## Technical Details

Integrated GEMM wrapper functions into ATOM linear.py

## Test Plan

Check traces for correct GEMM kernels, lm_eval accuracy matches non-triton accuracy

## Test Result

lm_eval passing accuracy and traces show correct GEMM kernels

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
