### PR TITLE
fix(sglang): align DeepSeek-V4 compressed KV block geometry

### DIFF
--- a/atom/plugin/sglang/models/deepseek_v4_attention.py
+++ b/atom/plugin/sglang/models/deepseek_v4_attention.py
@@ -118,8 +118,12 @@ def _install_draft_extend_fused_swa_patch() -> None:
     """Patch ATOM DSV4 symbols only while SGLang graph integration needs them."""
 
     import atom.models.deepseek_v4 as dsv4
+    from atom.plugin.sglang.deepseek_v4_bridge import ATOM_DEEPSEEK_V4_BLOCK_SIZE
 
     _install_v4_nm_aiter_compat_patch()
+    # Keep compressor scatter/gather geometry aligned with the proxy pool's
+    # 128-token compressed-KV page layout.
+    dsv4._V4_BLOCK_SIZE = ATOM_DEEPSEEK_V4_BLOCK_SIZE
     if getattr(dsv4, "_atom_sglang_draft_extend_fused_swa_patched", False):
         return
 


### PR DESCRIPTION
## Motivation
[PR #1709](https://github.com/ROCm/ATOM/pull/1709) changed the shared DeepSeek-V4 compressed-KV block geometry from 128 to 256 tokens, while the SGLang proxy pool continued using 128-token pages. This caused incorrect CSA/HCA cache scatter and gather addressing.

The mismatch became visible after [PR #1775](https://github.com/ROCm/ATOM/pull/1775) correctly enabled the compressor quantization modes.

## Technical Details
This fix aligns the model-side block geometry with the SGLang proxy pool during adapter installation. The change is scoped to the SGLang plugin and does not alter native ATOM or vLLM behavior.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<img width="1026" height="213" alt="image" src="https://github.com/user-attachments/assets/581f2c0a-7923-46f9-bc1b-01be66a3757d" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
