### PR TITLE
feat(kimi-k3): run full attention through MLA instead of MHA

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -680,6 +680,8 @@ class ModelRunner:
         self.use_mla = self.is_deepseek_mla()
         self.use_gdn = self.is_qwen_next()
         self.use_v4 = self.is_deepseek_v4()
+        self.use_kimi_mla = self.is_kimi_linear()
+
         rope_parameters = getattr(self.hf_text_config, "rope_parameters", None) or {}
         self.use_mrope = "mrope_section" in rope_parameters
         self.is_deepseek_v32 = (
@@ -715,6 +717,7 @@ class ModelRunner:
             use_mla=self.use_mla,
             use_gdn=self.use_gdn,
             use_v4=self.use_v4,
+            use_kimi_mla=self.use_kimi_mla,
         )
         use_spec = bool(self.config.speculative_config) and get_pp_group().is_last_rank
         self.num_spec_tokens = (

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -4,7 +4,7 @@
 import logging
 from dataclasses import dataclass
 from functools import partial as functools_partial
-from typing import Optional
+from typing import Optional, Protocol
 
 import torch
 import triton
@@ -183,6 +183,18 @@ class MLAModules:
     topk_tokens: Optional[int] = None
 
 
+class _MLAOutputShape(Protocol):
+    o_proj: nn.Module
+    num_heads: int
+    v_head_dim: int
+
+
+def _mla_output_width(impl: _MLAOutputShape, hidden_size: int) -> int:
+    if isinstance(getattr(impl, "o_proj", None), nn.Identity):
+        return impl.num_heads * impl.v_head_dim
+    return hidden_size
+
+
 def dynamic_per_batched_tensor_quant(
     x: torch.Tensor, dtype: torch.dtype = torch.float8_e4m3fn
 ):
@@ -216,18 +228,19 @@ class MLAAttention(nn.Module):
         self.dtype = dtype
 
         self.padded_num_heads = max(num_heads, _MLA_MIN_HEADS)
-        self.head_repeat_factor = self.padded_num_heads // num_heads
-        if self.head_repeat_factor > 1:
-            assert self.padded_num_heads % num_heads == 0, (
-                f"Padded head count ({self.padded_num_heads}) must be divisible "
-                f"by num_heads ({num_heads}) for head repeat"
-            )
-            if not getattr(MLAAttention, "_head_repeat_logged", False):
-                MLAAttention._head_repeat_logged = True
-                logger.info(
-                    f"MLA head repeat enabled: {num_heads} -> {self.padded_num_heads} "
-                    f"(repeat factor {self.head_repeat_factor})"
-                )
+        self.head_repeat_factor = 1
+        self.head_pad = 0
+        if self.padded_num_heads != num_heads:
+            if self.padded_num_heads % num_heads == 0:
+                self.head_repeat_factor = self.padded_num_heads // num_heads
+                if not getattr(MLAAttention, "_head_repeat_logged", False):
+                    MLAAttention._head_repeat_logged = True
+                    logger.info(
+                        f"MLA head repeat enabled: {num_heads} -> {self.padded_num_heads} "
+                        f"(repeat factor {self.head_repeat_factor})"
+                    )
+            else:
+                self.head_pad = self.padded_num_heads - num_heads
 
         self.q_lora_rank = mla_modules.q_lora_rank
         self.kv_lora_rank = mla_modules.kv_lora_rank
@@ -294,6 +307,20 @@ class MLAAttention(nn.Module):
                     "which are not available in the installed aiter build. Upgrade "
                     "aiter or set ATOM_MLA_PAGE_SIZE=1."
                 )
