### PR TITLE
fix(scheduler): strip deferred-output placeholder on preempt when MTP is off

### DIFF
--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -1440,6 +1440,23 @@ class Scheduler:
                 del seq.token_ids[-strip:]
                 del seq.output_tokens[-strip:]
                 seq.num_tokens -= strip
+        elif self.is_deferred_out:
+            # MTP off, but deferred-output mode still appends exactly one
+            # placeholder per step (postprocess: num_placeholder = mtp_k + 1 when
+            # is_deferred_out, i.e. 1 here). The `mtp_k > 0` guard above skipped
+            # it, so on preemption the stale eos placeholder — and the +1 it
+            # added to seq.num_tokens — survived requeue. After recompute the
+            # bookkeeping was off by one and the next deferred-output write
+            # (seq.output_tokens[pos] = el in postprocess) indexed out of range,
+            # raising IndexError and killing the engine core. Strip that lone
+            # placeholder here too so requeue starts from a clean token count.
+            # num_rejected is 0 without speculation; the min() clamp is
+            # defensive against a seq preempted before it ever got a placeholder.
+            strip = min(1 + seq.num_rejected, len(seq.output_tokens))
+            if strip > 0:
+                del seq.token_ids[-strip:]
+                del seq.output_tokens[-strip:]
+                seq.num_tokens -= strip
         seq.num_rejected = 0
         seq.num_bonus_tokens = 0
         seq.spec_token_ids = np.array([], dtype=np.int32)
@@ -1508,6 +1525,13 @@ class Scheduler:
         prev_token_ids = fwd_output.token_ids
         draft_token_ids = fwd_output.draft_token_ids
         is_deferred_out = fwd_output.is_deferred_out
+        # Cache the engine's actual deferred-output state. It is set per step by
+        # the ModelRunner's tokenID_processor (which lives in the worker process
+        # and is invisible to the Scheduler at construction time, so the
+        # constructor default is a stale False). preempt() reads this to learn
+        # that a trailing deferred-output placeholder was appended even when MTP
+        # is off (mtp_k == 0). See preempt() for the crash this prevents.
+        self.is_deferred_out = is_deferred_out
         token_logprobs = fwd_output.logprobs  # Optional[dict[int, float]]
         # update token_ids with the actual sampled token ids
 


### PR DESCRIPTION
## Symptom

On a long-context deploy, `EngineCore-DP0` dies mid-serve with:

```
atom/model_engine/scheduler.py, in postprocess
    seq.output_tokens[pos] = el
IndexError: list assignment index out of range
```

The uvicorn front-end survives, so the container stays **Up** and `/v1/models`
keeps answering, but every request just queues (pending climbs, nothing decodes).
"Up + answers /v1/models" is therefore **not** a health signal — only a
`/v1/messages` decode is.

## Root cause

`preempt()` strips the trailing placeholder token(s) added by `postprocess`, but
only under `if self.mtp_k > 0`:

```python
if self.mtp_k > 0:
    strip = self.mtp_k + seq.num_rejected
    del seq.token_ids[-strip:]; del seq.output_tokens[-strip:]; seq.num_tokens -= strip
```

Deferred-output mode is owned by the worker-process `ModelRunner.tokenID_processor`
(`is_deferred_out = True`, **on by default and independent of MTP**). It makes
`postprocess` append one placeholder every step even when `mtp_k == 0`:

```python
num_placeholder = self.mtp_k
if is_deferred_out:
    num_placeholder += 1   # == 1 when MTP is off
```

So with **MTP off**, each running seq carries exactly one trailing deferred
placeholder. When KV pressure at long context forces a preemption (the *silent*
path in the mixed prefill+decode scheduler — no "Cannot allocate" log), the
`mtp_k > 0` guard skips the strip: the stale `eos` placeholder stays in
`output_tokens`/`token_ids` and its `+1` stays in `num_tokens`. After
requeue + recompute the bookkeeping is off by one, and the next deferred write
`seq.output_tokens[pos] = el` indexes out of range → crash.

## Fix

Add an `elif self.is_deferred_out:` branch that strips the single deferred
placeholder when MTP is off. **The `mtp_k > 0` path is byte-for-byte unchanged**
(zero risk to the speculative-decode path). `self.is_deferred_out` is now
refreshed each step in `postprocess` from `fwd_output.is_deferred_out` — the
constructor default was a stale `False` because the Scheduler is built in the
engine-core process and never sees the worker's `tokenID_processor`. A `min()`
clamp guards a seq preempted before it ever received a placeholder.

## Scope / risk

- One file, +24 lines, no behavior change when `mtp_k > 0` or when deferred
  output is off.
- Latent on all MTP-off deploys that hit preemption at high context; not
  GLM-specific.

## Validation status

Root-caused from a production crash (MXFP4 GLM-5.2, MTP off, tp8, 1M max ctx).
**Not yet run under a preemption-forcing load** — reviewer note: I plan to
validate with a small-KV-headroom serve + concurrent long requests
(reproduce IndexError on `main`, confirm survival on this branch) before merge.
Opening as draft for review of the reasoning first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)