### PR TITLE
Enable TBO Support & Fix Accuracy Regressions for Kimi K2.5

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1032,6 +1032,7 @@ class Config:
     long_prefill_token_threshold: int = 0
     attn_prefill_chunk_size: int = 16384
     scheduler_delay_factor: float = 0.0
+    prefill_batch_token_threshold: int = 0
     max_num_seqs: int = 512
     max_model_len: int | None = None
     gpu_memory_utilization: float = 0.9

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -43,6 +43,7 @@ class EngineArgs:
     attn_prefill_chunk_size: int = 16384
     enable_chunked_prefill: bool = True
     scheduler_delay_factor: float = 0.0
+    prefill_batch_token_threshold: int = 0
     max_num_seqs: int = 512
     gpu_memory_utilization: float = 0.9
     cudagraph_capture_sizes: str = "[1,2,4,8,16,32,48,64,128,256]"
@@ -211,6 +212,15 @@ class EngineArgs:
             type=int,
             default=16384,
             help="Maximum number of tokens to batch together in async engine",
+        )
+        parser.add_argument(
+            "--prefill-batch-token-threshold",
+            type=int,
+            default=0,
+            help=(
+                "Hold new prefills until this many eligible tokens are waiting. "
+                "0 uses max-num-batched-tokens."
+            ),
         )
         parser.add_argument(
             "--long-prefill-token-threshold",

--- a/atom/model_engine/prefill_delayer.py
+++ b/atom/model_engine/prefill_delayer.py
@@ -7,7 +7,7 @@ the "mixed prefillable status → delay" core that fixes our 1k/1k workload's
 
 Mechanism (per scheduler tick):
   1. Each DP rank reports its local state via cpu all_gather:
-       (local_prefillable, watermark_force_allow)
+       (local_prefillable, local_prefill_sufficient, watermark_force_allow)
   2. Compute `prefillable_status` ∈ {all, none, mixed}:
        - "all"   → every rank has a new prefill ready  → allow (8-way aligned)
        - "none"  → no rank has any prefill             → allow (vacuous)
@@ -97,10 +97,11 @@ class PrefillDelayer:
         # Encoding:
         #   slot 0 = local_prefillable          (MAX → "any rank prefillable")
         #   slot 1 = local_force                (MAX → "any rank forces allow")
-        #   slot 2 = NOT local_prefillable      (MAX → "any rank lacks prefill")
+        #   slot 2 = NOT local_prefill_sufficient
+        #            (MAX → "any rank lacks the configured dense batch")
         # Then prefillable_status:
-        #   any_prefillable AND any_not_prefillable → "mixed"
-        #   any_prefillable AND NOT any_not_prefillable → "all"
+        #   any_prefillable AND any_not_sufficient → "mixed"
+        #   any_prefillable AND NOT any_not_sufficient → "all"
         #   NOT any_prefillable → "none"
         # Single all_reduce, 3 int64s on cpu — negligible overhead.
         self._reduce_buf = torch.zeros(3, dtype=torch.int64, device="cpu")
@@ -132,6 +133,7 @@ class PrefillDelayer:
         self,
         local_prefillable: bool,
         token_usage: float,
+        local_prefill_sufficient: Optional[bool] = None,
     ) -> bool:
         """
         Returns True iff this rank is allowed to admit new prefills this tick.
@@ -139,10 +141,16 @@ class PrefillDelayer:
         Args:
             local_prefillable: this rank has at least one new prefill ready
                 (i.e. self.waiting non-empty and admission would succeed).
+            local_prefill_sufficient: this rank also meets the configured
+                token/request density target. Defaults to local_prefillable
+                for compatibility with existing callers.
             token_usage: fraction of KV cache blocks currently in use
                 (used_blocks / total_blocks ∈ [0, 1]). Used by the
                 low-watermark safety valve.
         """
+        if local_prefill_sufficient is None:
+            local_prefill_sufficient = local_prefillable
+
         # Local "force allow" if KV cache is underutilized — don't delay
         # when GPU is starving. Only meaningful if this rank actually has
         # a prefill to push through (otherwise force_allow is a no-op).
@@ -157,7 +165,7 @@ class PrefillDelayer:
         # Cross-DP MAX-reduce: 3 booleans encoded as int64.
         self._reduce_buf[0] = 1 if local_prefillable else 0
         self._reduce_buf[1] = 1 if force else 0
-        self._reduce_buf[2] = 0 if local_prefillable else 1
+        self._reduce_buf[2] = 0 if local_prefill_sufficient else 1
         torch.distributed.all_reduce(
             self._reduce_buf,
             op=torch.distributed.ReduceOp.MAX,
@@ -165,11 +173,11 @@ class PrefillDelayer:
         )
         any_prefillable = int(self._reduce_buf[0].item()) > 0
         force_max = int(self._reduce_buf[1].item())
-        any_not_prefillable = int(self._reduce_buf[2].item()) > 0
+        any_not_sufficient = int(self._reduce_buf[2].item()) > 0
 
         # Derive 3-way status: all / none / mixed.
         prefillable_max = 1 if any_prefillable else 0