+
+    def _pad_query_heads(self, q: torch.Tensor) -> torch.Tensor:
+        if self.head_repeat_factor > 1:
+            return q.repeat_interleave(self.head_repeat_factor, dim=1)
+        if self.head_pad > 0:
+            return torch.nn.functional.pad(q, (0, 0, 0, self.head_pad))
+        return q
+
+    def _restore_query_heads(self, output: torch.Tensor) -> torch.Tensor:
+        if self.head_repeat_factor > 1:
+            return output[:, :: self.head_repeat_factor, :].contiguous()
+        if self.head_pad > 0:
+            return output[:, : self.num_heads, :].contiguous()
+        return output
 
     def _seg_kv_cache_view(self, kv_cache: torch.Tensor) -> torch.Tensor:
         """Reshape the KV cache buffer into the page-level flat seg layout
@@ -847,8 +874,7 @@ class MLAAttention(nn.Module):
         assert attn_metadata is not None
         B = q.shape[0]
 
-        if self.head_repeat_factor > 1:
-            q = q.repeat_interleave(self.head_repeat_factor, dim=1)
+        q = self._pad_query_heads(q)
 
         # In the seg path q arrives with a padded per-head row stride
         # (_MLA_Q_OUT_PADDED_DIM); slice back to the logical
@@ -933,8 +959,7 @@ class MLAAttention(nn.Module):
                     None,
                 )
 
-        if self.head_repeat_factor > 1:
-            o = o[:, :: self.head_repeat_factor, :].contiguous()
+        o = self._restore_query_heads(o)
 
         return self._v_up_proj_and_o_proj(o)
 
@@ -969,8 +994,7 @@ class MLAAttention(nn.Module):
         assert attn_metadata is not None
         B = q.shape[0]
 
-        if self.head_repeat_factor > 1:
-            q = q.repeat_interleave(self.head_repeat_factor, dim=1)
+        q = self._pad_query_heads(q)
 
         # In the seg path q arrives with a padded per-head row stride
         # (_MLA_Q_OUT_PADDED_DIM); slice back to the logical
@@ -1127,8 +1151,7 @@ class MLAAttention(nn.Module):
                 kv_scale=self._k_scale,
             )
 
-        if self.head_repeat_factor > 1:
-            o = o[:, :: self.head_repeat_factor, :].contiguous()
+        o = self._restore_query_heads(o)
 
         return self._v_up_proj_and_o_proj(o)
 
@@ -1190,7 +1213,9 @@ class MLAAttention(nn.Module):
         if forward_context.context.is_dummy_run:
             output_shape = list(q.shape)
             atom_config = get_current_atom_config()
-            output_shape[-1] = atom_config.hf_config.hidden_size
+            output_shape[-1] = _mla_output_width(
+                self, atom_config.hf_config.hidden_size
+            )
             output_dtype = atom_config.torch_dtype
             output = torch.empty(output_shape, dtype=output_dtype, device=q.device)
             return output

--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -67,15 +67,15 @@ class GDNAttentionMetadata:
     token_chunk_offset_ptr: torch.Tensor | None = None
 
 
-class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
+class GDNStateMixin:
+    def __init__(self, model_runner, **kwargs):
+        super().__init__(model_runner=model_runner, **kwargs)
+        self._init_gdn_state(model_runner)
 
-    reorder_batch_threshold: int = 1
-
-    def __init__(
+    def _init_gdn_state(
         self,
         model_runner,
     ):
-        super().__init__(model_runner=model_runner)
         # Hybrid model layer-counting state (formerly set as a side effect
         # inside ModelRunner._compute_block_bytes' qwen_next branch).
         # Promoted to runner attributes here so all consumers
@@ -98,7 +98,9 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
                 hf, "linear_num_key_heads", lin.get("num_heads", hf.num_attention_heads)
             )
             hf.linear_num_value_heads = getattr(
-                hf, "linear_num_value_heads", lin.get("num_heads", hf.num_attention_heads)
+                hf,
+                "linear_num_value_heads",
+                lin.get("num_heads", hf.num_attention_heads),
             )
             hf.linear_key_head_dim = getattr(
                 hf, "linear_key_head_dim", lin.get("head_dim", hf.qk_nope_head_dim)
@@ -215,7 +217,10 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
         return conv_state_shape, temporal_state_shape
 
     def _state_dtypes(self) -> tuple[torch.dtype, torch.dtype]:
-        if getattr(self.model_runner.config.hf_config, "model_type", None) == "kimi_linear":
+        if (
+            getattr(self.model_runner.config.hf_config, "model_type", None)
+            == "kimi_linear"
+        ):
             return (
                 self.model_runner.config.torch_dtype,
                 torch.float32,
@@ -267,6 +272,240 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
                 (n, num_slots) + shape_v, dtype=dt_v, device="cuda"
             ),
         }
+
+    def prepare_state_indices(self, batch: ScheduledBatch, with_spec: bool = False):
+        non_spec_state_indices = self.non_spec_state_indices_tensor.np
+        spec_state_indices = self.spec_state_indices_tensor.np
+        slots_per_group = 1 + self.num_spec
+        for idx, slot_group in enumerate(batch.per_req_cache_groups):
+            non_spec_state_indices[idx] = 0
+            spec_state_indices[idx] = 0
+            base = slot_group * slots_per_group
+
+            if not with_spec:
+                non_spec_state_indices[idx] = base
+            else:
+                spec_state_indices[idx, : 1 + self.num_spec] = np.arange(
+                    base, base + 1 + self.num_spec
+                )
+
+    def prepare_num_accepted_tokens(self, batch: ScheduledBatch):
+        self.num_accepted_tokens.fill_(1)
+
+        if self.model_runner.tokenID_processor.num_bonus is None:
+            return
+        for idx, num_bonus in enumerate(self.model_runner.tokenID_processor.num_bonus):
+            self.num_accepted_tokens[idx] = num_bonus + 1
+
+    def prepare_gdn_metadata(
+        self,
+        batch: ScheduledBatch,
+        attn_metadata: AttentionMetaData,
+        is_prefill: bool = False,
+        *,
+        prepare_block_tables: bool = True,
+    ) -> GDNAttentionMetadata:
+
+        num_decodes = batch.total_seqs_num_decode
+        num_prefills = batch.total_seqs_num_prefill
+        num_decode_tokens = batch.total_tokens_num_decode
+        num_prefill_tokens = batch.total_tokens_num_prefill
+        num_reqs = batch.total_seqs_num
+        if prepare_block_tables:
+            self.prepare_block_tables(batch)
+
+        context_lens_tensor = attn_metadata.context_lens
+        query_start_loc = attn_metadata.cu_seqlens_q
+        context_lens_tensor = torch.zeros((batch.total_seqs_num_prefill)).cuda()
+        nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
+        if not self.use_spec_decode or is_prefill:
+            self.prepare_state_indices(batch, with_spec=False)
+            spec_token_indx = None
+            non_spec_token_indx = None
+            spec_state_indices_tensor = None
+            non_spec_state_indices_tensor = (
+                self.non_spec_state_indices_tensor.copy_to_gpu(num_reqs)
+            )
+            spec_query_start_loc = None
+            non_spec_query_start_loc = query_start_loc
+            num_accepted_tokens = None
+            spec_sequence_masks = None
+            num_spec_decodes = 0
+            num_spec_decode_tokens = 0
+        else:
+            self.prepare_state_indices(batch, with_spec=True)
+            self.prepare_num_accepted_tokens(batch)
+            spec_token_size = min(
+                num_decodes * (self.num_spec + 1), query_start_loc[-1].item()
+            )
+            spec_token_indx = torch.arange(
+                spec_token_size, dtype=torch.int32, device=self.device
+            )
+            non_spec_token_indx = torch.empty(
+                0, dtype=torch.int32, device=query_start_loc.device
+            )
+            spec_sequence_masks = torch.ones(
+                num_reqs, dtype=torch.bool, device=self.device
+            )
+            spec_state_indices_tensor = self.spec_state_indices_tensor.copy_to_gpu(
+                num_reqs
+            )
+            non_spec_state_indices_tensor = None
+            spec_query_start_loc = query_start_loc
+            non_spec_query_start_loc = None
+            num_accepted_tokens = self.num_accepted_tokens[:num_reqs]
+            num_spec_decodes = num_decodes
+            num_prefills = 0
+            num_decodes = 0
+            num_spec_decode_tokens = num_decode_tokens
+            num_decode_tokens = 0
+            num_prefill_tokens = 0
+
+        if num_prefills > 0:
+            has_initial_state = context_lens_tensor > 0
+            nums_dict, batch_ptr, token_chunk_offset_ptr = (
+                compute_causal_conv1d_metadata(non_spec_query_start_loc)
+            )
+        else:
+            has_initial_state = None
+
+        gdn_attn_metadata = GDNAttentionMetadata(
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_spec_decodes=num_spec_decodes,
+            num_spec_decode_tokens=num_spec_decode_tokens,
+            num_actual_tokens=batch.total_tokens_num,
+            has_initial_state=has_initial_state,
+            spec_query_start_loc=spec_query_start_loc,
+            non_spec_query_start_loc=non_spec_query_start_loc,
+            spec_state_indices_tensor=spec_state_indices_tensor,
+            non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+            spec_sequence_masks=spec_sequence_masks,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
+            num_accepted_tokens=num_accepted_tokens,
+            nums_dict=nums_dict,
+            batch_ptr=batch_ptr,
+            token_chunk_offset_ptr=token_chunk_offset_ptr,
+        )
+        return gdn_attn_metadata
+
+    def _attach_gdn_decode_metadata(
+        self,
+        batch,
+        attn_metadata,
+        *,
+        prepare_block_tables: bool = True,
+    ) -> None:
+        num_decodes = batch.total_seqs_num_decode
+        gdn_metadata = self.prepare_gdn_metadata(
+            batch,
+            attn_metadata,
+            prepare_block_tables=prepare_block_tables,
+        )
+
+        # transfer data to ps buffer
+        if self.use_spec_decode:
+            self.spec_state_indices_tensor.gpu[num_decodes:, :].fill_(PAD_SLOT_ID)
+
+            self.spec_sequence_masks[:num_decodes].copy_(
+                gdn_metadata.spec_sequence_masks, non_blocking=True
+            )
+            self.spec_sequence_masks[num_decodes:].fill_(False)
+            gdn_metadata.spec_sequence_masks = self.spec_sequence_masks[:num_decodes]
+
+            self.spec_token_indx[: gdn_metadata.spec_token_indx.size(0)].copy_(
+                gdn_metadata.spec_token_indx, non_blocking=True
+            )
+            gdn_metadata.spec_token_indx = self.spec_token_indx[
+                : gdn_metadata.spec_token_indx.size(0)
+            ]
+
+            self.spec_query_start_loc[: num_decodes + 1].copy_(
+                gdn_metadata.spec_query_start_loc[: num_decodes + 1], non_blocking=True
+            )
+            spec_num_query_tokens = self.spec_query_start_loc[num_decodes]
+            self.spec_query_start_loc[num_decodes + 1 :].fill_(spec_num_query_tokens)
+            gdn_metadata.spec_query_start_loc = self.spec_query_start_loc[
+                : num_decodes + 1
+            ]
+
+            self.num_accepted_tokens[:num_decodes].copy_(
+                gdn_metadata.num_accepted_tokens[:num_decodes], non_blocking=True
+            )
+            self.num_accepted_tokens[num_decodes:].fill_(1)
+            gdn_metadata.num_accepted_tokens = self.num_accepted_tokens[:num_decodes]
+        else:
+            self.non_spec_state_indices_tensor.gpu[num_decodes:].fill_(PAD_SLOT_ID)
+
+            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
+                gdn_metadata.non_spec_query_start_loc[: num_decodes + 1],
+                non_blocking=True,
+            )
+            self.non_spec_query_start_loc[num_decodes + 1 :].fill_(
+                gdn_metadata.non_spec_query_start_loc[num_decodes]
+            )
+            gdn_metadata.non_spec_query_start_loc = self.non_spec_query_start_loc[
+                : num_decodes + 1
+            ]
+
+        attn_metadata.gdn_metadata = gdn_metadata
+
+    def _build_gdn_capture_metadata(self, bs: int):
+        if self.use_spec_decode:
+            gdn_metadata = GDNAttentionMetadata(
+                num_prefills=0,
+                num_prefill_tokens=0,
+                num_decodes=0,
+                num_decode_tokens=0,
+                num_spec_decodes=bs,
+                num_spec_decode_tokens=bs * (self.num_spec + 1),
+                num_actual_tokens=bs * (self.num_spec + 1),
+                has_initial_state=None,
+                spec_query_start_loc=self.spec_query_start_loc[: bs + 1],
+                non_spec_query_start_loc=None,
+                spec_state_indices_tensor=self.spec_state_indices_tensor.gpu[:bs],
+                non_spec_state_indices_tensor=None,
+                spec_sequence_masks=self.spec_sequence_masks[:bs],
+                spec_token_indx=self.spec_token_indx[: bs * (self.num_spec + 1)],
+                non_spec_token_indx=self.non_spec_token_indx[:0],
+                num_accepted_tokens=self.num_accepted_tokens[:bs],
+                nums_dict=None,
+                batch_ptr=None,
+                token_chunk_offset_ptr=None,
+            )
+        else:
+            gdn_metadata = GDNAttentionMetadata(
+                num_prefills=0,
+                num_prefill_tokens=0,
+                num_decodes=bs,
+                num_decode_tokens=bs,
+                num_spec_decodes=0,
+                num_spec_decode_tokens=0,
+                num_actual_tokens=bs,
+                has_initial_state=None,
+                spec_query_start_loc=None,
+                non_spec_query_start_loc=self.non_spec_query_start_loc[: bs + 1],
+                spec_state_indices_tensor=None,
+                non_spec_state_indices_tensor=self.non_spec_state_indices_tensor.gpu[
+                    :bs
+                ],
+                spec_sequence_masks=None,
+                spec_token_indx=None,
+                non_spec_token_indx=None,
+                num_accepted_tokens=None,
+                nums_dict=None,
+                batch_ptr=None,
+                token_chunk_offset_ptr=None,
+            )
+        return gdn_metadata
+
+
+class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
+
+    reorder_batch_threshold: int = 1
 
     def compute_block_bytes(self) -> int:
         """GDN hybrid: only full-attention layer slots contribute paged KV
