### PR TITLE
[feat](qwen): support Qwen3.x on gfx12xx

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -88,6 +88,7 @@ support_model_arch_dict = {
     "Qwen3NextForCausalLM": "atom.models.qwen3_next.Qwen3NextForCausalLM",
     "Qwen3_5ForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5MultimodalModel",
     "Qwen3_5MoeForConditionalGeneration": "atom.models.qwen3_5.Qwen3_5MoeMultimodalModel",
+    "Qwen3_5MoeForCausalLM": "atom.models.qwen3_5.Qwen3_5MoeForCausalLM",
     "KimiK25ForConditionalGeneration": "atom.models.kimi_k25.KimiK25ForCausalLM",
     "KimiK3ForConditionalGeneration": "atom.models.kimi_k3.KimiK3ForCausalLM",
     "MiniMaxM2ForCausalLM": "atom.models.minimax_m2.MiniMaxM2ForCausalLM",

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -858,6 +858,19 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.block_tables = self.model_runner.forward_vars[
                 "block_tables"
             ].copy_to_gpu(bs)
+        # `prefill_attention_triton` reads the paged KV cache, so it needs a
+        # block_table even with no cached tokens. The base builder only uploads
+        # one when `has_cached`.
+        if (
+            attn_metadata.block_tables is None
+            and envs.ATOM_USE_UNIFIED_ATTN
+            and batch.block_tables
+        ):
+            bs = batch.total_seqs_num_prefill
+            self.prepare_block_tables(batch)
+            attn_metadata.block_tables = self.model_runner.forward_vars[
+                "block_tables"
+            ].copy_to_gpu(bs)
         if self._has_sparse_attention:
             from atom.model_ops.minimax_m3.sparse_attn import (
                 make_sparse_prefill_metadata,

--- a/atom/models/qwen3_5.py
+++ b/atom/models/qwen3_5.py
@@ -462,7 +462,44 @@ class Qwen3_5Model(Qwen3NextModel):
         self.norm = Qwen3_5RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
 
+_QWEN3_5_PACKED_MODULES_MAPPING = {
+    "q_proj": ("qkv_proj", "q"),
+    "k_proj": ("qkv_proj", "k"),
+    "v_proj": ("qkv_proj", "v"),
+    "gate_proj": ("gate_up_proj", 0),
+    "up_proj": ("gate_up_proj", 1),
+    "gate_up_proj": ["gate_proj", "up_proj"],
+    "in_proj_qkv": ("in_proj_qkvz", (0, 1, 2)),
+    "in_proj_z": ("in_proj_qkvz", 3),
+    "in_proj_b": ("in_proj_ba", 0),
+    "in_proj_a": ("in_proj_ba", 1),
+    ".gate.": (".gate.", 0),
+    "shared_expert_gate": ("gate", 1),
+}
+
+
+_BF16_IN_PROJ_MAPPING = {
+    "in_proj_qkv": ("in_proj_qkvzba", (0, 1, 2)),
+    "in_proj_z": ("in_proj_qkvzba", 3),
+    "in_proj_b": ("in_proj_qkvzba", 4),
+    "in_proj_a": ("in_proj_qkvzba", 5),
+}
+
+
+def _apply_bf16_in_proj_mapping(mapping: dict, atom_config: Config) -> dict:
+    if atom_config.quant_config.global_quant_config.quant_dtype != torch.bfloat16:
+        return mapping
+
+    mapping.pop("in_proj_qkvz", None)
+    mapping.pop("in_proj_ba", None)
+    mapping["in_proj_qkvzba"] = ("in_proj_qkvzba", None)
+    mapping.update(_BF16_IN_PROJ_MAPPING)
+    return mapping
+
+
 class Qwen3_5ForCausalLMBase(nn.Module):
+    packed_modules_mapping = _QWEN3_5_PACKED_MODULES_MAPPING
+
     def __init__(self, atom_config: Config, prefix: str = ""):
         config: Qwen3_5MoeTextConfig = get_qwen3_5_text_config(atom_config)
         self.atom_config = atom_config
@@ -470,6 +507,9 @@ class Qwen3_5ForCausalLMBase(nn.Module):
         self.quant_config = atom_config.quant_config
 
         super().__init__()
+        self.packed_modules_mapping = _apply_bf16_in_proj_mapping(
+            dict(self.packed_modules_mapping), atom_config
+        )
         self.config = config
         self.model = Qwen3_5Model(
             atom_config=atom_config,
@@ -536,41 +576,35 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase):
             + (self.config.n_shared_experts or 0),
         )
 
+    def detect_fused_expert_format(self, weight_name: str) -> bool:
+        """Detect if weight is from fused expert checkpoint (BF16 format)."""
+        return detect_fused_expert_format(weight_name)
 
-_BF16_IN_PROJ_MAPPING = {
-    "in_proj_qkv": ("in_proj_qkvzba", (0, 1, 2)),
-    "in_proj_z": ("in_proj_qkvzba", 3),
-    "in_proj_b": ("in_proj_qkvzba", 4),
-    "in_proj_a": ("in_proj_qkvzba", 5),
-}
+    def get_fused_expert_mapping(self) -> list[tuple[str, str, str]]:
+        """Return mapping for fused expert weights (BF16 format)."""
+        return get_fused_expert_mapping()
 
-
-def _apply_bf16_in_proj_mapping(mapping: dict, atom_config: Config) -> dict:
-    if atom_config.quant_config.global_quant_config.quant_dtype != torch.bfloat16:
-        return mapping
-
-    mapping.pop("in_proj_qkvz", None)
-    mapping.pop("in_proj_ba", None)
-    mapping["in_proj_qkvzba"] = ("in_proj_qkvzba", None)
-    mapping.update(_BF16_IN_PROJ_MAPPING)
-    return mapping
+    def load_fused_expert_weights(
+        self,
+        original_name: str,
+        name: str,
+        params_dict: dict,
+        loaded_weight: torch.Tensor,
+        shard_id: str,
+        num_experts: int,
+    ) -> bool:
+        return load_fused_expert_weights(
+            original_name,
+            name,
+            params_dict,
+            loaded_weight,
+            shard_id,
+            num_experts,
+        )
 
 
 class Qwen3_5ForConditionalGenerationTextOnly(nn.Module):
-    packed_modules_mapping = {
-        "q_proj": ("qkv_proj", "q"),
-        "k_proj": ("qkv_proj", "k"),
-        "v_proj": ("qkv_proj", "v"),
-        "gate_proj": ("gate_up_proj", 0),
-        "up_proj": ("gate_up_proj", 1),
-        "gate_up_proj": ["gate_proj", "up_proj"],
-        "in_proj_qkv": ("in_proj_qkvz", (0, 1, 2)),
-        "in_proj_z": ("in_proj_qkvz", 3),
-        "in_proj_b": ("in_proj_ba", 0),
-        "in_proj_a": ("in_proj_ba", 1),
-        ".gate.": (".gate.", 0),
-        "shared_expert_gate": ("gate", 1),
-    }
+    packed_modules_mapping = _QWEN3_5_PACKED_MODULES_MAPPING
     weights_mapping = {
         "model.language_model.": "language_model.model.",
         "lm_head.": "language_model.lm_head.",

--- a/atom/models/qwen3_next.py
+++ b/atom/models/qwen3_next.py
@@ -32,7 +32,9 @@ from atom.model_ops.linear import (
     RowParallelLinear,
 )  # noqa: F401
 from atom.model_ops.moe import FusedMoE
-from atom.model_ops.topK import is_rocm_aiter_fusion_shared_expert_enabled
+from atom.model_ops.topK import (
+    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
+)
 from atom.model_ops.utils import atom_parameter
 from atom.models.utils import (
     IntermediateTensors,
@@ -202,7 +204,8 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             prefix=f"{prefix}.gate",
         )
         self.is_rocm_aiter_fusion_shared_expert_enabled = (
-            is_rocm_aiter_fusion_shared_expert_enabled(
+            is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+                quant_config,
                 shared_expert_prefix=f"{prefix}.shared_expert",
                 routed_expert_prefix=f"{prefix}.experts",
             )


### PR DESCRIPTION
## What

Enables `Qwen/Qwen3.5 (`Qwen3_5MoeForCausalLM`, text-only MoE) on the
standalone ATOM engine, plus two bugs found on the way.

Relative to the already-supported `Qwen3.5-397B-A17B`, this model is a scaled-up,
vision-free variant: `Qwen3_5MoeForCausalLM` instead of `*ForConditionalGeneration`,
`model_type: qwen3_5_moe_text`, and weights living at `model.*` instead of
`model.language_model.*`. Everything else (head_dim 256, 3:1 GDN/full hybrid,
512 experts top-10, mrope, MTP) is unchanged.

### `atom/model_engine/model_runner.py`
Register `Qwen3_5MoeForCausalLM` in `support_model_arch_dict`.

Dense `Qwen3_5ForCausalLM` is intentionally **not** registered: every dense Qwen3.5
model published so far is `Qwen3_5ForConditionalGeneration`, so that entry would be
unreachable and unverifiable. It can be added once such a checkpoint exists.

### `atom/models/qwen3_5.py`
The bare `Qwen3_5MoeForCausalLM` had no `packed_modules_mapping` — the fusion rules
were only attached to `Qwen3_5ForConditionalGenerationTextOnly` and the multimodal
wrapper.

- Hoist the fusion table to a module-level `_QWEN3_5_PACKED_MODULES_MAPPING` as the
  single source of truth; move `_BF16_IN_PROJ_MAPPING` / `_apply_bf16_in_proj_mapping`
  above `Qwen3_5ForCausalLMBase` accordingly.
- Add `packed_modules_mapping` as a **class attribute** on `Qwen3_5ForCausalLMBase`.
  It has to be a class attribute because `ModelRunner` reads it via
  `getattr(model_class, ...)` to remap the quant exclude list *before* instantiation.
- Add the `detect_fused_expert_format` / `get_fused_expert_mapping` /
  `load_fused_expert_weights` hooks to `Qwen3_5MoeForCausalLM`.

No `weights_mapping` is needed — the bare checkpoint already stores `model.*` /
`lm_head.*`. This is also why `Qwen3_5MoeForConditionalGenerationTextOnly` cannot be
reused directly: its mapping rewrites `model.language_model.*`.

### `atom/models/qwen3_next.py` — MTP shared-expert weights silently dropped

`mtp.layers.0.mlp.shared_expert.{gate,up,down}_proj` were dropped when loading the
draft model.

`Qwen3NextSparseMoeBlock` decided whether to fuse the shared expert via
`is_rocm_aiter_fusion_shared_expert_enabled(...)`, which ignores the `quant_config`
passed to it and always reads the global one. But `Qwen3_5MTP.__init__` (and
`Qwen3NextMTP`) deliberately keeps its own copy, renumbering excludes from the
checkpoint's 0-based `mtp.layers.0.*` to the absolute `mtp.layers.92.*`. So:

- module side looked up `mtp.layers.92.mlp.shared_expert` in the **global** (still
  0-based) list → miss → assumed FP8 → fusable → never built the `shared_expert`
  submodule;
- loader side looked up the 0-based checkpoint name → hit → correctly decided *not*
  fusable → the weights had nowhere to go.

Switched to `is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(quant_config, ...)`.
Non-MTP callers already pass the global config, so their behaviour is unchanged.

397B never hit this: its MTP `modules_to_not_convert` doesn't exclude
`shared_expert.{gate,up,down}_proj`, so shared and routed had matching precision and
both sides agreed either way. Qwen3.5 excludes them to BF16, which exposed it.

### `atom/model_ops/attentions/aiter_attention.py` — unified attn prefill

With `ATOM_USE_UNIFIED_ATTN=1`, `prefill_attention_triton` reads the paged KV cache
and so needs a `block_table` even when there are no cached tokens, but the base
builder only uploads one when `has_cached`. Upload it in that case too.

## Validation

Weight-name mapping was dry-run against a real `WeightDispatcher` (meta-device model
construction + `CheckpointNameRewriter` + `dispatch`), requiring both
`dropped_ckpt_keys` and never-written model params to be zero:

| check | result |
|---|---|
| full index dry run (287,119 keys) | 0 dropped, 0 unwritten; 3,089 skipped = exactly the `mtp.*` set |
| MTP draft dry run | 0 dropped, 0 unwritten (3 dropped before the fix) |
| real 4-layer checkpoint (12,484 local tensors) | 0 dropped, all 64 params written |
| 397B multimodal regression | byte-identical before/after (1251 params) |
| `pytest tests/ -k "qwen or moe or quant or loader or register or weight" --ignore=tests/plugin` | 101 passed |

End-to-end on the full 92-layer `Qwen3.5 MI355 (gfx950), TP8,
`--kv_cache_dtype fp8`, via `atom.entrypoints.openai_server`:

| GSM8K (lm_eval, local-completions) | strict-match | flexible-extract |
|---|---|---|
| 3-shot, limit=100 | 0.98 | 0.98 |
| 5-shot, limit=50 | 1.00 | 1.00 |

Note for anyone reproducing: this checkpoint emits a `<think>` block, so lm_eval's
default `max_gen_toks=256` truncates before the `#### N` line and scores ~0.37
regardless of correctness. Use `max_gen_toks=2048` with a matching `max_length`.

## Not covered

- sglang / vllm plugin registration. Neither framework is installed in the container
  used here, and the plugin path subclasses the upstream `Qwen3_5*ForConditionalGeneration`,
  for which the text-only model has no counterpart to wrap. Standalone ATOM only.
- The new `output_gate_type: "swish"` config field is read by neither ATOM nor
  transformers 5.12.1. Current behaviour happens to be correct
  (`RMSNormGated(norm_before_gate=True)` computes `norm(x) * silu(z)`, and silu is
  swish), but any other value would be silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
