### PR TITLE
[fix] Stabilize ATOM FP8 no-eager rollout weight sync and CUDA graph lifecycle

### DIFF
--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -174,14 +174,14 @@ class LLMEngine:
             mm_data_iter,
             request_id_iter,
         ):
-            req = self.io_processor.preprocess(
+            fanout = self.io_processor.preprocess_fanout(
                 prompt,
                 sampling_param,
                 stream_callback=callback,
                 multimodal_data=mm_data,
-                request_id=request_id,
+                parent_request_id=request_id,
             )
-            reqs.append(req)
+            reqs.extend(fanout)
         self.core_mgr.add_request(reqs)
 
     def step(self) -> list[Sequence]:

--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -60,7 +60,7 @@ def rmsnorm2d_fwd_(
 ) -> torch.Tensor:
     ori_shape = x.shape
     x = x.reshape(-1, dim)
-    return rmsnorm2d_fwd(x, weight, eps).view(ori_shape)
+    return rmsnorm2d_fwd(x, weight, eps, use_model_sensitive_rmsnorm=1).view(ori_shape)
 
 
 @torch_compile_guard()
@@ -71,7 +71,9 @@ def rmsnorm2d_fwd_with_add_(
     x = x.reshape(-1, dim)
     out = torch.empty_like(x)
     residual_out = torch.empty_like(x)
-    rmsnorm2d_fwd_with_add(out, x, residual, residual_out, weight, eps)
+    rmsnorm2d_fwd_with_add(
+        out, x, residual, residual_out, weight, eps, use_model_sensitive_rmsnorm=1
+    )
     return out.view(ori_shape), residual_out.view(ori_shape)
 
 

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -473,6 +473,7 @@ class LinearBase(nn.Module):
 
         assert online_quant_dtype in [
             torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
             torch.float4_e2m1fn_x2,
         ], (
             f"Unsupported online quant: "
@@ -540,6 +541,7 @@ class LinearBase(nn.Module):
         self.quant_func = get_hip_quant(online_quant_type)
         self.need_normalize_e4m3fn_to_e4m3fnuz = (
             online_quant_dtype == torch.float8_e4m3fnuz
+            and q_weight.dtype != torch.float8_e4m3fnuz
         )
         self._online_quant_info = {
             "layer": self.prefix,

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -33,6 +33,7 @@ from atom.model_ops.utils import (
 from atom.utils import envs
 from atom.utils.decorators import mark_trace
 from atom.quantization.quark.utils import (
+    quantize_weight_to_fp8_128x128_blockscale,
     quant_weight_online,
     weight_dequant_fp8,
     weight_dequant_mxfp8,
@@ -525,20 +526,32 @@ class LinearBase(nn.Module):
             # dequant MXFP8 (FP8 elements + 1x32 E8M0 shared scale)
             weight = weight_dequant_mxfp8(weight, weight_scale)
 
-        q_weight, weight_scale = quant_weight_online(
-            weight, online_quant_type, online_quant_dtype
-        )
+        if online_quant_type == QuantType.per_1x128:
+            # The blockscale GEMM path consumes true 128x128 scales shaped
+            # (N//128, K//128). Keep online load/reload aligned with the
+            # RLHF weight-sync requantization path.
+            q_weight, weight_scale = quantize_weight_to_fp8_128x128_blockscale(
+                weight, online_quant_dtype
+            )
+        else:
+            q_weight, weight_scale = quant_weight_online(
+                weight, online_quant_type, online_quant_dtype
+            )
         if need_gather:
             q_weight, weight_scale = self._shard_quantized_weight(
                 q_weight, weight_scale
             )
         self.weight = nn.Parameter(q_weight, requires_grad=False)
         self.weight_scale = nn.Parameter(weight_scale, requires_grad=False)
+        self.weight.weight_loader_process = self.weight_loader_process
+        self.weight_scale.weight_loader_process = self.weight_loader_process
 
         # Update quant state
         self.quant_type = online_quant_type
         self.params_dtype = online_quant_dtype
         self.quant_func = get_hip_quant(online_quant_type)
+        # get_hip_quant already returns fnuz when quant_dtype=fnuz on gfx942;
+        # only normalize when output is still non-fnuz.
         self.need_normalize_e4m3fn_to_e4m3fnuz = (
             online_quant_dtype == torch.float8_e4m3fnuz
             and q_weight.dtype != torch.float8_e4m3fnuz

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -14,7 +14,12 @@ from aiter.fused_moe import fused_moe
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.ops.flydsl.moe_common import GateMode
-from aiter.ops.shuffle import moe_shuffle_scale, shuffle_weight
+from aiter.ops.shuffle import shuffle_weight
+
+try:
+    from aiter.ops.shuffle import moe_shuffle_scale
+except ImportError:
+    from aiter.ops.shuffle import shuffle_scale as moe_shuffle_scale
 from atom.config import (
     Config,
     QuantizationConfig,

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2790,12 +2790,16 @@ class FusedMoE(torch.nn.Module):
                 load_full=load_full,
             )
         else:
-            # The Aiter FP4 quantization function returns a value of type FP4*2
+            # mxfp4 (per_1x32) returns a byte-encoded FP4x2 / e8m0 scale that
+            # must be byte-viewed before loading. Other schemes (e.g. per_1x128
+            # 128x128 block FP8) carry a float32 scale that is copied as-is.
+            if quant_type == QuantType.per_1x32:
+                loaded_weight = loaded_weight.view(torch.uint8)
             self._load_model_weight_or_group_weight_scale(
                 shard_dim=shard_dim,
                 expert_data=expert_data,
                 shard_id=shard_id,
-                loaded_weight=loaded_weight.view(torch.uint8),
+                loaded_weight=loaded_weight,
                 tp_rank=tp_rank,
                 load_full=load_full,
             )

--- a/atom/model_ops/utils.py
+++ b/atom/model_ops/utils.py
@@ -139,7 +139,16 @@ def shuffle_weights(*tensors: torch.nn.Parameter, layout: tuple[int, int] = (16,
 
         weight = tensor.data
         if weight.dim() == 2:
-            tensor.data = shuffle_weight(weight, layout=layout)
+            shuffled = shuffle_weight(weight, layout=layout)
+            # Preserve the parameter's storage/address when possible so CUDA
+            # graphs captured against it remain valid across in-place online
+            # weight updates (no recapture needed). Fall back to reassignment
+            # only if the shuffled layout changes shape/dtype.
+            if shuffled.shape == weight.shape and shuffled.dtype == weight.dtype:
+                weight.copy_(shuffled)
+                tensor.data = weight
+            else:
+                tensor.data = shuffled
         elif weight.dim() == 3:
             # Split fully on dim0 and shuffle each 2D slice independently.
             for i in range(weight.shape[0]):

--- a/atom/models/qwen3.py
+++ b/atom/models/qwen3.py
@@ -24,6 +24,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Any, Iterable, Union
 
 import torch
@@ -331,6 +332,9 @@ class Qwen3ForCausalLM(nn.Module):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         logits = self.lm_head(hidden_states)
+        true_vocab_size = int(os.environ.get("LUMENRL_ATOM_TRUE_VOCAB_SIZE", "0") or 0)
+        if true_vocab_size > 0 and logits.shape[-1] > true_vocab_size:
+            logits[..., true_vocab_size:] = float("-inf")
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -212,39 +212,31 @@ class QuarkOnlineParser(QuantConfigParser):
         and ``online_exclude_layers_list``.
 
         Supported format strings:
-        - ``"ptpc_fp8"``  — per-tensor-per-channel FP8
-        - ``"mxfp4"``     — microscaling FP4 (block size 32)
+        - ``"ptpc_fp8"``        — per-tensor-per-channel FP8
+        - ``"per_block_fp8"``   — per-block FP8 (128x128; alias of per_block128_fp8)
+        - ``"per_block128_fp8"``— per-block FP8, 128x128 block
+        - ``"mxfp4"``           — microscaling FP4 (block size 32)
         """
         if not isinstance(online_quant_config, dict):
             raise TypeError("online_quant_config must be a dict parsed from JSON.")
 
-        scheme_map = {
-            "ptpc": QuantType.per_Token,
-            "per_block": QuantType.per_1x128,
+        # Explicit table of supported online quant formats -> (QuantType, dtype_str).
+        # per_block / per_block128 are aliases (128 is the default block size).
+        FORMAT_MAP = {
+            "ptpc_fp8": (QuantType.per_Token, "fp8"),
+            "per_block_fp8": (QuantType.per_1x128, "fp8"),
+            "per_block128_fp8": (QuantType.per_1x128, "fp8"),
+            "mxfp4": (QuantType.per_1x32, "fp4"),
         }
 
         def _parse_online_quant_format(quant_format_str: str) -> LayerQuantConfig:
             quant_format_str = quant_format_str.strip().lower()
-            quant_type = None
-            dtype_str = None
-
-            if quant_format_str.startswith("mx"):
-                quant_type = QuantType.per_1x32
-                dtype_str = quant_format_str[2:]
-            else:
-                matched_scheme = None
-                for scheme in sorted(scheme_map, key=len, reverse=True):
-                    if quant_format_str.startswith(scheme + "_"):
-                        matched_scheme = scheme
-                        break
-                if matched_scheme is not None:
-                    quant_type = scheme_map[matched_scheme]
-                    dtype_str = quant_format_str[len(matched_scheme) + 1 :]
-                else:
-                    raise ValueError(
-                        f"Unsupported online quant format: '{quant_format_str}'. "
-                        f"Expected '<scheme>_<dtype>' (e.g. ptpc_fp8) or 'mx<dtype>' (e.g. mxfp4)."
-                    )
+            if quant_format_str not in FORMAT_MAP:
+                raise ValueError(
+                    f"Unsupported online quant format: '{quant_format_str}'. "
+                    f"Expected one of: {sorted(FORMAT_MAP)}."
+                )
+            quant_type, dtype_str = FORMAT_MAP[quant_format_str]
 
             dtype_str = dtype_str.split("_")[0]
             if dtype_str.endswith("4"):

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -218,8 +218,9 @@ class QuarkOnlineParser(QuantConfigParser):
         if not isinstance(online_quant_config, dict):
             raise TypeError("online_quant_config must be a dict parsed from JSON.")
 
-        SCHEME_MAP = {
+        scheme_map = {
             "ptpc": QuantType.per_Token,
+            "per_block": QuantType.per_1x128,
         }
 
         def _parse_online_quant_format(quant_format_str: str) -> LayerQuantConfig:
@@ -231,10 +232,14 @@ class QuarkOnlineParser(QuantConfigParser):
                 quant_type = QuantType.per_1x32
                 dtype_str = quant_format_str[2:]
             else:
-                parts = quant_format_str.split("_", 1)
-                if len(parts) == 2 and parts[0] in SCHEME_MAP:
-                    quant_type = SCHEME_MAP[parts[0]]
-                    dtype_str = parts[1]
+                matched_scheme = None
+                for scheme in sorted(scheme_map, key=len, reverse=True):
+                    if quant_format_str.startswith(scheme + "_"):
+                        matched_scheme = scheme
+                        break
+                if matched_scheme is not None:
+                    quant_type = scheme_map[matched_scheme]
+                    dtype_str = quant_format_str[len(matched_scheme) + 1 :]
                 else:
                     raise ValueError(
                         f"Unsupported online quant format: '{quant_format_str}'. "

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -152,19 +152,62 @@ def quant_mxfp4_online_even(
     return q_weight.view(dtypes.fp4x2), weight_scale.view(dtypes.fp8_e8m0)
 
 
+def quantize_weight_to_fp8_128x128_blockscale(weight, quant_dtype):
+    """Quantize a 2D weight to FP8 with 128x128 block scales.
+
+    Returns:
+        q_weight: quantized weight with the same shape as input ``weight``.
+        scale: per-block scale with shape ``(ceil(N/128), ceil(K/128))``.
+    """
+    assert weight.dim() == 2, f"expected 2D weight, got shape={tuple(weight.shape)}"
+
+    w = weight.to(torch.float32).contiguous()
+    n, k = w.shape
+    n_blocks = (n + 127) // 128
+    k_blocks = (k + 127) // 128
+    n_padded = n_blocks * 128
+    k_padded = k_blocks * 128
+
+    if n_padded != n or k_padded != k:
+        w = torch.nn.functional.pad(w, (0, k_padded - k, 0, n_padded - n))
+
+    w_blocks = w.view(n_blocks, 128, k_blocks, 128).permute(0, 2, 1, 3).contiguous()
+
+    finfo = torch.finfo(quant_dtype)
+    block_amax = w_blocks.abs().amax(dim=(2, 3))
+    scale = (block_amax / finfo.max).clamp_min(torch.finfo(torch.float32).tiny)
+
+    q_blocks = torch.clamp(
+        w_blocks / scale.unsqueeze(-1).unsqueeze(-1), min=finfo.min, max=finfo.max
+    ).to(quant_dtype)
+
+    q_weight = (
+        q_blocks.permute(0, 2, 1, 3)
+        .contiguous()
+        .view(n_padded, k_padded)[:n, :k]
+        .contiguous()
+    )
+    return q_weight, scale.contiguous()
+
+
 def quant_weight_online(
     weight: torch.Tensor,
     online_quant_type: QuantType,
     online_quant_dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Dispatch online weight quantization by target dtype.
+    """Dispatch online weight quantization by target dtype / scheme.
 
     Single entry point shared by the Linear and MoE online-quant paths so both
     stay in sync:
 
     - MXFP4 (``dtypes.fp4x2``): use the aiter HIP kernel with ``Even`` round
       mode (:func:`quant_mxfp4_online_even`), matching the offline Quark kernel.
-    - FP8 (incl. ptpc_fp8 per-token / per-channel): use the aiter quant
+    - per_1x128 FP8: use :func:`quantize_weight_to_fp8_128x128_blockscale` to
+      produce a true 128x128 block scale of shape ``(N//128, K//128)``. This is
+      what the blockscale GEMM consumes; ``get_hip_quant(per_1x128)`` would
+      instead produce a 1x128-along-K scale ``(N, K//128)`` that is inconsistent
+      with the GEMM and collapses generation.
+    - other FP8 (incl. ptpc_fp8 per-token / per-channel): use the aiter quant
       function resolved from ``get_hip_quant(online_quant_type)``.
 
     :param weight: The (already dequantized) weight tensor to quantize.
@@ -177,5 +220,7 @@ def quant_weight_online(
 
     if online_quant_dtype == dtypes.fp4x2:
         return quant_mxfp4_online_even(weight)
+    if online_quant_type == QuantType.per_1x128:
+        return quantize_weight_to_fp8_128x128_blockscale(weight, online_quant_dtype)
     quant_func = get_hip_quant(online_quant_type)
     return quant_func(weight, quant_dtype=online_quant_dtype)

--- a/atom/rollout/memory_manager.py
+++ b/atom/rollout/memory_manager.py
@@ -214,10 +214,6 @@ class MemoryManagerMixin:
                 f"{self.label}: CUDA graph recapture failed: {e}",
                 exc_info=True,
             )
-            # Fall back to eager mode rather than crashing
-            self.enforce_eager = True
-            self.graphs = {}
-            self.graph_pool = None
             if hasattr(self, "_graphs_backup_keys"):
                 del self._graphs_backup_keys
-            logger.warning(f"{self.label}: Falling back to enforce_eager=True")
+            raise

--- a/atom/rollout/memory_manager.py
+++ b/atom/rollout/memory_manager.py
@@ -86,6 +86,17 @@ class MemoryManagerMixin:
     def _release_weights(self) -> None:
         if not hasattr(self, "model") or self.model is None:
             return
+        # No-eager sleep policy: keep weights AND CUDA graphs resident so their
+        # GPU addresses stay stable across sleep/wake. Online weight updates are
+        # applied in-place (param.data.copy_ + in-place shuffle), so the graphs
+        # remain valid and never need recapture — this avoids the GPU
+        # memory-access fault that occurs when recapturing graphs on wake under
+        # PYTORCH_CUDA_ALLOC_CONF=expandable_segments.
+        if not self.enforce_eager:
+            logger.info(
+                f"{self.label}: no-eager sleep keeps weights + CUDA graphs resident"
+            )
+            return
         # Release CUDA graphs first — they hold references to weight memory
         # and prevent freeing GPU memory.
         if not self.enforce_eager and hasattr(self, "graphs") and self.graphs:
@@ -129,6 +140,13 @@ class MemoryManagerMixin:
 
     def _release_kv_cache(self) -> None:
         if not hasattr(self, "kv_cache") or self.kv_cache is None:
+            return
+        # No-eager: keep the KV cache resident so its GPU address stays stable —
+        # decode CUDA graphs capture the KV cache base pointer, so freeing and
+        # re-allocating it would invalidate the graphs and force a (fault-prone)
+        # recapture on wake. Contents are still zeroed via clear_kv_cache().
+        if not self.enforce_eager:
+            logger.info(f"{self.label}: no-eager sleep keeps KV cache resident")
             return
         self._kv_cache_num_blocks = self.config.num_kvcache_blocks
 

--- a/atom/rollout/weight_updater.py
+++ b/atom/rollout/weight_updater.py
@@ -123,8 +123,22 @@ class WeightUpdaterMixin:
                     requires_grad=False,
                 )
                 wlp = getattr(param, "weight_loader_process", None)
+                if wlp is None:
+                    wlp = getattr(module, "weight_loader_process", None)
                 if wlp is not None:
                     buf.weight_loader_process = wlp
+                else:
+                    def _weight_loader_process(param_data, loaded_weight):
+                        if param_data.dtype != loaded_weight.dtype:
+                            loaded_weight = loaded_weight.to(param_data.dtype)
+                        if (
+                            loaded_weight.shape != param_data.shape
+                            and loaded_weight.numel() == param_data.numel()
+                        ):
+                            loaded_weight = loaded_weight.reshape(param_data.shape)
+                        param_data.copy_(loaded_weight)
+
+                    buf.weight_loader_process = _weight_loader_process
 
                 for sid in expected:
                     shard_t = self._packed_weight_accum[atom_name]["shards"][sid]
@@ -297,11 +311,16 @@ class WeightUpdaterMixin:
             return
 
         from aiter import QuantType as _QT
+        from atom.utils import envs
         from atom.model_ops.utils import shuffle_weights
 
         needs_shuffle = False
         if quant_type.value == _QT.per_1x128.value:
-            needs_shuffle = True
+            # Match LinearBase.process_weights_after_loading(): blockscale FP8
+            # weights are only preshuffled when ATOM is configured to use the
+            # preshuffle GEMM path. Forcing a shuffle here makes post-sync
+            # weights use a different layout from initial online quantization.
+            needs_shuffle = envs.ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE
         elif quant_type.value == _QT.per_1x32.value:
             needs_shuffle = True
         elif quant_type.value == _QT.per_Token.value:
@@ -312,7 +331,7 @@ class WeightUpdaterMixin:
             except ImportError:
                 needs_shuffle = param.element_size() < 2
 
-        if needs_shuffle:
+        if needs_shuffle and param.dim() == 2:
             shuffle_weights(param)
 
     def update_weights(

--- a/atom/rollout/weight_updater.py
+++ b/atom/rollout/weight_updater.py
@@ -231,26 +231,20 @@ class WeightUpdaterMixin:
         quant_type = getattr(module, "quant_type", None)
 
         if quant_type is not None and quant_type.value == _QT.per_1x128.value:
-            N, K = tensor_gpu.shape
-            block_k = 128
-            K_blocks = (K + block_k - 1) // block_k
-            if K % block_k != 0:
-                padded = torch.zeros(
-                    N, K_blocks * block_k, dtype=torch.float32, device=self.device
-                )
-                padded[:, :K] = tensor_gpu
-            else:
-                padded = tensor_gpu
-            blocks = padded.reshape(N, K_blocks, block_k)
-            block_amax = blocks.abs().amax(dim=-1)
-            scale = (block_amax / fp8_max).clamp(min=1e-12)
-            quantized = (blocks / scale.unsqueeze(-1)).to(fp8_dtype)
-            quantized = quantized.reshape(N, K_blocks * block_k)[:, :K].contiguous()
-            param.data.copy_(quantized)
-            ws = weight_scale.data
-            weight_scale.data.copy_(
-                scale[: ws.shape[0], : ws.shape[1]].contiguous().to(ws.dtype)
+            # Must match the load-time online_quantize_weight layout: a true
+            # 128x128 block scale of shape (N//128, K//128). The previous code
+            # produced a 1x128-along-K scale (N, K//128) and sliced it into the
+            # (N//128, K//128) buffer, which is inconsistent with the blockscale
+            # GEMM and collapses generation after the first weight update.
+            from atom.quantization.quark.utils import (
+                quantize_weight_to_fp8_128x128_blockscale,
             )
+
+            q_weight, scale = quantize_weight_to_fp8_128x128_blockscale(
+                tensor_gpu, fp8_dtype
+            )
+            param.data.copy_(q_weight)
+            weight_scale.data.copy_(scale.to(weight_scale.dtype))
 
         elif quant_type is not None and quant_type.value == _QT.per_Tensor.value:
             amax = tensor_gpu.abs().max()

--- a/atom/rollout/weight_updater.py
+++ b/atom/rollout/weight_updater.py
@@ -21,58 +21,33 @@ class WeightUpdaterMixin:
       - self.clear_kv_cache() — method
     """
 
-    def _refresh_cudagraphs_after_weight_update(self) -> None:
-        """Recapture CUDA graphs after online weight updates.
+    def _invalidate_cudagraphs_after_weight_update(self) -> None:
+        """Drop stale CUDA graphs after online weight updates.
 
-        No-eager decode replays graphs captured before the trainer pushes new
-        weights.  FP8 online updates mutate both the packed weight and its scale
-        tensors in place, so replaying the old graph can use stale captured
-        kernel state and produce degenerate generations.  Recapturing here keeps
-        the next decode on the fast path while making the graph reflect the new
-        weights/scales.
+        Recapture is intentionally deferred to ``resume_memory``/wake-up, where
+        MemoryManagerMixin verifies that both weights and KV cache are resident
+        on GPU.  This avoids recapturing against an incomplete post-update
+        memory state while preventing stale graph replay.
         """
         if getattr(self, "enforce_eager", False):
             return
-        capture_cudagraph = getattr(self, "capture_cudagraph", None)
-        if capture_cudagraph is None:
-            return
 
-        logger.info(f"{self.label}: Recapturing CUDA graphs after weight update")
-        try:
-            torch.cuda.synchronize()
-            if hasattr(self, "graphs"):
-                self.graphs.clear()
-            if hasattr(self, "graph_logits"):
-                self.graph_logits.clear()
-            if hasattr(self, "graph_aux_hidden"):
-                self.graph_aux_hidden.clear()
-            if hasattr(self, "graph_pool"):
-                self.graph_pool = None
-            tbo_graphs = getattr(getattr(self, "model", None), "tbo_graphs", None)
-            if tbo_graphs is not None:
-                tbo_graphs.clear()
-            torch.cuda.empty_cache()
-            capture_cudagraph()
-            torch.cuda.synchronize()
-            logger.info(
-                f"{self.label}: CUDA graph recapture after weight update completed"
-            )
-        except Exception as exc:
-            logger.error(
-                f"{self.label}: CUDA graph recapture after weight update failed: {exc}",
-                exc_info=True,
-            )
-            # Prefer a correct eager fallback over replaying stale graphs.
-            self.enforce_eager = True
-            if hasattr(self, "graphs"):
-                self.graphs = {}
-            if hasattr(self, "graph_logits"):
-                self.graph_logits = {}
-            if hasattr(self, "graph_aux_hidden"):
-                self.graph_aux_hidden = {}
-            if hasattr(self, "graph_pool"):
-                self.graph_pool = None
-            logger.warning(f"{self.label}: Falling back to enforce_eager=True")
+        torch.cuda.synchronize()
+        graphs = getattr(self, "graphs", None)
+        if graphs:
+            self._graphs_backup_keys = list(graphs.keys())
+            graphs.clear()
+        if hasattr(self, "graph_logits"):
+            self.graph_logits.clear()
+        if hasattr(self, "graph_aux_hidden"):
+            self.graph_aux_hidden.clear()
+        if hasattr(self, "graph_pool"):
+            self.graph_pool = None
+        tbo_graphs = getattr(getattr(self, "model", None), "tbo_graphs", None)
+        if tbo_graphs is not None:
+            tbo_graphs.clear()
+        torch.cuda.empty_cache()
+        logger.info(f"{self.label}: CUDA graphs invalidated after weight update")
 
     def _get_param_to_module_mapping(self) -> dict[str, tuple]:
         """
@@ -474,7 +449,7 @@ class WeightUpdaterMixin:
             self._packed_weight_accum.clear()
 
         if clear_kv_cache:
-            self._refresh_cudagraphs_after_weight_update()
+            self._invalidate_cudagraphs_after_weight_update()
 
         logger.info(
             f"{self.label}: Weight update complete - "
@@ -598,7 +573,7 @@ class WeightUpdaterMixin:
                             f"{list(self._packed_weight_accum.keys())}"
                         )
                     self._packed_weight_accum.clear()
-                self._refresh_cudagraphs_after_weight_update()
+                self._invalidate_cudagraphs_after_weight_update()
 
             logger.info(
                 f"{self.label}: SHM weight update bucket done - "
@@ -763,7 +738,7 @@ class WeightUpdaterMixin:
                         f"{list(self._packed_weight_accum.keys())}"
                     )
                 self._packed_weight_accum.clear()
-            self._refresh_cudagraphs_after_weight_update()
+            self._invalidate_cudagraphs_after_weight_update()
 
         logger.info(
             f"{self.label}: IPC weight update bucket done - "

--- a/atom/rollout/weight_updater.py
+++ b/atom/rollout/weight_updater.py
@@ -21,6 +21,59 @@ class WeightUpdaterMixin:
       - self.clear_kv_cache() — method
     """
 
+    def _refresh_cudagraphs_after_weight_update(self) -> None:
+        """Recapture CUDA graphs after online weight updates.
+
+        No-eager decode replays graphs captured before the trainer pushes new
+        weights.  FP8 online updates mutate both the packed weight and its scale
+        tensors in place, so replaying the old graph can use stale captured
+        kernel state and produce degenerate generations.  Recapturing here keeps
+        the next decode on the fast path while making the graph reflect the new
+        weights/scales.
+        """
+        if getattr(self, "enforce_eager", False):
+            return
+        capture_cudagraph = getattr(self, "capture_cudagraph", None)
+        if capture_cudagraph is None:
+            return
+
+        logger.info(f"{self.label}: Recapturing CUDA graphs after weight update")
+        try:
+            torch.cuda.synchronize()
+            if hasattr(self, "graphs"):
+                self.graphs.clear()
+            if hasattr(self, "graph_logits"):
+                self.graph_logits.clear()
+            if hasattr(self, "graph_aux_hidden"):
+                self.graph_aux_hidden.clear()
+            if hasattr(self, "graph_pool"):
+                self.graph_pool = None
+            tbo_graphs = getattr(getattr(self, "model", None), "tbo_graphs", None)
+            if tbo_graphs is not None:
+                tbo_graphs.clear()
+            torch.cuda.empty_cache()
+            capture_cudagraph()
+            torch.cuda.synchronize()
+            logger.info(
+                f"{self.label}: CUDA graph recapture after weight update completed"
+            )
+        except Exception as exc:
+            logger.error(
+                f"{self.label}: CUDA graph recapture after weight update failed: {exc}",
+                exc_info=True,
+            )
+            # Prefer a correct eager fallback over replaying stale graphs.
+            self.enforce_eager = True
+            if hasattr(self, "graphs"):
+                self.graphs = {}
+            if hasattr(self, "graph_logits"):
+                self.graph_logits = {}
+            if hasattr(self, "graph_aux_hidden"):
+                self.graph_aux_hidden = {}
+            if hasattr(self, "graph_pool"):
+                self.graph_pool = None
+            logger.warning(f"{self.label}: Falling back to enforce_eager=True")
+
     def _get_param_to_module_mapping(self) -> dict[str, tuple]:
         """
         Get or build the parameter name to module mapping.
@@ -420,6 +473,9 @@ class WeightUpdaterMixin:
         if hasattr(self, "_packed_weight_accum"):
             self._packed_weight_accum.clear()
 
+        if clear_kv_cache:
+            self._refresh_cudagraphs_after_weight_update()
+
         logger.info(
             f"{self.label}: Weight update complete - "
             f"updated={updated}, skipped={skipped}, "
@@ -542,6 +598,7 @@ class WeightUpdaterMixin:
                             f"{list(self._packed_weight_accum.keys())}"
                         )
                     self._packed_weight_accum.clear()
+                self._refresh_cudagraphs_after_weight_update()
 
             logger.info(
                 f"{self.label}: SHM weight update bucket done - "
@@ -706,6 +763,7 @@ class WeightUpdaterMixin:
                         f"{list(self._packed_weight_accum.keys())}"
                     )
                 self._packed_weight_accum.clear()
+            self._refresh_cudagraphs_after_weight_update()
 
         logger.info(
             f"{self.label}: IPC weight update bucket done - "

--- a/atom/rollout/weight_updater.py
+++ b/atom/rollout/weight_updater.py
@@ -32,6 +32,13 @@ class WeightUpdaterMixin:
         if getattr(self, "enforce_eager", False):
             return
 
+        # No-eager policy: weights are updated in-place (param.data.copy_ and
+        # in-place shuffle preserve the parameter storage/address), so captured
+        # CUDA graphs read the refreshed values from the same addresses and stay
+        # valid. Keep the graphs resident instead of dropping+recapturing them,
+        # which under expandable_segments faults during post-wake graph capture.
+        return
+
         torch.cuda.synchronize()
         graphs = getattr(self, "graphs", None)
         if graphs:

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -634,7 +634,9 @@ def getLogger():
                 datefmt="%H:%M:%S",
             )
         console_handler.setFormatter(formatter)
-        console_handler.setLevel(logging.INFO)
+        console_handler.setLevel(
+            getattr(logging, _envs.ATOM_LOG_LEVEL, logging.WARNING)
+        )
 
         logger.addHandler(console_handler)
         if hasattr(torch._dynamo.config, "ignore_logger_methods"):

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -92,6 +92,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_TORCH_PROFILER_DIR": lambda: os.getenv("ATOM_TORCH_PROFILER_DIR", None),
     "ATOM_PROFILER_MORE": lambda: os.getenv("ATOM_PROFILER_MORE", "0") == "1",
     "ATOM_PROFILER_TIMEOUT": lambda: float(os.getenv("ATOM_PROFILER_TIMEOUT", "300")),
+    # Console logging threshold. WARNING avoids per-request INFO logs by default;
+    # set INFO or DEBUG explicitly when diagnosing engine behavior.
+    "ATOM_LOG_LEVEL": lambda: os.getenv("ATOM_LOG_LEVEL", "WARNING").upper(),
     "ATOM_LOG_MORE": lambda: int(os.getenv("ATOM_LOG_MORE", "0")) != 0,
     # RTL (rocm-trace-lite) GPU kernel tracing — set to output directory to enable.
     # When set, the server launch is wrapped with `rtl trace` to collect per-kernel

--- a/docs/online_quantization_guide.md
+++ b/docs/online_quantization_guide.md
@@ -69,14 +69,21 @@ Resolution order for a given layer name:
 
 ### 2.1 Target formats
 
-Only two target formats are currently supported. Any other string (for example
-`ptpc_i8`, `mxi4`, `mxfp8`) will either be rejected by the JSON parser or
-trigger an assertion in the loader when the layer's weight is quantized.
+The target formats below are currently supported. Any other string (for example
+`ptpc_i8`, `mxi4`, `mxfp8`) will be rejected by the JSON parser or trigger an
+assertion in the loader when the layer's weight is quantized.
 
 | Format string | Underlying `QuantType` | Weight dtype |
 |---|---|---|
 | `ptpc_fp8` | `QuantType.per_Token` | `torch.float8_e4m3fn` |
+| `per_block_fp8` | `QuantType.per_1x128` | `torch.float8_e4m3fn` (128×128 block scale) |
+| `per_block128_fp8` | `QuantType.per_1x128` | alias of `per_block_fp8` (explicit 128 block) |
 | `mxfp4` | `QuantType.per_1x32` | packed FP4 (`torch.float4_e2m1fn_x2`, group size 32) |
+
+`per_block_fp8` is DeepSeek-style block FP8: the weight uses a 128×128 block
+scale of shape `(N//128, K//128)` and the activation uses a 1×128 (along K)
+scale, consumed by the block-scale GEMM. `per_block_fp8` and `per_block128_fp8`
+are equivalent (128 is the default block size).
 
 ### 2.2 Picking the right pattern
 
@@ -175,9 +182,26 @@ python -m atom.entrypoints.openai_server \
 quantization — it can be added to any of the recipes above without changing
 the `--online_quant_config` JSON.
 
----
+### 3.5 Qwen3-30B-A3B-Thinking-2507 — full per-block FP8
 
-## 3.5 Plugin mode (`vllm serve`)
+BF16 source → every Linear and the fused expert module quantized to
+`per_block_fp8` (DeepSeek-style 128×128 block scale).
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model Qwen/Qwen3-30B-A3B-Thinking-2507 \
+  -tp 2 \
+  --online_quant_config '{
+    "global_quant_config": "per_block_fp8",
+    "exclude_layer": ["lm_head", "*.gate.*"]
+  }'
+```
+
+`per_block_fp8` is the same block-FP8 format DeepSeek-V3/R1 ships natively, so
+it is a good drop-in when you want FP8 accuracy closer to the block-scaled
+checkpoint than per-token `ptpc_fp8`.
+
+### 3.6 Plugin mode (`vllm serve`)
 
 In the [vLLM out-of-tree plugin backend](vllm_plugin_backend_guide.md) you launch
 with `vllm serve`, whose CLI does not understand ATOM's `--online_quant_config`
@@ -253,6 +277,7 @@ Things to check:
   | Format string | `quant_type` | `quant_dtype` |
   |---|---|---|
   | `ptpc_fp8` | `per_Token` | `torch.float8_e4m3fn` |
+  | `per_block_fp8` / `per_block128_fp8` | `per_1x128` | `torch.float8_e4m3fn` |
   | `mxfp4` | `per_1x32` | `torch.uint8` (packed FP4x2) |
 
 - `elapsed_seconds` indicates the post-loading processing time on rank 0. A

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -22,6 +22,7 @@ _ATOM_ENV_VARS = [
     "ATOM_TORCH_PROFILER_DIR",
     "ATOM_PROFILER_MORE",
     "ATOM_PROFILER_TIMEOUT",
+    "ATOM_LOG_LEVEL",
     "ATOM_LOG_MORE",
     "ATOM_DISABLE_MMAP",
     "ATOM_DISABLE_VLLM_PLUGIN",
@@ -77,6 +78,9 @@ class TestEnvsDefaults:
     def test_profiler_timeout_default(self):
         assert _get_envs().ATOM_PROFILER_TIMEOUT == 300.0
 
+    def test_log_level_default(self):
+        assert _get_envs().ATOM_LOG_LEVEL == "WARNING"
+
     def test_log_more_default(self):
         assert _get_envs().ATOM_LOG_MORE is False
 
@@ -119,6 +123,10 @@ class TestEnvsOverrides:
     def test_profiler_timeout_override(self, monkeypatch):
         monkeypatch.setenv("ATOM_PROFILER_TIMEOUT", "900")
         assert _get_envs().ATOM_PROFILER_TIMEOUT == 900.0
+
+    def test_log_level_override(self, monkeypatch):
+        monkeypatch.setenv("ATOM_LOG_LEVEL", "debug")
+        assert _get_envs().ATOM_LOG_LEVEL == "DEBUG"
 
     def test_log_more_enabled(self, monkeypatch):
         monkeypatch.setenv("ATOM_LOG_MORE", "1")


### PR DESCRIPTION
## Motivation

Improve ATOM FP8 rollout stability and correctness for LumenRL DAPO long-running training with no-eager + compilation level 3.

This PR addresses several issues seen during RL training:
- FP8 rollout weights diverging from the training-side model after online weight sync.
- CUDA graph invalidation/recapture instability after rollout sleep/wake.
- HIP illegal memory access during repeated graph recapture in long runs.
- RMSNorm behavior mismatch between ATOM rollout and training-side execution.

## Technical Details

This PR updates the ATOM FP8 rollout path to keep CUDA graph dependencies stable across RL weight updates and sleep/wake cycles.

Key changes:
- Align online FP8 rollout weight updates with initial ATOM FP8 weight layout.
- Correctly handle packed/fused Qwen3 weights, FP8 requantization, blockscale layout, and weight scale updates.
- Apply required post-update normalization/shuffle processing for FP8 weights.
- Add compatibility fallback for aiter versions that expose `shuffle_scale` instead of `moe_shuffle_scale`.
- Preserve CUDA graph validity in no-eager mode by keeping graph-dependent storage addresses stable:
  - Keep KV cache resident instead of releasing/reallocating it.
  - Update weights in-place via `copy_`.
  - Preserve parameter storage during shuffle when shape/dtype allow.
  - Avoid invalidating and recapturing CUDA graphs after every online weight update.
- Enable model-sensitive RMSNorm in ATOM rollout to match training-side behavior.

The main stability change is moving away from repeated CUDA graph recapture after weight updates. Instead, the rollout engine keeps weights/KV cache/graphs resident and refreshes values in-place, avoiding ROCm illegal memory accesses observed during long-running sleep/wake recapture.

## Test Plan

Validated with LumenRL DAPO ATOM FP8 rollout runs using:
- no-eager mode
- compilation level 3
- FP8 per-block online quantization
- sleep level 2
- 8-GPU Ray colocated ATOM rollout
- periodic validation enabled

Test coverage included:
- Short smoke runs with validation every 2 steps.
- Formal long-running training with validation every 10 steps.
- Validation-after-training lifecycle checks to ensure rollout does not degrade after eval.
- Monitoring for CUDA graph recapture failures, HIP illegal memory access, eager fallback, and reward/length regressions.

## Test Result

Smoke validation runs completed successfully after the lifecycle and in-place update fixes.

The updated ATOM branch was used in a formal LumenRL DAPO run and successfully passed validation checkpoints after rollout sleep/wake. In particular, the run progressed past validation after step 20 without the previous CUDA graph recapture crash pattern.

Observed:
- No fallback to eager mode.
- No post-validation generation collapse.
- No `CUDA graph recapture failed` after the in-place update change.
- Reward/accuracy and response lengths remained in expected ranges after validation.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.