### PR TITLE
[Feature] Supports quark perchannel dequantization

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -33,9 +33,8 @@ from atom.model_ops.utils import (
 from atom.utils import envs
 from atom.utils.decorators import mark_trace
 from atom.quantization.quark.utils import (
+    dequant_weight_online,
     quant_weight_online,
-    weight_dequant_fp8,
-    weight_dequant_mxfp8,
 )
 from torch import nn
 
@@ -587,14 +586,22 @@ class LinearBase(nn.Module):
             f"Unsupported online quant: "
             f"dtype={online_quant_dtype}, type={online_quant_type}"
         )
+        # Quark models arrive in several source formats. We can re-quantize any
+        # source we know how to dequantize back to float first: unquantized
+        # (No), per-tensor FP8 (per_Tensor), per-output-channel FP8 (per_Token /
+        # ptpc_fp8), 128x128 block FP8 (per_1x128) and MXFP8 (per_1x32). Any
+        # other source is rejected up front rather than silently producing
+        # garbage.
         assert self.quant_type in [
             QuantType.No,
             QuantType.per_Tensor,
+            QuantType.per_Token,
             QuantType.per_1x128,
             QuantType.per_1x32,
         ], (
             f"Unsupported source quant_type for online quantization: "
-            f"{self.quant_type} (layer={self.prefix})"
+            f"{self.quant_type} (layer={self.prefix}). Supported sources: "
+            f"No, per_Tensor, per_Token, per_1x128, per_1x32."
         )
         weight = self.weight.data
         weight_scale = getattr(self, "weight_scale", None)
@@ -624,28 +631,29 @@ class LinearBase(nn.Module):
                 need_gather = self.tp_dim == 1 and self.input_size % 32 != 0
         if need_gather:
             weight = self._gather_full_weight(weight)
-            if weight_scale is not None:
+            # Only gather the scale along a dim it is actually sharded on. A
+            # per_Token scale is (N, 1): sharded on dim 0 (column parallel) but
+            # already full on dim 1 (row parallel), so gathering the size-1 dim
+            # would corrupt it. Block scales (per_1x128 / per_1x32) have a real
+            # size on tp_dim and are gathered as before.
+            if (
+                weight_scale is not None
+                and weight_scale.dim() > self.tp_dim
+                and weight_scale.shape[self.tp_dim] > 1
+            ):
                 weight_scale = self._gather_full_weight(weight_scale)
 
