### PR TITLE
Enable index_share_for_mtp_iteration in native MTP EagleProposer.

### DIFF
--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -208,6 +208,41 @@ class DeepSeekMultiTokenPredictor(nn.Module):
         normed = mtp_layer.shared_head(hidden_states)
         return mtp_layer.shared_head.head.compute_argmax_token(normed)
 
+    def set_skip_topk(self, skip: bool) -> None:
+        """Toggle ``skip_topk`` on MTP sparse-attention layers.
+
+        Used by ``EagleProposer`` for ``index_share_for_mtp_iteration``: draft
+        step 0 sets ``skip=False`` (compute indexer top-k), steps 1+ set
+        ``skip=True`` (reuse step 0's ``sparse_kv_indices_buffer``).
+        Matches vLLM ``DeepSeekMultiTokenPredictor.set_skip_topk``.
+        """
+        for layer in self.layers.values():
+            mtp_block = getattr(layer, "mtp_block", None)
+            if mtp_block is None:
+                continue
+            self_attn = getattr(mtp_block, "self_attn", None)
+            if self_attn is None or not hasattr(self_attn, "skip_topk"):
+                continue
+            if getattr(self_attn, "indexer", None) is not None:
+                self_attn.skip_topk = skip
+
+    def compact_topk_indices(self, slot_ids: torch.Tensor) -> None:
+        """Gather sparse top-k rows at ``slot_ids`` to the front of each buffer."""
+        num_slots = slot_ids.numel()
+        for layer in self.layers.values():
+            mtp_block = getattr(layer, "mtp_block", None)
+            if mtp_block is None:
+                continue
+            self_attn = getattr(mtp_block, "self_attn", None)
+            if self_attn is None:
+                continue
+            mla_attn = getattr(self_attn, "mla_attn", None)
+            if mla_attn is None:
+                continue
+            sparse_buf = getattr(mla_attn, "sparse_kv_indices_buffer", None)
+            if sparse_buf is not None and sparse_buf.numel() > 0:
+                sparse_buf[:num_slots] = sparse_buf[slot_ids]
+
 
 @support_torch_compile
 class DeepSeekMTP(nn.Module):
