### PR TITLE
[ATOM-vLLM] Add support for Qwen3.8

### DIFF
--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -37,6 +37,29 @@ _GLUON_PA_DECODE_BS_MAPPING = {
 _NO_PS_FIXED_SPLITS = 64
 
 
+def _pa_decode_context_partition_num(
+    num_seqs: int,
+    num_kv_heads: int,
+    max_context_len: int,
+    context_partition_size: int,
+    page_size: int,
+) -> int:
+    """Context partitions for the Gluon paged-decode kernel.
+
+    The count bounds how much KV history the kernel reads -- it walks
+    `n * context_partition_size` tokens per sequence and silently drops the
+    rest -- and a partition crossing a page boundary resolves the wrong page.
+    So: floor at what the context needs, ceiling at the page-aligned prefix.
+    """
+    required = (
+        int(max_context_len) + context_partition_size - 1
+    ) // context_partition_size
+    partitions = max(get_recommended_splits(num_seqs, num_kv_heads), required)
+    if page_size % context_partition_size:
+        partitions = min(partitions, page_size // context_partition_size)
+    return max(partitions, 1)
+
+
 def _init_vllm_mha_layer_state(
     layer,
     *,
@@ -419,10 +442,20 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
         query_group_size = max_qlen * (num_q_heads_total // num_kv_heads)
         context_partition_size = 256
 
+        max_context_len = (
+            decode_metadata.max_seq_len
+            if decode_metadata is not None
+            else attn_metadata.max_seq_len
+        )
+
         use_ps = True
         if use_ps:
-            max_context_partition_num = get_recommended_splits(
-                num_decodes, num_kv_heads
+            max_context_partition_num = _pa_decode_context_partition_num(
+                num_decodes,
+                num_kv_heads,
+                max_context_len,
+                context_partition_size,
+                block_size,
             )
         else:
             max_context_partition_num = _NO_PS_FIXED_SPLITS

--- a/atom/plugin/vllm/model_wrapper.py
+++ b/atom/plugin/vllm/model_wrapper.py
@@ -154,6 +154,7 @@ _ATOM_MODEL_CLASSES: dict[str, str] = {
     "Qwen3NextMTP": "atom.models.qwen3_next_mtp:Qwen3NextMTP",
     "Qwen3_5MoeForConditionalGeneration": "atom.plugin.vllm.models.qwen3_5:Qwen3_5MoeForConditionalGeneration_",
     "Qwen3_5ForConditionalGeneration": "atom.plugin.vllm.models.qwen3_5:Qwen3_5ForConditionalGeneration_",
+    "Qwen3_5MoeForCausalLM": "atom.plugin.vllm.models.qwen3_5:Qwen3_5MoeForCausalLM",
     "KimiK25ForConditionalGeneration": "atom.plugin.vllm.models.kimi_k25:KimiK25ForConditionalGeneration_",
     "KimiK3ForConditionalGeneration": (
         "atom.plugin.vllm.models.kimi_k3:KimiK3ForCausalLM"

--- a/atom/plugin/vllm/models/qwen3_5.py
+++ b/atom/plugin/vllm/models/qwen3_5.py
@@ -12,12 +12,16 @@ from atom.models.qwen3_5 import (
     Qwen3_5GatedDeltaNet,
     Qwen3_5MoeConfig,
     Qwen3_5MoeForCausalLM as Qwen3_5MoeForCausalLMBase,
+    _apply_bf16_in_proj_mapping,
     detect_fused_expert_format,
     get_fused_expert_mapping,
     load_fused_expert_weights,
     maybe_prefix,
 )
-from atom.plugin.vllm.model_wrapper import ATOMForConditionalGeneration
+from atom.plugin.vllm.model_wrapper import (
+    ATOMForConditionalGeneration,
+    ATOMMoEForCausalLM,
+)
 from atom.model_loader.loader import WeightsMapper, load_model_in_plugin_mode
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.model_executor.layers.mamba.abstract import MambaBase
@@ -27,7 +31,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateDtypeCalculator,
     MambaStateShapeCalculator,
 )
-from vllm.model_executor.models.interfaces import IsHybrid
+from vllm.model_executor.models.interfaces import IsHybrid, SupportsMRoPE
 from vllm.model_executor.models.qwen3_5 import (
     Qwen3_5ForConditionalGeneration as vLLMQwen3_5,
     Qwen3_5MoeForConditionalGeneration as vLLMQwen3_5Moe,
@@ -41,6 +45,22 @@ from vllm.model_executor.models.qwen3_vl import (
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+
+
+def _ssm_cache_dtype(vllm_config: VllmConfig) -> str:
+    # vLLM's mamba_ssm_cache_dtype defaults to "auto" and resolves to the model
+    # dtype. The Qwen3.5 family declares the state precision mamba_ssm_dtype in
+    # model checkpoints and it can differ from model dtype. If unset, use
+    # state dtype from model config otherwise respect the
+    # --mamba-ssm-cache-dtype flag.
+    cache_config = vllm_config.cache_config
+    if cache_config.mamba_ssm_cache_dtype != "auto":
+        return cache_config.mamba_ssm_cache_dtype
+    return getattr(
+        vllm_config.model_config.hf_text_config,
+        "mamba_ssm_dtype",
+        cache_config.mamba_ssm_cache_dtype,
+    )
 
 
 class Qwen3_5GatedDeltaNetVllm(Qwen3_5GatedDeltaNet, MambaBase):
@@ -57,8 +77,10 @@ class Qwen3_5GatedDeltaNetVllm(Qwen3_5GatedDeltaNet, MambaBase):
             speculative_config=speculative_config,
             prefix=prefix,
         )
-        self.model_config = atom_config.plugin_config.vllm_config.model_config
-        self.cache_config = atom_config.plugin_config.vllm_config.cache_config
+        vllm_config = atom_config.plugin_config.vllm_config
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.ssm_cache_dtype = _ssm_cache_dtype(vllm_config)
         self.tp_rank = get_tensor_model_parallel_rank()
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
@@ -69,7 +91,7 @@ class Qwen3_5GatedDeltaNetVllm(Qwen3_5GatedDeltaNet, MambaBase):
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             self.model_config.dtype,
             self.cache_config.mamba_cache_dtype,
-            self.cache_config.mamba_ssm_cache_dtype,
+            self.ssm_cache_dtype,
         )
 
     def get_state_shape(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
@@ -99,13 +121,38 @@ class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase):
 
 
 class Qwen3_5MoeForCausalLM(Qwen3_5MoeForCausalLMBase):
-    def __init__(self, *args, **kwargs):
+    # Text-only Qwen3.5-family checkpoints (Qwen3.8) store weights under
+    # `model.`/`lm_head.` with no vision tower, so the module names line up
+    # with this class directly and no prefix rewrite is needed
+    # However, there are some packed remaps that ForConditionalGeneration
+    # carries but ForCausalLM does not.
+    packed_modules_mapping = {
+        "q_proj": ("qkv_proj", "q"),
+        "k_proj": ("qkv_proj", "k"),
+        "v_proj": ("qkv_proj", "v"),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkv": ("in_proj_qkvz", (0, 1, 2)),
+        "in_proj_z": ("in_proj_qkvz", 3),
+        "in_proj_b": ("in_proj_ba", 0),
+        "in_proj_a": ("in_proj_ba", 1),
+        ".gate.": (".gate.", 0),
+        "shared_expert_gate": ("gate", 1),
+    }
+
+    def __init__(self, atom_config: Config, prefix: str = ""):
         original_gdn_cls = qwen3_5_base.Qwen3_5GatedDeltaNet
         qwen3_5_base.Qwen3_5GatedDeltaNet = Qwen3_5GatedDeltaNetVllm
         try:
-            super().__init__(*args, **kwargs)
+            super().__init__(atom_config=atom_config, prefix=prefix)
         finally:
             qwen3_5_base.Qwen3_5GatedDeltaNet = original_gdn_cls
+        # A BF16 checkpoint fuses the GDN input projections into one
+        # `in_proj_qkvzba`; quantized ones keep qkvz and ba apart.
+        self.packed_modules_mapping = _apply_bf16_in_proj_mapping(
+            dict(self.packed_modules_mapping), atom_config
+        )
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -359,7 +406,7 @@ class Qwen3_5ForConditionalGeneration(ATOMForConditionalGeneration, IsHybrid):
         return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
-            vllm_config.cache_config.mamba_ssm_cache_dtype,
+            _ssm_cache_dtype(vllm_config),
         )
 
     @classmethod
@@ -403,5 +450,79 @@ class Qwen3_5ForConditionalGeneration(ATOMForConditionalGeneration, IsHybrid):
     dummy_inputs=Qwen3VLDummyInputsBuilder,
 )
 class Qwen3_5MoeForConditionalGeneration(Qwen3_5ForConditionalGeneration, IsHybrid):
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.model.get_expert_mapping()
+
+
+class Qwen3_5MoeForCausalLMVllm(ATOMMoEForCausalLM, IsHybrid, SupportsMRoPE):
+    """vLLM entry point for text-only Qwen3.5-family MoE checkpoints.
+
+    Qwen3.8-2.4T-A95B declares `Qwen3_5MoeForCausalLM`: the same hybrid
+    (full attention + Gated DeltaNet) MoE backbone as Qwen3.5-MoE, but with a
+    flat text config and no vision tower, so it needs the plain causal-LM
+    wrapper rather than the `ForConditionalGeneration` one.
+
+    The checkpoint keeps the family's `mrope_section` rope parameters, so the
+    rotary embedding is still M-RoPE and vLLM's runner asks every request for
+    3-D positions. Text-only prompts make all three T/H/W sections share the
+    token index, which is what `get_mrope_input_positions` below returns.
+    """
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list,
+    ) -> tuple[torch.Tensor, int]:
+        if mm_features:
+            raise NotImplementedError(
+                "Qwen3_5MoeForCausalLM is the text-only entry point for the "
+                "Qwen3.5 family; serve image/video through "
+                "Qwen3_5MoeForConditionalGeneration instead."
+            )
+        num_tokens = len(input_tokens)
+        positions = torch.arange(num_tokens, dtype=torch.long).unsqueeze(0).repeat(3, 1)
+        # Every section advances with the token index, so decode positions need
+        # no correction against the prompt length.
+        return positions, 0
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            _ssm_cache_dtype(vllm_config),
+        )
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        parallel_config = vllm_config.parallel_config
+        hf_config = vllm_config.model_config.hf_text_config
+        tp_size = parallel_config.tensor_parallel_size
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            tp_size,
+            hf_config.linear_num_key_heads,
+            hf_config.linear_num_value_heads,
+            hf_config.linear_key_head_dim,
+            hf_config.linear_value_head_dim,
+            hf_config.linear_conv_kernel_dim,
+            num_spec,
+        )
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
+
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -35,6 +35,7 @@ _VLLM_MODEL_REGISTRY_OVERRIDES: dict[str, str] = {
     "Qwen3NextMTP": ATOM_MOE_CAUSAL_LM_MODEL_WRAPPER,
     "Qwen3_5ForConditionalGeneration": "atom.plugin.vllm.models.qwen3_5:Qwen3_5ForConditionalGeneration",
     "Qwen3_5MoeForConditionalGeneration": "atom.plugin.vllm.models.qwen3_5:Qwen3_5MoeForConditionalGeneration",
+    "Qwen3_5MoeForCausalLM": "atom.plugin.vllm.models.qwen3_5:Qwen3_5MoeForCausalLMVllm",
     "KimiK25ForConditionalGeneration": "atom.plugin.vllm.models.kimi_k25:KimiK25ForConditionalGeneration",
     "KimiK3ForConditionalGeneration": (
         "atom.plugin.vllm.models.kimi_k3:KimiK3ForCausalLMVllm"

--- a/recipes/atom_vllm/Qwen3.8.md
+++ b/recipes/atom_vllm/Qwen3.8.md
@@ -1,0 +1,84 @@
+# Qwen3.8 with vLLM-ATOM Plugin Backend
+
+This recipe shows how to run `amd/Qwen3.8-2.4T-A95B-Quark-MXFP4` with the vLLM-ATOM plugin backend. For background on the plugin backend, see [vLLM plugin backend](../../docs/vllm_plugin_backend_guide.md). For how this configuration was arrived at, see [Qwen3.8 bring-up findings](../../docs/qwen3_8_vllm_plugin_bringup.md).
+
+## Step 1: Pull the OOT Docker
+
+```bash
+docker pull rocm/atom-dev:vllm-latest
+```
+
+## Step 2: Launch vLLM Server
+
+The vLLM-ATOM plugin backend keeps the standard vLLM CLI, server APIs, and general usage flow compatible with upstream vLLM. For general server options and API usage, refer to the [official vLLM documentation](https://docs.vllm.ai/en/latest/).
+
+### Qwen3.8-2.4T-A95B-Quark-MXFP4 (TP=8, MI355X)
+
+```bash
+TP=8
+export VLLM_ROCM_USE_AITER=1
+export ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1
+export ATOM_USE_CUSTOM_ALL_GATHER=0
+export ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0
+export GATED_DELTA_RULE_TRITON_AUTOTUNE=1
+
+vllm serve amd/Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+    --host localhost \
+    --port 8000 \
+    --tensor-parallel-size "${TP}" \
+    --kv-cache-dtype fp8 \
+    --async-scheduling \
+    --trust-remote-code \
+    --max-num-batched-tokens 16384 \
+    --max-model-len 16384 \
+    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
+    --gpu-memory-utilization 0.9 \
+    --no-enable-prefix-caching
+```
+
+## Step 3: Performance Benchmark
+
+Users can use the default vllm bench commands for performance benchmarking.
+
+```bash
+ISL=1000
+OSL=100
+CONC=4
+
+vllm bench serve \
+    --backend vllm \
+    --base-url http://127.0.0.1:8000 \
+    --endpoint /v1/completions \
+    --model amd/Qwen3.8-2.4T-A95B-Quark-MXFP4 \
+    --dataset-name random \
+    --random-input-len "${ISL}" \
+    --random-output-len "${OSL}" \
+    --random-range-ratio 0.0 \
+    --max-concurrency "${CONC}" \
+    --num-prompts "$(( CONC * 8 ))" \
+    --trust_remote_code \
+    --num-warmups "${CONC}" \
+    --request-rate inf \
+    --ignore-eos \
+    --disable-tqdm \
+    --save-result \
+    --percentile-metrics ttft,tpot,itl,e2el
+```
+
+### Optional: Enable Profiling
+If you want to collect profiling trace, you can use the same API as default vLLM to add `--profiler-config "$profiler_config"` to the `vllm serve` command above.
+
+```bash
+profiler_config=$(printf '{"profiler":"torch","torch_profiler_dir":"%s","torch_profiler_with_stack":true,"torch_profiler_record_shapes":true}' \
+    "${your-profiler-dir}")
+```
+
+## Step 4: Accuracy Validation
+
+```bash
+lm_eval --model local-completions \
+        --model_args model=amd/Qwen3.8-2.4T-A95B-Quark-MXFP4,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False \
+        --tasks gsm8k \
+        --num_fewshot 5 \
+        --gen_kwargs max_gen_toks=2048
+```


### PR DESCRIPTION
## Motivation
This PR adds support for Qwen3.8 in ATOM-vLLM mode.
Currently only tested with MXFP4 weights on single-node MI355 x8.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
- Add and register text-only Qwen3_5
- Resolve ssm state dtype to dtype from model config unless otherwise set
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
lm_eval with gsm8k (single node MI355 x8, TP8)

Model: amd/Qwen3.8-2.4T-A95B-Quark-MXFP4

Server command
```
TP=8
export VLLM_ROCM_USE_AITER=1
export ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION=1
export ATOM_USE_CUSTOM_ALL_GATHER=0
export ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE=0
export GATED_DELTA_RULE_TRITON_AUTOTUNE=1

vllm serve amd/Qwen3.8-2.4T-A95B-Quark-MXFP4 \
    --host localhost \
    --port 8000 \
    --tensor-parallel-size "${TP}" \
    --kv-cache-dtype fp8 \
    --async-scheduling \
    --trust-remote-code \
    --max-num-batched-tokens 16384 \
    --max-model-len 16384 \
    --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
    --gpu-memory-utilization 0.9 \
    --no-enable-prefix-caching
```

lm_eval

```
lm_eval --model local-completions \
        --model_args model=amd/Qwen3.8-2.4T-A95B-Quark-MXFP4,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False \
        --tasks gsm8k \
        --num_fewshot 5 \
        --gen_kwargs max_gen_toks=2048
```
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
gsm8k

local-completions ({'model': 'amd/Qwen3.8-2.4T-A95B-Quark-MXFP4', 'base_url': 'http://localhost:8000/v1/completions', 'num_concurrent': 64, 'max_retries': 3, 'tokenized_requests': False}), gen_kwargs: ({'max_gen_toks': 2048}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9591|±  |0.0055|
|     |       |strict-match    |     5|exact_match|↑  |0.9598|±  |0.0054|

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
