### PR TITLE
[fix](pytorch): fix dynamo args in torch2.13

### DIFF
--- a/atom/utils/decorators.py
+++ b/atom/utils/decorators.py
@@ -564,10 +564,14 @@ def _support_torch_compile(
             # during Dynamo tracing, and their corresponding files
             inline_call = InliningInstructionTranslator.inline_call
 
-            def patched_inline_call(parent, func, args, kwargs):
+            def patched_inline_call(
+                parent, func, args, kwargs, *inline_args, **inline_kwargs
+            ):
                 code = func.get_code()
                 self.vllm_config.compilation_config.traced_files.add(code.co_filename)
-                return inline_call(parent, func, args, kwargs)
+                return inline_call(
+                    parent, func, args, kwargs, *inline_args, **inline_kwargs
+                )
 
             with patch.object(
                 InliningInstructionTranslator, "inline_call", patched_inline_call


### PR DESCRIPTION
## Motivation

PyTorch 2.13 added the allow_nested_graph_breaks argument to Dynamo’s inline_call. ATOM’s wrapper did not accept it, causing a TypeError. The fix forwards additional positional and keyword arguments to maintain compatibility across PyTorch versions.
