### PR TITLE
feat: add dtype option in LayerNorm class

### DIFF
--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -1054,18 +1054,23 @@ class LayerNorm(nn.Module):
         self,
         dim: int,
         eps: float = 1e-6,
+        dtype: torch.dtype | None = None
     ) -> None:
         super().__init__()
         self.dim = dim
         self.eps = eps
-        self.weight = atom_parameter(torch.ones(dim))
-        self.bias = atom_parameter(torch.zeros(dim))
+        self.dtype = dtype
+        self.weight = atom_parameter(torch.ones(dim, dtype=dtype))
+        self.bias = atom_parameter(torch.zeros(dim, dtype=dtype))
 
     def forward(
         self,
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        weight, bias = self.weight, self.bias
+        if self.dtype is not None and self.dtype != weight:
+            weight, bias = weight.to(self.dtype), bias.to(self.dtype)
         if residual is None:
             return layernorm2d_fwd_(x, self.weight, self.bias, self.eps, self.dim)
         else:

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -1069,11 +1069,11 @@ class LayerNorm(nn.Module):
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         weight, bias = self.weight, self.bias
-        if self.dtype is not None and self.dtype != weight:
+        if self.dtype is not None and self.dtype != weight.dtype:
             weight, bias = weight.to(self.dtype), bias.to(self.dtype)
         if residual is None:
-            return layernorm2d_fwd_(x, self.weight, self.bias, self.eps, self.dim)
+            return layernorm2d_fwd_(x, weight, bias, self.eps, self.dim)
         else:
             return layernorm2d_fwd_with_add_(
-                x, self.weight, residual, self.bias, self.eps, self.dim
+                x, weight, residual, bias, self.eps, self.dim
             )

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -1054,7 +1054,7 @@ class LayerNorm(nn.Module):
         self,
         dim: int,
         eps: float = 1e-6,
-        dtype: torch.dtype | None = None
+        dtype: torch.dtype | None = None,
     ) -> None:
         super().__init__()
         self.dim = dim

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -1059,7 +1059,6 @@ class LayerNorm(nn.Module):
         super().__init__()
         self.dim = dim
         self.eps = eps
-        self.dtype = dtype
         self.weight = atom_parameter(torch.ones(dim, dtype=dtype))
         self.bias = atom_parameter(torch.zeros(dim, dtype=dtype))
 
@@ -1068,12 +1067,9 @@ class LayerNorm(nn.Module):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        weight, bias = self.weight, self.bias
-        if self.dtype is not None and self.dtype != weight.dtype:
-            weight, bias = weight.to(self.dtype), bias.to(self.dtype)
         if residual is None:
-            return layernorm2d_fwd_(x, weight, bias, self.eps, self.dim)
+            return layernorm2d_fwd_(x, self.weight, self.bias, self.eps, self.dim)
         else:
             return layernorm2d_fwd_with_add_(
-                x, weight, residual, bias, self.eps, self.dim
+                x, self.weight, residual, self.bias, self.eps, self.dim
             )

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1551,7 +1551,7 @@ class Indexer(nn.Module):
                 quant_config=None,
                 prefix=f"{prefix}.weights_proj",
             )
-        self.k_norm = LayerNorm(self.head_dim, eps=1e-6)
+        self.k_norm = LayerNorm(self.head_dim, eps=1e-6, dtype=torch.float32)
         self.softmax_scale = self.head_dim**-0.5
         self._weights_scale = self.softmax_scale * self.n_head**-0.5
 


### PR DESCRIPTION
## Motivation

This is a companion PR to https://github.com/ROCm/aiter/pull/3451.

https://github.com/ROCm/aiter/pull/3451 requires that LayerNorm weights are in fp32 for use in the DeepSeek v3.2 fused indexer, this is done to prevent casting weights from fp32 to bf16 which results in a loss of precision. This PR aligns with this by making the LayerNorm weights FP32 for the DeepSeek v3.2 ATOM pipeline.

## Test Plan

Verify performance and accuracy before and after changes from this PR in combination with the companion aiter PR.

## Test Result

### Performance comparison

**Configuration:** ISL=1000, OSL=100, CONC=4

| Metric | FP32 LayerNorm | Main | Δ (%) |
| --- | --- | --- | --- |
| Time to First Token (TTFT, ms) | 229.31 | 216.36  | -5.6% |
| Time per Output Token (TPOT, ms) | 13.08 | 13.25  | +1.3% |
| Inter-token Latency (ITL, ms) | 13.08 | 13.25 | +1.3% |
| End-to-end Latency (E2EL, ms) | 1524.64 | 1528.34 | +0.2% |

### Accuracy

### FP32 LayerNorm
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9568|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9560|±  |0.0056|

### Main
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9598|±  |0.0054|
|     |       |strict-match    |     5|exact_match|↑  |0.9591|±  |0.0055|

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
