### PR TITLE
fix: force buffer_load for qo_indptr reads to bypass K$ stale on gfx950

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1315,8 +1315,11 @@ def _convert_req_index_to_global_index_kernel(
     kv_end = tl.load(kv_indptr + batch_id + 1)
     out_kv_start = tl.load(page_kv_indptr + batch_id)
     kv_len = kv_end - kv_start
-    qo_start = tl.load(qo_indptr + batch_id, cache_modifier=".cv")
-    qo_end = tl.load(qo_indptr + batch_id + 1, cache_modifier=".cv")
+    # Force buffer_load (vector path, bypasses K$/scalar-cache) instead of s_load.
+    # s_load uses K$ which H2D DMA does not invalidate on gfx950, causing stale reads
+    # in CUDAGraph replay. tl.arange makes the address a tensor → buffer_load → L2 path.
+    qo_start = tl.sum(tl.load(qo_indptr + batch_id     + tl.arange(0, 1)))
+    qo_end   = tl.sum(tl.load(qo_indptr + batch_id + 1 + tl.arange(0, 1)))
 
     for token_id in range(qo_start, qo_end):
         # Load token indices for this tile


### PR DESCRIPTION
On gfx950/MI355X, H2D DMA writes to cu_seqlens_q are not reflected in the GPU scalar data cache (K$) during CUDAGraph replay, causing _convert_req_index_to_global_index_kernel to read stale cumulative qo_start/qo_end values and access token_indices out-of-bounds.

Root cause: Triton compiles `tl.load(qo_indptr + batch_id)` as `s_load_dwordx2` (scalar load through K$). cache_modifier=".cv" (GLC) has no effect on s_load instructions — GLC only applies to vector loads.

Fix: use `tl.arange(0, 1)` to make the address a [1]-tensor, forcing Triton to emit `buffer_load_dwordx2` (vector path through L2, not K$). The compiler merges the two qo_start/qo_end loads into a single 2-dword vector load, which is also more efficient. tl.sum on a [1]-element tensor extracts the scalar value at zero cost.

ISA verified via llvm-objdump on gfx950:
  before: s_load_dwordx2   (K$, not invalidated by H2D DMA)
  after:  buffer_load_dwordx2  (L2 path, avoids K$ staleness)

Pending: runtime validation on gfx950 to confirm bug suppression.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
