### PR TITLE
[draft] support ATOM plugin for qwen3.5 DPxTPx/DPxEPx

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2462,19 +2462,6 @@ direct_register_custom_op(
     tags=(torch.Tag.needs_fixed_stride_order,),
 )
 
-def get_aiter_topk_metadata_max_tokens(atom_config: Config, use_ep: bool) -> int:
-    """Return the topK metadata capacity required by the active MoE layout.
-
-    In DP-attention + EP, MoE/topK operates on the token view gathered across
-    DP ranks, so buffers sized only for the local per-rank token budget are too
-    small. Keep non-DP-attention paths unchanged to avoid unnecessary memory use.
-    """
-
-    max_num_tokens = int(atom_config.max_num_batched_tokens)
-    if bool(atom_config.enable_dp_attention) and use_ep:
-        dp_size = int(getattr(atom_config.parallel_config, "data_parallel_size", 1))
-        max_num_tokens *= max(1, dp_size)
-    return max_num_tokens
 
 @FusedMoEDecoratorForPluginMode
 class FusedMoE(torch.nn.Module):
@@ -2640,8 +2627,7 @@ class FusedMoE(torch.nn.Module):
                     if is_rocm_aiter_fuse_routed_scaling_factor()
                     else 1 / self.routed_scaling_factor
                 ),
-                max_num_tokens=get_aiter_topk_metadata_max_tokens(atom_config, self.use_ep), 
-                # max_num_tokens=atom_config.max_num_batched_tokens,
+                max_num_tokens=atom_config.max_num_batched_tokens,
                 is_EP=self.use_ep,
             )
         if fuse_shared_experts:

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2462,6 +2462,19 @@ direct_register_custom_op(
     tags=(torch.Tag.needs_fixed_stride_order,),
 )
 
+def get_aiter_topk_metadata_max_tokens(atom_config: Config, use_ep: bool) -> int:
+    """Return the topK metadata capacity required by the active MoE layout.
+
+    In DP-attention + EP, MoE/topK operates on the token view gathered across
+    DP ranks, so buffers sized only for the local per-rank token budget are too
+    small. Keep non-DP-attention paths unchanged to avoid unnecessary memory use.
+    """
+
+    max_num_tokens = int(atom_config.max_num_batched_tokens)
+    if bool(atom_config.enable_dp_attention) and use_ep:
+        dp_size = int(getattr(atom_config.parallel_config, "data_parallel_size", 1))
+        max_num_tokens *= max(1, dp_size)
+    return max_num_tokens
 
 @FusedMoEDecoratorForPluginMode
 class FusedMoE(torch.nn.Module):
@@ -2627,7 +2640,8 @@ class FusedMoE(torch.nn.Module):
                     if is_rocm_aiter_fuse_routed_scaling_factor()
                     else 1 / self.routed_scaling_factor
                 ),
-                max_num_tokens=atom_config.max_num_batched_tokens,
+                max_num_tokens=get_aiter_topk_metadata_max_tokens(atom_config, self.use_ep), 
+                # max_num_tokens=atom_config.max_num_batched_tokens,
                 is_EP=self.use_ep,
             )
         if fuse_shared_experts:

--- a/atom/plugin/sglang/attention_backend/attention_gdn.py
+++ b/atom/plugin/sglang/attention_backend/attention_gdn.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -122,8 +123,11 @@ class SGLangGDNForwardContext:
         atom_config = get_current_atom_config()
         enable_dp_attention = bool(getattr(atom_config, "enable_dp_attention", False))
         global_forward_mode = getattr(forward_batch, "global_forward_mode", None)
