### PR TITLE
[atom-sgl-accuracy] Add fewshot for GLM-5.1-FP8 on MI355

### DIFF
--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -302,6 +302,7 @@
     "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models",
     "runner": "atom-mi355-8gpu-conductor-sgl-runner",
     "test_level": "nightly",
+    "lm_eval_num_fewshot": 5,
     "accuracy_threshold": 0.9,
     "accuracy_baseline": null,
     "accuracy_baseline_model": "zai-org/GLM-5.1-FP8",

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -351,6 +351,7 @@ jobs:
                   "model_name": "GLM-5.1-FP8 TP8",
                   "model_path": "zai-org/GLM-5.1-FP8",
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
+                  "lm_eval_num_fewshot": 5,
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models",
                   "runner": "atom-plugin-acc-validation-runner",


### PR DESCRIPTION
## Motivation

Add  `--num_fewshot 5` for GLM-5.1-FP8 on MI355 to improve performance.

Without parameter "--num_fewshot", "--num_fewshot" is default set 3, the flexible-extract value of GLM-5.1-FP8 TP8 is about 0.9030. 
<img width="736" height="135" alt="image" src="https://github.com/user-attachments/assets/355047d8-5d89-47c8-a3f8-90faf3096054" />
When "--num_fewshot" is set 5, the flexible-extract value of GLM-5.1-FP8 TP8 is 0.9507
<img width="737" height="134" alt="image" src="https://github.com/user-attachments/assets/fb26c2e1-a9e6-4622-9981-d41f447d22cf" />
