### PR TITLE
[Bugfix] support mxfp8 online quantization

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -97,7 +97,7 @@
       "config": {
         "tp": 4,
         "kv_cache_dtype": "fp8",
-        "extra_args": "--no-enable_prefix_caching --online_quant_config '{\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"per_block_fp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}'"
+        "extra_args": "--no-enable_prefix_caching --online_quant_config '{\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"mxfp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}'"
       },
       "variants": [
         { "label": "", "suffix": "", "conc_max": 256 },

--- a/.github/benchmark/oot_benchmark_models.json
+++ b/.github/benchmark/oot_benchmark_models.json
@@ -137,7 +137,7 @@
           "display": "GLM-5.2-FP8 TP4 (OOB)",
           "dashboard_model": "GLM-5.2-FP8-oob-tp4",
           "prefix": "glm-5-2-fp8-oob-tp4",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.9 --additional-config '{\"online_quant_config\": {\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"per_block_fp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.9 --additional-config '{\"online_quant_config\": {\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"mxfp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}}'",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1"
         },
         {
@@ -145,7 +145,7 @@
           "display": "GLM-5.2-FP8 MTP TP4 (OOB)",
           "dashboard_model": "GLM-5.2-FP8-mtp-oob-tp4",
           "prefix": "glm-5-2-fp8-mtp-oob-tp4",
-          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.9 --additional-config '{\"online_quant_config\": {\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"per_block_fp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}}' --speculative-config '{\"method\": \"mtp\", \"num_speculative_tokens\": 3}'",
+          "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.9 --additional-config '{\"online_quant_config\": {\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"mxfp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}}' --speculative-config '{\"method\": \"mtp\", \"num_speculative_tokens\": 3}'",
           "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1"
         },
         {

--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -397,7 +397,7 @@
   {
     "model_name": "GLM-5.2-FP8 TP4",
     "model_path": "zai-org/GLM-5.2-FP8",
-    "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.9 --additional-config '{\"online_quant_config\": {\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"per_block_fp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}}'",
+    "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.9 --additional-config '{\"online_quant_config\": {\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"mxfp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}}'",
     "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1",
     "runner": "atom-plugin-acc-validation-runner-vllm",
     "test_level": "nightly",
@@ -411,7 +411,7 @@
   {
     "model_name": "GLM-5.2-FP8 MTP TP4",
     "model_path": "zai-org/GLM-5.2-FP8",
-    "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.9 --additional-config '{\"online_quant_config\": {\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"per_block_fp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}}' --speculative-config '{\"method\": \"mtp\", \"num_speculative_tokens\": 3}'",
+    "extra_args": "--trust-remote-code --tensor-parallel-size 4 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.9 --additional-config '{\"online_quant_config\": {\"global_quant_config\": \"ptpc_fp8\", \"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"mxfp8\"}, \"exclude_layer\": [\"lm_head\", \"model.embed_tokens\", \"*.mlp.gate\"]}}' --speculative-config '{\"method\": \"mtp\", \"num_speculative_tokens\": 3}'",
     "env_vars": "AITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1",
     "runner": "atom-plugin-acc-validation-runner-vllm",
     "test_level": "nightly",

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -216,6 +216,7 @@ class QuarkOnlineParser(QuantConfigParser):
         - ``"per_block_fp8"``   — per-block FP8 (128x128; alias of per_block128_fp8)
         - ``"per_block128_fp8"``— per-block FP8, 128x128 block
         - ``"mxfp4"``           — microscaling FP4 (block size 32)
+        - ``"mxfp8"``           — microscaling FP8 (block size 32)
         """
         if not isinstance(online_quant_config, dict):
             raise TypeError("online_quant_config must be a dict parsed from JSON.")
@@ -227,6 +228,7 @@ class QuarkOnlineParser(QuantConfigParser):
             "per_block_fp8": (QuantType.per_1x128, "fp8"),
             "per_block128_fp8": (QuantType.per_1x128, "fp8"),
             "mxfp4": (QuantType.per_1x32, "fp4"),
+            "mxfp8": (QuantType.per_1x32, "fp8"),
         }
 
         def _parse_online_quant_format(quant_format_str: str) -> LayerQuantConfig:


### PR DESCRIPTION
as title
```
AITER_QUICK_REDUCE_QUANTIZATION=INT4 AITER_USE_FLYDSL_MOE_SORTING=1 \
python -m atom.entrypoints.openai_server \
  --model /shareddata/zai-org/GLM-5.2-FP8 \
  --server-port 8000 \
  --kv_cache_dtype fp8 \
  --no-enable_prefix_caching \
  --online_quant_config '{"global_quant_config": "ptpc_fp8", "layer_quant_config":{"model.layers.*.mlp.experts":"mxfp8"}, "exclude_layer": ["lm_head", "model.embed_tokens", "*.mlp.gate"]}' \
  -tp 4 2>&1 | tee server.log

lm_eval \
  --model local-completions \
  --model_args model=/shareddata/zai-org/GLM-5.2-FP8,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False \
  --tasks gsm8k \
  --num_fewshot 3

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9393|±  |0.0066|
|     |       |strict-match    |     3|exact_match|↑  |0.9393|±  |0.0066|

lm_eval \
  --model local-completions \
  --model_args model=/shareddata/zai-org/GLM-5.2-FP8,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False \
  --tasks gsm8k \
  --num_fewshot 20


|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9416|±  |0.0065|
|     |       |strict-match    |    20|exact_match|↑  |0.9401|±  |0.0065|

```