### PR TITLE
feat: prefill coalescer for DP-attention (+ profiler labels, TTFT guard)

### DIFF
--- a/.claude/skills/capture-trace/SKILL.md
+++ b/.claude/skills/capture-trace/SKILL.md
@@ -144,11 +144,23 @@ For a UI view, drop the `.gz` (decompressed `.json`) into <https://ui.perfetto.d
 
 ## `record_function` tag format
 
-ATOM annotates the critical path with `torch.profiler.record_function`. The tags follow a stable format used by `parse_trace.py`:
+ATOM annotates the critical path with `torch.profiler.record_function`. The **kind** is the label prefix (groups in Perfetto, greppable); sub-attributes are `key=value` fields. Taxonomy lives in `atom/model_engine/run_labels.py`:
 
-- Prefill: `prefill[bs=<batch> tok=<num_tokens> ctx=<max_ctx>]`
-- Decode: `decode[bs=<batch> tok=<num_tokens> d=<draft_step> spec=<num_spec>]`
-- Draft (eagle mid-step): `draft[i/k bs=<batch>]`
+| Prefix | Meaning |
+|---|---|
+| `prefill[bs= tok= ctx=]` | real prefill (eager) |
+| `decode[bs= tok= p= d= spec=]` | real decode via CUDAGraph |
+| `eager_decode[bs= tok= ctx=]` | real decode forced eager |
+| `dummy_decode[...]` | **DP-sync dummy** (idle rank keeps the MoE collective aligned) |
+| `dummy_eager_decode[...]` | DP-sync dummy, forced eager |
+| `dummy_prefill[...]` | warmup dummy prefill |
+| `draft[i/k bs=]` | eagle/MTP draft mid-step |
+
+Fields: `bs` effective batch, `tok` total tokens, `ctx` per-seq context lens (truncated if many), `p`/`d` prefill/decode seq counts, `spec` speculative steps, and **`tbo=1`** appended when the step ran Two-Batch-Overlap ubatches.
+
+Distinguishing dummy vs real matters: e.g. the leading `dummy_decode[bs=1 tok=1]` runs are DP-sync idle steps, NOT real decode. `parse_trace.py` matches only the exact `prefill[` / `decode[` prefixes, so dummy/eager variants are auto-excluded from its stats.
+
+> **Comparability note:** pre-taxonomy traces labeled DP-sync dummies as plain `decode[...]`, so `parse_trace.py` counted them as real decodes. New traces exclude dummies — decode/prefill counts and averages on a new trace will differ from an old trace of the same workload. Don't attribute that delta to a perf change; re-baseline with a fresh trace.
 
 Searching by these tags is far more reliable than searching by kernel name (which varies across PyTorch/Triton/AITER versions).
 

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -485,8 +485,12 @@ class DPEngineCoreProc(EngineCore):
                 PrefillDelayer(
                     dp_size=config.parallel_config.data_parallel_size,
                     cpu_group=self.dp_group,
-                    max_delay_passes=envs.ATOM_PREFILL_DELAYER_MAX_DELAY_PASSES,
-                    max_delay_ms=envs.ATOM_PREFILL_DELAYER_MAX_DELAY_MS,
+                    max_num_batched_tokens=config.max_num_batched_tokens,
+                    target_fill=envs.ATOM_PREFILL_DELAYER_TARGET_FILL,
+                    ttft_max_ticks=envs.ATOM_PREFILL_DELAYER_TTFT_MAX_TICKS,
+                    partial_max_ticks=envs.ATOM_PREFILL_DELAYER_PARTIAL_MAX_TICKS,
+                    stall_ticks=envs.ATOM_PREFILL_DELAYER_STALL_TICKS,
+                    kv_high_watermark=envs.ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK,
                     token_usage_low_watermark=envs.ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK,
                 )
             )

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -492,6 +492,7 @@ class DPEngineCoreProc(EngineCore):
                     stall_ticks=envs.ATOM_PREFILL_DELAYER_STALL_TICKS,
                     kv_high_watermark=envs.ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK,
                     token_usage_low_watermark=envs.ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK,
+                    max_queue_ms=envs.ATOM_PREFILL_DELAYER_MAX_QUEUE_MS,
                 )
             )
 

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -23,6 +23,7 @@ from aiter.dist.parallel_state import (
 from aiter.dist.utils import get_distributed_init_method
 from atom.config import Config, CUDAGraphMode, set_current_atom_config
 from atom.utils.cuda_graph import BatchDescriptor
+from atom.model_engine.run_labels import build_run_label
 from atom.model_engine.scheduler import ScheduledBatch, ScheduledBatchOutput
 from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
 from atom.model_loader.loader import load_model
@@ -2066,23 +2067,21 @@ class ModelRunner:
         # internally short-circuits for prefill / cudagraph.
         forward_mode.assert_shape_contract(input_ids, forward_context.attn_metadata)
 
+        # Profiler label. Kind (prefix) distinguishes real/dummy and
+        # eager/cudagraph; `tbo=1` marks a step that ran TBO ubatches. See
+        # `build_run_label`.
+        label = build_run_label(
+            is_prefill=is_prefill,
+            use_cudagraph=forward_mode.use_cudagraph,
+            is_dummy=context.is_dummy_run,
+            tbo_on=forward_context.ubatch_slices is not None,
+            bs=bs,
+            batch=batch,
+        )
+
         if not forward_mode.use_cudagraph:
             # prefill, or decode forced eager (enforce_eager / DP peer
             # prefill / bs above the largest captured graph).
-            if is_prefill:
-                label = f"prefill[bs={bs}"
-            else:
-                label = f"eager_decode[bs={bs}"
-            if batch is not None:
-                ctx = batch.context_lens
-                if len(ctx) == 1:
-                    ctx_str = str(ctx[0])
-                elif len(ctx) <= 5:
-                    ctx_str = str(ctx.tolist())
-                else:
-                    ctx_str = f"{ctx[:3].tolist()}...+{len(ctx)-3}"
-                label += f" tok={batch.total_tokens_num} ctx={ctx_str}"
-            label += "]"
             with record_function(label):
                 # Handle multimodal prefill: compute vision embeddings and merge
                 inputs_embeds = None
@@ -2122,16 +2121,8 @@ class ModelRunner:
                     self._aux_hidden_states = None
                 logits = self.model.compute_logits(hidden_states)
         else:
-            # decode[bs=128 tok=128 d=128]  or  decode[bs=128 tok=128 p=2 d=126 spec=3]
-            label = f"decode[bs={bs}"
-            if batch is not None:
-                label += f" tok={batch.total_tokens_num}"
-                if batch.total_seqs_num_prefill > 0:
-                    label += f" p={batch.total_seqs_num_prefill}"
-                label += f" d={batch.total_seqs_num_decode}"
-                if batch.num_spec_step > 0:
-                    label += f" spec={batch.num_spec_step}"
-            label += "]"
+            # decode[bs=128 tok=128 d=128] / decode[... p=2 d=126 spec=3] /
+            # dummy_decode[...] — see build_run_label.
             with record_function(label):
                 graph_bs = context.graph_bs
                 max_q_len = forward_context.attn_metadata.max_seqlen_q

--- a/atom/model_engine/prefill_delayer.py
+++ b/atom/model_engine/prefill_delayer.py
@@ -89,6 +89,7 @@ class PrefillDelayer:
         "stall_ticks",
         "kv_high_watermark",
         "token_usage_low_watermark",
+        "max_queue_ms",
         # buffer / episode state
         "_reduce_buf",
         "_hold_ticks",
@@ -102,6 +103,7 @@ class PrefillDelayer:
         "_stat_fire_kv",
         "_stat_fire_partial",
         "_stat_fire_nodecode",
+        "_stat_fire_queue_ms",
         "_stat_fire_vacuous",
         "_stat_hold",
         "_stat_log_every",
@@ -118,6 +120,7 @@ class PrefillDelayer:
         stall_ticks: int = 3,
         kv_high_watermark: float = 0.9,
         token_usage_low_watermark: Optional[float] = None,
+        max_queue_ms: Optional[float] = None,
     ):
         self.dp_size = dp_size
         self.cpu_group = cpu_group
@@ -150,15 +153,26 @@ class PrefillDelayer:
         self.stall_ticks = self._clamp_ticks("stall_ticks", stall_ticks)
         self.kv_high_watermark = kv_high_watermark
         self.token_usage_low_watermark = token_usage_low_watermark
+        # TTFT SLA guard: if any rank's oldest schedulable waiting-prefill has
+        # queued (since arrival) >= this many ms, force release regardless of the
+        # fill target. None disables it. Wall-clock, but lockstep-safe: each rank
+        # compares its OWN requests' ages to the threshold locally (disjoint
+        # request sets across ranks), and only the OR of those per-rank booleans
+        # crosses the collective — so all ranks act on the identical result the
+        # same tick. (Contrast the removed per-rank hold-clock E1, which compared
+        # each rank's own clock to a threshold for a GLOBAL decision → skew.)
+        self.max_queue_ms = max_queue_ms
 
-        # 6-slot SUM-reduce buffer (gloo-safe). Encoding:
+        # 7-slot SUM-reduce buffer (gloo-safe). Encoding:
         #   slot 0 = prefillable        (SUM → n_prefillable)
         #   slot 1 = pending_tokens     (SUM → G_pending; fresh + partial remain)
         #   slot 2 = running_decode     (SUM → G_running_dec)
-        #   slot 3 = kv_high flag       (SUM>0 → any prefillable rank KV-high; E-KV)
-        #   slot 4 = kv_low flag        (SUM>0 → any prefillable rank KV-low; E-KV)
+        #   slot 3 = kv_high flag       (SUM>0 → any prefillable rank KV-high)
+        #   slot 4 = kv_low flag        (SUM>0 → any prefillable rank KV-low)
         #   slot 5 = has_partial flag   (SUM>0 → any rank mid-chunked-prefill)
-        self._reduce_buf = torch.zeros(6, dtype=torch.int64, device="cpu")
+        #   slot 6 = queue_hot flag     (SUM>0 → any rank's oldest waiting prefill
+        #                                aged past max_queue_ms; TTFT SLA guard)
+        self._reduce_buf = torch.zeros(7, dtype=torch.int64, device="cpu")
 
         # Episode state. All ticks decide FIRE/HOLD in lockstep, so these evolve
         # identically on every rank (deterministic).
@@ -179,6 +193,7 @@ class PrefillDelayer:
         self._stat_fire_kv = 0
         self._stat_fire_partial = 0
         self._stat_fire_nodecode = 0
+        self._stat_fire_queue_ms = 0
         self._stat_fire_vacuous = 0
         self._stat_hold = 0
         self._stat_log_every = int(
@@ -193,7 +208,8 @@ class PrefillDelayer:
             f"partial_max_ticks={self.partial_max_ticks} "
             f"stall_ticks={self.stall_ticks} "
             f"kv_high_watermark={kv_high_watermark} "
-            f"token_usage_low_watermark={token_usage_low_watermark}"
+            f"token_usage_low_watermark={token_usage_low_watermark} "
+            f"max_queue_ms={max_queue_ms}"
         )
 
     @staticmethod
@@ -213,6 +229,7 @@ class PrefillDelayer:
         running_decode_batch: int = 0,
         kv_usage: float = 0.0,
         has_partial: bool = False,
