### PR TITLE
[fix] Fix GLM5.2 nshot20 accuracy

### DIFF
--- a/atom/model_ops/layernorm.py
+++ b/atom/model_ops/layernorm.py
@@ -1252,9 +1252,14 @@ class LayerNorm(nn.Module):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # aiter layernorm kernels require weight/bias to match the input dtype;
+        # cast here (no-op when they already match) since params may be stored in
+        # a different dtype (e.g. fp32 for a fused kernel that reads them directly).
+        weight = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype)
         if residual is None:
-            return layernorm2d_fwd_(x, self.weight, self.bias, self.eps, self.dim)
+            return layernorm2d_fwd_(x, weight, bias, self.eps, self.dim)
         else:
             return layernorm2d_fwd_with_add_(
-                x, self.weight, residual, self.bias, self.eps, self.dim
+                x, weight, residual, bias, self.eps, self.dim
             )


### PR DESCRIPTION
## Motivation

GLM-5.2-FP8 loses accuracy on the **unfused indexer path** (`use_qk_rope_cache_fusion=False`): gsm8k n-shot=20 drops **0.96 → 0.73**.

**Root cause.** #1359 stores `indexer.k_norm` params as **fp32** (needed by the fused kernel `indexer_qk_rope_quant_and_cache`, which reads them as `const float*`). But the unfused path runs `k = self.k_norm(k)` → CK `layernorm2d_fwd`, which **requires weight/bias to match the input dtype (bf16)**. fp32 weight + bf16 input doesn't crash — it returns numerically **wrong** output → wrong indexer `k` → wrong top-k → accuracy drop. (This is the case flagged in the #1359 review; we confirmed CK `layernorm2d_fwd` does not accept fp32 weight.)

## Technical Details

`atom/model_ops/layernorm.py` — `LayerNorm.forward` casts weight/bias to the activation dtype before the kernel (no-op when they already match):

```python
weight = self.weight.to(x.dtype)
bias = self.bias.to(x.dtype)
```

- Fixes only the unfused path. `LayerNorm` has a single instance (indexer `k_norm`), so zero blast radius.
- Fused path unchanged: params stay fp32; the fused kernel still reads `self.k_norm.weight/.bias` (fp32) directly. No change to `deepseek_v2.py` (call site stays `k = self.k_norm(k)`).

## Test Plan

```bash
# unfused indexer path
ATOM_ENABLE_DS_INDEXER_QK_ROPE_CACHE_FUSION=0 \
python -m atom.entrypoints.openai_server --model /data1/models/GLM-5.2-FP8 -tp 8 \
  --kv_cache_dtype bf16

lm_eval --model local-completions \
  --model_args model=/data1/models/GLM-5.2-FP8,base_url=http://localhost:8000/v1/completions,num_concurrent=64,tokenized_requests=False \
  --tasks gsm8k --num_fewshot 20 --limit 100
```

## Test Result

gsm8k, GLM-5.2-FP8, TP8:

| Config | n-shot | samples | exact_match |
|--------|-------:|--------:|-------------|
| fused (default) | 20 | 100 | 0.96 |
| unfused — before fix | 20 | 100 | **0.73** |
| unfused — after fix | 20 | 100 | **0.96** |
| unfused — after fix | 100 | 1319 (full) | **0.9447** (±0.0063) |

## Submission Checklist
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
