### PR TITLE
[SGL+ATOM]ci(sglang): use baked ATOM for scheduled benchmarks

### DIFF
--- a/.github/scripts/atom_sglang_test.sh
+++ b/.github/scripts/atom_sglang_test.sh
@@ -72,6 +72,10 @@ fi
 
 prepare_runtime_paths() {
   local path_prefix=""
+  local use_workspace_atom="false"
+  case "${ATOM_BENCH_USE_WORKSPACE_ATOM:-true}" in
+    true|TRUE|1|yes|YES|on|ON) use_workspace_atom="true" ;;
+  esac
   if [[ -d /app/aiter-test ]]; then
     path_prefix="/app/aiter-test"
   fi
@@ -79,9 +83,14 @@ prepare_runtime_paths() {
     path_prefix="${path_prefix:+${path_prefix}:}/app/sglang/python"
   fi
   if [[ -d /workspace ]]; then
-    # The CI checkout is mounted at /workspace; prefer it over the ATOM copy
-    # baked into the base image so validation covers the current branch.
-    path_prefix="${path_prefix:+${path_prefix}:}/workspace"
+    # Manual and rebuild runs validate the selected checkout. Scheduled
+    # prebuilt nightly runs use the ATOM copy baked into the Docker image so
+    # the benchmark data is reproducible from that image alone.
+    if [[ "${use_workspace_atom}" == "true" ]]; then
+      path_prefix="${path_prefix:+${path_prefix}:}/workspace"
+    elif [[ -d /app/ATOM ]]; then
+      path_prefix="${path_prefix:+${path_prefix}:}/app/ATOM"
+    fi
     cd /workspace
   elif [[ -d /app/ATOM ]]; then
     path_prefix="${path_prefix:+${path_prefix}:}/app/ATOM"

--- a/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
@@ -44,6 +44,9 @@ on:
       atom_source_sha_for_checkout:
         required: true
         type: string
+      use_workspace_atom:
+        required: true
+        type: string
 
 jobs:
   benchmark:
@@ -80,6 +83,7 @@ jobs:
       BENCH_SERVING_REPO_URL: https://github.com/kimbochen/bench_serving.git
       ATOM_SOURCE_REPOSITORY: ${{ inputs.atom_repository }}
       ATOM_SOURCE_REF: ${{ inputs.atom_ref }}
+      ATOM_BENCH_USE_WORKSPACE_ATOM: ${{ inputs.use_workspace_atom }}
       SGLANG_REF_USED: ${{ inputs.selected_sglang_ref }}
       SGLANG_VERSION_USED: ${{ inputs.selected_sglang_version }}
       PUBLISH_TO_DASHBOARD: ${{ inputs.publish_to_dashboard }}
@@ -178,6 +182,11 @@ jobs:
           SOURCE_SHA="$(git rev-parse HEAD)"
           echo "ATOM_SOURCE_SHA=${SOURCE_SHA}" >> "$GITHUB_ENV"
           echo "Benchmarking ${ATOM_SOURCE_REPOSITORY}@${ATOM_SOURCE_REF} (${SOURCE_SHA}) with ${SGLANG_IMAGE_SOURCE} image ${SGLANG_IMAGE_TAG}"
+          if [[ "${ATOM_BENCH_USE_WORKSPACE_ATOM}" == "true" ]]; then
+            echo "ATOM runtime source: workspace checkout"
+          else
+            echo "ATOM runtime source: baked Docker image"
+          fi
 
       - name: Container Engine Login
         run: |
@@ -328,6 +337,7 @@ jobs:
             --ulimit stack=67108864 \
             --env-file "${OOT_ENV_FILE}" \
             -e HF_TOKEN="${HF_TOKEN:-}" \
+            -e ATOM_BENCH_USE_WORKSPACE_ATOM="${ATOM_BENCH_USE_WORKSPACE_ATOM}" \
             --name "$CONTAINER_NAME" \
             --entrypoint /bin/bash \
             "${SGLANG_IMAGE_REF:-${SGLANG_IMAGE_TAG}}" \
@@ -545,6 +555,7 @@ jobs:
             -e ATOM_SOURCE_REPOSITORY="${ATOM_SOURCE_REPOSITORY}" \
             -e ATOM_SOURCE_REF="${ATOM_SOURCE_REF}" \
             -e ATOM_SOURCE_SHA="${ATOM_SOURCE_SHA}" \
+            -e ATOM_BENCH_USE_WORKSPACE_ATOM="${ATOM_BENCH_USE_WORKSPACE_ATOM}" \
             -e SGLANG_REF_USED="${SGLANG_REF_USED}" \
             -e SGLANG_VERSION_USED="${SGLANG_VERSION_USED}" \
             -e SGLANG_IMAGE_SOURCE="${SGLANG_IMAGE_SOURCE}" \
@@ -595,6 +606,11 @@ jobs:
           data["atom_source_repository"] = os.environ.get("ATOM_SOURCE_REPOSITORY", "")
           data["atom_source_ref"] = os.environ.get("ATOM_SOURCE_REF", "")
           data["atom_source_sha"] = os.environ.get("ATOM_SOURCE_SHA", "")
+          data["atom_runtime_source"] = (
+              "workspace"
+              if os.environ.get("ATOM_BENCH_USE_WORKSPACE_ATOM", "true").lower() == "true"
+              else "baked-image"
+          )
           data["sglang_ref"] = os.environ.get("SGLANG_REF_USED", "")
           data["sglang_version"] = os.environ.get("SGLANG_VERSION_USED", "")
           data["sglang_image_source"] = os.environ.get("SGLANG_IMAGE_SOURCE", "")

--- a/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
+++ b/.github/workflows/atom-sglang-benchmark-gpu-shard.yaml
@@ -182,11 +182,6 @@ jobs:
           SOURCE_SHA="$(git rev-parse HEAD)"
           echo "ATOM_SOURCE_SHA=${SOURCE_SHA}" >> "$GITHUB_ENV"
           echo "Benchmarking ${ATOM_SOURCE_REPOSITORY}@${ATOM_SOURCE_REF} (${SOURCE_SHA}) with ${SGLANG_IMAGE_SOURCE} image ${SGLANG_IMAGE_TAG}"
-          if [[ "${ATOM_BENCH_USE_WORKSPACE_ATOM}" == "true" ]]; then
-            echo "ATOM runtime source: workspace checkout"
-          else
-            echo "ATOM runtime source: baked Docker image"
-          fi
 
       - name: Container Engine Login
         run: |
@@ -606,11 +601,6 @@ jobs:
           data["atom_source_repository"] = os.environ.get("ATOM_SOURCE_REPOSITORY", "")
           data["atom_source_ref"] = os.environ.get("ATOM_SOURCE_REF", "")
           data["atom_source_sha"] = os.environ.get("ATOM_SOURCE_SHA", "")
-          data["atom_runtime_source"] = (
-              "workspace"
-              if os.environ.get("ATOM_BENCH_USE_WORKSPACE_ATOM", "true").lower() == "true"
-              else "baked-image"
-          )
           data["sglang_ref"] = os.environ.get("SGLANG_REF_USED", "")
           data["sglang_version"] = os.environ.get("SGLANG_VERSION_USED", "")
           data["sglang_image_source"] = os.environ.get("SGLANG_IMAGE_SOURCE", "")

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -346,6 +346,7 @@ jobs:
       publish_to_dashboard: ${{ steps.resolve.outputs.publish_to_dashboard }}
       upload_to_custom_dashboard: ${{ steps.resolve.outputs.upload_to_custom_dashboard }}
       workload_label: ${{ steps.resolve.outputs.workload_label }}
+      use_workspace_atom: ${{ steps.resolve.outputs.use_workspace_atom }}
     steps:
       - name: Checkout selected branch
         uses: actions/checkout@v6
@@ -377,6 +378,7 @@ jobs:
           REBUILD_SGLANG_IMAGE=false
           SGLANG_IMAGE_SOURCE="prebuilt"
           USER_PROVIDED_SGLANG_IMAGE=false
+          USE_WORKSPACE_ATOM=true
           RESOLVED_PREBUILT_ALIAS=""
           RESOLVED_PREBUILT_DIGEST=""
           PREBUILT_RESOLUTION_TYPE=""
@@ -388,6 +390,7 @@ jobs:
           elif [[ "${GITHUB_EVENT_NAME}" == "schedule" && "${NORMALIZED_REF}" == "main" && -n "${SCHEDULED_SGLANG_IMAGE}" ]]; then
             PREBUILT_SGLANG_IMAGE="${SCHEDULED_SGLANG_IMAGE}"
             SGLANG_IMAGE_SOURCE="prebuilt-scheduled-nightly"
+            USE_WORKSPACE_ATOM=false
             RESOLVED_PREBUILT_ALIAS="rocm/atom-dev:${SCHEDULED_SGLANG_TAG}"
             RESOLVED_PREBUILT_DIGEST="${SCHEDULED_SGLANG_DIGEST}"
             PREBUILT_RESOLUTION_TYPE="${SCHEDULED_SGLANG_RESOLUTION:-scheduled-nightly-tag}"
@@ -487,12 +490,18 @@ jobs:
             echo "publish_to_dashboard=${PUBLISH_TO_DASHBOARD}"
             echo "upload_to_custom_dashboard=${UPLOAD_TO_CUSTOM_DASHBOARD}"
             echo "workload_label=${WORKLOAD_LABEL}"
+            echo "use_workspace_atom=${USE_WORKSPACE_ATOM}"
           } >> "$GITHUB_OUTPUT"
 
           printf '### SGLang benchmark source\n- Repository: `%s`\n- Ref: `%s`\n- Image mode: `%s`\n' \
             "${ATOM_REPOSITORY}" \
             "${ATOM_REF}" \
             "${SGLANG_IMAGE_SOURCE}" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${USE_WORKSPACE_ATOM}" == "true" ]]; then
