### PR TITLE
[Misc][UI] Allow using --kv-cache-dtype kebab-case flag 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,10 @@ black . && ruff check .                   # format + lint (CI enforced)
 
 ```bash
 # OpenAI-compatible serving
-python -m atom.entrypoints.openai_server --model <model> --kv_cache_dtype fp8 -tp 8
+python -m atom.entrypoints.openai_server --model <model> --kv-cache-dtype fp8 -tp 8
 
 # Offline inference
-python -m atom.examples.simple_inference --model <model> --kv_cache_dtype fp8
+python -m atom.examples.simple_inference --model <model> --kv-cache-dtype fp8
 ```
 
 - Accuracy validation: see `/ci-pr-guide` for `lm_eval` setup and CI thresholds

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ hf auth login
 The default optimization level is 3 (piecewise torch.compile with CUDA graphs).
 
 ```bash
-python -m atom.examples.simple_inference --model meta-llama/Meta-Llama-3-8B --kv_cache_dtype fp8
+python -m atom.examples.simple_inference --model meta-llama/Meta-Llama-3-8B --kv-cache-dtype fp8
 ```
 
 > **Note:** First-time execution may take approximately 10 minutes for model compilation.
@@ -137,13 +137,13 @@ Start an OpenAI-compatible server:
 
 ```bash
 # Single GPU
-python -m atom.entrypoints.openai_server --model Qwen/Qwen3-0.6B --kv_cache_dtype fp8
+python -m atom.entrypoints.openai_server --model Qwen/Qwen3-0.6B --kv-cache-dtype fp8
 
 # Multi-GPU with tensor parallelism
-python -m atom.entrypoints.openai_server --model deepseek-ai/DeepSeek-R1 --kv_cache_dtype fp8 -tp 8
+python -m atom.entrypoints.openai_server --model deepseek-ai/DeepSeek-R1 --kv-cache-dtype fp8 -tp 8
 
 # With MTP speculative decoding
-python -m atom.entrypoints.openai_server --model deepseek-ai/DeepSeek-R1 --kv_cache_dtype fp8 -tp 8 \
+python -m atom.entrypoints.openai_server --model deepseek-ai/DeepSeek-R1 --kv-cache-dtype fp8 -tp 8 \
   --method mtp --num-speculative-tokens 3
 ```
 
@@ -191,7 +191,7 @@ Launch the server with `--torch-profiler-dir` and `--mark-trace`:
 
 ```bash
 python -m atom.entrypoints.openai_server \
-  --model deepseek-ai/DeepSeek-R1 --kv_cache_dtype fp8 -tp 8 \
+  --model deepseek-ai/DeepSeek-R1 --kv-cache-dtype fp8 -tp 8 \
   --torch-profiler-dir ./trace --mark-trace
 ```
 

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -115,7 +115,9 @@ class EngineArgs:
             help="Engine internal port",
         )
         parser.add_argument(
+            "--kv-cache-dtype",
             "--kv_cache_dtype",
+            dest="kv_cache_dtype",
             choices=["bf16", "fp8"],
             type=str,
             default="bf16",

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -31,7 +31,27 @@ if _atom_config_stub is not None:
             {"NONE": 0, "PIECEWISE": 1, "FULL": 2, "FULL_AND_PIECEWISE": 3},
         )
 
+import argparse  # noqa: E402
+
 from atom.model_engine.arg_utils import EngineArgs  # noqa: E402
+
+
+class TestKVCacheDtypeCliAlias:
+    """--kv-cache-dtype and --kv_cache_dtype must both set kv_cache_dtype."""
+
+    def _parse(self, argv):
+        parser = argparse.ArgumentParser()
+        EngineArgs.add_cli_args(parser)
+        return parser.parse_args(argv)
+
+    def test_dashed_form(self):
+        assert self._parse(["--kv-cache-dtype", "fp8"]).kv_cache_dtype == "fp8"
+
+    def test_underscore_form(self):
+        assert self._parse(["--kv_cache_dtype", "fp8"]).kv_cache_dtype == "fp8"
+
+    def test_default(self):
+        assert self._parse([]).kv_cache_dtype == "bf16"
 
 
 class TestEngineArgsSpeculativeValidation:


### PR DESCRIPTION
## Motivation

Currently you need to use the somewhat unconventional case `--kv_cache_dtype`, while every other argument in ATOM is kebab case.

Keep the old one for backwards compatibility.
 
Note: in the docs there are still lots of uses of the old version. Let's see when/if we want to rename those as well.

## Technical Details

N/A

## Test Plan

```shell
pytest tests/test_arg_utils_spec.py
```
## Test Result

```shell
...
tests/test_arg_utils_spec.py .......                                                                                                                                      [100%]

=============================================================================== 7 passed in 0.03s ===============================================================================
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
