### PR TITLE
ci(benchmark): shard matrix by (variant×scenario) + concurrency to dodge GitHub's 256 limit

### DIFF
--- a/.github/benchmark/README.md
+++ b/.github/benchmark/README.md
@@ -8,10 +8,17 @@ Nightly + on-demand performance benchmarking for the models in
 
 ```
 build-matrix            (ubuntu) validate catalog ⟷ dispatch inputs;
-  │                              expand catalog → cells.json (one cell = one run)
+  │                              expand catalog → configs_json (one config =
+  │                              variant × scenario, carrying a concurrency list)
   ▼
-benchmark               (GPU, matrix: cell) composite container setup →
+benchmark               (caller, matrix: config) one entry per variant×scenario;
+  │                              each calls benchmark-tmpl.yml (secrets: inherit)
+  ▼
+  └ benchmark-tmpl.yml   (GPU, matrix: conc) composite container setup →
   │                              atom_test.sh launch + benchmark → benchmark-<rf>.json
+  │                              Two-level fan-out (config × conc) keeps each
+  │                              matrix < GitHub's 256-jobs-per-matrix limit while
+  │                              every cell still runs as its own parallel job.
   ▼
 summarize-benchmark-result (ubuntu) gather results + previous-nightly baseline →
   │                              summarize.py → regression_report.json;
@@ -101,8 +108,8 @@ allocated for them**.
 
 | script | role |
 |--------|------|
-| `catalog.py` | catalog loader: `load_variants`, `build_cells`, `validate_dispatch_inputs`, `build_args` |
-| `build_benchmark_matrix.py` | turns the GitHub event + dispatch inputs into the `cells_json` matrix output |
+| `catalog.py` | catalog loader: `load_variants`, `build_cells`, `build_cell_configs`, `scenario_tag`, `validate_dispatch_inputs`, `build_args` |
+| `build_benchmark_matrix.py` | turns the GitHub event + dispatch inputs into the `configs_json` matrix output (variant×scenario configs, each with a concurrency list) |
 | `dashboard_models_map.py` | prefix→display map JS for the dashboard |
 | `regression_rerun.py` | regression report → rerun matrix |
 | `atom_test.sh` | in-container driver: `launch` / `benchmark` / `accuracy` / `stop` |
@@ -110,7 +117,7 @@ allocated for them**.
 
 The GPU container lifecycle (start container + download model) is the composite
 action [`.github/actions/atom-bench-container`](../actions/atom-bench-container/action.yml),
-shared by the `benchmark` and `regression-rerun` jobs.
+shared by the `benchmark-tmpl.yml` reusable workflow and the `regression-rerun` job.
 
 ## Data contracts (keep stable)
 
@@ -120,8 +127,14 @@ shared by the `benchmark` and `regression-rerun` jobs.
   this — do not change the format without updating the dashboard.
 - **Cell**: `build_cells` emits
   `{display, prefix, suffix, model_path, server_args, bench_args, env_vars,
-  runner, isl, osl, conc, ratio, result_filename}` — the single `benchmark`
-  matrix dimension.
+  runner, isl, osl, conc, ratio, result_filename}` — one fully-resolved run.
+- **Config** (matrix entry): `build_cell_configs` regroups cells by
+  (variant × scenario) into `{display, prefix, suffix, model_path, server_args,
+  bench_args, env_vars, runner, isl, osl, ratio, ratio_str, scenario,
+  concurrency}` where `concurrency` is a JSON list. The `benchmark` caller
+  matrixes over configs; `benchmark-tmpl.yml` matrixes over each config's
+  `concurrency`. Both stay < GitHub's 256-jobs-per-matrix limit. Adding a model
+  or scenario needs no workflow edit — the caller matrix is fully dynamic.
 
 ## How to …
 

