### PR TITLE
[CI] Support shared NFS model cache for benchmarks

### DIFF
--- a/.github/actions/atom-bench-container/action.yml
+++ b/.github/actions/atom-bench-container/action.yml
@@ -59,8 +59,8 @@ runs:
         MODEL_PROGRESS_INTERVAL: "60"
       run: |
         set -euo pipefail
-        if [ ! -d "/models" ]; then
-          echo "/models directory not found, skipping model download"
+        if [ -z "${MODEL_HOST_ROOT:-}" ]; then
+          echo "Model cache directory not found, skipping model download"
           exit 0
         fi
         model_dir="/models/${{ inputs.model-path }}"

--- a/.github/actions/setup-gpu-container/action.yml
+++ b/.github/actions/setup-gpu-container/action.yml
@@ -87,11 +87,20 @@ runs:
           DEVICE_FLAG="--device /dev/dri"
         fi
 
-        if [ -d "/models" ]; then
-          MODEL_MOUNT="-v /models:/models"
+        MODEL_HOST_ROOT=""
+        for d in /shared_nfs/huggingface_models /models /data/models; do
+          if [ -d "$d" ]; then
+            MODEL_HOST_ROOT="$d"
+            break
+          fi
+        done
+
+        MODEL_MOUNT=""
+        if [ -n "$MODEL_HOST_ROOT" ]; then
+          MODEL_MOUNT="-v ${MODEL_HOST_ROOT}:/models"
+          echo "MODEL_HOST_ROOT=${MODEL_HOST_ROOT}" >> "$GITHUB_ENV"
         else
-          echo "Warning: /models directory not found on runner; skipping /models mount and disabling model pre-download optimization."
-          MODEL_MOUNT=""
+          echo "Warning: no model cache directory found on runner; skipping /models mount and disabling model pre-download optimization."
         fi
 
         # Write env_vars via env block (avoids expression injection). Key the

--- a/.github/scripts/download_aiter_wheel.sh
+++ b/.github/scripts/download_aiter_wheel.sh
@@ -1,23 +1,30 @@
 #!/usr/bin/env bash
 # Resolve and download the aiter wheel: latest-main S3 manifest first, then
 # fall back to the newest matching aiter-whl-* artifact from ROCm/aiter.
+# Set AITER_WHEEL_DOWNLOAD_MODE=workflow_artifact to download an already
+# uploaded workflow artifact from the current GitHub Actions run instead.
 # De-inlined from atom-test.yaml / atomesh-accuracy-validation.yaml (identical
 # blocks). Inputs via env: ATOM_PYTHON_TAG (required), GITHUB_TOKEN (required);
 # S3_MAIN_MANIFEST_URL / API_URL / AITER_TEST_WORKFLOW_ID are overridable.
-# Output: aiter-whl/amd_aiter*.whl in the current directory.
+# Output: ${AITER_WHEEL_OUTPUT_DIR:-aiter-whl}/amd_aiter*.whl.
 set -euo pipefail
 : "${ATOM_PYTHON_TAG:?ATOM_PYTHON_TAG must be set}"
 : "${GITHUB_TOKEN:?GITHUB_TOKEN must be set}"
-echo "=== Trying latest main aiter wheel manifest from S3 first ==="
 
 S3_MAIN_MANIFEST_URL="${S3_MAIN_MANIFEST_URL:-https://rocm.frameworks-nightlies.amd.com/whl-staging/gfx942-gfx950/main/latest.json}"
 API_URL="${API_URL:-https://api.github.com}"
 AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 AITER_TEST_WORKFLOW_ID="${AITER_TEST_WORKFLOW_ID:-179476100}"
