### PR TITLE
[Feature] OFFLOAD: MultiConnector — run P/D (mooncake/moriio) + LMCache offload together

### DIFF
--- a/atom/kv_transfer/disaggregation/factory.py
+++ b/atom/kv_transfer/disaggregation/factory.py
@@ -135,6 +135,17 @@ KVConnectorFactory.register(
     scheduler_class="MooncakeConnectorScheduler",
 )
 
+# Composite backend: fans out to several sub-connectors listed under
+# kv_transfer_config["connectors"] (e.g. moriio P/D + lmcache_offload on one
+# prefill node). Lightweight import — no heavy deps until a sub is built.
+KVConnectorFactory.register(
+    "multi",
+    worker_module="atom.kv_transfer.disaggregation.multi.multi_connector",
+    worker_class="MultiConnector",
+    scheduler_module="atom.kv_transfer.disaggregation.multi.multi_connector",
+    scheduler_class="MultiConnectorScheduler",
+)
+
 
 # ATOM standalone CPU/NVMe KV offload backend (registers "lmcache_offload").
 # Import is lightweight (offload/__init__ only records module paths as strings;

--- a/atom/kv_transfer/disaggregation/multi/README.md
+++ b/atom/kv_transfer/disaggregation/multi/README.md
@@ -1,0 +1,473 @@
+# KV Connectors, MultiConnector, and P/D Disaggregation
+
+This document explains how KV connectors relate to the inference engine, the
+structure of the `multi` connector (run P/D disaggregation **and** LMCache
+offload at once), how prefilled KV blocks are safely freed when both a P/D send
+and an offload save read them, and an end-to-end runbook for bringing up and
+verifying P/D disaggregation.
+
+Code: `atom/kv_transfer/disaggregation/` (`base.py`, `factory.py`,
+`multi/multi_connector.py`), engine side `atom/model_engine/scheduler.py`,
+`model_runner.py`, `utils/forward_context.py`.
+
+---
+
+## 1. Connector vs Inference Engine
+
+- **Inference engine** computes tokens and **owns** the KV cache in HBM. It is
+  the main body of the system and runs fine with no connector at all.
+- **KV connector** does not compute; it only **moves** KV bytes — to a remote
+  decode node (P/D disaggregation) or to CPU/NVMe (offload), and back when
+  needed. It is pluggable; the factory selects exactly one by the
+  `kv_connector` config name.
+
+They are decoupled by a narrow set of hooks in `base.py`. Each step the engine
+calls the connector at fixed points; the connector reads/writes the HBM KV
+tensors it was handed, then reports "transfer finished" so the engine can free
+blocks / wake sequences.
+
+```
+                        +------------------+
+                        |    API Server    |
+                        +------------------+
+                                 |
+                                 v
++=================================================+
+| INFERENCE ENGINE - computes tokens, owns KV     |
+| EngineCore -> Scheduler -> ModelRunner (GPU)    |
+| BlockManager -> [ HBM KV Cache = real KV bytes ]|
++=================================================+
+                 ^               |
+                 |   hooks (engine calls connector)
+                 |               v
++=================================================+
+| KV CONNECTOR - moves KV bytes, no compute       |
+| KVConnectorBase (7 hooks) -> pick ONE:          |
+| moriio | mooncake | lmcache_offload | multi     |
++=================================================+
+            |                          |
+            v                          v
+     +-------------+            +-------------+
+     | Decode node |            |  CPU / NVMe |
+     +-------------+            +-------------+
+       (P/D xfer)                (LMCache)
+```
+
+### The seven hooks (`base.py`)
+
+| Side | Hook | Purpose |
+|---|---|---|
+| scheduler | `get_num_new_matched_tokens(seq)` | Does this seq have reusable KV (remote already computed / cached on CPU)? If so, park it and wait for the transfer. |
+| scheduler | `update_state_after_alloc(seq)` | After HBM blocks are allocated, record the "to recv / to save" intent. |
+| scheduler | `build_connector_meta()` | Pack this step's transfer requests into a `meta`. |
+| scheduler | `request_finished(seq)` | Clean up when a request finishes. |
+| worker | `register_kv_caches(tensors)` | Once at init: hand the HBM KV tensor addresses to the connector (it reads/writes through these). |
+| worker | `start_load_kv(meta)` | Kick off the async transfers (load in / save out). |
+| worker | `get_finished()` | Report which req IDs finished sending / recving / saving / failed. |
+
+> Offload-specific scheduler methods (`should_park_*`, `save_finished`,
+> `load_failed`, ...) are all guarded with `hasattr` on the engine side, so a
+> connector that does not implement them works fine.
+
+---
+
+## 2. Two layers: scheduler vs worker
+
+The connector is split into two objects living in two processes:
+- **scheduler-side** (main / EngineCore process, no GPU) — built by
+  `get_kvconnector("scheduler")`. Decides / bookkeeps / packs / cleans up.
+- **worker-side** (GPU TP-worker process, one per rank, **holds HBM KV
+  pointers**) — built by `get_kvconnector("worker")`. Actually moves bytes.
+
+`meta` flows down (scheduler → workers), `KVConnectorOutput` flows up
+(workers → scheduler, merged across TP ranks by `KVOutputAggregator`). Left
+column = what the engine does that tick; right column = the connector hook fired
+on the same tick.
+
+```
++=====================================================================+
+| SCHEDULER LAYER   -   main process  (no GPU)                        |
+| Scheduler  +  scheduler-side connector object                       |
++=====================================================================+
+| WORK / SCHEDULE                | CONNECTOR HOOKS  (*)               |
+|                                                                     |
+| [1] Scheduler.schedule()       |                                    |
+|       reuse remote / CPU KV ?  | * get_num_new_matched_tokens       |
+|       alloc HBM blocks         |                                    |
+|       record transfer intent   | * update_state_after_alloc         |
+|       snapshot this step       | * build_connector_meta  => meta    |
+|                                                                     |
++=====================================================================+
+
+        |  meta   (IPC:  scheduler  -->  workers)
+        v
+
++=====================================================================+
+| WORKER LAYER   -   GPU TP-worker process  (per rank)                |
+| ModelRunner  +  worker-side connector  (holds HBM KV)               |
++=====================================================================+
+| GPU WORK                       | CONNECTOR HOOKS  (*)               |
+|                                                                     |
+| (init, once)                   | * register_kv_caches(tensors)      |
+|                                                                     |
+| [2] receive meta               | * start_load_kv(meta)              |
+|       async copy HBM <-> ext   |   (load / save)                    |
+|                                                                     |
+| [3] GPU forward prefill/dec    |   compute (no connector)           |
+|       connector copy parallel  |   (side stream)                    |
+|                                                                     |
+| [4] poll transfer status       | * get_finished()                   |
+|                                |   => {sent,recv,saved,fail}        |
+|                                                                     |
++=====================================================================+
+
+        ^  KVConnectorOutput
+        |  (IPC:  workers --> scheduler,  merged across TP)
+
++=====================================================================+
+| SCHEDULER LAYER   -   back in main process                          |
++=====================================================================+
+| APPLY RESULTS                  | CONNECTOR HOOKS  (*)               |
+|                                                                     |
+| [5] recv done -> wake seq      |                                    |
+|         -> start its decode    |                                    |
+|     sent/saved -> free HBM     |                                    |
+|     finished                   | * request_finished(seq)            |
+|                                                                     |
+|     loop  -->  back to [1]     |                                    |
++=====================================================================+
+```
+
+The scheduler is the clock. The worker only "moves + reports"; block freeing and
+sequence waking are decided by the scheduler in `[5]` based on what was reported.
+`[3]` GPU forward and the worker-side copy run on different streams in parallel,
+so transfers do not block compute.
+
+---
+
+## 3. MultiConnector structure
+
+To the engine, `multi` is just one connector (implements the same `base.py`
+interface; the engine does not know it is multi). Internally it holds a list of
+real sub-connectors and fans out / merges per hook. Three classes:
+`MultiConnector` (worker), `MultiConnectorScheduler` (scheduler),
+`MultiConnectorMetadata`.
+
+```
+            engine  -->  base interface  (unchanged, doesn't know it's multi)
+                                |
+                                v
++=============================================================+
+| MultiConnectorScheduler   (SCHEDULER layer)                 |
+| one connector, holds a list of sub-connectors               |
++=============================================================+
+| HOOK                       | MERGE POLICY                   |
+|                                                             |
+| get_num_new_matched        | first-hit-wins (1 sub owns it) |
+| update_state_after_alloc   | fan-out to ALL subs            |
+| build_connector_meta       | pack -> MultiConnectorMetadata |
+| request_finished           | fan-out to ALL subs            |
++=============================================================+
+            |                                       |
+            v                                       v
+   +--------------------------+      +------------------------------+
+   | mooncake (sched sub)     |      | lmcache_offload (sched sub)  |
+   | kv_role=kv_producer      |      | kv_role=offload              |
+   +--------------------------+      +------------------------------+
+
+   build_connector_meta()  =>  MultiConnectorMetadata(
+                                  metas = [ meta_mooncake , meta_offload ] )
+                                |   IPC down  (scheduler -> workers)
+                                v
++=============================================================+
+| MultiConnector            (WORKER layer, per TP rank)       |
+| holds worker-side sub-connectors (touch HBM KV)             |
++=============================================================+
+| HOOK                       | MERGE POLICY                   |
+|                                                             |
+| register_kv_caches         | fan-out to ALL subs            |
+| start_load_kv(meta)        | route metas[i] -> subs[i]      |
+| get_finished()             | UNION + send/save gating       |
++=============================================================+
+            |                                       |
+            v                                       v
+   +--------------------------+      +------------------------------+
+   | mooncake (worker sub)    |      | lmcache_offload (worker sub) |
+   |   -> Decode node (P/D)   |      |   -> CPU / NVMe (LMCache)    |
+   +--------------------------+      +------------------------------+
+```
+
+**How subs are built (no recursion):** `_build_subconnectors` does
+`copy.copy(config)`, swaps in the sub `kv_transfer_config`, and goes through the
+factory again. Each sub dict carries its own `kv_connector`
+(moriio / mooncake / lmcache_offload), never `multi`, so there is no recursion.
+List index is strictly aligned: `metas[i] <-> subs[i]`, which is how the worker
+de-multiplexes.
+
+### Priority when more than one sub could match
+
+`get_num_new_matched_tokens` is **first-hit-wins by `connectors` list order**:
+
+```python
+result = (0, False)
+for c in self._connectors:            # iterate in config order
+    toks, needs_load = c.get_num_new_matched_tokens(seq)
+    if result[0] == 0 and toks > 0:   # first sub returning >0 owns the request
+        result = (toks, needs_load)
+return result
+```
+
+- Priority = list order. Reorder `connectors` to change it.
+- **In the actual producer topology, offload always wins regardless of order:**
+  `mooncake (kv_producer)` only returns `>0` when
+  `seq.kv_transfer_params["do_remote_prefill"]` is set — and that flag is a
+  *consumer-side* flag (set by the proxy on the decode node), never on the
+  producer. So `mooncake-producer` always returns `(0, False)`, and only offload
+  can match.
+- Order only matters on a node where two subs could match the same request
+  (e.g. a hypothetical `multi=[mooncake-consumer, offload]` on the decode node).
+  Then prefer putting cheaper local offload first.
+
+> Caveat: the loop calls `get_num_new_matched_tokens` on every sub (only the
+> first non-zero is returned). For offload this method has side effects (records
+> `_load_specs`, pins LMCache, appends `_lookup_in_step`). Harmless in the
+> producer topology (mooncake no-ops, offload is the winner). If you ever run a
+> node where both could match the same request, the non-winning sub still leaves
+> state; vLLM's MultiConnector avoids this with a `_requests_to_connector` owner
+> map — the current ATOM version does not track an owner.
+
+---
+
+## 4. Block-free correctness: send ∧ save gating
+
+On a producer node, a prefilled request's KV blocks must survive until **both**
+the P/D send **and** the offload save have read them. mooncake send and offload
+save both only *read* the same HBM blocks (no write conflict), but if one
+finishes first and the engine frees the block, the other is left reading freed
+memory.
+
+### The engine natively frees on a single condition
+
+```python
+# scheduler.py  _update_from_kv_xfer_finished
+for req_id in finished_sending:          # loop A
+    seq = _pop_deferred(req_id)
+    self.block_manager.deallocate(seq)   # frees as soon as send is done
+
+for req_id in finished_saving:           # loop B
+    save_finished(req_id)
+    seq = deferred_free_blocks.get(req_id)
+    if seq is not None and not should_defer_free(seq):
+        deallocate(seq)                  # save completion can also free
+```
+
+Two independent free triggers — fine for plain mooncake, unsafe for `multi`.
+
+### The gate (in `MultiConnector.get_finished`, engine untouched)
+
+```python
+# start_load_kv: remember which reqs have an offload save in flight
+for req in m.requests:
+    if req.save_spec is not None:
+        self._pending_save.add(str(req.req_id))
+
+# get_finished (producer branch): release send + save only once BOTH are done
+for r in send_now: self._sent[str(r)]  = r
+for r in save_now: self._saved[str(r)] = r
+for key, raw in list(self._sent.items()):
+    needs_save = key in self._pending_save
+    if needs_save and key not in self._saved:
+        continue                          # hold: save not done -> do not report finished_sending
+    rel_send.add(raw); del self._sent[key]; self._pending_save.discard(key)
+    if key in self._saved:
+        rel_save.add(self._saved.pop(key))
+out.finished_sending = rel_send
+out.finished_saving  = rel_save
+```
+
+Both arrival orders are covered: send-first holds `finished_sending`; save-first
+buffers in `_saved` and is only reported paired with the send. When both are
+done they are emitted in the same step.
+
+### Why the separate loops are still safe
+
+Because both sets land in the **same** `_update_from_kv_xfer_finished` call, and
+loop A (sending) runs before loop B (saving): loop A pops + frees the block;
+loop B then `get`s `None` and is a no-op. Holds across TP ranks too — each rank
+gates, and `KVOutputAggregator` reaches quorum on both sets in the same cycle.
+
+Unit-tested in both orders (`test_send_is_withheld_until_save_completes`,
+`test_save_then_send_also_pairs`); integration runs show 0 corruption.
+
+### Code subtleties
+
+- **Loop B's `if seq is not None and not should_defer_free(seq)` is dead in the
+  multi-producer P/D path** (loop A already popped the seq), but it is *not*
+  removable: it is the real free path for standalone offload
+  (`is_producer=False`, no send), and `should_defer_free` guards multi-chunk
+  saves still in flight.
+- **`if key in self._saved` is not always true.** It is true on the
+  `needs_save` path, but false for **send-only** requests (a req mooncake sends
+  but offload does not save — e.g. prompt `< chunk_size` so `chunk_floor=0`, or
+  the prefix is already fully in LMCache). Such requests release
+  `finished_sending` immediately and contribute nothing to `finished_saving`.
+- **`del self._sent[key]` needs no extra guard.** For `multi=[offload]` (all
+  non-producer subs), `is_producer=False` so `get_finished` returns early via
+  the pass-through branch and never touches `_sent`. When a producer is present,
+  the loop iterates a `list(...)` snapshot, so deleting during iteration is
+  safe and `key` is guaranteed present.
+
+### HBM-hit + send + offload at the same time
+
+These are three independent things; an HBM prefix-cache hit only skips the
+redundant offload **reload**, it does not affect the send or the save:
+
+| Action | Owner | Effect of HBM hit |
+|---|---|---|
+| send to decode (P/D) | mooncake sub | none — sends the HBM blocks regardless |
+| offload save to CPU | offload sub | none — saves whatever is not yet in LMCache |
+| reload from offload | offload sub | correctly skipped (`need = lmcache_hit - num_cached <= 0`) |
+
+---
+
+## 5. P/D disaggregation runbook (tested)
+
+Validated on MI325X, container `yhl_kvoff_009`, `Llama-3.1-8B-Instruct`,
+mooncake `protocol=tcp`.
+
+### 5.1 Prerequisites / gotchas
+
+- **mori is unusable on this host** (container ionic RoCE driver ABI 1 vs
+  libibverbs needs 4 -> MORI finds no usable RDMA device). Use mooncake with
+  `"protocol":"tcp"`, which needs no RDMA.
+- Container deps: `mooncake`, `msgpack`, `msgspec`, `quart`; offload also needs
+  `lmcache`. Verify:
+  ```bash
+  python -c "import mooncake,lmcache,msgpack,msgspec,quart,zmq; print('deps ok')"
+  ```
+- `--network host` ⇒ ports are host-global. Rapid restarts hit
+  `Address already in use` (ROUTER socket TIME_WAIT); use a fresh
+  `handshake_port` or wait ~60s.
+- Shared GPU box: pick 0%-VRAM cards via `rocm-smi --showmemuse`. Repeated `-9`
+  kills leak `psm_*` segments in host-shared `/dev/shm` and can exhaust aiter's
+  broadcast pool (NCCL `Failed to CUDA calloc`). **Do not blindly delete
+  `/dev/shm` — it is shared with other users' jobs.**
+
+### 5.2 Topology
+
+```
+Client --> Proxy(:10003, discovery :36367)
+              |--> Prefill node (kv_producer)  GPU a  API :8000  handshake 6700
+              '--> Decode  node (kv_consumer)  GPU b  API :8001  handshake 6800
+```
+Plain P/D: both ends use `kv_connector:"mooncake"`. P/D + offload: switch only
+the **prefill** node to `kv_connector:"multi"`; the decode node stays a plain
+mooncake consumer.
+
+### 5.3 Launch
+
+Proxy:
+```bash
+python -m atom.kv_transfer.disaggregation.proxy --port 10003
+```
+
+Prefill / producer (plain P/D):
+```bash
+HIP_VISIBLE_DEVICES=5 python -m atom.entrypoints.openai_server \
+  --model /shared/data/amd_int/models/Llama-3.1-8B-Instruct \
+  --kv_cache_dtype fp8 --block-size 16 -tp 1 --trust-remote-code \
+  --max-model-len 8192 --gpu-memory-utilization 0.40 \
+  --port 8009 --server-port 8000 \
+  --kv-transfer-config '{"kv_role":"kv_producer","kv_connector":"mooncake","protocol":"tcp","proxy_ip":"127.0.0.1","proxy_ping_port":36367,"http_port":8000,"handshake_port":6700}'
+```
+
+Prefill / producer (P/D + offload via multi) — add LMCache env +
+`--enable_prefix_caching`, swap the connector config:
+```bash
+HIP_VISIBLE_DEVICES=5 \
+LMCACHE_LOCAL_CPU=True LMCACHE_MAX_LOCAL_CPU_SIZE=16.0 LMCACHE_CHUNK_SIZE=256 LMCACHE_USE_GDS=False PYTHONHASHSEED=0 \
+python -m atom.entrypoints.openai_server \
+  --model /shared/data/amd_int/models/Llama-3.1-8B-Instruct \
+  --kv_cache_dtype fp8 --block-size 16 -tp 1 --trust-remote-code \
+  --enable_prefix_caching --max-model-len 8192 --gpu-memory-utilization 0.40 \
+  --port 8009 --server-port 8000 \
+  --kv-transfer-config '{"kv_connector":"multi","connectors":[{"kv_connector":"mooncake","kv_role":"kv_producer","protocol":"tcp","proxy_ip":"127.0.0.1","proxy_ping_port":36367,"http_port":8000,"handshake_port":6700},{"kv_connector":"lmcache_offload","kv_role":"offload"}]}'
+```
+
+Decode / consumer (always plain mooncake):
+```bash
+HIP_VISIBLE_DEVICES=6 python -m atom.entrypoints.openai_server \
+  --model /shared/data/amd_int/models/Llama-3.1-8B-Instruct \
+  --kv_cache_dtype fp8 --block-size 16 -tp 1 --trust-remote-code \
+  --max-model-len 8192 --gpu-memory-utilization 0.40 \
+  --port 8019 --server-port 8001 \
+  --kv-transfer-config '{"kv_role":"kv_consumer","kv_connector":"mooncake","protocol":"tcp","proxy_ip":"127.0.0.1","proxy_ping_port":36367,"http_port":8001,"handshake_port":6800}'
+```
+
+> Config-key note: moriio uses `http_prt`; **mooncake uses `http_port`** plus
+> `handshake_port` (producer/consumer must differ on a single host: 6700 vs
+> 6800). `http_port` must equal `--server-port`.
+
+### 5.4 Readiness (do not `tail -f` forever)
+
+Poll `until curl /v1/models` with a 6-minute cap and fail-fast on
+`Traceback|HIP out of memory|proc died|NCCL error|Failed to CUDA|Address already in use`.
+
+### 5.5 End-to-end test (send only to the proxy)
+
+```bash
+curl -s http://127.0.0.1:10003/v1/completions -H 'Content-Type: application/json' \
+  -d '{"prompt":"The capital of France is","max_tokens":16,"temperature":0}'
+```
+For an offload save, use a prompt >= chunk_size (256 tokens).
+
+### 5.6 How to verify it works
+
+**P/D transfer happened:**
+- response: `kv_transfer_params.do_remote_prefill == true`
+- producer log: `Received write_request`, `_execute_transfer`,
+  `All 1 consumers served`, `get_finished: sending={0}`
+- consumer log: `Queued req ... for remote KV recv`, `Sending write_request ...`,
+  `Write-done received ... done_recving now: {0}`
+- output is coherent (greedy temp=0 can be diffed token-for-token vs single-node)
+
+**offload save happened (P/D + multi):**
+- producer log: `LMCache ... Stored <N> tokens` (needs prompt >= 256). Measured:
+  2509-token prompt -> `Stored 2304` (= chunk_floor(2509)), concurrent with
+  `All 1 consumers served`.
+
+**offload reload (optional, needs HBM eviction first):**
+- a second identical request right away will NOT reload (prefix still in HBM;
+  `Retrieved=0` is correct). Forcing a real reload needs evicting HBM (hard on a
+  256 GB card with an 8B model — use MiniMax + low util + long context and
+  `scripts/offload_ttft_micro.py`). Marker: `LMCache ... Retrieved`.
+
+**block-free safety (send ∧ save gating):**
+- a clean run shows 0 hard errors:
+  ```bash
+  grep -acE "Traceback|assert|use.after.free|MEMORY_VIOLATION|Memory access fault" <prefill log>
+  # ignore the benign tokenizer warning that contains the word "corrupt"
+  ```
+
+### 5.7 Cleanup
+
+```bash
+pkill -9 -f "atom.entrypoints.openai_server|disaggregation.proxy"
+rocm-smi --showmemuse | grep -E "GPU\[(5|6)\].*VRAM"   # confirm VRAM freed
+```
+Do not delete `psm_*` in host-shared `/dev/shm` (would break other containers).
+
+### 5.8 Validated results (8B / mooncake-tcp)
+
+| Item | Result |
+|---|---|
+| plain mooncake P/D | OK — end-to-end, log handshake closed, coherent output |
+| MultiConnector as P/D producer | OK — P/D transfer works through multi |
+| producer offload save (via multi) | OK — `Stored 2304`, concurrent with P/D send |
+| HBM-hit second request | OK — send proceeds, reload correctly skipped, no re-store |
+| block free / gating | OK — 0 errors / 0 asserts |
+| unit tests | OK — `tests/test_multi_connector.py` 16/16 |
+
+> Not separately isolated: the exact "prefix in HBM but not in LMCache" case of
+> HBM-hit + send + a NEW save (mechanism supports it, see §4); a real reload demo
+> needs tight HBM (hard on this host — use MiniMax).

