### PR TITLE
fix(mtp): recycle post-final-norm hidden between MTP draft steps

### DIFF
--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -194,7 +194,8 @@ class DeepSeekMultiTokenPredictor(nn.Module):
         self,
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
-    ) -> torch.Tensor:
+        return_normed: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Greedy draft token via distributed argmax over the TP-sharded vocab —
         avoids all-gathering the full [N, vocab] logits every draft step.
 
@@ -202,11 +203,19 @@ class DeepSeekMultiTokenPredictor(nn.Module):
         rank's logit shard to (max_val, global_idx) and all-gathers only [N, 2]
         instead of the O(vocab) logits. Token-identical to
         compute_logits(...).argmax(-1).
+
+        ``return_normed`` also hands back the post-final-norm hidden the next
+        draft step must consume. shared_head.norm is the MTP layer's counterpart
+        of the backbone's final norm, and its per-channel weight is not
+        idempotent, so recycling the pre-norm hidden feeds the draft an
+        off-distribution input and costs acceptance. It is already materialized
+        here, so returning it is free.
         """
         current_step_idx = spec_step_idx % self.num_mtp_layers
         mtp_layer = self.layers[str(self.mtp_start_layer_idx + current_step_idx)]
         normed = mtp_layer.shared_head(hidden_states)
-        return mtp_layer.shared_head.head.compute_argmax_token(normed)
+        token = mtp_layer.shared_head.head.compute_argmax_token(normed)
+        return (token, normed) if return_normed else token
 
     def set_skip_topk(self, skip: bool) -> None:
         """Toggle ``skip_topk`` on MTP sparse-attention layers.
@@ -246,6 +255,10 @@ class DeepSeekMultiTokenPredictor(nn.Module):
 
 @support_torch_compile
 class DeepSeekMTP(nn.Module):
+
+    # compute_draft_token(return_normed=True) can hand back the post-final-norm
+    # hidden, so EagleProposer recycles that into the next draft step.
+    returns_postnorm_hidden = True
 
     def __init__(self, atom_config: Config, prefix: str = ""):
         super().__init__()
@@ -336,7 +349,8 @@ class DeepSeekMTP(nn.Module):
         self,
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
-    ) -> torch.Tensor:
+        return_normed: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Distributed greedy argmax for the MTP draft rollout (GLM-5.2).
 
         EagleProposer picks this over compute_logits().argmax(-1) when present
