### PR TITLE
[atom benchmark] add indexer cache and online quant for M3 in atom benchmark

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -142,7 +142,7 @@
       "path": "MiniMaxAI/MiniMax-M3-MXFP8",
       "prefix": "m3-mxfp8",
       "runner": "atom-mi355-8gpu.predownload",
-      "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_FORCE_ATTN_TRITON=1\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
+      "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_FORCE_ATTN_TRITON=1",
       "config": {
         "tp": 4,
         "kv_cache_dtype": "fp8",
@@ -166,7 +166,7 @@
       "path": "amd/MiniMax-M3-MXFP4",
       "prefix": "m3-mxfp4",
       "runner": "atom-mi355-8gpu.predownload",
-      "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_FORCE_ATTN_TRITON=1\nAITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0",
+      "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_FORCE_ATTN_TRITON=1",
       "config": {
         "tp": 4,
         "kv_cache_dtype": "fp8",

--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -147,7 +147,7 @@
         "tp": 4,
         "kv_cache_dtype": "fp8",
         "trust_remote_code": true,
-        "extra_args": "--gpu-memory-utilization 0.8 --block-size 128 --max-model-len 32768 --max-num-batched-tokens 32768 --no-enable_prefix_caching --online_quant_config '{\"global_quant_config\": \"ptpc_fp8\", \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"vision_tower\", \"multi_modal_projector\", \"patch_merge_mlp\", \"*block_sparse_moe\"]}'"
+        "extra_args": "--gpu-memory-utilization 0.8 --block-size 128 --max-model-len 32768 --max-num-batched-tokens 32768 --no-enable_prefix_caching --online_quant_config '{\"global_quant_config\": \"ptpc_fp8\", \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"vision_tower\", \"multi_modal_projector\", \"patch_merge_mlp\", \"*block_sparse_moe\"]}' --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}'"
       },
       "variants": [
         { "label": "", "suffix": "", "extra_args": "--max-num-seqs 256" },
@@ -171,7 +171,7 @@
         "tp": 4,
         "kv_cache_dtype": "fp8",
         "trust_remote_code": true,
-        "extra_args": "--gpu-memory-utilization 0.8 --block-size 128 --max-model-len 32768 --max-num-batched-tokens 32768 --no-enable_prefix_caching"
+        "extra_args": "--gpu-memory-utilization 0.8 --block-size 128 --max-model-len 32768 --max-num-batched-tokens 32768 --no-enable_prefix_caching --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}'"
       },
       "variants": [
         { "label": "", "suffix": "", "extra_args": "--max-num-seqs 256" },

--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -171,7 +171,7 @@
         "tp": 4,
         "kv_cache_dtype": "fp8",
         "trust_remote_code": true,
-        "extra_args": "--gpu-memory-utilization 0.8 --block-size 128 --max-model-len 32768 --max-num-batched-tokens 32768 --no-enable_prefix_caching --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}'"
+        "extra_args": "--gpu-memory-utilization 0.8 --block-size 128 --max-model-len 32768 --max-num-batched-tokens 32768 --no-enable_prefix_caching --online_quant_config '{\"global_quant_config\": \"ptpc_fp8\", \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"vision_tower\", \"multi_modal_projector\", \"patch_merge_mlp\", \"*block_sparse_moe\"]}' --hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}'"
       },
       "variants": [
         { "label": "", "suffix": "", "extra_args": "--max-num-seqs 256" },

--- a/recipes/MiniMax-M3.md
+++ b/recipes/MiniMax-M3.md
@@ -170,7 +170,6 @@ draft_path=Inferact/MiniMax-M3-EAGLE3
 
 export ATOM_FORCE_ATTN_TRITON=1
 export AITER_QUICK_REDUCE_QUANTIZATION=INT4
-export AITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0
 
 python -m atom.entrypoints.openai_server \
   --model "$model_path" \

--- a/recipes/MiniMax-M3.md
+++ b/recipes/MiniMax-M3.md
@@ -30,7 +30,9 @@ python -m atom.entrypoints.openai_server \
   --max-model-len 32768 \
   --max-num-seqs 128 \
   --max-num-batched-tokens 32768 \
-  --no-enable_prefix_caching 2>&1 | tee "${run_name}-server.log"
+  --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
+  --no-enable_prefix_caching \
+  --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' 2>&1 | tee "${run_name}-server.log"
 ```
 
 ## MXFP8 on 4xMI355 GPUs
@@ -57,7 +59,8 @@ python -m atom.entrypoints.openai_server \
   --max-num-seqs 128 \
   --max-num-batched-tokens 32768 \
   --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
-  --no-enable_prefix_caching 2>&1 | tee "${run_name}-server.log"
+  --no-enable_prefix_caching \
+  --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' 2>&1 | tee "${run_name}-server.log"
 ```
 
 
@@ -182,7 +185,9 @@ python -m atom.entrypoints.openai_server \
   --max-num-seqs 256 \
   --kv_cache_dtype fp8 \
   --max-num-batched-tokens 32768 \
+  --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
   --no-enable_prefix_caching \
+  --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
   --method eagle3 \
   --draft-model "$draft_path" \
   --num-speculative-tokens 3 2>&1 | tee m3-mxfp4-eagle3-server.log


### PR DESCRIPTION
With online quant + index cache(M3 MXFP4 Eagle)
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9454|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9462|±  |0.0062|

Acceptance rate: 73.32%, Accepted tokens distribution: {0: '14.36%', 1: '12.10%', 2: '12.78%', 3: '60.77%'}