### PR TITLE
feat: add reliable DP/TP collective RPC support for ATOM workers

### DIFF
--- a/atom/model_engine/async_proc.py
+++ b/atom/model_engine/async_proc.py
@@ -25,7 +25,14 @@ from threading import Thread
 import zmq
 import zmq.asyncio
 from aiter.dist.shm_broadcast import MessageQueue
+
 from atom.kv_transfer.disaggregation import KVOutputAggregator
+from atom.model_engine.collective_rpc import (
+    COLLECTIVE_RPC_COMMAND,
+    CollectiveRPCRequest,
+    RPCErrorInfo,
+    WorkerRPCResponse,
+)
 from atom.utils import (
     get_mp_context,
     get_open_zmq_ipc_path,
@@ -55,6 +62,7 @@ class AsyncIOProc:
         runner_qualname: Fully qualified class name of the runner to instantiate.
         rank: TP rank of this worker.
         kv_output_addr: Optional ZMQ endpoint for KV aggregation output.
+        rpc_output_addr: Optional ZMQ endpoint for collective RPC acknowledgements.
     """
 
     # Function names whose output goes to the KV channel instead of primary
@@ -70,6 +78,7 @@ class AsyncIOProc:
         kv_output_addr: str | None = None,
         all_ranks_barrier=None,
         *args,
+        rpc_output_addr: str | None = None,
         **kwargs,
     ):
         # Bind this worker's lifetime to its parent EngineCore: if the parent
@@ -115,6 +124,10 @@ class AsyncIOProc:
         # KV aggregation output channel
         self.kv_output_addr = kv_output_addr
         self.kv_queue: queue.Queue | None = None
+        # Collective RPC completion channel. Unlike the primary output channel,
+        # every TP rank owns one so the caller can prove that all ranks finished.
+        self.rpc_output_addr = rpc_output_addr
+        self.rpc_queue: queue.Queue | None = None
 
         self.rpc_broadcast_mq = MessageQueue.create_from_handle(input_shm_handle, rank)
         import atexit
@@ -140,6 +153,16 @@ class AsyncIOProc:
             t = threading.Thread(
                 target=self.send_output_to_socket,
                 args=(self.kv_output_addr, self.kv_queue),
+                daemon=True,
+            )
+            t.start()
+            self.io_threads.append(t)
+
+        if self.rpc_output_addr is not None:
+            self.rpc_queue = queue.Queue()
+            t = threading.Thread(
+                target=self.send_output_to_socket,
+                args=(self.rpc_output_addr, self.rpc_queue),
                 daemon=True,
             )
             t.start()
@@ -210,6 +233,9 @@ class AsyncIOProc:
         """Main event loop: dequeue RPCs and dispatch to runners."""
         while True:
             func_name, args = self.get_func()
+            if func_name == COLLECTIVE_RPC_COMMAND:
+                self._execute_collective_rpc(*args)
+                continue
             need_barrier = func_name in self._BARRIER_FUNCS
             for runner in self.runners:
                 func = getattr(runner, func_name, None)
@@ -230,6 +256,28 @@ class AsyncIOProc:
                 break
         logger.debug(f"{self.label}: exit busy_loop...")
 
+    def _execute_collective_rpc(
+        self,
+        request: CollectiveRPCRequest,
+    ) -> None:
+        """Execute one control-plane RPC and always acknowledge this TP rank."""
+        try:
+            runner = self.runners[0]
+            func = getattr(runner, request.method)
+            result = func(*request.args, **request.kwargs)
+            response = WorkerRPCResponse.success(request.request_id, self.rank, result)
+            # Turn an unpicklable result into a normal RPC failure instead of
+            # silently killing the socket sender thread.
+            pickle.dumps(response)
+        except Exception as exc:
+            response = WorkerRPCResponse.failure(
+                request.request_id, self.rank, RPCErrorInfo.from_exception(exc)
+            )
+
+        if self.rpc_queue is None:
+            raise RuntimeError("collective RPC response channel is not configured")
+        self.rpc_queue.put_nowait(response)
+
     def get_func(self):
         method_name, *args = self.rpc_broadcast_mq.dequeue()
         return method_name, args
@@ -241,10 +289,11 @@ class AsyncIOProcManager:
     Handles process lifecycle, function dispatch via shared-memory broadcast,
     and KV output aggregation across all workers.
 
-    The manager maintains two output channels:
+    The manager maintains three output channels:
     - **Primary channel** (rank 0 only): Regular forward outputs.
     - **KV channels** (all ranks): Per-worker KV transfer status, aggregated
       by :class:`KVOutputAggregator` before returning to the caller.
+    - **RPC channels** (all ranks): Per-worker control-plane results and errors.
 
     Args:
         finalizer: Callback invoked when the manager shuts down.
@@ -282,6 +331,11 @@ class AsyncIOProcManager:
             queue.Queue() for _ in range(proc_num)
         ]
         self.kv_output_threads: list[threading.Thread] = []
+        self.rpc_output_addrs = [get_open_zmq_ipc_path() for _ in range(proc_num)]
+        self.rpc_outputs_queues: list[queue.Queue] = [
+            queue.Queue() for _ in range(proc_num)
+        ]
+        self.rpc_output_threads: list[threading.Thread] = []
 
         for i in range(proc_num):
             label = f"ModelRunner{i}/{proc_num}"
@@ -301,6 +355,7 @@ class AsyncIOProcManager:
                     self.all_ranks_barrier,
                     *args,
                 ),
+                kwargs={"rpc_output_addr": self.rpc_output_addrs[i]},
             )
             process.start()
             self.procs.append(process)
@@ -328,6 +383,16 @@ class AsyncIOProcManager:
             t.start()
             self.kv_output_threads.append(t)
 
+        for i, output_addr in enumerate(self.rpc_output_addrs):
+            t = threading.Thread(
+                target=self.process_rpc_output_sockets,
+                name=f"{self.label}_rpc_output_thread_{i}",
+                args=(output_addr, i),
+                daemon=True,
+            )
+            t.start()
+            self.rpc_output_threads.append(t)
+
         self.monitor_procs()
 
     def exit(self):
@@ -343,6 +408,8 @@ class AsyncIOProcManager:
         self.procs = []
         self.output_thread.join(timeout=1)
         for thread in self.kv_output_threads:
+            thread.join(timeout=0.5)
+        for thread in self.rpc_output_threads:
             thread.join(timeout=0.5)
         logger.info(f"{self.label}: All runners are shutdown.")
         self.outputs_queue.put_nowait(SystemExit())
@@ -397,6 +464,22 @@ class AsyncIOProcManager:
             output_socket.close(linger=0)
             logger.debug(f"{self.label}: kv output thread {worker_id} exit")
 
+    def process_rpc_output_sockets(self, output_address: str, worker_id: int):
+        """Receive collective RPC acknowledgements from one TP worker."""
+        output_socket = make_zmq_socket(self.zmq_ctx, output_address, zmq.PULL)
+        try:
+            poller = zmq.Poller()
+            poller.register(output_socket, zmq.POLLIN)
+            while self.still_running:
+                socks = poller.poll(timeout=1000)
+                if not socks:
+                    continue
+                obj = pickle.loads(output_socket.recv(copy=False))
+                self.rpc_outputs_queues[worker_id].put_nowait(obj)
+        finally:
+            output_socket.close(linger=0)
+            logger.debug(f"{self.label}: RPC output thread {worker_id} exit")
+
     def call_func(self, func_name: str, *args, wait_out: bool = False):
         """Standard RPC call for non-KV operations."""
         logger.debug(f"{self.label}: call_func {func_name} {args}")
@@ -407,6 +490,96 @@ class AsyncIOProcManager:
             if isinstance(ret, SystemExit):
                 raise ret
             return ret
+
+    @staticmethod
+    def _rpc_transport_failure(
+        request_id: str, tp_rank: int, message: str
+    ) -> WorkerRPCResponse:
+        return WorkerRPCResponse.failure(
+            request_id, tp_rank, RPCErrorInfo.transport(message)
+        )
+
+    def collective_rpc(
+        self,
+        request: CollectiveRPCRequest,
+    ) -> list[WorkerRPCResponse]:
+        """Execute a method on every TP runner and collect rank-ordered replies."""
+        if not isinstance(request, CollectiveRPCRequest):
+            raise TypeError("collective RPC request must be CollectiveRPCRequest")
+
+        self.rpc_broadcast_mq.enqueue((COLLECTIVE_RPC_COMMAND, request))
+
+        responses: list[WorkerRPCResponse] = []
+        for tp_rank, output_queue in enumerate(self.rpc_outputs_queues):
+            while True:
+                try:
+                    response = output_queue.get_nowait()
+                except queue.Empty:
+                    response = None
+
+                if response is None:
+                    if tp_rank >= len(self.procs) or not self.procs[tp_rank].is_alive():
+                        responses.append(
+                            self._rpc_transport_failure(
+                                request.request_id,
+                                tp_rank,
+                                f"TP worker {tp_rank} is not alive",
+                            )
+                        )
+                        break
+
+                    remaining = request.remaining_timeout()
+                    if remaining is None:
+                        wait_s = 1.0
+                    else:
+                        if remaining <= 0:
+                            responses.append(
+                                self._rpc_transport_failure(
+                                    request.request_id,
+                                    tp_rank,
+                                    f"RPC method {request.method!r} timed out "
+                                    f"on TP worker {tp_rank}",
+                                )
+                            )
+                            break
+                        wait_s = min(1.0, remaining)
+
+                    try:
+                        response = output_queue.get(timeout=wait_s)
+                    except queue.Empty:
+                        continue
+
+                if not isinstance(response, WorkerRPCResponse):
+                    responses.append(
+                        self._rpc_transport_failure(
+                            request.request_id,
+                            tp_rank,
+                            f"invalid RPC response type: {type(response).__name__}",
+                        )
+                    )
+                    break
+                if response.request_id != request.request_id:
+                    logger.warning(
+                        "%s: dropping stale RPC response for request %s while waiting for %s",
+                        self.label,
+                        response.request_id,
+                        request.request_id,
+                    )
+                    continue
+                if response.tp_rank != tp_rank:
+                    responses.append(
+                        self._rpc_transport_failure(
+                            request.request_id,
+                            tp_rank,
+                            "RPC response rank mismatch: "
+                            f"expected {tp_rank}, got {response.tp_rank}",
+                        )
+                    )
+                else:
+                    responses.append(response)
+                break
+
+        return responses
 
     def call_func_with_aggregation(self, func_name: str, *args, timeout: float = 10.0):
         """RPC call with KV output aggregation across all workers.

--- a/atom/model_engine/collective_rpc.py
+++ b/atom/model_engine/collective_rpc.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Transport-independent protocol types for collective worker RPCs."""
+
+from __future__ import annotations
+
+import queue
+import time
+import traceback
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any
+
+COLLECTIVE_RPC_COMMAND = "__atom_collective_rpc__"
+COLLECTIVE_RPC_UTILITY = "collective_rpc"
+
+
+@dataclass(frozen=True, slots=True)
+class RPCErrorInfo:
+    type: str
+    message: str
+    traceback: str = ""
+
+    @classmethod
+    def from_exception(cls, exc: Exception) -> RPCErrorInfo:
+        return cls(type(exc).__name__, str(exc), traceback.format_exc())
+
+    @classmethod
+    def transport(cls, message: str) -> RPCErrorInfo:
+        return cls("CollectiveRPCTransportError", message)
+
+    @classmethod
+    def protocol(cls, message: str) -> RPCErrorInfo:
+        return cls("CollectiveRPCProtocolError", message)
+
+
+@dataclass(frozen=True, slots=True)
+class CollectiveRPCRequest:
+    request_id: str
+    method: str
+    args: tuple
+    kwargs: dict
+    deadline: float | None
+
+    @classmethod
+    def create(
+        cls,
+        method: str,
+        timeout: float | None = None,
+        args: tuple = (),
+        kwargs: dict | None = None,
+    ) -> CollectiveRPCRequest:
+        if not isinstance(method, str) or not method:
+            raise TypeError("collective RPC method must be a non-empty string")
+        if not isinstance(args, tuple):
+            raise TypeError("collective RPC args must be a tuple")
+        if kwargs is None:
+            kwargs = {}
+        if not isinstance(kwargs, dict):
+            raise TypeError("collective RPC kwargs must be a dict")
+        if timeout is not None and timeout < 0:
+            raise ValueError("collective RPC timeout must be non-negative or None")
+        deadline = None if timeout is None else time.monotonic() + timeout
+        return cls(uuid.uuid4().hex, method, args, kwargs, deadline)
+
+    def remaining_timeout(self) -> float | None:
+        if self.deadline is None:
+            return None
+        return max(0.0, self.deadline - time.monotonic())
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerRPCResponse:
+    request_id: str
+    tp_rank: int
+    ok: bool
+    result: Any = None
+    error: RPCErrorInfo | None = None
+
+    @classmethod
+    def success(cls, request_id: str, tp_rank: int, result: Any) -> WorkerRPCResponse:
+        return cls(request_id=request_id, tp_rank=tp_rank, ok=True, result=result)
+
+    @classmethod
+    def failure(
+        cls, request_id: str, tp_rank: int, error: RPCErrorInfo
+    ) -> WorkerRPCResponse:
+        return cls(request_id=request_id, tp_rank=tp_rank, ok=False, error=error)
+
+
+@dataclass(frozen=True, slots=True)
+class EngineCoreRPCResponse:
+    request_id: str
+    method: str
+    tp_world_size: int
+    tp_responses: tuple[WorkerRPCResponse, ...]
+    error: RPCErrorInfo | None = None
+
+    @classmethod
+    def success(
+        cls,
+        request: CollectiveRPCRequest,
+        tp_world_size: int,
+        tp_responses: list[WorkerRPCResponse],
+    ) -> EngineCoreRPCResponse:
+        return cls(
+            request_id=request.request_id,
+            method=request.method,
+            tp_world_size=tp_world_size,
+            tp_responses=tuple(tp_responses),
+        )
+
+    @classmethod
+    def failure(
+        cls,
+        request_id: str,
+        method: str,
+        error: RPCErrorInfo,
+    ) -> EngineCoreRPCResponse:
+        return cls(request_id, method, 0, (), error)
+
+
+@dataclass(frozen=True, slots=True)
+class RankedRPCFailure:
+    dp_rank: int
+    tp_rank: int | None
+    error: RPCErrorInfo
+
+
+class CollectiveRPCError(RuntimeError):
+    """Raised when one or more DP/TP workers fail a collective RPC."""
+
+    def __init__(self, method: str, failures: list[RankedRPCFailure]):
+        self.method = method
+        self.failures = failures
+        details = "; ".join(
+            f"DP{item.dp_rank}"
+            f"{'/TP' + str(item.tp_rank) if item.tp_rank is not None else ''}: "
+            f"{item.error.type}: {item.error.message}"
+            for item in failures
+        )
+        super().__init__(f"collective RPC {method!r} failed: {details}")
+
+
+def validate_worker_responses(response: EngineCoreRPCResponse) -> RPCErrorInfo | None:
+    ranks = sorted(item.tp_rank for item in response.tp_responses)
+    if response.tp_world_size < 1 or ranks != list(range(response.tp_world_size)):
+        return RPCErrorInfo.protocol(
+            "invalid TP response set: "
+            f"world_size={response.tp_world_size}, ranks={ranks}"
+        )
+    return None
+
+
+class CollectiveRPCResponseRouter:
+    """Route request-scoped EngineCore responses to concurrent callers."""
+
+    def __init__(self) -> None:
+        self._queues: dict[str, queue.Queue] = {}
+        self._lock = Lock()
+
+    @contextmanager
+    def register(self, request_id: str) -> Iterator[queue.Queue]:
+        response_queue: queue.Queue = queue.Queue()
+        with self._lock:
+            if request_id in self._queues:
+                raise RuntimeError(
+                    f"collective RPC request already registered: {request_id}"
+                )
+            self._queues[request_id] = response_queue
+        try:
+            yield response_queue
+        finally:
+            with self._lock:
+                self._queues.pop(request_id, None)
+
+    def route(self, request_id: str, response: Any) -> bool:
+        with self._lock:
+            response_queue = self._queues.get(request_id)
+            if response_queue is None:
+                return False
+            response_queue.put_nowait(response)
+            return True

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -59,6 +59,8 @@ class CoreManager:
         self.outputs_queue = queue.Queue[list[Sequence]]()
         self.stream_outputs_queue = queue.Queue()
         self.utility_response_queue = queue.Queue()
+        self._collective_rpc_router = CollectiveRPCResponseRouter()
+        self._utility_send_lock = Lock()
         self._seq_id_to_callback = {}
         # Batched stream-flush hook, resolved lazily by the API server (avoids
         # an api_server <-> engine_core_mgr import cycle). Stays None on every
@@ -354,7 +356,7 @@ class CoreManager:
                                     exc_info=True,
                                 )
                     elif request_type == EngineCoreRequestType.UTILITY_RESPONSE:
-                        self.utility_response_queue.put_nowait(data)
+                        self._route_utility_response(dp_rank, data)
                     elif request_type == EngineCoreRequestType.ADD:
                         # logger.info(f"Engine core output sequence id: {seq.id}")
                         seqs = data
@@ -373,6 +375,20 @@ class CoreManager:
             name=f"EngineCoreOutputThread-DP{dp_rank}",
             daemon=True,
         )
+
+    def _route_utility_response(self, dp_rank: int, data) -> None:
+        """Route correlated collective responses without disturbing legacy FIFO."""
+        if not isinstance(data, EngineCoreRPCResponse):
+            self.utility_response_queue.put_nowait(data)
+            return
+
+        if not self._collective_rpc_router.route(data.request_id, (dp_rank, data)):
+            logger.warning(
+                "%s: dropping late response for collective RPC %s from DP rank %d",
+                self.label,
+                data.request_id,
+                dp_rank,
+            )
 
     def _ensure_output_handler_task(self):
         if self._asyncio_mode and self._output_handler_task is None:
@@ -764,17 +780,20 @@ class CoreManager:
         payload = {"cmd": cmd, **kwargs}
         # Serialize once and reuse for all ranks (optimization: avoid repeated pickle.dumps)
         serialized_payload = pickle.dumps((EngineCoreRequestType.UTILITY, payload))
-        for rank in range(self.local_engine_count):
-            logger.debug(
-                f"{self.label}: Broadcast utility command '{cmd}' to DP rank {rank}"
-            )
-            self.input_sockets[rank].send_multipart(
-                [
-                    self.engine_core_identities[rank],
-                    serialized_payload,
-                ],
-                copy=True,  # Use copy=True since we're reusing the same buffer
-            )
+        # ZeroMQ sockets are not safe for concurrent sends from multiple caller
+        # threads (e.g. overlapping Ray control RPCs).
+        with self._utility_send_lock:
+            for rank in range(self.local_engine_count):
+                logger.debug(
+                    f"{self.label}: Broadcast utility command '{cmd}' to DP rank {rank}"
+                )
+                self.input_sockets[rank].send_multipart(
+                    [
+                        self.engine_core_identities[rank],
+                        serialized_payload,
+                    ],
+                    copy=True,  # Use copy=True since we're reusing the same buffer
+                )
 
     def broadcast_utility_command_sync(
         self, cmd: str, timeout: float = 300.0, **kwargs
@@ -800,6 +819,120 @@ class CoreManager:
                     f"for command '{cmd}' (timeout={timeout}s)"
                 )
         return responses
+
+    @staticmethod
+    def _dp_rpc_transport_failure(
+        request_id: str, method: str, message: str
+    ) -> EngineCoreRPCResponse:
+        return EngineCoreRPCResponse.failure(
+            request_id, method, RPCErrorInfo.transport(message)
+        )
+
+    def collective_rpc(
+        self,
+        method: str,
+        timeout: float | None = None,
+        args: tuple = (),
+        kwargs: dict | None = None,
+    ) -> list:
+        """Execute a control-plane method on all DP/TP model runners."""
+        request = CollectiveRPCRequest.create(method, timeout, args, kwargs)
+        responses_by_rank: dict[int, EngineCoreRPCResponse] = {}
+
+        with self._collective_rpc_router.register(request.request_id) as response_queue:
+            self.broadcast_utility_command(
+                COLLECTIVE_RPC_UTILITY,
+                request=request,
+            )
+            while len(responses_by_rank) < self.local_engine_count:
+                remaining = request.remaining_timeout()
+                if remaining is None:
+                    wait_s = 1.0
+                else:
+                    if remaining <= 0:
+                        break
+                    wait_s = min(1.0, remaining)
+
+                try:
+                    dp_rank, response = response_queue.get(timeout=wait_s)
+                except queue.Empty:
+                    for dp_rank, process in enumerate(self.engine_core_processes):
+                        if dp_rank not in responses_by_rank and not process.is_alive():
+                            responses_by_rank[dp_rank] = self._dp_rpc_transport_failure(
+                                request.request_id,
+                                request.method,
+                                f"DP EngineCore {dp_rank} is not alive",
+                            )
+                    continue
+
+                if not isinstance(dp_rank, int) or not (
+                    0 <= dp_rank < self.local_engine_count
+                ):
+                    logger.warning(
+                        "%s: ignoring collective RPC %s response with invalid DP rank %r",
+                        self.label,
+                        request.request_id,
+                        dp_rank,
+                    )
+                    continue
+                if not isinstance(response, EngineCoreRPCResponse):
+                    responses_by_rank[dp_rank] = self._dp_rpc_transport_failure(
+                        request.request_id,
+                        request.method,
+                        f"invalid DP response type: {type(response).__name__}",
+                    )
+                    continue
+                if dp_rank in responses_by_rank:
+                    logger.warning(
+                        "%s: ignoring duplicate collective RPC %s response from DP rank %d",
+                        self.label,
+                        request.request_id,
+                        dp_rank,
+                    )
+                    continue
+                responses_by_rank[dp_rank] = response
+
+            for dp_rank in range(self.local_engine_count):
+                if dp_rank not in responses_by_rank:
+                    responses_by_rank[dp_rank] = self._dp_rpc_transport_failure(
+                        request.request_id,
+                        request.method,
+                        f"RPC method {request.method!r} timed out "
+                        f"on DP EngineCore {dp_rank}",
+                    )
+
+        failures: list[RankedRPCFailure] = []
+        results: list = []
+        for dp_rank in range(self.local_engine_count):
+            dp_response = responses_by_rank[dp_rank]
+            if dp_response.error is not None:
+                failures.append(RankedRPCFailure(dp_rank, None, dp_response.error))
+                continue
+
+            protocol_error = validate_worker_responses(dp_response)
+            if protocol_error is not None:
+                failures.append(RankedRPCFailure(dp_rank, None, protocol_error))
+                continue
+            for tp_response in sorted(
+                dp_response.tp_responses, key=lambda item: item.tp_rank
+            ):
+                if not tp_response.ok:
+                    failures.append(
+                        RankedRPCFailure(
+                            dp_rank,
+                            tp_response.tp_rank,
+                            tp_response.error
+                            or RPCErrorInfo.protocol(
+                                "failed worker response has no error"
+                            ),
+                        )
+                    )
+                else:
+                    results.append(tp_response.result)
+
+        if failures:
+            raise CollectiveRPCError(request.method, failures)
+        return results
 
     def _shutdown_engine_core_rank(self, dp_rank: int):
         if dp_rank >= len(self.engine_core_processes):

--- a/atom/model_engine/engine_utility.py
+++ b/atom/model_engine/engine_utility.py
@@ -125,6 +125,28 @@ class EngineUtilityHandler:
         )
         logger.info(f"{self.label}: update_weights completed, updated={result}")
 
+    def _handle_collective_rpc(self, args: dict):
+        """Fan a generic control-plane call out to every local TP runner."""
+        request = args.get("request")
+        if not isinstance(request, CollectiveRPCRequest):
+            raise TypeError("collective RPC utility payload has no valid request")
+
+        try:
+            tp_responses = self.runner_mgr.collective_rpc(request)
+            response = EngineCoreRPCResponse.success(
+                request,
+                tp_world_size=self.runner_mgr.proc_num,
+                tp_responses=tp_responses,
+            )
+        except Exception as exc:
+            response = EngineCoreRPCResponse.failure(
+                request.request_id,
+                request.method,
+                RPCErrorInfo.from_exception(exc),
+            )
+
+        self.output_queue.put_nowait(("UTILITY_RESPONSE", response))
+
     def _handle_update_weights_shm(self, args: dict):
         """Handle shared-memory weight update command.
 

--- a/atom/rollout/async_engine.py
+++ b/atom/rollout/async_engine.py
@@ -4,7 +4,7 @@
 import logging
 
 from atom.model_engine.llm_engine import LLMEngine
-from atom.rollout.weight_sync import load_weights_via_shm, load_weights_via_ipc
+from atom.rollout.weight_sync import load_weights_via_ipc, load_weights_via_shm
 
 logger = logging.getLogger("atom")
 
@@ -30,6 +30,26 @@ class AsyncLLMEngine(LLMEngine):
             "atom.rollout.model_runner_ext.RLHFModelRunner",
         )
         super().__init__(model, **kwargs)
