### PR TITLE
[feat] Enable ssm replay for gdn attention & kda.

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -47,6 +47,13 @@ class KVCacheTensor:
     # DSA sparse layers (GLM-5.2 / DeepSeek-V3.2): indexer key cache, block-major
     # ``(num_blocks, block_size, aligned_index_dim)``. Omitted for non-DSA layers.
     index_cache: torch.Tensor | None = None
+    # ReplaySSM record buffers for linear-attention layers: this layer's slice
+    # of the (k, u, g) pools.  None for every other attention type.  Carried
+    # here because the layer-id -> linear-attn-index mapping already lives in
+    # the builder's `build_kv_cache_tensor`.
+    replay_buf_k: torch.Tensor = None
+    replay_buf_u: torch.Tensor = None
+    replay_buf_g: torch.Tensor = None
 
 
 @dataclass

--- a/atom/model_ops/attention_gdn.py
+++ b/atom/model_ops/attention_gdn.py
@@ -13,6 +13,7 @@ from atom.model_ops.fla_ops import (
     fused_recurrent_gated_delta_rule,
     gdn_decode_update_lossy_fast,
 )
+from atom.model_ops.fla_ops.replayssm import replayssm_gated_delta_rule
 from atom.model_ops.mamba_ops.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
@@ -173,8 +174,13 @@ class GatedDeltaNet(nn.Module):
             return core_attn_out
 
         gdn_cache = fwd_ctx.kv_cache_data
-        conv_state = gdn_cache[f"layer_{self.layer_num}"].k_cache
-        ssm_state = gdn_cache[f"layer_{self.layer_num}"].v_cache
+        layer_cache = gdn_cache[f"layer_{self.layer_num}"]
+        conv_state = layer_cache.k_cache
+        # Under ReplaySSM this pool holds one checkpoint per request rather
+        # than one state per speculative token; the per-draft states it used
+        # to hold are reconstructed from `replay_buf_*` on demand.
+        ssm_state = layer_cache.v_cache
+        use_replayssm = getattr(gdn_metadata, "replayssm", False)
 
         has_initial_state = gdn_metadata.has_initial_state
         spec_query_start_loc = gdn_metadata.spec_query_start_loc
@@ -219,6 +225,9 @@ class GatedDeltaNet(nn.Module):
 
         use_lossy_gdn_decode = (
             envs.ATOM_ENABLE_GDN_DECODE_LOSSY_FAST
+            # The lossy fast path writes the full state back every step, which
+            # is precisely what ReplaySSM removes; the two are alternatives.
+            and not use_replayssm
             and spec_sequence_masks is None
             and gdn_metadata.num_prefills == 0
             and gdn_metadata.num_decodes > 0
@@ -244,7 +253,18 @@ class GatedDeltaNet(nn.Module):
                 ],
                 num_accepted_tokens=num_accepted_tokens,
                 query_start_loc=spec_query_start_loc,
-                max_query_len=spec_state_indices_tensor.size(-1),
+                # The verify window, which sizes the conv rollback window
+                # (state_len = kernel_width-1 + max_query_len-1) and hence the
+                # kernel's NP2_STATELEN tile. It used to be inferred from the
+                # slot table's last dim, which only coincided with the window
+                # because that table carried one column per draft; state that
+                # dependency explicitly so a narrower table cannot silently
+                # truncate the conv state.
+                max_query_len=(
+                    gdn_metadata.replayssm_max_query_len
+                    if use_replayssm
+                    else spec_state_indices_tensor.size(-1)
+                ),
                 validate_data=False,
             )
             num_tokens_spec = query_spec.shape[0]
@@ -330,19 +350,49 @@ class GatedDeltaNet(nn.Module):
 
         # 2.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            core_attn_out_spec, last_recurrent_state = fused_recurrent_gated_delta_rule(
-                q=query_spec,
-                k=key_spec,
-                v=value_spec,
-                g=g_spec,
-                beta=beta_spec,
-                initial_state=ssm_state,
-                inplace_final_state=True,
-                cu_seqlens=spec_query_start_loc[: gdn_metadata.num_spec_decodes + 1],
-                ssm_state_indices=spec_state_indices_tensor,
-                num_accepted_tokens=num_accepted_tokens,
-                use_qk_l2norm_in_kernel=True,
-            )
+            if use_replayssm:
+                # No per-draft state snapshot: the kernel rebuilds the state
+                # from the checkpoint plus the committed records, so the
+                # rejected drafts of the previous step are undone simply by
+                # `write_pos` never having advanced past them.
+                nsd = gdn_metadata.num_spec_decodes
+                core_attn_out_spec = replayssm_gated_delta_rule(
+                    q=query_spec,
+                    k=key_spec,
+                    v=value_spec,
+                    g=g_spec,
+                    beta=beta_spec,
+                    ckpt=ssm_state,
+                    buf_k=layer_cache.replay_buf_k,
+                    buf_u=layer_cache.replay_buf_u,
+                    buf_g=layer_cache.replay_buf_g,
+                    write_pos=gdn_metadata.write_pos,
+                    slot_idx=gdn_metadata.slot_idx[:nsd],
+                    cu_seqlens=spec_query_start_loc[: nsd + 1],
+                    max_query_len=gdn_metadata.replayssm_max_query_len,
+                    use_qk_l2norm_in_kernel=True,
+                    is_kda=False,
+                    route=gdn_metadata.replayssm_route,
+                )
+                last_recurrent_state = None
+            else:
+                core_attn_out_spec, last_recurrent_state = (
+                    fused_recurrent_gated_delta_rule(
+                        q=query_spec,
+                        k=key_spec,
+                        v=value_spec,
+                        g=g_spec,
+                        beta=beta_spec,
+                        initial_state=ssm_state,
+                        inplace_final_state=True,
+                        cu_seqlens=spec_query_start_loc[
+                            : gdn_metadata.num_spec_decodes + 1
+                        ],
+                        ssm_state_indices=spec_state_indices_tensor,
+                        num_accepted_tokens=num_accepted_tokens,
+                        use_qk_l2norm_in_kernel=True,
+                    )
+                )
         else:
             core_attn_out_spec, last_recurrent_state = None, None
 
@@ -420,6 +470,27 @@ class GatedDeltaNet(nn.Module):
                         non_spec_query_start_loc,
                         CHUNK_SIZE,
                     )
+        elif gdn_metadata.num_decodes > 0 and use_replayssm:
+            nd = gdn_metadata.num_decodes
+            core_attn_out_non_spec = replayssm_gated_delta_rule(
+                q=query_non_spec,
+                k=key_non_spec,
+                v=value_non_spec,
+                g=g_non_spec,
+                beta=beta_non_spec,
+                ckpt=ssm_state,
+                buf_k=layer_cache.replay_buf_k,
+                buf_u=layer_cache.replay_buf_u,
+                buf_g=layer_cache.replay_buf_g,
+                write_pos=gdn_metadata.write_pos,
+                slot_idx=gdn_metadata.slot_idx[:nd],
+                cu_seqlens=non_spec_query_start_loc[: nd + 1],
+                max_query_len=gdn_metadata.replayssm_max_query_len,
+                use_qk_l2norm_in_kernel=True,
+                is_kda=False,
+                route=gdn_metadata.replayssm_route,
+            )
+            last_recurrent_state = None
         elif gdn_metadata.num_decodes > 0:
             if use_lossy_gdn_decode:
                 core_attn_out_non_spec, last_recurrent_state = (

--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+import logging
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -13,7 +14,11 @@ from atom.model_engine.kv_block import STATE_SLOT_CLASS
 from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_engine.state_runtime import StateTransfer
 from atom.model_ops.attention_gdn import GatedDeltaNet
-from atom.utils import CpuGpuBuffer
+from atom.model_ops.fla_ops.replayssm import (
+    replayssm_buffer_shapes,
+    replayssm_commit,
+)
+from atom.utils import CpuGpuBuffer, envs
 from atom.utils.forward_context import AttentionMetaData, Context
 
 from .aiter_attention import (
@@ -27,6 +32,8 @@ from .paged_state_copy import (
     plan_segmented_copy,
 )
 from .sub_pool_spec import SubPoolSpec, page_pool, state_pool
+
+logger = logging.getLogger("atom")
 
 
 class GDNAttentionBackend(AiterBackend):
@@ -82,6 +89,18 @@ class GDNAttentionMetadata:
     # mapping the chunk kernel builds internally. Only computed when there are
     # checkpoints to place against it.
     ssm_chunk_offsets: torch.Tensor | None = None
+    # --- ReplaySSM ---------------------------------------------------------
+    # When enabled the recurrent state is NOT snapshotted per speculative
+    # token, so `spec_state_indices_tensor` collapses to a single slot per
+    # request and `slot_idx` (1-D) addresses both the checkpoint pool and the
+    # record buffers.  `write_pos` is the per-slot committed-record cursor,
+    # advanced once per forward by `replayssm_commit` (never by a layer).
+    replayssm: bool = False
+    slot_idx: torch.Tensor | None = None  # shape: [batch,]
+    write_pos: torch.Tensor | None = None  # shape: [num_slots,]
+    replayssm_cache_len: int = 0
+    replayssm_route: str = "auto"
+    replayssm_max_query_len: int = 1
 
     # The following attributes are for triton implementation of causal_conv1d
     nums_dict: dict | None = None
@@ -148,6 +167,35 @@ class GDNStateMixin:
         if hasattr(model_runner, "drafter"):
             self.num_spec = model_runner.drafter.mtp_k
         self.use_spec_decode = self.num_spec > 0
+
+        # --- ReplaySSM ------------------------------------------------------
+        # The verify window is mtp_k+1 tokens (anchor + drafts); the record
+        # buffer has to hold two of them for the early-flush invariant.
+        self.replayssm = envs.ATOM_ENABLE_REPLAYSSM
+        self.replayssm_max_query_len = self.num_spec + 1
+        self.replayssm_route = envs.ATOM_REPLAYSSM_ROUTE
+        self.replayssm_cache_len = 0
+        if self.replayssm:
+            requested_cache_len = envs.ATOM_REPLAYSSM_CACHE_LEN
+            min_cache_len = 2 * self.replayssm_max_query_len
+            self.replayssm_cache_len = max(requested_cache_len, min_cache_len)
+            if self.replayssm_cache_len != requested_cache_len:
+                logger.warning(
+                    "ATOM_REPLAYSSM_CACHE_LEN=%d is below the required "
+                    "2*(mtp_k+1)=%d; raising it to %d.",
+                    requested_cache_len,
+                    min_cache_len,
+                    self.replayssm_cache_len,
+                )
+            logger.info(
+                "ReplaySSM enabled for linear attention: cache_len=%d, "
+                "route=%s, verify window=%d (1 state slot per request instead "
+                "of %d).",
+                self.replayssm_cache_len,
+                self.replayssm_route,
+                self.replayssm_max_query_len,
+                self.num_spec + 1,
+            )
 
         self.spec_state_indices_tensor = CpuGpuBuffer(
             (self.max_bs, self.num_spec + 1),
@@ -271,6 +319,40 @@ class GDNStateMixin:
             self.model_runner.num_spec_tokens,
         )
 
+    def _replayssm_buffer_shapes(self):
+        """Per-slot (k, u, g) record buffer shapes, or None when disabled."""
+        if not self.replayssm:
+            return None
+        hf = self.model_runner.config.hf_config
+        tp = get_tp_group().world_size
+        return replayssm_buffer_shapes(
+            self.replayssm_cache_len,
+            hf.linear_num_value_heads // tp,
+            hf.linear_key_head_dim,
+            hf.linear_value_head_dim,
+            self._is_kda(),
+        )
+
+    def _is_kda(self) -> bool:
+        return (
+            getattr(self.model_runner.config.hf_config, "model_type", None)
+            == "kimi_linear"
+        )
+
+    def _replayssm_bytes_per_slot(self) -> int:
+        """Record-buffer bytes per slot, summed over all linear-attn layers."""
+        shapes = self._replayssm_buffer_shapes()
+        if shapes is None:
+            return 0
+        rec_dtype = self.model_runner.config.torch_dtype
+        sk, su, sg = shapes
+        per_layer = (
+            math.prod(sk) * rec_dtype.itemsize
+            + math.prod(su) * rec_dtype.itemsize
+            + math.prod(sg) * 4  # g stays fp32: it is exponentiated on rebuild
+        )
+        return self.model_runner.num_gdn_attn_state * per_layer
+
     def state_transfer(self) -> StateTransfer:
         """A fork whose successor forward need only carry one token.
 
@@ -317,6 +399,10 @@ class GDNStateMixin:
         """The GDN state pool: conv_state + temporal_state over all GDN
         layers, with one extra slot per speculative token for rollback.
 
+        Under ReplaySSM there is no per-draft fan-out: `slots_per_req()` drops
+        to 1 and the (k, u, g) record buffers ride along in the same per-slot
+        budget.
+
         Concrete builders splice this into their `sub_pool_specs()` alongside
         whatever paged KV pool they own.
 
@@ -336,14 +422,27 @@ class GDNStateMixin:
         )
         return state_pool(
             STATE_SLOT_CLASS,
-            self.model_runner.num_gdn_attn_state * per_layer,
-            entries_per_req=1 + self.num_spec,
+            self.model_runner.num_gdn_attn_state * per_layer
+            + self._replayssm_bytes_per_slot(),
+            entries_per_req=self.slots_per_req(),
         )
+
+    def slots_per_req(self) -> int:
+        """Baseline GDN reserves one extra state slot per speculative token so
+        a rejected draft can be rolled back by resuming from a different slot.
+
+        ReplaySSM reconstructs the state from cached inputs instead, so one
+        slot per request is enough regardless of the MTP window.  (This also
+        drops the conv-state over-allocation that came along for the ride:
+        `causal_conv1d_update` only ever addresses column 0, because it rolls
+        the conv window back in place via `num_accepted_tokens`.)
+        """
+        return 1 if self.replayssm else 1 + self.num_spec
 
     def allocate_per_req_cache(
         self, entries: dict[str, int]
     ) -> dict[str, torch.Tensor]:
-        """Allocate mamba_k_cache / mamba_v_cache.
+        """Allocate mamba_k_cache / mamba_v_cache (+ ReplaySSM buffers).
 
         Names preserved for backward compat with `attention_gdn.py` which
         accesses them as `model_runner.mamba_{k,v}_cache`.
@@ -360,6 +459,25 @@ class GDNStateMixin:
                 (n, num_slots) + shape_v, dtype=dt_v, device="cuda"
             ),
         }
+        shapes = self._replayssm_buffer_shapes()
+        if shapes is not None:
+            sk, su, sg = shapes
+            rec_dtype = self.model_runner.config.torch_dtype
+            tensors["replayssm_buf_k"] = torch.zeros(
+                (n, num_slots) + sk, dtype=rec_dtype, device="cuda"
+            )
+            tensors["replayssm_buf_u"] = torch.zeros(
+                (n, num_slots) + su, dtype=rec_dtype, device="cuda"
+            )
+            tensors["replayssm_buf_g"] = torch.zeros(
+                (n, num_slots) + sg, dtype=torch.float32, device="cuda"
+            )
+            # One cursor per slot, shared by every linear-attention layer:
+            # the record index depends on the sequence's decode history, not
+            # on which layer is running.
+            tensors["replayssm_write_pos"] = torch.zeros(
+                num_slots, dtype=torch.int32, device="cuda"
+            )
         self._assert_checkpoint_geometry_still_holds()
         return tensors
 
@@ -829,6 +947,13 @@ class GDNStateMixin:
                 non_spec_state_indices_in[idx] = src if src >= 0 else committed
             else:
                 spec_state_indices[idx, : len(slots)] = slots
+                if self.replayssm:
+                    # ReplaySSM holds one slot per request, and that same index
+                    # addresses the checkpoint pool and the record buffers
+                    # alike. Mirror it into the 1-D tensor so `slot_idx` has
+                    # somewhere to read it from -- the spec path otherwise
+                    # fills only the 2-D one.
+                    non_spec_state_indices[idx] = committed
 
     def prepare_num_accepted_tokens(self, batch: ScheduledBatch):
         self.num_accepted_tokens.fill_(1)
@@ -895,6 +1020,10 @@ class GDNStateMixin:
             spec_state_indices_tensor = self.spec_state_indices_tensor.copy_to_gpu(
                 num_reqs
             )
+            if self.replayssm:
+                # `prepare_state_indices` mirrored the single slot into the
+                # 1-D tensor too; ship that to the device for `slot_idx`.
+                self.non_spec_state_indices_tensor.copy_to_gpu(num_reqs)
             non_spec_state_indices_tensor = None
             non_spec_state_indices_in_tensor = None
             spec_query_start_loc = query_start_loc
@@ -950,7 +1079,47 @@ class GDNStateMixin:
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
         )
+        if self.replayssm:
+            self._attach_replayssm(gdn_attn_metadata, num_reqs, is_prefill)
         return gdn_attn_metadata
