### PR TITLE
[gfx1250] Route wo_a grouped LoRA through the flydsl a8w4 batched GEMM

### DIFF
--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2561,14 +2561,8 @@ class DeepseekV4Attention(nn.Module):
         # Cached at construction (non-compiled) so `_attn_post` — now traced into
         # the graphed dense piece — doesn't graph-break on a runtime get_gfx().
         self._is_gfx1250 = get_gfx() == "gfx1250"
-        # Route wo_a (grouped output LoRA) through the flydsl strided-batched
-        # a8w4 kernel instead of the BF16 batched GEMM / einsum. gfx1250-only;
-        # gated by ATOM_WO_A_USE_FLYDSL (default "never"). The a8w4 weight +
-        # scale buffers are prepared once in process_weights_after_loading.
-        self._use_flydsl_wo_a = self._is_gfx1250 and envs.ATOM_WO_A_USE_FLYDSL in (
-            "auto",
-            "always",
-        )
+        # gfx1250-only; ATOM_WO_A_USE_FLYDSL=1 selects flydsl a8w4 wo_a GEMM.
+        self._use_flydsl_wo_a = self._is_gfx1250 and envs.ATOM_WO_A_USE_FLYDSL
         self.wo_a_fp4 = None  # [B, N//16, (K//2)*16] uint8 MXFP4 codes (shuffled)
         self.wo_a_wscale = None  # [B, N//32, (K//32)*32] uint8 e8m0 n32k4
         self._is_gfx950 = get_gfx() == "gfx950"
@@ -2695,8 +2689,6 @@ class DeepseekV4Attention(nn.Module):
 
         w = self.wo_a.weight
         if w.dtype == torch.bfloat16:
-            # Already BF16 on disk (e.g. V4-Flash-FP8) — still build the a8w4
-            # buffers from it when the flydsl wo_a path is enabled.
             self._maybe_build_wo_a_a8w4(w.data)
             return  # already dequanted
         scale = getattr(self.wo_a, "weight_scale", None)
@@ -2766,18 +2758,10 @@ class DeepseekV4Attention(nn.Module):
         # subsequent LinearBase post-load a no-op for wo_a.
         self.wo_a.quant_type = QuantType.No
         self.wo_a.need_normalize_e4m3fn_to_e4m3fnuz = False
-        # Build the flydsl a8w4 (MXFP4 codes + n32k4 e8m0 scale) buffers from the
-        # freshly-dequanted BF16 weight when the flydsl wo_a path is enabled.
         self._maybe_build_wo_a_a8w4(bf16)
 
     def _maybe_build_wo_a_a8w4(self, wo_a_bf16: torch.Tensor) -> None:
-        """Quantize + preshuffle wo_a to the flydsl a8w4 kernel layout (once).
-
-        ``wo_a_bf16`` is the [n_groups*o_lora_rank, in_per_group] BF16 weight.
-        Reshaped to [B=n_local_groups, N=o_lora_rank, K=in_per_group] and turned
-        into (MXFP4 codes, e8m0 n32k4 scale) stored on ``self.wo_a_fp4`` /
-        ``self.wo_a_wscale``. No-op unless ``self._use_flydsl_wo_a``.
-        """
+        """Preshuffle wo_a BF16 to flydsl a8w4 layout; no-op if disabled."""
         if not self._use_flydsl_wo_a:
             return
         from aiter.ops.flydsl.batched_gemm_mxfp4 import preshuffle_a8w4_weight_mbn
@@ -3043,10 +3027,6 @@ class DeepseekV4Attention(nn.Module):
         )
         o = o.view(num_tokens, self.n_local_groups, -1)  # [M, B(groups), K]
         if self._use_flydsl_wo_a and self.wo_a_fp4 is not None:
-            # a8w4 path: quantize the attention output to MXFP8 (ADDED pre-quant)
-            # then run the flydsl strided-batched a8w4 GEMM against the
-            # preshuffled MXFP4 wo_a. Output stays BF16 -> wo_b's own input quant
-            # (per-128 blockscale FP8) after this is unchanged.
             a_fp8, a_scales = quant_act_mxfp8_mbn(o)  # [M,B,K], [M//32,B,(K//32)*32]
             y = flydsl_batched_gemm_a8w4_v2(
                 a_fp8,

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -42,6 +42,10 @@ from aiter.dist.parallel_state import (
 )
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.batched_gemm_op_a8w8 import batched_gemm_a8w8_mxscale
+from aiter.ops.flydsl.batched_gemm_mxfp4 import (
+    flydsl_batched_gemm_a8w4_v2,
+    quant_act_mxfp8_mbn,
+)
 from aiter.ops.inverse_rope_group_quant import inverse_rope_group_quant
 from aiter.ops.topk import top_k_per_row_decode, top_k_per_row_prefill
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
@@ -2557,6 +2561,16 @@ class DeepseekV4Attention(nn.Module):
         # Cached at construction (non-compiled) so `_attn_post` — now traced into
         # the graphed dense piece — doesn't graph-break on a runtime get_gfx().
         self._is_gfx1250 = get_gfx() == "gfx1250"
+        # Route wo_a (grouped output LoRA) through the flydsl strided-batched
+        # a8w4 kernel instead of the BF16 batched GEMM / einsum. gfx1250-only;
+        # gated by ATOM_WO_A_USE_FLYDSL (default "never"). The a8w4 weight +
+        # scale buffers are prepared once in process_weights_after_loading.
+        self._use_flydsl_wo_a = self._is_gfx1250 and envs.ATOM_WO_A_USE_FLYDSL in (
+            "auto",
+            "always",
+        )
+        self.wo_a_fp4 = None  # [B, N//16, (K//2)*16] uint8 MXFP4 codes (shuffled)
+        self.wo_a_wscale = None  # [B, N//32, (K//32)*32] uint8 e8m0 n32k4
         self._is_gfx950 = get_gfx() == "gfx950"
         # Flipped by process_weights_after_loading when wo_a is eligible for the
         # mxscale BMM; off means the BF16 grouped-LoRA path.
@@ -2681,6 +2695,9 @@ class DeepseekV4Attention(nn.Module):
 
         w = self.wo_a.weight
         if w.dtype == torch.bfloat16:
+            # Already BF16 on disk (e.g. V4-Flash-FP8) — still build the a8w4
+            # buffers from it when the flydsl wo_a path is enabled.
+            self._maybe_build_wo_a_a8w4(w.data)
             return  # already dequanted
         scale = getattr(self.wo_a, "weight_scale", None)
         if w.dtype not in (torch.float8_e4m3fn, torch.float8_e4m3fnuz) or scale is None:
@@ -2749,6 +2766,26 @@ class DeepseekV4Attention(nn.Module):
         # subsequent LinearBase post-load a no-op for wo_a.
         self.wo_a.quant_type = QuantType.No
         self.wo_a.need_normalize_e4m3fn_to_e4m3fnuz = False
+        # Build the flydsl a8w4 (MXFP4 codes + n32k4 e8m0 scale) buffers from the
+        # freshly-dequanted BF16 weight when the flydsl wo_a path is enabled.
+        self._maybe_build_wo_a_a8w4(bf16)
+
+    def _maybe_build_wo_a_a8w4(self, wo_a_bf16: torch.Tensor) -> None:
+        """Quantize + preshuffle wo_a to the flydsl a8w4 kernel layout (once).
+
+        ``wo_a_bf16`` is the [n_groups*o_lora_rank, in_per_group] BF16 weight.
+        Reshaped to [B=n_local_groups, N=o_lora_rank, K=in_per_group] and turned
+        into (MXFP4 codes, e8m0 n32k4 scale) stored on ``self.wo_a_fp4`` /
+        ``self.wo_a_wscale``. No-op unless ``self._use_flydsl_wo_a``.
+        """
+        if not self._use_flydsl_wo_a:
+            return
+        from aiter.ops.flydsl.batched_gemm_mxfp4 import preshuffle_a8w4_weight_mbn
+
+        w = wo_a_bf16.view(self.n_local_groups, self.o_lora_rank, -1).contiguous()
+        w_codes, w_scales = preshuffle_a8w4_weight_mbn(w.to(torch.bfloat16))
+        self.wo_a_fp4 = w_codes
+        self.wo_a_wscale = w_scales
 
     def maybe_compressors_async(
         self, x, plan, state_slot_in, state_slot_out, block_tables
@@ -3004,7 +3041,23 @@ class DeepseekV4Attention(nn.Module):
             self.rope_head_dim,
             prefix=f"{self.layer_name}.inverse_rope",
         )
-        o = o.view(num_tokens, self.n_local_groups, -1)
+        o = o.view(num_tokens, self.n_local_groups, -1)  # [M, B(groups), K]
+        if self._use_flydsl_wo_a and self.wo_a_fp4 is not None:
+            # a8w4 path: quantize the attention output to MXFP8 (ADDED pre-quant)
+            # then run the flydsl strided-batched a8w4 GEMM against the
+            # preshuffled MXFP4 wo_a. Output stays BF16 -> wo_b's own input quant
+            # (per-128 blockscale FP8) after this is unchanged.
+            a_fp8, a_scales = quant_act_mxfp8_mbn(o)  # [M,B,K], [M//32,B,(K//32)*32]
+            y = flydsl_batched_gemm_a8w4_v2(
+                a_fp8,
+                self.wo_a_fp4,
+                a_scales,
+                self.wo_a_wscale,
+                N=self.o_lora_rank,
+                dtype=o.dtype,
+                layout="mbn",
+            )  # [B, M, N] view of a [M, B, N] physical buffer
+            return y.transpose(0, 1)  # -> [M, B, N]
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
         if num_tokens <= 32 or self._is_gfx1250:
             y = torch.empty(

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1080,6 +1080,13 @@ class _V4RoPE(nn.Module):
                 nope_first=False,
             )
 
+    def cos_sin_2d(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """2D ``[max_pos, rd//2]`` cos/sin for ops that take the flat cache."""
+        return (
+            self.cos_cache.squeeze(-2).squeeze(-2),
+            self.sin_cache.squeeze(-2).squeeze(-2),
+        )
+
     def inverse(
         self,
         positions: torch.Tensor,
@@ -2565,6 +2572,8 @@ class DeepseekV4Attention(nn.Module):
         self._use_flydsl_wo_a = self._is_gfx1250 and envs.ATOM_WO_A_USE_FLYDSL
         self.wo_a_fp4 = None  # [B, N//16, (K//2)*16] uint8 MXFP4 codes (shuffled)
         self.wo_a_wscale = None  # [B, N//32, (K//32)*32] uint8 e8m0 n32k4
+        # (a_fp8, a_scales) from inverse_rope_group_quant, consumed by _wo_a_grouped_lora.
+        self._wo_a_prefused: tuple[torch.Tensor, torch.Tensor] | None = None
         self._is_gfx950 = get_gfx() == "gfx950"
         # Flipped by process_weights_after_loading when wo_a is eligible for the
         # mxscale BMM; off means the BF16 grouped-LoRA path.
@@ -2974,6 +2983,31 @@ class DeepseekV4Attention(nn.Module):
         group-quant, and keeps the attention halves free of wo_a path knowledge.
         """
         num_tokens = o.size(0)
+        out_dtype = o.dtype
+        if self._use_flydsl_wo_a and self.wo_a_fp4 is not None:
+            # a8w4 path: MXFP8 activation + flydsl strided-batched a8w4 GEMM against
+            # the preshuffled MXFP4 wo_a. When inverse_rope_group_quant ran in
+            # _attn_core, its (a_fp8, a_scales) are stashed in _wo_a_prefused;
+            # otherwise fall back to quant_act_mxfp8_mbn (no inverse RoPE fused).
+            prefused = self._wo_a_prefused
+            if prefused is not None:
+                a_fp8, a_scales = prefused
+                self._wo_a_prefused = None
+            else:
+                o_mbn = o.view(num_tokens, self.n_local_groups, -1)
+                a_fp8, a_scales = quant_act_mxfp8_mbn(o_mbn)
+            y = flydsl_batched_gemm_a8w4_v2(
+                a_fp8,
+                self.wo_a_fp4,
+                a_scales,
+                self.wo_a_wscale,
+                N=self.o_lora_rank,
+                dtype=out_dtype,
+                layout="mbn",
+            )  # [B, M, N] view of a [M, B, N] physical buffer
+            # transpose back to the physical [M, B, N] (contiguous) and flatten
+            # to the 2-D [M, B*N] wo_b expects, like the BF16 paths below.
+            return y.transpose(0, 1).flatten(1)
         if self._wo_a_mxscale:
             # `inverse_rope_group_quant` fuses the output inverse RoPE into the
             # per-token e8m0 group-quant, saving a bf16 round trip. The output
@@ -3026,18 +3060,6 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{self.layer_name}.inverse_rope",
         )
         o = o.view(num_tokens, self.n_local_groups, -1)  # [M, B(groups), K]
-        if self._use_flydsl_wo_a and self.wo_a_fp4 is not None:
-            a_fp8, a_scales = quant_act_mxfp8_mbn(o)  # [M,B,K], [M//32,B,(K//32)*32]
-            y = flydsl_batched_gemm_a8w4_v2(
-                a_fp8,
-                self.wo_a_fp4,
-                a_scales,
-                self.wo_a_wscale,
-                N=self.o_lora_rank,
-                dtype=o.dtype,
-                layout="mbn",
-            )  # [B, M, N] view of a [M, B, N] physical buffer
-            return y.transpose(0, 1)  # -> [M, B, N]
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
         if num_tokens <= 32 or self._is_gfx1250:
             y = torch.empty(
@@ -3524,9 +3546,23 @@ class DeepseekV4Attention(nn.Module):
                 prefix=f"{self.layer_name}.swa_write",
             )
 
-        # `o` is returned un-inverse-RoPE'd: `_wo_a_grouped_lora` removes the
-        # absolute-position contribution the value-side RoPE carried in, on both
-        # paths, so the positions travel downstream instead.
+        # gfx1250 a8w4 wo_a: fuse inverse RoPE + n32k4 MXFP8 group quant here so
+        # _wo_a_grouped_lora can feed flydsl_batched_gemm_a8w4_v2 directly.
+        # Other paths return `o` un-inverse-RoPE'd; `_wo_a_grouped_lora` handles
+        # inverse RoPE (mxscale fusion or plain inverse) downstream.
+        if self._use_flydsl_wo_a and self.wo_a_fp4 is not None:
+            cos, sin = self.rotary_emb.cos_sin_2d()
+            self._wo_a_prefused = inverse_rope_group_quant(
+                o,
+                positions,
+                cos,
+                sin,
+                self.n_local_groups,
+                quant_group_size=32,
+                scale_layout="n32k4",
+            )
+        else:
+            self._wo_a_prefused = None
         return o.reshape(num_tokens, -1)  # [num_tokens, n_local_heads*head_dim]
 
     def _fill_csa_paged_compress(

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -42,10 +42,7 @@ from aiter.dist.parallel_state import (
 )
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.batched_gemm_op_a8w8 import batched_gemm_a8w8_mxscale
-from aiter.ops.flydsl.batched_gemm_mxfp4 import (
-    flydsl_batched_gemm_a8w4_v2,
-    quant_act_mxfp8_mbn,
-)
+from aiter.ops.flydsl.batched_gemm_mxfp4 import flydsl_batched_gemm_a8w4_v2
 from aiter.ops.inverse_rope_group_quant import inverse_rope_group_quant
 from aiter.ops.topk import top_k_per_row_decode, top_k_per_row_prefill
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
@@ -2572,8 +2569,6 @@ class DeepseekV4Attention(nn.Module):
         self._use_flydsl_wo_a = self._is_gfx1250 and envs.ATOM_WO_A_USE_FLYDSL
         self.wo_a_fp4 = None  # [B, N//16, (K//2)*16] uint8 MXFP4 codes (shuffled)
         self.wo_a_wscale = None  # [B, N//32, (K//32)*32] uint8 e8m0 n32k4
-        # (a_fp8, a_scales) from inverse_rope_group_quant, consumed by _wo_a_grouped_lora.
-        self._wo_a_prefused: tuple[torch.Tensor, torch.Tensor] | None = None
         self._is_gfx950 = get_gfx() == "gfx950"
         # Flipped by process_weights_after_loading when wo_a is eligible for the
         # mxscale BMM; off means the BF16 grouped-LoRA path.
@@ -2978,24 +2973,25 @@ class DeepseekV4Attention(nn.Module):
     ) -> torch.Tensor:
         """Output inverse RoPE + grouped output LoRA.
 
-        `o` arrives un-inverse-RoPE'd from `_sparse_attention` on both paths. Owning the
-        inverse RoPE here is what lets the mxscale branch fuse it into the
-        group-quant, and keeps the attention halves free of wo_a path knowledge.
+        `o` arrives un-inverse-RoPE'd from `_sparse_attention` on all paths. Owning the
+        inverse RoPE here is what lets the flydsl and mxscale branches fuse it into
+        the group-quant, and keeps the attention halves free of wo_a path knowledge.
         """
         num_tokens = o.size(0)
         out_dtype = o.dtype
         if self._use_flydsl_wo_a and self.wo_a_fp4 is not None:
-            # a8w4 path: MXFP8 activation + flydsl strided-batched a8w4 GEMM against
-            # the preshuffled MXFP4 wo_a. When inverse_rope_group_quant ran in
-            # _attn_core, its (a_fp8, a_scales) are stashed in _wo_a_prefused;
-            # otherwise fall back to quant_act_mxfp8_mbn (no inverse RoPE fused).
-            prefused = self._wo_a_prefused
-            if prefused is not None:
-                a_fp8, a_scales = prefused
-                self._wo_a_prefused = None
-            else:
-                o_mbn = o.view(num_tokens, self.n_local_groups, -1)
-                a_fp8, a_scales = quant_act_mxfp8_mbn(o_mbn)
+            H = self.n_local_heads
+            o = o.view(num_tokens, H, self.head_dim)
+            cos, sin = self.rotary_emb.cos_sin_2d()
+            a_fp8, a_scales = inverse_rope_group_quant(
+                o,
+                positions,
+                cos,
+                sin,
+                self.n_local_groups,
+                quant_group_size=32,
+                scale_layout="n32k4",
+            )
             y = flydsl_batched_gemm_a8w4_v2(
                 a_fp8,
                 self.wo_a_fp4,
@@ -3004,9 +3000,7 @@ class DeepseekV4Attention(nn.Module):
                 N=self.o_lora_rank,
                 dtype=out_dtype,
                 layout="mbn",
-            )  # [B, M, N] view of a [M, B, N] physical buffer
-            # transpose back to the physical [M, B, N] (contiguous) and flatten
-            # to the 2-D [M, B*N] wo_b expects, like the BF16 paths below.
+            )
             return y.transpose(0, 1).flatten(1)
         if self._wo_a_mxscale:
             # `inverse_rope_group_quant` fuses the output inverse RoPE into the
@@ -3059,7 +3053,7 @@ class DeepseekV4Attention(nn.Module):
             self.rope_head_dim,
             prefix=f"{self.layer_name}.inverse_rope",
         )
-        o = o.view(num_tokens, self.n_local_groups, -1)  # [M, B(groups), K]
+        o = o.view(num_tokens, self.n_local_groups, -1)
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
         if num_tokens <= 32 or self._is_gfx1250:
             y = torch.empty(
@@ -3546,23 +3540,9 @@ class DeepseekV4Attention(nn.Module):
                 prefix=f"{self.layer_name}.swa_write",
             )
 
-        # gfx1250 a8w4 wo_a: fuse inverse RoPE + n32k4 MXFP8 group quant here so
-        # _wo_a_grouped_lora can feed flydsl_batched_gemm_a8w4_v2 directly.
-        # Other paths return `o` un-inverse-RoPE'd; `_wo_a_grouped_lora` handles
-        # inverse RoPE (mxscale fusion or plain inverse) downstream.
-        if self._use_flydsl_wo_a and self.wo_a_fp4 is not None:
-            cos, sin = self.rotary_emb.cos_sin_2d()
-            self._wo_a_prefused = inverse_rope_group_quant(
-                o,
-                positions,
-                cos,
-                sin,
-                self.n_local_groups,
-                quant_group_size=32,
-                scale_layout="n32k4",
-            )
-        else:
-            self._wo_a_prefused = None
+        # `o` is returned un-inverse-RoPE'd: `_wo_a_grouped_lora` removes the
+        # absolute-position contribution the value-side RoPE carried in, on every
+        # path, so the positions travel downstream instead.
         return o.reshape(num_tokens, -1)  # [num_tokens, n_local_heads*head_dim]
 
     def _fill_csa_paged_compress(

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -99,6 +99,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_FUSED_COMPRESS_USE_FLYDSL": lambda: os.getenv(
         "ATOM_FUSED_COMPRESS_USE_FLYDSL", "auto"
     ).lower(),
+    # wo_a (grouped output LoRA) batched GEMM backend on gfx1250. Default keeps
+    # the proven BF16 Triton/einsum path. "always"/"auto" route it through the
+    # flydsl strided-batched a8w4 kernel (MXFP8 act x MXFP4 wo_a): the attention
+    # output is quantized to MXFP8 before the GEMM (an ADDED pre-quant) and the
+    # existing wo_b input quant after it is unchanged. This trades a few-percent
+    # numeric error for a faster GEMM + halved wo_a weight bandwidth, so validate
+    # accuracy before enabling in prod.
+    "ATOM_WO_A_USE_FLYDSL": lambda: os.getenv("ATOM_WO_A_USE_FLYDSL", "never").lower(),
     # QK-norm-rope-cache-quant fusion for Qwen3 dense and MoE; disabled by default.
     "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION", "0") == "1"

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -99,14 +99,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_FUSED_COMPRESS_USE_FLYDSL": lambda: os.getenv(
         "ATOM_FUSED_COMPRESS_USE_FLYDSL", "auto"
     ).lower(),
-    # wo_a (grouped output LoRA) batched GEMM backend on gfx1250. Default keeps
-    # the proven BF16 Triton/einsum path. "always"/"auto" route it through the
-    # flydsl strided-batched a8w4 kernel (MXFP8 act x MXFP4 wo_a): the attention
-    # output is quantized to MXFP8 before the GEMM (an ADDED pre-quant) and the
-    # existing wo_b input quant after it is unchanged. This trades a few-percent
-    # numeric error for a faster GEMM + halved wo_a weight bandwidth, so validate
-    # accuracy before enabling in prod.
-    "ATOM_WO_A_USE_FLYDSL": lambda: os.getenv("ATOM_WO_A_USE_FLYDSL", "never").lower(),
+    # gfx1250 wo_a grouped LoRA: flydsl a8w4 batched GEMM instead of BF16 einsum.
+    "ATOM_WO_A_USE_FLYDSL": lambda: os.getenv("ATOM_WO_A_USE_FLYDSL", "0") == "1",
     # QK-norm-rope-cache-quant fusion for Qwen3 dense and MoE; disabled by default.
     "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION": lambda: (
         os.getenv("ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION", "0") == "1"


### PR DESCRIPTION
## Summary

Adds an opt-in a8w4 (MXFP8 activation x MXFP4 weight) backend for the DeepSeek-V4 `wo_a` grouped output LoRA on gfx1250, replacing the BF16 batched GEMM / einsum with the flydsl strided-batched kernel (`aiter.ops.flydsl.batched_gemm_mxfp4`).

- New env toggle `ATOM_WO_A_USE_FLYDSL` (default `never`). `auto`/`always` enable the path; it additionally requires gfx1250, so every other target keeps the existing behavior.
- Weight prep once at load time: `process_weights_after_loading` calls the new `_maybe_build_wo_a_a8w4`, which reshapes `wo_a` to `[B=n_local_groups, N=o_lora_rank, K=in_per_group]` and stores the preshuffled MXFP4 codes plus e8m0 n32k4 scale on `self.wo_a_fp4` / `self.wo_a_wscale`. Covers both the FP8-on-disk case (built from the freshly dequanted BF16) and the BF16-on-disk case (e.g. V4-Flash-FP8).
- Forward path: `_wo_a_grouped_lora` quantizes the attention output to MXFP8 via `quant_act_mxfp8_mbn` and runs `flydsl_batched_gemm_a8w4_v2` in `mbn` layout. Output stays BF16, so `wo_b`'s own per-128 blockscale FP8 input quant afterwards is unchanged. The existing BF16 `batched_gemm_bf16` / einsum branches are left intact and still run when the flag is off.

The trade-off is a few-percent numeric error (from the added activation pre-quant) in exchange for a faster GEMM and halved `wo_a` weight bandwidth. That is why the default is off.

Ported from `origin/flydsl_fake_ep4` (commit 6812ef02), which mixed these changes with an unrelated fake single-GPU EP harness; only the batched-GEMM parts are included here, re-based onto current `main` where the wo_a path has since been refactored into `_wo_a_grouped_lora`.

## Test plan

- [ ] Default path unchanged: run existing DeepSeek-V4 correctness/perf jobs without setting `ATOM_WO_A_USE_FLYDSL` and confirm no diff.
- [ ] Non-gfx1250 targets: confirm the new module-level `aiter.ops.flydsl.batched_gemm_mxfp4` import is harmless and the flag stays disabled.
- [ ] gfx1250 accuracy: enable `ATOM_WO_A_USE_FLYDSL=always` 和 compare wo_a output / end-to-end accuracy against the BF16 baseline before considering it for production.
- [ ] gfx1250 perf: measure the wo_a GEMM and end-to-end throughput with the flag on vs. off.
