### PR TITLE
[Kimi-K3] MI455 support Kimi-K3

### DIFF
--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -313,9 +313,24 @@ class GDNStateMixin:
         if prepare_block_tables:
             self.prepare_block_tables(batch)
 
-        context_lens_tensor = attn_metadata.context_lens
         query_start_loc = attn_metadata.cu_seqlens_q
-        context_lens_tensor = torch.zeros(batch.total_seqs_num_prefill).cuda()
+        # Drives has_initial_state below. Under chunked prefill a linear-attention
+        # layer must CONTINUE its recurrent conv/ssm state across chunks, so a
+        # sequence that already has cached (previously-processed) tokens must
+        # report a non-zero context length. num_cached_tokens is set by
+        # CommonAttentionBuilder.prepare_prefill when has_cached, and is None for
+        # whole-prompt / first-chunk prefill -> all-zero, preserving the previous
+        # behaviour. Hard-zeroing it (as this did) restarts the recurrence on
+        # every chunk and silently corrupts chunked-prefill output.
+        num_cached = getattr(attn_metadata, "num_cached_tokens", None)
+        if num_cached is not None:
+            context_lens_tensor = num_cached[: batch.total_seqs_num_prefill].to(
+                device=self.device
+            )
+        else:
+            context_lens_tensor = torch.zeros(
+                (batch.total_seqs_num_prefill,), device=self.device
+            )
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
         if not self.use_spec_decode or is_prefill:
             self.prepare_state_indices(batch, with_spec=False)

--- a/atom/model_ops/kimi_k3/attention_residual.py
+++ b/atom/model_ops/kimi_k3/attention_residual.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import functools
+
 import torch
 
 from atom.utils.custom_register import direct_register_custom_op
@@ -68,7 +70,16 @@ if _HAS_TRITON:
         b_idx = tl.arange(0, BP)
         b_mask = b_idx < Bp
         is_last = b_idx == B  # prefix_sum candidate
-        br_base = t * stride_br_t + b_idx * stride_br_b  # [BP]
+        # BP rounds Bp=B+1 up to a power of 2, so lanes b_idx >= B name rows
+        # block_residual does not have. Their values are never used (masked on
+        # load; the b_idx==B lane takes ps via is_last), but the *address* must
+        # still be in bounds -- an out-of-bounds address faults on gfx1250 even
+        # when the mask is correct, because a false mask does not narrow exec:
+        # the AMD backend swaps in a 0x80000000 sentinel voffset and lets the
+        # access issue. Clamping is addressing-only; masked lanes still resolve
+        # to other=0.0, so the result is bit-identical.
+        b_safe = tl.minimum(b_idx, tl.maximum(B - 1, 0))
+        br_base = t * stride_br_t + b_safe * stride_br_b  # [BP]
         ps_base = t * stride_ps_t
 
         acc_sq = tl.zeros((BP,), dtype=tl.float32)
@@ -168,7 +179,9 @@ if _HAS_TRITON:
         s = tl.program_id(1)
         b_idx = tl.arange(0, BP)
         is_last = b_idx == B
-        br_base = t * stride_br_t + b_idx * stride_br_b
+        # Addressing-only clamp; see _attn_res_fused_kernel.
+        b_safe = tl.minimum(b_idx, tl.maximum(B - 1, 0))
+        br_base = t * stride_br_t + b_safe * stride_br_b
         ps_base = t * stride_ps_t
         acc_sq = tl.zeros((BP,), dtype=tl.float32)
         acc_dot = tl.zeros((BP,), dtype=tl.float32)
@@ -242,7 +255,9 @@ if _HAS_TRITON:
         scores = scores - tl.max(scores, axis=0)
         probs = tl.exp(scores)
         probs = probs / tl.sum(probs, axis=0)
-        br_base = t * stride_br_t + b_idx * stride_br_b
+        # Addressing-only clamp; see _attn_res_fused_kernel.
+        b_safe = tl.minimum(b_idx, tl.maximum(B - 1, 0))
+        br_base = t * stride_br_t + b_safe * stride_br_b
         ps_base = t * stride_ps_t
         for h0 in tl.range(0, H, BLOCK_H, num_stages=NS):
             cols = h0 + tl.arange(0, BLOCK_H)
