### PR TITLE
fix(fused_moe): drop top-k from mori dispatch trim bound

### DIFF
--- a/atom/model_ops/fused_moe/modular_kernel.py
+++ b/atom/model_ops/fused_moe/modular_kernel.py
@@ -294,8 +294,10 @@ class FusedMoEModularKernel(torch.nn.Module):
         """Trim the mori dispatch buffer's dead tail before fused_moe.
 
         Default (native/sglang/rtp) policy: under a uniform all-ranks-decode
-        batch, trim to the static graph_bs*topk*dp bound so the shape is
-        consistent across cudagraph capture/replay. atom-vllm needs a different,
+        batch, trim to the static graph_bs*dp bound so the shape is
+        consistent across cudagraph capture/replay. mori dispatch dedups per
+        destination rank, so a rank receives at most graph_bs tokens per source
+        rank -- the bound must not multiply by topk. atom-vllm needs a different,
         exact received-token trim for DP+EP mixed batches and overrides this
         method via a plugin patch -- keep this body frontend-agnostic.
         """
@@ -304,9 +306,8 @@ class FusedMoEModularKernel(torch.nn.Module):
             return dispatch_a1, dispatch_scale, dispatch_ids, dispatch_weights
 
         dp_size = get_dp_group().world_size
-        topk = topk_ids.shape[1]
         # graph_bs keeps the trimmed shape consistent during capture/replay.
-        total_valid_tokens = context.graph_bs * topk * dp_size
+        total_valid_tokens = context.graph_bs * dp_size
         all_ranks_decode = getattr(context, "dp_uniform_decode", not context.is_prefill)
         if total_valid_tokens < dispatch_a1.shape[0] and all_ranks_decode:
             dispatch_a1 = dispatch_a1[:total_valid_tokens]

--- a/tests/test_mori_dispatch_trim_bound.py
+++ b/tests/test_mori_dispatch_trim_bound.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""The mori dispatch trim bound must not multiply by top-k.
+
+mori's IntraNode/AsyncLL dispatch kernel deduplicates per destination rank: a
+source token whose several top-k experts all resolve to the same rank is written
+into that rank's receive buffer exactly once (see the "Deduplicate" block in
+mori intranode.hpp, which skips any top-k slot whose destPe already appeared in
+an earlier slot of the same token). So a single rank's receive buffer holds at
+most `graph_bs` tokens per source rank -> `graph_bs * dp_size` total, never
+`graph_bs * topk * dp_size`. The topk-inflated bound sat above the real
+valid-token count, making the trim a no-op and leaving fused_moe reading
+uninitialized tail rows.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("aiter", reason="needs the AITER GPU kernel library")
+
+import torch
+
+import atom.model_ops.fused_moe.modular_kernel as mk
+
+
+def _trim(monkeypatch, *, graph_bs, dp_size, topk, recv_rows):
+    context = SimpleNamespace(
+        graph_bs=graph_bs, is_prefill=False, dp_uniform_decode=True
+    )
+    monkeypatch.setattr(
+        mk, "get_forward_context", lambda: SimpleNamespace(context=context)
+    )
+    monkeypatch.setattr(mk, "get_dp_group", lambda: SimpleNamespace(world_size=dp_size))
+    kernel = mk.FusedMoEModularKernel.__new__(mk.FusedMoEModularKernel)
+    hidden = 8
+    a1 = torch.arange(recv_rows * hidden, dtype=torch.float32).reshape(
+        recv_rows, hidden
+    )
+    ids = torch.zeros(recv_rows, topk, dtype=torch.int32)
+    weights = torch.ones(recv_rows, topk, dtype=torch.float32)
+    scale = torch.ones(recv_rows, 4, dtype=torch.float32)
+    topk_ids = torch.zeros(3, topk, dtype=torch.int32)  # only its .shape[1] matters
+    return kernel._maybe_trim_dispatch_output(
+        a1, scale, ids, weights, topk_ids, expert_tokens_meta=None
+    )
+
+
+def test_trims_to_graph_bs_times_dp_size_not_topk(monkeypatch):
+    graph_bs, dp_size, topk = 4, 8, 6
+    a1, scale, ids, weights = _trim(
+        monkeypatch, graph_bs=graph_bs, dp_size=dp_size, topk=topk, recv_rows=512
+    )
+    expected = graph_bs * dp_size  # 32, NOT 32*topk=192
+    assert a1.shape[0] == expected
+    assert ids.shape[0] == expected
+    assert weights.shape[0] == expected
+    assert scale.shape[0] == expected
+
+
+def test_topk_does_not_change_the_bound(monkeypatch):
+    graph_bs, dp_size = 4, 8
+    rows = {
+        topk: _trim(
+            monkeypatch, graph_bs=graph_bs, dp_size=dp_size, topk=topk, recv_rows=512
+        )[0].shape[0]
+        for topk in (1, 2, 6, 9)
+    }
+    assert set(rows.values()) == {graph_bs * dp_size}
+
+
+def test_no_trim_when_bound_exceeds_buffer(monkeypatch):
+    # fused_moe is driven by num_local_tokens; the buffer must never be cut
+    # below the bound.
+    a1, _, _, _ = _trim(monkeypatch, graph_bs=64, dp_size=8, topk=4, recv_rows=16)
+    assert a1.shape[0] == 16


### PR DESCRIPTION
The bound was `graph_bs * topk * dp_size`, which over-counts. mori's IntraNode/AsyncLL dispatch kernel deduplicates per destination rank: a source token whose multiple top-k experts all resolve to the same rank is written into that rank's receive buffer exactly once (see the "Deduplicate" block in mori intranode.hpp, which skips any top-k slot whose destPe already appeared in an earlier slot of the same token). So a single rank's receive buffer holds at most `graph_bs` tokens per source rank -> `graph_bs * dp_size` total, never multiplied by topk.


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
