### PR TITLE
fix(offload): prevent KV corruption on LMCache reload

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -44,6 +44,9 @@ class KVCacheTensor:
     v_cache: torch.Tensor = torch.tensor([])
     k_scale: torch.Tensor = None
     v_scale: torch.Tensor = None
+    # DSA sparse layers (GLM-5.2 / DeepSeek-V3.2): indexer key cache, block-major
+    # ``(num_blocks, block_size, aligned_index_dim)``. Omitted for non-DSA layers.
+    index_cache: torch.Tensor | None = None
 
 
 @dataclass

--- a/atom/config.py
+++ b/atom/config.py
@@ -40,8 +40,8 @@ class KVCacheTensor:
     """
 
     layer_num: int
-    k_cache: torch.Tensor = torch.tensor([])
-    v_cache: torch.Tensor = torch.tensor([])
+    k_cache: torch.Tensor = field(default_factory=lambda: torch.tensor([]))
+    v_cache: torch.Tensor = field(default_factory=lambda: torch.tensor([]))
     k_scale: torch.Tensor = None
     v_scale: torch.Tensor = None
     # DSA sparse layers (GLM-5.2 / DeepSeek-V3.2): indexer key cache, block-major

--- a/atom/kv_transfer/disaggregation/base.py
+++ b/atom/kv_transfer/disaggregation/base.py
@@ -39,7 +39,7 @@ class KVConnectorBase(ABC):
         """Register local KV cache tensors for remote access.
 
         Called once after model loading and KV cache allocation. ``num_blocks``
