### PR TITLE
fix(scheduler): unblock decode behind a long chunked prefill

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -387,7 +387,24 @@ class tokenIDProcessor:
         ]
         self.input_ids.copy_to_gpu(total_tokens_prefill)
 
-        self.prev_rejected_num, self.prev_bonus_num = self.recv_mtp_status_async()
+        # `pending_mtp_status_copies` is filled in `postprocess`, which the
+        # pure-middle-chunk / non-last-PP early return in `forward` skips. Popping it
+        # on every step drains it: a chunked prefill that produces no token discards
+        # the status belonging to the previous decode, and the next decode step then
+        # reads an empty queue and gets (None, None). Consume it under the same
+        # predicate that fills it so producer and consumer stay in lockstep.
+        if batch.produces_output():
+            self.prev_rejected_num, self.prev_bonus_num = self.recv_mtp_status_async()
+            if (
+                self.is_deferred_out
+                and self.prev_rejected_num is None
+                and batch.total_seqs_num_decode > 0
+                and not batch.is_dummy_run
+            ):
+                logger.warning(
+                    "MTP status queue was empty on a token-producing decode step; "
+                    "speculative bookkeeping for this step is unreliable."
+                )
 
         # TODO: remove this when we support mixed prefill and decode in one batch
         if total_reqs_prefill > 0:

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -18,6 +18,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
+import os
 import struct
 import threading
 import time
@@ -26,6 +27,15 @@ from collections import deque
 import numpy as np
 
 from atom.config import Config
+
+# --- head-of-line scheduling bounds (see Scheduler.schedule) -----------------
+# Upper bound on how long decode-priority may hold prefill admission back.
+_HOL_STARVE_MS = float(os.environ.get("ATOM_PREFILL_STARVE_MS", "2000"))
+# A partial prefill with more than this many tokens left counts as "large" and may
+# be deferred so that short waiting prefills can be admitted first.
+_HOL_LARGE_TOKENS = int(os.environ.get("ATOM_LARGE_PREFILL_DEFER_TOKENS", "30000"))
+# Upper bound on how long one large prefill resume may be deferred.
+_HOL_DEFER_MS = float(os.environ.get("ATOM_LARGE_PREFILL_DEFER_MS", "2000"))
 from atom.kv_transfer.disaggregation import KVConnectorOutput
 from atom.model_engine.block_manager import BlockManager
 from atom.model_engine.request import RequestOutput
@@ -970,6 +980,21 @@ class Scheduler:
         if not self.running and not self.waiting:
             return None
 
+        # Decode-priority: a chunked prefill occupies the whole token budget for
+        # every tick it runs, so scheduling it ahead of ready decodes stalls every
+        # running sequence for the length of the prompt.  Run decode first and let
+        # the prefill resume on a later tick -- but only while prefill work has not
+        # been held back past `_HOL_STARVE_MS`, otherwise a steady decode load would
+        # block new admissions forever.
+        if (
+            self.running
+            and self._has_decode_ready_seqs()
+            and not self._prefill_admission_starving()
+        ):
+            decode_result = self._try_schedule_decode_priority()
+            if decode_result is not None:
+                return decode_result
+
         # ---- Phase 1: resume partial prefills from running ----
         # Gated by `delayer_allows` so cross-DP alignment still holds when one
         # rank is mid-chunked-prefill: a delayer veto skips both Phase 1 and
@@ -977,12 +1002,26 @@ class Scheduler:
         # when no seq is mid-prefill — the common steady-state decode case —
         # using the counter maintained by postprocess / preempt / finished-removal.
         if delayer_allows and self._partial_prefill_count > 0:
+            # One resume chunk of a long prompt fills the whole batch budget, so a
+            # short prompt queued behind it waits out the rest of that prompt.  Hold
+            # the large resume back for at most `_HOL_DEFER_MS` so the short prompt
+            # is admitted first and reaches decode.
+            defer_large = self._has_small_waiting()
+            now = time.time()
             for seq in self.running:
                 if num_seqs_prefill >= self.max_num_seqs:
                     break
                 if not seq.is_partial_prefill:
                     continue
                 remaining = seq.num_tokens - seq.num_cached_tokens
