### PR TITLE
[ATOM SGL][model] Kimi K3

### DIFF
--- a/.github/benchmark/sglang_benchmark_models.json
+++ b/.github/benchmark/sglang_benchmark_models.json
@@ -10,6 +10,7 @@
       "glm52_pcp_fp8_runtime": "--trust-remote-code --tp-size 4 --enable-nsa-prefill-context-parallel --attn-cp-size 4 --nsa-prefill-cp-mode round-robin-split --max-prefill-tokens 30720 --chunked-prefill-size 30720 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.85 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"layer_quant_config\":{\"model.layers.*.mlp.experts\":\"per_block_fp8\"},\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"*.mlp.gate\"]}}'",
       "glm52_mi308_fp8_runtime": "--trust-remote-code --tp-size 8 --mem-fraction-static 0.8 --disable-radix-cache --max-prefill-tokens 65536 --kv-cache-dtype fp8_e4m3",
       "glm52_fp4_runtime": "--trust-remote-code --tp-size 4 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --disable-radix-cache --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"*.mlp.gate\",\"*expert*\"]}}'",
+      "kimi_k3_runtime": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --page-size 128 --context-length 16384 --mem-fraction-static 0.93 --disable-radix-cache",
       "glm52_mtp3_runtime": "--enable-return-hidden-states --max-running-requests 256 --cuda-graph-backend-decode full --cuda-graph-backend-prefill disabled --cuda-graph-max-bs-decode 256 --speculative-algorithm EAGLE --speculative-draft-attention-backend aiter --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4",
       "minimax_m3_eagle3_runtime": "--trust-remote-code --random-seed 0 --tensor-parallel-size 4 --attention-backend aiter --mem-fraction-static 0.75 --page-size 128 --context-length 32768 --max-running-requests 128 --model-loader-extra-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"vision_tower\",\"multi_modal_projector\",\"patch_merge_mlp\",\"*block_sparse_moe\"]}}' --json-model-override-args '{\"use_index_cache\":true,\"index_topk_freq\":4}' --speculative-algorithm EAGLE3 --speculative-draft-model-path Inferact/MiniMax-M3-EAGLE3 --speculative-num-steps 3 --speculative-eagle-topk 1 --kv-cache-dtype fp8_e4m3 --disable-radix-cache --decode-log-interval 1",
       "mtp1_common": "--speculative-draft-model-path SGLang/DeepSeek-R1-NextN --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 --max-running-requests 256 --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 160 192 224 256",
@@ -26,6 +27,7 @@
       "glm52_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1\nSGLANG_USE_AITER=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
       "glm52_pcp_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_SGLANG_PCP_SIZE=4\nATOM_PCP_MOE_MERGE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
       "glm52_mi308_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nAITER_USE_FLYDSL_MOE_SORTING=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_ENABLE_TORCH_COMPILE=1\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nTORCHINDUCTOR_COMPILE_THREADS=128",
+      "kimi_k3_common": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_PLUGINS=atom_sglang\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models\nATOM_LOADER_NUM_THREADS=16\nATOM_SYNC_AFTER_LOAD=1\nATOM_DIST_TIMEOUT_SECONDS=3600\nATOM_USE_TRITON_GEMM=1\nAITER_USE_GROUPED_GEMM=0\nATOM_USE_TRITON_MOE=0\nAITER_FLYDSL_FORCE=1\nAITER_FORCE_GFX1250=0\nATOM_MLA_PAGE_SIZE=1\nATOM_USE_UNIFIED_ATTN=1\nATOM_FORCE_ATTN_TRITON=1",
       "qwen_common": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=0",
       "minimax_m3_common": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models",
       "minimax_m3_eagle3_common": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_USE_AITER=1\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nATOM_FORCE_ATTN_TRITON=1\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128\nATOM_SGLANG_EAGLE3_TP_VERIFY_BROADCAST=1"
@@ -376,6 +378,24 @@
         "deepseek_mtp_dp_common",
         "SGLANG_AITER_FP8_PREFILL_ATTN=1"
       ]
