### PR TITLE
[Kernel Opt] Optimize DeepSeek-V4 sparse prefill attention triton kernel

### DIFF
--- a/atom/model_ops/v4_kernels/paged_prefill.py
+++ b/atom/model_ops/v4_kernels/paged_prefill.py
@@ -59,6 +59,14 @@ except ImportError:
     _HAS_OPUS = False
 
 
+# Fixed best-known Triton meta for DeepSeek-V4 TP=8 / local H=8 prefill.
+_BLOCK_H = 16
+_BLOCK_K = 32
+_NUM_WARPS = 4
+_NUM_STAGES = 1
+_WAVES_PER_EU = 2
+
+
 @triton.jit
 def _sparse_attn_v4_paged_prefill_kernel(
     q_ptr,  # [N, H, D]
@@ -86,6 +94,10 @@ def _sparse_attn_v4_paged_prefill_kernel(
     BLOCK_H: tl.constexpr,
     BLOCK_D: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    PREFIX_BLOCK_K: tl.constexpr,
+    CHECK_NEG_ONE_SENTINEL: tl.constexpr,
+    HAS_PREFIX: tl.constexpr,
+    FULL_D: tl.constexpr,
 ):
     t = tl.program_id(0)
     pid_h = tl.program_id(1)
@@ -95,58 +107,79 @@ def _sparse_attn_v4_paged_prefill_kernel(
     h_mask = h_offs < H
     d_mask = d_offs < D
 
-    q = tl.load(
+    q_ptrs = (
         q_ptr
         + t * q_stride_t
         + h_offs[:, None] * q_stride_h
-        + d_offs[None, :] * q_stride_d,
-        mask=h_mask[:, None] & d_mask[None, :],
-        other=0.0,
+        + d_offs[None, :] * q_stride_d
     )
+    # FULL_D keeps the D=512 path free of d_mask overhead, while preserving a
+    # masked fallback for future V4 variants with non-power-of-two head dims.
+    if FULL_D:
+        q = tl.load(q_ptrs, mask=h_mask[:, None], other=0.0)
+    else:
+        q = tl.load(q_ptrs, mask=h_mask[:, None] & d_mask[None, :], other=0.0)
 
     neg_large = -3.4028234663852886e38
+    # Use exp2/log2 softmax form, matching the faster attention convention on
+    # this ROCm/Triton path: exp(x) == exp2(x * log2(e)).
+    qk_scale = softmax_scale * 1.4426950408889634  # log2(e)
     m_i = tl.full((BLOCK_H,), neg_large, dtype=tl.float32)
     l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
     acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
 
     k_offs = tl.arange(0, BLOCK_K)
+    p_k_offs = tl.arange(0, PREFIX_BLOCK_K)
 
     # ===== Region 1: prefix from unified_kv =====
-    p_start = tl.load(kv_indptr_prefix_ptr + t)
-    p_end = tl.load(kv_indptr_prefix_ptr + t + 1)
-    p_len = p_end - p_start
+    # HAS_PREFIX specializes ratio=0/Dense-SWA to skip the whole prefix region.
+    if HAS_PREFIX:
+        p_start = tl.load(kv_indptr_prefix_ptr + t)
+        p_end = tl.load(kv_indptr_prefix_ptr + t + 1)
+        p_len = p_end - p_start
 
-    for k_start in tl.range(0, p_len, BLOCK_K):
-        k_pos = k_start + k_offs
-        in_range = k_pos < p_len
-        slot = tl.load(
-            kv_indices_prefix_ptr + p_start + k_pos,
-            mask=in_range,
-            other=-1,
-        )
-        valid = in_range & (slot >= 0)
+        for k_start in tl.range(0, p_len, PREFIX_BLOCK_K):
+            k_pos = k_start + p_k_offs
+            in_range = k_pos < p_len
+            slot = tl.load(
+                kv_indices_prefix_ptr + p_start + k_pos,
+                mask=in_range,
+                other=-1,
+            )
+            # Some legacy index buffers can use -1 as a sentinel. HCA's
+            # short-prefix path can disable this check via constexpr.
+            if CHECK_NEG_ONE_SENTINEL:
+                valid = in_range & (slot >= 0)
+            else:
+                valid = in_range
 
-        kv = tl.load(
-            unified_kv_ptr
-            + slot[:, None] * pkv_stride_n
-            + d_offs[None, :] * pkv_stride_d,
-            mask=valid[:, None] & d_mask[None, :],
-            other=0.0,
-        )
+            kv_ptrs = (
+                unified_kv_ptr
+                + slot[:, None] * pkv_stride_n
+                + d_offs[None, :] * pkv_stride_d
+            )
+            if FULL_D:
+                kv = tl.load(kv_ptrs, mask=valid[:, None], other=0.0)
+            else:
+                kv = tl.load(
+                    kv_ptrs,
+                    mask=valid[:, None] & d_mask[None, :],
+                    other=0.0,
+                )
 
-        scores = tl.dot(q, tl.trans(kv)) * softmax_scale
-        scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
+            scores = tl.dot(q, tl.trans(kv)) * qk_scale
+            scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
 
-        m_block = tl.max(scores, axis=1)
-        m_new = tl.maximum(m_i, m_block)
-        alpha = tl.exp(m_i - m_new)
-        p = tl.exp(scores - m_new[:, None])
-        p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
-        l_new = l_i * alpha + tl.sum(p, axis=1)
+            m_block = tl.max(scores, axis=1)
+            m_new = tl.maximum(m_i, m_block)
+            alpha = tl.exp2(m_i - m_new)
+            p = tl.exp2(scores - m_new[:, None])
+            p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
+            l_new = l_i * alpha + tl.sum(p, axis=1)
 
-        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
-        m_i = m_new
-        l_i = l_new
+            acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+            m_i = m_new
+            l_i = l_new
 
     # ===== Region 2: extend from kv (per-fwd flat) =====
     e_start = tl.load(kv_indptr_extend_ptr + t)
@@ -161,21 +194,26 @@ def _sparse_attn_v4_paged_prefill_kernel(
             mask=in_range,
             other=-1,
         )
-        valid = in_range & (slot >= 0)
+        # Same sentinel policy as prefix; production extend indices are fully
+        # written, but the check keeps compatibility for generic fallback.
+        if CHECK_NEG_ONE_SENTINEL:
+            valid = in_range & (slot >= 0)
+        else:
+            valid = in_range
 
-        kv = tl.load(
-            kv_ptr + slot[:, None] * ekv_stride_n + d_offs[None, :] * ekv_stride_d,
-            mask=valid[:, None] & d_mask[None, :],
-            other=0.0,
-        )
+        kv_ptrs = kv_ptr + slot[:, None] * ekv_stride_n + d_offs[None, :] * ekv_stride_d
+        if FULL_D:
+            kv = tl.load(kv_ptrs, mask=valid[:, None], other=0.0)
+        else:
+            kv = tl.load(kv_ptrs, mask=valid[:, None] & d_mask[None, :], other=0.0)
 
-        scores = tl.dot(q, tl.trans(kv)) * softmax_scale
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
         scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
 
         m_block = tl.max(scores, axis=1)
         m_new = tl.maximum(m_i, m_block)
-        alpha = tl.exp(m_i - m_new)
-        p = tl.exp(scores - m_new[:, None])
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
         p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
         l_new = l_i * alpha + tl.sum(p, axis=1)
 
@@ -191,20 +229,148 @@ def _sparse_attn_v4_paged_prefill_kernel(
     # to m_final frame. The sink itself adds exp(sink - m_final) to l_final
     # but contributes 0 to acc since V_sink = 0.
     sink = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(tl.float32)
+    sink = sink * 1.4426950408889634
     m_final = tl.maximum(m_i, sink)
-    alpha = tl.exp(m_i - m_final)
-    l_final = l_i * alpha + tl.exp(sink - m_final)
+    alpha = tl.exp2(m_i - m_final)
+    l_final = l_i * alpha + tl.exp2(sink - m_final)
 
     denom = tl.maximum(l_final, 1.0e-30)
     out = tl.where(l_final[:, None] > 0.0, (acc * alpha[:, None]) / denom[:, None], 0.0)
-    tl.store(
+    out_ptrs = (
         out_ptr
         + t * out_stride_t
         + h_offs[:, None] * out_stride_h
-        + d_offs[None, :] * out_stride_d,
-        out,
-        mask=h_mask[:, None] & d_mask[None, :],
+        + d_offs[None, :] * out_stride_d
     )
+    if FULL_D:
+        tl.store(out_ptrs, out, mask=h_mask[:, None])
+    else:
+        tl.store(out_ptrs, out, mask=h_mask[:, None] & d_mask[None, :])
+
+
+@triton.jit
+def _sparse_attn_v4_paged_prefill_csa_kernel(
+    q_ptr,  # [N, H, D]
+    unified_kv_ptr,
+    kv_indices_prefix_ptr,
+    kv_indptr_prefix_ptr,
+    kv_ptr,
+    kv_indices_extend_ptr,
+    kv_indptr_extend_ptr,
+    attn_sink_ptr,
+    out_ptr,
+    q_stride_t: tl.constexpr,
+    q_stride_h: tl.constexpr,
+    q_stride_d: tl.constexpr,
+    pkv_stride_n: tl.constexpr,
+    pkv_stride_d: tl.constexpr,
+    ekv_stride_n: tl.constexpr,
+    ekv_stride_d: tl.constexpr,
+    out_stride_t: tl.constexpr,
+    out_stride_h: tl.constexpr,
+    out_stride_d: tl.constexpr,
+    H: tl.constexpr,
+    softmax_scale: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    PREFIX_BLOCK_K: tl.constexpr,
+):
+    # CSA-only fast path for DeepSeek-V4 D=512. It removes generic prefix/HCA
+    # options from the shared kernel and keeps the proven BLOCK_K/PREFIX_BLOCK_K
+    # shape for ratio=4.
+    t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    d_offs = tl.arange(0, BLOCK_D)
+    h_mask = h_offs < H
+
+    q_ptrs = (
+        q_ptr
+        + t * q_stride_t
+        + h_offs[:, None] * q_stride_h
+        + d_offs[None, :] * q_stride_d
+    )
+    q = tl.load(q_ptrs, mask=h_mask[:, None], other=0.0)
+
+    neg_large = -3.4028234663852886e38
+    qk_scale = softmax_scale * 1.4426950408889634
+    m_i = tl.full((BLOCK_H,), neg_large, dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
+
+    p_k_offs = tl.arange(0, PREFIX_BLOCK_K)
+    p_start = tl.load(kv_indptr_prefix_ptr + t)
+    p_end = tl.load(kv_indptr_prefix_ptr + t + 1)
+    p_len = p_end - p_start
+
+    for k_start in tl.range(0, p_len, PREFIX_BLOCK_K):
+        k_pos = k_start + p_k_offs
+        valid = k_pos < p_len
+        slot = tl.load(kv_indices_prefix_ptr + p_start + k_pos, mask=valid, other=0)
+        kv_ptrs = (
+            unified_kv_ptr
+            + slot[:, None] * pkv_stride_n
+            + d_offs[None, :] * pkv_stride_d
+        )
+        kv = tl.load(kv_ptrs, mask=valid[:, None], other=0.0)
+
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
+
+        m_block = tl.max(scores, axis=1)
+        m_new = tl.maximum(m_i, m_block)
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
+        l_new = l_i * alpha + tl.sum(p, axis=1)
+
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+        l_i = l_new
+
+    k_offs = tl.arange(0, BLOCK_K)
+    e_start = tl.load(kv_indptr_extend_ptr + t)
+    e_end = tl.load(kv_indptr_extend_ptr + t + 1)
+    e_len = e_end - e_start
+
+    for e_k_start in tl.range(0, e_len, BLOCK_K):
+        k_pos = e_k_start + k_offs
+        valid = k_pos < e_len
+        slot = tl.load(kv_indices_extend_ptr + e_start + k_pos, mask=valid, other=0)
+        kv_ptrs = kv_ptr + slot[:, None] * ekv_stride_n + d_offs[None, :] * ekv_stride_d
+        kv = tl.load(kv_ptrs, mask=valid[:, None], other=0.0)
+
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(h_mask[:, None] & valid[None, :], scores, neg_large)
+
+        m_block = tl.max(scores, axis=1)
+        m_new = tl.maximum(m_i, m_block)
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        p = tl.where(h_mask[:, None] & valid[None, :], p, 0.0)
+        l_new = l_i * alpha + tl.sum(p, axis=1)
+
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+        l_i = l_new
+
+    sink = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(tl.float32)
+    sink = sink * 1.4426950408889634
+    m_final = tl.maximum(m_i, sink)
+    alpha = tl.exp2(m_i - m_final)
+    l_final = l_i * alpha + tl.exp2(sink - m_final)
+
+    denom = tl.maximum(l_final, 1.0e-30)
+    out = tl.where(l_final[:, None] > 0.0, (acc * alpha[:, None]) / denom[:, None], 0.0)
+    out_ptrs = (
+        out_ptr
+        + t * out_stride_t
+        + h_offs[:, None] * out_stride_h
+        + d_offs[None, :] * out_stride_d
+    )
+    tl.store(out_ptrs, out, mask=h_mask[:, None])
 
 
 def _sparse_attn_v4_paged_prefill_triton(
@@ -217,6 +383,7 @@ def _sparse_attn_v4_paged_prefill_triton(
     kv_indptr_extend: torch.Tensor,
     attn_sink: torch.Tensor,
     softmax_scale: float,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     if not q.is_cuda:
         raise RuntimeError(
@@ -238,15 +405,71 @@ def _sparse_attn_v4_paged_prefill_triton(
         )
 
     T, H, D = q.shape
-    out = torch.empty_like(q)
+    if out is None:
+        # Callers can pass `out` to reuse a buffer and avoid this allocation.
+        out = torch.empty_like(q)
+    elif out.shape != q.shape or out.dtype != q.dtype or out.device != q.device:
+        raise RuntimeError(
+            f"out shape/dtype/device mismatch: got shape={tuple(out.shape)} "
+            f"dtype={out.dtype} device={out.device}, expected shape={tuple(q.shape)} "
+            f"dtype={q.dtype} device={q.device}"
+        )
     kv_indices_prefix = kv_indices_prefix.to(torch.int32).contiguous()
     kv_indptr_prefix = kv_indptr_prefix.to(torch.int32).contiguous()
     kv_indices_extend = kv_indices_extend.to(torch.int32).contiguous()
     kv_indptr_extend = kv_indptr_extend.to(torch.int32).contiguous()
 
-    block_h = 16  # AMD MFMA min tile
+    block_h = _BLOCK_H
+    block_k = _BLOCK_K
+    num_warps = _NUM_WARPS
+    num_stages = _NUM_STAGES
+    waves_per_eu = _WAVES_PER_EU
     block_d = triton.next_power_of_2(D)
-    block_k = 16 if D >= 256 else 32
+    full_d = D == block_d
+    avg_prefix_len = kv_indices_prefix.numel() / max(T, 1)
+    # HCA prefill has a very short prefix, while CSA has a long prefix. A
+    # smaller prefix tile helps HCA but hurts CSA, so choose it by prefix size.
+    prefix_block_k = min(block_k, 16) if 0 < avg_prefix_len <= 16 else block_k
+    # Prefix/extend indices are fully written in production; keep sentinel
+    # checks only for non-short-prefix shapes for compatibility with legacy data.
+    check_neg_one_sentinel = not (0 < avg_prefix_len <= 16)
+    has_prefix = kv_indices_prefix.numel() > 0
+    # Only long-prefix CSA with D=512 uses the CSA fast kernel. Other prefix
+    # shapes, including HCA and non-512 V4 variants, use the generic kernel.
+    use_csa_fast_kernel = has_prefix and avg_prefix_len > 16 and D == 512 and full_d
+    if use_csa_fast_kernel:
+        _sparse_attn_v4_paged_prefill_csa_kernel[(T, triton.cdiv(H, block_h))](
+            q,
+            unified_kv,
+            kv_indices_prefix,
+            kv_indptr_prefix,
+            kv,
+            kv_indices_extend,
+            kv_indptr_extend,
+            attn_sink,
+            out,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            unified_kv.stride(0),
+            unified_kv.stride(1),
+            kv.stride(0),
+            kv.stride(1),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            H,
+            float(softmax_scale),
+            BLOCK_H=block_h,
+            BLOCK_D=block_d,
+            BLOCK_K=block_k,
+            PREFIX_BLOCK_K=prefix_block_k,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            waves_per_eu=waves_per_eu,
+        )
+        return out
+
     _sparse_attn_v4_paged_prefill_kernel[(T, triton.cdiv(H, block_h))](
         q,
         unified_kv,
@@ -273,7 +496,13 @@ def _sparse_attn_v4_paged_prefill_triton(
         BLOCK_H=block_h,
         BLOCK_D=block_d,
         BLOCK_K=block_k,
-        num_warps=8,
+        PREFIX_BLOCK_K=prefix_block_k,
+        CHECK_NEG_ONE_SENTINEL=check_neg_one_sentinel,
+        HAS_PREFIX=has_prefix,
+        FULL_D=full_d,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        waves_per_eu=waves_per_eu,
     )
     return out
 
@@ -348,6 +577,7 @@ def sparse_attn_v4_paged_prefill(
     kv_indptr_extend: torch.Tensor,
     attn_sink: torch.Tensor,
     softmax_scale: float,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """V4 prefill sparse attention over two KV sources (paged unified_kv +
     flat per-fwd kv).
@@ -365,6 +595,8 @@ def sparse_attn_v4_paged_prefill(
       kv_indptr_extend:  [T+1] int32 — true prefix sum.
       attn_sink:         [H] — per-head softmax-denom bias.
       softmax_scale:     float.
+      out:               optional output buffer. Can alias q when the caller no
+        longer needs q after attention.
 
     Returns:
       out: [T, H, D] same dtype as q.
@@ -383,6 +615,7 @@ def sparse_attn_v4_paged_prefill(
                 kv_indptr_extend,
                 attn_sink,
                 softmax_scale,
+                out=out,
             )
         except RuntimeError:
             pass
@@ -396,4 +629,5 @@ def sparse_attn_v4_paged_prefill(
         kv_indptr_extend,
         attn_sink,
         softmax_scale,
+        out=out,
     )

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1907,6 +1907,9 @@ class DeepseekV4Attention(nn.Module):
                 attn_md.kv_indptr_extend,
                 self.attn_sink,
                 self.softmax_scale,
+                # Reuse q_sa as the attention output buffer; q_sa is not needed
+                # after this call and this avoids an extra empty_like allocation.
+                out=q_sa,
             )  # [S, H, head_dim]
             # swa_write AFTER attn so chunked-prefill prefix SWA reads see
             # prior-chunk's ring contents (current swa_write would overwrite


### PR DESCRIPTION
## Motivation
Improve DeepSeek-V4 paged sparse prefill attention performance **in MI308** by replacing the env-driven experimental tuning path with a fixed, validated Triton implementation. The optimized path reduces prefill attention latency across Dense/SWA, CSA, and HCA layers while keeping OPUS support available.

## Technical Details
- Bakes the validated DeepSeek-V4 prefill attention Triton meta into code:
  - `BLOCK_H=16`
  - `BLOCK_K=32`
  - `num_warps=4`
  - `num_stages=1`
  - `waves_per_eu=2`
- Uses the `exp2/log2` online softmax form:
  - Converts `softmax_scale` into the `log2(e)` domain.
  - Uses `tl.exp2` instead of `tl.exp`.
  - Applies the same `exp2` path in sink finalization.
- Ads the `FULL_D` fast path:
  - Skips unnecessary `d_mask` for the current DeepSeek-V4 power-of-two head dim `D=512`.
  - Keeps a masked fallback path for possible future V4 variants with non-power-of-two head dims.
- Adds prefix specialization:
  - `ratio=0` / Dense-SWA has no prefix and skips the entire prefix region.
  - `ratio=4` / CSA and `ratio=128` / HCA continue to use prefix + extend online softmax.
- Adds HCA short-prefix tile specialization:
  - Uses `avg_prefix_len` to identify short-prefix HCA cases.
  - HCA uses `PREFIX_BLOCK_K=16`.
  - CSA and other long-prefix paths keep `PREFIX_BLOCK_K=32`.
  - Avoids applying `PREFIX_BLOCK_K=16` globally, which regresses CSA.
- Adds the sentinel-check policy:
  - Preserves `slot >= 0` checks for paths that may contain `-1` sentinel indices.
  - Allows the short-prefix HCA path to skip the check via constexpr.
  - Maintains compatibility with legacy index buffers while avoiding unnecessary checks on short-prefix paths.
- Adds a CSA fast kernel:
  - Adds `_sparse_attn_v4_paged_prefill_csa_kernel` for long-prefix `ratio=4` CSA layers.
  - Enables it only when `D=512`, `FULL_D=True`, and the long-prefix CSA condition is satisfied.
  - Falls back to the generic Triton kernel for non-CSA, HCA, Dense/SWA, non-512 head dims, and other unsupported cases.
  - Removes unnecessary generic branches from the CSA fast path to simplify the Triton code shape.
- Supports output buffer reuse:
  - Adds `sparse_attn_v4_paged_prefill(..., out=...)` support for caller-provided output buffers.
  - Passes `out=q_sa` in the DeepSeek-V4 prefill path to reuse the query buffer as the attention output.
  - Avoids one extra `torch.empty_like(q)` allocation per layer.


## Command
```
set -x

export AITER_BF16_FP8_MOE_BOUND=0
export ATOM_MOE_GU_ITLV=1
export SGLANG_DEFAULT_THINKING=1
export SGLANG_DSV4_REASONING_EFFORT=max
export SGLANG_USE_AITER=1
export SGLANG_DSV4_FP4_EXPERTS=true
# Introduce ATOM as external model package of SGLang
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
# Keep the fixed optimized Triton prefill path by default; OPUS remains
# available in ATOM_final when this override is unset/disabled.
export ATOM_FORCE_ATTN_TRITON=1

model_path=/models/DeepSeek-V4-Flash-Base/

export SGLANG_PROFILE_RECORD_SHAPES=1
export SGLANG_PROFILE_WITH_STACK=1
export SGLANG_TORCH_PROFILER_DIR=./profile_sglang_plugin_dsv4/


TP=8

TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 8000 \
    --trust-remote-code \
    --tensor-parallel-size "${TP}" \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.9 \
    --swa-full-tokens-ratio 0.1 \
    --max-running-requests 256 \
    --page-size 256 \
    --disable-radix-cache \
    --disable-shared-experts-fusion \
    --tool-call-parser deepseekv4 \
    --reasoning-parser deepseek-v4
```
## Acc
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.8597|±  |0.0096|
|     |       |strict-match    |     3|exact_match|↑  |0.8597|±  |0.0096|
```

## Performance
before:
<img width="286" height="67" alt="image" src="https://github.com/user-attachments/assets/c87319c0-e5b7-461e-8ec2-4f6e23914426" />
<img width="300" height="45" alt="image" src="https://github.com/user-attachments/assets/8ff8415c-9fc1-4f81-8ca1-8287292e5fa2" />


after:
<img width="640" height="67" alt="image" src="https://github.com/user-attachments/assets/87aa80b3-da27-45a3-8e80-280e8150b6ba" />
<img width="228" height="43" alt="image" src="https://github.com/user-attachments/assets/dd21e53d-2b5d-4540-98c1-adaef16c423d" />



## Benchamark
before:
```
============ Serving Benchmark Result ============
Successful requests:                     80        
Benchmark duration (s):                  71.69     
Total input tokens:                      80000     
Total generated tokens:                  27200     
Request throughput (req/s):              1.12      
Output token throughput (tok/s):         379.41    
Total Token throughput (tok/s):          1495.34   
---------------Time to First Token----------------
Mean TTFT (ms):                          597.76    
Median TTFT (ms):                        638.61    
P50 TTFT (ms):                           638.61    
P99 TTFT (ms):                           641.60    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.38     
Median TPOT (ms):                        19.24     
P50 TPOT (ms):                           19.24     
P99 TPOT (ms):                           20.84     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.38     
Median ITL (ms):                         18.99     
P50 ITL (ms):                            18.99     
P99 ITL (ms):                            21.20     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          7167.63   
Median E2EL (ms):                        7150.56   
P50 E2EL (ms):                           7150.56   
P99 E2EL (ms):                           7375.35   
==================================================
```


after:
```
============ Serving Benchmark Result ============
Successful requests:                     80        
Benchmark duration (s):                  69.81     
Total input tokens:                      80000     
Total generated tokens:                  27200     
Request throughput (req/s):              1.15      
Output token throughput (tok/s):         389.62    
Total Token throughput (tok/s):          1535.56   
---------------Time to First Token----------------
Mean TTFT (ms):                          497.10    
Median TTFT (ms):                        534.13    
P50 TTFT (ms):                           534.13    
P99 TTFT (ms):                           537.16    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.12     
Median TPOT (ms):                        18.98     
P50 TPOT (ms):                           18.98     
P99 TPOT (ms):                           20.41     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.12     
Median ITL (ms):                         18.96     
P50 ITL (ms):                            18.96     
P99 ITL (ms):                            21.23     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          6979.71   
Median E2EL (ms):                        6946.82   
P50 E2EL (ms):                           6946.82   
P99 E2EL (ms):                           7266.99   
==================================================
```

