### PR TITLE
[SGL+ATOM] Harden SGLang accuracy test script

### DIFF
--- a/.github/scripts/atom_sglang_test.sh
+++ b/.github/scripts/atom_sglang_test.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# The CI checkout is mounted into the container. Avoid leaving root-owned
+# __pycache__ files in that host workspace between matrix jobs.
+export PYTHONDONTWRITEBYTECODE="${PYTHONDONTWRITEBYTECODE:-1}"
+
 # Usage:
 #   .github/scripts/atom_sglang_test.sh start
 #   .github/scripts/atom_sglang_test.sh launch
@@ -39,7 +43,8 @@ fi
 MAX_WAIT_RETRIES=${MAX_WAIT_RETRIES:-60}
 WAIT_INTERVAL_SEC=${WAIT_INTERVAL_SEC:-30}
 SGLANG_PORT=${SGLANG_PORT:-8000}
-SGLANG_HOST=${SGLANG_HOST:-localhost}
+# Prefer IPv4 loopback: Docker often sets disable_ipv6=1 while localhost still resolves to ::1.
+SGLANG_HOST=${SGLANG_HOST:-127.0.0.1}
 SGLANG_PID_FILE=${SGLANG_PID_FILE:-/tmp/atom_sglang.pid}
 SGLANG_LOG_FILE=${SGLANG_LOG_FILE:-/tmp/atom_sglang.log}
 RESULT_DIR=${RESULT_DIR:-/tmp/atom_sglang_accuracy_results}
@@ -66,15 +71,24 @@ if [[ -z "${MODEL_NAME}" || -z "${MODEL_PATH}" ]]; then
 fi
 
 prepare_runtime_paths() {
-  if [[ -d /app/sglang/python && -d /app/ATOM ]]; then
-    local path_prefix="/app/sglang/python:/app/ATOM"
-    if [[ -d /app/aiter-test ]]; then
-      path_prefix="/app/aiter-test:${path_prefix}"
-    fi
-    export PYTHONPATH="${path_prefix}${PYTHONPATH:+:${PYTHONPATH}}"
-    cd /app
-  elif [[ -d /workspace ]]; then
+  local path_prefix=""
+  if [[ -d /app/aiter-test ]]; then
+    path_prefix="/app/aiter-test"
+  fi
+  if [[ -d /app/sglang/python ]]; then
+    path_prefix="${path_prefix:+${path_prefix}:}/app/sglang/python"
+  fi
+  if [[ -d /workspace ]]; then
+    # The CI checkout is mounted at /workspace; prefer it over the ATOM copy
+    # baked into the base image so validation covers the current branch.
+    path_prefix="${path_prefix:+${path_prefix}:}/workspace"
     cd /workspace
+  elif [[ -d /app/ATOM ]]; then
+    path_prefix="${path_prefix:+${path_prefix}:}/app/ATOM"
+    cd /app
+  fi
+  if [[ -n "${path_prefix}" ]]; then
+    export PYTHONPATH="${path_prefix}${PYTHONPATH:+:${PYTHONPATH}}"
   fi
 }
 


### PR DESCRIPTION
## Summary

Harden the SGLang accuracy validation helper script without changing model configs, thresholds, image versions, or runtime code.

## Why This Is Needed

The SGLang accuracy workflow runs inside a container while mounting the GitHub workspace from the host. Without these script-level safeguards, validation can still be flaky even after the workflow-level hardening in #1668:

* Python may write root-owned `__pycache__` files into the mounted workspace, causing later checkout or cleanup steps to fail.
* `localhost` may resolve to IPv6 `::1`, while Docker/container networking can have IPv6 disabled, causing readiness checks to fail even when the server is listening on IPv4.
* Some images contain a baked `/app/ATOM` copy. If that path takes precedence over the mounted `/workspace`, the job may validate stale image code instead of the PR checkout.

This PR keeps validation focused on the current checkout and reduces avoidable CI flakes without changing model configs, thresholds, image versions, or runtime behavior.

## Relation to #1668

This is a follow-up hardening change to #1668, but it is independent and touches a different layer.

#1668 hardened the reusable SGLang accuracy shard workflow around checkout ownership, container early-exit detection, and artifact cleanup. This PR hardens the helper script executed inside the validation container by preventing root-owned Python bytecode files, preferring IPv4 loopback, and ensuring the mounted `/workspace` checkout is used for validation.

It does not change model configs, thresholds, image versions, or ATOM runtime code.

## Changes

* Avoid writing Python bytecode into the mounted CI workspace to prevent root-owned `__pycache__` files between jobs.
* Prefer IPv4 loopback (`127.0.0.1`) over `localhost` because CI containers may disable IPv6 while `localhost` still resolves to `::1`.
* Prefer the mounted `/workspace` checkout over the ATOM copy baked into the image so validation covers the current branch.

## Validation

* `bash -n .github/scripts/atom_sglang_test.sh`
* `git diff --check`