### PR TITLE
docs: add Kimi-K3 Day 0 AMD developer article to News

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 ## 📢 News
 
+- **[2026/07] Featured AMD Developer Article:** [Day 0 Kimi-K3 Inference Deployment with ATOM on AMD Instinct MI355X GPUs](https://www.amd.com/en/developer/resources/technical-articles/2026/kimi-k3-on-amd-instinct-gpus.html) walks through Day 0 deployment of the 2.78T-parameter Kimi-K3 (KDA + Gated MLA) on a single 8x MI355X node with TP8 — why the ~1.56 TB checkpoint fits, how the weights are distributed under TP8, and how to bring the model up with ATOM and run a minimal correctness check. See [Kimi-K3 recipe](recipes/Kimi-K3.md).
 - **[2026/07]** ATOM now supports **DeepSeek-V4-Pro DSpark** speculative decoding — a semi-autoregressive block drafter (parallel backbone + Markov head + confidence head) with confidence-scheduled ragged verification, FP8 KV cache, DP attention, and PIECEWISE CUDA graphs. See [DeepSeek-V4-DSpark recipe](recipes/DeepSeek-V4-DSpark.md).
 - **[2026/06]** ATOM now supports **MiniMax-M3** inference on the native OpenAI-compatible server path, including MXFP4/MXFP8 checkpoints, FP8 KV cache, and EAGLE3 speculative decoding. See [MiniMax-M3 recipe](recipes/MiniMax-M3.md).
 - **[2026/06] Featured ROCm Blog:** [DP Attention and TBO for DeepSeek-V4 on MI355X](https://rocm.blogs.amd.com/software-tools-optimization/atom-optimiztion/README.html) highlights how ATOM optimizes DeepSeek-V4 inference on AMD Instinct MI355X GPUs with DP Attention using all-gather/reduce-scatter and Two-Batch Overlap, achieving strongly competitive DeepSeek-V4 inference performance.


### PR DESCRIPTION
Adds the AMD developer technical article [Day 0 Kimi-K3 Inference Deployment with ATOM on AMD Instinct MI355X GPUs](https://www.amd.com/en/developer/resources/technical-articles/2026/kimi-k3-on-amd-instinct-gpus.html) (published 2026-07-27) to the README News section.

The article covers Day 0 deployment of the 2.78T-parameter Kimi-K3 (69 KDA + 24 Gated MLA layers) on a single 8x MI355X node with TP8: HBM capacity budgeting for the ~1.56 TB checkpoint, weight distribution under TP8, and bring-up with ATOM plus a minimal correctness check.

Placed at the top of News (reverse-chronological) and cross-linked to the existing `recipes/Kimi-K3.md`.

## Changes

- `README.md`: +1 line in the News section

## Test plan

- [x] Article URL returns HTTP 200 and the linked title matches the page
- [x] Relative link target `recipes/Kimi-K3.md` exists in the repo
- [x] Diff is limited to a single added line in `README.md`
- [ ] Markdown renders correctly in the GitHub README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)