+        oldest_waiting_age_ms: float = 0.0,
     ) -> bool:
         """Return True iff this rank may admit new prefills this tick (FIRE).
 
@@ -235,6 +252,10 @@ class PrefillDelayer:
             has_partial: this rank has a mid-chunked-prefill seq in flight. Its
                 remaining tokens are in pending_tokens; a partial only forces
                 release once held for partial_max_ticks (it holds KV).
+            oldest_waiting_age_ms: age (ms since arrival) of this rank's oldest
+                schedulable waiting prefill. If it reaches max_queue_ms, this
+                rank flags the TTFT SLA guard and all ranks release. 0 / no
+                waiting prefill / max_queue_ms=None → guard inactive.
         """
         # First call fires unconditionally (one-time warmup seed); not counted in
         # the per-exit stats so `fire_vacuous` stays exactly "n_prefillable == 0".
@@ -243,10 +264,16 @@ class PrefillDelayer:
             self._reset()
             return True
 
-        # KV bounds are gated on this rank actually having prefill to push.
+        # KV + queue-age bounds are gated on this rank actually having prefill to
+        # push (firing when this rank can't admit anything would be a no-op).
         low = self.token_usage_low_watermark
         kv_high = prefillable and kv_usage >= self.kv_high_watermark
         kv_low = prefillable and low is not None and kv_usage < low
+        queue_hot = (
+            prefillable
+            and self.max_queue_ms is not None
+            and oldest_waiting_age_ms >= self.max_queue_ms
+        )
 
         self._reduce_buf[0] = 1 if prefillable else 0
         self._reduce_buf[1] = int(pending_tokens)
@@ -254,6 +281,7 @@ class PrefillDelayer:
         self._reduce_buf[3] = 1 if kv_high else 0
         self._reduce_buf[4] = 1 if kv_low else 0
         self._reduce_buf[5] = 1 if has_partial else 0
+        self._reduce_buf[6] = 1 if queue_hot else 0
         try:
             torch.distributed.all_reduce(
                 self._reduce_buf,
@@ -268,14 +296,21 @@ class PrefillDelayer:
             self._reset()
             return True
 
-        # One host<-device readback for all 6 slots (a single .tolist() beats
-        # six .item() boundary crossings on this per-tick hot path).
-        n_prefillable, g_pending, g_running_dec, kv_high_n, kv_low_n, partial_n = (
-            self._reduce_buf.tolist()
-        )
+        # One host<-device readback for all 7 slots (a single .tolist() beats
+        # seven .item() boundary crossings on this per-tick hot path).
+        (
+            n_prefillable,
+            g_pending,
+            g_running_dec,
+            kv_high_n,
+            kv_low_n,
+            partial_n,
+            queue_hot_n,
+        ) = self._reduce_buf.tolist()
         any_kv_high = kv_high_n > 0
         any_kv_low = kv_low_n > 0
         any_partial = partial_n > 0
+        any_queue_hot = queue_hot_n > 0
 
         # Nothing to prefill anywhere → allow (vacuous), reset the episode.
         if n_prefillable == 0:
@@ -289,6 +324,12 @@ class PrefillDelayer:
             return self._fire("nodecode", g_pending)
         if any_kv_high or any_kv_low:
             return self._fire("kv", g_pending)
+        # TTFT SLA guard: a real request has queued (since arrival) past the
+        # threshold — release now regardless of fill/alignment. This is the
+        # end-to-end wait (includes backlog + coalescer holds), unlike the
+        # tick-based ttft bound below which only caps a single hold episode.
+        if any_queue_hot:
+            return self._fire("queue_ms", g_pending)
         if self._hold_ticks >= self.ttft_max_ticks:
             return self._fire("ttft", g_pending)
         if any_partial and self._hold_ticks >= self.partial_max_ticks:
@@ -348,7 +389,7 @@ class PrefillDelayer:
         self._prev_pending = -1
 
     def _maybe_log(self) -> None:
-        # Cheap guard first — skip the 8-counter sum entirely when logging is
+        # Cheap guard first — skip the counter sum entirely when logging is
         # disabled (this runs on every FIRE/HOLD tick).
         if self._stat_log_every <= 0:
             return
@@ -359,6 +400,7 @@ class PrefillDelayer:
             + self._stat_fire_kv
             + self._stat_fire_partial
             + self._stat_fire_nodecode
+            + self._stat_fire_queue_ms
             + self._stat_fire_vacuous
             + self._stat_hold
         )
@@ -373,6 +415,7 @@ class PrefillDelayer:
                 f"fire_kv={self._stat_fire_kv} "
                 f"fire_partial={self._stat_fire_partial} "
                 f"fire_nodecode={self._stat_fire_nodecode} "
+                f"fire_queue_ms={self._stat_fire_queue_ms} "
                 f"fire_vacuous={self._stat_fire_vacuous} "
                 f"hold={self._stat_hold} "
                 f"(hold_rate={self._stat_hold / total:.2%})"

