### PR TITLE
fix: FP8 MoE weight load in MI308

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2797,7 +2797,7 @@ class FusedMoE(torch.nn.Module):
                 load_size = loaded_weight.shape[shard_dim]
                 if load_size != expert_data.shape[shard_dim]:
                     expert_data = expert_data.narrow(shard_dim, 0, load_size)
-                expert_data.copy_(loaded_weight)
+                self._copy_quant_storage(expert_data, loaded_weight)
             elif shard_id in ("w1", "w3"):
                 self._load_w13(
                     shard_id=shard_id,
@@ -2809,7 +2809,7 @@ class FusedMoE(torch.nn.Module):
                 )
             return
         if shard_id == "w2":
-            expert_data.copy_(loaded_weight)
+            self._copy_quant_storage(expert_data, loaded_weight)
         elif shard_id in ("w1", "w3"):
             self._load_w13(
                 shard_id=shard_id,
@@ -2823,6 +2823,19 @@ class FusedMoE(torch.nn.Module):
     def _copy_quant_storage(dst: torch.Tensor, src: torch.Tensor) -> None:
         """Copy quantized tensors without numeric conversion of byte formats."""
         if dst.dtype == dtypes.fp4x2:
+            dst.view(torch.uint8).copy_(src.view(torch.uint8))
+            return
+        fp8_storage_dtypes = (
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+            torch.float8_e8m0fnu,
+            dtypes.fp8,
+            dtypes.fp8_e8m0,
+        )
+        if dst.dtype in fp8_storage_dtypes and src.dtype in fp8_storage_dtypes:
+            # Offline FP8 checkpoints encode raw FP8 bytes. Avoid dtype-to-dtype
+            # numeric conversion when destination storage uses a different FP8
+            # variant; later scale fixups expect the original bytes.
             dst.view(torch.uint8).copy_(src.view(torch.uint8))
             return
         if dst.dtype == dtypes.fp8_e8m0 and src.dtype == torch.uint8:


### PR DESCRIPTION
Motivation
MI308 has an FP8 MoE accuracy issue that can affect GLM5 and DeepSeek V4.

Technical Details
This PR preserves FP8 MoE checkpoint storage bytes during weight loading.

When both source and destination tensors use FP8 storage dtypes, the loader copies through uint8 views instead of using dtype-to-dtype Tensor.copy_(). This avoids unintended numeric conversion between FP8 variants such as float8_e4m3fn and float8_e4m3fnuz.

Test Plan
RTP+ATOM: Verified with GLM5 FP8 RTP serving on MI308.

Test Result
After this change, the MI308 FP8 MoE accuracy issue is fixed.