### PR TITLE
fix(v4-kernels): let a V4 pool have no dense class, which V4-Pro plus DSpark is

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -550,6 +550,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         self._field_window_layers, self._field_window_dtype = (
             self._discover_field_windows()
         )
+        # A layer whose window moved into a state field is not served by the
+        # dense class any more — it is not in the row space at all — so the
+        # SWA-only MTP fast path cannot address it, whatever its config ratio
+        # says. Narrowed here rather than where the ratios are read, because
+        # which layers those are is only known once the modules exist.
+        self._mtp_layers_are_swa_only = self._mtp_layers_are_swa_only and not any(
+            layer_id >= self._n_main_layers for layer_id in self._field_window_layers
+        )
         # How the compressor state divides between the planes, and what that
         # costs a slot in rows. Settled here because the row space is built
         # from it and sizing prices a slot before either count exists.
@@ -1811,9 +1819,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         if not self.num_state_slots:
             return {}
         assert self._mtp_layers_are_swa_only, (
-            "prepare_mtp_decode fast path only supports SWA-only MTP layers "
-            f"(compress_ratio==0); got compress_ratios[mtp]="
-            f"{self.compress_ratios[self._n_main_layers:]}"
+            "prepare_mtp_decode fast path only supports MTP layers the pool "
+            "serves from the dense class; got compress_ratios[mtp]="
+            f"{self.compress_ratios[self._n_main_layers:]} and field-window "
+            f"layers {self._field_window_layers}"
         )
 
         var = self.model_runner.forward_vars

--- a/atom/model_ops/v4_kernels/paged_decode_indices.py
+++ b/atom/model_ops/v4_kernels/paged_decode_indices.py
@@ -44,7 +44,11 @@ from atom.model_ops.attentions.v4_pool_geometry import (
     HCA_RATIO,
     UnifiedPoolGeometry,
 )
-from atom.model_ops.v4_kernels.pool_index import window_constexprs, window_row
+from atom.model_ops.v4_kernels.pool_index import (
+    served_window_params,
+    window_constexprs,
+    window_row,
+)
 from atom.utils.decorators import mark_trace
 
 