--- a/atom/kv_transfer/disaggregation/multi/__init__.py
+++ b/atom/kv_transfer/disaggregation/multi/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Composite KV connector that fans out to several sub-connectors.
+
+Lets a single engine run e.g. moriio (P/D RDMA transfer) and lmcache_offload
+(CPU/NVMe KV cache) at the same time. Registered under the name ``"multi"``;
+see :mod:`atom.kv_transfer.disaggregation.multi.multi_connector`.
+"""

--- a/atom/kv_transfer/disaggregation/multi/multi_connector.py
+++ b/atom/kv_transfer/disaggregation/multi/multi_connector.py
@@ -290,9 +290,7 @@ class MultiConnectorScheduler(KVConnectorSchedulerBase):
         )
         # Opt into the scheduler's offload suffix-prefill path if any sub is the
         # offload backend (Scheduler._is_offload_connector reads this).
-        self.is_offload = any(
-            getattr(c, "is_offload", False) for c in self._connectors
-        )
+        self.is_offload = any(getattr(c, "is_offload", False) for c in self._connectors)
 
     # -- base interface -----------------------------------------------------
 
@@ -329,13 +327,13 @@ class MultiConnectorScheduler(KVConnectorSchedulerBase):
 
     def adjust_prefill_chunk_after_alloc(self, seq: Any, chunk: int) -> int:
         c = _first_with(self._connectors, "adjust_prefill_chunk_after_alloc")
-        return c.adjust_prefill_chunk_after_alloc(seq, chunk) if c is not None else chunk
+        return (
+            c.adjust_prefill_chunk_after_alloc(seq, chunk) if c is not None else chunk
+        )
 
     def should_park_partial_prefill_for_load(self, seq: Any) -> bool:
         c = _first_with(self._connectors, "should_park_partial_prefill_for_load")
-        return (
-            c.should_park_partial_prefill_for_load(seq) if c is not None else False
-        )
+        return c.should_park_partial_prefill_for_load(seq) if c is not None else False
 
     def should_defer_free(self, seq: Any) -> bool:
         # Defer if ANY sub wants to defer (so neither a pending save nor a

--- a/atom/kv_transfer/disaggregation/multi/multi_connector.py
+++ b/atom/kv_transfer/disaggregation/multi/multi_connector.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Composite KV connector — run several sub-connectors behind one interface.
+
+The canonical use case is a prefill node that must do two things with the same
+KV at once:
+
+* **moriio** (``kv_role: kv_producer``) — RDMA-send the KV to a remote decode
+  node for P/D disaggregation;
+* **lmcache_offload** (``kv_role: offload``) — save the KV to CPU/NVMe so a
+  future request that shares the prefix can skip recompute.
+
+A single engine selects exactly one connector (``KVConnectorFactory`` reads one
+``kv_connector`` name). ``MultiConnector`` is that one connector; it owns a list
+of real sub-connectors and merges their results so the engine, scheduler, and
+output aggregator stay unchanged.
+
+Config::
+
+    --kv-transfer-config '{
+      "kv_connector": "multi",
+      "connectors": [
+        {"kv_connector": "moriio", "kv_role": "kv_producer", "proxy_ip": "...", ...},
+        {"kv_connector": "lmcache_offload", "kv_role": "offload"}
+      ]
+    }'
+
+Merge strategy mirrors vLLM's ``MultiConnector``, adapted to ATOM's
+``base.py`` interface:
+
+* ``get_num_new_matched_tokens`` — **first-hit-wins**: the first sub-connector
+  that reports a prefix match owns the load for that request.
+* ``update_state_after_alloc`` / ``request_finished`` — fan out to **all** subs
+  (moriio sets up its send, offload sets up its save; both must run).
+* ``build_connector_meta`` — returns :class:`MultiConnectorMetadata` carrying one
+  sub-metadata per connector, in connector order. The worker de-multiplexes by
+  index in ``start_load_kv``.
+* ``get_finished`` — union the completion sets, **but** see the send/save
+  pairing below.
+
+Send/save pairing (the one tricky correctness point)
+----------------------------------------------------
+On a producer node the scheduler frees a finished request's blocks as soon as it
+sees ``finished_sending`` (``scheduler.py``: producer path), and it can *also*
+free on ``finished_saving`` when the connector does not defer. If offload is
+still reading those blocks for its save when the moriio send completes (or vice
+versa), the free would corrupt the in-flight transfer. So when a request needs
+**both** a send and a save, ``MultiConnector`` withholds *both* completion
+signals until the pair is done, then emits them together. The scheduler's
+``finished_sending`` handler frees first; the ``finished_saving`` handler then
+finds nothing to free and no-ops. This is the analogue of vLLM's
+``_extra_async_saves`` refcount.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+from atom.kv_transfer.disaggregation.base import (
+    KVConnectorBase,
+    KVConnectorSchedulerBase,
+)
+from atom.kv_transfer.disaggregation.types import ConnectorMetadata, KVConnectorOutput
+
+logger = logging.getLogger("atom")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_subconnectors(config: Any, role: str) -> list:
+    """Instantiate each sub-connector listed in ``kv_transfer_config.connectors``.
+
+    Each entry is a full ``kv_transfer_config`` dict (with its own
+    ``kv_connector`` name). We shallow-copy the engine config, swap in the
+    sub-dict, and route through the normal factory — no recursion, since each
+    sub names a concrete backend (moriio / lmcache_offload / ...), not ``multi``.
+    """
+    # Imported lazily: the factory module registers backends at import time and
+    # we must not create an import cycle with it.
+    from atom.kv_transfer.disaggregation.factory import KVConnectorFactory
+
+    kvc = getattr(config, "kv_transfer_config", None) or {}
+    subs = kvc.get("connectors")
+    if not subs:
+        raise ValueError(
+            "multi connector requires a non-empty 'connectors' list in "
+            "kv_transfer_config"
+        )
+
+    connectors = []
+    for i, sub in enumerate(subs):
+        if not isinstance(sub, dict) or "kv_connector" not in sub:
+            raise ValueError(
+                f"connectors[{i}] must be a dict with a 'kv_connector' key, "
+                f"got {sub!r}"
+            )
+        if sub["kv_connector"] == "multi":
+            raise ValueError("multi connector cannot nest another 'multi'")
+        cfg_i = copy.copy(config)
+        cfg_i.kv_transfer_config = sub
+        connectors.append(KVConnectorFactory.create_connector(cfg_i, role=role))
+        logger.debug(
+            "multi: built sub-connector[%d] backend=%s role=%s",
+            i,
+            sub["kv_connector"],
+            role,
+        )
+    return connectors
+
+
+def _normalize_finished(finished: Any) -> KVConnectorOutput:
+    """Coerce a sub-connector's ``get_finished()`` result to KVConnectorOutput.
+
+    Legacy P/D connectors (moriio/mooncake) return a ``(done_sending,
+    done_recving)`` tuple; the offload connector already returns a full
+    :class:`KVConnectorOutput`.
+    """
+    if isinstance(finished, KVConnectorOutput):
+        return finished
+    done_sending, done_recving = finished
+    return KVConnectorOutput(
+        finished_sending=set(done_sending or ()),
+        finished_recving=set(done_recving or ()),
+    )
+
+
+def _first_with(connectors: list, name: str):
+    """Return the first sub-connector exposing attribute/method *name*, or None."""
+    for c in connectors:
+        if hasattr(c, name):
+            return c
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+class MultiConnectorMetadata(ConnectorMetadata):
+    """Carries one sub-connector metadata per connector, in connector order.
+
+    Subclasses :class:`ConnectorMetadata` so existing ``isinstance`` checks and
+    the worker dispatch path accept it unchanged. The worker reads ``metas`` and
+    routes ``metas[i]`` to ``connectors[i].start_load_kv``.
+    """
+
+    def __init__(self, metas: list) -> None:
+        super().__init__()
+        self.metas = list(metas)
+
+    @property
+    def requests(self):
+        """Aggregate of sub-metas' ``requests`` (offload uses this attribute).
+
+        ``EngineCore._dispatch_idle_offload_work`` gates its idle dispatch on a
+        truthy ``meta.requests``; exposing it here keeps offload's idle
+        save/load flowing when offload runs inside a ``multi`` connector.
+        """
+        agg: list = []
+        for m in self.metas:
+            sub = getattr(m, "requests", None)
+            if sub:
+                agg.extend(sub)
+        return agg
+
+
+# ---------------------------------------------------------------------------
+# Worker side
+# ---------------------------------------------------------------------------
+
+
+class MultiConnector(KVConnectorBase):
+    """Worker-side composite connector (one instance per TP rank)."""
+
+    def __init__(self, config: Any) -> None:
+        self._connectors = _build_subconnectors(config, role="worker")
+        # Producer if any sub is a producer (moriio kv_producer drives the
+        # scheduler's producer-side deferred-free path).
+        self.is_producer = any(
+            getattr(c, "is_producer", False) for c in self._connectors
+        )
+
+        # Send/save pairing state (see module docstring).
+        # _pending_save: str(req_id) for requests offload will save this lifetime.
+        self._pending_save: set[str] = set()
+        # _sent / _saved: completed-but-unpaired transfers, str(req_id) -> raw id.
+        self._sent: dict[str, Any] = {}
+        self._saved: dict[str, Any] = {}
+
+    def register_kv_caches(
+        self,
+        kv_caches: dict[str, Any],
+        transfer_tensors: Any = None,
+        num_blocks: int | None = None,
+    ) -> None:
+        for c in self._connectors:
+            c.register_kv_caches(kv_caches, transfer_tensors, num_blocks)
+
+    def start_load_kv(self, metadata: ConnectorMetadata) -> None:
+        metas = getattr(metadata, "metas", None)
+        if metas is None:
+            logger.warning(
+                "multi: start_load_kv got %s, expected MultiConnectorMetadata",
+                type(metadata).__name__,
+            )
+            return
+        for c, m in zip(self._connectors, metas):
+            if m is None:
+                continue
+            # Remember which requests offload is about to save, so get_finished
+            # can hold their send completion until the save also finishes.
+            reqs = getattr(m, "requests", None)
+            if reqs:
+                for req in reqs:
+                    if getattr(req, "save_spec", None) is not None:
+                        self._pending_save.add(str(getattr(req, "req_id")))
+            c.start_load_kv(m)
+
+    def get_finished(self) -> KVConnectorOutput:
+        recv: set = set()
+        failed: set = set()
+        send_now: list = []
+        save_now: list = []
+        for c in self._connectors:
+            o = _normalize_finished(c.get_finished())
+            recv |= o.finished_recving
+            failed |= o.failed_recving
+            send_now.extend(o.finished_sending)
+            save_now.extend(o.finished_saving)
+
+        out = KVConnectorOutput(finished_recving=recv, failed_recving=failed)
+
+        if not self.is_producer:
+            # No moriio send to pair with: offload save / recv pass straight
+            # through (the scheduler frees consumer/offload requests on
+            # finished_saving via should_defer_free).
+            out.finished_sending = set(send_now)
+            out.finished_saving = set(save_now)
+            return out
+
+        # Producer + offload: pair each request's send and save before
+        # releasing either (see module docstring).
+        for r in send_now:
+            self._sent[str(r)] = r
+        for r in save_now:
+            self._saved[str(r)] = r
+
+        rel_send: set = set()
+        rel_save: set = set()
+        for key, raw in list(self._sent.items()):
+            needs_save = key in self._pending_save
+            if needs_save and key not in self._saved:
+                continue  # hold: save still in flight for this request
+            rel_send.add(raw)
+            del self._sent[key]
+            self._pending_save.discard(key)
+            if key in self._saved:
+                rel_save.add(self._saved.pop(key))
+
+        out.finished_sending = rel_send
+        out.finished_saving = rel_save
+        return out
+
+    def get_finished_recv_blocks(self) -> list[int]:
+        blocks: list[int] = []
+        for c in self._connectors:
+            blocks.extend(c.get_finished_recv_blocks())
+        return blocks
+
+
+# ---------------------------------------------------------------------------
+# Scheduler side
+# ---------------------------------------------------------------------------
+
+
+class MultiConnectorScheduler(KVConnectorSchedulerBase):
+    """Scheduler-side composite connector."""
+
+    def __init__(self, config: Any) -> None:
+        self._connectors = _build_subconnectors(config, role="scheduler")
+        self.is_producer = any(
+            getattr(c, "is_producer", False) for c in self._connectors
+        )
+        # Opt into the scheduler's offload suffix-prefill path if any sub is the
+        # offload backend (Scheduler._is_offload_connector reads this).
+        self.is_offload = any(
+            getattr(c, "is_offload", False) for c in self._connectors
+        )
+
+    # -- base interface -----------------------------------------------------
+
+    def get_num_new_matched_tokens(self, seq: Any) -> tuple[int, bool]:
+        """First-hit-wins: the first sub that reports a match owns the load."""
+        result = (0, False)
+        for c in self._connectors:
+            toks, needs_load = c.get_num_new_matched_tokens(seq)
+            if result[0] == 0 and toks > 0:
+                result = (toks, needs_load)
+        return result
+
+    def build_connector_meta(self) -> MultiConnectorMetadata:
+        return MultiConnectorMetadata(
+            metas=[c.build_connector_meta() for c in self._connectors]
+        )
+
+    def update_state_after_alloc(self, seq: Any) -> None:
+        for c in self._connectors:
+            c.update_state_after_alloc(seq)
+
+    def request_finished(self, seq: Any) -> None:
+        for c in self._connectors:
+            if hasattr(c, "request_finished"):
+                c.request_finished(seq)
+
+    # -- offload-specific methods, forwarded to the owning sub --------------
+    # The scheduler guards every one of these with hasattr(), so MultiConnector
+    # only needs to expose them when a sub-connector implements them.
+
+    def should_park_for_load_after_alloc(self, seq: Any) -> bool:
+        c = _first_with(self._connectors, "should_park_for_load_after_alloc")
+        return c.should_park_for_load_after_alloc(seq) if c is not None else False
+
+    def adjust_prefill_chunk_after_alloc(self, seq: Any, chunk: int) -> int:
+        c = _first_with(self._connectors, "adjust_prefill_chunk_after_alloc")
+        return c.adjust_prefill_chunk_after_alloc(seq, chunk) if c is not None else chunk
+
+    def should_park_partial_prefill_for_load(self, seq: Any) -> bool:
+        c = _first_with(self._connectors, "should_park_partial_prefill_for_load")
+        return (
+            c.should_park_partial_prefill_for_load(seq) if c is not None else False
+        )
+
+    def should_defer_free(self, seq: Any) -> bool:
+        # Defer if ANY sub wants to defer (so neither a pending save nor a
+        # pending send loses its blocks early).
+        return any(
+            hasattr(c, "should_defer_free") and c.should_defer_free(seq)
+            for c in self._connectors
+        )
+
+    def save_finished(self, req_id: Any) -> None:
+        for c in self._connectors:
+            if hasattr(c, "save_finished"):
+                c.save_finished(req_id)
+
+    def load_failed(self, req_id: Any) -> None:
+        for c in self._connectors:
+            if hasattr(c, "load_failed"):
+                c.load_failed(req_id)

--- a/tests/test_multi_connector.py
+++ b/tests/test_multi_connector.py
@@ -20,7 +20,6 @@ from atom.kv_transfer.disaggregation.multi.multi_connector import (
     MultiConnectorScheduler,
 )
 
-
 # ---------------------------------------------------------------------------
 # Mock sub-connectors
 # ---------------------------------------------------------------------------
@@ -29,8 +28,14 @@ from atom.kv_transfer.disaggregation.multi.multi_connector import (
 class FakeSchedSub:
     """Scheduler-side sub-connector mock."""
 
-    def __init__(self, *, match=(0, False), is_producer=False, is_offload=False,
-                 offload_methods=False):
+    def __init__(
+        self,
+        *,
+        match=(0, False),
+        is_producer=False,
+        is_offload=False,
+        offload_methods=False,
+    ):
         self._match = match
         self.is_producer = is_producer
         if is_offload:
@@ -188,16 +193,18 @@ def test_build_connector_meta_wraps_subs_in_order():
 
 
 def test_role_attrs_aggregate():
-    sched = _sched([
-        FakeSchedSub(is_producer=True),
-        FakeSchedSub(is_offload=True, offload_methods=True),
-    ])
+    sched = _sched(
+        [
+            FakeSchedSub(is_producer=True),
+            FakeSchedSub(is_offload=True, offload_methods=True),
+        ]
+    )
     assert sched.is_producer is True
     assert sched.is_offload is True
 
 
 def test_offload_methods_forwarded_to_owning_sub():
-    moriio = FakeSchedSub(is_producer=True)            # no offload methods
+    moriio = FakeSchedSub(is_producer=True)  # no offload methods
     off = FakeSchedSub(is_offload=True, offload_methods=True)
     off.park = True
     off.partial_park = True
@@ -241,8 +248,8 @@ def test_register_kv_caches_fans_out():
 def test_start_load_kv_routes_by_index_and_records_saves():
     a, b = FakeWorkerSub(is_producer=True), FakeWorkerSub()
     w = _worker([a, b])
-    m0 = ConnectorMetadata()               # moriio sub-meta (no .requests)
-    m1 = _save_meta(101, 102)              # offload sub-meta with two saves
+    m0 = ConnectorMetadata()  # moriio sub-meta (no .requests)
+    m1 = _save_meta(101, 102)  # offload sub-meta with two saves
     w.start_load_kv(MultiConnectorMetadata([m0, m1]))
     assert a.loaded_meta is m0
     assert b.loaded_meta is m1
@@ -251,11 +258,11 @@ def test_start_load_kv_routes_by_index_and_records_saves():
 
 def test_get_finished_unions_and_normalizes_tuple():
     # moriio returns a legacy tuple; offload returns KVConnectorOutput.
-    moriio = FakeWorkerSub(finished=(set(), {"d1"}))          # recving d1
+    moriio = FakeWorkerSub(finished=(set(), {"d1"}))  # recving d1
     off = FakeWorkerSub(
         finished=KVConnectorOutput(finished_recving={"d2"}, failed_recving={"f1"})
     )
-    w = _worker([moriio, off])              # not producer
+    w = _worker([moriio, off])  # not producer
     out = w.get_finished()
     assert out.finished_recving == {"d1", "d2"}
     assert out.failed_recving == {"f1"}
@@ -268,7 +275,7 @@ def test_recv_blocks_concat():
 
 def test_non_producer_passes_saving_through():
     off = FakeWorkerSub(finished=KVConnectorOutput(finished_saving={"s1"}))
-    w = _worker([off])                      # is_producer False
+    w = _worker([off])  # is_producer False
     out = w.get_finished()
     assert out.finished_saving == {"s1"}
 
@@ -294,7 +301,7 @@ def test_send_is_withheld_until_save_completes():
     moriio._finished = ({9}, set())
     off._finished = KVConnectorOutput()
     out1 = w.get_finished()
-    assert out1.finished_sending == set()        # withheld
+    assert out1.finished_sending == set()  # withheld
     assert out1.finished_saving == set()
 
     # Step 2: offload reports save done -> both released together.
@@ -303,7 +310,7 @@ def test_send_is_withheld_until_save_completes():
     out2 = w.get_finished()
     assert out2.finished_sending == {9}
     assert out2.finished_saving == {9}
-    assert w._pending_save == set()              # cleared after release
+    assert w._pending_save == set()  # cleared after release
 
 
 def test_save_then_send_also_pairs():

--- a/tests/test_multi_connector.py
+++ b/tests/test_multi_connector.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the composite ``multi`` KV connector.
+
+Pure-Python: sub-connectors are mocked, so no GPU / lmcache / moriio runtime is
+needed. Covers the merge strategy (first-hit-wins, fan-out, metadata routing,
+completion union) and the send/save pairing that protects a producer node's
+blocks from being freed while a transfer is still reading them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from atom.kv_transfer.disaggregation.types import ConnectorMetadata, KVConnectorOutput
+from atom.kv_transfer.disaggregation.multi.multi_connector import (
+    MultiConnector,
+    MultiConnectorMetadata,
+    MultiConnectorScheduler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock sub-connectors
+# ---------------------------------------------------------------------------
+
+
+class FakeSchedSub:
+    """Scheduler-side sub-connector mock."""
+
+    def __init__(self, *, match=(0, False), is_producer=False, is_offload=False,
+                 offload_methods=False):
+        self._match = match
+        self.is_producer = is_producer
+        if is_offload:
+            self.is_offload = True
+        self.alloc_calls = []
+        self.finished_calls = []
+        self.meta = ConnectorMetadata()
+        self._offload = offload_methods
+
+        if offload_methods:
+            self.park = False
+            self.partial_park = False
+            self.defer = False
+            self.chunk_ret = None
+            self.saved = []
+            self.load_failed_ids = []
+
+    def get_num_new_matched_tokens(self, seq):
+        return self._match
+
+    def build_connector_meta(self):
+        return self.meta
+
+    def update_state_after_alloc(self, seq):
+        self.alloc_calls.append(seq)
+
+    def request_finished(self, seq):
+        self.finished_calls.append(seq)
+
+    # offload-specific (only present when offload_methods=True)
+    def should_park_for_load_after_alloc(self, seq):
+        return self.park
+
+    def adjust_prefill_chunk_after_alloc(self, seq, chunk):
+        return self.chunk_ret if self.chunk_ret is not None else chunk
+
+    def should_park_partial_prefill_for_load(self, seq):
+        return self.partial_park
+
+    def should_defer_free(self, seq):
+        return self.defer
+
+    def save_finished(self, req_id):
+        self.saved.append(req_id)
+
+    def load_failed(self, req_id):
+        self.load_failed_ids.append(req_id)
+
+    def __getattribute__(self, name):
+        # Hide offload-specific methods unless this mock opts in, so
+        # MultiConnector's hasattr() guards are exercised realistically.
+        offload_api = {
+            "should_park_for_load_after_alloc",
+            "adjust_prefill_chunk_after_alloc",
+            "should_park_partial_prefill_for_load",
+            "should_defer_free",
+            "save_finished",
+            "load_failed",
+        }
+        if name in offload_api and not object.__getattribute__(self, "_offload"):
+            raise AttributeError(name)
+        return object.__getattribute__(self, name)
+
+
+class FakeWorkerSub:
+    """Worker-side sub-connector mock."""
+
+    def __init__(self, *, is_producer=False, finished=None, recv_blocks=None):
+        self.is_producer = is_producer
+        self._finished = finished if finished is not None else KVConnectorOutput()
+        self._recv_blocks = recv_blocks or []
+        self.registered = None
+        self.loaded_meta = None
+
+    def register_kv_caches(self, kv_caches, transfer_tensors=None, num_blocks=None):
+        self.registered = (kv_caches, transfer_tensors, num_blocks)
+
+    def start_load_kv(self, metadata):
+        self.loaded_meta = metadata
+
+    def get_finished(self):
+        return self._finished
+
+    def get_finished_recv_blocks(self):
+        return self._recv_blocks
+
+
+def _sched(connectors):
+    obj = MultiConnectorScheduler.__new__(MultiConnectorScheduler)
+    obj._connectors = connectors
+    obj.is_producer = any(getattr(c, "is_producer", False) for c in connectors)
+    obj.is_offload = any(getattr(c, "is_offload", False) for c in connectors)
+    return obj
+
+
+def _worker(connectors):
+    obj = MultiConnector.__new__(MultiConnector)
+    obj._connectors = connectors
+    obj.is_producer = any(getattr(c, "is_producer", False) for c in connectors)
+    obj._pending_save = set()
+    obj._sent = {}
+    obj._saved = {}
+    return obj
+
+
+def _save_meta(*req_ids):
+    """An offload-style metadata: .requests with save_spec set."""
+    meta = ConnectorMetadata()
+    meta.requests = [
+        SimpleNamespace(req_id=r, save_spec=object(), load_spec=None) for r in req_ids
+    ]
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Scheduler-side
+# ---------------------------------------------------------------------------
+
+
+def test_matched_tokens_first_hit_wins():
+    a = FakeSchedSub(match=(0, False))
+    b = FakeSchedSub(match=(5, True))
+    sched = _sched([a, b])
+    assert sched.get_num_new_matched_tokens(object()) == (5, True)
+
+
+def test_matched_tokens_earlier_connector_wins_over_later():
+    a = FakeSchedSub(match=(3, True))
+    b = FakeSchedSub(match=(5, True))
+    sched = _sched([a, b])
+    assert sched.get_num_new_matched_tokens(object()) == (3, True)
+
+
+def test_no_match_returns_zero():
+    sched = _sched([FakeSchedSub(), FakeSchedSub()])
+    assert sched.get_num_new_matched_tokens(object()) == (0, False)
+
+
+def test_update_and_finished_fan_out_to_all():
+    a, b = FakeSchedSub(), FakeSchedSub()
+    sched = _sched([a, b])
+    seq = object()
+    sched.update_state_after_alloc(seq)
+    sched.request_finished(seq)
+    assert a.alloc_calls == [seq] and b.alloc_calls == [seq]
+    assert a.finished_calls == [seq] and b.finished_calls == [seq]
+
+
+def test_build_connector_meta_wraps_subs_in_order():
+    a, b = FakeSchedSub(), FakeSchedSub()
+    sched = _sched([a, b])
+    meta = sched.build_connector_meta()
+    assert isinstance(meta, MultiConnectorMetadata)
+    assert meta.metas == [a.meta, b.meta]
+
+
+def test_role_attrs_aggregate():
+    sched = _sched([
+        FakeSchedSub(is_producer=True),
+        FakeSchedSub(is_offload=True, offload_methods=True),
+    ])
+    assert sched.is_producer is True
+    assert sched.is_offload is True
+
+
+def test_offload_methods_forwarded_to_owning_sub():
+    moriio = FakeSchedSub(is_producer=True)            # no offload methods
+    off = FakeSchedSub(is_offload=True, offload_methods=True)
+    off.park = True
+    off.partial_park = True
+    off.defer = True
+    off.chunk_ret = 7
+    sched = _sched([moriio, off])
+    seq = object()
+    assert sched.should_park_for_load_after_alloc(seq) is True
+    assert sched.should_park_partial_prefill_for_load(seq) is True
+    assert sched.should_defer_free(seq) is True
+    assert sched.adjust_prefill_chunk_after_alloc(seq, 10) == 7
+    sched.save_finished("r1")
+    sched.load_failed("r2")
+    assert off.saved == ["r1"]
+    assert off.load_failed_ids == ["r2"]
+
+
+def test_offload_methods_default_when_no_sub_implements():
+    sched = _sched([FakeSchedSub(is_producer=True), FakeSchedSub()])
+    seq = object()
+    assert sched.should_park_for_load_after_alloc(seq) is False
+    assert sched.should_park_partial_prefill_for_load(seq) is False
+    assert sched.should_defer_free(seq) is False
+    assert sched.adjust_prefill_chunk_after_alloc(seq, 10) == 10  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Worker-side
+# ---------------------------------------------------------------------------
+
+
+def test_register_kv_caches_fans_out():
+    a, b = FakeWorkerSub(), FakeWorkerSub()
+    w = _worker([a, b])
+    kv = {"layer_0": object()}
+    w.register_kv_caches(kv, transfer_tensors="tt", num_blocks=42)
+    assert a.registered == (kv, "tt", 42)
+    assert b.registered == (kv, "tt", 42)
+
+
+def test_start_load_kv_routes_by_index_and_records_saves():
+    a, b = FakeWorkerSub(is_producer=True), FakeWorkerSub()
+    w = _worker([a, b])
+    m0 = ConnectorMetadata()               # moriio sub-meta (no .requests)
+    m1 = _save_meta(101, 102)              # offload sub-meta with two saves
+    w.start_load_kv(MultiConnectorMetadata([m0, m1]))
+    assert a.loaded_meta is m0
+    assert b.loaded_meta is m1
+    assert w._pending_save == {"101", "102"}
+
+
+def test_get_finished_unions_and_normalizes_tuple():
+    # moriio returns a legacy tuple; offload returns KVConnectorOutput.
+    moriio = FakeWorkerSub(finished=(set(), {"d1"}))          # recving d1
+    off = FakeWorkerSub(
+        finished=KVConnectorOutput(finished_recving={"d2"}, failed_recving={"f1"})
+    )
+    w = _worker([moriio, off])              # not producer
+    out = w.get_finished()
+    assert out.finished_recving == {"d1", "d2"}
+    assert out.failed_recving == {"f1"}
+
+
+def test_recv_blocks_concat():
+    w = _worker([FakeWorkerSub(recv_blocks=[1, 2]), FakeWorkerSub(recv_blocks=[3])])
+    assert w.get_finished_recv_blocks() == [1, 2, 3]
+
+
+def test_non_producer_passes_saving_through():
+    off = FakeWorkerSub(finished=KVConnectorOutput(finished_saving={"s1"}))
+    w = _worker([off])                      # is_producer False
+    out = w.get_finished()
+    assert out.finished_saving == {"s1"}
+
+
+def test_send_without_pending_save_is_released_immediately():
+    moriio = FakeWorkerSub(is_producer=True, finished=({"r1"}, set()))
+    w = _worker([moriio])
+    out = w.get_finished()
+    assert out.finished_sending == {"r1"}
+
+
+def test_send_is_withheld_until_save_completes():
+    # One producer (moriio) + one offload sub, sharing req "r9".
+    moriio = FakeWorkerSub(is_producer=True)
+    off = FakeWorkerSub()
+    w = _worker([moriio, off])
+
+    # offload will save r9
+    w.start_load_kv(MultiConnectorMetadata([ConnectorMetadata(), _save_meta(9)]))
+    assert w._pending_save == {"9"}
+
+    # Step 1: moriio reports send done, offload's save still in flight.
+    moriio._finished = ({9}, set())
+    off._finished = KVConnectorOutput()
+    out1 = w.get_finished()
+    assert out1.finished_sending == set()        # withheld
+    assert out1.finished_saving == set()
+
+    # Step 2: offload reports save done -> both released together.
+    moriio._finished = (set(), set())
+    off._finished = KVConnectorOutput(finished_saving={9})
+    out2 = w.get_finished()
+    assert out2.finished_sending == {9}
+    assert out2.finished_saving == {9}
+    assert w._pending_save == set()              # cleared after release
+
+
+def test_save_then_send_also_pairs():
+    moriio = FakeWorkerSub(is_producer=True)
+    off = FakeWorkerSub()
+    w = _worker([moriio, off])
+    w.start_load_kv(MultiConnectorMetadata([ConnectorMetadata(), _save_meta(9)]))
+
+    # Step 1: save completes first, send not yet -> nothing released.
+    off._finished = KVConnectorOutput(finished_saving={9})
+    out1 = w.get_finished()
+    assert out1.finished_sending == set()
+    assert out1.finished_saving == set()
+
+    # Step 2: send completes -> both released.
+    off._finished = KVConnectorOutput()
+    moriio._finished = ({9}, set())
+    out2 = w.get_finished()
+    assert out2.finished_sending == {9}
+    assert out2.finished_saving == {9}


### PR DESCRIPTION
## Summary

Adds a **MultiConnector** so a single ATOM engine can run a P/D-disaggregation connector (moriio / mooncake) **and** the LMCache CPU/NVMe offload connector **at the same time**. The canonical use case is a prefill node that both (a) RDMA/TCP-sends KV to a remote decode node and (b) offloads the same KV to CPU so a future request sharing the prefix can skip recompute.

> Note on scope: this branch builds on the LMCache offload subsystem; the diff therefore includes that stack. The new piece in this PR is `multi/multi_connector.py` (+ factory registration + unit tests).

## What's added

- `atom/kv_transfer/disaggregation/multi/multi_connector.py` — `MultiConnector` (worker), `MultiConnectorScheduler` (scheduler), `MultiConnectorMetadata`
- `atom/kv_transfer/disaggregation/factory.py` — registers `kv_connector: "multi"`
- `tests/test_multi_connector.py` — pure-mock unit tests (no GPU / lmcache / moriio), **16/16 passing**

## Connector vs engine (where this sits)

The engine computes tokens and **owns** the KV in HBM; a connector only **moves** KV bytes (to a remote decode node, or to CPU/NVMe) and never computes. They are decoupled by a narrow set of hooks in `base.py`.

```
                        +------------------+
                        |    API Server    |
                        +------------------+
                                 |
                                 v
+=================================================+
| INFERENCE ENGINE - computes tokens, owns KV     |
| EngineCore -> Scheduler -> ModelRunner (GPU)    |
| BlockManager -> [ HBM KV Cache = real KV bytes ]|
+=================================================+
                 ^               |
                 |   hooks (engine calls connector)
                 |               v
+=================================================+
| KV CONNECTOR - moves KV bytes, no compute       |
| KVConnectorBase (7 hooks) -> pick ONE:          |
| moriio | mooncake | lmcache_offload | multi     |
+=================================================+
            |                          |
            v                          v
     +-------------+            +-------------+
     | Decode node |            |  CPU / NVMe |
     +-------------+            +-------------+
       (P/D xfer)                (LMCache)
```

The connector is split across two processes/layers — a scheduler-side object (no GPU) and a worker-side object (holds HBM KV pointers); `meta` flows down, `KVConnectorOutput` flows up:

```
SCHEDULER LAYER (main, no GPU)        | hook                      -> policy in MultiConnector
  Scheduler + scheduler-side conn     | get_num_new_matched_tokens-> first-hit-wins (one sub owns it)
                                      | update_state_after_alloc  -> fan-out to ALL subs
                                      | build_connector_meta      -> pack -> MultiConnectorMetadata
                                      | request_finished          -> fan-out to ALL subs
        | build_connector_meta() => MultiConnectorMetadata(metas=[meta_sub0, meta_sub1])
        v  (IPC down: scheduler -> workers)
WORKER LAYER (GPU TP-worker, per rank)| register_kv_caches        -> fan-out to ALL subs
  ModelRunner + worker-side conn      | start_load_kv(meta)       -> route metas[i] -> subs[i]
  (holds HBM KV)                      | get_finished()            -> UNION + send/save gating
        ^  (IPC up: workers -> scheduler, merged across TP by KVOutputAggregator)
```

## Merge strategy (mirrors vLLM's MultiConnector, adapted to ATOM `base.py`)

- **`get_num_new_matched_tokens`** — first-hit-wins by `connectors` list order (the first sub reporting a match owns the load).
- **`update_state_after_alloc` / `request_finished`** — fan out to all subs.
- **`build_connector_meta`** — produces `MultiConnectorMetadata(metas=[...])`; the worker de-multiplexes by index in `start_load_kv` (each sub only sees its own metadata).
- **`get_finished`** — unions the four completion sets across subs.
- **offload-specific scheduler methods** (`should_park_*`, `adjust_prefill_chunk_after_alloc`, `should_defer_free`, `save_finished`, `load_failed`) are forwarded to the owning sub. The scheduler already guards each call with `hasattr`, so **the engine is unchanged**.

## Block-free correctness: send ∧ save gating

On a producer node, prefilled KV blocks must survive until **both** the P/D send **and** the offload save have read them. The scheduler frees a deferred block on `finished_sending` (and may free on `finished_saving` when not deferred) — so if one transfer finishes first, the block could be freed while the other is still reading it.

MultiConnector solves this at the connector layer (engine untouched): when a request needs both a send and a save, it **withholds both completion signals until the pair is done, then emits them in the same step**. Within one `_update_from_kv_xfer_finished`, the `finished_sending` loop runs first (pops + frees), and the `finished_saving` loop then finds nothing to free (no-op). Both arrival orders (send-first / save-first) are covered, and it holds across TP ranks (each rank gates; `KVOutputAggregator` reaches quorum on both sets in the same cycle). Unit-tested in both orders.

## Usage

Prefill node (decode node stays a plain mooncake/moriio consumer):

```bash
--kv-transfer-config '{
  "kv_connector": "multi",
  "connectors": [
    {"kv_connector": "mooncake", "kv_role": "kv_producer", "protocol": "tcp",
     "proxy_ip": "127.0.0.1", "proxy_ping_port": 36367, "http_port": 8000, "handshake_port": 6700},
    {"kv_connector": "lmcache_offload", "kv_role": "offload"}
  ]
}'
```

## Test plan

- [x] `pytest tests/test_multi_connector.py` — 16/16 (first-hit-wins, fan-out, metadata routing, get_finished union, send∧save gating in both orders, attribute aggregation). Pure mock, no GPU.
- [x] End-to-end on MI325X (Llama-3.1-8B, mooncake `protocol=tcp`): proxy + producer `multi[mooncake-producer + lmcache_offload]` + plain mooncake consumer.
  - P/D transfer through MultiConnector: `do_remote_prefill=true`, producer `All 1 consumers served`.
  - offload save through MultiConnector on the producer: `LMCache ... Stored 2304 tokens` for a 2509-token prompt, **concurrent with** the P/D send, 0 errors / 0 asserts.
  - HBM-hit second request: send proceeds, offload reload correctly skipped (HBM satisfies), no redundant re-store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
