### PR TITLE
[SGL][M3] Align attention path with atom

### DIFF
--- a/atom/plugin/config.py
+++ b/atom/plugin/config.py
@@ -255,6 +255,9 @@ def _generate_atom_config_from_sglang_config(config: Any):
         "online_quant_config", None
     )
     server_args.model_loader_extra_config = json.dumps(sglang_model_loader_extra_config)
+    hf_overrides = json.loads(
+        getattr(server_args, 'json_model_override_args', None) or '{}'
+    )
 
     sgl_model_config = SglangModelConfig.from_server_args(server_args)
     sgl_model_opt_config = ModelOptConfig(
@@ -349,12 +352,19 @@ def _generate_atom_config_from_sglang_config(config: Any):
         sglang_port_args=sglang_port_args,
     )
 
-    # force max num batched tokens to 16K because sgl doesn't have
-    # concept for max num batched tokens
+    max_num_batched_tokens = max(
+        int(getattr(server_args, "max_prefill_tokens", 0) or 0),
+        int(getattr(server_args, "chunked_prefill_size", 0) or 0),
+        16384,
+    )
+    atom_kv_cache_dtype = server_args.kv_cache_dtype
+    if str(atom_kv_cache_dtype).startswith("fp8"):
+        atom_kv_cache_dtype = "fp8"
+
     return Config(
         model=server_args.model_path,
         trust_remote_code=server_args.trust_remote_code,
-        max_num_batched_tokens=16384,
+        max_num_batched_tokens=max_num_batched_tokens,
         max_num_seqs=server_args.max_running_requests or 512,
         max_model_len=server_args.context_length,
         gpu_memory_utilization=server_args.mem_fraction_static,
@@ -365,7 +375,8 @@ def _generate_atom_config_from_sglang_config(config: Any):
         # preventing double-compile.
         enforce_eager=True,
         parallel_config=sgl_parallel_config,
-        kv_cache_dtype=server_args.kv_cache_dtype,
+        kv_cache_dtype=atom_kv_cache_dtype,
+        index_cache_dtype=atom_kv_cache_dtype,
         enable_prefix_caching=False,
         port=None,
         torch_profiler_dir=None,
@@ -377,6 +388,7 @@ def _generate_atom_config_from_sglang_config(config: Any):
         enable_dp_attention=server_args.enable_dp_attention,
         plugin_config=plugin_config,
         online_quant_config=online_quant_config,
+        hf_overrides=hf_overrides,
     )
 
 

--- a/atom/plugin/config.py
+++ b/atom/plugin/config.py
@@ -256,7 +256,7 @@ def _generate_atom_config_from_sglang_config(config: Any):
     )
     server_args.model_loader_extra_config = json.dumps(sglang_model_loader_extra_config)
     hf_overrides = json.loads(
-        getattr(server_args, 'json_model_override_args', None) or '{}'
+        getattr(server_args, "json_model_override_args", None) or "{}"
     )
 
     sgl_model_config = SglangModelConfig.from_server_args(server_args)