+
+    def collective_rpc(
+        self,
+        method: str,
+        timeout: float | None = None,
+        args: tuple = (),
+        kwargs: dict | None = None,
+    ) -> list:
+        """Execute a control-plane method on every DP/TP model runner.
+
+        The return order is DP-major, then TP rank. This API is intended for
+        small control messages; bulk tensors should use the weight-sync data
+        plane instead.
+        """
+        return self.core_mgr.collective_rpc(
+            method=method,
+            timeout=timeout,
+            args=args,
+            kwargs=kwargs,
+        )
 
     def sleep(self, level: int = 1):
         """Release GPU resources.

--- a/atom/rollout/model_runner_ext.py
+++ b/atom/rollout/model_runner_ext.py
@@ -12,16 +12,20 @@ import torch
 from aiter import init_dist_env
 from aiter.dist.parallel_state import get_tp_group
 from aiter.dist.utils import get_distributed_init_method
+
 from atom.model_engine.model_runner import ModelRunner
 from atom.model_engine.scheduler import ScheduledBatch, ScheduledBatchOutput
 from atom.rollout.memory_manager import MemoryManagerMixin
+from atom.rollout.rdma_weight_receiver import RDMAWeightReceiverMixin
 from atom.rollout.weight_updater import WeightUpdaterMixin
 from atom.utils.forward_context import get_forward_context
 
 logger = logging.getLogger("atom")
 
 
-class RLHFModelRunner(ModelRunner, WeightUpdaterMixin, MemoryManagerMixin):
+class RLHFModelRunner(
+    ModelRunner, WeightUpdaterMixin, RDMAWeightReceiverMixin, MemoryManagerMixin
+):
     """ModelRunner with RLHF extensions (weight sync + memory lifecycle + DP isolation).
 
     Used when ATOM is driven by an external RLHF framework (veRL or TorchSpec).
