### PR TITLE
Add feature to parse Hermes <tool_call>{json}</tool_call> tool calls

### DIFF
--- a/atom/entrypoints/openai/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser.py
@@ -21,6 +21,12 @@ Two on-the-wire formats are auto-detected and normalized into the OpenAI
     </function>
     </tool_call>
 
+3. Hermes format (Qwen3 default chat template)::
+
+    <tool_call>
+    {"name": "NAME", "arguments": {...}}
+    </tool_call>
+
 The Qwen XML carries no value types, so when the request's ``tools`` schema is
 supplied each parameter is coerced to the declared JSON-Schema type (int, float,
 bool, null, object, array); otherwise it is left as a string. This mirrors the
@@ -74,6 +80,87 @@ _QWEN_PARAM_RE = re.compile(
 def _is_qwen_xml(text: str) -> bool:
     """Detect the Qwen3 XML tool-call format (and not the Kimi token format)."""
     return _QWEN_TOOL_PREFIX in text and "<|tool_calls_section_begin|>" not in text
+
+
+# ---------------------------------------------------------------------------
+# Hermes tool-call format (Qwen3 default chat template, NousResearch Hermes)
+#   <tool_call>
+#   {"name": "NAME", "arguments": {...}}
+#   </tool_call>
+# JSON body inside <tool_call> rather than the qwen3_coder <function=> XML.
+# ---------------------------------------------------------------------------
+
+_HERMES_TOOL_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+_HERMES_TOOL_UNCLOSED_RE = re.compile(r"<tool_call>\s*(\{.*)$", re.DOTALL)
+
+
+def _is_hermes(text: str) -> bool:
+    """Detect the Hermes JSON-in-<tool_call> format (not qwen_coder XML / Kimi)."""
+    return (
+        "<tool_call>" in text
+        and _QWEN_TOOL_PREFIX not in text
+        and "<|tool_calls_section_begin|>" not in text
+    )
+
+
+def _hermes_call_from_obj(obj: Any) -> Optional[ToolCall]:
+    if not isinstance(obj, dict):
+        return None
+    name = obj.get("name")
+    if not name:
+        return None
+    args = obj.get("arguments", obj.get("parameters", {}))
+    if not isinstance(args, str):
+        args = json.dumps(args, ensure_ascii=False)
+    return ToolCall(
+        id=_unique_tool_call_id(),
+        type="function",
+        function={"name": name, "arguments": args},
+    )
+
+
+def _parse_hermes(text: str, tools: Optional[list] = None) -> Tuple[str, List[ToolCall]]:
+    """Parse Hermes ``<tool_call>{json}</tool_call>`` blocks into ToolCalls."""
+    first = text.find("<tool_call>")
+    content = text[:first] if first != -1 else text
+    tool_calls: List[ToolCall] = []
+    for m in _HERMES_TOOL_RE.finditer(text):
+        try:
+            obj = json.loads(m.group(1))
+        except Exception:
+            continue
+        tc = _hermes_call_from_obj(obj)
+        if tc is not None:
+            tool_calls.append(tc)
+    if not tool_calls:
+        # Tolerate an unclosed trailing block (streaming truncation).
+        um = _HERMES_TOOL_UNCLOSED_RE.search(text)
+        if um:
+            try:
+                obj = json.loads(um.group(1))
+                tc = _hermes_call_from_obj(obj)
+                if tc is not None:
+                    tool_calls.append(tc)
+            except Exception:
+                pass
+    return content.strip(), tool_calls
+
+
+def _is_xmlish(text: str) -> bool:
+    """Detect either qwen_coder XML or Hermes JSON tool calls (not Kimi tokens)."""
+    return (
+        _QWEN_TOOL_PREFIX in text or "<tool_call>" in text
+    ) and "<|tool_calls_section_begin|>" not in text
+
+
+def _parse_xmlish(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCall]]:
+    """Parse a <tool_call> region as qwen_coder XML, falling back to Hermes JSON."""
+    content, calls = _parse_qwen_xml(text, tools)
+    if calls:
+        return content, calls
+    if "<tool_call>" in text:
+        return _parse_hermes(text, tools)
+    return content, calls
 
 
 def _build_param_types(tools: Optional[list]) -> Dict[str, Dict[str, Any]]:
@@ -198,9 +285,9 @@ def parse_tool_calls(
         Tuple of (content_text, list_of_tool_calls). ``content_text`` has the
         tool-call sections removed.
     """
-    # Qwen3 XML format
-    if _is_qwen_xml(text):
-        return _parse_qwen_xml(text, tools)
+    # Qwen3 XML (qwen_coder) or Hermes (<tool_call>{json}</tool_call>) format
+    if _is_xmlish(text):
+        return _parse_xmlish(text, tools)
 
     # Kimi-K2 special-token format
     section_match = re.search(
@@ -341,7 +428,7 @@ class ToolCallStreamParser:
                 self.buf = ""
             return results
         # state 1: parse the complete (or trailing) tool-call block.
-        _content, tool_calls = _parse_qwen_xml(self.buf, self.tools)
+        _content, tool_calls = _parse_xmlish(self.buf, self.tools)
         self.buf = ""
         for tc in tool_calls:
             tc.id = _unique_tool_call_id()

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -115,6 +115,51 @@ class TestParseToolCalls:
         assert tool_calls[0].function["arguments"] == args
 
 
+class TestParseHermesToolCalls:
+    """Hermes ``<tool_call>{json}</tool_call>`` format (Qwen3 default template)."""
+
+    def test_single_hermes_tool_call(self):
+        text = (
+            "I'll check the weather."
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+        )
+        content, tool_calls = parse_tool_calls(text)
+        assert content == "I'll check the weather."
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function["name"] == "get_weather"
+        assert '"city"' in tool_calls[0].function["arguments"]
+        assert tool_calls[0].type == "function"
+
+    def test_multiple_hermes_tool_calls(self):
+        text = (
+            '<tool_call>\n{"name": "search", "arguments": {"q": "test"}}\n</tool_call>'
+            '<tool_call>\n{"name": "fetch", "arguments": {"url": "http://example.com"}}\n</tool_call>'
+        )
+        content, tool_calls = parse_tool_calls(text)
+        assert len(tool_calls) == 2
+        assert tool_calls[0].function["name"] == "search"
+        assert tool_calls[1].function["name"] == "fetch"
+
+    def test_hermes_empty_arguments(self):
+        text = '<tool_call>\n{"name": "list_files", "arguments": {}}\n</tool_call>'
+        content, tool_calls = parse_tool_calls(text)
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function["name"] == "list_files"
+        assert tool_calls[0].function["arguments"] == "{}"
+
+    def test_hermes_unclosed_block(self):
+        text = '<tool_call>\n{"name": "run", "arguments": {"cmd": "ls"}}'
+        content, tool_calls = parse_tool_calls(text)
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function["name"] == "run"
+
+    def test_hermes_does_not_break_qwen_xml(self):
+        text = "<tool_call>\n<function=exec>\n<parameter=cmd>ls</parameter>\n</function>\n</tool_call>"
+        content, tool_calls = parse_tool_calls(text)
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function["name"] == "exec"
+
+
 # ============================================================================
 # ToolCallStreamParser Tests
 # ============================================================================
@@ -211,3 +256,26 @@ class TestToolCallStreamParser:
         assert len(starts) == 1
         ends = [d for t, d in results if t == "tool_call_end"]
         assert len(ends) == 1  # flush should emit tool_call_end
+
+    def test_hermes_tool_call_streaming(self):
+        tokens = [
+            "Let me read that.",
+            "<tool_",
+            'call>\n{"name": "read_file"',
+            ', "arguments": {"path": "/etc/hos',
+            'ts"}}\n</tool_call>',
+        ]
+        results = self._run_parser(tokens)
+        content = "".join(d for t, d in results if t == "content")
+        assert "Let me read that." in content
+
+        starts = [d for t, d in results if t == "tool_call_start"]
+        assert len(starts) == 1
+        assert starts[0]["function"]["name"] == "read_file"
+
+        args = [d for t, d in results if t == "tool_call_args"]
+        assert len(args) == 1
+        assert "/etc/hosts" in args[0]["function"]["arguments"]
+
+        ends = [d for t, d in results if t == "tool_call_end"]
+        assert len(ends) == 1


### PR DESCRIPTION
The tool-call parser handled two formats: the Kimi-K2 special-token format and the Qwen3 qwen_coder XML format (<function=NAME>...). Models that emit the Hermes format used by the Qwen3 default chat template --

    <tool_call>
    {"name": "NAME", "arguments": {...}}
    </tool_call>

-- fell through both paths, so the raw <tool_call> text leaked into the assistant message instead of being parsed into a tool_use call. Clients (e.g. Claude Code over /v1/messages) then saw no tool call and the loop stalled.

Add a Hermes parser (JSON body inside <tool_call>) and route <tool_call> regions through a combined handler that tries qwen_coder XML first and falls back to Hermes JSON, for both the non-streaming parse_tool_calls() and the streaming ToolCallStreamParser flush path. The Kimi token format is untouched. Tolerates an unclosed trailing block for streaming truncation.

Verified end-to-end with Qwen3-8B on ATOM: non-stream tool_use, multi-turn tool_result round-trip, and streaming input_json_delta all produce correct Anthropic tool_use blocks. Adds unit tests for single, multiple, empty-arg, unclosed, and streaming Hermes calls, plus regressions asserting the qwen_coder XML and Kimi paths still parse.

<img width="1853" height="559" alt="image" src="https://github.com/user-attachments/assets/106f0b1f-ceb5-4f56-ae72-ceb806df6133" />
