### PR TITLE
feat: support GLM-5.2 tool call parser

### DIFF
--- a/atom/entrypoints/openai/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser.py
@@ -43,7 +43,7 @@ import json
 import re
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 
 def _unique_tool_call_id() -> str:
@@ -60,9 +60,9 @@ class ToolCall:
 
     id: str
     type: str
-    function: Dict[str, str]
+    function: dict[str, str]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {"id": self.id, "type": self.type, "function": self.function}
 
 
@@ -97,13 +97,13 @@ def _is_glm_xml(text: str) -> bool:
     )
 
 
-def _build_param_types(tools: Optional[list]) -> Dict[str, Dict[str, Any]]:
+def _build_param_types(tools: list | None) -> dict[str, dict[str, Any]]:
     """Map ``function_name -> {param_name: json_schema_type}`` from request tools.
 
     Accepts OpenAI (``{"type": "function", "function": {...}}``) and bare
     (``{"name": ..., "parameters"/"input_schema": {...}}``) tool entries.
     """
-    out: Dict[str, Dict[str, Any]] = {}
+    out: dict[str, dict[str, Any]] = {}
     for tool in tools or []:
         if not isinstance(tool, dict):
             continue
@@ -147,9 +147,9 @@ def _coerce_param_value(value: str, ptype: Any) -> Any:
         if t.startswith(("object", "dict", "map", "array", "list", "tuple")):
             try:
                 return json.loads(v)
-            except Exception:
+            except json.JSONDecodeError:
                 return ast.literal_eval(v)  # safer for single-quoted Python literals
-    except Exception:
+    except (ValueError, SyntaxError, OverflowError):
         return v
     return v
 
@@ -170,23 +170,23 @@ def _coerce_glm_param_value(value: str, ptype: Any) -> Any:
                     parsed = json.loads(v) if v[0] == '"' else ast.literal_eval(v)
                     if isinstance(parsed, str):
                         return parsed
-                except Exception:
+                except (ValueError, SyntaxError):
                     return v[1:-1]
             return v
         return _coerce_param_value(v, ptype)
 
     try:
         return json.loads(v)
-    except Exception:
+    except json.JSONDecodeError:
         try:
             return ast.literal_eval(v)
-        except Exception:
+        except (ValueError, SyntaxError):
             return v
 
 
 def _parse_qwen_function(
-    fn_text: str, param_types: Dict[str, Dict[str, Any]], index: int
-) -> Optional[ToolCall]:
+    fn_text: str, param_types: dict[str, dict[str, Any]], index: int
+) -> ToolCall | None:
     """Parse the inside of one ``<function=NAME>...`` block into a ToolCall."""
     gt = fn_text.find(">")
     if gt == -1:
@@ -196,7 +196,7 @@ def _parse_qwen_function(
         return None
     body = fn_text[gt + 1 :]
     types = param_types.get(name, {})
-    args: Dict[str, Any] = {}
+    args: dict[str, Any] = {}
     for pm in _QWEN_PARAM_RE.finditer(body):
         seg = pm.group(1)
         if seg is None:
@@ -215,7 +215,7 @@ def _parse_qwen_function(
     )
 
 
-def _parse_qwen_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCall]]:
+def _parse_qwen_xml(text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
     """Parse Qwen3 XML tool calls; return (leading_content, tool_calls)."""
     param_types = _build_param_types(tools)
     # Content precedes the first tool marker.
@@ -223,7 +223,7 @@ def _parse_qwen_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCal
         i for i in (text.find("<tool_call>"), text.find(_QWEN_TOOL_PREFIX)) if i != -1
     ]
     content = text[: min(markers)] if markers else text
-    tool_calls: List[ToolCall] = []
+    tool_calls: list[ToolCall] = []
     for fm in _QWEN_FUNCTION_RE.finditer(text):
         fn_text = fm.group(1) if fm.group(1) is not None else fm.group(2)
         if not fn_text:
@@ -234,11 +234,11 @@ def _parse_qwen_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCal
     return content.strip(), tool_calls
 
 
