### PR TITLE
fix: skip distributed barrier on single-rank runs

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1754,7 +1754,14 @@ class ModelRunner:
                     f"diff={diff_pct:.1%}"
                 )
 
-        if torch.distributed.is_initialized():
+        # Skip on single-rank: a world_size==1 barrier is a no-op but still
+        # forces lazy NCCL communicator creation (CUDA-allocs its buffers),
+        # which can OOM/fail on single-card runs. The process group stays
+        # initialized so get_tp_group() and friends keep working.
+        if (
+            torch.distributed.is_initialized()
+            and torch.distributed.get_world_size() > 1
+        ):
             torch.distributed.barrier()
         return True
 

--- a/atom/utils/debug_helper/dump.py
+++ b/atom/utils/debug_helper/dump.py
@@ -196,7 +196,8 @@ def maybe_dump_weights_and_exit(model: torch.nn.Module) -> None:
         import torch.distributed as dist
 
         if dist.is_initialized():
-            dist.barrier()
+            if dist.get_world_size() > 1:
+                dist.barrier()
             dist.destroy_process_group()
         sys.exit(0)
 


### PR DESCRIPTION
## Summary

The nightly Docker single-GPU smoke test (`simple_inference --model Meta-Llama-3-8B-Instruct`, `tensor_parallel_size=1, data_parallel_size=1`) crashes during `allocate_kv_cache()`:

```
torch.distributed.barrier()
  -> NCCL error ... unhandled cuda error
     Failed to CUDA calloc 33554432 bytes
```

## Root cause

`allocate_kv_cache()` guarded the barrier only on `torch.distributed.is_initialized()`, which is **True even for single-card runs** — ATOM always sets up a process group (log: `rank 0 in world size 1 is assigned as DP rank 0, ...`). The barrier is the first (and only) eager collective on single card, so it forces **lazy NCCL communicator creation**, whose CUDA buffer alloc failed and killed the engine.

A `world_size == 1` barrier is semantically a no-op; the only thing it does on single card is trigger the NCCL init that crashes.

## Fix

Guard both barriers on `get_world_size() > 1`:
- `atom/model_engine/model_runner.py` — `allocate_kv_cache()`
- `atom/utils/debug_helper/dump.py` — weight-dump exit path (same latent pattern)

`torch.distributed.get_world_size()` on the default group returns the full `DP * TP * PP * PCP` world (`init_distributed_environment` folds DP into the default PG world size), so it matches exactly the group `torch.distributed.barrier()` synchronizes:

| Config | get_world_size() | barrier |
|---|---:|---|
| DP1 TP1 (crash) | 1 | skipped |
| DP8 TP1 | 8 | runs |
| TP8 DP1 | 8 | runs |
| TP8 DP8 | 64 | runs |

Multi-rank barriers are preserved; only genuine single-rank runs skip. `world_size` is globally consistent across ranks, so there is no split (some barrier, some skip) and no deadlock risk. The process group stays initialized, so `get_tp_group()` and the collective helpers keep working.

## Test plan
- [x] Single-card `simple_inference` no longer hits the NCCL barrier path
- [x] `black --check` clean on changed files
