### PR TITLE
debug: run15 cu_seqlens_q stale probe (3-state dump + guard)

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2009,7 +2009,40 @@ class ModelRunner:
                 graph_bs = context.graph_bs
                 max_q_len = forward_context.attn_metadata.max_seqlen_q
                 graph_key = (graph_bs, max_q_len)
+                try:
+                    self._host16 = self.forward_vars["cu_seqlens_q"].np[:16].tolist()
+                except Exception:
+                    self._host16 = None
+                try:
+                    import atom.model_ops.attention_mla as _am
+                    if _am._PRE_SNAP is not None:
+                        _am._PRE_SNAP.copy_(self.forward_vars["cu_seqlens_q"].gpu[:16])
+                except Exception:
+                    pass
                 self.graphs[graph_key].replay()
+                try:
+                    if self._host16 is not None and int(self._host16[1]) != 1:
+                        self._cuq_host_bad = getattr(self, "_cuq_host_bad", 0) + 1
+                except Exception:
+                    pass
+                self._probe_step = getattr(self, "_probe_step", 0) + 1
+                if self._probe_step % 200 == 0:
+                    try:
+                        import atom.model_ops.attention_mla as _am2
+                        _p = getattr(_am2, "_DBG_PROBE", None)
+                        _hits = int(_p[0].item()) if _p is not None else -1
+                        _sb = _am2._SRC_BAD_AT_COPY[0]
+                        _ls = _am2._LAST_SRC_AT_COPY[:6] if _am2._LAST_SRC_AT_COPY else None
+                        _bad = None
+                        if _p is not None and _hits > 0:
+                            _r = _p[2:2 + 64].tolist()
+                            _bad = {"after_copy": _r[16:22], "pre_replay": _r[32:38], "live": _r[0:6]}
+                        logger.warning(
+                            "[PROBE_HOSTSRC] step=%d hits=%d host_bad=%d src_bad_at_copy=%d last_src=%s %s",
+                            self._probe_step, _hits, getattr(self, "_cuq_host_bad", 0), _sb, _ls, _bad,
+                        )
+                    except Exception:
+                        pass
                 num_tokens = context.batch_size * max_q_len
                 hidden_states = self.forward_vars["outputs"][:num_tokens]
                 if graph_key in self.graph_aux_hidden:

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -984,6 +984,13 @@ class MLAAttention(nn.Module):
         )
 
 
