### PR TITLE
feat(benchmark): report Concurrency, Accept length and Acceptance rate

### DIFF
--- a/.github/scripts/plugin_benchmark_to_dashboard.py
+++ b/.github/scripts/plugin_benchmark_to_dashboard.py
@@ -146,6 +146,25 @@ def build_entries(
             value=payload.get("mean_tpot_ms"),
             extra=extra,
         )
+        # Speculative-decoding metrics; None for non-spec runs (append_metric
+        # skips them), so only MTP/DSpark/Eagle variants get these series.
+        append_metric(
+            entries,
+            label_prefix=label_prefix,
+            metric_label="Accept Length (tok/fwd)",
+            unit="tok/fwd",
+            value=payload.get("accept_length"),
+            extra=extra,
+        )
+        accept_rate = payload.get("acceptance_rate")
+        append_metric(
+            entries,
+            label_prefix=label_prefix,
+            metric_label="Acceptance Rate (%)",
+            unit="%",
+            value=(accept_rate * 100 if accept_rate is not None else None),
+            extra=extra,
+        )
 
         if "tensor_parallel_size" in payload:
             tp = int(payload["tensor_parallel_size"])

--- a/atom/benchmarks/benchmark_serving.py
+++ b/atom/benchmarks/benchmark_serving.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
 
+import aiohttp
 import numpy as np
 from tqdm.asyncio import tqdm
 from transformers import PreTrainedTokenizerBase
@@ -69,6 +70,7 @@ class BenchmarkMetrics:
     request_goodput: float
     output_throughput: float
     total_token_throughput: float
+    concurrency: float
     mean_ttft_ms: float
     median_ttft_ms: float
     std_ttft_ms: float
