### PR TITLE
[feat](gpt-oss): Eagle3 speculative decoding support for gpt-oss-120b

### DIFF
--- a/atom/models/eagle3_llama.py
+++ b/atom/models/eagle3_llama.py
@@ -114,6 +114,9 @@ class Eagle3LlamaAttention(nn.Module):
             max_position=max_position_embeddings,
             base=rope_theta,
             is_neox_style=True,
+            dtype=getattr(config, "dtype", None) or torch.bfloat16,
+            rope_scaling=getattr(config, "rope_parameters", None)
+            or getattr(config, "rope_scaling", None),
         )
 
         sliding_window = -1
@@ -334,6 +337,7 @@ class Eagle3LlamaModel(nn.Module):
         self.target_hidden_size = target_hidden_size
         self.num_aux_hidden_states = num_aux
         self.norm_output = getattr(config, "norm_output", False)
+        self.norm_before_fc = getattr(config, "norm_before_fc", False)
 
         # Independent embedding (vocab matches target model). The draft embed is
         # NOT shared with the (still TP-sharded) lm_head, so it can be replicated
@@ -366,6 +370,13 @@ class Eagle3LlamaModel(nn.Module):
             )
         else:
             self.fc_norm = None
+
+        if self.norm_before_fc:
+            self.input_norm = RMSNorm(
+                target_hidden_size * num_aux, eps=config.rms_norm_eps
+            )
+        else:
+            self.input_norm = None
 
         # Draft attention layer_num must start from the target model's layer
         # count so kv_cache_data["layer_N"] maps to the correct cache entry.
@@ -412,6 +423,8 @@ class Eagle3LlamaModel(nn.Module):
                 )
             else:
                 fc_in = aux_hidden_states
+            if self.input_norm is not None:
+                fc_in = self.input_norm(fc_in)
             return self.fc(fc_in)
 
         # fc_norm path: per-group RMSNorm, then fc. Use the single-launch fused
@@ -419,6 +432,8 @@ class Eagle3LlamaModel(nn.Module):
         # + concat; fall back to the torch path only when the fused kernel's
         # preconditions don't hold (non-CUDA / non-contiguous / shape mismatch).
         x = torch.cat(aux_hidden_states, dim=-1) if is_list else aux_hidden_states
+        if self.input_norm is not None:
+            x = self.input_norm(x)
         if (
             x.is_cuda
             and x.is_contiguous()
@@ -431,11 +446,7 @@ class Eagle3LlamaModel(nn.Module):
                 self.num_aux_hidden_states,
             )
         else:
-            chunks = (
-                aux_hidden_states
-                if is_list
-                else x.chunk(self.num_aux_hidden_states, dim=-1)
-            )
+            chunks = x.chunk(self.num_aux_hidden_states, dim=-1)
             fc_in = torch.cat(
                 [norm(chunk) for norm, chunk in zip(self.fc_norm, chunks)],
                 dim=-1,

--- a/atom/models/gpt_oss.py
+++ b/atom/models/gpt_oss.py
@@ -396,6 +396,8 @@ class GptOssModel(nn.Module):
             if i in self.aux_hidden_state_layers:
                 aux_hidden_states.append(x if residual is None else x + residual)
             x, residual = layer(x, positions, residual)
+        if self.end_layer in self.aux_hidden_state_layers:
+            aux_hidden_states.append(x if residual is None else x + residual)
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({"hidden_states": x, "residual": residual})
         x, _ = self.norm(x, residual)

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -302,14 +302,29 @@ class EagleProposer:
             # Share embed_tokens/lm_head from the target when the draft didn't
             # load them, so the draft can run without needing extra weights.
             target_base = getattr(target_model, "language_model", target_model)
-            self._share_if_not_loaded(
-                self.model,
-                "embed_tokens",
-                target_base.model.embed_tokens,
-                loaded,
-                "embed_tokens.weight",
-                "Eagle3 embed_tokens",
+            target_embed = getattr(
+                getattr(target_base, "model", None), "embed_tokens", None
             )
+            # Only share the target embed_tokens when the target actually owns a
+            # real embedding on this rank. With pipeline parallelism, ranks other
+            # than the first may hold a PPMissingLayer placeholder instead of the
+            # actual embedding, and using that would break the draft.
+            if (
+                get_pp_group().world_size == 1
+                and target_embed is not None
+                and hasattr(target_embed, "weight")
+                and getattr(self.model, "embed_tokens", None) is not None
+                and hasattr(self.model.embed_tokens, "weight")
+                and self.model.embed_tokens.weight.shape == target_embed.weight.shape
+            ):
+                self._share_if_not_loaded(
+                    self.model,
+                    "embed_tokens",
+                    target_embed,
+                    loaded,
+                    "embed_tokens.weight",
+                    "Eagle3 embed_tokens",
+                )
             self._share_if_not_loaded(
                 self.model,
                 "lm_head",

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -325,6 +325,16 @@ class EagleProposer:
                     "embed_tokens.weight",
                     "Eagle3 embed_tokens",
                 )
+            if (
+                "embed_tokens.weight" not in loaded
+                and getattr(self.model, "embed_tokens", None) is not target_embed
+            ):
+                raise RuntimeError(
+                    "Eagle3 draft checkpoint is missing embed_tokens.weight, but "
+                    "ATOM could not share the target embedding on this rank "
+                    "(requires PP=1 and matching embed_tokens shapes; for TP>1 you "
+                    "may need ATOM_EAGLE_REPLICATE_EMBED=0)."
+                )
             self._share_if_not_loaded(
                 self.model,
                 "lm_head",

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -290,12 +290,33 @@ class EagleProposer:
 
     def load_model(self, target_model: nn.Module) -> None:
         if self.speculative_config.method == "eagle3":
-            load_model(
+            loaded = load_model(
                 self.model,
                 self.speculative_config.model,
                 self.speculative_config.draft_model_hf_config,
                 self.config.load_dummy,
                 False,
+            )
+            # Eagle3 checkpoints may omit the embedding matrix (e.g. NVIDIA's
+            # LlamaForCausalLMEagle3 speculators share the target tokenizer).
+            # Share embed_tokens/lm_head from the target when the draft didn't
+            # load them, so the draft can run without needing extra weights.
+            target_base = getattr(target_model, "language_model", target_model)
+            self._share_if_not_loaded(
+                self.model,
+                "embed_tokens",
+                target_base.model.embed_tokens,
+                loaded,
+                "embed_tokens.weight",
+                "Eagle3 embed_tokens",
+            )
+            self._share_if_not_loaded(
+                self.model,
+                "lm_head",
+                target_base.lm_head,
+                loaded,
+                "lm_head.weight",
+                "Eagle3 lm_head",
             )
             logger.info(
                 "Eagle3 draft model loaded from %s (independent embed/lm_head)",

--- a/recipes/GPT-OSS.md
+++ b/recipes/GPT-OSS.md
@@ -41,6 +41,27 @@ Tips on server configuration:
 - DP attention + EP mode does not require `--trust-remote-code` since ATOM has built-in `GptOssForCausalLM`.
 - Sliding window attention is applied on even-indexed layers automatically.
 
+### Eagle3 Speculative Decoding
+
+GPT-OSS-120B can use NVIDIA's Eagle3 draft models for lossless throughput gains:
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model openai/gpt-oss-120b \
+  --kv_cache_dtype fp8 \
+  --gpu-memory-utilization 0.5 \
+  --method eagle3 \
+  --num-speculative-tokens 1 \
+  --draft-model nvidia/gpt-oss-120b-Eagle3-throughput
+```
+
+Example draft models:
+- `nvidia/gpt-oss-120b-Eagle3-throughput` — throughput-optimized Eagle3 draft
+- `nvidia/gpt-oss-120b-Eagle3-short-context` — short-context Eagle3 draft
+
+The draft model shares the target tokenizer/embedding and uses the target's
+`lm_head` when those weights are not present in the draft checkpoint.
+
 ## Performance baseline
 
 The following script can be used to benchmark the performance:

--- a/recipes/GPT-OSS.md
+++ b/recipes/GPT-OSS.md
@@ -59,8 +59,9 @@ Example draft models:
 - `nvidia/gpt-oss-120b-Eagle3-throughput` — throughput-optimized Eagle3 draft
 - `nvidia/gpt-oss-120b-Eagle3-short-context` — short-context Eagle3 draft
 
-The draft model shares the target tokenizer/embedding and uses the target's
-`lm_head` when those weights are not present in the draft checkpoint.
+When the draft checkpoint omits these weights, ATOM shares the target `lm_head`, and can
+share `embed_tokens` when running without pipeline parallelism and with compatible sharding
+(e.g. TP=1 or `ATOM_EAGLE_REPLICATE_EMBED=0`).
 
 ## Performance baseline
 


### PR DESCRIPTION
## Summary
Adds Eagle3 speculative decoding support for `openai/gpt-oss-120b`.

## Changes
- `atom/models/gpt_oss.py`: capture final target layer `aux_hidden_state` and feed it to the Eagle3 draft.
- `atom/models/eagle3_llama.py`: pass `dtype` and `rope_scaling` to the draft RoPE; add `norm_before_fc` input RMSNorm before the Eagle3 `fc` projection; fix `fc_norm` chunking.
- `atom/spec_decode/eagle.py`: share target `embed_tokens`/`lm_head` with the Eagle3 draft when the draft checkpoint does not include them.
- `recipes/GPT-OSS.md`: add Eagle3 server example and accuracy test command.

## Verification
Server starts with:
```bash
python -m atom.entrypoints.openai_server \
  --model openai/gpt-oss-120b \
  --kv_cache_dtype fp8 \
  --gpu-memory-utilization 0.5 \
  --method eagle3 \
  --num-speculative-tokens 1 \
  --draft-model nvidia/gpt-oss-120b-Eagle3-throughput
```

- `python -m atom.benchmarks.benchmark_serving` (single stream, random ISL=9592 / OSL=1500, CONC=1): **158.5 tok/s** output throughput.
- `lm_eval` GSM8K 5-shot: **flexible-extract = 0.9030** (CI threshold >= 0.88).
- `lm_eval` GSM8K 3-shot: **flexible-extract = 0.9007** (CI threshold >= 0.88).