+                if defer_large and remaining > _HOL_LARGE_TOKENS:
+                    deferred_since = getattr(seq, "hol_deferred_since", None)
+                    if deferred_since is None:
+                        seq.hol_deferred_since = now
+                        continue
+                    if (now - deferred_since) * 1000.0 <= _HOL_DEFER_MS:
+                        continue
+                    # deferred long enough -- resume it on this tick
                 if 0 < self.long_prefill_token_threshold < remaining:
                     remaining = self.long_prefill_token_threshold
                 budget_remaining = self.max_num_batched_tokens - num_batched_tokens
@@ -992,6 +1031,8 @@ class Scheduler:
                 num_batched_tokens += chunk
                 num_seqs_prefill += 1
                 seq.type = SequenceType.PREFILL
+                seq.hol_deferred_since = None
+                seq.hol_decode_parked_since = None
                 scheduled_seqs[seq.id] = seq
                 num_scheduled_tokens.append(chunk)
 
@@ -1236,6 +1277,25 @@ class Scheduler:
             return (prefill_batch, scheduled_seqs)
 
         # --- Decode scheduling ---
+        return self._schedule_decode_batch(park_partial_prefills=False)
+
+    def _schedule_decode_batch(
+        self, *, park_partial_prefills: bool
+    ) -> tuple[ScheduledBatch, dict[int, Sequence]]:
+        """Build a decode-only batch from `self.running`.
+
+        Shared by the decode phase of `schedule()` and by
+        `_try_schedule_decode_priority()`. `schedule()` only reaches its decode
+        phase when no prefill was scheduled, so both callers start from empty
+        accumulators and the batch is decode-only either way.
+
+        `park_partial_prefills` stamps `hol_decode_parked_since` on chunked
+        prefills this loop steps over, which `_prefill_admission_starving()`
+        uses to release them once they have waited long enough.
+        """
+        scheduled_seqs: dict[int, Sequence] = {}
+        num_scheduled_tokens: list[int] = []
+        scheduled_spec_decode_tokens: dict[int, np.ndarray] = {}
         num_seqs_decode = 0
         num_decode_tokens = 0
         tokens_per_decode_seq = self.mtp_k + 1
@@ -1248,11 +1308,18 @@ class Scheduler:
         # they are reconsidered once the head releases them post-postprocess.
         skipped_pp_inflight: list[Sequence] = []
         _pp_block = self._pp_inflight_token_block
+        now = time.time()
         while self.running and num_seqs_decode < self.max_num_seqs:
             if num_decode_tokens + tokens_per_decode_seq > self.max_num_batched_tokens:
                 break
             seq = self.running.popleft()
             if seq.is_partial_prefill:
+                # Stamp the first tick this prefill was parked so
+                # `_prefill_admission_starving` can release it later.
+                if park_partial_prefills and (
+                    getattr(seq, "hol_decode_parked_since", None) is None
+                ):
+                    seq.hol_decode_parked_since = now
                 skipped_partial_prefills.append(seq)
                 continue
             if _pp_block and seq.id in _pp_block:
@@ -1334,8 +1401,8 @@ class Scheduler:
             num_scheduled_tokens=num_scheduled_tokens,
             total_tokens_num=total_tokens_num_decode,
             total_tokens_num_decode=total_tokens_num_decode,
-            total_seqs_num=num_seqs_prefill + num_seqs_decode,
-            total_seqs_num_prefill=num_seqs_prefill,
+            total_seqs_num=num_seqs_decode,
+            total_seqs_num_prefill=0,
             total_seqs_num_decode=num_seqs_decode,
             connector_meta_output=connector_meta_output,
             num_spec_step=self.mtp_k,
@@ -1344,6 +1411,66 @@ class Scheduler:
             remote_kv_seq_blocks=remote_kv_seq_blocks,
         )
         return (decode_batch, scheduled_seqs)
