### PR TITLE
[SGL+ATOM]Fix/docker release decouple oot sglang

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -287,6 +287,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push OOT Docker image
+        id: push_oot
         if: ${{ steps.login_oot.outcome == 'success' }}
         continue-on-error: true
         run: |
@@ -357,6 +358,12 @@ jobs:
           else
             echo "Custom SGLang tag suffix '${SGLANG_TAG_SUFFIX}' provided; skipping rocm/atom-dev:${SGLANG_LATEST_TAG} update."
           fi
+
+      - name: Fail if OOT Docker image failed
+        if: ${{ always() && steps.gates.outputs.oot == 'true' && (steps.build_oot.outcome == 'failure' || steps.login_oot.outcome == 'failure' || steps.push_oot.outcome == 'failure') }}
+        run: |
+          echo "OOT vLLM Docker image failed; SGLang steps were allowed to run first."
+          exit 1
 
       - name: Clean Up
         if: always()

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -279,7 +279,7 @@ jobs:
         id: login_oot
         # Fresh token before this push: the OOT build above adds even more time
         # since the initial login, so the auth token is stale by push time.
-        if: ${{ steps.gates.outputs.oot == 'true' && steps.build_oot.outcome == 'success' }}
+        if: ${{ steps.build_oot.outcome == 'success' }}
         continue-on-error: true
         uses: ./.github/actions/docker-auth
         with:
@@ -287,8 +287,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push OOT Docker image
-        id: push_oot
-        if: ${{ steps.gates.outputs.oot == 'true' && steps.build_oot.outcome == 'success' && steps.login_oot.outcome == 'success' }}
+        if: ${{ steps.login_oot.outcome == 'success' }}
         continue-on-error: true
         run: |
           set -euo pipefail

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -259,7 +259,9 @@ jobs:
           fi
 
       - name: Build OOT Docker image
+        id: build_oot
         if: ${{ success() && steps.gates.outputs.oot == 'true' }}
+        continue-on-error: true
         timeout-minutes: 180
         run: |
           OOT_BASE_IMAGE="atom_release:ci"
@@ -274,16 +276,20 @@ jobs:
           docker inspect atom_oot_release:ci
 
       - name: Re-login to Docker Hub before OOT push
+        id: login_oot
         # Fresh token before this push: the OOT build above adds even more time
         # since the initial login, so the auth token is stale by push time.
-        if: ${{ success() && steps.gates.outputs.oot == 'true' }}
+        if: ${{ steps.gates.outputs.oot == 'true' && steps.build_oot.outcome == 'success' }}
+        continue-on-error: true
         uses: ./.github/actions/docker-auth
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push OOT Docker image
-        if: ${{ success() && steps.gates.outputs.oot == 'true' }}
+        id: push_oot
+        if: ${{ steps.gates.outputs.oot == 'true' && steps.build_oot.outcome == 'success' && steps.login_oot.outcome == 'success' }}
+        continue-on-error: true
         run: |
           set -euo pipefail
           VLLM_VER="${VLLM_VERSION}"


### PR DESCRIPTION
## Summary
- Allow OOT vLLM Docker build/login/push failures to continue so SGLang+ATOM Docker build can still run using the local `atom_release:ci` base image.
- Gate OOT re-login and push on the previous OOT step outcome to avoid pushing when the OOT image was not built.
- Add a final OOT failure check after SGLang steps so the workflow still fails red when the requested OOT image fails.

## Test plan
- Not run locally; GitHub Actions workflow change only.
- Expected behavior: if OOT vLLM fails, SGLang build/push still runs, then the workflow fails at the final OOT failure check.
- Expected behavior: if OOT and SGLang both succeed, the workflow remains green.