+
+    def _attach_replayssm(
+        self, md: GDNAttentionMetadata, num_reqs: int, is_prefill: bool
+    ) -> None:
+        """Fill the ReplaySSM fields and move the record cursor exactly once.
+
+        The cursor advance is a *forward-level* action, not a layer-level one:
+        every linear-attention layer in the step must see the same `write_pos`,
+        so it happens here (metadata prep, outside any captured graph) rather
+        than inside the layer kernel.
+        """
+        slot_idx = self.non_spec_state_indices_tensor.gpu[:num_reqs]
+        write_pos = self.model_runner.replayssm_write_pos
+        md.replayssm = True
+        md.slot_idx = slot_idx
+        md.write_pos = write_pos
+        md.replayssm_cache_len = self.replayssm_cache_len
+        md.replayssm_route = self.replayssm_route
+        md.replayssm_max_query_len = self.replayssm_max_query_len
+
+        if is_prefill:
+            # A prefill (re)initialises the checkpoint wholesale via
+            # `chunk_gated_delta_rule`, so any records left over from a prior
+            # tenant of this slot are stale.  Zeroing the cursor here is also
+            # what makes slot reuse safe without a block-manager hook.
+            write_pos.index_fill_(0, slot_idx.to(torch.int64), 0)
+            return
+
+        # Decode: apply the PREVIOUS step's accepted counts.  For non-spec
+        # decode `num_accepted_tokens` stays at its initialised value of 1,
+        # which is exactly one committed token per step.
+        replayssm_commit(
+            write_pos,
+            slot_idx,
+            self.num_accepted_tokens[:num_reqs],
+            self.replayssm_max_query_len,
+            self.replayssm_cache_len,
+        )
 
     def _attach_gdn_decode_metadata(
         self,
@@ -967,6 +1136,10 @@ class GDNStateMixin:
         )
 
         # transfer data to ps buffer
+        if self.replayssm:
+            # Idle graph-padding entries must resolve to PAD so the kernel
+            # skips them instead of touching slot 0's checkpoint.
+            self.non_spec_state_indices_tensor.gpu[num_decodes:].fill_(PAD_SLOT_ID)
         if self.use_spec_decode:
             self.spec_state_indices_tensor.gpu[num_decodes:, :].fill_(PAD_SLOT_ID)
 
@@ -1064,6 +1237,17 @@ class GDNStateMixin:
                 batch_ptr=None,
                 token_chunk_offset_ptr=None,
             )
+        if self.replayssm:
+            # Capture-time only wires up the (address-stable) buffers; the
+            # cursor is deliberately NOT advanced here.  Warmup and capture
+            # replay dummy batches, and letting them commit would leave real
+            # sequences resuming from records that were never written.
+            gdn_metadata.replayssm = True
+            gdn_metadata.slot_idx = self.non_spec_state_indices_tensor.gpu[:bs]
+            gdn_metadata.write_pos = self.model_runner.replayssm_write_pos
+            gdn_metadata.replayssm_cache_len = self.replayssm_cache_len
+            gdn_metadata.replayssm_route = self.replayssm_route
+            gdn_metadata.replayssm_max_query_len = self.replayssm_max_query_len
         return gdn_metadata
 
 
@@ -1165,6 +1349,15 @@ class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
                 v_cache=runner.mamba_v_cache[gdn_idx],
                 k_scale=None,
                 v_scale=None,
+                replay_buf_k=(
+                    runner.replayssm_buf_k[gdn_idx] if self.replayssm else None
+                ),
+                replay_buf_u=(
+                    runner.replayssm_buf_u[gdn_idx] if self.replayssm else None
+                ),
+                replay_buf_g=(
+                    runner.replayssm_buf_g[gdn_idx] if self.replayssm else None
+                ),
             )
         return super().build_kv_cache_tensor(layer_id, module)
 

--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -817,16 +817,36 @@ class GDNStateMixin:
         move whatever mechanism the class uses to checkpoint. A backend
         declaring `StateTransfer.fork` therefore still owes this method.
 
+        Under ReplaySSM the records and the cursor travel with the slot. They
+        are not an accelerator for the state, they are part of it: the
+        checkpoint alone only describes the sequence up to the last flush, and
+        a slot relocated without them resumes against whatever the destination
+        slot's previous tenant left behind.
+
         Both caches are layer-major with the slot as the second axis, so one
         slot's rows are strided rather than contiguous and there is no single
         range to copy. `_foreach_copy_` keeps it to one launch for the batch.