-        if self.quant_type == QuantType.per_1x128:
-            # dequant per block fp8
-            weight = weight_dequant_fp8(weight, weight_scale)
-        elif self.quant_type == QuantType.per_1x32:
-            # dequant MXFP8 (FP8 elements + 1x32 E8M0 shared scale)
-            weight = weight_dequant_mxfp8(weight, weight_scale)
-        elif self.quant_type == QuantType.per_Tensor:
-            # dequant per-tensor fp8: weight (N, K) * per-partition scalar scale.
-            # Merged layers (qkv/gate_up) carry one scale per output partition.
-            w = weight.to(torch.float32)
-            ws = weight_scale.reshape(-1)
-            if ws.numel() <= 1:
-                w = w * ws.reshape(())
-            else:
-                off = 0
-                for i, sz in enumerate(self.output_partition_sizes):
-                    w[off : off + sz] = w[off : off + sz] * ws[i]
-                    off += sz
-            weight = w.to(get_current_atom_config().torch_dtype)
+        # Dequantize the source weight back to float so it can be re-quantized
+        # to the online target format (no-op for an unquantized source).
+        # output_partition_sizes lets per_Tensor merged layers (qkv/gate_up)
+        # apply the right per-partition scale to each output row-range.
+        weight = dequant_weight_online(
+            weight,
+            weight_scale,
+            self.quant_type,
+            self.params_dtype,
+            self.output_partition_sizes,
+        )
 
         q_weight, weight_scale = quant_weight_online(
             weight, online_quant_type, online_quant_dtype

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -631,15 +631,12 @@ class LinearBase(nn.Module):
                 need_gather = self.tp_dim == 1 and self.input_size % 32 != 0
         if need_gather:
             weight = self._gather_full_weight(weight)
-            # Only gather the scale along a dim it is actually sharded on. A
-            # per_Token scale is (N, 1): sharded on dim 0 (column parallel) but
-            # already full on dim 1 (row parallel), so gathering the size-1 dim
-            # would corrupt it. Block scales (per_1x128 / per_1x32) have a real
-            # size on tp_dim and are gathered as before.
-            if (
-                weight_scale is not None
-                and weight_scale.dim() > self.tp_dim
-                and weight_scale.shape[self.tp_dim] > 1
+            # Per-token scales are shaped (N, 1). In row-parallel layers
+            # (tp_dim=1), that size-1 dim is replicated rather than sharded, so
+            # gathering it would duplicate the scale columns. Block scales still
+            # follow the weight sharding and are gathered here.
+            if weight_scale is not None and not (
+                self.quant_type == QuantType.per_Token and self.tp_dim == 1
             ):
                 weight_scale = self._gather_full_weight(weight_scale)
 

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -60,9 +60,8 @@ from atom.model_ops.utils import (
 from atom.plugin.vllm.moe import FusedMoEDecoratorForPluginMode
 from atom.quant_spec import LayerQuantConfig, should_skip_online_quant
 from atom.quantization.quark.utils import (
+    dequant_weight_online,
     quant_weight_online,
-    weight_dequant_fp8,
-    weight_dequant_mxfp8,
 )
 from atom.utils import envs
 from atom.utils.custom_register import direct_register_custom_op
@@ -2691,29 +2690,37 @@ class FusedMoE(torch.nn.Module):
         online_quant_type = online_quant_config.quant_type
         online_quant_dtype = online_quant_config.quant_dtype
         source_quant_type = self.layer_quant_config.quant_type
+        source_quant_dtype = self.layer_quant_config.quant_dtype
         if should_skip_online_quant(
             source_quant_type, self.params_dtype, online_quant_config
         ):
             return
 
+        # Re-quantize any source we can dequantize back to float first:
+        # unquantized (No), per-output-channel FP8 (per_Token / ptpc_fp8),
+        # 128x128 block FP8 (per_1x128) and MXFP8 (per_1x32). Other sources
+        # (e.g. per_Tensor) are rejected up front rather than silently
+        # producing garbage.
         assert source_quant_type in (
             QuantType.No,
+            QuantType.per_Token,
             QuantType.per_1x128,
             QuantType.per_1x32,
         ), (
             f"Unsupported source quant_type for MoE online quantization: "
-            f"{source_quant_type} (layer={self.layer_name})"
+            f"{source_quant_type} (layer={self.layer_name}). Supported sources: "
+            f"No, per_Token, per_1x128, per_1x32."
         )
         need_dequant = source_quant_type in (
+            QuantType.per_Token,
             QuantType.per_1x128,
             QuantType.per_1x32,
         )
 
         def _dequant_func(w: torch.Tensor, sc: torch.Tensor) -> torch.Tensor:
-            # per_1x128 -> deepseek-style square-block FP8; per_1x32 -> MXFP8.
-            if source_quant_type == QuantType.per_1x32:
-                return weight_dequant_mxfp8(w.contiguous(), sc.contiguous())
-            return weight_dequant_fp8(w.contiguous(), sc.contiguous())
+            return dequant_weight_online(
+                w.contiguous(), sc.contiguous(), source_quant_type, source_quant_dtype
+            )
 
         # Online weight quant dispatch (MXFP4 vs FP8), shared with the Linear
         # path via a single helper under quark so both stay in sync.

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -9,6 +9,13 @@ import triton.language as tl
 import torch
 from aiter import QuantType
 
+_FP8_SOURCE_DTYPES = frozenset(
+    {
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+    }
+)
+
 
 def deep_compare(dict1: Any, dict2: Any) -> bool:
     if type(dict1) is not type(dict2):
@@ -82,11 +89,12 @@ def _weight_dequant_kernel(  # type: ignore[no-untyped-def]
     tl.store(y_ptr + offs, y, mask=mask)
 
 
-def weight_dequant_fp8(
+def dequant_per_block_fp8(
     x: torch.Tensor, s: torch.Tensor, block_size: int = 128
 ) -> torch.Tensor:
     """
-    Dequantize FP8 weight tensor using inverse scale with Triton kernel.
+    Dequantize a per-block (128x128) FP8 weight using inverse scale with a
+    Triton kernel.
     """
     assert x.is_contiguous() and s.is_contiguous(), "Input tensors must be contiguous"
     assert x.dim() == 2 and s.dim() == 2, "Input tensors must have 2 dimensions"
@@ -118,10 +126,14 @@ def _mx_block_scale_dtype():
     return dtypes.fp8_e8m0
 
 
-def weight_dequant_mxfp8(
+def dequant_mxfp8(
     x: torch.Tensor, s: torch.Tensor, block_size: int = 32
 ) -> torch.Tensor:
-    """Dequantize an MXFP8 weight to the default float dtype."""
+    """Dequantize an MXFP8 weight to the default float dtype.
+
+    MXFP8 is a standard microscaling dtype (its 1x32 block scale is part of the
+    format), so the name carries no explicit granularity suffix.
+    """
     assert x.dim() == 2 and s.dim() == 2, "Input tensors must have 2 dimensions"
     M, K = x.shape
     assert K % block_size == 0, f"K={K} not divisible by block_size={block_size}"
@@ -139,6 +151,118 @@ def weight_dequant_mxfp8(
     y = x.to(torch.float32).reshape(M, n_blocks, block_size)
     y = y * scale.unsqueeze(-1)
     return y.reshape(M, K).to(out_dtype)
+
+
+def dequant_per_channel_fp8(x: torch.Tensor, s: torch.Tensor) -> torch.Tensor:
+    """Dequantize a per-output-channel (per_Token / PTPC) FP8 weight to the
+    default float dtype.
+
+    :param x: quantized weight ``[N, K]`` (last dim is the contracted dim).
+    :param s: per-output-channel scale, ``[N]`` or ``[N, 1]``.
+    """
+    assert x.dim() == 2, f"expected 2D weight, got shape={tuple(x.shape)}"
+    out_dtype = torch.get_default_dtype()
+    scale = s.reshape(-1).to(torch.float32).view(-1, 1)
+    return (x.to(torch.float32) * scale).to(out_dtype)
+
+
+def dequant_per_tensor_fp8(
+    x: torch.Tensor,
+    s: torch.Tensor,
+    output_partition_sizes: list[int] | None = None,
+) -> torch.Tensor:
+    """Dequantize a per-tensor  FP8 weight to the atom config float dtype.
+
+    Merged layers (qkv / gate_up) carry one scalar scale per output partition,
+    so each output row-range is scaled by its own scale. A single scale
+    (``numel <= 1``) scales the whole tensor.
+
+    :param x: quantized weight ``[N, K]``.
+    :param s: per-partition scalar scale(s).
+    :param output_partition_sizes: row counts of each merged output partition,
+        required when there is more than one scale.
+    """
+    out_dtype = torch.get_default_dtype()
+
+    w = x.to(torch.float32)
+    scale = s.reshape(-1)
+    if scale.numel() <= 1:
+        return (w * scale.reshape(())).to(out_dtype)
+    assert output_partition_sizes is not None, (
+        "per_Tensor merged layer needs output_partition_sizes to map each "
+        "scale to its output rows."
+    )
+    off = 0
+    for i, sz in enumerate(output_partition_sizes):
+        w[off : off + sz] = w[off : off + sz] * scale[i]
+        off += sz
+    return w.to(out_dtype)
+
+
+def dequant_weight_online(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor | None,
+    source_quant_type: QuantType,
+    source_quant_dtype: torch.dtype | None = None,
+    output_partition_sizes: list[int] | None = None,
+) -> torch.Tensor:
+    """Dequantize an online-quant SOURCE weight back to the default float dtype.
+
+    Single entry point shared by the Linear and MoE online-quant paths and the
+    inverse counterpart of :func:`quant_weight_online`: it turns an
+    already-quantized weight back into float so it can be re-quantized to a
+    different target format.
+
+    A source is identified by BOTH its ``quant_type`` (the block layout) and its
+    element ``quant_dtype``. The layout alone is not enough: e.g. ``per_1x32``
+    can carry either MXFP8 (8-bit) or MXFP4 (4-bit) elements. We only support
+    dequantizing 8-bit FP8 sources; any 4-bit (e.g. MXFP4) source is rejected,
+    since MXFP4 is only ever an online-quant target, never a weight we
+    dequantize. Supported sources:
+
+    - ``No``: unquantized, returned unchanged.
+    - ``per_Tensor``: per-tensor FP8, one scalar scale per output partition.
+    - ``per_Token`` (ptpc_fp8): per-output-channel FP8, scale ``(N, 1)``.
+    - ``per_1x128``: DeepSeek-style 128x128 block FP8.
+    - ``per_1x32``: MXFP8 (1x32 E8M0 shared scale).
+
+    :param weight: The quantized (or float, for ``No``) weight tensor.
+    :param weight_scale: The source weight scale (``None`` for ``No``).
+    :param source_quant_type: The source quantization scheme (block layout).
+    :param source_quant_dtype: The source element dtype. Used together with
+        ``source_quant_type`` to reject non-8-bit (e.g. MXFP4) sources. When
+        ``None`` the dtype check is skipped (caller vouches for an 8-bit source).
+    :param output_partition_sizes: row counts of each merged output partition,
+        only used (and required) by ``per_Tensor`` merged layers.
+    :return: The dequantized weight in the default float dtype.
+    """
+    if source_quant_type == QuantType.No:
+        return weight
+
+    # Reject any non-8-bit source up front. The element dtype -- not just the
+    # block layout -- decides whether we can dequantize: MXFP4 (fp4x2) shares
+    # the per_1x32 layout with MXFP8 but is a target-only format.
+    if source_quant_dtype is not None and source_quant_dtype not in _FP8_SOURCE_DTYPES:
+        raise ValueError(
+            f"Unsupported online dequant source dtype={source_quant_dtype} "
+            f"(quant_type={source_quant_type}); only 8-bit FP8 sources are "
+            f"supported (MXFP4 and other 4-bit formats are target-only)."
+        )
+
+    if source_quant_type == QuantType.per_Tensor:
+        return dequant_per_tensor_fp8(weight, weight_scale, output_partition_sizes)
+    if source_quant_type == QuantType.per_Token:
+        return dequant_per_channel_fp8(weight, weight_scale)
+    if source_quant_type == QuantType.per_1x128:
+        return dequant_per_block_fp8(weight, weight_scale)
+    if source_quant_type == QuantType.per_1x32:
+        # per_1x32 is only the block layout; the (8-bit) dtype check above has
+        # already ruled out MXFP4, so a valid source here is always MXFP8.
+        return dequant_mxfp8(weight, weight_scale)
+    raise ValueError(
+        f"Unsupported source quant_type for online dequant: {source_quant_type}. "
+        f"Supported sources: No, per_Tensor, per_Token, per_1x128, per_1x32."
+    )
 
 
 def quant_mxfp4_online_even(


### PR DESCRIPTION
support quark ptpc dequantization
```
HIP_VISIBLE_DEVICES=4,5,6,7 \
vllm serve /shareddata/deepseek-ai/DeepSeek-R1-0528 \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --no-enable-prefix-caching \
  --port 8000 \
  --additional-config '{"online_quant_config":{"global_quant_config":"ptpc_fp8","layer_quant_config":{"*expert*":"mxfp4"},"exclude_layer":["lm_head","*.gate.*"]}}'


lm_eval --model local-completions \
  --model_args model=/shareddata/deepseek-ai/DeepSeek-R1-0528,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True \
  --tasks gsm8k \
  --num_fewshot 3


gsm8k 3-shot
flexible-extract exact_match: 0.9401 ± 0.0065
strict-match     exact_match: 0.9386 ± 0.0066
```

```
Server command:

HIP_VISIBLE_DEVICES=4,5,6,7 \
vllm serve /shareddata/amd/DeepSeek-R1-0528-ptpc \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --no-enable-prefix-caching \
  --port 8001 \
  --additional-config '{"online_quant_config":{"layer_quant_config":{"*expert*":"mxfp4"}}}'
Client command:

lm_eval --model local-completions \
  --model_args model=/shareddata/amd/DeepSeek-R1-0528-ptpc,base_url=http://localhost:8001/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True \
  --tasks gsm8k \
  --num_fewshot 3
Result:

GSM8K 3-shot
flexible-extract exact_match: 0.9401 ± 0.0065
strict-match     exact_match: 0.9356 ± 0.0068

```