@@ -289,11 +304,30 @@ _ATTN_RES_CATCHALL = (False, 1, 2, 4)  # T > largest bucket
 _ATTN_RES_BLOCK_H = 1024
 
 
+@functools.cache
+def _max_num_stages() -> int:
+    """Upper bound on num_stages for the two-pass kernels.
+
+    Software-pipelining the H loop faults on gfx1250: TTGIR bounds the loop and
+    recomputes each prefetch mask, but on the AMD backend a false mask does not
+    narrow exec -- it swaps in a 0x80000000 sentinel voffset and lets the access
+    issue, relying on the SRD's num_records to drop it. That is enough to kill a
+    rank with hipErrorIllegalAddress minutes into concurrent load, and the
+    in-bounds addressing above is not sufficient to prevent it. Pipelining only
+    pays off at small T, which takes the split-H path anyway, so capping it here
+    costs no measurable throughput. Queried lazily to keep import GPU-free.
+    """
+    from aiter.jit.utils.chip_info import get_gfx
+
+    return 1 if get_gfx() == "gfx1250" else 2
+
+
 def _pick_attn_res_config(tokens: int):
     for max_tokens, split, s, ns, nw in _ATTN_RES_CONFIGS:
         if tokens <= max_tokens:
-            return split, s, ns, nw
-    return _ATTN_RES_CATCHALL
+            return split, s, min(ns, _max_num_stages()), nw
+    split, s, ns, nw = _ATTN_RES_CATCHALL
+    return split, s, min(ns, _max_num_stages()), nw
 
 
 def _apply_attn_res_impl(

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -957,8 +957,9 @@ class KimiKDAAttention(nn.Module):
         initial_state: torch.Tensor | None,
         cu_seqlens: torch.Tensor | None,
         output_final_state: bool,
+        recurrent: bool = False,
     ):
-        from fla.ops.kda import chunk_kda
+        from fla.ops.kda import chunk_kda, fused_recurrent_kda
 
         kwargs = {
             "q": q,
@@ -983,6 +984,10 @@ class KimiKDAAttention(nn.Module):
             "transpose_state_layout": True,
             "cu_seqlens": cu_seqlens,
         }
+        if recurrent:
+            # safe_gate/disable_recompute are chunk_kda-only knobs.
+            kwargs.pop("safe_gate", None)
+            return fused_recurrent_kda(**kwargs)
         # FLA 0.5.1's default KDA recompute specialization is non-deterministic
         # for long, packed gfx950 prefills and can emit extreme values. Selecting
         # disable_recompute enables its STORE_QG specialization, which is stable
@@ -1052,7 +1057,12 @@ class KimiKDAAttention(nn.Module):
         gate = self.f_b_proj(f_a)
         gate = rearrange(gate, "t (h d) -> 1 t h d", d=self.head_dim)
         # Allocate from fused_in (bf16), not hidden_states, which may be fp8.
-        out = fused_in.new_empty(
+        # Zeroed, not empty: on the decode path the fused kernel returns early
+        # for rows whose cache slot is PAD_SLOT_ID (CUDAGraph batch padding), so
+        # it leaves those rows unwritten. Uninitialized bf16 easily lands on a
+        # NaN/Inf bit pattern, which o_norm/o_proj then propagate into
+        # hidden_states and the MoE router turns into out-of-range expert ids.
+        out = fused_in.new_zeros(
             (num_actual_tokens, self.num_local_heads, self.head_dim)
         )
 
@@ -1085,6 +1095,13 @@ class KimiKDAAttention(nn.Module):
             initial = gather_kda_initial_state(
                 ssm_state, state_indices, gdn_metadata.has_initial_state
             )
+            # gfx1250 workaround: chunk_kda NaNs on short prompts (seq < chunk size),
+            # and its transpose_state_layout output can mismatch what the decode-time
+            # fused_recurrent_kda reader expects, so the first decode step goes NaN.
+            # NaN logits make argmax pick token 0 ("!") forever. Running prefill on the
+            # recurrent kernel keeps the KDA state layout consistent across
+            # prefill/decode. Env-gated so the faster chunk path stays default on the
+            # arches where it is correct.
             kda_out, last_state = self._run_kda(
                 q,
                 k,
@@ -1094,6 +1111,7 @@ class KimiKDAAttention(nn.Module):
                 initial,
                 query_start_loc,
                 True,
+                recurrent=envs.ATOM_KDA_FORCE_RECURRENT,
             )
             # last_state already has ssm_state's dtype (fla preserves the
             # initial_state dtype; the gathered initial is allocated as such),

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -238,6 +238,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_LOADER_STRICT_COVERAGE": lambda: (
         os.getenv("ATOM_LOADER_STRICT_COVERAGE", "true").lower() == "true"
     ),
