### PR TITLE
chore: fix black formatting in tbo/ubatching.py

### DIFF
--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -159,7 +159,9 @@ def local_tbo_precompute(
             return _precompute_prefill_token_split(
                 num_scheduled_tokens, num_pref_reqs, min_pref
             )
-        return _precompute_prefill_req_split(num_scheduled_tokens, num_pref_reqs, min_pref)
+        return _precompute_prefill_req_split(
+            num_scheduled_tokens, num_pref_reqs, min_pref
+        )
 
     # Decode path
     if not config.enable_tbo_decode or batch.is_dummy_run:


### PR DESCRIPTION
Wrap an over-length call to `_precompute_prefill_req_split` in `atom/utils/tbo/ubatching.py` so the repo passes the CI `Check Code Style with Black` job.

This is a pre-existing black violation on `main` (the line exceeds 88 chars); it currently fails the black `--check` on every PR. No behavior change — pure formatting.

## Test plan
- [x] `black --check atom/utils/tbo/ubatching.py` passes