### PR TITLE
[GLM5.2][vllm-atom] fix small con perf gap with atom native

### DIFF
--- a/atom/plugin/vllm/attention/layer_mla.py
+++ b/atom/plugin/vllm/attention/layer_mla.py
@@ -1309,13 +1309,20 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                 transpose_bm=True,
             )
 
+        # Fuse the q fp8-quant into the aiter rope+concat+cache kernel by
+        # allocating q_out as fp8 directly (matches the dense decode path,
+        # forward_impl's decode_only branch). The kernel quantizes q
+        # with self._q_scale on write, so the separate vllm scaled_fp8_quant
+        # below is no longer needed — it saved nothing but an extra
+        # vllm::scaled_fp8_quant kernel launch + a bf16->fp8 pass over q every
+        # decode step. Non-fp8 attention keeps the bf16 output unchanged.
         q_out = torch.empty(
             (
                 ql_nope.shape[0],
                 self.num_heads,
                 self.kv_lora_rank + self.qk_rope_head_dim,
             ),
-            dtype=ql_nope.dtype,
+            dtype=dtypes.fp8 if fp8_attention else ql_nope.dtype,
             device=ql_nope.device,
         )
         if kv_cache.numel() > 0:
@@ -1341,15 +1348,6 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
         if self.head_repeat_factor > 1:
             q_out = q_out.repeat_interleave(self.head_repeat_factor, dim=1)
 
-        if fp8_attention:
-            from vllm import _custom_ops as ops
-
-            # Reshape to 2D for scaled_fp8_quant, then restore
-            q_flat, _ = ops.scaled_fp8_quant(
-                q_out.reshape(q_out.shape[0], -1),
-                self._q_scale,
-            )
-            q_out = q_flat.reshape(q_out.shape)
         attn_out = self._forward_sparse_bf16_kv(q_out, kv_cache, attn_metadata)
 
         # V up-projection

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,22 @@ ENV MAX_JOBS=${MAX_JOBS}
 ENV VLLM_TARGET_DEVICE=rocm
 ENV CMAKE_MAKE_PROGRAM=/usr/local/bin/ninja
 
+# Preserve the base image's custom RCCL before any OOT apt runs.
+# The native base builds RCCL from the pinned RCCL_BRANCH (build_rccl stage) and
+# installs it to /usr/local/lib with an /etc/ld.so.conf.d/rccl.conf entry, so
+# ldconfig resolves the custom build. The custom `dpkg -i --force-all` leaves
+# rocm-hip's rccl version dep "broken" on purpose; the OOT `apt --fix-broken
+# install` below satisfies it by reinstalling the STOCK ROCm rccl into
+# /opt/rocm, which then shadows the custom build via ldconfig. That regresses
+# GLM-5.2 decode perf (memory-bound kernels run ~40% slower under the stock rccl
+# even though its collective kernels are never called in decode). Back it up here
+# and restore after all OOT installs (mirrors the Triton backup/restore below).
+RUN echo "========== [OOT 0/7] Back up base-image custom RCCL ==========" && \
+    mkdir -p /tmp/rccl-base-backup && \
+    (cp -a /usr/local/lib/librccl.so* /tmp/rccl-base-backup/ 2>/dev/null || true) && \
+    (cp -a /etc/ld.so.conf.d/rccl.conf /tmp/rccl-base-backup/ 2>/dev/null || true) && \
+    ls -l /tmp/rccl-base-backup/ || true
+
 RUN echo "========== [OOT 1/7] Prepare build tools ==========" && \
     apt-get update && \
     apt --fix-broken install -y && \
@@ -118,6 +134,29 @@ RUN echo "========== [OOT] Restore base image triton ==========" && \
     rm -rf /tmp/triton-base-backup && \
     "${VENV_PYTHON}" -c "import triton; print(f'triton.__version__ = {triton.__version__}')" && \
     "${VENV_PYTHON}" -m pip show triton || true
