### PR TITLE
[fix][atom]add tbo support for m3-eagle

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2400,7 +2400,11 @@ class ModelRunner:
                             capture_ctx.stream,
                             output_buffer=outputs[:num_tokens],
                         )
-                        graph_aux = None
+                        graph_aux = (
+                            graph_output[1]
+                            if self.use_aux_hidden_state_outputs
+                            else None
+                        )
                     else:
                         # Standard single-stream capture
                         graph = torch.cuda.CUDAGraph()

--- a/atom/models/minimax_m3.py
+++ b/atom/models/minimax_m3.py
@@ -585,8 +585,11 @@ class MiniMaxM3DecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
-        aux_out: list[torch.Tensor] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        capture_aux: bool = False,
+    ) -> (
+        tuple[torch.Tensor, torch.Tensor]
+        | tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ):
         if residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
@@ -599,8 +602,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
         # layer (post input-norm). Captured here, not as `hidden_states + residual`
         # in the model loop, because M3's fused all-reduce RMSNorm leaves that sum
         # TP-partial / NaN-prone under CUDAGraph.
-        if aux_out is not None:
-            aux_out.append(residual.clone())
+        aux_hidden_state = residual.clone() if capture_aux else None
 
         hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
         hidden_states, residual = fused_allreduce_gemma_rms_norm(
@@ -608,6 +610,8 @@ class MiniMaxM3DecoderLayer(nn.Module):
         )
         ffn = self.block_sparse_moe if self.is_moe_layer else self.mlp
         hidden_states = ffn(hidden_states)
+        if aux_hidden_state is not None:
+            return hidden_states, residual, aux_hidden_state
         return hidden_states, residual
 
 
@@ -669,7 +673,7 @@ class MiniMaxM3Model(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             hidden_states = (
                 inputs_embeds
@@ -684,10 +688,15 @@ class MiniMaxM3Model(nn.Module):
 
         aux_hidden_states: list[torch.Tensor] = []
         for idx in range(self.start_layer, self.end_layer):
-            aux_out = aux_hidden_states if idx in self.aux_hidden_state_layers else None
-            hidden_states, residual = self.layers[idx](
-                positions, hidden_states, residual, aux_out=aux_out
-            )
+            if idx in self.aux_hidden_state_layers:
+                hidden_states, residual, aux_hidden_state = self.layers[idx](
+                    positions, hidden_states, residual, capture_aux=True
+                )
+                aux_hidden_states.append(aux_hidden_state)
+            else:
+                hidden_states, residual = self.layers[idx](
+                    positions, hidden_states, residual
+                )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(

--- a/atom/utils/tbo/ubatch_wrapper.py
+++ b/atom/utils/tbo/ubatch_wrapper.py
@@ -5,7 +5,7 @@ import logging
 import threading
 import traceback
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Optional, TypeAlias
 
 import torch
 import torch.nn as nn
@@ -22,6 +22,8 @@ from .ubatching import make_tbo_contexts
 
 logger = logging.getLogger("atom")
 
+UBatchModelOutput: TypeAlias = torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]
+
 
 @dataclass
 class TBOGraphData:
@@ -29,7 +31,7 @@ class TBOGraphData:
 
     graph: torch.cuda.CUDAGraph
     tbo_ctxs: list  # keep torch.Event objects alive for replay
-    output: Any = None  # output tensor reference from capture
+    output: Optional[UBatchModelOutput] = None  # output reference from capture
 
 
 class UBatchWrapper(nn.Module):
@@ -55,7 +57,9 @@ class UBatchWrapper(nn.Module):
         if self.comm_stream is None:
             self.comm_stream = torch.cuda.Stream()
 
-    def forward(self, input_ids: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, input_ids: torch.Tensor, positions: torch.Tensor
+    ) -> UBatchModelOutput:
         ctx = get_forward_context()
         if ctx.ubatch_slices is None:
             return self.model(input_ids, positions)
@@ -66,7 +70,7 @@ class UBatchWrapper(nn.Module):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         ctx: ForwardContext,
-    ) -> torch.Tensor:
+    ) -> UBatchModelOutput:
         """Launch threads that each call self.model() inside a TBOContext."""
         self._ensure_comm_stream()
         original_ctx = ctx
@@ -131,7 +135,7 @@ class UBatchWrapper(nn.Module):
             ready_barrier=self.ready_barrier,
         )
 
-        results: list[tuple[int, torch.Tensor]] = []
+        results: list[tuple[int, UBatchModelOutput]] = []
         errors: list[Optional[Exception]] = [None] * N
 
         device = input_ids.device
