### PR TITLE
[vLLM-ATOM] Support DSpark speculative decoding for Kimi-K3

### DIFF
--- a/atom/plugin/vllm/attention/layer_mla.py
+++ b/atom/plugin/vllm/attention/layer_mla.py
@@ -946,6 +946,12 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
         q = q[:num_actual_toks, ...]
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...]
+        # Model runner V2 sizes slot_mapping to the CUDA-graph token width and
+        # marks the tail with PAD_SLOT_ID, but leaves num_actual_tokens unpadded
+        # on the piecewise path; V1 never pads it. The cache kernels launch one
+        # block per slot and index q/kv by that block, so slot_mapping must not
+        # outrun the tensors sliced above. Same trim layer_mha already applies.
+        slot_mapping = attn_metadata.slot_mapping[:num_actual_toks]
 
         decode_q = q[:num_decode_tokens]
         prefill_q = q[num_decode_tokens:]
@@ -973,7 +979,7 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                     k_c_normed,
                     self.rotary_emb_cos_sin_cache,
                     self.rotary_emb.is_neox_style,
-                    attn_metadata.slot_mapping,
+                    slot_mapping,
                     kv_cache,
                     self.kv_cache_dtype,
                     self._k_scale,
@@ -985,7 +991,7 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                         k_c_normed,
                         k_pe.squeeze(1),
                         kv_cache,
-                        attn_metadata.slot_mapping.flatten(),
+                        slot_mapping.flatten(),
                         kv_cache_dtype=self.kv_cache_dtype,
                         scale=self._k_scale,
                     )
@@ -1066,7 +1072,7 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                         self.kv_lora_rank + self.qk_rope_head_dim,
                     ),
                     decode_q,
-                    attn_metadata.slot_mapping,
+                    slot_mapping,
                     self._k_scale,
                     self._q_scale,
                     positions,
@@ -1236,6 +1242,7 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
         q = q[:num_actual_toks, ...]
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...].unsqueeze(1)
+        slot_mapping = sparse_meta.slot_mapping[:num_actual_toks]
 
         positions = None
         if self._is_vllm_forward_context_available():
@@ -1314,7 +1321,7 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                     kv_cache.shape[0], -1, self.kv_lora_rank + self.qk_rope_head_dim
                 ),
                 q_out,
-                sparse_meta.slot_mapping,
+                slot_mapping,
                 self._k_scale,
                 self._q_scale,
                 positions,
@@ -1372,11 +1379,60 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
         )
         return self.o_proj(output)
 
+    def pin_kv_cache_dtype(self, kv_cache_dtype: str) -> None:
+        """Cache in `kv_cache_dtype` rather than the engine-wide dtype.
+
+        Layers otherwise take the engine's `--kv-cache-dtype`, which is right
+        for anything sharing the engine's pool. A draft that owns a separate
+        pool in another dtype re-pins it here, so that the dtype-driven
+        dispatch -- the fp8 decode overload, the cache-write kernel, aiter's
+        fp8 split-KV table -- matches the pool the layer actually reads.
+        """
+        from vllm.config import get_current_vllm_config
+        from vllm.utils.torch_utils import kv_cache_dtype_str_to_dtype
+
+        is_fp8 = kv_cache_dtype.startswith("fp8")
+        self.kv_cache_dtype = "fp8" if is_fp8 else "auto"
+        self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
+            kv_cache_dtype if is_fp8 else "auto",
+            get_current_vllm_config().model_config,
+        )
+
     def get_kv_cache_spec(self, vllm_config):
+        from vllm.utils.torch_utils import (
+            get_dtype_size,
+            kv_cache_dtype_str_to_dtype,
+        )
         from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
+        block_size = vllm_config.cache_config.block_size
+        if getattr(self, "align_page_size_to_engine_dtype", False):
+            # This layer caches in a different dtype than the engine's, so at a
+            # shared block size its pages would be a different size than
+            # everyone else's -- and vLLM allocates a single page size across
+            # all KV cache groups, sizing it to the largest. Scaling the block
+            # size by the inverse dtype ratio makes the pages match exactly.
+            #
+            # Read the block size here rather than at construction: hybrid
+            # models raise it afterwards to line attention pages up with mamba
+            # state pages.
+            engine_element_size = get_dtype_size(
+                kv_cache_dtype_str_to_dtype(
+                    vllm_config.cache_config.cache_dtype,
+                    vllm_config.model_config,
+                )
+            )
+            element_size = get_dtype_size(self.kv_cache_torch_dtype)
+            scaled = block_size * engine_element_size
+            if scaled % element_size:
+                raise ValueError(
+                    f"{self.layer_name}: a {element_size}-byte cache dtype "
+                    f"cannot be page-aligned to the engine's at "
+                    f"block_size={block_size}."
+                )
+            block_size = scaled // element_size
         return MLAAttentionSpec(
-            block_size=vllm_config.cache_config.block_size,
+            block_size=block_size,
             num_kv_heads=1,
             head_size=self.head_size,
             dtype=self.kv_cache_torch_dtype,

--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from dataclasses import dataclass
 from typing import Optional
 
@@ -29,6 +30,10 @@ logger = logging.getLogger("atom")
 
 _PARTITION_SIZE_ROCM = 256
 _CP_TOKENS_PER_ITER_ROCM = 32 * 1024
+
+# aiter's persistent MLA work plan, matching ATOM's native decode settings.
+_MLA_FAST_MODE = True
+_MLA_MAX_SPLIT_PER_BATCH = 16
 
 
 def get_aiter_kv_cache_dtype(config) -> torch.dtype:
@@ -1010,6 +1015,11 @@ class AiterMhaMetadataBuilderForVllm(AttentionMetadataBuilder):
 class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
     """vLLM-only dense MLA metadata builder."""
 
+    # Multi-token (speculative verify) decode batches are uniform in shape, so
+    # they replay from a full decode graph. vLLM takes the minimum support
+    # across every attention backend, and anything below UNIFORM_BATCH here
+    # downgrades the whole model -- the target's verify included -- to
+    # piecewise.
     _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
     reorder_batch_threshold = 1
     query_len_support = QueryLenSupport.UNIFORM
@@ -1085,6 +1095,44 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
         )
         self.qo_indptr = torch.zeros(max_num_reqs + 1, dtype=torch.int32, device=device)
 
+        # split_decodes_and_prefills routes every request whose query length is
+        # within reorder_batch_threshold to _build_decode, so that threshold is
+        # the widest query the persistent work descriptors below ever have to
+        # hold. It covers the speculative verify, and under parallel drafting
+        # it also covers short prompts, whose prefill lands in the decode split.
+        # Sizing the descriptors for a 1-token decode while
+        # _set_mla_persistent_worker_buffers fills them at the real width
+        # overflows the plan, and the persistent kernel then spins forever on a
+        # work queue whose indptr disagrees with its work set.
+        self.max_qo_len_capacity = self.reorder_batch_threshold
+
+        # The plan aiter asks for is not monotonic in the query length -- bf16
+        # wants the doubled one from 5 to 7 and the small one again at 8 -- so
+        # take the worst case over every length a step can present.
+        _infos = [
+            get_mla_metadata_info_v1(
+                max_num_reqs,
+                qo_len,
+                self.persistent_num_heads,
+                self.dtype_q,
+                self.dtype_kv,
+                is_sparse=False,
+                fast_mode=_MLA_FAST_MODE,
+                max_split_per_batch=_MLA_MAX_SPLIT_PER_BATCH,
+            )
+            for qo_len in range(1, self.max_qo_len_capacity + 1)
+        ]
+
+        def _largest(slot: int):
+            return max(
+                (info[slot] for info in _infos),
+                key=lambda size_and_type: math.prod(
+                    (size_and_type[0],)
+                    if isinstance(size_and_type[0], int)
+                    else size_and_type[0]
+                ),
+            )
+
         (
             (work_meta_data_size, work_meta_data_type),
             (work_indptr_size, work_indptr_type),
@@ -1092,14 +1140,13 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
             (reduce_indptr_size, reduce_indptr_type),
             (reduce_final_map_size, reduce_final_map_type),
             (reduce_partial_map_size, reduce_partial_map_type),
-        ) = get_mla_metadata_info_v1(
-            max_num_reqs,
-            1,
-            self.persistent_num_heads,
-            self.dtype_q,
-            self.dtype_kv,
-            is_sparse=False,
-            fast_mode=True,
+        ) = (
+            _largest(0),
+            _largest(1),
+            _largest(2),
+            _largest(3),
+            _largest(4),
+            _largest(5),
         )
 
         self.mla_persistent_metadata = {
@@ -1172,8 +1219,8 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
             "kv_granularity": max(self.block_size, 16),
             "max_seqlen_qo": max_q_len,
             "uni_seqlen_qo": max_q_len,
-            "fast_mode": 1,
-            "max_split_per_batch": 16,
+            "fast_mode": int(_MLA_FAST_MODE),
+            "max_split_per_batch": _MLA_MAX_SPLIT_PER_BATCH,
         }
         var = self.mla_persistent_metadata
         work_meta_data = var["work_meta_data"]
@@ -1223,18 +1270,39 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
         device = self.device
         num_reqs = seq_lens_device.size(0)
 