+AITER_WHEEL_DOWNLOAD_MODE="${AITER_WHEEL_DOWNLOAD_MODE:-resolve}"
+AITER_WHEEL_OUTPUT_DIR="${AITER_WHEEL_OUTPUT_DIR:-aiter-whl}"
 AITER_WHEEL_DOWNLOAD_MAX_ATTEMPTS="${AITER_WHEEL_DOWNLOAD_MAX_ATTEMPTS:-3}"
 AITER_WHEEL_RETRY_DELAY_SECONDS="${AITER_WHEEL_RETRY_DELAY_SECONDS:-30}"
 AITER_WHEEL_CURL_CONNECT_TIMEOUT_SECONDS="${AITER_WHEEL_CURL_CONNECT_TIMEOUT_SECONDS:-30}"
 AITER_WHEEL_CURL_MAX_TIME_SECONDS="${AITER_WHEEL_CURL_MAX_TIME_SECONDS:-540}"
+AITER_WORKFLOW_ARTIFACT_NAME="${AITER_WORKFLOW_ARTIFACT_NAME:-aiter-whl}"
+AITER_WORKFLOW_ARTIFACT_REPO="${AITER_WORKFLOW_ARTIFACT_REPO:-${GITHUB_REPOSITORY:-}}"
+AITER_WORKFLOW_RUN_ID="${AITER_WORKFLOW_RUN_ID:-${GITHUB_RUN_ID:-}}"
+AITER_WORKFLOW_ARTIFACT_ID="${AITER_WORKFLOW_ARTIFACT_ID:-}"
 
 ARTIFACT_ID=""
 ARTIFACT_NAME=""
