### PR TITLE
[fix] MXFP4 MoE: single-source use_triton_moe() to fix gfx94x load assert (#1582)

### DIFF
--- a/atom/model_ops/fused_moe_triton.py
+++ b/atom/model_ops/fused_moe_triton.py
@@ -24,12 +24,14 @@ from aiter import ActivationType
 from aiter.ops.triton.fusions.fused_clamp_act_mul import fused_clamp_act_mul
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 from atom.utils import envs
+from atom.model_ops.moe import MoEActivationQuant, use_triton_moe
 
-if (
-    envs.ATOM_USE_TRITON_GEMM
-    or envs.ATOM_USE_TRITON_MOE
-    or envs.ATOM_USE_TRITON_MOE_DECODE
-):
+# Import the triton kernels whenever the triton MoE path can be selected.
+# use_triton_moe() is the same predicate moe.py uses to route through this
+# module (True by default on gfx94x), so the imports here stay consistent with
+# actual usage; ATOM_USE_TRITON_MOE_DECODE additionally enables the triton
+# decode kernels.
+if use_triton_moe() or envs.ATOM_USE_TRITON_MOE_DECODE:
     from aiter.ops.triton.moe.moe_routing.routing import routing
     from aiter.ops.triton.moe.moe_op_gemm_a8w4 import (
         moe_gemm_a8w4,
@@ -44,8 +46,6 @@ if (
     from aiter.ops.triton.utils.shuffle import shuffle_scale_moe
     from aiter.ops.triton.moe.quant_moe import downcast_to_static_fp8
     from aiter.ops.triton.moe.quant_moe import downcast_to_mxfp
-
-from atom.model_ops.moe import MoEActivationQuant
 
 
 def _swizzle_mxfp4(
@@ -65,7 +65,7 @@ def _swizzle_mxfp4(
     The arch -> SWIZZLE_MX_SCALE label decision lives in aiter
     (``shuffle_scale_moe(..., return_layout=True)``), so this stays arch-agnostic.
     """
-    assert envs.ATOM_USE_TRITON_GEMM or envs.ATOM_USE_TRITON_MOE
+    assert use_triton_moe()
 
     # Transposing for expected layout of aiter triton kernels
     w1_triton_layout = w1.transpose(-2, -1)

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -70,6 +70,23 @@ from transformers import PretrainedConfig
 logger = logging.getLogger("atom")
 
 
+def use_triton_moe() -> bool:
+    """Whether the triton MoE path is selected for the current arch/env.
+
+    Single source of truth shared with ``fused_moe_triton.py``'s module-level
+    kernel imports and the ``_swizzle_mxfp4`` assert, so that "the triton
+    kernels are imported" always matches "moe.py routes through them". On gfx94x
+    this path is the default even when ATOM_USE_TRITON_MOE / ATOM_USE_TRITON_GEMM
+    are unset.
+    """
+    if envs.is_set("ATOM_USE_TRITON_MOE"):
+        return envs.ATOM_USE_TRITON_MOE
+    gfx = get_gfx()
+    return gfx.startswith("gfx94") or (
+        gfx.startswith("gfx95") and envs.ATOM_USE_TRITON_GEMM
+    )
+
+
 class MoEActivationQuant(Enum):
     BF16 = "bf16"
     FP8 = "fp8"
@@ -804,12 +821,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         )
         gfx = get_gfx()
         self.is_gfx1250 = gfx == "gfx1250"
-        if envs.is_set("ATOM_USE_TRITON_MOE"):
-            self.use_triton = envs.ATOM_USE_TRITON_MOE
-        else:
-            self.use_triton = gfx.startswith("gfx94") or (
-                gfx.startswith("gfx95") and envs.ATOM_USE_TRITON_GEMM
-            )
+        self.use_triton = use_triton_moe()
         self.act_quant = MoEActivationQuant.from_model_config(moe.a_quant_dtype)
         if envs.is_set("ATOM_USE_TRITON_MOE_DECODE") and not self.is_guinterleave:
             self.use_triton_decode = envs.ATOM_USE_TRITON_MOE_DECODE


### PR DESCRIPTION
On gfx94x (e.g. MI300X), moe.py selects the triton MoE path by default (gfx.startswith("gfx94")) even when ATOM_USE_TRITON_MOE / ATOM_USE_TRITON_GEMM are unset, so process_weights_after_loading calls _swizzle_mxfp4. But fused_moe_triton.py gated both its module-level kernel imports and the _swizzle_mxfp4 assert on the raw env flags only. The two judgments disagreed: the default path was taken, the kernels were never imported, and the assert fired -- crashing every TP worker when following recipes/atom_vllm/Kimi-K2.5.md verbatim.

Factor the path decision into a single use_triton_moe() helper in moe.py and use it in all three places (layer selection, module import guard, assert) so "the triton kernels are imported" always matches "moe.py routes through them". No new env var required in the recipe.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
