### PR TITLE
fix[plugin]: bind DeepSeek-V4 plugin compressor quant metadata

### DIFF
--- a/atom/plugin/sglang/deepseek_v4_bridge.py
+++ b/atom/plugin/sglang/deepseek_v4_bridge.py
@@ -695,21 +695,20 @@ def _bind_compressor_state(
             raise ValueError("indexer compressor binding requires explicit head_dim")
         block_fp32_stride = (k1 * aligned_dim) // 4
         scale_fp32_offset = (k1 * head_dim) // 4
-        compressor.cache_scale = (
-            kv_cache.view(torch.float32)
-            .view(-1)
-            .as_strided(
-                size=(nb, k1),
-                stride=(block_fp32_stride, 1),
-                storage_offset=scale_fp32_offset,
-            )
+        kv_cache_f32 = kv_cache.view(torch.float32)
+        compressor.cache_scale = kv_cache_f32.view(-1).as_strided(
+            size=(nb, k1),
+            stride=(block_fp32_stride, 1),
+            storage_offset=kv_cache_f32.storage_offset() + scale_fp32_offset,
         )
         compressor.write_mode = "indexer_fp8"
+        compressor.quant_mode = "per_row_fp8"
     else:
         compressor.cache_scale = None
         compressor.write_mode = (
             "main_2buff_fp8" if kv_cache_rope is not None else "bf16"
         )
+        compressor.quant_mode = "group_fp8" if kv_cache_rope is not None else "none"
 
 
 def _iter_deepseek_v4_cache_blocks(model):

--- a/atom/plugin/vllm/deepseek_v4_bridge.py
+++ b/atom/plugin/vllm/deepseek_v4_bridge.py
@@ -571,14 +571,11 @@ def _bind_compressor_state(
         nb, k1, aligned_dim = kv_cache.shape
         block_fp32_stride = (k1 * aligned_dim) // 4
         scale_fp32_offset = (k1 * head_dim) // 4
-        compressor.cache_scale = (
-            kv_cache.view(torch.float32)
-            .view(-1)
-            .as_strided(
-                size=(nb, k1),
-                stride=(block_fp32_stride, 1),
-                storage_offset=scale_fp32_offset,
-            )
+        kv_cache_f32 = kv_cache.view(torch.float32)
+        compressor.cache_scale = kv_cache_f32.view(-1).as_strided(
+            size=(nb, k1),
+            stride=(block_fp32_stride, 1),
+            storage_offset=kv_cache_f32.storage_offset() + scale_fp32_offset,
         )
     else:
         compressor.cache_scale = None
@@ -588,6 +585,10 @@ def _bind_compressor_state(
     # "main_2buff_fp8" with a parallel bf16 RoPE pool bound via `kv_cache_rope`.
     compressor.kv_cache_rope = kv_cache_rope
     compressor.write_mode = write_mode
+    if is_indexer:
+        compressor.quant_mode = "per_row_fp8"
+    else:
+        compressor.quant_mode = "group_fp8" if kv_cache_rope is not None else "none"
 
 
 def _v4_max_spec_steps(vllm_config) -> int:


### PR DESCRIPTION
## Motivation

Fix DeepSeek-V4 plugin cache binding so SGLang and vLLM use the same compressor metadata layout as native ATOM. Without this, plugin serving can either route fp8 KV cache through the wrong compressor mode or bind indexer cache scales to the wrong storage offset, causing runtime failures or accuracy regressions.

## Technical Details
Set compressor.quant_mode explicitly when binding DeepSeek-V4 plugin cache views:
- per_row_fp8 for indexer-inner compressors
- group_fp8 for fp8 main CSA/HCA compressors
- none for bf16 main compressors
Also align SGLang and vLLM indexer cache_scale binding with native ATOM by adding the sliced KV view’s storage_offset() when constructing the strided fp32 scale view. This prevents different layers from aliasing the wrong scale region in the shared fp8 indexer cache storage.

## Test Result
**before：**
https://github.com/ROCm/ATOM/actions/runs/30756496221/job/91519560443
<img width="1719" height="365" alt="image" src="https://github.com/user-attachments/assets/9f184925-7986-48e1-84e5-5612472dd48a" />

https://github.com/ROCm/ATOM/actions/runs/30557449111/job/90925362192
<img width="1410" height="435" alt="image" src="https://github.com/user-attachments/assets/bd2b2926-759a-462f-a08d-42a12c6d6517" />

**after:**
<img width="742" height="127" alt="image" src="https://github.com/user-attachments/assets/68919d51-551b-4847-9775-326f2783ed21" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
