### PR TITLE
feat: load-aware DP request routing for CoreManager

### DIFF
--- a/.claude/skills/capture-trace/SKILL.md
+++ b/.claude/skills/capture-trace/SKILL.md
@@ -156,7 +156,7 @@ ATOM annotates the critical path with `torch.profiler.record_function`. The **ki
 | `dummy_prefill[...]` | warmup dummy prefill |
 | `draft[i/k bs=]` | eagle/MTP draft mid-step |
 
-Fields: `bs` effective batch, `tok` total tokens, `ctx` per-seq context lens (truncated if many), `p`/`d` prefill/decode seq counts, `spec` speculative steps, and **`tbo=1`** appended when the step ran Two-Batch-Overlap ubatches.
+Fields: `bs` effective (real) batch — on the CUDAGraph path shown as `bs=<real>/<graph>` (e.g. `bs=117/128`) when the replayed graph is padded above the real batch; `tok` total tokens, `ctx` per-seq context lens (truncated if many), `p`/`d` prefill/decode seq counts, `spec` speculative steps, and **`tbo=1`** appended when the step ran Two-Batch-Overlap ubatches.
 
 Distinguishing dummy vs real matters: e.g. the leading `dummy_decode[bs=1 tok=1]` runs are DP-sync idle steps, NOT real decode. `parse_trace.py` matches only the exact `prefill[` / `decode[` prefixes, so dummy/eager variants are auto-excluded from its stats.
 

--- a/atom/config.py
+++ b/atom/config.py
@@ -1063,6 +1063,13 @@ class Config:
     master_addr: str = "127.0.0.1"
     graph_bs: Optional[list[int]] = None
     enable_dp_attention: bool = False
+    # DP request-routing strategy used by CoreManager to pick an engine rank:
+    # "round_robin" | "least_requests" (default) | "least_tokens". Only has an
+    # effect when more than one DP engine rank is launched. See
+    # atom/model_engine/engine_core_mgr.py:_select_dp_rank_locked. The literal
+    # default must stay in sync with engine_core_mgr.DP_LB_DEFAULT (config.py
+    # cannot import it without a cycle: engine_core_mgr imports Config).
+    dp_load_balance: str = "least_requests"
     # MoE expert-parallel layout policy. When True, MoE EP computes ranks in the
     # flattened DP x TP device space (and shared-expert fusion is disabled,
     # because the fused shared expert assumes the per-DP MoE layout). The vLLM

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 
 from atom import LLMEngine
 from atom.config import CompilationConfig, CUDAGraphMode, SpeculativeConfig
+from atom.model_engine.engine_core_mgr import DP_LB_DEFAULT, DP_LB_STRATEGIES
 
 logger = logging.getLogger("atom")
 
@@ -53,6 +54,7 @@ class EngineArgs:
     enable_expert_parallel: bool = False
     torch_profiler_dir: Optional[str] = None
     enable_dp_attention: bool = False
+    dp_load_balance: str = DP_LB_DEFAULT
     enable_tbo: Optional[str] = None
     all2all_backend: Optional[str] = None
     method: Optional[str] = None
@@ -190,6 +192,20 @@ class EngineArgs:
             "--enable-dp-attention",
             action="store_true",
             help="Enable DP attention.",