+        # Slicing past the end silently truncates, which would hand the metadata
+        # kernel a bs it has no indptr entries for and wedge the persistent kernel.
+        assert num_reqs + 1 <= self.paged_kv_indptr.numel(), (
+            f"decode batch of {num_reqs} requests exceeds the MLA metadata "
+            f"capacity of {self.paged_kv_indptr.numel() - 1}"
+        )
+
         paged_kv_last_page_len = self.paged_kv_last_page_len[:num_reqs]
 
+        qo_len = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+        max_qo_len = qo_len.max().item() if qo_len.numel() > 0 else 1
+
+        # A full decode graph replays at the request count it was captured on,
+        # so vLLM pads the batch with slots that carry no query rows and no
+        # sequence. The persistent work plan is laid out for a uniform query
+        # length, and those empty slots leave the kernel waiting on partials
+        # nothing ever produces. Hand the padding one page of KV and its full
+        # share of query rows, the same shape the graph was captured on -- the
+        # rows it computes land in padded output slots nothing reads. Single
+        # token decode already does this via the arange below, which is why it
+        # replays from a full graph today.
+        num_padded_slots = int((qo_len == 0).sum()) if max_qo_len > 1 else 0
+        seq_lens_for_pages = (
+            seq_lens_device.clamp(min=1) if num_padded_slots else seq_lens_device
+        )
+
         torch.cumsum(
-            seq_lens_device,
+            seq_lens_for_pages,
             dim=0,
             dtype=torch.int32,
             out=self.paged_kv_indptr[1 : 1 + num_reqs],
         )
         paged_kv_indptr = self.paged_kv_indptr[: 1 + num_reqs]
