### PR TITLE
feat(lmcache): validate NVMe offload storage

### DIFF
--- a/atom/kv_transfer/offload/README.md
+++ b/atom/kv_transfer/offload/README.md
@@ -527,11 +527,16 @@ LMCache is driven by `LMCACHE_*` env, exactly like the vLLM recipe:
 
 | Env | Purpose |
 |-----|---------|
-| `LMCACHE_LOCAL_CPU=True` | Enable the CPU (L2) tier. |
-| `LMCACHE_MAX_LOCAL_CPU_SIZE` | CPU tier size, GiB. |
+| `LMCACHE_LOCAL_CPU` | Enable the CPU hot-cache tier. Set `False` for NVMe-only storage. |
+| `LMCACHE_MAX_LOCAL_CPU_SIZE` | CPU hot-cache/staging allocator size, GiB. This must remain greater than zero for NVMe I/O even when `LMCACHE_LOCAL_CPU=False`. |
 | `LMCACHE_CHUNK_SIZE=256` | LMCache chunk size (must be a multiple of ATOM block size). |
-| `LMCACHE_LOCAL_DISK` | NVMe (L3) tier path; omit to disable. |
-| `LMCACHE_MAX_LOCAL_DISK_SIZE` | NVMe tier size, GiB. |
+| `LMCACHE_LOCAL_DISK` | NVMe (L3) tier path; omit together with disk size to disable. |
+| `LMCACHE_MAX_LOCAL_DISK_SIZE` | NVMe tier size, GiB; must be greater than zero when a disk path is set. |
+
+NVMe uses LMCache's host-mediated POSIX path, not GDS: HBM is staged through
+the CPU allocator before `LocalDiskBackend` writes or reads the NVMe files. At
+startup each worker logs the realized backend list and capacities; a configured
+disk tier fails startup if `LocalDiskBackend` was not actually created.
 
 Connector-specific tuning (env):
 
@@ -559,6 +564,12 @@ export LMCACHE_LOCAL_CPU=True
 export LMCACHE_MAX_LOCAL_CPU_SIZE=200          # GiB CPU tier
 export LMCACHE_CHUNK_SIZE=256
 # Optional NVMe L3 tier:
+# export LMCACHE_LOCAL_DISK=/nvme/lmcache
+# export LMCACHE_MAX_LOCAL_DISK_SIZE=2000
+
+# For an NVMe-backed tier without a CPU hot cache, use:
+# export LMCACHE_LOCAL_CPU=False
+# export LMCACHE_MAX_LOCAL_CPU_SIZE=8           # required host staging pool
 # export LMCACHE_LOCAL_DISK=/nvme/lmcache
 # export LMCACHE_MAX_LOCAL_DISK_SIZE=2000
 

