### PR TITLE
[NO REVIEW][atom/atom-vllm] fix MTP accept-rate drop at con>=256 on sparse-MLA (DSA) decode

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1628,17 +1628,19 @@ def triton_gather_kv_indices_sparse(
     assert topk_indices.shape[1] == NUM_TOPK_TOKENS
     assert NUM_TOPK_TOKENS % BLOCK_N == 0
 
-    # token_to_seq_idxs is the authoritative output row count. Do not silently
-    # truncate if the sparse indexer produced fewer top-k rows; that would leave
-    # stale values in the persistent sparse-KV index buffer.
-    num_tokens = token_to_seq_idxs.shape[0]
-    assert topk_indices.shape[0] >= num_tokens, (
-        "sparse indexer under-produced top-k rows: "
-        f"topk_rows={topk_indices.shape[0]} expected_rows={num_tokens}"
-    )
-    assert sparse_kv_indptr.shape[0] >= num_tokens + 1, (
-        "sparse_kv_indptr is shorter than sparse token metadata: "
-        f"indptr_rows={sparse_kv_indptr.shape[0] - 1} expected_rows={num_tokens}"
+    # MTP decode can carry metadata tensors padded to a larger query layout than
+    # the number of rows the indexer actually produced (e.g. real tokens <
+    # batch_size * max_seqlen_q under cudagraph padding, so token_to_seq_idxs is
+    # longer than topk_indices). Align every per-token input to the valid
+    # intersection before launch, otherwise the kernel reads past topk_indices.
+    # This truncation only drops padding rows, never real requests: the chunked
+    # indexer launches in sparse_attn_indexer already guarantee every real row
+    # has fresh top-k content (that is what fixes the con>=256 stale-index drop),
+    # so no stale rows survive within the valid range.
+    num_tokens = min(
+        token_to_seq_idxs.shape[0],
+        topk_indices.shape[0],
+        sparse_kv_indptr.shape[0] - 1,
     )
     sparse_kv_indptr = sparse_kv_indptr[: num_tokens + 1]
     token_to_seq_idxs = token_to_seq_idxs[:num_tokens]

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -17,6 +17,7 @@ from aiter import (
     fused_qk_rope_concat_and_cache_mla,
     get_hip_quant,
 )
+from aiter.ops.triton.utils.device_info import get_num_sms
 
 # The segmented (page_size>1) MLA cache kernels only exist in newer aiter
 # builds. Import them lazily so that the default page_size=1 path keeps working
@@ -1627,14 +1628,17 @@ def triton_gather_kv_indices_sparse(
     assert topk_indices.shape[1] == NUM_TOPK_TOKENS
     assert NUM_TOPK_TOKENS % BLOCK_N == 0
 
-    # MTP decode can carry metadata tensors padded to a larger query layout
-    # than the number of rows produced by the current indexer call. Keep all
-    # per-token inputs aligned to the actual valid intersection before launch;
-    # otherwise the kernel may read past topk_indices.
-    num_tokens = min(
-        token_to_seq_idxs.shape[0],
-        topk_indices.shape[0],
-        sparse_kv_indptr.shape[0] - 1,
+    # token_to_seq_idxs is the authoritative output row count. Do not silently
+    # truncate if the sparse indexer produced fewer top-k rows; that would leave
+    # stale values in the persistent sparse-KV index buffer.
+    num_tokens = token_to_seq_idxs.shape[0]
+    assert topk_indices.shape[0] >= num_tokens, (
+        "sparse indexer under-produced top-k rows: "
+        f"topk_rows={topk_indices.shape[0]} expected_rows={num_tokens}"
+    )
+    assert sparse_kv_indptr.shape[0] >= num_tokens + 1, (
+        "sparse_kv_indptr is shorter than sparse token metadata: "
+        f"indptr_rows={sparse_kv_indptr.shape[0] - 1} expected_rows={num_tokens}"
     )
     sparse_kv_indptr = sparse_kv_indptr[: num_tokens + 1]
     token_to_seq_idxs = token_to_seq_idxs[:num_tokens]
@@ -1663,3 +1667,10 @@ def triton_gather_kv_indices_sparse(
         ti_stride1,
     )
     return out_buf
+
+
+def sparse_indexer_decode_rows_per_launch(wave_per_eu: int = 2) -> int:
+    # Keep sparse-indexer decode launches within the CU wave capacity. Large
+    # single launches can leave stale sparse indices in the persistent buffer on
+    # the GLM MTP path, even though standalone kernel probes may cover all rows.
+    return max(1, get_num_sms() * wave_per_eu)

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -58,6 +58,7 @@ from atom.model_ops.attention_mla import (
     triton_convert_req_index_to_global_index,
     triton_convert_req_index_to_global_index_dsa_prefill,
     triton_gather_kv_indices_sparse,
+    sparse_indexer_decode_rows_per_launch,
 )
 from atom.model_ops.base_attention import Attention
 from atom.model_ops.embed_head import (
@@ -1350,32 +1351,69 @@ def sparse_attn_indexer(
         assert batch_size == context.batch_size
         num_padded_tokens = batch_size * next_n
         batch_size, next_n, heads, _ = padded_q_fp8_decode_tokens.shape
-        logits = torch.empty(
-            [batch_size * next_n, max_model_len], dtype=torch.float32, device="cuda"
-        )
-        deepgemm_fp8_paged_mqa_logits(
-            padded_q_fp8_decode_tokens,
-            kv_cache,
-            weights[:num_padded_tokens],
-            logits,
-            decode_metadata.context_lens,
-            attn_metadata.block_tables,
-            max_model_len,
-            KVBlockSize=runner_block_size,
-            Preshuffle=True,
-        )
-        num_rows = logits.shape[0]
         assert topk_tokens == 2048, "top_k_per_row assumes size 2048"
         topk_indices_decode = topk_indices[:num_decode_tokens, :topk_tokens]
-        top_k_per_row_decode(
-            logits,
-            next_n,
-            decode_metadata.context_lens,
-            topk_indices_decode,
-            num_rows,
-            logits.stride(0),
-            logits.stride(1),
-        )
+        # Keep each sparse-indexer decode launch under the row cliff observed at
+        # large MTP batches; otherwise later rows can retain stale sparse KV
+        # indices in the persistent buffer.
+        max_indexer_rows = sparse_indexer_decode_rows_per_launch()
+        if num_padded_tokens > max_indexer_rows:
+            chunk_reqs = max(1, max_indexer_rows // next_n)
+            for req_start in range(0, batch_size, chunk_reqs):
+                req_end = min(req_start + chunk_reqs, batch_size)
+                row_start = req_start * next_n
+                row_end = req_end * next_n
+                logits = torch.empty(
+                    [row_end - row_start, max_model_len],
+                    dtype=torch.float32,
+                    device="cuda",
+                )
+                deepgemm_fp8_paged_mqa_logits(
+                    padded_q_fp8_decode_tokens[req_start:req_end],
+                    kv_cache,
+                    weights[row_start:row_end],
+                    logits,
+                    decode_metadata.context_lens[req_start:req_end],
+                    attn_metadata.block_tables[req_start:req_end],
+                    max_model_len,
+                    KVBlockSize=runner_block_size,
+                    Preshuffle=True,
+                )
+                top_k_per_row_decode(
+                    logits,
+                    next_n,
+                    decode_metadata.context_lens[req_start:req_end],
+                    topk_indices_decode[row_start:row_end],
+                    row_end - row_start,
+                    logits.stride(0),
+                    logits.stride(1),
+                )
+        else:
+            logits = torch.empty(
+                [num_padded_tokens, max_model_len],
+                dtype=torch.float32,
+                device="cuda",
+            )
+            deepgemm_fp8_paged_mqa_logits(
+                padded_q_fp8_decode_tokens,
+                kv_cache,
+                weights[:num_padded_tokens],
+                logits,
+                decode_metadata.context_lens,
+                attn_metadata.block_tables,
+                max_model_len,
+                KVBlockSize=runner_block_size,
+                Preshuffle=True,
+            )
+            top_k_per_row_decode(
+                logits,
+                next_n,
+                decode_metadata.context_lens,
+                topk_indices_decode,
+                num_padded_tokens,
+                logits.stride(0),
+                logits.stride(1),
+            )
         if attn_metadata.max_seqlen_q > 1:
             triton_gather_kv_indices_sparse(
                 attn_metadata.sparse_kv_indptr,

--- a/atom/plugin/vllm/attention/layer_sparse_mla.py
+++ b/atom/plugin/vllm/attention/layer_sparse_mla.py
@@ -24,6 +24,7 @@ from aiter import (
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
 
+from atom.model_ops.attention_mla import sparse_indexer_decode_rows_per_launch
 from atom.plugin.prepare import is_vllm
 from atom.utils import envs
 from atom.utils.custom_register import direct_register_custom_op
@@ -458,35 +459,81 @@ def sparse_attn_indexer_plugin_mode(
         next_n = padded_q_fp8_decode_tokens.shape[1]
         assert batch_size == decode_metadata.seq_lens.shape[0]
         num_padded_tokens = batch_size * next_n
-        logits = torch.empty(
-            [batch_size * next_n, max_model_len], dtype=torch.float32, device="cuda"
-        )
-        deepgemm_fp8_paged_mqa_logits(
-            padded_q_fp8_decode_tokens,
-            kv_cache,
-            weights[:num_padded_tokens],
-            logits,
-            decode_metadata.seq_lens,
-            decode_metadata.block_table,
-            max_model_len,
-            ChunkK=256,
-            KVBlockSize=kv_block_size,
-            Preshuffle=preshuffle_cache,
-            WavePerEU=2,
-        )
-
-        num_rows = logits.shape[0]
         assert topk_tokens == 2048, "top_k_per_row assumes size 2048"
-        topk_indices_decode = topk_indices[:num_decode_tokens, :topk_tokens]
-        top_k_per_row_decode(
-            logits,
-            next_n,
-            decode_metadata.seq_lens,
-            topk_indices_decode,
-            num_rows,
-            logits.stride(0),
-            logits.stride(1),
-        )
+        if decode_metadata.requires_padding:
+            padded_weights_decode = pack_seq_triton(
+                weights[:num_decode_tokens], decode_lens
+            ).reshape(num_padded_tokens, *weights.shape[1:])
+            topk_indices_decode = torch.empty(
+                [num_padded_tokens, topk_tokens],
+                dtype=torch.int32,
+                device=topk_indices.device,
+            )
+        else:
+            padded_weights_decode = weights[:num_padded_tokens]
+            topk_indices_decode = topk_indices[:num_decode_tokens, :topk_tokens]
+        max_indexer_rows = sparse_indexer_decode_rows_per_launch()
+        if num_padded_tokens > max_indexer_rows:
+            chunk_reqs = max(1, max_indexer_rows // next_n)
+            for req_start in range(0, batch_size, chunk_reqs):
+                req_end = min(req_start + chunk_reqs, batch_size)
+                row_start = req_start * next_n
+                row_end = req_end * next_n
+                logits = torch.empty(
+                    [row_end - row_start, max_model_len],
+                    dtype=torch.float32,
+                    device="cuda",
+                )
+                deepgemm_fp8_paged_mqa_logits(
+                    padded_q_fp8_decode_tokens[req_start:req_end],
+                    kv_cache,
+                    padded_weights_decode[row_start:row_end],
+                    logits,
+                    decode_metadata.seq_lens[req_start:req_end],
+                    decode_metadata.block_table[req_start:req_end],
+                    max_model_len,
+                    ChunkK=256,
+                    KVBlockSize=kv_block_size,
+                    Preshuffle=preshuffle_cache,
+                    WavePerEU=2,
+                )
+                top_k_per_row_decode(
+                    logits,
+                    next_n,
+                    decode_metadata.seq_lens[req_start:req_end],
+                    topk_indices_decode[row_start:row_end],
+                    row_end - row_start,
+                    logits.stride(0),
+                    logits.stride(1),
+                )
+        else:
+            logits = torch.empty(
+                [num_padded_tokens, max_model_len],
+                dtype=torch.float32,
+                device="cuda",
+            )
+            deepgemm_fp8_paged_mqa_logits(
+                padded_q_fp8_decode_tokens,
+                kv_cache,
+                padded_weights_decode,
+                logits,
+                decode_metadata.seq_lens,
+                decode_metadata.block_table,
+                max_model_len,
+                ChunkK=256,
+                KVBlockSize=kv_block_size,
+                Preshuffle=preshuffle_cache,
+                WavePerEU=2,
+            )
+            top_k_per_row_decode(
+                logits,
+                next_n,
+                decode_metadata.seq_lens,
+                topk_indices_decode,
+                num_padded_tokens,
+                logits.stride(0),
+                logits.stride(1),
+            )
 
         if decode_metadata.requires_padding:
             # if padded, we need to unpack


### PR DESCRIPTION
Root cause: at large MTP batches the sparse-indexer decode path issues one big deepgemm_fp8_paged_mqa_logits + top_k_per_row_decode launch whose later rows can retain stale sparse-KV indices in the persistent buffer (rows beyond the CU wave capacity), so requests past the cliff attend to wrong KV and their drafts get rejected -> acceptance halves (~50% -> ~25% at con256, cliff at seq 128).

so when specify max num seqs to the value which is smaller than 128, the accept ratio restores to the normal value, while for default 512, most of requests has low draft token accept ratio. Here is the histogram illustration.
<img width="1037" height="583" alt="image" src="https://github.com/user-attachments/assets/6738dca2-5eb2-4119-82c9-d5ca1056e2d0" />

Fix:
- Chunk the sparse-indexer decode launches to <= get_num_sms()*wave_per_eu rows (new helper sparse_indexer_decode_rows_per_launch), so every row's logits/topk are actually computed. Applied to both native (deepseek_v2) and plugin paths.
- triton_gather_kv_indices_sparse: use token_to_seq_idxs as the authoritative row count and assert topk/sparse_kv_indptr are large enough instead of silently truncating (which left stale rows in the persistent sparse-KV index buffer).
- plugin: handle requires_padding by packing weights and unpacking topk indices.

## atom-vllm

| Configuration | Position 1 Acceptance Rate | Position 2 Acceptance Rate | Position 3 Acceptance Rate | Avg Draft Acceptance Rate |
| --- | ---: | ---: | ---: | ---: |
| without fix | 0.422 | 0.245 | 0.108 | 25.8% |
| with fix | 0.721 | 0.494 | 0.235 | 48.3% |

## atom

| Configuration | Acceptance Rate | Accepted 0 Tokens | Accepted 1 Token | Accepted 2 Tokens | Accepted 3 Tokens |
| --- | ---: | ---: | ---: | ---: | ---: |
| without fix | 26.87% | 52.30% | 23.90% | 14.70% | 9.10% |
| with fix | 53.53% | 17.64% | 27.65% | 31.20% | 23.51% |