@@ -310,6 +345,12 @@ class DeepSeekMTP(nn.Module):
         reductions. See DeepSeekMultiTokenPredictor.compute_draft_token.
         """
         return self.model.compute_draft_token(hidden_states, spec_step_idx)
+
+    def set_skip_topk(self, skip: bool) -> None:
+        self.model.set_skip_topk(skip)
+
+    def compact_topk_indices(self, slot_ids: torch.Tensor) -> None:
+        self.model.compact_topk_indices(slot_ids)
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -310,6 +310,22 @@ class EagleProposer:
 
         self._draft_argmax_fused = hasattr(self.model, "compute_draft_token")
 
+        draft_hf = self.speculative_config.draft_model_hf_config
+        mtp_inner = getattr(self.model, "model", None)
+        self._share_mtp_indices = (
+            not self.use_dspark
+            and self.speculative_config.method == "mtp"
+            and getattr(draft_hf, "index_share_for_mtp_iteration", False)
+            and hasattr(draft_hf, "index_topk")
+            and mtp_inner is not None
+            and hasattr(mtp_inner, "set_skip_topk")
+        )
+        if self._share_mtp_indices:
+            logger.info(
+                "MTP draft index_share_for_mtp_iteration enabled: "
+                "step 0 computes indexer top-k, steps 1+ reuse the buffer."
+            )
+
         i32_kwargs = {"dtype": torch.int32, "device": self.device}
         i64_kwargs = {"dtype": torch.int64, "device": self.device}
         max_bs = self.config.max_num_seqs
@@ -645,6 +661,10 @@ class EagleProposer:
                         positions,
                         hidden_states,
                     )
+                # index_share_for_mtp_iteration: step 0 runs the MTP indexer;
+                # steps 1+ skip it and read the compacted sparse_kv buffer.
+                if self._share_mtp_indices and i == 0:
+                    self.model.model.set_skip_topk(False)
                 ret_hidden_states = self.model(
                     input_ids=d_input_ids,
                     positions=d_positions,
@@ -654,6 +674,9 @@ class EagleProposer:
                     ret_hidden_states = pcp_allgather_rerange(
                         ret_hidden_states, pcp_ws
                     )[:n_global_draft]
+                if self._share_mtp_indices and i == 0:
+                    self.model.model.set_skip_topk(True)
+                    self.model.model.compact_topk_indices(last_token_indices)
 
                 sample_hidden_states = (
                     torch.index_select(ret_hidden_states, 0, last_token_indices)

--- a/tests/test_mtp_index_share.py
+++ b/tests/test_mtp_index_share.py
@@ -1,0 +1,131 @@
+"""Unit tests for MTP draft index_share_for_mtp_iteration helpers.
+
+Avoid importing ``atom.models.deepseek_mtp`` here: that module pulls in
+``atom.config`` (torch / aiter / transformers) and is brittle in lightweight
+test collection.  The helpers below mirror
+``DeepSeekMultiTokenPredictor.set_skip_topk`` /
+``compact_topk_indices`` — keep them in sync when editing production code.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+
+class _FakeMlaAttn:
+    def __init__(self, buf: torch.Tensor):
+        self.sparse_kv_indices_buffer = buf
+
+
+class _FakeSelfAttn:
+    def __init__(self, *, has_indexer: bool, buf: torch.Tensor):
+        self.skip_topk = False
+        self.indexer = object() if has_indexer else None
+        self.mla_attn = _FakeMlaAttn(buf)
+
+
+class _FakeMtpBlock:
+    def __init__(self, self_attn: _FakeSelfAttn):
+        self.self_attn = self_attn
+
+
+class _FakeLayer:
+    def __init__(self, self_attn: _FakeSelfAttn):
+        self.mtp_block = _FakeMtpBlock(self_attn)
+
+
+def _set_skip_topk(layers: dict[str, Any], skip: bool) -> None:
+    """Mirror of ``DeepSeekMultiTokenPredictor.set_skip_topk``."""
+    for layer in layers.values():
+        mtp_block = getattr(layer, "mtp_block", None)
+        if mtp_block is None:
+            continue
+        self_attn = getattr(mtp_block, "self_attn", None)
+        if self_attn is None or not hasattr(self_attn, "skip_topk"):
+            continue
+        if getattr(self_attn, "indexer", None) is not None:
+            self_attn.skip_topk = skip
+
+
+def _compact_topk_indices(layers: dict[str, Any], slot_ids: torch.Tensor) -> None:
+    """Mirror of ``DeepSeekMultiTokenPredictor.compact_topk_indices``."""
+    num_slots = slot_ids.numel()
+    for layer in layers.values():
+        mtp_block = getattr(layer, "mtp_block", None)
+        if mtp_block is None:
+            continue
+        self_attn = getattr(mtp_block, "self_attn", None)
+        if self_attn is None:
+            continue
+        mla_attn = getattr(self_attn, "mla_attn", None)
+        if mla_attn is None:
+            continue
+        sparse_buf = getattr(mla_attn, "sparse_kv_indices_buffer", None)
+        if sparse_buf is not None and sparse_buf.numel() > 0:
+            sparse_buf[:num_slots] = sparse_buf[slot_ids]
+
+
+def test_set_skip_topk_only_layers_with_indexer():
+    buf0 = torch.zeros(4, 8, dtype=torch.int32)
+    buf1 = torch.zeros(4, 8, dtype=torch.int32)
+    layers = {
+        "80": _FakeLayer(_FakeSelfAttn(has_indexer=True, buf=buf0)),
+        "81": _FakeLayer(_FakeSelfAttn(has_indexer=False, buf=buf1)),
+    }
+
+    _set_skip_topk(layers, True)
+
+    assert layers["80"].mtp_block.self_attn.skip_topk is True
+    assert layers["81"].mtp_block.self_attn.skip_topk is False
+
+
+def test_compact_topk_indices_gathers_rows_to_front():
+    buf = torch.arange(20, dtype=torch.int32).reshape(10, 2)
+    layers = {"80": _FakeLayer(_FakeSelfAttn(has_indexer=True, buf=buf))}
+
+    slot_ids = torch.tensor([3, 7], dtype=torch.int64)
+    _compact_topk_indices(layers, slot_ids)
+
+    expected_row0 = torch.arange(6, 8, dtype=torch.int32)
+    expected_row1 = torch.arange(14, 16, dtype=torch.int32)
+    assert torch.equal(buf[0], expected_row0)
+    assert torch.equal(buf[1], expected_row1)
+
+
+def test_compact_topk_indices_skips_empty_buffer():
+    empty = torch.empty(0, dtype=torch.int32)
+    layers = {"80": _FakeLayer(_FakeSelfAttn(has_indexer=True, buf=empty))}
+    _compact_topk_indices(layers, torch.tensor([0], dtype=torch.int64))
+
+
+@pytest.mark.parametrize(
+    "method,index_share,index_topk,has_api,expected",
+    [
+        ("mtp", True, 2048, True, True),
+        ("mtp", False, 2048, True, False),
+        ("eagle3", True, 2048, True, False),
+        ("mtp", True, None, True, False),
+        ("mtp", True, 2048, False, False),
+    ],
+)
+def test_share_mtp_indices_gate(method, index_share, index_topk, has_api, expected):
+    draft_hf = SimpleNamespace(
+        index_share_for_mtp_iteration=index_share,
+    )
+    if index_topk is not None:
+        draft_hf.index_topk = index_topk
+    mtp_inner = (
+        SimpleNamespace(set_skip_topk=lambda _: None) if has_api else SimpleNamespace()
+    )
+
+    share = (
+        method == "mtp"
+        and getattr(draft_hf, "index_share_for_mtp_iteration", False)
+        and hasattr(draft_hf, "index_topk")
+        and hasattr(mtp_inner, "set_skip_topk")
+    )
+    assert share is expected


