### PR TITLE
fix(sglang): restore DeepSeek-R1 TP4 accuracy

### DIFF
--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -65,7 +65,7 @@
     "accuracy_threshold": 0.91,
     "accuracy_baseline": null,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-R1-0528",
-    "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
+    "_baseline_note": "TP4 uses AITER attention with FP8 Q/KV decode; threshold aligned with the SGLANG gsm8k target."
   },
   {
     "model_name": "DeepSeek-R1-FP8 TP4 Online Quant",
@@ -77,7 +77,7 @@
     "accuracy_threshold": 0.91,
     "accuracy_baseline": null,
     "accuracy_baseline_model": "deepseek-ai/DeepSeek-R1-0528",
-    "_baseline_note": "Online quant coverage based on the DeepSeek-R1-FP8 TP4 SGLang accuracy validation target for gsm8k."
+    "_baseline_note": "Online quant TP4 uses AITER attention with FP8 Q/KV decode; threshold follows the DeepSeek-R1-FP8 TP4 gsm8k target."
   },
   {
     "model_name": "Kimi-K2.6-MXFP4 TP4",
@@ -219,13 +219,13 @@
     "model_name": "DeepSeek-R1-FP4 TP4",
     "model_path": "amd/DeepSeek-R1-0528-MXFP4-v2",
     "extraArgs": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
-    "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+    "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128\nATOM_LOADER_NUM_THREADS=1",
     "runner": "atom-plugin-acc-validation-runner-sgl",
     "test_level": "nightly",
     "accuracy_threshold": 0.91,
     "accuracy_baseline": null,
     "accuracy_baseline_model": "amd/DeepSeek-R1-0528-MXFP4-v2",
-    "_baseline_note": "Threshold aligned with the SGLANG accuracy validation workflow target for gsm8k."
+    "_baseline_note": "TP4 uses AITER attention with FP8 Q/KV decode; serial loading avoids under-filled batched MoE expert groups."
   },
   {
     "model_name": "DeepSeek-R1-FP4 TP4 DP4 EP4",

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -175,6 +175,8 @@ jobs:
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_BF16_FP8_MOE_BOUND=0\nATOM_MOE_GU_ITLV=1\nSGLANG_DEFAULT_THINKING=1\nSGLANG_DSV4_REASONING_EFFORT=max\nSGLANG_USE_AITER=1\nSGLANG_DSV4_FP4_EXPERTS=true\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
                   "runner": "atom-plugin-acc-validation-runner-sgl",
               },