+
+# Restore the base image's custom RCCL over any stock rccl that OOT apt pulled
+# into /opt/rocm, so the OOT image runs the SAME custom RCCL as the native image.
+# Must run after ALL OOT apt/pip installs. Removes the stock /opt/rocm librccl so
+# ldconfig unambiguously resolves the custom build in /usr/local/lib (leaving the
+# stock rccl dpkg metadata in place keeps rocm-hip's dep satisfied — only the .so
+# is swapped, exactly the runtime state the native image ships).
+RUN echo "========== [OOT] Restore base-image custom RCCL ==========" && \
+    if ls /tmp/rccl-base-backup/librccl.so* >/dev/null 2>&1; then \
+      echo "Removing stock rccl from /opt/rocm and restoring custom build to /usr/local/lib" && \
+      rm -f /opt/rocm*/lib/librccl.so* && \
+      cp -a /tmp/rccl-base-backup/librccl.so* /usr/local/lib/ && \
+      if [ -f /tmp/rccl-base-backup/rccl.conf ]; then \
+        cp -a /tmp/rccl-base-backup/rccl.conf /etc/ld.so.conf.d/rccl.conf ; \
+      else \
+        echo "/usr/local/lib" > /etc/ld.so.conf.d/rccl.conf ; \
+      fi && \
+      ldconfig && \
+      echo "librccl now resolves to:" && ldconfig -p | grep -i librccl ; \
+    else \
+      echo "WARNING: no base-image custom RCCL backup found; leaving rccl unchanged" ; \
+    fi && \
+    rm -rf /tmp/rccl-base-backup
 
 
 RUN echo "========== [vLLM-ATOM] Final transformers version ==========" && \


### PR DESCRIPTION
这个PR fix了小并发场景下，vllm-atom的性能小于atom native的性能的问题，分为两个部分
1. fuse q quant 进 fused_qk_rope_concat_and_cache_mla，之前把q quant漏在了外面，导致多一个冗余op
2. 对齐了vllm-atom最后release出来的image中RCCL的版本，对齐到atom native

关于2，没有真正的root cause，对比了breakdown，vllm-atom的kernel(除了多了个q quant kernel外)，和atom kernel个数/name/调用栈都相同，但是性能上平均比atom kernel慢0-10%，小部分慢30-50%，且慢的kernel不固定，每个layer随机出现，并且在vllm-atom的image内完全卸载vllm，跑atom native的性能，依旧偏低，依旧是kernel随机慢的现象，于是考虑环境不对齐，最后证明，在vllm-atom的image内，LD_PRELOAD atom native image内的RCCL lib时，性能问题消失，多次测试都是如此。虽然当前的code不会调用任何rccl的op，但是性能问题经过实测，确实和rccl相关。

当前两个image中的RCCL版本。vllm-atom构建过程中，一开始是完全对齐atom native image的rccl的，但是apt --fix-broken的时候，会安装stock的RCCL下来，于是两边的RCCL有了gap，虽然版本号是一样的
| Item | atom native | atom-vllm OOT |
|---|---|---|
| Image | `rocm/atom-dev:nightly_202607151539` | `rocm/atom-dev:vllm-v0.22.0-nightly_20260715` |
| Resolved path | `/usr/local/lib/librccl.so.1` | `/opt/rocm-7.2.4/lib/librccl.so.1` |
| Real file | `/usr/local/lib/librccl.so.1.0` | `/opt/rocm-7.2.4/lib/librccl.so.1.0.70204` |
| File size | 19,918,024 B (~19 MB) | 571,818,592 B (~571 MB) |
| RCCL version | 2.27.7 | 2.27.7 |
| Build string | 2.27.7 compiled with ROCm "7.2.4.0-93-97f5574fe2" | 2.27.7 compiled with ROCm "7.2.4.0-93-97f5574fe2" |
| dpkg package | `rccl 2.27.7-29e1567b` (custom, tag = RCCL_BRANCH commit) | `rccl 2.27.7.70204-93~24.04` (stock ROCm apt repo, Ubuntu 24.04) |
| How installed | Built from source at pinned `RCCL_BRANCH=29e1567b` via `./install.sh -p` (deb prefix `/usr/local`), then `dpkg -i --force-all` | Pulled by `apt --fix-broken install` during OOT build — it replaced the inherited custom rccl with the stock ROCm-repo package |
| Built for GPU archs | only `gfx942;gfx950` (`--amdgpu_targets`), stripped | all ROCm-supported gfx archs, not stripped |

比较了用坏RCCL时的mem clock，fabric clock，shader clock，没有发现gap
试图用rocprofv3比较L1/2 hit rate，TLB，结果没有dump成功

最后带着本PR，跑了下精度
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9310|±  |0.0070|
|     |       |strict-match    |    20|exact_match|↑  |0.9318|±  |0.0069|