@@ -148,7 +152,7 @@ class UBatchWrapper(nn.Module):
                 ub_input_ids, ub_positions = ub_inputs[idx]
                 with tbo_ctxs[idx]:
                     model_output = self.model(ub_input_ids, ub_positions)
-                results.append((idx, model_output))
+                results.append((idx, self._validate_ubatch_output(model_output)))
             except Exception as e:
                 # `logger.exception` captures the full traceback to the atom
                 # logger (which goes to stderr + log file); previously the
@@ -186,7 +190,7 @@ class UBatchWrapper(nn.Module):
                 raise e
 
         sorted_results = [value for _, value in sorted(results)]
-        return torch.cat(sorted_results, dim=0)
+        return self._concat_ubatch_outputs(sorted_results)
 
     def capture_tbo_graph(
         self,
@@ -195,7 +199,7 @@ class UBatchWrapper(nn.Module):
         graph_pool,
         capture_stream: torch.cuda.Stream,
         output_buffer: Optional[torch.Tensor] = None,
-    ) -> tuple[torch.cuda.CUDAGraph, torch.Tensor]:
+    ) -> tuple[torch.cuda.CUDAGraph, UBatchModelOutput]:
         """Capture a CUDAGraph for TBO ubatch execution.
 
         Threads are started and cuBLAS is initialized BEFORE graph capture
@@ -246,7 +250,7 @@ class UBatchWrapper(nn.Module):
             ready_barrier=self.ready_barrier,
         )
 
-        results: list[tuple[int, torch.Tensor]] = []
+        results: list[tuple[int, UBatchModelOutput]] = []
         errors: list[Optional[Exception]] = [None] * N
         device = input_ids.device
 
@@ -264,7 +268,7 @@ class UBatchWrapper(nn.Module):
                 ub_input_ids, ub_positions = ub_inputs[idx]
                 with tbo_ctxs[idx]:
                     model_output = self.model(ub_input_ids, ub_positions)
-                results.append((idx, model_output))
+                results.append((idx, self._validate_ubatch_output(model_output)))
             except Exception as e:
                 traceback.print_exc()
                 errors[idx] = e
@@ -292,10 +296,10 @@ class UBatchWrapper(nn.Module):
                     t.join()
                 # Concatenate results (this op is captured too)
                 sorted_results = [v for _, v in sorted(results)]
-                output = torch.cat(sorted_results, dim=0)
+                output = self._concat_ubatch_outputs(sorted_results)
                 # Copy into caller's buffer so replay writes to the right place
                 if output_buffer is not None:
-                    output_buffer.copy_(output)
+                    output_buffer.copy_(self._primary_output(output))
         finally:
             _forward_context_local.ctx = saved_ctx
 
@@ -313,6 +317,56 @@ class UBatchWrapper(nn.Module):
         logger.info(f"[TBO] Captured CUDAGraph for {graph_key}")
 
         return graph, output
+
+    @staticmethod
+    def _concat_ubatch_outputs(
+        outputs: list[UBatchModelOutput],
+    ) -> UBatchModelOutput:
+        """Concatenate Tensor or Eagle3 aux outputs from per-ubatch forwards."""
+        first = outputs[0]
+        if isinstance(first, torch.Tensor):
+            if not all(isinstance(output, torch.Tensor) for output in outputs):
+                raise TypeError("TBO ubatch outputs must have matching structures")
+            return torch.cat(outputs, dim=0)
+
+        if not all(isinstance(output, tuple) for output in outputs):
+            raise TypeError("TBO ubatch outputs must have matching structures")
+
+        hidden_states = torch.cat([output[0] for output in outputs], dim=0)
+        num_aux = len(first[1])
+        if not all(len(output[1]) == num_aux for output in outputs):
+            raise ValueError("TBO ubatch aux output counts must match")
+        aux_hidden_states = [
+            torch.cat([output[1][idx] for output in outputs], dim=0)
+            for idx in range(num_aux)
+        ]
+        return hidden_states, aux_hidden_states
+
+    @staticmethod
+    def _primary_output(output: UBatchModelOutput) -> torch.Tensor:
+        """Return the tensor backed by ModelRunner's preallocated output buffer."""
+        if isinstance(output, tuple):
+            return output[0]
+        return output
+
+    @staticmethod
+    def _validate_ubatch_output(output: object) -> UBatchModelOutput:
+        """Accept only the TBO output contracts: Tensor or Eagle3 aux tuple."""
+        if isinstance(output, torch.Tensor):
+            return output
+        if (
+            isinstance(output, tuple)
+            and len(output) == 2
+            and isinstance(output[0], torch.Tensor)
+            and isinstance(output[1], list)
+            and all(isinstance(aux, torch.Tensor) for aux in output[1])
+        ):
+            return output
+        raise TypeError(
+            "TBO ubatch output must be a Tensor or "
+            "(Tensor, list[Tensor]), got "
+            f"{type(output).__name__}"
+        )
 
     @staticmethod
     def _get_dp_size() -> int:


### PR DESCRIPTION
## Motivation
add tbo support for MiniMax-M3 Eagle3

Before this change, TBO assumed that each ubatch model forward returned a single torch.Tensor. That is true for normal target-model serving, but not for Eagle3 with aux hidden states enabled. In the Eagle3 path, the target model may return `(hidden_states, aux_hidden_states)`. Where aux_hidden_states is a list of intermediate target-layer tensors used by the drafter. Without extending TBO’s output handling, ubatch results cannot be merged correctly, and captured TBO graphs cannot preserve the aux outputs needed during replay.

## Tech Details
expose Eagle3 aux hidden states from the correct layer positions. 

## Test Plan
#### M3 FP8
server:
```bash
model_path=/shared/data/amd_int/models/MiniMax-M3-MXFP8/
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export ATOM_FORCE_ATTN_TRITON=1

draft_path=Inferact/MiniMax-M3-EAGLE3

python -m atom.entrypoints.openai_server \
  --model "$model_path" \
  --tensor-parallel-size 4 \
  --enable-dp-attention \
  --server-port 8013 \
  --trust-remote-code \
  --gpu-memory-utilization 0.8 \
  --block-size 128 \
  --max-model-len 32768 \
  --max-num-seqs 256 \
  --kv_cache_dtype fp8 \
  --max-num-batched-tokens 32768 \
  --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*.gate.*", "*.block_sparse_moe.experts*"]}' \
  --no-enable_prefix_caching \
  --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
  --enable-tbo prefill \
  --method eagle3 \
  --draft-model "$draft_path" \
  --num-speculative-tokens 3 2>&1 | tee m3-mxfp8-eagle3-server.log
```

#### M3 FP4
server:
```bash
model_path=/shared/data/amd_int/models/MiniMax-M3-MXFP4/
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export ATOM_FORCE_ATTN_TRITON=1

draft_path=Inferact/MiniMax-M3-EAGLE3

python -m atom.entrypoints.openai_server \
  --model "$model_path" \
  --tensor-parallel-size 4 \
  --enable-dp-attention \
  --server-port 8013 \
  --trust-remote-code \
  --gpu-memory-utilization 0.8 \
  --block-size 128 \
  --max-model-len 32768 \
  --max-num-seqs 256 \
  --kv_cache_dtype fp8 \
  --max-num-batched-tokens 32768 \
  --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
  --no-enable_prefix_caching \
  --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
  --enable-tbo prefill \
  --method eagle3 \
  --draft-model "$draft_path" \
  --num-speculative-tokens 3 2>&1 | tee m3-mxfp4-eagle3-server.log
```

## Test Result
#### M3 FP8
benchmark: TTT from 55512.71 to 61728.22  tok/s, improved 11.2%
w/o tbo
```bash
============ Serving Benchmark Result ============
Successful requests:                     768       
Benchmark duration (s):                  113.35    
Total input tokens:                      6291456   
Total generated tokens:                  768       
Request throughput (req/s):              6.78      
Output token throughput (tok/s):         6.78      
Total Token throughput (tok/s):          55512.71  
---------------Time to First Token----------------
Mean TTFT (ms):                          31590.62  
Median TTFT (ms):                        37620.36  
P99 TTFT (ms):                           37641.55  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.02      
Median ITL (ms):                         0.02      
P99 ITL (ms):                            0.06      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          31590.64  
Median E2EL (ms):                        37620.39  
P99 E2EL (ms):                           37641.57  
==================================================
```
w/ tbo
```bash
============ Serving Benchmark Result ============
Successful requests:                     768       
Benchmark duration (s):                  101.93    
Total input tokens:                      6291456   
Total generated tokens:                  768       
Request throughput (req/s):              7.53      
Output token throughput (tok/s):         7.53      
Total Token throughput (tok/s):          61728.22  
---------------Time to First Token----------------
Mean TTFT (ms):                          28805.96  
Median TTFT (ms):                        33781.56  
P99 TTFT (ms):                           34457.39  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.02      
Median ITL (ms):                         0.02      
P99 ITL (ms):                            0.04      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          28805.98  
Median E2EL (ms):                        33781.57  
P99 E2EL (ms):                           34457.41  
==================================================
```
accuracy
```bash
accept: Average toks/fwd: 3.17, Accepted/Total Draft tokens: 43407/60000, Acceptance rate: 72.34%, Accepted tokens distribution: {0: '15.12%', 1: '12.27%', 2: '13.05%', 3: '59.55%'}
local-chat-completions ({'model': '/shared/data/amd_int/models/MiniMax-M3-MXFP8/', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 64, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 32768}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9515|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9522|±  |0.0059|
```
```bash
local-chat-completions ({'model': '/shared/data/amd_int/models/MiniMax-M3-MXFP8/', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 256, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 32768}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9477|±  |0.0061|
|     |       |strict-match    |     5|exact_match|↑  |0.9484|±  |0.0061|
```


