### PR TITLE
[feat](kimi): support kimi k3 on vllm plugin mode

### DIFF
--- a/atom/plugin/vllm/attention/layer_mla.py
+++ b/atom/plugin/vllm/attention/layer_mla.py
@@ -804,8 +804,8 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
         attn_metadata,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         assert isinstance(q, torch.Tensor)
-        if self.head_repeat_factor > 1:
-            q = q.repeat_interleave(self.head_repeat_factor, dim=1)
+        original_num_heads = q.shape[1]
+        q = self._pad_query_heads(q)
         B = q.shape[0]
         num_heads_q = q.shape[1]
         o = torch.empty(
@@ -892,10 +892,12 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
         )
         if do_fold:
             o = o.view(ori_total_s, ori_nhead, -1)
-        if self.head_repeat_factor > 1:
-            o = o[:, :: self.head_repeat_factor, :]
-            if lse is not None:
+        o = self._restore_query_heads(o, original_num_heads)
+        if lse is not None:
+            if self.head_repeat_factor > 1:
                 lse = lse[:, :: self.head_repeat_factor]
+            elif self.head_pad > 0:
+                lse = lse[:, :original_num_heads]
         return o, lse
 
     def forward_impl(

--- a/atom/plugin/vllm/model_wrapper.py
+++ b/atom/plugin/vllm/model_wrapper.py
@@ -154,6 +154,9 @@ _ATOM_MODEL_CLASSES: dict[str, str] = {
     "Qwen3_5MoeForConditionalGeneration": "atom.plugin.vllm.models.qwen3_5:Qwen3_5MoeForConditionalGeneration_",
     "Qwen3_5ForConditionalGeneration": "atom.plugin.vllm.models.qwen3_5:Qwen3_5ForConditionalGeneration_",
     "KimiK25ForConditionalGeneration": "atom.plugin.vllm.models.kimi_k25:KimiK25ForConditionalGeneration_",
+    "KimiK3ForConditionalGeneration": (
+        "atom.plugin.vllm.models.kimi_k3:KimiK3ForCausalLM"
+    ),
     "MiniMaxM2ForCausalLM": "atom.models.minimax_m2:MiniMaxM2ForCausalLM",
     "DeepseekV4ForCausalLM": "atom.plugin.vllm.models.deepseek_v4:DeepseekV4ForCausalLM",
     "MiniMaxM3SparseForCausalLM": "atom.models.minimax_m3:MiniMaxM3SparseForCausalLM",

--- a/atom/plugin/vllm/models/kimi_k3.py
+++ b/atom/plugin/vllm/models/kimi_k3.py
@@ -1,0 +1,184 @@
+from types import SimpleNamespace
+
+import torch
+from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.forward_context import get_forward_context as get_vllm_forward_context
+from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+)
+from vllm.model_executor.models.interfaces import IsHybrid
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+
+from atom.models import kimi_k3 as kimi_k3_base
+from atom.models.kimi_k3 import (
+    KimiK3ForCausalLM as KimiK3ForCausalLMBase,
+)
+from atom.models.kimi_k3 import (
+    KimiKDAAttention,
+    _normalize_kimi_config,
+)
+from atom.plugin.vllm.model_wrapper import ATOMMoEForCausalLM
+from atom.utils.forward_context import get_forward_context as get_atom_forward_context
+
+
+def _get_k3_state_shape(
+    vllm_config: VllmConfig,
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    config = vllm_config.model_config.hf_text_config
+    _normalize_kimi_config(config)
+    num_spec = (
+        vllm_config.speculative_config.num_speculative_tokens
+        if vllm_config.speculative_config
+        else 0
+    )
+    return MambaStateShapeCalculator.gated_delta_net_state_shape(
+        vllm_config.parallel_config.tensor_parallel_size,
+        config.linear_num_key_heads,
+        config.linear_num_value_heads,
+        config.linear_key_head_dim,
+        config.linear_value_head_dim,
+        config.linear_conv_kernel_dim,
+        num_spec,
+    )
+
+
+def _get_k3_state_dtype(vllm_config: VllmConfig) -> tuple[torch.dtype, torch.dtype]:
+    conv_dtype, _ = MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+        vllm_config.model_config.dtype,
+        vllm_config.cache_config.mamba_cache_dtype,
+        vllm_config.cache_config.mamba_ssm_cache_dtype,
+    )
+    # FLA KDA accumulates the recurrent matrix in fp32 and rejects lower
+    # precision initial state. Native ATOM uses the same fp32 state contract.
+    return conv_dtype, torch.float32
+
+
+class KimiKDAAttentionVllm(KimiKDAAttention, MambaBase):
+    """Kimi-K3 KDA layer backed by vLLM-owned recurrent state."""
+
+    def __init__(self, atom_config, quant_config=None, prefix: str = "") -> None:
+        super().__init__(
+            atom_config=atom_config,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        vllm_config = atom_config.plugin_config.vllm_config
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.num_k_heads = self.num_heads
+        self.num_v_heads = self.num_heads
+        self.head_k_dim = self.head_dim
+        self.head_v_dim = self.head_dim
+        self.num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+        self._atom_metadata = SimpleNamespace(gdn_metadata=None)
+        self._atom_cache = SimpleNamespace(k_cache=None, v_cache=None)
+        self._atom_kv_cache_data = {f"layer_{self.layer_num}": self._atom_cache}
+
+    def get_state_dtype(self) -> tuple[torch.dtype, torch.dtype]:
+        return _get_k3_state_dtype(self.vllm_config)
+
+    def get_state_shape(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            self.tp_size,
+            self.num_k_heads,
+            self.num_v_heads,
+            self.head_k_dim,
+            self.head_v_dim,
+            self.conv_kernel_size,
+            self.num_spec,
+        )
+
+    @property
+    def mamba_type(self) -> MambaAttentionBackendEnum:
+        return MambaAttentionBackendEnum.GDN_ATTN
+
+    def _forward_impl(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        vllm_context = get_vllm_forward_context()
+        attn_metadata = vllm_context.attn_metadata
+        if attn_metadata is None:
+            return hidden_states.new_zeros(hidden_states.shape)
+
+        if not isinstance(attn_metadata, dict):
+            raise TypeError("Kimi-K3 vLLM attention metadata must be layer-indexed")
+        gdn_metadata = attn_metadata[self.layer_name]
+        if not isinstance(gdn_metadata, GDNAttentionMetadata):
+            raise TypeError(
+                f"Expected GDNAttentionMetadata for {self.layer_name}, "
+                f"got {type(gdn_metadata).__name__}"
+            )
+
+        vllm_layer = vllm_context.no_compile_layers[self.layer_name]
+        conv_state, ssm_state = vllm_layer.kv_cache
+        self._atom_metadata.gdn_metadata = gdn_metadata
+        self._atom_cache.k_cache = conv_state
+        self._atom_cache.v_cache = ssm_state
+
+        atom_context = get_atom_forward_context()
+        previous_metadata = atom_context.attn_metadata
+        previous_kv_cache_data = atom_context.kv_cache_data
+        atom_context.attn_metadata = self._atom_metadata
+        atom_context.kv_cache_data = self._atom_kv_cache_data
+        try:
+            output = super()._forward_impl(hidden_states)
+        finally:
+            atom_context.attn_metadata = previous_metadata
+            atom_context.kv_cache_data = previous_kv_cache_data
+
+        # vLLM pads token rows to the selected piecewise/full graph bucket,
+        # while GDN metadata tracks only real tokens. The native KDA path
+        # intentionally slices to num_actual_tokens; restore the graph bucket
+        # width so this custom op matches its empty_like fake implementation.
+        if output.shape[0] < hidden_states.shape[0]:
+            output = torch.nn.functional.pad(
+                output,
+                (0, 0, 0, hidden_states.shape[0] - output.shape[0]),
+            )
+        return output
+
+
+class KimiK3ForCausalLM(KimiK3ForCausalLMBase):
+    def __init__(self, *args, **kwargs):
+        original_kda_cls = kimi_k3_base.KimiKDAAttention
+        kimi_k3_base.KimiKDAAttention = KimiKDAAttentionVllm
+        try:
+            super().__init__(*args, **kwargs)
+        finally:
+            kimi_k3_base.KimiKDAAttention = original_kda_cls
+
+
+class KimiK3ForCausalLMVllm(ATOMMoEForCausalLM, IsHybrid):
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return _get_k3_state_dtype(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        return _get_k3_state_shape(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -36,6 +36,9 @@ _VLLM_MODEL_REGISTRY_OVERRIDES: dict[str, str] = {
     "Qwen3_5ForConditionalGeneration": "atom.plugin.vllm.models.qwen3_5:Qwen3_5ForConditionalGeneration",
     "Qwen3_5MoeForConditionalGeneration": "atom.plugin.vllm.models.qwen3_5:Qwen3_5MoeForConditionalGeneration",
     "KimiK25ForConditionalGeneration": "atom.plugin.vllm.models.kimi_k25:KimiK25ForConditionalGeneration",
+    "KimiK3ForConditionalGeneration": (
+        "atom.plugin.vllm.models.kimi_k3:KimiK3ForCausalLMVllm"
+    ),
     "MiniMaxM2ForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,
     "DeepseekV4ForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,
     "MiniMaxM3SparseForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,

--- a/docs/vllm_plugin_backend_guide.md
+++ b/docs/vllm_plugin_backend_guide.md
@@ -185,8 +185,14 @@ Currently, the plugin backend supports the following model architectures:
 | `GptOssForCausalLM` | `atom.models.gpt_oss.GptOssForCausalLM` | GPT-OSS |
 | `DeepseekV3ForCausalLM` | `atom.models.deepseek_v2.DeepseekV3ForCausalLM` | DeepSeek-R1 / DeepSeek V3 / Kimi-K2 style models |
 | `Glm4MoeForCausalLM` | `atom.models.glm4_moe.Glm4MoeForCausalLM` | GLM-4-MoE |
+| `KimiK3ForConditionalGeneration` | `atom.plugin.vllm.models.kimi_k3.KimiK3ForCausalLM` | Kimi-K3 text-only KDA + MLA hybrid MoE |
 
 `Kimi-K2` is also supported. Although it is usually loaded with `--trust-remote-code`, it shares the same DeepSeek-style MLA+MoE architecture path and reuses `atom.models.deepseek_v2.DeepseekV3ForCausalLM` in the ATOM vLLM OOT backend.
+
+Kimi-K3 uses vLLM's hybrid/Mamba cache contract for KDA recurrent state and
+ATOM's MLA backend for full-attention layers. See the
+[Kimi-K3 vLLM recipe](../recipes/atom_vllm/Kimi-K3.md) for its TP8, FLA,
+prefix-caching, and text-only requirements.
 
 ## Installation and quick start
 

--- a/recipes/atom_vllm/Kimi-K3.md
+++ b/recipes/atom_vllm/Kimi-K3.md
@@ -1,0 +1,116 @@
+# Kimi-K3 with ATOM vLLM Plugin Backend
+
+This recipe serves the text-only Kimi-K3 backbone
+(`KimiK3ForConditionalGeneration`) through the ATOM vLLM out-of-tree plugin.
+Kimi-K3 combines KDA recurrent-attention layers, MLA full-attention layers, and
+an MXFP4 latent MoE.
+
+The validated configuration requires eight MI355 (gfx950) GPUs with TP8.
+
+## Prerequisites
+
+Use the ATOM vLLM OOT image and install the KDA dependency used by the native
+Kimi-K3 implementation:
+
+```bash
+docker pull rocm/atom-dev:vllm-latest
+pip install "fla-core==0.5.1" "flash-linear-attention==0.5.1"
+```
+
+Install the target ATOM checkout into the same environment:
+
+```bash
+pip install -e /path/to/ATOM --no-deps
+```
+
+## Launch
+
+```bash
+MODEL=/path/to/Kimi-K3
+
+export AITER_LOG_LEVEL=WARNING
+export ATOM_LOADER_USE_THREADPOOL=1
+export ATOM_LOADER_THREADPOOL_WORKERS=16
+export ATOM_SYNC_AFTER_LOAD=1
+export ATOM_DIST_TIMEOUT_SECONDS=3600
+
+export ATOM_USE_TRITON_GEMM=1
+export AITER_USE_GROUPED_GEMM=0
+export ATOM_USE_TRITON_MOE=0
+export AITER_FLYDSL_FORCE=1
+export AITER_FORCE_GFX1250=0
+
+vllm serve "${MODEL}" \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --language-model-only \
+    --kv-cache-dtype fp8 \
+    --max-model-len 16384 \
+    --max-num-seqs 64 \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.93 \
+    --block-size 128 \
+    --no-enable-prefix-caching \
+    --no-async-scheduling \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+```
+
+The plugin keeps KDA temporal state in fp32, registers every KDA layer through
+vLLM's hybrid/Mamba cache contract, and uses ATOM's MLA backend for full
+attention. vLLM may increase the physical attention block size so its MLA and
+KDA pages have equal byte size; this is expected.
+
+Prefix caching must stay disabled because KDA recurrent state cannot be
+reconstructed from the paged MLA cache alone.
+
+## Smoke test
+
+```bash
+curl http://127.0.0.1:8000/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "/path/to/Kimi-K3",
+      "prompt": "Question: What is 17 + 25? Answer:",
+      "max_tokens": 32,
+      "temperature": 0
+    }'
+```
+
+The deterministic response starts with `42`.
+
+## Accuracy validation
+
+```bash
+lm_eval \
+    --model local-completions \
+    --model_args "model=${MODEL},base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
+    --tasks gsm8k \
+    --num_fewshot 5 \
+    --output_path /app/logs_claude/kimi_k3_vllm_graph_clean_gsm8k
+```
+
+Validated on the full 1319-example GSM8K test set with TP8 and
+`FULL_AND_PIECEWISE` CUDA Graph:
+
+```text
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9553|±  |0.0057|
+|     |       |strict-match    |     5|exact_match|↑  |0.9553|±  |0.0057|
+```
+
+Raw result JSON is written below
+`/app/logs_claude/kimi_k3_vllm_graph_clean_gsm8k/`.
+
+Use a freshly started server for each reported accuracy run, matching the
+native Kimi-K3 validation protocol. Back-to-back evaluations on a warm server
+are not used as baselines for this model.
+
+## Current scope
+
+- Text generation only; the vision tower and multimodal projector are skipped.
+- TP8 on MI355/gfx950 is the validated deployment.
+- Prefix caching and asynchronous scheduling are disabled.
+- Speculative decoding is not enabled for this model.

--- a/tests/plugin/test_vllm_kimi_k3.py
+++ b/tests/plugin/test_vllm_kimi_k3.py
@@ -1,0 +1,103 @@
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_without_test_stubs(source: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_kimi_k3_plugin_registries_are_synchronized():
+    from atom.plugin.vllm.model_wrapper import _ATOM_MODEL_CLASSES
+    from atom.plugin.vllm.register import _VLLM_MODEL_REGISTRY_OVERRIDES
+
+    arch = "KimiK3ForConditionalGeneration"
+    assert (
+        _VLLM_MODEL_REGISTRY_OVERRIDES[arch]
+        == "atom.plugin.vllm.models.kimi_k3:KimiK3ForCausalLMVllm"
+    )
+    assert (
+        _ATOM_MODEL_CLASSES[arch] == "atom.plugin.vllm.models.kimi_k3:KimiK3ForCausalLM"
+    )
+
+
+def test_kimi_k3_temporal_state_uses_fp32():
+    _run_without_test_stubs("""
+        from types import SimpleNamespace
+
+        import torch
+
+        from atom.plugin.vllm.models.kimi_k3 import _get_k3_state_dtype
+
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(dtype=torch.bfloat16),
+            cache_config=SimpleNamespace(
+                mamba_cache_dtype="auto",
+                mamba_ssm_cache_dtype="auto",
+            ),
+        )
+        conv_dtype, temporal_dtype = _get_k3_state_dtype(vllm_config)
+        assert conv_dtype == torch.bfloat16
+        assert temporal_dtype == torch.float32
+        """)
+
+
+def test_dense_mla_decode_pads_small_head_count():
+    _run_without_test_stubs("""
+        from types import SimpleNamespace
+
+        import torch
+
+        from atom.plugin.vllm.attention import layer_mla
+
+        seen = {}
+
+        def fake_mla_decode_fwd(q, _kv, output, *_args, **_kwargs):
+            seen["num_heads"] = q.shape[1]
+            output.fill_(1)
+            return output, None
+
+        layer_mla.mla_decode_fwd = fake_mla_decode_fwd
+        attention = SimpleNamespace(
+            head_repeat_factor=1,
+            head_pad=4,
+            kv_lora_rank=8,
+            dcp_world_size=1,
+            scale=1.0,
+            _q_scale=None,
+            _k_scale=None,
+            _pad_query_heads=lambda q: torch.nn.functional.pad(
+                q, (0, 0, 0, 4)
+            ),
+            _restore_query_heads=lambda output, num_heads: output[:, :num_heads],
+        )
+        decode = SimpleNamespace(
+            attn_out_dtype=torch.bfloat16,
+            use_persistent_metadata=False,
+            paged_kv_indptr=torch.tensor([0, 1], dtype=torch.int32),
+            paged_kv_indices=torch.tensor([0], dtype=torch.int32),
+            qo_indptr=torch.tensor([0, 1], dtype=torch.int32),
+            paged_kv_last_page_len=torch.tensor([1], dtype=torch.int32),
+            fold_factor=None,
+            max_qo_len=1,
+        )
+        output, lse = layer_mla.AttentionForVllmMLA._forward_decode(
+            attention,
+            torch.zeros(1, 12, 8, dtype=torch.bfloat16),
+            torch.zeros(1, 8, dtype=torch.bfloat16),
+            SimpleNamespace(decode=decode),
+        )
+        assert seen["num_heads"] == 16
+        assert output.shape == (1, 12, 8)
+        assert lse is None
+        """)


### PR DESCRIPTION
## Motivation

Native ATOM support for Kimi-K3 was introduced in [#1718](https://github.com/ROCm/ATOM/pull/1718), but the vLLM OOT plugin did not support its KDA recurrent state and MLA cache requirements.

This PR adds text-only Kimi-K3 serving through the ATOM vLLM plugin.

## Technical Details

- Register `KimiK3ForConditionalGeneration` in both the vLLM wrapper and ATOM model registries.
- Add a dedicated hybrid adapter that:
  - Implements the vLLM `MambaBase` and `IsHybrid` contracts.
  - Uses vLLM-owned KDA recurrent state.
  - Keeps the KDA temporal state in FP32.
  - Bridges attention metadata and cache state between vLLM and ATOM.
  - Restores padded token rows required by CUDA Graph buckets.
- Fix MLA decode for small query-head counts by padding queries to a supported head count and restoring the original shape afterward.
- Add registry, state-dtype, and MLA-padding unit tests.
- Add the Kimi-K3 vLLM plugin recipe and documentation.

Validated scope:

- Text-only serving
- TP8 on MI355/gfx950
- FP8 KV cache
- `FULL_AND_PIECEWISE` CUDA Graph
- Prefix caching and asynchronous scheduling disabled

## Test Plan

- Run Kimi-K3 plugin unit tests:
  - `pytest -q tests/plugin/test_vllm_kimi_k3.py`
- Run related plugin regression tests.
- Run Ruff checks on the modified files.
- Launch the Kimi-K3 vLLM plugin server on 8×MI355 with TP8.
- Run a deterministic completion smoke test.
- Run the complete 1,319-sample GSM8K 5-shot evaluation on two freshly started servers.

## Test Result

- Kimi-K3 plugin unit tests: `3 passed`
- Related plugin regression tests: `9 passed`
- Ruff checks: passed
- Smoke test: correctly returned `42`
- GSM8K Run 1:
  - flexible-extract: `0.9522`
  - strict-match: `0.9515`
- GSM8K Run 2:
  - flexible-extract: `0.9575`
  - strict-match: `0.9568`

The second run matches the documented recipe baseline. Neither run encountered server disconnects, worker failures, or runtime crashes.
