### PR TITLE
perf: derive V4 decode compress/write plan caps from graph_bs

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1372,7 +1372,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         compress_plans = self._build_compress_plans(
             extend_lens_np,
             context_lens_np,
-            for_decode_cg=True,
+            graph_bs=bs,
+            max_q_len=max_seqlen_q,
         )
 
         # ---- sync, build attn_metadata, per-fwd meta ----
@@ -1549,7 +1550,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             compress_plans = self._build_compress_plans(
                 extend_lens_np,
                 ctx_for_plan,
-                for_decode_cg=True,
+                graph_bs=padded_bs,
+                max_q_len=max_seqlen_q,
                 buf_prefix_ubatch=p,
             )
 
@@ -1664,7 +1666,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             var["context_lens"].np[:scheduled_bs], dtype=np.int32
         )
         attn_metadata.compress_plans = self._build_compress_plans(
-            extend_lens_np, context_lens_np, for_decode_cg=False
+            extend_lens_np, context_lens_np
         )
         # Prefill goes through eager (no CG): defaults make padded_total_tokens
         # collapse to total_tokens — no padding logic kicks in. Must still run
@@ -1883,14 +1885,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             # Per-ubatch plan buffers — sharing the main pool would let
             # ubatch 1's CPU build overwrite ubatch 0's before ubatch 0
             # launches its compressor kernel. TBO prefill is eager-only,
-            # so `decode_capacity_per_ratio=None` (tight n_compress slice).
+            # so leave graph_bs/max_q_len unset (tight n_compress/n_write).
             ub_plan_buffers = self._get_ubatch_compress_plan_buffers(ubatch_idx)
             ub_attn.compress_plans = make_compress_plans(
                 np.ascontiguousarray(extend_lens_np, dtype=np.int32),
                 np.ascontiguousarray(context_lens_np, dtype=np.int32),
                 self._unique_compress_ratios_overlap,
                 plan_buffers=ub_plan_buffers,
-                decode_capacity_per_ratio=None,
             )
         else:
             ub_attn.compress_plans = {}
@@ -2601,7 +2602,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         extend_lens_np,
         context_lens_np,
         *,
-        for_decode_cg: bool,
+        graph_bs: int | None = None,
+        max_q_len: int | None = None,
         buf_prefix_ubatch: str = "",
     ):
         """Build per-ratio CompressPlan dict consumed by batched compressor.
@@ -2616,10 +2618,12 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         (fixed pointers for CUDAGraph capture); the kernels skip
         sentinel-marked tail rows.
 
-        `for_decode_cg`: True for decode runtime AND decode CG capture —
-        the returned plan_gpu is sliced to a fixed `_decode_compress_cap`
-        per ratio so capture/replay shapes match. False for eager prefill —
-        the plan_gpu is sliced to the actual `n_compress` (smallest grid).
+        `graph_bs` / `max_q_len`: set BOTH for decode runtime AND decode CG
+        capture — the returned compress/write plan_gpu are sliced to fixed
+        `graph_bs * per_seq_bound` capacities (per ratio) so capture/replay
+        shapes match, with `[bs, graph_bs)` padding rows sentinel-filled.
+        Leave both None for eager prefill — the plan_gpu are sliced to the
+        actual `n_compress` / `n_write` (smallest grid, no padding).
         """
         from atom.model_ops.v4_kernels import make_compress_plans
 
@@ -2648,9 +2652,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             context_lens_np,
             self._unique_compress_ratios_overlap,
             plan_buffers=plan_buffers,
