### PR TITLE
[Fix] Fix DeepSeek-V4 DP+EP on gfx942 (MI308X)

### DIFF
--- a/atom/model_ops/fused_moe/mori_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_prepare_finalize.py
@@ -27,6 +27,19 @@ _NUM_TBO_UBATCHES = 2
 
 
 @lru_cache(maxsize=8)
+def _device_cu_count(device_index: int | None = None) -> int:
+    """Compute-unit (multiprocessor) count of the current CUDA/HIP device.
+
+    Used to cap mori IntraNode block_num so the kernels' grid-wide barrier
+    never asks for more co-resident blocks than the GPU has CUs (see
+    _get_dispatch_config). MI308X=80, MI300X=304, MI355X=256.
+    """
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+@lru_cache(maxsize=8)
 def init_mori_op(
     rank: int,
     world_size: int,
@@ -160,11 +173,22 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         atom-vllm has no stable prefill/decode flag at this call site and
         instead selects by a token-count threshold; it overrides this method
         via a plugin patch, so keep this body frontend-agnostic.
+
+        block_num is capped at the device CU count: mori's IntraNode
+        dispatch/combine use a hand-rolled grid-wide barrier
+        (CrossDeviceBarrierIntraNodeKernel) that spins until *all* gridDim.x
+        blocks have arrived, which requires every block to be co-resident. The
+        combine block (1024 threads + larger dynamic smem) gets ~1 block/CU
+        occupancy, so launching more blocks than CUs (e.g. 128 on the 80-CU
+        MI308X) leaves the surplus blocks unscheduled -> the barrier never
+        completes -> warmup deadlocks. Capping at multi_processor_count keeps
+        big-CU GPUs (MI300X/MI355X, >=128 CU) at 128 with no perf loss.
         """
+        mp = _device_cu_count()
         context = get_forward_context().context
         if context.is_prefill:
-            return 128, 16
-        return 64, 4
+            return min(128, mp), 16
+        return min(64, mp), 4
 
     # ---- Synchronous (non-TBO) path ----
 

--- a/atom/model_ops/fused_moe/mori_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_prepare_finalize.py
@@ -11,6 +11,7 @@ import atom.model_ops.fused_moe.modular_kernel as mk
 from atom.model_ops.fused_moe.config import FusedMoEQuantConfig
 from atom.utils.forward_context import get_forward_context
 from aiter import QuantType, dtypes
+from aiter.jit.utils.chip_info import get_cu_num
 
 try:
     import mori
@@ -24,19 +25,6 @@ logger = logging.getLogger("atom")
 
 
 _NUM_TBO_UBATCHES = 2
-
-
-@lru_cache(maxsize=8)
-def _device_cu_count(device_index: int | None = None) -> int:
-    """Compute-unit (multiprocessor) count of the current CUDA/HIP device.
-
-    Used to cap mori IntraNode block_num so the kernels' grid-wide barrier
-    never asks for more co-resident blocks than the GPU has CUs (see
-    _get_dispatch_config). MI308X=80, MI300X=304, MI355X=256.
-    """
-    if device_index is None:
-        device_index = torch.cuda.current_device()
-    return torch.cuda.get_device_properties(device_index).multi_processor_count
 
 
 @lru_cache(maxsize=8)
@@ -184,7 +172,7 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         completes -> warmup deadlocks. Capping at multi_processor_count keeps
         big-CU GPUs (MI300X/MI355X, >=128 CU) at 128 with no perf loss.
         """
-        mp = _device_cu_count()
+        mp = get_cu_num()
         context = get_forward_context().context
         if context.is_prefill:
             return min(128, mp), 16

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -459,7 +459,9 @@ class FusedMoEMethodBase(QuantizeMethodBase):
                 world_size=all2all_manager.world_size,
                 hidden_dim=moe.hidden_dim,
                 scale_dim=scale_dim,
-                max_num_inp_token_per_rank=16384,
+                # Match max_num_tokens_per_dp_rank / max_tokens_per_rank (= moe.max_num_tokens);
+                # leaving this hardcoded 16384 truncates the TBO mori buffer at mbt>16384.
+                max_num_inp_token_per_rank=moe.max_num_tokens,
                 num_local_experts=moe.num_experts // all2all_manager.world_size,
                 num_experts_per_token=moe.experts_per_token,
                 gpu_per_node=moe.moe_parallel_config.local_ep_size,

--- a/atom/plugin/vllm/mori_patch.py
+++ b/atom/plugin/vllm/mori_patch.py
@@ -22,7 +22,10 @@ from typing import Optional
 import torch
 
 import atom.model_ops.fused_moe.modular_kernel as mk
-from atom.model_ops.fused_moe.mori_prepare_finalize import MoriPrepareAndFinalize
+from atom.model_ops.fused_moe.mori_prepare_finalize import (
+    MoriPrepareAndFinalize,
+    _device_cu_count,
+)
 from atom.plugin.config import VLLM_MORI_LAUNCH_CONFIG_TOKEN_THRESHOLD
 
 _MORI_PATCH_APPLIED = False
@@ -108,9 +111,14 @@ def apply_vllm_mori_patch() -> None:
         assert (
             num_tokens is not None
         ), "num_tokens is required to choose MORI launch config in vLLM mode."
+        # Cap block_num at the device CU count: mori's IntraNode grid-wide
+        # barrier requires all gridDim.x blocks co-resident; >CU blocks (e.g.
+        # 128 on the 80-CU MI308X) deadlock at warmup. Mirrors the native
+        # MoriPrepareAndFinalize._get_dispatch_config cap.
+        mp = _device_cu_count()
         if num_tokens >= VLLM_MORI_LAUNCH_CONFIG_TOKEN_THRESHOLD:
-            return 128, 16
-        return 64, 4
+            return min(128, mp), 16
+        return min(64, mp), 4
 
     setattr(vllm_get_dispatch_config, "_atom_vllm_mori_patched", True)
     MoriPrepareAndFinalize._get_dispatch_config = vllm_get_dispatch_config

--- a/atom/plugin/vllm/mori_patch.py
+++ b/atom/plugin/vllm/mori_patch.py
@@ -22,11 +22,9 @@ from typing import Optional
 import torch
 
 import atom.model_ops.fused_moe.modular_kernel as mk
-from atom.model_ops.fused_moe.mori_prepare_finalize import (
-    MoriPrepareAndFinalize,
-    _device_cu_count,
-)
+from atom.model_ops.fused_moe.mori_prepare_finalize import MoriPrepareAndFinalize
 from atom.plugin.config import VLLM_MORI_LAUNCH_CONFIG_TOKEN_THRESHOLD
+from aiter.jit.utils.chip_info import get_cu_num
 
 _MORI_PATCH_APPLIED = False
 
@@ -115,7 +113,7 @@ def apply_vllm_mori_patch() -> None:
         # barrier requires all gridDim.x blocks co-resident; >CU blocks (e.g.
         # 128 on the 80-CU MI308X) deadlock at warmup. Mirrors the native
         # MoriPrepareAndFinalize._get_dispatch_config cap.
-        mp = _device_cu_count()
+        mp = get_cu_num()
         if num_tokens >= VLLM_MORI_LAUNCH_CONFIG_TOKEN_THRESHOLD:
             return min(128, mp), 16
         return min(64, mp), 4


### PR DESCRIPTION
## Motivation

On gfx942 (MI308X), DeepSeek-V4 with `--enable-dp-attention --enable-expert-parallel` never reached `Application startup complete`. This PR fixes **two** independent root causes:

1. **MoE warmup deadlock** (GPU 100% spin): mori IntraNode combine launched `block_num=128`, but its grid-wide barrier (`CrossDeviceBarrierIntraNodeKernel`) needs all blocks co-resident. MI308X has 80 CU and the combine block gets ~1 block/CU → 48 blocks never schedule → barrier hangs. (Dispatch survived at ~2 blocks/CU; gfx950 ≥128 CU never hit it.)
2. **mori buffer inconsistency**: after #1101, `max_num_inp_token_per_rank` was still hardcoded `16384` while the other two params used `max_num_batched_tokens`, truncating routed output at `mbt>16384` on the TBO path.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
