### PR TITLE
[Frontend] Abort streaming seq only on real disconnect, not normal completion

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -808,12 +808,21 @@ async def setup_streaming_request(
     return seq_id, stream_queue, seq.num_prompt_tokens
 
 
-def cleanup_streaming_request(request_id: str, seq_id: int) -> None:
+def cleanup_streaming_request(
+    request_id: str, seq_id: int, aborted: bool = False
+) -> None:
     """Clean up resources for a streaming request.
 
     Safe to call multiple times for the same ``request_id`` with different
     ``seq_id`` values (as happens in fan-out cleanup): the per-request
     dicts use ``dict.pop(..., None)`` so repeated removal is a no-op.
+
+    ``aborted`` says the stream did NOT reach its normal end (client disconnect
+    or abnormal generator teardown), so the seq is likely still running in the
+    engine and must be stopped. On normal completion pass False (the default):
+    the engine has already dropped the seq, so an abort would be a guaranteed
+    no-op that just floods the control path (one broadcast per engine core, per
+    request).
     """
     global engine, _stream_queues, _seq_id_to_request_id
     global _stream_loops, _request_start_times
@@ -822,13 +831,11 @@ def cleanup_streaming_request(request_id: str, seq_id: int) -> None:
     _seq_id_to_request_id.pop(seq_id, None)
     _stream_loops.pop(request_id, None)
     _request_start_times.pop(request_id, None)
-    # If the stream ended early (client disconnected) the seq may still be
-    # generating in the engine core -> tell it to stop so it doesn't run to
-    # max_tokens and pile up. No-op if the seq already finished.
-    try:
-        engine.core_mgr.abort_request(seq_id)
-    except Exception:
-        pass
+    if aborted:
+        try:
+            engine.core_mgr.abort_request(seq_id)
+        except Exception:
+            pass
     engine.io_processor.requests.pop(seq_id, None)
 
 
@@ -1435,6 +1442,10 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
                 message_started = False
                 _thinking_enabled = bool(getattr(request, "thinking", None))
+                # Assume abort until we reach the normal end of the stream. If
+                # the client disconnects, GeneratorExit unwinds through the
+                # yields and the finally runs with this still True -> abort.
+                aborted = True
 
                 try:
                     while True:
@@ -1573,9 +1584,10 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                 yield stream_content_block_stop(block_index)
                             yield stream_message_delta(stop_reason, output_tokens)
                             yield stream_message_stop()
+                            aborted = False
                             break
                 finally:
-                    cleanup_streaming_request(request_id, seq_id)
+                    cleanup_streaming_request(request_id, seq_id, aborted=aborted)
 
             return StreamingResponse(
                 generate_anthropic_stream(),

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -79,38 +79,64 @@ async def stream_chat_response(
     tool_parser = ToolCallStreamParser(tools=tools)
     has_tool_calls = False
 
-    # Send initial role chunk
-    yield create_chat_chunk(request_id, model, delta={"role": "assistant"})
-
     kv_transfer_params_value = None
 
-    while True:
-        chunk_data = await stream_queue.get()
-        new_text = chunk_data["text"]
-        num_tokens_output += len(chunk_data.get("token_ids", []))
-        _ct = chunk_data.get("num_cached_tokens", 0)
-        if _ct:
-            num_cached_tokens = _ct
+    # Assume abort until the engine's finished chunk arrives. A client
+    # disconnect closes the generator before then, leaving this True so the
+    # finally aborts the still-running seq; normal completion flips it to False.
+    aborted = True
+    try:
+        # Send initial role chunk
+        yield create_chat_chunk(request_id, model, delta={"role": "assistant"})
 
-        if "kv_transfer_params" in chunk_data:
-            kv_transfer_params_value = chunk_data["kv_transfer_params"]
+        while True:
+            chunk_data = await stream_queue.get()
+            new_text = chunk_data["text"]
+            num_tokens_output += len(chunk_data.get("token_ids", []))
+            _ct = chunk_data.get("num_cached_tokens", 0)
+            if _ct:
+                num_cached_tokens = _ct
 
-        # Phase 1: Process through reasoning filter
-        segments = reasoning_filter.process(new_text)
-        if chunk_data.get("finished", False):
-            segments.extend(reasoning_filter.flush())
+            if "kv_transfer_params" in chunk_data:
+                kv_transfer_params_value = chunk_data["kv_transfer_params"]
 
-        # Phase 2: For content segments, check for tool calls
-        for field, text in segments:
-            if field == "reasoning_content":
-                if text:
-                    yield create_chat_chunk(
-                        request_id, model, delta={"reasoning_content": text}
-                    )
-            elif field == "content":
-                # Run through tool parser
-                events = tool_parser.process(text)
-                for event_type, data in events:
+            # Phase 1: Process through reasoning filter
+            segments = reasoning_filter.process(new_text)
+            if chunk_data.get("finished", False):
+                segments.extend(reasoning_filter.flush())
+
+            # Phase 2: For content segments, check for tool calls
+            for field, text in segments:
+                if field == "reasoning_content":
+                    if text:
+                        yield create_chat_chunk(
+                            request_id, model, delta={"reasoning_content": text}
+                        )
+                elif field == "content":
+                    # Run through tool parser
+                    events = tool_parser.process(text)
+                    for event_type, data in events:
+                        if event_type == "content":
+                            yield create_chat_chunk(
+                                request_id, model, delta={"content": data}
+                            )
+                        elif event_type == "tool_call_start":
+                            has_tool_calls = True
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                            )
+                        elif event_type == "tool_call_args":
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                            )
+
+            if chunk_data.get("finished", False):
+                # Flush tool parser
+                for event_type, data in tool_parser.flush():
                     if event_type == "content":
                         yield create_chat_chunk(
                             request_id, model, delta={"content": data}
@@ -118,60 +144,43 @@ async def stream_chat_response(
                     elif event_type == "tool_call_start":
                         has_tool_calls = True
                         yield create_chat_chunk(
-                            request_id,
-                            model,
-                            delta={"tool_calls": [data]},
+                            request_id, model, delta={"tool_calls": [data]}
                         )
                     elif event_type == "tool_call_args":
                         yield create_chat_chunk(
-                            request_id,
-                            model,
-                            delta={"tool_calls": [data]},
+                            request_id, model, delta={"tool_calls": [data]}
                         )
+                break
 
-        if chunk_data.get("finished", False):
-            # Flush tool parser
-            for event_type, data in tool_parser.flush():
-                if event_type == "content":
-                    yield create_chat_chunk(request_id, model, delta={"content": data})
-                elif event_type == "tool_call_start":
-                    has_tool_calls = True
-                    yield create_chat_chunk(
-                        request_id, model, delta={"tool_calls": [data]}
-                    )
-                elif event_type == "tool_call_args":
-                    yield create_chat_chunk(
-                        request_id, model, delta={"tool_calls": [data]}
-                    )
-            break
+        aborted = False
 
-    cleanup_fn(request_id, seq_id)
-
-    # Final chunks
-    finish_reason = "tool_calls" if has_tool_calls else "stop"
-    usage = {
-        "prompt_tokens": num_tokens_input,
-        "completion_tokens": num_tokens_output,
-        "total_tokens": num_tokens_input + num_tokens_output,
-        "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
-    }
-    usage_chunk = {
-        "id": request_id,
-        "object": CHAT_COMPLETION_CHUNK_OBJECT,
-        "created": int(time.time()),
-        "model": model,
-        "usage": usage,
-    }
-    if kv_transfer_params_value is not None:
-        usage_chunk["kv_transfer_params"] = kv_transfer_params_value
-    # Coalesce finish + usage + [DONE] into one send: at a wave boundary many
-    # requests finalize at once, so collapsing 3 socket writes/req to 1 cuts
-    # the syscalls that saturate the API event loop.
-    yield (
-        create_chat_chunk(request_id, model, finish_reason=finish_reason)
-        + f"data: {json.dumps(usage_chunk)}\n\n"
-        + STREAM_DONE_MESSAGE
-    )
+        # Final chunks
+        finish_reason = "tool_calls" if has_tool_calls else "stop"
+        usage = {
+            "prompt_tokens": num_tokens_input,
+            "completion_tokens": num_tokens_output,
+            "total_tokens": num_tokens_input + num_tokens_output,
+            "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
+        }
+        usage_chunk = {
+            "id": request_id,
+            "object": CHAT_COMPLETION_CHUNK_OBJECT,
+            "created": int(time.time()),
+            "model": model,
+            "usage": usage,
+        }
+        if kv_transfer_params_value is not None:
+            usage_chunk["kv_transfer_params"] = kv_transfer_params_value
+        # Coalesce finish + usage + [DONE] into one send: at a wave boundary many
+        # requests finalize at once, so collapsing 3 socket writes/req to 1 cuts
+        # the syscalls that saturate the API event loop.
+        yield (
+            create_chat_chunk(request_id, model, finish_reason=finish_reason)
+            + f"data: {json.dumps(usage_chunk)}\n\n"
+            + STREAM_DONE_MESSAGE
+        )
+    finally:
+        cleanup_fn(request_id, seq_id, aborted=aborted)
 
 
 def _build_chat_choice(
@@ -319,38 +328,67 @@ async def stream_chat_response_fanout(
     kv_transfer_params_value = None
     num_cached_tokens = 0
 
-    for i in range(n):
-        yield create_chat_chunk(request_id, model, delta={"role": "assistant"}, index=i)
+    # Assume abort until every sibling reports finished; a client disconnect
+    # closes the generator first, leaving this True so the finally aborts
+    # whichever siblings are still running.
+    aborted = True
+    try:
+        for i in range(n):
+            yield create_chat_chunk(
+                request_id, model, delta={"role": "assistant"}, index=i
+            )
 
-    while not all(finished):
-        idx, chunk_data = await shared_queue.get()
-        if finished[idx]:
-            # Defensive: should not happen, engine emits finished once per seq.
-            continue
-        new_text = chunk_data["text"]
-        num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
-        _ct = chunk_data.get("num_cached_tokens", 0)
-        if _ct:
-            num_cached_tokens = _ct
+        while not all(finished):
+            idx, chunk_data = await shared_queue.get()
+            if finished[idx]:
+                # Defensive: should not happen, engine emits finished once per seq.
+                continue
+            new_text = chunk_data["text"]
+            num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
+            _ct = chunk_data.get("num_cached_tokens", 0)
+            if _ct:
+                num_cached_tokens = _ct
 
-        if "kv_transfer_params" in chunk_data:
-            kv_transfer_params_value = chunk_data["kv_transfer_params"]
+            if "kv_transfer_params" in chunk_data:
+                kv_transfer_params_value = chunk_data["kv_transfer_params"]
 
-        segments = reasoning_filters[idx].process(new_text)
-        if chunk_data.get("finished", False):
-            segments.extend(reasoning_filters[idx].flush())
+            segments = reasoning_filters[idx].process(new_text)
+            if chunk_data.get("finished", False):
+                segments.extend(reasoning_filters[idx].flush())
 
-        for field, text in segments:
-            if field == "reasoning_content":
-                if text:
-                    yield create_chat_chunk(
-                        request_id,
-                        model,
-                        delta={"reasoning_content": text},
-                        index=idx,
-                    )
-            elif field == "content":
-                for event_type, data in tool_parsers[idx].process(text):
+            for field, text in segments:
+                if field == "reasoning_content":
+                    if text:
+                        yield create_chat_chunk(
+                            request_id,
+                            model,
+                            delta={"reasoning_content": text},
+                            index=idx,
+                        )
+                elif field == "content":
+                    for event_type, data in tool_parsers[idx].process(text):
+                        if event_type == "content":
+                            yield create_chat_chunk(
+                                request_id, model, delta={"content": data}, index=idx
+                            )
+                        elif event_type == "tool_call_start":
+                            has_tool_calls[idx] = True
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                                index=idx,
+                            )
+                        elif event_type == "tool_call_args":
+                            yield create_chat_chunk(
+                                request_id,
+                                model,
+                                delta={"tool_calls": [data]},
+                                index=idx,
+                            )
+
+            if chunk_data.get("finished", False):
+                for event_type, data in tool_parsers[idx].flush():
                     if event_type == "content":
                         yield create_chat_chunk(
                             request_id, model, delta={"content": data}, index=idx
@@ -370,61 +408,41 @@ async def stream_chat_response_fanout(
                             delta={"tool_calls": [data]},
                             index=idx,
                         )
+                finished[idx] = True
 
-        if chunk_data.get("finished", False):
-            for event_type, data in tool_parsers[idx].flush():
-                if event_type == "content":
-                    yield create_chat_chunk(
-                        request_id, model, delta={"content": data}, index=idx
-                    )
-                elif event_type == "tool_call_start":
-                    has_tool_calls[idx] = True
-                    yield create_chat_chunk(
-                        request_id,
-                        model,
-                        delta={"tool_calls": [data]},
-                        index=idx,
-                    )
-                elif event_type == "tool_call_args":
-                    yield create_chat_chunk(
-                        request_id,
-                        model,
-                        delta={"tool_calls": [data]},
-                        index=idx,
-                    )
-            finished[idx] = True
+        aborted = False
 
-    # Clean up all sibling seq_id entries then the shared request state.
-    for sid in seq_ids:
-        cleanup_fn(request_id, sid)
-
-    usage = {
-        "prompt_tokens": num_tokens_input,
-        "completion_tokens": sum(num_tokens_output),
-        "total_tokens": num_tokens_input + sum(num_tokens_output),
-        "num_choices": n,
-        "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
-    }
-    usage_chunk = {
-        "id": request_id,
-        "object": CHAT_COMPLETION_CHUNK_OBJECT,
-        "created": int(time.time()),
-        "model": model,
-        "usage": usage,
-    }
-    if kv_transfer_params_value is not None:
-        usage_chunk["kv_transfer_params"] = kv_transfer_params_value
-    # Coalesce the per-sibling finish chunks + usage + [DONE] into one send.
-    yield (
-        "".join(
-            create_chat_chunk(
-                request_id,
-                model,
-                finish_reason="tool_calls" if has_tool_calls[i] else "stop",
-                index=i,
+        usage = {
+            "prompt_tokens": num_tokens_input,
+            "completion_tokens": sum(num_tokens_output),
+            "total_tokens": num_tokens_input + sum(num_tokens_output),
+            "num_choices": n,
+            "prompt_tokens_details": {"cached_tokens": num_cached_tokens},
+        }
+        usage_chunk = {
+            "id": request_id,
+            "object": CHAT_COMPLETION_CHUNK_OBJECT,
+            "created": int(time.time()),
+            "model": model,
+            "usage": usage,
+        }
+        if kv_transfer_params_value is not None:
+            usage_chunk["kv_transfer_params"] = kv_transfer_params_value
+        # Coalesce the per-sibling finish chunks + usage + [DONE] into one send.
+        yield (
+            "".join(
+                create_chat_chunk(
+                    request_id,
+                    model,
+                    finish_reason="tool_calls" if has_tool_calls[i] else "stop",
+                    index=i,
+                )
+                for i in range(n)
             )
-            for i in range(n)
+            + f"data: {json.dumps(usage_chunk)}\n\n"
+            + STREAM_DONE_MESSAGE
         )
-        + f"data: {json.dumps(usage_chunk)}\n\n"
-        + STREAM_DONE_MESSAGE
-    )
+    finally:
+        # Clean up all sibling seq_id entries then the shared request state.
+        for sid in seq_ids:
+            cleanup_fn(request_id, sid, aborted=aborted)

--- a/atom/entrypoints/openai/serving_completion.py
+++ b/atom/entrypoints/openai/serving_completion.py
@@ -69,49 +69,57 @@ async def stream_completion_response(
     num_tokens_input = num_prompt_tokens
     num_tokens_output = 0
 
-    while True:
-        chunk_data = await stream_queue.get()
-        new_text = chunk_data["text"]
-        num_tokens_output += len(chunk_data.get("token_ids", []))
+    # Assume abort until the engine's finished chunk arrives. On client
+    # disconnect the generator is closed (GeneratorExit) before we get there,
+    # so the finally below aborts the still-running seq; on normal completion
+    # we flip this to False and skip the (no-op) abort.
+    aborted = True
+    try:
+        while True:
+            chunk_data = await stream_queue.get()
+            new_text = chunk_data["text"]
+            num_tokens_output += len(chunk_data.get("token_ids", []))
 
-        extra_fields: Dict[str, Any] = {}
-        if "kv_transfer_params" in chunk_data:
-            extra_fields["kv_transfer_params"] = chunk_data["kv_transfer_params"]
+            extra_fields: Dict[str, Any] = {}
+            if "kv_transfer_params" in chunk_data:
+                extra_fields["kv_transfer_params"] = chunk_data["kv_transfer_params"]
 
-        content_chunk = create_completion_chunk(
-            request_id,
-            model,
-            new_text,
-            finish_reason=chunk_data.get("finish_reason"),
-            **extra_fields,
-        )
-
-        if chunk_data.get("finished", False):
-            # Coalesce the finalization SSE messages (content + stop + usage +
-            # [DONE]) into a single send. At a wave boundary many requests
-            # finish simultaneously; collapsing 4 sends/req to 1 cuts the
-            # per-request socket-write syscalls that saturate the API loop.
-            cleanup_fn(request_id, seq_id)
-            usage_chunk = {
-                "id": request_id,
-                "object": TEXT_COMPLETION_OBJECT,
-                "created": int(time.time()),
-                "model": model,
-                "usage": {
-                    "prompt_tokens": num_tokens_input,
-                    "completion_tokens": num_tokens_output,
-                    "total_tokens": num_tokens_input + num_tokens_output,
-                },
-            }
-            yield (
-                content_chunk
-                + create_completion_chunk(request_id, model, "", "stop")
-                + f"data: {json.dumps(usage_chunk)}\n\n"
-                + STREAM_DONE_MESSAGE
+            content_chunk = create_completion_chunk(
+                request_id,
+                model,
+                new_text,
+                finish_reason=chunk_data.get("finish_reason"),
+                **extra_fields,
             )
-            return
 
-        yield content_chunk
+            if chunk_data.get("finished", False):
+                aborted = False
+                # Coalesce the finalization SSE messages (content + stop + usage
+                # + [DONE]) into a single send. At a wave boundary many requests
+                # finish simultaneously; collapsing 4 sends/req to 1 cuts the
+                # per-request socket-write syscalls that saturate the API loop.
+                usage_chunk = {
+                    "id": request_id,
+                    "object": TEXT_COMPLETION_OBJECT,
+                    "created": int(time.time()),
+                    "model": model,
+                    "usage": {
+                        "prompt_tokens": num_tokens_input,
+                        "completion_tokens": num_tokens_output,
+                        "total_tokens": num_tokens_input + num_tokens_output,
+                    },
+                }
+                yield (
+                    content_chunk
+                    + create_completion_chunk(request_id, model, "", "stop")
+                    + f"data: {json.dumps(usage_chunk)}\n\n"
+                    + STREAM_DONE_MESSAGE
+                )
+                return
+
+            yield content_chunk
+    finally:
+        cleanup_fn(request_id, seq_id, aborted=aborted)
 
 
 def build_completion_response(
@@ -213,51 +221,58 @@ async def stream_completion_response_fanout(
     num_tokens_output = [0] * n
     finished = [False] * n
 
-    while not all(finished):
-        idx, chunk_data = await shared_queue.get()
-        if finished[idx]:
-            continue
-        new_text = chunk_data["text"]
-        num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
+    # Assume abort until every sibling has reported finished; a client
+    # disconnect closes the generator first, leaving this True so the finally
+    # aborts whichever siblings are still running.
+    aborted = True
+    try:
+        while not all(finished):
+            idx, chunk_data = await shared_queue.get()
+            if finished[idx]:
+                continue
+            new_text = chunk_data["text"]
+            num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
 
-        extra_fields: Dict[str, Any] = {}
-        if "kv_transfer_params" in chunk_data:
-            extra_fields["kv_transfer_params"] = chunk_data["kv_transfer_params"]
+            extra_fields: Dict[str, Any] = {}
+            if "kv_transfer_params" in chunk_data:
+                extra_fields["kv_transfer_params"] = chunk_data["kv_transfer_params"]
 
-        yield create_completion_chunk(
-            request_id,
-            model,
-            new_text,
-            finish_reason=chunk_data.get("finish_reason"),
-            index=idx,
-            **extra_fields,
+            yield create_completion_chunk(
+                request_id,
+                model,
+                new_text,
+                finish_reason=chunk_data.get("finish_reason"),
+                index=idx,
+                **extra_fields,
+            )
+
+            if chunk_data.get("finished", False):
+                finished[idx] = True
+
+        aborted = False
+
+        usage = {
+            "prompt_tokens": num_tokens_input,
+            "completion_tokens": sum(num_tokens_output),
+            "total_tokens": num_tokens_input + sum(num_tokens_output),
+            "num_choices": n,
+        }
+        usage_chunk = {
+            "id": request_id,
+            "object": TEXT_COMPLETION_OBJECT,
+            "created": int(time.time()),
+            "model": model,
+            "usage": usage,
+        }
+        # Coalesce the per-sibling stop chunks + usage + [DONE] into one send.
+        yield (
+            "".join(
+                create_completion_chunk(request_id, model, "", "stop", index=i)
+                for i in range(n)
+            )
+            + f"data: {json.dumps(usage_chunk)}\n\n"
+            + STREAM_DONE_MESSAGE
         )
-
-        if chunk_data.get("finished", False):
-            finished[idx] = True
-
-    for sid in seq_ids:
-        cleanup_fn(request_id, sid)
-
-    usage = {
-        "prompt_tokens": num_tokens_input,
-        "completion_tokens": sum(num_tokens_output),
-        "total_tokens": num_tokens_input + sum(num_tokens_output),
-        "num_choices": n,
-    }
-    usage_chunk = {
-        "id": request_id,
-        "object": TEXT_COMPLETION_OBJECT,
-        "created": int(time.time()),
-        "model": model,
-        "usage": usage,
-    }
-    # Coalesce the per-sibling stop chunks + usage + [DONE] into one send.
-    yield (
-        "".join(
-            create_completion_chunk(request_id, model, "", "stop", index=i)
-            for i in range(n)
-        )
-        + f"data: {json.dumps(usage_chunk)}\n\n"
-        + STREAM_DONE_MESSAGE
-    )
+    finally:
+        for sid in seq_ids:
+            cleanup_fn(request_id, sid, aborted=aborted)


### PR DESCRIPTION
## Summary

Follow-up to #1562. The streaming cleanup path (`cleanup_streaming_request`)
unconditionally aborted the engine request on every teardown. Two problems:

1. **Useless abort flood on normal completion.** The chat/completion generators
   call cleanup from inside their finished branch, so the abort always hit an
   already-finished seq and fanned out a broadcast to every engine core, once
   per request. A scheduled DSV4-Pro benchmark (c=1024, streaming) logged
   **58,455** `abort_request ... found=False` lines — 100% found=False, 0
   found=True.

2. **Seq/KV leak on client disconnect.** Those same generators have no
   `try/finally`, so on disconnect cleanup never ran — the seq kept generating
   to `max_tokens` (forever under `ignore_eos`), held KV, and leaked in
   `io_processor.requests`.

## Fix

Decide abort from what the frontend can actually observe: **did the stream
reach the engine's `finished` chunk before teardown?** (The frontend seq is a
pickled husk whose status is never updated cross-process, so it can't be
queried — the `finished` flag on the streamed `RequestOutput` is the only
reliable signal.)

- `cleanup_streaming_request(request_id, seq_id, aborted=False)` — abort only
  when the stream did **not** complete normally.
- Every streaming generator (chat / completion + fan-out, and the anthropic
  `/v1/messages` generator) wraps its loop in `try/finally` with `aborted =
  True`, flipped to `False` once the finished chunk arrives:
  - normal completion → `aborted=False` → no abort broadcast
  - client disconnect (GeneratorExit before finished) → finally runs with
    `aborted=True` → stops the still-running seq and frees KV

Net: normal streaming requests emit no abort broadcast; disconnects now
correctly abort on the completion/chat paths too (previously only non-stream
and anthropic handled disconnect).

## Test plan
- [x] `py_compile`, `black --check`, `ruff check` clean on all three files.
- [x] GPU smoke — see results below.

## Test results (GPU)

Setup: Llama-3.1-8B-Instruct, ATOM `-tp 1 --enforce-eager`, this branch mounted
into the container, OpenAI server on `:9700`. Signal = the engine-core log line
`abort_request req_id=<id> found=<bool>` (unchanged in this PR).

**A. Normal streaming completion — expect zero aborts**
```
$ 5x  POST /v1/completions       {stream:true, max_tokens:15}
$ 5x  POST /v1/chat/completions  {stream:true, max_tokens:15}
served (200 OK):            10
abort_request lines:         0        <-- was 1 found=False per request before
```

**B. Streaming disconnect (curl --max-time 2) — expect abort found=True**
```
/v1/completions      (rc=28 cut) -> Engine Core: abort_request req_id=10 found=True
/v1/chat/completions (rc=28 cut) -> Engine Core: abort_request req_id=11 found=True
```

**C. Fan-out n=2, normal streaming — expect zero aborts**
```
abort_request lines: 0
```

**D. Fan-out n=2, streaming disconnect — expect abort per sibling**
```
Engine Core: abort_request req_id=14 found=True
Engine Core: abort_request req_id=15 found=True
```

**No leak** — after the 6 aborted requests above, fresh requests arrive at
`pending requests: 1` (aborted seqs freed + popped from io_processor.requests,
not accumulating):
```
Request 16 arrived, input tokens: 2, pending requests: 1
Request 17 arrived, input tokens: 2, pending requests: 1
Request 18 arrived, input tokens: 2, pending requests: 1
```

Test A reproduces the original benchmark path (`/v1/completions` stream=true run
to completion) and shows the 58k `found=False` flood is gone at the source; B/D
show disconnects now correctly abort; the pending-count check shows no leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)