### PR TITLE
chore(benchmark): raise DPA/DPA-TBO conc_max to 2048, trim generic sweep

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -3,7 +3,7 @@
     {
       "isl": 1024,
       "osl": 1024,
-      "concurrency": [4, 8, 16, 32, 64, 128, 256, 512, 1024],
+      "concurrency": [4, 8, 16, 32, 64, 128, 256, 512],
       "random_range_ratio": 0.8
     },
     {
@@ -40,7 +40,7 @@
           "suffix": "-dpa",
           "extra_args": "--enable-dp-attention",
           "conc_min": 64,
-          "conc_max": 1024
+          "conc_max": 2048
         },
         {
           "label": "DPA TBO",
@@ -48,7 +48,7 @@
           "extra_args": "--enable-dp-attention --enable-tbo",
           "env_vars": "GPU_MAX_HW_QUEUES=5\nATOM_NUMA_BIND=1",
           "conc_min": 256,
-          "conc_max": 1024
+          "conc_max": 2048
         },
         {
           "label": "DPA MTP3",


### PR DESCRIPTION
## Summary
Tune the benchmark matrix (`.github/benchmark/models.json`):

- **DPA** tier: `conc_max` 1024 → **2048**
- **DPA TBO** tier: `conc_max` 1024 → **2048**
- Generic isl1024/osl1024 sweep: drop the trailing **1024** concurrency point (now `[4,8,16,32,64,128,256,512]`)

Extends dp-attention throughput coverage to higher concurrency while trimming the redundant top point on the generic sweep.

## Test plan
- [ ] Benchmark CI picks up the new matrix (config-only change, no code paths touched)