@@ -53,6 +60,25 @@ curl_with_retry() {
       --connect-timeout "$AITER_WHEEL_CURL_CONNECT_TIMEOUT_SECONDS" \
       --max-time "$AITER_WHEEL_CURL_MAX_TIME_SECONDS" \
       "$@"
+}
+
+prepare_output_dir() {
+  mkdir -p "$AITER_WHEEL_OUTPUT_DIR"
+  rm -f "$AITER_WHEEL_OUTPUT_DIR"/amd_aiter*.whl
+}
+
+selected_wheel() {
+  ls -t "$AITER_WHEEL_OUTPUT_DIR"/amd_aiter*.whl 2>/dev/null | head -1
+}
+
+download_artifact_zip() {
+  local repo="$1"
+  local artifact_id="$2"
+  local output_zip="$3"
+
+  curl_with_retry -H "$AUTH_HEADER" \
+    "$API_URL/repos/$repo/actions/artifacts/$artifact_id/zip" \
+    -o "$output_zip"
 }
 
 resolve_download_url() {
@@ -105,8 +131,7 @@ find_latest_artifact() {
 download_from_s3_manifest() {
   local manifest_file manifest_fetch_url manifest_branch manifest_timestamp manifest_commit wheel_name wheel_url resolved_wheel_url
 
-  mkdir -p aiter-whl
-  rm -f aiter-whl/amd_aiter*.whl
+  prepare_output_dir
 
   manifest_file=$(mktemp)
   trap 'rm -f "$manifest_file"' RETURN
@@ -156,8 +181,8 @@ download_from_s3_manifest() {
   echo "Manifest commit: $manifest_commit"
   echo "Manifest wheel: $wheel_name"
   echo "Downloading manifest-selected wheel: $resolved_wheel_url"
-  curl_with_retry "$resolved_wheel_url" -o "aiter-whl/$wheel_name" || return 1
-  echo "Downloaded wheel from manifest: aiter-whl/$wheel_name"
+  curl_with_retry "$resolved_wheel_url" -o "$AITER_WHEEL_OUTPUT_DIR/$wheel_name" || return 1
+  echo "Downloaded wheel from manifest: $AITER_WHEEL_OUTPUT_DIR/$wheel_name"
 
   rm -f "$manifest_file"
   trap - RETURN
@@ -172,35 +197,90 @@ download_from_artifact() {
     return 1
   }
 
-  mkdir -p aiter-whl
-  rm -f aiter-whl/amd_aiter*.whl
-  curl_with_retry -H "$AUTH_HEADER" \
-    "$API_URL/repos/ROCm/aiter/actions/artifacts/$ARTIFACT_ID/zip" \
-    -o aiter-whl.zip
-  unzip -o aiter-whl.zip -d aiter-whl
+  prepare_output_dir
+  download_artifact_zip "ROCm/aiter" "$ARTIFACT_ID" aiter-whl.zip
+  unzip -o aiter-whl.zip -d "$AITER_WHEEL_OUTPUT_DIR"
   rm -f aiter-whl.zip
 
-  fallback_wheel=$(ls -t aiter-whl/amd_aiter*.whl 2>/dev/null | head -1)
+  fallback_wheel=$(selected_wheel)
   fallback_wheel_name=$(basename "${fallback_wheel:-}")
   if [ -z "$fallback_wheel" ] || [[ "$fallback_wheel_name" != *${ATOM_PYTHON_TAG}* ]]; then
     echo "ERROR: artifact fallback did not produce a ${ATOM_PYTHON_TAG} wheel"
-    ls -la aiter-whl/ || true
+    ls -la "$AITER_WHEEL_OUTPUT_DIR"/ || true
     return 1
   fi
   echo "Downloaded artifact-selected wheel: $fallback_wheel"
 }
 
-if download_from_s3_manifest; then
-  echo "Using wheel from S3 main manifest"
-else
-  echo "Main wheel manifest download failed, falling back to GitHub artifact"
-  download_from_artifact
-fi
+find_workflow_artifact() {
+  local artifacts_json artifact_json
 
-AITER_WHL=$(ls -t aiter-whl/amd_aiter*.whl 2>/dev/null | head -1)
+  : "${AITER_WORKFLOW_ARTIFACT_REPO:?AITER_WORKFLOW_ARTIFACT_REPO or GITHUB_REPOSITORY must be set}"
+  : "${AITER_WORKFLOW_RUN_ID:?AITER_WORKFLOW_RUN_ID or GITHUB_RUN_ID must be set}"
+
+  echo "=== Finding workflow artifact ${AITER_WORKFLOW_ARTIFACT_NAME} in ${AITER_WORKFLOW_ARTIFACT_REPO} run ${AITER_WORKFLOW_RUN_ID} ==="
+  artifacts_json=$(curl_with_retry -H "$AUTH_HEADER" \
+    "$API_URL/repos/$AITER_WORKFLOW_ARTIFACT_REPO/actions/runs/$AITER_WORKFLOW_RUN_ID/artifacts?per_page=100")
+
+  artifact_json=$(echo "$artifacts_json" \
+    | jq --arg artifact_name "$AITER_WORKFLOW_ARTIFACT_NAME" '[.artifacts[] | select(.name == $artifact_name) | select(.expired == false)] | sort_by(.created_at) | last')
+
+  if [ "$artifact_json" = "null" ] || [ -z "$artifact_json" ]; then
+    echo "ERROR: No non-expired workflow artifact named ${AITER_WORKFLOW_ARTIFACT_NAME} found in run ${AITER_WORKFLOW_RUN_ID}"
+    return 1
+  fi
+
+  AITER_WORKFLOW_ARTIFACT_ID=$(echo "$artifact_json" | jq -r '.id')
+  echo "Found workflow artifact ${AITER_WORKFLOW_ARTIFACT_NAME} (ID: ${AITER_WORKFLOW_ARTIFACT_ID})"
+}
+
+download_from_workflow_artifact() {
+  local workflow_wheel workflow_wheel_name
+
+  : "${AITER_WORKFLOW_ARTIFACT_REPO:?AITER_WORKFLOW_ARTIFACT_REPO or GITHUB_REPOSITORY must be set}"
+  if [ -z "$AITER_WORKFLOW_ARTIFACT_ID" ] || [ "$AITER_WORKFLOW_ARTIFACT_ID" = "null" ]; then
+    retry_cmd "$AITER_WHEEL_DOWNLOAD_MAX_ATTEMPTS" find_workflow_artifact
+  fi
+
+  echo "=== Downloading workflow artifact ${AITER_WORKFLOW_ARTIFACT_NAME} (ID: ${AITER_WORKFLOW_ARTIFACT_ID}) ==="
+  prepare_output_dir
+  download_artifact_zip "$AITER_WORKFLOW_ARTIFACT_REPO" "$AITER_WORKFLOW_ARTIFACT_ID" aiter-whl.zip
+  unzip -o aiter-whl.zip -d "$AITER_WHEEL_OUTPUT_DIR"
+  rm -f aiter-whl.zip
+
+  workflow_wheel=$(selected_wheel)
+  workflow_wheel_name=$(basename "${workflow_wheel:-}")
+  if [ -z "$workflow_wheel" ] || [[ "$workflow_wheel_name" != *${ATOM_PYTHON_TAG}* ]]; then
+    echo "ERROR: workflow artifact did not produce a ${ATOM_PYTHON_TAG} wheel"
+    ls -la "$AITER_WHEEL_OUTPUT_DIR"/ || true
+    return 1
+  fi
+  echo "Downloaded workflow artifact-selected wheel: $workflow_wheel"
+}
+
+case "$AITER_WHEEL_DOWNLOAD_MODE" in
+  resolve)
+    echo "=== Trying latest main aiter wheel manifest from S3 first ==="
+    if download_from_s3_manifest; then
+      echo "Using wheel from S3 main manifest"
+    else
+      echo "Main wheel manifest download failed, falling back to GitHub artifact"
+      download_from_artifact
+    fi
+    ;;
+  workflow_artifact|workflow-artifact)
+    download_from_workflow_artifact
+    ;;
+  *)
+    echo "ERROR: unsupported AITER_WHEEL_DOWNLOAD_MODE=${AITER_WHEEL_DOWNLOAD_MODE}" >&2
+    exit 1
+    ;;
+esac
+
+AITER_WHL=$(selected_wheel)
 if [ -z "$AITER_WHL" ]; then
