### PR TITLE
[sglang+atom] enable minimax-m3 mtp && fix m3 error cased by sglang update

### DIFF
--- a/.github/benchmark/sglang_benchmark_models.json
+++ b/.github/benchmark/sglang_benchmark_models.json
@@ -10,6 +10,7 @@
       "glm52_pcp_fp8_runtime": "--trust-remote-code --tp-size 4 --enable-nsa-prefill-context-parallel --attn-cp-size 2 --nsa-prefill-cp-mode round-robin-split --max-prefill-tokens 30720 --chunked-prefill-size 30720 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"per_block_fp8\"},\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"*.mlp.gate\"]}}'",
       "glm52_mi308_fp8_runtime": "--trust-remote-code --tp-size 8 --mem-fraction-static 0.8 --disable-radix-cache --max-prefill-tokens 65536 --kv-cache-dtype fp8_e4m3",
       "glm52_fp4_runtime": "--trust-remote-code --tp-size 4 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"*.mlp.gate\",\"*expert*\"]}}'",
+      "minimax_m3_eagle3_runtime": "--trust-remote-code --random-seed 0 --tensor-parallel-size 4 --attention-backend aiter --mem-fraction-static 0.75 --page-size 128 --context-length 32768 --max-running-requests 128 --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"vision_tower\",\"multi_modal_projector\",\"patch_merge_mlp\",\"*block_sparse_moe\"]}}' --json-model-override-args '{\"use_index_cache\":true,\"index_topk_freq\":4}' --speculative-algorithm EAGLE3 --speculative-draft-model-path Inferact/MiniMax-M3-EAGLE3 --speculative-num-steps 3 --speculative-eagle-topk 1 --kv-cache-dtype fp8_e4m3 --disable-radix-cache --decode-log-interval 1",
       "mtp1_common": "--speculative-draft-model-path SGLang/DeepSeek-R1-NextN --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 --max-running-requests 256 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256",
       "mtp3_common": "--speculative-draft-model-path SGLang/DeepSeek-R1-NextN --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256"
     },
@@ -24,6 +25,7 @@
       "glm52_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1\nSGLANG_USE_AITER=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
       "glm52_pcp_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_SGLANG_PCP_SIZE=2\nATOM_PCP_MOE_MERGE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
       "glm52_mi308_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_ENABLE_TORCH_COMPILE=1\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
+      "minimax_m3_eagle3_common": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128\nATOM_SGLANG_EAGLE3_TP_VERIFY_BROADCAST=1",
       "qwen_common": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0"
     }
   },
@@ -372,6 +374,23 @@
         "deepseek_mtp_dp_common",
         "SGLANG_AITER_FP8_PREFILL_ATTN=1"
       ]
+    },
+    {
+      "display": "MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3",
+      "dashboard_model": "MiniMax-M3-MXFP8-EAGLE3-MTP3",
+      "workload_label": "SGLang-OOB",
+      "source_path": "MiniMaxAI/MiniMax-M3-MXFP8",
+      "path": "MiniMaxAI/MiniMax-M3-MXFP8",
+      "prefix": "minimax-m3-mxfp8-eagle3-tp4-mtp3",
+      "extra_args": "minimax_m3_eagle3_runtime",
+      "bench_args": "--use-chat-template",
+      "runner": "atom-mi355-8gpu-aac-runner",
+      "nightly_group": "B",
+      "supported_input_output_pairs": ["1024x1024"],
+      "supported_concurrency_values_by_pair": {
+        "1024x1024": [128]
+      },
+      "env_vars": "minimax_m3_eagle3_common"
     },
     {
       "display": "Qwen3.5-397B-A17B-FP8 TP4",

--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -120,6 +120,22 @@
     "_baseline_note": "SGLang-ATOM MiniMax-M3-MXFP4 TP4 measured on GSM8K benchmark."
   },
   {
+    "model_name": "MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3",
+    "model_path": "MiniMaxAI/MiniMax-M3-MXFP8",
+    "extraArgs": "--trust-remote-code --random-seed 0 --tensor-parallel-size 4 --attention-backend aiter --mem-fraction-static 0.75 --page-size 128 --context-length 32768 --max-running-requests 128 --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"vision_tower\",\"multi_modal_projector\",\"patch_merge_mlp\",\"*block_sparse_moe\"]}}' --json-model-override-args '{\"use_index_cache\":true,\"index_topk_freq\":4}' --speculative-algorithm EAGLE3 --speculative-draft-model-path Inferact/MiniMax-M3-EAGLE3 --speculative-num-steps 3 --speculative-eagle-topk 1 --kv-cache-dtype fp8_e4m3 --disable-radix-cache --decode-log-interval 1",
+    "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128\nATOM_SGLANG_EAGLE3_TP_VERIFY_BROADCAST=1",
+    "runner": "atom-plugin-acc-validation-runner-sgl",
+    "test_level": "nightly",
+    "lm_eval_num_fewshot": 5,
+    "lm_eval_num_concurrent": 32,
+    "lm_eval_use_chat_completions": "1",
+    "lm_eval_extra_model_args": "max_gen_toks=16384",
+    "accuracy_threshold": 0.93,
+    "accuracy_baseline": null,
+    "accuracy_baseline_model": "MiniMaxAI/MiniMax-M3-MXFP8 + Inferact/MiniMax-M3-EAGLE3",
+    "_baseline_note": "SGLang-ATOM MiniMax-M3-MXFP8 TP4 with EAGLE3 speculative decoding; threshold follows the existing MiniMax-M3 GSM8K validation target."
+  },
+  {
     "model_name": "Qwen3.5-35B-A3B-FP8 TP2",
     "model_path": "Qwen/Qwen3.5-35B-A3B-FP8",
     "extraArgs": "--tensor-parallel-size 2 --mem-fraction-static 0.9 --reasoning-parser qwen3 --disable-radix-cache",

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -26,6 +26,7 @@ on:
           - Kimi-K2.6-MXFP4 TP4
           - Kimi-K2.6-MXFP4 TP8
           - MiniMax-M3-MXFP4 TP4
+          - MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3
           - Qwen3.5-35B-A3B-FP8 TP2
           - Qwen3.5-35B-A3B TP2
           - Qwen3.5-397B-A17B-FP8 TP4
@@ -249,6 +250,19 @@ jobs:
                   "lm_eval_extra_model_args": "max_gen_toks=16384",
                   "accuracy_test_threshold": 0.93,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models",
+                  "runner": "atom-plugin-acc-validation-runner-sgl",
+              },
+              {
+                  "toggle_env": "RUN_MINIMAX_M3_MXFP8_EAGLE3_TP4_MTP3",
+                  "model_name": "MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3",
+                  "model_path": "MiniMaxAI/MiniMax-M3-MXFP8",
+                  "extra_args": "--trust-remote-code --random-seed 0 --tensor-parallel-size 4 --attention-backend aiter --mem-fraction-static 0.75 --page-size 128 --context-length 32768 --max-running-requests 128 --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"vision_tower\",\"multi_modal_projector\",\"patch_merge_mlp\",\"*block_sparse_moe\"]}}' --json-model-override-args '{\"use_index_cache\":true,\"index_topk_freq\":4}' --speculative-algorithm EAGLE3 --speculative-draft-model-path Inferact/MiniMax-M3-EAGLE3 --speculative-num-steps 3 --speculative-eagle-topk 1 --kv-cache-dtype fp8_e4m3 --disable-radix-cache --decode-log-interval 1",
+                  "lm_eval_num_fewshot": 5,
+                  "lm_eval_num_concurrent": 32,
+                  "lm_eval_use_chat_completions": "1",
+                  "lm_eval_extra_model_args": "max_gen_toks=16384",
+                  "accuracy_test_threshold": 0.93,
+                  "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128\nATOM_SGLANG_EAGLE3_TP_VERIFY_BROADCAST=1",
                   "runner": "atom-plugin-acc-validation-runner-sgl",
               },
               {

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -51,6 +51,7 @@ on:
           - GLM-5.2 FP8 TP4
           - GLM-5.2 FP8 TP4 PCP2
           - GLM-5.2 FP4 TP4
+          - MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3
       model_mi308:
         description: "Manual MI308 benchmark model selection"
         required: false
@@ -666,6 +667,7 @@ jobs:
               "GLM-5.2 FP8 TP4": "glm-5-2-fp8-tp4",
               "GLM-5.2 FP8 TP4 PCP2": "glm-5-2-fp8-tp4-pcp2",
               "GLM-5.2 FP4 TP4": "glm-5-2-fp4-tp4",
+              "MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3": "minimax-m3-mxfp8-eagle3-tp4-mtp3",
               "MI308 Qwen3.5-397B-A17B-FP8 TP4": "qwen3-5-397b-a17b-fp8-tp4-mi308",
               "MI308 Qwen3.5-397B-A17B-FP8 TP8": "qwen3-5-397b-a17b-fp8-tp8-mi308",
               "MI308 Qwen3.5-35B-A3B-FP8 TP1": "qwen3-5-35b-a3b-fp8-tp1-mi308",
@@ -703,6 +705,7 @@ jobs:
               "deepseek-v3-2-fp8-tp4-dp4-ep4",
               "deepseek-v3-2-fp8-tp8",
               "deepseek-v3-2-fp8-tp8-dp8-ep8",
+              "minimax-m3-mxfp8-eagle3-tp4-mtp3",
           ]
           OOB_P2_PREFIX_ORDER = [
               "deepseek-r1-fp8-tp8",

--- a/atom/plugin/register.py
+++ b/atom/plugin/register.py
@@ -35,6 +35,7 @@ _ATOM_SUPPORTED_MODELS = {
 
 if is_sglang():
     from atom.models.deepseek_v4 import DeepseekV4ForCausalLM
+    from atom.models.eagle3_llama import Eagle3LlamaModel
     from atom.models.kimi_k25 import KimiK25ForCausalLM
     from atom.models.qwen3_5 import (
         Qwen3_5ForCausalLM,
@@ -57,6 +58,10 @@ if is_sglang():
             "KimiK25ForConditionalGeneration": KimiK25ForCausalLM,
         }
     )
+    _ATOM_SUPPORTED_DRAFT_MODELS = {
+        "LlamaForCausalLMEagle3": Eagle3LlamaModel,
+    }
+    _ATOM_SUPPORTED_MODELS.update(_ATOM_SUPPORTED_DRAFT_MODELS)
 
 
 def _register_custom_attention_to_sglang() -> None:
@@ -178,6 +183,78 @@ def _patch_sglang_dsv4_draft_backends() -> None:
     DraftBackendFactory._create_dsv4_prefill_backend = _create_atom_dsv4_prefill_backend
     DraftBackendFactory._atom_dsv4_draft_backend_patched = True
     logger.info("Patched SGLang DSV4 speculative draft backends to ATOM")
+
+
+def _patch_sglang_mtp_total_accept_rate_logging() -> None:
+    """Log cumulative SGLang speculative acceptance statistics."""
+
+    if os.getenv("ATOM_SGLANG_MTP_LOG", "0") != "1":
+        return
+
+    try:
+        from sglang.srt.managers.scheduler import Scheduler
+    except Exception:  # noqa: BLE001 - optional across SGLang versions
+        return
+
+    # SGLang <= 0.5.12 exposes reporting and counters directly on Scheduler.
+    # In 0.5.15 they moved to SchedulerMetricsReporter.
+    if hasattr(Scheduler, "report_decode_stats"):
+        stats_owner_cls = Scheduler
+    else:
+        try:
+            from sglang.srt.managers.scheduler_components.metrics_reporter import (
+                SchedulerMetricsReporter,
+            )
+        except Exception:  # noqa: BLE001 - optional across SGLang versions
+            return
+        stats_owner_cls = SchedulerMetricsReporter
+
+    if getattr(stats_owner_cls, "_atom_spec_stats_logging_patched", False):
+        return
+
+    original_report_decode_stats = stats_owner_cls.report_decode_stats
+    stats_logger = logging.getLogger("atom.plugin.sglang.spec_stats")
+
+    def report_decode_stats(self, *args, **kwargs):
+        total_forward_ct_before = int(
+            getattr(self, "spec_total_num_forward_ct", 0) or 0
+        )
+        ret = original_report_decode_stats(self, *args, **kwargs)
+        scheduler = getattr(self, "scheduler", self)
+        if scheduler.spec_algorithm.is_none():
+            return ret
+
+        total_forward_ct = int(getattr(self, "spec_total_num_forward_ct", 0) or 0)
+        total_accept_tokens = int(getattr(self, "spec_total_num_accept_tokens", 0) or 0)
+        # The original method updates lifetime counters only at
+        # decode_log_interval. Avoid repeating the same cumulative snapshot on
+        # every decode iteration between reporting intervals.
+        if total_forward_ct <= total_forward_ct_before:
+            return ret
+
+        draft_per_round = (
+            int(scheduler.server_args.speculative_num_draft_tokens) - 1
+            if getattr(scheduler.server_args, "speculative_num_draft_tokens", None)
+            else int(getattr(scheduler.server_args, "speculative_num_steps", 0) or 0)
+        )
+        accepted_drafts = total_accept_tokens - total_forward_ct
+        total_draft_tokens = total_forward_ct * max(draft_per_round, 0)
+        accept_rate = (
+            accepted_drafts / total_draft_tokens if total_draft_tokens > 0 else 0.0
+        )
+
+        stats_logger.info(
+            "[MTP Stats         ] Average toks/fwd: %.2f, "
+            "Accepted/Total Draft tokens: %d/%d, Acceptance rate: %.2f%%",
+            total_accept_tokens / total_forward_ct,
+            accepted_drafts,
+            total_draft_tokens,
+            accept_rate * 100.0,
+        )
+        return ret
+
+    stats_owner_cls.report_decode_stats = report_decode_stats
+    stats_owner_cls._atom_spec_stats_logging_patched = True
 
 
 def _patch_sglang_dsv4_spec_cuda_graph() -> None:
@@ -590,8 +667,14 @@ def register_ops_to_sglang(atom_config: Config) -> None:
     """
     Register custom ops to sglang, including attention
     """
+    from atom.plugin.sglang.eagle3_llama_bridge import (
+        patch_sglang_eagle3_runtime_compat,
+    )
+
     _register_custom_attention_to_sglang()
     _patch_sglang_dsv4_draft_backends()
+    _patch_sglang_mtp_total_accept_rate_logging()
+    patch_sglang_eagle3_runtime_compat()
     _patch_sglang_dsv4_spec_cuda_graph()
 
 

--- a/atom/plugin/sglang/attention_backend/full_attention/full_attention_backend.py
+++ b/atom/plugin/sglang/attention_backend/full_attention/full_attention_backend.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import sglang.srt.layers.attention.aiter_backend as _sglang_aiter
 import torch
+from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
 from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
 from sglang.srt.layers.attention.utils import (
     create_flashinfer_kv_indices_triton,
@@ -24,6 +25,7 @@ from sglang.srt.layers.attention.utils import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.utils import get_bool_env_var
 
+from atom.model_ops.base_attention import run_pa_decode_gluon
 from atom.plugin.sglang.attention_backend.full_attention.kv_cache import (
     set_kv_buffer_with_layout_shuffle as _set_kv_buffer_with_layout_shuffle,
 )
@@ -38,6 +40,7 @@ from atom.plugin.sglang.attention_backend.full_attention.pa_metadata import (
     build_pa_metadata_for_prefill as _build_pa_metadata_for_prefill,
 )
 from atom.plugin.sglang.runtime.context import is_draft_extend_mode
+from atom.utils import envs
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
@@ -227,8 +230,14 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
             self._init_draft_extend_v2_mla(forward_batch.batch_size, forward_batch)
         elif self.use_mla and is_draft_extend_mode(forward_batch.forward_mode):
             self._init_draft_extend_mla(forward_batch.batch_size, forward_batch)
+        elif (not self.use_mla) and forward_batch.forward_mode.is_draft_extend_v2():
+            self._init_draft_extend_v2_mha(forward_batch.batch_size, forward_batch)
+        elif (not self.use_mla) and is_draft_extend_mode(forward_batch.forward_mode):
+            self._init_draft_extend_mha(forward_batch.batch_size, forward_batch)
         elif self.use_mla and forward_batch.forward_mode.is_target_verify():
             self._init_target_verify_mla(forward_batch.batch_size, forward_batch)
+        elif (not self.use_mla) and forward_batch.forward_mode.is_target_verify():
+            self._init_target_verify_mha(forward_batch.batch_size, forward_batch)
         else:
             self._init_forward_metadata_extend(forward_batch)
         self._fixup_page_table(forward_batch)
@@ -587,6 +596,67 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
             run_graph=False,
         )
 
+    def _init_draft_extend_v2_mha(self, bs, forward_batch):
+        spec_info = forward_batch.spec_info
+        if spec_info is None:
+            raise RuntimeError("MHA draft_extend_v2 requires speculative metadata")
+        if forward_batch.extend_prefix_lens is None:
+            raise RuntimeError("MHA draft_extend_v2 requires extend_prefix_lens")
+        self.indices_updater_prefill.update(
+            forward_batch.req_pool_indices,
+            forward_batch.seq_lens,
+            forward_batch.seq_lens_sum,
+            prefix_lens=forward_batch.extend_prefix_lens,
+            encoder_lens=forward_batch.encoder_lens,
+            spec_info=None,
+        )
+        max_q_len = self._max_len(
+            forward_batch.extend_seq_lens_cpu,
+            forward_batch.extend_seq_lens,
+        )
+        max_kv_len = self._max_len(forward_batch.seq_lens_cpu, forward_batch.seq_lens)
+        self.forward_metadata = ForwardMetadata(
+            self.indices_updater_prefill.kv_indptr,
+            self.indices_updater_prefill.kv_indices,
+            self.qo_indptr[: bs + 1],
+            None,
+            max_q_len,
+            max_kv_len,
+            None,
+            None,
+            custom_mask=None,
+            mask_indptr=None,
+            max_extend_len=max_q_len,
+        )
+
+    def _init_draft_extend_mha(self, bs, forward_batch):
+        spec_info = forward_batch.spec_info
+        if spec_info is None:
+            raise RuntimeError("MHA draft_extend requires speculative metadata")
+        kv_indices, kv_indptr, qo_indptr, custom_mask = (
+            spec_info.generate_attn_arg_prefill(
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens,
+                forward_batch.seq_lens_sum,
+                self.req_to_token,
+            )
+        )
+        kv_indices = kv_indices.to(torch.int64)
+        draft_max_extend_len = int(torch.max(spec_info.num_accept_tokens).item())
+        self.forward_metadata = ForwardMetadata(
+            kv_indptr,
+            kv_indices,
+            qo_indptr,
+            None,
+            draft_max_extend_len,
+            None,
+            None,
+            None,
+            custom_mask=custom_mask,
+            mask_indptr=None,
+            max_extend_len=draft_max_extend_len,
+        )
+
     def _init_target_verify_mla(self, bs, forward_batch):
         """Init MLA metadata for speculative target_verify."""
         spec_info = forward_batch.spec_info
@@ -779,6 +849,55 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
             forward_batch.seq_lens,
         )
 
