### PR TITLE
[VLLM plugin] fix(kimi): align input norm quant with attention quant

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -2060,29 +2060,52 @@ class DeepseekV2DecoderLayer(nn.Module):
         #   1. RMS_Quant fusion is only used for input_layernorm
         #   2. The reduce_results variable is re-enabled for feed forward layers (MOE and MLP), because AR_RMS is now disabled in the beginning of the next layer
         #   3. AR_RMS is turned off for input_layernorm but still enabled for post_attention_layernorm if ENABLE_ALLREDUCE_RMSNORM_FUSION is turned on
-        self.quant_dtype = (
+        attn_input_proj_name = (
+            "fused_qkv_a_proj"
+            if getattr(config, "q_lora_rank", None) is not None
+            else "q_proj"
+        )
+        attn_input_quant_config = (
             None
             if quant_config is None
-            else quant_config.get_layer_quant_config(prefix).quant_dtype
+            else quant_config.get_layer_quant_config(
+                f"{prefix}.self_attn.{attn_input_proj_name}"
+            )
+        )
+        attn_accepts_quantized_input = (
+            attn_input_quant_config is not None
+            and attn_input_quant_config.quant_type != QuantType.No
+            and attn_input_quant_config.quant_dtype in (dtypes.fp8, dtypes.fp4x2)
+        )
+        self.quant_dtype = (
+            attn_input_quant_config.quant_dtype
+            if attn_accepts_quantized_input
+            else None
         )
         self.input_norm_quant_type = (
-            None
-            if quant_config is None
-            else quant_config.get_layer_quant_config(prefix).quant_type.value
+            attn_input_quant_config.quant_type.value
+            if attn_accepts_quantized_input
+            else None
         )
         self.fuse_input_norm_quant = False
         self.fuse_ar_input_norm = ENABLE_ALLREDUCE_RMSNORM_FUSION
         if quant_config is not None and ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION:
             enable_fp8_input_norm_quant = (
-                self.quant_dtype == dtypes.fp8 and use_triton_gemm()
+                attn_accepts_quantized_input
+                and self.quant_dtype == dtypes.fp8
+                and use_triton_gemm()
             )
-            enable_fp4_input_norm_quant = self.quant_dtype == dtypes.fp4x2 and (
-                use_triton_gemm()
-                or _enable_non_triton_global_mxfp4_input_norm_quant(
-                    config,
-                    quant_config,
-                    self.quant_dtype,
-                    is_mtp_block,
+            enable_fp4_input_norm_quant = (
+                attn_accepts_quantized_input
+                and self.quant_dtype == dtypes.fp4x2
+                and (
+                    use_triton_gemm()
+                    or _enable_non_triton_global_mxfp4_input_norm_quant(
+                        config,
+                        quant_config,
+                        self.quant_dtype,
+                        is_mtp_block,
+                    )
                 )
             )
             if enable_fp8_input_norm_quant or enable_fp4_input_norm_quant:


### PR DESCRIPTION
## Motivation

Fix an input RMSNorm quantization fusion mismatch in the Kimi/DeepSeek v2 path. 

The previous logic inferred the input norm quant dtype from the decoder layer prefix, which could enable RMSNorm quant fusion even when the attention input projection itself did not accept that quantized input format. This could route activations through an incompatible fused path and cause incorrect behavior for mixed quantization layouts.

## Technical Details

- Specifically, the code now resolves the attention input projection name (`fused_qkv_a_proj` for LoRA Q, otherwise `q_proj`) and checks that projection's quant config before enabling input norm quant fusion. 
- RMSNorm quant fusion is only enabled when the attention input projection uses a real FP8 or FP4 quant type. The existing Triton and non-Triton MXFP4 gating logic is preserved, but now depends on whether the attention path can consume quantized input.

## Test Plan
launch server:
```
export HIP_VISIBLE_DEVICES=0,1,2,3
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export AITER_USE_FLYDSL_MOE_SORTING=1
export AITER_AR_1STAGE_MAX_KB=512

model_path=/shared/data/amd_int/models/Kimi-K2.5-MXFP4
vllm serve $model_path \
    --host localhost \
    --port 9000 \
    --tensor-parallel-size 4 \
    --trust-remote-code \
    --async-scheduling \
    --gpu_memory_utilization 0.9 \
    --kv-cache-dtype fp8 \
    --max-num-batched-tokens 16384 \
    --max-model-len 16384 \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --profiler-config '{"profiler": "torch", "torch_profiler_dir": "kimi_k2_5_mxfp4_attnfp8_tp4_profile", "torch_profiler_record_shapes": "True"}' \
    --no-enable-prefix-caching
```

**before：**
<img width="962" height="295" alt="image" src="https://github.com/user-attachments/assets/eb51416f-db62-48da-81c6-115be0837b11" />

**after:**
<img width="643" height="203" alt="image" src="https://github.com/user-attachments/assets/9dd92dd0-bd70-4974-bbc1-634915ee8504" />

<img width="575" height="153" alt="image" src="https://github.com/user-attachments/assets/59bb2334-717f-4db7-b748-36ee5932d345" />

## Test Result
**accuracy:**
<img width="925" height="159" alt="image" src="https://github.com/user-attachments/assets/caaae850-9056-42ae-b608-cbcaf98778fc" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
