### PR TITLE
fix : (GLM-5-2-FP8)do not use buffer out of cudagraph when unnecessary

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1288,7 +1288,6 @@ class MLAAttention(nn.Module):
 
 @triton.jit
 def _convert_req_index_to_global_index_kernel(
-    qo_indptr,  # int32 [num_requests]
     kv_indptr,  # int32 [num_requests+1]
     page_kv_indptr,  # int32 [num_requests+1]
     kv_indices,  # int32 [num_requests * max_num_blocks_per_req]
@@ -1315,33 +1314,33 @@ def _convert_req_index_to_global_index_kernel(
     kv_end = tl.load(kv_indptr + batch_id + 1)
     out_kv_start = tl.load(page_kv_indptr + batch_id)
     kv_len = kv_end - kv_start
-    qo_start = tl.load(qo_indptr + batch_id)
-    qo_end = tl.load(qo_indptr + batch_id + 1)
 
-    for token_id in range(qo_start, qo_end):
-        # Load token indices for this tile
-        ti_ptr = token_indices_ptr + token_id * ti_stride0 + indice_id * ti_stride1
-        tok = tl.load(ti_ptr)  # int32
+    # Decode-only: token_id == batch_id. Don't read qo_indptr (cu_seqlens_q),
+    # which can be stale/cumulative under CUDA-graph replay.
+    token_id = batch_id
 
-        # Guard block_table access
-        valid_mask = (indice_id < kv_len) & (indice_id < NUM_TOPK_TOKENS)
-        out_val = tl.load(
-            kv_indices + kv_start + tok,
-            mask=valid_mask,
-            other=0,
-        )
+    # Load token indices for this tile
+    ti_ptr = token_indices_ptr + token_id * ti_stride0 + indice_id * ti_stride1
+    tok = tl.load(ti_ptr)  # int32
 
-        # Store results
-        out_ptr_ij = out_kv_indices + out_kv_start + indice_id
-        tl.store(
-            out_ptr_ij,
-            out_val,
-            mask=valid_mask,
-        )
+    # Guard block_table access
+    valid_mask = (indice_id < kv_len) & (indice_id < NUM_TOPK_TOKENS)
+    out_val = tl.load(
+        kv_indices + kv_start + tok,
+        mask=valid_mask,
+        other=0,
+    )
+
+    # Store results
+    out_ptr_ij = out_kv_indices + out_kv_start + indice_id
+    tl.store(
+        out_ptr_ij,
+        out_val,
+        mask=valid_mask,
+    )
 
 
 def triton_convert_req_index_to_global_index(
-    qo_indptr: torch.Tensor,  # int32 [num_tokens + 1]
     kv_indptr: torch.Tensor,  # int32 [num_tokens + 1]
     page_kv_indptr: torch.Tensor,  # int32 [num_tokens + 1]
     kv_indices: torch.Tensor,  # int32 [total_kv_seqlen]
@@ -1373,7 +1372,6 @@ def triton_convert_req_index_to_global_index(
     tiles_per_row = NUM_TOPK_TOKENS // BLOCK_N
 
     # Ensure contiguous tensors on the same device
-    qo_indptr_c = qo_indptr.contiguous()
     kv_indptr_c = kv_indptr.contiguous()
     kv_indices_c = kv_indices.contiguous()
     token_indices_c = token_indices.contiguous()
@@ -1391,7 +1389,6 @@ def triton_convert_req_index_to_global_index(
     grid = (num_batch, tiles_per_row)
 
     _convert_req_index_to_global_index_kernel[grid](
-        qo_indptr_c,
         kv_indptr_c,
         page_kv_indptr_c,
         kv_indices_c,

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1301,7 +1301,6 @@ def sparse_attn_indexer(
             )
         else:
             triton_convert_req_index_to_global_index(
-                attn_metadata.cu_seqlens_q,
                 attn_metadata.kv_indptr,
                 attn_metadata.sparse_kv_indptr,
                 attn_metadata.kv_indices,


### PR DESCRIPTION
## Motivation

GLM-5.2-FP8 benchmark/serving (isl=1024 osl=1024, higher concurrency) intermittently dies with a GPU Memory access fault ... Reason: Unknown (process exit -6). The faulting kernel is the sparse-MLA decode index converter _convert_req_index_to_global_index_kernel (MEMORY_VIOLATION). The failure is non-deterministic (the same commit passes and fails across CI runs) and only happens under CUDA/HIP-graph capture — with --enforce-eager it never reproduces (145k+ eager decode steps, zero faults).

Under CUDA-graph replay, the convert kernel reads a stale/cumulative cu_seqlens_q (qo_indptr) instead of the decode arange. For decode each request has exactly one query token, so cu_seqlens_q must be [0,1,2,...,bs] (qo_end[i] = i+1 ≤ bs). At the fault, the registers show qo_end values far larger than bs (e.g. 860/875 with bs ≤ 512), i.e. a prefill-shaped cumulative layout.

That drives the loop variable token_id out of range, so the kernel reads a row of token_indices (a per-step torch.empty buffer) that the indexer never filled. Those positions hold the -1 "invalid" sentinel, which leaks into a lane the row mask treats as valid; the unbounded kv_indices + kv_start + tok load with tok = -1 then underflows to kv_indices_base - 4 and hits an unmapped page. This is confirmed byte-exact from the debug-agent dump (faulting address == kv_indices base − 4, kv_start == 0, tok == -1).

The Python metadata path writes cu_seqlens_q correctly (decode arange) every step on the main stream before replay; static analysis shows no logic bug. The staleness is a CUDA/HIP-graph runtime artifact on gfx950/MI355X — a captured kernel observing stale device memory under replay.

## Technical Details

The convert kernel is decode-only (max_seqlen_q == 1), so token_id == batch_id by construction. Derive the row directly from tl.program_id(0) instead of reading qo_indptr/cu_seqlens_q. The kernel no longer depends on the buffer that goes stale under graph replay, so the fault cannot occur regardless of the underlying runtime root cause — it is a correctness-preserving change, not a band-aid.

## Test Plan
 Accuracy CI && nightly Benchmark 

## Test Result

- Accuracy (g64): gsm8k 3-shot flexible-extract = 0.9606 (CI baseline 0.9447, threshold 0.92), 0 faults — accuracy preserved.
- Crash : https://github.com/ROCm/ATOM/actions/runs/28325465813

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
