### PR TITLE
fix(engine): offline output thread dies on the first streamed token

### DIFF
--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -373,26 +373,13 @@ jobs:
           MODEL_PROGRESS_INTERVAL: "60"
 
       - name: Run ATOM simple inference
-        # Completing is the assertion -- the output is printed for eyeballing
-        # but not diffed, so this needs no per-model golden file.
-        #
-        # Not redundant with the accuracy test below: that one drives the
-        # server over HTTP, while this is the offline entrypoint, and the two
-        # do not share the path that hands tokens back to the caller. A bug
-        # that killed the offline output thread reached main precisely because
-        # nothing on the PR gate ran this; the nightly Docker smoke test caught
-        # it a day later, as a 60-minute timeout.
-        #
-        # Model download is a separate step, so this is load plus a handful of
-        # prompts. The timeout is what turns the hang it guards against into a
-        # failure rather than a stuck runner.
+        # Skip simple inference; accuracy test already validates correctness
+        if: false
         timeout-minutes: 30
-        env:
-          MODEL_EXTRA_ARGS: ${{ matrix.extraArgs }}
         run: |
           # Run the inference and capture output
           set -euo pipefail
-
+          
           echo ""
           echo "========== Running test =========="
 
@@ -410,22 +397,34 @@ jobs:
           rocm-smi --showpids
           docker ps -a
           echo "========= End runner debug logs ==============="
-          # Pipe via stdin so container bash parses the shell quoting in
-          # extraArgs, exactly as the accuracy step below does. Interpolating
-          # it into a double-quoted `bash -lc "…"` instead lets the *host*
-          # shell strip the inner quotes first, so single-quoted JSON such as
-          # --hf-overrides '{"use_index_cache": true}' arrives as
-          # '{use_index_cache: true}' and argparse rejects it. Four of the
-          # PR-level models carry JSON in extraArgs.
-          echo "python3 -m atom.examples.simple_inference \
-            --model $model_path $MODEL_EXTRA_ARGS --temperature 0" \
-            | docker exec -i "$CONTAINER_NAME" bash -l \
-            | grep -E '^Prompt: |^Completion:' > atom_test_output.txt
-
+          docker exec "$CONTAINER_NAME" bash -lc "
+            set -euo pipefail
+            python3 -m atom.examples.simple_inference \
+              --model \"$model_path\" \
+              ${{ matrix.extraArgs }} \
+              --temperature 0 \
+            | grep -E '^Prompt: |^Completion:'
+          " > atom_test_output.txt
+          
           echo ""
           echo "========== Showing test output below =========="
           cat atom_test_output.txt
 
+      - name: Compare output with golden outputs
+        if: false
+        timeout-minutes: 30
+        # TODO: skip for all test until it's fixed
+        run: |
+          echo "========== Comparing output with golden outputs =========="
+          if ! diff -u -B -w --strip-trailing-cr \
+            atom_test_output.txt \
+            ".github/workflows/golden_outputs/${{ matrix.model_name }}_golden_output.txt"; then
+            echo "Failed: Output does not match golden outputs."
+            exit 1
+          else
+            echo "Success: Output matches golden outputs."
+          fi
+      
       - name: Run ATOM accuracy test
         timeout-minutes: 30
         env:

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -226,7 +226,10 @@ jobs:
           fi
 
       - name: Run offline inference
-        timeout-minutes: 30
+        # An 8B model loads and answers a handful of prompts in a couple of
+        # minutes. This bound is the guard: the failure it exists to catch is a
+        # hang, and a hang should cost minutes rather than most of an hour.
+        timeout-minutes: 15
         run: |
           set -euo pipefail
           if [ -d "/models" ]; then

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -163,6 +163,92 @@ jobs:
               print(f"  {enabled} {m['model_name']:<43} {m.get('test_level','?'):<10} {m['runner']}")
           PY
 
