### PR TITLE
test(mtp): cover deferred status queue across chunked prefill

### DIFF
--- a/tests/test_mtp_deferred_status_queue.py
+++ b/tests/test_mtp_deferred_status_queue.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+
+from atom.model_engine.model_runner import tokenIDProcessor
+from atom.model_engine.scheduler import ScheduledBatch
+
+
+def _prefill_batch(is_final_chunk: list[bool]) -> ScheduledBatch:
+    batch = object.__new__(ScheduledBatch)
+    batch.scheduled_tokens = np.arange(4, dtype=np.int32)
+    batch.total_tokens_num = 4
+    batch.total_tokens_num_prefill = 4
+    batch.total_tokens_num_decode = 0
+    batch.total_seqs_num_prefill = len(is_final_chunk)
+    batch.total_seqs_num_decode = 0
+    batch.is_final_chunk = is_final_chunk
+    return batch
+
+
+def _processor() -> tokenIDProcessor:
+    processor = object.__new__(tokenIDProcessor)
+    processor.input_ids = SimpleNamespace(
+        np=np.zeros(8, dtype=np.int32),
+        gpu=np.zeros(8, dtype=np.int32),
+        copy_to_gpu=mock.Mock(),
+    )
+    processor.recv_mtp_status_async = mock.Mock(
+        return_value=(
+            np.array([2], dtype=np.int32),
+            np.array([1], dtype=np.int32),
+        )
+    )
+    processor.prev_rejected_num = np.array([7], dtype=np.int32)
+    processor.prev_bonus_num = np.array([8], dtype=np.int32)
+    return processor
+
+
+def test_middle_prefills_preserve_status_until_mixed_final_batch():
+    processor = _processor()
+
+    # Pure middle chunks skip postprocess, so neither the deferred-token queue
+    # nor its matching MTP-status queue may advance.
+    tokenIDProcessor.prepare_input_ids(processor, _prefill_batch([False]))
+    tokenIDProcessor.prepare_input_ids(processor, _prefill_batch([False, False]))
+
+    processor.recv_mtp_status_async.assert_not_called()
+    np.testing.assert_array_equal(processor.prev_rejected_num, [7])
+    np.testing.assert_array_equal(processor.prev_bonus_num, [8])
+
+    # If any request reaches its final chunk, the batch runs postprocess. Its
+    # status dequeue must therefore happen exactly once, even though another
+    # request in the same batch is still a middle chunk.
+    tokenIDProcessor.prepare_input_ids(processor, _prefill_batch([False, True]))
+
+    processor.recv_mtp_status_async.assert_called_once_with()
+    np.testing.assert_array_equal(processor.prev_rejected_num, [2])
+    np.testing.assert_array_equal(processor.prev_bonus_num, [1])


### PR DESCRIPTION
## Motivation

Deferred MTP tokens and their rejection/bonus metadata are copied through parallel FIFO queues. Pure middle prefill chunks skip `postprocess()`, so they must not drain the status queue while leaving the token queue untouched.

`main` now gates that drain with `ScheduledBatch.produces_output()`, but there was no direct regression test tying the gate to the MTP status queue. This test protects the original `num_rejected=None` failure mode without duplicating the implementation already present on `main`.

## Test coverage

The new test uses the real `ScheduledBatch.produces_output()` method and verifies that:

- consecutive all-middle prefill batches do not call `recv_mtp_status_async()` or overwrite the previous status;
- a mixed `[middle, final]` prefill batch drains the status exactly once;
- the drained rejection and bonus arrays replace the prior deferred metadata together.

## Validation

- `python -m pytest -q tests/test_mtp_deferred_status_queue.py tests/test_pp.py` — 62 passed
- `python -m pytest -q tests/test_mtp_deferred_status_queue.py tests/test_scheduler.py` — 63 passed
- Black check passed
- Ruff check passed

Signed-off-by: honglie <275632494+yhl-amd@users.noreply.github.com>