### PR TITLE
(fix)Fix missing MTP metadata in interleaved agentic prefill and decode

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -3210,6 +3210,9 @@ class ModelRunner:
             is_deferred_out=self.tokenID_processor.is_deferred_out,
             num_rejected=prev_rejected_num,
             num_bonus=prev_bonus_num,
+            is_prev_prefill=(
+                prev_batch is not None and prev_batch.total_seqs_num_prefill > 0
+            ),
             logprobs=logprobs_map,
             dspark_ell=dspark_ell,
         )

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -1817,8 +1817,7 @@ class Scheduler:
                 # that case (it previously crashed long AgentX MTP runs).
                 if fwd_output.num_rejected is None or fwd_output.num_bonus is None:
                     if not (
-                        fwd_output.num_rejected is None
-                        and fwd_output.num_bonus is None
+                        fwd_output.num_rejected is None and fwd_output.num_bonus is None
                     ):
                         raise RuntimeError(
                             "Incomplete speculative metadata: num_rejected and "

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -554,6 +554,11 @@ class Scheduler:
 
         # Speculative decoding
         self.use_spec = config.speculative_config is not None
+        self.spec_method = (
+            getattr(config.speculative_config, "method", None)
+            if self.use_spec
+            else None
+        )
         self.mtp_k: int = (
             config.speculative_config.num_speculative_tokens if self.use_spec else 0
         )  # type: ignore
@@ -1805,13 +1810,49 @@ class Scheduler:
                 token_logprob = token_logprobs.get(seq.id)
 
             if is_deferred_out or self.use_spec:
-                # int() casts strip the np.int32 wrapper coming out of
-                # fwd_output's np.ndarray indexing. Without these, the values
-                # propagate into seq.num_rejected / seq.num_bonus_tokens, then
-                # into seq.num_tokens via `preempt()`'s `-= mtp_k + num_rejected`,
-                # contaminating downstream logs and arithmetic with np.int32.
-                num_rejected = int(fwd_output.num_rejected[idx])
-                num_bonus = int(fwd_output.num_bonus[idx])
+                # A prefill forward does not run speculative verification. In
+                # deferred/chunked execution its sampled token can surface with
+                # no rejection metadata, which is equivalent to zero rejected
+                # and zero bonus tokens. Do not index the optional arrays in
+                # that case (it previously crashed long AgentX MTP runs).
+                if fwd_output.num_rejected is None or fwd_output.num_bonus is None:
+                    if not (
+                        fwd_output.num_rejected is None
+                        and fwd_output.num_bonus is None
+                    ):
+                        raise RuntimeError(
+                            "Incomplete speculative metadata: num_rejected and "
+                            "num_bonus must either both be present or both be None"
+                        )
+                    if fwd_output.is_prev_prefill or not self.use_spec:
+                        # Prefill emits one target token without proposing or
+                        # validating drafts.
+                        num_rejected = 0
+                        num_bonus = 0
+                    elif (
+                        self.spec_method == "mtp"
+                        and 1 <= num_new_token <= self.mtp_k + 1
+                    ):
+                        # In deferred plain-MTP execution, an interleaved
+                        # prefill can consume the queued D2H status before the
+                        # previous decode output surfaces. The output length is
+                        # sufficient to reconstruct the fixed-width MTP status:
+                        # one target token plus num_bonus accepted drafts.
+                        num_bonus = num_new_token - 1
+                        num_rejected = self.mtp_k - num_bonus
+                    else:
+                        raise RuntimeError(
+                            "Missing speculative metadata for an output with "
+                            f"{num_new_token} accepted tokens"
+                        )
+                else:
+                    # int() casts strip the np.int32 wrapper coming out of
+                    # fwd_output's np.ndarray indexing. Without these, the values
+                    # propagate into seq.num_rejected / seq.num_bonus_tokens, then
+                    # into seq.num_tokens via `preempt()`'s `-= mtp_k + num_rejected`,
+                    # contaminating downstream logs and arithmetic with np.int32.
+                    num_rejected = int(fwd_output.num_rejected[idx])
+                    num_bonus = int(fwd_output.num_bonus[idx])
                 offset = 0 if (num_new_token + num_rejected) == 1 else self.mtp_k
                 # Align stats with vLLM: only count steps that actually ran
                 # speculation (drafts proposed and validated). Skip the
@@ -1857,8 +1898,13 @@ class Scheduler:
                 seq._injected_t0 = None
 
             if self.mtp_k > 0:
-                # idx already resolved above via get_idx
-                seq.spec_token_ids = draft_token_ids[idx]
+                # Prefill outputs do not propose draft tokens. Clear any stale
+                # draft state instead of indexing the optional draft array.
+                seq.spec_token_ids = (
+                    draft_token_ids[idx]
+                    if draft_token_ids is not None
+                    else np.empty(0, dtype=np.int32)
+                )
 
             if seq.num_completion_tokens <= 3 and seq.kv_transfer_params:
                 logger.info(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -775,6 +775,56 @@ class TestPostprocess:
         assert 10 in seq.token_ids
         assert finished == []
 
+    def test_mtp_prefill_output_without_rejection_metadata(self, seq_factory):
+        config = MockConfig(
+            speculative_config=SimpleNamespace(num_speculative_tokens=3, method="mtp")
+        )
+        scheduler = Scheduler(config)
+        seq = self._prefill(scheduler, seq_factory([1, 2, 3, 4]))
+        # The deferred prefill output surfaces after the next speculative
+        # schedule has reserved its placeholder slots.
+        seq.token_ids.extend([0] * scheduler.mtp_k)
+        seq.output_tokens.extend([0] * scheduler.mtp_k)
+        output = ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[(10,)],
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
+            is_prev_prefill=True,
+        )
+
+        finished = scheduler.postprocess(list(scheduler.running), output)
+
+        assert 10 in seq.token_ids
+        assert seq.num_rejected == 0
+        assert seq.num_bonus_tokens == 0
+        assert seq.spec_token_ids.size == 0
+        assert finished == []
+
+    def test_mtp_decode_reconstructs_missing_rejection_metadata(self, seq_factory):
+        config = MockConfig(
+            speculative_config=SimpleNamespace(num_speculative_tokens=3, method="mtp")
+        )
+        scheduler = Scheduler(config)
+        seq = self._prefill(scheduler, seq_factory([1, 2, 3, 4]))
+        seq.token_ids.extend([0] * (scheduler.mtp_k * 2))
+        seq.output_tokens.extend([0] * (scheduler.mtp_k * 2))
+        output = ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[(10, 11, 12, 13)],
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
+            is_prev_prefill=False,
+        )
+
+        scheduler.postprocess(list(scheduler.running), output)
+
+        assert seq.num_rejected == 0
+        assert seq.num_bonus_tokens == 3
+        assert seq.spec_token_ids.size == 0
+
     def test_eos_finishes(self, scheduler, seq_factory):
         seq = self._prefill(scheduler, seq_factory([1, 2, 3, 4]))
         finished = scheduler.postprocess(


### PR DESCRIPTION
## Motivation
Long-running agentic workloads can interleave chunked prefill with deferred MTP decode output. In this case, prefill outputs legitimately contain no speculative rejection metadata, and an interleaved prefill may consume the queued D2H status before the previous MTP decode output is processed.

The scheduler previously assumed that every output had num_rejected, num_bonus, and draft_token_ids whenever speculative decoding was enabled. Indexing these optional arrays caused EngineCore to crash with:
<img width="742" height="358" alt="image" src="https://github.com/user-attachments/assets/37649b4b-b5ba-47c4-b83f-2536e1ac1144" />


## Technical Details

 - Propagate is_prev_prefill from ModelRunner to ScheduledBatchOutput.
 - Record the configured speculative decoding method in the scheduler.
 - Handle missing speculative metadata according to the output type:
    - For prefill output, set rejected and bonus token counts to zero because prefill does not perform speculative verification.
    - For deferred plain-MTP decode output, reconstruct the fixed-width MTP status from the number of returned tokens:
       - num_bonus = num_new_tokens - 1
       - num_rejected = mtp_k - num_bonus
 - Restrict reconstruction to plain MTP outputs with a valid token count.
 - Require num_rejected and num_bonus to be either both present or both absent.
 - Clear stale draft-token state when no draft metadata is returned.
 - Preserve integer normalization for metadata returned as NumPy scalar values.

## Test Result

With this fix, the AgentX MTP3 matrix at concurrency 1, 2, 4, 8, and 10 completed the full profiling duration with zero request errors and passed the AIPerf metric-coverage checks.
<img width="863" height="145" alt="image" src="https://github.com/user-attachments/assets/ce98d472-170e-4b84-b120-183a11ef0c12" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