-        prefillable_min = 0 if any_not_prefillable else 1
+        prefillable_min = 0 if any_not_sufficient else 1
 
         # Watermark short-circuit: ANY rank below the watermark forces all
         # ranks to allow this tick. Without this the delayer can stall a
@@ -211,7 +219,7 @@ class PrefillDelayer:
                     f"[PrefillDelayer] DELAY: count={self._delayed_count} "
                     f"elapsed={elapsed_ms:.1f}ms "
                     f"any_prefillable={any_prefillable} "
-                    f"any_not_prefillable={any_not_prefillable}"
+                    f"any_not_sufficient={any_not_sufficient}"
                 )
             self._maybe_log()
             return False

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -447,7 +447,11 @@ class Scheduler:
         # Latency of the last prompt step
         self.last_prompt_latency = 0.0
         self.delay_factor = config.scheduler_delay_factor
-        self.prefill_batch_token_threshold = self.max_num_batched_tokens
+        self.prefill_batch_token_threshold = (
+            config.prefill_batch_token_threshold
+            if config.prefill_batch_token_threshold > 0
+            else self.max_num_batched_tokens
+        )
         self._prefill_hold_passes = 0
         self._prefill_hold_max_passes = 30
         _pc = getattr(config, "parallel_config", None)

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -452,10 +452,6 @@ class Scheduler:
             if config.prefill_batch_token_threshold > 0
             else self.max_num_batched_tokens
         )
-        self._prefill_hold_passes = 0
-        self._prefill_hold_max_passes = 30
-        _pc = getattr(config, "parallel_config", None)
-        self._prefill_gate_enabled = getattr(_pc, "data_parallel_size", 1) > 1
 
         # Speculative decoding
         self.use_spec = config.speculative_config is not None
@@ -594,38 +590,6 @@ class Scheduler:
             if total >= cap:
                 return cap
         return total