@@ -267,6 +271,7 @@ class RLHFModelRunner(ModelRunner, WeightUpdaterMixin, MemoryManagerMixin):
 
     @torch.inference_mode()
     def forward(self, batch: ScheduledBatch) -> ScheduledBatchOutput:
+        self.assert_weight_update_ready()
         result = super().forward(batch)
 
         if self._extract_mode and self._captured_hidden_states is not None:

--- a/atom/rollout/rdma_weight_receiver.py
+++ b/atom/rollout/rdma_weight_receiver.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""vLLM-compatible bucketed weight receive path for LumenRL.
+
+The wire format intentionally mirrors
+``lumenrl.engine.inference.rdma_weight_transfer`` v1.  ATOM's transaction
+state is local to the receiver and does not add acknowledgements or commands.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+
+logger = logging.getLogger("atom")
+
+_CMD_END = 0
+_CMD_BUCKET = 1
+_HEADER_WORDS = 4  # command, metadata bytes, payload bytes, version
+
+
+def _broadcast_header(group, *, device: torch.device) -> torch.Tensor:
+    header = torch.empty(_HEADER_WORDS, dtype=torch.int64, device=device)
+    dist.broadcast(header, src=0, group=group)
+    return header
+
+
+def _decode_bucket(
+    metadata_tensor: torch.Tensor,
+    payload: torch.Tensor,
+) -> list[tuple[str, torch.Tensor]]:
+    metadata = json.loads(bytes(metadata_tensor.cpu().tolist()).decode("utf-8"))
+    if not isinstance(metadata, list) or not metadata:
+        raise RuntimeError("invalid RDMA weight metadata: expected a non-empty list")
+
+    weights: list[tuple[str, torch.Tensor]] = []
+    for entry in metadata:
+        try:
+            name = str(entry["name"])
+            shape = [int(dim) for dim in entry["shape"]]
+            dtype = getattr(torch, entry["dtype"])
+            start = int(entry["offset"])
+            nbytes = int(entry["nbytes"])
+        except (KeyError, TypeError, ValueError, AttributeError) as exc:
+            raise RuntimeError(f"invalid RDMA weight metadata entry: {entry}") from exc
+        end = start + nbytes
+        if start < 0 or nbytes <= 0 or end > payload.numel():
+            raise RuntimeError(
+                f"invalid RDMA payload range for {name}: "
+                f"offset={start}, nbytes={nbytes}, payload={payload.numel()}"
+            )
+        value = payload[start:end].view(dtype).view(shape)
+        if value.numel() * value.element_size() != nbytes:
+            raise RuntimeError(
+                f"RDMA metadata size mismatch for {name}: "
+                f"shape={shape}, dtype={dtype}, nbytes={nbytes}"
+            )
+        weights.append((name, value))
+    return weights
+
+
+@torch.no_grad()
+def receive_weight_stream(
+    group,
+    runner,
+    *,
+    device: torch.device,
+    expected_version: int,
+    verify_full_load: bool = True,
+) -> dict[str, float]:
+    """Receive the frozen LumenRL v1 stream and transactionally load ATOM."""
+    total_bytes = 0
+    total_weights = 0
+    total_buckets = 0
+    started = time.perf_counter()
+    runner.begin_weight_update(expected_version)
+
+    try:
+        while True:
+            header = _broadcast_header(group, device=device)
+            command, metadata_bytes, payload_bytes, version = [
+                int(value) for value in header.cpu().tolist()
+            ]
+            if version != expected_version:
+                raise RuntimeError(
+                    "RDMA weight version mismatch: "
+                    f"expected {expected_version}, got {version}"
+                )
+            if command == _CMD_END:
+                break
+            if command != _CMD_BUCKET or metadata_bytes <= 0 or payload_bytes <= 0:
+                raise RuntimeError(f"invalid RDMA weight header: {header.tolist()}")
+
+            metadata_tensor = torch.empty(
+                metadata_bytes, dtype=torch.uint8, device=device
+            )
+            payload = torch.empty(payload_bytes, dtype=torch.uint8, device=device)
+            dist.broadcast(metadata_tensor, src=0, group=group)
+            dist.broadcast(payload, src=0, group=group)
+            weights = _decode_bucket(metadata_tensor, payload)
+            runner.apply_weight_bucket(weights, payload_bytes=payload_bytes)
+            total_bytes += payload_bytes
+            total_weights += len(weights)
+            total_buckets += 1
+
+        manifest = runner.commit_weight_update(
+            expected_version, verify_full_load=verify_full_load
+        )
+    except Exception as exc:
+        if getattr(runner, "_weight_update_transaction", None) is not None:
+            runner.abort_weight_update(expected_version, exc)
+        raise
+
+    torch.cuda.synchronize(device)
+    elapsed = time.perf_counter() - started
+    return {
+        "version": float(expected_version),
+        "buckets": float(total_buckets),
+        "weights": float(total_weights),
+        "bytes": float(total_bytes),
+        "seconds": elapsed,
+        "gbps": (total_bytes * 8 / 1e9 / elapsed) if elapsed > 0 else 0.0,
+        "loaded_internal": float(manifest["loaded_internal"]),
+    }
+
+
+class RDMAWeightReceiverMixin:
+    """Worker methods matching LumenRL's vLLM collective-RPC contract."""
+
+    def init_rdma_weight_group(
+        self,
+        master_addr: str,
+        master_port: int,
+        base_rank: int,
+        world_size: int,
+        group_name: str,
+        timeout_s: int = 600,
+    ) -> bool:
+        from lumenrl.utils.independent_process_group import (
+            init_independent_process_group,
+        )
+
+        groups = getattr(self, "_rdma_weight_groups", None)
+        if groups is None:
+            groups = {}
+            self._rdma_weight_groups = groups
+        if group_name in groups:
+            return True
+
+        dp_rank_local = int(
+            getattr(self.config.parallel_config, "data_parallel_rank_local", 0) or 0
+        )
+        tp_size = int(self.world_size)
+        rank = int(base_rank) + dp_rank_local * tp_size + int(self.rank)
+        if rank <= 0 or rank >= int(world_size):
+            raise ValueError(
+                f"invalid ATOM RDMA rank={rank}, world_size={world_size}, "
+                f"base_rank={base_rank}, dp_rank_local={dp_rank_local}, "
+                f"tp_rank={self.rank}, tp_size={tp_size}"
+            )
+
+        groups[group_name] = init_independent_process_group(
+            backend="nccl",
+            init_method=f"tcp://{master_addr}:{master_port}",
+            timeout=timedelta(seconds=int(timeout_s)),
+            world_size=int(world_size),
+            rank=rank,
+            group_name=group_name,
+        )
+        logger.warning(
+            "%s joined RDMA weight group %s as rank=%d/%d "
+            "(dp_local=%d, tp_rank=%d)",
+            self.label,
+            group_name,
+            rank,
+            world_size,
+            dp_rank_local,
+            self.rank,
+        )
+        return True
+
+    def receive_weights_rdma(
+        self,
+        group_name: str,
+        version: int,
+        verify_full_load: bool = True,
+    ) -> dict[str, float]:
+        groups = getattr(self, "_rdma_weight_groups", {})
+        if group_name not in groups:
+            raise RuntimeError(f"RDMA weight group is not initialized: {group_name}")
+        stats = receive_weight_stream(
+            groups[group_name],
+            self,
+            device=self.device,
+            expected_version=int(version),
+            verify_full_load=bool(verify_full_load),
+        )
+        logger.warning("%s RDMA weight reload verified: %s", self.label, stats)
+        return stats
+
+    def destroy_rdma_weight_group(self, group_name: str) -> bool:
+        groups = getattr(self, "_rdma_weight_groups", {})
+        group = groups.pop(group_name, None)
+        if group is not None:
+            dist.destroy_process_group(group)
+        return True

