### PR TITLE
feat(prezero): wire split-K GEMM prezero into MLA / MoE decode

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -237,6 +237,7 @@ class CompilationConfig:
         factors.append(self.local_cache_dir)
         factors.append(self.cudagraph_capture_sizes)
         factors.append(self.cuda_graph_sizes)
+        factors.append(envs.ATOM_ENABLE_SPLITK_PREZERO)
 
         return hashlib.sha256(str(factors).encode()).hexdigest()
 

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -32,6 +32,8 @@ except ImportError:
 from aiter.dist.parallel_state import get_dp_group
 from aiter.mla import mla_decode_fwd, mla_prefill_fwd
 from aiter.tuned_gemm import tgemm
+
+from atom.model_ops.prezero import prezero_active
 from aiter.ops.triton.attention.mla import (
     mla_decode_fwd as triton_shuffle_mla_decode_fwd,
 )
@@ -371,10 +373,8 @@ class MLAAttention(nn.Module):
     @mark_trace(prefix="q_proj_and_k_up_proj", torch_compile=False)
     def _q_proj_and_k_up_proj(self, x, x_scale=None, qb_prezero=None):
         if qb_prezero is not None:
-            # The q up-proj output buffer was pre-zeroed for free by the layer's
-            # fused allreduce-rmsnorm; run the bf16 q_b GEMM as a split-K
-            # atomic-add into it (zero_init=False) instead of allocating fresh.
-            tgemm.mm(x, self.q_proj.weight, None, zero_init=False, out=qb_prezero)
+            active = prezero_active(self.q_proj.prezero_n_total)
+            tgemm.mm(x, self.q_proj.weight, None, zero_init=not active, out=qb_prezero)
             q_proj_out = qb_prezero
         else:
             q_proj_out = self.q_proj(x, x_scale)

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -31,6 +31,7 @@ except ImportError:
     fused_qk_rope_concat_and_cache_mla_seg = None
 from aiter.dist.parallel_state import get_dp_group
 from aiter.mla import mla_decode_fwd, mla_prefill_fwd
+from aiter.tuned_gemm import tgemm
 from aiter.ops.triton.attention.mla import (
     mla_decode_fwd as triton_shuffle_mla_decode_fwd,
 )
@@ -368,11 +369,17 @@ class MLAAttention(nn.Module):
         return self.o_proj(x)
 
     @mark_trace(prefix="q_proj_and_k_up_proj", torch_compile=False)
