### PR TITLE
ci: re-login to Docker Hub before each push in nightly release

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -114,6 +114,19 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Compute push gates
+        # Single source of truth for which images get pushed. The build,
+        # re-login, and push steps below all read these outputs instead of each
+        # duplicating the same long boolean, so the conditions can't drift.
+        id: gates
+        run: |
+          set -euo pipefail
+          {
+            echo "main=${{ inputs.only_release_oot != true && inputs.only_release_sglang != true }}"
+            echo "oot=${{ inputs.only_release_oot == true || (inputs.only_release_sglang != true && (github.event_name == 'schedule' || inputs.build_oot_image == true)) }}"
+            echo "sglang=${{ inputs.only_release_sglang == true || (inputs.only_release_oot != true && (github.event_name == 'schedule' || inputs.build_sglang_image == true)) }}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Echo environment variables
         run: |
           echo "ATOM_REPO: ${{ inputs.atom_repo || env.ATOM_REPO }}"
@@ -156,7 +169,7 @@ jobs:
           docker inspect atom_release:ci
 
       - name: Test Docker image
-        if: ${{ inputs.skip_tests != true && inputs.only_release_oot != true && inputs.only_release_sglang != true }}
+        if: ${{ success() && steps.gates.outputs.main == 'true' && inputs.skip_tests != true }}
         timeout-minutes: 60
         run: |
           echo "Clean up containers..."
@@ -204,8 +217,19 @@ jobs:
             echo "Output matches golden outputs."
           fi
 
+      - name: Re-login to Docker Hub before push
+        # The initial login happens before a ~1h image build, so its auth token
+        # is stale by the time this push finalizes (multi-GB push of a large
+        # image), causing "unauthorized: authentication required" on the manifest
+        # PUT. Re-authenticate immediately before pushing to get a fresh token.
+        if: ${{ success() && steps.gates.outputs.main == 'true' }}
+        uses: ./.github/actions/docker-auth
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Push Docker image
-        if: ${{ success() && inputs.only_release_oot != true && inputs.only_release_sglang != true }}
+        if: ${{ success() && steps.gates.outputs.main == 'true' }}
         run: |
           CUSTOM_TAG="${{ inputs.custom_tag || '' }}"
           if [ -n "${CUSTOM_TAG}" ]; then
@@ -235,7 +259,7 @@ jobs:
           fi
 
       - name: Build OOT Docker image
-        if: ${{ success() && (inputs.only_release_oot == true || (inputs.only_release_sglang != true && (github.event_name == 'schedule' || inputs.build_oot_image == true))) }}
+        if: ${{ success() && steps.gates.outputs.oot == 'true' }}
         timeout-minutes: 180
         run: |
           OOT_BASE_IMAGE="atom_release:ci"
@@ -250,8 +274,17 @@ jobs:
             -f docker/Dockerfile .
           docker inspect atom_oot_release:ci
 
+      - name: Re-login to Docker Hub before OOT push
+        # Fresh token before this push: the OOT build above adds even more time
+        # since the initial login, so the auth token is stale by push time.
+        if: ${{ success() && steps.gates.outputs.oot == 'true' }}
+        uses: ./.github/actions/docker-auth
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Push OOT Docker image
-        if: ${{ success() && (inputs.only_release_oot == true || (inputs.only_release_sglang != true && (github.event_name == 'schedule' || inputs.build_oot_image == true))) }}
+        if: ${{ success() && steps.gates.outputs.oot == 'true' }}
         run: |
           set -euo pipefail
           VLLM_VER="${{ env.VLLM_VERSION }}"
@@ -275,7 +308,7 @@ jobs:
           fi
 
       - name: Build SGLang Docker image
-        if: ${{ success() && (inputs.only_release_sglang == true || (inputs.only_release_oot != true && (github.event_name == 'schedule' || inputs.build_sglang_image == true))) }}
+        if: ${{ success() && steps.gates.outputs.sglang == 'true' }}
         timeout-minutes: 180
         run: |
           SGLANG_BASE_IMAGE="atom_release:ci"
@@ -289,8 +322,17 @@ jobs:
             -f docker/Dockerfile .
           docker inspect atom_sglang_release:ci
 
+      - name: Re-login to Docker Hub before SGLang push
+        # Fresh token before this push: the SGLang build above adds even more
+        # time since the initial login, so the auth token is stale by push time.
+        if: ${{ success() && steps.gates.outputs.sglang == 'true' }}
+        uses: ./.github/actions/docker-auth
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Push SGLang+ATOM Docker image
-        if: ${{ success() && (inputs.only_release_sglang == true || (inputs.only_release_oot != true && (github.event_name == 'schedule' || inputs.build_sglang_image == true))) }}
+        if: ${{ success() && steps.gates.outputs.sglang == 'true' }}
         run: |
           set -euo pipefail
           SGLANG_VER="${{ inputs.sglang_version || env.SGLANG_VERSION }}"


### PR DESCRIPTION
## Problem

The Nightly Docker Release job (`docker-release.yaml`) fails intermittently at the **Push Docker image** step with:

```
unauthorized: authentication required
##[error]Process completed with exit code 1.
```

Root cause (from run [29195974371](https://github.com/ROCm/ATOM/actions/runs/29195974371/job/86658882216)):
- `docker login` happens **once** at job start.
- The image build takes **~64 min**; the push starts ~1h later.
- All layers upload fine, but the **manifest finalize** ~70 min after login gets `401` — the Docker Hub auth token has gone stale over the long build + multi-GB push.

This is a credential-staleness issue, not a bad secret (login succeeds, dozens of layers push successfully; only the finalize 401s).

## Fix

1. **Re-login before each push.** Add a fresh `docker-auth` step immediately before each of the three push steps (native / OOT / SGLang), each following a long build, so every push starts with a fresh token. Fix-then-sweep: all three, not just the one that failed.

2. **Single source of truth for push gating.** The three push-selection booleans were duplicated across build/push `if:` conditions (and now would be duplicated again on the re-login steps). Fold them into one `Compute push gates` step whose `main`/`oot`/`sglang` outputs every build/re-login/push/test step references, so the conditions are defined once and can't drift. The gate step uses `set -euo pipefail` so a failed `$GITHUB_OUTPUT` write fails loudly instead of silently skipping all pushes.

## Notes

- The shared `docker-auth` composite action is unchanged; secrets stay scoped to each login step via `with:` (not job-level env), so `DOCKER_PASSWORD` is not exposed to the build/test steps.
- Behavior is otherwise preserved: the gate expressions are byte-identical to the original `if:` conditions.

## Test plan

- [ ] Trigger a manual `workflow_dispatch` release run and confirm all three images push without `unauthorized`.
- [ ] Confirm `only_release_oot` / `only_release_sglang` selective runs still gate correctly (only the selected image builds/pushes).