### PR TITLE
support online quant for quark models

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -300,7 +300,7 @@ class QuantizationConfig:
             self.quant_method = self.hf_quant_config.get("quant_method", "")
 
         # Online quantization: re-quantize float / FP8 / MXFP4 / MXFP8 / Quark
-        # models at load time. 
+        # models at load time.
         self.online_quant = False
         self.online_quant_config_raw = online_quant_config
         self.online_global_spec: LayerQuantConfig = LayerQuantConfig()

--- a/atom/config.py
+++ b/atom/config.py
@@ -299,7 +299,10 @@ class QuantizationConfig:
         else:
             self.quant_method = self.hf_quant_config.get("quant_method", "")
 
-        # Online quantization: re-quantize float / FP8 / MXFP4 models at load time
+        # Online quantization: re-quantize float / FP8 / MXFP4 / MXFP8 / Quark
+        # models at load time. Quark-exported checkpoints report
+        # quant_method="quark" regardless of their element dtype (e.g. the
+        # MiniMax-M3 MXFP4 export), so it must be allowed here too.
         self.online_quant = False
         self.online_quant_config_raw = online_quant_config
         self.online_global_spec: LayerQuantConfig = LayerQuantConfig()
@@ -310,6 +313,7 @@ class QuantizationConfig:
             "fp8",
             "mxfp4",
             "mxfp8",
+            "quark",
         ]:
             self.online_quant = True
             online_parser = get_quant_parser("online_quant")

--- a/atom/config.py
+++ b/atom/config.py
@@ -300,9 +300,7 @@ class QuantizationConfig:
             self.quant_method = self.hf_quant_config.get("quant_method", "")
 
         # Online quantization: re-quantize float / FP8 / MXFP4 / MXFP8 / Quark
-        # models at load time. Quark-exported checkpoints report
-        # quant_method="quark" regardless of their element dtype (e.g. the
-        # MiniMax-M3 MXFP4 export), so it must be allowed here too.
+        # models at load time. 
         self.online_quant = False
         self.online_quant_config_raw = online_quant_config
         self.online_global_spec: LayerQuantConfig = LayerQuantConfig()


### PR DESCRIPTION
## Motivation

There are cases where we want to online quant the quark models for some specific modules. For example, quant the bf16 attn linear layers to PTPC fp8 for https://huggingface.co/amd/MiniMax-M3-MXFP4, which is already quark quant model.

<img width="720" height="166" alt="image" src="https://github.com/user-attachments/assets/b2f1b582-d889-45f5-b0d4-b62796930862" />


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
