### PR TITLE
feat(cli): accept both --kebab-case and --snake_case for every flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ python -m atom.examples.simple_inference --model meta-llama/Meta-Llama-3-8B --kv
 
 > **Note:** First-time execution may take approximately 10 minutes for model compilation.
 
+> **Flags accept both spellings:** every long flag can be written kebab-case or
+> snake_case interchangeably (e.g. `--kv-cache-dtype` == `--kv_cache_dtype`).
+
 ### Serving
 
 Start an OpenAI-compatible server:

--- a/atom/benchmarks/benchmark_serving.py
+++ b/atom/benchmarks/benchmark_serving.py
@@ -35,7 +35,6 @@ import os
 import random
 import time
 import warnings
-from argparse import ArgumentParser as FlexibleArgumentParser
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
@@ -48,6 +47,7 @@ from atom.entrypoints.openai.chat_encoders import (
     apply_chat_template,
     load_custom_message_encoder,
 )
+from atom.utils.arg_parser import FlexibleArgumentParser
 
 from .backend_request_func import (
     ASYNC_REQUEST_FUNCS,

--- a/atom/entrypoints/atomesh/server.py
+++ b/atom/entrypoints/atomesh/server.py
@@ -149,8 +149,9 @@ def json_object_arg(raw_value: str) -> dict[str, Any]:
 
 def parse_standalone_args(raw_args: list[str]) -> StandaloneArgs:
     from atom.model_engine.arg_utils import EngineArgs
+    from atom.utils.arg_parser import FlexibleArgumentParser
 
-    parser = argparse.ArgumentParser(
+    parser = FlexibleArgumentParser(
         description="Atomesh Python interface",
         allow_abbrev=False,
     )

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -12,7 +12,6 @@ Usage:
     python -m atom.entrypoints.openai_server --model <model> [options]
 """
 
-import argparse
 import asyncio
 import base64
 import binascii
@@ -31,6 +30,7 @@ from atom import SamplingParams
 from atom.model_engine.arg_utils import EngineArgs
 from atom.model_engine.llm_engine import _load_tokenizer
 from atom.model_engine.request import RequestOutput
+from atom.utils.arg_parser import FlexibleArgumentParser
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from PIL import Image
@@ -1745,7 +1745,7 @@ def main():
     global engine, tokenizer, model_name, default_chat_template_kwargs, _request_logger
     global custom_message_encoder
 
-    parser = argparse.ArgumentParser(description="ATOM OpenAI API Server")
+    parser = FlexibleArgumentParser(description="ATOM OpenAI API Server")
     EngineArgs.add_cli_args(parser)
     parser.add_argument("--host", type=str, default=DEFAULT_HOST, help="Server host")
     parser.add_argument(

--- a/atom/examples/multimodal_inference.py
+++ b/atom/examples/multimodal_inference.py
@@ -9,8 +9,9 @@ from transformers import AutoProcessor
 
 from atom import SamplingParams
 from atom.model_engine.arg_utils import EngineArgs
+from atom.utils.arg_parser import FlexibleArgumentParser
 
-parser = argparse.ArgumentParser(
+parser = FlexibleArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     description=(
         "Generic image+text multimodal offline inference using the native ATOM engine.\n"

--- a/atom/examples/profile_offline.py
+++ b/atom/examples/profile_offline.py
@@ -7,8 +7,9 @@ from transformers import AutoTokenizer
 
 from atom import SamplingParams
 from atom.model_engine.arg_utils import EngineArgs
+from atom.utils.arg_parser import FlexibleArgumentParser
 
-parser = argparse.ArgumentParser(
+parser = FlexibleArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     description="Offline profiling example for Atom LLM Engine",
 )

--- a/atom/examples/simple_inference.py
+++ b/atom/examples/simple_inference.py
@@ -9,9 +9,10 @@ from atom.entrypoints.openai.chat_encoders import (
     load_custom_message_encoder,
 )
 from atom.model_engine.arg_utils import EngineArgs
+from atom.utils.arg_parser import FlexibleArgumentParser
 from transformers import AutoTokenizer
 
-parser = argparse.ArgumentParser(
+parser = FlexibleArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     description="config of test",
 )

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -143,9 +143,7 @@ class EngineArgs:
             help="Engine internal port",
         )
         parser.add_argument(
-            "--kv-cache-dtype",
             "--kv_cache_dtype",
-            dest="kv_cache_dtype",
             choices=["bf16", "fp8"],
             type=str,
             default="bf16",

--- a/atom/utils/arg_parser.py
+++ b/atom/utils/arg_parser.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""A drop-in ArgumentParser that accepts both spellings of every long flag.
+
+Historically some ATOM flags were registered kebab-case (``--tensor-parallel-size``)
+and some snake_case (``--kv_cache_dtype``), so users had to remember which was
+which. Rather than spelling out both forms on every ``add_argument`` call, this
+parser adds the missing counterpart automatically.
+"""
+
+import argparse
+
+__all__ = ["FlexibleArgumentParser"]
+
+
+class FlexibleArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser accepting both ``--kebab-case`` and ``--snake_case`` flags.
+
+    For each long option registered in one spelling, the dash/underscore
+    counterpart is auto-registered as an alias for the same ``dest``. Only the
+    flag *name* (after the leading ``--``) is transformed, so option *values* are
+    never touched — this is safe for JSON-valued flags such as
+    ``--online_quant_config '{"use_index_cache": true}'``. Short flags (``-tp``)
+    and positionals are left untouched, and ``dest`` still derives from the first
+    (original) option string, so existing callers are unaffected.
+    """
+
+    def add_argument(self, *names, **kwargs):
+        expanded = list(names)
+        for opt in names:
+            if not opt.startswith("--"):
+                continue
+            stem = opt[2:]
+            for alt in (
+                "--" + stem.replace("_", "-"),
+                "--" + stem.replace("-", "_"),
+            ):
+                # Skip the option itself, in-call duplicates, and any collision
+                # with an already-registered flag (a real argument wins over an
+                # auto-generated alias — never raise "conflicting option string").
+                if alt not in expanded and alt not in self._option_string_actions:
+                    expanded.append(alt)
+        return super().add_argument(*expanded, **kwargs)

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -39,13 +39,67 @@ if _atom_config_stub is not None:
         )
 
 from atom.model_engine.arg_utils import EngineArgs  # noqa: E402
+from atom.utils.arg_parser import FlexibleArgumentParser  # noqa: E402
+
+
+class TestFlexibleArgumentParser:
+    """Unit tests for the dash/underscore aliasing, isolated from EngineArgs."""
+
+    def test_snake_case_flag_accepts_kebab(self):
+        p = FlexibleArgumentParser()
+        p.add_argument("--kv_cache_dtype")
+        assert p.parse_args(["--kv-cache-dtype", "fp8"]).kv_cache_dtype == "fp8"
+        assert p.parse_args(["--kv_cache_dtype", "fp8"]).kv_cache_dtype == "fp8"
+
+    def test_kebab_case_flag_accepts_snake(self):
+        p = FlexibleArgumentParser()
+        p.add_argument("--tensor-parallel-size", type=int)
+        assert p.parse_args(["--tensor_parallel_size", "4"]).tensor_parallel_size == 4
+        assert p.parse_args(["--tensor-parallel-size", "4"]).tensor_parallel_size == 4
+
+    def test_short_flag_untouched(self):
+        p = FlexibleArgumentParser()
+        p.add_argument("--tensor-parallel-size", "-tp", type=int)
+        # short flag still works and no bogus alias was minted from it
+        assert p.parse_args(["-tp", "8"]).tensor_parallel_size == 8
+
+    def test_json_value_with_underscores_preserved(self):
+        # Only the flag name is rewritten; the value is passed through verbatim,
+        # so JSON payloads with underscore keys survive intact.
+        p = FlexibleArgumentParser()
+        p.add_argument("--online_quant_config")
+        ns = p.parse_args(["--online-quant-config", '{"global_quant_config": "fp8"}'])
+        assert ns.online_quant_config == '{"global_quant_config": "fp8"}'
+
+    def test_both_spellings_passed_explicitly_do_not_conflict(self):
+        # Callers that still spell out both forms (the pre-refactor style) must
+        # not trip a "conflicting option string" — the aliaser dedups instead.
+        p = FlexibleArgumentParser()
+        p.add_argument("--kv-cache-dtype", "--kv_cache_dtype", dest="kv_cache_dtype")
+        assert p.parse_args(["--kv-cache-dtype", "fp8"]).kv_cache_dtype == "fp8"
+        assert p.parse_args(["--kv_cache_dtype", "fp8"]).kv_cache_dtype == "fp8"
+
+    def test_boolean_optional_action_both_negations(self):
+        p = FlexibleArgumentParser()
+        p.add_argument(
+            "--enable_prefix_caching",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+        )
+        assert (
+            p.parse_args(["--no-enable_prefix_caching"]).enable_prefix_caching is False
+        )
+        assert (
+            p.parse_args(["--no-enable-prefix-caching"]).enable_prefix_caching is False
+        )
+        assert p.parse_args(["--enable-prefix-caching"]).enable_prefix_caching is True
 
 
 class TestKVCacheDtypeCliAlias:
-    """--kv-cache-dtype and --kv_cache_dtype must both set kv_cache_dtype."""
+    """--kv-cache-dtype and --kv_cache_dtype must both set kv_cache_dtype end-to-end."""
 
     def _parse(self, argv):
-        parser = argparse.ArgumentParser()
+        parser = FlexibleArgumentParser()
         EngineArgs.add_cli_args(parser)
         return parser.parse_args(argv)
 
@@ -57,6 +111,10 @@ class TestKVCacheDtypeCliAlias:
 
     def test_default(self):
         assert self._parse([]).kv_cache_dtype == "bf16"
+
+    def test_kebab_registered_flag_accepts_underscore(self):
+        # --tensor-parallel-size is registered kebab-case; underscore must work.
+        assert self._parse(["--tensor_parallel_size", "4"]).tensor_parallel_size == 4
 
 
 class TestEngineArgsSpeculativeValidation:


### PR DESCRIPTION
## Motivation

ATOM flags were registered inconsistently — most kebab-case
(`--tensor-parallel-size`), a few snake_case (`--kv_cache_dtype`,
`--enable_prefix_caching`, ...) — so users had to remember which spelling each
flag used. #1597 fixed this for a single flag by spelling out both option
strings and a `dest=` on that one `add_argument`. Doing that for *every* flag
would be repetitive and easy to forget on new flags.

## Technical Details

Introduces `FlexibleArgumentParser` (`atom/utils/arg_parser.py`), a drop-in
`argparse.ArgumentParser` whose `add_argument` auto-registers the
dash/underscore counterpart of every long option as an alias for the same
`dest`. One place, all flags — current and future.

- Only the flag **name** (after the leading `--`) is transformed, so option
  **values** are never touched — safe for JSON-valued flags like
  `--online_quant_config '{"use_index_cache": true}'`.
- Short flags (`-tp`) and positionals are left untouched.
- `dest` still derives from the first (original) option string, so existing
  callers are unaffected.
- An auto-alias that would collide with an already-registered flag is skipped
  (a real argument always wins; never raises "conflicting option string").

Wiring:
- Reverts the per-flag manual aliasing added in #1597 back to a single
  `--kv_cache_dtype` — the generic mechanism subsumes it.
- Routes the five parser creation sites (`simple_inference`, `profile_offline`,
  `multimodal_inference`, openai `api_server`, atomesh `server`) through
  `FlexibleArgumentParser`, so entrypoint-specific flags (e.g. the OpenAI
  server args, `--default-chat-template-kwargs`) accept both forms too.
- Points `benchmark_serving`'s `FlexibleArgumentParser` alias (previously a bare
  `argparse.ArgumentParser`) at the real implementation.

## Test Plan

- New isolated unit tests for `FlexibleArgumentParser`: snake→kebab and
  kebab→snake acceptance, short flag untouched, **JSON value with underscore
  keys preserved**, `BooleanOptionalAction` both negation forms, and
  both-spellings-passed-explicitly does not conflict.
- End-to-end tests over `EngineArgs.add_cli_args` (kv-cache-dtype both forms,
  and a kebab-registered flag accepted in underscore form).

## Test Result

- `tests/test_arg_utils_spec.py`: 17 passed.
- Full unit suite (`.github/scripts/run_unit_tests.sh`): 684 passed, 12 skipped.
- `ruff` / `black`: clean.

## Known trade-off

`--help` lists both spellings for each flag (one extra entry per flag). A custom
`HelpFormatter` could collapse the alias, but that adds machinery for a cosmetic
gain, so it is intentionally left out (KISS).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
