### PR TITLE
fix atomesh mocker benchmark timeout

### DIFF
--- a/.github/scripts/atomesh_mocker_benchmark.sh
+++ b/.github/scripts/atomesh_mocker_benchmark.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCENARIO="${SCENARIO:-pd-chat}"
 BENCHMARK_NAME="${BENCHMARK_NAME:-${SCENARIO}}"
 DURATION="${DURATION:-20s}"
-KILL_AFTER="${KILL_AFTER:-300s}"
+KILL_AFTER="${KILL_AFTER:-30s}"
 PRODUCER_THREADS="${PRODUCER_THREADS:-1}"
 CONSUMER_THREADS="${CONSUMER_THREADS:-8}"
 PREFILL_WORKERS="${PREFILL_WORKERS:-1}"
@@ -35,6 +35,29 @@ if (( PREFILL_WORKERS < 1 || DECODE_WORKERS < 1 )); then
   echo "PREFILL_WORKERS and DECODE_WORKERS must both be >= 1" >&2
   exit 2
 fi
+
+duration_seconds() {
+  local value="$1"
+  local number
+  local multiplier
+  case "${value}" in
+    *s) number="${value%s}"; multiplier=1 ;;
+    *m) number="${value%m}"; multiplier=60 ;;
+    *h) number="${value%h}"; multiplier=3600 ;;
+    *[!0-9]* | "") echo "Invalid duration '${value}'; use an integer with s, m, or h" >&2; return 2 ;;
+    *) number="${value}"; multiplier=1 ;;
+  esac
+
+  if [[ ! "${number}" =~ ^[0-9]+$ || "${number}" -eq 0 ]]; then
+    echo "Invalid duration '${value}'; use a positive integer with s, m, or h" >&2
+    return 2
+  fi
+
+  echo "$((number * multiplier))"
+}
+
+DURATION_SECONDS="$(duration_seconds "${DURATION}")"
+BENCH_TIMEOUT="$((DURATION_SECONDS + 30))s"
 
 pick_ports() {
   python3 - <<'PY'
@@ -134,9 +157,10 @@ wait_http "http://127.0.0.1:${ROUTER_PORT}/health" "Atomesh router"
 echo "=== Running request benchmark ${BENCHMARK_NAME} for ${DURATION} ==="
 BENCH_LOG="${LOG_DIR}/benchmark-request.log"
 set +e
-timeout --signal=INT --kill-after="${KILL_AFTER}" "${DURATION}" \
+timeout --signal=TERM --kill-after="${KILL_AFTER}" "${BENCH_TIMEOUT}" \
   "${MOCKER_BIN}" benchmark-request \
     --base-url "http://127.0.0.1:${ROUTER_PORT}" \
+    --duration "${DURATION}" \
     --producer-threads "${PRODUCER_THREADS}" \
     --consumer-threads "${CONSUMER_THREADS}" \
     "${FIXTURE}" \

--- a/atom/mesh/mocker/main.rs
+++ b/atom/mesh/mocker/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use atomesh_mocker::{
     MockCase, VirtualRequestMode, VirtualRequestPipeline, VirtualRequestPipelineConfig,
@@ -51,6 +51,10 @@ struct BenchmarkRequestArgs {
     #[arg(long, default_value_t = 4096)]
     queue_capacity: usize,
 
+    /// Optional run duration, for example 30s, 3m, or 1h. Without this, run until Ctrl-C.
+    #[arg(long)]
+    duration: Option<String>,
+
     /// Fixture file paths to run.
     #[arg(required = true)]
     fixtures: Vec<PathBuf>,
@@ -93,12 +97,14 @@ async fn run_benchmark_request(
         .map(MockCase::from_fixture)
         .collect::<Result<Vec<_>, _>>()?;
     let mode = request_mode_from_base_url(&args.base_url);
+    let duration = args.duration.as_deref().map(parse_duration).transpose()?;
     let pipeline = VirtualRequestPipeline::try_new(
         VirtualRequestPipelineConfig::new(args.base_url)
             .mode(mode)
             .host_header(args.host)
             .tls_ca_cert_path(args.tls_ca_cert_path)
             .tls_accept_invalid_certs(args.tls_accept_invalid_certs)
+            .duration(duration)
             .producer_threads(args.producer_threads)
             .consumer_threads(args.consumer_threads)
             .queue_capacity(args.queue_capacity),
@@ -122,6 +128,34 @@ fn request_mode_from_base_url(base_url: &str) -> VirtualRequestMode {
     } else {
         VirtualRequestMode::Http
     }
+}
+
+fn parse_duration(value: &str) -> Result<Duration, Box<dyn std::error::Error>> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err("duration must not be empty".into());
+    }
+
+    let (number, multiplier) = match value.as_bytes().last().copied() {
+        Some(b's') => (&value[..value.len() - 1], 1),
+        Some(b'm') => (&value[..value.len() - 1], 60),
+        Some(b'h') => (&value[..value.len() - 1], 60 * 60),
+        Some(byte) if byte.is_ascii_digit() => (value, 1),
+        _ => {
+            return Err(
+                format!("unsupported duration `{value}`; use an integer with s, m, or h").into(),
+            )
+        }
+    };
+
+    let amount = number
+        .parse::<u64>()
+        .map_err(|_| format!("invalid duration `{value}`; use an integer with s, m, or h"))?;
+    if amount == 0 {
+        return Err("duration must be greater than zero".into());
+    }
+
+    Ok(Duration::from_secs(amount.saturating_mul(multiplier)))
 }
 
 async fn run_virtual_workers(args: VirtualWorkersArgs) -> Result<(), Box<dyn std::error::Error>> {

--- a/atom/mesh/mocker/virtual_workers/request.rs
+++ b/atom/mesh/mocker/virtual_workers/request.rs
@@ -6,12 +6,13 @@
 //! or a real HTTP POST for the standalone mocker CLI.
 
 use std::{
+    future,
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use axum::{body::Body, extract::Request, http::header::CONTENT_TYPE};
@@ -235,6 +236,7 @@ pub struct VirtualRequestPipelineConfig {
     pub host_header: Option<String>,
     pub tls_ca_cert_path: Option<PathBuf>,
     pub tls_accept_invalid_certs: bool,
+    pub duration: Option<Duration>,
     pub producer_threads: usize,
     pub consumer_threads: usize,
     pub queue_capacity: usize,
@@ -248,6 +250,7 @@ impl VirtualRequestPipelineConfig {
             host_header: None,
             tls_ca_cert_path: None,
             tls_accept_invalid_certs: false,
+            duration: None,
             producer_threads: 1,
             consumer_threads: 1,
             queue_capacity: 64,
@@ -266,6 +269,11 @@ impl VirtualRequestPipelineConfig {
 
     pub fn tls_accept_invalid_certs(mut self, accept_invalid_certs: bool) -> Self {
         self.tls_accept_invalid_certs = accept_invalid_certs;
+        self
+    }
+
+    pub fn duration(mut self, duration: Option<Duration>) -> Self {
+        self.duration = duration;
         self
     }
 
@@ -394,9 +402,23 @@ impl VirtualRequestPipeline {
         let results = Vec::new();
         let mut first_error = None;
         let mut shutdown_requested = false;
+        let duration = self.config.duration;
+        let duration_sleep = async move {
+            if let Some(duration) = duration {
+                tokio::time::sleep(duration).await;
+            } else {
+                future::pending::<()>().await;
+            }
+        };
+        tokio::pin!(duration_sleep);
         loop {
             tokio::select! {
                 biased;
+                _ = &mut duration_sleep => {
+                    running.store(false, Ordering::Relaxed);
+                    shutdown_requested = true;
+                    break;
+                }
                 _ = tokio::signal::ctrl_c() => {
                     running.store(false, Ordering::Relaxed);
                     shutdown_requested = true;


### PR DESCRIPTION
## Motivation

- Adds an internal `--duration` option to benchmark-request, so benchmark runs stop through the mocker’s own shutdown path instead of relying on external SIGINT.

- Fixes CI 137 failures caused by high-concurrency benchmark cells not exiting promptly after timeout --signal=INT.

- Keeps the workflow protected with an outer safety timeout, now calculated as DURATION + 30s, to handle truly stuck processes.