+        )
+        parser.add_argument(
+            "--dp-load-balance",
+            type=str,
+            default=DP_LB_DEFAULT,
+            choices=list(DP_LB_STRATEGIES),
+            help="Strategy the CoreManager uses to route a request to a DP "
+            "engine rank. 'round_robin': legacy request-count-agnostic "
+            "rotation. 'least_requests' (default): route to the rank with the "
+            "fewest in-flight requests, breaking ties by the lighter in-flight "
+            "prompt-token load. 'least_tokens': route to the rank with "
+            "the lowest combined in-flight token load (prompt tokens + "
+            "per-request token-equivalent, tunable via ATOM_DP_LB_REQ_EQUIV). "
+            "Has no effect when data_parallel_size == 1.",
         )
         parser.add_argument(
             "--enable-tbo",

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-import enum
 import logging
 import pickle
 import queue
@@ -14,6 +13,7 @@ import torch
 import zmq
 from atom.config import Config, ParallelConfig
 from atom.model_engine.async_proc import AsyncIOProcManager
+from atom.model_engine.engine_core_protocol import EngineCoreRequestType
 from atom.model_engine.engine_utility import EngineUtilityHandler
 from atom.model_engine.scheduler import Scheduler
 from atom.model_engine.sequence import Sequence, SequenceStatus, get_exit_sequence
@@ -30,28 +30,6 @@ from atom.utils.distributed.utils import (
 from atom.kv_transfer.disaggregation import KVOutputAggregator
 
 logger = logging.getLogger("atom")
-
-
-class EngineCoreRequestType(enum.Enum):
-    """
-    Request types defined as hex byte strings, so it can be sent over sockets
-    without separate encoding step.
-    """
-
-    ADD = b"\x00"
-    ABORT = b"\x01"
-    START_DP_WAVE = b"\x02"
-    UTILITY = b"\x03"
-    # Sentinel used within EngineCoreProc.
-    EXECUTOR_FAILED = b"\x04"
-    # Sentinel used within EngineCore.
-    SHUTDOWN = b"\x05"
-    # Stream output for callbacks
-    STREAM = b"\x06"
-    # Signal that EngineCore is fully initialized and ready
-    READY = b"\x07"
-    # Response to a synchronous utility command
-    UTILITY_RESPONSE = b"\x08"
 
 
 class EngineCore:

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -7,15 +7,16 @@ import multiprocessing
 import pickle
 import queue
 import weakref
-from threading import Thread
-from typing import List
+from threading import Lock, Thread
+from typing import List, Optional
 
 import zmq
 import zmq.asyncio
 from atom.config import Config
-from atom.model_engine.engine_core import EngineCore, EngineCoreRequestType
+from atom.model_engine.engine_core_protocol import EngineCoreRequestType
 from atom.model_engine.sequence import Sequence
 from atom.utils import (
+    envs,
     get_open_zmq_inproc_path,
     get_open_zmq_ipc_path,
     make_zmq_socket,
@@ -23,6 +24,12 @@ from atom.utils import (
 )
 
 logger = logging.getLogger("atom")
+
+# Valid values for Config.dp_load_balance / --dp-load-balance, and the default.
+# Single source of truth for argparse (choices + default) so the CLI flag and
+# the Config field can never diverge.
+DP_LB_STRATEGIES = ("round_robin", "least_requests", "least_tokens")
+DP_LB_DEFAULT = "least_requests"
 
 
 class CoreManager:
@@ -51,7 +58,30 @@ class CoreManager:
         self.engine_core_identities = []
         self.shutdown_paths = []
         self.output_threads = []
-        self._rr_counter = 0
+        # Fair-rotation cursor, advanced once per selection. round_robin picks the
+        # rank directly (cursor % n); the load-aware strategies use it only to seed
+        # the argmin start offset so fully-tied ranks rotate instead of always
+        # resolving to rank 0.
+        self._rank_rotation_cursor = 0
+
+        # --- DP request load balancing (see _select_dp_rank_locked) ---
+        # Strategy: "round_robin" | "least_requests" | "least_tokens" (validated
+        # at the CLI by argparse choices=DP_LB_STRATEGIES).
+        self._dp_lb_strategy = config.dp_load_balance
+        # Token-equivalent weight of one in-flight request for "least_tokens".
+        # Read once here: this is a construction-time config value (CoreManager
+        # is built after env/args are finalized), not a runtime-tunable knob.
+        self._dp_lb_req_equiv = envs.ATOM_DP_LB_REQ_EQUIV
+        # Authoritative in-flight load per rank, maintained locally: incremented
+        # on dispatch, decremented on finish/abort. Guarded by _lb_lock because
+        # dispatch runs on the request thread while release runs on the per-rank
+        # output threads.
+        self._rank_reqs = [0] * self.local_engine_count
+        self._rank_tokens = [0] * self.local_engine_count
+        # seq_id -> (dp_rank, req_cost, tok_cost) so release subtracts exactly
+        # what dispatch added, and only for ranks that were actually charged.
+        self._seq_load = {}
+        self._lb_lock = Lock()
 
         import torch
 
@@ -249,6 +279,7 @@ class CoreManager:
                                     )
                             if request_output.finished:
                                 self._seq_id_to_callback.pop(seq_id, None)
+                                self._release_seq_load(seq_id)
                                 logger.debug(
                                     f"{self.label}: Cleaned up callback for finished sequence {seq_id}"
                                 )
@@ -257,6 +288,10 @@ class CoreManager:
                     elif request_type == EngineCoreRequestType.ADD:
                         # logger.info(f"Engine core output sequence id: {seq.id}")
                         seqs = data
+                        # Offline (non-streaming) completions arrive here as
+                        # finished sequences; release their in-flight DP load.
+                        for seq in seqs:
+                            self._release_seq_load(seq.id)
                         self.outputs_queue.put_nowait(seqs)
             finally:
                 # Close sockets.
@@ -393,40 +428,208 @@ class CoreManager:
                 copy=False,
             )
         else:
-            # DP ranks: honor an explicit atomesh DPA routing hint when present;
-            # otherwise keep the existing round-robin behavior.
-            dp_seqs = [[] for _ in range(self.local_engine_count)]
-            for seq in seqs:
-                requested_dp_rank = getattr(seq, "data_parallel_rank", None)
-                if requested_dp_rank is not None:
-                    dp_rank = int(requested_dp_rank)
-                    if not 0 <= dp_rank < self.local_engine_count:
-                        raise ValueError(
-                            f"Invalid data_parallel_rank={dp_rank}; "
-                            f"local_engine_count={self.local_engine_count}"
-                        )
-                else:
-                    dp_rank = self._rr_counter % self.local_engine_count
-                    self._rr_counter += 1
-                dp_seqs[dp_rank].append(seq)
+            self._dispatch_to_dp_ranks(seqs)
 
+    def _resolve_and_validate_hints(self, seqs: List[Sequence]) -> List[Optional[int]]:
+        """Resolve every seq's explicit ``data_parallel_rank`` hint and validate
+        the whole batch, once.
+
+        Returns the per-seq resolved hint (an int rank, or None for a
+        load-balanced seq) so the dispatch loop can reuse it instead of calling
+        getattr/int a second time per seq.
+
+        Validation runs BEFORE any load is charged so a bad hint in the middle
+        of a batch cannot leave earlier siblings charged-but-undispatched (a
+        permanent in-flight-load leak).
+        """
+        hints: List[Optional[int]] = []
+        for seq in seqs:
+            raw = getattr(seq, "data_parallel_rank", None)
+            hint = None if raw is None else int(raw)
+            if hint is not None and not 0 <= hint < self.local_engine_count:
+                raise ValueError(
+                    f"Invalid data_parallel_rank={hint}; "
+                    f"local_engine_count={self.local_engine_count}"
+                )
+            hints.append(hint)
+        return hints
+
+    def _dispatch_to_dp_ranks(self, seqs: List[Sequence]) -> None:
+        """Route a batch across DP ranks and send each rank its sub-batch.
+
+        Honors an explicit ``data_parallel_rank`` hint; otherwise picks a rank
+        via ``_select_dp_rank_locked`` (load-aware by default). Selection and the
+        in-flight-load charge happen atomically under ``_lb_lock`` so a burst of
+        requests spreads across ranks instead of all landing on the current
+        minimum.
+        """
+        # Resolve + validate all hints in one pass first — no charging until the
+        # whole batch is known good, so a rejected batch never leaks partial
+        # load. The resolved hints are reused in the loop below to avoid a second
+        # getattr/int pass per seq.
+        hints = self._resolve_and_validate_hints(seqs)
+
+        # round_robin is load-agnostic and skips the charge/release bookkeeping;
+        # the load-aware strategies track per-rank load.
+        track_load = self._dp_lb_strategy != "round_robin"
+        dp_seqs = [[] for _ in range(self.local_engine_count)]
+        reqs_snapshot = tokens_snapshot = None
+        with self._lb_lock:
+            for seq, hint in zip(seqs, hints):
+                dp_rank = hint if hint is not None else self._select_dp_rank_locked()
+                if track_load:
+                    self._charge_seq_load_locked(seq, dp_rank)
+                dp_seqs[dp_rank].append(seq)
+            # Copy the counters under the lock so the snapshot log below is a
+            # consistent instant, not a torn read racing _release_seq_load.
+            if track_load:
+                reqs_snapshot = list(self._rank_reqs)
+                tokens_snapshot = list(self._rank_tokens)
+
+        # Track which ranks were actually handed off, plus a compact per-rank
+        # delta ("rankR:Nreq/Ttok") for the single summary log after the loop. If
+        # a send fails partway, the seqs on the not-yet-dispatched ranks were
+        # charged above but will never produce a finished output to release them,
+        # so we roll back their in-flight load before propagating — otherwise
+        # routing skews forever.
+        dispatched = [False] * self.local_engine_count
+        added = []
+        try:
             for dp_rank, rank_seqs in enumerate(dp_seqs):
-                if rank_seqs:
-                    request_ids = [seq.id for seq in rank_seqs]
-                    logger.info(
-                        "%s: Add %d request(s) to DP rank %d, sequence ids: %s",
-                        self.label,
-                        len(rank_seqs),
-                        dp_rank,
-                        request_ids,
-                    )
-                    self.input_sockets[dp_rank].send_multipart(
-                        [
-                            self.engine_core_identities[dp_rank],
-                            pickle.dumps((EngineCoreRequestType.ADD, rank_seqs)),
-                        ],
-                        copy=False,
-                    )
+                if not rank_seqs:
+                    continue
+                self.input_sockets[dp_rank].send_multipart(
+                    [
+                        self.engine_core_identities[dp_rank],
+                        pickle.dumps((EngineCoreRequestType.ADD, rank_seqs)),
+                    ],
+                    copy=False,
+                )
+                dispatched[dp_rank] = True
+                batch_prefill_tokens = sum(
+                    int(getattr(seq, "num_prompt_tokens", 0) or 0) for seq in rank_seqs
+                )
+                added.append(
+                    f"rank{dp_rank}: {len(rank_seqs)} req / {batch_prefill_tokens} tok"
+                )
+        except Exception:
+            # Roll back only ranks we never handed off. _release_seq_load is
+            # idempotent (pops from _seq_load), so even if a failing send had
+            # already delivered its frames and the engine finished + released
+            # those seqs on an output thread, this rollback cannot double-count:
+            # whichever release runs first wins, the other is a no-op.
+            if track_load:
+                for dp_rank, rank_seqs in enumerate(dp_seqs):
+                    if rank_seqs and not dispatched[dp_rank]:
+                        for seq in rank_seqs:
+                            self._release_seq_load(seq.id)
+            raise
+
+        # One line per add: the per-rank delta this add placed, plus (for the
+        # load-aware strategies) the resulting in-flight distribution across all
+        # ranks, so a single grep shows both what changed and how balanced it is.
+        if reqs_snapshot is not None:
+            logger.info(
+                "%s: add %s | in-flight reqs=%s prefill_tokens=%s",
+                self.label,
+                ", ".join(added),
+                reqs_snapshot,
+                tokens_snapshot,
+            )
+        else:
+            logger.info("%s: add %s", self.label, ", ".join(added))
+
+    def _select_dp_rank_locked(self) -> int:
+        """Pick a DP engine rank for a new request. Caller must hold _lb_lock.
+
+        - "round_robin": load-agnostic rotation.
+        - "least_requests" (default): fewest in-flight requests, ties broken by
+          the lighter in-flight prompt-token load. Request count keeps the
+          lockstep DP ranks in phase; the token tie-break packs pending prefill
+          work evenly across the equal-request ranks.
+        - "least_tokens": lowest combined load ``tokens + req_equiv * reqs``
+          (prefill pressure + decode-slot pressure).
+
+        Fully-tied ranks are resolved by a rotating cursor so selection does not
+        always fall on rank 0. See docs/distributed_guide.md for the rationale.
+        """
+        n = self.local_engine_count
+        if self._dp_lb_strategy == "round_robin":
+            dp_rank = self._rank_rotation_cursor % n
+            self._rank_rotation_cursor += 1
+            return dp_rank
+
+        # argmin over per-rank load, scanned from a rotating start offset so a run
+        # of fully-equal ranks spreads evenly. Scores are computed inline (no
+        # intermediate list) — the loop reads the counters directly.
+        least_requests = self._dp_lb_strategy == "least_requests"
+        best_rank = 0
+        best_score = None
+        offset = self._rank_rotation_cursor % n
+        for i in range(n):
+            r = (offset + i) % n
+            if least_requests:
+                # Lexicographic (request count, prompt-token load): tuples compare
+                # element-wise, so tokens only decide among request-count ties.
+                score = (self._rank_reqs[r], self._rank_tokens[r])
+            else:  # "least_tokens"
+                score = (
+                    self._rank_tokens[r] + self._dp_lb_req_equiv * self._rank_reqs[r]
+                )
+            if best_score is None or score < best_score:
+                best_score = score
+                best_rank = r
+        self._rank_rotation_cursor += 1
+        return best_rank
+
+    def _charge_seq_load_locked(self, seq: Sequence, dp_rank: int) -> None:
+        """Record a seq's in-flight load on dp_rank. Caller must hold _lb_lock."""
+        req_cost = 1
+        tok_cost = int(getattr(seq, "num_prompt_tokens", 0) or 0)
+        self._rank_reqs[dp_rank] += req_cost
+        self._rank_tokens[dp_rank] += tok_cost
+        self._seq_load[seq.id] = (dp_rank, req_cost, tok_cost)
+
+    def _release_seq_load(self, seq_id) -> None:
+        """Undo a seq's in-flight load when it finishes or is aborted.
+
+        Idempotent: a seq is only charged once and released once, so a repeated
+        call (e.g. finish followed by abort) is a no-op.
+        """
+        with self._lb_lock:
+            entry = self._seq_load.pop(seq_id, None)
+            if entry is None:
+                return
+            dp_rank, req_cost, tok_cost = entry
+            self._rank_reqs[dp_rank] -= req_cost
+            self._rank_tokens[dp_rank] -= tok_cost
+
+    def reset_dp_router(self) -> None:
+        """Reset all DP routing state (rotation cursor + in-flight load).
+
+        Called at the start of a fresh offline ``generate()`` batch so counts do
+        not leak across independent batches and DP assignment is deterministic.
+
+        Precondition: the previous batch has fully drained. If any request is
+        still charged when this runs (e.g. this CoreManager is being shared with
+        a concurrent streaming path), that request's later release becomes a
+        no-op and the per-rank counters would drift — so we warn loudly instead
+        of corrupting accounting silently.
+        """
+        with self._lb_lock:
+            if self._seq_load:
+                logger.warning(
+                    "%s: reset_dp_router() called with %d request(s) still "
+                    "charged in-flight; dropping their load. Expected only "
+                    "between fully-drained offline batches — a shared/concurrent "
+                    "CoreManager will see counters drift.",
+                    self.label,
+                    len(self._seq_load),
+                )
+            self._rank_rotation_cursor = 0
+            self._rank_reqs = [0] * self.local_engine_count
+            self._rank_tokens = [0] * self.local_engine_count
+            self._seq_load.clear()
 
     def get_stream_outputs(self):
         try:
@@ -467,6 +670,10 @@ class CoreManager:
         scheduler finishes the seq at its next step via the normal stop path,
         freeing its KV blocks. Fire-and-forget; safe if the seq already finished.
         """
+        # Release DP load bookkeeping now: an aborted seq may never emit a
+        # finished STREAM output, so relying on the finish path alone would leak
+        # its in-flight count. _release_seq_load is idempotent.
+        self._release_seq_load(req_id)
         try:
             self.broadcast_utility_command("abort_request", req_id=req_id)
         except Exception as e:
@@ -560,6 +767,12 @@ def launch_engine_core(config: Config, dp_rank: int = 0):
     input_address = get_open_zmq_ipc_path()
     output_address = get_open_zmq_ipc_path()
     import torch
+
+    # Imported here, not at module scope: EngineCore pulls the heavy
+    # engine_core -> async_proc -> aiter chain. Spawning a worker is inherently a
+    # GPU-side operation, so the cost belongs here and keeps CoreManager (routing
+    # only) importable on a CPU-only runner.
+    from atom.model_engine.engine_core import EngineCore
 
     if torch.multiprocessing.get_start_method(allow_none=True) is None:
         torch.multiprocessing.set_start_method("spawn", force=False)

--- a/atom/model_engine/engine_core_protocol.py
+++ b/atom/model_engine/engine_core_protocol.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Lightweight protocol types shared between CoreManager and EngineCore.
+
+Deliberately free of torch/aiter/zmq imports so the CPU-only CoreManager
+(request thread) and unit tests can import ``EngineCoreRequestType`` without
+dragging in the heavy ``engine_core`` -> ``async_proc`` -> ``aiter`` chain.
+"""
+
+import enum
+
+
+class EngineCoreRequestType(enum.Enum):
+    """
+    Request types defined as hex byte strings, so it can be sent over sockets
+    without separate encoding step.
+    """
+
+    ADD = b"\x00"
+    ABORT = b"\x01"
+    START_DP_WAVE = b"\x02"
+    UTILITY = b"\x03"
+    # Sentinel used within EngineCoreProc.
+    EXECUTOR_FAILED = b"\x04"
+    # Sentinel used within EngineCore.
+    SHUTDOWN = b"\x05"
+    # Stream output for callbacks
+    STREAM = b"\x06"
+    # Signal that EngineCore is fully initialized and ready
+    READY = b"\x07"
+    # Response to a synchronous utility command
+    UTILITY_RESPONSE = b"\x08"

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -197,8 +197,9 @@ class LLMEngine:
         sampling_params: SamplingParams | list[SamplingParams],
         request_ids: Optional[list[str]] = None,
     ) -> list[str]:
-        # Reset round-robin counter to ensure consistent DP not core dump
-        self.core_mgr._rr_counter = 0
+        # Reset DP routing state (round-robin cursor + in-flight load) so a
+        # fresh batch gets deterministic DP assignment and no leaked counts.
+        self.core_mgr.reset_dp_router()
 
         self.add_request(prompts, sampling_params, request_ids=request_ids)
         outputs = {}
@@ -219,7 +220,7 @@ class LLMEngine:
         multimodal_data_list: list[dict],
     ) -> list[dict]:
         """Generate completions for multimodal inputs (token IDs + vision data)."""
-        self.core_mgr._rr_counter = 0
+        self.core_mgr.reset_dp_router()
         self.add_request(
             token_ids_list,
             sampling_params,

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2098,6 +2098,9 @@ class ModelRunner:
             is_dummy=context.is_dummy_run,
             tbo_on=forward_context.ubatch_slices is not None,
             bs=bs,
+            # The CUDAGraph replays a padded batch (context.graph_bs); pass it so
+            # the label shows bs=<real>/<graph> when they differ.
+            graph_bs=context.graph_bs if forward_mode.use_cudagraph else None,
             batch=batch,
         )
 

--- a/atom/model_engine/run_labels.py
+++ b/atom/model_engine/run_labels.py
@@ -12,7 +12,10 @@ Kinds (label prefix — groups in Perfetto UI, greppable):
   - ``dummy_prefill``      warmup dummy prefill
 
 Fields (``key=value`` inside brackets):