--- a/atom/model_engine/prefill_delayer.py
+++ b/atom/model_engine/prefill_delayer.py
@@ -1,51 +1,74 @@
 """
-PrefillDelayer — cross-DP-rank prefill alignment for ATOM.
+PrefillDelayer — a cross-DP-rank prefill *coalescer* for ATOM.
 
-Direct port of SGLang's PrefillDelayer (refactored form, post #16269), keeping
-the "mixed prefillable status → delay" core that fixes our 1k/1k workload's
-~81% pad_waste during prefill forwards.
+Purpose
+-------
+Under DP-attention each rank schedules independently. Left alone, ranks fire
+many prefill forwards that each carry only a handful of tokens (a short fresh
+prompt, or the small tail chunk of a chunked prefill). Every prefill forward
+has ~fixed cost (kernel launch, pad-to-shape, the lockstep MoE all-to-all), so a
+forward carrying 500 of a 16384-token budget wastes ~97% of that forward.
 
-Mechanism (per scheduler tick):
-  1. Each DP rank reports its local state via cpu all_gather:
-       (local_prefillable, watermark_force_allow)
-  2. Compute `prefillable_status` ∈ {all, none, mixed}:
-       - "all"   → every rank has a new prefill ready  → allow (8-way aligned)
-       - "none"  → no rank has any prefill             → allow (vacuous)
-       - "mixed" → only some ranks have prefill ready  → DELAY
-  3. In "mixed", refuse the prefill (return False from `should_allow_prefill`)
-     for up to `max_delay_passes` consecutive ticks (default 30, ≈ 255ms at
-     8.5ms/decode-tick) OR `max_delay_ms` wall-clock (default 5000ms),
-     whichever comes first. After timeout, force-allow to bound worst-case
-     TTFT.
-  4. Safety valve: if local KV-cache usage drops below
-     `token_usage_low_watermark`, the rank reports "force_allow" and the
-     delayer falls through immediately (the GPU is idling, don't delay).
+The delayer's single job: **hold back prefill admission until the accumulated
+prefill is worth a forward, then release** — Nagle's algorithm for prefill.
+While it holds, decode keeps running (nothing is wasted); TTFT is bounded so a
+held request never starves.
 
-Why this fixes our problem:
-  Today (no delayer) — when 1 rank has a new prefill and 7 have decodes,
-  ATOM runs eager forward NOW. MoE all_to_all is bottlenecked by the
-  prefill rank's ~1000 tokens, costing all 8 ranks ~118ms (a1.log: 81.7%
-  pad_waste, 67% of wall in moe.gather). 57 such mixed forwards = 6.7s.
-  With delayer — the prefilling rank waits up to 255ms for sibling ranks'
-  waiting queues to also gain prefills, then all 8 ranks do prefill
-  simultaneously (balanced all_to_all). 57 mixed forwards → ~8 aligned
-  forwards × ~140ms = 1.1s. Expected: ~5.6s saved per request burst.
+It is NOT about mixing prefill+decode in one forward. It DOES preserve cross-DP
+phase alignment: it only releases when every rank is prefill-ready (so all ranks
+enter prefill together and the MoE collective stays aligned), except when a
+must-fire bound forces release regardless.
 
-What's intentionally NOT ported from SGL (HEAD):
-  - prometheus / observability hooks (ATOM has dp_timing instead)
-  - NCCL gather path (ATOM's dp_group is gloo cpu_group; sufficient)
-  - TBO / hisparse / dllm / spec interactions (N/A)
-  - `queue_min_ratio` adaptive trigger (added 2026-05; defer until baseline)
-  - `slot_condition` (max_running_requests - global_running_bs check):
-        ATOM steady-state running_bs ≈ 16 vs max_num_seqs ≈ 256+, condition
-        never true → omitted to keep code simple
+Decision (evaluated every tick, on every rank, in lockstep)
+-----------------------------------------------------------
+Each rank reports local state; a single cpu ``all_reduce(SUM)`` reduces it; then
+every rank computes the SAME FIRE/HOLD from the reduced values:
+
+  n_prefillable   = #ranks with admittable prefill (SUM of a 0/1 flag)
+  G_pending       = total pending prefill tokens across ranks (fresh + partial
+                    remaining, each rank capped at the token budget)
+  G_running_dec   = total decode seqs across ranks
+  any_kv_high/low = any prefillable rank at/above / below a KV watermark
+  any_partial     = any rank mid-chunked-prefill
+
+  if n_prefillable == 0:                          FIRE   # nothing to do (vacuous)
+  # -- must-fire bounds (release even if unaligned / underfilled) --
+  if G_running_dec == 0:                          FIRE   # no decode to hide the wait behind
+  if any_kv_high or any_kv_low:                   FIRE   # KV pressure / starvation
+  if hold_ticks >= ttft_max_ticks:                FIRE   # TTFT bound
+  if any_partial and hold_ticks >= partial_max_ticks: FIRE  # partial holds KV — tight bound
+  # -- alignment gate: never fire while some rank lacks prefill (anti-skew) --
+  if n_prefillable < dp_size:                     HOLD
+  # -- goal: fire once the aggregate fills a worthwhile forward --
+  fill = G_pending / (n_prefillable * budget)
+  if fill >= target_fill:                         FIRE
+  # -- adaptive give-up: queue stopped growing, waiting longer is futile --
+  if G_pending <= prev_G_pending:  stall += 1  else  stall = 0
+  if stall >= stall_ticks:                        FIRE
+  HOLD
+
+Why SUM (not MAX)
+-----------------
+A MAX ("fire as soon as the busiest rank is ready") drags quiet ranks into
+firing tiny prefills. A SUM/aggregate-fill target holds until the forward is
+collectively worthwhile, so quiet ranks keep accumulating during the hold and
+fire larger when release finally happens. Under-balanced load a quiet rank still
+fires smaller — that is a request-routing problem, out of scope here.
+
+Cross-DP comms
+--------------
+Single ``all_reduce(SUM)`` over a 6-int64 cpu buffer (gloo-safe). Booleans are
+encoded as 0/1 and read back as ``sum > 0`` (logical OR). All timing is
+tick-based (``hold_ticks``), which is deterministic across ranks — no per-rank
+wall-clock, so ranks never diverge on a timeout boundary. Fail-open on a
+collective error (a peer dying should not crash schedule()); the guarded
+DP-state barrier drives shutdown.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import time
 from typing import Optional
 
 import torch
@@ -59,17 +82,28 @@ class PrefillDelayer:
     __slots__ = (
         "dp_size",
         "cpu_group",
-        "max_delay_passes",
-        "max_delay_ms",
+        "max_num_batched_tokens",
+        "target_fill",
+        "ttft_max_ticks",
+        "partial_max_ticks",
+        "stall_ticks",
+        "kv_high_watermark",
         "token_usage_low_watermark",
+        # buffer / episode state
         "_reduce_buf",
-        "_delayed_count",
-        "_delay_start_ts",
-        "_skip_first",
-        "_stat_allow",
-        "_stat_delay",
-        "_stat_timeout",
-        "_stat_watermark",
+        "_hold_ticks",
+        "_stall_count",
+        "_prev_pending",
+        "_first",
+        # stats
+        "_stat_fire_fill",
+        "_stat_fire_stall",
+        "_stat_fire_ttft",
+        "_stat_fire_kv",
+        "_stat_fire_partial",
+        "_stat_fire_nodecode",
+        "_stat_fire_vacuous",
+        "_stat_hold",
         "_stat_log_every",
     )
 
@@ -77,173 +111,269 @@ class PrefillDelayer:
         self,
         dp_size: int,
         cpu_group,
-        max_delay_passes: int = 30,
+        max_num_batched_tokens: int,
+        target_fill: float = 0.7,
+        ttft_max_ticks: int = 30,
+        partial_max_ticks: int = 8,
+        stall_ticks: int = 3,
+        kv_high_watermark: float = 0.9,
         token_usage_low_watermark: Optional[float] = None,
-        max_delay_ms: float = 5000.0,
     ):
         self.dp_size = dp_size
         self.cpu_group = cpu_group
-        self.max_delay_passes = max_delay_passes
-        self.max_delay_ms = max_delay_ms
+        self.max_num_batched_tokens = max_num_batched_tokens
+
+        # target_fill is the fraction of a full prefill batch that must be
+        # accumulated (across prefillable ranks) before we release. Must be in
+        # (0, 1]: <= 0 would fire every tick (no coalescing); > 1 is unreachable
+        # (fill is capped at 1) and would degrade to stall/timeout-only. Clamp.
+        if target_fill <= 0.0:
+            logger.warning(
+                f"target_fill={target_fill} <= 0 disables coalescing "
+                "(fires every tick); clamping to a small positive 0.05."
+            )
+            target_fill = 0.05
+        elif target_fill > 1.0:
+            logger.warning(
+                f"target_fill={target_fill} > 1.0 is unreachable (fill is capped "
+                "at 1.0); clamping to 1.0."
+            )
+            target_fill = 1.0
+        self.target_fill = target_fill
+
+        # Tick bounds must be >= 1. 0 would make the corresponding `>=` fire on
+        # the first tick, defeating the bound.
+        self.ttft_max_ticks = self._clamp_ticks("ttft_max_ticks", ttft_max_ticks)
+        self.partial_max_ticks = self._clamp_ticks(
+            "partial_max_ticks", partial_max_ticks
+        )
+        self.stall_ticks = self._clamp_ticks("stall_ticks", stall_ticks)
+        self.kv_high_watermark = kv_high_watermark
         self.token_usage_low_watermark = token_usage_low_watermark
 
-        # 3-slot MAX-reduce buffer (gloo-friendly; mirrors the proven
-        # `_sync_dp_state` all_reduce path in engine_core.py rather than
-        # relying on all_gather_into_tensor — the stateless gloo group's
-        # docstring warns broadcast-like ops are unreliable, and the
-        # initial hang we saw with all_gather_into_tensor was consistent
-        # with this caveat).
-        #
-        # Encoding:
-        #   slot 0 = local_prefillable          (MAX → "any rank prefillable")
-        #   slot 1 = local_force                (MAX → "any rank forces allow")
-        #   slot 2 = NOT local_prefillable      (MAX → "any rank lacks prefill")
-        # Then prefillable_status:
-        #   any_prefillable AND any_not_prefillable → "mixed"
-        #   any_prefillable AND NOT any_not_prefillable → "all"
-        #   NOT any_prefillable → "none"
-        # Single all_reduce, 3 int64s on cpu — negligible overhead.
-        self._reduce_buf = torch.zeros(3, dtype=torch.int64, device="cpu")
+        # 6-slot SUM-reduce buffer (gloo-safe). Encoding:
+        #   slot 0 = prefillable        (SUM → n_prefillable)
+        #   slot 1 = pending_tokens     (SUM → G_pending; fresh + partial remain)
+        #   slot 2 = running_decode     (SUM → G_running_dec)
+        #   slot 3 = kv_high flag       (SUM>0 → any prefillable rank KV-high; E-KV)
+        #   slot 4 = kv_low flag        (SUM>0 → any prefillable rank KV-low; E-KV)
+        #   slot 5 = has_partial flag   (SUM>0 → any rank mid-chunked-prefill)
+        self._reduce_buf = torch.zeros(6, dtype=torch.int64, device="cpu")
 
-        self._delayed_count: int = 0
-        self._delay_start_ts: float = 0.0
-        # Skip first negotiation: during warmup / first burst we want
-        # decode batch_size to grow as fast as possible. Mirrors SGL
-        # PR #19836 (`skip_first_delayer`).
-        self._skip_first: bool = True
+        # Episode state. All ticks decide FIRE/HOLD in lockstep, so these evolve
+        # identically on every rank (deterministic).
+        self._hold_ticks = 0
+        self._stall_count = 0
+        self._prev_pending = -1
+        # First call fires immediately to seed the initial decode batch build-up
+        # (mirrors SGL PR #19836's skip_first).
+        self._first = True
 
-        # Aggregate counters for periodic logging
-        self._stat_allow = 0
-        self._stat_delay = 0
-        self._stat_timeout = 0
-        self._stat_watermark = 0
+        # Per-exit fire counters + hold counter for periodic logging. Each exit
+        # is counted separately so the log shows WHICH reason released prefill —
+        # a high fire_stall/fire_ttft vs fire_fill means the queue rarely reaches
+        # target and the coalescer is mostly giving up rather than batching.
+        self._stat_fire_fill = 0
+        self._stat_fire_stall = 0
+        self._stat_fire_ttft = 0
+        self._stat_fire_kv = 0
+        self._stat_fire_partial = 0
+        self._stat_fire_nodecode = 0
+        self._stat_fire_vacuous = 0
+        self._stat_hold = 0
         self._stat_log_every = int(
             os.environ.get("ATOM_PREFILL_DELAYER_LOG_EVERY", "1000")
         )
 
         logger.info(
             f"PrefillDelayer initialized: dp_size={dp_size} "
-            f"max_delay_passes={max_delay_passes} "
-            f"max_delay_ms={max_delay_ms} "
-            f"watermark={token_usage_low_watermark}"
+            f"max_num_batched_tokens={max_num_batched_tokens} "
+            f"target_fill={self.target_fill} "
+            f"ttft_max_ticks={self.ttft_max_ticks} "
+            f"partial_max_ticks={self.partial_max_ticks} "
+            f"stall_ticks={self.stall_ticks} "
+            f"kv_high_watermark={kv_high_watermark} "
+            f"token_usage_low_watermark={token_usage_low_watermark}"
         )
+
+    @staticmethod
+    def _clamp_ticks(name: str, value: int) -> int:
+        if value < 1:
+            logger.warning(
+                f"{name}={value} < 1 would fire on the first tick (bound "
+                "disabled); clamping to 1."
+            )
+            return 1
+        return value
 
     def should_allow_prefill(
         self,
-        local_prefillable: bool,
-        token_usage: float,
+        prefillable: bool,
+        pending_tokens: int,
+        running_decode_batch: int = 0,
+        kv_usage: float = 0.0,
+        has_partial: bool = False,
     ) -> bool:
-        """
-        Returns True iff this rank is allowed to admit new prefills this tick.
+        """Return True iff this rank may admit new prefills this tick (FIRE).
+
+        MUST be called every tick on every DP rank (it runs a cross-DP
+        all_reduce) so ranks stay in lockstep.
 
         Args:
-            local_prefillable: this rank has at least one new prefill ready
-                (i.e. self.waiting non-empty and admission would succeed).
-            token_usage: fraction of KV cache blocks currently in use
-                (used_blocks / total_blocks ∈ [0, 1]). Used by the
-                low-watermark safety valve.
+            prefillable: this rank has admittable prefill work (fresh head that
+                can allocate, or a resumable partial). Only prefillable ranks
+                count toward the fill target and the alignment gate.
+            pending_tokens: this rank's accumulated prefill tokens — fresh
+                waiting new-tokens PLUS the remaining tokens of resumable
+                partials — already capped at max_num_batched_tokens by the
+                caller. The coalescer's fill signal.
+            running_decode_batch: decode seqs running on this rank (NOT counting
+                mid-chunked-prefill seqs). If no rank has decode, holding wastes
+                GPU → fire.
+            kv_usage: fraction of KV cache blocks in use ∈ [0, 1]. Drives the
+                KV-high (can't accumulate more) and KV-low (GPU starving) bounds.
+            has_partial: this rank has a mid-chunked-prefill seq in flight. Its
+                remaining tokens are in pending_tokens; a partial only forces
+                release once held for partial_max_ticks (it holds KV).
         """
-        # Local "force allow" if KV cache is underutilized — don't delay
-        # when GPU is starving. Only meaningful if this rank actually has
-        # a prefill to push through (otherwise force_allow is a no-op).
-        force = False
-        if (
-            self.token_usage_low_watermark is not None
-            and local_prefillable
-            and token_usage < self.token_usage_low_watermark
-        ):
-            force = True
+        # First call fires unconditionally (one-time warmup seed); not counted in
+        # the per-exit stats so `fire_vacuous` stays exactly "n_prefillable == 0".
+        if self._first:
+            self._first = False
+            self._reset()
+            return True
 