--- a/atom/plugin/sglang/minimax_m3_bridge.py
+++ b/atom/plugin/sglang/minimax_m3_bridge.py
@@ -1,0 +1,601 @@
+"""Bridge SGLang ForwardBatch metadata to ATOM MiniMax-M3 sparse attention."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from atom.model_ops.minimax_m3.sparse_attn import (
+    SPARSE_BLOCK_SIZE,
+    make_sparse_decode_metadata,
+    make_sparse_prefill_metadata,
+)
+
+
+def is_minimax_m3_config(config: Any) -> bool:
+    archs = getattr(config, "architectures", None) or []
+    model_type = str(getattr(config, "model_type", "")).lower()
+    return any("MiniMaxM3" in str(arch) for arch in archs) or "minimax_m3" in model_type
+
+
+def _text_config(config: Any) -> Any:
+    return getattr(config, "text_config", config)
+
+
+def _m3_sparse_cfg(config: Any) -> dict:
+    return getattr(_text_config(config), "sparse_attention_config", None) or {}
+
+
+def _m3_sparse_layer_ids(config: Any) -> list[int]:
+    freq = _m3_sparse_cfg(config).get("sparse_attention_freq", []) or []
+    return [i for i, enabled in enumerate(freq) if enabled]
+
+
+def _m3_index_dim(config: Any) -> int:
+    index_dim = _m3_sparse_cfg(config).get("sparse_index_dim", None)
+    if index_dim is None:
+        raise RuntimeError(
+            "MiniMax-M3 sparse_attention_config.sparse_index_dim missing"
+        )
+    return int(index_dim)
+
+
+def _dtype_size(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _is_fp8_dtype(dtype: torch.dtype) -> bool:
+    return dtype in {
+        candidate
+        for candidate in (
+            getattr(torch, "float8_e4m3fn", None),
+            getattr(torch, "float8_e4m3fnuz", None),
+            getattr(torch, "float8_e5m2", None),
+        )
+        if candidate is not None
+    }
+
+
+def _resolve_m3_index_cache_dtype(fallback: torch.dtype) -> torch.dtype:
+    try:
+        from atom.config import get_current_atom_config
+
+        index_cache_dtype = getattr(get_current_atom_config(), 'index_cache_dtype', None)
+    except Exception:
+        index_cache_dtype = None
+
+    if str(index_cache_dtype).startswith('fp8'):
+        from aiter import dtypes
+
+        return dtypes.d_dtypes['fp8']
+    if index_cache_dtype == 'bf16':
+        return torch.bfloat16
+    return fallback
+
+
+class ATOMMiniMaxM3SGLangKVPool:
+    """Add MiniMax-M3 index-K cache to an older SGLang MHA KV pool."""
+
+    is_atom_minimax_m3_pool = True
+
+    def __init__(
+        self,
+        main_pool,
+        hf_config: Any,
+        index_dtype: torch.dtype,
+        *,
+        use_fp8_scales: bool,
+    ) -> None:
+        self.main_pool = main_pool
+        self.size = int(main_pool.size)
+        self.page_size = int(main_pool.page_size)
+        self.dtype = main_pool.dtype
+        self.device = main_pool.device
+        self.layer_num = main_pool.layer_num
+        self.start_layer = main_pool.start_layer
+        self.end_layer = main_pool.end_layer
+        self.head_num = main_pool.head_num
+        self.head_dim = main_pool.head_dim
+        self.layer_transfer_counter = getattr(main_pool, "layer_transfer_counter", None)
+        self._local_layers = list(range(self.start_layer, self.end_layer))
+        self._layer_mapping = {
+            layer_id: idx for idx, layer_id in enumerate(self._local_layers)
+        }
+        self._sparse_layers = [
+            lid
+            for lid in _m3_sparse_layer_ids(hf_config)
+            if self.start_layer <= lid < self.end_layer
+        ]
+        self._sparse_layer_mapping = {
+            layer_id: idx for idx, layer_id in enumerate(self._sparse_layers)
+        }
+        index_dim = _m3_index_dim(hf_config)
+        self.index_k_buffer = [
+            torch.empty(
+                (self.size + self.page_size, 1, index_dim),
+                dtype=index_dtype,
+                device=self.device,
+            )
+            for _ in self._sparse_layers
+        ]
+        self.k_scale_buffer = []
+        self.v_scale_buffer = []
+        if use_fp8_scales:
+            num_blocks = (self.size + self.page_size) // self.page_size
+            self.k_scale_buffer = [
+                torch.zeros(
+                    (num_blocks, self.head_num, self.page_size),
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+                for _ in self._local_layers
+            ]
+            self.v_scale_buffer = [
+                torch.zeros(
+                    (num_blocks, self.head_num, self.page_size),
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+                for _ in self._local_layers
+            ]
+        self.mem_usage = (
+            float(getattr(main_pool, "mem_usage", 0.0))
+            + sum(t.nbytes for t in self.index_k_buffer) / (1 << 30)
+            + sum(t.nbytes for t in self.k_scale_buffer) / (1 << 30)
+            + sum(t.nbytes for t in self.v_scale_buffer) / (1 << 30)
+        )
+
+    def __getattr__(self, name: str):
+        return getattr(self.main_pool, name)
+
+    def get_key_buffer(self, layer_id: int):
+        return self.main_pool.get_key_buffer(layer_id)
+
+    def get_value_buffer(self, layer_id: int):
+        return self.main_pool.get_value_buffer(layer_id)
+
+    def get_kv_buffer(self, layer_id: int):
+        return self.main_pool.get_kv_buffer(layer_id)
+
+    def set_kv_buffer(self, *args, **kwargs) -> None:
+        return self.main_pool.set_kv_buffer(*args, **kwargs)
+
+    def get_kv_size_bytes(self):
+        k_bytes, v_bytes = self.main_pool.get_kv_size_bytes()
+        return (
+            k_bytes
+            + sum(t.nbytes for t in self.index_k_buffer)
+            + sum(t.nbytes for t in self.k_scale_buffer),
+            v_bytes + sum(t.nbytes for t in self.v_scale_buffer),
+        )
+
+    def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
+        mapped = self._sparse_layer_mapping.get(int(layer_id))
+        if mapped is None:
+            raise ValueError(f"MiniMax-M3 layer {layer_id} has no index-K cache")
+        return self.index_k_buffer[mapped]
+
+    def get_kv_scale_buffer(
+        self, layer_id: int
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        mapped = self._layer_mapping.get(int(layer_id))
+        if mapped is None or not self.k_scale_buffer:
+            return None, None
+        return self.k_scale_buffer[mapped], self.v_scale_buffer[mapped]
+
+
+def install_minimax_m3_pool_patch() -> None:
+    """Patch older SGLang builds that lack MiniMaxSparseKVPool support."""
+
+    import sglang.srt.model_executor.model_runner_kv_cache_mixin as mixin
+
+    if getattr(mixin.ModelRunnerKVCacheMixin, "_atom_minimax_m3_pool_patched", False):
+        return
+
+    original_resolve = mixin.ModelRunnerKVCacheMixin._resolve_memory_pool_config
+    original_init_pools = mixin.ModelRunnerKVCacheMixin._init_pools
+
+    def _is_m3_runner(runner) -> bool:
+        return is_minimax_m3_config(getattr(runner.model_config, "hf_config", None))
+
+    def _local_kv_heads(runner) -> int:
+        try:
+            from sglang.srt.layers.dp_attention import get_attention_tp_size
+
+            return int(runner.model_config.get_num_kv_heads(get_attention_tp_size()))
+        except Exception:
+            hf_config = _text_config(runner.model_config.hf_config)
+            tp_size = max(1, int(getattr(runner, "tp_size", 1)))
+            return max(1, int(getattr(hf_config, "num_key_value_heads", 1)) // tp_size)
+
+    def _resolve_memory_pool_config(self, pre_model_load_memory: int):
+        config = original_resolve(self, pre_model_load_memory)
+        if not _is_m3_runner(self):
+            return config
+
+        hf_config = _text_config(self.model_config.hf_config)
+        kv_dtype = self.kv_cache_dtype
+        use_fp8_scales = _is_fp8_dtype(self.kv_cache_dtype) or str(
+            self.kv_cache_dtype
+        ).startswith("fp8")
+        index_dtype = _resolve_m3_index_cache_dtype(
+            getattr(self, 'dtype', getattr(self, 'torch_dtype', torch.bfloat16))
+        )
+        num_layers = int(
+            getattr(self, "num_effective_layers", hf_config.num_hidden_layers)
+        )
+        main_bytes = (
+            2
+            * num_layers
+            * _local_kv_heads(self)
+            * int(hf_config.head_dim)
+            * _dtype_size(kv_dtype)
+        )
+        index_bytes = (
+            len(_m3_sparse_layer_ids(self.model_config.hf_config))
+            * _m3_index_dim(self.model_config.hf_config)
+            * _dtype_size(index_dtype)
+        )
+        scale_bytes = 0
+        if use_fp8_scales:
+            scale_bytes = (
+                2 * num_layers * _local_kv_heads(self) * _dtype_size(torch.float32)
+            )
+        extra_bytes = index_bytes + scale_bytes
+        if main_bytes <= 0 or extra_bytes <= 0:
+            return config
+
+        old_tokens = int(config.max_total_num_tokens)
+        new_tokens = (old_tokens * main_bytes) // (main_bytes + extra_bytes)
+        page_size = int(self.server_args.page_size)
+        new_tokens = max(page_size, (new_tokens // page_size) * page_size)
+        if new_tokens < old_tokens:
+            config.max_total_num_tokens = new_tokens
+            config.max_running_requests = self._resolve_max_num_reqs(new_tokens)
+        return config
+
+    def _init_pools(self):
+        original_init_pools(self)
+        if not _is_m3_runner(self):
+            return
+        pool = getattr(self, "token_to_kv_pool", None)
+        if pool is None or hasattr(pool, "get_index_k_buffer"):
+            return
+        use_fp8_scales = _is_fp8_dtype(self.kv_cache_dtype) or str(
+            self.kv_cache_dtype
+        ).startswith("fp8")
+        index_dtype = _resolve_m3_index_cache_dtype(
+            getattr(self, 'dtype', getattr(self, 'torch_dtype', torch.bfloat16))
+        )
+        self.token_to_kv_pool = ATOMMiniMaxM3SGLangKVPool(
+            pool,
+            self.model_config.hf_config,
+            index_dtype,
+            use_fp8_scales=use_fp8_scales,
+        )
+
+    mixin.ModelRunnerKVCacheMixin._resolve_memory_pool_config = (
+        _resolve_memory_pool_config
+    )
+    mixin.ModelRunnerKVCacheMixin._init_pools = _init_pools
+    mixin.ModelRunnerKVCacheMixin._atom_minimax_m3_pool_patched = True
+
+
+def maybe_get_minimax_m3_pools_from_sglang_batch(forward_batch=None):
+    if forward_batch is None:
+        return None, None
+    token_to_kv_pool = getattr(forward_batch, "token_to_kv_pool", None)
+    req_to_token_pool = getattr(forward_batch, "req_to_token_pool", None)
+    if token_to_kv_pool is None or req_to_token_pool is None:
+        return None, None
+    return token_to_kv_pool, req_to_token_pool
+
+
+def _page_size(token_to_kv_pool) -> int:
+    page_size = int(getattr(token_to_kv_pool, "page_size", 1))
+    if page_size != SPARSE_BLOCK_SIZE:
+        raise ValueError(
+            "MiniMax-M3 native sparse attention requires SGLang page size "
+            f"{SPARSE_BLOCK_SIZE}, got {page_size}. Launch with --page-size "
+            f"{SPARSE_BLOCK_SIZE}."
+        )
+    return page_size
+
+
+def _is_stream_capturing() -> bool:
+    try:
+        return bool(torch.cuda.is_current_stream_capturing())
+    except Exception:
+        return False
+
+
+def _seq_lens(forward_batch, bs: int) -> torch.Tensor:
+    return forward_batch.seq_lens[:bs].to(dtype=torch.int32)
+
+
+def _extend_lens(forward_batch, positions: torch.Tensor, bs: int) -> torch.Tensor:
+    extend_lens = getattr(forward_batch, "extend_seq_lens", None)
+    if extend_lens is not None:
+        return extend_lens[:bs].to(device=positions.device, dtype=torch.int32)
+
+    extend_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+    if extend_lens_cpu is not None:
+        return torch.as_tensor(
+            extend_lens_cpu[:bs], dtype=torch.int32, device=positions.device
+        )
+
+    tokens_per_req = getattr(
+        getattr(forward_batch, "spec_info", None), "num_tokens_per_req", None
+    )
+    if tokens_per_req is None:
+        tokens_per_req = max(1, int(positions.numel()) // max(1, bs))
+    return torch.full(
+        (bs,), int(tokens_per_req), dtype=torch.int32, device=positions.device
+    )
+
+
+def _build_block_table(
+    forward_batch,
+    req_to_token_pool,
+    *,
+    seq_lens: torch.Tensor,
+    extend_lens: torch.Tensor | None,
+    page_size: int,
+    max_seq_len: int | None = None,
+) -> torch.Tensor:
+    bs = int(forward_batch.batch_size)
+    if max_seq_len is None:
+        # This path is prefill/eager only. Decode graph capture must pass a static
+        # max_seq_len because GPU scalar reads (`.item()`) are illegal in capture.
+        max_seq_len = int(seq_lens.max().item()) if bs else 0
+    max_blocks = max(1, (max_seq_len + page_size - 1) // page_size)
+    req_pool_indices = forward_batch.req_pool_indices[:bs]
+    token_table = req_to_token_pool.req_to_token[
+        req_pool_indices, : max_blocks * page_size
+    ].clone()
+
+    if extend_lens is not None:
+        prefix_lens = seq_lens - extend_lens
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if out_cache_loc is not None:
+            offset = 0
+            for req_idx in range(bs):
+                prefix_len = int(prefix_lens[req_idx].item())
+                query_len = int(extend_lens[req_idx].item())
+                if query_len > 0:
+                    token_table[req_idx, prefix_len : prefix_len + query_len] = (
+                        out_cache_loc[offset : offset + query_len]
+                    )
+                offset += query_len
+
+    return (
+        (token_table[:, : max_blocks * page_size : page_size] // page_size)
+        .to(dtype=torch.int32)
+        .contiguous()
+    )
+
+
+def build_atom_minimax_m3_attention_metadata_from_sglang(
+    forward_batch,
+    positions: torch.Tensor,
+    *,
+    token_to_kv_pool,
+    req_to_token_pool,
+):
+    from atom.utils.forward_context import AttentionMetaData
+
+    page_size = _page_size(token_to_kv_pool)
+    bs = int(forward_batch.batch_size)
+    seq_lens = _seq_lens(forward_batch, bs)
+    is_prefill = bool(
+        getattr(forward_batch.forward_mode, "is_prefill", lambda: False)()
+    )
+    max_context_len = int(req_to_token_pool.req_to_token.shape[1])
+
+    if is_prefill:
+        extend_lens = _extend_lens(forward_batch, positions, bs)
+        cu_q = torch.empty(bs + 1, dtype=torch.int32, device=positions.device)
+        cu_q[0] = 0
+        torch.cumsum(extend_lens, dim=0, out=cu_q[1:])
+        total_tokens = int(cu_q[-1].item()) if bs else 0
+        block_table = _build_block_table(
+            forward_batch,
+            req_to_token_pool,
+            seq_lens=seq_lens,
+            extend_lens=extend_lens,
+            page_size=page_size,
+        )
+        max_query_len = int(extend_lens.max().item()) if bs else 0
+        max_seq_len = int(seq_lens.max().item()) if bs else 0
+        slot_mapping = getattr(forward_batch, "out_cache_loc", None)
+        slot_mapping = (
+            slot_mapping[:total_tokens]
+            if torch.is_tensor(slot_mapping)
+            else torch.empty(0, dtype=torch.int64, device=positions.device)
+        )
+        sparse_md = make_sparse_prefill_metadata(
+            cu_seqlens_q=cu_q,
+            seq_lens=seq_lens,
+            block_table=block_table,
+            slot_mapping=slot_mapping,
+            max_query_len=max_query_len,
+            max_seq_len=max_seq_len,
+            num_prefills=bs,
+            num_prefill_tokens=total_tokens,
+        )
+        sparse_md.prefill.qo_indptr = torch.arange(
+            total_tokens + 1,
+            dtype=torch.int32,
+            device=positions.device,
+        )
+        md = AttentionMetaData(
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=cu_q,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=max_seq_len,
+            slot_mapping=slot_mapping,
+            context_lens=seq_lens,
+            block_tables=block_table,
+        )
+        md.sparse_attention_metadata = sparse_md
+        return md
+
+    tokens_per_req = max(1, int(positions.numel()) // max(1, bs)) if bs else 1
+    # Decode CUDA graph capture cannot synchronize on seq_lens.max(). Use the
+    # static req_to_token table capacity, matching the fixed-shape graph contract.
+    max_seq_len = (
+        max_context_len
+        if _is_stream_capturing()
+        else (int(seq_lens.max().item()) if bs else 0)
+    )
+    block_table = _build_block_table(
+        forward_batch,
+        req_to_token_pool,
+        seq_lens=seq_lens,
+        extend_lens=None,
+        page_size=page_size,
+        max_seq_len=max_seq_len,
+    )
+    out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+    if torch.is_tensor(out_cache_loc):
+        slot_mapping = out_cache_loc[: bs * tokens_per_req]
+    else:
+        scratch = max(0, int(getattr(token_to_kv_pool, "size", 1)) - 1)
+        slot_mapping = torch.full(
+            (bs * tokens_per_req,),
+            scratch,
+            dtype=torch.int64,
+            device=positions.device,
+        )
+    sparse_md = make_sparse_decode_metadata(
+        seq_lens=seq_lens,
+        block_table=block_table,
+        slot_mapping=slot_mapping,
+        max_seq_len=max_seq_len,
+        max_query_len=tokens_per_req,
+    )
+    cu_q = torch.arange(
+        0,
+        bs * tokens_per_req + 1,
+        tokens_per_req,
+        dtype=torch.int32,
+        device=positions.device,
+    )
+    md = AttentionMetaData(
+        cu_seqlens_q=cu_q,
+        max_seqlen_q=tokens_per_req,
+        max_seqlen_k=max_seq_len,
+        slot_mapping=slot_mapping,
+        context_lens=seq_lens,
+        block_tables=block_table,
+    )
+    md.sparse_attention_metadata = sparse_md
+    return md
+
+
+def _iter_m3_attention_layers(model):
+    from atom.models.minimax_m3 import MiniMaxM3Attention, MiniMaxM3SparseAttention
+
+    for module in model.modules():
+        if isinstance(module, (MiniMaxM3Attention, MiniMaxM3SparseAttention)):
+            attn = getattr(module, "attn", None)
+            impl = getattr(attn, "impl", None)
+            if impl is not None:
+                yield module, attn, impl, isinstance(module, MiniMaxM3SparseAttention)
+
+
+def _get_index_cache_view(
+    token_to_kv_pool,
+    layer_id: int,
+    *,
+    k_buffer: torch.Tensor,
+    index_dim: int,
+) -> torch.Tensor:
+    """Return SGLang MiniMaxSparseKVPool's existing index-K cache view."""
+
+    if not hasattr(token_to_kv_pool, "get_index_k_buffer"):
+        raise RuntimeError(
+            "MiniMax-M3 native sparse attention requires SGLang MiniMaxSparseKVPool "
+            "with get_index_k_buffer(); refusing to allocate a side index cache."
+        )
+    page_size = _page_size(token_to_kv_pool)
+    num_slots = int(k_buffer.shape[0])
+    num_blocks = max(1, num_slots // page_size)
+    expected = (num_blocks, page_size, int(index_dim))
+    index_buffer = token_to_kv_pool.get_index_k_buffer(layer_id)
+    return index_buffer[: num_blocks * page_size].view(*expected)
+
+
+def bind_minimax_m3_sparse_cache_views(model, token_to_kv_pool) -> bool:
+    if token_to_kv_pool is None or not hasattr(token_to_kv_pool, "get_kv_buffer"):
+        return False
+
+    from atom.config import KVCacheTensor
+    from atom.utils.forward_context import get_forward_context, set_kv_cache_data
+
+    page_size = _page_size(token_to_kv_pool)
+    kv_cache_data = {}
+    bound = False
+    for _, attn, impl, is_sparse_layer in _iter_m3_attention_layers(model):
+        layer_id = int(impl.layer_num)
+        k_buffer, v_buffer = token_to_kv_pool.get_kv_buffer(layer_id)
+        num_slots, num_kv_heads, head_dim = k_buffer.shape
+        num_blocks = max(1, int(num_slots) // page_size)
+        live_slots = num_blocks * page_size
+        x = 16 // k_buffer.element_size()
+        k_cache = k_buffer[:live_slots].view(
+            num_blocks, num_kv_heads, head_dim // x, page_size, x
+        )
+        v_cache = v_buffer[:live_slots].view(
+            num_blocks, num_kv_heads, page_size // x, head_dim, x
+        )
+        if hasattr(token_to_kv_pool, "get_kv_scale_buffer"):
+            k_scale, v_scale = token_to_kv_pool.get_kv_scale_buffer(layer_id)
+        else:
+            k_scale = None
+            v_scale = None
+        if not is_sparse_layer:
+            pass
+        elif getattr(impl, "skip_index_topk", False):
+            # Shared-index sparse layers reuse the previous full-index layer's
+            # top-k result and never write/read their own index-K cache.
+            impl.index_cache = None
+        else:
+            impl.index_cache = _get_index_cache_view(
+                token_to_kv_pool,
+                layer_id,
+                k_buffer=k_buffer,
+                index_dim=impl.index_head_dim,
+            )
+        impl.max_model_len = int(getattr(token_to_kv_pool, "size", live_slots))
+        if is_sparse_layer:
+            impl.index_topk_cache_state = getattr(
+                token_to_kv_pool, "_atom_minimax_m3_topk_cache_state", None
+            )
+            if impl.index_topk_cache_state is None:
+                impl.index_topk_cache_state = {}
+                setattr(
+                    token_to_kv_pool,
+                    "_atom_minimax_m3_topk_cache_state",
+                    impl.index_topk_cache_state,
+                )
+        kv_cache_data[f"layer_{layer_id}"] = KVCacheTensor(
+            layer_num=layer_id,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+        attn.k_cache = k_cache
+        attn.v_cache = v_cache
+        attn.k_scale = k_scale
+        attn.v_scale = v_scale
+        bound = True
+
+    if not bound:
+        return False
+
+    set_kv_cache_data(kv_cache_data)
+    get_forward_context().kv_cache_data = kv_cache_data
+    return True

--- a/atom/plugin/sglang/minimax_m3_bridge.py
+++ b/atom/plugin/sglang/minimax_m3_bridge.py
@@ -61,15 +61,17 @@ def _resolve_m3_index_cache_dtype(fallback: torch.dtype) -> torch.dtype:
     try:
         from atom.config import get_current_atom_config
 
-        index_cache_dtype = getattr(get_current_atom_config(), 'index_cache_dtype', None)
+        index_cache_dtype = getattr(
+            get_current_atom_config(), "index_cache_dtype", None
+        )
     except Exception:
         index_cache_dtype = None
 
-    if str(index_cache_dtype).startswith('fp8'):
+    if str(index_cache_dtype).startswith("fp8"):
         from aiter import dtypes
 
-        return dtypes.d_dtypes['fp8']
-    if index_cache_dtype == 'bf16':
+        return dtypes.d_dtypes["fp8"]
+    if index_cache_dtype == "bf16":
         return torch.bfloat16
     return fallback
 
@@ -220,7 +222,7 @@ def install_minimax_m3_pool_patch() -> None:
             self.kv_cache_dtype
         ).startswith("fp8")
         index_dtype = _resolve_m3_index_cache_dtype(
-            getattr(self, 'dtype', getattr(self, 'torch_dtype', torch.bfloat16))
+            getattr(self, "dtype", getattr(self, "torch_dtype", torch.bfloat16))
         )
         num_layers = int(
             getattr(self, "num_effective_layers", hf_config.num_hidden_layers)
@@ -266,7 +268,7 @@ def install_minimax_m3_pool_patch() -> None:
             self.kv_cache_dtype
         ).startswith("fp8")
         index_dtype = _resolve_m3_index_cache_dtype(
-            getattr(self, 'dtype', getattr(self, 'torch_dtype', torch.bfloat16))
+            getattr(self, "dtype", getattr(self, "torch_dtype", torch.bfloat16))
         )
         self.token_to_kv_pool = ATOMMiniMaxM3SGLangKVPool(
             pool,

--- a/atom/plugin/sglang/models/minimax_m3.py
+++ b/atom/plugin/sglang/models/minimax_m3.py
@@ -1,46 +1,148 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from types import MethodType
+from typing import Any
 
 import torch
 
-from atom.model_ops.layernorm import fused_qk_norm
+from atom.model_ops.base_attention import BaseAttention
 from atom.models.minimax_m3 import MiniMaxM3Attention, MiniMaxM3SparseAttention
-from atom.plugin.sglang.attention_backend.minimax_m3_sparse import (
-    minimax_m3_sparse_attention_for_sglang,
-)
 
 
-def _gemma_qk_norm_for_sglang(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    q_norm,
-    k_norm,
-    num_q_heads: int,
-    num_kv_heads: int,
-    head_dim: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    q, k = fused_qk_norm(
-        q.view(-1, num_q_heads, head_dim),
-        k.view(-1, num_kv_heads, head_dim),
-        q_norm.weight,
-        k_norm.weight,
-        q_norm.variance_epsilon,
-        add_unit_offset=True,
-    )
-    return (
-        q.view(-1, num_q_heads * head_dim),
-        k.view(-1, num_kv_heads * head_dim),
-    )
+@contextmanager
+def minimax_m3_native_sparse_attention_construction():
+    """Construct MiniMax-M3 attention layers with ATOM's native impls."""
+
+    import atom.models.minimax_m3 as minimax_m3
+
+    previous = minimax_m3.Attention
+
+    def _build_minimax_m3_attention(*args: Any, **kwargs: Any):
+        return SGLangATOMMiniMaxM3Attention(*args, **kwargs)
+
+    minimax_m3.Attention = _build_minimax_m3_attention
+    try:
+        yield
+    finally:
+        minimax_m3.Attention = previous
+
+
+class SGLangATOMMiniMaxM3Attention(BaseAttention):
+    """Use ATOM native MiniMax-M3 attention under SGLang plugin runtime."""
+
+    def __init__(
+        self,
+        num_heads,
+        head_dim,
+        scale,
+        num_kv_heads,
+        alibi_slopes: list[float] | None = None,
+        kv_cache_dtype="bf16",
+        layer_num=0,
+        use_mla: bool = False,
+        mla_modules=None,
+        sinks=None,
+        per_layer_sliding_window=None,
+        rotary_emb=None,
+        prefix: str | None = None,
+        q_norm=None,
+        k_norm=None,
+        impl_cls=None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            kv_cache_dtype=kv_cache_dtype,
+            layer_num=layer_num,
+            use_mla=use_mla,
+            mla_modules=mla_modules,
+            sinks=sinks,
+            per_layer_sliding_window=per_layer_sliding_window,
+            rotary_emb=rotary_emb,
+            prefix=prefix,
+            q_norm=q_norm,
+            k_norm=k_norm,
+            **kwargs,
+        )
+
+        from atom.config import get_current_atom_config
+        from atom.model_ops.attention_mha import PagedAttentionImpl
+
+        atom_config = get_current_atom_config()
+        impl_cls = impl_cls or PagedAttentionImpl
+        atom_kv_cache_dtype = (
+            "fp8" if str(kv_cache_dtype).startswith("fp8") else kv_cache_dtype
+        )
+        self.use_mla = use_mla
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.scale = scale
+        self.num_kv_heads = num_kv_heads
+        self.kv_cache_dtype = atom_kv_cache_dtype
+        self.layer_num = layer_num
+        self.base_attention = None
+        self.k_cache = self.v_cache = torch.tensor([])
+        self.k_scale = self.v_scale = None
+        self.impl = impl_cls(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            alibi_slopes=alibi_slopes,
+            kv_cache_dtype=atom_kv_cache_dtype,
+            layer_num=layer_num,
+            mla_modules=mla_modules,
+            sinks=sinks,
+            sliding_window=per_layer_sliding_window,
+            rotary_emb=rotary_emb,
+            dtype=atom_config.torch_dtype,
+            q_norm=q_norm,
+            k_norm=k_norm,
+            **kwargs,
+        )
+        self.layer_name = prefix if prefix is not None else f"MHA_{layer_num}"
+        static_context = atom_config.compilation_config.static_forward_context
+        if self.layer_name in static_context:
+            raise ValueError(f"Duplicate layer: {self.layer_name}")
+        static_context[self.layer_name] = self
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        positions: torch.Tensor = None,
+        q_scale: torch.Tensor | None = None,
+        qkv: torch.Tensor = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        del kwargs
+        return torch.ops.aiter.unified_attention_with_output_base(
+            query,
+            q_scale,
+            key,
+            value,
+            positions,
+            self.layer_name,
+            self.use_mla,
+            qkv,
+        )
 
 
 def _patch_minimax_m3_dense_attention_for_sglang(module: MiniMaxM3Attention) -> None:
-    inner_attn = getattr(getattr(module, "attn", None), "attn", None)
-    if inner_attn is not None:
-        setattr(inner_attn, "_atom_minimax_m3_dense_mha", True)
+    if not isinstance(getattr(module, "attn", None), SGLangATOMMiniMaxM3Attention):
+        raise RuntimeError(
+            "MiniMax-M3 SGLang dense setup expected native ATOM attention. "
+            "Ensure the MiniMax-M3 construction context is installed before "
+            "model initialization."
+        )
 
 
-def _sparse_forward_for_sglang(
+def _sparse_forward_native_for_sglang(
     self: MiniMaxM3SparseAttention,
     positions: torch.Tensor,
     hidden_states: torch.Tensor,
@@ -49,8 +151,7 @@ def _sparse_forward_for_sglang(
     qkv = self.qkv_proj(hidden_states, x_scale=hidden_states_scale)
     if isinstance(qkv, tuple):
         qkv = qkv[0]
-
-    q, k, v, index_q, index_k = qkv.split(
+    q, k, v, _, _ = qkv.split(
         [
             self.q_size,
             self.kv_size,
@@ -60,36 +161,7 @@ def _sparse_forward_for_sglang(
         ],
         dim=-1,
     )
-    q, k = _gemma_qk_norm_for_sglang(
-        q,
-        k,
-        self.q_norm,
-        self.k_norm,
-        self.num_heads,
-        self.num_kv_heads,
-        self.head_dim,
-    )
-    q, k = self.rotary_emb(positions, q, k)
-
-    index_q, index_k = _gemma_qk_norm_for_sglang(
-        index_q,
-        index_k,
-        self.index_q_norm,
-        self.index_k_norm,
-        self.num_idx_heads,
-        1,
-        self.idx_head_dim,
-    )
-    index_q, index_k = self.index_rotary_emb(positions, index_q, index_k)
-
-    attn_output = minimax_m3_sparse_attention_for_sglang(
-        q,
-        k,
-        v,
-        index_q,
-        index_k,
-        self,
-    )
+    attn_output = self.attn(q, k, v, positions, qkv=qkv)
     return self.o_proj(attn_output)
 
 
@@ -101,7 +173,14 @@ def _patch_minimax_m3_sparse_attention_for_sglang(
     # SGLang's token_to_kv_pool APIs are keyed by layer_id.  The native ATOM
     # layer uses layer_num, so expose both names for the plugin helper.
     module.layer_id = module.layer_num
-    module.forward = MethodType(_sparse_forward_for_sglang, module)
+    impl = getattr(getattr(module, "attn", None), "impl", None)
+    if not getattr(impl, "is_indexed_sparse_attention", False):
+        raise RuntimeError(
+            "MiniMax-M3 SGLang native sparse setup expected "
+            "SparseMHAPagedAttentionImpl. Ensure the MiniMax-M3 construction "
+            "context is installed before model initialization."
+        )
+    module.forward = MethodType(_sparse_forward_native_for_sglang, module)
     module._atom_sglang_minimax_m3_sparse_patched = True
 
 

--- a/atom/plugin/sglang/prepare.py
+++ b/atom/plugin/sglang/prepare.py
@@ -39,6 +39,15 @@ def prepare_model(config: Any):
         )
 
         install_deepseek_v4_proxy_pool_patch()
+    elif model_arch in (
+        "MiniMaxM3SparseForCausalLM",
+        "MiniMaxM3SparseForConditionalGeneration",
+    ):
+        from atom.plugin.sglang.minimax_m3_bridge import (
+            install_minimax_m3_pool_patch,
+        )
+
+        install_minimax_m3_pool_patch()
 
     # Import here to avoid partial initialization while SGLang discovers models.
     from atom.plugin.register import (

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -284,6 +284,38 @@ def _build_glm52_dsa_metadata(
     return attn_metadata
 
 
+def _build_minimax_m3_metadata(
+    atom_config: Any,
+    forward_batch: ForwardBatch,
+    positions: torch.Tensor,
+):
+    hf_config = getattr(atom_config, "hf_config", None)
+    if _is_dummy_forward(forward_batch) or hf_config is None:
+        return None
+
+    from atom.plugin.sglang.minimax_m3_bridge import (
+        build_atom_minimax_m3_attention_metadata_from_sglang,
+        is_minimax_m3_config,
+        maybe_get_minimax_m3_pools_from_sglang_batch,
+    )
+
+    if not is_minimax_m3_config(hf_config):
+        return None
+
+    token_to_kv_pool, req_to_token_pool = maybe_get_minimax_m3_pools_from_sglang_batch(
+        forward_batch
+    )
+    if token_to_kv_pool is None or req_to_token_pool is None:
+        return None
+
+    return build_atom_minimax_m3_attention_metadata_from_sglang(
+        forward_batch,
+        positions,
+        token_to_kv_pool=token_to_kv_pool,
+        req_to_token_pool=req_to_token_pool,
+    )
+
+
 def _build_deepseek_v4_metadata(forward_batch: ForwardBatch, positions: torch.Tensor):
     backend = None
     attn_metadata = getattr(forward_batch, "atom_v4_graph_metadata", None)
@@ -355,15 +387,27 @@ def _set_atom_forward_context(
     max_seqlen_q = 1 if forward_mode.is_decode_or_idle() else 0
     attn_metadata = None
     try:
-        attn_metadata = _build_glm52_dsa_metadata(
+        attn_metadata = _build_minimax_m3_metadata(
             atom_config,
             forward_batch,
             positions,
         )
     except Exception as exc:
         raise RuntimeError(
-            "Failed to build ATOM GLM-5.2 DSA metadata for SGLang"
+            "Failed to build ATOM MiniMax-M3 sparse metadata for SGLang"
         ) from exc
+
+    if attn_metadata is None:
+        try:
+            attn_metadata = _build_glm52_dsa_metadata(
+                atom_config,
+                forward_batch,
+                positions,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to build ATOM GLM-5.2 DSA metadata for SGLang"
+            ) from exc
 
     if attn_metadata is None:
         try:

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -70,6 +70,10 @@ def _prepare_minimax_m3_config(atom_config: Any, model_arch: str) -> None:
         MiniMaxM3SparseForConditionalGeneration,
     )
 
+    # MiniMax-M3 native sparse attention is block-sparse at 128-token granularity.
+    # The SGLang recipe must use --page-size 128; keep ATOM's config aligned so
+    # sparse metadata and SHUFFLE cache views speak the same page ABI.
+    atom_config.kv_cache_block_size = 128
     quant_config = getattr(atom_config, "quant_config", None)
     if quant_config is None:
         return
@@ -188,6 +192,30 @@ def _install_minimax_m3_adapters(model: Any) -> None:
     setup_minimax_m3_for_sglang(model)
 
 
+def _minimax_m3_construction_context():
+    from atom.plugin.sglang.models.minimax_m3 import (
+        minimax_m3_native_sparse_attention_construction,
+    )
+
+    return minimax_m3_native_sparse_attention_construction()
+
+
+def _bind_minimax_m3_cache_views(model: Any, runtime: Any) -> None:
+    if getattr(runtime.forward_batch.forward_mode, "is_idle", lambda: False)():
+        return
+
+    from atom.plugin.sglang.minimax_m3_bridge import (
+        bind_minimax_m3_sparse_cache_views,
+        maybe_get_minimax_m3_pools_from_sglang_batch,
+    )
+
+    token_to_kv_pool, _ = maybe_get_minimax_m3_pools_from_sglang_batch(
+        runtime.forward_batch
+    )
+    if not bind_minimax_m3_sparse_cache_views(model, token_to_kv_pool):
+        raise RuntimeError("MiniMax-M3 SGLang sparse KV pool is not initialized")
+
+
 MODEL_ADAPTER_SPECS = {
     "DeepseekV3ForCausalLM": SGLangModelAdapterSpec(
         install_adapters=_install_deepseek_mla_adapters,
@@ -230,12 +258,16 @@ MODEL_ADAPTER_SPECS = {
     "MiniMaxM3SparseForCausalLM": SGLangModelAdapterSpec(
         uses_context_only_forward=True,
         prepare_config=_prepare_minimax_m3_config,
+        construction_context=_minimax_m3_construction_context,
         install_adapters=_install_minimax_m3_adapters,
+        bind_cache_views=_bind_minimax_m3_cache_views,
     ),
     "MiniMaxM3SparseForConditionalGeneration": SGLangModelAdapterSpec(
         uses_context_only_forward=True,
         prepare_config=_prepare_minimax_m3_config,
+        construction_context=_minimax_m3_construction_context,
         install_adapters=_install_minimax_m3_adapters,
+        bind_cache_views=_bind_minimax_m3_cache_views,
     ),
 }
 


### PR DESCRIPTION
## Motivation

This PR makes SGLang-ATOM MiniMax-M3 use the same ATOM-owned attention path as standalone ATOM. The previous SGLang path partially fell back to SGLang attention/cache logic, causing poor M3 attention performance and several fp8/cache/graph-capture mismatches.

## Technical Details

 - Construct MiniMax-M3 dense and sparse attention with ATOM native implementations.
 - Add an SGLang-to-ATOM M3 bridge for metadata and KV/index-cache binding.
 - Patch older SGLang KV pool behavior to provide M3 index-K cache and fp8 scale buffers.
 - Align SGLang M3 config with standalone ATOM (use_index_cache=true, index_topk_freq=4).
 - Fix CUDA graph capture and fp8 KV-cache contract issues.

## Test Plan
#### fp4 tp4 server
```bash
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
export SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models

export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_USE_AITER=1
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export ATOM_FORCE_ATTN_TRITON=1
export SGLANG_ENABLE_TORCH_COMPILE=1
export TORCHINDUCTOR_COMPILE_THREADS=128
MODEL_LOADER_EXTRA_CONFIG='{"online_quant_config":{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}}'
JSON_MODEL_OVERRIDE_ARGS='{"use_index_cache": true, "index_topk_freq": 4}'

model_path=${model_path:-/shared/data/amd_int/models/MiniMax-M3-MXFP4/}
PORT=${PORT:-8000}
TP=${TP:-4}

python3 -m sglang.launch_server \
    --model-path "${model_path}" \
    --host 127.0.0.1 \
    --port "${PORT}" \
    --trust-remote-code \
    --tensor-parallel-size "${TP}" \
    --attention-backend aiter \
    --mem-fraction-static 0.8 \
    --page-size 128 \
    --context-length 32768 \
    --max-running-requests 128 \
    --model-loader-extra-config "${MODEL_LOADER_EXTRA_CONFIG}" \
    --json-model-override-args "${JSON_MODEL_OVERRIDE_ARGS}" \
    --kv-cache-dtype fp8_e4m3 \
    --disable-radix-cache  2>&1 | tee minimax-m3-mxfp4-sglang-server.log
```

#### accuracy
```bash
model_path=/shared/data/amd_int/models/MiniMax-M3-MXFP4/
PORT=8000

lm_eval \
    --model local-chat-completions \
    --model_args "model=${model_path},base_url=http://127.0.0.1:${PORT}/v1/chat/completions,num_concurrent=64" \
    --tasks gsm8k \
    --num_fewshot 5 \
    --batch_size "${BS}" \
    --apply_chat_template \
    --fewshot_as_multiturn 2>&1 | tee minimax-m3-mxfp4-sglang-gsm8k.log
```

#### benchmark
```bash
if [ ! -d bench_serving ]; then
    git clone https://github.com/kimbochen/bench_serving.git
fi
 
model_path=/shared/data/amd_int/models/MiniMax-M3-MXFP4/

ISL=$1
OSL=$2
CONC=$3
RANGE_RATIO=0.8

NUM=$(( CONC * 3 ))

echo "=== Running benchmark with ISL=${ISL}, OSL=${OSL}, RANGE_RATIO=${RANGE_RATIO}, CONC=${CONC} ==="

PYTHONDONTWRITEBYTECODE=1 python "./bench_serving/benchmark_serving.py" \
    --model="$model_path" \
    --backend=sglang \
    --base-url=http://localhost:8000 \
    --dataset-name=random \
    --random-input-len="${ISL}" \
    --random-output-len="${OSL}" \
    --random-range-ratio "${RANGE_RATIO}" \
    --num-prompts="${NUM}" \
    --max-concurrency="${CONC}" \
    --trust-remote-code \
    --request-rate=inf \
    --num-warmups="$(( 2 * CONC ))" \
    --ignore-eos \
    --save-result \
    --percentile-metrics="ttft,tpot,itl,e2el" \
    --result-dir="./tmp/dpsk-tp8-mtp-moefp4-benchmark" \
    --result-filename="dsr1_tp8_mtp_moefp4_${ISL}_${OSL}_${CONC}.json"
```

## Test Result
#### fp4 tp4 acc
```bash
local-chat-completions ({'model': '/shared/data/amd_int/models/MiniMax-M3-MXFP4/', 'base_url': 'http://127.0.0.1:8000/v1/chat/completions', 'num_concurrent': 64}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 65
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9363|±  |0.0067|
|     |       |strict-match    |     5|exact_match|↑  |0.9371|±  |0.0067|
```

#### fp4 tp4 benchmark 8192 1024 16
```bash
=== Running benchmark with ISL=8192, OSL=1024, RANGE_RATIO=0.8, CONC=16 ===
-------------------  Input/Output Length Statistics  -------------------
 input_lens : min=6625  max=8177  mean=7318.65  avg_token_mismatch=0.00  
 output_lens: min=820   max=1023  mean=923.29  
------------------------------------------------------------------------ 

Starting initial single prompt test run...
Warming up with 32 requests...
100%|████████████████████████████████████████████████████| 32/32 [00:21<00:00,  1.46it/s]
Warmup completed.
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 16
  0%|                                                             | 0/48 [00:00<?, ?it/s]Starting main benchmark run...
100%|████████████████████████████████████████████████████| 48/48 [00:33<00:00,  1.45it/s]
============ Serving Benchmark Result ============
Successful requests:                     48        
Benchmark duration (s):                  33.11     
Total input tokens:                      351295    
Total generated tokens:                  44318     
Request throughput (req/s):              1.45      
Output token throughput (tok/s):         1338.69   
Total Token throughput (tok/s):          11950.10  
---------------Time to First Token----------------
Mean TTFT (ms):                          572.20    
Median TTFT (ms):                        271.07    
P99 TTFT (ms):                           1906.58   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.77     
Median TPOT (ms):                        10.93     
P99 TPOT (ms):                           12.61     
---------------Inter-token Latency----------------
Mean ITL (ms):                           10.78     
Median ITL (ms):                         9.34      
P99 ITL (ms):                            70.49     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          10512.25  
Median E2EL (ms):                        10303.41  
P99 E2EL (ms):                           13189.04  
==================================================
```


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
