### PR TITLE
feat: add served name

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1787,7 +1787,7 @@ def main():
 
     logger.info(f"Loading tokenizer from {args.model}...")
     tokenizer = _load_tokenizer(args.model, args.trust_remote_code)
-    model_name = args.model
+    model_name = args.served_model_name if args.served_model_name else args.model
     custom_message_encoder = load_custom_message_encoder(args.model)
 
     logger.info(f"Initializing engine with model {args.model}...")

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -91,6 +91,13 @@ class EngineArgs:
             "--model", type=str, default="Qwen/Qwen3-0.6B", help="Model name or path."
         )
         parser.add_argument(
+            "--served-model-name",
+            type=str,
+            default=None,
+            help="Override the model name returned by the API. "
+            "If not specified, defaults to the --model value.",
+        )
+        parser.add_argument(
             "--trust-remote-code",
             action="store_true",
             help="Trust remote code when loading model.",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Support predefined served model name

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
args.model is overrided by args.served_model_name  if set

## Usage

```bash
python -m atom.entrypoints.openai_server \
  --model /mnt/md0/models/DeepSeek-V4-Flash \
  --kv_cache_dtype fp8 \
  --gpu-memory-utilization 0.83 \
  --served-model-name DeepSeek-V4-Flash \
  -tp 8
```