### PR TITLE
optimize attn res ref fla and fuse all possible part around it

### DIFF
--- a/atom/model_ops/attention_residual.py
+++ b/atom/model_ops/attention_residual.py
@@ -4,7 +4,15 @@
 """Attention-residual mixing layer (Kimi-K3).
 
 The layer wrapper lives here; the Triton kernel it dispatches lives in
-``atom.model_ops.kimi_k3.attention_residual``.
+``atom.model_ops.kimi_k3.attention_residual``, which follows
+flash-linear-attention's ``fused_attnres`` (that module's docstring lists the
+deltas). Attention Residuals: https://arxiv.org/abs/2603.15031
+
+This wrapper mirrors how the reference KDA layer drives that op
+(``fla/models/kda/modeling_kda.py``): ``proj`` and ``norm`` here are its
+``attn_res_proj``/``attn_res_norm``, and ``out_norm`` is its ``attn_norm``,
+which fla passes as ``output_rms_weight`` -- hence the result coming back
+already normed rather than the caller norming it.
 """
 
 from __future__ import annotations

--- a/atom/model_ops/attention_residual.py
+++ b/atom/model_ops/attention_residual.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Attention-residual mixing layer (Kimi-K3).
+
+The layer wrapper lives here; the Triton kernel it dispatches lives in
+``atom.model_ops.kimi_k3.attention_residual``.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from atom.model_ops.layernorm import RMSNorm
+from atom.model_ops.linear import ReplicatedLinear
+
+__all__ = ["AttnRes"]
+
+
+def _rms_eps(norm: RMSNorm) -> float:
+    return getattr(norm, "variance_epsilon", getattr(norm, "eps", 1e-6))
+
+
+class AttnRes(nn.Module):
+    """One attention-residual mixing site.
+
+    Mixes the B candidates of ``block_residual`` with a running ``prefix_sum``:
+    rmsnorm each of the B+1, score = <normed, score_weight>, softmax over B+1,
+    weighted sum. ``proj`` and ``norm`` define that scoring; their product is a
+    load-time constant folded into a single [H] vector (see ``score_weight``).
+
+    Three independent things decide what forward() actually runs, and all three
+    are settled here rather than at the call site:
+
+    * ``enabled`` -- whether this model uses attention residuals at all. When
+      False there is no mixing and no block state; forward degenerates to
+      ``out_norm(prefix_sum + addends)``, i.e. the ordinary pre-norm residual
+      step. ``proj``/``norm`` are then unused and may be None.
+    * ``block_residual`` empty vs populated -- with no candidates yet the
+      softmax is a no-op, so the same degenerate path applies.
+    * ``out_norm`` -- the caller's rmsnorm OF THE RESULT. Passing one is what
+      decides the fusion: it is folded into the kernel's store and the returned
+      mix comes back already normed and scaled, so the caller must not norm it
+      again. Given None, the mix is returned raw.
+
+    The upshot for callers is that forward() has one shape in every mode:
+    hand it the prefix, the block, and any pending addends; get back
+    ``(mixed_output, prefix_out)``. It never returns a mix that still needs
+    norming, and never asks the caller which path it took.
+
+    ``proj``/``norm``/``out_norm`` are passed in already constructed and stay
+    owned by the caller. That is deliberate: weights load by exact
+    ``named_parameters()`` path and a miss only WARNs, silently leaving an
+    RMSNorm at all-ones, so re-parenting them under this module would corrupt
+    the model quietly. Torch dedups a shared parameter to the name it was FIRST
+    registered under, so aliasing here is invisible as long as the owner
+    constructs them before handing them over.
+    """
+
+    def __init__(
+        self,
+        proj: ReplicatedLinear | None = None,
+        norm: RMSNorm | None = None,
+        out_norm: RMSNorm | None = None,
+        enabled: bool = True,
+        block_size: int | None = None,
+        layer_idx: int = 0,
+    ):
+        super().__init__()
+        if enabled and (proj is None or norm is None):
+            raise ValueError("an enabled AttnRes needs both proj and norm")
+        self.enabled = enabled
+        self.proj = proj
+        self.norm = norm
+        self.out_norm = out_norm
+        self.eps = 1e-6 if norm is None else _rms_eps(norm)
+        self.out_eps = 1e-6 if out_norm is None else _rms_eps(out_norm)
+        self.score_weight: torch.Tensor | None = None
+        # Set only on the site that closes out blocks (see maybe_close_block).
+        self.block_size = block_size
+        self.layer_idx = layer_idx
+
+    def process_weights_after_loading(self) -> None:
+        # Fold the static rmsnorm gain and the scoring projection into one [H]
+        # vector. Both operands are load-time constants, so the kernel reads a
+        # single vector per row instead of reloading and multiplying two.
+        # The loader calls this for every module, after the proj's own hook.
+        if not self.enabled:
+            return
+        self.score_weight = (
+            self.norm.weight.float() * self.proj.weight.squeeze(0).float()
+        ).contiguous()
+
+    def forward(
+        self,
+        prefix_sum: torch.Tensor | None,
+        block_residual: torch.Tensor | None = None,
+        add_hidden: torch.Tensor | None = None,
+        add_hidden2: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Returns ``(mixed_output, prefix_out)``.
+
+        The addends are the caller's ``prefix_sum = prefix_sum + ...``, folded
+        into the kernel's on-load so no separate [T, H] elementwise kernel runs;
+        ``prefix_out`` is that sum. A None ``prefix_sum`` means the block was
+        just closed out and this site starts a fresh one, so the first addend
+        IS the prefix.
+        """
+        if prefix_sum is None:
+            prefix_sum, add_hidden, add_hidden2 = add_hidden, add_hidden2, None
+        assert prefix_sum is not None
+
+        if self.enabled and block_residual is not None and block_residual.shape[1] > 0:
+            score_weight = self.score_weight
+            if score_weight is None:  # loader hook did not run (plugin hosts)
+                self.process_weights_after_loading()
+                score_weight = self.score_weight
+            from atom.model_ops.kimi_k3 import apply_attn_res
+
+            return apply_attn_res(
+                prefix_sum,
+                block_residual,
+                score_weight,
+                self.eps,
+                add_hidden,
+                None if self.out_norm is None else self.out_norm.weight,
+                self.out_eps,
+                add_hidden2,
+            )
+
+        # Nothing to mix (residuals off, or no candidates yet). Apply by hand
+        # what the kernel would otherwise have folded into its load and store.
+        if add_hidden is not None:
+            prefix_sum = prefix_sum + add_hidden
+            if add_hidden2 is not None:
+                prefix_sum = prefix_sum + add_hidden2
+        mixed = prefix_sum if self.out_norm is None else self.out_norm(prefix_sum)
+        return mixed, prefix_sum
+
+    def maybe_close_block(
+        self,
+        prefix_sum: torch.Tensor,
+        block_residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Append ``prefix_sum`` as a candidate every ``block_size`` layers.
+
+        Returns the new ``(block_residual, prefix_sum)``. A closed-out block
+        leaves prefix_sum None: the running sum has been banked as a candidate
+        and the next site starts a fresh one from whatever it is handed.
+        Residuals disabled, or a layer mid-block, means no change.
+        """
+        if not self.enabled or self.block_size is None:
+            return block_residual, prefix_sum
+        if self.layer_idx % self.block_size != 0:
+            return block_residual, prefix_sum
+        assert block_residual is not None
+        block_residual = torch.cat([block_residual, prefix_sum.unsqueeze(1)], dim=1)
+        return block_residual, None

--- a/atom/model_ops/kimi_k3/attention_residual.py
+++ b/atom/model_ops/kimi_k3/attention_residual.py
@@ -28,272 +28,137 @@ if _HAS_TRITON:
         sw_ptr,
         y_ptr,
         hs_ptr,
+        hs2_ptr,
         pref_ptr,
+        ow_ptr,
         B,
         Bp,
         H,
         eps,
+        out_eps,
         stride_br_t,
         stride_br_b,
         stride_ps_t,
         stride_yt,
         stride_hs_t,
+        stride_hs2_t,
         stride_pref_t,
-        BP: tl.constexpr,  # Bp padded to a power of 2 (vectorized candidate axis)
-        BLOCK_H: tl.constexpr,
-        NS: tl.constexpr,  # num_stages for the H-loop software pipeline
-        DO_ADD: tl.constexpr,  # fold prefix += hidden_states on-load
+        BL: tl.constexpr,  # candidates per tile
+        BD: tl.constexpr,  # next_pow2(H) -- one tile spans all of H
+        DO_ADD: tl.constexpr,  # fold prefix += add_hidden on-load
+        DO_ADD2: tl.constexpr,  # fold a second addend (shared-expert output)
         WRITE_PREF: tl.constexpr,  # write the (summed) prefix back to pref_ptr
+        OUT_NORM: tl.constexpr,  # fold the caller's output rmsnorm into the store
     ):
         # One program per row t: rmsnorm each of the Bp = B+1 candidates, score =
         # <normed, score_weight>, softmax over Bp, then weighted sum -> y[t].
         # Candidates 0..B-1 are block_residual rows; candidate B is prefix_sum.
