### PR TITLE
feat(glm): support GLM-5.2 DP attention

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -30,7 +30,7 @@ except ImportError:
     concat_and_cache_mla_seg = None
     fused_qk_rope_concat_and_cache_mla_seg = None
 from aiter.dist.parallel_state import get_dp_group
-from aiter.mla import mla_decode_fwd, mla_decode_fwd_ds32, mla_prefill_fwd
+from aiter.mla import mla_decode_fwd, mla_prefill_fwd
 from aiter.ops.triton.attention.mla import (
     mla_decode_fwd as triton_shuffle_mla_decode_fwd,
 )
@@ -85,9 +85,19 @@ if fused_qk_rope_concat_and_cache_mla_seg is not None:
     )
 mla_prefill_fwd = mark_trace(mla_prefill_fwd, prefix="mla_prefill", torch_compile=False)
 mla_decode_fwd = mark_trace(mla_decode_fwd, prefix="mla_decode", torch_compile=False)
-mla_decode_fwd_ds32 = mark_trace(
-    mla_decode_fwd_ds32, prefix="mla_decode_ds32", torch_compile=False
-)
+_mla_decode_fwd_ds32 = None
+
+
+def _get_mla_decode_fwd_ds32():
+    global _mla_decode_fwd_ds32
+    if _mla_decode_fwd_ds32 is None:
+        from aiter.mla import mla_decode_fwd_ds32
+
+        _mla_decode_fwd_ds32 = mark_trace(
+            mla_decode_fwd_ds32, prefix="mla_decode_ds32", torch_compile=False
+        )
+    return _mla_decode_fwd_ds32
+
 
 # Shuffled-KV (block_size=64) Triton/Gluon MLA kernels, gated by
 # ATOM_USE_TRITON_MLA and ATOM_USE_TRITON_MLA_SHUFFLE_KV:. Write kernels mirror the aiter
@@ -322,6 +332,7 @@ class MLAAttention(nn.Module):
             and mla_modules.kv_lora_rank == _DS32_NOPE_DIM
             and mla_modules.qk_rope_head_dim == _DS32_ROPE_DIM
         )
+        self.mla_decode_fwd_ds32 = _get_mla_decode_fwd_ds32() if self.use_ds32 else None
         min_mla_heads = 128 if self.use_ds32 else _MLA_MIN_HEADS
         self.padded_num_heads = max(num_heads, min_mla_heads)
         self.head_repeat_factor = 1
@@ -569,7 +580,7 @@ class MLAAttention(nn.Module):
             dtype=torch.bfloat16,
             device=q_nope.device,
         )
