### PR TITLE
fix: apply MoE pad_align override before create_weights

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -588,13 +588,13 @@ class ModelRunner:
         # so that dp config fields are still at their original values)
         self.profiler = None
         self.profiler_dir = None
+        dp_rank_local = config.parallel_config.data_parallel_rank_local or 0
+        if dp_rank_local > 0 or config.parallel_config.data_parallel_size > 1:
+            self.rank_name = f"dp{dp_rank_local}_tp{rank}"
+        else:
+            self.rank_name = f"rank_{rank}"
         if config.torch_profiler_dir is not None:
-            dp_rank_local = config.parallel_config.data_parallel_rank_local or 0
-            if dp_rank_local > 0 or config.parallel_config.data_parallel_size > 1:
-                rank_name = f"dp{dp_rank_local}_tp{rank}"
-            else:
-                rank_name = f"rank_{rank}"
-            self.profiler_dir = os.path.join(config.torch_profiler_dir, rank_name)
+            self.profiler_dir = os.path.join(config.torch_profiler_dir, self.rank_name)
             os.makedirs(self.profiler_dir, exist_ok=True)
 
         self._setup_device_and_distributed(rank, config)
@@ -653,6 +653,7 @@ class ModelRunner:
         if hasattr(self.model, "load_fused_expert_weights"):
             fused_shared_expert_load_fn = self.model.load_fused_expert_weights
         torch.set_default_device(None)
+        load_start = time.perf_counter()
         load_model(
             self.model,
             config.model,
@@ -660,7 +661,11 @@ class ModelRunner:
             config.load_dummy,
             load_fused_expert_weights_fn=fused_shared_expert_load_fn,
         )
-        logger.info(f"Model load done: {config.model}")
+        load_elapsed = time.perf_counter() - load_start
+        logger.info(
+            f"[{self.rank_name}] Model load done: {config.model} "
+            f"(weights loaded in {load_elapsed:.2f}s)"
+        )
 
         # Optional debug instrumentation; no-op when env vars unset.
         # See atom/utils/debug_helper/.
@@ -1834,12 +1839,19 @@ class ModelRunner:
         # the cross-DP packed gather below). `meets_min_tokens` = this rank's
         # prefill reached the min-token bar (e.g. 8k), OR-reduced across DP;
         # `can_split` = structurally splittable, AND-reduced across DP.
-        local_meets_min_tokens, local_can_split, local_ub0, local_ub1 = False, False, 0, 0
+        local_meets_min_tokens, local_can_split, local_ub0, local_ub1 = (
+            False,
+            False,
+            0,
+            0,
+        )
         if tbo_on:
             if num_scheduled_tokens is None:
                 num_scheduled_tokens = np.asarray(batch.num_scheduled_tokens)
-            local_meets_min_tokens, local_can_split, local_ub0, local_ub1 = local_tbo_precompute(
-                self.config, batch, is_prefill, num_scheduled_tokens
+            local_meets_min_tokens, local_can_split, local_ub0, local_ub1 = (
+                local_tbo_precompute(
+                    self.config, batch, is_prefill, num_scheduled_tokens
+                )
             )
 
         if dp_size <= 1:

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -800,6 +800,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.quant_method = quant_config.quant_method or ""
         self.static_input_scales = not quant_config.is_dynamic
         self.is_guinterleave = envs.ATOM_MOE_GU_ITLV
+        self.pad_align = 256
         self.block_quant = (
             self.quant_type == QuantType.per_1x128
             or self.quant_type == QuantType.per_1x32
@@ -832,7 +833,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         scale_dtype = torch.uint8
 
         mxfp4_block = 32
-        pad_align = 256
+        pad_align = self.pad_align
 
         intermediate_size_per_partition_after_pad = (
             (intermediate_size_per_partition + pad_align - 1) // pad_align * pad_align
@@ -1147,10 +1148,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
     ) -> torch.Tensor:
         if self.use_triton_decode and not get_forward_context().context.is_prefill:
             # Triton decode is GGUU-only; GUGU uses the FlyDSL path.
+            from aiter.ops.triton.moe.moe_routing.routing import routing
             from atom.model_ops.fused_moe_triton import (
                 triton_kernel_fused_experts_a8w4_silu_gguu,
             )
-            from aiter.ops.triton.moe.moe_routing.routing import routing
 
             n_expts_act = top_k
 
@@ -2389,6 +2390,7 @@ class FusedMoE(torch.nn.Module):
         shared_expert_scoring_func: Optional[str] = None,
         config: Optional[PretrainedConfig] = None,
         shared_expert_prefix: Optional[str] = None,
+        pad_align: Optional[int] = None,
     ):
         super().__init__()
         self.prefix = prefix
@@ -2563,6 +2565,12 @@ class FusedMoE(torch.nn.Module):
             )
 
         assert self.quant_method is not None
+
+        # Override weight padding alignment before create_weights consumes it.
+        # Must happen here (pre-create_weights) — setting it on quant_method
+        # after FusedMoE construction is a no-op since weights are already sized.
+        if pad_align is not None:
+            self.quant_method.pad_align = pad_align
 
         self.apply_router_weight_on_input = apply_router_weight_on_input
         self.moe_quant_params = {

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2652,6 +2652,9 @@ class MoE(nn.Module):
             e_score_correction_bias=getattr(self.gate, "e_score_correction_bias", None),
             config=moe_cfg,
             shared_expert_prefix=f"{prefix}.shared_experts",
+            # inter=3072/TP8=384 is a 128-multiple; pad to 128 (not the 256
+            # default) to avoid padding the MoE intermediate up to 512.
+            pad_align=128,
         )
         self.experts.swiglu_limit = args.swiglu_limit
 


### PR DESCRIPTION
## Summary

Two changes for DeepSeek-V4-Pro MoE weight loading.

### 1. Fix: apply MoE `pad_align` override before `create_weights`

`Mxfp4MoEMethod.create_weights` runs inside `FusedMoE.__init__`, so setting
`quant_method.pad_align` *after* constructing `FusedMoE` was a no-op — the
weight buffers were already sized with the default `pad_align=256`, padding the
per-rank MoE intermediate from 384 up to 512.

This threads `pad_align` through `FusedMoE.__init__` and applies it to the quant
method **before** `create_weights` consumes it. V4-Pro now allocates with
`inter_dim=384` (`3072 / TP8`, already a 128-multiple) instead of padding to 512.

### 2. Log per-rank model weight load time

Time the `load_model()` call and include the elapsed seconds plus the rank name
in the `Model load done` log. `rank_name` is hoisted out of the profiler branch
into `self.rank_name` (computed unconditionally) so it is available for logging
regardless of whether the profiler is enabled.

Example:
```
[dp3_tp0] Model load done: /data/DeepSeek-V4-Pro (weights loaded in 42.31s)
```

## Verification

- fused_moe dispatch key confirms `inter_dim` changed from 512 -> 384 across all
  token buckets (`('gfx950', 256, <tok>, 7168, 384, 384, 6)`).
- `dsv4_fp8fp4_tuned_fmoe.csv` already contains complete `inter=384` tuned rows
  (all token buckets, `err1=0.0%`), so dispatch does not fall back.
- GSM8K (V4-Pro, tp8, TBO+DPA, fewshot=3): flexible-extract 0.9530 /
  strict-match 0.9538 -- no regression vs baseline 0.95.

## Test plan

- [x] Server boots, `inter_dim=384` in fused_moe dispatch log
- [x] GSM8K accuracy within noise of baseline
