### PR TITLE
[sgl/vllm + atom][CI] update benchmark schedules

### DIFF
--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -6,10 +6,10 @@ concurrency:
 
 on:
   schedule:
-    # Nightly at 23:00 Beijing time (15:00 UTC). OOB tiers + MI308.
-    - cron: '0 15 * * 1,3,5'  # Mon/Wed/Fri: SGLang-OOB P0 + MI308
-    - cron: '0 15 * * 2,4'    # Tue/Thu: SGLang-OOB P1 + MI308
-    - cron: '0 15 * * 6'      # Sat only: SGLang-OOB P2 + MI308 (Sun excluded)
+    # Nightly at 23:00 Beijing time (15:00 UTC). MI308 runs Mon-Sat; MI355 tiers run Tue/Thu/Sat.
+    - cron: '0 15 * * 1,3,5'  # Mon/Wed/Fri: MI308 only
+    - cron: '0 15 * * 2,4'    # Tue/Thu: SGLang-OOB P0 + P1 on MI355, plus MI308
+    - cron: '0 15 * * 6'      # Sat only: SGLang-OOB P0 + P1 + P2 on MI355, plus MI308
   workflow_dispatch:
     inputs:
       benchmark_suite:
@@ -735,14 +735,22 @@ jobs:
               return by_prefix
 
           def scheduled_oob_selection(schedule_cron):
-              schedule_to_tier = {
-                  "0 15 * * 1,3,5": ("OOB-P0", OOB_P0_PREFIX_ORDER),
-                  "0 15 * * 2,4": ("OOB-P1", OOB_P1_PREFIX_ORDER),
-                  "0 15 * * 6": ("OOB-P2", OOB_P2_PREFIX_ORDER),
+              schedule_to_tiers = {
+                  "0 15 * * 1,3,5": ("MI308-only", []),
+                  "0 15 * * 2,4": (
+                      "OOB-P0+P1",
+                      OOB_P0_PREFIX_ORDER + OOB_P1_PREFIX_ORDER,
+                  ),
+                  "0 15 * * 6": (
+                      "OOB-P0+P1+P2",
+                      OOB_P0_PREFIX_ORDER
+                      + OOB_P1_PREFIX_ORDER
+                      + OOB_P2_PREFIX_ORDER,
+                  ),
               }
-              if schedule_cron not in schedule_to_tier:
+              if schedule_cron not in schedule_to_tiers:
                   return "SKIP-UNKNOWN-DAY", []
-              selected_group, tier_order = schedule_to_tier[schedule_cron]
+              selected_group, tier_order = schedule_to_tiers[schedule_cron]
               by_prefix = first_model_by_prefix(models)
               tier_prefixes = frozenset(tier_order)
               selected = []

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -7,8 +7,8 @@ concurrency:
 
 on:
   schedule:
-    # Daily at 00:30 Beijing (16:30 UTC previous day): run the same model set every day.
-    - cron: '30 16 * * *'
+    # Mon/Wed/Fri at 00:30 Beijing (16:30 UTC on Sun/Tue/Thu).
+    - cron: '30 16 * * 0,2,4'
   workflow_dispatch:
     inputs:
       benchmark_client:


### PR DESCRIPTION
## Summary
- Update SGLang benchmark schedule so MI308 continues running Mon-Sat, while MI355 runs P0/P1 on Tue/Thu and P0/P1/P2 on Sat only.
- Update vLLM benchmark schedule to run on Mon/Wed/Fri Beijing time only.

## Test plan
- Verified workflow diff only touches `atom-sglang-benchmark.yaml` and `atom-vllm-benchmark.yaml`.
- Ran `git diff --check`.