### PR TITLE
fix(dsv4): align TBO v4_batch_id_per_token buffer to int32

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -931,11 +931,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         # batch_id_per_token + n_committed_csa: reuse the shared GPU
         # tensors set in `_attach_v4_per_fwd_meta` (which MUST run before
-        # this helper — see prepare_decode/prefill ordering). int64
-        # batch_id is mandated by PyTorch fancy indexing; int32 n_committed
-        # is the gather SOURCE so any dtype works (and both downstream
+        # this helper — see prepare_decode/prefill ordering). batch_id is
+        # int32 (accepted by PyTorch advanced-indexing); n_committed is int32
+        # too — it is the gather SOURCE so any dtype works, and both downstream
         # kernels — `deepgemm_fp8_paged_mqa_logits`, `top_k_per_row_decode`
-        # — want int32 anyway).
+        # — want int32 anyway.
         batch_id_per_token_gpu = attn_metadata.batch_id_per_token[:total_tokens]
         n_committed_per_seq_gpu = attn_metadata.n_committed_csa_per_seq
         # cu_committed_gpu is consumed both as `cu_starts/cu_ends` for the
@@ -2739,7 +2739,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             bufs[f"{p}v4_kv_indptr_csa"] = CpuGpuBuffer(T_dec + 1, **i32)
             bufs[f"{p}v4_kv_indptr_hca"] = CpuGpuBuffer(T_dec + 1, **i32)
             bufs[f"{p}v4_n_committed_csa_per_seq"] = CpuGpuBuffer(bs, **i32)
-            bufs[f"{p}v4_batch_id_per_token"] = CpuGpuBuffer(mnbt, **i64)
+            bufs[f"{p}v4_batch_id_per_token"] = CpuGpuBuffer(mnbt, **i32)
             bufs[f"{p}v4_indexer_cu_committed"] = CpuGpuBuffer(bs + 1, **i32)
 
             for ratio, is_overlap in self._unique_compress_ratios_overlap:
@@ -2757,8 +2757,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
     def _stage(self, name: str, arr) -> torch.Tensor:
         """Write numpy `arr` into `forward_vars[name]` (CpuGpuBuffer) and
-        return its GPU view sliced to len(arr). Auto-casts dtype to match
-        the buffer (e.g. int64 → int32). Asserts the buffer is large enough.
+        return its GPU view sliced to len(arr). Asserts the buffer is large
+        enough and that `arr.dtype` matches the buffer dtype (callers must
+        cast to the buffer dtype before staging).
         """
         buf = self.model_runner.forward_vars[name]
         n = arr.shape[0] if arr.ndim > 0 else 1


### PR DESCRIPTION
## Problem

Serving DeepSeek-V4 with `--enable-tbo` crashes in `_stage()` the moment it
stages `batch_id_per_token`. The ubatch (TBO) allocation of
`v4_batch_id_per_token` was `int64`, while:

- the **non-ubatch** allocation was already `int32`,
- the staged numpy array is `int32` (`np.full(..., dtype=np.int32)`),
- `_stage()` asserts `arr.dtype == buffer.dtype`.

So the int32 array → int64 buffer path trips the dtype-mismatch assertion.

## Fix

Make the ubatch buffer `int32` to match the array, the non-ubatch buffer, and
the downstream `int32` consumers.

`int32` is correct here: `batch_id` is used as a PyTorch advanced index
(`cu_committed_gpu[batch_id_per_token_gpu]`), which accepts int32 (verified on
torch 2.9.1), and the downstream kernels (`deepgemm_fp8_paged_mqa_logits`,
`top_k_per_row_decode`, flydsl SWA scatter) all want/tolerate int32.

## Docs

Also corrected two stale docs that contradicted the code:
- `_stage` docstring said "Auto-casts dtype" — the body actually asserts dtype equality.
- A comment claimed "int64 batch_id is mandated by PyTorch fancy indexing".

## Sweep

Audited all 7 `_stage` call sites: every staged array is `int32` and every V4
buffer is `int32`. `batch_id_per_token`'s ubatch buffer was the only `int64`
outlier; no other dtype mismatch remains.