### PR TITLE
[Fix] Automatic orphan reaping  so EngineCore/worker processes can't pin stale IPC/VRAM on parent exit

### DIFF
--- a/atom/model_engine/async_proc.py
+++ b/atom/model_engine/async_proc.py
@@ -72,6 +72,17 @@ class AsyncIOProc:
         *args,
         **kwargs,
     ):
+        # Bind this worker's lifetime to its parent EngineCore: if the parent
+        # exits for any reason, have the kernel reap this process immediately
+        # instead of leaving it orphaned. A ModelRunner worker holds a large GPU
+        # allocation and the custom all-reduce IPC resources; an orphan blocks
+        # forever in busy_loop() on the shm dequeue while keeping those pinned,
+        # causing the stale-IPC all-reduce crash on the next restart. Must be
+        # armed here, before any GPU / IPC state is created.
+        from atom.utils import enable_orphan_reaping
+
+        enable_orphan_reaping()
+
         # NUMA-local CPU/memory pinning (see atom.utils.numa_utils).
         # Auto-detects the GPU's local node by default; gated by
         # ATOM_NUMA_BIND. Must run before any large allocation / native

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -198,6 +198,16 @@ class EngineCore:
 
     @staticmethod
     def run_engine(config: Config, input_address: str, output_address: str):
+        # Bind this EngineCore's lifetime to its parent (the server /
+        # CoreManager): if the parent exits, have the kernel reap this process —
+        # and, transitively, the ModelRunner workers it spawns — instead of
+        # leaving them orphaned. Orphans keep pinning GPU VRAM + the custom
+        # all-reduce IPC handles / rendezvous TCPStore, which makes the next
+        # restart reuse a stale hipIpc handle and crash. See
+        # atom.utils.enable_orphan_reaping for the full rationale.
+        from atom.utils import enable_orphan_reaping
+
+        enable_orphan_reaping()
         engine: EngineCore = None
         try:
             if config.parallel_config.data_parallel_size > 1:

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -8,6 +8,7 @@ import multiprocessing
 import os
 import signal
 import socket
+import sys
 import tempfile
 import time
 from functools import lru_cache
@@ -223,6 +224,73 @@ def shutdown_all_processes(procs: list[BaseProcess], allowed_seconds: int = 2):
             proc.close()
         except (ValueError, OSError):
             pass
+
+
+def enable_orphan_reaping(sig: int = signal.SIGKILL) -> bool:
+    """Arm the kernel to reap *this* process if its parent ever exits.
+
+    ATOM runs a tree of processes: the server (main) -> one ``EngineCore``
+    process per DP rank -> ``tensor_parallel_size`` ``ModelRunner`` worker
+    processes.  Each worker holds a large slice of GPU VRAM plus the custom
+    all-reduce IPC resources (``hipIpcGetMemHandle`` handles + the rendezvous
+    ``TCPStore`` bound to ``MASTER_PORT``).
+
+    If a parent exits abnormally (OOM-kill, segfault, ``SIGKILL``,
+    ``docker stop``) the kernel does not clean up its children: the worker's
+    ``busy_loop`` blocks forever on the shared-memory RPC dequeue and the
+    EngineCore blocks on its input queue.  These orphans keep the VRAM and the
+    IPC/TCP resources pinned, so a subsequent restart either fails to bind the
+    rendezvous port or, worse, opens a *stale* IPC mem handle exported by the
+    dead run -> the ``hipIpcGetMemHandle`` all-reduce crash operators work
+    around with ``docker rm -f`` + a lowered ``--gpu-memory-utilization``.
+
+    This helper wires up ``prctl(PR_SET_PDEATHSIG)`` so the kernel delivers
+    ``sig`` to the caller the instant its parent exits, for *any* reason --
+    turning a silent orphan into an immediate, self-reaping exit that releases
+    every GPU and IPC resource it held.  The setting is per-thread and is
+    cleared across ``execve``, so it cannot be inherited: each process must arm
+    itself early in its entrypoint, before any GPU / IPC state is created.
+
+    Linux-only (no-op elsewhere).  Returns ``True`` when reaping is armed and
+    ``False`` if it could not be set.  If the parent is found to be already gone
+    at arm time, it does not return: it calls ``os._exit(1)`` rather than let the
+    process linger as the orphan this is meant to prevent.
+
+    Caveat: ``PR_SET_PDEATHSIG`` fires when the *thread that created this
+    process* exits, not when the parent process as a whole exits.  Arm it only
+    from a process whose creating thread lives for the process's lifetime --
+    ATOM spawns workers from the main thread, so this holds; a short-lived
+    creator thread could otherwise trigger a premature kill.
+    """
+    if not sys.platform.startswith("linux"):
+        return False
+    try:
+        import ctypes
+
+        PR_SET_PDEATHSIG = 1
+        # Resolve libc from the already-loaded image (``CDLL(None)``) rather than
+        # hard-coding ``libc.so.6``; this works on glibc and musl (e.g. Alpine)
+        # alike, where the soname differs.
+        libc = ctypes.CDLL(None, use_errno=True)
+        if libc.prctl(PR_SET_PDEATHSIG, sig, 0, 0, 0) != 0:
+            err = ctypes.get_errno()
+            logger.warning("prctl(PR_SET_PDEATHSIG) failed: errno=%d", err)
+            return False
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Could not arm orphan reaping: %s", e)
+        return False
+
+    # The parent can die between spawning us and this call -- before or after the
+    # prctl above -- so PR_SET_PDEATHSIG may never fire.  Detect it unambiguously
+    # via multiprocessing's parent handle (a sentinel pipe): unlike
+    # ``getppid() == 1``, this is not fooled by a parent that legitimately runs
+    # as PID 1 (ATOM's server is PID 1 in the container).  If the parent is
+    # already gone, exit now rather than linger as the orphan this prevents.
+    parent = multiprocessing.parent_process()
+    if parent is not None and not parent.is_alive():
+        logger.warning("Parent already exited while arming orphan reaping; exiting.")
+        os._exit(1)
+    return True
 
 
 def kill_process_tree(pid: int):