+    },
+    {
+      "display": "Kimi-K3 TP8",
+      "dashboard_model": "Kimi-K3",
+      "workload_label": "SGLang-OOB",
+      "source_path": "moonshotai/Kimi-K3",
+      "path": "moonshotai/Kimi-K3",
+      "prefix": "kimi-k3-tp8",
+      "extra_args": "kimi_k3_runtime",
+      "bench_args": "",
+      "runner": "atom-mi355-8gpu-aac-runner",
+      "nightly_group": "B",
+      "supported_input_output_pairs": ["1024x1024", "8192x1024"],
+      "supported_concurrency_values_by_pair": {
+        "1024x1024": [4, 8, 16, 32, 64, 128, 256],
+        "8192x1024": [4, 8, 16, 32, 64, 128, 256]
+      },
+      "env_vars": "kimi_k3_common"
     },
     {
       "display": "MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3",

--- a/.github/benchmark/sglang_models_accuracy.json
+++ b/.github/benchmark/sglang_models_accuracy.json
@@ -106,6 +106,20 @@
     "_baseline_note": "TP8 coverage for the Kimi-K2.6-MXFP4 SGLang accuracy validation target for gsm8k."
   },
   {
+    "model_name": "Kimi-K3 TP8",
+    "model_path": "moonshotai/Kimi-K3",
+    "extraArgs": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --page-size 128 --context-length 16384 --mem-fraction-static 0.93 --disable-radix-cache",
+    "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_PLUGINS=atom_sglang\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models\nATOM_LOADER_NUM_THREADS=16\nATOM_SYNC_AFTER_LOAD=1\nATOM_DIST_TIMEOUT_SECONDS=3600\nATOM_USE_TRITON_GEMM=1\nAITER_USE_GROUPED_GEMM=0\nATOM_USE_TRITON_MOE=0\nAITER_FLYDSL_FORCE=1\nAITER_FORCE_GFX1250=0\nATOM_MLA_PAGE_SIZE=1\nATOM_USE_UNIFIED_ATTN=1\nATOM_FORCE_ATTN_TRITON=1",
+    "runner": "atom-plugin-acc-validation-runner-sgl",
+    "test_level": "nightly",
+    "lm_eval_num_fewshot": 5,
+    "lm_eval_num_concurrent": 64,
+    "accuracy_threshold": 0.94,
+    "accuracy_baseline": 0.9553,
+    "accuracy_baseline_model": "moonshotai/Kimi-K3",
+    "_baseline_note": "Kimi-K3 TP8 with FP8 KV cache and CUDA Graph. The 0.9553 GSM8K 5-shot flexible-extract reference comes from the validated ATOM vLLM Kimi-K3 recipe; refresh with the first SGLang nightly measurement."
+  },
+  {
     "model_name": "MiniMax-M3-MXFP4 TP4",
     "model_path": "amd/MiniMax-M3-MXFP4",
     "extraArgs": "--trust-remote-code --tensor-parallel-size 4 --attention-backend aiter --page-size 128 --mem-fraction-static 0.8 --max-running-requests 128 --disable-radix-cache",

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -25,6 +25,7 @@ on:
           - DeepSeek-R1-FP8 TP4 Online Quant
           - Kimi-K2.6-MXFP4 TP4
           - Kimi-K2.6-MXFP4 TP8
+          - Kimi-K3 TP8
           - MiniMax-M3-MXFP4 TP4
           - MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3
           - Qwen3.5-35B-A3B-FP8 TP2
@@ -241,6 +242,17 @@ jobs:
                   "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.8 --page-size 1 --disable-radix-cache",
                   "accuracy_test_threshold": 0.91,
                   "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nAITER_QUICK_REDUCE_QUANTIZATION=INT4\nSGLANG_AITER_FP8_PREFILL_ATTN=0\nSGLANG_USE_AITER=1\nATOM_ENABLE_DS_QKNORM_QUANT_FUSION=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_ENABLE_TORCH_COMPILE=1\nTORCHINDUCTOR_COMPILE_THREADS=128",
+                  "runner": "atom-plugin-acc-validation-runner-sgl",
+              },
+              {
+                  "toggle_env": "RUN_KIMI_K3_TP8",
+                  "model_name": "Kimi-K3 TP8",
+                  "model_path": "moonshotai/Kimi-K3",
+                  "extra_args": "--trust-remote-code --tensor-parallel-size 8 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --page-size 128 --context-length 16384 --mem-fraction-static 0.93 --disable-radix-cache",
+                  "lm_eval_num_fewshot": 5,
+                  "lm_eval_num_concurrent": 64,
+                  "accuracy_test_threshold": 0.94,
+                  "env_vars": "SGLANG_DEFAULT_SERVER_ARGS=\nSGLANG_PLUGINS=atom_sglang\nSGLANG_USE_AITER=1\nSGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models\nSGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models\nATOM_LOADER_NUM_THREADS=16\nATOM_SYNC_AFTER_LOAD=1\nATOM_DIST_TIMEOUT_SECONDS=3600\nATOM_USE_TRITON_GEMM=1\nAITER_USE_GROUPED_GEMM=0\nATOM_USE_TRITON_MOE=0\nAITER_FLYDSL_FORCE=1\nAITER_FORCE_GFX1250=0\nATOM_MLA_PAGE_SIZE=1\nATOM_USE_UNIFIED_ATTN=1\nATOM_FORCE_ATTN_TRITON=1",
                   "runner": "atom-plugin-acc-validation-runner-sgl",
               },
               {

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -55,6 +55,7 @@ on:
           - GLM-5.2 FP8 TP4
           - GLM-5.2 FP8 TP4 PCP4
           - GLM-5.2 FP4 TP4
+          - Kimi-K3 TP8
           - GLM-5.2 FP4 TP4 MTP3
           - MiniMax-M3-MXFP4 TP4
           - MiniMax-M3-MXFP8 EAGLE3 TP4 MTP3

--- a/atom/plugin/register.py
+++ b/atom/plugin/register.py
@@ -38,8 +38,8 @@ _ATOM_SUPPORTED_MODELS = {
 if is_sglang():
     from atom.models.deepseek_v4 import DeepseekV4ForCausalLM
     from atom.models.eagle3_llama import Eagle3LlamaModel
-    from atom.models.kimi_k25 import KimiK25ForCausalLM
     from atom.models.kimi_k3 import KimiK3ForCausalLM
+    from atom.models.kimi_k25 import KimiK25ForCausalLM
     from atom.models.qwen3_5 import (
         Qwen3_5ForCausalLM,
         Qwen3_5MoeForCausalLM,

--- a/atom/plugin/register.py
+++ b/atom/plugin/register.py
@@ -39,6 +39,7 @@ if is_sglang():
     from atom.models.deepseek_v4 import DeepseekV4ForCausalLM
     from atom.models.eagle3_llama import Eagle3LlamaModel
     from atom.models.kimi_k25 import KimiK25ForCausalLM
+    from atom.models.kimi_k3 import KimiK3ForCausalLM
     from atom.models.qwen3_5 import (
         Qwen3_5ForCausalLM,
         Qwen3_5MoeForCausalLM,
@@ -58,6 +59,7 @@ if is_sglang():
             # sglang's native model and failed weight loading on the excluded
             # (BF16) attention projections.
             "KimiK25ForConditionalGeneration": KimiK25ForCausalLM,
+            "KimiK3ForConditionalGeneration": KimiK3ForCausalLM,
         }
     )
     _ATOM_SUPPORTED_DRAFT_MODELS = {
@@ -87,6 +89,10 @@ def _register_custom_attention_to_sglang() -> None:
         ATOMGLM52DSABackendForSgl,
         install_upstream_glm52_graph_metadata_adapter,
     )
+    from atom.plugin.sglang.attention_backend.kimi_k3_backend import (
+        ATOMKimiK3BackendForSgl,
+    )
+    from atom.plugin.sglang.kimi_k3_bridge import is_kimi_k3_config
     from atom.plugin.sglang.runtime import is_glm52_dsa_config
 
     # here register the custom attention backend with the name "aiter"
@@ -118,6 +124,11 @@ def _register_custom_attention_to_sglang() -> None:
             return ATOMDeepseekV4BackendForSgl(runner)
         if is_glm52_dsa_config(hf_config):
             return create_glm52_backend(runner)
+        if is_kimi_k3_config(hf_config):
+            logger.info(
+                "Use ATOMKimiK3BackendForSgl for Kimi-K3 through SGLang aiter backend choice"
+            )
+            return ATOMKimiK3BackendForSgl(runner)
         return ATOMAttnBackendForSgl(runner)
 
     @register_attention_backend("dsv4")

--- a/atom/plugin/sglang/attention_backend/attention_gdn.py
+++ b/atom/plugin/sglang/attention_backend/attention_gdn.py
@@ -154,7 +154,7 @@ class SGLangGDNForwardContext:
             "num_spec_decodes": 0,
             "num_spec_decode_tokens": 0,
             "spec_query_start_loc": None,
-            "non_spec_query_start_loc": fm.query_start_loc,
+            "non_spec_query_start_loc": query_start_loc,
             "spec_state_indices_tensor": None,
             "non_spec_state_indices_tensor": idx,
             "spec_sequence_masks": None,

--- a/atom/plugin/sglang/attention_backend/attention_gdn.py
+++ b/atom/plugin/sglang/attention_backend/attention_gdn.py
@@ -17,6 +17,11 @@ from atom.model_ops.attentions.gdn_attn import (
     GDNAttentionMetadata,
     compute_causal_conv1d_metadata,
 )
+from atom.plugin.sglang.attention_backend.backend_resolver import (
+    reconstruct_linear_metadata,
+    resolve_attn_backend,
+    resolve_mamba_req_pool,
+)
 from atom.utils.forward_context import (
     AttentionMetaData,
     Context,
@@ -55,22 +60,7 @@ class SGLangGDNForwardContext:
 
     @staticmethod
     def _resolve_attn_backend(forward_batch: Any) -> Any:
-        backend = getattr(forward_batch, "attn_backend", None)
-        if backend is not None:
-            return backend
-
-        try:
-            from sglang.srt.model_executor.forward_context import (
-                get_attn_backend,
-                has_forward_context,
-            )
-
-            if has_forward_context():
-                return get_attn_backend()
-        except Exception:  # noqa: BLE001, S110 - forward context is optional
-            pass
-
-        return None
+        return resolve_attn_backend(forward_batch)
 
     @staticmethod
     def _patch_forward_batch_pools(forward_batch: Any, attn_backend: Any) -> None:
@@ -87,10 +77,8 @@ class SGLangGDNForwardContext:
     def _build_kv_cache_tensors(
         forward_batch: Any, attn_backend: Any
     ) -> dict[str, KVCacheTensor]:
-        pool = getattr(forward_batch, "req_to_token_pool", None)
-        if pool is None:
-            pool = getattr(attn_backend, "req_to_token_pool", None)
-        if pool is None:
+        pool = resolve_mamba_req_pool(forward_batch, attn_backend)
+        if pool is None or getattr(pool, "mamba_map", None) is None:
             try:
                 from sglang.srt.model_executor.forward_context import (
                     get_req_to_token_pool,
@@ -126,7 +114,9 @@ class SGLangGDNForwardContext:
         mode = forward_batch.forward_mode
         is_prefill = mode.is_prefill()
         num_tokens = (
-            forward_batch.seq_lens_sum if mode.is_extend() else forward_batch.batch_size
+            int(forward_batch.seq_lens_sum)
+            if mode.is_extend()
+            else int(forward_batch.batch_size)
         )
         return (
             Context(
@@ -142,10 +132,6 @@ class SGLangGDNForwardContext:
     def _build_gdn_metadata(
         forward_batch: Any, linear_backend: Any
     ) -> GDNAttentionMetadata | None:
-        fm = getattr(linear_backend, "forward_metadata", None)
-        if fm is None:
-            return None
-
         mode = forward_batch.forward_mode
         if mode.is_target_verify():
             logger.warning(
@@ -153,9 +139,17 @@ class SGLangGDNForwardContext:
             )
             return None
 
-        device = fm.query_start_loc.device
-        idx = fm.mamba_cache_indices.to(dtype=torch.int32, device=device)
         bs = forward_batch.batch_size
+        fm = getattr(linear_backend, "forward_metadata", None)
+        query_start_loc = getattr(fm, "query_start_loc", None)
+        idx = getattr(fm, "mamba_cache_indices", None)
+        if query_start_loc is None or idx is None:
+            reconstructed = reconstruct_linear_metadata(forward_batch, linear_backend)
+            if reconstructed is None:
+                return None
+            query_start_loc, idx = reconstructed
+        device = query_start_loc.device
+        idx = idx.to(dtype=torch.int32, device=device)
         common_kwargs = {
             "num_spec_decodes": 0,
             "num_spec_decode_tokens": 0,
@@ -184,11 +178,13 @@ class SGLangGDNForwardContext:
             )
 
         if mode.is_extend():
-            seq_sum = forward_batch.seq_lens_sum
+            # SGLang's seq_lens_sum includes cached prefix tokens for some
+            # hybrid batches; GDN only receives the active query tokens.
+            seq_sum = int(query_start_loc[-1].item())
             epl = forward_batch.extend_prefix_lens
             has_initial_state = None if epl is None else epl > 0
             nums_dict, batch_ptr, token_chunk_offset_ptr = (
-                compute_causal_conv1d_metadata(fm.query_start_loc)
+                compute_causal_conv1d_metadata(query_start_loc)
             )
             return GDNAttentionMetadata(
                 num_prefills=bs,
@@ -234,7 +230,7 @@ class SGLangGDNForwardContext:
         if gdn_metadata is None:
             return None
 
-        kv_cache_data = cls._build_kv_cache_tensors(forward_batch, attn_backend)
+        kv_cache_data = cls._build_kv_cache_tensors(forward_batch, linear_backend)
         if not kv_cache_data:
             return None
 

--- a/atom/plugin/sglang/attention_backend/backend_resolver.py
+++ b/atom/plugin/sglang/attention_backend/backend_resolver.py
@@ -1,0 +1,79 @@
+from typing import Any
+
+import torch
+
+
+def resolve_attn_backend(forward_batch: Any) -> Any:
+    try:
+        from sglang.srt.model_executor.forward_context import (
+            get_attn_backend,
+            has_forward_context,
+        )
+
+        if has_forward_context():
+            backend = get_attn_backend()
+            if backend is not None:
+                return backend
+    except Exception:  # noqa: BLE001, S110 - forward context is optional
+        pass
+
+    return getattr(forward_batch, "attn_backend", None)
+
+
+def resolve_mamba_req_pool(forward_batch: Any, linear_backend: Any) -> Any:
+    token_pool = getattr(forward_batch, "token_to_kv_pool", None)
+    candidates = (
+        getattr(token_pool, "_atom_kimi_k3_req_pool", None),
+        getattr(linear_backend, "req_to_token_pool", None),
+        getattr(forward_batch, "req_to_token_pool", None),
+    )
+    for pool in candidates:
+        if pool is not None and hasattr(pool, "get_mamba_indices"):
+            return pool
+
+    try:
+        from sglang.srt.model_executor.forward_context import (
+            get_req_to_token_pool,
+            has_forward_context,
+        )
+
+        if has_forward_context():
+            pool = get_req_to_token_pool()
+            if pool is not None and hasattr(pool, "get_mamba_indices"):
+                return pool
+    except Exception:  # noqa: BLE001, S110 - forward context is optional
+        pass
+    return None
+
+
+def reconstruct_linear_metadata(
+    forward_batch: Any, linear_backend: Any
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    pool = resolve_mamba_req_pool(forward_batch, linear_backend)
+    if pool is None:
+        return None
+
+    indices = pool.get_mamba_indices(forward_batch.req_pool_indices)
+    translate = getattr(pool, "translate_mamba_indices", None)
+    if translate is not None:
+        indices = translate(indices)
+
+    mode = forward_batch.forward_mode
+    batch_size = forward_batch.batch_size
+    device = indices.device
+    if mode.is_decode_or_idle():
+        query_start_loc = torch.arange(
+            0, batch_size + 1, dtype=torch.int32, device=device
+        )
+    elif mode.is_extend():
+        query_start_loc = torch.empty(
+            (batch_size + 1,), dtype=torch.int32, device=device
+        )
+        query_start_loc[:batch_size] = forward_batch.extend_start_loc
+        query_start_loc[batch_size] = (
+            forward_batch.extend_start_loc[-1] + forward_batch.extend_seq_lens[-1]
+        )
+    else:
+        return None
+
+    return query_start_loc, indices.to(dtype=torch.int32, device=device)

--- a/atom/plugin/sglang/attention_backend/kimi_k3_backend.py
+++ b/atom/plugin/sglang/attention_backend/kimi_k3_backend.py
@@ -1,0 +1,155 @@
+"""CUDA-graph metadata shim for Kimi-K3 native ATOM attention."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from atom.plugin.sglang.attention_backend.full_attention.full_attention_backend import (
+    ATOMAttnBackendForSgl,
+)
+
+
+class ATOMKimiK3BackendForSgl(ATOMAttnBackendForSgl):
+    """Keep K3's native ATOM MHA metadata at stable graph addresses."""
+
+    _last_atom_kimi_k3_graph_metadata = None
+
+    def __init__(self, model_runner, *args, **kwargs):
+        # The outer K3 config is hybrid KDA/full-attention, but every
+        # full-attention layer is true MLA.  Initialize the parent as MLA so
+        # it owns the complete, graph-stable MLA metadata lifecycle (CSR
+        # indices and persistent-worker buffers). K3 TP8 has 12 local heads;
+        # present the kernel ABI's padded 16 heads only for initialization.
+        from sglang.srt.configs.model_config import AttentionArch
+        from sglang.srt.runtime_context import get_parallel
+
+        model_config = model_runner.model_config
+        original_attention_arch = model_config.attention_arch
+        original_num_attention_heads = model_config.num_attention_heads
+        attn_tp_size = get_parallel().attn_tp_size
+        local_num_heads = original_num_attention_heads // attn_tp_size
+        padded_local_num_heads = max(16, ((local_num_heads + 15) // 16) * 16)
+        model_config.attention_arch = AttentionArch.MLA
+        model_config.num_attention_heads = padded_local_num_heads * attn_tp_size
+        try:
+            super().__init__(model_runner, *args, **kwargs)
+        finally:
+            model_config.attention_arch = original_attention_arch
+            model_config.num_attention_heads = original_num_attention_heads
+        self.atom_kimi_k3_graph_metadata = None
+        self._kimi_graph_context_lens = None
+        self._kimi_graph_block_tables = None
+        self._kimi_graph_slot_mapping = None
+        self._kimi_graph_cu_seqlens_q = None
+
+    def _kimi_pools(self):
+        token_pool = getattr(self, "token_to_kv_pool", None)
+        if token_pool is None:
+            token_pool = getattr(self, "_atom_token_to_kv_pool", None)
+        req_pool = getattr(self, "req_to_token_pool", None)
+        if req_pool is None:
+            req_pool = getattr(self, "_atom_req_to_token_pool", None)
+        if token_pool is None or req_pool is None:
+            raise RuntimeError("Kimi-K3 attention pools are not bound")
+        return token_pool, req_pool
+
+    def _init_kimi_graph_buffers(self, max_bs: int) -> None:
+        token_pool, req_pool = self._kimi_pools()
+        page_size = int(token_pool.page_size)
+        max_context_len = int(req_pool.req_to_token.shape[1])
+        max_blocks = max(1, (max_context_len + page_size - 1) // page_size)
+        self._kimi_graph_context_lens = torch.zeros(
+            max_bs, dtype=torch.int32, device=self.device
+        )
+        self._kimi_graph_block_tables = torch.zeros(
+            (max_bs, max_blocks), dtype=torch.int32, device=self.device
+        )
+        self._kimi_graph_slot_mapping = torch.zeros(
+            max_bs, dtype=torch.int64, device=self.device
+        )
+        self._kimi_graph_cu_seqlens_q = torch.arange(
+            max_bs + 1, dtype=torch.int32, device=self.device
+        )
+
+    def _build_kimi_decode_graph_metadata(self, forward_batch: Any) -> None:
+        if not forward_batch.forward_mode.is_decode_or_idle():
+            self.atom_kimi_k3_graph_metadata = None
+            return
+
+        bs = int(forward_batch.batch_size)
+        if (
+            self._kimi_graph_context_lens is None
+            or bs > self._kimi_graph_context_lens.numel()
+        ):
+            self._init_kimi_graph_buffers(bs)
+
+        from atom.plugin.sglang.kimi_k3_bridge import (
+            _attach_sglang_mla_metadata,
+            kimi_k3_query_dtype,
+        )
+        from atom.utils.forward_context import AttentionMetaData, AttnState
+
+        token_pool, req_pool = self._kimi_pools()
+        page_size = int(token_pool.page_size)
+        max_blocks = self._kimi_graph_block_tables.shape[1]
+        self._kimi_graph_context_lens[:bs].copy_(forward_batch.seq_lens[:bs])
+        req_indices = forward_batch.req_pool_indices[:bs]
+        token_table = req_pool.req_to_token[req_indices, : max_blocks * page_size]
+        self._kimi_graph_block_tables[:bs].copy_(
+            (token_table[:, ::page_size] // page_size).to(dtype=torch.int32)
+        )
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if torch.is_tensor(out_cache_loc):
+            num_real_tokens = int(out_cache_loc.numel())
+            if num_real_tokens > bs:
+                raise RuntimeError(
+                    "Kimi-K3 decode graph received more cache slots than its "
+                    f"bucket: slots={num_real_tokens}, bucket_bs={bs}"
+                )
+            # SGLang pads graph decode batches but keeps out_cache_loc compact.
+            # Route padded lanes to slot 0, matching its native graph backends.
+            self._kimi_graph_slot_mapping[:bs].zero_()
+            self._kimi_graph_slot_mapping[:num_real_tokens].copy_(out_cache_loc)
+        else:
+            self._kimi_graph_slot_mapping[:bs].zero_()
+
+        metadata = AttentionMetaData(
+            cu_seqlens_q=self._kimi_graph_cu_seqlens_q[: bs + 1],
+            max_seqlen_q=1,
+            max_seqlen_k=int(req_pool.req_to_token.shape[1]),
+            min_seqlen_q=1,
+            # The graph ABI requires a Python integer here. Avoid a device
+            # synchronization during capture; MLA decode consumes the CSR
+            # indptr/indices above, not this bookkeeping upper bound.
+            total_kv=bs * int(req_pool.req_to_token.shape[1]),
+            has_cached=False,
+            dropout_p=0.0,
+            slot_mapping=self._kimi_graph_slot_mapping[:bs],
+            context_lens=self._kimi_graph_context_lens[:bs],
+            block_tables=self._kimi_graph_block_tables[:bs],
+            state=AttnState.DECODE,
+        )
+        metadata.dtype_q = kimi_k3_query_dtype()
+        self.atom_kimi_k3_graph_metadata = _attach_sglang_mla_metadata(metadata)
+        forward_batch.atom_kimi_k3_graph_metadata = self.atom_kimi_k3_graph_metadata
+        type(self)._last_atom_kimi_k3_graph_metadata = self.atom_kimi_k3_graph_metadata
+
+    def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int, *args, **kwargs):
+        result = super().init_cuda_graph_state(max_bs, max_num_tokens, *args, **kwargs)
+        self._init_kimi_graph_buffers(int(max_bs))
+        return result
+
+    def init_forward_metadata_out_graph(self, forward_batch, in_capture: bool = False):
+        super().init_forward_metadata_out_graph(forward_batch, in_capture=in_capture)
+        self._build_kimi_decode_graph_metadata(forward_batch)
+
+    def init_forward_metadata_in_graph(self, forward_batch):
+        # SGLang's parent contract performs graph metadata allocation and
+        # refreshes outside the capture region. Keep capture free of host
+        # synchronization and dynamic allocation.
+        return None
+
+    def init_forward_metadata(self, forward_batch):
+        super().init_forward_metadata(forward_batch)

--- a/atom/plugin/sglang/kimi_k3_bridge.py
+++ b/atom/plugin/sglang/kimi_k3_bridge.py
@@ -1,0 +1,526 @@
+"""Native ATOM attention bridge for Kimi-K3 on SGLang 0.5.15."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Any
+
+import torch
+
+# Kimi-K3 full attention uses true MLA.  Each cache entry stores the latent KV
+# plus the rotary lane: kv_lora_rank (512) + qk_rope_head_dim (64).
+KIMI_K3_MLA_CACHE_ENTRY_DIM = 576
+logger = logging.getLogger(__name__)
+
+
+def is_kimi_k3_config(config: Any) -> bool:
+    archs = getattr(config, "architectures", None) or []
+    return any("KimiK3ForConditionalGeneration" in str(arch) for arch in archs)
+
+
+def _is_kimi_k3_runner(runner: Any) -> bool:
+    return is_kimi_k3_config(getattr(runner.model_config, "hf_config", None))
+
+
+def _restore_kimi_k3_mem_fraction(runner: Any) -> None:
+    if getattr(runner, "_atom_kimi_k3_mem_fraction_restored", False):
+        return
+    server_args = runner.server_args
+    context_len = int(getattr(runner.model_config, "context_len", 0) or 0)
+    attention_backend = str(getattr(server_args, "attention_backend", ""))
+    current = float(
+        getattr(runner, "mem_fraction_static", server_args.mem_fraction_static)
+    )
+    if attention_backend == "aiter" and context_len > 8192:
+        restored = current / 0.85
+        if restored <= 1.0:
+            runner.mem_fraction_static = restored
+            server_args.mem_fraction_static = restored
+            logger.info(
+                "Kimi-K3 restored mem_fraction_static %.4f -> %.4f after "
+                "SGLang AITER long-context reserve",
+                current,
+                restored,
+            )
+    runner._atom_kimi_k3_mem_fraction_restored = True
+
+
+def install_kimi_k3_pool_patch() -> None:
+    """Allocate K3 full-attention KV with ATOM's true-MLA cache ABI."""
+
+    import sglang.srt.model_executor.model_runner_kv_cache_mixin as mixin
+    from sglang.srt.configs.kimi_linear import KimiLinearConfig
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+    cls = mixin.ModelRunnerKVCacheMixin
+    if getattr(cls, "_atom_kimi_k3_pool_patched", False):
+        return
+
+    original_kimi_property = ModelRunner.kimi_linear_config
+    original_resolve = cls._resolve_memory_pool_config
+    original_init_pools = cls._init_pools
+
+    def _kimi_linear_config(self):
+        config = original_kimi_property.__get__(self, type(self))
+        if config is not None:
+            return config
+        text_config = getattr(self.model_config, "hf_text_config", None)
+        if not _is_kimi_k3_runner(self):
+            return None
+        if isinstance(text_config, KimiLinearConfig):
+            return text_config
+        if getattr(text_config, "model_type", None) != "kimi_linear":
+            return None
+
+        cache_name = "_atom_kimi_k3_linear_config"
+        config = getattr(self, cache_name, None)
+        if config is None:
+            config = KimiLinearConfig(**text_config.to_dict())
+            setattr(self, cache_name, config)
+        return config
+
+    def _resolve_memory_pool_config(self, pre_model_load_memory: int):
+        if not _is_kimi_k3_runner(self):
+            return original_resolve(self, pre_model_load_memory)
+
+        _restore_kimi_k3_mem_fraction(self)
+        config = original_resolve(self, pre_model_load_memory)
+
+        old_k = int(getattr(self.model_config, "head_dim", 0))
+        old_v = int(getattr(self.model_config, "v_head_dim", old_k))
+        old_row = old_k + old_v
+        # SGLang's hybrid pool exposes paired K/V buffers.  ATOM consumes only
+        # the K buffer as the 576-wide MLA latent cache, while the V buffer is
+        # retained solely to satisfy SGLang's pool interface.
+        native_row = 2 * KIMI_K3_MLA_CACHE_ENTRY_DIM
+        if old_row > 0 and old_row != native_row:
+            page_size = int(self.server_args.page_size)
+            tokens = int(config.max_total_num_tokens) * old_row // native_row
+            config.max_total_num_tokens = max(
+                page_size, (tokens // page_size) * page_size
+            )
+            config.max_running_requests = self._resolve_max_num_reqs(
+                config.max_total_num_tokens
+            )
+        return config
+
+    def _init_pools(self):
+        if not _is_kimi_k3_runner(self):
+            return original_init_pools(self)
+
+        old_head_dim = self.model_config.head_dim
+        old_v_head_dim = self.model_config.v_head_dim
+        self.model_config.head_dim = KIMI_K3_MLA_CACHE_ENTRY_DIM
+        self.model_config.v_head_dim = KIMI_K3_MLA_CACHE_ENTRY_DIM
+        try:
+            original_init_pools(self)
+        finally:
+            self.model_config.head_dim = old_head_dim
+            self.model_config.v_head_dim = old_v_head_dim
+
+        pool = getattr(self, "token_to_kv_pool", None)
+        full_pool = getattr(pool, "full_kv_pool", pool)
+        if full_pool is None:
+            raise RuntimeError("Kimi-K3 SGLang full-attention KV pool is missing")
+        if (
+            int(full_pool.head_dim) != KIMI_K3_MLA_CACHE_ENTRY_DIM
+            or int(full_pool.v_head_dim) != KIMI_K3_MLA_CACHE_ENTRY_DIM
+        ):
+            raise RuntimeError(
+                "Kimi-K3 KV pool ABI mismatch: "
+                f"K={full_pool.head_dim}, V={full_pool.v_head_dim}, "
+                "expected "
+                f"{KIMI_K3_MLA_CACHE_ENTRY_DIM}/{KIMI_K3_MLA_CACHE_ENTRY_DIM}"
+            )
+        req_pool = getattr(self, "req_to_token_pool", None)
+        if req_pool is None or not hasattr(req_pool, "get_mamba_indices"):
+            raise RuntimeError("Kimi-K3 HybridReqToTokenPool is missing")
+        setattr(pool, "_atom_kimi_k3_req_pool", req_pool)
+        if full_pool is not pool:
+            setattr(full_pool, "_atom_kimi_k3_req_pool", req_pool)
+        logger.info(
+            "Kimi-K3 attention owner=ATOM, KV owner=SGLang, "
+            "layout=MLA/NHD, latent_dim=576"
+        )
+
+    ModelRunner.kimi_linear_config = property(_kimi_linear_config)
+    cls._resolve_memory_pool_config = _resolve_memory_pool_config
+    cls._init_pools = _init_pools
+    cls._atom_kimi_k3_pool_patched = True
+
+
+@contextmanager
+def kimi_k3_native_attention_construction():
+    """Construct K3 full-attention layers with native ATOM attention."""
+
+    import atom.models.kimi_k3 as kimi_k3
+
+    previous = kimi_k3.Attention
+    kimi_k3.Attention = SGLangATOMKimiK3Attention
+    try:
+        yield
+    finally:
+        kimi_k3.Attention = previous
+
+
+class SGLangATOMKimiK3Attention(torch.nn.Module):
+    """Thin frontend preserving ATOM's native true-MLA execution path."""
+
+    def __init__(
+        self,
+        num_heads,
+        head_dim,
+        scale,
+        num_kv_heads,
+        kv_cache_dtype="bf16",
+        layer_num=0,
+        use_mla=False,
+        prefix: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        from atom.config import get_current_atom_config
+        from atom.model_ops.attention_mla import MLAAttention
+
+        if (
+            int(head_dim) != KIMI_K3_MLA_CACHE_ENTRY_DIM
+            or not use_mla
+            or int(num_kv_heads) != 1
+        ):
+            raise RuntimeError(
+                f"Unexpected Kimi-K3 full-attention contract: head_dim={head_dim}, "
+                f"num_kv_heads={num_kv_heads}, use_mla={use_mla}"
+            )
+        atom_config = get_current_atom_config()
+        cache_dtype = "fp8" if str(kv_cache_dtype).startswith("fp8") else kv_cache_dtype
+        self.layer_num = int(layer_num)
+        self.layer_name = prefix or f"KIMI_K3_MLA_{layer_num}"
+        self.impl = MLAAttention(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            kv_cache_dtype=cache_dtype,
+            layer_num=layer_num,
+            dtype=atom_config.torch_dtype,
+            mla_modules=kwargs.pop("mla_modules"),
+            **kwargs,
+        )
+        atom_config.compilation_config.static_forward_context[self.layer_name] = self
+
+    def forward(self, query, key, value, positions=None, **kwargs):
+        del kwargs
+        return torch.ops.aiter.unified_attention_with_output_base(
+            query,
+            None,
+            key,
+            value,
+            positions,
+            self.layer_name,
+            True,
+            None,
+        )
+
+    def process_weights_after_loading(self):
+        return self.impl.process_weights_after_loading()
+
+
+def _iter_kimi_full_attention(model: Any):
+    from atom.models.kimi_k3 import KimiFullAttention
+
+    for module in model.modules():
+        if isinstance(module, KimiFullAttention):
+            attn = getattr(module, "attn", None)
+            if not isinstance(attn, SGLangATOMKimiK3Attention):
+                raise RuntimeError(
+                    "Kimi-K3 full attention did not construct the native ATOM frontend"
+                )
+            yield attn
+
+
+def maybe_get_kimi_k3_pools(forward_batch: Any):
+    token_pool = getattr(forward_batch, "token_to_kv_pool", None)
+    req_pool = getattr(token_pool, "_atom_kimi_k3_req_pool", None)
+    if req_pool is None:
+        req_pool = getattr(forward_batch, "req_to_token_pool", None)
+    if token_pool is not None and req_pool is not None:
+        return token_pool, req_pool
+
+    try:
+        from sglang.srt.model_executor.forward_context import (
+            get_attn_backend,
+            has_forward_context,
+        )
+
+        backend = get_attn_backend() if has_forward_context() else None
+    except Exception:  # noqa: BLE001 - forward context is optional
+        backend = None
+    if backend is not None:
+        if token_pool is None:
+            token_pool = getattr(backend, "_atom_token_to_kv_pool", None)
+            if token_pool is None:
+                token_pool = getattr(backend, "token_to_kv_pool", None)
+        if req_pool is None:
+            req_pool = getattr(token_pool, "_atom_kimi_k3_req_pool", None)
+        if req_pool is None:
+            req_pool = getattr(backend, "_atom_req_to_token_pool", None)
+        if req_pool is None:
+            req_pool = getattr(backend, "req_to_token_pool", None)
+    return token_pool, req_pool
+
+
+def _is_stream_capturing() -> bool:
+    try:
+        return bool(torch.cuda.is_current_stream_capturing())
+    except Exception:
+        return False
+
+
+def kimi_k3_query_dtype() -> torch.dtype:
+    """Match Q's fused MLA representation to the SGLang KV-cache dtype."""
+
+    from atom.config import get_current_atom_config
+    from atom.plugin.sglang.models.kv_cache_utils import is_fp8_kv_cache_dtype
+
+    atom_config = get_current_atom_config()
+    if is_fp8_kv_cache_dtype(getattr(atom_config, "kv_cache_dtype", "bf16")):
+        # AITER's FP8 MLA decode kernels require both Q and the latent KV
+        # cache to use the FP8 ABI. The fused Q+RoPE+cache op quantizes Q with
+        # its existing q_scale when metadata.dtype_q selects this dtype.
+        return torch.float8_e4m3fn
+    return atom_config.torch_dtype
+
+
+def _seq_lens(forward_batch: Any, batch_size: int) -> torch.Tensor:
+    return forward_batch.seq_lens[:batch_size].to(dtype=torch.int32)
+
+
+def _extend_lens(
+    forward_batch: Any, positions: torch.Tensor, batch_size: int
+) -> torch.Tensor:
+    extend_lens = getattr(forward_batch, "extend_seq_lens", None)
+    if extend_lens is not None:
+        return extend_lens[:batch_size].to(device=positions.device, dtype=torch.int32)
+
+    extend_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+    if extend_lens_cpu is not None:
+        return torch.as_tensor(
+            extend_lens_cpu[:batch_size],
+            dtype=torch.int32,
+            device=positions.device,
+        )
+
+    tokens_per_req = getattr(
+        getattr(forward_batch, "spec_info", None), "num_tokens_per_req", None
+    )
+    if tokens_per_req is None:
+        tokens_per_req = max(1, int(positions.numel()) // max(1, batch_size))
+    return torch.full(
+        (batch_size,),
+        int(tokens_per_req),
+        dtype=torch.int32,
+        device=positions.device,
+    )
+
+
+def _build_block_table(
+    forward_batch: Any,
+    req_to_token_pool: Any,
+    *,
+    seq_lens: torch.Tensor,
+    extend_lens: torch.Tensor | None,
+    page_size: int,
+    max_seq_len: int | None = None,
+) -> torch.Tensor:
+    batch_size = int(forward_batch.batch_size)
+    if max_seq_len is None:
+        max_seq_len = int(seq_lens.max().item()) if batch_size else 0
+    max_blocks = max(1, (max_seq_len + page_size - 1) // page_size)
+    req_pool_indices = forward_batch.req_pool_indices[:batch_size]
+    token_table = req_to_token_pool.req_to_token[
+        req_pool_indices, : max_blocks * page_size
+    ].clone()
+
+    if extend_lens is not None:
+        prefix_lens = seq_lens - extend_lens
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if out_cache_loc is not None:
+            offset = 0
+            for req_idx in range(batch_size):
+                prefix_len = int(prefix_lens[req_idx].item())
+                query_len = int(extend_lens[req_idx].item())
+                if query_len > 0:
+                    token_table[req_idx, prefix_len : prefix_len + query_len] = (
+                        out_cache_loc[offset : offset + query_len]
+                    )
+                offset += query_len
+
+    return (
+        (token_table[:, : max_blocks * page_size : page_size] // page_size)
+        .to(dtype=torch.int32)
+        .contiguous()
+    )
+
+
+def _attach_sglang_mla_metadata(metadata: Any) -> Any:
+    """Reuse the active SGLang backend's graph-stable MLA decode buffers."""
+
+    try:
+        from sglang.srt.model_executor.forward_context import (
+            get_attn_backend,
+            has_forward_context,
+        )
+
+        backend = get_attn_backend() if has_forward_context() else None
+        forward_metadata = getattr(backend, "forward_metadata", None)
+    except Exception:  # noqa: BLE001 - optional during eager unit tests
+        forward_metadata = None
+
+    if forward_metadata is None:
+        return metadata
+
+    metadata.kv_indptr = getattr(forward_metadata, "kv_indptr", None)
+    metadata.kv_indices = getattr(forward_metadata, "kv_indices", None)
+    metadata.kv_last_page_lens = getattr(forward_metadata, "kv_last_page_len", None)
+    metadata.work_meta_data = getattr(forward_metadata, "work_meta_data", None)
+    metadata.work_info_set = getattr(forward_metadata, "work_info_set", None)
+    metadata.work_indptr = getattr(forward_metadata, "work_indptr", None)
+    metadata.reduce_indptr = getattr(forward_metadata, "reduce_indptr", None)
+    metadata.reduce_final_map = getattr(forward_metadata, "reduce_final_map", None)
+    metadata.reduce_partial_map = getattr(forward_metadata, "reduce_partial_map", None)
+    metadata.num_kv_splits = getattr(forward_metadata, "num_kv_splits", None)
+    return metadata
+
+
+def bind_kimi_k3_cache_views(model: Any, token_to_kv_pool: Any) -> bool:
+    if token_to_kv_pool is None or not hasattr(token_to_kv_pool, "get_kv_buffer"):
+        return False
+
+    from atom.config import KVCacheTensor
+    from atom.utils.forward_context import get_forward_context, set_kv_cache_data
+
+    page_size = int(token_to_kv_pool.page_size)
+    if page_size != 128:
+        raise RuntimeError(f"Kimi-K3 requires page_size=128, got {page_size}")
+
+    kv_cache_data = dict(getattr(get_forward_context(), "kv_cache_data", None) or {})
+    for attn in _iter_kimi_full_attention(model):
+        k_buffer, _ = token_to_kv_pool.get_kv_buffer(attn.layer_num)
+        if (
+            k_buffer.ndim != 3
+            or int(k_buffer.shape[1]) < 1
+            or int(k_buffer.shape[2]) != KIMI_K3_MLA_CACHE_ENTRY_DIM
+        ):
+            raise RuntimeError(
+                "Kimi-K3 SGLang pool must expose [slots, kv_heads>=1, 576] "
+                "MLA K cache, "
+                f"got K={tuple(k_buffer.shape)}"
+            )
+        # SGLang's hybrid pool retains one logical KV head per full-attention
+        # head (12 for K3).  True MLA needs one shared latent lane; using the
+        # first lane preserves SGLang's slot ownership without duplicating the
+        # 576-wide cache in every logical head.
+        k_cache = k_buffer[:, :1, :]
+        attn.impl.kv_cache = k_cache
+        kv_cache_data[f"layer_{attn.layer_num}"] = KVCacheTensor(
+            layer_num=attn.layer_num,
+            k_cache=k_cache,
+            v_cache=None,
+            k_scale=None,
+            v_scale=None,
+        )
+
+    set_kv_cache_data(kv_cache_data)
+    get_forward_context().kv_cache_data = kv_cache_data
+    return bool(kv_cache_data)
+
+
+def build_kimi_k3_attention_metadata(
+    forward_batch: Any,
+    positions: torch.Tensor,
+    *,
+    token_to_kv_pool: Any,
+    req_to_token_pool: Any,
+):
+    """Translate the current SGLang batch into native ATOM paged-MHA metadata."""
+
+    from atom.utils.forward_context import AttentionMetaData, AttnState
+
+    page_size = int(token_to_kv_pool.page_size)
+    try:
+        dtype_q = kimi_k3_query_dtype()
+    except AssertionError:
+        # Metadata-only unit tests run outside an initialized ATOM runtime.
+        dtype_q = torch.bfloat16
+    bs = int(forward_batch.batch_size)
+    seq_lens = _seq_lens(forward_batch, bs)
+    is_prefill = bool(forward_batch.forward_mode.is_prefill())
+
+    if is_prefill:
+        extend_lens = _extend_lens(forward_batch, positions, bs)
+        cu_q = torch.zeros(bs + 1, dtype=torch.int32, device=positions.device)
+        torch.cumsum(extend_lens, dim=0, out=cu_q[1:])
+        total_tokens = int(positions.shape[0])
+        block_tables = _build_block_table(
+            forward_batch,
+            req_to_token_pool,
+            seq_lens=seq_lens,
+            extend_lens=extend_lens,
+            page_size=page_size,
+        )
+        slot_mapping = forward_batch.out_cache_loc[:total_tokens]
+        metadata = AttentionMetaData(
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=cu_q,
+            max_seqlen_q=int(extend_lens.max().item()) if bs else 0,
+            max_seqlen_k=int(seq_lens.max().item()) if bs else 0,
+            min_seqlen_q=int(extend_lens.min().item()) if bs else 0,
+            total_kv=int(seq_lens.sum().item()),
+            has_cached=False,
+            dropout_p=0.0,
+            slot_mapping=slot_mapping,
+            context_lens=seq_lens,
+            block_tables=block_tables,
+            state=AttnState.PREFILL_NATIVE,
+        )
+        metadata.dtype_q = dtype_q
+        return _attach_sglang_mla_metadata(metadata)
+
+    max_seq_len = (
+        int(req_to_token_pool.req_to_token.shape[1])
+        if _is_stream_capturing()
+        else (int(seq_lens.max().item()) if bs else 0)
+    )
+    total_kv = (
+        bs * max_seq_len if _is_stream_capturing() else int(seq_lens.sum().item())
+    )
+    block_tables = _build_block_table(
+        forward_batch,
+        req_to_token_pool,
+        seq_lens=seq_lens,
+        extend_lens=None,
+        page_size=page_size,
+        max_seq_len=max_seq_len,
+    )
+    slot_mapping = forward_batch.out_cache_loc[:bs]
+    metadata = AttentionMetaData(
+        cu_seqlens_q=torch.arange(
+            0, bs + 1, dtype=torch.int32, device=positions.device
+        ),
+        max_seqlen_q=1,
+        max_seqlen_k=max_seq_len,
+        min_seqlen_q=1,
+        # CSR metadata, rather than this bookkeeping value, drives MLA
+        # decode. Use a static upper bound while CUDA graph capture forbids
+        # device-to-host scalar synchronization.
+        total_kv=total_kv,
+        has_cached=False,
+        dropout_p=0.0,
+        slot_mapping=slot_mapping,
+        context_lens=seq_lens,
+        block_tables=block_tables,
+        state=AttnState.DECODE,
+    )
+    metadata.dtype_q = dtype_q
+    return _attach_sglang_mla_metadata(metadata)

--- a/atom/plugin/sglang/kimi_k3_bridge.py
+++ b/atom/plugin/sglang/kimi_k3_bridge.py
@@ -136,9 +136,9 @@ def install_kimi_k3_pool_patch() -> None:
         req_pool = getattr(self, "req_to_token_pool", None)
         if req_pool is None or not hasattr(req_pool, "get_mamba_indices"):
             raise RuntimeError("Kimi-K3 HybridReqToTokenPool is missing")
-        setattr(pool, "_atom_kimi_k3_req_pool", req_pool)
+        pool._atom_kimi_k3_req_pool = req_pool
         if full_pool is not pool:
-            setattr(full_pool, "_atom_kimi_k3_req_pool", req_pool)
+            full_pool._atom_kimi_k3_req_pool = req_pool
         logger.info(
             "Kimi-K3 attention owner=ATOM, KV owner=SGLang, "
             "layout=MLA/NHD, latent_dim=576"
@@ -154,7 +154,7 @@ def install_kimi_k3_pool_patch() -> None:
 def kimi_k3_native_attention_construction():
     """Construct K3 full-attention layers with native ATOM attention."""
 
-    import atom.models.kimi_k3 as kimi_k3
+    from atom.models import kimi_k3
 
     previous = kimi_k3.Attention
     kimi_k3.Attention = SGLangATOMKimiK3Attention
@@ -233,7 +233,7 @@ def _iter_kimi_full_attention(model: Any):
         if isinstance(module, KimiFullAttention):
             attn = getattr(module, "attn", None)
             if not isinstance(attn, SGLangATOMKimiK3Attention):
-                raise RuntimeError(
+                raise TypeError(
                     "Kimi-K3 full attention did not construct the native ATOM frontend"
                 )
             yield attn
@@ -273,7 +273,7 @@ def maybe_get_kimi_k3_pools(forward_batch: Any):
 def _is_stream_capturing() -> bool:
     try:
         return bool(torch.cuda.is_current_stream_capturing())
-    except Exception:
+    except (AssertionError, RuntimeError):
         return False
 
 

--- a/atom/plugin/sglang/models/base_model_wrapper.py
+++ b/atom/plugin/sglang/models/base_model_wrapper.py
@@ -11,12 +11,11 @@ import logging
 from typing import Any, Iterable, Optional, Tuple, Union
 
 import torch
-from torch import nn
-
 from sglang.srt.distributed import get_pp_group
 from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from torch import nn
 
 from atom.plugin.sglang.runtime import (
     MODEL_ARCH_SPECS,
@@ -24,8 +23,8 @@ from atom.plugin.sglang.runtime import (
     SGLangPluginRuntime,
     bind_current_forward_batch,
     get_current_forward_batch,
-    get_model_arch_spec,
     plugin_runtime_scope,
+    resolve_model_arch_spec,
 )
 
 logger = logging.getLogger("atom.plugin.sglang.models")
@@ -83,8 +82,7 @@ class _AtomCausalLMBaseForSglang(nn.Module):
         self.config = config
         self.vocab_size = config.vocab_size
         self.unpadded_vocab_size = config.vocab_size
-        self.model_arch = getattr(config, "architectures", [""])[0]
-        self.model_arch_spec = get_model_arch_spec(self.model_arch)
+        self.model_arch, self.model_arch_spec = resolve_model_arch_spec(config)
         if self.model_arch_spec.uses_text_config:
             text_config = getattr(config, "text_config", None)
             if text_config is None:

--- a/atom/plugin/sglang/models/base_model_wrapper.py
+++ b/atom/plugin/sglang/models/base_model_wrapper.py
@@ -85,6 +85,15 @@ class _AtomCausalLMBaseForSglang(nn.Module):
         self.unpadded_vocab_size = config.vocab_size
         self.model_arch = getattr(config, "architectures", [""])[0]
         self.model_arch_spec = get_model_arch_spec(self.model_arch)
+        if self.model_arch_spec.uses_text_config:
+            text_config = getattr(config, "text_config", None)
+            if text_config is None:
+                raise ValueError(
+                    f"{self.model_arch} requires a nested text_config for SGLang"
+                )
+            self.config = text_config
+            self.vocab_size = text_config.vocab_size
+            self.unpadded_vocab_size = text_config.vocab_size
         self.capture_aux_hidden_states = False
 
         with plugin_runtime_scope(framework="sglang"):
@@ -444,7 +453,9 @@ class _AtomCausalLMBaseForSglang(nn.Module):
 
         with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
             return load_model_in_plugin_mode(
-                model=self.model, config=self.atom_config, prefix="model."
+                model=self.model,
+                config=self.atom_config,
+                prefix=self.model_arch_spec.load_weights_prefix,
             )
 
 

--- a/atom/plugin/sglang/models/base_model_wrapper.py
+++ b/atom/plugin/sglang/models/base_model_wrapper.py
@@ -8,7 +8,8 @@ To add a new model, append its architecture class name to _MODEL_NAMES.
 
 import inspect
 import logging
-from typing import Any, Iterable, Optional, Tuple, Union
+from collections.abc import Iterable
+from typing import Any
 
 import torch
 from sglang.srt.distributed import get_pp_group
@@ -23,8 +24,8 @@ from atom.plugin.sglang.runtime import (
     SGLangPluginRuntime,
     bind_current_forward_batch,
     get_current_forward_batch,
+    get_model_arch_spec,
     plugin_runtime_scope,
-    resolve_model_arch_spec,
 )
 
 logger = logging.getLogger("atom.plugin.sglang.models")
@@ -71,7 +72,7 @@ class _AtomCausalLMBaseForSglang(nn.Module):
     def __init__(
         self,
         config,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -80,18 +81,17 @@ class _AtomCausalLMBaseForSglang(nn.Module):
         self.pp_group = get_pp_group()
         self.quant_config = quant_config
         self.config = config
-        self.vocab_size = config.vocab_size
-        self.unpadded_vocab_size = config.vocab_size
-        self.model_arch, self.model_arch_spec = resolve_model_arch_spec(config)
-        if self.model_arch_spec.uses_text_config:
-            text_config = getattr(config, "text_config", None)
-            if text_config is None:
-                raise ValueError(
-                    f"{self.model_arch} requires a nested text_config for SGLang"
-                )
-            self.config = text_config
-            self.vocab_size = text_config.vocab_size
-            self.unpadded_vocab_size = text_config.vocab_size
+        vocab_size = getattr(config, "vocab_size", None)
+        if vocab_size is None and hasattr(config, "text_config"):
+            vocab_size = getattr(config.text_config, "vocab_size", None)
+        if vocab_size is None:
+            raise AttributeError(f"{type(config).__name__} does not define vocab_size")
+        if not hasattr(config, "vocab_size"):
+            config.vocab_size = vocab_size
+        self.vocab_size = vocab_size
+        self.unpadded_vocab_size = vocab_size
+        self.model_arch = getattr(config, "architectures", [""])[0]
+        self.model_arch_spec = get_model_arch_spec(self.model_arch)
         self.capture_aux_hidden_states = False
 
         with plugin_runtime_scope(framework="sglang"):
@@ -300,10 +300,12 @@ class _AtomCausalLMBaseForSglang(nn.Module):
         forward_batch: ForwardBatch,
         input_embeds: torch.Tensor = None,
         get_embedding: bool = False,
-        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        pp_proxy_tensors: PPProxyTensors | None = None,
         **model_kwargs: Any,
-    ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
-        with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
+    ) -> LogitsProcessorOutput | PPProxyTensors:
+        with plugin_runtime_scope(  # noqa: SIM117
+            framework="sglang", atom_config=self.atom_config
+        ):
             with SGLangPluginRuntime(
                 atom_config=self.atom_config,
                 forward_batch=forward_batch,
@@ -409,7 +411,7 @@ class _AtomCausalLMBaseForSglang(nn.Module):
                     )
                 return hidden_states
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         # The passed `weights` iterable from sglang is ignored because ATOM
         # uses its own weight loading pipeline (handling AITER-specific quant
         # formats, kv_b_proj splitting, etc.) that is incompatible with
@@ -451,9 +453,7 @@ class _AtomCausalLMBaseForSglang(nn.Module):
 
         with plugin_runtime_scope(framework="sglang", atom_config=self.atom_config):
             return load_model_in_plugin_mode(
-                model=self.model,
-                config=self.atom_config,
-                prefix=self.model_arch_spec.load_weights_prefix,
+                model=self.model, config=self.atom_config, prefix="model."
             )
 
 

--- a/atom/plugin/sglang/models/kimi_k3_processor.py
+++ b/atom/plugin/sglang/models/kimi_k3_processor.py
@@ -1,0 +1,37 @@
+"""Processor registration for Kimi-K3 in SGLang plugin mode."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+try:
+    from sglang.srt.multimodal.processors.transformers_auto import (
+        TransformersAutoMultimodalProcessor,
+    )
+except Exception:  # noqa: BLE001 - SGLang multimodal symbols are optional
+    TransformersAutoMultimodalProcessor = object
+
+
+class KimiK3ForConditionalGeneration:
+    pass
+
+
+class KimiK3TextOnlyProcessor(TransformersAutoMultimodalProcessor):
+    """Use SGLang's generic HF processor path for Kimi-K3 text inputs."""
+
+    models: ClassVar[list[type]] = [KimiK3ForConditionalGeneration]
+    supports_transformers_backend = True
+
+
+def register_kimi_k3_text_only_processor() -> None:
+    """Register Kimi-K3 on SGLang's generic HF processor path."""
+
+    try:
+        from sglang.srt.managers.multimodal_processor import PROCESSOR_MAPPING
+    except Exception:  # noqa: BLE001 - processor mapping is optional outside SGLang
+        return
+
+    PROCESSOR_MAPPING.setdefault(
+        KimiK3ForConditionalGeneration,
+        KimiK3TextOnlyProcessor,
+    )

--- a/atom/plugin/sglang/prepare.py
+++ b/atom/plugin/sglang/prepare.py
@@ -51,8 +51,8 @@ def prepare_model(config: Any):
     elif model_arch == "KimiK3ForConditionalGeneration":
         from atom.plugin.sglang.kimi_k3_bridge import install_kimi_k3_pool_patch
 
-        # Keep this idempotent fallback for source-mounted development installs
-        # whose SGLang entry-point metadata has not been refreshed.
+        # Model construction precedes ModelRunner.init_memory_pool(), so install
+        # the K3-only pool hooks here after the architecture is known.
         install_kimi_k3_pool_patch()
 
     # Import here to avoid partial initialization while SGLang discovers models.

--- a/atom/plugin/sglang/prepare.py
+++ b/atom/plugin/sglang/prepare.py
@@ -32,7 +32,10 @@ def prepare_model(config: Any):
     logger.info("Prepare model for plugin mode, the upper engine is sglang")
     _set_framework_backbone("sglang")
 
-    model_arch = config.architectures[0]
+    from atom.plugin.sglang.runtime import resolve_model_arch_spec
+
+    source_model_arch = (getattr(config, "architectures", None) or [""])[0]
+    model_arch, model_adapter = resolve_model_arch_spec(config)
     if model_arch == "DeepseekV4ForCausalLM":
         from atom.plugin.sglang.deepseek_v4_bridge import (
             install_deepseek_v4_proxy_pool_patch,
@@ -66,7 +69,9 @@ def prepare_model(config: Any):
     if model_arch not in _ATOM_SUPPORTED_MODELS:
         supported_archs = list(_ATOM_SUPPORTED_MODELS.keys())
         raise ValueError(
-            f"ATOM does not support the required model architecture: {model_arch}. "
+            "ATOM does not support the required model architecture: "
+            f"{source_model_arch or '<unknown>'} (resolved as "
+            f"{model_arch or '<unknown>'}). "
             f"For now supported model architectures: {supported_archs}"
         )
 
@@ -77,9 +82,6 @@ def prepare_model(config: Any):
     model_cls = _ATOM_SUPPORTED_MODELS[model_arch]
     logger.info("ATOM model class for %s is %s", model_arch, model_cls)
 
-    from atom.plugin.sglang.runtime import get_model_arch_spec
-
-    model_adapter = get_model_arch_spec(model_arch)
     if model_adapter.prepare_draft_model_config is not None:
         model_adapter.prepare_draft_model_config(atom_config, config)
     if model_adapter.prepare_config is not None:

--- a/atom/plugin/sglang/prepare.py
+++ b/atom/plugin/sglang/prepare.py
@@ -48,6 +48,12 @@ def prepare_model(config: Any):
         )
 
         install_minimax_m3_pool_patch()
+    elif model_arch == "KimiK3ForConditionalGeneration":
+        from atom.plugin.sglang.kimi_k3_bridge import install_kimi_k3_pool_patch
+
+        # Keep this idempotent fallback for source-mounted development installs
+        # whose SGLang entry-point metadata has not been refreshed.
+        install_kimi_k3_pool_patch()
 
     # Import here to avoid partial initialization while SGLang discovers models.
     from atom.plugin.register import (

--- a/atom/plugin/sglang/register.py
+++ b/atom/plugin/sglang/register.py
@@ -79,6 +79,13 @@ def register_plugin() -> None:
 
     _install_model_config_quant_patch()
     _install_loader_quant_patch()
+    from atom.plugin.sglang.kimi_k3_bridge import install_kimi_k3_pool_patch
+    from atom.plugin.sglang.models.kimi_k3_processor import (
+        register_kimi_k3_text_only_processor,
+    )
+
+    install_kimi_k3_pool_patch()
+    register_kimi_k3_text_only_processor()
 
     try:
         from atom.plugin.sglang.runtime import apply_load_config_patch

--- a/atom/plugin/sglang/register.py
+++ b/atom/plugin/sglang/register.py
@@ -79,12 +79,10 @@ def register_plugin() -> None:
 
     _install_model_config_quant_patch()
     _install_loader_quant_patch()
-    from atom.plugin.sglang.kimi_k3_bridge import install_kimi_k3_pool_patch
     from atom.plugin.sglang.models.kimi_k3_processor import (
         register_kimi_k3_text_only_processor,
     )
 
-    install_kimi_k3_pool_patch()
     register_kimi_k3_text_only_processor()
 
     try:

--- a/atom/plugin/sglang/runtime/__init__.py
+++ b/atom/plugin/sglang/runtime/__init__.py
@@ -16,6 +16,7 @@ from atom.plugin.sglang.runtime.model_arch import (
     SGLangModelAdapterSpec,
     get_model_arch_spec,
     is_glm52_dsa_config,
+    resolve_model_arch_spec,
 )
 
 apply_load_config_patch()
@@ -34,4 +35,5 @@ __all__ = [
     "is_draft_extend_mode",
     "is_glm52_dsa_config",
     "plugin_runtime_scope",
+    "resolve_model_arch_spec",
 ]

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -589,6 +589,74 @@ def _build_eagle3_llama_metadata(
     )
 
 
+def _build_kimi_k3_metadata(
+    atom_config: Any, forward_batch: ForwardBatch, positions: torch.Tensor
+):
+    from atom.plugin.sglang.kimi_k3_bridge import (
+        build_kimi_k3_attention_metadata,
+        maybe_get_kimi_k3_pools,
+    )
+
+    attn_metadata = getattr(forward_batch, "atom_kimi_k3_graph_metadata", None)
+    if attn_metadata is None:
+        backend = _get_sglang_attention_backend()
+        attn_metadata = getattr(backend, "atom_kimi_k3_graph_metadata", None)
+    if attn_metadata is None and _is_current_stream_capturing():
+        from atom.plugin.sglang.attention_backend.kimi_k3_backend import (
+            ATOMKimiK3BackendForSgl,
+        )
+
+        attn_metadata = ATOMKimiK3BackendForSgl._last_atom_kimi_k3_graph_metadata
+
+    token_to_kv_pool, req_to_token_pool = maybe_get_kimi_k3_pools(forward_batch)
+    if token_to_kv_pool is None or req_to_token_pool is None:
+        raise RuntimeError("Kimi-K3 SGLang pools are unavailable")
+    if attn_metadata is None:
+        attn_metadata = build_kimi_k3_attention_metadata(
+            forward_batch,
+            positions,
+            token_to_kv_pool=token_to_kv_pool,
+            req_to_token_pool=req_to_token_pool,
+        )
+
+    from atom.plugin.sglang.attention_backend.attention_gdn import (
+        SGLangGDNForwardContext,
+    )
+
+    attn_backend = SGLangGDNForwardContext._resolve_attn_backend(forward_batch)
+    if forward_batch.forward_mode.is_decode_or_idle():
+        full_attn_backend = getattr(attn_backend, "full_attn_backend", attn_backend)
+        forward_metadata = getattr(full_attn_backend, "forward_metadata", None)
+        kv_indices = getattr(forward_metadata, "kv_indices", None)
+        if kv_indices is None:
+            raise RuntimeError(
+                "Kimi-K3 decode metadata has no KV indices; "
+                f"backend={type(full_attn_backend).__name__}, "
+                f"forward_metadata={forward_metadata is not None}"
+            )
+        attn_metadata.kv_indptr = forward_metadata.kv_indptr
+        attn_metadata.kv_indices = kv_indices
+        attn_metadata.kv_last_page_lens = getattr(
+            forward_metadata, "kv_last_page_len", None
+        )
+        for name in (
+            "work_meta_data",
+            "work_info_set",
+            "work_indptr",
+            "reduce_indptr",
+            "reduce_final_map",
+            "reduce_partial_map",
+            "num_kv_splits",
+        ):
+            setattr(attn_metadata, name, getattr(forward_metadata, name, None))
+
+    linear_backend = SGLangGDNForwardContext._linear_attn_backend(attn_backend)
+    attn_metadata.gdn_metadata = SGLangGDNForwardContext._build_gdn_metadata(
+        forward_batch, linear_backend
+    )
+    return attn_metadata
+
+
 def _set_atom_forward_context(
     atom_config: Any,
     forward_batch: ForwardBatch,
@@ -608,129 +676,20 @@ def _set_atom_forward_context(
             include_v2=True
         )
     )
+    from atom.plugin.sglang.runtime.model_arch import resolve_model_arch_spec
+
+    hf_config = getattr(atom_config, "hf_config", None)
+    model_arch, model_adapter = resolve_model_arch_spec(hf_config)
     attn_metadata = None
-    try:
-        from atom.plugin.sglang.kimi_k3_bridge import (
-            build_kimi_k3_attention_metadata,
-            is_kimi_k3_config,
-            maybe_get_kimi_k3_pools,
-        )
-
-        if is_kimi_k3_config(atom_config.hf_config):
-            attn_metadata = getattr(forward_batch, "atom_kimi_k3_graph_metadata", None)
-            if attn_metadata is None:
-                backend = _get_sglang_attention_backend()
-                attn_metadata = getattr(backend, "atom_kimi_k3_graph_metadata", None)
-            if attn_metadata is None and _is_current_stream_capturing():
-                from atom.plugin.sglang.attention_backend.kimi_k3_backend import (
-                    ATOMKimiK3BackendForSgl,
-                )
-
-                attn_metadata = (
-                    ATOMKimiK3BackendForSgl._last_atom_kimi_k3_graph_metadata
-                )
-            token_to_kv_pool, req_to_token_pool = maybe_get_kimi_k3_pools(forward_batch)
-            if token_to_kv_pool is None or req_to_token_pool is None:
-                raise RuntimeError("Kimi-K3 SGLang pools are unavailable")
-            if attn_metadata is None:
-                attn_metadata = build_kimi_k3_attention_metadata(
-                    forward_batch,
-                    positions,
-                    token_to_kv_pool=token_to_kv_pool,
-                    req_to_token_pool=req_to_token_pool,
-                )
-            from atom.plugin.sglang.attention_backend.attention_gdn import (
-                SGLangGDNForwardContext,
-            )
-
-            attn_backend = SGLangGDNForwardContext._resolve_attn_backend(forward_batch)
-            if forward_mode.is_decode_or_idle():
-                # K3 uses SGLang's HybridLinearAttnBackend. The wrapper owns
-                # dispatch only; full-attention (MLA) metadata is maintained
-                # by its full_attn_backend child.
-                full_attn_backend = getattr(
-                    attn_backend, "full_attn_backend", attn_backend
-                )
-                # Do not depend on get_attn_backend() in the bridge: while
-                # CUDA graphs are captured, the global SGLang forward context
-                # can still point at the capture wrapper rather than K3's
-                # concrete backend. Resolve metadata through the backend used
-                # for this batch and fail before calling the MLA kernel if its
-                # CSR buffers were not initialized.
-                forward_metadata = getattr(full_attn_backend, "forward_metadata", None)
-                kv_indices = getattr(forward_metadata, "kv_indices", None)
-                if kv_indices is None:
-                    raise RuntimeError(
-                        "Kimi-K3 decode metadata has no KV indices; "
-                        f"backend={type(full_attn_backend).__name__}, "
-                        f"forward_metadata={forward_metadata is not None}"
-                    )
-                attn_metadata.kv_indptr = forward_metadata.kv_indptr
-                attn_metadata.kv_indices = kv_indices
-                attn_metadata.kv_last_page_lens = getattr(
-                    forward_metadata, "kv_last_page_len", None
-                )
-                for name in (
-                    "work_meta_data",
-                    "work_info_set",
-                    "work_indptr",
-                    "reduce_indptr",
-                    "reduce_final_map",
-                    "reduce_partial_map",
-                    "num_kv_splits",
-                ):
-                    setattr(attn_metadata, name, getattr(forward_metadata, name, None))
-            linear_backend = SGLangGDNForwardContext._linear_attn_backend(attn_backend)
-            attn_metadata.gdn_metadata = SGLangGDNForwardContext._build_gdn_metadata(
-                forward_batch, linear_backend
-            )
-    except Exception as exc:
-        raise RuntimeError(
-            "Failed to build native ATOM Kimi-K3 metadata for SGLang"
-        ) from exc
-
-    if attn_metadata is None:
+    if model_adapter.build_forward_metadata is not None:
         try:
-            attn_metadata = _build_minimax_m3_metadata(
-                atom_config,
-                forward_batch,
-                positions,
+            attn_metadata = model_adapter.build_forward_metadata(
+                atom_config, forward_batch, positions
             )
         except Exception as exc:
             raise RuntimeError(
-                "Failed to build ATOM MiniMax-M3 sparse metadata for SGLang"
-            ) from exc
-
-    if attn_metadata is None:
-        try:
-            attn_metadata = _build_glm52_dsa_metadata(
-                atom_config,
-                forward_batch,
-                positions,
-            )
-        except Exception as exc:
-            raise RuntimeError(
-                "Failed to build ATOM GLM-5.2 DSA metadata for SGLang"
-            ) from exc
-
-    if attn_metadata is None:
-        try:
-            attn_metadata = _build_deepseek_v4_metadata(forward_batch, positions)
-        except Exception as exc:
-            raise RuntimeError(
-                "Failed to build ATOM DeepSeek-V4 metadata for SGLang"
-            ) from exc
-
-    if attn_metadata is None:
-        try:
-            attn_metadata = _build_eagle3_llama_metadata(
-                atom_config,
-                forward_batch,
-                positions,
-            )
-        except Exception as exc:
-            raise RuntimeError(
-                "Failed to build ATOM EAGLE3 draft metadata for SGLang"
+                "Failed to build ATOM metadata for SGLang model "
+                f"{model_arch or '<unknown>'}"
             ) from exc
 
     if attn_metadata is None:

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -610,15 +610,96 @@ def _set_atom_forward_context(
     )
     attn_metadata = None
     try:
-        attn_metadata = _build_minimax_m3_metadata(
-            atom_config,
-            forward_batch,
-            positions,
+        from atom.plugin.sglang.kimi_k3_bridge import (
+            build_kimi_k3_attention_metadata,
+            is_kimi_k3_config,
+            maybe_get_kimi_k3_pools,
         )
+
+        if is_kimi_k3_config(atom_config.hf_config):
+            attn_metadata = getattr(forward_batch, "atom_kimi_k3_graph_metadata", None)
+            if attn_metadata is None:
+                backend = _get_sglang_attention_backend()
+                attn_metadata = getattr(backend, "atom_kimi_k3_graph_metadata", None)
+            if attn_metadata is None and _is_current_stream_capturing():
+                from atom.plugin.sglang.attention_backend.kimi_k3_backend import (
+                    ATOMKimiK3BackendForSgl,
+                )
+
+                attn_metadata = (
+                    ATOMKimiK3BackendForSgl._last_atom_kimi_k3_graph_metadata
+                )
+            token_to_kv_pool, req_to_token_pool = maybe_get_kimi_k3_pools(forward_batch)
+            if token_to_kv_pool is None or req_to_token_pool is None:
+                raise RuntimeError("Kimi-K3 SGLang pools are unavailable")
+            if attn_metadata is None:
+                attn_metadata = build_kimi_k3_attention_metadata(
+                    forward_batch,
+                    positions,
+                    token_to_kv_pool=token_to_kv_pool,
+                    req_to_token_pool=req_to_token_pool,
+                )
+            from atom.plugin.sglang.attention_backend.attention_gdn import (
+                SGLangGDNForwardContext,
+            )
+
+            attn_backend = SGLangGDNForwardContext._resolve_attn_backend(forward_batch)
+            if forward_mode.is_decode_or_idle():
+                # K3 uses SGLang's HybridLinearAttnBackend. The wrapper owns
+                # dispatch only; full-attention (MLA) metadata is maintained
+                # by its full_attn_backend child.
+                full_attn_backend = getattr(
+                    attn_backend, "full_attn_backend", attn_backend
+                )
+                # Do not depend on get_attn_backend() in the bridge: while
+                # CUDA graphs are captured, the global SGLang forward context
+                # can still point at the capture wrapper rather than K3's
+                # concrete backend. Resolve metadata through the backend used
+                # for this batch and fail before calling the MLA kernel if its
+                # CSR buffers were not initialized.
+                forward_metadata = getattr(full_attn_backend, "forward_metadata", None)
+                kv_indices = getattr(forward_metadata, "kv_indices", None)
+                if kv_indices is None:
+                    raise RuntimeError(
+                        "Kimi-K3 decode metadata has no KV indices; "
+                        f"backend={type(full_attn_backend).__name__}, "
+                        f"forward_metadata={forward_metadata is not None}"
+                    )
+                attn_metadata.kv_indptr = forward_metadata.kv_indptr
+                attn_metadata.kv_indices = kv_indices
+                attn_metadata.kv_last_page_lens = getattr(
+                    forward_metadata, "kv_last_page_len", None
+                )
+                for name in (
+                    "work_meta_data",
+                    "work_info_set",
+                    "work_indptr",
+                    "reduce_indptr",
+                    "reduce_final_map",
+                    "reduce_partial_map",
+                    "num_kv_splits",
+                ):
+                    setattr(attn_metadata, name, getattr(forward_metadata, name, None))
+            linear_backend = SGLangGDNForwardContext._linear_attn_backend(attn_backend)
+            attn_metadata.gdn_metadata = SGLangGDNForwardContext._build_gdn_metadata(
+                forward_batch, linear_backend
+            )
     except Exception as exc:
         raise RuntimeError(
-            "Failed to build ATOM MiniMax-M3 sparse metadata for SGLang"
+            "Failed to build native ATOM Kimi-K3 metadata for SGLang"
         ) from exc
+
+    if attn_metadata is None:
+        try:
+            attn_metadata = _build_minimax_m3_metadata(
+                atom_config,
+                forward_batch,
+                positions,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to build ATOM MiniMax-M3 sparse metadata for SGLang"
+            ) from exc
 
     if attn_metadata is None:
         try:

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -10,9 +10,24 @@ from typing import Any
 GLM52_DSA_ARCH = "GlmMoeDsaForCausalLM"
 GLM52_DSA_MODEL_TYPE = "glm_moe_dsa"
 
+MODEL_TYPE_ADAPTER_ARCHES = {
+    GLM52_DSA_MODEL_TYPE: GLM52_DSA_ARCH,
+    "deepseek_v4": "DeepseekV4ForCausalLM",
+    "kimi_k3": "KimiK3ForConditionalGeneration",
+    "minimax_m3": "MiniMaxM3SparseForCausalLM",
+    "minimax_m3_vl": "MiniMaxM3SparseForConditionalGeneration",
+    "qwen3": "Qwen3ForCausalLM",
+    "qwen3_moe": "Qwen3MoeForCausalLM",
+    "qwen3_next": "Qwen3NextForCausalLM",
+    "qwen3_5": "Qwen3_5ForConditionalGeneration",
+    "qwen3_5_text": "Qwen3_5ForConditionalGeneration",
+    "qwen3_5_moe": "Qwen3_5MoeForConditionalGeneration",
+    "qwen3_5_moe_text": "Qwen3_5MoeForConditionalGeneration",
+}
+
 
 def is_glm52_dsa_config(config: Any) -> bool:
-    """Return whether an HF config describes GLM-5.2 DSA."""
+    """Return whether an HF config describes the GLM-5 DSA family."""
 
     archs = getattr(config, "architectures", None) or []
     return (
@@ -43,6 +58,48 @@ class SGLangModelAdapterSpec:
     construction_context: Callable[[], AbstractContextManager[Any]] | None = None
     install_adapters: Callable[[Any], None] | None = None
     bind_cache_views: Callable[[Any, Any], None] | None = None
+    build_forward_metadata: Callable[[Any, Any, Any], Any] | None = None
+
+
+def _build_kimi_k3_forward_metadata(
+    atom_config: Any, forward_batch: Any, positions: Any
+) -> Any:
+    from atom.plugin.sglang.runtime.forward_context import _build_kimi_k3_metadata
+
+    return _build_kimi_k3_metadata(atom_config, forward_batch, positions)
+
+
+def _build_minimax_m3_forward_metadata(
+    atom_config: Any, forward_batch: Any, positions: Any
+) -> Any:
+    from atom.plugin.sglang.runtime.forward_context import _build_minimax_m3_metadata
+
+    return _build_minimax_m3_metadata(atom_config, forward_batch, positions)
+
+
+def _build_glm52_dsa_forward_metadata(
+    atom_config: Any, forward_batch: Any, positions: Any
+) -> Any:
+    from atom.plugin.sglang.runtime.forward_context import _build_glm52_dsa_metadata
+
+    return _build_glm52_dsa_metadata(atom_config, forward_batch, positions)
+
+
+def _build_deepseek_v4_forward_metadata(
+    atom_config: Any, forward_batch: Any, positions: Any
+) -> Any:
+    del atom_config
+    from atom.plugin.sglang.runtime.forward_context import _build_deepseek_v4_metadata
+
+    return _build_deepseek_v4_metadata(forward_batch, positions)
+
+
+def _build_eagle3_llama_forward_metadata(
+    atom_config: Any, forward_batch: Any, positions: Any
+) -> Any:
+    from atom.plugin.sglang.runtime.forward_context import _build_eagle3_llama_metadata
+
+    return _build_eagle3_llama_metadata(atom_config, forward_batch, positions)
 
 
 def _prepare_qwen35_config(atom_config: Any, model_arch: str) -> None:
@@ -367,6 +424,7 @@ MODEL_ADAPTER_SPECS = {
         construction_context=_glm52_dsa_construction_context,
         install_adapters=_install_glm52_dsa_native_adapters,
         bind_cache_views=_bind_glm52_dsa_cache_views,
+        build_forward_metadata=_build_glm52_dsa_forward_metadata,
         uses_context_only_forward=True,
     ),
     "KimiK25ForConditionalGeneration": SGLangModelAdapterSpec(
@@ -380,6 +438,7 @@ MODEL_ADAPTER_SPECS = {
         prepare_config=_prepare_kimi_k3_config,
         construction_context=_kimi_k3_construction_context,
         bind_cache_views=_bind_kimi_k3_cache_views,
+        build_forward_metadata=_build_kimi_k3_forward_metadata,
     ),
     "Qwen3ForCausalLM": SGLangModelAdapterSpec(),
     "Qwen3MoeForCausalLM": SGLangModelAdapterSpec(),
@@ -399,6 +458,7 @@ MODEL_ADAPTER_SPECS = {
     "DeepseekV4ForCausalLM": SGLangModelAdapterSpec(
         install_adapters=_install_deepseek_v4_adapters,
         bind_cache_views=_bind_deepseek_v4_cache_views,
+        build_forward_metadata=_build_deepseek_v4_forward_metadata,
     ),
     "MiniMaxM3SparseForCausalLM": SGLangModelAdapterSpec(
         uses_context_only_forward=True,
@@ -406,6 +466,7 @@ MODEL_ADAPTER_SPECS = {
         construction_context=_minimax_m3_construction_context,
         install_adapters=_install_minimax_m3_adapters,
         bind_cache_views=_bind_minimax_m3_cache_views,
+        build_forward_metadata=_build_minimax_m3_forward_metadata,
     ),
     "MiniMaxM3SparseForConditionalGeneration": SGLangModelAdapterSpec(
         uses_context_only_forward=True,
@@ -413,12 +474,14 @@ MODEL_ADAPTER_SPECS = {
         construction_context=_minimax_m3_construction_context,
         install_adapters=_install_minimax_m3_adapters,
         bind_cache_views=_bind_minimax_m3_cache_views,
+        build_forward_metadata=_build_minimax_m3_forward_metadata,
     ),
     "LlamaForCausalLMEagle3": SGLangModelAdapterSpec(
         uses_context_only_forward=True,
         prepare_draft_model_config=_prepare_eagle3_llama_draft_model_config,
         construction_context=_eagle3_llama_construction_context,
         bind_cache_views=_bind_eagle3_llama_cache_views,
+        build_forward_metadata=_build_eagle3_llama_forward_metadata,
     ),
 }
 
@@ -446,3 +509,23 @@ MODEL_ARCH_SPECS = {
 
 def get_model_arch_spec(model_arch: str) -> SGLangModelAdapterSpec:
     return MODEL_ADAPTER_SPECS.get(model_arch, SGLangModelAdapterSpec())
+
+
+def resolve_model_arch_spec(config: Any) -> tuple[str, SGLangModelAdapterSpec]:
+    """Resolve an adapter by exact architecture, then stable model family."""
+
+    architectures = getattr(config, "architectures", None) or []
+    for architecture in architectures:
+        model_arch = str(architecture)
+        if model_arch in MODEL_ADAPTER_SPECS:
+            return model_arch, MODEL_ADAPTER_SPECS[model_arch]
+
+    configs = (config, getattr(config, "text_config", None))
+    for candidate in configs:
+        model_type = str(getattr(candidate, "model_type", "") or "").lower()
+        model_arch = MODEL_TYPE_ADAPTER_ARCHES.get(model_type)
+        if model_arch is not None:
+            return model_arch, MODEL_ADAPTER_SPECS[model_arch]
+
+    model_arch = str(architectures[0]) if architectures else ""
+    return model_arch, get_model_arch_spec(model_arch)

--- a/atom/plugin/sglang/runtime/model_arch.py
+++ b/atom/plugin/sglang/runtime/model_arch.py
@@ -32,6 +32,8 @@ class SGLangModelAdapterSpec:
 
     wrapper_binds_gdn_context: bool = False
     uses_context_only_forward: bool = False
+    uses_text_config: bool = False
+    load_weights_prefix: str = "model."
     # SGLang initializes atom_config from the target ServerArgs but passes a
     # draft-local HF config to the external draft model. This early hook lets
     # adapters preserve target metadata and switch to the draft config before
@@ -68,6 +70,67 @@ def _prepare_kimi_k25_config(atom_config: Any, model_arch: str) -> None:
     )
 
     remap_kimi_k25_quant_config_for_sglang_plugin(atom_config, model_arch)
+
+
+def _prepare_kimi_k3_config(atom_config: Any, model_arch: str) -> None:
+    del model_arch
+    from atom.models.kimi_k3 import (
+        KimiK3ForCausalLM,
+        _kda_packed_modules_mapping,
+        _normalize_kimi_config,
+        _text_config,
+    )
+
+    text_config = _text_config(atom_config.hf_config)
+    _normalize_kimi_config(text_config)
+    # K3's SGLang bridge allocates a 128-token hybrid pool.  True MLA uses
+    # ATOM_MLA_PAGE_SIZE=1 with that pool rather than segmented MLA (page 64).
+    atom_config.kv_cache_block_size = 128
+    quant_config = getattr(atom_config, "quant_config", None)
+    if quant_config is not None:
+        quant_config.remap_layer_name(
+            atom_config.hf_config,
+            packed_modules_mapping=_kda_packed_modules_mapping(
+                text_config.kimi_kda_layers
+            ),
+            quant_exclude_name_mapping=KimiK3ForCausalLM.quant_exclude_name_mapping,
+        )
+
+
+def _kimi_k3_construction_context():
+    from atom.plugin.sglang.kimi_k3_bridge import (
+        kimi_k3_native_attention_construction,
+    )
+
+    return kimi_k3_native_attention_construction()
+
+
+def _bind_kimi_k3_cache_views(model: Any, runtime: Any) -> None:
+    from atom.plugin.sglang.attention_backend.attention_gdn import (
+        SGLangGDNForwardContext,
+    )
+    from atom.plugin.sglang.kimi_k3_bridge import (
+        bind_kimi_k3_cache_views,
+        maybe_get_kimi_k3_pools,
+    )
+    from atom.utils.forward_context import get_forward_context, set_kv_cache_data
+
+    token_to_kv_pool, _ = maybe_get_kimi_k3_pools(runtime.forward_batch)
+    if not bind_kimi_k3_cache_views(model, token_to_kv_pool):
+        raise RuntimeError("Kimi-K3 SGLang KV pool is not initialized")
+
+    attn_backend = SGLangGDNForwardContext._resolve_attn_backend(runtime.forward_batch)
+    linear_backend = SGLangGDNForwardContext._linear_attn_backend(attn_backend)
+    gdn_cache = SGLangGDNForwardContext._build_kv_cache_tensors(
+        runtime.forward_batch, linear_backend
+    )
+    if not gdn_cache:
+        raise RuntimeError("Kimi-K3 SGLang GDN state cache is not initialized")
+    ctx = get_forward_context()
+    kv_cache_data = dict(ctx.kv_cache_data or {})
+    kv_cache_data.update(gdn_cache)
+    set_kv_cache_data(kv_cache_data)
+    ctx.kv_cache_data = kv_cache_data
 
 
 def _prepare_minimax_m3_config(atom_config: Any, model_arch: str) -> None:
@@ -310,6 +373,14 @@ MODEL_ADAPTER_SPECS = {
         prepare_config=_prepare_kimi_k25_config,
         install_adapters=_install_deepseek_mla_adapters,
     ),
+    "KimiK3ForConditionalGeneration": SGLangModelAdapterSpec(
+        uses_context_only_forward=True,
+        uses_text_config=True,
+        load_weights_prefix="",
+        prepare_config=_prepare_kimi_k3_config,
+        construction_context=_kimi_k3_construction_context,
+        bind_cache_views=_bind_kimi_k3_cache_views,
+    ),
     "Qwen3ForCausalLM": SGLangModelAdapterSpec(),
     "Qwen3MoeForCausalLM": SGLangModelAdapterSpec(),
     "Qwen3NextForCausalLM": SGLangModelAdapterSpec(
@@ -360,6 +431,7 @@ MODEL_ARCH_SPECS = {
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
         GLM52_DSA_ARCH,
+        "KimiK3ForConditionalGeneration",
         "Qwen3ForCausalLM",
         "Qwen3MoeForCausalLM",
         "Qwen3NextForCausalLM",

--- a/recipes/atom_sglang/Kimi-K3.md
+++ b/recipes/atom_sglang/Kimi-K3.md
@@ -1,0 +1,137 @@
+# Kimi-K3 with ATOM SGLang Plugin
+
+[Kimi-K3](https://huggingface.co/moonshotai/Kimi-K3) combines KDA
+linear-attention layers, MLA full-attention layers, and an MXFP4 latent MoE.
+This recipe serves its text-only backbone through the ATOM SGLang plugin.
+
+The validated configuration requires eight MI355 (gfx950) GPUs with TP8.
+Prefix caching and speculative decoding are not supported in this configuration.
+
+## Preparing Environment
+
+Pull the latest SGLang development image and install the KDA dependency:
+
+```bash
+docker pull rocm/atom-dev:sglang-latest
+pip install "fla-core==0.5.1" "flash-linear-attention==0.5.1"
+pip install -e /path/to/ATOM --no-deps
+```
+
+## Launching Server
+
+```bash
+MODEL_PATH=${MODEL_PATH:-moonshotai/Kimi-K3}
+PORT=${PORT:-8000}
+TP=${TP:-8}
+
+export SGLANG_PLUGINS=atom_sglang
+export SGLANG_EXTERNAL_MODEL_PACKAGE=atom.plugin.sglang.models
+export SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE=atom.plugin.sglang.models
+export SGLANG_USE_AITER=1
+
+export ATOM_LOADER_NUM_THREADS=16
+export ATOM_SYNC_AFTER_LOAD=1
+export ATOM_DIST_TIMEOUT_SECONDS=3600
+
+export ATOM_USE_TRITON_GEMM=1
+export AITER_USE_GROUPED_GEMM=0
+export ATOM_USE_TRITON_MOE=0
+export AITER_FLYDSL_FORCE=1
+export AITER_FORCE_GFX1250=0
+
+# SGLang allocates 128-token hybrid-cache pages. ATOM MLA keeps its native
+# per-token page layout when translating those pages for the attention kernel.
+export ATOM_MLA_PAGE_SIZE=1
+export ATOM_USE_UNIFIED_ATTN=1
+export ATOM_FORCE_ATTN_TRITON=1
+export AITER_LOG_LEVEL=WARNING
+
+python3 -m sglang.launch_server \
+    --model-path "${MODEL_PATH}" \
+    --host 0.0.0.0 \
+    --port "${PORT}" \
+    --trust-remote-code \
+    --tensor-parallel-size "${TP}" \
+    --attention-backend aiter \
+    --kv-cache-dtype fp8_e4m3 \
+    --page-size 128 \
+    --context-length 16384 \
+    --mem-fraction-static 0.93 \
+    --disable-radix-cache \
+    2>&1 | tee kimi-k3-tp8-sglang-server.log
+```
+
+The plugin keeps KDA recurrent state in fp32 and translates SGLang's hybrid
+KDA/MLA cache metadata to ATOM attention metadata. Radix cache must stay
+disabled because KDA recurrent state cannot be reconstructed from MLA KV pages.
+
+## Smoke Test
+
+```bash
+curl "http://127.0.0.1:${PORT}/v1/completions" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"model\": \"${MODEL_PATH}\",
+      \"prompt\": \"Question: What is 17 + 25? Answer:\",
+      \"max_tokens\": 32,
+      \"temperature\": 0
+    }"
+```
+
+The deterministic response starts with `42`.
+
+## Accuracy Validation
+
+Run the same GSM8K 5-shot evaluation used by the ATOM vLLM Kimi-K3 recipe:
+
+```bash
+OUTPUT_PATH=./kimi-k3-sglang-gsm8k
+
+lm_eval \
+    --model local-completions \
+    --model_args "model=${MODEL_PATH},base_url=http://127.0.0.1:${PORT}/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
+    --tasks gsm8k \
+    --num_fewshot 5 \
+    --output_path "${OUTPUT_PATH}"
+```
+
+The ATOM vLLM TP8 reference is `0.9553` flexible-extract exact match. SGLang
+nightly CI initially uses `0.94` as its pass threshold and should record a
+SGLang-specific baseline after the first complete run.
+
+Use a freshly started server for each reported accuracy run. Reusing a warm
+Kimi-K3 server for back-to-back accuracy measurements is not a validated
+baseline protocol.
+
+## Serving Benchmark
+
+The SGLang CI catalog covers 1024/1024 and 8192/1024 input/output lengths:
+
+```bash
+ISL=${ISL:-8192}
+OSL=${OSL:-1024}
+CONC=${CONC:-16}
+NUM_PROMPTS=$((CONC * 10))
+
+python -m atom.benchmarks.benchmark_serving \
+    --model="${MODEL_PATH}" \
+    --backend=sglang \
+    --base-url="http://127.0.0.1:${PORT}" \
+    --dataset-name=random \
+    --random-input-len="${ISL}" \
+    --random-output-len="${OSL}" \
+    --random-range-ratio=0.8 \
+    --num-prompts="${NUM_PROMPTS}" \
+    --max-concurrency="${CONC}" \
+    --request-rate=inf \
+    --ignore-eos \
+    --save-result \
+    --percentile-metrics="ttft,tpot,itl,e2el"
+```
+
+## Current Scope
+
+- Text generation only; the vision tower and multimodal projector are skipped.
+- TP8 on MI355/gfx950 is the validated deployment.
+- FP8 KV cache and CUDA Graph capture/replay are enabled.
+- Prefix caching and speculative decoding are disabled.

--- a/tests/plugin/test_sglang_gdn_forward_context.py
+++ b/tests/plugin/test_sglang_gdn_forward_context.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import torch
+
+from atom.plugin.sglang.attention_backend.attention_gdn import (
+    SGLangGDNForwardContext,
+)
+
+
+class _DecodeMode:
+    @staticmethod
+    def is_target_verify():
+        return False
+
+    @staticmethod
+    def is_decode_or_idle():
+        return True
+
+    @staticmethod
+    def is_extend():
+        return False
+
+
+class _MambaPool:
+    @staticmethod
+    def get_mamba_indices(req_pool_indices):
+        return req_pool_indices + 10
+
+
+def test_build_gdn_metadata_reconstructs_missing_forward_metadata():
+    pool = _MambaPool()
+    forward_batch = SimpleNamespace(
+        forward_mode=_DecodeMode(),
+        batch_size=2,
+        req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+        req_to_token_pool=pool,
+    )
+    linear_backend = SimpleNamespace(
+        forward_metadata=None,
+        req_to_token_pool=pool,
+    )
+
+    metadata = SGLangGDNForwardContext._build_gdn_metadata(
+        forward_batch, linear_backend
+    )
+
+    assert metadata is not None
+    assert torch.equal(
+        metadata.non_spec_query_start_loc,
+        torch.tensor([0, 1, 2], dtype=torch.int32),
+    )
+    assert torch.equal(
+        metadata.non_spec_state_indices_tensor,
+        torch.tensor([10, 11], dtype=torch.int32),
+    )

--- a/tests/plugin/test_sglang_glm52_dsa_bridge.py
+++ b/tests/plugin/test_sglang_glm52_dsa_bridge.py
@@ -29,11 +29,19 @@ def test_glm52_pool_lookup_falls_back_to_sglang_attention_backend():
         req_to_token_pool=req_pool,
     )
     runtime_mod = _package("atom.plugin.sglang.runtime")
+    runtime_resolver_mod = ModuleType(
+        "atom.plugin.sglang.runtime.attention_backend_resolver"
+    )
+    runtime_resolver_mod.resolve_sglang_runtime = lambda forward_batch: SimpleNamespace(
+        token_to_kv_pool=token_pool,
+        req_to_token_pool=req_pool,
+    )
     model_arch_mod = ModuleType("atom.plugin.sglang.runtime.model_arch")
     model_arch_mod.is_glm52_dsa_config = lambda config: True
 
     fake_modules = {
         "atom.plugin.sglang.runtime": runtime_mod,
+        "atom.plugin.sglang.runtime.attention_backend_resolver": runtime_resolver_mod,
         "atom.plugin.sglang.runtime.model_arch": model_arch_mod,
         "aiter": aiter_mod,
         "sglang": _package("sglang"),

--- a/tests/plugin/test_sglang_model_arch_metadata.py
+++ b/tests/plugin/test_sglang_model_arch_metadata.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+
+import pytest
+
+from atom.plugin.sglang.runtime.model_arch import resolve_model_arch_spec
+
+
+@pytest.mark.parametrize(
+    ("model_arch", "builder_name"),
+    (
+        ("KimiK3ForConditionalGeneration", "_build_kimi_k3_forward_metadata"),
+        ("GlmMoeDsaForCausalLM", "_build_glm52_dsa_forward_metadata"),
+        ("DeepseekV4ForCausalLM", "_build_deepseek_v4_forward_metadata"),
+        (
+            "MiniMaxM3SparseForCausalLM",
+            "_build_minimax_m3_forward_metadata",
+        ),
+        (
+            "MiniMaxM3SparseForConditionalGeneration",
+            "_build_minimax_m3_forward_metadata",
+        ),
+        ("LlamaForCausalLMEagle3", "_build_eagle3_llama_forward_metadata"),
+    ),
+)
+def test_resolve_model_arch_spec_selects_metadata_builder(
+    model_arch: str, builder_name: str
+):
+    resolved_arch, model_spec = resolve_model_arch_spec(
+        SimpleNamespace(architectures=[model_arch])
+    )
+
+    assert resolved_arch == model_arch
+    assert model_spec.build_forward_metadata is not None
+    assert model_spec.build_forward_metadata.__name__ == builder_name
+
+
+@pytest.mark.parametrize(
+    "model_arch",
+    (
+        "Qwen3ForCausalLM",
+        "Qwen3NextForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "UnknownForCausalLM",
+    ),
+)
+def test_resolve_model_arch_spec_uses_generic_metadata(model_arch: str):
+    resolved_arch, model_spec = resolve_model_arch_spec(
+        SimpleNamespace(architectures=[model_arch])
+    )
+
+    assert resolved_arch == model_arch
+    assert model_spec.build_forward_metadata is None
+
+
+def test_resolve_model_arch_spec_supports_glm_model_type_fallback():
+    resolved_arch, model_spec = resolve_model_arch_spec(
+        SimpleNamespace(architectures=[], model_type="glm_moe_dsa")
+    )
+
+    assert resolved_arch == "GlmMoeDsaForCausalLM"
+    assert model_spec.build_forward_metadata is not None
+    assert (
+        model_spec.build_forward_metadata.__name__
+        == "_build_glm52_dsa_forward_metadata"
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_arch", "builder_name"),
+    (
+        ("glm_moe_dsa", "GlmMoeDsaForCausalLM", "_build_glm52_dsa_forward_metadata"),
+        (
+            "kimi_k3",
+            "KimiK3ForConditionalGeneration",
+            "_build_kimi_k3_forward_metadata",
+        ),
+        (
+            "minimax_m3_vl",
+            "MiniMaxM3SparseForConditionalGeneration",
+            "_build_minimax_m3_forward_metadata",
+        ),
+        (
+            "deepseek_v4",
+            "DeepseekV4ForCausalLM",
+            "_build_deepseek_v4_forward_metadata",
+        ),
+    ),
+)
+def test_resolve_model_arch_spec_supports_family_version_architectures(
+    model_type: str, expected_arch: str, builder_name: str
+):
+    resolved_arch, model_spec = resolve_model_arch_spec(
+        SimpleNamespace(
+            architectures=["FutureVersionForCausalLM"], model_type=model_type
+        )
+    )
+
+    assert resolved_arch == expected_arch
+    assert model_spec.build_forward_metadata is not None
+    assert model_spec.build_forward_metadata.__name__ == builder_name
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_arch"),
+    (
+        ("qwen3", "Qwen3ForCausalLM"),
+        ("qwen3_moe", "Qwen3MoeForCausalLM"),
+        ("qwen3_next", "Qwen3NextForCausalLM"),
+        ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
+        ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
+    ),
+)
+def test_resolve_qwen_family_versions_use_their_own_adapter(
+    model_type: str, expected_arch: str
+):
+    resolved_arch, model_spec = resolve_model_arch_spec(
+        SimpleNamespace(architectures=["FutureQwenArchitecture"], model_type=model_type)
+    )
+
+    assert resolved_arch == expected_arch
+    assert model_spec is not None
+
+
+def test_resolve_model_arch_spec_uses_nested_text_model_type():
+    resolved_arch, _ = resolve_model_arch_spec(
+        SimpleNamespace(
+            architectures=["FutureQwenConditionalGeneration"],
+            model_type="future_qwen_vl",
+            text_config=SimpleNamespace(model_type="qwen3_5_moe_text"),
+        )
+    )
+
+    assert resolved_arch == "Qwen3_5MoeForConditionalGeneration"
+
+
+def test_resolve_model_arch_spec_does_not_treat_plain_llama_as_eagle3():
+    resolved_arch, model_spec = resolve_model_arch_spec(
+        SimpleNamespace(architectures=["LlamaForCausalLM"], model_type="llama")
+    )
+
+    assert resolved_arch == "LlamaForCausalLM"
+    assert model_spec.build_forward_metadata is None

--- a/tests/plugin/test_sglang_prepare_hooks.py
+++ b/tests/plugin/test_sglang_prepare_hooks.py
@@ -47,9 +47,12 @@ def _module(name: str, **attrs) -> ModuleType:
 
 def _make_fake_runtime_module(model_arch: str, prepare_config):
     module = ModuleType("atom.plugin.sglang.runtime")
-    module.get_model_arch_spec = MagicMock(
-        return_value=_Obj(prepare_config=prepare_config)
+    model_spec = _Obj(
+        prepare_config=prepare_config,
+        prepare_draft_model_config=None,
+        construction_context=None,
     )
+    module.resolve_model_arch_spec = MagicMock(return_value=(model_arch, model_spec))
     return module
 
 
@@ -119,4 +122,45 @@ def test_prepare_model_register_ops_gate(model_arch: str):
         )
     else:
         fake_qwen35_mod.apply_prepare_model_adaptations.assert_not_called()
+    fake_model_cls.assert_called_once()
+
+
+def test_prepare_model_uses_canonical_family_architecture():
+    source_arch = "FutureQwen35MoeForConditionalGeneration"
+    canonical_arch = "Qwen3_5MoeForConditionalGeneration"
+    fake_atom_config = _Obj(plugin_config=_Obj(is_plugin_mode=True))
+    fake_register, _fake_model, fake_model_cls = _make_fake_register_module(
+        canonical_arch
+    )
+    fake_config_mod = MagicMock()
+    fake_config_mod.generate_atom_config_for_plugin_mode = MagicMock(
+        return_value=fake_atom_config
+    )
+    prepare_config = MagicMock()
+    model_spec = _Obj(
+        prepare_config=prepare_config,
+        prepare_draft_model_config=None,
+        construction_context=None,
+    )
+    fake_runtime_mod = ModuleType("atom.plugin.sglang.runtime")
+    fake_runtime_mod.resolve_model_arch_spec = MagicMock(
+        return_value=(canonical_arch, model_spec)
+    )
+
+    config = _Obj(architectures=[source_arch], model_type="qwen3_5_moe")
+    with patch.dict(
+        sys.modules,
+        {
+            "atom.plugin.register": fake_register,
+            "atom.plugin.config": fake_config_mod,
+            "atom.plugin.sglang.runtime": fake_runtime_mod,
+            "atom.plugin.sglang.graph_capture_patch": MagicMock(
+                apply_graph_capture_patch=MagicMock()
+            ),
+        },
+    ):
+        sglang_prepare.prepare_model(config=config)
+
+    fake_runtime_mod.resolve_model_arch_spec.assert_called_once_with(config)
+    prepare_config.assert_called_once_with(fake_atom_config, canonical_arch)
     fake_model_cls.assert_called_once()

--- a/tests/plugin/test_sglang_register.py
+++ b/tests/plugin/test_sglang_register.py
@@ -375,3 +375,28 @@ def test_register_custom_attention_uses_aiter_name():
     assert recorded["backend_name"] == "aiter"
     assert isinstance(backend, _FakeBackend)
     assert backend.runner == "runner"
+
+
+def test_sglang_plugin_registration_does_not_require_kimi_k3_pool_modules():
+    from atom.plugin.sglang import register
+
+    register_processor = MagicMock()
+    apply_load_config_patch = MagicMock()
+
+    with (
+        patch.object(register, "_install_model_config_quant_patch"),
+        patch.object(register, "_install_loader_quant_patch"),
+        patch.dict(sys.modules, {"atom.plugin.sglang.kimi_k3_bridge": None}),
+        patch(
+            "atom.plugin.sglang.models.kimi_k3_processor.register_kimi_k3_text_only_processor",
+            register_processor,
+        ),
+        patch(
+            "atom.plugin.sglang.runtime.apply_load_config_patch",
+            apply_load_config_patch,
+        ),
+    ):
+        register.register_plugin()
+
+    register_processor.assert_called_once_with()
+    apply_load_config_patch.assert_called_once_with()


### PR DESCRIPTION
## Motivation

Enable Kimi K3 at sglang plugin side

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Attention kernel path


| Layer | Stage | Native ATOM kernel | K3 SGLang plugin | Status |
|---|---|---|---|---|
| KDA | Prefill / extend | `causal_conv1d_fn` → FLA `chunk_kda` | Same ATOM `KimiKDAAttention` | Aligned |
| KDA | Decode | `causal_conv1d_update` → `fused_sigmoid_gating_delta_rule_update` | Same ATOM path; plugin maps SGLang state slots | Aligned |
| MLA | Fresh prefill | `fused_qk_rope_concat_and_cache_mla` → `flash_attn_varlen_func` | Same ATOM `MLAAttention` | Aligned |
| MLA | Eager decode | Fused Q/RoPE/cache → AITER `mla_decode_fwd` | Same kernel; plugin provides CSR KV metadata | Aligned |
| MLA | CUDA graph decode | AITER `mla_decode_fwd` | Same kernel; graph-stable CSR and persistent-worker metadata | Aligned |
| MLA | FP8 KV decode | FP8 Q + FP8 KV `mla_decode_fwd` | Plugin explicitly produces FP8 Q to match the ABI | Aligned |
| MLA | Prefix-cache prefill | ATOM cache-aware Flash prefill | Bridge always sets `has_cached=False` | Not aligned; inactive while radix cache is disabled |
| KDA / MLA | MTP / speculative verify | KDA core has a speculative delta-rule path | No complete K3 draft / `TARGET_VERIFY` / `DRAFT_EXTEND` integration | Unsupported |

Core conclusion: all proven no-spec prefill, decode, and CUDA-graph decode paths execute ATOM model-side attention kernels. SGLang owns scheduling, KV-pool allocation, and metadata translation only.



<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result


<img width="879" height="205" alt="image" src="https://github.com/user-attachments/assets/940248b8-ab69-4955-8ced-4aed94877750" />


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
