### PR TITLE
fix(moe): auto-degrade FP8 block_n/k from 128 to 64 on alignment mismatch (#442)

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1408,16 +1408,49 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
         # Check block alignment for block quantization
         if self.block_quant:
             tp_size = get_tp_group().world_size
+            # Auto-degrade block_n to 64 when the per-partition intermediate
+            # size is not divisible by 128 (e.g. intermediate_size=1536 at
+            # TP=8 → 192 per partition, which 128 does not divide).
+            if (
+                self.quant_type == QuantType.per_1x128
+                and intermediate_size_per_partition % self.block_n != 0
+                and intermediate_size_per_partition % 64 == 0
+            ):
+                logger.warning(
+                    "Block quantisation block_n=%d does not divide "
+                    "intermediate_size_per_partition=%d (world_size=%d). "
+                    "Automatically degrading block_n from %d to 64.",
+                    self.block_n,
+                    intermediate_size_per_partition,
+                    tp_size,
+                    self.block_n,
+                )
+                self.block_n = 64
             if intermediate_size_per_partition % self.block_n != 0:
                 raise ValueError(
                     f"intermediate_size_per_partition={intermediate_size_per_partition} "
                     f"must be divisible by block_n={self.block_n}"
                 )
             if tp_size > 1 and intermediate_size_per_partition % self.block_k != 0:
-                raise ValueError(
-                    f"intermediate_size_per_partition={intermediate_size_per_partition} "
-                    f"must be divisible by block_k={self.block_k}"
-                )
+                if (
+                    self.quant_type == QuantType.per_1x128
+                    and intermediate_size_per_partition % 64 == 0
+                ):
+                    logger.warning(
+                        "Block quantisation block_k=%d does not divide "
+                        "intermediate_size_per_partition=%d (world_size=%d). "
+                        "Automatically degrading block_k from %d to 64.",
+                        self.block_k,
+                        intermediate_size_per_partition,
+                        tp_size,
+                        self.block_k,
+                    )
+                    self.block_k = 64
+                else:
+                    raise ValueError(
+                        f"intermediate_size_per_partition={intermediate_size_per_partition} "
+                        f"must be divisible by block_k={self.block_k}"
+                    )
 
         # WEIGHTS
         w13_weight = atom_parameter(
@@ -1769,6 +1802,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             self.quant_type == QuantType.per_1x128
             or self.quant_type == QuantType.per_1x32
         )
+        # Block sizes for block quantization
+        if self.block_quant:
+            if self.quant_type == QuantType.per_1x128:
+                self.block_n = 128
+                self.block_k = 128
+            elif self.quant_type == QuantType.per_1x32:
+                self.block_n = 1
+                self.block_k = 32
         self.channel_quant = self.quant_type == QuantType.per_Token
         self.need_normalize_e4m3fn_to_e4m3fnuz = (
             self.quant_dtype == torch.float8_e4m3fnuz
@@ -1787,35 +1828,62 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         intermediate_size_for_weight = intermediate_size_per_partition
 
         if self.block_quant:
-            if self.quant_type == QuantType.per_1x128:
-                block_n = 128
-                block_k = 128
-            elif self.quant_type == QuantType.per_1x32:
-                block_n = 1
-                block_k = 32
             tp_size = get_tp_group().world_size
+            # Auto-degrade block_n to 64 when the per-partition intermediate
+            # size is not divisible by 128 (e.g. intermediate_size=1536 at
+            # TP=8 → 192 per partition, which 128 does not divide).
+            if (
+                self.quant_type == QuantType.per_1x128
+                and intermediate_size_per_partition % self.block_n != 0
+                and intermediate_size_per_partition % 64 == 0
+            ):
+                logger.warning(
+                    "Block quantisation block_n=%d does not divide "
+                    "intermediate_size_per_partition=%d (world_size=%d). "
+                    "Automatically degrading block_n from %d to 64.",
+                    self.block_n,
+                    intermediate_size_per_partition,
+                    tp_size,
+                    self.block_n,
+                )
+                self.block_n = 64
             # NOTE: To ensure proper alignment of the block-wise quantization
             # scales, the output_size of the weights for both the gate and up
             # layers must be divisible by block_n.
             # Required by column parallel or enabling merged weights
-            if intermediate_size_per_partition % block_n != 0:
+            if intermediate_size_per_partition % self.block_n != 0:
                 raise ValueError(
                     f"The output_size of gate's and up's weight = "
                     f"{intermediate_size_per_partition} is not divisible by "
-                    f"weight quantization block_n = {block_n}."
+                    f"weight quantization block_n = {self.block_n}."
                 )
-            if tp_size > 1 and intermediate_size_per_partition % block_k != 0:
+            if tp_size > 1 and intermediate_size_per_partition % self.block_k != 0:
                 # Required by row parallel
-                raise ValueError(
-                    f"The input_size of down's weight = "
-                    f"{intermediate_size_per_partition} is not divisible by "
-                    f"weight quantization block_k = {block_k}."
-                )
+                if (
+                    self.quant_type == QuantType.per_1x128
+                    and intermediate_size_per_partition % 64 == 0
+                ):
+                    logger.warning(
+                        "Block quantisation block_k=%d does not divide "
+                        "intermediate_size_per_partition=%d (world_size=%d). "
+                        "Automatically degrading block_k from %d to 64.",
+                        self.block_k,
+                        intermediate_size_per_partition,
+                        tp_size,
+                        self.block_k,
+                    )
+                    self.block_k = 64
+                else:
+                    raise ValueError(
+                        f"The input_size of down's weight = "
+                        f"{intermediate_size_per_partition} is not divisible by "
+                        f"weight quantization block_k = {self.block_k}."
+                    )
             if self.quant_type == QuantType.per_1x32:
                 # aiter's GU-interleaved MXFP8 scale shuffle packs 8 scale
                 # columns, i.e. 256 weight columns for 1x32 scales. TP8 on
                 # MiniMax-M3 has local intermediate=384, so pad to 512.
-                scale_pack_k = block_k * 8
+                scale_pack_k = self.block_k * 8
                 intermediate_size_for_weight = (
                     (intermediate_size_per_partition + scale_pack_k - 1)
                     // scale_pack_k
@@ -1868,13 +1936,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         elif self.block_quant:
             scale_shape_w13 = (
                 num_experts,
-                2 * ((intermediate_size_for_weight + block_n - 1) // block_n),
-                (hidden_size + block_k - 1) // block_k,
+                2 * ((intermediate_size_for_weight + self.block_n - 1) // self.block_n),
+                (hidden_size + self.block_k - 1) // self.block_k,
             )
             scale_shape_w2 = (
                 num_experts,
-                (hidden_size + block_n - 1) // block_n,
-                (intermediate_size_for_weight + block_k - 1) // block_k,
+                (hidden_size + self.block_n - 1) // self.block_n,
+                (intermediate_size_for_weight + self.block_k - 1) // self.block_k,
             )
             # MXFP8 checkpoints store 1x32 scales as e8m0 bytes. Keep the
             # existing float32 initialization for the original 1x128 path.
@@ -2073,12 +2141,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             # V4-Flash-Base on gfx942 hits this: routed experts are FP8 e4m3
             # per_1x128 + UE8M0 block-scale.
             if self.block_quant:
-                if self.quant_type == QuantType.per_1x128:
-                    block_shape = [128, 128]
-                elif self.quant_type == QuantType.per_1x32:
-                    block_shape = [1, 32]
-                else:
-                    block_shape = None
+                block_shape = [self.block_n, self.block_k]
             else:
                 block_shape = None
             return fp8_w8a8_moe_quant_config(

--- a/tests/test_fp8_moe_block_align.py
+++ b/tests/test_fp8_moe_block_align.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Regression test for FP8 MoE block_n/block_k alignment auto-degradation (#442).
+
+Root cause:
+  Models with intermediate_size=1536 at TP=8 produce
+  intermediate_size_per_partition=192, which is not divisible by
+  block_n=128 or block_k=128 (the defaults for per_1x128 quantisation).
+  Both CompressedTensorsFp8MoEMethod and Fp8MoEMethod raise ValueError.
+
+Fix (Option B from #442 analysis):
+  When intermediate_size_per_partition is not divisible by 128 but
+  *is* divisible by 64, auto-degrade block_n and/or block_k to 64
+  and emit a logger warning.  The ValueErrors are preserved when
+  alignment is still impossible (e.g. 190 % 64 != 0).
+"""
+
+import logging
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("aiter", reason="needs the AITER GPU kernel library")
+
+# ---------- saved-modules snapshots for isolation ----------
+_saved_atom_modules: dict[str, object] = {}
+
+
+def setUpModule():
+    global _saved_atom_modules
+    _saved_atom_modules = {
+        name: mod for name, mod in sys.modules.items() if name.startswith("atom")
+    }
+    for name in list(_saved_atom_modules):
+        del sys.modules[name]
+
+
+def tearDownModule():
+    for name in [n for n in sys.modules if n.startswith("atom")]:
+        del sys.modules[name]
+    sys.modules.update(_saved_atom_modules)
+
+
+# ---------- helpers ----------
+
+
+def _make_compressed_tensors_method(quant_type=None):
+    """Return a CompressedTensorsFp8MoEMethod with default per_1x128."""
+    import torch
+    from aiter import QuantType
+    from atom.config import LayerQuantConfig
+    from atom.model_ops.moe import CompressedTensorsFp8MoEMethod
+
+    qt = quant_type if quant_type is not None else QuantType.per_1x128
+    qc = LayerQuantConfig(
+        quant_type=qt,
+        quant_dtype=torch.float8_e4m3fn,
+        quant_method="compressed-tensors",
+        is_dynamic=True,
+    )
+    moe_config = MagicMock()
+    return CompressedTensorsFp8MoEMethod(qc, moe_config)
+
+
+def _make_fp8_method(quant_type=None):
+    """Return a Fp8MoEMethod with default per_1x128."""
+    import torch
+    from aiter import QuantType
+    from atom.config import LayerQuantConfig
+    from atom.model_ops.moe import Fp8MoEMethod
+
+    qt = quant_type if quant_type is not None else QuantType.per_1x128
+    qc = LayerQuantConfig(
+        quant_type=qt,
+        quant_dtype=torch.float8_e4m3fn,
+        quant_method="online_quant",
+        is_dynamic=True,
+    )
+    moe_config = MagicMock()
+    return Fp8MoEMethod(qc, moe_config)
+
+
+def _make_mock_layer(hidden_size=7168):
+    """Create a mock layer with register_parameter spy."""
+    layer = MagicMock()
+    layer.hidden_size = hidden_size
+    layer.intermediate_size_per_partition = 192
+    layer.activation = "silu"
+    layer.has_bias = False
+    registered = {}
+
+    def _reg(name, param):
+        registered[name] = param
+
+    layer.register_parameter = _reg
+    return layer, registered
+
+
+def _tp_mock(world_size=1):
+    """Return a mock tensor-parallel group."""
+    mg = MagicMock()
+    mg.world_size = world_size
+    return mg
+
+
+# ---------- CompressedTensorsFp8MoEMethod tests ----------
+
+
+class TestCompressedTensorsFp8MoEAutoDegrade(unittest.TestCase):
+    """block_n=128 → 64 when intermediate % 128 != 0 and % 64 == 0."""
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_degrades_to_64_on_alignment_mismatch(self, mock_tp):
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=1)
+
+        method = _make_compressed_tensors_method()
+        self.assertEqual(method.block_n, 128)
+        self.assertEqual(method.block_k, 128)
+
+        layer, _registered = _make_mock_layer()
+
+        with self.assertLogs(logger="atom", level="WARNING") as log_ctx:
+            method.create_weights(
+                layer=layer,
+                num_experts=8,
+                hidden_size=7168,
+                intermediate_size_per_partition=192,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+
+        self.assertEqual(method.block_n, 64)
+        self.assertGreaterEqual(len(log_ctx.output), 1)
+        warning_text = log_ctx.output[0].lower()
+        self.assertIn("block_n", warning_text)
+        self.assertIn("64", warning_text)
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_degrade_block_k_at_tp_gt_1(self, mock_tp):
+        """block_k also degrades when tp_size > 1."""
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=8)
+
+        method = _make_compressed_tensors_method()
+        layer, _registered = _make_mock_layer()
+
+        with self.assertLogs(logger="atom", level="WARNING") as log_ctx:
+            method.create_weights(
+                layer=layer,
+                num_experts=8,
+                hidden_size=7168,
+                intermediate_size_per_partition=192,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+
+        self.assertEqual(method.block_n, 64)
+        self.assertEqual(method.block_k, 64)
+        # Should see warnings for both block_n and block_k
+        self.assertGreaterEqual(len(log_ctx.output), 2)
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_keeps_128_when_aligned(self, mock_tp):
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=1)
+
+        method = _make_compressed_tensors_method()
+        layer, _registered = _make_mock_layer()
+
+        with self.assertNoLogs(logger="atom", level="WARNING"):
+            method.create_weights(
+                layer=layer,
+                num_experts=8,
+                hidden_size=7168,
+                intermediate_size_per_partition=256,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+
+        self.assertEqual(method.block_n, 128)
+        self.assertEqual(method.block_k, 128)
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_raises_when_no_safe_degradation_possible(self, mock_tp):
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=1)
+
+        method = _make_compressed_tensors_method()
+        layer, _registered = _make_mock_layer()
+
+        with self.assertRaises(ValueError):
+            method.create_weights(
+                layer=layer,
+                num_experts=8,
+                hidden_size=7168,
+                intermediate_size_per_partition=190,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_per_1x32_not_affected(self, mock_tp):
+        import torch
+        from aiter import QuantType
+
+        mock_tp.return_value = _tp_mock(world_size=8)
+
+        method = _make_compressed_tensors_method(quant_type=QuantType.per_1x32)
+        self.assertEqual(method.block_n, 1)
+
+        layer, _registered = _make_mock_layer()
+
+        method.create_weights(
+            layer=layer,
+            num_experts=8,
+            hidden_size=7168,
+            intermediate_size_per_partition=192,
+            params_dtype=torch.float4_e2m1fn_x2,
+            weight_loader=lambda *a: None,
+        )
+        self.assertEqual(method.block_n, 1)
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_scale_shapes_after_degrade(self, mock_tp):
+        """Scale tensor shapes must use the degraded block_n=64 (tp=1)."""
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=1)
+
+        method = _make_compressed_tensors_method()
+        layer, registered = _make_mock_layer()
+
+        method.create_weights(
+            layer=layer,
+            num_experts=8,
+            hidden_size=7168,
+            intermediate_size_per_partition=192,
+            params_dtype=torch.float8_e4m3fn,
+            weight_loader=lambda *a: None,
+        )
+
+        w13_scale = registered["w13_weight_scale"]
+        w2_scale = registered["w2_weight_scale"]
+
+        # block_n=64, block_k=128 (tp=1 skips block_k check):
+        # w13_scale: (E, 2 * ceil(192/64), ceil(7168/128)) = (8, 6, 56)
+        # w2_scale:  (E, ceil(7168/64), ceil(192/128))      = (8, 112, 2)
+        self.assertEqual(w13_scale.shape, (8, 6, 56))
+        self.assertEqual(w2_scale.shape, (8, 112, 2))
+
+
+# ---------- Fp8MoEMethod tests ----------
+
+
+class TestFp8MoEAutoDegrade(unittest.TestCase):
+    """block_n=128 → 64 when intermediate % 128 != 0 and % 64 == 0."""
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_degrades_to_64_on_alignment_mismatch(self, mock_tp):
+        import torch
+        from aiter import QuantType
+
+        mock_tp.return_value = _tp_mock(world_size=1)
+
+        method = _make_fp8_method()
+        self.assertEqual(method.quant_type, QuantType.per_1x128)
+
+        layer, _registered = _make_mock_layer()
+
+        with self.assertLogs(logger="atom", level="WARNING") as log_ctx:
+            method.create_weights(
+                layer=layer,
+                num_experts=8,
+                hidden_size=7168,
+                intermediate_size_per_partition=192,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+
+        self.assertGreaterEqual(len(log_ctx.output), 1)
+        warning_text = log_ctx.output[0].lower()
+        self.assertIn("block_n", warning_text)
+        self.assertIn("64", warning_text)
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_keeps_128_when_aligned(self, mock_tp):
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=1)
+
+        method = _make_fp8_method()
+        layer, _registered = _make_mock_layer()
+
+        with self.assertNoLogs(logger="atom", level="WARNING"):
+            method.create_weights(
+                layer=layer,
+                num_experts=8,
+                hidden_size=7168,
+                intermediate_size_per_partition=256,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_raises_when_no_safe_degradation_possible(self, mock_tp):
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=1)
+
+        method = _make_fp8_method()
+        layer, _registered = _make_mock_layer()
+
+        with self.assertRaises(ValueError):
+            method.create_weights(
+                layer=layer,
+                num_experts=8,
+                hidden_size=7168,
+                intermediate_size_per_partition=190,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_scale_shapes_after_degrade(self, mock_tp):
+        """Scale tensor shapes must use the degraded block_n=64 (tp=1)."""
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=1)
+
+        method = _make_fp8_method()
+        layer, registered = _make_mock_layer()
+
+        method.create_weights(
+            layer=layer,
+            num_experts=8,
+            hidden_size=7168,
+            intermediate_size_per_partition=192,
+            params_dtype=torch.float8_e4m3fn,
+            weight_loader=lambda *a: None,
+        )
+
+        w13_scale = registered["w13_weight_scale"]
+        w2_scale = registered["w2_weight_scale"]
+
+        # block_n=64, block_k=128 (tp=1 skips block_k check):
+        self.assertEqual(w13_scale.shape, (8, 6, 56))
+        self.assertEqual(w2_scale.shape, (8, 112, 2))
+
+
+# ---------- Real-world scenario tests ----------
+
+
+class TestTP8Scenarios(unittest.TestCase):
+    """Simulate the TP=8 scenario from #442 report."""
+
+    INTERMEDIATE_PER_TP8 = 192  # 1536 / 8
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_compressed_tensors_method_tp8_1536(self, mock_tp):
+        """CompressedTensorsFp8MoEMethod must not raise at TP=8, 1536."""
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=8)
+
+        method = _make_compressed_tensors_method()
+        layer, _registered = _make_mock_layer()
+
+        try:
+            method.create_weights(
+                layer=layer,
+                num_experts=128,
+                hidden_size=7168,
+                intermediate_size_per_partition=self.INTERMEDIATE_PER_TP8,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+        except ValueError:
+            self.fail(
+                "CompressedTensorsFp8MoEMethod raised ValueError at "
+                "TP=8, intermediate=1536 — auto-degradation failed"
+            )
+        self.assertEqual(method.block_n, 64)
+        self.assertEqual(method.block_k, 64)
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_fp8_method_tp8_1536(self, mock_tp):
+        """Fp8MoEMethod must not raise at TP=8, 1536."""
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=8)
+
+        method = _make_fp8_method()
+        layer, _registered = _make_mock_layer()
+
+        try:
+            method.create_weights(
+                layer=layer,
+                num_experts=128,
+                hidden_size=7168,
+                intermediate_size_per_partition=self.INTERMEDIATE_PER_TP8,
+                params_dtype=torch.float8_e4m3fn,
+                weight_loader=lambda *a: None,
+            )
+        except ValueError:
+            self.fail(
+                "Fp8MoEMethod raised ValueError at "
+                "TP=8, intermediate=1536 — auto-degradation failed"
+            )
+
+    @patch("atom.model_ops.moe.get_tp_group")
+    def test_scale_shapes_tp8(self, mock_tp):
+        """Scale shapes after both block_n and block_k degrade at TP=8."""
+        import torch
+
+        mock_tp.return_value = _tp_mock(world_size=8)
+
+        method = _make_compressed_tensors_method()
+        layer, registered = _make_mock_layer()
+
+        method.create_weights(
+            layer=layer,
+            num_experts=8,
+            hidden_size=7168,
+            intermediate_size_per_partition=192,
+            params_dtype=torch.float8_e4m3fn,
+            weight_loader=lambda *a: None,
+        )
+
+        w13_scale = registered["w13_weight_scale"]
+        w2_scale = registered["w2_weight_scale"]
+
+        # Both block_n and block_k degrade to 64:
+        # w13_scale: (8, 2 * ceil(192/64), ceil(7168/64)) = (8, 6, 112)
+        # w2_scale:  (8, ceil(7168/64), ceil(192/64))      = (8, 112, 3)
+        self.assertEqual(w13_scale.shape, (8, 6, 112))
+        self.assertEqual(w2_scale.shape, (8, 112, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Models with `intermediate_size=1536` (MiniMax M2.5, Qwen3-235B) at TP=8 produce `intermediate_size_per_partition=192`, which is not divisible by `block_n=128` (the default for `per_1x128` block quantisation). Both `CompressedTensorsFp8MoEMethod` and `Fp8MoEMethod` raise `ValueError`, forcing users to fall back to TP=4 and waste 4 GPUs.

The existing error:
```
ValueError: The output_size of gate's and up's weight = 192 is not divisible by weight quantization block_n = 128.
```

Additionally, after fixing `block_n`, `block_k=128` also fails at TP=8 (`192 % 128 != 0`), which was masked by the earlier `block_n` error.

## Fix (Option B from #442)

When `intermediate_size_per_partition` is not divisible by 128 but **is** divisible by 64, auto-degrade `block_n` and/or `block_k` to 64 and emit a `logger.warning`. The `ValueError` is preserved when alignment is truly impossible (e.g. `190 % 64 != 0`).

### Changes

- **`CompressedTensorsFp8MoEMethod.create_weights`**: auto-degrade `self.block_n` and `self.block_k` before alignment checks.
- **`Fp8MoEMethod.__init__`**: initialise `self.block_n`/`self.block_k` instance attributes (were local variables in `create_weights` only).
- **`Fp8MoEMethod.create_weights`**: auto-degrade both block sizes using instance attributes.
- **`Fp8MoEMethod.get_fused_moe_quant_config`**: use `[self.block_n, self.block_k]` instead of hardcoded `[128, 128]` that would mismatch the degraded scale shapes.
- **`tests/test_fp8_moe_block_align.py`**: 13 unit tests covering degrade path, aligned path, impossible alignment, `per_1x32` no-op, scale shape correctness, `block_k` degradation at TP>1, and full TP=8/1536 end-to-end scenarios.

## Validation

- **13/13 tests passed on MI300X** (gfx942, ROCm 7.1, Python 3.12, aiter 0.1.1.dev1)
- scale shapes verified: `block_n=block_k=64` → `w13_scale=(E, 6, 112)`, `w2_scale=(E, 112, 3)` for 192 intermediate at TP=8
- existing TP=4 / aligned paths unchanged

Refs: #442