### PR TITLE
Drop stale GLM5.2 AITER JIT artifacts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -270,6 +270,12 @@ RUN echo "========== [SGLANG-ATOM 4/6] Restore base image Triton ==========" && 
     "${VENV_PYTHON}" -c "import triton; print(f'triton.__version__ = {triton.__version__}')" && \
     "${VENV_PYTHON}" -m pip show triton
 
+RUN echo "========== [SGLANG-ATOM] Drop stale GLM-5.2 AITER JIT artifacts ==========" && \
+    if [ -d /app/aiter-test/aiter/jit ]; then \
+      rm -f /app/aiter-test/aiter/jit/module_moe_ck2stages_f8_f8_preshuffle_on_b16_silu_per_token_mulWeightStage2.so && \
+      rm -rf /app/aiter-test/aiter/jit/build/module_moe_ck2stages_f8_f8_preshuffle_on_b16_silu_per_token_mulWeightStage2; \
+    fi
+
 RUN echo "========== [SGLANG-ATOM 5/6] Validate vision/audio wheels ==========" && \
     "${VENV_PYTHON}" -m sglang.launch_server --help >/dev/null && \
     "${VENV_PYTHON}" -c "import os, torch, torchvision, torchaudio, sglang, triton, transformers; from torchvision.io import decode_jpeg; assert torch.version.hip is not None, 'Torch is not ROCm build (torch.version.hip is None).'; print(f'torch: {torch.__version__}'); print(f'triton: {triton.__version__}'); print(f'transformers: {transformers.__version__}'); print(f'torchvision: {torchvision.__version__}'); print(f'torchaudio: {torchaudio.__version__}'); print(f'decode_jpeg: {decode_jpeg.__name__}'); print(f'sglang imported from: {sglang.__file__}'); print(f'PYTHONPATH={os.environ.get(\"PYTHONPATH\", \"\")}')" && \


### PR DESCRIPTION
## Motivation
Fix GLM-5.2 SGLang startup failures caused by stale AITER JIT artifacts baked into the image.

```
File "/app/aiter-test/aiter/ops/moe_op.py", line 597, in ck_moe_stage2_fwd
    ck_moe_stage2(...)
RuntimeError: Unsupported block_m value for moe heuristic dispatch: 16
Exception: Capture cuda graph failed: ...
```

## Technical Details
This PR removes the stale GLM-5.2 MoE b16 AITER JIT .so and its build directory during image build for both atom_sglang and atom_image. This forces AITER to regenerate the kernel from the current source at runtime, avoiding Unsupported block_m value for moe heuristic dispatch: 16.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