-        is the physical KV block count (used by the offload connector to
+        is the scheduler-visible block count (used by the offload connector to
         byte-slice MLA's token-major latent cache); connectors that don't need
         it may ignore it.
         """

--- a/atom/kv_transfer/offload/atom_kv_byte_codec.py
+++ b/atom/kv_transfer/offload/atom_kv_byte_codec.py
@@ -45,8 +45,8 @@ class ATOMKVByteCodec:
         ``register_kv_caches``. We flatten every movable per-layer tensor (K, V,
         and fp8 scales when present) into one ordered segment list.
 
-        Each segment is a contiguous GPU tensor whose first ``num_blocks``
-        equal slices are the per-physical-block payloads we copy as raw bytes.
+        Each segment is a contiguous GPU tensor whose first ``num_blocks`` equal
+        slices are scheduler-visible transfer-block payloads copied as raw bytes.
         Two layouts must both work:
 
         * **Standard MHA/GQA** — block-major ``[num_blocks, ...]`` (e.g. ATOM's
@@ -69,6 +69,8 @@ class ATOMKVByteCodec:
                 getattr(kvt, "v_cache", None),
                 getattr(kvt, "k_scale", None),
                 getattr(kvt, "v_scale", None),
+                # DSA indexer cache (GLM-5.2 / DeepSeek-V3.2 sparse layers).
+                getattr(kvt, "index_cache", None),
             ):
                 if t is not None and isinstance(t, torch.Tensor) and t.numel() > 0:
                     self._segments.append(t)
@@ -101,7 +103,7 @@ class ATOMKVByteCodec:
                     f"(shape={tuple(seg.shape)})"
                 )
 
-        # Bytes for one physical block of each segment. Works for both
+        # Bytes for one scheduler-visible block of each segment. Works for both
         # block-major (numel = num_blocks * per_block) and token-major MLA
         # (numel = num_blocks * block_size * per_token) because both reduce to
         # the same contiguous per-block stride.

--- a/atom/kv_transfer/offload/connector.py
+++ b/atom/kv_transfer/offload/connector.py
@@ -187,6 +187,14 @@ class LMCacheOffloadConnector(KVConnectorBase):
     def start_load_kv(self, metadata) -> None:
         if not isinstance(metadata, LMCacheOffloadMetadata):
             return
+        loading_lookup_ids = {
+            str(req.req_id)
+            for req in metadata.requests
+            if req.load_spec is not None and self._do_load
+        }
+        for lookup_id in metadata.lookup_requests_in_step:
+            if str(lookup_id) not in loading_lookup_ids:
+                self._lookup_unpin(lookup_id)
         save_ready_event = None
         if self._do_save and any(
             req.save_spec is not None for req in metadata.requests
@@ -229,7 +237,7 @@ class LMCacheOffloadConnector(KVConnectorBase):
         if getattr(self, "_engine", None) is None:
             return
         try:
-            self._engine.lookup_unpin([str(req_id)])  # LMCache pin keyed by str id
+            self._engine.lookup_unpin(str(req_id))
         except Exception:  # best-effort third-party cleanup
             logger.debug(
                 "LMCache offload: lookup unpin failed for %s",
@@ -510,8 +518,11 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
             return 0, False
         num_prompt = seq.num_prompt_tokens
         token_ids = list(seq.token_ids[:num_prompt])
+        sid = str(seq.id)
+        if sid not in self._lookup_in_step:
+            self._lookup_in_step.append(sid)
         try:
-            hit = self._lookup_client.lookup(token_ids, lookup_id=str(seq.id))
+            hit = self._lookup_client.lookup(token_ids, lookup_id=sid)
         except Exception:
             logger.exception("LMCache offload lookup failed for seq %s", seq.id)
             return 0, False
@@ -538,7 +549,6 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
             )
         if not hit:
             return 0, False
-        sid = str(seq.id)
         hit = int(hit)
         if hit == num_prompt:  # full-prompt hit → recompute last token
             hit -= 1
@@ -555,7 +565,6 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
                         exc_info=True,
                     )
             return 0, False
-        self._lookup_in_step.append(sid)
         self._load_specs[sid] = LoadSpec(
             hbm_cached_tokens=int(seq.num_cached_tokens),
             lmcache_cached_tokens=hit,
@@ -618,9 +627,6 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
         self._handoff_loads.discard(sid)
         self._load_save_floors.pop(sid, None)
         self._hit_save_floors.pop(sid, None)
-        self._lookup_in_step = [
-            req_id for req_id in self._lookup_in_step if req_id != sid
-        ]
         if self._lookup_client is not None:
             try:
                 self._lookup_client.clear_lookup_status(sid)
@@ -835,8 +841,12 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
                     load_spec=ls,
                 )
             )
-        meta.lookup_requests_in_step = self._lookup_in_step
-        self._lookup_in_step = []
+        meta.lookup_requests_in_step = [
+            sid for sid in self._lookup_in_step if sid not in self._handoff_loads
+        ]
+        self._lookup_in_step = [
+            sid for sid in self._lookup_in_step if sid in self._handoff_loads
+        ]
         # Saves: store fully computed prompt chunks. Under scheduler-side
         # chunked prefill, seq.num_cached_tokens advances after each prefill
         # chunk's forward has completed; use it as the D2H-safe frontier.

--- a/atom/kv_transfer/offload/connector.py
+++ b/atom/kv_transfer/offload/connector.py
@@ -112,10 +112,11 @@ class LMCacheOffloadConnector(KVConnectorBase):
             cfg, getattr(self._config, "kv_transfer_config", None)
         )
         self.chunk_size = int(cfg.chunk_size)
-        # num_blocks is the physical block count (num_physical_kvcache_blocks),
-        # threaded from the model runner. MLA stores its KV token-major, so the
-        # codec can't infer the block count from tensor.shape[0]; pass it.
+        # num_blocks is the scheduler-visible block count, threaded from the
+        # model runner. MLA stores its KV token-major, so the codec cannot infer
+        # this count from tensor.shape[0] (the page-size-1 physical row count).
         self._codec = ATOMKVByteCodec(kv_caches, num_blocks=num_blocks)
+        self._validate_block_geometry(transfer_tensors)
         base_meta = offcfg.build_lmcache_metadata(self._config, cfg, world, rank)
         meta = ATOMRawBytesLMCacheMetadata(
             base_meta,
@@ -168,19 +169,48 @@ class LMCacheOffloadConnector(KVConnectorBase):
             self._do_load,
         )
 
+    def _validate_block_geometry(self, transfer_tensors) -> None:
+        """Cross-check codec blocks against existing transfer-region metadata."""
+        block_regions = getattr(transfer_tensors, "block_regions", None) or []
+        if not block_regions:
+            return
+        expected = sum(int(region.unit_bytes) for region in block_regions)
+        if self._codec.bytes_per_block != expected:
+            raise ValueError(
+                "LMCache offload KV block geometry mismatch: "
+                f"codec={self._codec.bytes_per_block} bytes, "
+                f"transfer_regions={expected} bytes, "
+                f"num_blocks={self._codec.num_blocks}"
+            )
+
     # -- per-step (RPC thread): only enqueue, never copy ------------------
     def start_load_kv(self, metadata) -> None:
         if not isinstance(metadata, LMCacheOffloadMetadata):
             return
+        save_ready_event = None
+        if self._do_save and any(
+            req.save_spec is not None for req in metadata.requests
+        ):
+            # Forward kernels publish KV on the RPC thread's current stream.
+            # Save workers pack it on independent streams, so carry an event
+            # across the thread boundary instead of racing the producer.
+            save_ready_event = torch.cuda.Event()
+            save_ready_event.record(torch.cuda.current_stream())
         for req in metadata.requests:
             if req.load_spec is not None and self._do_load:
                 self._load_executor.submit(self._guard, "load", self._do_load_req, req)
             if req.save_spec is not None and self._do_save:
-                self._save_executor.submit(self._guard, "save", self._do_save_req, req)
+                self._save_executor.submit(
+                    self._guard,
+                    "save",
+                    self._do_save_req,
+                    req,
+                    save_ready_event,
+                )
 
-    def _guard(self, kind: str, fn, req) -> None:
+    def _guard(self, kind: str, fn, req, *args) -> None:
         try:
-            fn(req)
+            fn(req, *args)
         except Exception:
             logger.exception(
                 "LMCache offload: %s failed for %s", fn.__name__, req.req_id
@@ -315,7 +345,7 @@ class LMCacheOffloadConnector(KVConnectorBase):
                 total_ms,
             )
 
-    def _do_save_req(self, req: LMCacheReqMeta) -> None:
+    def _do_save_req(self, req: LMCacheReqMeta, producer_event=None) -> None:
         ss = req.save_spec
         assert ss is not None
         toks = req.token_ids
@@ -326,6 +356,12 @@ class LMCacheOffloadConnector(KVConnectorBase):
             with self._lock:
                 self._done_save.add(req.req_id)
             return
+
+        # Wait only for the forward work that produces this save's KV. This
+        # blocks the background save worker, not the model RPC thread, and is
+        # intentionally narrower than a device-wide synchronize().
+        if producer_event is not None:
+            producer_event.synchronize()
 
         t_total0 = time.perf_counter()
         mask = torch.ones(len(toks), dtype=torch.bool)

--- a/atom/kv_transfer/offload/metadata.py
+++ b/atom/kv_transfer/offload/metadata.py
@@ -129,7 +129,7 @@ class LMCacheOffloadMetadata(ConnectorMetadata):
     def __init__(self) -> None:
         super().__init__()
         self.requests: list[LMCacheReqMeta] = []
-        # req_ids whose scheduler-side lookup pin should be released this step.
+        # req_ids whose worker-side lookup pin can be released this step.
         self.lookup_requests_in_step: list[str] = []
 
     def add_request(self, meta: LMCacheReqMeta) -> None:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1976,13 +1976,16 @@ class ModelRunner:
             draft_regions = self.eagle3_draft_builder.get_kv_transfer_tensors()
             if draft_regions:
                 transfer_tensors.block_regions.extend(draft_regions)
-        # Pass the physical block count so the offload connector can byte-slice
-        # MLA's token-major latent cache (shape[0] is tokens, not blocks there).
+        # The transfer protocol addresses scheduler blocks, whose IDs index
+        # ``req.block_ids``.  MLA's cache is allocated in page-size-1 physical
+        # rows, so ``num_physical_kvcache_blocks`` is larger by block_ratio and
+        # must not be used here: doing so would make the codec treat one token
+        # as a complete scheduler block.
         set_kv_cache_data(
             kv_cache_data,
             config,
             transfer_tensors,
-            num_blocks=self.num_physical_kvcache_blocks,
+            num_blocks=num_kvcache_blocks,
         )
 
         # Cross-validate: compare estimated vs actual KV cache allocation.

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -1076,6 +1076,7 @@ class Scheduler:
                     num_seqs_prefill,
                     num_batched_tokens,
                 )
+                self._uncount_inflight_load(seq)
                 continue
 
             if (
@@ -1379,7 +1380,8 @@ class Scheduler:
         if self.kv_connector is not None and hasattr(self.kv_connector, "load_failed"):
             self.kv_connector.load_failed(seq.id)
         seq.status = SequenceStatus.WAITING
-        self._uncount_inflight_load(seq)
+        if not self._connector_flag("is_offload"):
+            self._uncount_inflight_load(seq)
         seq.offload_loaded = False
         seq.offload_loaded_tokens = seq.num_cached_tokens
         seq.offload_load_start_tokens = None
@@ -1537,8 +1539,12 @@ class Scheduler:
     ) -> None:
         skipped_waiting_requests.append(seq)
         seq.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
-        self._num_parked_remote_kv += 1
-        seq._counted_as_inflight_load = True
+        self._count_inflight_load(seq)
+
+    def _count_inflight_load(self, seq: Sequence) -> None:
+        if not getattr(seq, "_counted_as_inflight_load", False):
+            self._num_parked_remote_kv += 1
+            seq._counted_as_inflight_load = True
 
     def _uncount_inflight_load(self, seq: Sequence) -> None:
         if getattr(seq, "_counted_as_inflight_load", False):
@@ -1755,23 +1761,13 @@ class Scheduler:
                     continue
             elif seq.is_partial_prefill:
                 continue
-            # Drop stale tokens produced by chunked-prefill steps.
-            #
-            # There are two ways a stale token reaches this point:
-            # 1. Normal chunked prefill: the seq was partial at the start of
-            #    this postprocess call. With deferred output, the visible token
-            #    is one step late, so it belongs to the previous partial chunk.
-            # 2. Offload/remote-KV handoff: a partial seq can be parked out of
-            #    running and have seq.is_partial_prefill cleared. In that case
-            #    prev_partial_ids can no longer see it, so the park path sets
-            #    _discard_next_deferred_output to carry "drop one old token"
-            #    across the park/resume boundary.
-            was_partial_prefill_at_step_start = seq.id in prev_partial_ids
-            drop_old_token_after_offload_park = False
-            if is_deferred_out and getattr(seq, "_discard_next_deferred_output", False):
-                seq._discard_next_deferred_output = False
-                drop_old_token_after_offload_park = True
-            if was_partial_prefill_at_step_start or drop_old_token_after_offload_park:
+            # With deferred output, a token visible after a normal chunked-
+            # prefill step belongs to the previous partial chunk and must be
+            # dropped. An offload handoff is different: parking removes the
+            # request from at least one intervening model-runner batch, which
+            # already discards its deferred partial output. The first output
+            # after the request resumes is fresh and must be kept.
+            if seq.id in prev_partial_ids:
                 continue
             # Register prefix-cache hashes for blocks the prefill step just
             # finalized. Deferred from BlockManager.allocate() so a hash is
@@ -2206,10 +2202,10 @@ class Scheduler:
             should_park = self.kv_connector.should_park_partial_prefill_for_load(seq)
             if should_park:
                 if seq.is_partial_prefill:
-                    seq._discard_next_deferred_output = True
                     seq.is_partial_prefill = False
                     self._partial_prefill_count -= 1
                 seq.status = SequenceStatus.WAITING_FOR_REMOTE_KVS
+                self._count_inflight_load(seq)
                 parked.append(seq)
             else:
                 keep_running.append(seq)

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -901,12 +901,16 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 runner.aligned_index_dim,
             )
         module.kv_cache = kv_cache
+        index_cache = None
+        if runner.is_deepseek_v32 and hasattr(runner, "index_cache"):
+            index_cache = runner.index_cache[layer_id]
         return KVCacheTensor(
             layer_num=layer_id,
             k_cache=kv_cache,
             v_cache=None,
             k_scale=None,
             v_scale=None,
+            index_cache=index_cache,
         )
 
     def get_kv_transfer_tensors(self):

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -721,8 +721,6 @@ def set_kv_cache_data(
     MLA's token-major latent cache, where tensor.shape[0] is the page-size-1
     physical row count rather than the scheduler block count.
     """
-    global _forward_kv_cache_context
-
     if hasattr(config, "kv_transfer_config") and config.kv_transfer_config:
         connector = get_kvconnector(config=config)
         if connector is not None:

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -716,9 +716,10 @@ def set_kv_cache_data(
 ) -> None:
     """Register KV cache data globally and with the KV connector if enabled.
 
-    ``num_blocks`` is the physical KV block count; the offload connector needs
-    it to byte-slice MLA's token-major latent cache (where tensor.shape[0] is
-    the token count, not the block count).
+    ``num_blocks`` is the scheduler-visible KV block count (the ID space used
+    by request block tables). The offload connector needs it to byte-slice
+    MLA's token-major latent cache, where tensor.shape[0] is the page-size-1
+    physical row count rather than the scheduler block count.
     """
     global _forward_kv_cache_context
 

--- a/tests/test_lmcache_offload_connector.py
+++ b/tests/test_lmcache_offload_connector.py
@@ -24,7 +24,11 @@ from atom.kv_transfer.offload.atom_kv_byte_codec import ATOMKVByteCodec
 from atom.kv_transfer.offload.atom_lmcache_gpu_connector import (
     ATOMLMCacheGPUConnector,
 )
-from atom.kv_transfer.offload.metadata import ATOMRawBytesLMCacheMetadata
+from atom.kv_transfer.offload.metadata import (
+    ATOMRawBytesLMCacheMetadata,
+    LMCacheOffloadMetadata,
+    LMCacheReqMeta,
+)
 from atom.model_engine.scheduler import Scheduler
 
 
@@ -567,6 +571,23 @@ def test_full_prompt_hit_is_clamped_before_load_spec():
     assert sched._load_specs[str(seq.id)].lmcache_cached_tokens == 7
 
 
+def test_lookup_miss_is_forwarded_for_worker_unpin():
+    sched = _scheduler()
+    seq = SimpleNamespace(
+        id=124,
+        num_prompt_tokens=8,
+        token_ids=list(range(8)),
+        num_cached_tokens=0,
+    )
+
+    need, should_park = sched.get_num_new_matched_tokens(seq)
+    meta = sched.build_connector_meta()
+
+    assert need == 0
+    assert should_park is False
+    assert meta.lookup_requests_in_step == ["124"]
+
+
 def test_load_is_skipped_if_hbm_satisfies_after_allocation():
     sched = _scheduler()
     lookup = _LookupClient(hit=8)
@@ -593,6 +614,7 @@ def test_load_is_skipped_if_hbm_satisfies_after_allocation():
 
     assert meta.requests == []
     assert [req for req in meta.requests if req.load_spec is not None] == []
+    assert meta.lookup_requests_in_step == ["321"]
     assert seq.offload_loaded_tokens == 8
     assert sched._save_tracker[str(seq.id)][1] == 8
     assert lookup.cleared == ["321"]
@@ -620,6 +642,7 @@ def test_lookup_time_hbm_satisfies_does_not_resave_hit_prefix():
     meta1 = sched.build_connector_meta()
 
     assert meta1.requests == []
+    assert meta1.lookup_requests_in_step == ["322"]
     assert sched._save_tracker[str(seq.id)][1] == 8
     assert lookup.cleared == ["322"]
 
@@ -657,6 +680,10 @@ def test_unaligned_hbm_handoff_prefills_boundary_then_emits_load():
     assert seq.offload_loaded_tokens == 6
     assert sched.adjust_prefill_chunk_after_alloc(seq, 10) == 2
 
+    handoff_meta = sched.build_connector_meta()
+    assert handoff_meta.lookup_requests_in_step == []
+    assert sched._lookup_in_step == ["657"]
+
     seq.num_cached_tokens = 8
     assert sched.should_park_partial_prefill_for_load(seq) is True
     meta = sched.build_connector_meta()
@@ -668,6 +695,7 @@ def test_unaligned_hbm_handoff_prefills_boundary_then_emits_load():
     assert req.token_ids == list(range(16))
     assert req.load_spec.hbm_cached_tokens == 8
     assert req.load_spec.lmcache_cached_tokens == 16
+    assert meta.lookup_requests_in_step == ["657"]
     assert seq.offload_loaded_tokens == 16
     assert str(seq.id) not in sched._handoff_loads
     assert lookup.cleared == []
@@ -699,6 +727,7 @@ def test_unaligned_handoff_skips_if_boundary_remainder_is_too_small():
     assert str(seq.id) not in sched._reqs_need_recv
     assert seq.offload_loaded_tokens == 6
     assert lookup.cleared == ["658"]
+    assert sched.build_connector_meta().lookup_requests_in_step == ["658"]
 
 
 def test_load_is_skipped_if_aligned_hit_is_below_threshold():
@@ -724,6 +753,7 @@ def test_load_is_skipped_if_aligned_hit_is_below_threshold():
     meta = sched.build_connector_meta()
 
     assert [req for req in meta.requests if req.load_spec is not None] == []
+    assert meta.lookup_requests_in_step == ["655"]
     assert seq.offload_loaded_tokens == 8
     assert lookup.cleared == ["655"]
 
@@ -758,6 +788,7 @@ def test_aligned_large_hit_parks_and_emits_load_metadata():
     assert req.block_ids == [1, 2, 3, 4]
     assert req.load_spec.hbm_cached_tokens == 4
     assert req.load_spec.lmcache_cached_tokens == 12
+    assert meta.lookup_requests_in_step == ["656"]
     assert seq.offload_loaded_tokens == 12
     assert lookup.cleared == []
 
@@ -834,7 +865,9 @@ def test_worker_completes_noop_load_when_hbm_satisfies():
     conn._failed_load = set()
     conn._done_save = set()
     conn._engine = SimpleNamespace(unpinned=[])
-    conn._engine.lookup_unpin = lambda ids: conn._engine.unpinned.extend(ids)
+    conn._engine.lookup_unpin = lambda lookup_id: conn._engine.unpinned.append(
+        lookup_id
+    )
 
     req = SimpleNamespace(
         req_id=321,
@@ -850,6 +883,46 @@ def test_worker_completes_noop_load_when_hbm_satisfies():
     assert conn._engine.unpinned == ["321"]
 
 
+def test_worker_unpins_only_lookups_without_an_emitted_load():
+    class _Executor:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def submit(self, *args) -> None:
+            self.calls.append(args)
+
+    class _Engine:
+        def __init__(self) -> None:
+            self.unpinned = []
+
+        def lookup_unpin(self, lookup_id) -> None:
+            self.unpinned.append(lookup_id)
+
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._do_load = True
+    conn._do_save = False
+    conn._engine = _Engine()
+    conn._load_executor = _Executor()
+    metadata = LMCacheOffloadMetadata()
+    metadata.lookup_requests_in_step = ["skipped", "loading"]
+    metadata.add_request(
+        LMCacheReqMeta(
+            req_id="loading",
+            token_ids=list(range(8)),
+            block_ids=[1, 2],
+            load_spec=SimpleNamespace(
+                hbm_cached_tokens=4,
+                lmcache_cached_tokens=8,
+            ),
+        )
+    )
+
+    conn.start_load_kv(metadata)
+
+    assert conn._engine.unpinned == ["skipped"]
+    assert len(conn._load_executor.calls) == 1
+
+
 def test_worker_reports_unaligned_hbm_load_as_failed_without_exception():
     conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
     conn._lock = threading.Lock()
@@ -858,7 +931,9 @@ def test_worker_reports_unaligned_hbm_load_as_failed_without_exception():
     conn._done_save = set()
     conn.chunk_size = 4
     conn._engine = SimpleNamespace(unpinned=[])
-    conn._engine.lookup_unpin = lambda ids: conn._engine.unpinned.extend(ids)
+    conn._engine.lookup_unpin = lambda lookup_id: conn._engine.unpinned.append(
+        lookup_id
+    )
 
     req = SimpleNamespace(
         req_id=654,
@@ -963,8 +1038,8 @@ def test_worker_load_uses_lmcache_engine_retrieve_and_marks_done():
             self.calls.append((tokens.tolist(), mask.tolist(), kwargs))
             return torch.tensor([False] * 4 + [True] * 8, dtype=torch.bool)
 
-        def lookup_unpin(self, ids) -> None:
-            self.unpinned.extend(ids)
+        def lookup_unpin(self, lookup_id) -> None:
+            self.unpinned.append(lookup_id)
 
     conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
     conn._lock = threading.Lock()
@@ -1006,8 +1081,8 @@ def test_worker_load_partial_retrieve_marks_failed():
         def retrieve(self, tokens, mask=None, **kwargs):
             return torch.tensor([False] * 4 + [True] * 4 + [False] * 4)
 
-        def lookup_unpin(self, ids) -> None:
-            self.unpinned.extend(ids)
+        def lookup_unpin(self, lookup_id) -> None:
+            self.unpinned.append(lookup_id)
 
     conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
     conn._lock = threading.Lock()

--- a/tests/test_lmcache_offload_connector.py
+++ b/tests/test_lmcache_offload_connector.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
-import threading
 import sys
+import threading
 import types
 from types import SimpleNamespace
 
@@ -16,13 +16,13 @@ except ModuleNotFoundError:
     sys.modules["torch"] = types.ModuleType("torch")
 
 from atom.kv_transfer.disaggregation import KVConnectorOutput, KVOutputAggregator
-from atom.kv_transfer.offload.connector import (
-    LMCacheOffloadConnector,
-    LMCacheOffloadConnectorScheduler,
-)
 from atom.kv_transfer.offload.atom_kv_byte_codec import ATOMKVByteCodec
 from atom.kv_transfer.offload.atom_lmcache_gpu_connector import (
     ATOMLMCacheGPUConnector,
+)
+from atom.kv_transfer.offload.connector import (
+    LMCacheOffloadConnector,
+    LMCacheOffloadConnectorScheduler,
 )
 from atom.kv_transfer.offload.metadata import (
     ATOMRawBytesLMCacheMetadata,
@@ -1403,9 +1403,9 @@ def test_codec_dsa_includes_index_cache_segment():
         pytest.skip("real torch is unavailable")
 
     num_blocks, block_size, latent, index_dim = 4, 2, 3, 5
-    k_cache = torch.arange(
-        num_blocks * block_size * latent, dtype=torch.uint8
-    ).reshape(num_blocks * block_size, 1, latent)
+    k_cache = torch.arange(num_blocks * block_size * latent, dtype=torch.uint8).reshape(
+        num_blocks * block_size, 1, latent
+    )
     # Block-major indexer cache (num_blocks, block_size, index_dim).
     index_cache = torch.arange(
         num_blocks * block_size * index_dim, dtype=torch.uint8
@@ -1440,8 +1440,14 @@ def test_codec_dsa_includes_index_cache_segment():
     # each chunk it is all K blocks, then all index blocks.
     expected = torch.cat(
         [
-            k_flat[0], k_flat[1], idx_flat[0], idx_flat[1],
-            k_flat[2], k_flat[3], idx_flat[2], idx_flat[3],
+            k_flat[0],
+            k_flat[1],
+            idx_flat[0],
+            idx_flat[1],
+            k_flat[2],
+            k_flat[3],
+            idx_flat[2],
+            idx_flat[3],
         ],
     )
     assert torch.equal(device_buf.cpu(), expected.cpu())
@@ -1521,9 +1527,9 @@ def test_codec_dsa_fp8_multilayer_including_mtp_round_trip():
     codec.gpu_to_chunk_major_device_buffer(device_buf, block_id_groups)
 
     # Wipe every segment (via the uint8 view for fp8) and scatter back.
-    for name in kv_caches:
-        kv_caches[name].k_cache.zero_()
-        kv_caches[name].index_cache.view(torch.uint8).zero_()
+    for cache in kv_caches.values():
+        cache.k_cache.zero_()
+        cache.index_cache.view(torch.uint8).zero_()
     codec.chunk_major_device_buffer_to_gpu(device_buf, block_id_groups)
 
     for name, (k, idx) in layers.items():

--- a/tests/test_lmcache_offload_connector.py
+++ b/tests/test_lmcache_offload_connector.py
@@ -912,6 +912,42 @@ def test_worker_save_uses_lmcache_engine_store():
     assert kwargs["req_id"] == "987"
 
 
+def test_worker_save_waits_for_forward_event_before_store():
+    import torch
+
+    if not hasattr(torch, "tensor"):
+        pytest.skip("real torch is unavailable")
+
+    order = []
+
+    class _Event:
+        def synchronize(self) -> None:
+            order.append("forward-ready")
+
+    class _Engine:
+        def store(self, *args, **kwargs) -> None:
+            order.append("store")
+
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._lock = threading.Lock()
+    conn._done_save = set()
+    conn.chunk_size = 4
+    conn._engine = _Engine()
+
+    req = SimpleNamespace(
+        req_id=988,
+        token_ids=list(range(8)),
+        block_ids=[3, 4],
+        is_last_prefill=True,
+        save_spec=SimpleNamespace(skip_leading_tokens=0),
+    )
+
+    conn._do_save_req(req, _Event())
+
+    assert order == ["forward-ready", "store"]
+    assert conn._done_save == {988}
+
+
 def test_worker_load_uses_lmcache_engine_retrieve_and_marks_done():
     import torch
 
@@ -1218,8 +1254,21 @@ def test_codec_mla_token_major_block_accounting():
 
     # Block count comes from the explicit arg, not tensor.shape[0] (= tokens).
     assert codec.num_blocks == num_blocks
-    # One physical block spans block_size tokens of `latent` bytes each.
+    # One scheduler block spans block_size tokens of `latent` bytes each.
     assert codec.bytes_per_block == block_size * latent
+
+    # Regression: passing the page-size-1 physical row count instead of the
+    # scheduler block count shrinks each transfer block by block_size. The
+    # connector compares this against its existing transfer-region metadata.
+    wrong_codec = ATOMKVByteCodec(kv_caches, num_blocks=num_blocks * block_size)
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._codec = wrong_codec
+    with pytest.raises(ValueError, match="KV block geometry mismatch"):
+        conn._validate_block_geometry(
+            SimpleNamespace(
+                block_regions=[SimpleNamespace(unit_bytes=block_size * latent)]
+            )
+        )
 
     # A segment whose element count is not divisible by num_blocks is rejected.
     with pytest.raises(ValueError):
@@ -1270,3 +1319,141 @@ def test_codec_mla_round_trip_byte_identical():
     kv_caches["l0"].k_cache.zero_()
     codec.chunk_major_device_buffer_to_gpu(device_buf, block_id_groups)
     assert torch.equal(kv_caches["l0"].k_cache, original)
+
+
+def test_codec_dsa_includes_index_cache_segment():
+    import torch
+
+    if not hasattr(torch, "arange"):
+        pytest.skip("real torch is unavailable")
+
+    num_blocks, block_size, latent, index_dim = 4, 2, 3, 5
+    k_cache = torch.arange(
+        num_blocks * block_size * latent, dtype=torch.uint8
+    ).reshape(num_blocks * block_size, 1, latent)
+    # Block-major indexer cache (num_blocks, block_size, index_dim).
+    index_cache = torch.arange(
+        num_blocks * block_size * index_dim, dtype=torch.uint8
+    ).reshape(num_blocks, block_size, index_dim)
+    kv_caches = {
+        "l0": SimpleNamespace(
+            k_cache=k_cache.clone(),
+            v_cache=None,
+            k_scale=None,
+            v_scale=None,
+            index_cache=index_cache.clone(),
+        )
+    }
+    codec = ATOMKVByteCodec(kv_caches, num_blocks=num_blocks)
+    mla_only = block_size * latent
+    index_only = block_size * index_dim
+    assert codec.bytes_per_block == mla_only + index_only
+
+    _install_byte_addressing_fused(codec)
+    # Stage every block (two chunks) so the round trip below can assert the full
+    # tensor is restored.
+    block_id_groups = [[0, 1], [2, 3]]
+    device_buf = torch.empty(
+        num_blocks * codec.bytes_per_block, dtype=torch.uint8, device=codec.device
+    )
+    codec.gpu_to_chunk_major_device_buffer(device_buf, block_id_groups)
+
+    k_flat = k_cache.view(torch.uint8).reshape(num_blocks, -1)
+    idx_flat = index_cache.reshape(num_blocks, -1)
+    # Staging is segment-major within a chunk (see ATOMKVByteCodec docstring and
+    # the Triton kernel's ``segment_prefix_bytes[seg] * nblocks`` base): within
+    # each chunk it is all K blocks, then all index blocks.
+    expected = torch.cat(
+        [
+            k_flat[0], k_flat[1], idx_flat[0], idx_flat[1],
+            k_flat[2], k_flat[3], idx_flat[2], idx_flat[3],
+        ],
+    )
+    assert torch.equal(device_buf.cpu(), expected.cpu())
+
+    kv_caches["l0"].k_cache.zero_()
+    kv_caches["l0"].index_cache.zero_()
+    codec.chunk_major_device_buffer_to_gpu(device_buf, block_id_groups)
+    assert torch.equal(kv_caches["l0"].k_cache, k_cache)
+    assert torch.equal(kv_caches["l0"].index_cache, index_cache)
+
+
+def test_codec_dsa_fp8_multilayer_including_mtp_round_trip():
+    """GLM-5.2 realistic geometry: an ``fp8`` indexer cache
+    (``aligned_index_dim=144``) alongside the token-major MLA latent (576),
+    across main *and* MTP layers.
+
+    For GLM-5.2 the MTP draft is MLA, so it shares the target's KV pool and is
+    bound by the main attention builder exactly like a decoder layer (no
+    ``eagle3_draft_builder``); its ``index_cache`` therefore reaches the codec
+    as just another registered layer. This asserts the codec moves the fp8
+    index segment byte-exact for every layer. Bytes are compared through a
+    ``uint8`` view so fp8 NaN bit patterns (which are ``!=`` themselves) do not
+    make a byte-identical round trip look unequal.
+    """
+    import torch
+
+    if not hasattr(torch, "arange"):
+        pytest.skip("real torch is unavailable")
+    fp8 = getattr(torch, "float8_e4m3fn", None)
+    if fp8 is None:
+        pytest.skip("fp8 dtype unavailable")
+
+    num_blocks, block_size = 4, 2
+    latent, aligned_index_dim = 576, 144  # DeepSeek-V3.2 / GLM-5.2 real dims
+
+    def _make_layer(seed: int):
+        # MLA latent: token-major (num_blocks*block_size, 1, latent).
+        k = (
+            torch.arange(num_blocks * block_size * latent, dtype=torch.uint8) + seed
+        ).reshape(num_blocks * block_size, 1, latent)
+        # Indexer: block-major (num_blocks, block_size, aligned_index_dim), fp8.
+        idx = (
+            (
+                torch.arange(
+                    num_blocks * block_size * aligned_index_dim, dtype=torch.uint8
+                )
+                + seed * 7
+            )
+            .view(fp8)
+            .reshape(num_blocks, block_size, aligned_index_dim)
+        )
+        return k, idx
+
+    # layer_0/layer_1 are decoder layers; layer_2 stands in for the MTP layer,
+    # which shares the pool and is registered identically.
+    layers = {f"layer_{i}": _make_layer(i) for i in range(3)}
+    kv_caches = {
+        name: SimpleNamespace(
+            k_cache=k.clone(),
+            v_cache=None,
+            k_scale=None,
+            v_scale=None,
+            index_cache=idx.clone(),
+        )
+        for name, (k, idx) in layers.items()
+    }
+    codec = ATOMKVByteCodec(kv_caches, num_blocks=num_blocks)
+
+    per_block = block_size * latent + block_size * aligned_index_dim
+    assert codec.bytes_per_block == len(layers) * per_block
+
+    _install_byte_addressing_fused(codec)
+    block_id_groups = [[0, 1], [2, 3]]
+    device_buf = torch.empty(
+        num_blocks * codec.bytes_per_block, dtype=torch.uint8, device=codec.device
+    )
+    codec.gpu_to_chunk_major_device_buffer(device_buf, block_id_groups)
+
+    # Wipe every segment (via the uint8 view for fp8) and scatter back.
+    for name in kv_caches:
+        kv_caches[name].k_cache.zero_()
+        kv_caches[name].index_cache.view(torch.uint8).zero_()
+    codec.chunk_major_device_buffer_to_gpu(device_buf, block_id_groups)
+
+    for name, (k, idx) in layers.items():
+        assert torch.equal(kv_caches[name].k_cache, k)
+        assert torch.equal(
+            kv_caches[name].index_cache.view(torch.uint8),
+            idx.view(torch.uint8),
+        )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -225,6 +225,52 @@ class TestSchedule:
 
         assert [seq.id for seq in sched.waiting] == [2, 1, 3]
 
+    def test_offload_parked_count_released_only_after_resume(self, seq_factory):
+        sched = Scheduler(
+            MockConfig(
+                max_num_seqs=2,
+                max_num_batched_tokens=64,
+                num_kvcache_blocks=100,
+            )
+        )
+        sched.kv_connector = SimpleNamespace(
+            is_offload=True,
+            build_connector_meta=lambda: None,
+        )
+
+        seq = seq_factory(list(range(8)))
+        seq.num_cached_tokens = 4
+        seq.block_table = [0]
+        seq.offload_loaded_tokens = 4
+        sched._park_for_remote_load(seq, deque())
+        sched._count_inflight_load(seq)
+        sched.finished_recving_kv_req_ids.append(seq.id)
+
+        assert sched._resolve_waiting_remote_kv(seq, deque()) is False
+        assert sched._num_parked_remote_kv == 1
+        sched.waiting.append(seq)
+
+        batch, _ = sched.schedule()
+
+        assert batch.total_seqs_num_prefill == 1
+        assert seq in sched.running
+        assert sched._num_parked_remote_kv == 0
+        assert seq._counted_as_inflight_load is False
+
+        sched.running.clear()
+        failed = seq_factory(list(range(8)))
+        failed.num_cached_tokens = 4
+        failed.block_table = [0]
+        sched._park_for_remote_load(failed, deque())
+        sched.failed_recving_kv_req_ids.append(failed.id)
+        sched.waiting.append(failed)
+
+        sched.schedule()
+
+        assert failed.offload_load_failed is True
+        assert failed in sched.running
+        assert sched._num_parked_remote_kv == 0
+
     def test_partial_prefill_ready_for_offload_load_moves_to_waiting(self):
         class _Connector:
             def should_park_partial_prefill_for_load(self, seq):
@@ -234,6 +280,7 @@ class TestSchedule:
         sched.kv_connector = _Connector()
         sched.waiting = deque()
         sched._partial_prefill_count = 1
+        sched._num_parked_remote_kv = 0
         keep = SimpleNamespace(
             id=1,
             status=SequenceStatus.RUNNING,
@@ -252,10 +299,12 @@ class TestSchedule:
         assert [seq.id for seq in sched.waiting] == [2]
         assert ready.status == SequenceStatus.WAITING_FOR_REMOTE_KVS
         assert ready.is_partial_prefill is False
-        assert ready._discard_next_deferred_output is True
+        assert not hasattr(ready, "_discard_next_deferred_output")
         assert sched._partial_prefill_count == 0
+        assert sched._num_parked_remote_kv == 1
+        assert ready._counted_as_inflight_load is True
 
-    def test_offload_partial_handoff_discards_stale_deferred_output(self, seq_factory):
+    def test_offload_partial_handoff_keeps_resumed_deferred_output(self, seq_factory):
         sched = Scheduler(
             MockConfig(
                 max_num_batched_tokens=64,
@@ -268,7 +317,9 @@ class TestSchedule:
         seq.status = SequenceStatus.RUNNING
         seq.type = SequenceType.PREFILL
         seq.num_cached_tokens = 8
-        seq._discard_next_deferred_output = True
+        # The pre-handoff partial-prefill postprocess already appended the
+        # deferred-output placeholder before the request was parked.
+        seq.append_token(sched.eos_token_id)
         sched.running = deque([seq])
 
         sched.postprocess(
@@ -285,9 +336,7 @@ class TestSchedule:
         )
 
         assert seq.num_cached_tokens == 10
-        assert seq._discard_next_deferred_output is False
-        assert 999 not in seq.output_tokens
-        assert seq.output_tokens == [sched.eos_token_id]
+        assert seq.output_tokens == [999, sched.eos_token_id]
 
 
 # ── _waiting_new_token_count (PrefillDelayer queue signal) ─────────────────


### PR DESCRIPTION
## Summary

- include the GLM-5.2 / DeepSeek-V3.2 DSA index cache in raw-byte KV transfers
- slice MLA KV tensors by scheduler-visible blocks and validate codec geometry against transfer regions
- synchronize background LMCache saves with the forward producer using a CUDA event
- preserve the first fresh token when an unaligned HBM-to-LMCache handoff resumes
- keep LMCache lookup pins and parked remote-KV accounting valid across the handoff

## Root cause

### Raw-byte KV transfer

MLA allocates page-size-1 physical rows while request block tables address 16-token scheduler blocks. Passing the physical row count made each codec block 16x too small. Separately, the asynchronous save pack stream could read the first KV group before forward finished producing it.

### Unaligned HBM-to-LMCache handoff

When the HBM-cached prefix ends in the middle of a scheduler block, the scheduler first computes to the next block boundary, parks the request, and then loads the remaining prefix from LMCache.

ATOM uses deferred model output, so output produced in one model-runner batch is consumed in the next batch. Parking removes the request from at least one intervening model-runner batch; that absence already discards the stale output from the partial-prefill step.

The previous handoff path additionally set `_discard_next_deferred_output` before parking and kept it across the park/resume boundary. After the LMCache load completed, the flag incorrectly discarded the first fresh token produced by the resumed request. The EOS placeholder then remained in the sequence state and could steer subsequent decoding away from the expected answer, including occasional Java/Python code output in the second GSM8K round.

Two related lifecycle issues were also present:

- lookup pins could be released before an unaligned handoff emitted its real load, while misses and skipped loads were not consistently forwarded to the worker for unpinning
- parked remote-KV requests could be counted more than once or released from the count before they actually re-entered the running batch

## Fix

- remove the cross-park `_discard_next_deferred_output` state
- continue dropping deferred output only for normal consecutive chunked-prefill steps identified by `prev_partial_ids`
- retain the lookup pin through an unaligned handoff until the real LMCache load, and unpin lookup misses, HBM-covered loads, and too-small skipped loads on the worker
- pass the single string lookup ID expected by `lookup_unpin()`
- make parked remote-KV counting idempotent and release it only after the request is actually scheduled back into the running batch
- retain the unaligned handoff and `publish_loaded_prefix` performance paths

## Validation

- original related unit suites: 167 passed, 1 skipped
- new scheduler/LMCache handoff regression suite: 98 passed in 0.57s
- TP8 GLM-5.2-FP8 forced-eviction regression: baseline, HBM hit, and LMCache reload all returned `zebra`; `MATCH=True`
- full GSM8K, TP8, `gpu-memory-utilization=0.45`, HBM prefix cache enabled, two consecutive rounds:
  - round 1: flexible accuracy 0.9477; strict accuracy 0.9469
  - round 2: flexible accuracy 0.9447; strict accuracy 0.9447
- 2638/2638 requests returned HTTP 200
- 1315 LMCache promotions
- 64 mixed handoffs with a non-zero LMCache load start
- 0 Java/Python code outputs
- 0 Traceback/ERROR entries
- 0 shared-memory timeouts
- `compileall` and `git diff --check` passed

The final handoff fix is included in commit `a4dbfbd4`.