+  offline-smoke-test:
+    # Ungated on purpose: this runs on every PR, unlike the accuracy matrix
+    # behind `ci-gate`, which only opens on an approval or a ci:* label.
+    #
+    # It guards the path the nightly Docker release smoke-tests after it builds
+    # the image -- the offline entrypoint. The accuracy job is not a substitute:
+    # it drives the server over HTTP, and the two do not share the code that
+    # hands tokens back to the caller. A bug that killed the offline output
+    # thread reached main and showed up a day later, as a 60-minute timeout in
+    # the nightly.
+    #
+    # Completing is the assertion. The failure it exists to catch is a hang or
+    # a crash, not wrong text, so there is no golden file to keep per model --
+    # and one small model exercises that code path as well as thirteen do.
+    name: Offline inference smoke test
+    runs-on: linux-atom-mi35x-1
+    timeout-minutes: 45
+    env:
+      CONTAINER_NAME: atom_smoke_test
+      SMOKE_MODEL: meta-llama/Meta-Llama-3-8B-Instruct
+      # Matches this model's entry in models_accuracy.json.
+      SMOKE_EXTRA_ARGS: --kv_cache_dtype fp8 --gpu-memory-utilization 0.3
+    steps:
+      - name: Kill stale containers
+        run: |
+          docker ps -aq -f "name=${CONTAINER_NAME}" | xargs -r docker rm -f || true
+
+      - name: Checkout ATOM repo
+        uses: actions/checkout@v6
+
+      - name: Docker Login
+        uses: ./.github/actions/docker-auth
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Start CI container
+        uses: ./.github/actions/setup-gpu-container
+        with:
+          container-name: ${{ env.CONTAINER_NAME }}
+          base-image: ${{ env.ATOM_BASE_IMAGE }}
+          runner: linux-atom-mi35x-1
+          hf-token: ${{ secrets.AMD_HF_TOKEN }}
+          network-host: "true"
+
+      - name: Download model
+        timeout-minutes: 30
+        env:
+          HF_TOKEN: ${{ secrets.AMD_HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -d "/models" ]; then
+            docker exec \
+              -e HF_TOKEN="${HF_TOKEN:-}" \
+              -e MODEL_ID="${SMOKE_MODEL}" \
+              -e TARGET_DIR="/models/${SMOKE_MODEL}" \
+              "$CONTAINER_NAME" \
+              bash -lc 'bash /workspace/.github/scripts/download_model_with_lock.sh "$MODEL_ID" "$TARGET_DIR"'
+          else
+            echo "No /models mount; simple_inference will fetch from the hub."
+          fi
+
+      - name: Run offline inference
+        timeout-minutes: 30
+        run: |
+          set -euo pipefail
+          if [ -d "/models" ]; then
+            model_path="/models/${SMOKE_MODEL}"
+          else
+            model_path="${SMOKE_MODEL}"
+          fi
+          echo "Model path: $model_path"
+          # Piped over stdin so the container's shell parses any quoting in the
+          # extra args itself; interpolating them into `bash -lc "..."` lets the
+          # host shell strip inner quotes first.
+          echo "python3 -m atom.examples.simple_inference \
+            --model $model_path $SMOKE_EXTRA_ARGS --temperature 0" \
+            | docker exec -i "$CONTAINER_NAME" bash -l | tee smoke_output.txt
+          grep -qE '^(Prompt|Completion):' smoke_output.txt \
+            || { echo "::error::simple_inference produced no completions"; exit 1; }
+
+      - name: Clean Up
+        if: always()
+        run: |
+          docker ps -aq -f "name=${CONTAINER_NAME}" | xargs -r docker rm -f || true
+
   atom-test:
     needs: [ci-gate, download_aiter_wheel, load-test-models]
     name: Accuracy

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -387,10 +387,12 @@ jobs:
         # prompts. The timeout is what turns the hang it guards against into a
         # failure rather than a stuck runner.
         timeout-minutes: 30
+        env:
+          MODEL_EXTRA_ARGS: ${{ matrix.extraArgs }}
         run: |
           # Run the inference and capture output
           set -euo pipefail
-          
+
           echo ""
           echo "========== Running test =========="
 
@@ -408,15 +410,18 @@ jobs:
           rocm-smi --showpids
           docker ps -a
           echo "========= End runner debug logs ==============="
-          docker exec "$CONTAINER_NAME" bash -lc "
-            set -euo pipefail
-            python3 -m atom.examples.simple_inference \
-              --model \"$model_path\" \
-              ${{ matrix.extraArgs }} \
-              --temperature 0 \
-            | grep -E '^Prompt: |^Completion:'
-          " > atom_test_output.txt
-          
+          # Pipe via stdin so container bash parses the shell quoting in
+          # extraArgs, exactly as the accuracy step below does. Interpolating
+          # it into a double-quoted `bash -lc "…"` instead lets the *host*
+          # shell strip the inner quotes first, so single-quoted JSON such as
+          # --hf-overrides '{"use_index_cache": true}' arrives as
+          # '{use_index_cache: true}' and argparse rejects it. Four of the
+          # PR-level models carry JSON in extraArgs.
+          echo "python3 -m atom.examples.simple_inference \
+            --model $model_path $MODEL_EXTRA_ARGS --temperature 0" \
+            | docker exec -i "$CONTAINER_NAME" bash -l \
+            | grep -E '^Prompt: |^Completion:' > atom_test_output.txt
+
           echo ""
           echo "========== Showing test output below =========="
           cat atom_test_output.txt

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -373,8 +373,19 @@ jobs:
           MODEL_PROGRESS_INTERVAL: "60"
 
       - name: Run ATOM simple inference
-        # Skip simple inference; accuracy test already validates correctness
-        if: false
+        # Completing is the assertion -- the output is printed for eyeballing
+        # but not diffed, so this needs no per-model golden file.
+        #
+        # Not redundant with the accuracy test below: that one drives the
+        # server over HTTP, while this is the offline entrypoint, and the two
+        # do not share the path that hands tokens back to the caller. A bug
+        # that killed the offline output thread reached main precisely because
+        # nothing on the PR gate ran this; the nightly Docker smoke test caught
+        # it a day later, as a 60-minute timeout.
+        #
+        # Model download is a separate step, so this is load plus a handful of
+        # prompts. The timeout is what turns the hang it guards against into a
+        # failure rather than a stuck runner.
         timeout-minutes: 30
         run: |
           # Run the inference and capture output
@@ -410,21 +421,6 @@ jobs:
           echo "========== Showing test output below =========="
           cat atom_test_output.txt
 
-      - name: Compare output with golden outputs
-        if: false
-        timeout-minutes: 30
-        # TODO: skip for all test until it's fixed
-        run: |
-          echo "========== Comparing output with golden outputs =========="
-          if ! diff -u -B -w --strip-trailing-cr \
-            atom_test_output.txt \
-            ".github/workflows/golden_outputs/${{ matrix.model_name }}_golden_output.txt"; then
-            echo "Failed: Output does not match golden outputs."
-            exit 1
-          else
-            echo "Success: Output matches golden outputs."
-          fi
-      
       - name: Run ATOM accuracy test
         timeout-minutes: 30
         env:

--- a/atom/__init__.py
+++ b/atom/__init__.py
@@ -1,13 +1,33 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-from atom.model_engine.llm_engine import LLMEngine
-from atom.sampling_params import SamplingParams
-
 from atom.plugin.sglang import prepare_model_for_sglang
+from atom.sampling_params import SamplingParams
 
 __all__ = [
     "LLMEngine",
     "SamplingParams",
     "prepare_model_for_sglang",
 ]
+
+# `LLMEngine` is resolved on first attribute access rather than at import time.
+# Importing it here pulls the whole engine -- zmq sockets, the model runner,
+# AITER kernels -- into *any* `import atom.<anything>`, because Python imports
+# a package before its submodule. `import atom.config` paid for a GPU inference
+# engine to read a dataclass, which is why the test suite hand-stubbed
+# `atom.config` instead of importing it.
+#
+# The two names above stay eager: both cost only dataclasses, logging and
+# typing.
+
+
+def __getattr__(name: str):
+    if name == "LLMEngine":
+        from atom.model_engine.llm_engine import LLMEngine
+
+        return LLMEngine
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/atom/config.py
+++ b/atom/config.py
@@ -9,10 +9,9 @@ import os
 import re
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import torch
-from aiter import QuantType
 from torch.distributed import ProcessGroup, ReduceOp
 from transformers import AutoConfig, GenerationConfig, PretrainedConfig
 
@@ -25,6 +24,11 @@ from atom.quant_spec import (
 )
 from atom.utils import envs, get_open_port
 from atom.utils.distributed.utils import stateless_init_torch_distributed_process_group
+
+if TYPE_CHECKING:
+    # Annotation only. Importing AITER here would put a GPU kernel build behind
+    # `import atom.config`, which is what `atom.quant_spec` defers on purpose.
+    from aiter import QuantType
 
 logger = logging.getLogger("atom")
 
@@ -290,9 +294,7 @@ class QuantizationConfig:
         self.hf_quant_config = getattr(config, "quantization_config", None)
 
         if self.hf_quant_config is None:
-            self.global_spec = LayerQuantConfig(
-                quant_type=QuantType.No, quant_dtype=self.torch_dtype
-            )
+            self.global_spec = LayerQuantConfig.no_quant(self.torch_dtype)
             self.layer_pattern_specs = []
             self.exclude_layers = []
             self.quant_method = ""
@@ -379,7 +381,7 @@ class QuantizationConfig:
     # -- convenience properties (delegate to global_spec) ---------------------
 
     @property
-    def quant_type(self) -> QuantType:
+    def quant_type(self) -> "QuantType":
         return self.global_spec.quant_type
 
     @property

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -35,41 +35,35 @@ DP_LB_DEFAULT = "least_requests"
 
 
 class CoreManager:
-    def __init__(self, config: Config):
-        self.label = "Engine Core Mgr"
+    def _init_shared_state(
+        self, config: Config, *, label: str, local_engine_count: int
+    ) -> None:
+        """Every field the inherited methods touch, before any engine is spawned.
+
+        Subclasses spawn their engines differently and so cannot run this
+        class's ``__init__`` -- but they inherit its output threads, ``close()``
+        and DP-load bookkeeping, all of which read the fields set here. This is
+        the one place to add another such field.
+
+        It exists because the alternative was tried: ``DisaggCoreManager`` used
+        to hand-copy this block, and the copy drifted. ``_flush_stream_batch_fn``
+        was added to the copy and to the API server that assigns it, but not to
+        this class -- so the offline entrypoint, which is the one path that
+        neither initialises nor assigns it, had its output thread die on the
+        first streamed token and hung until CI timed out an hour later.
+        """
+        self.label = label
         self._closed = False  # Track whether already closed
-        pp_size = config.pipeline_parallel_size
-        self.pp_size = pp_size
-        if config.enable_dp_attention:
-            assert pp_size == 1, "Pipeline parallel + DP-attention is not supported yet"
-            self.local_engine_count = (
-                config.tensor_parallel_size * config.parallel_config.data_parallel_size
-            )
-            logger.info(
-                f"Enable dp attention, using {self.local_engine_count} data parallel ranks"
-            )
-            config.parallel_config.data_parallel_size = self.local_engine_count
-            config.tensor_parallel_size = 1
-        else:
-            dp_size = config.parallel_config.data_parallel_size
-            assert not (
-                pp_size > 1 and dp_size > 1
-            ), "Pipeline parallel combined with data parallel is not supported yet."
-            # One EngineCore per (dp_rank, pp_rank) stage.
-            self.local_engine_count = dp_size * pp_size
-        # Inter-stage ZMQ channels (head<->downstream metadata, last->head
-        # tokens), shared across the single dp group. PP+DP would need per-group
-        # sets — deferred with the assertion above.
-        self.pp_meta_addrs = []
-        self.pp_token_addr = ""
-        if pp_size > 1:
-            self.pp_meta_addrs = [get_open_zmq_ipc_path() for _ in range(pp_size)]
-            self.pp_token_addr = get_open_zmq_ipc_path()
+        self.local_engine_count = local_engine_count
         self.ctx = zmq.Context(io_threads=2)
         self.outputs_queue = queue.Queue[list[Sequence]]()
         self.stream_outputs_queue = queue.Queue()
         self.utility_response_queue = queue.Queue()
         self._seq_id_to_callback = {}
+        # Batched stream-flush hook, resolved lazily by the API server (avoids
+        # an api_server <-> engine_core_mgr import cycle). Stays None on every
+        # path that never streams, which the output thread checks for.
+        self._flush_stream_batch_fn = None
         self.engine_core_processes = []
         self.input_sockets = []
         self.output_sockets = []
@@ -83,6 +77,9 @@ class CoreManager:
         self._rank_rotation_cursor = 0
 
         # --- DP request load balancing (see _select_dp_rank_locked) ---
+        # A subclass may fan out through its own add_request() and never charge
+        # load at all, but the inherited output thread still calls
+        # _release_seq_load() on every finished sequence, so these MUST exist.
         # Strategy: "round_robin" | "least_requests" | "least_tokens" (validated
         # at the CLI by argparse choices=DP_LB_STRATEGIES).
         self._dp_lb_strategy = config.dp_load_balance
@@ -94,12 +91,46 @@ class CoreManager:
         # on dispatch, decremented on finish/abort. Guarded by _lb_lock because
         # dispatch runs on the request thread while release runs on the per-rank
         # output threads.
-        self._rank_reqs = [0] * self.local_engine_count
-        self._rank_tokens = [0] * self.local_engine_count
+        self._rank_reqs = [0] * local_engine_count
+        self._rank_tokens = [0] * local_engine_count
         # seq_id -> (dp_rank, req_cost, tok_cost) so release subtracts exactly
         # what dispatch added, and only for ranks that were actually charged.
         self._seq_load = {}
         self._lb_lock = Lock()
+
+    def __init__(self, config: Config):
+        pp_size = config.pipeline_parallel_size
+        self.pp_size = pp_size
+        if config.enable_dp_attention:
+            assert pp_size == 1, "Pipeline parallel + DP-attention is not supported yet"
+            local_engine_count = (
+                config.tensor_parallel_size * config.parallel_config.data_parallel_size
+            )
+            logger.info(
+                f"Enable dp attention, using {local_engine_count} data parallel ranks"
+            )
+            config.parallel_config.data_parallel_size = local_engine_count
+            config.tensor_parallel_size = 1
+        else:
+            dp_size = config.parallel_config.data_parallel_size
+            assert not (
+                pp_size > 1 and dp_size > 1
+            ), "Pipeline parallel combined with data parallel is not supported yet."
+            # One EngineCore per (dp_rank, pp_rank) stage.
+            local_engine_count = dp_size * pp_size
+        # Inter-stage ZMQ channels (head<->downstream metadata, last->head
+        # tokens), shared across the single dp group. PP+DP would need per-group
+        # sets — deferred with the assertion above. Not shared state: only this
+        # class's spawn loop reads them.
+        self.pp_meta_addrs = []
+        self.pp_token_addr = ""
+        if pp_size > 1:
+            self.pp_meta_addrs = [get_open_zmq_ipc_path() for _ in range(pp_size)]
+            self.pp_token_addr = get_open_zmq_ipc_path()
+
+        self._init_shared_state(
+            config, label="Engine Core Mgr", local_engine_count=local_engine_count
+        )
 
         import torch
 
@@ -963,53 +994,15 @@ class DisaggCoreManager(CoreManager):
             },
         )
 
