### PR TITLE
fix(plugin): gate dual-stream MoE by runtime graph mode

### DIFF
--- a/atom/model_ops/module_dispatch_ops.py
+++ b/atom/model_ops/module_dispatch_ops.py
@@ -25,9 +25,10 @@ Currently registered:
 
 import torch
 
-from atom.config import get_current_atom_config
+from atom.config import CUDAGraphMode, get_current_atom_config
 from atom.utils import envs
 from atom.utils.custom_register import direct_register_custom_op
+from atom.utils.forward_context import get_current_cudagraph_runtime_mode
 
 # ---------------------------------------------------------------------------
 # Dual-stream MoE dispatch (V2 / V3.2 / V4)
@@ -54,13 +55,12 @@ def maybe_dual_stream_forward(
     # Under TBO the two micro-batches already overlap on separate threads
     from atom.utils.tbo.ubatching import tbo_active
 
-    # PIECEWISE cudagraph only: dual_stream_moe_forward forks work onto
-    # `alt_stream` and does a caching-allocator alloc there; under PIECEWISE
-    # per-piece capture close the dual stream
-    compilation_config = get_current_atom_config().compilation_config
-    cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
+    # Graph ownership belongs to the active frontend.  Only a concrete
+    # PIECEWISE runtime decision is unsafe here: per-piece capture closes over
+    # the main stream while this forward forks work onto `alt_stream`.  Eager
+    # NONE and whole-model FULL capture both support the fork/join topology.
     is_piecewise_cudagraph = (
-        cudagraph_mode is not None and cudagraph_mode.requires_piecewise_compilation()
+        get_current_cudagraph_runtime_mode() == CUDAGraphMode.PIECEWISE
     )
 
     if (

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -11,7 +11,7 @@ from typing import Any, Union
 import numpy as np
 import torch
 
-from atom.config import CUDAGraphMode, Config, KVCacheTensor, ParallelConfig
+from atom.config import Config, CUDAGraphMode, KVCacheTensor, ParallelConfig
 
 
 class AttnState(Enum):

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -11,7 +11,7 @@ from typing import Any, Union
 import numpy as np
 import torch
 
-from atom.config import Config, KVCacheTensor, ParallelConfig
+from atom.config import CUDAGraphMode, Config, KVCacheTensor, ParallelConfig
 
 
 class AttnState(Enum):
@@ -598,6 +598,57 @@ def get_forward_context() -> ForwardContext:
         "Please use `set_forward_context` to set the forward context."
     )
     return _forward_context
+
+
+def _normalize_cudagraph_runtime_mode(mode: Any) -> CUDAGraphMode | None:
+    """Normalize a frontend runtime mode to ATOM's concrete enum.
+
+    Frontends own their graph dispatch and therefore use distinct enum
+    classes.  Match by name rather than value so their enum layouts can evolve
+    independently.  Composite configuration modes are deliberately rejected:
+    a forward context must describe the concrete NONE/PIECEWISE/FULL decision
+    for the current batch.
+    """
+    name = mode if isinstance(mode, str) else getattr(mode, "name", None)
+    if name not in {"NONE", "PIECEWISE", "FULL"}:
+        return None
+    return CUDAGraphMode[name]
+
+
+def get_current_cudagraph_runtime_mode() -> CUDAGraphMode:
+    """Return the concrete graph mode for the active model forward.
+
+    In vLLM plugin mode graph capture/replay is owned by vLLM, so its forward
+    context is authoritative.  Native ATOM records the same decision on its
+    own ForwardContext.  An unavailable/unknown context is treated as NONE:
+    eager dual-stream execution is valid, and some vLLM runners expose NONE
+    while a whole-model FULL graph is being captured.  Replay does not execute
+    this Python dispatcher.
+    """
+    from atom.plugin import is_vllm
+
+    if is_vllm():
+        try:
+            from vllm.forward_context import (
+                get_forward_context as get_vllm_forward_context,
+            )
+            from vllm.forward_context import (
+                is_forward_context_available,
+            )
+
+            if is_forward_context_available():
+                mode = _normalize_cudagraph_runtime_mode(
+                    get_vllm_forward_context().cudagraph_runtime_mode
+                )
+                if mode is not None:
+                    return mode
+        except (ImportError, AttributeError, AssertionError):
+            pass
+
+    mode = _normalize_cudagraph_runtime_mode(
+        getattr(get_forward_context(), "cudagraph_runtime_mode", None)
+    )
+    return mode if mode is not None else CUDAGraphMode.NONE
 
 
 def set_forward_context(


### PR DESCRIPTION
## Problem

In vLLM plugin mode, CUDA/HIP graph capture is owned by vLLM and the concrete runtime mode is selected per forward (`FULL`, `PIECEWISE`, or `NONE`). ATOM's MoE dispatcher instead checks its static compilation config.

For `FULL_AND_PIECEWISE`, the plugin maps vLLM's compile mode to ATOM level 3, which initializes the ATOM-side static graph mode as `PIECEWISE`. As a result, decode forwards that vLLM actually dispatches as `FULL` are incorrectly forced onto the single-stream MoE path. This was observed while validating Kimi-K3 dual-stream shared/routed expert overlap in ROCm/ATOM#1752.

## Solution

- Resolve the concrete graph mode from the active frontend's forward context.
- Normalize frontend enums by name instead of relying on matching numeric values.
- Fall back to ATOM's native forward context when vLLM context is unavailable.
- Disable dual-stream MoE only for an actual `PIECEWISE` forward; preserve it for eager/`NONE` and whole-model `FULL` capture.

## Validation

- [x] Black formatting check
- [x] Ruff lint check
- [x] Kimi-K3 TP8 with vLLM `FULL_DECODE_ONLY` and `FULL_AND_PIECEWISE`
- [x] Profiler confirmed decode dual-stream graph execution on all TP ranks; with the native-matched online quant configuration, measured stream overlap was 99.1%–100%