-def _parse_glm_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCall]]:
+def _parse_glm_xml(text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
     """Parse GLM-4.7 / GLM-5 XML tool calls."""
     param_types = _build_param_types(tools)
-    content_parts: List[str] = []
-    tool_calls: List[ToolCall] = []
+    content_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
     last_end = 0
 
     for match in _GLM_TOOL_CALL_RE.finditer(text):
@@ -258,7 +258,7 @@ def _parse_glm_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCall
             continue
 
         types = param_types.get(name, {})
-        arguments: Dict[str, Any] = {}
+        arguments: dict[str, Any] = {}
         for key, value in _GLM_ARG_RE.findall(args_text):
             key = key.strip()
             if key:
@@ -281,8 +281,8 @@ def _parse_glm_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCall
 
 
 def parse_tool_calls(
-    text: str, tools: Optional[list] = None
-) -> Tuple[str, List[ToolCall]]:
+    text: str, tools: list | None = None
+) -> tuple[str, list[ToolCall]]:
     """Parse tool calls from model output text.
 
     Args:
@@ -326,7 +326,7 @@ def parse_tool_calls(
     return content.strip(), tool_calls
 
 
-def _parse_tool_call_entries(section_text: str) -> List[ToolCall]:
+def _parse_tool_call_entries(section_text: str) -> list[ToolCall]:
     """Parse individual tool call entries from the section content."""
     tool_calls = []
     pattern = re.compile(
@@ -377,8 +377,8 @@ class ToolCallStreamParser:
     buf: str = ""
     current_index: int = 0
     _emitted_calls: int = 0
-    tools: Optional[list] = None
-    fmt: Optional[str] = None  # None (undecided) | "kimi" | "xml"
+    tools: list | None = None
+    fmt: str | None = None  # None (undecided) | "kimi" | "xml"
 
     def process(self, text: str) -> list:
         """Process a text chunk and return list of (event_type, data) tuples."""

--- a/atom/entrypoints/openai/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser.py
@@ -3,7 +3,7 @@
 
 """Tool call parser for models that output tool calls.
 
-Two on-the-wire formats are auto-detected and normalized into the OpenAI
+Three on-the-wire formats are auto-detected and normalized into the OpenAI
 ``tool_calls`` structure:
 
 1. Kimi-K2 special-token format::
@@ -21,10 +21,17 @@ Two on-the-wire formats are auto-detected and normalized into the OpenAI
     </function>
     </tool_call>
 
