### PR TITLE
Fix DeepSeek V4 fused shared expert mapping

### DIFF
--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -3054,9 +3054,21 @@ class DeepseekV4ForCausalLM(nn.Module):
         # mis-load expert weights -> garbage.
         num_fused_shared = 0
         for _m in self.model.modules():
-            if _m.__class__.__name__ == "FusedMoE":
+            if hasattr(_m, "num_fused_shared_experts"):
                 num_fused_shared = getattr(_m, "num_fused_shared_experts", 0)
                 break
+        if num_fused_shared == 0:
+            # Some plugin builds wrap/alias FusedMoE such that the exact class-name
+            # probe above misses it.  If the owning MoE layer was constructed in
+            # fused-shared mode, the loader will rewrite ffn.shared_experts.* to
+            # ffn.experts.{n_routed_experts}.*; include that final slot here so the
+            # generic expert mapping loads it into w13/w2 instead of dropping it.
+            for _m in self.model.modules():
+                if _m.__class__.__name__ == "MoE" and getattr(
+                    _m, "_fuse_shared_into_routed", False
+                ):
+                    num_fused_shared = getattr(self.args, "n_shared_experts", 0)
+                    break
         num_experts = self.args.n_routed_experts + num_fused_shared
         return FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="w1",


### PR DESCRIPTION
## Summary

Fix DeepSeek V4 expert weight mapping so fused shared expert weights are included in `FusedMoE.make_expert_params_mapping()` when the owning MoE layer is built in fused-shared mode.

The previous lookup only detected modules whose class name was exactly `FusedMoE`. In the vLLM plugin path this can miss the actual fused MoE module/wrapper, causing `num_fused_shared` to stay `0`. The generic loader then rewrites `ffn.shared_experts.*` to `ffn.experts.{n_routed_experts}.*`, but `get_expert_mapping()` does not include that final shared slot, so the shared expert tensors are silently dropped and model quality collapses.

## Validation

- Patched service started successfully in a clean container on port `8002`.
- Loader log no longer reports `ffn.shared_experts.*` tensors being silently dropped.
- Completion smoke test: `3 cars * 4 wheels` returns `12`.

- `lm_eval --tasks gsm8k --num_fewshot 5 --limit 20`: `0.9` exact match.
- Prior full validation on the same fix: full GSM8K 5-shot recovered to `flexible-extract=0.9477`, `strict-match=0.9484`.