-        # Read both source tensors directly (no torch.cat materialization); the
-        # Bp axis is vectorized, so scores/probs stay in registers and softmax +
-        # weighted-sum never touch HBM.
+        # Read both source tensors directly (no torch.cat materialization).
         #
-        # DO_ADD folds the caller's ``prefix_sum = prefix_sum + hidden_states``
+        # SINGLE PASS. The tile spans all of H and the running output stays in
+        # registers, so the softmax runs online (flash-style): each new candidate
+        # tile rescales the accumulator by exp(m_prev - m_new) instead of waiting
+        # for a completed reduction over the candidate axis. Every candidate is
+        # therefore read exactly ONCE.
+        #
+        # The tiling axis is what makes that work: tiling over CANDIDATES (not
+        # over H, as an earlier version did) is what lets the whole output live in
+        # registers. Tiling over H forces two passes -- probs aren't known until
+        # the H-reduction completes, so the combine has to re-read everything --
+        # and forces a third to fold OUT_NORM, since sum_h y_h^2 needs a formed y.
+        # Here y is already formed in registers when the loop ends, so OUT_NORM is
+        # free, and the token-count gate that the H-tiled version needed (the fold
+        # stopped paying once a row's [Bp, H] reload spilled L2) is gone with it.
+        #
+        # Cost is registers: BD = next_pow2(H) floats of accumulator, 32 KB of VGPR
+        # at H=7168, plus the [BL, BD] tile. BL is kept small for that reason.
+        #
+        # Adapted from FLA's fused_attnres (fla/ops/attnres/fused.py, MIT).
+        # Theirs gathers from a tuple of separate residual tensors via a pointer
+        # table; ours indexes one contiguous [T, B, H] block_residual, which is
+        # both cheaper and necessary here -- the pointer-table form miscompiles on
+        # ROCm (TritonAMDGPUCanonicalizePointers rejects arith.select on
+        # tensor<Nx!tt.ptr>), so their kernel cannot run on this backend at all.
+        #
+        # DO_ADD folds the caller's ``prefix_sum = prefix_sum + add_hidden``
         # elementwise add into the last-candidate on-load (saving a separate
         # kernel launch + HBM round-trip); WRITE_PREF then stores that summed
-        # prefix once (first pass) so downstream layers reuse it.
-        #
-        # Two HBM passes over H: the softmax + weighted-sum combine is over the
-        # small Bp axis, so probs isn't known until the whole H-reduction is done.
-        # The second pass re-reads br/ps -- but for one row that footprint is only
-        # ~Bp*H*2B (L2-resident), so the reload is served from cache, not HBM.
-        # (Holding the [BP, H] tile in registers to avoid the reload was measured
-        # slower: it blows the VGPR file and collapses occupancy.) num_stages
-        # pipelines each pass so the next chunk's load overlaps the current
-        # reduce -- the only win at small T where occupancy alone can't hide it.
+        # prefix so downstream layers reuse it. DO_ADD2 folds a SECOND addend the
+        # same way, so an MoE layer can hand over its routed and shared expert
+        # outputs unsummed and skip an entire [T, H] elementwise kernel.
         t = tl.program_id(0)
-        b_idx = tl.arange(0, BP)
-        b_mask = b_idx < Bp
-        is_last = b_idx == B  # prefix_sum candidate
-        br_base = t * stride_br_t + b_idx * stride_br_b  # [BP]
-        ps_base = t * stride_ps_t
+        o_d = tl.arange(0, BD)
+        m_d = o_d < H
+        sw = tl.load(sw_ptr + o_d, mask=m_d, other=0.0).to(tl.float32)
 
