### PR TITLE
publish ATOMesh benchmark data with MI350X/MI355X hardware tag on dashboard

### DIFF
--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -516,7 +516,7 @@ const DASHBOARD_MODES = ['Aggregated', 'Disaggregated'];
 const ATOMESH_DATA = {
   updatedAt: Date.UTC(2026, 6, 3, 7, 9, 0),
   backend: 'ATOMesh',
-  hardware: 'MI355X',
+  hardware: window.ATOMESH_HARDWARE || 'MI355X',
   gpuCount: 16,
   rocmVersion: '7.2.4',
   dockerImage: 'rocm/atom-dev:nightly_202607030204',
@@ -536,6 +536,13 @@ function atomeshSummaryHeaderKey(header) {
   return String(header || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
 }
 
+function atomeshHardwareKey(value) {
+  const text = String(value || ATOMESH_DATA.hardware || '').toLowerCase();
+  if (text.includes('mi350')) return 'mi350x';
+  if (text.includes('mi355')) return 'mi355x';
+  return text || 'unknown';
+}
+
 function parseAtomeshSummaryRows(markdown) {
   const lines = String(markdown || '').split(/\r?\n/).filter(line => line.trim().startsWith('|'));
   if (lines.length < 3) return [];
@@ -551,7 +558,7 @@ function parseAtomeshSummaryRows(markdown) {
     return {
       id: `atomesh-summary-${idx}`,
       backend: ATOMESH_DATA.backend,
-      hardware: ATOMESH_DATA.hardware.toLowerCase(),
+      hardware: atomeshHardwareKey(raw.hardware),
       model: raw.model || 'unknown',
       topology: raw.topology || 'unknown',
       islOsl: raw.islosl || '--',
@@ -626,6 +633,7 @@ const allRuns = Object.values(rawData.entries).flat().sort((a, b) => b.date - a.
 
 function hardwareFromGpuName(name) {
   const text = String(name || '').toLowerCase();
+  if (text.includes('mi350')) return 'mi350x';
   if (text.includes('mi355') || text.includes('mi35x')) return 'mi355x';
   if (text.includes('mi325')) return 'mi325x';
   if (text.includes('mi308')) return 'mi308x';
@@ -1209,7 +1217,7 @@ function updateHeaderGpuMeta() {
   const span = document.getElementById('header-gpu-meta');
   if (!span) return;
   if (state.dashboardMode === 'Disaggregated') {
-    span.textContent = ` · ${ATOMESH_DATA.hardware} · ROCm ${ATOMESH_DATA.rocmVersion}`;
+    span.textContent = ` · ${fmtHardware(selectedHardware())} · ROCm ${ATOMESH_DATA.rocmVersion}`;
     return;
   }
   const entries = Object.values(filteredConfigs());
@@ -3279,7 +3287,7 @@ function renderAtomeshKPICards() {
       <div class="kpi-card">
         <div class="kpi-label">Hardware</div>
         <div class="kpi-value">${ATOMESH_DATA.gpuCount} <span class="kpi-unit">GPUs</span></div>
-        <div class="kpi-sub">${ATOMESH_DATA.hardware} · ROCm ${ATOMESH_DATA.rocmVersion}</div>
+        <div class="kpi-sub">${fmtHardware(selectedHardware())} · ROCm ${ATOMESH_DATA.rocmVersion}</div>
       </div>
       <div class="kpi-card clickable" id="atomesh-acc-card" title="Click to view accuracy">
         <div class="kpi-label">Accuracy</div>

--- a/.github/scripts/atomesh/process_result.py
+++ b/.github/scripts/atomesh/process_result.py
@@ -243,7 +243,7 @@ def derive_fields(path: Path, payload: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def enrich_payload(
-    path: Path, payload: dict[str, Any], fields: dict[str, Any]
+    path: Path, payload: dict[str, Any], fields: dict[str, Any], hardware: str | None
 ) -> dict[str, Any]:
     env = slurm_job_env(path)
     enriched = dict(payload)
@@ -263,6 +263,13 @@ def enrich_payload(
     enriched.setdefault("decode_workers", env.get("DECODE_WORKERS"))
     enriched.setdefault("prefill_tp", env.get("PREFILL_TP"))
     enriched.setdefault("decode_tp", env.get("DECODE_TP"))
+    runner = env.get("SLURM_SUBMIT_RUNNER", "")
+    if hardware:
+        enriched["hardware"] = hardware
+    elif runner == "atomesh-cicd-mi350":
+        enriched["hardware"] = "MI350X"
+    elif runner == "atomesh-cicd":
+        enriched["hardware"] = "MI355X"
 
     if "total_token_throughput" not in enriched:
         enriched["total_token_throughput"] = number(
@@ -330,7 +337,9 @@ def perf_point(
     hardware = string_value(
         payload.get("hardware"), payload.get("gpu_name"), default="mi355x"
     ).lower()
-    if "mi355" in hardware:
+    if "mi350" in hardware:
+        hardware = "mi350x"
+    elif "mi355" in hardware:
         hardware = "mi355x"
     backend = string_value(
         payload.get("backend"), fields.get("backend"), default="atom"
@@ -457,6 +466,7 @@ def collect_dashboard_entries(
     paths: list[Path],
     run_url: str | None,
     gsm8k_scores: dict[tuple[str, int], dict[str, Any]],
+    hardware: str | None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     entries: list[dict[str, Any]] = []
     rows: list[dict[str, Any]] = []
@@ -469,7 +479,7 @@ def collect_dashboard_entries(
         fields = derive_fields(path, payload)
         if not fields:
             continue
-        payload = enrich_payload(path, payload, fields)
+        payload = enrich_payload(path, payload, fields, hardware)
         conc = int(payload.get("max_concurrency", fields["conc"]))
         gsm8k_score = gsm8k_scores.get((topology_key(fields["topology"]), conc))
         if gsm8k_score is None:
@@ -538,12 +548,13 @@ def write_summary(rows: list[dict[str, Any]], summary_path: Path) -> None:
     lines = [
         "### ATOMesh Model Performance Benchmark Summary",
         "",
-        "| Model | Topology | ISL/OSL | Concurrency | Interactivity | Total tok/s | Input tok/s | Output tok/s | Total tok/s/GPU | Input tok/s/GPU | Output tok/s/GPU | TTFT ms | TPOT ms | E2E ms | GSM8K |",
-        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| Hardware | Model | Topology | ISL/OSL | Concurrency | Interactivity | Total tok/s | Input tok/s | Output tok/s | Total tok/s/GPU | Input tok/s/GPU | Output tok/s/GPU | TTFT ms | TPOT ms | E2E ms | GSM8K |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for row in rows:
         lines.append(
-            "| {model} | {topology} | {isl}/{osl} | {conc} | {interactivity} | {total} | {input_} | {output} | {total_per_gpu} | {input_per_gpu} | {output_per_gpu} | {ttft} | {tpot} | {e2e} | {gsm8k} |".format(
+            "| {hardware} | {model} | {topology} | {isl}/{osl} | {conc} | {interactivity} | {total} | {input_} | {output} | {total_per_gpu} | {input_per_gpu} | {output_per_gpu} | {ttft} | {tpot} | {e2e} | {gsm8k} |".format(
+                hardware=row.get("hardware", "--"),
                 model=row.get("benchmark_model_name", "--"),
                 topology=row.get("display_topology") or row.get("topology", "--"),
                 isl=row.get("random_input_len", "--"),
@@ -578,12 +589,15 @@ def main() -> None:
     )
     parser.add_argument("--summary", default="benchmark-summary.md")
     parser.add_argument("--run-url", default=None)
+    parser.add_argument("--hardware", default=None)
     args = parser.parse_args()
 
     root = Path(args.result_dir)
     bench_paths = list(root.rglob("pd-*.json"))
     gsm8k_scores = find_eval_scores(root)
-    entries, rows = collect_dashboard_entries(bench_paths, args.run_url, gsm8k_scores)
+    entries, rows = collect_dashboard_entries(
+        bench_paths, args.run_url, gsm8k_scores, args.hardware
+    )
     Path(args.output).write_text(json.dumps(entries, indent=2), encoding="utf-8")
     write_summary(rows, Path(args.summary))
     print(

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -117,6 +117,7 @@ env:
   ATOMESH_SLURM_ACCOUNT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_account != '' && inputs.atomesh_slurm_account || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'amd-frameworks') }}
   ATOMESH_SLURM_PARTITION: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_partition != '' && inputs.atomesh_slurm_partition || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'amd-frameworks') }}
   ATOMESH_SLURM_SUBMIT_RUNNER: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd') }}
+  ATOMESH_DASHBOARD_HARDWARE: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'MI350X' || 'MI355X' }}
   ATOMESH_LOG_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_log_root != '' && inputs.atomesh_log_root || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/${USER}/logs/ATOMESH_LOG/' || '/it-share/ATOMESH_LOG/') }}
   ATOMESH_MODEL_ROOT: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/models2' || '/mnt/models' }}
   ATOMESH_1P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes != '' && inputs.atomesh_1p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '' || 'mia1-p02-g42,mia1-p02-g44') }}
@@ -289,6 +290,7 @@ jobs:
             "atomesh-results/${MATRIX_ID}" \
             --output "${BENCHMARK_ACTION_INPUT}" \
             --summary "${SUMMARY_PATH}" \
+            --hardware "${ATOMESH_DASHBOARD_HARDWARE}" \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           {
@@ -315,8 +317,10 @@ jobs:
   summarize-results:
     name: Summarize ATOMesh benchmark results
     needs: [run-model-benchmark]
-    if: ${{ !cancelled() && needs.run-model-benchmark.result != 'skipped' }}
+    if: ${{ always() && !cancelled() && needs.run-model-benchmark.result != 'skipped' }}
     runs-on: ubuntu-latest
+    outputs:
+      has_results: ${{ steps.summary.outputs.has_results }}
     steps:
       - name: Checkout ATOM repo
         uses: actions/checkout@v6
@@ -329,16 +333,35 @@ jobs:
           path: atomesh-results
 
       - name: Build benchmark summary
+        id: summary
         run: |
           set -euo pipefail
+          mkdir -p atomesh-results
           python3 .github/scripts/atomesh/process_result.py \
             atomesh-results \
             --output atomesh-benchmark-action.json \
             --summary atomesh-benchmark-summary.md \
+            --hardware "${ATOMESH_DASHBOARD_HARDWARE}" \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           cat atomesh-benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
+          ENTRY_COUNT="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+          path = Path("atomesh-benchmark-action.json")
+          entries = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else []
+          print(len(entries))
+          PY
+          )"
+          echo "entry_count=${ENTRY_COUNT}" >> "$GITHUB_OUTPUT"
+          if [[ "${ENTRY_COUNT}" -gt 0 ]]; then
+            echo "has_results=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_results=false" >> "$GITHUB_OUTPUT"
+            echo "No successful ATOMesh benchmark result JSONs were produced; dashboard publish will be skipped." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload benchmark summary
+        if: ${{ steps.summary.outputs.has_results == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: atomesh-benchmark-summary
@@ -355,6 +378,7 @@ jobs:
     if: >-
       !cancelled()
       && needs.summarize-results.result == 'success'
+      && needs.summarize-results.outputs.has_results == 'true'
       && (
         github.event_name == 'schedule'
         || github.event_name == 'push'
@@ -384,6 +408,9 @@ jobs:
           Path("/tmp/atomesh_summary.js").write_text(
               "window.ATOMESH_RUN_URL = "
               + json.dumps("https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+              + ";\n"
+              + "window.ATOMESH_HARDWARE = "
+              + json.dumps("${{ env.ATOMESH_DASHBOARD_HARDWARE }}")
               + ";\n"
               + "window.ATOMESH_SUMMARY_MARKDOWN = "
               + json.dumps(summary, ensure_ascii=False)


### PR DESCRIPTION
- publish ATOMesh benchmark data with MI350X/MI355X hardware tag on dashboard
- allow dashboard publishing whenever successful benchmark artifacts exist instead of requiring every matrix case to pass.