### PR TITLE
[atom-plugin-accuracy] Use /mnt/dcgpuval cache mount for accuracy validation for mi355

### DIFF
--- a/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
@@ -155,7 +155,9 @@ jobs:
           MODEL_MOUNT_PATH="/models"
           HF_CACHE_ROOT=""
 
-          if [ -d "/shared/data/WRH/models" ]; then
+          if [ -d "/mnt/dcgpuval" ]; then
+            MODEL_CACHE_ROOT="/mnt/dcgpuval"
+          elif [ -d "/shared/data/WRH/models" ]; then
             MODEL_CACHE_ROOT="/shared/data/WRH/models"
           elif [ -d "/mnt/raid0/pretrained_model" ]; then
             MODEL_CACHE_ROOT="/mnt/raid0/pretrained_model"

--- a/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation-gpu-shard.yaml
@@ -349,7 +349,7 @@ jobs:
             lock_suffix="$(printf '%s' "${{ matrix.model_path }}" | tr '/:@' '___')"
             if ! $CONTAINER_ENGINE exec \
               -e HF_TOKEN="${HF_TOKEN:-}" \
-              -e MODEL_CACHE_ROOT="${MODEL_CACHE_ROOT}" \
+              -e MODEL_MOUNT_PATH="${MODEL_MOUNT_PATH}" \
               -e MODEL_PATH="${{ matrix.model_path }}" \
               -e MODEL_DIR="$model_dir" \
               -e RUNNER_NAME="${{ matrix.runner }}" \
@@ -382,7 +382,7 @@ jobs:
                   echo "Baremetal runner ${RUNNER_NAME} detected; skipping shared model download lock"
                   download_model
                 else
-                  lock_dir="${MODEL_CACHE_ROOT}/.cache/atom-download-locks"
+                  lock_dir="${MODEL_MOUNT_PATH}/.cache/atom-download-locks"
                   mkdir -p "$lock_dir"
                   lock_file="$lock_dir/${LOCK_SUFFIX}.lock"
                   exec 9>"$lock_file"

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -2,8 +2,8 @@ name: ATOM vLLM Nightly
 
 on:
   schedule:
-    # Nightly at 02:00 Beijing time (18:00 UTC on the previous day)
-    - cron: '0 18 * * *'
+    # Nightly at 00:00 Beijing time (16:00 UTC on the previous day)
+    - cron: '0 16 * * *'
   workflow_dispatch:
     # Manual runs use GitHub Actions' built-in branch dropdown ("Use workflow
     # from") as the ATOM branch selector, so users do not need to type branch

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -960,27 +960,34 @@ jobs:
       - name: Prepare model cache mount
         if: ${{ steps.validation-window.outputs.should_run == 'true' }}
         run: |
+          MODEL_CACHE_ROOT=""
           MODEL_CACHE_MOUNT=""
           MODEL_CACHE_DESC="container-local /models (no host cache mount)"
-          if [ -d "/shared/data/WRH/models" ]; then
-            MODEL_CACHE_MOUNT="-v /shared/data/WRH/models:/models"
-            MODEL_CACHE_DESC="/shared/data/WRH/models (shared host path)"
+          MODEL_MOUNT_PATH="/models"
+          if [ -d "/mnt/dcgpuval" ]; then
+            MODEL_CACHE_ROOT="/mnt/dcgpuval"
+          elif [ -d "/shared/data/WRH/models" ]; then
+            MODEL_CACHE_ROOT="/shared/data/WRH/models"
           elif [ -d "/it-share/models" ]; then
-            MODEL_CACHE_MOUNT="-v /it-share/models:/models"
-            MODEL_CACHE_DESC="/it-share/models (shared host path)"
+            MODEL_CACHE_ROOT="/it-share/models"
           elif [ -d "/models" ]; then
-            MODEL_CACHE_MOUNT="-v /models:/models"
-            MODEL_CACHE_DESC="/models (shared host path)"
+            MODEL_CACHE_ROOT="/models"
           elif [ -d "/data/models" ]; then
