### PR TITLE
[CI] make the aiter_branch dispatch input actually take effect

### DIFF
--- a/.github/scripts/install_aiter_from_source.sh
+++ b/.github/scripts/install_aiter_from_source.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 
 : "${CONTAINER_NAME:?CONTAINER_NAME must be set}"
 : "${AITER_GIT_REF:?AITER_GIT_REF must be set}"
+if [[ "${AITER_GIT_REF}" == -* || "${AITER_GIT_REF}" =~ [[:space:]] ]]; then
+  echo "ERROR: AITER_GIT_REF must be a git ref / tag / commit and must not start with '-' or contain whitespace (got: ${AITER_GIT_REF})" >&2
+  exit 1
+fi
 AITER_REPO_URL="${AITER_REPO_URL:-https://github.com/ROCm/aiter.git}"
 AITER_SRC_DIR="${AITER_SRC_DIR:-/app/aiter-test}"
 MAX_JOBS="${MAX_JOBS:-64}"

--- a/.github/scripts/install_aiter_from_source.sh
+++ b/.github/scripts/install_aiter_from_source.sh
@@ -44,6 +44,7 @@ docker exec \
   echo "=== Building aiter $(git rev-parse --short HEAD) (${AITER_GIT_REF}) ==="
 
   pip install --upgrade setuptools_scm
+  pip install --upgrade "pybind11>=3.0.1"
   # requirements.txt is intentionally skipped: the base image already satisfies
   # aiter, and its pins would move flydsl/pandas out from under ATOM. GPU_ARCHS
   # is left unset so aiter targets the runner GPU it detects.

--- a/.github/scripts/install_aiter_from_source.sh
+++ b/.github/scripts/install_aiter_from_source.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build and install aiter from a git ref inside the running CI container. Backs
+# the workflow_dispatch `aiter_branch` input, which exists to validate an
+# unmerged aiter branch against ATOM. This replaces install_aiter_wheel.sh
+# (whose wheel always comes from aiter main), so the caller must run exactly one
+# of the two.
+# Inputs via env: CONTAINER_NAME, AITER_GIT_REF (required); AITER_REPO_URL,
+# AITER_SRC_DIR, MAX_JOBS (defaults below).
+set -euo pipefail
+
+: "${CONTAINER_NAME:?CONTAINER_NAME must be set}"
+: "${AITER_GIT_REF:?AITER_GIT_REF must be set}"
+AITER_REPO_URL="${AITER_REPO_URL:-https://github.com/ROCm/aiter.git}"
+AITER_SRC_DIR="${AITER_SRC_DIR:-/app/aiter-test}"
+MAX_JOBS="${MAX_JOBS:-64}"
+
+echo "=== Installing aiter ${AITER_GIT_REF} from ${AITER_REPO_URL} ==="
+docker exec \
+  -e AITER_REPO_URL="${AITER_REPO_URL}" \
+  -e AITER_GIT_REF="${AITER_GIT_REF}" \
+  -e AITER_SRC_DIR="${AITER_SRC_DIR}" \
+  -e MAX_JOBS="${MAX_JOBS}" \
+  "$CONTAINER_NAME" bash -lc '
+  set -euo pipefail
+
+  echo "=== amd-aiter version BEFORE uninstall ==="
+  pip show amd-aiter || true
+  pip uninstall -y amd-aiter || true
+
+  # The base image ships an editable install rooted at AITER_SRC_DIR; rebuild
+  # in place so nothing keeps pointing at the old tree.
+  rm -rf "${AITER_SRC_DIR}"
+  # Clone every ref (blobless) and then check out, so a branch, tag or commit
+  # all work -- same contract as the aiter_commit input in docker-release.yaml.
+  # Not a depth-1 clone: setuptools_scm needs tags to derive a real version.
+  git clone --filter=blob:none "${AITER_REPO_URL}" "${AITER_SRC_DIR}"
+  cd "${AITER_SRC_DIR}"
+  git checkout "${AITER_GIT_REF}"
+  git submodule sync && git submodule update --init --recursive
+  echo "=== Building aiter $(git rev-parse --short HEAD) (${AITER_GIT_REF}) ==="
+
+  pip install --upgrade setuptools_scm
+  # requirements.txt is intentionally skipped: the base image already satisfies
+  # aiter, and its pins would move flydsl/pandas out from under ATOM. GPU_ARCHS
+  # is left unset so aiter targets the runner GPU it detects.
+  PREBUILD_KERNELS=0 python3 setup.py develop
+
+  echo "=== amd-aiter version AFTER installation ==="
+  pip show amd-aiter
+'

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -28,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       aiter_branch:
-        description: 'ROCm/aiter branch to build inside the CI image'
+        description: 'ROCm/aiter branch, tag or commit to build in the container. Leave as main to use the prebuilt main wheel.'
         required: false
         default: 'main'
         type: string