@@ -354,7 +593,9 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
                 gdn_idx = runner.kda_attention_layers.index(layer_id)
             else:
                 interval = runner.full_attention_interval
-                gdn_idx = (layer_id // interval) * (interval - 1) + (layer_id % interval)
+                gdn_idx = (layer_id // interval) * (interval - 1) + (
+                    layer_id % interval
+                )
             return KVCacheTensor(
                 layer_num=layer_id,
                 k_cache=runner.mamba_k_cache[gdn_idx],
@@ -363,122 +604,6 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
                 v_scale=None,
             )
         return super().build_kv_cache_tensor(layer_id, module)
-
-    def prepare_state_indices(self, batch: ScheduledBatch, with_spec: bool = False):
-        non_spec_state_indices = self.non_spec_state_indices_tensor.np
-        spec_state_indices = self.spec_state_indices_tensor.np
-        slots_per_group = 1 + self.num_spec
-        for idx, slot_group in enumerate(batch.per_req_cache_groups):
-            non_spec_state_indices[idx] = 0
-            spec_state_indices[idx] = 0
-            base = slot_group * slots_per_group
-
-            if not with_spec:
-                non_spec_state_indices[idx] = base
-            else:
-                spec_state_indices[idx, : 1 + self.num_spec] = np.arange(
-                    base, base + 1 + self.num_spec
-                )
-
-    def prepare_num_accepted_tokens(self, batch: ScheduledBatch):
-        self.num_accepted_tokens.fill_(1)
-
-        if self.model_runner.tokenID_processor.num_bonus is None:
-            return
-        for idx, num_bonus in enumerate(self.model_runner.tokenID_processor.num_bonus):
-            self.num_accepted_tokens[idx] = num_bonus + 1
-
-    def prepare_gdn_metadata(
-        self,
-        batch: ScheduledBatch,
-        attn_metadata: AttentionMetaData,
-        is_prefill: bool = False,
-    ) -> GDNAttentionMetadata:
-
-        num_decodes = batch.total_seqs_num_decode
-        num_prefills = batch.total_seqs_num_prefill
-        num_decode_tokens = batch.total_tokens_num_decode
-        num_prefill_tokens = batch.total_tokens_num_prefill
-        num_reqs = batch.total_seqs_num
-        self.prepare_block_tables(batch)
-
-        context_lens_tensor = attn_metadata.context_lens
-        query_start_loc = attn_metadata.cu_seqlens_q
-        context_lens_tensor = torch.zeros((batch.total_seqs_num_prefill)).cuda()
-        nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
-        if not self.use_spec_decode or is_prefill:
-            self.prepare_state_indices(batch, with_spec=False)
-            spec_token_indx = None
-            non_spec_token_indx = None
-            spec_state_indices_tensor = None
-            non_spec_state_indices_tensor = (
-                self.non_spec_state_indices_tensor.copy_to_gpu(num_reqs)
-            )
-            spec_query_start_loc = None
-            non_spec_query_start_loc = query_start_loc
-            num_accepted_tokens = None
-            spec_sequence_masks = None
-            num_spec_decodes = 0
-            num_spec_decode_tokens = 0
-        else:
-            self.prepare_state_indices(batch, with_spec=True)
-            self.prepare_num_accepted_tokens(batch)
-            spec_token_size = min(
-                num_decodes * (self.num_spec + 1), query_start_loc[-1].item()
-            )
-            spec_token_indx = torch.arange(
-                spec_token_size, dtype=torch.int32, device=self.device
-            )
-            non_spec_token_indx = torch.empty(
-                0, dtype=torch.int32, device=query_start_loc.device
-            )
-            spec_sequence_masks = torch.ones(
-                num_reqs, dtype=torch.bool, device=self.device
-            )
-            spec_state_indices_tensor = self.spec_state_indices_tensor.copy_to_gpu(
-                num_reqs
-            )
-            non_spec_state_indices_tensor = None
-            spec_query_start_loc = query_start_loc
-            non_spec_query_start_loc = None
-            num_accepted_tokens = self.num_accepted_tokens[:num_reqs]
-            num_spec_decodes = num_decodes
-            num_prefills = 0
-            num_decodes = 0
-            num_spec_decode_tokens = num_decode_tokens
-            num_decode_tokens = 0
-            num_prefill_tokens = 0
-
-        if num_prefills > 0:
-            has_initial_state = context_lens_tensor > 0
-            nums_dict, batch_ptr, token_chunk_offset_ptr = (
-                compute_causal_conv1d_metadata(non_spec_query_start_loc)
-            )
-        else:
-            has_initial_state = None
-
-        gdn_attn_metadata = GDNAttentionMetadata(
-            num_prefills=num_prefills,
-            num_prefill_tokens=num_prefill_tokens,
-            num_decodes=num_decodes,
-            num_decode_tokens=num_decode_tokens,
-            num_spec_decodes=num_spec_decodes,
-            num_spec_decode_tokens=num_spec_decode_tokens,
-            num_actual_tokens=batch.total_tokens_num,
-            has_initial_state=has_initial_state,
-            spec_query_start_loc=spec_query_start_loc,
-            non_spec_query_start_loc=non_spec_query_start_loc,
-            spec_state_indices_tensor=spec_state_indices_tensor,
-            non_spec_state_indices_tensor=non_spec_state_indices_tensor,
-            spec_sequence_masks=spec_sequence_masks,
-            spec_token_indx=spec_token_indx,
-            non_spec_token_indx=non_spec_token_indx,
-            num_accepted_tokens=num_accepted_tokens,
-            nums_dict=nums_dict,
-            batch_ptr=batch_ptr,
-            token_chunk_offset_ptr=token_chunk_offset_ptr,
-        )
-        return gdn_attn_metadata
 
     def prepare_prefill(  # type: ignore[override]
         self,
@@ -498,7 +623,6 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
         batch: ScheduledBatch,
         bs: int,
     ) -> GDNAttentionMetadata:
-        num_decodes = batch.total_seqs_num_decode
         attn_metadata, positions = super().prepare_decode(batch, bs)
         self.model_runner.forward_vars["cu_seqlens_q"].cpu[
             bs:
@@ -508,54 +632,7 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
             "cu_seqlens_q"
         ].copy_to_gpu(bs + 1)
 
-        gdn_metadata = self.prepare_gdn_metadata(batch, attn_metadata)
-
-        # transfer data to ps buffer
-        if self.use_spec_decode:
-            self.spec_state_indices_tensor.gpu[num_decodes:, :].fill_(PAD_SLOT_ID)
-
-            self.spec_sequence_masks[:num_decodes].copy_(
-                gdn_metadata.spec_sequence_masks, non_blocking=True
-            )
-            self.spec_sequence_masks[num_decodes:].fill_(False)
-            gdn_metadata.spec_sequence_masks = self.spec_sequence_masks[:num_decodes]
-
-            self.spec_token_indx[: gdn_metadata.spec_token_indx.size(0)].copy_(
-                gdn_metadata.spec_token_indx, non_blocking=True
-            )
-            gdn_metadata.spec_token_indx = self.spec_token_indx[
-                : gdn_metadata.spec_token_indx.size(0)
-            ]
-
-            self.spec_query_start_loc[: num_decodes + 1].copy_(
-                gdn_metadata.spec_query_start_loc[: num_decodes + 1], non_blocking=True
-            )
-            spec_num_query_tokens = self.spec_query_start_loc[num_decodes]
-            self.spec_query_start_loc[num_decodes + 1 :].fill_(spec_num_query_tokens)
-            gdn_metadata.spec_query_start_loc = self.spec_query_start_loc[
-                : num_decodes + 1
-            ]
-
-            self.num_accepted_tokens[:num_decodes].copy_(
-                gdn_metadata.num_accepted_tokens[:num_decodes], non_blocking=True
-            )
-            self.num_accepted_tokens[num_decodes:].fill_(1)
-            gdn_metadata.num_accepted_tokens = self.num_accepted_tokens[:num_decodes]
-        else:
-            self.non_spec_state_indices_tensor.gpu[num_decodes:].fill_(PAD_SLOT_ID)
-
-            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
-                gdn_metadata.non_spec_query_start_loc[: num_decodes + 1],
-                non_blocking=True,
-            )
-            self.non_spec_query_start_loc[num_decodes + 1 :].fill_(
-                gdn_metadata.non_spec_query_start_loc[num_decodes]
-            )
-            gdn_metadata.non_spec_query_start_loc = self.non_spec_query_start_loc[
-                : num_decodes + 1
-            ]
-
-        attn_metadata.gdn_metadata = gdn_metadata
+        self._attach_gdn_decode_metadata(batch, attn_metadata)
         return attn_metadata, positions
 
     def prepare_mtp_decode(
@@ -608,53 +685,7 @@ class GDNAttentionMetadataBuilder(AiterAttentionMetadataBuilder):
             **ctx_pa_ps,
         )
 
