### PR TITLE
ci(atomesh): add Spur cluster benchmark support

### DIFF
--- a/.github/benchmark/models_atomesh.yaml
+++ b/.github/benchmark/models_atomesh.yaml
@@ -45,7 +45,7 @@ backends:
 models:
   DeepSeek-V4-Pro:
     backend: atom
-    model_path: /mnt/models/DeepSeek-V4-Pro/
+    model_path: "${ATOMESH_MODEL_ROOT}/DeepSeek-V4-Pro/"
     precision: FP4
     env:
       common:
@@ -109,7 +109,7 @@ models:
 
   Kimi-K2.5-MXFP4:
     backend: atom
-    model_path: /mnt/models/Kimi-K2.5-MXFP4/
+    model_path: "${ATOMESH_MODEL_ROOT}/Kimi-K2.5-MXFP4/"
     precision: MXFP4
     env:
       common:
@@ -178,7 +178,7 @@ models:
 
   MiniMax-M3-MXFP4:
     backend: atom
-    model_path: /mnt/models/MiniMax-M3-MXFP4
+    model_path: "${ATOMESH_MODEL_ROOT}/MiniMax-M3-MXFP4"
     precision: MXFP4
     env:
       common:
@@ -264,7 +264,7 @@ models:
           server:
             common_args:
               method: eagle3
-              draft_model: /mnt/models/MiniMax-M3-EAGLE3
+              draft_model: "${ATOMESH_MODEL_ROOT}/MiniMax-M3-EAGLE3"
               num_speculative_tokens: 3
           prefill:
             workers: 1
@@ -295,7 +295,7 @@ models:
             common_args:
               decode_max_num_seqs: 1024
               method: eagle3
-              draft_model: /mnt/models/MiniMax-M3-EAGLE3
+              draft_model: "${ATOMESH_MODEL_ROOT}/MiniMax-M3-EAGLE3"
               num_speculative_tokens: 3
           prefill:
             workers: 2
@@ -325,7 +325,7 @@ models:
 
   MiniMax-M3-MXFP8:
     backend: atom
-    model_path: /mnt/models/MiniMax-M3-MXFP8
+    model_path: "${ATOMESH_MODEL_ROOT}/MiniMax-M3-MXFP8"
     precision: MXFP8
     env:
       common:
@@ -411,7 +411,7 @@ models:
           server:
             common_args:
               method: eagle3
-              draft_model: /mnt/models/MiniMax-M3-EAGLE3
+              draft_model: "${ATOMESH_MODEL_ROOT}/MiniMax-M3-EAGLE3"
               num_speculative_tokens: 3
           prefill:
             workers: 1
@@ -442,7 +442,7 @@ models:
             common_args:
               decode_max_num_seqs: 1024
               method: eagle3
-              draft_model: /mnt/models/MiniMax-M3-EAGLE3
+              draft_model: "${ATOMESH_MODEL_ROOT}/MiniMax-M3-EAGLE3"
               num_speculative_tokens: 3
               online_quant_config: '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*.gate.*", "*.block_sparse_moe.experts*"]}'
           prefill:

--- a/.github/scripts/atomesh/pd_matrix.py
+++ b/.github/scripts/atomesh/pd_matrix.py
@@ -73,12 +73,21 @@ def resolve_model_path(model_name: str, model_cfg: dict[str, Any]) -> str:
 def resolve_env_refs(value: str) -> str:
     def expand_env(match: re.Match[str]) -> str:
         name = match.group(1)
-        env_value = os.environ.get(name, "").strip()
-        if not env_value:
+        if name not in os.environ:
             raise ValueError(f"Environment variable {name} is not set")
-        return env_value
+        return os.environ[name].strip()
 
     return ENV_REF_RE.sub(expand_env, value)
+
+
+def resolve_env_refs_in_value(value: Any) -> Any:
+    if isinstance(value, str) and "${" in value:
+        return resolve_env_refs(value)
+    if isinstance(value, list):
+        return [resolve_env_refs_in_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: resolve_env_refs_in_value(item) for key, item in value.items()}
+    return value
 
 
 def resolve_nodes(value: Any) -> list[str]:
@@ -96,7 +105,22 @@ def resolve_runner(runner_cfg: dict[str, Any]) -> dict[str, Any]:
         value = runner.get(key)
         if isinstance(value, str):
             runner[key] = resolve_env_refs(value)
+    if runner.get("slurm_submit_runner") == "atomesh-cicd-mi350":
+        runner["slurm_account"] = ""
+        runner["slurm_partition"] = ""
     return runner
+
+
+def required_node_count(
+    pd_worker_layout: str,
+    prefill_cfg: dict[str, Any],
+    decode_cfg: dict[str, Any],
+) -> int:
+    if pd_worker_layout == "single_node":
+        return 1
+    if pd_worker_layout == "prefill_single_node":
+        return 1 + int(decode_cfg.get("workers", 1))
+    return int(prefill_cfg.get("workers", 1)) + int(decode_cfg.get("workers", 1))
 
 
 def slug(value: str) -> str:
@@ -190,34 +214,49 @@ def build_cell(
     pd_worker_layout = str(suite_cfg.get("pd_worker_layout", "multi_node"))
     single_node_pd = pd_worker_layout == "single_node"
     prefill_single_node_pd = pd_worker_layout == "prefill_single_node"
+    runner_cfg = resolve_runner(
+        deep_merge(defaults.get("runner", {}), suite_cfg.get("runner", {}))
+    )
+    required_nodes = required_node_count(pd_worker_layout, prefill_cfg, decode_cfg)
+    slurm_submit_runner = str(runner_cfg.get("slurm_submit_runner", ""))
+    allow_auto_nodes = slurm_submit_runner == "atomesh-cicd-mi350"
 
-    nodes = resolve_nodes(suite_cfg.get("nodes"))
+    nodes = [] if allow_auto_nodes else resolve_nodes(suite_cfg.get("nodes"))
     if single_node_pd:
-        if not nodes:
+        if not nodes and not allow_auto_nodes:
             raise ValueError(
                 f"{suite_cfg.get('name', model_name)} needs at least one node"
             )
         nodes = nodes[:1]
     elif prefill_single_node_pd:
-        required_nodes = 1 + int(decode_cfg.get("workers", 1))
-        if len(nodes) < required_nodes:
+        if nodes and len(nodes) < required_nodes:
+            raise ValueError(
+                f"{suite_cfg.get('name', model_name)} needs at least "
+                f"{required_nodes} node(s)"
+            )
+        if not nodes and not allow_auto_nodes:
             raise ValueError(
                 f"{suite_cfg.get('name', model_name)} needs at least "
                 f"{required_nodes} node(s)"
             )
         nodes = nodes[:required_nodes]
-    elif len(nodes) < 2:
+    elif nodes and len(nodes) < required_nodes:
         raise ValueError(
-            f"{suite_cfg.get('name', model_name)} needs at least two nodes"
+            f"{suite_cfg.get('name', model_name)} needs at least "
+            f"{required_nodes} node(s)"
         )
+    elif not nodes and not allow_auto_nodes:
+        raise ValueError(
+            f"{suite_cfg.get('name', model_name)} needs at least "
+            f"{required_nodes} node(s)"
+        )
+    num_nodes = len(nodes) if nodes else required_nodes
 
     server_args = deep_merge(
         model_cfg.get("server", {}).get("common_args", {}),
         suite_cfg.get("server", {}).get("common_args", {}),
     )
-    runner_cfg = resolve_runner(
-        deep_merge(defaults.get("runner", {}), suite_cfg.get("runner", {}))
-    )
+    server_args = resolve_env_refs_in_value(server_args)
     benchmark_cfg = deep_merge(
         defaults.get("benchmark", {}),
         suite_cfg.get("benchmark", {}),
@@ -261,7 +300,7 @@ def build_cell(
         "display_topology": display_topology,
         "pd_worker_layout": pd_worker_layout,
         "nodes": nodes,
-        "num_nodes": len(nodes),
+        "num_nodes": num_nodes,
         "isl": isl,
         "osl": int(suite_cfg["osl"]),
         "concurrency": concurrency,

--- a/.github/scripts/atomesh/pd_server_atom.sh
+++ b/.github/scripts/atomesh/pd_server_atom.sh
@@ -352,7 +352,6 @@ start_router() {
     --policy "${ROUTER_POLICY}" \
     --backend atom \
     --log-level info \
-    --disable-health-check \
     --disable-circuit-breaker \
     --prometheus-port "${PROMETHEUS_PORT}" \
     2>&1 | tee "${RUN_DIR}/logs/router.log" &

--- a/.github/scripts/atomesh/pd_slurm_job.sh
+++ b/.github/scripts/atomesh/pd_slurm_job.sh
@@ -43,6 +43,8 @@ allow = (
     "MAX_NUM_BATCHED_TOKENS",
     "ONLINE_QUANT_CONFIG",
     "HF_OVERRIDES",
+    # Preserve FlyDSL cache overrides for non-root Spur containers.
+    "FLYDSL_",
     "SPEC_",
     "DRAFT_MODEL_PATH",
     "NUM_SPEC_TOKENS",
@@ -130,6 +132,9 @@ EOF
     -e TORCHINDUCTOR_CACHE_DIR="/tmp/atomesh-cache-${JOB_ID}-${rank}/torchinductor"
     -e AITER_CACHE_DIR="/tmp/atomesh-cache-${JOB_ID}-${rank}/aiter"
     -e AITER_JIT_DIR="/tmp/atomesh-cache-${JOB_ID}-${rank}/aiter/jit"
+    # FlyDSL otherwise tries to create caches under /app/aiter-test, which is
+    # read-only for the Slurm uid required by Spur's Docker template.
+    -e FLYDSL_RUNTIME_CACHE_DIR="/tmp/atomesh-cache-${JOB_ID}-${rank}/flydsl"
     -e NCCL_NET_PLUGIN=none
     -e NCCL_SOCKET_IFNAME=eth1
     -e NCCL_IB_HCA=ionic_0,ionic_1,ionic_2,ionic_3,ionic_4,ionic_5,ionic_6,ionic_7

--- a/.github/scripts/atomesh/pd_slurm_job.sh
+++ b/.github/scripts/atomesh/pd_slurm_job.sh
@@ -7,9 +7,244 @@ set -euo pipefail
 
 REPO_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
 SCRIPT_PATH="${REPO_ROOT}/.github/scripts/atomesh/pd_server_atom.sh"
-RUN_DIR="${LOG_ROOT}/slurm_job-${SLURM_JOB_ID}"
+JOB_ID="${SLURM_JOB_ID:-${SPUR_JOB_ID:-local}}"
+RUN_DIR="${LOG_ROOT}/slurm_job-${JOB_ID}"
 
 mkdir -p "${RUN_DIR}"
+
+write_env_file() {
+  local env_file="$1"
+  python3 - <<'PY' > "${env_file}"
+import os
+
+allow = (
+    "ATOMESH_",
+    "MODEL_",
+    "BACKEND",
+    "PRECISION",
+    "TOPOLOGY",
+    "DISPLAY_TOPOLOGY",
+    "ISL_LIST",
+    "OSL",
+    "CONC_LIST",
+    "BENCH_",
+    "RANDOM_RANGE_RATIO",
+    "REQUEST_RATE",
+    "WAIT_",
+    "PREFILL_",
+    "DECODE_",
+    "ROUTER_",
+    "PROMETHEUS_PORT",
+    "KV_CACHE_DTYPE",
+    "BLOCK_SIZE",
+    "MEM_FRACTION",
+    "MAX_MODEL_LEN",
+    "MAX_NUM_SEQS",
+    "MAX_NUM_BATCHED_TOKENS",
+    "ONLINE_QUANT_CONFIG",
+    "HF_OVERRIDES",
+    "SPEC_",
+    "DRAFT_MODEL_PATH",
+    "NUM_SPEC_TOKENS",
+    "EXTRA_SERVER_ARGS",
+    "RUN_EVAL",
+    "EVAL_",
+)
+for key, value in sorted(os.environ.items()):
+    if key.startswith(allow):
+        print(f"{key}={value}")
+PY
+}
+
+pre_cleanup_local() {
+  echo "=== pre-cleanup: stop running containers on $(hostname) ==="
+  set +e
+  running=()
+  while read -r id; do
+    [[ -n "${id}" ]] && running+=("${id}")
+  done < <(docker ps -q 2>/dev/null)
+
+  if [[ "${#running[@]}" -gt 0 ]]; then
+    docker ps --format "  {{.ID}} {{.Names}} {{.Status}}"
+    docker stop -t 0 "${running[@]}" >/dev/null 2>&1 || true
+  else
+    echo "no running containers"
+  fi
+  set -e
+}
+
+run_container_rank() {
+  local rank="$1"
+  local env_file="$2"
+  local container="atomesh-${ATOMESH_CELL_ID}-${JOB_ID}-${rank}"
+  local rank_dir="${RUN_DIR}/rank-${rank}"
+  local bin_dir="${RUN_DIR}/bin"
+  local video_gid render_gid host_ionic
+
+  mkdir -p "${rank_dir}"
+  mkdir -p "${bin_dir}"
+  # PyTorch Inductor may call `nvcc --version` while formatting compiler errors.
+  # Spur requires containers to run as the Slurm user, and the image's CUDA nvcc
+  # path is not executable for that uid. Provide a narrow ROCm-only shim for the
+  # version probe without pretending to support CUDA compilation.
+  cat > "${bin_dir}/nvcc" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  exec hipcc --version
+fi
+echo "nvcc shim is only available for --version on ROCm CI" >&2
+exit 127
+EOF
+  chmod +x "${bin_dir}/nvcc"
+
+  video_gid="$(getent group video 2>/dev/null | cut -d: -f3 || true)"
+  render_gid="$(getent group render 2>/dev/null | cut -d: -f3 || true)"
+  host_ionic="$(readlink -f /usr/lib/x86_64-linux-gnu/libionic.so.1 2>/dev/null || true)"
+
+  docker rm -f "${container}" >/dev/null 2>&1 || true
+  docker pull "${DOCKER_IMAGE}"
+
+  docker_args=(
+    run --rm --name "${container}"
+    --user "$(id -u):$(id -g)"
+    --network host --ipc host
+    --device=/dev/kfd --device=/dev/dri --device=/dev/infiniband
+    --cap-add=IPC_LOCK --cap-add=NET_ADMIN
+    --ulimit memlock=-1:-1 --ulimit stack=67108864 --ulimit nofile=65536:524288
+    --shm-size=128G
+    --env-file "${env_file}"
+    -e SLURM_JOB_ID="${JOB_ID}"
+    -e SPUR_JOB_ID="${SPUR_JOB_ID:-${JOB_ID}}"
+    -e NODE_RANK="${rank}"
+    -e NODE0_ADDR="${NODE0_ADDR}"
+    -e IPADDRS="${IPADDRS}"
+    -e xP="${PREFILL_WORKERS}"
+    -e yD="${DECODE_WORKERS}"
+    -e PREFILL_TP_SIZE="${PREFILL_TP}"
+    -e DECODE_TP_SIZE="${DECODE_TP}"
+    -e RUN_DIR="/run_logs/slurm_job-${JOB_ID}"
+    -e USER="$(id -un)"
+    -e LOGNAME="$(id -un)"
+    -e HOME="/tmp/atomesh-home-${JOB_ID}-${rank}"
+    -e XDG_CACHE_HOME="/tmp/atomesh-cache-${JOB_ID}-${rank}"
+    -e TORCHINDUCTOR_CACHE_DIR="/tmp/atomesh-cache-${JOB_ID}-${rank}/torchinductor"
+    -e AITER_CACHE_DIR="/tmp/atomesh-cache-${JOB_ID}-${rank}/aiter"
+    -e AITER_JIT_DIR="/tmp/atomesh-cache-${JOB_ID}-${rank}/aiter/jit"
+    -e NCCL_NET_PLUGIN=none
+    -e NCCL_SOCKET_IFNAME=eth1
+    -e NCCL_IB_HCA=ionic_0,ionic_1,ionic_2,ionic_3,ionic_4,ionic_5,ionic_6,ionic_7
+    -e NCCL_IB_GID_INDEX=1
+    -e NCCL_CROSS_NIC=0
+    -e NCCL_PXN_DISABLE=0
+    -e NCCL_NET_DISABLE_INTRA=1
+    -e NCCL_IB_TC=104
+    -e NCCL_IB_FIFO_TC=192
+    -e NCCL_IB_QPS_PER_CONNECTION=1
+    -e NCCL_IB_TIMEOUT=22
+    -e NCCL_IB_RETRY_CNT=12
+    -e NCCL_DEBUG=WARN
+    -v "${REPO_ROOT}":/workspace/ATOM:ro
+    -v "${RUN_DIR}":/run_logs/slurm_job-"${JOB_ID}"
+    -v /mnt:/mnt
+    -v /data:/data
+  )
+
+  [[ -n "${video_gid}" ]] && docker_args+=(--group-add "${video_gid}")
+  [[ -n "${render_gid}" ]] && docker_args+=(--group-add "${render_gid}")
+  [[ -n "${host_ionic}" && -e "${host_ionic}" ]] && docker_args+=(-v "${host_ionic}:/usr/lib/x86_64-linux-gnu/libionic.so.1:ro")
+  [[ -e /usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so ]] && docker_args+=(-v /usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so:ro)
+  [[ -e /etc/libibverbs.d/ionic.driver ]] && docker_args+=(-v /etc/libibverbs.d/ionic.driver:/etc/libibverbs.d/ionic.driver:ro)
+  [[ -d /it-share ]] && docker_args+=(-v /it-share:/it-share)
+
+  docker_args+=(
+    "${DOCKER_IMAGE}"
+    bash -lc "export PATH=/run_logs/slurm_job-${JOB_ID}/bin:\${PATH}; cd /workspace/ATOM && bash .github/scripts/atomesh/pd_server_atom.sh"
+  )
+
+  docker "${docker_args[@]}" 2>&1 | tee "${rank_dir}/container.log"
+}
+
+run_spur_job() {
+  if [[ -z "${SPUR_TASK_OFFSET:-}" || -z "${SPUR_PEER_NODES:-}" ]]; then
+    return 1
+  fi
+
+  local node_rank="${SPUR_TASK_OFFSET}"
+  local env_file="${RUN_DIR}/docker-rank-${node_rank}.env"
+  local peers=()
+  IFS=',' read -r -a peers <<< "${SPUR_PEER_NODES}"
+  IFS=',' read -r -a SELECTED_NODES <<< "${SPUR_NODELIST:-${NODE_LIST}}"
+
+  IPS=()
+  for peer in "${peers[@]}"; do
+    IPS+=("${peer%%:*}")
+  done
+
+  if [[ "${#SELECTED_NODES[@]}" -eq 0 || -z "${SELECTED_NODES[0]:-}" ]]; then
+    SELECTED_NODES=()
+    for idx in "${!IPS[@]}"; do
+      SELECTED_NODES+=("spur-node-${idx}")
+    done
+  fi
+
+  if [[ "${#IPS[@]}" -lt "${NUM_NODES}" ]]; then
+    echo "ERROR: SPUR_PEER_NODES has ${#IPS[@]} nodes, expected ${NUM_NODES}" >&2
+    exit 1
+  fi
+
+  SELECTED_NODES=("${SELECTED_NODES[@]:0:${NUM_NODES}}")
+  IPS=("${IPS[@]:0:${NUM_NODES}}")
+  SELECTED_NODELIST="$(IFS=,; echo "${SELECTED_NODES[*]}")"
+  IPADDRS="$(IFS=,; echo "${IPS[*]}")"
+  NODE0_ADDR="${IPS[0]}"
+
+  echo "=== ATOMesh Spur job ${JOB_ID} rank ${node_rank}/${NUM_NODES} ==="
+  echo "nodes=${SELECTED_NODELIST}"
+  echo "ips=${IPADDRS}"
+  echo "run_dir=${RUN_DIR}"
+
+  pre_cleanup_local
+  write_env_file "${env_file}"
+  if [[ "${node_rank}" -eq 0 ]]; then
+    cat > "${RUN_DIR}/cell-metadata.json" <<EOF
+{
+  "cell_id": "${ATOMESH_CELL_ID}",
+  "model": "${MODEL_NAME}",
+  "backend": "${BACKEND}",
+  "topology": "${TOPOLOGY}",
+  "display_topology": "${DISPLAY_TOPOLOGY}",
+  "nodes": "${SELECTED_NODELIST}",
+  "ips": "${IPADDRS}",
+  "slurm_job_id": "${JOB_ID}",
+  "log_root": "${RUN_DIR}"
+}
+EOF
+  fi
+
+  SPUR_NODE_RANK_FOR_CLEANUP="${node_rank}"
+  cleanup_spur() {
+    local rc=$?
+    echo "=== cleanup rank=${SPUR_NODE_RANK_FOR_CLEANUP} rc=${rc} ==="
+    docker stop -t 0 "atomesh-${ATOMESH_CELL_ID}-${JOB_ID}-${SPUR_NODE_RANK_FOR_CLEANUP}" >/dev/null 2>&1 || true
+    return "${rc}"
+  }
+  trap cleanup_spur EXIT
+
+  local rc=0
+  run_container_rank "${node_rank}" "${env_file}" || rc=$?
+  if [[ "${rc}" -ne 0 ]]; then
+    echo "=== Spur rank ${node_rank} failed rc=${rc} ==="
+    return "${rc}"
+  fi
+
+  echo "=== Spur rank ${node_rank} completed ==="
+  find "${RUN_DIR}" -maxdepth 3 -type f | sort
+  return 0
+}
+
+if run_spur_job; then
+  exit 0
+fi
 
 mapfile -t ALLOC_NODES < <(scontrol show hostnames "$SLURM_JOB_NODELIST")
 if [[ "${#ALLOC_NODES[@]}" -lt "${NUM_NODES}" ]]; then
@@ -85,39 +320,7 @@ echo "ips=${IPADDRS}"
 echo "run_dir=${RUN_DIR}"
 
 ENV_FILE="${RUN_DIR}/docker.env"
-python3 - <<'PY' > "${ENV_FILE}"
-import os
-
-allow = (
-    "ATOMESH_",
-    "MODEL_",
-    "BACKEND",
-    "PRECISION",
-    "TOPOLOGY",
-    "DISPLAY_TOPOLOGY",
-    "ISL_LIST",
-    "OSL",
-    "CONC_LIST",
-    "BENCH_",
-    "RANDOM_RANGE_RATIO",
-    "REQUEST_RATE",
-    "WAIT_",
-    "PREFILL_",
-    "DECODE_",
-    "ROUTER_",
-    "PROMETHEUS_PORT",
-    "KV_CACHE_DTYPE",
-    "BLOCK_SIZE",
-    "MEM_FRACTION",
-    "MAX_NUM_SEQS",
-    "EXTRA_SERVER_ARGS",
-    "RUN_EVAL",
-    "EVAL_",
-)
-for key, value in sorted(os.environ.items()):
-    if key.startswith(allow):
-        print(f"{key}={value}")
-PY
+write_env_file "${ENV_FILE}"
 
 cleanup() {
   local rc=$?

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -305,6 +305,30 @@ set_slurm_job_log_paths() {
   echo "slurm_error=${SLURM_JOB_ERROR}"
 }
 
+write_slurm_cancel_helper() {
+  local job_id="$1"
+  local helper="${RESULT_DIR}/${ATOMESH_CELL_ID}.slurm-cancel.sh"
+
+  if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+    cat > "${helper}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if command -v scancel >/dev/null 2>&1; then
+  scancel --controller "${SPUR_CONTROLLER_ADDR}" "${job_id}" || true
+fi
+EOF
+  else
+    cat > "${helper}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if command -v scancel >/dev/null 2>&1; then
+  scancel "${job_id}" || true
+fi
+EOF
+  fi
+  chmod +x "${helper}"
+}
+
 stream_file_lines() {
   local file="$1"
   local prefix="$2"
@@ -472,6 +496,7 @@ fi
 
 JOB_ID="$(parse_sbatch_job_id "${SBATCH_OUTPUT}")"
 echo "${JOB_ID}" | tee "${RESULT_DIR}/${ATOMESH_CELL_ID}.slurm-job-id"
+write_slurm_cancel_helper "${JOB_ID}"
 
 SLURM_JOB_ACTIVE=1
 set_slurm_job_log_paths "${JOB_ID}"

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -19,6 +19,7 @@ DRY_RUN=0
 JOB_ID=""
 SLURM_JOB_ACTIVE=0
 SCANCEL_SENT=0
+declare -A SPUR_SHARED_LOG_LINES=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -327,19 +328,47 @@ stream_slurm_logs_once() {
   ERR_LINE="$(stream_file_lines "${SLURM_JOB_ERROR}" "[slurm.err] " "${ERR_LINE}")"
 }
 
+stream_spur_shared_logs_once() {
+  local job_id="$1"
+  local run_dir="${LOG_ROOT}/slurm_job-${job_id}"
+  local log_file rel_path current_line
+
+  [[ -d "${run_dir}" ]] || return 0
+
+  shopt -s nullglob
+  for log_file in "${run_dir}"/rank-*/container.log "${run_dir}"/logs/*.log; do
+    rel_path="${log_file#"${run_dir}/"}"
+    current_line="${SPUR_SHARED_LOG_LINES[${log_file}]:-0}"
+    SPUR_SHARED_LOG_LINES["${log_file}"]="$(stream_file_lines "${log_file}" "[spur:${rel_path}] " "${current_line}")"
+  done
+  shopt -u nullglob
+}
+
 monitor_slurm_job() {
   local job_id="$1"
+  local squeue_cmd=(squeue)
   OUT_LINE=0
   ERR_LINE=0
+  SPUR_SHARED_LOG_LINES=()
+
+  if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+    squeue_cmd+=(--controller "${SPUR_CONTROLLER_ADDR}")
+  fi
 
   echo "=== monitoring Slurm job ${job_id} ==="
-  while squeue -h -j "${job_id}" >/dev/null 2>&1 && [[ -n "$(squeue -h -j "${job_id}" 2>/dev/null)" ]]; do
-    squeue -h -j "${job_id}" -o "[slurm] job=%i state=%T elapsed=%M nodes=%D reason=%R" || true
+  while "${squeue_cmd[@]}" -h -j "${job_id}" >/dev/null 2>&1 && [[ -n "$("${squeue_cmd[@]}" -h -j "${job_id}" 2>/dev/null)" ]]; do
+    "${squeue_cmd[@]}" -h -j "${job_id}" -o "[slurm] job=%i state=%T elapsed=%M nodes=%D reason=%R" || true
     stream_slurm_logs_once
+    if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+      stream_spur_shared_logs_once "${job_id}"
+    fi
     sleep "${SLURM_LOG_POLL_INTERVAL}"
   done
 
   stream_slurm_logs_once
+  if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+    stream_spur_shared_logs_once "${job_id}"
+  fi
 }
 
 read_slurm_exit_code() {

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -443,6 +443,7 @@ if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
 #SBATCH --job-name=${ATOMESH_CELL_ID}
 #SBATCH --nodes=${NUM_NODES}
 #SBATCH --ntasks-per-node=1
+#SBATCH --exclusive
 #SBATCH --time=${SLURM_TIME_LIMIT}
 #SBATCH --chdir=/tmp
 EOF

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -151,12 +151,21 @@ exports = {
     "EVAL_CONCURRENCY": csv_value(
         accuracy.get("concurrency") or cell.get("concurrency", [])
     ),
+    "SLURM_SUBMIT_RUNNER": runner.get("slurm_submit_runner", "atomesh-cicd"),
     "SLURM_ACCOUNT": runner.get("slurm_account", "amd-frameworks"),
     "SLURM_PARTITION": runner.get("slurm_partition", "amd-frameworks"),
     "SLURM_CPUS_PER_TASK": runner.get("cpus_per_task", 114),
     "SLURM_GPUS_PER_NODE": runner.get("gpus_per_node", 8),
     "SLURM_TIME_LIMIT": runner.get("time_limit", "06:00:00"),
     "SLURM_LOG_ROOT": runner.get("log_root", "/it-share/ATOMESH_LOG/"),
+    "SPUR_CONTROLLER_ADDR": runner.get(
+        "spur_controller_addr",
+        os.environ.get("SPUR_CONTROLLER_ADDR", "http://134.199.196.72:6817"),
+    ),
+    "SPUR_ACCOUNTING_ADDR": runner.get(
+        "spur_accounting_addr",
+        os.environ.get("SPUR_ACCOUNTING_ADDR", "http://134.199.196.72:6819"),
+    ),
 }
 
 for key, value in exports.items():
@@ -172,9 +181,17 @@ PY
 )"
 
 export RESULT_DIR
+CURRENT_USER="$(id -un)"
+SLURM_LOG_ROOT="${SLURM_LOG_ROOT//\$\{USER\}/${CURRENT_USER}}"
+SLURM_LOG_ROOT="${SLURM_LOG_ROOT//\$USER/${CURRENT_USER}}"
 export LOG_ROOT="${SLURM_LOG_ROOT%/}/${ATOMESH_CELL_ID}-${GITHUB_RUN_ID:-local}-$(date +%Y%m%d%H%M%S)"
-export SLURM_OUTPUT="${LOG_ROOT}/slurm-%j.out"
-export SLURM_ERROR="${LOG_ROOT}/slurm-%j.err"
+if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+  export SLURM_OUTPUT="/tmp/atomesh-%j.out"
+  export SLURM_ERROR="/tmp/atomesh-%j.err"
+else
+  export SLURM_OUTPUT="${LOG_ROOT}/slurm-%j.out"
+  export SLURM_ERROR="${LOG_ROOT}/slurm-%j.err"
+fi
 SLURM_LOG_POLL_INTERVAL="${SLURM_LOG_POLL_INTERVAL:-30}"
 
 echo "=== ATOMesh benchmark cell ==="
@@ -184,6 +201,10 @@ echo "topology=${DISPLAY_TOPOLOGY}"
 echo "nodes=${NODE_LIST}"
 echo "isl=${ISL_LIST} osl=${OSL} concurrency=${CONC_LIST}"
 echo "log_root=${LOG_ROOT}"
+if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+  echo "spur_controller=${SPUR_CONTROLLER_ADDR}"
+  echo "spur_accounting=${SPUR_ACCOUNTING_ADDR}"
+fi
 
 mkdir -p "${RESULT_DIR}"
 
@@ -231,6 +252,24 @@ scancel_slurm_job() {
   else
     echo "WARNING: scancel not found; unable to cancel Slurm job ${JOB_ID}" >&2
   fi
+}
+
+parse_sbatch_job_id() {
+  local output="$1"
+  output="${output//$'\r'/}"
+
+  if [[ "${output}" =~ ^[[:space:]]*([0-9]+)(\;.*)?[[:space:]]*$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  if [[ "${output}" =~ Submitted[[:space:]]+batch[[:space:]]+job[[:space:]]+([0-9]+) ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  echo "ERROR: unable to parse Slurm job id from sbatch output: ${output}" >&2
+  return 1
 }
 
 on_cancel() {
@@ -312,7 +351,11 @@ read_slurm_exit_code() {
     return 0
   fi
 
-  sacct_line="$(sacct -j "${job_id}" -X -n -P -o State,ExitCode 2>/dev/null | awk -F'|' 'NF { print; exit }' || true)"
+  if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+    sacct_line="$(sacct --accounting "${SPUR_ACCOUNTING_ADDR}" --brief --noheader 2>/dev/null | awk -v job_id="${job_id}" '$1 == job_id { print $2 "|" $3; exit }' || true)"
+  else
+    sacct_line="$(sacct -j "${job_id}" -X -n -P -o State,ExitCode 2>/dev/null | awk -F'|' 'NF { print; exit }' || true)"
+  fi
   if [[ -z "${sacct_line}" ]]; then
     return 0
   fi
@@ -330,45 +373,72 @@ read_slurm_exit_code() {
     SLURM_JOB_RC="${exit_status}"
   fi
 
-  if [[ "${SLURM_STATE}" != COMPLETED && "${SLURM_JOB_RC}" -eq 0 ]]; then
+  if [[ "${SLURM_STATE}" != COMPLETE && "${SLURM_STATE}" != COMPLETED && "${SLURM_JOB_RC}" -eq 0 ]]; then
     SLURM_JOB_RC=1
   fi
 }
 
 IFS=',' read -r -a NODE_ARRAY <<< "${NODE_LIST}"
-SBATCH_CMD=(
-  sbatch
-  --parsable
-  --exclusive
-  --account "${SLURM_ACCOUNT}"
-  --partition "${SLURM_PARTITION}"
-  --nodes "${NUM_NODES}"
-  --ntasks "${NUM_NODES}"
-  --ntasks-per-node 1
-  --cpus-per-task "${SLURM_CPUS_PER_TASK}"
-  --gres "gpu:${SLURM_GPUS_PER_NODE}"
-  --time "${SLURM_TIME_LIMIT}"
-  --nodelist "${NODE_LIST}"
-  --output "${SLURM_OUTPUT}"
-  --error "${SLURM_ERROR}"
-  "${JOB_SCRIPT}"
-)
+if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+  SUBMIT_SCRIPT="${LOG_ROOT}/submit-${ATOMESH_CELL_ID}.sbatch.sh"
+  cat > "${SUBMIT_SCRIPT}" <<EOF
+#!/usr/bin/env bash
+#SBATCH --job-name=${ATOMESH_CELL_ID}
+#SBATCH --nodes=${NUM_NODES}
+#SBATCH --ntasks-per-node=1
+#SBATCH --time=${SLURM_TIME_LIMIT}
+#SBATCH --chdir=/tmp
+EOF
+  if [[ -n "${NODE_LIST}" ]]; then
+    printf '#SBATCH --nodelist=%s\n' "${NODE_LIST}" >> "${SUBMIT_SCRIPT}"
+  fi
+  cat >> "${SUBMIT_SCRIPT}" <<EOF
+#SBATCH --output=${SLURM_OUTPUT}
+#SBATCH --error=${SLURM_ERROR}
+EOF
+  {
+    printf 'export %q=%q\n' GITHUB_WORKSPACE "${REPO_ROOT}"
+    printf 'exec %q\n' "${JOB_SCRIPT}"
+  } >> "${SUBMIT_SCRIPT}"
+  chmod +x "${SUBMIT_SCRIPT}"
+  SBATCH_CMD=(sbatch --controller "${SPUR_CONTROLLER_ADDR}" "${SUBMIT_SCRIPT}")
+else
+  SBATCH_CMD=(
+    sbatch
+    --parsable
+    --exclusive
+    --account "${SLURM_ACCOUNT}"
+    --partition "${SLURM_PARTITION}"
+    --nodes "${NUM_NODES}"
+    --ntasks "${NUM_NODES}"
+    --ntasks-per-node 1
+    --cpus-per-task "${SLURM_CPUS_PER_TASK}"
+    --gres "gpu:${SLURM_GPUS_PER_NODE}"
+    --time "${SLURM_TIME_LIMIT}"
+    --nodelist "${NODE_LIST}"
+    --output "${SLURM_OUTPUT}"
+    --error "${SLURM_ERROR}"
+    "${JOB_SCRIPT}"
+  )
+fi
 
 echo "=== submitting Slurm job ==="
 printf ' %q' "${SBATCH_CMD[@]}"
 echo
 
 set +e
-JOB_ID="$("${SBATCH_CMD[@]}")"
+SBATCH_OUTPUT="$("${SBATCH_CMD[@]}")"
 SBATCH_RC=$?
 set -e
-JOB_ID="${JOB_ID%%;*}"
-echo "${JOB_ID}" | tee "${RESULT_DIR}/${ATOMESH_CELL_ID}.slurm-job-id"
+echo "${SBATCH_OUTPUT}"
 
 if [[ "${SBATCH_RC}" -ne 0 ]]; then
   echo "sbatch submit exit code: ${SBATCH_RC}"
   exit "${SBATCH_RC}"
 fi
+
+JOB_ID="$(parse_sbatch_job_id "${SBATCH_OUTPUT}")"
+echo "${JOB_ID}" | tee "${RESULT_DIR}/${ATOMESH_CELL_ID}.slurm-job-id"
 
 SLURM_JOB_ACTIVE=1
 set_slurm_job_log_paths "${JOB_ID}"
@@ -382,7 +452,21 @@ echo "slurm job exit code: ${SBATCH_RC}"
 
 if [[ -d "${LOG_ROOT}" ]]; then
   mkdir -p "${RESULT_DIR}/${ATOMESH_CELL_ID}"
-  cp -a "${LOG_ROOT}/." "${RESULT_DIR}/${ATOMESH_CELL_ID}/" || true
+  if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+    tar \
+      --exclude='.cache' \
+      --exclude='./.cache' \
+      --exclude='.aiter' \
+      --exclude='./.aiter' \
+      -C "${LOG_ROOT}" \
+      -cf - . | tar \
+      --no-same-owner \
+      --no-same-permissions \
+      -C "${RESULT_DIR}/${ATOMESH_CELL_ID}" \
+      -xf - || true
+  else
+    cp -a "${LOG_ROOT}/." "${RESULT_DIR}/${ATOMESH_CELL_ID}/" || true
+  fi
 fi
 
 exit "${SBATCH_RC}"

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -248,7 +248,11 @@ scancel_slurm_job() {
   SCANCEL_SENT=1
   echo "=== cancelling Slurm job ${JOB_ID}: ${reason} ===" >&2
   if command -v scancel >/dev/null 2>&1; then
-    scancel "${JOB_ID}" || true
+    if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+      scancel --controller "${SPUR_CONTROLLER_ADDR}" "${JOB_ID}" || true
+    else
+      scancel "${JOB_ID}" || true
+    fi
   else
     echo "WARNING: scancel not found; unable to cancel Slurm job ${JOB_ID}" >&2
   fi

--- a/.github/scripts/atomesh/process_result.py
+++ b/.github/scripts/atomesh/process_result.py
@@ -18,6 +18,10 @@ RESULT_RE = re.compile(
 TOPOLOGY_RE = re.compile(r"(?P<p>\d+)p(?P<d>\d+)d", re.IGNORECASE)
 TP_RE = re.compile(r"tp(?P<tp>\d+)", re.IGNORECASE)
 EVAL_CONC_RE = re.compile(r"(?:^|[_-])c(?P<conc>\d+)(?:$|[_-])", re.IGNORECASE)
+EVAL_TOPOLOGY_RE = re.compile(
+    r"(?:^|[_-])(?P<topology>\d+p\d+d(?:[_-]dpa)?)(?:$|[_-])",
+    re.IGNORECASE,
+)
 
 
 def number(*values: Any) -> float | None:
@@ -56,6 +60,8 @@ def slurm_job_env(path: Path) -> dict[str, str]:
     for parent in path.parents:
         env_path = parent / "docker.env"
         if env_path.is_file():
+            return read_env_file(env_path)
+        for env_path in sorted(parent.glob("docker-rank-*.env")):
             return read_env_file(env_path)
     return {}
 
@@ -203,6 +209,12 @@ def extra_text(
 def perf_point_extra(base_extra: str, point: dict[str, Any]) -> str:
     encoded = quote(json.dumps(point, separators=(",", ":"), sort_keys=True), safe="")
     return " | ".join(part for part in (base_extra, f"perf_point={encoded}") if part)
+
+
+def topology_key(value: Any) -> str:
+    text = string_value(value).lower().replace("-", "_")
+    match = EVAL_TOPOLOGY_RE.search(text)
+    return match.group("topology").replace("-", "_") if match else text
 
 
 def derive_fields(path: Path, payload: dict[str, Any]) -> dict[str, Any] | None:
@@ -444,7 +456,7 @@ def dashboard_point_entry(point: dict[str, Any], extra: str) -> dict[str, Any] |
 def collect_dashboard_entries(
     paths: list[Path],
     run_url: str | None,
-    gsm8k_scores: dict[int, dict[str, Any]],
+    gsm8k_scores: dict[tuple[str, int], dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     entries: list[dict[str, Any]] = []
     rows: list[dict[str, Any]] = []
@@ -458,9 +470,10 @@ def collect_dashboard_entries(
         if not fields:
             continue
         payload = enrich_payload(path, payload, fields)
-        gsm8k_score = gsm8k_scores.get(
-            int(payload.get("max_concurrency", fields["conc"]))
-        )
+        conc = int(payload.get("max_concurrency", fields["conc"]))
+        gsm8k_score = gsm8k_scores.get((topology_key(fields["topology"]), conc))
+        if gsm8k_score is None:
+            gsm8k_score = gsm8k_scores.get(("", conc))
         gsm8k = gsm8k_score.get("value") if gsm8k_score else None
         if gsm8k_score is not None:
             payload["gsm8k"] = gsm8k
@@ -482,7 +495,15 @@ def eval_concurrency(path: Path) -> int | None:
     return None
 
 
-def find_eval_scores(root: Path) -> dict[int, dict[str, Any]]:
+def eval_topology(path: Path) -> str:
+    for part in reversed(path.parts):
+        match = EVAL_TOPOLOGY_RE.search(part)
+        if match:
+            return match.group("topology").replace("-", "_").lower()
+    return ""
+
+
+def find_eval_scores(root: Path) -> dict[tuple[str, int], dict[str, Any]]:
     scores = {}
     for path in sorted(root.rglob("results*.json")):
         payload = read_json(path)
@@ -506,7 +527,10 @@ def find_eval_scores(root: Path) -> dict[int, dict[str, Any]]:
         )
         score = number(score_raw)
         if score is not None:
-            scores[conc] = {"value": round(score, 4), "raw": f"{score:.4f}"}
+            scores[(eval_topology(path), conc)] = {
+                "value": round(score, 4),
+                "raw": f"{score:.4f}",
+            }
     return scores
 
 

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -118,7 +118,7 @@ env:
   ATOMESH_2P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes != '' && inputs.atomesh_2p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47') }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd') }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -20,8 +20,8 @@ on:
     # TW weekend nightly at 21:00 Beijing time (13:00 UTC).
     - cron: '0 13 * * 6'
     - cron: '0 13 * * 0'
-    # Spur nightly at 23:00 Beijing time (15:00 UTC).
-    - cron: '0 15 * * *'
+    # Spur nightly at 00:10 Beijing time (16:10 UTC).
+    - cron: '10 16 * * *'
   workflow_dispatch:
     inputs:
       suite:
@@ -109,16 +109,16 @@ on:
         type: boolean
 
 env:
-  ATOMESH_SLURM_ACCOUNT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_account != '' && inputs.atomesh_slurm_account || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'amd-frameworks') }}
-  ATOMESH_SLURM_PARTITION: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_partition != '' && inputs.atomesh_slurm_partition || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'amd-frameworks') }}
-  ATOMESH_SLURM_SUBMIT_RUNNER: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd') }}
-  ATOMESH_LOG_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_log_root != '' && inputs.atomesh_log_root || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/${USER}/logs/ATOMESH_LOG/' || '/it-share/ATOMESH_LOG/') }}
-  ATOMESH_MODEL_ROOT: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/models2' || '/mnt/models' }}
-  ATOMESH_1P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes != '' && inputs.atomesh_1p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'mia1-p02-g42,mia1-p02-g44') }}
-  ATOMESH_2P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes != '' && inputs.atomesh_2p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47') }}
+  ATOMESH_SLURM_ACCOUNT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_account != '' && inputs.atomesh_slurm_account || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'amd-frameworks') }}
+  ATOMESH_SLURM_PARTITION: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_partition != '' && inputs.atomesh_slurm_partition || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'amd-frameworks') }}
+  ATOMESH_SLURM_SUBMIT_RUNNER: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd') }}
+  ATOMESH_LOG_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_log_root != '' && inputs.atomesh_log_root || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/${USER}/logs/ATOMESH_LOG/' || '/it-share/ATOMESH_LOG/') }}
+  ATOMESH_MODEL_ROOT: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/models2' || '/mnt/models' }}
+  ATOMESH_1P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes != '' && inputs.atomesh_1p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'mia1-p02-g42,mia1-p02-g44') }}
+  ATOMESH_2P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes != '' && inputs.atomesh_2p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47') }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd') }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd') }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -17,10 +17,11 @@ on:
       - '.github/scripts/atomesh/**'
       - '.github/workflows/atomesh-benchmark.yaml'
   schedule:
-    # Start weekend nightly runs at 21:00 Beijing time (13:00 UTC).
-    # Runs are expected to occupy the Sat 21:00-Sun 09:00 and Sun 21:00-Mon 09:00 windows.
+    # TW weekend nightly at 21:00 Beijing time (13:00 UTC).
     - cron: '0 13 * * 6'
     - cron: '0 13 * * 0'
+    # Spur nightly at 23:00 Beijing time (15:00 UTC).
+    - cron: '0 15 * * *'
   workflow_dispatch:
     inputs:
       suite:
@@ -56,26 +57,6 @@ on:
         required: false
         default: false
         type: boolean
-      deepseek_v4_pro_model_path:
-        description: 'Model path for DeepSeek-V4-Pro'
-        required: false
-        default: /mnt/models/DeepSeek-V4-Pro/
-        type: string
-      kimi_k25_mxfp4_model_path:
-        description: 'Model path for Kimi-K2.5-MXFP4'
-        required: false
-        default: /mnt/models/Kimi-K2.5-MXFP4/
-        type: string
-      minimax_m3_mxfp4_model_path:
-        description: 'Model path for MiniMax-M3-MXFP4'
-        required: false
-        default: /mnt/models/MiniMax-M3-MXFP4
-        type: string
-      minimax_m3_mxfp8_model_path:
-        description: 'Model path for MiniMax-M3-MXFP8'
-        required: false
-        default: /mnt/models/MiniMax-M3-MXFP8
-        type: string
       atomesh_image:
         description: 'Override ATOM docker image'
         required: false
@@ -84,12 +65,12 @@ on:
       atomesh_slurm_account:
         description: 'Slurm account'
         required: false
-        default: amd-frameworks
+        default: ''
         type: string
       atomesh_slurm_partition:
         description: 'Slurm partition'
         required: false
-        default: amd-frameworks
+        default: ''
         type: string
       atomesh_slurm_submit_runner:
         description: 'GitHub runner label used to submit Slurm jobs'
@@ -99,17 +80,17 @@ on:
       atomesh_log_root:
         description: 'Root directory for ATOMesh Slurm logs'
         required: false
-        default: /it-share/ATOMESH_LOG/
+        default: ''
         type: string
       atomesh_1p1d_nodes:
-        description: 'Comma-separated ATOMesh 1P1D nodes'
+        description: 'Optional comma-separated ATOMesh 1P1D nodes'
         required: false
-        default: mia1-p02-g42,mia1-p02-g44
+        default: ''
         type: string
       atomesh_2p1d_nodes:
-        description: 'Comma-separated ATOMesh 2P1D nodes'
+        description: 'Optional comma-separated ATOMesh 2P1D nodes'
         required: false
-        default: mia1-p02-g42,mia1-p02-g44,mia1-p02-g47
+        default: ''
         type: string
       benchmark_concurrency:
         description: 'Optional benchmark concurrency override, e.g. 1,2,4 (no quotes)'
@@ -128,12 +109,13 @@ on:
         type: boolean
 
 env:
-  ATOMESH_SLURM_ACCOUNT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_account || 'amd-frameworks' }}
-  ATOMESH_SLURM_PARTITION: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_partition || 'amd-frameworks' }}
-  ATOMESH_SLURM_SUBMIT_RUNNER: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || 'atomesh-cicd' }}
-  ATOMESH_LOG_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_log_root || '/it-share/ATOMESH_LOG/' }}
-  ATOMESH_1P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes || 'mia1-p02-g42,mia1-p02-g44' }}
-  ATOMESH_2P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47' }}
+  ATOMESH_SLURM_ACCOUNT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_account != '' && inputs.atomesh_slurm_account || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'amd-frameworks') }}
+  ATOMESH_SLURM_PARTITION: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_partition != '' && inputs.atomesh_slurm_partition || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'amd-frameworks') }}
+  ATOMESH_SLURM_SUBMIT_RUNNER: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd') }}
+  ATOMESH_LOG_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_log_root != '' && inputs.atomesh_log_root || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/${USER}/logs/ATOMESH_LOG/' || '/it-share/ATOMESH_LOG/') }}
+  ATOMESH_MODEL_ROOT: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/models2' || '/mnt/models' }}
+  ATOMESH_1P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes != '' && inputs.atomesh_1p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'mia1-p02-g42,mia1-p02-g44') }}
+  ATOMESH_2P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes != '' && inputs.atomesh_2p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '0 15 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47') }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -167,10 +149,6 @@ jobs:
           RUN_KIMI_K25_MXFP4: ${{ github.event_name == 'workflow_dispatch' && inputs.run_kimi_k25_mxfp4 || false }}
           RUN_MINIMAX_M3_MXFP4: ${{ github.event_name == 'workflow_dispatch' && inputs.run_minimax_m3_mxfp4 || false }}
           RUN_MINIMAX_M3_MXFP8: ${{ github.event_name == 'workflow_dispatch' && inputs.run_minimax_m3_mxfp8 || false }}
-          ATOMESH_MODEL_PATH_DEEPSEEK_V4_PRO: ${{ github.event_name == 'workflow_dispatch' && inputs.deepseek_v4_pro_model_path || '' }}
-          ATOMESH_MODEL_PATH_KIMI_K2_5_MXFP4: ${{ github.event_name == 'workflow_dispatch' && inputs.kimi_k25_mxfp4_model_path || '' }}
-          ATOMESH_MODEL_PATH_MINIMAX_M3_MXFP4: ${{ github.event_name == 'workflow_dispatch' && inputs.minimax_m3_mxfp4_model_path || '' }}
-          ATOMESH_MODEL_PATH_MINIMAX_M3_MXFP8: ${{ github.event_name == 'workflow_dispatch' && inputs.minimax_m3_mxfp8_model_path || '' }}
           ATOMESH_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_image || '' }}
           ATOMESH_BENCHMARK_CONCURRENCY: ${{ github.event_name == 'workflow_dispatch' && inputs.benchmark_concurrency || '' }}
           ATOMESH_EVAL_CONCURRENCY: ${{ github.event_name == 'workflow_dispatch' && inputs.eval_concurrency || '' }}
@@ -259,8 +237,22 @@ jobs:
         env:
           CELL_JSON: ${{ toJson(matrix) }}
           RESULT_DIR: atomesh-results
+          SLURM_SUBMIT_RUNNER: ${{ matrix.runner.slurm_submit_runner }}
         run: |
           set -euo pipefail
+          ORIGINAL_WORKSPACE="${GITHUB_WORKSPACE}"
+          if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
+            SHARED_WORKSPACE="/data/$(id -un)/atomesh-ci/${GITHUB_RUN_ID}/${{ matrix.id }}"
+            rm -rf "${SHARED_WORKSPACE}"
+            mkdir -p "${SHARED_WORKSPACE}"
+            if command -v rsync >/dev/null 2>&1; then
+              rsync -a --delete "${ORIGINAL_WORKSPACE}/" "${SHARED_WORKSPACE}/"
+            else
+              tar -C "${ORIGINAL_WORKSPACE}" -cf - . | tar -C "${SHARED_WORKSPACE}" -xf -
+            fi
+            cd "${SHARED_WORKSPACE}"
+            RESULT_DIR="${ORIGINAL_WORKSPACE}/${RESULT_DIR}"
+          fi
           chmod +x .github/scripts/atomesh/*.sh .github/scripts/atomesh/*.py
           bash .github/scripts/atomesh/pd_submit.sh \
             --cell-json "$CELL_JSON" \

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -254,6 +254,18 @@ jobs:
             RESULT_DIR="${ORIGINAL_WORKSPACE}/${RESULT_DIR}"
           fi
           chmod +x .github/scripts/atomesh/*.sh .github/scripts/atomesh/*.py
+          SLURM_CANCEL_HELPER="${RESULT_DIR}/${{ matrix.id }}.slurm-cancel.sh"
+          cancel_slurm_from_wrapper() {
+            local rc=$?
+            if [[ "${rc}" -ne 0 && -x "${SLURM_CANCEL_HELPER}" ]]; then
+              echo "=== cancelling Slurm job from workflow wrapper rc=${rc} ==="
+              bash "${SLURM_CANCEL_HELPER}" || true
+            fi
+            exit "${rc}"
+          }
+          trap cancel_slurm_from_wrapper EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
           bash .github/scripts/atomesh/pd_submit.sh \
             --cell-json "$CELL_JSON" \
             --result-dir "$RESULT_DIR"

--- a/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
+++ b/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
@@ -67,6 +67,23 @@ MOONCAKE_DEFAULT_PROTOCOL = "rdma"
 PREFILL_LOOKUP_TIMEOUT = 60
 PREFILL_LOOKUP_POLL_INTERVAL = 0.01
 
+
+def _ib_device_exists(device_name: str) -> bool:
+    return os.path.exists(f"/sys/class/infiniband/{device_name}")
+
+
+def _auto_select_ib_device(phys_idx: int) -> str:
+    # Older environments expose paired HCAs as rdmaN. Spur MI350 fabric exposes
+    # them as ionic_N, so try ionic_N only when rdmaN is not present.
+    rdma_device = f"rdma{phys_idx}"
+    if _ib_device_exists(rdma_device):
+        return rdma_device
+    ionic_device = f"ionic_{phys_idx}"
+    if _ib_device_exists(ionic_device):
+        return ionic_device
+    return rdma_device
+
+
 # ZMQ side-channel message types
 MSG_WRITE_REQUEST = b"write_request"
 MSG_WRITE_DONE = b"write_done"
@@ -293,7 +310,8 @@ class MooncakeConnector(KVConnectorBase):
             )
 
         # Determine which RDMA device this TP rank should use.
-        # On AMD MI300X, each GPU has a paired RDMA NIC: GPU N → rdmaN.
+        # AMD GPU nodes pair GPU N with NIC N, but the HCA name is cluster
+        # dependent: Spur MI350 exposes ionic_N while older setups used rdmaN.
         # Registering GPU memory with a non-local RDMA NIC fails with
         # EINVAL.  Pass the device name as a filter so Mooncake only
         # creates a context for the local NIC.
@@ -310,7 +328,7 @@ class MooncakeConnector(KVConnectorBase):
                 phys_idx = int(visible_list[visible_idx])
             else:
                 phys_idx = visible_idx
-            ib_device = f"rdma{phys_idx}"
+            ib_device = _auto_select_ib_device(phys_idx)
             logger.info(
                 "Auto-selecting RDMA device %s for physical GPU %d "
                 "(visible_idx=%d, tp_rank=%d)",


### PR DESCRIPTION
### Summary

- Add Spur cluster benchmark support
- Select TW or Spur model roots and nightly schedules from the runner label 
    - atomesh-cicd for MI355X, and atomesh-cicd-mi350 for MI350X.
- [fix Mooncake RDMA device auto-selection](https://github.com/ROCm/ATOM/pull/1475/changes/8db43a59c39c768c53d844acdee5a4a4ab4652fe)
- Considering Spur cluster resources, configure 4 runners to execute benchmark jobs concurrently.

## CI Runs

https://github.com/ROCm/ATOM/actions/runs/28844135493