-  echo "ERROR: No amd_aiter wheel available after S3/artifact attempts"
-  ls -la aiter-whl/ || true
+  echo "ERROR: No amd_aiter wheel available in $AITER_WHEEL_OUTPUT_DIR"
+  ls -la "$AITER_WHEEL_OUTPUT_DIR"/ || true
   exit 1
 fi
 if [[ "$(basename "$AITER_WHL")" != *${ATOM_PYTHON_TAG}* ]]; then
@@ -211,5 +291,6 @@ fi
 echo "Selected wheel: $AITER_WHL"
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "aiter_artifact_id=${ARTIFACT_ID}" >> "$GITHUB_OUTPUT"
+  echo "aiter_workflow_artifact_id=${AITER_WORKFLOW_ARTIFACT_ID}" >> "$GITHUB_OUTPUT"
   echo "aiter_wheel_name=$(basename "$AITER_WHL")" >> "$GITHUB_OUTPUT"
 fi

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -382,7 +382,7 @@ jobs:
         env:
           SERVER_ARGS: ${{ matrix.cell.server_args }}
         run: |
-          if [ -d "/models" ]; then MODEL_DIR="/models/${{ matrix.cell.model_path }}"
+          if [ -n "${MODEL_HOST_ROOT:-}" ]; then MODEL_DIR="/models/${{ matrix.cell.model_path }}"
           else MODEL_DIR="${{ matrix.cell.model_path }}"; fi
 
           # cell.env_vars are already injected into the container env via
@@ -404,7 +404,7 @@ jobs:
         run: |
           set -uo pipefail  # no -e: allow per-config failure without aborting loop
 
-          if [ -d "/models" ]; then MODEL_DIR="/models/${{ matrix.cell.model_path }}"
+          if [ -n "${MODEL_HOST_ROOT:-}" ]; then MODEL_DIR="/models/${{ matrix.cell.model_path }}"
           else MODEL_DIR="${{ matrix.cell.model_path }}"; fi
 
           FAIL_COUNT=0

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -208,6 +208,9 @@ jobs:
             accuracy_test_threshold: 0.94
             runner: atom-mi355-8gpu-vllm-sgl-ci
     runs-on: ${{ matrix.runner }}
+    permissions:
+      actions: read
+      contents: read
     timeout-minutes: 180
     env:
       CONTAINER_NAME: atom_sglang_${{ strategy.job-index }}