+        effective_forward_mode = (
+            global_forward_mode if global_forward_mode is not None else mode
+        )
         dp_uniform_decode = not enable_dp_attention or bool(
-            global_forward_mode is not None and global_forward_mode.is_decode_or_idle()
+            effective_forward_mode.is_decode_or_idle()
         )
         return (
             Context(
@@ -267,13 +271,18 @@ class SGLangGDNForwardContext:
         prev_context_kv = current_context.kv_cache_data
         try:
             set_kv_cache_data(forward_context.kv_cache_data)
-            attn_md = AttentionMetaData()
+            attn_md = (
+                copy.copy(prev_attn_metadata)
+                if reuse_current_context and prev_attn_metadata is not None
+                else AttentionMetaData()
+            )
             attn_md.gdn_metadata = forward_context.gdn_metadata
             if reuse_current_context:
                 # SGLangPluginRuntime already created the cross-rank-consistent
                 # Context and DPMetadata. Rebuilding it here would issue a second
                 # CPU all-reduce only on ranks where GDN metadata exists; idle
                 # ranks skip this binder and would never join that collective.
+                # Preserve all outer attention fields while injecting GDN data.
                 current_context.attn_metadata = attn_md
                 current_context.kv_cache_data = forward_context.kv_cache_data
             else:

--- a/atom/plugin/sglang/attention_backend/attention_gdn.py
+++ b/atom/plugin/sglang/attention_backend/attention_gdn.py
@@ -26,6 +26,7 @@ from atom.utils.forward_context import (
     AttentionMetaData,
     Context,
     _forward_kv_cache_context,
+    get_forward_context,
     reset_forward_context,
     set_forward_context,
     set_kv_cache_data,
@@ -118,12 +119,20 @@ class SGLangGDNForwardContext:
             if mode.is_extend()
             else int(forward_batch.batch_size)
         )
+        atom_config = get_current_atom_config()
+        enable_dp_attention = bool(getattr(atom_config, "enable_dp_attention", False))
+        global_forward_mode = getattr(forward_batch, "global_forward_mode", None)
+        dp_uniform_decode = not enable_dp_attention or bool(
+            global_forward_mode is not None and global_forward_mode.is_decode_or_idle()
+        )
         return (
             Context(
                 positions=forward_batch.positions,
                 is_prefill=is_prefill,
+                is_dummy_run=mode.is_idle(),
                 batch_size=forward_batch.batch_size,
                 graph_bs=forward_batch.batch_size,
+                dp_uniform_decode=dp_uniform_decode,
             ),
             num_tokens,
         )
@@ -252,17 +261,33 @@ class SGLangGDNForwardContext:
             return
 
         prev_kv = _forward_kv_cache_context.kv_cache_data
+        current_context = get_forward_context()
+        reuse_current_context = current_context.context is not None
+        prev_attn_metadata = current_context.attn_metadata
+        prev_context_kv = current_context.kv_cache_data
         try:
             set_kv_cache_data(forward_context.kv_cache_data)
             attn_md = AttentionMetaData()
             attn_md.gdn_metadata = forward_context.gdn_metadata
-            set_forward_context(
-                attn_metadata=attn_md,
-                atom_config=get_current_atom_config(),
-                context=forward_context.context,
-                num_tokens=forward_context.num_tokens,
-            )
+            if reuse_current_context:
+                # SGLangPluginRuntime already created the cross-rank-consistent
+                # Context and DPMetadata. Rebuilding it here would issue a second
+                # CPU all-reduce only on ranks where GDN metadata exists; idle
+                # ranks skip this binder and would never join that collective.
+                current_context.attn_metadata = attn_md
+                current_context.kv_cache_data = forward_context.kv_cache_data
+            else:
+                set_forward_context(
+                    attn_metadata=attn_md,
+                    atom_config=get_current_atom_config(),
+                    context=forward_context.context,
+                    num_tokens=forward_context.num_tokens,
+                )
             yield
         finally:
-            reset_forward_context()
+            if reuse_current_context:
+                current_context.attn_metadata = prev_attn_metadata
+                current_context.kv_cache_data = prev_context_kv
+            else:
+                reset_forward_context()
             set_kv_cache_data(prev_kv if prev_kv is not None else {})

--- a/atom/plugin/sglang/models/qwen3_5.py
+++ b/atom/plugin/sglang/models/qwen3_5.py
@@ -39,6 +39,8 @@ from atom.plugin.sglang.attention_backend.attention_gdn import (
 )
 from atom.plugin.sglang.runtime import (
     SGLangForwardBatchMetadata,
+    SGLangPluginRuntime,
+    plugin_runtime_scope,
 )
 
 _PACKED_MODULES_MAPPING = {
@@ -277,36 +279,49 @@ def _get_qwen35_language_model_stack_cls(
             **kwargs: Any,
         ):
             kwargs = dict(kwargs)
-            metadata = SGLangForwardBatchMetadata.build(
-                forward_batch,
-                pp_proxy_tensors=pp_proxy_tensors,
-                save_kv_cache=save_kv_cache,
-            )
             if inputs_embeds is None:
                 inputs_embeds = input_embeds
             if inputs_embeds is None:
                 inputs_embeds = kwargs.pop("inputs_embeds", None)
-            if intermediate_tensors is None:
-                intermediate_tensors = (
-                    SGLangForwardBatchMetadata.to_intermediate_tensors(
-                        pp_proxy_tensors,
-                        metadata,
-                    )
-                )
             del kwargs
-            with SGLangForwardBatchMetadata.bind(metadata):
-                with SGLangGDNForwardContext.bind(metadata):
-                    out = _forward_qwen35_decoder_stack(
-                        self.model,
-                        input_ids,
-                        positions,
-                        intermediate_tensors=intermediate_tensors,
-                        inputs_embeds=inputs_embeds,
-                        input_deepstack_embeds=input_deepstack_embeds,
+
+            with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
+                with SGLangPluginRuntime(
+                    atom_config=self.atom_config,
+                    forward_batch=forward_batch,
+                    positions=positions,
+                    input_ids=input_ids,
+                    input_embeds=inputs_embeds,
+                    set_forward_context=True,
+                ) as runtime:
+                    metadata = SGLangForwardBatchMetadata.build(
+                        runtime.forward_batch,
+                        pp_proxy_tensors=pp_proxy_tensors,
+                        save_kv_cache=save_kv_cache,
                     )
-            if isinstance(out, IntermediateTensors):
-                return PPProxyTensors(dict(out.tensors))
-            return out
+
+                    if intermediate_tensors is None:
+                        intermediate_tensors = (
+                            SGLangForwardBatchMetadata.to_intermediate_tensors(
+                                pp_proxy_tensors,
+                                metadata,
+                            )
+                        )
+
+                    with SGLangForwardBatchMetadata.bind(metadata):
+                        with SGLangGDNForwardContext.bind(metadata):
+                            out = _forward_qwen35_decoder_stack(
+                                self.model,
+                                runtime.input_ids,
+                                runtime.positions,
+                                intermediate_tensors=intermediate_tensors,
+                                inputs_embeds=runtime.input_embeds,
+                                input_deepstack_embeds=input_deepstack_embeds,
+                            )
+                    out = runtime.trim_output(out)
+                    if isinstance(out, IntermediateTensors):
+                        return PPProxyTensors(dict(out.tensors))
+                    return out
 
     _QWEN35_SGLANG_LANGUAGE_MODEL_STACKS[atom_model_cls] = (
         _AtomQwen35LanguageModelAdapter

--- a/atom/plugin/sglang/models/qwen3_5.py
+++ b/atom/plugin/sglang/models/qwen3_5.py
@@ -285,43 +285,47 @@ def _get_qwen35_language_model_stack_cls(
                 inputs_embeds = kwargs.pop("inputs_embeds", None)
             del kwargs
 
-            with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
-                with SGLangPluginRuntime(
+            with (
+                plugin_runtime_scope(framework="sglang", atom_config=self.atom_config),
+                SGLangPluginRuntime(
                     atom_config=self.atom_config,
                     forward_batch=forward_batch,
                     positions=positions,
                     input_ids=input_ids,
                     input_embeds=inputs_embeds,
                     set_forward_context=True,
-                ) as runtime:
-                    metadata = SGLangForwardBatchMetadata.build(
-                        runtime.forward_batch,
-                        pp_proxy_tensors=pp_proxy_tensors,
-                        save_kv_cache=save_kv_cache,
+                ) as runtime,
+            ):
+                metadata = SGLangForwardBatchMetadata.build(
+                    runtime.forward_batch,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                    save_kv_cache=save_kv_cache,
+                )
+
+                if intermediate_tensors is None:
+                    intermediate_tensors = (
+                        SGLangForwardBatchMetadata.to_intermediate_tensors(
+                            pp_proxy_tensors,
+                            metadata,
+                        )
                     )
 
-                    if intermediate_tensors is None:
-                        intermediate_tensors = (
-                            SGLangForwardBatchMetadata.to_intermediate_tensors(
-                                pp_proxy_tensors,
-                                metadata,
-                            )
-                        )
-
-                    with SGLangForwardBatchMetadata.bind(metadata):
-                        with SGLangGDNForwardContext.bind(metadata):
-                            out = _forward_qwen35_decoder_stack(
-                                self.model,
-                                runtime.input_ids,
-                                runtime.positions,
-                                intermediate_tensors=intermediate_tensors,
-                                inputs_embeds=runtime.input_embeds,
-                                input_deepstack_embeds=input_deepstack_embeds,
-                            )
-                    out = runtime.trim_output(out)
-                    if isinstance(out, IntermediateTensors):
-                        return PPProxyTensors(dict(out.tensors))
-                    return out
+                with (
+                    SGLangForwardBatchMetadata.bind(metadata),
+                    SGLangGDNForwardContext.bind(metadata),
+                ):
+                    out = _forward_qwen35_decoder_stack(
+                        self.model,
+                        runtime.input_ids,
+                        runtime.positions,
+                        intermediate_tensors=intermediate_tensors,
+                        inputs_embeds=runtime.input_embeds,
+                        input_deepstack_embeds=input_deepstack_embeds,
+                    )
+                out = runtime.trim_output(out)
+                if isinstance(out, IntermediateTensors):
+                    return PPProxyTensors(dict(out.tensors))
+                return out
 
     _QWEN35_SGLANG_LANGUAGE_MODEL_STACKS[atom_model_cls] = (
         _AtomQwen35LanguageModelAdapter

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -11,6 +11,7 @@ from typing import Any
 import torch
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
+from atom.models.utils import IntermediateTensors
 from atom.plugin.sglang.runtime.context import bind_current_forward_batch
 
 logger = logging.getLogger("atom.plugin.sglang.runtime.forward_context")
@@ -86,6 +87,8 @@ def _materialize_atom_dummy_forward(
 
 
 def _trim_hidden_states_for_output(hidden_states, num_tokens: int):
+    if isinstance(hidden_states, IntermediateTensors):
+        return hidden_states[:num_tokens]
     if torch.is_tensor(hidden_states):
         return hidden_states[:num_tokens]
     if isinstance(hidden_states, tuple):

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -51,32 +51,26 @@ def _materialize_atom_dummy_forward(
     ForwardBatch,
 ]:
     """Convert an empty SGLang IDLE batch into ATOM-style dummy inputs."""
-    # if positions is None and input_ids is None and input_embeds is None:
-    #     raise RuntimeError("SGLang dummy forward materialization requires positions,input ids, input embeds")
-    # if positions is None:
-    #     raise RuntimeError("SGLang dummy forward materialization requires positions")
-    # if input_ids is None:
-    # raise RuntimeError("SGLang dummy forward materialization requires input_ids")
     if positions is not None:
-        reference = positions
+        device = positions.device
     elif input_ids is not None:
-        reference = input_ids
+        device = input_ids.device
     elif input_embeds is not None:
-        reference = input_embeds
+        device = input_embeds.device
     else:
         raise RuntimeError(
-            "SGLang dummy forward materialization requires positions,input ids, input embeds"
+            "SGLang dummy forward materialization requires positions, input ids, input embeds"
         )
 
     dummy_positions = (
         positions.new_zeros((1,))
         if positions is not None
-        else torch.zeros((1,), dtype=torch.long, device=reference.device)
+        else torch.zeros((1,), dtype=torch.long, device=device)
     )
     dummy_input_ids = (
         input_ids.new_zeros((1,))
         if input_ids is not None
-        else torch.zeros((1,), dtype=torch.long, device=reference.device)
+        else torch.zeros((1,), dtype=torch.long, device=device)
     )
     dummy_input_embeds = _pad_dummy_like(input_embeds, length=1, fill_value=0)
 

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -59,7 +59,8 @@ def _materialize_atom_dummy_forward(
         device = input_embeds.device
     else:
         raise RuntimeError(
-            "SGLang dummy forward materialization requires positions, input ids, input embeds"
+            "SGLang dummy forward materialization requires at least one of "
+            "positions, input_ids, or input_embeds"
         )
 
     dummy_positions = (

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -51,14 +51,33 @@ def _materialize_atom_dummy_forward(
     ForwardBatch,
 ]:
     """Convert an empty SGLang IDLE batch into ATOM-style dummy inputs."""
+    # if positions is None and input_ids is None and input_embeds is None:
+    #     raise RuntimeError("SGLang dummy forward materialization requires positions,input ids, input embeds")
+    # if positions is None:
+    #     raise RuntimeError("SGLang dummy forward materialization requires positions")
+    # if input_ids is None:
+    # raise RuntimeError("SGLang dummy forward materialization requires input_ids")
+    if positions is not None:
+        reference = positions
+    elif input_ids is not None:
+        reference = input_ids
+    elif input_embeds is not None:
+        reference = input_embeds
+    else:
+        raise RuntimeError(
+            "SGLang dummy forward materialization requires positions,input ids, input embeds"
+        )
 
-    if positions is None:
-        raise RuntimeError("SGLang dummy forward materialization requires positions")
-    if input_ids is None:
-        raise RuntimeError("SGLang dummy forward materialization requires input_ids")
-
-    dummy_positions = positions.new_zeros((1,))
-    dummy_input_ids = input_ids.new_zeros((1,))
+    dummy_positions = (
+        positions.new_zeros((1,))
+        if positions is not None
+        else torch.zeros((1,), dtype=torch.long, device=reference.device)
+    )
+    dummy_input_ids = (
+        input_ids.new_zeros((1,))
+        if input_ids is not None
+        else torch.zeros((1,), dtype=torch.long, device=reference.device)
+    )
     dummy_input_embeds = _pad_dummy_like(input_embeds, length=1, fill_value=0)
 
     model_forward_batch = copy.copy(forward_batch)
@@ -86,7 +105,6 @@ def _resolve_num_tokens_across_dp(
     atom_config: Any,
     forward_batch: ForwardBatch,
     num_tokens: int,
-    is_dummy_run: bool,
 ) -> torch.Tensor:
     """Resolve per-DP token counts for ATOM's CPU-side DPMetadata."""
 
@@ -117,11 +135,10 @@ def _resolve_num_tokens_across_dp(
             (dp_size,), num_tokens, dtype=torch.int32, device="cpu"
         )
 
-    if is_dummy_run:
-        # SGLang reports idle ranks as 0 tokens, but ATOM materializes them
-        # as one local dummy token so collectives and DPMetadata stay aligned.
-        dp_rank = atom_config.parallel_config.data_parallel_rank
-        num_tokens_across_dp[dp_rank] = num_tokens
+    # SGLang reports idle ranks as 0 tokens, but ATOM materializes every idle
+    # rank as one physical dummy token. Normalize the complete vector on every
+    # rank so collectives and DPMetadata use identical sizes.
+    num_tokens_across_dp.clamp_min_(1)
     return num_tokens_across_dp
 
 
@@ -744,11 +761,19 @@ def _set_atom_forward_context(
             AttnState.PREFILL_PREFIX,
             AttnState.PREFILL_NATIVE,
         )
-    num_tokens = int(positions.shape[0])
+    # Qwen-VL mRoPE positions use [3, num_tokens], while ordinary position
+    # tensors use [num_tokens]. The token dimension is therefore the last
+    # dimension for mRoPE rather than the leading coordinate dimension.
+    num_tokens = int(
+        positions.shape[-1]
+        if positions.ndim == 2 and positions.shape[0] == 3
+        else positions.shape[0]
+    )
 
-    if bool(atom_config.enable_dp_attention):
+    enable_dp_attention = bool(atom_config.enable_dp_attention)
+    if enable_dp_attention:
         num_tokens_across_dp = _resolve_num_tokens_across_dp(
-            atom_config, forward_batch, num_tokens, is_dummy_run
+            atom_config, forward_batch, num_tokens
         )
         graph_bs = int(torch.max(num_tokens_across_dp).item())
     else:

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -64,11 +64,13 @@ def _materialize_atom_dummy_forward(
             "positions, input_ids, or input_embeds"
         )
 
-    dummy_positions = (
-        positions.new_zeros((1,))
-        if positions is not None
-        else torch.zeros((1,), dtype=torch.long, device=device)
-    )
+    if positions is not None:
+        dummy_positions_shape = (
+            (3, 1) if positions.ndim == 2 and positions.shape[0] == 3 else (1,)
+        )
+        dummy_positions = positions.new_zeros(dummy_positions_shape)
+    else:
+        dummy_positions = torch.zeros((1,), dtype=torch.long, device=device)
     dummy_input_ids = (
         input_ids.new_zeros((1,))
         if input_ids is not None
@@ -80,8 +82,18 @@ def _materialize_atom_dummy_forward(
     model_forward_batch.positions = dummy_positions
     model_forward_batch.batch_size = 1
     model_forward_batch.seq_lens_sum = 1
-    model_forward_batch.seq_lens = forward_batch.seq_lens.new_ones((1,))
-    model_forward_batch.seq_lens_cpu = forward_batch.seq_lens_cpu.new_ones((1,))
+    seq_lens = getattr(forward_batch, "seq_lens", None)
+    seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+    model_forward_batch.seq_lens = (
+        seq_lens.new_ones((1,))
+        if torch.is_tensor(seq_lens)
+        else torch.ones((1,), dtype=torch.int32, device=device)
+    )
+    model_forward_batch.seq_lens_cpu = (
+        seq_lens_cpu.new_ones((1,))
+        if torch.is_tensor(seq_lens_cpu)
+        else torch.ones((1,), dtype=torch.int32, device="cpu")
+    )
 
     return dummy_input_ids, dummy_positions, dummy_input_embeds, model_forward_batch
 

--- a/tests/plugin/test_sglang_gdn_forward_context.py
+++ b/tests/plugin/test_sglang_gdn_forward_context.py
@@ -2,12 +2,21 @@ from types import SimpleNamespace
 
 import torch
 
+from atom.plugin.sglang.attention_backend import attention_gdn
 from atom.plugin.sglang.attention_backend.attention_gdn import (
     SGLangGDNForwardContext,
 )
 
 
 class _DecodeMode:
+    @staticmethod
+    def is_prefill():
+        return False
+
+    @staticmethod
+    def is_idle():
+        return False
+
     @staticmethod
     def is_target_verify():
         return False
@@ -53,3 +62,65 @@ def test_build_gdn_metadata_reconstructs_missing_forward_metadata():
         metadata.non_spec_state_indices_tensor,
         torch.tensor([10, 11], dtype=torch.int32),
     )
+
+
+def test_build_context_falls_back_to_local_decode_mode(monkeypatch):
+    monkeypatch.setattr(
+        attention_gdn,
+        "get_current_atom_config",
+        lambda: SimpleNamespace(enable_dp_attention=True),
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=_DecodeMode(),
+        positions=torch.zeros(2, dtype=torch.long),
+        batch_size=2,
+    )
+
+    context, num_tokens = SGLangGDNForwardContext._build_context(forward_batch)
+
+    assert context.dp_uniform_decode
+    assert num_tokens == 2
+
+
+def test_bind_preserves_outer_attention_metadata(monkeypatch):
+    slot_mapping = object()
+    outer_metadata = SimpleNamespace(max_seqlen_k=128, slot_mapping=slot_mapping)
+    outer_kv = {"outer": object()}
+    current_context = SimpleNamespace(
+        context=object(),
+        attn_metadata=outer_metadata,
+        kv_cache_data=outer_kv,
+    )
+    gdn_metadata = object()
+    inner_kv = {"inner": object()}
+    forward_context = SimpleNamespace(
+        gdn_metadata=gdn_metadata,
+        kv_cache_data=inner_kv,
+    )
+    kv_updates = []
+
+    def fail_if_forward_context_is_rebuilt(**_kwargs):
+        raise AssertionError("outer forward context must be reused")
+
+    monkeypatch.setattr(
+        SGLangGDNForwardContext,
+        "build",
+        classmethod(lambda cls, _metadata: forward_context),
+    )
+    monkeypatch.setattr(attention_gdn, "get_forward_context", lambda: current_context)
+    monkeypatch.setattr(attention_gdn, "set_kv_cache_data", kv_updates.append)
+    monkeypatch.setattr(
+        attention_gdn, "set_forward_context", fail_if_forward_context_is_rebuilt
+    )
+
+    with SGLangGDNForwardContext.bind(object()):
+        bound_metadata = current_context.attn_metadata
+        assert bound_metadata is not outer_metadata
+        assert bound_metadata.max_seqlen_k == 128
+        assert bound_metadata.slot_mapping is slot_mapping
+        assert bound_metadata.gdn_metadata is gdn_metadata
+        assert current_context.kv_cache_data is inner_kv
+
+    assert current_context.attn_metadata is outer_metadata
+    assert current_context.kv_cache_data is outer_kv
+    assert kv_updates[0] is inner_kv

--- a/tests/plugin/test_sglang_qwen35_wrapper.py
+++ b/tests/plugin/test_sglang_qwen35_wrapper.py
@@ -101,6 +101,12 @@ def _make_fake_modules() -> dict[str, ModuleType]:
                 {},
             ),
         ),
+        "atom.plugin.sglang.runtime": _module(
+            "atom.plugin.sglang.runtime",
+            SGLangForwardBatchMetadata=object,
+            SGLangPluginRuntime=object,
+            plugin_runtime_scope=lambda **_kwargs: None,
+        ),
         "atom.plugin.sglang.models.base_model_wrapper": _module(
             "atom.plugin.sglang.models.base_model_wrapper",
             SGLangForwardBatchMetadata=type(

--- a/tests/plugin/test_sglang_qwen35_wrapper.py
+++ b/tests/plugin/test_sglang_qwen35_wrapper.py
@@ -5,6 +5,7 @@
 
 import importlib
 import sys
+from contextlib import nullcontext
 from types import ModuleType
 from unittest.mock import patch
 
@@ -82,7 +83,7 @@ def _make_fake_modules() -> dict[str, ModuleType]:
             Qwen3_5Model=type("Qwen3_5Model", (), {}),
             Qwen3_5MoeForCausalLM=type("Qwen3_5MoeForCausalLM", (), {}),
             detect_fused_expert_format=lambda *_a, **_k: False,
-            get_fused_expert_mapping=lambda: [],
+            get_fused_expert_mapping=list,
             load_fused_expert_weights=lambda *_a, **_k: True,
         ),
         "atom.models.utils": _module(
@@ -105,7 +106,7 @@ def _make_fake_modules() -> dict[str, ModuleType]:
             "atom.plugin.sglang.runtime",
             SGLangForwardBatchMetadata=object,
             SGLangPluginRuntime=object,
-            plugin_runtime_scope=lambda **_kwargs: None,
+            plugin_runtime_scope=lambda **_kwargs: nullcontext(),
         ),
         "atom.plugin.sglang.models.base_model_wrapper": _module(
             "atom.plugin.sglang.models.base_model_wrapper",

--- a/tests/plugin/test_sglang_runtime_forward_context.py
+++ b/tests/plugin/test_sglang_runtime_forward_context.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Regression tests for SGLang-to-ATOM forward normalization."""
+
+import importlib.util
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from atom.models.utils import IntermediateTensors
+
+
+def _package(name: str) -> ModuleType:
+    module = ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _load_forward_context_module():
+    @contextmanager
+    def bind_current_forward_batch(_forward_batch):
+        yield
+
+    fake_modules = {
+        "sglang": _package("sglang"),
+        "sglang.srt": _package("sglang.srt"),
+        "sglang.srt.model_executor": _package("sglang.srt.model_executor"),
+        "sglang.srt.model_executor.forward_batch_info": ModuleType(
+            "sglang.srt.model_executor.forward_batch_info"
+        ),
+        "atom.plugin": _package("atom.plugin"),
+        "atom.plugin.sglang": _package("atom.plugin.sglang"),
+        "atom.plugin.sglang.runtime": _package("atom.plugin.sglang.runtime"),
+        "atom.plugin.sglang.runtime.context": ModuleType(
+            "atom.plugin.sglang.runtime.context"
+        ),
+    }
+    fake_modules["sglang.srt.model_executor.forward_batch_info"].ForwardBatch = object
+    fake_modules["atom.plugin.sglang.runtime.context"].bind_current_forward_batch = (
+        bind_current_forward_batch
+    )
+
+    module_name = "_test_sglang_runtime_forward_context"
+    module_path = (
+        Path(__file__).parents[2]
+        / "atom"
+        / "plugin"
+        / "sglang"
+        / "runtime"
+        / "forward_context.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, fake_modules):
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.modules.pop(module_name, None)
+    return module
+
+
+def test_idle_runtime_trims_pipeline_intermediate_tensors():
+    module = _load_forward_context_module()
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_idle=lambda: True),
+        positions=torch.empty(0, dtype=torch.long),
+        seq_lens=torch.empty(0, dtype=torch.int32),
+        seq_lens_cpu=torch.empty(0, dtype=torch.int32),
+        batch_size=0,
+        seq_lens_sum=0,
+    )
+    runtime = module.SGLangPluginRuntime(
+        atom_config=SimpleNamespace(),
+        forward_batch=forward_batch,
+        positions=forward_batch.positions,
+        input_ids=torch.empty(0, dtype=torch.long),
+        set_forward_context=False,
+    )
+
+    with runtime:
+        assert runtime.positions.shape == (1,)
+        assert runtime.forward_batch.seq_lens.tolist() == [1]
+
+        output = IntermediateTensors(
+            {
+                "hidden_states": torch.ones(1, 4),
+                "residual": torch.ones(1, 4),
+            }
+        )
+        trimmed = runtime.trim_output(output)
+
+    assert isinstance(trimmed, IntermediateTensors)
+    assert trimmed["hidden_states"].shape == (0, 4)
+    assert trimmed["residual"].shape == (0, 4)
+
+
+def test_dp_token_counts_materialize_every_idle_rank():
+    module = _load_forward_context_module()
+    atom_config = SimpleNamespace(parallel_config=SimpleNamespace(data_parallel_size=4))
+    forward_batch = SimpleNamespace(global_num_tokens_cpu=[0, 3, 0, 2])
+
+    token_counts = module._resolve_num_tokens_across_dp(
+        atom_config, forward_batch, num_tokens=1
+    )
+
+    assert token_counts.dtype == torch.int32
+    assert token_counts.device.type == "cpu"
+    assert token_counts.tolist() == [1, 3, 1, 2]

--- a/tests/plugin/test_sglang_runtime_forward_context.py
+++ b/tests/plugin/test_sglang_runtime_forward_context.py
@@ -100,6 +100,30 @@ def test_idle_runtime_trims_pipeline_intermediate_tensors():
     assert trimmed["residual"].shape == (0, 4)
 
 
+def test_idle_runtime_preserves_mrope_shape_without_sequence_lengths():
+    module = _load_forward_context_module()
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_idle=lambda: True),
+        positions=torch.empty((3, 0), dtype=torch.long),
+        seq_lens=None,
+        batch_size=0,
+        seq_lens_sum=0,
+    )
+    runtime = module.SGLangPluginRuntime(
+        atom_config=SimpleNamespace(),
+        forward_batch=forward_batch,
+        positions=forward_batch.positions,
+        input_ids=None,
+        set_forward_context=False,
+    )
+
+    with runtime:
+        assert runtime.positions.shape == (3, 1)
+        assert runtime.forward_batch.seq_lens.tolist() == [1]
+        assert runtime.forward_batch.seq_lens_cpu.tolist() == [1]
+        assert runtime.forward_batch.seq_lens_cpu.device.type == "cpu"
+
+
 def test_dp_token_counts_materialize_every_idle_rank():
     module = _load_forward_context_module()
     atom_config = SimpleNamespace(parallel_config=SimpleNamespace(data_parallel_size=4))


### PR DESCRIPTION
## Summary

Add Qwen3.5 SGLang plugin support for DP-attention layouts, including DP+TP and DP+EP execution.

This change makes the Qwen3.5-specific language-model adapter use the same `SGLangPluginRuntime` lifecycle as the generic ATOM SGLang wrapper, and fixes the nested GDN context handling that previously caused rank-divergent collectives.

## Problem

Qwen3.5 uses a dedicated SGLang language-model adapter instead of the generic ATOM causal-LM wrapper. As a result:

- idle DP ranks could pass zero-token tensors into AITER GEMM kernels (`M=0`);
- Qwen3.5-VL idle forwards could omit `positions` and `input_ids`;
- mRoPE positions shaped `[3, num_tokens]` were interpreted as three tokens;
- each rank could build a different physical DP token-count vector after idle batches were materialized;
- the nested GDN binder rebuilt `ForwardContext`/`DPMetadata` and issued a second CPU all-reduce only on ranks with valid GDN metadata, while idle ranks skipped it and later waited in a different collective.

The last issue produced a deterministic distributed deadlock: active ranks waited in GDN DP metadata synchronization while idle ranks progressed to the logits all-gather.

## Implementation

### Qwen3.5 SGLang adapter

- Wrap the Qwen3.5 language-model forward with `plugin_runtime_scope` and `SGLangPluginRuntime`.
- Build SGLang metadata from the runtime-normalized batch.
- Forward the normalized `input_ids`, `positions`, and `input_embeds` to the ATOM decoder.
- Trim physical dummy-token outputs back to the logical SGLang token count.

### SGLang forward-context bridge

- Materialize an idle batch from any available tensor (`positions`, `input_ids`, or `input_embeds`).
- Create fallback dummy positions/token IDs when Qwen3.5-VL does not provide them.
- Normalize every zero entry in the cross-DP token-count vector to one physical dummy token so all ranks use identical `DPMetadata`.
- Read the token dimension correctly for mRoPE `[3, num_tokens]` positions.
- Propagate SGLang's global forward mode into `dp_uniform_decode` so mixed EXTEND/IDLE steps use the variable-length DP path.

### GDN context handling

- Reuse the cross-rank-consistent `ForwardContext` and `DPMetadata` already created by `SGLangPluginRuntime`.
- Temporarily inject only GDN attention metadata and KV-cache data.
- Restore the previous metadata/cache on exit instead of resetting the complete context.
- Retain the previous standalone fallback when no outer context exists.

This prevents GDN from creating a second, rank-local DP synchronization point.

## Parallel layouts covered

For the full-DP SGLang configurations used here:

- `TPN`: attention/dense TP=N, expert TP=N.
- `DPNTPN`: attention DP=N with physical attention TP=1; experts use logical TP=N over the DP ranks.
- `DPNEPN`: attention DP=N with physical attention TP=1; experts use EP=N and TP=1. When MORI is available, expert tokens use MORI dispatch/combine.

## Performance results

Measured Qwen3.5-397B results on AMD Instinct MI308X GPUs with OSL=2048. TP8 and TP8DP8 use the separate concurrency settings shown below, so the comparison reflects the tested configurations rather than equal-load scaling.

| Layout | ISL/OSL | Concurrency | Prompts | Successful | Total throughput (tok/s) | Input throughput (tok/s) | Output throughput (tok/s) | Median TTFT (ms) | Median TPOT (ms) | Duration (s) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| TP8 | 4096/2048 | 216 | 432 | 432 | 5451.97 | 3634.65 | 1817.32 | 37408.86 | 100.70 | 486.83 |
| TP8 | 6144/2048 | 160 | 320 | 320 | 5651.08 | 4238.31 | 1412.77 | 40645.01 | 93.52 | 463.88 |
| TP8 | 14336/2048 | 80 | 160 | 160 | 6784.86 | 5936.75 | 848.11 | 49087.91 | 70.38 | 386.37 |
| TP8 | 30720/2048 | 40 | 80 | 80 | 7087.62 | 6644.64 | 442.98 | 50416.43 | 65.79 | 369.86 |
| TP8 | 63488/2048 | 20 | 40 | 40 | 6747.36 | 6536.51 | 210.86 | 52134.43 | 69.40 | 388.51 |
| TP8 | 129024/2048 | 8 | 16 | 16 | 6547.94 | 6445.62 | 102.31 | 55508.87 | 51.22 | 320.28 |
| TP8DP8 | 4096/2048 | 608 | 1216 | 1216 | 6972.32 | 4648.21 | 2324.11 | 147548.01 | 127.51 | 1071.54 |
| TP8DP8 | 6144/2048 | 512 | 1024 | 1024 | 7301.85 | 5476.39 | 1825.46 | 165676.38 | 143.10 | 1148.83 |
| TP8DP8 | 14336/2048 | 256 | 512 | 512 | 7688.74 | 6727.65 | 961.09 | 118323.00 | 196.07 | 1091.03 |
| TP8DP8 | 30720/2048 | 128 | 256 | 256 | 7499.75 | 7031.01 | 468.73 | 112871.17 | 191.42 | 1118.52 |
| TP8DP8 | 63488/2048 | 64 | 128 | 128 | 7142.03 | 6918.84 | 223.19 | 172455.53 | 183.74 | 1174.54 |
| TP8DP8 | 129024/2048 | 32 | 64 | 64 | 5178.52 | 5097.60 | 80.91 | 213152.23 | 249.80 | 1619.89 |

Total throughput change for TP8DP8 relative to TP8 at the listed concurrency settings: +27.9%, +29.2%, +13.3%, +5.8%, +5.8%, and -20.9% from ISL 4096 through 129024, respectively.