### PR TITLE
perf(frontend): remove four host-side bottlenecks that idle the GPU at high concurrency

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -15,6 +15,7 @@ Usage:
 import asyncio
 import base64
 import binascii
+import gc
 import io
 import json
 import logging
@@ -37,6 +38,7 @@ from atom import SamplingParams
 from atom.model_engine.arg_utils import EngineArgs
 from atom.model_engine.llm_engine import _load_tokenizer
 from atom.model_engine.request import RequestOutput
+from atom.utils import envs
 from atom.utils.arg_parser import FlexibleArgumentParser
 
 from .chat_encoders import apply_chat_template, load_custom_message_encoder
@@ -1035,10 +1037,39 @@ async def setup_streaming_request_fanout(
 # ============================================================================
 
 
+def _tune_gc() -> None:
+    """Stretch the interval between full (generation-2) collections.
+
+    Only gen-2 matters: it is stop-the-world and rescans every tracked
+    container, so its cost tracks live objects rather than recent garbage.
+    At c=2048 it was 47% of wall clock while the 23k gen-0/1 passes over the
+    same window cost 0.1s. Raising the thresholds is close to free because
+    reference counting, not the collector, reclaims everything acyclic --
+    peak RSS actually fell, since a larger gen-0 threshold lets more objects
+    die before a collection can promote them.
+
+    gc.freeze() was tried here and removed: once gen-2 stops running there is
+    nothing left for it to make cheaper, and alone it made collections more
+    frequent by emptying gen-2, which is the denominator CPython gates full
+    collections on (long_lived_pending > long_lived_total / 4).
+    """
+    thresholds = envs.ATOM_GC_THRESHOLD
+    if not thresholds:
+        return
+    try:
+        t = tuple(int(x) for x in thresholds.split(","))
+        old = gc.get_threshold()
+        gc.set_threshold(*t)
+        logger.info("[gc] thresholds %s -> %s", old, t)
+    except (ValueError, TypeError):
+        logger.warning("[gc] bad ATOM_GC_THRESHOLD=%r, ignored", thresholds)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown."""
     logger.info("Server started successfully and ready to accept requests")
+    _tune_gc()
     yield
     logger.info("Server shutting down, releasing resources...")
     if engine is not None:

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -3,11 +3,22 @@
 
 """Batched cross-thread dispatch for streaming model output."""
 
+import os
 import threading
+import time
 from asyncio import AbstractEventLoop, Queue
 from collections.abc import Hashable
 from dataclasses import dataclass, field
 from typing import Any
+
+# SSE coalescing. Two tokenizer.decode calls, a queue put/get, a json.dumps
+# and a socket write are paid once per (request, engine step); at high
+# concurrency that fixed cost, not the GPU, is what caps throughput. Holding
+# the buffer open across steps collapses N tokens into one of each (update()
+# takes a list and decodes twice regardless of length). Costs up to this much
+# extra inter-token latency, so it is opt-in. A finished chunk always flushes.
+_COALESCE_S = max(0.0, float(os.environ.get("ATOM_SSE_COALESCE_MS", "0") or 0)) / 1000.0
+_COALESCE_MAX_STEPS = int(os.environ.get("ATOM_SSE_COALESCE_MAX_STEPS", "8") or 8)
 
 
 @dataclass
@@ -56,7 +67,6 @@ class StreamBatchDispatcher:
         self.tokenizer = tokenizer
         self._thread_local = threading.local()
         self._states: dict[Hashable, IncrementalStreamDetokenizer] = {}
-        self._states_lock = threading.Lock()
 
     def enqueue(
         self,
@@ -83,54 +93,89 @@ class StreamBatchDispatcher:
 
     def flush(self) -> None:
         """Detokenize buffered chunks and schedule one drain per event loop."""
-        buf = getattr(self._thread_local, "buf", None)
+        tl = self._thread_local
+        buf = getattr(tl, "buf", None)
         if not buf:
             return
-        self._thread_local.buf = []
+
+        now = time.monotonic()
+        if _COALESCE_S > 0:
+            steps = getattr(tl, "steps", 0) + 1
+            tl.steps = steps
+            if (
+                steps < _COALESCE_MAX_STEPS
+                and now - getattr(tl, "last_flush", 0.0) < _COALESCE_S
+                and not any(i.chunk.get("finished") for i in buf)
+            ):
+                return  # keep accumulating; nothing here is final yet
+        tl.buf = []
+        tl.steps = 0
+        tl.last_flush = now
+
+        # One group per stream. state_key already distinguishes fan-out
+        # siblings, and loop/queue are constant per stream, so the last item
+        # of a group carries the right destination plus the terminal
+        # finish_reason/finished flags.
+        groups: dict[Hashable, list[_BufferedChunk]] = {}
+        for item in buf:
+            groups.setdefault(item.state_key, []).append(item)
 
         by_loop: dict[AbstractEventLoop, list[tuple[Queue, Any]]] = {}
-        for item in buf:
-            state = self._get_state(item.state_key)
-            item.chunk["text"] = state.update(
-                item.chunk.get("token_ids") or [],
-                bool(item.chunk.get("finished")),
-            )
-            if item.chunk.get("finished"):
-                self._drop_state(item.state_key, state)
+        for state_key, items in groups.items():
+            last = items[-1]
+            token_ids = last.chunk.get("token_ids") or []
+            if len(items) > 1:
+                token_ids = []
+                for i in items:
+                    token_ids.extend(i.chunk.get("token_ids") or [])
+                last.chunk["token_ids"] = token_ids
+                for i in items[:-1]:
+                    if "kv_transfer_params" in i.chunk:
+                        last.chunk.setdefault(
+                            "kv_transfer_params", i.chunk["kv_transfer_params"]
+                        )
 
-            payload = item.chunk if item.tag is None else (item.tag, item.chunk)
-            by_loop.setdefault(item.loop, []).append((item.queue, payload))
+            state = self._get_state(state_key)
+            last.chunk["text"] = state.update(
+                token_ids, bool(last.chunk.get("finished"))
+            )
+            if last.chunk.get("finished"):
+                self._drop_state(state_key, state)
+
+            payload = last.chunk if last.tag is None else (last.tag, last.chunk)
+            by_loop.setdefault(last.loop, []).append((last.queue, payload))
 
         for loop, items in by_loop.items():
             loop.call_soon_threadsafe(self._drain_into_queues, items)
 
+    # These three ran under a shared lock, which cost 27% of the API server's
+    # CPU -- _get_state is called once per stream per flush, with all output
+    # threads contending. No lock is needed: each operation below is a single
+    # C-level dict method that no other Python thread can interrupt, and
+    # list() snapshots atomically so discard_request cannot hit "dict changed
+    # size". GIL-dependent; a free-threaded build would need real locks.
+
     def discard_request(self, request_id: str) -> None:
         """Drop direct and fan-out detokenizer state after request cleanup."""
-        with self._states_lock:
-            keys = [
-                key
-                for key in self._states
-                if key == request_id
-                or (isinstance(key, tuple) and key and key[0] == request_id)
-            ]
-            for key in keys:
+        for key in list(self._states):
+            if key == request_id or (
+                isinstance(key, tuple) and key and key[0] == request_id
+            ):
                 self._states.pop(key, None)
 
     def _get_state(self, state_key: Hashable) -> IncrementalStreamDetokenizer:
-        with self._states_lock:
-            state = self._states.get(state_key)
-            if state is None:
-                state = self._states[state_key] = IncrementalStreamDetokenizer(
-                    self.tokenizer
-                )
-            return state
+        state = self._states.get(state_key)
+        if state is None:
+            state = self._states.setdefault(
+                state_key, IncrementalStreamDetokenizer(self.tokenizer)
+            )
+        return state
 
     def _drop_state(
         self, state_key: Hashable, state: IncrementalStreamDetokenizer
     ) -> None:
-        with self._states_lock:
-            if self._states.get(state_key) is state:
-                self._states.pop(state_key)
+        if self._states.get(state_key) is state:
+            self._states.pop(state_key, None)
 
     @staticmethod
     def _drain_into_queues(items: list[tuple[Queue, Any]]) -> None:

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -57,7 +57,6 @@ class CoreManager:
         self.local_engine_count = local_engine_count
         self.ctx = zmq.Context(io_threads=2)
         self.outputs_queue = queue.Queue[list[Sequence]]()
-        self.stream_outputs_queue = queue.Queue()
         self.utility_response_queue = queue.Queue()
         self._seq_id_to_callback = {}
         # Batched stream-flush hook, resolved lazily by the API server (avoids
@@ -315,19 +314,29 @@ class CoreManager:
                         logger.debug(
                             f"{self.label}: Received STREAM message with {len(stream_outputs)} outputs"
                         )
-                        self.stream_outputs_queue.put_nowait(stream_outputs)
-                        # Also call callbacks if registered
+                        # Delivered only through the per-seq callbacks below.
+                        # These also used to go onto stream_outputs_queue,
+                        # which nothing ever read, so every RequestOutput
+                        # stayed reachable for the life of the process and
+                        # made each gen-2 GC pass progressively slower.
+                        #
+                        # The f-strings below are built by the caller before
+                        # logger.debug() can drop them, so check the level
+                        # once per step rather than twice per chunk.
+                        dbg = logger.isEnabledFor(logging.DEBUG)
                         for seq_id, request_output in stream_outputs:
                             callback = self._seq_id_to_callback.get(seq_id)
-                            logger.debug(
-                                f"{self.label}: seq_id={seq_id}, callback={'found' if callback is not None else 'NOT FOUND'}, tokens={request_output.output_tokens}"
-                            )
+                            if dbg:
+                                logger.debug(
+                                    f"{self.label}: seq_id={seq_id}, callback={'found' if callback is not None else 'NOT FOUND'}, tokens={request_output.output_tokens}"
+                                )
                             if callback is not None:
                                 try:
                                     callback(request_output)
-                                    logger.debug(
-                                        f"{self.label}: Successfully called callback for seq_id={seq_id}"
-                                    )
+                                    if dbg:
+                                        logger.debug(
+                                            f"{self.label}: Successfully called callback for seq_id={seq_id}"
+                                        )
                                 except Exception as e:
                                     logger.warning(
                                         f"Error calling stream_callback for sequence {seq_id}: {e}",
@@ -336,9 +345,10 @@ class CoreManager:
                             if request_output.finished:
                                 self._seq_id_to_callback.pop(seq_id, None)
                                 self._release_seq_load(seq_id)
-                                logger.debug(
-                                    f"{self.label}: Cleaned up callback for finished sequence {seq_id}"
-                                )
+                                if dbg:
+                                    logger.debug(
+                                        f"{self.label}: Cleaned up callback for finished sequence {seq_id}"
+                                    )
                         # Batched stream dispatch: the per-seq callbacks only buffer
                         # their chunks into a thread-local; flush the whole step's
                         # buffer into the per-request asyncio queues now (one
@@ -711,12 +721,6 @@ class CoreManager:
             self._rank_reqs = [0] * self.local_engine_count
             self._rank_tokens = [0] * self.local_engine_count
             self._seq_load.clear()
-
-    def get_stream_outputs(self):
-        try:
-            return self.stream_outputs_queue.get_nowait()
-        except queue.Empty:
-            return None
 
     def send_utility_command(self, cmd: str, dp_rank: int = None):
         if dp_rank is None:

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -722,7 +722,7 @@ class CoreManager:
             self._rank_tokens = [0] * self.local_engine_count
             self._seq_load.clear()
 
-    def send_utility_command(self, cmd: str, dp_rank: int = None):
+    def send_utility_command(self, cmd: str, dp_rank: int | None = None):
         if dp_rank is None:
             # Send to all DP ranks
             for rank in range(self.local_engine_count):

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -887,7 +887,10 @@ def _patch_torch_dynamo_metrics_config_logging() -> None:
 
 def getLogger():
     if not logger.handlers:
-        logger.setLevel(logging.DEBUG)
+        # Must match the handler level below: a logger at DEBUG feeding a
+        # handler at INFO still builds a LogRecord per logger.debug() call
+        # and then discards it -- 10.4% of the API server's CPU at c=2048.
+        logger.setLevel(logging.INFO)
 
         console_handler = logging.StreamHandler()
         from atom.utils import envs as _envs

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -178,6 +178,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # --- Profiling & Logging ---
     "ATOM_TORCH_PROFILER_DIR": lambda: os.getenv("ATOM_TORCH_PROFILER_DIR", None),
+    # "t0,t1,t2" for gc.set_threshold(); empty keeps CPython's default.
+    # See _tune_gc in api_server.py.
+    "ATOM_GC_THRESHOLD": lambda: os.getenv("ATOM_GC_THRESHOLD", "").strip(),
     "ATOM_PROFILER_MORE": lambda: os.getenv("ATOM_PROFILER_MORE", "0") == "1",
     # When profiling is active, append detailed attention aggregates (sqsq, sqsk, sk)
     # to the prefill[]/decode[] trace labels emitted by ModelRunner.run_model.


### PR DESCRIPTION
## Symptom

At `--max-concurrency 2048` the GPU finishes a wave of requests and then sits **completely idle** before the next wave starts:

| config | largest GPU bubble | GPU busy |
|---|---|---|
| DeepSeek-V4-Pro, tp8 | 34.0 s (second boundary 25.3 s) | 83.8% |
| DeepSeek-V4-Flash, tp4 | **103.8 s** | **47.9%** |

During the bubble the trace has **no kernels, no memcpy, no memset**, and not even the per-step `gloo:all_gather`. The last annotation before it is `dummy_decode[bs=1]`, i.e. `DPEngineCoreProc.busy_loop` took the `global_has_unfinished == False` branch — **the scheduler queue was empty, the requests had not reached the engine yet**.

None of this is GPU-, model- or kernel-related. It is all in the `api_server` process.

## Why a delivery deficit turns into lost throughput

Three things have to be true at once.

**1. Production outruns delivery.** The frontend is a single Python process under one GIL, so its ceiling does not move with the model or the GPU count:

| | V4-Pro tp8 | Flash tp4 |
|---|---|---|
| GPU decode step | 77.6 ms | 31.6 ms |
| GPU can produce | 26.4k tok/s | **64.8k tok/s** |
| frontend can deliver | ~11.5k chunk/s | ~11.5k chunk/s |

The faster the GPU, the worse the mismatch — 2.1× becomes 5.6×.

**2. There is no back-pressure.** `setup_streaming_request` creates an unbounded `asyncio.Queue()`, and the EngineCore side uses `output_queue.put_nowait()`. The engine never slows down, so the shortfall accumulates linearly. Over an ~84 s decode phase that is ≈ 84 × (1 − 77.6/146.3) ≈ **39 s** of backlog.

Corroborated end-to-end: client-measured mean E2EL was 148.4 s while the server-side generation window was only ~112 s.

**3. The benchmark is closed-loop.** `benchmark_serving.py` uses `asyncio.Semaphore(max_concurrency)` with `request_rate=inf`; request N+2048 is only released once request N has been **fully received by the client**. So the backlog is not absorbed as latency — it becomes GPU idle time. The server log shows `pending requests` still at 2043–2048 a full 33 s after the GPU had produced their last token.

> Under real open-loop traffic the same problem shows up as worse TTFT/ITL, not as lost throughput. The closed loop is what converts it.

The wave shape is self-reinforcing, which is why it never disperses: chunked prefill admits all 2048 requests within ~28 s → `ignore_eos` with OSL ∈ [819, 1024] keeps them in lockstep → they finish within ~14 s of each other → 2048 semaphore slots free at once → repeat.

## Root causes

### 1. A queue nobody ever drained

`CoreManager.stream_outputs_queue` is fed on every streaming step, and `get_stream_outputs()` has **zero callers anywhere in the repo**. That retains ~26k `RequestOutput` objects/s for the life of the process (RSS +6.7 MB/s, observed reaching 6.4 GB).

A gen-2 collection is stop-the-world and rescans every tracked container, so its cost tracks live objects:

| heap | gen-2 pause |
|---|---|
| 1.3 GB | 270 ms |
| 3.1 GB | 3.9 s |
| 6.3 GB | **10.7 s** |

Each pause freezes the whole frontend — no SSE moves, no new request is accepted. 21% of wall clock.

*Attribution:* timing every collection via `gc.callbacks` and lining it up against event-loop lag, **47 of 48 stalls >300 ms were fully explained by GC** (median `gc_max/looplag` ratio **1.01**).

**Fix:** remove the queue and its dead accessor.

### 2. A lock that is not needed — 27% of frontend CPU

`StreamBatchDispatcher._get_state` took a global `threading.Lock` on every chunk, with all four `EngineCoreOutputThread`s contending. A py-spy profile of the API server (26,332 on-CPU samples):

| | share |
|---|---|
| **acquiring `self._states_lock` in `_get_state`** | **27.0%** |
| the `tokenizer.decode` calls it guarded | 3.5% |

`self._states` is a plain dict, and `get` / `setdefault` / `pop` / `list()` are each a single C-level dict method that no other Python thread can interrupt. The lock was only ever needed because `discard_request` iterated the live dict (`for key in self._states`), which can raise *dict changed size during iteration*; a `list()` snapshot removes that need.

**Fix:** drop the lock. The reasoning is GIL-dependent and the code says so — a free-threaded build would need real synchronisation again.

### 3. Log records built and thrown away — 10.4% of frontend CPU

```python
logger.setLevel(logging.DEBUG)           # logger accepts DEBUG
console_handler.setLevel(logging.INFO)   # its only handler drops it
```

Every `logger.debug()` allocated and formatted a `LogRecord` that was then discarded. `makeRecord` was **10.4%** of process CPU, for output that **never appeared in the log** (grep count: 0).

There is a second layer: **f-string arguments are evaluated by the caller** before `logger.debug()` can decide to drop them. The STREAM loop had two such calls per chunk (one formatting the entire token list) — roughly **120k throwaway strings/s** at c=2048.

**Fix:** logger level matches its handler (INFO), and `isEnabledFor` is hoisted out of the per-chunk loop so the f-strings are guarded.

This adds no way to turn DEBUG back on — there never was one, since the handler has always filtered at INFO. Making the 113 `logger.debug()` call sites reachable would be a separate change.

### 4. gen-2 rescanning the startup heap — 47% of wall clock

Breaking the GC cost down by generation is what decides the remedy:

| | passes | total | each |
|---|---|---|---|
| gen-0 / gen-1 | 23,191 | **0.1 s** | ~0.004 ms |
| **gen-2** | **105** | **79.1 s** | **~753 ms** |

gen-0/1 are irrelevant. What gen-2 walks is mostly the import graph, tokenizer and config — alive until shutdown and never collectable.

**Fix:** `ATOM_GC_THRESHOLD` raises `gc.set_threshold()`. With everything else held equal, `20000,50,50` vs the default `700,10,10`:

| | GC | total passes | gen-2 | max pause | peak RSS |
|---|---|---|---|---|---|
| `700,10,10` | 38.8% | 23160 | 170 | 709 ms | 2030 MB |
| `20000,50,50` | **3.8%** | **447** | **0** | **278 ms** | **1914 MB** |

It is nearly free because reference counting, not the collector, reclaims everything acyclic — the collector only exists to break cycles. Peak RSS actually **fell**, because a larger gen-0 threshold lets more objects die before a collection can promote them into an older generation.

<details>
<summary><code>gc.freeze()</code> was tried here and removed — why</summary>

Freezing the startup heap (646,796 objects) did make each pass 45% cheaper (754 → 411 ms), but the **number** of passes went **up**, 105 → 167, for a net gain of only 4.4 points.

CPython gates full collections on `long_lived_pending > long_lived_total / 4`. `long_lived_total` is the gen-2 population, and `freeze()` empties gen-2 — collapsing the denominator and making collections *more* frequent. Once the thresholds are raised gen-2 stops running at all, so there is nothing left for freeze to make cheaper. Ablation put its contribution at noise level.

The identical mechanism runs in reverse for the leak in cause 1 — see the ablation section.
</details>

## Results

DeepSeek-V4-Flash, tp=4, c=2048, 4096 requests, ISL/OSL 1024/1024:

| | start | end |
|---|---|---|
| largest GPU bubble | 103.8 s | **0.45 s** |
| GPU busy | 47.9% | **91.1%** |
| output throughput | 11009 | **35073 tok/s** (×3.19) |
| duration | 342.9 s | **107.6 s** |
| mean TPOT | 168.5 ms | **48.5 ms** |
| p99 TTFT | 21.9 s | **15.8 s** |
| time in GC | 26.2% | **4.7%** |
| api_server CPU | 104% (one core, saturated) | **70%** |

Step by step:

| config | bubble | GPU busy | tok/s | duration | GC |
|---|---|---|---|---|---|
| leak fix only | 103.8 s | 47.9% | 11009 | 342.9 s | 26.2% |
| + lock + logging | 27.9 s | 71.1% | 17835 | 211.7 s | 41.5% |
| + SSE coalescing | 5.4 s | 87.3% | 28233 | 133.7 s | 47.1% |
| + GC threshold | **0.45 s** | **91.1%** | **35073** | **107.6 s** | **4.7%** |

Each fix moves the bottleneck somewhere else, which the asyncio queue depth shows directly:

| config | peak qdepth | frontend CPU | |
|---|---|---|---|
| leak fix only | 363 | 104% | bottleneck upstream (the lock); the queue never fills |
| + lock + logging | **76384** | 101% | upstream freed, now it floods the event loop |
| + SSE coalescing | 146 | 100% | fewer items per token, rebalanced |
| + GC threshold | **2** | **70%** | event loop keeps up; the GPU is the limit again |

## Ablation

Two rounds. **The first design was wrong**, which is itself informative.

> Both rounds ran on `main`, which has no `--fake-eplb`, so the GPU produces ~29k tok/s rather than the 64.8k above. Absolute values are **not** comparable to the tables above; within each round all variants share one base and are comparable to each other.

### Round 1 — leave-one-out (inconclusive)

Removing any single fix from the full config landed within ±2.6%:

| variant | tok/s | vs full | GPU busy | frontend CPU |
|---|---|---|---|---|
| full | 29120 | — | 92.7% | 57% |
| no_coalesce | 28842 | −1.0% | 92.7% | 86% |
| no_gcthresh | 29805 | +2.4% | 94.1% | 89% |
| no_gcfreeze | 29875 | +2.6% | 94.0% | 55% |
| no_lockfix | 29830 | +2.4% | 94.1% | 58% |
| no_logfix | 29215 | +0.3% | 92.4% | 88% |
| no_leakfix | 29822 | +2.4% | 93.7% | 51% |

Leave-one-out assumes the frontend is still the bottleneck — and together these fixes destroy that assumption. With the GPU at 92–94% and `api_server` at 51–58% CPU, removing any one fix still leaves enough headroom. The probe *can* see each fix working (dropping the GC threshold immediately returns GC to 38.8%, 170 gen-2 passes, 4.1 s loop lag); it just does not cost throughput.

### Round 2 — add-one-in (conclusive)

Starting from everything disabled, enabling one fix at a time:

| variant | tok/s | vs none | GPU busy | bubble | GC | gen-2 | frontend CPU |
|---|---|---|---|---|---|---|---|
| `none` | 13103 | — | 61.6% | 68.6 s | 24.7% | 43 | 106% |
| **`only_coalesce`** | **26848** | **+104.9%** | 93.3% | 0.45 s | 26.9% | 27 | 104% |
| **`only_lockfix`** | **24332** | **+85.7%** | 85.9% | 12.2 s | 23.8% | 11 | 101% |
| `only_logfix` | 15832 | +20.8% | 67.4% | 49.1 s | 28.9% | 42 | 105% |
| `only_gcthresh` | 15594 | +19.0% | 66.4% | 49.0 s | **4.6%** | **0** | 106% |
| `only_gcfreeze` | 14254 | +8.8% | 61.4% | 65.5 s | 24.1% | 52 | 105% |
| **`only_leakfix`** | **10780** | **−17.7%** | 55.7% | 90.4 s | **39.0%** | **224** | 104% |
| `all` | 29040 | +121.6% | 93.0% | 0.47 s | 3.5% | 0 | **57%** |

Three conclusions:

**`gc.freeze()` is redundant — removed.** Both directions agree: taking it out of the full config is a wash, and enabling it alone gives +8.8% while raising gen-2 passes 43 → 52.

**Fixing the leak *alone* is a 17.7% regression — but it still has to be fixed.** Same mechanism as `freeze()`, in reverse: the leak inflated `long_lived_total`, raising the 25% bar, so full collections were *rare* (43). Removing it shrinks the denominator and gen-2 jumps to 224 passes, GC 24.7% → 39.0%. The leak is a memory-correctness bug, not a perf tweak — RSS growth +8.87 → **+3.11 MB/s** — and its throughput benefit only appears together with the threshold.

**The fixes are strongly sub-additive.** Individual gains sum to ≈ +222%; combined they give +121.6%. They all relieve the *same* constraint (one core, one GIL), so once any of them takes the frontend off the critical path the rest have little left to win. This is also why leave-one-out failed.

### Minimum useful configuration

| | coalescing only | **everything except coalescing** | everything |
|---|---|---|---|
| tok/s | 26848 | **28842** | 29040 |
| bubble | 0.45 s | 0.43 s | 0.47 s |
| GC | 26.9% | **1.3%** | 3.5% |
| frontend CPU (headroom) | **104%** | 86% | **57%** |
| peak RSS | **4289 MB** | **1913 MB** | 1911 MB |
| added ITL | **≤200 ms** | **none** | ≤200 ms |

Dropping coalescing and keeping the other three is *faster*, removes the bubble just as well, and costs no latency. `only_coalesce` looks sufficient only because this GPU happens to top out at ~29k tok/s — its frontend CPU is still 104%, i.e. zero headroom. At 64.8k tok/s (the fake-eplb config) coalescing alone reached 18197 against 35073 for all four, i.e. barely half.

Coalescing *mitigates* (fewer items for the event loop); the other three *remove waste*. Removing waste is free, so it should come first — which is exactly the shipped default.

## Defaults

Causes 1–3 are unconditional and none of them trades latency for throughput. Two knobs are opt-in:

| variable | default | |
|---|---|---|
| `ATOM_GC_THRESHOLD` | unset | `"20000,50,50"` produced the numbers above. Off by default because it is a global VM tuning knob whose payoff is specific to high concurrency. |
| `ATOM_SSE_COALESCE_MS` | `0` | Collapses a stream's chunks across engine steps into one detokenize + one queue item + one SSE write. Costs up to that much extra inter-token latency, so opt-in. A `finished` chunk always flushes immediately, so completion is never delayed. |
| `ATOM_SSE_COALESCE_MAX_STEPS` | `8` | Cap on steps coalesced. |

> **Note on measurement coverage:** the shipped default (causes 1–3, both knobs off) was not benchmarked as a single configuration — every table above has at least one knob on. The individual contributions are in the add-one-in ablation.

## Testing

- Test suite identical to `main`: **87 failed / 942 passed / 22 skipped** with and without this branch (the failures are pre-existing import errors, verified by stashing the change and re-running).
- `black --check` clean; `ruff` reports the **same finding count per file** as `main`.
- SSE coalescing correctness: a synthetic tokenizer that emits `U+FFFD` partial characters (exercising the path where the incremental detokenizer must *not* advance its window) — coalesced output is **byte-identical** to unbatched, token sequences match, exactly one `finished` chunk per stream, at 2.8×/4.3×/6.6× batching.
- Lock removal: 4 threads × 400 streams × 60 steps sharing one dispatcher with concurrent `discard_request`, 96,000 chunks, no exceptions, no leaked state.

## Follow-ups (not in this PR)

- The instrumentation used to find all of this — a probe over stream queues, socket Send-Q/Recv-Q, per-thread CPU, GC pause attribution, RSS and event-loop lag — is on `jun/cpu_dbg`, branched from here.
- RSS still grows ~4 MB/s (peak ~2 GB). Not a problem over a 107 s run; worth confirming for long-lived servers.
- The coalescing factor only reaches 2.82 (vs a theoretical 6): a `finished` chunk force-flushes the whole buffer. Flushing just that one stream should improve it.
- Unrelated and unresolved: every run on **GPUs 0–3** died with `Memory access fault by GPU node-2 ... on address (nil)` → `ModelRunner0 exitcode=-6`, reproducibly, across two models and two tp sizes. All measurements above avoid that group (`HIP_VISIBLE_DEVICES=4,5,6,7`), where eight consecutive runs had zero crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
