### PR TITLE
[Kimi-K3] Enable align-mode mamba prefix caching (vLLM-ATOM)

### DIFF
--- a/atom/plugin/vllm/models/kimi_k3.py
+++ b/atom/plugin/vllm/models/kimi_k3.py
@@ -10,7 +10,10 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateDtypeCalculator,
     MambaStateShapeCalculator,
 )
-from vllm.model_executor.models.interfaces import IsHybrid
+from vllm.model_executor.models.interfaces import (
+    IsHybrid,
+    SupportsMambaPrefixCaching,
+)
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 
@@ -162,7 +165,7 @@ class KimiK3ForCausalLM(KimiK3ForCausalLMBase):
             kimi_k3_base.KimiKDAAttention = original_kda_cls
 
 
-class KimiK3ForCausalLMVllm(ATOMMoEForCausalLM, IsHybrid):
+class KimiK3ForCausalLMVllm(ATOMMoEForCausalLM, IsHybrid, SupportsMambaPrefixCaching):
     @classmethod
     def get_mamba_state_dtype_from_config(
         cls,

--- a/recipes/atom_vllm/Kimi-K3.md
+++ b/recipes/atom_vllm/Kimi-K3.md
@@ -52,7 +52,8 @@ vllm serve "${MODEL}" \
     --max-num-batched-tokens 16384 \
     --gpu-memory-utilization 0.93 \
     --block-size 128 \
-    --no-enable-prefix-caching \
+    --enable-prefix-caching \
+    --mamba-cache-mode align \
     --no-async-scheduling \
     --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
 ```
@@ -62,8 +63,21 @@ vLLM's hybrid/Mamba cache contract, and uses ATOM's MLA backend for full
 attention. vLLM may increase the physical attention block size so its MLA and
 KDA pages have equal byte size; this is expected.
 
-Prefix caching must stay disabled because KDA recurrent state cannot be
-reconstructed from the paged MLA cache alone.
+Prefix caching runs in `align` mamba-cache mode. The plugin marks Kimi-K3 with
+vLLM's `SupportsMambaPrefixCaching` contract, so vLLM reuses cached MLA prefixes
+while the KDA layers recompute their recurrent state over the cached prefix from
+a single per-sequence state slot (align keeps the sequence-end block only, so
+there are no interior KDA checkpoints to reuse). This is always correct and
+speeds up the attention half of the prefill; the KDA half is still recomputed.
+
+`align` mode requires chunked prefill (on by default) and `--block-size` must be
+`<= --max-num-batched-tokens`; both hold for the configuration above. Leaving
+`--mamba-cache-mode` unset selects `none`, which retains a single working state
+slot and provides no cross-request prefix reuse.
+
+`--mamba-cache-mode all` (per-block KDA state checkpointing, enabling KDA reuse
+at interior block boundaries) is not yet validated for Kimi-K3 and should not be
+used in production.
 
 ## Smoke test
 
@@ -112,5 +126,6 @@ are not used as baselines for this model.
 
 - Text generation only; the vision tower and multimodal projector are skipped.
 - TP8 on MI355/gfx950 is the validated deployment.
-- Prefix caching and asynchronous scheduling are disabled.
+- Prefix caching runs in `align` mamba-cache mode; `all` mode is not yet
+  validated. Asynchronous scheduling is disabled.
 - Speculative decoding is not enabled for this model.


### PR DESCRIPTION
Kimi-K3's KDA/MLA hybrid backbone previously ran with prefix caching disabled because vLLM gates prefix caching off for hybrid models unless the model class declares the mamba prefix-caching contract. Mark KimiK3ForCausalLMVllm with SupportsMambaPrefixCaching so vLLM enables prefix caching for the model.

In align mamba-cache mode this reuses cached MLA prefixes while the KDA layers recompute their recurrent state over the cached prefix from a single per-sequence state slot. The KDA forward and GDN metadata builder are unchanged: align uses vLLM's stock GDN path (block_table[:, 0]), which is already correct, so the marker is the only code change required.

Update recipes/atom_vllm/Kimi-K3.md to launch with --enable-prefix-caching --mamba-cache-mode align and document the align semantics, the chunked-prefill / block-size constraints, and that 'all' mode is not yet validated.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
