### PR TITLE
[Enhancement] Supports per_block_fp8 format for online quantization

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -597,6 +597,7 @@ class LinearBase(nn.Module):
 
         assert online_quant_dtype in [
             torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
             torch.float4_e2m1fn_x2,
         ], (
             f"Unsupported online quant: "
@@ -678,6 +679,7 @@ class LinearBase(nn.Module):
         self.quant_func = get_hip_quant(online_quant_type)
         self.need_normalize_e4m3fn_to_e4m3fnuz = (
             online_quant_dtype == torch.float8_e4m3fnuz
+            and q_weight.dtype != torch.float8_e4m3fnuz
         )
         # A dynamic online target (e.g. ptpc per_Token) quantizes activations at
         # runtime. Drop any static input_scale inherited from a static per_Tensor

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2882,12 +2882,16 @@ class FusedMoE(torch.nn.Module):
                 load_full=load_full,
             )
         else:
-            # The Aiter FP4 quantization function returns a value of type FP4*2
+            # mxfp4 (per_1x32) returns a byte-encoded FP4x2 / e8m0 scale that
+            # must be byte-viewed before loading. Other schemes (e.g. per_1x128
+            # 128x128 block FP8) carry a float32 scale that is copied as-is.
+            if quant_type == QuantType.per_1x32:
+                loaded_weight = loaded_weight.view(torch.uint8)
             self._load_model_weight_or_group_weight_scale(
                 shard_dim=shard_dim,
                 expert_data=expert_data,
                 shard_id=shard_id,
-                loaded_weight=loaded_weight.view(torch.uint8),
+                loaded_weight=loaded_weight,
                 tp_rank=tp_rank,
                 load_full=load_full,
             )

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -212,39 +212,31 @@ class QuarkOnlineParser(QuantConfigParser):
         and ``online_exclude_layers_list``.
 
         Supported format strings:
-        - ``"ptpc_fp8"``  — per-tensor-per-channel FP8
-        - ``"mxfp4"``     — microscaling FP4 (block size 32)
+        - ``"ptpc_fp8"``        — per-tensor-per-channel FP8
+        - ``"per_block_fp8"``   — per-block FP8 (128x128; alias of per_block128_fp8)
+        - ``"per_block128_fp8"``— per-block FP8, 128x128 block
+        - ``"mxfp4"``           — microscaling FP4 (block size 32)
         """
         if not isinstance(online_quant_config, dict):
             raise TypeError("online_quant_config must be a dict parsed from JSON.")
 
-        scheme_map = {
-            "ptpc": QuantType.per_Token,
-            "per_block": QuantType.per_1x128,
+        # Explicit table of supported online quant formats -> (QuantType, dtype_str).
+        # per_block / per_block128 are aliases (128 is the default block size).
+        FORMAT_MAP = {
+            "ptpc_fp8": (QuantType.per_Token, "fp8"),
+            "per_block_fp8": (QuantType.per_1x128, "fp8"),
+            "per_block128_fp8": (QuantType.per_1x128, "fp8"),
+            "mxfp4": (QuantType.per_1x32, "fp4"),
         }
 
         def _parse_online_quant_format(quant_format_str: str) -> LayerQuantConfig:
             quant_format_str = quant_format_str.strip().lower()
-            quant_type = None
-            dtype_str = None
-
-            if quant_format_str.startswith("mx"):
-                quant_type = QuantType.per_1x32
-                dtype_str = quant_format_str[2:]
-            else:
-                matched_scheme = None
-                for scheme in sorted(scheme_map, key=len, reverse=True):
-                    if quant_format_str.startswith(scheme + "_"):
-                        matched_scheme = scheme
-                        break
-                if matched_scheme is not None:
-                    quant_type = scheme_map[matched_scheme]
-                    dtype_str = quant_format_str[len(matched_scheme) + 1 :]
-                else:
-                    raise ValueError(
-                        f"Unsupported online quant format: '{quant_format_str}'. "
-                        f"Expected '<scheme>_<dtype>' (e.g. ptpc_fp8) or 'mx<dtype>' (e.g. mxfp4)."
-                    )
+            if quant_format_str not in FORMAT_MAP:
+                raise ValueError(
+                    f"Unsupported online quant format: '{quant_format_str}'. "
+                    f"Expected one of: {sorted(FORMAT_MAP)}."
+                )
+            quant_type, dtype_str = FORMAT_MAP[quant_format_str]
 
             dtype_str = dtype_str.split("_")[0]
             if dtype_str.endswith("4"):

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -218,8 +218,9 @@ class QuarkOnlineParser(QuantConfigParser):
         if not isinstance(online_quant_config, dict):
             raise TypeError("online_quant_config must be a dict parsed from JSON.")
 
-        SCHEME_MAP = {
+        scheme_map = {
             "ptpc": QuantType.per_Token,
+            "per_block": QuantType.per_1x128,
         }
 
         def _parse_online_quant_format(quant_format_str: str) -> LayerQuantConfig:
@@ -231,10 +232,14 @@ class QuarkOnlineParser(QuantConfigParser):
                 quant_type = QuantType.per_1x32
                 dtype_str = quant_format_str[2:]
             else:
-                parts = quant_format_str.split("_", 1)
-                if len(parts) == 2 and parts[0] in SCHEME_MAP:
-                    quant_type = SCHEME_MAP[parts[0]]
-                    dtype_str = parts[1]
+                matched_scheme = None
+                for scheme in sorted(scheme_map, key=len, reverse=True):
+                    if quant_format_str.startswith(scheme + "_"):
+                        matched_scheme = scheme
+                        break
+                if matched_scheme is not None:
+                    quant_type = scheme_map[matched_scheme]
+                    dtype_str = quant_format_str[len(matched_scheme) + 1 :]
                 else:
                     raise ValueError(
                         f"Unsupported online quant format: '{quant_format_str}'. "

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -166,21 +166,64 @@ def quant_mxfp4_online_even(
     return q_weight.view(dtypes.fp4x2), weight_scale.view(_mx_block_scale_dtype())
 
 
+def quantize_weight_to_fp8_128x128_blockscale(weight, quant_dtype):
+    """Quantize a 2D weight to FP8 with 128x128 block scales.
+
+    Returns:
+        q_weight: quantized weight with the same shape as input ``weight``.
+        scale: per-block scale with shape ``(ceil(N/128), ceil(K/128))``.
+    """
+    assert weight.dim() == 2, f"expected 2D weight, got shape={tuple(weight.shape)}"
+
+    w = weight.to(torch.float32).contiguous()
+    n, k = w.shape
+    n_blocks = (n + 127) // 128
+    k_blocks = (k + 127) // 128
+    n_padded = n_blocks * 128
+    k_padded = k_blocks * 128
+
+    if n_padded != n or k_padded != k:
+        w = torch.nn.functional.pad(w, (0, k_padded - k, 0, n_padded - n))
+
+    w_blocks = w.view(n_blocks, 128, k_blocks, 128).permute(0, 2, 1, 3).contiguous()
+
+    finfo = torch.finfo(quant_dtype)
+    block_amax = w_blocks.abs().amax(dim=(2, 3))
+    scale = (block_amax / finfo.max).clamp_min(torch.finfo(torch.float32).tiny)
+
+    q_blocks = torch.clamp(
+        w_blocks / scale.unsqueeze(-1).unsqueeze(-1), min=finfo.min, max=finfo.max
+    ).to(quant_dtype)
+
+    q_weight = (
+        q_blocks.permute(0, 2, 1, 3)
+        .contiguous()
+        .view(n_padded, k_padded)[:n, :k]
+        .contiguous()
+    )
+    return q_weight, scale.contiguous()
+
+
 def quant_weight_online(
     weight: torch.Tensor,
     online_quant_type: QuantType,
     online_quant_dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Dispatch online weight quantization by target dtype.
+    """Dispatch online weight quantization by target dtype / scheme.
 
     Single entry point shared by the Linear and MoE online-quant paths so both
     stay in sync:
 
     - MXFP4 (``dtypes.fp4x2``): use the aiter HIP kernel with ``Even`` round
       mode (:func:`quant_mxfp4_online_even`), matching the offline Quark kernel.
