### PR TITLE
[fix OOM][Sparse MLA] chunked indexer and online topk to reduce the mem foorprint of logits tensor

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1252,7 +1252,11 @@ def sparse_attn_indexer(
         # budget is disabled (0) or a single chunk fits, the loop runs exactly
         # once and matches the original single-shot behavior.
         budget_bytes = SPARSE_INDEXER_LOGITS_BUDGET_MB * 1024 * 1024
-        if budget_bytes > 0 and total_kv > 0 and budget_bytes // (total_kv * 4) < num_rows:
+        if (
+            budget_bytes > 0
+            and total_kv > 0
+            and budget_bytes // (total_kv * 4) < num_rows
+        ):
             # 4 bytes per fp32 logit; total_kv * 4 is one query row's footprint.
             # Round the budget-derived row count DOWN to keep the buffer within
             # budget: a multiple of 128 (aligned to the kernel's row tiling) in

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -127,7 +127,7 @@ ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_F
 ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION = (
     envs.ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
 )
-SPARSE_INDEXER_CHUNK_TOKENS = envs.ATOM_SPARSE_INDEXER_CHUNK_TOKENS
+SPARSE_INDEXER_LOGITS_BUDGET_MB = envs.ATOM_SPARSE_INDEXER_LOGITS_BUDGET_MB
 _FP8_DTYPES = tuple(
     dtype
     for dtype in (
@@ -1115,100 +1115,6 @@ class DeepseekV32IndexerCache(nn.Module):
         self.dtype = dtype
 
 
-def _fp8_mqa_topk_prefill_chunked(
-    q_fp8: torch.Tensor,
-    k_fp8: torch.Tensor,
-    k_scale: torch.Tensor,
-    weights: torch.Tensor,
-    cu_seqlen_ks: torch.Tensor,
-    cu_seqlen_ke: torch.Tensor,
-    topk_tokens: int,
-    chunk_tokens: int,
-    out: torch.Tensor,
-) -> None:
-    """Compute the sparse-indexer prefill top-k without materializing the full
-    ``[prefill_tokens, total_kv]`` logits buffer, writing indices into ``out``.
-
-    The indexer is block-diagonal per request (query row ``i`` is only valid
-    within ``[cu_seqlen_ks[i], cu_seqlen_ke[i])``), yet ``fp8_mqa_logits``
-    allocates a dense ``[rows, total_kv]`` fp32 matrix. ``total_kv`` is the sum
-    of all co-scheduled prefill contexts and is NOT bounded by
-    ``max_num_batched_tokens``, so a concurrency burst of long-context requests
-    can drive a single allocation to tens of GiB (GLM-5.2 OOM #1376). Chunking
-    along KV and merging per-row top-k across chunks caps the peak to
-    ``[rows, chunk_tokens]``. Selection stays exact: each ``logit(i, j)`` is an
-    independent ``q_i·k_j`` dot, so chunking KV and merging by value yields the
-    same global top-k.
-
-    ``out`` (shape ``[num_rows, topk_tokens]``, int32) is used directly as the
-    running index accumulator, so the final result lands there in place — no
-    extra allocation or copy back in the caller.
-    """
-    num_rows = q_fp8.shape[0]
-    total_kv = k_fp8.shape[0]
-    device = q_fp8.device
-    best_values = torch.full(
-        (num_rows, topk_tokens), -float("inf"), dtype=torch.float32, device=device
-    )
-    # Use the caller's output buffer as the running index accumulator.
-    best_indices = out
-    best_indices.fill_(-1)
-
-    for chunk_start in range(0, total_kv, chunk_tokens):
-        chunk_end = min(chunk_start + chunk_tokens, total_kv)
-        chunk_len = chunk_end - chunk_start
-        # Rebase each row's [start, end) window into this chunk's local column
-        # space; rows whose window misses the chunk collapse to an empty range.
-        local_starts = (cu_seqlen_ks - chunk_start).clamp_(0, chunk_len).to(torch.int32)
-        local_ends = (cu_seqlen_ke - chunk_start).clamp_(0, chunk_len).to(torch.int32)
-
-        logits = fp8_mqa_logits(
-            Q=q_fp8,
-            KV=k_fp8[chunk_start:chunk_end],
-            kv_scales=k_scale[chunk_start:chunk_end],
-            weights=weights,
-            cu_starts=local_starts,
-            cu_ends=local_ends,
-        )
-
-        chunk_indices = torch.full(
-            (num_rows, topk_tokens), -1, dtype=torch.int32, device=device
-        )
-        chunk_values = torch.full(
-            (num_rows, topk_tokens), -float("inf"), dtype=torch.float32, device=device
-        )
-        # The kernel emits -1 index sentinels and 0-valued padding for rows
-        # shorter than topk_tokens. Read values straight from the kernel's
-        # output buffer (no re-gather from logits) and mask the padding back to
-        # -inf via the index sentinel so it never wins the cross-chunk merge.
-        top_k_per_row_prefill(
-            logits=logits,
-            rowStarts=local_starts,
-            rowEnds=local_ends,
-            indices=chunk_indices,
-            values=chunk_values,
-            numRows=num_rows,
-            stride0=logits.stride(0),
-            stride1=logits.stride(1),
-        )
-        chunk_values = torch.where(
-            chunk_indices < 0,
-            torch.full_like(chunk_values, -float("inf")),
-            chunk_values,
-        )
-        # Local chunk column -> global concatenated-KV offset; -1 stays -1.
-        chunk_indices = torch.where(
-            chunk_indices < 0, chunk_indices, chunk_indices + chunk_start
-        )
-
-        # merged_indices is a fresh cat (separate storage from best_indices), so
-        # gathering back into best_indices=out is alias-safe.
-        merged_values = torch.cat((best_values, chunk_values), dim=1)
-        merged_indices = torch.cat((best_indices, chunk_indices), dim=1)
-        best_values, merge_positions = torch.topk(merged_values, k=topk_tokens, dim=1)
-        torch.gather(merged_indices, 1, merge_positions, out=best_indices)
-
-
 def sparse_attn_indexer(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
@@ -1334,37 +1240,54 @@ def sparse_attn_indexer(
         # The dense logits buffer is [num_rows, total_kv] fp32. total_kv is the
         # sum of all co-scheduled prefill contexts and is unbounded by
         # max_num_batched_tokens, so a burst of long-context requests can push a
-        # single allocation to tens of GiB (#1376). Chunk along KV once total_kv
-        # exceeds the budget; short contexts keep the single-shot fast path.
-        chunk_tokens = SPARSE_INDEXER_CHUNK_TOKENS
-        if chunk_tokens > 0 and total_kv > chunk_tokens:
-            _fp8_mqa_topk_prefill_chunked(
-                q_fp8=q_prefill,
-                k_fp8=k_fp8,
-                k_scale=k_scale,
-                weights=weights_prefill,
-                cu_seqlen_ks=cu_seqlen_ks,
-                cu_seqlen_ke=cu_seqlen_ke,
-                topk_tokens=topk_tokens,
-                chunk_tokens=chunk_tokens,
-                out=topk_indices_prefill,
-            )
+        # single allocation to tens of GiB (#1376). Under chunked prefill
+        # num_rows is already capped by max_num_batched_tokens, so the OOM is
+        # driven by total_kv (the column dim). Chunk along the Q (query-row)
+        # dimension with q_chunk sized so the buffer [q_chunk, total_kv] fp32
+        # stays within the memory budget — q_chunk shrinks as total_kv grows.
+        # Each chunk still scores the FULL KV, so every row's top-k is computed
+        # completely in one shot: the result is exact with no cross-chunk merge,
+        # the kernel's column indices are already global (no remapping), and each
+        # chunk writes straight into its output row slice (no copy). When the
+        # budget is disabled (0) or a single chunk fits, the loop runs exactly
+        # once and matches the original single-shot behavior.
+        budget_bytes = SPARSE_INDEXER_LOGITS_BUDGET_MB * 1024 * 1024
+        if budget_bytes > 0 and total_kv > 0 and budget_bytes // (total_kv * 4) < num_rows:
+            # 4 bytes per fp32 logit; total_kv * 4 is one query row's footprint.
+            # Round the budget-derived row count DOWN to keep the buffer within
+            # budget: a multiple of 128 (aligned to the kernel's row tiling) in
+            # the normal regime, avoiding the coarse power-of-2 doubling. When
+            # the budget affords < 128 rows (extreme total_kv), fall back to a
+            # power-of-2 floor so it degrades to 64/32/.../1 instead of
+            # collapsing straight to 1.
+            budget_rows = budget_bytes // (total_kv * 4)
+            if budget_rows >= 128:
+                chunk_tokens = (budget_rows // 128) * 128
+            else:
+                chunk_tokens = 1 << (max(1, budget_rows).bit_length() - 1)
         else:
+            # Budget disabled, or a single chunk already fits all rows.
+            chunk_tokens = num_rows
+        for chunk_start in range(0, num_rows, chunk_tokens):
+            chunk_end = min(chunk_start + chunk_tokens, num_rows)
+            # Per-row window bounds slice 1:1 with this chunk's rows.
+            row_starts = cu_seqlen_ks[chunk_start:chunk_end]
+            row_ends = cu_seqlen_ke[chunk_start:chunk_end]
             logits = fp8_mqa_logits(
-                Q=q_prefill,
+                Q=q_prefill[chunk_start:chunk_end],
                 KV=k_fp8,
                 kv_scales=k_scale,
-                weights=weights_prefill,
-                cu_starts=cu_seqlen_ks,
-                cu_ends=cu_seqlen_ke,
+                weights=weights_prefill[chunk_start:chunk_end],
+                cu_starts=row_starts,
+                cu_ends=row_ends,
             )
             top_k_per_row_prefill(
                 logits=logits,
-                rowStarts=cu_seqlen_ks,
-                rowEnds=cu_seqlen_ke,
-                indices=topk_indices_prefill,
+                rowStarts=row_starts,
+                rowEnds=row_ends,
+                indices=topk_indices_prefill[chunk_start:chunk_end],
                 values=None,
-                numRows=num_rows,
+                numRows=chunk_end - chunk_start,
                 stride0=logits.stride(0),
                 stride1=logits.stride(1),
             )

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1124,9 +1124,10 @@ def _fp8_mqa_topk_prefill_chunked(
     cu_seqlen_ke: torch.Tensor,
     topk_tokens: int,
     chunk_tokens: int,
-) -> torch.Tensor:
+    out: torch.Tensor,
+) -> None:
     """Compute the sparse-indexer prefill top-k without materializing the full
-    ``[prefill_tokens, total_kv]`` logits buffer.
+    ``[prefill_tokens, total_kv]`` logits buffer, writing indices into ``out``.
 
     The indexer is block-diagonal per request (query row ``i`` is only valid
     within ``[cu_seqlen_ks[i], cu_seqlen_ke[i])``), yet ``fp8_mqa_logits``
@@ -1138,6 +1139,10 @@ def _fp8_mqa_topk_prefill_chunked(
     ``[rows, chunk_tokens]``. Selection stays exact: each ``logit(i, j)`` is an
     independent ``q_i·k_j`` dot, so chunking KV and merging by value yields the
     same global top-k.
+
+    ``out`` (shape ``[num_rows, topk_tokens]``, int32) is used directly as the
+    running index accumulator, so the final result lands there in place — no
+    extra allocation or copy back in the caller.
     """
     num_rows = q_fp8.shape[0]
     total_kv = k_fp8.shape[0]
@@ -1145,9 +1150,9 @@ def _fp8_mqa_topk_prefill_chunked(
     best_values = torch.full(
         (num_rows, topk_tokens), -float("inf"), dtype=torch.float32, device=device
     )
-    best_indices = torch.full(
-        (num_rows, topk_tokens), -1, dtype=torch.int32, device=device
-    )
+    # Use the caller's output buffer as the running index accumulator.
+    best_indices = out
+    best_indices.fill_(-1)
 
     for chunk_start in range(0, total_kv, chunk_tokens):
         chunk_end = min(chunk_start + chunk_tokens, total_kv)
@@ -1196,12 +1201,12 @@ def _fp8_mqa_topk_prefill_chunked(
             chunk_indices < 0, chunk_indices, chunk_indices + chunk_start
         )
 
+        # merged_indices is a fresh cat (separate storage from best_indices), so
+        # gathering back into best_indices=out is alias-safe.
         merged_values = torch.cat((best_values, chunk_values), dim=1)
         merged_indices = torch.cat((best_indices, chunk_indices), dim=1)
         best_values, merge_positions = torch.topk(merged_values, k=topk_tokens, dim=1)
-        best_indices = torch.gather(merged_indices, 1, merge_positions)
-
-    return best_indices
+        torch.gather(merged_indices, 1, merge_positions, out=best_indices)
 
 
 def sparse_attn_indexer(
@@ -1333,17 +1338,16 @@ def sparse_attn_indexer(
         # exceeds the budget; short contexts keep the single-shot fast path.
         chunk_tokens = SPARSE_INDEXER_CHUNK_TOKENS
         if chunk_tokens > 0 and total_kv > chunk_tokens:
-            topk_indices_prefill.copy_(
-                _fp8_mqa_topk_prefill_chunked(
-                    q_fp8=q_prefill,
-                    k_fp8=k_fp8,
-                    k_scale=k_scale,
-                    weights=weights_prefill,
-                    cu_seqlen_ks=cu_seqlen_ks,
-                    cu_seqlen_ke=cu_seqlen_ke,
-                    topk_tokens=topk_tokens,
-                    chunk_tokens=chunk_tokens,
-                )
+            _fp8_mqa_topk_prefill_chunked(
+                q_fp8=q_prefill,
+                k_fp8=k_fp8,
+                k_scale=k_scale,
+                weights=weights_prefill,
+                cu_seqlen_ks=cu_seqlen_ks,
+                cu_seqlen_ke=cu_seqlen_ke,
+                topk_tokens=topk_tokens,
+                chunk_tokens=chunk_tokens,
+                out=topk_indices_prefill,
             )
         else:
             logits = fp8_mqa_logits(

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -127,6 +127,7 @@ ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_F
 ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION = (
     envs.ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION
 )
+SPARSE_INDEXER_CHUNK_TOKENS = envs.ATOM_SPARSE_INDEXER_CHUNK_TOKENS
 _FP8_DTYPES = tuple(
     dtype
     for dtype in (
@@ -1114,6 +1115,95 @@ class DeepseekV32IndexerCache(nn.Module):
         self.dtype = dtype
 
 
+def _fp8_mqa_topk_prefill_chunked(
+    q_fp8: torch.Tensor,
+    k_fp8: torch.Tensor,
+    k_scale: torch.Tensor,
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    topk_tokens: int,
+    chunk_tokens: int,
+) -> torch.Tensor:
+    """Compute the sparse-indexer prefill top-k without materializing the full
+    ``[prefill_tokens, total_kv]`` logits buffer.
+
+    The indexer is block-diagonal per request (query row ``i`` is only valid
+    within ``[cu_seqlen_ks[i], cu_seqlen_ke[i])``), yet ``fp8_mqa_logits``
+    allocates a dense ``[rows, total_kv]`` fp32 matrix. ``total_kv`` is the sum
+    of all co-scheduled prefill contexts and is NOT bounded by
+    ``max_num_batched_tokens``, so a concurrency burst of long-context requests
+    can drive a single allocation to tens of GiB (GLM-5.2 OOM #1376). Chunking
+    along KV and merging per-row top-k across chunks caps the peak to
+    ``[rows, chunk_tokens]``. Selection stays exact: each ``logit(i, j)`` is an
+    independent ``q_i·k_j`` dot, so chunking KV and merging by value yields the
+    same global top-k.
+    """
+    num_rows = q_fp8.shape[0]
+    total_kv = k_fp8.shape[0]
+    device = q_fp8.device
+    best_values = torch.full(
+        (num_rows, topk_tokens), -float("inf"), dtype=torch.float32, device=device
+    )
+    best_indices = torch.full(
+        (num_rows, topk_tokens), -1, dtype=torch.int32, device=device
+    )
+
+    for chunk_start in range(0, total_kv, chunk_tokens):
+        chunk_end = min(chunk_start + chunk_tokens, total_kv)
+        chunk_len = chunk_end - chunk_start
+        # Rebase each row's [start, end) window into this chunk's local column
+        # space; rows whose window misses the chunk collapse to an empty range.
+        local_starts = (cu_seqlen_ks - chunk_start).clamp_(0, chunk_len).to(torch.int32)
+        local_ends = (cu_seqlen_ke - chunk_start).clamp_(0, chunk_len).to(torch.int32)
+
+        logits = fp8_mqa_logits(
+            Q=q_fp8,
+            KV=k_fp8[chunk_start:chunk_end],
+            kv_scales=k_scale[chunk_start:chunk_end],
+            weights=weights,
+            cu_starts=local_starts,
+            cu_ends=local_ends,
+        )
+
+        chunk_indices = torch.full(
+            (num_rows, topk_tokens), -1, dtype=torch.int32, device=device
+        )
+        chunk_values = torch.full(
+            (num_rows, topk_tokens), -float("inf"), dtype=torch.float32, device=device
+        )
+        # The kernel emits -1 index sentinels and 0-valued padding for rows
+        # shorter than topk_tokens. Read values straight from the kernel's
+        # output buffer (no re-gather from logits) and mask the padding back to
+        # -inf via the index sentinel so it never wins the cross-chunk merge.
+        top_k_per_row_prefill(
+            logits=logits,
+            rowStarts=local_starts,
+            rowEnds=local_ends,
+            indices=chunk_indices,
+            values=chunk_values,
+            numRows=num_rows,
+            stride0=logits.stride(0),
+            stride1=logits.stride(1),
+        )
+        chunk_values = torch.where(
+            chunk_indices < 0,
+            torch.full_like(chunk_values, -float("inf")),
+            chunk_values,
+        )
+        # Local chunk column -> global concatenated-KV offset; -1 stays -1.
+        chunk_indices = torch.where(
+            chunk_indices < 0, chunk_indices, chunk_indices + chunk_start
+        )
+
+        merged_values = torch.cat((best_values, chunk_values), dim=1)
+        merged_indices = torch.cat((best_indices, chunk_indices), dim=1)
+        best_values, merge_positions = torch.topk(merged_values, k=topk_tokens, dim=1)
+        best_indices = torch.gather(merged_indices, 1, merge_positions)
+
+    return best_indices
+
+
 def sparse_attn_indexer(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
@@ -1231,28 +1321,49 @@ def sparse_attn_indexer(
         cu_seqlen_ks = prefill_metadata.cu_seqlen_ks
         cu_seqlen_ke = prefill_metadata.cu_seqlen_ke
         num_tokens = hidden_states.shape[0]
-        logits = fp8_mqa_logits(
-            Q=q_fp8[num_decode_tokens:num_tokens],
-            KV=k_fp8,
-            kv_scales=k_scale,
-            weights=weights[num_decode_tokens:num_tokens],
-            cu_starts=cu_seqlen_ks,
-            cu_ends=cu_seqlen_ke,
-        )
-
-        num_rows = logits.shape[0]
+        q_prefill = q_fp8[num_decode_tokens:num_tokens]
+        weights_prefill = weights[num_decode_tokens:num_tokens]
+        num_rows = q_prefill.shape[0]
         assert topk_tokens == 2048, "top_k_per_row assumes size 2048"
         topk_indices_prefill = topk_indices[num_decode_tokens:num_tokens, :topk_tokens]
-        top_k_per_row_prefill(
-            logits=logits,
-            rowStarts=cu_seqlen_ks,
-            rowEnds=cu_seqlen_ke,
-            indices=topk_indices_prefill,
-            values=None,
-            numRows=num_rows,
-            stride0=logits.stride(0),
-            stride1=logits.stride(1),
-        )
+        # The dense logits buffer is [num_rows, total_kv] fp32. total_kv is the
+        # sum of all co-scheduled prefill contexts and is unbounded by
+        # max_num_batched_tokens, so a burst of long-context requests can push a
+        # single allocation to tens of GiB (#1376). Chunk along KV once total_kv
+        # exceeds the budget; short contexts keep the single-shot fast path.
+        chunk_tokens = SPARSE_INDEXER_CHUNK_TOKENS
+        if chunk_tokens > 0 and total_kv > chunk_tokens:
+            topk_indices_prefill.copy_(
+                _fp8_mqa_topk_prefill_chunked(
+                    q_fp8=q_prefill,
+                    k_fp8=k_fp8,
+                    k_scale=k_scale,
+                    weights=weights_prefill,
+                    cu_seqlen_ks=cu_seqlen_ks,
+                    cu_seqlen_ke=cu_seqlen_ke,
+                    topk_tokens=topk_tokens,
+                    chunk_tokens=chunk_tokens,
+                )
+            )
+        else:
+            logits = fp8_mqa_logits(
+                Q=q_prefill,
+                KV=k_fp8,
+                kv_scales=k_scale,
+                weights=weights_prefill,
+                cu_starts=cu_seqlen_ks,
+                cu_ends=cu_seqlen_ke,
+            )
+            top_k_per_row_prefill(
+                logits=logits,
+                rowStarts=cu_seqlen_ks,
+                rowEnds=cu_seqlen_ke,
+                indices=topk_indices_prefill,
+                values=None,
+                numRows=num_rows,
+                stride0=logits.stride(0),
+                stride1=logits.stride(1),
+            )
         triton_convert_req_index_to_global_index_dsa_prefill(
             attn_metadata.sparse_cu_seqlens_q,
             attn_metadata.sparse_kv_indptr,

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -136,6 +136,7 @@ _V4_USE_REF_QUANT = os.environ.get("V4_USE_REF_QUANT", "0") == "1"
 # Fused-kernel switches. Default off; flip via env to A/B against the eager path.
 _V4_USE_TRITON_FUSION = os.environ.get("ATOM_V4_USE_TRITON_FUSION", "0") == "1"
 ENABLE_DS_QKNORM_QUANT_FUSION = envs.ATOM_ENABLE_DS_QKNORM_QUANT_FUSION
+SPARSE_INDEXER_LOGITS_BUDGET_MB = envs.ATOM_SPARSE_INDEXER_LOGITS_BUDGET_MB
 
 
 def _rmsnorm_nw(x: torch.Tensor, eps: float, dim: int) -> torch.Tensor:
@@ -1312,14 +1313,6 @@ class Indexer(nn.Module):
 
         cu_starts = indexer_meta["cu_starts_gpu"]  # [total_tokens] int32
         cu_ends = indexer_meta["cu_ends_gpu"]  # [total_tokens] int32
-        logits = fp8_mqa_logits(
-            Q=q_fp8,
-            KV=k_fp8,
-            kv_scales=k_scale,
-            weights=weights,
-            cu_starts=cu_starts,
-            cu_ends=cu_ends,
-        )  # [total_tokens, total_committed] fp32; outside [start,end) is -inf
 
         # aiter `top_k_per_row_prefill` (radix kernel, parametric `k` via the
         # pybind kwarg). Honors per-row [cu_starts[i], cu_ends[i]) so cells
@@ -1336,17 +1329,65 @@ class Indexer(nn.Module):
         topk_global = torch.empty(
             (total_tokens, topk), dtype=torch.int32, device=device
         )
-        top_k_per_row_prefill(
-            logits,
-            cu_starts,
-            cu_ends,
-            topk_global,
-            None,  # values not needed, only indices
-            total_tokens,
-            logits.stride(0),
-            logits.stride(1),
-            k=topk,
-        )
+        # The dense `fp8_mqa_logits` buffer is [total_tokens, total_committed]
+        # fp32. total_committed is the sum of all co-scheduled prefill contexts
+        # and is unbounded by max_num_batched_tokens, so a burst of long-context
+        # requests can push a single allocation to tens of GiB (#1376). Under
+        # chunked prefill total_tokens is already capped by
+        # max_num_batched_tokens, so the OOM is driven by total_committed (the
+        # column dim). Chunk along the Q (query-row) dimension with q_chunk sized
+        # so the buffer [q_chunk, total_committed] fp32 stays within the memory
+        # budget — q_chunk shrinks as total_committed grows. Each chunk still
+        # scores the FULL KV, so every row's top-k is computed completely in one
+        # shot: the result is exact with no cross-chunk merge, and the kernel's
+        # global column indices need no remapping (the seq_base subtraction below
+        # is per-token). When the budget is disabled (0) or a single chunk fits,
+        # the loop runs exactly once and matches the original single-shot path.
+        budget_bytes = SPARSE_INDEXER_LOGITS_BUDGET_MB * 1024 * 1024
+        if (
+            budget_bytes > 0
+            and total_committed > 0
+            and budget_bytes // (total_committed * 4) < total_tokens
+        ):
+            # 4 bytes per fp32 logit; total_committed * 4 is one row's footprint.
+            # Round the budget-derived row count DOWN to keep the buffer within
+            # budget: a multiple of 128 (aligned to the kernel's row tiling) in
+            # the normal regime, avoiding the coarse power-of-2 doubling. When
+            # the budget affords < 128 rows (extreme total_committed), fall back
+            # to a power-of-2 floor so it degrades to 64/32/.../1 instead of
+            # collapsing straight to 1.
+            budget_rows = budget_bytes // (total_committed * 4)
+            if budget_rows >= 128:
+                chunk_tokens = (budget_rows // 128) * 128
+            else:
+                chunk_tokens = 1 << (max(1, budget_rows).bit_length() - 1)
+        else:
+            # Budget disabled, or a single chunk already fits all rows.
+            chunk_tokens = total_tokens
+        for chunk_start in range(0, total_tokens, chunk_tokens):
+            chunk_end = min(chunk_start + chunk_tokens, total_tokens)
+            # Per-row window bounds slice 1:1 with this chunk's rows.
+            row_starts = cu_starts[chunk_start:chunk_end]
+            row_ends = cu_ends[chunk_start:chunk_end]
+            logits = fp8_mqa_logits(
+                Q=q_fp8[chunk_start:chunk_end],
+                KV=k_fp8,
+                kv_scales=k_scale,
+                weights=weights[chunk_start:chunk_end],
+                cu_starts=row_starts,
+                cu_ends=row_ends,
+            )  # [chunk, total_committed] fp32; outside [start,end) is -inf
+            top_k_per_row_prefill(
+                logits,
+                row_starts,
+                row_ends,
+                topk_global[chunk_start:chunk_end],
+                None,  # values not needed, only indices
+                chunk_end - chunk_start,
+                logits.stride(0),
+                logits.stride(1),
+                k=topk,
+            )
         seq_base = indexer_meta["seq_base_per_token_gpu"].unsqueeze(
             1
         )  # [total_tokens, 1] int32

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -77,11 +77,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # total_kv = sum of all co-scheduled prefill contexts and is NOT bounded by
     # max_num_batched_tokens, so a concurrency burst of long-context requests
     # can drive a single allocation to tens of GiB (see GLM-5.2 OOM #1376).
-    # When total_kv exceeds this value the indexer chunks along KV and merges
-    # top-k across chunks, capping peak to [prefill_tokens, chunk]. Set to 0 to
-    # disable chunking (always single-shot).
-    "ATOM_SPARSE_INDEXER_CHUNK_TOKENS": lambda: int(
-        os.getenv("ATOM_SPARSE_INDEXER_CHUNK_TOKENS", "65536")
+    # Target peak (in MiB) for the indexer's dense fp32 logits buffer during
+    # prefill. The indexer chunks along the query (Q) dimension so the buffer
+    # stays ~[q_chunk, total_kv] with q_chunk = budget_bytes // (total_kv * 4);
+    # q_chunk shrinks automatically as total_kv (the unbounded KV dimension)
+    # grows. Under chunked prefill num_rows is already capped by
+    # max_num_batched_tokens, so a fixed row count would not adapt to total_kv
+    # (see GLM-5.2 OOM #1376) — a memory budget does. Each chunk still scores
+    # the full KV, so every row's top-k is exact (no cross-chunk merge). Set to
+    # 0 to disable chunking (always single-shot).
+    "ATOM_SPARSE_INDEXER_LOGITS_BUDGET_MB": lambda: int(
+        os.getenv("ATOM_SPARSE_INDEXER_LOGITS_BUDGET_MB", "2048")
     ),
     "ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION", "1") == "1"

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -72,6 +72,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION", "1") == "1"
     ),
+    # DSA sparse-indexer prefill: KV-dimension chunk size (in tokens) for
+    # `fp8_mqa_logits`. The dense logits buffer is [prefill_tokens, total_kv];
+    # total_kv = sum of all co-scheduled prefill contexts and is NOT bounded by
+    # max_num_batched_tokens, so a concurrency burst of long-context requests
+    # can drive a single allocation to tens of GiB (see GLM-5.2 OOM #1376).
+    # When total_kv exceeds this value the indexer chunks along KV and merges
+    # top-k across chunks, capping peak to [prefill_tokens, chunk]. Set to 0 to
+    # disable chunking (always single-shot).
+    "ATOM_SPARSE_INDEXER_CHUNK_TOKENS": lambda: int(
+        os.getenv("ATOM_SPARSE_INDEXER_CHUNK_TOKENS", "65536")
+    ),
     "ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_ALLREDUCE_RMSNORM_FUSION", "1") == "1"
     ),


### PR DESCRIPTION
fix: https://github.com/ROCm/ATOM/issues/1376

GLM5.2 FP8 TP4
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9469|±  |0.0062|
|     |       |strict-match    |    20|exact_match|↑  |0.9477|±  |0.0061|