### PR TITLE
Fix DeepSeek-V4 SGLang index top-k metadata

### DIFF
--- a/atom/plugin/sglang/deepseek_v4_bridge.py
+++ b/atom/plugin/sglang/deepseek_v4_bridge.py
@@ -10,6 +10,58 @@ import torch
 ATOM_DEEPSEEK_V4_BLOCK_SIZE = 128
 
 
+def _resolve_v4_index_topk(model: Any = None, proxy_pool: Any = None) -> int:
+    """Resolve the indexer width from the active ATOM model configuration.
+
+    The first eager SGLang metadata batch is built before proxy cache views are
+    bound to the model, so it cannot rely on ``model._atom_v4_meta_params``.
+    ATOM's active config is available then and carries the same Hugging Face
+    ``index_topk`` value used to construct the indexer.
+    """
+    value = None
+    source = None
+    if model is not None:
+        value = getattr(getattr(model, "args", None), "index_topk", None)
+        source = "model.args.index_topk"
+        if value is None:
+            value = getattr(
+                getattr(getattr(model, "atom_config", None), "hf_config", None),
+                "index_topk",
+                None,
+            )
+            source = "model.atom_config.hf_config.index_topk"
+    cached = (
+        getattr(proxy_pool, "_atom_v4_index_topk", None)
+        if proxy_pool is not None
+        else None
+    )
+    if value is None and cached is not None:
+        value = cached
+        source = "proxy_pool._atom_v4_index_topk"
+    if value is None:
+        from atom.config import get_current_atom_config
+
+        atom_config = get_current_atom_config()
+        value = getattr(getattr(atom_config, "hf_config", None), "index_topk", None)
+        source = "current_atom_config.hf_config.index_topk"
+    if value is None:
+        value = 1024
+        source = "DeepSeek-V4 default"
+    value = int(value)
+    if value <= 0:
+        raise ValueError(
+            f"DeepSeek-V4 index_topk must be positive, got {value} from {source}"
+        )
+    if cached is not None and int(cached) != value:
+        raise RuntimeError(
+            "DeepSeek-V4 index_topk mismatch: "
+            f"resolved={value} ({source}), proxy={int(cached)}"
+        )
+    if proxy_pool is not None:
+        proxy_pool._atom_v4_index_topk = value
+    return value
+
+
 def _aligned_index_dim(index_head_dim: int) -> int:
     # extra 4 bytes for scale, then 16-byte alignment.
     return ((int(index_head_dim) + 4 + 15) // 16) * 16
@@ -446,6 +498,7 @@ def bind_deepseek_v4_proxy_cache_views(model, proxy_pool: Any) -> bool:
     """
     if not getattr(proxy_pool, "is_atom_v4_proxy_pool", False):
         return False
+    index_topk = _resolve_v4_index_topk(model=model, proxy_pool=proxy_pool)
     ptr = proxy_pool.raw_arena.untyped_storage().data_ptr()
     if getattr(model, "_atom_sglang_v4_proxy_cache_ptr", None) == ptr:
         return True
@@ -465,6 +518,12 @@ def bind_deepseek_v4_proxy_cache_views(model, proxy_pool: Any) -> bool:
         attn.swa_kv = swa_view.reshape(-1, swa_view.shape[-1])
         attn.swa_block_size = proxy_pool.swa_cache_size
         if ratio == 4:
+            indexer_topk = int(attn.indexer.index_topk)
+            if indexer_topk != index_topk:
+                raise RuntimeError(
+                    "DeepSeek-V4 index_topk mismatch at layer "
+                    f"{local_layer_id}: metadata={index_topk}, indexer={indexer_topk}"
+                )
             _bind_compressor_state(
                 attn.compressor,
                 proxy_pool.views["csa_main"][csa_i],
@@ -495,7 +554,7 @@ def bind_deepseek_v4_proxy_cache_views(model, proxy_pool: Any) -> bool:
         num_slots=proxy_pool.num_slots,
         window_size=proxy_pool.window_size,
         cs=proxy_pool.swa_cache_size,
-        index_topk=int(getattr(model.args, "index_topk", 1024)),
+        index_topk=index_topk,
     )
     return True
 
@@ -1031,6 +1090,7 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
     from atom.plugin.vllm.deepseek_v4_ops import write_v4_decode_hca_compress_tail
     from atom.utils.forward_context import AttentionMetaData, AttnState
 
+    index_topk = _resolve_v4_index_topk(model=model, proxy_pool=proxy_pool)
     device = positions.device
     bs = int(forward_batch.batch_size)
     seq_np = _get_seq_lens_cpu(forward_batch)[:bs]
@@ -1062,12 +1122,13 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
         or bufs.num_slots < bs
         or bufs.max_blocks < max_blocks
         or bufs.max_decode_tokens < total
+        or bufs.index_topk != index_topk
     ):
         bufs = proxy_pool._atom_v4_decode_graph_buffers = _V4SGLangDecodeGraphBuffers(
             num_slots=proxy_pool.num_slots,
             max_decode_tokens=max(proxy_pool.num_slots, bs, total),
             window=proxy_pool.window_size,
-            index_topk=1024,
+            index_topk=index_topk,
             max_committed_hca=max_blocks,
             max_blocks=max_blocks,
             device=device,
@@ -1102,7 +1163,7 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
     md.swa_num_slots = proxy_pool.num_slots
     md.swa_window = proxy_pool.window_size
     md.swa_cs = proxy_pool.swa_cache_size
-    md.index_topk = 1024
+    md.index_topk = index_topk
     md.swa_pages = proxy_pool.num_slots * proxy_pool.swa_cache_size
 
     if total:
@@ -1258,6 +1319,7 @@ def build_atom_v4_verify_graph_metadata_from_sglang(
     from atom.model_ops.v4_kernels import write_v4_paged_prefill_indices
     from atom.utils.forward_context import AttentionMetaData, AttnState
 
+    index_topk = _resolve_v4_index_topk(model=model, proxy_pool=proxy_pool)
     device = positions.device
     bs = int(forward_batch.batch_size)
     seq_np = _get_seq_lens_cpu(forward_batch)[:bs]
@@ -1317,12 +1379,13 @@ def build_atom_v4_verify_graph_metadata_from_sglang(
         or bufs.num_slots < bs
         or bufs.max_blocks < max_blocks
         or bufs.max_verify_tokens < total
+        or bufs.index_topk != index_topk
     ):
         bufs = _V4SGLangVerifyGraphBuffers(
             num_slots=proxy_pool.num_slots,
             max_verify_tokens=max(proxy_pool.num_slots, total),
             window=proxy_pool.window_size,
-            index_topk=1024,
+            index_topk=index_topk,
             max_committed_hca=max_blocks,
             max_blocks=max_blocks,
             device=device,
@@ -1357,7 +1420,7 @@ def build_atom_v4_verify_graph_metadata_from_sglang(
     md.swa_num_slots = proxy_pool.num_slots
     md.swa_window = proxy_pool.window_size
     md.swa_cs = proxy_pool.swa_cache_size
-    md.index_topk = 1024
+    md.index_topk = index_topk
     md.swa_pages = proxy_pool.num_slots * proxy_pool.swa_cache_size
     # Target verify is extend-shaped for attention/compressor state, but the
     # indexer needs the fixed-shape decode scorer to be graph-safe.
@@ -1527,6 +1590,7 @@ def build_atom_v4_attention_metadata_from_sglang(
     """
     from atom.utils.forward_context import AttentionMetaData
 
+    index_topk = _resolve_v4_index_topk(proxy_pool=proxy_pool)
     state = _infer_atom_attn_state(forward_batch)
     device = positions.device
     num_reqs = int(forward_batch.batch_size)
@@ -1614,7 +1678,7 @@ def build_atom_v4_attention_metadata_from_sglang(
     md.swa_num_slots = proxy_pool.num_slots
     md.swa_window = proxy_pool.window_size
     md.swa_cs = proxy_pool.swa_cache_size
-    md.index_topk = 1024
+    md.index_topk = index_topk
     md.swa_pages = proxy_pool.num_slots * proxy_pool.swa_cache_size
 
     if is_draft_extend:


### PR DESCRIPTION
## Motivation

The DeepSeek-V4 SGLang bridge previously hard-coded `index_topk=1024` when constructing attention metadata and CUDA graph buffers. However, the DeepSeek-V4-Flash-FP8 model uses:

```json
{
  "index_topk": 512
}
```

This caused an inconsistency between the ATOM indexer and the SGLang bridge:

- ATOM model/indexer: index_topk=512
- SGLang attention metadata: index_topk=1024
- SGLang CUDA graph buffers: allocated using index_topk=1024

The issue is difficult to detect with short prompts because DeepSeek-V4 CSA uses a compression ratio of 4:

```
effective_topk = min(sequence_length / 4, index_topk)
```

For a 1K prompt, the effective number of CSA entries is only about 256, so both 512 and 1024 produce the same result. The mismatch starts affecting execution after approximately 2K tokens.
At longer sequence lengths, the inconsistent value may cause incorrect sparse-attention metadata, incompatible graph buffer sizes, accuracy degradation, or invalid kernel inputs.

## Technical Details

This PR adds `_resolve_v4_index_topk()` to `atom/plugin/sglang/deepseek_v4_bridge.py`.
The resolver obtains `index_topk` from the following sources:

1. `model.args.index_topk`
2. `model.atom_config.hf_config.index_topk`
3. The cached value on the SGLang proxy pool
4. The active ATOM Hugging Face configuration
5. The DeepSeek-V4 default value as a fallback

The resolved value is cached on the proxy pool because the first eager SGLang metadata batch may be constructed before the model proxy cache views are bound.
The resolved value is now used consistently in:

- Eager attention metadata
- Decode CUDA graph metadata and buffers
- Verify CUDA graph metadata and buffers
- Proxy cache metadata

CUDA graph buffers are recreated when their existing `index_topk` does not match the active model configuration.
The proxy cache binding path also validates that each DeepSeek-V4 layer's indexer uses the same `index_topk` as the SGLang metadata. A mismatch now fails early with a descriptive error instead of propagating inconsistent metadata to sparse-attention kernels.

## Test Result

Flexible final-number matching results:

| Input length | Completed samples | Accuracy | Request errors |
|---|---|---|---|
| 3,072 | 1,319/1,319 | 92.65% | 0 |
| 12,288 | 1,319/1,319 | 86.43% | 0 |
| 16,384 | 1,319/1,319 | 85.29% | 0 |