-
-        qo_len = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-        max_qo_len = qo_len.max().item() if qo_len.numel() > 0 else 1
 
         kv_indices_generate_triton(
             block_table_tensor,
@@ -1263,6 +1331,18 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
                     self.qo_indptr[num_reqs + 1 :] = num_reqs
                 self._qo_indptr_arange_ready = True
                 self._qo_indptr_arange_n = num_reqs
+        elif num_padded_slots:
+            self._qo_indptr_arange_ready = False
+            torch.arange(
+                0,
+                (num_reqs + 1) * max_qo_len,
+                max_qo_len,
+                dtype=torch.int32,
+                device=device,
+                out=self.qo_indptr[: num_reqs + 1],
+            )
+            if 1 + num_reqs < self.qo_indptr.shape[0]:
+                self.qo_indptr[1 + num_reqs :] = num_reqs * max_qo_len
         else:
             self._qo_indptr_arange_ready = False
             self.qo_indptr[: 1 + num_reqs].copy_(
@@ -1283,6 +1363,14 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
             and not self.dcp_persistent_supported
         ):
             use_persistent_metadata = False
+        # Overflowing the work descriptors wedges the persistent kernel in a
+        # spin that no timeout recovers from, so fail loudly instead. Falling
+        # back to the non-persistent kernel is not an option: asm_mla.cu rejects
+        # gqa_ratio=16 fp8 decode with qo_len > 4 outside persistent mode.
+        assert not use_persistent_metadata or max_qo_len <= self.max_qo_len_capacity, (
+            f"decode query length {max_qo_len} exceeds the persistent MLA "
+            f"work-descriptor capacity {self.max_qo_len_capacity}"
+        )
         if use_persistent_metadata:
             ctx_mla_ps = self._set_mla_persistent_worker_buffers(
                 num_reqs,

--- a/atom/plugin/vllm/model_wrapper.py
+++ b/atom/plugin/vllm/model_wrapper.py
@@ -164,7 +164,12 @@ _ATOM_MODEL_CLASSES: dict[str, str] = {
     "MiniMaxM3SparseForConditionalGeneration": "atom.models.minimax_m3:MiniMaxM3SparseForConditionalGeneration",
     "Eagle3LlamaModel": "atom.models.eagle3_llama:Eagle3LlamaModel",
     "Eagle3DeepseekMLAModel": "atom.models.eagle3_deepseek_mla:Eagle3DeepseekMLAModel",
+    "K3DSparkModel": "atom.plugin.vllm.models.kimi_k3_dspark:KimiK3DSparkDraft",
 }
+
+# DSpark drafts ship as their own checkpoint, so like EAGLE3 they are built from
+# the draft's hf_config and their layers are numbered past the target's.
+_DSPARK_DRAFT_ARCHS: frozenset[str] = frozenset({"K3DSparkModel"})
 
 
 def _normalize_atom_model_arch(model_arch: str) -> str:
@@ -264,7 +269,7 @@ def _select_model_arch(vllm_config: VllmConfig) -> str:
         model_tag = getattr(
             getattr(vllm_config, "compilation_config", None), "model_tag", None
         )
-    if model_tag in {"eagle_head", "draft_model", "drafter"}:
+    if model_tag in {"eagle_head", "draft_model", "drafter", "dspark_head"}:
         logger.info(
             f"Use draft model architecture {draft_arch} for speculative tag {model_tag}"
         )
@@ -360,12 +365,14 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
         self.vllm_config = vllm_config
         self.is_mtp = False
         self.is_eagle3 = False
+        self.is_dspark = False
         self._mtp_target_hidden_states = None
         speculative_config = getattr(vllm_config, "speculative_config", None)
         if speculative_config is not None:
             spec_method = speculative_config.method
             self.is_mtp = spec_method == "mtp"
             self.is_eagle3 = spec_method == "eagle3"
+            self.is_dspark = spec_method == "dspark"
 
         main_model_arch = vllm_config.model_config.architectures[0]
         selected_model_arch = _select_model_arch(vllm_config)
@@ -380,14 +387,23 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
             and selected_model_arch != main_model_arch
             and _is_eagle3_draft_arch(selected_model_arch)
         )
-        self.is_spec_draft_model = self.is_mtp_draft_model or self.is_eagle3_draft_model
+        self.is_dspark_draft_model = (
+            self.is_dspark and selected_model_arch in _DSPARK_DRAFT_ARCHS
+        )
+        # Both are standalone checkpoints configured off their own hf_config.
+        self._is_standalone_draft = (
+            self.is_eagle3_draft_model or self.is_dspark_draft_model
+        )
+        self.is_spec_draft_model = self.is_mtp_draft_model or self._is_standalone_draft
 
-        if self.is_eagle3_draft_model and draft_hf_config is None:
-            raise ValueError("EAGLE3 draft model config is missing hf_config")
+        if self._is_standalone_draft and draft_hf_config is None:
+            raise ValueError(
+                f"{selected_model_arch} draft model config is missing hf_config"
+            )
 
         self.config = (
             draft_hf_config
-            if self.is_eagle3_draft_model
+            if self._is_standalone_draft
             else vllm_config.model_config.hf_config
         )
         self.text_config = (
@@ -403,9 +419,22 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
             main_atom_config = get_current_atom_config()
             self.atom_config = _generate_atom_config_from_vllm_config(vllm_config)
             self.atom_config.hf_config = main_atom_config.hf_config
-        elif self.is_eagle3_draft_model:
+        elif self._is_standalone_draft:
             self.atom_config = _generate_atom_config_from_vllm_config(vllm_config)
-            self.atom_config.hf_config = draft_hf_config
+            # Prefer ATOM's normalized copy of the draft config. Building the
+            # atom_config already ran `hf_config_override` on a deepcopy, which
+            # is what maps a standalone draft's checkpoint field names onto the
+            # canonical ones the ATOM model reads (e.g. DSpark's `mask_token_id`
+            # -> `dspark_noise_token_id`). vLLM's own copy never sees that.
+            atom_spec_config = getattr(self.atom_config, "speculative_config", None)
+            normalized_hf_config = getattr(
+                atom_spec_config, "draft_model_hf_config", None
+            )
+            self.atom_config.hf_config = (
+                normalized_hf_config
+                if self.is_dspark_draft_model and normalized_hf_config is not None
+                else draft_hf_config
+            )
         else:
             self.atom_config = generate_atom_config_for_plugin_mode(vllm_config)
             # root HF config so --hf-overrides survive without losing multimodal
@@ -462,12 +491,13 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
             # with the draft model's atom_config so that the correct forward context
             # can be registered
             with use_custom_atom_config(self.atom_config):
-                if self.is_eagle3_draft_model:
+                if self._is_standalone_draft:
                     target_layer_num = vllm_config.model_config.get_num_layers(
                         vllm_config.parallel_config
                     )
                     logger.info(
-                        "Construct EAGLE3 draft with layer_offset=%s",
+                        "Construct %s draft with layer_offset=%s",
+                        model_arch,
                         target_layer_num,
                     )
                     self.model = model_cls(
@@ -494,8 +524,14 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
             self._adapt_mtp_layers_for_vllm()
         if self.is_eagle3_draft_model:
             self._enable_eagle3_draft_interface()
-        elif self.is_eagle3 and self._eagle3_uses_aux_hidden_state():
+        elif (self.is_eagle3 and self._eagle3_uses_aux_hidden_state()) or (
+            # DSpark targets are tapped through the same SupportsEagle3 surface.
+            self.is_dspark
+            and not self.is_dspark_draft_model
+        ):
             self._enable_eagle3_target_interface()
+        if self.is_mtp:
+            self.get_mtp_target_hidden_states = self._get_mtp_target_hidden_states
         if self.is_mtp or self.is_eagle3:
             # Mirror nested attributes required by vLLM speculative decoding.
             self._expose_spec_decode_attrs()
@@ -720,13 +756,18 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
                     f"static_forward_context, skipping"
                 )
 
-    def get_mtp_target_hidden_states(self):
+    def _get_mtp_target_hidden_states(self):
         """Return the target hidden state that vLLM should feed to MTP.
 
         DeepSeek V4 target forward returns the pre-hc_head mHC residual
         `[num_tokens, hc, hidden]`; vLLM's generic hidden state path would
         otherwise feed the post-logits hidden shape expected by older MTP
         models.
+
+        Exposed under its public name only on MTP targets (see `__init__`):
+        vLLM decides whether to override the drafter's input by testing for the
+        attribute alone, and would feed the result to any speculator that has
+        it, including ones with no MTP residual to hand over.
         """
         # Prefer the persistent in-graph residual buffer on the native V4 model.
         # It is refreshed by a captured `copy_` every forward (including FULL
@@ -1017,9 +1058,10 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
                 draft_hf_config = getattr(
                     draft_model_config, "hf_config", draft_model_config
                 )
-        if self.is_eagle3_draft_model:
-            # EAGLE3 drafts are standalone checkpoints, so we need both the draft
-            # hf_config and the draft checkpoint path
+        if self._is_standalone_draft:
+            # EAGLE3 and DSpark drafts are their own checkpoints, so the loader
+            # needs both the draft hf_config and the draft checkpoint path;
+            # otherwise it would read the target's weights and match nothing.
             spec_config = getattr(self.vllm_config, "speculative_config", None)
             draft_model_config = getattr(spec_config, "draft_model_config", None)
             if draft_model_config is not None:
@@ -1030,7 +1072,7 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
                     draft_model_config, "model", None
                 ) or getattr(spec_config, "model", None)
             if not draft_model_path:
-                raise ValueError("EAGLE3 draft model path is missing.")
+                raise ValueError(f"{self.model_arch} draft model path is missing.")
 
         loaded_weights_record = load_model_in_plugin_mode(
             model=self.model,

--- a/atom/plugin/vllm/models/kimi_k3.py
+++ b/atom/plugin/vllm/models/kimi_k3.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from types import SimpleNamespace
 
 import torch
@@ -22,6 +23,7 @@ from atom.models.kimi_k3 import (
     KimiKDAAttention,
     _normalize_kimi_config,
 )
+from atom.models.utils import IntermediateTensors
 from atom.plugin.vllm.model_wrapper import ATOMMoEForCausalLM
 from atom.utils.forward_context import get_forward_context as get_atom_forward_context
 
@@ -108,6 +110,70 @@ class KimiKDAAttentionVllm(KimiKDAAttention, MambaBase):
     def mamba_type(self) -> MambaAttentionBackendEnum:
         return MambaAttentionBackendEnum.GDN_ATTN
 
+    def _forward_segments(
+        self, hidden_states: torch.Tensor, gdn_metadata: GDNAttentionMetadata
+    ) -> torch.Tensor:
+        """Run the native KDA layer once per request class in the batch.
+
+        The native layer takes one branch per call -- prefill, decode, or
+        speculative decode -- and writes only that class's rows into an
+        uninitialized output. Its own runtime batches by class, so a single
+        branch always covers everything; vLLM's continuous batching does not.
+        It never mixes plain and speculative decodes (it folds the former into
+        the prefill counts), but a request still prefilling while another
+        drafts is routine, and there the speculative rows would come back as
+        whatever the allocator last left there.
+
+        The builder already splits every per-class input -- token indices,
+        zero-based ``query_start_loc``, state indices -- so each class runs as
+        if it were the whole batch and the rows are scattered back afterwards.
+        """
+        mixed = gdn_metadata.num_spec_decodes > 0 and (
+            gdn_metadata.num_prefills > 0 or gdn_metadata.num_decodes > 0
+        )
+        if not mixed:
+            self._atom_metadata.gdn_metadata = gdn_metadata
+            return super()._forward_impl(hidden_states)
+
+        spec_indx = gdn_metadata.spec_token_indx
+        non_spec_indx = gdn_metadata.non_spec_token_indx
+        assert spec_indx is not None and non_spec_indx is not None
+        rows = hidden_states[: gdn_metadata.num_actual_tokens]
+
+        spec_out = self._forward_one_segment(
+            rows.index_select(0, spec_indx),
+            replace(
+                gdn_metadata,
+                num_prefills=0,
+                num_prefill_tokens=0,
+                num_decodes=0,
+                num_decode_tokens=0,
+                num_actual_tokens=gdn_metadata.num_spec_decode_tokens,
+            ),
+        )
+        non_spec_out = self._forward_one_segment(
+            rows.index_select(0, non_spec_indx),
+            replace(
+                gdn_metadata,
+                num_spec_decodes=0,
+                num_spec_decode_tokens=0,
+                num_actual_tokens=(
+                    gdn_metadata.num_prefill_tokens + gdn_metadata.num_decode_tokens
+                ),
+            ),
+        )
+
+        merged = spec_out.new_empty((rows.shape[0], spec_out.shape[-1]))
+        merged.index_copy_(0, spec_indx, spec_out)
+        merged.index_copy_(0, non_spec_indx, non_spec_out)
+        return merged
+
+    def _forward_one_segment(
+        self, hidden_states: torch.Tensor, gdn_metadata: GDNAttentionMetadata
+    ) -> torch.Tensor:
+        self._atom_metadata.gdn_metadata = gdn_metadata
+        return super()._forward_impl(hidden_states)
+
     def _forward_impl(self, hidden_states: torch.Tensor) -> torch.Tensor:
         vllm_context = get_vllm_forward_context()
         attn_metadata = vllm_context.attn_metadata
@@ -125,7 +191,6 @@ class KimiKDAAttentionVllm(KimiKDAAttention, MambaBase):
 
         vllm_layer = vllm_context.no_compile_layers[self.layer_name]
         conv_state, ssm_state = vllm_layer.kv_cache
-        self._atom_metadata.gdn_metadata = gdn_metadata
         self._atom_cache.k_cache = conv_state
         self._atom_cache.v_cache = ssm_state
 
@@ -135,7 +200,7 @@ class KimiKDAAttentionVllm(KimiKDAAttention, MambaBase):
         atom_context.attn_metadata = self._atom_metadata
         atom_context.kv_cache_data = self._atom_kv_cache_data
         try:
-            output = super()._forward_impl(hidden_states)
+            output = self._forward_segments(hidden_states, gdn_metadata)
         finally:
             atom_context.attn_metadata = previous_metadata
             atom_context.kv_cache_data = previous_kv_cache_data
@@ -152,17 +217,127 @@ class KimiKDAAttentionVllm(KimiKDAAttention, MambaBase):
         return output
 
 
+def _aux_hidden_state_tap(original_forward, sink: list, slot: int):
+    """Record the hidden state entering a layer, then run it unchanged.
+
+    ``pending_add`` carries a residual the native loop defers to the next
+    layer, so the value actually entering this layer is the sum of the two.
+    """
+
+    def forward(positions, hidden_states, block_residual=None, pending_add=None):
+        sink[slot] = (
+            hidden_states if pending_add is None else hidden_states + pending_add
+        )
+        return original_forward(
+            positions, hidden_states, block_residual, pending_add=pending_add
+        )
+
+    return forward
+
+
+class KimiLinearModelVllm(kimi_k3_base.KimiLinearModel):
+    """Native Kimi-K3 body that can also emit Eagle3/DSpark auxiliary states.
+
+    The DSpark draft is trained on the outputs of five target layers. Those are
+    collected by tapping the chosen layers once, when the layer set is
+    configured, rather than by restating the native forward -- whose deferred
+    residual and attention-residual bookkeeping is easy to get subtly wrong and
+    would silently drift from the original.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.aux_hidden_state_layers: tuple[int, ...] = ()
+        # One slot per layer, allocated once. The taps close over this list, so
+        # replacing it would leave them writing somewhere nothing reads --
+        # including inside an already-traced graph.
+        self._aux_hidden_states: list[torch.Tensor | None] = [None] * len(self.layers)
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        for layer in self.layers:
+            original = layer.__dict__.pop("_atom_aux_untapped_forward", None)
+            if original is not None:
+                layer.forward = original
+
+        self.aux_hidden_state_layers = tuple(layers)
+        # Fixed slots rather than appends: the collection order then matches the
+        # configured layer order no matter how the taps fire.
+        for slot in range(len(self._aux_hidden_states)):
+            self._aux_hidden_states[slot] = None
+        for slot, idx in enumerate(self.aux_hidden_state_layers):
+            layer = self.layers[idx]
+            layer._atom_aux_untapped_forward = layer.forward
+            layer.forward = _aux_hidden_state_tap(
+                layer.forward, self._aux_hidden_states, slot
+            )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ):
+        # The signature must stay explicit: ATOM's compile decorator marks the
+        # dynamic token dimension by binding these argument names, and a
+        # *args/**kwargs override would silently compile the model at a single
+        # static shape.
+        hidden_states = super().forward(
+            input_ids, positions, intermediate_tensors, inputs_embeds
+        )
+        if not self.aux_hidden_state_layers:
+            return hidden_states
+        if isinstance(hidden_states, IntermediateTensors):
+            return hidden_states
+        collected = self._aux_hidden_states[: len(self.aux_hidden_state_layers)]
+        missing = [
+            self.aux_hidden_state_layers[i]
+            for i, h in enumerate(collected)
+            if h is None
+        ]
+        if missing:
+            raise RuntimeError(
+                f"Kimi-K3 aux hidden states were not produced by layers {missing}."
+            )
+        return hidden_states, collected
+
+
 class KimiK3ForCausalLM(KimiK3ForCausalLMBase):
     def __init__(self, *args, **kwargs):
         original_kda_cls = kimi_k3_base.KimiKDAAttention
+        original_model_cls = kimi_k3_base.KimiLinearModel
         kimi_k3_base.KimiKDAAttention = KimiKDAAttentionVllm
+        kimi_k3_base.KimiLinearModel = KimiLinearModelVllm
         try:
             super().__init__(*args, **kwargs)
         finally:
             kimi_k3_base.KimiKDAAttention = original_kda_cls
+            kimi_k3_base.KimiLinearModel = original_model_cls
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.language_model.model.set_aux_hidden_state_layers(layers)
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        """Fallback only; the DSpark checkpoint names its own target layers."""
+        num_layers = len(self.language_model.model.layers)
+        return (2, num_layers // 2, num_layers - 3)
 
 
 class KimiK3ForCausalLMVllm(ATOMMoEForCausalLM, IsHybrid):
+    def get_language_model(self) -> torch.nn.Module:
+        """Expose the inner causal-LM so draft loaders can find ``embed_tokens``.
+
+        vLLM's DSpark loader reaches for ``target.get_language_model().model
+        .embed_tokens``; without this it would stop at the multimodal wrapper
+        and silently skip sharing the embedding with the draft.
+        """
+        return self.model.language_model
+
+    @property
+    def lm_head(self) -> torch.nn.Module:
+        """The head the DSpark draft borrows to score its block."""
+        return self.model.language_model.lm_head
+
     @classmethod
     def get_mamba_state_dtype_from_config(
         cls,

--- a/atom/plugin/vllm/models/kimi_k3_dspark.py
+++ b/atom/plugin/vllm/models/kimi_k3_dspark.py
@@ -1,0 +1,130 @@
+"""vLLM-specific Kimi-K3 DSpark draft.
+
+Two layers of adaptation, kept out of the native model:
+
+* :class:`KimiK3DSparkDraft` adds the plain backbone pass vLLM's speculator
+  calls. The native module only exposes ``forward_spec``, which also builds the
+  block and samples it -- work vLLM does itself, in its own buffers.
+* :class:`KimiK3DSparkVllm` is what vLLM instantiates, and translates the
+  speculator's drafting contract onto that module.
+"""
+
+import torch
+
+from atom.models.kimi_k3_dspark import KimiK3DSpark as KimiK3DSparkBase
+from atom.plugin.vllm.model_wrapper import ATOMForCausalLM
+
+
+class KimiK3DSparkDraft(KimiK3DSparkBase):
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors=None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """One parallel pass over the draft block.
+
+        vLLM has already laid the block out as ``[anchor, MASK, ...]`` in its
+        own input buffer, so this neither seeds the block nor samples it -- the
+        speculator's Markov loop runs over the hidden states returned here.
+        """
+        hidden_states = (
+            inputs_embeds if inputs_embeds is not None else self.embed_tokens(input_ids)
+        )
+        for layer in self.layers:
+            hidden_states = layer(positions, hidden_states)
+        return self.final_norm(hidden_states)
+
+    def write_combined_context_kv(
+        self,
+        ctx_hidden: torch.Tensor,
+        positions: torch.Tensor,
+        slot_mappings: torch.Tensor | list[torch.Tensor],
+    ) -> None:
+        """Scatter the target-derived context rows into every draft layer.
+
+        Unlike the native ``write_context_kv`` this does not project first: vLLM
+        combines the aux hidden states in a separate step (so it can stage them
+        in a persistent buffer) and hands the result straight here. Slots may
+        differ per layer when the draft spans several KV cache groups.
+        """
+        per_layer_slots = isinstance(slot_mappings, (list, tuple))
+        for i, layer in enumerate(self.layers):
+            layer.write_context_kv(
+                ctx_hidden,
+                positions,
+                slot_mappings[i] if per_layer_slots else slot_mappings,
+            )
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        return [layer.self_attn.mla_attn.layer_name for layer in self.layers]
+
+
+class KimiK3DSparkVllm(ATOMForCausalLM):
+    """The DSpark drafting contract, backed by the ATOM draft module."""
+
+    # The draft ships neither an embedding table nor an LM head; vLLM's loader
+    # consults these before binding the target's.
+    has_own_embed_tokens = False
+    has_own_lm_head = False
+
+    def __init__(self, *, vllm_config, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        # Plain attributes, not properties: vLLM's DSpark loader rebinds
+        # ``lm_head`` to the target's head after construction.
+        self.lm_head = None
+        # The draft scores the full target vocabulary, so its sampled ids are
+        # already target ids and need no remap table.
+        self.draft_id_to_target_id = None
+        self._align_draft_kv_page_size(vllm_config)
+
+    def _align_draft_kv_page_size(self, vllm_config) -> None:
+        """Keep the draft's pages the same size as the target's.
+
+        The draft caches in bf16 even when the target's cache is fp8: aiter has
+        no fp8 MLA decode kernel wide enough for a 7-token draft block. The
+        native module asks for bf16 already, but the vLLM attention layer takes
+        the engine's `--kv-cache-dtype` over its caller's, so re-pin it here.
+
+        Left alone, a bf16 draft page would then be twice the target's, and
+        since vLLM allocates one page size across all KV cache groups, half of
+        every page would go unused. The layers scale their own block size down
+        to compensate, once the engine's final block size is known.
+        """
+        for layer in self.model.layers:
+            attn = layer.self_attn.mla_attn
+            attn.pin_kv_cache_dtype("bf16")
+            attn.align_page_size_to_engine_dtype = True
+
+    def combine_hidden_states(self, aux_concat: torch.Tensor) -> torch.Tensor:
+        return self.model.project_context(aux_concat)
+
+    def precompute_and_store_context_kv(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        slot_mappings: torch.Tensor | list[torch.Tensor] | None = None,
+    ) -> None:
+        # Dummy and memory-profiling steps pass no slots; the block tables are
+        # placeholders there and writing would clobber real cache entries.
+        if slot_mappings is None:
+            return
+        self.model.write_combined_context_kv(hidden_states, positions, slot_mappings)
+
+    def compute_draft_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.lm_head(hidden_states)
+
+    def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_head.markov_w1(token_ids)
+
+    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        # fp32: this bias lands inside the softmax that decides acceptance.
+        weight = self.model.markov_head.markov_w2.weight
+        return torch.matmul(markov_embed.float(), weight.float().t())
+
+    def map_draft_to_target(self, draft_token_ids: torch.Tensor) -> torch.Tensor:
+        return draft_token_ids
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        return self.model.get_draft_kv_cache_layer_names()

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -39,6 +39,7 @@ _VLLM_MODEL_REGISTRY_OVERRIDES: dict[str, str] = {
     "KimiK3ForConditionalGeneration": (
         "atom.plugin.vllm.models.kimi_k3:KimiK3ForCausalLMVllm"
     ),
+    "K3DSparkModel": "atom.plugin.vllm.models.kimi_k3_dspark:KimiK3DSparkVllm",
     "MiniMaxM2ForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,
     "DeepseekV4ForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,
     "MiniMaxM3SparseForCausalLM": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,
@@ -85,16 +86,29 @@ class MiniMaxM3Config(PretrainedConfig):
             setattr(text_config, name, value)
 
 
+class K3DSparkConfig(PretrainedConfig):
+    """Minimal local config shim for the standalone Kimi-K3 DSpark draft.
+
+    The checkpoint declares ``model_type: k3_dspark``, which neither
+    Transformers nor vLLM knows, and ships no remote code to define it. Every
+    field the draft reads is a plain scalar, so the base class's own
+    deserialization is all that is needed.
+    """
+
+    model_type = "k3_dspark"
+
+
 def _set_plugin_mode() -> None:
     _set_framework_backbone("vllm")
 
 
 def _register_hf_configs() -> None:
-    try:
-        AutoConfig.register(MiniMaxM3Config.model_type, MiniMaxM3Config)
-    except ValueError as exc:
-        if "already used by a Transformers config" not in str(exc):
-            raise
+    for config_cls in (MiniMaxM3Config, K3DSparkConfig):
+        try:
+            AutoConfig.register(config_cls.model_type, config_cls)
+        except ValueError as exc:
+            if "already used by a Transformers config" not in str(exc):
+                raise
 
 
 def _register_mxfp8_quantization_config() -> None:

--- a/atom/plugin/vllm/spec_decode_patch.py
+++ b/atom/plugin/vllm/spec_decode_patch.py
@@ -13,9 +13,8 @@ def _patch_eagle3_model_type_checks() -> None:
     # through the ATOMModelBase wrapper, so patch the type checks to accept the
     # ATOMModelBase wrapper
     try:
-        import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
-
         from atom.plugin.vllm.model_wrapper import ATOMModelBase
+        import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
     except Exception:
         logger.warning(
             "vLLM plugin: failed to patch vLLM V1 EAGLE3 proposer type checks. "
@@ -59,7 +58,7 @@ def _patch_dspark_standalone_draft_config() -> None:
         from vllm.config.speculative import SpeculativeConfig
 
         from atom.plugin.vllm.register import K3DSparkConfig
-    except Exception:
+    except ImportError:
         logger.warning(
             "vLLM plugin: failed to patch SpeculativeConfig for standalone "
             "DSpark drafts. This can happen with an incompatible vLLM version."
@@ -135,7 +134,7 @@ def _patch_dspark_causal_draft() -> None:
             _K3_DSPARK_ARCH,
         )
 
-    setattr(wrapped_init, "_atom_dspark_causal_patched", True)
+    wrapped_init._atom_dspark_causal_patched = True
     DSparkSpeculator.__init__ = wrapped_init
 
 
@@ -624,7 +623,7 @@ def _patch_vllm_dflash_kernel_block_units() -> None:
             block_tables = _KernelUnitBlockTables(block_tables)
         return original_set_attn(self, model_state, kv_cache_config, block_tables)
 
-    setattr(wrapped_set_attn, "_atom_kernel_block_units_patched", True)
+    wrapped_set_attn._atom_kernel_block_units_patched = True
     DFlashSpeculator.set_attn = wrapped_set_attn
 
 

--- a/atom/plugin/vllm/spec_decode_patch.py
+++ b/atom/plugin/vllm/spec_decode_patch.py
@@ -3,6 +3,8 @@ import logging
 
 logger = logging.getLogger("atom")
 
+_K3_DSPARK_ARCH = "K3DSparkModel"
+
 
 def _patch_eagle3_model_type_checks() -> None:
     # vLLM's V1 EAGLE proposer SpecDecodeBaseProposer.propose() has an explicit
@@ -11,8 +13,9 @@ def _patch_eagle3_model_type_checks() -> None:
     # through the ATOMModelBase wrapper, so patch the type checks to accept the
     # ATOMModelBase wrapper
     try:
-        from atom.plugin.vllm.model_wrapper import ATOMModelBase
         import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
+
+        from atom.plugin.vllm.model_wrapper import ATOMModelBase
     except Exception:
         logger.warning(
             "vLLM plugin: failed to patch vLLM V1 EAGLE3 proposer type checks. "
@@ -37,6 +40,100 @@ def _patch_eagle3_model_type_checks() -> None:
 
     setattr(llm_base_proposer, "_atom_eagle3_model_types_patched", True)
     logger.info("ATOM plugin: patched vLLM EAGLE3 proposer type checks.")
+
+
+def _patch_dspark_standalone_draft_config() -> None:
+    """Keep the Kimi-K3 DSpark draft from being rewritten into a DeepSeek-V4 one.
+
+    vLLM assumes every DSpark draft other than Qwen3's ships inside a
+    DeepSeek-V4 target checkpoint, so it overwrites the draft's ``model_type``
+    and ``architectures`` to match. Kimi-K3-DSpark is its own checkpoint with
+    its own architecture, and the rewrite makes the config unresolvable.
+
+    The rewrite is always followed by ``update_arch_()``, which is where the
+    new names are first acted on, so undoing it there catches it before
+    anything downstream can observe it. The rewrite touches nothing else, so
+    the config shim class still identifies the draft.
+    """
+    try:
+        from vllm.config.speculative import SpeculativeConfig
+
+        from atom.plugin.vllm.register import K3DSparkConfig
+    except Exception:
+        logger.warning(
+            "vLLM plugin: failed to patch SpeculativeConfig for standalone "
+            "DSpark drafts. This can happen with an incompatible vLLM version."
+        )
+        return
+
+    original_update_arch = SpeculativeConfig.update_arch_
+    if getattr(original_update_arch, "_atom_dspark_draft_arch_patched", False):
+        return
+
+    @functools.wraps(original_update_arch)
+    def patched_update_arch(self):
+        hf_config = getattr(self.draft_model_config, "hf_config", None)
+        if isinstance(hf_config, K3DSparkConfig) and hf_config.architectures != [
+            _K3_DSPARK_ARCH
+        ]:
+            hf_config.model_type = K3DSparkConfig.model_type
+            hf_config.architectures = [_K3_DSPARK_ARCH]
+            logger.info(
+                "ATOM plugin: kept standalone DSpark draft architecture %s.",
+                _K3_DSPARK_ARCH,
+            )
+        return original_update_arch(self)
+
+    patched_update_arch._atom_dspark_draft_arch_patched = True
+    SpeculativeConfig.update_arch_ = patched_update_arch
+    logger.info("ATOM plugin: patched SpeculativeConfig for standalone DSpark drafts.")
+
+
+def _patch_dspark_causal_draft() -> None:
+    """Draft the Kimi-K3 DSpark block causally, the way ATOM's own DSpark does.
+
+    vLLM's DSpark speculator pins drafting to non-causal: every block position
+    attends to the whole block. ``mla_decode_fwd`` masks tail-aligned-causally
+    whatever it is asked for, so getting that upper triangle means merging a
+    second partial attention in by log-sum-exp -- and no aiter decode kernel
+    hands back an LSE we could rely on at serving batch sizes. The persistent
+    kernel leaves ``final_lse`` at FLT_MAX for part of the batch once sequence
+    lengths vary, and routing around it to the split-KV kernel did not hold up
+    end to end at 64 concurrency.
+
+    ATOM's native DSpark never merges: the block pass just takes what the
+    kernel gives, so position ``i`` sees ``context + block[:i+1]``. That costs
+    the block's tail -- positions 5-7 are almost never accepted, so acceptance
+    lands near 3.9 rather than 4.7 -- but it needs no LSE at all. Causal
+    drafting is a first-class DFlash mode here, so matching native is just
+    flipping the flag the DSpark subclass pins off, for the Kimi-K3 draft only.
+    """
+    try:
+        from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+    except ImportError:
+        return
+
+    original_init = DSparkSpeculator.__init__
+    if getattr(original_init, "_atom_dspark_causal_patched", False):
+        return
+
+    @functools.wraps(original_init)
+    def wrapped_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        hf_config = getattr(self.draft_model_config, "hf_config", None)
+        if _K3_DSPARK_ARCH not in (getattr(hf_config, "architectures", None) or ()):
+            return
+        # Read by init_cudagraph_manager() and by every draft attention
+        # metadata build, both of which run after __init__.
+        self.dflash_causal = True
+        logger.info(
+            "ATOM plugin: drafting the %s block causally, matching ATOM's "
+            "native DSpark attention path.",
+            _K3_DSPARK_ARCH,
+        )
+
+    setattr(wrapped_init, "_atom_dspark_causal_patched", True)
+    DSparkSpeculator.__init__ = wrapped_init
 
 
 def _get_attn_backend_block_size(backend) -> int:
@@ -488,6 +585,46 @@ def _patch_vllm_draft_positions_on_metadata() -> None:
     )
 
 
+class _KernelUnitBlockTables:
+    """``BlockTables`` whose ``block_sizes`` are the kernel's, not the manager's.
+
+    ``BlockTables`` stores block ids in *kernel* blocks: it expands each
+    manager block into ``block_size // kernel_block_size`` of them
+    (`append_block_ids`). The DFlash speculator turns those ids back into slots
+    with ``block_id * block_sizes[gid] + offset``, which only lands on the right
+    slot while the two sizes agree -- they do for vLLM's own backends, but
+    ATOM's MLA kernels page by the token (kernel block size 1), so the manager's
+    size overshoots by that ratio and the draft writes past its pool.
+    """
+
+    def __init__(self, block_tables):
+        self._block_tables = block_tables
+        self.block_sizes = list(block_tables.kernel_block_sizes)
+
+    def __getattr__(self, name):
+        return getattr(self._block_tables, name)
+
+
+def _patch_vllm_dflash_kernel_block_units() -> None:
+    try:
+        from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+    except ImportError:
+        return
+
+    original_set_attn = DFlashSpeculator.set_attn
+    if getattr(original_set_attn, "_atom_kernel_block_units_patched", False):
+        return
+
+    @functools.wraps(original_set_attn)
+    def wrapped_set_attn(self, model_state, kv_cache_config, block_tables):
+        if list(block_tables.kernel_block_sizes) != list(block_tables.block_sizes):
+            block_tables = _KernelUnitBlockTables(block_tables)
+        return original_set_attn(self, model_state, kv_cache_config, block_tables)
+
+    setattr(wrapped_set_attn, "_atom_kernel_block_units_patched", True)
+    DFlashSpeculator.set_attn = wrapped_set_attn
+
+
 def _patch_vllm_deepseek_v4_mtp_first_pass_inputs() -> None:
     from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 
@@ -537,10 +674,15 @@ def _patch_vllm_deepseek_v4_mtp_first_pass_inputs() -> None:
 
 def apply_vllm_spec_decode_patch() -> None:
     """Patch vLLM speculative decoding for ATOM metadata compatibility."""
+    _patch_dspark_standalone_draft_config()
+    _patch_dspark_causal_draft()
     _patch_vllm_llm_base_model_sharing()
     _patch_vllm_draft_kv_group_validation()
     _patch_vllm_draft_positions_on_metadata()
+    _patch_vllm_dflash_kernel_block_units()
     _patch_vllm_deepseek_v4_mtp_first_pass_inputs()
+
+    from vllm.v1.spec_decode.eagle import SpecDecodeBaseProposer
 
     from atom.plugin.vllm.attention.metadata import (
         AiterMhaMetadataForVllm,
@@ -551,7 +693,6 @@ def apply_vllm_spec_decode_patch() -> None:
     from atom.utils.forward_context import (
         AttentionMetaData as AtomAttentionMetaData,
     )
-    from vllm.v1.spec_decode.eagle import SpecDecodeBaseProposer
 
     _patch_eagle3_model_type_checks()
     _patch_heterogeneous_eagle3_kv_cache()

--- a/atom/plugin/vllm/spec_decode_patch.py
+++ b/atom/plugin/vllm/spec_decode_patch.py
@@ -95,18 +95,21 @@ def _patch_dspark_causal_draft() -> None:
     vLLM's DSpark speculator pins drafting to non-causal: every block position
     attends to the whole block. ``mla_decode_fwd`` masks tail-aligned-causally
     whatever it is asked for, so getting that upper triangle means merging a
-    second partial attention in by log-sum-exp -- and no aiter decode kernel
-    hands back an LSE we could rely on at serving batch sizes. The persistent
-    kernel leaves ``final_lse`` at FLT_MAX for part of the batch once sequence
-    lengths vary, and routing around it to the split-KV kernel did not hold up
-    end to end at 64 concurrency.
+    second partial attention in by log-sum-exp.
 
     ATOM's native DSpark never merges: the block pass just takes what the
-    kernel gives, so position ``i`` sees ``context + block[:i+1]``. That costs
-    the block's tail -- positions 5-7 are almost never accepted, so acceptance
-    lands near 3.9 rather than 4.7 -- but it needs no LSE at all. Causal
-    drafting is a first-class DFlash mode here, so matching native is just
-    flipping the flag the DSpark subclass pins off, for the Kimi-K3 draft only.
+    kernel gives, so position ``i`` sees ``context + block[:i+1]``. Matching it
+    keeps one drafting semantics across both engines, and it needs no LSE at
+    all. The cost is the block's tail -- positions 5-7 are almost never
+    accepted, so acceptance lands near 3.8. Causal drafting is a first-class
+    DFlash mode here, so matching native is just flipping the flag the DSpark
+    subclass pins off, for the Kimi-K3 draft only.
+
+    Non-causal is a possible follow-up rather than a dead end: the persistent
+    decode kernel does return a usable LSE on gfx950 -- DCP merges cross-rank
+    on it -- so the merge is buildable. The split-KV kernel is the one to avoid,
+    its stage2 reduce leaving ``final_lse`` untouched for a request whose valid
+    split count collapses, which is what a large batch produces.
     """
     try:
         from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator

--- a/recipes/atom_vllm/DSpark.md
+++ b/recipes/atom_vllm/DSpark.md
@@ -1,0 +1,172 @@
+# DSpark Speculative Decoding with the ATOM vLLM Plugin Backend
+
+DSpark is a semi-autoregressive *block* drafter. Instead of running `k`
+sequential MTP passes, it drafts a whole block of `k` tokens in one parallel
+backbone pass (parallel backbone + Markov sequential head), and the target then
+verifies the block in a single `1 + k` token forward.
+
+This recipe covers DSpark under the **ATOM vLLM out-of-tree plugin**. For DSpark
+on ATOM's native engine (`atom.entrypoints.openai_server`) — including
+DeepSeek-V4-Pro and the confidence-scheduled ragged verify — see
+[`recipes/DSpark.md`](../DSpark.md).
+
+In plugin mode the validated target is **Kimi-K3** with the standalone
+[Inferact/Kimi-K3-DSpark](https://huggingface.co/Inferact/Kimi-K3-DSpark) draft
+checkpoint, on eight MI355 (gfx950) GPUs at TP8.
+
+## Prerequisites
+
+Identical to the [Kimi-K3 recipe](./Kimi-K3.md) — the ATOM vLLM OOT image plus
+the KDA dependency, with the target ATOM checkout installed over it:
+
+```bash
+docker pull rocm/atom-dev:vllm-latest
+pip install "fla-core==0.5.1" "flash-linear-attention==0.5.1"
+pip install -e /path/to/ATOM --no-deps
+```
+
+The draft checkpoint is downloaded on startup, so no separate fetch is needed.
+
+## Launch
+
+```bash
+MODEL=/path/to/Kimi-K3
+
+vllm serve "${MODEL}" \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --language-model-only \
+    --kv-cache-dtype fp8 \
+    --max-num-seqs 64 \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.93 \
+    --block-size 128 \
+    --no-enable-prefix-caching \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+    --speculative-config '{"method":"dspark","model":"Inferact/Kimi-K3-DSpark","num_speculative_tokens":7}'
+```
+
+`model` inside `--speculative-config` takes a local path or an HF repo id.
+`num_speculative_tokens` is the block width; the draft checkpoint does not pin
+it, and 7 is the validated setting.
+
+## How the plugin differs from upstream vLLM DSpark
+
+### Causal block drafting
+
+vLLM's DSpark speculator drafts **non-causally**: every position in the block
+attends to the whole block. ATOM's `mla_decode_fwd` masks tail-aligned-causally
+whatever it is asked for, so producing that upper triangle means merging a
+second partial attention in by log-sum-exp — and no aiter decode kernel hands
+back an LSE that holds up at serving batch sizes (the persistent kernel leaves
+`final_lse` at `FLT_MAX` for part of the batch once sequence lengths vary).
+
+The plugin therefore flips the draft to **causal** for the `K3DSparkModel`
+architecture only, matching what ATOM's native DSpark has always done: position
+`i` sees `context + block[:i+1]`. That costs the block's tail — the last three
+of the seven positions contribute almost no accepted tokens — so acceptance
+lands near 3.8 rather than the non-causal ceiling, and it needs no LSE at all.
+Nothing else in the DSpark path changes, and no other model's drafting is
+touched.
+
+### Separate bf16 draft KV cache
+
+The draft is a standalone MLA model, so it gets its own KV cache group, pinned
+to **bf16** regardless of the target's `--kv-cache-dtype fp8`. Its pages are
+therefore twice the target's per token. Budget for that before raising
+`--max-model-len` or `--max-num-seqs`.
+
+### Model Runner V2 is selected automatically
+
+DSpark is implemented only by vLLM's V2 GPU model runner. vLLM turns V2 on for
+`"method": "dspark"` by itself, so `VLLM_USE_V2_MODEL_RUNNER` does not need to
+be set.
+
+### Asynchronous scheduling stays enabled
+
+vLLM disables async scheduling for most speculative methods but exempts DSpark,
+and every run reported below kept it on. This is the one place the DSpark launch
+departs from the target-only Kimi-K3 recipe, which turns it off.
+
+### Full CUDA graphs cover both models
+
+Under `FULL_AND_PIECEWISE`, the target's 8-token verify and the draft's 7-token
+block both replay from full graphs. ATOM's MLA metadata builder declares
+`UNIFORM_BATCH` graph support for exactly this reason: vLLM takes the minimum
+across every attention backend, so anything lower here would downgrade the whole
+model — the target's verify included — to piecewise.
+
+### Prefix caching must stay off
+
+Inherited from Kimi-K3 rather than from DSpark: KDA recurrent state cannot be
+reconstructed from the paged MLA cache alone.
+
+## Validation
+
+Accuracy and acceptance were measured with the engine driven directly by
+`lm_eval`'s vLLM class rather than over HTTP: TP8, fp8 KV, block size 128, 64
+concurrent sequences, `FULL_AND_PIECEWISE` CUDA Graph, async scheduling on. The
+context length is pinned short here only because 5-shot GSM8K prompts are short;
+it is an evaluation setting, not a serving constraint.
+
+```python
+from lm_eval import simple_evaluate
+from lm_eval.models.vllm_causallms import VLLM
+
+model = VLLM(
+    pretrained="/path/to/Kimi-K3",
+    tensor_parallel_size=8,
+    trust_remote_code=True,
+    max_model_len=4096,
+    batch_size=64,
+    max_num_seqs=64,
+    gpu_memory_utilization=0.90,
+    block_size=128,
+    kv_cache_dtype="fp8",
+    enable_prefix_caching=False,
+    speculative_config={
+        "method": "dspark",
+        "model": "Inferact/Kimi-K3-DSpark",
+        "num_speculative_tokens": 7,
+    },
+)
+results = simple_evaluate(model=model, tasks=["gsm8k"], num_fewshot=5,
+                          bootstrap_iters=0)
+print(results["results"]["gsm8k"])
+```
+
+Full 1319-example GSM8K test set:
+
+```text
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |
+|-----|------:|----------------|-----:|-----------|---|-----:|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9530|
+|     |       |strict-match    |     5|exact_match|↑  |0.9530|
+```
+
+- **Mean accepted length: 3.776 tokens/forward** — 1 verified token plus ~2.78
+  accepted draft tokens.
+- **Acceptance rate: 39.7%** — accepted draft tokens / total drafted tokens.
+
+Verification always emits the target-greedy token, so drafting is accuracy
+neutral; the target alone scores `0.9553` on the same benchmark, though that
+number was measured over the served endpoint at a longer context (see
+[Kimi-K3](./Kimi-K3.md)) and is a reference point rather than a paired control.
+
+Use a freshly started engine for each reported accuracy run, matching the
+Kimi-K3 validation protocol.
+
+## Current scope
+
+- Kimi-K3 is the only DSpark target validated in plugin mode. DeepSeek-V4-Pro
+  DSpark runs on ATOM's native engine only.
+- The verify length is batch-uniform `1 + num_speculative_tokens`. The draft
+  checkpoint's confidence head is not used here — confidence-scheduled ragged
+  verify (`--dspark-config`) exists only on the native engine.
+- Drafting is causal, so acceptance is below the non-causal upper bound.
+- TP8 on MI355/gfx950 is the validated deployment. DP attention and decode
+  context parallel are not exercised with DSpark.
+- Serving throughput has not been benchmarked in plugin mode; only accuracy and
+  acceptance are tracked here.

--- a/recipes/atom_vllm/DSpark.md
+++ b/recipes/atom_vllm/DSpark.md
@@ -103,60 +103,98 @@ model — the target's verify included — to piecewise.
 Inherited from Kimi-K3 rather than from DSpark: KDA recurrent state cannot be
 reconstructed from the paged MLA cache alone.
 
-## Validation
+## Accuracy validation
 
-Accuracy and acceptance were measured with the engine driven directly by
-`lm_eval`'s vLLM class rather than over HTTP: TP8, fp8 KV, block size 128, 64
-concurrent sequences, `FULL_AND_PIECEWISE` CUDA Graph, async scheduling on. The
-context length is pinned short here only because 5-shot GSM8K prompts are short;
-it is an evaluation setting, not a serving constraint.
+Same protocol as the [Kimi-K3 recipe](./Kimi-K3.md) — over the served endpoint,
+against a freshly started server launched exactly as above:
 
-```python
-from lm_eval import simple_evaluate
-from lm_eval.models.vllm_causallms import VLLM
-
-model = VLLM(
-    pretrained="/path/to/Kimi-K3",
-    tensor_parallel_size=8,
-    trust_remote_code=True,
-    max_model_len=4096,
-    batch_size=64,
-    max_num_seqs=64,
-    gpu_memory_utilization=0.90,
-    block_size=128,
-    kv_cache_dtype="fp8",
-    enable_prefix_caching=False,
-    speculative_config={
-        "method": "dspark",
-        "model": "Inferact/Kimi-K3-DSpark",
-        "num_speculative_tokens": 7,
-    },
-)
-results = simple_evaluate(model=model, tasks=["gsm8k"], num_fewshot=5,
-                          bootstrap_iters=0)
-print(results["results"]["gsm8k"])
+```bash
+lm_eval \
+    --model local-completions \
+    --model_args "model=${MODEL},base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
+    --tasks gsm8k \
+    --num_fewshot 5 \
+    --output_path /app/logs/kimi_k3_dspark_gsm8k
 ```
 
-Full 1319-example GSM8K test set:
+Full 1319-example GSM8K test set, TP8, fp8 KV, `FULL_AND_PIECEWISE` CUDA Graph,
+async scheduling on:
 
 ```text
-|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |
-|-----|------:|----------------|-----:|-----------|---|-----:|
-|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9530|
-|     |       |strict-match    |     5|exact_match|↑  |0.9530|
+|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9522|±  |0.0059|
+|     |       |strict-match    |     5|exact_match|↑  |0.9522|±  |0.0059|
 ```
 
-- **Mean accepted length: 3.776 tokens/forward** — 1 verified token plus ~2.78
-  accepted draft tokens.
-- **Acceptance rate: 39.7%** — accepted draft tokens / total drafted tokens.
-
 Verification always emits the target-greedy token, so drafting is accuracy
-neutral; the target alone scores `0.9553` on the same benchmark, though that
-number was measured over the served endpoint at a longer context (see
-[Kimi-K3](./Kimi-K3.md)) and is a reference point rather than a paired control.
+neutral. The target alone scores `0.9553 ± 0.0057` under the same harness and
+concurrency (see [Kimi-K3](./Kimi-K3.md)); the two are within each other's error
+bars.
 
-Use a freshly started engine for each reported accuracy run, matching the
-Kimi-K3 validation protocol.
+### Acceptance
+
+Aggregated over the same run — 36,338 verify forwards, 254,366 drafted tokens:
+
+- **Mean accepted length: 3.772 tokens/forward** — 1 verified token plus 2.77
+  accepted draft tokens.
+- **Acceptance rate: 39.6%** — accepted draft tokens / total drafted tokens.
+
+Per-position acceptance rate across the 7-token block:
+
+```text
+position   |    1  |    2  |    3  |    4  |    5  |    6  |    7
+rate       | 0.923 | 0.775 | 0.600 | 0.440 | 0.032 | 0.001 | 0.000
+```
+
+The collapse after position 4 is the cost of causal drafting: the block's tail
+positions see the least context and contribute roughly 1% of accepted tokens
+between them. With positions 6 and 7 already at zero, widening the block past 7
+has no headroom left to buy — it would only widen the verify forward.
+
+The server logs these as it runs (`Mean acceptance length`, `Draft acceptance
+rate` per position), and Prometheus exposes them as
+`vllm:spec_decode_num_{accepted,drafted}_tokens_total` and
+`vllm:spec_decode_num_accepted_tokens_per_pos_total`.
+
+## Profiling
+
+Torch profiling is a server-side flag in vLLM 0.25.x, not an environment
+variable. Add to the launch command:
+
+```bash
+    --profiler-config '{"profiler":"torch","torch_profiler_dir":"/app/prof_dspark","torch_profiler_with_stack":true}'
+```
+
+Then drive it from the benchmark client, which starts and stops the profiler
+around the measured window:
+
+```bash
+vllm bench serve \
+    --backend vllm --base-url http://localhost:8000 \
+    --model "${MODEL}" --trust-remote-code \
+    --dataset-name random \
+    --random-input-len 8192 --random-output-len 100 --random-range-ratio 0 \
+    --max-concurrency 16 --num-prompts 16 \
+    --ignore-eos --profile
+```
+
+`--random-range-ratio 0` pins every prompt to exactly the requested length; in
+this version the ratio is the *width of the variation*, so `1.0` would let
+sampled lengths reach zero and the run aborts. Run the same command once without
+`--profile` first — the first pass pays autotuning and graph-replay warmup that
+otherwise lands in the trace.
+
+This writes one gzipped trace per TP rank plus one for the API server front end,
+and a `profiler_out_<rank>.txt` CUDA-time summary. Expect them to be large:
+`torch_profiler_with_stack` records every Python frame, which for 8k/100/16 at
+TP8 is about 3.6 GB gzipped and ~30M Python-frame events per rank. Drop
+`torch_profiler_with_stack` if you only need kernel timings.
+
+Both models show up in the trace under their own MLA kernels —
+`aiter::mla_a8w8_*` for the fp8 target and `aiter::mla_a16w16_*` for the bf16
+draft — which is the quickest way to confirm the draft is running on its own
+cache.
 
 ## Current scope
 
@@ -168,5 +206,6 @@ Kimi-K3 validation protocol.
 - Drafting is causal, so acceptance is below the non-causal upper bound.
 - TP8 on MI355/gfx950 is the validated deployment. DP attention and decode
   context parallel are not exercised with DSpark.
-- Serving throughput has not been benchmarked in plugin mode; only accuracy and
+- Serving throughput has not been swept in plugin mode. The 8k/100/16 point
+  above exists to produce a trace, not as a reported number; only accuracy and
   acceptance are tracked here.

--- a/recipes/atom_vllm/DSpark.md
+++ b/recipes/atom_vllm/DSpark.md
@@ -127,8 +127,8 @@ async scheduling on:
 ```text
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
 |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
-|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9522|±  |0.0059|
-|     |       |strict-match    |     5|exact_match|↑  |0.9522|±  |0.0059|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9545|±  |0.0057|
+|     |       |strict-match    |     5|exact_match|↑  |0.9538|±  |0.0058|
 ```
 
 Verification always emits the target-greedy token, so drafting is accuracy
@@ -136,19 +136,26 @@ neutral. The target alone scores `0.9553 ± 0.0057` under the same harness and
 concurrency (see [Kimi-K3](./Kimi-K3.md)); the two are within each other's error
 bars.
 
+Check the run for `TimeoutError` before reporting a number. A run that hits the
+`local-completions` client timeout retries the request, and the retry both
+doubles the server's work and re-generates the answer under a different batch
+composition — enough numeric difference to flip a chain of thought that was
+already marginal. One such run here read `0.9424` while its acceptance figures
+stayed normal, which is the tell: DSpark was fine and the harness was not.
+
 ### Acceptance
 
-Aggregated over the same run — 36,338 verify forwards, 254,366 drafted tokens:
+Aggregated over the same run — 36,119 verify forwards, 252,833 drafted tokens:
 
-- **Mean accepted length: 3.772 tokens/forward** — 1 verified token plus 2.77
+- **Mean accepted length: 3.777 tokens/forward** — 1 verified token plus 2.78
   accepted draft tokens.
-- **Acceptance rate: 39.6%** — accepted draft tokens / total drafted tokens.
+- **Acceptance rate: 39.7%** — accepted draft tokens / total drafted tokens.
 
 Per-position acceptance rate across the 7-token block:
 
 ```text
 position   |    1  |    2  |    3  |    4  |    5  |    6  |    7
-rate       | 0.923 | 0.775 | 0.600 | 0.440 | 0.032 | 0.001 | 0.000
+rate       | 0.923 | 0.774 | 0.602 | 0.442 | 0.034 | 0.002 | 0.000
 ```
 
 The collapse after position 4 is the cost of causal drafting: the block's tail

--- a/recipes/atom_vllm/DSpark.md
+++ b/recipes/atom_vllm/DSpark.md
@@ -59,17 +59,21 @@ it, and 7 is the validated setting.
 vLLM's DSpark speculator drafts **non-causally**: every position in the block
 attends to the whole block. ATOM's `mla_decode_fwd` masks tail-aligned-causally
 whatever it is asked for, so producing that upper triangle means merging a
-second partial attention in by log-sum-exp — and no aiter decode kernel hands
-back an LSE that holds up at serving batch sizes (the persistent kernel leaves
-`final_lse` at `FLT_MAX` for part of the batch once sequence lengths vary).
+second partial attention in by log-sum-exp.
 
-The plugin therefore flips the draft to **causal** for the `K3DSparkModel`
+The plugin instead flips the draft to **causal** for the `K3DSparkModel`
 architecture only, matching what ATOM's native DSpark has always done: position
-`i` sees `context + block[:i+1]`. That costs the block's tail — the last three
-of the seven positions contribute almost no accepted tokens — so acceptance
-lands near 3.8 rather than the non-causal ceiling, and it needs no LSE at all.
-Nothing else in the DSpark path changes, and no other model's drafting is
-touched.
+`i` sees `context + block[:i+1]`. One drafting semantics across both engines,
+and no merge to build. That costs the block's tail — the last three of the seven
+positions contribute almost no accepted tokens — so acceptance lands near 3.8
+rather than the non-causal ceiling. Nothing else in the DSpark path changes, and
+no other model's drafting is touched.
+
+Non-causal remains open as a follow-up. The persistent decode kernel does return
+a usable LSE on gfx950 — DCP merges cross-rank on it — so the merge is
+buildable; it is the split-KV kernel that is not usable here, its stage2 reduce
+leaving `final_lse` untouched for any request whose valid split count collapses,
+which is exactly what a large batch produces.
 
 ### Separate bf16 draft KV cache
 

--- a/recipes/atom_vllm/Kimi-K3.md
+++ b/recipes/atom_vllm/Kimi-K3.md
@@ -28,18 +28,6 @@ pip install -e /path/to/ATOM --no-deps
 ```bash
 MODEL=/path/to/Kimi-K3
 
-export AITER_LOG_LEVEL=WARNING
-export ATOM_LOADER_USE_THREADPOOL=1
-export ATOM_LOADER_THREADPOOL_WORKERS=16
-export ATOM_SYNC_AFTER_LOAD=1
-export ATOM_DIST_TIMEOUT_SECONDS=3600
-
-export ATOM_USE_TRITON_GEMM=1
-export AITER_USE_GROUPED_GEMM=0
-export ATOM_USE_TRITON_MOE=0
-export AITER_FLYDSL_FORCE=1
-export AITER_FORCE_GFX1250=0
-
 vllm serve "${MODEL}" \
     --host 0.0.0.0 \
     --port 8000 \
@@ -47,13 +35,11 @@ vllm serve "${MODEL}" \
     --trust-remote-code \
     --language-model-only \
     --kv-cache-dtype fp8 \
-    --max-model-len 16384 \
     --max-num-seqs 64 \
     --max-num-batched-tokens 16384 \
     --gpu-memory-utilization 0.93 \
     --block-size 128 \
     --no-enable-prefix-caching \
-    --no-async-scheduling \
     --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
 ```
 
@@ -108,9 +94,17 @@ Use a freshly started server for each reported accuracy run, matching the
 native Kimi-K3 validation protocol. Back-to-back evaluations on a warm server
 are not used as baselines for this model.
 
+## Speculative decoding
+
+Kimi-K3 can be served with DSpark block drafting by adding a
+`--speculative-config` pointing at the standalone
+[Inferact/Kimi-K3-DSpark](https://huggingface.co/Inferact/Kimi-K3-DSpark) draft.
+That path enables asynchronous scheduling, needs headroom for a separate bf16
+draft KV cache, and drafts causally rather than the way upstream vLLM does; see
+[DSpark](./DSpark.md) for the full launch command and validated numbers.
+
 ## Current scope
 
 - Text generation only; the vision tower and multimodal projector are skipped.
 - TP8 on MI355/gfx950 is the validated deployment.
-- Prefix caching and asynchronous scheduling are disabled.
-- Speculative decoding is not enabled for this model.
+- Prefix caching is disabled.


### PR DESCRIPTION
## Summary

Enables DSpark block-drafting speculative decoding for Kimi-K3 under the ATOM vLLM plugin backend, with the standalone [Inferact/Kimi-K3-DSpark](https://huggingface.co/Inferact/Kimi-K3-DSpark) draft checkpoint. Validated at TP8 on MI355 with full CUDA graphs and asynchronous scheduling.

The draft is a standalone MLA model rather than an in-checkpoint MTP head, which is what most of this diff is about:

- **Causal block drafting.** vLLM's DSpark speculator drafts non-causally, so every block position attends to the whole block. ATOM's `mla_decode_fwd` masks tail-aligned-causally whatever it is asked for, so that upper triangle would have to be merged in by log-sum-exp. `spec_decode_patch.py` drafts causally instead for the `K3DSparkModel` architecture only, matching ATOM's native DSpark — one drafting semantics across both engines and no merge to build. This is a scope decision, not a kernel limitation: the persistent decode kernel does return a usable LSE on gfx950, which is what #1746 just put DCP's cross-rank merge on, so non-causal is a buildable follow-up. No other model's drafting is touched.
- **Standalone draft plumbing.** `SpeculativeConfig` rewrites every non-Qwen3 DSpark draft into a DeepSeek-V4 one, which makes the Kimi-K3 draft config unresolvable; the patch keeps its own architecture. `model_wrapper.py` generalizes the eagle3-specific standalone-draft handling to cover DSpark, and stops exposing `get_mtp_target_hidden_states` on non-MTP models, which MRV2 probes with a bare `hasattr`.
- **Separate bf16 draft KV pool.** The draft gets its own KV cache group, pinned to bf16 regardless of the target's `--kv-cache-dtype fp8`.
- **Persistent MLA work-descriptor sizing.** The descriptors were sized for a 1-token decode but filled at the real decode width. They are now sized for the worst case over every width `split_decodes_and_prefills` can route to `_build_decode`, i.e. `1..reorder_batch_threshold`. The sizes are not monotonic in query length, so this takes a per-slot maximum rather than the value at the largest width. Costs no extra memory: the descriptor shapes saturate well below the threshold.
- **Padded decode slots.** A full decode graph replays at its captured request count, so vLLM pads the batch with slots carrying no query rows and no sequence. Those empty slots left the persistent kernel waiting on partials nothing produces; they now get one page of KV and their share of query rows.
- **DFlash slot-mapping units.** `BlockTables` stores block ids in kernel blocks, but the DFlash speculator converts them back to slots with the manager's block size. Those agree for vLLM's own backends; ATOM's MLA pages by the token, so the draft wrote past its pool. Wrapped for the `set_attn` call only, and only when the two sizes actually differ.

## Validation

Full 1319-example GSM8K, 5-shot, over the served endpoint at 64 concurrency, TP8, fp8 KV, `FULL_AND_PIECEWISE` CUDA Graph, async scheduling on:

| | exact_match |
|---|---|
| flexible-extract | 0.9545 ± 0.0057 |
| strict-match | 0.9538 ± 0.0058 |

The target alone scores 0.9553 ± 0.0057 under the same harness and concurrency (see the [Kimi-K3 recipe](recipes/atom_vllm/Kimi-K3.md)), so drafting is accuracy neutral as expected for verify-based speculative decoding.

Acceptance over that run: mean accepted length **3.777** tokens per forward, acceptance rate **39.7%**, over 36,119 verify forwards. Per-position acceptance rate is `0.923 / 0.774 / 0.602 / 0.442 / 0.034 / 0.002 / 0.000` — causal drafting means the last three of the seven block positions contribute about 1% of accepted tokens between them, which is the cost of not needing the LSE merge.

Also verified that prompts of every length from 1 to 20 tokens serve correctly. Prompts of 10 to 15 tokens are the interesting ones: `parallel_drafting` widens `reorder_batch_threshold` to `1 + 2 * num_speculative_tokens = 15`, so their prefill is classified as a decode and reaches `_build_decode`. An accuracy sweep never covers that window.

Rebased onto `main` over #1746 (DCP persistent PA), which touched the same two attention files. The work-descriptor sizing now uses that PR's `persistent_num_heads` inside this PR's per-query-length worst-case loop, and its DCP-on-gfx942 persistent opt-out runs before this PR's capacity assertion. Every number above was measured against the rebased tree, and the length sweep and smoke were re-run on it too. Acceptance held at 3.77-3.79 across four separate runs spanning the pre- and post-#1746 trees.

## Test plan

- [x] Full GSM8K 1319 examples over `vllm serve`, 64 concurrency, fresh server
- [x] Prompt length sweep 1..20 tokens against the served endpoint
- [x] Deterministic smoke from the recipe (`Question: What is 17 + 25? Answer:` returns ` 42`)
- [x] Torch profile at 8k input / 100 output / 16 concurrency with stacks, both models visible under their own MLA kernels (`aiter::mla_a8w8_*` target, `aiter::mla_a16w16_*` draft)
- [ ] Reviewer: confirm no regression for DeepSeek-V4 MTP and MiniMax-M3 EAGLE3, which share the patched speculative-decoding paths