+            printf -- '- ATOM runtime source: `workspace checkout`\n' >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf -- '- ATOM runtime source: `baked Docker image`\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           if [[ "${USER_PROVIDED_SGLANG_IMAGE}" == "true" ]]; then
             printf -- '- User-provided image: `%s`\n- Expected SGLang version: `%s`\n- Expected SGLang commit: `%s`\n' \
@@ -1108,6 +1117,7 @@ jobs:
       selected_sglang_version: ${{ needs.resolve-atom-source.outputs.selected_sglang_version }}
       publish_to_dashboard: ${{ needs.resolve-atom-source.outputs.publish_to_dashboard }}
       upload_to_custom_dashboard: ${{ needs.resolve-atom-source.outputs.upload_to_custom_dashboard }}
+      use_workspace_atom: ${{ needs.resolve-atom-source.outputs.use_workspace_atom }}
       sglang_image_tag: ${{ needs.build-sglang-image.outputs.sglang_image_tag || needs.resolve-atom-source.outputs.prebuilt_sglang_image }}
       atom_source_sha_for_checkout: ${{ needs.build-sglang-image.outputs.atom_source_sha || github.sha }}
 
@@ -1137,6 +1147,7 @@ jobs:
       selected_sglang_version: ${{ needs.resolve-atom-source.outputs.selected_sglang_version }}
       publish_to_dashboard: ${{ needs.resolve-atom-source.outputs.publish_to_dashboard }}
       upload_to_custom_dashboard: ${{ needs.resolve-atom-source.outputs.upload_to_custom_dashboard }}