--- a/atom/rollout/weight_updater.py
+++ b/atom/rollout/weight_updater.py
@@ -2,11 +2,40 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import logging
+from dataclasses import dataclass, field
 from typing import Optional
 
 import torch
 
 logger = logging.getLogger("atom")
+
+
+@dataclass
+class WeightBucketResult:
+    """Result of applying one bucket of HF-named weights."""
+
+    updated: int = 0
+    received_names: set[str] = field(default_factory=set)
+    loaded_internal: set[str] = field(default_factory=set)
+    skipped_names: set[str] = field(default_factory=set)
+    ignored_scale_names: set[str] = field(default_factory=set)
+    packed_shards: dict[str, set[object]] = field(default_factory=dict)
+    packed_expected: dict[str, set[object]] = field(default_factory=dict)
+
+
+@dataclass
+class WeightUpdateTransaction:
+    """Cross-bucket state for one atomic-at-the-serving-boundary reload."""
+
+    version: int
+    buckets: int = 0
+    payload_bytes: int = 0
+    received_names: set[str] = field(default_factory=set)
+    loaded_internal: set[str] = field(default_factory=set)
+    skipped_names: set[str] = field(default_factory=set)
+    ignored_scale_names: set[str] = field(default_factory=set)
+    packed_shards: dict[str, set[object]] = field(default_factory=dict)
+    packed_expected: dict[str, set[object]] = field(default_factory=dict)
 
 
 class WeightUpdaterMixin:
@@ -131,8 +160,12 @@ class WeightUpdaterMixin:
                     shard_gpu = shard_t.to(device=self.device, dtype=torch.float32)
                     weight_loader(buf, shard_gpu, sid)
 
-                self._requantize_fp8_weight(module, param_name, param, buf.data)
+                requantized = self._requantize_fp8_weight(
+                    module, param_name, param, buf.data
+                )
                 del self._packed_weight_accum[atom_name]
+                if not requantized:
+                    return "skipped"
                 logger.debug(
                     f"{self.label}: FP8 packed weight updated: {atom_name} "
                     f"(composed from {len(expected)} shards)"
@@ -196,7 +229,7 @@ class WeightUpdaterMixin:
         param_name: str,
         param: torch.nn.Parameter,
         tensor: torch.Tensor,
-    ) -> None:
+    ) -> bool:
         """Requantize a full-precision weight to FP8 with updated weight_scale.
 
         Called when FSDP sends float32/bfloat16 trained weights to an FP8 model.
@@ -224,7 +257,7 @@ class WeightUpdaterMixin:
                 f"{self.label}: Shape mismatch in FP8 requantize for {param_name}: "
                 f"param={param.shape}, tensor={tensor_gpu.shape}"
             )
-            return
+            return False
 
         from aiter import QuantType as _QT
 
@@ -262,13 +295,14 @@ class WeightUpdaterMixin:
             logger.warning(
                 f"{self.label}: Unknown quant_type {quant_type} for FP8 requantize"
             )
-            return
+            return False
 
         self._post_process_fp8_weight(module, param)
         logger.debug(
             f"{self.label}: FP8 requantized {param_name} on {type(module).__name__}, "
             f"quant_type={quant_type}, scale_shape={weight_scale.shape}"
         )
+        return True
 
     def _post_process_fp8_weight(
         self,
@@ -315,6 +349,305 @@ class WeightUpdaterMixin:
         if needs_shuffle:
             shuffle_weights(param)
 
+    @staticmethod
+    def _module_parameter_name(name: str, param_name: str, sibling: str) -> str:
+        prefix = name[: -len(param_name)] if param_name and name.endswith(param_name) else ""
+        return f"{prefix}{sibling}"
+
+    def _record_fp8_side_effects(
+        self,
+        loaded_internal: set[str],
+        name: str,
+        module: torch.nn.Module,
+        param_name: str,
+        param: torch.nn.Parameter,
+        *,
+        scale_updated: bool,
+    ) -> None:
+        """Record parameters modified indirectly by FP8 post-processing."""
+        loaded_internal.add(name)
+        if not scale_updated or not self._is_fp8_param(module, param):
+            return
+        weight_scale = getattr(module, "weight_scale", None)
+        if isinstance(weight_scale, torch.nn.Parameter):
+            loaded_internal.add(
+                self._module_parameter_name(name, param_name, "weight_scale")
+            )
+
+    def _apply_named_tensors(
+        self, named_tensors: list[tuple[str, torch.Tensor]]
+    ) -> WeightBucketResult:
+        """Apply one bucket without finalizing the cross-bucket lifecycle."""
+        param_to_module = self._get_param_to_module_mapping()
+        result = WeightBucketResult()
+
+        for name, tensor in named_tensors:
+            result.received_names.add(name)
+            if name not in param_to_module:
+                packed = self._resolve_packed_name(name, param_to_module)
+                if packed is not None:
+                    atom_name, shard_id, target_suffix = packed
+                    result.packed_shards.setdefault(atom_name, set()).add(shard_id)
+                    result.packed_expected[atom_name] = set(
+                        self._get_packed_shard_order().get(target_suffix, [])
+                    )
+                packed_result = self._apply_packed_weight(name, tensor, param_to_module)
+                if packed_result == "updated":
+                    result.updated += 1
+                    if packed is not None:
+                        atom_name, _, _ = packed
+                        module, param_name, param = param_to_module[atom_name]
+                        self._record_fp8_side_effects(
+                            result.loaded_internal,
+                            atom_name,
+                            module,
+                            param_name,
+                            param,
+                            scale_updated=tensor.dtype != param.dtype,
+                        )
+                elif packed_result == "accumulated":
+                    pass
+                elif "weight_scale" in name or "input_scale" in name:
+                    result.ignored_scale_names.add(name)
+                else:
+                    logger.debug(f"{self.label}: Unmatched parameter: {name}")
+                    result.skipped_names.add(name)
+                continue
+
+            module, param_name, param = param_to_module[name]
+            weight_loader = getattr(module, "weight_loader", None)
+            loaded = False
+            scale_updated = False
+
+            if self._is_fp8_param(module, param) and tensor.dtype != param.dtype:
+                loaded = self._requantize_fp8_weight(
+                    module, param_name, param, tensor
+                )
+                scale_updated = loaded
+            elif self._is_fp8_param(module, param) and tensor.dtype == param.dtype:
+                tensor = tensor.to(device=self.device)
+                param.data.copy_(tensor)
+                self._post_process_fp8_weight(module, param)
+                loaded = True
+            elif tensor.shape == param.shape:
+                tensor = tensor.to(device=self.device, dtype=param.dtype)
+                param.data.copy_(tensor)
+                loaded = True
+            elif weight_loader is not None and callable(weight_loader):
+                try:
+                    tensor = tensor.to(device=self.device)
+                    weight_loader(param, tensor)
+                    loaded = True
+                except Exception as exc:
+                    logger.warning(
+                        f"{self.label}: weight_loader failed for {name}: {exc}"
+                    )
+            else:
+                tp_size = self.world_size
+                tp_rank = self.rank
+                loaded = tp_size > 1 and self._try_shard_weight(
+                    param, tensor, tp_rank, tp_size
+                )
+
+            if loaded:
+                result.updated += 1
+                self._record_fp8_side_effects(
+                    result.loaded_internal,
+                    name,
+                    module,
+                    param_name,
+                    param,
+                    scale_updated=scale_updated,
+                )
+            else:
+                if tensor.shape != param.shape:
+                    logger.warning(
+                        f"{self.label}: Shape mismatch for {name}: "
+                        f"expected {param.shape}, got {tensor.shape}"
+                    )
+                result.skipped_names.add(name)
+
+        return result
+
+    def begin_weight_update(self, version: int) -> dict:
+        """Begin a versioned, cross-bucket weight update transaction."""
+        version = int(version)
+        active = getattr(self, "_weight_update_transaction", None)
+        if active is not None:
+            raise RuntimeError(
+                f"weight update version {active.version} is already in progress"
+            )
+        last_version = getattr(self, "_last_started_weight_version", None)
+        if last_version is not None and version <= last_version:
+            raise RuntimeError(
+                f"weight update version must increase: "
+                f"last_started={last_version}, got={version}"
+            )
+        if hasattr(self, "_packed_weight_accum"):
+            self._packed_weight_accum.clear()
+        self._weight_update_transaction = WeightUpdateTransaction(version=version)
+        self._last_started_weight_version = version
+        logger.info(f"{self.label}: began weight update version={version}")
+        return {"version": version, "state": "receiving"}
+
+    def apply_weight_bucket(
+        self,
+        named_tensors: list[tuple[str, torch.Tensor]],
+        payload_bytes: int = 0,
+    ) -> dict:
+        """Apply one bucket and retain packed/fused state for later buckets."""
+        transaction = getattr(self, "_weight_update_transaction", None)
+        if transaction is None:
+            raise RuntimeError("no weight update transaction is in progress")
+        try:
+            bucket = self._apply_named_tensors(named_tensors)
+        except Exception as exc:
+            self.abort_weight_update(transaction.version, exc)
+            raise
+        transaction.buckets += 1
+        transaction.payload_bytes += int(payload_bytes)
+        transaction.received_names.update(bucket.received_names)
+        transaction.loaded_internal.update(bucket.loaded_internal)
+        transaction.skipped_names.update(bucket.skipped_names)
+        transaction.ignored_scale_names.update(bucket.ignored_scale_names)
+        for name, shards in bucket.packed_shards.items():
+            transaction.packed_shards.setdefault(name, set()).update(shards)
+        transaction.packed_expected.update(bucket.packed_expected)
+        return {
+            "version": transaction.version,
+            "bucket": transaction.buckets,
+            "updated": bucket.updated,
+            "received": len(bucket.received_names),
+            "loaded_internal": len(bucket.loaded_internal),
+            "skipped": sorted(bucket.skipped_names),
+            "ignored_scales": sorted(bucket.ignored_scale_names),
+        }
+
+    def commit_weight_update(self, version: int, verify_full_load: bool = True) -> dict:
+        """Finalize a reload once, making the new version eligible for serving."""
+        version = int(version)
+        transaction = getattr(self, "_weight_update_transaction", None)
+        if transaction is None:
+            raise RuntimeError("no weight update transaction is in progress")
+        if transaction.version != version:
+            error = RuntimeError(
+                f"weight update version mismatch: active={transaction.version}, got={version}"
+            )
+            self.abort_weight_update(transaction.version, error)
+            raise error
+
+        try:
+            incomplete_shards = {
+                name: sorted(
+                    transaction.packed_expected[name]
+                    - transaction.packed_shards.get(name, set()),
+                    key=str,
+                )
+                for name in transaction.packed_expected
+                if transaction.packed_expected[name]
+                - transaction.packed_shards.get(name, set())
+            }
+            if incomplete_shards:
+                raise RuntimeError(
+                    "incomplete packed shards after RDMA reload: "
+                    f"{incomplete_shards}"
+                )
+            incomplete_packed = sorted(
+                getattr(self, "_packed_weight_accum", {}).keys()
+            )
+            if incomplete_packed:
+                raise RuntimeError(
+                    "incomplete packed parameters after RDMA reload: "
+                    f"{incomplete_packed[:20]}"
+                )
+
+            expected_names = {name for name, _ in self.model.named_parameters()}
+            missing = sorted(expected_names - transaction.loaded_internal)
+            if verify_full_load and (missing or transaction.skipped_names):
+                raise RuntimeError(
+                    "incomplete ATOM RDMA weight reload: "
+                    f"loaded {len(transaction.loaded_internal)}/{len(expected_names)} "
+                    f"internal parameters from {len(transaction.received_names)} HF tensors; "
+                    f"missing={missing[:20]}, "
+                    f"skipped={sorted(transaction.skipped_names)[:20]}"
+                )
+
+            self.clear_kv_cache()
+            self._invalidate_cudagraphs_after_weight_update()
+        except Exception as exc:
+            self.abort_weight_update(version, exc)
+            raise
+
+        manifest = {
+            "version": version,
+            "buckets": transaction.buckets,
+            "bytes": transaction.payload_bytes,
+            "received": len(transaction.received_names),
+            "loaded_internal": len(transaction.loaded_internal),
+            "loaded_internal_names": sorted(transaction.loaded_internal),
+            "skipped": sorted(transaction.skipped_names),
+            "ignored_scales": sorted(transaction.ignored_scale_names),
+            "packed_shards": {
+                name: sorted(shards, key=str)
+                for name, shards in transaction.packed_shards.items()
+            },
+            "missing": missing,
+        }
+        self._last_committed_weight_version = version
+        self._weight_update_healthy = True
+        self._weight_update_transaction = None
+        if hasattr(self, "_packed_weight_accum"):
+            self._packed_weight_accum.clear()
+        logger.info(
+            f"{self.label}: committed weight update version={version}, "
+            f"buckets={manifest['buckets']}, loaded={manifest['loaded_internal']}"
+        )
+        return manifest
+
+    def abort_weight_update(self, version: int, error) -> dict:
+        """Discard transaction state and fence serving after a partial write."""
+        active = getattr(self, "_weight_update_transaction", None)
+        active_version = active.version if active is not None else int(version)
+        self._weight_update_transaction = None
+        self._weight_update_healthy = False
+        self._weight_update_failure = str(error)
+        if hasattr(self, "_packed_weight_accum"):
+            self._packed_weight_accum.clear()
+        logger.error(
+            f"{self.label}: aborted weight update version={active_version}: {error}"
+        )
+        return {
+            "version": active_version,
+            "state": "aborted",
+            "error": str(error),
+        }
+
+    def assert_weight_update_ready(self) -> None:
+        transaction = getattr(self, "_weight_update_transaction", None)
+        if transaction is not None:
+            raise RuntimeError(
+                "ATOM serving is fenced while weight update "
+                f"version={transaction.version} is in progress"
+            )
+        if getattr(self, "_weight_update_healthy", True):
+            return
+        raise RuntimeError(
+            "ATOM serving is fenced after a partial weight update; "
+            "complete a newer full reload or restart the worker. "
+            f"failure={getattr(self, '_weight_update_failure', 'unknown')}"
+        )
+
+    def get_weight_update_status(self) -> dict:
+        transaction = getattr(self, "_weight_update_transaction", None)
+        return {
+            "healthy": getattr(self, "_weight_update_healthy", True),
+            "active_version": transaction.version if transaction is not None else None,
+            "last_committed_version": getattr(
+                self, "_last_committed_weight_version", None
+            ),
+            "failure": getattr(self, "_weight_update_failure", None),
+        }
+
     def update_weights(
         self, named_tensors: list[tuple[str, torch.Tensor]], clear_kv_cache: bool = True
     ) -> int:
@@ -336,77 +669,25 @@ class WeightUpdaterMixin:
         Returns:
             Number of parameters successfully updated
         """
