### PR TITLE
fix(server): raise RLIMIT_NOFILE at startup to survive high connection concurrency

### DIFF
--- a/atom/entrypoints/openai_server.py
+++ b/atom/entrypoints/openai_server.py
@@ -7,7 +7,7 @@ Usage:
     python -m atom.entrypoints.openai_server --model <model> [options]
 """
 
-from atom.utils import envs
+from atom.utils import envs, set_ulimit
 
 if envs.USE_ATOMESH_ENTRYPOINTS:
     from atom.entrypoints.atomesh.server import main
@@ -15,4 +15,8 @@ else:
     from atom.entrypoints.openai.api_server import main
 
 if __name__ == "__main__":
+    # Raise the open-file soft limit before the server (and the engine-core
+    # subprocesses it spawns) start, so high connection concurrency does not
+    # exhaust file descriptors. Inherited by spawned children.
+    set_ulimit()
     main()

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -41,6 +41,54 @@ from unittest.mock import patch
 logger = logging.getLogger("atom")
 
 
+def set_ulimit(target_soft_limit: int = 65535) -> None:
+    """Raise the open-file soft limit toward ``target_soft_limit`` (capped at
+    the hard limit).
+
+    High streaming concurrency needs roughly one file descriptor per in-flight
+    connection plus the engine's ZMQ/shared-memory fds. The default soft
+    ``RLIMIT_NOFILE`` (~1024) is exhausted under large concurrency (e.g. the
+    conc=1000 accuracy job), surfacing as EMFILE on ``accept()`` — which drops
+    incoming connections. vLLM and SGLang raise this at process startup for the
+    same reason; ATOM must too (the mesh launch scripts already pass
+    ``--ulimit nofile`` to docker, but plain server launches do not).
+    """
+    try:
+        import resource
+    except ImportError:  # POSIX-only; Windows has no RLIMIT_NOFILE.
+        logger.warning("resource module unavailable (non-POSIX); skipping ulimit bump.")
+        return
+
+    resource_type = resource.RLIMIT_NOFILE
+    soft, hard = resource.getrlimit(resource_type)
+    desired = (
+        target_soft_limit
+        if hard == resource.RLIM_INFINITY
+        else min(target_soft_limit, hard)
+    )
+    if soft >= desired:
+        return
+    try:
+        resource.setrlimit(resource_type, (desired, hard))
+        logger.info(
+            "Raised RLIMIT_NOFILE soft limit %d -> %d (hard=%d)", soft, desired, hard
+        )
+    except (ValueError, OSError) as e:
+        logger.warning(
+            "Found RLIMIT_NOFILE soft=%d hard=%d and failed to automatically "
+            "raise the soft limit to %d (error: %s). This can cause fd-limit "
+            "errors like `OSError: [Errno 24] Too many open files` under high "
+            "connection concurrency. The hard limit is the ceiling and cannot "
+            "be raised from inside the process — raise it where the server is "
+            "launched: docker `--ulimit nofile=65536:524288`, systemd "
+            "`LimitNOFILE=`, or /etc/security/limits.conf.",
+            soft,
+            hard,
+            desired,
+            e,
+        )
+
+
 @contextlib.contextmanager
 def set_device_control_env_var(config: "Config", local_dp_rank: int):
     """


### PR DESCRIPTION
## Problem

The nightly **DeepSeek-V4-Pro TBO+DPA conc1000** accuracy job started failing ([run 28295021197](https://github.com/ROCm/ATOM/actions/runs/28295021197)): the server reset every client mid-eval (`ServerDisconnectedError` ×3030), lm_eval's session collapsed (`Session is closed`), and only 921/1319 requests were served → no score → fail.

## Root cause

At `conc=1000` the server holds ~1000 simultaneous HTTP connections plus the engine's DP-rank ZMQ / shared-memory fds, which sits right on the **default soft `RLIMIT_NOFILE` (~1024)**. ATOM never raises that limit, so the server rides a knife-edge and intermittently hits **EMFILE on `accept()`**.

Evidence across six nightlies (all `num_concurrent=1000`, docker ulimit config unchanged):

| night | loop | EMFILE (`out of system resource`) | ServerDisconnected | requests served | result |
|---|---|---|---|---|---|
| 6-23/24/25 | stdlib | 0 | 0 | 1321 | pass / accuracy-only fail |
| 6-26 | stdlib | **620,212** | 0 | 1321 | **pass** (asyncio pauses-and-retries on accept-EMFILE) |
| 6-27 | uvloop | — | **3030** | 921 | **fail** (uvloop resets incoming connections on accept-EMFILE) |

So the fd ceiling was always latent; the *visible* failure needed both crossing 1024 **and** uvloop (which, unlike the stdlib loop, drops connections instead of pausing). The fix targets the ceiling itself, independent of the event loop.

vLLM and SGLang both call `set_ulimit()` at startup for exactly this reason, and ATOM's own `atom/mesh/scripts/*.sh` already pass `--ulimit nofile=65536:524288` to docker — but plain `python -m atom.entrypoints.openai_server` launches (CI, ad-hoc) inherit the daemon default and never bump it.

## Fix

- Add `atom/utils/set_ulimit()` — raises the soft limit to `min(65535, hard)`; no-op when already high enough. `resource` is imported lazily inside the function and guarded (`ImportError` → warn + return) so this POSIX-only call never breaks import on non-POSIX platforms, matching vLLM/SGLang.
- Call it at the server entry point (`openai_server.py`) before the engine-core subprocesses are spawned, so the raised limit is inherited.

Keeps uvloop; does not touch docker run args or revert anything.

## Test plan
- [x] `ruff` + `black` clean
- [x] `pytest tests/` identical to baseline (no new failures; pre-existing env import errors only)
- [x] Verified: simulated `soft=1024` → `set_ulimit()` raises to 65535; no-op when soft already ≥ target
- [x] Lazy/guarded `import resource` — safe on non-POSIX