+              # DeepSeek-R1 TP4 uses FP8 Q/KV decode so AITER dispatches its
+              # native 32-head kernel on MI355X.
               {
                   "toggle_env": "RUN_DSR1_FP8_TP4",
                   "model_name": "DeepSeek-R1-FP8 TP4",
@@ -302,7 +304,7 @@ jobs:
                   "model_path": "amd/DeepSeek-R1-0528-MXFP4-v2",
                   "extra_args": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
-                  "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+                  "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128\nATOM_LOADER_NUM_THREADS=1",
                   "runner": "atom-plugin-acc-validation-runner-sgl",
               },
               {

--- a/atom/plugin/sglang/models/deepseek_mla_attention.py
+++ b/atom/plugin/sglang/models/deepseek_mla_attention.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from torch import nn
 
+from atom.plugin.sglang.models.kv_cache_utils import is_fp8_kv_cache_dtype
 from atom.plugin.sglang.runtime.context import is_draft_extend_mode
 
 if TYPE_CHECKING:
@@ -245,10 +246,9 @@ class SGLangDeepseekMLAAttention(nn.Module):
             q_cache_scale = getattr(mla_attn, "q_scale", None)
             if q_cache_scale is None:
                 q_cache_scale = mla_attn.k_scale
-            q_out_dtype = (
-                dtypes.fp8 if attn.kv_cache_dtype == "fp8_e4m3" else q_nope_out.dtype
-            )
-            q_descale = q_cache_scale if attn.kv_cache_dtype == "fp8_e4m3" else None
+            use_fp8_q = is_fp8_kv_cache_dtype(attn.kv_cache_dtype)
+            q_out_dtype = dtypes.fp8 if use_fp8_q else q_nope_out.dtype
+            q_descale = q_cache_scale if use_fp8_q else None
             q = torch.empty(
                 (
                     q_nope_out.shape[0],

--- a/atom/plugin/sglang/models/deepseek_mla_forward.py
+++ b/atom/plugin/sglang/models/deepseek_mla_forward.py
@@ -26,6 +26,7 @@ from atom.models.deepseek_v2 import (
     _mxfp4_activation_quant_layout,
 )
 from atom.models.utils import maybe_prefix
+from atom.plugin.sglang.models.kv_cache_utils import is_fp8_kv_cache_dtype
 
 try:
     from sglang.srt.model_executor.runner import get_is_capture_mode
@@ -291,7 +292,7 @@ def init_sgl_attrs(
     attn.alt_stream = None
     attn.kv_cache_dtype = kv_cache_dtype
     attn.use_fused_qk_rope_concat_and_cache_mla = (
-        kv_cache_dtype == "fp8_e4m3" or _use_aiter_gfx95
+        is_fp8_kv_cache_dtype(kv_cache_dtype) or _use_aiter_gfx95
     )
     attn.current_sgl_plugin_attn_path = None
     attn.w_kc, attn.w_vc = None, None

--- a/atom/plugin/sglang/models/kv_cache_utils.py
+++ b/atom/plugin/sglang/models/kv_cache_utils.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""KV-cache dtype helpers shared by SGLang model adapters."""
+
+from __future__ import annotations
+
+
+def is_fp8_kv_cache_dtype(kv_cache_dtype: object) -> bool:
+    """Recognize CLI aliases, ATOM's ``fp8`` canonical form, and torch dtypes."""
+    cache_dtype = getattr(kv_cache_dtype, "cache_dtype", kv_cache_dtype)
+    normalized = str(cache_dtype).lower().removeprefix("torch.")
+    return normalized.startswith(("fp8", "float8"))

--- a/recipes/atom_sglang/DeepSeek-R1.md
+++ b/recipes/atom_sglang/DeepSeek-R1.md
@@ -43,6 +43,9 @@ python3 -m sglang.launch_server \
 
 ### DeepSeek with FP8 (TP=4)
 
+Use the AITER attention backend for TP4. With an FP8 KV cache, ATOM keeps the
+absorbed decode query in FP8 so AITER dispatches its native 32-head kernel.
+
 ```bash
 export AITER_QUICK_REDUCE_QUANTIZATION=INT4
 export SGLANG_AITER_FP8_PREFILL_ATTN=0
@@ -93,11 +96,15 @@ python3 -m sglang.launch_server \
 
 ### DeepSeek with MXFP4 (TP=4)
 
+As with the FP8 TP4 configuration, use AITER attention with FP8 Q/KV decode.
+Load this FP4 checkpoint serially to avoid incomplete batched MoE expert groups.
+
 ```bash
 export AITER_QUICK_REDUCE_QUANTIZATION=INT4
-export SGLANG_AITER_FP8_PREFILL_ATTN=1
+export SGLANG_AITER_FP8_PREFILL_ATTN=0
 export SGLANG_USE_AITER=1
 export ATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1
+export ATOM_LOADER_NUM_THREADS=1
 # Introduce ATOM as external model package of SGLang
 export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
 export SGLANG_ENABLE_TORCH_COMPILE=1

--- a/tests/plugin/test_sglang_kv_cache_utils.py
+++ b/tests/plugin/test_sglang_kv_cache_utils.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+import pytest
+
+from atom.plugin.sglang.models.kv_cache_utils import is_fp8_kv_cache_dtype
+
+
+@pytest.mark.parametrize(
+    "cache_dtype",
+    [
+        "fp8",
+        "fp8_e4m3",
+        "fp8_e5m2",
+        "torch.float8_e4m3fn",
+        SimpleNamespace(cache_dtype="fp8_e4m3"),
+    ],
+)
+def test_fp8_kv_cache_dtype_aliases(cache_dtype):
+    assert is_fp8_kv_cache_dtype(cache_dtype)
+
+
+@pytest.mark.parametrize("cache_dtype", ["bf16", "bfloat16", "auto", None])
+def test_non_fp8_kv_cache_dtypes(cache_dtype):
+    assert not is_fp8_kv_cache_dtype(cache_dtype)

--- a/tests/test_sglang_deepseek_r1_accuracy_config.py
+++ b/tests/test_sglang_deepseek_r1_accuracy_config.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-
 REPO = Path(__file__).resolve().parent.parent
 CATALOG = REPO / ".github" / "benchmark" / "sglang_models_accuracy.json"
 WORKFLOW = REPO / ".github" / "workflows" / "atom-sglang-accuracy-validation.yaml"
@@ -31,9 +30,7 @@ def _workflow_block(model_name: str) -> str:
 
 def _workflow_args(model_name: str) -> str:
     block = _workflow_block(model_name).splitlines()
-    args_line = next(
-        line for line in block[1:] if '"extra_args":' in line
-    )
+    args_line = next(line for line in block[1:] if '"extra_args":' in line)
     return args_line
 
 

--- a/tests/test_sglang_deepseek_r1_accuracy_config.py
+++ b/tests/test_sglang_deepseek_r1_accuracy_config.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+CATALOG = REPO / ".github" / "benchmark" / "sglang_models_accuracy.json"
+WORKFLOW = REPO / ".github" / "workflows" / "atom-sglang-accuracy-validation.yaml"
+
+TP4_AITER_MODELS = {
+    "DeepSeek-R1-FP8 TP4",
+    "DeepSeek-R1-FP8 TP4 Online Quant",
+    "DeepSeek-R1-FP4 TP4",
+}
+
+
+def _catalog_rows() -> dict[str, dict]:
+    rows = json.loads(CATALOG.read_text())
+    return {row["model_name"]: row for row in rows}
+
+
+def _catalog_args() -> dict[str, str]:
+    return {name: row["extraArgs"] for name, row in _catalog_rows().items()}
+
+
+def _workflow_block(model_name: str) -> str:
+    lines = WORKFLOW.read_text().splitlines()
+    marker = f'"model_name": "{model_name}"'
+    model_line = next(i for i, line in enumerate(lines) if marker in line)
+    return "\n".join(lines[model_line : model_line + 10])
+
+
+def _workflow_args(model_name: str) -> str:
+    block = _workflow_block(model_name).splitlines()
+    args_line = next(
+        line for line in block[1:] if '"extra_args":' in line
+    )
+    return args_line
+
+
+def test_deepseek_r1_tp4_accuracy_uses_aiter_attention():
+    catalog_args = _catalog_args()
+    for model_name in TP4_AITER_MODELS:
+        assert "--attention-backend aiter" in catalog_args[model_name]
+        assert "--attention-backend triton" not in catalog_args[model_name]
+
+        workflow_args = _workflow_args(model_name)
+        assert "--attention-backend aiter" in workflow_args
+        assert "--attention-backend triton" not in workflow_args
+
+
+def test_deepseek_r1_tp8_accuracy_keeps_aiter_attention():
+    model_name = "DeepSeek-R1-FP8 TP8"
+    assert "--attention-backend aiter" in _catalog_args()[model_name]
+    assert "--attention-backend aiter" in _workflow_args(model_name)
+
+
+def test_deepseek_r1_fp4_tp4_accuracy_loads_experts_serially():
+    model_name = "DeepSeek-R1-FP4 TP4"
+    assert "ATOM_LOADER_NUM_THREADS=1" in _catalog_rows()[model_name]["env_vars"]
+    assert "ATOM_LOADER_NUM_THREADS=1" in _workflow_block(model_name)


### PR DESCRIPTION

## Motivation

Fix the near-zero GSM8K accuracy of DeepSeek-R1 with SGLang ATOM TP4 + AITER, while removing the temporary Triton attention fallback.

SGLang normalizes `fp8_e4m3` to `fp8`, but MLA decode only recognized `fp8_e4m3`. This caused TP4 to use BF16 Q with FP8 KV instead of AITER’s native FP8 32-head decode kernel.

## Technical Details

- Add unified FP8 KV-cache dtype detection for:
  - `fp8`
  - `fp8_e4m3` / `fp8_e5m2`
  - PyTorch FP8 dtypes
  - Configuration objects exposing `cache_dtype`
- Generate FP8 Q and propagate the correct descale for absorbed MLA decode with FP8 KV cache.
- Keep DeepSeek-R1 TP4, Online Quant, and FP4 configurations on AITER attention.
- Retain `ATOM_LOADER_NUM_THREADS=1` for FP4 TP4 to avoid incomplete MoE expert groups.
- Update CI, recipes, and regression tests to prevent reintroducing the Triton workaround.

## Test Plan

- Run full 3-shot GSM8K evaluation (1,319 samples) on MI355X using `rocm/atom-dev:sglang-latest`:
  - DeepSeek-R1-FP8 TP4
  - DeepSeek-R1-FP8 TP4 Online Quant
  - DeepSeek-R1-FP4 TP4
  - DeepSeek-R1-FP8 TP8 control
- Validate TP4 AITER with CUDA Graph both enabled and disabled.
- Run FP8 dtype and accuracy configuration regression tests.
- Validate Python syntax, JSON/YAML parsing, and linter diagnostics.

## Test Result

- TP4 AITER before the fix:
  - Flexible extract: `0.00986`
  - Strict match: `0.00076`
- FP8 TP4 after the fix:
  - Flexible extract: `0.94541`
  - Strict match: `0.94162`
- Online Quant TP4:
  - Flexible extract: `0.94162`
  - Strict match: `0.93783`
- FP4 TP4:
  - Flexible extract: `0.92570`
  - Strict match: `0.91054`
- FP8 TP8 control:
  - Flexible extract: `0.94390`
  - Strict match: `0.93707`
- Targeted regression tests: `12 passed`