-  - ``bs``   effective batch size
+  - ``bs``   effective (real) batch size; on the CUDAGraph path shown as
+             ``<real>/<graph>`` when the replayed graph is padded above the real
+             batch (e.g. ``bs=117/128``). ``parse_trace.py`` reads the leading
+             ``\\d+`` so the real batch is still what it extracts.
   - ``tok``  total scheduled tokens
   - ``ctx``  per-seq context lengths (prefill/eager paths; truncated if many)
   - ``p``/``d``  prefill / decode seq counts (cudagraph decode path)
@@ -40,14 +43,22 @@ def build_run_label(
     tbo_on: bool,
     bs: int,
     batch: Optional["ScheduledBatch"],
+    graph_bs: Optional[int] = None,
 ) -> str:
     """Build the ``record_function`` label for one forward pass.
 
     Pure function (no runtime state) — see module docstring for the taxonomy.
+
+    ``graph_bs`` is the padded batch size the CUDAGraph actually replays. When it
+    is given and exceeds the real ``bs`` (CUDAGraph path only), the label shows
+    ``bs=<real>/<graph>`` so the padding is visible in the trace.
     """
     if use_cudagraph:
         kind = "dummy_decode" if is_dummy else "decode"
-        label = f"{kind}[bs={bs}"
+        if graph_bs is not None and graph_bs > bs:
+            label = f"{kind}[bs={bs}/{graph_bs}"
+        else:
+            label = f"{kind}[bs={bs}"
         if batch is not None:
             label += f" tok={batch.total_tokens_num}"
             if batch.total_seqs_num_prefill > 0:

--- a/atom/rollout/async_engine.py
+++ b/atom/rollout/async_engine.py
@@ -133,7 +133,7 @@ class AsyncLLMEngine(LLMEngine):
             ids if isinstance(ids, list) else ids.tolist() for ids in input_ids_list
         ]
 
-        self.core_mgr._rr_counter = 0
+        self.core_mgr.reset_dp_router()
         self.add_request(prompts, sampling_params, request_ids=data_ids)
 
         outputs = {}

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -28,6 +28,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DP_SIZE": lambda: int(os.getenv("ATOM_DP_SIZE", "1")),
     "ATOM_DP_MASTER_IP": lambda: os.getenv("ATOM_DP_MASTER_IP", "127.0.0.1"),
     "ATOM_DP_MASTER_PORT": lambda: int(os.getenv("ATOM_DP_MASTER_PORT", "29500")),
+    # Token-equivalent cost of one in-flight request for the "least_tokens" DP
+    # load-balance strategy. The per-rank load score is
+    #   sum(prompt_tokens) + ATOM_DP_LB_REQ_EQUIV * num_in_flight_requests
+    # so a larger value biases routing toward request-count balance (decode
+    # pressure) and a smaller value toward prompt-token balance (prefill
+    # pressure). See engine_core_mgr.CoreManager._select_dp_rank_locked.
+    "ATOM_DP_LB_REQ_EQUIV": lambda: int(os.getenv("ATOM_DP_LB_REQ_EQUIV", "512")),
     # Prefix for process titles set via set_process_title (shown in ps/top/rocm-smi)
     "ATOM_PROCESS_NAME_PREFIX": lambda: os.getenv("ATOM_PROCESS_NAME_PREFIX", "ATOM"),
     # --- Compilation & Execution ---

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -71,7 +71,7 @@ A request flows through the system in ten steps:
 
 2. **`InputOutputProcessor.preprocess()`** -- each prompt is tokenized via the HuggingFace tokenizer. A `Sequence` object is created to track the request's state, timing, and block allocation. `arrive_time` is recorded.
 
-3. **`CoreManager.add_request()`** -- the list of `Sequence` objects is serialized with `pickle` and sent over a ZMQ `ROUTER` socket. When multiple DP ranks are active, requests are distributed round-robin.
+3. **`CoreManager.add_request()`** -- the list of `Sequence` objects is serialized with `pickle` and sent over a ZMQ `ROUTER` socket. When multiple DP ranks are active, requests are routed by a configurable load-balancing strategy (`least_requests` by default; `round_robin` and `least_tokens` also available).
 
 4. **`EngineCore.process_input_sockets()`** -- an I/O thread on the `EngineCore` process receives the serialized data on a ZMQ `DEALER` socket, deserializes it, and places the sequences into the `input_queue`.
 
@@ -273,7 +273,7 @@ Each attention backend provides its own `prepare_mtp_decode()` implementation:
 |------|-------------|
 | `atom/model_engine/llm_engine.py` | `LLMEngine` user-facing API, `InputOutputProcessor` for tokenization/detokenization and TTFT/TPOT statistics |
 | `atom/model_engine/engine_core.py` | `EngineCore` main execution loop, `DPEngineCoreProc` data-parallel variant, `EngineCoreRequestType` message protocol |
