### PR TITLE
[DeepSeek-V4] Fix illegal memory access in CSA decode top-k under MTP

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -176,6 +176,12 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     """[csa_indptr[T]] int32 GPU — packed paged offsets for CSA layers
     (CSA topk compress at slice head + SWA window prefix at tail; topk section
     filled per-layer by csa_translate_pack)."""
+    csa_topk_row_ends: torch.Tensor | None = None
+    """[padded_T] int32 GPU — per-token row length for the decode top-k, passed
+    as its `rowEnds` with `next_n=1`. Literally the array the CSA slice head was
+    reserved from, so what the indexer writes and what the slice holds cannot
+    drift. None outside the decode path (and on callers that build their own
+    metadata, e.g. the SGLang bridge, whose decode is one token per seq)."""
     kv_indices_hca: torch.Tensor | None = None
     """[hca_indptr[T]] int32 GPU — packed paged offsets for HCA layers
     (HCA compress at slice head + SWA window prefix at tail; layer-invariant)."""
@@ -1238,6 +1244,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         _ls = self._v4_fp4_ragged_local_starts[:_padded]
         _le = self._v4_fp4_ragged_local_ends[:_padded]
         compute_varqlen_windows(cu_seq_q, _ncmt, _padded, out=(_rtb, _ls, _le))