-The Qwen XML carries no value types, so when the request's ``tools`` schema is
+3. GLM-4.7 / GLM-5 XML format::
+
+    <tool_call>NAME
+    <arg_key>PNAME</arg_key><arg_value>VALUE</arg_value>
+    ...
+    </tool_call>
+
+The XML formats carry no value types, so when the request's ``tools`` schema is
 supplied each parameter is coerced to the declared JSON-Schema type (int, float,
-bool, null, object, array); otherwise it is left as a string. This mirrors the
-qwen3_coder/qwen3_xml parsers in vLLM and SGLang.
+bool, null, object, array). This mirrors the qwen3_xml and glm47 parsers in
+vLLM and SGLang.
 
 OpenAI format:
     {"tool_calls": [{"id": "call_0", "type": "function",
@@ -69,11 +76,25 @@ _QWEN_PARAM_RE = re.compile(
     r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
     re.DOTALL,
 )
+_GLM_TOOL_CALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
+_GLM_ARG_RE = re.compile(
+    r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>",
+    re.DOTALL,
+)
 
 
 def _is_qwen_xml(text: str) -> bool:
     """Detect the Qwen3 XML tool-call format (and not the Kimi token format)."""
     return _QWEN_TOOL_PREFIX in text and "<|tool_calls_section_begin|>" not in text
+
+
+def _is_glm_xml(text: str) -> bool:
+    """Detect the GLM-4.7 / GLM-5 native XML tool-call format."""
+    return (
+        "<tool_call>" in text
+        and _QWEN_TOOL_PREFIX not in text
+        and "<|tool_calls_section_begin|>" not in text
+    )
 
 
 def _build_param_types(tools: Optional[list]) -> Dict[str, Dict[str, Any]]:
@@ -133,6 +154,36 @@ def _coerce_param_value(value: str, ptype: Any) -> Any:
     return v
 
 
+def _coerce_glm_param_value(value: str, ptype: Any) -> Any:
+    """Coerce a GLM argument while preserving bare string values.
+
+    GLM emits schema-declared strings without JSON quotes and emits structured
+    values as JSON. When no schema is available, use JSON/literal parsing as a
+    best effort and fall back to the original text.
+    """
+    v = value.strip("\n")
+    if ptype is not None:
+        t = str(ptype).lower()
+        if t in ("string", "str", "text", "varchar", "char", "enum"):
+            if len(v) >= 2 and v[0] == v[-1] and v[0] in {'"', "'"}:
+                try:
+                    parsed = json.loads(v) if v[0] == '"' else ast.literal_eval(v)
+                    if isinstance(parsed, str):
+                        return parsed
+                except Exception:
+                    return v[1:-1]
+            return v
+        return _coerce_param_value(v, ptype)
+
+    try:
+        return json.loads(v)
+    except Exception:
+        try:
+            return ast.literal_eval(v)
+        except Exception:
+            return v
+
+
 def _parse_qwen_function(
     fn_text: str, param_types: Dict[str, Dict[str, Any]], index: int
 ) -> Optional[ToolCall]:
@@ -183,15 +234,61 @@ def _parse_qwen_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCal
     return content.strip(), tool_calls
 
 
+def _parse_glm_xml(text: str, tools: Optional[list]) -> Tuple[str, List[ToolCall]]:
+    """Parse GLM-4.7 / GLM-5 XML tool calls."""
+    param_types = _build_param_types(tools)
+    content_parts: List[str] = []
+    tool_calls: List[ToolCall] = []
+    last_end = 0
+
+    for match in _GLM_TOOL_CALL_RE.finditer(text):
+        content_parts.append(text[last_end : match.start()])
+        body = match.group(1)
+        args_start = body.find("<arg_key>")
+        if args_start == -1:
+            name = body.strip()
+            args_text = ""
+        else:
+            name = body[:args_start].strip()
+            args_text = body[args_start:]
+
+        if not name:
+            content_parts.append(match.group(0))
+            last_end = match.end()
+            continue
+
+        types = param_types.get(name, {})
+        arguments: Dict[str, Any] = {}
+        for key, value in _GLM_ARG_RE.findall(args_text):
+            key = key.strip()
+            if key:
+                arguments[key] = _coerce_glm_param_value(value, types.get(key))
+
+        tool_calls.append(
+            ToolCall(
+                id=_unique_tool_call_id(),
+                type="function",
+                function={
+                    "name": name,
+                    "arguments": json.dumps(arguments, ensure_ascii=False),
+                },
+            )
+        )
+        last_end = match.end()
+
+    content_parts.append(text[last_end:])
+    return "".join(content_parts).strip(), tool_calls
+
+
 def parse_tool_calls(
     text: str, tools: Optional[list] = None
 ) -> Tuple[str, List[ToolCall]]:
     """Parse tool calls from model output text.
 
     Args:
-        text: Raw model output that may contain tool calls (Kimi token format
-            or Qwen3 XML format).
-        tools: Optional request tool definitions; used to type-coerce Qwen XML
+        text: Raw model output that may contain tool calls (Kimi token format,
+            Qwen3 XML format, or GLM XML format).
+        tools: Optional request tool definitions; used to type-coerce XML
             parameter values to their declared JSON-Schema types.
 
     Returns:
@@ -201,6 +298,10 @@ def parse_tool_calls(
     # Qwen3 XML format
     if _is_qwen_xml(text):
         return _parse_qwen_xml(text, tools)
+
+    # GLM-4.7 / GLM-5 XML format
+    if _is_glm_xml(text):
+        return _parse_glm_xml(text, tools)
 
     # Kimi-K2 special-token format
     section_match = re.search(
@@ -253,7 +354,7 @@ def _parse_tool_call_entries(section_text: str) -> List[ToolCall]:
 
 @dataclass
 class ToolCallStreamParser:
-    """Stateful streaming parser for tool calls (Kimi tokens or Qwen3 XML).
+    """Stateful streaming parser for tool calls (Kimi, Qwen3, or GLM).
 
     Processes text chunks and emits structured events:
     - ("content", text) — regular content before tool calls
@@ -261,9 +362,9 @@ class ToolCallStreamParser:
     - ("tool_call_args", {"index": N, "function": {"arguments": chunk}})
     - ("tool_call_end", None) — all tool calls complete
 
-    The wire format is auto-detected from the first chunks. For the Qwen3 XML
-    format content is streamed normally and the ``<tool_call>`` block is buffered
-    and parsed when complete (robust against partial-XML streaming edge cases);
+    The wire format is auto-detected from the first chunks. For XML formats,
+    content is streamed normally and the ``<tool_call>`` block is buffered and
+    parsed when complete (robust against partial-XML streaming edge cases);
     ``tools`` enables JSON-Schema type coercion of parameter values.
 
     Kimi states:
@@ -277,14 +378,14 @@ class ToolCallStreamParser:
     current_index: int = 0
     _emitted_calls: int = 0
     tools: Optional[list] = None
-    fmt: Optional[str] = None  # None (undecided) | "kimi" | "qwen"
+    fmt: Optional[str] = None  # None (undecided) | "kimi" | "xml"
 
     def process(self, text: str) -> list:
         """Process a text chunk and return list of (event_type, data) tuples."""
         if self.fmt is None:
             self.buf += text
             if _QWEN_TOOL_PREFIX in self.buf or "<tool_call>" in self.buf:
-                self.fmt = "qwen"
+                self.fmt = "xml"
             elif "<|tool_calls_section_begin|>" in self.buf:
                 self.fmt = "kimi"
             elif "<" not in self.buf and len(self.buf) > 8:
@@ -297,12 +398,12 @@ class ToolCallStreamParser:
             # Format decided: replay the accumulated buffer through the handler.
             text, self.buf = self.buf, ""
 
-        if self.fmt == "qwen":
-            return self._process_qwen(text)
+        if self.fmt == "xml":
+            return self._process_xml(text)
         return self._process_kimi(text)
 
-    # -- Qwen3 XML ----------------------------------------------------------
-    def _process_qwen(self, text: str) -> list:
+    # -- Qwen3 / GLM XML ----------------------------------------------------
+    def _process_xml(self, text: str) -> list:
         results: list = []
         self.buf += text
         if self.state == 0:
@@ -333,7 +434,7 @@ class ToolCallStreamParser:
                     self.buf = self.buf[cut:]
         return results
 
-    def _flush_qwen(self) -> list:
+    def _flush_xml(self) -> list:
         results: list = []
         if self.state == 0:
             if self.buf:
@@ -341,8 +442,18 @@ class ToolCallStreamParser:
                 self.buf = ""
             return results
         # state 1: parse the complete (or trailing) tool-call block.
-        _content, tool_calls = _parse_qwen_xml(self.buf, self.tools)
+        raw_buffer = self.buf
+        if _is_qwen_xml(raw_buffer):
+            content, tool_calls = _parse_qwen_xml(raw_buffer, self.tools)
+        elif _is_glm_xml(raw_buffer):
+            content, tool_calls = _parse_glm_xml(raw_buffer, self.tools)
+        else:
+            content, tool_calls = raw_buffer, []
         self.buf = ""
+        if not tool_calls:
+            content = raw_buffer
+        if content:
+            results.append(("content", content))
         for tc in tool_calls:
             tc.id = _unique_tool_call_id()
             results.append(
@@ -449,8 +560,8 @@ class ToolCallStreamParser:
 
     def flush(self) -> list:
         """Flush remaining buffer content."""
-        if self.fmt == "qwen":
-            return self._flush_qwen()
+        if self.fmt == "xml":
+            return self._flush_xml()
         results = []
         if self.state == 0 and self.buf:
             results.append(("content", self.buf))

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -5,7 +5,6 @@
 
 import json
 
-
 from atom.entrypoints.openai.serving_chat import (
     build_chat_response,
     build_chat_response_multi,

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -120,6 +120,34 @@ class TestBuildChatResponse:
         assert '"cmd"' in tc["function"]["arguments"]
         assert resp.choices[0]["finish_reason"] == "tool_calls"
 
+    def test_glm_tool_call_parsed(self):
+        raw = (
+            "<tool_call>bash"
+            "<arg_key>command</arg_key><arg_value>ls</arg_value>"
+            "</tool_call>"
+        )
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        output = self._make_output(text=raw)
+        resp = build_chat_response("req-1", "model", raw, output, tools=tools)
+
+        message = resp.choices[0]["message"]
+        assert message["content"] == ""
+        assert json.loads(message["tool_calls"][0]["function"]["arguments"]) == {
+            "command": "ls"
+        }
+        assert resp.choices[0]["finish_reason"] == "tool_calls"
+
     def test_timing_in_usage(self):
         output = self._make_output(ttft=0.15, tpot=0.03, latency=0.8)
         resp = build_chat_response("req-1", "model", "text", output)

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -3,6 +3,8 @@
 
 """Tests for tool call parsing."""
 
+import json
+
 from atom.entrypoints.openai.tool_parser import (
     ToolCall,
     ToolCallStreamParser,
@@ -115,6 +117,116 @@ class TestParseToolCalls:
         assert tool_calls[0].function["arguments"] == args
 
 
+class TestGlmToolCalls:
+    """Tests for the GLM-4.7 / GLM-5 native XML format."""
+
+    @staticmethod
+    def _tools():
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "configure",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "count": {"type": "integer"},
+                            "enabled": {"type": "boolean"},
+                            "payload": {"type": "object"},
+                            "labels": {"type": "array"},
+                            "raw": {"type": "string"},
+                        },
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "ping",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+
+    def test_single_tool_call(self):
+        text = (
+            "<tool_call>bash"
+            "<arg_key>command</arg_key><arg_value>ls</arg_value>"
+            "</tool_call>"
+        )
+        content, tool_calls = parse_tool_calls(text, self._tools())
+
+        assert content == ""
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function["name"] == "bash"
+        assert json.loads(tool_calls[0].function["arguments"]) == {"command": "ls"}
+
+    def test_multiple_typed_arguments(self):
+        text = (
+            "Checking. "
+            "<tool_call>configure"
+            "<arg_key>count</arg_key><arg_value>3</arg_value>"
+            "<arg_key>enabled</arg_key><arg_value>false</arg_value>"
+            '<arg_key>payload</arg_key><arg_value>{"mode":"fast"}</arg_value>'
+            '<arg_key>labels</arg_key><arg_value>["a","b"]</arg_value>'
+            '<arg_key>raw</arg_key><arg_value>{"keep":"as text"}</arg_value>'
+            "</tool_call>"
+            " Done."
+        )
+        content, tool_calls = parse_tool_calls(text, self._tools())
+
+        assert "Checking." in content
+        assert "Done." in content
+        arguments = json.loads(tool_calls[0].function["arguments"])
+        assert arguments == {
+            "count": 3,
+            "enabled": False,
+            "payload": {"mode": "fast"},
+            "labels": ["a", "b"],
+            "raw": '{"keep":"as text"}',
+        }
+
+    def test_multiple_calls_and_zero_arguments(self):
+        text = (
+            "<tool_call>ping</tool_call>"
+            "<tool_call>bash"
+            "<arg_key>command</arg_key><arg_value>pwd</arg_value>"
+            "</tool_call>"
+        )
+        content, tool_calls = parse_tool_calls(text, self._tools())
+
+        assert content == ""
+        assert [tc.function["name"] for tc in tool_calls] == ["ping", "bash"]
+        assert json.loads(tool_calls[0].function["arguments"]) == {}
+        assert json.loads(tool_calls[1].function["arguments"]) == {"command": "pwd"}
+        assert tool_calls[0].id != tool_calls[1].id
+
+    def test_quoted_string_is_unwrapped(self):
+        text = (
+            "<tool_call>bash"
+            '<arg_key>command</arg_key><arg_value>"ls -la"</arg_value>'
+            "</tool_call>"
+        )
+        _, tool_calls = parse_tool_calls(text, self._tools())
+        assert json.loads(tool_calls[0].function["arguments"]) == {"command": "ls -la"}
+
+    def test_empty_function_name_is_preserved_as_content(self):
+        text = "<tool_call>  </tool_call>"
+        content, tool_calls = parse_tool_calls(text, self._tools())
+        assert content == text
+        assert tool_calls == []
+
+
 # ============================================================================
 # ToolCallStreamParser Tests
 # ============================================================================
@@ -123,9 +235,9 @@ class TestParseToolCalls:
 class TestToolCallStreamParser:
     """Tests for the ToolCallStreamParser streaming state machine."""
 
-    def _run_parser(self, tokens):
+    def _run_parser(self, tokens, tools=None):
         """Helper: run tokens through parser and return all events."""
-        parser = ToolCallStreamParser()
+        parser = ToolCallStreamParser(tools=tools)
         results = []
         for token in tokens:
             results.extend(parser.process(token))
@@ -211,3 +323,57 @@ class TestToolCallStreamParser:
         assert len(starts) == 1
         ends = [d for t, d in results if t == "tool_call_end"]
         assert len(ends) == 1  # flush should emit tool_call_end
+
+    def test_glm_tool_call_streaming(self):
+        tools = TestGlmToolCalls._tools()
+        tokens = [
+            "I'll ",
+            "check.",
+            "<tool_",
+            "call>ba",
+            "sh<arg_key>comm",
+            "and</arg_key><arg_value>ls -la",
+            "</arg_value></tool_",
+            "call>",
+        ]
+        results = self._run_parser(tokens, tools)
+
+        content = "".join(d for t, d in results if t == "content")
+        assert content == "I'll check."
+
+        starts = [d for t, d in results if t == "tool_call_start"]
+        assert len(starts) == 1
+        assert starts[0]["function"]["name"] == "bash"
+
+        args = [d for t, d in results if t == "tool_call_args"]
+        assert len(args) == 1
+        assert json.loads(args[0]["function"]["arguments"]) == {"command": "ls -la"}
+
+        ends = [d for t, d in results if t == "tool_call_end"]
+        assert len(ends) == 1
+
+    def test_glm_multiple_and_zero_arg_streaming(self):
+        tools = TestGlmToolCalls._tools()
+        tokens = [
+            "<tool_call>ping</tool_call>",
+            "<tool_call>bash<arg_key>command</arg_key>",
+            "<arg_value>pwd</arg_value></tool_call>",
+        ]
+        results = self._run_parser(tokens, tools)
+
+        starts = [d for t, d in results if t == "tool_call_start"]
+        assert [start["function"]["name"] for start in starts] == ["ping", "bash"]
+        assert [start["index"] for start in starts] == [0, 1]
+        assert starts[0]["id"] != starts[1]["id"]
+
+        args = [d for t, d in results if t == "tool_call_args"]
+        assert json.loads(args[0]["function"]["arguments"]) == {}
+        assert json.loads(args[1]["function"]["arguments"]) == {"command": "pwd"}
+
+    def test_incomplete_glm_call_is_returned_as_content(self):
+        text = "<tool_call>bash" "<arg_key>command</arg_key><arg_value>ls</arg_value>"
+        results = self._run_parser([text], TestGlmToolCalls._tools())
+
+        content = "".join(d for t, d in results if t == "content")
+        assert content == text
+        assert not [d for t, d in results if t == "tool_call_start"]

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -112,7 +112,7 @@ class TestParseToolCalls:
             f"<|tool_call_begin|>functions.chat:0<|tool_call_argument_begin|>{args}<|tool_call_end|>"
             "<|tool_calls_section_end|>"
         )
-        content, tool_calls = parse_tool_calls(text)
+        _, tool_calls = parse_tool_calls(text)
         assert len(tool_calls) == 1
         assert tool_calls[0].function["arguments"] == args
 
@@ -291,9 +291,11 @@ class TestToolCallStreamParser:
         tokens = [
             "I'll fetch that for you.",
             "<|tool_calls_section_begin|>",
-            "<|tool_call_begin|>functions.curl:0"
-            '<|tool_call_argument_begin|>{"url": "https://api.example.com/data", "method": "POST", "body": "{\\"key\\": \\"value\\"}"}'
-            "<|tool_call_end|>",
+            (
+                "<|tool_call_begin|>functions.curl:0"
+                '<|tool_call_argument_begin|>{"url": "https://api.example.com/data", "method": "POST", "body": "{\\"key\\": \\"value\\"}"}'
+                "<|tool_call_end|>"
+            ),
             "<|tool_calls_section_end|>",
         ]
         results = self._run_parser(tokens)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Support GLM-5.2 tool call parser.

For GLM-5.2, it follows the `glm47` tool call parser convention, its format is xml style like
```xml
  <tool_call>NAME
  <arg_key>PNAME</arg_key><arg_value>VALUE</arg_value>
  ...
  </tool_call>
``` 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
