### PR TITLE
ci: reuse setup-gpu-container for bench/mmstar + advance nightly benchmark schedule

### DIFF
--- a/.github/actions/atom-bench-container/action.yml
+++ b/.github/actions/atom-bench-container/action.yml
@@ -35,36 +35,19 @@ inputs:
 runs:
   using: composite
   steps:
+    # Container boilerplate is shared with the test/accuracy jobs. benchmark
+    # always pulls the (often `latest`) image fresh, runs with --network=host,
+    # and passes its -e ISL/OSL/... knobs through extra-run-flags.
     - name: Start CI container
-      shell: bash
-      env:
-        GITHUB_WORKSPACE: ${{ github.workspace }}
-        MODEL_ENV_VARS: ${{ inputs.env-vars }}
-        HF_TOKEN: ${{ inputs.hf-token }}
-      run: |
-        docker ps -aq -f name="${{ inputs.container-name }}" | xargs -r docker stop | xargs -r docker rm
-        DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices 2>/dev/null || echo "--device /dev/dri")
-        MODEL_MOUNT=""
-        [ -d "/models" ] && MODEL_MOUNT="-v /models:/models"
-
-        # env_vars come in via the env block (not the command line) so literal
-        # newlines in model env_vars can't break the host shell or silently
-        # drop the first variable.
-        ENV_FILE="/tmp/atom_${{ inputs.container-name }}_env.txt"
-        printenv MODEL_ENV_VARS 2>/dev/null | grep -v '^$' > "$ENV_FILE" || true
-
-        docker run -dt --device=/dev/kfd $DEVICE_FLAG \
-          -v "${GITHUB_WORKSPACE:-$PWD}":/workspace $MODEL_MOUNT \
-          -w /workspace --ipc=host --network=host --group-add video \
-          --shm-size=16G --privileged --cap-add=SYS_PTRACE \
-          -e HF_TOKEN="${HF_TOKEN:-}" \
-          --security-opt seccomp=unconfined \
-          --ulimit memlock=-1 --ulimit stack=67108864 --pull always \
-          -e ATOM_DISABLE_MMAP=true \
-          ${{ inputs.container-env }} \
-          --env-file "$ENV_FILE" \
-          --name "${{ inputs.container-name }}" \
-          "${{ inputs.image }}"
+      uses: ./.github/actions/setup-gpu-container
+      with:
+        container-name: ${{ inputs.container-name }}
+        base-image: ${{ inputs.image }}
+        env-vars: ${{ inputs.env-vars }}
+        hf-token: ${{ inputs.hf-token }}
+        network-host: "true"
+        pull-policy: "always"
+        extra-run-flags: ${{ inputs.container-env }}
 
     - name: Download model
       shell: bash

--- a/.github/actions/setup-gpu-container/action.yml
+++ b/.github/actions/setup-gpu-container/action.yml
@@ -3,7 +3,8 @@ description: >-
   Start the ROCm CI container for test / accuracy jobs: clean up any old
   container of the same name, resolve the render-device flag and optional
   /models mount, write the model env-file, then docker run. De-inlined from the
-  identical "Start CI container" steps in atom-test and atomesh-accuracy-validation.
+  identical "Start CI container" steps in atom-test and atomesh-accuracy-validation,
+  and also reused by atom-bench-container (which adds model download on top).
   The caller handles checkout, GPU preflight, and container teardown.
 
 inputs:
@@ -18,8 +19,17 @@ inputs:
     required: false
     default: ""
   runner:
-    description: Job runner label (matrix.runner); drives the --pull policy.
-    required: true
+    description: >-
+      Job runner label (matrix.runner); drives the --pull policy when
+      pull-policy is unset. Optional — leave empty when pull-policy is given.
+    required: false
+    default: ""
+  pull-policy:
+    description: >-
+      Explicit docker run --pull policy (always/missing/never). When set it
+      takes precedence; when empty the runner-based heuristic below decides.
+    required: false
+    default: ""
   env-vars:
     description: Newline-separated KEY=VAL model env vars (written to an env-file).
     required: false
