### PR TITLE
Expose Prometheus metrics for KV-aware routing and modernize API

### DIFF
--- a/atom/entrypoints/openai/metrics.py
+++ b/atom/entrypoints/openai/metrics.py
@@ -109,6 +109,23 @@ class _AtomMetricsCollector:
             metric.add_metric([], float(value))
             yield metric
 
+        # Geometry carried on labels rather than as a value, the convention
+        # vllm:cache_config_info established and that llm-d's prefix-cache
+        # scorer reads by the label names below.
+        metric = GaugeMetricFamily(
+            "atom:cache_config_info",
+            "KV-cache geometry of this engine.",
+            labels=["block_size", "num_gpu_blocks"],
+        )
+        metric.add_metric(
+            [
+                str(int(snapshot.get("block_size", 0))),
+                str(int(snapshot.get("kv_blocks_total", 0))),
+            ],
+            1.0,
+        )
+        yield metric
+
         for name, documentation, value in (
             (
                 "atom:requests_finished",

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -551,6 +551,7 @@ class CoreManager:
                     self._record_ready_payload(data)
                     ready_received[dp_rank] = True
                     remaining -= 1
+                    poller.unregister(socket)
                 elif request_type == EngineCoreRequestType.SHUTDOWN:
                     raise RuntimeError(
                         f"{self.label}: Received unexpected SHUTDOWN signal from DP rank {dp_rank} during initialization"

--- a/atom/model_engine/engine_utility.py
+++ b/atom/model_engine/engine_utility.py
@@ -401,6 +401,7 @@ class EngineUtilityHandler:
                     "kv_blocks_free": kv_pool.num_free,
                     "kv_blocks_total": kv_pool.num_blocks,
                     "kv_blocks_indexed": kv_pool.num_indexed,
+                    "block_size": block_manager.block_size,
                 }
 
         return result

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -591,6 +591,10 @@ class LLMEngine:
             "kv_blocks_total": kv_total,
             "kv_blocks_indexed": summed("kv_blocks_indexed"),
             "kv_cache_usage_ratio": kv_used / kv_total if kv_total else 0.0,
+            # KV-owning ranks share the block size; prefill-only ranks omit it.
+            "block_size": next(
+                (int(s["block_size"]) for s in rank_stats if "block_size" in s), 0
+            ),
             "mtp": {
                 "enabled": bool(mtp_rank_stats),
                 "total_draft_tokens": mtp_draft,

--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -16,6 +16,7 @@ Usage:
 
 import json
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -197,8 +198,18 @@ class TestHealthAndModels:
         assert r.status_code == 200
         assert r.headers["content-type"].startswith("text/plain")
         assert "atom:metrics_snapshot_available" in r.text
-        assert "atom:requests_running" in r.text
         assert "vllm:" not in r.text
+
+        # llm-d's endpoint picker resolves ATOM by these exact names (its
+        # built-in atom engine config), so renaming one silently unroutes
+        # every scorer. Pin all four.
+        assert "atom:requests_running" in r.text
+        assert "atom:requests_waiting" in r.text
+        assert "atom:kv_cache_usage_ratio" in r.text
+        assert re.search(
+            r'atom:cache_config_info\{block_size="\d+",num_gpu_blocks="\d+"\} 1\.0',
+            r.text,
+        )
 
         head = requests.head(f"{base_url}/metrics")
         assert head.status_code == 200

--- a/tests/test_disagg_modes.py
+++ b/tests/test_disagg_modes.py
@@ -144,8 +144,28 @@ def test_metrics_work_on_the_prefill_scheduler():
     # those keys rather than reporting a pool of size zero. The aggregator
     # sums with `.get(key, 0)`, so the decode rank's real figures still land.
     assert not [k for k in metrics if k.startswith("kv_blocks")]
+    assert "block_size" not in metrics
 
     handler.push_metrics()  # must not raise from inside the busy loop
+
+
+@pytest.mark.parametrize("scheduler_kind", ["aggregated", "decode"])
+def test_kv_owning_scheduler_reports_cache_geometry(scheduler_kind):
+    import queue
+
+    from atom.model_engine.engine_utility import EngineUtilityHandler
+    from atom.model_engine.scheduler import DecodeScheduler, Scheduler
+
+    cfg = MockConfig()
+    sched = (
+        Scheduler(cfg)
+        if scheduler_kind == "aggregated"
+        else DecodeScheduler(cfg, disagg_cu_shm_name="")
+    )
+    handler = EngineUtilityHandler(None, queue.Queue(), scheduler=sched)
+    metrics = handler.collect_metrics()
+    assert metrics["block_size"] == cfg.kv_cache_block_size
+    assert metrics["kv_blocks_total"] == cfg.num_kvcache_blocks
 
 
 def test_idle_heartbeat_is_available_on_every_scheduler(caplog):
@@ -322,3 +342,33 @@ def test_prefill_only_window_still_reports_its_queues():
     metrics = _aggregate(_snapshot("prefill", running=6, waiting=2))
     assert metrics["requests_running"] == 6
     assert metrics["requests_waiting"] == 2
+
+
+@pytest.mark.parametrize("prefill_first", [True, False])
+def test_cache_geometry_comes_from_decode_regardless_of_snapshot_order(prefill_first):
+    prefill = _snapshot("prefill", running=6, waiting=2)
+    decode = _snapshot(
+        "decode", running=3, waiting=6, block_size=16, kv_blocks_total=80
+    )
+    snapshots = (prefill, decode) if prefill_first else (decode, prefill)
+    metrics = _aggregate(*snapshots)
+    assert metrics["block_size"] == 16
+    assert metrics["kv_blocks_total"] == 80
+
+
+def test_cache_block_size_is_not_summed_across_dp_ranks():
+    metrics = _aggregate(
+        _snapshot("", running=0, waiting=0, block_size=16, kv_blocks_total=80),
+        _snapshot("", running=0, waiting=0, block_size=16, kv_blocks_total=120),
+    )
+    assert metrics["block_size"] == 16
+    assert metrics["kv_blocks_total"] == 200
+
+
+@pytest.mark.parametrize(
+    "snapshots", [(), (_snapshot("prefill", running=0, waiting=0),)]
+)
+def test_cache_geometry_defaults_before_a_kv_owning_rank_reports(snapshots):
+    metrics = _aggregate(*snapshots)
+    assert metrics["block_size"] == 0
+    assert metrics["kv_blocks_total"] == 0


### PR DESCRIPTION
## Motivation

  llm-d-router's built-in ATOM metrics mapping expects
  `atom:cache_config_info` with `block_size` and `num_gpu_blocks` labels.
  ATOM already exposes the running request count, waiting request count,
  and KV-cache utilization, but does not expose cache geometry in this format.

  Add the missing metric so the router can populate `CacheBlockSize` and
  `CacheNumBlocks` from ATOM's `/metrics` endpoint.

  ## Technical Details

  - Include `block_size` in metrics snapshots from schedulers that own KV cache.
  - Select the block size from a KV-owning rank during aggregation, while
    summing KV-cache capacity across ranks. Prefill-only ranks omit cache
    geometry.
  - Export an info-style gauge using the label names expected by llm-d-router:

    ```prometheus
    atom:cache_config_info{block_size="16",num_gpu_blocks="138302"} 1.0

  Values above are illustrative. Before a KV-owning rank reports its
  snapshot, both labels default to "0".

  - Unregister each engine socket from the readiness poller after its ready
    signal is received.
