### PR TITLE
[fix](rccl): fix rccl compile path for new docker

### DIFF
--- a/docker/atom_release.dockerfile
+++ b/docker/atom_release.dockerfile
@@ -32,6 +32,17 @@ RUN pip install --upgrade pip && \
         libpci-dev cmake libdw1 locales && \
     rm -rf /var/lib/apt/lists/*
 
+# Newer rocm/pytorch images install ROCm libraries through Python wheels
+# instead of /opt/rocm. Register those directories so dpkg-shlibdeps can
+# resolve RCCL's dependencies while retaining compatibility with /opt/rocm.
+RUN ROCM_SDK_LIB_DIRS="$(python -c \
+        'import glob, os; print("\n".join(sorted({os.path.dirname(p) for p in glob.glob("/opt/venv/lib/python*/site-packages/_rocm_sdk*/lib/*.so*")})))')" && \
+    if [ -n "${ROCM_SDK_LIB_DIRS}" ]; then \
+        printf '%s\n' "${ROCM_SDK_LIB_DIRS}" \
+            > /etc/ld.so.conf.d/rocm-python-sdk.conf; \
+        ldconfig; \
+    fi
+
 # --------------------------------------------------------------------
 # Stage 1: RCCL — parallel
 # --------------------------------------------------------------------
@@ -220,6 +231,8 @@ ARG LMCACHE_TAG=v0.4.5
 # PYTORCH_ROCM_ARCH is inherited as ENV from the `base` stage (=${GPU_ARCH});
 # hipcc reads it to target both gfx942 and gfx950. Do not re-derive from
 # ${GPU_ARCH} here — ARG does not cross FROM so it would be empty in this stage.
+# Docker builds do not expose a GPU, so LMCache's torch.cuda.is_available()
+# backend predicate is overridden only in the validation process below.
 RUN echo "========== [ATOM] LMCache HIP c_ops (${LMCACHE_TAG}, arch=${PYTORCH_ROCM_ARCH}) ==========" && \
     git clone https://github.com/LMCache/LMCache.git /opt/LMCache && \
     cd /opt/LMCache && git checkout ${LMCACHE_TAG} && \
@@ -228,7 +241,11 @@ RUN echo "========== [ATOM] LMCache HIP c_ops (${LMCACHE_TAG}, arch=${PYTORCH_RO
       "${VENV_PYTHON}" -m pip install -e . --no-build-isolation --no-deps && \
     "${VENV_PYTHON}" -m pip install --no-deps \
         prometheus_client==0.25.0 aiofile==3.11.1 caio==0.9.25 && \
-    "${VENV_PYTHON}" -c "import torch, lmcache, lmcache.c_ops; \
+    "${VENV_PYTHON}" -c "import glob, torch; \
+c_ops_paths = glob.glob('/opt/LMCache/lmcache/c_ops*.so'); \
+assert c_ops_paths, 'LMCache HIP c_ops extension was not built'; \
+torch.cuda.is_available = lambda: True; \
+import lmcache, lmcache.c_ops; \
 from lmcache.v1.cache_engine import LMCacheEngineBuilder; \
 from lmcache.v1.memory_management import MemoryFormat; \
 from lmcache.v1.lookup_client.factory import LookupClientFactory; \


### PR DESCRIPTION
## Motivation

Handle the ROCm library path change from /opt/rocm(torch2.10) to Python wheel directories(torch2.13) and register them so dpkg-shlibdeps can resolve RCCL dependencies.