### PR TITLE
fix(glm_moe_dsa): run the MTP layer's own DSA indexer instead of reus…

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -215,14 +215,15 @@ def _should_skip_index_topk(config: PretrainedConfig, prefix: str) -> bool:
 
     layer_id = _extract_layer_index_from_prefix(prefix)
 
-    # GLM-5.2 MTP layer (index >= num_hidden_layers) reuses the cached topk.
+    # GLM-5.2 MTP layer (index >= num_hidden_layers): the MTP block ships its
+    # OWN indexer weights and computes its own top-k for the drafted position,
+    # so do not skip it. `index_share_for_mtp_iteration` only concerns sharing
+    # across MULTIPLE MTP draft steps (num_speculative_tokens>1); it does NOT
+    # mean the MTP reuses the target model's index. Matches vLLM upstream and
+    # the ATOM sglang plugin, which both run the MTP indexer independently.
     num_hidden_layers = getattr(config, "num_hidden_layers", None)
-    if (
-        num_hidden_layers is not None
-        and layer_id >= num_hidden_layers
-        and getattr(config, "index_share_for_mtp_iteration", False)
-    ):
-        return True
+    if num_hidden_layers is not None and layer_id >= num_hidden_layers:
+        return False
 
     # GLM-5.2 IndexShare: per-layer schedule, "shared" reuses the prior "full"
     # layer's topk. Authoritative when present; else fall back to pattern/freq.


### PR DESCRIPTION
## Summary

  GLM-5.2 (`glm_moe_dsa`) MTP speculative decoding has a very low acceptance
  rate because the MTP layer is forced to reuse the **target** model's DSA
  indexer top-k instead of computing its own.

  `_should_skip_index_topk` skips the indexer top-k for the MTP layer
  (`layer_id >= num_hidden_layers`) whenever `index_share_for_mtp_iteration`
  is set, so the MTP block attends with the target model's top-k. But the MTP
  block ships its **own** indexer weights in the checkpoint
  (`model.layers.{num_hidden_layers}.self_attn.indexer.{wk,wq_b,weights_proj,k_norm}`)
  and is meant to compute a fresh top-k for the drafted position. Reusing the
  target's top-k feeds the draft a wrong attention context at all sequence
  lengths (short context `< index_topk` is affected too), which collapses the
  accept rate.

  ## Why this is the correct behavior

  Neither reference implementation reuses the target index:

  - **vLLM upstream** (`deepseek_mtp.py`) allocates a dedicated
    `topk_indices_buffer` and its own `Indexer` for the MTP block, and
    computes the MTP top-k independently. There is no
    `index_share_for_mtp_iteration` concept upstream at all.
  - **ATOM sglang plugin** runs the MTP indexer independently as well — no
    skip/share logic.

  `index_share_for_mtp_iteration` should, at most, share the index across
  **multiple** MTP draft steps (`num_speculative_tokens > 1`); it must not make
  the MTP reuse the **target** model's index.

  ## Change

  Drop the MTP special-case in `_should_skip_index_topk` so the MTP layer
  computes its own top-k with its own (already loaded) indexer weights,
  matching vLLM upstream and the ATOM sglang plugin.

  ## Scope / blast radius

  - Only affects models with the DSA indexer (`hasattr(config, "index_topk")`)
    **and** MTP layers — i.e. GLM-5.2 (`glm_moe_dsa`) and DeepSeek-V3.2
    (`deepseek_v32`). Non-DSA models never call this function.
  - Only the MTP/nextn layers (`layer_id >= num_hidden_layers`) are touched;
    the main stack still goes through the unchanged
    `indexer_types`/`pattern`/`freq` logic.
  - `forward` already guards on `self.indexer is not None`, so an MTP layer
    without its own indexer simply won't call it (no crash).

  ## Validation

  8×MI355X, TP=8, GLM-5.2-MXFP4, bf16 KV cache, `num_speculative_tokens=1`,
  greedy (`temperature 0 / top_p 1.0 / top_k 1`), ShareGPT:

  | | per-position accept | accept length | TPOT |
  |---|---|---|---|
  | before | ~46% | 1.46 | ~63 ms |
  | after  | ~88% | 1.88 | ~51 ms |

  Long-context correctness unchanged: a 20k-token needle-in-haystack prompt
  returns the exact embedded answer.

  ## Regression origin

  Introduced by #1260 (`glm_moe_dsa: support GLM-5.2 IndexShare (FP8)`), which
  validated generation correctness/gsm8k on FP8 weights but did not measure MTP
  acceptance.