### PR TITLE
fix: dpa kv transfer error on spur

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -438,6 +438,7 @@ async def generate_async(
     sampling_params: SamplingParams,
     request_id: str,
     kv_transfer_params: Optional[Dict[str, Any]] = None,
+    data_parallel_rank: Optional[int] = None,
 ) -> AsyncGenerator[Dict[str, Any], None]:
     """Generate text asynchronously for non-streaming requests."""
     global engine, tokenizer
@@ -482,6 +483,11 @@ async def generate_async(
         )
 
     seq = await loop.run_in_executor(None, do_preprocess)
+    if data_parallel_rank is not None:
+        seq.data_parallel_rank = data_parallel_rank
+        logger.info(
+            "Request %s pinned to data_parallel_rank=%s", seq.id, data_parallel_rank
+        )
     try:
         _validate_sequence_context_length(seq)
     except Exception:
@@ -624,6 +630,7 @@ async def generate_async_fanout(
     request_id: str,
     kv_transfer_params: Optional[Dict[str, Any]] = None,
     multimodal_data: Optional[Dict[str, Any]] = None,
+    data_parallel_rank: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Non-streaming n>1 path: fan out N siblings and await all of them.
 
@@ -677,6 +684,15 @@ async def generate_async_fanout(
         )
 
     seqs = await loop.run_in_executor(None, do_preprocess)
+    if data_parallel_rank is not None:
+        for seq in seqs:
+            seq.data_parallel_rank = data_parallel_rank
+        logger.info(
+            "Request %s fanout pinned %d sequence(s) to data_parallel_rank=%s",
+            request_id,
+            len(seqs),
+            data_parallel_rank,
+        )
     try:
         _validate_sequence_context_length(seqs[0])
     except Exception:
@@ -1182,6 +1198,7 @@ async def completions(request: CompletionRequest):
                 sampling_params,
                 request_id,
                 kv_transfer_params=request.kv_transfer_params,
+                data_parallel_rank=request.data_parallel_rank,
             )
             if not outputs:
                 raise RuntimeError("No output generated")
@@ -1193,6 +1210,7 @@ async def completions(request: CompletionRequest):
                 sampling_params,
                 request_id,
                 kv_transfer_params=request.kv_transfer_params,
+                data_parallel_rank=request.data_parallel_rank,
             ):
                 final_output = output
 

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -157,6 +157,8 @@ class CompletionRequest(BaseModel):
     stream: Optional[bool] = False
     # Optional KV-transfer metadata for P/D disaggregation.
     kv_transfer_params: Optional[Dict[str, Any]] = None
+    # Optional DPA routing hint inserted by atomesh for DP-aware workers.
+    data_parallel_rank: Optional[int] = None
     n: Optional[int] = 1
 
     def get_max_tokens(self) -> int:

--- a/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
+++ b/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
@@ -10,8 +10,10 @@ KV cache data from producer (prefill) to consumer (decode) nodes.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
+import subprocess
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -101,6 +103,115 @@ class MooncakeAgentMetadata(
 
 def _port_offset(dp_rank: int, tp_rank: int, tp_size: int = 1) -> int:
     return dp_rank * tp_size + tp_rank
+
+
+def _ip_for_ib_device(ib_device: str, fallback: str) -> str:
+    """Return the IPv4 address bound to the netdev backing an RDMA HCA."""
+    net_root = f"/sys/class/infiniband/{ib_device}/device/net"
+    netdevs: list[str] = []
+    try:
+        netdevs = sorted(os.listdir(net_root))
+    except OSError:
+        logger.info(
+            "Could not list netdevs for ib_device=%s under %s; "
+            "falling back to RDMA GID lookup",
+            ib_device,
+            net_root,
+        )
+
+    for netdev in netdevs:
+        try:
+            out = subprocess.check_output(
+                ["ip", "-o", "-4", "addr", "show", "dev", netdev, "scope", "global"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        for line in out.splitlines():
+            parts = line.split()
+            if "inet" in parts:
+                ip_cidr = parts[parts.index("inet") + 1]
+                return ip_cidr.split("/", 1)[0]
+
+    gid_ip = _ip_for_ib_device_from_gid(ib_device)
+    if gid_ip:
+        logger.info(
+            "Using IPv4 %s parsed from RDMA GID for ib_device=%s", gid_ip, ib_device
+        )
+        return gid_ip
+
+    logger.info(
+        "Could not determine RDMA-local IPv4 for ib_device=%s (netdevs=%s); "
+        "falling back to default IP %s",
+        ib_device,
+        ",".join(netdevs) if netdevs else "<none>",
+        fallback,
+    )
+    return fallback
+
+
+def _ip_for_ib_device_from_gid(ib_device: str) -> str | None:
+    """Parse an IPv4-mapped RoCE GID from sysfs for containers without host netns."""
+    ports_root = f"/sys/class/infiniband/{ib_device}/ports"
+    try:
+        ports = sorted(os.listdir(ports_root))
+    except OSError:
+        return None
+
+    preferred_gid_indexes: list[str] = []
+    for env_name in ("MC_IB_GID_INDEX", "MOONCAKE_IB_GID_INDEX"):
+        env_value = os.environ.get(env_name)
+        if env_value:
+            preferred_gid_indexes.append(env_value)
+    preferred_gid_indexes.extend(["1", "3", "0"])
+
+    for port in ports:
+        gids_root = os.path.join(ports_root, port, "gids")
+        try:
+            available_indexes = sorted(os.listdir(gids_root), key=lambda x: int(x))
+        except (OSError, ValueError):
+            available_indexes = []
+
+        seen_indexes: set[str] = set()
+        gid_indexes = []
+        for idx in preferred_gid_indexes + available_indexes:
+            if idx not in seen_indexes:
+                seen_indexes.add(idx)
+                gid_indexes.append(idx)
+
+        for gid_index in gid_indexes:
+            gid_path = os.path.join(gids_root, gid_index)
+            try:
+                with open(gid_path) as f:
+                    gid = f.read().strip()
+            except OSError:
+                continue
+            ip = _ipv4_from_gid(gid)
+            if ip and ip != "0.0.0.0":
+                logger.info(
+                    "Parsed RDMA GID %s from %s for ib_device=%s as IPv4 %s",
+                    gid,
+                    gid_path,
+                    ib_device,
+                    ip,
+                )
+                return ip
+    return None
+
+
+def _ipv4_from_gid(gid: str) -> str | None:
+    try:
+        ip = ipaddress.ip_address(gid)
+    except ValueError:
+        return None
+
+    if isinstance(ip, ipaddress.IPv4Address):
+        return str(ip)
+    mapped = ip.ipv4_mapped
+    if mapped is not None:
+        return str(mapped)
+    return None
 
 
 # ===================================================================
@@ -264,7 +375,8 @@ class MooncakeConnector(KVConnectorBase):
         self.dp_size = get_dp_group().world_size
 
         kv_transfer_config = config.kv_transfer_config
-        self.local_ip = get_ip()
+        default_local_ip = get_ip()
+        self.local_ip = default_local_ip
         self._local_ping_port = get_open_port()
 
         self.is_producer = (
@@ -319,6 +431,17 @@ class MooncakeConnector(KVConnectorBase):
                 visible_idx,
                 self.tp_rank,
             )
+
+        rdma_local_ip = _ip_for_ib_device(ib_device, default_local_ip)
+        if rdma_local_ip != default_local_ip:
+            logger.info(
+                "Using RDMA-local IP %s for ib_device=%s instead of default IP %s",
+                rdma_local_ip,
+                ib_device,
+                default_local_ip,
+            )
+        self.local_ip = rdma_local_ip
+        self.request_address = f"{self.local_ip}:{self.http_port}"
 
         self.transfer_engine = TransferEngine()
         ret = self.transfer_engine.initialize(
@@ -928,7 +1051,7 @@ class MooncakeConnector(KVConnectorBase):
                     )
 
             if has_slot_data:
-                self._execute_block_slot_transfer(
+                transfer_ok = self._execute_block_slot_transfer(
                     request_data,
                     target,
                     src_block_ids,
@@ -937,13 +1060,22 @@ class MooncakeConnector(KVConnectorBase):
                     req_id,
                 )
             else:
-                self._execute_block_transfer(
+                transfer_ok = self._execute_block_transfer(
                     request_data,
                     target,
                     src_block_ids,
                     dst_block_ids,
                     req_id,
                 )
+
+            if not transfer_ok:
+                logger.error(
+                    "[PRODUCER] transfer failed for req %s (transfer_id=%s); "
+                    "not sending write-done",
+                    req_id,
+                    transfer_id,
+                )
+                return
 
             # Notify consumer — all data (blocks + state for V4) is written.
             self._send_write_done(notify_host, notify_port, req_id)
@@ -983,7 +1115,7 @@ class MooncakeConnector(KVConnectorBase):
         src_block_ids: list[int],
         dst_block_ids: list[int],
         req_id: str,
-    ) -> None:
+    ) -> bool:
         """Block-only RDMA transfer (MHA, MLA, and other block-indexed backends)."""
         consumer_base_addrs = request_data["consumer_base_addrs"]
 
@@ -1014,6 +1146,8 @@ class MooncakeConnector(KVConnectorBase):
             target, src_addrs, dst_addrs, sizes, req_id, "block"
         ):
             logger.error("[PRODUCER] block transfer failed for req %s", req_id)
+            return False
+        return True
 
     def _execute_block_slot_transfer(
         self,
@@ -1023,7 +1157,7 @@ class MooncakeConnector(KVConnectorBase):
         dst_block_ids: list[int],
         prefill_data: dict,
         req_id: str,
-    ) -> None:
+    ) -> bool:
         """Two-phase RDMA for backends with per-request state: block regions first, then slot regions."""
         consumer_block_addrs = request_data["consumer_v4_block_base_addrs"]
         consumer_block_bpb = request_data["consumer_v4_block_bpb"]
@@ -1056,7 +1190,7 @@ class MooncakeConnector(KVConnectorBase):
             target, block_src, block_dst, block_sizes, req_id, "block"
         ):
             logger.error("[PRODUCER] block transfer failed for req %s", req_id)
-            return
+            return False
 
         # ---- Phase 2: Slot transfer ----
         if src_slot < 0 or dst_slot < 0:
@@ -1065,7 +1199,7 @@ class MooncakeConnector(KVConnectorBase):
                 src_slot,
                 dst_slot,
             )
-            return
+            return True
 
         slot_src: list[int] = []
         slot_dst: list[int] = []
@@ -1104,13 +1238,15 @@ class MooncakeConnector(KVConnectorBase):
             sum(slot_sizes),
         )
 
-        if not self._rdma_write_with_retry(
+        slot_ok = self._rdma_write_with_retry(
             target, slot_src, slot_dst, slot_sizes, req_id, "slot"
-        ):
+        )
+        if not slot_ok:
             logger.error("[PRODUCER] slot transfer failed for req %s", req_id)
 
         if producer_pool_idx >= 0:
             self._release_staging_slot(producer_pool_idx)