-        if self.use_spec_decode:
-            gdn_metadata = GDNAttentionMetadata(
-                num_prefills=0,
-                num_prefill_tokens=0,
-                num_decodes=0,
-                num_decode_tokens=0,
-                num_spec_decodes=bs,
-                num_spec_decode_tokens=bs * (self.num_spec + 1),
-                num_actual_tokens=bs * (self.num_spec + 1),
-                has_initial_state=None,
-                spec_query_start_loc=self.spec_query_start_loc[: bs + 1],
-                non_spec_query_start_loc=None,
-                spec_state_indices_tensor=self.spec_state_indices_tensor.gpu[:bs],
-                non_spec_state_indices_tensor=None,
-                spec_sequence_masks=self.spec_sequence_masks[:bs],
-                spec_token_indx=self.spec_token_indx[: bs * (self.num_spec + 1)],
-                non_spec_token_indx=self.non_spec_token_indx[:0],
-                num_accepted_tokens=self.num_accepted_tokens[:bs],
-                nums_dict=None,
-                batch_ptr=None,
-                token_chunk_offset_ptr=None,
-            )
-        else:
-            gdn_metadata = GDNAttentionMetadata(
-                num_prefills=0,
-                num_prefill_tokens=0,
-                num_decodes=bs,
-                num_decode_tokens=bs,
-                num_spec_decodes=0,
-                num_spec_decode_tokens=0,
-                num_actual_tokens=bs,
-                has_initial_state=None,
-                spec_query_start_loc=None,
-                non_spec_query_start_loc=self.non_spec_query_start_loc[: bs + 1],
-                spec_state_indices_tensor=None,
-                non_spec_state_indices_tensor=self.non_spec_state_indices_tensor.gpu[
-                    :bs
-                ],
-                spec_sequence_masks=None,
-                spec_token_indx=None,
-                non_spec_token_indx=None,
-                num_accepted_tokens=None,
-                nums_dict=None,
-                batch_ptr=None,
-                token_chunk_offset_ptr=None,
-            )
-        attn_metadata.gdn_metadata = gdn_metadata
+        attn_metadata.gdn_metadata = self._build_gdn_capture_metadata(bs)
 
         positions = var["positions"].copy_to_gpu(bs)
         context = Context(

--- a/atom/model_ops/attentions/kimi_mla_gdn_attn.py
+++ b/atom/model_ops/attentions/kimi_mla_gdn_attn.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+from typing import Type
+
+import numpy as np
+import torch
+from aiter import dtypes
+from atom.model_engine.scheduler import ScheduledBatch
+from atom.model_ops.attention_mla import MLAAttention
+from atom.utils import envs
+
+from .aiter_mla import AiterMLAMetadataBuilder
+from .backends import AttentionBackend
+from .gdn_attn import GDNStateMixin
+from .triton_mla import TritonMLAMetadataBuilder
+
+
+class KimiMLAGDNBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "KIMI_MLA_GDN"
+
+    @staticmethod
+    def get_builder_cls() -> Type["_KimiMLAGDNCommon"]:
+        if envs.ATOM_USE_TRITON_MLA:
+            return KimiTritonMLAGDNMetadataBuilder
+        return KimiAiterMLAGDNMetadataBuilder
+
+    @staticmethod
+    def get_impl_cls() -> Type["MLAAttention"]:
+        return MLAAttention
+
+
+class _KimiMLAGDNCommon(GDNStateMixin):
+    def __init__(self, model_runner):
+        super().__init__(model_runner=model_runner)
+        self.mla_idx_by_layer = {
+            layer: index
+            for index, layer in enumerate(model_runner.full_attention_layers)
+        }
+        self.kda_idx_by_layer = {
+            layer: index
+            for index, layer in enumerate(model_runner.kda_attention_layers)
+        }
+
+    def compute_block_bytes(self) -> int:
+        runner = self.model_runner
+        config = runner.config
+        hf = config.hf_config
+        num_draft = runner._get_total_num_layers() - hf.num_hidden_layers
+        num_layers = runner.num_full_attn + num_draft
+        entry = hf.kv_lora_rank + hf.qk_rope_head_dim
+        kv_dtype_size = dtypes.d_dtypes[config.kv_cache_dtype].itemsize
+        return num_layers * runner.block_size * entry * kv_dtype_size
+
+    def allocate_kv_cache_tensors(
+        self, num_kv_heads: int, num_draft_layers: int
+    ) -> dict:
+        del num_kv_heads
+        runner = self.model_runner
+        config = runner.config
+        hf = config.hf_config
+        num_layers = runner.num_full_attn + num_draft_layers
+        entry = hf.kv_lora_rank + hf.qk_rope_head_dim
+        return {
+            "kv_cache": torch.zeros(
+                num_layers,
+                runner.num_physical_kvcache_blocks,
+                runner.physical_block_size,
+                entry,
+                dtype=dtypes.d_dtypes[config.kv_cache_dtype],
+                device="cuda",
+            )
+        }
+
+    def build_kv_cache_tensor(self, layer_id: int, module):
+        from atom.config import KVCacheTensor
+
+        runner = self.model_runner
+        if hasattr(module, "base_linear_attention"):
+            row = self.kda_idx_by_layer[layer_id]
+            return KVCacheTensor(
+                layer_num=layer_id,
+                k_cache=runner.mamba_k_cache[row],
+                v_cache=runner.mamba_v_cache[row],
+                k_scale=None,
+                v_scale=None,
+            )
+
+        if hasattr(module, "base_attention") and getattr(module, "use_mla", False):
+            hf = runner.config.hf_config
+            row = self.mla_idx_by_layer.get(layer_id)
+            if row is None:
+                assert layer_id >= hf.num_hidden_layers, (
+                    f"MLA model layer {layer_id} is neither a K3 full-attention "
+                    "layer nor a draft layer"
+                )
+                row = runner.num_full_attn + (layer_id - hf.num_hidden_layers)
+            allocated_rows = runner.kv_cache.shape[0]
+            assert row < allocated_rows, (
+                f"MLA cache row {row} for model layer {layer_id} "
+                f"exceeds {allocated_rows} allocated rows"
+            )
+            entry = hf.kv_lora_rank + hf.qk_rope_head_dim
+            kv_cache = runner.kv_cache[row].view(-1, 1, entry)
+            module.max_model_len = runner.config.max_model_len
+            module.kv_cache = kv_cache
+            return KVCacheTensor(
+                layer_num=layer_id,
+                k_cache=kv_cache,
+                v_cache=None,
+                k_scale=None,
+                v_scale=None,
+            )
+
+        return None
+
+    def prepare_prefill(self, batch: ScheduledBatch):
+        attn_metadata, positions = super().prepare_prefill(batch)
+        if batch.block_tables == []:
+            attn_metadata.gdn_metadata = None
+            return attn_metadata, positions
+        attn_metadata.gdn_metadata = self.prepare_gdn_metadata(
+            batch,
+            attn_metadata,
+            is_prefill=True,
+            prepare_block_tables=False,
+        )
+        return attn_metadata, positions
+
+    def prepare_decode(self, batch: ScheduledBatch, bs: int):
+        attn_metadata, positions = super().prepare_decode(batch, bs)
+        self._attach_gdn_decode_metadata(
+            batch,
+            attn_metadata,
+            prepare_block_tables=False,
+        )
+        return attn_metadata, positions
+
+    def build_for_cudagraph_capture(self, bs: int):
+        if self.block_size == 1:
+            var = self.model_runner.forward_vars
+            var["kv_indptr"].np[: bs + 1] = np.arange(bs + 1, dtype=np.int32)
+            var["kv_indptr"].copy_to_gpu(bs + 1)
+            var["kv_indices"].gpu[:bs].zero_()
+            var["kv_last_page_lens"].gpu[:bs].fill_(1)
+
+        attn_metadata, context = super().build_for_cudagraph_capture(bs)
+        attn_metadata.gdn_metadata = self._build_gdn_capture_metadata(bs)
+        return attn_metadata, context
+
+
+class KimiAiterMLAGDNMetadataBuilder(_KimiMLAGDNCommon, AiterMLAMetadataBuilder):
+    pass
+
+
+class KimiTritonMLAGDNMetadataBuilder(_KimiMLAGDNCommon, TritonMLAMetadataBuilder):
+    pass

--- a/atom/model_ops/base_attention.py
+++ b/atom/model_ops/base_attention.py
@@ -12,7 +12,7 @@ import triton.language as tl
 
 
 from atom.utils import mark_spliting_op
-from .attention_mla import MLAModules
+from .attention_mla import MLAModules, _mla_output_width
 from atom.config import get_current_atom_config
 from atom.utils.selector import get_attn_backend
 
@@ -332,7 +332,9 @@ def fake_(
     # If we fusion rmsnorm and quant, the input dtype is fp8, but actually we use bf16 for output.
     atom_config = get_current_atom_config()
     if use_mla:
-        output_shape[-1] = atom_config.hf_config.hidden_size
+        bound = atom_config.compilation_config.static_forward_context[layer_name]
+        impl = getattr(bound, "impl", bound)
+        output_shape[-1] = _mla_output_width(impl, atom_config.hf_config.hidden_size)
     output_dtype = atom_config.torch_dtype
     output = torch.zeros(output_shape, dtype=output_dtype, device=q.device)
 

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -23,6 +23,7 @@ from einops import rearrange
 from torch import nn
 
 from atom.config import Config, QuantizationConfig, get_current_atom_config
+from atom.model_ops.attention_mla import MLAModules
 from atom.model_ops.base_attention import Attention
 
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
@@ -41,6 +42,7 @@ from atom.model_ops.fla_ops.fused_sigmoid_gating import (
     fused_sigmoid_gating_delta_rule_update,
 )
 from atom.model_ops.moe import FusedMoE
+from atom.model_ops.rotary_embedding import RotaryEmbedding
 from atom.model_ops.utils import atom_parameter
 from atom.models.utils import (
     IntermediateTensors,
@@ -99,8 +101,7 @@ def _normalize_kimi_config(config) -> None:
     config.num_gdn_attn_state = len(config.kimi_kda_layers)
     config.num_full_attn = len(config.kimi_full_attn_layers)
 
-    # Kimi full-attention layers run MLA math but are stored in the standard
-    # paged-MHA cache by padding V to q_head_dim.
+    # Keep the logical Q/K head width available to shared model infrastructure.
     config.head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
     if getattr(config, "rope_parameters", None) is None:
         config.rope_parameters = {
@@ -129,6 +130,28 @@ def _extract_layer_idx(prefix: str) -> int:
         if part.isdigit():
             return int(part)
     return 0
+
+
+class _NoPositionalRotaryEmbedding(RotaryEmbedding):
+    def _compute_cos_sin_cache(self) -> tuple[torch.Tensor, torch.Tensor]:
+        cache_shape = (
+            self.max_position_embeddings,
+            1,
+            1,
+            self.rotary_dim // 2,
+        )
+        return (
+            torch.ones(cache_shape, dtype=torch.float32),
+            torch.zeros(cache_shape, dtype=torch.float32),
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return query, key
 
 
 class SituAndMul(nn.Module):
@@ -397,8 +420,6 @@ class KimiFullAttention(nn.Module):
         self.scaling = self.q_head_dim**-0.5
         self.tp_size = get_tensor_model_parallel_world_size()
         self.num_local_heads = self.num_heads // self.tp_size
-        self.local_q_size = self.num_local_heads * self.q_head_dim
-        self.local_v_size = self.num_local_heads * self.v_head_dim
 
         self.q_a_proj = ReplicatedLinear(
             self.hidden_size,
@@ -445,63 +466,54 @@ class KimiFullAttention(nn.Module):
             prefix=f"{prefix}.o_proj",
         )
 
+        rope_parameters = getattr(config, "rope_parameters", None) or {}
+        rope_theta = rope_parameters.get("rope_theta") or 10000.0
+        self.rotary_emb = _NoPositionalRotaryEmbedding(
+            head_size=self.qk_rope_head_dim,
+            rotary_dim=self.qk_rope_head_dim,
+            max_position_embeddings=int(
+                getattr(atom_config, "max_model_len", None) or 16384
+            ),
+            base=rope_theta,
+        )
+        mla_modules = MLAModules(
+            q_lora_rank=self.q_lora_rank,
+            kv_lora_rank=self.kv_lora_rank,
+            qk_nope_head_dim=self.qk_nope_head_dim,
+            qk_rope_head_dim=self.qk_rope_head_dim,
+            qk_head_dim=self.q_head_dim,
+            v_head_dim=self.v_head_dim,
+            rotary_emb=self.rotary_emb,
+            q_proj=self.q_b_proj,
+            kv_b_proj=self.kv_b_proj,
+            o_proj=nn.Identity(),
+            indexer=None,
+            is_sparse=False,
+            topk_tokens=None,
+        )
         self.layer_num = _extract_layer_idx(prefix)
         self.attn = Attention(
             self.num_local_heads,
-            self.q_head_dim,
+            self.kv_lora_rank + self.qk_rope_head_dim,
             self.scaling,
-            num_kv_heads=self.num_local_heads,
+            num_kv_heads=1,
             kv_cache_dtype=atom_config.kv_cache_dtype,
-            quant_config=quant_config,
-            use_mla=False,
             layer_num=self.layer_num,
-            config=atom_config,
+            use_mla=True,
+            mla_modules=mla_modules,
             prefix=prefix,
         )
 
     def forward(
         self, positions: torch.Tensor, hidden_states: torch.Tensor
     ) -> torch.Tensor:
-        # q already has the [nope | rope] head layout from q_b_proj; RoPE is
-        # applied inside self.attn, so there is no split/re-cat here (that would
-        # be an identity round-trip that just copies q).
-        q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states)))
-        q = q.view(-1, self.num_local_heads, self.q_head_dim)
-
+        q = self.q_a_layernorm(self.q_a_proj(hidden_states))
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
-        k_latent, k_rope = torch.split(
+        kv, k_rope = torch.split(
             compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
         )
-        kv = self.kv_b_proj(self.kv_a_layernorm(k_latent))
-        kv = kv.view(-1, self.num_local_heads, self.qk_nope_head_dim + self.v_head_dim)
-
-        # Fused assembly (one kernel instead of split + cat + pad): builds
-        # k = [k_nope (from kv) | k_rope (MQA-shared)] and v_padded = [v | 0].
-        # Kimi MLA is stored in the standard paged-MHA cache, so V is padded to
-        # the query head dim to share a cache entry with K (sliced back after).
-        from atom.models.kimi_k3_fused import fuse_mla_kv
-
-        k, v_padded = fuse_mla_kv(
-            kv,
-            k_rope,
-            self.qk_nope_head_dim,
-            self.v_head_dim,
-            self.qk_rope_head_dim,
-        )
-
-        # MLA-as-MHA at head_dim=192. self.attn both writes the paged KV cache
-        # (4D FLASH layout, reshape_and_cache_flash) and runs aiter unified_attention
-        # for prefill (varlen) AND decode: the standard Triton kernel handles the
-        # non-power-of-two head dim via HEAD_SIZE_PADDED, so prefill needs no torch
-        # SDPA fallback. This routing also lets chunked prefill read the paged cache.
-        attn_out = self.attn(
-            q.reshape(-1, self.local_q_size),
-            k.reshape(-1, self.local_q_size),
-            v_padded.reshape(-1, self.local_q_size),
-        )
-        attn_out = attn_out.view(-1, self.num_local_heads, self.q_head_dim)[
-            :, :, : self.v_head_dim
-        ].reshape(-1, self.local_v_size)
+        kv = self.kv_a_layernorm(kv)
+        attn_out = self.attn(q, kv, k_rope, positions)
         attn_out = attn_out * torch.sigmoid(self.g_proj(hidden_states))
         return self.o_proj(attn_out)
 

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -776,7 +776,11 @@ class KimiKDAAttention(nn.Module):
         if recurrent:
             kwargs.pop("safe_gate", None)
             return fused_recurrent_kda(**kwargs)
-        return chunk_kda(**kwargs)
+        # FLA 0.5.1's default KDA recompute specialization is non-deterministic
+        # for long, packed gfx950 prefills and can emit extreme values. Selecting
+        # disable_recompute enables its STORE_QG specialization, which is stable
+        # and preserves the same chunk-KDA forward semantics.
+        return chunk_kda(**kwargs, disable_recompute=True)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # Route through the opaque custom op so torch.compile splits the graph

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -1288,6 +1288,7 @@ class KimiK3ForCausalLM(nn.Module):
     def __init__(self, atom_config: Config, prefix: str = ""):
         super().__init__()
         root_config = atom_config.hf_config
+        rebuilt_quant_config = False
         if (
             hasattr(root_config, "text_config")
             and root_config.text_config is not root_config
@@ -1302,6 +1303,7 @@ class KimiK3ForCausalLM(nn.Module):
                     root_config.text_config,
                     atom_config.online_quant_config,
                 )
+                rebuilt_quant_config = True
         else:
             _normalize_kimi_config(root_config)
         self.config = _text_config(root_config)
@@ -1309,6 +1311,12 @@ class KimiK3ForCausalLM(nn.Module):
         self.packed_modules_mapping = _kda_packed_modules_mapping(
             self.config.kimi_kda_layers
         )
+        if rebuilt_quant_config:
+            self.quant_config.remap_layer_name(
+                self.config,
+                packed_modules_mapping=self.packed_modules_mapping,
+                quant_exclude_name_mapping=self.quant_exclude_name_mapping,
+            )
         self.language_model = KimiLinearForCausalLM(
             atom_config=atom_config,
             prefix=maybe_prefix(prefix, "language_model"),

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -31,6 +31,7 @@ from atom.model_ops.layernorm import RMSNorm
 from atom.model_ops.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
+    MergedReplicatedLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
@@ -116,6 +117,8 @@ def _kda_packed_modules_mapping(
     mapping = {
         ".gate_proj": (".gate_up_proj", 0),
         ".up_proj": (".gate_up_proj", 1),
+        ".q_a_proj": (".fused_qkv_a_proj", 0),
+        ".kv_a_proj_with_mqa": (".fused_qkv_a_proj", 1),
     }
     projection_names = ("q_proj", "k_proj", "v_proj", "g_proj")
     for layer_idx in kda_layer_indices:
@@ -421,12 +424,12 @@ class KimiFullAttention(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.num_local_heads = self.num_heads // self.tp_size
 
-        self.q_a_proj = ReplicatedLinear(
+        self.fused_qkv_a_proj = MergedReplicatedLinear(
             self.hidden_size,
-            self.q_lora_rank,
+            [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
             bias=False,
             quant_config=quant_config,
-            prefix=f"{prefix}.q_a_proj",
+            prefix=f"{prefix}.fused_qkv_a_proj",
         )
         self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=1e-6)
         self.q_b_proj = ColumnParallelLinear(
@@ -435,13 +438,6 @@ class KimiFullAttention(nn.Module):
             bias=False,
             quant_config=quant_config,
             prefix=f"{prefix}.q_b_proj",
-        )
-        self.kv_a_proj_with_mqa = ReplicatedLinear(
-            self.hidden_size,
-            self.kv_lora_rank + self.qk_rope_head_dim,
-            bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.kv_a_proj_with_mqa",
         )
         self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=1e-6)
         self.kv_b_proj = ColumnParallelLinear(
@@ -507,12 +503,21 @@ class KimiFullAttention(nn.Module):
     def forward(
         self, positions: torch.Tensor, hidden_states: torch.Tensor
     ) -> torch.Tensor:
-        q = self.q_a_layernorm(self.q_a_proj(hidden_states))
-        compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
-        kv, k_rope = torch.split(
-            compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+        from atom.models.kimi_k3_fused import dual_rmsnorm
+
+        q, kv, k_rope = torch.split(
+            self.fused_qkv_a_proj(hidden_states),
+            [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
         )
-        kv = self.kv_a_layernorm(kv)
+        q, kv = dual_rmsnorm(
+            q,
+            self.q_a_layernorm.weight,
+            self.q_a_layernorm.eps,
+            kv,
+            self.kv_a_layernorm.weight,
+            self.kv_a_layernorm.eps,
+        )
         attn_out = self.attn(q, kv, k_rope, positions)
         attn_out = attn_out * torch.sigmoid(self.g_proj(hidden_states))
         return self.o_proj(attn_out)

--- a/atom/models/kimi_k3_fused.py
+++ b/atom/models/kimi_k3_fused.py
@@ -863,10 +863,9 @@ def dual_rmsnorm(
     k_weight: torch.Tensor,
     k_eps: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    q = q.contiguous()
-    k = k.contiguous()
-    q_out = torch.empty_like(q)
-    k_out = torch.empty_like(k)
+    # The AITER kernel honors row strides; K3 split views have inner stride 1.
+    q_out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+    k_out = torch.empty(k.shape, dtype=k.dtype, device=k.device)
     _aiter_fused_qk_rmsnorm_kernel(
         q,
         q_weight,

--- a/atom/models/kimi_k3_fused.py
+++ b/atom/models/kimi_k3_fused.py
@@ -10,15 +10,18 @@ several separate torch ops (each a kernel launch + full HBM round-trip):
 
 The activation and gated-rmsnorm kernels remain gated behind ``ATOM_K3_FUSED``
 in kimi_k3.py. ``apply_attn_res`` is the production path; correctness is checked
-against a local torch reference in my_script/optest_fused.py. ``dual_rmsnorm`` is
-ungated and always invokes the fused AITER q/k RMSNorm kernel.
+against a local torch reference in my_script/optest_fused.py. ``dual_rmsnorm`` has
+no environment gate or fallback and always launches the fused AITER q/k RMSNorm
+kernel.
 """
 
 from __future__ import annotations
 
 import torch
-from aiter import QuantType as _QuantType
-from aiter import fused_qk_rmsnorm as _aiter_fused_qk_rmsnorm
+from aiter.jit.utils.torch_guard import torch_compile_guard
+from aiter.ops.fused_qk_norm_rope_cache_quant import (
+    _fused_qk_rmsnorm_kernel as _aiter_fused_qk_rmsnorm_kernel,
+)
 
 try:
     import triton
@@ -840,6 +843,18 @@ def fuse_mla_kv(
     return k, v_padded
 
 
+def _dual_rmsnorm_fake(
+    q: torch.Tensor,
+    q_weight: torch.Tensor,
+    q_eps: float,
+    k: torch.Tensor,
+    k_weight: torch.Tensor,
+    k_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return q.new_empty(q.shape), k.new_empty(k.shape)
+
+
+@torch_compile_guard(gen_fake=_dual_rmsnorm_fake, mutates_args=[])
 def dual_rmsnorm(
     q: torch.Tensor,
     q_weight: torch.Tensor,
@@ -852,15 +867,14 @@ def dual_rmsnorm(
     k = k.contiguous()
     q_out = torch.empty_like(q)
     k_out = torch.empty_like(k)
-    _aiter_fused_qk_rmsnorm(
-        q_out_quantized=q_out,
-        q=q,
-        q_weight=q_weight,
-        q_epsilon=q_eps,
-        k_out=k_out,
-        k=k,
-        k_weight=k_weight,
-        k_epsilon=k_eps,
-        quant_type=_QuantType.No,
+    _aiter_fused_qk_rmsnorm_kernel(
+        q,
+        q_weight,
+        q_eps,
+        k,
+        k_weight,
+        k_eps,
+        q_out,
+        k_out,
     )
     return q_out, k_out

--- a/atom/models/kimi_k3_fused.py
+++ b/atom/models/kimi_k3_fused.py
@@ -6,16 +6,19 @@ several separate torch ops (each a kernel launch + full HBM round-trip):
 - ``situ_and_mul``      : SiTU(gate) * linear(up)  (dense/shared-expert MLP act)
 - ``rmsnorm_gated``     : rmsnorm(x) * weight * sigmoid(gate)  (KDA o_norm)
 - ``apply_attn_res``    : block-residual soft-attention mix (attn_res boundaries)
+- ``dual_rmsnorm``      : q + k RMSNorm in one AITER kernel (MLA a_layernorm)
 
 The activation and gated-rmsnorm kernels remain gated behind ``ATOM_K3_FUSED``
-in kimi_k3.py, with the torch reference implementations at the bottom of this
-module doubling as the no-triton fallback. ``apply_attn_res`` is the production
-path and is not env-gated.
+in kimi_k3.py. ``apply_attn_res`` is the production path; correctness is checked
+against a local torch reference in my_script/optest_fused.py. ``dual_rmsnorm`` is
+ungated and always invokes the fused AITER q/k RMSNorm kernel.
 """
 
 from __future__ import annotations
 
 import torch
+from aiter import QuantType as _QuantType
+from aiter import fused_qk_rmsnorm as _aiter_fused_qk_rmsnorm
 
 try:
     import triton
@@ -835,3 +838,29 @@ def fuse_mla_kv(
         BLOCK=BLOCK,
     )
     return k, v_padded
+
+
+def dual_rmsnorm(
+    q: torch.Tensor,
+    q_weight: torch.Tensor,
+    q_eps: float,
+    k: torch.Tensor,
+    k_weight: torch.Tensor,
+    k_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q = q.contiguous()
+    k = k.contiguous()
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
+    _aiter_fused_qk_rmsnorm(
+        q_out_quantized=q_out,
+        q=q,
+        q_weight=q_weight,
+        q_epsilon=q_eps,
+        k_out=k_out,
+        k=k,
+        k_weight=k_weight,
+        k_epsilon=k_eps,
+        quant_type=_QuantType.No,
+    )
+    return q_out, k_out

--- a/atom/utils/selector.py
+++ b/atom/utils/selector.py
@@ -15,6 +15,7 @@ def get_attn_backend(
     use_mla: bool = False,
     use_gdn: bool = False,
     use_v4: bool = False,
+    use_kimi_mla: bool = False,
 ) -> Type[AttentionBackend]:
     """Selects which attention backend to use and lazily imports it."""
     return _cached_get_attn_backend(
@@ -24,6 +25,7 @@ def get_attn_backend(
         use_v4=use_v4,
         use_sglang=is_sglang(),
         use_vllm=is_vllm(),
+        use_kimi_mla=use_kimi_mla,
     )
 
 
@@ -35,11 +37,18 @@ def _cached_get_attn_backend(
     use_v4: bool = False,
     use_sglang: bool = False,
     use_vllm: bool = False,
+    use_kimi_mla: bool = False,
 ) -> Type[AttentionBackend]:
 
     # get device-specific attn_backend
     attention_cls = get_attn_backend_cls(
-        block_size, use_mla, use_gdn, use_v4, use_sglang, use_vllm
+        block_size=block_size,
+        use_mla=use_mla,
+        use_gdn=use_gdn,
+        use_v4=use_v4,
+        use_sglang=use_sglang,
+        use_vllm=use_vllm,
+        use_kimi_mla=use_kimi_mla,
     )
     if not attention_cls:
         raise ValueError(f"Invalid attention backend for {attention_cls}")
@@ -47,10 +56,18 @@ def _cached_get_attn_backend(
 
 
 def get_attn_backend_cls(
-    block_size, use_mla, use_gdn, use_v4, use_sglang, use_vllm
+    block_size,
+    use_mla,
+    use_gdn,
+    use_v4,
+    use_sglang,
+    use_vllm,
+    use_kimi_mla=False,
 ) -> str:
     if use_v4:
         return "atom.model_ops.attentions.deepseek_v4_attn.DeepseekV4Backend"
+    if use_kimi_mla:
+        return "atom.model_ops.attentions.kimi_mla_gdn_attn.KimiMLAGDNBackend"
     if use_mla:
         if envs.ATOM_USE_TRITON_MLA:
             return "atom.model_ops.attentions.triton_mla.TritonMLABackend"


### PR DESCRIPTION
## Summary

Cherry-pick the six commits from [`carlushuang/ATOM-K3#24`](https://github.com/carlushuang/ATOM-K3/pull/24) onto `ROCm/ATOM:zejun/kimi-k3`, preserving their order and commit boundaries:

1. `feat(kimi-k3): run full attention through true MLA`
2. `perf(kimi-k3): fuse MLA latent projections and norms`
3. `fix(kimi-k3): make dual RMSNorm compile-safe at 16K`
4. `fix(kimi-k3): remap rebuilt quant config`
5. `perf(kimi-k3): eliminate latent norm copies`
6. `fix accuracy stabilization issue`


## Validation