-        param_to_module = self._get_param_to_module_mapping()
-
-        updated = 0
-        skipped = 0
-        ignored_scales = 0
-
-        for name, tensor in named_tensors:
-            if name not in param_to_module:
-                result = self._apply_packed_weight(name, tensor, param_to_module)
-                if result == "updated":
-                    updated += 1
-                elif result == "accumulated":
-                    pass
-                elif "weight_scale" in name or "input_scale" in name:
-                    ignored_scales += 1
-                else:
-                    logger.debug(f"{self.label}: Unmatched parameter: {name}")
-                    skipped += 1
-                continue
-
-            module, param_name, param = param_to_module[name]
-            weight_loader = getattr(module, "weight_loader", None)
-
-            if self._is_fp8_param(module, param) and tensor.dtype != param.dtype:
-                self._requantize_fp8_weight(module, param_name, param, tensor)
-                updated += 1
-            elif self._is_fp8_param(module, param) and tensor.dtype == param.dtype:
-                tensor = tensor.to(device=self.device)
-                param.data.copy_(tensor)
-                self._post_process_fp8_weight(module, param)
-                updated += 1
-            elif tensor.shape == param.shape:
-                tensor = tensor.to(device=self.device, dtype=param.dtype)
-                param.data.copy_(tensor)
-                updated += 1
-            elif weight_loader is not None and callable(weight_loader):
-                try:
-                    tensor = tensor.to(device=self.device)
-                    weight_loader(param, tensor)
-                    updated += 1
-                except Exception as e:
-                    logger.warning(
-                        f"{self.label}: weight_loader failed for {name}: {e}"
-                    )
-                    skipped += 1
-            else:
-                tp_size = self.world_size
-                tp_rank = self.rank
-                if tp_size > 1 and self._try_shard_weight(
-                    param, tensor, tp_rank, tp_size
-                ):
-                    updated += 1
-                else:
-                    logger.warning(
-                        f"{self.label}: Shape mismatch for {name}: "
-                        f"expected {param.shape}, got {tensor.shape}"
-                    )
-                    skipped += 1
+        result = self._apply_named_tensors(named_tensors)
 
         if clear_kv_cache:
             self.clear_kv_cache()
 
-        if hasattr(self, "_packed_weight_accum"):
+        if clear_kv_cache and hasattr(self, "_packed_weight_accum"):
+            if self._packed_weight_accum:
+                logger.warning(
+                    f"{self.label}: Incomplete packed weight accumulators: "
+                    f"{list(self._packed_weight_accum.keys())}"
+                )
             self._packed_weight_accum.clear()
 
         logger.info(
             f"{self.label}: Weight update complete - "
-            f"updated={updated}, skipped={skipped}, "
-            f"ignored_scales={ignored_scales}"
+            f"updated={result.updated}, skipped={len(result.skipped_names)}, "
+            f"ignored_scales={len(result.ignored_scale_names)}"
         )
