### PR TITLE
[ATOM SGL] GLM 5.2 MTP

### DIFF
--- a/atom/plugin/sglang/attention_backend/sparse_mla_indexer.py
+++ b/atom/plugin/sglang/attention_backend/sparse_mla_indexer.py
@@ -131,6 +131,31 @@ def _build_sglang_query_ranges(forward_batch) -> tuple[torch.Tensor, torch.Tenso
         ends = forward_batch.seq_lens[:bs].to(dtype=torch.int32)
         return starts, ends
 
+    if forward_batch.forward_mode.is_target_verify():
+        bs = int(forward_batch.batch_size)
+        draft_token_num = int(
+            getattr(getattr(forward_batch, "spec_info", None), "draft_token_num", 0)
+            or 0
+        )
+        if draft_token_num <= 0:
+            raise RuntimeError("TARGET_VERIFY sparse MLA requires draft_token_num")
+        seq_lens = forward_batch.seq_lens[:bs].to(dtype=torch.int32)
+        kv_lens = seq_lens + draft_token_num
+        base_offsets = torch.cumsum(
+            torch.cat([torch.zeros(1, dtype=torch.int32, device=device), kv_lens[:-1]]),
+            dim=0,
+        )
+        starts = torch.repeat_interleave(base_offsets, draft_token_num)
+        per_req_end_base = torch.repeat_interleave(
+            base_offsets + seq_lens, draft_token_num
+        )
+        draft_offsets = torch.arange(
+            1, draft_token_num + 1, dtype=torch.int32, device=device
+        ).repeat(bs)
+        return starts.to(dtype=torch.int32), (per_req_end_base + draft_offsets).to(
+            dtype=torch.int32
+        )
+
     query_lens = getattr(forward_batch, "extend_seq_lens", None)
     if query_lens is None:
         query_lens = forward_batch.seq_lens
@@ -164,28 +189,54 @@ def _build_sglang_block_table(forward_batch, page_size: int) -> torch.Tensor:
     token_table = req_to_token[req_pool_indices, :]
     if not forward_batch.forward_mode.is_decode_or_idle():
         token_table = token_table.clone()
-        query_lens = getattr(forward_batch, "extend_seq_lens", None)
-        if query_lens is None:
-            query_lens = forward_batch.seq_lens
-        prefix_lens = getattr(forward_batch, "extend_prefix_lens", None)
-        if prefix_lens is None:
-            prefix_lens = forward_batch.seq_lens - query_lens
-        query_lens_cpu = query_lens[: int(forward_batch.batch_size)].detach().cpu()
-        prefix_lens_cpu = prefix_lens[: int(forward_batch.batch_size)].detach().cpu()
+        bs = int(forward_batch.batch_size)
+        if forward_batch.forward_mode.is_target_verify():
+            draft_token_num = int(
+                getattr(
+                    getattr(forward_batch, "spec_info", None), "draft_token_num", 0
+                )
+                or 0
+            )
+            if draft_token_num <= 0:
+                raise RuntimeError("TARGET_VERIFY sparse MLA requires draft_token_num")
+            query_lens_cpu = [draft_token_num] * bs
+            seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+            if seq_lens_cpu is None:
+                seq_lens_cpu = forward_batch.seq_lens[:bs].detach().cpu()
+            prefix_lens_cpu = [int(x) for x in seq_lens_cpu[:bs]]
+        else:
+            query_lens = getattr(forward_batch, "extend_seq_lens", None)
+            if query_lens is None:
+                query_lens = forward_batch.seq_lens
+            prefix_lens = getattr(forward_batch, "extend_prefix_lens", None)
+            if prefix_lens is None:
+                prefix_lens = forward_batch.seq_lens - query_lens
+            query_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+            if query_lens_cpu is None:
+                query_lens_cpu = query_lens[:bs].detach().cpu()
+            else:
+                query_lens_cpu = query_lens_cpu[:bs]
+            prefix_lens_cpu = getattr(forward_batch, "extend_prefix_lens_cpu", None)
+            if prefix_lens_cpu is None:
+                prefix_lens_cpu = prefix_lens[:bs].detach().cpu()
+            else:
+                prefix_lens_cpu = prefix_lens_cpu[:bs]
         offset = 0
         for req_idx, (prefix_len_raw, query_len_raw) in enumerate(
             zip(prefix_lens_cpu, query_lens_cpu)
         ):
             prefix_len = int(prefix_len_raw)
             query_len = int(query_len_raw)
+            remaining = int(forward_batch.out_cache_loc.shape[0]) - offset
+            query_len = min(query_len, max(remaining, 0))
             if query_len > 0:
                 token_table[req_idx, prefix_len : prefix_len + query_len] = (
                     forward_batch.out_cache_loc[offset : offset + query_len]
                 )
             offset += query_len
     if page_size == 1:
-        return token_table
-    return token_table[:, ::page_size] // page_size
+        return token_table.to(dtype=torch.int32).contiguous()
+    return (token_table[:, ::page_size] // page_size).to(dtype=torch.int32).contiguous()
 
 
 def _build_sparse_req_id_per_token_for_sglang(
@@ -196,6 +247,14 @@ def _build_sparse_req_id_per_token_for_sglang(
     req_ids = torch.arange(bs, dtype=torch.int32, device=device)
     if forward_batch.forward_mode.is_decode_or_idle():
         return req_ids
+    if forward_batch.forward_mode.is_target_verify():
+        draft_token_num = int(
+            getattr(getattr(forward_batch, "spec_info", None), "draft_token_num", 0)
+            or 0
+        )
+        if draft_token_num <= 0:
+            raise RuntimeError("TARGET_VERIFY sparse MLA requires draft_token_num")
+        return torch.repeat_interleave(req_ids, draft_token_num)
     query_lens = getattr(forward_batch, "extend_seq_lens", None)
     if query_lens is None:
         query_lens = forward_batch.seq_lens

--- a/atom/plugin/sglang/models/base_model_wrapper.py
+++ b/atom/plugin/sglang/models/base_model_wrapper.py
@@ -270,18 +270,36 @@ class _AtomCausalLMBaseForSglang(nn.Module):
                         )
 
                 hidden_states = runtime.trim_output(hidden_states)
+                logits_input_ids = input_ids
+                try:
+                    mode = getattr(forward_batch, "forward_mode", None)
+                    spec_info = getattr(forward_batch, "spec_info", None)
+                    draft_token_num = int(getattr(spec_info, "draft_token_num", 0) or 0)
+                    target_verify_rows = int(forward_batch.batch_size) * draft_token_num
+                    if (
+                        mode is not None
+                        and bool(getattr(mode, "is_target_verify", lambda: False)())
+                        and target_verify_rows > 0
+                        and torch.is_tensor(hidden_states)
+                        and hidden_states.shape[0] != target_verify_rows
+                    ):
+                        hidden_states = hidden_states[:target_verify_rows]
+                        if torch.is_tensor(logits_input_ids):
+                            logits_input_ids = logits_input_ids[:target_verify_rows]
+                except Exception:
+                    logger.exception("Failed to trim target-verify outputs for logits")
 
                 if self.pp_group.is_last_rank:
                     if self.model_arch == "DeepseekV4ForCausalLM":
                         return self.logits_processor(
-                            input_ids,
+                            logits_input_ids,
                             hidden_states,
                             self.logits_head,
                             forward_batch,
                             hidden_states_before_norm=hidden_states,
                         )
                     return self.logits_processor(
-                        input_ids,
+                        logits_input_ids,
                         hidden_states,
                         self.logits_head,
                         forward_batch,

--- a/atom/plugin/sglang/models/deepseek_nextn_wrapper.py
+++ b/atom/plugin/sglang/models/deepseek_nextn_wrapper.py
@@ -7,6 +7,7 @@ actual draft core to ATOM's `DeepSeekMTP`.
 
 import copy
 import logging
+import re
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -69,11 +70,23 @@ def _retag_mtp_runtime_layer_ids(model: nn.Module) -> None:
     Rebind only the runtime ids used by the attention/KV-cache path.
     """
 
-    for local_layer_id, mtp_layer in enumerate(model.model.layers.values()):
+    for local_layer_id, (global_layer_id, mtp_layer) in enumerate(
+        model.model.layers.items()
+    ):
         mtp_block = mtp_layer.mtp_block
         self_attn = mtp_block.self_attn
 
         _set_runtime_layer_id(self_attn, local_layer_id)
+        indexer = getattr(self_attn, "indexer", None)
+        if indexer is not None:
+            k_cache = getattr(indexer, "k_cache", None)
+            if k_cache is not None and hasattr(k_cache, "prefix"):
+                k_cache.prefix = re.sub(
+                    rf"\.layers\.{re.escape(str(global_layer_id))}\.",
+                    f".layers.{local_layer_id}.",
+                    k_cache.prefix,
+                    count=1,
+                )
 
         for attr_name in ("mla_attn", "attn_non_absorbed", "attn_mha"):
             attn_obj = getattr(self_attn, attr_name, None)
@@ -113,6 +126,8 @@ def _install_local_nextn_weight_remap(model: nn.Module) -> None:
 class DeepseekV3ForCausalLMNextN(nn.Module):
     """SGLang-compatible draft wrapper backed by ATOM's `DeepSeekMTP`."""
 
+    draft_model_name = "DeepSeek MTP"
+
     def __init__(
         self,
         config,
@@ -129,6 +144,11 @@ class DeepseekV3ForCausalLMNextN(nn.Module):
         self.config = config
         self.vocab_size = config.vocab_size
         self.unpadded_vocab_size = config.vocab_size
+        self._is_glm_moe_dsa_nextn = (
+            str(getattr(config, "model_type", "")).lower() == "glm_moe_dsa"
+        )
+        if self._is_glm_moe_dsa_nextn:
+            self.draft_model_name = "GLM DSA MTP"
 
         with plugin_runtime_scope(framework="sglang"):
             self.atom_config = generate_atom_config_for_plugin_mode(config)
@@ -152,14 +172,30 @@ class DeepseekV3ForCausalLMNextN(nn.Module):
             self.atom_config.hf_config.quantization_config = copy.deepcopy(
                 config.quantization_config
             )
-        SpeculativeConfig.hf_config_override(
-            self.atom_config.hf_config, model_path=draft_model_path
-        )
+        if self._is_glm_moe_dsa_nextn:
+            n_predict = int(
+                getattr(self.atom_config.hf_config, "num_nextn_predict_layers", 1) or 1
+            )
+            self.atom_config.hf_config.update(
+                {
+                    "n_predict": n_predict,
+                    "num_nextn_predict_layers": n_predict,
+                }
+            )
+        else:
+            SpeculativeConfig.hf_config_override(
+                self.atom_config.hf_config, model_path=draft_model_path
+            )
         if use_standalone_draft:
             self.atom_config.quant_config = AtomQuantizationConfig(
                 self.atom_config.hf_config,
                 self.atom_config.online_quant_config,
             )
+        self._prepare_atom_config_for_nextn(
+            config=config,
+            draft_model_path=draft_model_path,
+            use_standalone_draft=use_standalone_draft,
+        )
 
         with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
             from atom.plugin.register import (
@@ -182,6 +218,31 @@ class DeepseekV3ForCausalLMNextN(nn.Module):
 
         self.logits_processor = LogitsProcessor(config)
         self.lm_head = self._first_mtp_layer().shared_head.head
+
+    def _prepare_atom_config_for_nextn(
+        self,
+        *,
+        config,
+        draft_model_path: str,
+        use_standalone_draft: bool,
+    ) -> None:
+        del config, draft_model_path, use_standalone_draft
+        if not getattr(self, "_is_glm_moe_dsa_nextn", False):
+            return None
+
+        # GLM-5.x quant configs name the DSA indexer projection as
+        # `indexers_proj`; ATOM's shared DSA/MTP module uses `indexer.weights_proj`.
+        # Also run the standard DeepSeek/GLM packed-module remap so excludes for
+        # q_a_proj/kv_a_proj follow ATOM's fused_qkv_a_proj module in MTP blocks.
+        quant_config = getattr(self.atom_config, "quant_config", None)
+        if quant_config is not None:
+            quant_config.remap_layer_name(
+                self.atom_config.hf_config,
+                quant_exclude_name_mapping={
+                    "indexers_proj": "indexer.weights_proj",
+                },
+            )
+        return None
 
     def _mtp_layers(self):
         return list(self.model.model.layers.values())
@@ -216,7 +277,9 @@ class DeepseekV3ForCausalLMNextN(nn.Module):
         **kwargs,
     ):
         if forward_batch.spec_info is None:
-            raise ValueError("DeepSeek MTP draft forward requires speculative info")
+            raise ValueError(
+                f"{self.draft_model_name} draft forward requires speculative info"
+            )
 
         with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
             with SGLangPluginRuntime(
@@ -226,17 +289,89 @@ class DeepseekV3ForCausalLMNextN(nn.Module):
                 input_ids=input_ids,
                 input_embeds=input_embeds,
             ) as runtime:
+                model_input_ids = runtime.input_ids
+                model_input_embeds = runtime.input_embeds
+                num_model_tokens = int(runtime.positions.shape[0])
+                if (
+                    torch.is_tensor(model_input_ids)
+                    and model_input_ids.shape[0] != num_model_tokens
+                ):
+                    if num_model_tokens % int(model_input_ids.shape[0]) == 0:
+                        model_input_ids = model_input_ids.repeat_interleave(
+                            num_model_tokens // int(model_input_ids.shape[0]), dim=0
+                        )
+                    elif int(model_input_ids.shape[0]) == 1:
+                        model_input_ids = model_input_ids.expand(num_model_tokens)
+                    else:
+                        raise RuntimeError(
+                            f"{self.draft_model_name} draft input_ids/positions "
+                            "layout mismatch: "
+                            f"input_ids={tuple(model_input_ids.shape)}, "
+                            f"positions={tuple(runtime.positions.shape)}"
+                        )
+                if (
+                    torch.is_tensor(model_input_embeds)
+                    and model_input_embeds.shape[0] != num_model_tokens
+                ):
+                    if num_model_tokens % int(model_input_embeds.shape[0]) == 0:
+                        model_input_embeds = model_input_embeds.repeat_interleave(
+                            num_model_tokens // int(model_input_embeds.shape[0]), dim=0
+                        )
+                    elif int(model_input_embeds.shape[0]) == 1:
+                        model_input_embeds = model_input_embeds.expand(
+                            num_model_tokens, -1
+                        )
+                    else:
+                        raise RuntimeError(
+                            f"{self.draft_model_name} draft input_embeds/positions "
+                            "layout mismatch: "
+                            f"input_embeds={tuple(model_input_embeds.shape)}, "
+                            f"positions={tuple(runtime.positions.shape)}"
+                        )
+
                 model_hidden_states = forward_batch.spec_info.hidden_states
                 if runtime.forward_batch is not forward_batch:
                     model_hidden_states = _materialize_dummy_hidden_states(
                         model_hidden_states,
-                        length=int(runtime.positions.shape[0]),
+                        length=num_model_tokens,
                     )
+                elif (
+                    torch.is_tensor(model_hidden_states)
+                    and model_hidden_states.shape[0] != num_model_tokens
+                ):
+                    tokens_per_req = int(
+                        getattr(
+                            getattr(runtime.forward_batch, "spec_info", None),
+                            "num_tokens_per_req",
+                            0,
+                        )
+                        or 0
+                    )
+                    if (
+                        tokens_per_req > 0
+                        and model_hidden_states.shape[0] * tokens_per_req
+                        == num_model_tokens
+                    ):
+                        model_hidden_states = model_hidden_states.repeat_interleave(
+                            tokens_per_req, dim=0
+                        )
+                    elif model_hidden_states.shape[0] == 1:
+                        model_hidden_states = model_hidden_states.expand(
+                            num_model_tokens, -1
+                        )
+                    else:
+                        raise RuntimeError(
+                            f"{self.draft_model_name} draft-extend hidden layout "
+                            "mismatch: "
+                            f"hidden={tuple(model_hidden_states.shape)}, "
+                            f"input_tokens={num_model_tokens}, "
+                            f"tokens_per_req={tokens_per_req}"
+                        )
                 hidden_states = self.model(
-                    input_ids=runtime.input_ids,
+                    input_ids=model_input_ids,
                     positions=runtime.positions,
                     hidden_states=model_hidden_states,
-                    inputs_embeds=runtime.input_embeds,
+                    inputs_embeds=model_input_embeds,
                 )
 
             if self.pp_group.is_last_rank:
@@ -268,4 +403,23 @@ class DeepseekV3ForCausalLMNextN(nn.Module):
             )
 
 
-EntryClass = [DeepseekV3ForCausalLMNextN]
+class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
+    """SGLang-compatible GLM-5.2 MTP draft wrapper backed by ATOM `DeepSeekMTP`."""
+
+    draft_model_name = "GLM DSA MTP"
+
+    def _prepare_atom_config_for_nextn(
+        self,
+        *,
+        config,
+        draft_model_path: str,
+        use_standalone_draft: bool,
+    ) -> None:
+        return super()._prepare_atom_config_for_nextn(
+            config=config,
+            draft_model_path=draft_model_path,
+            use_standalone_draft=use_standalone_draft,
+        )
+
+
+EntryClass = [DeepseekV3ForCausalLMNextN, GlmMoeDsaForCausalLMNextN]


### PR DESCRIPTION
## Motivation

Enable glm5.2 MTP support.

## Test Plan
```bash
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export AITER_USE_FLYDSL_MOE_SORTING=1
export SGLANG_USE_AITER=1
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
export PYTHONPATH=/home/qichu_qle/zhiwei/dsv4/atom:/app/sglang

MODEL_PATH=/workspace/shared/data/amd_int/models/GLM-5.2-MXFP4
TP=4
PORT=8015
MODEL_LOADER_EXTRA_CONFIG='{"online_quant_config":{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate","*expert*"]}}'

export CUDA_VISIBLE_DEVICES=4,5,6,7
TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path "${MODEL_PATH}" \
    --host localhost \
    --port "${PORT}" \
    --trust-remote-code \
    --tp-size "${TP}" \
    --mem-fraction-static 0.8 \
    --disable-radix-cache \
    --kv-cache-dtype fp8_e4m3 \
    --model-loader-extra-config "${MODEL_LOADER_EXTRA_CONFIG}" \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    2>&1 | tee glm-server-mxfp4-tp4-mtp.log
```

gsm8k script, `--gen_kwargs '{"chat_template_kwargs":{"enable_thinking":false}}'` is added, avoiding too long thinking.

```
#!/usr/bin/env bash
set -x

addr=localhost
port=8015
url=http://${addr}:${port}/v1/chat/completions
# model=/workspace/shared/data/amd_int/models/MiniMax-M3-MXFP8
model=/workspace/shared/data/amd_int/models/GLM-5.2-MXFP4
task=gsm8k
limit=${1:-}
limit_args=()
if [[ -n "${limit}" ]]; then
        limit_args+=(--limit "${limit}")
fi

lm_eval --model local-chat-completions \
        --model_args model=${model},base_url=${url},num_concurrent=32,max_retries=1,max_gen_toks=16384 \
        --tasks ${task} \
        --num_fewshot 5 \
        --batch_size 16 \
        --apply_chat_template \
        --fewshot_as_multiturn \
        --gen_kwargs '{"chat_template_kwargs":{"enable_thinking":false}}' \
        "${limit_args[@]}" \
        2>&1 | tee log.m3_mxfp8_sglang.gsm8k.log
```

## Test Result

<img width="1952" height="402" alt="image" src="https://github.com/user-attachments/assets/8296d5f5-9f54-47f9-88a2-4f039e5b32be" />


<img width="1951" height="122" alt="image" src="https://github.com/user-attachments/assets/ebd47b46-0ec7-4876-8872-69bd34b33f12" />


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
