### PR TITLE
dspark perf optimization

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -605,19 +605,7 @@ class tokenIDProcessor:
             f"ragged total {total} > num_deferred_tokens {num_deferred_tokens} "
             f"(graph bucket capacity); ragged must fit within bs*q_eff"
         )
-        anchors = self.prev_token_ids.detach().to("cpu").numpy()  # [bs]
-        drafts = (
-            self.draft_token_ids.detach().to("cpu").numpy()
-            if self.draft_token_ids is not None
-            else None
-        )  # [bs, mtp_k]
-        flat = self.input_ids.np
-        for i in range(bs):
-            s = int(cu[i])
-            flat[s] = anchors[i]
-            d = int(lens[i]) - 1
-            if d > 0 and drafts is not None:
-                flat[s + 1 : s + 1 + d] = drafts[i, :d]
+
         # FLAT graph tail-padding. Under CUDAGraph the captured grid processes
         # C = effective_bs * q_eff tokens (effective_bs = the graph bs bucket
         # >= bs), but this ragged step has only Σ = total real tokens (Σ ≤ C).
@@ -632,9 +620,28 @@ class tokenIDProcessor:
             gbs = next((g for g in reversed(self.runner.graph_bs) if g >= bs), None)
             if gbs is not None:
                 fill_to = max(fill_to, int(gbs) * q_eff)
+
+        # Per flat pos p in [0, total): seq_of_pos[p] = owning seq i,
+        # local_of_pos[p] = p - cu[i] (0 = anchor, >=1 = draft column local-1).
+        gpu = self.input_ids.gpu
+        if total > 0:
+            seq_of_pos = np.repeat(np.arange(bs, dtype=np.int64), lens)  # [total]
+            local_of_pos = np.arange(total, dtype=np.int64) - cu[seq_of_pos]
+            dev = self.prev_token_ids.device
+            seq_t = torch.as_tensor(seq_of_pos, device=dev)
+            local_t = torch.as_tensor(local_of_pos, device=dev)
+            anchor_vals = self.prev_token_ids[seq_t]  # [total]
+            if self.draft_token_ids is not None:
+                # draft column = local-1; clamp anchor rows (local==0) to 0 then
+                # mask them back to the anchor value.
+                draft_col = (local_t - 1).clamp_(min=0)
+                draft_vals = self.draft_token_ids[seq_t, draft_col]
+                out = torch.where(local_t == 0, anchor_vals, draft_vals)
+            else:
+                out = anchor_vals
+            gpu[:total] = out
         if fill_to > total:
-            flat[total:fill_to] = 0
-        self.input_ids.copy_to_gpu(fill_to)
+            gpu[total:fill_to].zero_()
 
     def prepare_draft_ids(
         self, batch: ScheduledBatch, draft_token_ids: torch.Tensor

--- a/atom/spec_decode/eagle.py
+++ b/atom/spec_decode/eagle.py
@@ -805,9 +805,9 @@ class EagleProposer:
         # normal path where indices are already in range.
 
         if self.use_dspark:
-            total_tokens = int(cu_seqlens_q[-1])
-            if total_tokens > 0:
-                token_indices = token_indices.clamp_(0, total_tokens - 1)
+            upper = (cu_seqlens_q[-1] - 1).clamp_(min=0)
+            token_indices = token_indices.clamp_(min=0)
+            torch.minimum(token_indices, upper, out=token_indices)
 
         return token_indices
 


### PR DESCRIPTION
## What

Remove two DSpark-only per-decode-step host syncs from the spec-decode hot path (both gated on `use_dspark` / the ragged path; plain V4 never hits them).

before 
<img width="1071" height="826" alt="image" src="https://github.com/user-attachments/assets/d5c0c661-ac76-4cdd-94fc-ce661171161b" />


after
<img width="1188" height="925" alt="image" src="https://github.com/user-attachments/assets/efded00c-459d-4c3e-9c62-2c074bfcae70" />


1. **`eagle.py` `prepare_inputs`** — `int(cu_seqlens_q[-1])` read a GPU scalar back to the host every decode step (`aten::item` → `_local_scalar_dense` → `hipMemcpyWithStream`). The copy is stream-ordered after the whole decode kernel, so the CPU blocked until the GPU queue drained, collapsing CPU/GPU overlap into a ping-pong. Replaced with an on-device clamp (`torch.minimum` against a 0-dim device scalar); `clamp_(min=0)` on the bound preserves the old `total_tokens > 0` guard.

2. **`model_runner` `_ragged_fill_deferred_all_same`** — assembled ragged decode `input_ids` via 2× D2H (prev/draft ids) + a Python per-seq scatter loop + a full H2D each step (the two D2H also forced a sync on the sampler/draft kernels). Rebuilt entirely on-device (gather anchors/drafts + masked select), mirroring the rectangular all-same path.

## Impact

Restores CPU/GPU overlap on the DSpark ragged + PIECEWISE + DP-attention decode path. The large `aten::item` span disappears from the profiler trace and decode throughput improves.

## Validation

- [ ] **Losslessness**: ragged on/off produce identical tokens under `--ignore-eos`; MTP acceptance rate unchanged. Change #2 alters `input_ids` assembly — please confirm before merge.
