### PR TITLE
[fea](req): change transformers version to 5.12.1

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -579,6 +579,7 @@ _CONFIG_REGISTRY: dict[str, str] = {
     # through as extra config attrs and are read in DeepseekV4Args.from_hf_config.
     "glm_moe_dsa": "deepseek_v3",  # GLM 5.0 MoE, structure similar to DeepSeek v3.2
     "kimi_k2": "deepseek_v3",
+    "qwen3_next": "qwen3_next",
 }
 
 

--- a/docker/atom_release.dockerfile
+++ b/docker/atom_release.dockerfile
@@ -244,8 +244,9 @@ RUN if [ "${INSTALL_SA_AIPERF}" = "1" ]; then \
         git clone https://github.com/SemiAnalysisAI/aiperf.git /opt/aiperf && \
         cd /opt/aiperf && \
         git checkout "${SA_AIPERF_COMMIT}" && \
+        sed -i '/^[[:space:]]*"transformers @ git+/d' pyproject.toml && \
+        ! grep -q '^[[:space:]]*"transformers @ git+' pyproject.toml && \
         "${VENV_PYTHON}" -m pip install -e . && \
-        "${VENV_PYTHON}" -m pip install --no-cache-dir "transformers==5.2.0" && \
         "${VENV_PYTHON}" -c "import transformers; print(f'transformers.__version__ = {transformers.__version__}')" && \
         "${VENV_PYTHON}" -m pip show aiperf || true && \
         command -v aiperf && aiperf --help >/dev/null; \

--- a/docker/sglang_release.dockerfile
+++ b/docker/sglang_release.dockerfile
@@ -85,6 +85,7 @@ RUN echo "========== [SGLANG-ATOM 3/6] Install SGLang dependencies ==========" &
       "cython>=0.29.36,<3.0" \
       "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@37d0485b2058885bf4e7a486f7d7b2174a8ac1ce" \
       "z3-solver==4.15.4.0" && \
+    "${VENV_PYTHON}" -m pip install --no-cache-dir "transformers==5.2.0" && \
     rm -f /tmp/sglang-runtime-common.txt && \
     "${VENV_PYTHON}" -m pip show sglang torch triton transformers IPython orjson pybase64 petit-kernel wave-lang xgrammar outlines apache-tvm-ffi || true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "a lightweight vLLM implementation built from scratch"
 requires-python = ">=3.10"
 dynamic = ["version"]
-dependencies = ["pybind11", "transformers==5.2.0", "zmq", "msgspec", "xxhash", "fastapi>=0.115,<0.137", "psutil", "protobuf", "uvicorn", "uvloop", "aiohttp", "datasets", "openpyxl", "tqdm", "setproctitle"]
+dependencies = ["pybind11", "transformers==5.12.1", "zmq", "msgspec", "xxhash", "fastapi>=0.115,<0.137", "psutil", "protobuf", "uvicorn", "uvloop", "aiohttp", "datasets", "openpyxl", "tqdm", "setproctitle"]
 
 [project.urls]
 Homepage = "https://github.com/ROCm/ATOM"

--- a/tests/test_quant_config.py
+++ b/tests/test_quant_config.py
@@ -755,3 +755,27 @@ class TestConvenienceProperties:
         assert qcfg.quant_type == QuantType.per_Token
         assert qcfg.quant_dtype == FP8
         assert qcfg.is_dynamic is True
+
+
+def test_get_hf_config_restores_qwen3_next_full_attention_interval(monkeypatch):
+    hf = FakeHFConfig(model_type="qwen3_next")
+    config_dict = {
+        "model_type": "qwen3_next",
+        "full_attention_interval": 4,
+    }
+    config_class = MagicMock()
+    config_class.from_pretrained.return_value = hf
+    monkeypatch.setattr(
+        _m.PretrainedConfig,
+        "get_config_dict",
+        staticmethod(lambda _model: (config_dict, {})),
+    )
+    monkeypatch.setattr(
+        _m.AutoConfig,
+        "for_model",
+        MagicMock(return_value=config_class),
+    )
+
+    result = _m.get_hf_config("Qwen/Qwen3-Next-80B-A3B-Thinking")
+
+    assert result.full_attention_interval == 4


### PR DESCRIPTION
## Motivation

This PR updates ATOM’s Transformers requirement to 5.12.1. It excludes only aiperf’s Transformers dependency to prevent it from pulling the latest version, while SGLang remains pinned to 5.2.0 until upgraded.
