### PR TITLE
[DSV4] remove kv_last_len

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1319,9 +1319,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.qo_indptr = self._stage(
                 "v4_qo_indptr", self._v4_qo_indptr_np[: bs + 1]
             )
-            attn_metadata.kv_last_page_lens = self._stage(
-                "v4_kv_last_page_lens", self._v4_kv_last_page_lens_np[:bs]
-            )
 
         # NOT rebuilt (unused by SWA-only MTP layer; would block a future
         # CSA/HCA MTP layer — assert at top guards):
@@ -2607,9 +2604,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             if T_pad > T:
                 qo_indptr_np[T + 1 :] = T
             attn_metadata.qo_indptr = self._stage("v4_qo_indptr", qo_indptr_np)
-            attn_metadata.kv_last_page_lens = self._stage(
-                "v4_kv_last_page_lens", self._v4_kv_last_page_lens_np[:T_pad]
-            )
 
     def _build_paged_prefill_meta(
         self,
@@ -3188,15 +3182,12 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # (`mla_decode_fwd_v4_nm`, page_size=1). Values are CONSTANT — they
         # depend only on the (padded) decode token count N, not the batch:
         #   qo_indptr        = arange(N+1)   (per-token q indptr, max_seqlen_q=1)
-        #   kv_last_page_lens = ones(N)       (page_size=1 → every page full)
         # Built the SAME way as `kv_indptr_*`: a CpuGpuBuffer re-staged via
         # `self._stage(...)` EVERY fwd, which is what makes them CUDAGraph-safe
         # (re-copied into the captured buffer before graph.replay). The constant
         # numpy sources are precomputed once so the per-fwd cost is a slice + H2D.
         bufs["v4_qo_indptr"] = CpuGpuBuffer(T_dec + 1, **i32)
-        bufs["v4_kv_last_page_lens"] = CpuGpuBuffer(T_dec, **i32)
         self._v4_qo_indptr_np = np.arange(T_dec + 1, dtype=np.int32)
-        self._v4_kv_last_page_lens_np = np.ones(T_dec, dtype=np.int32)
         # Per-seq `ctx_len // 4` (raw, no clamp). Consumed by csa_translate_pack
         # (kernel masks `(k < n_committed) & (k < index_topk)`) AND by the
         # indexer (cast to int64 inline). Built unconditionally in

--- a/atom/model_ops/v4_kernels/paged_decode.py
+++ b/atom/model_ops/v4_kernels/paged_decode.py
@@ -916,7 +916,7 @@ def _sparse_attn_v4_paged_decode_asm(
     q_packed_in: torch.Tensor,
     q_rope_in: torch.Tensor,
     qo_indptr: torch.Tensor,
-    kv_last_page_lens: torch.Tensor,
+    kv_last_page_lens: torch.Tensor | None = None,  # unused on v4 nm (page_size=1)
     num_kv_splits: int | None = None,
 ) -> torch.Tensor:
     """Native 2buff fp8 V4 decode via the aiter assembly kernel
@@ -931,8 +931,10 @@ def _sparse_attn_v4_paged_decode_asm(
     The flat-CSR ``unified_kv`` is made compatible with the kernel's paged
     format by treating each token as a 1-token page (``page_size=1``):
     ``kv_page_indices = kv_indices``, ``kv_indptr`` is the existing CSR indptr,
-    ``kv_last_page_lens = ones(N)``, ``qo_indptr = arange(N+1)``,
-    ``max_seqlen_q = 1``. No translation layer needed.
+    ``qo_indptr = arange(N+1)``, ``max_seqlen_q = 1``. No translation layer
+    needed. ``kv_last_page_lens`` is not built/forwarded: page_size=1 makes it
+    logically ones(N), but the kernel derives kv_seq_len from the token-level
+    ``kv_indptr`` and ignores the values (aiter synthesizes a throwaway buffer).
 
     softmax_scale is ignored by the kernel (hardcodes 1/sqrt(512)); passed
     through for API parity.
@@ -1000,7 +1002,6 @@ def _sparse_attn_v4_paged_decode_asm(
     # needed — only the trim to the real query count N (and a contiguity fixup on
     # the possibly-viewed kv_indices).
     qo_indptr = qo_indptr[: N + 1]
-    kv_last_page_lens = kv_last_page_lens[:N]
     kv_indptr_i32 = kv_indptr[: N + 1]
     kv_page_indices_i32 = kv_indices.contiguous()
     max_seqlen_q = 1
@@ -1008,9 +1009,8 @@ def _sparse_attn_v4_paged_decode_asm(
     output = torch.empty(
         (N, H, V4_DIM_NOPE + V4_DIM_ROPE), dtype=torch.bfloat16, device=device
     )
-    out_16_nosplit = 1 if num_kv_splits == 1 else 0
 
-    logits, _ = aiter.mla.mla_decode_fwd_v4_nm(
+    aiter.mla.mla_decode_fwd_v4_nm(
         q_packed,
         q_rope,
         kv_packed,
@@ -1019,20 +1019,12 @@ def _sparse_attn_v4_paged_decode_asm(
         qo_indptr,
         kv_indptr_i32,
         kv_page_indices_i32,
-        kv_last_page_lens,
         max_seqlen_q,
         sink=attn_sink,
         sm_scale=softmax_scale,
-        out_16_nosplit=out_16_nosplit,
         num_kv_splits=num_kv_splits,
     )
-    # Result lands in `output` for the bf16-direct write (out_16_nosplit=1) or
-    # the stage2 LSE merge (resolved splits > 1). Only the single-pass fp32
-    # path leaves it in logits[:, 0]. logits.shape[1] = resolved split count.
-    resolved_splits = logits.shape[1]
-    if out_16_nosplit != 0 or resolved_splits > 1:
-        return output
-    return logits[:, 0].to(torch.bfloat16)
+    return output
 
 
 @mark_trace

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2406,8 +2406,6 @@ class DeepseekV4Attention(nn.Module):
             # Dispatch on kv-cache layout inside the wrapper: fp8 2buff
             # (unified_kv_rope set) → aiter asm op5 with pre-packed fp8 Q + the
             # 2buff fp8/bf16 pools read with no requant; bf16 (unified_kv_rope
-            # None) → Triton. qo_indptr / kv_last_page_lens come from the builder
-            # (None on bf16, ignored by the Triton path).
             o = sparse_attn_v4_paged_decode(
                 qkn.q_sa,
                 self.unified_kv,
@@ -2419,7 +2417,6 @@ class DeepseekV4Attention(nn.Module):
                 q_packed_in=qkn.q_packed,
                 q_rope_in=qkn.q_rope,
                 qo_indptr=attn_md.qo_indptr,
-                kv_last_page_lens=attn_md.kv_last_page_lens,
                 prefix=f"{self.layer_name}.sparse_attn_decode",
             )  # [S, H, head_dim]
         else:


### PR DESCRIPTION
## Summary
Remove the redundant `kv_last_page_lens` from the V4 page_size=1 asm decode
path. aiter's `mla_decode_fwd_v4_nm` derives kv_seq_len from the token-level
`kv_indptr` and ignores the value, so building/forwarding it is dead work.

## Changes
- deepseek_v4_attn.py: stop building/staging the `v4_kv_last_page_lens`
  CpuGpuBuffer (removes a per-fwd slice + H2D copy in both decode metadata paths).
- paged_decode.py: drop `kv_last_page_lens` from the aiter call; simplify the
  asm-decode return path (remove the `out_16_nosplit` / logits branch, return
  `output` directly).
- deepseek_v4.py: drop the `kv_last_page_lens` argument at the call site.

## Test plan
Verified on this branch (with the current aiter build), DeepSeek-V4-Pro fp8, tp8:
- gsm8k accuracy — all pass: base 0.9538, MTP 0.9530 (accept 64.4%),
  TBO+DPA conc1000 0.9454 (thresholds 0.94 / 0.94 / 0.93).
- perf conc256 1k/1k: 9292 tok/s total, no regression.
- `black --check` + `ruff check` clean.