-
-    def _prefill_batch_ready(self) -> bool:
-        """Gate for firing a NEW prefill step (dense-batch requirement).
-
-        The threshold is max_num_batched_tokens (a full prefill batch).
-
-        Returns True (allow prefill) when:
-          - the waiting queue can fill a dense batch (>= threshold tokens), or
-          - there is nothing left to decode (running empty) — tail escape so a
-            partial final batch still goes out, or
-          - we've suppressed prefill for too many consecutive passes
-            (_prefill_hold_max_passes) — starvation bound.
-
-        Otherwise returns False (keep decoding) and advances the hold counter.
-        The counter resets whenever prefill is allowed to fire.
-        """
-        # Gate only applies under DP (>1); otherwise never hold (legacy path).
-        if not self._prefill_gate_enabled:
-            return True
-        # Tail escape: no decode work left — never hold, or we'd deadlock.
-        if not self.running:
-            self._prefill_hold_passes = 0
-            return True
-        if self._waiting_prefill_tokens() >= self.prefill_batch_token_threshold:
-            self._prefill_hold_passes = 0
-            return True
-        # Under-full: hold prefill (keep decoding) up to the pass budget.
-        self._prefill_hold_passes += 1
-        if self._prefill_hold_passes >= self._prefill_hold_max_passes:
-            self._prefill_hold_passes = 0
-            return True
-        return False
 
     def _kv_usage(self) -> float:
         """Fraction of KV-cache blocks currently in use ∈ [0, 1].
@@ -810,7 +774,12 @@ class Scheduler:
         if not self.running and not self.waiting:
             return None
 
-        _new_prefill_allowed = _delayer_allows_prefill and self._prefill_batch_ready()
+        # PrefillDelayer's result is a cross-rank decision. Do not apply a
+        # second rank-local density gate here: ranks could otherwise disagree
+        # after negotiation and recreate the mixed prefill/decode step the
+        # delayer is meant to prevent. Without a delayer, preserve immediate
+        # prefill admission rather than holding decode behind a local gate.
+        _new_prefill_allowed = _delayer_allows_prefill
 
         # ---- Phase 1: resume partial prefills from running ----
         # Gated by `delayer_allows` so cross-DP alignment still holds when one

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -795,11 +795,15 @@ class Scheduler:
             # can admit a prefill AND has a full batch's worth of waiting tokens.
             # This makes all ranks align on firing dense prefills together
             # instead of straggling partials.
-            _local_prefillable = self._can_admit_head_prefill() and (
-                self._waiting_prefill_tokens() >= self.prefill_batch_token_threshold
+            _local_prefillable = self._can_admit_head_prefill()
+            _local_prefill_sufficient = (
+                _local_prefillable
+                and self._waiting_prefill_tokens()
+                >= self.prefill_batch_token_threshold
             )
             _delayer_allows_prefill = self.prefill_delayer.should_allow_prefill(
                 local_prefillable=_local_prefillable,
+                local_prefill_sufficient=_local_prefill_sufficient,
                 token_usage=self._kv_usage(),
             )
 

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -447,6 +447,11 @@ class Scheduler:
         # Latency of the last prompt step
         self.last_prompt_latency = 0.0
         self.delay_factor = config.scheduler_delay_factor
+        self.prefill_batch_token_threshold = self.max_num_batched_tokens
+        self._prefill_hold_passes = 0
+        self._prefill_hold_max_passes = 30
+        _pc = getattr(config, "parallel_config", None)
+        self._prefill_gate_enabled = getattr(_pc, "data_parallel_size", 1) > 1
 
         # Speculative decoding
         self.use_spec = config.speculative_config is not None
@@ -556,6 +561,65 @@ class Scheduler:
                 continue
             if self.block_manager.can_allocate(seq) < 0:
                 return False  # KV-pressured: definitely cannot prefill
+            return True
+        return False
+
+    def _waiting_prefill_tokens(self) -> int:
+        """Sum of admissible new-prefill tokens sitting in the waiting queue,
+        capped at max_num_batched_tokens (we only care whether a *dense* batch
+        can be filled). Skips unschedulable / remote-KV-waiting entries and
+        clamps each seq to the chunked-prefill / budget limit, mirroring the
+        Phase-2 admission math so the count reflects what would actually pack
+        into one prefill step."""
+        total = 0
+        cap = self.max_num_batched_tokens
+        for seq in self.waiting:
+            if self._unschedulable_reason(seq) is not None:
+                continue
+            if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
+                continue
+            n = seq.num_tokens - seq.num_cached_tokens
+            if (
+                self.enable_chunked_prefill
+                and 0 < self.long_prefill_token_threshold < n
+            ):
+                n = self.long_prefill_token_threshold
+            if n > cap:
+                n = cap
+            total += n
+            if total >= cap:
+                return cap
+        return total
+
+    def _prefill_batch_ready(self) -> bool:
+        """Gate for firing a NEW prefill step (dense-batch requirement).
+
+        The threshold is max_num_batched_tokens (a full prefill batch).
+
+        Returns True (allow prefill) when:
+          - the waiting queue can fill a dense batch (>= threshold tokens), or
+          - there is nothing left to decode (running empty) — tail escape so a
+            partial final batch still goes out, or
+          - we've suppressed prefill for too many consecutive passes
+            (_prefill_hold_max_passes) — starvation bound.
+
+        Otherwise returns False (keep decoding) and advances the hold counter.
+        The counter resets whenever prefill is allowed to fire.
+        """
+        # Gate only applies under DP (>1); otherwise never hold (legacy path).
+        if not self._prefill_gate_enabled:
+            return True
+        # Tail escape: no decode work left — never hold, or we'd deadlock.
+        if not self.running:
+            self._prefill_hold_passes = 0
+            return True
+        if self._waiting_prefill_tokens() >= self.prefill_batch_token_threshold:
+            self._prefill_hold_passes = 0
+            return True
+        # Under-full: hold prefill (keep decoding) up to the pass budget.
+        self._prefill_hold_passes += 1
+        if self._prefill_hold_passes >= self._prefill_hold_max_passes:
+            self._prefill_hold_passes = 0
             return True
         return False
 
@@ -721,16 +785,24 @@ class Scheduler:
 
         # should_allow_prefill() runs a cross-DP all_reduce and MUST be called
         # every tick on every rank for lockstep — hence before the early-return.
+        _delayer_allows_prefill = True
         if self.prefill_delayer is not None:
-            delayer_allows = self.prefill_delayer.should_allow_prefill(
-                local_prefillable=self._can_admit_head_prefill(),
+            # A rank counts as "prefillable" for cross-DP alignment only if it
+            # can admit a prefill AND has a full batch's worth of waiting tokens.
+            # This makes all ranks align on firing dense prefills together
+            # instead of straggling partials.
+            _local_prefillable = self._can_admit_head_prefill() and (
+                self._waiting_prefill_tokens() >= self.prefill_batch_token_threshold
+            )
+            _delayer_allows_prefill = self.prefill_delayer.should_allow_prefill(
+                local_prefillable=_local_prefillable,
                 token_usage=self._kv_usage(),
             )
-        else:
-            delayer_allows = True
 
         if not self.running and not self.waiting:
             return None
+
+        _new_prefill_allowed = _delayer_allows_prefill and self._prefill_batch_ready()
 
         # ---- Phase 1: resume partial prefills from running ----
         # Gated by `delayer_allows` so cross-DP alignment still holds when one
@@ -738,7 +810,7 @@ class Scheduler:
         # Phase 2 in lockstep. Inside that, skip the running-queue scan entirely
         # when no seq is mid-prefill — the common steady-state decode case —
         # using the counter maintained by postprocess / preempt / finished-removal.
-        if delayer_allows and self._partial_prefill_count > 0:
+        if _delayer_allows_prefill and self._partial_prefill_count > 0:
             for seq in self.running:
                 if num_seqs_prefill >= self.max_num_seqs:
                     break
@@ -759,7 +831,7 @@ class Scheduler:
 
         # ---- Phase 2: new requests from waiting ----
         while (
-            delayer_allows
+            _new_prefill_allowed
             and (self.delay_factor <= 0 or self._passed_delay(time.time()))
             and self.waiting
             and num_seqs_prefill < self.max_num_seqs

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1051,7 +1051,15 @@ class MLAAttention(nn.Module):
                     paged_kv_indices = self.sparse_kv_indices_buffer
 
             dp_size = get_dp_group().world_size
-            use_persistent_mode = dp_size <= 8
+            # for DPA, AITER has no non-persistent kernel: fp8 Q + fp8 KV with a
+            # GQA ratio of 64.
+            gqa_ratio = self.padded_num_heads // self.num_kv_heads
+            requires_persistent_mode = (
+                q.dtype == dtypes.fp8
+                and kv_buffer.dtype == dtypes.fp8
+                and gqa_ratio == 64
+            )
+            use_persistent_mode = dp_size == 1 or requires_persistent_mode
             if envs.ATOM_MLA_PAGE_SIZE > 1:
                 use_persistent_mode = False
 

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1051,7 +1051,7 @@ class MLAAttention(nn.Module):
                     paged_kv_indices = self.sparse_kv_indices_buffer
 
             dp_size = get_dp_group().world_size
-            use_persistent_mode = not (dp_size > 1)
+            use_persistent_mode = dp_size <= 8
             if envs.ATOM_MLA_PAGE_SIZE > 1:
                 use_persistent_mode = False
 

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2477,6 +2477,17 @@ class FusedMoE(torch.nn.Module):
                 ),
                 dim=0,
             )
+        # In the DP-attn fallback path (dp>1, no MORI all2all), MoE runs
+        # after all_gather_with_padding, so the token dim can be dp_size times
+        # the per-rank max.
+        moe_max_num_tokens = atom_config.max_num_batched_tokens
+        if (
+            self.moe_parallel_config.dp_size > 1
+            and not self.moe_parallel_config.use_all2all_kernels
+            and atom_config.enable_dp_attention
+        ):
+            moe_max_num_tokens *= self.moe_parallel_config.dp_size
+
         if fuse_shared_experts and self.num_fused_shared_experts > 0:
             init_aiter_topK_meta_data(
                 n_routed_experts=self.global_num_experts,
@@ -2489,7 +2500,7 @@ class FusedMoE(torch.nn.Module):
                     if is_rocm_aiter_fuse_routed_scaling_factor()
                     else 1 / self.routed_scaling_factor
                 ),
-                max_num_tokens=atom_config.max_num_batched_tokens,
+                max_num_tokens=moe_max_num_tokens,
                 is_EP=self.use_ep,
             )
         if fuse_shared_experts:
@@ -2529,7 +2540,7 @@ class FusedMoE(torch.nn.Module):
             moe_parallel_config=self.moe_parallel_config,
             in_dtype=atom_config.torch_dtype,
             a_quant_dtype=a_quant_dtype,
-            max_num_tokens=atom_config.max_num_batched_tokens,
+            max_num_tokens=moe_max_num_tokens,
             has_bias=self.has_bias,
             # is_act_and_mul=True,
             is_lora_enabled=False,

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -87,6 +87,9 @@ class MoEActivationQuant(Enum):
         return MoEActivationQuant.BF16
 
 
+_TBO_KEEPALIVE: dict[tuple[str, int], tuple[torch.Tensor, ...]] = {}
+
+
 class FusedMoeWeightScaleSupported(Enum):
     """Supported quantization strategies for MoE weight scales."""
 
@@ -3459,6 +3462,26 @@ class FusedMoE(torch.nn.Module):
             hidden_states, router_logits, self.layer_name
         )
 
+    def _tbo_keepalive_slot(self) -> int:
+        try:
+            from atom.utils.tbo.ubatching import tbo_current_ubatch_id
+
+            return tbo_current_ubatch_id()
+        except Exception:
+            return 0
+
+    def _hold_tbo_keepalive(self, role: str, *tensors: torch.Tensor) -> None:
+        tensors = tuple(tensor for tensor in tensors if tensor is not None)
+        if tensors:
+            # Keep one previous tensor set per ubatch/role alive globally.
+            # The next same-role hold, often in the next MoE layer, happens
+            # after this ubatch has waited on the prior comm work, so
+            # overwriting here is the delayed safe release point.
+            key = (role, self._tbo_keepalive_slot())
+            if key in _TBO_KEEPALIVE:
+                del _TBO_KEEPALIVE[key]
+            _TBO_KEEPALIVE[key] = tensors
+
     def forward_impl_graph(
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor
     ):
@@ -3489,6 +3512,7 @@ class FusedMoE(torch.nn.Module):
                 )
 
                 tbo_yield_and_switch_from_compute_to_comm()
+                self._hold_tbo_keepalive("ag_source", hidden_states, router_logits)
 
             (
                 hidden_states,
@@ -3501,6 +3525,7 @@ class FusedMoE(torch.nn.Module):
 
             if _tbo:
                 tbo_switch_to_compute_sync()
+                self._hold_tbo_keepalive("ag_output", hidden_states, router_logits)
 
         # Matrix multiply.
         final_hidden_states = self.quant_method.apply(
@@ -3526,6 +3551,7 @@ class FusedMoE(torch.nn.Module):
         if use_dp_gather_scatter:
             if _tbo:
                 tbo_yield_and_switch_from_compute_to_comm()
+                self._hold_tbo_keepalive("rs_source", final_hidden_states)
             if dp_eager_mode:
                 final_hidden_states = reduce_scatterv(
                     final_hidden_states, sizes, dp_group
@@ -3536,6 +3562,7 @@ class FusedMoE(torch.nn.Module):
                 )
             if _tbo:
                 tbo_switch_to_compute_sync()
+                self._hold_tbo_keepalive("rs_output", final_hidden_states)
 
         if self.reduce_results and (self.tp_size > 1 or self.ep_size > 1):
             # Default set to False. (May have to add shared expert outputs.)

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -25,7 +25,13 @@ def is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
     # layout (set by the vLLM plugin under DP+EP); disable it there.
     if dp_size > 1 and config.moe_ep_flatten_tp_across_dp:
         return False
-    if dp_size > 1 and _has_module("mori") and config.enable_dp_attention:
+    use_mori_all2all = (
+        dp_size > 1
+        and _has_module("mori")
+        and config.enable_dp_attention
+        and config.enable_expert_parallel
+    )
+    if use_mori_all2all:
         return False
 
     if quant_config is not None and shared_expert_prefix is not None:
@@ -66,15 +72,6 @@ def is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
                 return False
             break
 
-    dp_size = config.parallel_config.data_parallel_size
-    use_mori_all2all = (
-        dp_size > 1
-        and _has_module("mori")
-        and config.enable_dp_attention
-        and config.enable_expert_parallel
-    )
-    if use_mori_all2all:
-        return False
     return True
 
 

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -66,6 +66,15 @@ def is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
                 return False
             break
 
+    dp_size = config.parallel_config.data_parallel_size
+    use_mori_all2all = (
+        dp_size > 1
+        and _has_module("mori")
+        and config.enable_dp_attention
+        and config.enable_expert_parallel
+    )
+    if use_mori_all2all:
+        return False
     return True
 
 

--- a/atom/utils/tbo/ubatch_wrapper.py
+++ b/atom/utils/tbo/ubatch_wrapper.py
@@ -542,6 +542,7 @@ class UBatchWrapper(nn.Module):
             batch_size=ub_num_reqs,
             graph_bs=graph_bs,
             is_draft=ctx.context.is_draft,
+            dp_uniform_decode=ctx.context.dp_uniform_decode,
         )
 
         return ForwardContext(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,8 @@ class _StubKVCacheTensor:
 class _StubParallelConfig:
     """Placeholder for ParallelConfig."""
 
-    pass
+    def __init__(self, data_parallel_size: int = 1):
+        self.data_parallel_size = data_parallel_size
 
 
 _atom_config.Config = _StubConfig
@@ -146,6 +147,12 @@ class MockConfig:
             stop_token_ids=[],
             scheduler_delay_factor=0.0,
             speculative_config=None,
+            # DP size gates the dense-batch prefill hold (see Scheduler). Default
+            # 1 (gate off) so unrelated tests keep legacy behavior; gate tests
+            # pass data_parallel_size>1.
+            parallel_config=_StubParallelConfig(
+                data_parallel_size=overrides.pop("data_parallel_size", 1)
+            ),
             # Scheduler.__init__ reads config.hf_config.architectures for V4
             # SWA-warmup detection; a non-V4 stub keeps that path inert.
             hf_config=_MockHFConfig(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,7 @@ class MockConfig:
             eos_token_id=2,
             stop_token_ids=[],
             scheduler_delay_factor=0.0,
+            prefill_batch_token_threshold=0,
             speculative_config=None,
             # DP size gates the dense-batch prefill hold (see Scheduler). Default
             # 1 (gate off) so unrelated tests keep legacy behavior; gate tests

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -673,3 +673,100 @@ class TestScheduledBatchPDFirstDecodeMTP:
         )
 
         assert list(batch.scheduled_tokens) == toks[-(mtp_k + 1) :]
+
+
+# ── Prefill dense-batch gate (threshold = max_num_batched_tokens) ───────────
+
+
+class TestPrefillBatchGate:
+    def test_threshold_defaults_to_batch_budget(self):
+        cfg = MockConfig(max_num_batched_tokens=32)
+        sched = Scheduler(cfg)
+        # Threshold is derived from the batch-token budget, not a separate knob.
+        assert sched.prefill_batch_token_threshold == 32
+
+    def test_ready_when_waiting_fills_threshold(self, seq_factory):
+        # chunked prefill on so a 40-token prompt is clamped to the 32 budget
+        # (not rejected as oversized) and counts toward the threshold.
+        cfg = MockConfig(max_num_batched_tokens=32, enable_chunked_prefill=True)
+        sched = Scheduler(cfg)
+        # Keep a decode running so the tail-escape doesn't trivially allow.
+        r = seq_factory([1, 2, 3])
+        r.status = SequenceStatus.RUNNING
+        sched.block_manager.allocate(r, 0)
+        sched.running.append(r)
+        # 40 waiting tokens, clamped to 32 == threshold -> ready.
+        sched.waiting.append(seq_factory(list(range(40))))
+        assert sched._waiting_prefill_tokens() >= 32
+        assert sched._prefill_batch_ready() is True
+
+    def test_holds_when_under_full(self, seq_factory):
+        # gate only active under DP>1
+        cfg = MockConfig(max_num_batched_tokens=32, data_parallel_size=8)
+        sched = Scheduler(cfg)
+        r = seq_factory([1, 2, 3])
+        r.status = SequenceStatus.RUNNING
+        sched.block_manager.allocate(r, 0)
+        sched.running.append(r)
+        # Only 8 waiting tokens < 32 -> hold (keep decoding).
+        sched.waiting.append(seq_factory(list(range(8))))
+        assert sched._prefill_batch_ready() is False
+        assert sched._prefill_hold_passes == 1
+
+    def test_gate_disabled_without_dp(self, seq_factory):
+        # DP<=1 (default): gate off -> under-full prefill is NOT held.
+        cfg = MockConfig(max_num_batched_tokens=32)  # data_parallel_size=1
+        sched = Scheduler(cfg)
+        assert sched._prefill_gate_enabled is False
+        r = seq_factory([1, 2, 3])
+        r.status = SequenceStatus.RUNNING
+        sched.block_manager.allocate(r, 0)
+        sched.running.append(r)
+        sched.waiting.append(seq_factory(list(range(8))))  # under-full
+        # Gate off -> ready True (legacy behavior), no hold counter advance.
+        assert sched._prefill_batch_ready() is True
+        assert sched._prefill_hold_passes == 0
+
+    def test_tail_escape_when_no_decode_left(self, seq_factory):
+        cfg = MockConfig(max_num_batched_tokens=32)  # threshold = 32
+        sched = Scheduler(cfg)
+        # running empty -> even an under-full waiting batch must be allowed,
+        # else the final partial batch would deadlock.
+        sched.waiting.append(seq_factory(list(range(8))))
+        assert not sched.running
+        assert sched._prefill_batch_ready() is True
+
+    def test_hold_pass_budget_forces_fire(self, seq_factory):
+        cfg = MockConfig(max_num_batched_tokens=32, data_parallel_size=8)
+        sched = Scheduler(cfg)
+        sched._prefill_hold_max_passes = 3
+        r = seq_factory([1, 2, 3])
+        r.status = SequenceStatus.RUNNING
+        sched.block_manager.allocate(r, 0)
+        sched.running.append(r)
+        sched.waiting.append(seq_factory(list(range(8))))  # under-full
+        # First (max_passes - 1) calls hold, then it force-fires and resets.
+        assert sched._prefill_batch_ready() is False  # pass 1
+        assert sched._prefill_batch_ready() is False  # pass 2
+        assert sched._prefill_batch_ready() is True  # pass 3 -> force
+        assert sched._prefill_hold_passes == 0
+
+    def test_gate_holds_new_prefill_but_decodes(self, seq_factory):
+        """End-to-end: under-full waiting + running decode -> schedule() should
+        NOT start a new prefill; it should return a decode batch instead."""
+        cfg = MockConfig(
+            max_num_batched_tokens=32,  # threshold = 32
+            enable_chunked_prefill=False,
+            data_parallel_size=8,  # gate only active under DP>1
+        )
+        sched = Scheduler(cfg)
+        r = seq_factory([1, 2, 3])
+        r.status = SequenceStatus.RUNNING
+        r.type = SequenceType.DECODE
+        sched.block_manager.allocate(r, 0)
+        sched.running.append(r)
+        sched.waiting.append(seq_factory(list(range(8))))  # under-full prefill
+        batch, _ = sched.schedule()
+        assert batch is not None
+        assert batch.total_seqs_num_prefill == 0
+        assert batch.total_seqs_num_decode == 1

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -678,7 +678,7 @@ class TestScheduledBatchPDFirstDecodeMTP:
 # ── Prefill dense-batch gate ───────────────────────────────────────────────
 
 
-class TestPrefillBatchGate:
+class TestPrefillBatchThreshold:
     def test_threshold_defaults_to_batch_budget(self):
         cfg = MockConfig(max_num_batched_tokens=32)
         sched = Scheduler(cfg)
@@ -694,79 +694,20 @@ class TestPrefillBatchGate:
         )
         assert sched.prefill_batch_token_threshold == 20
 
-    def test_ready_when_waiting_fills_threshold(self, seq_factory):
+    def test_waiting_prefill_tokens_reaches_threshold(self, seq_factory):
         # chunked prefill on so a 40-token prompt is clamped to the 32 budget
         # (not rejected as oversized) and counts toward the threshold.
         cfg = MockConfig(max_num_batched_tokens=32, enable_chunked_prefill=True)
         sched = Scheduler(cfg)
-        # Keep a decode running so the tail-escape doesn't trivially allow.
-        r = seq_factory([1, 2, 3])
-        r.status = SequenceStatus.RUNNING
-        sched.block_manager.allocate(r, 0)
-        sched.running.append(r)
-        # 40 waiting tokens, clamped to 32 == threshold -> ready.
+        # 40 waiting tokens are clamped to the 32-token batch budget.
         sched.waiting.append(seq_factory(list(range(40))))
         assert sched._waiting_prefill_tokens() >= 32
-        assert sched._prefill_batch_ready() is True
 
-    def test_holds_when_under_full(self, seq_factory):
-        # gate only active under DP>1
-        cfg = MockConfig(max_num_batched_tokens=32, data_parallel_size=8)
-        sched = Scheduler(cfg)
-        r = seq_factory([1, 2, 3])
-        r.status = SequenceStatus.RUNNING
-        sched.block_manager.allocate(r, 0)
-        sched.running.append(r)
-        # Only 8 waiting tokens < 32 -> hold (keep decoding).
-        sched.waiting.append(seq_factory(list(range(8))))
-        assert sched._prefill_batch_ready() is False
-        assert sched._prefill_hold_passes == 1
-
-    def test_gate_disabled_without_dp(self, seq_factory):
-        # DP<=1 (default): gate off -> under-full prefill is NOT held.
-        cfg = MockConfig(max_num_batched_tokens=32)  # data_parallel_size=1
-        sched = Scheduler(cfg)
-        assert sched._prefill_gate_enabled is False
-        r = seq_factory([1, 2, 3])
-        r.status = SequenceStatus.RUNNING
-        sched.block_manager.allocate(r, 0)
-        sched.running.append(r)
-        sched.waiting.append(seq_factory(list(range(8))))  # under-full
-        # Gate off -> ready True (legacy behavior), no hold counter advance.
-        assert sched._prefill_batch_ready() is True
-        assert sched._prefill_hold_passes == 0
-
-    def test_tail_escape_when_no_decode_left(self, seq_factory):
-        cfg = MockConfig(max_num_batched_tokens=32)  # threshold = 32
-        sched = Scheduler(cfg)
-        # running empty -> even an under-full waiting batch must be allowed,
-        # else the final partial batch would deadlock.
-        sched.waiting.append(seq_factory(list(range(8))))
-        assert not sched.running
-        assert sched._prefill_batch_ready() is True
-
-    def test_hold_pass_budget_forces_fire(self, seq_factory):
-        cfg = MockConfig(max_num_batched_tokens=32, data_parallel_size=8)
-        sched = Scheduler(cfg)
-        sched._prefill_hold_max_passes = 3
-        r = seq_factory([1, 2, 3])
-        r.status = SequenceStatus.RUNNING
-        sched.block_manager.allocate(r, 0)
-        sched.running.append(r)
-        sched.waiting.append(seq_factory(list(range(8))))  # under-full
-        # First (max_passes - 1) calls hold, then it force-fires and resets.
-        assert sched._prefill_batch_ready() is False  # pass 1
-        assert sched._prefill_batch_ready() is False  # pass 2
-        assert sched._prefill_batch_ready() is True  # pass 3 -> force
-        assert sched._prefill_hold_passes == 0
-
-    def test_gate_holds_new_prefill_but_decodes(self, seq_factory):
-        """End-to-end: under-full waiting + running decode -> schedule() should
-        NOT start a new prefill; it should return a decode batch instead."""
+    def test_without_delayer_underfull_prefill_is_admitted(self, seq_factory):
         cfg = MockConfig(
-            max_num_batched_tokens=32,  # threshold = 32
+            max_num_batched_tokens=32,
             enable_chunked_prefill=False,
-            data_parallel_size=8,  # gate only active under DP>1
+            data_parallel_size=8,
         )
         sched = Scheduler(cfg)
         r = seq_factory([1, 2, 3])
@@ -774,8 +715,7 @@ class TestPrefillBatchGate:
         r.type = SequenceType.DECODE
         sched.block_manager.allocate(r, 0)
         sched.running.append(r)
-        sched.waiting.append(seq_factory(list(range(8))))  # under-full prefill
+        sched.waiting.append(seq_factory(list(range(8))))
         batch, _ = sched.schedule()
         assert batch is not None
-        assert batch.total_seqs_num_prefill == 0
-        assert batch.total_seqs_num_decode == 1
+        assert batch.total_seqs_num_prefill == 1

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -675,7 +675,7 @@ class TestScheduledBatchPDFirstDecodeMTP:
         assert list(batch.scheduled_tokens) == toks[-(mtp_k + 1) :]
 
 
-# ── Prefill dense-batch gate (threshold = max_num_batched_tokens) ───────────
+# ── Prefill dense-batch gate ───────────────────────────────────────────────
 
 
 class TestPrefillBatchGate:
@@ -684,6 +684,15 @@ class TestPrefillBatchGate:
         sched = Scheduler(cfg)
         # Threshold is derived from the batch-token budget, not a separate knob.
         assert sched.prefill_batch_token_threshold == 32
+
+    def test_token_threshold_can_be_lower_than_batch_budget(self):
+        sched = Scheduler(
+            MockConfig(
+                max_num_batched_tokens=32,
+                prefill_batch_token_threshold=20,
+            )
+        )
+        assert sched.prefill_batch_token_threshold == 20
 
     def test_ready_when_waiting_fills_threshold(self, seq_factory):
         # chunked prefill on so a 40-token prompt is clamped to the 32 budget


### PR DESCRIPTION
## Motivation

Kimi K2.5 inference under Data-Parallel Attention (DPA) combined with Two-Batch Overlap (TBO) exposed several gaps that either crashed the engine or left performance on the table. This PR enables the DPA + TBO path end-to-end: it fixes the fused-MoE fallback and tensor lifetimes in the TBO overlap, aligns cross-DP prefill admission with TBO's two-batch requirement, and extends persistent MLA to multi-rank DP.

## Technical Details

- **Persistent MLA for DP attention** (`attention_mla.py`): relax `use_persistent_mode` from "single-rank only" (`not (dp_size > 1)`) to `dp_size <= 8`, so persistent MLA also runs in the multi-rank DP configuration used by Kimi K2.5.

- **Fix fused MoE on the DPA fallback path** (`moe.py`, `topK.py`):
  - In the DP-attn fallback (`dp_size > 1`, no MORI all2all), MoE runs after `all_gather_with_padding`, so the token dim can grow to `dp_size ×` the per-rank max. Scale `max_num_tokens` for the topK / fused-MoE metadata accordingly to avoid undersized buffers.
  - Only select the MORI all2all path when expert parallel is actually enabled (`enable_expert_parallel`), so DPA-without-EP correctly falls back instead of assuming all2all.

- **Fix TBO tensor live range** (`moe.py`): add a per-(role, ubatch) `_TBO_KEEPALIVE` holder around the all-gather and reduce-scatter comm/compute switches. Under TBO the source/output tensors of in-flight collectives could be freed before the overlapping ubatch waited on the comm; the keepalive defers release to the next same-role hold, which is past the wait point.

- **Two-batch-aware prefill alignment** (`scheduler.py`, `prefill_delayer.py`): TBO prefill splitting needs at least two local prefill requests per DP rank. Replace `_can_admit_head_prefill` (boolean) with `_count_admittable_head_prefills(limit)` and a `_prefill_delayer_readiness()` helper that reports both "has any prefill" and "alignment-ready" (`>= 2` requests when TBO is on, `>= 1` otherwise). `PrefillDelayer` gains a 4th MAX-reduce slot (`local_alignment_ready`) so prefill is delayed until every DP rank can launch a full two-batch, not just until one rank has a request.

- **Fix TBO prefill ubatch DP offsets** by propagating per-ubatch per-rank token counts through ForwardContext, then rebuilding ubatch-local DPMetadata inside UBatchWrapper. This prevents DP all_gatherv/reduce_scatterv from using full-batch offsets for individual ubatches.

- **Zero MoE all-gather padding rows** before fused-MoE routing/sort/dispatch. Padding rows are later sliced away, but they still participate in fused MoE internals; leaving them uninitialized can introduce NaN/Inf garbage, perturb expert buckets/shared scratch, and corrupt real tokens.

## Bugfix Validation

Bad TBO run before MoE padding fix: GSM8K flexible 0.8999, with 125 invalid responses and 238 corrupted outputs.
After fix: GSM8K flexible 0.9742, invalid down to 1, corrupted outputs down to 0.

## Perf Benchmark Plan

We tested Kimi K2.5 MXFP4 end-to-end inference on MI355X with ROCm 7.2.3, TP4.

The comparison includes:

- baseline without DPA / TBO
- DPA only
- DPA + TBO

## Test Results

Numbers in parentheses are throughput/GPU changes relative to the baseline.

| Conc | baseline throughput/GPU | baseline interactivity | DPA throughput/GPU | DPA interactivity | DPA+TBO throughput/GPU | DPA+TBO interactivity |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 898.9 | 104.95 | 611.7 (-32.0%) | 73.53 | 610.2 (-32.1%) | 73.63 |
| 8 | 1502.8 | 89.61 | 1061.4 (-29.4%) | 65.48 | 1077.1 (-28.3%) | 65.67 |
| 16 | 2045.6 | 61.85 | 1653.5 (-19.2%) | 51.93 | 1677.6 (-18.0%) | 52.86 |
| 32 | 2964.5 | 43.46 | 2542.4 (-14.2%) | 38.51 | 2588.0 (-12.7%) | 39.21 |
| 64 | 3946.8 | 29.06 | 3761.2 (-4.7%) | 28.52 | 3961.7 (+0.4%) | 30.09 |
| 128 | 4984.5 | 19.81 | 5133.1 (+3.0%) | 21.04 | 5745.4 (+15.3%) | 23.55 |

At higher concurrency, DPA and TBO show a higher throughput ceiling, with DPA+TBO reaching +15.3% throughput/GPU over the baseline at conc=128.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
