### PR TITLE
[plugin][fix] DSA indexer: single-source decode_lens to fix random illegal memory access

### DIFF
--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -118,7 +118,20 @@ def replicated_embedding(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     # embedding gather into the surrounding graph, which corrupts the MTP draft
     # rollout (acceptance collapses ~69%->45%) — the same reason
     # VocabParallelEmbedding routes through the masked_embedding custom op.
-    return F.embedding(x, weight)
+    #
+    # Route through the masked kernel with the full-table range [0, num_rows) so
+    # out-of-range ids never reach a raw gather. Under async scheduling + MTP
+    # spec-decode, input_ids can transiently carry the optimistic placeholder
+    # token -1 (an unresolved "assumed-accepted" draft/bonus slot, produced in
+    # gpu_model_runner and read back via prepare_next_token_ids_padded's backup
+    # before the deferred correction lands) — for BOTH the target and the shared
+    # draft embedding. A raw F.embedding(-1) reads the row before the table ->
+    # random illegal memory access. The masked load returns a zero vector for any
+    # out-of-range id: bit-identical to F.embedding for every valid token, and
+    # matching vLLM's VocabParallelEmbedding (which masks the same -1 to 0) so the
+    # unverified -1 slots — whose output is discarded/corrected by async
+    # spec-decode — see the same value native does. No accuracy change.
+    return _masked_embedding_launcher(x, weight, 0, weight.shape[0])
 
 
 class VocabParallelEmbedding(nn.Module):

--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -2222,14 +2222,31 @@ class AiterMlaSparseIndexerMetadataBuilder(AttentionMetadataBuilder):
 
         decode_metadata = None
         if num_decodes > 0:
-            torch.diff(
-                common_attn_metadata.query_start_loc[: num_decodes + 1],
-                out=self.decode_lens_buffer[:num_decodes],
-            )
-            decode_lens = self.decode_lens_buffer[:num_decodes]
+            # Single-source the decode lengths from query_start_loc_cpu.
+            #
+            # `decode_lens` is used below as the `repeats` argument of
+            # torch.repeat_interleave, while `actual_expanded` (derived from
+            # decode_lens_cpu.sum()) is passed as its `output_size`. When
+            # output_size is given, repeat_interleave SKIPS the device sync and
+            # trusts that `output_size == repeats.sum()`; if that contract is
+            # violated it emits an internal gather index past the source rows and
+            # the underlying index_select over-reads -> random illegal memory
+            # access.
+            #
+            # Previously `decode_lens` was diffed from the GPU `query_start_loc`
+            # while `output_size` came from the CPU `query_start_loc_cpu`. Under
+            # async scheduling the GPU and CPU copies of query_start_loc can
+            # momentarily disagree, so `repeats` and `output_size` came from two
+            # different sources and could mismatch. Deriving `decode_lens` from
+            # the SAME CPU tensor (copied into the persistent GPU buffer) makes
+            # `decode_lens.sum() == actual_expanded` hold by construction.
             decode_lens_cpu = torch.diff(
                 common_attn_metadata.query_start_loc_cpu[: num_decodes + 1]
             )
+            self.decode_lens_buffer[:num_decodes].copy_(
+                decode_lens_cpu, non_blocking=True
+            )
+            decode_lens = self.decode_lens_buffer[:num_decodes]
 
             seq_lens = common_attn_metadata.seq_lens[:num_decodes]
             block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]


### PR DESCRIPTION
_build_indexer's multi-token-decode branch feeds torch.repeat_interleave with repeats=decode_lens and output_size=actual_expanded. With output_size given, repeat_interleave skips the device sync and trusts output_size == repeats.sum(); a violation makes its internal gather index run past the source rows, so the underlying index_select over-reads and triggers an intermittent illegal memory access (faults only when the over-read lands on an unmapped page -> random, data/timing dependent; surfaced late by async_copy_ready_event.synchronize() under async scheduling).

The two operands came from different sources: decode_lens was diffed from the GPU query_start_loc, while actual_expanded came from the CPU query_start_loc_cpu. Under async scheduling the GPU/CPU copies can momentarily disagree, so repeats and output_size could mismatch.

Derive decode_lens from the same CPU query_start_loc_cpu (copied into the persistent GPU buffer) so decode_lens.sum() == actual_expanded by construction. Same single-source-of-truth principle as the native-path fix in #1559.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