#### M3 FP4
benchmark: TTT from 63229.82 to 72502.89 tok/s, improved 14.7%
w/o tbo
```bash
============ Serving Benchmark Result ============
Successful requests:                     768       
Benchmark duration (s):                  99.51     
Total input tokens:                      6291456   
Total generated tokens:                  768       
Request throughput (req/s):              7.72      
Output token throughput (tok/s):         7.72      
Total Token throughput (tok/s):          63229.82  
---------------Time to First Token----------------
Mean TTFT (ms):                          27734.47  
Median TTFT (ms):                        33018.78  
P99 TTFT (ms):                           33031.97  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.02      
Median ITL (ms):                         0.02      
P99 ITL (ms):                            0.06      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          27734.49  
Median E2EL (ms):                        33018.80  
P99 E2EL (ms):                           33032.00  
```
w/ tbo
```bash
============ Serving Benchmark Result ============
Successful requests:                     768       
Benchmark duration (s):                  86.79     
Total input tokens:                      6291456   
Total generated tokens:                  768       
Request throughput (req/s):              8.85      
Output token throughput (tok/s):         8.85      
Total Token throughput (tok/s):          72502.89  
---------------Time to First Token----------------
Mean TTFT (ms):                          24483.72  
Median TTFT (ms):                        28562.82  
P99 TTFT (ms):                           30428.87  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.02      
Median ITL (ms):                         0.02      
P99 ITL (ms):                            0.04      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          24483.74  
Median E2EL (ms):                        28562.84  
P99 E2EL (ms):                           30428.89  
==================================================
```
accuracy
```bash
[atom 06:47:01] [MTP Stats Interval] Average toks/fwd: 3.30, Accepted/Total Draft tokens: 2296/3000, Acceptance rate: 76.53%, Accepted tokens distribution: {0: '11.20%', 1: '12.60%', 2: '11.60%', 3: '64.60%'}
[atom 06:47:01] [MTP Stats         ] Average toks/fwd: 3.32, Accepted/Total Draft tokens: 57987/75000, Acceptance rate: 77.32%, Accepted tokens distribution: {0: '12.18%', 1: '10.47%', 2: '10.57%', 3: '66.78%'}
local-chat-completions ({'model': '/shared/data/amd_int/models/MiniMax-M3-MXFP4/', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 64, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 32768}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9447|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9454|±  |0.0063|
```
```bash
local-chat-completions ({'model': '/shared/data/amd_int/models/MiniMax-M3-MXFP4/', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 256, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 32768}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9454|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9462|±  |0.0062|
```

Tested TBO without Eagle enabled. Accuracy and performance are consistent with the previous results: https://github.com/ROCm/ATOM/pull/1373
w/ tbo, FP4 without Eagle
```bash
============ Serving Benchmark Result ============
Successful requests:                     768       
Benchmark duration (s):                  84.41     
Total input tokens:                      6291456   
Total generated tokens:                  768       
Request throughput (req/s):              9.10      
Output token throughput (tok/s):         9.10      
Total Token throughput (tok/s):          74542.59  
---------------Time to First Token----------------
Mean TTFT (ms):                          23901.57  
Median TTFT (ms):                        27880.63  
P99 TTFT (ms):                           29345.93  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.02      
Median ITL (ms):                         0.02      
P99 ITL (ms):                            0.05      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          23901.59  
Median E2EL (ms):                        27880.65  
P99 E2EL (ms):                           29345.96  
==================================================
```
```bash
local-chat-completions ({'model': '/shared/data/amd_int/models/MiniMax-M3-MXFP4/', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 256, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 32768}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9433|±  |0.0069|
|     |       |strict-match    |     5|exact_match|↑  |0.9433|±  |0.0069|
```