@@ -46,9 +46,9 @@ concurrency:
 env:
   ATOM_BASE_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.atom_base_image || 'rocm/atom-dev:latest' }}
   ATOM_PYTHON_TAG: "cp312"
-  GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/ATOM.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
-  # workflow_dispatch: inputs.aiter_branch; otherwise main (matches previous default-branch shallow clone)
+  # 'main' takes the prebuilt main wheel; any other ref is built from source in
+  # the container instead (see the two mutually exclusive aiter install steps).
   AITER_GIT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.aiter_branch || 'main' }}
 
 jobs:
@@ -337,38 +337,8 @@ jobs:
           echo "Pulling immutable native dashboard image: ${RESOLVED_ATOM_BASE_IMAGE}"
           docker pull "${RESOLVED_ATOM_BASE_IMAGE}"
 
-      - name: Generate Dockerfile for forked repo
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        run: |
-          cat <<EOF > Dockerfile.mod
-          FROM ${{ env.ATOM_BASE_IMAGE }}
-          RUN pip install -U lm-eval[api]
-          RUN pip show lm-eval || true
-          RUN pip install hf_transfer
-          RUN pip show hf_transfer || true
-          RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
-          RUN pip uninstall -y amd-aiter
-          RUN pip install --upgrade "pybind11>=3.0.1"
-          RUN pip show pybind11
-          RUN rm -rf /app/aiter-test
-          RUN git clone --filter=blob:none -b ${{ env.AITER_GIT_REF }} https://github.com/ROCm/aiter.git /app/aiter-test && \\
-              cd /app/aiter-test && \\
-              git submodule sync && git submodule update --init --recursive && \\
-              MAX_JOBS=64 PREBUILD_KERNELS=0 GPU_ARCHS=gfx950 python3 setup.py develop
-          RUN echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true
-          
-          RUN echo "=== ATOM version BEFORE uninstall ===" && pip show atom || true
-          RUN pip uninstall -y atom
-          RUN rm -rf /app/ATOM
-          RUN git clone ${{ env.GITHUB_REPO_URL }} /app/ATOM && \\
-              cd /app/ATOM && \\
-              git checkout ${{ env.GITHUB_COMMIT_SHA }} && \\
-              pip install -e .
-
-          RUN echo "=== ATOM version AFTER installation ===" && pip show atom || true
-          EOF
-
       - name: Download aiter wheel
+        if: ${{ env.AITER_GIT_REF == 'main' }}
         timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -411,7 +381,13 @@ jobs:
         run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" docker "${{ matrix.runner }}"
 
       - name: Install aiter from wheel
+        if: ${{ env.AITER_GIT_REF == 'main' }}
         run: bash .github/scripts/install_aiter_wheel.sh
+
+      - name: Install aiter from branch
+        if: ${{ env.AITER_GIT_REF != 'main' }}
+        timeout-minutes: 60
+        run: bash .github/scripts/install_aiter_from_source.sh
 
       - name: Install ATOM and dependencies
         run: |

--- a/.github/workflows/atomesh-accuracy-validation.yaml
+++ b/.github/workflows/atomesh-accuracy-validation.yaml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       aiter_branch:
-        description: 'ROCm/aiter branch to build inside the CI image'
+        description: 'ROCm/aiter branch, tag or commit to build in the container. Leave as main to use the prebuilt main wheel.'
         required: false
         default: 'main'
         type: string
@@ -40,9 +40,9 @@ concurrency:
 env:
   ATOM_BASE_IMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.atom_base_image || 'rocm/atom-dev:latest' }}
   ATOM_PYTHON_TAG: "cp312"
-  GITHUB_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/ROCm/ATOM.git' }}
   GITHUB_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.sha }}
-  # workflow_dispatch: inputs.aiter_branch; otherwise main (matches previous default-branch shallow clone)
+  # 'main' takes the prebuilt main wheel; any other ref is built from source in
+  # the container instead (see the two mutually exclusive aiter install steps).
   AITER_GIT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.aiter_branch || 'main' }}
 
 jobs:
@@ -210,51 +210,8 @@ jobs:
           echo "Pulling immutable native dashboard image: ${RESOLVED_ATOM_BASE_IMAGE}"
           docker pull "${RESOLVED_ATOM_BASE_IMAGE}"
 
-      - name: Generate Dockerfile for forked repo
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        run: |
-          cat <<EOF > Dockerfile.mod
-          FROM ${{ env.ATOM_BASE_IMAGE }}
-          RUN pip install -U lm-eval[api]
-          RUN pip show lm-eval || true
-          RUN pip install hf_transfer
-          RUN pip show hf_transfer || true
-          RUN echo "=== Aiter version BEFORE uninstall ===" && pip show amd-aiter || true
-          RUN pip uninstall -y amd-aiter
-          RUN pip install --upgrade "pybind11>=3.0.1"
-          RUN pip show pybind11
-          RUN rm -rf /app/aiter-test
-          RUN git clone --filter=blob:none -b ${{ env.AITER_GIT_REF }} https://github.com/ROCm/aiter.git /app/aiter-test && \\
-              cd /app/aiter-test && \\
-              git submodule sync && git submodule update --init --recursive && \\
-              MAX_JOBS=64 PREBUILD_KERNELS=0 GPU_ARCHS=gfx950 python3 setup.py develop
-          RUN echo "=== Aiter version AFTER installation ===" && pip show amd-aiter || true
-          
-          RUN echo "=== ATOM version BEFORE uninstall ===" && pip show atom || true
-          RUN pip uninstall -y atom
-          RUN rm -rf /app/ATOM
-          ARG RUST_VERSION="1.94.0"
-          RUN if ! command -v cargo >/dev/null 2>&1; then \\
-                echo "=== Installing Rust toolchain for atomesh build ===" && \\
-                apt-get update && \\
-                apt --fix-broken install -y && \\
-                apt-get install -y --no-install-recommends curl build-essential pkg-config libssl-dev protobuf-compiler libprotobuf-dev && \\
-                rm -rf /var/lib/apt/lists/* && \\
-                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \\
-                  | sh -s -- -y --default-toolchain "\${RUST_VERSION}" --profile minimal && \\
-                . "\$HOME/.cargo/env" && \\
-                rustc --version && cargo --version; \\
-              fi
-          ENV PATH="/root/.cargo/bin:\$PATH"
-          RUN git clone ${{ env.GITHUB_REPO_URL }} /app/ATOM && \\
-              cd /app/ATOM && \\
-              git checkout ${{ env.GITHUB_COMMIT_SHA }} && \\
-              ATOM_MESH_BUILD=1 python -m pip install -e .
-
-          RUN echo "=== ATOM version AFTER installation ===" && pip show atom || true
-          EOF
-
       - name: Download aiter wheel
+        if: ${{ env.AITER_GIT_REF == 'main' }}
         uses: actions/download-artifact@v8
         with:
           name: aiter-whl
@@ -285,7 +242,13 @@ jobs:
         run: bash .github/scripts/collect_gpu_info.sh "$CONTAINER_NAME" docker "${{ matrix.runner }}"
 
       - name: Install aiter from wheel
+        if: ${{ env.AITER_GIT_REF == 'main' }}
         run: bash .github/scripts/install_aiter_wheel.sh
+
+      - name: Install aiter from branch
+        if: ${{ env.AITER_GIT_REF != 'main' }}
+        timeout-minutes: 60
+        run: bash .github/scripts/install_aiter_from_source.sh
 
       - name: Install ATOM and dependencies
         run: |


### PR DESCRIPTION
## Motivation

The input was only consumed by a "Generate Dockerfile for forked repo" step that no workflow ever built (neither atom-test.yaml nor atomesh-accuracy-validation.yaml has a docker build), so every run -- workflow_dispatch included -- silently fell through to install_aiter_wheel.sh and tested aiter main instead of the requested ref.

## Technical Details

- Drop the dead Dockerfile.mod generation, and GITHUB_REPO_URL with it.
- Add install_aiter_from_source.sh, which rebuilds aiter from a branch, tag or commit inside the running container.
- Make the wheel and source installs mutually exclusive on AITER_GIT_REF, so the wheel can no longer clobber a requested aiter ref.
- Behavior is unchanged when aiter_branch is main (push, PR, schedule and default dispatch): those still take the prebuilt main wheel.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