--- a/.github/scripts/build_benchmark_matrix.py
+++ b/.github/scripts/build_benchmark_matrix.py
@@ -2,8 +2,9 @@
 """Compute the benchmark cell matrix for the ATOM Benchmark workflow.
 
 Reads the GitHub event name and workflow_dispatch inputs from the environment
-and emits the fully-expanded list of benchmark cells (see ``catalog.build_cells``)
-to ``$GITHUB_OUTPUT`` as ``cells_json`` plus a ``has_cells`` flag.
+and emits the first-level matrix configs (variant × scenario, each carrying a
+concurrency list; see ``catalog.build_cell_configs``) to ``$GITHUB_OUTPUT`` as
+``configs_json`` plus a ``has_cells`` flag.
 
 Behaviour by event:
 - ``schedule``      -> all models, catalog ``default_scenarios`` (nightly grid).
@@ -25,7 +26,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from catalog import (  # noqa: E402
     build_cell_configs,
-    build_cells,
     load_variants,
     validate_dispatch_inputs,
 )
@@ -82,16 +82,16 @@ def main() -> int:
         model_filter = {k for k in model_keys if inputs.get(k)}
         param_lists = inputs.get("param_lists") or DEFAULT_PARAM_LISTS
 
-    cells = build_cells(CATALOG, param_lists=param_lists, model_filter=model_filter)
     configs = build_cell_configs(
         CATALOG, param_lists=param_lists, model_filter=model_filter
     )
     _emit(configs)
 
-    n_models = len({c["prefix"] for c in cells})
+    n_cells = sum(len(json.loads(c["concurrency"])) for c in configs)
+    n_models = len({c["prefix"] for c in configs})
     n_total = len(load_variants(CATALOG))
     print(
-        f"Event={event}: {len(cells)} cells across {n_models} models "
+        f"Event={event}: {n_cells} cells across {n_models} models "
         f"-> {len(configs)} matrix configs ({n_total} variants in catalog)",
         file=sys.stderr,
     )

--- a/.github/scripts/build_benchmark_matrix.py
+++ b/.github/scripts/build_benchmark_matrix.py
@@ -23,7 +23,12 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from catalog import build_cells, load_variants, validate_dispatch_inputs  # noqa: E402
+from catalog import (  # noqa: E402
+    build_cell_configs,
+    build_cells,
+    load_variants,
+    validate_dispatch_inputs,
+)
 
 CATALOG = ".github/benchmark/models.json"
 DEFAULT_PARAM_LISTS = "1024,1024,128,0.8"
@@ -40,13 +45,17 @@ RESERVED_INPUTS = {
 }
 
 
-def _emit(cells: list[dict]) -> None:
-    payload = json.dumps(cells)
+def _emit(configs: list[dict]) -> None:
+    # One entry per first-level matrix config (variant × scenario); each carries
+    # a JSON `concurrency` list the reusable template fans out over. Grouping
+    # keeps both matrix levels far under GitHub's 256-job-per-matrix limit that a
+    # flat per-cell matrix would overflow.
+    payload = json.dumps(configs)
     out = os.environ.get("GITHUB_OUTPUT")
     if out:
         with open(out, "a", encoding="utf-8") as f:
-            f.write(f"cells_json={payload}\n")
-            f.write(f"has_cells={'true' if cells else 'false'}\n")
+            f.write(f"configs_json={payload}\n")
+            f.write(f"has_cells={'true' if configs else 'false'}\n")
     else:
         print(payload)
 
@@ -74,13 +83,16 @@ def main() -> int:
         param_lists = inputs.get("param_lists") or DEFAULT_PARAM_LISTS
 
     cells = build_cells(CATALOG, param_lists=param_lists, model_filter=model_filter)
-    _emit(cells)
+    configs = build_cell_configs(
+        CATALOG, param_lists=param_lists, model_filter=model_filter
+    )
+    _emit(configs)
 
     n_models = len({c["prefix"] for c in cells})
     n_total = len(load_variants(CATALOG))
     print(
         f"Event={event}: {len(cells)} cells across {n_models} models "
-        f"({n_total} variants in catalog)",
+        f"-> {len(configs)} matrix configs ({n_total} variants in catalog)",
         file=sys.stderr,
     )
     return 0

--- a/.github/scripts/catalog.py
+++ b/.github/scripts/catalog.py
@@ -47,8 +47,10 @@ Three public entry points keep every consumer in sync:
 - `load_variants(path)`  -> flat per-variant dicts (server args, suffix, ...).
   Used by the dashboard display-name map and regression rerun.
 - `build_cells(path, ...)` -> fully-expanded benchmark cells (variant x scenario
-  x concurrency). Each cell self-describes one server+benchmark run and is the
-  single matrix dimension the GPU `benchmark` job iterates.
+  x concurrency). Each cell self-describes one server+benchmark run.
+- `build_cell_configs(path, ...)` -> cells regrouped by (variant x scenario) into
+  the first-level matrix configs the GPU `benchmark` job iterates; each config
+  carries a concurrency list the reusable template fans out over.
 - `validate_dispatch_inputs(path, keys)` -> assert the workflow_dispatch model
   checkboxes stay in sync with the catalog prefixes.
 """

