### PR TITLE
[Feature] Quantize weights online when loading weights

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -194,6 +194,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Docker Login
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: ./.github/actions/docker-auth
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -24,6 +24,7 @@ if "F8_E8M0" not in safetensors.torch._TYPES and hasattr(torch, "float8_e8m0fnu"
 from aiter.dist.parallel_state import get_tp_group
 
 from atom.model_loader.loading_core import load_weights_into_model, rank_tag
+from atom.model_loader.online_quant_streaming import OnlineQuantStreamer
 from atom.model_loader.weight_iterator import (
     safetensors_weights_iterator,
 )
@@ -138,6 +139,8 @@ def _save_online_quant_info(
     model_name_or_path: str,
     elapsed_seconds: float,
     online_quant_config: dict,
+    timing_scope: str,
+    peak_gpu_memory_gb: float | None,
 ):
     """Save online quantization info to a JSON file (rank 0 only)."""
     if get_tp_group().rank_in_group != 0:
@@ -154,6 +157,10 @@ def _save_online_quant_info(
         "model": model_name_or_path,
         "online_quant_config": online_quant_config,
         "elapsed_seconds": round(elapsed_seconds, 3),
+        "timing_scope": timing_scope,
+        "peak_gpu_memory_gb": (
+            round(peak_gpu_memory_gb, 3) if peak_gpu_memory_gb is not None else None
+        ),
         "num_layers": len(oq_layers),
         "layers": oq_layers,
     }
@@ -272,6 +279,12 @@ def load_model(
         except Exception:  # noqa: BLE001
             return True
 
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+
+    # Quantize eligible modules as soon as their source weights complete.
+    online_quant_streamer = OnlineQuantStreamer.maybe_create(model, load_dummy)
+
     loaded_weights_record = load_weights_into_model(
         model=model,
         model_name_or_path=model_name_or_path,
@@ -285,12 +298,16 @@ def load_model(
         fuse_shared_expert=_fuse_shared_expert,
         is_rank0=_is_rank0,
         weights_iterator=safetensors_weights_iterator,
+        online_quant_streamer=online_quant_streamer,
     )
 
     # Dummy modes other than "empty" fill the skipped-load params with finite
     # values before post-processing, so shuffle/swizzle runs on clean constants.
     if load_dummy and load_dummy != "empty":
         initialize_dummy_weights(model, load_dummy)
+
+    if online_quant_streamer is not None:
+        online_quant_streamer.replay_stragglers_and_report(_is_rank0())
 
     has_online_quant = any(
         getattr(m, "online_quant", False)
@@ -300,12 +317,40 @@ def load_model(
         )
         for _, m in model.named_modules()
     )
-    if has_online_quant:
-        logger.info("Weight post-processing started (includes online quantization)")
+    streamed_done = (
+        online_quant_streamer.done_module_ids
+        if online_quant_streamer is not None
+        else frozenset()
+    )
+    stream_candidate_count = (
+        len(online_quant_streamer.candidates)
+        if online_quant_streamer is not None
+        else 0
+    )
+    stream_fallback_count = stream_candidate_count - len(streamed_done)
+    if online_quant_streamer is not None:
+        logger.info(
+            "[%s] Streaming online quantization: %d/%d eligible modules were "
+            "quantized while loading; the post-load pass remains enabled to "
+            "quantize %d fallback module(s) and finish weight processing",
+            rank_tag(),
+            len(streamed_done),
+            stream_candidate_count,
+            stream_fallback_count,
+        )
+    elif has_online_quant:
+        logger.info(
+            "[%s] Post-load online quantization and weight processing started",
+            rank_tag(),
+        )
     pp_start = time.perf_counter()
 
     for module_name, module in model.named_modules():
-        if hasattr(module, "process_weights_after_loading"):
+        # Avoid repeating module post-processing already run by the streamer.
+        if (
+            hasattr(module, "process_weights_after_loading")
+            and id(module) not in streamed_done
+        ):
             module.process_weights_after_loading()
         quant_method = getattr(module, "quant_method", None)
 
@@ -329,6 +374,11 @@ def load_model(
     # the load time the caller reports, so it is timed unconditionally: without
     # this line a shuffle-dominated load is indistinguishable from a slow read.
     pp_elapsed = time.perf_counter() - pp_start
+    peak_gpu_memory_gb = (
+        torch.cuda.max_memory_allocated() / (1 << 30)
+        if torch.cuda.is_available()
+        else None
+    )
     if not has_online_quant:
         logger.info(
             "[%s] Weight post-processing done: %.2f seconds",
@@ -346,18 +396,59 @@ def load_model(
                 qc = getattr(module, "quant_config", None)
                 if qc is not None and hasattr(qc, "online_quant_config_raw"):
                     raw_online_quant_config = qc.online_quant_config_raw
-        logger.info(
-            "[%s] Weight post-processing done: %.2f seconds, "
-            "%d layers online-quantized",
-            rank_tag(),
-            pp_elapsed,
-            len(oq_layers),
-        )
+        if online_quant_streamer is not None:
+            logger.info(
+                "[%s] Post-stream fallback and weight processing done: %.2f "
+                "seconds; %d module(s) quantized while loading, %d fallback "
+                "module(s) quantized after loading, %d layers online-quantized "
+                "in total",
+                rank_tag(),
+                pp_elapsed,
+                len(streamed_done),
+                stream_fallback_count,
+                len(oq_layers),
+            )
+            timing_scope = "post_stream_fallback_and_weight_processing"
+        else:
+            logger.info(
+                "[%s] Post-load online quantization and weight processing done: "
+                "%.2f seconds, %d layers online-quantized",
+                rank_tag(),
+                pp_elapsed,
+                len(oq_layers),
+            )
+            timing_scope = "post_load_online_quantization_and_weight_processing"
         _save_online_quant_info(
             oq_layers,
             model_name_or_path,
             pp_elapsed,
             raw_online_quant_config or {},
+            timing_scope,
+            peak_gpu_memory_gb,
         )
+
+    # Measure both loading and post-processing for comparable peak memory.
+    if peak_gpu_memory_gb is not None:
+        if online_quant_streamer is not None:
+            logger.info(
+                "[%s] Peak GPU memory during streaming weight loading and "
+                "online quantization: %.2f GB",
+                rank_tag(),
+                peak_gpu_memory_gb,
+            )
+        elif has_online_quant:
+            logger.info(
+                "[%s] Peak GPU memory during weight loading and post-load "
+                "online quantization: %.2f GB",
+                rank_tag(),
+                peak_gpu_memory_gb,
+            )
+        else:
+            logger.info(
+                "[%s] Peak GPU memory during weight loading and "
+                "post-processing: %.2f GB",
+                rank_tag(),
+                peak_gpu_memory_gb,
+            )
 
     return loaded_weights_record

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -283,6 +283,9 @@ def load_model(
         torch.cuda.reset_peak_memory_stats()
 
     # Quantize eligible modules as soon as their source weights complete.
+    # This must also run for speculative draft loads: those modules were built
+    # with the same meta-backed streaming parameters as the target. `spec_decode`
+    # only changes checkpoint-name selection; it must not disable materialization.
     online_quant_streamer = OnlineQuantStreamer.maybe_create(model, load_dummy)
 
     loaded_weights_record = load_weights_into_model(

--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -348,6 +348,9 @@ def load_model(
         )
     pp_start = time.perf_counter()
 
+    # Parent-first traversal is significant for streaming-deferred children:
+    # their parent first combines source weights, then the child's normal hook
+    # online-quantizes the final fused weight.
     for module_name, module in model.named_modules():
         # Avoid repeating module post-processing already run by the streamer.
         if (

--- a/atom/model_loader/loading_core.py
+++ b/atom/model_loader/loading_core.py
@@ -17,6 +17,7 @@ import logging
 import os
 import time
 from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
 
 import torch
 from torch import nn
@@ -30,6 +31,9 @@ from atom.model_loader.weight_names import (
     WeightsMapper,
 )
 from atom.utils import envs
+
+if TYPE_CHECKING:
+    from atom.model_loader.online_quant_streaming import OnlineQuantStreamer
 
 logger = logging.getLogger("atom")
 
@@ -98,6 +102,7 @@ def load_weights_into_model(
     fuse_shared_expert: Callable[[str, str], bool],
     is_rank0: Callable[[], bool],
     weights_iterator: Callable[..., Iterable[tuple[str, torch.Tensor]]],
+    online_quant_streamer: "OnlineQuantStreamer | None" = None,
 ) -> set[str]:
     """Copy every checkpoint tensor into the model parameter it belongs to.
 
@@ -108,6 +113,8 @@ def load_weights_into_model(
     - ``fuse_shared_expert``     ``(shared_prefix, routed_prefix) -> fuse?``
     - ``is_rank0``               suppress duplicate diagnostics off rank 0
     - ``weights_iterator``       ``(path, disable_mmap, wants) -> (name, tensor)``
+
+    ``online_quant_streamer`` tracks module completion during loading.
     """
 
     def _n_routed_experts() -> int | None:
@@ -154,6 +161,8 @@ def load_weights_into_model(
         ),
     )
     params_dict = dict(model.named_parameters())
+    if online_quant_streamer is not None:
+        online_quant_streamer.bind_params_dict(params_dict)
     # Pre-index expert_mapping by weight_name_part for O(1) lookup.
     # Original code does O(N) scan of expert_mapping (768 entries) per tensor,
     # causing ~19s of CPU time for 90k expert tensors. This reduces it to O(1).
@@ -185,6 +194,9 @@ def load_weights_into_model(
     staging_pool = ExpertStagingPool(_lookup_moe_module)
 
     num_threads = envs.ATOM_LOADER_NUM_THREADS
+    if online_quant_streamer is not None:
+        num_threads = online_quant_streamer.resolve_num_threads(num_threads)
+        online_quant_streamer.setup_online_quant_pool()
     if num_threads > 1:
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=num_threads)
     else:
@@ -192,7 +204,13 @@ def load_weights_into_model(
     futures = []
 
     def _submit(fn, *args):
-        if executor is not None:
+        # All streamed writes pass through `run` for completion tracking.
+        if online_quant_streamer is not None:
+            if executor is None:
+                online_quant_streamer.run(fn, args)
+            else:
+                futures.append(executor.submit(online_quant_streamer.run, fn, args))
+        elif executor is not None:
             futures.append(executor.submit(fn, *args))
         else:
             fn(*args)
@@ -205,7 +223,7 @@ def load_weights_into_model(
         spec_decode=spec_decode,
         submit=_submit,
         staging_pool=staging_pool,
-        batching_enabled=executor is not None,
+        batching_enabled=executor is not None and online_quant_streamer is None,
         default_weight_loader=default_weight_loader,
         packed_modules_mapping=packed_modules_mapping,
         expert_index=expert_index,
@@ -214,6 +232,11 @@ def load_weights_into_model(
         detect_fused_expert_fn=getattr(model, "detect_fused_expert_format", None),
         get_fused_expert_mapping_fn=getattr(model, "get_fused_expert_mapping", None),
         load_fused_expert_weights_fn=load_fused_expert_weights_fn,
+        on_fused_param=(
+            None
+            if online_quant_streamer is None
+            else online_quant_streamer.materialize_fused_param
+        ),
     )
 
     # Rewriting a name is the same question as "is this tensor wanted", and the
@@ -239,7 +262,7 @@ def load_weights_into_model(
     # races ahead of the work it queues, so a small `read+queue` next to a large
     # `drain` locates the cost in the workers rather than in the read.
     num_tensors = 0
-    t_read = t_drain = t_flush = 0.0
+    t_read = t_drain = t_quant_drain = t_flush = 0.0
 
     try:
         disable_mmap = envs.ATOM_DISABLE_MMAP
@@ -273,6 +296,12 @@ def load_weights_into_model(
                 future.result()
         t_drain = time.perf_counter() - _t0
 
+        # Measure the non-overlapped streaming tail.
+        if online_quant_streamer is not None:
+            _t0 = time.perf_counter()
+            online_quant_streamer.drain()
+            t_quant_drain = time.perf_counter() - _t0
+
         loaded_weights_record = dispatcher.loaded_weights_record
         dropped_ckpt_keys = dispatcher.dropped_ckpt_keys
 
@@ -300,19 +329,35 @@ def load_weights_into_model(
     finally:
         if executor is not None:
             executor.shutdown(wait=True)
+        if online_quant_streamer is not None:
+            online_quant_streamer.shutdown()
 
     # Every rank logs its own line: the spread between ranks is itself one of
     # the things these numbers exist to explain.
-    logger.info(
-        "[%s] load phases: read+queue %.2fs (%d tensors) | drain %.2fs | "
-        "staging flush %.2fs | threads %d",
-        rank_tag(),
-        t_read,
-        num_tensors,
-        t_drain,
-        t_flush,
-        num_threads,
-    )
+    if online_quant_streamer is not None:
+        logger.info(
+            "[%s] weight load phases (including streaming online quant): "
+            "read+queue %.2fs (%d tensors) | drain %.2fs | quant drain %.2fs | "
+            "staging flush %.2fs | threads %d",
+            rank_tag(),
+            t_read,
+            num_tensors,
+            t_drain,
+            t_quant_drain,
+            t_flush,
+            num_threads,
+        )
+    else:
+        logger.info(
+            "[%s] weight load phases: read+queue %.2fs (%d tensors) | "
+            "drain %.2fs | staging flush %.2fs | threads %d",
+            rank_tag(),
+            t_read,
+            num_tensors,
+            t_drain,
+            t_flush,
+            num_threads,
+        )
 
     _report_coverage(
         loaded_weights_record=loaded_weights_record,
@@ -323,6 +368,8 @@ def load_weights_into_model(
     )
 
     # Avoid holding stale Parameter refs that prevent storage release.
+    if online_quant_streamer is not None:
+        online_quant_streamer.release_params_dict()
     del params_dict
 
     return loaded_weights_record

--- a/atom/model_loader/loading_core.py
+++ b/atom/model_loader/loading_core.py
@@ -215,6 +215,10 @@ def load_weights_into_model(
         else:
             fn(*args)
 
+    batching_excluded = None
+    if online_quant_streamer is not None:
+        batching_excluded = online_quant_streamer.manages_param
+
     dispatcher = WeightDispatcher(
         model=model,
         params_dict=params_dict,
@@ -223,7 +227,14 @@ def load_weights_into_model(
         spec_decode=spec_decode,
         submit=_submit,
         staging_pool=staging_pool,
-        batching_enabled=executor is not None and online_quant_streamer is None,
+        # The streamer and ExpertStagingPool own disjoint parameters. Streamed
+        # parameters use the streamer's host staging so they can be quantized
+        # and released as soon as their module completes. Non-streamed expert
+        # parameters still need ExpertStagingPool; globally disabling it when a
+        # streamer exists turns large per-expert checkpoints into tens of
+        # thousands of small loader/H2D operations.
+        batching_enabled=executor is not None,
+        batching_excluded=batching_excluded,
         default_weight_loader=default_weight_loader,
         packed_modules_mapping=packed_modules_mapping,
         expert_index=expert_index,

--- a/atom/model_loader/online_quant_streaming.py
+++ b/atom/model_loader/online_quant_streaming.py
@@ -172,6 +172,8 @@ class OnlineQuantStreamer:
         if module is None:
             fn(*args)
             return
+        if self._is_nonlocal_expert_arrival(module, fn, args):
+            return
         if module._stream_claimed:
             # Never overwrite quantized storage with a late source arrival.
             self.excessive_loads.append(
@@ -206,6 +208,16 @@ class OnlineQuantStreamer:
                 module._stream_claimed = True
         if claimed:
             self._submit_finalize(module)
+
+    @staticmethod
+    def _is_nonlocal_expert_arrival(module, fn, args) -> bool:
+        """Whether a claimed EP module can ignore this checkpoint arrival."""
+        return (
+            len(args) >= 5
+            and getattr(fn, "__self__", None) is module
+            and hasattr(module, "_map_global_expert_id_to_local_expert_id")
+            and module._map_global_expert_id_to_local_expert_id(args[4]) == -1
+        )
 
     def _run_counted(self, module, param, fn, args) -> _CopyCounter:
         """Apply one loader call and return its logical or physical coverage."""

--- a/atom/model_loader/online_quant_streaming.py
+++ b/atom/model_loader/online_quant_streaming.py
@@ -54,10 +54,21 @@ class OnlineQuantStreamer:
         ]
         if not candidates:
             return None
-        return cls(candidates)
+        deferred_module_ids = {
+            id(child)
+            for parent in model.modules()
+            if hasattr(parent, "get_streaming_deferred_modules")
+            for child in parent.get_streaming_deferred_modules()
+        }
+        return cls(candidates, deferred_module_ids)
 
-    def __init__(self, candidates: list[tuple[str, nn.Module]]):
+    def __init__(
+        self,
+        candidates: list[tuple[str, nn.Module]],
+        deferred_module_ids: set[int] | None = None,
+    ):
         self.candidates = candidates
+        self.deferred_module_ids = deferred_module_ids or set()
         self.param_to_module: dict[int, nn.Module] = {}
         # Claimed modules no longer accept loader arrivals.
         self.done_module_ids: set[int] = set()
@@ -210,7 +221,11 @@ class OnlineQuantStreamer:
             )
             if claimed:
                 module._stream_claimed = True
-        if claimed:
+        # Some child modules must keep their source weights until a parent
+        # post-load hook has combined them. They still use host staging here,
+        # but intentionally fall back to the ordered post-load pass for
+        # finalization and quantization.
+        if claimed and id(module) not in self.deferred_module_ids:
             self._submit_finalize(module)
 
     @staticmethod

--- a/atom/model_loader/online_quant_streaming.py
+++ b/atom/model_loader/online_quant_streaming.py
@@ -1,0 +1,477 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Stream online quantization module by module during checkpoint loading.
+
+Eligible parameters start on meta, stage arrivals on the host, then move to the
+device, quantize, and release their source storage once complete.
+"""
+
+import concurrent.futures
+import logging
+import threading
+
+import torch
+import torch.utils._python_dispatch
+from torch import nn
+
+from atom.utils import envs
+
+logger = logging.getLogger("atom")
+
+_HOST = torch.device("cpu")
+
+
+class _CopyCounter(torch.utils._python_dispatch.TorchDispatchMode):
+    """Count elements written by ``aten.copy_`` in the current thread."""
+
+    def __init__(self):
+        super().__init__()
+        self.copied_numel = 0
+        self.moe_arrival = None
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if func is torch.ops.aten.copy_.default:
+            assert args[0].numel() == args[1].numel()
+            self.copied_numel += args[0].numel()
+        return func(*args, **kwargs)
+
+
+class OnlineQuantStreamer:
+    """Per-load state for streaming online quantization."""
+
+    @classmethod
+    def maybe_create(cls, model: nn.Module, load_dummy: str | None):
+        """Return a streamer when enabled and applicable."""
+        if not envs.ATOM_ONLINE_QUANT_STREAMING or load_dummy:
+            return None
+        candidates = [
+            (mod_name, m)
+            for mod_name, m in model.named_modules()
+            if getattr(m, "_stream_online_quant", False)
+        ]
+        if not candidates:
+            return None
+        return cls(candidates)
+
+    def __init__(self, candidates: list[tuple[str, nn.Module]]):
+        self.candidates = candidates
+        self.param_to_module: dict[int, nn.Module] = {}
+        # Claimed modules no longer accept loader arrivals.
+        self.done_module_ids: set[int] = set()
+        self.excessive_loads: list[str] = []
+
+        self._host_staging = envs.ATOM_ONLINE_QUANT_STREAMING_HOST_STAGING
+        # Module claims are decided under each module's lock.
+        self._done_lock = threading.Lock()
+        self._params_dict: dict | None = None
+        self._executor: concurrent.futures.ThreadPoolExecutor | None = None
+        self._futures: list = []
+        # Bound the executor's otherwise-unbounded queue and its memory usage.
+        self._slots: threading.Semaphore | None = None
+        # Side streams avoid serializing workers on the default stream.
+        self._worker_stream = threading.local()
+
+        for mod_name, m in candidates:
+            # Coverage comes from copy counts or explicit MoE regions.
+            m._stream_loaded_numel = 0
+            # Protects storage materialization and coverage accounting.
+            m._stream_lock = threading.Lock()
+            m._stream_claimed = False
+            m._stream_on_host = self._host_staging
+            # Used only when loader calls must be replayed from meta.
+            m._stream_buffer_list = []
+            # Published after materialization under `_stream_lock`.
+            m._stream_materialized_param_ids = set()
+            # Names of source parameters released by `_finalize`.
+            m._stream_param_names = [
+                (f"{mod_name}.{p_name}" if mod_name else p_name, p_name)
+                for p_name, p in m.named_parameters(recurse=False)
+                if p is not None
+            ]
+            # Per-parameter `(expert, shard)` coverage from ExpertStagingPool.
+            m._stream_moe_arrivals = {}
+            # Mixed semantic and generic accounting cannot trigger early.
+            m._stream_moe_declined_param_ids = set()
+            m._stream_tracking_invalid = False
+            m._stream_expected_numel = sum(
+                p.numel() for _, p in m.named_parameters(recurse=False) if p is not None
+            )
+            for _, p in m.named_parameters(recurse=False):
+                if p is not None:
+                    self.param_to_module[id(p)] = m
+
+    # ── loading-loop wiring ───────────────────────────────────────────────
+
+    def bind_params_dict(self, params_dict: dict) -> None:
+        self._params_dict = params_dict
+
+    def release_params_dict(self) -> None:
+        """Drop the params_dict ref so its Parameters can be collected."""
+        self._params_dict = None
+
+    def resolve_num_threads(self, num_threads: int) -> int:
+        """Use concurrent checkpoint loading only with host staging."""
+        if self._host_staging:
+            return num_threads
+        if num_threads > 1:
+            tail_threads = envs.ATOM_ONLINE_QUANT_STREAMING_THREADS
+            logger.info(
+                "Online-quant streaming enabled: the checkpoint walk runs "
+                "single-threaded; per-module quantization %s.",
+                (
+                    f"is offloaded to {tail_threads} worker thread(s)"
+                    if tail_threads > 0
+                    else "runs inline on the walking thread"
+                ),
+            )
+        return 1
+
+    def setup_online_quant_pool(self) -> None:
+        """Create the module-finalization pool.
+
+        Worker threads must set their CUDA device and use independent streams.
+        """
+        num_workers = envs.ATOM_ONLINE_QUANT_STREAMING_THREADS
+        if num_workers <= 0:
+            return
+        device = torch.cuda.current_device() if torch.cuda.is_available() else None
+        worker_stream = self._worker_stream
+
+        def _worker_init():
+            if device is not None:
+                torch.cuda.set_device(device)
+                worker_stream.s = torch.cuda.Stream(device=device)
+
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=num_workers,
+            thread_name_prefix="atom-stream-quant",
+            initializer=_worker_init,
+        )
+        self._slots = threading.Semaphore(2 * num_workers)
+
+    def drain(self) -> None:
+        """Wait for all finalizers and surface worker exceptions."""
+        for future in concurrent.futures.as_completed(self._futures):
+            future.result()
+        self._futures.clear()
+
+    def shutdown(self) -> None:
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None
+
+    # ── trigger ───────────────────────────────────────────────────────────
+
+    def run(self, fn, args) -> None:
+        """Run one loader call and record its physical or logical coverage."""
+        param = args[0] if args else None
+        module = self.param_to_module.get(id(param)) if param is not None else None
+        if module is None:
+            fn(*args)
+            return
+        if module._stream_claimed:
+            # Never overwrite quantized storage with a late source arrival.
+            self.excessive_loads.append(
+                getattr(module, "prefix", type(module).__name__)
+            )
+            return
+        counter = self._run_counted(module, param, fn, args)
+        with module._stream_lock:
+            moe_arrival = counter.moe_arrival
+            if moe_arrival is not None:
+                param_id, region, covered_numel = moe_arrival
+                if param_id in module._stream_moe_declined_param_ids:
+                    # A concurrent decline invalidated semantic accounting.
+                    module._stream_tracking_invalid = True
+                elif region is not None:
+                    filled = module._stream_moe_arrivals.setdefault(param_id, set())
+                    if region not in filled:
+                        filled.add(region)
+                        module._stream_loaded_numel += covered_numel
+            else:
+                # Repeated copies into one parameter must not claim it early.
+                module._stream_loaded_numel += min(
+                    counter.copied_numel,
+                    param.numel(),
+                )
+            claimed = (
+                not module._stream_tracking_invalid
+                and module._stream_loaded_numel >= module._stream_expected_numel
+                and not module._stream_claimed
+            )
+            if claimed:
+                module._stream_claimed = True
+        if claimed:
+            self._submit_finalize(module)
+
+    def _run_counted(self, module, param, fn, args) -> _CopyCounter:
+        """Apply one loader call and return its logical or physical coverage."""
+        deferred = self._ensure_storage_or_defer(module, param)
+        # MoE fast path
+        if not deferred:
+            try:
+                moe_arrival = self._try_stage_expert_arrival(module, param, fn, args)
+            except NotImplementedError:
+                if not module._stream_on_host:
+                    raise
+                # Retry on the load device when the CPU lacks a kernel.
+                self._settle_on_device(module)
+                moe_arrival = self._try_stage_expert_arrival(module, param, fn, args)
+            if moe_arrival is not None:
+                counter = _CopyCounter()
+                counter.moe_arrival = moe_arrival
+                return counter
+
+        # Generic path
+        counter = _CopyCounter()
+        try:
+            with counter:
+                fn(*args)
+        except NotImplementedError:
+            # Preserve staged data and retry where the dtype has kernels.
+            if not module._stream_on_host:
+                raise
+            self._settle_on_device(module)
+            counter = _CopyCounter()
+            with counter:
+                fn(*args)
+        if deferred:
+            module._stream_buffer_list.append((fn, args))
+        return counter
+
+    def _try_stage_expert_arrival(self, module, param, fn, args):
+        """Try the ExpertStagingPool semantic protocol on stream storage."""
+        if (
+            len(args) < 5
+            or getattr(fn, "__self__", None) is not module
+            or not hasattr(module, "stage_expert_weight")
+            or not hasattr(module, "expected_batched_arrivals")
+            or not hasattr(module, "_map_global_expert_id_to_local_expert_id")
+            or not hasattr(module, "is_batched_expert_slot")
+            or not hasattr(module, "batched_expert_region_numel")
+        ):
+            return None
+
+        param_id = id(param)
+        if param_id in module._stream_moe_declined_param_ids:
+            return None
+
+        _, loaded_weight, weight_name, shard_id, global_expert_id = args[:5]
+        expected = module.expected_batched_arrivals(param)
+        if not expected:
+            return None
+
+        local_expert_id = module._map_global_expert_id_to_local_expert_id(
+            global_expert_id
+        )
+        if local_expert_id == -1:
+            return (param_id, None, 0)
+        if not module.is_batched_expert_slot(local_expert_id):
+            return None
+
+        staged = module.stage_expert_weight(
+            param=param,
+            staging=param.data,
+            loaded_weight=loaded_weight,
+            local_expert_id=local_expert_id,
+            shard_id=shard_id,
+            weight_name=weight_name,
+        )
+        if staged:
+            covered_numel = module.batched_expert_region_numel(
+                param,
+                local_expert_id,
+                shard_id,
+            )
+            return (
+                param_id,
+                (local_expert_id, shard_id),
+                covered_numel,
+            )
+
+        # False means no bytes were written, so generic fallback is safe.
+        with module._stream_lock:
+            module._stream_moe_declined_param_ids.add(param_id)
+            if module._stream_moe_arrivals.get(param_id):
+                module._stream_tracking_invalid = True
+        return None
+
+    def materialize_fused_param(self, param: nn.Parameter) -> None:
+        """Materialize a fused parameter whose loader bypasses ``run``."""
+        param_id = id(param)
+        module = self.param_to_module.get(param_id)
+        if module is None:
+            return
+        with module._stream_lock:
+            # Fused writes have no semantic coverage, so force post-load fallback.
+            module._stream_moe_declined_param_ids.add(param_id)
+            module._stream_tracking_invalid = True
+            if param.data.is_meta:
+                self._materialize_meta_to_host_or_device(param, module._load_device)
+            elif param.data.device != module._load_device:
+                self._swap_storage(param, param.data.to(module._load_device))
+            module._stream_materialized_param_ids.add(param_id)
+
+    # ── tail ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _swap_storage(param: nn.Parameter, buf: torch.Tensor) -> None:
+        """Replace storage while preserving the Parameter object and attributes.
+
+        Copy attributes before ``swap_tensors`` so concurrent dispatch never
+        observes a missing ``weight_loader``.
+        """
+        replacement = nn.Parameter(buf, requires_grad=param.requires_grad)
+        replacement.__dict__.update(param.__dict__)
+        torch.utils.swap_tensors(param, replacement)
+
+    @classmethod
+    def _materialize_meta_to_host_or_device(cls, param: nn.Parameter, device) -> None:
+        """Materialize zeroed storage, including unwritten padding bytes."""
+        buf = torch.empty(tuple(param.shape), dtype=param.dtype, device=device)
+        buf.view(torch.uint8).zero_()
+        cls._swap_storage(param, buf)
+
+    def _ensure_storage_or_defer(self, module: nn.Module, param: nn.Parameter) -> bool:
+        """Materialize host storage or defer the loader call for replay.
+
+        Storage inspection and swapping stay under the module lock so racing
+        arrivals cannot discard each other's writes.
+        """
+        param_id = id(param)
+        if param_id in module._stream_materialized_param_ids:
+            return False
+        with module._stream_lock:
+            # Recheck after waiting before touching a possibly swapped TensorImpl.
+            if param_id in module._stream_materialized_param_ids:
+                return False
+            if not param.data.is_meta:
+                module._stream_materialized_param_ids.add(param_id)
+                return False
+            if not module._stream_on_host:
+                return True
+            self._materialize_meta_to_host_or_device(param, _HOST)
+            module._stream_materialized_param_ids.add(param_id)
+            return False
+
+    def _settle_on_device(self, module: nn.Module) -> None:
+        """Move staged parameters to the module's load device."""
+        device = module._load_device
+        with module._stream_lock:
+            if not module._stream_on_host:
+                return
+            module._stream_on_host = False
+            for _, p in module.named_parameters(recurse=False):
+                if p is not None and not p.data.is_meta and p.data.device != device:
+                    self._swap_storage(p, p.data.to(device))
+                if p is not None and not p.data.is_meta:
+                    module._stream_materialized_param_ids.add(id(p))
+
+    def _materialize_and_replay(self, module: nn.Module) -> None:
+        """Materialize remaining parameters and replay deferred loader calls."""
+        for _, p in module.named_parameters(recurse=False):
+            if p is not None and p.data.is_meta:
+                self._materialize_meta_to_host_or_device(p, module._load_device)
+            if p is not None:
+                module._stream_materialized_param_ids.add(id(p))
+        for fn, args in module._stream_buffer_list:
+            fn(*args)
+        module._stream_buffer_list.clear()
+
+    def _settle_weights(self, module: nn.Module) -> None:
+        """Give the module device storage holding everything that arrived."""
+        self._settle_on_device(module)
+        self._materialize_and_replay(module)
+
+    def _finalize(self, module: nn.Module) -> None:
+        """Move, quantize, and release one completed module."""
+        self._settle_weights(module)
+        module.process_weights_after_loading()
+        # Keep stale objects alive for id-based lookup, but release their storage.
+        params_dict = self._params_dict
+        if params_dict is None:
+            return
+        for full_name, p_name in module._stream_param_names:
+            stale = params_dict.get(full_name)
+            if stale is not None and stale is not getattr(module, p_name, None):
+                stale.data = torch.empty(0, dtype=stale.dtype, device=stale.device)
+
+    def _submit_finalize(self, module: nn.Module) -> None:
+        """Hand a completed module to the tail workers and return immediately."""
+        # Mark claimed before the worker starts to prevent double post-processing.
+        with self._done_lock:
+            self.done_module_ids.add(id(module))
+        if self._executor is None:
+            self._finalize(module)
+            return
+
+        def _task():
+            try:
+                s = getattr(self._worker_stream, "s", None)
+                if s is None:
+                    self._finalize(module)
+                else:
+                    with torch.cuda.stream(s):
+                        self._finalize(module)
+                    s.synchronize()
+            finally:
+                # Always release the slot so worker failures cannot deadlock loading.
+                self._slots.release()
+
+        self._slots.acquire()
+        self._futures.append(self._executor.submit(_task))
+
+    # ── post-load report ──────────────────────────────────────────────────
+
+    def replay_stragglers_and_report(self, is_rank0: bool) -> None:
+        """Settle unclaimed modules and report coverage fallbacks."""
+        stranded = []
+        for mod_name, m in self.candidates:
+            # Detect missing params before `_settle_weights` zero-fills them.
+            targeted = {id(a[0]) for _, a in m._stream_buffer_list}
+            for p_name, p in m.named_parameters(recurse=False):
+                if p.data.is_meta and id(p) not in targeted:
+                    stranded.append(f"{mod_name}.{p_name}")
+            self._settle_weights(m)
+
+        fell_back = [n for n, m in self.candidates if id(m) not in self.done_module_ids]
+        if not is_rank0:
+            return
+        if stranded:
+            logger.warning(
+                "Online-quant streaming: %d parameter(s) were never loaded "
+                "and stayed on the meta device; they have been zero-filled "
+                "so post-processing can run, but the model is almost "
+                "certainly wrong. First %d: %s",
+                len(stranded),
+                min(len(stranded), 20),
+                stranded[:20],
+            )
+        if self.excessive_loads:
+            unique = sorted(set(self.excessive_loads))
+            logger.warning(
+                "Online-quant streaming: dropped %d load(s) that arrived "
+                "after their module was already quantized, across %d "
+                "module(s). The checkpoint supplies more elements for these "
+                "than _stream_expected_numel accounts for, so the surplus cannot "
+                "be stored; verify the expected-size computation. First "
+                "%d: %s",
+                len(self.excessive_loads),
+                len(unique),
+                min(len(unique), 20),
+                unique[:20],
+            )
+        log = logger.warning if fell_back else logger.info
+        log(
+            "Online-quant streaming: %d/%d eligible modules quantized during "
+            "load, %d fell back to the post-load pass (no memory saving for "
+            "those). First %d fallbacks: %s",
+            len(self.candidates) - len(fell_back),
+            len(self.candidates),
+            len(fell_back),
+            min(len(fell_back), 20),
+            fell_back[:20],
+        )

--- a/atom/model_loader/online_quant_streaming.py
+++ b/atom/model_loader/online_quant_streaming.py
@@ -105,6 +105,10 @@ class OnlineQuantStreamer:
 
     # ── loading-loop wiring ───────────────────────────────────────────────
 
+    def manages_param(self, param: nn.Parameter) -> bool:
+        """Whether this parameter belongs to a streamed quantization module."""
+        return id(param) in self.param_to_module
+
     def bind_params_dict(self, params_dict: dict) -> None:
         self._params_dict = params_dict
 

--- a/atom/model_loader/online_quant_streaming.py
+++ b/atom/model_loader/online_quant_streaming.py
@@ -30,6 +30,13 @@ class _CopyCounter(torch.utils._python_dispatch.TorchDispatchMode):
         self.copied_numel = 0
         self.moe_arrival = None
 
+    @classmethod
+    def ignore_compile_internals(cls) -> bool:
+        # TorchDispatchMode keeps its compile-internal state in process-global
+        # booleans. Concurrent counter scopes can restore those booleans out of
+        # order and leave Dynamo believing that a mode is still active.
+        return True
+
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}

--- a/atom/model_loader/weight_dispatch.py
+++ b/atom/model_loader/weight_dispatch.py
@@ -52,6 +52,7 @@ class WeightDispatcher:
         submit: Callable[..., None],
         staging_pool: Any,
         batching_enabled: bool,
+        batching_excluded: Callable[[nn.Parameter], bool] | None,
         default_weight_loader: Callable,
         packed_modules_mapping: Mapping[str, Any],
         expert_index: Mapping[str, tuple[str, int, str]],
@@ -70,6 +71,7 @@ class WeightDispatcher:
         self.submit = submit
         self.staging_pool = staging_pool
         self.batching_enabled = batching_enabled
+        self.batching_excluded = batching_excluded
         self.default_weight_loader = default_weight_loader
         self.packed_modules_mapping = packed_modules_mapping
         self.expert_index = expert_index
@@ -224,7 +226,14 @@ class WeightDispatcher:
                 # Parameter absent from model (e.g. weight scales for an
                 # unquantized drafter MTP block); skip silently.
                 return True, name
-            if self.batching_enabled and self.staging_pool.is_batchable(param, name):
+            batching_excluded = (
+                self.batching_excluded is not None and self.batching_excluded(param)
+            )
+            if (
+                self.batching_enabled
+                and not batching_excluded
+                and self.staging_pool.is_batchable(param, name)
+            ):
                 self.submit(
                     self.staging_pool.stage, param, name, shard_id, expert_id, tensor
                 )

--- a/atom/model_loader/weight_dispatch.py
+++ b/atom/model_loader/weight_dispatch.py
@@ -60,6 +60,7 @@ class WeightDispatcher:
         detect_fused_expert_fn: Callable[[str], bool] | None,
         get_fused_expert_mapping_fn: Callable[[], Sequence[tuple]] | None,
         load_fused_expert_weights_fn: Callable | None,
+        on_fused_param: Callable[[nn.Parameter], None] | None = None,
     ):
         self.model = model
         self.params_dict = params_dict
@@ -77,6 +78,8 @@ class WeightDispatcher:
         self.detect_fused_expert_fn = detect_fused_expert_fn
         self.get_fused_expert_mapping_fn = get_fused_expert_mapping_fn
         self.load_fused_expert_weights_fn = load_fused_expert_weights_fn
+        # Fused writes bypass `submit` and need storage prepared first.
+        self.on_fused_param = on_fused_param
 
         self.loaded_weights_record: set[str] = set()
         self.dropped_ckpt_keys: list[tuple[str, str]] = []
@@ -181,6 +184,8 @@ class WeightDispatcher:
             # the staging pool must not also own it -- see ExpertStagingPool's
             # ownership rule.
             self.staging_pool.decline(self.params_dict[name_mapped])
+            if self.on_fused_param is not None:
+                self.on_fused_param(self.params_dict[name_mapped])
 
             # Generic call - model provides implementation details
             num_experts = getattr(self.hf_config, "n_routed_experts", 0) or getattr(
@@ -194,7 +199,7 @@ class WeightDispatcher:
                 shard_id,
                 num_experts,
             ):
-                self._record(name)
+                self._record(name_mapped)
                 return True
         return False
 

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -32,7 +32,11 @@ from atom.model_ops.utils import (
     requantize_with_max_scale,
     shuffle_weights,
 )
-from atom.quant_spec import LayerQuantConfig, should_skip_online_quant
+from atom.quant_spec import (
+    LayerQuantConfig,
+    should_skip_online_quant,
+    should_stream_online_quant,
+)
 from atom.quantization.quark.utils import (
     dequant_weight_online,
     quant_weight_online,
@@ -467,10 +471,20 @@ class LinearBase(nn.Module):
                 divide(s, self.tp_size) for s in self.output_partition_sizes
             ]
 
+        # Stream eligible source weights through meta storage.
+        self._stream_online_quant = self.source_quant_dtype is None and (
+            should_stream_online_quant(quant_config, prefix, quant_type, params_dtype)
+        )
+        # The default device may be reset before loading starts.
+        self._load_device = torch.empty(0).device if self._stream_online_quant else None
+        param_device = "meta" if self._stream_online_quant else None
+
         if self.source_quant_dtype is not None:
             weight_size = (self.output_size, self.input_size)
             self.weight = atom_parameter(
-                torch.empty(weight_size, dtype=self.source_quant_dtype)
+                torch.empty(
+                    weight_size, dtype=self.source_quant_dtype, device=param_device
+                )
             )
         else:
             weight_size = (
@@ -478,10 +492,14 @@ class LinearBase(nn.Module):
                 if params_dtype not in [dtypes.fp4x2, dtypes.i4x2]
                 else (self.output_size, self.input_size // 2)
             )
-            self.weight = atom_parameter(torch.empty(weight_size, dtype=params_dtype))
+            self.weight = atom_parameter(
+                torch.empty(weight_size, dtype=params_dtype, device=param_device)
+            )
         if bias:
             output_type = get_current_atom_config().torch_dtype
-            self.bias = atom_parameter(torch.empty(self.output_size, dtype=output_type))
+            self.bias = atom_parameter(
+                torch.empty(self.output_size, dtype=output_type, device=param_device)
+            )
             self.bias.weight_loader_process = self.weight_loader_process
         else:
             self.register_parameter("bias", None)
@@ -491,19 +509,29 @@ class LinearBase(nn.Module):
         if quant_type != QuantType.No and self.source_quant_dtype is None:
             if quant_type == QuantType.per_Tensor:
                 self.weight_scale = atom_parameter(
-                    torch.empty(len(self.output_partition_sizes), 1, dtype=dtypes.fp32)
+                    torch.empty(
+                        len(self.output_partition_sizes),
+                        1,
+                        dtype=dtypes.fp32,
+                        device=param_device,
+                    )
                 )
                 if not layer_quant_config.is_dynamic:
                     self.input_scale = atom_parameter(
                         torch.empty(
-                            len(self.output_partition_sizes), 1, dtype=dtypes.fp32
+                            len(self.output_partition_sizes),
+                            1,
+                            dtype=dtypes.fp32,
+                            device=param_device,
                         )
                     )
                     self.input_scale.weight_loader_process = self.weight_loader_process
                     self.input_scale.weight_loader = self.weight_loader
             elif quant_type == QuantType.per_Token:
                 self.weight_scale = atom_parameter(
-                    torch.empty(self.output_size, 1, dtype=dtypes.fp32)
+                    torch.empty(
+                        self.output_size, 1, dtype=dtypes.fp32, device=param_device
+                    )
                 )
             elif quant_type == QuantType.per_1x128:
                 scale_dtype = (
@@ -516,6 +544,7 @@ class LinearBase(nn.Module):
                         (self.output_size + 127) // 128,
                         (self.input_size + 127) // 128,
                         dtype=scale_dtype,
+                        device=param_device,
                     )
                 )
             elif quant_type == QuantType.per_1x32:
@@ -524,6 +553,7 @@ class LinearBase(nn.Module):
                         self.output_size,
                         (self.input_size + 31) // 32,
                         dtype=dtypes.fp8_e8m0,
+                        device=param_device,
                     )
                 )
             self.weight.weight_loader_process = self.weight_loader_process
@@ -659,14 +689,24 @@ class LinearBase(nn.Module):
         )
         weight = self.weight.data
         weight_scale = getattr(self, "weight_scale", None)
+        if (
+            self.tp_size > 1
+            and self.tp_dim is not None
+            and isinstance(self, ReplicatedLinear)
+        ):
+            # W and S of kv_a_proj_with_mqa don't match,
+            # but it doesn't need to be split.
+            return
         # Gather is required whenever local quantization would differ from
         # quantizing the full unpartitioned weight (bit-exact with offline).
+        # Streaming tails are collective-free because modules complete in
+        # different orders across ranks; they quantize the local shard instead.
         need_gather = False
-        if self.tp_size > 1 and self.tp_dim is not None:
-            if isinstance(self, ReplicatedLinear):
-                # W and S of kv_a_proj_with_mqa don't match,
-                # but it doesn't need to be split.
-                return
+        if (
+            not self._stream_online_quant
+            and self.tp_size > 1
+            and self.tp_dim is not None
+        ):
             # col qkv w13, tp_dim=0, [m, n] -> [m // tp, n] -> [m // tp, 1], don't need gather
             # row o, w2, tp_dim=1, [m, n] -> [m, n //tp] -> [m, 1], need gather
             if online_quant_type == QuantType.per_Token:

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -69,8 +69,13 @@ from atom.model_ops.utils import (
     shuffle_weights,
 )
 from atom.plugin.vllm.moe import FusedMoEDecoratorForPluginMode
-from atom.quant_spec import LayerQuantConfig, should_skip_online_quant
+from atom.quant_spec import (
+    LayerQuantConfig,
+    should_skip_online_quant,
+    should_stream_online_quant,
+)
 from atom.quantization.quark.utils import (
+    dequant_moe_weight_online,
     dequant_weight_online,
     quant_weight_online,
 )
@@ -654,6 +659,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
+        # Streaming source weights start on meta; target weights remain real.
+        stream_online_quant = getattr(layer, "_stream_online_quant", False)
+        weight_device = "meta" if stream_online_quant else None
+
         # Fused gate_up_proj (column parallel)
         w13_weight = atom_parameter(
             torch.empty(
@@ -661,6 +670,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
                 2 * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype,
+                device=weight_device,
             )
         )
         layer.register_parameter("w13_weight", w13_weight)
@@ -673,6 +683,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
                 hidden_size,
                 intermediate_size_per_partition,
                 dtype=params_dtype,
+                device=weight_device,
             )
         )
         layer.register_parameter("w2_weight", w2_weight)
@@ -945,6 +956,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.intermediate_pad = (
             self.intermediate_size - layer.intermediate_size_per_partition
         )
+        # MXFP4 is target-only; online dequantization accepts only FP8 sources.
         # Fused gate_up_proj (column parallel)
         w13_weight = atom_parameter(
             torch.empty(
@@ -2054,6 +2066,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     ):
         self.num_experts = num_experts
         intermediate_size_for_weight = intermediate_size_per_partition
+        # Transient sources use checkpoint shapes; target-only kernel padding
+        # would prevent streaming coverage from completing.
+        stream_online_quant = getattr(layer, "_stream_online_quant", False)
 
         if self.block_quant:
             if self.quant_type == QuantType.per_1x128:
@@ -2080,10 +2095,16 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     f"{intermediate_size_per_partition} is not divisible by "
                     f"weight quantization block_k = {block_k}."
                 )
-            if self.quant_type == QuantType.per_1x32:
+            if self.quant_type == QuantType.per_1x32 and not stream_online_quant:
                 # aiter's GU-interleaved MXFP8 scale shuffle packs 8 scale
                 # columns, i.e. 256 weight columns for 1x32 scales. TP8 on
                 # MiniMax-M3 has local intermediate=384, so pad to 512.
+                # For stream online quantization
+                # Streaming sources skip this padding because they are temporary
+                # checkpoint storage and never enter the shuffled kernel. Keeping
+                # their logical shape also lets loaded coverage reach the expected
+                # numel. This does not change the quantized target: _online_quant
+                # clears the streaming flag before creating its target buffers.
                 scale_pack_k = block_k * 8
                 intermediate_size_for_weight = (
                     (intermediate_size_per_partition + scale_pack_k - 1)
@@ -2092,16 +2113,19 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 )
 
         # WEIGHTS
+        weight_device = "meta" if stream_online_quant else None
         w13_weight = atom_parameter(
             torch.empty(
                 num_experts,
                 2 * intermediate_size_for_weight,
                 hidden_size,
                 dtype=params_dtype,
+                device=weight_device,
             )
         )
         layer.register_parameter("w13_weight", w13_weight)
-        if self.quant_type == QuantType.per_1x32:
+        # Only target buffers contain padding bytes.
+        if self.quant_type == QuantType.per_1x32 and not stream_online_quant:
             w13_weight.data.view(torch.uint8).zero_()
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
@@ -2111,10 +2135,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 hidden_size,
                 intermediate_size_for_weight,
                 dtype=params_dtype,
+                device=weight_device,
             )
         )
         layer.register_parameter("w2_weight", w2_weight)
-        if self.quant_type == QuantType.per_1x32:
+        if self.quant_type == QuantType.per_1x32 and not stream_online_quant:
             w2_weight.data.view(torch.uint8).zero_()
         set_weight_attrs(w2_weight, extra_weight_attrs)
 
@@ -2767,6 +2792,14 @@ class FusedMoE(torch.nn.Module):
             "params_dtype": self.params_dtype,
             "weight_loader": self.weight_loader,
         }
+        # Set before create_weights so streaming sources allocate on meta.
+        self._stream_online_quant = should_stream_online_quant(
+            quant_config,
+            prefix,
+            layer_quant_config.quant_type if layer_quant_config else QuantType.No,
+            self.params_dtype,
+        )
+        self._load_device = torch.empty(0).device if self._stream_online_quant else None
         self.quant_method.create_weights(layer=self, **self.moe_quant_params)
         compilation_config = atom_config.compilation_config
         if prefix in compilation_config.static_forward_context:
@@ -2851,6 +2884,140 @@ class FusedMoE(torch.nn.Module):
                 "the dispatch space; the legacy AITER fusion is unsupported."
             )
 
+    def _online_quant_row_local_batched(
+        self,
+        old_w13_data: torch.Tensor,
+        old_w2_data: torch.Tensor,
+        old_w13_scale: torch.Tensor | None,
+        old_w2_scale: torch.Tensor | None,
+        source_quant_type: QuantType,
+        source_quant_dtype: torch.dtype | None,
+        online_quant_type: QuantType,
+        online_quant_dtype: torch.dtype,
+    ) -> None:
+        """Batch row-local experts to accelerate streaming online quantization."""
+        batch_size = 8
+
+        def _quantize(source, scale):
+            bf16 = dequant_moe_weight_online(
+                source,
+                scale,
+                source_quant_type,
+                source_quant_dtype,
+            )
+            quantized, quant_scale = quant_weight_online(
+                bf16,
+                online_quant_type=online_quant_type,
+                online_quant_dtype=online_quant_dtype,
+            )
+            del bf16
+            return quantized, quant_scale
+
+        def _reshape_scale(scale: torch.Tensor, count: int) -> torch.Tensor:
+            assert scale.dim() == 2, (
+                "row-local online quantization must return a 2D scale, "
+                f"got shape={tuple(scale.shape)}"
+            )
+            assert scale.shape[0] % count == 0
+            return scale.reshape(count, scale.shape[0] // count, scale.shape[1])
+
+        def _copy_scale(
+            target: torch.Tensor,
+            source: torch.Tensor,
+            *,
+            split_gate_up: bool,
+        ) -> None:
+            # PTPC stores [E, rows], while block schemes store
+            # [E, scale_rows, scale_cols].
+            if online_quant_type == QuantType.per_Token:
+                assert source.shape[2] == 1
+                source = source.squeeze(2)
+            assert source.dim() == target.dim()
+
+            def _copy_rows(
+                target_start: int,
+                source_start: int,
+                rows: int,
+            ) -> None:
+                if target.dim() == 2:
+                    target_region = target[:, target_start : target_start + rows]
+                    source_region = source[:, source_start : source_start + rows]
+                else:
+                    target_region = target[
+                        :,
+                        target_start : target_start + rows,
+                        : source.shape[2],
+                    ]
+                    source_region = source[
+                        :,
+                        source_start : source_start + rows,
+                    ]
+                FusedMoE._copy_quant_storage(target_region, source_region)
+
+            if split_gate_up:
+                source_half_rows = source.shape[1] // 2
+                target_half_rows = target.shape[1] // 2
+                _copy_rows(0, 0, source_half_rows)
+                _copy_rows(
+                    target_half_rows,
+                    source_half_rows,
+                    source_half_rows,
+                )
+            else:
+                _copy_rows(0, 0, source.shape[1])
+
+        for start in range(0, self.local_num_experts, batch_size):
+            end = min(start + batch_size, self.local_num_experts)
+            count = end - start
+
+            # Copy gate/up separately to support target-side padding between
+            # the two halves; without padding their offsets are identical.
+            source_w13 = old_w13_data[start:end]
+            source_w13_scale = (
+                old_w13_scale[start:end] if old_w13_scale is not None else None
+            )
+            w13_q, w13_s = _quantize(source_w13, source_w13_scale)
+            source_w13_rows = source_w13.shape[1]
+            source_half_rows = source_w13_rows // 2
+            w13_q = w13_q.reshape(count, source_w13_rows, w13_q.shape[1])
+            w13_s = _reshape_scale(w13_s, count)
+
+            target_w13 = self.w13_weight.data[start:end]
+            target_w13_scale = self.w13_weight_scale.data[start:end]
+            target_half_rows = target_w13.shape[1] // 2
+            FusedMoE._copy_quant_storage(
+                target_w13[:, :source_half_rows, : w13_q.shape[2]],
+                w13_q[:, :source_half_rows],
+            )
+            FusedMoE._copy_quant_storage(
+                target_w13[
+                    :,
+                    target_half_rows : target_half_rows + source_half_rows,
+                    : w13_q.shape[2],
+                ],
+                w13_q[:, source_half_rows:],
+            )
+            _copy_scale(target_w13_scale, w13_s, split_gate_up=True)
+            del w13_q, w13_s
+
+            source_w2 = old_w2_data[start:end]
+            source_w2_scale = (
+                old_w2_scale[start:end] if old_w2_scale is not None else None
+            )
+            w2_q, w2_s = _quantize(source_w2, source_w2_scale)
+            source_w2_rows = source_w2.shape[1]
+            w2_q = w2_q.reshape(count, source_w2_rows, w2_q.shape[1])
+            w2_s = _reshape_scale(w2_s, count)
+
+            target_w2 = self.w2_weight.data[start:end]
+            target_w2_scale = self.w2_weight_scale.data[start:end]
+            FusedMoE._copy_quant_storage(
+                target_w2[:, :source_w2_rows, : w2_q.shape[2]],
+                w2_q,
+            )
+            _copy_scale(target_w2_scale, w2_s, split_gate_up=False)
+            del w2_q, w2_s
+
     def _online_quant(self):
         """Handle online quantization: (optionally dequant →) quantize weights,
         then switch quant_method.
@@ -2861,6 +3028,7 @@ class FusedMoE(torch.nn.Module):
           2. Switch quant_method and allocate target quantized buffers
           3. Per-expert: quantize bf16 → write into buffers via
              _load_model_weight_or_group_weight_scale (reuses TP-shard + padding)
+             Row-local targets may batch experts before writing the same layout.
           4. Loader then calls target method's process_weights_after_loading
              which does fn→fnuz normalization and shuffle on the already-FP8 weights.
         """
@@ -2918,13 +3086,14 @@ class FusedMoE(torch.nn.Module):
         # w13 (column parallel): (E, (2*intermediate/tp, hidden)) — TP dim 0
         # w2  (row parallel):    (E, (hidden, intermediate/tp)) — TP dim 1
         # w13 [e, m, n]->[e, m//tp, n//2]->[e, m//tp, n//32]
+        # Streaming tails must remain collective-free across ranks.
         def check_need_allgather():
             if self.use_ep:
                 assert self.tp_size == 1, "EP MoE should not TP-shard expert weights"
                 return False
 
             need_gather_w2 = False
-            if self.tp_size > 1:
+            if not self._stream_online_quant and self.tp_size > 1:
                 # self.intermediate_size_per_partition = intermediate_size // self.tp_size
                 w2_in = self.intermediate_size_per_partition
                 if online_quant_type == QuantType.per_Token:
@@ -2957,11 +3126,40 @@ class FusedMoE(torch.nn.Module):
                 f"Unsupported online quant_dtype for MoE: {online_quant_dtype}"
             )
         self.moe_quant_params["params_dtype"] = online_quant_dtype
+        # Target buffers must use real storage.
+        self._stream_online_quant = False
         with torch.device(device):
             self.quant_method.create_weights(layer=self, **self.moe_quant_params)
 
         self.w13_input_scale = None
         self.w2_input_scale = None
+
+        # Batch row-local formats; per-tensor and gathered formats stay expertwise.
+        row_local_target = online_quant_type in (
+            QuantType.per_Token,
+            QuantType.per_1x32,
+            QuantType.per_1x128,
+        )
+        target_rows_are_batchable = online_quant_type != QuantType.per_1x128 or (
+            old_w13_data.shape[1] // 2 % 128 == 0 and old_w2_data.shape[1] % 128 == 0
+        )
+        if row_local_target and target_rows_are_batchable and not need_gather_w2:
+            self._online_quant_row_local_batched(
+                old_w13_data=old_w13_data,
+                old_w2_data=old_w2_data,
+                old_w13_scale=old_w13_scale,
+                old_w2_scale=old_w2_scale,
+                source_quant_type=source_quant_type,
+                source_quant_dtype=source_quant_dtype,
+                online_quant_type=online_quant_type,
+                online_quant_dtype=online_quant_dtype,
+            )
+            self._online_quant_info = {
+                "layer": self.layer_name,
+                "quant_type": online_quant_type.name,
+                "quant_dtype": str(online_quant_dtype),
+            }
+            return
 
         for expert_id in range(self.local_num_experts):
             # --- w13 column-parallel ---
@@ -3590,6 +3788,20 @@ class FusedMoE(torch.nn.Module):
         if any(param is p for p in w2_batchable if p is not None):
             return n_local_base
         return None
+
+    def batched_expert_region_numel(
+        self,
+        param: torch.nn.Parameter,
+        local_expert_id: int,
+        shard_id: str,
+    ) -> int:
+        """Return the physical size of one staged ``(expert, shard)`` region."""
+        return expert_region(
+            param.data,
+            local_expert_id,
+            shard_id,
+            getattr(param, "is_transposed", False),
+        ).numel()
 
     @property
     def num_local_base_experts(self) -> int:

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -934,6 +934,10 @@ class KimiKDAAttention(nn.Module):
         self.fuse_input_norm_quant = in_proj_type in _RMS_FUSABLE_QUANT_TYPES
         self.input_quant_prefix = f"{prefix}.in_proj"
 
+    def get_streaming_deferred_modules(self) -> tuple[nn.Module, ...]:
+        """Children that must remain unquantized until KDA fuses their weights."""
+        return self.in_proj, self.f_a_proj
+
     def process_weights_after_loading(self) -> None:
         """Fuse all hidden-input projections into the single in-proj (one GEMM).
 

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -97,6 +97,32 @@ def should_skip_online_quant(cur_type, cur_dtype, online_cfg) -> bool:
     )
 
 
+def should_stream_online_quant(
+    quant_config,
+    prefix: str,
+    source_quant_type,
+    source_quant_dtype,
+) -> bool:
+    """Return whether this source can be streamed to a distinct online target."""
+    # Attention stays in the post-load pass because MLA post-processing reads
+    # an already-loaded and processed kv_b_proj.
+    # Imported lazily to avoid a module-load cycle (envs/quark pull in config
+    # which can pull in quant_spec).
+    from atom.quantization.quark.utils import can_dequant_weight_online
+    from atom.utils import envs
+
+    if not envs.ATOM_ONLINE_QUANT_STREAMING:
+        return False
+    if quant_config is None or not getattr(quant_config, "online_quant", False):
+        return False
+    if not can_dequant_weight_online(source_quant_type, source_quant_dtype):
+        return False
+    online_cfg = quant_config.get_layer_quant_config(prefix, use_online_quant=True)
+    return not should_skip_online_quant(
+        source_quant_type, source_quant_dtype, online_cfg
+    )
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Structured parsed config
 # ──────────────────────────────────────────────────────────────────────

--- a/atom/quantization/quark/utils.py
+++ b/atom/quantization/quark/utils.py
@@ -3,10 +3,11 @@
 
 from collections.abc import Iterable
 from typing import Any
+
 import regex as re
+import torch
 import triton
 import triton.language as tl
-import torch
 from aiter import QuantType
 
 _FP8_SOURCE_DTYPES = frozenset(
@@ -199,6 +200,23 @@ def dequant_per_tensor_fp8(
     return w.to(out_dtype)
 
 
+def can_dequant_weight_online(
+    source_quant_type: QuantType,
+    source_quant_dtype: torch.dtype | None = None,
+) -> bool:
+    """Return whether the online path can dequantize this source."""
+    if source_quant_type == QuantType.No:
+        return True
+    if source_quant_dtype is not None and source_quant_dtype not in _FP8_SOURCE_DTYPES:
+        return False
+    return source_quant_type in (
+        QuantType.per_Tensor,
+        QuantType.per_Token,
+        QuantType.per_1x128,
+        QuantType.per_1x32,
+    )
+
+
 def dequant_weight_online(
     weight: torch.Tensor,
     weight_scale: torch.Tensor | None,
@@ -214,11 +232,9 @@ def dequant_weight_online(
     different target format.
 
     A source is identified by BOTH its ``quant_type`` (the block layout) and its
-    element ``quant_dtype``. The layout alone is not enough: e.g. ``per_1x32``
-    can carry either MXFP8 (8-bit) or MXFP4 (4-bit) elements. We only support
-    dequantizing 8-bit FP8 sources; any 4-bit (e.g. MXFP4) source is rejected,
-    since MXFP4 is only ever an online-quant target, never a weight we
-    dequantize. Supported sources:
+    element ``quant_dtype``. The layout alone is not enough: ``per_1x32`` is the
+    MX layout, which the format allows to carry 4-bit elements as well, and only
+    the 8-bit (MXFP8) form is accepted here. Supported sources:
 
     - ``No``: unquantized, returned unchanged.
     - ``per_Tensor``: per-tensor FP8, one scalar scale per output partition.
@@ -245,8 +261,7 @@ def dequant_weight_online(
     if source_quant_dtype is not None and source_quant_dtype not in _FP8_SOURCE_DTYPES:
         raise ValueError(
             f"Unsupported online dequant source dtype={source_quant_dtype} "
-            f"(quant_type={source_quant_type}); only 8-bit FP8 sources are "
-            f"supported (MXFP4 and other 4-bit formats are target-only)."
+            f"(quant_type={source_quant_type}); supported sources are 8-bit FP8."
         )
 
     if source_quant_type == QuantType.per_Tensor:
@@ -262,6 +277,46 @@ def dequant_weight_online(
     raise ValueError(
         f"Unsupported source quant_type for online dequant: {source_quant_type}. "
         f"Supported sources: No, per_Tensor, per_Token, per_1x128, per_1x32."
+    )
+
+
+def dequant_moe_weight_online(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor | None,
+    source_quant_type: QuantType,
+    source_quant_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """Dequantize ``[E, N, K]`` by flattening row-local expert groups."""
+    assert (
+        weight.dim() == 3
+    ), f"expected batched MoE weight [E, N, K], got shape={tuple(weight.shape)}"
+    experts, rows, cols = weight.shape
+    flat_weight = weight.reshape(experts * rows, cols)
+    if source_quant_type == QuantType.No:
+        return flat_weight
+
+    assert (
+        weight_scale is not None
+    ), f"source quant_type={source_quant_type} requires a weight scale"
+    if source_quant_type == QuantType.per_Token:
+        flat_scale = weight_scale.reshape(experts * rows, -1)
+    elif source_quant_type == QuantType.per_1x128:
+        assert (
+            rows % 128 == 0
+        ), f"per_1x128 expert rows must be 128-aligned, got N={rows}"
+        flat_scale = weight_scale.reshape(experts * (rows // 128), -1)
+    elif source_quant_type == QuantType.per_1x32:
+        flat_scale = weight_scale.reshape(experts * rows, -1)
+    else:
+        raise ValueError(
+            "Batched MoE online dequant does not support "
+            f"source quant_type={source_quant_type}."
+        )
+    return dequant_weight_online(
+        flat_weight.contiguous(),
+        flat_scale.contiguous(),
+        source_quant_type,
+        source_quant_dtype,
     )
 
 

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -256,6 +256,22 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_LOADER_STRICT_COVERAGE": lambda: (
         os.getenv("ATOM_LOADER_STRICT_COVERAGE", "true").lower() == "true"
     ),
+    # Quantize eligible modules as they load to reduce peak memory. Streaming
+    # quantizes local TP shards, so results may differ slightly from offline.
+    "ATOM_ONLINE_QUANT_STREAMING": lambda: (
+        os.getenv("ATOM_ONLINE_QUANT_STREAMING", "1").lower() in ("1", "true")
+    ),
+    # Tail workers for H2D, quantization, and source release. More workers
+    # increase overlap and in-flight memory; 0 runs inline.
+    "ATOM_ONLINE_QUANT_STREAMING_THREADS": lambda: int(
+        os.getenv("ATOM_ONLINE_QUANT_STREAMING_THREADS", "4")
+    ),
+    # Stage on the host and upload once per completed parameter. Disabling this
+    # buffers loader calls on meta and forces a single-threaded checkpoint walk.
+    "ATOM_ONLINE_QUANT_STREAMING_HOST_STAGING": lambda: (
+        os.getenv("ATOM_ONLINE_QUANT_STREAMING_HOST_STAGING", "1").lower()
+        in ("1", "true")
+    ),
     # --- Attention Backend ---
     # Use unified_attention (flash-style) for MHA paged/prefill attention instead
     # of pa_decode_gluon. Set to 1 to enable the unified_attention path.

--- a/tests/test_moe_online_quant_batch.py
+++ b/tests/test_moe_online_quant_batch.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Numerical tests for batched MoE online re-quantization."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+aiter = pytest.importorskip("aiter", reason="needs the AITER GPU kernel library")
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="needs a ROCm GPU"
+)
+
+from aiter import QuantType, dtypes
+
+from atom.model_ops.moe import FusedMoE
+from atom.quantization.quark.utils import (
+    dequant_moe_weight_online,
+    dequant_weight_online,
+    quant_weight_online,
+)
+
+
+def _quantize_expertwise(weight, scale):
+    """Reference the old w1/w3-per-expert implementation."""
+    experts, rows, _ = weight.shape
+    half_rows = rows // 2
+    scale_half_rows = scale.shape[1] // 2
+    quantized = []
+    quant_scales = []
+    for expert in range(experts):
+        expert_q = []
+        expert_s = []
+        for row_slice, scale_slice in (
+            (slice(0, half_rows), slice(0, scale_half_rows)),
+            (slice(half_rows, rows), slice(scale_half_rows, scale.shape[1])),
+        ):
+            bf16 = dequant_weight_online(
+                weight[expert, row_slice].contiguous(),
+                scale[expert, scale_slice].contiguous(),
+                QuantType.per_1x128,
+                torch.float8_e4m3fnuz,
+            )
+            q_weight, q_scale = quant_weight_online(
+                bf16,
+                online_quant_type=QuantType.per_1x32,
+                online_quant_dtype=dtypes.fp4x2,
+            )
+            expert_q.append(q_weight)
+            expert_s.append(q_scale)
+        quantized.append(torch.cat(expert_q))
+        quant_scales.append(torch.cat(expert_s))
+    return torch.stack(quantized), torch.stack(quant_scales)
+
+
+def test_batched_dequant_quant_matches_expertwise():
+    torch.manual_seed(7)
+    experts, rows, cols = 3, 512, 256
+    weight = torch.randn(experts, rows, cols, device="cuda").to(torch.float8_e4m3fnuz)
+    scale = torch.rand(experts, rows // 128, cols // 128, device="cuda") + 0.125
+
+    bf16 = dequant_moe_weight_online(
+        weight,
+        scale,
+        QuantType.per_1x128,
+        torch.float8_e4m3fnuz,
+    )
+    batch_q, batch_s = quant_weight_online(
+        bf16,
+        online_quant_type=QuantType.per_1x32,
+        online_quant_dtype=dtypes.fp4x2,
+    )
+    batch_q = batch_q.reshape(experts, rows, cols // 2)
+    batch_s = batch_s.reshape(experts, rows, cols // 32)
+    ref_q, ref_s = _quantize_expertwise(weight, scale)
+    torch.cuda.synchronize()
+
+    assert torch.equal(batch_q.view(torch.uint8), ref_q.view(torch.uint8))
+    assert torch.equal(batch_s.view(torch.uint8), ref_s.view(torch.uint8))
+
+
+@pytest.mark.parametrize(
+    ("quant_type", "scale_shape"),
+    [
+        (QuantType.per_Token, lambda e, n, k: (e, n)),
+        (QuantType.per_1x32, lambda e, n, k: (e, n, k // 32)),
+    ],
+)
+def test_batched_dequant_matches_expertwise_for_row_local_sources(
+    quant_type, scale_shape
+):
+    torch.manual_seed(9)
+    experts, rows, cols = 3, 64, 256
+    weight = torch.randn(experts, rows, cols, device="cuda").to(torch.float8_e4m3fnuz)
+    if quant_type == QuantType.per_Token:
+        scale = torch.rand(scale_shape(experts, rows, cols), device="cuda") + 0.125
+    else:
+        # Raw E8M0 code 127 represents a scale of one.
+        scale = torch.full(
+            scale_shape(experts, rows, cols),
+            127,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+
+    batched = dequant_moe_weight_online(
+        weight,
+        scale,
+        quant_type,
+        torch.float8_e4m3fnuz,
+    )
+    reference = torch.cat(
+        [
+            dequant_weight_online(
+                weight[expert].contiguous(),
+                scale[expert].contiguous(),
+                quant_type,
+                torch.float8_e4m3fnuz,
+            )
+            for expert in range(experts)
+        ]
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(batched, reference)
+
+
+def test_batched_dequant_unquantized_is_zero_copy_view():
+    weight = torch.randn(3, 8, 32, device="cuda")
+    flat = dequant_moe_weight_online(weight, None, QuantType.No)
+
+    assert flat.shape == (24, 32)
+    assert flat.untyped_storage().data_ptr() == weight.untyped_storage().data_ptr()
+
+
+@pytest.mark.parametrize(
+    "target_quant_type",
+    [
+        QuantType.per_Token,
+        QuantType.per_1x32,
+        QuantType.per_1x128,
+    ],
+)
+def test_batched_path_matches_expertwise_fp8_targets(monkeypatch, target_quant_type):
+    torch.manual_seed(10)
+    monkeypatch.setenv("ATOM_ONLINE_QUANT_MOE_EXPERT_BATCH_SIZE", "2")
+    experts, intermediate, hidden = 3, 256, 256
+    old_w13 = torch.randn(
+        experts,
+        2 * intermediate,
+        hidden,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    old_w2 = torch.randn(
+        experts,
+        hidden,
+        intermediate,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    target_w13 = torch.empty(
+        experts,
+        2 * intermediate,
+        hidden,
+        dtype=dtypes.fp8,
+        device="cuda",
+    )
+    target_w2 = torch.empty(
+        experts,
+        hidden,
+        intermediate,
+        dtype=dtypes.fp8,
+        device="cuda",
+    )
+    if target_quant_type == QuantType.per_Token:
+        target_w13_scale = torch.zeros(
+            experts, 2 * intermediate, dtype=torch.float32, device="cuda"
+        )
+        target_w2_scale = torch.zeros(
+            experts, hidden, dtype=torch.float32, device="cuda"
+        )
+    elif target_quant_type == QuantType.per_1x32:
+        target_w13_scale = torch.empty(
+            experts,
+            2 * intermediate,
+            hidden // 32,
+            dtype=dtypes.fp8_e8m0,
+            device="cuda",
+        )
+        target_w2_scale = torch.empty(
+            experts,
+            hidden,
+            intermediate // 32,
+            dtype=dtypes.fp8_e8m0,
+            device="cuda",
+        )
+        target_w13_scale.view(torch.uint8).zero_()
+        target_w2_scale.view(torch.uint8).zero_()
+    else:
+        target_w13_scale = torch.zeros(
+            experts,
+            2 * (intermediate // 128),
+            hidden // 128,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        target_w2_scale = torch.zeros(
+            experts,
+            hidden // 128,
+            intermediate // 128,
+            dtype=torch.float32,
+            device="cuda",
+        )
+
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        w13_weight=SimpleNamespace(data=target_w13),
+        w2_weight=SimpleNamespace(data=target_w2),
+        w13_weight_scale=SimpleNamespace(data=target_w13_scale),
+        w2_weight_scale=SimpleNamespace(data=target_w2_scale),
+    )
+    FusedMoE._online_quant_row_local_batched(
+        layer,
+        old_w13_data=old_w13,
+        old_w2_data=old_w2,
+        old_w13_scale=None,
+        old_w2_scale=None,
+        source_quant_type=QuantType.No,
+        source_quant_dtype=torch.bfloat16,
+        online_quant_type=target_quant_type,
+        online_quant_dtype=dtypes.fp8,
+    )
+
+    ref_w13 = []
+    ref_w13_scale = []
+    ref_w2 = []
+    ref_w2_scale = []
+    for expert in range(experts):
+        w13_parts = []
+        w13_scale_parts = []
+        for rows in (
+            slice(0, intermediate),
+            slice(intermediate, 2 * intermediate),
+        ):
+            q_weight, q_scale = quant_weight_online(
+                old_w13[expert, rows],
+                online_quant_type=target_quant_type,
+                online_quant_dtype=dtypes.fp8,
+            )
+            w13_parts.append(q_weight)
+            w13_scale_parts.append(q_scale)
+        ref_w13.append(torch.cat(w13_parts))
+        ref_w13_scale.append(torch.cat(w13_scale_parts))
+
+        q_weight, q_scale = quant_weight_online(
+            old_w2[expert],
+            online_quant_type=target_quant_type,
+            online_quant_dtype=dtypes.fp8,
+        )
+        ref_w2.append(q_weight)
+        ref_w2_scale.append(q_scale)
+
+    ref_w13 = torch.stack(ref_w13)
+    ref_w13_scale = torch.stack(ref_w13_scale)
+    ref_w2 = torch.stack(ref_w2)
+    ref_w2_scale = torch.stack(ref_w2_scale)
+    torch.cuda.synchronize()
+
+    assert torch.equal(
+        target_w13.view(torch.uint8),
+        ref_w13.view(torch.uint8),
+    )
+    assert torch.equal(
+        target_w2.view(torch.uint8),
+        ref_w2.view(torch.uint8),
+    )
+    if target_quant_type == QuantType.per_Token:
+        ref_w13_scale = ref_w13_scale.squeeze(-1)
+        ref_w2_scale = ref_w2_scale.squeeze(-1)
+    if target_quant_type == QuantType.per_1x32:
+        target_w13_scale = target_w13_scale.view(torch.uint8)
+        target_w2_scale = target_w2_scale.view(torch.uint8)
+        ref_w13_scale = ref_w13_scale.view(torch.uint8)
+        ref_w2_scale = ref_w2_scale.view(torch.uint8)
+    assert torch.equal(target_w13_scale, ref_w13_scale)
+    assert torch.equal(target_w2_scale, ref_w2_scale)
+
+
+def test_batched_path_preserves_target_padding(monkeypatch):
+    torch.manual_seed(11)
+    monkeypatch.setenv("ATOM_ONLINE_QUANT_MOE_EXPERT_BATCH_SIZE", "2")
+    experts, intermediate, hidden = 3, 256, 256
+    padded_intermediate, padded_hidden = 512, 512
+
+    old_w13 = torch.randn(experts, 2 * intermediate, hidden, device="cuda").to(
+        torch.float8_e4m3fnuz
+    )
+    old_w2 = torch.randn(experts, hidden, intermediate, device="cuda").to(
+        torch.float8_e4m3fnuz
+    )
+    old_w13_scale = (
+        torch.rand(
+            experts,
+            2 * (intermediate // 128),
+            hidden // 128,
+            device="cuda",
+        )
+        + 0.125
+    )
+    old_w2_scale = (
+        torch.rand(
+            experts,
+            hidden // 128,
+            intermediate // 128,
+            device="cuda",
+        )
+        + 0.125
+    )
+
+    target_w13 = torch.empty(
+        experts,
+        2 * padded_intermediate,
+        padded_hidden // 2,
+        dtype=dtypes.fp4x2,
+        device="cuda",
+    )
+    target_w2 = torch.empty(
+        experts,
+        padded_hidden,
+        padded_intermediate // 2,
+        dtype=dtypes.fp4x2,
+        device="cuda",
+    )
+    target_w13.view(torch.uint8).zero_()
+    target_w2.view(torch.uint8).zero_()
+    target_w13_scale = torch.zeros(
+        experts,
+        2 * padded_intermediate,
+        padded_hidden // 32,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    target_w2_scale = torch.zeros(
+        experts,
+        padded_hidden,
+        padded_intermediate // 32,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        w13_weight=SimpleNamespace(data=target_w13),
+        w2_weight=SimpleNamespace(data=target_w2),
+        w13_weight_scale=SimpleNamespace(data=target_w13_scale),
+        w2_weight_scale=SimpleNamespace(data=target_w2_scale),
+    )
+
+    FusedMoE._online_quant_row_local_batched(
+        layer,
+        old_w13_data=old_w13,
+        old_w2_data=old_w2,
+        old_w13_scale=old_w13_scale,
+        old_w2_scale=old_w2_scale,
+        source_quant_type=QuantType.per_1x128,
+        source_quant_dtype=torch.float8_e4m3fnuz,
+        online_quant_type=QuantType.per_1x32,
+        online_quant_dtype=dtypes.fp4x2,
+    )
+    torch.cuda.synchronize()
+
+    ref_w13, ref_w13_scale = _quantize_expertwise(old_w13, old_w13_scale)
+    ref_w2 = []
+    ref_w2_scale = []
+    for expert in range(experts):
+        bf16 = dequant_weight_online(
+            old_w2[expert].contiguous(),
+            old_w2_scale[expert].contiguous(),
+            QuantType.per_1x128,
+            torch.float8_e4m3fnuz,
+        )
+        q_weight, q_scale = quant_weight_online(
+            bf16,
+            online_quant_type=QuantType.per_1x32,
+            online_quant_dtype=dtypes.fp4x2,
+        )
+        ref_w2.append(q_weight)
+        ref_w2_scale.append(q_scale)
+    ref_w2 = torch.stack(ref_w2)
+    ref_w2_scale = torch.stack(ref_w2_scale)
+    torch.cuda.synchronize()
+
+    assert torch.equal(
+        target_w13[:, :intermediate, : hidden // 2].view(torch.uint8),
+        ref_w13[:, :intermediate].view(torch.uint8),
+    )
+    assert torch.equal(
+        target_w13[
+            :,
+            padded_intermediate : padded_intermediate + intermediate,
+            : hidden // 2,
+        ].view(torch.uint8),
+        ref_w13[:, intermediate:].view(torch.uint8),
+    )
+    assert torch.equal(
+        target_w2[:, :hidden, : intermediate // 2].view(torch.uint8),
+        ref_w2.view(torch.uint8),
+    )
+    assert torch.equal(
+        target_w13_scale[:, :intermediate, : hidden // 32],
+        ref_w13_scale[:, :intermediate].view(torch.uint8),
+    )
+    assert torch.equal(
+        target_w13_scale[
+            :,
+            padded_intermediate : padded_intermediate + intermediate,
+            : hidden // 32,
+        ],
+        ref_w13_scale[:, intermediate:].view(torch.uint8),
+    )
+    assert torch.equal(
+        target_w2_scale[:, :hidden, : intermediate // 32],
+        ref_w2_scale.view(torch.uint8),
+    )
+
+    # All target-only padding remains at the zero initialization expected by
+    # Mxfp4MoEMethod.create_weights.
+    target_w13_bytes = target_w13.view(torch.uint8)
+    target_w2_bytes = target_w2.view(torch.uint8)
+    assert (
+        target_w13_bytes[:, intermediate:padded_intermediate].count_nonzero().item()
+        == 0
+    )
+    assert (
+        target_w13_bytes[:, padded_intermediate + intermediate :].count_nonzero().item()
+        == 0
+    )
+    assert target_w2_bytes[:, hidden:].count_nonzero().item() == 0
+    assert target_w2_bytes[:, :hidden, intermediate // 2 :].count_nonzero().item() == 0

--- a/tests/test_online_quant_streaming.py
+++ b/tests/test_online_quant_streaming.py
@@ -14,7 +14,6 @@ from unittest import mock
 import torch
 from torch import nn
 
-import atom.model_loader.loader as loader_module
 import atom.model_loader.online_quant_streaming as streaming_module
 from atom.model_loader.loading_core import load_weights_into_model
 from atom.model_loader.online_quant_streaming import OnlineQuantStreamer
@@ -811,6 +810,13 @@ class StreamingCoverageTest(unittest.TestCase):
 
 class DraftStreamingSelectionTest(unittest.TestCase):
     def test_spec_decode_load_passes_streamer_to_loading_core(self):
+        try:
+            import atom.model_loader.loader as loader_module
+        except ModuleNotFoundError as exc:
+            if exc.name == "aiter":
+                self.skipTest("loader integration requires AITER")
+            raise
+
         model = nn.Module()
         streamer = mock.Mock()
         streamer.done_module_ids = set()

--- a/tests/test_online_quant_streaming.py
+++ b/tests/test_online_quant_streaming.py
@@ -14,6 +14,7 @@ from unittest import mock
 import torch
 from torch import nn
 
+import atom.model_loader.loader as loader_module
 import atom.model_loader.online_quant_streaming as streaming_module
 from atom.model_loader.loading_core import load_weights_into_model
 from atom.model_loader.online_quant_streaming import OnlineQuantStreamer
@@ -806,6 +807,45 @@ class StreamingCoverageTest(unittest.TestCase):
             torch.testing.assert_close(
                 want, dict(model.named_parameters())[name].detach(), rtol=0, atol=0
             )
+
+
+class DraftStreamingSelectionTest(unittest.TestCase):
+    def test_spec_decode_load_passes_streamer_to_loading_core(self):
+        model = nn.Module()
+        streamer = mock.Mock()
+        streamer.done_module_ids = set()
+        streamer.candidates = []
+
+        with (
+            mock.patch.object(
+                loader_module.OnlineQuantStreamer,
+                "maybe_create",
+                return_value=streamer,
+            ) as maybe_create,
+            mock.patch.object(
+                loader_module,
+                "load_weights_into_model",
+                return_value=set(),
+            ) as load_weights,
+            mock.patch.object(
+                loader_module.torch.cuda,
+                "is_available",
+                return_value=False,
+            ),
+        ):
+            loader_module.load_model(
+                model,
+                "<synthetic>",
+                mock.Mock(),
+                spec_decode=True,
+            )
+
+        maybe_create.assert_called_once_with(model, None)
+        self.assertIs(
+            load_weights.call_args.kwargs["online_quant_streamer"],
+            streamer,
+        )
+        streamer.replay_stragglers_and_report.assert_called_once_with(True)
 
 
 if __name__ == "__main__":

--- a/tests/test_online_quant_streaming.py
+++ b/tests/test_online_quant_streaming.py
@@ -298,6 +298,46 @@ class _MixedLayer(nn.Module):
         self.mlp.experts = StreamMoE(num_experts, False)
 
 
+class _DeferredAttention(nn.Module):
+    """Parent hook that must run before its streamed child is finalized."""
+
+    def __init__(self, stream: bool, linear_cls):
+        super().__init__()
+        self.o_proj = linear_cls(HIDDEN, HIDDEN, stream)
+        self.child_calls_when_processed = None
+
+    def get_streaming_deferred_modules(self):
+        return (self.o_proj,)
+
+    def process_weights_after_loading(self):
+        self.child_calls_when_processed = self.o_proj.post_process_calls
+        self.o_proj.weight.data.add_(1)
+
+
+class _DeferredLayer(nn.Module):
+    def __init__(self, num_experts: int, stream: bool, linear_cls):
+        super().__init__()
+        self.self_attn = _DeferredAttention(stream, linear_cls)
+        self.mlp = nn.Module()
+        self.mlp.experts = StreamMoE(num_experts, False)
+
+
+class DeferredStreamModel(StreamModel):
+    def __init__(
+        self,
+        num_layers: int,
+        num_experts: int,
+        stream: bool,
+        linear_cls=StreamLinear,
+    ):
+        nn.Module.__init__(self)
+        self.num_experts = num_experts
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList(
+            _DeferredLayer(num_experts, stream, linear_cls) for _ in range(num_layers)
+        )
+
+
 class SharedExpertStreamModel(StreamModel):
     moe_cls = SharedExpertStreamMoE
 
@@ -520,6 +560,45 @@ class StreamingDifferentialTest(unittest.TestCase):
                 online_quant_streamer.done_module_ids,
             )
             self.assertNotIn(id(experts), online_quant_streamer.done_module_ids)
+
+    def test_deferred_child_finalizes_after_parent_post_process(self):
+        baseline, _ = run_load(
+            streaming=False,
+            num_layers=1,
+            model_cls=DeferredStreamModel,
+        )
+        model, online_quant_streamer = run_load(
+            streaming=True,
+            host_staging=True,
+            num_threads=8,
+            num_layers=1,
+            model_cls=DeferredStreamModel,
+        )
+
+        for module in baseline.modules():
+            if hasattr(module, "process_weights_after_loading"):
+                module.process_weights_after_loading()
+        for module in model.modules():
+            if (
+                hasattr(module, "process_weights_after_loading")
+                and id(module) not in online_quant_streamer.done_module_ids
+            ):
+                module.process_weights_after_loading()
+
+        for name, want in weights_of(baseline).items():
+            torch.testing.assert_close(
+                want,
+                dict(model.named_parameters())[name].detach(),
+                rtol=0,
+                atol=0,
+            )
+        attention = model.model.layers[0].self_attn
+        self.assertEqual(attention.child_calls_when_processed, 0)
+        self.assertEqual(attention.o_proj.post_process_calls, 1)
+        self.assertNotIn(
+            id(attention.o_proj),
+            online_quant_streamer.done_module_ids,
+        )
 
     def test_host_staging_with_tail_workers_matches_non_streaming(self):
         model, _ = run_load(

--- a/tests/test_online_quant_streaming.py
+++ b/tests/test_online_quant_streaming.py
@@ -95,6 +95,7 @@ class StreamMoE(nn.Module):
         self.post_process_calls = 0
         self.loader_calls = 0
         self.stage_calls = 0
+        self.flush_calls = 0
 
     def weight_loader(
         self,
@@ -156,6 +157,10 @@ class StreamMoE(nn.Module):
 
     def is_batched_expert_slot(self, local_expert_id):
         return local_expert_id < self.num_batched_experts
+
+    def flush_staged(self, param, staging, filled):
+        self.flush_calls += 1
+        param.data.copy_(staging)
 
     @staticmethod
     def batched_expert_region_numel(param, local_expert_id, shard_id):
@@ -264,6 +269,33 @@ class StreamModel(nn.Module):
                 ("w3", "up_proj"),
             )
         ]
+
+
+class MixedStreamModel(StreamModel):
+    """Stream attention while leaving per-expert checkpoint weights unstreamed."""
+
+    def __init__(
+        self,
+        num_layers: int,
+        num_experts: int,
+        stream: bool,
+        linear_cls=StreamLinear,
+    ):
+        nn.Module.__init__(self)
+        self.num_experts = num_experts
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList(
+            _MixedLayer(num_experts, stream, linear_cls) for _ in range(num_layers)
+        )
+
+
+class _MixedLayer(nn.Module):
+    def __init__(self, num_experts: int, stream: bool, linear_cls):
+        super().__init__()
+        self.self_attn = nn.Module()
+        self.self_attn.o_proj = linear_cls(HIDDEN, HIDDEN, stream)
+        self.mlp = nn.Module()
+        self.mlp.experts = StreamMoE(num_experts, False)
 
 
 class SharedExpertStreamModel(StreamModel):
@@ -467,6 +499,27 @@ class StreamingDifferentialTest(unittest.TestCase):
     def test_host_staging_with_parallel_walk_matches_non_streaming(self):
         model, _ = run_load(streaming=True, host_staging=True, num_threads=8)
         self.assert_matches_baseline(model)
+
+    def test_unstreamed_experts_keep_batched_staging(self):
+        """Streamer candidates and excluded experts must use disjoint staging."""
+        model, online_quant_streamer = run_load(
+            streaming=True,
+            host_staging=True,
+            num_threads=8,
+            model_cls=MixedStreamModel,
+        )
+
+        self.assert_matches_baseline(model)
+        for layer in model.model.layers:
+            experts = layer.mlp.experts
+            self.assertEqual(experts.stage_calls, 3 * NUM_EXPERTS)
+            self.assertEqual(experts.loader_calls, 0)
+            self.assertEqual(experts.flush_calls, 2)
+            self.assertIn(
+                id(layer.self_attn.o_proj),
+                online_quant_streamer.done_module_ids,
+            )
+            self.assertNotIn(id(experts), online_quant_streamer.done_module_ids)
 
     def test_host_staging_with_tail_workers_matches_non_streaming(self):
         model, _ = run_load(

--- a/tests/test_online_quant_streaming.py
+++ b/tests/test_online_quant_streaming.py
@@ -808,51 +808,5 @@ class StreamingCoverageTest(unittest.TestCase):
             )
 
 
-class DraftStreamingSelectionTest(unittest.TestCase):
-    def test_spec_decode_load_passes_streamer_to_loading_core(self):
-        try:
-            import atom.model_loader.loader as loader_module
-        except ModuleNotFoundError as exc:
-            if exc.name == "aiter":
-                self.skipTest("loader integration requires AITER")
-            raise
-
-        model = nn.Module()
-        streamer = mock.Mock()
-        streamer.done_module_ids = set()
-        streamer.candidates = []
-
-        with (
-            mock.patch.object(
-                loader_module.OnlineQuantStreamer,
-                "maybe_create",
-                return_value=streamer,
-            ) as maybe_create,
-            mock.patch.object(
-                loader_module,
-                "load_weights_into_model",
-                return_value=set(),
-            ) as load_weights,
-            mock.patch.object(
-                loader_module.torch.cuda,
-                "is_available",
-                return_value=False,
-            ),
-        ):
-            loader_module.load_model(
-                model,
-                "<synthetic>",
-                mock.Mock(),
-                spec_decode=True,
-            )
-
-        maybe_create.assert_called_once_with(model, None)
-        self.assertIs(
-            load_weights.call_args.kwargs["online_quant_streamer"],
-            streamer,
-        )
-        streamer.replay_stragglers_and_report.assert_called_once_with(True)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_online_quant_streaming.py
+++ b/tests/test_online_quant_streaming.py
@@ -1,0 +1,759 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""CPU tests for online-quant streaming and completion tracking."""
+
+import contextlib
+import os
+import sys
+import threading
+import unittest
+from typing import ClassVar
+from unittest import mock
+
+import torch
+from torch import nn
+
+import atom.model_loader.online_quant_streaming as streaming_module
+from atom.model_loader.loading_core import load_weights_into_model
+from atom.model_loader.online_quant_streaming import OnlineQuantStreamer
+
+HIDDEN = 8
+INTER = 4
+
+
+def default_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+    param.data.copy_(loaded_weight)
+
+
+class StreamLinear(nn.Module):
+    """The parts of `LinearBase` the streamer talks to."""
+
+    def __init__(self, out_features: int, in_features: int, stream: bool):
+        super().__init__()
+        self._stream_online_quant = stream
+        self._load_device = torch.device("cpu")
+        device = "meta" if stream else None
+        self.weight = nn.Parameter(
+            torch.zeros(out_features, in_features, device=device), requires_grad=False
+        )
+        self.bias = nn.Parameter(
+            torch.zeros(out_features, device=device), requires_grad=False
+        )
+        for p in (self.weight, self.bias):
+            p.weight_loader = self.weight_loader
+        self.post_process_calls = 0
+
+    def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+        param.data.copy_(loaded_weight)
+
+    def process_weights_after_loading(self) -> None:
+        self.post_process_calls += 1
+
+
+class DoubleCopyLinear(StreamLinear):
+    """A loader that copies into its destination twice."""
+
+    def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+        param.data.copy_(loaded_weight)
+        param.data.copy_(param.data)
+
+
+class HostHostileLinear(StreamLinear):
+    """Simulate a loader without a host kernel."""
+
+    def __init__(self, out_features: int, in_features: int, stream: bool):
+        super().__init__(out_features, in_features, stream)
+        self.refusals = 0
+
+    def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+        if getattr(self, "_stream_on_host", False):
+            self.refusals += 1
+            raise NotImplementedError("no kernel for host storage")
+        param.data.copy_(loaded_weight)
+
+
+class StreamMoE(nn.Module):
+    """One fused MoE parameter pair fed one (expert, shard) tensor at a time."""
+
+    def __init__(self, num_experts: int, stream: bool):
+        super().__init__()
+        self.num_experts = num_experts
+        self.num_batched_experts = num_experts
+        self._stream_online_quant = stream
+        self._load_device = torch.device("cpu")
+        device = "meta" if stream else None
+        self.w13_weight = nn.Parameter(
+            torch.zeros(num_experts, 2 * INTER, HIDDEN, device=device),
+            requires_grad=False,
+        )
+        self.w2_weight = nn.Parameter(
+            torch.zeros(num_experts, HIDDEN, INTER, device=device), requires_grad=False
+        )
+        for p in (self.w13_weight, self.w2_weight):
+            p.weight_loader = self.weight_loader
+        self.post_process_calls = 0
+        self.loader_calls = 0
+        self.stage_calls = 0
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        weight_name: str,
+        shard_id: str,
+        expert_id: int,
+    ) -> None:
+        self.loader_calls += 1
+        self._copy_expert_shard(
+            param.data[expert_id],
+            loaded_weight,
+            shard_id,
+        )
+
+    @staticmethod
+    def _copy_expert_shard(
+        expert_data: torch.Tensor,
+        loaded_weight: torch.Tensor,
+        shard_id: str,
+    ) -> None:
+        if shard_id == "w2":
+            expert_data.copy_(loaded_weight)
+            return
+        offset = 0 if shard_id == "w1" else INTER
+        expert_data[offset : offset + INTER].copy_(loaded_weight)
+
+    def process_weights_after_loading(self) -> None:
+        self.post_process_calls += 1
+
+    def stage_expert_weight(
+        self,
+        param,
+        staging,
+        loaded_weight,
+        local_expert_id,
+        shard_id,
+        weight_name,
+    ):
+        self.stage_calls += 1
+        self._copy_expert_shard(
+            staging[local_expert_id],
+            loaded_weight,
+            shard_id,
+        )
+        return True
+
+    def expected_batched_arrivals(self, param):
+        if param is self.w13_weight:
+            return self.num_batched_experts * 2
+        if param is self.w2_weight:
+            return self.num_batched_experts
+        return None
+
+    @staticmethod
+    def _map_global_expert_id_to_local_expert_id(expert_id):
+        return expert_id
+
+    def is_batched_expert_slot(self, local_expert_id):
+        return local_expert_id < self.num_batched_experts
+
+    @staticmethod
+    def batched_expert_region_numel(param, local_expert_id, shard_id):
+        expert_data = param.data[local_expert_id]
+        if shard_id == "w2":
+            return expert_data.numel()
+        return expert_data[:INTER].numel()
+
+
+class SharedExpertStreamMoE(StreamMoE):
+    """Treat the final slot as a separately loaded fused shared expert."""
+
+    def __init__(self, num_experts: int, stream: bool):
+        super().__init__(num_experts, stream)
+        self.num_batched_experts = num_experts - 1
+
+
+class DeclineW2StreamMoE(StreamMoE):
+    def stage_expert_weight(self, *args, shard_id, **kwargs):
+        if shard_id == "w2":
+            return False
+        return super().stage_expert_weight(*args, shard_id=shard_id, **kwargs)
+
+
+class DeclineW3StreamMoE(StreamMoE):
+    def stage_expert_weight(self, *args, shard_id, **kwargs):
+        if shard_id == "w3":
+            return False
+        return super().stage_expert_weight(*args, shard_id=shard_id, **kwargs)
+
+
+class _Layer(nn.Module):
+    def __init__(self, num_experts: int, stream: bool, linear_cls, moe_cls):
+        super().__init__()
+        self.self_attn = nn.Module()
+        self.self_attn.o_proj = linear_cls(HIDDEN, HIDDEN, stream)
+        self.mlp = nn.Module()
+        self.mlp.experts = moe_cls(num_experts, stream)
+
+
+class StreamModel(nn.Module):
+    """Model exposing the hooks `load_weights_into_model` looks for."""
+
+    packed_modules_mapping: ClassVar[dict] = {}
+    weights_mapping: ClassVar[dict] = {}
+    moe_cls = StreamMoE
+
+    def __init__(
+        self,
+        num_layers: int,
+        num_experts: int,
+        stream: bool,
+        linear_cls=StreamLinear,
+    ):
+        super().__init__()
+        self.num_experts = num_experts
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList(
+            _Layer(num_experts, stream, linear_cls, self.moe_cls)
+            for _ in range(num_layers)
+        )
+
+    def streamed_modules(self) -> list[nn.Module]:
+        return [m for m in self.modules() if getattr(m, "_stream_online_quant", False)]
+
+    def get_expert_mapping(self):
+        return [
+            (
+                "experts.w13_" if weight in ("gate_proj", "up_proj") else "experts.w2_",
+                f"experts.{expert_id}.{weight}.",
+                expert_id,
+                shard,
+            )
+            for expert_id in range(self.num_experts)
+            for shard, weight in (
+                ("w1", "gate_proj"),
+                ("w2", "down_proj"),
+                ("w3", "up_proj"),
+            )
+        ]
+
+
+class SharedExpertStreamModel(StreamModel):
+    moe_cls = SharedExpertStreamMoE
+
+
+class DeclineW2StreamModel(StreamModel):
+    moe_cls = DeclineW2StreamMoE
+
+
+class DeclineW3StreamModel(StreamModel):
+    moe_cls = DeclineW3StreamMoE
+
+
+class FusedExpertStreamModel(StreamModel):
+    """A model whose checkpoint stacks all routed experts into one tensor.
+
+    Separate from `StreamModel` so the per-expert tests keep exercising a
+    dispatcher with no fused-expert hooks at all.
+    """
+
+    def detect_fused_expert_format(self, weight_name: str) -> bool:
+        return "experts.gate_up_proj" in weight_name or (
+            "experts.down_proj" in weight_name and ".experts." in weight_name
+        )
+
+    def get_fused_expert_mapping(self) -> list[tuple[str, str, str]]:
+        return [
+            ("experts.w13_weight", "experts.gate_up_proj", "w1"),
+            ("experts.w2_weight", "experts.down_proj", "w2"),
+        ]
+
+    def load_fused_expert_weights(
+        self,
+        original_name: str,
+        name: str,
+        params_dict: dict,
+        loaded_weight: torch.Tensor,
+        shard_id: str,
+        num_experts: int,
+    ) -> bool:
+        """Write every routed expert at once, the way a stacked checkpoint does.
+
+        Deliberately straight into the parameter, bypassing `submit` and hence
+        the streamer's arrival count -- which is what the real fused-expert path
+        does, and why it needs `materialize_fused_param` to have given the
+        parameter real storage first. A meta tensor would take this copy
+        silently, so the resulting values are the only evidence it ran.
+        """
+        params_dict[name].data.copy_(loaded_weight)
+        return True
+
+
+def fused_checkpoint(num_layers: int, num_experts: int):
+    """Attention weights per layer plus one stacked tensor per expert matrix."""
+    torch.manual_seed(0)
+    tensors = {}
+    for layer in range(num_layers):
+        base = f"model.layers.{layer}"
+        tensors[f"{base}.self_attn.o_proj.weight"] = torch.randn(HIDDEN, HIDDEN)
+        tensors[f"{base}.self_attn.o_proj.bias"] = torch.randn(HIDDEN)
+        tensors[f"{base}.mlp.experts.gate_up_proj"] = torch.randn(
+            num_experts, 2 * INTER, HIDDEN
+        )
+        tensors[f"{base}.mlp.experts.down_proj"] = torch.randn(
+            num_experts, HIDDEN, INTER
+        )
+    return tensors
+
+
+class HFConfig:
+    def __init__(self, num_hidden_layers: int, n_routed_experts: int):
+        self.num_hidden_layers = num_hidden_layers
+        self.n_routed_experts = n_routed_experts
+        self.num_experts = n_routed_experts
+
+
+def checkpoint(num_layers: int, num_experts: int) -> dict[str, torch.Tensor]:
+    """Attention weights and per-expert MoE tensors, in checkpoint order."""
+    torch.manual_seed(0)
+    tensors: dict[str, torch.Tensor] = {}
+    for layer in range(num_layers):
+        base = f"model.layers.{layer}"
+        tensors[f"{base}.self_attn.o_proj.weight"] = torch.randn(HIDDEN, HIDDEN)
+        tensors[f"{base}.self_attn.o_proj.bias"] = torch.randn(HIDDEN)
+        for expert_id in range(num_experts):
+            p = f"{base}.mlp.experts.{expert_id}"
+            tensors[f"{p}.gate_proj.weight"] = torch.randn(INTER, HIDDEN)
+            tensors[f"{p}.up_proj.weight"] = torch.randn(INTER, HIDDEN)
+            tensors[f"{p}.down_proj.weight"] = torch.randn(HIDDEN, INTER)
+    return tensors
+
+
+def iterator_over(tensors):
+    """A weights iterator over a name->tensor mapping or a list of pairs.
+
+    Pairs are what a checkpoint that repeats a name looks like from here, which a
+    dict cannot express.
+    """
+    pairs = list(tensors.items() if isinstance(tensors, dict) else tensors)
+
+    def _iterator(path, disable_mmap, wants=None):
+        for name, tensor in pairs:
+            if wants is None or wants(name):
+                yield name, tensor
+
+    return _iterator
+
+
+@contextlib.contextmanager
+def env_overrides(**values: str):
+    previous = {k: os.environ.get(k) for k in values}
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+NUM_LAYERS = 2
+NUM_EXPERTS = 4
+
+
+def run_load(
+    *,
+    streaming: bool,
+    host_staging: bool = True,
+    num_threads: int = 1,
+    tail_threads: int = 0,
+    linear_cls=StreamLinear,
+    num_layers: int = NUM_LAYERS,
+    tensors=None,
+    model_cls=StreamModel,
+) -> tuple[StreamModel, OnlineQuantStreamer | None]:
+    with env_overrides(
+        ATOM_LOADER_NUM_THREADS=str(num_threads),
+        ATOM_ONLINE_QUANT_STREAMING="1" if streaming else "0",
+        ATOM_ONLINE_QUANT_STREAMING_HOST_STAGING="1" if host_staging else "0",
+        ATOM_ONLINE_QUANT_STREAMING_THREADS=str(tail_threads),
+    ):
+        model = model_cls(num_layers, NUM_EXPERTS, streaming, linear_cls)
+        online_quant_streamer = OnlineQuantStreamer.maybe_create(model, None)
+        # Stashed rather than returned so the existing two-value unpacking holds;
+        # the coverage record is only interesting to a couple of tests.
+        model._loaded_weights_record = load_weights_into_model(
+            model=model,
+            model_name_or_path="<synthetic>",
+            hf_config=HFConfig(num_layers, NUM_EXPERTS),
+            default_weight_loader=default_weight_loader,
+            fuse_shared_expert=lambda *_args, **_kw: False,
+            is_rank0=lambda: True,
+            weights_iterator=iterator_over(
+                checkpoint(num_layers, NUM_EXPERTS) if tensors is None else tensors
+            ),
+            load_fused_expert_weights_fn=getattr(
+                model, "load_fused_expert_weights", None
+            ),
+            online_quant_streamer=online_quant_streamer,
+        )
+        if online_quant_streamer is not None:
+            online_quant_streamer.replay_stragglers_and_report(True)
+    return model, online_quant_streamer
+
+
+def weights_of(model: StreamModel) -> dict[str, torch.Tensor]:
+    return {name: p.detach().clone() for name, p in model.named_parameters()}
+
+
+class StreamingDifferentialTest(unittest.TestCase):
+    """Every storage path must leave the same bytes in the parameters."""
+
+    def setUp(self):
+        self.baseline, _ = run_load(streaming=False)
+        self.expected = weights_of(self.baseline)
+
+    def assert_matches_baseline(self, model: StreamModel):
+        actual = weights_of(model)
+        self.assertEqual(sorted(self.expected), sorted(actual))
+        for name, want in self.expected.items():
+            self.assertFalse(actual[name].is_meta, f"{name} left on meta")
+            torch.testing.assert_close(
+                want, actual[name], rtol=0, atol=0, msg=f"mismatch: {name}"
+            )
+
+    def test_host_staging_matches_non_streaming(self):
+        model, _ = run_load(streaming=True, host_staging=True)
+        self.assert_matches_baseline(model)
+
+    def test_buffered_replay_matches_non_streaming(self):
+        model, _ = run_load(streaming=True, host_staging=False)
+        self.assert_matches_baseline(model)
+
+    def test_host_staging_with_parallel_walk_matches_non_streaming(self):
+        model, _ = run_load(streaming=True, host_staging=True, num_threads=8)
+        self.assert_matches_baseline(model)
+
+    def test_host_staging_with_tail_workers_matches_non_streaming(self):
+        model, _ = run_load(
+            streaming=True, host_staging=True, num_threads=8, tail_threads=2
+        )
+        self.assert_matches_baseline(model)
+
+    def test_loader_without_a_host_kernel_falls_back_to_the_device(self):
+        model, online_quant_streamer = run_load(
+            streaming=True, linear_cls=HostHostileLinear
+        )
+        self.assert_matches_baseline(model)
+        for layer in model.model.layers:
+            # The first refusal moves the whole module off host storage.
+            self.assertEqual(layer.self_attn.o_proj.refusals, 1)
+            self.assertEqual(layer.mlp.experts.stage_calls, 3 * NUM_EXPERTS)
+        self.assertEqual(
+            len(online_quant_streamer.done_module_ids),
+            len(online_quant_streamer.candidates),
+        )
+
+
+class StreamingTriggerTest(unittest.TestCase):
+    """Completion has to fire during the walk, once per module."""
+
+    def assert_every_module_streamed(self, model, online_quant_streamer):
+        streamed = model.streamed_modules()
+        self.assertEqual(len(online_quant_streamer.done_module_ids), len(streamed))
+        for module in streamed:
+            self.assertIn(id(module), online_quant_streamer.done_module_ids)
+            self.assertEqual(module.post_process_calls, 1)
+        self.assertEqual(online_quant_streamer.excessive_loads, [])
+
+    def test_every_module_completes_under_host_staging(self):
+        model, online_quant_streamer = run_load(streaming=True, host_staging=True)
+        self.assert_every_module_streamed(model, online_quant_streamer)
+
+    def test_every_module_completes_under_buffered_replay(self):
+        model, online_quant_streamer = run_load(streaming=True, host_staging=False)
+        self.assert_every_module_streamed(model, online_quant_streamer)
+
+    def test_every_module_completes_with_a_parallel_walk(self):
+        model, online_quant_streamer = run_load(
+            streaming=True, host_staging=True, num_threads=8, tail_threads=2
+        )
+        self.assert_every_module_streamed(model, online_quant_streamer)
+
+    def test_a_loader_that_copies_twice_does_not_claim_early(self):
+        """Repeated copies into one parameter must not claim the module early."""
+        model, online_quant_streamer = run_load(
+            streaming=True, linear_cls=DoubleCopyLinear
+        )
+        self.assert_every_module_streamed(model, online_quant_streamer)
+        baseline, _ = run_load(streaming=False, linear_cls=DoubleCopyLinear)
+        for name, want in weights_of(baseline).items():
+            torch.testing.assert_close(
+                want, dict(model.named_parameters())[name].detach(), rtol=0, atol=0
+            )
+
+    def test_host_staging_buffers_no_loader_calls(self):
+        """Host staging must release checkpoint tensors immediately."""
+        model, _ = run_load(streaming=True, host_staging=True)
+        for module in model.streamed_modules():
+            self.assertEqual(module._stream_buffer_list, [])
+
+    def test_materialized_param_skips_module_lock_on_later_arrivals(self):
+        """Only the first shard should serialize to create parameter storage."""
+
+        class FailIfEntered:
+            def __enter__(self):
+                raise AssertionError("materialized fast path reacquired module lock")
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+        with env_overrides(ATOM_ONLINE_QUANT_STREAMING_HOST_STAGING="1"):
+            model = StreamModel(1, NUM_EXPERTS, stream=True)
+            streamer = OnlineQuantStreamer.maybe_create(model, None)
+            experts = model.model.layers[0].mlp.experts
+            param = experts.w13_weight
+
+            self.assertFalse(
+                streamer._ensure_storage_or_defer(experts, param),
+            )
+            self.assertIn(id(param), experts._stream_materialized_param_ids)
+            experts._stream_lock = FailIfEntered()
+            self.assertFalse(
+                streamer._ensure_storage_or_defer(experts, param),
+            )
+
+    def test_fused_param_declines_later_semantic_staging(self):
+        """A fused writer owns the parameter even if expert shards follow."""
+        with env_overrides(ATOM_ONLINE_QUANT_STREAMING_HOST_STAGING="1"):
+            model = StreamModel(1, NUM_EXPERTS, stream=True)
+            streamer = OnlineQuantStreamer.maybe_create(model, None)
+            experts = model.model.layers[0].mlp.experts
+            param = experts.w13_weight
+
+            streamer.materialize_fused_param(param)
+            self.assertIn(id(param), experts._stream_moe_declined_param_ids)
+            self.assertTrue(experts._stream_tracking_invalid)
+
+            source = torch.ones(INTER, HIDDEN)
+            counter = streamer._run_counted(
+                experts,
+                param,
+                experts.weight_loader,
+                (param, source, "experts.w13_weight", "w1", 0),
+            )
+
+            self.assertIsNone(counter.moe_arrival)
+            self.assertEqual(experts.stage_calls, 0)
+            self.assertEqual(experts.loader_calls, 1)
+
+    def test_moe_arrivals_use_semantic_regions_without_dispatch_counting(self):
+        class CountingCopyCounter(streaming_module._CopyCounter):
+            entries = 0
+
+            def __enter__(self):
+                type(self).entries += 1
+                return super().__enter__()
+
+        with mock.patch.object(
+            streaming_module,
+            "_CopyCounter",
+            CountingCopyCounter,
+        ):
+            model, _ = run_load(
+                streaming=True,
+                num_layers=1,
+                num_threads=1,
+            )
+
+        # MoE shards use semantic regions; only Linear params use copy counting.
+        self.assertEqual(CountingCopyCounter.entries, 2)
+        experts = model.model.layers[0].mlp.experts
+        self.assertEqual(experts.loader_calls, 0)
+        self.assertEqual(experts.stage_calls, 3 * NUM_EXPERTS)
+        self.assertEqual(
+            len(experts._stream_moe_arrivals[id(experts.w13_weight)]),
+            2 * NUM_EXPERTS,
+        )
+        self.assertEqual(
+            len(experts._stream_moe_arrivals[id(experts.w2_weight)]),
+            NUM_EXPERTS,
+        )
+
+    def test_duplicate_moe_region_does_not_claim_module_early(self):
+        tensors = list(checkpoint(1, NUM_EXPERTS).items())
+        duplicate_index = next(
+            i for i, (name, _) in enumerate(tensors) if ".0.gate_proj.weight" in name
+        )
+        tensors.insert(duplicate_index + 1, tensors[duplicate_index])
+
+        model, online_quant_streamer = run_load(
+            streaming=True,
+            num_layers=1,
+            tensors=tensors,
+        )
+
+        self.assert_every_module_streamed(model, online_quant_streamer)
+        baseline, _ = run_load(streaming=False, num_layers=1)
+        for name, want in weights_of(baseline).items():
+            torch.testing.assert_close(
+                want,
+                dict(model.named_parameters())[name].detach(),
+                rtol=0,
+                atol=0,
+            )
+
+    def test_shared_expert_regions_are_not_covered_by_routed_staging(self):
+        model, online_quant_streamer = run_load(
+            streaming=True,
+            num_layers=1,
+            model_cls=SharedExpertStreamModel,
+        )
+
+        self.assert_every_module_streamed(model, online_quant_streamer)
+        experts = model.model.layers[0].mlp.experts
+        # Routed base slots take the staging protocol; the final shared slot
+        # remains on the generic loader and contributes its own three regions.
+        self.assertEqual(experts.stage_calls, 3 * (NUM_EXPERTS - 1))
+        self.assertEqual(experts.loader_calls, 3)
+
+    def test_param_that_declines_before_staging_uses_generic_counter(self):
+        model, online_quant_streamer = run_load(
+            streaming=True,
+            num_layers=1,
+            model_cls=DeclineW2StreamModel,
+        )
+
+        self.assert_every_module_streamed(model, online_quant_streamer)
+        experts = model.model.layers[0].mlp.experts
+        self.assertEqual(experts.loader_calls, NUM_EXPERTS)
+        self.assertIn(
+            id(experts.w2_weight),
+            experts._stream_moe_declined_param_ids,
+        )
+
+    def test_mixed_semantic_and_declined_param_falls_back_safely(self):
+        model, online_quant_streamer = run_load(
+            streaming=True,
+            num_layers=1,
+            model_cls=DeclineW3StreamModel,
+        )
+
+        experts = model.model.layers[0].mlp.experts
+        self.assertNotIn(id(experts), online_quant_streamer.done_module_ids)
+        self.assertTrue(experts._stream_tracking_invalid)
+        baseline, _ = run_load(
+            streaming=False,
+            num_layers=1,
+            model_cls=DeclineW3StreamModel,
+        )
+        for name, want in weights_of(baseline).items():
+            torch.testing.assert_close(
+                want,
+                dict(model.named_parameters())[name].detach(),
+                rtol=0,
+                atol=0,
+            )
+
+
+class SwapStorageVisibilityTest(unittest.TestCase):
+    """Keep parameter attributes visible during concurrent storage swaps."""
+
+    def test_attributes_stay_visible_across_a_concurrent_swap(self):
+        param = nn.Parameter(torch.zeros(4, 4, device="meta"), requires_grad=False)
+        sentinel = object()
+        param.weight_loader = sentinel
+        misses = []
+        stop = threading.Event()
+
+        def reader():
+            while not stop.is_set():
+                if getattr(param, "weight_loader", None) is not sentinel:
+                    misses.append(1)
+
+        # Increase scheduling frequency to expose the narrow swap window.
+        interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        watcher = threading.Thread(target=reader)
+        watcher.start()
+        try:
+            for _ in range(2000):
+                OnlineQuantStreamer._swap_storage(param, torch.zeros(4, 4))
+        finally:
+            stop.set()
+            watcher.join()
+            sys.setswitchinterval(interval)
+        self.assertEqual(misses, [], "weight_loader disappeared during a swap")
+        self.assertIs(param.weight_loader, sentinel)
+
+
+class StreamingCoverageTest(unittest.TestCase):
+    """What the checkpoint over- or under-delivers must not pass silently."""
+
+    def test_missing_parameter_is_zero_filled_not_left_on_meta(self):
+        tensors = checkpoint(1, NUM_EXPERTS)
+        del tensors["model.layers.0.self_attn.o_proj.bias"]
+        model, online_quant_streamer = run_load(
+            streaming=True, num_layers=1, tensors=tensors
+        )
+        o_proj = model.model.layers[0].self_attn.o_proj
+        self.assertFalse(o_proj.bias.data.is_meta)
+        torch.testing.assert_close(o_proj.bias.data, torch.zeros_like(o_proj.bias.data))
+        # It never reached its expected numel, so it fell back to the post-load
+        # pass -- while the MoE beside it, which did complete, still streamed.
+        self.assertNotIn(id(o_proj), online_quant_streamer.done_module_ids)
+        self.assertIn(
+            id(model.model.layers[0].mlp.experts),
+            online_quant_streamer.done_module_ids,
+        )
+
+    def test_fused_expert_writes_get_storage_and_fall_back(self):
+        """Fused writes get storage and fall back when coverage is unknown."""
+        model, online_quant_streamer = run_load(
+            streaming=True,
+            num_layers=1,
+            tensors=fused_checkpoint(1, NUM_EXPERTS),
+            model_cls=FusedExpertStreamModel,
+        )
+        experts = model.model.layers[0].mlp.experts
+        for param in (experts.w13_weight, experts.w2_weight):
+            self.assertFalse(param.data.is_meta)
+        self.assertNotIn(id(experts), online_quant_streamer.done_module_ids)
+        self.assertEqual(experts.post_process_calls, 0)
+        self.assertLessEqual(
+            {
+                "model.layers.0.mlp.experts.w13_weight",
+                "model.layers.0.mlp.experts.w2_weight",
+            },
+            model._loaded_weights_record,
+        )
+
+        baseline, _ = run_load(
+            streaming=False,
+            num_layers=1,
+            tensors=fused_checkpoint(1, NUM_EXPERTS),
+            model_cls=FusedExpertStreamModel,
+        )
+        for name, want in weights_of(baseline).items():
+            torch.testing.assert_close(
+                want, dict(model.named_parameters())[name].detach(), rtol=0, atol=0
+            )
+
+    def test_load_arriving_after_the_module_was_quantized_is_dropped(self):
+        """Drop source writes that arrive after quantization."""
+        tensors = checkpoint(1, NUM_EXPERTS)
+        weight_name = "model.layers.0.self_attn.o_proj.weight"
+        wanted = tensors[weight_name].clone()
+        surplus = list(tensors.items()) + [(weight_name, torch.full_like(wanted, 7.0))]
+        model, online_quant_streamer = run_load(
+            streaming=True, num_layers=1, tensors=surplus
+        )
+        weight = model.model.layers[0].self_attn.o_proj.weight
+        torch.testing.assert_close(weight.detach(), wanted, rtol=0, atol=0)
+        self.assertEqual(len(online_quant_streamer.excessive_loads), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_online_quant_streaming.py
+++ b/tests/test_online_quant_streaming.py
@@ -173,6 +173,34 @@ class SharedExpertStreamMoE(StreamMoE):
         self.num_batched_experts = num_experts - 1
 
 
+class ExpertParallelStreamMoE(StreamMoE):
+    """Rank-zero EP storage for half of the checkpoint experts."""
+
+    def __init__(self, num_experts: int, stream: bool):
+        super().__init__(num_experts // 2, stream)
+
+    @staticmethod
+    def _map_global_expert_id_to_local_expert_id(expert_id):
+        return expert_id if expert_id < NUM_EXPERTS // 2 else -1
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        weight_name: str,
+        shard_id: str,
+        expert_id: int,
+    ) -> None:
+        local_expert_id = self._map_global_expert_id_to_local_expert_id(expert_id)
+        if local_expert_id == -1:
+            return
+        self._copy_expert_shard(
+            param.data[local_expert_id],
+            loaded_weight,
+            shard_id,
+        )
+
+
 class DeclineW2StreamMoE(StreamMoE):
     def stage_expert_weight(self, *args, shard_id, **kwargs):
         if shard_id == "w2":
@@ -240,6 +268,10 @@ class StreamModel(nn.Module):
 
 class SharedExpertStreamModel(StreamModel):
     moe_cls = SharedExpertStreamMoE
+
+
+class ExpertParallelStreamModel(StreamModel):
+    moe_cls = ExpertParallelStreamMoE
 
 
 class DeclineW2StreamModel(StreamModel):
@@ -753,6 +785,27 @@ class StreamingCoverageTest(unittest.TestCase):
         weight = model.model.layers[0].self_attn.o_proj.weight
         torch.testing.assert_close(weight.detach(), wanted, rtol=0, atol=0)
         self.assertEqual(len(online_quant_streamer.excessive_loads), 1)
+
+    def test_nonlocal_ep_loads_after_quantization_are_ignored(self):
+        """Do not report non-local expert arrivals after local completion."""
+        model, online_quant_streamer = run_load(
+            streaming=True,
+            num_layers=1,
+            model_cls=ExpertParallelStreamModel,
+        )
+        baseline, _ = run_load(
+            streaming=False,
+            num_layers=1,
+            model_cls=ExpertParallelStreamModel,
+        )
+
+        experts = model.model.layers[0].mlp.experts
+        self.assertIn(id(experts), online_quant_streamer.done_module_ids)
+        self.assertEqual(online_quant_streamer.excessive_loads, [])
+        for name, want in weights_of(baseline).items():
+            torch.testing.assert_close(
+                want, dict(model.named_parameters())[name].detach(), rtol=0, atol=0
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This feature implements streaming online quantization, with the primary goal of reducing peak video memory usage. You can use `ATOM_ONLINE_QUANT_STREAMING=0` to safely fall back to the normal post-quantization workflow.

To speed up streaming online quantization in a multithreaded environment, gather-weight has been temporarily disabled. If you need fully aligned offline quantization, please use `ATOM_ONLINE_QUANT_STREAMING=0` to disable streaming online quantization.

## Background

The original implementation was a naive single-threaded loop. To keep GPU memory down, every parameter of an eligible module is created on the meta device. We track how many elements a module expects against how many have actually arrived, and use that to decide when to give the parameters real storage and load the checkpoint data into them. Loader calls that arrive before a module is complete are buffered and replayed once the remaining shards land.

That first version was correct but slow: MXFP4 quantization of DeepSeek-R1-0528 took over three minutes.

## What this PR changes

This PR makes the path multithreaded, structured as a two-stage pipeline:

- **Stage 1** — the existing `submit` path: disk reads and CPU memcpy.
- **Stage 2** — H2D transfer plus GPU compute.

`OnlineQuantStreamer` owns online quantization for both Linear and FusedMoE modules.

## How it works

Everything the streamer does once `submit` starts calling it concurrently is visible in `run`.

The streamer holds the list of modules that need quantization. Modules that don't need it are initialized on the device up front as usual, and the streamer passes their loads straight through.

The first thread to reach a given module is responsible for materializing that module's weights on the host, so those parameters start life on CPU.

Loading itself goes through the existing weight loader, which writes the safetensors data into those parameters. A counter records how many elements each call contributed to the module.

Once a module has received every element it expects, a stage-2 worker uploads it to the device — one copy per parameter rather than one per shard — and then runs online quantization on it.

## Design notes

1. Streaming online quantization and `ExpertStagingPool` online quantize are mutually exclusive. The streamer works at module granularity while the pool works at parameter granularity, and the streamer has to cover the whole model whereas the pool only handles the MoE part. Streaming adopts the same coalesced-H2D idea, which is what keeps it fast.
2. Streaming is enabled by default, and it slightly changes numerics. A streamed layer quantizes its own TP shard as the weights land, instead of all-gathering the full weight first, so its scales are computed over partial rows/blocks rather than over the whole tensor. Output is therefore no longer bit-exact with offline quantization (see `LinearBase.online_quantize_weight`), though the difference is a scale-granularity effect rather than a correctness issue. Set `ATOM_ONLINE_QUANT_STREAMING=0` to fall back to the classic load-then-quantize path when you need to match offline results exactly.
3. Host staging is what lets the checkpoint walk stay multithreaded. With it, the walk performs the copies itself and runs with the usual `ATOM_LOADER_NUM_THREADS`. With it off, parameters stay on meta, every loader call is buffered and replayed against device storage at the end, and the walk is forced single-threaded — the buffer list is not safe to interleave, and there is no copy work to parallelize anyway. That mode also pins a reference to every pending checkpoint tensor and turns a FusedMoE's thousands of per-expert writes into thousands of small H2D copies instead of one per parameter.
4. The stage-2 pool is bounded by a semaphore sized at twice the worker count. `ThreadPoolExecutor`'s queue is unbounded and `submit` never blocks, so without the gate the walk would race ahead and pile up every remaining module's host sources — and, once a worker picks them up, their device memory — which is exactly the peak streaming exists to avoid. A consequence worth knowing: raising `ATOM_ONLINE_QUANT_STREAMING_THREADS` is not merely more threads, it lifts the in-flight watermark proportionally and both the host and the device peak follow.
5. Each stage-2 worker gets its own CUDA side stream, and the pool initializer pins the worker's device. A fresh thread's current CUDA device defaults to 0 regardless of the process's, so a worker on rank > 0 would launch kernels onto the wrong GPU. Sharing the default stream instead makes the workers convoy — a blocking H2D issued by one cannot start until everything the others already queued has drained — which inflated the per-module quantization cost by more than an order of magnitude while buying no overlap.
6. Completion is detected by measuring copies, not by deriving them. Loaders narrow and shard the source, so the incoming tensor's size is not the answer; a `TorchDispatchMode` counts the elements actually written by `aten.copy_` instead. Each call is capped at the destination parameter's `numel`, because some loaders write their destination more than once — an in-place post-load transform layered on the initial copy — and the double count would trigger the module early, quantizing it while later parameters are still in flight.
7. `_finalize` releases the pre-quantization parameter storage explicitly. Quantization swaps in fresh `Parameter` objects while `params_dict` still points at the originals, and `del params_dict` only runs after the whole load — so without this the BF16 sources accumulate alongside the quantized weights and streaming would peak *higher* than the classic post-load path. The storage is emptied rather than the object dropped, because `param_to_module` is keyed on `id(param)` and a recycled id would produce false hits.
8. Why does Streamer remove the padding from Moe?
When the original model creates weights, `_stream_expected_numel` is calculated based on the padded shape (512), while the loader only writes the logical columns from the checkpoint (384), so the count is never sufficient.
When the second creation is completed during online quantization, any padding is restored and does not affect normal functionality.


## Test

stream online quant

```
python -m atom.examples.simple_inference   --model /shareddata/haoyanli/deepseek-ai/DeepSeek-R1-0528 --enforce-eager -tp 4   --online_quant_config '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": ["lm_head", "*.gate.*"]}'

Peak Video Memory During Weight Loading: 92GB
load phases: read+queue 54.56s (90427 tensors) | drain 6.89s | quant drain 0.16s | staging flush 0.00s | threads 16

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9424|±  |0.0064|
|     |       |strict-match    |     3|exact_match|↑  |0.9386|±  |0.0066|

```

normal loading

```
python -m atom.examples.simple_inference   --model /shareddata/haoyanli/deepseek-ai/DeepSeek-R1-0528 --enforce-eager -tp 4

Peak Video Memory During Weight Loading: 161GB
load phases: read+queue 30.45s (90427 tensors) | drain 0.28s | staging flush 0.00s | threads 16
```

original online quant

```
ATOM_ONLINE_QUANT_STREAMING=0 python -m atom.examples.simple_inference   --model /shareddata/haoyanli/deepseek-ai/DeepSeek-R1-0528 --enforce-eager -tp 4   --online_quant_config '{"global_quant_config": "ptpc_fp8", "layer_quant_config": {"*expert*": "mxfp4"}, "exclude_layer": ["lm_head", "*.gate.*"]}'

Peak Video Memory During Weight Loading: 161GB
load phases: read+queue 29.29s (90427 tensors) | drain 0.30s | staging flush 0.00s | threads 16
+
post-processing 8s
```

**Update 20260804**
Speed up (test model: deeseek-r1-0528)
1.The counter that tracks whether all weight parameters are present uses `torchdispatch`, but Moe’s sharding format causes this call to be made tens of thousands of times, resulting in significant overhead.
We directly reused some existing Moe code; instead of dynamically monitoring, we use `(expert_id, shard_id)` to determine which region this write operation overwrites.
This reduced the runtime of deepseek-r1 by approximately 5s.

2.Multithreading requires locks to determine the module's state. State queries should be moved outside the lock as much as possible, with operations inside the lock serving as a fallback measure; this results in a performance gain of approximately 3 seconds.

3.In a multithreaded environment, it is best to avoid having too many small kernels, as this significantly increases scheduling overhead. Some Other Code Optimizations



model | mode | tp | load_time_run1_s | load_time_run2_s | peak_gpu_memory_gb | gsm8k_3shot_flexible_pct
-- | -- | -- | -- | -- | -- | --
DeepSeek-R1-0528 fp8+mxfp4 | streaming online | 4 | 39.45 | 39.54 | 90.72 | 94.62
DeepSeek-R1-0528 fp8+mxfp4 | non-streaming | 4 | 31.58 | 31.89 | 161.21 | 94.39
Qwen3-235B EP mxfp4 | streaming online | 4 | 16.93 | 16.7 | 33 | 88.86
Qwen3-235B EP mxfp4 | non-streaming | 4 | 14.56 | 14.74 | 111.95 | 89.01


TODO:
1. optimize the qwen3.5 Series.