-        # Cross-DP MAX-reduce: 3 booleans encoded as int64.
-        self._reduce_buf[0] = 1 if local_prefillable else 0
-        self._reduce_buf[1] = 1 if force else 0
-        self._reduce_buf[2] = 0 if local_prefillable else 1
-        torch.distributed.all_reduce(
-            self._reduce_buf,
-            op=torch.distributed.ReduceOp.MAX,
-            group=self.cpu_group,
+        # KV bounds are gated on this rank actually having prefill to push.
+        low = self.token_usage_low_watermark
+        kv_high = prefillable and kv_usage >= self.kv_high_watermark
+        kv_low = prefillable and low is not None and kv_usage < low
+
+        self._reduce_buf[0] = 1 if prefillable else 0
+        self._reduce_buf[1] = int(pending_tokens)
+        self._reduce_buf[2] = int(running_decode_batch)
+        self._reduce_buf[3] = 1 if kv_high else 0
+        self._reduce_buf[4] = 1 if kv_low else 0
+        self._reduce_buf[5] = 1 if has_partial else 0
+        try:
+            torch.distributed.all_reduce(
+                self._reduce_buf,
+                op=torch.distributed.ReduceOp.SUM,
+                group=self.cpu_group,
+            )
+        except RuntimeError:
+            logger.warning(
+                "PrefillDelayer all_reduce failed (peer down?); admitting prefill "
+                "and deferring to the DP-state shutdown barrier."
+            )
+            self._reset()
+            return True
+
+        # One host<-device readback for all 6 slots (a single .tolist() beats
+        # six .item() boundary crossings on this per-tick hot path).
+        n_prefillable, g_pending, g_running_dec, kv_high_n, kv_low_n, partial_n = (
+            self._reduce_buf.tolist()
         )
-        any_prefillable = int(self._reduce_buf[0].item()) > 0
-        force_max = int(self._reduce_buf[1].item())
-        any_not_prefillable = int(self._reduce_buf[2].item()) > 0
+        any_kv_high = kv_high_n > 0
+        any_kv_low = kv_low_n > 0
+        any_partial = partial_n > 0
 
-        # Derive 3-way status: all / none / mixed.
-        prefillable_max = 1 if any_prefillable else 0
-        prefillable_min = 0 if any_not_prefillable else 1
-
-        # Watermark short-circuit: ANY rank below the watermark forces all
-        # ranks to allow this tick. Without this the delayer can stall a
-        # rank with a fresh prefill while the cluster is underloaded.
-        if force_max > 0:
-            self._stat_watermark += 1
-            self._reset_delay()
+        # Nothing to prefill anywhere → allow (vacuous), reset the episode.
+        if n_prefillable == 0:
+            self._reset()
+            self._stat_fire_vacuous += 1
             self._maybe_log()
             return True
 
-        # Skip first call to maximize initial decode batch size build-up.
-        if self._skip_first:
-            self._skip_first = False
-            self._reset_delay()
-            self._stat_allow += 1
-            self._maybe_log()
-            return True
+        # ---- must-fire bounds (release even if unaligned / underfilled) ----
+        if g_running_dec == 0:
+            return self._fire("nodecode", g_pending)
+        if any_kv_high or any_kv_low:
+            return self._fire("kv", g_pending)
+        if self._hold_ticks >= self.ttft_max_ticks:
+            return self._fire("ttft", g_pending)
+        if any_partial and self._hold_ticks >= self.partial_max_ticks:
+            return self._fire("partial", g_pending)
 
-        # status = "all" or "none" → no skew, just allow
-        if prefillable_min == prefillable_max:
-            self._reset_delay()
-            self._stat_allow += 1
-            self._maybe_log()
-            return True
+        # ---- alignment gate: never fire while a rank lacks prefill (anti-skew).
+        # Hold to let stragglers catch up; the ttft bound above bounds the wait.
+        if n_prefillable < self.dp_size:
+            return self._hold(g_pending)
 
-        # status = "mixed" → delay if still within budget
-        if self._delayed_count == 0:
-            self._delay_start_ts = time.perf_counter()
-        elapsed_ms = (time.perf_counter() - self._delay_start_ts) * 1000.0
+        # ---- goal: fire once the aggregate fills a worthwhile forward ----
+        budget = n_prefillable * self.max_num_batched_tokens
+        fill = g_pending / budget if budget > 0 else 1.0
+        if fill >= self.target_fill:
+            return self._fire("fill", g_pending)
 
-        if (
-            self._delayed_count < self.max_delay_passes
-            and elapsed_ms < self.max_delay_ms
-        ):
-            self._delayed_count += 1
-            self._stat_delay += 1
-            if _DEBUG:
-                logger.info(
-                    f"[PrefillDelayer] DELAY: count={self._delayed_count} "
-                    f"elapsed={elapsed_ms:.1f}ms "
-                    f"any_prefillable={any_prefillable} "
-                    f"any_not_prefillable={any_not_prefillable}"
-                )
-            self._maybe_log()
-            return False
+        # ---- adaptive give-up: queue stopped growing → waiting is futile ----
+        if g_pending <= self._prev_pending:
+            self._stall_count += 1
+        else:
+            self._stall_count = 0
+        self._prev_pending = g_pending
+        if self._stall_count >= self.stall_ticks:
+            return self._fire("stall", g_pending)
 
-        # Timed out — force allow to bound worst-case TTFT
-        self._stat_timeout += 1
+        return self._hold(g_pending)
+
+    def _fire(self, reason: str, g_pending: int) -> bool:
+        # reason ∈ {fill, stall, ttft, kv, partial, nodecode, vacuous}; each maps
+        # to a dedicated _stat_fire_<reason> slot so the log shows what released.
+        attr = f"_stat_fire_{reason}"
+        setattr(self, attr, getattr(self, attr) + 1)
         if _DEBUG:
             logger.info(
-                f"[PrefillDelayer] TIMEOUT: count={self._delayed_count} "
-                f"elapsed={elapsed_ms:.1f}ms force-allow"
+                f"[PrefillDelayer] FIRE ({reason}): g_pending={g_pending} "
+                f"hold_ticks={self._hold_ticks} stall={self._stall_count}"
             )
-        self._reset_delay()
+        self._reset()
         self._maybe_log()
         return True
 
-    def _reset_delay(self):
-        self._delayed_count = 0
-        self._delay_start_ts = 0.0
+    def _hold(self, g_pending: int) -> bool:
+        self._hold_ticks += 1
+        self._stat_hold += 1
+        if _DEBUG:
+            logger.info(
+                f"[PrefillDelayer] HOLD: g_pending={g_pending} "
+                f"hold_ticks={self._hold_ticks} stall={self._stall_count} "
+                f"target_fill={self.target_fill}"
+            )
+        self._maybe_log()
+        return False
 
-    def _maybe_log(self):
+    def _reset(self) -> None:
+        self._hold_ticks = 0
+        self._stall_count = 0
+        self._prev_pending = -1
+
+    def _maybe_log(self) -> None:
+        # Cheap guard first — skip the 8-counter sum entirely when logging is
+        # disabled (this runs on every FIRE/HOLD tick).
+        if self._stat_log_every <= 0:
+            return
         total = (
-            self._stat_allow
-            + self._stat_delay
-            + self._stat_timeout
-            + self._stat_watermark
+            self._stat_fire_fill
+            + self._stat_fire_stall
+            + self._stat_fire_ttft
+            + self._stat_fire_kv
+            + self._stat_fire_partial
+            + self._stat_fire_nodecode
+            + self._stat_fire_vacuous
+            + self._stat_hold
         )
-        if self._stat_log_every <= 0 or total == 0:
+        if total == 0:
             return
         if total % self._stat_log_every == 0:
             logger.info(
                 f"[PrefillDelayer stats] total={total} "
-                f"allow={self._stat_allow} delay={self._stat_delay} "
-                f"timeout={self._stat_timeout} watermark={self._stat_watermark} "
-                f"(delay_rate={self._stat_delay/total:.2%})"
+                f"fire_fill={self._stat_fire_fill} "
+                f"fire_stall={self._stat_fire_stall} "
+                f"fire_ttft={self._stat_fire_ttft} "
+                f"fire_kv={self._stat_fire_kv} "
+                f"fire_partial={self._stat_fire_partial} "
+                f"fire_nodecode={self._stat_fire_nodecode} "
+                f"fire_vacuous={self._stat_fire_vacuous} "
+                f"hold={self._stat_hold} "
+                f"(hold_rate={self._stat_hold / total:.2%})"
             )

--- a/atom/model_engine/run_labels.py
+++ b/atom/model_engine/run_labels.py
@@ -1,0 +1,76 @@
+"""Profiler ``record_function`` label taxonomy for forward passes.
+
+Kept in its own dependency-free module so the label contract is unit-testable
+without importing the heavy ``model_runner`` chain (aiter kernels, config, …).
+
+Kinds (label prefix — groups in Perfetto UI, greppable):
+  - ``prefill``             real prefill (eager)
+  - ``decode``             real decode via CUDAGraph
+  - ``eager_decode``       real decode forced eager
+  - ``dummy_decode``       DP-sync dummy (CUDAGraph path)
+  - ``dummy_eager_decode`` DP-sync dummy forced eager
+  - ``dummy_prefill``      warmup dummy prefill
+
+Fields (``key=value`` inside brackets):
+  - ``bs``   effective batch size
+  - ``tok``  total scheduled tokens
+  - ``ctx``  per-seq context lengths (prefill/eager paths; truncated if many)
+  - ``p``/``d``  prefill / decode seq counts (cudagraph decode path)
+  - ``spec`` speculative steps (when > 0)
+  - ``tbo=1`` appended when the step ran Two-Batch-Overlap ubatches
+
+NOTE: ``tools/parse_trace.py`` selects real steps via ``startswith("prefill[")``
+/ ``startswith("decode[")``. The ``dummy_`` / ``eager_`` prefixes deliberately
+fall outside those, so dummies never pollute the prefill/decode statistics.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from atom.model_engine.scheduler import ScheduledBatch
+
+
+def build_run_label(
+    *,
+    is_prefill: bool,
+    use_cudagraph: bool,
+    is_dummy: bool,
+    tbo_on: bool,
+    bs: int,
+    batch: Optional["ScheduledBatch"],
+) -> str:
+    """Build the ``record_function`` label for one forward pass.
+
+    Pure function (no runtime state) — see module docstring for the taxonomy.
+    """
+    if use_cudagraph:
+        kind = "dummy_decode" if is_dummy else "decode"
+        label = f"{kind}[bs={bs}"
+        if batch is not None:
+            label += f" tok={batch.total_tokens_num}"
+            if batch.total_seqs_num_prefill > 0:
+                label += f" p={batch.total_seqs_num_prefill}"
+            label += f" d={batch.total_seqs_num_decode}"
+            if batch.num_spec_step > 0:
+                label += f" spec={batch.num_spec_step}"
+    else:
+        if is_prefill:
+            kind = "dummy_prefill" if is_dummy else "prefill"
+        else:
+            kind = "dummy_eager_decode" if is_dummy else "eager_decode"
+        label = f"{kind}[bs={bs}"
+        if batch is not None:
+            ctx = batch.context_lens
+            if len(ctx) == 1:
+                ctx_str = str(ctx[0])
+            elif len(ctx) <= 5:
+                ctx_str = str(ctx.tolist())
+            else:
+                ctx_str = f"{ctx[:3].tolist()}...+{len(ctx) - 3}"
+            label += f" tok={batch.total_tokens_num} ctx={ctx_str}"
+    if tbo_on:
+        label += " tbo=1"
+    label += "]"
+    return label

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -562,15 +562,86 @@ class Scheduler:
     def _kv_usage(self) -> float:
         """Fraction of KV-cache blocks currently in use ∈ [0, 1].
 
-        Used as the `token_usage` signal for PrefillDelayer's low-watermark
-        safety valve. Derived from BlockManager bookkeeping; cheap (no
-        traversal of seq tables).
+        The `kv_usage` signal for PrefillDelayer's KV watermark bounds — both the
+        high watermark (near-full → release, can't accumulate more) and the
+        optional low watermark (GPU starving → release, feed it). Derived from
+        BlockManager bookkeeping; cheap (no traversal of seq tables).
         """
         bm = self.block_manager
         total = len(bm.blocks)
         if total <= 0:
             return 0.0
         return len(bm.used_block_ids) / total
+
+    def _waiting_new_token_count(self) -> int:
+        """Sum of new (uncached) tokens across the ADMITTABLE waiting queue,
+        saturated at `max_num_batched_tokens`.
+
+        Feeds PrefillDelayer's coalescer fill signal (accumulate a full prefill
+        batch before releasing, instead of firing many tiny fragments). The cap
+        early-exits the scan: one batch's worth is all the coalescer compares
+        against, so there's no point summing a deep queue.
+
+        Skips the same non-admittable seqs as `_can_admit_head_prefill` —
+        unschedulable, WAITING_FOR_REMOTE_KVS, and oversized-when-chunking-off —
+        so the "queued work" signal counts only tokens this rank could actually
+        prefill this step. Counting remote-KV / unschedulable tokens here would
+        inflate the cross-rank aggregate and reach the fill target before a real
+        batch has accumulated. The `num_cached_tokens` discount is best-effort:
+        an un-admitted seq has not been probed against the prefix cache yet, so
+        this is an upper bound on new tokens for cache-hit prompts.
+        """
+        cap = self.max_num_batched_tokens
+        total = 0
+        for seq in self.waiting:
+            if self._unschedulable_reason(seq) is not None:
+                continue
+            if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
+                continue
+            num_new_tokens = seq.num_tokens - seq.num_cached_tokens
+            if (
+                not self.enable_chunked_prefill
+                and num_new_tokens > self.max_num_batched_tokens
+            ):
+                continue
+            total += max(0, num_new_tokens)
+            if total >= cap:
+                return cap
+        return total
+
+    def _partial_prefill_remaining_tokens(self) -> int:
+        """Sum of remaining (not-yet-computed) tokens across mid-chunked-prefill
+        seqs in `running`, saturated at `max_num_batched_tokens`.
+
+        Folded into the coalescer's pending-token signal so a small partial tail
+        chunk does not force its own tiny prefill forward — it accumulates with
+        fresh prefills instead, bounded by the coalescer's partial deadline.
+        Skipped entirely in the common steady-state (no partial) via the
+        `_partial_prefill_count` counter, and stops scanning once all
+        `_partial_prefill_count` partials have been summed.
+
+        This is an UPPER BOUND on what a partial can actually contribute in one
+        forward: `remaining = num_tokens - num_cached_tokens` does NOT apply the
+        per-step `long_prefill_token_threshold` chunk clamp that Phase-1
+        scheduling uses, so when that threshold is set the coalescer fill signal
+        may read slightly high. Acceptable for a coalescing heuristic; consistent
+        with `_waiting_new_token_count`'s best-effort estimate.
+        """
+        if self._partial_prefill_count == 0:
+            return 0
+        cap = self.max_num_batched_tokens
+        total = 0
+        seen = 0
+        for seq in self.running:
+            if not seq.is_partial_prefill:
+                continue
+            total += max(0, seq.num_tokens - seq.num_cached_tokens)
+            if total >= cap:
+                return cap
+            seen += 1
+            if seen >= self._partial_prefill_count:
+                break  # all partials summed; skip the rest of the decode tail
+        return total
 
     def publish_kv_events(self) -> None:
         """Drain BlockManager's event log and publish as one EventBatch. Called
@@ -722,9 +793,24 @@ class Scheduler:
         # should_allow_prefill() runs a cross-DP all_reduce and MUST be called
         # every tick on every rank for lockstep — hence before the early-return.
         if self.prefill_delayer is not None:
+            # pending = fresh waiting new-tokens + resumable partials' remaining,
+            # capped at the batch budget: the coalescer's accumulation signal.
+            pending_tokens = min(
+                self._waiting_new_token_count()
+                + self._partial_prefill_remaining_tokens(),
+                self.max_num_batched_tokens,
+            )
             delayer_allows = self.prefill_delayer.should_allow_prefill(
-                local_prefillable=self._can_admit_head_prefill(),
-                token_usage=self._kv_usage(),
+                prefillable=self._can_admit_head_prefill(),
+                pending_tokens=pending_tokens,
+                # decode-only: self.running also holds mid-chunked-prefill seqs,
+                # which are NOT decode load — counting them would defeat the
+                # coalescer's "no decode → fire" fast path.
+                running_decode_batch=max(
+                    0, len(self.running) - self._partial_prefill_count
+                ),
+                kv_usage=self._kv_usage(),
+                has_partial=self._partial_prefill_count > 0,
             )
         else:
             delayer_allows = True

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -643,6 +643,29 @@ class Scheduler:
                 break  # all partials summed; skip the rest of the decode tail
         return total
 
+    def _oldest_waiting_prefill_age_ms(self) -> float:
+        """Age in ms (since arrival) of the oldest ADMITTABLE waiting prefill,
+        or 0.0 if none.
+
+        Feeds PrefillDelayer's TTFT SLA guard: if this exceeds max_queue_ms the
+        coalescer force-releases so a request never starves in the queue. Uses
+        `seq.arrive_time` (wall-clock seconds, stamped at engine entry) — the
+        true end-to-end wait, including backlog and coalescer holds. Skips the
+        same non-admittable seqs as `_can_admit_head_prefill` (unschedulable,
+        WAITING_FOR_REMOTE_KVS) so a permanently-stuck seq can't peg the guard.
+        """
+        oldest_arrive = None
+        for seq in self.waiting:
+            if self._unschedulable_reason(seq) is not None:
+                continue
+            if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
+                continue
+            if oldest_arrive is None or seq.arrive_time < oldest_arrive:
+                oldest_arrive = seq.arrive_time
+        if oldest_arrive is None:
+            return 0.0
+        return max(0.0, (time.time() - oldest_arrive) * 1000.0)
+
     def publish_kv_events(self) -> None:
         """Drain BlockManager's event log and publish as one EventBatch. Called
         by EngineCore at the end of each scheduler step. No-op when events are
@@ -811,6 +834,7 @@ class Scheduler:
                 ),
                 kv_usage=self._kv_usage(),
                 has_partial=self._partial_prefill_count > 0,
+                oldest_waiting_age_ms=self._oldest_waiting_prefill_age_ms(),
             )
         else:
             delayer_allows = True

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -41,6 +41,7 @@ from aiter.dist.communication_op import (
 from aiter.dist.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
+from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.topk import top_k_per_row_decode, top_k_per_row_prefill
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 from aiter.ops.triton.fusions.fused_clamp_act_mul import (
@@ -48,7 +49,6 @@ from aiter.ops.triton.fusions.fused_clamp_act_mul import (
 )
 from aiter.ops.triton.gemm.batched.batched_gemm_bf16 import batched_gemm_bf16
 from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
-from aiter.jit.utils.chip_info import get_gfx
 from atom.config import (
     Config,
     LayerQuantConfig,

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -250,20 +250,43 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # --- PrefillDelayer (cross-DP prefill alignment) ---
     # Master switch; default on. Set "0" to disable construction.
+    # The delayer is a prefill COALESCER: it holds back prefill admission under
+    # DP-attention until the accumulated prefill fills a worthwhile forward, so
+    # fragmented short-input prefills / small partial tail chunks batch into one
+    # forward instead of firing many tiny ones.
     "ATOM_ENABLE_PREFILL_DELAYER": lambda: (
         os.getenv("ATOM_ENABLE_PREFILL_DELAYER", "1") == "1"
     ),
-    # Max consecutive scheduler passes the delayer is allowed to suppress
-    # prefill admission while waiting for cross-DP alignment.
-    "ATOM_PREFILL_DELAYER_MAX_DELAY_PASSES": lambda: int(
-        os.getenv("ATOM_PREFILL_DELAYER_MAX_DELAY_PASSES", "30")
+    # Fill target: release prefill once accumulated pending tokens reach
+    # target_fill * max_num_batched_tokens (averaged across prefillable ranks).
+    # In (0, 1]; higher batches harder (fewer, larger prefills) at some TTFT
+    # cost. Default 0.7.
+    "ATOM_PREFILL_DELAYER_TARGET_FILL": lambda: float(
+        os.getenv("ATOM_PREFILL_DELAYER_TARGET_FILL", "0.7")
     ),
-    # Wall-clock cap (milliseconds) on a single delay window.
-    "ATOM_PREFILL_DELAYER_MAX_DELAY_MS": lambda: float(
-        os.getenv("ATOM_PREFILL_DELAYER_MAX_DELAY_MS", "5000")
+    # TTFT bound: max consecutive scheduler ticks a held prefill waits before
+    # force-release (deterministic across ranks; replaces the old wall-clock +
+    # pass-count pair).
+    "ATOM_PREFILL_DELAYER_TTFT_MAX_TICKS": lambda: int(
+        os.getenv("ATOM_PREFILL_DELAYER_TTFT_MAX_TICKS", "30")
     ),
-    # Optional KV-usage low watermark below which delaying is allowed.
-    # Empty string => None (use PrefillDelayer's internal default).
+    # Tight bound (ticks) for a held mid-chunked-prefill: a partial holds already
+    # allocated KV, so it force-releases sooner than a fresh prefill.
+    "ATOM_PREFILL_DELAYER_PARTIAL_MAX_TICKS": lambda: int(
+        os.getenv("ATOM_PREFILL_DELAYER_PARTIAL_MAX_TICKS", "8")
+    ),
+    # Consecutive non-growing ticks after which the coalescer gives up waiting
+    # (burst ended, more won't come) and releases.
+    "ATOM_PREFILL_DELAYER_STALL_TICKS": lambda: int(
+        os.getenv("ATOM_PREFILL_DELAYER_STALL_TICKS", "3")
+    ),
+    # KV high watermark: at/above this KV usage a prefillable rank force-releases
+    # (can't accumulate a bigger batch anyway).
+    "ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK": lambda: float(
+        os.getenv("ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK", "0.9")
+    ),
+    # Optional KV-usage low watermark: below it a prefillable rank force-releases
+    # (GPU starving — feed it). Empty string => None => disabled.
     "ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK": lambda: (
         None
         if os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK", "") == ""

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -292,6 +292,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK", "") == ""
         else float(os.getenv("ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK"))
     ),
+    # TTFT SLA guard: if any rank's oldest schedulable waiting prefill has queued
+    # (since arrival) >= this many ms, force-release regardless of the fill
+    # target. Bounds worst-case TTFT. Empty string => None => disabled (set this
+    # to your TTFT budget in ms to activate; a small value under heavy backlog
+    # will fire every tick and defeat coalescing, so size it to the SLA).
+    "ATOM_PREFILL_DELAYER_MAX_QUEUE_MS": lambda: (
+        None
+        if os.getenv("ATOM_PREFILL_DELAYER_MAX_QUEUE_MS", "") == ""
+        else float(os.getenv("ATOM_PREFILL_DELAYER_MAX_QUEUE_MS"))
+    ),
     # --- TBO prefill ubatch splitting ---
     # Split prefill ubatches at the exact token midpoint (vLLM-DBO style),
     # cutting through a request if needed for perfectly balanced 50/50 ubatches.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -16,6 +16,34 @@ This document describes the environment variables used in the ATOM project.
 
 ---
 
+## Prefill Delayer (DP attention)
+
+Prefill **coalescer** for DP-attention + EP-MoE serving. Holds back prefill
+admission until the accumulated prefill (fresh waiting tokens + resumable
+partials' remaining tokens) fills a worthwhile forward, so fragmented
+short-input prefills / small partial tail chunks batch into one forward instead
+of firing many tiny ones. Releases when the fill target is reached, when a
+must-fire bound trips (no decode to hide behind, KV pressure/starvation, TTFT
+deadline, partial deadline), or when the queue stops growing. Preserves
+cross-rank phase alignment (releases only when every rank is prefill-ready,
+unless a bound forces it). All timing is tick-based (deterministic across ranks —
+no wall-clock skew). See `atom/model_engine/prefill_delayer.py`. Active only when
+`data_parallel_size > 1`.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| **ATOM_ENABLE_PREFILL_DELAYER** | bool | true | Master switch for the prefill coalescer. |
+| **ATOM_PREFILL_DELAYER_TARGET_FILL** | float | 0.7 | Release once accumulated pending tokens reach `target_fill × max_num_batched_tokens` (averaged across prefillable ranks). In (0, 1]; higher = fewer, larger prefills at some TTFT cost. Clamped to (0, 1]. |
+| **ATOM_PREFILL_DELAYER_TTFT_MAX_TICKS** | int | 30 | Max consecutive scheduler ticks a held prefill waits before force-release. Values `< 1` clamped to 1. |
+| **ATOM_PREFILL_DELAYER_PARTIAL_MAX_TICKS** | int | 8 | Tighter bound for a held mid-chunked-prefill (it holds allocated KV). Values `< 1` clamped to 1. |
+| **ATOM_PREFILL_DELAYER_STALL_TICKS** | int | 3 | After this many consecutive non-growing ticks, release (burst ended, more won't come). Values `< 1` clamped to 1. |
+| **ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK** | float | 0.9 | At/above this KV usage a prefillable rank force-releases (can't accumulate a bigger batch anyway). |
+| **ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK** | float\|"" | "" (None) | If set, a prefillable rank below this KV usage force-releases (GPU starving). |
+| **ATOM_PREFILL_DELAYER_DEBUG** | bool | false | Per-tick FIRE/HOLD debug logging. |
+| **ATOM_PREFILL_DELAYER_LOG_EVERY** | int | 1000 | Emit aggregate stats (per-exit fire counts + hold rate) every N decisions (0 disables). |
+
+---
+
 ## Model Loading
 
 | Variable | Type | Default | Description |

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -39,6 +39,7 @@ no wall-clock skew). See `atom/model_engine/prefill_delayer.py`. Active only whe
 | **ATOM_PREFILL_DELAYER_STALL_TICKS** | int | 3 | After this many consecutive non-growing ticks, release (burst ended, more won't come). Values `< 1` clamped to 1. |
 | **ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK** | float | 0.9 | At/above this KV usage a prefillable rank force-releases (can't accumulate a bigger batch anyway). |
 | **ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK** | float\|"" | "" (None) | If set, a prefillable rank below this KV usage force-releases (GPU starving). |
+| **ATOM_PREFILL_DELAYER_MAX_QUEUE_MS** | float\|"" | "" (None) | TTFT SLA guard: if any rank's oldest schedulable waiting prefill has queued (since arrival) ≥ this many ms, force-release regardless of the fill target. Measures true end-to-end wait (backlog + coalescer holds), unlike the tick-based TTFT bound which only caps one hold episode. Empty = disabled; set to your TTFT budget (a small value under heavy backlog fires every tick and defeats coalescing). |
 | **ATOM_PREFILL_DELAYER_DEBUG** | bool | false | Per-tick FIRE/HOLD debug logging. |
 | **ATOM_PREFILL_DELAYER_LOG_EVERY** | int | 1000 | Emit aggregate stats (per-exit fire counts + hold rate) every N decisions (0 disables). |
 

--- a/tests/test_prefill_delayer.py
+++ b/tests/test_prefill_delayer.py
@@ -61,6 +61,7 @@ def call(
     running_decode_batch=64,
     kv_usage=0.5,
     has_partial=False,
+    oldest_waiting_age_ms=0.0,
     reduce=_noop_all_reduce,
 ):
     with mock.patch("torch.distributed.all_reduce", reduce):
@@ -70,6 +71,7 @@ def call(
             running_decode_batch=running_decode_batch,
             kv_usage=kv_usage,
             has_partial=has_partial,
+            oldest_waiting_age_ms=oldest_waiting_age_ms,
         )
 
 
@@ -138,6 +140,46 @@ class TestMustFireBounds:
         assert call(d, pending_tokens=3000) is False  # hold_ticks 3
         assert call(d, pending_tokens=4000) is True  # hold_ticks>=3 → ttft
         assert d._stat_fire_ttft == 1
+
+
+class TestQueueAgeGuard:
+    def test_disabled_by_default(self):
+        # max_queue_ms=None → guard inactive even with an ancient waiting req.
+        d = make_delayer()  # no max_queue_ms
+        skip_first(d)
+        assert call(d, pending_tokens=1000, oldest_waiting_age_ms=1e9) is False
+
+    def test_fires_when_queue_age_exceeds_threshold(self):
+        d = make_delayer(max_queue_ms=5000, ttft_max_ticks=1000, stall_ticks=1000)
+        skip_first(d)
+        # below target, below age → hold
+        assert call(d, pending_tokens=1000, oldest_waiting_age_ms=1000) is False
+        # aged past 5000ms → force release regardless of fill
+        assert call(d, pending_tokens=1000, oldest_waiting_age_ms=6000) is True
+        assert d._stat_fire_queue_ms == 1
+
+    def test_age_guard_beats_alignment_gate(self):
+        # Even when mixed (n_prefillable<dp_size), an over-age request releases.
+        d = make_delayer(dp_size=2, max_queue_ms=5000, ttft_max_ticks=1000)
+        skip_first(d)
+        mixed = _add_rank({})  # sibling not prefillable → mixed
+        assert (
+            call(d, pending_tokens=1000, oldest_waiting_age_ms=6000, reduce=mixed)
+            is True
+        )
+        assert d._stat_fire_queue_ms == 1
+
+    def test_age_guard_gated_on_prefillable(self):
+        # A non-prefillable rank (can't admit) does not trip the guard itself;
+        # with dp_size=1 that means no release from age.
+        d = make_delayer(max_queue_ms=5000, ttft_max_ticks=1000, stall_ticks=1000)
+        skip_first(d)
+        # not prefillable → vacuous allow (n_prefillable==0), not a queue_ms fire
+        assert (
+            call(d, prefillable=False, pending_tokens=0, oldest_waiting_age_ms=9000)
+            is True
+        )
+        assert d._stat_fire_queue_ms == 0
 
 
 class TestStall:

--- a/tests/test_prefill_delayer.py
+++ b/tests/test_prefill_delayer.py
@@ -1,0 +1,256 @@
+"""Unit tests for PrefillDelayer — the prefill coalescer.
+
+The delayer's only cross-process dependency is a single
+``torch.distributed.all_reduce(SUM)`` over its internal buffer. We patch that so
+a single test process behaves as one DP rank whose local values ARE the global
+sum (dp_size=1), and inject extra ranks explicitly where alignment matters.
+
+No GPU / real distributed group needed.
+"""
+
+from unittest import mock
+
+import pytest
+
+from atom.model_engine.prefill_delayer import PrefillDelayer
+
+MAX_BATCHED = 16384
+
+
+def _noop_all_reduce(tensor, op=None, group=None):
+    # Single rank: SUM(x) == x, so leaving the buffer untouched is correct.
+    return tensor
+
+
+def _add_rank(slots):
+    """all_reduce mock that adds one more rank's contribution to the buffer.
+
+    `slots` maps buffer index → that sibling rank's value (indices per
+    PrefillDelayer._reduce_buf: 0=prefillable, 1=pending, 2=running_decode).
+    """
+
+    def f(tensor, op=None, group=None):
+        for i, v in slots.items():
+            tensor[i] += v
+        return tensor
+
+    return f
+
+
+def make_delayer(**kw):
+    defaults = dict(
+        dp_size=1,
+        cpu_group=None,
+        max_num_batched_tokens=MAX_BATCHED,
+        target_fill=0.7,
+        ttft_max_ticks=30,
+        partial_max_ticks=8,
+        stall_ticks=3,
+        kv_high_watermark=0.9,
+        token_usage_low_watermark=None,
+    )
+    defaults.update(kw)
+    return PrefillDelayer(**defaults)
+
+
+def call(
+    d,
+    *,
+    prefillable=True,
+    pending_tokens=0,
+    running_decode_batch=64,
+    kv_usage=0.5,
+    has_partial=False,
+    reduce=_noop_all_reduce,
+):
+    with mock.patch("torch.distributed.all_reduce", reduce):
+        return d.should_allow_prefill(
+            prefillable=prefillable,
+            pending_tokens=pending_tokens,
+            running_decode_batch=running_decode_batch,
+            kv_usage=kv_usage,
+            has_partial=has_partial,
+        )
+
+
+def skip_first(d):
+    # The first call always fires (seed initial decode batch); tests want steady.
+    assert call(d, pending_tokens=0) is True
+
+
+class TestSkipFirst:
+    def test_first_call_fires(self):
+        d = make_delayer()
+        assert call(d, pending_tokens=0) is True  # one-time warmup seed
+        assert d._first is False
+
+
+class TestFillTarget:
+    def test_holds_below_target(self):
+        d = make_delayer()
+        skip_first(d)
+        # threshold = 0.7 * 16384 = 11468.8; 1000 < that, decode running → HOLD
+        assert call(d, pending_tokens=1000) is False
+        assert d._stat_hold == 1
+
+    def test_fires_at_target(self):
+        d = make_delayer()
+        skip_first(d)
+        assert call(d, pending_tokens=12000) is True  # >= 0.7 * budget
+        assert d._stat_fire_fill == 1
+
+    def test_fires_exactly_at_threshold(self):
+        d = make_delayer()
+        skip_first(d)
+        assert call(d, pending_tokens=11469) is True  # ceil(0.7*16384)
+
+
+class TestMustFireBounds:
+    def test_no_decode_fires(self):
+        d = make_delayer()
+        skip_first(d)
+        assert call(d, pending_tokens=1000, running_decode_batch=0) is True
+        assert d._stat_fire_nodecode == 1
+
+    def test_kv_high_fires(self):
+        d = make_delayer()
+        skip_first(d)
+        assert call(d, pending_tokens=1000, kv_usage=0.95) is True
+        assert d._stat_fire_kv == 1
+
+    def test_kv_low_fires_when_watermark_set(self):
+        d = make_delayer(token_usage_low_watermark=0.2)
+        skip_first(d)
+        assert call(d, pending_tokens=1000, kv_usage=0.1) is True
+        assert d._stat_fire_kv == 1
+
+    def test_kv_low_disabled_by_default(self):
+        d = make_delayer()  # low watermark None
+        skip_first(d)
+        assert call(d, pending_tokens=1000, kv_usage=0.001) is False  # no kv fire
+
+    def test_ttft_bound_fires(self):
+        # Growing (no stall) but always below target → held until TTFT bound.
+        d = make_delayer(ttft_max_ticks=3, stall_ticks=1000)
+        skip_first(d)
+        assert call(d, pending_tokens=1000) is False  # hold_ticks 1
+        assert call(d, pending_tokens=2000) is False  # hold_ticks 2
+        assert call(d, pending_tokens=3000) is False  # hold_ticks 3
+        assert call(d, pending_tokens=4000) is True  # hold_ticks>=3 → ttft
+        assert d._stat_fire_ttft == 1
+
+
+class TestStall:
+    def test_stall_fires_when_queue_not_growing(self):
+        d = make_delayer(stall_ticks=3, ttft_max_ticks=1000)
+        skip_first(d)
+        assert call(d, pending_tokens=1000) is False  # prev set
+        assert call(d, pending_tokens=1000) is False  # stall 1
+        assert call(d, pending_tokens=1000) is False  # stall 2
+        assert call(d, pending_tokens=1000) is True  # stall 3 → fire
+        assert d._stat_fire_stall == 1
+
+    def test_growth_resets_stall(self):
+        d = make_delayer(stall_ticks=2, ttft_max_ticks=1000)
+        skip_first(d)
+        assert call(d, pending_tokens=1000) is False  # prev set
+        assert call(d, pending_tokens=1000) is False  # stall 1
+        assert call(d, pending_tokens=2000) is False  # grew → stall reset to 0
+        assert call(d, pending_tokens=2000) is False  # stall 1
+        assert call(d, pending_tokens=2000) is True  # stall 2 → fire
+
+
+class TestPartial:
+    def test_small_partial_does_not_fire_immediately(self):
+        # A small partial (below fill target) must be held, not fired at once.
+        d = make_delayer(partial_max_ticks=3, ttft_max_ticks=1000, stall_ticks=1000)
+        skip_first(d)
+        assert call(d, pending_tokens=500, has_partial=True) is False
+        assert call(d, pending_tokens=500, has_partial=True) is False
+
+    def test_partial_fires_after_partial_deadline(self):
+        d = make_delayer(partial_max_ticks=2, ttft_max_ticks=1000, stall_ticks=1000)
+        skip_first(d)
+        assert call(d, pending_tokens=500, has_partial=True) is False  # hold 1
+        assert call(d, pending_tokens=500, has_partial=True) is False  # hold 2
+        assert call(d, pending_tokens=500, has_partial=True) is True  # >=2 → fire
+        assert d._stat_fire_partial == 1
+
+    def test_partial_deadline_tighter_than_ttft(self):
+        # Same held duration fires via partial (2) well before ttft (1000).
+        d = make_delayer(partial_max_ticks=2, ttft_max_ticks=1000, stall_ticks=1000)
+        skip_first(d)
+        call(d, pending_tokens=500, has_partial=True)
+        call(d, pending_tokens=500, has_partial=True)
+        assert call(d, pending_tokens=500, has_partial=True) is True
+        assert d._stat_fire_ttft == 0
+
+
+class TestVacuous:
+    def test_no_prefillable_rank_allows(self):
+        d = make_delayer()
+        skip_first(d)
+        assert call(d, prefillable=False, pending_tokens=0) is True
+        assert d._stat_fire_vacuous == 1  # skip_first is not counted
+
+
+class TestAlignmentGate:
+    def test_mixed_holds_even_when_full(self):
+        # dp_size=2, sibling rank NOT prefillable → n_prefillable(1) < 2 → HOLD,
+        # even though local pending alone would exceed the fill target.
+        d = make_delayer(dp_size=2, ttft_max_ticks=1000)
+        skip_first(d)
+        mixed = _add_rank({})  # sibling contributes nothing (prefillable=0)
+        assert call(d, pending_tokens=MAX_BATCHED, reduce=mixed) is False
+        assert d._stat_hold == 1
+
+    def test_aligned_fires_when_full(self):
+        # dp_size=2, sibling prefillable + full → aligned, aggregate fill high.
+        d = make_delayer(dp_size=2, ttft_max_ticks=1000)
+        skip_first(d)
+        aligned = _add_rank({0: 1, 1: MAX_BATCHED, 2: 64})
+        assert call(d, pending_tokens=MAX_BATCHED, reduce=aligned) is True
+        assert d._stat_fire_fill == 1
+
+    def test_mixed_released_by_ttft(self):
+        d = make_delayer(dp_size=2, ttft_max_ticks=2, stall_ticks=1000)
+        skip_first(d)
+        mixed = _add_rank({})
+        assert call(d, pending_tokens=MAX_BATCHED, reduce=mixed) is False  # hold 1
+        assert call(d, pending_tokens=MAX_BATCHED, reduce=mixed) is False  # hold 2
+        assert call(d, pending_tokens=MAX_BATCHED, reduce=mixed) is True  # ttft
+        assert d._stat_fire_ttft == 1
+
+
+class TestParamClamps:
+    def test_target_fill_above_one_clamped(self):
+        d = make_delayer(target_fill=1.5)
+        assert d.target_fill == 1.0
+
+    def test_target_fill_zero_clamped_positive(self):
+        d = make_delayer(target_fill=0.0)
+        assert 0.0 < d.target_fill <= 0.1
+
+    def test_ticks_below_one_clamped(self):
+        d = make_delayer(ttft_max_ticks=0, partial_max_ticks=-3, stall_ticks=0)
+        assert d.ttft_max_ticks == 1
+        assert d.partial_max_ticks == 1
+        assert d.stall_ticks == 1
+
+
+class TestStatsDistinct:
+    def test_fill_and_stall_counted_separately(self):
+        d = make_delayer(stall_ticks=2, ttft_max_ticks=1000)
+        skip_first(d)
+        # a stall fire
+        call(d, pending_tokens=1000)
+        call(d, pending_tokens=1000)
+        assert call(d, pending_tokens=1000) is True  # stall
+        # then a healthy fill fire
+        assert call(d, pending_tokens=12000) is True
+        assert d._stat_fire_stall == 1
+        assert d._stat_fire_fill == 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_run_label.py
+++ b/tests/test_run_label.py
@@ -1,0 +1,171 @@
+"""Unit tests for the profiler label taxonomy (`build_run_label`).
+
+Pure-function tests — no GPU / no forward pass needed. Guards the label
+contract that `tools/parse_trace.py` and the capture-trace skill depend on.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from atom.model_engine.run_labels import build_run_label
+
+
+@dataclass
+class _FakeBatch:
+    total_tokens_num: int = 0
+    total_seqs_num_prefill: int = 0
+    total_seqs_num_decode: int = 0
+    num_spec_step: int = 0
+    context_lens: object = None
+
+
+def prefill_batch(tok, ctx):
+    return _FakeBatch(
+        total_tokens_num=tok,
+        total_seqs_num_prefill=len(ctx),
+        context_lens=np.asarray(ctx, dtype=np.int64),
+    )
+
+
+def decode_batch(tok, d, p=0, spec=0):
+    return _FakeBatch(
+        total_tokens_num=tok,
+        total_seqs_num_prefill=p,
+        total_seqs_num_decode=d,
+        num_spec_step=spec,
+        context_lens=np.zeros(d, dtype=np.int64),
+    )
+
+
+class TestKindPrefix:
+    def test_real_prefill(self):
+        lbl = build_run_label(
+            is_prefill=True,
+            use_cudagraph=False,
+            is_dummy=False,
+            tbo_on=False,
+            bs=2,
+            batch=prefill_batch(14721, [7803, 6918]),
+        )
+        assert lbl.startswith("prefill[")
+        assert "tok=14721" in lbl and "ctx=[7803, 6918]" in lbl
+
+    def test_real_cudagraph_decode(self):
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=64,
+            batch=decode_batch(64, d=64),
+        )
+        assert lbl.startswith("decode[")
+        assert " d=64" in lbl
+
+    def test_real_eager_decode(self):
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=False,
+            is_dummy=False,
+            tbo_on=False,
+            bs=300,
+            batch=decode_batch(300, d=300),
+        )
+        assert lbl.startswith("eager_decode[")
+
+    def test_dummy_decode_distinct_from_real(self):
+        dummy = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=True,
+            tbo_on=False,
+            bs=1,
+            batch=decode_batch(1, d=1),
+        )
+        real = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=1,
+            batch=decode_batch(1, d=1),
+        )
+        assert dummy.startswith("dummy_decode[")
+        assert real.startswith("decode[")
+        # The whole point: dummy must NOT be mistaken for a real decode.
+        assert not dummy.startswith("decode[")
+
+    def test_dummy_prefill(self):
+        lbl = build_run_label(
+            is_prefill=True,
+            use_cudagraph=False,
+            is_dummy=True,
+            tbo_on=False,
+            bs=1,
+            batch=prefill_batch(8192, [8192]),
+        )
+        assert lbl.startswith("dummy_prefill[")
+        assert not lbl.startswith("prefill[")
+
+    def test_dummy_eager_decode(self):
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=False,
+            is_dummy=True,
+            tbo_on=False,
+            bs=1,
+            batch=decode_batch(1, d=1),
+        )
+        assert lbl.startswith("dummy_eager_decode[")
+
+
+class TestFields:
+    def test_tbo_field(self):
+        lbl = build_run_label(
+            is_prefill=True,
+            use_cudagraph=False,
+            is_dummy=False,
+            tbo_on=True,
+            bs=3,
+            batch=prefill_batch(16384, [7000, 6000, 3384]),
+        )
+        assert lbl.endswith("tbo=1]")
+
+    def test_spec_and_p_fields(self):
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=128,
+            batch=decode_batch(128, d=126, p=2, spec=3),
+        )
+        assert " p=2" in lbl and " d=126" in lbl and " spec=3" in lbl
+
+    def test_ctx_truncation_many_seqs(self):
+        lbl = build_run_label(
+            is_prefill=True,
+            use_cudagraph=False,
+            is_dummy=False,
+            tbo_on=False,
+            bs=8,
+            batch=prefill_batch(8000, list(range(8))),
+        )
+        assert "...+5" in lbl  # 8 seqs → first 3 shown + "...+5"
+
+    def test_no_batch(self):
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=16,
+            batch=None,
+        )
+        assert lbl == "decode[bs=16]"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -252,6 +252,114 @@ class TestSchedule:
         assert seq.output_tokens == [sched.eos_token_id]
 
 