--- a/atom/kv_transfer/offload/README.md
+++ b/atom/kv_transfer/offload/README.md
@@ -581,6 +581,119 @@ python -m atom.entrypoints.openai_server \
   --kv-transfer-config '{"kv_connector":"lmcache_offload","kv_role":"offload"}'
 ```
 
+### NVMe-only standalone example
+
+Use the following configuration to keep reusable KV on NVMe without retaining
+it in the LMCache CPU hot-cache tier. `LMCACHE_MAX_LOCAL_CPU_SIZE` must still be
+positive because the POSIX disk backend stages data through host memory.
+
+Start the server in terminal 1:
+
+```bash
+export MODEL_PATH=/path/to/model
+export NVME_CACHE_DIR=/mnt/nvme/lmcache
+export SERVER_LOG=/tmp/atom-lmcache-nvme.log
+
+mkdir -p "${NVME_CACHE_DIR}"
+export PYTHONHASHSEED=0
+export LMCACHE_LOCAL_CPU=False
+export LMCACHE_MAX_LOCAL_CPU_SIZE=8
+export LMCACHE_LOCAL_DISK="${NVME_CACHE_DIR}"
+export LMCACHE_MAX_LOCAL_DISK_SIZE=200
+export LMCACHE_CHUNK_SIZE=256
+export LMCACHE_USE_GDS=False
+export OFFLOAD_MIN_LOAD_TOKENS=0
+
+python -m atom.entrypoints.openai_server \
+  --model "${MODEL_PATH}" \
+  --host 0.0.0.0 \
+  --server-port 8000 \
+  --trust-remote-code \
+  --tensor-parallel-size 8 \
+  --kv_cache_dtype fp8 \
+  --block-size 16 \
+  --max-model-len 8192 \
+  --no-enable_prefix_caching \
+  --kv-transfer-config '{"kv_connector":"lmcache_offload","kv_role":"offload"}' \
+  2>&1 | tee "${SERVER_LOG}"
+```
+
+`LMCACHE_CHUNK_SIZE` must be divisible by `--block-size`. Native prefix caching
+is disabled above so repeated requests demonstrate LMCache retrieval rather than
+an HBM prefix-cache hit. It may remain enabled in production if both tiers are
+desired. `OFFLOAD_MIN_LOAD_TOKENS=0` makes short validation prompts eligible for
+reload; tune it upward in production when recomputing small prefixes is cheaper.
+
+In terminal 2, wait for readiness and send requests normally:
+
+```bash
+export MODEL_PATH=/path/to/model
+export NVME_CACHE_DIR=/mnt/nvme/lmcache
+export SERVER_LOG=/tmp/atom-lmcache-nvme.log
+
+curl -sf http://127.0.0.1:8000/v1/models
+
+curl http://127.0.0.1:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"${MODEL_PATH}\",\"prompt\":\"Repeat a sufficiently long prompt here...\",\"max_tokens\":32,\"temperature\":0}"
+```
+
+Send the same prompt again to exercise the NVMe reload path, then confirm the
+realized backend topology and store/retrieve operations:
+
+```bash
+grep -E 'storage: backends|Stored [1-9]|Retrieved [1-9]|OFFLOAD-(LOAD|SAVE)-PROF' \
+  "${SERVER_LOG}"
+find "${NVME_CACHE_DIR}" -name '*.pt' -type f | wc -l
+```
+
+For a GSM8K validation, run the evaluator twice against the same live server.
+The first pass populates NVMe and the second pass reuses the same prompt KV:
+
+```bash
+export OPENAI_API_KEY=dummy
+
+lm_eval \
+  --model local-completions \
+  --model_args "model=${MODEL_PATH},base_url=http://127.0.0.1:8000/v1/completions,tokenizer=${MODEL_PATH},tokenized_requests=False,max_length=4096,num_concurrent=32,max_retries=3,trust_remote_code=True" \
+  --tasks gsm8k \
+  --num_fewshot 5 \
+  --batch_size 1 \
+  --output_path /tmp/gsm8k-pass1 \
+  --log_samples
+```
+
+To require physical disk reads rather than Linux file-page-cache hits during a
+controlled test, evict only this cache directory between passes. Do not drop the
+host's global page cache:
+
+```bash
+python - "${NVME_CACHE_DIR}" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+files = list(Path(sys.argv[1]).rglob("*.pt"))
+for path in files:
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+    finally:
+        os.close(fd)
+print(f"evicted file pages for {len(files)} LMCache chunks")
+PY
+
+lm_eval \
+  --model local-completions \
+  --model_args "model=${MODEL_PATH},base_url=http://127.0.0.1:8000/v1/completions,tokenizer=${MODEL_PATH},tokenized_requests=False,max_length=4096,num_concurrent=32,max_retries=3,trust_remote_code=True" \
+  --tasks gsm8k \
+  --num_fewshot 5 \
+  --batch_size 1 \
+  --output_path /tmp/gsm8k-pass2 \
+  --log_samples
+```
+
 `kv_role` selects direction: `offload` (default, save + load), `kv_producer`
 (save only), `kv_consumer` (load only), `kv_both`.
 

--- a/atom/kv_transfer/offload/config.py
+++ b/atom/kv_transfer/offload/config.py
@@ -43,10 +43,7 @@ def build_lmcache_config(
     apply_extra_overrides(cfg, kv_transfer_config)
     # cufile GDS has no NVMe-GDS hardware here and hangs on init; force off.
     if getattr(cfg, "use_gds", False):
-        try:
-            cfg.use_gds = False
-        except Exception:
-            pass
+        cfg.use_gds = False
     # TP>1 fix: only rank 0 serves/answers the ZMQ lookup. Without this the
     # client queries all ranks and takes min() over results; we observed rank!=0
     # engine.lookup returning 0 even though that rank stored the chunk
@@ -54,10 +51,7 @@ def build_lmcache_config(
     # always recomputes. Our connector saves on ALL ranks in lockstep, so rank 0
     # is authoritative for "is it offloaded?"; each rank still loads its own KV
     # shard, and _do_load is all-or-nothing (re-prefills if a shard is missing).
-    try:
-        cfg.lookup_server_worker_ids = [0]
-    except Exception:
-        pass
+    cfg.lookup_server_worker_ids = [0]
     validate_lmcache_storage_config(cfg)
     return cfg
 
@@ -71,10 +65,7 @@ def apply_extra_overrides(cfg, kv_transfer_config: dict[str, Any] | None) -> Non
         if isinstance(key, str) and key.startswith("lmcache."):
             field = key[len("lmcache.") :]
             if hasattr(cfg, field):
-                try:
-                    setattr(cfg, field, value)
-                except Exception:
-                    pass
+                setattr(cfg, field, value)
 
 
 def validate_lmcache_storage_config(cfg: Any) -> None:

--- a/atom/kv_transfer/offload/config.py
+++ b/atom/kv_transfer/offload/config.py
@@ -16,11 +16,31 @@ from __future__ import annotations
 from typing import Any
 
 
-def build_lmcache_config():
-    """Return an ``LMCacheEngineConfig`` from ``LMCACHE_*`` env + extras."""
+def build_lmcache_config(
+    kv_transfer_config: dict[str, Any] | None = None,
+) -> Any:
+    """Return a validated ``LMCacheEngineConfig`` for ATOM offload.
+
+    LMCache's local-disk backend always uses the local-CPU allocator as its
+    host staging pool, even when the CPU hot-cache tier is disabled. Validate
+    that relationship here so an incomplete NVMe configuration fails during
+    connector startup instead of silently running CPU-only.
+
+    Args:
+        kv_transfer_config: Optional ATOM connector configuration containing
+            ``lmcache.<field>`` overrides.
+
+    Returns:
+        The finalized LMCache engine configuration.
+
+    Raises:
+        ValueError: If the local-disk path, capacity, or CPU staging capacity
+            is incomplete.
+    """
     from lmcache.v1.config import LMCacheEngineConfig
 
     cfg = LMCacheEngineConfig.from_env()
+    apply_extra_overrides(cfg, kv_transfer_config)
     # cufile GDS has no NVMe-GDS hardware here and hangs on init; force off.
     if getattr(cfg, "use_gds", False):
         try:
@@ -38,6 +58,7 @@ def build_lmcache_config():
         cfg.lookup_server_worker_ids = [0]
     except Exception:
         pass
+    validate_lmcache_storage_config(cfg)
     return cfg
 
 
@@ -54,6 +75,41 @@ def apply_extra_overrides(cfg, kv_transfer_config: dict[str, Any] | None) -> Non
                     setattr(cfg, field, value)
                 except Exception:
                     pass
+
+
+def validate_lmcache_storage_config(cfg: Any) -> None:
+    """Validate the host-staged LMCache local-disk configuration.
+
+    Args:
+        cfg: An LMCache engine configuration object.
+
+    Raises:
+        ValueError: If only one of the local-disk path/capacity is configured,
+            or if no local-CPU staging capacity is available for disk I/O.
+    """
+    local_disk = getattr(cfg, "local_disk", None)
+    disk_path_configured = bool(str(local_disk).strip()) if local_disk else False
+    try:
+        disk_size_gib = float(getattr(cfg, "max_local_disk_size", 0.0) or 0.0)
+        cpu_size_gib = float(getattr(cfg, "max_local_cpu_size", 0.0) or 0.0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "LMCache CPU/disk capacities must be numeric GiB values"
+        ) from exc
+
+    if disk_path_configured and disk_size_gib <= 0:
+        raise ValueError(
+            "LMCACHE_LOCAL_DISK is set but LMCACHE_MAX_LOCAL_DISK_SIZE must be > 0"
+        )
+    if not disk_path_configured and disk_size_gib > 0:
+        raise ValueError(
+            "LMCACHE_MAX_LOCAL_DISK_SIZE is set but LMCACHE_LOCAL_DISK is missing"
+        )
+    if disk_path_configured and cpu_size_gib <= 0:
+        raise ValueError(
+            "LMCache local-disk offload requires LMCACHE_MAX_LOCAL_CPU_SIZE > 0 "
+            "for the host staging allocator, even when LMCACHE_LOCAL_CPU=False"
+        )
 
 
 def build_lmcache_metadata(config, cfg, world_size: int, worker_id: int):

--- a/atom/kv_transfer/offload/connector.py
+++ b/atom/kv_transfer/offload/connector.py
@@ -107,9 +107,8 @@ class LMCacheOffloadConnector(KVConnectorBase):
         rank, world = tp.rank_in_group, tp.world_size
         self._rank = rank
 
-        cfg = offcfg.build_lmcache_config()
-        offcfg.apply_extra_overrides(
-            cfg, getattr(self._config, "kv_transfer_config", None)
+        cfg = offcfg.build_lmcache_config(
+            getattr(self._config, "kv_transfer_config", None)
         )
         self.chunk_size = int(cfg.chunk_size)
         # num_blocks is the scheduler-visible block count, threaded from the
@@ -142,6 +141,7 @@ class LMCacheOffloadConnector(KVConnectorBase):
         # opaque uint8 object, so keep a supported tensor MemoryFormat.
         self._engine.fmt = MemoryFormat.KV_2LTD
         self._engine.post_init()
+        self._validate_and_log_storage_backends(cfg)
 
         # ZMQ lookup server so the scheduler process can query our hit counts.
         try:
@@ -182,6 +182,41 @@ class LMCacheOffloadConnector(KVConnectorBase):
                 f"transfer_regions={expected} bytes, "
                 f"num_blocks={self._codec.num_blocks}"
             )
+
+    def _validate_and_log_storage_backends(self, cfg) -> None:
+        """Report the realized LMCache tier topology and validate NVMe startup."""
+        storage_manager = getattr(self._engine, "storage_manager", None)
+        backend_names: list[str] = []
+        if storage_manager is not None:
+            list_backends = getattr(storage_manager, "list_backends", None)
+            if callable(list_backends):
+                backend_names = sorted(str(name) for name in list_backends())
+            else:
+                storage_backends = getattr(storage_manager, "storage_backends", {})
+                backend_names = sorted(str(name) for name in storage_backends)
+
+        local_disk = getattr(cfg, "local_disk", None)
+        disk_size_gib = float(getattr(cfg, "max_local_disk_size", 0.0) or 0.0)
+        disk_configured = bool(local_disk) and disk_size_gib > 0
+        if disk_configured and "LocalDiskBackend" not in backend_names:
+            raise RuntimeError(
+                "LMCache local-disk offload was configured but LocalDiskBackend "
+                f"was not created on rank {self._rank}; backends={backend_names}"
+            )
+
+        logger.info(
+            "LMCache offload worker rank=%d storage: backends=%s "
+            "local_cpu=%s max_local_cpu_gib=%s local_disk=%s "
+            "max_local_disk_gib=%s store_location=%s retrieve_locations=%s",
+            self._rank,
+            backend_names,
+            getattr(cfg, "local_cpu", None),
+            getattr(cfg, "max_local_cpu_size", None),
+            local_disk,
+            getattr(cfg, "max_local_disk_size", None),
+            getattr(cfg, "store_location", None),
+            getattr(cfg, "retrieve_locations", None),
+        )
 
     # -- per-step (RPC thread): only enqueue, never copy ------------------
     def start_load_kv(self, metadata) -> None:
@@ -499,8 +534,7 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
             self._min_load_tokens = 8192
 
         try:
-            cfg = offcfg.build_lmcache_config()
-            offcfg.apply_extra_overrides(cfg, kvc)
+            cfg = offcfg.build_lmcache_config(kvc)
             self.chunk_size = int(cfg.chunk_size)
             from lmcache.v1.lookup_client.factory import LookupClientFactory
 

--- a/tests/test_lmcache_offload_connector.py
+++ b/tests/test_lmcache_offload_connector.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import threading
 import types
@@ -16,6 +17,7 @@ except ModuleNotFoundError:
     sys.modules["torch"] = types.ModuleType("torch")
 
 from atom.kv_transfer.disaggregation import KVConnectorOutput, KVOutputAggregator
+from atom.kv_transfer.offload import config as offcfg
 from atom.kv_transfer.offload.atom_kv_byte_codec import ATOMKVByteCodec
 from atom.kv_transfer.offload.atom_lmcache_gpu_connector import (
     ATOMLMCacheGPUConnector,
@@ -143,6 +145,129 @@ def test_raw_bytes_metadata_rejects_unaligned_chunk_size():
             atom_block_size=4,
             bytes_per_block=32,
         )
+
+
+@pytest.mark.parametrize(
+    ("cfg", "message"),
+    [
+        (
+            SimpleNamespace(
+                local_disk="/nvme/lmcache",
+                max_local_disk_size=0,
+                max_local_cpu_size=1,
+            ),
+            "LMCACHE_MAX_LOCAL_DISK_SIZE must be > 0",
+        ),
+        (
+            SimpleNamespace(
+                local_disk=None,
+                max_local_disk_size=1,
+                max_local_cpu_size=1,
+            ),
+            "LMCACHE_LOCAL_DISK is missing",
+        ),
+        (
+            SimpleNamespace(
+                local_disk="/nvme/lmcache",
+                max_local_disk_size=1,
+                max_local_cpu_size=0,
+            ),
+            "LMCACHE_MAX_LOCAL_CPU_SIZE > 0",
+        ),
+    ],
+)
+def test_lmcache_disk_config_requires_complete_host_staging(cfg, message):
+    with pytest.raises(ValueError, match=message):
+        offcfg.validate_lmcache_storage_config(cfg)
+
+
+def test_build_lmcache_config_validates_extras_and_keeps_gds_disabled(monkeypatch):
+    fake_config_module = types.ModuleType("lmcache.v1.config")
+
+    class _FakeEngineConfig:
+        @staticmethod
+        def from_env():
+            return SimpleNamespace(
+                chunk_size=256,
+                local_cpu=True,
+                max_local_cpu_size=1,
+                local_disk=None,
+                max_local_disk_size=0,
+                use_gds=True,
+                lookup_server_worker_ids=None,
+            )
+
+    fake_config_module.LMCacheEngineConfig = _FakeEngineConfig
+    monkeypatch.setitem(sys.modules, "lmcache", types.ModuleType("lmcache"))
+    monkeypatch.setitem(sys.modules, "lmcache.v1", types.ModuleType("lmcache.v1"))
+    monkeypatch.setitem(sys.modules, "lmcache.v1.config", fake_config_module)
+
+    cfg = offcfg.build_lmcache_config(
+        {
+            "kv_connector_extra_config": {
+                "lmcache.local_cpu": False,
+                "lmcache.max_local_cpu_size": 2,
+                "lmcache.local_disk": "/nvme/lmcache",
+                "lmcache.max_local_disk_size": 10,
+                "lmcache.use_gds": True,
+            }
+        }
+    )
+
+    assert cfg.local_cpu is False
+    assert cfg.max_local_cpu_size == 2
+    assert cfg.local_disk == "/nvme/lmcache"
+    assert cfg.max_local_disk_size == 10
+    assert cfg.use_gds is False
+    assert cfg.lookup_server_worker_ids == [0]
+
+
+def test_lmcache_disk_startup_fails_if_backend_was_not_created():
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._rank = 2
+    conn._engine = SimpleNamespace(
+        storage_manager=SimpleNamespace(
+            list_backends=lambda: {"LocalCPUBackend": "LocalCPUBackend"}
+        )
+    )
+    cfg = SimpleNamespace(
+        local_cpu=False,
+        max_local_cpu_size=1,
+        local_disk="/nvme/lmcache",
+        max_local_disk_size=10,
+        store_location=None,
+        retrieve_locations=None,
+    )
+
+    with pytest.raises(RuntimeError, match="LocalDiskBackend was not created"):
+        conn._validate_and_log_storage_backends(cfg)
+
+
+def test_lmcache_disk_startup_logs_realized_backend_topology(caplog):
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._rank = 0
+    conn._engine = SimpleNamespace(
+        storage_manager=SimpleNamespace(
+            list_backends=lambda: {
+                "LocalCPUBackend": "LocalCPUBackend",
+                "LocalDiskBackend": "LocalDiskBackend",
+            }
+        )
+    )
+    cfg = SimpleNamespace(
+        local_cpu=False,
+        max_local_cpu_size=1,
+        local_disk="/nvme/lmcache",
+        max_local_disk_size=10,
+        store_location="LocalDiskBackend",
+        retrieve_locations=["LocalDiskBackend"],
+    )
+
+    with caplog.at_level(logging.INFO, logger="atom"):
+        conn._validate_and_log_storage_backends(cfg)
+
+    assert "LocalDiskBackend" in caplog.text
+    assert "local_disk=/nvme/lmcache" in caplog.text
 
 
 def test_lmcache_connector_maps_token_ranges_to_block_ids():

--- a/tests/test_lmcache_offload_disk_integration.py
+++ b/tests/test_lmcache_offload_disk_integration.py
@@ -61,11 +61,9 @@ def _wait_for_disk_chunks(
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         files = list(disk_path.rglob("*.pt"))
-        if (
-            len(files) == 2
-            and engine.lookup(tokens, search_range=["LocalDiskBackend"])
-            == len(tokens)
-        ):
+        if len(files) == 2 and engine.lookup(
+            tokens, search_range=["LocalDiskBackend"]
+        ) == len(tokens):
             return files
         time.sleep(0.01)
     return list(disk_path.rglob("*.pt"))

--- a/tests/test_lmcache_offload_disk_integration.py
+++ b/tests/test_lmcache_offload_disk_integration.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+if not hasattr(torch, "Tensor") or not hasattr(torch, "arange"):
+    pytest.skip("real torch is unavailable", allow_module_level=True)
+pytest.importorskip("lmcache")
+
+from lmcache.v1.cache_engine import LMCacheEngineBuilder
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryFormat
+from lmcache.v1.metadata import LMCacheMetadata
+
+from atom.kv_transfer.offload.metadata import ATOMRawBytesLMCacheMetadata
+
+
+class _CPUBytesConnector:
+    """Fill and capture LMCache MemoryObjs without requiring a GPU."""
+
+    def __init__(self) -> None:
+        self.expected: list[torch.Tensor] = []
+        self.retrieved: list[torch.Tensor] = []
+
+    def batched_from_gpu(self, memory_objs, starts, ends, **kwargs) -> None:
+        del starts, ends, kwargs
+        self.expected = []
+        for index, memory_obj in enumerate(memory_objs):
+            assert memory_obj.tensor is not None
+            payload = (
+                torch.arange(memory_obj.tensor.numel(), dtype=torch.int64)
+                .add(index * 73)
+                .remainder(256)
+                .to(torch.uint8)
+            )
+            memory_obj.tensor.copy_(payload)
+            self.expected.append(payload.clone())
+
+    def batched_to_gpu(self, memory_objs, starts, ends, **kwargs) -> None:
+        del starts, ends, kwargs
+        self.retrieved = []
+        for memory_obj in memory_objs:
+            assert memory_obj.tensor is not None
+            self.retrieved.append(memory_obj.tensor.detach().cpu().clone())
+
+
+def _wait_for_disk_chunks(
+    engine,
+    tokens: list[int],
+    disk_path: Path,
+    *,
+    timeout_s: float = 5.0,
+) -> list[Path]:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        files = list(disk_path.rglob("*.pt"))
+        if (
+            len(files) == 2
+            and engine.lookup(tokens, search_range=["LocalDiskBackend"])
+            == len(tokens)
+        ):
+            return files
+        time.sleep(0.01)
+    return list(disk_path.rglob("*.pt"))
+
+
+def test_lmcache_local_disk_round_trip_without_cpu_hot_cache(tmp_path: Path):
+    """Store raw ATOM bytes on disk, clear CPU cache, and retrieve them."""
+    instance_id = f"atom-disk-test-{uuid.uuid4().hex}"
+    connector = _CPUBytesConnector()
+    tokens = list(range(16))
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=8,
+        local_cpu=False,
+        max_local_cpu_size=0.01,
+        local_disk=str(tmp_path),
+        max_local_disk_size=0.01,
+        store_location="LocalDiskBackend",
+        retrieve_locations=["LocalDiskBackend"],
+        use_gds=False,
+    )
+    base_metadata = LMCacheMetadata(
+        model_name="atom-disk-test",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.uint8,
+        kv_shape=(1, 2, 8, 1, 1),
+        chunk_size=8,
+        engine_id=instance_id,
+    )
+    metadata = ATOMRawBytesLMCacheMetadata(
+        base_metadata,
+        atom_block_size=4,
+        bytes_per_block=32,
+    )
+
+    engine = LMCacheEngineBuilder.get_or_create(
+        instance_id,
+        config,
+        metadata,
+        connector,
+        lambda tensor, source: None,
+        lambda obj, source: obj,
+    )
+    try:
+        engine.fmt = MemoryFormat.KV_2LTD
+        engine.post_init()
+        assert engine.storage_manager is not None
+        assert "LocalDiskBackend" in engine.storage_manager.list_backends()
+
+        engine.store(tokens)
+        disk_files = _wait_for_disk_chunks(engine, tokens, tmp_path)
+
+        assert len(disk_files) == 2
+        assert all(path.stat().st_size > 0 for path in disk_files)
+        assert engine.lookup(tokens, search_range=["LocalDiskBackend"]) == len(tokens)
+
+        engine.set_hot_cache(False)
+        assert engine.lookup(tokens, search_range=["LocalCPUBackend"]) == 0
+
+        ret_mask = engine.retrieve(tokens)
+
+        assert bool(ret_mask.all())
+        assert len(connector.retrieved) == len(connector.expected) == 2
+        assert all(
+            torch.equal(actual, expected)
+            for actual, expected in zip(
+                connector.retrieved, connector.expected, strict=True
+            )
+        )
+    finally:
+        LMCacheEngineBuilder.destroy(instance_id)

--- a/tests/test_lmcache_offload_gpu_disk_e2e.py
+++ b/tests/test_lmcache_offload_gpu_disk_e2e.py
@@ -106,11 +106,9 @@ def _wait_for_disk_hit(
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         files = list(disk_path.rglob("*.pt"))
-        if (
-            len(files) == 2
-            and engine.lookup(tokens, search_range=["LocalDiskBackend"])
-            == len(tokens)
-        ):
+        if len(files) == 2 and engine.lookup(
+            tokens, search_range=["LocalDiskBackend"]
+        ) == len(tokens):
             return files
         time.sleep(0.01)
     return list(disk_path.rglob("*.pt"))
@@ -200,8 +198,8 @@ def test_gpu_kv_round_trip_through_cpu_staging_and_nvme(tmp_path: Path):
         assert bool(ret_mask.all())
         for layer_name, cache in kv_caches.items():
             for field, expected_tensor in expected[layer_name].items():
-                assert torch.equal(getattr(cache, field), expected_tensor), (
-                    f"GPU KV mismatch after NVMe round trip: {layer_name}.{field}"
-                )
+                assert torch.equal(
+                    getattr(cache, field), expected_tensor
+                ), f"GPU KV mismatch after NVMe round trip: {layer_name}.{field}"
     finally:
         LMCacheEngineBuilder.destroy(instance_id)

--- a/tests/test_lmcache_offload_gpu_disk_e2e.py
+++ b/tests/test_lmcache_offload_gpu_disk_e2e.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+import math
+import time
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+if (
+    not hasattr(torch, "version")
+    or getattr(torch.version, "hip", None) is None
+    or not hasattr(torch, "cuda")
+    or not torch.cuda.is_available()
+):
+    pytest.skip("a ROCm GPU is required", allow_module_level=True)
+pytest.importorskip("lmcache")
+
+from lmcache.v1.cache_engine import LMCacheEngineBuilder
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryFormat
+from lmcache.v1.metadata import LMCacheMetadata
+
+from atom.kv_transfer.offload.atom_kv_byte_codec import ATOMKVByteCodec
+from atom.kv_transfer.offload.atom_lmcache_gpu_connector import (
+    ATOMLMCacheGPUConnector,
+)
+from atom.kv_transfer.offload.metadata import ATOMRawBytesLMCacheMetadata
+
+
+def _uint8_payload(shape: tuple[int, ...], offset: int) -> torch.Tensor:
+    count = math.prod(shape)
+    return (
+        torch.arange(count, dtype=torch.int64, device="cuda")
+        .add(offset)
+        .remainder(251)
+        .to(torch.uint8)
+        .reshape(shape)
+    )
+
+
+def _make_aiter_kv_caches(
+    *,
+    num_blocks: int,
+    block_size: int,
+) -> dict[str, SimpleNamespace]:
+    num_heads = 2
+    head_dim = 16
+    pack = 16
+    caches: dict[str, SimpleNamespace] = {}
+    for layer_id in range(2):
+        base = layer_id * 47
+        caches[f"layer-{layer_id}"] = SimpleNamespace(
+            # AITER x-packed K: (blocks, heads, head_dim/x, block_size, x).
+            k_cache=_uint8_payload(
+                (num_blocks, num_heads, head_dim // pack, block_size, pack),
+                base,
+            ),
+            # AITER head-major V: (blocks, heads, head_dim, block_size).
+            v_cache=_uint8_payload(
+                (num_blocks, num_heads, head_dim, block_size),
+                base + 13,
+            ),
+            k_scale=torch.linspace(
+                0.25 + layer_id,
+                1.75 + layer_id,
+                steps=num_blocks * num_heads,
+                dtype=torch.float32,
+                device="cuda",
+            ).reshape(num_blocks, num_heads),
+            v_scale=torch.linspace(
+                2.25 + layer_id,
+                3.75 + layer_id,
+                steps=num_blocks * num_heads,
+                dtype=torch.float32,
+                device="cuda",
+            ).reshape(num_blocks, num_heads),
+        )
+    return caches
+
+
+def _clone_segments(
+    kv_caches: dict[str, SimpleNamespace],
+) -> dict[str, dict[str, torch.Tensor]]:
+    return {
+        layer_name: {
+            field: getattr(cache, field).clone()
+            for field in ("k_cache", "v_cache", "k_scale", "v_scale")
+        }
+        for layer_name, cache in kv_caches.items()
+    }
+
+
+def _wait_for_disk_hit(
+    engine,
+    tokens: list[int],
+    disk_path: Path,
+    *,
+    timeout_s: float = 20.0,
+) -> list[Path]:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        files = list(disk_path.rglob("*.pt"))
+        if (
+            len(files) == 2
+            and engine.lookup(tokens, search_range=["LocalDiskBackend"])
+            == len(tokens)
+        ):
+            return files
+        time.sleep(0.01)
+    return list(disk_path.rglob("*.pt"))
+
+
+def test_gpu_kv_round_trip_through_cpu_staging_and_nvme(tmp_path: Path):
+    """Round-trip AITER-layout GPU KV bytes through LMCache local disk."""
+    num_blocks = 4
+    block_size = 4
+    chunk_size = 8
+    tokens = list(range(num_blocks * block_size))
+    block_ids = list(range(num_blocks))
+    instance_id = f"atom-gpu-disk-e2e-{uuid.uuid4().hex}"
+
+    kv_caches = _make_aiter_kv_caches(
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+    expected = _clone_segments(kv_caches)
+    codec = ATOMKVByteCodec(kv_caches, num_blocks=num_blocks)
+    assert codec.has_fused_chunk_major_staging
+    gpu_connector = ATOMLMCacheGPUConnector(
+        codec,
+        block_size=block_size,
+        chunk_size=chunk_size,
+    )
+
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=chunk_size,
+        local_cpu=False,
+        max_local_cpu_size=0.01,
+        local_disk=str(tmp_path),
+        max_local_disk_size=0.01,
+        store_location="LocalDiskBackend",
+        retrieve_locations=["LocalDiskBackend"],
+        use_gds=False,
+    )
+    base_metadata = LMCacheMetadata(
+        model_name="atom-gpu-disk-e2e",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.uint8,
+        kv_shape=(2, 2, chunk_size, 2, 16),
+        chunk_size=chunk_size,
+        engine_id=instance_id,
+    )
+    metadata = ATOMRawBytesLMCacheMetadata(
+        base_metadata,
+        atom_block_size=block_size,
+        bytes_per_block=codec.bytes_per_block,
+    )
+
+    engine = LMCacheEngineBuilder.get_or_create(
+        instance_id,
+        config,
+        metadata,
+        gpu_connector,
+        lambda tensor, source: None,
+        lambda obj, source: obj,
+    )
+    try:
+        engine.fmt = MemoryFormat.KV_2LTD
+        engine.post_init()
+        assert engine.storage_manager is not None
+        assert "LocalDiskBackend" in engine.storage_manager.list_backends()
+
+        engine.store(tokens, block_ids=block_ids)
+        disk_files = _wait_for_disk_hit(engine, tokens, tmp_path)
+
+        assert len(disk_files) == 2
+        assert all(path.stat().st_size > 0 for path in disk_files)
+        engine.set_hot_cache(False)
+        assert engine.lookup(tokens, search_range=["LocalCPUBackend"]) == 0
+
+        for cache in kv_caches.values():
+            cache.k_cache.zero_()
+            cache.v_cache.zero_()
+            cache.k_scale.zero_()
+            cache.v_scale.zero_()
+        torch.cuda.synchronize()
+
+        ret_mask = engine.retrieve(tokens, block_ids=block_ids)
+        torch.cuda.synchronize()
+
+        assert bool(ret_mask.all())
+        for layer_name, cache in kv_caches.items():
+            for field, expected_tensor in expected[layer_name].items():
+                assert torch.equal(getattr(cache, field), expected_tensor), (
+                    f"GPU KV mismatch after NVMe round trip: {layer_name}.{field}"
+                )
+    finally:
+        LMCacheEngineBuilder.destroy(instance_id)


### PR DESCRIPTION
## Summary

- validate LMCache local-disk path, capacity, and required CPU staging capacity after connector overrides are applied
- fail connector startup when NVMe is configured but `LocalDiskBackend` was not actually created, and log the realized backend topology on every rank
- document the host-mediated NVMe path (`HBM -> CPU staging -> LocalDiskBackend/POSIX -> NVMe`) and the `LMCACHE_LOCAL_CPU=False` configuration
- add CPU/local-disk and ROCm GPU/local-disk round-trip coverage, including byte-identical AITER KV tensors and FP8 scales

## Why

ATOM delegates storage orchestration to LMCache. A partially configured local-disk tier could previously start without an explicit validation that the requested disk backend was usable. LMCache also still requires a positive local-CPU allocator for host staging when the CPU hot-cache tier is disabled.

This change validates those relationships at startup while continuing to force `use_gds=False`; the tested NVMe path is host-mediated POSIX I/O, not GPU Direct Storage.

## Testing

```text
pytest -q \
  tests/test_lmcache_offload_connector.py \
  tests/test_lmcache_offload_disk_integration.py \
  tests/test_lmcache_offload_gpu_disk_e2e.py