+    def _init_target_verify_mha(self, bs, forward_batch):
+        spec_info = forward_batch.spec_info
+        if spec_info is None:
+            raise RuntimeError("MHA target_verify requires speculative metadata")
+
+        draft_num = spec_info.draft_token_num
+        qo_indptr = torch.arange(
+            0,
+            (1 + bs) * draft_num,
+            step=draft_num,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        kv_indptr = self.kv_indptr[: bs + 1]
+        kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
+        kv_indptr = kv_indptr[: bs + 1]
+
+        kv_indices_len = int(kv_indptr[-1].item())
+        kv_indices = torch.empty(kv_indices_len, dtype=torch.int64, device=self.device)
+        create_flashinfer_kv_indices_triton[(bs,)](
+            self.req_to_token,
+            forward_batch.req_pool_indices,
+            forward_batch.seq_lens,
+            kv_indptr,
+            None,
+            kv_indices,
+            self.req_to_token.stride(0),
+        )
+
+        seq_mask_len = draft_num * (forward_batch.seq_lens + draft_num)
+        mask_indptr = self.mask_indptr
+        mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
+        mask_indptr = mask_indptr[: bs + 1]
+
+        self.forward_metadata = ForwardMetadata(
+            kv_indptr,
+            kv_indices,
+            qo_indptr,
+            None,
+            draft_num,
+            None,
+            None,
+            None,
+            custom_mask=spec_info.custom_mask,
+            mask_indptr=mask_indptr,
+            max_extend_len=draft_num,
+        )
+
     def _fixup_page_table(self, forward_batch: ForwardBatch):
         """Post-process page_table for non-MLA extend mode."""
         if (
@@ -833,6 +952,14 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
             )
         else:
             self.cuda_graph_kv_indices = kv_indices_buf
+
+        draft_tokens = int(self.num_draft_tokens or 1)
+        custom_mask_size = max_bs * draft_tokens * (self.max_context_len + draft_tokens)
+        self.cuda_graph_custom_mask = torch.ones(
+            custom_mask_size,
+            dtype=torch.bool,
+            device=self.device,
+        )
 
         # Always use preshuffle layout for pa_fwd_asm
         self.page_table = torch.zeros(
@@ -1653,17 +1780,6 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
 
     def _should_use_native_dense_mha(self, layer) -> bool:
         sliding_window_size = getattr(layer, "sliding_window_size", None)
-        is_minimax_m3 = bool(getattr(layer, "_atom_minimax_m3_dense_mha", False))
-        if (
-            is_minimax_m3
-            and not self.use_mla
-            and not layer.is_cross_attention
-            and layer.head_dim == 128
-            and layer.qk_head_dim == 128
-            and layer.v_head_dim == 128
-            and (sliding_window_size is None or sliding_window_size <= -1)
-        ):
-            return True
         return (
             not self.use_mla
             and not layer.is_cross_attention
@@ -1810,29 +1926,14 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
                 elif self.use_mla:
                     forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
                 else:
-                    k_buffer, v_buffer = forward_batch.token_to_kv_pool.get_kv_buffer(
-                        layer.layer_id
-                    )
-                    k_scale, v_scale = self._ensure_fp8_kv_scales(
-                        layer, k_buffer, self.page_size
-                    )
-                    self.set_kv_buffer_with_layout_shuffle(
-                        cache_loc,
-                        k,
-                        v,
-                        k_buffer,
-                        v_buffer,
-                        k_scale,
-                        v_scale,
-                        self.page_size,
-                    )
+                    forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
 
         if self.use_mla:
             return self._forward_extend_mla(q, k, v, layer, forward_batch)
-        if bool(getattr(layer, "_atom_minimax_m3_dense_mha", False)):
-            # M3 dense decode benefits from the native ragged path, but batched
-            # SGLang prefill is safer through the standard varlen extend path.
-            return self._forward_extend_mha(q, k, v, layer, forward_batch)
+        if forward_batch.forward_mode.is_target_verify() or is_draft_extend_mode(
+            forward_batch.forward_mode, include_v2=True
+        ):
+            return self._forward_extend_mha_speculative(q, k, v, layer, forward_batch)
         if use_native_dense_mha:
             return self._forward_extend_native_dense_mha(q, layer, forward_batch)
         else:
@@ -1870,6 +1971,42 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
             v_descale=v_descale,
         )
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+
+    def _forward_extend_mha_speculative(self, q, k, v, layer, forward_batch):
+        """Non-MLA EAGLE verify/draft-extend path.
+
+        Mirrors /app/sglang's AiterAttnBackend: speculative MHA uses the
+        extend-attention kernel with custom masks, not plain flash_attn_varlen.
+        """
+
+        if k is None or v is None:
+            raise RuntimeError("MHA speculative extend requires explicit k/v tensors")
+
+        if layer.qk_head_dim != layer.v_head_dim:
+            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+        else:
+            o = torch.empty_like(q)
+
+        self.extend_attention_fwd(
+            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+            k.contiguous(),
+            v.contiguous(),
+            o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
+            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
+            self.forward_metadata.qo_indptr,
+            self.forward_metadata.kv_indptr,
+            self.forward_metadata.kv_indices,
+            self.forward_metadata.custom_mask,
+            True,
+            self.forward_metadata.mask_indptr,
+            self.forward_metadata.max_extend_len,
+            1.0,
+            1.0,
+            layer.scaling,
+            logit_cap=layer.logit_cap,
+        )
+        return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
     def _forward_extend_mha(self, q, k, v, layer, forward_batch):
         """Non-MLA extend path: standard MHA with flash_attn_varlen_func."""
@@ -2459,6 +2596,18 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
                 )
             return self._forward_decode_native_dense_mha(q, layer, forward_batch)
 
+        if (
+            envs.ATOM_FORCE_ATTN_TRITON
+            and not layer.is_cross_attention
+            and layer.qk_head_dim == layer.v_head_dim
+            and layer.head_dim == layer.qk_head_dim
+        ):
+            if save_kv_cache:
+                self._set_kv_buffer_native_dense(
+                    layer, forward_batch.out_cache_loc, k, v, forward_batch
+                )
+            return self._forward_decode_native_dense_mha(q, layer, forward_batch)
+
         o = q.new_empty((batch_size, layer.tp_q_head_num, head_dim_out))
 
         if save_kv_cache:
@@ -2524,13 +2673,9 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
             )
         else:
             q_3d = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
-            page_table = getattr(self.forward_metadata, "page_table", None)
+            page_table = self.forward_metadata.page_table
             if page_table is None:
-                page_table = getattr(self.forward_metadata, "swa_page_table", None)
-            if page_table is None:
-                raise AttributeError(
-                    "ForwardMetadata has neither page_table nor swa_page_table"
-                )
+                raise AttributeError("ForwardMetadata.page_table is not initialized")
             if page_table.dtype != torch.int32:
                 raise TypeError(
                     "pa_fwd_asm block_tables must be torch.int32, got "
@@ -2563,6 +2708,80 @@ class ATOMAttnBackendForSgl(AiterAttnBackend):
 
     def _forward_decode_native_dense_mha(self, q, layer, forward_batch):
         k_cache, v_cache = forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+        if envs.ATOM_FORCE_ATTN_TRITON:
+            block_size = self.page_size
+            num_slots, num_kv_heads, head_size = k_cache.shape
+            num_blocks = num_slots // block_size
+            k_cache = k_cache[: num_blocks * block_size].view(
+                num_blocks, block_size, num_kv_heads, head_size
+            )
+            v_cache = v_cache[: num_blocks * block_size].view(
+                num_blocks, block_size, num_kv_heads, layer.v_head_dim
+            )
+            x = 16 // k_cache.element_size()
+            k_cache = (
+                k_cache.view(num_blocks, block_size, num_kv_heads, head_size // x, x)
+                .permute(0, 2, 3, 1, 4)
+                .contiguous()
+            )
+            v_cache = (
+                v_cache.view(
+                    num_blocks, block_size // x, x, num_kv_heads, layer.v_head_dim
+                )
+                .permute(0, 3, 1, 4, 2)
+                .contiguous()
+            )
+            q_3d = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+            out = torch.empty_like(q_3d, dtype=self.input_dtype)
+            num_seqs = self.forward_metadata.kv_lens.shape[0]
+            query_group_size = 1 * (layer.tp_q_head_num // layer.tp_k_head_num)
+            max_context_partition_num = get_recommended_splits(
+                num_seqs, layer.tp_k_head_num
+            )
+            context_partition_size = 256
+            intermediate_shape = (
+                num_seqs,
+                layer.tp_k_head_num,
+                max_context_partition_num,
+                query_group_size,
+            )
+            exp_sums = torch.empty(
+                intermediate_shape, dtype=torch.float32, device=q.device
+            )
+            max_logits = torch.empty(
+                intermediate_shape, dtype=torch.float32, device=q.device
+            )
+            temporary_output = torch.empty(
+                *intermediate_shape,
+                layer.head_dim,
+                dtype=q.dtype,
+                device=q.device,
+            )
+            run_pa_decode_gluon(
+                output=out,
+                q=q_3d,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                context_lens=self.forward_metadata.kv_lens,
+                block_tables=self.forward_metadata.page_table,
+                softmax_scale=layer.scaling,
+                max_seqlen_q=1,
+                max_context_partition_num=max_context_partition_num,
+                context_partition_size=context_partition_size,
+                compute_type=torch.bfloat16,
+                q_scale=None,
+                k_scale=None,
+                v_scale=None,
+                exp_sums=exp_sums,
+                max_logits=max_logits,
+                temporary_output=temporary_output,
+                alibi_slopes=None,
+                sinks=None,
+                sliding_window=-1,
+                ps=True,
+            )
+            return out.reshape_as(q)
+
         aiter_kv_str = self._get_aiter_paged_ragged_kv_cache_dtype()
 
         o = torch.empty_like(q, dtype=self.input_dtype)

--- a/atom/plugin/sglang/attention_backend/full_attention/metadata.py
+++ b/atom/plugin/sglang/attention_backend/full_attention/metadata.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 import torch
 
@@ -11,27 +10,30 @@ class ForwardMetadata:
     """Per-batch metadata consumed by SGLang full-attention backend kernels."""
 
     # kv_indptr and kv_indices are only used in MLA mode, optional for non-MLA mode
-    kv_indptr: Optional[torch.Tensor]
-    kv_indices: Optional[torch.Tensor]
-    qo_indptr: Optional[torch.Tensor]
-    kv_last_page_len: Optional[torch.Tensor]
-    max_q_len: Optional[int]
-    max_kv_len: Optional[int]
-    page_table: Optional[torch.Tensor]
-    kv_lens: Optional[torch.Tensor]
+    kv_indptr: torch.Tensor | None
+    kv_indices: torch.Tensor | None
+    qo_indptr: torch.Tensor | None
+    kv_last_page_len: torch.Tensor | None
+    max_q_len: int | None
+    max_kv_len: int | None
+    page_table: torch.Tensor | None
+    kv_lens: torch.Tensor | None
     # MLA metadata
-    work_metadata: Optional[torch.Tensor] = None
-    work_info_set: Optional[torch.Tensor] = None
-    work_indptr: Optional[torch.Tensor] = None
-    reduce_indptr: Optional[torch.Tensor] = None
-    reduce_final_map: Optional[torch.Tensor] = None
-    reduce_partial_map: Optional[torch.Tensor] = None
-    fp8_prefill_kv_indices: Optional[torch.Tensor] = None
-    num_kv_splits: Optional[int] = None
-    run_graph: Optional[bool] = True
+    work_metadata: torch.Tensor | None = None
+    work_info_set: torch.Tensor | None = None
+    work_indptr: torch.Tensor | None = None
+    reduce_indptr: torch.Tensor | None = None
+    reduce_final_map: torch.Tensor | None = None
+    reduce_partial_map: torch.Tensor | None = None
+    fp8_prefill_kv_indices: torch.Tensor | None = None
+    num_kv_splits: int | None = None
+    run_graph: bool | None = True
+    custom_mask: torch.Tensor | None = None
+    mask_indptr: torch.Tensor | None = None
+    max_extend_len: int | None = None
     # PA metadata for pa_persistent_fwd (only used in decode mode, non-MLA)
-    pa_metadata_qo_indptr: Optional[torch.Tensor] = None
-    pa_metadata_pages_kv_indptr: Optional[torch.Tensor] = None
-    pa_metadata_kv_indices: Optional[torch.Tensor] = None
-    pa_metadata_context_lens: Optional[torch.Tensor] = None
-    pa_metadata_max_qlen: Optional[int] = None
+    pa_metadata_qo_indptr: torch.Tensor | None = None
+    pa_metadata_pages_kv_indptr: torch.Tensor | None = None
+    pa_metadata_kv_indices: torch.Tensor | None = None
+    pa_metadata_context_lens: torch.Tensor | None = None
+    pa_metadata_max_qlen: int | None = None

--- a/atom/plugin/sglang/attention_backend/minimax_m3_sparse.py
+++ b/atom/plugin/sglang/attention_backend/minimax_m3_sparse.py
@@ -51,10 +51,46 @@ def _slice_i32(tensor: torch.Tensor, batch_size: int) -> torch.Tensor:
 
 
 def _get_query_lens(forward_batch, batch_size: int) -> torch.Tensor:
+    if forward_batch.forward_mode.is_target_verify():
+        spec_info = getattr(forward_batch, "spec_info", None)
+        if spec_info is None:
+            raise RuntimeError("MiniMax-M3 target_verify requires speculative metadata")
+        draft_num = int(spec_info.draft_token_num)
+        return torch.full(
+            (batch_size,),
+            draft_num,
+            dtype=torch.int32,
+            device=forward_batch.seq_lens.device,
+        )
     query_lens = getattr(forward_batch, "extend_seq_lens", None)
     if query_lens is None:
-        query_lens = getattr(forward_batch, "seq_lens")
+        query_lens = forward_batch.seq_lens
     return _slice_i32(query_lens, batch_size)
+
+
+def _get_seq_lens(forward_batch, batch_size: int) -> torch.Tensor:
+    seq_lens = _slice_i32(forward_batch.seq_lens, batch_size)
+    if forward_batch.forward_mode.is_target_verify():
+        spec_info = getattr(forward_batch, "spec_info", None)
+        if spec_info is None:
+            raise RuntimeError("MiniMax-M3 target_verify requires speculative metadata")
+        seq_lens = seq_lens + int(spec_info.draft_token_num)
+    return seq_lens
+
+
+def _get_max_seq_len(forward_batch, batch_size: int, seq_lens: torch.Tensor) -> int:
+    seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+    if seq_lens_cpu is not None and batch_size:
+        max_seq_len = int(seq_lens_cpu[:batch_size].max().item())
+        if forward_batch.forward_mode.is_target_verify():
+            spec_info = getattr(forward_batch, "spec_info", None)
+            if spec_info is None:
+                raise RuntimeError(
+                    "MiniMax-M3 target_verify requires speculative metadata"
+                )
+            max_seq_len += int(spec_info.draft_token_num)
+        return max_seq_len
+    return int(seq_lens.max().item()) if batch_size else 0
 
 
 def _get_prefix_lens(
@@ -93,8 +129,9 @@ def _is_fp8_kv_cache_tensor(kv_cache: torch.Tensor) -> bool:
         "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
         "BLOCK_SIZE_H": lambda args: triton.next_power_of_2(args["gqa_group_size"]),
         "BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["max_topk"]),
-        "BLOCK_SIZE_QH": lambda args: args["BLOCK_SIZE_Q"]
-        * triton.next_power_of_2(args["gqa_group_size"]),
+        "BLOCK_SIZE_QH": lambda args: (
+            args["BLOCK_SIZE_Q"] * triton.next_power_of_2(args["gqa_group_size"])
+        ),
     }
 )
 @triton.jit
@@ -607,21 +644,37 @@ def build_minimax_m3_block_table(forward_batch, page_size: int) -> torch.Tensor:
 
     if not forward_batch.forward_mode.is_decode_or_idle():
         query_lens = _get_query_lens(forward_batch, batch_size)
-        seq_lens = _slice_i32(forward_batch.seq_lens, batch_size)
+        seq_lens = _get_seq_lens(forward_batch, batch_size)
         prefix_lens = _get_prefix_lens(forward_batch, batch_size, seq_lens, query_lens)
         out_cache_loc = forward_batch.out_cache_loc
-        offset = 0
-        for req_idx in range(batch_size):
-            prefix_len = int(prefix_lens[req_idx].item())
-            query_len = int(query_lens[req_idx].item())
-            if query_len > 0:
-                token_table[req_idx, prefix_len : prefix_len + query_len] = (
-                    out_cache_loc[offset : offset + query_len]
-                )
-            offset += query_len
+        # MTP target verify can run inside a non-decode CUDA Graph. Keep this
+        # update tensor-only because the eager fallback's .item() calls cannot
+        # be captured.
+        if _is_stream_capturing():
+            columns = torch.arange(token_table.shape[1], device=token_table.device)
+            rel_pos = columns.unsqueeze(0) - prefix_lens.unsqueeze(1)
+            mask = (rel_pos >= 0) & (rel_pos < query_lens.unsqueeze(1))
+            query_offsets = torch.cumsum(query_lens, dim=0) - query_lens
+            src_idx = (query_offsets.unsqueeze(1) + rel_pos).clamp_min(0)
+            max_src_idx = max(int(out_cache_loc.numel()) - 1, 0)
+            src_idx = src_idx.clamp_max(max_src_idx).to(torch.long)
+            src_values = out_cache_loc.gather(0, src_idx.reshape(-1)).view_as(src_idx)
+            token_table = torch.where(mask, src_values, token_table)
+        else:
+            offset = 0
+            for req_idx in range(batch_size):
+                prefix_len = int(prefix_lens[req_idx].item())
+                query_len = int(query_lens[req_idx].item())
+                if query_len > 0:
+                    token_table[req_idx, prefix_len : prefix_len + query_len] = (
+                        out_cache_loc[offset : offset + query_len]
+                    )
+                offset += query_len
 
-    seq_lens = _slice_i32(forward_batch.seq_lens, batch_size)
-    if _is_stream_capturing() and forward_batch.forward_mode.is_decode_or_idle():
+    seq_lens = _get_seq_lens(forward_batch, batch_size)
+    # MTP target verify also reaches this builder during graph capture. Use the
+    # static token-table width instead of reading seq_lens.max() back to CPU.
+    if _is_stream_capturing():
         max_blocks = int(token_table.shape[1]) // page_size
     else:
         max_seq_len = int(seq_lens.max().item()) if batch_size else 0
@@ -639,11 +692,8 @@ def build_minimax_m3_forward_metadata(
 
     validate_minimax_m3_page_size(page_size)
     batch_size = _get_batch_size(forward_batch)
-    seq_lens = _slice_i32(forward_batch.seq_lens, batch_size)
-    if _is_stream_capturing() and forward_batch.forward_mode.is_decode_or_idle():
-        max_seq_len = int(block_table.shape[1]) * page_size
-    else:
-        max_seq_len = int(seq_lens.max().item()) if batch_size else 0
+    seq_lens = _get_seq_lens(forward_batch, batch_size)
+    max_seq_len = _get_max_seq_len(forward_batch, batch_size, seq_lens)
 
     if forward_batch.forward_mode.is_decode_or_idle():
         return MiniMaxM3SGLangMetadata(
@@ -666,6 +716,16 @@ def build_minimax_m3_forward_metadata(
     torch.cumsum(query_lens, dim=0, out=cu_seqlens_q[1:])
     torch.cumsum(seq_lens, dim=0, out=cu_seqlens_k[1:])
 
+    # MTP target verify graph metadata needs a host scalar without synchronizing
+    # on the GPU query_lens tensor.
+    if _is_stream_capturing():
+        if forward_batch.forward_mode.is_target_verify():
+            max_query_len = int(getattr(forward_batch.spec_info, "draft_token_num", 1))
+        else:
+            max_query_len = int(getattr(forward_batch, "extend_num_tokens", None) or 1)
+    else:
+        max_query_len = int(query_lens.max().item()) if batch_size else 0
+
     return MiniMaxM3SGLangMetadata(
         is_decode=False,
         seq_lens=seq_lens,
@@ -674,7 +734,7 @@ def build_minimax_m3_forward_metadata(
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
         context_lens=context_lens,
-        max_query_len=int(query_lens.max().item()) if batch_size else 0,
+        max_query_len=max_query_len,
     )
 
 
@@ -825,7 +885,13 @@ def minimax_m3_sparse_attention_for_sglang(
     else:
         assert metadata.cu_seqlens_q is not None
         assert metadata.context_lens is not None
-        num_tokens = int(metadata.cu_seqlens_q[-1].item())
+        # Captured MTP verify/extend uses the fixed padded Q shape; avoid reading
+        # cu_seqlens_q back to the host while the graph is being recorded.
+        num_tokens = (
+            int(q.shape[0])
+            if _is_stream_capturing()
+            else int(metadata.cu_seqlens_q[-1].item())
+        )
         topk_idx = minimax_m3_index_topk(
             index_q[:num_tokens],
             index_cache,

--- a/atom/plugin/sglang/eagle3_llama_bridge.py
+++ b/atom/plugin/sglang/eagle3_llama_bridge.py
@@ -1,0 +1,1090 @@
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Any
+
+import torch
+
+from atom.plugin.sglang.models.minimax_m3 import SGLangATOMMiniMaxM3Attention
+
+logger = logging.getLogger("atom")
+
+
+def _is_stream_capturing() -> bool:
+    try:
+        return bool(torch.cuda.is_current_stream_capturing())
+    except Exception:  # noqa: BLE001 - ROCm capture query may fail before init
+        return False
+
+
+@contextmanager
+def eagle3_llama_native_attention_construction():
+    """Construct EAGLE3 draft attention layers with ATOM native MHA."""
+
+    from atom.models import eagle3_llama
+
+    previous = eagle3_llama.Attention
+
+    def _build_eagle3_attention(*args: Any, **kwargs: Any):
+        return SGLangATOMEagle3Attention(*args, **kwargs)
+
+    eagle3_llama.Attention = _build_eagle3_attention
+    try:
+        yield
+    finally:
+        eagle3_llama.Attention = previous
+
+
+class SGLangATOMEagle3Attention(SGLangATOMMiniMaxM3Attention):
+    """Use ATOM native dense MHA for EAGLE3 draft under SGLang plugin runtime."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        from atom.config import get_current_atom_config
+
+        atom_config = get_current_atom_config()
+        layer_offset = int(getattr(atom_config, "sgl_atom_eagle3_layer_offset", 0) or 0)
+        if layer_offset > 0 and int(kwargs.get("layer_num", 0) or 0) == 0:
+            kwargs["layer_num"] = layer_offset
+        super().__init__(*args, **kwargs)
+
+
+def is_eagle3_llama_config(config: Any) -> bool:
+    archs = getattr(config, "architectures", None) or []
+    return any("LlamaForCausalLMEagle3" in str(arch) for arch in archs)
+
+
+def maybe_get_eagle3_pools_from_sglang_batch(forward_batch=None):
+    if forward_batch is None:
+        return None, None
+    token_to_kv_pool = getattr(forward_batch, "token_to_kv_pool", None)
+    req_to_token_pool = getattr(forward_batch, "req_to_token_pool", None)
+
+    # SGLang v0.5.15 builds an inner ForwardBatch for each multi-step draft
+    # attention backend. The inner view receives the pools, while the outer
+    # ForwardBatch passed to the draft model no longer does. Recover them from
+    # the active backend (or one of its per-step children) during graph capture.
+    if token_to_kv_pool is None or req_to_token_pool is None:
+        try:
+            from sglang.srt.model_executor.forward_context import (
+                get_attn_backend,
+                has_forward_context,
+            )
+
+            backends = []
+            if has_forward_context():
+                active_backend = get_attn_backend()
+                backends.append(active_backend)
+                full_backend = getattr(active_backend, "full_attn_backend", None)
+                if full_backend is not None:
+                    backends.append(full_backend)
+                backends.extend(getattr(active_backend, "attn_backends", None) or [])
+
+            for backend in backends:
+                token_to_kv_pool = token_to_kv_pool or getattr(
+                    backend,
+                    "_atom_token_to_kv_pool",
+                    getattr(backend, "token_to_kv_pool", None),
+                )
+                req_to_token_pool = req_to_token_pool or getattr(
+                    backend,
+                    "_atom_req_to_token_pool",
+                    getattr(backend, "req_to_token_pool", None),
+                )
+                if token_to_kv_pool is not None and req_to_token_pool is not None:
+                    break
+        except Exception:  # noqa: BLE001, S110 - optional across SGLang versions
+            pass
+
+    if token_to_kv_pool is None or req_to_token_pool is None:
+        return None, None
+    if getattr(forward_batch, "token_to_kv_pool", None) is None:
+        forward_batch.token_to_kv_pool = token_to_kv_pool
+    if getattr(forward_batch, "req_to_token_pool", None) is None:
+        forward_batch.req_to_token_pool = req_to_token_pool
+    return token_to_kv_pool, req_to_token_pool
+
+
+def _page_size(token_to_kv_pool) -> int:
+    return int(getattr(token_to_kv_pool, "page_size", 1))
+
+
+def _seq_lens(forward_batch, bs: int) -> torch.Tensor:
+    return forward_batch.seq_lens[:bs].to(dtype=torch.int32)
+
+
+def _extend_lens(forward_batch, positions: torch.Tensor, bs: int) -> torch.Tensor:
+    extend_lens = getattr(forward_batch, "extend_seq_lens", None)
+    if extend_lens is not None:
+        return extend_lens[:bs].to(device=positions.device, dtype=torch.int32)
+
+    extend_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+    if extend_lens_cpu is not None:
+        return torch.as_tensor(
+            extend_lens_cpu[:bs], dtype=torch.int32, device=positions.device
+        )
+
+    tokens_per_req = getattr(
+        getattr(forward_batch, "spec_info", None), "num_tokens_per_req", None
+    )
+    if tokens_per_req is None:
+        tokens_per_req = max(1, int(positions.numel()) // max(1, bs))
+    return torch.full(
+        (bs,), int(tokens_per_req), dtype=torch.int32, device=positions.device
+    )
+
+
+def _effective_decode_lens(
+    forward_batch, bs: int, seq_lens: torch.Tensor
+) -> torch.Tensor:
+    spec_info = getattr(forward_batch, "spec_info", None)
+    kv_indptr = getattr(spec_info, "kv_indptr", None)
+    if torch.is_tensor(kv_indptr) and kv_indptr.numel() >= bs + 1:
+        return (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(
+            device=seq_lens.device, dtype=torch.int32
+        )
+
+    backend_metadata = getattr(
+        getattr(forward_batch, "attn_backend", None), "forward_metadata", None
+    )
+    backend_lens = getattr(backend_metadata, "kv_lens", None)
+    if torch.is_tensor(backend_lens) and backend_lens.numel() >= bs:
+        return backend_lens[:bs].to(device=seq_lens.device, dtype=torch.int32)
+
+    return seq_lens
+
+
+def _decode_lens_from_positions(
+    positions: torch.Tensor | None, bs: int, seq_lens: torch.Tensor
+) -> torch.Tensor | None:
+    if not torch.is_tensor(positions) or positions.numel() < bs:
+        return None
+    # The EAGLE3 wrapper forwards draft tokens at positions + 1 to match native
+    # ATOM. Keep the attention metadata's position-derived KV length in the same
+    # coordinate system; kv_indptr remains the upper bound.
+    return positions[:bs].to(device=seq_lens.device, dtype=torch.int32) + 1
+
+
+def _atom_num_reject_tokens(
+    forward_batch, bs: int, seq_lens: torch.Tensor
+) -> torch.Tensor | None:
+    spec_info = getattr(forward_batch, "spec_info", None)
+    num_reject_tokens = getattr(
+        spec_info, "_atom_sglang_eagle3_num_reject_tokens", None
+    )
+    if not torch.is_tensor(num_reject_tokens):
+        # CUDA graph capture owns a fixed-address generic input buffer because
+        # plugin-only Python attributes are not re-evaluated during replay.
+        num_reject_tokens = getattr(spec_info, "num_reject_tokens", None)
+    if not torch.is_tensor(num_reject_tokens) or num_reject_tokens.numel() < bs:
+        return None
+    return num_reject_tokens[:bs].to(device=seq_lens.device, dtype=torch.int32)
+
+
+def _frontier_slot_mapping(
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    page_size: int,
+) -> torch.Tensor:
+    """Map each sequence's speculative frontier to its physical KV slot."""
+    if context_lens.numel() == 0:
+        return torch.empty((0,), dtype=torch.long, device=context_lens.device)
+    logical_slots = (context_lens.to(dtype=torch.long) - 1).clamp_min_(0)
+    block_indices = torch.div(
+        logical_slots, int(page_size), rounding_mode="floor"
+    ).unsqueeze(1)
+    block_ids = (
+        block_tables[: context_lens.numel()]
+        .to(device=context_lens.device, dtype=torch.long)
+        .gather(1, block_indices)
+        .squeeze(1)
+    )
+    return block_ids * int(page_size) + torch.remainder(logical_slots, int(page_size))
+
+
+def _block_tables_from_token_table(
+    token_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_size: int,
+    max_seq_len: int | None = None,
+) -> torch.Tensor:
+    if max_seq_len is None:
+        max_seq_len = int(seq_lens.max().item()) if seq_lens.numel() else 0
+    max_blocks = max(1, (max_seq_len + page_size - 1) // page_size)
+    return (
+        (token_table[:, : max_blocks * page_size : page_size] // page_size)
+        .to(dtype=torch.int32)
+        .contiguous()
+    )
+
+
+def _build_block_table(
+    forward_batch,
+    req_to_token_pool,
+    *,
+    seq_lens: torch.Tensor,
+    extend_lens: torch.Tensor | None,
+    page_size: int,
+    max_seq_len: int | None = None,
+) -> torch.Tensor:
+    bs = int(forward_batch.batch_size)
+    if max_seq_len is None:
+        max_seq_len = int(seq_lens.max().item()) if bs else 0
+    max_blocks = max(1, (max_seq_len + page_size - 1) // page_size)
+    req_pool_indices = forward_batch.req_pool_indices[:bs]
+    token_table = req_to_token_pool.req_to_token[
+        req_pool_indices, : max_blocks * page_size
+    ].clone()
+
+    if extend_lens is not None:
+        prefix_lens = seq_lens - extend_lens
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if out_cache_loc is not None:
+            columns = torch.arange(token_table.shape[1], device=token_table.device)
+            rel_pos = columns.unsqueeze(0) - prefix_lens.unsqueeze(1)
+            mask = (rel_pos >= 0) & (rel_pos < extend_lens.unsqueeze(1))
+            query_offsets = torch.cumsum(extend_lens, dim=0) - extend_lens
+            src_idx = query_offsets.unsqueeze(1) + rel_pos
+            max_src_idx = max(int(out_cache_loc.numel()) - 1, 0)
+            src_idx = src_idx.clamp_min(0).clamp_max(max_src_idx).to(torch.long)
+            src_values = out_cache_loc.gather(0, src_idx.reshape(-1)).view_as(src_idx)
+            token_table = torch.where(mask, src_values, token_table)
+
+    return _block_tables_from_token_table(
+        token_table, seq_lens, page_size, max_seq_len=max_seq_len
+    )
+
+
+def _metadata_from_backend(
+    forward_batch,
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    bs: int,
+    *,
+    page_size: int,
+):
+    backend_metadata = getattr(
+        getattr(forward_batch, "attn_backend", None), "forward_metadata", None
+    )
+    page_table = getattr(backend_metadata, "page_table", None)
+    if not torch.is_tensor(page_table):
+        return None
+
+    from atom.utils.forward_context import AttentionMetaData, AttnState
+
+    context_lens = _effective_decode_lens(forward_batch, bs, seq_lens)
+    position_lens = _decode_lens_from_positions(positions, bs, seq_lens)
+    if position_lens is not None:
+        num_reject_tokens = _atom_num_reject_tokens(forward_batch, bs, seq_lens)
+        context_lens = (
+            position_lens + num_reject_tokens
+            if num_reject_tokens is not None
+            else position_lens
+        )
+    cu_q = torch.arange(0, bs + 1, dtype=torch.int32, device=seq_lens.device)
+    if position_lens is not None:
+        slot_mapping = _frontier_slot_mapping(page_table, context_lens, page_size)
+    else:
+        slot_mapping = getattr(forward_batch, "out_cache_loc", None)
+    if torch.is_tensor(slot_mapping) and position_lens is None:
+        slot_mapping = slot_mapping[:bs].to(dtype=torch.long)
+    # Draft graph capture cannot read context_lens.max() back to the host. Use
+    # the captured page-table width as the static K-length bound.
+    max_seq_len = (
+        int(page_table.shape[1]) * int(page_size)
+        if _is_stream_capturing()
+        else (int(context_lens.max().item()) if bs else 0)
+    )
+    md = AttentionMetaData(
+        cu_seqlens_q=cu_q,
+        max_seqlen_q=1,
+        max_seqlen_k=max_seq_len,
+        slot_mapping=slot_mapping,
+        context_lens=context_lens,
+        block_tables=page_table[:bs],
+        state=AttnState.DECODE,
+    )
+    return md
+
+
+def build_atom_eagle3_attention_metadata_from_sglang(
+    forward_batch,
+    positions: torch.Tensor,
+    *,
+    token_to_kv_pool,
+    req_to_token_pool,
+):
+    from atom.utils.forward_context import AttentionMetaData, AttnState
+
+    bs = int(forward_batch.batch_size)
+    page_size = _page_size(token_to_kv_pool)
+    max_context_len = int(req_to_token_pool.req_to_token.shape[1])
+    # EAGLE3 decode and draft-extend graphs need a static block-table width;
+    # eager execution can derive the live bound from sequence lengths.
+    capture_max_seq_len = max_context_len if _is_stream_capturing() else None
+    forward_mode = forward_batch.forward_mode
+    seq_lens = _seq_lens(forward_batch, bs)
+
+    if forward_mode.is_decode_or_idle():
+        backend_md = _metadata_from_backend(
+            forward_batch, positions, seq_lens, bs, page_size=page_size
+        )
+        if backend_md is not None:
+            return backend_md
+
+        context_lens = _effective_decode_lens(forward_batch, bs, seq_lens)
+        position_lens = _decode_lens_from_positions(positions, bs, seq_lens)
+        if position_lens is not None:
+            num_reject_tokens = _atom_num_reject_tokens(forward_batch, bs, seq_lens)
+            context_lens = (
+                position_lens + num_reject_tokens
+                if num_reject_tokens is not None
+                else position_lens
+            )
+        cu_q = torch.arange(0, bs + 1, dtype=torch.int32, device=positions.device)
+        block_table = _build_block_table(
+            forward_batch,
+            req_to_token_pool,
+            seq_lens=context_lens,
+            extend_lens=None,
+            page_size=page_size,
+            max_seq_len=capture_max_seq_len,
+        )
+        slot_mapping = (
+            _frontier_slot_mapping(block_table, context_lens, page_size)
+            if position_lens is not None
+            else getattr(forward_batch, "out_cache_loc", None)[:bs].to(torch.long)
+        )
+        max_seqlen_k = (
+            max_context_len
+            if _is_stream_capturing()
+            else (int(context_lens.max().item()) if bs else 0)
+        )
+        md = AttentionMetaData(
+            cu_seqlens_q=cu_q,
+            max_seqlen_q=1,
+            max_seqlen_k=max_seqlen_k,
+            slot_mapping=slot_mapping,
+            context_lens=context_lens,
+            block_tables=block_table,
+            state=AttnState.DECODE,
+        )
+        return md
+
+    # Prefill / draft-extend paths are extend-like: seq_lens includes the new
+    # tokens, extend_lens tells how much of each sequence is newly written.
+    is_draft_extend_v2 = bool(
+        getattr(forward_mode, "is_draft_extend_v2", lambda: False)()
+    )
+    if is_draft_extend_v2:
+        tokens_per_req = getattr(
+            getattr(forward_batch, "spec_info", None), "num_tokens_per_req", None
+        )
+        if tokens_per_req is None:
+            if bs <= 0:
+                raise RuntimeError(
+                    "DRAFT_EXTEND_V2 requires a positive batch size to infer "
+                    "num_tokens_per_req"
+                )
+            tokens_per_req = int(positions.numel()) // bs
+        tokens_per_req = int(tokens_per_req)
+        expected_num_positions = bs * tokens_per_req
+        if tokens_per_req <= 0 or positions.numel() != expected_num_positions:
+            raise RuntimeError(
+                "Invalid DRAFT_EXTEND_V2 padded query layout: expected "
+                "num_tokens_per_req > 0 and positions.numel() == "
+                f"batch_size * num_tokens_per_req, but got batch_size={bs}, "
+                f"num_tokens_per_req={tokens_per_req}, "
+                f"positions.numel()={positions.numel()}"
+            )
+        # In SGLang v0.5.15, V2 extend_seq_lens may describe this step's
+        # accepted/valid token count, while model inputs retain a fixed padded
+        # tree width. Attention's QO layout must use num_tokens_per_req.
+        extend_lens = torch.full(
+            (bs,),
+            tokens_per_req,
+            dtype=torch.int32,
+            device=positions.device,
+        )
+    else:
+        extend_lens = _extend_lens(forward_batch, positions, bs)
+        tokens_per_req = max(1, int(positions.numel()) // max(1, bs))
+    cu_q = torch.zeros(bs + 1, dtype=torch.int32, device=positions.device)
+    cu_q[1:] = torch.cumsum(extend_lens, dim=0)
+    block_table = _build_block_table(
+        forward_batch,
+        req_to_token_pool,
+        seq_lens=seq_lens,
+        extend_lens=extend_lens,
+        page_size=page_size,
+        max_seq_len=capture_max_seq_len,
+    )
+    # DRAFT_EXTEND_V2 uses a fixed padded Q width. Other captured extend shapes
+    # also require static Q/K bounds because GPU scalar reads are not capturable.
+    max_seqlen_q = (
+        tokens_per_req
+        if is_draft_extend_v2 or _is_stream_capturing()
+        else (int(extend_lens.max().item()) if bs else 0)
+    )
+    max_seqlen_k = (
+        max_context_len
+        if _is_stream_capturing()
+        else (int(seq_lens.max().item()) if bs else 0)
+    )
+    md = AttentionMetaData(
+        cu_seqlens_q=cu_q,
+        cu_seqlens_k=cu_q,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        slot_mapping=getattr(forward_batch, "out_cache_loc", None),
+        context_lens=(seq_lens if is_draft_extend_v2 else seq_lens - extend_lens),
+        block_tables=block_table,
+        state=AttnState.PREFILL_PREFIX,
+    )
+    return md
+
+
+def _iter_eagle3_attention_layers(model):
+    for module in model.modules():
+        attn = getattr(module, "attn", None)
+        impl = getattr(attn, "impl", None)
+        if isinstance(attn, SGLangATOMEagle3Attention) and impl is not None:
+            yield attn, impl
+
+
+def bind_eagle3_llama_cache_views(model, token_to_kv_pool) -> bool:
+    if token_to_kv_pool is None or not hasattr(token_to_kv_pool, "get_kv_buffer"):
+        return False
+
+    from atom.config import KVCacheTensor
+    from atom.utils.forward_context import get_forward_context, set_kv_cache_data
+
+    page_size = _page_size(token_to_kv_pool)
+    pool_start_layer = int(getattr(token_to_kv_pool, "start_layer", 0) or 0)
+    pool_layer_num = int(getattr(token_to_kv_pool, "layer_num", 0) or 0)
+    kv_cache_data = {}
+    bound = False
+    for attn, impl in _iter_eagle3_attention_layers(model):
+        layer_id = int(impl.layer_num)
+        # SGLang draft workers allocate an independent one-layer draft KV pool
+        # whose physical layer index can still start at 0. ATOM native EAGLE3
+        # uses the logical layer id after target layers (e.g. 60), so bind the
+        # physical pool slot while keeping kv_cache_data keyed by layer_id.
+        if pool_layer_num == 1 and not (
+            pool_start_layer <= layer_id < pool_start_layer + pool_layer_num
+        ):
+            pool_layer_id = pool_start_layer
+        else:
+            pool_layer_id = layer_id
+        k_buffer, _v_buffer = token_to_kv_pool.get_kv_buffer(pool_layer_id)
+        num_slots, num_kv_heads, head_dim = k_buffer.shape
+        num_blocks = max(1, int(num_slots) // page_size)
+        x = 16 // k_buffer.element_size()
+
+        # SGLang's MHA KV pool is row-major [slot, kv_head, head_dim].  Native
+        # ATOM EAGLE3 allocates a page-major draft cache
+        # [block, block_size, kv_head, head_dim] and then reinterprets it as the
+        # shuffle views below.  A direct view of SGLang's row-major pool has the
+        # same shape but not the same page/head/dim memory layout, which breaks
+        # later draft decode steps that read previously written draft KV.  Keep
+        # an ATOM-native draft cache while reusing SGLang's slot ids/metadata.
+        native_cache = getattr(model, "_atom_sglang_eagle3_native_kv_cache", None)
+        cache_shape = (2, num_blocks, page_size, num_kv_heads, head_dim)
+        if (
+            native_cache is None
+            or tuple(native_cache.shape) != cache_shape
+            or native_cache.dtype != k_buffer.dtype
+            or native_cache.device != k_buffer.device
+        ):
+            native_cache = torch.zeros(
+                cache_shape, dtype=k_buffer.dtype, device=k_buffer.device
+            )
+            model._atom_sglang_eagle3_native_kv_cache = native_cache
+
+        native_scale = getattr(model, "_atom_sglang_eagle3_native_kv_scale", None)
+        scale_shape = (2, num_blocks, num_kv_heads, page_size)
+        use_fp8_cache = k_buffer.element_size() == 1
+        if use_fp8_cache and (
+            native_scale is None
+            or tuple(native_scale.shape) != scale_shape
+            or native_scale.device != k_buffer.device
+        ):
+            native_scale = torch.zeros(
+                scale_shape, dtype=torch.float32, device=k_buffer.device
+            )
+            model._atom_sglang_eagle3_native_kv_scale = native_scale
+
+        k_cache = native_cache[0].view(
+            num_blocks, num_kv_heads, head_dim // x, page_size, x
+        )
+        v_cache = native_cache[1].view(num_blocks, num_kv_heads, head_dim, page_size)
+        if use_fp8_cache:
+            k_scale = native_scale[0]
+            v_scale = native_scale[1]
+        elif hasattr(token_to_kv_pool, "get_kv_scale_buffer"):
+            k_scale, v_scale = token_to_kv_pool.get_kv_scale_buffer(pool_layer_id)
+        else:
+            k_scale = None
+            v_scale = None
+
+        kv_cache_data[f"layer_{layer_id}"] = KVCacheTensor(
+            layer_num=layer_id,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+        attn.k_cache = k_cache
+        attn.v_cache = v_cache
+        attn.k_scale = k_scale
+        attn.v_scale = v_scale
+        bound = True
+
+    if not bound:
+        return False
+
+    set_kv_cache_data(kv_cache_data)
+    get_forward_context().kv_cache_data = kv_cache_data
+    return True
+
+
+def _patch_sglang_eagle3_state_lifecycle() -> None:
+    """Keep ATOM EAGLE3 reject state aligned with SGLang V2 batch rows.
+
+    The reject-count tensor is an ATOM plugin extension on ``EagleDraftInput``.
+    SGLang's native ``filter_batch`` / ``merge_batch`` only know about the
+    dataclass fields, so the extension otherwise keeps stale row order whenever
+    requests are merged or removed.  This is invisible for a steady bs=1 batch
+    but corrupts per-request draft context lengths under continuous batching.
+    """
+
+    try:
+        from sglang.srt.managers.overlap_utils import FutureMap
+        from sglang.srt.speculative.eagle_info import EagleDraftInput
+    except Exception:  # noqa: BLE001 - optional across SGLang versions
+        return
+
+    if getattr(EagleDraftInput, "_atom_eagle3_state_lifecycle_patched", False):
+        return
+
+    state_attr = "_atom_sglang_eagle3_num_reject_tokens"
+    original_filter_batch = EagleDraftInput.filter_batch
+    original_merge_batch = EagleDraftInput.merge_batch
+    uses_pool_indexed_future_map = all(
+        hasattr(FutureMap, name) for name in ("stash", "_resolve_spec_extras")
+    )
+    if uses_pool_indexed_future_map:
+        from sglang.srt.managers.overlap_utils import RelayPayload
+
+        original_relay_from_draft_input = RelayPayload.from_draft_input
+        original_future_store = FutureMap.stash
+        original_future_resolve = FutureMap._resolve_spec_extras
+    else:
+        original_future_lazy_init = FutureMap._lazy_init_buf
+        original_future_store = FutureMap.store_to_map_for_new_batch
+        original_future_resolve = FutureMap.resolve_future
+
+    def _row_count(spec_info) -> int:
+        future_indices = getattr(spec_info, "future_indices", None)
+        indices = getattr(future_indices, "indices", None)
+        if torch.is_tensor(indices):
+            return int(indices.numel())
+        topk_index = getattr(spec_info, "topk_index", None)
+        if torch.is_tensor(topk_index):
+            return int(topk_index.shape[0])
+        return 0
+
+    def _state_for_rows(state, rows: int, reference):
+        device = (
+            state.device
+            if torch.is_tensor(state)
+            else (
+                reference.device if torch.is_tensor(reference) else torch.device("cpu")
+            )
+        )
+        if rows <= 0:
+            return torch.empty((0,), dtype=torch.int32, device=device)
+        if not torch.is_tensor(state):
+            return torch.zeros((rows,), dtype=torch.int32, device=device)
+        state = state.reshape(-1).to(dtype=torch.int32)
+        if state.numel() >= rows:
+            return state[:rows]
+        return torch.cat(
+            [
+                state,
+                torch.zeros(
+                    (rows - state.numel(),), dtype=torch.int32, device=state.device
+                ),
+            ]
+        )
+
+    def filter_batch(self, new_indices, has_been_filtered: bool = True):
+        # With overlap scheduling, ``future_indices`` is the only payload that
+        # is ready on the scheduler stream.  The tensors attached to
+        # ``EagleDraftInput`` are produced on the forward stream and are
+        # intentionally resolved lazily by ``FutureMap.resolve_future``.
+        # Reading/indexing our plugin-only state here would introduce the same
+        # cross-stream race that SGLang's native early-return avoids.
+        state_is_deferred = getattr(self, "future_indices", None) is not None
+        state_before = getattr(self, state_attr, None)
+        ret = original_filter_batch(
+            self, new_indices, has_been_filtered=has_been_filtered
+        )
+
+        output_rows = _row_count(self)
+        if state_is_deferred:
+            # The authoritative state is already stored in the parallel
+            # FutureMap buffer.  Drop this possibly-not-yet-ready tensor; the
+            # filtered future indices will gather the correct rows on the
+            # forward stream before the next model invocation.
+            setattr(self, state_attr, None)
+            return ret
+
+        reference = getattr(self, "topk_index", None)
+        if torch.is_tensor(state_before):
+            state_before = state_before.reshape(-1)
+            indices = new_indices.to(device=state_before.device, dtype=torch.long)
+            if has_been_filtered and state_before.numel() == output_rows:
+                state_after = state_before.to(dtype=torch.int32)
+            elif indices.numel() == output_rows:
+                state_after = state_before.index_select(0, indices).to(
+                    dtype=torch.int32
+                )
+            else:
+                state_after = _state_for_rows(state_before, output_rows, reference)
+        else:
+            state_after = _state_for_rows(None, output_rows, reference)
+        setattr(self, state_attr, state_after)
+        return ret
+
+    def merge_batch(self, spec_info):
+        left_rows = _row_count(self)
+        right_rows = _row_count(spec_info)
+        left_state = getattr(self, state_attr, None)
+        right_state = getattr(spec_info, state_attr, None)
+        left_reference = getattr(self, "topk_index", None)
+        right_reference = getattr(spec_info, "topk_index", None)
+        state_is_deferred = getattr(self, "future_indices", None) is not None
+
+        ret = original_merge_batch(self, spec_info)
+
+        if state_is_deferred:
+            # ``original_merge_batch`` concatenated the two future-index lists.
+            # Their payload rows, including the plugin state, remain in
+            # FutureMap and must not be touched from the scheduler stream.
+            setattr(self, state_attr, None)
+            return ret
+
+        left_state = _state_for_rows(left_state, left_rows, left_reference)
+        right_state = _state_for_rows(right_state, right_rows, right_reference)
+        if left_state.device != right_state.device:
+            if left_rows == 0:
+                left_state = left_state.to(right_state.device)
+            else:
+                right_state = right_state.to(left_state.device)
+        merged_state = torch.cat([left_state, right_state])
+        setattr(self, state_attr, merged_state)
+        return ret
+
+    def future_lazy_init(self, draft_input):
+        ret = original_future_lazy_init(self, draft_input)
+        if not hasattr(self, "_atom_eagle3_reject_tokens_buf"):
+            self._atom_eagle3_reject_tokens_buf = torch.zeros(
+                (self.future_buffer_len,), dtype=torch.int32, device=self.device
+            )
+        return ret
+
+    def future_store(self, future_indices, draft_input):
+        ret = original_future_store(self, future_indices, draft_input)
+        interval = future_indices.interval
+        if (
+            interval is None
+            or self.is_empty_slice(interval)
+            or not hasattr(self, "_atom_eagle3_reject_tokens_buf")
+        ):
+            return ret
+        rows = _row_count(draft_input)
+        state = _state_for_rows(
+            getattr(draft_input, state_attr, None),
+            rows,
+            getattr(draft_input, "topk_index", None),
+        ).to(self._atom_eagle3_reject_tokens_buf.device)
+        self._atom_eagle3_reject_tokens_buf[interval] = state
+        return ret
+
+    def future_resolve(self, model_worker_batch):
+        ret = original_future_resolve(self, model_worker_batch)
+        draft_input = getattr(model_worker_batch, "spec_info", None)
+        future_indices = getattr(draft_input, "future_indices", None)
+        indices = getattr(future_indices, "indices", None)
+        if (
+            draft_input is not None
+            and torch.is_tensor(indices)
+            and hasattr(self, "_atom_eagle3_reject_tokens_buf")
+        ):
+            resolved_state = self._atom_eagle3_reject_tokens_buf[indices].to(
+                torch.int32
+            )
+            setattr(
+                draft_input,
+                state_attr,
+                resolved_state,
+            )
+        return ret
+
+    def relay_from_draft_input(cls, draft_input):
+        payload = original_relay_from_draft_input(draft_input)
+        setattr(payload, state_attr, getattr(draft_input, state_attr, None))
+        return payload
+
+    def pool_indexed_future_store(self, future_indices, payload):
+        ret = original_future_store(self, future_indices, payload)
+        indices = future_indices
+        if not torch.is_tensor(indices) or indices.numel() == 0:
+            return ret
+        if not hasattr(self, "_atom_eagle3_reject_tokens_buf"):
+            self._atom_eagle3_reject_tokens_buf = torch.zeros(
+                (self.req_pool_size,), dtype=torch.int32, device=self.device
+            )
+        rows = int(indices.numel())
+        state = _state_for_rows(
+            getattr(payload, state_attr, None),
+            rows,
+            getattr(payload, "topk_index", None),
+        ).to(self._atom_eagle3_reject_tokens_buf.device)
+        self._atom_eagle3_reject_tokens_buf[indices] = state
+        return ret
+
+    def pool_indexed_future_resolve(self, batch):
+        ret = original_future_resolve(self, batch)
+        draft_input = getattr(batch, "spec_info", None)
+        indices = getattr(draft_input, "future_indices", None)
+        if (
+            draft_input is not None
+            and torch.is_tensor(indices)
+            and hasattr(self, "_atom_eagle3_reject_tokens_buf")
+        ):
+            setattr(
+                draft_input,
+                state_attr,
+                self._atom_eagle3_reject_tokens_buf[indices].to(torch.int32),
+            )
+        return ret
+
+    EagleDraftInput.filter_batch = filter_batch
+    EagleDraftInput.merge_batch = merge_batch
+    if uses_pool_indexed_future_map:
+        RelayPayload.from_draft_input = classmethod(relay_from_draft_input)
+        FutureMap.stash = pool_indexed_future_store
+        FutureMap._resolve_spec_extras = pool_indexed_future_resolve
+    else:
+        FutureMap._lazy_init_buf = future_lazy_init
+        FutureMap.store_to_map_for_new_batch = future_store
+        FutureMap.resolve_future = future_resolve
+    EagleDraftInput._atom_eagle3_state_lifecycle_patched = True
+
+
+def _patch_sglang_eagle3_cuda_graph_reject_state() -> None:
+    """Stage plugin reject state through a fixed-address draft graph buffer."""
+
+    try:
+        from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
+            EAGLEDraftCudaGraphRunner,
+        )
+        from sglang.srt.speculative.eagle_info import EagleDraftInput
+    except Exception:  # noqa: BLE001 - optional across SGLang versions
+        return
+
+    if getattr(
+        EAGLEDraftCudaGraphRunner,
+        "_atom_eagle3_reject_graph_state_patched",
+        False,
+    ):
+        return
+
+    state_attr = "_atom_sglang_eagle3_num_reject_tokens"
+    graph_state_attr = "_atom_eagle3_reject_graph_buffer"
+    active_capture_runner = {"runner": None}
+    original_input_init = EagleDraftInput.__init__
+    # v0.5.15 uses shape-based capture/execute; retain the older
+    # batch-size/replay API as a compatibility fallback.
+    uses_shape_graph_api = hasattr(EAGLEDraftCudaGraphRunner, "capture_one_shape")
+    if uses_shape_graph_api:
+        original_capture = EAGLEDraftCudaGraphRunner.capture_one_shape
+        original_replay = EAGLEDraftCudaGraphRunner.execute
+    else:
+        original_capture = EAGLEDraftCudaGraphRunner.capture_one_batch_size
+        original_replay = EAGLEDraftCudaGraphRunner.replay
+
+    def _graph_state_buffer(runner):
+        buffer = getattr(runner, graph_state_attr, None)
+        max_bs = int(getattr(runner, "max_bs", 0) or 0)
+        reference = getattr(getattr(runner, "buffers", None), "topk_p", None)
+        if max_bs <= 0 or not torch.is_tensor(reference):
+            raise RuntimeError("EAGLE3 draft graph inputs are not initialized")
+        if (
+            not torch.is_tensor(buffer)
+            or buffer.numel() < max_bs
+            or buffer.device != reference.device
+        ):
+            buffer = torch.zeros(
+                (max_bs,),
+                dtype=torch.int32,
+                device=reference.device,
+            )
+            setattr(runner, graph_state_attr, buffer)
+        return buffer
+
+    def input_init(self, *args, **kwargs):
+        original_input_init(self, *args, **kwargs)
+        runner = active_capture_runner["runner"]
+        if runner is None:
+            return
+        topk_p = getattr(self, "topk_p", None)
+        if not torch.is_tensor(topk_p):
+            return
+        state = _graph_state_buffer(runner)[: int(topk_p.shape[0])]
+        setattr(self, state_attr, state)
+        self.num_reject_tokens = state
+
+    def capture_one_batch_size(self, num_seqs, forward, stream_idx=0):
+        buffer = _graph_state_buffer(self)
+        buffer.zero_()
+        previous_runner = active_capture_runner["runner"]
+        active_capture_runner["runner"] = self
+        try:
+            return original_capture(
+                self,
+                num_seqs,
+                forward,
+                stream_idx=stream_idx,
+            )
+        finally:
+            active_capture_runner["runner"] = previous_runner
+
+    def capture_one_shape(self, *args, **kwargs):
+        buffer = _graph_state_buffer(self)
+        buffer.zero_()
+        previous_runner = active_capture_runner["runner"]
+        active_capture_runner["runner"] = self
+        try:
+            return original_capture(self, *args, **kwargs)
+        finally:
+            active_capture_runner["runner"] = previous_runner
+
+    def replay(self, forward_batch):
+        buffer = _graph_state_buffer(self)
+        buffer.zero_()
+        raw_bs = int(forward_batch.batch_size)
+        spec_info = getattr(forward_batch, "spec_info", None)
+        live_state = getattr(spec_info, state_attr, None)
+        if not torch.is_tensor(live_state):
+            live_state = getattr(spec_info, "num_reject_tokens", None)
+        if torch.is_tensor(live_state):
+            if live_state.numel() < raw_bs:
+                raise RuntimeError(
+                    "EAGLE3 reject graph state has fewer rows than the replay "
+                    f"batch: state_rows={live_state.numel()} batch_size={raw_bs}"
+                )
+            buffer[:raw_bs].copy_(
+                live_state[:raw_bs].to(
+                    device=buffer.device,
+                    dtype=buffer.dtype,
+                )
+            )
+        return original_replay(self, forward_batch)
+
+    EagleDraftInput.__init__ = input_init
+    if uses_shape_graph_api:
+        EAGLEDraftCudaGraphRunner.capture_one_shape = capture_one_shape
+        EAGLEDraftCudaGraphRunner.execute = replay
+    else:
+        EAGLEDraftCudaGraphRunner.capture_one_batch_size = capture_one_batch_size
+        EAGLEDraftCudaGraphRunner.replay = replay
+    EAGLEDraftCudaGraphRunner._atom_eagle3_reject_graph_state_patched = True
+
+
+def _patch_sglang_eagle3_draft_extend_compat() -> None:
+    """Keep SGLang EAGLE3 draft-extend semantics aligned with ATOM."""
+
+    try:
+        from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker
+    except Exception:  # noqa: BLE001 - optional across SGLang versions
+        return
+
+    if getattr(
+        EagleDraftWorker,
+        "_atom_eagle3_draft_extend_compat_patched",
+        False,
+    ):
+        return
+
+    original_draft_extend_for_prefill = EagleDraftWorker._draft_extend_for_prefill
+    original_draft_extend_for_decode = EagleDraftWorker._draft_extend_for_decode
+
+    def _draft_extend_for_prefill(
+        self,
+        batch,
+        target_hidden_states,
+        next_token_ids,
+        mm_input_embeds=None,
+    ):
+        ret = original_draft_extend_for_prefill(
+            self,
+            batch,
+            target_hidden_states,
+            next_token_ids,
+            mm_input_embeds=mm_input_embeds,
+        )
+        # A fresh request has no rejected draft suffix.  Set an explicit
+        # per-request zero vector so merging it into an active decode batch
+        # cannot inherit the previous batch's plugin-only reject state.
+        ret._atom_sglang_eagle3_num_reject_tokens = torch.zeros(
+            (len(batch.seq_lens),), dtype=torch.int32, device=next_token_ids.device
+        )
+        return ret
+
+    def _draft_extend_for_decode(self, batch, batch_result):
+        is_eagle3 = bool(
+            getattr(
+                getattr(self, "speculative_algorithm", None),
+                "is_eagle3",
+                lambda: False,
+            )()
+        )
+        if not is_eagle3:
+            return original_draft_extend_for_decode(self, batch, batch_result)
+
+        patched_next_token_ids = None
+        original_next_token_ids = getattr(batch_result, "next_token_ids", None)
+        spec_info = getattr(batch, "spec_info", None)
+        candidates = getattr(spec_info, "draft_token", None)
+        accept_lens = getattr(batch_result, "accept_lens", None)
+        num_draft_tokens = int(getattr(self, "speculative_num_draft_tokens", 0) or 0)
+
+        if (
+            torch.is_tensor(original_next_token_ids)
+            and torch.is_tensor(candidates)
+            and torch.is_tensor(accept_lens)
+            and num_draft_tokens > 1
+            and original_next_token_ids.numel()
+            >= len(batch.seq_lens) * num_draft_tokens
+            and candidates.numel() >= len(batch.seq_lens) * num_draft_tokens
+        ):
+            bs = len(batch.seq_lens)
+            patched_next_token_ids = original_next_token_ids.clone()
+            patched_view = patched_next_token_ids[: bs * num_draft_tokens].view(
+                bs, num_draft_tokens
+            )
+            candidate_view = candidates[: bs * num_draft_tokens].view(
+                bs, num_draft_tokens
+            )
+            accept_view = accept_lens[:bs].to(device=patched_view.device)
+            # SGLang stores verify candidates as
+            # [target_next, draft_1, ..., draft_k], while native ATOM's
+            # draft-extend input is the one-column left rotation.
+            rotated_candidates = torch.roll(candidate_view, shifts=-1, dims=1)
+            columns = torch.arange(
+                num_draft_tokens, device=patched_view.device
+            ).unsqueeze(0)
+            fill_mask = (columns >= accept_view.unsqueeze(1)) & (columns > 0)
+            patched_view.copy_(torch.where(fill_mask, rotated_candidates, patched_view))
+            batch_result.next_token_ids = patched_next_token_ids
+
+        try:
+            ret = original_draft_extend_for_decode(self, batch, batch_result)
+        finally:
+            if patched_next_token_ids is not None:
+                batch_result.next_token_ids = original_next_token_ids
+
+        accept_lens = getattr(batch_result, "accept_lens", None)
+        next_draft_input = getattr(batch_result, "next_draft_input", None)
+        if (
+            next_draft_input is not None
+            and torch.is_tensor(accept_lens)
+            and num_draft_tokens > 1
+        ):
+            bs = len(batch.seq_lens)
+            num_reject_tokens = (
+                num_draft_tokens - accept_lens[:bs].to(dtype=torch.int32)
+            ).clamp(min=0, max=num_draft_tokens - 1)
+            next_draft_input._atom_sglang_eagle3_num_reject_tokens = num_reject_tokens
+        return ret
+
+    EagleDraftWorker._draft_extend_for_prefill = _draft_extend_for_prefill
+    EagleDraftWorker._draft_extend_for_decode = _draft_extend_for_decode
+    EagleDraftWorker._atom_eagle3_draft_extend_compat_patched = True
+
+
+def _patch_sglang_eagle3_tp_verify_broadcast() -> None:
+    """Optionally broadcast SGLang EAGLE3 verify outputs across TP ranks."""
+
+    if os.getenv("ATOM_SGLANG_EAGLE3_TP_VERIFY_BROADCAST", "0") != "1":
+        return
+
+    try:
+        from sglang.srt.distributed import get_tp_group
+        from sglang.srt.layers.dp_attention import (
+            get_attention_tp_group,
+            is_dp_attention_enabled,
+        )
+        from sglang.srt.speculative import eagle_worker_v2 as eagle_worker_module
+        from sglang.srt.speculative.eagle_info import EagleVerifyInput
+
+        if not hasattr(EagleVerifyInput, "sample"):
+            from sglang.srt.speculative import eagle_utils
+    except Exception as exc:
+        logger.debug(
+            "Skipping optional EAGLE3 TP verify broadcast patch: %s",
+            exc,
+            exc_info=True,
+        )
+        return
+
+    if getattr(
+        eagle_worker_module,
+        "_atom_eagle3_tp_verify_broadcast_patched",
+        False,
+    ):
+        return
+
+    def _broadcast_sample_result(result):
+        predict, accept_lens, accept_index = result
+        tp_group = (
+            get_attention_tp_group() if is_dp_attention_enabled() else get_tp_group()
+        )
+        if tp_group.world_size > 1:
+            tp_group.broadcast(predict, src=0)
+            tp_group.broadcast(accept_lens, src=0)
+            tp_group.broadcast(accept_index, src=0)
+        return predict, accept_lens, accept_index
+
+    if hasattr(EagleVerifyInput, "sample"):
+        original_sample = EagleVerifyInput.sample
+
+        def sample(self, batch, logits_output, vocab_mask=None):
+            return _broadcast_sample_result(
+                original_sample(self, batch, logits_output, vocab_mask)
+            )
+
+        EagleVerifyInput.sample = sample
+    else:
+        original_eagle_sample = eagle_utils.eagle_sample
+
+        def eagle_sample(*args, **kwargs):
+            return _broadcast_sample_result(original_eagle_sample(*args, **kwargs))
+
+        eagle_utils.eagle_sample = eagle_sample
+        eagle_worker_module.eagle_sample = eagle_sample
+
+    eagle_worker_module._atom_eagle3_tp_verify_broadcast_patched = True
+
+
+def patch_sglang_eagle3_runtime_compat() -> None:
+    """Install all ATOM runtime compatibility patches for SGLang EAGLE3."""
+
+    _patch_sglang_eagle3_state_lifecycle()
+    _patch_sglang_eagle3_cuda_graph_reject_state()
+    _patch_sglang_eagle3_draft_extend_compat()
+    _patch_sglang_eagle3_tp_verify_broadcast()

--- a/atom/plugin/sglang/minimax_m3_bridge.py
+++ b/atom/plugin/sglang/minimax_m3_bridge.py
@@ -113,14 +113,41 @@ class ATOMMiniMaxM3SGLangKVPool:
             layer_id: idx for idx, layer_id in enumerate(self._sparse_layers)
         }
         index_dim = _m3_index_dim(hf_config)
-        self.index_k_buffer = [
-            torch.empty(
-                (self.size + self.page_size, 1, index_dim),
-                dtype=index_dtype,
-                device=self.device,
+        # SGLang v0.5.15 may allocate the native MiniMax sparse index cache in
+        # the model dtype (for example, BF16) even when the main KV cache uses
+        # FP8. ATOM's FP8 sparse-cache kernels only accept FP8 values or their
+        # uint8 storage representation, so reuse the native cache only when its
+        # concrete tensor dtype is compatible; otherwise allocate an ATOM-owned
+        # index cache below with the requested dtype.
+        requested_index_is_fp8 = _is_fp8_dtype(index_dtype)
+
+        def index_dtype_is_compatible(buffer: torch.Tensor) -> bool:
+            return buffer.dtype == index_dtype or (
+                requested_index_is_fp8
+                and (buffer.dtype == torch.uint8 or _is_fp8_dtype(buffer.dtype))
             )
-            for _ in self._sparse_layers
-        ]
+
+        self._reuse_main_index_cache = False
+        if hasattr(main_pool, "get_index_k_buffer"):
+            try:
+                self._reuse_main_index_cache = all(
+                    index_dtype_is_compatible(main_pool.get_index_k_buffer(layer_id))
+                    for layer_id in self._sparse_layers
+                )
+            except (AttributeError, RuntimeError, ValueError):
+                self._reuse_main_index_cache = False
+        self.index_k_buffer = (
+            []
+            if self._reuse_main_index_cache
+            else [
+                torch.empty(
+                    (self.size + self.page_size, 1, index_dim),
+                    dtype=index_dtype,
+                    device=self.device,
+                )
+                for _ in self._sparse_layers
+            ]
+        )
         self.k_scale_buffer = []
         self.v_scale_buffer = []
         if use_fp8_scales:
@@ -173,6 +200,8 @@ class ATOMMiniMaxM3SGLangKVPool:
         )
 
     def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
+        if self._reuse_main_index_cache:
+            return self.main_pool.get_index_k_buffer(layer_id)
         mapped = self._sparse_layer_mapping.get(int(layer_id))
         if mapped is None:
             raise ValueError(f"MiniMax-M3 layer {layer_id} has no index-K cache")
@@ -262,7 +291,7 @@ def install_minimax_m3_pool_patch() -> None:
         if not _is_m3_runner(self):
             return
         pool = getattr(self, "token_to_kv_pool", None)
-        if pool is None or hasattr(pool, "get_index_k_buffer"):
+        if pool is None or hasattr(pool, "get_kv_scale_buffer"):
             return
         use_fp8_scales = _is_fp8_dtype(self.kv_cache_dtype) or str(
             self.kv_cache_dtype
@@ -337,6 +366,35 @@ def _extend_lens(forward_batch, positions: torch.Tensor, bs: int) -> torch.Tenso
     )
 
 
+def _is_target_verify(forward_batch) -> bool:
+    return bool(
+        getattr(forward_batch.forward_mode, "is_target_verify", lambda: False)()
+    )
+
+
+def _target_verify_lens(
+    forward_batch,
+    positions: torch.Tensor,
+    bs: int,
+    seq_lens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    spec_info = getattr(forward_batch, "spec_info", None)
+    if spec_info is None:
+        raise RuntimeError("MiniMax-M3 target_verify requires speculative metadata")
+    draft_num = int(getattr(spec_info, "draft_token_num", 0) or 0)
+    if draft_num <= 0:
+        # Keep this robust for future SGLang variants that expose only the flat
+        # token tensor shape.
+        draft_num = max(1, int(positions.numel()) // max(1, bs))
+    query_lens = torch.full(
+        (bs,),
+        draft_num,
+        dtype=torch.int32,
+        device=positions.device,
+    )
+    return seq_lens + query_lens, query_lens, draft_num
+
+
 def _build_block_table(
     forward_batch,
     req_to_token_pool,
@@ -361,15 +419,15 @@ def _build_block_table(
         prefix_lens = seq_lens - extend_lens
         out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
         if out_cache_loc is not None:
-            offset = 0
-            for req_idx in range(bs):
-                prefix_len = int(prefix_lens[req_idx].item())
-                query_len = int(extend_lens[req_idx].item())
-                if query_len > 0:
-                    token_table[req_idx, prefix_len : prefix_len + query_len] = (
-                        out_cache_loc[offset : offset + query_len]
-                    )
-                offset += query_len
+            columns = torch.arange(token_table.shape[1], device=token_table.device)
+            rel_pos = columns.unsqueeze(0) - prefix_lens.unsqueeze(1)
+            mask = (rel_pos >= 0) & (rel_pos < extend_lens.unsqueeze(1))
+            query_offsets = torch.cumsum(extend_lens, dim=0) - extend_lens
+            src_idx = query_offsets.unsqueeze(1) + rel_pos
+            max_src_idx = max(int(out_cache_loc.numel()) - 1, 0)
+            src_idx = src_idx.clamp_min(0).clamp_max(max_src_idx).to(torch.long)
+            src_values = out_cache_loc.gather(0, src_idx.reshape(-1)).view_as(src_idx)
+            token_table = torch.where(mask, src_values, token_table)
 
     return (
         (token_table[:, : max_blocks * page_size : page_size] // page_size)
@@ -384,16 +442,71 @@ def build_atom_minimax_m3_attention_metadata_from_sglang(
     *,
     token_to_kv_pool,
     req_to_token_pool,
+    max_model_len: int,
 ):
     from atom.utils.forward_context import AttentionMetaData
 
     page_size = _page_size(token_to_kv_pool)
     bs = int(forward_batch.batch_size)
     seq_lens = _seq_lens(forward_batch, bs)
-    is_prefill = bool(
-        getattr(forward_batch.forward_mode, "is_prefill", lambda: False)()
-    )
+    forward_mode = forward_batch.forward_mode
+    is_prefill = bool(getattr(forward_mode, "is_prefill", lambda: False)())
+    is_target_verify = _is_target_verify(forward_batch)
     max_context_len = int(req_to_token_pool.req_to_token.shape[1])
+
+    if is_target_verify:
+        seq_lens, query_lens, tokens_per_req = _target_verify_lens(
+            forward_batch,
+            positions,
+            bs,
+            seq_lens,
+        )
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if not torch.is_tensor(out_cache_loc):
+            raise RuntimeError("MiniMax-M3 target_verify requires out_cache_loc")
+
+        # Keep a full model-length block table so its shape matches CUDA graph
+        # capture and native ATOM. In eager mode, use the live context maximum
+        # for max_seqlen_k, matching native ATOM target verify.
+        block_table_max_seq_len = min(max_context_len, max_model_len)
+        max_seq_len = (
+            block_table_max_seq_len
+            if _is_stream_capturing()
+            else (int(seq_lens.max().item()) if bs else 0)
+        )
+        block_table = _build_block_table(
+            forward_batch,
+            req_to_token_pool,
+            seq_lens=seq_lens,
+            extend_lens=query_lens,
+            page_size=page_size,
+            max_seq_len=block_table_max_seq_len,
+        )
+        slot_mapping = out_cache_loc[: bs * tokens_per_req].to(dtype=torch.int64)
+        sparse_md = make_sparse_decode_metadata(
+            seq_lens=seq_lens,
+            block_table=block_table,
+            slot_mapping=slot_mapping,
+            max_seq_len=max_seq_len,
+            max_query_len=tokens_per_req,
+        )
+        cu_q = torch.arange(
+            0,
+            bs * tokens_per_req + 1,
+            tokens_per_req,
+            dtype=torch.int32,
+            device=positions.device,
+        )
+        metadata = AttentionMetaData(
+            cu_seqlens_q=cu_q,
+            max_seqlen_q=tokens_per_req,
+            max_seqlen_k=max_seq_len,
+            slot_mapping=slot_mapping,
+            context_lens=seq_lens,
+            block_tables=block_table,
+        )
+        metadata.sparse_attention_metadata = sparse_md
+        return metadata
 
     if is_prefill:
         extend_lens = _extend_lens(forward_batch, positions, bs)

--- a/atom/plugin/sglang/models/base_model_wrapper.py
+++ b/atom/plugin/sglang/models/base_model_wrapper.py
@@ -65,6 +65,10 @@ class _AtomCausalLMBaseForSglang(nn.Module):
     type that sglang expects.
     """
 
+    # ATOM owns checkpoint quantization parsing, allocation and weight loading
+    # for external models; SGLang must not construct its native quant_config.
+    sglang_skip_quant_config = True
+
     def __init__(
         self,
         config,
@@ -81,6 +85,7 @@ class _AtomCausalLMBaseForSglang(nn.Module):
         self.unpadded_vocab_size = config.vocab_size
         self.model_arch = getattr(config, "architectures", [""])[0]
         self.model_arch_spec = get_model_arch_spec(self.model_arch)
+        self.capture_aux_hidden_states = False
 
         with plugin_runtime_scope(framework="sglang"):
             from atom.config import get_current_atom_config
@@ -101,8 +106,17 @@ class _AtomCausalLMBaseForSglang(nn.Module):
             raise ValueError(
                 f"ATOM failed to create model for architecture {self.model_arch}"
             )
+        if hasattr(self.model, "start_layer"):
+            self.start_layer = self.model.start_layer
+        if hasattr(self.model, "end_layer"):
+            self.end_layer = self.model.end_layer
 
-        if hasattr(self.model, "lm_head"):
+        if self.model_arch == "LlamaForCausalLMEagle3" and hasattr(
+            self.model, "compute_logits"
+        ):
+            self.logits_head = _ComputeLogitsHeadAdapter(self.model)
+            logits_head_handles_all_gather = True
+        elif hasattr(self.model, "lm_head"):
             self.logits_head = self.model.lm_head
             logits_head_handles_all_gather = False
         elif hasattr(self.model, "compute_logits"):
@@ -123,6 +137,10 @@ class _AtomCausalLMBaseForSglang(nn.Module):
         self.logits_processor = LogitsProcessor(
             config, skip_all_gather=plugin_skip_all_gather
         )
+        self.load_lm_head_from_target = getattr(
+            self.model, "load_lm_head_from_target", False
+        )
+        self.hot_token_id = getattr(self.model, "hot_token_id", None)
 
         # Apply model-specific install-time adapters (attn dispatch, weight hooks, etc.).
         if self.model_arch_spec.install_adapters is not None:
@@ -150,45 +168,122 @@ class _AtomCausalLMBaseForSglang(nn.Module):
         if self.model_arch == "DeepseekV4ForCausalLM":
             return self.model.model.embed.weight, self.model.model.head.weight
 
+        embed_owner, head_owner = self._embed_and_head_owners()
+        return embed_owner.embed_tokens.weight, head_owner.lm_head.weight
+
+    def _embed_and_head_owners(self):
+        if hasattr(self.model, "language_model"):
+            language_model = self.model.language_model
+            embed_owner = (
+                language_model.model
+                if hasattr(language_model, "model")
+                and hasattr(language_model.model, "embed_tokens")
+                else language_model
+            )
+            return embed_owner, language_model
+
         embed_owner = (
             self.model.model
             if hasattr(self.model, "model")
             and hasattr(self.model.model, "embed_tokens")
             else self.model
         )
-        return embed_owner.embed_tokens.weight, self.model.lm_head.weight
+        return embed_owner, self.model
 
     def set_embed_and_head(self, embed, head):
         if hasattr(self.model, "set_embed_and_head"):
             return self.model.set_embed_and_head(embed, head)
+        if self.model_arch == "LlamaForCausalLMEagle3":
+            logger.info(
+                "Skip sharing target embed/lm_head for ATOM EAGLE3 draft; "
+                "the draft checkpoint owns independent weights."
+            )
+            return None
 
-        embed_owner = (
-            self.model.model
-            if hasattr(self.model, "model")
-            and hasattr(self.model.model, "embed_tokens")
-            else self.model
-        )
+        embed_owner, head_owner = self._embed_and_head_owners()
         del embed_owner.embed_tokens.weight
-        del self.model.lm_head.weight
+        del head_owner.lm_head.weight
         embed_owner.embed_tokens.weight = embed
-        self.model.lm_head.weight = head
+        head_owner.lm_head.weight = head
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
 
     def set_embed(self, embed):
         if hasattr(self.model, "set_embed"):
             return self.model.set_embed(embed)
+        if self.model_arch == "LlamaForCausalLMEagle3":
+            logger.info(
+                "Skip sharing target embedding for ATOM EAGLE3 draft; "
+                "the draft checkpoint owns independent embedding."
+            )
+            return None
 
-        embed_owner = (
-            self.model.model
-            if hasattr(self.model, "model")
-            and hasattr(self.model.model, "embed_tokens")
-            else self.model
-        )
+        embed_owner, _ = self._embed_and_head_owners()
         del embed_owner.embed_tokens.weight
         embed_owner.embed_tokens.weight = embed
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+    def set_eagle3_layers_to_capture(self, layer_ids: Iterable[int] | None = None):
+        self.capture_aux_hidden_states = True
+        if layer_ids is None:
+            get_default_layers = getattr(
+                self.model, "get_eagle3_aux_hidden_state_layers", None
+            )
+            if get_default_layers is None:
+                raise AttributeError(
+                    f"ATOM model {type(self.model).__name__} does not define "
+                    "get_eagle3_aux_hidden_state_layers"
+                )
+            layer_ids = get_default_layers()
+
+        layer_ids = tuple(int(layer_id) for layer_id in layer_ids)
+        if hasattr(self.model, "set_eagle3_layers_to_capture"):
+            return self.model.set_eagle3_layers_to_capture(layer_ids)
+        if hasattr(self.model, "set_aux_hidden_state_layers"):
+            return self.model.set_aux_hidden_state_layers(layer_ids)
+        raise AttributeError(
+            f"ATOM model {type(self.model).__name__} does not support "
+            "EAGLE3 auxiliary hidden-state capture"
+        )
+
+    def _split_aux_hidden_states(self, output):
+        if (
+            isinstance(output, tuple)
+            and len(output) == 2
+            and (torch.is_tensor(output[0]) or hasattr(output[0], "tensors"))
+        ):
+            return output[0], output[1]
+        return output, None
+
+    def _trim_aux_hidden_states(self, runtime, aux_hidden_states):
+        if aux_hidden_states is None:
+            return None
+        if torch.is_tensor(aux_hidden_states):
+            return runtime.trim_output(aux_hidden_states)
+        if isinstance(aux_hidden_states, list):
+            return [
+                runtime.trim_output(aux_hidden_state)
+                for aux_hidden_state in aux_hidden_states
+            ]
+        return aux_hidden_states
+
+    def _forward_eagle3_draft_model(self, input_ids, positions, forward_batch):
+        spec_info = getattr(forward_batch, "spec_info", None)
+        hidden_states = getattr(spec_info, "hidden_states", None)
+        if hidden_states is None:
+            raise RuntimeError("EAGLE3 draft forward requires spec_info.hidden_states")
+        if hidden_states.shape[-1] != self.model.config.hidden_size:
+            hidden_states = self.model.combine_hidden_states(hidden_states)
+        # SGLang stores the target token's position in EAGLE draft phases.
+        # Native ATOM runs the draft token at the next position, including
+        # the DRAFT_EXTEND_V2 fill-cache phase.
+        effective_positions = positions + 1
+        return self.model(
+            input_ids=input_ids,
+            positions=effective_positions,
+            hidden_states=hidden_states,
+        )
 
     @torch.no_grad()
     def forward(
@@ -218,17 +313,23 @@ class _AtomCausalLMBaseForSglang(nn.Module):
                     pp_proxy_tensors=pp_proxy_tensors,
                     save_kv_cache=model_kwargs.get("save_kv_cache"),
                 )
-                model_inputs = dict(
-                    input_ids=runtime.input_ids,
-                    positions=runtime.positions,
-                    intermediate_tensors=SGLangForwardBatchMetadata.to_intermediate_tensors(
+                model_inputs = {
+                    "input_ids": runtime.input_ids,
+                    "positions": runtime.positions,
+                    "intermediate_tensors": SGLangForwardBatchMetadata.to_intermediate_tensors(
                         pp_proxy_tensors, metadata
                     ),
-                    inputs_embeds=runtime.input_embeds,
-                )
+                    "inputs_embeds": runtime.input_embeds,
+                }
 
                 with SGLangForwardBatchMetadata.bind(metadata):
-                    if self.model_arch_spec.wrapper_binds_gdn_context:
+                    if self.model_arch == "LlamaForCausalLMEagle3":
+                        hidden_states = self._forward_eagle3_draft_model(
+                            runtime.input_ids,
+                            runtime.positions,
+                            runtime.forward_batch,
+                        )
+                    elif self.model_arch_spec.wrapper_binds_gdn_context:
                         from atom.plugin.sglang.attention_backend.attention_gdn import (
                             SGLangGDNForwardContext,
                         )
@@ -253,7 +354,13 @@ class _AtomCausalLMBaseForSglang(nn.Module):
                             **self._filter_model_forward_kwargs(model_call_kwargs)
                         )
 
+                hidden_states, aux_hidden_states = self._split_aux_hidden_states(
+                    hidden_states
+                )
                 hidden_states = runtime.trim_output(hidden_states)
+                aux_hidden_states = self._trim_aux_hidden_states(
+                    runtime, aux_hidden_states
+                )
 
                 if self.pp_group.is_last_rank:
                     if self.model_arch == "DeepseekV4ForCausalLM":
@@ -262,6 +369,7 @@ class _AtomCausalLMBaseForSglang(nn.Module):
                             hidden_states,
                             self.logits_head,
                             forward_batch,
+                            aux_hidden_states=aux_hidden_states,
                             hidden_states_before_norm=hidden_states,
                         )
                     return self.logits_processor(
@@ -269,6 +377,7 @@ class _AtomCausalLMBaseForSglang(nn.Module):
                         hidden_states,
                         self.logits_head,
                         forward_batch,
+                        aux_hidden_states=aux_hidden_states,
                     )
                 return hidden_states
 
@@ -277,6 +386,39 @@ class _AtomCausalLMBaseForSglang(nn.Module):
         # uses its own weight loading pipeline (handling AITER-specific quant
         # formats, kv_b_proj splitting, etc.) that is incompatible with
         # sglang's default weight iterator.
+        if self.model_arch == "LlamaForCausalLMEagle3":
+            from atom.model_loader.loader import load_model
+
+            draft_path = None
+            try:
+                from sglang.srt.server_args import get_global_server_args
+
+                server_args = get_global_server_args()
+                draft_path = getattr(server_args, "speculative_draft_model_path", None)
+            except Exception:
+                logger.exception("Failed to resolve SGLang EAGLE3 draft model path")
+            draft_path = draft_path or getattr(self.config, "_name_or_path", None)
+            draft_path = draft_path or getattr(self.config, "name_or_path", None)
+            if not draft_path:
+                raise RuntimeError("Cannot resolve EAGLE3 draft model path")
+            logger.info("Loading ATOM EAGLE3 draft weights from %s", draft_path)
+            self.atom_config.model = draft_path
+            self.atom_config.hf_config = self.config
+            with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
+                result = load_model(
+                    model=self.model,
+                    model_name_or_path=draft_path,
+                    hf_config=self.config,
+                    load_dummy=self.atom_config.load_dummy,
+                    prefix="",
+                    is_plugin_mode=True,
+                )
+            # This draft uses the target vocabulary directly; do not apply
+            # SGLang's optional hot-token remapping table.
+            self.hot_token_id = None
+            self.model.hot_token_id = None
+            return result
+
         from atom.model_loader.loader import load_model_in_plugin_mode
 
         with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):

--- a/atom/plugin/sglang/prepare.py
+++ b/atom/plugin/sglang/prepare.py
@@ -74,6 +74,8 @@ def prepare_model(config: Any):
     from atom.plugin.sglang.runtime import get_model_arch_spec
 
     model_adapter = get_model_arch_spec(model_arch)
+    if model_adapter.prepare_draft_model_config is not None:
+        model_adapter.prepare_draft_model_config(atom_config, config)
     if model_adapter.prepare_config is not None:
         model_adapter.prepare_config(atom_config, model_arch)
     else:

--- a/atom/plugin/sglang/register.py
+++ b/atom/plugin/sglang/register.py
@@ -1,0 +1,88 @@
+import logging
+
+logger = logging.getLogger("atom.plugin.sglang.register")
+
+
+def _is_atom_external_model_enabled() -> bool:
+    try:
+        from sglang.srt.environ import envs
+
+        return envs.SGLANG_EXTERNAL_MODEL_PACKAGE.get() == "atom.plugin.sglang.models"
+    except Exception:  # noqa: BLE001 - optional across SGLang versions
+        return False
+
+
+def _hf_quant_method(model_config) -> str:
+    try:
+        quant_cfg = model_config._parse_quant_hf_config()
+    except Exception:  # noqa: BLE001 - tolerate absent or incompatible HF config
+        quant_cfg = None
+    if not quant_cfg:
+        return ""
+    return str(quant_cfg.get("quant_method", "")).lower()
+
+
+def _install_model_config_quant_patch() -> None:
+    from sglang.srt.configs.model_config import ModelConfig
+
+    if getattr(ModelConfig, "_atom_sglang_quant_patch", False):
+        return
+
+    original_verify_quantization = ModelConfig._verify_quantization
+
+    def verify_quantization_with_atom_external_bypass(self):
+        try:
+            return original_verify_quantization(self)
+        except ValueError as exc:
+            if (
+                _is_atom_external_model_enabled()
+                and _hf_quant_method(self) == "mxfp8"
+                and "quantization is currently not supported in ROCm" in str(exc)
+            ):
+                logger.info(
+                    "Skipping SGLang server-args quantization gate for ATOM "
+                    "external MXFP8 model; ATOM owns quantized weight loading."
+                )
+                self.quantization = None
+                return None
+            raise
+
+    ModelConfig._verify_quantization = verify_quantization_with_atom_external_bypass
+    ModelConfig._atom_sglang_quant_patch = True
+
+
+def _install_loader_quant_patch() -> None:
+    from sglang.srt.model_loader import loader
+
+    if getattr(loader, "_atom_sglang_quant_patch", False):
+        return
+
+    original_get_quantization_config = loader._get_quantization_config
+
+    def get_quantization_config_with_atom_external_bypass(model_config, load_config):
+        model_class, _ = loader.get_model_architecture(model_config)
+        if getattr(model_class, "sglang_skip_quant_config", False):
+            logger.info(
+                "Skipping SGLang native quant_config for external model %s; "
+                "the model wrapper owns quantized weight loading.",
+                model_class.__name__,
+            )
+            return None
+        return original_get_quantization_config(model_config, load_config)
+
+    loader._get_quantization_config = get_quantization_config_with_atom_external_bypass
+    loader._atom_sglang_quant_patch = True
+
+
+def register_plugin() -> None:
+    """Install ATOM patches that must run before SGLang parses server args."""
+
+    _install_model_config_quant_patch()
+    _install_loader_quant_patch()
+
+    try:
+        from atom.plugin.sglang.runtime import apply_load_config_patch
+
+        apply_load_config_patch()
+    except Exception:
+        logger.exception("Failed to install ATOM SGLang load-config patch")

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -353,6 +353,7 @@ def _build_minimax_m3_metadata(
         positions,
         token_to_kv_pool=token_to_kv_pool,
         req_to_token_pool=req_to_token_pool,
+        max_model_len=int(atom_config.max_model_len),
     )
 
 
@@ -409,6 +410,36 @@ def _build_deepseek_v4_metadata(forward_batch: ForwardBatch, positions: torch.Te
     return attn_metadata
 
 
+def _build_eagle3_llama_metadata(
+    atom_config: Any, forward_batch: ForwardBatch, positions: torch.Tensor
+):
+    hf_config = getattr(atom_config, "hf_config", None)
+    if _is_dummy_forward(forward_batch) or hf_config is None:
+        return None
+
+    from atom.plugin.sglang.eagle3_llama_bridge import (
+        build_atom_eagle3_attention_metadata_from_sglang,
+        is_eagle3_llama_config,
+        maybe_get_eagle3_pools_from_sglang_batch,
+    )
+
+    if not is_eagle3_llama_config(hf_config):
+        return None
+
+    token_to_kv_pool, req_to_token_pool = maybe_get_eagle3_pools_from_sglang_batch(
+        forward_batch
+    )
+    if token_to_kv_pool is None or req_to_token_pool is None:
+        return None
+
+    return build_atom_eagle3_attention_metadata_from_sglang(
+        forward_batch,
+        positions,
+        token_to_kv_pool=token_to_kv_pool,
+        req_to_token_pool=req_to_token_pool,
+    )
+
+
 def _set_atom_forward_context(
     atom_config: Any,
     forward_batch: ForwardBatch,
@@ -457,10 +488,22 @@ def _set_atom_forward_context(
             ) from exc
 
     if attn_metadata is None:
+        try:
+            attn_metadata = _build_eagle3_llama_metadata(
+                atom_config,
+                forward_batch,
+                positions,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to build ATOM EAGLE3 draft metadata for SGLang"
+            ) from exc
+
+    if attn_metadata is None:
         attn_metadata = _build_generic_attention_metadata(forward_batch, max_seqlen_q)
     batch_size = int(forward_batch.batch_size)
     is_dummy_run = _is_dummy_forward(forward_batch)
-    is_prefill = forward_mode.is_prefill()
+    is_prefill = forward_mode.is_prefill() and not forward_mode.is_target_verify()
     num_tokens = int(positions.shape[0])
 
     if bool(atom_config.enable_dp_attention):

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Callable
 from contextlib import AbstractContextManager
-from typing import Any, Callable, Optional
+from dataclasses import dataclass
+from typing import Any
 
 GLM52_DSA_ARCH = "GlmMoeDsaForCausalLM"
 GLM52_DSA_MODEL_TYPE = "glm_moe_dsa"
@@ -31,10 +32,15 @@ class SGLangModelAdapterSpec:
 
     wrapper_binds_gdn_context: bool = False
     uses_context_only_forward: bool = False
-    prepare_config: Optional[Callable[[Any, str], None]] = None
-    construction_context: Optional[Callable[[], AbstractContextManager[Any]]] = None
-    install_adapters: Optional[Callable[[Any], None]] = None
-    bind_cache_views: Optional[Callable[[Any, Any], None]] = None
+    # SGLang initializes atom_config from the target ServerArgs but passes a
+    # draft-local HF config to the external draft model. This early hook lets
+    # adapters preserve target metadata and switch to the draft config before
+    # normal config preparation.
+    prepare_draft_model_config: Callable[[Any, Any], None] | None = None
+    prepare_config: Callable[[Any, str], None] | None = None
+    construction_context: Callable[[], AbstractContextManager[Any]] | None = None
+    install_adapters: Callable[[Any], None] | None = None
+    bind_cache_views: Callable[[Any, Any], None] | None = None
 
 
 def _prepare_qwen35_config(atom_config: Any, model_arch: str) -> None:
@@ -70,6 +76,20 @@ def _prepare_minimax_m3_config(atom_config: Any, model_arch: str) -> None:
         MiniMaxM3SparseForConditionalGeneration,
     )
 
+    # SGLang applies JSON model overrides to the root HF config. Mirror the
+    # sparse-attention options into the text config consumed by MiniMax-M3.
+    hf_config = atom_config.hf_config
+    text_config = getattr(hf_config, "text_config", None)
+    if text_config is not None:
+        for name in (
+            "use_index_cache",
+            "index_topk_freq",
+            "index_topk_pattern",
+            "index_skip_topk_offset",
+        ):
+            if hasattr(hf_config, name):
+                setattr(text_config, name, getattr(hf_config, name))
+
     # MiniMax-M3 native sparse attention is block-sparse at 128-token granularity.
     # The SGLang recipe must use --page-size 128; keep ATOM's config aligned so
     # sparse metadata and SHUFFLE cache views speak the same page ABI.
@@ -84,7 +104,7 @@ def _prepare_minimax_m3_config(atom_config: Any, model_arch: str) -> None:
         else MiniMaxM3SparseForCausalLM
     )
     quant_config.remap_layer_name(
-        atom_config.hf_config,
+        hf_config,
         packed_modules_mapping=model_cls.packed_modules_mapping,
         quant_exclude_name_mapping=getattr(model_cls, "quant_exclude_name_mapping", {}),
     )
@@ -216,6 +236,60 @@ def _bind_minimax_m3_cache_views(model: Any, runtime: Any) -> None:
         raise RuntimeError("MiniMax-M3 SGLang sparse KV pool is not initialized")
 
 
+def _prepare_eagle3_llama_draft_model_config(
+    atom_config: Any, draft_config: Any
+) -> None:
+    from atom.config import QuantizationConfig
+
+    num_draft_layers = int(getattr(draft_config, "num_hidden_layers", 0) or 0)
+    if num_draft_layers != 1:
+        raise ValueError("ATOM SGLang EAGLE3 supports exactly one draft layer")
+
+    target_config = getattr(atom_config.hf_config, "text_config", atom_config.hf_config)
+    layer_offset = int(getattr(target_config, "num_hidden_layers", 0) or 0)
+    # SGLang allocates the independent one-layer draft KV pool at physical
+    # layer [0, 1), while ATOM numbers the draft attention logically after the
+    # target layers (for example, layer 60). Save the target layer count here so
+    # SGLangATOMEagle3Attention can assign ATOM's logical layer_num=60; the
+    # EAGLE3 cache bridge maps that logical id back to SGLang's physical slot 0.
+    atom_config.sgl_atom_eagle3_layer_offset = layer_offset
+
+    atom_config.hf_config = draft_config
+    model_path = getattr(draft_config, "_name_or_path", None) or getattr(
+        draft_config, "name_or_path", None
+    )
+    if model_path:
+        atom_config.model = model_path
+    atom_config.quant_config = QuantizationConfig(
+        draft_config,
+        online_quant_config=getattr(atom_config, "online_quant_config", None),
+    )
+
+
+def _eagle3_llama_construction_context():
+    from atom.plugin.sglang.eagle3_llama_bridge import (
+        eagle3_llama_native_attention_construction,
+    )
+
+    return eagle3_llama_native_attention_construction()
+
+
+def _bind_eagle3_llama_cache_views(model: Any, runtime: Any) -> None:
+    if getattr(runtime.forward_batch.forward_mode, "is_idle", lambda: False)():
+        return
+
+    from atom.plugin.sglang.eagle3_llama_bridge import (
+        bind_eagle3_llama_cache_views,
+        maybe_get_eagle3_pools_from_sglang_batch,
+    )
+
+    token_to_kv_pool, _ = maybe_get_eagle3_pools_from_sglang_batch(
+        runtime.forward_batch
+    )
+    if not bind_eagle3_llama_cache_views(model, token_to_kv_pool):
+        raise RuntimeError("EAGLE3 SGLang draft KV pool is not initialized")
+
+
 MODEL_ADAPTER_SPECS = {
     "DeepseekV3ForCausalLM": SGLangModelAdapterSpec(
         install_adapters=_install_deepseek_mla_adapters,
@@ -269,6 +343,12 @@ MODEL_ADAPTER_SPECS = {
         install_adapters=_install_minimax_m3_adapters,
         bind_cache_views=_bind_minimax_m3_cache_views,
     ),
+    "LlamaForCausalLMEagle3": SGLangModelAdapterSpec(
+        uses_context_only_forward=True,
+        prepare_draft_model_config=_prepare_eagle3_llama_draft_model_config,
+        construction_context=_eagle3_llama_construction_context,
+        bind_cache_views=_bind_eagle3_llama_cache_views,
+    ),
 }
 
 # Architectures whose SGLang EntryClass is generated by base_model_wrapper.
@@ -286,6 +366,7 @@ MODEL_ARCH_SPECS = {
         "MiniMaxM2ForCausalLM",
         "MiniMaxM3SparseForCausalLM",
         "MiniMaxM3SparseForConditionalGeneration",
+        "LlamaForCausalLMEagle3",
         "DeepseekV4ForCausalLM",
     )
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ atom = "atom.plugin.vllm.register:register_platform"
 
 [project.entry-points."vllm.general_plugins"]
 atom_model_registry = "atom.plugin.vllm.register:register_model"
+
+[project.entry-points."sglang.srt.plugins"]
+atom_sglang = "atom.plugin.sglang.register:register_plugin"

--- a/recipes/atom_sglang/MiniMax-M3.md
+++ b/recipes/atom_sglang/MiniMax-M3.md
@@ -92,6 +92,59 @@ python3 -m sglang.launch_server \
     --disable-radix-cache 2>&1 | tee "${run_name}-server.log"
 ```
 
+## MXFP8 with MTP (EAGLE3) on 4xMI355 GPUs
+
+Use the [`Inferact/MiniMax-M3-EAGLE3`](https://huggingface.co/Inferact/MiniMax-M3-EAGLE3)
+draft checkpoint with the MXFP8 target model to enable MTP decoding through
+SGLang's `EAGLE3` speculative algorithm. The following example uses three
+speculative draft steps.
+
+### Launching Server
+
+```bash
+model_path=${model_path:-MiniMaxAI/MiniMax-M3-MXFP8}
+draft_model_path=${draft_model_path:-Inferact/MiniMax-M3-EAGLE3}
+run_name=${run_name:-m3-mxfp8-mtp3}
+
+export SGLANG_PLUGINS=atom_sglang
+export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
+export SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
+export SGLANG_USE_AITER=1
+export SGLANG_AITER_FP8_PREFILL_ATTN=0
+export ATOM_FORCE_ATTN_TRITON=1
+export SGLANG_ENABLE_TORCH_COMPILE=1
+export TORCHINDUCTOR_COMPILE_THREADS=128
+
+MODEL_LOADER_EXTRA_CONFIG='{"online_quant_config":{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","vision_tower","multi_modal_projector","patch_merge_mlp","*block_sparse_moe"]}}'
+JSON_MODEL_OVERRIDE_ARGS='{"use_index_cache":true,"index_topk_freq":4}'
+
+PORT=${PORT:-8000}
+TP=${TP:-4}
+
+python3 -m sglang.launch_server \
+    --model-path "${model_path}" \
+    --host 127.0.0.1 \
+    --port "${PORT}" \
+    --trust-remote-code \
+    --random-seed 0 \
+    --tensor-parallel-size "${TP}" \
+    --attention-backend aiter \
+    --mem-fraction-static 0.75 \
+    --page-size 128 \
+    --context-length 32768 \
+    --max-running-requests 128 \
+    --model-loader-extra-config "${MODEL_LOADER_EXTRA_CONFIG}" \
+    --json-model-override-args "${JSON_MODEL_OVERRIDE_ARGS}" \
+    --speculative-algorithm EAGLE3 \
+    --speculative-draft-model-path "${draft_model_path}" \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --kv-cache-dtype fp8_e4m3 \
+    --disable-radix-cache \
+    --decode-log-interval 1 2>&1 | tee "${run_name}-server.log"
+```
+
 
 ### Accuracy Test
 


### PR DESCRIPTION
## Motivation

enable minimax-m3 mtp in sglang atom && m3 error cased by sglang update.

## command

```
#!/usr/bin/env bash
set -euo pipefail
 
MODEL_PATH=${MODEL_PATH:-/models/MiniMax-M3-MXFP8}
DRAFT_MODEL_PATH=${DRAFT_MODEL_PATH:-/models/MiniMax-M3-EAGLE3}
PORT=${PORT:-8000}

 
export CUDA_VISIBLE_DEVICES=0,1,2,3

export SGLANG_PLUGINS=atom_sglang
export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
export SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export SGLANG_USE_AITER=1
export SGLANG_AITER_FP8_PREFILL_ATTN=0
export ATOM_FORCE_ATTN_TRITON=1
export SGLANG_ENABLE_TORCH_COMPILE=1
export TORCHINDUCTOR_COMPILE_THREADS=128

export ATOM_SGLANG_EAGLE3_TP_VERIFY_BROADCAST=1

MODEL_LOADER_EXTRA_CONFIG='{"online_quant_config":{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","vision_tower","multi_modal_projector","patch_merge_mlp","*block_sparse_moe"]}}'
JSON_MODEL_OVERRIDE_ARGS='{"use_index_cache":true,"index_topk_freq":4}'

python3 -m sglang.launch_server \
    --model-path "${MODEL_PATH}" \
    --host 127.0.0.1 \
    --port "${PORT}" \
    --trust-remote-code \
    --random-seed 0 \
    --tensor-parallel-size 4 \
    --attention-backend aiter \
    --mem-fraction-static 0.75 \
    --page-size 128 \
    --context-length 32768 \
    --max-running-requests 128 \
    --model-loader-extra-config "${MODEL_LOADER_EXTRA_CONFIG}" \
    --json-model-override-args "${JSON_MODEL_OVERRIDE_ARGS}" \
    --speculative-algorithm EAGLE3 \
    --speculative-draft-model-path "${DRAFT_MODEL_PATH}" \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --kv-cache-dtype fp8_e4m3 \
    --disable-radix-cache \
    --decode-log-interval 1
```


## Acc
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9484|±  |0.0061|
|     |       |strict-match    |     5|exact_match|↑  |0.9492|±  |0.0060|
```

## Accept ratio
68%, same as atom

## Additional ENVS
ATOM_SGLANG_EAGLE3_TP_VERIFY_BROADCAST=1: Broadcasts EAGLE3 verification results from rank 0 to all TP ranks to keep speculative decoding state synchronized, just like ATOM does. It will improve accept rate.

ATOM_SGLANG_MTP_LOG=1: Enables cumulative MTP acceptance-rate and average accepted-tokens-per-forward logging for debug