### PR TITLE
feat: set process titles for engine/worker processes

### DIFF
--- a/atom/model_engine/async_proc.py
+++ b/atom/model_engine/async_proc.py
@@ -32,6 +32,7 @@ from atom.utils import (
     init_exit_handler,
     make_zmq_socket,
     resolve_obj_by_qualname,
+    set_process_title,
     shutdown_all_processes,
 )
 from atom.utils.numa_utils import numa_bind_to_node
@@ -86,6 +87,16 @@ class AsyncIOProc:
         except Exception as e:
             logger.warning(f"AsyncIOProc({label}): NUMA bind skipped: {e}")
         self.label = f"AsyncIOProc({label})"
+        # Set process title so this GPU worker is distinguishable by rank in
+        # ps/top/rocm-smi (otherwise all workers show as "python").
+        try:
+            cfg = args[0]
+            if cfg.parallel_config.data_parallel_size > 1:
+                set_process_title(f"DP{cfg.parallel_config.data_parallel_rank}TP{rank}")
+            else:
+                set_process_title(f"TP{rank}")
+        except Exception:
+            set_process_title(f"TP{rank}")
         self.io_addrs = io_addrs
         self.io_queues = queue.Queue(), queue.Queue()
         self.io_threads: list[threading.Thread] = []

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -17,7 +17,12 @@ from atom.model_engine.async_proc import AsyncIOProcManager
 from atom.model_engine.engine_utility import EngineUtilityHandler
 from atom.model_engine.scheduler import Scheduler
 from atom.model_engine.sequence import Sequence, SequenceStatus, get_exit_sequence
-from atom.utils import envs, init_exit_handler, make_zmq_socket
+from atom.utils import (
+    envs,
+    init_exit_handler,
+    make_zmq_socket,
+    set_process_title,
+)
 from atom.utils.distributed.utils import (
     stateless_destroy_torch_distributed_process_group,
 )
@@ -196,8 +201,12 @@ class EngineCore:
         engine: EngineCore = None
         try:
             if config.parallel_config.data_parallel_size > 1:
+                set_process_title(
+                    f"EngineCore_DP{config.parallel_config.data_parallel_rank}"
+                )
                 engine = DPEngineCoreProc(config, input_address, output_address)
             else:
+                set_process_title("EngineCore")
                 engine = EngineCore(config, input_address, output_address)
             engine.busy_loop()
         except Exception as e:

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -171,6 +171,29 @@ def get_mp_context() -> Union[ForkContext, SpawnContext]:
     return multiprocessing.get_context("spawn")
 
 
+def set_process_title(
+    name: str, suffix: str = "", prefix: Optional[str] = None
+) -> None:
+    """Set the current process title (comm/cmdline) for ps/top/rocm-smi.
+
+    rocm-smi --showpids reads the process ``comm`` field, which defaults to the
+    interpreter name (``python``). Setting a title makes GPU-holding worker
+    processes distinguishable by rank. Soft dependency: no-op if setproctitle
+    is not installed.
+    """
+    try:
+        import setproctitle
+    except ImportError:
+        return
+    from atom.utils import envs
+
+    if prefix is None:
+        prefix = envs.ATOM_PROCESS_NAME_PREFIX
+    if suffix:
+        name = f"{name}_{suffix}"
+    setproctitle.setproctitle(f"{prefix}::{name}")
+
+
 def shutdown_all_processes(procs: list[BaseProcess], allowed_seconds: int = 2):
     # First join any already-exited processes (instant, no wait).
     for proc in procs:

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -28,6 +28,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DP_SIZE": lambda: int(os.getenv("ATOM_DP_SIZE", "1")),
     "ATOM_DP_MASTER_IP": lambda: os.getenv("ATOM_DP_MASTER_IP", "127.0.0.1"),
     "ATOM_DP_MASTER_PORT": lambda: int(os.getenv("ATOM_DP_MASTER_PORT", "29500")),
+    # Prefix for process titles set via set_process_title (shown in ps/top/rocm-smi)
+    "ATOM_PROCESS_NAME_PREFIX": lambda: os.getenv("ATOM_PROCESS_NAME_PREFIX", "ATOM"),
     # --- Compilation & Execution ---
     "ATOM_USE_TRITON_GEMM": lambda: os.getenv("ATOM_USE_TRITON_GEMM", "0") == "1",
     "ATOM_USE_TRITON_MXFP4_BMM": lambda: (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "a lightweight vLLM implementation built from scratch"
 requires-python = ">=3.10"
 dynamic = ["version"]
-dependencies = ["pybind11", "transformers==5.2.0", "zmq", "msgspec", "xxhash", "fastapi>=0.115,<0.137", "psutil", "protobuf", "uvicorn", "uvloop", "aiohttp", "datasets", "openpyxl", "tqdm"]
+dependencies = ["pybind11", "transformers==5.2.0", "zmq", "msgspec", "xxhash", "fastapi>=0.115,<0.137", "psutil", "protobuf", "uvicorn", "uvloop", "aiohttp", "datasets", "openpyxl", "tqdm", "setproctitle"]
 
 [project.urls]
 Homepage = "https://github.com/ROCm/ATOM"


### PR DESCRIPTION
## Background

In `rocm-smi --showpids` / `ps` / `top`, all of ATOM's child processes show up as `python`, so there is no way to tell the EngineCore apart from the per-TP-rank GPU workers. For comparison, SGLang (`sglang::scheduler_TP*`) and vLLM (`VLLM::Worker_TP*`) both rename their processes via `setproctitle`. Root cause: rocm-smi reads the kernel `comm` field (`ps -o comm=`), which ATOM never sets, so spawned children keep the default interpreter name.

## Changes (mirrors vLLM's `set_process_title` helper)

- Add `set_process_title(name, suffix, prefix)` in `atom/utils/__init__.py`: soft dependency on setproctitle (no-op if not installed), format `{prefix}::{name}`
- Add env `ATOM_PROCESS_NAME_PREFIX` (default `ATOM`)
- `EngineCore.run_engine` → `ATOM::EngineCore` (`ATOM::EngineCore_DP{n}` when DP>1)
- Each GPU worker (`AsyncIOProc`) → `ATOM::TP{rank}` (`ATOM::DP{d}TP{rank}` when DP>1)
- Add `setproctitle` to `pyproject.toml` dependencies

## Effect / verification

After starting gpt-oss-120b (tp=1), `ps -eo pid,comm,args`:

```
ATOM::EngineCor   ATOM::EngineCore   # comm truncated at the 15-char limit; cmdline is full
ATOM::TP0         ATOM::TP0          # worker, fully visible
```

`cat /proc/<worker>/comm` → `ATOM::TP0`. Names are shorter than 15 chars, so the rank is not lost to comm truncation.

## Test plan

- [x] `black --check` + `ruff check` pass
- [x] Import smoke test of changed modules
- [x] Real server start + `ps` / `/proc/comm` verification of process names
- [ ] (optional) follow-up: name the main HTTP process `ATOM::APIServer` (not changed here; it does not hold GPU)