-        return updated
+        return result.updated
 
     def update_weights_from_shm(
         self,

--- a/tests/run_lumenrl_rdma_compat.py
+++ b/tests/run_lumenrl_rdma_compat.py
@@ -1,0 +1,237 @@
+"""Two-node RCCL compatibility check for LumenRL sender -> ATOM receiver.
+
+Run under Spur with five tasks (rank 0 trainer, ranks 1..4 ATOM workers).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from typing import ClassVar
+
+import torch
+import torch.distributed as dist
+from lumenrl.engine.inference.rdma_weight_transfer import send_weight_stream
+
+from atom.rollout.rdma_weight_receiver import receive_weight_stream
+from atom.rollout.weight_updater import WeightUpdaterMixin
+
+
+class PackedProjection(torch.nn.Module):
+    def __init__(self, device: torch.device):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(2, 2, device=device))
+        self.weight_scale = torch.nn.Parameter(torch.ones(1, device=device))
+
+    @staticmethod
+    def weight_loader(param, tensor, shard_id):
+        param.data[{"q": 0, "k": 1}[shard_id]].copy_(tensor.reshape(-1))
+
+
+class PackedModel(torch.nn.Module):
+    packed_modules_mapping: ClassVar[dict] = {
+        "q_proj": ("qkv_proj", "q"),
+        "k_proj": ("qkv_proj", "k"),
+    }
+
+    def __init__(self, device: torch.device):
+        super().__init__()
+        self.qkv_proj = PackedProjection(device)
+
+
+class CompatRunner(WeightUpdaterMixin):
+    def __init__(self, device: torch.device, rank: int):
+        self.model = PackedModel(device)
+        self.device = device
+        self.rank = rank - 1
+        self.world_size = 4
+        self.label = f"compat-rank-{rank}"
+        self.clear_count = 0
+
+    def clear_kv_cache(self):
+        self.clear_count += 1
+
+    @staticmethod
+    def _is_fp8_param(module, param):
+        return isinstance(module, PackedProjection)
+
+    def _requantize_fp8_weight(self, module, param_name, param, tensor):
+        param.data.copy_(tensor)
+        module.weight_scale.data.fill_(2.0)
+        return True
+
+    def _invalidate_cudagraphs_after_weight_update(self):
+        pass
+
+
+def weights_for(version: int, device: torch.device, *, complete: bool = True):
+    q = torch.tensor([version, version + 0.25], dtype=torch.bfloat16, device=device)
+    k = torch.tensor([version + 0.5, version + 0.75], dtype=torch.bfloat16, device=device)
+    values = [("q_proj.weight", q)]
+    if complete:
+        values.append(("k_proj.weight", k))
+    return values
+
+
+def expected_weight(version: int, device: torch.device):
+    return torch.stack([tensor for _, tensor in weights_for(version, device)]).float()
+
+
+def gather(value):
+    values = [None] * dist.get_world_size()
+    dist.all_gather_object(values, value)
+    return values
+
+
+def main() -> None:
+    rank_base = int(os.getenv("RDMA_TEST_RANK_BASE", "0"))
+    rank = rank_base + int(os.environ["SLURM_PROCID"])
+    local_rank = int(os.environ["SLURM_LOCALID"])
+    world_size = int(
+        os.getenv("RDMA_TEST_WORLD_SIZE", os.environ["SLURM_NTASKS"])
+    )
+    if world_size != 5:
+        raise RuntimeError(f"expected trainer + DP2xTP2 world of 5, got {world_size}")
+
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    master_port = int(os.getenv("RDMA_TEST_MASTER_PORT", "29612"))
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://{os.environ['RDMA_TEST_MASTER_ADDR']}:{master_port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    runner = CompatRunner(device, rank) if rank else None
+    completed = []
+
+    for version in (1, 2, 3):
+        if rank == 0:
+            stats = send_weight_stream(
+                dist.group.WORLD,
+                weights_for(version, device),
+                bucket_size_bytes=4,
+                version=version,
+            )
+            local = {"role": "sender", **stats}
+        else:
+            stats = receive_weight_stream(
+                dist.group.WORLD,
+                runner,
+                device=device,
+                expected_version=version,
+                verify_full_load=True,
+            )
+            torch.testing.assert_close(
+                runner.model.qkv_proj.weight,
+                expected_weight(version, device),
+            )
+            local = {
+                "role": "receiver",
+                "rank": rank,
+                "clear_count": runner.clear_count,
+                **stats,
+            }
+        round_stats = gather(local)
+        if rank == 0:
+            receivers = round_stats[1:]
+            invariant = {
+                (item["version"], item["buckets"], item["weights"], item["bytes"])
+                for item in receivers
+            }
+            if invariant != {(float(version), 2.0, 2.0, 8.0)}:
+                raise RuntimeError(f"receiver statistics diverged: {receivers}")
+            completed.append(round_stats)
+
+    failure_version = 4
+    if rank == 0:
+        send_weight_stream(
+            dist.group.WORLD,
+            weights_for(failure_version, device, complete=False),
+            bucket_size_bytes=4,
+            version=failure_version,
+        )
+        failure = {"role": "sender", "sent_incomplete": True}
+    else:
+        try:
+            receive_weight_stream(
+                dist.group.WORLD,
+                runner,
+                device=device,
+                expected_version=failure_version,
+                verify_full_load=True,
+            )
+        except RuntimeError as exc:
+            fenced = False
+            try:
+                runner.assert_weight_update_ready()
+            except RuntimeError:
+                fenced = True
+            failure = {
+                "role": "receiver",
+                "rank": rank,
+                "failed": True,
+                "fenced": fenced,
+                "error": str(exc),
+            }
+        else:
+            raise RuntimeError("incomplete stream unexpectedly committed")
+    failure_stats = gather(failure)
+    if rank == 0 and not all(
+        item.get("failed") and item.get("fenced") for item in failure_stats[1:]
+    ):
+        raise RuntimeError(f"failure did not fence every receiver: {failure_stats}")
+
+    recovery_version = 5
+    if rank == 0:
+        recovery = send_weight_stream(
+            dist.group.WORLD,
+            weights_for(recovery_version, device),
+            bucket_size_bytes=4,
+            version=recovery_version,
+        )
+        recovery_local = {"role": "sender", **recovery}
+    else:
+        recovery = receive_weight_stream(
+            dist.group.WORLD,
+            runner,
+            device=device,
+            expected_version=recovery_version,
+            verify_full_load=True,
+        )
+        runner.assert_weight_update_ready()
+        torch.testing.assert_close(
+            runner.model.qkv_proj.weight,
+            expected_weight(recovery_version, device),
+        )
+        recovery_local = {"role": "receiver", "rank": rank, **recovery}
+    recovery_stats = gather(recovery_local)
+
+    if rank == 0:
+        print(
+            "RDMA_COMPAT_RESULT "
+            + json.dumps(
+                {
+                    "status": "PASS",
+                    "nodes": sorted(
+                        {item["host"] for item in gather({"host": socket.gethostname()})}
+                    ),
+                    "world_size": world_size,
+                    "versions": [1, 2, 3],
+                    "rounds": completed,
+                    "failure": failure_stats,
+                    "recovery": recovery_stats,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+    else:
+        gather({"host": socket.gethostname()})
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run_lumenrl_rdma_node_processes.sh
+++ b/tests/run_lumenrl_rdma_node_processes.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -u
+
+RANK_BASE=${RDMA_TEST_RANK_BASE:?rank base is required}
+RANK_COUNT=${RDMA_NODE_RANK_COUNT:?rank count is required}
+LOG_DIR=${RDMA_LOG_DIR:?log directory is required}
+
+pids=()
+global_ranks=()
+for ((local_rank = 0; local_rank < RANK_COUNT; local_rank++)); do
+  global_rank=$((RANK_BASE + local_rank))
+  echo "starting global_rank=${global_rank} local_rank=${local_rank} host=$(hostname)"
+  SLURM_PROCID=${local_rank} \
+  SLURM_LOCALID=${local_rank} \
+  SLURM_NTASKS=${RANK_COUNT} \
+    python tests/run_lumenrl_rdma_compat.py >"${LOG_DIR}/rank-${global_rank}.log" 2>&1 &
+  pids+=("$!")
+  global_ranks+=("${global_rank}")
+done
+
+rc=0
+for index in "${!pids[@]}"; do
+  if wait "${pids[${index}]}"; then
+    echo "global_rank=${global_ranks[${index}]} rc=0"
+  else
+    rank_rc=$?
+    echo "global_rank=${global_ranks[${index}]} rc=${rank_rc}"
+    rc=1
+  fi
+done
+exit "${rc}"

--- a/tests/spur_lumenrl_rdma_validation.sh
+++ b/tests/spur_lumenrl_rdma_validation.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="docker.io/jiaolyu/qwen3-30b-a3b-vllm-rollout:rocm724-20260729-step54"
+MOUNTS="/home/jiaolyu/lumenrl-rdma-work/ATOM:/workspace/ATOM,/home/jiaolyu/lumenrl-rdma-work/Lumen-RL:/workspace/Lumen-RL"
+NODE_A=${1:?first validation node is required}
+NODE_B=${2:?second validation node is required}
+NODELIST="${NODE_A},${NODE_B}"
+
+echo "VALIDATION_JOB=${SLURM_JOB_ID}"
+echo "VALIDATION_NODES=${SLURM_JOB_NODELIST}"
+echo "REQUESTED_NODES=${NODELIST}"
+
+spur run \
+  --jobid "${SLURM_JOB_ID}" \
+  --overlap \
+  --nodes 1 \
+  --ntasks 1 \
+  --gpus 1 \
+  --nodelist "${NODE_A}" \
+  --container-image "${IMAGE}" \
+  --container-mounts "${MOUNTS}" \
+  --container-workdir /workspace/ATOM \
+  /bin/bash -lc \
+  'PYTHONPATH=/workspace/ATOM:/workspace/Lumen-RL python -m pytest -q tests/test_rdma_weight_receiver.py tests/test_collective_rpc.py /workspace/Lumen-RL/tests/unit/engine/test_atom_ray_server_rdma.py'
+
+spur run \
+  --jobid "${SLURM_JOB_ID}" \
+  --overlap \
+  --nodes 2 \
+  --ntasks 5 \
+  --gpus-per-task 1 \
+  --distribution block \
+  --nodelist "${NODELIST}" \
+  --container-image "${IMAGE}" \
+  --container-mounts "${MOUNTS}" \
+  --container-workdir /workspace/ATOM \
+  /bin/bash -lc \
+  "export PYTHONPATH=/workspace/ATOM:/workspace/Lumen-RL; export RDMA_TEST_MASTER_ADDR=${NODE_A}; export NCCL_IB_DISABLE=0; export NCCL_IB_HCA=ionic_0; export NCCL_IB_GID_INDEX=1; export NCCL_SOCKET_IFNAME=ens3; export NCCL_NET_GDR_LEVEL=PHB; export NCCL_DMABUF_ENABLE=1; export NCCL_DEBUG=INFO; export NCCL_DEBUG_SUBSYS=INIT,NET; python tests/run_lumenrl_rdma_compat.py"

--- a/tests/test_collective_rpc.py
+++ b/tests/test_collective_rpc.py
@@ -1,0 +1,523 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import inspect
+import pickle
+import queue
+import sys
+import threading
+import time
+import types
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+from atom.model_engine.collective_rpc import (
+    COLLECTIVE_RPC_COMMAND,
+    CollectiveRPCError,
+    CollectiveRPCRequest,
+    CollectiveRPCResponseRouter,
+    EngineCoreRPCResponse,
+    RPCErrorInfo,
+    WorkerRPCResponse,
+    validate_worker_responses,
+)
+from atom.model_engine.engine_utility import EngineUtilityHandler
+
+ATOM_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module_with_stubs(module_name, relative_path, stubs):
+    originals = {name: sys.modules.get(name) for name in stubs}
+    try:
+        sys.modules.update(stubs)
+        spec = spec_from_file_location(module_name, ATOM_ROOT / relative_path)
+        module = module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+class _MessageQueue:
+    pass
+
+
+aiter_module = types.ModuleType("aiter")
+aiter_dist_module = types.ModuleType("aiter.dist")
+shm_broadcast_module = types.ModuleType("aiter.dist.shm_broadcast")
+shm_broadcast_module.MessageQueue = _MessageQueue
+
+atom_utils_module = types.ModuleType("atom.utils")
+atom_utils_module.get_mp_context = lambda: None
+atom_utils_module.get_open_zmq_ipc_path = lambda: ""
+atom_utils_module.init_exit_handler = lambda *args, **kwargs: None
+atom_utils_module.make_zmq_socket = lambda *args, **kwargs: None
+atom_utils_module.resolve_obj_by_qualname = lambda *args, **kwargs: None
+atom_utils_module.shutdown_all_processes = lambda *args, **kwargs: None
+
+numa_utils_module = types.ModuleType("atom.utils.numa_utils")
+numa_utils_module.numa_bind_to_node = lambda *args, **kwargs: None
+
+kv_disaggregation_module = types.ModuleType("atom.kv_transfer.disaggregation")
+kv_disaggregation_module.KVOutputAggregator = object
+
+async_proc_module = _load_module_with_stubs(
+    "_collective_rpc_async_proc",
+    "atom/model_engine/async_proc.py",
+    {
+        "aiter": aiter_module,
+        "aiter.dist": aiter_dist_module,
+        "aiter.dist.shm_broadcast": shm_broadcast_module,
+        "atom.utils": atom_utils_module,
+        "atom.utils.numa_utils": numa_utils_module,
+        "atom.kv_transfer.disaggregation": kv_disaggregation_module,
+    },
+)
+AsyncIOProc = async_proc_module.AsyncIOProc
+AsyncIOProcManager = async_proc_module.AsyncIOProcManager
+
+
+core_manager_utils_module = types.ModuleType("atom.utils")
+core_manager_utils_module.get_open_zmq_inproc_path = lambda: ""
+core_manager_utils_module.get_open_zmq_ipc_path = lambda: ""
+core_manager_utils_module.make_zmq_socket = lambda *args, **kwargs: None
+core_manager_utils_module.set_device_control_env_var = lambda *args, **kwargs: None
+
+engine_core_module = types.ModuleType("atom.model_engine.engine_core")
+
+
+class _EngineCoreRequestType:
+    UTILITY = b"utility"
+    UTILITY_RESPONSE = b"utility_response"
+    SHUTDOWN = b"shutdown"
+    STREAM = b"stream"
+    ADD = b"add"
+    READY = b"ready"
+
+
+engine_core_module.EngineCore = object
+engine_core_module.EngineCoreRequestType = _EngineCoreRequestType
+
+engine_core_mgr_module = _load_module_with_stubs(
+    "_collective_rpc_engine_core_mgr",
+    "atom/model_engine/engine_core_mgr.py",
+    {
+        "atom.utils": core_manager_utils_module,
+        "atom.model_engine.engine_core": engine_core_module,
+    },
+)
+CoreManager = engine_core_mgr_module.CoreManager
+
+
+class _Runner:
+    def echo(self, value, *, suffix=""):
+        return f"{value}{suffix}"
+
+    def returns_none(self):
+        return None
+
+    def fails(self):
+        raise ValueError("boom")
+
+
+class _AliveProc:
+    def is_alive(self):
+        return True
+
+
+class _DeadProc:
+    def is_alive(self):
+        return False
+
+
+class _BroadcastQueue:
+    def __init__(self):
+        self.messages = []
+
+    def enqueue(self, message):
+        self.messages.append(message)
+
+
+def _make_worker(rank=0):
+    worker = AsyncIOProc.__new__(AsyncIOProc)
+    worker.rank = rank
+    worker.runners = [_Runner()]
+    worker.rpc_queue = queue.Queue()
+    return worker
+
+
+def _success(request_id, tp_rank, result):
+    return WorkerRPCResponse.success(request_id, tp_rank, result)
+
+
+def _request(request_id="req", method="echo", timeout=1.0, args=(), kwargs=None):
+    deadline = None if timeout is None else time.monotonic() + timeout
+    return CollectiveRPCRequest(request_id, method, args, kwargs or {}, deadline)
+
+
+def _make_manager(responses, procs=None):
+    manager = AsyncIOProcManager.__new__(AsyncIOProcManager)
+    manager.label = "test-manager"
+    manager.rpc_broadcast_mq = _BroadcastQueue()
+    manager.rpc_outputs_queues = []
+    for rank_responses in responses:
+        output_queue = queue.Queue()
+        for response in rank_responses:
+            output_queue.put_nowait(response)
+        manager.rpc_outputs_queues.append(output_queue)
+    manager.procs = procs or [_AliveProc() for _ in responses]
+    return manager
+
+
+def test_protocol_request_factory_validates_inputs_and_tracks_deadline(monkeypatch):
+    monkeypatch.setattr("atom.model_engine.collective_rpc.time.monotonic", lambda: 10.0)
+
+    request = CollectiveRPCRequest.create(
+        "echo", timeout=2.5, args=("value",), kwargs={"suffix": "!"}
+    )
+    assert request.method == "echo"
+    assert request.args == ("value",)
+    assert request.kwargs == {"suffix": "!"}
+    assert request.deadline == 12.5
+    assert request.remaining_timeout() == 2.5
+
+    no_deadline = CollectiveRPCRequest.create("echo")
+    assert no_deadline.deadline is None
+    assert no_deadline.remaining_timeout() is None
+
+    with pytest.raises(TypeError, match="non-empty string"):
+        CollectiveRPCRequest.create("")
+    with pytest.raises(TypeError, match="args must be a tuple"):
+        CollectiveRPCRequest.create("echo", args=[])
+    with pytest.raises(TypeError, match="kwargs must be a dict"):
+        CollectiveRPCRequest.create("echo", kwargs=[])
+    with pytest.raises(ValueError, match="non-negative"):
+        CollectiveRPCRequest.create("echo", timeout=-1)
+
+
+def test_async_io_proc_keeps_existing_positional_constructor_contract():
+    parameters = inspect.signature(AsyncIOProc.__init__).parameters
+
+    assert (
+        parameters["all_ranks_barrier"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    )
+    assert parameters["rpc_output_addr"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_protocol_validates_complete_tp_rank_set_independent_of_arrival_order():
+    request = _request()
+    out_of_order = EngineCoreRPCResponse.success(
+        request,
+        2,
+        [
+            _success(request.request_id, 1, "tp1"),
+            _success(request.request_id, 0, "tp0"),
+        ],
+    )
+    assert validate_worker_responses(out_of_order) is None
+
+    missing = EngineCoreRPCResponse.success(
+        request, 2, [_success(request.request_id, 0, "tp0")]
+    )
+    assert validate_worker_responses(missing).type == "CollectiveRPCProtocolError"
+
+    duplicate = EngineCoreRPCResponse.success(
+        request,
+        2,
+        [
+            _success(request.request_id, 0, "first"),
+            _success(request.request_id, 0, "second"),
+        ],
+    )
+    assert validate_worker_responses(duplicate).type == "CollectiveRPCProtocolError"
+
+
+def test_protocol_types_are_pickle_safe():
+    request = _request(args=("value",), kwargs={"suffix": "!"})
+    worker_response = WorkerRPCResponse.failure(
+        request.request_id, 0, RPCErrorInfo.transport("disconnected")
+    )
+    engine_response = EngineCoreRPCResponse.success(request, 1, [worker_response])
+
+    for value in (request, worker_response, engine_response):
+        assert pickle.loads(pickle.dumps(value)) == value
+
+
+def test_response_router_rejects_duplicates_and_cleans_up_registration():
+    router = CollectiveRPCResponseRouter()
+
+    with router.register("req") as response_queue:
+        with (
+            pytest.raises(RuntimeError, match="already registered"),
+            router.register("req"),
+        ):
+            pass
+        assert router.route("req", "response") is True
+        assert response_queue.get_nowait() == "response"
+
+    assert router.route("req", "late") is False
+
+
+def test_worker_collective_rpc_forwards_args_kwargs_and_none_result():
+    worker = _make_worker(rank=2)
+
+    worker._execute_collective_rpc(
+        _request("req-1", args=("value",), kwargs={"suffix": "!"})
+    )
+    assert worker.rpc_queue.get_nowait() == _success("req-1", 2, "value!")
+
+    worker._execute_collective_rpc(_request("req-2", method="returns_none"))
+    assert worker.rpc_queue.get_nowait() == _success("req-2", 2, None)
+
+
+def test_worker_collective_rpc_reports_missing_method_and_exception():
+    worker = _make_worker(rank=1)
+
+    worker._execute_collective_rpc(_request("missing", method="does_not_exist"))
+    missing = worker.rpc_queue.get_nowait()
+    assert missing.ok is False
+    assert missing.tp_rank == 1
+    assert missing.error.type == "AttributeError"
+
+    worker._execute_collective_rpc(_request("failure", method="fails"))
+    failure = worker.rpc_queue.get_nowait()
+    assert failure.ok is False
+    assert failure.error.type == "ValueError"
+    assert failure.error.message == "boom"
+
+
+def test_manager_collective_rpc_returns_tp_rank_order_and_drops_stale_response():
+    request_id = "current"
+    manager = _make_manager(
+        [
+            [_success("stale", 0, "old"), _success(request_id, 0, "tp0")],
+            [_success(request_id, 1, "tp1")],
+        ]
+    )
+
+    request = _request(request_id, args=("value",), kwargs={"suffix": "!"}, timeout=1.0)
+    responses = manager.collective_rpc(request)
+
+    assert [response.result for response in responses] == ["tp0", "tp1"]
+    assert manager.rpc_broadcast_mq.messages == [(COLLECTIVE_RPC_COMMAND, request)]
+
+
+def test_manager_collective_rpc_reports_dead_and_timed_out_workers():
+    manager = _make_manager([[], []], procs=[_DeadProc(), _AliveProc()])
+
+    responses = manager.collective_rpc(_request(timeout=0.01))
+
+    assert [response.ok for response in responses] == [False, False]
+    assert "not alive" in responses[0].error.message
+    assert "timed out" in responses[1].error.message
+
+
+class _RunnerManager:
+    def __init__(self, responses=None, error=None):
+        self.responses = responses
+        self.error = error
+        self.calls = []
+        self.proc_num = len(responses) if responses else 1
+
+    def collective_rpc(self, request):
+        self.calls.append(request)
+        if self.error is not None:
+            raise self.error
+        return self.responses
+
+
+def test_utility_handler_preserves_request_id_and_reports_tp_results():
+    tp_responses = [_success("req", 0, None), _success("req", 1, "ok")]
+    runner_manager = _RunnerManager(responses=tp_responses)
+    output_queue = queue.Queue()
+    handler = EngineUtilityHandler(runner_manager, output_queue)
+
+    request = _request(args=("value",), kwargs={"suffix": "!"}, timeout=5)
+    handler._handle_collective_rpc({"request": request})
+
+    kind, response = output_queue.get_nowait()
+    assert kind == "UTILITY_RESPONSE"
+    assert response.request_id == "req"
+    assert response.tp_responses == tuple(tp_responses)
+    assert response.error is None
+    assert runner_manager.calls == [request]
+
+
+def test_utility_handler_turns_local_dispatch_exception_into_response():
+    output_queue = queue.Queue()
+    handler = EngineUtilityHandler(
+        _RunnerManager(error=TypeError("bad arguments")), output_queue
+    )
+
+    handler._handle_collective_rpc({"request": _request()})
+
+    _, response = output_queue.get_nowait()
+    assert response.request_id == "req"
+    assert response.tp_responses == ()
+    assert response.error.type == "TypeError"
+    assert response.error.message == "bad arguments"
+
+
+def _make_core_manager(dp_count=2):
+    manager = CoreManager.__new__(CoreManager)
+    manager.label = "test-core-manager"
+    manager.local_engine_count = dp_count
+    manager.utility_response_queue = queue.Queue()
+    manager._collective_rpc_router = CollectiveRPCResponseRouter()
+    manager._utility_send_lock = threading.Lock()
+    manager.engine_core_processes = [_AliveProc() for _ in range(dp_count)]
+    return manager
+
+
+def test_core_manager_collective_rpc_flattens_dp_major_order():
+    manager = _make_core_manager()
+
+    def broadcast(_cmd, **payload):
+        request = payload["request"]
+        manager._route_utility_response(
+            1,
+            EngineCoreRPCResponse.success(
+                request,
+                2,
+                [
+                    _success(request.request_id, 0, "dp1-tp0"),
+                    _success(request.request_id, 1, "dp1-tp1"),
+                ],
+            ),
+        )
+        manager._route_utility_response(
+            0,
+            EngineCoreRPCResponse.success(
+                request,
+                2,
+                [
+                    _success(request.request_id, 1, "dp0-tp1"),
+                    _success(request.request_id, 0, "dp0-tp0"),
+                ],
+            ),
+        )
+
+    manager.broadcast_utility_command = broadcast
+
+    assert manager.collective_rpc("echo", timeout=1.0) == [
+        "dp0-tp0",
+        "dp0-tp1",
+        "dp1-tp0",
+        "dp1-tp1",
+    ]
+
+
+def test_core_manager_collective_rpc_raises_ranked_worker_failure():
+    manager = _make_core_manager(dp_count=1)
+
+    def broadcast(_cmd, **payload):
+        request = payload["request"]
+        failure = WorkerRPCResponse.failure(
+            request.request_id,
+            0,
+            RPCErrorInfo("ValueError", "boom", "trace"),
+        )
+        manager._route_utility_response(
+            0,
+            EngineCoreRPCResponse.success(request, 1, [failure]),
+        )
+
+    manager.broadcast_utility_command = broadcast
+
+    try:
+        manager.collective_rpc("fails", timeout=1.0)
+    except CollectiveRPCError as exc:
+        assert "DP0/TP0" in str(exc)
+        assert "ValueError: boom" in str(exc)
+    else:
+        raise AssertionError("CollectiveRPCError was not raised")
+
+
+def test_core_manager_routes_legacy_and_drops_late_correlated_responses():
+    manager = _make_core_manager(dp_count=1)
+    manager._route_utility_response(0, {"cmd": "legacy", "result": True})
+    assert manager.utility_response_queue.get_nowait()["cmd"] == "legacy"
+
+    request = _request("already-finished")
+    manager._route_utility_response(
+        0,
+        EngineCoreRPCResponse.success(
+            request, 1, [_success(request.request_id, 0, None)]
+        ),
+    )
+    assert manager.utility_response_queue.empty()
+
+
+def test_core_manager_routes_concurrent_request_ids_to_separate_queues():
+    manager = _make_core_manager(dp_count=1)
+    first = EngineCoreRPCResponse.failure(
+        "first", "echo", RPCErrorInfo.transport("first")
+    )
+    second = EngineCoreRPCResponse.failure(
+        "second", "echo", RPCErrorInfo.transport("second")
+    )
+
+    with (
+        manager._collective_rpc_router.register("first") as first_queue,
+        manager._collective_rpc_router.register("second") as second_queue,
+    ):
+        manager._route_utility_response(0, second)
+        manager._route_utility_response(0, first)
+
+        assert first_queue.get_nowait() == (0, first)
+        assert second_queue.get_nowait() == (0, second)
+
+
+def test_async_engine_collective_rpc_delegates_public_contract(monkeypatch):
+    llm_engine_module = types.ModuleType("atom.model_engine.llm_engine")
+    llm_engine_module.LLMEngine = object
+    monkeypatch.setitem(sys.modules, "atom.model_engine.llm_engine", llm_engine_module)
+
+    weight_sync_module = types.ModuleType("atom.rollout.weight_sync")
+    weight_sync_module.load_weights_via_ipc = lambda *args, **kwargs: None
+    weight_sync_module.load_weights_via_shm = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "atom.rollout.weight_sync", weight_sync_module)
+
+    module_path = (
+        Path(__file__).resolve().parents[1] / "atom" / "rollout" / "async_engine.py"
+    )
+    spec = spec_from_file_location("_collective_rpc_async_engine", module_path)
+    module = module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    AsyncLLMEngine = module.AsyncLLMEngine
+
+    class _CoreManager:
+        def __init__(self):
+            self.calls = []
+
+        def collective_rpc(self, **kwargs):
+            self.calls.append(kwargs)
+            return ["ok"]
+
+    engine = AsyncLLMEngine.__new__(AsyncLLMEngine)
+    engine.core_mgr = _CoreManager()
+
+    result = engine.collective_rpc(
+        "echo",
+        timeout=3.0,
+        args=("value",),
+        kwargs={"suffix": "!"},
+    )
+
+    assert result == ["ok"]
+    assert engine.core_mgr.calls == [
+        {
+            "method": "echo",
+            "timeout": 3.0,
+            "args": ("value",),
+            "kwargs": {"suffix": "!"},
+        }
+    ]

--- a/tests/test_rdma_weight_receiver.py
+++ b/tests/test_rdma_weight_receiver.py
@@ -1,0 +1,203 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+import torch
+
+
+def _load_module(name: str, relative_path: str):
+    path = Path(__file__).parents[1] / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_receiver = _load_module(
+    "_atom_rdma_weight_receiver_test", "atom/rollout/rdma_weight_receiver.py"
+)
+_updater = _load_module("_atom_weight_updater_test", "atom/rollout/weight_updater.py")
+_CMD_BUCKET = _receiver._CMD_BUCKET
+_CMD_END = _receiver._CMD_END
+_HEADER_WORDS = _receiver._HEADER_WORDS
+RDMAWeightReceiverMixin = _receiver.RDMAWeightReceiverMixin
+_decode_bucket = _receiver._decode_bucket
+WeightUpdaterMixin = _updater.WeightUpdaterMixin
+
+
+class _PackedProjection(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(2, 2))
+        self.weight_scale = torch.nn.Parameter(torch.ones(1))
+
+    @staticmethod
+    def weight_loader(param, tensor, shard_id):
+        row = {"q": 0, "k": 1}[shard_id]
+        param.data[row].copy_(tensor.reshape(-1))
+
+
+class _PackedModel(torch.nn.Module):
+    packed_modules_mapping: ClassVar[dict] = {
+        "q_proj": ("qkv_proj", "q"),
+        "k_proj": ("qkv_proj", "k"),
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.qkv_proj = _PackedProjection()
+
+
+class _Runner(WeightUpdaterMixin):
+    def __init__(self):
+        self.model = _PackedModel()
+        self.device = torch.device("cpu")
+        self.rank = 0
+        self.world_size = 1
+        self.label = "test-runner"
+        self.clear_count = 0
+
+    def clear_kv_cache(self):
+        self.clear_count += 1
+
+    @staticmethod
+    def _is_fp8_param(module, param):
+        return isinstance(module, _PackedProjection)
+
+    def _requantize_fp8_weight(self, module, param_name, param, tensor):
+        param.data.copy_(tensor)
+        module.weight_scale.data.fill_(2.0)
+        return True
+
+    def _invalidate_cudagraphs_after_weight_update(self):
+        pass
+
+
+def test_transaction_preserves_packed_shards_across_buckets():
+    runner = _Runner()
+    runner.begin_weight_update(7)
+    with pytest.raises(RuntimeError, match="is in progress"):
+        runner.assert_weight_update_ready()
+
+    first = runner.apply_weight_bucket(
+        [("q_proj.weight", torch.tensor([1.0, 2.0], dtype=torch.bfloat16))],
+        payload_bytes=4,
+    )
+    assert first["loaded_internal"] == 0
+    assert runner.clear_count == 0
+    assert list(runner._packed_weight_accum) == ["qkv_proj.weight"]
+
+    second = runner.apply_weight_bucket(
+        [("k_proj.weight", torch.tensor([3.0, 4.0], dtype=torch.bfloat16))],
+        payload_bytes=4,
+    )
+    assert second["loaded_internal"] == 2
+    manifest = runner.commit_weight_update(7, verify_full_load=True)
+
+    assert manifest["buckets"] == 2
+    assert manifest["bytes"] == 8
+    assert manifest["missing"] == []
+    assert manifest["loaded_internal_names"] == [
+        "qkv_proj.weight",
+        "qkv_proj.weight_scale",
+    ]
+    assert runner.clear_count == 1
+    torch.testing.assert_close(
+        runner.model.qkv_proj.weight,
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+    )
+
+
+def test_failed_reload_fences_serving_until_new_full_commit():
+    runner = _Runner()
+    runner.begin_weight_update(1)
+    runner.apply_weight_bucket([("unknown.weight", torch.ones(1))])
+
+    with pytest.raises(RuntimeError, match="incomplete ATOM RDMA weight reload"):
+        runner.commit_weight_update(1, verify_full_load=True)
+    with pytest.raises(RuntimeError, match="serving is fenced"):
+        runner.assert_weight_update_ready()
+
+    runner.begin_weight_update(2)
+    runner.apply_weight_bucket(
+        [
+            ("q_proj.weight", torch.tensor([5.0, 6.0], dtype=torch.bfloat16)),
+            ("k_proj.weight", torch.tensor([7.0, 8.0], dtype=torch.bfloat16)),
+        ]
+    )
+    runner.commit_weight_update(2, verify_full_load=True)
+    runner.assert_weight_update_ready()
+
+    with pytest.raises(RuntimeError, match="must increase"):
+        runner.begin_weight_update(2)
+
+
+def test_bf16_packed_parameter_requires_every_declared_shard():
+    runner = _Runner()
+    runner._is_fp8_param = lambda module, param: False
+    runner.begin_weight_update(1)
+    runner.apply_weight_bucket([("q_proj.weight", torch.tensor([1.0, 2.0]))])
+
+    with pytest.raises(RuntimeError, match="incomplete packed shards"):
+        runner.commit_weight_update(1, verify_full_load=True)
+    with pytest.raises(RuntimeError, match="serving is fenced"):
+        runner.assert_weight_update_ready()
+
+
+def test_vllm_v1_bucket_metadata_decodes_without_translation():
+    assert (_CMD_END, _CMD_BUCKET, _HEADER_WORDS) == (0, 1, 4)
+    values = torch.tensor([[1.0, 2.0]], dtype=torch.bfloat16)
+    payload = values.contiguous().view(torch.uint8).reshape(-1)
+    entries = [
+        {
+            "name": "model.embed_tokens.weight",
+            "shape": [1, 2],
+            "dtype": "bfloat16",
+            "offset": 0,
+            "nbytes": payload.numel(),
+        }
+    ]
+    metadata = torch.tensor(
+        list(json.dumps(entries, separators=(",", ":")).encode("utf-8")),
+        dtype=torch.uint8,
+    )
+
+    decoded = _decode_bucket(metadata, payload)
+    assert decoded[0][0] == "model.embed_tokens.weight"
+    torch.testing.assert_close(decoded[0][1], values)
+
+
+def test_dp_tp_rank_is_flattened_inside_server_base_rank(monkeypatch):
+    calls = []
+
+    def fake_init(**kwargs):
+        calls.append(kwargs)
+        return object()
+
+    lumenrl = types.ModuleType("lumenrl")
+    utils = types.ModuleType("lumenrl.utils")
+    independent = types.ModuleType("lumenrl.utils.independent_process_group")
+    independent.init_independent_process_group = fake_init
+    monkeypatch.setitem(sys.modules, "lumenrl", lumenrl)
+    monkeypatch.setitem(sys.modules, "lumenrl.utils", utils)
+    monkeypatch.setitem(
+        sys.modules, "lumenrl.utils.independent_process_group", independent
+    )
+
+    runner = type("RankRunner", (RDMAWeightReceiverMixin,), {})()
+    runner.config = types.SimpleNamespace(
+        parallel_config=types.SimpleNamespace(data_parallel_rank_local=1)
+    )
+    runner.world_size = 2
+    runner.rank = 1
+    runner.label = "rank-runner"
+
+    assert runner.init_rdma_weight_group("10.0.0.1", 1234, 1, 5, "weights")
+    assert calls[0]["rank"] == 4
+    assert calls[0]["world_size"] == 5


### PR DESCRIPTION

## Motivation

  Adds request-scoped response routing, per-TP acknowledgements, timeout/error propagation, and a public AsyncLLMEngine.collective_rpc() API.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