--- a/.github/scripts/catalog.py
+++ b/.github/scripts/catalog.py
@@ -241,6 +241,84 @@ def build_cells(
     return cells
 
 
+def scenario_tag(isl: int, osl: int) -> str:
+    """Short scenario key for an (isl, osl) pair, e.g. 1024/1024 -> ``1k1k``.
+
+    Falls back to ``<isl>_<osl>`` for lengths that are not whole 1024 multiples
+    so the tag stays unambiguous.
+    """
+
+    def _fmt(n: int) -> str:
+        return f"{n // 1024}k"
+
+    if isl >= 1024 and osl >= 1024 and isl % 1024 == 0 and osl % 1024 == 0:
+        return f"{_fmt(isl)}{_fmt(osl)}"
+    return f"{isl}_{osl}"
+
+
+def build_cell_configs(
+    path: str | Path,
+    param_lists: str | None = None,
+    model_filter: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Group cells into first-level matrix configs: one per (variant, scenario).
+
+    A single GitHub Actions matrix tops out at 256 entries, which one-job-per-cell
+    overflows once the catalog passes 256 cells. Instead the workflow drives a
+    two-level fan-out (mirrors InferenceX run-sweep): the top ``benchmark`` job
+    matrixes over these configs (model variant × scenario), and the reusable
+    ``benchmark-tmpl.yml`` it calls matrixes over each config's ``concurrency``
+    list. Both matrices stay far below 256 while every (cell = config × conc)
+    still runs as its own parallel job.
+
+    Each config carries the per-server-launch fields plus the scenario shape and
+    a JSON-encoded ``concurrency`` list (the second-level matrix). ``result_filename``
+    is rebuilt per concurrency inside the template from
+    ``{prefix}{suffix}-{isl}-{osl}-{conc}-{ratio_str}`` (unchanged naming contract).
+    """
+    cells = build_cells(path, param_lists=param_lists, model_filter=model_filter)
+
+    configs: dict[tuple, dict[str, Any]] = {}
+    for c in cells:
+        key = (
+            c["prefix"],
+            c["suffix"],
+            c["model_path"],
+            c["server_args"],
+            c["env_vars"],
+            c["isl"],
+            c["osl"],
+            c["ratio"],
+        )
+        cfg = configs.get(key)
+        if cfg is None:
+            cfg = {
+                "display": c["display"],
+                "prefix": c["prefix"],
+                "suffix": c["suffix"],
+                "model_path": c["model_path"],
+                "server_args": c["server_args"],
+                "bench_args": c["bench_args"],
+                "env_vars": c["env_vars"],
+                "runner": c["runner"],
+                "isl": c["isl"],
+                "osl": c["osl"],
+                "ratio": c["ratio"],
+                "ratio_str": _fmt_ratio(c["ratio"]),
+                "scenario": scenario_tag(c["isl"], c["osl"]),
+                "_conc": [],
+            }
+            configs[key] = cfg
+        cfg["_conc"].append(c["conc"])
+
+    out: list[dict[str, Any]] = []
+    for cfg in configs.values():
+        conc = sorted(cfg.pop("_conc"))
+        cfg["concurrency"] = json.dumps(conc)
+        out.append(cfg)
+    return out
+
+
 def validate_dispatch_inputs(path: str | Path, input_keys: set[str]) -> list[str]:
     """Check workflow_dispatch boolean keys stay in sync with catalog prefixes.
 

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -106,7 +106,7 @@ jobs:
     name: Build benchmark matrix
     runs-on: ubuntu-latest
     outputs:
-      cells_json: ${{ steps.build.outputs.cells_json }}
+      configs_json: ${{ steps.build.outputs.configs_json }}
       has_cells: ${{ steps.build.outputs.has_cells }}
     steps:
       - uses: actions/checkout@v6
@@ -118,8 +118,14 @@ jobs:
           INPUTS_JSON: ${{ toJson(inputs) }}
         run: python3 .github/scripts/build_benchmark_matrix.py
 
+  # Top-level fan-out: one matrix entry per (model variant × scenario) config.
+  # Each invokes benchmark-tmpl.yml, which fans out over the config's
+  # `concurrency` list. Two bounded matrices replace the former flat per-cell
+  # matrix that overflowed GitHub's 256-job-per-matrix limit (278 cells). Every
+  # (config × conc) cell still runs as its own parallel job; the caller job name
+  # stays `benchmark` so downstream `needs:` are unchanged.
   benchmark:
-    name: ${{ matrix.cell.display }} (isl=${{ matrix.cell.isl }} osl=${{ matrix.cell.osl }} c=${{ matrix.cell.conc }})
+    name: ${{ matrix.config.display }} ${{ matrix.config.scenario }}
     needs: [build-matrix]
     if: >-
       !cancelled()
@@ -128,181 +134,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Single dimension: each cell is one fully-resolved run (model variant ×
-        # scenario × concurrency). Concurrency bands are already applied by
-        # build_benchmark_matrix.py, so out-of-range combos never get scheduled —
-        # no GPU runner is allocated for them (the old exclude/IN_RANGE gate is gone).
-        cell: ${{ fromJson(needs.build-matrix.outputs.cells_json) }}
-
-    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.cell.runner }}
-
-    env:
-      MODEL_PATH: ${{ matrix.cell.model_path }}
-      ARGS: ${{ matrix.cell.server_args }}
-      ISL: ${{ matrix.cell.isl }}
-      OSL: ${{ matrix.cell.osl }}
-      CONC: ${{ matrix.cell.conc }}
-      RANDOM_RANGE_RATIO: ${{ matrix.cell.ratio }}
-      RESULT_FILENAME: ${{ matrix.cell.result_filename }}
-
-    steps:
-      - name: Kill all Docker containers
-        run: |
-          echo "=== Cleaning up containers on $(hostname) ==="
-          containers=$(docker ps -q)
-          if [ -n "$containers" ]; then
-            docker kill $containers || true
-          fi
-          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "ls -la /workspace/ && find /workspace -mindepth 1 -delete" || true
-
-      - name: Show ROCm status (host)
-        run: docker ps -a && rocm-smi --showmemuse 2>/dev/null || true
-
-      - name: Checkout ATOM repo
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.atom_commit || github.ref }}
-
-      - name: Start container + download model
-        uses: ./.github/actions/atom-bench-container
-        with:
-          image: ${{ inputs.image || 'rocm/atom-dev:latest' }}
-          container-name: atom-benchmark
-          model-path: ${{ matrix.cell.model_path }}
-          env-vars: ${{ matrix.cell.env_vars }}
-          hf-token: ${{ secrets.AMD_HF_TOKEN }}
-          download-required: "true"
-          container-env: >-
-            -e ISL=${{ env.ISL }} -e OSL=${{ env.OSL }}
-            -e CONC=${{ env.CONC }} -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }}
-            -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }}
-            -e ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }}
-
-      - name: Collect GPU info (inside container)
-        id: gpu-info
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          RUNNER_HINT="${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.cell.runner }}"
-          bash .github/scripts/collect_gpu_info.sh atom-benchmark docker "$RUNNER_HINT"
-          # Resolve latest → nightly_YYYYMMDDHHMMSS for dashboard display
-          DOCKER_IMAGE="${{ inputs.image || 'rocm/atom-dev:latest' }}"
-          if [ "$DOCKER_IMAGE" = "rocm/atom-dev:latest" ]; then
-            RESOLVED_IMAGE=""
-            if RESOLUTION_JSON="$(python3 .github/scripts/resolve_atom_image.py --repository rocm/atom-dev --reference-tag latest --image-family native 2>/dev/null)"; then
-              RESOLVED_IMAGE="$(echo "$RESOLUTION_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("resolved_image",""))')" || true
-            fi
-            DOCKER_IMAGE="${RESOLVED_IMAGE:-$DOCKER_IMAGE}"
-          fi
-          echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
-          echo "Docker: ${DOCKER_IMAGE}"
-
-      - name: Run benchmark
-        timeout-minutes: 80
-        env:
-          EXTRA_LAUNCH_ARGS: ${{ inputs.extra_args || '' }}
-        run: |
-          set -euo pipefail
-          if [ -d "/models" ]; then model_path="/models/${{ env.MODEL_PATH }}"
-          else model_path="${{ env.MODEL_PATH }}"; fi
-
-          # Launch via stdin so the container's bash parses the shell quoting in
-          # ARGS exactly once -- single-quoted JSON values survive intact (e.g.
-          # --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}').
-          # Substituting ${{ env.ARGS }} into a `bash -lc "..."` string instead
-          # collides the JSON's double quotes with the outer quotes and strips
-          # them (argparse: invalid loads value). Mirrors atom-test.yaml.
-          echo "ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
-            ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
-            .github/scripts/atom_test.sh launch $model_path $ARGS $EXTRA_LAUNCH_ARGS" \
-            | docker exec -i atom-benchmark bash -l
-
-          echo "========== Running benchmark =========="
-          docker exec \
-            -e ENABLE_TORCH_PROFILER="${{ inputs.enable_profiler && '1' || '0' }}" \
-            -e RESULT_FILENAME="${{ env.RESULT_FILENAME }}" \
-            -e SERVER_ARGS="$ARGS" \
-            -e BENCH_EXTRA_ARGS="${{ matrix.cell.bench_args }}" \
-            -e MP="$model_path" \
-            atom-benchmark bash -lc '.github/scripts/atom_test.sh benchmark "$MP"'
-
-      - name: Dump server log
-        if: always()
-        run: |
-          docker exec atom-benchmark cat /tmp/atom_server.log 2>/dev/null || true
-
-      - name: Dump client log
-        if: always()
-        run: |
-          docker exec atom-benchmark cat /tmp/atom_client.log 2>/dev/null || true
-
-      - name: Inject GPU metadata into benchmark result
-        run: |
-          docker exec \
-            -e GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
-            -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
-            -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
-            -e DOCKER_IMAGE="${{ steps.gpu-info.outputs.docker_image }}" \
-            -e RESULT_PATH="${{ env.RESULT_FILENAME }}.json" \
-            -e DISPLAY_NAME="${{ matrix.cell.display }}" \
-            atom-benchmark python3 -c "
-          import json, os
-          p = os.environ['RESULT_PATH']
-          if not os.path.exists(p):
-              print(f'{p} not found, skipping GPU metadata injection')
-          else:
-              with open(p) as f:
-                  d = json.load(f)
-              d['gpu_name'] = os.environ.get('GPU_NAME', '')
-              d['gpu_vram_gb'] = int(os.environ.get('GPU_VRAM_GB') or 0)
-              d['rocm_version'] = os.environ.get('ROCM_VERSION', '')
-              d['docker_image'] = os.environ.get('DOCKER_IMAGE', '')
-              display_name = os.environ.get('DISPLAY_NAME', '')
-              if display_name:
-                  d['benchmark_model_name'] = display_name
-              with open(p, 'w') as f:
-                  json.dump(d, f, indent=2)
-          "
-
-      - name: Copy profiler traces
-        if: inputs.enable_profiler
-        run: docker cp atom-benchmark:/app/trace ./profiler-traces 2>/dev/null || true
-
-      - name: Upload profiler traces
-        if: inputs.enable_profiler
-        uses: actions/upload-artifact@v7
-        with:
-          name: profiler-traces-${{ env.RESULT_FILENAME }}
-          path: profiler-traces/
-
-      - name: Stop server and collect RTL traces
-        if: inputs.enable_rtl
-        run: |
-          docker exec atom-benchmark bash -lc \
-            "ENABLE_RTL_PROFILER=1 .github/scripts/atom_test.sh stop" || true
-          docker cp atom-benchmark:/app/rtl_traces ./rtl-traces 2>/dev/null || true
-
-      - name: Upload RTL traces
-        if: inputs.enable_rtl
-        uses: actions/upload-artifact@v7
-        with:
-          name: rtl-traces-${{ env.RESULT_FILENAME }}
-          path: rtl-traces/
-
-      - name: Upload benchmark result
-        uses: actions/upload-artifact@v7
-        with:
-          name: benchmark-${{ env.RESULT_FILENAME }}
-          path: ${{ env.RESULT_FILENAME }}.json
-
-      - name: Clean Up
-        if: always()
-        run: |
-          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged \
-            ${{ inputs.image || 'rocm/atom-dev:latest' }} bash -lc "rm -rf /workspace/atom/ /workspace/aiter/ /workspace/bench_serving/" || true
-          docker stop atom-benchmark || true
-          docker rm atom-benchmark || true
+        config: ${{ fromJson(needs.build-matrix.outputs.configs_json) }}
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      display: ${{ matrix.config.display }}
+      prefix: ${{ matrix.config.prefix }}
+      suffix: ${{ matrix.config.suffix }}
+      model_path: ${{ matrix.config.model_path }}
+      server_args: ${{ matrix.config.server_args }}
+      bench_args: ${{ matrix.config.bench_args }}
+      env_vars: ${{ matrix.config.env_vars }}
+      runner: ${{ (github.event_name == 'workflow_dispatch' && inputs.runner != '' && inputs.runner) || matrix.config.runner }}
+      isl: ${{ matrix.config.isl }}
+      osl: ${{ matrix.config.osl }}
+      ratio: ${{ matrix.config.ratio }}
+      ratio_str: ${{ matrix.config.ratio_str }}
+      concurrency: ${{ matrix.config.concurrency }}
+      image: ${{ inputs.image || 'rocm/atom-dev:latest' }}
+      enable_profiler: ${{ inputs.enable_profiler || false }}
+      enable_rtl: ${{ inputs.enable_rtl || false }}
+      extra_args: ${{ inputs.extra_args || '' }}
+      atom_commit: ${{ inputs.atom_commit || '' }}
 
   summarize-benchmark-result:
     if: always()

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -1,0 +1,256 @@
+# Reusable benchmark template: runs ONE (model variant × scenario) config across
+# its concurrency list. The caller (atom-benchmark.yaml) matrixes over configs
+# and invokes this once per config; this workflow matrixes over `concurrency`.
+# Two-level fan-out keeps both matrices under GitHub's 256-job-per-matrix limit
+# while every (config × conc) cell still runs as its own parallel job. Mirrors
+# the scenario-sharded reusable-workflow pattern in InferenceX run-sweep.
+name: Benchmark template
+
+on:
+  workflow_call:
+    inputs:
+      display:
+        type: string
+        required: true
+      prefix:
+        type: string
+        required: true
+      suffix:
+        type: string
+        required: false
+        default: ""
+      model_path:
+        type: string
+        required: true
+      server_args:
+        type: string
+        required: false
+        default: ""
+      bench_args:
+        type: string
+        required: false
+        default: ""
+      env_vars:
+        type: string
+        required: false
+        default: ""
+      runner:
+        type: string
+        required: true
+      isl:
+        type: string
+        required: true
+      osl:
+        type: string
+        required: true
+      ratio:
+        type: string
+        required: true
+      ratio_str:
+        type: string
+        required: true
+      concurrency:
+        description: "JSON array of concurrency values (second-level matrix)"
+        type: string
+        required: true
+      image:
+        type: string
+        required: false
+        default: "rocm/atom-dev:latest"
+      enable_profiler:
+        type: boolean
+        required: false
+        default: false
+      enable_rtl:
+        type: boolean
+        required: false
+        default: false
+      extra_args:
+        type: string
+        required: false
+        default: ""
+      atom_commit:
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: ${{ inputs.display }} ${{ inputs.isl }}/${{ inputs.osl }} c=${{ matrix.conc }}
+    strategy:
+      fail-fast: false
+      matrix:
+        conc: ${{ fromJson(inputs.concurrency) }}
+
+    runs-on: ${{ inputs.runner }}
+
+    env:
+      MODEL_PATH: ${{ inputs.model_path }}
+      ARGS: ${{ inputs.server_args }}
+      ISL: ${{ inputs.isl }}
+      OSL: ${{ inputs.osl }}
+      CONC: ${{ matrix.conc }}
+      RANDOM_RANGE_RATIO: ${{ inputs.ratio }}
+      RESULT_FILENAME: ${{ inputs.prefix }}${{ inputs.suffix }}-${{ inputs.isl }}-${{ inputs.osl }}-${{ matrix.conc }}-${{ inputs.ratio_str }}
+
+    steps:
+      - name: Kill all Docker containers
+        run: |
+          echo "=== Cleaning up containers on $(hostname) ==="
+          containers=$(docker ps -q)
+          if [ -n "$containers" ]; then
+            docker kill $containers || true
+          fi
+          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged rocm/pytorch:latest bash -lc "ls -la /workspace/ && find /workspace -mindepth 1 -delete" || true
+
+      - name: Show ROCm status (host)
+        run: docker ps -a && rocm-smi --showmemuse 2>/dev/null || true
+
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.atom_commit || github.ref }}
+
+      - name: Start container + download model
+        uses: ./.github/actions/atom-bench-container
+        with:
+          image: ${{ inputs.image }}
+          container-name: atom-benchmark
+          model-path: ${{ inputs.model_path }}
+          env-vars: ${{ inputs.env_vars }}
+          hf-token: ${{ secrets.AMD_HF_TOKEN }}
+          download-required: "true"
+          container-env: >-
+            -e ISL=${{ env.ISL }} -e OSL=${{ env.OSL }}
+            -e CONC=${{ env.CONC }} -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }}
+            -e ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }}
+            -e ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }}
+
+      - name: Collect GPU info (inside container)
+        id: gpu-info
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          RUNNER_HINT="${{ inputs.runner }}"
+          bash .github/scripts/collect_gpu_info.sh atom-benchmark docker "$RUNNER_HINT"
+          # Resolve latest → nightly_YYYYMMDDHHMMSS for dashboard display
+          DOCKER_IMAGE="${{ inputs.image }}"
+          if [ "$DOCKER_IMAGE" = "rocm/atom-dev:latest" ]; then
+            RESOLVED_IMAGE=""
+            if RESOLUTION_JSON="$(python3 .github/scripts/resolve_atom_image.py --repository rocm/atom-dev --reference-tag latest --image-family native 2>/dev/null)"; then
+              RESOLVED_IMAGE="$(echo "$RESOLUTION_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("resolved_image",""))')" || true
+            fi
+            DOCKER_IMAGE="${RESOLVED_IMAGE:-$DOCKER_IMAGE}"
+          fi
+          echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
+          echo "Docker: ${DOCKER_IMAGE}"
+
+      - name: Run benchmark
+        timeout-minutes: 80
+        env:
+          EXTRA_LAUNCH_ARGS: ${{ inputs.extra_args }}
+        run: |
+          set -euo pipefail
+          if [ -d "/models" ]; then model_path="/models/${{ env.MODEL_PATH }}"
+          else model_path="${{ env.MODEL_PATH }}"; fi
+
+          # Launch via stdin so the container's bash parses the shell quoting in
+          # ARGS exactly once -- single-quoted JSON values survive intact (e.g.
+          # --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}').
+          # Substituting ${{ env.ARGS }} into a `bash -lc "..."` string instead
+          # collides the JSON's double quotes with the outer quotes and strips
+          # them (argparse: invalid loads value). Mirrors atom-test.yaml.
+          echo "ENABLE_TORCH_PROFILER=${{ inputs.enable_profiler && '1' || '0' }} \
+            ENABLE_RTL_PROFILER=${{ inputs.enable_rtl && '1' || '0' }} \
+            .github/scripts/atom_test.sh launch $model_path $ARGS $EXTRA_LAUNCH_ARGS" \
+            | docker exec -i atom-benchmark bash -l
+
+          echo "========== Running benchmark =========="
+          docker exec \
+            -e ENABLE_TORCH_PROFILER="${{ inputs.enable_profiler && '1' || '0' }}" \
+            -e RESULT_FILENAME="${{ env.RESULT_FILENAME }}" \
+            -e SERVER_ARGS="$ARGS" \
+            -e BENCH_EXTRA_ARGS="${{ inputs.bench_args }}" \
+            -e MP="$model_path" \
+            atom-benchmark bash -lc '.github/scripts/atom_test.sh benchmark "$MP"'
+
+      - name: Dump server log
+        if: always()
+        run: |
+          docker exec atom-benchmark cat /tmp/atom_server.log 2>/dev/null || true
+
+      - name: Dump client log
+        if: always()
+        run: |
+          docker exec atom-benchmark cat /tmp/atom_client.log 2>/dev/null || true
+
+      - name: Inject GPU metadata into benchmark result
+        run: |
+          docker exec \
+            -e GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
+            -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
+            -e ROCM_VERSION="${{ steps.gpu-info.outputs.rocm_version }}" \
+            -e DOCKER_IMAGE="${{ steps.gpu-info.outputs.docker_image }}" \
+            -e RESULT_PATH="${{ env.RESULT_FILENAME }}.json" \
+            -e DISPLAY_NAME="${{ inputs.display }}" \
+            atom-benchmark python3 -c "
+          import json, os
+          p = os.environ['RESULT_PATH']
+          if not os.path.exists(p):
+              print(f'{p} not found, skipping GPU metadata injection')
+          else:
+              with open(p) as f:
+                  d = json.load(f)
+              d['gpu_name'] = os.environ.get('GPU_NAME', '')
+              d['gpu_vram_gb'] = int(os.environ.get('GPU_VRAM_GB') or 0)
+              d['rocm_version'] = os.environ.get('ROCM_VERSION', '')
+              d['docker_image'] = os.environ.get('DOCKER_IMAGE', '')
+              display_name = os.environ.get('DISPLAY_NAME', '')
+              if display_name:
+                  d['benchmark_model_name'] = display_name
+              with open(p, 'w') as f:
+                  json.dump(d, f, indent=2)
+          "
+
+      - name: Copy profiler traces
+        if: inputs.enable_profiler
+        run: docker cp atom-benchmark:/app/trace ./profiler-traces 2>/dev/null || true
+
+      - name: Upload profiler traces
+        if: inputs.enable_profiler
+        uses: actions/upload-artifact@v7
+        with:
+          name: profiler-traces-${{ env.RESULT_FILENAME }}
+          path: profiler-traces/
+
+      - name: Stop server and collect RTL traces
+        if: inputs.enable_rtl
+        run: |
+          docker exec atom-benchmark bash -lc \
+            "ENABLE_RTL_PROFILER=1 .github/scripts/atom_test.sh stop" || true
+          docker cp atom-benchmark:/app/rtl_traces ./rtl-traces 2>/dev/null || true
+
+      - name: Upload RTL traces
+        if: inputs.enable_rtl
+        uses: actions/upload-artifact@v7
+        with:
+          name: rtl-traces-${{ env.RESULT_FILENAME }}
+          path: rtl-traces/
+
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-${{ env.RESULT_FILENAME }}
+          path: ${{ env.RESULT_FILENAME }}.json
+
+      - name: Clean Up
+        if: always()
+        run: |
+          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged \
+            ${{ inputs.image }} bash -lc "rm -rf /workspace/atom/ /workspace/aiter/ /workspace/bench_serving/" || true
+          docker stop atom-benchmark || true
+          docker rm atom-benchmark || true

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -79,7 +79,9 @@ permissions:
 
 jobs:
   benchmark:
-    name: ${{ inputs.display }} ${{ inputs.isl }}/${{ inputs.osl }} c=${{ matrix.conc }}
+    # Nested under the caller job (which already shows model + scenario), so the
+    # template only needs the distinguishing second-level dimension: concurrency.
+    name: c=${{ matrix.conc }}
     strategy:
       fail-fast: false
       matrix:

--- a/tests/test_benchmark_catalog.py
+++ b/tests/test_benchmark_catalog.py
@@ -80,7 +80,7 @@ def test_build_args_golden():
 
 def test_load_variants_shape():
     variants = catalog.load_variants(CATALOG)
-    assert len(variants) == 18
+    assert len(variants) == 21
     required = {
         "display",
         "path",
@@ -150,22 +150,23 @@ def test_param_lists_override_and_conc_band():
     cells = catalog.build_cells(
         CATALOG, param_lists="1024,1024,512,0.7", model_filter={"deepseek-v4-pro"}
     )
-    assert sorted(c["suffix"] for c in cells) == ["-dpa", "-dpa-mtp3"]
+    assert sorted(c["suffix"] for c in cells) == ["-dpa", "-dpa-mtp3", "-dpa-tbo"]
     rfs = {c["result_filename"] for c in cells}
     assert "deepseek-v4-pro-dpa-1024-1024-512-0.7" in rfs
     assert "deepseek-v4-pro-dpa-mtp3-1024-1024-512-0.7" in rfs
+    assert "deepseek-v4-pro-dpa-tbo-1024-1024-512-0.7" in rfs
 
 
 def test_model_filter():
-    cells = catalog.build_cells(CATALOG, model_filter={"glm-5-fp8"})
-    assert {c["prefix"] for c in cells} == {"glm-5-fp8"}
+    cells = catalog.build_cells(CATALOG, model_filter={"glm-5-2-fp8"})
+    assert {c["prefix"] for c in cells} == {"glm-5-2-fp8"}
 
 
 def test_validate_dispatch_inputs_in_sync_and_drift():
     prefixes = {m["prefix"] for m in catalog._load_catalog(CATALOG)["models"]}
     assert catalog.validate_dispatch_inputs(CATALOG, prefixes) == []
     # missing a checkbox
-    assert catalog.validate_dispatch_inputs(CATALOG, prefixes - {"glm-5-fp8"})
+    assert catalog.validate_dispatch_inputs(CATALOG, prefixes - {"glm-5-2-fp8"})
     # extra checkbox
     assert catalog.validate_dispatch_inputs(CATALOG, prefixes | {"ghost"})
 
@@ -180,3 +181,55 @@ def test_workflow_dispatch_inputs_match_catalog():
     model_toggles = dispatch_inputs - RESERVED_INPUTS
     prefixes = {m["prefix"] for m in catalog._load_catalog(CATALOG)["models"]}
     assert model_toggles == prefixes
+
+
+def test_scenario_tag():
+    assert catalog.scenario_tag(1024, 1024) == "1k1k"
+    assert catalog.scenario_tag(8192, 1024) == "8k1k"
+    # Non-1024-multiple lengths fall back to an unambiguous tag.
+    assert catalog.scenario_tag(1000, 1024) == "1000_1024"
+
+
+def test_build_cell_configs_partitions_cells():
+    """Configs are a lossless regrouping of build_cells: every cell appears in
+    exactly one config (keyed by variant × scenario), expanded over concurrency."""
+    import json
+
+    cells = catalog.build_cells(CATALOG)
+    configs = catalog.build_cell_configs(CATALOG)
+
+    # Reconstruct the flat (variant, scenario, conc) set from configs.
+    from_configs = set()
+    for cfg in configs:
+        conc_list = json.loads(cfg["concurrency"])
+        assert conc_list == sorted(conc_list), "concurrency must be sorted"
+        for conc in conc_list:
+            from_configs.add(
+                (cfg["prefix"], cfg["suffix"], cfg["isl"], cfg["osl"], conc)
+            )
+    from_cells = {
+        (c["prefix"], c["suffix"], c["isl"], c["osl"], c["conc"]) for c in cells
+    }
+    assert from_configs == from_cells
+    # Total cells preserved (no dup / drop).
+    assert sum(len(json.loads(c["concurrency"])) for c in configs) == len(cells)
+
+
+def test_build_cell_configs_matrix_under_github_limit():
+    """Both fan-out levels must stay under GitHub's 256-jobs-per-matrix cap."""
+    import json
+
+    configs = catalog.build_cell_configs(CATALOG)
+    assert len(configs) <= 256, "first-level (config) matrix exceeds 256"
+    for cfg in configs:
+        assert len(json.loads(cfg["concurrency"])) <= 256, "conc matrix exceeds 256"
+
+
+def test_build_cell_configs_one_config_per_server_key():
+    """Each config is a unique (variant, scenario) server-launch key."""
+    configs = catalog.build_cell_configs(CATALOG)
+    keys = [
+        (c["model_path"], c["server_args"], c["env_vars"], c["isl"], c["osl"])
+        for c in configs
+    ]
+    assert len(keys) == len(set(keys))


### PR DESCRIPTION
## Problem

The nightly `ATOM Benchmark` workflow expands the catalog into a **single flat
matrix of 278 cells** (`matrix: cell`). GitHub caps a matrix at **256 jobs**, so
the `benchmark` job was never scheduled, and `summarize` failed with
`Benchmark output was '[]'` (e.g. run 28189176774).

## Fix: two-level fan-out (mirrors InferenceX run-sweep)

Replace the flat per-cell matrix with a bounded two-level fan-out:

- **`catalog.build_cell_configs`** groups cells by `(variant × scenario)`, folding
  concurrency into a JSON list. **`build_benchmark_matrix.py`** emits `configs_json`.
- **New reusable workflow `benchmark-tmpl.yml`** runs one config across its
  `concurrency` matrix — the per-cell body (container / launch / benchmark /
  metadata / upload) is moved over unchanged.
- The **`benchmark` caller** matrixes over configs and calls the template
  (`secrets: inherit`).

Every `(config × conc)` cell still runs as its **own parallel job** (full
parallelism, no serialization, no shared server). The caller job is still named
`benchmark`, so all downstream `needs:` and the summarize/dashboard chain are
unchanged. Artifact naming (`benchmark-<result_filename>`) is unchanged.

### Limits, before → after

| matrix | before | after |
|---|---|---|
| benchmark fan-out | 1 flat matrix of **278** cells (❌ > 256) | caller `config` matrix = **42** (variant×scenario) |
| | | per-config `conc` matrix = **≤7** |

The 256-per-matrix cap now applies to ~42 configs (≈6× headroom) and ≤7
concurrencies — neither is near the limit.

## Changes

- `catalog.py`: `+scenario_tag()`, `+build_cell_configs()`
- `build_benchmark_matrix.py`: emit `configs_json` (was `cells_json`)
- `.github/workflows/benchmark-tmpl.yml`: **new** reusable workflow
- `atom-benchmark.yaml`: `build-matrix` → `configs_json`; `benchmark` job → caller
- `tests/test_benchmark_catalog.py`: +4 tests; refreshed 4 stale tests (21 variants, `glm-5-2-fp8`, `-dpa-tbo` 512 band)
- `.github/benchmark/README.md`: flow + data contracts + script table

## Test plan

- [x] `pytest tests/test_benchmark_catalog.py` — 13 passed
- [x] `ruff` / `black` clean
- [x] Local: schedule → 278 cells → 42 configs (max 7 conc), every matrix ≤256
- [x] `workflow_dispatch` dry-run (gpt-oss-120b) — run 28241897780: `build-matrix` ✓, nested job `gpt-oss-120b 1k1k / c=8` scheduled correctly (caller→template→conc matrix wiring confirmed)