+        return slot_ok
 
     def _wait_for_prefill_data(self, req_id: str) -> dict | None:
         """Wait until prefill data is available for this request.

--- a/atom/mesh/src/cliargs.rs
+++ b/atom/mesh/src/cliargs.rs
@@ -4,8 +4,9 @@ use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 
 use crate::{
     config::{
-        BackendType, CircuitBreakerConfig, ConfigError, ConfigResult, HealthCheckConfig,
-        MetricsConfig, PolicyConfig, RetryConfig, RouterConfig, RoutingMode, TokenizerCacheConfig,
+        AtomPdRankMappingPolicy, BackendType, CircuitBreakerConfig, ConfigError, ConfigResult,
+        HealthCheckConfig, MetricsConfig, PolicyConfig, RetryConfig, RouterConfig, RoutingMode,
+        TokenizerCacheConfig,
     },
     core::ConnectionMode,
     observability::metrics::PrometheusConfig,
@@ -264,6 +265,10 @@ pub struct CliArgs {
     /// Specific policy for decode nodes in PD mode
     #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "prefix_hash"], help_heading = "PD Disaggregation")]
     pub decode_policy: Option<String>,
+
+    /// ATOM-only policy for mapping selected prefill DP ranks to decode DP ranks
+    #[arg(long, default_value = "none", value_parser = ["none", "idx2idx"], help_heading = "PD Disaggregation")]
+    pub atom_pd_rank_mapping_policy: String,
 
     /// Timeout in seconds for worker startup and registration
     #[arg(long, default_value_t = 1800, help_heading = "PD Disaggregation")]
@@ -548,6 +553,14 @@ impl CliArgs {
         };
 
         let policy = self.parse_policy(&self.policy);
+        let atom_pd_rank_mapping_policy = self
+            .atom_pd_rank_mapping_policy
+            .parse::<AtomPdRankMappingPolicy>()
+            .map_err(|reason| ConfigError::InvalidValue {
+                field: "atom_pd_rank_mapping_policy".to_string(),
+                value: self.atom_pd_rank_mapping_policy.clone(),
+                reason,
+            })?;
 
         let metrics = Some(MetricsConfig {
             port: self.prometheus_port,
@@ -575,6 +588,7 @@ impl CliArgs {
         RouterConfig::builder()
             .mode(mode)
             .backend(self.backend.into())
+            .atom_pd_rank_mapping_policy(atom_pd_rank_mapping_policy)
             .policy(policy)
             .connection_mode(connection_mode)
             .host(&self.host)
@@ -699,6 +713,7 @@ impl Default for CliArgs {
             decode: Vec::new(),
             prefill_policy: None,
             decode_policy: None,
+            atom_pd_rank_mapping_policy: "none".to_string(),
             worker_startup_timeout_secs: 1800,
             worker_startup_check_interval: 30,
             log_dir: None,

--- a/atom/mesh/src/config/builder.rs
+++ b/atom/mesh/src/config/builder.rs
@@ -1,6 +1,6 @@
 use super::{
-    BackendType, CircuitBreakerConfig, ConfigResult, HealthCheckConfig, MetricsConfig,
-    PolicyConfig, RetryConfig, RouterConfig, RoutingMode, TokenizerCacheConfig,
+    AtomPdRankMappingPolicy, BackendType, CircuitBreakerConfig, ConfigResult, HealthCheckConfig,
+    MetricsConfig, PolicyConfig, RetryConfig, RouterConfig, RoutingMode, TokenizerCacheConfig,
 };
 use crate::core::ConnectionMode;
 
@@ -141,6 +141,11 @@ impl RouterConfigBuilder {
 
     pub fn atom_standalone(mut self, enable: bool) -> Self {
         self.config.atom_standalone = enable;
+        self
+    }
+
+    pub fn atom_pd_rank_mapping_policy(mut self, policy: AtomPdRankMappingPolicy) -> Self {
+        self.config.atom_pd_rank_mapping_policy = policy;
         self
     }
 

--- a/atom/mesh/src/config/types.rs
+++ b/atom/mesh/src/config/types.rs
@@ -16,6 +16,40 @@ pub enum BackendType {
     Atom,
 }
 
+/// Strategy used by the ATOM PD router to map a selected prefill DP rank to
+/// the selected decode DP rank.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum AtomPdRankMappingPolicy {
+    /// Do not rewrite the planner-selected prefill/decode DP ranks.
+    #[default]
+    #[serde(rename = "none")]
+    None,
+    /// Map prefill rank N to decode rank N when both sides expose DP workers.
+    #[serde(rename = "idx2idx")]
+    Idx2Idx,
+}
+
+impl std::fmt::Display for AtomPdRankMappingPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Idx2Idx => write!(f, "idx2idx"),
+        }
+    }
+}
+
+impl std::str::FromStr for AtomPdRankMappingPolicy {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "none" | "disabled" | "off" => Ok(Self::None),
+            "idx2idx" | "index_to_index" | "same_index" => Ok(Self::Idx2Idx),
+            other => Err(format!("unsupported ATOM PD rank mapping policy: {other}")),
+        }
+    }
+}
+
 /// Main router configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouterConfig {
@@ -26,6 +60,8 @@ pub struct RouterConfig {
     pub connection_mode: ConnectionMode,
     #[serde(default)]
     pub atom_standalone: bool,
+    #[serde(default)]
+    pub atom_pd_rank_mapping_policy: AtomPdRankMappingPolicy,
 
     pub policy: PolicyConfig,
     pub host: String,
@@ -357,6 +393,7 @@ impl Default for RouterConfig {
             health_check: HealthCheckConfig::default(),
             connection_mode: ConnectionMode::Http,
             atom_standalone: false,
+            atom_pd_rank_mapping_policy: AtomPdRankMappingPolicy::None,
             model_path: None,
             tokenizer_path: None,
             chat_template: None,

--- a/atom/mesh/src/core/placement/backend/atom.rs
+++ b/atom/mesh/src/core/placement/backend/atom.rs
@@ -47,8 +47,11 @@ impl AtomAdapter {
             })?;
         obj.insert("remote_dp_size".to_string(), json!(ctx.prefill_dp_size));
         obj.insert("remote_tp_size".to_string(), json!(tp_size));
-        // Only a numeric rank; else leave unset so decode defaults to 0.
-        if let Some(dp_rank) = obj.get("dp_rank").filter(|v| v.is_number()).cloned() {
+        let remote_dp_rank = ctx
+            .prefill_dp_rank
+            .map(|r| json!(r))
+            .or_else(|| obj.get("dp_rank").filter(|v| v.is_number()).cloned());
+        if let Some(dp_rank) = remote_dp_rank {
             obj.insert("remote_dp_rank".to_string(), dp_rank);
         }
         Ok(())
@@ -60,6 +63,8 @@ pub struct AtomPairCtx {
     pub transfer_id: String,
     pub prefill_url: String,
     pub prefill_dp_size: usize,
+    pub prefill_dp_rank: Option<usize>,
+    pub decode_dp_rank: Option<usize>,
 }
 
 fn downcast(ctx: &PairCtx) -> Result<&AtomPairCtx, AdapterError> {
@@ -77,6 +82,8 @@ impl BackendAdapter for AtomAdapter {
             transfer_id: format!("xfer-{}", Uuid::new_v4()),
             prefill_url: prefill.url().to_string(),
             prefill_dp_size: prefill.dp_size().unwrap_or(1),
+            prefill_dp_rank: prefill.dp_rank(),
+            decode_dp_rank: _decode.dp_rank(),
         }))
     }
 

--- a/atom/mesh/src/core/placement/tests.rs
+++ b/atom/mesh/src/core/placement/tests.rs
@@ -1486,10 +1486,13 @@ mod f_atom_adapter {
             transfer_id: "xfer-test".to_string(),
             prefill_url: "http://p:8000".to_string(),
             prefill_dp_size: 4,
+            prefill_dp_rank: Some(2),
+            decode_dp_rank: Some(2),
         });
         let mut kv = json!({});
         adapter.enrich_decode_kv(&mut kv, &ctx).unwrap();
         assert_eq!(kv["remote_dp_size"], json!(4));
+        assert_eq!(kv["remote_dp_rank"], json!(2));
         assert_eq!(kv["remote_tp_size"], json!(8));
     }
 
@@ -1537,6 +1540,8 @@ mod f_atom_adapter {
             transfer_id: "x".to_string(),
             prefill_url: "http://unknown:8000".to_string(),
             prefill_dp_size: 1,
+            prefill_dp_rank: None,
+            decode_dp_rank: None,
         });
         let mut kv = json!({});
         let err = adapter.enrich_decode_kv(&mut kv, &ctx).unwrap_err();

--- a/atom/mesh/src/core/steps/worker/local/discover_dp.rs
+++ b/atom/mesh/src/core/steps/worker/local/discover_dp.rs
@@ -1,11 +1,23 @@
 //! Data Parallel (DP) information discovery step.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
-use tracing::debug;
+use once_cell::sync::Lazy;
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, warn};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
-use super::discover_metadata::get_server_info;
+use super::discover_metadata::{get_openai_model_id, get_server_info};
 use crate::core::{steps::workflow_data::LocalWorkerWorkflowData, UNKNOWN_MODEL_ID};
+
+static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("Failed to create HTTP client")
+});
 
 /// DP (Data Parallel) information for a worker.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -14,23 +26,86 @@ pub struct DpInfo {
     pub model_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct AtomKvTransferInfo {
+    dp_size: Option<usize>,
+}
+
+async fn get_atom_dp_size(url: &str, api_key: Option<&str>) -> Result<usize, String> {
+    let base_url = url.trim_end_matches('/');
+    let endpoint = format!("{}/kv_transfer_info", base_url);
+    let mut req = HTTP_CLIENT.get(&endpoint);
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key);
+    }
+
+    let response = req
+        .send()
+        .await
+        .map_err(|e| format!("Failed to connect to {}: {}", endpoint, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "Server returned status {} from {}",
+            response.status(),
+            endpoint
+        ));
+    }
+
+    let info = response
+        .json::<AtomKvTransferInfo>()
+        .await
+        .map_err(|e| format!("Failed to parse response from {}: {}", endpoint, e))?;
+
+    info.dp_size
+        .ok_or_else(|| format!("No dp_size in response from {}", endpoint))
+}
+
 /// Get DP info for a worker URL.
 pub async fn get_dp_info(url: &str, api_key: Option<&str>) -> Result<DpInfo, String> {
-    let info = get_server_info(url, api_key).await?;
+    let info = match get_server_info(url, api_key).await {
+        Ok(info) => Some(info),
+        Err(e) => {
+            debug!(
+                "Unable to fetch /server_info for DP discovery from {}; trying ATOM /kv_transfer_info fallback: {}",
+                url, e
+            );
+            None
+        }
+    };
 
-    let dp_size = info
-        .dp_size
-        .ok_or_else(|| format!("No dp_size in response from {}", url))?;
+    let dp_size = if let Some(dp_size) = info.as_ref().and_then(|info| info.dp_size) {
+        dp_size
+    } else {
+        let dp_size = get_atom_dp_size(url, api_key).await.map_err(|e| {
+            format!(
+                "No dp_size in /server_info response from {} and ATOM /kv_transfer_info fallback failed: {}",
+                url, e
+            )
+        })?;
+        warn!(
+            "Using ATOM /kv_transfer_info dp_size={} for DP-aware worker discovery at {}",
+            dp_size, url
+        );
+        dp_size
+    };
 
-    let model_id = info
-        .model_id
-        .filter(|s| !s.is_empty())
-        .or(info.served_model_name.filter(|s| !s.is_empty()))
-        .or_else(|| {
-            info.model_path
-                .and_then(|path| path.split('/').next_back().map(|s| s.to_string()))
-        })
-        .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string());
+    let model_id = if let Some(model_id) = info
+        .and_then(|info| {
+            info.model_id
+                .filter(|s| !s.is_empty())
+                .or(info.served_model_name.filter(|s| !s.is_empty()))
+                .or_else(|| {
+                    info.model_path
+                        .and_then(|path| path.split('/').next_back().map(|s| s.to_string()))
+                })
+        }) {
+        model_id
+    } else {
+        get_openai_model_id(url, api_key)
+            .await
+            .unwrap_or_else(|_| UNKNOWN_MODEL_ID.to_string())
+    };
 
     Ok(DpInfo { dp_size, model_id })
 }

--- a/atom/mesh/src/routers/http_pd_router.rs
+++ b/atom/mesh/src/routers/http_pd_router.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
 
 use async_trait::async_trait;
 use axum::{
@@ -16,7 +20,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    config::types::{BackendType, RetryConfig},
+    config::types::{AtomPdRankMappingPolicy, BackendType, RetryConfig},
     core::{
         is_retryable_status,
         placement::{
@@ -69,6 +73,7 @@ pub struct PDRouter {
     pub client: Client,
     pub retry_config: RetryConfig,
     pub backend: BackendType,
+    pub atom_pd_rank_mapping_policy: AtomPdRankMappingPolicy,
     pub planner: Arc<dyn PdPlanner>,
     pub adapter: Arc<dyn BackendAdapter>,
     /// Set when backend == Atom. enrich_decode_kv is ATOM-specific and not on the trait.
@@ -82,6 +87,10 @@ impl std::fmt::Debug for PDRouter {
             .field("client", &self.client)
             .field("retry_config", &self.retry_config)
             .field("backend", &self.backend)
+            .field(
+                "atom_pd_rank_mapping_policy",
+                &self.atom_pd_rank_mapping_policy,
+            )
             .finish()
     }
 }
@@ -201,10 +210,86 @@ impl PDRouter {
             client,
             retry_config: ctx.router_config.effective_retry_config(),
             backend,
+            atom_pd_rank_mapping_policy: ctx.router_config.atom_pd_rank_mapping_policy,
             planner,
             adapter,
             atom_adapter,
         })
+    }
+
+    fn apply_atom_pd_rank_mapping_policy(
+        &self,
+        prefill: Arc<dyn Worker>,
+        decode: &Arc<dyn Worker>,
+    ) -> Arc<dyn Worker> {
+        match self.atom_pd_rank_mapping_policy {
+            AtomPdRankMappingPolicy::None => prefill,
+            AtomPdRankMappingPolicy::Idx2Idx => self.map_atom_prefill_idx2idx(prefill, decode),
+        }
+    }
+
+    fn map_atom_prefill_idx2idx(
+        &self,
+        prefill: Arc<dyn Worker>,
+        decode: &Arc<dyn Worker>,
+    ) -> Arc<dyn Worker> {
+        let (Some(prefill_dp_size), Some(decode_dp_rank)) = (prefill.dp_size(), decode.dp_rank())
+        else {
+            debug!(
+                "ATOM PD rank mapping policy=idx2idx skipped: prefill={} prefill_dp_size={:?} decode={} decode_dp_rank={:?}",
+                prefill.url(),
+                prefill.dp_size(),
+                decode.url(),
+                decode.dp_rank()
+            );
+            return prefill;
+        };
+
+        if decode_dp_rank >= prefill_dp_size {
+            warn!(
+                "ATOM PD rank mapping policy=idx2idx skipped: decode rank {} is outside prefill dp_size {} (prefill={}, decode={})",
+                decode_dp_rank,
+                prefill_dp_size,
+                prefill.url(),
+                decode.url()
+            );
+            return prefill;
+        }
+
+        if prefill.dp_rank() == Some(decode_dp_rank) {
+            return prefill;
+        }
+
+        let mapped_url = format!("{}@{}", prefill.base_url(), decode_dp_rank);
+        match self.worker_registry.get_by_url(&mapped_url) {
+            Some(mapped) if mapped.is_healthy() => {
+                info!(
+                    "ATOM PD rank mapping policy=idx2idx: prefill {} -> {}, decode={}",
+                    prefill.url(),
+                    mapped.url(),
+                    decode.url()
+                );
+                mapped
+            }
+            Some(mapped) => {
+                warn!(
+                    "ATOM PD rank mapping policy=idx2idx target {} is unhealthy; keeping prefill {} (decode={})",
+                    mapped.url(),
+                    prefill.url(),
+                    decode.url()
+                );
+                prefill
+            }
+            None => {
+                warn!(
+                    "ATOM PD rank mapping policy=idx2idx target {} not found; keeping prefill {} (decode={})",
+                    mapped_url,
+                    prefill.url(),
+                    decode.url()
+                );
+                prefill
+            }
+        }
     }
 
     async fn fetch_vllm_prefill_info(
@@ -314,9 +399,17 @@ impl PDRouter {
         }
 
         let mut tp_sizes = HashMap::new();
+        let mut queried_base_urls = HashSet::new();
         for worker in &prefill_workers {
             let worker_url = worker.url().to_string();
-            let info_url = format!("{}/kv_transfer_info", worker_url);
+            let base_url = worker.base_url().trim_end_matches('/').to_string();
+            if !queried_base_urls.insert(base_url.clone()) {
+                if let Some(tp) = tp_sizes.get(&base_url).copied() {
+                    tp_sizes.insert(worker_url, tp);
+                }
+                continue;
+            }
+            let info_url = format!("{}/kv_transfer_info", base_url);
 
             info!("Querying ATOM prefill kv_transfer_info: {}", info_url);
             let resp = client
@@ -341,10 +434,11 @@ impl PDRouter {
             if kv_role != Some("kv_producer") {
                 return Err(format!(
                     "{} is not a prefill (kv_role={:?}, expected kv_producer)",
-                    worker_url, kv_role
+                    base_url, kv_role
                 ));
             }
-            info!("ATOM prefill {} tp_size={}", worker_url, tp);
+            info!("ATOM prefill {} tp_size={}", base_url, tp);
+            tp_sizes.insert(base_url, tp);
             tp_sizes.insert(worker_url, tp);
         }
         Ok(AtomPrefillInfo { tp_sizes })
@@ -420,7 +514,7 @@ impl PDRouter {
             stream: context.is_stream,
         };
 
-        let (prefill, decode, prefill_policy, decode_policy) =
+        let (mut prefill, decode, prefill_policy, decode_policy) =
             match self.planner.plan(&descriptor).await {
                 Ok(PlacementPlan::Pair {
                     prefill,
@@ -451,6 +545,18 @@ impl PDRouter {
             model,
             decode_policy,
         );
+
+        if let BackendType::Atom = self.backend {
+            prefill = self.apply_atom_pd_rank_mapping_policy(prefill, &decode);
+            info!(
+                "ATOM PD DP ranks selected: policy={} prefill={} prefill_dp_rank={:?} decode={} decode_dp_rank={:?}",
+                self.atom_pd_rank_mapping_policy,
+                prefill.url(),
+                prefill.dp_rank(),
+                decode.url(),
+                decode.dp_rank()
+            );
+        }
 
         let ctx = self
             .adapter
@@ -606,14 +712,20 @@ impl PDRouter {
 
         // P request: fire-and-forget background task. Mooncake coordinates KV transfer
         // via its own out-of-band channel; we only need to ensure P starts processing.
-        let prefill_post = self.build_post_with_headers(
-            &self.client,
-            prefill.url(),
-            context.route,
-            &prefill_request_json,
-            headers,
-            false,
-        );
+        let prefill_post = match self
+            .build_worker_post_with_headers(
+                &self.client,
+                prefill.as_ref(),
+                context.route,
+                prefill_request_json,
+                headers,
+                false,
+            )
+            .await
+        {
+            Ok(req) => req,
+            Err(resp) => return resp,
+        };
         let prefill_url_for_log = prefill.url().to_string();
         let prefill_for_outcome = prefill.clone();
         let correlation_for_log = correlation_id.unwrap_or_else(|| "unknown".to_string());
@@ -647,14 +759,20 @@ impl PDRouter {
         });
 
         // D request: client sees the streamed (or buffered) response from D.
-        let decode_post = self.build_post_with_headers(
-            &self.client,
-            decode.url(),
-            context.route,
-            &decode_request_json,
-            headers,
-            false,
-        );
+        let decode_post = match self
+            .build_worker_post_with_headers(
+                &self.client,
+                decode.as_ref(),
+                context.route,
+                decode_request_json,
+                headers,
+                false,
+            )
+            .await
+        {
+            Ok(req) => req,
+            Err(resp) => return resp,
+        };
         let decode_result = decode_post.send().await;
         events::RequestReceivedEvent {}.emit();
 
@@ -871,14 +989,20 @@ impl PDRouter {
         }
         .emit();
 
-        let prefill_post = self.build_post_with_headers(
-            &self.client,
-            prefill.url(),
-            context.route,
-            &prefill_request_json,
-            headers,
-            false,
-        );
+        let prefill_post = match self
+            .build_worker_post_with_headers(
+                &self.client,
+                prefill.as_ref(),
+                context.route,
+                prefill_request_json,
+                headers,
+                false,
+            )
+            .await
+        {
+            Ok(req) => req,
+            Err(resp) => return resp,
+        };
         let correlation_for_log = correlation_id
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
@@ -989,14 +1113,20 @@ impl PDRouter {
         };
         decode_obj.insert("kv_transfer_params".to_string(), kv_params);
 
-        let decode_post = self.build_post_with_headers(
-            &self.client,
-            decode.url(),
-            context.route,
-            &decode_request_json,
-            headers,
-            false,
-        );
+        let decode_post = match self
+            .build_worker_post_with_headers(
+                &self.client,
+                decode.as_ref(),
+                context.route,
+                decode_request_json,
+                headers,
+                false,
+            )
+            .await
+        {
+            Ok(req) => req,
+            Err(resp) => return resp,
+        };
         let decode_result = decode_post.send().await;
         events::RequestReceivedEvent {}.emit();
 
@@ -1665,6 +1795,45 @@ impl PDRouter {
         request
     }
 
+    async fn build_worker_post_with_headers(
+        &self,
+        client: &Client,
+        worker: &dyn Worker,
+        route: &'static str,
+        json_request: Value,
+        headers: Option<&HeaderMap>,
+        connection_close: bool,
+    ) -> Result<reqwest::RequestBuilder, Response> {
+        let prepared_request = worker.prepare_request(json_request).await.map_err(|e| {
+            error!(
+                worker_url = %worker.url(),
+                error = ?e,
+                "Failed to prepare DP-aware worker request"
+            );
+            error::internal_error(
+                "worker_prepare_request_failed",
+                format!("Failed to prepare worker request for {}: {:?}", worker.url(), e),
+            )
+        })?;
+
+        let mut request = client
+            .post(worker.endpoint_url(route))
+            .json(&prepared_request);
+        if connection_close {
+            request = request.header("Connection", "close");
+        }
+        if let Some(headers) = headers {
+            for (name, value) in headers.iter() {
+                if header_utils::should_forward_request_header(name.as_str()) {
+                    if let Ok(val) = value.to_str() {
+                        request = request.header(name, val);
+                    }
+                }
+            }
+        }
+        Ok(request)
+    }
+
     // Helper to merge logprobs from prefill and decode responses
     // Optimized to avoid double cloning by taking ownership of decode array
     fn merge_logprobs_in_json(prefill_json: &Value, decode_json: &mut Value) -> bool {
@@ -1965,7 +2134,10 @@ impl RouterTrait for PDRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{placement::backend::sglang::SglangAdapter, BasicWorkerBuilder, WorkerType};
+    use crate::core::{
+        placement::backend::sglang::SglangAdapter, BasicWorkerBuilder, DPAwareWorkerBuilder,
+        WorkerType,
+    };
 
     fn create_test_pd_router() -> PDRouter {
         let worker_registry = Arc::new(WorkerRegistry::new());
@@ -1984,6 +2156,7 @@ mod tests {
             client: Client::new(),
             retry_config: RetryConfig::default(),
             backend: BackendType::Sglang,
+            atom_pd_rank_mapping_policy: AtomPdRankMappingPolicy::None,
             planner,
             adapter,
             atom_adapter: None,
@@ -1996,6 +2169,80 @@ mod tests {
             .build();
         worker.set_healthy(healthy);
         Box::new(worker)
+    }
+
+    fn create_test_dp_worker(
+        base_url: &str,
+        dp_rank: usize,
+        dp_size: usize,
+        worker_type: WorkerType,
+        healthy: bool,
+    ) -> Arc<dyn Worker> {
+        let worker = DPAwareWorkerBuilder::new_with_type(
+            base_url.to_string(),
+            dp_rank,
+            dp_size,
+            worker_type,
+        )
+        .build();
+        worker.set_healthy(healthy);
+        Arc::new(worker)
+    }
+
+    #[test]
+    fn test_atom_pd_rank_mapping_none_keeps_prefill_rank() {
+        let mut router = create_test_pd_router();
+        router.backend = BackendType::Atom;
+        router.atom_pd_rank_mapping_policy = AtomPdRankMappingPolicy::None;
+
+        let prefill = create_test_dp_worker(
+            "http://prefill",
+            2,
+            8,
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        );
+        let decode = create_test_dp_worker("http://decode", 5, 8, WorkerType::Decode, true);
+
+        let mapped = router.apply_atom_pd_rank_mapping_policy(prefill.clone(), &decode);
+        assert_eq!(mapped.url(), prefill.url());
+        assert_eq!(mapped.dp_rank(), Some(2));
+    }
+
+    #[test]
+    fn test_atom_pd_rank_mapping_idx2idx_maps_prefill_to_decode_rank() {
+        let mut router = create_test_pd_router();
+        router.backend = BackendType::Atom;
+        router.atom_pd_rank_mapping_policy = AtomPdRankMappingPolicy::Idx2Idx;
+
+        let prefill_rank_2 = create_test_dp_worker(
+            "http://prefill",
+            2,
+            8,
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        );
+        let prefill_rank_5 = create_test_dp_worker(
+            "http://prefill",
+            5,
+            8,
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        );
+        let decode_rank_5 = create_test_dp_worker("http://decode", 5, 8, WorkerType::Decode, true);
+
+        router.worker_registry.register(prefill_rank_2.clone());
+        router.worker_registry.register(prefill_rank_5.clone());
+
+        let mapped = router.apply_atom_pd_rank_mapping_policy(prefill_rank_2, &decode_rank_5);
+        assert_eq!(mapped.url(), "http://prefill@5");
+        assert_eq!(mapped.dp_rank(), Some(5));
     }
 
     #[test]

--- a/atom/mesh/src/server.rs
+++ b/atom/mesh/src/server.rs
@@ -23,7 +23,7 @@ use wfaas::LoggingSubscriber;
 
 use crate::{
     app_context::AppContext,
-    config::RouterConfig,
+    config::{RouterConfig, RoutingMode},
     core::{
         job_queue::{JobQueue, JobQueueConfig},
         steps::{TokenizerConfigRequest, WorkflowEngines},
@@ -59,6 +59,32 @@ pub struct AppState {
     pub context: Arc<AppContext>,
     pub concurrency_queue_tx: Option<tokio::sync::mpsc::Sender<QueuedRequest>>,
     pub router_manager: Option<Arc<RouterManager>>,
+}
+
+fn configured_worker_urls(config: &RouterConfig) -> Vec<String> {
+    match &config.mode {
+        RoutingMode::Regular { worker_urls } => worker_urls.clone(),
+        RoutingMode::PrefillDecode {
+            prefill_urls,
+            decode_urls,
+            ..
+        } => prefill_urls
+            .iter()
+            .map(|(url, _)| url.clone())
+            .chain(decode_urls.iter().cloned())
+            .collect(),
+    }
+}
+
+fn has_registered_worker_for_url(registered_urls: &[String], configured_url: &str) -> bool {
+    let configured = configured_url.trim_end_matches('/');
+    registered_urls.iter().any(|url| {
+        let registered = url.trim_end_matches('/');
+        registered == configured
+            || registered
+                .strip_prefix(configured)
+                .map_or(false, |suffix| suffix.starts_with('@'))
+    })
 }
 
 async fn parse_function_call(
@@ -657,23 +683,31 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     // so we poll until all expected workers appear in the registry.
     let expected_workers = config.router_config.mode.worker_count();
     if expected_workers > 0 {
+        let expected_worker_urls = configured_worker_urls(&config.router_config);
         let max_wait = Duration::from_secs(config.router_config.worker_startup_timeout_secs + 60);
         let poll_interval = Duration::from_millis(500);
         let start = std::time::Instant::now();
         loop {
             let current = app_context.worker_registry.len();
-            if current >= expected_workers {
+            let registered_urls = app_context.worker_registry.get_all_urls();
+            let missing_worker_urls: Vec<&str> = expected_worker_urls
+                .iter()
+                .map(String::as_str)
+                .filter(|url| !has_registered_worker_for_url(&registered_urls, url))
+                .collect();
+            if current >= expected_workers && missing_worker_urls.is_empty() {
                 info!(
-                    "All {} expected workers registered (took {:?})",
+                    "All {} expected worker endpoint(s) registered as {} worker(s) (took {:?})",
                     expected_workers,
+                    current,
                     start.elapsed()
                 );
                 break;
             }
             if start.elapsed() > max_wait {
                 warn!(
-                    "Timed out waiting for workers: {} of {} registered after {:?}",
-                    current, expected_workers, max_wait
+                    "Timed out waiting for workers: {} worker(s) registered, expected {} endpoint(s), missing {:?} after {:?}",
+                    current, expected_workers, missing_worker_urls, max_wait
                 );
                 break;
             }

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -397,17 +397,32 @@ class CoreManager:
                 copy=False,
             )
         else:
-            # DP ranks, round-robin with counter for load balancing for atom server
+            # DP ranks: honor an explicit atomesh DPA routing hint when present;
+            # otherwise keep the existing round-robin behavior.
             dp_seqs = [[] for _ in range(self.local_engine_count)]
             for seq in seqs:
-                dp_rank = self._rr_counter % self.local_engine_count
+                requested_dp_rank = getattr(seq, "data_parallel_rank", None)
+                if requested_dp_rank is not None:
+                    dp_rank = int(requested_dp_rank)
+                    if not 0 <= dp_rank < self.local_engine_count:
+                        raise ValueError(
+                            f"Invalid data_parallel_rank={dp_rank}; "
+                            f"local_engine_count={self.local_engine_count}"
+                        )
+                else:
+                    dp_rank = self._rr_counter % self.local_engine_count
+                    self._rr_counter += 1
                 dp_seqs[dp_rank].append(seq)
-                self._rr_counter += 1
 
             for dp_rank, rank_seqs in enumerate(dp_seqs):
                 if rank_seqs:
-                    logger.debug(
-                        f"{self.label}: Add {len(rank_seqs)} requests to DP rank {dp_rank}"
+                    request_ids = [seq.id for seq in rank_seqs]
+                    logger.info(
+                        "%s: Add %d request(s) to DP rank %d, sequence ids: %s",
+                        self.label,
+                        len(rank_seqs),
+                        dp_rank,
+                        request_ids,
                     )
                     self.input_sockets[dp_rank].send_multipart(
                         [


### PR DESCRIPTION
  This patch fixes several issues in ATOM disaggregated inference with DPA:

  1. Preserve data_parallel_rank in OpenAI completion requests
     - Add data_parallel_rank to CompletionRequest.
     - Pass it through the non-streaming /v1/completions path.
     - Attach it to the sequence before engine scheduling.

  2. Honor pinned DP ranks in the ATOM engine
     - Route requests to the requested DP rank when data_parallel_rank is set.
     - Keep existing round-robin behavior when no rank is specified.
     - Validate invalid DP rank values.

  3. Align prefill and decode DP ranks in mesh
     - Select matching prefill@N and decode@N workers for ATOM PD requests.
     - Inject data_parallel_rank into worker requests.
     - Avoid prefill/decode rank mismatch during KV transfer.

  4. Fix KV-transfer metadata rank selection
     - Track selected prefill/decode DP ranks in the ATOM pair context.
     - Use the aligned prefill DP rank when enriching decode KV metadata.

  5. Improve ATOM DP worker discovery
     - Fall back to /kv_transfer_info when /server_info lacks DP metadata.
     - Fall back to /v1/models for model id discovery.
     - Allow mesh to expand ATOM endpoints into per-DP-rank workers.

  6. Wait for expanded DP workers during mesh startup
     - Wait until all configured ATOM endpoints are registered as DP workers.
     - Prevent routing before the full worker set is ready.

  7. Make Mooncake transfer completion safer
     - Return transfer success/failure from block and slot transfer paths.
     - Avoid sending write-done after a failed transfer.
     - Improve RDMA-local IP detection from IB devices/GIDs.