### PR TITLE
Fix(mxfp4): align activation quant rounding with Quark offline calibr…

### DIFF
--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -20,6 +20,7 @@ from aiter import (
 # import torch.distributed as dist
 from aiter.dist.parallel_state import get_tp_group
 from aiter.jit.utils.torch_guard import torch_compile_guard
+from aiter.ops.quant import quant_mxfp4_hip
 from aiter.tuned_gemm import tgemm
 from aiter.utility import fp4_utils
 from torch import nn
@@ -45,6 +46,20 @@ from atom.utils import envs
 from atom.utils.decorators import mark_trace
 
 logger = logging.getLogger("atom")
+
+
+def _resolve_mxfp4_act_round_mode() -> int:
+    """Return the HIP quant_mxfp4_hip round_mode for activation quant.
+
+    Every other ATOM MXFP4 quant path (weights, MoE, fused SiLU/RMSNorm)
+    already produces Even scales, so we hardcode Even here for consistency.
+    Set ATOM_ACT_QUANT_HIP_ROUNDUP=1 to restore the legacy RoundUp path.
+    """
+    from aiter.utility.mx_types import MxScaleRoundModeInt
+
+    if envs.ATOM_ACT_QUANT_HIP_ROUNDUP:
+        return int(MxScaleRoundModeInt.RoundUp)
+    return int(MxScaleRoundModeInt.Even)
 
 
 def use_triton_gemm() -> bool:
@@ -116,6 +131,7 @@ def gemm_a4w4_quant_fake(
     params_dtype: torch.dtype,
     input_scale: torch.Tensor,
     output_size: int,
+    act_round_mode: int = 2,  # 2 = Even
 ) -> torch.Tensor:
     return torch.empty((*x.shape[:-1], weight.shape[0]), dtype=otype, device=x.device)
 
@@ -131,6 +147,7 @@ def gemm_a4w4_quant(
     params_dtype: torch.dtype,
     input_scale: torch.Tensor,
     output_size: int,
+    act_round_mode: int = 2,  # 2 = Even
 ) -> torch.Tensor:
     # Non-shuffle FP4 Triton path: keep x/weight/scale in the original MXFP4
     # layout and call the non-preshuffled gemm_afp4wfp4 kernel.
@@ -140,7 +157,7 @@ def gemm_a4w4_quant(
                 "ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM=1 requires aiter.ops.triton.gemm_afp4wfp4"
             )
         if x_scale is None:
-            quant_func = get_hip_quant(QuantType.per_1x32)
+            quant_func = functools_partial(quant_mxfp4_hip, round_mode=act_round_mode)
             x, x_scale = quant_func(
                 x,
                 quant_dtype=params_dtype,
@@ -191,7 +208,7 @@ def gemm_a4w4_quant(
             device=x.device,
         )
         if x_scale is None:
-            quant_func = get_hip_quant(QuantType.per_1x32)
+            quant_func = functools_partial(quant_mxfp4_hip, round_mode=act_round_mode)
             x, x_scale = quant_func(
                 x,
                 quant_dtype=params_dtype,
@@ -221,7 +238,7 @@ def gemm_a4w4_quant(
     # and use the backend ASM implementation.
     else:
         if x_scale is None:
-            quant_func = get_hip_quant(QuantType.per_1x32)
+            quant_func = functools_partial(quant_mxfp4_hip, round_mode=act_round_mode)
             x, x_scale = quant_func(
                 x,
                 quant_dtype=params_dtype,
@@ -583,6 +600,9 @@ class LinearBase(nn.Module):
         self.need_normalize_e4m3fn_to_e4m3fnuz = params_dtype == torch.float8_e4m3fnuz
         self.quant_func = get_hip_quant(self.quant_type)
         self.is_output_padded = False
+        # Activation quant rounding = Even, matching all other ATOM MXFP4
+        # paths; ATOM_ACT_QUANT_HIP_ROUNDUP=1 forces legacy RoundUp.
+        self.mxfp4_act_round_mode = _resolve_mxfp4_act_round_mode()
 
     @staticmethod
     def weight_loader_process(
@@ -1105,6 +1125,7 @@ class LinearBase(nn.Module):
                     self.params_dtype,
                     getattr(self, "input_scale", None),
                     self.output_size,
+                    self.mxfp4_act_round_mode,
                 )
                 if self.bias is not None:
                     y += self.bias

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -338,10 +338,20 @@ def quant_mxfp4_online_even(
     from aiter.ops.quant import quant_mxfp4_hip
     from aiter.utility.mx_types import MxScaleRoundModeInt
 
+    orig_shape = weight.shape
     q_in = weight.contiguous()
     if q_in.dtype not in (torch.float16, torch.bfloat16):
         q_in = q_in.to(torch.bfloat16)
+    # quant_mxfp4_hip requires 2D input; reshape higher-rank tensors
+    # (e.g. fused MoE expert weights [num_experts, N, K]) before the call
+    # and restore the leading dimensions on the outputs.
+    if q_in.dim() > 2:
+        q_in = q_in.reshape(-1, q_in.shape[-1])
     q_weight, weight_scale = quant_mxfp4_hip(q_in, round_mode=MxScaleRoundModeInt.Even)
+    if len(orig_shape) > 2:
+        leading = orig_shape[:-1]
+        q_weight = q_weight.reshape(*leading, q_weight.shape[-1])
+        weight_scale = weight_scale.reshape(*leading, weight_scale.shape[-1])
     return q_weight.view(dtypes.fp4x2), weight_scale.view(_mx_block_scale_dtype())
 
 

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -59,6 +59,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_FP8_BLOCKSCALE_USE_E8M0_SCALE": lambda: (
         os.getenv("ATOM_FP8_BLOCKSCALE_USE_E8M0_SCALE", "0") == "1"
     ),
+    # Restore the legacy HIP RoundUp rounding for MXFP4 activation quant.
+    # Default (0) uses Even, matching Quark's offline weight calibration and
+    # every other ATOM MXFP4 quant path. Debug/comparison escape hatch only.
+    "ATOM_ACT_QUANT_HIP_ROUNDUP": lambda: (
+        os.getenv("ATOM_ACT_QUANT_HIP_ROUNDUP", "0") == "1"
+    ),
     "ATOM_USE_TRITON_MXFP4_BMM": lambda: (
         os.getenv("ATOM_USE_TRITON_MXFP4_BMM", "0") == "1"
     ),

--- a/tests/test_mxfp4_act_rounding.py
+++ b/tests/test_mxfp4_act_rounding.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Tests for MXFP4 activation quantization rounding alignment.
+
+Covers:
+  atom/model_ops/linear.py  — _resolve_mxfp4_act_round_mode()
+  atom/quantization/quark/utils.py — quant_mxfp4_online_even() 3D reshape
+
+Both changes ensure ATOM's runtime activation quant rounding matches the
+Even rounding used by Quark during offline weight calibration, eliminating
+the round-mode mismatch that degraded e2e accuracy.
+
+These modules import ``aiter``/``triton`` at module load, which need a GPU
+build absent on a CPU test runner. Rather than hand-mocking the whole
+``atom.*`` import graph and loading the files by path, we install a
+``sys.meta_path`` finder that fabricates a stub for *only* those GPU
+packages, then import the modules under test the same way the engine does.
+The real ``atom`` package (config, quant_spec, utils.envs, ...) is imported
+unstubbed, so a test breaks if one of those APIs drifts.
+"""
+
+import importlib
+import importlib.abc
+import importlib.machinery
+import math
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# ── round-mode constants (mirror aiter.utility.mx_types.MxScaleRoundModeInt) ──
+
+ROUND_DOWN = 0
+ROUND_UP = 1
+EVEN = 2
+CEIL = 3
+
+
+class _FakeMxScaleRoundModeInt:
+    """Stand-in for aiter.utility.mx_types.MxScaleRoundModeInt."""
+
+    RoundDown = ROUND_DOWN
+    RoundUp = ROUND_UP
+    Even = EVEN
+    Ceil = CEIL
+
+    def __init__(self, v=0):
+        self.value = int(v)
+
+    def __int__(self):
+        return self.value
+
+
+# ── GPU-dependency stub (aiter / triton only) ──────────────────────────────────
+#
+# aiter and triton are the only imports that require a GPU build; everything
+# else linear.py / quark/utils.py pull in (torch, regex, and the real atom.*
+# modules) is present on a CPU runner. This finder answers imports for those
+# two roots with auto-populating stub modules and nothing else, so real
+# packages keep their real behavior.
+
+_STUB_ROOTS = ("aiter", "triton")
+
+
+def _make_stub_module(name):
+    if name == "aiter.utility.mx_types":
+        mod = types.ModuleType(name)
+        mod.MxScaleRoundModeInt = _FakeMxScaleRoundModeInt
+        mod.MX_DEFAULT_ROUND_MODE = ROUND_UP
+        return mod
+    mod = types.ModuleType(name)
+    mod.__getattr__ = lambda _attr: MagicMock()
+    mod.__path__ = []
+    return mod
+
+
+class _GpuDepFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, name, path, target=None):
+        root = name.split(".")[0]
+        if root in _STUB_ROOTS:
+            return importlib.machinery.ModuleSpec(name, self)
+        return None
+
+    def create_module(self, spec):
+        return _make_stub_module(spec.name)
+
+    def exec_module(self, module):
+        pass
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _modules_under_test():
+    """Import the modules under test against stubbed GPU deps.
+
+    Installs the aiter/triton finder, imports linear.py and quark/utils.py
+    normally, exposes the functions under test, then removes the finder and
+    the stub modules so nothing leaks into other test files.
+    """
+    finder = _GpuDepFinder()
+    sys.meta_path.insert(0, finder)
+
+    # A partial *real* aiter/triton build may already be in sys.modules (CI has
+    # one; a CPU dev box does not). Evict those entries plus the two modules
+    # under test so the finder owns every aiter/triton import during load, then
+    # restore the originals on teardown so nothing leaks into other test files.
+    evict = [
+        "atom.model_ops.linear",
+        "atom.quantization.quark.utils",
+    ]
+    evict += [n for n in sys.modules if n.split(".")[0] in _STUB_ROOTS]
+    saved = {n: sys.modules.pop(n) for n in evict if n in sys.modules}
+    try:
+        linear = importlib.import_module("atom.model_ops.linear")
+        utils = importlib.import_module("atom.quantization.quark.utils")
+        yield types.SimpleNamespace(
+            resolve=linear._resolve_mxfp4_act_round_mode,
+            quant=utils.quant_mxfp4_online_even,
+            utils_mod=utils,
+        )
+    finally:
+        sys.meta_path.remove(finder)
+        # Drop everything imported under the stubs, then restore what was there.
+        for name in list(sys.modules):
+            if name.split(".")[0] in _STUB_ROOTS or name in (
+                "atom.model_ops.linear",
+                "atom.quantization.quark.utils",
+            ):
+                del sys.modules[name]
+        sys.modules.update(saved)
+
+
+@pytest.fixture
+def resolve(_modules_under_test):
+    return _modules_under_test.resolve
+
+
+@pytest.fixture
+def quant(_modules_under_test):
+    return _modules_under_test.quant
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+class _FakeTensor:
+    """CPU-only fake tensor with .shape, .dim(), .reshape(), .contiguous(), .to()."""
+
+    def __init__(self, shape, dtype="bfloat16"):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+        self._numel = math.prod(shape)
+
+    def dim(self):
+        return len(self.shape)
+
+    def contiguous(self):
+        return self
+
+    def to(self, dtype):
+        return _FakeTensor(self.shape, dtype)
+
+    def view(self, dtype):
+        return _FakeTensor(self.shape, dtype)
+
+    def reshape(self, *args):
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            new_shape = list(args[0])
+        else:
+            new_shape = list(args)
+        neg = [i for i, s in enumerate(new_shape) if s == -1]
+        if neg:
+            known = math.prod(s for s in new_shape if s != -1)
+            new_shape[neg[0]] = self._numel // known
+        assert (
+            math.prod(new_shape) == self._numel
+        ), f"reshape {self.shape} → {new_shape} invalid"
+        return _FakeTensor(new_shape, self.dtype)
+
+
+def _make_fake_hip():
+    """Return (fake_quant_mxfp4_hip, call_log) for injection into quark/utils."""
+    call_log = []
+
+    def _hip(w, round_mode):
+        call_log.append({"shape": w.shape, "round_mode": int(round_mode)})
+        rows, k = w.shape
+        return _FakeTensor((rows, k // 2)), _FakeTensor((rows, k // 32))
+
+    return _hip, call_log
+
+
+# ── Tests: _resolve_mxfp4_act_round_mode ──────────────────────────────────────
+
+
+class TestResolveMxfp4ActRoundMode:
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        monkeypatch.delenv("ATOM_ACT_QUANT_HIP_ROUNDUP", raising=False)
+
+    def test_returns_even_by_default(self, resolve):
+        assert resolve() == EVEN
+
+    def test_env_var_forces_roundup(self, resolve, monkeypatch):
+        """ATOM_ACT_QUANT_HIP_ROUNDUP=1 forces the legacy RoundUp path."""
+        monkeypatch.setenv("ATOM_ACT_QUANT_HIP_ROUNDUP", "1")
+        assert resolve() == ROUND_UP
+
+    def test_env_var_zero_stays_even(self, resolve, monkeypatch):
+        """ATOM_ACT_QUANT_HIP_ROUNDUP=0 keeps the default Even path."""
+        monkeypatch.setenv("ATOM_ACT_QUANT_HIP_ROUNDUP", "0")
+        assert resolve() == EVEN
+
+
+# ── Tests: quant_mxfp4_online_even 3D reshape ─────────────────────────────────
+
+
+class TestQuantMxfp4OnlineEven3DReshape:
+
+    @pytest.fixture(autouse=True)
+    def _inject_fake_hip(self, _modules_under_test):
+        """Inject fake quant_mxfp4_hip via sys.modules so lazy imports resolve it."""
+        fake_hip, call_log = _make_fake_hip()
+        self._calls = call_log
+        # utils.py does `from aiter.ops.quant import quant_mxfp4_hip` at call
+        # time, so we patch the sys.modules entry that the lazy import will hit.
+        sys.modules["aiter.ops.quant"].quant_mxfp4_hip = fake_hip
+        _modules_under_test.utils_mod.quant_mxfp4_hip = fake_hip
+        yield
+        sys.modules["aiter.ops.quant"].quant_mxfp4_hip = MagicMock()
+        _modules_under_test.utils_mod.quant_mxfp4_hip = MagicMock()
+
+    def test_2d_weight_passes_unchanged(self, quant):
+        """Standard [N, K] weight: no reshape, kernel called once with original shape."""
+        q, s = quant(_FakeTensor((512, 128)))
+        assert len(self._calls) == 1
+        assert self._calls[0]["shape"] == (512, 128)
+        assert q.shape == (512, 64)
+        assert s.shape == (512, 4)
+
+    def test_3d_moe_weight_reshaped_before_kernel(self, quant):
+        """[num_experts, N, K] → kernel sees [num_experts*N, K]."""
+        quant(_FakeTensor((8, 512, 128)))
+        assert len(self._calls) == 1
+        assert self._calls[0]["shape"] == (8 * 512, 128)
+
+    def test_3d_output_leading_dim_restored(self, quant):
+        """Packed weight and scale recover the [E, N, ...] leading dims."""
+        q, s = quant(_FakeTensor((4, 256, 64)))
+        assert q.shape == (4, 256, 32), f"q.shape={q.shape}"
+        assert s.shape == (4, 256, 2), f"s.shape={s.shape}"
+
+    def test_4d_weight_also_handled(self, quant):
+        """[batch, experts, N, K] tensors reshape and restore correctly."""
+        q, s = quant(_FakeTensor((2, 4, 128, 64)))
+        assert self._calls[0]["shape"] == (2 * 4 * 128, 64)
+        assert q.shape == (2, 4, 128, 32)
+        assert s.shape == (2, 4, 128, 2)
+
+    def test_even_round_mode_passed_to_kernel(self, quant):
+        """quant_mxfp4_hip must receive Even (2) as round_mode for 2D input."""
+        quant(_FakeTensor((64, 32)))
+        assert self._calls[0]["round_mode"] == EVEN
+
+    def test_3d_even_round_mode_preserved_through_reshape(self, quant):
+        """Even round mode is not lost when the 3D reshape path is taken."""
+        quant(_FakeTensor((8, 128, 64)))
+        assert self._calls[0]["round_mode"] == EVEN
+
+    @pytest.mark.parametrize(
+        "num_experts,n,k",
+        [
+            (8, 512, 128),  # DeepSeek-R1 expert shape
+            (256, 128, 64),  # Qwen3.5-35B-A3B expert shape
+            (64, 256, 32),  # smaller expert
+        ],
+    )
+    def test_various_moe_shapes(self, quant, num_experts, n, k):
+        """3D MoE expert shapes all reshape, quantize, and restore correctly."""
+        q, s = quant(_FakeTensor((num_experts, n, k)))
+        assert self._calls[0]["shape"] == (num_experts * n, k)
+        assert q.shape == (num_experts, n, k // 2)
+        assert s.shape == (num_experts, n, k // 32)


### PR DESCRIPTION
…ation

MXFP4 activation quantization during inference used hardcoded HIP RoundUp rounding while Quark's offline weight calibration uses Even rounding.  The mismatch might degrade e2e accuracy: +1.82% GSM8K flexible-extract on Qwen3.5-35B-A3B-MXFP4 when switching to Even.

Changes
-------
atom/model_ops/linear.py
  - Add _resolve_mxfp4_act_round_mode(quant_config) which reads quantization_config.global_quant_config.input_tensors .scale_calculation_mode from the model checkpoint (Quark standard field) and maps it to the corresponding quant_mxfp4_hip round_mode int. Defaults to Even, which is Quark's calibration standard.
  - LinearBase.__init__ now resolves the round_mode once at load time and stores it as self.mxfp4_act_round_mode.
  - gemm_a4w4_quant accepts an act_round_mode parameter (default=2/Even) and uses functools.partial(quant_mxfp4_hip, round_mode=...) at all three activation quant call sites, replacing get_hip_quant(per_1x32) which always used RoundUp.
  - LinearBase.forward passes self.mxfp4_act_round_mode into gemm_a4w4_quant so the resolved mode is used at inference time.
  - Escape hatch: ATOM_ACT_QUANT_HIP_ROUNDUP=1 forces legacy RoundUp for debugging or comparison.

atom/quantization/quark/utils.py
  - quant_mxfp4_online_even: handle higher-rank weight tensors (e.g. fused MoE expert weights shaped [num_experts, N, K]) by reshaping to 2D before quant_mxfp4_hip (which requires 2D input) and restoring the leading dimensions on both packed-weight and scale outputs.


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

# Accuracy Results — GSM8K 3-shot, n=1319

| Model | Kernel | Rounding | flexible-extract | strict-match | Δ flex |
|-------|--------|----------|:----------------:|:------------:|:------:|
| Qwen3.5-35B-A3B-MXFP4 | HIP | RoundUp (before) | 0.8506 ± 0.0098 | 0.8378 ± 0.0102 | — |
| Qwen3.5-35B-A3B-MXFP4 | HIP | **Even (after)** | **0.8688 ± 0.0093** | **0.8537 ± 0.0097** | **+1.82%** |
| Kimi-K2.6-MXFP4 | HIP | RoundUp (before) | 0.8666 ± 0.0094 | 0.8567 ± 0.0097 | — |
| Kimi-K2.6-MXFP4 | HIP | Even (after) | 0.8673 ± 0.0093 | 0.8575 ± 0.0096 | +0.07% |
| GLM-5-MXFP4 | HIP | RoundUp (before) | 0.9371 ± 0.0067 | 0.9416 ± 0.0065 | — |
| GLM-5-MXFP4 | HIP | Even (after) | 0.9378 ± 0.0067 | 0.9416 ± 0.0065 | +0.07% |


Some extra results  MATH-500 and GPQA-Diamond

  ## Accuracy: activation-rounding fix (Even vs RoundUp)

  Two MXFP4 models, thinking mode enabled, greedy (temp 0), single run.
  **Fix ON = Even rounding** (default); **Fix OFF = RoundUp** (`ATOM_ACT_QUANT_HIP_ROUNDUP=1`).

  ### MATH-500 — `math_verify` (sympy), 500 Q, 0-shot, 32768 tok

  | Model | Even (fix ON) | RoundUp (fix OFF) | Δ (fix) |
  |-------|:-------------:|:-----------------:|:-------:|
  | Kimi-K2.6-MXFP4 | **0.972** ± 0.007 | 0.960 ± 0.009 | **+1.2** |
  | GLM-5.2-MXFP4   | **0.614** ± 0.022 | 0.580 ± 0.022 | **+3.4** |
  | Qwen3.5-35B-A3B-MXFP4 | **0.964** ± 0.008 | 0.954 ± 0.009 | **+1.0** |

  <!-- comment: fix improves both models on the higher-power benchmark (n=500) -->

  ### GPQA-Diamond — `exact_match`, 198 Q, 0-shot, 32768 tok

  | Model | Even (fix ON) | RoundUp (fix OFF) | Δ (fix) |
  |-------|:-------------:|:-----------------:|:-------:|
  | Kimi-K2.6-MXFP4 | 0.783 ± 0.029 | **0.803** ± 0.028 | −2.0 |
  | GLM-5.2-MXFP4   | **0.667** ± 0.034 | 0.657 ± 0.034 | +1.0 |
  | Qwen3.5-35B-A3B-MXFP4 | **0.778** ± 0.030 | 0.753 ± 0.031 | **+2.5** |

  <!-- comment: Kimi inversion here is within ~1σ (n=198); resolved by MATH-500 above -->

  ### Summary

  - On **MATH-500** (higher power, n=500) the Even-rounding fix improves **both** models — GLM +3.4 pts (~1.5σ), Kimi +1.2 pts.
  - On **GPQA-Diamond** (n=198) the fix is +1.0 for GLM and −2.0 for Kimi, but the Kimi result is within ~1σ and reverses on the larger MATH-500 set — i.e. small-sample noise, not a regression.
  - **Net: consistent with the fix's intent, no real regression on either model.**

  <!-- comment: add your recommendation here -->

  <details>
  <summary>Setup / caveats</summary>

  - Serving: ATOM openai_server, TP4, `--kv_cache_dtype fp8`, chat-completions endpoint with `--apply_chat_template` (thinking template applied server-side).
  - MATH-500 via ungated `HuggingFaceH4/MATH-500`; GPQA-Diamond via ungated mirror `fingertap/GPQA-Diamond` (official `Idavidrein/gpqa` needs an HF token).
  - MATH-500 headline metric is `math_verify` (sympy equivalence). Minerva's `exact_match` reads 0.000 for all cells — it keys on a rigid `\boxed{}` string that free-form thinking output doesn't match, so it's not meaningful here.
  - Single run, greedy; ± is the metric's stderr.

  </details>

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

