### PR TITLE
fix(scheduler): back-fill deferred-output placeholders before overwrite (IndexError crash)

### DIFF
--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -1612,6 +1612,26 @@ class Scheduler:
                     ell_r = fwd_output.dspark_ell.get(seq.id)
                     if ell_r is not None:
                         seq.dspark_next_ell = int(ell_r)
+                # Back-fill placeholder slots if this seq reached the
+                # deferred-output write without them. Placeholders are normally
+                # appended at the END of postprocess (the `if need_placeholder`
+                # loop below), so by the next step the tail of token_ids /
+                # output_tokens holds `num_placeholder (+ offset)` eos slots for
+                # the negative-index overwrite here to land on. But a seq whose
+                # prefill completes in a single chunk was never partial at step
+                # start, so it is NOT continue'd above and reaches this write on
+                # its very first appearance — output_tokens is still empty. The
+                # negative index would then raise IndexError on output_tokens
+                # (killing the engine core) and, worse, silently overwrite the
+                # last PROMPT token in token_ids. append_token keeps token_ids,
+                # output_tokens and num_tokens in lockstep; the loop below then
+                # overwrites these eos slots with the real sampled values. This
+                # is self-healing: any step that arrives short back-fills exactly
+                # what it needs, independent of whether the tail loop ran.
+                while len(seq.output_tokens) < num_placeholder + offset:
+                    seq.append_token(self.eos_token_id)
+                    if seq.return_logprobs:
+                        seq.logprobs.append(0.0)
                 for i, el in enumerate(token_ids):
                     seq.token_ids[-num_placeholder - offset + i] = el
                     seq.output_tokens[-num_placeholder - offset + i] = el


### PR DESCRIPTION
## Symptom

`EngineCore-DP0` dies with:
```
atom/model_engine/scheduler.py, in postprocess
    seq.output_tokens[-num_placeholder - offset + i] = el
IndexError: list assignment index out of range
```
The uvicorn front-end survives, so the container stays **Up** and `/v1/models`
answers, but requests just queue (nothing decodes). Reproduced twice on a
GLM-5.2 MXFP4 deploy (MTP off, tp8, chunked prefill on, chunk=16384, 1M ctx).

## Root cause

The deferred-output write overwrites the last `num_placeholder (+offset)` slots
of `token_ids` / `output_tokens` with the real sampled tokens, assuming the
**previous** step's tail (`if need_placeholder:` loop) already appended those
eos placeholder slots.

That holds for a normally chunk-prefilled seq: on the step its prefill
completes it is still partial at step start, gets `continue`'d, receives its
placeholder in the tail loop, and only writes on the *next* step.

It breaks for a seq whose **prefill completes in a single chunk** — e.g. a
prefix-cache-heavy prompt that only forwards a few new tokens (observed:
`cached=33584, new=4`). Such a seq is never partial at step start, so it is
**not** `continue`'d, and reaches the deferred write on its *first* appearance
with `output_tokens` still empty. The negative index then:
- raises `IndexError` on `output_tokens` → engine core dies; and
- would otherwise **silently overwrite the last PROMPT token** in `token_ids`
  (`token_ids[-1]` points at the prompt when no completion slot exists yet).

## Fix

Back-fill the missing eos placeholder slots via `append_token` (keeping
`token_ids` / `output_tokens` / `num_tokens` in lockstep) immediately before the
overwrite loop. Self-healing (any step arriving short fixes exactly what it
needs, regardless of whether the tail loop ran) and a **no-op on the normal
path** (slots already reserved → guard never fires).

## Scope / risk
- One file, +20 lines, guarded by `while len(output_tokens) < num_placeholder + offset`
  so the normal decode path is untouched.
- Not GLM-specific; affects any deferred-output deploy with prefix caching /
  single-chunk prefill completion.

## Validation status
Root-caused from two captured crashes + code-path analysis (preempt and
abort_request were ruled out as red herrings — the aborted seq is `continue`'d
before the write). **NOT yet run under a repro load.** Reviewer note: repro plan
is to resend a long prompt so the second request hits the prefix cache and
completes prefill in one chunk, confirming crash on `main` and survival here,
and verifying the first decoded token is correct (not the back-filled eos).
Draft pending that validation.

Supersedes #1703 (that PR chased a preempt() placeholder-strip hypothesis which
the second crash log refuted — no preempt occurred; the trigger is
single-chunk prefill completion, not preemption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)