@@ -90,6 +94,7 @@ def _v4_paged_decode_indices_kernel(
     BLOCK_N: tl.constexpr,  # next_pow2(win)
     HAS_CSA: tl.constexpr,  # caller has layers of this class to serve
     HAS_HCA: tl.constexpr,
+    HAS_DENSE: tl.constexpr,
     DENSE_RING_SLOTS: tl.constexpr,
     DENSE_SLOT_ROWS: tl.constexpr,
     DENSE_RING_STRIDE: tl.constexpr,
@@ -122,11 +127,6 @@ def _v4_paged_decode_indices_kernel(
     # `n` = actual valid SWA prefix count. Cast to match `win` (compile-time
     # int) — pos is i32/i64 from positions buffer.
     n = tl.minimum(pos + 1, win)
-    # SWA prefix segment lives at the TAIL of each token's slice (compress
-    # section fills the head). Write base = slice END (indptr[t+1]) - n. For
-    # the SWA buffer (compress=0) end-n == indptr[t], same as a head write.
-    swa_end = tl.load(swa_indptr_ptr + t + 1)
-
     i = tl.arange(0, BLOCK_N)
     mask = i < n
     abs_pos = pos - n + 1 + i  # ∈ [0, pos] for valid i
@@ -135,35 +135,41 @@ def _v4_paged_decode_indices_kernel(
     # ring's last lap.
     slot = tl.load(state_slot_per_seq_ptr + bid)
 
-    tl.store(
-        swa_indices_ptr + swa_end - n + i,
-        window_row(
-            slot,
-            abs_pos,
-            dense_ring_start,
-            DENSE_RING_SLOTS,
-            DENSE_SLOT_ROWS,
-            DENSE_RING_STRIDE,
-            DENSE_RUN_ROWS,
-        ),
-        mask=mask,
-    )
-    # Where this token's own KV row lands. Same formula at `pos` — the last
-    # position of its own window — handed to the fused SWA write so the two
-    # cache-writing paths cannot drift, and so no kernel outside this file
-    # has to know how a window is laid out.
-    tl.store(
-        dense_dest_ptr + t,
-        window_row(
-            slot,
-            pos,
-            dense_ring_start,
-            DENSE_RING_SLOTS,
-            DENSE_SLOT_ROWS,
-            DENSE_RING_STRIDE,
-            DENSE_RUN_ROWS,
-        ),
-    )
+    if HAS_DENSE:
+        # SWA prefix segment lives at the TAIL of each token's slice (compress
+        # section fills the head). Write base = slice END (indptr[t+1]) - n.
+        # For the SWA buffer (compress=0) end-n == indptr[t], same as a head
+        # write.
+        swa_end = tl.load(swa_indptr_ptr + t + 1)
+        tl.store(
+            swa_indices_ptr + swa_end - n + i,
+            window_row(
+                slot,
+                abs_pos,
+                dense_ring_start,
+                DENSE_RING_SLOTS,
+                DENSE_SLOT_ROWS,
+                DENSE_RING_STRIDE,
+                DENSE_RUN_ROWS,
+            ),
+            mask=mask,
+        )
+        # Where this token's own KV row lands. Same formula at `pos` — the last
+        # position of its own window — handed to the fused SWA write so the two
+        # cache-writing paths cannot drift, and so no kernel outside this file
+        # has to know how a window is laid out.
+        tl.store(
+            dense_dest_ptr + t,
+            window_row(
+                slot,
+                pos,
+                dense_ring_start,
+                DENSE_RING_SLOTS,
+                DENSE_SLOT_ROWS,
+                DENSE_RING_STRIDE,
+                DENSE_RUN_ROWS,
+            ),
+        )
     if HAS_CSA:
         csa_end = tl.load(csa_indptr_ptr + t + 1)
         tl.store(
@@ -266,7 +272,10 @@ def write_v4_paged_decode_indices(
                                    prefix + HCA committed per token). `None`
                                    likewise.
       swa_indices:         [>=swa_indptr[T]] int32 OUT — fully written by
-                                   this kernel (no other source).
+                                   this kernel (no other source), unless no
+                                   layer is dense, when it is left untouched:
+                                   the dense class is the only reader and a
+                                   geometry can turn out not to have one.
       csa_indices:         [>=csa_indptr[T]] int32 OUT — SWA prefix written
                                    here at the slice tail
                                    `[csa_indptr[t+1] - n, csa_indptr[t+1])`;
@@ -281,8 +290,11 @@ def write_v4_paged_decode_indices(
                                    caller via numpy fill.
       dest_rows:           {ratio: [>=T] int32 OUT} — the row token `t`'s own
                                    KV goes to in a layer of that class. Needed
-                                   for every class the caller enabled; the
-                                   fused SWA write reads it instead of deriving
+                                   for every class that is both served by the
+                                   geometry and enabled here; the rest are
+                                   handed some other class's buffer and never
+                                   written. The fused SWA write reads it
+                                   instead of deriving
                                    the row itself, which is what keeps the pool
                                    layout out of the fused kernels.
                                    **Defined only where `batch_id_per_token[t]
@@ -311,9 +323,27 @@ def write_v4_paged_decode_indices(
     assert has_csa == (csa_indptr is not None)
     assert has_hca == (hca_indptr is not None)
 
-    dense = geometry.window_params(DENSE_RATIO)
-    csa = geometry.window_params(CSA_RATIO)
-    hca = geometry.window_params(HCA_RATIO)
+    # A class that is off — not in the geometry, or one the caller did not ask
+    # for — still needs a pointer and a value for every `constexpr`, because
+    # Triton takes them by position. It borrows another class's; its `HAS_`
+    # flag is what keeps them away from a store.
+    #
+    # The classes that are ON index `served` directly, on purpose. A caller
+    # asking for rows of a class no layer belongs to then gets a KeyError here
+    # instead of a plausible row written from borrowed parameters — and unlike
+    # an `assert`, that holds under `python -O`.
+    served = served_window_params(geometry)
+    if not served or not dest_rows:
+        raise ValueError(
+            "a V4 index build needs at least one compress class and one "
+            f"destination buffer; got {sorted(served)} and {sorted(dest_rows)}"
+        )
+    has_dense = DENSE_RATIO in served
+    borrowed = next(iter(served.values()))
+    borrowed_dest = next(iter(dest_rows.values()))
+    dense = served[DENSE_RATIO] if has_dense else borrowed
+    csa = served[CSA_RATIO] if has_csa else borrowed
+    hca = served[HCA_RATIO] if has_hca else borrowed
     BLOCK_N = triton.next_power_of_2(win)
     _v4_paged_decode_indices_kernel[(T,)](
         state_slot_per_seq,
@@ -327,9 +357,9 @@ def write_v4_paged_decode_indices(
         swa_indices,
         csa_indices if has_csa else swa_indices,
         hca_indices if has_hca else swa_indices,
-        dest_rows[DENSE_RATIO],
-        dest_rows[CSA_RATIO] if has_csa else dest_rows[DENSE_RATIO],
-        dest_rows[HCA_RATIO] if has_hca else dest_rows[DENSE_RATIO],
+        dest_rows[DENSE_RATIO] if has_dense else borrowed_dest,
+        dest_rows[CSA_RATIO] if has_csa else borrowed_dest,
+        dest_rows[HCA_RATIO] if has_hca else borrowed_dest,
         dense.ring_start,
         csa.ring_start,
         hca.ring_start,
@@ -337,6 +367,7 @@ def write_v4_paged_decode_indices(
         BLOCK_N=BLOCK_N,
         HAS_CSA=has_csa,
         HAS_HCA=has_hca,
+        HAS_DENSE=has_dense,
         **window_constexprs(dense, "DENSE_"),
         **window_constexprs(csa, "CSA_"),
         **window_constexprs(hca, "HCA_"),
@@ -366,8 +397,8 @@ def write_v4_paged_decode_indices_reference(
     """
     if T == 0:
         return
-    params = {r: geometry.window_params(r) for r in (DENSE_RATIO, CSA_RATIO, HCA_RATIO)}
-    served = {
+    params = served_window_params(geometry)
+    outputs = {
         DENSE_RATIO: (swa_indices, swa_indptr),
         CSA_RATIO: (csa_indices, csa_indptr),
         HCA_RATIO: (hca_indices, hca_indptr),
@@ -387,8 +418,11 @@ def write_v4_paged_decode_indices_reference(
         abs_pos = range(p - n + 1, p + 1)
         slot = int(state_slot_per_seq[b])
         # SWA prefix segment at the slice TAIL (compress section fills the head).
-        for ratio, (buf, indptr) in served.items():
-            if buf is None:
+        for ratio, (buf, indptr) in outputs.items():
+            # A class the caller switched off, or one the geometry does not
+            # have at all — the kernel skips both, on `HAS_*` respectively
+            # `HAS_DENSE`.
+            if buf is None or ratio not in params:
                 continue
             end = int(indptr[t + 1].item())
             rows = [params[ratio].index(slot, int(q)) for q in abs_pos]

--- a/atom/model_ops/v4_kernels/paged_prefill_indices.py
+++ b/atom/model_ops/v4_kernels/paged_prefill_indices.py
@@ -57,6 +57,7 @@ from atom.model_ops.attentions.v4_pool_geometry import (
 )
 from atom.model_ops.v4_kernels.pool_index import (
     compress_row,
+    served_window_params,
     window_constexprs,
     window_row,
 )
@@ -94,6 +95,7 @@ def _v4_paged_prefill_indices_kernel(
     HCA_ROWS_PER_BLOCK: tl.constexpr,  # HCA rows per block (block_size // HCA_RATIO)
     ENVELOPE_ROWS: tl.constexpr,  # rows one block occupies across all layers
     BLOCK_N: tl.constexpr,  # next_pow2(win) — covers SWA prefix and extend segments
+    HAS_DENSE: tl.constexpr,  # geometry has layers of this class to serve
     DENSE_RING_SLOTS: tl.constexpr,
     DENSE_SLOT_ROWS: tl.constexpr,
     DENSE_RING_STRIDE: tl.constexpr,
@@ -160,24 +162,25 @@ def _v4_paged_prefill_indices_kernel(
     # this reads is inside the ring's last lap. That bound is what lets a ring
     # serve chunked prefill at all — the in-chunk part comes from the extend
     # tensor, never from the pool.
-    swa_base_swa = tl.load(prefix_swa_indptr_ptr + t)
     swa_base_hca = tl.load(prefix_hca_indptr_ptr + t)
     swa_mask = i < prefix_swa_count
     global_pos = swa_low + i
     swa_slot = tl.load(state_slot_per_seq_ptr + bid)
-    tl.store(
-        prefix_swa_indices_ptr + swa_base_swa + i,
-        window_row(
-            swa_slot,
-            global_pos,
-            dense_ring_start,
-            DENSE_RING_SLOTS,
-            DENSE_SLOT_ROWS,
-            DENSE_RING_STRIDE,
-            DENSE_RUN_ROWS,
-        ),
-        mask=swa_mask,
-    )
+    if HAS_DENSE:
+        swa_base_swa = tl.load(prefix_swa_indptr_ptr + t)
+        tl.store(
+            prefix_swa_indices_ptr + swa_base_swa + i,
+            window_row(
+                swa_slot,
+                global_pos,
+                dense_ring_start,
+                DENSE_RING_SLOTS,
+                DENSE_SLOT_ROWS,
+                DENSE_RING_STRIDE,
+                DENSE_RUN_ROWS,
+            ),
+            mask=swa_mask,
+        )
     # CSA buffer: the SWA prefix goes at the slice TAIL. `csa_translate_pack`
     # writes the CSA topk section at the slice HEAD
     # `[indptr[t], indptr[t]+valid_k)` (valid_k = slice_len - prefix_swa_count),
@@ -300,7 +303,13 @@ def write_v4_paged_prefill_indices(
       prefix_csa_indptr:         ``[T+1]``  int.
       prefix_hca_indptr:         ``[T+1]``  int.
       extend_indices:            ``[ext_total]`` int OUT — fully written.
-      prefix_swa_indices:        ``[swa_total]`` int OUT — fully written.
+      prefix_swa_indices:        ``[swa_total]`` int OUT — fully written,
+                                  unless no layer is dense, when it is left
+                                  untouched: the dense class is its only
+                                  reader and a geometry can turn out not to
+                                  have one. The caller allocates it with
+                                  ``torch.empty`` and publishes it either way,
+                                  so in that case it holds whatever was there.
       prefix_csa_indices:        ``[csa_total]`` int OUT — SWA prefix
                                   segment written at the slice TAIL; CSA topk
                                   HEAD section filled per layer by
@@ -331,9 +340,22 @@ def write_v4_paged_prefill_indices(
     ):
         assert idx.dim() == 1
 
-    dense = geometry.window_params(DENSE_RATIO)
-    csa = geometry.window_params(CSA_RATIO)
-    hca = geometry.window_params(HCA_RATIO)
+    # DENSE is the one class a V4 config can turn out not to have: a layer that
+    # carries its window in a state field leaves the row space entirely, and on
+    # a trunk that is all CSA and HCA the draft layer is the only ratio-0 one
+    # there was. `prefix_swa_indices` then has no reader, so `HAS_DENSE` skips
+    # it and the borrowed parameters below never reach a store. CSA and HCA
+    # have no such exit today; the assert is there so the day one appears it
+    # says so instead of raising a bare KeyError out of the geometry.
+    served = served_window_params(geometry)
+    assert CSA_RATIO in served and HCA_RATIO in served, (
+        "V4 paged prefill writes the CSA and HCA prefix buffers unconditionally; "
+        f"this pool serves only {sorted(served)}"
+    )
+    has_dense = DENSE_RATIO in served
+    csa = served[CSA_RATIO]
+    hca = served[HCA_RATIO]
+    dense = served.get(DENSE_RATIO, csa)
     BLOCK_N = triton.next_power_of_2(win)
     _v4_paged_prefill_indices_kernel[(T,)](
         positions,
@@ -360,6 +382,7 @@ def write_v4_paged_prefill_indices(
         HCA_ROWS_PER_BLOCK=hca_rows_per_block,
         ENVELOPE_ROWS=geometry.envelope_rows,
         BLOCK_N=BLOCK_N,
+        HAS_DENSE=has_dense,
         **window_constexprs(dense, "DENSE_"),
         **window_constexprs(csa, "CSA_"),
         **window_constexprs(hca, "HCA_"),
@@ -399,9 +422,10 @@ def write_v4_paged_prefill_indices_reference(
     """
     if T == 0:
         return
-    dense = geometry.window_params(DENSE_RATIO)
-    csa = geometry.window_params(CSA_RATIO)
-    hca = geometry.window_params(HCA_RATIO)
+    served = served_window_params(geometry)
+    dense = served.get(DENSE_RATIO)
+    csa = served[CSA_RATIO]
+    hca = served[HCA_RATIO]
     bid_cpu = bid_per_token[:T].cpu().tolist()
     pos_cpu = positions[:T].cpu().tolist()
     cs_per_seq_cpu = chunk_start_per_seq.cpu().tolist()
@@ -452,9 +476,12 @@ def write_v4_paged_prefill_indices_reference(
                     device=device,
                 )
 
-            prefix_swa_indices[sb_swa : sb_swa + prefix_swa_count] = rows(
-                dense, prefix_swa_indices
-            )
+            # No dense layer means no reader for this buffer — the kernel
+            # leaves it alone too, on `HAS_DENSE`.
+            if dense is not None:
+                prefix_swa_indices[sb_swa : sb_swa + prefix_swa_count] = rows(
+                    dense, prefix_swa_indices
+                )
             # CSA: SWA prefix at the slice TAIL (head holds the CSA topk section
             # filled by csa_translate_pack). See the kernel comment above.
             csa_end = csa_indptr_cpu[t + 1]

--- a/atom/model_ops/v4_kernels/pool_index.py
+++ b/atom/model_ops/v4_kernels/pool_index.py
@@ -22,7 +22,24 @@ address at all; see `UnifiedPoolGeometry.window_params`.
 import triton
 import triton.language as tl
 
-from atom.model_ops.attentions.v4_pool_geometry import WindowParams
+from atom.model_ops.attentions.v4_pool_geometry import (
+    UnifiedPoolGeometry,
+    WindowParams,
+)
+
+
+def served_window_params(geometry: UnifiedPoolGeometry) -> dict[int, WindowParams]:
+    """Window parameters for the classes this geometry actually has.
+
+    A class with no layers is not in `UnifiedPoolGeometry.classes` and has no
+    address to give: asking for one raises. That is easy to forget for DENSE,
+    which every V4 config used to have — until a layer whose window moved into
+    a state field took the last one with it, which is what a DSpark draft does
+    to a trunk that is all CSA and HCA. The index builders serve one output
+    buffer per class, so an absent class simply has no output; they read
+    presence from here rather than each deciding what "absent" means.
+    """
+    return {ratio: geometry.window_params(ratio) for ratio in geometry.classes}
 
 
 def window_constexprs(params: WindowParams, prefix: str = "") -> dict:

--- a/tests/test_decode_indices_paged.py
+++ b/tests/test_decode_indices_paged.py
@@ -49,8 +49,7 @@ CSA_HEAD = [3, 0, 5, 0]
 HCA_HEAD = [1, 2, 0, 0]
 
 
-@pytest.fixture(scope="module")
-def indices():
+def build(geometry):
     """Run kernel and reference over one shared decode batch."""
     torch.manual_seed(0)
     positions = torch.tensor(POSITIONS, dtype=torch.int32, device=DEV)
@@ -93,7 +92,7 @@ def indices():
             dest_rows=dest,
             T=T,
             win=WIN,
-            geometry=GEOMETRY,
+            geometry=geometry,
             **ptrs,
             **bufs,
         )
@@ -102,10 +101,16 @@ def indices():
     ref = run(write_v4_paged_decode_indices_reference)
     ker = run(write_v4_paged_decode_indices)
     torch.cuda.synchronize()
+    return {"ref": ref, "ker": ker, "ptrs": ptrs}
+
+
+@pytest.fixture(scope="module")
+def indices():
+    out = build(GEOMETRY)
     # Two buffers both left at the sentinel compare equal, so check the SWA
     # section — the one this kernel fills completely — actually got written.
-    assert not (ref["swa_indices"] == -7).any(), "reference wrote no SWA indices"
-    return {"ref": ref, "ker": ker, "ptrs": ptrs}
+    assert not (out["ref"]["swa_indices"] == -7).any(), "reference wrote no SWA indices"
+    return out
 
 
 @pytest.mark.parametrize("section", ["swa_indices", "csa_indices", "hca_indices"])
@@ -158,6 +163,43 @@ def test_the_three_buffers_disagree_by_class(indices):
         (HCA_RATIO, hca_row),
     ):
         assert row == GEOMETRY.window_params(ratio).index(SLOTS[1], 13)
+
+
+# A pool with no dense layer at all. V4-Pro's trunk is entirely CSA and HCA and
+# its one ratio-0 layer is the draft slot, so a draft that carries its window in
+# a state field takes the dense class out of the geometry with it. The builders
+# used to ask for that class unconditionally and died on a bare KeyError before
+# any of this ran.
+NO_DENSE_GEOMETRY = UnifiedPoolGeometry(
+    [CSA_RATIO, HCA_RATIO, CSA_RATIO, HCA_RATIO],
+    num_blocks=4,
+    num_slots=6,
+    ring_slots=CACHE_SIZE,
+    block_size=256,
+)
+
+
+@pytest.fixture(scope="module")
+def no_dense():
+    return build(NO_DENSE_GEOMETRY)
+
+
+@pytest.mark.parametrize("section", ["csa_indices", "hca_indices"])
+def test_the_served_classes_are_unaffected_by_a_missing_one(no_dense, section):
+    ref, ker = no_dense["ref"][section], no_dense["ker"][section]
+    # Only the SWA tail of each slice belongs to this kernel; the compress head
+    # keeps the sentinel. So the check is that some of it moved, not all.
+    assert (ref != -7).any(), f"{section} was not written"
+    assert torch.equal(ker, ref), f"{section} mismatch\nref={ref}\nker={ker}"
+
+
+def test_a_missing_class_gets_no_rows_rather_than_borrowed_ones(no_dense):
+    """The parameters an absent class is launched with belong to another class,
+    so the failure this guards against is not a crash but a plausible row: the
+    SWA buffer filled with CSA addresses, which no reader would flag."""
+    for side in ("ref", "ker"):
+        assert (no_dense[side]["swa_indices"] == -7).all(), side
+        assert (no_dense[side]["dest"][DENSE_RATIO] == -7).all(), side
 
 
 # --- HCA compress paged offsets with more than one row per block ----------

--- a/tests/test_prefill_indices_paged.py
+++ b/tests/test_prefill_indices_paged.py
@@ -47,8 +47,7 @@ def _indptr(counts, n):
     return torch.tensor(v, dtype=torch.int32, device=DEV)
 
 
-@pytest.fixture(scope="module")
-def two_seq():
+def build(geometry):
     """seq0: fresh chunk (chunk_start=0), pos 0..4 -> prefix_swa_count == 0.
     seq1: prefix-cache hit, chunk_start=16, recompute pos 16..19 -> count > 0."""
     torch.manual_seed(0)
@@ -95,7 +94,7 @@ def two_seq():
             block_tables=block_tables,
             T=total,
             win=WIN,
-            geometry=GEOMETRY,
+            geometry=geometry,
             hca_ratio=HCA_RATIO,
             **ptrs,
             **bufs,
@@ -111,6 +110,45 @@ def two_seq():
     assert prefix_swa_count.max() > 0
     assert not (ref["extend_indices"] == -9).any(), "reference wrote no indices"
     return {"ref": ref, "ker": ker, "ptrs": ptrs, "slot": int(state_slot[1])}
+
+
+@pytest.fixture(scope="module")
+def two_seq():
+    return build(GEOMETRY)
+
+
+# A pool with no dense layer at all — V4-Pro's shape once a DSpark draft moves
+# the only ratio-0 layer's window into a state field. The class then leaves the
+# geometry, and the builders used to ask for it unconditionally.
+NO_DENSE_GEOMETRY = UnifiedPoolGeometry(
+    [CSA_RATIO, HCA_POOL_RATIO, CSA_RATIO, HCA_POOL_RATIO],
+    num_blocks=40,
+    num_slots=4,
+    ring_slots=CACHE_SIZE,
+    block_size=256,
+)
+
+
+@pytest.fixture(scope="module")
+def no_dense():
+    return build(NO_DENSE_GEOMETRY)
+
+
+@pytest.mark.parametrize(
+    "section", ["extend_indices", "prefix_csa_indices", "prefix_hca_indices"]
+)
+def test_the_served_classes_are_unaffected_by_a_missing_one(no_dense, section):
+    ref, ker = no_dense["ref"][section], no_dense["ker"][section]
+    assert (ref != -9).any(), f"{section} was not written"
+    assert torch.equal(ker, ref), f"{section} mismatch\nref={ref}\nker={ker}"
+
+
+def test_a_missing_class_gets_no_rows_rather_than_borrowed_ones(no_dense):
+    """An absent class is launched with a served class's parameters, so what
+    this guards against is not a crash but a plausible row: the SWA prefix
+    buffer filled with CSA addresses, which no reader downstream would flag."""
+    for side in ("ref", "ker"):
+        assert (no_dense[side]["prefix_swa_indices"] == -9).all(), side
 
 
 @pytest.mark.parametrize(

--- a/tests/test_v4_pool_geometry.py
+++ b/tests/test_v4_pool_geometry.py
@@ -13,6 +13,7 @@ pairwise rather than comparing against a restatement of the same expression.
 import pytest
 
 from atom.model_ops.attentions.v4_pool_geometry import (
+    ABSENT_RATIO,
     CSA_RATIO,
     DENSE_RATIO,
     HCA_RATIO,
@@ -463,3 +464,57 @@ class TestTheBoundaryIsInvisibleToAddresses:
         assert len({g.physical_slot(0) for g in tight}) > 1
         # The formula itself is innocent — it never mentions the plane.
         assert len({g.window_params(CSA_RATIO) for g in tight}) == 1
+
+
+# V4-Pro: an all-CSA/HCA trunk whose only ratio-0 layer is the draft slot. The
+# shape matters because it is the one FLASH_RATIOS cannot express — Flash has
+# two dense layers in the trunk, which keep the dense class alive no matter
+# what happens to the draft.
+PRO_RATIOS = [128, 128] + [4, 128] * 29 + [4] + [0]
+
+
+class TestAClassCanBeAbsent:
+    """A compress class with no layers is not in the layout at all.
+
+    The dense class used to be in every V4 config, so callers grew a habit of
+    asking for it unconditionally. Then a layer that carries its window in a
+    state field started leaving the row space entirely, and on a trunk with no
+    dense layers of its own the draft was the last one — the class goes with
+    it. What must not happen is that this reads as a layout with a dense class
+    whose address happens to be wrong.
+    """
+
+    def geometry(self, ratios):
+        return UnifiedPoolGeometry(
+            ratios, num_blocks=4, num_slots=3, ring_slots=FLASH_WINDOW, block_size=256
+        )
+
+    def test_a_trunk_dense_layer_keeps_the_class_when_the_draft_leaves(self):
+        flash = list(FLASH_RATIOS)
+        for i in (43, 44, 45):
+            flash[i] = ABSENT_RATIO
+        assert DENSE_RATIO in self.geometry(flash).classes
+
+    def test_the_class_goes_with_the_last_layer_that_had_it(self):
+        pro = list(PRO_RATIOS)
+        assert DENSE_RATIO in self.geometry(pro).classes
+        pro[-1] = ABSENT_RATIO
+        assert DENSE_RATIO not in self.geometry(pro).classes
+
+    def test_asking_an_absent_class_for_an_address_raises(self):
+        pro = list(PRO_RATIOS)
+        pro[-1] = ABSENT_RATIO
+        geo = self.geometry(pro)
+        with pytest.raises(KeyError):
+            geo.window_params(DENSE_RATIO)
+
+    def test_the_classes_that_remain_are_laid_out_as_if_it_never_existed(self):
+        """The absent class must not leave a hole the others address around."""
+        pro = list(PRO_RATIOS)
+        pro[-1] = ABSENT_RATIO
+        geo = self.geometry(pro)
+        without = self.geometry(pro[:-1])
+        assert geo.entry_rows == without.entry_rows
+        assert geo.envelope_rows == without.envelope_rows
+        for ratio in (CSA_RATIO, HCA_RATIO):
+            assert geo.window_params(ratio) == without.window_params(ratio)


### PR DESCRIPTION
## What breaks

`UnifiedPoolGeometry` only describes a compress class that has layers, and a layer carrying its window in a state field leaves the row space entirely (`ABSENT_RATIO`). On a trunk that is all CSA and HCA, a DSpark draft therefore takes the **dense class** with it.

V4-Pro is exactly that shape — its ratio list opens `[128, 128, 4, 128, ...]` and its only zero is the draft slot:

```
V4-Flash-DSpark: nhl=43  zeros=[0, 1, 43, 44, 45]
   trunk dense=[0, 1]      draft/MTP dense=[43, 44, 45]
   draft -> ABSENT  =>  classes=[0, 4, 128]   DENSE survives

DeepSeek-V4-Pro:  nhl=61  zeros=[61]
   trunk dense=[]          draft/MTP dense=[61]
   draft -> ABSENT  =>  classes=[4, 128]      DENSE is gone
```

All four index-builder entry points asked for that class unconditionally, so the first metadata build dies on `KeyError: 0`:

| file | line |
|---|---|
| `paged_decode_indices.py` | `write_v4_paged_decode_indices` |
| `paged_decode_indices.py` | its `_reference` |
| `paged_prefill_indices.py` | `write_v4_paged_prefill_indices` |
| `paged_prefill_indices.py` | its `_reference` |

## Why no gate caught it

The bug needs two conditions and each shipped config misses one — V4-Flash has two dense layers in its trunk, V4-Pro runs MTP (which declares no window dtype, so nothing moves into a field). Gate A runs on V4-Flash-DSpark, the one shape of the two that cannot reach it.

## The fix

DENSE stops being "the class that is always there" and becomes optional like CSA and HCA: `HAS_DENSE` skips the SWA index tail and the dense destination rows, whose only readers are layers of that class.

Triton needs a value for every `constexpr`, so an off class borrows a served one's. The classes that are **on** index `served` directly, deliberately — a caller asking for rows of a class no layer belongs to gets a `KeyError` rather than a plausible row written from borrowed parameters, and unlike an `assert` that holds under `python -O`.

`prepare_mtp_decode` needed the same correction from the other side: its guard reads the *config* ratio, which a field-window layer still reports as `0`, so the change above would have turned a loud `KeyError` into a silent no-write plus a stale `swa_dest_rows` / `kv_indices_swa` republished from the previous forward. It now excludes those layers, computed once where they are discovered rather than per decode step. Not reachable today (DSpark has its own proposer and never calls it), but the guard no longer covered what it used to.

## Test plan

- [x] `bash .github/scripts/run_unit_tests.sh` — **1319 passed / 52 skipped**, +11 over the base
- [x] `black --check` + `ruff check` clean on all seven files
- [x] **Armed**: forcing `has_dense = True` in either wrapper fails the new assertion — and fails it with *borrowed rows*, not with a crash, which is the failure mode that matters here

The existing fixtures were all V4-Flash-shaped and could not express a trunk with no dense layer. There is now one that can, at three levels: the geometry drops the class with its last layer (`tests/test_v4_pool_geometry.py`, CPU-only), and both index kernels still match their references while leaving the SWA buffer at its sentinel.

Not covered: no e2e run of V4-Pro + DSpark — it is the configuration this unblocks, so there was no working baseline to compare against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)