### PR TITLE
[sgl atom] Enable pcp in sglang atom in glm5.2

### DIFF
--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -94,6 +94,7 @@ from atom.utils.custom_register import direct_register_custom_op
 # `_use_dual_stream` is True so torch.compile/Dynamo treats stream code as opaque.
 from atom.model_ops import module_dispatch_ops as _module_dispatch_ops  # noqa: F401
 from atom.distributed.pcp_utils import (
+    pcp_all_reduce,
     get_pcp_world_size,
     pcp_allgather_rerange,
     pcp_is_enabled,
@@ -1205,6 +1206,40 @@ class DeepseekV2MoE(nn.Module):
         )
         return final_hidden_states
 
+    def _pcp_moe_merge_active(self) -> bool:
+        if not bool(envs.ATOM_PCP_MOE_MERGE) or get_pcp_world_size() <= 1:
+            return False
+        ctx = get_forward_context()
+        context = getattr(ctx, "context", None)
+        if context is None or bool(getattr(context, "is_dummy_run", False)):
+            return False
+        return True
+
+    def _pcp_moe_merge_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        shared_output = None
+        if (
+            self.n_shared_experts is not None
+            and not self.is_rocm_aiter_fusion_shared_expert_enabled
+        ):
+            # Shared-expert weights are still sharded only by ATOM TP, not by the
+            # folded PCP*TP routed-expert sharding. Keep shared experts on local
+            # query rows; only routed experts use PCP merge collectives.
+            shared_output = self.shared_experts(hidden_states)
+
+        # Match native ATOM PCP MoE semantics: routed MoE runs on this rank's
+        # local token rows.  ATOM_PCP_MOE_MERGE folds the PCP dimension into the
+        # routed-expert weight partitioning, so the missing PCP partial is a
+        # hidden-dimension partial sum, not missing token rows.  Therefore use a
+        # PCP all-reduce over the local output and avoid per-layer full-token
+        # all-gather/reduce-scatter.
+        routed_output = self.routed_expert_forward(hidden_states)
+        routed_output = pcp_all_reduce(routed_output, get_pcp_world_size())
+
+        final_hidden_states = self.combine_outputs(
+            routed_output, shared_output, hidden_states
+        )
+        return final_hidden_states
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         assert (
             hidden_states.dim() == 2
@@ -1212,6 +1247,9 @@ class DeepseekV2MoE(nn.Module):
         assert (
             hidden_states.shape[1] == self.experts.hidden_size
         ), f"Hidden states dimension {hidden_states.shape[1]} does not match expected {self.experts.hidden_size}"
+
+        if self._pcp_moe_merge_active():
+            return self._pcp_moe_merge_forward(hidden_states)
 
         if self._use_dual_stream:
             return torch.ops.aiter.maybe_dual_stream_forward(hidden_states, self.prefix)

--- a/atom/plugin/config.py
+++ b/atom/plugin/config.py
@@ -40,6 +40,8 @@ class PluginConfig:
     sglang_aiter_rank_id: int = 0
     sglang_dist_init_addr: Optional[str] = None
     sglang_port_args: Any = None
+    sglang_enable_nsa_prefill_cp: bool = False
+    sglang_nsa_prefill_cp_mode: str = "round-robin-split"
 
     # rtp-llm specific
     rtpllm_model_config: Any = None
@@ -51,7 +53,13 @@ def _normalize_sglang_parallel_config(
     dp_size: int,
     tp_rank: int,
     enable_dp_attention: bool,
-) -> tuple[int, int, int, int]:
+    enable_nsa_prefill_context_parallel: bool = False,
+    nsa_prefill_cp_mode: str = "round-robin-split",
+    attn_cp_size: int = 1,
+    attn_cp_rank: int = 0,
+    attn_tp_size: int = 1,
+    attn_tp_rank: int = 0,
+) -> tuple[int, int, int, int, int]:
     """Translate SGLang parallel args into the runtime layout ATOM expects.
 
     SGLang's ``tp_size`` is the whole world used by the model runner, while
@@ -60,6 +68,96 @@ def _normalize_sglang_parallel_config(
     so ATOM should treat that DP dimension as external scheduling rather than
     a model-internal communication group.
     """
