### PR TITLE
fix(dpa+mesh) stabilize atomesh routing sticky and scheduling

### DIFF
--- a/.github/benchmark/models_atomesh.yaml
+++ b/.github/benchmark/models_atomesh.yaml
@@ -325,60 +325,45 @@ models:
           name: glm-52-mxfp4-1p1d-tp4-agentic-1m-c48
           concurrency: [48]
 
-        - &glm52_agentic_lmcache
+        - &glm52_agentic_lmcache_tp4_dpa
           <<: *glm52_agentic_tp4_tp4
-          name: glm-52-mxfp4-1p1d-tp8-dpa-agentic-lmcache-1m-c48
+          name: glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c24
           topology: 1p1d_dpa
-          concurrency: [48]
-          prefill:
-            workers: 1
-            tp: 8
-            extra_args: >-
-              --enable-dp-attention
-              --enable-tbo
-              --attn-prefill-chunk-size 131072
-              --long-prefill-token-threshold 131072
-          decode:
-            workers: 1
-            tp: 8
-            cudagraph: none
-            extra_args: "--enable-dp-attention --enable-tbo"
-          env: &glm52_agentic_lmcache_env
-            common: &glm52_agentic_lmcache_common_env
-              PYTHONHASHSEED: "0"
-            prefill: &glm52_agentic_lmcache_prefill_env
-              LMCACHE_LOCAL_CPU: "True"
-              LMCACHE_MAX_LOCAL_CPU_SIZE: "200"
-              LMCACHE_CHUNK_SIZE: "256"
-              PREFILL_KV_TRANSFER_CONFIG: >-
-                {"kv_connector":"multi","connectors":[{"kv_connector":"mooncake","kv_role":"kv_producer","proxy_ip":"${ROLE_IP}","handshake_port":6301},{"kv_connector":"lmcache_offload","kv_role":"offload"}]}
-            decode: &glm52_agentic_lmcache_decode_env
-              MAX_JOBS: "16"
-
-        - <<: *glm52_agentic_lmcache
-          name: glm-52-mxfp4-1p1d-tp4-pcp2-agentic-lmcache-1m-c48
-          topology: 1p1d-tp4-pcp2
-          pd_worker_layout: multi_node
-          concurrency: [48]
+          pd_worker_layout: single_node
+          concurrency: [24]
           prefill:
             workers: 1
             tp: 4
             extra_args: >-
-              --prefill-context-parallel-size 2
+              --enable-dp-attention
               --attn-prefill-chunk-size 131072
               --long-prefill-token-threshold 131072
           decode:
             workers: 1
-            tp: 8
+            tp: 4
             cudagraph: none
+            extra_args: "--enable-dp-attention"
           env:
             common:
-              <<: *glm52_agentic_lmcache_common_env
+              PYTHONHASHSEED: "0"
             prefill:
-              <<: *glm52_agentic_lmcache_prefill_env
-              HIP_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+              LMCACHE_LOCAL_CPU: "True"
+              LMCACHE_MAX_LOCAL_CPU_SIZE: "256"
+              LMCACHE_CHUNK_SIZE: "256"
+              PREFILL_KV_TRANSFER_CONFIG: >-
+                {"kv_connector":"multi","connectors":[{"kv_connector":"mooncake","kv_role":"kv_producer","proxy_ip":"${ROLE_IP}","handshake_port":6301},{"kv_connector":"lmcache_offload","kv_role":"offload"}]}
+              HIP_VISIBLE_DEVICES: "0,1,2,3"
             decode:
-              <<: *glm52_agentic_lmcache_decode_env
+              MAX_JOBS: "16"
+              HIP_VISIBLE_DEVICES: "4,5,6,7"
+
+        - <<: *glm52_agentic_lmcache_tp4_dpa
+          name: glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c32
+          concurrency: [32]
+
+        - <<: *glm52_agentic_lmcache_tp4_dpa
+          name: glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c48
+          concurrency: [48]
 
     accuracy:
       task: gsm8k

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -34,28 +34,38 @@ on:
       run_all_models:
         description: 'Run all models from models_atomesh.yaml'
         required: false
-        default: true
+        default: false
         type: boolean
       model_names:
-        description: 'Optional when run_all_models=false. Comma-separated: DeepSeek-V4-Pro,GLM-5.2-MXFP4,Kimi-K2.5-MXFP4,MiniMax-M3-MXFP4,MiniMax-M3-MXFP8'
+        description: 'When run_all_models=false, run all cases in the selected suite for these model families. Comma-separated: DeepSeek-V4-Pro,GLM-5.2-MXFP4,Kimi-K2.5-MXFP4,MiniMax-M3-MXFP4,MiniMax-M3-MXFP8'
         required: false
         default: ''
         type: string
       case_names:
-        description: >-
-          Overrides model_names. Comma-separated:
-          ds-v4-1p1d-tp8-smoke,ds-v4-1p1d-tp8,ds-v4-1p1d-dpa-tp8,
-          ds-v4-1p1d-tp8-mtp3,ds-v4-1p1d-dpa-tp8-mtp1,
-          glm-52-mxfp4-1p1d-tp4,glm-52-mxfp4-1p1d-tp8,
-          glm-52-mxfp4-1p1d-tp4-agentic-1m-c1,glm-52-mxfp4-1p1d-tp4-agentic-1m-c2,
-          glm-52-mxfp4-1p1d-tp4-agentic-1m-c4,glm-52-mxfp4-1p1d-tp4-agentic-1m-c8,
-          glm-52-mxfp4-1p1d-tp4-agentic-1m-c48,glm-52-mxfp4-1p1d-tp8-dpa-agentic-lmcache-1m-c48,
-          glm-52-mxfp4-1p1d-tp4-pcp2-agentic-lmcache-1m-c48,
-          kimi-k25-1p1d-tp4,kimi-k25-1p1d-tp4-tp8,kimi-k25-2p1d-tp4,kimi-k25-1p2d-tp4,
-          minimax-m3-fp4-1p1d-tp4,minimax-m3-fp4-2p1d-dpa-tp4,
-          minimax-m3-fp4-1p1d-tp4-eagle3,minimax-m3-fp4-2p1d-dpa-tp4-eagle3,
-          minimax-m3-fp8-1p1d-tp4,minimax-m3-fp8-2p1d-dpa-tp4,
-          minimax-m3-fp8-1p1d-tp4-eagle3,minimax-m3-fp8-2p1d-dpa-tp4-eagle3
+        description: |
+          Overrides model_names. Enter comma-separated case names.
+          DeepSeek:
+            ds-v4-1p1d-tp8-smoke,ds-v4-1p1d-tp8,ds-v4-1p1d-dpa-tp8,
+            ds-v4-1p1d-tp8-mtp3,ds-v4-1p1d-dpa-tp8-mtp1
+
+          GLM:
+            glm-52-mxfp4-1p1d-tp4,glm-52-mxfp4-1p1d-tp8,
+            glm-52-mxfp4-1p1d-tp4-agentic-1m-c1,glm-52-mxfp4-1p1d-tp4-agentic-1m-c2,
+            glm-52-mxfp4-1p1d-tp4-agentic-1m-c4,glm-52-mxfp4-1p1d-tp4-agentic-1m-c8,
+            glm-52-mxfp4-1p1d-tp4-agentic-1m-c48,
+            glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c24,
+            glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c32,
+            glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c48
+
+          Kimi:
+            kimi-k25-1p1d-tp4,kimi-k25-1p1d-tp4-tp8,
+            kimi-k25-2p1d-tp4,kimi-k25-1p2d-tp4
+
+          MiniMax:
+            minimax-m3-fp4-1p1d-tp4,minimax-m3-fp4-2p1d-dpa-tp4,
+            minimax-m3-fp4-1p1d-tp4-eagle3,minimax-m3-fp4-2p1d-dpa-tp4-eagle3,
+            minimax-m3-fp8-1p1d-tp4,minimax-m3-fp8-2p1d-dpa-tp4,
+            minimax-m3-fp8-1p1d-tp4-eagle3,minimax-m3-fp8-2p1d-dpa-tp4-eagle3
         required: false
         default: ''
         type: string

--- a/atom/config.py
+++ b/atom/config.py
@@ -881,6 +881,12 @@ class ParallelConfig:
             self.data_parallel_rank = envs.ATOM_DP_RANK
         if envs.is_set("ATOM_DP_RANK_LOCAL"):
             self.data_parallel_rank_local = envs.ATOM_DP_RANK_LOCAL