@@ -265,10 +268,12 @@ jobs:
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Download aiter wheel
-        uses: actions/download-artifact@v8
-        with:
-          name: aiter-whl
-          path: aiter-whl
+        timeout-minutes: 30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AITER_WHEEL_DOWNLOAD_MODE: workflow_artifact
+          AITER_WORKFLOW_ARTIFACT_NAME: aiter-whl
+        run: bash .github/scripts/download_aiter_wheel.sh
 
       - name: Generate SGLANG overlay Dockerfile
         run: |

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -172,6 +172,9 @@ jobs:
         include: ${{ fromJson(needs.load-test-models.outputs.models_json || '[{"runner":"ubuntu-latest","model_name":"skip"}]') }}
     if: ${{ needs.ci-gate.outputs.should_run == 'true' && needs.download_aiter_wheel.result == 'success' && needs.load-test-models.result == 'success' }}
     runs-on: ${{ matrix.runner }}
+    permissions:
+      actions: read
+      contents: read
 
     env:
       CONTAINER_NAME: atom_test_${{ strategy.job-index }}
@@ -277,10 +280,13 @@ jobs:
           EOF
 
       - name: Download aiter wheel
-        uses: actions/download-artifact@v8
-        with:
-          name: aiter-whl
-          path: /tmp/aiter-whl
+        timeout-minutes: 30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AITER_WHEEL_DOWNLOAD_MODE: workflow_artifact
+          AITER_WORKFLOW_ARTIFACT_NAME: aiter-whl
+          AITER_WHEEL_OUTPUT_DIR: /tmp/aiter-whl
+        run: bash .github/scripts/download_aiter_wheel.sh
 
       - name: Set HF token for predownload runner
         if: matrix.runner == 'atom-mi355-8gpu.predownload' || matrix.runner == 'linux-atom-do-mi350x-8'

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -169,6 +169,9 @@ jobs:
             accuracy_test_threshold: 0.83
             runner: atom-mi355-8gpu-vllm-sgl-ci
     runs-on: ${{ matrix.runner }}
+    permissions:
+      actions: read
+      contents: read
     timeout-minutes: 180
     env:
       CONTAINER_NAME: atom_vllm_oot_${{ strategy.job-index }}
@@ -243,10 +246,12 @@ jobs:
           echo "=== End container engine diagnostics ==="
       
       - name: Download aiter wheel
-        uses: actions/download-artifact@v8
-        with:
-          name: aiter-whl
-          path: aiter-whl
+        timeout-minutes: 30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AITER_WHEEL_DOWNLOAD_MODE: workflow_artifact
+          AITER_WORKFLOW_ARTIFACT_NAME: aiter-whl
+        run: bash .github/scripts/download_aiter_wheel.sh
 
       - name: Generate OOT overlay Dockerfile
         run: |

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -157,7 +157,7 @@ jobs:
           EXTRA_LAUNCH_ARGS: ${{ inputs.extra_args }}
         run: |
           set -euo pipefail
-          if [ -d "/models" ]; then model_path="/models/${{ env.MODEL_PATH }}"
+          if [ -n "${MODEL_HOST_ROOT:-}" ]; then model_path="/models/${{ env.MODEL_PATH }}"
           else model_path="${{ env.MODEL_PATH }}"; fi
 
           # Launch via stdin so the container's bash parses the shell quoting in


### PR DESCRIPTION
## What

Support the new Crusoe runner model cache path for ATOM benchmark workflows.

- Detect model cache roots in this order: `/shared_nfs/huggingface_models`, `/models`, `/data/models`
- Mount the selected host cache root into containers as `/models`
- Use `MODEL_HOST_ROOT` to decide when benchmark and regression jobs should use local `/models/...` paths
- Preserve the existing fallback to HF model IDs when no host cache is available

## Why

The new cluster provisions HuggingFace models under `/shared_nfs/huggingface_models` instead of host `/models`. Mounting it as container `/models` keeps existing benchmark scripts and model paths unchanged.

## Test

- Parsed updated workflow/action YAML with PyYAML
- `actionlint` is not installed locally