+        The cursor is the exception — one entry per slot, no layer axis.
         """
-        caches = (self.model_runner.mamba_k_cache, self.model_runner.mamba_v_cache)
+        caches = [self.model_runner.mamba_k_cache, self.model_runner.mamba_v_cache]
+        cursor = None
+        if self.replayssm:
+            caches += [
+                self.model_runner.replayssm_buf_k,
+                self.model_runner.replayssm_buf_u,
+                self.model_runner.replayssm_buf_g,
+            ]
+            # One entry per slot, no layer axis -- moved alongside, not with
+            # the layer-major caches above.
+            cursor = self.model_runner.replayssm_write_pos
         destinations, sources = [], []
         for src, dst in pairs:
             for cache in caches:
                 destinations.append(cache[:, dst])
                 sources.append(cache[:, src])
+            if cursor is not None:
+                destinations.append(cursor[dst : dst + 1])
+                sources.append(cursor[src : src + 1])
         if destinations:
             torch._foreach_copy_(destinations, sources)
 
@@ -1104,10 +1124,20 @@ class GDNStateMixin:
 
         if is_prefill:
             # A prefill (re)initialises the checkpoint wholesale via
-            # `chunk_gated_delta_rule`, so any records left over from a prior
-            # tenant of this slot are stale.  Zeroing the cursor here is also
-            # what makes slot reuse safe without a block-manager hook.
-            write_pos.index_fill_(0, slot_idx.to(torch.int64), 0)
+            # `chunk_gated_delta_rule` and writes NO records, so the next
+            # forward must fold none.  Parking the cursor at -1 rather than 0
+            # is what says that: `num_bonus` is 0 on the first decode after a
+            # prefill, so the commit below would otherwise advance 0 -> 1 and
+            # fold record 0 -- which this generation never wrote, and which on
+            # a reused slot still holds the previous tenant's.  The sentinel is
+            # also what makes slot reuse safe without a block-manager hook.
+            # Drop any PAD before indexing. `per_req_cache_groups` is filtered
+            # to non-negative groups, so it can be shorter than `num_reqs` and
+            # leave stale tail entries in the slice -- and a stale tail from a
+            # decode step is PAD_SLOT_ID. index_fill_ would read that as "from
+            # the end" and park a live, unrelated slot's cursor.
+            live = slot_idx[slot_idx >= 0].to(torch.int64)
+            write_pos.index_fill_(0, live, -1)
             return
 
         # Decode: apply the PREVIOUS step's accepted counts.  For non-spec

--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -171,7 +171,13 @@ class GDNStateMixin:
         # --- ReplaySSM ------------------------------------------------------
         # The verify window is mtp_k+1 tokens (anchor + drafts); the record
         # buffer has to hold two of them for the early-flush invariant.
-        self.replayssm = envs.ATOM_ENABLE_REPLAYSSM
+        # Default to whatever speculative decoding is doing: ReplaySSM pays for
+        # itself when there are drafts to roll back, and does not when there
+        # are none.  `ATOM_ENABLE_REPLAYSSM` overrides in either direction.
+        replayssm_override = envs.ATOM_ENABLE_REPLAYSSM
+        self.replayssm = (
+            self.use_spec_decode if replayssm_override is None else replayssm_override
+        )
         self.replayssm_max_query_len = self.num_spec + 1
         self.replayssm_route = envs.ATOM_REPLAYSSM_ROUTE
         self.replayssm_cache_len = 0
@@ -188,13 +194,27 @@ class GDNStateMixin:
                     self.replayssm_cache_len,
                 )
             logger.info(
-                "ReplaySSM enabled for linear attention: cache_len=%d, "
+                "ReplaySSM enabled for linear attention (%s): cache_len=%d, "
                 "route=%s, verify window=%d (1 state slot per request instead "
                 "of %d).",
+                (
+                    "ATOM_ENABLE_REPLAYSSM=1"
+                    if replayssm_override
+                    else "default, speculative decoding is on"
+                ),
                 self.replayssm_cache_len,
                 self.replayssm_route,
                 self.replayssm_max_query_len,
                 self.num_spec + 1,
+            )
+        else:
+            logger.info(
+                "ReplaySSM disabled for linear attention (%s).",
+                (
+                    "ATOM_ENABLE_REPLAYSSM=0"
+                    if replayssm_override is not None
+                    else "default, no speculative decoding"
+                ),
             )
 
         self.spec_state_indices_tensor = CpuGpuBuffer(

--- a/atom/model_ops/attentions/kimi_mla_gdn_attn.py
+++ b/atom/model_ops/attentions/kimi_mla_gdn_attn.py
@@ -240,6 +240,9 @@ class _KimiMLAGDNCommon(GDNStateMixin):
                 v_cache=runner.mamba_v_cache[row],
                 k_scale=None,
                 v_scale=None,
+                replay_buf_k=(runner.replayssm_buf_k[row] if self.replayssm else None),
+                replay_buf_u=(runner.replayssm_buf_u[row] if self.replayssm else None),
+                replay_buf_g=(runner.replayssm_buf_g[row] if self.replayssm else None),
             )
 
         if hasattr(module, "base_attention") and getattr(module, "use_mla", False):

--- a/atom/model_ops/fla_ops/replayssm.py
+++ b/atom/model_ops/fla_ops/replayssm.py
@@ -1,0 +1,944 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+"""ReplaySSM for gated-delta-rule / KDA linear attention.
+
+Instead of materialising one recurrent state per speculative token, cache the
+*inputs* that produced them and rebuild the state on demand.  The recurrence
+
+    S_t = diag(a_t) S_{t-1} + k_t u_t^T ,   u_t = beta_t (v_t - (diag(a_t)S_{t-1})^T k_t)
+
+is linear in the state, so
+
+    S_h = diag(e^{G_h}) S_0 + sum_j diag(e^{G_h - G_j}) k_j u_j^T
+
+with G_j the running sum of log-decays.  Keeping a checkpoint ``S_0`` plus the
+last few ``(k, u, g)`` records is therefore equivalent to keeping the state,
+at ~1/40 of the bytes for K = V = 128.
+
+Two consequences:
+
+* **Speculative rollback becomes a cursor move.**  A rejected draft is undone
+  by not advancing the cursor past its record; no per-draft state snapshot is
+  needed, so the state pool stops scaling with ``num_speculative_tokens``.
+* **The full-state write moves off the per-step path.**  The checkpoint is only
+  rewritten when the record buffer fills (every ``cache_len`` committed
+  tokens), so most steps read the state and never write it.
+
+Divergence from upstream ReplaySSM: the checkpoint absorbs the committed
+records at the *start* of a step rather than the end.  Upstream folds at the
+end, which strands the current step's speculative records at a non-zero offset
+and forces a true ring with modular indexing; folding at the start means the
+buffer always refills from offset 0, so it is a plain linear buffer with reset.
+Same state traffic, same flush cadence, no wrap-around arithmetic.
+
+Reference: https://tridao.me/blog/2026/replayssm/
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from .op import exp
+
+__all__ = [
+    "PAD_SLOT_ID",
+    "flush_threshold_ok",
+    "replayssm_buffer_shapes",
+    "replayssm_commit",
+    "replayssm_gated_delta_rule",
+    "replayssm_sigmoid_gating_delta_rule",
+]
+
+PAD_SLOT_ID = -1
+
+#: `route="auto"` switches to the UT-transform kernel at or above this verify
+#: window.  See the measurement table in `replayssm_gated_delta_rule`.
+UT_MIN_QUERY_LEN = 12
+
+
+# --------------------------------------------------------------------------- #
+# Flush policy                                                                 #
+# --------------------------------------------------------------------------- #
+#
+# The predicate below is evaluated in two places -- the layer kernel (to decide
+# whether *this* step folds) and the commit kernel (to re-derive what the
+# *previous* step decided, since the forward does not touch the cursor).  They
+# must agree exactly, so both call the same expression; do not inline a variant.
+#
+# Firing at `h + 2T > L` rather than `h + T > L` keeps at least one full window
+# free: a step that lands at h = L-T followed by a full accept would otherwise
+# leave a single free slot and truncate the next window to one draft.  It also
+# guarantees h + T <= L, i.e. appends never run off the end of the buffer.
+
+
+def flush_threshold_ok(cache_len: int, max_query_len: int) -> bool:
+    """`cache_len` must hold two full windows or the invariant above breaks."""
+    return cache_len >= 2 * max_query_len
+
+
+def replayssm_buffer_shapes(
+    cache_len: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+    is_kda: bool,
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    """Per-slot record buffer shapes: (k, u, g)."""
+    return (
+        (cache_len, num_v_heads, head_k_dim),
+        (cache_len, num_v_heads, head_v_dim),
+        (cache_len, num_v_heads, head_k_dim) if is_kda else (cache_len, num_v_heads),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Commit kernel -- runs once per forward, shared by every linear-attn layer    #
+# --------------------------------------------------------------------------- #
+
+
+@triton.jit(do_not_specialize=["N", "T_MAX", "CAP"])
+def _replayssm_commit_kernel(
+    write_pos,
+    slot_idx,
+    num_accepted,
+    N,
+    T_MAX,
+    CAP,
+):
+    i_n = tl.program_id(0)
+    if i_n >= N:
+        return
+    slot = tl.load(slot_idx + i_n).to(tl.int64)
+    if slot < 0:
+        return
+    h = tl.load(write_pos + slot)
+    # Re-derive the previous forward's flush decision.  The forward never
+    # mutates write_pos, so `h` here is exactly what that forward branched on.
+    prev_flushed = h + 2 * T_MAX > CAP
+    base = tl.where(prev_flushed, 0, h)
+    tl.store(write_pos + slot, base + tl.load(num_accepted + i_n))
+
+
+def replayssm_commit(
+    write_pos: torch.Tensor,
+    slot_idx: torch.Tensor,
+    num_accepted: torch.Tensor,
+    max_query_len: int,
+    cache_len: int,
+) -> None:
+    """Advance each sequence's record cursor by the previous step's accepts.
+
+    Call exactly once per forward, before any linear-attention layer runs.
+    Device-side so the accepted counts never round-trip to the host.
+    """
+    n = slot_idx.numel()
+    if n == 0:
+        return
+    _replayssm_commit_kernel[(n,)](
+        write_pos,
+        slot_idx,
+        num_accepted,
+        n,
+        max_query_len,
+        cache_len,
+        num_warps=1,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fused rebuild + decode/verify kernel                                         #
+# --------------------------------------------------------------------------- #
+
+
+@triton.jit(do_not_specialize=["N", "T_TOT", "T_MAX", "CAP"])
+def _replayssm_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    o,
+    ckpt,
+    buf_k,
+    buf_u,
+    buf_g,
+    write_pos,
+    slot_idx,
+    cu_seqlens,
+    scale,
+    N,
+    T_TOT,
+    T_MAX,
+    CAP,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    stride_ckpt_slot: tl.constexpr,
+    stride_bufk_slot: tl.constexpr,
+    stride_bufk_pos: tl.constexpr,
+    stride_bufu_slot: tl.constexpr,
+    stride_bufu_pos: tl.constexpr,
+    stride_bufg_slot: tl.constexpr,
+    stride_bufg_pos: tl.constexpr,
+    stride_beta_tok: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_KDA: tl.constexpr,
+    IS_BETA_HEADWISE: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+    eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+    T = eos - bos
+    if T == 0:
+        return
+
+    slot = tl.load(slot_idx + i_n).to(tl.int64)
+    if slot < 0:  # padded / idle batch entry
+        return
+
+    h = tl.load(write_pos + slot).to(tl.int32)
+    do_flush = h + 2 * T_MAX > CAP
+    base = tl.where(do_flush, 0, h).to(tl.int64)
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_k[:, None] & mask_v[None, :]
+
+    # ---- 1. rebuild S_h = ckpt + the h committed records -------------------
+    p_ckpt = ckpt + slot * stride_ckpt_slot + i_hv * K * V
+    p_ckpt_hv = p_ckpt + o_k[:, None] * V + o_v[None, :]
+    b_h = tl.load(p_ckpt_hv, mask=mask_h, other=0.0).to(tl.float32)
+
+    for j in range(h):
+        p_bg = buf_g + slot * stride_bufg_slot + j * stride_bufg_pos
+        if IS_KDA:
+            b_rg = tl.load(p_bg + i_hv * K + o_k, mask=mask_k, other=0.0).to(tl.float32)
+            b_h *= exp(b_rg)[:, None]
+        else:
+            b_rg = tl.load(p_bg + i_hv).to(tl.float32)
+            b_h *= exp(b_rg)
+        b_rk = tl.load(
+            buf_k + slot * stride_bufk_slot + j * stride_bufk_pos + i_hv * K + o_k,
+            mask=mask_k,
+            other=0.0,
+        ).to(tl.float32)
+        b_ru = tl.load(
+            buf_u + slot * stride_bufu_slot + j * stride_bufu_pos + i_hv * V + o_v,
+            mask=mask_v,
+            other=0.0,
+        ).to(tl.float32)
+        b_h += b_rk[:, None] * b_ru[None, :]
+
+    # ---- 2. flush: the checkpoint absorbs the committed prefix --------------
+    if do_flush:
+        tl.store(p_ckpt_hv, b_h.to(p_ckpt_hv.dtype.element_ty), mask=mask_h)
+
+    # ---- 3. this step's tokens ---------------------------------------------
+    p_q = q + (bos * H + i_h) * K + o_k
+    p_k = k + (bos * H + i_h) * K + o_k
+    p_v = v + (bos * HV + i_hv) * V + o_v
+    p_o = o + (bos * HV + i_hv) * V + o_v
+    if IS_BETA_HEADWISE:
+        p_beta = beta + (bos * HV + i_hv) * V + o_v
+    else:
+        p_beta = beta + bos * HV + i_hv
+    if IS_KDA:
+        p_g = g + (bos * HV + i_hv) * K + o_k
+    else:
+        p_g = g + bos * HV + i_hv
+
+    for i_t in range(T):
+        b_q = tl.load(p_q, mask=mask_k, other=0.0).to(tl.float32)
+        b_k = tl.load(p_k, mask=mask_k, other=0.0).to(tl.float32)
+        b_v = tl.load(p_v, mask=mask_v, other=0.0).to(tl.float32)
+
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q = b_q * scale
+
+        if IS_KDA:
+            b_g = tl.load(p_g, mask=mask_k, other=0.0).to(tl.float32)
+            b_h *= exp(b_g)[:, None]
+        else:
+            b_g = tl.load(p_g).to(tl.float32)
+            b_h *= exp(b_g)
+
+        b_v -= tl.sum(b_h * b_k[:, None], 0)
+        if IS_BETA_HEADWISE:
+            b_beta = tl.load(p_beta, mask=mask_v, other=0.0).to(tl.float32)
+        else:
+            b_beta = tl.load(p_beta).to(tl.float32)
+        b_v *= b_beta
+        b_h += b_k[:, None] * b_v[None, :]
+
+        tl.store(
+            p_o, tl.sum(b_h * b_q[:, None], 0).to(p_o.dtype.element_ty), mask=mask_v
+        )
+
+        # ---- append the record ---------------------------------------------
+        pos = base + i_t
+        p_bu = buf_u + slot * stride_bufu_slot + pos * stride_bufu_pos + i_hv * V + o_v
+        tl.store(p_bu, b_v.to(p_bu.dtype.element_ty), mask=mask_v)
+        # k and g do not depend on the V split; let one program own the store
+        # instead of having every V-block redundantly write the same bytes.
+        if i_v == 0:
+            p_bk = (
+                buf_k + slot * stride_bufk_slot + pos * stride_bufk_pos + i_hv * K + o_k
+            )
+            tl.store(p_bk, b_k.to(p_bk.dtype.element_ty), mask=mask_k)
+            p_bg2 = buf_g + slot * stride_bufg_slot + pos * stride_bufg_pos
+            if IS_KDA:
+                tl.store(
+                    p_bg2 + i_hv * K + o_k,
+                    b_g.to(p_bg2.dtype.element_ty),
+                    mask=mask_k,
+                )
+            else:
+                tl.store(p_bg2 + i_hv, b_g.to(p_bg2.dtype.element_ty))
+
+        p_q += H * K
+        p_k += H * K
+        p_v += HV * V
+        p_o += HV * V
+        p_beta += stride_beta_tok
+        p_g += HV * K if IS_KDA else HV
+
+
+# --------------------------------------------------------------------------- #
+# UT-transform verify route (chunked delta rule)                               #
+# --------------------------------------------------------------------------- #
+#
+# The serial kernel above walks the T verify tokens one at a time because
+# u_s depends on the state after token s-1.  Expanding every token from the
+# same rebuilt S_h instead decouples them:
+#
+#   R_s     = beta_s (v_s - S_h^T (e^{G_s} . k_s))            <- all s in parallel
+#   A_{s,s'}= beta_s <e^{G_s-G_{s'}} . k_{s'}, k_s>,  s' < s  <- strictly lower
+#   U       = (I + A)^{-1} R                                  <- T x T solve
+#   o_s     = S_h^T (e^{G_s} . q_s) + sum_{s'<=s} <e^{G_s-G_{s'}} . k_{s'}, q_s> U_{s'}
+#
+# with G_s the running sum of log-decays.  The only serial part left is the
+# T x T triangular solve, which is O(T^2 V) instead of O(T K V).
+#
+# Scope: scalar-gate GDN only.  With KDA's per-channel gate, e^{G_s - G_{s'}}
+# sits inside the contraction over K, so the pairwise weight cannot be folded
+# into a single GEMM without splitting it into e^{G_s} * e^{-G_{s'}} -- and
+# e^{-G_{s'}} grows without bound over the window.  KDA therefore stays on the
+# serial route, which costs nothing in memory (the whole point of ReplaySSM)
+# and only forgoes this throughput optimisation.  Upstream vLLM/SGLang draw
+# the same line.
+
+
+@triton.jit(do_not_specialize=["N", "T_TOT", "T_MAX", "CAP"])
+def _replayssm_ut_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    o,
+    ckpt,
+    buf_k,
+    buf_u,
+    buf_g,
+    write_pos,
+    slot_idx,
+    cu_seqlens,
+    scale,
+    N,
+    T_TOT,
+    T_MAX,
+    CAP,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    BT: tl.constexpr,
+    stride_ckpt_slot: tl.constexpr,
+    stride_bufk_slot: tl.constexpr,
+    stride_bufk_pos: tl.constexpr,
+    stride_bufu_slot: tl.constexpr,
+    stride_bufu_pos: tl.constexpr,
+    stride_bufg_slot: tl.constexpr,
+    stride_bufg_pos: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+    eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+    T = eos - bos
+    if T == 0:
+        return
+    slot = tl.load(slot_idx + i_n).to(tl.int64)
+    if slot < 0:
+        return
+
+    h = tl.load(write_pos + slot).to(tl.int32)
+    do_flush = h + 2 * T_MAX > CAP
+    base = tl.where(do_flush, 0, h).to(tl.int64)
+
+    o_t = tl.arange(0, BT)
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_k = o_k < K
+    m_v = o_v < V
+    m_tk = m_t[:, None] & m_k[None, :]
+    m_tv = m_t[:, None] & m_v[None, :]
+
+    # ---- token tiles --------------------------------------------------------
+    p_qk = (bos + o_t)[:, None] * (H * K) + i_h * K + o_k[None, :]
+    b_k = tl.load(k + p_qk, mask=m_tk, other=0.0).to(tl.float32)
+    b_q = tl.load(q + p_qk, mask=m_tk, other=0.0).to(tl.float32)
+    if USE_QK_L2NORM_IN_KERNEL:
+        b_k = b_k / tl.sqrt(tl.sum(b_k * b_k, 1) + 1e-6)[:, None]
+        b_q = b_q / tl.sqrt(tl.sum(b_q * b_q, 1) + 1e-6)[:, None]
+    b_q = b_q * scale
+    b_v = tl.load(
+        v + (bos + o_t)[:, None] * (HV * V) + i_hv * V + o_v[None, :],
+        mask=m_tv,
+        other=0.0,
+    ).to(tl.float32)
+    b_gt = tl.load(g + (bos + o_t) * HV + i_hv, mask=m_t, other=0.0).to(tl.float32)
+    b_beta = tl.load(beta + (bos + o_t) * HV + i_hv, mask=m_t, other=0.0).to(tl.float32)
+
+    # running log-decay; padded rows contribute 0 so they never disturb the sum
+    b_G = tl.cumsum(b_gt, axis=0)
+
+    # ---- rebuild S_h --------------------------------------------------------
+    p_ckpt_hv = (
+        ckpt + slot * stride_ckpt_slot + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+    )
+    m_h = m_k[:, None] & m_v[None, :]
+    b_h = tl.load(p_ckpt_hv, mask=m_h, other=0.0).to(tl.float32)
+    for j in range(h):
+        b_rg = tl.load(buf_g + slot * stride_bufg_slot + j * stride_bufg_pos + i_hv)
+        b_h *= exp(b_rg.to(tl.float32))
+        b_rk = tl.load(
+            buf_k + slot * stride_bufk_slot + j * stride_bufk_pos + i_hv * K + o_k,
+            mask=m_k,
+            other=0.0,
+        ).to(tl.float32)
+        b_ru = tl.load(
+            buf_u + slot * stride_bufu_slot + j * stride_bufu_pos + i_hv * V + o_v,
+            mask=m_v,
+            other=0.0,
+        ).to(tl.float32)
+        b_h += b_rk[:, None] * b_ru[None, :]
+
+    if do_flush:
+        tl.store(p_ckpt_hv, b_h.to(p_ckpt_hv.dtype.element_ty), mask=m_h)
+
+    # ---- project the rebuilt state onto every token at once -----------------
+    b_eG = exp(b_G)  # <= 1, decays are non-positive
+    b_hk = tl.dot((b_k * b_eG[:, None]).to(b_h.dtype), b_h)
+    b_hq = tl.dot((b_q * b_eG[:, None]).to(b_h.dtype), b_h)
+    b_R = b_beta[:, None] * (b_v - b_hk)
+
+    # ---- pairwise decay weights --------------------------------------------
+    # dG = G_s - G_s' is <= 0 for s > s' (log-decays are negative); clamping at
+    # 0 is exact there and keeps the masked upper triangle from overflowing.
+    b_dG = exp(tl.minimum(b_G[:, None] - b_G[None, :], 0.0))
+    m_lo = (o_t[:, None] > o_t[None, :]) & m_t[:, None] & m_t[None, :]
+    m_le = (o_t[:, None] >= o_t[None, :]) & m_t[:, None] & m_t[None, :]
+    b_kk = tl.dot(b_k.to(b_h.dtype), tl.trans(b_k).to(b_h.dtype))
+    b_qk = tl.dot(b_q.to(b_h.dtype), tl.trans(b_k).to(b_h.dtype))
+    b_A = tl.where(m_lo, b_beta[:, None] * b_dG * b_kk, 0.0)
+
+    # ---- (I + A)^-1, built row by row (same recurrence as solve_tril) -------
+    b_Ai = -b_A
+    for i in range(1, BT):
+        b_row = -tl.sum(tl.where((o_t == i)[:, None], b_A, 0.0), 0)
+        b_row = b_row + tl.sum(b_row[:, None] * b_Ai, 0)
+        b_Ai = tl.where((o_t == i)[:, None], b_row, b_Ai)
+    b_Ai += (o_t[:, None] == o_t[None, :]).to(tl.float32)
+
+    b_U = tl.dot(b_Ai.to(b_h.dtype), b_R.to(b_h.dtype))
+    b_o = b_hq + tl.dot(
+        tl.where(m_le, b_dG * b_qk, 0.0).to(b_h.dtype), b_U.to(b_h.dtype)
+    )
+
+    # ---- write output and records ------------------------------------------
+    p_o = o + (bos + o_t)[:, None] * (HV * V) + i_hv * V + o_v[None, :]
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_tv)
+
+    p_bu = (
+        buf_u
+        + slot * stride_bufu_slot
+        + (base + o_t)[:, None] * stride_bufu_pos
+        + i_hv * V
+        + o_v[None, :]
+    )
+    tl.store(p_bu, b_U.to(p_bu.dtype.element_ty), mask=m_tv)
+    if i_v == 0:
+        p_bk = (
+            buf_k
+            + slot * stride_bufk_slot
+            + (base + o_t)[:, None] * stride_bufk_pos
+            + i_hv * K
+            + o_k[None, :]
+        )
+        tl.store(p_bk, b_k.to(p_bk.dtype.element_ty), mask=m_tk)
+        p_bg = buf_g + slot * stride_bufg_slot + (base + o_t) * stride_bufg_pos + i_hv
+        tl.store(p_bg, b_gt.to(p_bg.dtype.element_ty), mask=m_t)
+
+
+def replayssm_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    ckpt: torch.Tensor,
+    buf_k: torch.Tensor,
+    buf_u: torch.Tensor,
+    buf_g: torch.Tensor,
+    write_pos: torch.Tensor,
+    slot_idx: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    max_query_len: int,
+    scale: float | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    is_kda: bool = False,
+    route: str = "auto",
+) -> torch.Tensor:
+    """ReplaySSM forward for one linear-attention layer.
+
+    Args:
+        q, k: ``[1, T_tot, H, K]``
+        v: ``[1, T_tot, HV, V]``
+        g: ``[1, T_tot, HV]`` (GDN) or ``[1, T_tot, HV, K]`` (KDA)
+        beta: ``[1, T_tot, HV]`` or ``[1, T_tot, HV, V]``
+        ckpt: ``[num_slots, HV, K, V]`` checkpoint pool (mutated on flush)
+        buf_k / buf_u / buf_g: record buffers, see ``replayssm_buffer_shapes``
+        write_pos: ``[num_slots]`` int32 committed-record cursor; advance with
+            :func:`replayssm_commit` once per forward, never here
+        slot_idx: ``[N]`` int32, ``PAD_SLOT_ID`` for idle entries
+        max_query_len: the ``T`` used by the flush predicate; must match the
+            value passed to :func:`replayssm_commit` in the same step
+        route: ``"serial"`` walks tokens one at a time; ``"ut"`` uses the
+            chunked delta-rule UT transform (scalar gate, non-headwise beta,
+            multi-token steps only); ``"auto"`` picks ``"ut"`` when eligible.
+
+    Returns:
+        ``o`` of shape ``[1, T_tot, HV, V]`` -- same leading-batch convention
+        as :func:`fused_recurrent_gated_delta_rule`, so this is a drop-in
+        replacement at the call sites in ``attention_gdn.py``.
+    """
+    assert q.shape[0] == 1, "varlen layout expected (B == 1)"
+    _, T_tot, H, K = q.shape
+    HV, V = v.shape[2], v.shape[3]
+    N = cu_seqlens.numel() - 1
+    cap = buf_k.shape[1]
+    if scale is None:
+        scale = K**-0.5
+    assert flush_threshold_ok(cap, max_query_len), (
+        f"replayssm cache_len={cap} must be >= 2*max_query_len="
+        f"{2 * max_query_len}; otherwise the record buffer overruns"
+    )
+
+    BK = triton.next_power_of_2(K)
+    assert triton.cdiv(K, BK) == 1, "K must fit one block"
+
+    q, k, v, g, beta = (x.contiguous() for x in (q, k, v, g, beta))
+    o = q.new_empty(1, T_tot, HV, V)
+
+    if route not in ("auto", "serial", "ut"):
+        raise ValueError(f"unknown replayssm route {route!r}; expected auto|serial|ut")
+    ut_eligible = (not is_kda) and beta.ndim != v.ndim and max_query_len > 1
+    if route == "auto":
+        # Measured crossover on gfx950 (MI355X), Qwen3.5-like shape
+        # H=2 HV=16 K=V=128 bf16, bs=128, best config per route:
+        #   T=  2   3   4   6   8  12  16
+        #   ut/serial 1.70 1.63 1.40 1.45 1.08 0.98 0.78
+        # The UT transform only pays once the verify window is long enough to
+        # amortise the T x T solve and the GEMM setup; below that the serial
+        # chain is just four dependent rank-1 updates and wins outright.
+        # Practical MTP windows (mtp_k = 1..3, i.e. T = 2..4) sit firmly on
+        # the serial side, so `auto` only reaches for UT at long windows.
+        route = "ut" if ut_eligible and max_query_len >= UT_MIN_QUERY_LEN else "serial"
+    if route == "ut":
+        if not ut_eligible:
+            raise ValueError(
+                "replayssm route='ut' requires a scalar gate (not KDA), "
+                "non-headwise beta, and max_query_len > 1"
+            )
+        # One program per (sequence, v-head): the [T, K] work (loads, l2norm,
+        # the K.K^T and Q.K^T gemms) does not depend on the V split, so
+        # splitting V would replicate it NV times.  Measured 2.9x worse at
+        # BV=32/NV=4 than BV=V/NV=1.
+        BV_UT = triton.next_power_of_2(V)
+        BT = triton.next_power_of_2(max_query_len)
+        _replayssm_ut_fwd_kernel[(1, N * HV)](
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            o=o,
+            ckpt=ckpt,
+            buf_k=buf_k,
+            buf_u=buf_u,
+            buf_g=buf_g,
+            write_pos=write_pos,
+            slot_idx=slot_idx,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            N=N,
+            T_TOT=T_tot,
+            T_MAX=max_query_len,
+            CAP=cap,
+            H=H,
+            HV=HV,
+            K=K,
+            V=V,
+            BK=BK,
+            BV=BV_UT,
+            BT=BT,
+            stride_ckpt_slot=ckpt.stride(0),
+            stride_bufk_slot=buf_k.stride(0),
+            stride_bufk_pos=buf_k.stride(1),
+            stride_bufu_slot=buf_u.stride(0),
+            stride_bufu_pos=buf_u.stride(1),
+            stride_bufg_slot=buf_g.stride(0),
+            stride_bufg_pos=buf_g.stride(1),
+            USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+            num_warps=4 if BT >= 16 else 2,
+            num_stages=2,
+        )
+        return o
+
+    # Serial route tuning (swept on gfx950 over bs 32..256, T 2..16, both the
+    # Qwen3.5 and Kimi-K3 head shapes): BV=64 with a single warp wins across
+    # the board.  BV=32 doubles the number of programs and replicates the
+    # per-token l2norm/loads; BV=128 overflows the register budget.
+    BV = min(triton.next_power_of_2(V), 64)
+    NV = triton.cdiv(V, BV)
+    _replayssm_fwd_kernel[(NV, N * HV)](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        o=o,
+        ckpt=ckpt,
+        buf_k=buf_k,
+        buf_u=buf_u,
+        buf_g=buf_g,
+        write_pos=write_pos,
+        slot_idx=slot_idx,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        N=N,
+        T_TOT=T_tot,
+        T_MAX=max_query_len,
+        CAP=cap,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        stride_ckpt_slot=ckpt.stride(0),
+        stride_bufk_slot=buf_k.stride(0),
+        stride_bufk_pos=buf_k.stride(1),
+        stride_bufu_slot=buf_u.stride(0),
+        stride_bufu_pos=buf_u.stride(1),
+        stride_bufg_slot=buf_g.stride(0),
+        stride_bufg_pos=buf_g.stride(1),
+        stride_beta_tok=beta.stride(1),
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        IS_KDA=is_kda,
+        IS_BETA_HEADWISE=beta.ndim == v.ndim,
+        num_warps=1,
+        num_stages=3,
+    )
+    return o
+
+
+# --------------------------------------------------------------------------- #
+# KDA variant (Kimi-K3): fused gating + transposed state layout                #
+# --------------------------------------------------------------------------- #
+#
+# Kimi's linear-attention layer calls `fused_sigmoid_gating_delta_rule_update`
+# rather than the GDN entry, and that kernel differs in two ways that matter
+# here, so it gets its own ReplaySSM kernel instead of more constexpr branches
+# on the GDN one (which is already carrying production validation):
+#
+# 1. The state is laid out [slot, HV, V, K] -- the transpose of the GDN pool's
+#    [slot, HV, K, V]. Same recurrence, written on S^T:
+#        S^T <- S^T diag(a) + u k^T
+#    so the ReplaySSM expansion carries over unchanged; only the reduction axis
+#    and the pointer arithmetic move.
+# 2. The gate is computed *inside* the kernel from (A_log, a, dt_bias) instead
+#    of being passed in pre-computed, and Kimi uses a lower-bounded sigmoid
+#    gate rather than GDN's -exp(A)*softplus. `a` and `dt_bias` are per-K-channel.
+#
+# The records are still (k, u, g); `g` is a [K] vector per token here, which
+# `replayssm_buffer_shapes(is_kda=True)` already accounts for.
+
+
+@triton.jit
+def _kda_gate(A_log_ptr, a_ptr, dt_bias_ptr, mask_k, LOWER_BOUND, USE_LOWER_BOUND):
+    """Per-K-channel log-decay, matching fused_sigmoid_gating's two branches."""
+    x = tl.load(a_ptr, mask=mask_k, other=0.0).to(tl.float32) + tl.load(
+        dt_bias_ptr, mask=mask_k, other=0.0
+    ).to(tl.float32)
+    b_A = tl.load(A_log_ptr).to(tl.float32)
+    if USE_LOWER_BOUND:
+        return LOWER_BOUND * tl.sigmoid(tl.exp(b_A) * x)
+    softplus_x = tl.where(x <= 20.0, tl.log(1 + tl.exp(x)), x)
+    return -tl.exp(b_A) * softplus_x
+
+
+@triton.jit(do_not_specialize=["N", "T_TOT", "T_MAX", "CAP"])
+def _replayssm_kda_fwd_kernel(
+    q,
+    k,
+    v,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    o,
+    ckpt,
+    buf_k,
+    buf_u,
+    buf_g,
+    write_pos,
+    slot_idx,
+    cu_seqlens,
+    scale,
+    LOWER_BOUND,
+    N,
+    T_TOT,
+    T_MAX,
+    CAP,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    stride_ckpt_slot: tl.constexpr,
+    stride_bufk_slot: tl.constexpr,
+    stride_bufk_pos: tl.constexpr,
+    stride_bufu_slot: tl.constexpr,
+    stride_bufu_pos: tl.constexpr,
+    stride_bufg_slot: tl.constexpr,
+    stride_bufg_pos: tl.constexpr,
+    stride_a_token: tl.constexpr,
+    stride_b_token: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+    eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+    T = eos - bos
+    if T == 0:
+        return
+    slot = tl.load(slot_idx + i_n).to(tl.int64)
+    if slot < 0:
+        return
+
+    h = tl.load(write_pos + slot).to(tl.int32)
+    do_flush = h + 2 * T_MAX > CAP
+    base = tl.where(do_flush, 0, h).to(tl.int64)
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_v[:, None] & mask_k[None, :]  # [BV, BK] -- transposed layout
+
+    # ---- 1. rebuild S_h -----------------------------------------------------
+    p_ckpt_hv = (
+        ckpt + slot * stride_ckpt_slot + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+    )
+    b_h = tl.load(p_ckpt_hv, mask=mask_h, other=0.0).to(tl.float32)
+
+    for j in range(h):
+        b_rg = tl.load(
+            buf_g + slot * stride_bufg_slot + j * stride_bufg_pos + i_hv * K + o_k,
+            mask=mask_k,
+            other=0.0,
+        ).to(tl.float32)
+        b_h *= exp(b_rg)[None, :]
+        b_rk = tl.load(
+            buf_k + slot * stride_bufk_slot + j * stride_bufk_pos + i_hv * K + o_k,
+            mask=mask_k,
+            other=0.0,
+        ).to(tl.float32)
+        b_ru = tl.load(
+            buf_u + slot * stride_bufu_slot + j * stride_bufu_pos + i_hv * V + o_v,
+            mask=mask_v,
+            other=0.0,
+        ).to(tl.float32)
+        b_h += b_ru[:, None] * b_rk[None, :]
+
+    if do_flush:
+        tl.store(p_ckpt_hv, b_h.to(p_ckpt_hv.dtype.element_ty), mask=mask_h)
+
+    # ---- 2. this step's tokens ---------------------------------------------
+    p_q = q + (bos * H + i_h) * K + o_k
+    p_k = k + (bos * H + i_h) * K + o_k
+    p_v = v + (bos * HV + i_hv) * V + o_v
+    p_o = o + (bos * HV + i_hv) * V + o_v
+    p_a = a + (bos * HV + i_hv) * K + o_k
+    p_b = b + bos * HV + i_hv
+    p_A_log = A_log + i_hv
+    p_dt_bias = dt_bias + i_hv * K + o_k
+
+    for i_t in range(T):
+        b_q = tl.load(p_q, mask=mask_k, other=0.0).to(tl.float32)
+        b_k = tl.load(p_k, mask=mask_k, other=0.0).to(tl.float32)
+        b_v = tl.load(p_v, mask=mask_v, other=0.0).to(tl.float32)
+        b_g = _kda_gate(p_A_log, p_a, p_dt_bias, mask_k, LOWER_BOUND, USE_LOWER_BOUND)
+        b_beta = tl.sigmoid(tl.load(p_b).to(tl.float32))
+
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q * tl.rsqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k * tl.rsqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q = b_q * scale
+
+        b_h *= exp(b_g)[None, :]
+        b_v -= tl.sum(b_h * b_k[None, :], 1)
+        b_v *= b_beta
+        b_h += b_v[:, None] * b_k[None, :]
+        tl.store(
+            p_o, tl.sum(b_h * b_q[None, :], 1).to(p_o.dtype.element_ty), mask=mask_v
+        )
+
+        pos = base + i_t
+        p_bu = buf_u + slot * stride_bufu_slot + pos * stride_bufu_pos + i_hv * V + o_v
+        tl.store(p_bu, b_v.to(p_bu.dtype.element_ty), mask=mask_v)
+        if i_v == 0:
+            p_bk = (
+                buf_k + slot * stride_bufk_slot + pos * stride_bufk_pos + i_hv * K + o_k
+            )
+            tl.store(p_bk, b_k.to(p_bk.dtype.element_ty), mask=mask_k)
+            p_bg = (
+                buf_g + slot * stride_bufg_slot + pos * stride_bufg_pos + i_hv * K + o_k
+            )
+            tl.store(p_bg, b_g.to(p_bg.dtype.element_ty), mask=mask_k)
+
+        p_q += H * K
+        p_k += H * K
+        p_v += HV * V
+        p_o += HV * V
+        p_a += stride_a_token
+        p_b += stride_b_token
+
+
+def replayssm_sigmoid_gating_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ckpt: torch.Tensor,
+    buf_k: torch.Tensor,
+    buf_u: torch.Tensor,
+    buf_g: torch.Tensor,
+    write_pos: torch.Tensor,
+    slot_idx: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    max_query_len: int,
+    o: torch.Tensor | None = None,
+    scale: float | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    lower_bound: float | None = None,
+) -> torch.Tensor:
+    """ReplaySSM for the KDA (Kimi-K3) linear-attention layer.
+
+    Drop-in for :func:`fused_sigmoid_gating_delta_rule_update` on the decode /
+    verify path: same fused gating, same ``[slot, HV, V, K]`` state layout, but
+    the pool holds one checkpoint per request instead of one state per
+    speculative token.  See the module docstring for the algebra.
+
+    ``o`` may be passed to write the output in place (K3 does this).
+    """
+    assert q.shape[0] == 1, "varlen layout expected (B == 1)"
+    _, T_tot, H, K = q.shape
+    HV, V = v.shape[2], v.shape[3]
+    N = cu_seqlens.numel() - 1
+    cap = buf_k.shape[1]
+    if scale is None:
+        scale = K**-0.5
+    assert flush_threshold_ok(cap, max_query_len), (
+        f"replayssm cache_len={cap} must be >= 2*max_query_len=" f"{2 * max_query_len}"
+    )
+
+    BK = triton.next_power_of_2(K)
+    assert triton.cdiv(K, BK) == 1, "K must fit one block"
+    BV = min(triton.next_power_of_2(V), 64)
+    NV = triton.cdiv(V, BV)
+
+    q, k, v, a, b = (x.contiguous() for x in (q, k, v, a, b))
+    out = q.new_empty(1, T_tot, HV, V) if o is None else o.unsqueeze(0)
+
+    _replayssm_kda_fwd_kernel[(NV, N * HV)](
+        q=q,
+        k=k,
+        v=v,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        o=out,
+        ckpt=ckpt,
+        buf_k=buf_k,
+        buf_u=buf_u,
+        buf_g=buf_g,
+        write_pos=write_pos,
+        slot_idx=slot_idx,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        LOWER_BOUND=0.0 if lower_bound is None else lower_bound,
+        N=N,
+        T_TOT=T_tot,
+        T_MAX=max_query_len,
+        CAP=cap,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        stride_ckpt_slot=ckpt.stride(0),
+        stride_bufk_slot=buf_k.stride(0),
+        stride_bufk_pos=buf_k.stride(1),
+        stride_bufu_slot=buf_u.stride(0),
+        stride_bufu_pos=buf_u.stride(1),
+        stride_bufg_slot=buf_g.stride(0),
+        stride_bufg_pos=buf_g.stride(1),
+        stride_a_token=a.stride(-3),
+        stride_b_token=b.stride(-2),
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        USE_LOWER_BOUND=lower_bound is not None,
+        num_warps=1,
+        num_stages=3,
+    )
+    return out

--- a/atom/model_ops/fla_ops/replayssm.py
+++ b/atom/model_ops/fla_ops/replayssm.py
@@ -237,6 +237,14 @@ def _replayssm_commit_kernel(
     if slot < 0:
         return
     h = tl.load(write_pos + slot)
+    # -1 is the prefill sentinel: that forward rebuilt the checkpoint wholesale
+    # and wrote no records, so there is nothing to commit and the first decode
+    # has to start from an empty prefix.  Advancing by the 1 that `num_bonus ==
+    # 0` yields would fold record 0, which on a reused slot is still the
+    # previous tenant's last record.
+    if h < 0:
+        tl.store(write_pos + slot, 0)
+        return
     # Re-derive the previous forward's flush decision.  The forward never
     # mutates write_pos, so `h` here is exactly what that forward branched on.
     prev_flushed = h + 2 * T_MAX > CAP
@@ -329,6 +337,12 @@ def _replayssm_fwd_kernel(
         return
 
     h = tl.load(write_pos + slot).to(tl.int32)
+    # Clamp the prefill sentinel.  In the normal order the commit kernel has
+    # already turned -1 into 0, but graph capture wires the buffers up and
+    # replays dummy batches without committing; folding nothing and writing
+    # from 0 is both the right answer and what keeps `base` off -1, which would
+    # index a record row outside this slot.
+    h = tl.maximum(h, 0)
     do_flush = h + 2 * T_MAX > CAP
     base = tl.where(do_flush, 0, h).to(tl.int64)
 
@@ -522,6 +536,12 @@ def _replayssm_ut_fwd_kernel(
         return
 
     h = tl.load(write_pos + slot).to(tl.int32)
+    # Clamp the prefill sentinel.  In the normal order the commit kernel has
+    # already turned -1 into 0, but graph capture wires the buffers up and
+    # replays dummy batches without committing; folding nothing and writing
+    # from 0 is both the right answer and what keeps `base` off -1, which would
+    # index a record row outside this slot.
+    h = tl.maximum(h, 0)
     do_flush = h + 2 * T_MAX > CAP
     base = tl.where(do_flush, 0, h).to(tl.int64)
 
@@ -913,6 +933,12 @@ def _replayssm_kda_fwd_kernel(
         return
 
     h = tl.load(write_pos + slot).to(tl.int32)
+    # Clamp the prefill sentinel.  In the normal order the commit kernel has
+    # already turned -1 into 0, but graph capture wires the buffers up and
+    # replays dummy batches without committing; folding nothing and writing
+    # from 0 is both the right answer and what keeps `base` off -1, which would
+    # index a record row outside this slot.
+    h = tl.maximum(h, 0)
     do_flush = h + 2 * T_MAX > CAP
     base = tl.where(do_flush, 0, h).to(tl.int64)
 

--- a/atom/model_ops/fla_ops/replayssm.py
+++ b/atom/model_ops/fla_ops/replayssm.py
@@ -57,6 +57,25 @@ PAD_SLOT_ID = -1
 #: window.  See the measurement table in `replayssm_gated_delta_rule`.
 UT_MIN_QUERY_LEN = 12
 
+#: Replay-GEMM arithmetic, keyed by the record buffer's dtype.  See
+#: `_replay_dot` for what the modes do and why the split is only one-sided.
+_DOT_MODE_BY_RECORD_DTYPE = {
+    torch.bfloat16: 2,
+    torch.float16: 3,
+}
+
+
+def _replay_dot_mode(record_dtype: torch.dtype) -> int:
+    """How to contract the records against the checkpoint on a flush.
+
+    A 16-bit record buffer replays on the bf16 matrix cores: fp32 MFMA runs at
+    an eighth of the bf16 rate on CDNA, and upcasting a bf16 record to fp32
+    cannot add information it never had.  An fp32 buffer is the other way
+    round -- a bf16 hi/lo pair tops out near 16 mantissa bits and would lose
+    real precision -- so those callers keep the fp32 contraction.
+    """
+    return _DOT_MODE_BY_RECORD_DTYPE.get(record_dtype, 0)
+
 
 # --------------------------------------------------------------------------- #
 # Flush policy                                                                 #
@@ -87,9 +106,9 @@ def replayssm_buffer_shapes(
 ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
     """Per-slot record buffer shapes: (k, u, g)."""
     return (
-        (cache_len, num_v_heads, head_k_dim),
-        (cache_len, num_v_heads, head_v_dim),
-        (cache_len, num_v_heads, head_k_dim) if is_kda else (cache_len, num_v_heads),
+        (num_v_heads, cache_len, head_k_dim),
+        (num_v_heads, cache_len, head_v_dim),
+        (num_v_heads, cache_len, head_k_dim) if is_kda else (num_v_heads, cache_len),
     )
 
 
@@ -128,10 +147,13 @@ def _replay_tiles(
     h,
     stride_bufk_slot,
     stride_bufk_pos,
+    stride_bufk_hv,
     stride_bufu_slot,
     stride_bufu_pos,
+    stride_bufu_hv,
     stride_bufg_slot,
     stride_bufg_pos,
+    stride_bufg_hv,
     i_hv,
     o_k,
     o_v,
@@ -163,18 +185,23 @@ def _replay_tiles(
             buf_g
             + slot * stride_bufg_slot
             + o_h[:, None] * stride_bufg_pos
-            + i_hv * K
+            + i_hv * stride_bufg_hv
             + o_k[None, :],
             mask=m_h[:, None] & mask_k[None, :],
             other=0.0,
         ).to(tl.float32)
     else:
         # Scalar gate: broadcast the per-record value across K so the cumsum
-        # and the weighting below stay one code path. BH is small (16-64) and
-        # the tile is dwarfed by the [BK, BV] state, so the waste is not worth
-        # a second branch.
+        # and the weighting below stay one code path.  Only the fused-gating
+        # KDA kernel reaches this helper, and it always has a per-channel gate,
+        # so in practice this branch is not instantiated -- the scalar-gate
+        # callers go through `_replay_tiles_kmajor`, which keeps the gate a
+        # [BH] vector instead of paying the broadcast.
         b_g1 = tl.load(
-            buf_g + slot * stride_bufg_slot + o_h * stride_bufg_pos + i_hv,
+            buf_g
+            + slot * stride_bufg_slot
+            + o_h * stride_bufg_pos
+            + i_hv * stride_bufg_hv,
             mask=m_h,
             other=0.0,
         ).to(tl.float32)
@@ -190,7 +217,7 @@ def _replay_tiles(
         buf_k
         + slot * stride_bufk_slot
         + o_h[:, None] * stride_bufk_pos
-        + i_hv * K
+        + i_hv * stride_bufk_hv
         + o_k[None, :],
         mask=m_h[:, None] & mask_k[None, :],
         other=0.0,
@@ -199,21 +226,178 @@ def _replay_tiles(
         buf_u
         + slot * stride_bufu_slot
         + o_h[:, None] * stride_bufu_pos
-        + i_hv * V
+        + i_hv * stride_bufu_hv
         + o_v[None, :],
         mask=m_h[:, None] & mask_v[None, :],
         other=0.0,
     ).to(tl.float32)
-    # fp32 operands, fp32 accumulation. A plain bf16 cast runs the contraction on
-    # the matrix cores (CDNA does fp32 MFMA at an eighth of the bf16 rate) and
-    # measured ~20 points faster, but it broke 17 of the 27 differential tests.
-    # Splitting each operand into bf16 hi+lo and summing four products restores
-    # the accuracy -- and gives back the speed with it: measured indistinguishable
-    # from this single fp32 dot both in the microbenchmark (+17% vs +15% over the
-    # aiter kernel, inside the 6% run-to-run spread) and end to end (-7.2%, +3.3%,
-    # +4.5% across conc 32/64/128, no consistent direction). Four dots plus the
-    # hi/lo decomposition is not worth carrying for a wash.
     return b_k * b_w, b_u, exp(b_ctot)
+
+
+@triton.jit
+def _replay_tiles_kmajor(
+    buf_k,
+    buf_u,
+    buf_g,
+    slot,
+    h,
+    stride_bufk_slot,
+    stride_bufk_pos,
+    stride_bufk_hv,
+    stride_bufu_slot,
+    stride_bufu_pos,
+    stride_bufu_hv,
+    stride_bufg_slot,
+    stride_bufg_pos,
+    stride_bufg_hv,
+    i_hv,
+    o_k,
+    o_v,
+    mask_k,
+    mask_v,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BH: tl.constexpr,
+    IS_KDA: tl.constexpr,
+):
+    """`_replay_tiles` with the k side already transposed, for a [BK, BV] state.
+
+    Returns ``(b_kw [BK, BH], b_u [BH, BV], b_decay [BK])`` so the caller can
+    contract with a bare ``tl.dot(b_kw, b_u)``.
+
+    k-major is here for the T == 1 path's reductions, not for the GEMM.  It
+    was originally tried as a way to drop the ``tl.trans`` ahead of `tl.dot`,
+    on the theory that the LDS staging Triton emits for it (`shared=8192`,
+    ~40 `ds_write` on the fp32 tile) was what made the replay GEMM cost 92 us
+    of a 173 us kernel.  That theory was wrong, or at least incomplete: with
+    an fp32 dot, k-major measured 171 us against 173 us -- nothing.  The
+    record axis is the strided one in the buffer whichever orientation the
+    tile is read in, so the layout conversion happens either way.
+
+    What it does buy is the orientation of `S_h^T x` on the T == 1 path, where
+    the contraction is a reduction rather than a dot: reducing a [BK, BH] tile
+    along BK measured 111.5 us against 118.1 us for the [BH, BK] tile reduced
+    along its last axis, despite k-major's loads being the less coalesced of
+    the two (consecutive lanes walk `stride_bufk_pos`, 4 KiB apart).
+
+    The scalar-gate branch also keeps the gate as a [BH] vector rather than
+    broadcasting it to [BH, BK] first: the weights are per-record, so the wide
+    tile made the cumsum and BK-1 of every BK exponentials redundant.
+    """
+    o_h = tl.arange(0, BH)
+    m_h = o_h < h
+
+    b_kt = tl.load(
+        buf_k
+        + slot * stride_bufk_slot
+        + o_h[None, :] * stride_bufk_pos
+        + i_hv * stride_bufk_hv
+        + o_k[:, None],
+        mask=m_h[None, :] & mask_k[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    b_u = tl.load(
+        buf_u
+        + slot * stride_bufu_slot
+        + o_h[:, None] * stride_bufu_pos
+        + i_hv * stride_bufu_hv
+        + o_v[None, :],
+        mask=m_h[:, None] & mask_v[None, :],
+        other=0.0,
+    ).to(tl.float32)
+
+    # Gates are log-decays (<= 0), so C - C_j <= 0 and every weight is in (0, 1]
+    # -- the exponentials cannot overflow however long the buffer gets.
+    if IS_KDA:
+        b_g = tl.load(
+            buf_g
+            + slot * stride_bufg_slot
+            + o_h[None, :] * stride_bufg_pos
+            + i_hv * stride_bufg_hv
+            + o_k[:, None],
+            mask=m_h[None, :] & mask_k[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        b_c = tl.cumsum(b_g, axis=1)
+        b_ctot = tl.sum(b_g, axis=1)
+        b_kw = b_kt * exp(b_ctot[:, None] - b_c)
+        b_decay = exp(b_ctot)
+    else:
+        b_g1 = tl.load(
+            buf_g
+            + slot * stride_bufg_slot
+            + o_h * stride_bufg_pos
+            + i_hv * stride_bufg_hv,
+            mask=m_h,
+            other=0.0,
+        ).to(tl.float32)
+        b_c1 = tl.cumsum(b_g1, axis=0)
+        b_ctot1 = tl.sum(b_g1, axis=0)
+        b_kw = b_kt * exp(b_ctot1 - b_c1)[None, :]
+        b_decay = exp(b_ctot1) + tl.zeros([BK], dtype=tl.float32)
+    return b_kw, b_u, b_decay
+
+
+@triton.jit
+def _replay_dot(
+    lhs,
+    rhs,
+    SPLIT_LHS: tl.constexpr,
+    DOT_MODE: tl.constexpr,
+):
+    """``tl.dot(lhs, rhs)`` for the replay contraction.
+
+    Operands arrive dot-ready: callers in the ``[BK, BV]`` state layout get a
+    k-major tile out of `_replay_tiles_kmajor`, KDA's ``[BV, BK]`` layout
+    transposes at the call site.
+
+    Reached on a flush, or on a multi-token (speculative) step.  At T == 1 the
+    caller takes the state-free path and never gets here, which is the point:
+    this contraction is expensive on CDNA for reasons that survive every fix
+    tried at it -- fp32 dot 92 us of a 173 us kernel, bf16 operands (an eighth
+    the MFMA cost) still 63 us, k-major to skip the ``tl.trans`` ~0.  Only one
+    step in ``cap - 1`` needs it now.
+
+    ``SPLIT_LHS`` says which side is ``b_kw``, the only operand genuinely wider
+    than the record buffer: ``b_u`` is a raw record load, so narrowing it back
+    to the buffer's own dtype is exact, while ``b_kw = k * w`` is a product and
+    is not.
+
+    ``DOT_MODE`` picks the arithmetic:
+      0 -- one fp32 dot.  What an fp32 record buffer needs: bf16 hi/lo tops out
+           near 16 mantissa bits and cannot carry fp32 records faithfully.
+      1 -- one bf16 dot.  ~8 mantissa bits; too lossy, attribution only.
+      2 -- bf16 hi/lo on the ``b_kw`` side only, 2 dots.  For a bf16 record
+           buffer the other side's lo term is identically zero, so this is the
+           whole split; measured 3.6e-06 relative against an fp64 reference,
+           553x tighter than mode 1, for 2.9 us over it.
+      3 -- also splits the record side, 3 dots (lo*lo is negligible).  Needed
+           when the buffer is 16-bit but not bf16, i.e. fp16.
+    """
+    if DOT_MODE == 0:
+        acc = tl.dot(lhs, rhs)
+    elif SPLIT_LHS:
+        b_hi = lhs.to(tl.bfloat16)
+        b_other = rhs.to(tl.bfloat16)
+        acc = tl.dot(b_hi, b_other)
+        if DOT_MODE >= 2:
+            b_lo = (lhs - b_hi.to(tl.float32)).to(tl.bfloat16)
+            acc += tl.dot(b_lo, b_other)
+        if DOT_MODE == 3:
+            b_other_lo = (rhs - b_other.to(tl.float32)).to(tl.bfloat16)
+            acc += tl.dot(b_hi, b_other_lo)
+    else:
+        b_hi = rhs.to(tl.bfloat16)
+        b_other = lhs.to(tl.bfloat16)
+        acc = tl.dot(b_other, b_hi)
+        if DOT_MODE >= 2:
+            b_lo = (rhs - b_hi.to(tl.float32)).to(tl.bfloat16)
+            acc += tl.dot(b_other, b_lo)
+        if DOT_MODE == 3:
+            b_other_lo = (lhs - b_other.to(tl.float32)).to(tl.bfloat16)
+            acc += tl.dot(b_other_lo, b_hi)
+    return acc
 
 
 # --------------------------------------------------------------------------- #
@@ -313,14 +497,20 @@ def _replayssm_fwd_kernel(
     stride_ckpt_slot: tl.constexpr,
     stride_bufk_slot: tl.constexpr,
     stride_bufk_pos: tl.constexpr,
+    stride_bufk_hv: tl.constexpr,
     stride_bufu_slot: tl.constexpr,
     stride_bufu_pos: tl.constexpr,
+    stride_bufu_hv: tl.constexpr,
     stride_bufg_slot: tl.constexpr,
     stride_bufg_pos: tl.constexpr,
+    stride_bufg_hv: tl.constexpr,
     stride_beta_tok: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
     IS_KDA: tl.constexpr,
     IS_BETA_HEADWISE: tl.constexpr,
+    DOT_MODE: tl.constexpr,
+    T1_FAST: tl.constexpr,
+    T1_TILED: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -352,12 +542,168 @@ def _replayssm_fwd_kernel(
     mask_v = o_v < V
     mask_h = mask_k[:, None] & mask_v[None, :]
 
-    # ---- 1. rebuild S_h = ckpt + the h committed records -------------------
+    if T1_TILED:
+        # Scalar-gate T == 1.  Same algebra as the T1_FAST block below, but
+        # specialised: the gate is per record, so it stays a [BH] vector and
+        # the checkpoint's decay stays a scalar, rather than going through
+        # `_replay_tiles_kmajor`'s [BK]-shaped form.  Worth 111.5 -> 104 us.
+        #
+        # This was written to be dstate-tiled -- walking the checkpoint in
+        # [BKT, BV] slices -- on the theory that holding the 8 KiB tile whole
+        # (128 VGPRs a lane at BK=128/BV=64) was capping occupancy, which is
+        # also the fix upstream names for exactly this regime: their fp32-state
+        # results do not transfer to a 16-bit state ("FP16/BF16 state is
+        # currently ~parity with baseline latency (high register pressure ->
+        # low bandwidth utilization); the planned fix is dstate-tiling"), and
+        # ATOM's GDN state is bf16.  Measured here it does not hold: BKT of
+        # 16/32/64/128 gave 116.6/107.2/136.2/104.0 us, so the untiled form
+        # wins and the loop was collapsed.  Re-tuning BV and num_warps for the
+        # new shape likewise landed back on the existing BV=64/num_warps=1
+        # (against 110.2 at BV=128, 111.8 at BV=32, 116.2 at num_warps=2).
+        o_h = tl.arange(0, BH)
+        m_h = o_h < h
+
+        # Replay weights: per record, so a [BH] vector, computed once.
+        b_g1 = tl.load(
+            buf_g
+            + slot * stride_bufg_slot
+            + o_h * stride_bufg_pos
+            + i_hv * stride_bufg_hv,
+            mask=m_h,
+            other=0.0,
+        ).to(tl.float32)
+        b_ctot1 = tl.sum(b_g1, axis=0)
+        b_w = exp(b_ctot1 - tl.cumsum(b_g1, axis=0))
+        b_decay = exp(b_ctot1)
+
+        b_ru = tl.load(
+            buf_u
+            + slot * stride_bufu_slot
+            + o_h[:, None] * stride_bufu_pos
+            + i_hv * stride_bufu_hv
+            + o_v[None, :],
+            mask=m_h[:, None] & mask_v[None, :],
+            other=0.0,
+        ).to(tl.float32)
+
+        b_gt = tl.load(g + bos * HV + i_hv).to(tl.float32)
+        b_eg = exp(b_gt)
+
+        # The l2 norms need the whole vector, so take them before tiling; the
+        # per-tile reloads below are [BKT] slices of the same two vectors.
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_qf = tl.load(q + (bos * H + i_h) * K + o_k, mask=mask_k, other=0.0).to(
+                tl.float32
+            )
+            b_kf = tl.load(k + (bos * H + i_h) * K + o_k, mask=mask_k, other=0.0).to(
+                tl.float32
+            )
+            q_rn = 1.0 / tl.sqrt(tl.sum(b_qf * b_qf) + 1e-6)
+            k_rn = 1.0 / tl.sqrt(tl.sum(b_kf * b_kf) + 1e-6)
+        else:
+            q_rn = 1.0
+            k_rn = 1.0
+
+        b_sk = tl.zeros([BV], dtype=tl.float32)
+        b_sq = tl.zeros([BV], dtype=tl.float32)
+        b_ck = tl.zeros([BH], dtype=tl.float32)
+        b_cq = tl.zeros([BH], dtype=tl.float32)
+        b_kq = 0.0
+        p_ckpt = ckpt + slot * stride_ckpt_slot + i_hv * K * V
+        b_qt = (
+            tl.load(q + (bos * H + i_h) * K + o_k, mask=mask_k, other=0.0).to(
+                tl.float32
+            )
+            * q_rn
+            * scale
+        )
+        b_kt = (
+            tl.load(k + (bos * H + i_h) * K + o_k, mask=mask_k, other=0.0).to(
+                tl.float32
+            )
+            * k_rn
+        )
+        b_kq += tl.sum(b_kt * b_qt)
+        b_xk = b_eg * b_kt
+        b_xq = b_eg * b_qt
+
+        p_s = p_ckpt + o_k[:, None] * V + o_v[None, :]
+        b_s = tl.load(p_s, mask=mask_k[:, None] & mask_v[None, :], other=0.0).to(
+            tl.float32
+        )
+        b_sk += tl.sum(b_s * (b_decay * b_xk)[:, None], 0)
+        b_sq += tl.sum(b_s * (b_decay * b_xq)[:, None], 0)
+
+        b_kwt = (
+            tl.load(
+                buf_k
+                + slot * stride_bufk_slot
+                + o_h[None, :] * stride_bufk_pos
+                + i_hv * stride_bufk_hv
+                + o_k[:, None],
+                mask=m_h[None, :] & mask_k[:, None],
+                other=0.0,
+            ).to(tl.float32)
+            * b_w[None, :]
+        )
+        b_ck += tl.sum(b_kwt * b_xk[:, None], 0)
+        b_cq += tl.sum(b_kwt * b_xq[:, None], 0)
+
+        if do_flush:
+            tl.store(
+                p_s,
+                (b_s * b_decay + _replay_dot(b_kwt, b_ru, True, DOT_MODE)).to(
+                    p_s.dtype.element_ty
+                ),
+                mask=mask_k[:, None] & mask_v[None, :],
+            )
+        if i_v == 0:
+            p_bkt = (
+                buf_k
+                + slot * stride_bufk_slot
+                + base * stride_bufk_pos
+                + i_hv * stride_bufk_hv
+                + o_k
+            )
+            tl.store(p_bkt, b_kt.to(p_bkt.dtype.element_ty), mask=mask_k)
+
+        # record half, once the per-record weights are complete
+        b_sk += tl.sum(b_ck[:, None] * b_ru, 0)
+        b_sq += tl.sum(b_cq[:, None] * b_ru, 0)
+
+        b_v = tl.load(v + (bos * HV + i_hv) * V + o_v, mask=mask_v, other=0.0).to(
+            tl.float32
+        )
+        if IS_BETA_HEADWISE:
+            b_beta = tl.load(
+                beta + (bos * HV + i_hv) * V + o_v, mask=mask_v, other=0.0
+            ).to(tl.float32)
+        else:
+            b_beta = tl.load(beta + bos * HV + i_hv).to(tl.float32)
+        b_u = b_beta * (b_v - b_sk)
+
+        p_o = o + (bos * HV + i_hv) * V + o_v
+        tl.store(p_o, (b_sq + b_u * b_kq).to(p_o.dtype.element_ty), mask=mask_v)
+
+        p_bu = (
+            buf_u
+            + slot * stride_bufu_slot
+            + base * stride_bufu_pos
+            + i_hv * stride_bufu_hv
+            + o_v
+        )
+        tl.store(p_bu, b_u.to(p_bu.dtype.element_ty), mask=mask_v)
+        if i_v == 0:
+            p_bg2 = buf_g + slot * stride_bufg_slot + base * stride_bufg_pos
+            tl.store(p_bg2 + i_hv * stride_bufg_hv, b_gt.to(p_bg2.dtype.element_ty))
+        return
+
+    # ---- 1. the checkpoint and the committed records -----------------------
     p_ckpt = ckpt + slot * stride_ckpt_slot + i_hv * K * V
     p_ckpt_hv = p_ckpt + o_k[:, None] * V + o_v[None, :]
-    b_h = tl.load(p_ckpt_hv, mask=mask_h, other=0.0).to(tl.float32)
+    b_s0 = tl.load(p_ckpt_hv, mask=mask_h, other=0.0).to(tl.float32)
 
-    b_kw, b_ru, b_decay = _replay_tiles(
+    b_kw, b_ru, b_decay = _replay_tiles_kmajor(
         buf_k,
         buf_u,
         buf_g,
@@ -365,10 +711,13 @@ def _replayssm_fwd_kernel(
         h,
         stride_bufk_slot,
         stride_bufk_pos,
+        stride_bufk_hv,
         stride_bufu_slot,
         stride_bufu_pos,
+        stride_bufu_hv,
         stride_bufg_slot,
         stride_bufg_pos,
+        stride_bufg_hv,
         i_hv,
         o_k,
         o_v,
@@ -380,9 +729,103 @@ def _replayssm_fwd_kernel(
         BH,
         IS_KDA,
     )
-    # State is [BK, BV] here, so the contraction runs k~^T @ u.
-    b_h = b_h * b_decay[:, None]
-    b_h += tl.dot(tl.trans(b_kw), b_ru)
+    if T1_FAST:
+        # T == 1: nothing chains from token to token, so S_h is never needed as
+        # a value -- only its two contractions, S_h^T k and S_h^T q, and both
+        # distribute over the record sum because (k_j (x) u_j)^T x = (k_j.x)u_j:
+        #
+        #   S_h^T x = e^C (S_0^T x) + sum_j (k~_j . x) u_j
+        #
+        # so two [BH]-long matvecs replace the [BK,BH]x[BH,BV] rebuild.  That
+        # GEMM measured 66-92 us of a 173 us kernel and would not come down:
+        # casting the operands to bf16 (an eighth the MFMA cost) only moved it
+        # 92 -> 63 us, and loading the k tile k-major to drop the `tl.trans`
+        # bought ~0, because Triton stages the layout conversion through LDS
+        # either way -- the record axis is the strided one in the buffer, whichever
+        # orientation it is read in.  Not doing the GEMM is the way past it.
+        # A flush is the one step that still needs S_h as a value, and it is
+        # one step in `cap - 1`.
+        p_o = o + (bos * HV + i_hv) * V + o_v
+        b_q = tl.load(q + (bos * H + i_h) * K + o_k, mask=mask_k, other=0.0).to(
+            tl.float32
+        )
+        b_k = tl.load(k + (bos * H + i_h) * K + o_k, mask=mask_k, other=0.0).to(
+            tl.float32
+        )
+        b_v = tl.load(v + (bos * HV + i_hv) * V + o_v, mask=mask_v, other=0.0).to(
+            tl.float32
+        )
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q = b_q * scale
+
+        if IS_KDA:
+            b_g = tl.load(g + (bos * HV + i_hv) * K + o_k, mask=mask_k, other=0.0).to(
+                tl.float32
+            )
+        else:
+            b_g = tl.load(g + bos * HV + i_hv).to(tl.float32)
+        # (diag(e^g) S_h)^T x == S_h^T (e^g . x), so this step's gate rides on
+        # the contraction vector instead of scaling a whole [BK, BV] tile.
+        b_eg = exp(b_g)
+        b_xk = b_eg * b_k
+        b_xq = b_eg * b_q
+
+        # checkpoint half; e^C likewise rides on the vector, not the tile
+        b_sk = tl.sum(b_s0 * (b_decay * b_xk)[:, None], 0)
+        b_sq = tl.sum(b_s0 * (b_decay * b_xq)[:, None], 0)
+        # record half: one weight per record, then scattered onto u
+        b_sk += tl.sum(tl.sum(b_kw * b_xk[:, None], 0)[:, None] * b_ru, 0)
+        b_sq += tl.sum(tl.sum(b_kw * b_xq[:, None], 0)[:, None] * b_ru, 0)
+
+        if IS_BETA_HEADWISE:
+            b_beta = tl.load(
+                beta + (bos * HV + i_hv) * V + o_v, mask=mask_v, other=0.0
+            ).to(tl.float32)
+        else:
+            b_beta = tl.load(beta + bos * HV + i_hv).to(tl.float32)
+        b_u = b_beta * (b_v - b_sk)
+        # o = (diag(e^g) S_h + k (x) u)^T q
+        b_o = b_sq + b_u * tl.sum(b_k * b_q)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+
+        p_bu = (
+            buf_u
+            + slot * stride_bufu_slot
+            + base * stride_bufu_pos
+            + i_hv * stride_bufu_hv
+            + o_v
+        )
+        tl.store(p_bu, b_u.to(p_bu.dtype.element_ty), mask=mask_v)
+        if i_v == 0:
+            p_bk = (
+                buf_k
+                + slot * stride_bufk_slot
+                + base * stride_bufk_pos
+                + i_hv * stride_bufk_hv
+                + o_k
+            )
+            tl.store(p_bk, b_k.to(p_bk.dtype.element_ty), mask=mask_k)
+            p_bg2 = buf_g + slot * stride_bufg_slot + base * stride_bufg_pos
+            if IS_KDA:
+                tl.store(
+                    p_bg2 + i_hv * stride_bufg_hv + o_k,
+                    b_g.to(p_bg2.dtype.element_ty),
+                    mask=mask_k,
+                )
+            else:
+                tl.store(p_bg2 + i_hv * stride_bufg_hv, b_g.to(p_bg2.dtype.element_ty))
+
+        if do_flush:
+            b_h = b_s0 * b_decay[:, None] + _replay_dot(b_kw, b_ru, True, DOT_MODE)
+            tl.store(p_ckpt_hv, b_h.to(p_ckpt_hv.dtype.element_ty), mask=mask_h)
+        return
+
+    # State is [BK, BV] here and the k tile arrives k-major, so the contraction
+    # is a bare k~ @ u with no transpose to stage through LDS.
+    b_h = b_s0 * b_decay[:, None]
+    b_h += _replay_dot(b_kw, b_ru, True, DOT_MODE)
 
     # ---- 2. flush: the checkpoint absorbs the committed prefix --------------
     if do_flush:
@@ -433,24 +876,34 @@ def _replayssm_fwd_kernel(
 
         # ---- append the record ---------------------------------------------
         pos = base + i_t
-        p_bu = buf_u + slot * stride_bufu_slot + pos * stride_bufu_pos + i_hv * V + o_v
+        p_bu = (
+            buf_u
+            + slot * stride_bufu_slot
+            + pos * stride_bufu_pos
+            + i_hv * stride_bufu_hv
+            + o_v
+        )
         tl.store(p_bu, b_v.to(p_bu.dtype.element_ty), mask=mask_v)
         # k and g do not depend on the V split; let one program own the store
         # instead of having every V-block redundantly write the same bytes.
         if i_v == 0:
             p_bk = (
-                buf_k + slot * stride_bufk_slot + pos * stride_bufk_pos + i_hv * K + o_k
+                buf_k
+                + slot * stride_bufk_slot
+                + pos * stride_bufk_pos
+                + i_hv * stride_bufk_hv
+                + o_k
             )
             tl.store(p_bk, b_k.to(p_bk.dtype.element_ty), mask=mask_k)
             p_bg2 = buf_g + slot * stride_bufg_slot + pos * stride_bufg_pos
             if IS_KDA:
                 tl.store(
-                    p_bg2 + i_hv * K + o_k,
+                    p_bg2 + i_hv * stride_bufg_hv + o_k,
                     b_g.to(p_bg2.dtype.element_ty),
                     mask=mask_k,
                 )
             else:
-                tl.store(p_bg2 + i_hv, b_g.to(p_bg2.dtype.element_ty))
+                tl.store(p_bg2 + i_hv * stride_bufg_hv, b_g.to(p_bg2.dtype.element_ty))
 
         p_q += H * K
         p_k += H * K
@@ -516,11 +969,15 @@ def _replayssm_ut_fwd_kernel(
     stride_ckpt_slot: tl.constexpr,
     stride_bufk_slot: tl.constexpr,
     stride_bufk_pos: tl.constexpr,
+    stride_bufk_hv: tl.constexpr,
     stride_bufu_slot: tl.constexpr,
     stride_bufu_pos: tl.constexpr,
+    stride_bufu_hv: tl.constexpr,
     stride_bufg_slot: tl.constexpr,
     stride_bufg_pos: tl.constexpr,
+    stride_bufg_hv: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    DOT_MODE: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -579,7 +1036,7 @@ def _replayssm_ut_fwd_kernel(
     )
     m_h = m_k[:, None] & m_v[None, :]
     b_h = tl.load(p_ckpt_hv, mask=m_h, other=0.0).to(tl.float32)
-    b_kw, b_ru, b_decay = _replay_tiles(
+    b_kw, b_ru, b_decay = _replay_tiles_kmajor(
         buf_k,
         buf_u,
         buf_g,
@@ -587,10 +1044,13 @@ def _replayssm_ut_fwd_kernel(
         h,
         stride_bufk_slot,
         stride_bufk_pos,
+        stride_bufk_hv,
         stride_bufu_slot,
         stride_bufu_pos,
+        stride_bufu_hv,
         stride_bufg_slot,
         stride_bufg_pos,
+        stride_bufg_hv,
         i_hv,
         o_k,
         o_v,
@@ -603,7 +1063,7 @@ def _replayssm_ut_fwd_kernel(
         False,
     )
     b_h = b_h * b_decay[:, None]
-    b_h += tl.dot(tl.trans(b_kw), b_ru)
+    b_h += _replay_dot(b_kw, b_ru, True, DOT_MODE)
 
     if do_flush:
         tl.store(p_ckpt_hv, b_h.to(p_ckpt_hv.dtype.element_ty), mask=m_h)
@@ -645,7 +1105,7 @@ def _replayssm_ut_fwd_kernel(
         buf_u
         + slot * stride_bufu_slot
         + (base + o_t)[:, None] * stride_bufu_pos
-        + i_hv * V
+        + i_hv * stride_bufu_hv
         + o_v[None, :]
     )
     tl.store(p_bu, b_U.to(p_bu.dtype.element_ty), mask=m_tv)
@@ -654,11 +1114,16 @@ def _replayssm_ut_fwd_kernel(
             buf_k
             + slot * stride_bufk_slot
             + (base + o_t)[:, None] * stride_bufk_pos
-            + i_hv * K
+            + i_hv * stride_bufk_hv
             + o_k[None, :]
         )
         tl.store(p_bk, b_k.to(p_bk.dtype.element_ty), mask=m_tk)
-        p_bg = buf_g + slot * stride_bufg_slot + (base + o_t) * stride_bufg_pos + i_hv
+        p_bg = (
+            buf_g
+            + slot * stride_bufg_slot
+            + (base + o_t) * stride_bufg_pos
+            + i_hv * stride_bufg_hv
+        )
         tl.store(p_bg, b_gt.to(p_bg.dtype.element_ty), mask=m_t)
 
 
@@ -708,7 +1173,7 @@ def replayssm_gated_delta_rule(
     _, T_tot, H, K = q.shape
     HV, V = v.shape[2], v.shape[3]
     N = cu_seqlens.numel() - 1
-    cap = buf_k.shape[1]
+    cap = buf_k.shape[2]
     if scale is None:
         scale = K**-0.5
     assert flush_threshold_ok(cap, max_query_len), (
@@ -778,12 +1243,16 @@ def replayssm_gated_delta_rule(
             BT=BT,
             stride_ckpt_slot=ckpt.stride(0),
             stride_bufk_slot=buf_k.stride(0),
-            stride_bufk_pos=buf_k.stride(1),
+            stride_bufk_pos=buf_k.stride(2),
+            stride_bufk_hv=buf_k.stride(1),
             stride_bufu_slot=buf_u.stride(0),
-            stride_bufu_pos=buf_u.stride(1),
+            stride_bufu_pos=buf_u.stride(2),
+            stride_bufu_hv=buf_u.stride(1),
             stride_bufg_slot=buf_g.stride(0),
-            stride_bufg_pos=buf_g.stride(1),
+            stride_bufg_pos=buf_g.stride(2),
+            stride_bufg_hv=buf_g.stride(1),
             USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+            DOT_MODE=_replay_dot_mode(buf_u.dtype),
             num_warps=4 if BT >= 16 else 2,
             num_stages=2,
         )
@@ -827,15 +1296,21 @@ def replayssm_gated_delta_rule(
         BH=BH,
         stride_ckpt_slot=ckpt.stride(0),
         stride_bufk_slot=buf_k.stride(0),
-        stride_bufk_pos=buf_k.stride(1),
+        stride_bufk_pos=buf_k.stride(2),
+        stride_bufk_hv=buf_k.stride(1),
         stride_bufu_slot=buf_u.stride(0),
-        stride_bufu_pos=buf_u.stride(1),
+        stride_bufu_pos=buf_u.stride(2),
+        stride_bufu_hv=buf_u.stride(1),
         stride_bufg_slot=buf_g.stride(0),
-        stride_bufg_pos=buf_g.stride(1),
+        stride_bufg_pos=buf_g.stride(2),
+        stride_bufg_hv=buf_g.stride(1),
         stride_beta_tok=beta.stride(1),
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_KDA=is_kda,
         IS_BETA_HEADWISE=beta.ndim == v.ndim,
+        DOT_MODE=_replay_dot_mode(buf_u.dtype),
+        T1_FAST=max_query_len == 1,
+        T1_TILED=(max_query_len == 1) and not is_kda,
         num_warps=1,
         num_stages=3,
     )
@@ -910,14 +1385,18 @@ def _replayssm_kda_fwd_kernel(
     stride_ckpt_slot: tl.constexpr,
     stride_bufk_slot: tl.constexpr,
     stride_bufk_pos: tl.constexpr,
+    stride_bufk_hv: tl.constexpr,
     stride_bufu_slot: tl.constexpr,
     stride_bufu_pos: tl.constexpr,
+    stride_bufu_hv: tl.constexpr,
     stride_bufg_slot: tl.constexpr,
     stride_bufg_pos: tl.constexpr,
+    stride_bufg_hv: tl.constexpr,
     stride_a_token: tl.constexpr,
     stride_b_token: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
+    DOT_MODE: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -962,10 +1441,13 @@ def _replayssm_kda_fwd_kernel(
         h,
         stride_bufk_slot,
         stride_bufk_pos,
+        stride_bufk_hv,
         stride_bufu_slot,
         stride_bufu_pos,
+        stride_bufu_hv,
         stride_bufg_slot,
         stride_bufg_pos,
+        stride_bufg_hv,
         i_hv,
         o_k,
         o_v,
@@ -979,7 +1461,7 @@ def _replayssm_kda_fwd_kernel(
     )
     # KDA keeps the state transposed as [BV, BK], so the contraction is u^T @ k~.
     b_h = b_h * b_decay[None, :]
-    b_h += tl.dot(tl.trans(b_ru), b_kw)
+    b_h += _replay_dot(tl.trans(b_ru), b_kw, False, DOT_MODE)
 
     if do_flush:
         tl.store(p_ckpt_hv, b_h.to(p_ckpt_hv.dtype.element_ty), mask=mask_h)
@@ -1015,15 +1497,29 @@ def _replayssm_kda_fwd_kernel(
         )
 
         pos = base + i_t
-        p_bu = buf_u + slot * stride_bufu_slot + pos * stride_bufu_pos + i_hv * V + o_v
+        p_bu = (
+            buf_u
+            + slot * stride_bufu_slot
+            + pos * stride_bufu_pos
+            + i_hv * stride_bufu_hv
+            + o_v
+        )
         tl.store(p_bu, b_v.to(p_bu.dtype.element_ty), mask=mask_v)
         if i_v == 0:
             p_bk = (
-                buf_k + slot * stride_bufk_slot + pos * stride_bufk_pos + i_hv * K + o_k
+                buf_k
+                + slot * stride_bufk_slot
+                + pos * stride_bufk_pos
+                + i_hv * stride_bufk_hv
+                + o_k
             )
             tl.store(p_bk, b_k.to(p_bk.dtype.element_ty), mask=mask_k)
             p_bg = (
-                buf_g + slot * stride_bufg_slot + pos * stride_bufg_pos + i_hv * K + o_k
+                buf_g
+                + slot * stride_bufg_slot
+                + pos * stride_bufg_pos
+                + i_hv * stride_bufg_hv
+                + o_k
             )
             tl.store(p_bg, b_g.to(p_bg.dtype.element_ty), mask=mask_k)
 
@@ -1069,7 +1565,7 @@ def replayssm_sigmoid_gating_delta_rule(
     _, T_tot, H, K = q.shape
     HV, V = v.shape[2], v.shape[3]
     N = cu_seqlens.numel() - 1
-    cap = buf_k.shape[1]
+    cap = buf_k.shape[2]
     if scale is None:
         scale = K**-0.5
     assert flush_threshold_ok(cap, max_query_len), (
@@ -1078,7 +1574,12 @@ def replayssm_sigmoid_gating_delta_rule(
 
     BK = triton.next_power_of_2(K)
     assert triton.cdiv(K, BK) == 1, "K must fit one block"
-    BV = min(triton.next_power_of_2(V), 64)
+    # KDA tile width.  Measured on Kimi-K3 (tp=8, conc=64, per-launch from a
+    # trace): BV=16 25.8 us, BV=32 23.3 us, BV=64 25.7 us against a 22.3 us
+    # baseline, and BV=32 with num_warps=4 -- the width and warp count the
+    # baseline `fused_sigmoid_gating` kernel itself uses -- is 36.2 us, so
+    # matching the baseline's launch config is the worst of the options here.
+    BV = min(triton.next_power_of_2(V), 32)
     NV = triton.cdiv(V, BV)
     # Replay tile height: the cursor can reach cap - max_query_len before a
     # flush resets it, and `tl.dot` wants at least 16 rows on CDNA, so a
@@ -1119,15 +1620,19 @@ def replayssm_sigmoid_gating_delta_rule(
         BH=BH,
         stride_ckpt_slot=ckpt.stride(0),
         stride_bufk_slot=buf_k.stride(0),
-        stride_bufk_pos=buf_k.stride(1),
+        stride_bufk_pos=buf_k.stride(2),
+        stride_bufk_hv=buf_k.stride(1),
         stride_bufu_slot=buf_u.stride(0),
-        stride_bufu_pos=buf_u.stride(1),
+        stride_bufu_pos=buf_u.stride(2),
+        stride_bufu_hv=buf_u.stride(1),
         stride_bufg_slot=buf_g.stride(0),
-        stride_bufg_pos=buf_g.stride(1),
+        stride_bufg_pos=buf_g.stride(2),
+        stride_bufg_hv=buf_g.stride(1),
         stride_a_token=a.stride(-3),
         stride_b_token=b.stride(-2),
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         USE_LOWER_BOUND=lower_bound is not None,
+        DOT_MODE=_replay_dot_mode(buf_u.dtype),
         num_warps=1,
         num_stages=3,
     )

--- a/atom/model_ops/fla_ops/replayssm.py
+++ b/atom/model_ops/fla_ops/replayssm.py
@@ -94,6 +94,129 @@ def replayssm_buffer_shapes(
 
 
 # --------------------------------------------------------------------------- #
+# Record replay                                                                #
+# --------------------------------------------------------------------------- #
+#
+# Unrolling the recurrence over the h committed records,
+#
+#     S_{j+1} = diag(exp(g_j)) S_j + u_j (x) k_j
+#
+# leaves a form with no sequential dependency in it at all:
+#
+#     S_h = exp(C) * S_0 + sum_j exp(C - C_j) * u_j (x) k_j,   C_j = sum_{i<=j} g_i
+#
+# so the replay is ONE diagonal scale plus ONE GEMM rather than h dependent
+# rank-1 updates.  What makes this legal is that the buffer stores `u` (already
+# delta-corrected) and not raw `v`: with `v`, each `u_j = beta_j (v_j - S_{j-1}^T
+# k_j)` would depend on the previous state and the chain could not be cut.
+#
+# This is not a micro-optimisation.  The serial form measured 4.95 us per record
+# at K = V = 128 -- not bandwidth, but h dependent full-tile multiplies with no
+# instruction-level parallelism to hide the latency.  Against a 23 us baseline
+# step at T=1 (mean h ~7.5) that made plain decoding 8% SLOWER than the kernel
+# ReplaySSM is supposed to beat, which is the opposite of the whole point:
+# skipping the state write-back on 14 of every 15 steps is only a win if
+# rebuilding is cheap.
+
+
+@triton.jit
+def _replay_tiles(
+    buf_k,
+    buf_u,
+    buf_g,
+    slot,
+    h,
+    stride_bufk_slot,
+    stride_bufk_pos,
+    stride_bufu_slot,
+    stride_bufu_pos,
+    stride_bufg_slot,
+    stride_bufg_pos,
+    i_hv,
+    o_k,
+    o_v,
+    mask_k,
+    mask_v,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BH: tl.constexpr,
+    IS_KDA: tl.constexpr,
+):
+    """The h committed records as dense `[BH, *]` tiles, ready for one GEMM.
+
+    Returns ``(b_kw, b_u, b_decay)`` with ``b_kw[j] = exp(C - C_j) * k_j``,
+    ``b_u[j] = u_j`` and ``b_decay = exp(C)``, the factor the incoming
+    checkpoint is scaled by.
+
+    Rows ``j >= h`` are zeroed rather than skipped, so they contribute nothing
+    to the GEMM and no caller has to branch on how many records were live.
+    Their gate loads default to 0, which leaves both the running sum and the
+    total untouched -- `b_ctot` is the sum over the whole tile precisely
+    because the padding is additively neutral.
+    """
+    o_h = tl.arange(0, BH)
+    m_h = o_h < h
+
+    if IS_KDA:
+        b_g = tl.load(
+            buf_g
+            + slot * stride_bufg_slot
+            + o_h[:, None] * stride_bufg_pos
+            + i_hv * K
+            + o_k[None, :],
+            mask=m_h[:, None] & mask_k[None, :],
+            other=0.0,
+        ).to(tl.float32)
+    else:
+        # Scalar gate: broadcast the per-record value across K so the cumsum
+        # and the weighting below stay one code path. BH is small (16-64) and
+        # the tile is dwarfed by the [BK, BV] state, so the waste is not worth
+        # a second branch.
+        b_g1 = tl.load(
+            buf_g + slot * stride_bufg_slot + o_h * stride_bufg_pos + i_hv,
+            mask=m_h,
+            other=0.0,
+        ).to(tl.float32)
+        b_g = b_g1[:, None] + tl.zeros([BH, BK], dtype=tl.float32)
+
+    # Gates are log-decays (<= 0), so C - C_j <= 0 and every weight is in (0, 1]
+    # -- the exponentials cannot overflow however long the buffer gets.
+    b_c = tl.cumsum(b_g, axis=0)
+    b_ctot = tl.sum(b_g, axis=0)
+    b_w = exp(b_ctot[None, :] - b_c)
+
+    b_k = tl.load(
+        buf_k
+        + slot * stride_bufk_slot
+        + o_h[:, None] * stride_bufk_pos
+        + i_hv * K
+        + o_k[None, :],
+        mask=m_h[:, None] & mask_k[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    b_u = tl.load(
+        buf_u
+        + slot * stride_bufu_slot
+        + o_h[:, None] * stride_bufu_pos
+        + i_hv * V
+        + o_v[None, :],
+        mask=m_h[:, None] & mask_v[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    # fp32 operands, fp32 accumulation. A plain bf16 cast runs the contraction on
+    # the matrix cores (CDNA does fp32 MFMA at an eighth of the bf16 rate) and
+    # measured ~20 points faster, but it broke 17 of the 27 differential tests.
+    # Splitting each operand into bf16 hi+lo and summing four products restores
+    # the accuracy -- and gives back the speed with it: measured indistinguishable
+    # from this single fp32 dot both in the microbenchmark (+17% vs +15% over the
+    # aiter kernel, inside the 6% run-to-run spread) and end to end (-7.2%, +3.3%,
+    # +4.5% across conc 32/64/128, no consistent direction). Four dots plus the
+    # hi/lo decomposition is not worth carrying for a wash.
+    return b_k * b_w, b_u, exp(b_ctot)
+
+
+# --------------------------------------------------------------------------- #
 # Commit kernel -- runs once per forward, shared by every linear-attn layer    #
 # --------------------------------------------------------------------------- #
 
@@ -178,6 +301,7 @@ def _replayssm_fwd_kernel(
     V: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    BH: tl.constexpr,
     stride_ckpt_slot: tl.constexpr,
     stride_bufk_slot: tl.constexpr,
     stride_bufk_pos: tl.constexpr,
@@ -219,25 +343,32 @@ def _replayssm_fwd_kernel(
     p_ckpt_hv = p_ckpt + o_k[:, None] * V + o_v[None, :]
     b_h = tl.load(p_ckpt_hv, mask=mask_h, other=0.0).to(tl.float32)
 
-    for j in range(h):
-        p_bg = buf_g + slot * stride_bufg_slot + j * stride_bufg_pos
-        if IS_KDA:
-            b_rg = tl.load(p_bg + i_hv * K + o_k, mask=mask_k, other=0.0).to(tl.float32)
-            b_h *= exp(b_rg)[:, None]
-        else:
-            b_rg = tl.load(p_bg + i_hv).to(tl.float32)
-            b_h *= exp(b_rg)
-        b_rk = tl.load(
-            buf_k + slot * stride_bufk_slot + j * stride_bufk_pos + i_hv * K + o_k,
-            mask=mask_k,
-            other=0.0,
-        ).to(tl.float32)
-        b_ru = tl.load(
-            buf_u + slot * stride_bufu_slot + j * stride_bufu_pos + i_hv * V + o_v,
-            mask=mask_v,
-            other=0.0,
-        ).to(tl.float32)
-        b_h += b_rk[:, None] * b_ru[None, :]
+    b_kw, b_ru, b_decay = _replay_tiles(
+        buf_k,
+        buf_u,
+        buf_g,
+        slot,
+        h,
+        stride_bufk_slot,
+        stride_bufk_pos,
+        stride_bufu_slot,
+        stride_bufu_pos,
+        stride_bufg_slot,
+        stride_bufg_pos,
+        i_hv,
+        o_k,
+        o_v,
+        mask_k,
+        mask_v,
+        K,
+        V,
+        BK,
+        BH,
+        IS_KDA,
+    )
+    # State is [BK, BV] here, so the contraction runs k~^T @ u.
+    b_h = b_h * b_decay[:, None]
+    b_h += tl.dot(tl.trans(b_kw), b_ru)
 
     # ---- 2. flush: the checkpoint absorbs the committed prefix --------------
     if do_flush:
@@ -366,6 +497,7 @@ def _replayssm_ut_fwd_kernel(
     V: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    BH: tl.constexpr,
     BT: tl.constexpr,
     stride_ckpt_slot: tl.constexpr,
     stride_bufk_slot: tl.constexpr,
@@ -427,20 +559,31 @@ def _replayssm_ut_fwd_kernel(
     )
     m_h = m_k[:, None] & m_v[None, :]
     b_h = tl.load(p_ckpt_hv, mask=m_h, other=0.0).to(tl.float32)
-    for j in range(h):
-        b_rg = tl.load(buf_g + slot * stride_bufg_slot + j * stride_bufg_pos + i_hv)
-        b_h *= exp(b_rg.to(tl.float32))
-        b_rk = tl.load(
-            buf_k + slot * stride_bufk_slot + j * stride_bufk_pos + i_hv * K + o_k,
-            mask=m_k,
-            other=0.0,
-        ).to(tl.float32)
-        b_ru = tl.load(
-            buf_u + slot * stride_bufu_slot + j * stride_bufu_pos + i_hv * V + o_v,
-            mask=m_v,
-            other=0.0,
-        ).to(tl.float32)
-        b_h += b_rk[:, None] * b_ru[None, :]
+    b_kw, b_ru, b_decay = _replay_tiles(
+        buf_k,
+        buf_u,
+        buf_g,
+        slot,
+        h,
+        stride_bufk_slot,
+        stride_bufk_pos,
+        stride_bufu_slot,
+        stride_bufu_pos,
+        stride_bufg_slot,
+        stride_bufg_pos,
+        i_hv,
+        o_k,
+        o_v,
+        m_k,
+        m_v,
+        K,
+        V,
+        BK,
+        BH,
+        False,
+    )
+    b_h = b_h * b_decay[:, None]
+    b_h += tl.dot(tl.trans(b_kw), b_ru)
 
     if do_flush:
         tl.store(p_ckpt_hv, b_h.to(p_ckpt_hv.dtype.element_ty), mask=m_h)
@@ -585,6 +728,7 @@ def replayssm_gated_delta_rule(
         # BV=32/NV=4 than BV=V/NV=1.
         BV_UT = triton.next_power_of_2(V)
         BT = triton.next_power_of_2(max_query_len)
+        BH_UT = max(16, triton.next_power_of_2(cap - max_query_len))
         _replayssm_ut_fwd_kernel[(1, N * HV)](
             q=q,
             k=k,
@@ -610,6 +754,7 @@ def replayssm_gated_delta_rule(
             V=V,
             BK=BK,
             BV=BV_UT,
+            BH=BH_UT,
             BT=BT,
             stride_ckpt_slot=ckpt.stride(0),
             stride_bufk_slot=buf_k.stride(0),
@@ -630,6 +775,10 @@ def replayssm_gated_delta_rule(
     # per-token l2norm/loads; BV=128 overflows the register budget.
     BV = min(triton.next_power_of_2(V), 64)
     NV = triton.cdiv(V, BV)
+    # Replay tile height: the cursor can reach cap - max_query_len before a
+    # flush resets it, and `tl.dot` wants at least 16 rows on CDNA, so a
+    # short buffer pads rather than shrinks.
+    BH = max(16, triton.next_power_of_2(cap - max_query_len))
     _replayssm_fwd_kernel[(NV, N * HV)](
         q=q,
         k=k,
@@ -655,6 +804,7 @@ def replayssm_gated_delta_rule(
         V=V,
         BK=BK,
         BV=BV,
+        BH=BH,
         stride_ckpt_slot=ckpt.stride(0),
         stride_bufk_slot=buf_k.stride(0),
         stride_bufk_pos=buf_k.stride(1),
@@ -736,6 +886,7 @@ def _replayssm_kda_fwd_kernel(
     V: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    BH: tl.constexpr,
     stride_ckpt_slot: tl.constexpr,
     stride_bufk_slot: tl.constexpr,
     stride_bufk_pos: tl.constexpr,
@@ -777,24 +928,32 @@ def _replayssm_kda_fwd_kernel(
     )
     b_h = tl.load(p_ckpt_hv, mask=mask_h, other=0.0).to(tl.float32)
 
-    for j in range(h):
-        b_rg = tl.load(
-            buf_g + slot * stride_bufg_slot + j * stride_bufg_pos + i_hv * K + o_k,
-            mask=mask_k,
-            other=0.0,
-        ).to(tl.float32)
-        b_h *= exp(b_rg)[None, :]
-        b_rk = tl.load(
-            buf_k + slot * stride_bufk_slot + j * stride_bufk_pos + i_hv * K + o_k,
-            mask=mask_k,
-            other=0.0,
-        ).to(tl.float32)
-        b_ru = tl.load(
-            buf_u + slot * stride_bufu_slot + j * stride_bufu_pos + i_hv * V + o_v,
-            mask=mask_v,
-            other=0.0,
-        ).to(tl.float32)
-        b_h += b_ru[:, None] * b_rk[None, :]
+    b_kw, b_ru, b_decay = _replay_tiles(
+        buf_k,
+        buf_u,
+        buf_g,
+        slot,
+        h,
+        stride_bufk_slot,
+        stride_bufk_pos,
+        stride_bufu_slot,
+        stride_bufu_pos,
+        stride_bufg_slot,
+        stride_bufg_pos,
+        i_hv,
+        o_k,
+        o_v,
+        mask_k,
+        mask_v,
+        K,
+        V,
+        BK,
+        BH,
+        True,
+    )
+    # KDA keeps the state transposed as [BV, BK], so the contraction is u^T @ k~.
+    b_h = b_h * b_decay[None, :]
+    b_h += tl.dot(tl.trans(b_ru), b_kw)
 
     if do_flush:
         tl.store(p_ckpt_hv, b_h.to(p_ckpt_hv.dtype.element_ty), mask=mask_h)
@@ -895,6 +1054,10 @@ def replayssm_sigmoid_gating_delta_rule(
     assert triton.cdiv(K, BK) == 1, "K must fit one block"
     BV = min(triton.next_power_of_2(V), 64)
     NV = triton.cdiv(V, BV)
+    # Replay tile height: the cursor can reach cap - max_query_len before a
+    # flush resets it, and `tl.dot` wants at least 16 rows on CDNA, so a
+    # short buffer pads rather than shrinks.
+    BH = max(16, triton.next_power_of_2(cap - max_query_len))
 
     q, k, v, a, b = (x.contiguous() for x in (q, k, v, a, b))
     out = q.new_empty(1, T_tot, HV, V) if o is None else o.unsqueeze(0)
@@ -927,6 +1090,7 @@ def replayssm_sigmoid_gating_delta_rule(
         V=V,
         BK=BK,
         BV=BV,
+        BH=BH,
         stride_ckpt_slot=ckpt.stride(0),
         stride_bufk_slot=buf_k.stride(0),
         stride_bufk_pos=buf_k.stride(1),

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -34,6 +34,9 @@ from atom.model_ops.embed_head import ParallelLMHead, VocabParallelEmbedding
 from atom.model_ops.fla_ops.fused_sigmoid_gating import (
     fused_sigmoid_gating_delta_rule_update,
 )
+from atom.model_ops.fla_ops.replayssm import (
+    replayssm_sigmoid_gating_delta_rule,
+)
 from atom.model_ops.layernorm import RMSNorm
 from atom.model_ops.linear import (
     ColumnParallelLinear,
@@ -1194,23 +1197,49 @@ class KimiKDAAttention(nn.Module):
             # one kernel. is_kda + lower_bound select the per-K-channel,
             # lower-bounded sigmoid gate that Kimi-KDA uses (beta stays raw
             # logits; the kernel applies sigmoid in fp32 internally).
-            fused_sigmoid_gating_delta_rule_update(
-                A_log=self.A_log,
-                a=gate,
-                b=beta,
-                dt_bias=self.dt_bias,
-                q=q,
-                k=k,
-                v=v,
-                o=out,
-                initial_state=ssm_state,
-                inplace_final_state=True,
-                cu_seqlens=query_start_loc[: kda_metadata.num_decodes + 1],
-                ssm_state_indices=decode_state_indices,
-                use_qk_l2norm_in_kernel=True,
-                is_kda=True,
-                lower_bound=self._kda_gate_lower_bound,
-            )
+            if getattr(kda_metadata, "replayssm", False):
+                # ReplaySSM: one checkpoint per request; the per-token state
+                # snapshots this pool used to hold are rebuilt from the
+                # (k, u, g) records on demand.
+                nd = kda_metadata.num_decodes
+                replayssm_sigmoid_gating_delta_rule(
+                    q,
+                    k,
+                    v,
+                    gate,
+                    beta,
+                    self.A_log,
+                    self.dt_bias,
+                    ckpt=ssm_state,
+                    buf_k=cache.replay_buf_k,
+                    buf_u=cache.replay_buf_u,
+                    buf_g=cache.replay_buf_g,
+                    write_pos=kda_metadata.write_pos,
+                    slot_idx=kda_metadata.slot_idx[:nd],
+                    cu_seqlens=query_start_loc[: nd + 1],
+                    max_query_len=kda_metadata.replayssm_max_query_len,
+                    o=out,
+                    use_qk_l2norm_in_kernel=True,
+                    lower_bound=self._kda_gate_lower_bound,
+                )
+            else:
+                fused_sigmoid_gating_delta_rule_update(
+                    A_log=self.A_log,
+                    a=gate,
+                    b=beta,
+                    dt_bias=self.dt_bias,
+                    q=q,
+                    k=k,
+                    v=v,
+                    o=out,
+                    initial_state=ssm_state,
+                    inplace_final_state=True,
+                    cu_seqlens=query_start_loc[: kda_metadata.num_decodes + 1],
+                    ssm_state_indices=decode_state_indices,
+                    use_qk_l2norm_in_kernel=True,
+                    is_kda=True,
+                    lower_bound=self._kda_gate_lower_bound,
+                )
         elif kda_metadata.num_spec_decodes > 0:
             # Speculative-decode pass
             spec_state_indices = kda_metadata.spec_state_indices_tensor
@@ -1231,33 +1260,64 @@ class KimiKDAAttention(nn.Module):
                 ],
                 num_accepted_tokens=num_accepted_tokens,
                 query_start_loc=spec_query_start_loc,
-                max_query_len=spec_state_indices.size(-1),
+                # Verify window: sizes the conv rollback window and hence the
+                # kernel's NP2_STATELEN tile. Under ReplaySSM the slot table
+                # keeps its [bs, mtp_k+1] shape but only column 0 is live, so
+                # read the window off the metadata instead of the table width.
+                max_query_len=(
+                    kda_metadata.replayssm_max_query_len
+                    if getattr(kda_metadata, "replayssm", False)
+                    else spec_state_indices.size(-1)
+                ),
                 validate_data=False,
             )
             q = rearrange(q, "t (h d) -> 1 t h d", d=self.head_dim)
             k = rearrange(k, "t (h d) -> 1 t h d", d=self.head_dim)
             v = rearrange(v, "t (h d) -> 1 t h d", d=self.head_dim)
-            fused_sigmoid_gating_delta_rule_update(
-                A_log=self.A_log,
-                a=gate,
-                b=beta,
-                dt_bias=self.dt_bias,
-                q=q,
-                k=k,
-                v=v,
-                o=out,
-                initial_state=ssm_state,
-                inplace_final_state=True,
-                cu_seqlens=spec_query_start_loc[: kda_metadata.num_spec_decodes + 1],
-                # 2D [bs, 1+num_spec]: per-token snapshot slots. Paired with
-                # num_accepted_tokens the kernel reads the resume state from
-                # slot[num_accepted-1] and writes a snapshot after each token.
-                ssm_state_indices=spec_state_indices,
-                num_accepted_tokens=num_accepted_tokens,
-                use_qk_l2norm_in_kernel=True,
-                is_kda=True,
-                lower_bound=self._kda_gate_lower_bound,
-            )
+            if getattr(kda_metadata, "replayssm", False):
+                nsd = kda_metadata.num_spec_decodes
+                replayssm_sigmoid_gating_delta_rule(
+                    q,
+                    k,
+                    v,
+                    gate,
+                    beta,
+                    self.A_log,
+                    self.dt_bias,
+                    ckpt=ssm_state,
+                    buf_k=cache.replay_buf_k,
+                    buf_u=cache.replay_buf_u,
+                    buf_g=cache.replay_buf_g,
+                    write_pos=kda_metadata.write_pos,
+                    slot_idx=kda_metadata.slot_idx[:nsd],
+                    cu_seqlens=spec_query_start_loc[: nsd + 1],
+                    max_query_len=kda_metadata.replayssm_max_query_len,
+                    o=out,
+                    use_qk_l2norm_in_kernel=True,
+                    lower_bound=self._kda_gate_lower_bound,
+                )
+            else:
+                fused_sigmoid_gating_delta_rule_update(
+                    A_log=self.A_log,
+                    a=gate,
+                    b=beta,
+                    dt_bias=self.dt_bias,
+                    q=q,
+                    k=k,
+                    v=v,
+                    o=out,
+                    initial_state=ssm_state,
+                    inplace_final_state=True,
+                    cu_seqlens=spec_query_start_loc[: kda_metadata.num_spec_decodes + 1],
+                    # 2D [bs, 1+num_spec]: per-token snapshot slots. Paired with
+                    # num_accepted_tokens the kernel reads the resume state from
+                    # slot[num_accepted-1] and writes a snapshot after each token.
+                    ssm_state_indices=spec_state_indices,
+                    num_accepted_tokens=num_accepted_tokens,
+                    use_qk_l2norm_in_kernel=True,
+                    is_kda=True,
+                    lower_bound=self._kda_gate_lower_bound,
+                )
         else:
             out.zero_()
 

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -1308,7 +1308,9 @@ class KimiKDAAttention(nn.Module):
                     o=out,
                     initial_state=ssm_state,
                     inplace_final_state=True,
-                    cu_seqlens=spec_query_start_loc[: kda_metadata.num_spec_decodes + 1],
+                    cu_seqlens=spec_query_start_loc[
+                        : kda_metadata.num_spec_decodes + 1
+                    ],
                     # 2D [bs, 1+num_spec]: per-token snapshot slots. Paired with
                     # num_accepted_tokens the kernel reads the resume state from
                     # slot[num_accepted-1] and writes a snapshot after each token.

--- a/atom/models/qwen3_5.py
+++ b/atom/models/qwen3_5.py
@@ -516,17 +516,14 @@ class Qwen3_5ForCausalLMBase(nn.Module):
             prefix=maybe_prefix(prefix, "model"),
         )
 
-        self.lm_head = ParallelLMHead(
-            config.vocab_size,
-            config.hidden_size,
-            prefix=maybe_prefix(prefix, "lm_head"),
-        )
         if config.tie_word_embeddings:
-            # Share the tensor, not the module: ParallelLMHead shards the vocab
-            # exactly like VocabParallelEmbedding, but its forward is a gemm.
-            # Aliasing the embedding module instead would send bf16 hidden
-            # states into F.embedding's integer indices arg.
-            self.lm_head.weight = self.model.embed_tokens.weight
+            self.lm_head = self.model.embed_tokens
+        else:
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
 
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors

--- a/atom/models/qwen3_5.py
+++ b/atom/models/qwen3_5.py
@@ -516,14 +516,17 @@ class Qwen3_5ForCausalLMBase(nn.Module):
             prefix=maybe_prefix(prefix, "model"),
         )
 
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
         if config.tie_word_embeddings:
-            self.lm_head = self.model.embed_tokens
-        else:
-            self.lm_head = ParallelLMHead(
-                config.vocab_size,
-                config.hidden_size,
-                prefix=maybe_prefix(prefix, "lm_head"),
-            )
+            # Share the tensor, not the module: ParallelLMHead shards the vocab
+            # exactly like VocabParallelEmbedding, but its forward is a gemm.
+            # Aliasing the embedding module instead would send bf16 hidden
+            # states into F.embedding's integer indices arg.
+            self.lm_head.weight = self.model.embed_tokens.weight
 
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -225,7 +225,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the record buffer fills).  Rollback becomes a cursor move.
     # See atom/model_ops/fla_ops/replayssm.py.
     "ATOM_ENABLE_REPLAYSSM": lambda: (
-        os.getenv("ATOM_ENABLE_REPLAYSSM", "0").lower() == "1"
+        None
+        if os.getenv("ATOM_ENABLE_REPLAYSSM") is None
+        else os.getenv("ATOM_ENABLE_REPLAYSSM", "0").lower() == "1"
     ),
     # Record-buffer depth L.  Must be >= 2*(mtp_k+1); raised automatically if
     # set too low.  Larger L means fewer checkpoint write-backs but a longer

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -217,6 +217,26 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_GDN_DECODE_LOSSY_FAST": lambda: (
         os.getenv("ATOM_ENABLE_GDN_DECODE_LOSSY_FAST", "0").lower() == "1"
     ),
+    # --- ReplaySSM (linear-attention state) ---
+    # Cache the SSM *inputs* (k, u, g) instead of one full recurrent state per
+    # speculative token.  The state pool stops scaling with the MTP window --
+    # e.g. Kimi-K3 at mtp_k=2, 64 seqs, tp=8 drops from 10.3 GiB to ~3.5 GiB --
+    # and the full-state write moves off the per-step path (rewritten only when
+    # the record buffer fills).  Rollback becomes a cursor move.
+    # See atom/model_ops/fla_ops/replayssm.py.
+    "ATOM_ENABLE_REPLAYSSM": lambda: (
+        os.getenv("ATOM_ENABLE_REPLAYSSM", "0").lower() == "1"
+    ),
+    # Record-buffer depth L.  Must be >= 2*(mtp_k+1); raised automatically if
+    # set too low.  Larger L means fewer checkpoint write-backs but a longer
+    # rebuild each step; upstream measured 8-16 as the sweet spot.
+    "ATOM_REPLAYSSM_CACHE_LEN": lambda: int(
+        os.getenv("ATOM_REPLAYSSM_CACHE_LEN", "16")
+    ),
+    # "auto" | "serial" | "ut".  The UT-transform verify route only beats the
+    # serial one at verify windows >= ~12 tokens (measured on gfx950), so
+    # "auto" keeps practical MTP windows on the serial route.
+    "ATOM_REPLAYSSM_ROUTE": lambda: os.getenv("ATOM_REPLAYSSM_ROUTE", "auto").lower(),
     "ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_RMSNORM_QUANT": lambda: (
         os.getenv("ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_RMSNORM_QUANT", "1") == "1"
     ),

--- a/tests/test_gdn_state_relocation.py
+++ b/tests/test_gdn_state_relocation.py
@@ -27,7 +27,12 @@ SHAPE_K = (2, 5)
 SHAPE_V = (2, 3, 4)
 
 
-def build(num_spec: int):
+CAP = 6
+REC_K = (2, 5)
+REC_V = (2, 3)
+
+
+def build(num_spec: int, replayssm: bool = False):
     """Caches whose every (layer, slot) plane carries a distinct value."""
     k = torch.zeros((LAYERS, SLOTS) + SHAPE_K)
     v = torch.zeros((LAYERS, SLOTS) + SHAPE_V)
@@ -35,11 +40,35 @@ def build(num_spec: int):
         for slot in range(SLOTS):
             k[layer, slot] = layer * 100 + slot
             v[layer, slot] = -(layer * 100 + slot)
+    runner = SimpleNamespace(mamba_k_cache=k, mamba_v_cache=v)
+    if replayssm:
+        # Distinct per (layer, slot) here too, and a cursor that is distinct
+        # per slot -- a relocation that drops either is then visible rather
+        # than accidentally right.
+        bufs = {}
+        for name, shape in (
+            ("replayssm_buf_k", (CAP,) + REC_K),
+            ("replayssm_buf_u", (CAP,) + REC_V),
+            ("replayssm_buf_g", (CAP,) + REC_K),
+        ):
+            t = torch.zeros((LAYERS, SLOTS) + shape)
+            for layer in range(LAYERS):
+                for slot in range(SLOTS):
+                    t[layer, slot] = layer * 100 + slot + 0.5
+            bufs[name] = t
+        setattr_all(runner, bufs)
+        runner.replayssm_write_pos = torch.arange(1, SLOTS + 1, dtype=torch.int32)
     stub = SimpleNamespace(
         num_spec=num_spec,
-        model_runner=SimpleNamespace(mamba_k_cache=k, mamba_v_cache=v),
+        replayssm=replayssm,
+        model_runner=runner,
     )
     return stub, k, v
+
+
+def setattr_all(obj, mapping):
+    for name, value in mapping.items():
+        setattr(obj, name, value)
 
 
 @pytest.mark.parametrize("num_spec", [0, 2])
@@ -114,3 +143,47 @@ def test_no_pairs_is_a_no_op():
 
     assert torch.equal(k, before_k)
     assert torch.equal(v, before_v)
+
+
+def test_replayssm_records_and_cursor_travel_with_the_slot():
+    """Under ReplaySSM the records ARE the state, not a cache in front of it.
+
+    The checkpoint only describes the sequence up to its last flush; the
+    records carry everything since. Relocate one without the other and the
+    request resumes against the destination slot's previous tenant -- and
+    because the cursor decides how many records get folded, a stale cursor
+    corrupts the rebuild even when the records themselves moved.
+    """
+    stub, _, _ = build(num_spec=7, replayssm=True)
+    runner = stub.model_runner
+    names = (
+        "replayssm_buf_k",
+        "replayssm_buf_u",
+        "replayssm_buf_g",
+        "replayssm_write_pos",
+    )
+    before = {n: getattr(runner, n).clone() for n in names}
+
+    GDNStateMixin.relocate_state_slots(stub, [(1, 3)])
+
+    for name in names[:3]:
+        moved = getattr(runner, name)
+        assert torch.equal(moved[:, 3], before[name][:, 1]), f"{name} left behind"
+        assert torch.equal(
+            moved[:, 2], before[name][:, 2]
+        ), f"{name} clobbered a neighbour"
+    cursor = runner.replayssm_write_pos
+    assert cursor[3] == before["replayssm_write_pos"][1], "cursor left behind"
+    assert cursor[2] == before["replayssm_write_pos"][2], "cursor clobbered a neighbour"
+
+
+def test_baseline_relocation_does_not_look_for_replay_buffers():
+    """`replayssm` off means the runner has no record buffers at all; touching
+    them would be an AttributeError, not a silent miss."""
+    stub, k, _ = build(num_spec=2)
+    assert not hasattr(stub.model_runner, "replayssm_buf_k")
+    before_k = k.clone()
+
+    GDNStateMixin.relocate_state_slots(stub, [(0, 2)])
+
+    assert torch.equal(k[:, 2], before_k[:, 0])


### PR DESCRIPTION
Speculative decoding made the GDN/KDA state pool scale with the verify window: every request reserved `1 + num_speculative_tokens` copies of the recurrent state so a rejected draft could roll back by resuming from a different slot. On Kimi-K3 + DSpark(7) at tp=8 that is 8 slots x 57.81 MiB = 28.91 GiB per rank, more than half the KV budget, leaving the paged cache with less memory than the rollback machinery.

ReplaySSM keeps ONE checkpoint per request plus a small ring of the SSM inputs `(k, u, g)`, and reconstructs any intermediate state on demand:

    S_h = exp(G_h)*S_0 + sum_j exp(G_h - G_j) * k_j (x) u_j,  G_j = sum_{i<=j} g_i

Rollback stops being a state copy and becomes a cursor move: the records a rejected draft wrote are simply never read, and the next step overwrites them. `slots_per_req()` drops from `1 + num_spec` to 1.

The buffer stores `u` (post-delta-correction), not raw `v`. Storing `v` would leave `u_j = beta_j (v_j - S_{j-1}^T k_j)` depending on the previous state, making the replay irreducibly serial; with `u` the expansion above is a plain weighted outer-product sum.

Divergence from the reference ReplaySSM: the checkpoint absorbs committed records at the START of a step rather than the end. Folding at the end strands the step's speculative records at a non-zero offset and forces a true ring with modular indexing; folding at the start means the buffer always refills from offset 0 -- a linear buffer with reset, same state traffic and flush cadence, no wrap-around arithmetic.

Flush fires at `h + 2T > L` rather than `h + T > L`, one window early. That keeps a full window free (a step landing at h = L-T followed by a full accept would otherwise truncate the next window to one draft) and guarantees `h + T <= L`, so appends never run off the end. Hence `cache_len >= 2*(mtp_k+1)`, raised automatically with a warning if the env var asks for less.

Off by default; enable with ATOM_ENABLE_REPLAYSSM=1.

Measured on Kimi-K3 + DSpark(--num-speculative-tokens 7), tp=8, MI355X:

  state pool   28.91 -> 4.42 GiB per rank (-24.49 GiB, ~196 GiB per node)
  KV blocks    8325 -> 18813 (2.26x)
  GSM8K        0.9515 -> 0.9530 (3-shot, full 1319, z=0.18)
  acceptance   47.64% -> 47.37% over 217k draft tokens (z=1.73)
  throughput   parity -- interleaved multi-instance A/B at conc=64 gives
               -0.69% at ISL/OSL 512/512 and +1.22% at 1024/1024 (t=0.50),
               both smaller than the spread BETWEEN base instances

Also covers the GDN backbone (Qwen3.5 / Qwen3-Next): validated at mtp_k=3 with -22.72 GiB at max_num_seqs=256 and GSM8K within 0.61 sigma.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