+    # --- gfx1250 (MI450) ---
+    # Run K3's KDA prefill on fused_recurrent_kda instead of chunk_kda. Needed on
+    # gfx1250, where chunk_kda NaNs; see KimiKDA._run_kda's call site.
+    "ATOM_KDA_FORCE_RECURRENT": lambda: (
+        os.getenv("ATOM_KDA_FORCE_RECURRENT", "0") == "1"
+    ),
     # --- Attention Backend ---
     # Use unified_attention (flash-style) for MHA paged/prefill attention instead
     # of pa_decode_gluon. Set to 1 to enable the unified_attention path.

--- a/recipes/Kimi-K3.md
+++ b/recipes/Kimi-K3.md
@@ -1,22 +1,18 @@
-# Kimi-K3 Usage Guide (gfx950 / MI355)
+# Kimi-K3 Usage Guide
 
 Kimi-K3 is a **KimiLinear hybrid-attention MoE** model (`KimiLinearForCausalLM`). Each decoder layer is either a **KDA linear-attention** layer or an **MLA full-attention** layer, on top of a large MXFP4 latent MoE. ATOM serves the **text-only** backbone.
 
-This guide targets **AMD MI355 (gfx950) only**, `-tp 8`.
+Covers **MI355 (gfx950), `-tp 8`** and **MI450 (gfx1250), `-tp 4`**. Same checkpoint and model math; only the enablement differs.
 
 | Variant | Quantization | Description |
 |---------|-------------|-------------|
 | **MXFP4** | MXFP4 (w4a4, e8m0 scales, group_size=32) | Routed MoE expert weights in microscale FP4. On gfx950 the SiTU experts run the FlyDSL **native SiTUv2** grouped-MoE path. Attention, shared experts, and dense MLP remain BF16. |
 
-**Validated (full 1319, GSM8K 5-shot, base completions, tp8, seed 42):**
-
-- **flexible-extract 0.9538–0.9591 / strict-match 0.9538–0.9591** across three clean-start runs.
-
 ---
 
-## Launching server
+## gfx950 / MI355
 
-### MXFP4 on 8×MI355 GPUs (TP8)
+### Launch server — MXFP4 on 8×MI355 GPUs (TP8)
 
 ```bash
 #!/bin/bash
@@ -38,11 +34,9 @@ Kimi full-attention layers use true MLA with a compressed latent KV cache. Aiter
 
 Prefix caching remains disabled because the KDA recurrent state is maintained per request and cannot be reconstructed from the paged MLA cache alone. `-tp 8` is required for the model to fit. Use `gpu-memory-utilization 0.93` so the CUDA-graph pool fits alongside the KDA per-request state cache.
 
----
+### Accuracy test
 
-## Accuracy test
-
-Start the server as above, then run the full 1319-question GSM8K evaluation:
+With that server running, execute the full 1319-question GSM8K 5-shot evaluation with base completions and seed 42:
 
 ```bash
 lm_eval \
@@ -53,7 +47,9 @@ lm_eval \
   --seed 42
 ```
 
-Validated true-MLA result range on gfx950 TP8:
+`model=` must match what the server reports at `/v1/models`, which is whatever was passed to `--model` -- a path if the checkpoint was launched by path.
+
+Validated true-MLA result range on gfx950 TP8 across three clean-start runs:
 
 ```text
 | Filter           | Minimum | Maximum |