+
+    # -- Head-of-line scheduling helpers ------------------------------------
+    def _has_decode_ready_seqs(self) -> bool:
+        """True when at least one running seq can be decoded on this tick."""
+        pp_block = self._pp_inflight_token_block
+        for seq in self.running:
+            if not seq.is_partial_prefill and seq.id not in pp_block:
+                return True
+        return False
+
+    def _has_small_waiting(self) -> bool:
+        """True when an admittable waiting prefill is short enough to be scheduled
+        beside, rather than behind, a large chunked prefill."""
+        for seq in self.waiting:
+            if self._unschedulable_reason(seq) is not None:
+                continue
+            if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
+                continue
+            if seq.num_tokens - seq.num_cached_tokens < _HOL_LARGE_TOKENS:
+                return True
+        return False
+
+    def _prefill_admission_starving(self) -> bool:
+        """True when prefill has been held back long enough that decode-priority
+        must yield this tick.
+
+        Bounds the inverse of the block decode-priority fixes: without it a
+        continuously busy decode batch keeps `_has_decode_ready_seqs()` true forever
+        and Phase 1 / Phase 2 -- the only paths that admit new work, resume chunked
+        prefills, and promote remote-KV consumers -- are never reached.
+        """
+        if _HOL_STARVE_MS <= 0:
+            return False
+        if self.waiting and self._oldest_waiting_prefill_age_ms() > _HOL_STARVE_MS:
+            return True
+        if self._partial_prefill_count > 0:
+            now = time.time()
+            for seq in self.running:
+                if not seq.is_partial_prefill:
+                    continue
+                parked_since = getattr(seq, "hol_decode_parked_since", None)
+                if (
+                    parked_since is not None
+                    and (now - parked_since) * 1000.0 > _HOL_STARVE_MS
+                ):
+                    return True
+        return False
+
+    def _try_schedule_decode_priority(
+        self,
+    ) -> tuple[ScheduledBatch, dict[int, Sequence]] | None:
+        """Schedule a decode-only batch ahead of any pending prefill work.
+
+        Returns None when nothing was decodable, so the caller falls through to
+        normal prefill scheduling.
+        """
+        batch, scheduled_seqs = self._schedule_decode_batch(park_partial_prefills=True)
+        if batch.total_seqs_num_decode == 0:
+            return None
+        return (batch, scheduled_seqs)
 
     # -- Remote KV / offload admission helpers ------------------------------
     def _resolve_waiting_remote_kv(
@@ -1563,7 +1690,13 @@ class Scheduler:
         # Strip placeholder + rejected draft tokens added by postprocess.
         # Real token count = seq.num_tokens - mtp_k - num_rejected
         # (same formula as postprocess line: num_tokens = seq.num_tokens - self.mtp_k - num_rejected)
-        if self.mtp_k > 0:
+        #
+        # A mid-chunked-prefill seq never received those placeholders -- postprocess
+        # appends them only for RUNNING seqs that are not partial prefills -- so
+        # stripping here would delete real prompt tokens and push num_tokens below
+        # num_prompt_tokens, which is fixed at construction. The seq would then stay
+        # partial forever on re-admission and pin its KV blocks.
+        if self.mtp_k > 0 and not seq.is_partial_prefill:
             strip = self.mtp_k + seq.num_rejected
             if strip > 0:
                 del seq.token_ids[-strip:]

--- a/tests/test_scheduler_hol.py
+++ b/tests/test_scheduler_hol.py
@@ -1,0 +1,144 @@
+"""Regression tests for bounded decode-priority scheduling.
+
+``schedule()`` returned as soon as any prefill was scheduled, so decode never ran
+on a tick carrying prefill work.  A chunked prefill fills the whole token budget on
+each of its ticks, so a long prompt stalled every running sequence for its entire
+duration.
+
+Scheduling decode first fixes that, but must be bounded in both directions: a
+continuously busy decode batch must not block new admissions forever, and a stream
+of short prompts must not freeze a long one.
+"""
+
+import time
+from types import SimpleNamespace
+
+from conftest import MockConfig
+
+import atom.model_engine.scheduler as scheduler_mod
+from atom.model_engine.scheduler import Scheduler
+
+
+def _spec_config(k=3):
+    return SimpleNamespace(num_speculative_tokens=k)
+
+
+def _make_sched(mtp_k=3, **overrides):
+    cfg = {
+        "max_num_seqs": 8,
+        "num_kvcache_blocks": 64,
+        "kv_cache_block_size": 4,
+        "max_model_len": 256,
+        "max_num_batched_tokens": 256,
+        "speculative_config": _spec_config(mtp_k),
+    }
+    cfg.update(overrides)
+    return Scheduler(MockConfig(**cfg))
+
+
+def _admit(sched, seq_factory, tokens):
+    """Queue a sequence the way the engine does, including the arrival stamp.
+
+    ``Sequence.__init__`` leaves ``arrive_time`` at 0.0; ``LLMEngine`` stamps it on
+    entry. A test that skips the stamp makes every queued prefill look infinitely
+    old to ``_oldest_waiting_prefill_age_ms``.
+    """
+    seq = seq_factory(tokens)
+    seq.arrive_time = time.time()
+    sched.add(seq)
+    return seq
+
+
+def _make_decode_ready(sched, seq_factory, tokens):
+    """Admit a sequence and drive it to the decode-ready state."""
+    seq = _admit(sched, seq_factory, tokens)
+    sched.schedule()
+    seq.num_cached_tokens = seq.num_prompt_tokens
+    seq.is_partial_prefill = False
+    seq.append_token(99)
+    return seq
+
+
+class TestDecodePriority:
+    def test_decode_runs_before_a_queued_prefill(self, seq_factory):
+        """With decode work ready and a fresh arrival queued, the tick is decode."""
+        sched = _make_sched()
+        _make_decode_ready(sched, seq_factory, [1, 2, 3, 4])
+
+        _admit(sched, seq_factory, [5, 6, 7, 8])
+
+        batch, _ = sched.schedule()
+
+        assert batch.total_seqs_num_decode >= 1
+        assert (
+            batch.total_seqs_num_prefill == 0
+        ), "a queued prefill preempted ready decode work"
+
+    def test_decode_priority_yields_to_an_aged_arrival(self, seq_factory):
+        """Decode-priority must yield once an arrival has waited too long.
+
+        Without this bound a steady decode load keeps decode work ready on every
+        tick, and Phase 1 / Phase 2 -- the only paths that admit new requests --
+        are never reached.
+        """
+        sched = _make_sched()
+        _make_decode_ready(sched, seq_factory, [1, 2, 3, 4])
+
+        arrival = _admit(sched, seq_factory, [5, 6, 7, 8])
+
+        # Fresh arrival: decode still wins.
+        batch, _ = sched.schedule()
+        assert batch.total_seqs_num_prefill == 0
+
+        # Same state, but the arrival has now waited past the bound.
+        arrival.arrive_time = (
+            time.time() - (scheduler_mod._HOL_STARVE_MS / 1000.0) - 1.0
+        )
+
+        batch, _ = sched.schedule()
+        assert batch.total_seqs_num_prefill >= 1, (
+            "decode-priority starved an arrival that aged past " "_HOL_STARVE_MS"
+        )
+
+
+class TestLargePrefillDefer:
+    def test_large_resume_is_deferred_then_released(self, monkeypatch, seq_factory):
+        """A large resume steps aside for a short prompt, but only for a bounded
+        time -- otherwise a stream of short prompts freezes the long one."""
+        monkeypatch.setattr(scheduler_mod, "_HOL_LARGE_TOKENS", 20)
+        monkeypatch.setattr(scheduler_mod, "_HOL_DEFER_MS", 1000.0)
+        # Keep decode-priority out of the way so this exercises Phase 1 only:
+        # any queued prefill counts as starving, so decode-priority always yields.
+        monkeypatch.setattr(scheduler_mod, "_HOL_STARVE_MS", 1e-6)
+
+        sched = _make_sched()
+        large = _admit(sched, seq_factory, list(range(100, 140)))  # 40 tokens
+        sched.schedule()
+
+        # Mid-chunk with more than _HOL_LARGE_TOKENS still to do.
+        large.num_cached_tokens = 10
+        large.is_partial_prefill = True
+        sched._partial_prefill_count = 1
+
+        short = _admit(sched, seq_factory, list(range(200, 208)))  # 8 tokens
+
+        cached_at_defer = large.num_cached_tokens
+        _, scheduled = sched.schedule()
+        assert (
+            large.id not in scheduled
+        ), "large prefill resumed even though a short prompt was queued"
+        assert short.id in scheduled, "short prompt was not admitted"
+        assert large.hol_deferred_since is not None
+
+        # Still queued behind the deferral bound -> large must resume anyway.
+        large.hol_deferred_since = (
+            time.time() - (scheduler_mod._HOL_DEFER_MS / 1000.0) - 1.0
+        )
+        _admit(sched, seq_factory, list(range(300, 308)))  # 8 tokens
+
+        _, scheduled = sched.schedule()
+        assert large.id in scheduled, (
+            "large prefill stayed frozen past _HOL_DEFER_MS while short prompts "
+            "kept arriving"
+        )
+        assert large.num_cached_tokens >= cached_at_defer

--- a/tests/test_scheduler_preempt_partial_prefill.py
+++ b/tests/test_scheduler_preempt_partial_prefill.py
@@ -1,0 +1,90 @@
+"""Regression test: ``preempt()`` must not truncate a chunked prefill.
+
+``postprocess`` appends the ``mtp_k - num_rejected`` speculative placeholders only
+to sequences that are RUNNING *and not* mid-chunked-prefill, but ``preempt()``
+stripped ``mtp_k + num_rejected`` tokens from every sequence.  Preempting a
+sequence that was still prefilling therefore deleted real prompt tokens and pushed
+``num_tokens`` below ``num_prompt_tokens`` -- which is assigned once, at
+construction.  On re-admission the sequence could never satisfy
+``num_cached_tokens >= num_prompt_tokens`` again: it stayed ``is_partial_prefill``
+forever, pinned its KV blocks, and because Phase 1 breaks (rather than continues)
+when a chunk cannot be sized, every later chunked prefill queued behind it.
+"""
+
+import time
+from types import SimpleNamespace
+
+from conftest import MockConfig
+
+from atom.model_engine.scheduler import Scheduler
+
+
+def _spec_config(k=3):
+    return SimpleNamespace(num_speculative_tokens=k)
+
+
+def _make_sched(mtp_k=3, **overrides):
+    cfg = {
+        "max_num_seqs": 8,
+        "num_kvcache_blocks": 64,
+        "kv_cache_block_size": 4,
+        "max_model_len": 256,
+        "max_num_batched_tokens": 256,
+        "speculative_config": _spec_config(mtp_k),
+    }
+    cfg.update(overrides)
+    return Scheduler(MockConfig(**cfg))
+
+
+def _admit(sched, seq_factory, tokens):
+    """Queue a sequence the way the engine does, including the arrival stamp.
+
+    ``Sequence.__init__`` leaves ``arrive_time`` at 0.0; ``LLMEngine`` stamps it on
+    entry. A test that skips the stamp makes every queued prefill look infinitely
+    old to ``_oldest_waiting_prefill_age_ms``.
+    """
+    seq = seq_factory(tokens)
+    seq.arrive_time = time.time()
+    sched.add(seq)
+    return seq
+
+
+def _make_decode_ready(sched, seq_factory, tokens):
+    """Admit a sequence and drive it to the decode-ready state."""
+    seq = _admit(sched, seq_factory, tokens)
+    sched.schedule()
+    seq.num_cached_tokens = seq.num_prompt_tokens
+    seq.is_partial_prefill = False
+    seq.append_token(99)
+    return seq
+
+
+class TestPreemptPartialPrefill:
+    def test_preempt_keeps_partial_prefill_prompt_tokens(self, seq_factory):
+        """A preempted chunked prefill must keep every prompt token.
+
+        It never received speculative placeholders, so stripping them removes
+        real prompt tokens and leaves ``num_tokens < num_prompt_tokens``
+        forever: the sequence stays partial on every re-admission and pins its
+        KV blocks.
+        """
+        sched = _make_sched(mtp_k=3)
+        seq = _admit(sched, seq_factory, [1, 2, 3, 4, 5, 6, 7, 8])
+        sched.schedule()
+
+        # Freeze it mid-chunk, as a real chunked prefill would be.
+        seq.num_cached_tokens = 4
+        seq.is_partial_prefill = True
+        sched._partial_prefill_count = 1
+
+        tokens_before = seq.num_tokens
+        sched.preempt(seq)
+
+        assert seq.num_tokens == tokens_before, (
+            "preempt() stripped speculative placeholders from a partial prefill "
+            "that never had any"
+        )
+        assert seq.num_tokens >= seq.num_prompt_tokens, (
+            "prompt was truncated: the sequence can never satisfy "
+            "num_cached_tokens >= num_prompt_tokens again"
+        )


### PR DESCRIPTION
## Motivation

A single long prompt stops every other request in the engine until it finishes.

`Scheduler.schedule()` returns as soon as it has scheduled any prefill, and the decode
scheduling block sits below that return. This is harmless for short prompts, which
occupy one tick. A chunked prefill, however, consumes the entire
`max_num_batched_tokens` budget on every tick it runs, so a 600K-token prompt keeps a
prefill in the batch for all ~37 of its ticks and no decode runs for their whole
duration.

Measured on a single MI355X x8 node (Kimi-K3 + DSpark `mtp_k=7`, TP=8, DP=1, PP=1,
`max_num_seqs=64`, `max_num_batched_tokens=16384`, chunked prefill enabled,
`kv_cache_dtype=fp8`), a 101-token request arriving 2 s into a 600,104-token prefill
waited **82.4 s** for its first token. With this change the same request is answered in
**1.9 s**, and the long prompt still finishes within 0.6 s of its original time.

<img src="https://raw.githubusercontent.com/hippothewild/ATOM/pr-assets/hol-prefill-decode.png" width="900" alt="Timeline: upstream blocks the short request for the whole prefill; the patched build answers it while the prefill continues">

<sub>Schematic of the two scenarios. Exact A/B numbers are under Test Result.</sub>

Two further defects surfaced while fixing this and are included here, because they are
not independently landable. Fixing the scheduling order makes defect 3 reachable:
decode-priority can preempt a mid-chunk prefill, and the Phase 1 early return is
precisely what makes that path unreachable at `dp_size == 1` today. Splitting this into
separate PRs would merge a change that activates a latent state-corruption bug before
the fix for it.

## Technical Details

### 1. Decode never runs on a tick that carries prefill

`atom/model_engine/scheduler.py`

The fix does not mix prefill and decode in one batch — the model runner does not support
that today. It changes the ordering instead: when decode work is ready, schedule a
decode-only batch first and let the prefill resume on a later tick. Batch shapes are
unchanged, so the runner needs no changes.

Both directions are bounded in time, and the second bound matters more than it appears.
An unbounded decode-priority produces the inverse failure: a busy decode batch keeps
decode work ready on every tick, so Phase 1 and Phase 2 — the only paths that admit new
requests, resume chunked prefills, and promote remote-KV consumers — are never reached.
An unbounded variant measured 36.4 s to first token for a 91-token request against a
0.65 s idle baseline. `_prefill_admission_starving()` yields the tick back once a queued
prefill has waited past the bound.

Symmetrically, a large prefill resume steps aside for a short queued prompt, but only
once and only for a bounded interval, so a stream of short prompts cannot freeze a long
one.

Three bounds are read from the environment to keep the diff small:

| variable | default | effect |
| --- | --- | --- |
| `ATOM_PREFILL_STARVE_MS` | 2000 | decode-priority yields to a prefill queued longer than this |
| `ATOM_LARGE_PREFILL_DEFER_TOKENS` | 30000 | a resume with more remaining tokens than this may be deferred |
| `ATOM_LARGE_PREFILL_DEFER_MS` | 2000 | maximum time such a resume is deferred |

### 2. The MTP status queue is consumed on every step but filled only on some

`atom/model_engine/model_runner.py`

`prepare_input_ids()` pops `pending_mtp_status_copies` unconditionally. The queue is
filled from `postprocess`, which the pure-middle-chunk / non-last-PP early return in
`forward` skips. A chunked prefill therefore discards the previous decode's
rejected/bonus counts, and the next decode step reads an empty queue:

```
TypeError: 'NoneType' object is not subscriptable
  File "atom/model_engine/scheduler.py", line 1817, in postprocess
    num_rejected = int(fwd_output.num_rejected[idx])
```

Any prompt above roughly 50K tokens killed the engine core within seconds. The fix gates
the consumer on the same predicate that gates the producer, `batch.produces_output()`.

Guarding the consumer in `Scheduler.postprocess` instead is worse than the crash. That
does not skip the step — it routes real deferred tokens into the non-speculative branch,
which appends tokens rather than overwriting the MTP placeholders. The placeholders then
stay in the context permanently, `num_tokens` inflates, and a stale `seq.num_rejected`
shifts both the next step's write offset and `preempt()`'s strip arithmetic. The crash
becomes silent context corruption.

### 3. `preempt()` truncates a chunked prefill's prompt

`atom/model_engine/scheduler.py`

`postprocess` appends the `mtp_k - num_rejected` speculative placeholders only to
sequences that are RUNNING and not mid-chunked-prefill, but `preempt()` strips
`mtp_k + seq.num_rejected` from every sequence it touches. Preempting a sequence that is
still prefilling deletes real prompt tokens.

`num_prompt_tokens` is assigned once at construction, so the sequence can never satisfy
`num_cached_tokens >= num_prompt_tokens` again. It stays `is_partial_prefill` forever on
every re-admission and pins its KV blocks, and because Phase 1 `break`s rather than
`continue`s, every later chunked prefill queues behind it. Nothing is logged — the
client simply hangs.

## Test Plan

Four regression tests are added. All four fail on `main` without this change and pass
with it.
They drive the real `Scheduler` on CPU through the existing `tests/conftest.py`
fixtures, so they need no GPU.

- `tests/test_scheduler_preempt_partial_prefill.py` — a preempted partial prefill keeps
  every prompt token and never drops below `num_prompt_tokens`.
- `tests/test_scheduler_hol.py` — decode runs ahead of a freshly queued prefill;
  decode-priority yields once an arrival ages past `_HOL_STARVE_MS`; a large resume is
  deferred for a short prompt and then released after `_HOL_DEFER_MS`.

End-to-end runs used the node configuration described under Motivation. The baseline is
the identical container image with `scheduler.py` and `model_runner.py` reverted to
`9acb0843`, so nothing else — AITER revision, kernels, model weights, engine flags —
differs between the two sides. Each build was driven with the same three probes: one 600K
prompt with short arrivals spread across its prefill, a c=16 throughput sweep, and a
three-way run combining sustained decode load, a 600K prefill, and short arrivals.

## Test Result

```
tests/test_scheduler_hol.py ...                                          [ 75%]
tests/test_scheduler_preempt_partial_prefill.py .                        [100%]
4 passed in 0.07s
```

Both builds are the same image with only `scheduler.py` and `model_runner.py` differing,
so the comparison isolates this change. Numbers below are the second 600K run on each
build — the first long prefill after engine start is warm-up dominated (95 s vs 84 s) and
is discarded on both sides.

**One 600K-token prompt, with N short requests fired together 10 s into its prefill.**
Median time to first token across the N:

| short requests in flight | upstream `9acb0843` | with this PR |
| --- | --- | --- |
| 1 | 74.5 s | **2.5 s** |
| 4 | 74.1 s | **3.1 s** |
| 16 | 74.3 s | **2.9 s** |

Upstream is flat at ~74 s because the number of short requests is irrelevant: none of them
runs until the prefill is done, so each one just waits out the ~75 s still remaining. With
this change the level drops ~25x and stays flat as concurrency grows — the short requests
are being served alongside the prefill rather than after it.

The prompt that causes the stall is unaffected: it completes in 85.6–86.0 s upstream and
86.1–86.3 s with this PR, across the same three runs.

Arrival time does not change the picture either. Staggering four arrivals at t = 2 / 20 /
45 / 70 s instead of firing them together gives 82.4 / 64.4 / 39.4 / 14.4 s upstream —
four different numbers that are all the same absolute deadline, the moment the prefill
ends — against 1.9 / 3.8 / 3.0 / 5.6 s with this PR.

**Sustained load, c=16, three rounds after a discarded warm-up:**

| | upstream `9acb0843` | with this PR |
| --- | --- | --- |
| total output | 606.9 / 694.2 tok/s | 650.4 / 660.1 tok/s |
| per request | 48.3 / 47.1 tok/s | 47.7 / 48.2 tok/s |

Run-to-run spread is wider than the difference between the two builds, so throughput is
unchanged.

**Crash reproduction.** Driving upstream with eight sustained decode streams plus a 600K
prefill killed the engine core, which is defect 2:

```
[atom 11:02:01] run_engine: exception: 'NoneType' object is not subscriptable
Traceback (most recent call last):
  File "/app/ATOM/atom/model_engine/engine_core.py", line 215, in run_engine
    engine.busy_loop()
  File "/app/ATOM/atom/model_engine/engine_core.py", line 245, in busy_loop
    self._process_engine_step()
  File "/app/ATOM/atom/model_engine/engine_core.py", line 258, in _process_engine_step
    return self._process_engine_step_inner()
  File "/app/ATOM/atom/model_engine/engine_core.py", line 314, in _process_engine_step_inner
    finished_seqs = self.scheduler.postprocess(
  File "/app/ATOM/atom/model_engine/scheduler.py", line 1817, in postprocess
    num_rejected = int(fwd_output.num_rejected[idx])
TypeError: 'NoneType' object is not subscriptable
```

Every in-flight request then hung and the run had to be abandoned. The same workload on
the patched build completed: the 600K prompt returned its first token in 113.9 s despite
the decode load, the three short arrivals in 2.8 / 3.7 / 3.9 s, no request starved, and
the log contains no traceback.

Style gates: `black --check .` is clean across the tree, and `ruff check .` reports 1585
findings both with and without this change — no new ones.

Under `.github/scripts/run_unit_tests.sh`, the command Pre Checkin actually runs:

| | passed | failed |
| --- | --- | --- |
| `main` | 756 | 0 |
| with this PR | 760 | 0 |

The four added tests are the whole difference; nothing else moved.

(A bare `pytest tests/` — without the script's `--ignore=tests/plugin` — breaks these and
several existing scheduler tests alike with `ImportError: cannot import name
'get_kvconnector' from 'atom.utils.forward_context'`. That is the module-stub leakage the
runner script already documents as its reason for excluding `tests/plugin`, and it
affects `main` identically, so I left it alone.)

Two points I would rather a maintainer decide:

- the three bounds should probably become `Config` fields
  (`prefill_starve_ms`, `large_prefill_defer_tokens`, `large_prefill_defer_ms`) with CLI
  flags rather than environment variables.
- `_schedule_decode_batch()` is now shared by `schedule()` and
  `_try_schedule_decode_priority()`. Splitting it differently, or folding the
  decode-priority decision into `schedule()` itself, is a reasonable alternative.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
