### PR TITLE
fix: forward extra args in patched_inline_call for torch _dynamo compat

### DIFF
--- a/atom/utils/decorators.py
+++ b/atom/utils/decorators.py
@@ -564,10 +564,14 @@ def _support_torch_compile(
             # during Dynamo tracing, and their corresponding files
             inline_call = InliningInstructionTranslator.inline_call
 
-            def patched_inline_call(parent, func, args, kwargs):
+            def patched_inline_call(
+                parent, func, args, kwargs, *extra_args, **extra_kwargs
+            ):
                 code = func.get_code()
                 self.vllm_config.compilation_config.traced_files.add(code.co_filename)
-                return inline_call(parent, func, args, kwargs)
+                return inline_call(
+                    parent, func, args, kwargs, *extra_args, **extra_kwargs
+                )
 
             with patch.object(
                 InliningInstructionTranslator, "inline_call", patched_inline_call


### PR DESCRIPTION
## Summary

The `@support_torch_compile` traced-files instrumentation in
`atom/utils/decorators.py` monkeypatches
`InliningInstructionTranslator.inline_call` to record every file Dynamo
traces. The wrapper hardcoded torch's `(parent, func, args, kwargs)`
signature.

Upstream torch added an `allow_nested_graph_breaks` parameter to
`inline_call` (present on [`pytorch/main`](https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/symbolic_convert.py),
the `InliningInstructionTranslator.inline_call` classmethod). When Dynamo
invokes `inline_call(..., allow_nested_graph_breaks=...)`, it hits our
wrapper, which has no such parameter, and the whole compile aborts with an
`InternalTorchDynamoError`. This breaks server startup on any recent torch
(reproduced here on a `2.13.0a0+rocm7.14` build serving Qwen3-8B).

## Fix

Forward `*extra_args, **extra_kwargs` through the wrapper so it is agnostic
to torch's `inline_call` signature. Backward compatible with the older
4-arg form, and resilient to future `_dynamo` signature changes.

```python
def patched_inline_call(
    parent, func, args, kwargs, *extra_args, **extra_kwargs
):
    code = func.get_code()
    self.vllm_config.compilation_config.traced_files.add(code.co_filename)
    return inline_call(
        parent, func, args, kwargs, *extra_args, **extra_kwargs
    )
```

## Stack trace (before fix)

```
  File "/opt/venv/lib64/python3.12/site-packages/torch/_dynamo/convert_frame.py", line 2168, in _compile
    raise InternalTorchDynamoError(
  ...
  File "/opt/venv/lib64/python3.12/site-packages/torch/_dynamo/symbolic_convert.py", line 1493, in call_function
    self.push(fn.call_function(self, args, kwargs))
  File "/opt/venv/lib64/python3.12/site-packages/torch/_dynamo/variables/functions.py", line 519, in call_function
    return tx.inline_user_function_return(
  File "/opt/venv/lib64/python3.12/site-packages/torch/_dynamo/symbolic_convert.py", line 1521, in inline_user_function_return
    return InliningInstructionTranslator.inline_call(
torch._dynamo.exc.InternalTorchDynamoError: TypeError: _support_torch_compile.<locals>.__call__.<locals>.patched_inline_call() got an unexpected keyword argument 'allow_nested_graph_breaks'
```

## Test plan

- [x] `black atom/utils/decorators.py` — no changes
- [x] `ruff check atom/utils/decorators.py` — passes
- [x] Server starts and serves (Qwen3-8B) on torch `2.13.0a0+rocm7.14`; compile no longer aborts
- [ ] CI accuracy/lint checks