@@ -40,6 +50,13 @@ inputs:
     description: Extra docker run flags injected verbatim before --env-file.
     required: false
     default: ""
+  disable-mmap:
+    description: >-
+      When 'true' (default) inject `-e ATOM_DISABLE_MMAP=true`. Set 'false' for
+      callers whose container never set it (e.g. mmstar) to stay byte-for-byte
+      equivalent.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -55,8 +72,10 @@ runs:
         RESOLVED_ATOM_BASE_IMAGE: ${{ inputs.resolved-image }}
         ATOM_DASHBOARD_DOCKER_IMAGE: ${{ inputs.dashboard-image }}
         RUNNER_LABEL: ${{ inputs.runner }}
+        PULL_POLICY: ${{ inputs.pull-policy }}
         NETWORK_HOST: ${{ inputs.network-host }}
         EXTRA_RUN_FLAGS: ${{ inputs.extra-run-flags }}
+        DISABLE_MMAP: ${{ inputs.disable-mmap }}
       run: |
         echo "Clean up containers..."
         (docker ps -aq -f name="^${CONTAINER_NAME}$" | xargs -r docker stop) || true
@@ -75,16 +94,21 @@ runs:
           MODEL_MOUNT=""
         fi
 
-        # Write env_vars via env block (avoids expression injection)
-        printenv MODEL_ENV_VARS | grep -v '^$' > /tmp/env_file.txt || true
+        # Write env_vars via env block (avoids expression injection). Key the
+        # env-file by container name so concurrent containers on one runner
+        # (e.g. benchmark + regression) don't clobber each other's file.
+        ENV_FILE="/tmp/atom_${CONTAINER_NAME}_env.txt"
+        printenv MODEL_ENV_VARS | grep -v '^$' > "$ENV_FILE" || true
 
         IMAGE_TAG="${RESOLVED_ATOM_BASE_IMAGE:-$ATOM_BASE_IMAGE}"
         echo "Starting container with image: $IMAGE_TAG"
         echo "Model-specific environment variables:"
-        cat /tmp/env_file.txt
+        cat "$ENV_FILE"
 
         PULL_FLAG=""
-        if [ -n "${RESOLVED_ATOM_BASE_IMAGE:-}" ]; then
+        if [ -n "${PULL_POLICY:-}" ]; then
+          PULL_FLAG="--pull ${PULL_POLICY}"
+        elif [ -n "${RESOLVED_ATOM_BASE_IMAGE:-}" ]; then
           PULL_FLAG=""
         elif [ "${RUNNER_LABEL}" = "atom-mi355-8gpu.predownload" ] || [ "${RUNNER_LABEL}" = "linux-atom-do-mi350x-8" ]; then
           PULL_FLAG="--pull always"
@@ -92,6 +116,9 @@ runs:
 
         NETWORK_FLAG=""
         [ "${NETWORK_HOST}" = "true" ] && NETWORK_FLAG="--network=host"
+
+        MMAP_FLAG=""
+        [ "${DISABLE_MMAP}" = "true" ] && MMAP_FLAG="-e ATOM_DISABLE_MMAP=true"
 
         docker run -dt $PULL_FLAG $NETWORK_FLAG --device=/dev/kfd $DEVICE_FLAG \
         -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
@@ -104,12 +131,10 @@ runs:
         -e HF_TOKEN="${HF_TOKEN:-}" \
         -e ATOM_DOCKER_IMAGE="${ATOM_DASHBOARD_DOCKER_IMAGE:-}" \
         $EXTRA_RUN_FLAGS \
-        --env-file /tmp/env_file.txt \
+        --env-file "$ENV_FILE" \
         --security-opt seccomp=unconfined \
         --ulimit memlock=-1 \
         --ulimit stack=67108864 \
-        -e ATOM_DISABLE_MMAP=true \
-        -v "${GITHUB_WORKSPACE}:/workspace" \
-        -w /workspace \
+        $MMAP_FLAG \
         --name "$CONTAINER_NAME" \
         $IMAGE_TAG

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -17,7 +17,7 @@
     "extraArgs": "--kv_cache_dtype fp8 -tp 8",
     "env_vars": "",
     "runner": "linux-atom-do-mi350x-8",
