### PR TITLE
bugfix: Add empty choices field to streaming usage chunks

### DIFF
--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -167,6 +167,7 @@ async def stream_chat_response(
             "object": CHAT_COMPLETION_CHUNK_OBJECT,
             "created": int(time.time()),
             "model": model,
+            "choices": [],
             "usage": usage,
         }
         if kv_transfer_params_value is not None:
@@ -424,6 +425,7 @@ async def stream_chat_response_fanout(
             "object": CHAT_COMPLETION_CHUNK_OBJECT,
             "created": int(time.time()),
             "model": model,
+            "choices": [],
             "usage": usage,
         }
         if kv_transfer_params_value is not None:

--- a/atom/entrypoints/openai/serving_completion.py
+++ b/atom/entrypoints/openai/serving_completion.py
@@ -103,6 +103,7 @@ async def stream_completion_response(
                     "object": TEXT_COMPLETION_OBJECT,
                     "created": int(time.time()),
                     "model": model,
+                    "choices": [],
                     "usage": {
                         "prompt_tokens": num_tokens_input,
                         "completion_tokens": num_tokens_output,
@@ -262,6 +263,7 @@ async def stream_completion_response_fanout(
             "object": TEXT_COMPLETION_OBJECT,
             "created": int(time.time()),
             "model": model,
+            "choices": [],
             "usage": usage,
         }
         # Coalesce the per-sibling stop chunks + usage + [DONE] into one send.


### PR DESCRIPTION
## Motivation

The OpenAI API spec requires every streamed chunk to include a choices field. Our final usage-only chunks omitted it, causing strict clients (e.g. OpenAI Python SDK) to reject the response. This adds "choices": [] to all four usage chunk paths (chat/completion, single/fanout).