+_DBG_PROBE = None   # int32[2+32*64] sticky: [0]hits [1]oob [2+slot*64..]=live[16]+after_copy[16]+pre_replay[16]
+_PRE_SNAP = None    # int32[16] persistent: model_runner D2D fills before each replay
+_SNAP_AFTER_COPY = None  # int32[16] persistent: aiter_mla D2D fills right after copy_to_gpu@1075
+_SRC_BAD_AT_COPY = [0]    # PURE-HOST sticky counter: copy source cpu[1] != 1 at copy site
+_LAST_SRC_AT_COPY = None  # PURE-HOST last snapshot of copy source cpu[:16] (for logging)
+
+
 @triton.jit
 def _convert_req_index_to_global_index_kernel(
     qo_indptr,  # int32 [num_requests]
@@ -999,6 +1006,11 @@ def _convert_req_index_to_global_index_kernel(
     # strides (in elements)
     ti_stride0,
     ti_stride1,
+    # Run15 probe
+    debug_buf,
+    pre_snap,
+    after_copy,
+    TOKEN_INDICES_ROWS: tl.constexpr,
 ):
     # program_id(0) -> batch_id (row)
     # program_id(1) -> tile index along columns
@@ -1016,7 +1028,26 @@ def _convert_req_index_to_global_index_kernel(
     qo_start = tl.load(qo_indptr + batch_id)
     qo_end = tl.load(qo_indptr + batch_id + 1)
 
-    for token_id in range(qo_start, qo_end):
+    if tile_id == 0:
+        span = qo_end - qo_start
+        bad = (span > 1) | (qo_start > TOKEN_INDICES_ROWS) | (qo_end > TOKEN_INDICES_ROWS)
+        bad_tid_oob = qo_end > TOKEN_INDICES_ROWS
+        if bad:
+            o = tl.atomic_add(debug_buf + 0, 1)
+            slot = o % 32
+            base = 2 + slot * 64
+            idx = tl.arange(0, 16)
+            live = tl.load(qo_indptr + idx)
+            ac = tl.load(after_copy + idx)
+            snap = tl.load(pre_snap + idx)
+            tl.store(debug_buf + base + idx, live)
+            tl.store(debug_buf + base + 16 + idx, ac)
+            tl.store(debug_buf + base + 32 + idx, snap)
+        if bad_tid_oob:
+            tl.atomic_add(debug_buf + 1, 1)
+
+    qo_end_clamped = tl.minimum(qo_end, TOKEN_INDICES_ROWS)
+    for token_id in range(qo_start, qo_end_clamped):
         # Load token indices for this tile
         ti_ptr = token_indices_ptr + token_id * ti_stride0 + indice_id * ti_stride1
         tok = tl.load(ti_ptr)  # int32
@@ -1025,7 +1056,7 @@ def _convert_req_index_to_global_index_kernel(
         valid_mask = (indice_id < kv_len) & (indice_id < NUM_TOPK_TOKENS)
         out_val = tl.load(
             kv_indices + kv_start + tok,
-            mask=valid_mask,
+            mask=valid_mask & (tok >= 0),
             other=0,
         )
 
@@ -1102,8 +1133,33 @@ def triton_convert_req_index_to_global_index(
         # strides
         ti_stride0,
         ti_stride1,
+        _get_dbg_probe(qo_indptr_c.device),
+        _get_pre_snap(qo_indptr_c.device),
+        _get_after_copy(qo_indptr_c.device),
+        token_indices_c.shape[0],
     )
     return new_kv_indices
+
+
+def _get_dbg_probe(device):
+    global _DBG_PROBE
+    if _DBG_PROBE is None:
+        _DBG_PROBE = torch.zeros(2 + 32 * 64, dtype=torch.int32, device=device)
+    return _DBG_PROBE
+
+
+def _get_pre_snap(device):
+    global _PRE_SNAP
+    if _PRE_SNAP is None:
+        _PRE_SNAP = torch.zeros(16, dtype=torch.int32, device=device)
+    return _PRE_SNAP
+
+
+def _get_after_copy(device):
+    global _SNAP_AFTER_COPY
+    if _SNAP_AFTER_COPY is None:
+        _SNAP_AFTER_COPY = torch.zeros(16, dtype=torch.int32, device=device)
+    return _SNAP_AFTER_COPY
 
 
 @triton.jit

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1038,6 +1038,18 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # metadata copies on main_stream
         positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
         ctx.update({el: var[el].copy_to_gpu(num) for el, num in vars_for_metadata})
+        # Run15: (a) D2D-snap the async-copy TARGET; (b) PURE-HOST read the copy SOURCE (.cpu)
+        try:
+            import atom.model_ops.attention_mla as _am15
+            if _am15._SNAP_AFTER_COPY is not None and "cu_seqlens_q" in var:
+                _am15._SNAP_AFTER_COPY.copy_(var["cu_seqlens_q"].gpu[:16])
+            if "cu_seqlens_q" in var:
+                _src = var["cu_seqlens_q"].cpu[:16].tolist()
+                _am15._LAST_SRC_AT_COPY = _src
+                if len(_src) > 1 and int(_src[1]) != 1:
+                    _am15._SRC_BAD_AT_COPY[0] += 1
+        except Exception:
+            pass
 
         if is_sparse_mtp:
             sum_tokens = bs * max_seqlen_q


### PR DESCRIPTION
 for the decode async H2D copy of cu_seqlens_q, the source is correct but the GPU destination head is already stale right after the copy.

 A probe placed immediately after the decode cu_seqlens_q H2D copy (aiter_mla copy_to_gpu) records, same-step aligned: host source (.cpu, pure host read), GPU dest right after copy (after_copy, D2D snapshot), pre-replay (pre_replay, D2D snapshot), and the kernel's live read during replay (live). Steady-state key log:

 [PROBE_HOSTSRC] step=5600 hits=42 host_bad=0 src_bad_at_copy=0
   last_src   = [0, 1,   2, 3, 4, 5]   # H2D SOURCE (.cpu) -- correct arange
   after_copy = [0, 996, 2, 3, 4, 5]   # GPU DEST right after copy -- head [1] already stale
   pre_replay = [0, 996, 2, 3, 4, 5]   # GPU before replay -- stale
   live       = [0, 996, 2, 3, 4, 5]   # kernel read during replay -- stale

 - src_bad_at_copy=0 / host_bad=0: the host source is correct on every step; last_src is the proper [0,1,2,...].
 - after_copy[1]=996: right after the same async H2D completes, reading the GPU destination shows the head element is already the old value 996 (the previous prefill's cumulative value; decode expects 1).
 - pre_replay / live are stale too → the stale head persists until the kernel reads it during CUDAGraph replay.