### PR TITLE
ci: keep PR welcome comment best effort

### DIFF
--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -37,9 +37,13 @@ jobs:
               `> Add labels via the sidebar or \`gh pr edit ${context.issue.number} --add-label <label>\``,
             ].join("\n");
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            } catch (error) {
+              core.warning(`Failed to post CI Guide comment: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary
- Make the PR welcome comment workflow best-effort.
- Convert `issues.createComment` failures into workflow warnings instead of failing the job.

This fixes cases where GitHub refuses the workflow token with `Resource not accessible by integration`.

## Test Plan
- `git diff --check`
- Parsed `.github/workflows/pr-welcome-comment.yaml` with PyYAML