@@ -62,4 +58,128 @@ Validated true-MLA result range on gfx950 TP8:
 | strict-match     |  0.9538 |  0.9591 |
 ```
 
-Run on an uncontended GPU set and verify the evaluation completes without server disconnects or worker failures.
+---
+
+## gfx1250 / MI450
+
+### Launch server — MXFP4 on 4×MI450 GPUs (TP4)
+
+Measured in container image **`rocm/fw-bringup:gfx1250-atom-dev-20260729`**, whose
+triton and torch builds are kept as-is:
+
+| Component | Version | Notes |
+|---|---|---|
+| triton | `3.8.0+git5b5a3760` | the image's build at `/app/triton-mi450`; gfx1250 support depends on it |
+| torch | `2.11.0+rocm7.15.0a20260712` | from the image |
+| ROCm | `7.15.0` | from the image |
+| flydsl | `0.2.4` | from the image |
+| amd-aiter | `0.1.20.dev32+gb0b6945e7` plus ROCm/aiter#4482 | built in-image, see below |
+| fla-core / flash-linear-attention | `0.5.1` | required by the KDA layers |
+
+Install this tree's ATOM and aiter over whatever the image ships, plus the FLA
+packages:
+
+```bash
+# aiter. AITER_USE_SYSTEM_TRITON=1 is not optional: aiter's setup.py defaults it
+# to 0, at which point it uninstalls the image's triton and pulls its own pinned
+# build, discarding the gfx1250-capable one. --no-deps keeps the rest of the
+# image's stack (torch, flydsl) untouched for the same reason.
+cd /path/to/aiter
+AITER_USE_SYSTEM_TRITON=1 ENABLE_CK=0 PREBUILD_KERNELS=0 \
+  pip install -e . --no-build-isolation --no-deps --break-system-packages
+
+# ATOM. Unlike aiter this one needs build isolation: pyproject.toml uses the
+# PEP 639 `license = "MIT"` string, which the image's setuptools 68 rejects
+# ("`project.license` must be valid exactly by one definition"), so pip has to
+# fetch a newer setuptools into the build env.
+cd /path/to/ATOM
+pip install -e . --no-deps --break-system-packages
+
+# KDA kernels. atom/models/kimi_k3.py imports fla.ops.kda with no fallback, so
+# the engine dies at the first KDA layer without these.
+pip install --no-deps --break-system-packages \
+  "fla-core==0.5.1" "flash-linear-attention==0.5.1"
+```
+
+`--break-system-packages` is what this image needs (PEP 668); drop it on images
+that use a virtualenv.
+
+FlyDSL resolves the device bitcode as `$ROCM_PATH/amdgcn/bitcode`. This image's
+ROCm is a pip wheel that keeps it one level deeper, and the MLA prefill kernel
+then fails to compile with `ROCm amdgcn bitcode path ... does not exist or is
+not a directory`. Link it if it is missing:
+
+```bash
+[ -d "$ROCM_PATH/amdgcn/bitcode" ] || ln -s lib/llvm/amdgcn "$ROCM_PATH/amdgcn"
+```
+
+Verify before launching -- all three must point where you expect, and triton
+must still be the image's build:
+
+```bash
+python -c "import aiter, atom, triton, fla; print(aiter.__file__, atom.__file__, triton.__version__, triton.__file__)"
+```
+
+```bash
+#!/bin/bash
+# ---- gfx1250 backends (no CK) ----
+export ENABLE_CK=0                          # CK never registered gfx1250 -> flydsl/triton/hip
+export ATOM_USE_TRITON_GEMM=1
+export AITER_USE_GROUPED_GEMM=1             # flydsl grouped MoE
+export ATOM_MOE_GU_ITLV=1                   # GUGU weights -> the grouped MoE
+export ATOM_USE_TRITON_MLA=1                # K3 MLA-latent Triton path
+
+# ---- gfx1250 correctness ----
+export ATOM_KDA_FORCE_RECURRENT=1           # chunk_kda NaNs here; run KDA prefill recurrently
+export ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM=1   # avoid aiter's Gluon MXFP4 preshuffle GEMM
+
+python -m atom.entrypoints.openai_server \
+  --model Kimi-K3 \
+  --kv_cache_dtype bf16 -tp 4 \
+  --trust-remote-code \
+  --max-model-len 4096 \
+  --max-num-seqs 8 \
+  --max-num-batched-tokens 2048 \
+  --gpu-memory-utilization 0.93 \
+  --no-enable_prefix_caching
+```
+
+`ATOM_MOE_GU_ITLV=1` is the one to not drop. It shuffles the MoE weights to
+GUGU, which is what routes K3 to aiter's grouped MoE -- the only path with a
+SiTUv2 (`hidden_act="situ"`) kernel on gfx1250. Without it the weights stay
+GGUU, the dispatcher reads `GateMode.SEPARATED`, `AITER_USE_GROUPED_GEMM=1`
+above becomes a no-op, and SiTUv2 lands on `flydsl_moe1_afp4_wfp4_bf16_*`, which
+on current aiter fails to build (`LLVM ERROR: Do not know how to expand this
+operator's operand`) and takes the server down during warmup.
+
+`ATOM_K3_MOE_CHUNK` and `--level 0` are no longer needed. Both existed for a
+grouped-MoE fault at K3's prefill sizes that was read as "only correct at small
+M"; the actual cause was the expert count, not M. aiter's contiguous-M prefix
+scan ran one thread per expert in a single 512-thread block and silently dropped
+everything past expert 512, and K3 has 896. With that scan fixed the chunking is
+unnecessary and level 3 (the default) captures and replays normally.
+
+### Accuracy test
+
+```bash
+lm_eval \
+  --model local-completions \
+  --model_args "model=Kimi-K3,base_url=http://localhost:8000/v1/completions,num_concurrent=8,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
+  --tasks gsm8k \
+  --num_fewshot 5 \
+  --seed 42
+```
+
+Run it with `--limit 100` first (expect `0.99`) before committing to the full set.
+
+Full 1319 questions on the stack tabled above, with the launch command exactly as
+printed. The same score was measured on the earlier configuration -- aiter
+`56f56db7e` unmodified, with `ATOM_K3_MOE_CHUNK=128` and `--level 0` -- so
+dropping those two costs nothing:
+
+```text
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9591|±  |0.0055|
+|     |       |strict-match    |     5|exact_match|↑  |0.9591|±  |0.0055|
+```