-            MODEL_CACHE_MOUNT="-v /data/models:/models"
-            MODEL_CACHE_DESC="/data/models (shared host path)"
+            MODEL_CACHE_ROOT="/data/models"
+          fi
+
+          if [ -n "${MODEL_CACHE_ROOT}" ]; then
+            MODEL_CACHE_MOUNT="-v ${MODEL_CACHE_ROOT}:${MODEL_MOUNT_PATH}"
+            MODEL_CACHE_DESC="${MODEL_CACHE_ROOT} (shared host path)"
           else
-            echo "No shared host model cache found; using container-local /models."
+            echo "No shared host model cache found; using container-local ${MODEL_MOUNT_PATH}."
           fi
 
           echo "Using model cache backend: ${MODEL_CACHE_DESC}"
+          echo "MODEL_CACHE_ROOT=${MODEL_CACHE_ROOT}" >> "$GITHUB_ENV"
           echo "MODEL_CACHE_MOUNT=${MODEL_CACHE_MOUNT}" >> "$GITHUB_ENV"
           echo "MODEL_CACHE_DESC=${MODEL_CACHE_DESC}" >> "$GITHUB_ENV"
+          echo "MODEL_MOUNT_PATH=${MODEL_MOUNT_PATH}" >> "$GITHUB_ENV"
 
       - name: Clean up old containers
         if: ${{ steps.validation-window.outputs.should_run == 'true' }}
@@ -1186,7 +1193,7 @@ jobs:
         if: ${{ steps.validation-window.outputs.should_run == 'true' }}
         run: |
           set -euo pipefail
-          model_dir="/models/${{ matrix.model_path }}"
+          model_dir="${MODEL_MOUNT_PATH}/${{ matrix.model_path }}"
           if [ "${OOT_MODEL_AVAILABLE_LOCALLY:-false}" = "true" ]; then
             echo "Using local model path ${OOT_RESOLVED_MODEL_PATH}; skip download."
             exit 0
@@ -1248,7 +1255,7 @@ jobs:
               exit 1
             fi
           else
-            echo "/models directory not mounted; skipping model download"
+            echo "${MODEL_MOUNT_PATH} directory not mounted; skipping model download"
           fi
 
       - name: Resolve OOT model path
@@ -1259,8 +1266,8 @@ jobs:
             exit 0
           fi
           if [ -n "${MODEL_CACHE_MOUNT}" ]; then
-            echo "OOT_RESOLVED_MODEL_PATH=/models/${{ matrix.model_path }}" >> "$GITHUB_ENV"
-            echo "Using mounted model path: /models/${{ matrix.model_path }}"
+            echo "OOT_RESOLVED_MODEL_PATH=${MODEL_MOUNT_PATH}/${{ matrix.model_path }}" >> "$GITHUB_ENV"
+            echo "Using mounted model path: ${MODEL_MOUNT_PATH}/${{ matrix.model_path }}"
           else
             echo "OOT_RESOLVED_MODEL_PATH=${{ matrix.model_path }}" >> "$GITHUB_ENV"
             echo "Using model id: ${{ matrix.model_path }}"

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -1006,6 +1006,11 @@ jobs:
           else
             DEVICE_FLAG="--device /dev/dri"
           fi
+          if [ "${CONTAINER_ENGINE}" = "podman" ]; then
+            GROUP_ADD_FLAG="--group-add keep-groups"
+          else
+            GROUP_ADD_FLAG="--group-add video"
+          fi
 
           MODEL_MOUNT="${MODEL_CACHE_MOUNT}"
           echo "Using model cache backend: ${MODEL_CACHE_DESC}"
@@ -1022,7 +1027,7 @@ jobs:
             -v "${GITHUB_WORKSPACE:-$PWD}":/workspace \
             $MODEL_MOUNT \
             -w /workspace \
-            --ipc=host --group-add keep-groups \
+            --ipc=host $GROUP_ADD_FLAG \
             --privileged \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \


### PR DESCRIPTION
## Summary
- Add `/mnt/dcgpuval` as the preferred model cache mount for ATOM-vLLM accuracy validation.
- Use `/mnt/dcgpuval` only for the MI355 SGLang accuracy shard, while keeping existing fallback cache paths for other shards.
- Select the correct container group flag for vLLM accuracy runs: `keep-groups` for podman and `video` for docker.

## Test Plan
- Verified workflow YAML diagnostics show no linter errors.
- Reviewed git diff to confirm SGLang changes are limited to the GPU shard and MI355 path.