-        acc_sq = tl.zeros((BP,), dtype=tl.float32)
-        acc_dot = tl.zeros((BP,), dtype=tl.float32)
-        for h0 in tl.range(0, H, BLOCK_H, num_stages=NS):
-            cols = h0 + tl.arange(0, BLOCK_H)
-            h_mask = cols < H
-            br = tl.load(
-                br_ptr + br_base[:, None] + cols[None, :],
-                mask=(b_idx < B)[:, None] & h_mask[None, :],
+        # prefix (the last candidate) is loaded once and reused across tiles;
+        # re-reading it per tile would undo the single-pass property.
+        ps = tl.load(ps_ptr + t * stride_ps_t + o_d, mask=m_d, other=0.0).to(tl.float32)
+        if DO_ADD:
+            ps += tl.load(
+                hs_ptr + t * stride_hs_t + o_d, mask=m_d, other=0.0
+            ).to(tl.float32)
+        if DO_ADD2:
+            ps += tl.load(
+                hs2_ptr + t * stride_hs2_t + o_d, mask=m_d, other=0.0
+            ).to(tl.float32)
+        if WRITE_PREF:
+            tl.store(
+                pref_ptr + t * stride_pref_t + o_d,
+                ps.to(pref_ptr.dtype.element_ty),
+                mask=m_d,
+            )
+
+        b_m = tl.full([], float("-inf"), dtype=tl.float32)  # running max
+        b_acc = tl.zeros([], dtype=tl.float32)  # running softmax denominator
+        b_o = tl.zeros([BD], dtype=tl.float32)  # running weighted sum
+
+        for i_l in range(tl.cdiv(Bp, BL)):
+            o_l = i_l * BL + tl.arange(0, BL)
+            m_l = o_l < Bp
+            is_last = o_l == B
+            v = tl.load(
+                br_ptr + t * stride_br_t + o_l[:, None] * stride_br_b + o_d[None, :],
+                mask=(o_l < B)[:, None] & m_d[None, :],
                 other=0.0,
             ).to(tl.float32)
-            ps = tl.load(ps_ptr + ps_base + cols, mask=h_mask, other=0.0).to(
-                tl.float32
-            )  # [BLOCK_H]
-            if DO_ADD:
-                ps += tl.load(
-                    hs_ptr + t * stride_hs_t + cols, mask=h_mask, other=0.0
-                ).to(tl.float32)
-            if WRITE_PREF:
-                tl.store(
-                    pref_ptr + t * stride_pref_t + cols,
-                    ps.to(pref_ptr.dtype.element_ty),
-                    mask=h_mask,
-                )
-            v = tl.where(
-                is_last[:, None], ps[None, :], br
-            )  # [BP, BLOCK_H], ps broadcast in-reg
+            v = tl.where(is_last[:, None], ps[None, :], v)
+
             # score_weight = norm_weight * proj_weight, precomputed at load time
-            sw = tl.load(sw_ptr + cols, mask=h_mask, other=0.0).to(tl.float32)
-            acc_sq += tl.sum(v * v, axis=1)  # [BP]
-            acc_dot += tl.sum(v * sw[None, :], axis=1)  # [BP]
+            rstd = tl.rsqrt(tl.sum(v * v, axis=1) / H + eps)
+            s = tl.where(m_l, tl.sum(v * sw[None, :], axis=1) * rstd, float("-inf"))
 
-        rstd = 1.0 / tl.sqrt(acc_sq / H + eps)
-        scores = tl.where(b_mask, rstd * acc_dot, float("-inf"))
-        scores = scores - tl.max(scores, axis=0)
-        probs = tl.exp(scores)
-        probs = probs / tl.sum(probs, axis=0)  # [BP], softmax over Bp
+            b_m, b_mp = tl.maximum(b_m, tl.max(s, axis=0)), b_m
+            r = tl.exp(b_mp - b_m)  # rescale for the new max
+            p = tl.exp(s - b_m)
+            b_acc = b_acc * r + tl.sum(p, axis=0)
+            b_o = b_o * r + tl.sum(p[:, None] * v, axis=0)
 
-        for h0 in tl.range(0, H, BLOCK_H, num_stages=NS):
-            cols = h0 + tl.arange(0, BLOCK_H)
-            h_mask = cols < H
-            br = tl.load(
-                br_ptr + br_base[:, None] + cols[None, :],
-                mask=(b_idx < B)[:, None] & h_mask[None, :],
-                other=0.0,
-            ).to(tl.float32)
-            ps = tl.load(ps_ptr + ps_base + cols, mask=h_mask, other=0.0).to(tl.float32)
-            if DO_ADD:
-                ps += tl.load(
-                    hs_ptr + t * stride_hs_t + cols, mask=h_mask, other=0.0
-                ).to(tl.float32)
-            v = tl.where(is_last[:, None], ps[None, :], br)
-            out = tl.sum(probs[:, None] * v, axis=0)  # [BLOCK_H]
-            tl.store(
-                y_ptr + t * stride_yt + cols,
-                out.to(y_ptr.dtype.element_ty),
-                mask=h_mask,
-            )
-
-    @triton.jit
-    def _attn_res_reduce_kernel(
-        br_ptr,
-        ps_ptr,
-        sw_ptr,
-        psq_ptr,
-        pdot_ptr,
-        hs_ptr,
-        pref_ptr,
-        B,
-        H,
-        S,
-        stride_br_t,
-        stride_br_b,
-        stride_ps_t,
-        stride_o_t,
-        stride_o_s,
-        stride_hs_t,
-        stride_pref_t,
-        BP: tl.constexpr,
-        BLOCK_H: tl.constexpr,
-        NS: tl.constexpr,
-        DO_ADD: tl.constexpr,
-        WRITE_PREF: tl.constexpr,
-    ):
-        # Split-H stage 1, grid=(T, S): S workgroups cooperate on one row t, each
-        # owning a block-cyclic subset of the H-chunks. They emit PARTIAL sums
-        # psq/pdot[t, s] -- no softmax here, the reduction axis (H) is orthogonal
-        # to the softmax axis (Bp), so we stop strictly before the softmax fence.
-        # This multiplies the grid by S to fill the GPU at small T (where the
-        # grid=(T,) kernel launches too few workgroups to reach full occupancy).
-        #
-        # DO_ADD folds prefix += hidden_states on-load; each (t, s) owns a disjoint
-        # block-cyclic slice of H, so WRITE_PREF here stores that slice of the
-        # summed prefix with no overlap -- together the S programs cover all of H.
-        t = tl.program_id(0)
-        s = tl.program_id(1)
-        b_idx = tl.arange(0, BP)
-        is_last = b_idx == B
-        br_base = t * stride_br_t + b_idx * stride_br_b
-        ps_base = t * stride_ps_t
-        acc_sq = tl.zeros((BP,), dtype=tl.float32)
-        acc_dot = tl.zeros((BP,), dtype=tl.float32)
-        for h0 in tl.range(s * BLOCK_H, H, S * BLOCK_H, num_stages=NS):
-            cols = h0 + tl.arange(0, BLOCK_H)
-            h_mask = cols < H
-            br = tl.load(
-                br_ptr + br_base[:, None] + cols[None, :],
-                mask=(b_idx < B)[:, None] & h_mask[None, :],
-                other=0.0,
-            ).to(tl.float32)
-            ps = tl.load(ps_ptr + ps_base + cols, mask=h_mask, other=0.0).to(tl.float32)
-            if DO_ADD:
-                ps += tl.load(
-                    hs_ptr + t * stride_hs_t + cols, mask=h_mask, other=0.0
-                ).to(tl.float32)
-            if WRITE_PREF:
-                tl.store(
-                    pref_ptr + t * stride_pref_t + cols,
-                    ps.to(pref_ptr.dtype.element_ty),
-                    mask=h_mask,
-                )
-            v = tl.where(is_last[:, None], ps[None, :], br)
-            sw = tl.load(sw_ptr + cols, mask=h_mask, other=0.0).to(tl.float32)
-            acc_sq += tl.sum(v * v, axis=1)
-            acc_dot += tl.sum(v * sw[None, :], axis=1)
-        o = t * stride_o_t + s * stride_o_s + b_idx
-        tl.store(psq_ptr + o, acc_sq)
-        tl.store(pdot_ptr + o, acc_dot)
-
-    @triton.jit
-    def _attn_res_combine_kernel(
-        br_ptr,
-        ps_ptr,
-        psq_ptr,
-        pdot_ptr,
-        y_ptr,
-        hs_ptr,
-        B,
-        Bp,
-        H,
-        S,
-        eps,
-        stride_br_t,
-        stride_br_b,
-        stride_ps_t,
-        stride_i_t,
-        stride_i_s,
-        stride_yt,
-        stride_hs_t,
-        BP: tl.constexpr,
-        BLOCK_H: tl.constexpr,
-        NS: tl.constexpr,
-        DO_ADD: tl.constexpr,
-    ):
-        # Split-H stage 2, grid=(T,): sum the S partials back to the full
-        # H-reduction (associative, so exact), then the identical softmax +
-        # weighted-sum tail as the single-kernel path.
-        t = tl.program_id(0)
-        b_idx = tl.arange(0, BP)
-        b_mask = b_idx < Bp
-        is_last = b_idx == B
-        acc_sq = tl.zeros((BP,), dtype=tl.float32)
-        acc_dot = tl.zeros((BP,), dtype=tl.float32)
-        for s in range(S):
-            o = t * stride_i_t + s * stride_i_s + b_idx
-            acc_sq += tl.load(psq_ptr + o)
-            acc_dot += tl.load(pdot_ptr + o)
-        rstd = 1.0 / tl.sqrt(acc_sq / H + eps)
-        scores = tl.where(b_mask, rstd * acc_dot, float("-inf"))
-        scores = scores - tl.max(scores, axis=0)
-        probs = tl.exp(scores)
-        probs = probs / tl.sum(probs, axis=0)
-        br_base = t * stride_br_t + b_idx * stride_br_b
-        ps_base = t * stride_ps_t
-        for h0 in tl.range(0, H, BLOCK_H, num_stages=NS):
-            cols = h0 + tl.arange(0, BLOCK_H)
-            h_mask = cols < H
-            br = tl.load(
-                br_ptr + br_base[:, None] + cols[None, :],
-                mask=(b_idx < B)[:, None] & h_mask[None, :],
-                other=0.0,
-            ).to(tl.float32)
-            ps = tl.load(ps_ptr + ps_base + cols, mask=h_mask, other=0.0).to(tl.float32)
-            if DO_ADD:
-                ps += tl.load(
-                    hs_ptr + t * stride_hs_t + cols, mask=h_mask, other=0.0
-                ).to(tl.float32)
-            v = tl.where(is_last[:, None], ps[None, :], br)
-            out = tl.sum(probs[:, None] * v, axis=0)
-            tl.store(
-                y_ptr + t * stride_yt + cols,
-                out.to(y_ptr.dtype.element_ty),
-                mask=h_mask,
-            )
+        b_o = b_o / b_acc
+        if OUT_NORM:
+            # Free: b_o is already fully formed in registers.
+            rs = tl.rsqrt(tl.sum(tl.where(m_d, b_o * b_o, 0.0), axis=0) / H + out_eps)
+            b_o = b_o * rs * tl.load(ow_ptr + o_d, mask=m_d, other=0.0).to(tl.float32)
+        tl.store(y_ptr + t * stride_yt + o_d, b_o.to(y_ptr.dtype.element_ty), mask=m_d)
 
 
-# Per-token-count tuning for apply_attn_res at H=7168 (gfx1250). Each bucket maps
-# an upper-bound token count to (split, S, num_stages, num_warps):
-#   split=True  -> two-kernel split-H (S workgroups per row); wins at small T by
-#                  filling the GPU that grid=(T,) leaves idle (~1.3-1.55x).
-#   split=False -> single grid=(T,) two-pass kernel with num_stages pipelining;
-#                  wins once T alone saturates the machine (the split-H partial
-#                  round-trip then becomes pure overhead).
-# Dispatch rounds T UP to the smallest bucket >= T (ceil-to-bucket), matching how
-# CUDAGraph captures a handful of fixed batch sizes; T above the largest bucket
-# falls through to the catch-all two-pass path.
+# (num_warps, num_stages, BL) by token count. One program per token, so at small T
+# the grid alone cannot fill the GPU and wider warps are what recover occupancy;
+# BL stays small throughout because the [BL, BD] tile competes with the [BD]
+# accumulator for the register file.
 _ATTN_RES_CONFIGS = (
-    # (max_tokens, split, S, num_stages, num_warps)
-    (8, True, 7, 1, 2),
-    (16, True, 7, 1, 4),
-    (32, True, 7, 1, 4),
-    (64, True, 7, 1, 4),
-    (128, True, 6, 1, 4),
-    (256, False, 1, 2, 4),
+    (8, 8, 2, 2),  # T <= 8
+    (64, 8, 2, 2),
+    (512, 8, 2, 2),
+    (2048, 4, 2, 2),
 )
-_ATTN_RES_CATCHALL = (False, 1, 2, 4)  # T > largest bucket
-_ATTN_RES_BLOCK_H = 1024
+_ATTN_RES_CATCHALL = (4, 2, 2)  # T > largest bucket
 
 
 def _pick_attn_res_config(tokens: int):
-    for max_tokens, split, s, ns, nw in _ATTN_RES_CONFIGS:
+    for max_tokens, nw, ns, bl in _ATTN_RES_CONFIGS:
         if tokens <= max_tokens:
-            return split, s, ns, nw
+            return nw, ns, bl
     return _ATTN_RES_CATCHALL
 
 
@@ -303,123 +168,77 @@ def _apply_attn_res_impl(
     score_weight: torch.Tensor,  # [H] (norm_weight * proj_weight, precomputed)
     eps: float,
     add_hidden: torch.Tensor | None = None,  # [T, H], folded: prefix += add_hidden
+    out_norm_weight: torch.Tensor | None = None,  # [H], folded: y = rmsnorm(y)
+    out_eps: float = 1e-6,
+    add_hidden2: torch.Tensor | None = None,  # [T, H], folded the same way
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Block-residual soft-attention mix: rmsnorm each of the B+1 candidates,
     score = <normed, score_weight>, softmax over B+1, weighted sum.
 
-    ``score_weight`` folds ``norm_weight * proj_weight`` once at load time (both
-    are static loaded weights), so the kernel loads a single vector instead of
-    two and drops the per-forward multiply.
+    Candidates are the B rows of ``block_residual`` plus ``prefix_sum``, so
+    ``score_weight`` must already fold the rmsnorm gain into the scoring
+    projection (see ``_attn_res_score_weight`` on the model side).
 
-    When ``add_hidden`` is given, the caller's ``prefix_sum = prefix_sum +
-    hidden_states`` elementwise add is folded into the kernel (added on-load to
-    the prefix candidate, one HBM read + one launch saved) and the summed prefix
-    is written back. Returns ``(y, prefix_out)`` where ``prefix_out`` is the
-    summed prefix (or the unchanged ``prefix_sum`` when ``add_hidden`` is None),
-    so downstream layers reuse it.
+    Returns ``(mixed_output, prefix_out)``. When ``add_hidden`` (and optionally
+    ``add_hidden2``) is given, the caller's ``prefix_sum = prefix_sum + ...``
+    elementwise add is folded into the kernel on-load and ``prefix_out`` is that
+    sum; otherwise ``prefix_out`` is ``prefix_sum`` unchanged. Two addends exist
+    so an MoE layer can pass its routed and shared expert outputs separately and
+    skip the [T, H] elementwise add that would otherwise combine them.
 
-    Dispatches by token count (see ``_ATTN_RES_CONFIGS``): split-H at small T to
-    fill the GPU, the single-pass pipelined kernel once T saturates it."""
+    When ``out_norm_weight`` is given, the caller's rmsnorm OF THE RESULT (every
+    apply_attn_res call site in kimi_k3.py feeds one) is folded in too, so the
+    returned ``y`` is already normed and scaled.
+    """
     T, B, H = block_residual.shape
     Bp = B + 1
     do_add = add_hidden is not None
+    do_add2 = add_hidden2 is not None
+    if do_add2 and not do_add:
+        raise ValueError("add_hidden2 requires add_hidden")
+    out_norm = out_norm_weight is not None
     br = block_residual.contiguous()
     ps = prefix_sum.contiguous()
     sw = score_weight.contiguous()
     y = torch.empty((T, H), device=block_residual.device, dtype=prefix_sum.dtype)
-    # hs/pref pointers are always passed (triton needs a tensor); when not adding
-    # they alias ps and are never dereferenced (DO_ADD / WRITE_PREF are False).
-    if do_add:
-        hs = add_hidden.contiguous()
-        pref = torch.empty((T, H), device=block_residual.device, dtype=prefix_sum.dtype)
-    else:
-        hs = ps
-        pref = ps
-    BP = triton.next_power_of_2(Bp)
-    BLOCK_H = _ATTN_RES_BLOCK_H
-    nchunk = triton.cdiv(H, BLOCK_H)
+    ow = out_norm_weight.contiguous() if out_norm else sw
+    # hs/hs2/pref pointers are always passed (triton needs a tensor); when not
+    # adding they alias ps and are never dereferenced (DO_ADD / DO_ADD2 /
+    # WRITE_PREF are False).
+    hs = add_hidden.contiguous() if do_add else ps
+    hs2 = add_hidden2.contiguous() if do_add2 else ps
+    pref = torch.empty_like(ps) if do_add else ps
 
-    split, s, ns, nw = _pick_attn_res_config(T)
-    # S can't exceed the chunk count (a workgroup with no chunk to own is wasted).
-    s = min(s, nchunk)
-    if split and s > 1:
-        psq = torch.empty((T, s, BP), device=br.device, dtype=torch.float32)
-        pdot = torch.empty((T, s, BP), device=br.device, dtype=torch.float32)
-        _attn_res_reduce_kernel[(T, s)](
-            br,
-            ps,
-            sw,
-            psq,
-            pdot,
-            hs,
-            pref,
-            B,
-            H,
-            s,
-            br.stride(0),
-            br.stride(1),
-            ps.stride(0),
-            psq.stride(0),
-            psq.stride(1),
-            hs.stride(0),
-            pref.stride(0),
-            BP=BP,
-            BLOCK_H=BLOCK_H,
-            NS=ns,
-            num_warps=nw,
-            DO_ADD=do_add,
-            WRITE_PREF=do_add,
-        )
-        _attn_res_combine_kernel[(T,)](
-            br,
-            ps,
-            psq,
-            pdot,
-            y,
-            hs,
-            B,
-            Bp,
-            H,
-            s,
-            eps,
-            br.stride(0),
-            br.stride(1),
-            ps.stride(0),
-            psq.stride(0),
-            psq.stride(1),
-            y.stride(0),
-            hs.stride(0),
-            BP=BP,
-            BLOCK_H=BLOCK_H,
-            NS=ns,
-            num_warps=nw,
-            DO_ADD=do_add,
-        )
-        return y, (pref if do_add else prefix_sum)
-
+    nw, ns, bl = _pick_attn_res_config(T)
     _attn_res_fused_kernel[(T,)](
         br,
         ps,
         sw,
         y,
         hs,
+        hs2,
         pref,
+        ow,
         B,
         Bp,
         H,
         float(eps),
+        float(out_eps),
         br.stride(0),
         br.stride(1),
         ps.stride(0),
         y.stride(0),
         hs.stride(0),
+        hs2.stride(0),
         pref.stride(0),
-        BP=BP,
-        BLOCK_H=BLOCK_H,
-        NS=ns,
+        BL=bl,
+        BD=triton.next_power_of_2(H),
+        num_stages=ns,
         num_warps=nw,
         DO_ADD=do_add,
+        DO_ADD2=do_add2,
         WRITE_PREF=do_add,
+        OUT_NORM=out_norm,
     )
     return y, (pref if do_add else prefix_sum)
 
@@ -429,9 +248,16 @@ def _apply_attn_res_op(
     block_residual: torch.Tensor,
     score_weight: torch.Tensor,
     eps: float,
+    out_norm_weight: torch.Tensor | None = None,
+    out_eps: float = 1e-6,
 ) -> torch.Tensor:
     mixed_output, _ = _apply_attn_res_impl(
-        prefix_sum, block_residual, score_weight, eps
+        prefix_sum,
+        block_residual,
+        score_weight,
+        eps,
+        out_norm_weight=out_norm_weight,
+        out_eps=out_eps,
     )
     return mixed_output
 
@@ -441,6 +267,8 @@ def _apply_attn_res_op_fake(
     block_residual: torch.Tensor,
     score_weight: torch.Tensor,
     eps: float,
+    out_norm_weight: torch.Tensor | None = None,
+    out_eps: float = 1e-6,
 ) -> torch.Tensor:
     return torch.empty_like(prefix_sum)
 
@@ -459,9 +287,19 @@ def _apply_attn_res_add_op(
     score_weight: torch.Tensor,
     eps: float,
     add_hidden: torch.Tensor,
+    out_norm_weight: torch.Tensor | None = None,
+    out_eps: float = 1e-6,
+    add_hidden2: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return _apply_attn_res_impl(
-        prefix_sum, block_residual, score_weight, eps, add_hidden
+        prefix_sum,
+        block_residual,
+        score_weight,
+        eps,
+        add_hidden,
+        out_norm_weight=out_norm_weight,
+        out_eps=out_eps,
+        add_hidden2=add_hidden2,
     )
 
 
@@ -471,6 +309,9 @@ def _apply_attn_res_add_op_fake(
     score_weight: torch.Tensor,
     eps: float,
     add_hidden: torch.Tensor,
+    out_norm_weight: torch.Tensor | None = None,
+    out_eps: float = 1e-6,
+    add_hidden2: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return torch.empty_like(prefix_sum), torch.empty_like(prefix_sum)
 
@@ -490,15 +331,31 @@ def apply_attn_res(
     score_weight: torch.Tensor,
     eps: float,
     add_hidden: torch.Tensor | None = None,
+    out_norm_weight: torch.Tensor | None = None,
+    out_eps: float = 1e-6,
+    add_hidden2: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Dispatch an opaque custom op whose CUDA implementation selects by concrete T."""
+    """Dispatch an opaque custom op whose CUDA implementation selects by concrete T.
+
+    ``out_norm_weight`` folds the caller's rmsnorm of the result into the kernel;
+    the returned mixed output is then already normed and scaled by it.
+    ``add_hidden2`` folds a second addend into the prefix (see the impl)."""
     if add_hidden is None:
+        if add_hidden2 is not None:
+            raise ValueError("add_hidden2 requires add_hidden")
         return (
             torch.ops.aiter.kimi_k3_apply_attn_res(
-                prefix_sum, block_residual, score_weight, eps
+                prefix_sum, block_residual, score_weight, eps, out_norm_weight, out_eps
             ),
             prefix_sum,
         )
     return torch.ops.aiter.kimi_k3_apply_attn_res_add(
-        prefix_sum, block_residual, score_weight, eps, add_hidden
+        prefix_sum,
+        block_residual,
+        score_weight,
+        eps,
+        add_hidden,
+        out_norm_weight,
+        out_eps,
+        add_hidden2,
     )

--- a/atom/model_ops/kimi_k3/attention_residual.py
+++ b/atom/model_ops/kimi_k3/attention_residual.py
@@ -1,7 +1,36 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# This file contains code adapted from the flash-linear-attention project
+# (fla/ops/attnres/fused.py). The original source code was licensed under the
+# MIT license and included the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
 
-"""Fused attention-residual operations for Kimi-K3."""
+"""Fused attention-residual operations for Kimi-K3.
+
+The algorithm is flash-linear-attention's ``fused_attnres``
+(``fla/ops/attnres/fused.py``, MIT; read against fla 0.5.2), which is what the
+reference KDA model calls -- see ``fla/models/kda/modeling_kda.py:135``.
+Attention Residuals: https://arxiv.org/abs/2603.15031
+
+Four deliberate divergences from that reference:
+
+* ``residuals`` is a Sequence of separate ``[..., D]`` tensors there; here it is
+  one packed ``[T, B, H]`` block_residual plus ``prefix_sum`` read as the final
+  candidate. Not just cheaper -- their pointer-table gather cannot run on ROCm
+  at all (details at the ``Adapted from FLA`` note in the kernel body).
+* the caller's ``prefix_sum = prefix_sum + ...`` adds are folded into the last
+  candidate's on-load (``DO_ADD``/``DO_ADD2``), which fla leaves to the caller.
+  That fold is what lets the decoder layers defer their FFN and routed/shared
+  expert adds across the layer boundary.
+* ``score_weight`` arrives pre-multiplied: fla passes ``query`` and
+  ``rms_weight`` separately, while ``AttnRes`` folds their product once at load
+  time (see ``AttnRes.process_weights_after_loading``).
+* forward only -- ATOM is inference-only, so there is no bwd and no
+  ``checkpoint_level`` counterpart.
+"""
 
 from __future__ import annotations
 
@@ -73,10 +102,10 @@ if _HAS_TRITON:
         # Cost is registers: BD = next_pow2(H) floats of accumulator, 32 KB of VGPR
         # at H=7168, plus the [BL, BD] tile. BL is kept small for that reason.
         #
-        # Adapted from FLA's fused_attnres (fla/ops/attnres/fused.py, MIT).
-        # Theirs gathers from a tuple of separate residual tensors via a pointer
-        # table; ours indexes one contiguous [T, B, H] block_residual, which is
-        # both cheaper and necessary here -- the pointer-table form miscompiles on
+        # Adapted from FLA's fused_attnres (see the module docstring). Theirs
+        # gathers from a tuple of separate residual tensors via a pointer table;
+        # ours indexes one contiguous [T, B, H] block_residual, which is both
+        # cheaper and necessary here -- the pointer-table form miscompiles on
         # ROCm (TritonAMDGPUCanonicalizePointers rejects arith.select on
         # tensor<Nx!tt.ptr>), so their kernel cannot run on this backend at all.
         #
@@ -95,13 +124,13 @@ if _HAS_TRITON:
         # re-reading it per tile would undo the single-pass property.
         ps = tl.load(ps_ptr + t * stride_ps_t + o_d, mask=m_d, other=0.0).to(tl.float32)
         if DO_ADD:
-            ps += tl.load(
-                hs_ptr + t * stride_hs_t + o_d, mask=m_d, other=0.0
-            ).to(tl.float32)
+            ps += tl.load(hs_ptr + t * stride_hs_t + o_d, mask=m_d, other=0.0).to(
+                tl.float32
+            )
         if DO_ADD2:
-            ps += tl.load(
-                hs2_ptr + t * stride_hs2_t + o_d, mask=m_d, other=0.0
-            ).to(tl.float32)
+            ps += tl.load(hs2_ptr + t * stride_hs2_t + o_d, mask=m_d, other=0.0).to(
+                tl.float32
+            )
         if WRITE_PREF:
             tl.store(
                 pref_ptr + t * stride_pref_t + o_d,

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -28,6 +28,7 @@ from atom.config import Config, QuantizationConfig, get_current_atom_config
 # forwards (shared with deepseek_v2/v4). Imported for the registration only.
 from atom.model_ops import module_dispatch_ops as _module_dispatch_ops  # noqa: F401
 from atom.model_ops.attention_mla import MLAModules
+from atom.model_ops.attention_residual import AttnRes
 from atom.model_ops.base_attention import Attention
 from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.fla_ops.fused_sigmoid_gating import (
@@ -438,10 +439,29 @@ class KimiSparseMoeBlock(nn.Module):
             cc = get_current_atom_config().compilation_config
             cc.static_forward_context[self.prefix] = self
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Returns ``(routed, shared)``, left unsummed.
+
+        The caller's next apply_attn_res folds both into its prefix on-load, so
+        deferring the add here removes a whole [T, H] elementwise kernel and its
+        HBM round-trip per MoE layer. ``shared`` is None when there are no shared
+        experts, when the two branches had to be summed before a collective (see
+        `split_moe_forward`), or when the dual-stream path ran.
+        """
         if self._use_dual_stream:
-            return torch.ops.aiter.maybe_dual_stream_forward(hidden_states, self.prefix)
-        return self.single_stream_moe_forward(hidden_states)
+            # maybe_dual_stream_forward is a registered custom op, and torch's
+            # schema inference has no representation for a tuple return, so the
+            # deferred add can't cross that boundary. Both dispatch targets sum
+            # internally and the pair collapses to (summed, None). Cheap to give
+            # up: dual-stream only engages at <= ATOM_DUAL_STREAM_MOE_TOKEN_
+            # THRESHOLD tokens, where the [T, H] add it costs us is small.
+            summed = torch.ops.aiter.maybe_dual_stream_forward(
+                hidden_states, self.prefix
+            )
+            return summed, None
+        return self.split_moe_forward(hidden_states)
 
     def routed_expert_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Routed-expert path only. For the latent MoE this includes the routed
@@ -474,25 +494,48 @@ class KimiSparseMoeBlock(nn.Module):
         return routed_output
 
     def single_stream_moe_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Single-tensor dispatch target for `maybe_dual_stream_forward`.
+
+        The op's schema can't carry a tuple, so this sums what
+        `split_moe_forward` hands back. Only reached via the dual-stream
+        dispatcher; `forward` calls `split_moe_forward` directly otherwise.
+        """
+        routed, shared = self.split_moe_forward(hidden_states)
+        return routed if shared is None else routed + shared
+
+    def split_moe_forward(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Routed and shared branches, returned unsummed where deferring is
+        legal. See `forward` for why the add is worth deferring."""
         identity = hidden_states
         routed_output = self.routed_expert_forward(hidden_states)
         if self.use_latent_moe:
             if self.shared_experts is not None:
                 # Shared branch is TP-partial (down_proj is row-parallel); reduce
-                # it separately and add to the already-full routed output.
+                # it separately. Both branches are full after their own
+                # all-reduce, so the add between them is deferrable.
                 shared_output = self.shared_experts(identity)
                 if self.tp_size > 1:
                     shared_output = tensor_model_parallel_all_reduce(shared_output)
-                routed_output = routed_output + shared_output
-            return routed_output
+                return routed_output, shared_output
+            return routed_output, None
         # Non-latent path: routed experts and shared experts are both TP-partial
         # and everything after them is linear, so a single deferred all-reduce
         # over their sum is correct.
         if self.shared_experts is not None:
-            routed_output = routed_output + self.shared_experts(identity)
+            shared_output = self.shared_experts(identity)
+            if self.tp_size == 1:
+                # No collective to batch, so the add is free to defer.
+                return routed_output, shared_output
+            # With TP the branches must be summed BEFORE the all-reduce: both are
+            # partial here, and while all_reduce is linear (so reducing them
+            # separately would also be correct), that would cost two collectives
+            # to save one elementwise add. Sum first, hand back a single tensor.
+            routed_output = routed_output + shared_output
         if self.tp_size > 1:
             routed_output = tensor_model_parallel_all_reduce(routed_output)
-        return routed_output
+        return routed_output, None
 
     def dual_stream_moe_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # Queue routed pre-AR work first on the current stream, then run the
@@ -1285,7 +1328,6 @@ class KimiDecoderLayer(nn.Module):
             getattr(config, "attn_res_block_size", None) is not None
         )
         if self.use_attn_residuals:
-            self.attn_res_block_size = config.attn_res_block_size
             self.self_attention_res_norm = RMSNorm(
                 config.hidden_size,
                 eps=config.rms_norm_eps,
@@ -1310,23 +1352,39 @@ class KimiDecoderLayer(nn.Module):
                 quant_config=None,
                 prefix=f"{prefix}.mlp_res_proj",
             )
+        # Built in both modes: a disabled AttnRes is the ordinary pre-norm
+        # residual step, which is exactly what this layer used to open-code.
+        # Both sites feed a rmsnorm, so both fold it into the kernel's store.
+        # The projs/norms above stay the parameter owners; these only alias
+        # them (see AttnRes).
+        self.self_attention_attn_res = AttnRes(
+            getattr(self, "self_attention_res_proj", None),
+            getattr(self, "self_attention_res_norm", None),
+            out_norm=self.input_layernorm,
+            enabled=self.use_attn_residuals,
+            # Only this site banks the running prefix as a candidate.
+            block_size=getattr(config, "attn_res_block_size", None),
+            layer_idx=layer_num,
+        )
+        self.mlp_attn_res = AttnRes(
+            getattr(self, "mlp_res_proj", None),
+            getattr(self, "mlp_res_norm", None),
+            out_norm=self.post_attention_layernorm,
+            enabled=self.use_attn_residuals,
+        )
 
-    def _ffn(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def _ffn(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Run the FFN, leaving the MoE's routed/shared add to the caller.
+
+        The second tensor (when not None) is folded into the next
+        apply_attn_res's prefix as ``add_hidden2``, skipping a [T, H]
+        elementwise kernel. A dense mlp has nothing to defer.
+        """
         if hasattr(self, "block_sparse_moe"):
             return self.block_sparse_moe(hidden_states)
-        return self.mlp(hidden_states)
-
-    def process_weights_after_loading(self) -> None:
-        # Fold each attn-residual (norm.weight * proj.weight) into a single
-        # static score vector consumed by apply_attn_res (see
-        # _attn_res_score_weight). Both operands are load-time constants.
-        if not self.use_attn_residuals:
-            return
-        for proj, norm in (
-            (self.self_attention_res_proj, self.self_attention_res_norm),
-            (self.mlp_res_proj, self.mlp_res_norm),
-        ):
-            proj.score_weight = _attn_res_score_weight(proj, norm)
+        return self.mlp(hidden_states), None
 
     def forward(
         self,
@@ -1334,94 +1392,33 @@ class KimiDecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         block_residual: torch.Tensor | None = None,
         pending_add: torch.Tensor | None = None,
+        pending_add2: torch.Tensor | None = None,
     ):
-        if not self.use_attn_residuals:
-            if pending_add is not None:
-                hidden_states = hidden_states + pending_add
-            residual = hidden_states
-            hidden_states = self.input_layernorm(hidden_states)
-            if self.is_linear_attn:
-                hidden_states = self.self_attn(hidden_states)
-            else:
-                hidden_states = self.self_attn(positions, hidden_states)
-            hidden_states = residual + hidden_states
-            residual = hidden_states
-            hidden_states = self.post_attention_layernorm(hidden_states)
-            hidden_states = self._ffn(hidden_states)
-            return residual + hidden_states, None, block_residual
+        # Both sites go through AttnRes in either mode: with residuals enabled
+        # it mixes the block candidates, and without it degenerates to the
+        # ordinary pre-norm residual step. input_layernorm and
+        # post_attention_layernorm are its out_norms, so hidden_states comes
+        # back already normed at both.
+        hidden_states, prefix_sum = self.self_attention_attn_res(
+            hidden_states, block_residual, pending_add, pending_add2
+        )
+        block_residual, prefix_sum = self.self_attention_attn_res.maybe_close_block(
+            prefix_sum, block_residual
+        )
 
-        prefix_sum = hidden_states
-        if block_residual is not None and block_residual.shape[1] > 0:
-            hidden_states, prefix_sum = _apply_attn_res(
-                prefix_sum,
-                block_residual,
-                self.self_attention_res_proj,
-                self.self_attention_res_norm,
-                add_hidden=pending_add,
-            )
-        elif pending_add is not None:
-            prefix_sum = prefix_sum + pending_add
-            hidden_states = prefix_sum
-        if self.layer_idx % self.attn_res_block_size == 0:
-            assert block_residual is not None
-            block_residual = torch.cat([block_residual, prefix_sum.unsqueeze(1)], dim=1)
-            prefix_sum = None
-
-        hidden_states = self.input_layernorm(hidden_states)
         if self.is_linear_attn:
             hidden_states = self.self_attn(hidden_states)
         else:
             hidden_states = self.self_attn(positions, hidden_states)
 
-        if prefix_sum is None:
-            prefix_sum = hidden_states
-            hidden_states, prefix_sum = _apply_attn_res(
-                prefix_sum, block_residual, self.mlp_res_proj, self.mlp_res_norm
-            )
-        else:
-            # Fold prefix_sum = prefix_sum + hidden_states into the fused kernel.
-            hidden_states, prefix_sum = _apply_attn_res(
-                prefix_sum,
-                block_residual,
-                self.mlp_res_proj,
-                self.mlp_res_norm,
-                add_hidden=hidden_states,
-            )
-        hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self._ffn(hidden_states)
-        if prefix_sum is None:
-            return hidden_states, None, block_residual
-        return prefix_sum, hidden_states, block_residual
-
-
-def _attn_res_score_weight(proj: ReplicatedLinear, norm: RMSNorm) -> torch.Tensor:
-    """Fold the static rmsnorm gain and projection into one [H] score vector.
-
-    Both operands are load-time constants, so this is precomputed once in
-    ``process_weights_after_loading`` and cached on ``proj.score_weight``; the
-    apply_attn_res kernel then reads a single vector per H-chunk instead of
-    reloading norm.weight and proj.weight and multiplying them every forward.
-    """
-    return (norm.weight.float() * proj.weight.squeeze(0).float()).contiguous()
-
-
-def _apply_attn_res(
-    prefix_sum: torch.Tensor,
-    block_residual: torch.Tensor,
-    proj: ReplicatedLinear,
-    norm: RMSNorm,
-    add_hidden: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    # Returns (mixed_output, prefix_out). When add_hidden is given the fused path
-    # folds ``prefix_sum = prefix_sum + add_hidden`` into the kernel and returns
-    # the summed prefix; otherwise prefix_out is prefix_sum unchanged.
-    eps = getattr(norm, "variance_epsilon", getattr(norm, "eps", 1e-6))
-    score_weight = getattr(proj, "score_weight", None)
-    if score_weight is None:
-        score_weight = _attn_res_score_weight(proj, norm)
-    from atom.model_ops.kimi_k3 import apply_attn_res
-
-    return apply_attn_res(prefix_sum, block_residual, score_weight, eps, add_hidden)
+        hidden_states, prefix_sum = self.mlp_attn_res(
+            prefix_sum, block_residual, hidden_states
+        )
+        # Routed and shared expert outputs come back unsummed: the next layer's
+        # attn_res kernel folds both into its prefix on-load, so the [T, H]
+        # elementwise add that would combine them here never runs.
+        hidden_states, shared = self._ffn(hidden_states)
+        return prefix_sum, hidden_states, shared, block_residual
 
 
 @support_torch_compile
@@ -1459,11 +1456,12 @@ class KimiLinearModel(nn.Module):
             prefix=f"{prefix}.layers",
             layer_num_offset=0,
         )
+        use_attn_residuals = getattr(config, "attn_res_block_size", None) is not None
         if get_pp_group().is_last_rank:
             self.norm = RMSNorm(
                 config.hidden_size, eps=config.rms_norm_eps, prefix=f"{prefix}.norm"
             )
-            if getattr(config, "attn_res_block_size", None) is not None:
+            if use_attn_residuals:
                 self.output_attn_res_norm = RMSNorm(
                     config.hidden_size,
                     eps=config.rms_norm_eps,
@@ -1476,21 +1474,21 @@ class KimiLinearModel(nn.Module):
                     quant_config=None,
                     prefix=f"{prefix}.output_attn_res_proj",
                 )
+            # self.norm folds into the kernel's store, so the mix it returns is
+            # the model's final hidden state. Disabled, this is just self.norm
+            # applied to the pending adds -- the old non-residual tail.
+            self.output_attn_res = AttnRes(
+                getattr(self, "output_attn_res_proj", None),
+                getattr(self, "output_attn_res_norm", None),
+                out_norm=self.norm,
+                enabled=use_attn_residuals,
+            )
         else:
             self.norm = PPMissingLayer()
 
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "block_residual"], config.hidden_size
         )
-
-    def process_weights_after_loading(self) -> None:
-        # Fold the final output attn-residual (norm.weight * proj.weight) into a
-        # single static score vector for apply_attn_res. Present only on the last
-        # PP rank when attn residuals are enabled.
-        if hasattr(self, "output_attn_res_proj"):
-            self.output_attn_res_proj.score_weight = _attn_res_score_weight(
-                self.output_attn_res_proj, self.output_attn_res_norm
-            )
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -1520,32 +1518,31 @@ class KimiLinearModel(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             block_residual = intermediate_tensors["block_residual"]
 
-        pending_add = None
+        # Each layer hands its FFN output back unapplied (pending_add), and an MoE
+        # layer hands its shared-expert output back separately (pending_add2); the
+        # next layer's attn_res kernel folds both into its prefix on-load.
+        pending_add = pending_add2 = None
         for layer in self.layers[self.start_layer : self.end_layer]:
-            hidden_states, pending_add, block_residual = layer(
+            hidden_states, pending_add, pending_add2, block_residual = layer(
                 positions,
                 hidden_states,
                 block_residual,
                 pending_add=pending_add,
+                pending_add2=pending_add2,
             )
 
         if not get_pp_group().is_last_rank:
             if pending_add is not None:
                 hidden_states = hidden_states + pending_add
+            if pending_add2 is not None:
+                hidden_states = hidden_states + pending_add2
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "block_residual": block_residual}
             )
-        if getattr(self.config, "attn_res_block_size", None) is not None:
-            hidden_states, _ = _apply_attn_res(
-                hidden_states,
-                block_residual,
-                self.output_attn_res_proj,
-                self.output_attn_res_norm,
-                add_hidden=pending_add,
-            )
-        elif pending_add is not None:
-            hidden_states = hidden_states + pending_add
-        return self.norm(hidden_states)
+        hidden_states, _ = self.output_attn_res(
+            hidden_states, block_residual, pending_add, pending_add2
+        )
+        return hidden_states
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return FusedMoE.make_expert_params_mapping(

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -1420,6 +1420,34 @@ class KimiDecoderLayer(nn.Module):
         hidden_states, shared = self._ffn(hidden_states)
         return prefix_sum, hidden_states, shared, block_residual
 
+    @staticmethod
+    def aux_hidden_state(output: tuple) -> torch.Tensor | None:
+        """Reconstruct this layer's post-layer hidden state from ``forward``'s
+        return, for a drafter tapping it as an aux hidden state.
+
+        Every DSpark draft is trained on the HF reference's
+        ``output.hidden_states[layer_idx + 1]`` -- the plain residual stream
+        after this layer, which the reference forms as
+        ``prefix_sum = prefix_sum + hidden_states`` before returning. forward()
+        deliberately does not: it hands the FFN output back unapplied so the
+        NEXT layer's attn_res kernel can fold it into its on-load, and an MoE
+        layer defers its routed and shared outputs separately so that same fold
+        absorbs their sum too. So add the pendings back here. Each is None on
+        the layers that already folded it in.
+
+        This lives on the layer rather than in the drafter because it is a
+        property of THIS layer's return protocol -- it has to change in lockstep
+        with forward(), and any drafter trained against a Kimi-K3 target needs
+        the same reconstruction.
+        """
+        prefix_sum, *pendings, _block_residual = output
+        if prefix_sum is None:
+            return None
+        for pending in pendings:
+            if pending is not None:
+                prefix_sum = prefix_sum + pending
+        return prefix_sum
+
 
 @support_torch_compile
 class KimiLinearModel(nn.Module):

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -241,17 +241,22 @@ class DSparkProposer(Drafter):
                 residual = block.hc_post(x_prev, residual, post, comb)
             return residual.mean(dim=1)
 
-        # Kimi-K3: (prefix_sum, pending_add, block_residual). ATOM's port defers
-        # the FFN residual add across the layer boundary so the next layer can
-        # fuse it into apply_attn_res; the HF reference adds it before returning
+        # Kimi-K3: (prefix_sum, pending_add, pending_add2, block_residual). ATOM's
+        # port defers the FFN residual add across the layer boundary so the next
+        # layer can fuse it into apply_attn_res, and an MoE layer defers its routed
+        # and shared expert outputs SEPARATELY (pending_add2) so that fold absorbs
+        # their sum too. The HF reference adds all of it before returning
         # (`prefix_sum = prefix_sum + hidden_states`), and THAT sum is what
         # transformers records and what the draft was trained on. So add it back.
-        # `pending_add` is None on the layers that already folded it in.
+        # Both pendings are None on the layers that already folded them in.
         if isinstance(output, tuple):
-            carrier, pending = output[0], output[1]
+            carrier = output[0]
             if carrier is None:
                 return None
-            return carrier if pending is None else carrier + pending
+            for pending in output[1:-1]:
+                if pending is not None:
+                    carrier = carrier + pending
+            return carrier
 
         # Plain residual stream (no special bookkeeping).
         return output

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -228,6 +228,13 @@ class DSparkProposer(Drafter):
         Returning ``None`` skips the capture for this call (the base hook
         treats it as "nothing to record").
         """
+        # A target that bookkeeps its residual stream in a non-obvious way can
+        # own the reconstruction itself; preferred, since it then changes in
+        # lockstep with that layer's forward(). Kimi-K3 does this.
+        own = getattr(block, "aux_hidden_state", None)
+        if own is not None:
+            return own(output)
+
         # DeepSeek-V4: an HCState carrying the multi-hidden-connection residual
         # [N, hc, dim]; the aux tensor is its mean over the hc axis.
         if hasattr(output, "residual"):
@@ -241,22 +248,20 @@ class DSparkProposer(Drafter):
                 residual = block.hc_post(x_prev, residual, post, comb)
             return residual.mean(dim=1)
 
-        # Kimi-K3: (prefix_sum, pending_add, pending_add2, block_residual). ATOM's
-        # port defers the FFN residual add across the layer boundary so the next
-        # layer can fuse it into apply_attn_res, and an MoE layer defers its routed
-        # and shared expert outputs SEPARATELY (pending_add2) so that fold absorbs
-        # their sum too. The HF reference adds all of it before returning
-        # (`prefix_sum = prefix_sum + hidden_states`), and THAT sum is what
-        # transformers records and what the draft was trained on. So add it back.
-        # Both pendings are None on the layers that already folded them in.
+        # A tuple means the layer carries residual bookkeeping we cannot
+        # interpret from here -- which component is the residual stream, and
+        # which are deferred addends, is that layer's private convention (K3
+        # returns four tensors, three of which must be summed). Guessing would
+        # feed the draft a silently wrong aux tensor, so require the target to
+        # say. Fail loudly instead.
         if isinstance(output, tuple):
-            carrier = output[0]
-            if carrier is None:
-                return None
-            for pending in output[1:-1]:
-                if pending is not None:
-                    carrier = carrier + pending
-            return carrier
+            raise TypeError(
+                f"{type(block).__name__}.forward returns a "
+                f"{len(output)}-tuple but the layer defines no "
+                "`aux_hidden_state(output)`. A drafter cannot reconstruct the "
+                "post-layer hidden state from an unknown tuple convention -- "
+                "add that method to the layer (see KimiDecoderLayer)."
+            )
 
         # Plain residual stream (no special bookkeeping).
         return output


### PR DESCRIPTION
## Summary

Kimi-K3 runs 186 `apply_attn_res` calls per forward (93 layers x 2 sites). This
rewrites that kernel from two HBM passes to one, folds the surrounding rmsnorm
and elementwise adds into it, and extracts the call-site branching into an
`AttnRes` layer.

Three independent changes, each standing on its own.

### 1. Two-pass -> single-pass kernel

`atom/model_ops/kimi_k3/attention_residual.py`

The old kernel tiled over `H`, which forced two passes: softmax probabilities
aren't known until the `H`-reduction completes, so the weighted-sum combine had
to re-read every candidate. Retiling over the *candidate* axis (`BL`) lets the
whole `[BD]` output live in registers, so the softmax runs online, flash-style —
each tile rescales the accumulator by `exp(m_prev - m_new)`. **Every candidate is
read exactly once.**

Cost is registers: `BD = next_pow2(H)` floats ~= 32 KB VGPR at H=7168, so `BL` is
kept small.

### 2. Fusions the single-pass form makes free

- `OUT_NORM` — the caller's output rmsnorm folds into the store. `y` is already
  formed in registers when the loop ends, so it costs nothing. The H-tiled
  version needed a *third* pass for this plus a token-count gate to decide when
  it stopped paying; both are gone.
- `DO_ADD2` — a second addend on-load, so an MoE layer hands back its routed and
  shared expert outputs **unsummed** and the next layer's kernel absorbs the sum.
  Removes a `[T, H]` elementwise kernel on each of the 92 MoE layers.

### 3. `AttnRes` layer

New file: `atom/model_ops/attention_residual.py`

`KimiDecoderLayer.forward` had two near-duplicate residual paths — one for
`use_attn_residuals`, one open-coding the ordinary pre-norm step — plus branching
on whether any candidates existed yet. All of it moved into `AttnRes`, which
decides on three axes (`enabled`, empty-vs-populated `block_residual`, `out_norm`
present) and presents one shape to callers: hand it prefix + block + pending
addends, get `(mixed_output, prefix_out)`.

**A disabled `AttnRes` *is* the ordinary pre-norm residual step** — that's what
collapsed the two paths into one rather than adding a third.

## Results

Correctness, 120 configs across the real K3 shape space (T in 1..2048, B in
1..12, all addend combinations):

```
correctness: 120/120 configs ok, worst y rel err 0.00389
```

Disabled path, bit-exact against the deleted hand-written branch transcribed
verbatim from HEAD:

```
disabled-path parity: 12/12 exact
5-layer chain + model tail: exact
PARITY OK
```

In-graph kernel time (H=7168, B=8, both addends + out-norm folded):

| T | us |
|---:|---:|
| 1 | 9.87 |
| 8 | 10.09 |
| 128 | 10.59 |
| 512 | 21.96 |
| 2048 | 93.42 |

The second addend costs ~0.2 us inside the kernel vs ~2.7 us as a standalone
`[T, H]` add — ~250 us/forward saved across 92 MoE layers at decode shapes.

## Notable side effects

- **`KimiSparseMoeBlock.forward` now returns `(routed, shared)`**, unsummed.
  `forward_split`/`_forward_impl` collapsed into it.
- **`DSparkProposer._extract_layer_hidden` updated**
  (`atom/spec_decode/dspark_proposer.py`). Aux-capture hooks sit on *decoder
  layers*, so they observe the deferred pendings before any later kernel folds
  them. The extractor must reconstruct the sum the HF reference records, or the
  draft gets a wrong aux hidden state — a silent acceptance-rate regression, not
  a crash. The new form (`output[1:-1]`) is arity-independent; the old
  `output[1]` hardcoded the tuple length, which is exactly why it broke.
- Deleted: `_attn_res_score_weight`, `_apply_attn_res`, two hand-written
  `process_weights_after_loading` hooks, the `_ffn`/`_ffn_split` split, and the
  whole `if not self.use_attn_residuals:` branch.

## Attribution

The kernel is adapted from flash-linear-attention's `fused_attnres`
(`fla/ops/attnres/fused.py`, MIT, fla 0.5.2) — [Attention
Residuals](https://arxiv.org/abs/2603.15031). Upstream copyright notice added
following the convention already used in `atom/model_ops/fla_ops/`.

Four documented divergences; notably **FLA's kernel cannot run on ROCm at all** —
its pointer-table gather miscompiles (`TritonAMDGPUCanonicalizePointers` rejects
`arith.select` on `tensor<Nx!tt.ptr>`), so the packed `[T, B, H]` indexing here
is necessary, not merely faster.
## Test Result
gsm8k test:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9560|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9553|±  |0.0057|
```



this PR:
<img width="1511" height="367" alt="image" src="https://github.com/user-attachments/assets/b1911560-b579-4d65-a47f-b2dcadb9886b" />
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  194.93    
Total input tokens:                      1048576   
Total generated tokens:                  131072    
Request throughput (req/s):              0.66      
Output token throughput (tok/s):         672.39    
Peak output token throughput (tok/s):    1056.00   
Peak concurrent requests:                35.00     
Total token throughput (tok/s):          6051.51   
---------------Time to First Token----------------
Mean TTFT (ms):                          4169.48   
Median TTFT (ms):                        3110.63   
P99 TTFT (ms):                           16570.62  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.51     
Median TPOT (ms):                        45.30     
P99 TPOT (ms):                           47.10     
---------------Inter-token Latency----------------
Mean ITL (ms):                           43.51     
Median ITL (ms):                         31.49     
P99 ITL (ms):                            1034.26   
==================================================
```
before:
<img width="1350" height="446" alt="image" src="https://github.com/user-attachments/assets/7141ae2f-95ea-4753-883c-61cdaa881adf" />
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  204.72    
Total input tokens:                      1048576   
Total generated tokens:                  131072    
Request throughput (req/s):              0.63      
Output token throughput (tok/s):         640.24    
Peak output token throughput (tok/s):    992.00    
Peak concurrent requests:                36.00     
Total token throughput (tok/s):          5762.12   
---------------Time to First Token----------------
Mean TTFT (ms):                          4462.52   
Median TTFT (ms):                        3228.30   
P99 TTFT (ms):                           17117.50  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          45.61     
Median TPOT (ms):                        47.28     
P99 TPOT (ms):                           49.43     
---------------Inter-token Latency----------------
Mean ITL (ms):                           45.61     
Median ITL (ms):                         33.02     
P99 ITL (ms):                            1067.81   
==================================================
```
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
