### PR TITLE
enable minimax m3 fp8 index cache and fuse index_score_kernel with  partial_topk kernel

### DIFF
--- a/.github/scripts/atom_sglang_test.sh
+++ b/.github/scripts/atom_sglang_test.sh
@@ -107,17 +107,10 @@ emit_new_sglang_logs() {
 }
 
 wait_server_ready() {
+  local expected_model_path="${1:-}"
   echo ""
   echo "========== Waiting for SGLang server (${MODEL_NAME}) =========="
   for ((i=1; i<=MAX_WAIT_RETRIES; i++)); do
-    if curl -fsS "http://127.0.0.1:${SGLANG_PORT}/v1/models" >/dev/null 2>&1; then
-      emit_new_sglang_logs
-      echo "SGLang server is ready for ${MODEL_NAME}."
-      return 0
-    fi
-
-    emit_new_sglang_logs
-
     if [[ -f "${SGLANG_PID_FILE}" ]]; then
       local pid
       pid=$(cat "${SGLANG_PID_FILE}")
@@ -129,6 +122,45 @@ wait_server_ready() {
       fi
     fi
 
+    local models_response
+    models_response=$(curl -fsS "http://127.0.0.1:${SGLANG_PORT}/v1/models" 2>/dev/null || true)
+    if [[ -n "${models_response}" ]]; then
+      if [[ -z "${expected_model_path}" ]] || \
+        MODELS_RESPONSE="${models_response}" EXPECTED_MODEL_PATH="${expected_model_path}" python3 - <<'PY'
+import json
+import os
+import sys
+
+
+def normalize_model_id(model_id: str) -> str:
+    model_id = model_id.rstrip("/")
+    if model_id.startswith("/models/"):
+        return model_id[len("/models/") :]
+    return model_id
+
+
+expected_model = normalize_model_id(os.environ["EXPECTED_MODEL_PATH"])
+try:
+    payload = json.loads(os.environ["MODELS_RESPONSE"])
+except Exception:
+    sys.exit(1)
+
+served_models = {
+    normalize_model_id(item.get("id", ""))
+    for item in payload.get("data", [])
+    if isinstance(item, dict) and isinstance(item.get("id"), str)
+}
+
+sys.exit(0 if expected_model in served_models else 1)
+PY
+      then
+        emit_new_sglang_logs
+        echo "SGLang server is ready for ${MODEL_NAME}."
+        return 0
+      fi
+    fi
+
+    emit_new_sglang_logs
     echo "Waiting for SGLang server... (${i}/${MAX_WAIT_RETRIES})"
     sleep "${WAIT_INTERVAL_SEC}"
   done
@@ -217,7 +249,7 @@ PY
   echo "Server PID: $(cat "${SGLANG_PID_FILE}")"
 
   if [[ "${wait_for_ready}" == "1" ]]; then
-    wait_server_ready
+    wait_server_ready "${resolved_model_path}"
   fi
 }
 

--- a/atom/config.py
+++ b/atom/config.py
@@ -1047,7 +1047,7 @@ class Config:
     kv_cache_block_size: int = 16
     num_kvcache_blocks: int = -1
     kv_cache_dtype: str = "bf16"
-    index_cache_dtype: str = "auto"
+    index_cache_dtype: str | None = None
     enable_prefix_caching: bool = True
     enable_chunked_prefill: bool = True
     port: int = 8006
@@ -1099,6 +1099,9 @@ class Config:
                 self.graph_bs = cuda_graph_sizes
 
     def __post_init__(self):
+        if self.index_cache_dtype is None:
+            self.index_cache_dtype = self.kv_cache_dtype
+
         if isinstance(self.compilation_config, dict):
             self.compilation_config = CompilationConfig(**self.compilation_config)
         # assert os.path.isdir(self.model)

--- a/atom/config.py
+++ b/atom/config.py
@@ -1047,6 +1047,7 @@ class Config:
     kv_cache_block_size: int = 16
     num_kvcache_blocks: int = -1
     kv_cache_dtype: str = "bf16"
+    index_cache_dtype: str = "auto"
     enable_prefix_caching: bool = True
     enable_chunked_prefill: bool = True
     port: int = 8006
@@ -1267,6 +1268,7 @@ class Config:
         factors.append(vllm_factors)
         factors.append(self.tensor_parallel_size)
         factors.append(self.enable_dp_attention)
+        factors.append(self.index_cache_dtype)
         text_config = getattr(self.hf_config, "text_config", self.hf_config)
         factors.append(
             (

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -36,6 +36,7 @@ class EngineArgs:
     enable_prefix_caching: bool = True
     port: int = 8006
     kv_cache_dtype: str = "bf16"
+    index_cache_dtype: str = "auto"
     block_size: int = 16
     max_model_len: Optional[int] = None
     max_num_batched_tokens: int = 16384
@@ -120,6 +121,16 @@ class EngineArgs:
             type=str,
             default="bf16",
             help="KV cache type. Default is 'bf16'.",
+        )
+        parser.add_argument(
+            "--index-cache-dtype",
+            choices=["auto", "fp8"],
+            type=str,
+            default="auto",
+            help=(
+                "MiniMax-M3 index cache type. 'auto' uses the model dtype; "
+                "'fp8' stores the index cache in FP8 independently of KV cache dtype."
+            ),
         )
         parser.add_argument(
             "--block-size", type=int, default=16, help="KV cache block size."

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -36,7 +36,7 @@ class EngineArgs:
     enable_prefix_caching: bool = True
     port: int = 8006
     kv_cache_dtype: str = "bf16"
-    index_cache_dtype: str = "auto"
+    index_cache_dtype: Optional[str] = None
     block_size: int = 16
     max_model_len: Optional[int] = None
     max_num_batched_tokens: int = 16384
@@ -62,6 +62,10 @@ class EngineArgs:
     mark_trace: bool = False
     online_quant_config: Optional[dict] = None
     hf_overrides: Optional[dict] = None
+
+    def __post_init__(self) -> None:
+        if self.index_cache_dtype is None:
+            self.index_cache_dtype = self.kv_cache_dtype
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -124,13 +128,11 @@ class EngineArgs:
         )
         parser.add_argument(
             "--index-cache-dtype",
-            choices=["auto", "fp8"],
+            "--index_cache_dtype",
+            choices=["bf16", "fp8"],
             type=str,
-            default="auto",
-            help=(
-                "MiniMax-M3 index cache type. 'auto' uses the model dtype; "
-                "'fp8' stores the index cache in FP8 independently of KV cache dtype."
-            ),
+            default=None,
+            help="Index cache type. Defaults to --kv_cache_dtype.",
         )
         parser.add_argument(
             "--block-size", type=int, default=16, help="KV cache block size."

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -958,6 +958,7 @@ class SparseMHAPagedAttentionImpl(PagedAttentionImpl):
         local_blocks: int = 0,
         skip_index_topk: bool = False,
         sparse_layer_ordinal: int = -1,
+        index_cache_dtype: str = "auto",
         **kwargs,
     ):
         super().__init__(
@@ -995,6 +996,7 @@ class SparseMHAPagedAttentionImpl(PagedAttentionImpl):
         self.local_blocks = local_blocks
         self.skip_index_topk = skip_index_topk
         self.sparse_layer_ordinal = sparse_layer_ordinal
+        self.index_cache_dtype = index_cache_dtype
         # Bound by AiterAttentionMetadataBuilder.build_kv_cache_tensor (Task 6):
         # the page-128 indexer-key cache. None until the runner binds it.
         self.index_cache: Optional[torch.Tensor] = None
@@ -1164,6 +1166,7 @@ class SparseMHAPagedAttentionImpl(PagedAttentionImpl):
             index_q,
             slot_mapping,
             kv_cache_dtype=kv_cache_dtype,
+            index_cache_dtype=self.index_cache_dtype,
             k_scale=fused_k_scale,
             v_scale=fused_v_scale,
             asm_layout=True,

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -958,7 +958,7 @@ class SparseMHAPagedAttentionImpl(PagedAttentionImpl):
         local_blocks: int = 0,
         skip_index_topk: bool = False,
         sparse_layer_ordinal: int = -1,
-        index_cache_dtype: str = "auto",
+        index_cache_dtype: str | None = None,
         **kwargs,
     ):
         super().__init__(
@@ -996,7 +996,9 @@ class SparseMHAPagedAttentionImpl(PagedAttentionImpl):
         self.local_blocks = local_blocks
         self.skip_index_topk = skip_index_topk
         self.sparse_layer_ordinal = sparse_layer_ordinal
-        self.index_cache_dtype = index_cache_dtype
+        self.index_cache_dtype = (
+            index_cache_dtype if index_cache_dtype is not None else kv_cache_dtype
+        )
         # Bound by AiterAttentionMetadataBuilder.build_kv_cache_tensor (Task 6):
         # the page-128 indexer-key cache. None until the runner binds it.
         self.index_cache: Optional[torch.Tensor] = None

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -1096,6 +1096,9 @@ class SparseMHAPagedAttentionImpl(PagedAttentionImpl):
         # per-token dequant scales into k_scale / v_scale (outputs).
         fused_k_scale = k_scale if is_fp8 else None
         fused_v_scale = v_scale if is_fp8 else None
+        fused_index_cache_dtype = (
+            self.index_cache_dtype if self.index_cache_dtype == "fp8" else "auto"
+        )
 
         if self.skip_index_topk:
             from atom.model_ops.triton_fused_qkv_norm_rope_cache import (
@@ -1168,7 +1171,7 @@ class SparseMHAPagedAttentionImpl(PagedAttentionImpl):
             index_q,
             slot_mapping,
             kv_cache_dtype=kv_cache_dtype,
-            index_cache_dtype=self.index_cache_dtype,
+            index_cache_dtype=fused_index_cache_dtype,
             k_scale=fused_k_scale,
             v_scale=fused_v_scale,
             asm_layout=True,

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -540,12 +540,17 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             sparse_layers = sum(
                 1 for enabled in sparse_cfg.get("sparse_attention_freq", []) if enabled
             )
+            index_cache_dtype = (
+                dtypes.d_dtypes[config.kv_cache_dtype]
+                if str(config.kv_cache_dtype).startswith("fp8")
+                else config.torch_dtype
+            )
             tensors["sparse_attention_index_cache"] = torch.zeros(
                 sparse_layers,
                 runner.num_physical_kvcache_blocks,
                 runner.physical_block_size,
                 sparse_cfg["sparse_index_dim"],
-                dtype=config.torch_dtype,
+                dtype=index_cache_dtype,
                 device="cuda",
             )
             tensors["_sparse_attention_cache_next"] = 0

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -42,6 +42,20 @@ def _is_indexed_sparse_attention(module) -> bool:
     return bool(getattr(impl, "is_indexed_sparse_attention", False))
 
 
+def _resolve_minimax_m3_index_cache_dtype(config) -> torch.dtype:
+    from aiter import dtypes
+
+    index_cache_dtype = getattr(config, "index_cache_dtype", "auto")
+    if index_cache_dtype == "auto":
+        return config.torch_dtype
+    if index_cache_dtype == "fp8":
+        return dtypes.d_dtypes["fp8"]
+    raise ValueError(
+        "MiniMax-M3 index_cache_dtype must be 'auto' or 'fp8', "
+        f"got {index_cache_dtype!r}"
+    )
+
+
 @triton.jit
 def _mtp_prepare_decode_metadata_kernel(
     context_lens_ptr,
@@ -480,11 +494,12 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                 1 for enabled in sparse_cfg.get("sparse_attention_freq", []) if enabled
             )
             index_dim = sparse_cfg["sparse_index_dim"]
+            index_cache_dtype = _resolve_minimax_m3_index_cache_dtype(config)
             block_bytes += (
                 sparse_layers
                 * runner.physical_block_size
                 * index_dim
-                * torch.empty((), dtype=config.torch_dtype).element_size()
+                * torch.empty((), dtype=index_cache_dtype).element_size()
             )
         return block_bytes
 
@@ -540,11 +555,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             sparse_layers = sum(
                 1 for enabled in sparse_cfg.get("sparse_attention_freq", []) if enabled
             )
-            index_cache_dtype = (
-                dtypes.d_dtypes[config.kv_cache_dtype]
-                if str(config.kv_cache_dtype).startswith("fp8")
-                else config.torch_dtype
-            )
+            index_cache_dtype = _resolve_minimax_m3_index_cache_dtype(config)
             tensors["sparse_attention_index_cache"] = torch.zeros(
                 sparse_layers,
                 runner.num_physical_kvcache_blocks,

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -51,8 +51,7 @@ def _resolve_index_cache_dtype(config) -> torch.dtype:
     if index_cache_dtype in ("bf16", "fp8"):
         return dtypes.d_dtypes[index_cache_dtype]
     raise ValueError(
-        "index_cache_dtype must be 'bf16' or 'fp8', "
-        f"got {index_cache_dtype!r}"
+        "index_cache_dtype must be 'bf16' or 'fp8', " f"got {index_cache_dtype!r}"
     )
 
 

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -45,13 +45,13 @@ def _is_indexed_sparse_attention(module) -> bool:
 def _resolve_index_cache_dtype(config) -> torch.dtype:
     from aiter import dtypes
 
-    index_cache_dtype = getattr(config, "index_cache_dtype", "auto")
-    if index_cache_dtype == "auto":
-        return config.torch_dtype
-    if index_cache_dtype == "fp8":
-        return dtypes.d_dtypes["fp8"]
+    index_cache_dtype = getattr(config, "index_cache_dtype", None)
+    if index_cache_dtype is None:
+        index_cache_dtype = getattr(config, "kv_cache_dtype", "bf16")
+    if index_cache_dtype in ("bf16", "fp8"):
+        return dtypes.d_dtypes[index_cache_dtype]
     raise ValueError(
-        "MiniMax-M3 index_cache_dtype must be 'auto' or 'fp8', "
+        "index_cache_dtype must be 'bf16' or 'fp8', "
         f"got {index_cache_dtype!r}"
     )
 

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -42,7 +42,7 @@ def _is_indexed_sparse_attention(module) -> bool:
     return bool(getattr(impl, "is_indexed_sparse_attention", False))
 
 
-def _resolve_minimax_m3_index_cache_dtype(config) -> torch.dtype:
+def _resolve_index_cache_dtype(config) -> torch.dtype:
     from aiter import dtypes
 
     index_cache_dtype = getattr(config, "index_cache_dtype", "auto")
@@ -494,7 +494,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                 1 for enabled in sparse_cfg.get("sparse_attention_freq", []) if enabled
             )
             index_dim = sparse_cfg["sparse_index_dim"]
-            index_cache_dtype = _resolve_minimax_m3_index_cache_dtype(config)
+            index_cache_dtype = _resolve_index_cache_dtype(config)
             block_bytes += (
                 sparse_layers
                 * runner.physical_block_size
@@ -555,7 +555,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             sparse_layers = sum(
                 1 for enabled in sparse_cfg.get("sparse_attention_freq", []) if enabled
             )
-            index_cache_dtype = _resolve_minimax_m3_index_cache_dtype(config)
+            index_cache_dtype = _resolve_index_cache_dtype(config)
             tensors["sparse_attention_index_cache"] = torch.zeros(
                 sparse_layers,
                 runner.num_physical_kvcache_blocks,

--- a/atom/model_ops/minimax_m3/index_topk.py
+++ b/atom/model_ops/minimax_m3/index_topk.py
@@ -420,20 +420,20 @@ def _decode_index_score_kernel(
     )  # [D]
     for blk in tl.range(chunk_start_block, chunk_end_block):
         page = tl.load(bt_row + blk).to(tl.int64)
-        pos = blk * BLOCK_SIZE_K + off_k
-        pos_mask = pos < causal_len
         k = tl.load(
             ik_cache_ptr
             + page * stride_ik_blk
             + off_k[None, :] * stride_ik_pos
             + off_d[:, None] * stride_ik_d,
-            mask=d_mask[:, None] & pos_mask[None, :],
+            mask=d_mask[:, None],
             other=0.0,
         ).to(
             tl.float32
         )  # [D, N]
         qk = tl.sum(q[:, None] * k, axis=0) * sm_scale_log2e  # [N]
-        qk = tl.where(pos_mask, qk, float("-inf"))
+        if (blk + 1) * BLOCK_SIZE_K > causal_len:
+            pos = blk * BLOCK_SIZE_K + off_k
+            qk = tl.where(pos < causal_len, qk, float("-inf"))
         score = tl.max(qk, axis=0)  # one score for this 128-block
         is_init = blk < init_blocks
         is_local = (blk >= local_start) & (blk < num_blocks)
@@ -580,6 +580,127 @@ def _topk_index_partial_kernel(
     )
     tl.store(ts_ptrs, final_score)
     tl.store(ti_ptrs, final_idx)
+
+
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"]),
+        "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
+    }
+)
+@triton.jit
+def _decode_index_score_topk_partial_kernel(
+    q_ptr,  # idx_q: [total_q, num_idx_heads, head_dim]
+    ik_cache_ptr,  # index-K cache: [num_blocks, 128, head_dim]
+    ts_partial_ptr,  # partial scores out: [NUM_TOPK_CHUNKS, num_idx_heads, total_q, T]
+    ti_partial_ptr,  # partial idx out (1-indexed global, 0=invalid): same shape
+    block_table_ptr,  # [num_reqs, max_blocks]
+    seq_lens,  # [batch]
+    num_idx_heads,
+    total_q,  # batch * max_q (one row per query token)
+    head_dim,
+    init_blocks,
+    local_blocks,
+    sm_scale,
+    topk: tl.constexpr,
+    chunk_blocks: tl.constexpr,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    stride_ik_blk,
+    stride_ik_pos,
+    stride_ik_d,
+    stride_ts_c,
+    stride_ts_h,
+    stride_ts_b,
+    stride_ts_t,
+    stride_ti_c,
+    stride_ti_h,
+    stride_ti_b,
+    stride_ti_t,
+    stride_bt_b,
+    MAX_Q: tl.constexpr,  # query tokens per request (num_spec + 1; 1 == plain decode)
+    BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+    BLOCK_SIZE_T: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+):
+    sm_scale_log2e = sm_scale * 1.4426950409
+    pid_t = tl.program_id(0)  # global query-token row
+    pid_h = tl.program_id(1)
+    pid_chunk = tl.program_id(2)
+
+    pid_b = pid_t // MAX_Q
+    tok = pid_t % MAX_Q
+    seq_len = tl.load(seq_lens + pid_b)
+    causal_len = seq_len - MAX_Q + tok + 1
+    num_blocks = (causal_len + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
+
+    chunk_start = pid_chunk * chunk_blocks
+    chunk_end = tl.minimum(chunk_start + chunk_blocks, num_blocks)
+    chunk_actual = tl.maximum(chunk_end - chunk_start, 0)
+
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+    off_d = tl.arange(0, BLOCK_SIZE_D)
+    d_mask = off_d < head_dim
+
+    topk_score = tl.full((BLOCK_SIZE_T,), -1e30, dtype=tl.float32)
+    topk_idx = tl.full((BLOCK_SIZE_T,), 0, dtype=tl.int32)
+
+    bt_row = block_table_ptr + pid_b * stride_bt_b
+    local_start = tl.maximum(0, num_blocks - local_blocks)
+    q = tl.load(
+        q_ptr + pid_t * stride_q_n + pid_h * stride_q_h + off_d * stride_q_d,
+        mask=d_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    for i in tl.range(0, chunk_actual):
+        blk = chunk_start + i
+        page = tl.load(bt_row + blk).to(tl.int64)
+        k = tl.load(
+            ik_cache_ptr
+            + page * stride_ik_blk
+            + off_k[None, :] * stride_ik_pos
+            + off_d[:, None] * stride_ik_d,
+            mask=d_mask[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        qk = tl.sum(q[:, None] * k, axis=0) * sm_scale_log2e
+        if (blk + 1) * BLOCK_SIZE_K > causal_len:
+            pos = blk * BLOCK_SIZE_K + off_k
+            qk = tl.where(pos < causal_len, qk, float("-inf"))
+        score = tl.max(qk, axis=0)
+        is_init = blk < init_blocks
+        is_local = (blk >= local_start) & (blk < num_blocks)
+        score = tl.where(is_local, 1e29, tl.where(is_init, 1e30, score))
+        score = tl.where(score == score, score, -1e30)
+
+        # Maintain an unordered top-k vector. The merge kernel sorts all partial
+        # candidates later, so replacing any current minimum is sufficient.
+        min_score = tl.min(topk_score, axis=0)
+        min_mask = topk_score == min_score
+        first_min = tl.cumsum(min_mask.to(tl.int32), axis=0) == 1
+        replace = (score > min_score) & min_mask & first_min
+        topk_score = tl.where(replace, score, topk_score)
+        topk_idx = tl.where(replace, (blk + 1).to(tl.int32), topk_idx)
+
+    ts_ptrs = (
+        ts_partial_ptr
+        + pid_chunk * stride_ts_c
+        + pid_h * stride_ts_h
+        + pid_t * stride_ts_b
+        + off_t * stride_ts_t
+    )
+    ti_ptrs = (
+        ti_partial_ptr
+        + pid_chunk * stride_ti_c
+        + pid_h * stride_ti_h
+        + pid_t * stride_ti_b
+        + off_t * stride_ti_t
+    )
+    tl.store(ts_ptrs, topk_score)
+    tl.store(ti_ptrs, topk_idx)
 
 
 @triton.heuristics(
@@ -908,47 +1029,6 @@ def minimax_m3_index_topk_decode(
         total_q % max_query_len == 0
     ), f"total_q {total_q} not divisible by max_query_len {max_query_len}"
     max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
-    score = torch.empty(
-        (num_idx_heads, total_q, max_block),
-        dtype=torch.float32,
-        device=idx_q.device,
-    )
-    # split-K over seq blocks; chunk count depends only on shape constants so
-    # the grid is fixed within a cuda graph.
-    TARGET_GRID = 4096
-    MAX_NUM_KV_CHUNKS = 256
-    target = max(
-        1, min(MAX_NUM_KV_CHUNKS, TARGET_GRID // max(1, total_q * num_idx_heads))
-    )
-    num_kv_chunks = 1 << (target.bit_length() - 1)
-    grid_score = (total_q * num_kv_chunks, num_idx_heads)
-    _decode_index_score_kernel[grid_score](
-        idx_q,
-        index_kv_cache,
-        score,
-        block_table,
-        seq_lens,
-        num_idx_heads,
-        total_q,
-        head_dim,
-        init_blocks,
-        local_blocks,
-        sm_scale,
-        idx_q.stride(0),
-        idx_q.stride(1),
-        idx_q.stride(2),
-        index_kv_cache.stride(0),
-        index_kv_cache.stride(1),
-        index_kv_cache.stride(2),
-        score.stride(0),
-        score.stride(1),
-        score.stride(2),
-        block_table.stride(0),
-        MAX_Q=max_query_len,
-        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
-        NUM_KV_CHUNKS=num_kv_chunks,
-    )
-
     topk_idx = torch.empty(
         (num_idx_heads, total_q, topk),
         dtype=torch.int32,
@@ -956,7 +1036,9 @@ def minimax_m3_index_topk_decode(
     )
     # Chunk count is shape-constant (cudagraph-safe), capped so the merge sorts
     # pow2(num_topk_chunks * pow2(topk)) candidates.
-    TOPK_TARGET_GRID = 64
+    # Fused score+partial-topk uses topk chunks as the score split-K dimension.
+    # Keep enough chunks to avoid serializing long contexts inside too few CTAs.
+    TOPK_TARGET_GRID = 2048
     MAX_NUM_TOPK_CHUNKS = 16
     topk_target = max(
         1, min(MAX_NUM_TOPK_CHUNKS, TOPK_TARGET_GRID // max(1, total_q * num_idx_heads))
@@ -980,18 +1062,27 @@ def minimax_m3_index_topk_decode(
         dtype=torch.int32,
         device=idx_q.device,
     )
-    _topk_index_partial_kernel[(total_q, num_idx_heads, num_topk_chunks)](
-        score,
+    _decode_index_score_topk_partial_kernel[(total_q, num_idx_heads, num_topk_chunks)](
+        idx_q,
+        index_kv_cache,
         topk_score_partial,
         topk_idx_partial,
+        block_table,
         seq_lens,
-        SPARSE_BLOCK_SIZE,
+        num_idx_heads,
+        total_q,
+        head_dim,
+        init_blocks,
+        local_blocks,
+        sm_scale,
         topk,
         chunk_blocks,
-        max_query_len,  # MAX_Q
-        score.stride(0),
-        score.stride(1),
-        score.stride(2),
+        idx_q.stride(0),
+        idx_q.stride(1),
+        idx_q.stride(2),
+        index_kv_cache.stride(0),
+        index_kv_cache.stride(1),
+        index_kv_cache.stride(2),
         topk_score_partial.stride(0),
         topk_score_partial.stride(1),
         topk_score_partial.stride(2),
@@ -1000,6 +1091,9 @@ def minimax_m3_index_topk_decode(
         topk_idx_partial.stride(1),
         topk_idx_partial.stride(2),
         topk_idx_partial.stride(3),
+        block_table.stride(0),
+        MAX_Q=max_query_len,
+        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
     )
     # The fused emit now produces one row per (token, kv-head): the ASM/gluon path
     # collapses kv-head into the row dim. sparse_bt/ctx are sized total_q*num_idx_heads

--- a/atom/model_ops/minimax_m3/index_topk.py
+++ b/atom/model_ops/minimax_m3/index_topk.py
@@ -129,6 +129,7 @@ def _index_block_score_kernel(
         order=(1, 0),
     )
     q = tl.load(q_ptrs, boundary_check=(0,), padding_option="zero")
+    q_f32 = q.to(tl.float32)
     q_start = prefix_len + pid_q * BLOCK_SIZE_Q
 
     off_q = tl.arange(0, BLOCK_SIZE_Q) + pid_q * BLOCK_SIZE_Q + prefix_len
@@ -152,7 +153,11 @@ def _index_block_score_kernel(
             + off_k[None, :] * stride_ik_pos
             + off_d[:, None] * stride_ik_d,
         )
-        qk = tl.dot(q, k) * sm_scale_log2e
+        if k.dtype.is_fp8():
+            k = k.to(tl.float32)
+            qk = tl.dot(q_f32, k, out_dtype=tl.float32) * sm_scale_log2e
+        else:
+            qk = tl.dot(q, k, out_dtype=tl.float32) * sm_scale_log2e
         # apply causal mask as needed
         if q_start < i + BLOCK_SIZE_K:
             qk = tl.where(off_q[:, None] >= pos[None, :], qk, float("-inf"))
@@ -427,9 +432,8 @@ def _decode_index_score_kernel(
             + off_d[:, None] * stride_ik_d,
             mask=d_mask[:, None],
             other=0.0,
-        ).to(
-            tl.float32
-        )  # [D, N]
+        )
+        k = k.to(tl.float32)  # [D, N]
         qk = tl.sum(q[:, None] * k, axis=0) * sm_scale_log2e  # [N]
         if (blk + 1) * BLOCK_SIZE_K > causal_len:
             pos = blk * BLOCK_SIZE_K + off_k
@@ -665,7 +669,8 @@ def _decode_index_score_topk_partial_kernel(
             + off_d[:, None] * stride_ik_d,
             mask=d_mask[:, None],
             other=0.0,
-        ).to(tl.float32)
+        )
+        k = k.to(tl.float32)
         qk = tl.sum(q[:, None] * k, axis=0) * sm_scale_log2e
         if (blk + 1) * BLOCK_SIZE_K > causal_len:
             pos = blk * BLOCK_SIZE_K + off_k

--- a/atom/model_ops/minimax_m3/index_topk.py
+++ b/atom/model_ops/minimax_m3/index_topk.py
@@ -129,7 +129,6 @@ def _index_block_score_kernel(
         order=(1, 0),
     )
     q = tl.load(q_ptrs, boundary_check=(0,), padding_option="zero")
-    q_f32 = q.to(tl.float32)
     q_start = prefix_len + pid_q * BLOCK_SIZE_Q
 
     off_q = tl.arange(0, BLOCK_SIZE_Q) + pid_q * BLOCK_SIZE_Q + prefix_len
@@ -154,8 +153,7 @@ def _index_block_score_kernel(
             + off_d[:, None] * stride_ik_d,
         )
         if k.dtype.is_fp8():
-            k = k.to(tl.float32)
-            qk = tl.dot(q_f32, k, out_dtype=tl.float32) * sm_scale_log2e
+            qk = tl.dot(q.to(k.dtype), k, out_dtype=tl.float32) * sm_scale_log2e
         else:
             qk = tl.dot(q, k, out_dtype=tl.float32) * sm_scale_log2e
         # apply causal mask as needed

--- a/atom/models/minimax_m3.py
+++ b/atom/models/minimax_m3.py
@@ -331,6 +331,7 @@ class MiniMaxM3Attention(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         cache_config: str = "bf16",
+        index_cache_config: str = "auto",
     ) -> None:
         super().__init__()
         self.layer_num = layer_id
@@ -409,6 +410,7 @@ class MiniMaxM3SparseAttention(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         cache_config: str = "bf16",
+        index_cache_config: str = "auto",
     ) -> None:
         super().__init__()
         self.is_indexed_sparse_attention = True
@@ -522,6 +524,7 @@ class MiniMaxM3SparseAttention(nn.Module):
             local_blocks=self.local_blocks,
             skip_index_topk=self.skip_index_topk,
             sparse_layer_ordinal=self.sparse_layer_ordinal,
+            index_cache_dtype=index_cache_config,
         )
 
     def forward(
@@ -553,6 +556,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
         config: PretrainedConfig,
         prefix: str,
         cache_config: str = "bf16",
+        index_cache_config: str = "auto",
         quant_config: Optional[QuantizationConfig] = None,
         params_dtype: Optional[torch.dtype] = None,
         layer_num: int = 0,
@@ -569,6 +573,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",
             cache_config=cache_config,
+            index_cache_config=index_cache_config,
         )
 
         self.is_moe_layer = _is_moe_layer(config, layer_num)
@@ -667,6 +672,7 @@ class MiniMaxM3Model(nn.Module):
         config = _get_text_config(atom_config.hf_config)
         self.config = config
         cache_config = atom_config.kv_cache_dtype
+        index_cache_config = atom_config.index_cache_dtype
         quant_config = atom_config.quant_config
 
         if get_pp_group().is_first_rank:
@@ -683,6 +689,7 @@ class MiniMaxM3Model(nn.Module):
                 config,
                 prefix,
                 cache_config=cache_config,
+                index_cache_config=index_cache_config,
                 quant_config=quant_config,
                 layer_num=layer_num,
                 params_dtype=atom_config.torch_dtype,

--- a/atom/plugin/vllm/attention/minimax_m3_attnetion.py
+++ b/atom/plugin/vllm/attention/minimax_m3_attnetion.py
@@ -236,7 +236,7 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
         self.index_cache_layer = MiniMaxM3SparseIndexerCache(
             layer_name=f"{self.layer_name}.index_cache",
             head_dim=index_head_dim,
-            kv_cache_dtype="auto",
+            kv_cache_dtype=cache_dtype if str(cache_dtype).startswith("fp8") else "auto",
         )
         _register_vllm_static_forward_context(self)
 

--- a/atom/plugin/vllm/attention/minimax_m3_attnetion.py
+++ b/atom/plugin/vllm/attention/minimax_m3_attnetion.py
@@ -236,7 +236,9 @@ class MiniMaxM3SparseAttentionForVllm(nn.Module, AttentionLayerBase):
         self.index_cache_layer = MiniMaxM3SparseIndexerCache(
             layer_name=f"{self.layer_name}.index_cache",
             head_dim=index_head_dim,
-            kv_cache_dtype=cache_dtype if str(cache_dtype).startswith("fp8") else "auto",
+            kv_cache_dtype=(
+                cache_dtype if str(cache_dtype).startswith("fp8") else "auto"
+            ),
         )
         _register_vllm_static_forward_context(self)
 

--- a/recipes/MiniMax-M3.md
+++ b/recipes/MiniMax-M3.md
@@ -30,6 +30,8 @@ python -m atom.entrypoints.openai_server \
   --max-model-len 32768 \
   --max-num-seqs 128 \
   --max-num-batched-tokens 32768 \
+  --kv_cache_dtype fp8 \
+  --index-cache-dtype fp8 \
   --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
   --no-enable_prefix_caching \
   --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' 2>&1 | tee "${run_name}-server.log"
@@ -57,6 +59,8 @@ python -m atom.entrypoints.openai_server \
   --block-size 128 \
   --max-model-len 32768 \
   --max-num-seqs 128 \
+  --kv_cache_dtype fp8 \
+  --index-cache-dtype fp8 \
   --max-num-batched-tokens 32768 \
   --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
   --no-enable_prefix_caching \

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Regression tests for speculative-config validation in EngineArgs._get_engine_kwargs.
 
+import argparse
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -73,3 +74,38 @@ class TestEngineArgsSpeculativeValidation:
             num_speculative_tokens=3,
         )
         assert kwargs["speculative_config"] is fake_spec_config
+
+
+class TestEngineArgsIndexCacheDtype:
+    """Regression tests for index-cache dtype CLI parity with KV cache dtype."""
+
+    def test_index_cache_dtype_defaults_to_kv_cache_dtype(self):
+        parser = argparse.ArgumentParser()
+        EngineArgs.add_cli_args(parser)
+
+        args = EngineArgs.from_cli_args(
+            parser.parse_args(["--kv_cache_dtype", "fp8"])
+        )
+
+        assert args.kv_cache_dtype == "fp8"
+        assert args.index_cache_dtype == "fp8"
+
+    def test_index_cache_dtype_accepts_dashed_spelling(self):
+        parser = argparse.ArgumentParser()
+        EngineArgs.add_cli_args(parser)
+
+        args = EngineArgs.from_cli_args(
+            parser.parse_args(["--index-cache-dtype", "fp8"])
+        )
+
+        assert args.index_cache_dtype == "fp8"
+
+    def test_index_cache_dtype_accepts_underscore_spelling(self):
+        parser = argparse.ArgumentParser()
+        EngineArgs.add_cli_args(parser)
+
+        args = EngineArgs.from_cli_args(
+            parser.parse_args(["--index_cache_dtype", "fp8"])
+        )
+
+        assert args.index_cache_dtype == "fp8"

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -83,9 +83,7 @@ class TestEngineArgsIndexCacheDtype:
         parser = argparse.ArgumentParser()
         EngineArgs.add_cli_args(parser)
 
-        args = EngineArgs.from_cli_args(
-            parser.parse_args(["--kv_cache_dtype", "fp8"])
-        )
+        args = EngineArgs.from_cli_args(parser.parse_args(["--kv_cache_dtype", "fp8"]))
 
         assert args.kv_cache_dtype == "fp8"
         assert args.index_cache_dtype == "fp8"


### PR DESCRIPTION
## Motivation

deps on aiter PR https://github.com/ROCm/aiter/pull/4098
launch script:
```
export HIP_VISIBLE_DEVICES=0,1,2,3
export ATOM_FORCE_ATTN_TRITON=1

python -m atom.entrypoints.openai_server --model $main_model \
  -tp 4 --server-port 8014 --trust-remote-code --gpu-memory-utilization 0.85 --block-size 128 --no-enable_prefix_caching \
  --max-num-batched-tokens 16384 --max-model-len 16384\
  --kv_cache_dtype fp8 --index-cache-dtype fp8 \
  --torch-profiler-dir ./trace
```


accuracy:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9424|±  |0.0064|
|     |       |strict-match    |     5|exact_match|↑  |0.9431|±  |0.0064|
```

Perf
This PR
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  138.58    
Total input tokens:                      2097152   
Total generated tokens:                  262144    
Request throughput (req/s):              1.85      
Output token throughput (tok/s):         1891.65   
Peak output token throughput (tok/s):    3392.00   
Peak concurrent requests:                64.00     
Total token throughput (tok/s):          17024.81  
---------------Time to First Token----------------
Mean TTFT (ms):                          3490.40   
Median TTFT (ms):                        3491.54   
P99 TTFT (ms):                           6514.43   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          13.52     
Median TPOT (ms):                        13.55     
P99 TPOT (ms):                           16.92     
---------------Inter-token Latency----------------
Mean ITL (ms):                           13.50     
Median ITL (ms):                         10.47     
P99 ITL (ms):                            12.96     
==================================================
```

before
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  142.15    
Total input tokens:                      2097152   
Total generated tokens:                  262144    
Request throughput (req/s):              1.80      
Output token throughput (tok/s):         1844.15   
Peak output token throughput (tok/s):    5088.00   
Peak concurrent requests:                64.00     
Total token throughput (tok/s):          16597.33  
---------------Time to First Token----------------
Mean TTFT (ms):                          3500.17   
Median TTFT (ms):                        3498.67   
P99 TTFT (ms):                           6520.38   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          13.94     
Median TPOT (ms):                        13.91     
P99 TPOT (ms):                           17.34     
---------------Inter-token Latency----------------
Mean ITL (ms):                           13.93     
Median ITL (ms):                         10.98     
P99 ITL (ms):                            12.66     
==================================================
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
