### PR TITLE
[atom-vllm] fix V4 OOM issue

### DIFF
--- a/atom/plugin/vllm/deepseek_v4_bridge.py
+++ b/atom/plugin/vllm/deepseek_v4_bridge.py
@@ -1190,7 +1190,60 @@ def build_atom_v4_attention_metadata(
         _populate_decode(md, common_attn_metadata, batch_np, pos_np, positions)
     else:
         _populate_prefill(md, common_attn_metadata, batch_np, pos_np, q_np, positions)
-    _populate_indexer(md, common_attn_metadata, batch_np, positions[:total], device)
+    # Decode/prefill split for the indexer. vLLM reorders rows with
+    # query_len <= (1 + num_spec_tokens) — i.e. decode / spec-verify / 1-token
+    # rows — to the FRONT of the batch (reorder_batch_threshold). Grouping by
+    # query length is exactly what the indexer needs: those rows only require
+    # committed K from the paged cache, so they take the fixed-shape paged
+    # `_score_topk_decode` path and are kept out of the dense prefill logits.
+    decode_q = 1 + max(0, int(num_spec_tokens))
+    if is_decode:
+        idx_num_decodes = num_reqs
+        idx_num_decode_tokens = total
+        idx_decode_next_n = int(lens[0]) if num_reqs > 0 else 1
+    else:
+        # The paged `_score_topk_decode` reshapes the decode tokens to
+        # `[num_decode_tokens // decode_next_n, decode_next_n]`, so the paged
+        # decode group must be a contiguous batch prefix that shares ONE query
+        # length (`decode_next_n`). vLLM usually reorders the short decode /
+        # spec-verify rows (query_len <= decode_q) ahead of the longer prefill
+        # rows, but that layout is NOT guaranteed under MTP + chunked prefill:
+        #   * the decode prefix is not uniform -- a steady-state verify row is
+        #     `1 + num_spec_tokens` long, but a request on its first decode step
+        #     (or one whose drafts were all rejected) contributes a shorter row,
+        #     e.g. `[4, 4, ..., 4, 1]`; and
+        #   * a prefill chunk can land AMONG the verify rows, e.g. `[4, 4, 10,
+        #     4]`, so decode-length rows are not always a clean leading prefix.
+        # Rather than assert a layout vLLM does not promise, take the paged
+        # decode group as the leading contiguous run of rows that share the
+        # FIRST row's length (only when that is a decode/verify length,
+        # `<= decode_q`), and end it at the first row that differs -- whether a
+        # short decode straggler or a longer prefill row. Everything from there
+        # flows to the dense prefill path below, which handles arbitrary per-row
+        # query lengths. This is memory-safe: the long-context verify rows are
+        # emitted first, so they stay on the paged path, and only the (few)
+        # rows after the first mismatch reach the dense `total_committed` -- so
+        # its `[total_tokens, total_committed]` logits never explode the way
+        # they would if every running seq were summed in. `lens` is a CPU numpy
+        # array (from `query_start_loc.cpu()`), so this adds no H2D/D2H sync.
+        if num_reqs > 0 and int(lens[0]) <= decode_q:
+            idx_decode_next_n = int(lens[0])
+            mismatch = np.nonzero(lens != idx_decode_next_n)[0]
+            idx_num_decodes = int(mismatch[0]) if mismatch.size else num_reqs
+        else:
+            idx_decode_next_n = 1
+            idx_num_decodes = 0
+        idx_num_decode_tokens = int(q_np[idx_num_decodes]) if idx_num_decodes > 0 else 0
+    _populate_indexer(
+        md,
+        common_attn_metadata,
+        batch_np,
+        positions[:total],
+        device,
+        num_decodes=idx_num_decodes,
+        num_decode_tokens=idx_num_decode_tokens,
+        decode_next_n=idx_decode_next_n,
+    )
     return md
 
 
@@ -1292,24 +1345,68 @@ def _populate_decode_persistent(
     md.swa_pages = swa_pages
 
 
-def _populate_indexer(md, common, batch_np, positions, device):
-    n_csa = md.n_committed_csa_per_seq_cpu
+def _populate_indexer(
+    md,
+    common,
+    batch_np,
+    positions,
+    device,
+    num_decodes=0,
+    num_decode_tokens=0,
+    decode_next_n=1,
+):
+    # In a MIXED (chunked-prefill + decode) batch vLLM orders the decode rows
+    # first (reorder threshold == 1[+spec]); only the prefill rows feed the
+    # dense `fp8_mqa_logits` indexer. Build the committed cumsum / per-token
+    # start-end offsets over the PREFILL SEQUENCES ONLY (seqs [num_decodes:],
+    # tokens [num_decode_tokens:]) so the long-context decode seqs do NOT get
+    # summed into `total_committed` (the O(total_tokens x total_committed) dense
+    # logits that OOMs at high concurrency). The decode rows are scored by the
+    # fixed-shape paged path (`_score_topk_decode`), which reads only the full
+    # per-seq committed tensor kept below. Pure prefill => num_decodes == 0, so
+    # this reduces to the whole batch (unchanged).
+    n_csa = md.n_committed_csa_per_seq_cpu[num_decodes:]
     cu = np.concatenate([np.zeros(1, dtype=np.int32), np.cumsum(n_csa, dtype=np.int32)])
     cu[-1] = max(int(cu[-1]), 1)
     cu_gpu = torch.from_numpy(cu).to(device)
-    bid = md.batch_id_per_token
+    # Per-prefill-token batch id, rebased to 0-based prefill-seq indexing.
+    bid = (md.batch_id_per_token[num_decode_tokens:] - num_decodes).to(
+        md.batch_id_per_token.dtype
+    )
+    n_committed_pref = md.n_committed_csa_per_seq[num_decodes:]
+    pos_pref = positions[num_decode_tokens:]
     base = cu_gpu[bid].to(torch.int32)
-    end = base + torch.minimum(
-        (positions + 1) // 4, md.n_committed_csa_per_seq[bid]
-    ).to(torch.int32)
+    end = base + torch.minimum((pos_pref + 1) // 4, n_committed_pref[bid]).to(
+        torch.int32
+    )
     md.indexer_meta = {
         "total_committed": int(cu[-1]),
         "cu_committed_gpu": cu_gpu,
+        # FULL per-seq committed (decode-first order): the decode sub-call
+        # slices [:num_decodes]; the pure-decode path reads it whole.
         "n_committed_per_seq_gpu": md.n_committed_csa_per_seq,
-        "batch_id_per_token_gpu": bid,
+        "batch_id_per_token_gpu": md.batch_id_per_token,
         "seq_base_per_token_gpu": base,
         "cu_starts_gpu": base,
         "cu_ends_gpu": end,
+        # Decode/prefill split (consumed by `indexer_score_topk` for mixed
+        # batches; harmless for pure prefill where num_decode_tokens == 0).
+        "num_decodes": int(num_decodes),
+        "num_decode_tokens": int(num_decode_tokens),
+        "decode_next_n": int(decode_next_n),
+        # Largest committed compressed-KV length among the DECODE sub-batch
+        # seqs (host int from the CPU committed array -- no D2H sync). The
+        # mixed-batch paged `_score_topk_decode` sizes its per-fwd logits width
+        # to this instead of the model-max `_max_model_len_idx` (= max_seq_len
+        # // compress_ratio). The deepgemm kernel guards every store by
+        # `col < max_model_len_arg` and only writes [0, n_committed) per row,
+        # so a width >= this max is exact, while the model-max width would
+        # allocate a ~GB transient per CSA layer and OOM at high concurrency.
+        "decode_max_committed": (
+            int(md.n_committed_csa_per_seq_cpu[:num_decodes].max())
+            if num_decodes > 0
+            else 0
+        ),
     }
 
 

--- a/atom/plugin/vllm/models/deepseek_v4.py
+++ b/atom/plugin/vllm/models/deepseek_v4.py
@@ -12,6 +12,8 @@ It follows the same construction-swap pattern as ``qwen3_next``: the
 variant, then restores it.
 """
 
+from typing import Optional
+
 import torch
 
 from atom.models import deepseek_v4 as deepseek_v4_base
@@ -19,8 +21,190 @@ from atom.models.deepseek_v4 import (
     DeepseekV4Attention as DeepseekV4AttentionBase,
     DeepseekV4ForCausalLM as DeepseekV4ForCausalLMBase,
     DeepseekV4Model as DeepseekV4ModelBase,
+    Indexer as IndexerBase,
 )
 from atom.utils.forward_context import AttnState, get_forward_context
+
+
+class IndexerVllm(IndexerBase):
+    """DeepSeek-V4 sparse indexer with vLLM mixed-batch decode/prefill split.
+
+    Native ATOM serves decode and prefill in *separate* forward passes, so its
+    ``indexer_score_topk`` can route the whole batch by ``is_prefill``: pure
+    decode -> fixed-shape paged ``_score_topk_decode``; pure prefill -> dense
+    ``_score_topk_prefill``.
+
+    vLLM continuous batching instead produces MIXED batches (chunked-prefill
+    rows + running decode rows) that ATOM classifies as PREFILL (batch
+    ``max_query_len`` > 1). Routing the decode rows through the dense
+    ``fp8_mqa_logits`` prefill path makes its ``[total_tokens, total_committed]``
+    logits sum EVERY running seq's committed K into ``total_committed`` —
+    quadratic in batch size, which OOMs the GPU at high concurrency.
+
+    Mirror native ATOM by splitting the mixed batch here: vLLM reorders decode
+    rows (query_len <= 1[+num_spec]) to the FRONT (``reorder_batch_threshold``),
+    so the split is a contiguous prefix. Decode rows take the fixed-shape paged
+    path (bounded per-seq, no batch-sum); prefill rows take the dense path whose
+    ``total_committed`` the bridge (``_populate_indexer``) now builds over the
+    PREFILL sub-batch only. This override lives in the vLLM plugin so native
+    ATOM behaviour is untouched.
+
+    Only the PREFILL-classified branch changes. The pure-decode branch is
+    byte-for-byte the native call, so the FULL-CUDAGraph-captured decode replay
+    path is unaffected; the split runs eager (mixed batches are always
+    PIECEWISE, never FULL-captured), introducing no new captured shapes or
+    Python branches into any graph.
+    """
+
+    def indexer_score_topk(
+        self,
+        q_fp8: torch.Tensor,  # [total_tokens, n_heads, head_dim] fp8
+        weights: torch.Tensor,  # [total_tokens, n_heads] fp32
+        topk: int,
+    ) -> torch.Tensor:
+        fc = get_forward_context()
+        indexer_meta = fc.attn_metadata.indexer_meta
+        block_tables = fc.attn_metadata.block_tables  # [bs, max_blocks_per_seq]
+
+        if not fc.context.is_prefill:
+            # Pure-decode step (AttnState.DECODE): the CUDAGraph-captured
+            # fixed-shape paged path. Byte-for-byte the native call.
+            return self._score_topk_decode(
+                q_fp8, weights, block_tables, indexer_meta, topk
+            )  # [total_tokens, topk] int32
+
+        # Prefill-classified step (may be MIXED under continuous batching).
+        num_decode_tokens = int(indexer_meta.get("num_decode_tokens", 0))
+        if num_decode_tokens == 0:
+            # Pure prefill: `total_committed` already spans only prefill seqs.
+            return self._score_topk_prefill(
+                q_fp8, weights, block_tables, indexer_meta, topk
+            )  # [total_tokens, topk] int32
+
+        num_decodes = int(indexer_meta["num_decodes"])
+        n_committed_per_seq = indexer_meta["n_committed_per_seq_gpu"]
+        # Decode rows: paged fixed-shape logits (bounded per-seq, no batch-sum).
+        decode_topk = self._score_topk_decode(
+            q_fp8[:num_decode_tokens],
+            weights[:num_decode_tokens],
+            block_tables[:num_decodes],
+            indexer_meta,
+            topk,
+            next_n=int(indexer_meta["decode_next_n"]),
+            n_committed_per_seq=n_committed_per_seq[:num_decodes],
+        )  # [num_decode_tokens, topk] int32
+        # Prefill rows: dense logits now sized only by the PREFILL seqs'
+        # committed K (the bridge builds the committed meta over the prefill
+        # sub-batch), so `total_committed` no longer explodes.
+        prefill_topk = self._score_topk_prefill(
+            q_fp8[num_decode_tokens:],
+            weights[num_decode_tokens:],
+            block_tables[num_decodes:],
+            indexer_meta,
+            topk,
+        )  # [num_prefill_tokens, topk] int32
+        # Decode-first ordering matches the reordered batch row order.
+        return torch.cat([decode_topk, prefill_topk], dim=0)
+
+    def _score_topk_decode(
+        self,
+        q_fp8: torch.Tensor,  # [total_tokens, n_heads, head_dim] fp8
+        weights: torch.Tensor,  # [total_tokens, n_heads] fp32
+        block_tables: torch.Tensor,  # [bs, max_blocks_per_seq] int32
+        indexer_meta: dict,
+        topk: int,
+        *,
+        next_n: Optional[int] = None,
+        n_committed_per_seq: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Paged decode top-k, extended for the DECODE slice of a mixed batch.
+
+        Native ATOM only ever calls this for a *pure* decode forward, where the
+        step size is the batch-wide ``max_seqlen_q`` and the committed tensor is
+        the whole ``indexer_meta["n_committed_per_seq_gpu"]``. Under vLLM
+        continuous batching this also runs on the leading decode slice of a
+        MIXED batch, where neither holds: ``max_seqlen_q`` is the prefill max
+        (not the decode step size) and the committed tensor must be sliced to
+        the decode sub-batch. So ``indexer_score_topk`` passes ``next_n`` and
+        ``n_committed_per_seq`` explicitly for that case.
+
+        When both are ``None`` (the pure-decode / spec-verify step) this is
+        byte-for-byte the native call -- delegating to it keeps the
+        FULL-CUDAGraph-captured decode replay path untouched. The mixed-batch
+        slice is always eager (mixed batches are PIECEWISE, never FULL), so the
+        extra Python branch introduces no new captured shapes. Living here keeps
+        native ATOM's ``Indexer`` interface unchanged.
+        """
+        if next_n is None and n_committed_per_seq is None:
+            return super()._score_topk_decode(
+                q_fp8, weights, block_tables, indexer_meta, topk
+            )
+        total_tokens = q_fp8.size(0)
+        n_committed_per_seq_gpu = (
+            n_committed_per_seq
+            if n_committed_per_seq is not None
+            else indexer_meta["n_committed_per_seq_gpu"]
+        )  # int32 [bs]
+        if next_n is None:
+            next_n = max(1, int(get_forward_context().attn_metadata.max_seqlen_q))
+        bs = total_tokens // next_n
+        # deepgemm requires Q in [bs, next_n, heads, head_dim], KV in
+        # [num_blocks, block_size, n_head=1, hidden_dim+scale_dim] (4D).
+        q_4d = q_fp8.view(bs, next_n, self.n_heads, self.head_dim)
+        kv_cache_4d = self.kv_cache.unsqueeze(-2)
+        # Logits column count. Native pure-decode allocates the model-max
+        # `_max_model_len_idx` (= max_seq_len // compress_ratio, e.g. 262144 at
+        # 1M context) because its captured shape must bound the longest
+        # possible sequence. This eager mixed-batch slice is NOT captured, so
+        # size it to this batch's actual max committed compressed-KV length
+        # instead: the deepgemm kernel guards every store by
+        # `col < max_model_len_arg` and only writes [0, n_committed) per row,
+        # and `top_k_per_row_decode` only reads [0, n_committed) per row, so a
+        # width >= max(n_committed) is exact. The model-max width would allocate
+        # a ~GB fp32 transient PER CSA layer and OOM the GPU at high concurrency
+        # (HSA_STATUS_ERROR_OUT_OF_RESOURCES). Round up to the kernel's ChunkK
+        # (256) so chunked stores never touch a partial tail column, and cap at
+        # the model max.
+        _CHUNK_K = 256
+        max_committed = int(indexer_meta.get("decode_max_committed", 0))
+        logits_width = min(
+            self._max_model_len_idx,
+            max(_CHUNK_K, ((max_committed + _CHUNK_K - 1) // _CHUNK_K) * _CHUNK_K),
+        )
+        # Per-fwd write-once GPU scratch; `top_k_per_row_decode` bounds each row
+        # by `n_committed_per_seq[batch]` so unwritten cols are never picked
+        # (no `fill_(-inf)` needed).
+        logits = torch.empty(
+            total_tokens,
+            logits_width,
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+        deepseek_v4_base.deepgemm_fp8_paged_mqa_logits(
+            q_4d,
+            kv_cache_4d,
+            weights,
+            logits,
+            n_committed_per_seq_gpu,  # int32, sized [bs] (staged in builder)
+            block_tables,
+            logits_width,  # max_model_len arg == buffer width (store guard)
+            KVBlockSize=self.kv_cache.size(1),  # k1_csa = 32
+            Preshuffle=True,
+        )
+        topk_local = torch.empty(
+            total_tokens, self.index_topk, dtype=torch.int32, device=q_fp8.device
+        )
+        deepseek_v4_base.top_k_per_row_decode(
+            logits,
+            next_n,
+            n_committed_per_seq_gpu,
+            topk_local,
+            total_tokens,
+            logits.stride(0),
+            logits.stride(1),
+            k=topk,
+        )
+        return topk_local  # [total_tokens, index_topk] int32, raw seq-local
 
 
 class DeepseekV4AttentionVllm(DeepseekV4AttentionBase):
@@ -121,10 +305,16 @@ class DeepseekV4ForCausalLM(DeepseekV4ForCausalLMBase):
     def __init__(self, *args, **kwargs):
         original_attn_cls = deepseek_v4_base.DeepseekV4Attention
         original_model_cls = deepseek_v4_base.DeepseekV4Model
+        original_indexer_cls = deepseek_v4_base.Indexer
         deepseek_v4_base.DeepseekV4Attention = DeepseekV4AttentionVllm
         deepseek_v4_base.DeepseekV4Model = DeepseekV4ModelVllm
+        # `DeepseekV4Attention.__init__` builds `self.indexer = Indexer(...)`
+        # via this module-global, so rebind it too to get the mixed-batch
+        # split variant across the whole model tree.
+        deepseek_v4_base.Indexer = IndexerVllm
         try:
             super().__init__(*args, **kwargs)
         finally:
             deepseek_v4_base.DeepseekV4Attention = original_attn_cls
             deepseek_v4_base.DeepseekV4Model = original_model_cls
+            deepseek_v4_base.Indexer = original_indexer_cls

--- a/atom/plugin/vllm/models/deepseek_v4_mtp.py
+++ b/atom/plugin/vllm/models/deepseek_v4_mtp.py
@@ -2,16 +2,24 @@
 
 from atom.models import deepseek_v4 as deepseek_v4_base
 from atom.models.deepseek_v4_mtp import DeepseekV4MTP as DeepseekV4MTPBase
-from atom.plugin.vllm.models.deepseek_v4 import DeepseekV4AttentionVllm
+from atom.plugin.vllm.models.deepseek_v4 import DeepseekV4AttentionVllm, IndexerVllm
 
 
 class DeepseekV4MTP(DeepseekV4MTPBase):
-    """Build native DeepSeek-V4 MTP blocks with the vLLM V4 attention variant."""
+    """Build native DeepSeek-V4 MTP blocks with the vLLM V4 attention variant.
+
+    Also rebind the ``Indexer`` global to the mixed-batch-split ``IndexerVllm``
+    so the draft's sparse indexer matches the target model's behaviour under
+    vLLM continuous batching / spec-verify.
+    """
 
     def __init__(self, *args, **kwargs):
         original_attn_cls = deepseek_v4_base.DeepseekV4Attention
+        original_indexer_cls = deepseek_v4_base.Indexer
         deepseek_v4_base.DeepseekV4Attention = DeepseekV4AttentionVllm
+        deepseek_v4_base.Indexer = IndexerVllm
         try:
             super().__init__(*args, **kwargs)
         finally:
             deepseek_v4_base.DeepseekV4Attention = original_attn_cls
+            deepseek_v4_base.Indexer = original_indexer_cls


### PR DESCRIPTION
## Motivation

This PR fixes the OOM error of running deepseek v4 with high concurrency.

Root cause: Previously atom-vllm routes mixed batch (prefill + decode) to prefill path, witch will create very large intermediate tensor `logits` witch is related with batch size.

Solution: Split mixed batch and let prefills and decodes go to their paths separately.



## Test Result

```

  ├──────────────────┼─────────────┼────────┼─────────┤
  │ flexible-extract │ exact_match │ 0.9522 │ ±0.0059 │
  ├──────────────────┼─────────────┼────────┼─────────┤
  │ strict-match     │ exact_match │ 0.9522 │ ±0.0059 
```

