### PR TITLE
[fix](llama): support llama-405B quant type

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -698,13 +698,28 @@ class LinearBase(nn.Module):
         # Re-quantize before process_weights if online quantization is enabled
         if self.quant_config is not None and self.quant_config.online_quant:
             self.online_quantize_weight()
-        if (
-            self.quant_type == QuantType.per_Tensor
-            and len(self.output_partition_sizes) > 1
+        if self.quant_type == QuantType.per_Tensor and (
+            len(self.output_partition_sizes) > 1
+            or hasattr(self, "_loaded_weight_scale_for_requant")
+            or hasattr(self, "_loaded_weight_scale_for_requant_parts")
         ):
+            loaded_weight_scale = getattr(
+                self, "_loaded_weight_scale_for_requant", None
+            )
+            loaded_weight_scale_parts = getattr(
+                self, "_loaded_weight_scale_for_requant_parts", None
+            )
+            if loaded_weight_scale is None and loaded_weight_scale_parts is not None:
+                if all(part is not None for part in loaded_weight_scale_parts):
+                    loaded_weight_scale = torch.cat(loaded_weight_scale_parts, dim=0)
+            weight_scale_for_requant = (
+                loaded_weight_scale
+                if loaded_weight_scale is not None
+                else self.weight_scale.data
+            )
             weight_scale, weight = requantize_with_max_scale(
                 weight=self.weight.data,
-                weight_scale=self.weight_scale.data,
+                weight_scale=weight_scale_for_requant.to(self.weight.device),
                 logical_widths=self.output_partition_sizes,
                 normalize_e4m3fn_to_e4m3fnuz=self.need_normalize_e4m3fn_to_e4m3fnuz,
             )
@@ -1052,9 +1067,26 @@ class MergedColumnParallelLinear(LinearBase):
                 shard_offset = (shard_offset + 127) // 128
                 shard_size = (shard_size + 127) // 128
             elif self.quant_type == QuantType.per_Tensor:
-                loaded_weight = loaded_weight.view(1, 1).repeat(self.tp_size, 1)
-                shard_offset = loaded_shard_id
-                shard_size = 1
+                param_data = param_data.narrow(self.tp_dim, loaded_shard_id, 1)
+                if (
+                    loaded_weight.ndim > self.tp_dim
+                    and loaded_weight.shape[self.tp_dim] > 1
+                ):
+                    local_scale = loaded_weight.chunk(self.tp_size, self.tp_dim)[
+                        self.tp_rank
+                    ].contiguous()
+                    if not hasattr(self, "_loaded_weight_scale_for_requant_parts"):
+                        self._loaded_weight_scale_for_requant_parts = [None] * len(
+                            self.output_sizes
+                        )
+                    self._loaded_weight_scale_for_requant_parts[loaded_shard_id] = (
+                        local_scale
+                    )
+                    loaded_weight = local_scale.max().view(1, 1)
+                else:
+                    loaded_weight = loaded_weight.max().view(1, 1)
+                param.weight_loader_process(param_data, loaded_weight)
+                return
 
         param_data = param_data.narrow(self.tp_dim, shard_offset, shard_size)
         loaded_weight = loaded_weight.chunk(self.tp_size, self.tp_dim)[self.tp_rank]
@@ -1787,6 +1819,14 @@ class RowParallelLinear(LinearBase):
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor):
         param_data = param.data
         if param is not getattr(self, "bias", None):
+            if (
+                param is getattr(self, "weight_scale", None)
+                or param is getattr(self, "input_scale", None)
+            ) and self.quant_type == QuantType.per_Tensor:
+                if loaded_weight.ndim > 0 and loaded_weight.shape[0] > 1:
+                    self._loaded_weight_scale_for_requant = loaded_weight.contiguous()
+                param.weight_loader_process(param_data, loaded_weight.max().view(1, 1))
+                return
             if len(loaded_weight.shape) == 0:
                 loaded_weight = loaded_weight.view(1, 1)
             if loaded_weight.ndim <= self.tp_dim:

--- a/atom/model_ops/utils.py
+++ b/atom/model_ops/utils.py
@@ -107,7 +107,11 @@ def requantize_with_max_scale(
         start = 0
         for idx, logical_width in enumerate(logical_widths):
             end = start + logical_width
-            weight_dq = per_tensor_dequantize(weight[start:end, :], weight_scale[idx])
+            if weight_scale.ndim > 0 and weight_scale.shape[0] == weight.shape[0]:
+                shard_scale = weight_scale[start:end, :]
+            else:
+                shard_scale = weight_scale[idx]
+            weight_dq = per_tensor_dequantize(weight[start:end, :], shard_scale)
             weight.view(quant_dtype)[start:end, :], _ = per_tensor_quant(
                 weight_dq, max_w_scale, quant_dtype=quant_dtype
             )

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -314,6 +314,13 @@ class GenericParser(QuantConfigParser):
 
         quant_dtype = self._infer_dtype(hf_quant_config, config_str)
         quant_type = self._infer_qtype(hf_quant_config, config_str)
+        if quant_method == "fbgemm_fp8":
+            # HF fbgemm_fp8 checkpoints store FP8 weights plus per-tensor
+            # weight_scale tensors, while activations are dynamically quantized.
+            # The config does not spell out a qscheme, so text heuristics would
+            # otherwise leave dense linears as QuantType.No and run GEMM on raw
+            # FP8 weights without scales.
+            quant_type = QuantType.per_Tensor
         # MXFP4 (fp4x2) uses microscaling with 1x32 block scaling by definition
         if quant_dtype == d_dtypes.get("fp4x2") and quant_type not in (
             QuantType.per_1x32,

--- a/tests/test_quant_config.py
+++ b/tests/test_quant_config.py
@@ -204,6 +204,23 @@ class TestParserRegistry:
         assert isinstance(parser, GenericParser)
 
 
+class TestGenericParser:
+    def test_fbgemm_fp8_uses_per_tensor_scales(self):
+        parser = GenericParser()
+        result = parser.parse(
+            {
+                "quant_method": "fbgemm_fp8",
+                "activation_scheme": "dynamic",
+                "fmt": "e4m3",
+            }
+        )
+
+        assert result.global_spec.quant_type == QuantType.per_Tensor
+        assert result.global_spec.quant_dtype == FP8
+        assert result.global_spec.is_dynamic is True
+        assert result.global_spec.quant_method == "fbgemm_fp8"
+
+
 # =========================================================================
 # Tests — QuarkParser
 # =========================================================================


### PR DESCRIPTION
## Motivation

Fix ATOM vLLM plugin accuracy for fbgemm_fp8 Llama checkpoints https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct-FP8 by correctly handling FP8 per-channel weight_scale tensors when converting them to the per-tensor scale format used by ATOM linear GEMMs. This prevents corrupted generations and restores GSM8K accuracy while keeping the change scoped to the affected FP8 path.
