### PR TITLE
[atom-sgl-benchmark] Ensure scheduled SGLang benchmarks use nightly Docker images

### DIFF
--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -306,7 +306,7 @@
   {
     "model_name": "MI308 Qwen3-32B-FP8 TP1",
     "model_path": "Qwen/Qwen3-32B-FP8",
-    "extraArgs": "--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
+    "extraArgs": "--tensor-parallel-size 1 --page-size 16 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
     "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
     "runner": "atom-mi308-8gpu-plugins-benchmark",
     "test_level": "nightly",
@@ -318,7 +318,7 @@
   {
     "model_name": "MI308 Qwen3-32B-FP8 TP8",
     "model_path": "Qwen/Qwen3-32B-FP8",
-    "extraArgs": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
+    "extraArgs": "--tensor-parallel-size 8 --page-size 16 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
     "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
     "runner": "atom-mi308-8gpu-plugins-benchmark",
     "test_level": "nightly",

--- a/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
@@ -211,7 +211,8 @@ jobs:
           MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
           echo "Using model cache backend: ${MODEL_CACHE_DESC}"
 
-          cat > /tmp/sglang_env_file.txt << 'EOF'
+          SGLANG_ENV_FILE="${RUNNER_TEMP:-${GITHUB_WORKSPACE:-$PWD}}/sglang_env_file.txt"
+          cat > "$SGLANG_ENV_FILE" << 'EOF'
           ${{ matrix.env_vars }}
           EOF
 
@@ -225,7 +226,7 @@ jobs:
             --security-opt seccomp=unconfined \
             --ulimit memlock=-1 \
             --ulimit stack=67108864 \
-            --env-file /tmp/sglang_env_file.txt \
+            --env-file "$SGLANG_ENV_FILE" \
             -e HF_TOKEN="${HF_TOKEN:-}" \
             --name "$CONTAINER_NAME" \
             "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}"

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -119,11 +119,21 @@ on:
         required: false
         type: boolean
         default: false
-      run_mi308_all:
-        description: "Run all MI308 gsm8k accuracy cases on atom-mi308-8gpu-plugins-benchmark"
+      model_mi308:
+        description: "Manual MI308 accuracy model selection"
         required: false
-        type: boolean
-        default: false
+        type: choice
+        default: none
+        options:
+          - none
+          - all
+          - MI308 Qwen3.5-397B-A17B-FP8 TP4
+          - MI308 Qwen3.5-397B-A17B-FP8 TP8
+          - MI308 Qwen3.5-35B-A3B-FP8 TP1
+          - MI308 Qwen3-32B-FP8 TP1
+          - MI308 Qwen3-32B-FP8 TP8
+          - MI308 GLM-5.1-FP8 TP8
+          - MI308 DeepSeek-V4-Flash
       rebuild_atom_base_from_dockerfile:
         description: "Full build image before validation"
         required: false
@@ -199,7 +209,7 @@ jobs:
           RUN_DSV32_FP8_TP8: ${{ inputs.run_dsv32_fp8_tp8 }}
           RUN_GLM51_FP8_TP8: ${{ inputs.run_glm51_fp8_tp8 }}
           RUN_MI355_ALL: ${{ inputs.run_mi355_all }}
-          RUN_MI308_ALL: ${{ inputs.run_mi308_all }}
+          MODEL_MI308: ${{ inputs.model_mi308 || 'none' }}
           REBUILD_ATOM_BASE_FROM_DOCKERFILE: ${{ inputs.rebuild_atom_base_from_dockerfile }}
         run: |
           set -euo pipefail
@@ -213,7 +223,7 @@ jobs:
 
           event = os.environ["GITHUB_EVENT_NAME"]
           run_mi355_all = os.environ.get("RUN_MI355_ALL", "").lower() == "true"
-          run_mi308_all = os.environ.get("RUN_MI308_ALL", "").lower() == "true"
+          model_mi308 = os.environ.get("MODEL_MI308", "none")
           models = [
               {
                   "toggle_env": "RUN_DSV4_PREFIX_CACHE_TP8",
@@ -406,7 +416,7 @@ jobs:
               },
           ]
 
-          # MI308 gsm8k accuracy: nightly schedule only (no workflow_dispatch inputs; GitHub limits 25 inputs).
+          # MI308 gsm8k accuracy: nightly schedule by default; manual runs select one case or all cases via model_mi308.
           mi308_models = [
               {
                   "model_name": "MI308 Qwen3.5-397B-A17B-FP8 TP4",
@@ -475,8 +485,12 @@ jobs:
           for model in models:
               toggle = model.get("toggle_env")
               if toggle is None:
-                  # MI308-only rows: nightly schedule, or manual when run_mi308_all is checked.
-                  enabled = (event != "workflow_dispatch") or run_mi308_all
+                  # MI308-only rows: all cases on nightly schedule; manual runs select one case or all cases.
+                  enabled = (
+                      event != "workflow_dispatch"
+                      or model_mi308 == "all"
+                      or model["model_name"] == model_mi308
+                  )
               else:
                   enabled = event != "workflow_dispatch" or run_mi355_all or os.environ.get(toggle, "").lower() == "true"
               if enabled:

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -435,7 +435,7 @@ jobs:
               {
                   "model_name": "MI308 Qwen3-32B-FP8 TP1",
                   "model_path": "Qwen/Qwen3-32B-FP8",
-                  "extra_args": "--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
+                  "extra_args": "--tensor-parallel-size 1 --page-size 16 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.8,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
                   "runner": "atom-mi308-8gpu-plugins-benchmark",
@@ -443,7 +443,7 @@ jobs:
               {
                   "model_name": "MI308 Qwen3-32B-FP8 TP8",
                   "model_path": "Qwen/Qwen3-32B-FP8",
-                  "extra_args": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
+                  "extra_args": "--tensor-parallel-size 8 --page-size 16 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
                   "accuracy_test_threshold": 0.8,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
                   "runner": "atom-mi308-8gpu-plugins-benchmark",

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -111,8 +111,214 @@ on:
         default: ""
 
 jobs:
+  wait-for-scheduled-sglang-image:
+    name: Wait for scheduled SGLang Docker image
+    runs-on: ubuntu-latest
+    outputs:
+      scheduled_sglang_image: ${{ steps.wait.outputs.scheduled_sglang_image }}
+      scheduled_sglang_tag: ${{ steps.wait.outputs.scheduled_sglang_tag }}
+      scheduled_sglang_digest: ${{ steps.wait.outputs.scheduled_sglang_digest }}
+      scheduled_sglang_resolution: ${{ steps.wait.outputs.scheduled_sglang_resolution }}
+    steps:
+      - name: Checkout selected branch
+        uses: actions/checkout@v6
+
+      - name: Wait for today's SGLang nightly tag
+        id: wait
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          WAIT_FOR_SGLANG_IMAGE: ${{ github.event_name == 'schedule' && github.ref_name == 'main' && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${WAIT_FOR_SGLANG_IMAGE}" != "true" ]]; then
+            echo "Not a scheduled main run; skipping SGLang nightly image wait."
+            {
+              echo "scheduled_sglang_image="
+              echo "scheduled_sglang_tag="
+              echo "scheduled_sglang_digest="
+              echo "scheduled_sglang_resolution="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          python3 - <<'PY'
+          import base64
+          import json
+          import os
+          import re
+          import sys
+          import time
+          from datetime import datetime
+          from pathlib import Path
+          from urllib.error import HTTPError, URLError
+          from urllib.parse import quote, urlencode
+          from urllib.parse import urljoin
+          from urllib.request import Request, urlopen
+          from zoneinfo import ZoneInfo
+
+          repository = "rocm/atom-dev"
+          auth_url = "https://auth.docker.io/token"
+          registry_url = "https://registry-1.docker.io"
+          manifest_accept = ", ".join(
+              (
+                  "application/vnd.oci.image.index.v1+json",
+                  "application/vnd.docker.distribution.manifest.list.v2+json",
+                  "application/vnd.oci.image.manifest.v1+json",
+                  "application/vnd.docker.distribution.manifest.v2+json",
+              )
+          )
+
+          text = Path(".github/workflows/docker-release.yaml").read_text(encoding="utf-8")
+          version_match = re.search(r'^\s*SGLANG_VERSION:\s*"([^"]+)"', text, re.MULTILINE)
+          if not version_match:
+              raise SystemExit("Failed to read SGLANG_VERSION from .github/workflows/docker-release.yaml")
+
+          today = datetime.now(ZoneInfo("Asia/Shanghai")).strftime("%Y%m%d")
+          version = version_match.group(1)
+          tag = f"sglang-v{version}-nightly_{today}"
+          nightly_pattern = re.compile(r"^sglang-v(?P<version>.+)-nightly_(?P<date>\d{8})$")
+
+          def request(url, *, headers=None):
+              req = Request(url, headers=headers or {})
+              with urlopen(req, timeout=30) as response:
+                  return response.read(), response.headers
+
+          def get_token():
+              query = urlencode(
+                  {
+                      "service": "registry.docker.io",
+                      "scope": f"repository:{repository}:pull",
+                  }
+              )
+              headers = {"User-Agent": "ATOM SGLang Benchmark Image Gate/1.0"}
+              username = os.environ.get("DOCKER_USERNAME")
+              password = os.environ.get("DOCKER_PASSWORD")
+              if username and password:
+                  creds = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+                  headers["Authorization"] = f"Basic {creds}"
+              body, _ = request(f"{auth_url}?{query}", headers=headers)
+              token = json.loads(body.decode("utf-8")).get("token")
+              if not token:
+                  raise RuntimeError(f"Registry token response did not include a token for {repository}")
+              return token
+
+          def get_digest(token, image_tag):
+              manifest_url = f"{registry_url}/v2/{repository}/manifests/{quote(image_tag, safe='')}"
+              _, headers = request(
+                  manifest_url,
+                  headers={
+                      "Authorization": f"Bearer {token}",
+                      "Accept": manifest_accept,
+                      "User-Agent": "ATOM SGLang Benchmark Image Gate/1.0",
+                  },
+              )
+              digest = headers.get("Docker-Content-Digest") or headers.get("docker-content-digest")
+              if not digest:
+                  raise RuntimeError(f"Registry did not return Docker-Content-Digest for {repository}:{image_tag}")
+              return str(digest).strip()
+
+          def next_page_url(base_url, link_header):
+              if not link_header:
+                  return None
+              for part in link_header.split(","):
+                  match = re.match(r'\s*<([^>]+)>\s*;\s*rel="next"\s*', part)
+                  if match:
+                      return urljoin(base_url, match.group(1))
+              return None
+
+          def list_tags(token):
+              tags = []
+              url = f"{registry_url}/v2/{repository}/tags/list?n=1000"
+              while url:
+                  body, headers = request(
+                      url,
+                      headers={
+                          "Authorization": f"Bearer {token}",
+                          "User-Agent": "ATOM SGLang Benchmark Image Gate/1.0",
+                      },
+                  )
+                  payload = json.loads(body.decode("utf-8"))
+                  tags.extend(payload.get("tags") or [])
+                  url = next_page_url(url, headers.get("Link"))
+              return tags
+
+          def latest_recent_nightly_tag(token):
+              candidates = []
+              for candidate in list_tags(token):
+                  match = nightly_pattern.match(candidate)
+                  if not match:
+                      continue
+                  candidates.append(
+                      (
+                          match.group("date"),
+                          1 if match.group("version") == version else 0,
+                          candidate,
+                      )
+                  )
+              if not candidates:
+                  raise RuntimeError(f"No SGLang nightly tags were found in {repository}")
+              return max(candidates)[2]
+
+          def write_selected_image(image_tag, digest, resolution):
+              image = f"{repository}:{image_tag}@{digest}"
+              output_path = os.environ["GITHUB_OUTPUT"]
+              with open(output_path, "a", encoding="utf-8") as fh:
+                  fh.write(f"scheduled_sglang_image={image}\n")
+                  fh.write(f"scheduled_sglang_tag={image_tag}\n")
+                  fh.write(f"scheduled_sglang_digest={digest}\n")
+                  fh.write(f"scheduled_sglang_resolution={resolution}\n")
+              with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+                  fh.write("### Scheduled SGLang image\n")
+                  fh.write(f"- Image: `{image}`\n")
+                  fh.write(f"- Tag: `{image_tag}`\n")
+                  fh.write(f"- Digest: `{digest}`\n")
+                  fh.write(f"- Resolution: `{resolution}`\n")
+              return image
+
+          token = get_token()
+          timeout_seconds = 2 * 60 * 60
+          interval_seconds = 5 * 60
+          deadline = time.monotonic() + timeout_seconds
+          last_error = ""
+
+          print(f"Waiting up to {timeout_seconds // 60} minutes for {repository}:{tag}")
+          while True:
+              try:
+                  digest = get_digest(token, tag)
+                  image = write_selected_image(tag, digest, "scheduled-nightly-tag")
+                  print(f"Found scheduled SGLang image: {image}")
+                  break
+              except HTTPError as exc:
+                  last_error = f"HTTP {exc.code}"
+                  if exc.code in (401, 403):
+                      token = get_token()
+                  elif exc.code != 404:
+                      print(f"Warning: failed to check {repository}:{tag}: {last_error}", file=sys.stderr)
+              except (RuntimeError, URLError) as exc:
+                  last_error = str(exc)
+                  print(f"Warning: failed to check {repository}:{tag}: {last_error}", file=sys.stderr)
+
+              remaining = deadline - time.monotonic()
+              if remaining <= 0:
+                  print(
+                      f"Timed out waiting for scheduled SGLang image {repository}:{tag}. "
+                      f"Falling back to the latest recent SGLang nightly tag. Last error: {last_error or 'not found'}"
+                  )
+                  fallback_tag = latest_recent_nightly_tag(token)
+                  digest = get_digest(token, fallback_tag)
+                  image = write_selected_image(fallback_tag, digest, "recent-nightly-tag")
+                  print(f"Using latest recent SGLang image: {image}")
+                  break
+              sleep_for = min(interval_seconds, remaining)
+              print(f"{repository}:{tag} is not available yet; retrying in {int(sleep_for)} seconds.")
+              time.sleep(sleep_for)
+          PY
+
   resolve-atom-source:
     name: Resolve ATOM benchmark source
+    needs: [wait-for-scheduled-sglang-image]
     runs-on: ubuntu-latest
     outputs:
       atom_repository: ${{ steps.resolve.outputs.atom_repository }}
@@ -141,6 +347,10 @@ jobs:
           INPUT_UPLOAD_TO_CUSTOM_DASHBOARD: ${{ inputs.upload_to_custom_dashboard }}
           INPUT_WORKLOAD_LABEL: ${{ inputs.benchmark_suite || 'SGLang-OOB' }}
           SCHEDULE_CRON: ${{ github.event.schedule || '' }}
+          SCHEDULED_SGLANG_IMAGE: ${{ needs.wait-for-scheduled-sglang-image.outputs.scheduled_sglang_image }}
+          SCHEDULED_SGLANG_TAG: ${{ needs.wait-for-scheduled-sglang-image.outputs.scheduled_sglang_tag }}
+          SCHEDULED_SGLANG_DIGEST: ${{ needs.wait-for-scheduled-sglang-image.outputs.scheduled_sglang_digest }}
+          SCHEDULED_SGLANG_RESOLUTION: ${{ needs.wait-for-scheduled-sglang-image.outputs.scheduled_sglang_resolution }}
         run: |
           set -euo pipefail
 
@@ -163,6 +373,13 @@ jobs:
             PREBUILT_SGLANG_IMAGE="${INPUT_DOCKER_IMAGE}"
             SGLANG_IMAGE_SOURCE="user-provided"
             USER_PROVIDED_SGLANG_IMAGE=true
+          elif [[ "${GITHUB_EVENT_NAME}" == "schedule" && "${NORMALIZED_REF}" == "main" && -n "${SCHEDULED_SGLANG_IMAGE}" ]]; then
+            PREBUILT_SGLANG_IMAGE="${SCHEDULED_SGLANG_IMAGE}"
+            SGLANG_IMAGE_SOURCE="prebuilt-scheduled-nightly"
+            RESOLVED_PREBUILT_ALIAS="rocm/atom-dev:${SCHEDULED_SGLANG_TAG}"
+            RESOLVED_PREBUILT_DIGEST="${SCHEDULED_SGLANG_DIGEST}"
+            PREBUILT_RESOLUTION_TYPE="${SCHEDULED_SGLANG_RESOLUTION:-scheduled-nightly-tag}"
+            RESOLVED_NIGHTLY_TAG="${SCHEDULED_SGLANG_TAG}"
           elif [[ "${NORMALIZED_REF}" == "main" ]]; then
             PREBUILT_SGLANG_IMAGE="rocm/atom-dev:sglang-latest"
             SGLANG_IMAGE_SOURCE="prebuilt"
@@ -309,6 +526,16 @@ jobs:
               reverse-lookup-failed-digest-pinned-latest)
                 printf -- '- Resolution: reverse lookup could not complete, so this run pins `sglang-latest` to its current digest instead of falling back to the floating tag.\n' \
                   >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              scheduled-nightly-tag)
+                printf -- '- Resolution: scheduled run waited for today'\''s nightly tag `%s` and pinned it to digest `%s`.\n' \
+                  "${RESOLVED_NIGHTLY_TAG}" \
+                  "${RESOLVED_PREBUILT_DIGEST}" >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              recent-nightly-tag)
+                printf -- '- Resolution: today'\''s nightly tag was not available before the wait timeout, so this run uses the latest recent SGLang nightly tag `%s` pinned to digest `%s`.\n' \
+                  "${RESOLVED_NIGHTLY_TAG}" \
+                  "${RESOLVED_PREBUILT_DIGEST}" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               resolution-failed)
                 printf -- '- Resolution: digest pinning itself failed, so this run falls back to floating `sglang-latest`.\n' \


### PR DESCRIPTION
## Summary

1. This PR updates the scheduled SGLang benchmark workflow to prefer the current day's published SGLang nightly Docker image before launching GPU benchmark jobs.
For scheduled `main` runs, the workflow now waits on a lightweight `ubuntu-latest` gate for `rocm/atom-dev:sglang-v<SGLANG_VERSION>-nightly_YYYYMMDD`, pins the selected image by digest, and passes that immutable image reference into the existing benchmark flow. If the current day's image is not available before the wait timeout, the workflow falls back to the most recent published `sglang-v*-nightly_*` image, also pinned by digest.
Manual runs, non-main branches, and explicit `docker_image` overrides keep their existing behavior.

2. Replace host file with workspace files in sglang-accuracy file.
3. Fixes the MI308 `Qwen3-32B-FP8` SGLang accuracy jobs by adding `--page-size 16` to both TP1 and TP8 configurations.
4. Add manual MI308 selection for SGLang accuracy.
