### PR TITLE
[ci][sgl+atom] add docker override for accuracy validation

### DIFF
--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -61,6 +61,11 @@ on:
         required: false
         type: boolean
         default: false
+      docker_image:
+        description: "Optional Docker image override."
+        required: false
+        type: string
+        default: ""
       upload_accuracy_to_dashboard:
         description: "Optional: upload SGLANG accuracy results to dashboard after this manual run"
         required: false
@@ -112,6 +117,7 @@ jobs:
           MODEL_MI355: ${{ inputs.model_mi355 || 'none' }}
           MODEL_MI308: ${{ inputs.model_mi308 || 'none' }}
           REBUILD_ATOM_BASE_FROM_DOCKERFILE: ${{ inputs.rebuild_atom_base_from_dockerfile }}
+          INPUT_DOCKER_IMAGE: ${{ inputs.docker_image || '' }}
         run: |
           set -euo pipefail
 
@@ -492,14 +498,25 @@ jobs:
           PY
 
           REBUILD_FROM_DOCKERFILE="${REBUILD_ATOM_BASE_FROM_DOCKERFILE:-false}"
+          USER_PROVIDED_SGLANG_IMAGE="${INPUT_DOCKER_IMAGE:-}"
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            if [ "${REBUILD_FROM_DOCKERFILE}" = "true" ]; then
+            if [ -n "${USER_PROVIDED_SGLANG_IMAGE}" ]; then
+              echo "Manual run will use user-provided SGLANG image: ${USER_PROVIDED_SGLANG_IMAGE}"
+            elif [ "${REBUILD_FROM_DOCKERFILE}" = "true" ]; then
               echo "Manual run selected full ATOM base rebuild from docker/Dockerfile"
             elif [ "${GITHUB_REF_NAME}" = "main" ]; then
               echo "Manual run on main reuses published SGLANG image"
             else
               echo "Manual run selected fast overlay rebuild from ${ATOM_BASE_NIGHTLY_IMAGE}"
             fi
+          fi
+
+          if [ -n "${USER_PROVIDED_SGLANG_IMAGE}" ]; then
+            echo "sglang_image_tag=${USER_PROVIDED_SGLANG_IMAGE}" >> "$GITHUB_OUTPUT"
+            echo "cleanup_temp_image=false" >> "$GITHUB_OUTPUT"
+            echo "manual_base_image_tag=" >> "$GITHUB_OUTPUT"
+            echo "rebuilt_atom_base_image_tag=" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ] || { [ "${GITHUB_REF_NAME}" = "main" ] && [ "${REBUILD_FROM_DOCKERFILE}" != "true" ]; }; then


### PR DESCRIPTION
## Summary
- Add a `docker_image` workflow_dispatch input to SGLang accuracy validation.
- Use the provided image directly when set, matching SGLang benchmark override behavior.
- Preserve existing scheduled/main nightly resolution and manual rebuild paths when no override is provided.

## Test plan
- Verified workflow diff is limited to `atom-sglang-accuracy-validation.yaml`.
- Checked IDE lints for the edited workflow.
- `actionlint` was not available locally.