-    def _q_proj_and_k_up_proj(self, x, x_scale=None):
-        q_nope, q_pe = (
-            self.q_proj(x, x_scale)
-            .view(-1, self.num_heads, self.qk_head_dim)
-            .split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+    def _q_proj_and_k_up_proj(self, x, x_scale=None, qb_prezero=None):
+        if qb_prezero is not None:
+            # The q up-proj output buffer was pre-zeroed for free by the layer's
+            # fused allreduce-rmsnorm; run the bf16 q_b GEMM as a split-K
+            # atomic-add into it (zero_init=False) instead of allocating fresh.
+            tgemm.mm(x, self.q_proj.weight, None, zero_init=False, out=qb_prezero)
+            q_proj_out = qb_prezero
+        else:
+            q_proj_out = self.q_proj(x, x_scale)
+        q_nope, q_pe = q_proj_out.view(-1, self.num_heads, self.qk_head_dim).split(
+            [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
         )
 
         # Convert from (B, N, P) to (N, B, P)
@@ -1090,6 +1097,7 @@ class MLAAttention(nn.Module):
         k_rope: torch.Tensor,
         positions: torch.Tensor = None,
         q_scale: Optional[torch.Tensor] = None,
+        qb_prezero: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         # kv_cache = self.kv_cache
         forward_context: ForwardContext = get_forward_context()
@@ -1171,7 +1179,9 @@ class MLAAttention(nn.Module):
                     prefill_q, k_nope, k_rope, kv_cache, attn_metadata
                 )
         else:
-            q_nope, q_rope = self._q_proj_and_k_up_proj(q, x_scale=q_scale)
+            q_nope, q_rope = self._q_proj_and_k_up_proj(
+                q, x_scale=q_scale, qb_prezero=qb_prezero
+            )
 
             if self.use_seg_mla:
                 # Seg path: allocate q_out with a padded last dim so each head row
@@ -1275,6 +1285,7 @@ class MLAAttention(nn.Module):
         positions: torch.Tensor = None,
         q_scale: Optional[torch.Tensor] = None,
         output: torch.Tensor = None,
+        qb_prezero: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         return self.forward_impl(
@@ -1283,6 +1294,7 @@ class MLAAttention(nn.Module):
             k_rope=k_rope,
             positions=positions,
             q_scale=q_scale,
+            qb_prezero=qb_prezero,
         )
 
 

--- a/atom/model_ops/base_attention.py
+++ b/atom/model_ops/base_attention.py
@@ -327,6 +327,7 @@ def fake_(
     layer_name: str,
     use_mla: bool,
     qkv: torch.Tensor,
+    qb_prezero: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     output_shape = list(q.shape)
     # If we fusion rmsnorm and quant, the input dtype is fp8, but actually we use bf16 for output.
@@ -342,7 +343,7 @@ def fake_(
 # Dynamo will not try to inspect any of the internal operations for prefill or decode
 # This way, although attention operation is complicated,
 # we can still capture the model's computation graph as a full-graph
-@mark_spliting_op(is_custom=True, gen_fake=fake_, mutates_args=[])
+@mark_spliting_op(is_custom=True, gen_fake=fake_, mutates_args=["qb_prezero"])
 def unified_attention_with_output_base(
     q: torch.Tensor,
     q_scale: Optional[torch.Tensor],
@@ -352,6 +353,7 @@ def unified_attention_with_output_base(
     layer_name: str,
     use_mla: bool,
     qkv: torch.Tensor,
+    qb_prezero: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     atom_config = get_current_atom_config()
     self = atom_config.compilation_config.static_forward_context[layer_name]
@@ -362,6 +364,7 @@ def unified_attention_with_output_base(
             k_rope=v,
             positions=positions,
             q_scale=q_scale,
+            qb_prezero=qb_prezero,
         )
     else:
         return self.impl.forward(

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -317,6 +317,7 @@ class RMSNorm(nn.Module):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
         x_scale: Optional[torch.Tensor] = None,
+        zero_fill: Optional[torch.Tensor] = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         if self.x_pad_to_multiple > 0:
             assert (
@@ -340,6 +341,7 @@ class RMSNorm(nn.Module):
                 residual,
                 self.weight,
                 self.eps,
+                zero_fill=zero_fill,
             )
             return x, residual
         else:

--- a/atom/model_ops/paged_attention.py
+++ b/atom/model_ops/paged_attention.py
@@ -116,9 +116,18 @@ class Attention(BaseAttention):
         positions: torch.Tensor = None,
         q_scale: Optional[torch.Tensor] = None,
         qkv: torch.Tensor = None,
+        qb_prezero: Optional[torch.Tensor] = None,
         **kwargs,
     ):
         output = torch.ops.aiter.unified_attention_with_output_base(
-            query, q_scale, key, value, positions, self.layer_name, self.use_mla, qkv
+            query,
+            q_scale,
+            key,
+            value,
+            positions,
+            self.layer_name,
+            self.use_mla,
+            qkv,
+            qb_prezero,
         )
         return output

--- a/atom/model_ops/prezero.py
+++ b/atom/model_ops/prezero.py
@@ -1,0 +1,66 @@
+"""Split-K GEMM "prezero" helpers.
+
+A split-K GEMM can skip its in-kernel output zero-init (NOZINIT) and atomic-add
+into a buffer the preceding fused allreduce-rmsnorm zeroed for free, when that
+pays off for the current batch. The decision lives inside opaque custom ops so
+it re-runs at each per-bs cudagraph capture instead of being frozen by the one
+prefill-time compile.
+"""
+
+from typing import Optional
+
+import torch
+from aiter import is_prezero_free
+from aiter.dist.communication_op import tensor_model_parallel_fused_allreduce_rmsnorm
+from aiter.jit.utils.torch_guard import torch_compile_guard
+from aiter.tuned_gemm import tgemm
+
+from atom.utils import envs
+from atom.utils.forward_context import get_forward_context
+
+
+def prezero_active(n_total: int) -> bool:
+    if not envs.ATOM_ENABLE_SPLITK_PREZERO:
+        return False
+    ctx = get_forward_context().context
+    return (not ctx.is_prefill) and is_prezero_free(ctx.graph_bs, n_total)
+
+
+@torch_compile_guard(
+    mutates_args=["out"],
+    gen_fake=lambda out, a, weight, n_total, bias=None: None,
+)
+def mm_maybe_prezero_(
+    out: torch.Tensor,
+    a: torch.Tensor,
+    weight: torch.Tensor,
+    n_total: int,
+    bias: Optional[torch.Tensor] = None,
+) -> None:
+    active = prezero_active(n_total)
+    tgemm.mm(a, weight, bias, zero_init=not active, out=out)
+
+
+@torch_compile_guard(
+    mutates_args=["zero_buf"],
+    gen_fake=lambda x, residual, weight, eps, zero_buf, n_total: (
+        torch.empty_like(x),
+        torch.empty_like(residual),
+    ),
+)
+def ar_rmsnorm_maybe_prezero_(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    zero_buf: torch.Tensor,
+    n_total: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    active = prezero_active(n_total)
+    return tensor_model_parallel_fused_allreduce_rmsnorm(
+        x.contiguous(),
+        residual,
+        weight,
+        eps,
+        zero_fill=zero_buf if active else None,
+    )

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -36,14 +36,12 @@ from aiter import (
     get_hip_quant,
     indexer_k_quant_and_cache,
     indexer_qk_rope_quant_and_cache,
-    is_prezero_free,
     top_k_per_row_decode,
     top_k_per_row_prefill,
 )
 from aiter.dist.communication_op import tensor_model_parallel_all_reduce
 from aiter.dist.parallel_state import get_pp_group, get_tensor_model_parallel_world_size
 from aiter.jit.utils.torch_guard import torch_compile_guard
-from aiter.tuned_gemm import tgemm
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 from aiter.ops.triton.fused_fp8_quant import fused_reduce_rms_fp8_group_quant
 from aiter.ops.triton.fused_mxfp4_quant import (
@@ -74,6 +72,7 @@ from atom.model_ops.linear import (
     use_triton_gemm,
 )
 from atom.model_ops.moe import FusedMoE
+from atom.model_ops.prezero import ar_rmsnorm_maybe_prezero_, mm_maybe_prezero_
 from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
 from atom.model_ops.utils import MXFP4_QUANT_BLOCK_SIZE, atom_parameter
 from atom.models.utils import (
@@ -876,21 +875,6 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant(
     return q_c, q_c_scale, kv_c_normed, k_pe
 
 
-@torch_compile_guard(
-    mutates_args=["out"], gen_fake=lambda out, a, weight, bias=None: None
-)
-def _mm_prezero_(
-    out: torch.Tensor,
-    a: torch.Tensor,
-    weight: torch.Tensor,
-    bias: Optional[torch.Tensor] = None,
-) -> None:
-    # The out buffer was pre-zeroed for free by the preceding fused
-    # allreduce-rmsnorm, so skip the in-kernel zero-init and let the split-K
-    # GEMM atomic-add into it (zero_init=False == prezero).
-    tgemm.mm(a, weight, bias, zero_init=False, out=out)
-
-
 class DeepseekV2MLP(nn.Module):
     def __init__(
         self,
@@ -1021,7 +1005,12 @@ class DeepseekV2MoE(nn.Module):
         gate_prezero: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if gate_prezero is not None:
-            _mm_prezero_(gate_prezero, hidden_states, self.gate.weight)
+            mm_maybe_prezero_(
+                gate_prezero,
+                hidden_states,
+                self.gate.weight,
+                self.gate.weight.shape[0],
+            )
             router_logits = gate_prezero
         else:
             router_logits = self.gate(hidden_states)
@@ -1088,6 +1077,12 @@ class DeepseekV2MoE(nn.Module):
             final_hidden_states, shared_output, hidden_states
         )
         return final_hidden_states
+
+    @property
+    def gate_prezero_n(self) -> int:
+        if self._use_dual_stream:
+            return 0
+        return self.gate.weight.shape[0]
 
     def forward(
         self,
@@ -1947,6 +1942,14 @@ class DeepseekV2MLAAttention(nn.Module):
             if layer_quant_dtype in (dtypes.fp8, dtypes.fp4x2):
                 self.fuse_qknorm_quant = True
 
+        if self.q_lora_rank is not None:
+            n_qb = (
+                self.q_b_proj.weight.shape[0]
+                if self.q_b_proj.quant_type.value == QuantType.No.value
+                else 0
+            )
+            self.q_b_proj.prezero_n_total = self.fused_qkv_a_proj.weight.shape[0] + n_qb
+
     def forward(
         self,
         positions: torch.Tensor,
@@ -1985,8 +1988,11 @@ class DeepseekV2MLAAttention(nn.Module):
                 hidden_states_or_q_c_scale = q_c_scale
             else:
                 if qkva_prezero is not None:
-                    _mm_prezero_(
-                        qkva_prezero, hidden_states, self.fused_qkv_a_proj.weight
+                    mm_maybe_prezero_(
+                        qkva_prezero,
+                        hidden_states,
+                        self.fused_qkv_a_proj.weight,
+                        self.q_b_proj.prezero_n_total,
                     )
                     qkv_lora = qkva_prezero
                 else:
@@ -2183,12 +2189,8 @@ class DeepseekV2DecoderLayer(nn.Module):
         residual: Optional[torch.Tensor],
     ) -> torch.Tensor:
         # Self Attention
-        zero_fill = None
         qkva_prezero = None
         qb_prezero = None
-        _pz_ctx = (
-            get_forward_context().context if envs.ATOM_ENABLE_SPLITK_PREZERO else None
-        )
         if self.fuse_input_norm_quant:
             assert self.quant_dtype is not None
             weight = self.input_layernorm.weight
@@ -2248,49 +2250,36 @@ class DeepseekV2DecoderLayer(nn.Module):
                 hidden_states = self.input_layernorm(hidden_states)
             else:
                 if (
-                    _pz_ctx is not None
-                    and not _pz_ctx.is_prefill
+                    envs.ATOM_ENABLE_SPLITK_PREZERO
                     and getattr(self.self_attn, "fused_qkv_a_proj", None) is not None
                     and self.input_layernorm.fused_allreduce
                     and self.input_layernorm.tp_size > 1
                 ):
-                    # Zero one buffer for free on the fused allreduce-rmsnorm's
-                    # idle CUs, then hand its contiguous blocks to the qkv_a and
-                    # (optionally) q_b split-K GEMMs to atomic-add into. q_b rides
-                    # the same input_layernorm zeroing even though its own
-                    # preceding norm (q_a_layernorm) is a plain local RMSNorm.
                     m = hidden_states.shape[0]
+                    n_total = self.self_attn.q_b_proj.prezero_n_total
                     n_qkva = self.self_attn.fused_qkv_a_proj.weight.shape[0]
-                    q_b_proj = getattr(self.self_attn, "q_b_proj", None)
-                    # q_b prezero only covers the bf16 q up-proj; a quantized
-                    # q_b_proj keeps its own quant GEMM (no prezero).
-                    n_qb = (
-                        q_b_proj.weight.shape[0]
-                        if q_b_proj is not None
-                        and q_b_proj.quant_type.value == QuantType.No.value
-                        else 0
+                    zero_fill = torch.empty(
+                        m,
+                        n_total,
+                        dtype=hidden_states.dtype,
+                        device=hidden_states.device,
                     )
-                    if n_qb and is_prezero_free(_pz_ctx.graph_bs, n_qkva + n_qb):
-                        zero_fill = torch.empty(
-                            m,
-                            n_qkva + n_qb,
-                            dtype=hidden_states.dtype,
-                            device=hidden_states.device,
-                        )
-                        flat = zero_fill.view(-1)
-                        qkva_prezero = flat[: m * n_qkva].view(m, n_qkva)
-                        qb_prezero = flat[m * n_qkva :].view(m, n_qb)
-                    elif is_prezero_free(_pz_ctx.graph_bs, n_qkva):
-                        zero_fill = torch.empty(
-                            m,
-                            n_qkva,
-                            dtype=hidden_states.dtype,
-                            device=hidden_states.device,
-                        )
-                        qkva_prezero = zero_fill
-                hidden_states, residual = self.input_layernorm(
-                    hidden_states, residual, zero_fill=zero_fill
-                )
+                    flat = zero_fill.view(-1)
+                    qkva_prezero = flat[: m * n_qkva].view(m, n_qkva)
+                    if n_total > n_qkva:
+                        qb_prezero = flat[m * n_qkva :].view(m, n_total - n_qkva)
+                    hidden_states, residual = ar_rmsnorm_maybe_prezero_(
+                        hidden_states,
+                        residual,
+                        self.input_layernorm.weight,
+                        self.input_layernorm.eps,
+                        zero_fill,
+                        n_total,
+                    )
+                else:
+                    hidden_states, residual = self.input_layernorm(
+                        hidden_states, residual
+                    )
 
         hidden_states = self.self_attn(
             positions=positions,
@@ -2311,26 +2300,33 @@ class DeepseekV2DecoderLayer(nn.Module):
 
         # Fully Connected
         gate_zero = None
+        n_experts = (
+            self.mlp.gate_prezero_n if isinstance(self.mlp, DeepseekV2MoE) else 0
+        )
         if (
-            _pz_ctx is not None
-            and not _pz_ctx.is_prefill
-            and isinstance(self.mlp, DeepseekV2MoE)
-            and not self.mlp._use_dual_stream
+            envs.ATOM_ENABLE_SPLITK_PREZERO
+            and n_experts
             and self.post_attention_layernorm.fused_allreduce
             and self.post_attention_layernorm.tp_size > 1
-            and is_prezero_free(_pz_ctx.graph_bs, self.mlp.gate.weight.shape[0])
         ):
-            # The fused allreduce-rmsnorm zeroes this gate buffer on idle CUs; the
-            # MoE then atomic-adds the split-K gate GEMM into it.
             gate_zero = torch.empty(
                 hidden_states.shape[0],
-                self.mlp.gate.weight.shape[0],
+                n_experts,
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
             )
-        hidden_states, residual = self.post_attention_layernorm(
-            hidden_states, residual, zero_fill=gate_zero
-        )
+            hidden_states, residual = ar_rmsnorm_maybe_prezero_(
+                hidden_states,
+                residual,
+                self.post_attention_layernorm.weight,
+                self.post_attention_layernorm.eps,
+                gate_zero,
+                n_experts,
+            )
+        else:
+            hidden_states, residual = self.post_attention_layernorm(
+                hidden_states, residual
+            )
         if isinstance(self.mlp, DeepseekV2MoE):
             hidden_states = self.mlp(hidden_states, gate_prezero=gate_zero)
         else:

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1015,8 +1015,16 @@ class DeepseekV2MoE(nn.Module):
                     prefix=f"{prefix}.shared_experts",
                 )
 
-    def routed_expert_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        router_logits = self.gate(hidden_states)
+    def routed_expert_forward(
+        self,
+        hidden_states: torch.Tensor,
+        gate_prezero: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if gate_prezero is not None:
+            _mm_prezero_(gate_prezero, hidden_states, self.gate.weight)
+            router_logits = gate_prezero
+        else:
+            router_logits = self.gate(hidden_states)
         final_hidden_states = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )
@@ -1066,6 +1074,7 @@ class DeepseekV2MoE(nn.Module):
     def single_stream_moe_forward(
         self,
         hidden_states: torch.Tensor,
+        gate_prezero: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         shared_output = None
         if (
@@ -1074,13 +1083,17 @@ class DeepseekV2MoE(nn.Module):
         ):
             shared_output = self.shared_experts(hidden_states)
 
-        final_hidden_states = self.routed_expert_forward(hidden_states)
+        final_hidden_states = self.routed_expert_forward(hidden_states, gate_prezero)
         final_hidden_states = self.combine_outputs(
             final_hidden_states, shared_output, hidden_states
         )
         return final_hidden_states
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        gate_prezero: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         assert (
             hidden_states.dim() == 2
         ), f"Expected hidden_states to be 2D (seq_len, hidden_dim), but got {hidden_states.dim()}D, with shape {hidden_states.shape}"
@@ -1089,10 +1102,12 @@ class DeepseekV2MoE(nn.Module):
         ), f"Hidden states dimension {hidden_states.shape[1]} does not match expected {self.experts.hidden_size}"
 
         if self._use_dual_stream:
+            # Dual-stream runs inside an opaque custom op; gate prezero is
+            # single-stream only, so the buffer is never allocated here (None).
             return torch.ops.aiter.maybe_dual_stream_forward(hidden_states, self.prefix)
 
         # Non-dual-stream path: shared experts + routed experts sequentially
-        return self.single_stream_moe_forward(hidden_states)
+        return self.single_stream_moe_forward(hidden_states, gate_prezero)
 
 
 def yarn_get_mscale(scale: float = 1, mscale: float = 1) -> float:
@@ -2264,8 +2279,31 @@ class DeepseekV2DecoderLayer(nn.Module):
                 residual *= 1.0 / self.routed_scaling_factor
 
         # Fully Connected
-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        hidden_states = self.mlp(hidden_states)
+        gate_zero = None
+        if (
+            _pz_ctx is not None
+            and not _pz_ctx.is_prefill
+            and isinstance(self.mlp, DeepseekV2MoE)
+            and not self.mlp._use_dual_stream
+            and self.post_attention_layernorm.fused_allreduce
+            and self.post_attention_layernorm.tp_size > 1
+            and is_prezero_free(_pz_ctx.graph_bs, self.mlp.gate.weight.shape[0])
+        ):
+            # The fused allreduce-rmsnorm zeroes this gate buffer on idle CUs; the
+            # MoE then atomic-adds the split-K gate GEMM into it.
+            gate_zero = torch.empty(
+                hidden_states.shape[0],
+                self.mlp.gate.weight.shape[0],
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states, residual, zero_fill=gate_zero
+        )
+        if isinstance(self.mlp, DeepseekV2MoE):
+            hidden_states = self.mlp(hidden_states, gate_prezero=gate_zero)
+        else:
+            hidden_states = self.mlp(hidden_states)
 
         if isinstance(self.mlp, DeepseekV2MLP) and hidden_states.dtype == torch.float16:
             # Fix FP16 overflow

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -36,12 +36,14 @@ from aiter import (
     get_hip_quant,
     indexer_k_quant_and_cache,
     indexer_qk_rope_quant_and_cache,
+    is_prezero_free,
     top_k_per_row_decode,
     top_k_per_row_prefill,
 )
 from aiter.dist.communication_op import tensor_model_parallel_all_reduce
 from aiter.dist.parallel_state import get_pp_group, get_tensor_model_parallel_world_size
 from aiter.jit.utils.torch_guard import torch_compile_guard
+from aiter.tuned_gemm import tgemm
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 from aiter.ops.triton.fused_fp8_quant import fused_reduce_rms_fp8_group_quant
 from aiter.ops.triton.fused_mxfp4_quant import (
@@ -872,6 +874,21 @@ def _fuse_qkv_a_proj_reduce_rmsnorm_quant(
 
     # logger.info(f"{q_c.shape=}, {q_c_scale.shape=}, {kv_c_normed.shape=}, {k_pe.shape=}, {q_c.stride()=}, {q_c_scale.stride()=}, {kv_c_normed.stride()=}, {k_pe.stride()=}")
     return q_c, q_c_scale, kv_c_normed, k_pe
+
+
+@torch_compile_guard(
+    mutates_args=["out"], gen_fake=lambda out, a, weight, bias=None: None
+)
+def _mm_prezero_(
+    out: torch.Tensor,
+    a: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+) -> None:
+    # The out buffer was pre-zeroed for free by the preceding fused
+    # allreduce-rmsnorm, so skip the in-kernel zero-init and let the split-K
+    # GEMM atomic-add into it (zero_init=False == prezero).
+    tgemm.mm(a, weight, bias, zero_init=False, out=out)
 
 
 class DeepseekV2MLP(nn.Module):
@@ -1919,6 +1936,7 @@ class DeepseekV2MLAAttention(nn.Module):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        qkva_prezero: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         hidden_states_scale = None
         if isinstance(hidden_states, tuple):
@@ -1950,7 +1968,13 @@ class DeepseekV2MLAAttention(nn.Module):
                 hidden_states_or_q_c = q_c
                 hidden_states_or_q_c_scale = q_c_scale
             else:
-                qkv_lora = self.fused_qkv_a_proj(hidden_states, hidden_states_scale)
+                if qkva_prezero is not None:
+                    _mm_prezero_(
+                        qkva_prezero, hidden_states, self.fused_qkv_a_proj.weight
+                    )
+                    qkv_lora = qkva_prezero
+                else:
+                    qkv_lora = self.fused_qkv_a_proj(hidden_states, hidden_states_scale)
                 # ckq = self.q_a_proj(hidden_states)
                 q_c, kv_c, k_pe = torch.split(
                     qkv_lora,
@@ -2139,6 +2163,11 @@ class DeepseekV2DecoderLayer(nn.Module):
         residual: Optional[torch.Tensor],
     ) -> torch.Tensor:
         # Self Attention
+        zero_fill = None
+        qkva_prezero = None
+        _pz_ctx = (
+            get_forward_context().context if envs.ATOM_ENABLE_SPLITK_PREZERO else None
+        )
         if self.fuse_input_norm_quant:
             assert self.quant_dtype is not None
             weight = self.input_layernorm.weight
@@ -2197,11 +2226,31 @@ class DeepseekV2DecoderLayer(nn.Module):
                 residual = hidden_states
                 hidden_states = self.input_layernorm(hidden_states)
             else:
-                hidden_states, residual = self.input_layernorm(hidden_states, residual)
+                if (
+                    _pz_ctx is not None
+                    and not _pz_ctx.is_prefill
+                    and getattr(self.self_attn, "fused_qkv_a_proj", None) is not None
+                    and self.input_layernorm.fused_allreduce
+                    and self.input_layernorm.tp_size > 1
+                ):
+                    m = hidden_states.shape[0]
+                    n_qkva = self.self_attn.fused_qkv_a_proj.weight.shape[0]
+                    if is_prezero_free(_pz_ctx.graph_bs, n_qkva):
+                        zero_fill = torch.empty(
+                            m,
+                            n_qkva,
+                            dtype=hidden_states.dtype,
+                            device=hidden_states.device,
+                        )
+                        qkva_prezero = zero_fill
+                hidden_states, residual = self.input_layernorm(
+                    hidden_states, residual, zero_fill=zero_fill
+                )
 
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
+            qkva_prezero=qkva_prezero,
         )
 
         if hidden_states.dtype == torch.float16:

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1952,6 +1952,7 @@ class DeepseekV2MLAAttention(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         qkva_prezero: Optional[torch.Tensor] = None,
+        qb_prezero: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         hidden_states_scale = None
         if isinstance(hidden_states, tuple):
@@ -2046,12 +2047,16 @@ class DeepseekV2MLAAttention(nn.Module):
                 self.indexer_rope_emb,
             )
 
+        # Only thread the q_b prezero buffer when it is actually allocated, so
+        # the prezero-off path (and non-atom attention backends) stays unchanged.
+        mla_kwargs = {} if qb_prezero is None else {"qb_prezero": qb_prezero}
         return self.mla_attn(
             hidden_states_or_q_c,
             kv_c_normed,
             k_pe,
             positions,
             hidden_states_or_q_c_scale,
+            **mla_kwargs,
         )
 
 
@@ -2180,6 +2185,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         # Self Attention
         zero_fill = None
         qkva_prezero = None
+        qb_prezero = None
         _pz_ctx = (
             get_forward_context().context if envs.ATOM_ENABLE_SPLITK_PREZERO else None
         )
@@ -2248,9 +2254,33 @@ class DeepseekV2DecoderLayer(nn.Module):
                     and self.input_layernorm.fused_allreduce
                     and self.input_layernorm.tp_size > 1
                 ):
+                    # Zero one buffer for free on the fused allreduce-rmsnorm's
+                    # idle CUs, then hand its contiguous blocks to the qkv_a and
+                    # (optionally) q_b split-K GEMMs to atomic-add into. q_b rides
+                    # the same input_layernorm zeroing even though its own
+                    # preceding norm (q_a_layernorm) is a plain local RMSNorm.
                     m = hidden_states.shape[0]
                     n_qkva = self.self_attn.fused_qkv_a_proj.weight.shape[0]
-                    if is_prezero_free(_pz_ctx.graph_bs, n_qkva):
+                    q_b_proj = getattr(self.self_attn, "q_b_proj", None)
+                    # q_b prezero only covers the bf16 q up-proj; a quantized
+                    # q_b_proj keeps its own quant GEMM (no prezero).
+                    n_qb = (
+                        q_b_proj.weight.shape[0]
+                        if q_b_proj is not None
+                        and q_b_proj.quant_type.value == QuantType.No.value
+                        else 0
+                    )
+                    if n_qb and is_prezero_free(_pz_ctx.graph_bs, n_qkva + n_qb):
+                        zero_fill = torch.empty(
+                            m,
+                            n_qkva + n_qb,
+                            dtype=hidden_states.dtype,
+                            device=hidden_states.device,
+                        )
+                        flat = zero_fill.view(-1)
+                        qkva_prezero = flat[: m * n_qkva].view(m, n_qkva)
+                        qb_prezero = flat[m * n_qkva :].view(m, n_qb)
+                    elif is_prezero_free(_pz_ctx.graph_bs, n_qkva):
                         zero_fill = torch.empty(
                             m,
                             n_qkva,
@@ -2266,6 +2296,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             positions=positions,
             hidden_states=hidden_states,
             qkva_prezero=qkva_prezero,
+            qb_prezero=qb_prezero,
         )
 
         if hidden_states.dtype == torch.float16:

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -73,6 +73,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION", "1") == "1"
     ),
+    "ATOM_ENABLE_SPLITK_PREZERO": lambda: (
+        os.getenv("ATOM_ENABLE_SPLITK_PREZERO", "0") == "1"
+    ),
     # Replicate the EAGLE3 draft vocab embedding on every TP rank (full table per
     # rank, local lookup) instead of sharding it — eliminates the post-embedding
     # all-reduce. The draft embed is independent of the (sharded) lm_head.


### PR DESCRIPTION
## Motivation

The split-K bf16 GEMMs on the MoE decode critical path — the fused `q_a + kv_a`
down-projection (N=2112, K=7168), the `q_b` up-projection, and the MoE router
gate — accumulate cross-block partial sums into the output `C` through
packed-bf16 global atomics, which requires `C` to be zero-initialized first. To
stay CUDA-graph safe, that zeroing happens inside the GEMM kernel, costing two
device-wide synchronizations per launch. In decode this is a **latency** cost —
on the order of 1-2us of pure latency, paid every layer, every step, largely
independent of problem size.

The companion aiter PR ([ROCm/aiter#4023](https://github.com/ROCm/aiter/pull/4023))
makes that zeroing relocatable: a preceding kernel can
zero the GEMM's output buffer, and the kernel-launch boundary already orders the
GEMM after it, so the GEMM atomic-adds straight in with no zero-init and no
handshake — no extra synchronization at all. The kernel that precedes these
GEMMs is the fused allreduce + RMSNorm that produces their input; it launches
one CTA per token, so in decode it leaves most CUs idle and can ride zero-fill
blocks along on them for free.

This PR is the **ATOM-side integration** of that capability: it allocates the
GEMM output buffers, has the fused AR-RMSNorm zero them on its idle CUs, and runs
the GEMMs as a `zero_init=False` atomic-add into them — for `qkv_a`, `q_b`, and
the MoE gate in DeepSeek-V3/V4 and Kimi-K2 decode.

> Stacked on the aiter prezero PR
> [ROCm/aiter#4023](https://github.com/ROCm/aiter/pull/4023) (the `zero_fill`
> ride-along, the `ZERO_INIT` skip path, and the `tgemm.mm` `zero_init`/`out=`
> passthrough live there). Please merge that first.

## Technical Details

Gated behind `ATOM_ENABLE_SPLITK_PREZERO` (default **off**); when off, the path
is byte-identical to before. Gating reads envs directly and derives buffer widths
from weights — no new stored module state.

**1. Wire prezero into the fused allreduce-RMSNorm (qkv_a).**
`RMSNorm.forward` gains an optional `zero_fill` argument forwarded to the fused
AR op, so the decoder layer can hand it a buffer to zero on idle CUs.
`_mm_prezero_` is added as a `torch.compile`-safe custom op
(`tgemm.mm(a, w, bias, zero_init=False, out=buf)`; mutates `out`, returns
`None`, since a custom op may not return an alias of a mutated input).
`MLAAttention` runs the bf16 `qkv_a` GEMM as a prezero atomic-add into the
`input_layernorm`-zeroed buffer. The path is taken only when
`is_prezero_free(graph_bs, n)` reports the zero-fill rides for free
(AR CTAs + zero CTAs < CU count), using the padded cudagraph token count,
requiring the fused-allreduce norm and `tp_size > 1`, and skipped on prefill.

**2. MoE router gate prezero.**
The single-stream MoE path runs the router gate GEMM as a prezero atomic-add into
a buffer zeroed by the `post_attention_layernorm` fused AR-RMSNorm, under the
same `is_prezero_free` gating. Dual-stream is left unchanged: it runs inside an
opaque custom op, so no gate buffer is threaded there.

**3. Extend prezero to the `q_b` up-projection via a shared buffer.**
`q_b` has no fused AR-RMSNorm of its own (`q_a_layernorm` is a plain local
RMSNorm), so it cannot get a free-zeroed buffer directly. Instead the
`input_layernorm` buffer is widened to `[M, N_qkva + N_qb]` and split into two
contiguous blocks: `qkv_a` atomic-adds into the first, `q_b` into the second, so
`q_b` rides the same `input_layernorm` zeroing. The wider half is gated on
`is_prezero_free(combined width)` and a bf16 (non-quantized) `q_b_proj`, falling
back to qkv_a-only when the wider zeroing would not fit — no regression vs. the
qkv_a path. `qb_prezero` is threaded as an optional mutable tensor arg through
`MLAAttention.forward -> unified_attention_with_output_base -> MLA.forward_impl
-> _q_proj_and_k_up_proj`, and passed only when allocated, keeping the
prezero-off path and non-ATOM attention backends byte-identical.

## Test Plan

End-to-end evaluation on the full model (the per-kernel halves are covered by the
aiter PR's standalone microbench).

Test environment:

- GPU: MI355X (gfx950)
- ROCm: 7.2.3

**Accuracy.** Prezero is mathematically identical to the baseline — it only
relocates where `C` is zeroed — so model output must be unchanged. Validated
end-to-end (GSM8K via `lm_eval`) with `ATOM_ENABLE_SPLITK_PREZERO=1` vs the
default, expecting no accuracy regression.

**End-to-end serving.** Kimi-K2.5 MXFP4 decode serving on the random dataset,
isl=8192 / osl=1024, random range ratio=0.8, concurrency 4 to 128, comparing the
baseline config against the prezero-enabled config. We report decode throughput /
per-token latency across the concurrency sweep, confirming the in-kernel
zero-init synchronizations are removed from the decode critical path with no
quality loss.

## Test Result

<!-- fill in: GSM8K accuracy (off vs on) + decode throughput / latency deltas across concurrency -->
