### PR TITLE
feat(openai): add tool calling support with GPT-OSS Harmony parser

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1791,7 +1791,7 @@ async def stop_profile():
 def main():
     """Main entry point for the server."""
     global engine, tokenizer, model_name, default_chat_template_kwargs, _request_logger
-    global custom_message_encoder
+    global custom_message_encoder, use_harmony
 
     parser = argparse.ArgumentParser(description="ATOM OpenAI API Server")
     EngineArgs.add_cli_args(parser)

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -959,6 +959,9 @@ async def chat_completions(request: ChatCompletionRequest):
         merged_kwargs = dict(default_chat_template_kwargs)
         if request.chat_template_kwargs:
             merged_kwargs.update(request.chat_template_kwargs)
+        tool_choice_val = request.get_tool_choice_value()
+        if tool_choice_val is not None:
+            merged_kwargs["tool_choice"] = tool_choice_val
 
         effective_n = _coerce_n(request.n, request.temperature)
         sampling_params = _build_sampling_params(

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1234,11 +1234,32 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         messages = [ChatMessage(**m) for m in openai_messages]
 
         merged_kwargs = dict(default_chat_template_kwargs)
+        openai_tools = anthropic_to_openai_tools(request.tools)
+        # Convert Anthropic tool_choice to OpenAI format for the chat template
+        tc = request.tool_choice
+        if tc is not None:
+            if isinstance(tc, dict):
+                tc_type = tc.get("type", "auto")
+                if tc_type == "any":
+                    merged_kwargs["tool_choice"] = "required"
+                elif tc_type == "tool":
+                    merged_kwargs["tool_choice"] = {
+                        "type": "function",
+                        "function": {"name": tc.get("name", "")},
+                    }
+                elif tc_type == "none":
+                    merged_kwargs["tool_choice"] = "none"
+                else:
+                    merged_kwargs["tool_choice"] = "auto"
+            elif isinstance(tc, str):
+                merged_kwargs["tool_choice"] = tc
+        elif openai_tools:
+            merged_kwargs["tool_choice"] = "auto"
         prompt = apply_chat_template(
             tokenizer,
             custom_message_encoder,
             [msg.to_template_dict() for msg in messages],
-            tools=anthropic_to_openai_tools(request.tools),
+            tools=openai_tools,
             **merged_kwargs,
         )
 
@@ -1294,7 +1315,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 reasoning_filter = ReasoningFilter()
                 if prompt.rstrip().endswith("<think>"):
                     reasoning_filter.state = 1
-                tool_parser = ToolCallStreamParser()
+                tool_parser = ToolCallStreamParser(tools=openai_tools)
                 block_index = 0
                 started_text = False
                 started_thinking = False
@@ -1467,7 +1488,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
         raw_text = final_output["text"]
         reasoning_content, content_with_tools = separate_reasoning(raw_text)
-        content_text, tool_calls = parse_tool_calls(content_with_tools)
+        content_text, tool_calls = parse_tool_calls(content_with_tools, openai_tools)
         output_tokens = len(tokenizer.encode(raw_text))
         cache_read_input_tokens = final_output.get("num_cached_tokens", 0)
         if not getattr(request, "thinking", None):

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -87,6 +87,7 @@ processor: Optional[Any] = None
 model_name: str = ""
 default_chat_template_kwargs: Dict[str, Any] = {}
 custom_message_encoder: Optional[Any] = None
+use_harmony: bool = False
 _stream_queues: Dict[str, asyncio.Queue] = {}
 _seq_id_to_request_id: Dict[int, str] = {}
 _stream_loops: Dict[str, AbstractEventLoop] = {}
@@ -943,6 +944,45 @@ async def general_error_handler(request: Request, exc: Exception):
     )
 
 
+def _build_harmony_chat_response(
+    request_id: str, model: str, final_output: Dict[str, Any]
+) -> "ChatCompletionResponse":
+    """Build a non-streaming chat response using Harmony token-level parsing."""
+    from .harmony_parser import HarmonyStreamParser
+    from .protocol import ChatCompletionResponse
+
+    parser = HarmonyStreamParser()
+    reasoning, content, tool_calls = parser.parse_full(
+        final_output.get("token_ids", [])
+    )
+
+    message: Dict[str, Any] = {"role": "assistant", "content": content or ""}
+    if reasoning:
+        message["reasoning_content"] = reasoning
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    finish_reason = "tool_calls" if tool_calls else (final_output.get("finish_reason") or "stop")
+    return ChatCompletionResponse(
+        id=request_id,
+        created=int(time.time()),
+        model=model,
+        choices=[{"index": 0, "message": message, "finish_reason": finish_reason}],
+        usage={
+            "prompt_tokens": final_output.get("num_tokens_input", 0),
+            "completion_tokens": final_output.get("num_tokens_output", 0),
+            "total_tokens": final_output.get("num_tokens_input", 0)
+            + final_output.get("num_tokens_output", 0),
+            "prompt_tokens_details": {
+                "cached_tokens": final_output.get("num_cached_tokens", 0)
+            },
+            "ttft_s": round(final_output.get("ttft", 0.0), 4),
+            "tpot_s": round(final_output.get("tpot", 0.0), 4),
+            "latency_s": round(final_output.get("latency", 0.0), 4),
+        },
+    )
+
+
 # ---- Endpoints ----
 
 
@@ -979,6 +1019,7 @@ async def chat_completions(request: ChatCompletionRequest):
         _log_request_event("request", request_id, request.model_dump())
 
         is_multimodal = _has_multimodal_content(messages)
+        is_harmony = use_harmony and not is_multimodal
         if is_multimodal:
             # Image loading (blocking network I/O, up to a 30s urlopen) plus
             # processor preprocessing are heavy and would stall the event loop;
@@ -989,6 +1030,22 @@ async def chat_completions(request: ChatCompletionRequest):
             token_ids, multimodal_data = await loop.run_in_executor(
                 None, _prepare_multimodal_inputs, messages, merged_kwargs
             )