+
+    if enable_nsa_prefill_context_parallel:
+        if nsa_prefill_cp_mode != "round-robin-split":
+            raise ValueError(
+                "SGLang+ATOM PCP only supports round-robin-split, got "
+                f"{nsa_prefill_cp_mode!r}"
+            )
+        if dp_size != 1:
+            raise ValueError(
+                "SGLang+ATOM PCP does not support dp_size > 1 yet, got "
+                f"dp_size={dp_size}"
+            )
+
+        atom_pcp_size_override = (
+            envs.ATOM_SGLANG_PCP_SIZE if envs.is_set("ATOM_SGLANG_PCP_SIZE") else None
+        )
+        if atom_pcp_size_override is not None:
+            # SGLang's DSA/GLM CP defaults currently force
+            # attn_cp_size = tp_size // dp_size, which collapses attention TP to
+            # 1 for pure PCP.  ATOM's internal DSA path can run TP + PCP
+            # together, so allow an ATOM-only override that maps the same
+            # SGLang world into aiter as atom_tp=tp_size/env_pcp and
+            # atom_pcp=env_pcp.  Keep this local to ATOM so native SGLang
+            # semantics stay unchanged.
+            if atom_pcp_size_override <= 1:
+                raise ValueError(
+                    "ATOM_SGLANG_PCP_SIZE must be greater than 1 when set, got "
+                    f"{atom_pcp_size_override}"
+                )
+            if tp_size % atom_pcp_size_override != 0:
+                raise ValueError(
+                    "SGLang tp_size must be divisible by ATOM_SGLANG_PCP_SIZE, "
+                    f"got tp_size={tp_size}, "
+                    f"ATOM_SGLANG_PCP_SIZE={atom_pcp_size_override}"
+                )
+
+            runtime_tp_size = tp_size // atom_pcp_size_override
+            runtime_pcp_size = atom_pcp_size_override
+            runtime_dp_size = 1
+            runtime_dp_rank = 0
+            runtime_pcp_rank = tp_rank // runtime_tp_size
+            runtime_tp_rank = tp_rank % runtime_tp_size
+            aiter_rank_id = runtime_pcp_rank * runtime_tp_size + runtime_tp_rank
+            logger.info(
+                "ATOM_SGLANG_PCP_SIZE overrides SGLang attention CP mapping: "
+                f"env_pcp_size={runtime_pcp_size}, "
+                f"sglang_attn_cp={attn_cp_rank}/{attn_cp_size}, "
+                f"sglang_attn_tp={attn_tp_rank}/{attn_tp_size}, "
+                f"atom_tp={runtime_tp_rank}/{runtime_tp_size}, "
+                f"atom_pcp={runtime_pcp_rank}/{runtime_pcp_size}, "
+                f"aiter_rank_id={aiter_rank_id}"
+            )
+            return (
+                runtime_tp_size,
+                runtime_pcp_size,
+                runtime_dp_size,
+                runtime_dp_rank,
+                aiter_rank_id,
+            )
+
+        if attn_cp_size <= 1:
+            raise ValueError(
+                "SGLang+ATOM PCP requires attn_cp_size > 1, got " f"{attn_cp_size}"
+            )
+        if tp_size % attn_cp_size != 0:
+            raise ValueError(
+                "SGLang tp_size must be divisible by attn_cp_size when "
+                "NSA prefill CP is enabled, got "
+                f"tp_size={tp_size}, attn_cp_size={attn_cp_size}"
+            )
+
+        runtime_tp_size = attn_tp_size
+        expected_runtime_tp_size = tp_size // attn_cp_size
+        if runtime_tp_size != expected_runtime_tp_size:
+            raise ValueError(
+                "SGLang attention TP size does not match tp_size / attn_cp_size, "
+                f"got attn_tp_size={runtime_tp_size}, "
+                f"tp_size={tp_size}, attn_cp_size={attn_cp_size}"
+            )
+        runtime_pcp_size = attn_cp_size
+        runtime_dp_size = 1
+        runtime_dp_rank = 0
+        aiter_rank_id = attn_cp_rank * runtime_tp_size + attn_tp_rank
+        return (
+            runtime_tp_size,
+            runtime_pcp_size,
+            runtime_dp_size,
+            runtime_dp_rank,
+            aiter_rank_id,
+        )
 
     if enable_dp_attention:
         if dp_size < 1:
@@ -71,15 +169,22 @@ def _normalize_sglang_parallel_config(
             )
 
         runtime_tp_size = 1
+        runtime_pcp_size = 1
         runtime_dp_size = tp_size
         runtime_dp_rank = tp_rank
         aiter_rank_id = 0
-        return runtime_tp_size, runtime_dp_size, runtime_dp_rank, aiter_rank_id
+        return (
+            runtime_tp_size,
+            runtime_pcp_size,
+            runtime_dp_size,
+            runtime_dp_rank,
+            aiter_rank_id,
+        )
 
     # Without dp-attention, SGLang's DP workers are external replicas. Keep
     # ATOM/aiter on the per-worker TP world and do not create an internal DP
     # communication group.
