### PR TITLE
Do not merge: d2d

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2009,6 +2009,34 @@ class ModelRunner:
                 graph_bs = context.graph_bs
                 max_q_len = forward_context.attn_metadata.max_seqlen_q
                 graph_key = (graph_bs, max_q_len)
+                # [CUQ_DUAL] dual probe over [: graph_bs+1] (full convert-kernel grid)
+                import torch as _t
+                _k = min(graph_bs + 1, 257)
+                if not hasattr(self, "_cuq_snap"):
+                    _dev = self.forward_vars["cu_seqlens_q"].gpu.device
+                    self._cuq_snap = _t.zeros(3000, 257, dtype=_t.int32, device=_dev)
+                    self._cuq_snap_n = 0
+                    self._cuq_step = 0
+                self._cuq_step += 1
+                if self._cuq_step > 1000:
+                    if self._cuq_step % 500 == 0:
+                        _np = self.forward_vars["cu_seqlens_q"].np
+                        logger.warning("[CUQ_DUAL]_HOST step=%d graph_bs=%d head=%s tail=%s",
+                                       self._cuq_step, graph_bs,
+                                       _np[:min(16, _k)].tolist(),
+                                       _np[max(_k - 3, 0):_k].tolist())
+                    if self._cuq_snap_n < 3000:
+                        self._cuq_snap[self._cuq_snap_n, :_k].copy_(
+                            self.forward_vars["cu_seqlens_q"].gpu[:_k])
+                        self._cuq_snap_n += 1
+                        if self._cuq_snap_n == 3000:
+                            import threading as _thr
+                            _snap = self._cuq_snap
+                            _rank = getattr(self, "rank", 0)
+                            _p = "/it-share/jiaolyu/glm52_repro/g43dbg_cuq_rank%d.pt" % _rank
+                            _thr.Thread(target=lambda: (_t.save(_snap.cpu(), _p),
+                                logger.warning("[CUQ_DUAL]_D2D saved %s", _p)),
+                                daemon=True).start()
                 self.graphs[graph_key].replay()
                 num_tokens = context.batch_size * max_q_len
                 hidden_states = self.forward_vars["outputs"][:num_tokens]


### PR DESCRIPTION
## Motivation

### Results — 8 ranks × 3000 snapshots per run, two batch sizes

| Run      | graph_bs | rows  | **bad rows** | value range | scheduled_bs (min..max, mean) |
| -------- | -------- | ----- | ------------ | ----------- | ----------------------------- |
| conc=256 | 256      | 24000 | **0**        | 0 .. 256    | 209 .. 256, mean 254.1        |
| conc=128 | 128      | 24000 | **0**        | 0 .. 128    | 116 .. 128, mean 127.8        |

"bad row" = any row whose in-grid region is not a valid `arange + flat-pad`
(e.g. a `-1` sentinel, or a giant cumulative/prefill value like the `812/875`
the kernel reads at fault time). **Total bad = 0 / 48000.**

scheduled_bs breakdown (total rows per sb, all bad=0):

```
conc=256:  sb=256:16960  255:3424  254:936  253:408  252:112  251:104  250:184
           249:48  248:176  245:216  241:232  240:128  239:104  220:128  ...
           (44 distinct sb values spanning 209..256, every one bad=0)
conc=128:  sb=128:21800  127:1504  126:336  125:72  124:64  123:88  122:72
           121:8  120:24  119:8  118:8  117:8  116:8
           (13 distinct sb values spanning 116..128, every one bad=0)
```

**Key statistic — global extrema over all captured values:**

| Run      | rows  | GLOBAL min | GLOBAL max | fault-time kernel actually read |
| -------- | ----- | ---------- | ---------- | ------------------------------- |
| conc=256 | 24000 | **0**      | **256**    | `qo_start/qo_end = 812 / 875`   |
| conc=128 | 24000 | **0**      | **128**    | `qo_start/qo_end = 812 / 875`   |

The max value anywhere in global memory is **exactly `graph_bs`** (256 / 128), the min
is **0** 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
