### PR TITLE
Fix DSpark mtp3 + DP + PIECEWISE tail-drain hang

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2201,6 +2201,7 @@ class ModelRunner:
             # multi-rank branch (`not enable_dp_attention` => True) and the
             # Context default — otherwise single-GPU/TP-only decode would
             # be forced into eager and lose the CUDAGraph decode path.
+            self._dspark_decode_replay = True
             return (
                 num_input_tokens,
                 None,
@@ -2221,6 +2222,7 @@ class ModelRunner:
             local_can_split=local_can_split,
             local_ub_tokens=(local_ub0, local_ub1),
             dspark_shape=dspark_shape,
+            local_is_dummy=bool(getattr(batch, "is_dummy_run", False)),
         )
 
         max_tokens = int(sync.num_tokens_across_dp.max())
@@ -2231,6 +2233,8 @@ class ModelRunner:
             # CUDAGraph path: all ranks pad to the same max for fixed-size all_gather.
             num_input_tokens = max_tokens
         # else: variable-length path — each rank keeps its own token count.
+
+        self._dspark_decode_replay = dp_uniform_decode and not sync.any_dummy
 
         return (
             num_input_tokens,
@@ -2556,6 +2560,8 @@ class ModelRunner:
             ub_max_tokens_across_dp,
             _dspark_shape_max,
         ) = preprocessed
+        # NOTE: self._dspark_decode_replay is set inside _preprocess (it needs
+        # sync.any_dummy), so it's already current here for build()/run_model.
 
         if not tbo_collective_active:
             self._pcp_tbo_balanced_active = False
@@ -3506,10 +3512,13 @@ class ModelRunner:
                 else int(batch.total_tokens_num_decode)
             )
             buckets = self._piecewise_sorted_tokens
-            idx = bisect.bisect_left(buckets, real_tokens)
-            if idx < len(buckets):
-                return buckets[idx], real_tokens, True
-            # total tokens exceeds the largest captured bucket -> eager.
+            q = int(max_q_len)
+            # Pick the q-divisible bucket N; replay only when all-real (see
+            # _dspark_decode_replay -- any dummy this step -> everyone eager).
+            _replay = bool(getattr(self, "_dspark_decode_replay", False))
+            for b in buckets:
+                if b >= real_tokens and q > 0 and b % q == 0:
+                    return b, real_tokens, _replay
             return max(real_tokens, graph_bs * max_q_len), real_tokens, False
 
         num_tokens_pad = graph_bs * max_q_len
@@ -3537,9 +3546,14 @@ class ModelRunner:
             return default_graph_bs
         q = int(batch.num_spec_query_tokens)
         buckets = self._piecewise_sorted_tokens
-        idx = bisect.bisect_left(buckets, int(dp_total_tokens))
-        if idx < len(buckets) and q > 0 and buckets[idx] % q == 0:
-            return buckets[idx] // q
+        # Select the SAME q-divisible bucket N that _piecewise_replay_shape picks
+        # (smallest captured bucket >= dp_total_tokens with q | N), and return
+        # graph_bs = N // q. Then graph_bs*max_seqlen_q == N on EVERY rank, so the
+        # eager (dummy) MoE all_gather size equals the size baked into the real
+        # ranks' replayed piecewise graph -> no cross-rank collective mismatch.
+        for b in buckets:
+            if b >= int(dp_total_tokens) and q > 0 and b % q == 0:
+                return int(b) // q
         return default_graph_bs
 
     def _dspark_capture_q_buckets(self, full_q: int) -> list[int]:

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1471,9 +1471,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         attn_metadata.compress_plans = compress_plans
         attn_metadata.swa_block_tables = swa_bt_gpu
         # DSpark RAGGED: pass per-seq verify lengths + full_q to the (rectangular-
