### PR TITLE
feat: report prefix-cache hits via prompt_tokens_details.cached_tokens

### DIFF
--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -74,6 +74,7 @@ async def stream_chat_response(
     """
     num_tokens_input = num_prompt_tokens
     num_tokens_output = 0
+    num_cached_tokens = 0
     reasoning_filter = ReasoningFilter()
     tool_parser = ToolCallStreamParser(tools=tools)
     has_tool_calls = False
@@ -87,6 +88,9 @@ async def stream_chat_response(
         chunk_data = await stream_queue.get()
         new_text = chunk_data["text"]
         num_tokens_output += len(chunk_data.get("token_ids", []))
+        _ct = chunk_data.get("num_cached_tokens", 0)
+        if _ct:
+            num_cached_tokens = _ct
 
         if "kv_transfer_params" in chunk_data:
             kv_transfer_params_value = chunk_data["kv_transfer_params"]
@@ -149,6 +153,7 @@ async def stream_chat_response(
         "prompt_tokens": num_tokens_input,
         "completion_tokens": num_tokens_output,
         "total_tokens": num_tokens_input + num_tokens_output,
+        "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
     }
     usage_chunk = {
         "id": request_id,
@@ -220,6 +225,9 @@ def build_chat_response(
             "completion_tokens": final_output["num_tokens_output"],
             "total_tokens": final_output["num_tokens_input"]
             + final_output["num_tokens_output"],
+            "prompt_tokens_details": {
+                "cached_tokens": final_output.get("num_cached_tokens", 0)
+            },
             "ttft_s": round(final_output.get("ttft", 0.0), 4),
             "tpot_s": round(final_output.get("tpot", 0.0), 4),
             "latency_s": round(final_output.get("latency", 0.0), 4),
@@ -264,6 +272,9 @@ def build_chat_response_multi(
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": prompt_tokens + completion_tokens,
+            "prompt_tokens_details": {
+                "cached_tokens": final_outputs[0].get("num_cached_tokens", 0)
+            },
             "ttft_s": round(
                 max((out.get("ttft", 0.0) for out in final_outputs), default=0.0), 4
             ),
@@ -306,6 +317,7 @@ async def stream_chat_response_fanout(
     has_tool_calls = [False] * n
     finished = [False] * n
     kv_transfer_params_value = None
+    num_cached_tokens = 0
 
     for i in range(n):
         yield create_chat_chunk(request_id, model, delta={"role": "assistant"}, index=i)
@@ -317,6 +329,9 @@ async def stream_chat_response_fanout(
             continue
         new_text = chunk_data["text"]
         num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
+        _ct = chunk_data.get("num_cached_tokens", 0)
+        if _ct:
+            num_cached_tokens = _ct
 
         if "kv_transfer_params" in chunk_data:
             kv_transfer_params_value = chunk_data["kv_transfer_params"]
@@ -388,6 +403,7 @@ async def stream_chat_response_fanout(
         "completion_tokens": sum(num_tokens_output),
         "total_tokens": num_tokens_input + sum(num_tokens_output),
         "num_choices": n,
+        "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
     }
     usage_chunk = {
         "id": request_id,


### PR DESCRIPTION
## What
The OpenAI-compatible `/v1/chat/completions` endpoint does not surface the engine's prefix-cache hit count in the response `usage`. OpenAI-style clients (and benchmarking tools that derive cache-hit rate from `usage`) therefore cannot observe prefix-cache effectiveness. The Anthropic `/v1/messages` endpoint already reports this via `cache_read_input_tokens`.

## Change
Add the standard OpenAI field `usage.prompt_tokens_details.cached_tokens` across all four chat response paths in `serving_chat.py`:
- `stream_chat_response` (single, streaming)
- `build_chat_response` (single, non-streaming)
- `build_chat_response_multi` (n>1, non-streaming)
- `stream_chat_response_fanout` (n>1, streaming)

The value comes from the engine's existing per-request `num_cached_tokens` (already emitted on the prefill chunk / final output) — no new engine work.

## Test
- `python -m py_compile` passes.
- Verified on a running server: sending an identical long prompt twice, the second response returns `usage.prompt_tokens_details.cached_tokens` ~= `prompt_tokens`, matching the server-side `[Cache Stats] Hit rate` log and the Anthropic endpoint's `cache_read_input_tokens`.