### PR TITLE
feat(mla): enable persistent decode for all MLA models under DPA

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -217,16 +217,9 @@ def supports_dpa_persistent_mode(
     Keep this gate exact so other DPA models retain the existing non-persistent
     policy and all MLA variants continue to use the common 576-wide KV layout.
     """
-    return (
-        atom_config.enable_dp_attention
-        and kv_cache_dtype == "fp8"
-        and getattr(mla_modules, "is_sparse", False)
-        and getattr(atom_config.hf_config, "model_type", None) == "glm_moe_dsa"
-        and mla_modules.kv_lora_rank == 512
-        and mla_modules.qk_rope_head_dim == 64
-        and num_heads == 64
-        and num_kv_heads == 1
-    )
+    # Force-enabled for now: persistent mode is turned on for all MLA models
+    # under DPA. Re-introduce the per-model gate here if a model regresses.
+    return True
 
 
 def should_use_persistent_mode(


### PR DESCRIPTION
## Summary

`supports_dpa_persistent_mode` previously gated persistent-mode MLA decode to the **GLM sparse DSA (GQA64)** model only. Under DP-attention + fp8 KV cache, DeepSeek R1/V3 (and other MLA variants) therefore fell back to the **non-persistent** decode path.

This PR force-enables persistent mode for all MLA models for now.

## Details

- The outer `should_use_persistent_mode` still enforces `page_size <= 1` and the DCP capability check, so the **gfx942 / DCP non-persistent fallback is preserved** (gfx942 lacks the bf16 lse persistent kernel).
- Verified on DeepSeek R1-0528, V3, and `Deepseek-S3_sq_a05_v2_mlperf6_1` (all `model_type == deepseek_v3`, 576-wide KV, single KV head) under `-tp 8 --enable-dp-attention --kv_cache_dtype fp8`.

## Follow-up

Re-introduce a per-model gate in `supports_dpa_persistent_mode` if any model regresses (accuracy or gpu-fault).