+        if envs.is_set("ATOM_DP_MASTER_IP"):
+            self.data_parallel_master_ip = envs.ATOM_DP_MASTER_IP
+        if envs.is_set("ATOM_DP_MASTER_PORT"):
+            self.data_parallel_master_port = envs.ATOM_DP_MASTER_PORT
+        if envs.is_set("ATOM_DP_BASE_PORT"):
+            self.data_parallel_base_port = envs.ATOM_DP_BASE_PORT
 
 
 _DSPARK_DEFAULT_MAX_BLOCK = 16

--- a/atom/mesh/src/core/placement/backend/atom.rs
+++ b/atom/mesh/src/core/placement/backend/atom.rs
@@ -47,10 +47,11 @@ impl AtomAdapter {
             })?;
         obj.insert("remote_dp_size".to_string(), json!(ctx.prefill_dp_size));
         obj.insert("remote_tp_size".to_string(), json!(tp_size));
-        let remote_dp_rank = ctx
-            .prefill_dp_rank
-            .map(|r| json!(r))
-            .or_else(|| obj.get("dp_rank").filter(|v| v.is_number()).cloned());
+        let remote_dp_rank = obj
+            .get("dp_rank")
+            .filter(|v| v.is_number())
+            .cloned()
+            .or_else(|| ctx.prefill_dp_rank.map(|r| json!(r)));
         if let Some(dp_rank) = remote_dp_rank {
             obj.insert("remote_dp_rank".to_string(), dp_rank);
         }

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -2086,9 +2086,21 @@ class Scheduler:
                     ell_r = fwd_output.dspark_ell.get(seq.id)
                     if ell_r is not None:
                         seq.dspark_next_ell = int(ell_r)
+                required_placeholders = num_placeholder + offset
+                missing_placeholders = required_placeholders - len(seq.output_tokens)
+                if missing_placeholders > 0:
+                    logger.warning(
+                        "Repairing missing deferred-output placeholders for seq %s: "
+                        "required=%d, available=%d",
+                        seq.id,
+                        required_placeholders,
+                        len(seq.output_tokens),
+                    )
+                    for _ in range(missing_placeholders):
+                        seq.append_token(self.eos_token_id)
                 for i, el in enumerate(token_ids):
-                    seq.token_ids[-num_placeholder - offset + i] = el
-                    seq.output_tokens[-num_placeholder - offset + i] = el
+                    seq.token_ids[-required_placeholders + i] = el
+                    seq.output_tokens[-required_placeholders + i] = el
                 if seq.return_logprobs and token_logprob is not None:
                     if seq.logprobs:
                         seq.logprobs[-1] = token_logprob

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -29,6 +29,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DP_SIZE": lambda: int(os.getenv("ATOM_DP_SIZE", "1")),
     "ATOM_DP_MASTER_IP": lambda: os.getenv("ATOM_DP_MASTER_IP", "127.0.0.1"),
     "ATOM_DP_MASTER_PORT": lambda: int(os.getenv("ATOM_DP_MASTER_PORT", "29500")),
+    # Rendezvous base port; set per role when prefill/decode share a node.
+    "ATOM_DP_BASE_PORT": lambda: int(os.getenv("ATOM_DP_BASE_PORT", "0")),
     # Token-equivalent cost of one in-flight request for the "least_tokens" DP
     # load-balance strategy. The per-rank load score is
     #   sum(prompt_tokens) + ATOM_DP_LB_REQ_EQUIV * num_in_flight_requests

--- a/tests/test_dp_load_balance.py
+++ b/tests/test_dp_load_balance.py
@@ -9,6 +9,7 @@
 # here works on the CPU-only / mocked CI runner without any sys.modules stub;
 # conftest.py supplies the atom.* / zmq stubs the import chain needs.
 
+import pickle
 from threading import Lock
 
 import pytest
@@ -178,6 +179,31 @@ def test_explicit_hint_takes_priority_and_is_charged():
     # Hinted rank's load is counted so it participates in future balancing.
     assert mgr._rank_reqs[2] >= 1
     assert mgr._rank_tokens[2] >= 30
