### PR TITLE
[1/3]refactor mesh worker registry into layered pools

### DIFF
--- a/atom/mesh/src/config/types.rs
+++ b/atom/mesh/src/config/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::ConfigResult;
-use crate::core::ConnectionMode;
+use crate::core::{ConnectionMode, Framework};
 
 /// Backend runtime type for inference workers.
 /// Determines PD-disaggregation protocol (SGLang dual-dispatch+bootstrap vs vLLM Mooncake kv_transfer_params).
@@ -14,6 +14,18 @@ pub enum BackendType {
     Vllm,
     #[serde(rename = "atom")]
     Atom,
+}
+
+/// Map the router-level backend to a per-worker framework.
+/// (`BackendType` has no anonymous variant, so this is total.)
+impl From<BackendType> for Framework {
+    fn from(backend: BackendType) -> Self {
+        match backend {
+            BackendType::Sglang => Framework::Sglang,
+            BackendType::Vllm => Framework::Vllm,
+            BackendType::Atom => Framework::Atom,
+        }
+    }
 }
 
 /// Main router configuration

--- a/atom/mesh/src/core/mod.rs
+++ b/atom/mesh/src/core/mod.rs
@@ -30,8 +30,8 @@ pub use error::{WorkerError, WorkerResult};
 pub use job_queue::{Job, JobQueue, JobQueueConfig};
 pub use retry::{is_retryable_status, RetryExecutor};
 pub use worker::{
-    AttachedBody, BasicWorker, ConnectionMode, HealthConfig, RuntimeType, Worker, WorkerLoadGuard,
-    WorkerType,
+    AttachedBody, BasicWorker, ConnectionMode, Framework, HealthConfig, PoolRole, Worker,
+    WorkerLoadGuard, WorkerType,
 };
 pub use worker_builder::{BasicWorkerBuilder, DPAwareWorkerBuilder};
 pub use worker_manager::{LoadMonitor, WorkerManager};

--- a/atom/mesh/src/core/placement/test_support.rs
+++ b/atom/mesh/src/core/placement/test_support.rs
@@ -8,7 +8,7 @@ use http::HeaderMap;
 
 use super::traits::{PolicySource, WorkerSource};
 use super::types::RequestDescriptor;
-use crate::core::{BasicWorkerBuilder, ConnectionMode, HashRing, RuntimeType, Worker, WorkerType};
+use crate::core::{BasicWorkerBuilder, ConnectionMode, Framework, HashRing, Worker, WorkerType};
 use crate::policies::{LoadBalancingPolicy, RoundRobinPolicy, SelectWorkerInfo};
 
 #[derive(Debug, Clone)]
@@ -280,12 +280,12 @@ pub fn make_worker(
     model_id: Option<&str>,
     api_key: Option<&str>,
     connection_mode: ConnectionMode,
-    runtime_type: RuntimeType,
+    framework: Framework,
 ) -> Arc<dyn Worker> {
     let mut builder = BasicWorkerBuilder::new(url.to_string())
         .worker_type(worker_type)
         .connection_mode(connection_mode)
-        .runtime_type(runtime_type);
+        .framework(framework);
     if let Some(m) = model_id {
         builder = builder.model_id(m.to_string());
     }
@@ -307,7 +307,7 @@ pub fn make_regular_http(url: &str, model_id: &str) -> Arc<dyn Worker> {
         Some(model_id),
         None,
         ConnectionMode::Http,
-        RuntimeType::Sglang,
+        Framework::Sglang,
     )
 }
 
@@ -319,7 +319,7 @@ pub fn make_regular_grpc(url: &str, model_id: &str) -> Arc<dyn Worker> {
         Some(model_id),
         None,
         ConnectionMode::Grpc { port: None },
-        RuntimeType::Sglang,
+        Framework::Sglang,
     )
 }
 
@@ -335,7 +335,7 @@ pub fn make_prefill_http(
         Some(model_id),
         None,
         ConnectionMode::Http,
-        RuntimeType::Sglang,
+        Framework::Sglang,
     )
 }
 
@@ -347,7 +347,7 @@ pub fn make_decode_http(url: &str, model_id: &str) -> Arc<dyn Worker> {
         Some(model_id),
         None,
         ConnectionMode::Http,
-        RuntimeType::Sglang,
+        Framework::Sglang,
     )
 }
 
@@ -363,7 +363,7 @@ pub fn make_prefill_grpc(
         Some(model_id),
         None,
         ConnectionMode::Grpc { port: None },
-        RuntimeType::Sglang,
+        Framework::Sglang,
     )
 }
 
@@ -375,7 +375,7 @@ pub fn make_decode_grpc(url: &str, model_id: &str) -> Arc<dyn Worker> {
         Some(model_id),
         None,
         ConnectionMode::Grpc { port: None },
-        RuntimeType::Sglang,
+        Framework::Sglang,
     )
 }
 
@@ -516,7 +516,7 @@ mod fixture_smoke_tests {
             Some("m"),
             None,
             ConnectionMode::Http,
-            RuntimeType::Sglang,
+            Framework::Sglang,
         );
         assert!(!w.is_healthy());
     }

