### PR TITLE
Fix sglang minimax m3 cuda graph capture problem

### DIFF
--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -106,7 +106,7 @@
   {
     "model_name": "MiniMax-M3-MXFP4 TP4",
     "model_path": "amd/MiniMax-M3-MXFP4",
-    "extraArgs": "--tensor-parallel-size 4 --attention-backend aiter --page-size 128 --mem-fraction-static 0.8 --max-running-requests 128 --disable-radix-cache",
+    "extraArgs": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --page-size 128 --mem-fraction-static 0.8 --max-running-requests 128 --disable-radix-cache",
     "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models",
     "runner": "atom-mi355-8gpu-conductor-sgl-runner",
     "test_level": "nightly",

--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -106,7 +106,7 @@
   {
     "model_name": "MiniMax-M3-MXFP4 TP4",
     "model_path": "amd/MiniMax-M3-MXFP4",
-    "extraArgs": "--tensor-parallel-size 4 --attention-backend triton --page-size 128 --mem-fraction-static 0.75 --max-running-requests 128 --disable-radix-cache --disable-cuda-graph",
+    "extraArgs": "--tensor-parallel-size 4 --attention-backend aiter --page-size 128 --mem-fraction-static 0.8 --max-running-requests 128 --disable-radix-cache",
     "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models",
     "runner": "atom-mi355-8gpu-conductor-sgl-runner",
     "test_level": "nightly",

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -340,7 +340,7 @@ jobs:
                   "toggle_env": "RUN_MINIMAX_M3_MXFP4_TP4",
                   "model_name": "MiniMax-M3-MXFP4 TP4",
                   "model_path": "amd/MiniMax-M3-MXFP4",
-                  "extra_args": "--tensor-parallel-size 4 --attention-backend aiter --page-size 128 --mem-fraction-static 0.8 --max-running-requests 128 --disable-radix-cache",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --page-size 128 --mem-fraction-static 0.8 --max-running-requests 128 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models",
                   "runner": "atom-plugin-acc-validation-runner",

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -340,7 +340,7 @@ jobs:
                   "toggle_env": "RUN_MINIMAX_M3_MXFP4_TP4",
                   "model_name": "MiniMax-M3-MXFP4 TP4",
                   "model_path": "amd/MiniMax-M3-MXFP4",
-                  "extra_args": "--tensor-parallel-size 4 --attention-backend triton --page-size 128 --mem-fraction-static 0.75 --max-running-requests 128 --disable-radix-cache --disable-cuda-graph",
+                  "extra_args": "--tensor-parallel-size 4 --attention-backend aiter --page-size 128 --mem-fraction-static 0.8 --max-running-requests 128 --disable-radix-cache",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models",
                   "runner": "atom-plugin-acc-validation-runner",

--- a/atom/plugin/sglang/attention_backend/minimax_m3_sparse.py
+++ b/atom/plugin/sglang/attention_backend/minimax_m3_sparse.py
@@ -11,6 +11,13 @@ import triton.language as tl
 SPARSE_BLOCK_SIZE = 128
 
 
+def _is_stream_capturing() -> bool:
+    try:
+        return bool(torch.cuda.is_current_stream_capturing())
+    except Exception:
+        return False
+
+
 @dataclass
 class MiniMaxM3SGLangMetadata:
     """Per-forward SGLang metadata for MiniMax-M3 sparse attention."""
@@ -614,8 +621,11 @@ def build_minimax_m3_block_table(forward_batch, page_size: int) -> torch.Tensor:
             offset += query_len
 
     seq_lens = _slice_i32(forward_batch.seq_lens, batch_size)
-    max_seq_len = int(seq_lens.max().item()) if batch_size else 0
-    max_blocks = (max_seq_len + page_size - 1) // page_size
+    if _is_stream_capturing() and forward_batch.forward_mode.is_decode_or_idle():
+        max_blocks = int(token_table.shape[1]) // page_size
+    else:
+        max_seq_len = int(seq_lens.max().item()) if batch_size else 0
+        max_blocks = (max_seq_len + page_size - 1) // page_size
     block_table = token_table[:, : max_blocks * page_size : page_size] // page_size
     return block_table.to(dtype=torch.int32).contiguous()
 
@@ -630,7 +640,10 @@ def build_minimax_m3_forward_metadata(
     validate_minimax_m3_page_size(page_size)
     batch_size = _get_batch_size(forward_batch)
     seq_lens = _slice_i32(forward_batch.seq_lens, batch_size)
-    max_seq_len = int(seq_lens.max().item()) if batch_size else 0
+    if _is_stream_capturing() and forward_batch.forward_mode.is_decode_or_idle():
+        max_seq_len = int(block_table.shape[1]) * page_size
+    else:
+        max_seq_len = int(seq_lens.max().item()) if batch_size else 0
 
     if forward_batch.forward_mode.is_decode_or_idle():
         return MiniMaxM3SGLangMetadata(
@@ -717,14 +730,21 @@ def _insert_sparse_cache(
     page_size = _get_page_size(forward_batch)
     slot_mapping = forward_batch.out_cache_loc[: key.shape[0]].to(dtype=torch.long)
     valid = slot_mapping >= 0
-
-    slots = slot_mapping[valid]
+    is_capture = _is_stream_capturing()
+    if is_capture:
+        # CUDA graph capture uses fixed-size decode batches; boolean compaction
+        # launches a dynamic-shape HIP op that is not graph-capture safe.
+        slots = slot_mapping
+        key = key.view(-1, layer.num_kv_heads, layer.head_dim)
+        value = value.view(-1, layer.num_kv_heads, layer.head_dim)
+        index_key = index_key.view(-1, layer.idx_head_dim)
+    else:
+        slots = slot_mapping[valid]
+        key = key.view(-1, layer.num_kv_heads, layer.head_dim)[valid]
+        value = value.view(-1, layer.num_kv_heads, layer.head_dim)[valid]
+        index_key = index_key.view(-1, layer.idx_head_dim)[valid]
     block_ids = torch.div(slots, page_size, rounding_mode="floor")
     block_offsets = slots % page_size
-
-    key = key.view(-1, layer.num_kv_heads, layer.head_dim)[valid]
-    value = value.view(-1, layer.num_kv_heads, layer.head_dim)[valid]
-    index_key = index_key.view(-1, layer.idx_head_dim)[valid]
     key_cache[block_ids, block_offsets] = key.to(key_cache.dtype)
     value_cache[block_ids, block_offsets] = value.to(value_cache.dtype)
     index_cache[block_ids, block_offsets] = index_key.to(index_cache.dtype)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fix Minimax M3 cuda graph capture problem. 
1. `.item()` introduces D2H synchronization
2. `max_blocks` 、 `max_seq_len` and `slot_mapping[valid]` depend on runtime data, which cause dynamic shape

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

### server
```shell
model_path=${model_path:-amd/MiniMax-M3-MXFP4}
PORT=${PORT:-8000}
TP=${TP:-4}

python3 -m sglang.launch_server \
    --model-path "${model_path}" \
    --host 127.0.0.1 \
    --port "${PORT}" \
    --trust-remote-code \
    --tensor-parallel-size "${TP}" \
    --attention-backend aiter \
    --mem-fraction-static 0.8 \
    --page-size 128 \
    --context-length 32768 \
    --max-running-requests 128 \
    --disable-radix-cache 2>&1 | tee minimax-m3-mxfp4-sglang-server.log
```
### gsm8k
```shell
BS=65

lm_eval \
    --model local-chat-completions \
    --model_args "model=${model_path},base_url=http://127.0.0.1:${PORT}/v1/chat/completions,num_concurrent=32,max_gen_toks=16384" \
    --tasks gsm8k \
    --num_fewshot 5 \
    --batch_size "${BS}" \
    --apply_chat_template \
    --fewshot_as_multiturn 2>&1 | tee minimax-m3-mxfp4-sglang-gsm8k.log
```
## Test Result

<!-- Briefly summarize test outcomes. -->

### accuracy
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9401|±  |0.0065|
|     |       |strict-match    |     5|exact_match|↑  |0.9409|±  |0.0065|

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
