### PR TITLE
perf(tbo): compute prefill split scalars on host to cut D2H syncs

### DIFF
--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -881,6 +881,11 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             )
         if self._tbo_token_split:
             self._stash_tbo_token_split_prefill_state(batch)
+        # TBO: publish CPU length copies for zero-sync ubatch splits.
+        # Attached last, once all metadata is finalized. No-op unless TBO is on.
+        self._attach_tbo_prefill_cpu_lens(
+            attn_metadata, batch.total_seqs_num_prefill
+        )
         return attn_metadata, positions
 
     # ================================================================

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -883,9 +883,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             self._stash_tbo_token_split_prefill_state(batch)
         # TBO: publish CPU length copies for zero-sync ubatch splits.
         # Attached last, once all metadata is finalized. No-op unless TBO is on.
-        self._attach_tbo_prefill_cpu_lens(
-            attn_metadata, batch.total_seqs_num_prefill
-        )
+        self._attach_tbo_prefill_cpu_lens(attn_metadata, batch.total_seqs_num_prefill)
         return attn_metadata, positions
 
     # ================================================================

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1024,6 +1024,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 attn_metadata.mla_chunk_meta = self._build_mla_chunk_meta(batch, bs)
 
         attn_metadata.dtype_q = self.dtype_q
+        # TBO: publish CPU length copies for zero-sync ubatch splits.
+        # Attached last, once all metadata is finalized. No-op unless TBO is on.
+        self._attach_tbo_prefill_cpu_lens(attn_metadata, bs)
         return attn_metadata, positions
 
     def _build_mla_chunk_meta(

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -14,7 +14,12 @@ from aiter.dist.parallel_state import get_tp_group
 from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_ops.attention_mla import MLAModules
 from atom.utils import CpuGpuBuffer
-from atom.utils.tbo.ubatch_splitting import UBatchSlice, split_attn_metadata
+from atom.utils.tbo.ubatch_splitting import (
+    UBatchSlice,
+    attach_tbo_cpu_lens,
+    split_attn_metadata,
+)
+from atom.utils.tbo.ubatching import tbo_enabled
 from atom.utils.forward_context import AttentionMetaData, AttnState
 from torch import nn
 
@@ -479,6 +484,26 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
     ) -> AttentionMetaData:
         del ubatch_idx  # only used by builders with per-ubatch plan buffers
         return split_attn_metadata(attn_metadata, ub_slice, padded_bs)
+
+    def _attach_tbo_prefill_cpu_lens(
+        self, attn_metadata: AttentionMetaData, bs: int
+    ) -> None:
+        """Publish CPU (numpy) copies of the per-request length arrays so that
+        split_attn_metadata can recompute per-ubatch max_seqlen_q/k and total_kv
+        on the host with zero device sync.
+        """
+        if not tbo_enabled():
+            return
+        var = self.model_runner.forward_vars
+        attach_tbo_cpu_lens(
+            attn_metadata, "context_lens", var["context_lens"].np[:bs].copy()
+        )
+        attach_tbo_cpu_lens(
+            attn_metadata, "cu_seqlens_q", var["cu_seqlens_q"].np[: bs + 1].copy()
+        )
+        attach_tbo_cpu_lens(
+            attn_metadata, "cu_seqlens_k", var["cu_seqlens_k"].np[: bs + 1].copy()
+        )
 
     def build(self, batch: ScheduledBatch, bs: int):
         is_prefill = batch.total_tokens_num_prefill > 0

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1946,6 +1946,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 block_tables_gpu=ub_block_tables_gpu,
             )
         finally:
+            # Helpers above launch async H2D from the shared pinned forward_vars
+            # buffers we overwrote (context_lens/block_tables). Drain before the
+            # restore (and next ubatch) clobbers those sources mid-copy -> OOB
+            # index bounds. Replaces the .item() syncs the host-scalar path removed.
+            torch.cuda.current_stream().synchronize()
             bt[:ub_num_reqs] = saved_bt
             var["context_lens"].np[:ub_num_reqs] = saved_ctx
 
