### PR TITLE
feat(spec-decode): add synthetic (forced) acceptance-rate knob

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -981,6 +981,12 @@ class SpeculativeConfig:
     draft_model_hf_config: PretrainedConfig | None = None
     use_aux_hidden_state: bool = False
     eagle3_aux_layer_ids: list[int] = field(default_factory=list)
+    # Debug/benchmark knob: when set (float in [0, 1]), the rejection sampler
+    # force-accepts draft tokens with a position-decaying probability calibrated
+    # so the measured mean acceptance rate matches this value, independent of the
+    # real draft/target agreement. Mirrors vLLM's synthetic_acceptance_rate. See
+    # ROCm/ATOM#555.
+    synthetic_acceptance_rate: float | None = None
 
     # model_type → mtp_model_type mapping
     _MTP_TYPE_MAP: ClassVar[dict[str, str]] = {
@@ -1043,6 +1049,13 @@ class SpeculativeConfig:
         return bool(getattr(cfg, "dspark_with_draft", False))
 
     def __post_init__(self):
+        if self.synthetic_acceptance_rate is not None and not (
+            0.0 <= self.synthetic_acceptance_rate <= 1.0
+        ):
+            raise ValueError(
+                "synthetic_acceptance_rate (--spec-decode-acceptance-rate) must "
+                f"be in [0, 1], but got {self.synthetic_acceptance_rate}."
+            )
         if self.draft_model_hf_config is None:
             self.draft_model_hf_config = get_hf_config(
                 self.model, trust_remote_code=True

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -69,6 +69,7 @@ class EngineArgs:
     num_speculative_tokens: int = 1
     kv_transfer_config: str = "{}"
     draft_model: str | None = None
+    spec_decode_acceptance_rate: float | None = None
     mark_trace: bool = False
     enable_rapidserve: bool = False
     disagg_prefill_max_num_seqs: int | None = None
@@ -285,6 +286,19 @@ class EngineArgs:
             "--method eagle3; optional for --method dspark (needed for the "
             "DFlash-backbone drafts such as Kimi-K3-DSpark, omitted for "
             "V4-Pro-DSpark which ships inside the target checkpoint).",
+        )
+        parser.add_argument(
+            "--spec-decode-acceptance-rate",
+            type=float,
+            default=None,
+            help="Debug/benchmark knob: force a fixed speculative-decoding "
+            "acceptance rate in [0, 1]. When set, the rejection sampler ignores "
+            "the real draft/target agreement and force-accepts each draft token "
+            "with a position-decaying probability calibrated so the measured "
+            "mean acceptance rate (accepted_draft/total_draft) matches this "
+            "value (equivalent accept length = 1 + num_speculative_tokens * "
+            "rate). Mirrors vLLM's 'synthetic' rejection_sample_method. Only "
+            "meaningful with a speculative method; leave unset to disable.",
         )
         parser.add_argument(
             "--max-num-batched-tokens",
@@ -517,6 +531,7 @@ class EngineArgs:
             method = kwargs.pop("method")
             num_spec_tokens = kwargs.pop("num_speculative_tokens")
             draft_model = kwargs.pop("draft_model")
+            synthetic_acceptance_rate = kwargs.pop("spec_decode_acceptance_rate")
             if method == "eagle3" and not draft_model:
                 raise ValueError("--draft-model is required when --method eagle3.")
             if draft_model and method == "mtp":
@@ -528,11 +543,13 @@ class EngineArgs:
                 method=method,
                 model=draft_model or self.model,
                 num_speculative_tokens=num_spec_tokens,
+                synthetic_acceptance_rate=synthetic_acceptance_rate,
             )
         else:
             kwargs.pop("method")
             kwargs.pop("num_speculative_tokens")
             kwargs.pop("draft_model")
+            kwargs.pop("spec_decode_acceptance_rate")
             kwargs["speculative_config"] = None
 
         # --enable-tbo [prefill|all] → enable_tbo + enable_tbo_decode

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -713,7 +713,11 @@ class ModelRunner:
             torch.set_default_device(self.device)
             with set_model_tag("drafter"):
                 self.drafter = build_drafter(self.config, self.device, self)
-            self.rejection_sampler = RejectionSampler()
+            self.rejection_sampler = RejectionSampler(
+                synthetic_acceptance_rate=(
+                    self.config.speculative_config.synthetic_acceptance_rate
+                )
+            )
             torch.set_default_device(None)
             logger.info("Loading drafter model...")
             self.drafter.load_model(self.model)

--- a/atom/model_ops/rejection_sampler.py
+++ b/atom/model_ops/rejection_sampler.py
@@ -35,9 +35,20 @@ _SYNTHETIC_PARAMS_CACHE: dict[tuple[float, int], tuple[float, float]] = {}
 # identical on every TP rank: sampled_tokens is broadcast from rank 0 while
 # num_bonus_tokens stays local, so a per-rank torch.rand would desync the two and
 # make the anchor gather read a rejected (-1) column -> the draft model then
-# embeds an invalid id (HSA out-of-bounds). We therefore derive the uniforms from
-# a fixed CPU-seeded generator (identical across ranks / GPUs, and reproducible).
+# embeds an invalid id (HSA out-of-bounds). A dedicated device generator re-seeded
+# from the step counter gives that: same Philox stream, so bit-identical uniforms
+# on every rank, and isolated from whatever else consumes the global RNG.
 _SYNTHETIC_RNG_BASE_SEED = 0x5EED
+# One generator per device, kept alive so the draw costs a kernel and nothing else.
+_SYNTHETIC_GENERATORS: dict[torch.device, torch.Generator] = {}
+
+
+def _synthetic_generator(device: torch.device) -> torch.Generator:
+    generator = _SYNTHETIC_GENERATORS.get(device)
+    if generator is None:
+        generator = torch.Generator(device=device)
+        _SYNTHETIC_GENERATORS[device] = generator
+    return generator
 
 
 def compute_synthetic_rejection_sampler_params(
@@ -211,16 +222,23 @@ def rejection_sample(
             synthetic_acceptance_rate, num_spec_steps
         )
         target_argmax = target_probs.argmax(dim=-1)
-        # Rank-consistent uniforms: draw on CPU from a fixed per-step seed (same on
-        # every TP rank / GPU) so the accept/reject pattern — and hence
-        # num_bonus_tokens — is identical across ranks and matches the broadcast
-        # sampled_tokens. A per-rank torch.rand would desync them and make the
-        # anchor gather read a -1 column (draft embeds an invalid id -> crash).
-        cpu_generator = torch.Generator()
-        cpu_generator.manual_seed(_SYNTHETIC_RNG_BASE_SEED + int(synthetic_step))
+        # Rank-consistent uniforms: a dedicated device generator re-seeded from the
+        # step counter draws the same Philox stream on every TP rank / GPU, so the
+        # accept/reject pattern — and hence num_bonus_tokens — matches the
+        # broadcast sampled_tokens. A per-rank unseeded torch.rand would desync
+        # them and make the anchor gather read a -1 column (draft embeds an
+        # invalid id -> crash).
+        #
+        # These stay on the device on purpose. Drawing on the host and copying in
+        # costs a pageable H2D, which PyTorch issues as memcpy + stream sync: the
+        # caller then blocks until the whole target forward has drained, right
+        # between verify and propose, so the draft model's kernels cannot be
+        # dispatched while the target is still running.
+        generator = _synthetic_generator(device)
+        generator.manual_seed(_SYNTHETIC_RNG_BASE_SEED + int(synthetic_step))
         uniform = torch.rand(
-            num_tokens, dtype=torch.float32, generator=cpu_generator
-        ).to(device)
+            num_tokens, dtype=torch.float32, device=device, generator=generator
+        )
         rejection_synthetic_sample_kernel[(batch_size,)](
             output_token_ids,
             num_bonus_tokens,

--- a/atom/model_ops/rejection_sampler.py
+++ b/atom/model_ops/rejection_sampler.py
@@ -102,7 +102,7 @@ def _get_synthetic_params(rate: float, num_spec_steps: int) -> tuple[float, floa
 
 
 class RejectionSampler(nn.Module):
-    def __init__(self, synthetic_acceptance_rate: Optional[float] = None):
+    def __init__(self, synthetic_acceptance_rate: float | None = None):
         super().__init__()
         # Debug/benchmark override: force a fixed acceptance rate (see module
         # docstring). None => normal draft/target rejection sampling.
@@ -171,7 +171,7 @@ def rejection_sample(
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
     # Debug override: forced acceptance rate in [0, 1] (None => normal path).
-    synthetic_acceptance_rate: Optional[float] = None,
+    synthetic_acceptance_rate: float | None = None,
     # Per-step seed for the (rank-consistent) synthetic RNG; ignored otherwise.
     synthetic_step: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:

--- a/atom/model_ops/rejection_sampler.py
+++ b/atom/model_ops/rejection_sampler.py
@@ -15,8 +15,110 @@ else:
     RELAXED_TOP_N = 1
     RELAXED_DELTA = 0.0
 
+# --- Synthetic (forced) acceptance rate for spec-decode debugging ---
+# Enabled via --spec-decode-acceptance-rate (SpeculativeConfig.synthetic_
+# acceptance_rate). When set (float in [0, 1]), the rejection sampler ignores the
+# real draft/target comparison and force-accepts each draft token with a
+# position-dependent probability calibrated so the measured mean acceptance rate
+# converges to the configured value. Purely a benchmarking / bring-up knob (e.g.
+# while an MTP/EAGLE head is still training). Mirrors vLLM's "synthetic"
+# rejection_sample_method. See ROCm/ATOM#555.
+#
+# Lowest per-position conditional-acceptance decay (empirically ~what a
+# well-tuned draft model exhibits); bounds the search so the base rate stays
+# <= 1 while still reaching the requested mean. Matches vLLM's constant.
+MIN_ACCEPTANCE_DECAY_FACTOR = 0.85
+# Cache {(rate, num_spec_steps): (base_rate, decay_factor)} — params depend on
+# both the target rate and the runtime step count.
+_SYNTHETIC_PARAMS_CACHE: dict[tuple[float, int], tuple[float, float]] = {}
+# Base seed for the per-step synthetic RNG. The forced accept/reject draw MUST be
+# identical on every TP rank: sampled_tokens is broadcast from rank 0 while
+# num_bonus_tokens stays local, so a per-rank torch.rand would desync the two and
+# make the anchor gather read a rejected (-1) column -> the draft model then
+# embeds an invalid id (HSA out-of-bounds). We therefore derive the uniforms from
+# a fixed CPU-seeded generator (identical across ranks / GPUs, and reproducible).
+_SYNTHETIC_RNG_BASE_SEED = 0x5EED
+
+
+def compute_synthetic_rejection_sampler_params(
+    p_avg: float, n: int, tol: float = 1e-9
+) -> tuple[float, float]:
+    """Derive (base_acceptance_rate, decay_factor) for a target mean rate.
+
+    With ``n`` speculative positions the conditional acceptance probability at
+    position ``i`` is ``base_rate * decay_factor**i``. The joint probability of
+    accepting through position ``i`` is therefore
+    ``base_rate**(i+1) * decay_factor**(i*(i+1)/2)`` and the mean of those joint
+    probabilities across the ``n`` positions equals ``p_avg`` (== ATOM's
+    ``accepted_draft_tokens / total_draft_tokens`` acceptance rate).
+    """
+
+    def mean_joint_prob(a_0: float, gamma: float, n: int) -> float:
+        total = 0.0
+        for i in range(n):
+            total += a_0 ** (i + 1) * gamma ** (i * (i + 1) // 2)
+        return total / n
+
+    def min_valid_decay_factor(p: float, n: int) -> float:
+        low, high = MIN_ACCEPTANCE_DECAY_FACTOR, 1.0
+        # Even with a base rate of 1, a large decay is required for big p; find
+        # the smallest decay that can still reach p so base_rate stays <= 1.
+        if mean_joint_prob(1.0, low, n) >= p:
+            return low
+        while (high - low) > tol:
+            mid = (low + high) / 2
+            if mean_joint_prob(1.0, mid, n) >= p:
+                high = mid
+            else:
+                low = mid
+        return high
+
+    def compute_base_acceptance_rate(p_avg: float, gamma: float, n: int) -> float:
+        if p_avg <= 0.0:
+            return 0.0
+        if p_avg >= 1.0:
+            return 1.0
+        low, high = 0.0, 1.0
+        while (high - low) > tol:
+            mid = (low + high) / 2
+            if mean_joint_prob(mid, gamma, n) >= p_avg:
+                high = mid
+            else:
+                low = mid
+        return high
+
+    decay_factor = min_valid_decay_factor(p_avg, n)
+    base_rate = compute_base_acceptance_rate(p_avg, decay_factor, n)
+    return base_rate, decay_factor
+
+
+def _get_synthetic_params(rate: float, num_spec_steps: int) -> tuple[float, float]:
+    key = (rate, num_spec_steps)
+    if key not in _SYNTHETIC_PARAMS_CACHE:
+        _SYNTHETIC_PARAMS_CACHE[key] = compute_synthetic_rejection_sampler_params(
+            rate, num_spec_steps
+        )
+    return _SYNTHETIC_PARAMS_CACHE[key]
+
 
 class RejectionSampler(nn.Module):
+    def __init__(self, synthetic_acceptance_rate: Optional[float] = None):
+        super().__init__()
+        # Debug/benchmark override: force a fixed acceptance rate (see module
+        # docstring). None => normal draft/target rejection sampling.
+        if synthetic_acceptance_rate is not None and not (
+            0.0 <= synthetic_acceptance_rate <= 1.0
+        ):
+            raise ValueError(
+                "synthetic_acceptance_rate must be in [0, 1], "
+                f"but got {synthetic_acceptance_rate}"
+            )
+        self.synthetic_acceptance_rate = synthetic_acceptance_rate
+        # Per-step seed for the synthetic RNG, advanced once per forward. Stays in
+        # lockstep across TP ranks (SPMD), so the forced accept/reject pattern is
+        # identical on every rank while still varying step to step.
+        self._synthetic_step = 0
+
     def forward(
         self,
         metadata: SpecDecodeMetadata,
@@ -46,7 +148,11 @@ class RejectionSampler(nn.Module):
             None,
             target_logits,
             bonus_token_ids,
+            synthetic_acceptance_rate=self.synthetic_acceptance_rate,
+            synthetic_step=self._synthetic_step,
         )
+        if self.synthetic_acceptance_rate is not None:
+            self._synthetic_step += 1
         return output_token_ids
 
 
@@ -64,6 +170,10 @@ def rejection_sample(
     target_probs: torch.Tensor,
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
+    # Debug override: forced acceptance rate in [0, 1] (None => normal path).
+    synthetic_acceptance_rate: Optional[float] = None,
+    # Per-step seed for the (rank-consistent) synthetic RNG; ignored otherwise.
+    synthetic_step: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert draft_token_ids.ndim == 1
     assert draft_probs is None or draft_probs.ndim == 2
@@ -91,7 +201,40 @@ def rejection_sample(
     )
     num_bonus_tokens = torch.empty(batch_size, dtype=torch.int32, device=device)
 
-    if RELAXED_TOP_N <= 1:
+    if synthetic_acceptance_rate is not None:
+        # Synthetic path: force a target acceptance rate independent of the real
+        # draft/target agreement. Draft tokens are accepted with a
+        # position-decaying probability; on the first rejection we emit the
+        # target argmax as the correction token and stop (same output layout /
+        # num_bonus_tokens semantics as the greedy path).
+        base_rate, decay_factor = _get_synthetic_params(
+            synthetic_acceptance_rate, num_spec_steps
+        )
+        target_argmax = target_probs.argmax(dim=-1)
+        # Rank-consistent uniforms: draw on CPU from a fixed per-step seed (same on
+        # every TP rank / GPU) so the accept/reject pattern — and hence
+        # num_bonus_tokens — is identical across ranks and matches the broadcast
+        # sampled_tokens. A per-rank torch.rand would desync them and make the
+        # anchor gather read a -1 column (draft embeds an invalid id -> crash).
+        cpu_generator = torch.Generator()
+        cpu_generator.manual_seed(_SYNTHETIC_RNG_BASE_SEED + int(synthetic_step))
+        uniform = torch.rand(
+            num_tokens, dtype=torch.float32, generator=cpu_generator
+        ).to(device)
+        rejection_synthetic_sample_kernel[(batch_size,)](
+            output_token_ids,
+            num_bonus_tokens,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            uniform,
+            base_rate,
+            decay_factor,
+            num_spec_steps,
+            num_warps=1,
+        )
+    elif RELAXED_TOP_N <= 1:
         # Strict greedy path: draft must exactly match target argmax
         target_argmax = target_probs.argmax(dim=-1)
         rejection_greedy_sample_kernel[(batch_size,)](
@@ -167,6 +310,74 @@ def rejection_greedy_sample_kernel(
         tl.store(
             output_token_ids_ptr + req_idx * (num_spec_steps + 1) + pos,
             target_argmax_id,
+        )
+
+    if rejected:
+        bonus_token_id = INVALID_TOKEN
+    else:
+        bonus_token_id = tl.load(bonus_token_ids_ptr + req_idx)
+        num_bonus_token += 1
+    tl.store(
+        output_token_ids_ptr + req_idx * (num_spec_steps + 1) + num_draft_tokens,
+        bonus_token_id,
+    )
+    # Fill the unwritten tail [num_draft_tokens+1 .. num_spec_steps] with the
+    # -1 sentinel so downstream first-`-1` truncation is correct with
+    # variable-length verification (output buffer is torch.empty).
+    for pos in range(num_draft_tokens + 1, num_spec_steps + 1):
+        tl.store(
+            output_token_ids_ptr + req_idx * (num_spec_steps + 1) + pos,
+            INVALID_TOKEN,
+        )
+    tl.store(num_bonus_tokens_ptr + req_idx, num_bonus_token)
+
+
+@triton.jit(do_not_specialize=["num_spec_steps"])
+def rejection_synthetic_sample_kernel(
+    output_token_ids_ptr,  # [batch_size, num_spec_steps + 1]
+    num_bonus_tokens_ptr,
+    cu_num_draft_tokens_ptr,  # [batch_size]
+    draft_token_ids_ptr,  # [num_tokens]
+    target_argmax_ptr,  # [num_tokens]
+    bonus_token_ids_ptr,  # [batch_size]
+    uniform_ptr,  # [num_tokens] — per-position U(0, 1) samples
+    base_acceptance_rate,
+    decay_factor,
+    num_spec_steps,
+):
+    req_idx = tl.program_id(0)
+
+    if req_idx == 0:
+        start_idx = 0
+    else:
+        start_idx = tl.load(cu_num_draft_tokens_ptr + req_idx - 1)
+    end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
+    num_draft_tokens = end_idx - start_idx
+
+    rejected = False
+    num_bonus_token = -1
+    INVALID_TOKEN: tl.constexpr = -1
+    # Per-position conditional acceptance probability, decaying geometrically.
+    acceptance_rate = base_acceptance_rate
+    for pos in range(num_draft_tokens):
+        if rejected:
+            output_id = INVALID_TOKEN
+        else:
+            u = tl.load(uniform_ptr + start_idx + pos)
+            if u < acceptance_rate:
+                # Force-accept: emit the draft's own proposed token.
+                output_id = tl.load(draft_token_ids_ptr + start_idx + pos)
+                output_id = tl.cast(output_id, tl.int32)
+            else:
+                # Reject: emit the target correction token and stop accepting.
+                output_id = tl.load(target_argmax_ptr + start_idx + pos)
+                output_id = tl.cast(output_id, tl.int32)
+                rejected = True
+            num_bonus_token += 1
+            acceptance_rate = acceptance_rate * decay_factor
+        tl.store(
+            output_token_ids_ptr + req_idx * (num_spec_steps + 1) + pos,
+            output_id,
         )
 
     if rejected:

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -154,6 +154,7 @@ class TestEngineArgsSpeculativeValidation:
             method="mtp",
             model=args.model,
             num_speculative_tokens=3,
+            synthetic_acceptance_rate=None,
         )
         assert kwargs["speculative_config"] is fake_spec_config
 


### PR DESCRIPTION
## Summary
Adds a `--spec-decode-acceptance-rate` knob that forces a fixed speculative-decoding acceptance rate, mirroring vLLM's "synthetic" rejection-sampling method (see ROCm/ATOM#555). It's a benchmarking / bring-up tool for measuring end-to-end speedup at a controlled acceptance rate, decoupled from real draft-model quality.

- **CLI**: `--spec-decode-acceptance-rate <float in [0,1]>` (only meaningful with a spec method; unset = normal rejection). Threaded through `SpeculativeConfig.synthetic_acceptance_rate` → `RejectionSampler`.
- **Kernel**: a Triton path in the rejection sampler force-accepts each draft token with a position-decaying geometric probability, with `(base_rate, decay_factor)` derived per `num_speculative_tokens` by binary search so the measured mean acceptance rate matches the target (accept length ≈ `1 + num_speculative_tokens * rate`). Replicates vLLM's math.
- **Works for MTP / EAGLE / DSpark** — all share the rejection-sample acceptance path.

## Files
- `atom/model_engine/arg_utils.py` — CLI arg + threading into `SpeculativeConfig`.
- `atom/config.py` — `synthetic_acceptance_rate` field + `[0,1]` validation.
- `atom/model_ops/rejection_sampler.py` — param computation, synthetic Triton kernel, rank-consistent RNG.
- `atom/model_engine/model_runner.py` — construct `RejectionSampler` with the configured rate.

## Test plan
- [x] Offline: parameter math matches vLLM; kernel measured rate within ±0.5% across `k∈{1..7}` and rates `{0..1}`; determinism + anchor-validity checks pass.
- [x] E2E DSpark (Kimi-K3, TP8, 96 conc): rate 0.3 → **30.2%** (client & server), rate 0.7 → **70.7%**; natural baseline 48.5%; no crashes.
- [x] E2E MTP (DeepSeek-V4-Flash-FP8, TP8): rate 0.7 → 69.9%, rate 0.3 → 30.1%.
