### PR TITLE
fix(pd): transfer MiniMax-M3 sparse indexer-key cache in disaggregation

### DIFF
--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -755,6 +755,12 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                 for layer_id in range(num_layers):
                     _add_region(runner.kv_scale[0, layer_id])
                     _add_region(runner.kv_scale[1, layer_id])
+            # MiniMax-M3 sparse attention's per-token indexer-key cache
+            # (used for top-k block selection on the consumer).
+            index_cache = getattr(runner, "sparse_attention_index_cache", None)
+            if index_cache is not None:
+                for sparse_idx in range(index_cache.shape[0]):
+                    _add_region(index_cache[sparse_idx])
 
         return KVTransferTensors(
             block_regions=block_regions,


### PR DESCRIPTION
MiniMax-M3 sparse attention reuses the unified KV cache and kv_scale for K/V, so the fp8 per-token scales already travel with the KV blocks. It keeps one extra per-token buffer, runner.sparse_attention_index_cache, holding the indexer keys used for top-k block selection at decode time. get_kv_transfer_tensors() never registered that buffer, so under PD disaggregation the decode node ran top-k against a zero/stale index for the prefilled tokens and attended to the wrong KV blocks. This is masked for short prompts (the init+local+topk window already covers every block, so selection is moot) but corrupts output once the context exceeds that window.

Register the indexer-key cache as block-indexed transfer regions (one per sparse layer, same physical-block striding as the KV cache), guarded by getattr so non-sparse models and bf16 paths are unaffected.

Tested (latest image, 1P+1D TP4, fp8 KV via Triton attention): GSM8K 5-shot = 0.9401, i.e. no regression to M3 fp8 PD. Short-prompt GSM8K does not exercise the long-context top-k path the buffer affects; that path is covered by review, not this run.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