### PR DESCRIPTION
Wire GLM-5.2 draft index_share_for_mtp_iteration like vLLM: step 0 runs the MTP indexer, steps 1+ reuse sparse_kv_indices_buffer via skip_topk and compact_topk_indices. Gated on method=mtp, DSA index_topk, and the config flag so other draft backends are unchanged.


## Motivation

GLM-5.2-MXFP4 sets `index_share_for_mtp_iteration: true` in `config.json`. Within one MTP draft iteration, step 0 should run the DSA indexer once; steps 1+ should reuse the same top-k indices from `sparse_kv_indices_buffer` instead of re-scoring the full KV cache.

vLLM already implements this in the MTP proposer. ATOM native `openai_server` did **not**, so each of the 3 draft steps ran a full indexer pass. This PR **aligns ATOM draft behavior with vLLM and the model config** (correctness / parity), not only a micro-optimization.

**Scope:** draft propose only. Target verify is unchanged (long-ISL gap vs vLLM is mostly verify + acceptance; separate follow-up).

**Goals:**

- Honor `index_share_for_mtp_iteration` for GLM-5.2 MTP (n=3)
- Reduce redundant draft indexer work (3× → 1× per propose)
- No weight, algorithm, or verify-path changes; other draft backends unchanged

---

## Technical Details

### Changed files

| File | Change |
|------|--------|
| `atom/models/deepseek_mtp.py` | Add `set_skip_topk` / `compact_topk_indices` on `DeepSeekMultiTokenPredictor`; delegate from `DeepSeekMTP` |
| `atom/spec_decode/eagle.py` | Gate + drive skip/compact in `EagleProposer.propose()` |
| `tests/test_mtp_index_share.py` | Unit tests for helpers and gate logic |

### `deepseek_mtp.py`

- `DeepSeekMultiTokenPredictor.set_skip_topk(skip)` — sets `self_attn.skip_topk` on MTP layers with an indexer
- `DeepSeekMultiTokenPredictor.compact_topk_indices(slot_ids)` — copies top-k rows from `last_token_indices` into the front of `sparse_kv_indices_buffer`
- `DeepSeekMTP` delegates both methods

### `eagle.py`

In `__init__`, detect `_share_mtp_indices` and log when enabled.

In `propose()` loop:

- Step 0, before forward: `set_skip_topk(False)`
- Step 0, after forward: `set_skip_topk(True)` + `compact_topk_indices(last_token_indices)`
- Steps 1+: indexer skipped via `skip_topk=True`

### Enable gates (all required)