--- a/atom/mesh/src/core/steps/worker/local/create_worker.rs
+++ b/atom/mesh/src/core/steps/worker/local/create_worker.rs
@@ -11,7 +11,7 @@ use crate::{
     core::{
         circuit_breaker::CircuitBreakerConfig,
         steps::workflow_data::LocalWorkerWorkflowData,
-        worker::{HealthConfig, RuntimeType, WorkerType},
+        worker::{Framework, HealthConfig, WorkerType},
         BasicWorkerBuilder, ConnectionMode, DPAwareWorkerBuilder, Worker, UNKNOWN_MODEL_ID,
     },
     protocols::worker_spec::WorkerConfigRequest,
@@ -95,7 +95,7 @@ impl StepExecutor<LocalWorkerWorkflowData> for CreateLocalWorkerStep {
         let worker_type = parse_worker_type(config);
 
         // Get runtime type (for gRPC workers)
-        let runtime_type = determine_runtime_type(connection_mode, &context.data, config);
+        let framework = determine_framework(connection_mode, &context.data, config);
 
         // Build circuit breaker config
         let circuit_breaker_config = build_circuit_breaker_config(app_context);
@@ -121,7 +121,7 @@ impl StepExecutor<LocalWorkerWorkflowData> for CreateLocalWorkerStep {
                 &model_id,
                 worker_type,
                 connection_mode,
-                runtime_type,
+                framework,
                 circuit_breaker_config,
                 health_config,
                 config,
@@ -133,7 +133,7 @@ impl StepExecutor<LocalWorkerWorkflowData> for CreateLocalWorkerStep {
                 &model_id,
                 worker_type,
                 connection_mode,
-                runtime_type,
+                framework,
                 circuit_breaker_config,
                 health_config,
                 config,
@@ -166,27 +166,29 @@ fn parse_worker_type(config: &WorkerConfigRequest) -> WorkerType {
         .unwrap_or(WorkerType::Regular)
 }
 
-fn determine_runtime_type(
+fn determine_framework(
     connection_mode: &ConnectionMode,
     data: &LocalWorkerWorkflowData,
     config: &WorkerConfigRequest,
-) -> RuntimeType {
-    if !matches!(connection_mode, ConnectionMode::Grpc { .. }) {
-        return RuntimeType::Sglang;
-    }
+) -> Framework {
+    // Prefer the framework detected from the worker, then the configured one.
+    let declared = data
+        .detected_runtime_type
+        .as_deref()
+        .or(config.runtime.as_deref());
 
-    if let Some(ref detected_runtime) = data.detected_runtime_type {
-        match detected_runtime.as_str() {
-            "vllm" => RuntimeType::Vllm,
-            _ => RuntimeType::Sglang,
-        }
-    } else if let Some(ref runtime) = config.runtime {
-        match runtime.as_str() {
-            "vllm" => RuntimeType::Vllm,
-            _ => RuntimeType::Sglang,
-        }
-    } else {
-        RuntimeType::Sglang
+    match connection_mode {
+        // gRPC transport is only implemented for Sglang/Vllm engine clients,
+        // so a gRPC worker must resolve to one of those. Default to Sglang.
+        ConnectionMode::Grpc { .. } => match declared.map(Framework::from) {
+            Some(Framework::Vllm) => Framework::Vllm,
+            _ => Framework::Sglang,
+        },
+        // HTTP workers carry framework for pool classification only.
+        // Honor whatever was declared (incl. atom); undeclared -> Anonymous.
+        ConnectionMode::Http => declared
+            .map(Framework::from)
+            .unwrap_or(Framework::Anonymous),
     }
 }
 
@@ -230,7 +232,7 @@ fn create_dp_aware_workers(
     model_id: &str,
     worker_type: WorkerType,
     connection_mode: &ConnectionMode,
-    runtime_type: RuntimeType,
+    framework: Framework,
     circuit_breaker_config: CircuitBreakerConfig,
     health_config: HealthConfig,
     config: &WorkerConfigRequest,
@@ -253,7 +255,7 @@ fn create_dp_aware_workers(
                 .model_id(model_id)
                 .worker_type(worker_type.clone())
                 .connection_mode(connection_mode.clone())
-                .runtime_type(runtime_type.clone())
+                .framework(framework)
                 .circuit_breaker_config(circuit_breaker_config.clone())
                 .health_config(health_config.clone());
 
@@ -299,7 +301,7 @@ fn create_single_worker(
     model_id: &str,
     worker_type: WorkerType,
     connection_mode: &ConnectionMode,
-    runtime_type: RuntimeType,
+    framework: Framework,
     circuit_breaker_config: CircuitBreakerConfig,
     health_config: HealthConfig,
     config: &WorkerConfigRequest,
@@ -311,7 +313,7 @@ fn create_single_worker(
         .model_id(model_id)
         .worker_type(worker_type)
         .connection_mode(connection_mode.clone())
-        .runtime_type(runtime_type)
+        .framework(framework)
         .circuit_breaker_config(circuit_breaker_config)
         .health_config(health_config);
 

--- a/atom/mesh/src/core/steps/worker/local/update_worker_properties.rs
+++ b/atom/mesh/src/core/steps/worker/local/update_worker_properties.rs
@@ -100,7 +100,7 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdateWorkerPropertiesStep {
                     crate::core::DPAwareWorkerBuilder::new(base_url, dp_rank, dp_size)
                         .worker_type(worker.worker_type().clone())
                         .connection_mode(worker.connection_mode().clone())
-                        .runtime_type(worker.metadata().runtime_type.clone())
+                        .framework(worker.metadata().framework)
                         .labels(updated_labels)
                         .health_config(updated_health_config.clone());
 
@@ -129,7 +129,7 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdateWorkerPropertiesStep {
                 let mut builder = BasicWorkerBuilder::new(worker.url())
                     .worker_type(worker.worker_type().clone())
                     .connection_mode(worker.connection_mode().clone())
-                    .runtime_type(worker.metadata().runtime_type.clone())
+                    .framework(worker.metadata().framework)
                     .labels(updated_labels)
                     .health_config(updated_health_config.clone());
 

--- a/atom/mesh/src/core/worker.rs
+++ b/atom/mesh/src/core/worker.rs
@@ -119,6 +119,16 @@ pub trait Worker: Send + Sync + fmt::Debug {
     /// Returns a reference to avoid cloning on every access
     fn connection_mode(&self) -> &ConnectionMode;
 
+    /// Get the inference framework this worker runs (Sglang/Vllm/Atom/Anonymous)
+    fn framework(&self) -> &Framework {
+        &self.metadata().framework
+    }
+
+    /// Get this worker's pool role (regular vs PD prefill/decode)
+    fn pool_role(&self) -> PoolRole {
+        self.worker_type().pool_role()
+    }
+
     /// Get the bootstrap hostname for PD mode
     /// Returns cached hostname parsed from URL at construction time
     fn bootstrap_host(&self) -> &str {
@@ -346,37 +356,57 @@ impl fmt::Display for ConnectionMode {
     }
 }
 
-/// Runtime implementation type for workers
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+/// Inference framework that a worker runs.
+///
+/// This is a per-worker property (distinct from the router-level `BackendType`,
+/// which selects the PD-disaggregation protocol). When a worker does not declare
+/// a framework it is classified as `Anonymous`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
-pub enum RuntimeType {
-    /// SGLang runtime (default)
-    #[default]
+pub enum Framework {
+    /// SGLang framework
     Sglang,
-    /// vLLM runtime
+    /// vLLM framework
     Vllm,
+    /// ATOM framework
+    Atom,
+    /// Framework not declared (default)
+    #[default]
+    Anonymous,
 }
 
-impl fmt::Display for RuntimeType {
+impl fmt::Display for Framework {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RuntimeType::Sglang => write!(f, "sglang"),
-            RuntimeType::Vllm => write!(f, "vllm"),
+            Framework::Sglang => write!(f, "sglang"),
+            Framework::Vllm => write!(f, "vllm"),
+            Framework::Atom => write!(f, "atom"),
+            Framework::Anonymous => write!(f, "anonymous"),
         }
     }
 }
 
-impl std::str::FromStr for RuntimeType {
-    type Err = String;
+impl std::str::FromStr for Framework {
+    type Err = std::convert::Infallible;
 
+    /// Parse a framework name. Unknown / empty values map to `Anonymous`
+    /// so callers never fail on an undeclared framework.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Framework::from(s))
+    }
+}
+
+impl From<&str> for Framework {
+    fn from(s: &str) -> Self {
         // Use eq_ignore_ascii_case to avoid to_lowercase() allocation
         if s.eq_ignore_ascii_case("sglang") {
-            Ok(RuntimeType::Sglang)
+            Framework::Sglang
         } else if s.eq_ignore_ascii_case("vllm") {
-            Ok(RuntimeType::Vllm)
+            Framework::Vllm
+        } else if s.eq_ignore_ascii_case("atom") {
+            Framework::Atom
         } else {
-            Err(format!("Unknown runtime type: {}", s))
+            Framework::Anonymous
         }
     }
 }
@@ -415,6 +445,40 @@ impl WorkerType {
             WorkerType::Regular => metrics_labels::WORKER_REGULAR,
             WorkerType::Prefill { .. } => metrics_labels::WORKER_PREFILL,
             WorkerType::Decode => metrics_labels::WORKER_DECODE,
+        }
+    }
+
+    /// Map this worker type to its pool role (regular pool vs PD prefill/decode).
+    pub fn pool_role(&self) -> PoolRole {
+        match self {
+            WorkerType::Regular => PoolRole::Regular,
+            WorkerType::Prefill { .. } => PoolRole::PrefillPD,
+            WorkerType::Decode => PoolRole::DecodePD,
+        }
+    }
+}
+
+/// Role of a worker within a model's pool.
+///
+/// A regular worker lives in the regular pool; prefill/decode workers live in
+/// the PD pool but are stored in separate buckets so P and D nodes can be
+/// selected independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PoolRole {
+    /// Regular (non-disaggregated) worker
+    Regular,
+    /// Prefill node of the PD pool
+    PrefillPD,
+    /// Decode node of the PD pool
+    DecodePD,
+}
+
+impl fmt::Display for PoolRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PoolRole::Regular => write!(f, "regular"),
+            PoolRole::PrefillPD => write!(f, "pd-prefill"),
+            PoolRole::DecodePD => write!(f, "pd-decode"),
         }
     }
 }
@@ -458,8 +522,8 @@ pub struct WorkerMetadata {
     pub worker_type: WorkerType,
     /// Connection mode
     pub connection_mode: ConnectionMode,
-    /// Runtime type (for gRPC workers)
-    pub runtime_type: RuntimeType,
+    /// Inference framework this worker runs (Sglang/Vllm/Atom/Anonymous)
+    pub framework: Framework,
     /// Additional labels/tags
     pub labels: std::collections::HashMap<String, String>,
     /// Health check configuration
@@ -673,7 +737,7 @@ impl Worker for BasicWorker {
                 let client = self
                     .grpc_client
                     .get_or_try_init(|| async {
-                        let runtime_str = self.metadata.runtime_type.to_string();
+                        let runtime_str = self.metadata.framework.to_string();
                         tracing::info!(
                             "Lazily initializing gRPC client ({}) for worker: {}",
                             runtime_str,
@@ -1051,7 +1115,7 @@ pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
     };
 
     let runtime_type = match connection_mode {
-        ConnectionMode::Grpc { .. } => Some(worker.metadata().runtime_type.to_string()),
+        ConnectionMode::Grpc { .. } => Some(worker.metadata().framework.to_string()),
         ConnectionMode::Http => None,
     };
 
@@ -1759,7 +1823,7 @@ mod tests {
             url: "http://test:8080".to_string(),
             worker_type: WorkerType::Regular,
             connection_mode: ConnectionMode::Http,
-            runtime_type: RuntimeType::default(),
+            framework: Framework::default(),
             labels: std::collections::HashMap::new(),
             health_config: HealthConfig::default(),
             api_key: None,

--- a/atom/mesh/src/core/worker_builder.rs
+++ b/atom/mesh/src/core/worker_builder.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::{
     circuit_breaker::{CircuitBreaker, CircuitBreakerConfig},
     worker::{
-        BasicWorker, ConnectionMode, DPAwareWorker, HealthConfig, RuntimeType, WorkerMetadata,
+        BasicWorker, ConnectionMode, DPAwareWorker, Framework, HealthConfig, WorkerMetadata,
         WorkerRoutingKeyLoad, WorkerType,
     },
 };
@@ -17,7 +17,7 @@ pub struct BasicWorkerBuilder {
     api_key: Option<String>,
     worker_type: WorkerType,
     connection_mode: ConnectionMode,
-    runtime_type: RuntimeType,
+    framework: Framework,
     labels: HashMap<String, String>,
     model_id: Option<String>,
     tokenizer_path: Option<String>,
@@ -37,7 +37,7 @@ impl BasicWorkerBuilder {
             api_key: None,
             worker_type: WorkerType::Regular,
             connection_mode: ConnectionMode::Http,
-            runtime_type: RuntimeType::default(),
+            framework: Framework::default(),
             labels: HashMap::new(),
             model_id: None,
             tokenizer_path: None,
@@ -57,7 +57,7 @@ impl BasicWorkerBuilder {
             api_key: None,
             worker_type,
             connection_mode: ConnectionMode::Http,
-            runtime_type: RuntimeType::default(),
+            framework: Framework::default(),
             labels: HashMap::new(),
             model_id: None,
             tokenizer_path: None,
@@ -88,9 +88,9 @@ impl BasicWorkerBuilder {
         self
     }
 
-    /// Set the runtime type (SGLang or vLLM)
-    pub fn runtime_type(mut self, runtime_type: RuntimeType) -> Self {
-        self.runtime_type = runtime_type;
+    /// Set the inference framework (Sglang/Vllm/Atom/Anonymous)
+    pub fn framework(mut self, framework: Framework) -> Self {
+        self.framework = framework;
         self
     }
 
@@ -196,7 +196,7 @@ impl BasicWorkerBuilder {
             api_key: self.api_key,
             worker_type: self.worker_type,
             connection_mode: self.connection_mode,
-            runtime_type: self.runtime_type,
+            framework: self.framework,
             labels: self.labels,
             health_config: self.health_config,
             bootstrap_host,
@@ -247,7 +247,7 @@ pub struct DPAwareWorkerBuilder {
     dp_size: usize,
     worker_type: WorkerType,
     connection_mode: ConnectionMode,
-    runtime_type: RuntimeType,
+    framework: Framework,
     labels: HashMap<String, String>,
     model_id: Option<String>,
     tokenizer_path: Option<String>,
@@ -269,7 +269,7 @@ impl DPAwareWorkerBuilder {
             dp_size,
             worker_type: WorkerType::Regular,
             connection_mode: ConnectionMode::Http,
-            runtime_type: RuntimeType::default(),
+            framework: Framework::default(),
             labels: HashMap::new(),
             model_id: None,
             tokenizer_path: None,
@@ -296,7 +296,7 @@ impl DPAwareWorkerBuilder {
             dp_size,
             worker_type,
             connection_mode: ConnectionMode::Http,
-            runtime_type: RuntimeType::default(),
+            framework: Framework::default(),
             labels: HashMap::new(),
             model_id: None,
             tokenizer_path: None,
@@ -327,9 +327,9 @@ impl DPAwareWorkerBuilder {
         self
     }
 
-    /// Set the runtime type (SGLang or vLLM)
-    pub fn runtime_type(mut self, runtime_type: RuntimeType) -> Self {
-        self.runtime_type = runtime_type;
+    /// Set the inference framework (Sglang/Vllm/Atom/Anonymous)
+    pub fn framework(mut self, framework: Framework) -> Self {
+        self.framework = framework;
         self
     }
 
@@ -399,7 +399,7 @@ impl DPAwareWorkerBuilder {
         let mut builder = BasicWorkerBuilder::new(worker_url)
             .worker_type(self.worker_type)
             .connection_mode(self.connection_mode)
-            .runtime_type(self.runtime_type)
+            .framework(self.framework)
             .labels(self.labels)
             .health_config(self.health_config)
             .circuit_breaker_config(self.circuit_breaker_config);
@@ -655,18 +655,18 @@ mod tests {
     }
 
     #[test]
-    fn test_basic_worker_runtime_type() {
+    fn test_basic_worker_framework() {
         let worker = BasicWorkerBuilder::new("http://w:8000")
-            .runtime_type(RuntimeType::Vllm)
+            .framework(Framework::Vllm)
             .build();
 
-        assert_eq!(worker.metadata().runtime_type, RuntimeType::Vllm);
+        assert_eq!(worker.metadata().framework, Framework::Vllm);
     }
 
     #[test]
-    fn test_basic_worker_default_runtime_is_sglang() {
+    fn test_basic_worker_default_framework_is_anonymous() {
         let worker = BasicWorkerBuilder::new("http://w:8000").build();
-        assert_eq!(worker.metadata().runtime_type, RuntimeType::Sglang);
+        assert_eq!(worker.metadata().framework, Framework::Anonymous);
     }
 
     #[test]
@@ -756,12 +756,12 @@ mod tests {
     }
 
     #[test]
-    fn test_dp_aware_worker_runtime_type() {
+    fn test_dp_aware_worker_framework() {
         let worker = DPAwareWorkerBuilder::new("http://w:8000", 0, 2)
-            .runtime_type(RuntimeType::Vllm)
+            .framework(Framework::Vllm)
             .build();
 
-        assert_eq!(worker.metadata().runtime_type, RuntimeType::Vllm);
+        assert_eq!(worker.metadata().framework, Framework::Vllm);
     }
 
     #[test]

--- a/atom/mesh/src/core/worker_registry.rs
+++ b/atom/mesh/src/core/worker_registry.rs
@@ -1,10 +1,12 @@
 //! Worker Registry for multi-router support
 //!
-//! Provides centralized registry for workers with model-based indexing
+//! Provides a centralized registry for workers organized as a layered pool:
+//! `model_id -> framework -> {regular, pd-prefill, pd-decode}`.
 //!
 //! # Performance Optimizations
-//! The model index uses immutable Arc snapshots instead of RwLock for lock-free reads.
-//! This is critical for high-concurrency scenarios where many requests query the same model.
+//! Each pool bucket is an immutable Arc slice updated copy-on-write, so reads
+//! are lock-free. This is critical for high-concurrency scenarios where many
+//! requests query the same model.
 //!
 //! # Consistent Hash Ring
 //! The registry maintains a pre-computed hash ring per model for O(log n) consistent hashing.
@@ -19,7 +21,7 @@ use uuid::Uuid;
 use crate::{
     core::{
         circuit_breaker::CircuitState,
-        worker::{HealthChecker, RuntimeType, WorkerType},
+        worker::{Framework, HealthChecker, PoolRole, WorkerType},
         ConnectionMode, Worker,
     },
     observability::metrics::MeshMetrics,
@@ -169,27 +171,143 @@ impl Default for WorkerId {
     }
 }
 
-/// Model index using immutable snapshots for lock-free reads.
-/// Each model maps to an Arc'd slice of workers that can be read without locking.
-/// Updates create new snapshots (copy-on-write semantics).
-type ModelIndex = Arc<DashMap<String, Arc<[Arc<dyn Worker>]>>>;
+/// Empty immutable worker slice (shared, avoids per-bucket allocation).
+fn empty_worker_slice() -> Arc<[Arc<dyn Worker>]> {
+    Arc::from(Vec::new().into_boxed_slice())
+}
 
-/// Worker registry with model-based indexing
+/// The three role buckets for a single (model, framework) pair.
+///
+/// `regular` holds standard (non-disaggregated) workers; `prefill` and `decode`
+/// hold the P and D nodes of the PD pool, kept separate so each can be selected
+/// independently. Each bucket is an immutable Arc slice updated copy-on-write,
+/// preserving the lock-free read path.
+#[derive(Debug, Clone)]
+pub struct FrameworkBuckets {
+    regular: Arc<[Arc<dyn Worker>]>,
+    prefill: Arc<[Arc<dyn Worker>]>,
+    decode: Arc<[Arc<dyn Worker>]>,
+}
+
+impl Default for FrameworkBuckets {
+    fn default() -> Self {
+        Self {
+            regular: empty_worker_slice(),
+            prefill: empty_worker_slice(),
+            decode: empty_worker_slice(),
+        }
+    }
+}
+
+impl FrameworkBuckets {
+    /// Immutable view of the bucket for a given role.
+    pub fn bucket(&self, role: PoolRole) -> Arc<[Arc<dyn Worker>]> {
+        match role {
+            PoolRole::Regular => Arc::clone(&self.regular),
+            PoolRole::PrefillPD => Arc::clone(&self.prefill),
+            PoolRole::DecodePD => Arc::clone(&self.decode),
+        }
+    }
+
+    /// All workers across the three buckets.
+    pub fn all(&self) -> Vec<Arc<dyn Worker>> {
+        let mut out =
+            Vec::with_capacity(self.regular.len() + self.prefill.len() + self.decode.len());
+        out.extend(self.regular.iter().cloned());
+        out.extend(self.prefill.iter().cloned());
+        out.extend(self.decode.iter().cloned());
+        out
+    }
+
+    fn is_empty(&self) -> bool {
+        self.regular.is_empty() && self.prefill.is_empty() && self.decode.is_empty()
+    }
+
+    fn slot_mut(&mut self, role: PoolRole) -> &mut Arc<[Arc<dyn Worker>]> {
+        match role {
+            PoolRole::Regular => &mut self.regular,
+            PoolRole::PrefillPD => &mut self.prefill,
+            PoolRole::DecodePD => &mut self.decode,
+        }
+    }
+
+    /// Return a new buckets snapshot with `worker` added to `role`'s bucket
+    /// (replacing any existing entry with the same URL). Copy-on-write.
+    fn with_added(&self, role: PoolRole, worker: Arc<dyn Worker>) -> Self {
+        let mut next = self.clone();
+        let slot = next.slot_mut(role);
+        let mut v: Vec<Arc<dyn Worker>> = slot
+            .iter()
+            .filter(|w| w.url() != worker.url())
+            .cloned()
+            .collect();
+        v.push(worker);
+        *slot = Arc::from(v.into_boxed_slice());
+        next
+    }
+
+    /// Return a new buckets snapshot with the worker at `url` removed from
+    /// `role`'s bucket. Copy-on-write.
+    fn with_removed(&self, role: PoolRole, url: &str) -> Self {
+        let mut next = self.clone();
+        let slot = next.slot_mut(role);
+        let v: Vec<Arc<dyn Worker>> = slot.iter().filter(|w| w.url() != url).cloned().collect();
+        *slot = Arc::from(v.into_boxed_slice());
+        next
+    }
+}
+
+/// All workers for one model, organized by framework then role.
+///
+/// Layer hierarchy: `model_id -> framework -> {regular, pd-prefill, pd-decode}`.
+#[derive(Debug, Default)]
+pub struct ModelPool {
+    /// framework -> role buckets (copy-on-write snapshots for lock-free reads)
+    buckets: DashMap<Framework, FrameworkBuckets>,
+}
+
+impl ModelPool {
+    /// Buckets for a specific framework, if any workers are registered under it.
+    pub fn framework_buckets(&self, framework: &Framework) -> Option<FrameworkBuckets> {
+        self.buckets.get(framework).map(|b| b.clone())
+    }
+
+    /// Frameworks that currently have at least one worker in this model pool.
+    pub fn frameworks(&self) -> Vec<Framework> {
+        self.buckets
+            .iter()
+            .filter(|e| !e.value().is_empty())
+            .map(|e| *e.key())
+            .collect()
+    }
+
+    /// All workers for this model across every framework and role.
+    pub fn all(&self) -> Vec<Arc<dyn Worker>> {
+        self.buckets.iter().flat_map(|e| e.value().all()).collect()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.buckets.iter().all(|e| e.value().is_empty())
+    }
+}
+
+/// Worker registry with a layered pool structure.
+///
+/// Workers are organized as `model_id -> framework -> {regular, pd-prefill,
+/// pd-decode}` in `pools`. The other maps are secondary indexes over the same
+/// workers for lookup by ID / URL / connection mode and for consistent hashing.
 #[derive(Debug)]
 pub struct WorkerRegistry {
     /// All workers indexed by ID
     workers: Arc<DashMap<WorkerId, Arc<dyn Worker>>>,
 
-    /// Model index for O(1) lookups using immutable snapshots.
-    /// Uses Arc<[T]> instead of Arc<RwLock<Vec<T>>> for lock-free reads.
-    model_index: ModelIndex,
+    /// Layered pools: model_id -> framework -> role buckets.
+    /// Replaces the former flat model_index + type_workers indexes.
+    pools: Arc<DashMap<String, Arc<ModelPool>>>,
 
     /// Consistent hash rings per model for O(log n) routing.
     /// Rebuilt on worker add/remove (copy-on-write).
     hash_rings: Arc<DashMap<String, Arc<HashRing>>>,
-
-    /// Workers indexed by worker type
-    type_workers: Arc<DashMap<WorkerType, Vec<WorkerId>>>,
 
     /// Workers indexed by connection mode
     connection_workers: Arc<DashMap<ConnectionMode, Vec<WorkerId>>>,
@@ -203,28 +321,58 @@ impl WorkerRegistry {
     pub fn new() -> Self {
         Self {
             workers: Arc::new(DashMap::new()),
-            model_index: Arc::new(DashMap::new()),
+            pools: Arc::new(DashMap::new()),
             hash_rings: Arc::new(DashMap::new()),
-            type_workers: Arc::new(DashMap::new()),
             connection_workers: Arc::new(DashMap::new()),
             url_to_id: Arc::new(DashMap::new()),
         }
     }
 
-    /// Rebuild the hash ring for a model based on current workers in the model index
+    /// Rebuild the hash ring for a model based on the current workers in its pool
     fn rebuild_hash_ring(&self, model_id: &str) {
-        if let Some(workers) = self.model_index.get(model_id) {
-            let ring = HashRing::new(&workers);
-            self.hash_rings.insert(model_id.to_string(), Arc::new(ring));
-        } else {
+        let workers = self.get_by_model(model_id);
+        if workers.is_empty() {
             // No workers for this model, remove the ring
             self.hash_rings.remove(model_id);
+        } else {
+            let ring = HashRing::new(&workers);
+            self.hash_rings.insert(model_id.to_string(), Arc::new(ring));
         }
     }
 
     /// Get the hash ring for a model (O(1) lookup)
     pub fn get_hash_ring(&self, model_id: &str) -> Option<Arc<HashRing>> {
         self.hash_rings.get(model_id).map(|r| Arc::clone(&r))
+    }
+
+    /// Add a worker into its `model -> framework -> role` bucket (copy-on-write).
+    fn pool_add(&self, worker: &Arc<dyn Worker>) {
+        let model_id = worker.model_id().to_string();
+        let framework = *worker.framework();
+        let role = worker.worker_type().pool_role();
+
+        let pool = self
+            .pools
+            .entry(model_id)
+            .or_insert_with(|| Arc::new(ModelPool::default()))
+            .clone();
+
+        let mut bucket = pool.buckets.entry(framework).or_default();
+        *bucket = bucket.with_added(role, worker.clone());
+    }
+
+    /// Remove a worker (identified by url) from its `model -> framework -> role`
+    /// bucket (copy-on-write). Cleans up empty pools.
+    fn pool_remove(&self, model_id: &str, framework: Framework, role: PoolRole, url: &str) {
+        if let Some(pool) = self.pools.get(model_id).map(|p| p.clone()) {
+            if let Some(mut bucket) = pool.buckets.get_mut(&framework) {
+                *bucket = bucket.with_removed(role, url);
+            }
+            pool.buckets.retain(|_, b| !b.is_empty());
+            if pool.is_empty() {
+                self.pools.remove(model_id);
+            }
+        }
     }
 
     /// Register a new worker
@@ -236,6 +384,24 @@ impl WorkerRegistry {
             WorkerId::new()
         };
 
+        // If a worker with this URL already exists, drop its old pool entry first
+        // (its model/framework/role may have changed on update).
+        if let Some(old) = self.workers.get(&worker_id).map(|w| w.clone()) {
+            let old_model = old.model_id().to_string();
+            self.pool_remove(
+                &old_model,
+                *old.framework(),
+                old.worker_type().pool_role(),
+                old.url(),
+            );
+            if let Some(mut conn_workers) = self.connection_workers.get_mut(old.connection_mode()) {
+                conn_workers.retain(|id| id != &worker_id);
+            }
+            if old_model != worker.model_id() {
+                self.rebuild_hash_ring(&old_model);
+            }
+        }
+
         // Store worker
         self.workers.insert(worker_id.clone(), worker.clone());
 
@@ -243,27 +409,12 @@ impl WorkerRegistry {
         self.url_to_id
             .insert(worker.url().to_string(), worker_id.clone());
 
-        // Update model index for O(1) lookups using copy-on-write
-        // This creates a new immutable snapshot with the added worker
+        // Insert into the layered pool (model -> framework -> role), copy-on-write.
         let model_id = worker.model_id().to_string();
-        self.model_index
-            .entry(model_id.clone())
-            .and_modify(|existing| {
-                // Create new snapshot with the additional worker
-                let mut new_workers: Vec<Arc<dyn Worker>> = existing.iter().cloned().collect();
-                new_workers.push(worker.clone());
-                *existing = Arc::from(new_workers.into_boxed_slice());
-            })
-            .or_insert_with(|| Arc::from(vec![worker.clone()].into_boxed_slice()));
+        self.pool_add(&worker);
 
         // Rebuild hash ring for this model
         self.rebuild_hash_ring(&model_id);
-
-        // Update type index (clone needed for DashMap key ownership)
-        self.type_workers
-            .entry(worker.worker_type().clone())
-            .or_default()
-            .push(worker_id.clone());
 
         // Update connection mode index (clone needed for DashMap key ownership)
         self.connection_workers
@@ -296,26 +447,17 @@ impl WorkerRegistry {
             // Remove from URL mapping
             self.url_to_id.remove(worker.url());
 
-            // Remove from model index using copy-on-write
-            // Create new snapshot without the removed worker
-            let worker_url = worker.url();
+            // Remove from the layered pool (model -> framework -> role), copy-on-write.
             let model_id = worker.model_id().to_string();
-            if let Some(mut entry) = self.model_index.get_mut(&model_id) {
-                let new_workers: Vec<Arc<dyn Worker>> = entry
-                    .iter()
-                    .filter(|w| w.url() != worker_url)
-                    .cloned()
-                    .collect();
-                *entry = Arc::from(new_workers.into_boxed_slice());
-            }
+            self.pool_remove(
+                &model_id,
+                *worker.framework(),
+                worker.worker_type().pool_role(),
+                worker.url(),
+            );
 
             // Rebuild hash ring for this model
             self.rebuild_hash_ring(&model_id);
-
-            // Remove from type index
-            if let Some(mut type_workers) = self.type_workers.get_mut(worker.worker_type()) {
-                type_workers.retain(|id| id != worker_id);
-            }
 
             // Remove from connection mode index
             if let Some(mut conn_workers) =
@@ -352,44 +494,78 @@ impl WorkerRegistry {
         self.url_to_id.get(url).and_then(|id| self.get(&id))
     }
 
-    /// Empty worker slice constant for returning when no workers found
-    const EMPTY_WORKERS: &'static [Arc<dyn Worker>] = &[];
-
-    /// Get all workers for a model (O(1) optimized, lock-free)
-    /// Returns an Arc to the immutable worker slice - just an atomic refcount bump.
-    /// This is the fastest possible read path with zero contention.
-    pub fn get_by_model(&self, model_id: &str) -> Arc<[Arc<dyn Worker>]> {
-        self.model_index
-            .get(model_id)
-            .map(|workers| Arc::clone(&workers))
-            .unwrap_or_else(|| Arc::from(Self::EMPTY_WORKERS))
+    /// Get the layered pool for a model, if it exists.
+    pub fn get_model_pool(&self, model_id: &str) -> Option<Arc<ModelPool>> {
+        self.pools.get(model_id).map(|p| p.clone())
     }
 
-    /// Get all workers by worker type
-    pub fn get_by_type(&self, worker_type: &WorkerType) -> Vec<Arc<dyn Worker>> {
-        self.type_workers
-            .get(worker_type)
-            .map(|ids| ids.iter().filter_map(|id| self.get(id)).collect())
+    /// Frameworks that currently have workers registered for a model.
+    pub fn get_frameworks(&self, model_id: &str) -> Vec<Framework> {
+        self.pools
+            .get(model_id)
+            .map(|p| p.frameworks())
             .unwrap_or_default()
     }
 
-    /// Get all prefill workers (regardless of bootstrap_port)
-    pub fn get_prefill_workers(&self) -> Vec<Arc<dyn Worker>> {
-        self.workers
+    /// Direct access to a single pool bucket: (model, framework, role).
+    /// Returns an immutable Arc slice — lock-free, just a refcount bump.
+    pub fn get_pool(
+        &self,
+        model_id: &str,
+        framework: &Framework,
+        role: PoolRole,
+    ) -> Arc<[Arc<dyn Worker>]> {
+        self.pools
+            .get(model_id)
+            .and_then(|p| p.framework_buckets(framework))
+            .map(|b| b.bucket(role))
+            .unwrap_or_else(empty_worker_slice)
+    }
+
+    /// Get all workers for a model (across every framework and role).
+    pub fn get_by_model(&self, model_id: &str) -> Arc<[Arc<dyn Worker>]> {
+        match self.pools.get(model_id) {
+            Some(pool) => Arc::from(pool.all().into_boxed_slice()),
+            None => empty_worker_slice(),
+        }
+    }
+
+    /// Get all workers matching a worker type (across all models/frameworks).
+    pub fn get_by_type(&self, worker_type: &WorkerType) -> Vec<Arc<dyn Worker>> {
+        let role = worker_type.pool_role();
+        self.pools
             .iter()
-            .filter_map(|entry| {
-                let worker = entry.value();
-                match worker.worker_type() {
-                    WorkerType::Prefill { .. } => Some(worker.clone()),
-                    _ => None,
-                }
+            .flat_map(|pool| {
+                pool.buckets
+                    .iter()
+                    .flat_map(|b| b.value().bucket(role).iter().cloned().collect::<Vec<_>>())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|w| w.worker_type() == worker_type)
+            .collect()
+    }
+
+    /// Collect every worker in a given pool role across all models/frameworks.
+    fn collect_role(&self, role: PoolRole) -> Vec<Arc<dyn Worker>> {
+        self.pools
+            .iter()
+            .flat_map(|pool| {
+                pool.buckets
+                    .iter()
+                    .flat_map(|b| b.value().bucket(role).iter().cloned().collect::<Vec<_>>())
+                    .collect::<Vec<_>>()
             })
             .collect()
     }
 
+    /// Get all prefill workers (regardless of bootstrap_port)
+    pub fn get_prefill_workers(&self) -> Vec<Arc<dyn Worker>> {
+        self.collect_role(PoolRole::PrefillPD)
+    }
+
     /// Get all decode workers
     pub fn get_decode_workers(&self) -> Vec<Arc<dyn Worker>> {
-        self.get_by_type(&WorkerType::Decode)
+        self.collect_role(PoolRole::DecodePD)
     }
 
     /// Get all workers by connection mode
@@ -448,7 +624,7 @@ impl WorkerRegistry {
 
     /// Get all model IDs with workers (lock-free)
     pub fn get_models(&self) -> Vec<String> {
-        self.model_index
+        self.pools
             .iter()
             .filter(|entry| !entry.value().is_empty())
             .map(|entry| entry.key().clone())
@@ -461,22 +637,22 @@ impl WorkerRegistry {
     /// - model_id: Filter by specific model
     /// - worker_type: Filter by worker type (Regular, Prefill, Decode)
     /// - connection_mode: Filter by connection mode (Http, Grpc)
-    /// - runtime_type: Filter by runtime type (Sglang, Vllm)
+    /// - framework: Filter by framework (Sglang, Vllm, Atom, Anonymous)
     /// - healthy_only: Only return healthy workers
     pub fn get_workers_filtered(
         &self,
         model_id: Option<&str>,
         worker_type: Option<WorkerType>,
         connection_mode: Option<ConnectionMode>,
-        runtime_type: Option<RuntimeType>,
+        framework: Option<Framework>,
         healthy_only: bool,
     ) -> Vec<Arc<dyn Worker>> {
-        // Start with the most efficient collection based on filters
-        // Use model index when possible as it's O(1) lookup
-        let workers: Vec<Arc<dyn Worker>> = if let Some(model) = model_id {
-            self.get_by_model(model).to_vec()
-        } else {
-            self.get_all()
+        // Start with the narrowest collection the pool layout allows.
+        // Best case: (model, framework, role) hits a single bucket directly.
+        let workers: Vec<Arc<dyn Worker>> = match (model_id, &framework, &worker_type) {
+            (Some(model), Some(fw), Some(wt)) => self.get_pool(model, fw, wt.pool_role()).to_vec(),
+            (Some(model), _, _) => self.get_by_model(model).to_vec(),
+            _ => self.get_all(),
         };
 
         // Apply remaining filters
@@ -497,9 +673,9 @@ impl WorkerRegistry {
                     }
                 }
 
-                // Check runtime_type if specified
-                if let Some(ref rt) = runtime_type {
-                    if w.metadata().runtime_type != *rt {
+                // Check framework if specified
+                if let Some(ref fw) = framework {
+                    if w.framework() != fw {
                         return false;
                     }
                 }
@@ -519,7 +695,7 @@ impl WorkerRegistry {
         let total_workers = self.workers.len();
         // Count models directly instead of allocating Vec via get_models() (lock-free)
         let total_models = self
-            .model_index
+            .pools
             .iter()
             .filter(|entry| !entry.value().is_empty())
             .count();
@@ -579,12 +755,17 @@ impl WorkerRegistry {
     /// Get counts of regular and PD workers efficiently (O(1))
     /// This avoids the overhead of get_all() which allocates memory and iterates all workers
     pub fn get_worker_distribution(&self) -> (usize, usize) {
-        // Use the existing type_workers index for O(1) lookup
-        let regular_count = self
-            .type_workers
-            .get(&WorkerType::Regular)
-            .map(|v| v.len())
-            .unwrap_or(0);
+        // Sum the regular buckets across every model/framework pool.
+        let regular_count: usize = self
+            .pools
+            .iter()
+            .map(|pool| {
+                pool.buckets
+                    .iter()
+                    .map(|b| b.value().bucket(PoolRole::Regular).len())
+                    .sum::<usize>()
+            })
+            .sum();
 
         // Get total workers count efficiently from DashMap
         let total_workers = self.workers.len();
@@ -686,7 +867,9 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::core::{circuit_breaker::CircuitBreakerConfig, BasicWorkerBuilder};
+    use crate::core::{
+        circuit_breaker::CircuitBreakerConfig, BasicWorkerBuilder, UNKNOWN_MODEL_ID,
+    };
 
     #[test]
     fn test_worker_registry() {
@@ -1133,5 +1316,159 @@ mod tests {
 
         assert_eq!(id1.as_str(), id2.as_str());
         assert_eq!(registry.len(), 1);
+    }
+
+    fn make_worker_fw(
+        url: &str,
+        wtype: WorkerType,
+        model_id: &str,
+        framework: Framework,
+    ) -> Arc<dyn Worker> {
+        let mut labels = HashMap::new();
+        labels.insert("model_id".to_string(), model_id.to_string());
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(wtype)
+                .framework(framework)
+                .labels(labels)
+                .circuit_breaker_config(CircuitBreakerConfig::default())
+                .build(),
+        )
+    }
+
+    #[test]
+    fn test_layered_pool_direct_bucket_access() {
+        let registry = WorkerRegistry::new();
+        // Same model, different frameworks and roles.
+        registry.register(make_worker_fw(
+            "http://r1:8000",
+            WorkerType::Regular,
+            "m",
+            Framework::Vllm,
+        ));
+        registry.register(make_worker_fw(
+            "http://p1:8000",
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            "m",
+            Framework::Vllm,
+        ));
+        registry.register(make_worker_fw(
+            "http://d1:8000",
+            WorkerType::Decode,
+            "m",
+            Framework::Vllm,
+        ));
+        registry.register(make_worker_fw(
+            "http://r2:8000",
+            WorkerType::Regular,
+            "m",
+            Framework::Sglang,
+        ));
+
+        // Direct bucket access hits exactly one (model, framework, role).
+        assert_eq!(
+            registry
+                .get_pool("m", &Framework::Vllm, PoolRole::Regular)
+                .len(),
+            1
+        );
+        assert_eq!(
+            registry
+                .get_pool("m", &Framework::Vllm, PoolRole::PrefillPD)
+                .len(),
+            1
+        );
+        assert_eq!(
+            registry
+                .get_pool("m", &Framework::Vllm, PoolRole::DecodePD)
+                .len(),
+            1
+        );
+        assert_eq!(
+            registry
+                .get_pool("m", &Framework::Sglang, PoolRole::Regular)
+                .len(),
+            1
+        );
+        assert_eq!(
+            registry
+                .get_pool("m", &Framework::Sglang, PoolRole::PrefillPD)
+                .len(),
+            0
+        );
+
+        // Frameworks present for the model.
+        let mut fws = registry.get_frameworks("m");
+        fws.sort_by_key(|f| f.to_string());
+        assert_eq!(fws, vec![Framework::Sglang, Framework::Vllm]);
+
+        // Aggregates across frameworks/roles.
+        assert_eq!(registry.get_by_model("m").len(), 4);
+        assert_eq!(registry.get_prefill_workers().len(), 1);
+        assert_eq!(registry.get_decode_workers().len(), 1);
+    }
+
+    #[test]
+    fn test_layered_pool_defaults_unknown_and_anonymous() {
+        let registry = WorkerRegistry::new();
+        // No model_id label and default (Anonymous) framework.
+        let w: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8000")
+                .worker_type(WorkerType::Regular)
+                .circuit_breaker_config(CircuitBreakerConfig::default())
+                .build(),
+        );
+        registry.register(w);
+
+        assert_eq!(
+            registry
+                .get_pool(UNKNOWN_MODEL_ID, &Framework::Anonymous, PoolRole::Regular)
+                .len(),
+            1
+        );
+        assert_eq!(registry.get_models(), vec![UNKNOWN_MODEL_ID.to_string()]);
+    }
+
+    #[test]
+    fn test_layered_pool_remove_shrinks_bucket() {
+        let registry = WorkerRegistry::new();
+        registry.register(make_worker_fw(
+            "http://a:8000",
+            WorkerType::Regular,
+            "m",
+            Framework::Atom,
+        ));
+        registry.register(make_worker_fw(
+            "http://b:8000",
+            WorkerType::Regular,
+            "m",
+            Framework::Atom,
+        ));
+        assert_eq!(
+            registry
+                .get_pool("m", &Framework::Atom, PoolRole::Regular)
+                .len(),
+            2
+        );
+
+        registry.remove_by_url("http://a:8000");
+        assert_eq!(
+            registry
+                .get_pool("m", &Framework::Atom, PoolRole::Regular)
+                .len(),
+            1
+        );
+
+        registry.remove_by_url("http://b:8000");
+        // Pool emptied -> model gone.
+        assert_eq!(
+            registry
+                .get_pool("m", &Framework::Atom, PoolRole::Regular)
+                .len(),
+            0
+        );
+        assert!(registry.get_models().is_empty());
     }
 }


### PR DESCRIPTION

## Motivation
Rework the worker registry from a flat model index into a layered model -> framework -> role pool structure. This keeps lock-free snapshot reads while allowing direct lookup of regular, PD prefill, and PD decode workers per framework.
Introduce Framework and PoolRole as first-class worker metadata, replacing the older RuntimeType naming. Worker creation now derives framework from discovered or configured runtime metadata, with HTTP workers defaulting to Anonymous and gRPC workers defaulting to Sglang when unspecified. Update worker builders, update flows, config mapping, and placement test support to preserve framework metadata through worker lifecycle operations. Add registry tests covering direct bucket access, anonymous defaults, and pool cleanup after worker removal.


## Test Plan
for atomesh mocker test
<img width="1147" height="253" alt="image" src="https://github.com/user-attachments/assets/2c2ba24a-fecc-45c1-bf1f-dc20205495df" />