47 passed in 4.59s
```

Additional validation:

- real `LocalDiskBackend` CPU `MemoryObj -> disk -> MemoryObj` round trip with the CPU hot cache disabled
- real gfx950 GPU AITER KV `GPU -> CPU staging -> disk -> CPU staging -> GPU` round trip; K, V, `k_scale`, and `v_scale` were byte-identical
- `python -m compileall` and `git diff --check`

## Full GSM8K NVMe validation

The end-to-end run used a fresh `rocm/atom-dev:latest` container with LMCache 0.4.5, ROCm PyTorch 2.10.0, eight gfx950 GPUs, GLM-5.2-FP8 at TP=8, and the full 1,319-sample GSM8K 5-shot task at concurrency 32.

Configuration relevant to cache isolation:

```text
LMCACHE_LOCAL_CPU=False
LMCACHE_MAX_LOCAL_CPU_SIZE=8
LMCACHE_LOCAL_DISK=<8-NVMe XFS/LVM mount>
LMCACHE_MAX_LOCAL_DISK_SIZE=200
LMCACHE_CHUNK_SIZE=256
LMCACHE_USE_GDS=False
OFFLOAD_MIN_LOAD_TOKENS=0
--no-enable_prefix_caching
```

All eight ranks logged `LocalCPUBackend` plus `LocalDiskBackend`, with `local_cpu=False`. The CPU backend is the required staging allocator rather than a hot-cache tier.

| Metric | Pass 1: populate NVMe | Pass 2: retrieve from NVMe |
|---|---:|---:|
| GSM8K samples | 1,319 / 1,319 | 1,319 / 1,319 |
| Request phase | 3m 54s | 3m 46s |
| Flexible exact match | 0.9378 +/- 0.0067 | 0.9447 +/- 0.0063 |
| Strict exact match | 0.9378 +/- 0.0067 | 0.9447 +/- 0.0063 |
| Cache files | 30,680 | 30,680 (unchanged) |
| Cache allocation | 411 GiB | 411 GiB |
| Physical NVMe I/O | 410.888 GiB written | 409.588 GiB read |

Before pass 2, every cache file was opened and advised with `POSIX_FADV_DONTNEED`; this evicted only this run's file pages rather than dropping the host's global page cache.

Pass 2 LMCache evidence:

```text
Retrieved log records:             10,552 = 1,319 requests x 8 TP ranks
Requests with a retrieve:           1,319 / 1,319
Prompt tokens:                      1,154,952
Tokens restored from NVMe:            983,040
Prompt tokens recomputed:              171,912
Fraction of all prompt tokens hit:       85.1152%
Fraction of chunk-eligible tokens hit:   99.8700%
```

1,314 prompts had a non-empty remainder below the 256-token chunk boundary (mean 129.36 tokens, maximum 255), so the second pass combined NVMe retrieval with real residual prefill before decoding. Five concurrent requests had a partial hit, recomputed one additional chunk, and refreshed the existing disk key without increasing the cache-file count.

The eight physical NVMe device counters were sampled from `/sys/block/nvme*n1/stat`. The server log contained no `ERROR` or traceback during either pass.

## Startup and usage

The full reusable workflow is also documented in `atom/kv_transfer/offload/README.md`. The following is the standalone NVMe-only setup used for validation.

Start ATOM in terminal 1:

```bash
export MODEL_PATH=/path/to/model
export NVME_CACHE_DIR=/mnt/nvme/lmcache
export SERVER_LOG=/tmp/atom-lmcache-nvme.log

