### PR TITLE
fix: account for non-torch (RCCL) memory in KV cache sizing

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -24,7 +24,7 @@ from aiter.dist.parallel_state import (
 )
 from aiter.dist.utils import get_distributed_init_method
 from atom.config import Config, CUDAGraphMode, set_current_atom_config
-from atom.utils.cuda_graph import BatchDescriptor
+from atom.kv_transfer.disaggregation import KVConnectorOutput
 from atom.model_engine.run_labels import build_run_label
 from atom.model_engine.scheduler import ScheduledBatch, ScheduledBatchOutput
 from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
@@ -43,8 +43,18 @@ from atom.utils import (
     init_exit_handler,
     resolve_obj_by_qualname,
 )
-from atom.kv_transfer.disaggregation import KVConnectorOutput
-from atom.utils.forward_context import get_kvconnector
+from atom.utils.cuda_graph import BatchDescriptor
+from atom.utils.forward_context import (
+    Context,
+    DPMetadata,
+    ForwardMode,
+    get_forward_context,
+    get_kvconnector,
+    reset_forward_context,
+    set_forward_context,
+    set_kv_cache_data,
+)
+from atom.utils.selector import get_attn_backend
 from atom.utils.tbo import (
     UBatchSlice,
     UBatchWrapper,
@@ -58,16 +68,6 @@ from atom.distributed.pcp_utils import (
     pcp_pad_len,
     pcp_round_robin_split,
 )
-from atom.utils.forward_context import (
-    Context,
-    DPMetadata,
-    ForwardMode,
-    get_forward_context,
-    reset_forward_context,
-    set_forward_context,
-    set_kv_cache_data,
-)
-from atom.utils.selector import get_attn_backend
 from torch.profiler import record_function
 
 logger = logging.getLogger("atom")
@@ -834,9 +834,7 @@ class ModelRunner:
         # tensor[-1] on first decode. Catch the misconfiguration up front
         # rather than producing wrong outputs at inference time.
         if self.attn_metadata_builder.compute_per_req_cache_bytes() > 0:
-            from atom.model_engine.llm_engine import (
-                InputOutputProcessor as _IOProc,
-            )
+            from atom.model_engine.llm_engine import InputOutputProcessor as _IOProc
 
             mt = self.config.hf_config.model_type
             known = _IOProc._per_req_cache_model_types()  # noqa: SLF001
@@ -1569,24 +1567,17 @@ class ModelRunner:
         free, total = torch.cuda.mem_get_info()
         peak = torch.cuda.memory_stats()["allocated_bytes.all.peak"]
         current = torch.cuda.memory_stats()["allocated_bytes.all.current"]
-
-        # Peak PyTorch usage (high watermark during warmup) — this is memory
-        # consumed by THIS process only (model weights + peak activations).
+        # weights + peak activation tensors (PyTorch allocator high-water).
         peak_torch = max(peak, current)
+        # RCCL/NCCL buffers etc. held outside the allocator: device-used minus
+        # torch-reserved. Ignoring it over-allocates KV and OOMs at runtime.
+        non_torch = max((total - free) - torch.cuda.memory_reserved(), 0)
 
-        # CUDA graph capture overhead estimate
         cudagraph_overhead = self._estimate_cudagraph_overhead()
-
-        # Safety margin (2% of total)
         safety_margin = int(total * 0.02)
 
-        # Budget: this server may use up to gpu_memory_utilization * total.
-        # Subtract our own PyTorch usage + CUDA graph estimate + safety.
-        # This is independent of other processes on the GPU.
         budget = int(total * config.gpu_memory_utilization)
-        # Fixed (utilization-independent) overhead of this process: model
-        # weights + peak activations + CUDA graph capture + safety margin.
-        non_kv_overhead = peak_torch + cudagraph_overhead + safety_margin
+        non_kv_overhead = peak_torch + non_torch + cudagraph_overhead + safety_margin
         available_for_kv_budget = budget - non_kv_overhead
 
         # Physical clamp: never exceed what's actually free on the GPU.
@@ -1714,6 +1705,7 @@ class ModelRunner:
             f"utilization={config.gpu_memory_utilization}, "
             f"budget={budget / (1 << 30):.2f}GB, "
             f"peak_torch={peak_torch / (1 << 30):.2f}GB, "
+            f"non_torch={non_torch / (1 << 30):.2f}GB, "
             f"cudagraph_est={cudagraph_overhead / (1 << 30):.2f}GB, "
             f"safety={safety_margin / (1 << 30):.2f}GB, "
             f"available_for_kv={available_for_kv / (1 << 30):.2f}GB, "
@@ -1769,6 +1761,7 @@ class ModelRunner:
             f"but available_for_kv={available_for_kv / (1 << 20):.2f}MB "
             f"(budget={budget / (1 << 30):.2f}GB, "
             f"peak_torch={peak_torch / (1 << 30):.2f}GB, "
+            f"non_torch={non_torch / (1 << 30):.2f}GB, "
             f"cudagraph_est={cudagraph_overhead / (1 << 30):.2f}GB, "
             f"safety={safety_margin / (1 << 30):.2f}GB, "
             f"free={free / (1 << 30):.2f}GB)"


### PR DESCRIPTION
## Problem

`ModelRunner.get_num_blocks` sized the KV pool from PyTorch's **allocated-bytes** peak only:

```python
non_kv_overhead = peak_torch + cudagraph_overhead + safety_margin
```

`peak_torch` (allocated high-water) covers model weights + peak activations, but **excludes memory held outside PyTorch's caching allocator** — RCCL/NCCL channel buffers and attention-backend scratch. On DeepSeek-V4-Pro with `--enable-dp-attention --enable-tbo` this is **~14GB** that was never subtracted from the KV budget, so the KV pool was over-allocated. Under sustained load the non-torch/RCCL side competes for raw device memory and a collective launch can fail with `HSA_STATUS_ERROR_OUT_OF_RESOURCES` (observed intermittently in the DPA+TBO 8k benchmark, crashing during an `ncclDevKernel` launch).

## Fix

Measure the non-torch footprint the same way vLLM does (`vllm/utils/mem_utils.py` `MemorySnapshot`) — device-used minus torch-reserved — and include it in the sizing:

```python
non_torch = max((total - free) - torch.cuda.memory_reserved(), 0)
non_kv_overhead = peak_torch + non_torch + cudagraph_overhead + safety_margin
```

Measured right after warmup (which already `empty_cache`s), so `reserved` has collapsed to the live weights and the delta is the true non-torch (RCCL) footprint. Sizing-only; the hot path is untouched. `non_torch` is added to the two memory-budget log lines for visibility.

## Verification (DeepSeek-V4-Pro, DPA+TBO, 8k/1k, c=512, 8×MI355X)

- Memory budget now reports `non_torch=13.97GB`; `available_for_kv` 106.93 → 92.96GB (KV pool −14GB).
- Throughput unchanged: **31976 tok/s** (baseline 32011) — no regression, as expected for a sizing-only change.
- Runtime memory (instrumented, temporary): peak `allocated` **242GB / 288GB** (~46GB headroom), device-free stable ~17GB, **`num_alloc_retries=0`** through the ramp — no allocator pressure.

## Notes

- The change is conservative (over-reserves by the fixed HIP/RCCL context baseline rather than a per-instance delta); a baseline-snapshot refinement (vLLM `non_torch_increase`) is a possible follow-up but not needed for the target dedicated-GPU deployment.
- `safety_margin` (2% of total) is intentionally retained — it provides part of the raw device-free cushion the RCCL path draws from.

The diff also includes an incidental import reordering in the same file.