### PR TITLE
Avoid cancelling heavy CI on review events

### DIFF
--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -21,7 +21,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ATOM_BASE_NIGHTLY_IMAGE: rocm/atom-dev:latest

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -41,7 +41,7 @@ on:
 concurrency:
   # Keep scheduled main runs from blocking push-triggered validation.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.number && 'pr' || github.event_name }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && (github.event_name != 'pull_request_review' || github.event.review.state == 'approved') }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ATOM_BASE_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.atom_base_image || 'rocm/atom-dev:latest' }}

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -21,7 +21,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'pull_request_review' || github.event.review.state == 'approved' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ATOM_BASE_NIGHTLY_IMAGE: rocm/atom-dev:latest


### PR DESCRIPTION
## Summary
- limit heavy CI workflow cancellation to pull_request events only
- prevent review approval/comment events from cancelling in-progress heavy CI runs

## Notes
- This is the first-step change only. It does not add an approval de-duplication gate.

## Testing
- Parsed updated workflow YAML files with Python yaml.safe_load
- Ran git diff --check