--- a/tests/test_orphan_reaping.py
+++ b/tests/test_orphan_reaping.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+"""CPU unit test for atom.utils.enable_orphan_reaping (bug5 IPC lifecycle).
+
+No GPU required. Builds a 3-level process tree:
+
+    main (this test)  ->  parent P  ->  child G
+
+G arms ``enable_orphan_reaping(SIGKILL)`` and then blocks forever. We kill P
+and assert that G is reaped by the OS (not left orphaned holding resources).
+
+Liveness is detected with a pipe whose write end only G keeps open: while G is
+alive the pipe stays open; the instant G dies (for any reason, including the
+kernel-delivered PR_SET_PDEATHSIG) its fds close and main sees EOF. This is
+independent of who reaps the zombie, so it works whether G reparents to a
+subreaper or to init.
+
+A negative-control test forks a child that does NOT arm reaping and asserts it
+is instead left orphaned/alive after its parent dies — proving the test
+actually exercises the mechanism the fix installs.
+"""
+
+import ast
+import logging
+import multiprocessing
+import os
+import select
+import signal
+import sys
+import textwrap
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="PR_SET_PDEATHSIG is Linux-only",
+)
+
+_UTILS_SRC = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "atom",
+    "utils",
+    "__init__.py",
+)
+
+
+def _load_enable_orphan_reaping():
+    """Return the REAL enable_orphan_reaping from atom/utils/__init__.py.
+
+    Prefer a normal import (works when the full atom package is importable, e.g.
+    inside a container with an up-to-date aiter). Fall back to extracting the
+    exact function body from the source file with AST, so this test still ties
+    to the shipped source on a CPU-only host where importing the whole `atom`
+    package pulls torch/aiter. Either way we exercise the real function text.
+    """
+    try:
+        from atom.utils import enable_orphan_reaping
+
+        return enable_orphan_reaping
+    except ImportError:
+        # A missing heavy dep (torch/aiter on a CPU-only host) is the expected
+        # reason the package import fails here; fall back to reading the function
+        # straight from source. Non-import errors (SyntaxError/runtime) still
+        # propagate, and the fallback exec()s the *same* source, so a genuine
+        # defect in enable_orphan_reaping is not masked either way.
+        with open(_UTILS_SRC) as f:
+            src = f.read()
+        tree = ast.parse(src)
+        for node in tree.body:
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "enable_orphan_reaping"
+            ):
+                fn_src = ast.get_source_segment(src, node)
+                ns = {
+                    "signal": signal,
+                    "os": os,
+                    "sys": sys,
+                    "multiprocessing": multiprocessing,
+                    "logger": logging.getLogger("atom-test"),
+                }
+                exec(textwrap.dedent(fn_src), ns)
+                return ns["enable_orphan_reaping"]
+        raise RuntimeError("enable_orphan_reaping not found in source")
+
+
+_enable_orphan_reaping = _load_enable_orphan_reaping()
+
+
+def _spawn_tree(arm: bool):
+    """Fork main -> P -> G. G optionally arms orphan reaping, then blocks.
+
+    Returns (parent_pid, read_fd). ``read_fd`` gets a line with G's pid as the
+    ready signal, and later reaches EOF exactly when G dies.
+    """
+    r, w = os.pipe()
+    pid_p = os.fork()
+    if pid_p == 0:
+        # ---- process P (the "parent" we will kill) ----
+        os.close(r)
+        pid_g = os.fork()
+        if pid_g == 0:
+            # ---- process G (the child that should die with its parent) ----
+            try:
+                if arm:
+                    _enable_orphan_reaping(signal.SIGKILL)
+                os.write(w, f"{os.getpid()}\n".encode())
+                while True:
+                    time.sleep(3600)
+            finally:
+                os._exit(0)
+        else:
+            # P: drop the write end so only G holds it, then block forever.
+            os.close(w)
+            while True:
+                time.sleep(3600)
+    else:
+        # ---- main ----
+        os.close(w)  # only G now holds the write end
+        return pid_p, r
+
+
+def _read_ready_pid(read_fd, timeout=15.0):
+    deadline = time.monotonic() + timeout
+    buf = b""
+    while b"\n" not in buf:
+        remaining = deadline - time.monotonic()
+        assert remaining > 0, "timed out waiting for child ready signal"
+        rl, _, _ = select.select([read_fd], [], [], remaining)
+        assert rl, "timed out waiting for child ready signal"
+        buf += os.read(read_fd, 64)
+    return int(buf.split(b"\n")[0])
+
+
+def _wait_eof(read_fd, timeout):
+    """Return True if the pipe reaches EOF (child died) within timeout."""
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        rl, _, _ = select.select([read_fd], [], [], remaining)
+        if not rl:
+            return False
+        if os.read(read_fd, 64) == b"":  # EOF -> G's fds closed -> G dead
+            return True
+
+
+def test_child_dies_when_parent_dies():
+    """G arms orphan reaping; killing P must cause the kernel to kill G."""
+    pid_p, read_fd = _spawn_tree(arm=True)
+    gpid = None
+    try:
+        gpid = _read_ready_pid(read_fd)
+        os.kill(pid_p, signal.SIGKILL)
+        reaped = _wait_eof(read_fd, timeout=10.0)
+        assert (
+            reaped
+        ), "child was orphaned: PR_SET_PDEATHSIG did not fire when parent died"
+    finally:
+        os.close(read_fd)
+        _reap(pid_p)
+        if gpid is not None:
+            try:
+                os.kill(gpid, signal.SIGKILL)  # ensure no leak if assert failed
+            except ProcessLookupError:
+                pass
+            _reap(gpid)
+
+
+def test_child_orphaned_without_arming():
+    """Negative control: without reaping armed, G survives P's death (orphan)."""
+    pid_p, read_fd = _spawn_tree(arm=False)
+    gpid = None
+    try:
+        gpid = _read_ready_pid(read_fd)
+        os.kill(pid_p, signal.SIGKILL)
+        # Expect NO EOF: the child stays alive (orphaned) after the parent dies.
+        reaped = _wait_eof(read_fd, timeout=3.0)
+        assert not reaped, "control child unexpectedly died without PR_SET_PDEATHSIG"
+    finally:
+        os.close(read_fd)
+        _reap(pid_p)
+        if gpid is not None:
+            try:
+                os.kill(gpid, signal.SIGKILL)  # clean up the deliberate orphan
+            except ProcessLookupError:  # already gone (e.g. external teardown)
+                pass
+            _reap(gpid)
+
+
+def _reap(pid):
+    if pid is None:
+        return
+    try:
+        os.waitpid(pid, 0)
+    except (ChildProcessError, OSError):
+        pass
+
+
+if __name__ == "__main__":
+    test_child_dies_when_parent_dies()
+    print("PASS: child reaped when parent dies (orphan reaping armed)")
+    test_child_orphaned_without_arming()
+    print("PASS: child orphaned when reaping NOT armed (control)")
+    print("\nALL PASS")


