### PR TITLE
[ATOM][Kimi-K3] enable KDA prefill on aiter

### DIFF
--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -958,36 +958,35 @@ class KimiKDAAttention(nn.Module):
         cu_seqlens: torch.Tensor | None,
         output_final_state: bool,
     ):
-        from fla.ops.kda import chunk_kda
+        from aiter.ops.triton.kimi_delta_attn import chunk_kimi_delta_attn
 
-        kwargs = {
-            "q": q,
-            "k": k,
-            "v": v,
-            "g": g,
-            # Keep beta in fp32: fla computes b = sigmoid(beta) in-kernel with
-            # use_beta_sigmoid_in_kernel, and triton's sigmoid follows the input
-            # dtype -- a bf16 beta yields a bf16 write strength, which erodes the
-            # delta-rule state update across the 71 KDA layers (measured gsm8k
-            # regression). b_proj stays bf16; only this reduction is widened.
-            "beta": beta.float(),
-            "A_log": self.A_log,
-            "dt_bias": self.dt_bias,
-            "initial_state": initial_state,
-            "output_final_state": output_final_state,
-            "use_qk_l2norm_in_kernel": True,
-            "use_gate_in_kernel": True,
-            "use_beta_sigmoid_in_kernel": True,
-            "safe_gate": self._kda_gate_lower_bound is not None,
-            "lower_bound": self._kda_gate_lower_bound,
-            "transpose_state_layout": True,
-            "cu_seqlens": cu_seqlens,
-        }
-        # FLA 0.5.1's default KDA recompute specialization is non-deterministic
-        # for long, packed gfx950 prefills and can emit extreme values. Selecting
-        # disable_recompute enables its STORE_QG specialization, which is stable
-        # and preserves the same chunk-KDA forward semantics.
-        return chunk_kda(**kwargs, disable_recompute=True)
+        return chunk_kimi_delta_attn(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            # Keep beta in fp32: the sigmoid b = sigmoid(beta) is applied
+            # in-kernel with use_beta_sigmoid_in_kernel, and triton's sigmoid
+            # follows the input dtype -- a bf16 beta yields a bf16 write
+            # strength, which erodes the delta-rule state update across the 71
+            # KDA layers (measured gsm8k regression). b_proj stays bf16; only
+            # this reduction is widened.
+            beta=beta.float(),
+            A_log=self.A_log,
+            dt_bias=self.dt_bias,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            use_beta_sigmoid_in_kernel=True,
+            safe_gate=self._kda_gate_lower_bound is not None,
+            lower_bound=self._kda_gate_lower_bound,
+            cu_seqlens=cu_seqlens,
+            # V-first state, matching the layout mamba_v_cache holds and the
+            # fused decode kernel writes. Without it the state comes back
+            # K-first and decode reads it transposed.
+            state_v_first=True,
+        )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # hidden_states is a (fp8, scale) tuple when input_layernorm fused the

--- a/docker/atom_release.dockerfile
+++ b/docker/atom_release.dockerfile
@@ -194,11 +194,6 @@ RUN pip show atom || true
 
 RUN pip install --no-cache-dir msgpack msgspec quart
 
-# flash-linear-attention (import name `fla`): Kimi-K3 KDA prefill uses
-# fla.ops.kda.chunk_kda. Its only core dep is einops (already present); torch and
-# triton sit behind extras, so this does NOT touch the image's ROCm torch/triton.
-RUN pip install --no-cache-dir flash-linear-attention==0.5.2 fla-core==0.5.2
-
 # atomesh: install the binary produced by the ATOM package build hook to /usr/local/bin
 RUN echo "========== Install atomesh binary ==========" && \
     cd /app/ATOM/atom/mesh && \

--- a/recipes/atom_vllm/Kimi-K3.md
+++ b/recipes/atom_vllm/Kimi-K3.md
@@ -9,12 +9,11 @@ The validated configuration requires eight MI355 (gfx950) GPUs with TP8.
 
 ## Prerequisites
 
-Use the ATOM vLLM OOT image and install the KDA dependency used by the native
-Kimi-K3 implementation:
+Use the ATOM vLLM OOT image. The KDA recurrence runs on aiter, which the image
+already carries, so no extra package is needed:
 
 ```bash
 docker pull rocm/atom-dev:vllm-latest
-pip install "fla-core==0.5.1" "flash-linear-attention==0.5.1"
 ```
 
 Install the target ATOM checkout into the same environment:


### PR DESCRIPTION
## Motivation

Kimi-K3's KDA prefill recurrence is hard-wired to `fla.ops.kda.chunk_kda`.
aiter ships an equivalent Triton implementation.

## Technical Details

- Rename `transpose_state_layout` -> `state_v_first`, fla's spelling since
  0.5.1. This raises the floor to fla >= 0.5.1; the release image installs
  0.5.2 (`docker/atom_release.dockerfile:200`) and the recipe pins 0.5.1
  (`recipes/atom_vllm/Kimi-K3.md:17`).
  Worth noting the direction of the risk: `chunk_kda` ends in `**kwargs`, so on
  a pre-0.5.1 fla the new name is swallowed without error and the state comes
  back K-first instead of matching `mamba_v_cache` -- a silent wrong answer,
  not an exception. The old name has the same exposure once fla drops its
  deprecation shim.

## Test Plan

- Kimi-K3 accuracy test

## Test Result

- Kimi-K3 accuracy passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.