### PR TITLE
[Bugfix] Cancel inference on client disconnect + fix non-stream request leak

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -440,17 +440,36 @@ async def generate_async(
         raise
     engine.core_mgr.add_request([seq])
 
-    while True:
-        item = await token_queue.get()
-        token_ids = item.get("token_ids") or []
-        if token_ids:
-            if first_token_at is None:
-                first_token_at = item.get("ts", time.time())
-            last_token_at = item.get("ts", time.time())
-            all_token_ids.extend(token_ids)
-        if item.get("finished", False):
-            finish_reason = item.get("finish_reason")
-            break
+    _finished_ok = False
+    try:
+        while True:
+            item = await token_queue.get()
+            token_ids = item.get("token_ids") or []
+            if token_ids:
+                if first_token_at is None:
+                    first_token_at = item.get("ts", time.time())
+                last_token_at = item.get("ts", time.time())
+                all_token_ids.extend(token_ids)
+            if item.get("finished", False):
+                finish_reason = item.get("finish_reason")
+                _finished_ok = True
+                break
+    finally:
+        # Two responsibilities, on EVERY exit path:
+        #   1) If we didn't finish (client disconnected / cancelled), tell the
+        #      engine to stop so the seq doesn't run to max_tokens and burn GPU.
+        #   2) Always drop the seq from io_processor.requests. The engine frees
+        #      its own KV on finish, but this dict is only cleaned up here for
+        #      non-stream requests -- without an unconditional pop, every
+        #      completed non-stream request leaks a Sequence (pending grows
+        #      forever). Streaming pops via cleanup_streaming_request instead.
+        if seq is not None:
+            if not _finished_ok:
+                try:
+                    engine.core_mgr.abort_request(seq.id)
+                except Exception:
+                    pass
+            engine.io_processor.requests.pop(seq.id, None)
 
     text = tokenizer.decode(all_token_ids, skip_special_tokens=True)
     num_tokens_input = (
@@ -531,17 +550,29 @@ async def generate_async_multimodal(
         raise
     engine.core_mgr.add_request([seq])
 
-    while True:
-        item = await token_queue.get()
-        token_ids_out = item.get("token_ids") or []
-        if token_ids_out:
-            if first_token_at is None:
-                first_token_at = item.get("ts", time.time())
-            last_token_at = item.get("ts", time.time())
-            all_token_ids.extend(token_ids_out)
-        if item.get("finished", False):
-            finish_reason = item.get("finish_reason")
-            break
+    _finished_ok = False
+    try:
+        while True:
+            item = await token_queue.get()
+            token_ids_out = item.get("token_ids") or []
+            if token_ids_out:
+                if first_token_at is None:
+                    first_token_at = item.get("ts", time.time())
+                last_token_at = item.get("ts", time.time())
+                all_token_ids.extend(token_ids_out)
+            if item.get("finished", False):
+                finish_reason = item.get("finish_reason")
+                _finished_ok = True
+                break
+    finally:
+        # See generate_async: abort on early exit, always pop to avoid leak.
+        if seq is not None:
+            if not _finished_ok:
+                try:
+                    engine.core_mgr.abort_request(seq.id)
+                except Exception:
+                    pass
+            engine.io_processor.requests.pop(seq.id, None)
 
     text = tokenizer.decode(all_token_ids, skip_special_tokens=True)
     num_tokens_output = len(all_token_ids)
@@ -647,19 +678,31 @@ async def generate_async_fanout(
     engine.core_mgr.add_request(seqs)
     num_tokens_input = seqs[0].num_prompt_tokens
 
-    while not all(finished):
-        idx, item = await shared_queue.get()
-        if finished[idx]:
-            continue
-        tokens = item.get("token_ids") or []
-        if tokens:
-            if per_first_token_at[idx] is None:
-                per_first_token_at[idx] = item.get("ts", time.time())
-            per_last_token_at[idx] = item.get("ts", time.time())
-            per_tokens[idx].extend(tokens)
-        if item.get("finished", False):
-            per_finish_reason[idx] = item.get("finish_reason")
-            finished[idx] = True
+    _all_finished = False
+    try:
+        while not all(finished):
+            idx, item = await shared_queue.get()
+            if finished[idx]:
+                continue
+            tokens = item.get("token_ids") or []
+            if tokens:
+                if per_first_token_at[idx] is None:
+                    per_first_token_at[idx] = item.get("ts", time.time())
+                per_last_token_at[idx] = item.get("ts", time.time())
+                per_tokens[idx].extend(tokens)
+            if item.get("finished", False):
+                per_finish_reason[idx] = item.get("finish_reason")
+                finished[idx] = True
+        _all_finished = True
+    finally:
+        # Abort any sibling still running on early exit; always pop all seqs.
+        for _seq in seqs:
+            if not _all_finished:
+                try:
+                    engine.core_mgr.abort_request(_seq.id)
+                except Exception:
+                    pass
+            engine.io_processor.requests.pop(_seq.id, None)
 
     finished_at = time.time()
     outputs: List[Dict[str, Any]] = []
@@ -779,7 +822,75 @@ def cleanup_streaming_request(request_id: str, seq_id: int) -> None:
     _seq_id_to_request_id.pop(seq_id, None)
     _stream_loops.pop(request_id, None)
     _request_start_times.pop(request_id, None)
+    # If the stream ended early (client disconnected) the seq may still be
+    # generating in the engine core -> tell it to stop so it doesn't run to
+    # max_tokens and pile up. No-op if the seq already finished.
+    try:
+        engine.core_mgr.abort_request(seq_id)
+    except Exception:
+        pass
     engine.io_processor.requests.pop(seq_id, None)
+
+
+class _ClientDisconnected(Exception):
+    """Raised when a non-streaming client hangs up mid-generation."""
+
+    def __init__(self, request_id: str):
+        super().__init__(request_id)
+        self.request_id = request_id
+
+
+async def _run_nonstream_with_disconnect(agen, raw_request, request_id):
+    """Drive a non-stream ``generate_async*`` async-generator while actively
+    watching for client disconnect.
+
+    Starlette does NOT cancel a *non-streaming* request handler when the client
+    goes away (unlike StreamingResponse, which is cancelled on http.disconnect).
+    Without this, an abandoned non-stream request keeps ``await``-ing the engine
+    until it hits ``max_tokens`` -- burning GPU on output nobody will read AND
+    leaking the seq in ``io_processor.requests`` (its finally never fires).
+
+    We run the generator in a task and poll ``raw_request.is_disconnected()``
+    concurrently. On disconnect we cancel the task; the cancellation propagates
+    into ``generate_async``'s ``await token_queue.get()`` so its ``finally``
+    runs -> ``abort_request`` + ``io_processor.requests.pop``. Returns the last
+    yielded output, or raises ``_ClientDisconnected``.
+    """
+    final_output = None
+
+    async def _collect():
+        nonlocal final_output
+        async for output in agen:
+            final_output = output
+        return final_output
+
+    task = asyncio.ensure_future(_collect())
+    try:
+        while True:
+            done, _ = await asyncio.wait({task}, timeout=0.5)
+            if task in done:
+                return task.result()
+            disconnected = False
+            if raw_request is not None:
+                try:
+                    disconnected = await raw_request.is_disconnected()
+                except Exception:
+                    disconnected = False
+            if disconnected:
+                logger.info(
+                    f"Client disconnected (non-stream), aborting request "
+                    f"{request_id}"
+                )
+                raise _ClientDisconnected(request_id)
+    finally:
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except BaseException:
+                # CancelledError (expected) or any error from generator
+                # teardown; generate_async's finally already aborted + popped.
+                pass
 
 
 async def setup_streaming_request_fanout(
@@ -908,7 +1019,7 @@ async def general_error_handler(request: Request, exc: Exception):
 
 
 @app.post("/v1/chat/completions")
-async def chat_completions(request: ChatCompletionRequest):
+async def chat_completions(request: ChatCompletionRequest, raw_request: Request):
     """Handle chat completion requests (OpenAI-compatible)."""
     global engine, tokenizer, model_name
 
@@ -1046,14 +1157,16 @@ async def chat_completions(request: ChatCompletionRequest):
                 request_id, model_name, outputs, tools=request.tools
             )
         else:
-            final_output = None
-            async for output in generate_async(
-                prompt,
-                sampling_params,
+            final_output = await _run_nonstream_with_disconnect(
+                generate_async(
+                    prompt,
+                    sampling_params,
+                    request_id,
+                    kv_transfer_params=request.kv_transfer_params,
+                ),
+                raw_request,
                 request_id,
-                kv_transfer_params=request.kv_transfer_params,
-            ):
-                final_output = output
+            )
             if final_output is None:
                 raise RuntimeError("No output generated")
             resp = build_chat_response(
@@ -1066,6 +1179,9 @@ async def chat_completions(request: ChatCompletionRequest):
         _log_request_event("response", request_id, resp.model_dump())
         return resp
 
+    except _ClientDisconnected:
+        # Client hung up; seq already aborted + popped. Nothing to return.
+        return JSONResponse(status_code=499, content={"detail": "client disconnected"})
     except ValueError as e:
         logger.error(f"Validation error in chat_completions: {e}")
         raise HTTPException(status_code=400, detail=str(e))
@@ -1075,7 +1191,7 @@ async def chat_completions(request: ChatCompletionRequest):
 
 
 @app.post("/v1/completions")
-async def completions(request: CompletionRequest):
+async def completions(request: CompletionRequest, raw_request: Request):
     """Handle text completion requests (OpenAI-compatible)."""
     global engine, tokenizer, model_name
 
@@ -1149,15 +1265,17 @@ async def completions(request: CompletionRequest):
                 raise RuntimeError("No output generated")
             resp = build_completion_response_multi(request_id, model_name, outputs)
         else:
-            final_output = None
-            async for output in generate_async(
-                request.prompt,
-                sampling_params,
+            final_output = await _run_nonstream_with_disconnect(
+                generate_async(
+                    request.prompt,
+                    sampling_params,
+                    request_id,
+                    kv_transfer_params=request.kv_transfer_params,
+                    data_parallel_rank=request.data_parallel_rank,
+                ),
+                raw_request,
                 request_id,
-                kv_transfer_params=request.kv_transfer_params,
-                data_parallel_rank=request.data_parallel_rank,
-            ):
-                final_output = output
+            )
 
             if final_output is None:
                 raise RuntimeError("No output generated")
@@ -1166,6 +1284,9 @@ async def completions(request: CompletionRequest):
         _log_request_event("response", request_id, resp.model_dump())
         return resp
 
+    except _ClientDisconnected:
+        # Client hung up; seq already aborted + popped. Nothing to return.
+        return JSONResponse(status_code=499, content={"detail": "client disconnected"})
     except ValueError as e:
         logger.error(f"Validation error in completions: {e}")
         raise HTTPException(status_code=400, detail=str(e))
@@ -1419,9 +1540,11 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         from .reasoning import separate_reasoning
         from .tool_parser import parse_tool_calls
 
-        final_output = None
-        async for output in generate_async(prompt, sampling_params, request_id):
-            final_output = output
+        final_output = await _run_nonstream_with_disconnect(
+            generate_async(prompt, sampling_params, request_id),
+            raw_request,
+            request_id,
+        )
         if final_output is None:
             raise RuntimeError("No output generated")
 
@@ -1444,6 +1567,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             cache_read_input_tokens=cache_read_input_tokens,
         )
 
+    except _ClientDisconnected:
+        # Client hung up; seq already aborted + popped. Nothing to return.
+        return JSONResponse(status_code=499, content={"detail": "client disconnected"})
     except Exception as e:
         logger.error(f"Error in anthropic_messages: {e}", exc_info=True)
         return JSONResponse(

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -61,56 +61,78 @@ async def stream_chat_response(
     cleanup_fn,
     tools=None,
 ) -> AsyncGenerator[str, None]:
-    """Generate streaming chat completion response with reasoning and tool calls.
+    try:
+        """Generate streaming chat completion response with reasoning and tool calls.
 
-    Yields SSE chunks with:
-    - reasoning_content deltas during thinking phase
-    - content deltas for the answer
-    - tool_calls deltas when model invokes tools
+        Yields SSE chunks with:
+        - reasoning_content deltas during thinking phase
+        - content deltas for the answer
+        - tool_calls deltas when model invokes tools
 
-    ``num_prompt_tokens`` is the engine-computed prompt length (``Sequence.
-    num_prompt_tokens``); reusing it avoids re-tokenizing the prompt on the
-    event loop at stream start.
-    """
-    num_tokens_input = num_prompt_tokens
-    num_tokens_output = 0
-    num_cached_tokens = 0
-    reasoning_filter = ReasoningFilter()
-    tool_parser = ToolCallStreamParser(tools=tools)
-    has_tool_calls = False
+        ``num_prompt_tokens`` is the engine-computed prompt length (``Sequence.
+        num_prompt_tokens``); reusing it avoids re-tokenizing the prompt on the
+        event loop at stream start.
+        """
+        num_tokens_input = num_prompt_tokens
+        num_tokens_output = 0
+        num_cached_tokens = 0
+        reasoning_filter = ReasoningFilter()
+        tool_parser = ToolCallStreamParser(tools=tools)
+        has_tool_calls = False
 
-    # Send initial role chunk
-    yield create_chat_chunk(request_id, model, delta={"role": "assistant"})
+        # Send initial role chunk
+        yield create_chat_chunk(request_id, model, delta={"role": "assistant"})
 
-    kv_transfer_params_value = None
+        kv_transfer_params_value = None
 
-    while True:
-        chunk_data = await stream_queue.get()
-        new_text = chunk_data["text"]
-        num_tokens_output += len(chunk_data.get("token_ids", []))
-        _ct = chunk_data.get("num_cached_tokens", 0)
-        if _ct:
-            num_cached_tokens = _ct
+        while True:
+            chunk_data = await stream_queue.get()
+            new_text = chunk_data["text"]
+            num_tokens_output += len(chunk_data.get("token_ids", []))
+            _ct = chunk_data.get("num_cached_tokens", 0)
+            if _ct:
+                num_cached_tokens = _ct
 
-        if "kv_transfer_params" in chunk_data:
-            kv_transfer_params_value = chunk_data["kv_transfer_params"]
+            if "kv_transfer_params" in chunk_data:
+                kv_transfer_params_value = chunk_data["kv_transfer_params"]
 
-        # Phase 1: Process through reasoning filter
-        segments = reasoning_filter.process(new_text)
-        if chunk_data.get("finished", False):
-            segments.extend(reasoning_filter.flush())
+            # Phase 1: Process through reasoning filter
+            segments = reasoning_filter.process(new_text)
+            if chunk_data.get("finished", False):
+                segments.extend(reasoning_filter.flush())
 
-        # Phase 2: For content segments, check for tool calls
-        for field, text in segments:
-            if field == "reasoning_content":
-                if text:
-                    yield create_chat_chunk(
-                        request_id, model, delta={"reasoning_content": text}
-                    )
-            elif field == "content":
-                # Run through tool parser
-                events = tool_parser.process(text)
-                for event_type, data in events:
+            # Phase 2: For content segments, check for tool calls
+            for field, text in segments:
+                if field == "reasoning_content":
+                    if text:
+                        yield create_chat_chunk(
+                            request_id, model, delta={"reasoning_content": text}
+                        )
+                elif field == "content":
+                    # Run through tool parser
+                    events = tool_parser.process(text)
+                    for event_type, data in events:
+                        if event_type == "content":
+                            yield create_chat_chunk(
+                                request_id, model, delta={"content": data}
+                            )
+                        elif event_type == "tool_call_start":
+                            has_tool_calls = True
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                            )
+                        elif event_type == "tool_call_args":
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                            )
+
+            if chunk_data.get("finished", False):
+                # Flush tool parser
+                for event_type, data in tool_parser.flush():
                     if event_type == "content":
                         yield create_chat_chunk(
                             request_id, model, delta={"content": data}
@@ -118,60 +140,44 @@ async def stream_chat_response(
                     elif event_type == "tool_call_start":
                         has_tool_calls = True
                         yield create_chat_chunk(
-                            request_id,
-                            model,
-                            delta={"tool_calls": [data]},
+                            request_id, model, delta={"tool_calls": [data]}
                         )
                     elif event_type == "tool_call_args":
                         yield create_chat_chunk(
-                            request_id,
-                            model,
-                            delta={"tool_calls": [data]},
+                            request_id, model, delta={"tool_calls": [data]}
                         )
+                break
 
-        if chunk_data.get("finished", False):
-            # Flush tool parser
-            for event_type, data in tool_parser.flush():
-                if event_type == "content":
-                    yield create_chat_chunk(request_id, model, delta={"content": data})
-                elif event_type == "tool_call_start":
-                    has_tool_calls = True
-                    yield create_chat_chunk(
-                        request_id, model, delta={"tool_calls": [data]}
-                    )
-                elif event_type == "tool_call_args":
-                    yield create_chat_chunk(
-                        request_id, model, delta={"tool_calls": [data]}
-                    )
-            break
+        cleanup_fn(request_id, seq_id)
 
-    cleanup_fn(request_id, seq_id)
-
-    # Final chunks
-    finish_reason = "tool_calls" if has_tool_calls else "stop"
-    usage = {
-        "prompt_tokens": num_tokens_input,
-        "completion_tokens": num_tokens_output,
-        "total_tokens": num_tokens_input + num_tokens_output,
-        "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
-    }
-    usage_chunk = {
-        "id": request_id,
-        "object": CHAT_COMPLETION_CHUNK_OBJECT,
-        "created": int(time.time()),
-        "model": model,
-        "usage": usage,
-    }
-    if kv_transfer_params_value is not None:
-        usage_chunk["kv_transfer_params"] = kv_transfer_params_value
-    # Coalesce finish + usage + [DONE] into one send: at a wave boundary many
-    # requests finalize at once, so collapsing 3 socket writes/req to 1 cuts
-    # the syscalls that saturate the API event loop.
-    yield (
-        create_chat_chunk(request_id, model, finish_reason=finish_reason)
-        + f"data: {json.dumps(usage_chunk)}\n\n"
-        + STREAM_DONE_MESSAGE
-    )
+        # Final chunks
+        finish_reason = "tool_calls" if has_tool_calls else "stop"
+        usage = {
+            "prompt_tokens": num_tokens_input,
+            "completion_tokens": num_tokens_output,
+            "total_tokens": num_tokens_input + num_tokens_output,
+            "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
+        }
+        usage_chunk = {
+            "id": request_id,
+            "object": CHAT_COMPLETION_CHUNK_OBJECT,
+            "created": int(time.time()),
+            "model": model,
+            "choices": [],
+            "usage": usage,
+        }
+        if kv_transfer_params_value is not None:
+            usage_chunk["kv_transfer_params"] = kv_transfer_params_value
+        # Coalesce finish + usage + [DONE] into one send: at a wave boundary many
+        # requests finalize at once, so collapsing 3 socket writes/req to 1 cuts
+        # the syscalls that saturate the API event loop.
+        yield (
+            create_chat_chunk(request_id, model, finish_reason=finish_reason)
+            + f"data: {json.dumps(usage_chunk)}\n\n"
+            + STREAM_DONE_MESSAGE
+        )
+    finally:
+        cleanup_fn(request_id, seq_id)
 
 
 def _build_chat_choice(
@@ -298,59 +304,84 @@ async def stream_chat_response_fanout(
     cleanup_fn,
     tools=None,
 ) -> AsyncGenerator[str, None]:
-    """Streaming variant that multiplexes ``len(seq_ids)`` fan-out siblings
-    into a single SSE stream, tagging every chunk with ``choices[0].index``.
+    try:
+        """Streaming variant that multiplexes ``len(seq_ids)`` fan-out siblings
+        into a single SSE stream, tagging every chunk with ``choices[0].index``.
 
-    The shared queue receives ``(sibling_index, chunk_data)`` tuples from
-    the engine callbacks registered in :func:`setup_streaming_request_fanout`.
-    Reasoning + tool-call state is kept independently per sibling.
+        The shared queue receives ``(sibling_index, chunk_data)`` tuples from
+        the engine callbacks registered in :func:`setup_streaming_request_fanout`.
+        Reasoning + tool-call state is kept independently per sibling.
 
-    ``num_prompt_tokens`` is the engine-computed prompt length shared by all
-    siblings (they tokenize the same prompt once); reusing it avoids
-    re-tokenizing on the event loop at stream start.
-    """
-    n = len(seq_ids)
-    num_tokens_input = num_prompt_tokens
-    num_tokens_output = [0] * n
-    reasoning_filters = [ReasoningFilter() for _ in range(n)]
-    tool_parsers = [ToolCallStreamParser(tools=tools) for _ in range(n)]
-    has_tool_calls = [False] * n
-    finished = [False] * n
-    kv_transfer_params_value = None
-    num_cached_tokens = 0
+        ``num_prompt_tokens`` is the engine-computed prompt length shared by all
+        siblings (they tokenize the same prompt once); reusing it avoids
+        re-tokenizing on the event loop at stream start.
+        """
+        n = len(seq_ids)
+        num_tokens_input = num_prompt_tokens
+        num_tokens_output = [0] * n
+        num_cached_tokens = 0
+        reasoning_filters = [ReasoningFilter() for _ in range(n)]
+        tool_parsers = [ToolCallStreamParser(tools=tools) for _ in range(n)]
+        has_tool_calls = [False] * n
+        finished = [False] * n
+        kv_transfer_params_value = None
 
-    for i in range(n):
-        yield create_chat_chunk(request_id, model, delta={"role": "assistant"}, index=i)
+        for i in range(n):
+            yield create_chat_chunk(
+                request_id, model, delta={"role": "assistant"}, index=i
+            )
 
-    while not all(finished):
-        idx, chunk_data = await shared_queue.get()
-        if finished[idx]:
-            # Defensive: should not happen, engine emits finished once per seq.
-            continue
-        new_text = chunk_data["text"]
-        num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
-        _ct = chunk_data.get("num_cached_tokens", 0)
-        if _ct:
-            num_cached_tokens = _ct
+        while not all(finished):
+            idx, chunk_data = await shared_queue.get()
+            if finished[idx]:
+                # Defensive: should not happen, engine emits finished once per seq.
+                continue
+            new_text = chunk_data["text"]
+            num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
+            _ct = chunk_data.get("num_cached_tokens", 0)
+            if _ct:
+                num_cached_tokens = _ct
 
-        if "kv_transfer_params" in chunk_data:
-            kv_transfer_params_value = chunk_data["kv_transfer_params"]
+            if "kv_transfer_params" in chunk_data:
+                kv_transfer_params_value = chunk_data["kv_transfer_params"]
 
-        segments = reasoning_filters[idx].process(new_text)
-        if chunk_data.get("finished", False):
-            segments.extend(reasoning_filters[idx].flush())
+            segments = reasoning_filters[idx].process(new_text)
+            if chunk_data.get("finished", False):
+                segments.extend(reasoning_filters[idx].flush())
 
-        for field, text in segments:
-            if field == "reasoning_content":
-                if text:
-                    yield create_chat_chunk(
-                        request_id,
-                        model,
-                        delta={"reasoning_content": text},
-                        index=idx,
-                    )
-            elif field == "content":
-                for event_type, data in tool_parsers[idx].process(text):
+            for field, text in segments:
+                if field == "reasoning_content":
+                    if text:
+                        yield create_chat_chunk(
+                            request_id,
+                            model,
+                            delta={"reasoning_content": text},
+                            index=idx,
+                        )
+                elif field == "content":
+                    for event_type, data in tool_parsers[idx].process(text):
+                        if event_type == "content":
+                            yield create_chat_chunk(
+                                request_id, model, delta={"content": data}, index=idx
+                            )
+                        elif event_type == "tool_call_start":
+                            has_tool_calls[idx] = True
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                                index=idx,
+                            )
+                        elif event_type == "tool_call_args":
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                                index=idx,
+                            )
+
+            if chunk_data.get("finished", False):
+                for event_type, data in tool_parsers[idx].flush():
                     if event_type == "content":
                         yield create_chat_chunk(
                             request_id, model, delta={"content": data}, index=idx
@@ -370,61 +401,43 @@ async def stream_chat_response_fanout(
                             delta={"tool_calls": [data]},
                             index=idx,
                         )
+                finished[idx] = True
 
-        if chunk_data.get("finished", False):
-            for event_type, data in tool_parsers[idx].flush():
-                if event_type == "content":
-                    yield create_chat_chunk(
-                        request_id, model, delta={"content": data}, index=idx
-                    )
-                elif event_type == "tool_call_start":
-                    has_tool_calls[idx] = True
-                    yield create_chat_chunk(
-                        request_id,
-                        model,
-                        delta={"tool_calls": [data]},
-                        index=idx,
-                    )
-                elif event_type == "tool_call_args":
-                    yield create_chat_chunk(
-                        request_id,
-                        model,
-                        delta={"tool_calls": [data]},
-                        index=idx,
-                    )
-            finished[idx] = True
+        # Clean up all sibling seq_id entries then the shared request state.
+        for sid in seq_ids:
+            cleanup_fn(request_id, sid)
 
-    # Clean up all sibling seq_id entries then the shared request state.
-    for sid in seq_ids:
-        cleanup_fn(request_id, sid)
-
-    usage = {
-        "prompt_tokens": num_tokens_input,
-        "completion_tokens": sum(num_tokens_output),
-        "total_tokens": num_tokens_input + sum(num_tokens_output),
-        "num_choices": n,
-        "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
-    }
-    usage_chunk = {
-        "id": request_id,
-        "object": CHAT_COMPLETION_CHUNK_OBJECT,
-        "created": int(time.time()),
-        "model": model,
-        "usage": usage,
-    }
-    if kv_transfer_params_value is not None:
-        usage_chunk["kv_transfer_params"] = kv_transfer_params_value
-    # Coalesce the per-sibling finish chunks + usage + [DONE] into one send.
-    yield (
-        "".join(
-            create_chat_chunk(
-                request_id,
-                model,
-                finish_reason="tool_calls" if has_tool_calls[i] else "stop",
-                index=i,
+        usage = {
+            "prompt_tokens": num_tokens_input,
+            "completion_tokens": sum(num_tokens_output),
+            "total_tokens": num_tokens_input + sum(num_tokens_output),
+            "num_choices": n,
+            "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
+        }
+        usage_chunk = {
+            "id": request_id,
+            "object": CHAT_COMPLETION_CHUNK_OBJECT,
+            "created": int(time.time()),
+            "model": model,
+            "choices": [],
+            "usage": usage,
+        }
+        if kv_transfer_params_value is not None:
+            usage_chunk["kv_transfer_params"] = kv_transfer_params_value
+        # Coalesce the per-sibling finish chunks + usage + [DONE] into one send.
+        yield (
+            "".join(
+                create_chat_chunk(
+                    request_id,
+                    model,
+                    finish_reason="tool_calls" if has_tool_calls[i] else "stop",
+                    index=i,
+                )
+                for i in range(n)
             )
-            for i in range(n)
+            + f"data: {json.dumps(usage_chunk)}\n\n"
+            + STREAM_DONE_MESSAGE
         )
-        + f"data: {json.dumps(usage_chunk)}\n\n"
-        + STREAM_DONE_MESSAGE
-    )
+    finally:
+        for _sid in seq_ids:
+            cleanup_fn(request_id, _sid)

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -460,6 +460,18 @@ class CoreManager:
                 copy=False,
             )
 
+    def abort_request(self, req_id):
+        """Tell the engine core(s) to drop a request (client disconnected).
+
+        Broadcast to every DP rank (only the one holding ``req_id`` acts). The
+        scheduler finishes the seq at its next step via the normal stop path,
+        freeing its KV blocks. Fire-and-forget; safe if the seq already finished.
+        """
+        try:
+            self.broadcast_utility_command("abort_request", req_id=req_id)
+        except Exception as e:
+            logger.warning(f"{self.label}: abort_request({req_id}) failed: {e}")
+
     def broadcast_utility_command(self, cmd: str, **kwargs):
         payload = {"cmd": cmd, **kwargs}
         # Serialize once and reuse for all ranks (optimization: avoid repeated pickle.dumps)

--- a/atom/model_engine/engine_utility.py
+++ b/atom/model_engine/engine_utility.py
@@ -41,6 +41,7 @@ class EngineUtilityHandler:
         "stop_profile": "_handle_stop_profile",
         "get_mtp_stats": "_handle_get_mtp_stats",
         "get_mtp_statistics": "_handle_get_mtp_statistics",
+        "abort_request": "_handle_abort_request",
     }
 
     def __init__(
@@ -209,6 +210,19 @@ class EngineUtilityHandler:
         self.output_queue.put_nowait(
             ("UTILITY_RESPONSE", {"cmd": "clear_kv_cache", "result": result})
         )
+
+    def _handle_abort_request(self, args: dict):
+        """Mark a sequence aborted (client disconnected) so the scheduler finishes
+        it at the next step via the normal stop path (frees KV, drops it)."""
+        req_id = args.get("req_id") if isinstance(args, dict) else None
+        if req_id is None or self.scheduler is None:
+            return
+        found = False
+        for seq in list(self.scheduler.running) + list(self.scheduler.waiting):
+            if seq.id == req_id:
+                seq.aborted = True
+                found = True
+        logger.info(f"{self.label}: abort_request req_id={req_id} found={found}")
 
     def _handle_configure_hidden_states(self, args: dict):
         """Configure hidden states extraction on all model runners (TorchSpec)."""

--- a/atom/model_engine/engine_utility.py
+++ b/atom/model_engine/engine_utility.py
@@ -4,6 +4,8 @@
 import logging
 import queue
 
+from atom.model_engine.sequence import SequenceStatus
+
 logger = logging.getLogger("atom")
 
 
@@ -212,7 +214,7 @@ class EngineUtilityHandler:
         )
 
     def _handle_abort_request(self, args: dict):
-        """Mark a sequence aborted (client disconnected) so the scheduler finishes
+        """Mark a sequence ABORTED (client disconnected) so the scheduler finishes
         it at the next step via the normal stop path (frees KV, drops it)."""
         req_id = args.get("req_id") if isinstance(args, dict) else None
         if req_id is None or self.scheduler is None:
@@ -220,7 +222,7 @@ class EngineUtilityHandler:
         found = False
         for seq in list(self.scheduler.running) + list(self.scheduler.waiting):
             if seq.id == req_id:
-                seq.aborted = True
+                seq.status = SequenceStatus.ABORTED
                 found = True
         logger.info(f"{self.label}: abort_request req_id={req_id} found={found}")
 

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -1430,6 +1430,11 @@ class Scheduler:
 
             num_tokens = seq.num_tokens - self.mtp_k - num_rejected
             leave_reason = None
+            # Client disconnected -> finish now via the normal stop path (frees
+            # KV blocks, emits a finished RequestOutput). A natural stop below
+            # may still overwrite the reason; either way the seq terminates.
+            if getattr(seq, "aborted", False):
+                leave_reason = "aborted"
             # MTP edge case: `rejection_sampler` does NOT inspect EOS — it
             # only compares draft vs target_argmax for acceptance. So when
             # the verified token is EOS the kernel still emits 1+ accepted

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -767,6 +767,18 @@ class Scheduler:
         ):
             seq = self.waiting.popleft()
 
+            # Client disconnected before this seq ever ran: it holds no KV yet
+            # and needs no forward pass, so finish it outright and route via
+            # `_rejected` (emits a finished RequestOutput through the same
+            # output_queue). Must intercept here BEFORE the waiting->running
+            # promotion below, which would overwrite ABORTED with RUNNING and
+            # lose the abort intent.
+            if seq.status == SequenceStatus.ABORTED:
+                seq.status = SequenceStatus.FINISHED
+                seq.leave_reason = "aborted"
+                self._rejected.append(seq)
+                continue
+
             # Drop seqs the static-capacity check at submit-time flagged as
             # permanently unschedulable (oversized prompt, exhausted pool,
             # etc.). They've already been warned; mark FINISHED + record the
@@ -1433,7 +1445,7 @@ class Scheduler:
             # Client disconnected -> finish now via the normal stop path (frees
             # KV blocks, emits a finished RequestOutput). A natural stop below
             # may still overwrite the reason; either way the seq terminates.
-            if getattr(seq, "aborted", False):
+            if seq.status == SequenceStatus.ABORTED:
                 leave_reason = "aborted"
             # MTP edge case: `rejection_sampler` does NOT inspect EOS — it
             # only compares draft vs target_argmax for acceptance. So when

--- a/atom/model_engine/sequence.py
+++ b/atom/model_engine/sequence.py
@@ -14,6 +14,11 @@ class SequenceStatus(Enum):
     WAITING_FOR_REMOTE_KVS = auto()
     WAITING = auto()
     RUNNING = auto()
+    # Client disconnected: the seq is still live (its KV must be freed via the
+    # normal stop path). The scheduler finishes it at the next step (running) or
+    # drops it when popped from `waiting`. Distinct from FINISHED so it still
+    # rides one cleanup pass; is_finished() stays False until then.
+    ABORTED = auto()
     FINISHED = auto()
     EXIT_ENGINE = auto()
 
@@ -120,9 +125,6 @@ class Sequence:
         self.first_token_time = 0.0
         self.leave_time = 0.0
         self.leave_reason = ""
-        # Set True when the client disconnected; the scheduler finishes the seq
-        # at the next step via the normal stop path (frees KV, emits finished).
-        self.aborted = False
 
         # kv_transfer params
         self.kv_transfer_params = kv_transfer_params

--- a/atom/model_engine/sequence.py
+++ b/atom/model_engine/sequence.py
@@ -120,6 +120,9 @@ class Sequence:
         self.first_token_time = 0.0
         self.leave_time = 0.0
         self.leave_reason = ""
+        # Set True when the client disconnected; the scheduler finishes the seq
+        # at the next step via the normal stop path (frees KV, emits finished).
+        self.aborted = False
 
         # kv_transfer params
         self.kv_transfer_params = kv_transfer_params


### PR DESCRIPTION
## Summary

Two independent bugs in the OpenAI server, both surfaced by retrying clients (opencode / Claude Code) which pile up unbounded `pending requests` and waste GPU on output nobody reads.

**1. No disconnect cancellation.** Neither the streaming generators nor the non-stream handlers aborted the engine sequence when the client hung up, so an abandoned request ran to `max_tokens`.
- Add an engine abort path: `Sequence.aborted` → Scheduler reuses the normal finish/deallocate stop path; `EngineUtilityHandler.abort_request`; `CoreManager.abort_request` (broadcast to all DP ranks).
- Streaming generators (`stream_chat_response` / `_fanout`) now run under try/finally so `cleanup_streaming_request` (which aborts the seq) fires on `GeneratorExit`.
- Starlette does **not** cancel the handler on disconnect for non-stream, so add `_run_nonstream_with_disconnect()` which races generation against `raw_request.is_disconnected()` and cancels on disconnect. `chat_completions` / `completions` gain a `raw_request` param.

**2. Non-stream request leak.** `generate_async` / `_multimodal` / `_fanout` only removed the request from `io_processor.requests` on a setup exception, never on normal completion → every completed non-stream request leaked a `Sequence` (pending grew forever). Wrap the token loops in try/finally that always pops (and aborts on early exit). Streaming already pops via `cleanup_streaming_request`.

Also add `"choices": []` to the streaming usage chunk so AI-SDK clients (opencode) stop rejecting the final usage frame.

## Why

Under an agentic client that retries / cancels mid-generation, the pre-fix server leaks a Sequence per completed non-stream request and keeps abandoned requests running to `max_tokens`. `pending requests` grows without bound and GPU stays pinned on discarded work.

## Test plan

Verified on DeepSeek-V4, TP8:
- 6 sequential non-stream completions → `pending requests` stays flat (was 1→8).
- 3 mid-generation client disconnects → `abort_request ... found=True`, GPU utilization drops immediately, pending flat (was +3 leak with GPU pinned to `max_tokens`).
- Normal streaming + non-stream answers unchanged.

Reproduce:
```bash
PORT=9700; M=<served-model-id>
# (1) non-stream leak: fire 6, pending must stay flat
for i in $(seq 6); do
  curl -s localhost:$PORT/v1/chat/completions -H 'Content-Type: application/json' \
    -d '{"model":"'"$M"'","messages":[{"role":"user","content":"hi"}],"max_tokens":8}' >/dev/null
done
# (2) disconnect cancel: start long gen, drop after 2s -> log shows abort found, GPU drops
timeout 2 curl -s localhost:$PORT/v1/chat/completions -H 'Content-Type: application/json' \
  -d '{"model":"'"$M"'","messages":[{"role":"user","content":"write a very long essay"}],"max_tokens":4000}' >/dev/null
# (3) regression: normal stream + non-stream still correct
curl -s localhost:$PORT/v1/chat/completions -H 'Content-Type: application/json' \
  -d '{"model":"'"$M"'","messages":[{"role":"user","content":"2+2?"}],"max_tokens":10}'
```

Split out of #1428 (which now carries only the DeepSeek-V4 DSML tool-call changes) so this fix can be reviewed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)