### PR TITLE
bugfix: defer streaming chat role chunk until generation starts

### DIFF
--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -86,11 +86,13 @@ async def stream_chat_response(
     # finally aborts the still-running seq; normal completion flips it to False.
     aborted = True
     try:
-        # Send initial role chunk
-        yield create_chat_chunk(request_id, model, delta={"role": "assistant"})
-
+        role_sent = False
         while True:
             chunk_data = await stream_queue.get()
+
+            if not role_sent:
+                yield create_chat_chunk(request_id, model, delta={"role": "assistant"})
+                role_sent = True
             new_text = chunk_data["text"]
             num_tokens_output += len(chunk_data.get("token_ids", []))
             _ct = chunk_data.get("num_cached_tokens", 0)
@@ -333,13 +335,16 @@ async def stream_chat_response_fanout(
     # whichever siblings are still running.
     aborted = True
     try:
-        for i in range(n):
-            yield create_chat_chunk(
-                request_id, model, delta={"role": "assistant"}, index=i
-            )
-
+        role_sent = [False] * n
         while not all(finished):
             idx, chunk_data = await shared_queue.get()
+
+            if not role_sent[idx]:
+                yield create_chat_chunk(
+                    request_id, model, delta={"role": "assistant"}, index=idx
+                )
+                role_sent[idx] = True
+
             if finished[idx]:
                 # Defensive: should not happen, engine emits finished once per seq.
                 continue


### PR DESCRIPTION
## Motivation


The streaming chat handler sent the `role: "assistant"` chunk as soon as the
request was accepted, before the engine produced anything.
That is not what OpenAI does -- the first chunk is supposed to mean generation
has actually started (vLLM emits it on the first iteration of the result
generator). It also skews client-side metrics: a chat client that times the
first SSE chunk without checking for content records a near-zero TTFT and
counts the real first token as an inter-token latency. The `/v1/completions`
benchmark path has no such chunk, so existing numbers are unaffected, but the
chat path is a trap for external clients.
This PR defers the role chunk until the first engine chunk arrives, for both
the single-sequence and n>1 fanout paths. It still precedes any content or
tool_calls delta, so client-visible ordering is unchanged.