-    return tp_size, 1, 0, tp_rank
+    return tp_size, 1, 1, 0, tp_rank
 
 
 def _build_atom_speculative_config_from_vllm(vllm_spec_config: Any):
@@ -220,6 +325,12 @@ def _generate_atom_config_from_vllm_config(config: Any) -> PluginConfig:
 
 def _generate_atom_config_from_sglang_config(config: Any):
     from sglang.srt.distributed import get_tensor_model_parallel_rank
+    from sglang.srt.layers.dp_attention import (
+        get_attention_cp_rank,
+        get_attention_cp_size,
+        get_attention_tp_rank,
+        get_attention_tp_size,
+    )
     from sglang.srt.server_args import (
         get_global_server_args,
         PortArgs,
@@ -284,8 +395,13 @@ def _generate_atom_config_from_sglang_config(config: Any):
     rank = torch.distributed.get_rank()
 
     tp_rank = get_tensor_model_parallel_rank()
+    attn_cp_size = get_attention_cp_size()
+    attn_cp_rank = get_attention_cp_rank()
+    attn_tp_size = get_attention_tp_size()
+    attn_tp_rank = get_attention_tp_rank()
     (
         atom_tensor_parallel_size,
+        atom_prefill_context_parallel_size,
         atom_data_parallel_size,
         atom_data_parallel_rank,
         sglang_aiter_rank_id,
@@ -294,6 +410,24 @@ def _generate_atom_config_from_sglang_config(config: Any):
         dp_size=server_args.dp_size,
         tp_rank=tp_rank,
         enable_dp_attention=server_args.enable_dp_attention,
+        enable_nsa_prefill_context_parallel=server_args.enable_nsa_prefill_context_parallel,
+        nsa_prefill_cp_mode=server_args.nsa_prefill_cp_mode,
+        attn_cp_size=attn_cp_size,
+        attn_cp_rank=attn_cp_rank,
+        attn_tp_size=attn_tp_size,
+        attn_tp_rank=attn_tp_rank,
+    )
+    logger.info(
+        "SGLang+ATOM parallel mapping: "
+        f"sglang_tp_size={server_args.tp_size}, sglang_tp_rank={tp_rank}, "
+        f"sglang_dp_size={server_args.dp_size}, "
+        f"sglang_attn_tp={attn_tp_rank}/{attn_tp_size}, "
+        f"sglang_attn_cp={attn_cp_rank}/{attn_cp_size}, "
+        f"atom_tp_size={atom_tensor_parallel_size}, "
+        f"atom_pcp_size={atom_prefill_context_parallel_size}, "
+        f"atom_dp_size={atom_data_parallel_size}, "
+        f"atom_dp_rank={atom_data_parallel_rank}, "
+        f"aiter_rank_id={sglang_aiter_rank_id}"
     )
 
     # sglang uses the atom parallel config
@@ -347,10 +481,33 @@ def _generate_atom_config_from_sglang_config(config: Any):
         sglang_enable_torch_compile=server_args.enable_torch_compile,
         sglang_disable_cuda_graph=server_args.disable_cuda_graph,
         sglang_enable_dp_attention=server_args.enable_dp_attention,
+        sglang_enable_nsa_prefill_cp=server_args.enable_nsa_prefill_context_parallel,
+        sglang_nsa_prefill_cp_mode=server_args.nsa_prefill_cp_mode,
         sglang_aiter_rank_id=sglang_aiter_rank_id,
         sglang_dist_init_addr=sglang_dist_init_addr,
         sglang_port_args=sglang_port_args,
     )