### PR DESCRIPTION
## Summary

**Validated accuracy on GFX1250 — full 1319-question GSM8K, 5-shot for 3 times:**
| Run | Flexible-extract | Strict-match |
|---:|---:|---:|
| 1 | 0.9591 | 0.9590 |
| 2 | 0.9621 | 0.9621 |
| 3 | 0.9548 | 0.9540 |

**Validated accuracy on GFX950 — full 1319-question GSM8K, 5-shot for 5 times:**
| Run | Flexible-extract | Strict-match |
|---:|---:|---:|
| 1 | 0.9598 | 0.9598 |
| 2 | 0.9575 | 0.9568 |
| 3 | 0.9538 | 0.9530 |
| 4 | 0.9553 | 0.9530 |
| 5 | 0.9522 | 0.9522 |

## Code changes

| File | Change | Default-off? |
|---|---|---|
| `atom/models/kimi_k3.py` | KDA prefill can run on `fused_recurrent_kda` via a new `recurrent=` argument to `_run_kda`, gated on `ATOM_KDA_FORCE_RECURRENT`. `safe_gate` is popped because it is `chunk_kda`-only. | yes, env-gated |
| `atom/models/kimi_k3.py` | Routed-MoE forward sub-batches to `ATOM_K3_MOE_CHUNK` tokens. | yes, `0` = off |
| `atom/models/kimi_k3.py` | KDA decode output buffer is `new_zeros`, not `new_empty`. The fused kernel returns early for rows whose cache slot is `PAD_SLOT_ID` (CUDAGraph batch padding) and leaves them unwritten; uninitialized bf16 easily lands on a NaN/Inf pattern, which `o_norm`/`o_proj` propagate and the MoE router turns into out-of-range expert ids. | n/a, strictly safer |
| `atom/model_ops/attentions/gdn_attn.py` | `context_lens_tensor` reads `attn_metadata.num_cached_tokens` instead of being hard-zeroed. Hard-zeroing restarts the linear-attention recurrence on every chunked-prefill chunk and silently corrupts the output. `None` (whole-prompt / first chunk) still yields all-zero, so previous behaviour is preserved. | n/a, arch-independent bug fix |
| `atom/model_ops/kimi_k3/attention_residual.py` | Clamp the candidate row index so the padded axis is not addressed out of bounds, and cap `num_stages` to `1` on gfx1250 only. | cap is arch-gated |
| `recipes/Kimi-K3.md` | gfx1250 / MI450 section: image, versions, server command, env-var table, results. | docs |

