### PR TITLE
[Fix] MiniMax-M3 EAGLE3+PD accuracy: make cross-layer top-k reuse CUD…

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -1261,12 +1261,36 @@ class SparseMHAPagedAttentionImpl(PagedAttentionImpl):
             return None
         return entry["value"]
 
+    def _persist_topk_value(self, value: tuple) -> tuple:
+        # Skip layers reuse this (topk_idx, sparse_bt, sparse_ctx) after the
+        # CUDAGraph-captured layers in between, but the kernel's torch.empty
+        # outputs are not stable across that boundary. Copy into per-impl
+        # persistent buffers (one per shape, held on self) so the reuse reads a
+        # fixed address.
+        bufs = getattr(self, "_persist_topk_buffers", None)
+        if bufs is None:
+            bufs = {}
+            self._persist_topk_buffers = bufs
+        out = []
+        for i, t in enumerate(value):
+            if t is None:
+                out.append(None)
+                continue
+            bkey = (i, tuple(t.shape), t.dtype)
+            buf = bufs.get(bkey)
+            if buf is None:
+                buf = torch.empty_like(t)
+                bufs[bkey] = buf
+            buf.copy_(t)
+            out.append(buf)
+        return tuple(out)
+
     def _store_cached_topk(self, sparse_metadata, key: tuple, value: tuple):
         state = self._topk_cache_state(sparse_metadata)
         if state is not None:
             state["topk"] = {
                 "key": key,
-                "value": value,
+                "value": self._persist_topk_value(value),
                 "layer_num": self.layer_num,
                 "sparse_layer_ordinal": self.sparse_layer_ordinal,
             }


### PR DESCRIPTION
…AGraph-safe

Cross-layer sparse top-k reuse (index_topk_freq>1) cached the compute layer's (topk_idx, sparse_bt, sparse_ctx) — transient torch.empty outputs of the sparse-attention op. Skip layers reuse them after the CUDAGraph- captured layers in between, where those tensors are not stable, corrupting the reused block selection. For q>1 EAGLE3 spec-verify this biases the verify logits and drops GSM8K ~14pt (0.80 vs 0.94) under PD.

Fix: _store_cached_topk copies the reused value into per-impl persistent buffers (one per shape, held on self) so skip layers read a fixed address.

Verified on MI355 1P1D PD: GSM8K c64 0.80 -> 0.9454 with CUDAGraph ON.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