-        mla_decode_fwd_ds32(
+        self.mla_decode_fwd_ds32(
             q_nope,
             q_rope,
             kv_nope,

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -197,6 +197,7 @@ def _ds32_store_kv(
         BLOCK=512,
     )
 
+
 if False:
     try:
         from aiter.ops.triton.fused_gemm_a8w8_blockscale_split_cat import (
@@ -321,11 +322,7 @@ class MLAAttention(nn.Module):
             and mla_modules.kv_lora_rank == _DS32_NOPE_DIM
             and mla_modules.qk_rope_head_dim == _DS32_ROPE_DIM
         )
-        min_mla_heads = (
-            128
-            if self.use_ds32
-            else _MLA_MIN_HEADS
-        )
+        min_mla_heads = 128 if self.use_ds32 else _MLA_MIN_HEADS
         self.padded_num_heads = max(num_heads, min_mla_heads)
         self.head_repeat_factor = 1
         self.head_pad = 0
@@ -468,9 +465,7 @@ class MLAAttention(nn.Module):
                     f"{dtype}, got {None if tensor is None else (tensor.shape, tensor.dtype, tensor.stride())}."
                 )
 
-    def _ds32_quantize_nope(
-        self, x: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    def _ds32_quantize_nope(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Quantize a 512-wide MLA latent to MXFP8 with per-1x32 E8M0 scales."""
         shape = x.shape
         if shape[-1] != _DS32_NOPE_DIM:

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -30,7 +30,7 @@ except ImportError:
     concat_and_cache_mla_seg = None
     fused_qk_rope_concat_and_cache_mla_seg = None
 from aiter.dist.parallel_state import get_dp_group
-from aiter.mla import mla_decode_fwd, mla_prefill_fwd
+from aiter.mla import mla_decode_fwd, mla_decode_fwd_ds32, mla_prefill_fwd
 from aiter.ops.triton.attention.mla import (
     mla_decode_fwd as triton_shuffle_mla_decode_fwd,
 )
@@ -85,6 +85,9 @@ if fused_qk_rope_concat_and_cache_mla_seg is not None:
     )
 mla_prefill_fwd = mark_trace(mla_prefill_fwd, prefix="mla_prefill", torch_compile=False)
 mla_decode_fwd = mark_trace(mla_decode_fwd, prefix="mla_decode", torch_compile=False)
+mla_decode_fwd_ds32 = mark_trace(
+    mla_decode_fwd_ds32, prefix="mla_decode_ds32", torch_compile=False
+)
 
 # Shuffled-KV (block_size=64) Triton/Gluon MLA kernels, gated by
 # ATOM_USE_TRITON_MLA and ATOM_USE_TRITON_MLA_SHUFFLE_KV:. Write kernels mirror the aiter
@@ -121,6 +124,78 @@ _MLA_Q_OUT_PADDED_DIM = 768
 # Dims the fused seg kernels are compiled against (KV_LORA / PE_DIM constexprs).
 _MLA_SEG_KV_LORA_RANK = 512
 _MLA_SEG_PE_DIM = 64
+_DS32_NOPE_DIM = 512
+_DS32_ROPE_DIM = 64
+_DS32_SCALE_DIM = _DS32_NOPE_DIM // 32
+_DS32_CACHE_BYTES = _DS32_NOPE_DIM + _DS32_SCALE_DIM + _DS32_ROPE_DIM * 2
+
+
+@triton.jit
+def _ds32_store_kv_kernel(
+    k_nope,
+    k_scale,
+    k_rope,
+    cache_nope,
+    cache_scale,
+    cache_rope,
+    slot_mapping,
+    stride_kn_t,
+    stride_ks_t,
+    stride_kr_t,
+    stride_cn_t,
+    stride_cs_t,
+    stride_cr_t,
+    NOPE_DIM: tl.constexpr,
+    SCALE_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+    slot = tl.load(slot_mapping + token_idx)
+    valid_slot = slot >= 0
+
+    nope_mask = valid_slot & (offsets < NOPE_DIM)
+    nope = tl.load(k_nope + token_idx * stride_kn_t + offsets, mask=nope_mask)
+    tl.store(cache_nope + slot * stride_cn_t + offsets, nope, mask=nope_mask)
+
+    scale_mask = valid_slot & (offsets < SCALE_DIM)
+    scale = tl.load(k_scale + token_idx * stride_ks_t + offsets, mask=scale_mask)
+    tl.store(cache_scale + slot * stride_cs_t + offsets, scale, mask=scale_mask)
+
+    rope_mask = valid_slot & (offsets < ROPE_DIM)
+    rope = tl.load(k_rope + token_idx * stride_kr_t + offsets, mask=rope_mask)
+    tl.store(cache_rope + slot * stride_cr_t + offsets, rope, mask=rope_mask)
+
+
+def _ds32_store_kv(
+    k_nope: torch.Tensor,
+    k_scale: torch.Tensor,
+    k_rope: torch.Tensor,
+    cache_nope: torch.Tensor,
+    cache_scale: torch.Tensor,
+    cache_rope: torch.Tensor,
+    slot_mapping: torch.Tensor,
+) -> None:
+    _ds32_store_kv_kernel[(k_nope.shape[0],)](
+        k_nope,
+        k_scale,
+        k_rope,
+        cache_nope,
+        cache_scale,
+        cache_rope,
+        slot_mapping.flatten(),
+        k_nope.stride(0),
+        k_scale.stride(0),
+        k_rope.stride(0),
+        cache_nope.stride(0),
+        cache_scale.stride(0),
+        cache_rope.stride(0),
+        NOPE_DIM=_DS32_NOPE_DIM,
+        SCALE_DIM=_DS32_SCALE_DIM,
+        ROPE_DIM=_DS32_ROPE_DIM,
+        BLOCK=512,
+    )
 
 if False:
     try:
@@ -235,7 +310,23 @@ class MLAAttention(nn.Module):
         self.kv_cache_dtype = "fp8" if kv_cache_dtype.startswith("fp8") else "auto"
         self.dtype = dtype
 
-        self.padded_num_heads = max(num_heads, _MLA_MIN_HEADS)
+        atom_config = get_current_atom_config()
+        # Select the dedicated DS32 kernel only for GLM DPA with the expected
+        # sparse MLA layout. PCP-only keeps the existing MLA/PCP path.
+        self.use_ds32 = (
+            atom_config.enable_dp_attention
+            and self.kv_cache_dtype == "fp8"
+            and getattr(mla_modules, "is_sparse", False)
+            and getattr(atom_config.hf_config, "model_type", None) == "glm_moe_dsa"
+            and mla_modules.kv_lora_rank == _DS32_NOPE_DIM
+            and mla_modules.qk_rope_head_dim == _DS32_ROPE_DIM
+        )
+        min_mla_heads = (
+            128
+            if self.use_ds32
+            else _MLA_MIN_HEADS
+        )
+        self.padded_num_heads = max(num_heads, min_mla_heads)
         self.head_repeat_factor = 1
         self.head_pad = 0
         if self.padded_num_heads != num_heads:
@@ -351,6 +442,164 @@ class MLAAttention(nn.Module):
         if self.head_pad > 0:
             return output[:, : (num_heads or self.num_heads), ...].contiguous()
         return output
+
+    def _validate_ds32_caches(
+        self,
+        kv_nope: torch.Tensor,
+        kv_scale: torch.Tensor,
+        kv_rope: torch.Tensor,
+    ) -> None:
+        """Verify the three independent cache buffers match the DS32 ABI."""
+        expected = (
+            (kv_nope, dtypes.fp8, _DS32_NOPE_DIM, "NoPE"),
+            (kv_scale, torch.uint8, _DS32_SCALE_DIM, "scale"),
+            (kv_rope, torch.bfloat16, _DS32_ROPE_DIM, "RoPE"),
+        )
+        for tensor, dtype, width, name in expected:
+            if (
+                tensor is None
+                or tensor.dtype != dtype
+                or tensor.ndim != 2
+                or tensor.shape[1] != width
+                or tensor.stride() != (width, 1)
+            ):
+                raise RuntimeError(
+                    f"DS32 {name} cache must be contiguous [slots, {width}] "
+                    f"{dtype}, got {None if tensor is None else (tensor.shape, tensor.dtype, tensor.stride())}."
+                )
+
+    def _ds32_quantize_nope(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Quantize a 512-wide MLA latent to MXFP8 with per-1x32 E8M0 scales."""
+        shape = x.shape
+        if shape[-1] != _DS32_NOPE_DIM:
+            raise RuntimeError(f"DS32 NoPE dimension must be 512, got {shape[-1]}.")
+        x_fp8, scale = get_hip_quant(QuantType.per_1x32)(
+            x.reshape(-1, _DS32_NOPE_DIM),
+            quant_dtype=dtypes.fp8,
+            scale_type=dtypes.fp8_e8m0,
+            shuffle=False,
+        )
+        x_fp8 = x_fp8.view(*shape)
+        scale = scale.view(torch.uint8).view(*shape[:-1], _DS32_SCALE_DIM)
+        return x_fp8, scale
+
+    def _write_ds32_kv_cache(
+        self,
+        k_nope: torch.Tensor,
+        k_rope: torch.Tensor,
+        kv_nope: torch.Tensor,
+        kv_scale: torch.Tensor,
+        kv_rope: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        """Quantize and store new KV entries in the three DS32 cache buffers."""
+        self._validate_ds32_caches(kv_nope, kv_scale, kv_rope)
+        k_nope_fp8, k_scale = self._ds32_quantize_nope(
+            k_nope.reshape(-1, _DS32_NOPE_DIM)
+        )
+        _ds32_store_kv(
+            k_nope_fp8,
+            k_scale,
+            k_rope.reshape(-1, _DS32_ROPE_DIM).to(torch.bfloat16),
+            kv_nope,
+            kv_scale,
+            kv_rope,
+            slot_mapping,
+        )
+
+    def _forward_ds32(
+        self,
+        q_nope: torch.Tensor,
+        q_rope: torch.Tensor,
+        q_scale: torch.Tensor,
+        kv_nope: torch.Tensor,
+        kv_scale: torch.Tensor,
+        kv_rope: torch.Tensor,
+        attn_metadata: AttentionMetaData,
+        *,
+        is_prefill: bool,
+    ) -> torch.Tensor:
+        """Run DS32 sparse MLA with mode-specific persistent work metadata."""
+        # This path requires sparse top-k KV indices and currently supports
+        # single-token decode only; multi-token decode is the MTP case.
+        if not self.is_sparse_mla:
+            raise RuntimeError("DS32 is only used by sparse MLA.")
+        if not is_prefill and attn_metadata.max_seqlen_q > 1:
+            raise RuntimeError("DS32 MTP verification is not enabled in phase 1.")
+
+        # Adapt GLM's query-head count to the DS32 kernel contract. Apply the
+        # same transformation to values and their corresponding block scales.
+        num_heads_q = q_nope.shape[1]
+        q_nope = self._pad_query_heads(q_nope)
+        q_rope = self._pad_query_heads(q_rope).to(torch.bfloat16)
+        q_scale = self._pad_query_heads(q_scale)
+        self._validate_ds32_caches(kv_nope, kv_scale, kv_rope)
+
+        # Prefill and decode use different query indptr and persistent
+        # work/reduction metadata, while sharing sparse KV page metadata.
+        if is_prefill:
+            qo_indptr = attn_metadata.sparse_cu_seqlens_q
+            kv_indptr = attn_metadata.sparse_kv_indptr
+            kv_indices = self.sparse_kv_indices_buffer
+            kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens
+            work_meta_data = attn_metadata.sparse_prefill_work_meta_data
+            work_indptr = attn_metadata.sparse_prefill_work_indptr
+            work_info_set = attn_metadata.sparse_prefill_work_info_set
+            reduce_indptr = attn_metadata.sparse_prefill_reduce_indptr
+            reduce_final_map = attn_metadata.sparse_prefill_reduce_final_map
+            reduce_partial_map = attn_metadata.sparse_prefill_reduce_partial_map
+        else:
+            qo_indptr = attn_metadata.cu_seqlens_q
+            kv_indptr = attn_metadata.sparse_kv_indptr
+            kv_indices = self.sparse_kv_indices_buffer
+            kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens
+            work_meta_data = attn_metadata.work_meta_data
+            work_indptr = attn_metadata.work_indptr
+            work_info_set = attn_metadata.work_info_set
+            reduce_indptr = attn_metadata.reduce_indptr
+            reduce_final_map = attn_metadata.reduce_final_map
+            reduce_partial_map = attn_metadata.reduce_partial_map
+
+        if kv_indices is None:
+            raise RuntimeError("DS32 sparse KV indices are not bound.")
+
+        # The kernel returns one 512-wide compressed value latent per query
+        # head; V-up and output projections are applied after head restoration.
+        output = torch.empty(
+            q_nope.shape[0],
+            q_nope.shape[1],
+            _DS32_NOPE_DIM,
+            dtype=torch.bfloat16,
+            device=q_nope.device,
+        )
+        mla_decode_fwd_ds32(
+            q_nope,
+            q_rope,
+            kv_nope,
+            kv_rope,
+            output,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_lens,
+            1,
+            page_size=1,
+            nhead_kv=1,
+            sm_scale=self.scale,
+            num_kv_splits=16,
+            work_meta_data=work_meta_data,
+            work_indptr=work_indptr,
+            work_info_set=work_info_set,
+            reduce_indptr=reduce_indptr,
+            reduce_final_map=reduce_final_map,
+            reduce_partial_map=reduce_partial_map,
+            q_scale=q_scale,
+            kv_scale=kv_scale,
+        )
+        output = self._restore_query_heads(output, num_heads_q)
+        return self._v_up_proj_and_o_proj(output)
 
     def _seg_kv_cache_view(self, kv_cache: torch.Tensor) -> torch.Tensor:
         """Reshape the KV cache buffer into the page-level flat seg layout
@@ -1418,7 +1667,10 @@ class MLAAttention(nn.Module):
             output = torch.empty(output_shape, dtype=output_dtype, device=q.device)
             return output
         kv_cache_data = forward_context.kv_cache_data
-        kv_cache = kv_cache_data[f"layer_{self.layer_num}"].k_cache
+        layer_cache = kv_cache_data[f"layer_{self.layer_num}"]
+        kv_cache = layer_cache.k_cache
+        ds32_kv_scale = layer_cache.k_scale if self.use_ds32 else None
+        ds32_kv_rope = layer_cache.v_cache if self.use_ds32 else None
 
         if context.is_prefill and not use_prefill_mla:
             prefill_q = self.q_proj(q, x_scale=q_scale).view(
@@ -1428,7 +1680,18 @@ class MLAAttention(nn.Module):
             self.rotary_emb(positions, prefill_q_pe, k_rope)
 
             if kv_cache.numel() > 0:
-                if envs.ATOM_USE_TRITON_MLA and envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV:
+                if self.use_ds32:
+                    # DS32 stores the compressed NoPE latent, its E8M0 block
+                    # scales, and the RoPE component in independent buffers.
+                    self._write_ds32_kv_cache(
+                        k_nope,
+                        k_rope,
+                        kv_cache,
+                        ds32_kv_scale,
+                        ds32_kv_rope,
+                        attn_metadata.slot_mapping,
+                    )
+                elif envs.ATOM_USE_TRITON_MLA and envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV:
                     shuffled_cache = self._shuffled_kv_view(kv_cache)
                     triton_cat_and_cache_mla(
                         k_nope.view(-1, self.num_kv_heads, self.kv_lora_rank),
@@ -1484,6 +1747,35 @@ class MLAAttention(nn.Module):
                 )
         else:
             q_nope, q_rope = self._q_proj_and_k_up_proj(q, x_scale=q_scale)
+
+            if self.use_ds32:
+                # DS32 flow:
+                # - Apply RoPE and quantize the 512-wide query latent.
+                # - Write NoPE, scale, and RoPE to independent KV caches.
+                # - Run sparse attention, then V-up and output projection.
+                self.rotary_emb(positions, q_rope, k_rope)
+                q_nope_fp8, q_nope_scale = self._ds32_quantize_nope(q_nope)
+
+                if kv_cache.numel() > 0:
+                    self._write_ds32_kv_cache(
+                        k_nope,
+                        k_rope,
+                        kv_cache,
+                        ds32_kv_scale,
+                        ds32_kv_rope,
+                        attn_metadata.slot_mapping,
+                    )
+
+                return self._forward_ds32(
+                    q_nope_fp8,
+                    q_rope,
+                    q_nope_scale,
+                    kv_cache,
+                    ds32_kv_scale,
+                    ds32_kv_rope,
+                    attn_metadata,
+                    is_prefill=context.is_prefill,
+                )
 
             # ---- Prefill Context Parallel --------------------------------
             # q is this rank's 1/pcp queries, so q_out is naturally 1/pcp. But

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -29,7 +29,11 @@ from atom.distributed.pcp_utils import (
     pcp_round_robin_query_indices,
 )
 from atom.model_engine.scheduler import ScheduledBatch
-from atom.model_ops.attention_mla import _MLA_MIN_HEADS, MLAAttention
+from atom.model_ops.attention_mla import (
+    _DS32_CACHE_BYTES,
+    _MLA_MIN_HEADS,
+    MLAAttention,
+)
 from atom.utils import CpuGpuBuffer, envs
 from atom.utils.block_convert import (
     kv_indices_generate_triton,
@@ -158,11 +162,26 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         config = model_runner.config
         hf_config = config.hf_config
         # `self.num_attention_heads` set by CommonAttentionBuilder.__init__.
-        self.padded_num_attention_heads = max(self.num_attention_heads, _MLA_MIN_HEADS)
         self.is_sparse = model_runner.is_deepseek_v32
         self.index_topk = hf_config.index_topk if self.is_sparse else -1
         self.dtype_kv = dtypes.d_dtypes[config.kv_cache_dtype]
         self.dtype_q = self.dtype_kv
+        # Keep cache allocation and metadata in sync with MLAAttention:
+        # DS32 is DPA-specific; PCP-only retains the legacy MLA cache layout.
+        self.use_ds32 = (
+            config.enable_dp_attention
+            and self.is_sparse
+            and self.dtype_kv == dtypes.fp8
+            and getattr(hf_config, "model_type", None) == "glm_moe_dsa"
+            and getattr(hf_config, "kv_lora_rank", None) == 512
+            and getattr(hf_config, "qk_rope_head_dim", None) == 64
+        )
+        min_mla_heads = (
+            128
+            if self.use_ds32
+            else _MLA_MIN_HEADS
+        )
+        self.padded_num_attention_heads = max(self.num_attention_heads, min_mla_heads)
 
         self.dcp_world_size = get_dcp_world_size()
         self.dcp_rank = get_dcp_rank()
@@ -815,7 +834,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         total_num_layers = runner._get_total_num_layers()
         kv_dtype_size = dtypes.d_dtypes[config.kv_cache_dtype].itemsize
 
-        block_bytes = total_num_layers * runner.block_size * 576 * kv_dtype_size
+        kv_entry_bytes = _DS32_CACHE_BYTES if self.use_ds32 else 576 * kv_dtype_size
+        block_bytes = total_num_layers * runner.block_size * kv_entry_bytes
         if runner.is_deepseek_v32:
             index_dim = hf_config.index_head_dim + 4
             aligned_index_dim = ((index_dim + 15) // 16) * 16
@@ -841,16 +861,34 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         config = runner.config
         hf_config = config.hf_config
         total_num_layers = runner._get_total_num_layers()
-        out: dict = {
-            "kv_cache": torch.zeros(
+        if self.use_ds32:
+            cache_prefix = (
                 total_num_layers,
                 runner.num_physical_kvcache_blocks,
                 runner.physical_block_size,
-                576,
-                dtype=dtypes.d_dtypes[config.kv_cache_dtype],
-                device="cuda",
-            ),
-        }
+            )
+            out: dict = {
+                "kv_cache": torch.zeros(
+                    *cache_prefix, 512, dtype=dtypes.fp8, device="cuda"
+                ),
+                "kv_scale_cache": torch.zeros(
+                    *cache_prefix, 16, dtype=torch.uint8, device="cuda"
+                ),
+                "kv_rope_cache": torch.zeros(
+                    *cache_prefix, 64, dtype=torch.bfloat16, device="cuda"
+                ),
+            }
+        else:
+            out = {
+                "kv_cache": torch.zeros(
+                    total_num_layers,
+                    runner.num_physical_kvcache_blocks,
+                    runner.physical_block_size,
+                    576,
+                    dtype=dtypes.d_dtypes[config.kv_cache_dtype],
+                    device="cuda",
+                ),
+            }
         if runner.is_deepseek_v32:
             # Align last dimension to 16 bytes for fp8 (1 byte per element)
             # to avoid unaligned memory access in torch inductor.
@@ -887,11 +925,17 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             return None
 
         runner = self.model_runner
-        kv_cache = runner.kv_cache[layer_id].view(
-            runner.num_physical_kvcache_blocks * runner.physical_block_size,
-            1,
-            576,
+        num_slots = (
+            runner.num_physical_kvcache_blocks * runner.physical_block_size
         )
+        if self.use_ds32:
+            kv_cache = runner.kv_cache[layer_id].view(num_slots, 512)
+            kv_scale = runner.kv_scale_cache[layer_id].view(num_slots, 16)
+            kv_rope = runner.kv_rope_cache[layer_id].view(num_slots, 64)
+        else:
+            kv_cache = runner.kv_cache[layer_id].view(num_slots, 1, 576)
+            kv_scale = None
+            kv_rope = None
         module.max_model_len = runner.config.max_model_len
         if runner.is_deepseek_v32 and module.indexer is not None:
             # Use aligned dimension to avoid memory copy in torch inductor
@@ -904,8 +948,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         return KVCacheTensor(
             layer_num=layer_id,
             k_cache=kv_cache,
-            v_cache=None,
-            k_scale=None,
+            v_cache=kv_rope,
+            k_scale=kv_scale,
             v_scale=None,
         )
 
@@ -931,6 +975,20 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                     unit_bytes=bpb,
                 )
             )
+
+        if self.use_ds32:
+            for cache_name in ("kv_scale_cache", "kv_rope_cache"):
+                cache = getattr(runner, cache_name)
+                for layer_id in range(cache.shape[0]):
+                    t = cache[layer_id]
+                    bpb = t.stride(0) * t.element_size() * self.block_ratio
+                    block_regions.append(
+                        KVTransferRegion(
+                            base_addr=t.data_ptr(),
+                            total_bytes=t.numel() * t.element_size(),
+                            unit_bytes=bpb,
+                        )
+                    )
 
         if hasattr(runner, "index_cache"):
             for layer_id in range(runner.index_cache.shape[0]):

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -176,11 +176,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             and getattr(hf_config, "kv_lora_rank", None) == 512
             and getattr(hf_config, "qk_rope_head_dim", None) == 64
         )
-        min_mla_heads = (
-            128
-            if self.use_ds32
-            else _MLA_MIN_HEADS
-        )
+        min_mla_heads = 128 if self.use_ds32 else _MLA_MIN_HEADS
         self.padded_num_attention_heads = max(self.num_attention_heads, min_mla_heads)
 
         self.dcp_world_size = get_dcp_world_size()
@@ -925,9 +921,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             return None
 
         runner = self.model_runner
-        num_slots = (
-            runner.num_physical_kvcache_blocks * runner.physical_block_size
-        )
+        num_slots = runner.num_physical_kvcache_blocks * runner.physical_block_size
         if self.use_ds32:
             kv_cache = runner.kv_cache[layer_id].view(num_slots, 512)
             kv_scale = runner.kv_scale_cache[layer_id].view(num_slots, 16)

--- a/recipes/GLM-5.md
+++ b/recipes/GLM-5.md
@@ -6,12 +6,12 @@
 
 Here is the support matrix for GLM-5.2 across different hardware platforms:
 
-| Hardware | Data Type | Model | Parallelism | MTP Support | Recipe Section |
-| --- | --- | --- | --- | --- | --- |
-| MI355 | FP4 | [amd/GLM-5.2-MXFP4](https://huggingface.co/amd/GLM-5.2-MXFP4) | TP4 | ✅ | [MI355 FP4](#mi355-fp4) |
-| MI355 | FP8 | [zai-org/GLM-5.2-FP8](https://huggingface.co/zai-org/GLM-5.2-FP8) | TP4 | ✅ | [MI355 FP8](#mi355-fp8) |
-| MI300X | FP8 | [zai-org/GLM-5.2-FP8](https://huggingface.co/zai-org/GLM-5.2-FP8) | TP8 | ✅ | [MI300X / MI308X FP8](#mi300x-mi308x-fp8) |
-| MI308X | FP8 | [zai-org/GLM-5.2-FP8](https://huggingface.co/zai-org/GLM-5.2-FP8) | TP8 | ✅ | [MI300X / MI308X FP8](#mi300x-mi308x-fp8) |
+| Hardware | Data Type | Model | Parallelism | MTP Support | DPA Support | Recipe Section |
+| --- | --- | --- | --- | --- | --- | --- |
+| MI355 | FP4 | [amd/GLM-5.2-MXFP4](https://huggingface.co/amd/GLM-5.2-MXFP4) | TP4 | ✅ | ✅ TP4/TP8 | [MI355 FP4](#mi355-fp4) |
+| MI355 | FP8 | [zai-org/GLM-5.2-FP8](https://huggingface.co/zai-org/GLM-5.2-FP8) | TP4 | ✅ | ⚠️ Not validated | [MI355 FP8](#mi355-fp8) |
+| MI300X | FP8 | [zai-org/GLM-5.2-FP8](https://huggingface.co/zai-org/GLM-5.2-FP8) | TP8 | ✅ | ❌ | [MI300X / MI308X FP8](#mi300x-mi308x-fp8) |
+| MI308X | FP8 | [zai-org/GLM-5.2-FP8](https://huggingface.co/zai-org/GLM-5.2-FP8) | TP8 | ✅ | ❌ | [MI300X / MI308X FP8](#mi300x-mi308x-fp8) |
 
 ## Preparing environment
 Pull the latest docker from https://hub.docker.com/r/rocm/atom-dev/ :
@@ -45,6 +45,50 @@ python -m atom.entrypoints.openai_server \
   --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "*.mlp.gate", "*expert*"]}' \
   -tp $TP 2>&1 | tee server.log &
 ```
+
+#### GLM-5.2 MXFP4 with DPA
+
+The native ATOM backend supports GLM-5.2 MXFP4 with Data Parallel Attention (DPA) and an FP8 KV cache on MI355/gfx950.
+
+Use `-tp 4` or `-tp 8` for the validated TP4 and TP8 configurations:
+
+```bash
+MODEL_PATH=amd/GLM-5.2-MXFP4
+
+python3 -m atom.entrypoints.openai_server \
+  --model ${MODEL_PATH} \
+  --host 0.0.0.0 \
+  --trust-remote-code \
+  --kv_cache_dtype fp8 \
+  --block-size 16 \
+  --gpu-memory-utilization 0.9 \
+  --online_quant_config \
+    '{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate","*expert*"]}' \
+  --server-port 8010 \
+  -tp <4-or-8> \
+  --max-num-seqs 512 \
+  --enable-dp-attention \
+  --attn-prefill-chunk-size 131072 \
+  --long-prefill-token-threshold 131072
+```
+
+The full 1319-sample GSM8K 20-shot evaluation with 65 concurrent requests produced the following results:
+
+TP4 + DPA:
+
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9265|±  |0.0072|
+|     |       |strict-match    |    20|exact_match|↑  |0.9280|±  |0.0071|
+
+TP8 + DPA:
+
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9340|±  |0.0068|
+|     |       |strict-match    |    20|exact_match|↑  |0.9363|±  |0.0067|
+
+DPA cannot currently be combined with PCP. PCP-only continues to use the existing MLA/PCP path.
 
 #### GLM-5.2 MXFP4 MTP Server
 


### PR DESCRIPTION
# GLM-5.2-MXFP4 DPA Support

## Summary

This change enables `amd/GLM-5.2-MXFP4` to run with Data Parallel Attention (DPA), FP8 KV cache, and GLM-5.2 IndexShare on MI355/gfx950.

The implementation is DPA-specific. PCP-only retains the existing MLA/PCP path, and no generic TBO code is changed.

## Background

### 1. Legacy non-persistent decode does not support this GLM shape

ATOM's existing MLA decode disables persistent mode under DPA and falls back to non-persistent decode:

```python
dp_size = get_dp_group().world_size
use_persistent_mode = not (dp_size > 1) and not return_lse
```

GLM-5.2 absorbed MLA uses one 512-dim KV latent head. Its 64 Q heads map to GQA ratio 64 at kernel level. AITER's non-persistent kernel does not support this FP8 Q/FP8 KV combination, so CUDA Graph capture aborts at `bs=512, max_q_len=1`.

The original `mla_decode_fwd` kernel uses merged 576-dim Q/KV tensors and legacy scales. It cannot directly consume the required DS32 runtime format: 512-dim MXFP8 latent NoPE, 64-dim BF16 RoPE, per-1x32 E8M0 scales, and three independent contiguous NoPE/scale/RoPE buffers. Forcing persistent mode alone does not add these kernel capabilities. Using `mla_decode_fwd_ds32` from [AITER PR #4430](https://github.com/ROCm/aiter/pull/4430) is therefore the smallest and lowest-risk ATOM-side adaptation.

#### KV-cache layout comparison

Both kernels represent the same logical 576-dimensional MLA key (`512-dim NoPE + 64-dim RoPE`), but their physical cache ABIs are different.

`mla_decode_fwd` uses one packed FP8 tensor. NoPE and RoPE for each token are adjacent, and the next token starts 576 bytes later:

```text
kv_cache: FP8 [num_layers, num_slots, 1, 576]

                     one 576-byte row                         row stride
             ┌───────────────────────────────┐
slot 0  ───► │ NoPE: 512 × FP8 │ RoPE: 64 × FP8 │ ──────────── 576 B
             ├─────────────────┼───────────────┤
slot 1  ───► │ NoPE: 512 × FP8 │ RoPE: 64 × FP8 │
             ├─────────────────┼───────────────┤
slot 2  ───► │ NoPE: 512 × FP8 │ RoPE: 64 × FP8 │
             └─────────────────┴───────────────┘

                         mla_decode_fwd
                                ▲
                                │ one merged KV pointer
                                │ + legacy Q/KV scales
```

`mla_decode_fwd_ds32` uses three physically independent contiguous tensors. It quantizes only NoPE to MXFP8, stores one E8M0 scale per 32 NoPE elements, and keeps RoPE in BF16:

```text
NoPE cache: FP8 [num_layers, num_slots, 512]       stride = 512 B
             ┌──────────────────────────────────┐
slot 0  ───► │ NoPE[0:512]                     │
slot 1  ───► │ NoPE[0:512]                     │
slot 2  ───► │ NoPE[0:512]                     │
             └──────────────────────────────────┘
                              │
Scale cache: uint8 [num_layers, num_slots, 16]    stride = 16 B
             ┌──────────────────────────────────┐
slot 0  ───► │ E8M0 scale[0:16]                │  512 / 32 = 16 scales
slot 1  ───► │ E8M0 scale[0:16]                │
slot 2  ───► │ E8M0 scale[0:16]                │
             └──────────────────────────────────┘
                              │
RoPE cache: BF16 [num_layers, num_slots, 64]      stride = 128 B
             ┌──────────────────────────────────┐
slot 0  ───► │ RoPE[0:64]                      │
slot 1  ───► │ RoPE[0:64]                      │
slot 2  ───► │ RoPE[0:64]                      │
             └──────────────────────────────────┘
                              │
                              ▼ three independent base pointers
                    mla_decode_fwd_ds32

Per-token storage: 512 B + 16 B + (64 × 2 B) = 656 B
```

The difference is therefore not the logical attention width, which remains 576, but the physical dtype, quantization metadata, base pointers, and row strides expected by each kernel.

### 2. Packed 656-byte cache silently corrupted decode

An intermediate implementation used an array-of-structures layout by packing all three regions for each token into one 656-byte row:

```text
one backing allocation:

             ┌───────────── 656-byte token row ─────────────┐
slot 0  ───► │ NoPE 512 B │ scale 16 B │ RoPE 128 B        │
slot 1  ───► │ NoPE 512 B │ scale 16 B │ RoPE 128 B        │
slot 2  ───► │ NoPE 512 B │ scale 16 B │ RoPE 128 B        │
             └───────────────────────────────────────────────┘

logical views into that allocation:

NoPE view:  slot 0 NoPE ──────── 656 B ────────► slot 1 NoPE
scale view: slot 0 scale ─────── 656 B ────────► slot 1 scale
RoPE view:  slot 0 RoPE ──────── 656 B ────────► slot 1 RoPE
```

Three logical views were created from this backing buffer. Their actual row strides were not contiguous:

```text
NoPE row stride = 656 bytes
scale row stride = 656 bytes
RoPE row stride = 656 bytes
```

The DS32 C++ kernel hardcodes contiguous strides:

```text
NoPE stride = 512 FP8 elements
scale stride = 16 bytes
RoPE stride = 64 BF16 elements
```

The logical views therefore did not satisfy the kernel ABI. Reads became incorrect from the second token onward, often producing one plausible token followed by EOS and `exact_match=0` without an immediate GPU fault. The fix is to allocate three physically independent contiguous tensors.

## Implementation

[AITER PR #4430](https://github.com/ROCm/aiter/pull/4430) adds the MI350 DS32 Opus persistent MLA path for `nhead * qseqlen = 128`. It provides the split NoPE/RoPE interface, MXFP8/E8M0 scale handling, persistent work metadata, and stage-1 plus reduce-v1 execution needed by this GLM-5.2 case.

ATOM integrates it in two files:

- `atom/model_ops/attention_mla.py`
  - Selects DS32 only for DPA-enabled GLM sparse MLA with FP8 KV and the expected 512/64 latent dimensions.
  - Quantizes Q/KV NoPE with MXFP8 per-1x32 E8M0 scales.
  - Stores NoPE, scale, and RoPE in independent contiguous buffers.
  - Repeats GLM's 64 Q heads to the kernel's 128-head contract, restores 64 heads after attention, then runs V-up and output projection.
  - Dispatches sparse prefill/decode directly to `mla_decode_fwd_ds32`.
- `atom/model_ops/attentions/aiter_mla.py`
  - Builds DS32 persistent work/reduction metadata for 128 heads.
  - Allocates and accounts for the three DS32 cache buffers.
  - Registers all three buffers for KV transfer.

The DS32 gate requires DPA, so PCP-only keeps the original MLA/PCP behavior. The legacy `use_persistent_mode` condition and generic TBO code are unchanged.

## Accuracy Evaluation

Common configuration:

```text
Model:       /mnt/models/GLM-5.2-MXFP4
Hardware:    MI355 / gfx950
KV cache:    FP8
Benchmark:   GSM8K, full 1319 samples
Few-shot:    20
Concurrency: 65
Sampling:    greedy
```

### Server command

Use `-tp 4` and `-tp 8` for the two configurations:

```bash
python3 -m atom.entrypoints.openai_server \
  --model /mnt/models/GLM-5.2-MXFP4 \
  --host 0.0.0.0 \
  --trust-remote-code \
  --kv_cache_dtype fp8 \
  --block-size 16 \
  --gpu-memory-utilization 0.9 \
  --online_quant_config \
    '{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate","*expert*"]}' \
  --server-port 8010 \
  -tp <4-or-8> \
  --max-num-seqs 512 \
  --enable-dp-attention \
  --attn-prefill-chunk-size 131072 \
  --long-prefill-token-threshold 131072
```

### lm-eval command

```bash
lm_eval \
  --model local-completions \
  --model_args \
    model=/mnt/models/GLM-5.2-MXFP4,base_url=http://localhost:8010/v1/completions,num_concurrent=65,max_retries=3,tokenized_requests=False,trust_remote_code=True \
  --tasks gsm8k \
  --num_fewshot 20
```

### DPA + TP4

```text
local-completions ({'model': '/mnt/models/GLM-5.2-MXFP4', 'base_url': 'http://localhost:8010/v1/completions', 'num_concurrent': 65, 'max_retries': 3, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 20, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9265|±  |0.0072|
|     |       |strict-match    |    20|exact_match|↑  |0.9280|±  |0.0071|
```

### DPA + TP8

```text
local-completions ({'model': '/mnt/models/GLM-5.2-MXFP4', 'base_url': 'http://localhost:8010/v1/completions', 'num_concurrent': 65, 'max_retries': 3, 'tokenized_requests': False}), gen_kwargs: ({}), limit: None, num_fewshot: 20, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9340|±  |0.0068|
|     |       |strict-match    |    20|exact_match|↑  |0.9363|±  |0.0067|
```

