### PR TITLE
[Bugfix] deepseek_v4: fix FP8 indexer cache_scale per-layer aliasing

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -685,14 +685,20 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 ) % 4 == 0, f"per-block bytes ({k1 * aligned_dim}) must be 4-aligned"
                 block_fp32_stride = (k1 * aligned_dim) // 4
                 scale_fp32_offset = (k1 * head_dim) // 4
-                module.cache_scale = (
-                    idx_kv.view(torch.float32)
-                    .view(-1)
-                    .as_strided(
-                        size=(nb, k1),
-                        stride=(block_fp32_stride, 1),
-                        storage_offset=scale_fp32_offset,
-                    )
+                # `as_strided(storage_offset=...)` is ABSOLUTE in the underlying
+                # storage, NOT relative to `idx_kv`. Since idx_kv =
+                # v4_csa_idx_kv[pos] carries its own storage_offset (pos *
+                # block_span), it MUST be added here — otherwise every CSA
+                # layer's `cache_scale` aliases pos 0's scale region, so only
+                # the first CSA layer's indexer reads valid scale and all other
+                # layers read zeros (FP8 indexer logits collapse at long
+                # context). The FP4 path is unaffected: it binds a real per-pos
+                # tensor (v4_csa_idx_kv_scale[pos]).
+                idx_kv_f32 = idx_kv.view(torch.float32)
+                module.cache_scale = idx_kv_f32.view(-1).as_strided(
+                    size=(nb, k1),
+                    stride=(block_fp32_stride, 1),
+                    storage_offset=idx_kv_f32.storage_offset() + scale_fp32_offset,
                 )
             elif ratio == 4:
                 pos = self.layer_id_to_csa_pos[layer_id_from_prefix]


### PR DESCRIPTION
## Summary

The FP8 indexer binds `module.cache_scale` as a strided fp32 view into the per-CSA-layer slice `idx_kv = v4_csa_idx_kv[pos]` using `as_strided(storage_offset=scale_fp32_offset)`.

`as_strided`'s `storage_offset` is **absolute in the underlying storage**, not relative to `idx_kv`. `idx_kv` carries its own `storage_offset` (`pos * block_span`), which was dropped — so **every CSA layer's `cache_scale` aliases pos 0's scale region**.

### Effect
- During compression each layer writes its fp32 scale into pos 0 (overwriting the others); scale regions for `pos >= 1` stay zero.
- At decode, only the **first** CSA layer's indexer reads valid scale. All other layers read zeros → `deepgemm_fp8_paged_mqa_logits` yields all-zero logits → `top_k_per_row_decode` degenerates to positional order.
- This collapses sparse top-k selection once context exceeds `index_topk` (long context). Short context (`n_committed <= index_topk`, all positions selected) is unaffected, which is why the bug only shows at long context.

The **FP4 path is not affected** — it binds a real per-pos tensor (`v4_csa_idx_kv_scale[pos]`), not an `as_strided` view.

### Fix
Add `idx_kv`'s own fp32 `storage_offset()` to the view's `storage_offset`.

## Test plan
gfx950, tp8, DeepSeek-V4-Pro, `--kv_cache_dtype fp8`, `--enforce-eager`. Random needle-in-haystack @16k tokens (`n_committed > index_topk`), 8 trials, char-accuracy of the retrieved secret:

- [x] before fix: **52.5%**
- [x] after fix: **82.5%** (FP4 reference: 88.8%; residual gap is FP8 K-quant precision, not the indexer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)