@@ -309,6 +311,9 @@ def calculate_metrics(
         request_goodput=good_completed / dur_s,
         output_throughput=sum(actual_output_lens) / dur_s,
         total_token_throughput=(total_input + sum(actual_output_lens)) / dur_s,
+        # Average number of requests in flight = sum of per-request end-to-end
+        # latencies divided by the wall-clock benchmark duration.
+        concurrency=sum(e2els) / dur_s,
         mean_ttft_ms=np.mean(ttfts or 0)
         * 1000,  # ttfts is empty if streaming is not supported by backend
         std_ttft_ms=np.std(ttfts or 0) * 1000,
@@ -337,6 +342,29 @@ def calculate_metrics(
     )
 
     return metrics, actual_output_lens
+
+
+async def get_spec_stats(base_url: str) -> Optional[dict]:
+    """Fetch speculative-decoding statistics from the ATOM server.
+
+    Returns the ``/debug/mtp_stats`` payload (which includes
+    ``average_tokens_per_forward`` = accept length = 1 + accepted draft tokens,
+    and ``acceptance_rate`` = accepted / drafted), or ``None`` when speculative
+    decoding is disabled or the endpoint is unavailable. The values are
+    cumulative since server start; for a per-config fresh server (the CI
+    benchmark flow) that is effectively this run.
+    """
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{base_url}/debug/mtp_stats") as resp:
+                if resp.status != 200:
+                    return None
+                stats = await resp.json()
+    except Exception:
+        return None
+    if not stats.get("enabled"):
+        return None
+    return stats
 
 
 async def benchmark(
@@ -518,6 +546,10 @@ async def benchmark(
         goodput_config_dict=goodput_config_dict,
     )
 
+    spec_stats = await get_spec_stats(base_url)
+    accept_length = spec_stats.get("average_tokens_per_forward") if spec_stats else None
+    acceptance_rate = spec_stats.get("acceptance_rate") if spec_stats else None
+
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
@@ -544,6 +576,11 @@ async def benchmark(
             "Total Token throughput (tok/s):", metrics.total_token_throughput
         )
     )
+    print("{:<40} {:<10.2f}".format("Concurrency:", metrics.concurrency))
+    if accept_length:
+        print("{:<40} {:<10.2f}".format("Accept length:", accept_length))
+    if acceptance_rate is not None:
+        print("{:<40} {:<10.2f}".format("Acceptance rate (%):", acceptance_rate * 100))
 
     result = {
         "duration": benchmark_duration,
@@ -554,6 +591,9 @@ async def benchmark(
         "request_goodput:": metrics.request_goodput if goodput_config_dict else None,
         "output_throughput": metrics.output_throughput,
         "total_token_throughput": metrics.total_token_throughput,
+        "concurrency": metrics.concurrency,
+        "accept_length": accept_length,
+        "acceptance_rate": acceptance_rate,
         "input_lens": [output.prompt_len for output in outputs],
         "output_lens": actual_output_lens,
         "ttfts": [output.ttft for output in outputs],

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -250,6 +250,9 @@ The `BenchmarkMetrics` dataclass tracks:
 | Output Token Throughput | -- | Generated tokens per second |
 | Total Token Throughput | -- | (input + output) tokens per second |
 | Request Goodput | -- | Requests per second meeting SLO targets |
+| Concurrency | -- | Average in-flight requests (sum of per-request end-to-end latency / benchmark duration) |
+| Accept Length | -- | Speculative decoding only: mean tokens per model forward (1 + accepted draft tokens), from `/debug/mtp_stats`; printed only when spec-decode is enabled |
+| Acceptance Rate | -- | Speculative decoding only: fraction of drafted tokens accepted (accepted / drafted), from `/debug/mtp_stats`; printed only when spec-decode is enabled |
 
 For each latency metric, mean, median, standard deviation, and configurable
 percentiles (default: P99) are reported.


### PR DESCRIPTION
## Motivation

The serving benchmark reported throughput and latency but not a few metrics
that help interpret a run:
- **Concurrency** — how many requests were actually in flight on average.
- **Accept length** — for speculative decoding, mean tokens emitted per model
  forward (1 + accepted draft tokens).
- **Acceptance rate** — for speculative decoding, the fraction of drafted
  tokens that were accepted.

## Technical Details

`atom/benchmarks/benchmark_serving.py`:
- `Concurrency` = sum of per-request end-to-end latencies / wall-clock
  duration. Computed client-side in `calculate_metrics`, always printed.
- `Accept length` (`average_tokens_per_forward`) and `Acceptance rate`
  (`acceptance_rate`) are fetched together from the server's existing
  `/debug/mtp_stats` endpoint via `get_spec_stats`. They print only when
  spec-decode is enabled; `get_spec_stats` returns `None` when the endpoint is
  unavailable or spec-decode is off, so the lines are skipped. No new
  dependency — `aiohttp` is already used by the benchmark client and declared
  in `pyproject.toml`.
- All three values are written to the result JSON.

`.github/scripts/plugin_benchmark_to_dashboard.py`:
- Tracks **Accept Length** and **Acceptance Rate** on the dashboard.
  `append_metric` skips `None`, so non-spec models emit no series and only
  spec-decode variants get these charts.

`docs/serving_benchmarking_guide.md`:
- Output-metrics table gains Concurrency, Accept Length and Acceptance Rate
  rows.

## Test Plan

Ran the standard server + benchmark flow on two models, one without and one
with speculative decoding.

## Test Result

gpt-oss-120b (tp1, 1024/1024, concurrency 64) — no spec-decode:

```
Total Token throughput (tok/s):          7631.64
Concurrency:                             62.36
```
Concurrency prints; the two spec lines are correctly omitted.

DeepSeek-V4-Pro MTP-3 (tp8, 1024/1024, concurrency 64) — spec-decode:

```
Total Token throughput (tok/s):          4993.70
Concurrency:                             57.29
Accept length:                           2.21
Acceptance rate (%):                     40.17
```
All three print and are self-consistent (3 drafts × 40.17% ≈ 1.2 accepted,
+1 bonus token = 2.21 accept length).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
