### PR TITLE
fix(kv): reserve prefill-activation headroom and size KV pool for the tightest TP rank

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1292,9 +1292,45 @@ class ModelRunner:
         non_kv_overhead = peak_torch + cudagraph_overhead + safety_margin
         available_for_kv_budget = budget - non_kv_overhead
 
-        # Physical clamp: never exceed what's actually free on the GPU.
-        # This prevents OOM when other processes share the GPU.
-        available_for_kv = min(available_for_kv_budget, free)
+        # Peak-activation headroom, taken from ACTUAL free memory.
+        #
+        # `peak_torch` is the warmup high-watermark, but it under-protects the
+        # KV pool in two ways: (1) warmup can under-measure the true serving
+        # prefill activation (e.g. DeepSeek-V4 short-circuits its
+        # sparse-attention path under `is_dummy_run`), and (2) it only counts
+        # torch-allocator memory, missing this process's non-torch resident
+        # (NCCL/RCCL comm buffers, HIP context, custom-all-reduce / P2P IPC),
+        # which on TP lands unevenly across ranks (coordinator ranks carry tens
+        # of GB more). Both are already reflected in the per-rank `free`, so
+        # reserving headroom off `free` (not off the utilization budget)
+        # protects the tightest rank from an OOM on the first large prefill.
+        # Fraction is env-tunable. See ROCm/ATOM#1483.
+        prefill_headroom = int(
+            float(os.environ.get("ATOM_KV_PREFILL_HEADROOM_FRAC", "0.08")) * total
+        )
+
+        # Physical clamp: never exceed what is actually free on the GPU (also
+        # prevents OOM when other processes share the GPU) and keep the
+        # prefill-activation headroom in reserve.
+        available_for_kv = min(available_for_kv_budget, free - prefill_headroom)
+
+        # The KV pool must be the SAME size on every TP rank, but per-rank
+        # `free` differs (uneven non-torch overhead above). Size the pool for
+        # the TIGHTEST rank; otherwise heavy ranks overshoot
+        # gpu_memory_utilization and OOM on a large prefill. On balanced setups
+        # the utilization budget still binds on every rank, so this reduces to
+        # a no-op (num_kvcache_blocks unchanged) with no throughput impact.
+        tp_group = get_tp_group()
+        if tp_group.world_size > 1:
+            _min_kv = torch.tensor(
+                [available_for_kv], dtype=torch.int64, device=self.device
+            )
+            torch.distributed.all_reduce(
+                _min_kv,
+                op=torch.distributed.ReduceOp.MIN,
+                group=tp_group.device_group,
+            )
+            available_for_kv = int(_min_kv.item())
 
         torch.set_default_device("cpu")
 


### PR DESCRIPTION
## Motivation

On tensor-parallel runs, `ModelRunner.get_num_blocks()` can size the KV pool too large on the "heavy" ranks, so they overshoot `--gpu-memory-utilization` and OOM on the first large prefill. Under P/D disaggregation this is silent: the prefill worker OOM-crashes and the proxy hangs waiting on the dead engine (see #1483 for the full investigation).

Root cause is in the budget formula:

```python
non_kv_overhead = peak_torch + cudagraph_overhead + safety_margin
available_for_kv = min(budget - non_kv_overhead, free)
```

1. `peak_torch` is the torch-allocator high-watermark from warmup. It **misses this process's non-torch resident memory** — NCCL/RCCL comm buffers, HIP context, custom-all-reduce / P2P IPC — which lands **unevenly across TP ranks** (coordinator ranks carry tens of GB more; measured ~34 GB on rank 0/1 for DeepSeek-V4-Pro, and it is *not* weights: `peak_torch` is identical across ranks, and *not* RCCL: NCCL_DEBUG shows ~10 GB/rank uniform). It can also under-measure the true serving prefill activation when warmup runs a reduced path (DeepSeek-V4 short-circuits its sparse-attention dispatch under `is_dummy_run`).

2. Because the utilization budget binds uniformly, every rank computes the same block count — sized for the *lightest* rank. The heavy ranks then overshoot the target (observed post-init: **99% vs an 85% target**) and OOM on the first prefill whose activation doesn't fit.

## Change

Reserve peak-activation headroom off the **actual per-rank `free`** (not off the utilization budget), then `all_reduce(MIN)` across the TP group so the uniform KV pool is sized for the **tightest** rank:

```python
prefill_headroom = int(float(os.environ.get("ATOM_KV_PREFILL_HEADROOM_FRAC", "0.08")) * total)
available_for_kv = min(available_for_kv_budget, free - prefill_headroom)
# all_reduce(MIN) available_for_kv across the TP group  (no-op when the budget binds on every rank)
```

On balanced setups the utilization budget still binds on every rank, so `available_for_kv` is unchanged and the `all_reduce(MIN)` is a no-op — `num_kvcache_blocks` is unchanged and there is no throughput impact. On imbalanced setups the heavy rank's smaller `free` binds, so the pool is sized conservatively enough to leave real prefill headroom (or, if the request cache genuinely cannot fit, the existing "reduce `--max-num-seqs`" error fires at init instead of a mid-serving OOM).

The headroom fraction is env-tunable via `ATOM_KV_PREFILL_HEADROOM_FRAC` (default `0.08`).

## Test Result

8×MI355X (gfx950), `deepseek-ai/DeepSeek-V4-Pro`, bf16 KV:

**Aggregated TP=8 (balanced) — no perf drop:**
- `num_kvcache_blocks`: 49230 → 49228 (0.004% — the `all_reduce(MIN)` picking the true-min rank; util budget still binds).
- output throughput c64: 2231 → 2195 tok/s; c256: ~4999 → 5304 tok/s (within run-to-run noise; fewer prompts in the spot re-run).

**TP=4 P/D (imbalanced) — OOM fixed:**
- Original config (`--max-num-seqs 512`, util 0.85, default chunk): previously *started then OOM-crashed the prefill worker at c=16* (silent hang). Now **fails fast at init** with the actionable "reduce `--max-num-seqs`" message.
- With `--max-num-seqs 128` (as the message suggests) at **default** `attn-prefill-chunk-size`: serves c=16 cleanly at 12.8 req/s, prefill worker stays alive (0 OOM events) — no chunked-prefill workaround needed.

## Notes / follow-ups

- This addresses the sizing/robustness side. The complementary fix — warming up DeepSeek-V4 without `is_dummy_run` (or adding an explicit sparse-attention activation reserve) so `peak_torch` reflects the true prefill peak — is left for a separate change.
- Draft: the `0.08` default headroom fraction is a heuristic; happy to tune it or derive it from `max_num_batched_tokens` if preferred.

Refs #1483