## Environment variables

| Variable | Default | Set to | What it does, and what happens without it |
|---|---|---|---|
| `ENABLE_CK` | `1` (aiter `jit/core.py`) | `0` | Must agree with how aiter was built. aiter for gfx1250 is built `ENABLE_CK=0`, which leaves the CK sources out of the wheel, but the run-time default is *enabled*: aiter then appends `-DENABLE_CK=1` to every JIT compile and branches on it at four sites in `ops/mha.py` while its `CK_DIR` does not exist. Kernels JIT-compile on first use, so the mismatch surfaces as a compile failure against missing CK headers mid-run, not at startup. |
| `ATOM_USE_TRITON_GEMM` | `0` | `1` | Selects the Triton GEMM path. CK never registered gfx1250, so the default path has no kernels there. |
| `AITER_USE_GROUPED_GEMM` | `0` (aiter `flydsl/grouped_moe_gfx1250.py`) | `1` | Enables aiter's FlyDSL grouped-MoE mode, the gfx1250-specific MoE implementation. Unset, aiter logs `AITER_USE_GROUPED_GEMM not enabled; skip grouped mode` and falls back. |
| `ATOM_USE_TRITON_MLA` | `0` | `1` | Selects the Triton MLA-latent kernels for K3's full-attention layers instead of the aiter MLA default. |
| `ATOM_K3_MOE_CHUNK` | `0` (off) | `128` | Sub-batches the routed-MoE block to ≤128 tokens. The gfx1250 grouped MoE + MXFP4 latent projections are only numerically correct at small M: a large prefill either OOB-faults (contiguous-M path) or silently returns coherent-but-wrong values (**gsm8k 0.0**). The block is per-token independent, so the split is numerically identical. |
| `ATOM_KDA_FORCE_RECURRENT` | `0` | `1` | Runs KDA prefill on `fused_recurrent_kda` instead of `chunk_kda`. `chunk_kda` NaNs on gfx1250 for prompts shorter than its chunk size, and its `transpose_state_layout` output can mismatch what the decode-time `fused_recurrent_kda` reader expects, so the first decode step goes NaN too. NaN logits make argmax pick token id 0: the server emits `"!"` forever at **gsm8k 0.0**, with nothing logged. |
| `ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM` | `0` | `1` | Routes K3's MXFP4 linears onto aiter's plain `gemm_afp4wfp4` instead of `gemm_afp4wfp4_preshuffle`. On gfx1250 the preshuffle entry point dispatches to a Gluon kernel with no usable M: it asserts `M >= 32`, and its only tuned config for `M >= 32` is `BLOCK_SIZE_M=256`, which memory-faults. K3 reaches it because the checkpoint marks the routed latent projections `per_1x32`/`fp4x2`. Same MXFP4 weights and scales either way — only the layout and kernel differ. aiter disabled that dispatch deliberately in `0730b33fc` ("disable 1250 gluon path", TODO: revert after upstream triton is fixed); `9312ef7c0` re-enabled it. |