### PR TITLE
Fix int32 overflow for DeepSeekV4

### DIFF
--- a/atom/model_ops/v4_kernels/inverse_rope.py
+++ b/atom/model_ops/v4_kernels/inverse_rope.py
@@ -29,10 +29,11 @@ def _inverse_rope_gptj_kernel(
     BLOCK_RD: tl.constexpr,
     BLOCK_RD_HALF: tl.constexpr,
 ):
-    pid_h = tl.program_id(0)
-    pid_s = tl.program_id(1)
+    # int64 to avoid 32-bit overflow in x_offs (s_offs * stride_x_s).
+    pid_h = tl.program_id(0).to(tl.int64)
+    pid_s = tl.program_id(1).to(tl.int64)
 
-    s_offs = pid_s * BLOCK_S + tl.arange(0, BLOCK_S)
+    s_offs = pid_s * BLOCK_S + tl.arange(0, BLOCK_S).to(tl.int64)
     d_offs = tl.arange(0, BLOCK_RD)
     s_mask = s_offs < S
 

--- a/atom/model_ops/v4_kernels/paged_prefill.py
+++ b/atom/model_ops/v4_kernels/paged_prefill.py
@@ -87,7 +87,9 @@ def _sparse_attn_v4_paged_prefill_kernel(
     BLOCK_D: tl.constexpr,
     BLOCK_K: tl.constexpr,
 ):
-    t = tl.program_id(0)
+    # int64 to avoid 32-bit overflow in per-token address offsets
+    # (t * q_stride_t / t * out_stride_t).
+    t = tl.program_id(0).to(tl.int64)
     pid_h = tl.program_id(1)
 
     h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)


### PR DESCRIPTION
## Motivation

Fix int32 overflow when running DeepSeekV4 with long context length.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