-    "test_level": "pr",
+    "test_level": "nightly",
     "accuracy_threshold": 0.94,
     "accuracy_baseline": 0.9553,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-R1-0528",
@@ -33,7 +33,7 @@
     "accuracy_threshold": 0.94,
     "accuracy_baseline": 0.96,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-V4-Pro",
-    "_baseline_note": "Full-eval (1319 samples) 3-shot flexible-extract = 0.9522 ± 0.0059 (measured 2026-06-10 with the env_vars/extraArgs above: AITER_BF16_FP8_MOE_BOUND=0 + ATOM_MOE_GU_ITLV=1). Threshold 0.94 sits ~1pp below the measured full-eval accuracy. Earlier GSM8K-100 4-run small-sample average was 0.96 (0.96/0.98/0.96/0.94, stderr ~0.024)."
+    "_baseline_note": "Full-eval (1319 samples) 3-shot flexible-extract = 0.9522 ± 0.0059"
   },
   {
     "model_name": "DeepSeek-V4-Pro MTP",
@@ -45,7 +45,7 @@
     "accuracy_threshold": 0.94,
     "accuracy_baseline": 0.96,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-V4-Pro",
-    "_baseline_note": "Same base model as DeepSeek-V4-Pro FP8 (MTP-3: 3 speculative tokens). Local full-eval (1319 samples, 3-shot) flexible-extract = 0.9560 ± 0.0056."
+    "_baseline_note": "Same base model as DeepSeek-V4-Pro FP8 (MTP-3)."
   },
   {
     "model_name": "DeepSeek-R1-0528 MTP",
@@ -69,7 +69,7 @@
     "accuracy_threshold": 0.93,
     "accuracy_baseline": 0.9553,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-R1-0528",
-    "_baseline_note": "Online quantization on top of DeepSeek-R1-0528 MTP (FP8 native): global ptpc_fp8 + expert layers mxfp4, excluding lm_head and *.gate.*. Threshold set to 0.93 (same headroom as DeepSeek-R1-0528-FP4 MTP) as a conservative placeholder for the MoE-MXFP4 accuracy drop; refresh after the first CI measurement."
+    "_baseline_note": "Online quantization on top of DeepSeek-R1-0528 MTP (FP8 native): global ptpc_fp8 + expert layers mxfp4, excluding lm_head and *.gate.*. Threshold set to 0.93 (same headroom as DeepSeek-R1-0528-FP4 MTP) as a conservative placeholder for the MoE-MXFP4 accuracy drop."
   },
   {
     "model_name": "gpt-oss-120b",
@@ -191,7 +191,7 @@
     "accuracy_threshold": 0.91,
     "accuracy_baseline": 0.9257,
     "accuracy_baseline_model": "amd/Kimi-K2.5-MXFP4 + lightseekorg/kimi-k2.5-eagle3",
-    "_baseline_note": "Eagle3 spec decode on Kimi-K2.5-MXFP4. Local case_verify_v9_gluon GSM8K 5-shot flexible-extract=0.9257 (vLLM=0.9280, within ±0.71% se). Threshold 0.91 leaves ~1.5pp headroom for noise. -tp 8 (vs base entry's tp=4) because Eagle3 draft KV needs the full 8-rank sharding."
+    "_baseline_note": "Eagle3 spec decode on Kimi-K2.5-MXFP4."
   },
   {
     "model_name": "GLM-5-FP8",
@@ -275,7 +275,7 @@
     "accuracy_threshold": 0.85,
     "accuracy_baseline": 0.9538,
     "accuracy_baseline_model": "Qwen/Qwen3.5-397B-A17B-FP8",
-    "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
+    "_baseline_note": "CI baseline=0.8605. HF card reports 0.9538 but uses chat API with reasoning_parser"
   },
   {
     "model_name": "Qwen3.5-397B-A17B-FP8 MTP",
@@ -287,7 +287,7 @@
     "accuracy_threshold": 0.85,
     "accuracy_baseline": 0.9538,
     "accuracy_baseline_model": "Qwen/Qwen3.5-397B-A17B-FP8",
-    "_baseline_note": "Same base model as Qwen3.5-397B-A17B-FP8; MTP3 speculative decoding"
+    "_baseline_note": "Same base model as Qwen3.5-397B-A17B-FP8; MTP3"
   },
   {
     "model_name": "Qwen3.5-397B-A17B-MXFP4",
@@ -299,7 +299,7 @@
     "accuracy_threshold": 0.835,
     "accuracy_baseline": 0.9538,
     "accuracy_baseline_model": "Qwen/Qwen3.5-397B-A17B-FP8",
-    "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
+    "_baseline_note": "CI baseline=0.8605. HF card reports 0.9538 but uses chat API with reasoning_parser"
   },
   {
     "model_name": "Qwen3.5-397B-A17B-MXFP4 MTP",
@@ -311,7 +311,7 @@
     "accuracy_threshold": 0.835,
     "accuracy_baseline": 0.9538,
     "accuracy_baseline_model": "Qwen/Qwen3.5-397B-A17B-FP8",
-    "_baseline_note": "CI baseline=0.8605 (FP8 tp=4, 3-shot completions API, thinking mode active). HF card reports 0.9538 but uses chat API with reasoning_parser"
+    "_baseline_note": "CI baseline=0.8605. HF card reports 0.9538 but uses chat API with reasoning_parser"
   },
   {
     "model_name": "MiniMax-M2.7",
@@ -348,7 +348,7 @@
     "accuracy_threshold": 0.93,
     "accuracy_baseline": 0.9363,
     "accuracy_baseline_model": "amd/MiniMax-M3-MXFP4",
-    "_baseline_note": "FP4 M3 tp8. GSM8K 5-shot chat (apply_chat_template + fewshot_as_multiturn, num_concurrent=32, max_gen_toks=16384) per /data/users/zejun/zejun_atom/m3.md: validated MXFP4 flexible-extract=0.9363 ± 0.0067 (measured at tp4). Threshold 0.93 leaves ~0.6pp headroom; refresh after first CI measurement at tp8."
+    "_baseline_note": "FP4 M3 tp8. GSM8K 5-shot chat (apply_chat_template + fewshot_as_multiturn, num_concurrent=32, max_gen_toks=16384)"
   },
   {
     "model_name": "MiniMax-M3-MXFP4 Eagle3",
@@ -361,7 +361,7 @@
     "accuracy_threshold": 0.93,
     "accuracy_baseline": 0.9469,
     "accuracy_baseline_model": "amd/MiniMax-M3-MXFP4 + Inferact/MiniMax-M3-EAGLE3",
-    "_baseline_note": "FP4 M3 + EAGLE3 draft (tp8), lossless vs greedy target. GSM8K 5-shot chat per /data/users/zejun/zejun_atom/m3.md: validated fp4_eagle_tp4 flexible-extract=0.9469 ± 0.0062 (accept ratio 73.36%, avg 3.20 toks/fwd, commit 9fc48338); baseline carried over from the tp4 validation since EAGLE3 is lossless wrt the target. Threshold 0.93 leaves ~1.7pp headroom; refresh after first CI measurement at tp8."
+    "_baseline_note": "FP4 M3 + EAGLE3 draft (tp8), lossless vs greedy target."
   },
   {
     "model_name": "MiMo-V2-Flash",
@@ -373,7 +373,7 @@
     "accuracy_threshold": 0.778,
     "accuracy_baseline": 0.79,
     "accuracy_baseline_model": "XiaomiMiMo/MiMo-V2-Flash",
-    "_baseline_note": "CI runs GSM8K 3-shot (atom_test.sh hardcodes --num_fewshot 3). Observed CI flexible-extract on the first stable run: base=0.8082 (run 26410931088, commit 24e4367b). Baseline 0.79 sits ~1.5pp below that to absorb run-to-run noise (stderr ±0.011); threshold 0.778 leaves ~1.2pp headroom below baseline (~1.1σ), matching the headroom pattern in DeepSeek-R1 / Kimi-Eagle3 / MiniMax-M2.7 entries. The original 0.8294 baseline was an out-of-band local 5-shot measurement that never matched what CI actually computes. tp pinned to 4 to match the MTP entry's setup (no separate base measurement)."
+    "_baseline_note": "CI GSM8K 3-shot. First stable run base=0.8082 (run 26410931088, commit 24e4367b). Baseline 0.79 sits ~1.5pp below to absorb run-to-run noise (stderr ±0.011); threshold 0.778 leaves ~1.1σ headroom. tp pinned to 4 to match the MTP entry."
   },
   {
     "model_name": "MiMo-V2-Flash MTP",
@@ -385,7 +385,7 @@
     "accuracy_threshold": 0.778,
     "accuracy_baseline": 0.79,
     "accuracy_baseline_model": "XiaomiMiMo/MiMo-V2-Flash",
-    "_baseline_note": "CI runs GSM8K 3-shot (atom_test.sh hardcodes --num_fewshot 3). Observed CI flexible-extract on the first stable run: MTP1=0.7983 (run 26410931088, commit 24e4367b); local reproduction with the fp8 + prefix-cache crash patches gave 0.8052. Baseline 0.79 sits just below the observed values to absorb run-to-run noise (stderr ±0.011); threshold 0.778 leaves ~1.2pp headroom below baseline (~1.1σ), matching the headroom pattern in DeepSeek-R1 / Kimi-Eagle3 / MiniMax-M2.7 entries. tp MUST be 4 and num-speculative-tokens MUST be 1: ATOM only constructs MTP layer 0 (matches vLLM _MIMO_V2_FLASH_NUM_MTP_LAYERS=1); driving more spec tokens would route through layers 1/2 whose KV is never populated and accept rate craters."
+    "_baseline_note": "CI GSM8K 3-shot MTP1=0.7983 (run 26410931088). Baseline 0.79; threshold 0.778 (~1.1σ). tp MUST=4, num-speculative-tokens MUST=1: ATOM builds only MTP layer 0 (vLLM _MIMO_V2_FLASH_NUM_MTP_LAYERS=1); more spec → layers 1/2 KV unpopulated, accept craters."
   },
   {
     "model_name": "DeepSeek-V4-Pro TBO+DPA conc1000",
@@ -398,6 +398,6 @@
     "accuracy_threshold": 0.93,
     "accuracy_baseline": 0.95,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-V4-Pro",
-    "_baseline_note": "TBO + dp-attention at high concurrency (client num_concurrent=1000). Local 1319-sample GSM8K 3-shot flexible-extract across 4 runs = 0.9439 / 0.9484 / 0.9538 / 0.9530 (mean ~0.950, measured 2026-06-14 after the TBO ids-gather inline fix + pad_for_all_gather zero-padding fix). Baseline 0.95; threshold 0.93 leaves ~1.4pp headroom below the lowest observed 0.9439 to absorb the wider run-to-run variance seen at conc=1000."
+    "_baseline_note": "TBO + dp-attention at conc=1000. Local 1319-sample GSM8K 3-shot, 4 runs = 0.9439/0.9484/0.9538/0.9530 (mean ~0.950, 2026-06-14, after TBO ids-gather + pad_for_all_gather fixes). Baseline 0.95; threshold 0.93 (~1.4pp below lowest 0.9439, conc=1000 variance)."
   }
 ]

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -6,8 +6,8 @@ concurrency:
 
 on:
   schedule:
-    # Nightly at 01:00 Beijing time (17:00 UTC)
-    - cron: '0 17 * * *'
+    # Nightly at 00:12 Beijing time (16:12 UTC)
+    - cron: '12 16 * * *'
   workflow_dispatch:
     inputs:
       deepseek-r1-0528:

--- a/.github/workflows/atom-mmstar-ci.yaml
+++ b/.github/workflows/atom-mmstar-ci.yaml
@@ -165,39 +165,19 @@ jobs:
           echo "Downloading aiter wheel: ${wheel_name}"
           curl -fsSL "${resolved_wheel_url}" -o "aiter-whl/${wheel_name}"
 
+      # Shared container boilerplate. MODEL_CACHE_MOUNT here is exactly the
+      # `-v /models:/models` that setup-gpu-container mounts automatically, so
+      # it isn't passed through; pull-policy:always reproduces the prior
+      # explicit `docker pull`.
       - name: Start validation container
-        run: |
-          if [ -f "/etc/podinfo/gha-render-devices" ]; then
-            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
-          else
-            DEVICE_FLAG="--device /dev/dri"
-          fi
-
-          MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
-          echo "Using model cache backend: ${MODEL_CACHE_DESC}"
-
-          cat > /tmp/mmstar_env_file.txt << 'EOF'
-          ${{ matrix.env_vars }}
-          EOF
-
-          docker pull "${ATOM_BASE_IMAGE}"
-          docker run -dt --device=/dev/kfd $DEVICE_FLAG \
-            -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
-            $MODEL_MOUNT \
-            -w /workspace \
-            --ipc=host --group-add video \
-            --shm-size=16G \
-            --privileged \
-            --cap-add=SYS_PTRACE \
-            --security-opt seccomp=unconfined \
-            --ulimit memlock=-1 \
-            --ulimit stack=67108864 \
-            --env-file /tmp/mmstar_env_file.txt \
-            -e HF_TOKEN="${HF_TOKEN:-}" \
-            --name "$CONTAINER_NAME" \
-            "${ATOM_BASE_IMAGE}"
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
+        uses: ./.github/actions/setup-gpu-container
+        with:
+          container-name: ${{ env.CONTAINER_NAME }}
+          base-image: ${{ env.ATOM_BASE_IMAGE }}
+          env-vars: ${{ matrix.env_vars }}
+          hf-token: ${{ env.HF_TOKEN }}
+          pull-policy: "always"
+          disable-mmap: "false"  # mmstar never set ATOM_DISABLE_MMAP; keep parity
 
       - name: Install aiter wheel
         run: |


