### PR TITLE
ci: trim benchmark/accuracy catalogs and de-brittle the shape test

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -15,25 +15,6 @@
   ],
   "models": [
     {
-      "display": "DeepSeek-R1-0528",
-      "path": "deepseek-ai/DeepSeek-R1-0528",
-      "prefix": "deepseek-r1-0528",
-      "runner": "atom-mi355-8gpu.predownload",
-      "env_vars": "",
-      "config": { "tp": 8, "kv_cache_dtype": "fp8" },
-      "variants": [
-        { "label": "", "suffix": "", "conc_max": 256 },
-        {
-          "label": "MTP3",
-          "suffix": "-mtp3",
-          "extra_args": "--method mtp --num-speculative-tokens 3",
-          "bench_args": "--use-chat-template",
-          "conc_min": 4,
-          "conc_max": 256
-        }
-      ]
-    },
-    {
       "display": "DeepSeek-V4-Pro",
       "path": "deepseek-ai/DeepSeek-V4-Pro",
       "prefix": "deepseek-v4-pro",

--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -235,23 +235,11 @@
     "extraArgs": "--kv_cache_dtype fp8 -tp 4 --default-chat-template-kwargs '{\"enable_thinking\":false}' --online_quant_config '{\"global_quant_config\": \"ptpc_fp8\", \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\", \"*expert*\"]}' --method mtp --num-speculative-tokens 3",
     "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1",
     "runner": "linux-atom-do-mi350x-8",
-    "test_level": "nightly",
+    "test_level": "pr",
     "accuracy_threshold": 0.92,
     "accuracy_baseline": 0.9447,
     "accuracy_baseline_model": "zai-org/GLM-5.2-FP8",
     "_baseline_note": "Initial GLM-5.2-MXFP4 MTP online-quant native accuracy case. Threshold/baseline follow GLM-5.2-FP8 until MXFP4 MTP CI baseline is calibrated."
-  },
-  {
-    "model_name": "GLM-5.1-FP8",
-    "model_path": "zai-org/GLM-5.1-FP8",
-    "extraArgs": "--kv_cache_dtype fp8 -tp 8 --default-chat-template-kwargs '{\"enable_thinking\":false}'",
-    "env_vars": "",
-    "runner": "linux-atom-do-mi350x-8",
-    "test_level": "pr",
-    "accuracy_threshold": 0.875,
-    "accuracy_baseline": 0.9545,
-    "accuracy_baseline_model": "zai-org/GLM-5.1",
-    "_baseline_note": "CI uses 3-shot, not comparable to HF 5-shot baseline"
   },
   {
     "model_name": "Qwen3.5-35B-A3B TP2",
@@ -324,18 +312,6 @@
     "accuracy_baseline": 0.9022,
     "accuracy_baseline_model": "MiniMaxAI/MiniMax-M2.7",
     "_baseline_note": "ATOM CI measured: 0.9022 (gsm8k 3-shot flexible-extract). Threshold = baseline - 0.015."
-  },
-  {
-    "model_name": "MiniMax-M2.7-MXFP4",
-    "model_path": "amd/MiniMax-M2.7-MXFP4",
-    "extraArgs": "--kv_cache_dtype fp8 --trust-remote-code",
-    "env_vars": "",
-    "runner": "linux-atom-do-mi350x-8",
-    "test_level": "nightly",
-    "accuracy_threshold": 0.8872,
-    "accuracy_baseline": 0.9022,
-    "accuracy_baseline_model": "MiniMaxAI/MiniMax-M2.7",
-    "_baseline_note": "ATOM CI measured BF16=0.9022 (gsm8k 3-shot flexible-extract). HF amd/MiniMax-M2.7-MXFP4: MXFP4=91.89, baseline=91.81 (percentage)."
   },
   {
     "model_name": "MiniMax-M3-MXFP4",

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -10,10 +10,6 @@ on:
     - cron: '12 16 * * *'
   workflow_dispatch:
     inputs:
-      deepseek-r1-0528:
-        description: "Benchmark DeepSeek-R1-0528 (+ MTP3)"
-        type: boolean
-        default: true
       deepseek-v4-pro:
         description: "Benchmark DeepSeek-V4-Pro"
         type: boolean

--- a/tests/test_benchmark_catalog.py
+++ b/tests/test_benchmark_catalog.py
@@ -82,8 +82,12 @@ def test_build_args_smoke_over_real_catalog():
 
 
 def test_load_variants_shape():
+    # Content-agnostic: assert the catalog produces at least one variant and
+    # every variant carries the required fields. Deliberately does NOT pin the
+    # variant count — that couples the test to catalog churn (models added /
+    # removed) without testing any real invariant.
     variants = catalog.load_variants(CATALOG)
-    assert len(variants) == 22
+    assert variants, "catalog produced no variants"
     required = {
         "display",
         "path",
@@ -175,7 +179,7 @@ def test_validate_dispatch_inputs_in_sync_and_drift():
 
 
 def test_workflow_dispatch_inputs_match_catalog():
-    """The 13 workflow_dispatch model toggles must equal the catalog prefixes."""
+    """The workflow_dispatch model toggles must equal the catalog prefixes."""
     yaml = pytest.importorskip("yaml")
     wf = yaml.safe_load(WORKFLOW.read_text())
     # PyYAML parses the bare `on:` key as boolean True.


### PR DESCRIPTION
## Summary

Trim the benchmark/accuracy catalogs to their intended coverage and remove a brittle test assertion.

- **`models.json`**: drop the `DeepSeek-R1-0528` throughput-benchmark entry (base + MTP3). R1-0528 stays a supported/accuracy-tested model; only its perf-trend coverage is retired. Also remove the now-orphan `deepseek-r1-0528` `workflow_dispatch` toggle in `atom-benchmark.yaml` so the catalog↔workflow sync test stays green.
- **`models_accuracy.json`**: drop the `GLM-5.1-FP8` and `MiniMax-M2.7-MXFP4` accuracy entries; promote `GLM-5.2-MXFP4 MTP` from `nightly` to `pr` gating.
- **`test_benchmark_catalog.py`**: replace the brittle `assert len(variants) == 22` golden assertion with a content-agnostic **non-empty + per-variant required-field shape** check, so adding/removing a model no longer forces a hand-edit of a magic count. Also drop a stale `13` from a docstring.

The `test_workflow_dispatch_inputs_match_catalog` sync test was intentionally **not** weakened — it correctly enforces workflow toggles == catalog prefixes, so the fix was to remove the orphan toggle, not the assertion.

## Test Plan

- [x] `python -m pytest tests/test_benchmark_catalog.py` — 14 passed
- [x] `python .github/scripts/validate_catalog.py` — all accuracy catalogs valid
- [x] `atom-benchmark.yaml` parses as valid YAML
- [x] `ruff check` clean