mkdir -p "${NVME_CACHE_DIR}"
export PYTHONHASHSEED=0
export LMCACHE_LOCAL_CPU=False
export LMCACHE_MAX_LOCAL_CPU_SIZE=8
export LMCACHE_LOCAL_DISK="${NVME_CACHE_DIR}"
export LMCACHE_MAX_LOCAL_DISK_SIZE=200
export LMCACHE_CHUNK_SIZE=256
export LMCACHE_USE_GDS=False
export OFFLOAD_MIN_LOAD_TOKENS=0

python -m atom.entrypoints.openai_server \
  --model "${MODEL_PATH}" \
  --host 0.0.0.0 \
  --server-port 8000 \
  --trust-remote-code \
  --tensor-parallel-size 8 \
  --kv_cache_dtype fp8 \
  --block-size 16 \
  --max-model-len 8192 \
  --no-enable_prefix_caching \
  --kv-transfer-config '{"kv_connector":"lmcache_offload","kv_role":"offload"}' \
  2>&1 | tee "${SERVER_LOG}"
```

`LMCACHE_CHUNK_SIZE` must be divisible by `--block-size`. The native HBM prefix cache is disabled here so repeated requests prove LMCache/NVMe reuse. In production it can remain enabled if both HBM and NVMe tiers are desired.

Run the full two-pass GSM8K validation in terminal 2:

```bash
export MODEL_PATH=/path/to/model
export NVME_CACHE_DIR=/mnt/nvme/lmcache
export OPENAI_API_KEY=dummy