+        elif is_harmony:
+            from .harmony_utils import (
+                build_harmony_preamble,
+                extract_instructions_from_messages,
+                parse_chat_inputs_to_harmony_messages,
+                render_for_completion,
+            )
+
+            chat_msgs = [msg.to_template_dict() for msg in messages]
+            instructions, chat_msgs = extract_instructions_from_messages(chat_msgs)
+            harmony_msgs = build_harmony_preamble(
+                instructions=instructions,
+                tools=request.get_tools_as_dicts(),
+            )
+            harmony_msgs.extend(parse_chat_inputs_to_harmony_messages(chat_msgs))
+            prompt = render_for_completion(harmony_msgs)  # List[int]
         else:
             prompt = apply_chat_template(
                 tokenizer,
@@ -1037,6 +1094,7 @@ async def chat_completions(request: ChatCompletionRequest):
                     num_prompt_tokens,
                     cleanup_streaming_request,
                     tools=request.get_tools_as_dicts(),
+                    use_harmony=is_harmony,
                 )
             return StreamingResponse(
                 _logged_stream(gen, request_id),
@@ -1098,13 +1156,18 @@ async def chat_completions(request: ChatCompletionRequest):
                 final_output = output
             if final_output is None:
                 raise RuntimeError("No output generated")
-            resp = build_chat_response(
-                request_id,
-                model_name,
-                final_output["text"],
-                final_output,
-                tools=request.get_tools_as_dicts(),
-            )
+            if is_harmony:
+                resp = _build_harmony_chat_response(
+                    request_id, model_name, final_output
+                )
+            else:
+                resp = build_chat_response(
+                    request_id,
+                    model_name,
+                    final_output["text"],
+                    final_output,
+                    tools=request.get_tools_as_dicts(),
+                )
         _log_request_event("response", request_id, resp.model_dump())
         return resp
 
@@ -1235,33 +1298,52 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
         merged_kwargs = dict(default_chat_template_kwargs)
         openai_tools = anthropic_to_openai_tools(request.tools)
-        # Convert Anthropic tool_choice to OpenAI format for the chat template
-        tc = request.tool_choice
-        if tc is not None:
-            if isinstance(tc, dict):
-                tc_type = tc.get("type", "auto")
-                if tc_type == "any":
-                    merged_kwargs["tool_choice"] = "required"
-                elif tc_type == "tool":
-                    merged_kwargs["tool_choice"] = {
-                        "type": "function",
-                        "function": {"name": tc.get("name", "")},
-                    }
-                elif tc_type == "none":
-                    merged_kwargs["tool_choice"] = "none"
-                else:
-                    merged_kwargs["tool_choice"] = "auto"
-            elif isinstance(tc, str):
-                merged_kwargs["tool_choice"] = tc
-        elif openai_tools:
-            merged_kwargs["tool_choice"] = "auto"
-        prompt = apply_chat_template(
-            tokenizer,
-            custom_message_encoder,
-            [msg.to_template_dict() for msg in messages],
-            tools=openai_tools,
-            **merged_kwargs,
-        )
+        is_harmony_request = use_harmony
+
+        if is_harmony_request:
+            from .harmony_utils import (
+                build_harmony_preamble,
+                extract_instructions_from_messages,
+                parse_chat_inputs_to_harmony_messages,
+                render_for_completion,
+            )
+
+            chat_msgs = [msg.to_template_dict() for msg in messages]
+            instructions, chat_msgs = extract_instructions_from_messages(chat_msgs)
+            harmony_msgs = build_harmony_preamble(
+                instructions=instructions,
+                tools=openai_tools,
+            )
+            harmony_msgs.extend(parse_chat_inputs_to_harmony_messages(chat_msgs))
+            prompt = render_for_completion(harmony_msgs)  # List[int]
+        else:
+            # Convert Anthropic tool_choice to OpenAI format for the chat template
+            tc = request.tool_choice
+            if tc is not None:
+                if isinstance(tc, dict):
+                    tc_type = tc.get("type", "auto")
+                    if tc_type == "any":
+                        merged_kwargs["tool_choice"] = "required"
+                    elif tc_type == "tool":
+                        merged_kwargs["tool_choice"] = {
+                            "type": "function",
+                            "function": {"name": tc.get("name", "")},
+                        }
+                    elif tc_type == "none":
+                        merged_kwargs["tool_choice"] = "none"
+                    else:
+                        merged_kwargs["tool_choice"] = "auto"
+                elif isinstance(tc, str):
+                    merged_kwargs["tool_choice"] = tc
+            elif openai_tools:
+                merged_kwargs["tool_choice"] = "auto"
+            prompt = apply_chat_template(
+                tokenizer,
+                custom_message_encoder,
+                [msg.to_template_dict() for msg in messages],
+                tools=openai_tools,
+                **merged_kwargs,
+            )
 
         sampling_params = _build_sampling_params(
             temperature=request.temperature or 1.0,
@@ -1273,7 +1355,10 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         )
 
         request_id = uuid.uuid4().hex[:24]
-        input_tokens = len(tokenizer.encode(prompt))
+        if isinstance(prompt, list):
+            input_tokens = len(prompt)
+        else:
+            input_tokens = len(tokenizer.encode(prompt))
 
         max_ctx = None
         for _path in (
@@ -1298,8 +1383,11 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             logger.warning(
                 f"Prompt too long ({input_tokens} > {max_input}), truncating"
             )
-            token_ids = tokenizer.encode(prompt)[:max_input]
-            prompt = tokenizer.decode(token_ids, skip_special_tokens=False)
+            if isinstance(prompt, list):
+                prompt = prompt[:max_input]
+            else:
+                token_ids = tokenizer.encode(prompt)[:max_input]
+                prompt = tokenizer.decode(token_ids, skip_special_tokens=False)
             input_tokens = max_input
 
         if request.stream:
@@ -1312,8 +1400,12 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 from .reasoning import ReasoningFilter
                 from .tool_parser import ToolCallStreamParser
 
+                if is_harmony_request:
+                    from .harmony_parser import HarmonyStreamParser
+
+                    harmony_parser = HarmonyStreamParser()
                 reasoning_filter = ReasoningFilter()
-                if prompt.rstrip().endswith("<think>"):
+                if isinstance(prompt, str) and prompt.rstrip().endswith("<think>"):
                     reasoning_filter.state = 1
                 tool_parser = ToolCallStreamParser(tools=openai_tools)
                 block_index = 0
@@ -1336,8 +1428,88 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             )
                             message_started = True
                         new_text = chunk_data["text"]
-                        output_tokens += len(chunk_data.get("token_ids", []))
+                        token_ids = chunk_data.get("token_ids", [])
+                        output_tokens += len(token_ids)
                         finished = chunk_data.get("finished", False)
+
+                        if is_harmony_request:
+                            # Harmony: token-level parsing
+                            h_events = harmony_parser.process_tokens(token_ids)
+                            if finished:
+                                h_events.extend(harmony_parser.flush())
+                            for etype, edata in h_events:
+                                if etype == "reasoning":
+                                    if not _thinking_enabled:
+                                        yield "event: ping\ndata: " + json.dumps(
+                                            {"type": "ping"}
+                                        ) + "\n\n"
+                                        continue
+                                    if not started_thinking and not started_text:
+                                        yield stream_content_block_start(
+                                            block_index, "thinking"
+                                        )
+                                        started_thinking = True
+                                    if started_thinking:
+                                        yield stream_content_block_delta(
+                                            block_index, edata, "thinking"
+                                        )
+                                elif etype == "content":
+                                    if started_thinking and not started_text:
+                                        yield stream_signature_delta(block_index)
+                                        yield stream_content_block_stop(block_index)
+                                        block_index += 1
+                                    if not started_text:
+                                        yield stream_content_block_start(
+                                            block_index, "text"
+                                        )
+                                        started_text = True
+                                    yield stream_content_block_delta(
+                                        block_index, edata, "text"
+                                    )
+                                elif etype == "tool_call_start":
+                                    has_tool_calls = True
+                                    stop_reason = "tool_use"
+                                    if started_text:
+                                        yield stream_content_block_stop(block_index)
+                                        block_index += 1
+                                        started_text = False
+                                    elif started_thinking:
+                                        yield stream_signature_delta(block_index)
+                                        yield stream_content_block_stop(block_index)
+                                        block_index += 1
+                                        started_thinking = False
+                                    fn = edata.get("function", {})
+                                    yield stream_content_block_start(
+                                        block_index,
+                                        "tool_use",
+                                        tool_use_id=edata.get("id", ""),
+                                        tool_name=fn.get("name", ""),
+                                    )
+                                elif etype == "tool_call_args":
+                                    fn = edata.get("function", {})
+                                    yield stream_content_block_delta(
+                                        block_index,
+                                        fn.get("arguments", ""),
+                                        "tool_use",
+                                    )
+                                elif etype == "tool_call_end":
+                                    yield stream_content_block_stop(block_index)
+                                    block_index += 1
+
+                            if finished:
+                                if not started_text and not has_tool_calls:
+                                    if started_thinking:
+                                        yield stream_signature_delta(block_index)
+                                        yield stream_content_block_stop(block_index)
+                                        block_index += 1
+                                    yield stream_content_block_start(block_index, "text")
+                                    started_text = True
+                                if started_text:
+                                    yield stream_content_block_stop(block_index)
+                                yield stream_message_delta(stop_reason, output_tokens)
+                                yield stream_message_stop()
+                                break
+                            continue
 
                         # Phase 1: Reasoning filter
                         segments = reasoning_filter.process(new_text)
@@ -1486,10 +1658,32 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         if final_output is None:
             raise RuntimeError("No output generated")
 
-        raw_text = final_output["text"]
-        reasoning_content, content_with_tools = separate_reasoning(raw_text)
-        content_text, tool_calls = parse_tool_calls(content_with_tools, openai_tools)
-        output_tokens = len(tokenizer.encode(raw_text))
+        if is_harmony_request:
+            from .harmony_parser import HarmonyStreamParser
+            from .tool_parser import ToolCall
+
+            h_parser = HarmonyStreamParser()
+            reasoning_content, content_text, h_tool_calls = h_parser.parse_full(
+                final_output.get("token_ids", [])
+            )
+            # Convert to ToolCall objects for build_anthropic_response
+            tool_calls = [
+                ToolCall(
+                    id=tc["id"],
+                    type="function",
+                    function=tc["function"],
+                )
+                for tc in h_tool_calls
+            ] if h_tool_calls else []
+        else:
+            raw_text = final_output["text"]
+            reasoning_content, content_with_tools = separate_reasoning(raw_text)
+            content_text, tool_calls = parse_tool_calls(
+                content_with_tools, openai_tools
+            )
+        output_tokens = final_output.get("num_tokens_output", 0) or len(
+            final_output.get("token_ids", [])
+        )
         cache_read_input_tokens = final_output.get("num_cached_tokens", 0)
         if not getattr(request, "thinking", None):
             reasoning_content = None
@@ -1497,7 +1691,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         return build_anthropic_response(
             request_id=request_id,
             model=model_name,
-            content_text=content_text,
+            content_text=content_text or "",
             reasoning_content=reasoning_content,
             tool_calls=tool_calls if tool_calls else None,
             input_tokens=input_tokens,
@@ -1643,6 +1837,17 @@ def main():
     tokenizer = _load_tokenizer(args.model, args.trust_remote_code)
     model_name = args.model
     custom_message_encoder = load_custom_message_encoder(args.model)
+
+    # Detect GPT-OSS models that require Harmony encoding
+    try:
+        from atom.config import get_hf_config
+
+        _hf_cfg = get_hf_config(args.model, args.trust_remote_code)
+        if getattr(_hf_cfg, "model_type", "") == "gpt_oss":
+            use_harmony = True
+            logger.info("GPT-OSS model detected: enabling Harmony tool calling")
+    except Exception:
+        pass
 
     logger.info(f"Initializing engine with model {args.model}...")
     engine_args = EngineArgs.from_cli_args(args)

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1310,6 +1310,18 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
             chat_msgs = [msg.to_template_dict() for msg in messages]
             instructions, chat_msgs = extract_instructions_from_messages(chat_msgs)
+            logger.info(
+                "[harmony] instructions=%d chars, %d chat_msgs, %d tools",
+                len(instructions) if instructions else 0,
+                len(chat_msgs),
+                len(openai_tools) if openai_tools else 0,
+            )
+            for ci, cm in enumerate(chat_msgs):
+                logger.info(
+                    "[harmony] chat_msg[%d]: role=%s content_type=%s keys=%s",
+                    ci, cm.get("role"), type(cm.get("content")).__name__,
+                    list(cm.keys()),
+                )
             harmony_msgs = build_harmony_preamble(
                 instructions=instructions,
                 tools=openai_tools,

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -991,7 +991,7 @@ async def chat_completions(request: ChatCompletionRequest):
                 tokenizer,
                 custom_message_encoder,
                 [msg.to_template_dict() for msg in messages],
-                tools=request.tools,
+                tools=request.get_tools_as_dicts(),
                 **merged_kwargs,
             )
 
@@ -1016,7 +1016,7 @@ async def chat_completions(request: ChatCompletionRequest):
                     seq_ids,
                     num_prompt_tokens,
                     cleanup_streaming_request,
-                    tools=request.tools,
+                    tools=request.get_tools_as_dicts(),
                 )
             else:
                 seq_id, stream_queue, num_prompt_tokens = await setup_streaming_request(
@@ -1033,7 +1033,7 @@ async def chat_completions(request: ChatCompletionRequest):
                     seq_id,
                     num_prompt_tokens,
                     cleanup_streaming_request,
-                    tools=request.tools,
+                    tools=request.get_tools_as_dicts(),
                 )
             return StreamingResponse(
                 _logged_stream(gen, request_id),
@@ -1052,7 +1052,7 @@ async def chat_completions(request: ChatCompletionRequest):
             if not outputs:
                 raise RuntimeError("No output generated")
             resp = build_chat_response_multi(
-                request_id, model_name, outputs, tools=request.tools
+                request_id, model_name, outputs, tools=request.get_tools_as_dicts()
             )
         elif is_multimodal:
             final_output = None
@@ -1070,7 +1070,7 @@ async def chat_completions(request: ChatCompletionRequest):
                 model_name,
                 final_output["text"],
                 final_output,
-                tools=request.tools,
+                tools=request.get_tools_as_dicts(),
             )
         elif effective_n > 1:
             outputs = await generate_async_fanout(
@@ -1082,7 +1082,7 @@ async def chat_completions(request: ChatCompletionRequest):
             if not outputs:
                 raise RuntimeError("No output generated")
             resp = build_chat_response_multi(
-                request_id, model_name, outputs, tools=request.tools
+                request_id, model_name, outputs, tools=request.get_tools_as_dicts()
             )
         else:
             final_output = None
@@ -1100,7 +1100,7 @@ async def chat_completions(request: ChatCompletionRequest):
                 model_name,
                 final_output["text"],
                 final_output,
-                tools=request.tools,
+                tools=request.get_tools_as_dicts(),
             )
         _log_request_event("response", request_id, resp.model_dump())
         return resp

--- a/atom/entrypoints/openai/harmony_parser.py
+++ b/atom/entrypoints/openai/harmony_parser.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Token-level streaming parser for GPT-OSS Harmony output.
+
+Wraps ``openai_harmony.StreamableParser`` to process raw token IDs and emit
+structured events compatible with ATOM's tool-call streaming protocol:
+
+- ``("reasoning", text)``   — chain-of-thought (analysis channel)
+- ``("content", text)``     — final response content
+- ``("tool_call_start", {"id": ..., "function": {"name": ..., "arguments": ""}})``
+- ``("tool_call_args", {"function": {"arguments": chunk}})``
+- ``("tool_call_end", None)``
+
+Adapted from vLLM's ``vllm/parser/harmony.py``.
+"""
+
+import json
+import logging
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+from openai_harmony import HarmonyError
+
+from .harmony_utils import (
+    extract_function_from_recipient,
+    get_streamable_parser_for_assistant,
+    is_function_recipient,
+)
+
+logger = logging.getLogger("atom")
+
+
+def _make_tool_call_id() -> str:
+    return f"call_{uuid.uuid4().hex}"
+
+
+class HarmonyStreamParser:
+    """Stateful token-level parser for GPT-OSS Harmony output.
+
+    Feed raw token IDs via :meth:`process_tokens` and call :meth:`flush` at
+    end-of-stream.  Events match the ``ToolCallStreamParser`` protocol so the
+    same downstream SSE formatting code can consume them.
+    """
+
+    def __init__(self) -> None:
+        self._parser = get_streamable_parser_for_assistant()
+        self._prev_recipient: Optional[str] = None
+        self._tool_call_index: int = 0
+        self._num_processed_messages: int = 0
+        self._has_tool_calls: bool = False
+
+    @property
+    def has_tool_calls(self) -> bool:
+        return self._has_tool_calls
+
+    def _normalize_recipient(self, recipient: Optional[str]) -> Optional[str]:
+        """Remove constrained-format suffixes misparsed by older Harmony."""
+        if recipient is None:
+            return None
+        idx = recipient.find("<|constrain|>")
+        if idx == -1:
+            return recipient
+        return recipient[:idx].rstrip() or None
+
+    def _poll_completed_message(self):
+        """Check if a new message has been completed by the parser."""
+        messages = self._parser.messages
+        if len(messages) <= self._num_processed_messages:
+            return None
+        msg = messages[self._num_processed_messages]
+        msg.recipient = self._normalize_recipient(msg.recipient)
+        self._num_processed_messages += 1
+        return msg
+
+    def _classify(self, channel, recipient):
+        """Route a segment to reasoning, content, tool, or ignore."""
+        if recipient and is_function_recipient(recipient):
+            return "tool"
+        if channel == "analysis":
+            return "reasoning"
+        if channel == "final" or (channel == "commentary" and recipient is None):
+            return "content"
+        return "ignore"
+
+    def process_tokens(self, token_ids: List[int]) -> List[Tuple[str, Any]]:
+        """Process a batch of raw token IDs and return structured events."""
+        if not token_ids:
+            return []
+
+        events: List[Tuple[str, Any]] = []
+
+        for token_id in token_ids:
+            self._parser.process(token_id)
+            channel = self._parser.current_channel
+            recipient = self._normalize_recipient(self._parser.current_recipient)
+            delta = self._parser.last_content_delta or ""
+            completed = self._poll_completed_message()
+
+            # A completed message resets the recipient tracking
+            if completed is not None:
+                self._prev_recipient = None
+                continue
+
+            if not delta:
+                continue
+
+            seg_type = self._classify(channel, recipient)
+
+            if seg_type == "reasoning":
+                events.append(("reasoning", delta))
+
+            elif seg_type == "content":
+                events.append(("content", delta))
+
+            elif seg_type == "tool":
+                self._has_tool_calls = True
+                if self._prev_recipient != recipient:
+                    # New tool call starting
+                    tool_name = extract_function_from_recipient(recipient)
+                    tool_id = _make_tool_call_id()
+                    events.append((
+                        "tool_call_start",
+                        {
+                            "index": self._tool_call_index,
+                            "id": tool_id,
+                            "type": "function",
+                            "function": {"name": tool_name, "arguments": ""},
+                        },
+                    ))
+                    # Also emit the first args delta
+                    events.append((
+                        "tool_call_args",
+                        {
+                            "index": self._tool_call_index,
+                            "function": {"arguments": delta},
+                        },
+                    ))
+                    self._tool_call_index += 1
+                    self._prev_recipient = recipient
+                else:
+                    # Continuing same tool call
+                    events.append((
+                        "tool_call_args",
+                        {
+                            "index": self._tool_call_index - 1,
+                            "function": {"arguments": delta},
+                        },
+                    ))
+
+        return events
+
+    def flush(self) -> List[Tuple[str, Any]]:
+        """Finalize parsing at end-of-stream."""
+        events: List[Tuple[str, Any]] = []
+        try:
+            self._parser.process_eos()
+            msg = self._poll_completed_message()
+            if msg is not None:
+                # Process the final completed message
+                text = ""
+                if msg.content:
+                    text = msg.content[0].text if hasattr(msg.content[0], "text") else str(msg.content[0])
+                seg_type = self._classify(msg.channel, msg.recipient)
+                if seg_type == "content" and text:
+                    events.append(("content", text))
+                elif seg_type == "tool" and msg.recipient:
+                    self._has_tool_calls = True
+                    tool_name = extract_function_from_recipient(msg.recipient)
+                    content_type = msg.content_type
+                    if content_type is not None and "json" not in str(content_type):
+                        arguments = text
+                    else:
+                        try:
+                            arguments = json.dumps(json.loads(text))
+                        except (json.JSONDecodeError, TypeError):
+                            arguments = text
+                    tool_id = _make_tool_call_id()
+                    events.append((
+                        "tool_call_start",
+                        {
+                            "index": self._tool_call_index,
+                            "id": tool_id,
+                            "type": "function",
+                            "function": {"name": tool_name, "arguments": ""},
+                        },
+                    ))
+                    events.append((
+                        "tool_call_args",
+                        {
+                            "index": self._tool_call_index,
+                            "function": {"arguments": arguments},
+                        },
+                    ))
+                    self._tool_call_index += 1
+        except HarmonyError:
+            logger.warning(
+                "Harmony parser ended in a non-terminal state; "
+                "raw unparsed output may be incomplete."
+            )
+
+        if self._has_tool_calls:
+            events.append(("tool_call_end", None))
+
+        return events
+
+    def parse_full(self, token_ids: List[int]) -> Tuple[Optional[str], Optional[str], list]:
+        """Non-streaming parse: returns (reasoning, content, tool_calls).
+
+        ``tool_calls`` is a list of dicts with ``id``, ``type``, ``function``
+        keys (OpenAI format).
+        """
+        events = self.process_tokens(token_ids)
+        events.extend(self.flush())
+
+        reasoning_parts: List[str] = []
+        content_parts: List[str] = []
+        tool_calls: List[Dict[str, Any]] = []
+        current_tool: Optional[Dict[str, Any]] = None
+
+        for etype, edata in events:
+            if etype == "reasoning":
+                reasoning_parts.append(edata)
+            elif etype == "content":
+                content_parts.append(edata)
+            elif etype == "tool_call_start":
+                if current_tool is not None:
+                    tool_calls.append(current_tool)
+                current_tool = {
+                    "id": edata["id"],
+                    "type": "function",
+                    "function": {
+                        "name": edata["function"]["name"],
+                        "arguments": "",
+                    },
+                }
+            elif etype == "tool_call_args" and current_tool is not None:
+                current_tool["function"]["arguments"] += edata["function"]["arguments"]
+            elif etype == "tool_call_end":
+                if current_tool is not None:
+                    tool_calls.append(current_tool)
+                    current_tool = None
+
+        reasoning = "".join(reasoning_parts) or None
+        content = "".join(content_parts) or None
+        return reasoning, content, tool_calls

--- a/atom/entrypoints/openai/harmony_utils.py
+++ b/atom/entrypoints/openai/harmony_utils.py
@@ -25,7 +25,6 @@ from openai_harmony import (
     Role,
     StreamableParser,
     SystemContent,
-    TextContent,
     ToolDescription,
     load_harmony_encoding,
 )
@@ -205,23 +204,22 @@ def _parse_single_message(
         msgs.append(analysis)
 
     # Default: user/assistant/system messages
-    content = chat_msg.get("content") or ""
-    if isinstance(content, str):
-        contents = [TextContent(text=content)]
-    else:
-        contents = [TextContent(text=c.get("text", "")) for c in content]
+    text = _flatten_content(chat_msg.get("content")) or ""
 
-    if role == "assistant" and contents and contents[0].text:
-        msg = Message.from_role_and_contents(role, contents)
+    _role_map = {"user": Role.USER, "assistant": Role.ASSISTANT,
+                 "system": Role.SYSTEM, "developer": Role.DEVELOPER}
+
+    if role == "assistant" and text:
+        msg = Message.from_role_and_content(Role.ASSISTANT, text)
         msg = msg.with_channel("final")
         msgs.append(msg)
     elif role in ("system", "developer"):
-        text = _flatten_content(chat_msg.get("content"))
         if text:
             dev_msg = get_developer_message(instructions=text)
             msgs.append(dev_msg)
     elif role != "assistant":
-        msg = Message.from_role_and_contents(role, contents)
+        hr = _role_map.get(role, Role.USER)
+        msg = Message.from_role_and_content(hr, text)
         msgs.append(msg)
 
     return msgs

--- a/atom/entrypoints/openai/harmony_utils.py
+++ b/atom/entrypoints/openai/harmony_utils.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Harmony encoding utilities for GPT-OSS tool calling.
+
+GPT-OSS models use OpenAI's proprietary Harmony format for structured output
+(tool calls, reasoning, content). This module wraps the ``openai_harmony``
+library to build Harmony messages and render them to token IDs for prompt
+construction, bypassing ``tokenizer.apply_chat_template`` entirely.
+
+Adapted from vLLM's ``vllm/entrypoints/openai/parser/harmony_utils.py``.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from openai_harmony import (
+    Author,
+    Conversation,
+    DeveloperContent,
+    HarmonyEncodingName,
+    Message,
+    RenderConversationConfig,
+    Role,
+    StreamableParser,
+    SystemContent,
+    TextContent,
+    ToolDescription,
+    load_harmony_encoding,
+)
+
+logger = logging.getLogger("atom")
+
+_harmony_encoding = None
+
+
+# ── Encoding ──────────────────────────────────────────────────────────
+
+
+def get_encoding():
+    """Return the singleton Harmony encoding for GPT-OSS."""
+    global _harmony_encoding
+    if _harmony_encoding is None:
+        _harmony_encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+    return _harmony_encoding
+
+
+def get_streamable_parser_for_assistant() -> StreamableParser:
+    """Create a StreamableParser for decoding assistant output tokens."""
+    return StreamableParser(get_encoding(), role=Role.ASSISTANT)
+
+
+# ── Recipient helpers ─────────────────────────────────────────────────
+
+
+def is_function_recipient(recipient: str) -> bool:
+    """Check whether *recipient* refers to a function tool call."""
+    if not recipient:
+        return False
+    if recipient.startswith("<|"):
+        return False
+    if recipient.startswith("functions."):
+        return len(recipient) > len("functions.")
+    if recipient == "assistant":
+        return False
+    return True
+
+
+def extract_function_from_recipient(recipient: str) -> str:
+    """Strip the ``functions.`` prefix from a recipient name."""
+    return recipient.removeprefix("functions.")
+
+
+# ── Message building ─────────────────────────────────────────────────
+
+
+def _create_tool_description(tool: Dict[str, Any]) -> ToolDescription:
+    """Create a Harmony ToolDescription from an OpenAI-format tool dict."""
+    fn = tool.get("function", tool)
+    return ToolDescription.new(
+        name=fn.get("name", ""),
+        description=fn.get("description", ""),
+        parameters=fn.get("parameters"),
+    )
+
+
+def get_system_message() -> Message:
+    """Build the Harmony system message."""
+    sys_content = SystemContent.new()
+    return Message.from_role_and_content(Role.SYSTEM, sys_content)
+
+
+def get_developer_message(
+    instructions: Optional[str] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+) -> Message:
+    """Build the Harmony developer message with optional tools."""
+    dev_content = DeveloperContent.new()
+    if instructions:
+        dev_content = dev_content.with_instructions(instructions)
+    if tools:
+        fn_tools = [t for t in tools if t.get("type") == "function"]
+        if fn_tools:
+            descriptions = [_create_tool_description(t) for t in fn_tools]
+            dev_content = dev_content.with_function_tools(descriptions)
+    return Message.from_role_and_content(Role.DEVELOPER, dev_content)
+
+
+def build_harmony_preamble(
+    *,
+    instructions: Optional[str] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+) -> List[Message]:
+    """Build the standard Harmony system + developer prefix."""
+    messages = [get_system_message()]
+    if instructions or tools:
+        messages.append(get_developer_message(instructions=instructions, tools=tools))
+    return messages
+
+
+def _flatten_content(content: Any) -> Optional[str]:
+    """Extract text from string or multimodal content list."""
+    if content is None or isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if text is not None:
+                    parts.append(text)
+        return "".join(parts) if parts else None
+    return None
+
+
+def extract_instructions_from_messages(
+    messages: List[Dict[str, Any]],
+) -> tuple:
+    """Peel a leading system/developer message and return (instructions, rest)."""
+    if not messages:
+        return None, messages
+    first = messages[0]
+    if first.get("role") not in ("system", "developer"):
+        return None, messages
+    instructions = _flatten_content(first.get("content"))
+    return instructions, messages[1:]
+
+
+def _parse_single_message(
+    chat_msg: Dict[str, Any],
+    tool_id_names: Dict[str, str],
+) -> List[Message]:
+    """Convert one OpenAI-format message dict to Harmony Message(s)."""
+    role = chat_msg.get("role", "")
+    msgs: List[Message] = []
+    tool_calls = chat_msg.get("tool_calls", [])
+
+    # Assistant message with tool calls
+    if role == "assistant" and tool_calls:
+        content = _flatten_content(chat_msg.get("content"))
+        if content:
+            commentary = Message.from_role_and_content(Role.ASSISTANT, content)
+            commentary = commentary.with_channel("commentary")
+            msgs.append(commentary)
+
+        reasoning = chat_msg.get("reasoning") or chat_msg.get("reasoning_content")
+        if reasoning:
+            analysis = Message.from_role_and_content(Role.ASSISTANT, reasoning)
+            analysis = analysis.with_channel("analysis")
+            msgs.append(analysis)
+
+        for call in tool_calls:
+            func = call.get("function", {})
+            name = func.get("name", "")
+            arguments = func.get("arguments", "") or ""
+            msg = Message.from_role_and_content(Role.ASSISTANT, arguments)
+            msg = msg.with_channel("commentary")
+            msg = msg.with_recipient(f"functions.{name}")
+            msg = msg.with_content_type("json")
+            msgs.append(msg)
+        return msgs
+
+    # Tool result message
+    if role == "tool":
+        tool_call_id = chat_msg.get("tool_call_id", "")
+        name = tool_id_names.get(tool_call_id, "")
+        content = _flatten_content(chat_msg.get("content")) or ""
+        msg = (
+            Message.from_author_and_content(
+                Author.new(Role.TOOL, f"functions.{name}"), content
+            )
+            .with_channel("commentary")
+            .with_recipient("assistant")
+        )
+        return [msg]
+
+    # Non-tool reasoning content
+    reasoning = chat_msg.get("reasoning") or chat_msg.get("reasoning_content")
+    if role == "assistant" and reasoning:
+        analysis = Message.from_role_and_content(Role.ASSISTANT, reasoning)
+        analysis = analysis.with_channel("analysis")
+        msgs.append(analysis)
+
+    # Default: user/assistant/system messages
+    content = chat_msg.get("content") or ""
+    if isinstance(content, str):
+        contents = [TextContent(text=content)]
+    else:
+        contents = [TextContent(text=c.get("text", "")) for c in content]
+
+    if role == "assistant" and contents and contents[0].text:
+        msg = Message.from_role_and_contents(role, contents)
+        msg = msg.with_channel("final")
+        msgs.append(msg)
+    elif role in ("system", "developer"):
+        text = _flatten_content(chat_msg.get("content"))
+        if text:
+            dev_msg = get_developer_message(instructions=text)
+            msgs.append(dev_msg)
+    elif role != "assistant":
+        msg = Message.from_role_and_contents(role, contents)
+        msgs.append(msg)
+
+    return msgs
+
+
+def parse_chat_inputs_to_harmony_messages(
+    chat_msgs: List[Dict[str, Any]],
+) -> List[Message]:
+    """Convert OpenAI-format message dicts to Harmony messages."""
+    tool_id_names: Dict[str, str] = {}
+    for msg in chat_msgs:
+        for tc in msg.get("tool_calls", []):
+            tool_id_names[tc.get("id", "")] = tc.get("function", {}).get("name", "")
+
+    result: List[Message] = []
+    for msg in chat_msgs:
+        result.extend(_parse_single_message(msg, tool_id_names))
+    return result
+
+
+def auto_drop_analysis_messages(msgs: List[Message]) -> List[Message]:
+    """Drop analysis (reasoning) messages before the last assistant final message."""
+    last_final_idx = -1
+    for i in range(len(msgs) - 1, -1, -1):
+        if msgs[i].author.role == "assistant" and msgs[i].channel == "final":
+            last_final_idx = i
+            break
+    if last_final_idx == -1:
+        return msgs
+    return [
+        m for i, m in enumerate(msgs) if not (i < last_final_idx and m.channel == "analysis")
+    ]
+
+
+def render_for_completion(messages: List[Message]) -> List[int]:
+    """Render Harmony messages to prompt token IDs."""
+    messages = auto_drop_analysis_messages(messages)
+    conversation = Conversation.from_messages(messages)
+    return get_encoding().render_conversation_for_completion(
+        conversation,
+        Role.ASSISTANT,
+        config=RenderConversationConfig(auto_drop_analysis=False),
+    )

--- a/atom/entrypoints/openai/harmony_utils.py
+++ b/atom/entrypoints/openai/harmony_utils.py
@@ -175,6 +175,10 @@ def _parse_single_message(
             func = call.get("function", {})
             name = func.get("name", "")
             arguments = func.get("arguments", "") or ""
+            # arguments may be a dict (deserialized by to_template_dict);
+            # Harmony requires a string
+            if isinstance(arguments, dict):
+                arguments = json.dumps(arguments, ensure_ascii=False)
             msg = Message.from_role_and_content(Role.ASSISTANT, arguments)
             msg = msg.with_channel("commentary")
             msg = msg.with_recipient(f"functions.{name}")
@@ -257,6 +261,21 @@ def auto_drop_analysis_messages(msgs: List[Message]) -> List[Message]:
 def render_for_completion(messages: List[Message]) -> List[int]:
     """Render Harmony messages to prompt token IDs."""
     messages = auto_drop_analysis_messages(messages)
+    # Validate each message can serialize before building Conversation
+    for i, msg in enumerate(messages):
+        try:
+            msg.to_dict()
+        except NotImplementedError:
+            logger.error(
+                "Harmony message %d failed to_dict: role=%s channel=%s "
+                "recipient=%s content_types=%s",
+                i,
+                getattr(msg.author, "role", "?"),
+                getattr(msg, "channel", None),
+                getattr(msg, "recipient", None),
+                [type(c).__name__ for c in (msg.content or [])],
+            )
+            raise
     conversation = Conversation.from_messages(messages)
     return get_encoding().render_conversation_for_completion(
         conversation,

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -230,6 +230,14 @@ class ChatCompletionRequest(BaseModel):
             return None
         return [t.model_dump() for t in self.tools]
 
+    def get_tool_choice_value(self) -> Optional[Union[str, Dict[str, Any]]]:
+        """Return tool_choice as a JSON-serializable value for chat templates."""
+        if self.tool_choice is None:
+            return None
+        if isinstance(self.tool_choice, str):
+            return self.tool_choice
+        return self.tool_choice.model_dump()
+
 
 class CompletionRequest(BaseModel):
     """Request model for text completions (OpenAI-compatible)."""

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -7,7 +7,7 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # ============================================================================
 # Constants
@@ -92,6 +92,34 @@ class ChatMessage(BaseModel):
         return d
 
 
+class FunctionDefinition(BaseModel):
+    """OpenAI function definition for tool calling."""
+
+    name: str
+    description: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+
+
+class ChatCompletionToolsParam(BaseModel):
+    """A tool the model may call (OpenAI-compatible)."""
+
+    type: str = "function"
+    function: FunctionDefinition
+
+
+class ChatCompletionNamedFunction(BaseModel):
+    """Reference to a specific function by name for tool_choice."""
+
+    name: str
+
+
+class ChatCompletionNamedToolChoiceParam(BaseModel):
+    """Force the model to call a specific named tool."""
+
+    function: ChatCompletionNamedFunction
+    type: str = "function"
+
+
 class ChatCompletionRequest(BaseModel):
     """Request model for chat completions (OpenAI-compatible)."""
 
@@ -111,16 +139,73 @@ class ChatCompletionRequest(BaseModel):
     seed: Optional[int] = None
     chat_template_kwargs: Optional[Dict[str, Any]] = None
     # Tool calling
-    tools: Optional[List[Dict[str, Any]]] = None
-    tool_choice: Optional[Any] = (
-        None  # "auto", "none", "required", or {function: {name}}
-    )
+    tools: Optional[List[ChatCompletionToolsParam]] = None
+    tool_choice: Optional[Union[str, ChatCompletionNamedToolChoiceParam]] = None
     # Accepted for compatibility, not actively used:
     presence_penalty: Optional[float] = 0.0
     frequency_penalty: Optional[float] = 0.0
     n: Optional[int] = 1
     # Optional KV-transfer metadata for P/D disaggregation.
     kv_transfer_params: Optional[Dict[str, Any]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_tool_usage(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        # Reject empty tools array (matches OpenAI API behaviour)
+        if data.get("tools") == []:
+            raise ValueError(
+                "`tools` must not be an empty array. "
+                "Either provide at least one tool or omit the field entirely."
+            )
+
+        # Default tool_choice to "auto" when tools are provided
+        if "tool_choice" not in data and data.get("tools"):
+            data["tool_choice"] = "auto"
+
+        # "none" needs no further validation
+        if data.get("tool_choice") == "none":
+            return data
+
+        # If tool_choice is set, tools must be present
+        if data.get("tool_choice") is not None:
+            if not data.get("tools"):
+                raise ValueError(
+                    "When using `tool_choice`, `tools` must be set."
+                )
+
+            choice = data["tool_choice"]
+            # Must be a known string or a named-tool dict
+            if choice not in ("auto", "required") and not isinstance(choice, dict):
+                raise ValueError(
+                    f"Invalid value for `tool_choice`: {choice!r}! "
+                    'Only named tools, "none", "auto" or "required" '
+                    "are supported."
+                )
+
+            # Validate named tool choice matches a provided tool
+            if isinstance(choice, dict):
+                fn = choice.get("function")
+                if not isinstance(fn, dict) or "name" not in fn:
+                    raise ValueError(
+                        "Invalid `tool_choice`: expected "
+                        '`{"type": "function", "function": {"name": "my_function"}}`'
+                    )
+                fn_name = fn["name"]
+                tool_names = {
+                    (t.get("function") or {}).get("name")
+                    for t in (data.get("tools") or [])
+                    if isinstance(t, dict)
+                }
+                if fn_name not in tool_names:
+                    raise ValueError(
+                        "The tool specified in `tool_choice` does not match "
+                        "any of the specified `tools`."
+                    )
+
+        return data
 
     def get_max_tokens(self) -> int:
         """Return the effective generation cap for OpenAI chat requests."""
@@ -138,6 +223,12 @@ class ChatCompletionRequest(BaseModel):
             return self.prompt
         else:
             raise ValueError("Either 'messages' or 'prompt' field is required")
+
+    def get_tools_as_dicts(self) -> Optional[List[Dict[str, Any]]]:
+        """Return tools as plain dicts for downstream consumers."""
+        if self.tools is None:
+            return None
+        return [t.model_dump() for t in self.tools]
 
 
 class CompletionRequest(BaseModel):

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -60,6 +60,7 @@ async def stream_chat_response(
     num_prompt_tokens: int,
     cleanup_fn,
     tools=None,
+    use_harmony: bool = False,
 ) -> AsyncGenerator[str, None]:
     """Generate streaming chat completion response with reasoning and tool calls.
 
@@ -71,12 +72,13 @@ async def stream_chat_response(
     ``num_prompt_tokens`` is the engine-computed prompt length (``Sequence.
     num_prompt_tokens``); reusing it avoids re-tokenizing the prompt on the
     event loop at stream start.
+
+    When ``use_harmony`` is True, uses the Harmony token-level parser for
+    GPT-OSS models instead of the text-based reasoning filter + tool parser.
     """
     num_tokens_input = num_prompt_tokens
     num_tokens_output = 0
     num_cached_tokens = 0
-    reasoning_filter = ReasoningFilter()
-    tool_parser = ToolCallStreamParser(tools=tools)
     has_tool_calls = False
 
     # Send initial role chunk
@@ -84,33 +86,99 @@ async def stream_chat_response(
 
     kv_transfer_params_value = None
 
-    while True:
-        chunk_data = await stream_queue.get()
-        new_text = chunk_data["text"]
-        num_tokens_output += len(chunk_data.get("token_ids", []))
-        _ct = chunk_data.get("num_cached_tokens", 0)
-        if _ct:
-            num_cached_tokens = _ct
+    if use_harmony:
+        from .harmony_parser import HarmonyStreamParser
 
-        if "kv_transfer_params" in chunk_data:
-            kv_transfer_params_value = chunk_data["kv_transfer_params"]
+        harmony_parser = HarmonyStreamParser()
 
-        # Phase 1: Process through reasoning filter
-        segments = reasoning_filter.process(new_text)
-        if chunk_data.get("finished", False):
-            segments.extend(reasoning_filter.flush())
+        while True:
+            chunk_data = await stream_queue.get()
+            token_ids = chunk_data.get("token_ids", [])
+            num_tokens_output += len(token_ids)
+            _ct = chunk_data.get("num_cached_tokens", 0)
+            if _ct:
+                num_cached_tokens = _ct
+            if "kv_transfer_params" in chunk_data:
+                kv_transfer_params_value = chunk_data["kv_transfer_params"]
+            finished = chunk_data.get("finished", False)
 
-        # Phase 2: For content segments, check for tool calls
-        for field, text in segments:
-            if field == "reasoning_content":
-                if text:
+            events = harmony_parser.process_tokens(token_ids)
+            if finished:
+                events.extend(harmony_parser.flush())
+
+            for etype, edata in events:
+                if etype == "reasoning":
                     yield create_chat_chunk(
-                        request_id, model, delta={"reasoning_content": text}
+                        request_id, model, delta={"reasoning_content": edata}
                     )
-            elif field == "content":
-                # Run through tool parser
-                events = tool_parser.process(text)
-                for event_type, data in events:
+                elif etype == "content":
+                    yield create_chat_chunk(
+                        request_id, model, delta={"content": edata}
+                    )
+                elif etype == "tool_call_start":
+                    has_tool_calls = True
+                    yield create_chat_chunk(
+                        request_id, model, delta={"tool_calls": [edata]}
+                    )
+                elif etype == "tool_call_args":
+                    yield create_chat_chunk(
+                        request_id, model, delta={"tool_calls": [edata]}
+                    )
+
+            if finished:
+                break
+    else:
+        reasoning_filter = ReasoningFilter()
+        tool_parser = ToolCallStreamParser(tools=tools)
+
+        while True:
+            chunk_data = await stream_queue.get()
+            new_text = chunk_data["text"]
+            num_tokens_output += len(chunk_data.get("token_ids", []))
+            _ct = chunk_data.get("num_cached_tokens", 0)
+            if _ct:
+                num_cached_tokens = _ct
+
+            if "kv_transfer_params" in chunk_data:
+                kv_transfer_params_value = chunk_data["kv_transfer_params"]
+
+            # Phase 1: Process through reasoning filter
+            segments = reasoning_filter.process(new_text)
+            if chunk_data.get("finished", False):
+                segments.extend(reasoning_filter.flush())
+
+            # Phase 2: For content segments, check for tool calls
+            for field, text in segments:
+                if field == "reasoning_content":
+                    if text:
+                        yield create_chat_chunk(
+                            request_id, model, delta={"reasoning_content": text}
+                        )
+                elif field == "content":
+                    # Run through tool parser
+                    events = tool_parser.process(text)
+                    for event_type, data in events:
+                        if event_type == "content":
+                            yield create_chat_chunk(
+                                request_id, model, delta={"content": data}
+                            )
+                        elif event_type == "tool_call_start":
+                            has_tool_calls = True
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                            )
+                        elif event_type == "tool_call_args":
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                            )
+
+            if chunk_data.get("finished", False):
+                # Flush tool parser
+                for event_type, data in tool_parser.flush():
                     if event_type == "content":
                         yield create_chat_chunk(
                             request_id, model, delta={"content": data}
@@ -118,32 +186,13 @@ async def stream_chat_response(
                     elif event_type == "tool_call_start":
                         has_tool_calls = True
                         yield create_chat_chunk(
-                            request_id,
-                            model,
-                            delta={"tool_calls": [data]},
+                            request_id, model, delta={"tool_calls": [data]}
                         )
                     elif event_type == "tool_call_args":
                         yield create_chat_chunk(
-                            request_id,
-                            model,
-                            delta={"tool_calls": [data]},
+                            request_id, model, delta={"tool_calls": [data]}
                         )
-
-        if chunk_data.get("finished", False):
-            # Flush tool parser
-            for event_type, data in tool_parser.flush():
-                if event_type == "content":
-                    yield create_chat_chunk(request_id, model, delta={"content": data})
-                elif event_type == "tool_call_start":
-                    has_tool_calls = True
-                    yield create_chat_chunk(
-                        request_id, model, delta={"tool_calls": [data]}
-                    )
-                elif event_type == "tool_call_args":
-                    yield create_chat_chunk(
-                        request_id, model, delta={"tool_calls": [data]}
-                    )
-            break
+                break
 
     cleanup_fn(request_id, seq_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "a lightweight vLLM implementation built from scratch"
 requires-python = ">=3.10"
 dynamic = ["version"]
-dependencies = ["pybind11", "transformers==5.2.0", "zmq", "msgspec", "xxhash", "fastapi>=0.115,<0.137", "psutil", "protobuf", "uvicorn", "uvloop", "aiohttp", "datasets", "openpyxl", "tqdm"]
+dependencies = ["pybind11", "transformers==5.2.0", "zmq", "msgspec", "xxhash", "fastapi>=0.115,<0.137", "psutil", "protobuf", "uvicorn", "uvloop", "aiohttp", "datasets", "openpyxl", "tqdm", "openai-harmony"]
 
 [project.urls]
 Homepage = "https://github.com/ROCm/ATOM"


### PR DESCRIPTION
  ## Summary

  - Add typed Pydantic models for `tools` and `tool_choice` in `ChatCompletionRequest` with input validation
  - Forward `tool_choice` to chat templates on both `/v1/chat/completions` and `/v1/messages` endpoints
  - Add GPT-OSS Harmony tool calling support via `openai_harmony` library — token-level prompt rendering and output parsing

  ## Changes

  | File | Description |
  |------|-------------|
  | `protocol.py` | Typed tool models + `check_tool_usage` validator |
  | `harmony_utils.py` | **New** — Harmony encoding, message building, prompt rendering for GPT-OSS |
  | `harmony_parser.py` | **New** — Token-level streaming parser via `openai_harmony.StreamableParser` |
  | `api_server.py` | Auto-detect GPT-OSS, route to Harmony on both endpoints |
  | `serving_chat.py` | Add `use_harmony` flag for token-level tool call parsing |

  ## Test plan

  - [ ] GPT-OSS tool calls via `/v1/messages` (Claude Code)
  - [ ] GPT-OSS tool calls via `/v1/chat/completions`
  - [ ] Qwen3/Kimi-K2 regression (existing tool parsers unaffected)

  ## Reproduce (on gfx942)

export ATOM_USE_TRITON_MOE=1
python -m atom.entrypoints.openai_server --model  openai/gpt-oss-20b --server-port 8006 --kv_cache_dtype fp8  --gpu-memory-utilization 0.7 

claude

<img width="1221" height="1487" alt="image" src="https://github.com/user-attachments/assets/4fcb5f2c-6b3f-4189-b0ef-57254ed9d8e1" />
