### PR TITLE
[sgl-atom] support Qwen3-32B in SGLang accuracy CI on MI308

### DIFF
--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -306,7 +306,7 @@
   {
     "model_name": "MI308 Qwen3-32B-FP8 TP1",
     "model_path": "Qwen/Qwen3-32B-FP8",
-    "extraArgs": "--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
+    "extraArgs": "--tensor-parallel-size 1 --mem-fraction-static 0.9 --page-size 16 --reasoning-parser qwen3 --disable-radix-cache",
     "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
     "runner": "atom-mi308-8gpu-plugins-benchmark",
     "test_level": "nightly",
@@ -318,7 +318,7 @@
   {
     "model_name": "MI308 Qwen3-32B-FP8 TP8",
     "model_path": "Qwen/Qwen3-32B-FP8",
-    "extraArgs": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
+    "extraArgs": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --page-size 16 --reasoning-parser qwen3 --disable-radix-cache",
     "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
     "runner": "atom-mi308-8gpu-plugins-benchmark",
     "test_level": "nightly",

--- a/.github/scripts/atom_sglang_test.sh
+++ b/.github/scripts/atom_sglang_test.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 #   LM_EVAL_TASK
 #   LM_EVAL_NUM_FEWSHOT
 #   LM_EVAL_NUM_CONCURRENT
+#   LM_EVAL_EXTRA_MODEL_ARGS
 
 TYPE=${1:-launch}
 if [[ "${TYPE}" != "start" && "${TYPE}" != "launch" && "${TYPE}" != "accuracy" ]]; then
@@ -47,6 +48,7 @@ KEEP_SERVER_ALIVE_ON_EXIT=${KEEP_SERVER_ALIVE_ON_EXIT:-0}
 LM_EVAL_TASK=${LM_EVAL_TASK:-gsm8k}
 LM_EVAL_NUM_FEWSHOT=${LM_EVAL_NUM_FEWSHOT:-3}
 LM_EVAL_NUM_CONCURRENT=${LM_EVAL_NUM_CONCURRENT:-65}
+LM_EVAL_EXTRA_MODEL_ARGS=${LM_EVAL_EXTRA_MODEL_ARGS:-}
 
 MODEL_NAME=${SGLANG_MODEL_NAME:-}
 MODEL_PATH=${SGLANG_MODEL_PATH:-}
@@ -240,8 +242,14 @@ run_accuracy() {
   echo "========== Running SGLang accuracy =========="
   echo "Model name: ${MODEL_NAME}"
 
+  local lm_eval_model_args
+  lm_eval_model_args="model=${resolved_model_path},base_url=http://127.0.0.1:${SGLANG_PORT}/v1/completions,num_concurrent=${LM_EVAL_NUM_CONCURRENT},max_retries=1,tokenized_requests=False,trust_remote_code=True"
+  if [[ -n "${LM_EVAL_EXTRA_MODEL_ARGS}" ]]; then
+    lm_eval_model_args="${lm_eval_model_args},${LM_EVAL_EXTRA_MODEL_ARGS}"
+  fi
+
   lm_eval --model local-completions \
-    --model_args model="${resolved_model_path}",base_url="http://127.0.0.1:${SGLANG_PORT}/v1/completions",num_concurrent="${LM_EVAL_NUM_CONCURRENT}",max_retries=1,tokenized_requests=False,trust_remote_code=True \
+    --model_args "${lm_eval_model_args}" \
     --tasks "${LM_EVAL_TASK}" \
     --num_fewshot "${LM_EVAL_NUM_FEWSHOT}" \
     --output_path "${output_path}" 2>&1 | tee -a "${ACCURACY_LOG_FILE}"

--- a/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
@@ -354,6 +354,7 @@ jobs:
           LM_EVAL_TASK: "gsm8k"
           LM_EVAL_NUM_FEWSHOT: ${{ matrix.lm_eval_num_fewshot }}
           LM_EVAL_NUM_CONCURRENT: ${{ matrix.lm_eval_num_concurrent }}
+          LM_EVAL_EXTRA_MODEL_ARGS: ${{ matrix.lm_eval_extra_model_args || '' }}
         run: |
           set -euo pipefail
 
@@ -381,6 +382,7 @@ jobs:
             -e LM_EVAL_TASK="${LM_EVAL_TASK}" \
             -e LM_EVAL_NUM_FEWSHOT="${LM_EVAL_NUM_FEWSHOT}" \
             -e LM_EVAL_NUM_CONCURRENT="${LM_EVAL_NUM_CONCURRENT}" \
+            -e LM_EVAL_EXTRA_MODEL_ARGS="${LM_EVAL_EXTRA_MODEL_ARGS}" \
             "$CONTAINER_NAME" bash -lc '
               (
                 set +e

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -435,7 +435,8 @@ jobs:
               {
                   "model_name": "MI308 Qwen3-32B-FP8 TP1",
                   "model_path": "Qwen/Qwen3-32B-FP8",
-                  "extra_args": "--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
+                  "extra_args": "--tensor-parallel-size 1 --mem-fraction-static 0.9 --page-size 16 --reasoning-parser qwen3 --disable-radix-cache",
+                  "lm_eval_extra_model_args": "max_gen_toks=2048,max_length=8192",
                   "accuracy_test_threshold": 0.8,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
                   "runner": "atom-mi308-8gpu-plugins-benchmark",
@@ -443,7 +444,8 @@ jobs:
               {
                   "model_name": "MI308 Qwen3-32B-FP8 TP8",
                   "model_path": "Qwen/Qwen3-32B-FP8",
-                  "extra_args": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
+                  "extra_args": "--tensor-parallel-size 8 --mem-fraction-static 0.9 --page-size 16 --reasoning-parser qwen3 --disable-radix-cache",
+                  "lm_eval_extra_model_args": "max_gen_toks=2048,max_length=8192",
                   "accuracy_test_threshold": 0.8,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
                   "runner": "atom-mi308-8gpu-plugins-benchmark",


### PR DESCRIPTION
## Summary

This PR completes Qwen3-32B-FP8 support in the SGLang accuracy CI path. on MI308

PR #1416 added `--page-size 16` for the MI308 Qwen3-32B-FP8 benchmark entries, but the nightly accuracy workflow still launched the same model with the default `page_size=1`. That can hit the dense attention KV-cache layout issue during startup. This PR aligns the accuracy CI runtime args with the validated Qwen3-32B configuration and also prevents GSM8K evaluation from being truncated by the default generation length.

## Changes

- `.github/workflows/atom-sglang-accuracy-validation.yaml`
  - Required for CI startup.
  - Adds `--page-size 16` to `MI308 Qwen3-32B-FP8 TP1/TP8`.
  - Adds `max_gen_toks=2048,max_length=8192` for these two accuracy cases so GSM8K reasoning outputs are not truncated.

- `.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml`
  - Required for the generation-length override to take effect.
  - Passes optional `lm_eval_extra_model_args` from the matrix into the container.

- `.github/scripts/atom_sglang_test.sh`
  - Required by the shard workflow change.
  - Adds optional `LM_EVAL_EXTRA_MODEL_ARGS` support and appends it to `lm_eval --model_args`.
  - Defaults to empty, so existing accuracy cases keep their current behavior.

- `.github/benchmark/sglang_models_accuracy.json`
  - Not required for CI startup, but keeps dashboard/catalog metadata aligned with the actual workflow args.
  - Adds `--page-size 16` for the MI308 Qwen3-32B-FP8 TP1/TP8 accuracy entries.

## Validation

- `bash -n .github/scripts/atom_sglang_test.sh`
- `python3 -m json.tool .github/benchmark/sglang_models_accuracy.json`
- `git diff --check`