### PR TITLE
[feat][DCP] Switch DCP decode to persistent PA + make DCP compatible with MTP

### DIFF
--- a/atom/distributed/dcp_utils.py
+++ b/atom/distributed/dcp_utils.py
@@ -7,8 +7,10 @@ process group (from aiter's parallel state), mirroring ``pcp_utils.py``. This
 keeps the ``getattr(config, "decode_context_parallel_size", 1)`` + ``get_dcp_group``
 boilerplate out of the attention / metadata-builder ``__init__``s.
 
-Scope: ATOM native (server) mode only. The vLLM plugin resolves its DCP world
-size / group from ``vllm.distributed`` instead and does not use this module.
+Scope: the DCP world-size / group wrappers are ATOM native (server) mode only —
+the vLLM plugin resolves those from ``vllm.distributed`` instead. The
+platform-capability query ``dcp_persistent_supported()`` is the one exception:
+it is arch-based (not distributed-access) and shared by both native and plugin.
 
 The DCP compute / communication primitives (``cp_lse_ag_out_rs``, ``reorg_kvcache``,
 ``dcp_gather_compressed_kv``, ...) live in ``atom.model_ops.dcp_ops``; this module is
@@ -44,3 +46,18 @@ def get_dcp_group():
 def get_dcp_rank() -> int:
     """This rank's position within the DCP group (0 when DCP is disabled)."""
     return get_dcp_group().rank_in_group if dcp_is_enabled() else 0
+
+
+def dcp_persistent_supported() -> bool:
+    """Whether DCP decode can run in *persistent* mode on this GPU.
+
+    Persistent DCP needs an lse-emitting ASM decode kernel (per-token
+    ``return_lse`` for the cross-rank merge); only gfx950 ships those — gfx942
+    has no bf16 lse persistent kernel — so DCP must stay non-persistent
+    elsewhere (lse then comes from the triton stage2 reduce). Platform-capability
+    query shared by native and the vLLM plugin; cache the result once per
+    ``__init__`` to avoid a per-forward ``get_gfx()`` (graph-break).
+    """
+    from aiter.jit.utils.chip_info import get_gfx
+
+    return get_gfx() == "gfx950"

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -43,6 +43,7 @@ from torch import nn
 
 from atom.config import get_current_atom_config
 from atom.distributed.dcp_utils import (
+    dcp_persistent_supported,
     get_dcp_group,
     get_dcp_rank,
     get_dcp_world_size,
@@ -329,6 +330,11 @@ class MLAAttention(nn.Module):
             self.dcp_group = None
             self.dcp_rank = 0
             self._cp_triton_ctx = None
+
+        # Whether DCP decode can run in persistent mode on this GPU (gfx950 has
+        # the lse persistent kernel, gfx942 does not — see dcp_utils). Cached
+        # once here to avoid a per-forward get_gfx() (graph-break).
+        self.dcp_persistent_supported = dcp_persistent_supported()
 
     def _pad_query_heads(self, q: torch.Tensor) -> torch.Tensor:
         if self.head_repeat_factor > 1:
@@ -1242,6 +1248,8 @@ class MLAAttention(nn.Module):
             use_persistent_mode = not (dp_size > 1)
             if envs.ATOM_MLA_PAGE_SIZE > 1:
                 use_persistent_mode = False
+            if self.dcp_world_size > 1 and not self.dcp_persistent_supported:
+                use_persistent_mode = False
 
             # Sparse layers in MTP verify use separate persistent metadata
             # (per-token, max_seqlen_qo=1) while dense layers use normal metadata
@@ -1270,7 +1278,10 @@ class MLAAttention(nn.Module):
                 reduce_final_map = attn_metadata.reduce_final_map
                 reduce_partial_map = attn_metadata.reduce_partial_map
 
-            num_kv_splits = 16
+            # persistent lets metadata (reduce_partial_map) drive the split, so
+            # 16 is inert; the non-persistent fallback (gfx942 DCP) still needs
+            # the DCP-scaled split to keep the fp32 `logits` small (CUDA-graph OOM).
+            num_kv_splits = 16 if use_persistent_mode else max(1, 16 // self.dcp_world_size)
 
             # TODO refactor this
             if envs.ATOM_MLA_PAGE_SIZE is not None:

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1239,10 +1239,7 @@ class MLAAttention(nn.Module):
                     paged_kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens
 
             dp_size = get_dp_group().world_size
-            # DCP needs the per-token LSE (return_lse); the persistent
-            # reduce path doesn't emit it, so fall back to the non-persistent
-            # decode when LSE is requested.
-            use_persistent_mode = not (dp_size > 1) and not return_lse
+            use_persistent_mode = not (dp_size > 1)
             if envs.ATOM_MLA_PAGE_SIZE > 1:
                 use_persistent_mode = False
 
@@ -1273,7 +1270,7 @@ class MLAAttention(nn.Module):
                 reduce_final_map = attn_metadata.reduce_final_map
                 reduce_partial_map = attn_metadata.reduce_partial_map
 
-            num_kv_splits = max(1, 16 // self.dcp_world_size)
+            num_kv_splits = 16
 
             # TODO refactor this
             if envs.ATOM_MLA_PAGE_SIZE is not None:
@@ -1293,8 +1290,7 @@ class MLAAttention(nn.Module):
                 max_q_len,
                 page_size=page_size,
                 # The seg/asm decode path runs with a single kv split; the
-                # original (page_size=1) persistent path keeps 16 splits, scaled
-                # down by dcp_world_size when DCP shards KV across ranks.
+                # page_size=1 persistent path keeps 16 splits (metadata-derived).
                 num_kv_splits=None if self.use_seg_mla else num_kv_splits,
                 sm_scale=self.scale,
                 work_meta_data=work_meta_data,

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1281,7 +1281,9 @@ class MLAAttention(nn.Module):
             # persistent lets metadata (reduce_partial_map) drive the split, so
             # 16 is inert; the non-persistent fallback (gfx942 DCP) still needs
             # the DCP-scaled split to keep the fp32 `logits` small (CUDA-graph OOM).
-            num_kv_splits = 16 if use_persistent_mode else max(1, 16 // self.dcp_world_size)
+            num_kv_splits = (
+                16 if use_persistent_mode else max(1, 16 // self.dcp_world_size)
+            )
 
             # TODO refactor this
             if envs.ATOM_MLA_PAGE_SIZE is not None:

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1289,6 +1289,30 @@ class MLAAttention(nn.Module):
             else:
                 page_size = 1
 
+            # DCP + MTP (max_q_len>1): KV is round-robin sharded across ranks, so
+            # the intra-block causal mask must be applied on GLOBAL positions
+            # g(j)=j*W+r. Pass the cprr params (g_kv_indptr + cp world/rank) so the
+            # kernel selects the cprr variant and masks correctly. qlen=1 keeps the
+            # plain path (single query sees all local KV -> no mask needed).
+            cp_world_size = 1
+            cp_rank = 0
+            g_kv_indptr = None
+            if self.dcp_world_size > 1 and max_q_len > 1:
+                # cprr kernel is bf16-only (no fp8 cprr kernel on gfx950).
+                if self.kv_cache_dtype == "fp8":
+                    raise NotImplementedError(
+                        "MTP + DCP (max_q_len>1) requires bf16 KV cache: the "
+                        "round-robin CP (cprr) MLA kernel has no fp8 variant. "
+                        "Use --kv_cache_dtype bf16, or disable DCP/MTP for fp8."
+                    )
+                cp_world_size = self.dcp_world_size
+                cp_rank = self.dcp_rank
+                g_kv_indptr = getattr(attn_metadata, "g_kv_indptr", None)
+                assert g_kv_indptr is not None, (
+                    "MTP+DCP decode requires attn_metadata.g_kv_indptr; the "
+                    "metadata builder / cudagraph-capture path must set it."
+                )
+
             seg_kv_buffer_4d = kv_buffer.view(-1, page_size, 1, q.shape[-1])
             _, final_lse = mla_decode_fwd(
                 q,
@@ -1313,6 +1337,9 @@ class MLAAttention(nn.Module):
                 q_scale=self._q_scale,
                 kv_scale=self._k_scale,
                 return_lse=return_lse,
+                g_kv_indptr=g_kv_indptr,
+                cp_world_size=cp_world_size,
+                cp_rank=cp_rank,
             )
 
         o = self._restore_query_heads(o, num_heads_q)

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -163,6 +163,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         self.dcp_world_size = get_dcp_world_size()
         self.dcp_rank = get_dcp_rank()
 
+        # DCP decode all-gathers Q on the head dim across the DCP group, so the
+        # head count that reaches mla_decode_fwd (and thus the persistent decode
+        # metadata) is padded_num_attention_heads * dcp_world_size. The module's
+        # head-repeat compensates the _MLA_MIN_HEADS padding, so this product
+        # matches the kernel's actual nhead in every case. dcp=1 -> unchanged.
+        self.persistent_num_heads = self.padded_num_attention_heads * self.dcp_world_size
+
         max_seqlen_qo = getattr(model_runner, "num_spec_tokens", 0) + 1
         (
             (work_meta_data_size, work_meta_data_type),
@@ -174,7 +181,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         ) = get_mla_metadata_info_v1(
             self.max_bs,
             max_seqlen_qo,
-            self.padded_num_attention_heads,
+            self.persistent_num_heads,
             self.dtype_q,
             self.dtype_kv,
             is_sparse=self.is_sparse,
@@ -602,7 +609,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 var["cu_seqlens_q"].gpu[: bs + 1],
                 kv_indptr_for_metadata,
                 kv_last_page_lens_for_metadata,
-                self.padded_num_attention_heads,
+                self.persistent_num_heads,
                 1,  # nhead_kv,
                 True,
                 work_meta_data,
@@ -623,7 +630,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 var["cu_seqlens_q"].gpu[: bs + 1],
                 kv_indptr_for_metadata,
                 kv_last_page_lens_for_metadata,
-                self.padded_num_attention_heads,
+                self.persistent_num_heads,
                 1,  # nhead_kv,
                 True,
                 work_meta_data,
@@ -1772,7 +1779,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             var[f"{p}cu_seqlens_q"].gpu[: padded_bs + 1],
             kv_indptr_for_mla,
             kv_last_page_lens_for_mla,
-            self.padded_num_attention_heads,
+            self.persistent_num_heads,
             1,  # nhead_kv
             True,
             var[f"{p}work_meta_data"],

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -15,6 +15,7 @@ from aiter import (
     get_mla_metadata_info_v1,
     get_mla_metadata_v1,
 )
+
 from atom.distributed.dcp_utils import (
     dcp_persistent_supported,
     get_dcp_rank,
@@ -1701,9 +1702,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # non-DCP / qlen=1 paths keep the plain kernel). Consumed by
         # _forward_decode -> mla_decode_fwd for the MTP (max_q_len>1) cprr mask.
         attn_metadata.g_kv_indptr = (
-            var["g_kv_indptr"].copy_to_gpu(bs + 1)
-            if self.dcp_world_size > 1
-            else None
+            var["g_kv_indptr"].copy_to_gpu(bs + 1) if self.dcp_world_size > 1 else None
         )
 
         if ctx_mla_ps_sparse is not None:

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -15,8 +15,11 @@ from aiter import (
     get_mla_metadata_info_v1,
     get_mla_metadata_v1,
 )
-
-from atom.distributed.dcp_utils import get_dcp_rank, get_dcp_world_size
+from atom.distributed.dcp_utils import (
+    dcp_persistent_supported,
+    get_dcp_rank,
+    get_dcp_world_size,
+)
 from atom.distributed.pcp_utils import (
     get_pcp_world_size,
     pcp_is_enabled,
@@ -168,7 +171,12 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # metadata) is padded_num_attention_heads * dcp_world_size. The module's
         # head-repeat compensates the _MLA_MIN_HEADS padding, so this product
         # matches the kernel's actual nhead in every case. dcp=1 -> unchanged.
-        self.persistent_num_heads = self.padded_num_attention_heads * self.dcp_world_size
+        # Only gfx950 runs DCP in persistent mode (gfx942 lacks the lse persistent
+        # kernel and stays non-persistent, where this metadata is unused); scale
+        # by dcp only there so gfx942 keeps the original per-rank head sizing.
+        self.persistent_num_heads = self.padded_num_attention_heads * (
+            self.dcp_world_size if dcp_persistent_supported() else 1
+        )
 
         max_seqlen_qo = getattr(model_runner, "num_spec_tokens", 0) + 1
         (

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -221,6 +221,12 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 device=self.device,
             ),
             "kv_indptr": CpuGpuBuffer(self.max_bs + 1, **i32_kwargs),
+            # Global (un-sharded) per-request KV indptr for round-robin CP: cumsum
+            # of the GLOBAL context_lens (token-level, page_size=1). Only filled
+            # when dcp_world_size > 1; consumed by the cprr kernel via
+            # mla_decode_fwd(g_kv_indptr=...) to apply the global-position causal
+            # mask for MTP (max_q_len > 1).
+            "g_kv_indptr": CpuGpuBuffer(self.max_bs + 1, **i32_kwargs),
             "kv_indices": CpuGpuBuffer(
                 self.max_bs * self.max_num_blocks_per_seq,
                 **i32_kwargs,
@@ -435,6 +441,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         for ub_idx in range(self._NUM_TBO_UBATCHES):
             p = f"ub{ub_idx}_"
             var[f"{p}kv_indptr"] = CpuGpuBuffer(ub_max_bs + 1, **i32_kwargs)
+            # Per-ubatch global (un-sharded) kv_indptr for round-robin CP (see the
+            # shared "g_kv_indptr" buffer). Filled in _build_ubatch when dcp>1.
+            var[f"{p}g_kv_indptr"] = CpuGpuBuffer(ub_max_bs + 1, **i32_kwargs)
             var[f"{p}kv_indices"] = CpuGpuBuffer(
                 self.max_bs * self.max_num_blocks_per_seq,
                 **i32_kwargs,
@@ -567,6 +576,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         only_update: bool = False,
         num_reject_tokens: torch.Tensor = None,
         sparse_decode: bool = False,
+        is_cp_round_robin: bool = False,
     ):
         split_params = {
             "kv_granularity": max(self.block_size, 16),
@@ -575,6 +585,12 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             "fast_mode": 1,
             "max_split_per_batch": 16,
         }
+        # round-robin CP only lands on the full-build path: decode_update_mla_
+        # metadata_v1 has no is_cp_round_robin arg and collapses qlen>1 to 1.
+        assert not (only_update and is_cp_round_robin), (
+            "is_cp_round_robin requires the full get_mla_metadata_v1 build "
+            "(only_update path does not support round-robin CP / qlen>1)"
+        )
         var = self.model_runner.forward_vars
         work_meta_data = var["work_meta_data"]
         work_info_set = var["work_info_set"]
@@ -650,6 +666,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 page_size=self.block_size,
                 dtype_q=self.dtype_q,
                 dtype_kv=self.dtype_kv,
+                is_cp_round_robin=is_cp_round_robin,
                 **split_params,
             )
         return {
@@ -717,13 +734,43 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             BLOCK=self._mtp_fuse_block,
         )
 
+        # DCP + MTP draft decode: each prepare_mtp_decode call advances every
+        # sequence's KV by exactly 1 token (mtp_k controls how many times this
+        # runs, not tokens-per-call), so rebuild for LOCAL qlen=1 regardless of
+        # the max_seqlen_q param above (which the non-DCP path may pass as
+        # i0_max_seqlen_q for its incremental-update fast path — DCP always
+        # needs a full local-shard rebuild, no incremental variant exists).
+        dcp_local_rebuild = self.dcp_world_size > 1 and not self.is_sparse
+        if dcp_local_rebuild:
+            assert self.block_size == 1
+            W = self.dcp_world_size
+            r = self.dcp_rank
+            ctx_g = var["context_lens"].gpu[:bs].to(torch.int64)
+            base = ctx_g // W
+            remainder = (ctx_g - base * W - r).clamp_(0, 1)
+            local_ctx = (base + remainder).to(torch.int32)  # local KV tokens/blocks
+            kv_indptr[0] = 0
+            kv_indptr[1 : bs + 1] = torch.cumsum(local_ctx, dim=0, dtype=torch.int32)
+            var["kv_last_page_lens"].gpu[:bs] = (local_ctx > 0).to(
+                var["kv_last_page_lens"].gpu.dtype
+            )
+            # Host upper bound for the index generator's loop (safe overestimate,
+            # avoids a device->host sync); kv_indptr caps the real per-seq count.
+            local_max_k = max_seqlen_k // W + 1
+
         kv_indices_generate_triton(
             var["block_tables"].gpu[:bs],
             var["kv_indices"].gpu,
             kv_indptr,
             self.block_ratio,
-            max_seqlen_k,
+            local_max_k if dcp_local_rebuild else max_seqlen_k,
         )
+        if dcp_local_rebuild:
+            # qlen==1 local decode: full build (not cprr; is_cp_round_robin=False),
+            # over the just-rebuilt LOCAL kv_indptr / kv_last_page_lens.
+            return self.set_mla_persistent_worker_buffers(
+                bs, 1, only_update=False, num_reject_tokens=None
+            )
         if self.is_sparse:
             # The MTP draft's single sparse block reads sparse_kv_indptr, but it
             # reuses the TARGET's work_info buffer, which was built dense. The
@@ -1395,6 +1442,19 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             owned_clamped
         ].contiguous()
 
+    def _dcp_round_robin_slot(self, block_table, pos: int) -> int:
+        """DCP round-robin write slot for global position ``pos`` on this rank, or
+        -1 if another rank owns it. KV is token-level round-robin sharded
+        (page_size=1). Shared by the qlen==1 and MTP qlen>1 decode paths."""
+        if pos % self.dcp_world_size != self.dcp_rank:
+            return -1
+        block_size = self.model_runner.block_size
+        virtual_block_size = block_size * self.dcp_world_size
+        return (
+            block_table[pos // virtual_block_size] * block_size
+            + (pos % virtual_block_size) // self.dcp_world_size
+        )
+
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
         scheduled_bs = batch.total_seqs_num_decode
         dropout_p = 0.0
@@ -1414,29 +1474,28 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                     num_blocks = cdiv(context_lens, self.model_runner.block_size)
                     block_tables = [bt[:n] for bt, n in zip(block_tables, num_blocks)]
 
-                slot_mapping = [
-                    block_table[pos // self.model_runner.block_size]
-                    * self.model_runner.block_size
-                    + (pos % self.model_runner.block_size)
-                    for block_table, seq_len in zip(block_tables, context_lens)
-                    for pos in range(seq_len - max_seqlen_q, seq_len)
-                ]
+                if self.dcp_world_size > 1:
+                    # DCP round-robin + MTP: each of the max_seqlen_q new (draft)
+                    # tokens is written only on the rank owning its global pos.
+                    slot_mapping = [
+                        self._dcp_round_robin_slot(block_table, pos)
+                        for block_table, seq_len in zip(block_tables, context_lens)
+                        for pos in range(seq_len - max_seqlen_q, seq_len)
+                    ]
+                else:
+                    slot_mapping = [
+                        block_table[pos // self.model_runner.block_size]
+                        * self.model_runner.block_size
+                        + (pos % self.model_runner.block_size)
+                        for block_table, seq_len in zip(block_tables, context_lens)
+                        for pos in range(seq_len - max_seqlen_q, seq_len)
+                    ]
             else:
                 if self.dcp_world_size > 1:
-                    slot_mapping = []
-                    block_size = self.model_runner.block_size
-                    virtual_block_size = block_size * self.dcp_world_size
-                    for block_table, seq_len in zip(block_tables, context_lens):
-                        pos = seq_len - 1
-                        if pos % self.dcp_world_size == self.dcp_rank:
-                            blk_idx = pos // virtual_block_size
-                            vb_offset = pos % virtual_block_size
-                            local_offset = vb_offset // self.dcp_world_size
-                            slot_mapping.append(
-                                block_table[blk_idx] * block_size + local_offset
-                            )
-                        else:
-                            slot_mapping.append(-1)
+                    slot_mapping = [
+                        self._dcp_round_robin_slot(block_table, seq_len - 1)
+                        for block_table, seq_len in zip(block_tables, context_lens)
+                    ]
                 else:
                     slot_mapping = [
                         block_table[-1] * self.model_runner.block_size
@@ -1488,6 +1547,16 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         self.prepare_block_tables(batch)
         var["kv_indptr"].np[1 : scheduled_bs + 1] = kv_indptr
         var["kv_indptr"].np[scheduled_bs + 1 : bs + 1] = sum_blocks
+        if self.dcp_world_size > 1:
+            # Global (un-sharded) token-level kv_indptr for the round-robin CP
+            # causal mask (page_size=1 -> token granularity). context_lens is the
+            # GLOBAL per-request KV length (local shard = get_dcp_local_seq_lens).
+            g_kv_indptr = np.cumsum(context_lens[:scheduled_bs], dtype=np.int32)
+            var["g_kv_indptr"].np[0] = 0
+            var["g_kv_indptr"].np[1 : scheduled_bs + 1] = g_kv_indptr
+            var["g_kv_indptr"].np[scheduled_bs + 1 : bs + 1] = (
+                g_kv_indptr[-1] if scheduled_bs > 0 else 0
+            )
         if self.dcp_world_size > 1 and self.block_size != 1:
             local_last = local_context_lens % self.block_size
             var["kv_last_page_lens"].np[:scheduled_bs] = np.where(
@@ -1601,7 +1670,21 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 sum_tokens
             )
         else:
-            ctx_mla_ps = self.set_mla_persistent_worker_buffers(bs, max_seqlen_q)
+            # DCP + MTP (max_q_len>1) needs the round-robin global-position causal
+            # mask: build persistent metadata with is_cp_round_robin so the kernel
+            # masks on global positions g(j)=j*W+r instead of local-causal trim.
+            cp_round_robin = self.dcp_world_size > 1 and max_seqlen_q > 1
+            # For cprr, build metadata over the REAL requests (scheduled_bs), not
+            # the cudagraph-padded bs. The padded tail is 0-query, which the cprr
+            # metadata kernel mishandles (num_qo_tiles=0 -> div-by-zero; and its
+            # is_cp_round_robin "no trim" is overridden by the nhead=128 M-fold
+            # qk_batch_ratio branch). The persistent kernel is work_indptr-driven,
+            # so scheduled_bs metadata naturally skips the padding rows. Eager has
+            # scheduled_bs == bs, so this is a no-op there.
+            meta_bs = scheduled_bs if cp_round_robin else bs
+            ctx_mla_ps = self.set_mla_persistent_worker_buffers(
+                meta_bs, max_seqlen_q, is_cp_round_robin=cp_round_robin
+            )
             ctx_mla_ps_sparse = None
         ctx.update(ctx_mla_ps)
         if not disagg:
@@ -1613,6 +1696,15 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             **ctx,
         )
         attn_metadata.dtype_q = self.dtype_q
+
+        # Round-robin CP global kv_indptr (only under DCP; None otherwise so the
+        # non-DCP / qlen=1 paths keep the plain kernel). Consumed by
+        # _forward_decode -> mla_decode_fwd for the MTP (max_q_len>1) cprr mask.
+        attn_metadata.g_kv_indptr = (
+            var["g_kv_indptr"].copy_to_gpu(bs + 1)
+            if self.dcp_world_size > 1
+            else None
+        )
 
         if ctx_mla_ps_sparse is not None:
             for k, v in ctx_mla_ps_sparse.items():
@@ -1712,6 +1804,22 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             last_val = var[f"{p}kv_indptr"].np[ub_real_reqs] if ub_real_reqs > 0 else 0
             var[f"{p}kv_indptr"].np[ub_real_reqs + 1 : padded_bs + 1] = last_val
 
+            if self.dcp_world_size > 1:
+                # Per-ubatch slice of the global kv_indptr (rebased); diffs (per-req
+                # global KV length) are preserved, which is what the cprr mask uses.
+                full_g_kv_indptr = var["g_kv_indptr"].np
+                g_base = full_g_kv_indptr[req_start]
+                var[f"{p}g_kv_indptr"].np[0] = 0
+                if ub_real_reqs > 0:
+                    var[f"{p}g_kv_indptr"].np[1 : ub_real_reqs + 1] = (
+                        full_g_kv_indptr[req_start + 1 : req_start + ub_real_reqs + 1]
+                        - g_base
+                    )
+                g_last = (
+                    var[f"{p}g_kv_indptr"].np[ub_real_reqs] if ub_real_reqs > 0 else 0
+                )
+                var[f"{p}g_kv_indptr"].np[ub_real_reqs + 1 : padded_bs + 1] = g_last
+
             if self.is_sparse:
                 full_sparse = var["sparse_kv_indptr"].np
                 sparse_base = full_sparse[req_start]
@@ -1747,6 +1855,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 (f"{p}kv_indptr", padded_bs + 1),
                 (f"{p}cu_seqlens_q", padded_bs + 1),
             ]
+            if self.dcp_world_size > 1:
+                vars_used.append((f"{p}g_kv_indptr", padded_bs + 1))
             if self.is_sparse:
                 vars_used.append((f"{p}sparse_kv_indptr", padded_bs + 1))
 
@@ -1766,9 +1876,16 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 ub_max_seqlen_k,
             )
 
-            self._set_ubatch_mla_buffers(padded_bs, max_seqlen_q, ub_idx)
+            self._set_ubatch_mla_buffers(
+                padded_bs,
+                max_seqlen_q,
+                ub_idx,
+                is_cp_round_robin=self.dcp_world_size > 1 and max_seqlen_q > 1,
+            )
 
-    def _set_ubatch_mla_buffers(self, padded_bs, max_q_len, ubatch_idx):
+    def _set_ubatch_mla_buffers(
+        self, padded_bs, max_q_len, ubatch_idx, is_cp_round_robin=False
+    ):
         """Compute MLA work buffers for a per-ubatch forward_vars set."""
         p = f"ub{ubatch_idx}_"
         var = self.model_runner.forward_vars
@@ -1799,6 +1916,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             page_size=self.block_size,
             dtype_q=self.dtype_q,
             dtype_kv=self.dtype_kv,
+            is_cp_round_robin=is_cp_round_robin,
             kv_granularity=max(self.block_size, 16),
             max_seqlen_qo=max_q_len,
             uni_seqlen_qo=max_q_len,
@@ -1828,6 +1946,21 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         max_q_len = var["mtp_k"] + 1 if "mtp_k" in var else 1
         sum_tokens = bs * max_q_len
         is_sparse_mtp = self.is_sparse and max_q_len > 1
+        # DCP + MTP (max_q_len>1) capture: the cprr kernel masks on GLOBAL
+        # positions, so capture needs a self-consistent (local, global) KV layout
+        # or the graph shape won't match replay. Give every seq 1 local token per
+        # rank -> global length = dcp_world_size (page_size=1 only; round-robin
+        # requires it). Replay overwrites these buffers with real values.
+        cp_round_robin = self.dcp_world_size > 1 and max_q_len > 1
+        if cp_round_robin and self.block_size == 1:
+            var["kv_indptr"].np[: bs + 1] = np.arange(bs + 1, dtype=np.int32)
+            var["kv_indptr"].copy_to_gpu(bs + 1)
+            var["kv_indices"].gpu[:bs].zero_()
+            var["kv_last_page_lens"].gpu[:bs].fill_(1)
+            var["g_kv_indptr"].np[: bs + 1] = (
+                np.arange(bs + 1, dtype=np.int32) * self.dcp_world_size
+            )
+            var["g_kv_indptr"].copy_to_gpu(bs + 1)
         if is_sparse_mtp:
             # Two sets: normal for dense layers, sparse_mtp for sparse layers
             ctx_mla_ps = self.set_mla_persistent_worker_buffers(bs, max_q_len)
@@ -1835,7 +1968,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 sum_tokens
             )
         else:
-            ctx_mla_ps = self.set_mla_persistent_worker_buffers(bs, max_q_len)
+            ctx_mla_ps = self.set_mla_persistent_worker_buffers(
+                bs, max_q_len, is_cp_round_robin=cp_round_robin
+            )
             ctx_mla_ps_sparse = None
         attn_matadata = AttentionMetaData(
             slot_mapping=var["slot_mapping"].gpu[:sum_tokens],
@@ -1850,6 +1985,12 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             **ctx_mla_ps,
         )
         attn_matadata.dtype_q = self.dtype_q
+        # Attach the round-robin CP global kv_indptr for the captured graph so
+        # replay (which overwrites the buffer with real values) matches. Only
+        # consumed by _forward_decode when dcp>1 and max_q_len>1.
+        attn_matadata.g_kv_indptr = (
+            var["g_kv_indptr"].gpu[: bs + 1] if self.dcp_world_size > 1 else None
+        )
         if ctx_mla_ps_sparse is not None:
             for k, v in ctx_mla_ps_sparse.items():
                 setattr(attn_matadata, k, v)
@@ -1890,7 +2031,12 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         max_q_len = var["mtp_k"] + 1 if "mtp_k" in var else 1
 
         # Compute MLA work buffers for this ubatch
-        self._set_ubatch_mla_buffers(padded_bs, max_q_len, ubatch_idx)
+        self._set_ubatch_mla_buffers(
+            padded_bs,
+            max_q_len,
+            ubatch_idx,
+            is_cp_round_robin=self.dcp_world_size > 1 and max_q_len > 1,
+        )
 
         attn = AttentionMetaData(
             slot_mapping=var[f"{p}slot_mapping"].gpu[: padded_bs * max_q_len],
@@ -1919,6 +2065,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             reduce_partial_map=var[f"{p}reduce_partial_map"],
         )
         attn.dtype_q = self.dtype_q
+        # Per-ubatch round-robin CP global kv_indptr (None when non-DCP). Consumed
+        # by _forward_decode when dcp>1 and max_q_len>1 (MTP).
+        attn.g_kv_indptr = (
+            var[f"{p}g_kv_indptr"].gpu[: padded_bs + 1]
+            if self.dcp_world_size > 1
+            else None
+        )
         return attn
 
     def build_ubatch_prefill_metadata(

--- a/atom/plugin/vllm/attention/layer_mla.py
+++ b/atom/plugin/vllm/attention/layer_mla.py
@@ -774,11 +774,7 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
 
         kv_buffer = kv_c_and_k_pe_cache.unsqueeze(2)
 
-        # DCP decode needs LSE from mla_decode_fwd; persistent mode does not
-        # return it, so disable persistent mode whenever DCP is active.
-        use_persistent_mode = (
-            attn_metadata.decode.use_persistent_metadata and self.dcp_world_size <= 1
-        )
+        use_persistent_mode = attn_metadata.decode.use_persistent_metadata
         if not use_persistent_mode:
             work_meta_data = None
             work_indptr = None

--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -1049,6 +1049,15 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
 
         self.num_attention_heads = num_attention_heads // get_tp_group().world_size
         self.padded_num_attention_heads = max(self.num_attention_heads, _MLA_MIN_HEADS)
+        # DCP decode all-gathers Q across the DCP group on the head dim, so the
+        # head count reaching mla_decode_fwd (and thus the persistent decode
+        # metadata) is padded_num_attention_heads * dcp_world_size. Sourced from
+        # the parallel config so it is available here in __init__. dcp=1 ->
+        # equals padded_num_attention_heads (zero regression for non-DCP).
+        self.persistent_num_heads = (
+            self.padded_num_attention_heads
+            * self.parallel_config.decode_context_parallel_size
+        )
         self.block_size = kv_cache_spec.block_size
         self.max_bs = max_num_reqs
         self.dtype_kv = get_aiter_kv_cache_dtype(config)
@@ -1077,7 +1086,7 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
         ) = get_mla_metadata_info_v1(
             max_num_reqs,
             1,
-            self.padded_num_attention_heads,
+            self.persistent_num_heads,
             self.dtype_q,
             self.dtype_kv,
             is_sparse=False,
@@ -1168,7 +1177,7 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
             cu_seqlens_q,
             self.paged_kv_indptr[: bs + 1],  # TODO: support sparse
             self.paged_kv_last_page_len[:bs],
-            self.padded_num_attention_heads,
+            self.persistent_num_heads,
             1,  # nhead_kv,
             True,
             work_meta_data,

--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -1,13 +1,20 @@
-from typing import Optional
 import logging
-
 from dataclasses import dataclass
+from typing import Optional
 
 import torch
-
 from aiter import dtypes, get_mla_metadata_info_v1, get_mla_metadata_v1
 from aiter.dist.parallel_state import get_dp_group, get_tp_group
 from aiter.jit.utils.chip_info import get_gfx
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonMetadataBuilder,
+    QueryLenSupport,
+)
+from vllm.v1.attention.backend import (
+    AttentionCGSupport,
+    AttentionMetadataBuilder,
+)
+
 from atom.config import get_current_atom_config
 from atom.distributed.dcp_utils import dcp_persistent_supported
 from atom.model_ops.attention_mla import _MLA_MIN_HEADS
@@ -17,14 +24,6 @@ from atom.plugin.vllm.attention.layer_mla import (
 )
 from atom.utils import CpuGpuBuffer
 from atom.utils.block_convert import kv_indices_generate_triton
-from vllm.model_executor.layers.attention.mla_attention import (
-    MLACommonMetadataBuilder,
-    QueryLenSupport,
-)
-from vllm.v1.attention.backend import (
-    AttentionCGSupport,
-    AttentionMetadataBuilder,
-)
 
 logger = logging.getLogger("atom")
 

--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -9,6 +9,7 @@ from aiter import dtypes, get_mla_metadata_info_v1, get_mla_metadata_v1
 from aiter.dist.parallel_state import get_dp_group, get_tp_group
 from aiter.jit.utils.chip_info import get_gfx
 from atom.config import get_current_atom_config
+from atom.distributed.dcp_utils import dcp_persistent_supported
 from atom.model_ops.attention_mla import _MLA_MIN_HEADS
 from atom.plugin.vllm.attention.layer_mla import (
     disabled_mla_persistent_metadata,
@@ -1049,14 +1050,21 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
 
         self.num_attention_heads = num_attention_heads // get_tp_group().world_size
         self.padded_num_attention_heads = max(self.num_attention_heads, _MLA_MIN_HEADS)
+        # Whether DCP decode can run in persistent mode on this GPU (gfx950 has
+        # the lse persistent kernel, gfx942 does not — see dcp_utils). Cached
+        # once to gate both the metadata sizing and the runtime persistent path.
+        self.dcp_persistent_supported = dcp_persistent_supported()
         # DCP decode all-gathers Q across the DCP group on the head dim, so the
         # head count reaching mla_decode_fwd (and thus the persistent decode
         # metadata) is padded_num_attention_heads * dcp_world_size. Sourced from
         # the parallel config so it is available here in __init__. dcp=1 ->
-        # equals padded_num_attention_heads (zero regression for non-DCP).
-        self.persistent_num_heads = (
-            self.padded_num_attention_heads
-            * self.parallel_config.decode_context_parallel_size
+        # equals padded_num_attention_heads (zero regression for non-DCP). Only
+        # scale by dcp on gfx950 (DCP persistent); gfx942 stays non-persistent
+        # where this metadata is unused, so keep the original per-rank sizing.
+        self.persistent_num_heads = self.padded_num_attention_heads * (
+            self.parallel_config.decode_context_parallel_size
+            if self.dcp_persistent_supported
+            else 1
         )
         self.block_size = kv_cache_spec.block_size
         self.max_bs = max_num_reqs
@@ -1269,6 +1277,11 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
         use_persistent_metadata = (not dp_enabled) or (
             self._mla_dp_native_persistent_enabled and max_qo_len == 1
         )
+        if (
+            self.parallel_config.decode_context_parallel_size > 1
+            and not self.dcp_persistent_supported
+        ):
+            use_persistent_metadata = False
         if use_persistent_metadata:
             ctx_mla_ps = self._set_mla_persistent_worker_buffers(
                 num_reqs,

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -400,7 +400,9 @@ class EagleProposer(Drafter):
                             # this draft token; other ranks' kv_indptr didn't grow,
                             # so raw_slots would point at a stale slot. Emit -1.
                             ctx = attn_metadata.context_lens[:bs]
-                            owned = ((ctx - 1) % builder.dcp_world_size) == builder.dcp_rank
+                            owned = (
+                                (ctx - 1) % builder.dcp_world_size
+                            ) == builder.dcp_rank
                             slot_mapping[:] = torch.where(owned, raw_slots, -1)
                         else:
                             slot_mapping[:] = raw_slots

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -222,8 +222,10 @@ class EagleProposer(Drafter):
         if draft_uses_mha:
             attn_metadata.slot_mapping = var["slot_mapping"].gpu[: len(input_ids)]
             attn_metadata.block_tables = var["block_tables"].gpu[:bs]
-        else:
-            # Make MLA draft slot_mapping == q rows.
+        elif attn_metadata.slot_mapping is not None:
+            # Make MLA draft slot_mapping == q rows. DeepSeek-V4 uses
+            # block_tables + context_lens (slot_mapping is None) — nothing to
+            # size, so skip instead of subscripting None.
             attn_metadata.slot_mapping = attn_metadata.slot_mapping[: len(input_ids)]
 
         # Backends that expose flat per-seq kv_indices/kv_indptr (MLA, MHA)

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -222,6 +222,9 @@ class EagleProposer(Drafter):
         if draft_uses_mha:
             attn_metadata.slot_mapping = var["slot_mapping"].gpu[: len(input_ids)]
             attn_metadata.block_tables = var["block_tables"].gpu[:bs]
+        else:
+            # Make MLA draft slot_mapping == q rows.
+            attn_metadata.slot_mapping = attn_metadata.slot_mapping[: len(input_ids)]
 
         # Backends that expose flat per-seq kv_indices/kv_indptr (MLA, MHA)
         # wire them through eagle's mid-step block; V4 has block_tables +
@@ -390,7 +393,17 @@ class EagleProposer(Drafter):
                         attn_metadata.__dict__[k] = v
                     if has_flat_kv and "slot_mapping" not in workinfos:
                         # MLA/MHA path: slot derived from flat kv_indices.
-                        slot_mapping[:] = kv_indices[kv_indptr[1 : bs + 1] - 1]
+                        raw_slots = kv_indices[kv_indptr[1 : bs + 1] - 1]
+                        builder = self.runner.attn_metadata_builder
+                        if getattr(builder, "dcp_world_size", 1) > 1:
+                            # DCP round-robin: only rank (context_len-1) % W owns
+                            # this draft token; other ranks' kv_indptr didn't grow,
+                            # so raw_slots would point at a stale slot. Emit -1.
+                            ctx = attn_metadata.context_lens[:bs]
+                            owned = ((ctx - 1) % builder.dcp_world_size) == builder.dcp_rank
+                            slot_mapping[:] = torch.where(owned, raw_slots, -1)
+                        else:
+                            slot_mapping[:] = raw_slots
 
                     input_ids = new_draft_ids
                     hidden_states = sample_hidden_states


### PR DESCRIPTION
## 1. Motivation

- gfx950 changes to persistent PA, while gfx942 still use non-persistent PA (lack lse=1 persistent kernel)
- gfx950: make MLA DCP compatible with MTP with BF16. (FP8 is waiting for aiter kernel). gfx942: can not use DCP and MTP simultaneously.

## 2. Usage

Persistent mode is automatic on gfx950 — no new flag. MTP+DCP: combine existing flags.

```bash
# Native
python -m atom.entrypoints.openai_server --model DeepSeek-R1 \
  --kv_cache_dtype bf16 -tp 8 -dcp 8 --method mtp --num-speculative-tokens 1  # or 2 / 3

# vLLM plugin
vllm serve DeepSeek-R1 -tp 8 -dcp 8 --kv-cache-dtype bfloat16 \
  --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
  --speculative-config '{"method": "mtp", "num_speculative_tokens": 1}'
```

fp8 + DCP + MTP raises `NotImplementedError` instead of silently miscomputing.

## 3. Design

Flow — MTP draft loop under DCP

```
 i == 0:  slot_mapping = slot_mapping[: len(input_ids)]     (FIX #1: grid == q rows)
             │
             ▼
 i >= 1:  kv_indptr += cu_seqlens_q   (GLOBAL, not DCP-aware)
          FIX #2 (dcp>1):
            local_ctx  = get_dcp_local_seq_lens(context_lens, W, rank)
            kv_indptr  = cumsum(local_ctx)        ← LOCAL shard
            kv_indices = regenerate from local kv_indptr
            worker buffers = full rebuild
            slot_mapping[t] = raw_slot[t] if (ctx-1)%W==rank else -1
```
## 4. Test

MTP+DCP: native + plugin, `-tp8 -dcp8`, bf16, `--method mtp --num-speculative-tokens {1,2,3}`; sustained concurrent load to force `bs>1` cudagraph decode, then full gsm8k (no `--limit`), confirm 0 crashes.

**MTP+DCP, native, full gsm8k (1319 questions, bf16, cudagraph):**

| `num_speculative_tokens` | Crashes | flexible | strict |
|---:|---:|---:|---:|
| 1 | 0 | 0.9484 | 0.9462 |
| 2 | 0 | 0.9515 | 0.9522 |
| 3 | 0 | 0.9500 | 0.9484 |

**MTP+DCP, vLLM plugin (`limit=100`, not yet full):**

| `num_speculative_tokens` | Crashes | flexible | strict |
|---:|---:|---:|---:|
| 1 | 0 | 0.97 | 0.97 |
| 2 | 0 | 0.94 | 0.93 |
| 3 | 0 | 0.95 | 0.95 |

## Submission Checklist
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
