### PR TITLE
fix(MI308): keep BF16 fallback out of FP8 quant mode

### DIFF
--- a/atom/model_ops/v4_kernels/fused_compress.py
+++ b/atom/model_ops/v4_kernels/fused_compress.py
@@ -526,7 +526,14 @@ def fused_compress_attn(
             cache_scale=cache_scale,
             use_ue8m0=use_ue8m0,
             preshuffle=preshuffle and not main_2buff_fp8,
-            quant_mode="group_fp8" if main_2buff_fp8 else "per_row_fp8",
+            # AITER treats quant_mode as authoritative; BF16 fallback must use "none".
+            quant_mode=(
+                "group_fp8"
+                if main_2buff_fp8
+                else "per_row_fp8"
+                if quant
+                else "none"
+            ),
             k_rope_cache=kv_cache_rope if main_2buff_fp8 else None,
         )
         return


### PR DESCRIPTION
## Motivation
Fix DeepSeek-V4 inference on MI308 (gfx942) after the latest AITER update. MI308 falls back to a BF16 KV-cache layout, but ATOM incorrectly reported the path as FP8, causing:

TypeError: fp8 quant needs fp8 kv_cache

## Technical Details
AITER [#4029](https://github.com/ROCm/aiter/pull/4029) made quant_mode the authoritative quantization selector.

Update ATOM’s fused-compress dispatch to pass:
- group_fp8 for native two-buffer FP8
- per_row_fp8 for indexer FP8
- none for the MI308 BF16 fallback path

## Test Result
**before:**
<img width="1207" height="481" alt="image" src="https://github.com/user-attachments/assets/f16f1998-06d8-4143-93ac-df9c0b2be1f1" />

**after:**
<img width="1409" height="248" alt="image" src="https://github.com/user-attachments/assets/7b0b7147-9cb6-4fe6-a2ff-ec9a3733d7ae" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