@@ -344,7 +358,9 @@ class DeepSeekMTP(nn.Module):
         [N, vocab] logits — it all-gathers only the packed [N, 2] per-rank
         reductions. See DeepSeekMultiTokenPredictor.compute_draft_token.
         """
-        return self.model.compute_draft_token(hidden_states, spec_step_idx)
+        return self.model.compute_draft_token(
+            hidden_states, spec_step_idx, return_normed=return_normed
+        )
 
     def set_skip_topk(self, skip: bool) -> None:
         self.model.set_skip_topk(skip)

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -65,6 +65,12 @@ class EagleProposer(Drafter):
                 "MTP draft index_share_for_mtp_iteration enabled: "
                 "step 0 computes indexer top-k, steps 1+ reuse the buffer."
             )
+        # Step 0 is fed the target's post-final-norm hidden, so steps 1+ must be
+        # fed the draft's post-final-norm hidden too. Only drafts that can hand
+        # it back do so; the rest keep the previous behaviour.
+        self._recycle_postnorm = self._draft_argmax_fused and getattr(
+            self.model, "returns_postnorm_hidden", False
+        )
 
     def _resolve_mtp_k(self) -> int:
         return self.speculative_config.num_speculative_tokens or 0
@@ -288,7 +294,12 @@ class EagleProposer(Drafter):
                 )
                 # Distributed argmax (all-gather [N, 2] not [N, vocab]) when the
                 # draft supports it; token-identical to compute_logits().argmax().
-                if self._draft_argmax_fused:
+                recycled_hidden = sample_hidden_states
+                if self._recycle_postnorm:
+                    new_draft_ids, recycled_hidden = self.model.compute_draft_token(
+                        sample_hidden_states, return_normed=True
+                    )
+                elif self._draft_argmax_fused:
                     new_draft_ids = self.model.compute_draft_token(sample_hidden_states)
                 else:
                     logits = self.model.compute_logits(sample_hidden_states)
@@ -393,7 +404,7 @@ class EagleProposer(Drafter):
                         slot_mapping[:] = kv_indices[kv_indptr[1 : bs + 1] - 1]
 
                     input_ids = new_draft_ids
-                    hidden_states = sample_hidden_states
+                    hidden_states = recycled_hidden
 
         # self.runner.debug(f"final {draft_token_ids=}")
         # [batch_size, mtp_k]


### PR DESCRIPTION
Draft step 0 gets the target's post-final-norm hidden, but steps 1+ were fed the pre-final-norm block output, skipping shared_head.norm. RMSNorm's per-channel weight is not idempotent, so the error compounded down the draft chain and acceptance collapsed at later steps; output stayed correct because the target verifies every token. Chain the post-final-norm hidden instead -- already materialized for the LM head, so it is free. Matches vLLM and SGLang.

A/B on 54f4d00 (GLM-5.2 MXFP4, n=3, TP4): +7~9% tok/s, accept_len 3.04 -> 3.46, GSM8K unchanged.

## Motivation

MTP draft step 0 is fed the target's post-final-norm hidden, but steps 1+ were fed the MTP block's
pre-final-norm output, skipping `shared_head.norm` — an input that layer never saw during training.
RMSNorm's divide-by-RMS is idempotent, but its per-channel weight is not (GLM-5.2 spans roughly
`[-0.07, 1.81]`), leaving a ~15% relative L2 deviation that compounds down the draft chain. Output
stays correct because the target verifies every drafted token, so the only symptom was a suppressed
acceptance rate at later draft positions.

vLLM carried the same bug and fixed it in vllm#45895. #1682 ported the `index_share` half of that
PR; this is the other half. SGLang's `deepseek_nextn` has always done it this way.

## Technical Details

- `compute_draft_token(..., return_normed=True)` also returns the post-final-norm hidden. That
  tensor is already materialized for the LM head, so this is free — no extra kernel, no extra
  memory traffic.
- `EagleProposer` chains it into steps 1+ in place of the raw block output.

Gated on `returns_postnorm_hidden`, so only DeepSeek MTP drafts change behaviour — `deepseek_v3`,
`deepseek_v32`, `glm_moe_dsa` per `_MTP_TYPE_MAP`. EAGLE3 and the other MTP families are untouched,
matching vLLM's `DeepSeekMTPModel` gate. No new kernels, no new config; prefill and verification
are unchanged.

## Test Plan

In-place A/B on the parent commit (54f4d00): same box, same container, patch applied then reverted,
so the only delta is this diff. GLM-5.2-MXFP4, TP4, `--kv_cache_dtype fp8`, `--method mtp
--num-speculative-tokens 3`, cudagraph FULL.

- Throughput: `benchmark_serving`, `dataset=random`, `ignore_eos`, 160 prompts, OSL 1024, CONC 16,
  ISL ∈ {1024, 8192, 10240}.
- Accuracy: GSM8K, full 1319 questions, 5-shot, `temperature=0`.

## Test Result

| ISL | out tok/s | TPOT mean | accept_len |
|---|---|---|---|
| 1024 | 1726 → **1873** (+8.5%) | 8.77 → **7.96 ms** | 3.044 → **3.452** |
| 8192 | 1253 → **1342** (+7.1%) | 11.80 → **10.99 ms** | 3.073 → **3.465** |
| 10240 | 1147 → **1230** (+7.2%) | 12.87 → **11.86 ms** | 3.082 → **3.476** |

GSM8K unchanged at 96.06% (1267/1319), against 96.06–96.29% spread across baseline reruns. Median
TTFT is flat, as expected since prefill is untouched.

On natural text the gain is larger (+16.8% tokens/forward) and the per-position breakdown shows the
compounding signature directly: pos0 87.7% → 87.7%, pos1 68.3% → **80.6%**, pos2 36.3% → **80.8%**.
Step 0 is unaffected because it always received the correct input.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