+        # `compute_varqlen_windows` ends a row at `n_committed_b - qlen_b + n + 1`
+        # — the same one-KV-row-per-query-token rule the rectangular decode top-k
+        # carries, and the same reason it falls short of the CSA reservation.
+        # Take the reservation instead, so the window the scorer fills, the range
+        # the top-k selects from and the cells the slice holds are one number.
+        _row_ends = attn_metadata.csa_topk_row_ends
+        if _row_ends is not None:
+            _le.copy_(_row_ends[:_padded])
         # Fixed logits width (max_model_len_idx) → the scorer's [padded, W] buffer
         # is a static shape (CG-capturable), same as the rectangular decode path.
         compute_prefill_schedule(
@@ -2693,7 +2707,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         All three per-token regions are RAGGED-PACKED — same layout family as
         the prefill path (`_build_paged_prefill_meta`). Per-token slot count:
           SWA: actual_swa_count = min(positions[t]+1, win)
-          CSA: actual_swa_count + min(n_committed_csa, index_topk)
+          CSA: actual_swa_count + csa_valid_k, where csa_valid_k is what the
+               indexer's top-k will WRITE, not what the token could see — see
+               the comment on `csa_valid_k_per_token` for why speculation
+               makes those two differ
           HCA: actual_swa_count + n_committed_hca
 
         Writes into stable forward_vars buffers (attn_metadata fields are
@@ -2775,9 +2792,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # + H2D-copied by the caller (prepare_decode / build_for_cudagraph_capture).
         actual_swa_count_np = np.minimum(positions_np_view + 1, win).astype(np.int32)
         # csa_valid_k_per_token = min((pos+1)//4, n_committed_csa[bid], index_topk)
-        # — mirrors `_attach_v4_indexer_meta`'s `visible_end_gpu` and the
-        # `csa_translate_pack` kernel's inline computation, so buffer size ↔
-        # kernel-writes match exactly.
+        # — the token's own causal visibility, capped by what the compressor has
+        # committed and by the top-k width. Mirrors `_attach_v4_indexer_meta`'s
+        # `visible_end_gpu`. Staged below and handed to the decode top-k as its
+        # per-row `rowEnds`, so the count the kernel writes IS this reservation
+        # rather than aiter's per-seq guess (see `Indexer._decode_top_k`).
         csa_valid_k_per_token = np.minimum(
             np.minimum(
                 (positions_np_view + 1) // 4,
@@ -2808,6 +2827,12 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         csa_indptr_np[1 : T + 1] = np.cumsum(csa_per_tok, dtype=np.int32)
         if T_pad > T:
             csa_indptr_np[T + 1 :].fill(int(csa_indptr_np[T]))
+        # The same counts, at the padded grid the top-k is launched over. A
+        # CG-padded row gets 0, which makes the kernel write nothing but its
+        # sentinels there — and nothing reads them, since `csa_translate_pack`
+        # bails on those tokens' `batch_id == -1`.
+        csa_topk_row_ends_np = np.zeros(T_pad, dtype=np.int32)
+        csa_topk_row_ends_np[:T] = csa_valid_k_per_token
         # HCA: ragged, per-token len = actual_swa_count + n_committed_hca
         hca_per_tok = actual_swa_count_np + n_committed_hca_per_token
         hca_indptr_np = np.zeros(T_pad + 1, dtype=np.int32)
@@ -2823,6 +2848,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
         hca_indptr_gpu = self._stage(
             f"{buf_prefix_ubatch}v4_kv_indptr_hca", hca_indptr_np
+        )
+        csa_topk_row_ends_gpu = self._stage(
+            f"{buf_prefix_ubatch}v4_csa_topk_row_ends", csa_topk_row_ends_np
         )
         # batch_id_per_token + n_committed_csa_per_seq already staged in
         # `_attach_v4_per_fwd_meta`.
@@ -2914,6 +2942,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # warmup carve-out fires (incomplete state_slot_mapping_cpu).
         attn_metadata.kv_indices_swa = swa_indices_gpu[: int(swa_indptr_np[T])]
         attn_metadata.kv_indices_csa = csa_indices_gpu[: int(csa_indptr_np[T])]
+        attn_metadata.csa_topk_row_ends = csa_topk_row_ends_gpu
         attn_metadata.kv_indices_hca = hca_indices_gpu  # already exact len
         attn_metadata.kv_indptr_swa = swa_indptr_gpu
         attn_metadata.kv_indptr_csa = csa_indptr_gpu
@@ -3539,6 +3568,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # Sized to `mnbt` (worst-case prefill total tokens) since swa_write
         # fires on prefill paths too. Phase B decode only uses [:T_dec].
         bufs["v4_batch_id_per_token"] = CpuGpuBuffer(mnbt, **i32)
+        # Per-token row length handed to the decode top-k as its `rowEnds`,
+        # which is the SAME array the CSA indptr reserves from — see
+        # `_attach_v4_paged_decode_meta`. Sized like `v4_batch_id_per_token`
+        # because it is indexed by the same token id.
+        bufs["v4_csa_topk_row_ends"] = CpuGpuBuffer(mnbt, **i32)
 
         # _build_v4_indexer_meta (CSA only — but allocate unconditionally;
         # never accessed when CSA layers are absent).
@@ -3687,6 +3721,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             bufs[f"{p}v4_kv_indptr_hca"] = CpuGpuBuffer(T_dec + 1, **i32)
             bufs[f"{p}v4_n_committed_csa_per_seq"] = CpuGpuBuffer(bs, **i32)
             bufs[f"{p}v4_batch_id_per_token"] = CpuGpuBuffer(mnbt, **i32)
+            bufs[f"{p}v4_csa_topk_row_ends"] = CpuGpuBuffer(mnbt, **i32)
             bufs[f"{p}v4_indexer_cu_committed"] = CpuGpuBuffer(bs + 1, **i32)
 
             for ratio, is_overlap in self._unique_compress_ratios_overlap:

--- a/atom/model_ops/v4_kernels/csa_translate_pack.py
+++ b/atom/model_ops/v4_kernels/csa_translate_pack.py
@@ -87,13 +87,11 @@ def _csa_translate_pack_kernel(
     # per token — see `_attach_v4_paged_decode_meta` / `_build_paged_prefill_meta`).
     # Reading the delta replaces the previous chain
     # `min(min((pos+1)//ratio, n_csa_seq), index_topk)` — eliminates the
-    # `n_csa_seq` load and the `(pos+1)//ratio` compute, and stays
-    # CORRECT under the aiter `top_k_per_row_*` contract which only writes
-    # `[0, min(k, row_length))` (the tail is uninitialized garbage from
-    # `torch.empty`, never -1 — aiter tests confirm via `compare_topk_results`
-    # checking only the head). The `k_offs < valid_k` mask remains the
-    # primary correctness barrier; `topk >= 0` is dropped as it was never
-    # a reliable filter for the uninitialized tail.
+    # `n_csa_seq` load and the `(pos+1)//ratio` compute. Correct only while
+    # `valid_k` equals aiter's `row_length`, since `top_k_per_row_*` writes
+    # `[0, min(k, row_length))` and leaves the rest as garbage (prefill) or as
+    # `-1` (decode). Both paths now hand the kernel that same number as its
+    # per-row ends. `k_offs < valid_k` is the barrier; the clamp below the floor.
     if INLINE_SKIP_FROM_POS:
         # Decode: skip = `actual_swa_count[t]` = min(positions[t]+1, win).
         # Derived inline so the caller can omit the per-token CPU write +
@@ -121,6 +119,12 @@ def _csa_translate_pack_kernel(
         mask=in_range,
         other=0,
     )
+    # A negative here means the top-k wrote fewer entries than `valid_k` cells
+    # were reserved — the two come from one array now, so it should not happen.
+    # If it ever does, floor to this request's own first compressed row rather
+    # than let `-1` become `phys * ENVELOPE_ROWS - 1`, which is either a fault
+    # or a silent read of whatever the previous block ends with.
+    topk = tl.maximum(topk, 0)
 
     # Translate seq-local row → physical paged offset.
     blk_idx = topk // csa_block_capacity
@@ -163,10 +167,11 @@ def csa_translate_pack(
     (`min((pos+1)//ratio, n_committed_csa[bid], index_topk)`) by construction
     of the CPU-side indptr builders (see `_attach_v4_paged_decode_meta`,
     `_build_paged_prefill_meta`). aiter's `top_k_per_row_*` writes only
-    `[0, valid_k)` and leaves the tail UNINITIALIZED (`torch.empty`, no
-    `-1` fill), so the explicit `k_offs < valid_k` mask is what keeps the
-    kernel correct — the previous `topk >= 0` check would NOT have been a
-    reliable filter for the garbage tail.
+    `[0, min(k, row_length))`, so this holds exactly as long as its `row_length`
+    is that same number — which both paths arrange by handing the kernel per-row
+    ends. The `k_offs < valid_k` mask is what keeps the kernel correct; a
+    `topk >= 0` check would not be, since a prefill tail is uninitialized
+    garbage rather than `-1`.
 
     Args:
       topk_local:                  [T, index_topk] int32 — indexer's seq-local

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1690,6 +1690,43 @@ class Indexer(nn.Module):
             topk_global - seq_base,
         )  # [total_tokens, topk] int32, raw seq-local with -1 in tail
 
+    def _decode_top_k(
+        self,
+        logits: torch.Tensor,
+        out: torch.Tensor,
+        *,
+        num_rows: int,
+        topk: int,
+        next_n: int,
+        n_committed_per_seq_gpu: torch.Tensor,
+        row_ends: torch.Tensor | None,
+    ) -> None:
+        """`top_k_per_row_decode`, bounded per ROW rather than per seq.
+
+        aiter's per-seq bound is `rowEnds[b] - next_n + (row % next_n) + 1` —
+        one KV row per query token, which is a ratio-1 indexer's rule. CSA packs
+        `ratio` query tokens into one compressed row, so under speculation that
+        writes FEWER entries than the CSA slice head reserved and leaves aiter's
+        `-1` sentinel in the rest, which `csa_translate_pack` turns into pool row
+        `phys * envelope_rows - 1`. `row_ends` is the array the head was reserved
+        from, so passing it makes the two exact by construction.
+
+        `row_ends=None` keeps the per-seq form, for callers that build their own
+        metadata (the SGLang bridge), whose decode is one token per seq — where
+        the two bounds coincide.
+        """
+        top_k_per_row_decode(
+            logits,
+            next_n,
+            n_committed_per_seq_gpu,
+            out,
+            num_rows,
+            logits.stride(0),
+            logits.stride(1),
+            k=topk,
+            rowEndsPerRow=row_ends,
+        )
+
     def _score_topk_decode(
         self,
         q_fp8: torch.Tensor,  # [total_tokens, n_heads, head_dim] fp8
@@ -1779,15 +1816,15 @@ class Indexer(nn.Module):
         topk_local = torch.empty(
             total_tokens, self.index_topk, dtype=torch.int32, device=q_fp8.device
         )
-        top_k_per_row_decode(
+        row_ends = getattr(attn_md, "csa_topk_row_ends", None)
+        self._decode_top_k(
             logits,
-            next_n,
-            n_committed_per_seq_gpu,
             topk_local,
-            total_tokens,
-            logits.stride(0),
-            logits.stride(1),
-            k=topk,
+            num_rows=total_tokens,
+            topk=topk,
+            next_n=next_n,
+            n_committed_per_seq_gpu=n_committed_per_seq_gpu,
+            row_ends=None if row_ends is None else row_ends[:total_tokens],
         )
         return topk_local  # [total_tokens, index_topk] int32, raw seq-local
 
@@ -1982,9 +2019,9 @@ class Indexer(nn.Module):
         cta_info = indexer_meta["fp4_cta_info"]
         total_ctas = indexer_meta["fp4_total_ctas"]
         # Write-once GPU scratch, NOT -inf-filled (mirrors the FP8 decode path).
-        # The kernel writes every column in `[0, context_len)` per row and
-        # `top_k_per_row_decode` bounds each row by `n_committed_per_seq` (==
-        # context_len) — so cells past it are never read. A `torch.full(-inf)`
+        # The kernel writes every column in `[0, context_len)` per row and the
+        # top-k bounds each row by at most `n_committed_per_seq` (== context_len)
+        # — so cells past it are never read. A `torch.full(-inf)`
         # pre-fill would be wasted ~290μs FillFunc work at width
         # `max_model_len_idx`. CG-safe: torch.empty lands in the graph's private
         # pool at a stable address across replays at this captured shape.
@@ -2016,15 +2053,15 @@ class Indexer(nn.Module):
         topk_local = torch.empty(
             total_tokens, self.index_topk, dtype=torch.int32, device=q_fp4.device
         )
-        top_k_per_row_decode(
+        row_ends = getattr(attn_md, "csa_topk_row_ends", None)
+        self._decode_top_k(
             logits,
-            next_n,
-            n_committed_per_seq_gpu,
             topk_local,
-            total_tokens,
-            logits.stride(0),
-            logits.stride(1),
-            k=topk,
+            num_rows=total_tokens,
+            topk=topk,
+            next_n=next_n,
+            n_committed_per_seq_gpu=n_committed_per_seq_gpu,
+            row_ends=None if row_ends is None else row_ends[:total_tokens],
         )
         return topk_local  # [total_tokens, index_topk] int32, raw seq-local
 
@@ -2225,15 +2262,23 @@ class Indexer(nn.Module):
         topk_rect = torch.full(
             (R + 1, self.index_topk), -1, dtype=torch.int32, device=device
         )
-        top_k_per_row_decode(
+        # Per-row ends follow the same scatter as Q, so a rect row is bounded by
+        # the count its own token reserved (see `_decode_top_k`). Rows no token
+        # landed on keep 0 — the kernel writes only sentinels there, and the
+        # gather never reads them.
+        row_ends = getattr(attn_md, "csa_topk_row_ends", None)
+        ends_rect = None
+        if row_ends is not None:
+            ends_rect = torch.zeros(R + 1, dtype=torch.int32, device=device)
+            ends_rect[dst] = row_ends[:total_tokens]
+        self._decode_top_k(
             logits,
-            full_q,
-            n_committed_per_seq_gpu,
             topk_rect[:R],
-            R,
-            logits.stride(0),
-            logits.stride(1),
-            k=topk,
+            num_rows=R,
+            topk=topk,
+            next_n=full_q,
+            n_committed_per_seq_gpu=n_committed_per_seq_gpu,
+            row_ends=None if ends_rect is None else ends_rect[:R],
         )
         # Gather each seq's real rows back to the ragged [total_tokens] layout.
         # Pad tokens (dst==R) read the -1 sentinel row → harmless downstream.


### PR DESCRIPTION
[aiter_topk_per_row_kernel](https://github.com/ROCm/aiter/pull/4661)
## Problem

DeepSeek-V4 with MTP speculative decoding crashes on short contexts:

```
torch.AcceleratorError: HIP error: an illegal memory access was encountered
```

Reproducer (tp=2, DeepSeek-V4-Flash-DSpark):

```
--kv_cache_dtype fp8 --level 0 --max-tokens 64 --method mtp --num-speculative-tokens 3
```

Without `--method mtp` the same run is clean.

## Root cause

The CSA slice of `kv_indices_csa` reserves a per-token head of `valid_k` cells and
records it in `kv_indptr_csa`. The attention kernel reads **every** reserved cell as a
live row number — it cannot tell an unwritten cell from a written one. So the head must
be filled exactly as reserved.

Two different formulas were computing that count:

| | who | formula |
|---|---|---|
| reserved | ATOM, on the host | `min((pos+1)//4, n_committed, index_topk)` |
| written | aiter `top_k_per_row_decode` | `rowEnds[b] - next_n + (row % next_n) + 1` |

aiter's bound means *one KV row per query token*, which is correct for a ratio-1 index
cache. V4's CSA is **ratio 4** — four tokens are compressed into one row — so under
speculation the kernel writes fewer entries than were reserved and leaves its documented
`-1` sentinel in the rest.

Concretely, with `n_committed = 2` and `next_n = 4`:

```
                   token0  token1  token2  token3
reserved  valid_k     2       2       2       2
written   row_len     0       0       1       2
unwritten (= -1)      2       2       1       0
```

`csa_translate_pack` then translates the sentinel unconditionally:

```
blk  = -1 / 64 = 0 ; slot = -1 % 64 = -1
row  = block_tables[bid, 0] * ENVELOPE_ROWS + (-1)
```

which is row `-1` when the sequence's first physical block is 0. The ASM MLA decode
kernel reads it and faults on `global_load_lds_dword`.

Two reasons this stayed hidden:

- **Only faults on the layer whose view base row is 0.** On every other layer, row `-1`
  still lands inside the plane and silently reads a neighbouring block's KV. The crash is
  the lucky outcome.
- **Only on short contexts.** Once `index_topk` (2048) caps the reservation, `n_committed
  - next_n + 1` exceeds it and the gap closes. It bites below roughly 8k tokens — exactly
  the GSM8K prompt range.

Non-speculative decode is unaffected: `next_n = 1` makes the two formulas coincide.

## Fix

Make the reservation and the write read from **one array** rather than two agreeing
formulas.

- `deepseek_v4_attn.py` — the causal per-token count is computed once, feeds both
  `kv_indptr_csa` (the reservation) and a new `attn_metadata.csa_topk_row_ends` (the
  bound handed to the top-k). Persistent `CpuGpuBuffer`, staged at the padded grid;
  CUDAGraph pad rows get 0. Also fixes the ragged-FP4 path, whose `local_ends` came from
  `compute_varqlen_windows` and carried the same ratio-1 rule.
- `deepseek_v4.py` — new `Indexer._decode_top_k()` wraps the three decode call sites
  (fp8 rectangular, fp4 rectangular, fp8 ragged) and passes those ends through aiter's
  new `rowEndsPerRow`. `row_ends=None` keeps the per-sequence form for callers that build
  their own metadata (the SGLang bridge, whose decode is one token per sequence, where
  the two bounds coincide).
- `csa_translate_pack.py` — `tl.maximum(topk, 0)` as a floor. If the contract ever breaks
  again, a bad cell degrades to the request's own first compressed row: in bounds, same
  sequence, no fault and no cross-request read.

## Dependency

Requires **ROCm/aiter#4661**, which adds the optional `rowEndsPerRow` argument to
`top_k_per_row_decode`. Please merge that first — without it this branch raises
`TypeError` on the V4 decode path.

## Validation

GSM8K, 3-shot, 1319 samples (CI parity), DeepSeek-V4-Flash-DSpark tp=2, fp8 KV:

| config | flexible-extract | strict | MTP accept |
|---|---|---|---|
| no MTP (target model, ground truth) | 0.9447 | 0.9439 | n/a |
| this fix, MTP-3, run 1 | 0.9454 | 0.9469 | 78.41% |
| this fix, MTP-3, run 2 | 0.9500 | 0.9492 | 78.79% |

Speculative decoding is back to being lossless against the target model — all deltas fall
within 1σ (±0.0063). Zero memory faults across four fresh processes.

For reference, an earlier workaround that clamped the *reservation* down to what aiter
writes scored 0.9363 — 0.84pp below the target model, since it discards visible history.
This PR does not take that approach.

## Test plan

- [x] `black .` / `ruff check .` clean on the changed files
- [x] `python -m pytest tests/` — no new failures vs. the base commit (95 pre-existing
      failures on both, unrelated: scheduler/pp/plugin import errors)
- [x] GSM8K accuracy above, plus a no-MTP control
- [ ] CI matrix has no DeepSeek-V4 entry, so this path is not covered there