### PR DESCRIPTION

ATOM spawns server -> EngineCore (per DP rank) -> ModelRunner workers. Each worker holds a large GPU allocation plus the custom all-reduce IPC resources (hipIpcGetMemHandle handles + the rendezvous TCPStore on MASTER_PORT). When a parent exits abnormally (OOM-kill, segfault, SIGKILL, `docker stop`) the kernel does not clean up its children: the worker blocks forever in busy_loop() on the shm dequeue and the EngineCore blocks on its input queue, leaving orphans that keep VRAM and the IPC/TCP resources pinned. The next restart then reuses a stale hipIpc handle exported by the dead run and crashes the all-reduce.

Add atom.utils.enable_orphan_reaping(): a Linux-only helper that arms prctl(PR_SET_PDEATHSIG) so the kernel reaps a process the instant its parent exits, for any reason -- turning a silent orphan into an immediate, self-reaping exit that releases the GPU and IPC resources it held. Includes a reparent-race guard (ppid==1 -> self-exit) for when the parent already died between fork and the prctl call. No-op on non-Linux.

Arm it at the very top of EngineCore.run_engine and AsyncIOProc.__init__, before any GPU / IPC state is created.

Adds tests/test_orphan_reaping.py: a CPU-only fork test that verifies an armed child is reaped when its parent dies, with a negative control showing the child is orphaned when reaping is NOT armed.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
