### PR TITLE
[sglang+atom] Add Qwen3.5 35B PTPC FP8 support

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -1023,8 +1023,8 @@ class MergedColumnParallelLinear(LinearBase):
                 if param is getattr(self, "weight_scale", None) or param is getattr(
                     self, "input_scale", None
                 ):
-                    if self.quant_type != QuantType.per_1x32:
-                        shard_size //= 128
+                    if self.quant_type == QuantType.per_1x128:
+                        shard_size = (shard_size + 127) // 128
                 shard = loaded_weight.narrow(self.tp_dim, current_offset, shard_size)
                 self.weight_loader(param, shard, shard_id)
                 current_offset += shard_size

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -1023,8 +1023,14 @@ class MergedColumnParallelLinear(LinearBase):
                 if param is getattr(self, "weight_scale", None) or param is getattr(
                     self, "input_scale", None
                 ):
-                    if self.quant_type == QuantType.per_1x128:
+                    if self.quant_type == QuantType.per_Token:
+                        # PTPC FP8 scale is per output channel, so it follows
+                        # the weight shard size rather than 128-wide blocks.
+                        pass
+                    elif self.quant_type == QuantType.per_1x128:
                         shard_size = (shard_size + 127) // 128
+                    elif self.quant_type != QuantType.per_1x32:
+                        shard_size //= 128
                 shard = loaded_weight.narrow(self.tp_dim, current_offset, shard_size)
                 self.weight_loader(param, shard, shard_id)
                 current_offset += shard_size
@@ -1049,8 +1055,13 @@ class MergedColumnParallelLinear(LinearBase):
             current_offset = 0
             for shard_id, output_size in enumerate(self.output_sizes):
                 shard_size = output_size
-                if is_scale_param and self.quant_type == QuantType.per_1x128:
-                    shard_size //= 128
+                if is_scale_param:
+                    if self.quant_type == QuantType.per_Token:
+                        pass
+                    elif self.quant_type == QuantType.per_1x128:
+                        shard_size = (shard_size + 127) // 128
+                    elif self.quant_type != QuantType.per_1x32:
+                        shard_size //= 128
 
                 shard = loaded_weight.narrow(self.tp_dim, current_offset, shard_size)
                 self.weight_loader(param, shard, shard_id)

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -1023,13 +1023,10 @@ class MergedColumnParallelLinear(LinearBase):
                 if param is getattr(self, "weight_scale", None) or param is getattr(
                     self, "input_scale", None
                 ):
-                    if self.quant_type == QuantType.per_Token:
-                        # PTPC FP8 scale is per output channel, so it follows
-                        # the weight shard size rather than 128-wide blocks.
-                        pass
-                    elif self.quant_type == QuantType.per_1x128:
-                        shard_size = (shard_size + 127) // 128
-                    elif self.quant_type != QuantType.per_1x32:
+                    if self.quant_type not in (
+                        QuantType.per_1x32,
+                        QuantType.per_Token,
+                    ):
                         shard_size //= 128
                 shard = loaded_weight.narrow(self.tp_dim, current_offset, shard_size)
                 self.weight_loader(param, shard, shard_id)
@@ -1055,8 +1052,12 @@ class MergedColumnParallelLinear(LinearBase):
             current_offset = 0
             for shard_id, output_size in enumerate(self.output_sizes):
                 shard_size = output_size
-                if is_scale_param and self.quant_type == QuantType.per_1x128:
-                    shard_size //= 128
+                if is_scale_param:
+                    if self.quant_type not in (
+                        QuantType.per_1x32,
+                        QuantType.per_Token,
+                    ):
+                        shard_size //= 128
 
                 shard = loaded_weight.narrow(self.tp_dim, current_offset, shard_size)
                 self.weight_loader(param, shard, shard_id)

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -1055,13 +1055,8 @@ class MergedColumnParallelLinear(LinearBase):
             current_offset = 0
             for shard_id, output_size in enumerate(self.output_sizes):
                 shard_size = output_size
-                if is_scale_param:
-                    if self.quant_type == QuantType.per_Token:
-                        pass
-                    elif self.quant_type == QuantType.per_1x128:
-                        shard_size = (shard_size + 127) // 128
-                    elif self.quant_type != QuantType.per_1x32:
-                        shard_size //= 128
+                if is_scale_param and self.quant_type == QuantType.per_1x128:
+                    shard_size //= 128
 
                 shard = loaded_weight.narrow(self.tp_dim, current_offset, shard_size)
                 self.weight_loader(param, shard, shard_id)

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -1052,12 +1052,8 @@ class MergedColumnParallelLinear(LinearBase):
             current_offset = 0
             for shard_id, output_size in enumerate(self.output_sizes):
                 shard_size = output_size
-                if is_scale_param:
-                    if self.quant_type not in (
-                        QuantType.per_1x32,
-                        QuantType.per_Token,
-                    ):
-                        shard_size //= 128
+                if is_scale_param and self.quant_type == QuantType.per_1x128:
+                    shard_size //= 128
 
                 shard = loaded_weight.narrow(self.tp_dim, current_offset, shard_size)
                 self.weight_loader(param, shard, shard_id)


### PR DESCRIPTION
## Summary

- Fix PTPC FP8 scale shard loading for merged column-parallel linear layers.
- Keep existing non-PTPC scale sharding behavior, and only exclude `QuantType.per_Token` from the legacy `// 128` scale shard adjustment.
- This enables Qwen3.5-35B-A3B-PTPC-FP8 to load and run correctly in the MI308 SGLang accuracy path.

## Validation

Ran MI308 35B PTPC local model accuracy without downloading:

- Model: `/models/amd/Qwen3.5-35B-A3B-PTPC-FP8`
- Args: `--tensor-parallel-size 1 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache`
- Task: GSM8K, 3-shot
- Result: `0.849128127369219` flexible-extract
- Strict match: `0.8332069749810462`
- Threshold: `0.76`
- Status: PASS