curl -sf http://127.0.0.1:8000/v1/models

run_gsm8k() {
  local output_path="$1"
  lm_eval \
    --model local-completions \
    --model_args "model=${MODEL_PATH},base_url=http://127.0.0.1:8000/v1/completions,tokenizer=${MODEL_PATH},tokenized_requests=False,max_length=4096,num_concurrent=32,max_retries=3,trust_remote_code=True" \
    --tasks gsm8k \
    --num_fewshot 5 \
    --batch_size 1 \
    --output_path "${output_path}" \
    --log_samples
}

# Pass 1: populate LocalDiskBackend on NVMe.
run_gsm8k /tmp/gsm8k-pass1

# Evict only these LMCache file pages before pass 2.
python - "${NVME_CACHE_DIR}" <<'PY'
import os
import sys
from pathlib import Path

files = list(Path(sys.argv[1]).rglob("*.pt"))
for path in files:
    fd = os.open(path, os.O_RDONLY)
    try:
        os.fsync(fd)
        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
    finally:
        os.close(fd)
print(f"evicted file pages for {len(files)} LMCache chunks")
PY

# Pass 2: retrieve aligned KV chunks from NVMe and recompute the tail.
run_gsm8k /tmp/gsm8k-pass2
```

Verify the backend and actual store/retrieve events:

```bash
grep -E 'storage: backends|Stored [1-9]|Retrieved [1-9]|OFFLOAD-(LOAD|SAVE)-PROF' \
  /tmp/atom-lmcache-nvme.log
find "${NVME_CACHE_DIR}" -name '*.pt' -type f | wc -l
```
