### PR TITLE
[ATOM][Fix] propagate dp_uniform_decode to TBO ubatches

### DIFF
--- a/atom/utils/tbo/ubatch_wrapper.py
+++ b/atom/utils/tbo/ubatch_wrapper.py
@@ -506,6 +506,7 @@ class UBatchWrapper(nn.Module):
             batch_size=ub_num_reqs,
             graph_bs=graph_bs,
             is_draft=ctx.context.is_draft,
+            dp_uniform_decode=ctx.context.dp_uniform_decode,
         )
 
         return ForwardContext(


### PR DESCRIPTION
## Motivation

In DP prefill with large ISL requests, one rank may process a request that has
already been chunked into a very small prefill segment, while other DP ranks are
still processing large prefill segments in the same step. For example, one rank
may have a TBO split of `6/6` tokens, while peer ranks have `4096/4097` or larger
ubatches.

This skewed shape is valid for variable-length DP prefill, but it is unsafe if a
TBO child context falls back to uniform-decode semantics. Native ATOM computes
`dp_uniform_decode` from the parent cross-DP synchronization result, but the TBO
child contexts previously did not inherit this flag and could use the default
value instead.

When a small chunked ISL segment is handled together with large ISL segments from
other ranks, this mismatch can make the small child ubatch look like uniform
decode. That is risky for MoE/MorI dispatch padding or buffer truncation logic,
because the local child token count no longer represents the amount of expert
traffic received from other DP ranks.

This change propagates the parent `dp_uniform_decode` flag into each native TBO
child context so that child ubatches preserve the same DP prefill semantics as
the parent forward.

## Command
```
AITER_QUICK_REDUCE_QUANTIZATION=INT4 \
SGLANG_AITER_FP8_PREFILL_ATTN=0 \
SGLANG_USE_AITER=1 \
SGLANG_ENABLE_SPEC_V2=1 \
SGLANG_ENABLE_TORCH_COMPILE=1 \
TORCHINDUCTOR_COMPILE_THREADS=128 \
ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1 \
MORI_SHMEM_MODE=ISOLATION \
ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD=0 \

python3 -m atom.entrypoints.openai_server \
  --model /models/deepseek-ai/DeepSeek-R1-0528-MXFP4-v2 \
  --host localhost \
  --server-port 9000 \
  --trust-remote-code \
  -tp 1 \
  -dp 4 \
  --kv_cache_dtype fp8 \
  --gpu-memory-utilization 0.85 \
  --max-num-seqs 4096 \
  --max-num-batched-tokens 4096 \
  --block-size 1 \
  --enable-tbo all \
  --all2all-backend high-throughput \
  --no-enable_prefix_caching \
  --enable-expert-parallel \
  --enable-dp-attention
```

## Benchamark
```
#!bin/bash
MODEL=/models/deepseek-ai/DeepSeek-R1-0528-MXFP4-v2

RANGE_RATIO=1.0

ISL=8192
OSL=1
CON=16
NUM=$(( CON * 3 ))

echo "ATOM Model=${MODEL}"
echo "ATOM ISL=${ISL}, OSL=${OSL}, NUM=${NUM}, CON=${CON} RANGE_RATIO=${RANGE_RATIO}"
 
sleep 2
 
# git clone https://github.com/kimbochen/bench_serving.git
echo "Starting bench with model: ${MODEL}"
python bench_serving/benchmark_serving.py \
    --model=$MODEL \
    --backend=sglang \
    --base-url=http://localhost:9000 \
    --dataset-name=random \
    --random-input-len=$ISL \
    --random-output-len=$OSL \
    --random-range-ratio ${RANGE_RATIO} \
    --num-prompts=${NUM} \
    --max-concurrency=${CON} \
    --request-rate=inf \
    --ignore-eos \
    --save-result \
    --percentile-metrics="ttft,tpot,itl,e2el" \
    --result-dir=./
```

before:
<img width="1127" height="542" alt="image" src="https://github.com/user-attachments/assets/3fc1587e-8d10-4306-bfe5-002b438d4e5f" />

after:
```
============ Serving Benchmark Result ============
Successful requests:                     48        
Benchmark duration (s):                  13.74     
Total input tokens:                      393216    
Total generated tokens:                  48        
Request throughput (req/s):              3.49      
Output token throughput (tok/s):         3.49      
Total Token throughput (tok/s):          28619.42  
---------------Time to First Token----------------
Mean TTFT (ms):                          4115.68   
Median TTFT (ms):                        4180.95   
P99 TTFT (ms):                           4909.96   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.03      
Median ITL (ms):                         0.03      
P99 ITL (ms):                            0.06      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          4115.71   
Median E2EL (ms):                        4180.98   
P99 E2EL (ms):                           4909.99   
==================================================
```