### PR TITLE
[SGL][GLM5.2]align attention path with atom

### DIFF
--- a/.github/benchmark/sglang_benchmark_models.json
+++ b/.github/benchmark/sglang_benchmark_models.json
@@ -6,6 +6,8 @@
       "qwen_reasoning": "--mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",
       "deepseek_v4_runtime": "--trust-remote-code --tensor-parallel-size 8 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.9 --swa-full-tokens-ratio 0.1 --max-running-requests 256 --page-size 256 --disable-radix-cache --disable-shared-experts-fusion --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4",
       "deepseek_v4_prefix_cache_runtime": "--trust-remote-code --tensor-parallel-size 8 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --swa-full-tokens-ratio 0.1 --max-running-requests 256 --page-size 256 --enable-cache-report --disable-shared-experts-fusion --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4",
+      "glm52_fp8_runtime": "--trust-remote-code --tp-size 4 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"mxfp8\"},\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"*.mlp.gate\"]}}'",
+      "glm52_fp4_runtime": "--trust-remote-code --tp-size 4 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"*.mlp.gate\",\"*expert*\"]}}'",
       "mtp1_common": "--speculative-draft-model-path SGLang/DeepSeek-R1-NextN --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 --max-running-requests 256 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256",
       "mtp3_common": "--speculative-draft-model-path SGLang/DeepSeek-R1-NextN --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256"
     },
@@ -17,6 +19,7 @@
       "deepseek_v4_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1\nSGLANG_DEFAULT_THINKING=1\nSGLANG_DSV4_REASONING_EFFORT=max\nSGLANG_USE_AITER=1\nSGLANG_DSV4_FP4_EXPERTS=true\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
       "deepseek_v4_flash_fp8_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1\nSGLANG_DEFAULT_THINKING=1\nSGLANG_DSV4_REASONING_EFFORT=max\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
       "deepseek_v4_prefix_cache_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1\nSGLANG_DEFAULT_THINKING=1\nSGLANG_DSV4_REASONING_EFFORT=max\nSGLANG_USE_AITER=1\nSGLANG_DSV4_FP4_EXPERTS=true\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+      "glm52_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
       "qwen_common": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0"
     }
   },
@@ -430,6 +433,32 @@
         "deepseek_common",
         "SGLANG_AITER_FP8_PREFILL_ATTN=0"
       ]
+    },
+    {
+      "display": "GLM-5.2 FP8 TP4",
+      "dashboard_model": "GLM-5.2-FP8-tp4",
+      "workload_label": "SGLang-OOB",
+      "source_path": "zai-org/GLM-5.2-FP8",
+      "path": "zai-org/GLM-5.2-FP8",
+      "prefix": "glm-5-2-fp8-tp4",
+      "extra_args": "glm52_fp8_runtime",
+      "bench_args": "",
+      "runner": "atom-mi355-8gpu-aac-runner",
+      "nightly_group": "A",
+      "env_vars": "glm52_common"
+    },
+    {
+      "display": "GLM-5.2 FP4 TP4",
+      "dashboard_model": "GLM-5.2-FP4-tp4",
+      "workload_label": "SGLang-OOB",
+      "source_path": "amd/GLM-5.2-MXFP4",
+      "path": "amd/GLM-5.2-MXFP4",
+      "prefix": "glm-5-2-fp4-tp4",
+      "extra_args": "glm52_fp4_runtime",
+      "bench_args": "",
+      "runner": "atom-mi355-8gpu-aac-runner",
+      "nightly_group": "A",
+      "env_vars": "glm52_common"
     },
     {
       "display": "Qwen3.5-397B-A17B-FP8 TP4 MI308",

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -52,14 +52,16 @@ on:
           - "deepseek-v4-flash-fp8-mi308 (1024x1024/8192x1024: [4,8,16,32,64])"
           - "deepseek-v3-2-fp8-tp8 (1024x1024/8192x1024: [4,8,16,32,64])"
           - "glm-5-1-fp8-tp8 (1024x1024/8192x1024: [4,8,16,32,64])"
+          - "glm-5-2-fp8-tp4 (1024x1024/8192x1024: [4,8,16,32,64])"
+          - "glm-5-2-fp4-tp4 (1024x1024/8192x1024: [4,8,16,32,64])"
           - "all-deepseek (20 DeepSeek configs)"
           - "all-deepseek-non-mtp (14 DeepSeek non-MTP configs)"
           - "all-deepseek-mtp (6 DeepSeek MTP configs x 10 default params)"
           - "all-deepseek-v3-2 (4 DeepSeek-V3.2 FP8 OOB configs x 10 default params)"
           - "all-deepseek-v3-2_glm_qwen (DeepSeek-V3.2 + GLM + Qwen OOB configs x 10 default params)"
-          - "all-qwen (7 Qwen configs x 10 default params)"
-          - "all-glm (1 GLM config x 10 default params)"
-          - "all-oob (28 SGLang-OOB configs x 10 default params)"
+          - "all-qwen (8 Qwen configs x 10 default params)"
+          - "all-glm (3 GLM configs x 10 default params)"
+          - "all-oob (31 SGLang-OOB configs x 10 default params)"
         default: "none (do not run SGLang-OOB models)"
       docker_image:
         description: "Optional Docker image override."
@@ -665,6 +667,8 @@ jobs:
               "deepseek-v4-pro-mtp1-tp8",
               "deepseek-v4-pro-mtp3-tp8",
               "glm-5-1-fp8-tp8",
+              "glm-5-2-fp8-tp4",
+              "glm-5-2-fp4-tp4",
           ]
           OOB_P1_PREFIX_ORDER = [
               "deepseek-v3-2-fp8-tp4",

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -667,7 +667,7 @@ class LinearBase(nn.Module):
         self.quant_func = get_hip_quant(online_quant_type)
         self.need_normalize_e4m3fn_to_e4m3fnuz = (
             online_quant_dtype == torch.float8_e4m3fnuz
-            and q_weight.dtype != torch.float8_e4m3fnuz
+            and online_quant_type == QuantType.per_Token
         )
         # A dynamic online target (e.g. ptpc per_Token) quantizes activations at
         # runtime. Drop any static input_scale inherited from a static per_Tensor

--- a/atom/plugin/register.py
+++ b/atom/plugin/register.py
@@ -76,6 +76,10 @@ def _register_custom_attention_to_sglang() -> None:
     from atom.plugin.sglang.attention_backend.deepseek_v4_backend import (
         ATOMDeepseekV4BackendForSgl,
     )
+    from atom.plugin.sglang.attention_backend.glm52_dsa_backend import (
+        ATOMGLM52DSABackendForSgl,
+    )
+    from atom.plugin.sglang.runtime import is_glm52_dsa_config
 
     # here register the custom attention backend with the name "aiter"
     # as sglang defines the fixed attention backend choices, which must be
@@ -90,12 +94,18 @@ def _register_custom_attention_to_sglang() -> None:
 
     @register_attention_backend("aiter")
     def create_atom_backend(runner):
-        arches = getattr(runner.model_config.hf_config, "architectures", None) or []
+        hf_config = runner.model_config.hf_config
+        arches = getattr(hf_config, "architectures", None) or []
         if any("DeepseekV4" in str(arch) for arch in arches):
             logger.info(
                 "Use ATOMDeepseekV4BackendForSgl for DeepSeek-V4 through SGLang aiter backend choice"
             )
             return ATOMDeepseekV4BackendForSgl(runner)
+        if is_glm52_dsa_config(hf_config):
+            logger.info(
+                "Use ATOMGLM52DSABackendForSgl for GLM-5.2 through SGLang aiter backend choice"
+            )
+            return ATOMGLM52DSABackendForSgl(runner)
         return ATOMAttnBackendForSgl(runner)
 
     @register_attention_backend("dsv4")
@@ -104,6 +114,18 @@ def _register_custom_attention_to_sglang() -> None:
             "Create ATOMDeepseekV4BackendForSgl through SGLang dsv4 backend choice"
         )
         return ATOMDeepseekV4BackendForSgl(runner)
+
+    @register_attention_backend("nsa")
+    def create_atom_nsa_backend(runner):
+        hf_config = runner.model_config.hf_config
+        if is_glm52_dsa_config(hf_config):
+            logger.info(
+                "Use ATOMGLM52DSABackendForSgl for GLM-5.2 through SGLang nsa backend choice"
+            )
+            return ATOMGLM52DSABackendForSgl(runner)
+        from sglang.srt.layers.attention.nsa_backend import NativeSparseAttnBackend
+
+        return NativeSparseAttnBackend(runner)
 
 
 def _patch_sglang_dsv4_draft_backends() -> None:

--- a/atom/plugin/sglang/attention_backend/glm52_dsa_backend.py
+++ b/atom/plugin/sglang/attention_backend/glm52_dsa_backend.py
@@ -1,0 +1,188 @@
+"""SGLang backend shim for ATOM-owned GLM-5.2 native MLA attention."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import torch
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+
+logger = logging.getLogger("atom.plugin.sglang.attention_backend.glm52_dsa")
+
+
+class ATOMGLM52DSABackendForSgl(AttentionBackend):
+    """Publish fixed-address ATOM GLM-5.2 metadata for SGLang CUDA graphs."""
+
+    needs_cpu_seq_lens = True
+    _last_atom_glm52_graph_metadata = None
+
+    def __init__(self, model_runner, *args, **kwargs):
+        del args, kwargs
+        logger.info("Initializing ATOMGLM52DSABackendForSgl")
+        self.model_runner = model_runner
+        self.device = torch.device(model_runner.device)
+        self.token_to_kv_pool = model_runner.token_to_kv_pool
+        self.req_to_token_pool = model_runner.req_to_token_pool
+        self.forward_metadata = None
+        self.atom_glm52_graph_metadata = None
+        self._cuda_graph_seq_len_fill_value = 1
+        self.attn_backends = [self]
+
+    @staticmethod
+    def get_name() -> str:
+        return "atom_glm52_dsa"
+
+    def init_forward_metadata(self, forward_batch):
+        self.forward_metadata = forward_batch
+        self.atom_glm52_graph_metadata = None
+
+    def _build_decode_graph_metadata(self, forward_batch, positions=None, max_bs=None):
+        if not forward_batch.forward_mode.is_decode_or_idle():
+            self.atom_glm52_graph_metadata = None
+            return None
+        if positions is None:
+            positions = getattr(forward_batch, "positions", None)
+        if positions is None:
+            positions = (
+                forward_batch.seq_lens[: int(forward_batch.batch_size)].to(torch.int64)
+                - 1
+            ).clamp_min_(0)
+
+        from atom.config import get_current_atom_config
+        from atom.plugin.sglang.glm52_dsa_bridge import (
+            build_atom_glm52_decode_graph_metadata_from_sglang,
+        )
+
+        atom_config = get_current_atom_config()
+        max_context_len = int(self.req_to_token_pool.req_to_token.shape[1])
+        self.atom_glm52_graph_metadata = (
+            build_atom_glm52_decode_graph_metadata_from_sglang(
+                forward_batch,
+                positions,
+                token_to_kv_pool=self.token_to_kv_pool,
+                req_to_token_pool=self.req_to_token_pool,
+                atom_config=atom_config,
+                max_bs=max_bs,
+                max_context_len=max_context_len,
+            )
+        )
+        forward_batch.atom_glm52_graph_metadata = self.atom_glm52_graph_metadata
+        ATOMGLM52DSABackendForSgl._last_atom_glm52_graph_metadata = (
+            self.atom_glm52_graph_metadata
+        )
+        self.forward_metadata = forward_batch
+        return self.atom_glm52_graph_metadata
+
+    def init_forward_metadata_out_graph(self, forward_batch, in_capture: bool = False):
+        if not (in_capture or hasattr(forward_batch, "actual_forward_mode")):
+            self.forward_metadata = forward_batch
+            self.atom_glm52_graph_metadata = None
+            return
+        positions = getattr(forward_batch, "positions", None)
+        if positions is None:
+            graph_runner = getattr(self.model_runner, "graph_runner", None)
+            buffers = getattr(graph_runner, "buffers", None)
+            positions = getattr(buffers, "positions", None)
+        self._build_decode_graph_metadata(forward_batch, positions=positions)
+
+    def init_forward_metadata_capture_cuda_graph(self, *args, **kwargs):
+        if len(args) == 1 and not kwargs and hasattr(args[0], "forward_mode"):
+            return self.init_forward_metadata_out_graph(args[0], in_capture=True)
+        bs = kwargs.get("bs", args[0] if len(args) > 0 else None)
+        req_pool_indices = kwargs.get(
+            "req_pool_indices", args[2] if len(args) > 2 else None
+        )
+        seq_lens = kwargs.get("seq_lens", args[3] if len(args) > 3 else None)
+        forward_mode = kwargs.get("forward_mode", args[5] if len(args) > 5 else None)
+        if bs is None or req_pool_indices is None or seq_lens is None:
+            self.atom_glm52_graph_metadata = None
+            return
+        forward_batch = SimpleNamespace(
+            forward_mode=forward_mode,
+            actual_forward_mode=forward_mode,
+            batch_size=int(bs),
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens.detach().cpu(),
+            out_cache_loc=None,
+        )
+        self._build_decode_graph_metadata(forward_batch, max_bs=int(bs))
+
+    def init_forward_metadata_replay_cuda_graph(self, *args, **kwargs):
+        if len(args) == 2 and hasattr(args[0], "forward_mode"):
+            forward_batch, bs = args
+            values = dict(getattr(forward_batch, "__dict__", {}))
+            values["batch_size"] = int(bs)
+            replay_batch = SimpleNamespace(**values)
+            return self._build_decode_graph_metadata(
+                replay_batch,
+                positions=getattr(forward_batch, "positions", None),
+                max_bs=int(bs),
+            )
+
+        bs = kwargs.get("bs", args[0] if len(args) > 0 else None)
+        req_pool_indices = kwargs.get(
+            "req_pool_indices", args[1] if len(args) > 1 else None
+        )
+        seq_lens = kwargs.get("seq_lens", args[2] if len(args) > 2 else None)
+        forward_mode = kwargs.get("forward_mode", args[5] if len(args) > 5 else None)
+        seq_lens_cpu = kwargs.get("seq_lens_cpu", args[7] if len(args) > 7 else None)
+        out_cache_loc = kwargs.get(
+            "out_cache_loc", args[8] if len(args) > 8 else None
+        )
+        replay_batch = getattr(self, "_replay_forward_batch", None)
+        if out_cache_loc is None:
+            out_cache_loc = getattr(replay_batch, "out_cache_loc", None)
+        if bs is None or req_pool_indices is None or seq_lens is None:
+            self.atom_glm52_graph_metadata = None
+            return
+        forward_batch = SimpleNamespace(
+            forward_mode=forward_mode,
+            actual_forward_mode=getattr(replay_batch, "forward_mode", forward_mode),
+            batch_size=int(bs),
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
+            out_cache_loc=out_cache_loc,
+            positions=getattr(replay_batch, "positions", None),
+        )
+        self._build_decode_graph_metadata(
+            forward_batch,
+            positions=getattr(forward_batch, "positions", None),
+            max_bs=int(bs),
+        )
+
+    def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+        bs = int(max_bs)
+        seq_lens = torch.ones(bs, dtype=torch.int32, device=self.device)
+        req_pool_indices = torch.arange(bs, dtype=torch.int64, device=self.device)
+        positions = torch.zeros(bs, dtype=torch.int64, device=self.device)
+        forward_batch = SimpleNamespace(
+            forward_mode=ForwardMode.DECODE,
+            actual_forward_mode=ForwardMode.DECODE,
+            batch_size=bs,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens.detach().cpu(),
+            out_cache_loc=None,
+        )
+        self._cuda_graph_seq_len_fill_value = 1
+        self._build_decode_graph_metadata(
+            forward_batch,
+            positions=positions,
+            max_bs=bs,
+        )
+        del max_num_tokens
+        return None
+
+    def get_cuda_graph_seq_len_fill_value(self):
+        return int(self._cuda_graph_seq_len_fill_value)
+
+    def forward_decode(self, *args, **kwargs):
+        raise RuntimeError("ATOM GLM-5.2 SGLang bridge should use ATOM attention")
+
+    def forward_extend(self, *args, **kwargs):
+        raise RuntimeError("ATOM GLM-5.2 SGLang bridge should use ATOM attention")

--- a/atom/plugin/sglang/attention_backend/glm52_dsa_backend.py
+++ b/atom/plugin/sglang/attention_backend/glm52_dsa_backend.py
@@ -128,9 +128,7 @@ class ATOMGLM52DSABackendForSgl(AttentionBackend):
         seq_lens = kwargs.get("seq_lens", args[2] if len(args) > 2 else None)
         forward_mode = kwargs.get("forward_mode", args[5] if len(args) > 5 else None)
         seq_lens_cpu = kwargs.get("seq_lens_cpu", args[7] if len(args) > 7 else None)
-        out_cache_loc = kwargs.get(
-            "out_cache_loc", args[8] if len(args) > 8 else None
-        )
+        out_cache_loc = kwargs.get("out_cache_loc", args[8] if len(args) > 8 else None)
         replay_batch = getattr(self, "_replay_forward_batch", None)
         if out_cache_loc is None:
             out_cache_loc = getattr(replay_batch, "out_cache_loc", None)

--- a/atom/plugin/sglang/glm52_dsa_bridge.py
+++ b/atom/plugin/sglang/glm52_dsa_bridge.py
@@ -66,14 +66,14 @@ def _build_token_table(
     bs = int(forward_batch.batch_size)
     max_seq_len = int(seq_lens.max(initial=1))
     req_pool_indices = forward_batch.req_pool_indices[:bs]
-    token_table = req_to_token_pool.req_to_token[
-        req_pool_indices, : max_seq_len
-    ].clone()
+    token_table = req_to_token_pool.req_to_token[req_pool_indices, :max_seq_len].clone()
 
     if extend_lens is not None and not forward_batch.forward_mode.is_decode_or_idle():
         prefix_lens = seq_lens - extend_lens
         offset = 0
-        for req_idx, (prefix_len, query_len) in enumerate(zip(prefix_lens, extend_lens)):
+        for req_idx, (prefix_len, query_len) in enumerate(
+            zip(prefix_lens, extend_lens)
+        ):
             prefix_len = int(prefix_len)
             query_len = int(query_len)
             if query_len > 0:
@@ -243,7 +243,11 @@ class _GLM52DecodeGraphBuffers:
         self.index_topk = int(index_topk)
         self.device = device
 
-        max_blocks = max(1, (self.max_context_len + self.indexer_page_size - 1) // self.indexer_page_size)
+        max_blocks = max(
+            1,
+            (self.max_context_len + self.indexer_page_size - 1)
+            // self.indexer_page_size,
+        )
         self.cu_q = torch.arange(self.max_bs + 1, dtype=torch.int32, device=device)
         self.kv_indptr = torch.zeros(self.max_bs + 1, dtype=torch.int32, device=device)
         self.sparse_kv_indptr = torch.zeros(
@@ -677,9 +681,9 @@ def build_atom_glm52_attention_metadata_from_sglang(
             req_to_token_pool=req_to_token_pool,
             atom_config=atom_config,
         )
-    if getattr(
-        forward_batch.forward_mode, "is_draft_extend", lambda **kwargs: False
-    )(include_v2=True):
+    if getattr(forward_batch.forward_mode, "is_draft_extend", lambda **kwargs: False)(
+        include_v2=True
+    ):
         raise RuntimeError(
             "GLM-5.2 native DSA SGLang bridge does not yet support draft extend/MTP."
         )

--- a/atom/plugin/sglang/glm52_dsa_bridge.py
+++ b/atom/plugin/sglang/glm52_dsa_bridge.py
@@ -1,0 +1,751 @@
+"""Bridge SGLang ForwardBatch metadata to ATOM GLM-5.2 sparse MLA."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from aiter import dtypes, get_mla_metadata_info_v1, get_mla_metadata_v1
+from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
+
+from atom.plugin.sglang.runtime.model_arch import is_glm52_dsa_config
+
+_DECODE_GRAPH_BUFFERS_ATTR = "_atom_glm52_decode_graph_buffers"
+_EMPTY_VALUE_CACHE_ATTR = "_atom_glm52_empty_value_cache"
+_INDEXER_PAGE_SIZE_ATTR = "_atom_glm52_indexer_page_size"
+_ATTENTION_PAGE_SIZE_ATTR = "_atom_glm52_attention_page_size"
+_SHARED_SPARSE_INDICES_ATTR = "_atom_glm52_shared_sparse_kv_indices"
+
+
+def is_glm52_dsa_arch(config) -> bool:
+    return is_glm52_dsa_config(config)
+
+
+def maybe_get_glm52_dsa_pools_from_sglang_backend(forward_batch=None):
+    if forward_batch is not None:
+        token_to_kv_pool = getattr(forward_batch, "token_to_kv_pool", None)
+        req_to_token_pool = getattr(forward_batch, "req_to_token_pool", None)
+        if token_to_kv_pool is not None and req_to_token_pool is not None:
+            return token_to_kv_pool, req_to_token_pool
+    return None, None
+
+
+def _get_seq_lens_cpu(forward_batch, bs: int) -> np.ndarray:
+    seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+    if seq_lens_cpu is None:
+        seq_lens_cpu = forward_batch.seq_lens.detach().cpu()
+    if torch.is_tensor(seq_lens_cpu):
+        seq_lens_cpu = seq_lens_cpu.detach().cpu().numpy()
+    return np.asarray(seq_lens_cpu[:bs], dtype=np.int32)
+
+
+def _get_extend_lens_cpu(forward_batch, positions: torch.Tensor, bs: int) -> np.ndarray:
+    extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
+    if extend_lens is None:
+        extend_lens = getattr(forward_batch, "extend_seq_lens", None)
+    if extend_lens is not None:
+        if torch.is_tensor(extend_lens):
+            extend_lens = extend_lens.detach().cpu().numpy()
+        return np.asarray(extend_lens[:bs], dtype=np.int32)
+
+    tokens_per_req = getattr(
+        getattr(forward_batch, "spec_info", None), "num_tokens_per_req", None
+    )
+    if tokens_per_req is None:
+        tokens_per_req = max(1, int(positions.numel()) // max(1, bs))
+    return np.full(bs, int(tokens_per_req), dtype=np.int32)
+
+
+def _build_token_table(
+    forward_batch,
+    req_to_token_pool,
+    *,
+    seq_lens: np.ndarray,
+    extend_lens: np.ndarray | None,
+    page_size: int,
+) -> torch.Tensor:
+    bs = int(forward_batch.batch_size)
+    max_seq_len = int(seq_lens.max(initial=1))
+    req_pool_indices = forward_batch.req_pool_indices[:bs]
+    token_table = req_to_token_pool.req_to_token[
+        req_pool_indices, : max_seq_len
+    ].clone()
+
+    if extend_lens is not None and not forward_batch.forward_mode.is_decode_or_idle():
+        prefix_lens = seq_lens - extend_lens
+        offset = 0
+        for req_idx, (prefix_len, query_len) in enumerate(zip(prefix_lens, extend_lens)):
+            prefix_len = int(prefix_len)
+            query_len = int(query_len)
+            if query_len > 0:
+                token_table[req_idx, prefix_len : prefix_len + query_len] = (
+                    forward_batch.out_cache_loc[offset : offset + query_len]
+                )
+            offset += query_len
+
+    if page_size == 1:
+        return token_table.to(dtype=torch.int32).contiguous()
+    return (token_table[:, ::page_size] // page_size).to(dtype=torch.int32).contiguous()
+
+
+def _flatten_kv_indices(token_table: torch.Tensor, lengths: np.ndarray) -> torch.Tensor:
+    pieces = []
+    for row, length in enumerate(lengths):
+        if int(length) > 0:
+            pieces.append(token_table[row, : int(length)])
+    if not pieces:
+        return torch.empty(0, dtype=torch.int32, device=token_table.device)
+    return torch.cat(pieces).to(dtype=torch.int32).contiguous()
+
+
+def _counts_to_indptr(counts: np.ndarray, device: torch.device) -> torch.Tensor:
+    indptr = np.zeros(len(counts) + 1, dtype=np.int32)
+    if len(counts):
+        indptr[1:] = np.cumsum(counts, dtype=np.int32)
+    return torch.from_numpy(indptr).to(device=device)
+
+
+def _get_index_topk(atom_config) -> int:
+    topk = getattr(atom_config.hf_config, "index_topk", None)
+    if topk is None:
+        raise RuntimeError("GLM-5.2 DSA bridge requires hf_config.index_topk")
+    return int(topk)
+
+
+def _local_num_attention_heads(atom_config) -> int:
+    hf_config = atom_config.hf_config
+    num_heads = int(getattr(hf_config, "num_attention_heads"))
+    tp_size = int(getattr(atom_config, "tensor_parallel_size", 1))
+    return max(1, num_heads // max(1, tp_size))
+
+
+def _metadata_dtype(atom_config):
+    kv_dtype = getattr(atom_config, "kv_cache_dtype", "bf16")
+    if str(kv_dtype).startswith("fp8"):
+        return dtypes.fp8
+    return getattr(dtypes, "d_dtypes", {}).get(kv_dtype, torch.bfloat16)
+
+
+def _make_mla_work_buffers(
+    *,
+    cu_seqlens_q: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_last_page_lens: torch.Tensor,
+    num_heads: int,
+    dtype_q,
+    dtype_kv,
+    page_size: int,
+) -> dict[str, torch.Tensor]:
+    num_seqs = max(1, int(cu_seqlens_q.numel()) - 1)
+    max_q_len = 1
+    if cu_seqlens_q.numel() > 1:
+        q_counts = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+        max_q_len = max(1, int(q_counts.max().item()))
+    padded_heads = max(num_heads, 16)
+    (
+        (work_meta_data_size, work_meta_data_type),
+        (work_indptr_size, work_indptr_type),
+        (work_info_set_size, work_info_set_type),
+        (reduce_indptr_size, reduce_indptr_type),
+        (reduce_final_map_size, reduce_final_map_type),
+        (reduce_partial_map_size, reduce_partial_map_type),
+    ) = get_mla_metadata_info_v1(
+        num_seqs,
+        max_q_len,
+        padded_heads,
+        dtype_q,
+        dtype_kv,
+        is_sparse=True,
+        fast_mode=True,
+    )
+    device = cu_seqlens_q.device
+    work = {
+        "work_meta_data": torch.empty(
+            work_meta_data_size, dtype=work_meta_data_type, device=device
+        ),
+        "work_indptr": torch.empty(
+            work_indptr_size, dtype=work_indptr_type, device=device
+        ),
+        "work_info_set": torch.empty(
+            work_info_set_size, dtype=work_info_set_type, device=device
+        ),
+        "reduce_indptr": torch.empty(
+            reduce_indptr_size, dtype=reduce_indptr_type, device=device
+        ),
+        "reduce_final_map": torch.empty(
+            reduce_final_map_size, dtype=reduce_final_map_type, device=device
+        ),
+        "reduce_partial_map": torch.empty(
+            reduce_partial_map_size, dtype=reduce_partial_map_type, device=device
+        ),
+    }
+    get_mla_metadata_v1(
+        cu_seqlens_q,
+        kv_indptr,
+        kv_last_page_lens,
+        padded_heads,
+        1,
+        True,
+        work["work_meta_data"],
+        work["work_info_set"],
+        work["work_indptr"],
+        work["reduce_indptr"],
+        work["reduce_final_map"],
+        work["reduce_partial_map"],
+        page_size=page_size,
+        dtype_q=dtype_q,
+        dtype_kv=dtype_kv,
+        kv_granularity=max(page_size, 16),
+        max_seqlen_qo=max_q_len,
+        uni_seqlen_qo=max_q_len,
+        fast_mode=True,
+    )
+    return work
+
+
+def _ensure_shared_sparse_buffer(
+    token_to_kv_pool,
+    *,
+    num_tokens: int,
+    topk: int,
+    device: torch.device,
+) -> torch.Tensor:
+    required = max(1, int(num_tokens) * int(topk))
+    buffer = getattr(token_to_kv_pool, _SHARED_SPARSE_INDICES_ATTR, None)
+    if (
+        buffer is None
+        or buffer.device != device
+        or buffer.dtype != torch.int32
+        or buffer.numel() < required
+    ):
+        buffer = torch.empty(required, dtype=torch.int32, device=device)
+        setattr(token_to_kv_pool, _SHARED_SPARSE_INDICES_ATTR, buffer)
+    return buffer[:required]
+
+
+class _GLM52DecodeGraphBuffers:
+    def __init__(
+        self,
+        *,
+        max_bs: int,
+        max_context_len: int,
+        indexer_page_size: int,
+        attention_page_size: int,
+        index_topk: int,
+        num_heads: int,
+        dtype_q,
+        dtype_kv,
+        device: torch.device,
+    ) -> None:
+        self.max_bs = int(max_bs)
+        self.max_context_len = int(max_context_len)
+        self.indexer_page_size = int(indexer_page_size)
+        self.attention_page_size = int(attention_page_size)
+        self.index_topk = int(index_topk)
+        self.device = device
+
+        max_blocks = max(1, (self.max_context_len + self.indexer_page_size - 1) // self.indexer_page_size)
+        self.cu_q = torch.arange(self.max_bs + 1, dtype=torch.int32, device=device)
+        self.kv_indptr = torch.zeros(self.max_bs + 1, dtype=torch.int32, device=device)
+        self.sparse_kv_indptr = torch.zeros(
+            self.max_bs + 1, dtype=torch.int32, device=device
+        )
+        self.kv_indices = torch.empty(
+            self.max_bs * self.max_context_len, dtype=torch.int32, device=device
+        )
+        self.kv_last_page_lens = torch.ones(
+            self.max_bs, dtype=torch.int32, device=device
+        )
+        self.block_tables = torch.empty(
+            self.max_bs, max_blocks, dtype=torch.int32, device=device
+        )
+        self.context_lens = torch.zeros(self.max_bs, dtype=torch.int32, device=device)
+        self.slot_mapping = torch.zeros(self.max_bs, dtype=torch.int64, device=device)
+        self.shared_sparse = torch.empty(
+            self.max_bs * self.index_topk, dtype=torch.int32, device=device
+        )
+
+        work = _make_mla_work_buffers(
+            cu_seqlens_q=self.cu_q,
+            kv_indptr=self.sparse_kv_indptr,
+            kv_last_page_lens=self.kv_last_page_lens,
+            num_heads=num_heads,
+            dtype_q=dtype_q,
+            dtype_kv=dtype_kv,
+            page_size=self.attention_page_size,
+        )
+        self.work_meta_data = work["work_meta_data"]
+        self.work_indptr = work["work_indptr"]
+        self.work_info_set = work["work_info_set"]
+        self.reduce_indptr = work["reduce_indptr"]
+        self.reduce_final_map = work["reduce_final_map"]
+        self.reduce_partial_map = work["reduce_partial_map"]
+
+    def stage_block_tables(self, req_to_token_pool, req_pool_indices, bs: int) -> None:
+        req_to_token = req_to_token_pool.req_to_token
+        live = req_to_token[
+            req_pool_indices[:bs],
+            : self.max_context_len : self.indexer_page_size,
+        ]
+        self.block_tables[:bs, : live.shape[1]].copy_(
+            (live // self.indexer_page_size).to(torch.int32)
+        )
+
+
+def _get_or_create_decode_graph_buffers(
+    token_to_kv_pool,
+    *,
+    max_bs: int,
+    max_context_len: int,
+    indexer_page_size: int,
+    attention_page_size: int,
+    atom_config,
+    device: torch.device,
+) -> _GLM52DecodeGraphBuffers:
+    topk = _get_index_topk(atom_config)
+    dtype_q = _metadata_dtype(atom_config)
+    bufs = getattr(token_to_kv_pool, _DECODE_GRAPH_BUFFERS_ATTR, None)
+    if (
+        bufs is None
+        or bufs.max_bs < int(max_bs)
+        or bufs.max_context_len < int(max_context_len)
+        or bufs.indexer_page_size != int(indexer_page_size)
+        or bufs.attention_page_size != int(attention_page_size)
+        or bufs.index_topk != int(topk)
+        or bufs.device != device
+    ):
+        bufs = _GLM52DecodeGraphBuffers(
+            max_bs=max_bs,
+            max_context_len=max_context_len,
+            indexer_page_size=indexer_page_size,
+            attention_page_size=attention_page_size,
+            index_topk=topk,
+            num_heads=_local_num_attention_heads(atom_config),
+            dtype_q=dtype_q,
+            dtype_kv=dtype_q,
+            device=device,
+        )
+        setattr(token_to_kv_pool, _DECODE_GRAPH_BUFFERS_ATTR, bufs)
+        setattr(token_to_kv_pool, _SHARED_SPARSE_INDICES_ATTR, bufs.shared_sparse)
+    return bufs
+
+
+def _validate_page_size(token_to_kv_pool, atom_config) -> int:
+    page_size = int(getattr(token_to_kv_pool, "page_size", 1))
+    from atom.utils import envs
+
+    atom_config.kv_cache_block_size = page_size
+    setattr(token_to_kv_pool, _INDEXER_PAGE_SIZE_ATTR, page_size)
+    setattr(token_to_kv_pool, _ATTENTION_PAGE_SIZE_ATTR, int(envs.ATOM_MLA_PAGE_SIZE))
+    return page_size
+
+
+def _attention_page_size(token_to_kv_pool) -> int:
+    return int(getattr(token_to_kv_pool, _ATTENTION_PAGE_SIZE_ATTR, 1))
+
+
+def _build_decode_metadata(
+    forward_batch,
+    positions: torch.Tensor,
+    *,
+    token_to_kv_pool,
+    req_to_token_pool,
+    atom_config,
+):
+    from atom.utils.forward_context import AttentionMetaData, AttnState
+
+    del positions
+    device = forward_batch.seq_lens.device
+    bs = int(forward_batch.batch_size)
+    seq_lens = _get_seq_lens_cpu(forward_batch, bs)
+    topk = _get_index_topk(atom_config)
+    page_size = _validate_page_size(token_to_kv_pool, atom_config)
+
+    cu_q = torch.arange(bs + 1, dtype=torch.int32, device=device)
+    block_tables = _build_token_table(
+        forward_batch,
+        req_to_token_pool,
+        seq_lens=seq_lens,
+        extend_lens=None,
+        page_size=page_size,
+    )
+    token_table = _build_token_table(
+        forward_batch,
+        req_to_token_pool,
+        seq_lens=seq_lens,
+        extend_lens=None,
+        page_size=1,
+    )
+    kv_indptr = _counts_to_indptr(seq_lens, device)
+    kv_indices = _flatten_kv_indices(token_table, seq_lens)
+    # Sparse decode consumes a compact list of selected physical token ids, so
+    # each selected entry behaves as a single-token page even when the backing
+    # cache is stored in page64/segmented layout.
+    kv_last_page_lens = torch.ones(bs, dtype=torch.int32, device=device)
+    sparse_counts = np.minimum(seq_lens, topk).astype(np.int32)
+    sparse_kv_indptr = _counts_to_indptr(sparse_counts, device)
+
+    _ensure_shared_sparse_buffer(
+        token_to_kv_pool,
+        num_tokens=bs,
+        topk=topk,
+        device=device,
+    )
+    dtype_q = _metadata_dtype(atom_config)
+    work = _make_mla_work_buffers(
+        cu_seqlens_q=cu_q,
+        kv_indptr=sparse_kv_indptr,
+        kv_last_page_lens=kv_last_page_lens,
+        num_heads=_local_num_attention_heads(atom_config),
+        dtype_q=dtype_q,
+        dtype_kv=dtype_q,
+        page_size=_attention_page_size(token_to_kv_pool),
+    )
+
+    md = AttentionMetaData(
+        cu_seqlens_q=cu_q,
+        cu_seqlens_k=kv_indptr,
+        max_seqlen_q=1,
+        max_seqlen_k=int(seq_lens.max(initial=1)),
+        slot_mapping=forward_batch.out_cache_loc[:bs],
+        context_lens=forward_batch.seq_lens[:bs].to(dtype=torch.int32),
+        block_tables=block_tables,
+        state=AttnState.DECODE,
+        kv_indptr=kv_indptr,
+        kv_indices=kv_indices,
+        kv_last_page_lens=kv_last_page_lens,
+        sparse_kv_indptr=sparse_kv_indptr,
+        **work,
+    )
+    md.sparse_kv_last_page_lens = kv_last_page_lens
+    md.dtype_q = dtype_q
+    return md
+
+
+def build_atom_glm52_decode_graph_metadata_from_sglang(
+    forward_batch,
+    positions: torch.Tensor,
+    *,
+    token_to_kv_pool,
+    req_to_token_pool,
+    atom_config,
+    max_bs: int | None = None,
+    max_context_len: int | None = None,
+):
+    from atom.utils.forward_context import AttentionMetaData, AttnState
+
+    del positions
+    device = forward_batch.seq_lens.device
+    bs = int(forward_batch.batch_size)
+    seq_lens = forward_batch.seq_lens[:bs].to(dtype=torch.int32)
+    if max_context_len is None:
+        req_to_token = req_to_token_pool.req_to_token
+        max_context_len = int(req_to_token.shape[1])
+    if max_bs is None:
+        max_bs = max(bs, int(getattr(req_to_token_pool, "size", bs)))
+
+    indexer_page_size = _validate_page_size(token_to_kv_pool, atom_config)
+    attention_page_size = _attention_page_size(token_to_kv_pool)
+    topk = _get_index_topk(atom_config)
+    dtype_q = _metadata_dtype(atom_config)
+
+    bufs = _get_or_create_decode_graph_buffers(
+        token_to_kv_pool,
+        max_bs=max_bs,
+        max_context_len=max_context_len,
+        indexer_page_size=indexer_page_size,
+        attention_page_size=attention_page_size,
+        atom_config=atom_config,
+        device=device,
+    )
+
+    bufs.kv_indptr.zero_()
+    bufs.kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
+    bufs.sparse_kv_indptr.zero_()
+    bufs.sparse_kv_indptr[1 : bs + 1] = torch.cumsum(
+        torch.clamp(seq_lens, max=topk), dim=0
+    )
+    bufs.context_lens[:bs].copy_(seq_lens)
+    bufs.kv_last_page_lens[:bs].fill_(1)
+
+    out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+    if torch.is_tensor(out_cache_loc):
+        copy_n = min(bs, int(out_cache_loc.numel()))
+        if copy_n:
+            bufs.slot_mapping[:copy_n].copy_(out_cache_loc[:copy_n])
+        if bs > copy_n:
+            scratch_slot = max(0, int(getattr(token_to_kv_pool, "size", 1)) - 1)
+            bufs.slot_mapping[copy_n:bs].fill_(scratch_slot)
+    else:
+        scratch_slot = max(0, int(getattr(token_to_kv_pool, "size", 1)) - 1)
+        bufs.slot_mapping[:bs].fill_(scratch_slot)
+
+    create_flashinfer_kv_indices_triton[(bs,)](
+        req_to_token_pool.req_to_token,
+        forward_batch.req_pool_indices[:bs],
+        seq_lens,
+        bufs.kv_indptr[: bs + 1],
+        None,
+        bufs.kv_indices,
+        req_to_token_pool.req_to_token.stride(0),
+    )
+    bufs.stage_block_tables(req_to_token_pool, forward_batch.req_pool_indices, bs)
+
+    get_mla_metadata_v1(
+        bufs.cu_q[: bs + 1],
+        bufs.sparse_kv_indptr[: bs + 1],
+        bufs.kv_last_page_lens[:bs],
+        max(_local_num_attention_heads(atom_config), 16),
+        1,
+        True,
+        bufs.work_meta_data,
+        bufs.work_info_set,
+        bufs.work_indptr,
+        bufs.reduce_indptr,
+        bufs.reduce_final_map,
+        bufs.reduce_partial_map,
+        page_size=attention_page_size,
+        dtype_q=dtype_q,
+        dtype_kv=dtype_q,
+        kv_granularity=max(attention_page_size, 16),
+        max_seqlen_qo=1,
+        uni_seqlen_qo=1,
+        fast_mode=True,
+    )
+
+    setattr(token_to_kv_pool, _SHARED_SPARSE_INDICES_ATTR, bufs.shared_sparse)
+    md = AttentionMetaData(
+        cu_seqlens_q=bufs.cu_q[: bs + 1],
+        cu_seqlens_k=bufs.kv_indptr[: bs + 1],
+        max_seqlen_q=1,
+        max_seqlen_k=int(seq_lens.max().item()) if bs else 1,
+        slot_mapping=bufs.slot_mapping[:bs],
+        context_lens=bufs.context_lens[:bs],
+        block_tables=bufs.block_tables[:bs],
+        state=AttnState.DECODE,
+        kv_indptr=bufs.kv_indptr[: bs + 1],
+        kv_indices=bufs.kv_indices,
+        kv_last_page_lens=bufs.kv_last_page_lens[:bs],
+        sparse_kv_indptr=bufs.sparse_kv_indptr[: bs + 1],
+        work_meta_data=bufs.work_meta_data,
+        work_indptr=bufs.work_indptr,
+        work_info_set=bufs.work_info_set,
+        reduce_indptr=bufs.reduce_indptr,
+        reduce_final_map=bufs.reduce_final_map,
+        reduce_partial_map=bufs.reduce_partial_map,
+    )
+    md.sparse_kv_last_page_lens = bufs.kv_last_page_lens[:bs]
+    md.dtype_q = dtype_q
+    return md
+
+
+def _build_prefill_metadata(
+    forward_batch,
+    positions: torch.Tensor,
+    *,
+    token_to_kv_pool,
+    req_to_token_pool,
+    atom_config,
+):
+    from atom.utils.forward_context import AttentionMetaData, AttnState
+
+    device = positions.device
+    bs = int(forward_batch.batch_size)
+    seq_lens = _get_seq_lens_cpu(forward_batch, bs)
+    extend_lens = _get_extend_lens_cpu(forward_batch, positions, bs)
+    topk = _get_index_topk(atom_config)
+    page_size = _validate_page_size(token_to_kv_pool, atom_config)
+
+    q_np = np.zeros(bs + 1, dtype=np.int32)
+    q_np[1:] = np.cumsum(extend_lens, dtype=np.int32)
+    cu_q = torch.from_numpy(q_np).to(device=device)
+    kv_indptr = _counts_to_indptr(seq_lens, device)
+    block_tables = _build_token_table(
+        forward_batch,
+        req_to_token_pool,
+        seq_lens=seq_lens,
+        extend_lens=extend_lens,
+        page_size=page_size,
+    )
+    token_table = _build_token_table(
+        forward_batch,
+        req_to_token_pool,
+        seq_lens=seq_lens,
+        extend_lens=extend_lens,
+        page_size=1,
+    )
+    kv_indices = _flatten_kv_indices(token_table, seq_lens)
+    has_cached = bool(np.any(seq_lens - extend_lens > 0))
+    state = AttnState.PREFILL_PREFIX if has_cached else AttnState.PREFILL_NATIVE
+    total_tokens = int(extend_lens.sum())
+    kv_last_page_lens = torch.ones(bs, dtype=torch.int32, device=device)
+
+    md = AttentionMetaData(
+        cu_seqlens_q=cu_q,
+        cu_seqlens_k=kv_indptr if has_cached else cu_q,
+        max_seqlen_q=int(extend_lens.max(initial=1)),
+        max_seqlen_k=int(seq_lens.max(initial=1)),
+        slot_mapping=forward_batch.out_cache_loc[:total_tokens],
+        context_lens=forward_batch.seq_lens[:bs].to(dtype=torch.int32),
+        block_tables=block_tables,
+        state=state,
+        kv_indptr=kv_indptr,
+        kv_indices=kv_indices,
+        kv_last_page_lens=kv_last_page_lens,
+        has_cached=has_cached,
+        total_kv=int(seq_lens.sum()),
+        num_cached_tokens=torch.from_numpy(seq_lens - extend_lens).to(device=device),
+        seq_starts=torch.from_numpy(seq_lens - extend_lens).to(device=device),
+    )
+    dtype_q = _metadata_dtype(atom_config)
+    md.dtype_q = dtype_q
+
+    if md.max_seqlen_k > topk:
+        counts = extend_lens.astype(np.int32)
+        local_offsets = np.concatenate(
+            [np.arange(int(count), dtype=np.int32) for count in counts]
+        )
+        if has_cached:
+            seq_starts = kv_indptr[:-1].detach().cpu().numpy().astype(np.int32)
+            cached_lens = seq_lens - counts
+            repeated_seq_starts = np.repeat(seq_starts, counts)
+            repeated_cached_lens = np.repeat(cached_lens, counts)
+            cu_ks = repeated_seq_starts
+            cu_ke = repeated_seq_starts + repeated_cached_lens + local_offsets + 1
+            sparse_counts = repeated_cached_lens + local_offsets + 1
+        else:
+            cu_ks = np.repeat(q_np[:bs], counts)
+            cu_ke = np.arange(total_tokens, dtype=np.int32) + 1
+            sparse_counts = local_offsets + 1
+
+        sparse_cu = torch.arange(total_tokens + 1, dtype=torch.int32, device=device)
+        sparse_kv_indptr = _counts_to_indptr(
+            np.minimum(sparse_counts, topk).astype(np.int32), device
+        )
+        sparse_last_page_lens = torch.ones(
+            total_tokens, dtype=torch.int32, device=device
+        )
+        md.cu_seqlen_ks = torch.from_numpy(cu_ks.astype(np.int32)).to(device=device)
+        md.cu_seqlen_ke = torch.from_numpy(cu_ke.astype(np.int32)).to(device=device)
+        md.sparse_cu_seqlens_q = sparse_cu
+        md.sparse_kv_indptr = sparse_kv_indptr
+        md.sparse_kv_last_page_lens = sparse_last_page_lens
+        md.token_to_seq_idxs = torch.repeat_interleave(
+            torch.arange(bs, dtype=torch.int32, device=device),
+            torch.from_numpy(counts.astype(np.int64)).to(device=device),
+        )
+        _ensure_shared_sparse_buffer(
+            token_to_kv_pool,
+            num_tokens=total_tokens,
+            topk=topk,
+            device=device,
+        )
+        sparse_work = _make_mla_work_buffers(
+            cu_seqlens_q=sparse_cu,
+            kv_indptr=sparse_kv_indptr,
+            kv_last_page_lens=sparse_last_page_lens,
+            num_heads=_local_num_attention_heads(atom_config),
+            dtype_q=dtype_q,
+            dtype_kv=dtype_q,
+            page_size=_attention_page_size(token_to_kv_pool),
+        )
+        for key, value in sparse_work.items():
+            setattr(md, f"sparse_prefill_{key}", value)
+    else:
+        _ensure_shared_sparse_buffer(
+            token_to_kv_pool,
+            num_tokens=max(1, total_tokens),
+            topk=topk,
+            device=device,
+        )
+
+    return md
+
+
+def build_atom_glm52_attention_metadata_from_sglang(
+    forward_batch,
+    positions: torch.Tensor,
+    *,
+    token_to_kv_pool,
+    req_to_token_pool,
+    atom_config,
+):
+    if forward_batch.forward_mode.is_decode_or_idle():
+        return _build_decode_metadata(
+            forward_batch,
+            positions,
+            token_to_kv_pool=token_to_kv_pool,
+            req_to_token_pool=req_to_token_pool,
+            atom_config=atom_config,
+        )
+    if getattr(
+        forward_batch.forward_mode, "is_draft_extend", lambda **kwargs: False
+    )(include_v2=True):
+        raise RuntimeError(
+            "GLM-5.2 native DSA SGLang bridge does not yet support draft extend/MTP."
+        )
+    return _build_prefill_metadata(
+        forward_batch,
+        positions,
+        token_to_kv_pool=token_to_kv_pool,
+        req_to_token_pool=req_to_token_pool,
+        atom_config=atom_config,
+    )
+
+
+def bind_glm52_dsa_cache_views(model, token_to_kv_pool) -> bool:
+    if token_to_kv_pool is None or not hasattr(token_to_kv_pool, "get_key_buffer"):
+        return False
+    if not hasattr(token_to_kv_pool, "get_index_k_with_scale_buffer"):
+        return False
+
+    from atom.config import KVCacheTensor
+    from atom.models.deepseek_v2 import DeepseekV2MLAAttention
+    from atom.utils.forward_context import get_forward_context, set_kv_cache_data
+
+    shared_sparse = getattr(token_to_kv_pool, _SHARED_SPARSE_INDICES_ATTR, None)
+    if shared_sparse is None:
+        return False
+
+    page_size = int(
+        getattr(
+            token_to_kv_pool,
+            _INDEXER_PAGE_SIZE_ATTR,
+            getattr(token_to_kv_pool, "page_size", 1),
+        )
+    )
+    empty_value_cache = getattr(token_to_kv_pool, _EMPTY_VALUE_CACHE_ATTR, None)
+    if empty_value_cache is None or empty_value_cache.device != shared_sparse.device:
+        empty_value_cache = torch.empty(0, device=shared_sparse.device)
+        setattr(token_to_kv_pool, _EMPTY_VALUE_CACHE_ATTR, empty_value_cache)
+    kv_cache_data = {}
+    for module in model.modules():
+        if not isinstance(module, DeepseekV2MLAAttention):
+            continue
+
+        layer_id = int(module.layer_num)
+        kv_cache_data[f"layer_{layer_id}"] = KVCacheTensor(
+            layer_num=layer_id,
+            k_cache=token_to_kv_pool.get_key_buffer(layer_id),
+            v_cache=empty_value_cache,
+            k_scale=getattr(module.mla_attn, "_k_scale", None),
+            v_scale=getattr(module.mla_attn, "_k_scale", None),
+        )
+
+        indexer = getattr(module, "indexer", None)
+        if indexer is not None:
+            index_cache = token_to_kv_pool.get_index_k_with_scale_buffer(layer_id)
+            index_entry_dim = int(getattr(indexer, "head_dim")) + 4
+            indexer.k_cache.kv_cache[0] = index_cache.view(
+                -1, page_size, index_entry_dim
+            )
+            indexer.sparse_kv_indices_buffer = shared_sparse
+
+        if hasattr(module.mla_attn, "sparse_kv_indices_buffer"):
+            module.mla_attn.sparse_kv_indices_buffer = shared_sparse
+
+    if not kv_cache_data:
+        return False
+
+    set_kv_cache_data(kv_cache_data)
+    get_forward_context().kv_cache_data = kv_cache_data
+    return True

--- a/atom/plugin/sglang/models/base_model_wrapper.py
+++ b/atom/plugin/sglang/models/base_model_wrapper.py
@@ -210,24 +210,8 @@ class _AtomCausalLMBaseForSglang(nn.Module):
                 input_embeds=input_embeds,
                 set_forward_context=not self.model_arch_spec.wrapper_binds_gdn_context,
             ) as runtime:
-                if self.model_arch == "DeepseekV4ForCausalLM":
-                    from atom.plugin.sglang.deepseek_v4_bridge import (
-                        bind_deepseek_v4_proxy_cache_views,
-                        maybe_get_proxy_pool_from_sglang_backend,
-                        reset_deepseek_v4_state_slots,
-                    )
-
-                    proxy_pool, _ = maybe_get_proxy_pool_from_sglang_backend()
-                    if not bind_deepseek_v4_proxy_cache_views(self.model, proxy_pool):
-                        raise RuntimeError(
-                            "DeepSeek-V4 SGLang proxy KV pool is not initialized"
-                        )
-                    from atom.utils.forward_context import get_forward_context
-
-                    reset_slots = getattr(
-                        get_forward_context().attn_metadata, "reset_slots", None
-                    )
-                    reset_deepseek_v4_state_slots(self.model, reset_slots)
+                if self.model_arch_spec.bind_cache_views is not None:
+                    self.model_arch_spec.bind_cache_views(self.model, runtime)
 
                 metadata = SGLangForwardBatchMetadata.build(
                     runtime.forward_batch,

--- a/atom/plugin/sglang/models/glm52_dsa.py
+++ b/atom/plugin/sglang/models/glm52_dsa.py
@@ -50,10 +50,9 @@ def setup_glm52_dsa_for_sglang(model: Any) -> None:
             )
 
         if getattr(module, "is_v32", False):
-            owns_active_indexer = (
-                getattr(module, "indexer", None) is not None
-                and not getattr(module, "skip_topk", False)
-            )
+            owns_active_indexer = getattr(
+                module, "indexer", None
+            ) is not None and not getattr(module, "skip_topk", False)
             if owns_active_indexer:
                 last_full_index_seen = True
             elif not last_full_index_seen:

--- a/atom/plugin/sglang/models/glm52_dsa.py
+++ b/atom/plugin/sglang/models/glm52_dsa.py
@@ -1,0 +1,65 @@
+"""Model-level GLM-5.2 DSA adaptation for SGLang plugin mode."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from atom.plugin.sglang.models.deepseek_mla import _align_qknorm_fusion_for_sglang
+from atom.plugin.sglang.models.deepseek_mla_forward import (
+    _patch_attention_projs_for_sglang_mxfp4,
+)
+from atom.plugin.sglang.models.glm52_dsa_attention import (
+    SGLangATOMGLM52MLAAttention,
+)
+
+
+def setup_glm52_dsa_for_sglang(model: Any) -> None:
+    """Patch GLM-5.2 for native ATOM sparse MLA under SGLang.
+
+    This deliberately does not install ``SGLangDeepseekMLAAttention``.  GLM-5.2
+    should keep ATOM's native ``MLAAttention`` frontend so full-index layers run
+    the ATOM indexer into a shared physical-index buffer and shared-index layers
+    reuse that buffer.
+    """
+
+    if not hasattr(model, "atom_config"):
+        from atom.config import get_current_atom_config
+
+        model.atom_config = get_current_atom_config()
+
+    from atom.models.deepseek_v2 import DeepseekV2MLAAttention
+    from sglang.srt.configs.model_config import is_deepseek_nsa
+    from sglang.srt.layers.communicator import get_attn_tp_context
+
+    config = model.config
+    get_attn_tp_context().init_context(config.q_lora_rank, is_deepseek_nsa(config))
+
+    last_full_index_seen = False
+    for module in model.modules():
+        if not isinstance(module, DeepseekV2MLAAttention):
+            continue
+
+        _align_qknorm_fusion_for_sglang(module)
+        _patch_attention_projs_for_sglang_mxfp4(module)
+
+        if not isinstance(module.mla_attn, SGLangATOMGLM52MLAAttention):
+            raise RuntimeError(
+                "GLM-5.2 SGLang native DSA setup expected "
+                "SGLangATOMGLM52MLAAttention. Ensure the GLM construction "
+                "context is installed before model initialization."
+            )
+
+        if getattr(module, "is_v32", False):
+            owns_active_indexer = (
+                getattr(module, "indexer", None) is not None
+                and not getattr(module, "skip_topk", False)
+            )
+            if owns_active_indexer:
+                last_full_index_seen = True
+            elif not last_full_index_seen:
+                raise RuntimeError(
+                    "GLM-5.2 IndexShare cannot start with a shared-index layer; "
+                    f"layer={getattr(module, 'prefix', '<unknown>')!r}"
+                )
+
+    model._atom_sglang_uses_glm52_native_dsa = True

--- a/atom/plugin/sglang/models/glm52_dsa_attention.py
+++ b/atom/plugin/sglang/models/glm52_dsa_attention.py
@@ -1,0 +1,133 @@
+"""GLM-5.2 native MLA attention frontend for SGLang plugin mode."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import torch
+
+from atom.model_ops.attention_mla import MLAAttention
+
+
+@contextmanager
+def glm52_native_mla_attention_construction():
+    """Temporarily make GLM sparse MLA layers construct native ATOM attention."""
+
+    import atom.models.deepseek_v2 as deepseek_v2
+
+    previous = deepseek_v2.Attention
+
+    def _build_glm52_native_mla_attention(*args: Any, **kwargs: Any):
+        mla_modules = kwargs.get("mla_modules", None)
+        if (
+            kwargs.get("use_mla", False)
+            and mla_modules is not None
+            and getattr(mla_modules, "is_sparse", False)
+        ):
+            return SGLangATOMGLM52MLAAttention(*args, **kwargs)
+        return previous(*args, **kwargs)
+
+    deepseek_v2.Attention = _build_glm52_native_mla_attention
+    try:
+        yield
+    finally:
+        deepseek_v2.Attention = previous
+
+
+class SGLangATOMGLM52MLAAttention(MLAAttention):
+    """Use ATOM native ``MLAAttention`` under SGLang plugin runtime.
+
+    ``DeepseekV2MLAAttention.forward`` calls ``self.mla_attn`` with the ATOM
+    model-side argument order, while ``MLAAttention.forward`` has the lower-level
+    backend argument order.  This frontend keeps the model-side call contract and
+    delegates directly to ``forward_impl``.
+    """
+
+    def __init__(self, *args: Any, prefix: str | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.layer_name = prefix if prefix is not None else f"GLM52_MLA_{self.layer_num}"
+        from atom.config import get_current_atom_config
+
+        get_current_atom_config().compilation_config.static_forward_context[
+            self.layer_name
+        ] = self
+
+    def _get_forward_batch(self):
+        from atom.plugin.sglang.runtime import get_current_forward_batch
+
+        forward_batch = get_current_forward_batch()
+        if forward_batch is None:
+            raise RuntimeError(
+                "forward_batch is required for SGLang GLM-5.2 native MLA attention"
+            )
+        return forward_batch
+
+    def _infer_total_tokens(self, forward_batch, tensor: torch.Tensor) -> int:
+        if hasattr(forward_batch, "input_ids") and forward_batch.input_ids is not None:
+            return int(forward_batch.input_ids.shape[0])
+        if hasattr(forward_batch, "positions") and forward_batch.positions is not None:
+            return int(forward_batch.positions.shape[0])
+        if hasattr(forward_batch, "seq_lens_sum"):
+            return int(forward_batch.seq_lens_sum)
+        return int(tensor.shape[0])
+
+    def _maybe_all_gather(
+        self,
+        tensor: torch.Tensor | None,
+        *,
+        total_tokens: int,
+        input_scattered: bool,
+    ):
+        if tensor is None or not input_scattered:
+            return tensor
+        from sglang.srt.distributed import get_tp_group
+
+        output = tensor.new_empty((total_tokens, *tensor.shape[1:]))
+        get_tp_group().all_gather_into_tensor(output, tensor)
+        return output
+
+    def forward(
+        self,
+        q_input: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        positions: torch.Tensor,
+        q_scale: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        del kwargs
+        forward_batch = self._get_forward_batch()
+
+        from sglang.srt.layers.communicator import get_attn_tp_context
+
+        attn_tp_context = get_attn_tp_context()
+        with attn_tp_context.maybe_input_scattered(forward_batch):
+            total_tokens = self._infer_total_tokens(forward_batch, q_input)
+            q_input = self._maybe_all_gather(
+                q_input,
+                total_tokens=total_tokens,
+                input_scattered=attn_tp_context.input_scattered,
+            )
+            kv_c_normed = self._maybe_all_gather(
+                kv_c_normed,
+                total_tokens=total_tokens,
+                input_scattered=attn_tp_context.input_scattered,
+            )
+            k_pe = self._maybe_all_gather(
+                k_pe,
+                total_tokens=total_tokens,
+                input_scattered=attn_tp_context.input_scattered,
+            )
+            positions = self._maybe_all_gather(
+                positions,
+                total_tokens=total_tokens,
+                input_scattered=attn_tp_context.input_scattered,
+            )
+            q_scale = self._maybe_all_gather(
+                q_scale,
+                total_tokens=total_tokens,
+                input_scattered=attn_tp_context.input_scattered,
+            )
+
+            return self.forward_impl(q_input, kv_c_normed, k_pe, positions, q_scale)

--- a/atom/plugin/sglang/models/glm52_dsa_attention.py
+++ b/atom/plugin/sglang/models/glm52_dsa_attention.py
@@ -46,7 +46,9 @@ class SGLangATOMGLM52MLAAttention(MLAAttention):
 
     def __init__(self, *args: Any, prefix: str | None = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.layer_name = prefix if prefix is not None else f"GLM52_MLA_{self.layer_num}"
+        self.layer_name = (
+            prefix if prefix is not None else f"GLM52_MLA_{self.layer_num}"
+        )
         from atom.config import get_current_atom_config
 
         get_current_atom_config().compilation_config.static_forward_context[

--- a/atom/plugin/sglang/prepare.py
+++ b/atom/plugin/sglang/prepare.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+from contextlib import nullcontext
 from typing import Any
 
 from atom.plugin.prepare import _set_framework_backbone
@@ -82,13 +83,19 @@ def prepare_model(config: Any):
 
     apply_graph_capture_patch()
 
-    init_params = inspect.signature(model_cls.__init__).parameters
-    if "atom_config" in init_params:
-        model = model_cls(atom_config=atom_config)
-    elif "config" in init_params:
-        model = model_cls(config=atom_config)
-    else:
-        model = model_cls(atom_config)
+    construct_context = (
+        model_adapter.construction_context()
+        if model_adapter.construction_context is not None
+        else nullcontext()
+    )
+    with construct_context:
+        init_params = inspect.signature(model_cls.__init__).parameters
+        if "atom_config" in init_params:
+            model = model_cls(atom_config=atom_config)
+        elif "config" in init_params:
+            model = model_cls(config=atom_config)
+        else:
+            model = model_cls(atom_config)
     if not hasattr(model, "atom_config"):
         model.atom_config = atom_config
     return model

--- a/atom/plugin/sglang/runtime/__init__.py
+++ b/atom/plugin/sglang/runtime/__init__.py
@@ -9,16 +9,19 @@ from atom.plugin.sglang.runtime.context import (
 )
 from atom.plugin.sglang.runtime.forward_context import SGLangPluginRuntime
 from atom.plugin.sglang.runtime.model_arch import (
+    GLM52_DSA_ARCH,
     MODEL_ADAPTER_SPECS,
     MODEL_ARCH_SPECS,
     SGLangModelAdapterSpec,
     get_model_arch_spec,
+    is_glm52_dsa_config,
 )
 
 apply_load_config_patch()
 
 __all__ = [
     "apply_load_config_patch",
+    "GLM52_DSA_ARCH",
     "MODEL_ADAPTER_SPECS",
     "MODEL_ARCH_SPECS",
     "SGLangForwardBatchMetadata",
@@ -27,5 +30,6 @@ __all__ = [
     "bind_current_forward_batch",
     "get_current_forward_batch",
     "get_model_arch_spec",
+    "is_glm52_dsa_config",
     "plugin_runtime_scope",
 ]

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -214,6 +214,130 @@ def _slice_v4_graph_metadata_for_capture(
     return md
 
 
+def _is_current_stream_capturing() -> bool:
+    try:
+        return bool(torch.cuda.is_current_stream_capturing())
+    except Exception:
+        return False
+
+
+def _get_sglang_attention_backend():
+    try:
+        from sglang.srt.model_executor.forward_context import get_attn_backend
+
+        return get_attn_backend()
+    except Exception:
+        return None
+
+
+def _build_glm52_dsa_metadata(
+    atom_config: Any,
+    forward_batch: ForwardBatch,
+    positions: torch.Tensor,
+):
+    if _is_dummy_forward(forward_batch) or getattr(atom_config, "hf_config", None) is None:
+        return None
+
+    from atom.plugin.sglang.glm52_dsa_bridge import (
+        build_atom_glm52_attention_metadata_from_sglang,
+        is_glm52_dsa_arch,
+        maybe_get_glm52_dsa_pools_from_sglang_backend,
+    )
+
+    if not is_glm52_dsa_arch(atom_config.hf_config):
+        return None
+
+    attn_metadata = getattr(forward_batch, "atom_glm52_graph_metadata", None)
+    if attn_metadata is None:
+        backend = _get_sglang_attention_backend()
+        attn_metadata = getattr(backend, "atom_glm52_graph_metadata", None)
+
+    is_capture_batch = _is_current_stream_capturing()
+    if attn_metadata is None and is_capture_batch:
+        from atom.plugin.sglang.attention_backend.glm52_dsa_backend import (
+            ATOMGLM52DSABackendForSgl,
+        )
+
+        attn_metadata = ATOMGLM52DSABackendForSgl._last_atom_glm52_graph_metadata
+
+    token_to_kv_pool, req_to_token_pool = maybe_get_glm52_dsa_pools_from_sglang_backend(
+        forward_batch
+    )
+    if (
+        attn_metadata is None
+        and token_to_kv_pool is not None
+        and req_to_token_pool is not None
+    ):
+        if is_capture_batch:
+            raise RuntimeError(
+                "ATOM GLM-5.2 CUDA graph metadata was not initialized before capture"
+            )
+        attn_metadata = build_atom_glm52_attention_metadata_from_sglang(
+            forward_batch,
+            positions,
+            token_to_kv_pool=token_to_kv_pool,
+            req_to_token_pool=req_to_token_pool,
+            atom_config=atom_config,
+        )
+    return attn_metadata
+
+
+def _build_deepseek_v4_metadata(forward_batch: ForwardBatch, positions: torch.Tensor):
+    backend = None
+    attn_metadata = getattr(forward_batch, "atom_v4_graph_metadata", None)
+    from atom.plugin.sglang.deepseek_v4_bridge import (
+        build_atom_v4_attention_metadata_from_sglang,
+        maybe_get_proxy_pool_from_sglang_backend,
+    )
+
+    if attn_metadata is None:
+        backend = _get_sglang_attention_backend()
+        attn_metadata = getattr(backend, "atom_v4_graph_metadata", None)
+
+    if attn_metadata is None:
+        backend = getattr(forward_batch, "attn_backend", None)
+        attn_metadata = getattr(backend, "atom_v4_graph_metadata", None)
+
+    if attn_metadata is None and backend is not None:
+        backend_forward_batch = getattr(backend, "forward_metadata", None)
+        attn_metadata = getattr(backend_forward_batch, "atom_v4_graph_metadata", None)
+
+    try:
+        proxy_pool, req_to_token_pool = maybe_get_proxy_pool_from_sglang_backend()
+    except Exception:
+        proxy_pool, req_to_token_pool = None, None
+
+    is_capture_batch = _is_current_stream_capturing()
+    if attn_metadata is None and is_capture_batch:
+        try:
+            from atom.plugin.sglang.attention_backend.deepseek_v4_backend import (
+                ATOMDeepseekV4BackendForSgl,
+            )
+
+            attn_metadata = ATOMDeepseekV4BackendForSgl._last_atom_v4_graph_metadata
+            if attn_metadata is not None:
+                attn_metadata = _slice_v4_graph_metadata_for_capture(
+                    attn_metadata,
+                    num_tokens=int(positions.shape[0]),
+                    bs=int(forward_batch.batch_size),
+                )
+        except Exception:
+            attn_metadata = None
+
+    if attn_metadata is None and getattr(proxy_pool, "is_atom_v4_proxy_pool", False):
+        if is_capture_batch:
+            raise RuntimeError(
+                "ATOM DeepSeek-V4 CUDA graph metadata was not initialized before capture"
+            )
+        attn_metadata = build_atom_v4_attention_metadata_from_sglang(
+            forward_batch,
+            positions,
+            proxy_pool=proxy_pool,
+            req_to_token_pool=req_to_token_pool,
+        )
+    return attn_metadata
+
+
 def _set_atom_forward_context(
     atom_config: Any,
     forward_batch: ForwardBatch,
@@ -232,69 +356,23 @@ def _set_atom_forward_context(
     max_seqlen_q = 1 if forward_mode.is_decode_or_idle() else 0
     attn_metadata = None
     try:
-        attn_metadata = getattr(forward_batch, "atom_v4_graph_metadata", None)
-        from atom.plugin.sglang.deepseek_v4_bridge import (
-            build_atom_v4_attention_metadata_from_sglang,
-            maybe_get_proxy_pool_from_sglang_backend,
+        attn_metadata = _build_glm52_dsa_metadata(
+            atom_config,
+            forward_batch,
+            positions,
         )
-
-        if attn_metadata is None:
-            try:
-                from sglang.srt.model_executor.forward_context import get_attn_backend
-
-                backend = get_attn_backend()
-                attn_metadata = getattr(backend, "atom_v4_graph_metadata", None)
-            except Exception:
-                attn_metadata = None
-
-        if attn_metadata is None:
-            backend = getattr(forward_batch, "attn_backend", None)
-            attn_metadata = getattr(backend, "atom_v4_graph_metadata", None)
-
-        if attn_metadata is None and backend is not None:
-            backend_forward_batch = getattr(backend, "forward_metadata", None)
-            attn_metadata = getattr(
-                backend_forward_batch, "atom_v4_graph_metadata", None
-            )
-
-        proxy_pool, req_to_token_pool = maybe_get_proxy_pool_from_sglang_backend()
-        try:
-            is_capture_batch = bool(torch.cuda.is_current_stream_capturing())
-        except Exception:
-            is_capture_batch = False
-        if attn_metadata is None and is_capture_batch:
-            try:
-                from atom.plugin.sglang.attention_backend.deepseek_v4_backend import (
-                    ATOMDeepseekV4BackendForSgl,
-                )
-
-                attn_metadata = ATOMDeepseekV4BackendForSgl._last_atom_v4_graph_metadata
-                if attn_metadata is not None:
-                    attn_metadata = _slice_v4_graph_metadata_for_capture(
-                        attn_metadata,
-                        num_tokens=int(positions.shape[0]),
-                        bs=int(forward_batch.batch_size),
-                    )
-            except Exception:
-                attn_metadata = None
-        if attn_metadata is None and getattr(
-            proxy_pool, "is_atom_v4_proxy_pool", False
-        ):
-            if is_capture_batch:
-                raise RuntimeError(
-                    "ATOM DeepSeek-V4 CUDA graph metadata was not initialized before capture"
-                )
-            else:
-                attn_metadata = build_atom_v4_attention_metadata_from_sglang(
-                    forward_batch,
-                    positions,
-                    proxy_pool=proxy_pool,
-                    req_to_token_pool=req_to_token_pool,
-                )
     except Exception as exc:
         raise RuntimeError(
-            "Failed to build ATOM DeepSeek-V4 metadata for SGLang"
+            "Failed to build ATOM GLM-5.2 DSA metadata for SGLang"
         ) from exc
+
+    if attn_metadata is None:
+        try:
+            attn_metadata = _build_deepseek_v4_metadata(forward_batch, positions)
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to build ATOM DeepSeek-V4 metadata for SGLang"
+            ) from exc
 
     if attn_metadata is None:
         attn_metadata = AttentionMetaData(max_seqlen_q=max_seqlen_q)

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -235,17 +235,19 @@ def _build_glm52_dsa_metadata(
     forward_batch: ForwardBatch,
     positions: torch.Tensor,
 ):
-    if _is_dummy_forward(forward_batch) or getattr(atom_config, "hf_config", None) is None:
+    hf_config = getattr(atom_config, "hf_config", None)
+    if _is_dummy_forward(forward_batch) or hf_config is None:
+        return None
+
+    from atom.plugin.sglang.runtime.model_arch import is_glm52_dsa_config
+
+    if not is_glm52_dsa_config(hf_config):
         return None
 
     from atom.plugin.sglang.glm52_dsa_bridge import (
         build_atom_glm52_attention_metadata_from_sglang,
-        is_glm52_dsa_arch,
         maybe_get_glm52_dsa_pools_from_sglang_backend,
     )
-
-    if not is_glm52_dsa_arch(atom_config.hf_config):
-        return None
 
     attn_metadata = getattr(forward_batch, "atom_glm52_graph_metadata", None)
     if attn_metadata is None:
@@ -302,10 +304,7 @@ def _build_deepseek_v4_metadata(forward_batch: ForwardBatch, positions: torch.Te
         backend_forward_batch = getattr(backend, "forward_metadata", None)
         attn_metadata = getattr(backend_forward_batch, "atom_v4_graph_metadata", None)
 
-    try:
-        proxy_pool, req_to_token_pool = maybe_get_proxy_pool_from_sglang_backend()
-    except Exception:
-        proxy_pool, req_to_token_pool = None, None
+    proxy_pool, req_to_token_pool = maybe_get_proxy_pool_from_sglang_backend()
 
     is_capture_batch = _is_current_stream_capturing()
     if attn_metadata is None and is_capture_batch:

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from contextlib import AbstractContextManager
 from typing import Any, Callable, Optional
 
-
 GLM52_DSA_ARCH = "GlmMoeDsaForCausalLM"
 GLM52_DSA_MODEL_TYPE = "glm_moe_dsa"
 
@@ -15,9 +14,10 @@ def is_glm52_dsa_config(config: Any) -> bool:
     """Return whether an HF config describes GLM-5.2 DSA."""
 
     archs = getattr(config, "architectures", None) or []
-    return any(GLM52_DSA_ARCH in str(arch) for arch in archs) or getattr(
-        config, "model_type", None
-    ) == GLM52_DSA_MODEL_TYPE
+    return (
+        any(GLM52_DSA_ARCH in str(arch) for arch in archs)
+        or getattr(config, "model_type", None) == GLM52_DSA_MODEL_TYPE
+    )
 
 
 @dataclass(frozen=True)
@@ -101,7 +101,9 @@ def _prepare_glm52_dsa_config(atom_config: Any, model_arch: str) -> None:
                 GlmMoeDsaForCausalLM, "quant_exclude_name_mapping", {}
             ),
         )
-        default_excludes = getattr(GlmMoeDsaForCausalLM, "quant_default_exclude_layers", [])
+        default_excludes = getattr(
+            GlmMoeDsaForCausalLM, "quant_default_exclude_layers", []
+        )
         if default_excludes:
             quant_config.apply_default_exclude_layers(default_excludes)
 

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -3,7 +3,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from contextlib import AbstractContextManager
 from typing import Any, Callable, Optional
+
+
+GLM52_DSA_ARCH = "GlmMoeDsaForCausalLM"
+GLM52_DSA_MODEL_TYPE = "glm_moe_dsa"
+
+
+def is_glm52_dsa_config(config: Any) -> bool:
+    """Return whether an HF config describes GLM-5.2 DSA."""
+
+    archs = getattr(config, "architectures", None) or []
+    return any(GLM52_DSA_ARCH in str(arch) for arch in archs) or getattr(
+        config, "model_type", None
+    ) == GLM52_DSA_MODEL_TYPE
 
 
 @dataclass(frozen=True)
@@ -18,7 +32,9 @@ class SGLangModelAdapterSpec:
     wrapper_binds_gdn_context: bool = False
     uses_context_only_forward: bool = False
     prepare_config: Optional[Callable[[Any, str], None]] = None
+    construction_context: Optional[Callable[[], AbstractContextManager[Any]]] = None
     install_adapters: Optional[Callable[[Any], None]] = None
+    bind_cache_views: Optional[Callable[[Any, Any], None]] = None
 
 
 def _prepare_qwen35_config(atom_config: Any, model_arch: str) -> None:
@@ -70,10 +86,49 @@ def _prepare_minimax_m3_config(atom_config: Any, model_arch: str) -> None:
     )
 
 
+def _prepare_glm52_dsa_config(atom_config: Any, model_arch: str) -> None:
+    from atom.models.deepseek_v2 import GlmMoeDsaForCausalLM
+
+    quant_config = getattr(atom_config, "quant_config", None)
+    if quant_config is not None:
+        quant_config.remap_layer_name(
+            atom_config.hf_config,
+            packed_modules_mapping=getattr(
+                GlmMoeDsaForCausalLM, "packed_modules_mapping", {}
+            ),
+            weights_mapper=getattr(GlmMoeDsaForCausalLM, "hf_to_atom_mapper", {}),
+            quant_exclude_name_mapping=getattr(
+                GlmMoeDsaForCausalLM, "quant_exclude_name_mapping", {}
+            ),
+        )
+        default_excludes = getattr(GlmMoeDsaForCausalLM, "quant_default_exclude_layers", [])
+        if default_excludes:
+            quant_config.apply_default_exclude_layers(default_excludes)
+
+    # SGLang's DSA pool uses page64/preshuffle for GLM/DeepSeek-family DSA.
+    # Keep ATOM's config aligned for the native GLM indexer, while
+    # ATOM_MLA_PAGE_SIZE can remain 1 so sparse MLA reads selected physical ids.
+    atom_config.kv_cache_block_size = 64
+
+
 def _install_deepseek_mla_adapters(model: Any) -> None:
     from atom.plugin.sglang.models.deepseek_mla import setup_deepseek_for_sglang
 
     setup_deepseek_for_sglang(model)
+
+
+def _glm52_dsa_construction_context():
+    from atom.plugin.sglang.models.glm52_dsa_attention import (
+        glm52_native_mla_attention_construction,
+    )
+
+    return glm52_native_mla_attention_construction()
+
+
+def _install_glm52_dsa_native_adapters(model: Any) -> None:
+    from atom.plugin.sglang.models.glm52_dsa import setup_glm52_dsa_for_sglang
+
+    setup_glm52_dsa_for_sglang(model)
 
 
 def _install_deepseek_v4_adapters(model: Any) -> None:
@@ -91,6 +146,40 @@ def _install_deepseek_v4_adapters(model: Any) -> None:
             patch_deepseek_v4_attention_for_sglang(module)
 
 
+def _bind_deepseek_v4_cache_views(model: Any, runtime: Any) -> None:
+    del runtime
+    from atom.plugin.sglang.deepseek_v4_bridge import (
+        bind_deepseek_v4_proxy_cache_views,
+        maybe_get_proxy_pool_from_sglang_backend,
+        reset_deepseek_v4_state_slots,
+    )
+
+    proxy_pool, _ = maybe_get_proxy_pool_from_sglang_backend()
+    if not bind_deepseek_v4_proxy_cache_views(model, proxy_pool):
+        raise RuntimeError("DeepSeek-V4 SGLang proxy KV pool is not initialized")
+
+    from atom.utils.forward_context import get_forward_context
+
+    reset_slots = getattr(get_forward_context().attn_metadata, "reset_slots", None)
+    reset_deepseek_v4_state_slots(model, reset_slots)
+
+
+def _bind_glm52_dsa_cache_views(model: Any, runtime: Any) -> None:
+    if getattr(runtime.forward_batch.forward_mode, "is_idle", lambda: False)():
+        return
+
+    from atom.plugin.sglang.glm52_dsa_bridge import (
+        bind_glm52_dsa_cache_views,
+        maybe_get_glm52_dsa_pools_from_sglang_backend,
+    )
+
+    token_to_kv_pool, _ = maybe_get_glm52_dsa_pools_from_sglang_backend(
+        runtime.forward_batch
+    )
+    if not bind_glm52_dsa_cache_views(model, token_to_kv_pool):
+        raise RuntimeError("GLM-5.2 SGLang DSA KV pool is not initialized")
+
+
 def _install_minimax_m3_adapters(model: Any) -> None:
     from atom.plugin.sglang.models.minimax_m3 import setup_minimax_m3_for_sglang
 
@@ -106,8 +195,11 @@ MODEL_ADAPTER_SPECS = {
         install_adapters=_install_deepseek_mla_adapters,
         uses_context_only_forward=True,
     ),
-    "GlmMoeDsaForCausalLM": SGLangModelAdapterSpec(
-        install_adapters=_install_deepseek_mla_adapters,
+    GLM52_DSA_ARCH: SGLangModelAdapterSpec(
+        prepare_config=_prepare_glm52_dsa_config,
+        construction_context=_glm52_dsa_construction_context,
+        install_adapters=_install_glm52_dsa_native_adapters,
+        bind_cache_views=_bind_glm52_dsa_cache_views,
         uses_context_only_forward=True,
     ),
     "KimiK25ForConditionalGeneration": SGLangModelAdapterSpec(
@@ -131,6 +223,7 @@ MODEL_ADAPTER_SPECS = {
     ),
     "DeepseekV4ForCausalLM": SGLangModelAdapterSpec(
         install_adapters=_install_deepseek_v4_adapters,
+        bind_cache_views=_bind_deepseek_v4_cache_views,
     ),
     "MiniMaxM3SparseForCausalLM": SGLangModelAdapterSpec(
         uses_context_only_forward=True,
@@ -152,7 +245,7 @@ MODEL_ARCH_SPECS = {
     for key in (
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
-        "GlmMoeDsaForCausalLM",
+        GLM52_DSA_ARCH,
         "Qwen3ForCausalLM",
         "Qwen3MoeForCausalLM",
         "Qwen3NextForCausalLM",


### PR DESCRIPTION
## Motivation

optimize glm5.2 for sglang-atom, using the same attention strategy with deepseek v4.
This PR enables GLM-5.2 to run through the SGLang-ATOM plugin using ATOM’s native sparse MLA attention path instead of falling back to the generic SGLang/DeepSeek MLA wrapper path. GLM-5.2 uses DSA sparse MLA with IndexShare, so routing attention through ATOM’s native MLAAttention lets the plugin reuse ATOM’s optimized indexer, KV cache layout, metadata, and kernel path while keeping SGLang responsible for serving, scheduling, request batching, and KV allocation.
It also adds SGLang-ATOM benchmark coverage for GLM-5.2 FP8 TP4 and FP4 TP4 so this path can be tracked in the regular benchmark workflow.

## Technical Details
The branch adds a GLM-5.2 DSA bridge under atom/plugin/sglang that converts SGLang ForwardBatch metadata into ATOM AttentionMetaData, binds SGLang’s DSA KV pool views into ATOM’s forward context, and shares sparse top-k index buffers across full-index and shared-index GLM layers.

A dedicated SGLang attention backend shim, ATOMGLM52DSABackendForSgl, publishes fixed-address decode metadata for CUDA graph capture/replay, while the actual attention computation remains in ATOM’s native MLAAttention.

The model adapter registry now owns GLM-5.2-specific setup: config preparation, construction-time attention replacement, install-time validation, and per-forward cache binding. This keeps the generic SGLang model wrapper and prepare path mostly architecture-agnostic.

The benchmark catalog adds:
 - glm-5-2-fp8-tp4
 - glm-5-2-fp4-tp4

and wires both into the SGLang benchmark workflow presets and P0 schedule.

## Test Plan
#### fp8 tp4 server
```bash
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export AITER_USE_FLYDSL_MOE_SORTING=1
export SGLANG_USE_AITER=1
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
MODEL_PATH=/shared/data/amd_int/models/GLM-5.2-FP8
TP=4
PORT=8015
MODEL_LOADER_EXTRA_CONFIG='{"online_quant_config":{"global_quant_config":"ptpc_fp8","layer_quant_config":{"model.layers.*.mlp.experts":"mxfp8"},"exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate"]}}'

TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path "${MODEL_PATH}" \
    --host localhost \
    --port "${PORT}" \
    --trust-remote-code \
    --tp-size "${TP}" \
    --mem-fraction-static 0.8 \
    --disable-radix-cache \
    --kv-cache-dtype fp8_e4m3 \
    --model-loader-extra-config "${MODEL_LOADER_EXTRA_CONFIG}" \
    2>&1 | tee glm-server-fp8-tp4-sglang.log
```
#### fp4 tp4 server
```bash
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export AITER_USE_FLYDSL_MOE_SORTING=1
export SGLANG_USE_AITER=1
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
MODEL_PATH=/shared/data/amd_int/models/GLM-5.2-MXFP4
TP=4
PORT=8015
MODEL_LOADER_EXTRA_CONFIG='{"online_quant_config":{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate","*expert*"]}}'

TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path "${MODEL_PATH}" \
    --host localhost \
    --port "${PORT}" \
    --trust-remote-code \
    --tp-size "${TP}" \
    --mem-fraction-static 0.8 \
    --disable-radix-cache \
    --kv-cache-dtype fp8_e4m3 \
    --model-loader-extra-config "${MODEL_LOADER_EXTRA_CONFIG}" \
    2>&1 | tee glm-server-mxfp4-tp4-sglang.log
```
#### acc test
```bash
PORT=8015
model_path=/shared/data/amd_int/models/GLM-5.2-MXFP4
model_path=/shared/data/amd_int/models/GLM-5.2-FP8

lm_eval --model local-completions \
    --model_args model=${model_path},base_url=http://localhost:${PORT}/v1/completions,num_concurrent=65,max_retries=1,tokenized_requests=False,trust_remote_code=True \
    --tasks gsm8k \
    --num_fewshot 5
```
#### perf test
```bash
if [ ! -d bench_serving ]; then
    git clone https://github.com/kimbochen/bench_serving.git
fi
model_path=/shared/data/amd_int/models/GLM-5.2-MXFP4
model_path=/shared/data/amd_int/models/GLM-5.2-FP8
ISL=$1
OSL=$2
CONC=$3
RANGE_RATIO=0.8

NUM=$(( CONC * 3 ))

echo "=== Running benchmark with ISL=${ISL}, OSL=${OSL}, RANGE_RATIO=${RANGE_RATIO}, CONC=${CONC} ==="

PYTHONDONTWRITEBYTECODE=1 python "./bench_serving/benchmark_serving.py" \
    --model="$model_path" \
    --backend=vllm \
    --base-url=http://localhost:8015 \
    --dataset-name=random \
    --random-input-len="${ISL}" \
    --random-output-len="${OSL}" \
    --random-range-ratio "${RANGE_RATIO}" \
    --num-prompts="${NUM}" \
    --max-concurrency="${CONC}" \
    --trust-remote-code \
    --request-rate=inf \
    --num-warmups="$(( 2 * CONC ))" \
    --ignore-eos \
    --save-result \
    --percentile-metrics="ttft,tpot,itl,e2el" \
    --result-dir="./tmp/glm-mxfp4-benchmark" \
    --result-filename="glm-mxfp4_${ISL}_${OSL}_${CONC}.json"
```

## Test Result
#### fp8 tp4
```bash
local-completions ({'model': '/shared/data/amd_int/models/GLM-5.2-FP8', 'base_url': 'http://localhost:8015/v1/completions', 'num_concurrent': 65, 'max_retries': 1, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9409|±  |0.0065|
|     |       |strict-match    |     5|exact_match|↑  |0.9409|±  |0.0065|
```
```bash
=== Running benchmark with ISL=8192, OSL=1024, RANGE_RATIO=0.8, CONC=32 ===
-------------------  Input/Output Length Statistics  -------------------
 input_lens : min=6581  max=8177  mean=7321.12  avg_token_mismatch=0.00  
 output_lens: min=819   max=1024  mean=915.62  
------------------------------------------------------------------------ 
============ Serving Benchmark Result ============
Successful requests:                     96        
Benchmark duration (s):                  101.92    
Total input tokens:                      702828    
Total generated tokens:                  87900     
Request throughput (req/s):              0.94      
Output token throughput (tok/s):         862.41    
Total Token throughput (tok/s):          7758.02   
---------------Time to First Token----------------
Mean TTFT (ms):                          2265.09   
Median TTFT (ms):                        717.51    
P99 TTFT (ms):                           10070.47  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          33.21     
Median TPOT (ms):                        33.92     
P99 TPOT (ms):                           40.40     
---------------Inter-token Latency----------------
Mean ITL (ms):                           33.31     
Median ITL (ms):                         24.59     
P99 ITL (ms):                            272.20    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          32733.33  
Median E2EL (ms):                        32239.81  
P99 E2EL (ms):                           44598.79  
==================================================
```
#### fp4 tp4
```bash
local-completions ({'model': '/shared/data/amd_int/models/GLM-5.2-MXFP4', 'base_url': 'http://localhost:8015/v1/completions', 'num_concurrent': 65, 'max_retries': 1, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.934|±  |0.0068|
|     |       |strict-match    |     5|exact_match|↑  |0.934|±  |0.0068|
```
```bash
=== Running benchmark with ISL=8192, OSL=1024, RANGE_RATIO=0.8, CONC=32 ===
-------------------  Input/Output Length Statistics  -------------------
 input_lens : min=6581  max=8177  mean=7321.12  avg_token_mismatch=0.00  
 output_lens: min=819   max=1024  mean=915.62  
------------------------------------------------------------------------ 
============ Serving Benchmark Result ============
Successful requests:                     96        
Benchmark duration (s):                  81.47     
Total input tokens:                      702828    
Total generated tokens:                  87900     
Request throughput (req/s):              1.18      
Output token throughput (tok/s):         1078.89   
Total Token throughput (tok/s):          9705.44   
---------------Time to First Token----------------
Mean TTFT (ms):                          2070.07   
Median TTFT (ms):                        617.30    
P99 TTFT (ms):                           9116.33   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          26.18     
Median TPOT (ms):                        26.60     
P99 TPOT (ms):                           32.34     
---------------Inter-token Latency----------------
Mean ITL (ms):                           26.27     
Median ITL (ms):                         18.42     
P99 ITL (ms):                            219.80    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          26097.51  
Median E2EL (ms):                        25691.50  
P99 E2EL (ms):                           36204.18  
==================================================
```