### PR DESCRIPTION
## Summary
Two CI changes (one commit each):

### 1. Reuse `setup-gpu-container` for the bench & mmstar container start
De-inlines the duplicated `Start CI container` `docker run` from
`atom-bench-container` and `atom-mmstar-ci` into the shared
`setup-gpu-container` composite action.

`setup-gpu-container` gains:
- `pull-policy` input (explicit `always`/`missing`/`never`; empty → existing runner-based heuristic)
- `disable-mmap` input (default `true`; `false` skips `ATOM_DISABLE_MMAP`)
- `runner` made optional (`default: ""`)
- env-file keyed by container name (no clobber when containers run concurrently)
- dropped the duplicated `-v/-w` in `docker run`

`atom-bench-container`: Start step → `uses: setup-gpu-container`
(`network-host: true`, `pull-policy: always`, `container-env` → `extra-run-flags`); keeps its model-download step.

`atom-mmstar-ci`: Start step → `uses: setup-gpu-container`; passes
`disable-mmap: false` for byte-for-byte parity (mmstar never set `ATOM_DISABLE_MMAP`).
`MODEL_CACHE_MOUNT` is exactly setup-gpu's automatic `/models` mount.

**Parity:** existing callers (`atom-test`, `atomesh-accuracy`) unaffected —
`disable-mmap` defaults to `true` (matches the prior hard-coded inject).
Only runtime change: mmstar's image pull now hard-fails on error
(`--pull always` vs prior best-effort `docker pull`).

### 2. Advance the nightly ATOM Benchmark schedule
`atom-benchmark.yaml` cron `0 17 * * *` → `12 16 * * *`
(01:00 → 00:12 Beijing, 48 min earlier).

## Test plan
- [x] YAML parses for all changed files
- [ ] Nested composite (`uses` a local composite) + pull/network behavior — only verifiable on a real runner (composite gotchas don't surface locally); confirm via a benchmark + mmstar run