+      use_workspace_atom: ${{ needs.resolve-atom-source.outputs.use_workspace_atom }}
       sglang_image_tag: ${{ needs.build-sglang-image.outputs.sglang_image_tag || needs.resolve-atom-source.outputs.prebuilt_sglang_image }}
       atom_source_sha_for_checkout: ${{ needs.build-sglang-image.outputs.atom_source_sha || github.sha }}
 

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -497,11 +497,6 @@ jobs:
             "${ATOM_REPOSITORY}" \
             "${ATOM_REF}" \
             "${SGLANG_IMAGE_SOURCE}" >> "$GITHUB_STEP_SUMMARY"
-          if [[ "${USE_WORKSPACE_ATOM}" == "true" ]]; then
-            printf -- '- ATOM runtime source: `workspace checkout`\n' >> "$GITHUB_STEP_SUMMARY"
-          else
-            printf -- '- ATOM runtime source: `baked Docker image`\n' >> "$GITHUB_STEP_SUMMARY"
-          fi
 
           if [[ "${USER_PROVIDED_SGLANG_IMAGE}" == "true" ]]; then
             printf -- '- User-provided image: `%s`\n- Expected SGLang version: `%s`\n- Expected SGLang commit: `%s`\n' \


### PR DESCRIPTION
## Summary
- Run scheduled main SGLang benchmark jobs with the ATOM code baked into the selected prebuilt nightly Docker image.
- Keep manual dispatch and rebuild flows using the selected workspace checkout so users can still benchmark a chosen branch/ref against a Docker image.
- Pass a minimal runtime-source switch through the main workflow, shard workflow, and container script to select `/workspace` or `/app/ATOM`.

## Test plan
- `git diff --check`
- `npx --yes js-yaml .github/workflows/atom-sglang-benchmark.yaml > $null`
- `npx --yes js-yaml .github/workflows/atom-sglang-benchmark-gpu-shard.yaml > $null`
- `bash -n .github/scripts/atom_sglang_test.sh`