-| `atom/model_engine/engine_core_mgr.py` | `CoreManager` ZMQ orchestration, process launching, round-robin DP dispatch |
+| `atom/model_engine/engine_core_mgr.py` | `CoreManager` ZMQ orchestration, process launching, load-balanced DP dispatch |
 | `atom/model_engine/model_runner.py` | `ModelRunner` per-GPU execution (model loading, CUDA graph capture, forward pass), `tokenIDProcessor` deferred output handling |
 | `atom/model_engine/scheduler.py` | `Scheduler` prefill-first scheduling, `ScheduledBatch` batch descriptor, `ScheduledBatchOutput` forward results |
 | `atom/model_engine/sequence.py` | `Sequence` request state, `SequenceStatus` and `SequenceType` enums |

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -55,6 +55,7 @@ Defined in `atom/config.py`. The root dataclass that the engine consumes.
 | `master_addr` | `str` | `"127.0.0.1"` | Master address for distributed communication |
 | `graph_bs` | `Optional[list[int]]` | `None` | Explicit list of batch sizes for CUDA graph capture; derived from `compilation_config` during init |
 | `enable_dp_attention` | `bool` | `False` | Enable data-parallel attention |
+| `dp_load_balance` | `str` | `"least_requests"` | DP request-routing strategy: `"round_robin"` (legacy), `"least_requests"` (default; fewest in-flight requests, ties broken by lighter in-flight prompt-token load), or `"least_tokens"` (lowest `sum_prompt_tokens + ATOM_DP_LB_REQ_EQUIV * num_reqs`). Only effective when >1 DP rank. See distributed guide §2 |
 | `torch_dtype` | `torch.dtype` | *(computed)* | Inferred from `hf_config.torch_dtype`; falls back to `torch.bfloat16` |
 | `speculative_config` | `Optional[SpeculativeConfig]` | `None` | Speculative decoding configuration (see Section 5) |
 | `bos_token_id` | `int` | `-1` | Beginning-of-sequence token ID (`-1` = use model default) |

--- a/docs/distributed_guide.md
+++ b/docs/distributed_guide.md
@@ -183,7 +183,7 @@ dist.all_reduce(num_tokens_tensor, group=get_dp_group().cpu_group)
 1. For each DP rank, it creates a `Config` copy with the appropriate `data_parallel_rank` and `data_parallel_rank_local`.
 2. Launches each `EngineCore` in a separate `multiprocessing.Process`.
 3. Uses ZMQ (ROUTER/DEALER) sockets for input distribution and ZMQ (PUSH/PULL) for output collection.
-4. Distributes incoming requests across DP ranks via round-robin load balancing.
+4. Distributes incoming requests across DP ranks via a configurable load-balancing strategy (see below).
 5. Waits for READY signals from all ranks before accepting requests.
 
 When `enable_dp_attention` is set, `CoreManager` flattens TP into DP:
@@ -195,12 +195,57 @@ if config.enable_dp_attention:
     config.tensor_parallel_size = 1
 ```
 
+### DP Request Load Balancing
+
+Because the DP busy loop is **lockstep** (all ranks `AllReduce` `has_unfinished`
+each step, and an idle rank runs `_execute_dummy_batch()` when any other rank is
+busy), an unbalanced request distribution directly wastes GPU: the step time is
+bounded by the busiest rank while lighter ranks burn cycles on dummy batches.
+`CoreManager` therefore routes each request to the *least-loaded* rank rather
+than blindly rotating.
+
+The strategy is selected with `--dp-load-balance` (`Config.dp_load_balance`):
+
+| Strategy | Signal | Selection |
+|----------|--------|-----------|
+| `round_robin` | none | Load-agnostic rotation (`cursor % n`). |
+| `least_requests` **(default)** | in-flight request count, then prompt-token load | `argmin((num_in_flight_reqs, in_flight_prompt_tokens))` — request count is primary; ties broken by the lighter prompt-token load, then the rotation cursor. |
+| `least_tokens` | combined token load per rank | `argmin(sum_prompt_tokens + ATOM_DP_LB_REQ_EQUIV * num_reqs)`. |
+
+`least_requests` (the default) keeps the number of in-flight requests even
+across ranks — the dominant lever for DP-lockstep efficiency (equal request
+counts keep ranks in prefill/decode phase). When ranks are tied on request
+count (the common case under saturation), it breaks the tie by the lighter
+in-flight prompt-token load, so pending prefill work is packed evenly across the
+equal-request ranks. `least_tokens`
+additionally weights by prompt-token load across *all* ranks, mirroring production guidance from the
+[DeepSeek-V3/R1 inference system](https://github.com/deepseek-ai/open-infra-index/blob/main/202502OpenSourceWeek/day_6_one_more_thing_deepseekV3R1_inference_system_overview.md)
+(prefill balances on input-token count, decode balances on request count) the `ATOM_DP_LB_REQ_EQUIV` request-equivalent term captures
+decode-slot pressure. It helps most with heterogeneous prompt lengths under
+moderate load; with uniform-length requests it degenerates to `least_requests`.
+All strategies break ties with a round-robin cursor.
+
+Bookkeeping is maintained entirely inside `CoreManager` (no engine-core protocol
+change): for the load-aware strategies, load is charged on dispatch and released
+when a sequence finishes (STREAM `finished` / offline `ADD` output) or is aborted
+— all idempotent under `_lb_lock`, since dispatch runs on the request thread and
+release on the per-rank output threads. Explicit `data_parallel_rank` hints are
+validated up front (a bad hint rejects the whole batch before any charge, so no
+partial load leaks) and, when valid, take priority but are still charged so they
+participate in balancing. `round_robin` skips this bookkeeping entirely. An
+invalid `dp_load_balance` value fails fast at `CoreManager` construction rather
+than silently defaulting. `reset_dp_router()` (called at the start of an offline
+`generate()` batch) assumes the previous batch has drained and warns if it is
+invoked while requests are still charged.
+
 ### Configuration
 
 - `ParallelConfig.data_parallel_size` (int, default `1`): Number of DP replicas.
 - `ParallelConfig.data_parallel_rank` (int, default `0`): This rank's DP index.
 - `ParallelConfig.data_parallel_rank_local` (int, default `None`): Local DP rank on this node.
-- CLI: `--data-parallel-size N` or `-dp N`
+- `Config.dp_load_balance` (str, default `"least_requests"`): DP routing strategy.
+- CLI: `--data-parallel-size N` or `-dp N`; `--dp-load-balance {round_robin,least_requests,least_tokens}`
+- Env: `ATOM_DP_LB_REQ_EQUIV` (int, default `512`): token-equivalent cost of one in-flight request for `least_tokens`.
 
 ---
 
@@ -306,6 +351,7 @@ The block configuration adapts to the batch type: prefill uses `block_num=128, w
 | `ATOM_DP_SIZE` | int | `1` | Total number of data parallel replicas |
 | `ATOM_DP_MASTER_IP` | str | `127.0.0.1` | IP address for DP Gloo rendezvous |
 | `ATOM_DP_MASTER_PORT` | int | `29500` | Port for DP Gloo rendezvous |
