### PR TITLE
[vllm+atom][CI] update vLLM benchmark nightly schedule

### DIFF
--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -7,8 +7,8 @@ concurrency:
 
 on:
   schedule:
-    # Mon/Wed/Fri at 00:30 Beijing (16:30 UTC on Sun/Tue/Thu).
-    - cron: '30 16 * * 0,2,4'
+    # Mon/Wed/Fri at 23:30 Beijing (15:30 UTC).
+    - cron: '30 15 * * 1,3,5'
   workflow_dispatch:
     inputs:
       benchmark_client:


### PR DESCRIPTION
## Summary

- Update vLLM benchmark schedule from 00:30 Beijing to 23:30 Beijing on Mon/Wed/Fri.
- Keep vLLM on the intended Beijing business day and avoid the 1.5-hour overlap window with SGLang MI355 runs from the previous night.

## Test plan

- Verified the workflow diff only changes `atom-vllm-benchmark.yaml`.
- Ran `git diff --check`.
- Checked workflow YAML lints.