+
+    # SGLang sets enable_dp_attention=True when enabling NSA prefill context
+    # parallelism because its attention TP/CP groups are built through the
+    # DP-attention layout code.  In ATOM plugin mode we remap that same SGLang
+    # layout to aiter PCP groups above, so propagating enable_dp_attention into
+    # ATOM would incorrectly interpret the PCP ranks as real ATOM DP-attention
+    # ranks.  SGLang's native round-robin PCP path also disallows true DP+PCP
+    # (it asserts dp_size == 1), so this keeps the plugin semantics aligned:
+    # true DP-attention + PCP remains unsupported; dp_size > 1 is rejected in
+    # _normalize_sglang_parallel_config().
+    if server_args.enable_nsa_prefill_context_parallel:
+        if server_args.enable_dp_attention:
+            logger.warning(
+                "SGLang enabled DP attention as part of NSA prefill context "
+                "parallel setup. ATOM plugin maps this layout to aiter PCP "
+                "groups, so ATOM-side enable_dp_attention is disabled. "
+                "True DP attention combined with PCP is not supported."
+            )
+        atom_enable_dp_attention = False
+    else:
+        atom_enable_dp_attention = server_args.enable_dp_attention
 
     max_num_batched_tokens = max(
         int(getattr(server_args, "max_prefill_tokens", 0) or 0),
@@ -369,6 +526,7 @@ def _generate_atom_config_from_sglang_config(config: Any):
         max_model_len=server_args.context_length,
         gpu_memory_utilization=server_args.mem_fraction_static,
         tensor_parallel_size=atom_tensor_parallel_size,
+        prefill_context_parallel_size=atom_prefill_context_parallel_size,
         # Disable ATOM's own torch.compile and CUDA graph capture —
         # sglang manages its own compilation/graph strategy, and the
         # @support_torch_compile decorator checks enforce_eager to skip,
@@ -385,7 +543,7 @@ def _generate_atom_config_from_sglang_config(config: Any):
         load_dummy=None,
         enable_expert_parallel=bool(server_args.ep_size > 1),
         master_addr=None,
-        enable_dp_attention=server_args.enable_dp_attention,
+        enable_dp_attention=atom_enable_dp_attention,
         plugin_config=plugin_config,
         online_quant_config=online_quant_config,
         hf_overrides=hf_overrides,

--- a/atom/plugin/register.py
+++ b/atom/plugin/register.py
@@ -807,8 +807,12 @@ def init_aiter_dist(config: Config) -> None:
 
     distributed_init_method = get_distributed_init_method(dp_master_ip, dp_master_port)
 
+    prefill_context_parallel_size = config.prefill_context_parallel_size
     logger.info(
-        f"Initialize aiter dist for using aiter custom collective op for plugin mode, rank:{rank}"
+        "Initialize aiter dist for using aiter custom collective op for "
+        f"plugin mode, rank:{rank}, tp:{tensor_parallel_size}, "
+        f"pcp:{prefill_context_parallel_size}, dp:{config.parallel_config.data_parallel_size}, "
+        f"dp_rank:{config.parallel_config.data_parallel_rank}"
     )
     init_dist_env(
         tensor_model_parallel_size=tensor_parallel_size,
@@ -817,4 +821,5 @@ def init_aiter_dist(config: Config) -> None:
         distributed_init_method=distributed_init_method,
         data_parallel_size=config.parallel_config.data_parallel_size,
         data_parallel_rank=config.parallel_config.data_parallel_rank,
+        prefill_context_model_parallel_size=prefill_context_parallel_size,
     )

--- a/atom/plugin/sglang/attention_backend/sparse_mla_indexer.py
+++ b/atom/plugin/sglang/attention_backend/sparse_mla_indexer.py
@@ -158,6 +158,97 @@ def _build_sglang_query_ranges(forward_batch) -> tuple[torch.Tensor, torch.Tenso
     )
 
 
+def _maybe_apply_pcp_query_split(
+    cu_starts: torch.Tensor,
+    cu_ends: torch.Tensor,
+    num_tokens: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Match full SGLang query metadata to ATOM's local PCP query rows."""
+
+    if int(cu_starts.shape[0]) <= num_tokens:
+        return cu_starts, cu_ends
+
+    try:
+        from atom.distributed.pcp_utils import (
+            get_pcp_world_size,
+            pcp_pad_dense,
+            pcp_pad_len,
+            pcp_round_robin_split,
+        )
+
+        pcp_size = get_pcp_world_size()
+    except Exception:
+        pcp_size = 1
+
+    if pcp_size <= 1:
+        return cu_starts, cu_ends
+
+    # DeepseekV2/GLM-DSA model forward splits input_ids/positions by ATOM PCP,
+    # but SGLang forward_batch still describes the full local-SGLang query set.
+    # Reindex per-query indexer metadata with the same round-robin rule so its
+    # rows line up with the already-split hidden/q tensors.
+    total_queries = int(cu_starts.shape[0])
+    padded_total = pcp_pad_len(total_queries, pcp_size)
+    n_pad = padded_total - total_queries
+    cu_starts = pcp_round_robin_split(pcp_pad_dense(cu_starts, n_pad), pcp_size)
+    cu_ends = pcp_round_robin_split(pcp_pad_dense(cu_ends, n_pad), pcp_size)
+    return cu_starts[:num_tokens], cu_ends[:num_tokens]
+
+
+def _maybe_apply_pcp_dense_query_split(
+    values: torch.Tensor,
+    num_tokens: int,
+) -> torch.Tensor:
+    """Match dense per-query metadata to ATOM's local PCP query rows."""
+
+    if int(values.shape[0]) <= num_tokens:
+        return values[:num_tokens]
+
+    try:
+        from atom.distributed.pcp_utils import (
+            get_pcp_world_size,
+            pcp_pad_dense,
+            pcp_pad_len,
+            pcp_round_robin_split,
+        )
+
+        pcp_size = get_pcp_world_size()
+    except Exception:
+        pcp_size = 1
+
+    if pcp_size <= 1:
+        return values
+
+    total_queries = int(values.shape[0])
+    padded_total = pcp_pad_len(total_queries, pcp_size)
+    values = pcp_round_robin_split(
+        pcp_pad_dense(values, padded_total - total_queries), pcp_size
+    )
+    return values[:num_tokens]
+
+
+def _pad_query_ranges_for_indexer(
+    cu_starts: torch.Tensor, cu_ends: torch.Tensor, num_tokens: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pad CP/DP dummy query rows with zero-length KV ranges."""
+    num_ranges = int(cu_starts.shape[0])
+    if num_ranges == num_tokens:
+        return cu_starts, cu_ends
+    if num_ranges > num_tokens:
+        raise RuntimeError(
+            "[SGL+ATOM] sparse indexer query metadata has more rows than input "
+            f"tokens: ranges={num_ranges}, tokens={num_tokens}."
+        )
+
+    pad_len = num_tokens - num_ranges
+    pad_starts = cu_starts.new_zeros(pad_len)
+    pad_ends = cu_ends.new_zeros(pad_len)
+    return (
+        torch.cat([cu_starts, pad_starts], dim=0),
+        torch.cat([cu_ends, pad_ends], dim=0),
+    )
+
+
 def _build_sglang_block_table(forward_batch, page_size: int) -> torch.Tensor:
     req_pool_indices = forward_batch.req_pool_indices
     req_to_token = forward_batch.req_to_token_pool.req_to_token
@@ -191,6 +282,7 @@ def _build_sglang_block_table(forward_batch, page_size: int) -> torch.Tensor:
 def _build_sparse_req_id_per_token_for_sglang(
     forward_batch,
     device: torch.device,
+    num_tokens: Optional[int] = None,
 ) -> torch.Tensor:
     bs = int(forward_batch.batch_size)
     req_ids = torch.arange(bs, dtype=torch.int32, device=device)
@@ -199,7 +291,12 @@ def _build_sparse_req_id_per_token_for_sglang(
     query_lens = getattr(forward_batch, "extend_seq_lens", None)
     if query_lens is None:
         query_lens = forward_batch.seq_lens
-    return torch.repeat_interleave(req_ids, query_lens[:bs].to(torch.int32))
+    req_id_per_token = torch.repeat_interleave(req_ids, query_lens[:bs].to(torch.int32))
+    if num_tokens is not None:
+        req_id_per_token = _maybe_apply_pcp_dense_query_split(
+            req_id_per_token, int(num_tokens)
+        )
+    return req_id_per_token
 
 
 def _supports_sparse_mla_fast_metadata(
@@ -247,7 +344,7 @@ def forward_sparse_mla_for_sglang(
     page_size = int(getattr(forward_batch.token_to_kv_pool, "page_size", 1))
 
     req_id_per_token = _build_sparse_req_id_per_token_for_sglang(
-        forward_batch, q.device
+        forward_batch, q.device, int(num_tokens)
     )
     block_table = _build_sglang_block_table(forward_batch, page_size).to(
         dtype=torch.int32
@@ -508,6 +605,12 @@ def sparse_attn_indexer_sglang_plugin_mode(
         return weights
 
     cu_starts, cu_ends = _build_sglang_query_ranges(forward_batch)
+    cu_starts, cu_ends = _maybe_apply_pcp_query_split(
+        cu_starts, cu_ends, int(num_tokens)
+    )
+    cu_starts, cu_ends = _pad_query_ranges_for_indexer(
+        cu_starts, cu_ends, int(num_tokens)
+    )
     total_kv = int(forward_batch.seq_lens_sum)
     k_fp8 = torch.empty([total_kv, head_dim], device=k.device, dtype=dtypes.fp8)
     k_scale = torch.empty([total_kv, 1], device=k.device, dtype=torch.float32)

--- a/atom/plugin/sglang/glm52_dsa_bridge.py
+++ b/atom/plugin/sglang/glm52_dsa_bridge.py
@@ -222,6 +222,71 @@ def _ensure_shared_sparse_buffer(
     return buffer[:required]
 
 
+def _maybe_apply_pcp_prefill_reindex(
+    md,
+    *,
+    sparse_counts: np.ndarray,
+    total_tokens: int,
+    topk: int,
+    token_to_kv_pool,
+    atom_config,
+    dtype_q,
+) -> None:
+    try:
+        from atom.distributed.pcp_utils import (
+            get_pcp_world_size,
+            pcp_is_enabled,
+            pcp_pad_dense,
+            pcp_pad_len,
+            pcp_round_robin_query_indices,
+        )
+    except Exception:
+        return
+
+    if not pcp_is_enabled():
+        return
+
+    device = md.slot_mapping.device
+    pcp_size = get_pcp_world_size()
+    padded_total = pcp_pad_len(int(total_tokens), pcp_size)
+    n_pad = padded_total - int(total_tokens)
+    owned_q = pcp_round_robin_query_indices(padded_total, pcp_size).to(device)
+    n_owned = int(owned_q.shape[0])
+
+    md.cu_seqlen_ks = pcp_pad_dense(md.cu_seqlen_ks, n_pad)[owned_q].contiguous()
+    md.cu_seqlen_ke = pcp_pad_dense(md.cu_seqlen_ke, n_pad)[owned_q].contiguous()
+    md.token_to_seq_idxs = pcp_pad_dense(md.token_to_seq_idxs, n_pad)[
+        owned_q
+    ].contiguous()
+    md.sparse_cu_seqlens_q = torch.arange(n_owned + 1, dtype=torch.int32, device=device)
+
+    counts = torch.as_tensor(sparse_counts, dtype=torch.int64, device=device)
+    owned_counts = pcp_pad_dense(counts, n_pad)[owned_q]
+    owned_counts = torch.clamp(owned_counts, max=int(topk))
+    sparse_kv_indptr = torch.zeros(n_owned + 1, dtype=torch.int32, device=device)
+    sparse_kv_indptr[1:] = torch.cumsum(owned_counts, dim=0).to(torch.int32)
+    md.sparse_kv_indptr = sparse_kv_indptr
+    md.sparse_kv_last_page_lens = torch.ones(n_owned, dtype=torch.int32, device=device)
+
+    sparse_work = _make_mla_work_buffers(
+        cu_seqlens_q=md.sparse_cu_seqlens_q,
+        kv_indptr=md.sparse_kv_indptr,
+        kv_last_page_lens=md.sparse_kv_last_page_lens,
+        num_heads=_local_num_attention_heads(atom_config),
+        dtype_q=dtype_q,
+        dtype_kv=dtype_q,
+        page_size=_attention_page_size(token_to_kv_pool),
+    )
+    for key, value in sparse_work.items():
+        setattr(md, f"sparse_prefill_{key}", value)
+
+    if int(total_tokens) > 0:
+        owned_clamped = torch.clamp(owned_q, max=int(total_tokens) - 1)
+        md.slot_mapping_owned = md.slot_mapping[owned_clamped].contiguous()
+    else:
+        md.slot_mapping_owned = md.slot_mapping[:0].contiguous()
+
+
 class _GLM52DecodeGraphBuffers:
     def __init__(
         self,
@@ -654,6 +719,15 @@ def _build_prefill_metadata(
         )
         for key, value in sparse_work.items():
             setattr(md, f"sparse_prefill_{key}", value)
+        _maybe_apply_pcp_prefill_reindex(
+            md,
+            sparse_counts=sparse_counts,
+            total_tokens=total_tokens,
+            topk=topk,
+            token_to_kv_pool=token_to_kv_pool,
+            atom_config=atom_config,
+            dtype_q=dtype_q,
+        )
     else:
         _ensure_shared_sparse_buffer(
             token_to_kv_pool,

--- a/atom/plugin/sglang/models/deepseek_mla_attention.py
+++ b/atom/plugin/sglang/models/deepseek_mla_attention.py
@@ -191,6 +191,7 @@ class SGLangDeepseekMLAAttention(nn.Module):
             mla_v_up_proj,
         )
         from sglang.srt.layers.attention.nsa.utils import nsa_use_prefill_cp
+        from atom.models.deepseek_v2 import _pcp_active
 
         q = self._project_q(q_input, q_scale)
         k_nope = kv_c_normed.unsqueeze(1)
@@ -206,7 +207,17 @@ class SGLangDeepseekMLAAttention(nn.Module):
         ):
             q_pe, k_pe = attn.rotary_emb(positions, q_pe, k_pe)
 
-        if nsa_use_prefill_cp(forward_batch):
+        atom_pcp_on = _pcp_active()
+        if atom_pcp_on:
+            from atom.distributed.pcp_utils import (
+                get_pcp_world_size,
+                pcp_allgather_rerange,
+            )
+
+            pcp_ws = get_pcp_world_size()
+            k_nope = pcp_allgather_rerange(k_nope.squeeze(1), pcp_ws).unsqueeze(1)
+            k_pe = pcp_allgather_rerange(k_pe.squeeze(1), pcp_ws).unsqueeze(1)
+        elif nsa_use_prefill_cp(forward_batch):
             latent_cache = torch.cat([k_nope.squeeze(1), k_pe.squeeze(1)], dim=-1)
             k_nope, k_pe = attn.rebuild_cp_kv_cache(
                 latent_cache, forward_batch, k_nope, k_pe
@@ -215,7 +226,7 @@ class SGLangDeepseekMLAAttention(nn.Module):
         save_kv_cache = True
         topk_indices = self._get_sparse_topk_indices(q_input.shape[0])
         q_descale = None
-        if attn.use_fused_qk_rope_concat_and_cache_mla:
+        if attn.use_fused_qk_rope_concat_and_cache_mla and not atom_pcp_on:
             mla_attn = _get_sglang_radix_attn(self.base_attn)
             kv_cache = forward_batch.token_to_kv_pool.get_key_buffer(mla_attn.layer_id)
             q_cache_scale = getattr(mla_attn, "q_scale", None)

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -125,6 +125,46 @@ def _resolve_num_tokens_across_dp(
     return num_tokens_across_dp
 
 
+def _max_len_from_optional(cpu_lens, gpu_lens, default: int) -> int:
+    if cpu_lens is not None:
+        if isinstance(cpu_lens, torch.Tensor):
+            return int(cpu_lens.max().item()) if cpu_lens.numel() else default
+        return max((int(x) for x in cpu_lens), default=default)
+    if gpu_lens is not None:
+        return int(gpu_lens.max().item()) if gpu_lens.numel() else default
+    return default
+
+
+def _build_generic_attention_metadata(forward_batch: ForwardBatch, max_seqlen_q: int):
+    """Build minimal ATOM metadata from SGLang batch fields for non-V4 models."""
+
+    from atom.utils.forward_context import AttentionMetaData
+
+    # GLM/DSA SGLang plugin attention kernels read detailed scheduling metadata
+    # directly from SGLang's forward_batch.  ATOM's model-level PCP gate,
+    # however, runs before those kernels and checks
+    # get_forward_context().attn_metadata.max_seqlen_k in deepseek_v2._pcp_active().
+    # Without this fallback metadata, max_seqlen_k stays at AttentionMetaData's
+    # default 0 and long-prefill PCP never activates.
+    forward_mode = forward_batch.forward_mode
+    seq_lens = getattr(forward_batch, "seq_lens", None)
+    seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+    extend_seq_lens = getattr(forward_batch, "extend_seq_lens", None)
+    extend_seq_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+
+    if not forward_mode.is_decode_or_idle():
+        max_seqlen_q = _max_len_from_optional(
+            extend_seq_lens_cpu, extend_seq_lens, max_seqlen_q
+        )
+    max_seqlen_k = _max_len_from_optional(seq_lens_cpu, seq_lens, 0)
+
+    return AttentionMetaData(
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        context_lens=seq_lens,
+    )
+
+
 def _slice_v4_graph_metadata_for_capture(
     attn_metadata: Any, *, num_tokens: int, bs: int
 ):
@@ -377,7 +417,6 @@ def _set_atom_forward_context(
     """Bridge SGLang batch metadata into ATOM's global forward context."""
 
     from atom.utils.forward_context import (
-        AttentionMetaData,
         Context,
         set_forward_context,
     )
@@ -418,7 +457,7 @@ def _set_atom_forward_context(
             ) from exc
 
     if attn_metadata is None:
-        attn_metadata = AttentionMetaData(max_seqlen_q=max_seqlen_q)
+        attn_metadata = _build_generic_attention_metadata(forward_batch, max_seqlen_q)
     batch_size = int(forward_batch.batch_size)
     is_dummy_run = _is_dummy_forward(forward_batch)
     is_prefill = forward_mode.is_prefill()

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -37,6 +37,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DP_LB_REQ_EQUIV": lambda: int(os.getenv("ATOM_DP_LB_REQ_EQUIV", "512")),
     # Prefix for process titles set via set_process_title (shown in ps/top/rocm-smi)
     "ATOM_PROCESS_NAME_PREFIX": lambda: os.getenv("ATOM_PROCESS_NAME_PREFIX", "ATOM"),
+    # Override the PCP size that SGLang+ATOM maps into aiter. 0 means unset.
+    "ATOM_SGLANG_PCP_SIZE": lambda: int(os.getenv("ATOM_SGLANG_PCP_SIZE", "0") or "0"),
     # --- Compilation & Execution ---
     "ATOM_USE_TRITON_GEMM": lambda: os.getenv("ATOM_USE_TRITON_GEMM", "0") == "1",
     "ATOM_FP8_BLOCKSCALE_USE_E8M0_SCALE": lambda: (


### PR DESCRIPTION
## Motivation

Enable sgl atom pcp in glm5.2.Also can run in model based on deepseekv2 attention backend like deepseekv3.2.

## Command
GLM5.2:
```
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export AITER_USE_FLYDSL_MOE_SORTING=1
export SGLANG_USE_AITER=1
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models

export CUDA_VISIBLE_DEVICES=0,1,2,3
MODEL_PATH=/models/GLM-5.2-FP8


TP=4
PORT=9000
MODEL_LOADER_EXTRA_CONFIG='{"online_quant_config":{"global_quant_config":"ptpc_fp8","layer_quant_config":{"model.layers.*.mlp.experts":"per_block_fp8"},"exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate"]}}'

export ATOM_SGLANG_PCP_SIZE=2
export ATOM_PCP_MOE_MERGE=1

TORCHINDUCTOR_COMPILE_THREADS=128 \
python3 -m sglang.launch_server \
    --model-path "${MODEL_PATH}" \
    --host localhost \
    --port "${PORT}" \
    --trust-remote-code \
    --tp-size "${TP}" \
    --enable-nsa-prefill-context-parallel \
    --attn-cp-size $ATOM_SGLANG_PCP_SIZE \
    --nsa-prefill-cp-mode round-robin-split \
    --max-prefill-tokens 30720 \
    --chunked-prefill-size 30720 \
    --mem-fraction-static 0.85 \
    --disable-radix-cache \
    --kv-cache-dtype fp8_e4m3 \
    --model-loader-extra-config "${MODEL_LOADER_EXTRA_CONFIG}"
```


## Acc
glm:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9424|±  |0.0064|
|     |       |strict-match    |     3|exact_match|↑  |0.9409|±  |0.0065|

```


## Performance
glm:
TP4:
```
============ Serving Benchmark Result ============
Successful requests:                     192       
Benchmark duration (s):                  778.15    
Total input tokens:                      11796480  
Total generated tokens:                  115200    
Request throughput (req/s):              0.25      
Output token throughput (tok/s):         148.04    
Total Token throughput (tok/s):          15307.70  
---------------Time to First Token----------------
Mean TTFT (ms):                          197197.47 
Median TTFT (ms):                        223083.68 
P99 TTFT (ms):                           254167.43 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          40.08     
Median TPOT (ms):                        38.71     
P99 TPOT (ms):                           62.80     
---------------Inter-token Latency----------------
Mean ITL (ms):                           40.08     
Median ITL (ms):                         18.88     
P99 ITL (ms):                            20.23     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          221207.79 
Median E2EL (ms):                        241903.43 
P99 E2EL (ms):                           283149.80 
==================================================
```
PCP2 TP2:
```
============ Serving Benchmark Result ============
Successful requests:                     192       
Benchmark duration (s):                  693.17    
Total input tokens:                      11796480  
Total generated tokens:                  115200    
Request throughput (req/s):              0.28      
Output token throughput (tok/s):         166.19    
Total Token throughput (tok/s):          17184.43  
---------------Time to First Token----------------
Mean TTFT (ms):                          173199.41 
Median TTFT (ms):                        195626.53 
P99 TTFT (ms):                           223147.38 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          37.23     
Median TPOT (ms):                        38.35     
P99 TPOT (ms):                           55.78     
---------------Inter-token Latency----------------
Mean ITL (ms):                           37.23     
Median ITL (ms):                         19.34     
P99 ITL (ms):                            20.80     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          195503.07 
Median E2EL (ms):                        213089.06 
P99 E2EL (ms):                           252064.32 
==================================================

```