+| `ATOM_DP_LB_REQ_EQUIV` | int | `512` | Token-equivalent cost of one in-flight request for the `least_tokens` DP load-balance strategy |
 | ~~`ATOM_ENFORCE_EAGER`~~ | | | Removed. Use CLI flag `--enforce-eager` instead. |
 | `ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION` | bool | `False` | Fuse QK-norm + RoPE + cache quant (for Qwen3-MoE) |
 
@@ -401,7 +447,7 @@ For throughput scaling with dense models, run multiple DP replicas:
 python -m atom.entrypoints.openai_server --model meta-llama/Meta-Llama-3-8B -tp 4 -dp 2
 ```
 
-Each DP replica independently processes a subset of requests. The `CoreManager` distributes requests via round-robin. Device mapping:
+Each DP replica independently processes a subset of requests. The `CoreManager` distributes requests via a configurable load-balancing strategy (`least_requests` by default; see [DP Request Load Balancing](#dp-request-load-balancing)). Device mapping:
 - DP rank 0, TP ranks 0-3 --> GPUs 0-3
 - DP rank 1, TP ranks 0-3 --> GPUs 4-7
 

--- a/tests/test_dp_load_balance.py
+++ b/tests/test_dp_load_balance.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: MIT
+# Unit tests for CoreManager DP request load-balancing (engine_core_mgr).
+#
+# These exercise the pure routing/bookkeeping helpers in isolation via
+# ``CoreManager.__new__`` — no engine cores, sockets, or GPU are created.
+# CoreManager gets ``EngineCoreRequestType`` from the lightweight
+# ``engine_core_protocol`` module and only lazy-imports the heavy ``EngineCore``
+# (which pulls aiter) inside ``launch_engine_core``, so importing CoreManager
+# here works on the CPU-only / mocked CI runner without any sys.modules stub;
+# conftest.py supplies the atom.* / zmq stubs the import chain needs.
+
+from threading import Lock
+
+import pytest
+
+from atom.model_engine.engine_core_mgr import (
+    DP_LB_STRATEGIES,
+    CoreManager,
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+class _FakeSeq:
+    """Minimal stand-in for Sequence: routing only reads id/num_prompt_tokens."""
+
+    def __init__(self, seq_id, num_prompt_tokens=1, data_parallel_rank=None):
+        self.id = seq_id
+        self.num_prompt_tokens = num_prompt_tokens
+        if data_parallel_rank is not None:
+            self.data_parallel_rank = data_parallel_rank
+
+
+def _make_mgr(n_ranks, strategy="least_tokens", req_equiv=512):
+    """Build a bare CoreManager with just the routing state initialized."""
+    mgr = CoreManager.__new__(CoreManager)
+    mgr.label = "Engine Core Mgr"
+    mgr.local_engine_count = n_ranks
+    mgr._dp_lb_strategy = strategy
+    mgr._dp_lb_req_equiv = req_equiv
+    mgr._rank_rotation_cursor = 0
+    mgr._rank_reqs = [0] * n_ranks
+    mgr._rank_tokens = [0] * n_ranks
+    mgr._seq_load = {}
+    mgr._lb_lock = Lock()
+    return mgr
+
+
+def _route(mgr, seqs):
+    """Replicate add_request's per-seq selection loop (hint > strategy)."""
+    assigned = []
+    with mgr._lb_lock:
+        for seq in seqs:
+            hint = getattr(seq, "data_parallel_rank", None)
+            rank = int(hint) if hint is not None else mgr._select_dp_rank_locked()
+            mgr._charge_seq_load_locked(seq, rank)
+            assigned.append(rank)
+    return assigned
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+def test_least_requests_spreads_uniformly():
+    mgr = _make_mgr(4, strategy="least_requests")
+    seqs = [_FakeSeq(i, num_prompt_tokens=10) for i in range(8)]
+    _route(mgr, seqs)
+    # 8 uniform requests across 4 ranks -> 2 each.
+    assert mgr._rank_reqs == [2, 2, 2, 2]
+
+
+def test_least_requests_tiebreak_prefers_fewer_prompt_tokens():
+    # Equal in-flight request count -> the prompt-token load breaks the tie.
+    mgr = _make_mgr(2, strategy="least_requests")
+    mgr._rank_reqs = [1, 1]
+    mgr._rank_tokens = [500, 100]
+    with mgr._lb_lock:
+        rank = mgr._select_dp_rank_locked()
+    assert rank == 1  # equal reqs -> pick the lighter-token rank
+
+
+def test_least_requests_count_dominates_token_tiebreak():
+    # Request count is the primary key: a rank with fewer requests wins even
+    # when it carries far more prompt tokens.
+    mgr = _make_mgr(2, strategy="least_requests")
+    mgr._rank_reqs = [1, 3]
+    mgr._rank_tokens = [10_000, 100]
+    with mgr._lb_lock:
+        rank = mgr._select_dp_rank_locked()
+    assert rank == 0  # fewer requests wins despite the larger token load
+
+
+def test_least_requests_tiebreak_then_count_primacy_over_route():
+    # Seed equal counts but skewed tokens; routing should first even the token
+    # load (tie-break), then request-count primacy takes over.
+    mgr = _make_mgr(2, strategy="least_requests")
+    mgr._rank_reqs = [1, 1]
+    mgr._rank_tokens = [1000, 100]
+    ranks = _route(mgr, [_FakeSeq("a", 100), _FakeSeq("b", 100)])
+    # a: reqs tie (1,1) -> tokens 1000 vs 100 -> rank 1; now reqs=[1,2].
+    # b: reqs 1 vs 2 -> rank 0 has fewer requests -> rank 0 (count primary).
+    assert ranks == [1, 0]
+
+
+def test_least_tokens_avoids_heavy_rank():
+    # Pure token balance (req_equiv=0): a long prompt should keep that rank out
+    # of rotation until the others accumulate comparable token load.
+    mgr = _make_mgr(2, strategy="least_tokens", req_equiv=0)
+    first = _route(mgr, [_FakeSeq("big", num_prompt_tokens=1000)])[0]
+    other = 1 - first
+    # Next several small requests must all go to the lighter rank.
+    ranks = _route(mgr, [_FakeSeq(f"s{i}", num_prompt_tokens=100) for i in range(5)])
+    assert all(r == other for r in ranks)
+    assert mgr._rank_tokens[other] == 500
+    assert mgr._rank_tokens[first] == 1000
+
+
+def test_least_tokens_combined_signal_counts_requests():
+    # With req_equiv>0 a rank holding many tiny requests still looks loaded, so
+    # routing balances request count even when token counts are equal-ish.
+    mgr = _make_mgr(2, strategy="least_tokens", req_equiv=512)
+    ranks = _route(mgr, [_FakeSeq(i, num_prompt_tokens=1) for i in range(6)])
+    # 6 near-zero-token requests -> alternate evenly by the req_equiv term.
+    assert mgr._rank_reqs == [3, 3]
+    assert sorted(ranks) == [0, 0, 0, 1, 1, 1]
+
+
+def test_release_restores_counts():
+    mgr = _make_mgr(3, strategy="least_tokens")
+    seqs = [_FakeSeq(i, num_prompt_tokens=50) for i in range(6)]
+    _route(mgr, seqs)
+    for seq in seqs:
+        mgr._release_seq_load(seq.id)
+    assert mgr._rank_reqs == [0, 0, 0]
+    assert mgr._rank_tokens == [0, 0, 0]
+    assert mgr._seq_load == {}
+
+
+def test_release_is_idempotent_no_leak_no_negative():
+    mgr = _make_mgr(2, strategy="least_tokens")
+    _route(mgr, [_FakeSeq("a", num_prompt_tokens=20)])
+    mgr._release_seq_load("a")
+    # Second release (e.g. abort after finish) must be a no-op.
+    mgr._release_seq_load("a")
+    # Unknown id must also be a no-op.
+    mgr._release_seq_load("never-seen")
+    assert mgr._rank_reqs == [0, 0]
+    assert mgr._rank_tokens == [0, 0]
+
+
+def test_burst_does_not_dogpile_one_rank():
+    mgr = _make_mgr(4, strategy="least_tokens")
+    # A burst of identical requests dispatched back-to-back (optimistic +1 in
+    # the same locked loop) must spread, not all land on rank 0.
+    _route(mgr, [_FakeSeq(i, num_prompt_tokens=128) for i in range(4)])
+    assert mgr._rank_reqs == [1, 1, 1, 1]
+
+
+def test_round_robin_ignores_load():
+    mgr = _make_mgr(3, strategy="round_robin")
+    # Pre-skew load; round_robin must still rotate purely by cursor.
+    mgr._rank_tokens = [10_000, 0, 0]
+    mgr._rank_reqs = [50, 0, 0]
+    ranks = _route(mgr, [_FakeSeq(i) for i in range(6)])
+    assert ranks == [0, 1, 2, 0, 1, 2]
+
+
+def test_explicit_hint_takes_priority_and_is_charged():
+    mgr = _make_mgr(4, strategy="least_tokens")
+    ranks = _route(
+        mgr,
+        [
+            _FakeSeq("h", num_prompt_tokens=30, data_parallel_rank=2),
+            _FakeSeq("auto", num_prompt_tokens=30),
+        ],
+    )
+    assert ranks[0] == 2
+    # Hinted rank's load is counted so it participates in future balancing.
+    assert mgr._rank_reqs[2] >= 1
+    assert mgr._rank_tokens[2] >= 30
+
+
+def test_invalid_hint_still_supported_via_add_request_validation():
+    # _route mimics add_request; out-of-range hints are validated in
+    # add_request itself, so here we only assert a valid hint routes exactly.
+    mgr = _make_mgr(2, strategy="least_tokens")
+    ranks = _route(mgr, [_FakeSeq("x", data_parallel_rank=1)])
+    assert ranks == [1]
+
+
+def test_reset_dp_router_clears_all_state():
+    mgr = _make_mgr(3, strategy="least_tokens")
+    _route(mgr, [_FakeSeq(i, num_prompt_tokens=40) for i in range(5)])
+    mgr.reset_dp_router()
+    assert mgr._rank_rotation_cursor == 0
+    assert mgr._rank_reqs == [0, 0, 0]
+    assert mgr._rank_tokens == [0, 0, 0]
+    assert mgr._seq_load == {}
+
+
+def test_tie_break_rotates_starting_rank():
+    # All ranks equal load -> successive picks rotate rather than always rank 0.
+    mgr = _make_mgr(3, strategy="least_tokens")
+    ranks = [mgr._select_dp_rank_locked() for _ in range(6)]
+    assert ranks == [0, 1, 2, 0, 1, 2]
+
+
+@pytest.mark.parametrize("strategy", ["round_robin", "least_requests", "least_tokens"])
+def test_all_strategies_route_within_range(strategy):
+    mgr = _make_mgr(4, strategy=strategy)
+    ranks = _route(mgr, [_FakeSeq(i, num_prompt_tokens=i + 1) for i in range(20)])
+    assert all(0 <= r < 4 for r in ranks)
+    # Every dispatched request is accounted for.
+    assert sum(mgr._rank_reqs) == 20
+
+
+def test_resolve_and_validate_hints_rejects_out_of_range_without_side_effects():
+    # An invalid hint anywhere in the batch must raise BEFORE any load is
+    # charged, so a rejected batch cannot leak partial in-flight load.
+    mgr = _make_mgr(4, strategy="least_requests")
+    seqs = [_FakeSeq("ok", 100), _FakeSeq("bad", 100, data_parallel_rank=9)]
+    with pytest.raises(ValueError):
+        mgr._resolve_and_validate_hints(seqs)
+    assert mgr._rank_reqs == [0, 0, 0, 0]
+    assert mgr._rank_tokens == [0, 0, 0, 0]
+    assert mgr._seq_load == {}
+
+
+def test_resolve_and_validate_hints_accepts_and_returns_resolved():
+    mgr = _make_mgr(4, strategy="least_requests")
+    # In-range hint and no-hint (None) are both fine, and the resolved hints are
+    # returned in order for the dispatch loop to reuse.
+    hints = mgr._resolve_and_validate_hints(
+        [_FakeSeq("a", 10, data_parallel_rank=3), _FakeSeq("b", 10)]
+    )
+    assert hints == [3, None]
+
+
+def test_send_failure_rolls_back_undispatched_charge():
+    # If a rank's send_multipart raises mid-batch, the seqs on ranks that were
+    # NOT successfully handed off were charged but will never emit a finished
+    # output to release them. Dispatch must roll those back so routing does not
+    # skew permanently; already-sent ranks keep their (legitimate) charge.
+    # dispatch pickles (EngineCoreRequestType.ADD, seqs) with the real enum.
+    class _FakeSocket:
+        def __init__(self, fail=False):
+            self.fail = fail
+
+        def send_multipart(self, parts, copy=False):
+            if self.fail:
+                raise RuntimeError("send failed")
+
+    mgr = _make_mgr(4, strategy="least_requests")
+    mgr.engine_core_identities = [b"e0", b"e1", b"e2", b"e3"]
+    # Rank 2 fails; ranks 0/1 send first, rank 3 is never attempted.
+    mgr.input_sockets = [
+        _FakeSocket(),
+        _FakeSocket(),
+        _FakeSocket(fail=True),
+        _FakeSocket(),
+    ]
+    seqs = [_FakeSeq(i, num_prompt_tokens=10) for i in range(4)]
+    with pytest.raises(RuntimeError):
+        mgr._dispatch_to_dp_ranks(seqs)
+    # Ranks 0,1 dispatched -> stay charged; ranks 2 (failed) and 3 (never
+    # attempted) -> rolled back to zero.
+    assert mgr._rank_reqs == [1, 1, 0, 0]
+    assert mgr._rank_tokens == [10, 10, 0, 0]
+    assert set(mgr._seq_load.keys()) == {0, 1}
+
+
+def test_reset_clears_even_with_charged_in_flight():
+    # reset must fully clear counters even if requests are still charged (it
+    # warns, but state must not be left dirty or go negative).
+    mgr = _make_mgr(2, strategy="least_requests")
+    _route(mgr, [_FakeSeq(i, num_prompt_tokens=50) for i in range(3)])
+    assert mgr._seq_load  # charged
+    mgr.reset_dp_router()
+    assert mgr._rank_reqs == [0, 0]
+    assert mgr._rank_tokens == [0, 0]
+    assert mgr._seq_load == {}
+
+
+def test_dp_lb_strategies_constant():
+    assert DP_LB_STRATEGIES == ("round_robin", "least_requests", "least_tokens")
+    assert "least_request" not in DP_LB_STRATEGIES  # guards against typos

--- a/tests/test_run_label.py
+++ b/tests/test_run_label.py
@@ -167,5 +167,105 @@ class TestFields:
         assert lbl == "decode[bs=16]"
 
 
+class TestGraphBs:
+    def test_padded_graph_shows_real_over_graph(self):
+        # CUDAGraph replays bs=128 for a real batch of 117 → "bs=117/128".
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=117,
+            graph_bs=128,
+            batch=decode_batch(117, d=117),
+        )
+        assert lbl.startswith("decode[bs=117/128 ")
+
+    def test_matching_graph_bs_omits_slash(self):
+        # No padding (graph bs == real bs) → plain "bs=128".
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=128,
+            graph_bs=128,
+            batch=decode_batch(128, d=128),
+        )
+        assert lbl.startswith("decode[bs=128 ")
+        assert "/" not in lbl
+
+    def test_graph_bs_below_real_bs_omits_slash(self):
+        # Guard is "graph padded ABOVE real" (graph_bs > bs). A graph_bs < bs
+        # never happens in production (the cudagraph path always has
+        # graph_bs >= bs), but if it did we keep the plain real bs rather than
+        # emit a misleading "bs=128/64".
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=128,
+            graph_bs=64,
+            batch=decode_batch(128, d=128),
+        )
+        assert lbl.startswith("decode[bs=128 ")
+        assert "/" not in lbl
+
+    def test_graph_bs_none_is_backward_compatible(self):
+        # Omitting graph_bs keeps the legacy single-number form.
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=64,
+            batch=decode_batch(64, d=64),
+        )
+        assert lbl.startswith("decode[bs=64 ")
+
+    def test_dummy_decode_padded(self):
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=True,
+            tbo_on=False,
+            bs=1,
+            graph_bs=8,
+            batch=decode_batch(1, d=1),
+        )
+        assert lbl.startswith("dummy_decode[bs=1/8 ")
+
+    def test_graph_bs_ignored_on_eager_path(self):
+        # graph_bs only applies to the CUDAGraph path; eager decode ignores it.
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=False,
+            is_dummy=False,
+            tbo_on=False,
+            bs=300,
+            graph_bs=512,
+            batch=decode_batch(300, d=300),
+        )
+        assert lbl.startswith("eager_decode[bs=300 ")
+        assert "/" not in lbl
+
+    def test_parse_trace_regex_extracts_real_bs(self):
+        # tools/parse_trace.py uses re.search(r"bs=(\d+)"), which must still pull
+        # the REAL batch (117), not the graph pad (128), from "bs=117/128".
+        import re
+
+        lbl = build_run_label(
+            is_prefill=False,
+            use_cudagraph=True,
+            is_dummy=False,
+            tbo_on=False,
+            bs=117,
+            graph_bs=128,
+            batch=decode_batch(117, d=117),
+        )
+        assert int(re.search(r"bs=(\d+)", lbl).group(1)) == 117
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Two related changes to the DP path:

1. **Load-aware DP request routing.** `CoreManager` previously dispatched across
   DP ranks with pure round-robin (`_rr_counter % n`), ignoring per-rank load.
   The DP busy loop is **lockstep** (every step all ranks `AllReduce`
   `has_unfinished`; an idle rank runs `_execute_dummy_batch()` while any other
   rank is busy), so uneven distribution wastes GPU on dummy batches. Requests
   now route to the least-loaded rank.
2. **Profiler label** shows the padded CUDAGraph batch as `bs=<real>/<graph>`
   (e.g. `bs=117/128`) so graph padding is visible in traces.

## DP load balancing

Strategy via `--dp-load-balance` (`Config.dp_load_balance`); no effect when
`data_parallel_size == 1`:

| Strategy | Selection |
|----------|-----------|
| `round_robin` | Legacy load-agnostic rotation. |
| `least_requests` **(default)** | Fewest in-flight requests; ties broken by the lighter in-flight prompt-token load, then a rotating cursor. |
| `least_tokens` | Lowest combined load `sum_prompt_tokens + ATOM_DP_LB_REQ_EQUIV * num_reqs`. |

- In-flight load tracked entirely inside `CoreManager` (no engine-core protocol
  change): charged on dispatch, released on finish (STREAM `finished` / offline
  `ADD`) or abort — idempotent under `_lb_lock` (dispatch on the request thread,
  release on the per-rank output threads).
- Explicit `data_parallel_rank` hints validated up front: a bad hint rejects the
  whole batch **before any charge**, so no partial load leaks.
- Send failure rolls back the in-flight load of ranks never handed off.
- `round_robin` skips the bookkeeping entirely.
- One merged INFO line per add (DP>1): per-rank delta + resulting in-flight
  distribution, e.g. `add rank3:1req/8055tok | in-flight reqs=[128,...] prefill_tokens=[...]`.

### Import cleanup (altitude)

`EngineCoreRequestType` moved to a new lightweight `engine_core_protocol.py` so
`CoreManager` (and unit tests) import it **without** the heavy
`engine_core -> async_proc -> aiter` chain; `async_proc` stays a normal top-level
import in `engine_core`, and `EngineCore` is lazy-imported only in
`launch_engine_core`. CPU-only CI imports the enum directly, no `sys.modules` stub.

## Profiler label

`build_run_label` gains an optional `graph_bs`; the CUDAGraph decode path renders
`bs=<real>/<graph>` when `graph_bs > bs`. `tools/parse_trace.py` is unaffected —
`re.search(r"bs=(\d+)")` still extracts the real batch (117) from `117/128`
(regression test added).

## Benchmark (A/B, identical config)

DeepSeek-V4-Pro TBO+DPA tp8, 8k/1k, conc=1024, prompt x4, `GPU_MEM_UTIL=0.85`:

| | Total throughput | Successful |
|---|---|---|
| original (round_robin) | 41065 tok/s | 4096/4096 |
| this PR (least_requests) | 40881 tok/s | 4096/4096 |

Δ −0.45% (within run-to-run noise); in-flight distribution observed at
`reqs=[128 x 8]` — perfectly balanced across 8 DP ranks.

## Test plan

- [x] `tests/test_dp_load_balance.py` (22 tests): spread, tie-breaks,
  release/abort idempotency, burst no-dogpile, hint priority/validation, reset,
  rotation, send-failure rollback.
- [x] `tests/test_run_label.py` (+7 tests): real/graph split, equal/None/dummy,
  eager-ignores-graph_bs, graph<bs guard, parse_trace regex.
- [x] Full unit suite: 612 passed / 5 skipped / 0 failed.
- [x] `black` + `ruff` clean.
- [x] e2e benchmark above (no regression, balanced routing).