### PR TITLE
expert map fix

### DIFF
--- a/atom/model_ops/fused_moe_triton.py
+++ b/atom/model_ops/fused_moe_triton.py
@@ -131,7 +131,11 @@ def triton_kernel_moe_forward(
     act_quant: MoEActivationQuant = MoEActivationQuant.BF16,
 ) -> torch.Tensor:
     routing_data, gather_idx, scatter_idx = routing(
-        gating_output, topk, sm_first=not renormalize
+        gating_output,
+        topk,
+        sm_first=not renormalize,
+        expert_map=expert_map,
+        local_num_experts=(int(w1.shape[0]) if expert_map is not None else None),
     )
 
     output = torch.empty_like(hidden_states)

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1168,6 +1168,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 use_grouped_topk=use_grouped_topk,
                 num_expert_group=num_expert_group,
                 topk_group=topk_group,
+                # Expert parallelism: remap global->local expert ids / local hist.
+                expert_map=expert_map,
+                local_num_experts=(
+                    layer.local_num_experts if expert_map is not None else None
+                ),
             )
             return triton_kernel_fused_experts_a8w4_silu_gguu(
                 x,
@@ -1226,6 +1231,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     use_grouped_topk=use_grouped_topk,
                     num_expert_group=num_expert_group,
                     topk_group=topk_group,
+                    # Expert parallelism: remap global->local expert ids and size
+                    # the routing histogram to the rank-local experts held in
+                    # layer.w13_weight, so the GEMM never indexes local weights
+                    # with a global id.
+                    expert_map=expert_map,
+                    local_num_experts=(
+                        layer.local_num_experts if expert_map is not None else None
+                    ),
                 )
                 # Routed-only gate count (no shared-expert widening).
                 n_expts_act = routing_data.n_expts_act


### PR DESCRIPTION
## Motivation

Allow expert parallel fix in ATOM https://github.com/ROCm/aiter/issues/3995

## Technical Details

Expert map routing added to main triton routing, ATOM fix to incorporate expert map

## Test Plan

lm_eval triton and non-triton ATOM DSV4, GPT, DS-R1

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