-            decode_capacity_per_ratio=(
-                self._decode_compress_cap if for_decode_cg else None
-            ),
+            graph_bs=graph_bs,
+            max_q_len=max_q_len,
         )
 
     def _populate_block_tables(
@@ -2738,12 +2741,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         grid=(bs, write_per_batch) with bs baked at capture and write_per_batch a
         `constexpr`; rows past each seq's actual token count sentinel-skip.
         `update_compressor_states` launches grid=(write_plan.shape[0],) — the
-        plan-buffer capacity fixed at builder init, NOT the per-fwd num_write —
-        and inactive rows carry `position=-1` and bail (see state_writes.py). So
-        model.forward inside torch.cuda.graph does NOT hit a variable-grid launch
-        here. (`fused_compress_attn` is likewise CG-safe: launches at the
-        decode-tight slice `_decode_compress_cap[ratio]` baked at capture and
-        sentinel-skips inactive rows for both BF16 Main and FP8 Indexer paths.)
+        decode-tight slice `graph_bs * min(qlen, K_pool)` baked at capture, NOT
+        the per-fwd num_write — and inactive rows carry `position=-1` and bail
+        (see state_writes.py). So model.forward inside torch.cuda.graph does NOT
+        hit a variable-grid launch here. (`fused_compress_attn` is likewise
+        CG-safe: launches at the decode-tight compress slice `graph_bs *
+        ceil(qlen/ratio)` baked at capture and sentinel-skips inactive rows for
+        both BF16 Main and FP8 Indexer paths.)
         """
         var = self.model_runner.forward_vars
         # Honor MTP at capture time: V4-Pro `mtp_k=1` → 2 tokens/req. The
@@ -2811,7 +2815,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # helpers used at runtime — guarantees addresses match.
         extend_lens_np = np.full(bs, max_q_len, dtype=np.int32)
         attn_metadata.compress_plans = self._build_compress_plans(
-            extend_lens_np, context_lens_np, for_decode_cg=True
+            extend_lens_np, context_lens_np, graph_bs=bs, max_q_len=max_q_len
         )
         # Capture: padded_bs == scheduled_bs == bs (synthetic batch is full).
         # Must run BEFORE `_attach_v4_indexer_meta` so the indexer-side meta
@@ -2970,16 +2974,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # The decode CG path uses a much tighter capacity than the prefill
         # worst case — the kernel grid is dictated by the slice of this
         # buffer that we hand to the kernel, and decode only ever needs
-        # `bs * ceil((1 + max_spec_steps) / ratio)` rows (vs `mnbt // ratio
-        # + bs` for prefill, which is ~13× larger at typical config). We
+        # `graph_bs * ceil((1 + max_spec_steps) / ratio)` compress rows (vs
+        # `mnbt // ratio + bs` for prefill, ~13× larger at typical config). We
         # still allocate the full prefill capacity (eager prefill needs it),
-        # but both decode capture and replay slice down to
-        # `_decode_compress_cap` so the captured grid is the decode-tight
-        # bound. capture and replay MUST use the same value (CG kernel call
-        # args are baked).
-        self._decode_compress_cap: dict[int, int] = {}
+        # but decode capture/replay slice down via `make_compress_plans(
+        # graph_bs=, max_q_len=)`, which computes the per-graph-tight caps
+        # `graph_bs * per_seq_bound` internally (see compress_plan.py).
         for ratio, is_overlap in self._unique_compress_ratios_overlap:
-            # NOTE: this is the pool-window size (algorithm constant), NOT the
+            # NOTE: K_pool is the pool-window size (algorithm constant), NOT the
             # state ring buffer size. The ring buffer is K_pool + max_spec_steps
             # (see csa_main_state_shape comment for the slot-aliasing argument),
             # but write_plan still emits ≤ K_pool rows per seq per fwd because
@@ -2995,20 +2997,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             bufs[f"v4_compress_plan_{ratio}"].copy_to_gpu()
             bufs[f"v4_write_plan_{ratio}"].cpu.fill_(-1)
             bufs[f"v4_write_plan_{ratio}"].copy_to_gpu()
-            # Decode-tight bound: each seq's qlen-token window contains at
-            # most ceil(qlen / ratio) ratio-aligned boundaries (qlen =
-            # 1 + max_spec_steps), so total ≤ bs * ceil(qlen / ratio).
-            # The integer expression `(max_spec_steps + ratio) // ratio`
-            # is ceil((1 + max_spec_steps) / ratio).
-            #
-            # Tighter than the old `max_decode_tokens // ratio + max_bs`:
-            #   CSA r=4 MTP3 bs=256:  256 vs 512 (2× smaller)
-            #   HCA r=128 MTP3 bs=256: 256 vs 264 (8 smaller)
-            #
-            # Smaller plan slice → fewer sentinel rows the kernel skips →
-            # smaller grid → less launch + scheduling overhead.
-            per_seq_max = (self.max_spec_steps + ratio) // ratio
-            self._decode_compress_cap[ratio] = bs * per_seq_max
 
         if getattr(self.model_runner.config, "enable_tbo_decode", False):
             self._alloc_v4_ubatch_decode_buffers(bufs, i32, i64)

--- a/atom/model_ops/v4_kernels/compress_plan.py
+++ b/atom/model_ops/v4_kernels/compress_plan.py
@@ -18,11 +18,16 @@ Each plan slot is a 16-byte struct of 4 int32 fields:
 Two plan tensors are produced per `compress_ratio`:
   - compress_plan: rows for tokens whose `(position+1) % ratio == 0`
                    (= compression boundaries). One row per fused-compress kernel
-                   program. Grid = `num_compress`.
+                   program.
   - write_plan:    rows for tokens whose `position` falls in the per-seq
                    "last K_pool positions" window (the only entries the
                    downstream compressor forward will actually read). One row
-                   per `update_compressor_states` kernel program. Grid = `num_write`.
+                   per `update_compressor_states` kernel program.
+
+Each plan is sliced to a kernel-grid length that depends on the mode: tight
+`num_compress` / `num_write` for eager, or a fixed `graph_bs * per_seq_bound`
+for the decode CUDAGraph path (padding rows sentinel-filled). See
+`make_compress_plans` for the exact per-mode capacities.
 
 Caller (per-seq loop) gets `cu_compress_cpu` for slicing the kernel's flat
 output `[num_compress, head_dim]` back to per-seq chunks.
@@ -65,6 +70,8 @@ def make_compress_plans(
     unique_ratios_overlap: Iterable[Tuple[int, bool]],
     *,
     plan_buffers: dict,
+    graph_bs: int | None = None,
+    max_q_len: int | None = None,
     decode_capacity_per_ratio: dict[int, int] | None = None,
 ) -> dict[int, CompressPlan]:
     """Build a CompressPlan per (ratio, overlap) variant.
@@ -86,19 +93,38 @@ def make_compress_plans(
                     calls (CUDAGraph requirement). Fresh per-call alloc is
                     not supported — that pattern caused allocator-churn
                     races (see `write_v4_paged_decode_indices` docstring).
-      decode_capacity_per_ratio: optional dict[ratio] -> int. Slice length
-                    for the returned `compress_plan_gpu`. When PROVIDED:
-                    the slice is exactly that fixed value (independent of
-                    `n_compress`) — required by the decode CUDAGraph path
-                    so capture and replay produce kernel calls with
-                    identical tensor shapes. Caller must size this to the
-                    decode worst case (`bs * ceil((1 + max_spec_steps) /
-                    ratio)`).
-                    When NONE: the slice is exactly `n_compress` (tight,
-                    eager-only) — gives the smallest possible kernel grid.
-                    The slice is contiguous-from-base so the data pointer
-                    is stable; only `shape[0]` shrinks. The underlying
-                    buffer is always sized to the prefill worst case.
+      graph_bs: optional int — the CUDAGraph-padded batch size (>= bs). When
+                    PROVIDED this selects the DECODE CUDAGraph path: both
+                    `compress_plan_gpu` and `write_plan_gpu` are sliced to a
+                    FIXED, content-independent capacity `graph_bs *
+                    per_seq_bound` (compress bound = `ceil(max_q_len / ratio)`;
+                    write bound = `min(max_q_len, K_pool)`), and rows
+                    `[n_actual, cap)` are sentinel-filled. The cap depends only
+                    on `graph_bs` and `max_q_len` (both fixed at capture), so
+                    capture and replay dispatch identically-shaped kernels; the
+                    `[bs, graph_bs)` padding seqs land in the sentinel region.
+                    `max_q_len` is required when `graph_bs` is set. Because the
+                    decode write count is EXACTLY `bs * min(qlen, K_pool)`
+                    (content-independent), no separate write-capacity dict is
+                    needed — the write cap is derived from `graph_bs`/`max_q_len`
+                    identically to compress.
+      max_q_len: optional int — uniform per-seq query length of the padded
+                    decode batch (`1 + max_spec_steps`). Required iff `graph_bs`
+                    is set; used to compute the per-seq compress/write bounds.
+      decode_capacity_per_ratio: optional dict[ratio] -> int — explicit FIXED
+                    COMPRESS slice length, for CUDAGraph paths whose per-fwd
+                    token count is not the uniform `graph_bs * max_q_len` shape
+                    (the extend-shaped target-verify graph, whose buffers are
+                    sized to a dynamic token count). Mutually exclusive with
+                    `graph_bs`. The write plan then keeps the full-buffer legacy
+                    slice (fixed = buffer capacity, sentinel-filled) since that
+                    path's write grid is bounded by its buffer sizing.
+                    When BOTH this and `graph_bs` are None (eager prefill /
+                    eager plugin bridges): compress slice = `n_compress` (tight)
+                    and write slice = full buffer (legacy). Slices are
+                    contiguous-from-base so data pointers stay stable; only
+                    `shape[0]` shrinks. Buffers are always sized to the prefill
+                    worst case.
 
     Returns:
       dict[ratio] -> CompressPlan. On empty fwd (`extend_lens_cpu.sum() == 0`)
@@ -111,29 +137,59 @@ def make_compress_plans(
     context_lens_cpu = np.ascontiguousarray(context_lens_cpu, dtype=np.int32)
     total = int(extend_lens_cpu.sum())
     out: dict[int, CompressPlan] = {}
+    if graph_bs is not None:
+        assert max_q_len is not None, "max_q_len is required when graph_bs is set"
+        assert (
+            decode_capacity_per_ratio is None
+        ), "graph_bs and decode_capacity_per_ratio are mutually exclusive"
+
+    def _slices(
+        ratio: int,
+        is_overlap: bool,
+        n_compress: int,
+        n_write: int,
+        full_wcap: int,
+    ) -> tuple[int, int]:
+        """(compress_slice, write_slice) — the fixed-or-tight kernel-grid lengths
+        for this ratio. Three modes:
+          * graph_bs set (uniform decode CG): both = `graph_bs * per_seq_bound`
+            (compress ceil(qlen/ratio); write min(qlen,K_pool)) — content-
+            independent, so capture/replay dispatch identical shapes and the
+            `[n_actual, cap)` region is exactly the `[bs, graph_bs)` padding.
+          * decode_capacity_per_ratio set (extend-shaped verify CG): compress =
+            explicit cap; write = full buffer (fixed by buffer sizing).
+          * neither (eager): compress = n_compress (tight); write = full buffer.
+        """
+        if graph_bs is not None:
+            k_pool = (2 if is_overlap else 1) * ratio
+            return (
+                graph_bs * ((max_q_len + ratio - 1) // ratio),  # ceil(qlen/ratio)
+                graph_bs * min(max_q_len, k_pool),
+            )
+        if decode_capacity_per_ratio is not None:
+            return decode_capacity_per_ratio[ratio], full_wcap
+        return n_compress, full_wcap
+
     if total == 0 or bs == 0:
         # Empty fwd: produce CompressPlans pointing at the pre-allocated
         # buffers so capture-time addresses match replay-time addresses
         # even on a zero-token fwd. Skipped via num_*=0.
-        #
-        # CG path (decode_capacity_per_ratio provided): slice = fixed cap.
-        # Eager path (None): slice = 0 — kernel grid is empty, no work
-        # dispatched, no sentinel fill required.
-        for ratio, _ in unique_ratios_overlap:
+        for ratio, is_overlap in unique_ratios_overlap:
             cbuf = plan_buffers[ratio]["compress"]
             wbuf = plan_buffers[ratio]["write"]
-            cap = (
-                decode_capacity_per_ratio.get(ratio)
-                if decode_capacity_per_ratio is not None
-                else 0
+            ccap, wcap = _slices(ratio, is_overlap, 0, 0, wbuf.np.shape[0])
+            assert ccap <= cbuf.np.shape[0] and wcap <= wbuf.np.shape[0], (
+                f"ratio={ratio} empty-fwd caps (compress={ccap}, write={wcap}) "
+                f"exceed buffers ({cbuf.np.shape[0]}, {wbuf.np.shape[0]}); "
+                f"bump plan-buffer sizing in the builder __init__."
             )
-            if cap > 0:
-                cbuf.np[:cap].fill(-1)
-            compress_plan_gpu = cbuf.copy_to_gpu(cap if cap > 0 else 0)
-            wbuf.np[:].fill(-1)
+            if ccap > 0:
+                cbuf.np[:ccap].fill(-1)
+            if wcap > 0:
+                wbuf.np[:wcap].fill(-1)
             out[ratio] = CompressPlan(
-                compress_plan_gpu=compress_plan_gpu,
-                write_plan_gpu=wbuf.copy_to_gpu(),
+                compress_plan_gpu=cbuf.copy_to_gpu(ccap),
+                write_plan_gpu=wbuf.copy_to_gpu(wcap),
                 num_compress=0,
                 num_write=0,
                 cu_compress_cpu=np.zeros(max(bs, 1) + 1, dtype=np.int32),
@@ -190,35 +246,35 @@ def make_compress_plans(
 
         cbuf = plan_buffers[ratio]["compress"]
         wbuf = plan_buffers[ratio]["write"]
-        full_cap = cbuf.np.shape[0]
-        # CG path: fixed slice (capture / replay must match). Eager
-        # path: slice = n_compress (smallest possible kernel grid).
-        cap = (
-            decode_capacity_per_ratio.get(ratio)
-            if decode_capacity_per_ratio is not None
-            else None
+        full_ccap = cbuf.np.shape[0]
+        full_wcap = wbuf.np.shape[0]
+        compress_slice, write_slice = _slices(
+            ratio, is_overlap, n_compress, n_write, full_wcap
         )
-        slice_cap = n_compress if cap is None else cap
-        assert n_compress <= slice_cap <= full_cap, (
-            f"ratio={ratio} num_compress={n_compress}, slice={slice_cap}, "
-            f"buffer={full_cap}: invariant violated. CG path requires "
-            f"n_compress ≤ decode_cap; eager path uses n_compress as slice."
+        assert n_compress <= compress_slice <= full_ccap, (
+            f"ratio={ratio} num_compress={n_compress}, slice={compress_slice}, "
+            f"buffer={full_ccap}: invariant violated. CG path requires "
+            f"n_compress ≤ graph_bs·ceil(qlen/ratio) / decode_cap; eager uses "
+            f"n_compress."
         )
-        assert n_write <= wbuf.np.shape[0], (
-            f"ratio={ratio} num_write={n_write} exceeds buffer "
-            f"capacity {wbuf.np.shape[0]}; bump in builder __init__."
+        assert n_write <= write_slice <= full_wcap, (
+            f"ratio={ratio} num_write={n_write}, slice={write_slice}, "
+            f"buffer={full_wcap}: invariant violated. CG path requires "
+            f"n_write ≤ graph_bs·min(qlen,K_pool); else uses full buffer."
         )
         if n_compress > 0:
             cbuf.np[:n_compress] = compress_plan
-        # Sentinel only within the slice we hand to the kernel; rows
-        # beyond `slice_cap` are unreachable from this launch.
-        if slice_cap > n_compress:
-            cbuf.np[n_compress:slice_cap].fill(-1)
+        # Sentinel only within the slice we hand to the kernel; rows beyond
+        # the slice are unreachable from this launch. For the CG path the
+        # `[n_*, cap)` region is exactly the `[bs, graph_bs)` padding seqs.
+        if compress_slice > n_compress:
+            cbuf.np[n_compress:compress_slice].fill(-1)
         if n_write > 0:
             wbuf.np[:n_write] = write_plan
-        wbuf.np[n_write:].fill(-1)  # sentinel
-        compress_plan_gpu = cbuf.copy_to_gpu(slice_cap)
-        write_plan_gpu = wbuf.copy_to_gpu()
+        if write_slice > n_write:
+            wbuf.np[n_write:write_slice].fill(-1)  # sentinel
+        compress_plan_gpu = cbuf.copy_to_gpu(compress_slice)
+        write_plan_gpu = wbuf.copy_to_gpu(write_slice)
 
         out[ratio] = CompressPlan(
             compress_plan_gpu=compress_plan_gpu,

--- a/atom/model_ops/v4_kernels/fused_compress.py
+++ b/atom/model_ops/v4_kernels/fused_compress.py
@@ -10,7 +10,7 @@ SGLang plan-style batched dispatch (vs. the earlier per-seq launcher):
   Each compression boundary across the entire fwd is one row in
   `compress_plan_gpu` — a packed `[num_compress, 4] int32` tensor where each
   row is `[ragged_id, batch_id, position, window_len]`. The kernel grid is
-  the caller-supplied slice length (decode CG: `_decode_compress_cap[ratio]`
+  the caller-supplied slice length (decode CG: `graph_bs * ceil(qlen/ratio)`
   / eager prefill: `n_compress`); inactive plan rows are sentinel-marked
   (`position == -1`) and bail at the top of the kernel. Each program does
   ONE 4×i32 load to get all the metadata it needs:
@@ -143,7 +143,7 @@ def _fused_compress_attn_kernel(
     FP8_MAX: tl.constexpr = 1.0,
 ):
     """One program per boundary in the plan. Grid = caller-supplied slice
-    length (decode CG: `_decode_compress_cap[ratio]` for capture/replay
+    length (decode CG: `graph_bs * ceil(qlen/ratio)` for capture/replay
     address stability; eager prefill: tight `n_compress`). Inactive rows
     are sentinel-marked (position == -1) and bail before any load /
     store / scatter."""

--- a/atom/model_ops/v4_kernels/state_writes.py
+++ b/atom/model_ops/v4_kernels/state_writes.py
@@ -429,7 +429,6 @@ def update_compressor_states(
     score_state: torch.Tensor,
     *,
     write_plan: torch.Tensor,  # [num_write, 4] int32
-    num_write: int,
     state_slot_mapping: torch.Tensor,  # [bs] int32 — per-seq state slot
     ratio: int,
     overlap: bool,
@@ -456,10 +455,13 @@ def update_compressor_states(
       kv_state:     [num_slots, S, dim] in-place ring buffer. S ≥ K_pool;
                     V4-Pro: S = K_pool + max_spec_steps.
       score_state:  same shape as kv_state.
-      write_plan:   [num_write, 4] int32 — packed (ragged_id, batch_id,
-                    position, _); each row = one token to write.
-      num_write:    grid size (CPU scalar, == write_plan.shape[0] but kept
-                    explicit to avoid GPU sync).
+      write_plan:   [grid, 4] int32 — packed (ragged_id, batch_id, position, _);
+                    each active row = one token to write. `grid` (== shape[0])
+                    is the caller-supplied slice length: the decode-tight
+                    `graph_bs * min(qlen, K_pool)` on the CUDAGraph path, tight
+                    `num_write` on the eager path, or the full buffer capacity
+                    for the extend-shaped verify path. Inactive tail rows carry
+                    sentinel `position=-1` and are skipped.
       state_slot_mapping: [bs] int32 — per-seq state cache slot.
       ratio, overlap: compress geometry.
     """
@@ -475,11 +477,10 @@ def update_compressor_states(
     assert write_plan.dim() == 2 and write_plan.shape[1] == 4
     assert write_plan.dtype == torch.int32
     assert state_slot_mapping.dim() == 1 and state_slot_mapping.dtype == torch.int32
-    # Grid = plan buffer capacity (fixed at builder __init__ time), NOT the
-    # per-fwd `num_write`. Inactive rows past `num_write` carry sentinel
-    # `position=-1` (filled host-side in `make_compress_plans`); the kernel
-    # bails on those, so this is functionally identical to the variable-grid
-    # version while keeping the launch CUDAGraph-capturable.
+    # Grid = the write-plan slice length (fixed at capture on the CUDAGraph
+    # path). Inactive tail rows carry sentinel `position=-1` (filled host-side
+    # in `make_compress_plans`); the kernel bails on those, so a padded slice is
+    # functionally identical to a tight one while staying CUDAGraph-capturable.
     grid_size = write_plan.shape[0]
     if grid_size == 0:
         return

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1159,7 +1159,6 @@ class Compressor(nn.Module):
             self.kv_state,
             self.score_state,
             write_plan=plan.write_plan_gpu,
-            num_write=plan.num_write,
             state_slot_mapping=state_slot_mapping,
             ratio=ratio,
             overlap=overlap,

--- a/atom/plugin/sglang/deepseek_v4_bridge.py
+++ b/atom/plugin/sglang/deepseek_v4_bridge.py
@@ -692,8 +692,9 @@ def _make_compress_plans(extend_lens_cpu, context_lens_cpu, device):
         np.ascontiguousarray(context_lens_cpu, dtype=np.int32),
         [(4, True), (128, False)],
         plan_buffers=plan_buffers,
-        decode_capacity_per_ratio=None,
     )
+    # Eager path (graph_bs unset): full-buffer write slice; the eager bridge
+    # launches update_compressor_states with exactly num_write rows.
     for plan in plans.values():
         plan.write_plan_gpu = plan.write_plan_gpu[: plan.num_write]
     return plans
@@ -755,17 +756,25 @@ class _V4SGLangDecodeGraphBuffers:
         self.idx_csa = i32(t * max(1, win + topk))
         self.idx_hca = i32(t * max(1, win + hca))
 
+        # Decode CG plan slicing is `graph_bs * per_seq_bound` (computed inside
+        # make_compress_plans). graph_bs == num_slots (padded decode batch);
+        # max_q_len == 1 + max_spec_steps (== max_decode_tokens // num_slots).
+        self.decode_graph_bs = s
+        self.decode_q_len = max(1, t // s)
+        # Compress buffer sized to the graph_bs compress cap `s*ceil(qlen/ratio)`
+        # (matches make_compress_plans' slice); write buffer to `s*K_pool`. Sizing
+        # flat `s` would undersize the compress plan once ceil(qlen/ratio)>1 (mtp_k
+        # >= 4). Mirrors the vllm bridge's `S*per_seq` sizing.
         self.plan_buffers = {
             4: {
-                "compress": i32(max(1, s), 4),
+                "compress": i32(max(1, s * ((self.decode_q_len + 3) // 4)), 4),
                 "write": i32(max(1, s * 8), 4),
             },
             128: {
-                "compress": i32(max(1, s), 4),
+                "compress": i32(max(1, s * ((self.decode_q_len + 127) // 128)), 4),
                 "write": i32(max(1, s * 128), 4),
             },
         }
-        self.decode_compress_cap = {4: max(1, s), 128: max(1, s)}
 
     def stage(self, buf, arr_np, n: Optional[int] = None):
         n = int(arr_np.shape[0]) if n is None else int(n)
@@ -872,7 +881,8 @@ def _make_decode_graph_compress_plans(extend_lens_cpu, context_lens_cpu, bufs):
         np.ascontiguousarray(context_lens_cpu, dtype=np.int32),
         [(4, True), (128, False)],
         plan_buffers=bufs.plan_buffers,
-        decode_capacity_per_ratio=bufs.decode_compress_cap,
+        graph_bs=bufs.decode_graph_bs,
+        max_q_len=bufs.decode_q_len,
     )
 
 

--- a/atom/plugin/vllm/deepseek_v4_bridge.py
+++ b/atom/plugin/vllm/deepseek_v4_bridge.py
@@ -606,18 +606,20 @@ class _V4DecodeMetaBuffers:
             make_compress_plans as _mcp,
         )
 
+        # Decode CG plan slicing is `graph_bs * per_seq_bound` (computed inside
+        # make_compress_plans from these two scalars). graph_bs == num_slots
+        # (padded decode batch); max_q_len == 1 + max_spec_steps.
+        self.decode_graph_bs = S
+        self.decode_q_len = max(1, T // S)
         self.plan_buffers: dict[int, dict] = {}
-        self.decode_compress_cap: dict[int, int] = {}
-        spec_plus_one = max(1, T // S)
         for ratio, is_overlap in ratios_overlap:
             ratio = int(ratio)
-            per_seq = (spec_plus_one + ratio - 1) // ratio
+            per_seq = (self.decode_q_len + ratio - 1) // ratio
             cap = max(1, S * per_seq)
             self.plan_buffers[ratio] = {
                 "compress": i32(cap, 4),
                 "write": i32(max(1, T), 4),
             }
-            self.decode_compress_cap[ratio] = cap
 
     def stage(self, buf, arr_np):
         """Copy ``arr_np`` into the head of CpuGpuBuffer ``buf`` and return the
@@ -884,12 +886,11 @@ def _make_compress_plans(
         context_lens_cpu,
         ratios,
         plan_buffers=plan_buffers,
-        decode_capacity_per_ratio=None,
     )
-    # Preserve the bridge eager path's old variable-grid behavior. Native
-    # make_compress_plans returns a sentinel-padded write buffer, while the
-    # previous bridge helper launched update_compressor_states with exactly
-    # num_write rows. Graph decode uses _make_decode_compress_plans instead.
+    # Eager path (graph_bs unset): make_compress_plans returns a full-buffer
+    # write slice (sentinel-padded). The eager bridge launches
+    # update_compressor_states with exactly num_write rows, so re-slice down.
+    # Graph decode uses _make_decode_compress_plans (fixed graph_bs slice).
     for plan in plans.values():
         plan.write_plan_gpu = plan.write_plan_gpu[: plan.num_write]
     return plans
@@ -1302,7 +1303,8 @@ def _make_decode_compress_plans(extend_lens_cpu, context_lens_cpu, bufs):
         np.ascontiguousarray(context_lens_cpu, dtype=np.int32),
         ratios_overlap,
         plan_buffers=bufs.plan_buffers,
-        decode_capacity_per_ratio=bufs.decode_compress_cap,
+        graph_bs=bufs.decode_graph_bs,
+        max_q_len=bufs.decode_q_len,
     )
 
 

--- a/tests/test_compress_plan.py
+++ b/tests/test_compress_plan.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""CPU unit tests for `make_compress_plans` write/compress slice capacities.
+
+Covers the three slicing modes (eager / decode-CUDAGraph / extend-shaped verify)
+and the CUDAGraph invariance that lets the decode write grid shrink to
+`graph_bs * min(qlen, K_pool)` while keeping `[bs, graph_bs)` padding rows
+sentinel-filled. No GPU required — a fake CpuGpuBuffer backs the plan tensors.
+"""
+
+import importlib.util
+import pathlib
+
+import numpy as np
+import pytest
+import torch
+
+# Load compress_plan.py directly by path: it has no atom imports (numpy+torch
+# only), so this avoids triggering `atom.model_ops.__init__`, whose heavy
+# import chain needs a full atom.config that the CPU test env stubs out.
+_CP_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "atom/model_ops/v4_kernels/compress_plan.py"
+)
+_spec = importlib.util.spec_from_file_location("_compress_plan_under_test", _CP_PATH)
+_cp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_cp)
+make_compress_plans = _cp.make_compress_plans
+
+# V4-Pro layer geometry: (ratio, is_overlap). CSA r=4 overlap (K_pool=8),
+# HCA r=128 non-overlap (K_pool=128).
+RATIOS_OVERLAP = [(4, True), (128, False)]
+POSITION_COL = 2  # write/compress plan row = [ragged_id, batch_id, position, wlen]
+
+
+def _k_pool(ratio, is_overlap):
+    return (2 if is_overlap else 1) * ratio
+
+
+class _FakeBuf:
+    """Minimal CpuGpuBuffer stand-in: numpy-backed, `copy_to_gpu(n)` returns a
+    from-base torch view (shares memory, so host writes are visible)."""
+
+    def __init__(self, rows):
+        # Pre-fill with a non-sentinel sentinel so we can prove the -1 fill ran.
+        self.np = np.full((rows, 4), 7, dtype=np.int32)
+        self._t = torch.from_numpy(self.np)
+
+    def copy_to_gpu(self, n=None):
+        return self._t if n is None else self._t[:n]
+
+
+def _buffers(compress_rows=256, write_rows=256):
+    return {
+        ratio: {"compress": _FakeBuf(compress_rows), "write": _FakeBuf(write_rows)}
+        for ratio, _ in RATIOS_OVERLAP
+    }
+
+
+def _uniform_decode(bs, qlen, ctx=100):
+    extend = np.full(bs, qlen, dtype=np.int32)
+    context = np.full(bs, ctx, dtype=np.int32)
+    return extend, context
+
+
+# ── eager path (graph_bs=None) ────────────────────────────────────────────
+
+
+def test_eager_compress_tight_write_full_buffer():
+    extend, context = _uniform_decode(bs=5, qlen=4)
+    bufs = _buffers(write_rows=200)
+    plans = make_compress_plans(extend, context, RATIOS_OVERLAP, plan_buffers=bufs)
+    for ratio, _ in RATIOS_OVERLAP:
+        p = plans[ratio]
+        # compress slice is tight; write slice is the full buffer (legacy).
+        assert p.compress_plan_gpu.shape[0] == p.num_compress
+        assert p.write_plan_gpu.shape[0] == 200
+
+
+# ── decode CUDAGraph path (graph_bs set) ──────────────────────────────────
+
+
+def test_decode_cg_slice_equals_graph_bs_times_bound():
+    graph_bs, qlen = 8, 4
+    extend, context = _uniform_decode(bs=5, qlen=qlen)
+    bufs = _buffers()
+    plans = make_compress_plans(
+        extend,
+        context,
+        RATIOS_OVERLAP,
+        plan_buffers=bufs,
+        graph_bs=graph_bs,
+        max_q_len=qlen,
+    )
+    for ratio, is_overlap in RATIOS_OVERLAP:
+        p = plans[ratio]
+        exp_ccap = graph_bs * ((qlen + ratio - 1) // ratio)
+        exp_wcap = graph_bs * min(qlen, _k_pool(ratio, is_overlap))
+        assert p.compress_plan_gpu.shape[0] == exp_ccap
+        assert p.write_plan_gpu.shape[0] == exp_wcap
+
+
+def test_decode_write_count_is_bs_times_bound():
+    # For decode (qlen <= K_pool) every query token lands in the ring window,
+    # so num_write is EXACTLY bs * min(qlen, K_pool) — content-independent.
+    graph_bs, qlen, bs = 8, 4, 5
+    extend, context = _uniform_decode(bs=bs, qlen=qlen)
+    plans = make_compress_plans(
+        extend,
+        context,
+        RATIOS_OVERLAP,
+        plan_buffers=_buffers(),
+        graph_bs=graph_bs,
+        max_q_len=qlen,
+    )
+    for ratio, is_overlap in RATIOS_OVERLAP:
+        assert plans[ratio].num_write == bs * min(qlen, _k_pool(ratio, is_overlap))
+
+
+def test_decode_padding_region_is_sentinel():
+    # The [n_write, cap) tail == the [bs, graph_bs) padding seqs → all sentinel.
+    graph_bs, qlen, bs = 8, 4, 5
+    extend, context = _uniform_decode(bs=bs, qlen=qlen)
+    plans = make_compress_plans(
+        extend,
+        context,
+        RATIOS_OVERLAP,
+        plan_buffers=_buffers(),
+        graph_bs=graph_bs,
+        max_q_len=qlen,
+    )
+    for ratio, _ in RATIOS_OVERLAP:
+        p = plans[ratio]
+        active = p.write_plan_gpu[: p.num_write, POSITION_COL]
+        padding = p.write_plan_gpu[p.num_write :, POSITION_COL]
+        assert (active >= 0).all(), "active write rows must carry real positions"
+        assert (padding == -1).all(), "padding rows must be sentinel (position=-1)"
+
+
+def test_decode_cg_invariant_across_real_bs():
+    # Same (graph_bs, qlen), different real bs → identical slice shapes. This is
+    # the CUDAGraph capture/replay invariant: capture runs at bs==graph_bs,
+    # replay at bs<graph_bs, both must dispatch the same-shaped kernel.
+    graph_bs, qlen = 16, 2
+    shapes = {}
+    for bs in (graph_bs, 1, 7):
+        extend, context = _uniform_decode(bs=bs, qlen=qlen)
+        plans = make_compress_plans(
+            extend,
+            context,
+            RATIOS_OVERLAP,
+            plan_buffers=_buffers(),
+            graph_bs=graph_bs,
+            max_q_len=qlen,
+        )
+        shapes[bs] = {
+            r: (plans[r].compress_plan_gpu.shape[0], plans[r].write_plan_gpu.shape[0])
+            for r, _ in RATIOS_OVERLAP
+        }
+    assert shapes[graph_bs] == shapes[1] == shapes[7]
+
+
+# ── empty fwd ─────────────────────────────────────────────────────────────
+
+
+def test_empty_fwd_decode_cg_matches_caps_all_sentinel():
+    graph_bs, qlen = 8, 4
+    extend = np.zeros(graph_bs, dtype=np.int32)
+    context = np.zeros(graph_bs, dtype=np.int32)
+    plans = make_compress_plans(
+        extend,
+        context,
+        RATIOS_OVERLAP,
+        plan_buffers=_buffers(),
+        graph_bs=graph_bs,
+        max_q_len=qlen,
+    )
+    for ratio, is_overlap in RATIOS_OVERLAP:
+        p = plans[ratio]
+        assert p.num_write == 0 and p.num_compress == 0
+        assert p.write_plan_gpu.shape[0] == graph_bs * min(
+            qlen, _k_pool(ratio, is_overlap)
+        )
+        assert (p.write_plan_gpu[:, POSITION_COL] == -1).all()
+
+
+def test_empty_fwd_eager_compress_zero_write_full():
+    extend = np.zeros(4, dtype=np.int32)
+    context = np.zeros(4, dtype=np.int32)
+    bufs = _buffers(write_rows=50)
+    plans = make_compress_plans(extend, context, RATIOS_OVERLAP, plan_buffers=bufs)
+    for ratio, _ in RATIOS_OVERLAP:
+        assert plans[ratio].compress_plan_gpu.shape[0] == 0
+        assert plans[ratio].write_plan_gpu.shape[0] == 50
+
+
+# ── extend-shaped verify path (explicit compress cap) ─────────────────────
+
+
+def test_verify_explicit_compress_cap_write_full_buffer():
+    extend, context = _uniform_decode(bs=3, qlen=2)
+    bufs = _buffers(compress_rows=64, write_rows=64)
+    cap = {4: 40, 128: 40}
+    plans = make_compress_plans(
+        extend,
+        context,
+        RATIOS_OVERLAP,
+        plan_buffers=bufs,
+        decode_capacity_per_ratio=cap,
+    )
+    for ratio, _ in RATIOS_OVERLAP:
+        p = plans[ratio]
+        assert p.compress_plan_gpu.shape[0] == cap[ratio]  # explicit fixed cap
+        assert p.write_plan_gpu.shape[0] == 64  # full buffer (legacy)
+
+
+def test_graph_bs_and_decode_cap_mutually_exclusive():
+    extend, context = _uniform_decode(bs=2, qlen=2)
+    with pytest.raises(AssertionError):
+        make_compress_plans(
+            extend,
+            context,
+            RATIOS_OVERLAP,
+            plan_buffers=_buffers(),
+            graph_bs=4,
+            max_q_len=2,
+            decode_capacity_per_ratio={4: 8, 128: 8},
+        )


### PR DESCRIPTION
## What

Unify how V4 DeepSeek compress/write plans are sliced for the decode CUDAGraph path. `make_compress_plans` now takes `graph_bs` + `max_q_len` and computes **both** caps internally as `graph_bs * per_seq_bound`, sentinel-filling `[n_actual, cap)` — which is exactly the `[bs, graph_bs)` CUDAGraph padding region:

- compress bound = `ceil(qlen / ratio)`
- write bound = `min(qlen, K_pool)`

The cap depends only on `graph_bs`/`max_q_len` (both fixed at capture), so capture and replay dispatch identically-shaped kernels — the CUDAGraph invariant.

## Why

The write plan never had the slicing that compress already had: its grid was always the **full buffer** with the whole tail sentinel-filled. For decode, the actual write count is exactly `bs * min(qlen, K_pool)` (content-independent), so the full-buffer grid + H2D copy + sentinel fill were mostly wasted — up to ~32× for the HCA ratio (r=128, buffer `bs*128` vs need `bs*qlen`).

## Changes

- **`make_compress_plans`**: `graph_bs`/`max_q_len` → decode CG (both caps computed internally, `[bs, graph_bs)` padding sentinelled). `decode_capacity_per_ratio` retained as an explicit compress cap for the extend-shaped **verify** graph (dynamic token-count buffers that can't use the graph_bs formula; its write plan stays full-buffer). The two are mutually exclusive. Eager (neither) → tight `n_compress` / full-buffer write.
- **compress cap** moves from a `max_bs`-global value to per-graph-tight `graph_bs*ceil(qlen/ratio)` → smaller grids for small-batch decode graphs.
- **`update_compressor_states`**: removed the dead `num_write` param (grid uses `write_plan.shape[0]`).
- **native** (`deepseek_v4_attn.py`): `_build_compress_plans` takes `graph_bs`/`max_q_len`; prepare_decode / ubatch / capture pass them; removed the stored `_decode_compress_cap`.
- **bridges**: vllm/sglang decode paths pass `graph_bs`; eager paths keep the tight manual re-slice; sglang decode compress buffer sized `s*ceil(qlen/ratio)` to match vllm (was flat `s`, undersized for `mtp_k>=4`).

## Test plan

- [x] `tests/test_compress_plan.py` — 9 tests: 3 modes, CG invariance across real bs, `[bs, graph_bs)` padding sentinel, empty-fwd, mutual-exclusion.
- [x] Full unit suite: 622 passed / 5 skipped / 0 failed; `black` + `ruff` clean.
- [x] E2e V4-Pro GSM8K (3-shot): base `0.9538`, MTP3 `0.953`, TBO+DPA @ conc=1000 (decode CUDAGraph, exercises the padding path) `0.9447` — all within baseline band.
- [x] Perf 8k1k1024c TBO+DPA ×4: `40785 tok/s`, neutral vs ~41000 baseline; no fault/hang.