-        # only) decode indexer so it can pad Q back to [bs, full_q]. Eager-only;
-        # None on the regular rectangular path.
-        if ragged_lens is not None:
+        # only) decode indexer so it can pad Q back to [bs, full_q].
+        _drafter = getattr(self.model_runner, "drafter", None)
+        _dspark_ragged_graph = (
+            self.model_runner.config.dspark.ragged
+            and _drafter is not None
+            and getattr(_drafter, "dspark_confidence_schedule", False)
+        )
+        if ragged_lens is not None or _dspark_ragged_graph:
             attn_metadata.dspark_ragged_lens_gpu = torch.as_tensor(
                 extend_lens_np, device=positions.device
             )

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -188,7 +188,13 @@ class DPSyncResult:
     # ``dspark_shape`` was passed in (DSpark active + DP). Folded into this
     # packed all_gather so DSpark's graph-shape sync no longer needs its own
     # separate all_reduce (halves the per-step DP round-trips).
-    dspark_shape_max: Optional[tuple[int, int, int]] = None
+    dspark_shape_max: tuple[int, int, int] | None = None
+    # True iff EVERY DP rank is running a dummy forward this step (AND-reduce of
+    # per-rank is_dummy). Used to gate DSpark cudagraph dummy-replay: an all-dummy
+    # step has no real rank replaying to rendezvous with, so all ranks must stay
+    # eager (vLLM never runs an all-idle forward). Only meaningful when
+    # ``dspark_shape`` was passed (DSpark + DP); False otherwise.
+    any_dummy: bool = False
 
 
 def sync_dp_metadata(
@@ -201,7 +207,8 @@ def sync_dp_metadata(
     local_meets_min_tokens: bool = False,
     local_can_split: bool = False,
     local_ub_tokens: tuple[int, int] = (0, 0),
-    dspark_shape: Optional[tuple[int, int, int]] = None,
+    dspark_shape: tuple[int, int, int] | None = None,
+    local_is_dummy: bool = False,
 ) -> DPSyncResult:
     """Single packed DP all_gather over all per-rank scalars a decode/prefill
     step needs synchronized: DP token padding, the prefill fan-out, the
@@ -238,7 +245,8 @@ def sync_dp_metadata(
     """
     tbo_fields = 6 if tbo_on else 2
     dspark_on = dspark_shape is not None
-    n_fields = tbo_fields + (3 if dspark_on else 0)
+    # +1 extra DSpark field: per-rank is_dummy (OR-reduced -> any_dummy).
+    n_fields = tbo_fields + (4 if dspark_on else 0)
     local = torch.zeros(n_fields, dtype=torch.int32, device="cpu")
     local[0] = num_input_tokens
     local[1] = 1 if is_prefill else 0
@@ -251,6 +259,7 @@ def sync_dp_metadata(
         local[tbo_fields + 0] = dspark_shape[0]
         local[tbo_fields + 1] = dspark_shape[1]
         local[tbo_fields + 2] = dspark_shape[2]
+        local[tbo_fields + 3] = 1 if local_is_dummy else 0
 
     gathered = [
         torch.empty(n_fields, dtype=torch.int32, device="cpu") for _ in range(dp_size)
@@ -284,13 +293,16 @@ def sync_dp_metadata(
                 int(sync[5].max()),
             )
 
-    dspark_shape_max: Optional[tuple[int, int, int]] = None
+    dspark_shape_max: tuple[int, int, int] | None = None
+    any_dummy = False
     if dspark_on:
         dspark_shape_max = (
             int(sync[tbo_fields + 0].max()),
             int(sync[tbo_fields + 1].max()),
             int(sync[tbo_fields + 2].max()),
         )
+        # OR-reduce: True if ANY rank is a dummy this step.
+        any_dummy = bool(sync[tbo_fields + 3].any())
 
     return DPSyncResult(
         num_tokens_across_dp=num_tokens_across_dp,
@@ -298,6 +310,7 @@ def sync_dp_metadata(
         tbo_collective_active=tbo_collective_active,
         ub_max_tokens_across_dp=ub_max_tokens_across_dp,
         dspark_shape_max=dspark_shape_max,
+        any_dummy=any_dummy,
     )
 
 


### PR DESCRIPTION
Root cause: under PIECEWISE cudagraph, a real decode rank replays the captured graph (DP MoE all_gather baked at capture) while an idle dummy rank runs eager(live collective). 

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
