### PR TITLE
fix(ci): run SGLang accuracy against checked-out ATOM

### DIFF
--- a/.github/scripts/atom_sglang_test.sh
+++ b/.github/scripts/atom_sglang_test.sh
@@ -29,6 +29,8 @@ set -euo pipefail
 #   LM_EVAL_NUM_CONCURRENT
 #   LM_EVAL_EXTRA_MODEL_ARGS
 #   LM_EVAL_USE_CHAT_COMPLETIONS
+#   ATOM_SGLANG_USE_WORKSPACE_ATOM: Prefer the checked-out ATOM source mounted
+#     at /workspace over the ATOM revision baked into the SGLang image (default: 0).
 
 TYPE=${1:-launch}
 if [[ "${TYPE}" != "start" && "${TYPE}" != "launch" && "${TYPE}" != "accuracy" ]]; then
@@ -66,12 +68,30 @@ if [[ -z "${MODEL_NAME}" || -z "${MODEL_PATH}" ]]; then
 fi
 
 prepare_runtime_paths() {
-  if [[ -d /app/sglang/python && -d /app/ATOM ]]; then
-    local path_prefix="/app/sglang/python:/app/ATOM"
+  local atom_source_dir="/app/ATOM"
+  if [[ "${ATOM_SGLANG_USE_WORKSPACE_ATOM:-0}" == "1" && -d /workspace/atom ]]; then
+    atom_source_dir="/workspace"
+  fi
+
+  if [[ -d /app/sglang/python && -d "${atom_source_dir}/atom" ]]; then
+    # The validation image intentionally supplies SGLang and its compiled
+    # dependencies, but accuracy CI must exercise the ATOM revision checked
+    # out by this workflow.  Put that checkout before /app/ATOM, which may be
+    # an older revision baked into a floating validation image.
+    local path_prefix="/app/sglang/python:${atom_source_dir}"
     if [[ -d /app/aiter-test ]]; then
       path_prefix="/app/aiter-test:${path_prefix}"
     fi
     export PYTHONPATH="${path_prefix}${PYTHONPATH:+:${PYTHONPATH}}"
+    echo "ATOM source root: ${atom_source_dir}"
+    python3 - <<'PY'
+import atom
+
+print(f"ATOM import path: {atom.__file__}")
+PY
+    if [[ -d "${atom_source_dir}/.git" ]]; then
+      echo "ATOM source commit: $(git -C "${atom_source_dir}" rev-parse HEAD)"
+    fi
     cd /app
   elif [[ -d /workspace ]]; then
     cd /workspace

--- a/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
@@ -417,6 +417,7 @@ jobs:
             -e SGLANG_MODEL_PATH="${SGLANG_RESOLVED_MODEL_PATH:-$SGLANG_MODEL_PATH}" \
             -e SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS}" \
             -e SGLANG_ENV_VARS="${SGLANG_ENV_VARS}" \
+            -e ATOM_SGLANG_USE_WORKSPACE_ATOM="1" \
             -e SGLANG_DOCKER_IMAGE="${SGLANG_IMAGE_TAG}" \
             -e GPU_NAME="${{ steps.gpu-info.outputs.gpu_name }}" \
             -e GPU_VRAM_GB="${{ steps.gpu-info.outputs.gpu_vram_gb }}" \
@@ -546,4 +547,3 @@ jobs:
           $CONTAINER_ENGINE stop "$CONTAINER_NAME" || true
           $CONTAINER_ENGINE rm "$CONTAINER_NAME" || true
           $CONTAINER_ENGINE rmi "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}" || true
-


### PR DESCRIPTION
## Summary
- make SGLang accuracy validation import ATOM from the mounted Actions checkout when requested
- enable that mode for the GPU accuracy driver so a floating SGLang image cannot shadow the tested revision
- log the imported ATOM path and source commit for provenance

## Validation
- `bash -n .github/scripts/atom_sglang_test.sh`
- YAML parse for `atom-sglang-accuracy-validation-gpu-shard.yaml`
- `git diff --check`
- verified workspace import precedence with `importlib.util.find_spec`

Fixes the stale-image ABI mismatch where the image used `cs` while the checked-out V4 kernel expects `block_size`.