### PR TITLE
[Fix] fix GLM5.2 n-shot100 accuracy

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -175,11 +175,19 @@ def _supports_fused_indexer_kernel_config(config: PretrainedConfig) -> bool:
 
 
 def _is_neox_rope_style(
-    config: PretrainedConfig, interleave_attr: str, default_interleave: bool
+    config: PretrainedConfig, interleave_attr: str, *, default_is_neox: bool
 ) -> bool:
-    interleave = getattr(config, interleave_attr, default_interleave)
+    """Resolve ``is_neox_style`` from a model's ``*_interleave`` rope config flag.
+
+    neox and interleaved (GPT-J) are the two mutually-exclusive rope layouts, so
+    an interleave flag of True means ``is_neox_style=False``. A missing or null
+    flag falls back to ``default_is_neox`` — the layout of DeepSeek checkpoints
+    that predate the flag, which differs per rope instance (see call sites):
+    DeepSeek's main MLA rope is interleaved, but its V3.2 indexer rope is neox.
+    """
+    interleave = getattr(config, interleave_attr, None)
     if interleave is None:
-        interleave = default_interleave
+        return default_is_neox
     return not bool(interleave)
 
 
@@ -1842,7 +1850,11 @@ class DeepseekV2MLAAttention(nn.Module):
             max_position=max_position_embeddings,
             base=rope_theta,
             rope_scaling=rope_scaling,
-            is_neox_style=_is_neox_rope_style(config, "rope_interleave", True),
+            # DeepSeek's main MLA rope is interleaved (is_neox_style=False) when
+            # unspecified; GLM-5.x sets rope_interleave=true, i.e. also interleaved.
+            is_neox_style=_is_neox_rope_style(
+                config, "rope_interleave", default_is_neox=False
+            ),
         )
         if rope_scaling:
             mscale_all_dim = rope_scaling.get("mscale_all_dim", False)
@@ -1861,8 +1873,11 @@ class DeepseekV2MLAAttention(nn.Module):
                 max_position=max_position_embeddings,
                 base=rope_theta,
                 rope_scaling=rope_scaling,
+                # DeepSeek-V3.2's indexer rope is neox (is_neox_style=True) when
+                # unspecified; GLM-5.x sets indexer_rope_interleave=true to override
+                # it to interleaved.
                 is_neox_style=_is_neox_rope_style(
-                    config, "indexer_rope_interleave", True
+                    config, "indexer_rope_interleave", default_is_neox=True
                 ),
             )
             if _indexer_weights_shared(config, prefix):

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1861,7 +1861,9 @@ class DeepseekV2MLAAttention(nn.Module):
                 max_position=max_position_embeddings,
                 base=rope_theta,
                 rope_scaling=rope_scaling,
-                is_neox_style=True,
+                is_neox_style=_is_neox_rope_style(
+                    config, "indexer_rope_interleave", True
+                ),
             )
             if _indexer_weights_shared(config, prefix):
                 # GLM-5.2 IndexShare: reuses prior "full" layer's indexer; the


### PR DESCRIPTION
## Motivation

Fix GLM5.2 n-shot100 accuracy.

Scripts
```python
lm_eval --model local-completions \
  --model_args model=zai-org/GLM-5.2-FP8,base_url=http://localhost:9677/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False \
  --tasks gsm8k --num_fewshot 100 --limit 100
```

Before:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|   100|exact_match|↑  | 0.36|±  |0.0482|
|     |       |strict-match    |   100|exact_match|↑  | 0.36|±  |0.0482|

After fix:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|   100|exact_match|↑  | 0.98|±  |0.0141|
|     |       |strict-match    |   100|exact_match|↑  | 0.98|±  |0.0141|


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
