### PR TITLE
feat(tbo): skip prefill TBO below a min token count

### DIFF
--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -256,6 +256,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_TBO_PREFILL_TOKEN_SPLIT": lambda: (
         os.getenv("ATOM_TBO_PREFILL_TOKEN_SPLIT", "1") == "1"
     ),
+    # Minimum prefill tokens (per rank) required to TBO-split.
+    "ATOM_TBO_PREFILL_MIN_TOKENS": lambda: int(
+        os.getenv("ATOM_TBO_PREFILL_MIN_TOKENS", "8192")
+    ),
     # --- NUMA binding ---
     # Master switch: pin each GPU worker to its GPU-local NUMA node's CPU cores
     # and preferred memory. Default off so baseline/pinned A/B stays clean.

--- a/atom/utils/tbo/ubatch_splitting.py
+++ b/atom/utils/tbo/ubatch_splitting.py
@@ -58,7 +58,7 @@ def maybe_create_ubatch_slices(
     num_tokens: int,
     num_ubatches: int = 2,
     is_prefill: bool = False,
-    num_scheduled_tokens: Optional[list[int]] = None,
+    num_scheduled_tokens: Optional[np.ndarray] = None,
     max_tokens_per_ubatch: Optional[int] = None,
 ) -> Optional[list[UBatchSlice]]:
     """Split a batch into N micro-batch slices.
@@ -85,7 +85,7 @@ def maybe_create_ubatch_slices(
         # Skip TBO for small prefills
         _min_pref = envs.ATOM_TBO_PREFILL_MIN_TOKENS
         if _min_pref > 0:
-            _pref_total = int(np.asarray(num_scheduled_tokens[:num_reqs]).sum())
+            _pref_total = int(num_scheduled_tokens[:num_reqs].sum())
             if _pref_total < _min_pref:
                 return None
         # Prefill: token-balanced split

--- a/atom/utils/tbo/ubatch_splitting.py
+++ b/atom/utils/tbo/ubatch_splitting.py
@@ -82,6 +82,12 @@ def maybe_create_ubatch_slices(
         return None
 
     if num_scheduled_tokens is not None:
+        # Skip TBO for small prefills
+        _min_pref = envs.ATOM_TBO_PREFILL_MIN_TOKENS
+        if _min_pref > 0:
+            _pref_total = int(np.asarray(num_scheduled_tokens[:num_reqs]).sum())
+            if _pref_total < _min_pref:
+                return None
         # Prefill: token-balanced split
         if token_split:
             if num_tokens < num_ubatches:

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -53,6 +53,8 @@ def local_tbo_precompute(
         # slices → all_gather size mismatch → RCCL hang.
         from atom.utils import envs
 
+        # Skip TBO when this rank's prefill is too small
+        _min_pref = envs.ATOM_TBO_PREFILL_MIN_TOKENS
         # MUST mirror maybe_create_ubatch_slices' gating exactly, or the
         # cross-DP MAX-reduced ub0/ub1 disagree with the realised slices → hang.
         if envs.ATOM_TBO_PREFILL_TOKEN_SPLIT:
@@ -61,6 +63,8 @@ def local_tbo_precompute(
             toks = np.asarray(num_scheduled_tokens[:n_pref], dtype=np.int64)
             total = int(toks.sum())
             if total < 2:
+                return False, 0, 0
+            if _min_pref > 0 and total < _min_pref:
                 return False, 0, 0
             ub0 = total // 2
             ub1 = total - ub0
@@ -72,6 +76,8 @@ def local_tbo_precompute(
         # produce post-decision.
         toks = np.asarray(num_scheduled_tokens[:n_pref], dtype=np.int64)
         total = int(toks.sum())
+        if _min_pref > 0 and total < _min_pref:
+            return False, 0, 0
         target = total // 2
         cumsum = 0
         split_idx = 1


### PR DESCRIPTION
Skip TBO when per-rank prefill tokens < ATOM_TBO_PREFILL_MIN_TOKENS (default 8192). 
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
