### PR TITLE
[Frontend] openai: multi-model tool-call parsing + reasoning (GLM / MiniMax-M3 / DSML)

### DIFF
--- a/atom/entrypoints/openai/chat_encoders.py
+++ b/atom/entrypoints/openai/chat_encoders.py
@@ -85,6 +85,46 @@ def load_custom_message_encoder(model_path: str) -> Optional[MessageEncoder]:
     return _load_encoder_from_dir(_resolve_model_path(model_path))
 
 
+def _content_str(c: Any) -> str:
+    if isinstance(c, list):
+        return "\n".join(
+            b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return c or ""
+
+
+def _normalize_for_v4(messages: List[dict], tools: Optional[List[dict]]) -> List[dict]:
+    """Prepare messages for DeepSeek-V4's ``encode_messages``.
+
+    Two things:
+    1. **Hoist system messages to the front.** Clients (notably Claude Code) send
+       a trailing ``system``-role message (its "skills" list) AFTER the user turn.
+       ``encode_messages`` only appends the ``<｜Assistant｜>`` generation marker
+       after a *user*/developer message, so a trailing system message leaves the
+       prompt ending mid-system-text and the model just *continues* it instead of
+       answering. Merging all system content into one leading system message keeps
+       the final turn a user turn, so the assistant marker is emitted.
+    2. **Attach tools** to that leading system message (``encode_messages`` reads
+       tool schemas from a system message's ``tools`` field).
+    Does not mutate the input.
+    """
+    sys_parts, others = [], []
+    for m in messages:
+        (sys_parts if m.get("role") == "system" else others).append(dict(m))
+
+    if not sys_parts and not tools:
+        return [dict(m) for m in messages]
+
+    merged = "\n\n".join(s for s in (_content_str(m.get("content")) for m in sys_parts) if s)
+    sys_msg: dict = {"role": "system", "content": merged}
+    for m in sys_parts:                      # preserve any pre-attached tools
+        if m.get("tools"):
+            sys_msg["tools"] = m["tools"]
+    if tools:
+        sys_msg["tools"] = tools
+    return [sys_msg] + others
+
+
 def apply_chat_template(
     tokenizer: Any,
     custom_encoder: Optional[MessageEncoder],
@@ -97,18 +137,15 @@ def apply_chat_template(
 
     Dispatches to ``custom_encoder`` if one was discovered for this model,
     otherwise to ``tokenizer.apply_chat_template``. Jinja-only kwargs
-    (``tokenize``, ``add_generation_prompt``) are stripped on the custom
-    path; ``tools`` are forwarded only on the Jinja path (custom encoders
-    don't currently have a tools API — caller is warned and tools are
-    dropped).
+    (``tokenize``, ``add_generation_prompt``) are stripped on the custom path.
+    ``tools`` are supported on both paths: custom encoders (e.g. DeepSeek-V4's
+    ``encode_messages``) read tool schemas from a system message's ``tools``
+    field, so we attach them there before encoding.
     """
     if custom_encoder is not None:
         for k in ("tokenize", "add_generation_prompt"):
             kwargs.pop(k, None)
-        if tools:
-            logger.warning(
-                "tools= is not supported with the custom message encoder; ignoring."
-            )
+        messages = _normalize_for_v4(messages, tools)
         return custom_encoder(messages, **kwargs)
 
     kwargs["tokenize"] = False

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -23,6 +23,9 @@ def separate_reasoning(text: str) -> Tuple[Optional[str], str]:
         Tuple of (reasoning_content, content). reasoning_content is None if
         no thinking block was found.
     """
+    # MiniMax M3 emits <mm:think>...</mm:think> instead of <think>...</think>;
+    # normalize so the shared logic below handles both.
+    text = text.replace("<mm:think>", "<think>").replace("</mm:think>", "</think>")
     # Check for closed thinking block: <think>...</think>
     match = re.match(r"<think>(.*?)</think>\s*(.*)", text, flags=re.DOTALL)
     if match:
@@ -75,6 +78,10 @@ class ReasoningFilter:
             List of (field_name, text) tuples where field_name is
             "reasoning_content" or "content".
         """
+        # MiniMax M3 uses <mm:think>/</mm:think>; normalize to the <think> tags
+        # the state machine below keys on. These are single special tokens, so
+        # each arrives whole in one chunk — a plain replace is safe.
+        text = text.replace("<mm:think>", "<think>").replace("</mm:think>", "</think>")
         results = []
 
         if self.state == 0:

--- a/atom/entrypoints/openai/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser.py
@@ -183,21 +183,312 @@ def _parse_qwen_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCal
     return content.strip(), tool_calls
 
 
+# ---------------------------------------------------------------------------
+# DeepSeek-V4 DSML tool-call format
+# ---------------------------------------------------------------------------
+#
+#     <｜DSML｜tool_calls>
+#     <｜DSML｜invoke name="NAME">
+#     <｜DSML｜parameter name="PNAME" string="true|false">VALUE</｜DSML｜parameter>
+#     ...
+#     </｜DSML｜invoke>
+#     </｜DSML｜tool_calls>
+#
+# string="true"  -> value is a raw string; string="false" -> value is JSON.
+# DeepSeek-V4-Flash occasionally malforms this (singular ``tool_call``, a missing
+# ``invoke`` wrapper, or params without ``string=``); the parser recovers those
+# best-effort: it infers a dropped tool name from the parameter signature vs the
+# request's ``tools`` and infers a missing value type from the schema / JSON.
+
+_DSML = "｜DSML｜"
+# The model often DROPS the ``｜DSML｜`` marker and emits bare
+# ``<invoke name=...>``/``<parameter ...>``/``<tool_calls>`` tags, so the marker
+# is matched OPTIONALLY everywhere.
+_OPT = r"(?:" + re.escape(_DSML) + r")?"      # optional ｜DSML｜ prefix
+_DSML_PARAM_RE = re.compile(
+    r"<" + _OPT + r'parameter\s+name="(.*?)"(?:\s+string="(true|false)")?\s*>'
+    r"(.*?)</" + _OPT + r"parameter>",
+    re.DOTALL,
+)
+_DSML_INVOKE_RE = re.compile(
+    r"<" + _OPT + r'invoke\s+name="(.*?)"\s*>(.*?)</' + _OPT + r"invoke>",
+    re.DOTALL,
+)
+# Region-start markers, both marked and marker-less variants.
+_DSML_STARTS = (
+    "<" + _DSML + "tool_call",   # marked (covers tool_call / tool_calls)
+    "<" + _DSML + "invoke",      # marked invoke
+    "<invoke name=",             # marker-less invoke (common malform)
+    "<tool_calls>",              # marker-less section open
+)
+
+
+def _dsml_start(text: str) -> int:
+    """Index of the earliest DSML tool-call marker (marked or marker-less), or -1."""
+    positions = [i for i in (text.find(m) for m in _DSML_STARTS) if i != -1]
+    return min(positions) if positions else -1
+
+
+def _is_dsml(text: str) -> bool:
+    return _dsml_start(text) != -1
+
+
+def _dsml_coerce(value: str, string_attr: Optional[str], ptype: Any) -> Any:
+    if string_attr == "true":
+        return value
+    if string_attr == "false":
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+    # attr absent -> use declared schema type if known, else infer via JSON.
+    if ptype is not None:
+        return _coerce_param_value(value, ptype)
+    v = value.strip()
+    try:
+        return json.loads(v)
+    except Exception:
+        return v
+
+
+def _infer_dsml_name(arg_names: set, param_types: Dict[str, Dict[str, Any]]) -> Optional[str]:
+    """Pick the request tool whose parameter set best matches ``arg_names``."""
+    best, best_score = None, -1e9
+    for name, props in param_types.items():
+        p = set(props)
+        if not p:
+            continue
+        score = len(p & arg_names) - 0.1 * len(p ^ arg_names)
+        if score > best_score:
+            best_score, best = score, name
+    return best
+
+
+def _parse_dsml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCall]]:
+    """Parse DeepSeek-V4 DSML tool calls; return (leading_content, tool_calls)."""
+    param_types = _build_param_types(tools)
+    start = _dsml_start(text)
+    if start == -1:
+        return text.strip(), []
+    content = text[:start]
+    region = text[start:]
+
+    calls: List[Tuple[str, Dict[str, Any]]] = []
+    invokes = list(_DSML_INVOKE_RE.finditer(region))
+    if invokes:
+        for m in invokes:
+            name = m.group(1)
+            types = param_types.get(name, {})
+            args = {
+                pm.group(1): _dsml_coerce(pm.group(3), pm.group(2), types.get(pm.group(1)))
+                for pm in _DSML_PARAM_RE.finditer(m.group(2))
+            }
+            calls.append((name, args))
+    else:
+        # malformed: no complete invoke wrapper -> collect params, infer tool name
+        raw = {pm.group(1): (pm.group(3), pm.group(2)) for pm in _DSML_PARAM_RE.finditer(region)}
+        if raw:
+            name = _infer_dsml_name(set(raw), param_types) or "unknown"
+            types = param_types.get(name, {})
+            args = {k: _dsml_coerce(v, s, types.get(k)) for k, (v, s) in raw.items()}
+            calls.append((name, args))
+
+    tool_calls = [
+        ToolCall(
+            id=_unique_tool_call_id(),
+            type="function",
+            function={"name": name, "arguments": json.dumps(args, ensure_ascii=False)},
+        )
+        for name, args in calls
+    ]
+    if _DSML in content:  # scrub any stray marker fragment
+        content = content.split("<" + _DSML, 1)[0]
+    return content.strip(), tool_calls
+
+
+# ---------------------------------------------------------------------------
+# GLM-4.5 / 4.6 / 5.x tool-call format
+# ---------------------------------------------------------------------------
+#
+#     <tool_call>NAME
+#     <arg_key>K1</arg_key><arg_value>V1</arg_value>
+#     <arg_key>K2</arg_key><arg_value>V2</arg_value>
+#     ...</tool_call>
+#
+# The function name follows the opening tag directly (no ``<function=`` wrapper,
+# which is how this is told apart from the Qwen3 XML format). GLM's chat template
+# renders non-string argument values with ``tojson`` and string values raw, so a
+# value is JSON-decoded when the request schema declares a non-string type (or
+# when it parses as JSON) and otherwise kept as a raw string.
+
+_GLM_TOOLCALL_RE = re.compile(
+    r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)$", re.DOTALL
+)
+_GLM_ARG_RE = re.compile(
+    r"<arg_key>(.*?)</arg_key>\s*<arg_value>"
+    r"(.*?)(?:</arg_value>|(?=<arg_key>)|(?=</tool_call>)|$)",
+    re.DOTALL,
+)
+
+
+def _is_glm(text: str) -> bool:
+    """Detect the GLM ``<tool_call>...<arg_key>`` format (never Qwen/DSML)."""
+    if _QWEN_TOOL_PREFIX in text:  # '<function=' -> Qwen, not GLM
+        return False
+    return "<arg_key>" in text or "<tool_call>" in text
+
+
+def _glm_coerce(value: str, ptype: Any) -> Any:
+    """Decode one GLM ``<arg_value>``: schema type wins, else JSON, else raw."""
+    v = value.strip("\n")
+    if ptype is not None:
+        return _coerce_param_value(v, ptype)
+    s = v.strip()
+    try:
+        return json.loads(s)
+    except Exception:
+        return v
+
+
+def _parse_glm(text: str, tools: Optional[list] = None) -> Tuple[str, List[ToolCall]]:
+    """Parse GLM tool calls; return (leading_content, tool_calls)."""
+    param_types = _build_param_types(tools)
+    start = text.find("<tool_call>")
+    if start == -1:
+        return text.strip(), []
+    content = text[:start]
+    tool_calls: List[ToolCall] = []
+    for m in _GLM_TOOLCALL_RE.finditer(text):
+        body = m.group(1) if m.group(1) is not None else m.group(2)
+        if not body:
+            continue
+        ak = body.find("<arg_key>")
+        name = (body if ak == -1 else body[:ak]).strip()
+        if not name:
+            continue
+        types = param_types.get(name, {})
+        args: Dict[str, Any] = {}
+        for pm in _GLM_ARG_RE.finditer(body):
+            k = pm.group(1).strip()
+            if k:
+                args[k] = _glm_coerce(pm.group(2), types.get(k))
+        tool_calls.append(
+            ToolCall(
+                id=_unique_tool_call_id(),
+                type="function",
+                function={
+                    "name": name,
+                    "arguments": json.dumps(args, ensure_ascii=False),
+                },
+            )
+        )
+    return content.strip(), tool_calls
+
+
+# ---------------------------------------------------------------------------
+# MiniMax-M3 tool-call format
+# ---------------------------------------------------------------------------
+#
+# Every tag is prefixed by the ns_token ``]<]minimax[>[``:
+#
+#     ]<]minimax[>[<tool_call>
+#     ]<]minimax[>[<invoke name="NAME">
+#     ]<]minimax[>[<pname>value]<]minimax[>[</pname>
+#     ...
+#     ]<]minimax[>[</invoke>
+#     ]<]minimax[>[</tool_call>
+#
+# Unlike DSML, parameters are named by the TAG itself (``<city>Paris</city>``),
+# not a ``name="..."`` attribute. Strip the ns_token first, then parse
+# <invoke>/<tag> pairs. Values: schema type wins, else JSON, else raw string.
+
+_MINIMAX_NS = "]<]minimax[>["
+_MINIMAX_INVOKE_RE = re.compile(
+    r'<invoke\s+name="(.*?)"\s*>(.*?)</invoke>|<invoke\s+name="(.*?)"\s*>(.*)$',
+    re.DOTALL,
+)
+_MINIMAX_PARAM_RE = re.compile(r"<([\w-]+)>(.*?)</\1>", re.DOTALL)
+
+
+def _is_minimax(text: str) -> bool:
+    """Detect the MiniMax-M3 ns_token tool-call format."""
+    return _MINIMAX_NS in text
+
+
+def _minimax_coerce(value: str, ptype: Any) -> Any:
+    v = value.strip("\n")
+    if ptype is not None:
+        return _coerce_param_value(v, ptype)
+    s = v.strip()
+    try:
+        return json.loads(s)
+    except Exception:
+        return v
+
+
+def _parse_minimax(text: str, tools: Optional[list] = None) -> Tuple[str, List[ToolCall]]:
+    """Parse MiniMax-M3 tool calls; return (leading_content, tool_calls)."""
+    param_types = _build_param_types(tools)
+    clean = text.replace(_MINIMAX_NS, "")
+    tc = clean.find("<tool_call>")
+    content = clean[:tc] if tc > 0 else ("" if tc == 0 else clean)
+    tool_calls: List[ToolCall] = []
+    for m in _MINIMAX_INVOKE_RE.finditer(clean):
+        name = m.group(1) if m.group(1) is not None else m.group(3)
+        body = m.group(2) if m.group(2) is not None else (m.group(4) or "")
+        if not name:
+            continue
+        name = name.strip()
+        types = param_types.get(name, {})
+        args: Dict[str, Any] = {}
+        for pm in _MINIMAX_PARAM_RE.finditer(body):
+            k = pm.group(1).strip()
+            if k:
+                args[k] = _minimax_coerce(pm.group(2), types.get(k))
+        tool_calls.append(
+            ToolCall(
+                id=_unique_tool_call_id(),
+                type="function",
+                function={
+                    "name": name,
+                    "arguments": json.dumps(args, ensure_ascii=False),
+                },
+            )
+        )
+    for mk in ("<tool_call>", "</tool_call>"):
+        content = content.replace(mk, "")
+    return content.strip(), tool_calls
+
+
 def parse_tool_calls(
     text: str, tools: Optional[list] = None
 ) -> Tuple[str, List[ToolCall]]:
     """Parse tool calls from model output text.
 
     Args:
-        text: Raw model output that may contain tool calls (Kimi token format
-            or Qwen3 XML format).
-        tools: Optional request tool definitions; used to type-coerce Qwen XML
-            parameter values to their declared JSON-Schema types.
+        text: Raw model output that may contain tool calls (DeepSeek-V4 DSML,
+            Kimi token format, or Qwen3 XML format).
+        tools: Optional request tool definitions; used to type-coerce parameter
+            values to their declared JSON-Schema types.
 
     Returns:
         Tuple of (content_text, list_of_tool_calls). ``content_text`` has the
         tool-call sections removed.
     """
+    # MiniMax-M3 ns_token format (checked before DSML: both use <invoke name=..>,
+    # but MiniMax names params by tag and prefixes every tag with ]<]minimax[>[)
+    if _is_minimax(text):
+        return _parse_minimax(text, tools)
+
+    # DeepSeek-V4 DSML format
+    if _is_dsml(text):
+        return _parse_dsml(text, tools)
+
+    # GLM <tool_call>/<arg_key> format (checked before Qwen: both use
+    # <tool_call>, but GLM never emits the Qwen '<function=' sub-tag)
+    if _is_glm(text):
+        return _parse_glm(text, tools)
+
     # Qwen3 XML format
     if _is_qwen_xml(text):
         return _parse_qwen_xml(text, tools)
@@ -277,14 +568,28 @@ class ToolCallStreamParser:
     current_index: int = 0
     _emitted_calls: int = 0
     tools: Optional[list] = None
-    fmt: Optional[str] = None  # None (undecided) | "kimi" | "qwen"
+    fmt: Optional[str] = None  # None|kimi|qwen|dsml|glm|minimax
 
     def process(self, text: str) -> list:
         """Process a text chunk and return list of (event_type, data) tuples."""
         if self.fmt is None:
             self.buf += text
-            if _QWEN_TOOL_PREFIX in self.buf or "<tool_call>" in self.buf:
+            if _MINIMAX_NS in self.buf:
+                self.fmt = "minimax"
+            elif _is_dsml(self.buf):
+                self.fmt = "dsml"
+            elif "<arg_key>" in self.buf:
+                self.fmt = "glm"
+            elif _QWEN_TOOL_PREFIX in self.buf:
                 self.fmt = "qwen"
+            elif "<tool_call>" in self.buf:
+                # '<tool_call>' seen but neither '<function=' (Qwen) nor
+                # '<arg_key>' (GLM) yet. A no-arg GLM call is complete once the
+                # closing tag arrives; otherwise wait for the sub-marker.
+                if "</tool_call>" in self.buf:
+                    self.fmt = "glm"
+                else:
+                    return []
             elif "<|tool_calls_section_begin|>" in self.buf:
                 self.fmt = "kimi"
             elif "<" not in self.buf and len(self.buf) > 8:
@@ -297,9 +602,201 @@ class ToolCallStreamParser:
             # Format decided: replay the accumulated buffer through the handler.
             text, self.buf = self.buf, ""
 
+        if self.fmt == "minimax":
+            return self._process_minimax(text)
+        if self.fmt == "dsml":
+            return self._process_dsml(text)
+        if self.fmt == "glm":
+            return self._process_glm(text)
         if self.fmt == "qwen":
             return self._process_qwen(text)
         return self._process_kimi(text)
+
+    # -- MiniMax-M3 ns_token ------------------------------------------------
+    def _process_minimax(self, text: str) -> list:
+        results: list = []
+        self.buf += text
+        if self.state == 0:
+            markers = [
+                i
+                for i in (self.buf.find(_MINIMAX_NS), self.buf.find("<tool_call>"))
+                if i != -1
+            ]
+            if markers:
+                m = min(markers)
+                before = self.buf[:m]
+                if before:
+                    results.append(("content", before))
+                self.buf = self.buf[m:]
+                self.state = 1
+            else:
+                cut = self.buf.rfind("<")
+                cut = max(cut, self.buf.rfind("]"))  # ns_token starts with ']'
+                if cut == -1:
+                    if self.buf:
+                        results.append(("content", self.buf))
+                        self.buf = ""
+                elif cut > 0:
+                    results.append(("content", self.buf[:cut]))
+                    self.buf = self.buf[cut:]
+        return results
+
+    def _flush_minimax(self) -> list:
+        results: list = []
+        if self.state == 0:
+            if self.buf:
+                results.append(("content", self.buf))
+                self.buf = ""
+            return results
+        _content, tool_calls = _parse_minimax(self.buf, self.tools)
+        self.buf = ""
+        for tc in tool_calls:
+            results.append(
+                (
+                    "tool_call_start",
+                    {
+                        "index": self.current_index,
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.function["name"], "arguments": ""},
+                    },
+                )
+            )
+            results.append(
+                (
+                    "tool_call_args",
+                    {
+                        "index": self.current_index,
+                        "function": {"arguments": tc.function["arguments"]},
+                    },
+                )
+            )
+            self.current_index += 1
+            self._emitted_calls += 1
+        if self._emitted_calls > 0:
+            results.append(("tool_call_end", None))
+        return results
+
+    # -- DeepSeek-V4 DSML ---------------------------------------------------
+    def _process_dsml(self, text: str) -> list:
+        results: list = []
+        self.buf += text
+        if self.state == 0:
+            m = _dsml_start(self.buf)
+            if m != -1:
+                before = self.buf[:m]
+                if before:
+                    results.append(("content", before))
+                self.buf = self.buf[m:]
+                self.state = 1
+            else:
+                # Emit content but hold back a possible partial '<...' marker tail.
+                cut = self.buf.rfind("<")
+                if cut == -1:
+                    if self.buf:
+                        results.append(("content", self.buf))
+                        self.buf = ""
+                elif cut > 0:
+                    results.append(("content", self.buf[:cut]))
+                    self.buf = self.buf[cut:]
+        return results
+
+    def _flush_dsml(self) -> list:
+        results: list = []
+        if self.state == 0:
+            if self.buf:
+                results.append(("content", self.buf))
+                self.buf = ""
+            return results
+        _content, tool_calls = _parse_dsml(self.buf, self.tools)
+        self.buf = ""
+        for tc in tool_calls:
+            results.append(
+                (
+                    "tool_call_start",
+                    {
+                        "index": self.current_index,
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.function["name"], "arguments": ""},
+                    },
+                )
+            )
+            results.append(
+                (
+                    "tool_call_args",
+                    {
+                        "index": self.current_index,
+                        "function": {"arguments": tc.function["arguments"]},
+                    },
+                )
+            )
+            self.current_index += 1
+            self._emitted_calls += 1
+        if self._emitted_calls > 0:
+            results.append(("tool_call_end", None))
+        return results
+
+    # -- Qwen3 XML ----------------------------------------------------------
+    # -- GLM <tool_call>/<arg_key> -----------------------------------------
+    def _process_glm(self, text: str) -> list:
+        results: list = []
+        self.buf += text
+        if self.state == 0:
+            m = self.buf.find("<tool_call>")
+            if m != -1:
+                before = self.buf[:m]
+                if before:
+                    results.append(("content", before))
+                self.buf = self.buf[m:]
+                self.state = 1
+            else:
+                # Emit content but hold back a possible partial '<...' marker tail.
+                cut = self.buf.rfind("<")
+                if cut == -1:
+                    if self.buf:
+                        results.append(("content", self.buf))
+                        self.buf = ""
+                elif cut > 0:
+                    results.append(("content", self.buf[:cut]))
+                    self.buf = self.buf[cut:]
+        return results
+
+    def _flush_glm(self) -> list:
+        results: list = []
+        if self.state == 0:
+            if self.buf:
+                results.append(("content", self.buf))
+                self.buf = ""
+            return results
+        _content, tool_calls = _parse_glm(self.buf, self.tools)
+        self.buf = ""
+        for tc in tool_calls:
+            results.append(
+                (
+                    "tool_call_start",
+                    {
+                        "index": self.current_index,
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.function["name"], "arguments": ""},
+                    },
+                )
+            )
+            results.append(
+                (
+                    "tool_call_args",
+                    {
+                        "index": self.current_index,
+                        "function": {"arguments": tc.function["arguments"]},
+                    },
+                )
+            )
+            self.current_index += 1
+            self._emitted_calls += 1
+        if self._emitted_calls > 0:
+            results.append(("tool_call_end", None))
+        return results
 
     # -- Qwen3 XML ----------------------------------------------------------
     def _process_qwen(self, text: str) -> list:
@@ -449,6 +946,12 @@ class ToolCallStreamParser:
 
     def flush(self) -> list:
         """Flush remaining buffer content."""
+        if self.fmt == "minimax":
+            return self._flush_minimax()
+        if self.fmt == "dsml":
+            return self._flush_dsml()
+        if self.fmt == "glm":
+            return self._flush_glm()
         if self.fmt == "qwen":
             return self._flush_qwen()
         results = []


### PR DESCRIPTION
## Summary

Teach the OpenAI server to parse three more model families' tool-call formats and normalize MiniMax-M3 reasoning tags, so `tool_calls` and `reasoning_content` surface correctly for **GLM**, **MiniMax-M3** and **DeepSeek-V4**.

**`tool_parser.py`** — new detectors + parsers (batch and streaming), dispatch order `minimax → dsml → glm → qwen → kimi`:
- **DeepSeek-V4 DSML**: `_is_dsml` / `_parse_dsml` (+ type coercion), with a streaming path in `ToolCallStreamParser`.
- **GLM-4.5/4.6/5.x**: `_is_glm` / `_parse_glm` for `<tool_call>NAME <arg_key>K</arg_key><arg_value>V</arg_value>`; told apart from Qwen XML by the absence of the `<function=` sub-tag; value decode is schema-type-aware (`_glm_coerce`).
- **MiniMax-M3**: `_is_minimax` / `_parse_minimax` for the ns-token format where every tag is prefixed by `]<]minimax[>[` and params are named by the tag (`<city>Paris</city>`); checked before DSML since both use `<invoke name=..>`.

**`reasoning.py`** — normalize MiniMax-M3 `<mm:think>...</mm:think>` → `<think>...</think>` in both `separate_reasoning()` and the streaming `ReasoningFilter`, so the shared state machine handles M3 with no separate path.

**`chat_encoders.py`** — `_normalize_for_v4`: hoist the system message into the DeepSeek-V4 prompt layout.

## Why

Without these, GLM / MiniMax-M3 / DeepSeek-V4 emit tool calls and reasoning as raw text in `content` — clients see the markup instead of structured `tool_calls` / `reasoning_content`, breaking agentic use (opencode / Claude Code).

## Scope

- **DeepSeek-V3 / R1 tool-call parsing is intentionally NOT included** in this PR.
- The streaming reasoning/tool wiring in `serving_chat.py` (which calls `ReasoningFilter` / `ToolCallStreamParser`) lands in #1441; this PR provides the parser + reasoning implementations those hooks call.

## Test plan

Per-family tool-call round-trip (OpenAI `tool_calls` + Anthropic `tool_use`) and reasoning separation, non-streaming and streaming:
```bash
PORT=9700; M=<served-model-id>   # run against a GLM / M3 / V4 backend
curl -s localhost:$PORT/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model":"'"$M"'",
  "messages":[{"role":"user","content":"What is the weather in Paris?"}],
  "tools":[{"type":"function","function":{"name":"get_weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]
}' | python3 -m json.tool   # expect tool_calls[0].function = get_weather {"city":"Paris"}, reasoning_content separated
```
Validated in deployment: OpenAI chat `tool_calls` + Anthropic `/v1/messages` `tool_use` + claude-local agentic file-read all parse cleanly; M3 reasoning separated with no `<mm:think>` leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)