### PR TITLE
Enable PIECEWISE cudagraph for DeepSeek-V4 (non-spec)

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1191,7 +1191,12 @@ class Config:
             if self.compilation_config.level == CompilationLevel.PIECEWISE:
                 self.compilation_config.set_splitting_ops_for_v1()
                 self._set_cudagraph_sizes()
-                self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                # Respect an explicitly chosen cudagraph_mode (e.g. FULL for the
+                # manual whole-forward capture). Only default to PIECEWISE when
+                # unset. splitting_ops/sizes above are set regardless so the
+                # model is still piece-split-compiled at level 3.
+                if self.compilation_config.cudagraph_mode is None:
+                    self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
                 self.compilation_config.init_with_cudagraph_sizes()
 
         self.torch_dtype = (

--- a/atom/config.py
+++ b/atom/config.py
@@ -1191,10 +1191,9 @@ class Config:
             if self.compilation_config.level == CompilationLevel.PIECEWISE:
                 self.compilation_config.set_splitting_ops_for_v1()
                 self._set_cudagraph_sizes()
-                # Respect an explicitly chosen cudagraph_mode (e.g. FULL for the
-                # manual whole-forward capture). Only default to PIECEWISE when
-                # unset. splitting_ops/sizes above are set regardless so the
-                # model is still piece-split-compiled at level 3.
+                # Keep an explicit cudagraph_mode (e.g. FULL); default to
+                # PIECEWISE only when unset. splitting_ops/sizes are set either
+                # way so the model is still piece-split-compiled at level 3.
                 if self.compilation_config.cudagraph_mode is None:
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
                 self.compilation_config.init_with_cudagraph_sizes()

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, fields
 from typing import List, Optional
 
 from atom import LLMEngine
-from atom.config import CompilationConfig, SpeculativeConfig
+from atom.config import CompilationConfig, CUDAGraphMode, SpeculativeConfig
 
 logger = logging.getLogger("atom")
 
@@ -47,6 +47,7 @@ class EngineArgs:
     gpu_memory_utilization: float = 0.9
     cudagraph_capture_sizes: str = "[1,2,4,8,16,32,48,64,128,256]"
     level: int = 3
+    cudagraph_mode: str = "FULL"
     load_dummy: bool = False
     enable_expert_parallel: bool = False
     torch_profiler_dir: Optional[str] = None
@@ -137,6 +138,15 @@ class EngineArgs:
         )
         parser.add_argument(
             "--level", type=int, default=3, help="The level of compilation (0-3)."
+        )
+        parser.add_argument(
+            "--cudagraph-mode",
+            type=str,
+            default="FULL",
+            choices=["NONE", "PIECEWISE", "FULL", "FULL_AND_PIECEWISE"],
+            help="CUDA graph runtime mode. FULL = manual whole-forward capture "
+            "(default, existing behavior). PIECEWISE = per-piece cudagraph with "
+            "attention eager (requires --level 3).",
         )
         parser.add_argument(
             "--load_dummy", action="store_true", help="Skip loading model weights."
@@ -319,6 +329,7 @@ class EngineArgs:
         kwargs["kv_cache_block_size"] = kwargs.pop("block_size")
         kwargs["compilation_config"] = CompilationConfig(
             level=kwargs.pop("level"),
+            cudagraph_mode=CUDAGraphMode[kwargs.pop("cudagraph_mode")],
             cudagraph_capture_sizes=(
                 parse_size_list(kwargs.pop("cudagraph_capture_sizes"))
                 if self.cudagraph_capture_sizes

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2460,21 +2460,6 @@ class ModelRunner:
                     # without a hardcoded token cap. Free floored to GB so
                     # symmetric-TP ranks skip the same set (DP needs a cross-rank
                     # min-reduce — TODO).
-                    #
-                    # The per-token footprint here is the CAPTURE-TIME cost = the
-                    # transient forward peak (MoE/expert intermediates + attention/
-                    # indexer buffers, released after capture) PLUS the retained
-                    # pool growth. The old 10MB/token was calibrated when the
-                    # weak_ref_tensor fallback silently used a STRONG ref, so every
-                    # piece output was retained (no pool overlay) and the retained
-                    # part alone was ~8.5MB/token. After the weak-ref fix the pool
-                    # overlays (measured retained 2.3MB/token, total pool 10GB for
-                    # Σtok=4472), so the real capture footprint is dominated by the
-                    # transient forward, ~4MB/token here. This lets bs*q buckets up
-                    # to num_tokens=4096 (bs512×q8) fit at capture-time free≈56GB
-                    # instead of being skipped. Still conservative: guard re-checks
-                    # LIVE free each bucket, so if a bucket truly doesn't fit it is
-                    # skipped rather than OOMing.
                     _slope = (
                         0.004 * (1 << 30) * (self.config.hf_config.hidden_size / 7168.0)
                     )
@@ -2541,13 +2526,6 @@ class ModelRunner:
                     self.model.compute_logits(outputs[:num_tokens])
 
                 if _piecewise:
-                    # (Bucket already memory-guarded above; capture unconditionally.)
-                    # PIECEWISE capture: warmup above already ran eager (autotune).
-                    # Flip to PIECEWISE + this num_tokens descriptor and call the
-                    # model; each dense piece's CUDAGraphWrapper captures its own
-                    # cudagraph (inside the shared graph_capture() ctx so
-                    # cross-rank collectives capture in lockstep). No manual
-                    # whole-forward graph.
                     fc = get_forward_context()
                     fc.cudagraph_runtime_mode = CUDAGraphMode.PIECEWISE
                     fc.batch_descriptor = BatchDescriptor(num_tokens=num_tokens)

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2624,9 +2624,9 @@ class ModelRunner:
             import atom.utils.cuda_graph as _cg_mod
 
             logger.info(
-                "PIECEWISE POOL-DIAG global_env=%s shared_pool=%s n_bucket_pools=%d "
-                "bucket_pool_keys=%s",
-                os.environ.get("ATOM_GLOBAL_POOL"),
+                "PIECEWISE POOL-DIAG per_bucket_env=%s shared_pool=%s "
+                "n_bucket_pools=%d bucket_pool_keys=%s",
+                os.environ.get("ATOM_PER_BUCKET_POOL"),
                 _cg_mod._shared_graph_pool is not None,
                 len(_cg_mod._graph_pools),
                 sorted(_cg_mod._graph_pools.keys()),

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-import bisect
 import gc
 import logging
 import math
@@ -1276,51 +1275,47 @@ class ModelRunner:
         current = torch.cuda.memory_stats()["allocated_bytes.all.current"]
         activation_bytes = max(peak - current, 0)
 
-        # PIECEWISE: the pool holds each dense piece captured at every distinct
-        # num_tokens shape (num_tokens = bs*q; capture is memory-guarded, below).
-        # Memory ~ per_token * Σ(distinct captured num_tokens). Estimate from the
-        # shapes (not the FULL Σq formula, which under-reserves here -> OOM).
+        # PIECEWISE pool ~ per_token * Σ(captured num_tokens). per_token from model
+        # geometry (hidden*dtype*layers*k), not a magic constant. Under-reserve is
+        # safe: capture re-checks live free mem per bucket and skips oversized.
         if self._piecewise_cg_active():
             cap_sizes = self.config.compilation_config.cudagraph_capture_sizes or [
                 self.config.max_num_seqs
             ]
             # Non-spec decode: one token per seq, so num_tokens == bs.
-            q_buckets = [1]
-            hidden = int(self.config.hf_config.hidden_size)
-            # Per-token retained cudagraph-pool cost. Calibrated to the MEASURED
-            # per_token_actual on DSV4 TP8 PIECEWISE after the weak_ref_tensor fix
-            # (atom/utils weak-ref op) let the shared pool OVERLAY captured piece
-            # outputs across shapes: actual_pool=10.14GB / Σtok=4472 = 2.322MB/tok
-            # (was 8.5MB/tok when weak_ref silently fell back to a strong ref and
-            # every piece output was retained -> no overlay -> 35GB pool). 2.5MB
-            # keeps a small margin above the measured 2.322MB. NOTE: the
-            # sum-of-distinct model below now OVER-estimates (overlay makes the
-            # true pool ~max-bucket-driven, not a sum), so this is a safe upper
-            # bound on the KV reservation. Under-reserving never OOMs: the
-            # capture-time guard re-checks live free memory per bucket and skips
-            # any that would not fit.
-            per_token_gb = 0.0025 * (hidden / 7168.0)
-            total_gpu = torch.cuda.mem_get_info()[1]
-            target_reserve = 0.12 * total_gpu
-            _all = sorted({bs * q for bs in cap_sizes for q in q_buckets})
-            distinct = []
-            _acc = 0
-            for _nt in _all:
-                if (
-                    distinct
-                    and 1.2 * per_token_gb * (1 << 30) * (_acc + _nt) > target_reserve
-                ):
+            hf_config = self.config.hf_config
+            hidden = int(hf_config.hidden_size)
+            num_layers = int(hf_config.num_hidden_layers)
+            dtype_bytes = torch.finfo(self.config.torch_dtype).bits // 8
+            _PER_TOKEN_LAYER_TENSORS = 2.8  # live hidden tensors kept per layer
+            per_token_bytes = (
+                hidden * dtype_bytes * num_layers * _PER_TOKEN_LAYER_TENSORS
+            )
+            # Cap the reserved buckets at a fraction of the KV budget so a huge
+            # capture list can't starve KV. Use the utilization budget (not raw
+            # total) as the reference — it tracks the configured memory envelope.
+            budget = self.config.gpu_memory_utilization * torch.cuda.mem_get_info()[1]
+            target_reserve = 0.15 * budget
+            captured = []
+            acc = 0
+            for num_tokens in sorted(set(cap_sizes)):
+                if captured and per_token_bytes * (acc + num_tokens) > target_reserve:
                     break
-                distinct.append(_nt)
-                _acc += _nt
-            overhead = 1.2 * per_token_gb * (1 << 30) * sum(distinct)
+                captured.append(num_tokens)
+                acc += num_tokens
+            overhead = int(per_token_bytes * acc)
             logger.info(
                 "PIECEWISE cudagraph mem estimate: n_shapes=%d/%d Σtok=%d "
-                "hidden=%d target=%.1fGB -> overhead=%.2fGB",
-                len(distinct), len(_all), sum(distinct), hidden,
-                target_reserve / (1 << 30), overhead / (1 << 30),
+                "per_token=%.3fMB hidden=%d layers=%d -> overhead=%.2fGB",
+                len(captured),
+                len(set(cap_sizes)),
+                acc,
+                per_token_bytes / (1 << 20),
+                hidden,
+                num_layers,
+                overhead / (1 << 30),
             )
-            return int(overhead)
+            return overhead
         # CUDA graph pool overhead is roughly 20% of single-pass activation
         # memory due to pooling across multiple captured batch sizes.
         return int(activation_bytes * 0.2)
@@ -2085,12 +2080,9 @@ class ModelRunner:
                 num_tokens = context.batch_size * max_q_len  # real (output slice)
 
                 if self._piecewise_cg_active():
-                    # PIECEWISE replay: no whole-forward graph. Dense pieces are
-                    # per-token, so (TP only) we replay at a 1D num_tokens bucket
-                    # replayed at the captured num_tokens bucket >= the real token
-                    # count (non-spec decode: num_tokens == bs). Attention is eager
-                    # on the flat [0:num_tokens] tokens; the [num_tokens:pad] tail
-                    # is padding the model ignores.
+                    # PIECEWISE replay at the captured num_tokens bucket >= real
+                    # token count (non-spec decode: num_tokens == bs); the pad tail
+                    # is ignored by the model.
                     _is_dummy = batch is not None and batch.is_dummy_run
                     num_tokens_pad = graph_bs * max_q_len
                     _captured = num_tokens_pad in getattr(
@@ -2119,14 +2111,9 @@ class ModelRunner:
                     else:
                         hidden_states = model_output
                         self._aux_hidden_states = None
-                    # Slice off the pad tail before sampling. The forward ran on the
-                    # padded [0:num_tokens_pad] window (so the captured piece shapes
-                    # match), but rows [num_tokens:num_tokens_pad] are pad garbage
-                    # and must not reach the sampler — otherwise they leak into
-                    # sampled_token_ids -> prev_token_ids -> next step's
-                    # prepare_input_ids assigns a pad-sized tensor into a smaller
-                    # deferred slot -> shape-mismatch crash. num_tokens is the same
-                    # real length the non-PIECEWISE path uses below.
+                    # Slice pad tail before sampling: pad rows must not leak into
+                    # sampled_token_ids -> prev_token_ids -> next-step shape
+                    # mismatch. num_tokens == the non-PIECEWISE real length.
                     hidden_states = hidden_states[:num_tokens]
                     logits = self.model.compute_logits(hidden_states)
                     return logits, hidden_states
@@ -2488,8 +2475,8 @@ class ModelRunner:
                     # instead of being skipped. Still conservative: guard re-checks
                     # LIVE free each bucket, so if a bucket truly doesn't fit it is
                     # skipped rather than OOMing.
-                    _slope = 0.004 * (1 << 30) * (
-                        self.config.hf_config.hidden_size / 7168.0
+                    _slope = (
+                        0.004 * (1 << 30) * (self.config.hf_config.hidden_size / 7168.0)
                     )
                     _free = torch.cuda.mem_get_info()[0]
                     _need = _slope * num_tokens * 1.25 + (4 << 30)
@@ -2498,7 +2485,9 @@ class ModelRunner:
                             logger.info(
                                 "PIECEWISE skip num_tokens=%d: free=%.1fGB "
                                 "< need=%.1fGB",
-                                num_tokens, _free / 1e9, _need / 1e9,
+                                num_tokens,
+                                _free / 1e9,
+                                _need / 1e9,
                             )
                         continue
                 # Use a simple, safe position pattern for capture.
@@ -2633,6 +2622,7 @@ class ModelRunner:
             _pool_bytes = max(torch.cuda.memory_reserved() - _rsv_before_capture, 0)
             _sumtok = sum(self._piecewise_sorted_tokens) or 1
             import atom.utils.cuda_graph as _cg_mod
+
             logger.info(
                 "PIECEWISE POOL-DIAG global_env=%s shared_pool=%s n_bucket_pools=%d "
                 "bucket_pool_keys=%s",

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+import bisect
 import gc
 import logging
 import math
@@ -21,7 +22,8 @@ from aiter.dist.parallel_state import (
     graph_capture,
 )
 from aiter.dist.utils import get_distributed_init_method
-from atom.config import Config, set_current_atom_config
+from atom.config import Config, CUDAGraphMode, set_current_atom_config
+from atom.utils.cuda_graph import BatchDescriptor
 from atom.model_engine.scheduler import ScheduledBatch, ScheduledBatchOutput
 from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
 from atom.model_loader.loader import load_model
@@ -1273,6 +1275,52 @@ class ModelRunner:
         peak = torch.cuda.memory_stats()["allocated_bytes.all.peak"]
         current = torch.cuda.memory_stats()["allocated_bytes.all.current"]
         activation_bytes = max(peak - current, 0)
+
+        # PIECEWISE: the pool holds each dense piece captured at every distinct
+        # num_tokens shape (num_tokens = bs*q; capture is memory-guarded, below).
+        # Memory ~ per_token * Σ(distinct captured num_tokens). Estimate from the
+        # shapes (not the FULL Σq formula, which under-reserves here -> OOM).
+        if self._piecewise_cg_active():
+            cap_sizes = self.config.compilation_config.cudagraph_capture_sizes or [
+                self.config.max_num_seqs
+            ]
+            # Non-spec decode: one token per seq, so num_tokens == bs.
+            q_buckets = [1]
+            hidden = int(self.config.hf_config.hidden_size)
+            # Per-token retained cudagraph-pool cost. Calibrated to the MEASURED
+            # per_token_actual on DSV4 TP8 PIECEWISE after the weak_ref_tensor fix
+            # (atom/utils weak-ref op) let the shared pool OVERLAY captured piece
+            # outputs across shapes: actual_pool=10.14GB / Σtok=4472 = 2.322MB/tok
+            # (was 8.5MB/tok when weak_ref silently fell back to a strong ref and
+            # every piece output was retained -> no overlay -> 35GB pool). 2.5MB
+            # keeps a small margin above the measured 2.322MB. NOTE: the
+            # sum-of-distinct model below now OVER-estimates (overlay makes the
+            # true pool ~max-bucket-driven, not a sum), so this is a safe upper
+            # bound on the KV reservation. Under-reserving never OOMs: the
+            # capture-time guard re-checks live free memory per bucket and skips
+            # any that would not fit.
+            per_token_gb = 0.0025 * (hidden / 7168.0)
+            total_gpu = torch.cuda.mem_get_info()[1]
+            target_reserve = 0.12 * total_gpu
+            _all = sorted({bs * q for bs in cap_sizes for q in q_buckets})
+            distinct = []
+            _acc = 0
+            for _nt in _all:
+                if (
+                    distinct
+                    and 1.2 * per_token_gb * (1 << 30) * (_acc + _nt) > target_reserve
+                ):
+                    break
+                distinct.append(_nt)
+                _acc += _nt
+            overhead = 1.2 * per_token_gb * (1 << 30) * sum(distinct)
+            logger.info(
+                "PIECEWISE cudagraph mem estimate: n_shapes=%d/%d Σtok=%d "
+                "hidden=%d target=%.1fGB -> overhead=%.2fGB",
+                len(distinct), len(_all), sum(distinct), hidden,
+                target_reserve / (1 << 30), overhead / (1 << 30),
+            )
+            return int(overhead)
         # CUDA graph pool overhead is roughly 20% of single-pass activation
         # memory due to pooling across multiple captured batch sizes.
         return int(activation_bytes * 0.2)
@@ -2034,9 +2082,57 @@ class ModelRunner:
             with record_function(label):
                 graph_bs = context.graph_bs
                 max_q_len = forward_context.attn_metadata.max_seqlen_q
+                num_tokens = context.batch_size * max_q_len  # real (output slice)
+
+                if self._piecewise_cg_active():
+                    # PIECEWISE replay: no whole-forward graph. Dense pieces are
+                    # per-token, so (TP only) we replay at a 1D num_tokens bucket
+                    # replayed at the captured num_tokens bucket >= the real token
+                    # count (non-spec decode: num_tokens == bs). Attention is eager
+                    # on the flat [0:num_tokens] tokens; the [num_tokens:pad] tail
+                    # is padding the model ignores.
+                    _is_dummy = batch is not None and batch.is_dummy_run
+                    num_tokens_pad = graph_bs * max_q_len
+                    _captured = num_tokens_pad in getattr(
+                        self, "_piecewise_captured_tokens", ()
+                    )
+                    _pos = (
+                        self._mrope_positions_view(num_tokens_pad)
+                        if self.use_mrope
+                        else self.forward_vars["positions"].gpu[:num_tokens_pad]
+                    )
+                    forward_context.cudagraph_runtime_mode = (
+                        CUDAGraphMode.PIECEWISE
+                        if (not _is_dummy and _captured)
+                        else CUDAGraphMode.NONE
+                    )
+                    forward_context.batch_descriptor = BatchDescriptor(
+                        num_tokens=num_tokens_pad
+                    )
+                    model_output = self.model(
+                        self.forward_vars["input_ids"].gpu[:num_tokens_pad], _pos
+                    )
+                    forward_context.cudagraph_runtime_mode = CUDAGraphMode.NONE
+                    forward_context.batch_descriptor = None
+                    if self.use_aux_hidden_state_outputs:
+                        hidden_states, self._aux_hidden_states = model_output
+                    else:
+                        hidden_states = model_output
+                        self._aux_hidden_states = None
+                    # Slice off the pad tail before sampling. The forward ran on the
+                    # padded [0:num_tokens_pad] window (so the captured piece shapes
+                    # match), but rows [num_tokens:num_tokens_pad] are pad garbage
+                    # and must not reach the sampler — otherwise they leak into
+                    # sampled_token_ids -> prev_token_ids -> next step's
+                    # prepare_input_ids assigns a pad-sized tensor into a smaller
+                    # deferred slot -> shape-mismatch crash. num_tokens is the same
+                    # real length the non-PIECEWISE path uses below.
+                    hidden_states = hidden_states[:num_tokens]
+                    logits = self.model.compute_logits(hidden_states)
+                    return logits, hidden_states
+
                 graph_key = (graph_bs, max_q_len)
                 self.graphs[graph_key].replay()
-                num_tokens = context.batch_size * max_q_len
                 hidden_states = self.forward_vars["outputs"][:num_tokens]
                 if graph_key in self.graph_aux_hidden:
                     self._aux_hidden_states = [
@@ -2266,7 +2362,25 @@ class ModelRunner:
         return self.tokenID_processor.prepare_draft_ids(batch, draft_token)
 
     @torch.inference_mode()
+    def _piecewise_cg_active(self) -> bool:
+        """True when the compiled model's dense pieces self-capture PIECEWISE
+        cudagraphs (attention eager between them). In that mode the runner does
+        NOT build the manual FULL whole-forward graphs — decode calls the model
+        directly and the per-piece CUDAGraphWrapper handles capture/replay."""
+        if self.enforce_eager:
+            return False
+        # Driven by --cudagraph-mode (default FULL -> manual capture, unchanged).
+        # PIECEWISE / FULL_AND_PIECEWISE -> per-piece cudagraph path.
+        mode = getattr(self.config.compilation_config, "cudagraph_mode", None)
+        return mode is not None and mode.requires_piecewise_compilation()
+
     def capture_cudagraph(self):
+        _piecewise = self._piecewise_cg_active()
+        if _piecewise:
+            logger.info(
+                "PIECEWISE cudagraph: capturing per-piece graphs (attention "
+                "eager); manual FULL whole-forward capture disabled."
+            )
         start_time = time.time()
         # self.graph_bs = [1, 2, 4, 8] + list(range(16, max_bs + 1, 16))
         if self.config.compilation_config.cudagraph_capture_sizes:
@@ -2302,6 +2416,12 @@ class ModelRunner:
             f"--max-num-seqs."
         )
 
+        # PIECEWISE: the set of num_tokens shapes whose dense pieces we captured.
+        # run_model dispatches by num_tokens; a shape NOT in here would force a
+        # runtime (uncoordinated) capture that hangs on collectives, so run_model
+        # falls back to eager for uncaptured shapes.
+        self._piecewise_captured_tokens: set[int] = set()
+
         input_ids = self.forward_vars["input_ids"].gpu
         positions = self.forward_vars["positions"].gpu
         outputs = self.forward_vars["outputs"]
@@ -2328,6 +2448,7 @@ class ModelRunner:
                 gc.enable()
                 gc.collect()
 
+        _rsv_before_capture = torch.cuda.memory_reserved()
         with pause_gc(), graph_capture() as capture_ctx:
             capture_range = (
                 tqdm.tqdm(self.graph_bs) if self.rank == 0 else self.graph_bs
@@ -2345,6 +2466,41 @@ class ModelRunner:
                 self.forward_vars["cu_seqlens_q"].copy_to_gpu(bs + 1)
 
                 num_tokens = bs * max_q_len
+                if _piecewise:
+                    # Memory-guarded cap (replaces the ATOM_PIECEWISE_MAX_TOKENS
+                    # env): skip a bucket whose estimated capture footprint would
+                    # not fit in free GPU memory. Adapts to GPU size / config
+                    # without a hardcoded token cap. Free floored to GB so
+                    # symmetric-TP ranks skip the same set (DP needs a cross-rank
+                    # min-reduce — TODO).
+                    #
+                    # The per-token footprint here is the CAPTURE-TIME cost = the
+                    # transient forward peak (MoE/expert intermediates + attention/
+                    # indexer buffers, released after capture) PLUS the retained
+                    # pool growth. The old 10MB/token was calibrated when the
+                    # weak_ref_tensor fallback silently used a STRONG ref, so every
+                    # piece output was retained (no pool overlay) and the retained
+                    # part alone was ~8.5MB/token. After the weak-ref fix the pool
+                    # overlays (measured retained 2.3MB/token, total pool 10GB for
+                    # Σtok=4472), so the real capture footprint is dominated by the
+                    # transient forward, ~4MB/token here. This lets bs*q buckets up
+                    # to num_tokens=4096 (bs512×q8) fit at capture-time free≈56GB
+                    # instead of being skipped. Still conservative: guard re-checks
+                    # LIVE free each bucket, so if a bucket truly doesn't fit it is
+                    # skipped rather than OOMing.
+                    _slope = 0.004 * (1 << 30) * (
+                        self.config.hf_config.hidden_size / 7168.0
+                    )
+                    _free = torch.cuda.mem_get_info()[0]
+                    _need = _slope * num_tokens * 1.25 + (4 << 30)
+                    if (_free >> 30) < (int(_need) >> 30):
+                        if self.rank == 0:
+                            logger.info(
+                                "PIECEWISE skip num_tokens=%d: free=%.1fGB "
+                                "< need=%.1fGB",
+                                num_tokens, _free / 1e9, _need / 1e9,
+                            )
+                        continue
                 # Use a simple, safe position pattern for capture.
                 self.forward_vars["positions"].np[:num_tokens] = (
                     np.arange(num_tokens, dtype=np.int64) % max_q_len
@@ -2394,6 +2550,23 @@ class ModelRunner:
                     outputs[:num_tokens] = model_output
                 if self.logits_in_graph:
                     self.model.compute_logits(outputs[:num_tokens])
+
+                if _piecewise:
+                    # (Bucket already memory-guarded above; capture unconditionally.)
+                    # PIECEWISE capture: warmup above already ran eager (autotune).
+                    # Flip to PIECEWISE + this num_tokens descriptor and call the
+                    # model; each dense piece's CUDAGraphWrapper captures its own
+                    # cudagraph (inside the shared graph_capture() ctx so
+                    # cross-rank collectives capture in lockstep). No manual
+                    # whole-forward graph.
+                    fc = get_forward_context()
+                    fc.cudagraph_runtime_mode = CUDAGraphMode.PIECEWISE
+                    fc.batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
+                    self.model(input_ids[:num_tokens], model_positions)
+                    fc.cudagraph_runtime_mode = CUDAGraphMode.NONE
+                    fc.batch_descriptor = None
+                    self._piecewise_captured_tokens.add(num_tokens)
+                    continue
 
                 # Capture
                 with (
@@ -2449,6 +2622,35 @@ class ModelRunner:
                     self.graph_aux_hidden[(bs, max_q_len)] = graph_aux
                 torch.cuda.synchronize()
         self.graph_bs.sort(reverse=False)
+
+        # PIECEWISE: sorted 1D num_tokens buckets for run_model's round_up_1d(Σ)
+        # dispatch (bisect_left over this to pick the tightest captured shape).
+        self._piecewise_sorted_tokens = sorted(self._piecewise_captured_tokens)
+        if _piecewise and self.rank == 0:
+            # ACTUAL cudagraph pool memory (reserved delta) vs the estimate, so we
+            # can validate/re-calibrate _estimate_cudagraph_overhead's per_token.
+            # Σtok = sum of captured num_tokens; per_token_actual = pool / Σtok.
+            _pool_bytes = max(torch.cuda.memory_reserved() - _rsv_before_capture, 0)
+            _sumtok = sum(self._piecewise_sorted_tokens) or 1
+            import atom.utils.cuda_graph as _cg_mod
+            logger.info(
+                "PIECEWISE POOL-DIAG global_env=%s shared_pool=%s n_bucket_pools=%d "
+                "bucket_pool_keys=%s",
+                os.environ.get("ATOM_GLOBAL_POOL"),
+                _cg_mod._shared_graph_pool is not None,
+                len(_cg_mod._graph_pools),
+                sorted(_cg_mod._graph_pools.keys()),
+            )
+            logger.info(
+                "PIECEWISE captured %d num_tokens buckets: %s | actual_pool="
+                "%.2fGB est=%.2fGB per_token_actual=%.3fMB Σtok=%d",
+                len(self._piecewise_sorted_tokens),
+                self._piecewise_sorted_tokens,
+                _pool_bytes / (1 << 30),
+                self._estimate_cudagraph_overhead() / (1 << 30),
+                _pool_bytes / _sumtok / (1 << 20),
+                _sumtok,
+            )
 
         # Post-init memory validation
         free_after, total_after = torch.cuda.mem_get_info()

--- a/atom/model_ops/module_dispatch_ops.py
+++ b/atom/model_ops/module_dispatch_ops.py
@@ -60,8 +60,7 @@ def maybe_dual_stream_forward(
     compilation_config = get_current_atom_config().compilation_config
     cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
     is_piecewise_cudagraph = (
-        cudagraph_mode is not None
-        and cudagraph_mode.requires_piecewise_compilation()
+        cudagraph_mode is not None and cudagraph_mode.requires_piecewise_compilation()
     )
 
     if (

--- a/atom/model_ops/module_dispatch_ops.py
+++ b/atom/model_ops/module_dispatch_ops.py
@@ -54,7 +54,21 @@ def maybe_dual_stream_forward(
     # Under TBO the two micro-batches already overlap on separate threads
     from atom.utils.tbo.ubatching import tbo_active
 
-    if self._use_dual_stream and 0 < num_tokens <= threshold and not tbo_active():
+    # cudagraph capture: dual_stream_moe_forward forks work onto `alt_stream`
+    # and allocates there; a side-stream allocation while the stream is capturing
+    # raises HIP "operation not permitted when stream is capturing". The whole
+    # per-bucket capture (incl. the eager warmup forward) runs inside a
+    # graph_capture() stream-capture context, and cudagraph_runtime_mode is only
+    # PIECEWISE for the narrow capture call (not the warmup) — so gate on the
+    # ACTUAL capture state, which covers warmup + capture and FULL too.
+    _capturing = torch.cuda.is_current_stream_capturing()
+
+    if (
+        self._use_dual_stream
+        and 0 < num_tokens <= threshold
+        and not tbo_active()
+        and not _capturing
+    ):
         return self.dual_stream_moe_forward(hidden_states)
     return self.single_stream_moe_forward(hidden_states)
 

--- a/atom/model_ops/module_dispatch_ops.py
+++ b/atom/model_ops/module_dispatch_ops.py
@@ -54,20 +54,21 @@ def maybe_dual_stream_forward(
     # Under TBO the two micro-batches already overlap on separate threads
     from atom.utils.tbo.ubatching import tbo_active
 
-    # cudagraph capture: dual_stream_moe_forward forks work onto `alt_stream`
-    # and allocates there; a side-stream allocation while the stream is capturing
-    # raises HIP "operation not permitted when stream is capturing". The whole
-    # per-bucket capture (incl. the eager warmup forward) runs inside a
-    # graph_capture() stream-capture context, and cudagraph_runtime_mode is only
-    # PIECEWISE for the narrow capture call (not the warmup) — so gate on the
-    # ACTUAL capture state, which covers warmup + capture and FULL too.
-    _capturing = torch.cuda.is_current_stream_capturing()
+    # PIECEWISE cudagraph only: dual_stream_moe_forward forks work onto
+    # `alt_stream` and does a caching-allocator alloc there; under PIECEWISE
+    # per-piece capture close the dual stream
+    compilation_config = get_current_atom_config().compilation_config
+    cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
+    is_piecewise_cudagraph = (
+        cudagraph_mode is not None
+        and cudagraph_mode.requires_piecewise_compilation()
+    )
 
     if (
         self._use_dual_stream
         and 0 < num_tokens <= threshold
         and not tbo_active()
-        and not _capturing
+        and not is_piecewise_cudagraph
     ):
         return self.dual_stream_moe_forward(hidden_states)
     return self.single_stream_moe_forward(hidden_states)

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1264,9 +1264,7 @@ class Indexer(nn.Module):
             Consumer (`csa_translate_pack`) skips negative entries via its
             `topk >= 0` write mask.
         """
-        q_fp8, weights = self.forward_pre(
-            x_full, qr_full, positions, qr_full_scale
-        )
+        q_fp8, weights = self.forward_pre(x_full, qr_full, positions, qr_full_scale)
         return self.score_topk_from(q_fp8, weights)
 
     def forward_pre(
@@ -1890,17 +1888,37 @@ class DeepseekV4Attention(nn.Module):
                 x, positions
             )
             o = torch.ops.aiter.v4_core_attention(
-                x, q, kv_pre, qr, qr_scale, positions, idx_q_fp8, idx_weights,
+                x,
+                q,
+                kv_pre,
+                qr,
+                qr_scale,
+                positions,
+                idx_q_fp8,
+                idx_weights,
                 self.layer_name,
             )
             return self._attn_post(o)
         return torch.ops.aiter.v4_attention_with_output(x, positions, self.layer_name)
 
-    def _attn_pre(self, x: torch.Tensor, positions: torch.Tensor):
-        """Q/KV + indexer input projections (graphable, num_tokens-shaped).
+    def _attn_pre(
+        self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+        run_indexer_proj: bool = True,
+    ):
+        """Q/KV (+ optional indexer input) projections (graphable, num_tokens).
 
-        Returns (q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights); the last
-        two are None on layers without an indexer (or when top-k is skipped).
+        Shared by both attention paths:
+          - PIECEWISE (narrow split): run_indexer_proj=True — the indexer Q/weights
+            projection is compiled into the graphed piece here; the eager core
+            then only does the paged score/top-k via `score_topk_from`.
+          - FULL (wide split): run_indexer_proj=False — the legacy `forward_impl`
+            keeps the indexer's `forward_batched` inline in the core (unchanged
+            ordering), so no indexer projection happens here.
+
+        Returns (q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights); the last two
+        are None when run_indexer_proj is False or the layer has no indexer.
         """
         assert (
             x.dim() == 2 and x.shape[-1] == self.dim
@@ -1917,7 +1935,7 @@ class DeepseekV4Attention(nn.Module):
         q = self.wq_b(qr, x_scale=qr_scale)
         # Indexer Q/weights projection (no paged access) -> graphed piece.
         idx_q_fp8 = idx_weights = None
-        if self.indexer is not None and not self.skip_topk:
+        if run_indexer_proj and self.indexer is not None and not self.skip_topk:
             idx_q_fp8, idx_weights = self.indexer.forward_pre(
                 x, qr, positions, qr_scale
             )
@@ -1955,244 +1973,56 @@ class DeepseekV4Attention(nn.Module):
         per-seq slot + block_table from the V4 attention builder's metadata.
         Per-seq slicing uses `cu_seqlens_q` from `forward_context`.
         """
-        assert (
-            x.dim() == 2 and x.shape[-1] == self.dim
-        ), f"DeepseekV4Attention expects [num_tokens, {self.dim}], got {tuple(x.shape)}"
-        # warmup_model runs BEFORE allocate_kv_cache → `unified_kv` is unbound
-        # and the new sparse_attn_v4_paged_{decode,prefill} kernels would read
-        # OOB. Same pattern as `attention_mha.py:98` — short-circuit dummy_run
-        # with a zero output of the correct shape; downstream layers compile
-        # on a real fwd. swa_write / Compressor / Indexer are also skipped to
-        # avoid touching unbound state caches.
+        # FULL / legacy wide-split path. Compose the shared helpers in the
+        # ORIGINAL order so behaviour is byte-equivalent to the pre-refactor
+        # inline body: launch the compressor BEFORE the Q/KV projections (to
+        # overlap on the side stream), run the projections (indexer projection
+        # stays inline in the core via forward_batched, so run_indexer_proj=
+        # False here), then the paged core, then the output LoRA.
         fc = get_forward_context()
-        if fc.context.is_dummy_run:
+        if fc.context.is_dummy_run or os.environ.get("ATOM_V4_BYPASS_ATTN") == "1":
             return torch.zeros_like(x)
-        if os.environ.get("ATOM_V4_BYPASS_ATTN") == "1":
-            return torch.zeros_like(x)
-        num_tokens = x.size(0)
-        cache_size = self.swa_kv.shape[1]
-        ratio = self.compress_ratio
-        rd = self.rope_head_dim
 
-        # ===== Per-fwd metadata (built once in prepare_prefill/decode). =====
-        # All per-fwd state read once. Production prepare_decode/prefill
-        # always populates these; warmup goes through the same path
-        # (`_populate_state_slot_mapping` falls back to slot 0).
-        # Cast to V4 typed metadata so V4-specific attribute access (v4_*,
-        # compress_plans, ...) is well-typed for pyright.
-        attn_md = cast("AttentionMetaData_DSV4", fc.attn_metadata)
-        compress_plans = attn_md.compress_plans
-        block_tables_gpu = attn_md.block_tables
-        state_slot_mapping = attn_md.state_slot_mapping
-        plan_for_layer = compress_plans[ratio] if ratio else None
-
-        # ----- Batched ops on full flat tensors -----
-        # `_V4_FORCE_UE8M0_QUANT` (module-level): round-trip x/qr to ue8m0-FP8
-        # to mirror the reference's `act_quant(scale_fmt="ue8m0")` Linear-input
-        # quantization. EXPERIMENT only.
+        # Experimental UE8M0 input round-trip BEFORE the compressor sees x, to
+        # match the legacy inline ordering (dead path: default off + asserted off
+        # under fused q_norm quant, but kept ordered for byte-equivalence).
         if _V4_FORCE_UE8M0_QUANT:
             x = x.clone()
             act_quant_inplace(x, 128, "ue8m0")
 
-        # ===== Triple-stream: Q/KV path + both Compressors in parallel =====
-        use_async_compress = self.maybe_compressors_async(
-            x, plan_for_layer, state_slot_mapping, block_tables_gpu
+        # Metadata + compressor launch (must precede projections for overlap).
+        ratio = self.compress_ratio
+        attn_md = cast("AttentionMetaData_DSV4", fc.attn_metadata)
+        plan_for_layer = attn_md.compress_plans[ratio] if ratio else None
+        self.maybe_compressors_async(
+            x,
+            plan_for_layer,
+            attn_md.state_slot_mapping,
+            attn_md.block_tables,
         )
 
-        # ----- Q/KV projections (main stream) -----
-        qkv_a = self.wqkv_a(x)
-        q_lora, kv_pre = torch.split(qkv_a, [self.q_lora_rank, self.head_dim], dim=-1)
-        assert (
-            not _V4_FORCE_UE8M0_QUANT
-        ), "_V4_FORCE_UE8M0_QUANT incompatible with fused q_norm quant (qr is already FP8)"
-        qr, qr_scale = self.q_norm(q_lora)
-        q = self.wq_b(qr, x_scale=qr_scale)
-        is_decode = attn_md.state is AttnState.DECODE
-        # Single kernel fuses per-head Q RMSNorm (weightless) + KV RMSNorm
-        # (weighted) + GPT-J interleaved RoPE on the tail rd dims. Dispatches
-        # to flydsl when the shape matches (V4-Pro is always V4-Pro shape →
-        # always flydsl). Microbench shows flydsl wins at every measured T
-        # from 4 (1.12×) to 32k (1.04×); used for both decode and prefill.
-        # Optional FP8 quant outputs left off — downstream sparse_attn /
-        # swa_write are still bf16.
-        # Decode folds the SWA cache-write into qk_norm_rope_maybe_quant: the
-        # post-norm/rope KV row is written into swa_kv[slot, pos%cache, :]
-        # (slot = state_slot_mapping[batch_id_per_token[t]]). The flydsl path
-        # fuses it into the kernel launch; the Triton fallback emits a separate
-        # swa_write internally — either way the bridge owns the SWA write, so
-        # no backend dispatch is needed here. Prefill writes its in-chunk SWA
-        # tail after sparse_attn, so it passes swa_kv=None and never fuses.
-        # For decode, write_per_batch (= min(max_seqlen_q, cache_size)) >=
-        # tokens-per-seq, so the fused per-token scatter (gated on batch_id>=0)
-        # covers exactly the tokens the old standalone swa_write did.
-        q_sa, kv, q_scale, kv_scale = qk_norm_rope_maybe_quant(
+        # Q/KV projections (indexer projection deferred to the core's inline
+        # forward_batched -> run_indexer_proj=False). x already UE8M0-quantised
+        # above, so _attn_pre must NOT re-quantise -> its guard is a no-op here
+        # because we pass the already-processed x (the flag re-clones, harmless
+        # on the dead path, but we rely on the assert keeping this off anyway).
+        q, kv_pre, qr, qr_scale, x, _idx_q, _idx_w = self._attn_pre(
+            x, positions, run_indexer_proj=False
+        )
+        # Paged attention core (compressor already launched above).
+        o = self._attn_core(
+            x,
             q,
             kv_pre,
-            self.kv_norm.weight,
-            self.rotary_emb.cos_cache,
-            self.rotary_emb.sin_cache,
+            qr,
+            qr_scale,
             positions,
-            self.n_local_heads,
-            self.head_dim,
-            rd,
-            self.eps,
-            quant_q=False,
-            quant_k=False,
-            swa_kv=self.swa_kv if is_decode else None,
-            state_slot_mapping=state_slot_mapping if is_decode else None,
-            batch_id_per_token=attn_md.batch_id_per_token if is_decode else None,
-            swa_cu_seqlens_q=attn_md.cu_seqlens_q if is_decode else None,
-            swa_cache_size=cache_size if is_decode else None,
-            swa_write_per_batch=(
-                min(attn_md.max_seqlen_q, cache_size) if is_decode else None
-            ),
+            idx_q_fp8=None,
+            idx_weights=None,
+            compressor_already_launched=True,
         )
-        if _V4_USE_REF_QUANT:
-            act_quant_inplace(kv[..., :-rd], 64, self.scale_fmt)
-
-        # HCA
-        if use_async_compress:
-            current_stream = fc.main_stream
-            if self.compressor is not None:
-                current_stream.wait_stream(self.alt_stream)
-            if self.indexer is not None:
-                current_stream.wait_stream(self.indexer_stream)
-        # ===== Compressor + Indexer =====
-        if self.indexer is not None and not self.skip_topk:
-            indexer_topk_batched = self.indexer.forward_batched(
-                x_full=x,
-                qr_full=qr,
-                qr_full_scale=qr_scale,
-                positions=positions,
-            )
-            # Translate seq-local topk → physical paged offsets and write into
-            # the CSA section of either:
-            #   - decode buffer `kv_indices_csa` (state is DECODE)
-            #   - prefill buffer `kv_indices_prefix_csa` (otherwise)
-            # `_fill_csa_paged_compress` dispatches internally on state.
-            self._fill_csa_paged_compress(
-                attn_md, indexer_topk_batched, positions, num_tokens
-            )
-
-        # ===== Sparse attention dispatch =====
-        # Decode SWA write fires upstream of this dispatch via the
-        # ``swa_write`` call in the decode branch — so ``paged_decode``
-        # always sees the current token's K in the ring. Prefill does NOT
-        # call swa_write from this layer (prior-chunk K is read from
-        # ``unified_kv`` ring via the kv_indices_prefix_swa region).
-        if is_decode:
-            if ratio == 0:
-                kv_indices = attn_md.kv_indices_swa
-                kv_indptr = attn_md.kv_indptr_swa
-            elif ratio == 4:
-                kv_indices = attn_md.kv_indices_csa
-                kv_indptr = attn_md.kv_indptr_csa
-            else:  # ratio == 128
-                kv_indices = attn_md.kv_indices_hca
-                kv_indptr = attn_md.kv_indptr_hca
-            o = sparse_attn_v4_paged_decode(
-                q_sa,
-                self.unified_kv,
-                kv_indices,
-                kv_indptr,
-                self.attn_sink,
-                self.softmax_scale,
-            )  # [S, H, head_dim]
-        else:
-            # Two-source paged prefill: prefix from `unified_kv` (per-ratio
-            # buffer with SWA history + compress section), extend from per-fwd
-            # `kv` tensor (in-chunk SWA tail; extend buffer is layer-invariant).
-            #
-            # ===== PCP (full-KV) =====
-            # Under PCP the model.forward entry round-robin-split x/positions to 1/W,
-            # so `q_sa` and `kv` here are this rank's 1/W shard. The per-query
-            # metadata (kv_indptr/indices_*, indexer_meta) was already reduced
-            # to this rank's owned queries in the builder (_apply_pcp_reindex),
-            # so `q_sa` + those indices are aligned and used as-is. The only
-            # runtime fixups here are on the actual K/V data:
-            #   - swa_write must write the FULL sequence SWA ring (every PCP
-            #     rank keeps full KV), and
-            #   - sparse_attn's extend source must be the FULL `kv` so each 1/W
-            #     query can attend the whole in-chunk SWA window.
-            # So all-gather `kv` back to full order; positions/cu_seqlens_q/
-            # state_slot_mapping for the SWA write stay full (cu_seqlens_q /
-            # state_slot_mapping are per-seq, never split; positions_full comes
-            # from the forward context which holds the pre-split copy).
-            pcp_on = _pcp_active()
-            if pcp_on:
-                pcp_ws = get_pcp_world_size()
-                kv_full = pcp_allgather_rerange(kv, pcp_ws)
-                # positions must match kv_full's full-sequence coords for the
-                # swa_write ring addressing (`positions[src] % cache_size`).
-                # `positions` here is this rank's 1/W shard (split in
-                # ForCausalLM.forward); all-gather it back to full order with
-                # the same rerange used for kv (NOT fc.context.positions, which
-                # the builder reindexed to 1/W).
-                positions_full = pcp_allgather_rerange(positions, pcp_ws)
-            else:
-                kv_full = kv
-                positions_full = positions
-
-            if ratio == 0:
-                kv_indices_prefix = attn_md.kv_indices_prefix_swa
-                kv_indptr_prefix = attn_md.kv_indptr_prefix_swa
-            elif ratio == 4:
-                kv_indices_prefix = attn_md.kv_indices_prefix_csa
-                kv_indptr_prefix = attn_md.kv_indptr_prefix_csa
-            elif ratio == 128:
-                kv_indices_prefix = attn_md.kv_indices_prefix_hca
-                kv_indptr_prefix = attn_md.kv_indptr_prefix_hca
-            else:
-                raise ValueError(f"Unsupported compress_ratio {ratio}")
-            o = sparse_attn_v4_paged_prefill(
-                q_sa,
-                self.unified_kv,
-                kv_indices_prefix,
-                kv_indptr_prefix,
-                kv_full,
-                attn_md.kv_indices_extend,
-                attn_md.kv_indptr_extend,
-                self.attn_sink,
-                self.softmax_scale,
-                # Reuse q_sa as the attention output buffer; q_sa is not needed
-                # after this call and this avoids an extra empty_like allocation.
-                out=q_sa,
-            )  # [S, H, head_dim]
-            # swa_write AFTER attn so chunked-prefill prefix SWA reads see
-            # prior-chunk's ring contents (current swa_write would overwrite
-            # ring slots `pos % cache_size` for positions in this chunk's tail).
-            # PCP: write the FULL sequence SWA ring from the gathered kv_full +
-            # full positions/cu_seqlens_q (full-KV scheme — every rank holds it).
-            swa_write(
-                kv_full,
-                positions_full,
-                attn_md.cu_seqlens_q,
-                state_slot_mapping,
-                self.swa_kv,
-                cache_size,
-                min(attn_md.max_seqlen_q, cache_size),
-            )
-
-        # Inverse RoPE on output's rope dims to remove absolute-position
-        # contribution carried in by the value-side RoPE of the KV entries.
-        self.rotary_emb.inverse(positions, o[..., -rd:])
-        # ----- Grouped output LoRA (batched on the full flat tensor) -----
-        o = o.view(num_tokens, self.n_local_groups, -1)
-        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-        if num_tokens <= 32 or get_gfx() == "gfx1250":
-            y = torch.empty(
-                num_tokens,
-                self.n_local_groups,
-                self.o_lora_rank,
-                dtype=o.dtype,
-                device=o.device,
-            ).transpose(0, 1)
-            y = batched_gemm_bf16(o.transpose(0, 1), wo_a, YQ=y)
-            o = y.transpose(0, 1)
-        else:
-            o = torch.einsum("sgd,grd->sgr", o, wo_a)
-        x = self.wo_b(o.flatten(1))
-        return x
+        # Output LoRA + wo_b.
+        return self._attn_post(o)
 
     def _attn_core(
         self,
@@ -2204,14 +2034,22 @@ class DeepseekV4Attention(nn.Module):
         positions: torch.Tensor,  # [num_tokens] int  absolute token positions
         idx_q_fp8: Optional[torch.Tensor] = None,  # indexer q_fp8 (from _attn_pre)
         idx_weights: Optional[torch.Tensor] = None,  # indexer weights (from _attn_pre)
+        compressor_already_launched: bool = False,
     ) -> torch.Tensor:  # [num_tokens, n_local_heads*head_dim]  flat attn output
-        """Paged/dynamic attention core (eager split op).
+        """Paged/dynamic attention core — SINGLE source of the paged attention
+        body, shared by both the PIECEWISE narrow-split op and the FULL/legacy
+        `forward_impl`. The two paths differ only in the compressor launch timing
+        and the indexer projection site, both parameterised here:
 
-        PR3-main: handles batched multi-sequence input. Linear projections + RoPE
-        run once on the flat `[num_tokens, ...]` batch; SWA write, Compressor
-        scatter, sparse_attn (gather + score) iterate over sequences using
-        per-seq slot + block_table from the V4 attention builder's metadata.
-        Per-seq slicing uses `cu_seqlens_q` from `forward_context`.
+        - `compressor_already_launched`: FULL launches the compressor BEFORE the
+          Q/KV projections (in `forward_impl`, to overlap with them — unchanged
+          legacy ordering) and passes True so we don't relaunch. PIECEWISE passes
+          False and launches here (its projections are in a separate captured
+          piece, and side-stream alloc can't happen during capture anyway).
+        - `idx_q_fp8`/`idx_weights`: if provided (PIECEWISE, projected in
+          `_attn_pre`), the indexer runs only its paged score/top-k via
+          `score_topk_from`; if None (FULL), the indexer's `forward_batched`
+          projects + scores inline here (unchanged legacy path).
         """
         assert (
             x.dim() == 2 and x.shape[-1] == self.dim
@@ -2242,13 +2080,20 @@ class DeepseekV4Attention(nn.Module):
         state_slot_mapping = attn_md.state_slot_mapping
         plan_for_layer = compress_plans[ratio] if ratio else None
 
-        # ===== Compressor launch (paged/dynamic — stays in the eager core) =====
-        # NOTE: q/kv/qr projections were computed in `_attn_pre` (graphed piece)
-        # and passed in. Under PIECEWISE the compressor runs single-stream anyway
-        # (side-stream alloc breaks capture), so no projection overlap is lost.
-        use_async_compress = self.maybe_compressors_async(
-            x, plan_for_layer, state_slot_mapping, block_tables_gpu
-        )
+        # ===== Compressor launch =====
+        # FULL already launched it before the projections (overlap); PIECEWISE
+        # launches here. maybe_compressors_async runs single-stream anyway when a
+        # cudagraph is capturing (side-stream alloc breaks capture).
+        if compressor_already_launched:
+            from atom.utils.tbo.ubatching import tbo_active
+
+            use_async_compress = (
+                self._use_async_compress and fc.in_hipgraph and not tbo_active()
+            )
+        else:
+            use_async_compress = self.maybe_compressors_async(
+                x, plan_for_layer, state_slot_mapping, block_tables_gpu
+            )
         is_decode = attn_md.state is AttnState.DECODE
         # Single kernel fuses per-head Q RMSNorm (weightless) + KV RMSNorm
         # (weighted) + GPT-J interleaved RoPE on the tail rd dims. Dispatches
@@ -2300,12 +2145,24 @@ class DeepseekV4Attention(nn.Module):
             if self.indexer is not None:
                 current_stream.wait_stream(self.indexer_stream)
         # ===== Compressor + Indexer =====
-        # Indexer Q/weights were projected in `_attn_pre` (graphed); here only
-        # the paged gather + score + top-k runs eager (needs compressor cache).
+        # Two indexer paths (same result, different split site):
+        #  - PIECEWISE: Q/weights were projected in `_attn_pre` (graphed piece)
+        #    and passed as idx_q_fp8/idx_weights; here only the paged gather +
+        #    score + top-k runs eager via `score_topk_from`.
+        #  - FULL: idx_q_fp8 is None; `forward_batched` projects + scores inline
+        #    (unchanged legacy path).
         if self.indexer is not None and not self.skip_topk:
-            indexer_topk_batched = self.indexer.score_topk_from(
-                idx_q_fp8, idx_weights
-            )
+            if idx_q_fp8 is not None:
+                indexer_topk_batched = self.indexer.score_topk_from(
+                    idx_q_fp8, idx_weights
+                )
+            else:
+                indexer_topk_batched = self.indexer.forward_batched(
+                    x_full=x,
+                    qr_full=qr,
+                    qr_full_scale=qr_scale,
+                    positions=positions,
+                )
             # Translate seq-local topk → physical paged offsets and write into
             # the CSA section of either:
             #   - decode buffer `kv_indices_csa` (state is DECODE)

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -171,23 +171,13 @@ def v4_attention_with_output(
     positions: torch.Tensor,
     layer_name: str,
 ) -> torch.Tensor:
+    # WIDE split (legacy / FULL cudagraph path): the whole attention (pre + core
+    # + post) is a single eager splitting op. Used when NOT doing PIECEWISE
+    # cudagraph — the manual whole-forward FULL capture graphs everything at once
+    # so there are no inter-piece tensors to stabilise. Unchanged from baseline.
     atom_config = get_current_atom_config()
     self = atom_config.compilation_config.static_forward_context[layer_name]
-    out = self.forward_impl(x, positions)
-
-    from atom.config import CUDAGraphMode
-    from atom.utils.forward_context import get_forward_context
-
-    fc = get_forward_context()
-    if getattr(fc, "cudagraph_runtime_mode", None) == CUDAGraphMode.PIECEWISE:
-        key = (layer_name, int(out.shape[0]))
-        buf = _v4_attn_piecewise_out.get(key)
-        if buf is None:
-            buf = torch.empty_like(out)
-            _v4_attn_piecewise_out[key] = buf
-        buf.copy_(out)
-        return buf
-    return out
+    return self.forward_impl(x, positions)
 
 
 # ---------------------------------------------------------------------------
@@ -1890,14 +1880,21 @@ class DeepseekV4Attention(nn.Module):
         x: torch.Tensor,
         positions: torch.Tensor,
     ) -> torch.Tensor:
-        # Narrow split: projections (incl. indexer Q/weights) run HERE (traced
-        # -> graphed dense pieces); only the paged attention core is eager.
-        q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights = self._attn_pre(x, positions)
-        o = torch.ops.aiter.v4_core_attention(
-            x, q, kv_pre, qr, qr_scale, positions, idx_q_fp8, idx_weights,
-            self.layer_name,
-        )
-        return self._attn_post(o)
+        # Split-op granularity depends on the cudagraph mode
+        #  - PIECEWISE cudagraph -> NARROW split attention
+        #  - FULL / NONE -> WIDE split attention: the whole attention is one eager
+        #  for torch compile.
+        cg_mode = get_current_atom_config().compilation_config.cudagraph_mode
+        if cg_mode is not None and cg_mode.requires_piecewise_compilation():
+            q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights = self._attn_pre(
+                x, positions
+            )
+            o = torch.ops.aiter.v4_core_attention(
+                x, q, kv_pre, qr, qr_scale, positions, idx_q_fp8, idx_weights,
+                self.layer_name,
+            )
+            return self._attn_post(o)
+        return torch.ops.aiter.v4_attention_with_output(x, positions, self.layer_name)
 
     def _attn_pre(self, x: torch.Tensor, positions: torch.Tensor):
         """Q/KV + indexer input projections (graphable, num_tokens-shaped).
@@ -1947,17 +1944,255 @@ class DeepseekV4Attention(nn.Module):
 
     def forward_impl(
         self,
-        x: torch.Tensor,
-        positions: torch.Tensor,
-    ) -> torch.Tensor:
-        """Non-split (eager/FULL) full attention: pre + core + post fused.
+        x: torch.Tensor,  # [num_tokens, dim]  flat ragged-batch hidden state
+        positions: torch.Tensor,  # [num_tokens] int  absolute token positions
+    ) -> torch.Tensor:  # [num_tokens, dim]  BF16 attention output
+        """Compute attention for `x` at absolute token `positions`.
 
-        Kept for the legacy `v4_attention_with_output` op; the compiled path uses
-        the narrow `v4_core_attention` split via `forward` above.
+        PR3-main: handles batched multi-sequence input. Linear projections + RoPE
+        run once on the flat `[num_tokens, ...]` batch; SWA write, Compressor
+        scatter, sparse_attn (gather + score) iterate over sequences using
+        per-seq slot + block_table from the V4 attention builder's metadata.
+        Per-seq slicing uses `cu_seqlens_q` from `forward_context`.
         """
-        q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights = self._attn_pre(x, positions)
-        o = self._attn_core(x, q, kv_pre, qr, qr_scale, positions, idx_q_fp8, idx_weights)
-        return self._attn_post(o)
+        assert (
+            x.dim() == 2 and x.shape[-1] == self.dim
+        ), f"DeepseekV4Attention expects [num_tokens, {self.dim}], got {tuple(x.shape)}"
+        # warmup_model runs BEFORE allocate_kv_cache → `unified_kv` is unbound
+        # and the new sparse_attn_v4_paged_{decode,prefill} kernels would read
+        # OOB. Same pattern as `attention_mha.py:98` — short-circuit dummy_run
+        # with a zero output of the correct shape; downstream layers compile
+        # on a real fwd. swa_write / Compressor / Indexer are also skipped to
+        # avoid touching unbound state caches.
+        fc = get_forward_context()
+        if fc.context.is_dummy_run:
+            return torch.zeros_like(x)
+        if os.environ.get("ATOM_V4_BYPASS_ATTN") == "1":
+            return torch.zeros_like(x)
+        num_tokens = x.size(0)
+        cache_size = self.swa_kv.shape[1]
+        ratio = self.compress_ratio
+        rd = self.rope_head_dim
+
+        # ===== Per-fwd metadata (built once in prepare_prefill/decode). =====
+        # All per-fwd state read once. Production prepare_decode/prefill
+        # always populates these; warmup goes through the same path
+        # (`_populate_state_slot_mapping` falls back to slot 0).
+        # Cast to V4 typed metadata so V4-specific attribute access (v4_*,
+        # compress_plans, ...) is well-typed for pyright.
+        attn_md = cast("AttentionMetaData_DSV4", fc.attn_metadata)
+        compress_plans = attn_md.compress_plans
+        block_tables_gpu = attn_md.block_tables
+        state_slot_mapping = attn_md.state_slot_mapping
+        plan_for_layer = compress_plans[ratio] if ratio else None
+
+        # ----- Batched ops on full flat tensors -----
+        # `_V4_FORCE_UE8M0_QUANT` (module-level): round-trip x/qr to ue8m0-FP8
+        # to mirror the reference's `act_quant(scale_fmt="ue8m0")` Linear-input
+        # quantization. EXPERIMENT only.
+        if _V4_FORCE_UE8M0_QUANT:
+            x = x.clone()
+            act_quant_inplace(x, 128, "ue8m0")
+
+        # ===== Triple-stream: Q/KV path + both Compressors in parallel =====
+        use_async_compress = self.maybe_compressors_async(
+            x, plan_for_layer, state_slot_mapping, block_tables_gpu
+        )
+
+        # ----- Q/KV projections (main stream) -----
+        qkv_a = self.wqkv_a(x)
+        q_lora, kv_pre = torch.split(qkv_a, [self.q_lora_rank, self.head_dim], dim=-1)
+        assert (
+            not _V4_FORCE_UE8M0_QUANT
+        ), "_V4_FORCE_UE8M0_QUANT incompatible with fused q_norm quant (qr is already FP8)"
+        qr, qr_scale = self.q_norm(q_lora)
+        q = self.wq_b(qr, x_scale=qr_scale)
+        is_decode = attn_md.state is AttnState.DECODE
+        # Single kernel fuses per-head Q RMSNorm (weightless) + KV RMSNorm
+        # (weighted) + GPT-J interleaved RoPE on the tail rd dims. Dispatches
+        # to flydsl when the shape matches (V4-Pro is always V4-Pro shape →
+        # always flydsl). Microbench shows flydsl wins at every measured T
+        # from 4 (1.12×) to 32k (1.04×); used for both decode and prefill.
+        # Optional FP8 quant outputs left off — downstream sparse_attn /
+        # swa_write are still bf16.
+        # Decode folds the SWA cache-write into qk_norm_rope_maybe_quant: the
+        # post-norm/rope KV row is written into swa_kv[slot, pos%cache, :]
+        # (slot = state_slot_mapping[batch_id_per_token[t]]). The flydsl path
+        # fuses it into the kernel launch; the Triton fallback emits a separate
+        # swa_write internally — either way the bridge owns the SWA write, so
+        # no backend dispatch is needed here. Prefill writes its in-chunk SWA
+        # tail after sparse_attn, so it passes swa_kv=None and never fuses.
+        # For decode, write_per_batch (= min(max_seqlen_q, cache_size)) >=
+        # tokens-per-seq, so the fused per-token scatter (gated on batch_id>=0)
+        # covers exactly the tokens the old standalone swa_write did.
+        q_sa, kv, q_scale, kv_scale = qk_norm_rope_maybe_quant(
+            q,
+            kv_pre,
+            self.kv_norm.weight,
+            self.rotary_emb.cos_cache,
+            self.rotary_emb.sin_cache,
+            positions,
+            self.n_local_heads,
+            self.head_dim,
+            rd,
+            self.eps,
+            quant_q=False,
+            quant_k=False,
+            swa_kv=self.swa_kv if is_decode else None,
+            state_slot_mapping=state_slot_mapping if is_decode else None,
+            batch_id_per_token=attn_md.batch_id_per_token if is_decode else None,
+            swa_cu_seqlens_q=attn_md.cu_seqlens_q if is_decode else None,
+            swa_cache_size=cache_size if is_decode else None,
+            swa_write_per_batch=(
+                min(attn_md.max_seqlen_q, cache_size) if is_decode else None
+            ),
+        )
+        if _V4_USE_REF_QUANT:
+            act_quant_inplace(kv[..., :-rd], 64, self.scale_fmt)
+
+        # HCA
+        if use_async_compress:
+            current_stream = fc.main_stream
+            if self.compressor is not None:
+                current_stream.wait_stream(self.alt_stream)
+            if self.indexer is not None:
+                current_stream.wait_stream(self.indexer_stream)
+        # ===== Compressor + Indexer =====
+        if self.indexer is not None and not self.skip_topk:
+            indexer_topk_batched = self.indexer.forward_batched(
+                x_full=x,
+                qr_full=qr,
+                qr_full_scale=qr_scale,
+                positions=positions,
+            )
+            # Translate seq-local topk → physical paged offsets and write into
+            # the CSA section of either:
+            #   - decode buffer `kv_indices_csa` (state is DECODE)
+            #   - prefill buffer `kv_indices_prefix_csa` (otherwise)
+            # `_fill_csa_paged_compress` dispatches internally on state.
+            self._fill_csa_paged_compress(
+                attn_md, indexer_topk_batched, positions, num_tokens
+            )
+
+        # ===== Sparse attention dispatch =====
+        # Decode SWA write fires upstream of this dispatch via the
+        # ``swa_write`` call in the decode branch — so ``paged_decode``
+        # always sees the current token's K in the ring. Prefill does NOT
+        # call swa_write from this layer (prior-chunk K is read from
+        # ``unified_kv`` ring via the kv_indices_prefix_swa region).
+        if is_decode:
+            if ratio == 0:
+                kv_indices = attn_md.kv_indices_swa
+                kv_indptr = attn_md.kv_indptr_swa
+            elif ratio == 4:
+                kv_indices = attn_md.kv_indices_csa
+                kv_indptr = attn_md.kv_indptr_csa
+            else:  # ratio == 128
+                kv_indices = attn_md.kv_indices_hca
+                kv_indptr = attn_md.kv_indptr_hca
+            o = sparse_attn_v4_paged_decode(
+                q_sa,
+                self.unified_kv,
+                kv_indices,
+                kv_indptr,
+                self.attn_sink,
+                self.softmax_scale,
+            )  # [S, H, head_dim]
+        else:
+            # Two-source paged prefill: prefix from `unified_kv` (per-ratio
+            # buffer with SWA history + compress section), extend from per-fwd
+            # `kv` tensor (in-chunk SWA tail; extend buffer is layer-invariant).
+            #
+            # ===== PCP (full-KV) =====
+            # Under PCP the model.forward entry round-robin-split x/positions to 1/W,
+            # so `q_sa` and `kv` here are this rank's 1/W shard. The per-query
+            # metadata (kv_indptr/indices_*, indexer_meta) was already reduced
+            # to this rank's owned queries in the builder (_apply_pcp_reindex),
+            # so `q_sa` + those indices are aligned and used as-is. The only
+            # runtime fixups here are on the actual K/V data:
+            #   - swa_write must write the FULL sequence SWA ring (every PCP
+            #     rank keeps full KV), and
+            #   - sparse_attn's extend source must be the FULL `kv` so each 1/W
+            #     query can attend the whole in-chunk SWA window.
+            # So all-gather `kv` back to full order; positions/cu_seqlens_q/
+            # state_slot_mapping for the SWA write stay full (cu_seqlens_q /
+            # state_slot_mapping are per-seq, never split; positions_full comes
+            # from the forward context which holds the pre-split copy).
+            pcp_on = _pcp_active()
+            if pcp_on:
+                pcp_ws = get_pcp_world_size()
+                kv_full = pcp_allgather_rerange(kv, pcp_ws)
+                # positions must match kv_full's full-sequence coords for the
+                # swa_write ring addressing (`positions[src] % cache_size`).
+                # `positions` here is this rank's 1/W shard (split in
+                # ForCausalLM.forward); all-gather it back to full order with
+                # the same rerange used for kv (NOT fc.context.positions, which
+                # the builder reindexed to 1/W).
+                positions_full = pcp_allgather_rerange(positions, pcp_ws)
+            else:
+                kv_full = kv
+                positions_full = positions
+
+            if ratio == 0:
+                kv_indices_prefix = attn_md.kv_indices_prefix_swa
+                kv_indptr_prefix = attn_md.kv_indptr_prefix_swa
+            elif ratio == 4:
+                kv_indices_prefix = attn_md.kv_indices_prefix_csa
+                kv_indptr_prefix = attn_md.kv_indptr_prefix_csa
+            elif ratio == 128:
+                kv_indices_prefix = attn_md.kv_indices_prefix_hca
+                kv_indptr_prefix = attn_md.kv_indptr_prefix_hca
+            else:
+                raise ValueError(f"Unsupported compress_ratio {ratio}")
+            o = sparse_attn_v4_paged_prefill(
+                q_sa,
+                self.unified_kv,
+                kv_indices_prefix,
+                kv_indptr_prefix,
+                kv_full,
+                attn_md.kv_indices_extend,
+                attn_md.kv_indptr_extend,
+                self.attn_sink,
+                self.softmax_scale,
+                # Reuse q_sa as the attention output buffer; q_sa is not needed
+                # after this call and this avoids an extra empty_like allocation.
+                out=q_sa,
+            )  # [S, H, head_dim]
+            # swa_write AFTER attn so chunked-prefill prefix SWA reads see
+            # prior-chunk's ring contents (current swa_write would overwrite
+            # ring slots `pos % cache_size` for positions in this chunk's tail).
+            # PCP: write the FULL sequence SWA ring from the gathered kv_full +
+            # full positions/cu_seqlens_q (full-KV scheme — every rank holds it).
+            swa_write(
+                kv_full,
+                positions_full,
+                attn_md.cu_seqlens_q,
+                state_slot_mapping,
+                self.swa_kv,
+                cache_size,
+                min(attn_md.max_seqlen_q, cache_size),
+            )
+
+        # Inverse RoPE on output's rope dims to remove absolute-position
+        # contribution carried in by the value-side RoPE of the KV entries.
+        self.rotary_emb.inverse(positions, o[..., -rd:])
+        # ----- Grouped output LoRA (batched on the full flat tensor) -----
+        o = o.view(num_tokens, self.n_local_groups, -1)
+        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+        if num_tokens <= 32 or get_gfx() == "gfx1250":
+            y = torch.empty(
+                num_tokens,
+                self.n_local_groups,
+                self.o_lora_rank,
+                dtype=o.dtype,
+                device=o.device,
+            ).transpose(0, 1)
+            y = batched_gemm_bf16(o.transpose(0, 1), wo_a, YQ=y)
+            o = y.transpose(0, 1)
+        else:
+            o = torch.einsum("sgd,grd->sgr", o, wo_a)
+        x = self.wo_b(o.flatten(1))
+        return x
 
     def _attn_core(
         self,

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -155,13 +155,7 @@ def _v4_attention_fake(
 
 
 # PIECEWISE cudagraph: persistent per-(layer, num_tokens) buffers holding each
-# attention op's output. Attention is the graph SPLIT point (eager); its output
-# is the INPUT to the next captured dense piece, so its address MUST be identical
-# every replay. forward_impl allocates a fresh output whose address drifts with
-# allocator state -> the piece cudagraph's input-address assert fires on the 2nd
-# step. Copying into a persistent buffer (allocated once, never freed) pins the
-# address. Only the attention outputs are stabilised (the real inter-piece
-# tensors); pure eager / FULL-capture paths are untouched.
+# attention op's output.
 _v4_attn_piecewise_out: dict = {}
 
 
@@ -182,11 +176,7 @@ def v4_attention_with_output(
 
 # ---------------------------------------------------------------------------
 # Narrow PIECEWISE split: only the paged / dynamic-shape attention core stays
-# eager. The Q/KV/O linear projections (wqkv_a, wq_b, wo_a, wo_b) live OUTSIDE
-# this op, in the compiled dense pieces -> they get cudagraph-captured AND scale
-# with num_tokens (so DSpark dynamic-q saves projection compute too, not just
-# MoE). This is what vLLM does: keep only the cudagraph-incompatible attention
-# kernel eager, graph everything else.
+# eager.
 # ---------------------------------------------------------------------------
 def _v4_core_attention_fake(
     x: torch.Tensor,

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -154,6 +154,17 @@ def _v4_attention_fake(
     return torch.empty_like(x)
 
 
+# PIECEWISE cudagraph: persistent per-(layer, num_tokens) buffers holding each
+# attention op's output. Attention is the graph SPLIT point (eager); its output
+# is the INPUT to the next captured dense piece, so its address MUST be identical
+# every replay. forward_impl allocates a fresh output whose address drifts with
+# allocator state -> the piece cudagraph's input-address assert fires on the 2nd
+# step. Copying into a persistent buffer (allocated once, never freed) pins the
+# address. Only the attention outputs are stabilised (the real inter-piece
+# tensors); pure eager / FULL-capture paths are untouched.
+_v4_attn_piecewise_out: dict = {}
+
+
 @mark_spliting_op(is_custom=True, gen_fake=_v4_attention_fake, mutates_args=[])
 def v4_attention_with_output(
     x: torch.Tensor,
@@ -162,7 +173,76 @@ def v4_attention_with_output(
 ) -> torch.Tensor:
     atom_config = get_current_atom_config()
     self = atom_config.compilation_config.static_forward_context[layer_name]
-    return self.forward_impl(x, positions)
+    out = self.forward_impl(x, positions)
+
+    from atom.config import CUDAGraphMode
+    from atom.utils.forward_context import get_forward_context
+
+    fc = get_forward_context()
+    if getattr(fc, "cudagraph_runtime_mode", None) == CUDAGraphMode.PIECEWISE:
+        key = (layer_name, int(out.shape[0]))
+        buf = _v4_attn_piecewise_out.get(key)
+        if buf is None:
+            buf = torch.empty_like(out)
+            _v4_attn_piecewise_out[key] = buf
+        buf.copy_(out)
+        return buf
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Narrow PIECEWISE split: only the paged / dynamic-shape attention core stays
+# eager. The Q/KV/O linear projections (wqkv_a, wq_b, wo_a, wo_b) live OUTSIDE
+# this op, in the compiled dense pieces -> they get cudagraph-captured AND scale
+# with num_tokens (so DSpark dynamic-q saves projection compute too, not just
+# MoE). This is what vLLM does: keep only the cudagraph-incompatible attention
+# kernel eager, graph everything else.
+# ---------------------------------------------------------------------------
+def _v4_core_attention_fake(
+    x: torch.Tensor,
+    q: torch.Tensor,
+    kv_pre: torch.Tensor,
+    qr: torch.Tensor,
+    qr_scale: torch.Tensor,
+    positions: torch.Tensor,
+    idx_q_fp8: Optional[torch.Tensor],
+    idx_weights: Optional[torch.Tensor],
+    layer_name: str,
+) -> torch.Tensor:
+    atom_config = get_current_atom_config()
+    self = atom_config.compilation_config.static_forward_context[layer_name]
+    return x.new_empty((x.shape[0], self.n_local_heads * self.head_dim))
+
+
+@mark_spliting_op(is_custom=True, gen_fake=_v4_core_attention_fake, mutates_args=[])
+def v4_core_attention(
+    x: torch.Tensor,
+    q: torch.Tensor,
+    kv_pre: torch.Tensor,
+    qr: torch.Tensor,
+    qr_scale: torch.Tensor,
+    positions: torch.Tensor,
+    idx_q_fp8: Optional[torch.Tensor],
+    idx_weights: Optional[torch.Tensor],
+    layer_name: str,
+) -> torch.Tensor:
+    atom_config = get_current_atom_config()
+    self = atom_config.compilation_config.static_forward_context[layer_name]
+    out = self._attn_core(x, q, kv_pre, qr, qr_scale, positions, idx_q_fp8, idx_weights)
+
+    from atom.config import CUDAGraphMode
+    from atom.utils.forward_context import get_forward_context
+
+    fc = get_forward_context()
+    if getattr(fc, "cudagraph_runtime_mode", None) == CUDAGraphMode.PIECEWISE:
+        key = (layer_name, int(out.shape[0]))
+        buf = _v4_attn_piecewise_out.get(key)
+        if buf is None:
+            buf = torch.empty_like(out)
+            _v4_attn_piecewise_out[key] = buf
+        buf.copy_(out)
+        return buf
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -1194,6 +1274,24 @@ class Indexer(nn.Module):
             Consumer (`csa_translate_pack`) skips negative entries via its
             `topk >= 0` write mask.
         """
+        q_fp8, weights = self.forward_pre(
+            x_full, qr_full, positions, qr_full_scale
+        )
+        return self.score_topk_from(q_fp8, weights)
+
+    def forward_pre(
+        self,
+        x_full: torch.Tensor,  # [total_tokens, dim]
+        qr_full: torch.Tensor,  # [total_tokens, q_lora_rank] fp8
+        positions: torch.Tensor,  # [total_tokens]
+        qr_full_scale: Optional[torch.Tensor] = None,
+    ):
+        """Graphable indexer Q proj + RoPE + weights (num_tokens-shaped).
+
+        No paged / KV-cache access, so this runs in the compiled dense piece.
+        Only `score_topk_from` (paged gather + score) must stay eager.
+        Returns (q_fp8, weights).
+        """
         assert self.rotary_emb is not None
         rd = self.rope_head_dim
         total_tokens = x_full.size(0)
@@ -1234,7 +1332,12 @@ class Indexer(nn.Module):
         # so no explicit `.float()` cast needed.
         weights = self.weights_proj(x_full)
         weights = scale_indexer_weights(weights, q_scale, self._weights_scale)
+        return q_fp8, weights
 
+    def score_topk_from(
+        self, q_fp8: torch.Tensor, weights: torch.Tensor
+    ) -> torch.Tensor:
+        """Eager paged gather + score + top-k (reads compressor KV cache)."""
         return torch.ops.aiter.indexer_score_topk(
             q_fp8, weights, self.prefix, self.index_topk
         )  # [total_tokens, index_topk] int32
@@ -1590,6 +1693,9 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{p}.wo_b",
         )
         self.softmax_scale = self.head_dim**-0.5
+        # Cached at construction (non-compiled) so `_attn_post` — now traced into
+        # the graphed dense piece — doesn't graph-break on a runtime get_gfx().
+        self._is_gfx1250 = get_gfx() == "gfx1250"
 
         # ----- Compressor (and Indexer for CSA) -----
         if self.compress_ratio:
@@ -1784,14 +1890,87 @@ class DeepseekV4Attention(nn.Module):
         x: torch.Tensor,
         positions: torch.Tensor,
     ) -> torch.Tensor:
-        return torch.ops.aiter.v4_attention_with_output(x, positions, self.layer_name)
+        # Narrow split: projections (incl. indexer Q/weights) run HERE (traced
+        # -> graphed dense pieces); only the paged attention core is eager.
+        q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights = self._attn_pre(x, positions)
+        o = torch.ops.aiter.v4_core_attention(
+            x, q, kv_pre, qr, qr_scale, positions, idx_q_fp8, idx_weights,
+            self.layer_name,
+        )
+        return self._attn_post(o)
+
+    def _attn_pre(self, x: torch.Tensor, positions: torch.Tensor):
+        """Q/KV + indexer input projections (graphable, num_tokens-shaped).
+
+        Returns (q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights); the last
+        two are None on layers without an indexer (or when top-k is skipped).
+        """
+        assert (
+            x.dim() == 2 and x.shape[-1] == self.dim
+        ), f"DeepseekV4Attention expects [num_tokens, {self.dim}], got {tuple(x.shape)}"
+        if _V4_FORCE_UE8M0_QUANT:
+            x = x.clone()
+            act_quant_inplace(x, 128, "ue8m0")
+        qkv_a = self.wqkv_a(x)
+        q_lora, kv_pre = torch.split(qkv_a, [self.q_lora_rank, self.head_dim], dim=-1)
+        assert (
+            not _V4_FORCE_UE8M0_QUANT
+        ), "_V4_FORCE_UE8M0_QUANT incompatible with fused q_norm quant (qr is already FP8)"
+        qr, qr_scale = self.q_norm(q_lora)
+        q = self.wq_b(qr, x_scale=qr_scale)
+        # Indexer Q/weights projection (no paged access) -> graphed piece.
+        idx_q_fp8 = idx_weights = None
+        if self.indexer is not None and not self.skip_topk:
+            idx_q_fp8, idx_weights = self.indexer.forward_pre(
+                x, qr, positions, qr_scale
+            )
+        return q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights
+
+    def _attn_post(self, o: torch.Tensor) -> torch.Tensor:
+        """Grouped output LoRA + wo_b (graphable, num_tokens-shaped)."""
+        num_tokens = o.shape[0]
+        o = o.view(num_tokens, self.n_local_groups, -1)
+        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+        if num_tokens <= 32 or self._is_gfx1250:
+            y = torch.empty(
+                num_tokens,
+                self.n_local_groups,
+                self.o_lora_rank,
+                dtype=o.dtype,
+                device=o.device,
+            ).transpose(0, 1)
+            y = batched_gemm_bf16(o.transpose(0, 1), wo_a, YQ=y)
+            o = y.transpose(0, 1)
+        else:
+            o = torch.einsum("sgd,grd->sgr", o, wo_a)
+        return self.wo_b(o.flatten(1))
 
     def forward_impl(
         self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Non-split (eager/FULL) full attention: pre + core + post fused.
+
+        Kept for the legacy `v4_attention_with_output` op; the compiled path uses
+        the narrow `v4_core_attention` split via `forward` above.
+        """
+        q, kv_pre, qr, qr_scale, x, idx_q_fp8, idx_weights = self._attn_pre(x, positions)
+        o = self._attn_core(x, q, kv_pre, qr, qr_scale, positions, idx_q_fp8, idx_weights)
+        return self._attn_post(o)
+
+    def _attn_core(
+        self,
         x: torch.Tensor,  # [num_tokens, dim]  flat ragged-batch hidden state
+        q: torch.Tensor,  # [num_tokens, n_heads*head_dim]  from wq_b
+        kv_pre: torch.Tensor,  # [num_tokens, head_dim]  KV latent (pre-norm/rope)
+        qr: torch.Tensor,  # [num_tokens, q_lora_rank] FP8  q RMSNorm out (for indexer)
+        qr_scale: torch.Tensor,  # qr FP8 scale
         positions: torch.Tensor,  # [num_tokens] int  absolute token positions
-    ) -> torch.Tensor:  # [num_tokens, dim]  BF16 attention output
-        """Compute attention for `x` at absolute token `positions`.
+        idx_q_fp8: Optional[torch.Tensor] = None,  # indexer q_fp8 (from _attn_pre)
+        idx_weights: Optional[torch.Tensor] = None,  # indexer weights (from _attn_pre)
+    ) -> torch.Tensor:  # [num_tokens, n_local_heads*head_dim]  flat attn output
+        """Paged/dynamic attention core (eager split op).
 
         PR3-main: handles batched multi-sequence input. Linear projections + RoPE
         run once on the flat `[num_tokens, ...]` batch; SWA write, Compressor
@@ -1809,10 +1988,8 @@ class DeepseekV4Attention(nn.Module):
         # on a real fwd. swa_write / Compressor / Indexer are also skipped to
         # avoid touching unbound state caches.
         fc = get_forward_context()
-        if fc.context.is_dummy_run:
-            return torch.zeros_like(x)
-        if os.environ.get("ATOM_V4_BYPASS_ATTN") == "1":
-            return torch.zeros_like(x)
+        if fc.context.is_dummy_run or os.environ.get("ATOM_V4_BYPASS_ATTN") == "1":
+            return x.new_zeros((x.shape[0], self.n_local_heads * self.head_dim))
         num_tokens = x.size(0)
         cache_size = self.swa_kv.shape[1]
         ratio = self.compress_ratio
@@ -1830,27 +2007,13 @@ class DeepseekV4Attention(nn.Module):
         state_slot_mapping = attn_md.state_slot_mapping
         plan_for_layer = compress_plans[ratio] if ratio else None
 
-        # ----- Batched ops on full flat tensors -----
-        # `_V4_FORCE_UE8M0_QUANT` (module-level): round-trip x/qr to ue8m0-FP8
-        # to mirror the reference's `act_quant(scale_fmt="ue8m0")` Linear-input
-        # quantization. EXPERIMENT only.
-        if _V4_FORCE_UE8M0_QUANT:
-            x = x.clone()
-            act_quant_inplace(x, 128, "ue8m0")
-
-        # ===== Triple-stream: Q/KV path + both Compressors in parallel =====
+        # ===== Compressor launch (paged/dynamic — stays in the eager core) =====
+        # NOTE: q/kv/qr projections were computed in `_attn_pre` (graphed piece)
+        # and passed in. Under PIECEWISE the compressor runs single-stream anyway
+        # (side-stream alloc breaks capture), so no projection overlap is lost.
         use_async_compress = self.maybe_compressors_async(
             x, plan_for_layer, state_slot_mapping, block_tables_gpu
         )
-
-        # ----- Q/KV projections (main stream) -----
-        qkv_a = self.wqkv_a(x)
-        q_lora, kv_pre = torch.split(qkv_a, [self.q_lora_rank, self.head_dim], dim=-1)
-        assert (
-            not _V4_FORCE_UE8M0_QUANT
-        ), "_V4_FORCE_UE8M0_QUANT incompatible with fused q_norm quant (qr is already FP8)"
-        qr, qr_scale = self.q_norm(q_lora)
-        q = self.wq_b(qr, x_scale=qr_scale)
         is_decode = attn_md.state is AttnState.DECODE
         # Single kernel fuses per-head Q RMSNorm (weightless) + KV RMSNorm
         # (weighted) + GPT-J interleaved RoPE on the tail rd dims. Dispatches
@@ -1902,12 +2065,11 @@ class DeepseekV4Attention(nn.Module):
             if self.indexer is not None:
                 current_stream.wait_stream(self.indexer_stream)
         # ===== Compressor + Indexer =====
+        # Indexer Q/weights were projected in `_attn_pre` (graphed); here only
+        # the paged gather + score + top-k runs eager (needs compressor cache).
         if self.indexer is not None and not self.skip_topk:
-            indexer_topk_batched = self.indexer.forward_batched(
-                x_full=x,
-                qr_full=qr,
-                qr_full_scale=qr_scale,
-                positions=positions,
+            indexer_topk_batched = self.indexer.score_topk_from(
+                idx_q_fp8, idx_weights
             )
             # Translate seq-local topk → physical paged offsets and write into
             # the CSA section of either:
@@ -2020,23 +2182,8 @@ class DeepseekV4Attention(nn.Module):
         # Inverse RoPE on output's rope dims to remove absolute-position
         # contribution carried in by the value-side RoPE of the KV entries.
         self.rotary_emb.inverse(positions, o[..., -rd:])
-        # ----- Grouped output LoRA (batched on the full flat tensor) -----
-        o = o.view(num_tokens, self.n_local_groups, -1)
-        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-        if num_tokens <= 32 or get_gfx() == "gfx1250":
-            y = torch.empty(
-                num_tokens,
-                self.n_local_groups,
-                self.o_lora_rank,
-                dtype=o.dtype,
-                device=o.device,
-            ).transpose(0, 1)
-            y = batched_gemm_bf16(o.transpose(0, 1), wo_a, YQ=y)
-            o = y.transpose(0, 1)
-        else:
-            o = torch.einsum("sgd,grd->sgr", o, wo_a)
-        x = self.wo_b(o.flatten(1))
-        return x
+        # Output LoRA (wo_a/wo_b) now runs in `_attn_post` (graphed piece).
+        return o.reshape(num_tokens, -1)  # [num_tokens, n_local_heads*head_dim]
 
     def _fill_csa_paged_compress(
         self,

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1257,6 +1257,27 @@ class Indexer(nn.Module):
         q_fp8, weights = self.forward_pre(x_full, qr_full, positions, qr_full_scale)
         return self.score_topk_from(q_fp8, weights)
 
+    def topk(
+        self,
+        x_full: torch.Tensor,
+        qr_full: torch.Tensor,
+        positions: torch.Tensor,
+        qr_full_scale: Optional[torch.Tensor] = None,
+        *,
+        pre_q_fp8: Optional[torch.Tensor] = None,
+        pre_weights: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Compute the top-k, reusing precomputed projections when available.
+
+        PIECEWISE narrow split projects Q/weights in `_attn_pre` (graphed piece)
+        and passes them as ``pre_q_fp8``/``pre_weights`` so only the eager paged
+        ``score_topk_from`` runs here. Otherwise (FULL/legacy) project inline via
+        ``forward_batched``. Same result either way — only the split site differs.
+        """
+        if pre_q_fp8 is not None:
+            return self.score_topk_from(pre_q_fp8, pre_weights)
+        return self.forward_batched(x_full, qr_full, positions, qr_full_scale)
+
     def forward_pre(
         self,
         x_full: torch.Tensor,  # [total_tokens, dim]
@@ -2135,29 +2156,20 @@ class DeepseekV4Attention(nn.Module):
             if self.indexer is not None:
                 current_stream.wait_stream(self.indexer_stream)
         # ===== Compressor + Indexer =====
-        # Two indexer paths (same result, different split site):
-        #  - PIECEWISE: Q/weights were projected in `_attn_pre` (graphed piece)
-        #    and passed as idx_q_fp8/idx_weights; here only the paged gather +
-        #    score + top-k runs eager via `score_topk_from`.
-        #  - FULL: idx_q_fp8 is None; `forward_batched` projects + scores inline
-        #    (unchanged legacy path).
+        # `topk` reuses the Q/weights projected in `_attn_pre` (graphed piece)
+        # when passed, else projects inline (FULL/legacy) — same result, only the
+        # split site differs. Then translate the seq-local top-k → physical paged
+        # offsets into the active CSA buffer (`_fill_csa_paged_compress`
+        # dispatches on decode vs prefill).
         if self.indexer is not None and not self.skip_topk:
-            if idx_q_fp8 is not None:
-                indexer_topk_batched = self.indexer.score_topk_from(
-                    idx_q_fp8, idx_weights
-                )
-            else:
-                indexer_topk_batched = self.indexer.forward_batched(
-                    x_full=x,
-                    qr_full=qr,
-                    qr_full_scale=qr_scale,
-                    positions=positions,
-                )
-            # Translate seq-local topk → physical paged offsets and write into
-            # the CSA section of either:
-            #   - decode buffer `kv_indices_csa` (state is DECODE)
-            #   - prefill buffer `kv_indices_prefix_csa` (otherwise)
-            # `_fill_csa_paged_compress` dispatches internally on state.
+            indexer_topk_batched = self.indexer.topk(
+                x,
+                qr,
+                positions,
+                qr_scale,
+                pre_q_fp8=idx_q_fp8,
+                pre_weights=idx_weights,
+            )
             self._fill_csa_paged_compress(
                 attn_md, indexer_topk_batched, positions, num_tokens
             )

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -627,14 +627,102 @@ def _is_torch_equal_or_newer(torch_version: str, target: str) -> bool:
     return torch_version >= version.parse(target)
 
 
+# Lazily-compiled fallback weak-ref op. vLLM ships a `torch.ops._C.weak_ref_tensor`
+# (csrc/libtorch_stable/ops.h) that returns a tensor SHARING the input's memory
+# but NOT owning its storage — so once the original tensor is freed the
+# CUDACachingAllocator block is reclaimable and a cudagraph memory pool can
+# OVERLAY it across shapes. That op is absent in some ROCm builds (no vLLM _C),
+# and a pure-Python weak ref is impossible: dlpack / set_(untyped_storage) both
+# share the Storage object and thus KEEP it alive -> the pool cannot reuse the
+# memory -> every captured piece's output accumulates (35GB+ on DSV4 TP8
+# PIECEWISE). We therefore JIT-compile a tiny `at::from_blob(..., no-op deleter)`
+# equivalent once (cached under ~/.cache/torch_extensions) so PIECEWISE cudagraph
+# pools overlay exactly like upstream vLLM.
+_ATOM_WEAKREF_OP = None  # None = not attempted, False = unavailable, else callable
+
+
+def _get_weak_ref_op():
+    global _ATOM_WEAKREF_OP
+    if _ATOM_WEAKREF_OP is not None:
+        return _ATOM_WEAKREF_OP or None
+
+    # 1) Prefer a native op if this build already registered one (e.g. vLLM _C).
+    try:
+        op = torch.ops._C.weak_ref_tensor
+        # Probe that it is actually callable / registered.
+        op  # noqa: B018
+        _ATOM_WEAKREF_OP = op
+        return op
+    except (AttributeError, RuntimeError):
+        pass
+
+    # 2) JIT-compile a minimal from_blob weak ref (no-op deleter => shares memory
+    #    without owning the allocator block). One-time compile, then cached.
+    try:
+        import os as _os
+
+        if _os.environ.get("ATOM_DISABLE_JIT_WEAKREF", "0") == "1":
+            _ATOM_WEAKREF_OP = False
+            return None
+        from torch.utils.cpp_extension import load_inline
+
+        _cpp = r"""
+#include <torch/extension.h>
+at::Tensor atom_weak_ref_tensor(at::Tensor input) {
+  TORCH_CHECK(input.is_cuda(), "weak_ref_tensor: input must be CUDA");
+  void* data_ptr = input.data_ptr();
+  auto options = at::TensorOptions()
+                     .dtype(input.scalar_type())
+                     .device(input.device());
+  // Empty deleter: the returned tensor shares `input`'s memory but does NOT own
+  // the CUDACachingAllocator block, so freeing `input` lets the pool reclaim it.
+  return at::from_blob(data_ptr, input.sizes(), input.strides(),
+                       [](void*) {}, options);
+}
+"""
+        _mod = load_inline(
+            name="atom_weakref",
+            cpp_sources=[_cpp],
+            functions=["atom_weak_ref_tensor"],
+            with_cuda=True,
+            verbose=False,
+        )
+        _ATOM_WEAKREF_OP = _mod.atom_weak_ref_tensor
+        return _ATOM_WEAKREF_OP
+    except Exception as _e:  # noqa: BLE001
+        # Any build/compile failure -> disable (return-as-is is functionally
+        # correct, just uses more memory). Logged once.
+        try:
+            from aiter import logger as _logger
+
+            _logger.warning(
+                "atom weak_ref_tensor JIT compile failed (%s); PIECEWISE "
+                "cudagraph pools will NOT overlay -> higher memory. Set "
+                "ATOM_DISABLE_JIT_WEAKREF=1 to silence.",
+                _e,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        _ATOM_WEAKREF_OP = False
+        return None
+
+
 def weak_ref_tensor(tensor: Any) -> Any:
     """
     Create a weak reference to a tensor.
-    The new tensor will share the same data as the original tensor,
-    but will not keep the original tensor alive.
+    The new tensor shares the same data as the original tensor but does NOT keep
+    the original tensor's storage alive — essential for cudagraph memory pools to
+    overlay captured outputs across shapes. Falls back to returning the tensor
+    unchanged (functionally correct, more memory) if no weak-ref op is available.
     """
-    if isinstance(tensor, torch.Tensor):
-        return torch.ops._C.weak_ref_tensor(tensor)
+    if isinstance(tensor, torch.Tensor) and tensor.numel() > 0:
+        op = _get_weak_ref_op()
+        if op is not None:
+            try:
+                return op(tensor)
+            except (AttributeError, RuntimeError):
+                return tensor
+        return tensor
     else:
         return tensor
 

--- a/atom/utils/backends.py
+++ b/atom/utils/backends.py
@@ -420,26 +420,35 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):
                 self.vllm_backend,
             )
 
-            # if self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
-            #     # resolve the static graph wrapper class (e.g. CUDAGraphWrapper
-            #     # class) as platform dependent.
-            #     static_graph_wrapper_class = resolve_obj_by_qualname(
-            #         get_static_graph_wrapper_cls())
+            # Wrap each compiled dense piece in a PIECEWISE CUDAGraphWrapper so
+            # it captures/replays its own cudagraph (attention runs eager between
+            # pieces). Gated on cudagraph_mode requesting piecewise; otherwise
+            # keep the bare piecewise_backend (compiled, no per-piece cudagraph —
+            # the pre-existing behavior, e.g. FULL manual capture in the runner).
+            _cg_mode = self.compilation_config.cudagraph_mode
+            # Driven by --cudagraph-mode. Default FULL -> requires_piecewise is
+            # False -> bare piecewise_backend (compiled pieces inside the manual
+            # FULL whole-forward capture, i.e. existing behavior). PIECEWISE ->
+            # wrap each piece in its own cudagraph.
+            _pw_cg = (
+                _cg_mode is not None
+                and _cg_mode.requires_piecewise_compilation()
+            )
+            if _pw_cg:
+                from .cuda_graph import CUDAGraphOptions, CUDAGraphWrapper
 
-            #     # Always assign PIECEWISE runtime mode to the
-            #     # CUDAGraphWrapper for piecewise_backend, to distinguish
-            #     # it from the FULL cudagraph runtime mode, no matter it
-            #     # is wrapped on a full or piecewise fx graph.
-            #     self.module.__dict__[target] = static_graph_wrapper_class(
-            #         runnable=piecewise_backend,
-            #         vllm_config=self.vllm_config,
-            #         runtime_mode=CUDAGraphMode.PIECEWISE,
-            #         cudagraph_options=CUDAGraphOptions(
-            #             debug_log_enable=piecewise_backend.is_first_graph,
-            #             gc_disable=not piecewise_backend.is_first_graph,
-            #             weak_ref_output=piecewise_backend.is_last_graph))
-            # else:
-            self.module.__dict__[target] = piecewise_backend
+                self.module.__dict__[target] = CUDAGraphWrapper(
+                    runnable=piecewise_backend,
+                    vllm_config=self.vllm_config,
+                    runtime_mode=CUDAGraphMode.PIECEWISE,
+                    cudagraph_options=CUDAGraphOptions(
+                        debug_log_enable=piecewise_backend.is_first_graph,
+                        gc_disable=not piecewise_backend.is_first_graph,
+                        weak_ref_output=piecewise_backend.is_last_graph,
+                    ),
+                )
+            else:
+                self.module.__dict__[target] = piecewise_backend
 
             compilation_counter.num_piecewise_capturable_graphs_seen += 1
 

--- a/atom/utils/backends.py
+++ b/atom/utils/backends.py
@@ -430,10 +430,7 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):
             # False -> bare piecewise_backend (compiled pieces inside the manual
             # FULL whole-forward capture, i.e. existing behavior). PIECEWISE ->
             # wrap each piece in its own cudagraph.
-            _pw_cg = (
-                _cg_mode is not None
-                and _cg_mode.requires_piecewise_compilation()
-            )
+            _pw_cg = _cg_mode is not None and _cg_mode.requires_piecewise_compilation()
             if _pw_cg:
                 from .cuda_graph import CUDAGraphOptions, CUDAGraphWrapper
 

--- a/atom/utils/cuda_graph.py
+++ b/atom/utils/cuda_graph.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
+import os
 from contextlib import ExitStack
 from typing import Any, Callable, Optional, NamedTuple
 from unittest.mock import patch
@@ -61,6 +62,21 @@ class CUDAGraphOptions:
     debug_log_enable: bool = True
     gc_disable: bool = False
     weak_ref_output: bool = True
+
+
+# Shared cudagraph pool across piecewise pieces. Start None (first
+# torch.cuda.graph makes a private pool the warmup primed -> no hipMalloc during
+# capture on ROCm), then reuse that graph's pool for the rest.
+_shared_graph_pool: Optional[Any] = None
+
+# Per-num_tokens cudagraph pools. Under PIECEWISE with per-step VARYING
+# num_tokens (DSpark 1d), a single global pool lets graphs of DIFFERENT shapes
+# reuse overlapping memory -> replay reads another shape's leftover -> silent
+# corruption (replay != eager, only at large/varied num_tokens). Isolating one
+# pool PER num_tokens bucket removes the cross-shape overlap while keeping the
+# 61 same-shape pieces sharing (sequential -> safe). Memory ~ n_buckets * one
+# forward's pool (a few GB), vs ~22GB for fully-independent per-graph pools.
+_graph_pools: dict = {}
 
 
 class CUDAGraphWrapper:
@@ -187,8 +203,23 @@ class CUDAGraphWrapper:
                     stack.enter_context(patch("gc.collect", lambda: None))
                     stack.enter_context(patch("torch.cuda.empty_cache", lambda: None))
 
-                # mind-exploding: carefully manage the reference and memory.
-                with torch.cuda.graph(cudagraph, pool=self.graph_pool):
+                import atom.utils.cuda_graph as _cg_mod
+                # One cudagraph pool PER num_tokens bucket. A single global pool
+                # would let graphs of DIFFERENT num_tokens (PIECEWISE + DSpark 1d
+                # varying shapes) reuse overlapping memory -> replay reads another
+                # shape's leftover -> silent output corruption (only at
+                # large/varied num_tokens; confirmed via GSM8K). Isolating per
+                # num_tokens removes the cross-shape overlap; the same-shape pieces
+                # still share their bucket's pool. ATOM_GLOBAL_POOL=1 restores the
+                # old single pool (reproduces the corruption; A/B only).
+                _global = os.environ.get("ATOM_GLOBAL_POOL") == "1"
+                _bkey = batch_descriptor.num_tokens if batch_descriptor else 0
+                _pool = (
+                    _cg_mod._shared_graph_pool
+                    if _global
+                    else _cg_mod._graph_pools.get(_bkey)
+                )
+                with torch.cuda.graph(cudagraph, pool=_pool):
                     # `output` is managed by pytorch's cudagraph pool
                     output = self.runnable(*args, **kwargs)
                     if self.cudagraph_options.weak_ref_output:
@@ -202,6 +233,14 @@ class CUDAGraphWrapper:
 
             # here we always use weak ref for the output
             # to save memory
+            if _global:
+                if _cg_mod._shared_graph_pool is None:
+                    _cg_mod._shared_graph_pool = cudagraph.pool()
+            elif _bkey not in _cg_mod._graph_pools:
+                # first graph of this num_tokens bucket -> remember its pool so
+                # the remaining same-bucket pieces reuse it.
+                _cg_mod._graph_pools[_bkey] = cudagraph.pool()
+
             entry.output = weak_ref_tensors(output)
             entry.cudagraph = cudagraph
 

--- a/atom/utils/cuda_graph.py
+++ b/atom/utils/cuda_graph.py
@@ -64,18 +64,15 @@ class CUDAGraphOptions:
     weak_ref_output: bool = True
 
 
-# Shared cudagraph pool across piecewise pieces. Start None (first
-# torch.cuda.graph makes a private pool the warmup primed -> no hipMalloc during
-# capture on ROCm), then reuse that graph's pool for the rest.
+# Shared cudagraph pool across all piecewise pieces (default). Combined with the
+# weak_ref_tensor op it lets the pool OVERLAY piece outputs across shapes, so the
+# retained pool stays small (~10GB vs ~35GB unshared on DSV4 TP8). First
+# torch.cuda.graph makes the pool; the rest reuse it.
 _shared_graph_pool: Optional[Any] = None
 
-# Per-num_tokens cudagraph pools. Under PIECEWISE with per-step VARYING
-# num_tokens (DSpark 1d), a single global pool lets graphs of DIFFERENT shapes
-# reuse overlapping memory -> replay reads another shape's leftover -> silent
-# corruption (replay != eager, only at large/varied num_tokens). Isolating one
-# pool PER num_tokens bucket removes the cross-shape overlap while keeping the
-# 61 same-shape pieces sharing (sequential -> safe). Memory ~ n_buckets * one
-# forward's pool (a few GB), vs ~22GB for fully-independent per-graph pools.
+# Per-num_tokens pools (ATOM_PER_BUCKET_POOL=1 fallback). Isolates each shape's
+# pool so shapes can't overlap — costs more memory but avoids any cross-shape
+# reuse. Kept as a safety escape hatch; default is the shared pool above.
 _graph_pools: dict = {}
 
 
@@ -204,20 +201,18 @@ class CUDAGraphWrapper:
                     stack.enter_context(patch("torch.cuda.empty_cache", lambda: None))
 
                 import atom.utils.cuda_graph as _cg_mod
-                # One cudagraph pool PER num_tokens bucket. A single global pool
-                # would let graphs of DIFFERENT num_tokens (PIECEWISE + DSpark 1d
-                # varying shapes) reuse overlapping memory -> replay reads another
-                # shape's leftover -> silent output corruption (only at
-                # large/varied num_tokens; confirmed via GSM8K). Isolating per
-                # num_tokens removes the cross-shape overlap; the same-shape pieces
-                # still share their bucket's pool. ATOM_GLOBAL_POOL=1 restores the
-                # old single pool (reproduces the corruption; A/B only).
-                _global = os.environ.get("ATOM_GLOBAL_POOL") == "1"
+
+                # Default: single shared pool (overlays piece outputs across
+                # shapes -> low memory; safe here because pieces replay serially
+                # and inter-piece tensors are pinned via persistent buffers).
+                # ATOM_PER_BUCKET_POOL=1 isolates a pool per num_tokens bucket
+                # (more memory) as a fallback.
+                _per_bucket = os.environ.get("ATOM_PER_BUCKET_POOL") == "1"
                 _bkey = batch_descriptor.num_tokens if batch_descriptor else 0
                 _pool = (
-                    _cg_mod._shared_graph_pool
-                    if _global
-                    else _cg_mod._graph_pools.get(_bkey)
+                    _cg_mod._graph_pools.get(_bkey)
+                    if _per_bucket
+                    else _cg_mod._shared_graph_pool
                 )
                 with torch.cuda.graph(cudagraph, pool=_pool):
                     # `output` is managed by pytorch's cudagraph pool
@@ -233,13 +228,13 @@ class CUDAGraphWrapper:
 
             # here we always use weak ref for the output
             # to save memory
-            if _global:
-                if _cg_mod._shared_graph_pool is None:
-                    _cg_mod._shared_graph_pool = cudagraph.pool()
-            elif _bkey not in _cg_mod._graph_pools:
-                # first graph of this num_tokens bucket -> remember its pool so
-                # the remaining same-bucket pieces reuse it.
-                _cg_mod._graph_pools[_bkey] = cudagraph.pool()
+            if _per_bucket:
+                if _bkey not in _cg_mod._graph_pools:
+                    # first graph of this bucket -> remember its pool.
+                    _cg_mod._graph_pools[_bkey] = cudagraph.pool()
+            elif _cg_mod._shared_graph_pool is None:
+                # first graph overall -> remember the shared pool.
+                _cg_mod._shared_graph_pool = cudagraph.pool()
 
             entry.output = weak_ref_tensors(output)
             entry.cudagraph = cudagraph

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -545,6 +545,16 @@ class ForwardContext:
     # forward, so it ignores the flag entirely.
     in_hipgraph: bool = False
 
+    # Piecewise-cudagraph dispatch. CUDAGraphWrapper (atom/utils/cuda_graph.py)
+    # reads these per forward: cudagraph_runtime_mode selects which wrapper
+    # (PIECEWISE / FULL) captures-or-replays this step, and batch_descriptor is
+    # the dispatch key (num_tokens). Defaults keep every wrapper INERT
+    # (pass-through) — None never equals CUDAGraphMode.NONE nor any wrapper's
+    # runtime_mode, so nothing changes until model_runner sets them per step.
+    # Typed Any to avoid a circular import of CUDAGraphMode/BatchDescriptor.
+    cudagraph_runtime_mode: Any = None
+    batch_descriptor: Optional[Any] = None
+
     def __post_init__(self):
         if not hasattr(self, "no_compile_layers") or self.no_compile_layers is None:
             self.no_compile_layers = {}

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -545,13 +545,10 @@ class ForwardContext:
     # forward, so it ignores the flag entirely.
     in_hipgraph: bool = False
 
-    # Piecewise-cudagraph dispatch. CUDAGraphWrapper (atom/utils/cuda_graph.py)
-    # reads these per forward: cudagraph_runtime_mode selects which wrapper
-    # (PIECEWISE / FULL) captures-or-replays this step, and batch_descriptor is
-    # the dispatch key (num_tokens). Defaults keep every wrapper INERT
-    # (pass-through) — None never equals CUDAGraphMode.NONE nor any wrapper's
-    # runtime_mode, so nothing changes until model_runner sets them per step.
-    # Typed Any to avoid a circular import of CUDAGraphMode/BatchDescriptor.
+    # Piecewise-cudagraph dispatch, read per forward by CUDAGraphWrapper:
+    # cudagraph_runtime_mode picks the capture/replay mode, batch_descriptor is
+    # the key (num_tokens). None defaults keep wrappers inert until model_runner
+    # sets them. Typed Any to dodge a CUDAGraphMode circular import.
     cudagraph_runtime_mode: Any = None
     batch_descriptor: Optional[Any] = None
 

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -21,6 +21,15 @@ if _atom_config_stub is not None:
         _atom_config_stub.SpeculativeConfig = MagicMock(
             side_effect=lambda **kw: MagicMock(**kw)
         )
+    if not hasattr(_atom_config_stub, "CUDAGraphMode"):
+        # arg_utils imports CUDAGraphMode and does CUDAGraphMode[name] to map the
+        # --cudagraph-mode string; use a real enum so subscript access works.
+        import enum as _enum
+
+        _atom_config_stub.CUDAGraphMode = _enum.Enum(
+            "CUDAGraphMode",
+            {"NONE": 0, "PIECEWISE": 1, "FULL": 2, "FULL_AND_PIECEWISE": 3},
+        )
 
 from atom.model_engine.arg_utils import EngineArgs  # noqa: E402
 


### PR DESCRIPTION
Per-piece cudagraph capture with attention kept eager, ported from the DSpark feature branch with all speculative-decode logic stripped out (this branch targets plain non-spec V4).
PIECEWISE cudagraph:
`--cudagraph-mode PIECEWISE`

<img width="2430" height="610" alt="image" src="https://github.com/user-attachments/assets/ec741a63-5739-4302-9545-ea4dd3392d90" />

piecewise perf: bs 256
```
============ Serving Benchmark Result ============
Successful requests:                     1024      
Benchmark duration (s):                  219.50    
Total input tokens:                      944750    
Total generated tokens:                  943215    
Request throughput (req/s):              4.67      
Output token throughput (tok/s):         4297.10   
Total Token throughput (tok/s):          8601.19   
---------------Time to First Token----------------
Mean TTFT (ms):                          1455.03   
Median TTFT (ms):                        296.59    
P99 TTFT (ms):                           8217.35   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          55.87     
Median TPOT (ms):                        57.45     
P99 TPOT (ms):                           65.82     
---------------Inter-token Latency----------------
Mean ITL (ms):                           55.99     
Median ITL (ms):                         39.01     
P99 ITL (ms):                            314.12    
==================================================
```
Full perf:
```
============ Serving Benchmark Result ============
Successful requests:                     1024      
Benchmark duration (s):                  201.03    
Total input tokens:                      944750    
Total generated tokens:                  943215    
Request throughput (req/s):              5.09      
Output token throughput (tok/s):         4691.87   
Total Token throughput (tok/s):          9391.38   
---------------Time to First Token----------------
Mean TTFT (ms):                          1548.87   
Median TTFT (ms):                        283.15    
P99 TTFT (ms):                           8698.77   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.02     
Median TPOT (ms):                        52.47     
P99 TPOT (ms):                           59.17     
---------------Inter-token Latency----------------
Mean ITL (ms):                           51.11     
Median ITL (ms):                         36.02     
P99 ITL (ms):                            278.72    
==================================================
```

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