-        # Initialise the base class fields that close() and other methods use,
-        # without calling super().__init__() (which would spawn its own processes).
-        self.label = "DisaggCoreManager"
-        self._closed = False
-        self.local_engine_count = 2  # prefill + decode
-        self.ctx = zmq.Context(io_threads=2)
-        self.outputs_queue = queue.Queue()
-        self.stream_outputs_queue = queue.Queue()
-        self.utility_response_queue = queue.Queue()
-        self._seq_id_to_callback = {}
-        # Batched stream-flush hook, resolved lazily (avoids import cycle).
-        self._flush_stream_batch_fn = None
-        self.engine_core_processes = []
-        self.input_sockets = []
-        self.output_sockets = []
-        self.engine_core_identities = []
-        self.shutdown_paths = []
-        self.output_threads = []
-        # Fair-rotation cursor, advanced once per selection. round_robin picks the
-        # rank directly (cursor % n); the load-aware strategies use it only to seed
-        # the argmin start offset so fully-tied ranks rotate instead of always
-        # resolving to rank 0.
-        self._rank_rotation_cursor = 0
-
-        # --- DP request load balancing (see _select_dp_rank_locked) ---
-        # DisaggCoreManager fans out via its own add_request() and never routes
-        # through _dispatch_to_dp_ranks, so load is never charged and _seq_load
-        # stays empty. But the inherited output thread still calls
-        # _release_seq_load() on every finished sequence, so these fields MUST
-        # exist or the output thread dies on the first finish and responses stop.
-        # Strategy: "round_robin" | "least_requests" | "least_tokens" (validated
-        # at the CLI by argparse choices=DP_LB_STRATEGIES).
-        self._dp_lb_strategy = config.dp_load_balance
-        # Token-equivalent weight of one in-flight request for "least_tokens".
-        # Read once here: this is a construction-time config value (CoreManager
-        # is built after env/args are finalized), not a runtime-tunable knob.
-        self._dp_lb_req_equiv = envs.ATOM_DP_LB_REQ_EQUIV
-        # Authoritative in-flight load per rank, maintained locally: incremented
-        # on dispatch, decremented on finish/abort. Guarded by _lb_lock because
-        # dispatch runs on the request thread while release runs on the per-rank
-        # output threads.
-        self._rank_reqs = [0] * self.local_engine_count
-        self._rank_tokens = [0] * self.local_engine_count
-        # seq_id -> (dp_rank, req_cost, tok_cost) so release subtracts exactly
-        # what dispatch added, and only for ranks that were actually charged.
-        self._seq_load = {}
-        self._lb_lock = Lock()
+        # Set up the inherited state without running CoreManager.__init__,
+        # which would spawn its own engines the base way. This manager fans out
+        # through its own add_request() and never charges DP load, but the
+        # inherited output thread still releases it on every finished sequence.
+        self._init_shared_state(
+            config,
+            label="DisaggCoreManager",
+            local_engine_count=2,  # prefill + decode
+        )
 
         import weakref
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -31,6 +31,7 @@ import aiter
 import torch
 import torch.nn.functional as F
 from aiter import (
+    QuantType,
     cp_gather_indexer_k_quant_cache,
     dtypes,
     rope_rotate_activation,
@@ -53,7 +54,6 @@ from atom.config import (
     Config,
     LayerQuantConfig,
     QuantizationConfig,
-    QuantType,
     get_current_atom_config,
 )
 from atom.distributed.pcp_utils import (

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -19,7 +19,7 @@ import importlib
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 import torch
 
@@ -339,7 +339,7 @@ class GenericParser(QuantConfigParser):
     """Fallback parser that uses heuristics for compressed-tensors, etc."""
 
     # Regex patterns for identifying quantization types from config keys/values
-    _DTYPE_PATTERNS = {
+    _DTYPE_PATTERNS: ClassVar[dict[str, str]] = {
         r"fp8|float8": "fp8",
         r"fp4|float4|mxfp4": "fp4x2",
         r"int8|w8a8": "int8",

--- a/atom/quant_spec.py
+++ b/atom/quant_spec.py
@@ -14,14 +14,48 @@ This module introduces:
 
 from __future__ import annotations
 
+import functools
+import importlib
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
 import torch
-from aiter import QuantType
-from aiter.utility.dtypes import d_dtypes
+
+
+class _LazyAiterAttr:
+    """One AITER attribute, resolved on first use rather than at import.
+
+    `atom.config` imports this module, and Python imports a package before its
+    submodule, so a plain `from aiter import QuantType` here makes *reading a
+    dataclass* require the AITER build. That is why the unit-test suite used to
+    replace `atom.config` with a hand-written stand-in, which then drifted from
+    the real thing and silently disabled test modules.
+
+    Only the name is deferred. Every attribute read returns the genuine AITER
+    object, so `quant_type` values compare and behave exactly as before -- this
+    is not a stand-in and never answers when AITER is missing.
+    """
+
+    __slots__ = ("_attr", "_module", "_value")
+
+    def __init__(self, module: str, attr: str):
+        self._module = module
+        self._attr = attr
+        self._value = None
+
+    def _resolve(self) -> Any:
+        if self._value is None:
+            self._value = getattr(importlib.import_module(self._module), self._attr)
+        return self._value
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resolve(), name)
+
+
+QuantType = _LazyAiterAttr("aiter", "QuantType")
+d_dtypes = _LazyAiterAttr("aiter.utility.dtypes", "d_dtypes")
 
 # ──────────────────────────────────────────────────────────────────────
 # Typed layer-level spec
@@ -32,7 +66,10 @@ from aiter.utility.dtypes import d_dtypes
 class LayerQuantConfig:
     """Immutable description of how a single layer (or default) is quantized."""
 
-    quant_type: QuantType = QuantType.No
+    # `default_factory`, not `default`: a plain default is evaluated when the
+    # class is created, which would resolve the lazy AITER name at import time
+    # and undo the deferral above. The factory runs per instantiation instead.
+    quant_type: QuantType = field(default_factory=lambda: QuantType.No)
     quant_dtype: Any = torch.bfloat16  # torch.dtype (use Any for forward compat)
     is_dynamic: bool = True
     quant_method: str | None = None
@@ -124,18 +161,27 @@ def get_quant_parser(method_name: str) -> QuantConfigParser:
 
 # -- helpers ----------------------------------------------------------------
 
-_QSCHEME_TO_QUANT_TYPE: dict[str, QuantType] = {
-    "per_channel": QuantType.per_Token,
-    "per_tensor": QuantType.per_Tensor,
-    "per_group": QuantType.per_1x32,
-    "per_block": QuantType.per_1x128,
-}
+
+@functools.cache
+def _qscheme_to_quant_type() -> dict[str, QuantType]:
+    """qscheme string -> AITER quant type, built on first use.
+
+    A module-level dict literal would read the lazy AITER names at import time,
+    which is exactly what the deferral above exists to avoid. Cached, so the
+    lookup stays a dict access after the first call.
+    """
+    return {
+        "per_channel": QuantType.per_Token,
+        "per_tensor": QuantType.per_Tensor,
+        "per_group": QuantType.per_1x32,
+        "per_block": QuantType.per_1x128,
+    }
 
 
 def _parse_quant_type(qscheme: str | None) -> QuantType:
     if qscheme is None:
         return QuantType.No
-    return _QSCHEME_TO_QUANT_TYPE.get(qscheme, QuantType.No)
+    return _qscheme_to_quant_type().get(qscheme, QuantType.No)
 
 
 def _parse_quant_dtype(dtype_str: str | None) -> Any:
@@ -300,12 +346,21 @@ class GenericParser(QuantConfigParser):
         r"int4|w4a16|gptq|awq": "int4x2",
     }
 
-    _QTYPE_PATTERNS = {
-        r"block|per_block|blockwise|1x128": QuantType.per_1x128,
-        r"per_channel|channel|per_token|token": QuantType.per_Token,
-        r"per_tensor|tensor": QuantType.per_Tensor,
-        r"per_group|group": QuantType.per_1x32,
-    }
+    @staticmethod
+    @functools.cache
+    def _qtype_patterns() -> dict[str, QuantType]:
+        """Regex -> AITER quant type, built on first use.
+
+        A class-level dict literal runs when the class is created, i.e. at
+        import time, which would resolve the lazy AITER names and defeat the
+        deferral. Same reason as `_qscheme_to_quant_type`.
+        """
+        return {
+            r"block|per_block|blockwise|1x128": QuantType.per_1x128,
+            r"per_channel|channel|per_token|token": QuantType.per_Token,
+            r"per_tensor|tensor": QuantType.per_Tensor,
+            r"per_group|group": QuantType.per_1x32,
+        }
 
     def parse(self, hf_quant_config: dict) -> ParsedQuantConfig:
         quant_method = hf_quant_config.get("quant_method", "")
@@ -416,7 +471,7 @@ class GenericParser(QuantConfigParser):
         for key in ("quant_type", "quantization_type", "scheme"):
             val = cfg.get(key)
             if val and isinstance(val, str):
-                for pattern, qtype in self._QTYPE_PATTERNS.items():
+                for pattern, qtype in self._qtype_patterns().items():
                     if re.search(pattern, val.lower()):
                         return qtype
         # Check compressed-tensors config_groups for weight strategy
@@ -428,13 +483,13 @@ class GenericParser(QuantConfigParser):
                 weights = group.get("weights") or {}
                 strategy = weights.get("strategy", "")
                 if strategy:
-                    mapped = _QSCHEME_TO_QUANT_TYPE.get(strategy)
+                    mapped = _qscheme_to_quant_type().get(strategy)
                     if mapped is None:
-                        mapped = _QSCHEME_TO_QUANT_TYPE.get(f"per_{strategy}")
+                        mapped = _qscheme_to_quant_type().get(f"per_{strategy}")
                     if mapped is not None:
                         return mapped
         # Fall back to regex heuristics on full config string
-        for pattern, qtype in self._QTYPE_PATTERNS.items():
+        for pattern, qtype in self._qtype_patterns().items():
             if re.search(pattern, config_str):
                 return qtype
         # Bare compressed-tensors / vLLM fp8 (no weight_block_size, no config_groups,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: MIT
-# Shared fixtures and module stubs for ATOM unit tests.
-# Must be imported before any atom.* module to avoid triggering heavy imports.
+# Shared fixtures for ATOM unit tests, and stand-ins for the third-party
+# packages a plain CPU runner does not have.
+#
+# Only *external* packages are stubbed, and only when genuinely missing. No
+# `atom.*` module is faked: a unit test imports the same class the engine
+# imports, so it cannot pass against an API the engine no longer has.
 
-import enum
 import hashlib
 import importlib
-import importlib.machinery
 import importlib.util
-import os
 import sys
 import types
 from itertools import count
@@ -22,117 +23,31 @@ ATOM_ROOT = str(Path(__file__).resolve().parent.parent)
 if ATOM_ROOT not in sys.path:
     sys.path.insert(0, ATOM_ROOT)
 
-# ── 2. Stub the top-level `atom` package so __init__.py never runs ─────────
-# atom/__init__.py imports LLMEngine which pulls in zmq, GPU init, etc.
+# ── 2. Stub AITER when it is absent ───────────────────────────────────────
+# The unit gate runs on a plain CPU runner with no AITER build. Only the
+# *external* boundary is stubbed: `atom.config` and friends are imported for
+# real, so a test exercises the same class the engine does.
+#
+# Stubbing internal modules instead is what this replaced, and it rotted --
+# the hand-written `atom.config` stand-in silently lost `CompilationLevel`,
+# and because the modules that import it are guarded by a broad try/except
+# that skips the whole file, four GPU kernel test modules stopped running on
+# every machine, blaming a circular import that never existed.
+#
+# `atom.config` reaches exactly two AITER attributes (`QuantType` and
+# `utility.dtypes.d_dtypes`); MagicMock covers them and anything added later.
 
-_atom_pkg = types.ModuleType("atom")
-_atom_pkg.__path__ = [os.path.join(ATOM_ROOT, "atom")]
-_atom_pkg.__package__ = "atom"
-# arg_utils does `from atom import LLMEngine`; stub it so the import resolves
-# without running atom/__init__.py (which pulls in zmq / GPU init).
-_atom_pkg.LLMEngine = MagicMock()
-sys.modules["atom"] = _atom_pkg
+if importlib.util.find_spec("aiter") is None:
+    for _mod_name in ("aiter", "aiter.utility", "aiter.utility.dtypes"):
+        sys.modules[_mod_name] = MagicMock()
 
-# ── 3. Stub `atom.config` to avoid HuggingFace / torch heavy imports ──────
-
-_atom_config = types.ModuleType("atom.config")
-_atom_config.__package__ = "atom.config"
-
-
-class _StubConfig:
-    """Placeholder so `from atom.config import Config` doesn't fail."""
-
-
-class _StubKVCacheTensor:
-    """Placeholder for KVCacheTensor."""
-
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-
-
-class _StubParallelConfig:
-    """Placeholder for ParallelConfig."""
-
-
-class _StubEPLBConfig:
-    """Placeholder for EPLBConfig with the defaults EPLB code reads."""
-
-    load_window_size = 1000
-    rebalance_interval = 3000
-    p2p_batch_chunk_size = 32
-    rebalance_layers_per_chunk = 64
-    num_redundant_experts = 0
-    rebalance_min_balancedness = 2.0
-    rebalance_balancedness_agg = "min"
-    placement_policy = "naive"
-
-    def __init__(self, **kwargs):
-        # AtomArgs builds EPLBConfig(**eplb_kwargs); mirror the real dataclass
-        # constructor by accepting and storing those fields (falls back to the
-        # class-level defaults above when constructed with no args).
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
-    @classmethod
-    def from_dict(cls, cfg):
-        # Mirror the real EPLBConfig.from_dict: arg_utils builds the config via
-        # EPLBConfig.from_dict(--eplb-config JSON dict).
-        return cls(**(cfg or {}))
-
-
-class _StubAtomConfig:
-    """Placeholder returned by get_current_atom_config in unit tests."""
-
-    eplb_enable = False
-    eplb_config = _StubEPLBConfig()
-
-
-class _StubCUDAGraphMode(enum.Enum):
-    """Mirror the real enum members so arg_utils' `CUDAGraphMode[name]` works."""
-
-    NONE = 0
-    PIECEWISE = 1
-    FULL = 2
-
-
-_atom_config.Config = _StubConfig
-_atom_config.KVCacheTensor = _StubKVCacheTensor
-_atom_config.ParallelConfig = _StubParallelConfig
-_atom_config.EPLBConfig = _StubEPLBConfig
-_atom_config.CUDAGraphMode = _StubCUDAGraphMode
-# Config dataclasses arg_utils imports; tests only need them constructible.
-_atom_config.CompilationConfig = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
-_atom_config.SpeculativeConfig = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
-_atom_config.DSparkConfig = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
-# Present so tests can monkeypatch it (raising=True) and so EPLB code paths that
-# call it without a patch get usable defaults.
-_atom_config.get_current_atom_config = lambda: _StubAtomConfig()
-sys.modules["atom.config"] = _atom_config
-
-# ── 3b. Stub forward_context; Scheduler only needs get_kvconnector in tests ──
-
-_forward_context = types.ModuleType("atom.utils.forward_context")
-_forward_context.__package__ = "atom.utils"
-_forward_context.__spec__ = importlib.machinery.ModuleSpec(
-    "atom.utils.forward_context", loader=None
-)
-_forward_context.get_kvconnector = lambda *args, **kwargs: None
-sys.modules["atom.utils.forward_context"] = _forward_context
-
-# ── 4. Stub zmq / zmq.asyncio if not installed ────────────────────────────
+# ── 3. Stub zmq / zmq.asyncio if not installed ────────────────────────────
 
 if importlib.util.find_spec("zmq") is None:
     for _mod_name in ("zmq", "zmq.asyncio"):
         sys.modules[_mod_name] = MagicMock()
 
-# ── 4b. Stub atom.utils.custom_register to avoid torch.library side effects
-
-_cr = types.ModuleType("atom.utils.custom_register")
-_cr.direct_register_custom_op = lambda **kwargs: None
-sys.modules["atom.utils.custom_register"] = _cr
-
-# ── 5. Stub xxhash with a hashlib-based fallback ──────────────────────────
+# ── 4. Stub xxhash with a hashlib-based fallback ──────────────────────────
 
 if importlib.util.find_spec("xxhash") is None:
     _xxhash_mod = types.ModuleType("xxhash")
@@ -155,14 +70,14 @@ if importlib.util.find_spec("xxhash") is None:
     _xxhash_mod.xxh64 = _XXH64
     sys.modules["xxhash"] = _xxhash_mod
 
-# ── 6. Now safe to import atom submodules ──────────────────────────────────
+# ── 5. Import atom submodules ──────────────────────────────────
 
 from atom.model_engine.block_manager import BlockManager
 from atom.model_engine.scheduler import Scheduler
 from atom.model_engine.sequence import Sequence
 from atom.sampling_params import SamplingParams
 
-# ── 7. MockConfig ──────────────────────────────────────────────────────────
+# ── 6. MockConfig ──────────────────────────────────────────────────────────
 
 
 class _MockHFConfig:
@@ -206,7 +121,7 @@ class MockConfig:
             setattr(self, k, v)
 
 
-# ── 8. Fixtures ────────────────────────────────────────────────────────────
+# ── 7. Fixtures ────────────────────────────────────────────────────────────
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,19 @@
 # SPDX-License-Identifier: MIT
-# Shared fixtures for ATOM unit tests, and stand-ins for the third-party
-# packages a plain CPU runner does not have.
+# Shared fixtures for ATOM unit tests.
 #
-# Only *external* packages are stubbed, and only when genuinely missing. No
-# `atom.*` module is faked: a unit test imports the same class the engine
-# imports, so it cannot pass against an API the engine no longer has.
+# Nothing here fakes a module. Tests import the same classes the engine
+# imports, so a test cannot pass against an API the engine no longer has --
+# which is what happened while this file hand-built stand-ins for `atom` and
+# `atom.config`: the copy lost `CompilationLevel`, and four test modules
+# silently stopped running on every machine.
+#
+# `atom.config` no longer needs the AITER build to import (`atom.quant_spec`
+# resolves its two AITER handles on first use), and every other third-party
+# import here is a declared dependency, so a plain CPU runner has them.
 
-import hashlib
-import importlib
-import importlib.util
 import sys
-import types
 from itertools import count
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -23,61 +23,14 @@ ATOM_ROOT = str(Path(__file__).resolve().parent.parent)
 if ATOM_ROOT not in sys.path:
     sys.path.insert(0, ATOM_ROOT)
 
-# ── 2. Stub AITER when it is absent ───────────────────────────────────────
-# The unit gate runs on a plain CPU runner with no AITER build. Only the
-# *external* boundary is stubbed: `atom.config` and friends are imported for
-# real, so a test exercises the same class the engine does.
-#
-# Stubbing internal modules instead is what this replaced, and it rotted --
-# the hand-written `atom.config` stand-in silently lost `CompilationLevel`,
-# and because the modules that import it are guarded by a broad try/except
-# that skips the whole file, four GPU kernel test modules stopped running on
-# every machine, blaming a circular import that never existed.
-#
-# `atom.config` reaches exactly two AITER attributes (`QuantType` and
-# `utility.dtypes.d_dtypes`); MagicMock covers them and anything added later.
-
-if importlib.util.find_spec("aiter") is None:
-    for _mod_name in ("aiter", "aiter.utility", "aiter.utility.dtypes"):
-        sys.modules[_mod_name] = MagicMock()
-
-# ── 3. Stub zmq / zmq.asyncio if not installed ────────────────────────────
-
-if importlib.util.find_spec("zmq") is None:
-    for _mod_name in ("zmq", "zmq.asyncio"):
-        sys.modules[_mod_name] = MagicMock()
-
-# ── 4. Stub xxhash with a hashlib-based fallback ──────────────────────────
-
-if importlib.util.find_spec("xxhash") is None:
-    _xxhash_mod = types.ModuleType("xxhash")
-
-    class _XXH64:
-        def __init__(self):
-            self._h = hashlib.sha256()
-
-        def update(self, data):
-            if isinstance(data, (bytes, bytearray, memoryview)):
-                self._h.update(data)
-            else:
-                raise TypeError(
-                    f"expected bytes-like object, got {type(data).__name__}"
-                )
-
-        def intdigest(self):
-            return int.from_bytes(self._h.digest()[:8], "little")
-
-    _xxhash_mod.xxh64 = _XXH64
-    sys.modules["xxhash"] = _xxhash_mod
-
-# ── 5. Import atom submodules ──────────────────────────────────
+# ── 2. Import atom submodules ──────────────────────────────────────────────
 
 from atom.model_engine.block_manager import BlockManager
 from atom.model_engine.scheduler import Scheduler
 from atom.model_engine.sequence import Sequence
 from atom.sampling_params import SamplingParams
 
-# ── 6. MockConfig ──────────────────────────────────────────────────────────
+# ── 3. MockConfig ──────────────────────────────────────────────────────────
 
 
 class _MockHFConfig:
@@ -121,7 +74,7 @@ class MockConfig:
             setattr(self, k, v)
 
 
-# ── 7. Fixtures ────────────────────────────────────────────────────────────
+# ── 4. Fixtures ────────────────────────────────────────────────────────────
 
 
 @pytest.fixture

--- a/tests/test_config_public_names.py
+++ b/tests/test_config_public_names.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Every `from atom.config import X` in the tree must resolve at runtime.
+
+`atom.config` is a hub: it re-exports names it imports from elsewhere, so a
+module can import something from it that it merely passes through. When such a
+pass-through moves -- or becomes a `TYPE_CHECKING`-only import, which binds
+nothing at runtime -- the importer breaks with
+
+    ImportError: cannot import name 'QuantType' from 'atom.config'
+
+and nothing catches it. The importers are mostly under `atom/models/`, which
+the CPU test gate never imports because they need the AITER kernel build, so
+the break surfaces only when someone loads that model on a GPU host.
+
+This check is pure AST: it reads the source and imports nothing, so it runs on
+the gate that cannot import the modules it is protecting.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / "atom" / "config.py"
+
+
+def _runtime_names(tree: ast.Module) -> set[str]:
+    """Names `atom.config` binds when actually executed.
+
+    Only `tree.body` -- the module's top level. Anything nested in an
+    `if TYPE_CHECKING:` block lives in that `If` node's body instead, and is
+    deliberately not counted: it exists for type checkers and is absent at
+    run time, which is exactly the failure this guards.
+    """
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names |= {a.asname or a.name.split(".")[0] for a in node.names}
+        elif isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            names |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def _config_importers() -> list[tuple[pathlib.Path, int, str]]:
+    """Every `(file, line, name)` imported from `atom.config` across the tree."""
+    found = []
+    for path in sorted(REPO_ROOT.glob("atom/**/*.py")) + sorted(
+        REPO_ROOT.glob("tests/**/*.py")
+    ):
+        try:
+            tree = ast.parse(path.read_text())
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "atom.config":
+                for alias in node.names:
+                    if alias.name != "*":
+                        found.append((path, node.lineno, alias.name))
+    return found
+
+
+def test_config_provides_every_name_imported_from_it():
+    available = _runtime_names(ast.parse(CONFIG_PATH.read_text()))
+    importers = _config_importers()
+    assert importers, "found no `from atom.config import ...` -- check the glob"
+
+    missing = [
+        f"{path.relative_to(REPO_ROOT)}:{lineno} imports {name!r}"
+        for path, lineno, name in importers
+        if name not in available
+    ]
+    assert not missing, (
+        "atom/config.py does not bind these at run time:\n  "
+        + "\n  ".join(missing)
+        + "\n(a TYPE_CHECKING-only import does not count -- import the name "
+        "from where it actually lives instead)"
+    )
+
+
+@pytest.mark.parametrize("name", ["Config", "LayerQuantConfig"])
+def test_known_reexports_are_detected(name):
+    """Guards the detector itself: these are re-exports, not local definitions."""
+    assert name in _runtime_names(ast.parse(CONFIG_PATH.read_text()))

--- a/tests/test_engine_core_mgr_shared_state.py
+++ b/tests/test_engine_core_mgr_shared_state.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""The engine-core managers must agree on the state their output thread reads.
+
+`CoreManager` spawns its engines one way and `DisaggCoreManager` another, so
+the subclass cannot run the base `__init__`. It used to hand-copy the field
+block instead, and the copy drifted: `_flush_stream_batch_fn` was added to the
+copy and to the API server that assigns it, but not to the base class. Nothing
+failed loudly -- the server path assigns the hook before the first request and
+the disagg path had it from the copy, so only the offline entrypoint was left
+without it. There, the output thread raised `AttributeError` on the first
+streamed token and died, the engine kept producing tokens nobody collected,
+and CI reported it a day later as a 60-minute timeout.
+
+These tests pin the invariant rather than that one field: whatever the output
+thread reads off `self`, both managers must provide.
+"""
+
+import ast
+import pathlib
+import unittest
+from types import SimpleNamespace
+
+from atom.model_engine.engine_core_mgr import CoreManager, DisaggCoreManager
+
+MODULE_PATH = pathlib.Path(CoreManager.__module__.replace(".", "/") + ".py")
+SOURCE = pathlib.Path(__file__).resolve().parent.parent / MODULE_PATH
+TREE = ast.parse(SOURCE.read_text())
+
+
+def _self_attributes_read_by(func_name: str) -> set[str]:
+    """Names read off `self` inside `func_name`, wherever it is nested.
+
+    Derived from the source rather than hardcoded so that a newly added read
+    is covered the day it lands -- which is the whole failure mode here.
+    """
+    for node in ast.walk(TREE):
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            return {
+                n.attr
+                for n in ast.walk(node)
+                if isinstance(n, ast.Attribute)
+                and isinstance(n.value, ast.Name)
+                and n.value.id == "self"
+                and isinstance(n.ctx, ast.Load)
+            }
+    raise AssertionError(f"{func_name} not found in {SOURCE}")
+
+
+def _calls_shared_initialiser(cls) -> bool:
+    """Whether `cls.__init__` routes through `_init_shared_state`."""
+    for node in ast.walk(TREE):
+        if isinstance(node, ast.ClassDef) and node.name == cls.__name__:
+            for fn in node.body:
+                if isinstance(fn, ast.FunctionDef) and fn.name == "__init__":
+                    return any(
+                        isinstance(c, ast.Call)
+                        and isinstance(c.func, ast.Attribute)
+                        and c.func.attr == "_init_shared_state"
+                        for c in ast.walk(fn)
+                    )
+    raise AssertionError(f"{cls.__name__}.__init__ not found")
+
+
+def _bare_manager(cls, **kwargs):
+    """A manager with its shared state set up and no engine processes spawned."""
+    mgr = cls.__new__(cls)
+    mgr._init_shared_state(
+        SimpleNamespace(dp_load_balance="round_robin"),
+        label=cls.__name__,
+        local_engine_count=kwargs.get("local_engine_count", 2),
+    )
+    return mgr
+
+
+class OutputThreadStateTest(unittest.TestCase):
+    """Fields the output thread reads must exist before the thread starts."""
+
+    def setUp(self):
+        self.managers = [_bare_manager(CoreManager), _bare_manager(DisaggCoreManager)]
+        self.addCleanup(self._terminate)
+
+    def _terminate(self):
+        for mgr in self.managers:
+            mgr.ctx.term()
+
+    def test_every_attribute_the_output_thread_reads_is_initialised(self):
+        reads = _self_attributes_read_by("process_outputs_socket")
+        self.assertIn(
+            "_flush_stream_batch_fn",
+            reads,
+            "the regression this guards is gone; retarget or drop this test",
+        )
+        for mgr in self.managers:
+            for attr in sorted(reads):
+                # Methods resolve on the class, so only instance state is at
+                # risk of being missed by an initialiser.
+                if callable(getattr(type(mgr), attr, None)):
+                    continue
+                self.assertTrue(
+                    hasattr(mgr, attr),
+                    f"{type(mgr).__name__} never initialises self.{attr}, which "
+                    f"process_outputs_socket reads -- the output thread will "
+                    f"die on the first output and take every response with it",
+                )
+
+    def test_stream_flush_hook_defaults_to_absent(self):
+        """It stays None until the API server resolves it; offline never does."""
+        for mgr in self.managers:
+            self.assertIsNone(mgr._flush_stream_batch_fn)
+
+    def test_load_accounting_is_sized_for_the_engine_count(self):
+        mgr = _bare_manager(CoreManager, local_engine_count=4)
+        self.addCleanup(mgr.ctx.term)
+        self.assertEqual(mgr._rank_reqs, [0] * 4)
+        self.assertEqual(mgr._rank_tokens, [0] * 4)
+        self.assertEqual(mgr.local_engine_count, 4)
+
+
+class SharedInitialiserIsTheOnlyPathTest(unittest.TestCase):
+    """Neither manager may go back to hand-copying the field block."""
+
+    def test_both_managers_call_the_shared_initialiser(self):
+        for cls in (CoreManager, DisaggCoreManager):
+            self.assertTrue(
+                _calls_shared_initialiser(cls),
+                f"{cls.__name__}.__init__ must call _init_shared_state rather "
+                f"than assigning the shared fields itself; a second copy of "
+                f"that block is what drifted last time",
+            )
+
+    def test_subclass_does_not_override_the_shared_initialiser(self):
+        self.assertIs(
+            DisaggCoreManager._init_shared_state,
+            CoreManager._init_shared_state,
+            "overriding _init_shared_state reintroduces the two-copies problem",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quant_config.py
+++ b/tests/test_quant_config.py
@@ -134,6 +134,17 @@ def _load_module(filename: str, module_name: str):
     sys.modules[module_name] = mod
     with _temporary_mocks():
         spec.loader.exec_module(mod)
+        # `quant_spec` resolves its AITER handles on first *use* rather than at
+        # import, so executing the module body is no longer enough to bind
+        # them. Touch them while the stand-ins above are still installed --
+        # afterwards there is no aiter to resolve against on a CPU-only runner.
+        #
+        # Deliberately not left in `sys.modules` instead: a lingering fake
+        # `aiter` would satisfy `pytest.importorskip("aiter")` in the other
+        # test modules, and whether it did would depend on collection order.
+        if hasattr(mod, "QuantType"):
+            _ = mod.QuantType.No
+            _ = mod.d_dtypes.get("fp8")
     return mod
 
 


### PR DESCRIPTION
A bug that killed the offline entrypoint's output thread reached `main` and was
caught a day later by the nightly Docker smoke test — as a 60-minute step
timeout. This fixes the bug, the reason the PR gate could not see it, and the
reason the unit suite could not see it either.

## The bug

`DisaggCoreManager` spawns its engines differently and so cannot run
`CoreManager.__init__`. It hand-copied the field block instead, and the copy
drifted: `_flush_stream_batch_fn` was added to the copy (`engine_core_mgr.py`)
and to the API server that assigns it (`api_server.py`), but never to the base
class.

Nothing failed loudly. The server path assigns the hook before the first
request and the disagg path had it from the copy, so only the **offline**
entrypoint was left with neither:

```
Exception in thread EngineCoreOutputThread-DP0:
  File "atom/model_engine/engine_core_mgr.py", line 317, in process_outputs_socket
    if self._flush_stream_batch_fn is not None:
AttributeError: 'CoreManager' object has no attribute '_flush_stream_batch_fn'
```

The thread died on the first streamed token. The engine kept producing tokens
nobody collected, `simple_inference` blocked forever, and the job hit
`The action 'Test Docker image' has timed out after 60 minutes`.

`_init_shared_state()` is now the one initialiser both constructors call. Only
`pp_*` (read solely by this class's spawn loop, and `DisaggCoreManager`
overrides the one method that touches it) and the post-spawn tail stay
per-class — verified by diffing the two field sets.

The tests pin the invariant rather than the single field: whatever
`process_outputs_socket` reads off `self` — **discovered from the source**, so
a newly added read is covered the day it lands — both managers must provide.
All five fail against `main`'s code.

## Why the PR gate missed it

Both the simple-inference step and its golden comparison were `if: false`, so
the offline entrypoint ran only in the nightly Docker release. The accuracy
test is not a substitute: it drives the server over HTTP, and the two do not
share the path that hands tokens back to the caller.

The inference step now runs for every model in the matrix. Completing is the
assertion — the output is printed but not diffed, which suits the failure mode
(the bug hung; it did not produce wrong text) and removes the need for a
per-model golden file. Only one such file was ever checked in, which is why the
comparison was disabled wholesale when the matrix moved to
`models_accuracy.json`; it is deleted rather than left dead a second time.

`extraArgs` also had to stop being interpolated into a double-quoted
`bash -lc "…"`: the host shell stripped the inner quotes, so
`--hf-overrides '{"use_index_cache": true}'` arrived as
`'{use_index_cache: true}'` and argparse rejected it. It now goes through an
env var and over stdin, as the accuracy step already does.

## Why the unit suite missed it

`tests/conftest.py` replaced `atom` and `atom.config` in `sys.modules` with
hand-built module objects, so unit tests ran against a parallel API nobody
updated. It rotted: the stand-in lost `CompilationLevel`, and because the
modules importing it are guarded by a broad `try/except` that skips the whole
file, four test modules stopped running **on every machine, including GPU
hosts** — while blaming a circular import that does not exist.

The stand-ins existed because `import atom.config` was expensive: Python
imports a package before its submodule, and `atom/__init__.py` eagerly imported
`LLMEngine`, so reading a dataclass pulled in zmq, the model runner and AITER.
That is now resolved on attribute access (PEP 562); `import atom.config` loads
no engine module at all, and `from atom import LLMEngine` is unchanged.

That left AITER. `atom.quant_spec` now resolves `QuantType` and `d_dtypes` on
first use — the handles return the genuine AITER objects, so values compare and
behave exactly as before; only the lookup moves. Deferring the import is not
enough by itself: three places evaluated those names while the module body ran,
and each had to move with it (the `LayerQuantConfig.quant_type` default →
`default_factory`; `_QSCHEME_TO_QUANT_TYPE` → a cached function;
`GenericParser._QTYPE_PATTERNS`, a **class body**, likewise). `config.py` then
needs AITER for neither of its two uses: the runtime one has an exact
equivalent in `LayerQuantConfig.no_quant()`, and the annotation moves under
`TYPE_CHECKING`.

**`tests/conftest.py` now fakes nothing at all.** The zmq and xxhash stubs went
too — both are declared dependencies in `pyproject.toml`, so their
`find_spec(...) is None` guard could never fire.

## Test plan

Simulating the CPU gate by blocking `aiter` at the meta path (the unit job runs
on `ubuntu-latest`, where it is genuinely absent):

| | `main` | this branch |
|---|---|---|
| CPU gate (no aiter) | 839 passed, 16 skipped, 0 failed | **846 passed, 14 skipped, 0 failed** |
| GPU host, full suite | 895 passed, 6 skipped | **902 passed, 2 skipped** |

Coverage rises and skips fall in both. The 2 remaining failures
(`test_mxfp4_moe_has_bias`) are pre-existing on `main` and untouched here.

- [x] 5 new tests for the shared-state invariant; all 5 fail against `main`.
- [x] `test_dspark_swa_fp8_2buff` (2 tests) runs again — it was one of the four
      modules the stand-in silently disabled.
- [x] Host-shell simulation confirming JSON in `extraArgs` now reaches the
      container intact.

## Reviewer notes

- **Commit 2 of 5 (`test: import the real atom modules…`) is red in isolation.**
  Removing the stubs un-skipped tests that need real AITER before the lazy
  import landed in commit 4. The branch head is green; squash-merge, or say the
  word and I will squash 2 and 4 together.
- The CPU-gate numbers come from a meta-path simulation, not a real
  `ubuntu-latest` run. Whether `pip install -e .` there pulls AITER by some
  other route is something only CI can answer.
- `test_profiler_regression.py::test_hipgraph_replay_occupancy` aborts
  intermittently on a GPU host (~4/10 on `main`, similar here). Pre-existing and
  unrelated; it skips on the CPU gate, which is why nobody has hit it.