+# ── _waiting_new_token_count (PrefillDelayer queue signal) ─────────────────
+
+
+class TestWaitingNewTokenCount:
+    """The coalescer fill signal must count only ADMITTABLE waiting seqs,
+    mirroring `_can_admit_head_prefill`'s skip set — otherwise remote-KV /
+    unschedulable tokens inflate the aggregate and reach the fill target early."""
+
+    def _sched(self):
+        return Scheduler(
+            MockConfig(
+                num_kvcache_blocks=100,
+                kv_cache_block_size=4,
+                max_num_batched_tokens=1000,
+                max_model_len=64,
+                enable_chunked_prefill=True,
+            )
+        )
+
+    def test_counts_normal_waiting_tokens(self, seq_factory):
+        sched = self._sched()
+        sched.waiting = deque(
+            [seq_factory(list(range(8))), seq_factory(list(range(10)))]
+        )
+        assert sched._waiting_new_token_count() == 18
+
+    def test_skips_remote_kv_seqs(self, seq_factory):
+        sched = self._sched()
+        normal = seq_factory(list(range(8)))
+        remote = seq_factory(list(range(10)))
+        remote.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
+        sched.waiting = deque([normal, remote])
+        # Only the 8 admittable tokens count; the 10 remote-KV tokens are skipped.
+        assert sched._waiting_new_token_count() == 8
+
+    def test_skips_unschedulable_oversized_seq(self, seq_factory):
+        # Prompt longer than max_model_len is permanently unschedulable → skipped.
+        sched = self._sched()
+        normal = seq_factory(list(range(8)))
+        oversized = seq_factory(list(range(200)))  # > max_model_len=64
+        sched.waiting = deque([normal, oversized])
+        assert sched._waiting_new_token_count() == 8
+
+    def test_saturates_at_cap(self, seq_factory):
+        sched = Scheduler(
+            MockConfig(
+                num_kvcache_blocks=100,
+                kv_cache_block_size=4,
+                max_num_batched_tokens=16,
+                max_model_len=64,
+                enable_chunked_prefill=True,
+            )
+        )
+        sched.waiting = deque([seq_factory(list(range(10))) for _ in range(5)])
+        assert sched._waiting_new_token_count() == 16  # capped, scan short-circuits
+
+
+class TestPartialPrefillRemainingTokens:
+    """Remaining tokens of mid-chunked-prefill seqs, folded into the coalescer
+    pending signal so a small partial tail chunk batches instead of firing
+    its own tiny forward. `remaining = num_tokens - num_cached_tokens`."""
+
+    def _sched(self):
+        return Scheduler(
+            MockConfig(
+                num_kvcache_blocks=100,
+                kv_cache_block_size=4,
+                max_num_batched_tokens=1000,
+                max_model_len=64,
+                enable_chunked_prefill=True,
+            )
+        )
+
+    def test_zero_when_no_partials(self, seq_factory):
+        sched = self._sched()
+        sched.running = deque([seq_factory(list(range(8)))])  # not partial
+        assert sched._partial_prefill_remaining_tokens() == 0
+
+    def test_sums_partial_remaining(self, seq_factory):
+        sched = self._sched()
+        p1 = seq_factory(list(range(20)))
+        p1.is_partial_prefill = True
+        p1.num_cached_tokens = 8  # 12 remaining
+        p2 = seq_factory(list(range(30)))
+        p2.is_partial_prefill = True
+        p2.num_cached_tokens = 25  # 5 remaining
+        plain = seq_factory(list(range(10)))  # not partial → excluded
+        sched.running = deque([p1, p2, plain])
+        sched._partial_prefill_count = 2
+        assert sched._partial_prefill_remaining_tokens() == 17
+
+    def test_saturates_at_cap(self, seq_factory):
+        sched = Scheduler(
+            MockConfig(
+                num_kvcache_blocks=1000,
+                kv_cache_block_size=4,
+                max_num_batched_tokens=16,
+                max_model_len=4096,
+                enable_chunked_prefill=True,
+            )
+        )
+        big = seq_factory(list(range(100)))
+        big.is_partial_prefill = True
+        sched.running = deque([big])
+        sched._partial_prefill_count = 1
+        assert sched._partial_prefill_remaining_tokens() == 16  # capped
+
+
 # ── long_prefill_token_threshold ──────────────────────────────────────────
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,6 +4,7 @@
 
 from collections import deque
 from types import SimpleNamespace