+
+
+def test_dispatch_sends_explicit_hint_to_exact_engine_rank():
+    class _RecordingSocket:
+        def __init__(self):
+            self.messages = []
+
+        def send_multipart(self, parts, copy=False):
+            self.messages.append(parts)
+
+    mgr = _make_mgr(4, strategy="least_requests")
+    mgr.engine_core_identities = [b"e0", b"e1", b"e2", b"e3"]
+    mgr.input_sockets = [_RecordingSocket() for _ in range(4)]
+    # Make rank 3 the least attractive load-balanced destination. An explicit
+    # mesh hint must still route there exactly.
+    mgr._rank_reqs = [0, 0, 0, 10]
+    mgr._rank_tokens = [0, 0, 0, 10_000]
+
+    seq = _FakeSeq("sticky", num_prompt_tokens=100, data_parallel_rank=3)
+    mgr._dispatch_to_dp_ranks([seq])
+
+    assert [len(sock.messages) for sock in mgr.input_sockets] == [0, 0, 0, 1]
+    request_type, dispatched = pickle.loads(mgr.input_sockets[3].messages[0][1])
+    assert request_type.name == "ADD"
+    assert [item.id for item in dispatched] == [seq.id]
 
 
 def test_invalid_hint_still_supported_via_add_request_validation():

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -10,6 +10,7 @@ _ATOM_ENV_VARS = [
     "ATOM_DP_SIZE",
     "ATOM_DP_MASTER_IP",
     "ATOM_DP_MASTER_PORT",
+    "ATOM_DP_BASE_PORT",
     "ATOM_USE_TRITON_GEMM",
     "ATOM_USE_TRITON_MXFP4_BMM",
     "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION",
@@ -66,6 +67,9 @@ class TestEnvsDefaults:
     def test_state_ckpt_extra_entries_default(self):
         assert _get_envs().STATE_CKPT_EXTRA_ENTRIES == 0
 
+    def test_dp_base_port_default(self):
+        assert _get_envs().ATOM_DP_BASE_PORT == 0
+
     def test_use_triton_gemm_default(self):
         assert _get_envs().ATOM_USE_TRITON_GEMM is False
 
@@ -119,6 +123,12 @@ class TestEnvsOverrides:
     def test_state_ckpt_extra_entries_empty_means_default(self, monkeypatch):
         monkeypatch.setenv("STATE_CKPT_EXTRA_ENTRIES", "")
         assert _get_envs().STATE_CKPT_EXTRA_ENTRIES == 0
+
+    def test_dp_port_overrides(self, monkeypatch):
+        monkeypatch.setenv("ATOM_DP_MASTER_PORT", "29700")
+        monkeypatch.setenv("ATOM_DP_BASE_PORT", "29800")
+        assert _get_envs().ATOM_DP_MASTER_PORT == 29700
+        assert _get_envs().ATOM_DP_BASE_PORT == 29800
 
     def test_torch_profiler_dir_override(self, monkeypatch):
         monkeypatch.setenv("ATOM_TORCH_PROFILER_DIR", "/tmp/prof")
@@ -174,3 +184,16 @@ class TestIsSet:
     def test_is_set_returns_false_for_empty_string(self, monkeypatch):
         monkeypatch.setenv("ATOM_DP_SIZE", "")
         assert _get_envs().is_set("ATOM_DP_SIZE") is False
+
+
+def test_parallel_config_applies_explicit_dp_endpoint_env(monkeypatch):
+    monkeypatch.setenv("ATOM_DP_MASTER_IP", "127.0.0.2")
+    monkeypatch.setenv("ATOM_DP_MASTER_PORT", "29700")
+    monkeypatch.setenv("ATOM_DP_BASE_PORT", "29800")
+
+    from atom.config import ParallelConfig
+
+    config = ParallelConfig()
+    assert config.data_parallel_master_ip == "127.0.0.2"
+    assert config.data_parallel_master_port == 29700
+    assert config.data_parallel_base_port == 29800


### PR DESCRIPTION
### Summary

- Preserve mesh-selected DP ranks across streaming and non-streaming request paths to maintain sticky affinity.
- Add role-specific DP rendezvous ports to prevent co-located prefill/decode conflicts on single node.
- Recover missing deferred-output placeholders before scheduler token replacement.
- Add coverage for DP sticky routing and rendezvous environment overrides.