### PR TITLE
fix(benchmark): raise RLIMIT_NOFILE in benchmark_serving for high concurrency

### DIFF
--- a/atom/benchmarks/benchmark_serving.py
+++ b/atom/benchmarks/benchmark_serving.py
@@ -686,6 +686,14 @@ def save_to_pytorch_benchmark_format(
 
 
 def main(args: argparse.Namespace):
+    # Raise the open-file soft limit before opening any connections. At high
+    # --max-concurrency each in-flight request is a socket (fd); the default
+    # RLIMIT_NOFILE soft (~1024) is exhausted client-side (EMFILE on socket()),
+    # silently dropping requests so most never reach the server. The server
+    # already calls set_ulimit() at startup; the client must too.
+    from atom.utils import set_ulimit
+
+    set_ulimit()
     print(args)
     random.seed(args.seed)
     np.random.seed(args.seed)


### PR DESCRIPTION
## Summary
At high `--max-concurrency`, each in-flight request holds a socket fd. The default soft `RLIMIT_NOFILE` (~1024) is exhausted **client-side** (`EMFILE` on `socket()`), so most requests fail before ever reaching the server. The benchmark then reports only ~one concurrency-wave of successes (e.g. **~919/10240** at `--max-concurrency=1024`) while the server logs `200 OK` for every request it actually receives.

The server already calls `set_ulimit()` at startup; this makes the **benchmark client** do the same (raise soft toward 65535, capped at the hard limit) before opening any connections.

This is purely a client-side fd-limit fix — no change to request logic.

## Root cause (for context)
Containers launched without `--ulimit nofile` inherit containerd's soft limit (1024 on hosts where systemd `DefaultLimitNOFILESoft=1024`). After a containerd 1.7→2.x upgrade, plainly-launched containers stopped getting a high default, surfacing this on the benchmark client.

## Test plan
- [ ] `python -m atom.benchmarks.benchmark_serving --dataset-name random --random-input-len 1024 --random-output-len 1024 --num-prompts 10240 --max-concurrency 1024 --request-rate inf --ignore-eos` -> all 10240 succeed (previously ~919).
- [ ] Confirm `set_ulimit()` runs before the first request.