### PR TITLE
fix(rtpllm): adapt to RTP-LLM PyAttentionInputs host/device field rename

### DIFF
--- a/atom/plugin/rtpllm/utils/forward_context.py
+++ b/atom/plugin/rtpllm/utils/forward_context.py
@@ -151,7 +151,7 @@ class RTPForwardContext:
             device=device,
         )
         cu_seqlens = RTPForwardContext._non_empty_int32(
-            getattr(attn_inputs, "cu_seqlens", None),
+            getattr(attn_inputs, "cu_seqlens_device", None),
             device=device,
         )
         if cu_seqlens is not None and cu_seqlens.numel() > 1:
@@ -183,7 +183,7 @@ class RTPForwardContext:
         # Decode: query length is runtime step token count (usually 1 per sequence),
         # not prompt input_lengths.
         sequence_lengths_plus_1 = RTPForwardContext._non_empty_int32(
-            getattr(attn_inputs, "sequence_lengths_plus_1_d", None),
+            getattr(attn_inputs, "sequence_lengths_plus_1_device", None),
             device=device,
         )
         sequence_lengths = RTPForwardContext._non_empty_int32(
@@ -262,7 +262,7 @@ class RTPForwardContext:
 
         if is_prefill:
             prefix_lengths = RTPForwardContext._non_empty_int32(
-                getattr(attn_inputs, "prefix_lengths_d", None),
+                getattr(attn_inputs, "prefix_lengths_device", None),
                 device=device,
             )
             if prefix_lengths is None:
@@ -283,7 +283,7 @@ class RTPForwardContext:
         else:
             # RTP decode kernels use sequence_lengths_plus_1_d as canonical runtime value.
             sequence_lengths_plus_1 = RTPForwardContext._non_empty_int32(
-                getattr(attn_inputs, "sequence_lengths_plus_1_d", None),
+                getattr(attn_inputs, "sequence_lengths_plus_1_device", None),
                 device=device,
             )
             if sequence_lengths_plus_1 is not None:
@@ -621,7 +621,7 @@ class RTPForwardContext:
             # For chunked prefill, prefix_lengths can remain per-chunk while
             # sequence_lengths_plus_1_d tracks the true cumulative context length.
             sequence_lengths_plus_1 = RTPForwardContext._non_empty_int32(
-                getattr(attn_inputs, "sequence_lengths_plus_1_d", None),
+                getattr(attn_inputs, "sequence_lengths_plus_1_device", None),
                 device=device,
             )
             if sequence_lengths_plus_1 is not None:
@@ -633,7 +633,7 @@ class RTPForwardContext:
                     )
                 return sequence_lengths_plus_1.contiguous()
             prefix_lengths = RTPForwardContext._non_empty_int32(
-                getattr(attn_inputs, "prefix_lengths_d", None),
+                getattr(attn_inputs, "prefix_lengths_device", None),
                 device=device,
             )
             if prefix_lengths is None:
@@ -654,7 +654,7 @@ class RTPForwardContext:
             return (prefix_lengths + input_lengths).contiguous()
 
         sequence_lengths_plus_1 = RTPForwardContext._non_empty_int32(
-            getattr(attn_inputs, "sequence_lengths_plus_1_d", None),
+            getattr(attn_inputs, "sequence_lengths_plus_1_device", None),
             device=device,
         )
         if sequence_lengths_plus_1 is not None:
@@ -1871,7 +1871,7 @@ class RTPForwardQwen35HybridContext(RTPForwardContext):
         is_prefill = bool(getattr(attn_inputs, "is_prefill", False))
         if is_prefill:
             prefix_lengths = RTPForwardContext._non_empty_int32(
-                getattr(attn_inputs, "prefix_lengths_d", None),
+                getattr(attn_inputs, "prefix_lengths_device", None),
                 device=device,
             )
             if prefix_lengths is None:
@@ -1896,7 +1896,7 @@ class RTPForwardQwen35HybridContext(RTPForwardContext):
         )
         if non_cuda_graph_mode:
             sequence_lengths_plus_1 = RTPForwardContext._non_empty_int32(
-                getattr(attn_inputs, "sequence_lengths_plus_1_d", None),
+                getattr(attn_inputs, "sequence_lengths_plus_1_device", None),
                 device=device,
             )
             if sequence_lengths_plus_1 is not None:
@@ -1923,7 +1923,7 @@ class RTPForwardQwen35HybridContext(RTPForwardContext):
 
         if not non_cuda_graph_mode:
             sequence_lengths_plus_1 = RTPForwardContext._non_empty_int32(
-                getattr(attn_inputs, "sequence_lengths_plus_1_d", None),
+                getattr(attn_inputs, "sequence_lengths_plus_1_device", None),
                 device=device,
             )
             if sequence_lengths_plus_1 is not None:

--- a/atom/plugin/rtpllm/utils/forward_context.py
+++ b/atom/plugin/rtpllm/utils/forward_context.py
@@ -1052,8 +1052,19 @@ class RTPForwardContext:
         cg_bufs: dict | None,
         in_capture: bool,
     ) -> torch.Tensor | None:
+        # NOTE: kv_cache_block_id_device is RTP-LLM's cache-store physical block table.
+        # RTP-LLM does NOT refresh it inside the CUDA/HIP graph on replay -- by design only
+        # kv_cache_kernel_block_id_device is D2D-refreshed, and cache store runs outside the
+        # graph (see RTP-LLM cuda_graph_runner.cc and OpDefs.h). Returning it under capture
+        # bakes a stale block_table / slot_mapping into the graph, so every replay step
+        # reads/writes KV at the frozen capture-time physical blocks -> garbled output.
+        # Under capture we must rebuild the physical table from the (refreshed) kernel table.
         physical_block_table = getattr(attn_inputs, "kv_cache_block_id_device", None)
-        if physical_block_table is not None and physical_block_table.numel() > 0:
+        if (
+            not in_capture
+            and physical_block_table is not None
+            and physical_block_table.numel() > 0
+        ):
             return physical_block_table
         kernel_block_table = cls._select_block_table_for_layer(attn_inputs=attn_inputs)
         if kernel_block_table is None or kernel_block_table.numel() == 0:
@@ -1796,8 +1807,19 @@ class RTPForwardMLAContext(RTPForwardContext):
         cg_bufs: dict | None,
         in_capture: bool,
     ) -> torch.Tensor | None:
+        # NOTE: kv_cache_block_id_device is RTP-LLM's cache-store physical block table.
+        # RTP-LLM does NOT refresh it inside the CUDA/HIP graph on replay -- by design only
+        # kv_cache_kernel_block_id_device is D2D-refreshed, and cache store runs outside the
+        # graph (see RTP-LLM cuda_graph_runner.cc and OpDefs.h). Returning it under capture
+        # bakes a stale block_table / slot_mapping into the graph, so every replay step
+        # reads/writes KV at the frozen capture-time physical blocks -> garbled output.
+        # Under capture we must rebuild the physical table from the (refreshed) kernel table.
         physical_block_table = getattr(attn_inputs, "kv_cache_block_id_device", None)
-        if physical_block_table is not None and physical_block_table.numel() > 0:
+        if (
+            not in_capture
+            and physical_block_table is not None
+            and physical_block_table.numel() > 0
+        ):
             return physical_block_table
         kernel_block_table = cls._select_block_table_for_layer(attn_inputs=attn_inputs)
         if kernel_block_table is None or kernel_block_table.numel() == 0:


### PR DESCRIPTION
RTP-LLM commit b1f8d50 ("refactor(attn): unify PyAttentionInputs host/device tensors with _host/_device suffixes") renamed the canonical device-side attention fields:

  sequence_lengths_plus_1_d -> sequence_lengths_plus_1_device
  prefix_lengths_d          -> prefix_lengths_device
  cu_seqlens (device)       -> cu_seqlens_device

forward_context.py still read the old names via getattr(..., None), so on post-rename RTP-LLM these silently returned None. The decode path then fell back to recomputing (sequence_lengths + input_lengths) into a transient device tensor. Under CUDA/HIP graph capture that transient is baked into the graph, while RTP-LLM updates sequence_lengths_plus_1_device in place on replay -> captured context_lens freeze at capture-time values -> decode attention reads KV with stale sequence lengths -> accuracy regression (only in CUDA-graph mode; eager recomputes each step so it was unaffected).

Point all getattr keys at the new _device names. _non_empty_int32 is a no-op on an already-on-device contiguous int32 tensor, so the canonical buffer identity is preserved and graph replay binds to RTP-LLM's in-place buffer.

Manifests as the GLM-5 ROCm CUDA-graph accuracy issue.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