@@ -2501,7 +2506,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         hca_total = int(hca_indptr_np[T])
 
         # ----- H2D: 4 indptrs + 2 per-seq scalars -----
-        # All non-blocking; bounded by `total ≤ T*max_per_tok`.
+        # All non-blocking; sources are per-call temp np arrays, so not a
+        # cross-ubatch race source (the shared-pinned-buffer race is handled by
+        # the stream sync before build_ubatch_prefill_metadata's finally).
         chunk_start_per_seq_gpu = torch.from_numpy(chunk_start_per_seq_np).to(
             device, non_blocking=True
         )

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1035,6 +1035,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         scheduled_bs: int,
         total_tokens: int,
         positions_gpu=None,
+        buf_prefix_ubatch: str = "",
     ) -> None:
         """Build and attach the CSA Indexer per-fwd GPU metadata.
 
@@ -1042,6 +1043,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         n_committed / seq_base_per_token / cu_ends) into a single per-fwd
         build. None for warmup or empty fwd; `_build_v4_indexer_meta`
         handles both.
+
+        ``buf_prefix_ubatch`` selects the ub{idx}_ prefixed cu_committed staging
+        buffer so TBO ubatches don't collide on the shared global one.
         """
         attn_metadata.indexer_meta = self._build_v4_indexer_meta(
             attn_metadata=attn_metadata,
@@ -1049,6 +1053,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             scheduled_bs=scheduled_bs,
             total_tokens=total_tokens,
             device=self.device,
+            buf_prefix_ubatch=buf_prefix_ubatch,
         )
 
     def _build_v4_indexer_meta(
@@ -1059,6 +1064,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         scheduled_bs: int,
         total_tokens: int,
         device,
+        buf_prefix_ubatch: str = "",
     ):
         """Build per-fwd GPU index tensors consumed by `Indexer.forward_batched`.
 
@@ -1141,7 +1147,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # cu_committed_gpu is consumed both as `cu_starts/cu_ends` for the
         # fp8_mqa_logits per-token range AND as `cu_seq_lens` for the
         # cp_gather_indexer_k_quant_cache call (per-seq cumulative committed K).
-        cu_committed_gpu = self._stage("v4_indexer_cu_committed", cu_committed_cpu)
+        cu_committed_gpu = self._stage(
+            f"{buf_prefix_ubatch}v4_indexer_cu_committed", cu_committed_cpu
+        )
 
         # Layer-invariant GPU derivations (each was previously rebuilt ~30x
         # per fwd inside the per-CSA-layer body).
@@ -1897,62 +1905,51 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         else:
             ub_attn.compress_plans = {}
 
-        # Multiple helpers read context_lens and block_tables from
-        # forward_vars by position [0:scheduled_bs]. For ubatch 1 the
-        # relevant rows live at [rs.start:rs.stop], not [0:ub_num_reqs].
-        # Temporarily place the ubatch's slices at the front so helpers
-        # see the right values.
-        bt = var["block_tables"].np
-        saved_ctx = var["context_lens"].np[:ub_num_reqs].copy()
-        saved_bt = bt[:ub_num_reqs].copy()
-        try:
-            var["context_lens"].np[:ub_num_reqs] = context_lens_np
-            bt[:ub_num_reqs] = bt[rs.start : rs.stop].copy()
+        # TBO path (_prepare_ubatch_decode). `_attach_v4_per_fwd_meta` reads
+        # var[f"{p}context_lens"].np[:ub_num_reqs] for this ubatch's ctx lens;
+        # its paged-decode branch is a no-op for prefill state, so only
+        # context_lens needs staging into the prefixed set here.
+        p = f"ub{ubatch_idx}_"
+        var[f"{p}context_lens"].np[:ub_num_reqs] = context_lens_np
 
-            self._attach_v4_per_fwd_meta(
-                ub_attn,
-                extend_lens_np,  # ubatch's per-seq token counts
-                ub_attn.state_slot_mapping_cpu,
-                ub_num_reqs,
-                ub_num_tokens,
-            )
+        self._attach_v4_per_fwd_meta(
+            ub_attn,
+            extend_lens_np,  # ubatch's per-seq token counts
+            ub_attn.state_slot_mapping_cpu,
+            ub_num_reqs,
+            ub_num_tokens,
+            buf_prefix_ubatch=p,
+        )
 
-            positions_gpu = var["positions"].gpu[ts.start : ts.stop]
-            self._attach_v4_indexer_meta(
-                ub_attn,
-                ub_num_reqs,
-                ub_num_tokens,
-                positions_gpu=positions_gpu,
-            )
+        positions_gpu = var["positions"].gpu[ts.start : ts.stop]
+        self._attach_v4_indexer_meta(
+            ub_attn,
+            ub_num_reqs,
+            ub_num_tokens,
+            positions_gpu=positions_gpu,
+            buf_prefix_ubatch=p,
+        )
 
-            # start_pos = position of first token of each seq in this ubatch.
-            ub_start_pos_per_seq_np = positions_np[ub_cu[:ub_num_reqs]]
-            ub_positions_gpu = var["positions"].gpu[ts.start : ts.stop]
-            ub_block_tables_gpu = var["block_tables"].gpu[rs.start : rs.stop]
-            ub_cu_q_per_seq_gpu = torch.from_numpy(
-                np.ascontiguousarray(ub_cu[:ub_num_reqs], dtype=np.int32)
-            ).to(self.device, non_blocking=True)
-            self._build_paged_prefill_meta(
-                ub_attn,
-                positions_np,
-                ub_cu,
-                extend_lens_np,
-                ub_start_pos_per_seq_np,
-                ub_attn.state_slot_mapping_cpu,
-                ub_num_reqs,
-                ub_num_tokens,
-                positions_gpu=ub_positions_gpu,
-                cu_q_per_seq_gpu=ub_cu_q_per_seq_gpu,
-                block_tables_gpu=ub_block_tables_gpu,
-            )
-        finally:
-            # Helpers above launch async H2D from the shared pinned forward_vars
-            # buffers we overwrote (context_lens/block_tables). Drain before the
-            # restore (and next ubatch) clobbers those sources mid-copy -> OOB
-            # index bounds. Replaces the .item() syncs the host-scalar path removed.
-            torch.cuda.current_stream().synchronize()
-            bt[:ub_num_reqs] = saved_bt
-            var["context_lens"].np[:ub_num_reqs] = saved_ctx
+        # start_pos = position of first token of each seq in this ubatch.
+        ub_start_pos_per_seq_np = positions_np[ub_cu[:ub_num_reqs]]
+        ub_positions_gpu = var["positions"].gpu[ts.start : ts.stop]
+        ub_block_tables_gpu = var["block_tables"].gpu[rs.start : rs.stop]
+        ub_cu_q_per_seq_gpu = torch.from_numpy(
+            np.ascontiguousarray(ub_cu[:ub_num_reqs], dtype=np.int32)
+        ).to(self.device, non_blocking=True)
+        self._build_paged_prefill_meta(
+            ub_attn,
+            positions_np,
+            ub_cu,
+            extend_lens_np,
+            ub_start_pos_per_seq_np,
+            ub_attn.state_slot_mapping_cpu,
+            ub_num_reqs,
+            ub_num_tokens,
+            positions_gpu=ub_positions_gpu,
+            cu_q_per_seq_gpu=ub_cu_q_per_seq_gpu,
+            block_tables_gpu=ub_block_tables_gpu,
+        )
 
         # `split_attn_metadata` computed ub_attn.cu_seqlens_q/k from RAW request
         # boundaries (orig_cu[rs] - base), which is WRONG for a straddling
@@ -3006,7 +3003,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             bufs[f"v4_write_plan_{ratio}"].cpu.fill_(-1)
             bufs[f"v4_write_plan_{ratio}"].copy_to_gpu()
 
-        if getattr(self.model_runner.config, "enable_tbo_decode", False):
+        # ub{0,1}_ prefixed buffer sets are used by BOTH TBO decode and TBO
+        # prefill ubatch metadata builds (each ubatch reads/writes its own set
+        # instead of racing on the shared global forward_vars buffers). Allocate
+        # whenever TBO is on, not just for decode.
+        if getattr(self.model_runner.config, "enable_tbo", False) or getattr(
+            self.model_runner.config, "enable_tbo_decode", False
+        ):
             self._alloc_v4_ubatch_decode_buffers(bufs, i32, i64)
 
         # paged-SWA: parallel SWA block table (same shape as the compressed

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1724,6 +1724,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             self._apply_pcp_reindex(
                 attn_metadata, positions, scheduled_bs, sum_scheduled_tokens
             )
+        self._attach_tbo_prefill_cpu_lens(attn_metadata, scheduled_bs)
         return attn_metadata, positions
 
     def _apply_pcp_reindex(

--- a/atom/utils/tbo/__init__.py
+++ b/atom/utils/tbo/__init__.py
@@ -8,6 +8,7 @@ from .prefill_token_split import (
 )
 from .ubatch_splitting import (
     UBatchSlice,
+    attach_tbo_cpu_lens,
     maybe_create_ubatch_slices,
     split_attn_metadata,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "TokenSplitPrefillState",
     "UBatchSlice",
     "UBatchWrapper",
+    "attach_tbo_cpu_lens",
     "compute_straddle_split_info",
     "local_tbo_precompute",
     "sync_dp_for_tbo",

--- a/atom/utils/tbo/ubatch_splitting.py
+++ b/atom/utils/tbo/ubatch_splitting.py
@@ -238,6 +238,48 @@ def _split_prefill_token_midpoint(
     return slices
 
 
+def attach_tbo_cpu_lens(
+    attn_metadata: AttentionMetaData, field_name: str, np_array
+) -> None:
+    """Publish a ready-made CPU (numpy) copy of a per-request length array.
+
+    Called from a backend's prefill ``prepare_prefill`` AFTER all metadata is
+    finalized, where the source numpy already exists (e.g.
+    ``forward_vars["context_lens"].np``). ``split_attn_metadata`` then reads it
+    via ``_get_tbo_cpu_lens`` (host math, zero device sync) instead of copying
+    the freshly-sliced device tensors back to the host.
+
+    NOTE: ``forward_vars[...].np`` is a *reused* pinned buffer that the next
+    forward will overwrite, so callers MUST pass a ``.copy()`` (or a freshly
+    allocated array) to keep it valid for this batch's lifetime.
+    """
+    setattr(attn_metadata, "_tbo_cpu_lens_" + field_name, np_array)
+
+
+def _get_tbo_cpu_lens(attn_metadata: AttentionMetaData, field_name: str):
+    """Fetch a CPU (numpy) copy of a per-request length array.
+
+    Fast path: one was already published by ``attach_tbo_cpu_lens`` from the
+    backend's prepare path (numpy was free there) — zero device sync.
+
+    Fallback path: if none was published (a backend whose prepare_prefill
+    doesn't attach one), lazily copy the device tensor to host once and cache it
+    under ``_tbo_cpu_lens_<field>``; subsequent ubatch slices in the same
+    forward reuse it. This is TBO-only: reached only through
+    ``split_attn_metadata`` and never touched when TBO is disabled, so non-TBO
+    runs pay zero extra cost.
+    """
+    cache_attr = "_tbo_cpu_lens_" + field_name
+    if not hasattr(attn_metadata, cache_attr):
+        t = getattr(attn_metadata, field_name, None)
+        setattr(
+            attn_metadata,
+            cache_attr,
+            None if t is None else t.detach().cpu().numpy(),
+        )
+    return getattr(attn_metadata, cache_attr)
+
+
 def split_attn_metadata(
     attn_metadata: AttentionMetaData,
     ub_slice: UBatchSlice,
@@ -270,8 +312,6 @@ def split_attn_metadata(
         ub_slot_mapping = attn_metadata.slot_mapping[ts]
         # Pad with -1 for padded positions
         tok_count = ts.stop - ts.start
-        # max_q_len = attn_metadata.max_seqlen_q
-        # padded_tok_count = padded_bs * max_q_len
         padded_tok_count = padded_bs
         if padded_tok_count > tok_count:
             pad = torch.full(
@@ -373,11 +413,6 @@ def split_attn_metadata(
             padding = last_val.expand(pad_size)
             ub_sparse_kv_indptr = torch.cat([ub_sparse_kv_indptr, padding])
 
-    # max_seqlen_k: recompute from the sliced context_lens
-    ub_max_seqlen_k = attn_metadata.max_seqlen_k
-    if ub_context_lens is not None and ub_num_reqs > 0:
-        ub_max_seqlen_k = int(ub_context_lens[:ub_num_reqs].max().item())
-
     # cu_seqlens_k: re-base like cu_seqlens_q (needed for prefill attention)
     ub_cu_seqlens_k = None
     if attn_metadata.cu_seqlens_k is not None:
@@ -394,12 +429,28 @@ def split_attn_metadata(
             padding = last_val.expand(pad_size)
             ub_cu_seqlens_k = torch.cat([ub_cu_seqlens_k, padding])
 
-    # max_seqlen_q: recompute from cu_seqlens_q for this ubatch
+    # Scalars (max_seqlen_q/k, total_kv) are derived from per-request lengths
+    # that originate as numpy on the CPU (see the attention builders). Instead of
+    # syncing the freshly-sliced device tensors back to the host, slice the CPU
+    # length copies and compute these with numpy — no GPU sync, no kernel
+    # launches. The copies are published by attach_tbo_cpu_lens (or created
+    # lazily on first use as a fallback) and are TBO-only.
+    ub_max_seqlen_k = attn_metadata.max_seqlen_k
     ub_max_seqlen_q = attn_metadata.max_seqlen_q
-    if ub_cu_seqlens_q is not None and ub_num_reqs > 0:
-        # Per-request q lengths are the diffs of consecutive cu_seqlens entries
-        per_req_q = ub_cu_seqlens_q[1 : ub_num_reqs + 1] - ub_cu_seqlens_q[:ub_num_reqs]
-        ub_max_seqlen_q = int(per_req_q.max().item())
+
+    if ub_num_reqs > 0:
+        # max_seqlen_k: max over this ubatch's context lengths.
+        ctx_cpu = _get_tbo_cpu_lens(attn_metadata, "context_lens")
+        if ctx_cpu is not None:
+            ub_ctx_cpu = ctx_cpu[req_start:req_end]
+            ub_max_seqlen_k = int(ub_ctx_cpu.max())
+
+        # max_seqlen_q: max per-request q length, matching the clamp/re-base that
+        # produced ub_cu_seqlens_q above (clamp to the token window, then diff).
+        cuq_cpu = _get_tbo_cpu_lens(attn_metadata, "cu_seqlens_q")
+        if cuq_cpu is not None:
+            seg = np.clip(cuq_cpu[req_start : req_end + 1], ts.start, ts.stop)
+            ub_max_seqlen_q = int(np.diff(seg).max())
 
     ub_total_kv = None
     if attn_metadata.has_cached:


### PR DESCRIPTION
split_attn_metadata recomputed per-ubatch max_seqlen_q/k with per-field .item() calls, forcing one GPU->CPU sync each. Derive these from CPU copies of the per-request length arrays instead:

- attach_tbo_cpu_lens(): backends publish CPU (numpy) copies of context_lens / cu_seqlens_q/k at the END of their own prepare_prefill (opt-in, TBO-only, gated by tbo_enabled). _get_tbo_cpu_lens() reads them (zero sync) and falls back to a one-shot lazy D2H if a backend didn't attach.


Non-TBO runs are unaffected (nothing attached, split path not reached).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