+from unittest import mock
 
 from atom.model_engine.scheduler import (
     ScheduledBatch,
@@ -358,6 +359,48 @@ class TestPartialPrefillRemainingTokens:
         sched.running = deque([big])
         sched._partial_prefill_count = 1
         assert sched._partial_prefill_remaining_tokens() == 16  # capped
+
+
+class TestOldestWaitingPrefillAge:
+    """TTFT SLA guard signal: age (ms) of the oldest ADMITTABLE waiting prefill,
+    skipping the same non-admittable seqs as _can_admit_head_prefill."""
+
+    def _sched(self):
+        return Scheduler(
+            MockConfig(
+                num_kvcache_blocks=100,
+                kv_cache_block_size=4,
+                max_num_batched_tokens=1000,
+                max_model_len=64,
+                enable_chunked_prefill=True,
+            )
+        )
+
+    def test_zero_when_empty(self):
+        sched = self._sched()
+        sched.waiting = deque()
+        assert sched._oldest_waiting_prefill_age_ms() == 0.0
+
+    def test_uses_oldest_arrival(self, seq_factory):
+        sched = self._sched()
+        new = seq_factory(list(range(8)))
+        old = seq_factory(list(range(8)))
+        sched.waiting = deque([new, old])
+        with mock.patch("atom.model_engine.scheduler.time.time", return_value=1000.0):
+            new.arrive_time = 999.0  # 1s ago
+            old.arrive_time = 997.5  # 2.5s ago → oldest
+            assert sched._oldest_waiting_prefill_age_ms() == 2500.0
+
+    def test_skips_remote_kv(self, seq_factory):
+        sched = self._sched()
+        admittable = seq_factory(list(range(8)))
+        remote = seq_factory(list(range(8)))
+        remote.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
+        sched.waiting = deque([admittable, remote])
+        with mock.patch("atom.model_engine.scheduler.time.time", return_value=1000.0):
+            admittable.arrive_time = 999.0  # 1s
+            remote.arrive_time = 990.0  # 10s but skipped (remote-KV)
+            assert sched._oldest_waiting_prefill_age_ms() == 1000.0
 
 
 # ── long_prefill_token_threshold ──────────────────────────────────────────

--- a/tests/test_scheduler_partial_prefill_tail.py
+++ b/tests/test_scheduler_partial_prefill_tail.py
@@ -33,7 +33,7 @@ class _VetoDelayer:
     """Stub cross-DP delayer that always refuses prefill this tick, forcing the
     decode loop to run while a partial prefill is still sitting in `running`."""
 
-    def should_allow_prefill(self, local_prefillable, token_usage):
+    def should_allow_prefill(self, prefillable, pending_tokens, **kwargs):
         return False
 
 

--- a/tools/analyze_trace_summary.py
+++ b/tools/analyze_trace_summary.py
@@ -63,7 +63,7 @@ def extract_labeled_events(events: list[dict]) -> list[StepEvent]:
 
 
 def parse_label(name: str) -> dict[str, str]:
-    """Parse label like 'decode[bs=4 tok=16 d=4 spec=3]' into dict."""
+    """Parse label like 'decode[bs=4 tok=16 p=0 d=4 spec=3]' into dict."""
     m = re.match(r"(\w+)\[(.+)\]", name)
     if not m:
         return {"type": name}
@@ -102,7 +102,12 @@ def generate_report(events: list[StepEvent], filepath: str) -> str:
     lines.append("# Trace Performance Summary")
     lines.append(f"\n**File:** `{Path(filepath).name}`\n")
 
-    # Separate by phase
+    # Separate by phase. The exact "prefill[" / "decode[" prefixes exclude
+    # DP-sync dummy steps ("dummy_decode[" / "dummy_prefill[") and forced-eager
+    # decodes ("eager_decode[") — see atom/model_engine/run_labels.py.
+    # NOTE: pre-taxonomy traces labeled dummies as plain "decode[", so counts
+    # here differ vs an old trace of the same workload; re-baseline, don't read
+    # the delta as a perf change.
     prefills = [
         e
         for e in events

--- a/tools/parse_trace.py
+++ b/tools/parse_trace.py
@@ -512,7 +512,9 @@ def parse_prefill(events: List[Dict], output_xlsx: str, target_layer: int = 3) -
     Parse prefill phase from a run trace (no warmup mixed in this trace).
     """
     # CPU side prefill annotations.
-    # Matches "prefill[bs=1 tok=115 ctx=115]" format.
+    # Matches "prefill[bs=1 tok=115 ctx=115]" format. The exact "prefill["
+    # prefix intentionally EXCLUDES dummy warmup prefills ("dummy_prefill[")
+    # so they don't pollute the stats — see atom/model_engine/run_labels.py.
     prefills = [
         e
         for e in events
@@ -809,7 +811,10 @@ def parse_decode(
     """
     print("Building event index...")
 
-    # Find GPU-annotated decode events (cat='gpu_user_annotation')
+    # Find GPU-annotated decode events (cat='gpu_user_annotation').
+    # "decode[" matches only real CUDAGraph decodes; "dummy_decode[" (DP-sync
+    # dummy) and "eager_decode[" are excluded by design — see
+    # atom/model_engine/run_labels.py for the full label taxonomy.
     decodes = [
         e
         for e in run_events


### PR DESCRIPTION
## Summary

Reworks DP-attention prefill scheduling into a **prefill coalescer** and adds profiler-label + TTFT-guard support. Three commits:

### 1. `feat: prefill coalescer for DP-attention`
Replaces the token-based queue trigger with a SUM-based coalescer — Nagle's algorithm for prefill. The delayer holds prefill admission until accumulated pending tokens (fresh waiting + resumable partials' remaining) fill a worthwhile forward, then releases. Decode keeps running during the hold; TTFT is bounded so a held request never starves.

- Single `all_reduce(SUM)` over a 6-int64 cpu buffer, all **tick-based** (deterministic across ranks, no wall-clock skew): must-fire bounds (no-decode / KV high+low / TTFT / partial deadline), a cross-rank **alignment gate** (hold while some rank lacks prefill — anti-skew), a **fill target**, and a **stall give-up**.
- **Aggregate SUM (not MAX)** so quiet ranks keep accumulating during a hold instead of being dragged into small prefills. Small partials fold into the pending signal with a tight deadline instead of firing their own tiny forwards.
- Config (`ATOM_PREFILL_DELAYER_*`): `TARGET_FILL` (0.7), `TTFT_MAX_TICKS` (30), `PARTIAL_MAX_TICKS` (8), `STALL_TICKS` (3), `KV_HIGH_WATERMARK` (0.9), `TOKEN_USAGE_LOW_WATERMARK` (off). Default on for `data_parallel_size > 1`.

**A/B (DeepSeek-V4-Pro, TBO+DPA, dp=8):**

| scenario | delayer OFF | coalescer ON | Δ |
|---|---|---|---|
| 1k/1k c1024 | 22,898 tok/s | 26,646 tok/s | **+16.4%** |
| 8k/1k c1024 | 37,215 tok/s | 44,416 tok/s | **+19.3%** |
| GSM8K (fewshot=3) | — | **0.9583** | ≥ baseline 0.95 |

Trace confirms coalescing: prefill forwards carry `bs=3–4 tok=16384` (multiple 8k prompts batched to full budget) instead of one ~8k prefill per prompt.

### 2. `refactor: distinguish dummy/eager/tbo in profiler forward labels`
`run_model`'s `record_function` labels couldn't tell a DP-sync dummy decode from a real bs=1 decode, and TBO on/off wasn't in the label. Extracts label building into a pure, unit-tested helper (`atom/model_engine/run_labels.build_run_label`) with a clear taxonomy (prefill / decode / eager_decode / dummy_* + `tbo=1`). `parse_trace.py` / `analyze_trace_summary.py` match exact prefixes so dummies are auto-excluded from stats.

### 3. `feat: TTFT SLA guard for prefill coalescer (max_queue_ms)`
Adds a queue-time release condition: if any DP rank's oldest schedulable waiting prefill has queued (since arrival) ≥ `ATOM_PREFILL_DELAYER_MAX_QUEUE_MS`, the coalescer force-releases regardless of the fill target. Measures **true end-to-end wait** via `seq.arrive_time` (backlog + coalescer holds), unlike the tick-based bound which only caps one hold episode. Lockstep-safe despite wall-clock: each rank compares its own requests' ages locally, only the OR crosses the collective. Default off (size it to your TTFT SLA).

## Test plan

- [x] `pytest tests/test_prefill_delayer.py tests/test_scheduler.py tests/test_scheduler_partial_prefill_tail.py tests/test_run_label.py` — all green
- [x] `black --check` + `ruff check` clean
- [x] A/B throughput + GSM8K accuracy on DeepSeek-V4-Pro (see table)
- [x] Trace captured & verified coalescing behavior
- [x] Multiple rounds of max-effort multi-agent code review, findings fixed

## Notes
- Branch name (`...queue-trigger...`) is legacy; the queue trigger was replaced by the coalescer in commit 1 (the old design never appears as an intermediate commit — history goes straight from main to coalescer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
