### PR TITLE
[fix](acc): fix gpt-oss tp8 accuracy

### DIFF
--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -312,7 +312,7 @@
     "model_path": "openai/gpt-oss-120b",
     "extra_args": "--trust-remote-code --tensor-parallel-size 8 --gpu-memory-utilization 0.5 --max-num-batched-tokens 16384 --max-model-len 16384",
     "client_command": "lm_eval --model local-chat-completions --apply_chat_template --model_args model=${MODEL_PATH},base_url=http://127.0.0.1:${VLLM_PORT}/v1/chat/completions,num_concurrent=65,max_retries=1,max_gen_toks=2048,tokenized_requests=False,trust_remote_code=True --tasks gsm8k --num_fewshot ${LM_EVAL_NUM_FEWSHOT} --output_path ${OUTPUT_PATH}",
-    "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nVLLM_ROCM_USE_AITER=1",
+    "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1\nVLLM_ROCM_USE_AITER=1\nATOM_MOE_GU_ITLV=1",
     "runner": "atom-plugin-acc-validation-runner",
     "test_level": "nightly",
     "priority": "P1",


### PR DESCRIPTION
## Motivation

gpt-oss 使用 a4w4 moe 在prefill ，然而小 prefill token 会出现量化误差：

op级a4w4 moe TP8精度单测误差：
M=128     约 0.32       注意：runtime 通常会用 bf16 activation，不是默认 a4w4
M=256     约 0.030 - 0.031
M=512     约 0.0089 - 0.0091
M=1024    约 3.6e-6
M=2048    约 3.6e-6
M=4096    约 3.6e-6
M=8192    约 3.6e-6

gsm8k moe M 统计：
M=480              padded_M=512
M=528 - 880          padded_M=1024
M=1336 - 1610        padded_M=2048
M=3254             padded_M=4096
M=16384            padded_M=16384
频次集中在 M=528 - 880 这一段，说明真实请求并不是只跑大 prefill，也会大量命中中等 M 的 a4w4 MoE kernel。误差范围在约 0.0089 - 0.0091一档。

因此，TP8的gpt-oss不能使用原始的a4w4的moe，会有量化误差。