1. `speculative_config.method == "mtp"`
2. `draft_hf_config.index_share_for_mtp_iteration == True`
3. DSA model (`index_topk` in config)
4. `DeepSeekMultiTokenPredictor.set_skip_topk` exists

Eagle3, Qwen MTP, DSpark, and models without the flag are unaffected.

---

## Test Plan

### Unit tests

```bash
python -m pytest tests/test_mtp_index_share.py -v
```

Expected: 8 passed.

### Server smoke test

Start the GLM-5.2 MXFP4 MTP server per `recipes/GLM-5.md` (MI355 FP4 MTP). Confirm log line (per TP rank):

`MTP draft index_share_for_mtp_iteration enabled: step 0 computes indexer top-k, steps 1+ reuse the buffer.`

### Benchmark (fair A/B methodology)

Use `atom.benchmarks.benchmark_serving` with **fixed lengths** (`random-range-ratio=1.0`), 160 prompts, closed-loop (`request-rate=inf`), `--ignore-eos`, OSL=1024, CONC=16 — same as internal GLM-5.2 MTP quick bench.

**Important:** Compare **pre-PR vs post-PR on the same machine/session**, with a **clean MTP server** and a **valid pre-PR baseline** (main without this patch). An earlier internal run used a contaminated 10240 baseline (~633 out tok/s); that number is **invalid** and must not be used to evaluate this PR.

Suggested points: ISL=1024, 8192, 10240.

Acceptance: `accept_length` / `acceptance_rate` within ~1pp of baseline.

---

## Test Result

| Item | Value |
|------|-------|
| ATOM version | `0.1.6rc1.dev161+g00266a01f` (editable install with this PR) |
| Model | GLM-5.2-MXFP4, MTP n=3, TP=4, port 8055 |
| P0 log | `MTP draft index_share_for_mtp_iteration enabled` (×4 TP ranks) |

**Unit tests:** 8/8 passed

### Fair A/B (same container, 2026-07-24)

Pre-PR = main **without** this patch (`083220` / `083420` / `083658`). Post-PR = same session after patch + server restart (`090112` / `090310` / `090546`).

| ISL | out tok/s (before → after) | Δ | TPOT mean (before → after) | Δ | accept_len | accept_rate |
|-----|----------------------------|---|----------------------------|---|------------|-------------|
| 1024 | 1483.5 → 1555.0 | +4.8% | 10.11 ms → 9.69 ms | −4.2% | 2.97 → 3.05 | 65.7% → 68.3% |
| 8192 | 1150.3 → 1156.2 | +0.5% | 12.74 ms → 12.82 ms | +0.7% | 3.04 → 3.07 | 68.1% → 69.0% |
| 10240 | 1065.4 → 1069.1 | +0.3% | 13.77 ms → 13.65 ms | −1.2% | 3.07 → 3.10 | 68.9% → 70.1% |

**Interpretation**

- End-to-end gains at 8192/10240 are **~0–1%** on throughput / TPOT — expected because **verify dominates** E2E; P0 only removes **2 of 3 draft indexer passes** per propose.
- 1024 shows larger variance (+4.8% out); treat 8192/10240 as the stable read for long-context draft share.
- **No acceptance regression** vs valid baseline.
- vs vLLM at 10240 (~1521 out tok/s), gap remains (~+42%); this PR does not claim to close that gap.

**Retracted claim:** Pre-PR 10240 **633 out tok/s** / **23 ms TPOT** and post-PR **+70%** were driven by a **wrong baseline** (stale server / environment), not by this patch alone. Do not use those numbers in review.

Internal artifacts (optional for reviewers): `glm5.2/mxfp4/p0_draft_index_share/bench_dev161/` + `P0_压测结果_dev161.md` on our fork bench branch.

---

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

---

### Suggested follow-up comment (paste on the PR thread)

> **Benchmark update (fair A/B):** We re-ran pre/post on the same machine with a valid pre-PR baseline (`~1065` out tok/s @ ISL=10240, not `633`). End-to-end delta is **~0–1%** at 8192/10240; the PR value is primarily **vLLM/config parity** on draft indexer sharing, with no accept regression. Earlier **+70% @ 10240** in the description is **retracted**. Updated tables are in the PR body.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
