### PR TITLE
[sglang plugin] Fix SGLang DSV4 fp8 KV cache binding

### DIFF
--- a/atom/plugin/sglang/deepseek_v4_bridge.py
+++ b/atom/plugin/sglang/deepseek_v4_bridge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from types import SimpleNamespace
 from typing import Any, Optional
@@ -8,12 +9,10 @@ import numpy as np
 import torch
 
 ATOM_DEEPSEEK_V4_BLOCK_SIZE = 128
-try:
-    from atom.model_ops.v4_kernels.v4_quant import (
-        V4_DIM_QK_PACKED as ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
-    )
-except Exception:  # pragma: no cover - import fallback for partial runtime envs
-    ATOM_DEEPSEEK_V4_FP8_PACKED_DIM = 512
+_V4_FP8_SUPPORTED_GFX = ("gfx950", "gfx1250")
+_V4_FP8_DOWNGRADE_WARNED = False
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_v4_index_topk(model: Any = None, proxy_pool: Any = None) -> int:
@@ -86,13 +85,27 @@ def _is_fp8_dtype(dtype: Any) -> bool:
     return "float8" in dtype_name or "fp8" in dtype_name or "e4m3" in dtype_name
 
 
-def _supports_dsv4_fp8_2buff() -> bool:
+def _get_gfx_name() -> Optional[str]:
     try:
         from aiter.jit.utils.chip_info import get_gfx
 
-        return get_gfx() in ("gfx950", "gfx1250")
+        return get_gfx()
     except Exception:
-        return False
+        return None
+
+
+def _warn_dsv4_fp8_downgrade(gfx: Optional[str]) -> None:
+    global _V4_FP8_DOWNGRADE_WARNED
+    if _V4_FP8_DOWNGRADE_WARNED:
+        return
+    _V4_FP8_DOWNGRADE_WARNED = True
+    logger.warning(
+        "DeepSeek-V4 fp8 KV cache was requested, but native 2-buffer fp8 "
+        "kernels are only supported on %s (current arch: %s); falling back to "
+        "the bf16 proxy KV layout.",
+        "/".join(_V4_FP8_SUPPORTED_GFX),
+        gfx or "unknown",
+    )
 
 
 def _resolve_sglang_spec_steps() -> int:
@@ -166,8 +179,11 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
                 pass
         # aiter DSV4 native 2-buffer fp8 op4/op5 kernels are only available on
         # gfx950/gfx1250. Keep unsupported GPUs on the bf16 layout.
-        if self.use_fp8_kv and not _supports_dsv4_fp8_2buff():
-            self.use_fp8_kv = False
+        if self.use_fp8_kv:
+            gfx = _get_gfx_name()
+            if gfx not in _V4_FP8_SUPPORTED_GFX:
+                _warn_dsv4_fp8_downgrade(gfx)
+                self.use_fp8_kv = False
         del c4_state_pool_size, c128_state_pool_size, dtype, state_dtype
         del enable_memory_saver, enable_hisparse
 
@@ -233,38 +249,19 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
         self.is_atom_v4_proxy_pool = True
 
     def _compute_raw_bytes(self) -> int:
+        entry_bytes = (
+            self.head_dim + self.qk_rope_head_dim * 2
+            if self.use_fp8_kv
+            else self.head_dim * 2
+        )
         total = 0
-        if self.use_fp8_kv:
-            swa_bytes = (
-                self.num_slots
-                * self.swa_cache_size
-                * (ATOM_DEEPSEEK_V4_FP8_PACKED_DIM + self.qk_rope_head_dim * 2)
-            )
-        else:
-            swa_bytes = self.num_slots * self.swa_cache_size * self.head_dim * 2
+        swa_bytes = self.num_slots * self.swa_cache_size * entry_bytes
         for ratio in self.stage_ratios:
             total += swa_bytes
+            k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // ratio if ratio in (4, 128) else 0
+            total += self.num_blocks * k * entry_bytes
             if ratio == 4:
-                k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // 4
-                if self.use_fp8_kv:
-                    total += (
-                        self.num_blocks
-                        * k
-                        * (ATOM_DEEPSEEK_V4_FP8_PACKED_DIM + self.qk_rope_head_dim * 2)
-                    )
-                else:
-                    total += self.num_blocks * k * self.head_dim * 2
                 total += self.num_blocks * k * self.index_dim
-            elif ratio == 128:
-                k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // 128
-                if self.use_fp8_kv:
-                    total += (
-                        self.num_blocks
-                        * k
-                        * (ATOM_DEEPSEEK_V4_FP8_PACKED_DIM + self.qk_rope_head_dim * 2)
-                    )
-                else:
-                    total += self.num_blocks * k * self.head_dim * 2
         return max(1, total)
 
     def _take(self, offset: int, nbytes: int) -> torch.Tensor:
@@ -294,77 +291,70 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
         hca_main: list[torch.Tensor] = []
         hca_main_rope: list[Optional[torch.Tensor]] = []
 
+        nope_dtype = fp8_dtype if self.use_fp8_kv else torch.bfloat16
+        nope_width = self.head_dim
+        nope_elt = 1 if self.use_fp8_kv else 2
+
+        def take_bytes(nbytes: int) -> torch.Tensor:
+            nonlocal offset
+            out = self._take(offset, nbytes)
+            offset += nbytes
+            return out
+
         for ratio in self.stage_ratios:
-            if self.use_fp8_kv:
-                k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // ratio if ratio in (4, 128) else 0
-                num_pages = self.num_slots * self.swa_cache_size + self.num_blocks * k
+            k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // ratio if ratio in (4, 128) else 0
+            num_swa_pages = self.num_slots * self.swa_cache_size
+            num_pages = num_swa_pages + self.num_blocks * k
 
-                nope_start = offset
-                swa_nope_bytes = (
-                    self.num_slots
-                    * self.swa_cache_size
-                    * ATOM_DEEPSEEK_V4_FP8_PACKED_DIM
-                )
-                swa_view = (
-                    self._take(offset, swa_nope_bytes)
-                    .view(fp8_dtype)
-                    .view(
-                        self.num_slots,
-                        self.swa_cache_size,
-                        ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
+            nope_start = offset
+            swa_view = (
+                take_bytes(num_swa_pages * nope_width * nope_elt)
+                .view(nope_dtype)
+                .view(self.num_slots, self.swa_cache_size, nope_width)
+            )
+            swa.append(swa_view)
+
+            main_view = None
+            if k:
+                main_view = (
+                    take_bytes(self.num_blocks * k * nope_width * nope_elt)
+                    .view(nope_dtype)
+                    .as_strided(
+                        size=(self.num_blocks, k, nope_width),
+                        stride=(k * nope_width, nope_width, 1),
                     )
                 )
-                offset += swa_nope_bytes
-
-                main_view = None
-                if ratio in (4, 128):
-                    main_nope_bytes = (
-                        self.num_blocks * k * ATOM_DEEPSEEK_V4_FP8_PACKED_DIM
-                    )
-                    main_view = (
-                        self._take(offset, main_nope_bytes)
-                        .view(fp8_dtype)
-                        .as_strided(
-                            size=(
-                                self.num_blocks,
-                                k,
-                                ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
-                            ),
-                            stride=(
-                                k * ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
-                                ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
-                                1,
-                            ),
-                        )
-                    )
-                    offset += main_nope_bytes
-
                 unified.append(
                     self.raw_arena[nope_start:offset]
-                    .view(fp8_dtype)
-                    .view(num_pages, ATOM_DEEPSEEK_V4_FP8_PACKED_DIM)
+                    .view(nope_dtype)
+                    .view(num_pages, nope_width)
                 )
+            else:
+                unified.append(swa_view.view(num_swa_pages, nope_width))
 
-                rope_start = offset
-                swa_rope_bytes = (
-                    self.num_slots * self.swa_cache_size * self.qk_rope_head_dim * 2
-                )
-                swa_rope_view = (
-                    self._take(offset, swa_rope_bytes)
-                    .view(torch.bfloat16)
-                    .view(
-                        self.num_slots,
-                        self.swa_cache_size,
-                        self.qk_rope_head_dim,
+            if ratio == 4:
+                idx = (
+                    take_bytes(self.num_blocks * k * self.index_dim)
+                    .view(fp8_dtype)
+                    .as_strided(
+                        size=(self.num_blocks, k, self.index_dim),
+                        stride=(k * self.index_dim, self.index_dim, 1),
                     )
                 )
-                offset += swa_rope_bytes
+                csa_indexer.append(idx)
 
-                main_rope_view = None
-                if ratio in (4, 128):
-                    main_rope_bytes = self.num_blocks * k * self.qk_rope_head_dim * 2
+            main_rope_view = None
+            if self.use_fp8_kv:
+                rope_start = offset
+                swa_rope_view = (
+                    take_bytes(num_swa_pages * self.qk_rope_head_dim * 2)
+                    .view(torch.bfloat16)
+                    .view(self.num_slots, self.swa_cache_size, self.qk_rope_head_dim)
+                )
+                swa_rope.append(swa_rope_view)
+                if k:
                     main_rope_view = (
-                        self._take(offset, main_rope_bytes)
+                        take_bytes(self.num_blocks * k * self.qk_rope_head_dim * 2)
                         .view(torch.bfloat16)
                         .as_strided(
                             size=(self.num_blocks, k, self.qk_rope_head_dim),
@@ -375,112 +365,25 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
                             ),
                         )
                     )
-                    offset += main_rope_bytes
-
-                unified_rope.append(
-                    self.raw_arena[rope_start:offset]
-                    .view(torch.bfloat16)
-                    .view(num_pages, self.qk_rope_head_dim)
-                )
-                swa.append(swa_view)
-                swa_rope.append(swa_rope_view)
-
-                if ratio == 4:
-                    assert main_view is not None
-                    assert main_rope_view is not None
-                    idx_bytes = self.num_blocks * k * self.index_dim
-                    idx = (
-                        self._take(offset, idx_bytes)
-                        .view(fp8_dtype)
-                        .as_strided(
-                            size=(self.num_blocks, k, self.index_dim),
-                            stride=(k * self.index_dim, self.index_dim, 1),
-                        )
+                    unified_rope.append(
+                        self.raw_arena[rope_start:offset]
+                        .view(torch.bfloat16)
+                        .view(num_pages, self.qk_rope_head_dim)
                     )
-                    offset += idx_bytes
-                    csa_main.append(main_view)
-                    csa_main_rope.append(main_rope_view)
-                    csa_indexer.append(idx)
-                elif ratio == 128:
-                    assert main_view is not None
-                    assert main_rope_view is not None
-                    hca_main.append(main_view)
-                    hca_main_rope.append(main_rope_view)
-                continue
-
-            layer_start = offset
-            swa_bytes = self.num_slots * self.swa_cache_size * self.head_dim * 2
-            swa_view = (
-                self._take(offset, swa_bytes)
-                .view(torch.bfloat16)
-                .view(self.num_slots, self.swa_cache_size, self.head_dim)
-            )
-            offset += swa_bytes
-            swa.append(swa_view)
-            swa_rope.append(None)
+                else:
+                    unified_rope.append(
+                        swa_rope_view.view(num_swa_pages, self.qk_rope_head_dim)
+                    )
+            else:
+                swa_rope.append(None)
+                unified_rope.append(None)
 
             if ratio == 4:
-                k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // 4
-                main_bytes = self.num_blocks * k * self.head_dim * 2
-                main = (
-                    self._take(offset, main_bytes)
-                    .view(torch.bfloat16)
-                    .as_strided(
-                        size=(self.num_blocks, k, self.head_dim),
-                        stride=(k * self.head_dim, self.head_dim, 1),
-                    )
-                )
-                offset += main_bytes
-                unified.append(
-                    self.raw_arena[layer_start:offset]
-                    .view(torch.bfloat16)
-                    .view(
-                        self.num_slots * self.swa_cache_size + self.num_blocks * k,
-                        self.head_dim,
-                    )
-                )
-                unified_rope.append(None)
-                idx_bytes = self.num_blocks * k * self.index_dim
-                idx = (
-                    self._take(offset, idx_bytes)
-                    .view(fp8_dtype)
-                    .as_strided(
-                        size=(self.num_blocks, k, self.index_dim),
-                        stride=(k * self.index_dim, self.index_dim, 1),
-                    )
-                )
-                offset += idx_bytes
-                csa_main.append(main)
-                csa_main_rope.append(None)
-                csa_indexer.append(idx)
+                csa_main.append(main_view)
+                csa_main_rope.append(main_rope_view)
             elif ratio == 128:
-                k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // 128
-                main_bytes = self.num_blocks * k * self.head_dim * 2
-                main = (
-                    self._take(offset, main_bytes)
-                    .view(torch.bfloat16)
-                    .as_strided(
-                        size=(self.num_blocks, k, self.head_dim),
-                        stride=(k * self.head_dim, self.head_dim, 1),
-                    )
-                )
-                offset += main_bytes
-                unified.append(
-                    self.raw_arena[layer_start:offset]
-                    .view(torch.bfloat16)
-                    .view(
-                        self.num_slots * self.swa_cache_size + self.num_blocks * k,
-                        self.head_dim,
-                    )
-                )
-                unified_rope.append(None)
-                hca_main.append(main)
-                hca_main_rope.append(None)
-            else:
-                unified.append(
-                    swa_view.view(self.num_slots * self.swa_cache_size, self.head_dim)
-                )
-                unified_rope.append(None)
+                hca_main.append(main_view)
+                hca_main_rope.append(main_rope_view)
 
         return {
             "unified": unified,
@@ -768,6 +671,7 @@ def bind_deepseek_v4_proxy_cache_views(model, proxy_pool: Any) -> bool:
         window_size=proxy_pool.window_size,
         cs=proxy_pool.swa_cache_size,
         index_topk=index_topk,
+        kv_fp8=bool(proxy_pool.use_fp8_kv),
     )
     return True
 
@@ -1409,6 +1313,8 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
     md.swa_cs = proxy_pool.swa_cache_size
     md.index_topk = index_topk
     md.swa_pages = proxy_pool.num_slots * proxy_pool.swa_cache_size
+    md.qo_indptr = None
+    md.kv_last_page_lens = None
 
     if total:
         if positions_numel > scheduled_bs:
@@ -1524,7 +1430,8 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
     md.kv_indptr_swa = swa_indptr
     md.kv_indptr_csa = csa_indptr
     md.kv_indptr_hca = hca_indptr
-    _stage_decode_fp8_page_metadata(md, total, t_pad, bufs=bufs)
+    if proxy_pool.use_fp8_kv:
+        _stage_decode_fp8_page_metadata(md, total, t_pad, bufs=bufs)
     cu_committed_cpu = np.concatenate(
         [
             np.zeros(1, dtype=np.int32),
@@ -1925,6 +1832,8 @@ def build_atom_v4_attention_metadata_from_sglang(
     md.swa_cs = proxy_pool.swa_cache_size
     md.index_topk = index_topk
     md.swa_pages = proxy_pool.num_slots * proxy_pool.swa_cache_size
+    md.qo_indptr = None
+    md.kv_last_page_lens = None
 
     if is_draft_extend:
         slot_arr = np.full(num_reqs, -1, dtype=np.int32)
@@ -1969,7 +1878,8 @@ def build_atom_v4_attention_metadata_from_sglang(
 
     if is_decode:
         _populate_decode_indices(md, block_tables, pos_np, device)
-        _stage_decode_fp8_page_metadata(md, total, total)
+        if proxy_pool.use_fp8_kv:
+            _stage_decode_fp8_page_metadata(md, total, total)
     else:
         _populate_prefill_indices(md, block_tables, batch_np, pos_np, q_np, device)
     _populate_indexer(md, batch_np, positions[:total], device)

--- a/atom/plugin/sglang/deepseek_v4_bridge.py
+++ b/atom/plugin/sglang/deepseek_v4_bridge.py
@@ -8,6 +8,12 @@ import numpy as np
 import torch
 
 ATOM_DEEPSEEK_V4_BLOCK_SIZE = 128
+try:
+    from atom.model_ops.v4_kernels.v4_quant import (
+        V4_DIM_QK_PACKED as ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
+    )
+except Exception:  # pragma: no cover - import fallback for partial runtime envs
+    ATOM_DEEPSEEK_V4_FP8_PACKED_DIM = 512
 
 
 def _resolve_v4_index_topk(model: Any = None, proxy_pool: Any = None) -> int:
@@ -75,6 +81,20 @@ def _layer_counts(compress_ratios) -> tuple[list[int], int, int, int]:
     return ratios, dense, csa, hca
 
 
+def _is_fp8_dtype(dtype: Any) -> bool:
+    dtype_name = str(dtype).lower()
+    return "float8" in dtype_name or "fp8" in dtype_name or "e4m3" in dtype_name
+
+
+def _supports_dsv4_fp8_2buff() -> bool:
+    try:
+        from aiter.jit.utils.chip_info import get_gfx
+
+        return get_gfx() in ("gfx950", "gfx1250")
+    except Exception:
+        return False
+
+
 def _resolve_sglang_spec_steps() -> int:
     try:
         from sglang.srt.server_args import get_global_server_args
@@ -133,6 +153,21 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
         end_layer: Optional[int] = None,
         enable_hisparse: bool = False,
     ) -> None:
+        self.use_fp8_kv = _is_fp8_dtype(dtype) or _is_fp8_dtype(state_dtype)
+        if not self.use_fp8_kv:
+            try:
+                from atom.config import get_current_atom_config
+
+                atom_config = get_current_atom_config()
+                self.use_fp8_kv = _is_fp8_dtype(
+                    getattr(atom_config, "kv_cache_dtype", None)
+                )
+            except Exception:
+                pass
+        # aiter DSV4 native 2-buffer fp8 op4/op5 kernels are only available on
+        # gfx950/gfx1250. Keep unsupported GPUs on the bf16 layout.
+        if self.use_fp8_kv and not _supports_dsv4_fp8_2buff():
+            self.use_fp8_kv = False
         del c4_state_pool_size, c128_state_pool_size, dtype, state_dtype
         del enable_memory_saver, enable_hisparse
 
@@ -154,6 +189,14 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
         self.qk_nope_head_dim = int(qk_nope_head_dim)
         self.qk_rope_head_dim = int(qk_rope_head_dim)
         self.head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        if self.use_fp8_kv and (
+            self.qk_nope_head_dim <= 0 or self.qk_rope_head_dim <= 0
+        ):
+            raise ValueError(
+                "DeepSeek-V4 fp8 proxy KV pool requires positive "
+                f"qk_nope_head_dim/qk_rope_head_dim, got "
+                f"{self.qk_nope_head_dim}/{self.qk_rope_head_dim}"
+            )
         self.indexer_head_dim = int(indexer_head_dim)
         self.index_dim = _aligned_index_dim(self.indexer_head_dim)
         self.compression_ratios = [int(r) for r in compression_ratios]
@@ -191,16 +234,37 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
 
     def _compute_raw_bytes(self) -> int:
         total = 0
-        swa_bytes = self.num_slots * self.swa_cache_size * self.head_dim * 2
+        if self.use_fp8_kv:
+            swa_bytes = (
+                self.num_slots
+                * self.swa_cache_size
+                * (ATOM_DEEPSEEK_V4_FP8_PACKED_DIM + self.qk_rope_head_dim * 2)
+            )
+        else:
+            swa_bytes = self.num_slots * self.swa_cache_size * self.head_dim * 2
         for ratio in self.stage_ratios:
             total += swa_bytes
             if ratio == 4:
                 k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // 4
-                total += self.num_blocks * k * self.head_dim * 2
+                if self.use_fp8_kv:
+                    total += (
+                        self.num_blocks
+                        * k
+                        * (ATOM_DEEPSEEK_V4_FP8_PACKED_DIM + self.qk_rope_head_dim * 2)
+                    )
+                else:
+                    total += self.num_blocks * k * self.head_dim * 2
                 total += self.num_blocks * k * self.index_dim
             elif ratio == 128:
                 k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // 128
-                total += self.num_blocks * k * self.head_dim * 2
+                if self.use_fp8_kv:
+                    total += (
+                        self.num_blocks
+                        * k
+                        * (ATOM_DEEPSEEK_V4_FP8_PACKED_DIM + self.qk_rope_head_dim * 2)
+                    )
+                else:
+                    total += self.num_blocks * k * self.head_dim * 2
         return max(1, total)
 
     def _take(self, offset: int, nbytes: int) -> torch.Tensor:
@@ -221,12 +285,129 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
 
         offset = 0
         unified: list[torch.Tensor] = []
+        unified_rope: list[Optional[torch.Tensor]] = []
         swa: list[torch.Tensor] = []
+        swa_rope: list[Optional[torch.Tensor]] = []
         csa_main: list[torch.Tensor] = []
+        csa_main_rope: list[Optional[torch.Tensor]] = []
         csa_indexer: list[torch.Tensor] = []
         hca_main: list[torch.Tensor] = []
+        hca_main_rope: list[Optional[torch.Tensor]] = []
 
         for ratio in self.stage_ratios:
+            if self.use_fp8_kv:
+                k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // ratio if ratio in (4, 128) else 0
+                num_pages = self.num_slots * self.swa_cache_size + self.num_blocks * k
+
+                nope_start = offset
+                swa_nope_bytes = (
+                    self.num_slots
+                    * self.swa_cache_size
+                    * ATOM_DEEPSEEK_V4_FP8_PACKED_DIM
+                )
+                swa_view = (
+                    self._take(offset, swa_nope_bytes)
+                    .view(fp8_dtype)
+                    .view(
+                        self.num_slots,
+                        self.swa_cache_size,
+                        ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
+                    )
+                )
+                offset += swa_nope_bytes
+
+                main_view = None
+                if ratio in (4, 128):
+                    main_nope_bytes = (
+                        self.num_blocks * k * ATOM_DEEPSEEK_V4_FP8_PACKED_DIM
+                    )
+                    main_view = (
+                        self._take(offset, main_nope_bytes)
+                        .view(fp8_dtype)
+                        .as_strided(
+                            size=(
+                                self.num_blocks,
+                                k,
+                                ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
+                            ),
+                            stride=(
+                                k * ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
+                                ATOM_DEEPSEEK_V4_FP8_PACKED_DIM,
+                                1,
+                            ),
+                        )
+                    )
+                    offset += main_nope_bytes
+
+                unified.append(
+                    self.raw_arena[nope_start:offset]
+                    .view(fp8_dtype)
+                    .view(num_pages, ATOM_DEEPSEEK_V4_FP8_PACKED_DIM)
+                )
+
+                rope_start = offset
+                swa_rope_bytes = (
+                    self.num_slots * self.swa_cache_size * self.qk_rope_head_dim * 2
+                )
+                swa_rope_view = (
+                    self._take(offset, swa_rope_bytes)
+                    .view(torch.bfloat16)
+                    .view(
+                        self.num_slots,
+                        self.swa_cache_size,
+                        self.qk_rope_head_dim,
+                    )
+                )
+                offset += swa_rope_bytes
+
+                main_rope_view = None
+                if ratio in (4, 128):
+                    main_rope_bytes = self.num_blocks * k * self.qk_rope_head_dim * 2
+                    main_rope_view = (
+                        self._take(offset, main_rope_bytes)
+                        .view(torch.bfloat16)
+                        .as_strided(
+                            size=(self.num_blocks, k, self.qk_rope_head_dim),
+                            stride=(
+                                k * self.qk_rope_head_dim,
+                                self.qk_rope_head_dim,
+                                1,
+                            ),
+                        )
+                    )
+                    offset += main_rope_bytes
+
+                unified_rope.append(
+                    self.raw_arena[rope_start:offset]
+                    .view(torch.bfloat16)
+                    .view(num_pages, self.qk_rope_head_dim)
+                )
+                swa.append(swa_view)
+                swa_rope.append(swa_rope_view)
+
+                if ratio == 4:
+                    assert main_view is not None
+                    assert main_rope_view is not None
+                    idx_bytes = self.num_blocks * k * self.index_dim
+                    idx = (
+                        self._take(offset, idx_bytes)
+                        .view(fp8_dtype)
+                        .as_strided(
+                            size=(self.num_blocks, k, self.index_dim),
+                            stride=(k * self.index_dim, self.index_dim, 1),
+                        )
+                    )
+                    offset += idx_bytes
+                    csa_main.append(main_view)
+                    csa_main_rope.append(main_rope_view)
+                    csa_indexer.append(idx)
+                elif ratio == 128:
+                    assert main_view is not None
+                    assert main_rope_view is not None
+                    hca_main.append(main_view)
+                    hca_main_rope.append(main_rope_view)
+                continue
+
             layer_start = offset
             swa_bytes = self.num_slots * self.swa_cache_size * self.head_dim * 2
             swa_view = (
@@ -236,6 +417,7 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
             )
             offset += swa_bytes
             swa.append(swa_view)
+            swa_rope.append(None)
 
             if ratio == 4:
                 k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // 4
@@ -257,6 +439,7 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
                         self.head_dim,
                     )
                 )
+                unified_rope.append(None)
                 idx_bytes = self.num_blocks * k * self.index_dim
                 idx = (
                     self._take(offset, idx_bytes)
@@ -268,6 +451,7 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
                 )
                 offset += idx_bytes
                 csa_main.append(main)
+                csa_main_rope.append(None)
                 csa_indexer.append(idx)
             elif ratio == 128:
                 k = ATOM_DEEPSEEK_V4_BLOCK_SIZE // 128
@@ -289,18 +473,25 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
                         self.head_dim,
                     )
                 )
+                unified_rope.append(None)
                 hca_main.append(main)
+                hca_main_rope.append(None)
             else:
                 unified.append(
                     swa_view.view(self.num_slots * self.swa_cache_size, self.head_dim)
                 )
+                unified_rope.append(None)
 
         return {
             "unified": unified,
+            "unified_rope": unified_rope,
             "swa": swa,
+            "swa_rope": swa_rope,
             "csa_main": csa_main,
+            "csa_main_rope": csa_main_rope,
             "csa_indexer": csa_indexer,
             "hca_main": hca_main,
+            "hca_main_rope": hca_main_rope,
         }
 
     def register_mapping(self, full_to_swa_index_mapping: torch.Tensor) -> None:
@@ -348,7 +539,9 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
         return torch.unique(pairs.cpu(), dim=0)
 
     @staticmethod
-    def _copy_block_views(views: list[torch.Tensor], block_pairs: torch.Tensor) -> None:
+    def _copy_block_views(
+        views: list[Optional[torch.Tensor]], block_pairs: torch.Tensor
+    ) -> None:
         """Copy compressed KV blocks between proxy views during radix relocation."""
         if not views or block_pairs.numel() == 0:
             return
@@ -356,6 +549,8 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
         tgt_blocks = block_pairs[:, 0]
         src_blocks = block_pairs[:, 1]
         for view in views:
+            if view is None:
+                continue
             num_blocks = int(view.shape[0])
             valid = (
                 (src_blocks >= 0)
@@ -410,8 +605,10 @@ class ATOMDeepSeekV4ProxyKVPool(BaseSWAKVPool):
         # compressed history by 128-token blocks, while SWA history lives in a
         # per-request state slot keyed by the request's first block.
         self._copy_block_views(self.views["csa_main"], block_pairs)
+        self._copy_block_views(self.views["csa_main_rope"], block_pairs)
         self._copy_block_views(self.views["csa_indexer"], block_pairs)
         self._copy_block_views(self.views["hca_main"], block_pairs)
+        self._copy_block_views(self.views["hca_main_rope"], block_pairs)
 
         allocator = getattr(self, "_atom_v4_slot_allocator", None)
         if allocator is not None:
@@ -443,6 +640,7 @@ def _bind_compressor_state(
     *,
     is_indexer: bool = False,
     head_dim: Optional[int] = None,
+    kv_cache_rope: Optional[torch.Tensor] = None,
 ) -> None:
     compressor.kv_state = torch.zeros(
         (num_slots, *compressor.kv_state.shape[1:]),
@@ -456,6 +654,7 @@ def _bind_compressor_state(
         device=kv_cache.device,
     )
     compressor.kv_cache = kv_cache
+    compressor.kv_cache_rope = kv_cache_rope
     if is_indexer:
         nb, k1, aligned_dim = kv_cache.shape
         if head_dim is None:
@@ -471,8 +670,12 @@ def _bind_compressor_state(
                 storage_offset=scale_fp32_offset,
             )
         )
+        compressor.write_mode = "indexer_fp8"
     else:
         compressor.cache_scale = None
+        compressor.write_mode = (
+            "main_2buff_fp8" if kv_cache_rope is not None else "bf16"
+        )
 
 
 def _iter_deepseek_v4_cache_blocks(model):
@@ -509,6 +712,8 @@ def bind_deepseek_v4_proxy_cache_views(model, proxy_pool: Any) -> bool:
         attn = block.attn
         ratio = int(attn.compress_ratio)
         attn.unified_kv = proxy_pool.views["unified"][local_layer_id]
+        attn.unified_kv_rope = proxy_pool.views["unified_rope"][local_layer_id]
+        attn.kv_fp8 = bool(proxy_pool.use_fp8_kv)
         # paged SWA ABI (#1423): the shared _attn_core / swa_write treat swa_kv as
         # a flat [pages, head_dim] region content-addressed by swa_block_tables.
         # Plugin keeps the ring pool but exposes it flat with block_size = cs, so
@@ -516,6 +721,12 @@ def bind_deepseek_v4_proxy_cache_views(model, proxy_pool: Any) -> bool:
         # `slot*cs + pos%cs`. See _build_swa_ring_block_tables.
         swa_view = proxy_pool.views["swa"][local_layer_id]
         attn.swa_kv = swa_view.reshape(-1, swa_view.shape[-1])
+        swa_rope_view = proxy_pool.views["swa_rope"][local_layer_id]
+        attn.swa_kv_rope = (
+            swa_rope_view.reshape(-1, swa_rope_view.shape[-1])
+            if swa_rope_view is not None
+            else None
+        )
         attn.swa_block_size = proxy_pool.swa_cache_size
         if ratio == 4:
             indexer_topk = int(attn.indexer.index_topk)
@@ -528,6 +739,7 @@ def bind_deepseek_v4_proxy_cache_views(model, proxy_pool: Any) -> bool:
                 attn.compressor,
                 proxy_pool.views["csa_main"][csa_i],
                 proxy_pool.num_slots,
+                kv_cache_rope=proxy_pool.views["csa_main_rope"][csa_i],
             )
             attn.indexer.kv_cache = proxy_pool.views["csa_indexer"][csa_i]
             attn.indexer._max_model_len_idx = max(
@@ -546,6 +758,7 @@ def bind_deepseek_v4_proxy_cache_views(model, proxy_pool: Any) -> bool:
                 attn.compressor,
                 proxy_pool.views["hca_main"][hca_i],
                 proxy_pool.num_slots,
+                kv_cache_rope=proxy_pool.views["hca_main_rope"][hca_i],
             )
             hca_i += 1
 
@@ -752,6 +965,8 @@ class _V4SGLangDecodeGraphBuffers:
         self.indptr_swa = i32(t + 1)
         self.indptr_csa = i32(t + 1)
         self.indptr_hca = i32(t + 1)
+        self.qo_indptr = i32(t + 1)
+        self.kv_last_page_lens = i32(t)
         self.idx_swa = i32(t * max(1, win))
         self.idx_csa = i32(t * max(1, win + topk))
         self.idx_hca = i32(t * max(1, win + hca))
@@ -884,6 +1099,25 @@ def _make_decode_graph_compress_plans(extend_lens_cpu, context_lens_cpu, bufs):
         graph_bs=bufs.decode_graph_bs,
         max_q_len=bufs.decode_q_len,
     )
+
+
+def _stage_decode_fp8_page_metadata(md, total: int, padded_total: int, *, bufs=None):
+    """Populate per-token page metadata for the DeepSeek-V4 FP8 decode kernel."""
+    total = max(0, int(total))
+    padded_total = max(total, int(padded_total))
+    qo_indptr_np = np.empty(padded_total + 1, dtype=np.int32)
+    qo_indptr_np[: total + 1] = np.arange(total + 1, dtype=np.int32)
+    if padded_total > total:
+        qo_indptr_np[total + 1 :] = total
+    if bufs is not None:
+        md.qo_indptr = bufs.stage(bufs.qo_indptr, qo_indptr_np, padded_total + 1)
+        bufs.kv_last_page_lens.np[:padded_total] = 1
+        md.kv_last_page_lens = bufs.kv_last_page_lens.copy_to_gpu(padded_total)
+        return
+
+    device = md.cu_seqlens_q.device
+    md.qo_indptr = torch.from_numpy(qo_indptr_np).to(device=device, dtype=torch.int32)
+    md.kv_last_page_lens = torch.ones(padded_total, dtype=torch.int32, device=device)
 
 
 def _get_extend_lens_cpu(
@@ -1290,6 +1524,7 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
     md.kv_indptr_swa = swa_indptr
     md.kv_indptr_csa = csa_indptr
     md.kv_indptr_hca = hca_indptr
+    _stage_decode_fp8_page_metadata(md, total, t_pad, bufs=bufs)
     cu_committed_cpu = np.concatenate(
         [
             np.zeros(1, dtype=np.int32),
@@ -1734,6 +1969,7 @@ def build_atom_v4_attention_metadata_from_sglang(
 
     if is_decode:
         _populate_decode_indices(md, block_tables, pos_np, device)
+        _stage_decode_fp8_page_metadata(md, total, total)
     else:
         _populate_prefill_indices(md, block_tables, batch_np, pos_np, q_np, device)
     _populate_indexer(md, batch_np, positions[:total], device)
@@ -1989,6 +2225,13 @@ def reset_deepseek_v4_state_slots(model, slots) -> None:
                     sorted(slots), dtype=torch.long, device=swa.device
                 )
             swa[idx] = 0
+        swa_rope = getattr(attn, "swa_kv_rope", None)
+        if isinstance(swa_rope, torch.Tensor):
+            if idx is None:
+                idx = torch.as_tensor(
+                    sorted(slots), dtype=torch.long, device=swa_rope.device
+                )
+            swa_rope[idx] = 0
         for compressor in (
             getattr(attn, "compressor", None),
             getattr(getattr(attn, "indexer", None), "compressor", None),

--- a/atom/plugin/sglang/models/deepseek_v4_attention.py
+++ b/atom/plugin/sglang/models/deepseek_v4_attention.py
@@ -39,14 +39,22 @@ def _install_draft_extend_fused_swa_patch() -> None:
             # swa_kv is now the flat [pages, head_dim] paged pool (project 024);
             # the ring stride (== swa_cache_size == cs) lives on attn.swa_block_size.
             cache_size = int(attn.swa_block_size)
+            kv_fp8 = bool(getattr(attn, "kv_fp8", False))
             kwargs.update(
-                swa_kv=attn.swa_kv,
+                fp8_2buff=kv_fp8,
                 swa_block_tables=attn_md.swa_block_tables,
                 swa_block_size=cache_size,
                 batch_id_per_token=attn_md.batch_id_per_token,
                 swa_cu_seqlens_q=attn_md.cu_seqlens_q,
                 swa_write_per_batch=min(int(attn_md.max_seqlen_q), cache_size),
             )
+            if kv_fp8:
+                kwargs.update(
+                    swa_nope_scale_buff=attn.swa_kv,
+                    swa_rope_buff=attn.swa_kv_rope,
+                )
+            else:
+                kwargs["swa_kv"] = attn.swa_kv
         return original_qk_norm_rope_maybe_quant(*args, **kwargs)
 
     def swa_write(*args, **kwargs):


### PR DESCRIPTION
## Motivation

Fix SGLang DeepSeek-V4 startup/runtime failures when fp8 KV cache is enabled. The SGLang proxy KV pool did not fully bind the native DSV4 fp8 2-buffer layout, causing attention modules to miss RoPE companion buffers such as unified_kv_rope.

## Technical Details
- Add SGLang proxy KV cache support for DSV4 fp8 2-buffer layout: packed fp8 NoPE/scale buffer plus bf16 RoPE companion buffer.
- Bind unified_kv_rope, swa_kv_rope, and compressor kv_cache_rope consistently for CSA/HCA layers.
- Set the correct compressor write_mode for bf16, fp8 main cache, and fp8 indexer cache.
- Populate decode page metadata needed by the fp8 paged decode kernel.
- Clean up the slicing logic to share the bf16/fp8 path and keep the effective kv_fp8 state in metadata.
## Test Plan

**server：**
```
set -x
export AITER_BF16_FP8_MOE_BOUND=0
export ATOM_MOE_GU_ITLV=1
export SGLANG_DEFAULT_THINKING=1
export SGLANG_DSV4_REASONING_EFFORT=max
export SGLANG_USE_AITER=1
export SGLANG_DSV4_FP4_EXPERTS=true

export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
export SGLANG_ENABLE_TORCH_COMPILE=1

model_path=/shared/data/amd_int/models/deepseek-ai/DeepSeek-V4-Pro
 
TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path $model_path \
    --host localhost \
    --port 9000 \
    --trust-remote-code \
    --tensor-parallel-size 8 \
    --kv-cache-dtype fp8_e4m3 \
    --mem-fraction-static 0.85 \
    --swa-full-tokens-ratio 0.1 \
    --max-running-requests 256 \
    --page-size 256 \
    --disable-radix-cache \
    --disable-shared-experts-fusion \
    --tool-call-parser deepseekv4 \
    --reasoning-parser deepseek-v4
```

## Test Result
<img width="948" height="137" alt="image" src="https://github.com/user-attachments/assets/32f2fe88-c133-4cb6-9bb3-db3aa886c3d3" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