+    - per_1x128 FP8: use :func:`quantize_weight_to_fp8_128x128_blockscale` to
+      produce a true 128x128 block scale of shape ``(N//128, K//128)``. This is
+      what the blockscale GEMM consumes; ``get_hip_quant(per_1x128)`` would
+      instead produce a 1x128-along-K scale ``(N, K//128)`` that is inconsistent
+      with the GEMM and collapses generation.
     - MXFP8 (``per_1x32`` + ``dtypes.fp8``): fp8 weights with a per-32 block
       scale. See the e8m0 note below for why ``scale_type`` must be forced.
-    - FP8 (incl. ptpc_fp8 per-token / per-channel): use the aiter quant
+    - other FP8 (incl. ptpc_fp8 per-token / per-channel): use the aiter quant
       function resolved from ``get_hip_quant(online_quant_type)``.
 
     :param weight: The (already dequantized) weight tensor to quantize.
@@ -193,6 +236,8 @@ def quant_weight_online(
 
     if online_quant_dtype == dtypes.fp4x2:
         return quant_mxfp4_online_even(weight)
+    if online_quant_type == QuantType.per_1x128:
+        return quantize_weight_to_fp8_128x128_blockscale(weight, online_quant_dtype)
     quant_func = get_hip_quant(online_quant_type)
     # A per_1x32 scheme *is* MX (microscaling): its block scale is E8M0 by
     # definition of the format, independent of the element dtype. So the scale

--- a/atom/rollout/weight_updater.py
+++ b/atom/rollout/weight_updater.py
@@ -231,26 +231,20 @@ class WeightUpdaterMixin:
         quant_type = getattr(module, "quant_type", None)
 
         if quant_type is not None and quant_type.value == _QT.per_1x128.value:
-            N, K = tensor_gpu.shape
-            block_k = 128
-            K_blocks = (K + block_k - 1) // block_k
-            if K % block_k != 0:
-                padded = torch.zeros(
-                    N, K_blocks * block_k, dtype=torch.float32, device=self.device
-                )
-                padded[:, :K] = tensor_gpu
-            else:
-                padded = tensor_gpu
-            blocks = padded.reshape(N, K_blocks, block_k)
-            block_amax = blocks.abs().amax(dim=-1)
-            scale = (block_amax / fp8_max).clamp(min=1e-12)
-            quantized = (blocks / scale.unsqueeze(-1)).to(fp8_dtype)
-            quantized = quantized.reshape(N, K_blocks * block_k)[:, :K].contiguous()
-            param.data.copy_(quantized)
-            ws = weight_scale.data
-            weight_scale.data.copy_(
-                scale[: ws.shape[0], : ws.shape[1]].contiguous().to(ws.dtype)
+            # Must match the load-time online_quantize_weight layout: a true
+            # 128x128 block scale of shape (N//128, K//128). The previous code
+            # produced a 1x128-along-K scale (N, K//128) and sliced it into the
+            # (N//128, K//128) buffer, which is inconsistent with the blockscale
+            # GEMM and collapses generation after the first weight update.
+            from atom.quantization.quark.utils import (
+                quantize_weight_to_fp8_128x128_blockscale,
             )
+
+            q_weight, scale = quantize_weight_to_fp8_128x128_blockscale(
+                tensor_gpu, fp8_dtype
+            )
+            param.data.copy_(q_weight)
+            weight_scale.data.copy_(scale.to(weight_scale.dtype))
 
         elif quant_type is not None and quant_type.value == _QT.per_Tensor.value:
             amax = tensor_gpu.abs().max()

--- a/docs/online_quantization_guide.md
+++ b/docs/online_quantization_guide.md
@@ -69,14 +69,21 @@ Resolution order for a given layer name:
 
 ### 2.1 Target formats
 
-Only two target formats are currently supported. Any other string (for example
-`ptpc_i8`, `mxi4`, `mxfp8`) will either be rejected by the JSON parser or
-trigger an assertion in the loader when the layer's weight is quantized.
+The target formats below are currently supported. Any other string (for example
+`ptpc_i8`, `mxi4`, `mxfp8`) will be rejected by the JSON parser or trigger an
+assertion in the loader when the layer's weight is quantized.
 
 | Format string | Underlying `QuantType` | Weight dtype |
 |---|---|---|
 | `ptpc_fp8` | `QuantType.per_Token` | `torch.float8_e4m3fn` |
+| `per_block_fp8` | `QuantType.per_1x128` | `torch.float8_e4m3fn` (128×128 block scale) |
+| `per_block128_fp8` | `QuantType.per_1x128` | alias of `per_block_fp8` (explicit 128 block) |
 | `mxfp4` | `QuantType.per_1x32` | packed FP4 (`torch.float4_e2m1fn_x2`, group size 32) |
+
+`per_block_fp8` is DeepSeek-style block FP8: the weight uses a 128×128 block
+scale of shape `(N//128, K//128)` and the activation uses a 1×128 (along K)
+scale, consumed by the block-scale GEMM. `per_block_fp8` and `per_block128_fp8`
+are equivalent (128 is the default block size).
 
 ### 2.2 Picking the right pattern
 
@@ -175,9 +182,26 @@ python -m atom.entrypoints.openai_server \
 quantization — it can be added to any of the recipes above without changing
 the `--online_quant_config` JSON.
 
----
+### 3.5 Qwen3-30B-A3B-Thinking-2507 — full per-block FP8
 
-## 3.5 Plugin mode (`vllm serve`)
+BF16 source → every Linear and the fused expert module quantized to
+`per_block_fp8` (DeepSeek-style 128×128 block scale).
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model Qwen/Qwen3-30B-A3B-Thinking-2507 \
+  -tp 2 \
+  --online_quant_config '{
+    "global_quant_config": "per_block_fp8",
+    "exclude_layer": ["lm_head", "*.gate.*"]
+  }'
+```
+
+`per_block_fp8` is the same block-FP8 format DeepSeek-V3/R1 ships natively, so
+it is a good drop-in when you want FP8 accuracy closer to the block-scaled
+checkpoint than per-token `ptpc_fp8`.
+
+### 3.6 Plugin mode (`vllm serve`)
 
 In the [vLLM out-of-tree plugin backend](vllm_plugin_backend_guide.md) you launch
 with `vllm serve`, whose CLI does not understand ATOM's `--online_quant_config`
@@ -253,6 +277,7 @@ Things to check:
   | Format string | `quant_type` | `quant_dtype` |
   |---|---|---|
   | `ptpc_fp8` | `per_Token` | `torch.float8_e4m3fn` |
+  | `per_block_fp8` / `per_block128_fp8` | `per_1x128` | `torch.float8_e4m3fn` |
   | `mxfp4` | `per_1x32` | `torch.uint8` (packed FP4x2) |
 
 - `elapsed_seconds` indicates the post-loading processing time on rank 0. A


### PR DESCRIPTION
1. For the `weight` layer, perform per_block_fp8 quantization by grouping according to a 128×128 shape; the input must be quantized to 1×128.
In offline mode, `atom` sets the `quant_type` of layers quantized to `per_128×128` to `per_1×128`; online quantization follows this approach.

2.
```
python -m atom.entrypoints.openai_server \
  --model /shareddata/deepseek-ai/DeepSeek-R1-0528 \
  -tp 4 \
  --server-port 01346 \
  --online_quant_config '{"global_quant_config":"per_block_fp8","exclude_layer":["lm_head","*.gate.*"]}'

lm_eval --model local-completions \
  --model_args "model=/shareddata/deepseek-ai/DeepSeek-R1-0528,base_url=http://localhost:01346/v1/completions,num_concurrent=65,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
  --tasks gsm8k \
  --num_fewshot 3

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.6907|±  |0.0127|
|     |       |strict-match    |     3|exact_match|↑  |0.7331|±  |0.0122|