### PR TITLE
ci(benchmark): disable prefix cache for dsv4 nightly, drop index cache

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -42,7 +42,7 @@
       "config": {
         "tp": 8,
         "kv_cache_dtype": "fp8",
-        "extra_args": "--hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}'"
+        "extra_args": "--no-enable_prefix_caching"
       },
       "variants": [
         { "label": "", "suffix": "", "conc_max": 256 },


### PR DESCRIPTION
## What

Update the DeepSeek-V4-Pro nightly benchmark config in `.github/benchmark/models.json`:

```diff
- "extra_args": "--hf-overrides '{\"use_index_cache\": true, \"index_topk_freq\": 4}'"
+ "extra_args": "--no-enable_prefix_caching"
```

## Why

- Drop `use_index_cache` from the dsv4 nightly benchmark as requested.
- `index_topk_freq` is only consumed by `_should_skip_v4_index_topk`, which early-returns when `use_index_cache` is off — it is a no-op without `use_index_cache`, so the whole `--hf-overrides` is removed rather than left orphaned.
- Add `--no-enable_prefix_caching` to disable prefix caching (same flag already used by the qwen35 / minimax entries; validated in `atom/model_engine/arg_utils.py`).

## Scope

Only the base `config.extra_args` is changed. Per `catalog.py` (`build_args`: `[config.extra_args] [variant.extra_args]`), the base is inherited by all variants (MTP3 / DPA / DPA-TBO / DPA-MTP3), which only append their own args — none of them re-declare `use_index_cache`.

## Test plan

- [x] `models.json` parses as valid JSON
- [x] Confirmed dsv4 base `extra_args` == `--no-enable_prefix_caching`
- [ ] Nightly benchmark run picks up the new config