### PR TITLE
fix(engine)+perf(frontend): unwedge the request socket, push metrics, merge backlogged SSE chunks

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -799,6 +799,11 @@ class ParallelConfig:
     pp_token_addr: str = ""
     """ZMQ endpoint where the head receives sampled tokens back from the last
     stage. Populated by CoreManager for pp_size > 1."""
+    control_address: str = ""
+    """ZMQ endpoint carrying control traffic (utility commands, abort, shutdown)
+    for this EngineCore, separate from the request endpoint. Keeping the two
+    apart leaves the request socket with a single writer thread, so admitting a
+    request needs no synchronization. Populated by launch_engine_core."""
     world_size: int = field(init=False)
     """Vestigial: never assigned or read; engine_core derives worker count directly."""
     data_parallel_master_port: int = 29500

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -44,6 +44,7 @@ from atom.entrypoints.openai.serving_completion import (
     build_completion_response_multi,
     create_completion_chunk,
 )
+from atom.entrypoints.openai.sse import data_frame
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser
 
 logger = logging.getLogger("atom")
@@ -715,7 +716,7 @@ class ChatCompletionStreamState:
                 "model": self.model_name,
                 "usage": usage,
             }
-            chunks.append(f"data: {json.dumps(usage_chunk)}\n\n")
+            chunks.append(data_frame(usage_chunk))
             chunks.append(STREAM_DONE_MESSAGE)
             self._pending_final_chunks = chunks
 
@@ -856,7 +857,7 @@ class CompletionStreamState:
                 "model": self.model_name,
                 "usage": usage,
             }
-            chunks.append(f"data: {json.dumps(usage_chunk)}\n\n")
+            chunks.append(data_frame(usage_chunk))
             chunks.append(STREAM_DONE_MESSAGE)
             self._pending_final_chunks = chunks
 

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -85,7 +85,8 @@ from .serving_completion import (
     stream_completion_response,
     stream_completion_response_fanout,
 )
-from .streaming_dispatch import StreamBatchDispatcher
+from .sse import event_frame
+from .streaming_dispatch import StreamBatchDispatcher, StreamOutputCollector
 
 # Configure logging
 logger = logging.getLogger("atom")
@@ -105,12 +106,12 @@ processor: Any | None = None
 model_name: str = ""
 default_chat_template_kwargs: dict[str, Any] = {}
 custom_message_encoder: Any | None = None
-_stream_queues: dict[str, asyncio.Queue] = {}
 _seq_id_to_request_id: dict[int, str] = {}
 _stream_loops: dict[str, AbstractEventLoop] = {}
 _request_start_times: dict[str, float] = {}
 _request_logger: logging.Logger | None = None
 _stream_batch_dispatcher: StreamBatchDispatcher | None = None
+_ANTHROPIC_PING_FRAME = event_frame("ping", {"type": "ping"})
 _metrics_exporter = AtomMetricsExporter()
 _metrics_refresh_task: asyncio.Task | None = None
 _METRICS_REFRESH_INTERVAL_SECONDS = 5.0
@@ -413,21 +414,21 @@ def _build_stream_chunk(request_output: RequestOutput, request_id: str) -> dict:
 def _send_stream_chunk_direct(
     request_output: RequestOutput,
     request_id: str,
-    stream_queue: asyncio.Queue,
+    stream_collector: StreamOutputCollector,
     loop: AbstractEventLoop,
 ) -> None:
     """Buffer a single-request chunk for this engine step."""
     assert _stream_batch_dispatcher is not None
     _stream_batch_dispatcher.enqueue(
         loop=loop,
-        queue=stream_queue,
+        collector=stream_collector,
         state_key=request_id,
         chunk=_build_stream_chunk(request_output, request_id),
     )
 
 
 def flush_stream_batch() -> None:
-    """Flush this output thread's engine-step batch into asyncio queues."""
+    """Flush this output thread's engine-step batch to the stream collectors."""
     if _stream_batch_dispatcher is not None:
         _stream_batch_dispatcher.flush()
 
@@ -436,14 +437,15 @@ def _send_stream_chunk_tagged(
     request_output: RequestOutput,
     request_id: str,
     sibling_index: int,
-    stream_queue: asyncio.Queue,
+    stream_collector: StreamOutputCollector,
     loop: AbstractEventLoop,
 ) -> None:
     """Variant of :func:`_send_stream_chunk_direct` for fan-out siblings.
 
-    Pushes ``(sibling_index, chunk_data)`` tuples onto a single shared
-    queue so the merge-stream consumer in :mod:`serving_chat` /
-    :mod:`serving_completion` can demultiplex by index.
+    Pushes ``(sibling_index, chunk_data)`` tuples into a single shared
+    collector so the merge-stream consumer in :mod:`serving_chat` /
+    :mod:`serving_completion` can demultiplex by index. The collector folds
+    per tag, so a lagging consumer never mixes two siblings' deltas.
 
     This path serves ``SamplingParams.n > 1`` by tagging each sibling's chunks
     so the shared stream consumer can merge them in order.
@@ -451,7 +453,7 @@ def _send_stream_chunk_tagged(
     assert _stream_batch_dispatcher is not None
     _stream_batch_dispatcher.enqueue(
         loop=loop,
-        queue=stream_queue,
+        collector=stream_collector,
         state_key=(request_id, sibling_index),
         chunk=_build_stream_chunk(request_output, request_id),
         tag=sibling_index,
@@ -823,24 +825,26 @@ async def setup_streaming_request(
     kv_transfer_params: dict[str, Any] | None = None,
     multimodal_data: dict[str, Any] | None = None,
     data_parallel_rank: int | None = None,
-) -> tuple[int, asyncio.Queue, int]:
+) -> tuple[int, StreamOutputCollector, int]:
     """Set up a streaming request with the engine.
 
-    Returns ``(seq_id, stream_queue, num_prompt_tokens)``. ``num_prompt_tokens``
-    is the engine-computed prompt length so the stream response generator does
-    not have to re-tokenize the prompt on the event loop.
+    Returns ``(seq_id, stream_collector, num_prompt_tokens)``.
+    ``num_prompt_tokens`` is the engine-computed prompt length so the stream
+    response generator does not have to re-tokenize the prompt on the event
+    loop.
     """
-    global engine, _stream_queues, _seq_id_to_request_id
+    global engine, _seq_id_to_request_id
     global _stream_loops, _request_start_times
 
-    stream_queue: asyncio.Queue = asyncio.Queue()
+    stream_collector = StreamOutputCollector(request_id)
     stream_loop = asyncio.get_running_loop()
-    _stream_queues[request_id] = stream_queue
     _stream_loops[request_id] = stream_loop
     _request_start_times[request_id] = time.time()
 
     def stream_callback(request_output: RequestOutput) -> None:
-        _send_stream_chunk_direct(request_output, request_id, stream_queue, stream_loop)
+        _send_stream_chunk_direct(
+            request_output, request_id, stream_collector, stream_loop
+        )
 
     executor_loop = asyncio.get_event_loop()
 
@@ -861,7 +865,6 @@ async def setup_streaming_request(
         seq = await executor_loop.run_in_executor(None, do_preprocess)
         _validate_sequence_context_length(seq)
     except Exception:
-        _stream_queues.pop(request_id, None)
         _stream_loops.pop(request_id, None)
         _request_start_times.pop(request_id, None)
         if seq is not None:
@@ -873,7 +876,7 @@ async def setup_streaming_request(
     logger.info(f"API: Created request_id={request_id}, seq_id={seq_id}")
     engine.core_mgr.add_request([seq])
 
-    return seq_id, stream_queue, seq.num_prompt_tokens
+    return seq_id, stream_collector, seq.num_prompt_tokens
 
 
 def cleanup_streaming_request(
@@ -892,10 +895,9 @@ def cleanup_streaming_request(
     no-op that just floods the control path (one broadcast per engine core, per
     request).
     """
-    global engine, _stream_queues, _seq_id_to_request_id
+    global engine, _seq_id_to_request_id
     global _stream_loops, _request_start_times
 
-    _stream_queues.pop(request_id, None)
     _seq_id_to_request_id.pop(seq_id, None)
     _stream_loops.pop(request_id, None)
     _request_start_times.pop(request_id, None)
@@ -1013,33 +1015,32 @@ async def setup_streaming_request_fanout(
     kv_transfer_params: dict[str, Any] | None = None,
     multimodal_data: dict[str, Any] | None = None,
     data_parallel_rank: int | None = None,
-) -> tuple[list[int], asyncio.Queue, int]:
+) -> tuple[list[int], StreamOutputCollector, int]:
     """Fan-out variant of :func:`setup_streaming_request`.
 
     Creates ``sampling_params.n`` sibling sequences sharing one output
-    queue. Every callback pushes ``(sibling_index, chunk_data)`` tuples so
+    collector. Every callback pushes ``(sibling_index, chunk_data)`` tuples so
     the merge-stream consumer can rewrite ``choices[0].index`` correctly.
 
-    Returns ``(seq_ids, shared_queue, num_prompt_tokens)``. All siblings
+    Returns ``(seq_ids, shared_collector, num_prompt_tokens)``. All siblings
     tokenize the same prompt once, so ``num_prompt_tokens`` is shared and lets
     the stream response generator skip re-tokenizing on the event loop.
     """
-    global engine, _stream_queues, _seq_id_to_request_id
+    global engine, _seq_id_to_request_id
     global _stream_loops, _request_start_times
 
     n = int(sampling_params.n)
     assert n >= 1
 
-    shared_queue: asyncio.Queue = asyncio.Queue()
+    shared_collector = StreamOutputCollector(request_id)
     stream_loop = asyncio.get_running_loop()
-    _stream_queues[request_id] = shared_queue
     _stream_loops[request_id] = stream_loop
     _request_start_times[request_id] = time.time()
 
     def make_callback(idx: int):
         def _cb(request_output: RequestOutput) -> None:
             _send_stream_chunk_tagged(
-                request_output, request_id, idx, shared_queue, stream_loop
+                request_output, request_id, idx, shared_collector, stream_loop
             )
 
         return _cb
@@ -1067,7 +1068,6 @@ async def setup_streaming_request_fanout(
         seqs = await executor_loop.run_in_executor(None, do_preprocess)
         _validate_sequence_context_length(seqs[0])
     except Exception:
-        _stream_queues.pop(request_id, None)
         _stream_loops.pop(request_id, None)
         _request_start_times.pop(request_id, None)
         for seq in seqs:
@@ -1079,7 +1079,7 @@ async def setup_streaming_request_fanout(
         f"API: Created fan-out request_id={request_id}, n={n}, seq_ids={seq_ids}"
     )
     engine.core_mgr.add_request(seqs)
-    return seq_ids, shared_queue, seqs[0].num_prompt_tokens
+    return seq_ids, shared_collector, seqs[0].num_prompt_tokens
 
 
 # ============================================================================
@@ -1280,7 +1280,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
             stream_input = token_ids if is_multimodal else prompt
             stream_multimodal_data = multimodal_data if is_multimodal else None
             if effective_n > 1:
-                seq_ids, stream_queue, num_prompt_tokens = (
+                seq_ids, stream_collector, num_prompt_tokens = (
                     await setup_streaming_request_fanout(
                         stream_input,
                         sampling_params,
@@ -1293,25 +1293,27 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 gen = stream_chat_response_fanout(
                     request_id,
                     model_name,
-                    stream_queue,
+                    stream_collector,
                     seq_ids,
                     num_prompt_tokens,
                     cleanup_streaming_request,
                     tools=request.tools,
                 )
             else:
-                seq_id, stream_queue, num_prompt_tokens = await setup_streaming_request(
-                    stream_input,
-                    sampling_params,
-                    request_id,
-                    multimodal_data=stream_multimodal_data,
-                    kv_transfer_params=request.kv_transfer_params,
-                    data_parallel_rank=dp_rank,
+                seq_id, stream_collector, num_prompt_tokens = (
+                    await setup_streaming_request(
+                        stream_input,
+                        sampling_params,
+                        request_id,
+                        multimodal_data=stream_multimodal_data,
+                        kv_transfer_params=request.kv_transfer_params,
+                        data_parallel_rank=dp_rank,
+                    )
                 )
                 gen = stream_chat_response(
                     request_id,
                     model_name,
-                    stream_queue,
+                    stream_collector,
                     seq_id,
                     num_prompt_tokens,
                     cleanup_streaming_request,
@@ -1453,7 +1455,7 @@ async def completions(request: CompletionRequest, raw_request: Request):
         # Streaming
         if request.stream:
             if effective_n > 1:
-                seq_ids, stream_queue, num_prompt_tokens = (
+                seq_ids, stream_collector, num_prompt_tokens = (
                     await setup_streaming_request_fanout(
                         request.prompt,
                         sampling_params,
@@ -1465,23 +1467,25 @@ async def completions(request: CompletionRequest, raw_request: Request):
                 gen = stream_completion_response_fanout(
                     request_id,
                     model_name,
-                    stream_queue,
+                    stream_collector,
                     seq_ids,
                     num_prompt_tokens,
                     cleanup_streaming_request,
                 )
             else:
-                seq_id, stream_queue, num_prompt_tokens = await setup_streaming_request(
-                    request.prompt,
-                    sampling_params,
-                    request_id,
-                    kv_transfer_params=request.kv_transfer_params,
-                    data_parallel_rank=dp_rank,
+                seq_id, stream_collector, num_prompt_tokens = (
+                    await setup_streaming_request(
+                        request.prompt,
+                        sampling_params,
+                        request_id,
+                        kv_transfer_params=request.kv_transfer_params,
+                        data_parallel_rank=dp_rank,
+                    )
                 )
                 gen = stream_completion_response(
                     request_id,
                     model_name,
-                    stream_queue,
+                    stream_collector,
                     seq_id,
                     num_prompt_tokens,
                     cleanup_streaming_request,
@@ -1622,8 +1626,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
         if request.stream:
             # Streaming response
-            seq_id, stream_queue, _num_prompt_tokens = await setup_streaming_request(
-                prompt, sampling_params, request_id
+            seq_id, stream_collector, _num_prompt_tokens = (
+                await setup_streaming_request(prompt, sampling_params, request_id)
             )
 
             async def generate_anthropic_stream():
@@ -1651,7 +1655,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
                 try:
                     while True:
-                        chunk_data = await stream_queue.get()
+                        chunk_data = await stream_collector.get()
                         if not message_started:
                             cache_read = chunk_data.get("num_cached_tokens", 0)
                             yield stream_message_start(
@@ -1673,9 +1677,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
                             if field == "reasoning_content":
                                 if not _thinking_enabled:
-                                    yield "event: ping\ndata: " + json.dumps(
-                                        {"type": "ping"}
-                                    ) + "\n\n"
+                                    yield _ANTHROPIC_PING_FRAME
                                     continue
                                 if not started_thinking and not started_text:
                                     yield stream_content_block_start(
@@ -2057,7 +2059,7 @@ def main():
     # Wire the batched stream-flush hook: per-seq stream callbacks only buffer
     # their chunks into a thread-local; the engine core manager's output thread
     # calls this flush after each step's callbacks to drain the buffer into the
-    # per-request asyncio queues (one call_soon_threadsafe per event loop).
+    # per-request stream collectors (one call_soon_threadsafe per event loop).
     # Registered lazily here to avoid the api_server <-> engine_core_mgr import
     # cycle; the core manager leaves the hook as None until this resolves it.
     engine.core_mgr._flush_stream_batch_fn = flush_stream_batch

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -833,9 +833,6 @@ async def setup_streaming_request(
     response generator does not have to re-tokenize the prompt on the event
     loop.
     """
-    global engine, _seq_id_to_request_id
-    global _stream_loops, _request_start_times
-
     stream_collector = StreamOutputCollector(request_id)
     stream_loop = asyncio.get_running_loop()
     _stream_loops[request_id] = stream_loop
@@ -895,9 +892,6 @@ def cleanup_streaming_request(
     no-op that just floods the control path (one broadcast per engine core, per
     request).
     """
-    global engine, _seq_id_to_request_id
-    global _stream_loops, _request_start_times
-
     _seq_id_to_request_id.pop(seq_id, None)
     _stream_loops.pop(request_id, None)
     _request_start_times.pop(request_id, None)
@@ -1026,9 +1020,6 @@ async def setup_streaming_request_fanout(
     tokenize the same prompt once, so ``num_prompt_tokens`` is shared and lets
     the stream response generator skip re-tokenizing on the event loop.
     """
-    global engine, _seq_id_to_request_id
-    global _stream_loops, _request_start_times
-
     n = int(sampling_params.n)
     assert n >= 1
 

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1119,8 +1119,9 @@ async def _refresh_metrics_once() -> None:
     if engine is None:
         return
     try:
-        timeout = _METRICS_REFRESH_INTERVAL_SECONDS
-        snapshot = await asyncio.to_thread(engine.get_metrics_statistics, timeout)
+        # A local read of the snapshots EngineCore pushes, so it runs inline on
+        # the loop -- no executor thread, and no writer on the control socket.
+        snapshot = engine.get_metrics_statistics()
     except asyncio.CancelledError:
         raise
     except Exception:

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -14,6 +14,8 @@ from typing import Any, List, Optional
 
 from pydantic import BaseModel
 
+from .sse import event_frame
+
 logger = logging.getLogger("atom")
 
 
@@ -253,7 +255,7 @@ def build_anthropic_response(
 
 def format_sse(event: str, data: Any) -> str:
     """Format a server-sent event."""
-    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+    return event_frame(event, data)
 
 
 def stream_message_start(

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -3,8 +3,6 @@
 
 """Chat completion handler for the OpenAI-compatible API."""
 
-import asyncio
-import json
 import logging
 import time
 from collections.abc import AsyncGenerator
@@ -23,6 +21,8 @@ from .reasoning import (
     ReasoningFilter,
     separate_reasoning,
 )
+from .sse import data_frame
+from .streaming_dispatch import StreamOutputCollector
 from .tool_parser import ToolCallStreamParser, parse_tool_calls
 
 logger = logging.getLogger("atom")
@@ -219,13 +219,13 @@ def create_chat_chunk(
     }
     if usage is not None:
         chunk["usage"] = usage
-    return f"data: {json.dumps(chunk)}\n\n"
+    return data_frame(chunk)
 
 
 async def stream_chat_response(
     request_id: str,
     model: str,
-    stream_queue: asyncio.Queue,
+    stream_collector: StreamOutputCollector,
     seq_id: int,
     num_prompt_tokens: int,
     cleanup_fn,
@@ -260,7 +260,7 @@ async def stream_chat_response(
     try:
         role_sent = False
         while True:
-            chunk_data = await stream_queue.get()
+            chunk_data = await stream_collector.get()
 
             if not role_sent:
                 yield create_chat_chunk(
@@ -353,7 +353,7 @@ async def stream_chat_response(
         # the syscalls that saturate the API event loop.
         yield (
             create_chat_chunk(request_id, model, finish_reason=finish_reason)
-            + f"data: {json.dumps(usage_chunk)}\n\n"
+            + data_frame(usage_chunk)
             + STREAM_DONE_MESSAGE
         )
     finally:
@@ -498,7 +498,7 @@ def build_chat_response_multi(
 async def stream_chat_response_fanout(
     request_id: str,
     model: str,
-    shared_queue: asyncio.Queue,
+    shared_collector: StreamOutputCollector,
     seq_ids: list[int],
     num_prompt_tokens: int,
     cleanup_fn,
@@ -532,7 +532,7 @@ async def stream_chat_response_fanout(
     try:
         role_sent = [False] * n
         while not all(finished):
-            idx, chunk_data = await shared_queue.get()
+            idx, chunk_data = await shared_collector.get()
 
             if not role_sent[idx]:
                 yield create_chat_chunk(
@@ -643,7 +643,7 @@ async def stream_chat_response_fanout(
                 )
                 for i in range(n)
             )
-            + f"data: {json.dumps(usage_chunk)}\n\n"
+            + data_frame(usage_chunk)
             + STREAM_DONE_MESSAGE
         )
     finally:

--- a/atom/entrypoints/openai/serving_completion.py
+++ b/atom/entrypoints/openai/serving_completion.py
@@ -3,17 +3,18 @@
 
 """Text completion handler for the OpenAI-compatible API."""
 
-import asyncio
-import json
 import logging
 import time
-from typing import Any, AsyncGenerator, Dict, List, Optional
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from .protocol import (
     STREAM_DONE_MESSAGE,
     TEXT_COMPLETION_OBJECT,
     CompletionResponse,
 )
+from .sse import data_frame
+from .streaming_dispatch import StreamOutputCollector
 
 logger = logging.getLogger("atom")
 
@@ -22,8 +23,8 @@ def create_completion_chunk(
     request_id: str,
     model: str,
     text: str,
-    finish_reason: Optional[str] = None,
-    usage: Optional[Dict] = None,
+    finish_reason: str | None = None,
+    usage: dict | None = None,
     index: int = 0,
     **extra_fields: Any,
 ) -> str:
@@ -49,13 +50,13 @@ def create_completion_chunk(
     chunk.update(extra_fields)
     if usage is not None:
         chunk["usage"] = usage
-    return f"data: {json.dumps(chunk)}\n\n"
+    return data_frame(chunk)
 
 
 async def stream_completion_response(
     request_id: str,
     model: str,
-    stream_queue: asyncio.Queue,
+    stream_collector: StreamOutputCollector,
     seq_id: int,
     num_prompt_tokens: int,
     cleanup_fn,
@@ -76,11 +77,11 @@ async def stream_completion_response(
     aborted = True
     try:
         while True:
-            chunk_data = await stream_queue.get()
+            chunk_data = await stream_collector.get()
             new_text = chunk_data["text"]
             num_tokens_output += len(chunk_data.get("token_ids", []))
 
-            extra_fields: Dict[str, Any] = {}
+            extra_fields: dict[str, Any] = {}
             if "kv_transfer_params" in chunk_data:
                 extra_fields["kv_transfer_params"] = chunk_data["kv_transfer_params"]
 
@@ -113,7 +114,7 @@ async def stream_completion_response(
                 yield (
                     content_chunk
                     + create_completion_chunk(request_id, model, "", "stop")
-                    + f"data: {json.dumps(usage_chunk)}\n\n"
+                    + data_frame(usage_chunk)
                     + STREAM_DONE_MESSAGE
                 )
                 return
@@ -126,7 +127,7 @@ async def stream_completion_response(
 def build_completion_response(
     request_id: str,
     model: str,
-    final_output: Dict[str, Any],
+    final_output: dict[str, Any],
 ) -> CompletionResponse:
     """Build a non-streaming text completion response (single choice)."""
     response = CompletionResponse(
@@ -162,7 +163,7 @@ def build_completion_response(
 def build_completion_response_multi(
     request_id: str,
     model: str,
-    final_outputs: List[Dict[str, Any]],
+    final_outputs: list[dict[str, Any]],
 ) -> CompletionResponse:
     """Build a non-streaming response with one choice per fan-out sibling."""
     assert final_outputs, "build_completion_response_multi requires at least one output"
@@ -202,14 +203,14 @@ def build_completion_response_multi(
 async def stream_completion_response_fanout(
     request_id: str,
     model: str,
-    shared_queue: asyncio.Queue,
-    seq_ids: List[int],
+    shared_collector: StreamOutputCollector,
+    seq_ids: list[int],
     num_prompt_tokens: int,
     cleanup_fn,
 ) -> AsyncGenerator[str, None]:
     """Streaming variant multiplexing ``len(seq_ids)`` siblings into one SSE.
 
-    Each chunk pulled from ``shared_queue`` is a ``(sibling_index, chunk_data)``
+    Each chunk pulled from ``shared_collector`` is a ``(sibling_index, chunk_data)``
     tuple; we re-emit with ``choices[0].index = sibling_index``. Finishes
     only when every sibling has reported ``finished=True``.
 
@@ -228,13 +229,13 @@ async def stream_completion_response_fanout(
     aborted = True
     try:
         while not all(finished):
-            idx, chunk_data = await shared_queue.get()
+            idx, chunk_data = await shared_collector.get()
             if finished[idx]:
                 continue
             new_text = chunk_data["text"]
             num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
 
-            extra_fields: Dict[str, Any] = {}
+            extra_fields: dict[str, Any] = {}
             if "kv_transfer_params" in chunk_data:
                 extra_fields["kv_transfer_params"] = chunk_data["kv_transfer_params"]
 
@@ -272,7 +273,7 @@ async def stream_completion_response_fanout(
                 create_completion_chunk(request_id, model, "", "stop", index=i)
                 for i in range(n)
             )
-            + f"data: {json.dumps(usage_chunk)}\n\n"
+            + data_frame(usage_chunk)
             + STREAM_DONE_MESSAGE
         )
     finally:

--- a/atom/entrypoints/openai/sse.py
+++ b/atom/entrypoints/openai/sse.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""SSE frame encoding for the streaming endpoints.
+
+One frame is encoded per streamed chunk per request, so at high concurrency
+this is one of the fixed per-token costs that caps the API server before the
+GPU does. ``msgspec`` with a reusable encoder measures 5.8x faster than
+``json.dumps`` on a chat delta (0.25 vs 1.47 us/chunk; see
+``/app/logs_claude/bench_sse_encode.py``).
+
+Encoding straight to ``bytes`` and letting the ASGI layer write them is another
+10% on top, but the frame builders are shared with the atomesh service, which
+assembles ``list[str]`` batches -- not worth splitting them for 1.6% of the
+original cost.
+
+Unlike ``json.dumps``, msgspec rejects NaN and Infinity rather than emitting
+the non-standard literals. Any float that can reach a frame (logprobs, for
+instance) has to be sanitised before it gets here.
+"""
+
+from typing import Any
+
+import msgspec
+
+_encoder = msgspec.json.Encoder()
+
+
+def data_frame(payload: Any) -> str:
+    """Encode one anonymous ``data:`` SSE frame."""
+    return f"data: {_encoder.encode(payload).decode()}\n\n"
+
+
+def event_frame(event: str, payload: Any) -> str:
+    """Encode one named-event SSE frame."""
+    return f"event: {event}\ndata: {_encoder.encode(payload).decode()}\n\n"

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -1,24 +1,24 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""Batched cross-thread dispatch for streaming model output."""
+"""Cross-thread dispatch and per-request delivery for streaming model output.
 
-import os
+Two halves of one hand-off. :class:`StreamBatchDispatcher` runs on the engine
+output threads: it buffers a whole engine step, detokenizes it, and schedules a
+single callback per event loop. :class:`StreamOutputCollector` is the loop-side
+landing point each stream's SSE generator reads from.
+"""
+
 import threading
-import time
-from asyncio import AbstractEventLoop, Queue
+from asyncio import AbstractEventLoop, Event
 from collections.abc import Hashable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NamedTuple
 
-# SSE coalescing. Two tokenizer.decode calls, a queue put/get, a json.dumps
-# and a socket write are paid once per (request, engine step); at high
-# concurrency that fixed cost, not the GPU, is what caps throughput. Holding
-# the buffer open across steps collapses N tokens into one of each (update()
-# takes a list and decodes twice regardless of length). Costs up to this much
-# extra inter-token latency, so it is opt-in. A finished chunk always flushes.
-_COALESCE_S = max(0.0, float(os.environ.get("ATOM_SSE_COALESCE_MS", "0") or 0)) / 1000.0
-_COALESCE_MAX_STEPS = int(os.environ.get("ATOM_SSE_COALESCE_MAX_STEPS", "8") or 8)
+# Fields a later chunk overrides on the one it merges into, when it has a value
+# of its own. The SSE consumers keep the newest non-empty value they see, so
+# merging this way hands them what reading each chunk separately would have.
+_LATEST_WINS = ("finish_reason", "kv_transfer_params", "num_cached_tokens")
 
 
 @dataclass
@@ -51,10 +51,74 @@ class IncrementalStreamDetokenizer:
         return ""
 
 
-@dataclass
-class _BufferedChunk:
+def merge_chunk(into: dict, new: dict) -> None:
+    """Fold ``new`` into the chunk already waiting. ``into`` is modified.
+
+    ``text`` and ``token_ids`` are deltas, so concatenating them is exact.
+    ``token_ids`` is rebuilt rather than extended: the first chunk's list is the
+    engine's own ``output_tokens``, which must not be appended to.
+    """
+    into["token_ids"] = [*into.get("token_ids", ()), *new.get("token_ids", ())]
+    into["text"] = into.get("text", "") + new.get("text", "")
+    into["finished"] = bool(into.get("finished") or new.get("finished"))
+    for key in _LATEST_WINS:
+        if new.get(key):
+            into[key] = new[key]
+
+
+class StreamOutputCollector:
+    """Per-request delivery point that merges chunks when the consumer lags.
+
+    Replaces the unbounded ``asyncio.Queue`` that used to sit between the engine
+    output threads and the SSE response generators. A queue hands over one item
+    per ``get()``, so when the frontend cannot keep up with the GPU the backlog
+    grows without bound and every queued item still costs its own coroutine
+    wakeup, JSON encode and socket write. Here a stream holds at most one chunk:
+    anything arriving behind an unread one merges into it.
+
+    Nothing is ever held back. With a consumer that keeps up nothing ever
+    merges, and delivery is identical to the queue this replaces. Merging only
+    covers chunks that were already waiting, so a token is never delivered later
+    than it would have been.
+
+    ``tag`` is the fan-out sibling index (``SamplingParams.n>1``) or ``None`` for
+    a plain single-sequence stream. Chunks merge per tag, so siblings never mix.
+    """
+
+    def __init__(self, request_id: str = "") -> None:
+        self.request_id = request_id
+        self._pending: dict[Any, dict] = {}
+        self._ready = Event()
+
+    def put_nowait(self, payload: dict | tuple[int, dict]) -> None:
+        """Accept one prepared chunk. Called on the event loop, never off it."""
+        if type(payload) is tuple:
+            tag, chunk = payload
+        else:
+            tag, chunk = None, payload
+        waiting = self._pending.get(tag)
+        if waiting is None:
+            self._pending[tag] = chunk
+        else:
+            merge_chunk(waiting, chunk)
+        self._ready.set()
+
+    async def get(self) -> dict | tuple[int, dict]:
+        """Await the next chunk, carrying whatever merged into it."""
+        while not self._pending:
+            await self._ready.wait()
+        tag, chunk = next(iter(self._pending.items()))
+        del self._pending[tag]
+        if not self._pending:
+            self._ready.clear()
+        return chunk if tag is None else (tag, chunk)
+
+
+class _BufferedChunk(NamedTuple):
+    """One stream's chunk, waiting for the end of the current engine step."""
+
     loop: AbstractEventLoop
-    queue: Queue
+    collector: Any
     state_key: Hashable
     chunk: dict
     tag: int | None
@@ -72,7 +136,7 @@ class StreamBatchDispatcher:
         self,
         *,
         loop: AbstractEventLoop,
-        queue: Queue,
+        collector: Any,
         state_key: Hashable,
         chunk: dict,
         tag: int | None = None,
@@ -81,75 +145,34 @@ class StreamBatchDispatcher:
         buf = getattr(self._thread_local, "buf", None)
         if buf is None:
             buf = self._thread_local.buf = []
-        buf.append(
-            _BufferedChunk(
-                loop=loop,
-                queue=queue,
-                state_key=state_key,
-                chunk=chunk,
-                tag=tag,
-            )
-        )
+        buf.append(_BufferedChunk(loop, collector, state_key, chunk, tag))
 
     def flush(self) -> None:
-        """Detokenize buffered chunks and schedule one drain per event loop."""
+        """Detokenize buffered chunks and schedule one delivery per event loop."""
         tl = self._thread_local
         buf = getattr(tl, "buf", None)
         if not buf:
             return
-
-        now = time.monotonic()
-        if _COALESCE_S > 0:
-            steps = getattr(tl, "steps", 0) + 1
-            tl.steps = steps
-            if (
-                steps < _COALESCE_MAX_STEPS
-                and now - getattr(tl, "last_flush", 0.0) < _COALESCE_S
-                and not any(i.chunk.get("finished") for i in buf)
-            ):
-                return  # keep accumulating; nothing here is final yet
         tl.buf = []
-        tl.steps = 0
-        tl.last_flush = now
 
-        # One group per stream. state_key already distinguishes fan-out
-        # siblings, and loop/queue are constant per stream, so the last item
-        # of a group carries the right destination plus the terminal
-        # finish_reason/finished flags.
-        groups: dict[Hashable, list[_BufferedChunk]] = {}
+        by_loop: dict[AbstractEventLoop, list[tuple[Any, Any]]] = {}
         for item in buf:
-            groups.setdefault(item.state_key, []).append(item)
-
-        by_loop: dict[AbstractEventLoop, list[tuple[Queue, Any]]] = {}
-        for state_key, items in groups.items():
-            last = items[-1]
-            token_ids = last.chunk.get("token_ids") or []
-            if len(items) > 1:
-                token_ids = []
-                for i in items:
-                    token_ids.extend(i.chunk.get("token_ids") or [])
-                last.chunk["token_ids"] = token_ids
-                for i in items[:-1]:
-                    if "kv_transfer_params" in i.chunk:
-                        last.chunk.setdefault(
-                            "kv_transfer_params", i.chunk["kv_transfer_params"]
-                        )
-
-            state = self._get_state(state_key)
-            last.chunk["text"] = state.update(
-                token_ids, bool(last.chunk.get("finished"))
+            state = self._get_state(item.state_key)
+            finished = bool(item.chunk.get("finished"))
+            item.chunk["text"] = state.update(
+                item.chunk.get("token_ids") or [], finished
             )
-            if last.chunk.get("finished"):
-                self._drop_state(state_key, state)
+            if finished:
+                self._drop_state(item.state_key, state)
 
-            payload = last.chunk if last.tag is None else (last.tag, last.chunk)
-            by_loop.setdefault(last.loop, []).append((last.queue, payload))
+            payload = item.chunk if item.tag is None else (item.tag, item.chunk)
+            by_loop.setdefault(item.loop, []).append((item.collector, payload))
 
         for loop, items in by_loop.items():
-            loop.call_soon_threadsafe(self._drain_into_queues, items)
+            loop.call_soon_threadsafe(self._deliver, items)
 
     # These three ran under a shared lock, which cost 27% of the API server's
-    # CPU -- _get_state is called once per stream per flush, with all output
+    # CPU -- _get_state is called once per buffered chunk, with all output
     # threads contending. No lock is needed: each operation below is a single
     # C-level dict method that no other Python thread can interrupt, and
     # list() snapshots atomically so discard_request cannot hit "dict changed
@@ -178,7 +201,16 @@ class StreamBatchDispatcher:
             self._states.pop(state_key, None)
 
     @staticmethod
-    def _drain_into_queues(items: list[tuple[Queue, Any]]) -> None:
-        """Run on the target event loop and deliver each prepared payload."""
-        for queue, payload in items:
-            queue.put_nowait(payload)
+    def _deliver(items: list[tuple[Any, Any]]) -> None:
+        """Run on the target event loop and hand a whole step to its collectors.
+
+        A step is delivered in one callback, never split across loop iterations.
+        Splitting was tried as a fairness measure -- deliver 128, re-arm the rest
+        with call_soon -- and it silently corrupts streams: the output thread can
+        schedule the next step's delivery in between, so a collector receives
+        step N+1's chunk before step N's leftovers. Deltas then merge in the
+        wrong order, and an end-of-stream that lands before a straggler is
+        overwritten by it, hanging that client for good.
+        """
+        for collector, payload in items:
+            collector.put_nowait(payload)

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -30,6 +30,11 @@ from atom.utils.distributed.utils import (
 
 logger = logging.getLogger("atom")
 
+# How often each EngineCore publishes its metrics snapshot. Kept at the API
+# server's scrape interval: the exporter reads a cache, so this bounds how
+# stale a Prometheus sample can be.
+METRICS_PUSH_INTERVAL_S = 5.0
+
 
 class EngineCore:
     def __init__(self, config: Config, input_address: str, output_address: str):
@@ -238,9 +243,14 @@ class EngineCore:
 
     def busy_loop(self):
         shutdown = False
+        next_metrics_push = 0.0
         try:
             while True:
                 self.utility_handler.process_queue(self.utility_queue, self)
+                now = time.monotonic()
+                if now >= next_metrics_push:
+                    next_metrics_push = now + METRICS_PUSH_INTERVAL_S
+                    self.utility_handler.push_metrics()
                 shutdown = shutdown or self.pull_and_process_input_queue()
                 if shutdown:
                     break
@@ -461,6 +471,11 @@ class EngineCore:
                     logger.debug(f"{self.label}: sent READY signal")
                     continue
 
+                if isinstance(item, tuple) and item[0] == "METRICS":
+                    obj = pickle.dumps((EngineCoreRequestType.METRICS, item[1]))
+                    socket.send(obj)
+                    continue
+
                 if isinstance(item, tuple) and item[0] == "UTILITY_RESPONSE":
                     # Send utility command response back to CoreManager
                     response_data = item[1]
@@ -539,9 +554,14 @@ class DPEngineCoreProc(EngineCore):
 
     def busy_loop(self):
         shutdown = False
+        next_metrics_push = 0.0
         try:
             while True:
                 self.utility_handler.process_queue(self.utility_queue, self)
+                now = time.monotonic()
+                if now >= next_metrics_push:
+                    next_metrics_push = now + METRICS_PUSH_INTERVAL_S
+                    self.utility_handler.push_metrics()
                 shutdown = shutdown or self.pull_and_process_input_queue()
                 local_unfinished = (
                     not self.scheduler.is_finished()

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -49,6 +49,13 @@ class EngineCore:
         )
         self.input_address = input_address
         self.output_address = output_address
+        # Control traffic arrives on its own socket so CoreManager can keep the
+        # request socket single-writer; see CoreManager._send_request.
+        self.control_address = config.parallel_config.control_address
+        assert self.control_address, (
+            "parallel_config.control_address is unset -- an EngineCore must be "
+            "launched through CoreManager, which allocates the control channel"
+        )
         self.output_thread = threading.Thread(
             target=self.process_output_sockets, args=(self.output_address,), daemon=True
         )
@@ -62,7 +69,9 @@ class EngineCore:
         # The READY signal (sent at the end of __init__) gates actual request
         # processing, so starting the input thread early is safe.
         self.input_thread = threading.Thread(
-            target=self.process_input_sockets, args=(self.input_address,), daemon=True
+            target=self.process_input_sockets,
+            args=(self.input_address, self.control_address),
+            daemon=True,
         )
         self.input_thread.start()
 
@@ -365,26 +374,51 @@ class EngineCore:
             self.scheduler.extend(recv_reqs)
         return False
 
-    def process_input_sockets(self, input_address: str):
-        """Input socket IO thread."""
+    def process_input_sockets(self, input_address: str, control_address: str):
+        """Input IO thread, serving both the request and control sockets.
+
+        Two sockets, one thread: requests arrive on ``input_address`` and
+        control traffic (utility commands, abort, shutdown) on
+        ``control_address``. The split exists on the sending side -- it lets
+        CoreManager keep the request socket single-writer and therefore
+        lock-free -- and both feed the same dispatch below.
+        """
         with ExitStack() as stack, zmq.Context() as ctx:
             input_socket = stack.enter_context(
                 make_zmq_socket(ctx, input_address, zmq.DEALER, bind=False)
             )
+            control_socket = stack.enter_context(
+                make_zmq_socket(ctx, control_address, zmq.DEALER, bind=False)
+            )
             poller = zmq.Poller()
-            # Send initial message to input socket - this is required
-            # before the front-end ROUTER socket can send input messages
+            # Send initial message on each socket - this is required
+            # before the front-end ROUTER sockets can send messages
             # back to us.
             input_socket.send(b"")
+            control_socket.send(b"")
             poller.register(input_socket, zmq.POLLIN)
-            logger.debug(f"{self.label}: input socket connected")
+            poller.register(control_socket, zmq.POLLIN)
+            logger.debug(f"{self.label}: input and control sockets connected")
             alive = True
 
             while alive:
-                for input_socket, _ in poller.poll():
+                for sock, _ in poller.poll():
                     # (RequestType, RequestData)
-                    obj = input_socket.recv(copy=False)
-                    request_type, reqs = pickle.loads(obj)
+                    obj = sock.recv(copy=False)
+                    try:
+                        request_type, reqs = pickle.loads(obj)
+                    except Exception:
+                        # This thread is the only way requests reach the engine,
+                        # so letting it die strands every later request: the
+                        # busy loop keeps polling an empty input queue, the
+                        # workers idle, and clients wait forever with no error
+                        # on any log but this thread's own traceback. Drop the
+                        # frame loudly and keep serving.
+                        logger.exception(
+                            f"{self.label}: dropping undecodable input frame "
+                            f"({len(obj.bytes)} bytes)"
+                        )
+                        continue
                     if request_type == EngineCoreRequestType.ADD:
                         req_ids = [req.id for req in reqs]
                         logger.debug(

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -96,6 +96,13 @@ class CoreManager:
         # what dispatch added, and only for ranks that were actually charged.
         self._seq_load = {}
         self._lb_lock = Lock()
+        # Control traffic (utility commands, abort, shutdown) travels on its own
+        # sockets so that input_sockets keeps a single writer -- see
+        # _send_request. These have several writer threads and so do need
+        # serializing, but none of them runs per request.
+        self.control_sockets = []
+        self.control_identities = []
+        self._control_send_lock = Lock()
 
     def __init__(self, config: Config):
         pp_size = config.pipeline_parallel_size
@@ -195,6 +202,14 @@ class CoreManager:
                     identity, _ = input_socket.recv_multipart()
                     self.input_sockets.append(input_socket)
                     self.engine_core_identities.append(identity)
+
+                    control_address = info["addresses"]["control_address"]
+                    control_socket = make_zmq_socket(
+                        self.ctx, control_address, zmq.ROUTER, bind=True
+                    )
+                    control_identity, _ = control_socket.recv_multipart()
+                    self.control_sockets.append(control_socket)
+                    self.control_identities.append(control_identity)
 
                     output_address = info["addresses"]["output_address"]
                     output_socket = make_zmq_socket(self.ctx, output_address, zmq.PULL)
@@ -441,6 +456,10 @@ class CoreManager:
             if not input_socket.closed:
                 input_socket.close()
 
+        for control_socket in self.control_sockets:
+            if not control_socket.closed:
+                control_socket.close()
+
         for shutdown_path in self.shutdown_paths:
             if shutdown_path:
                 try:
@@ -488,6 +507,40 @@ class CoreManager:
 
         logger.info(f"{self.label}: All EngineCores shut down")
 
+    def _send_request(self, dp_rank: int, payload: bytes) -> None:
+        """Send one already-pickled request to an engine core. Hot path.
+
+        Deliberately unsynchronized: ``input_sockets`` carries nothing but
+        ``add_request``, which runs on a single thread (the API server's event
+        loop online, the caller's thread offline). Everything that can be sent
+        from another thread -- utility commands, abort, shutdown -- goes to
+        :meth:`_send_control` on a separate socket instead.
+
+        That separation is load-bearing, not stylistic. A ZMQ socket is not
+        thread-safe: two unserialized ``send_multipart`` calls interleave their
+        frames, the DEALER on the other end then reads a routing identity where
+        a payload should be, and its input thread dies on ``UnpicklingError``.
+        Nothing recovers from that -- the engine spins on a forever-empty input
+        queue, the workers idle, and every client hangs with no error logged
+        anywhere but that thread's own traceback. So: never send to
+        ``input_sockets`` from anywhere but here.
+        """
+        self.input_sockets[dp_rank].send_multipart(
+            [self.engine_core_identities[dp_rank], payload], copy=False
+        )
+
+    def _send_control(self, dp_rank: int, payload: bytes, copy: bool = False) -> None:
+        """Send one already-pickled control message. Serialized, never hot.
+
+        Writers here are the event loop (abort, the /debug/* endpoints) and the
+        per-rank output threads (shutdown), so this does need a lock -- but none
+        of them runs per request, so its cost never lands on admission.
+        """
+        with self._control_send_lock:
+            self.control_sockets[dp_rank].send_multipart(
+                [self.control_identities[dp_rank], payload], copy=copy
+            )
+
     def add_request(self, seqs: list[Sequence]):
         logger.debug(
             f"{self.label}: Add request, sequence ids: {[seq.id for seq in seqs]}"
@@ -501,23 +554,11 @@ class CoreManager:
             # Pipeline parallel (dp=1): requests enter only at stage 0, which
             # drives the pipeline downstream.
             logger.debug(f"{self.label}: Add {len(seqs)} requests to PP head 0")
-            self.input_sockets[0].send_multipart(
-                [
-                    self.engine_core_identities[0],
-                    pickle.dumps((EngineCoreRequestType.ADD, seqs)),
-                ],
-                copy=False,
-            )
+            self._send_request(0, pickle.dumps((EngineCoreRequestType.ADD, seqs)))
         elif self.local_engine_count == 1:
             # Single DP rank, send all requests
             logger.debug(f"{self.label}: Add {len(seqs)} requests to DP rank 0")
-            self.input_sockets[0].send_multipart(
-                [
-                    self.engine_core_identities[0],
-                    pickle.dumps((EngineCoreRequestType.ADD, seqs)),
-                ],
-                copy=False,
-            )
+            self._send_request(0, pickle.dumps((EngineCoreRequestType.ADD, seqs)))
         else:
             self._dispatch_to_dp_ranks(seqs)
 
@@ -589,12 +630,8 @@ class CoreManager:
             for dp_rank, rank_seqs in enumerate(dp_seqs):
                 if not rank_seqs:
                     continue
-                self.input_sockets[dp_rank].send_multipart(
-                    [
-                        self.engine_core_identities[dp_rank],
-                        pickle.dumps((EngineCoreRequestType.ADD, rank_seqs)),
-                    ],
-                    copy=False,
+                self._send_request(
+                    dp_rank, pickle.dumps((EngineCoreRequestType.ADD, rank_seqs))
                 )
                 dispatched[dp_rank] = True
                 batch_prefill_tokens = sum(
@@ -729,23 +766,15 @@ class CoreManager:
                 logger.debug(
                     f"{self.label}: Send utility command '{cmd}' to DP rank {rank}"
                 )
-                self.input_sockets[rank].send_multipart(
-                    [
-                        self.engine_core_identities[rank],
-                        pickle.dumps((EngineCoreRequestType.UTILITY, {"cmd": cmd})),
-                    ],
-                    copy=False,
+                self._send_control(
+                    rank, pickle.dumps((EngineCoreRequestType.UTILITY, {"cmd": cmd}))
                 )
         else:
             logger.debug(
                 f"{self.label}: Send utility command '{cmd}' to DP rank {dp_rank}"
             )
-            self.input_sockets[dp_rank].send_multipart(
-                [
-                    self.engine_core_identities[dp_rank],
-                    pickle.dumps((EngineCoreRequestType.UTILITY, {"cmd": cmd})),
-                ],
-                copy=False,
+            self._send_control(
+                dp_rank, pickle.dumps((EngineCoreRequestType.UTILITY, {"cmd": cmd}))
             )
 
     def abort_request(self, req_id):
@@ -772,13 +801,8 @@ class CoreManager:
             logger.debug(
                 f"{self.label}: Broadcast utility command '{cmd}' to DP rank {rank}"
             )
-            self.input_sockets[rank].send_multipart(
-                [
-                    self.engine_core_identities[rank],
-                    serialized_payload,
-                ],
-                copy=True,  # Use copy=True since we're reusing the same buffer
-            )
+            # copy=True: the same buffer is reused for every rank.
+            self._send_control(rank, serialized_payload, copy=True)
 
     def broadcast_utility_command_sync(
         self, cmd: str, timeout: float = 300.0, **kwargs
@@ -812,16 +836,24 @@ class CoreManager:
         process = self.engine_core_processes[dp_rank]
         if process is not None and process.is_alive():
             try:
-                input_socket = self.input_sockets[dp_rank]
-                if not input_socket.closed:
-                    input_socket.send_multipart(
-                        [
-                            self.engine_core_identities[dp_rank],
-                            pickle.dumps((EngineCoreRequestType.SHUTDOWN, None)),
-                        ],
-                        copy=False,
+                # Guard the socket actually used. A partial init -- an exception
+                # between the input and control handshakes -- leaves
+                # control_sockets shorter than engine_core_processes, and the
+                # IndexError would be swallowed below, reporting a clean
+                # shutdown for an engine that never received one.
+                if (
+                    dp_rank < len(self.control_sockets)
+                    and not self.control_sockets[dp_rank].closed
+                ):
+                    self._send_control(
+                        dp_rank, pickle.dumps((EngineCoreRequestType.SHUTDOWN, None))
                     )
                     logger.debug(f"{self.label}: Sent shutdown to DP rank {dp_rank}")
+                else:
+                    logger.warning(
+                        f"{self.label}: no usable control socket for DP rank "
+                        f"{dp_rank}; shutdown not delivered"
+                    )
             except Exception as e:
                 logger.debug(
                     f"{self.label}: Error sending shutdown to DP rank {dp_rank}: {e}"
@@ -851,6 +883,7 @@ class CoreManager:
 def launch_engine_core(config: Config, dp_rank: int = 0):
     input_address = get_open_zmq_ipc_path()
     output_address = get_open_zmq_ipc_path()
+    control_address = get_open_zmq_ipc_path()
     import torch
 
     # Imported here, not at module scope: EngineCore pulls the heavy
@@ -864,6 +897,9 @@ def launch_engine_core(config: Config, dp_rank: int = 0):
 
     config.parallel_config.data_parallel_rank = dp_rank
     config.parallel_config.data_parallel_rank_local = dp_rank
+    # Rides on the config rather than run_engine's signature, which every
+    # EngineCore subclass would otherwise have to thread through.
+    config.parallel_config.control_address = control_address
 
     logger.info(
         f"Creating EngineCore process: DP rank {dp_rank}, will use GPUs {dp_rank * config.tensor_parallel_size} to {(dp_rank + 1) * config.tensor_parallel_size - 1}"
@@ -881,7 +917,11 @@ def launch_engine_core(config: Config, dp_rank: int = 0):
 
     return (
         process,
-        {"input_address": input_address, "output_address": output_address},
+        {
+            "input_address": input_address,
+            "output_address": output_address,
+            "control_address": control_address,
+        },
         dp_rank,
     )
 
@@ -971,11 +1011,13 @@ class DisaggCoreManager(CoreManager):
             os.makedirs(prefill_config.torch_profiler_dir, exist_ok=True)
             os.makedirs(decode_config.torch_profiler_dir, exist_ok=True)
 
-        # Addresses for the standard CoreManager input/output sockets.
+        # Addresses for the standard CoreManager input/output/control sockets.
         prefill_input_addr = get_open_zmq_ipc_path()
         prefill_output_addr = get_open_zmq_ipc_path()
         decode_input_addr = get_open_zmq_ipc_path()
         decode_output_addr = get_open_zmq_ipc_path()
+        prefill_config.parallel_config.control_address = get_open_zmq_ipc_path()
+        decode_config.parallel_config.control_address = get_open_zmq_ipc_path()
 
         from atom.model_engine.engine_core import DecodeEngineCore, PrefillEngineCore
 
@@ -1010,13 +1052,17 @@ class DisaggCoreManager(CoreManager):
 
         import weakref
 
-        def _connect_proc(proc, in_addr, out_addr, name):
+        def _connect_proc(proc, in_addr, out_addr, ctrl_addr, name):
             proc.start()
             self.engine_core_processes.append(proc)
             in_sock = make_zmq_socket(self.ctx, in_addr, zmq.ROUTER, bind=True)
             identity, _ = in_sock.recv_multipart()
             self.input_sockets.append(in_sock)
             self.engine_core_identities.append(identity)
+            ctrl_sock = make_zmq_socket(self.ctx, ctrl_addr, zmq.ROUTER, bind=True)
+            ctrl_identity, _ = ctrl_sock.recv_multipart()
+            self.control_sockets.append(ctrl_sock)
+            self.control_identities.append(ctrl_identity)
             out_sock = make_zmq_socket(self.ctx, out_addr, zmq.PULL)
             self.output_sockets.append(out_sock)
             self.shutdown_paths.append(get_open_zmq_inproc_path())
@@ -1027,9 +1073,19 @@ class DisaggCoreManager(CoreManager):
             # PUSH socket and blocks on send() until decode connects and calls
             # recv() — they rendezvous naturally without any sequential ordering.
             _connect_proc(
-                prefill_proc, prefill_input_addr, prefill_output_addr, "prefill"
+                prefill_proc,
+                prefill_input_addr,
+                prefill_output_addr,
+                prefill_config.parallel_config.control_address,
+                "prefill",
             )
-            _connect_proc(decode_proc, decode_input_addr, decode_output_addr, "decode")
+            _connect_proc(
+                decode_proc,
+                decode_input_addr,
+                decode_output_addr,
+                decode_config.parallel_config.control_address,
+                "decode",
+            )
             self._wait_for_single_ready(idx=0)
             self._wait_for_single_ready(idx=1)
             logger.info(f"{self.label}: both EngineCores ready")
@@ -1079,10 +1135,7 @@ class DisaggCoreManager(CoreManager):
 
         # Send decode payload as-is.
         decode_payload = pickle.dumps((EngineCoreRequestType.ADD, seqs))
-        self.input_sockets[1].send_multipart(
-            [self.engine_core_identities[1], decode_payload],
-            copy=False,
-        )
+        self._send_request(1, decode_payload)
 
         # For prefill: limit each sequence to 1 output token.  Prefill discards
         # all sampled tokens (postprocess is a no-op), but setting max_tokens=1
@@ -1096,10 +1149,7 @@ class DisaggCoreManager(CoreManager):
             ps.max_tokens = 1
             prefill_seqs.append(ps)
         prefill_payload = pickle.dumps((EngineCoreRequestType.ADD, prefill_seqs))
-        self.input_sockets[0].send_multipart(
-            [self.engine_core_identities[0], prefill_payload],
-            copy=False,
-        )
+        self._send_request(0, prefill_payload)
 
     def close(self):
         super().close()

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -103,6 +103,10 @@ class CoreManager:
         self.control_sockets = []
         self.control_identities = []
         self._control_send_lock = Lock()
+        # dp_rank -> newest metrics snapshot, refreshed by the output threads
+        # from EngineCore's own periodic push. Read directly by the exporter, so
+        # scraping costs no round trip and cannot time out.
+        self.latest_metrics: dict[int, dict] = {}
 
     def __init__(self, config: Config):
         pp_size = config.pipeline_parallel_size
@@ -378,6 +382,8 @@ class CoreManager:
                                     f"{self.label}: flush_stream_batch failed: {e}",
                                     exc_info=True,
                                 )
+                    elif request_type == EngineCoreRequestType.METRICS:
+                        self.latest_metrics[dp_rank] = data
                     elif request_type == EngineCoreRequestType.UTILITY_RESPONSE:
                         self.utility_response_queue.put_nowait(data)
                     elif request_type == EngineCoreRequestType.ADD:

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -860,7 +860,7 @@ class CoreManager:
                         f"{self.label}: no usable control socket for DP rank "
                         f"{dp_rank}; shutdown not delivered"
                     )
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - teardown must not raise
                 logger.debug(
                     f"{self.label}: Error sending shutdown to DP rank {dp_rank}: {e}"
                 )

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -370,7 +370,7 @@ class CoreManager:
                                     )
                         # Batched stream dispatch: the per-seq callbacks only buffer
                         # their chunks into a thread-local; flush the whole step's
-                        # buffer into the per-request asyncio queues now (one
+                        # buffer into the per-request stream collectors now (one
                         # call_soon_threadsafe per loop). Resolved lazily by the API
                         # server to avoid the api_server <-> engine_core_mgr import
                         # cycle. No-op when no streaming request is in flight.

--- a/atom/model_engine/engine_core_protocol.py
+++ b/atom/model_engine/engine_core_protocol.py
@@ -31,3 +31,5 @@ class EngineCoreRequestType(enum.Enum):
     READY = b"\x07"
     # Response to a synchronous utility command
     UTILITY_RESPONSE = b"\x08"
+    # Unsolicited metrics snapshot, pushed by EngineCore on its own clock.
+    METRICS = b"\x09"

--- a/atom/model_engine/engine_utility.py
+++ b/atom/model_engine/engine_utility.py
@@ -45,7 +45,6 @@ class EngineUtilityHandler:
         "get_mtp_stats": "_handle_get_mtp_stats",
         "get_mtp_statistics": "_handle_get_mtp_statistics",
         "get_cache_statistics": "_handle_get_cache_statistics",
-        "get_metrics_statistics": "_handle_get_metrics_statistics",
         "abort_request": "_handle_abort_request",
     }
 
@@ -106,7 +105,7 @@ class EngineUtilityHandler:
     def _execute_utility_command(self, cmd: str, args: dict):
         import time as _time
 
-        log = logger.debug if cmd == "get_metrics_statistics" else logger.info
+        log = logger.info
         log(f"{self.label}: executing utility command: {cmd}")
         t0 = _time.monotonic()
 
@@ -320,8 +319,22 @@ class EngineUtilityHandler:
             ("UTILITY_RESPONSE", {"cmd": "get_cache_statistics", "result": result})
         )
 
-    def _handle_get_metrics_statistics(self, args: dict):
-        """Return one rank's scheduler, KV, MTP, and cache metrics."""
+    def push_metrics(self) -> None:
+        """Publish this rank's metrics snapshot on the output socket.
+
+        Pushed on the engine's own clock rather than answered on demand. The
+        pull version was a synchronous round trip with a 5s deadline fired every
+        5s from the API server; whenever the engine was busy -- a long prefill,
+        a GEMM autotune, a large batch -- it could not answer in time, so under
+        load it failed on essentially every attempt, buried the server log in
+        tracebacks, and left late replies in the response queue for the *next*
+        caller to mistake for its own. Pushing removes the deadline, and with it
+        the last off-loop writer on the control socket.
+        """
+        self.output_queue.put_nowait(("METRICS", self.collect_metrics()))
+
+    def collect_metrics(self) -> dict:
+        """One rank's scheduler, KV, MTP, and cache metrics."""
         if self.scheduler is None:
             result = {"enabled": False}
         else:
@@ -377,6 +390,4 @@ class EngineUtilityHandler:
                 "offload": offload,
             }
 
-        self.output_queue.put_nowait(
-            ("UTILITY_RESPONSE", {"cmd": "get_metrics_statistics", "result": result})
-        )
+        return result

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -395,15 +395,17 @@ class LLMEngine:
             ),
         }
 
-    def get_metrics_statistics(self, timeout: float = 5.0) -> dict[str, Any]:
-        """Return a DP-aggregated snapshot for the Prometheus exporter."""
-        responses = self.core_mgr.broadcast_utility_command_sync(
-            "get_metrics_statistics", timeout=timeout
-        )
+    def get_metrics_statistics(self) -> dict[str, Any]:
+        """Return a DP-aggregated snapshot for the Prometheus exporter.
+
+        Reads the snapshots each EngineCore pushes on its own clock, so this is
+        a local dict lookup: no round trip, no deadline, and nothing that can
+        fail just because the engine is busy.
+        """
         rank_stats = [
-            resp.get("result", resp)
-            for resp in responses
-            if resp.get("result", resp).get("enabled", False)
+            stats
+            for stats in self.core_mgr.latest_metrics.values()
+            if stats.get("enabled", False)
         ]
 
         def summed(key: str) -> int:

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -92,6 +92,37 @@ Both `ChatCompletionResponse` and `CompletionResponse` include:
 Streaming responses use the SSE (Server-Sent Events) protocol with
 `data: [DONE]\n\n` as the termination signal.
 
+#### Delivery under load
+
+The API server is a single Python process, so at high concurrency the fixed
+per-chunk cost of delivering tokens (detokenize, coroutine wakeup, JSON encode,
+socket write) can cap throughput before the GPU does. Two things keep that cost
+down, neither of which delays a token:
+
+- **Backlog merging.** Each request's chunks land in a `StreamOutputCollector`
+  (`atom/entrypoints/openai/streaming_dispatch.py`), which holds at most one
+  chunk per stream: anything arriving behind an unread one merges into it.
+  Nothing is held back waiting for more, so a consumer that keeps up sees
+  exactly one chunk per engine step and a token is never delivered later than
+  it otherwise would have been.
+- **msgspec frame encoding** (`atom/entrypoints/openai/sse.py`), roughly 5.8x
+  cheaper per frame than `json.dumps`.
+
+One consequence matters when reading benchmark output. ITL is sampled once per
+received SSE chunk (`backend_request_func.py`, `benchmark_serving.py`), so
+merging N tokens into one chunk removes N-1 samples and stretches the gaps that
+remain: **every ITL statistic - mean, median and p99 alike - inflates by roughly
+the merge factor**, without any token being delivered later. Measured on
+Qwen3.5-27B-FP8 tp4 at concurrency 2048, mean ITL read 191.8 ms against a TPOT
+of 126.6 ms, while the same workload with merging disabled read 122.9 ms against
+a TPOT of 123.3 ms.
+
+**Compare TPOT, not ITL, whenever merging is active.** It is the only
+token-normalized latency in the report (`latency - ttft` over `output_len - 1`),
+so it stays honest at any merge factor. The ratio ITL/TPOT is itself the useful
+number: it *is* the merge factor, and a value near 1.0 means the frontend is
+keeping up and nothing ever merged.
+
 ### Server startup
 
 ```bash
@@ -661,6 +692,8 @@ server without modification.
 | File | Description |
 |------|-------------|
 | `atom/entrypoints/openai_server.py` | OpenAI-compatible API server (FastAPI + Uvicorn) |
+| `atom/entrypoints/openai/streaming_dispatch.py` | `StreamBatchDispatcher` (per-engine-step cross-thread dispatch) and `StreamOutputCollector` (per-request delivery, folds a backlog) |
+| `atom/entrypoints/openai/sse.py` | SSE frame encoding (`data_frame`, `event_frame`) on a shared msgspec encoder |
 | `atom/model_engine/llm_engine.py` | `LLMEngine` programmatic API |
 | `atom/sampling_params.py` | `SamplingParams` dataclass |
 | `atom/model_engine/arg_utils.py` | `EngineArgs` CLI argument definitions and engine factory |

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -14,6 +14,7 @@ from atom.entrypoints.openai.serving_chat import (
     stream_chat_response,
     stream_chat_response_fanout,
 )
+from atom.entrypoints.openai.streaming_dispatch import StreamOutputCollector
 
 # ============================================================================
 # normalize_chat_tools Tests
@@ -296,12 +297,12 @@ class TestStreamingRoleChunkContent:
 
     def test_single_stream_role_chunk_has_empty_content(self):
         async def run():
-            queue = asyncio.Queue()
-            await queue.put({"text": "Hi", "token_ids": [1], "finished": True})
+            collector = StreamOutputCollector("req-1")
+            collector.put_nowait({"text": "Hi", "token_ids": [1], "finished": True})
             gen = stream_chat_response(
                 request_id="req-1",
                 model="model",
-                stream_queue=queue,
+                stream_collector=collector,
                 seq_id=0,
                 num_prompt_tokens=1,
                 cleanup_fn=lambda *a, **k: None,
@@ -319,17 +320,17 @@ class TestStreamingRoleChunkContent:
 
     def test_fanout_stream_role_chunks_have_empty_content(self):
         async def run():
-            queue = asyncio.Queue()
-            # Empty text + finished=False means each queue item triggers
+            collector = StreamOutputCollector("req-2")
+            # Empty text + finished=False means each pending chunk triggers
             # *only* the role-announcement yield (no content/finish chunks
             # in between), so the first two yields are guaranteed to be
             # sibling 0's and sibling 1's role chunks respectively.
-            await queue.put((0, {"text": "", "token_ids": [], "finished": False}))
-            await queue.put((1, {"text": "", "token_ids": [], "finished": False}))
+            collector.put_nowait((0, {"text": "", "token_ids": [], "finished": False}))
+            collector.put_nowait((1, {"text": "", "token_ids": [], "finished": False}))
             gen = stream_chat_response_fanout(
                 request_id="req-2",
                 model="model",
-                shared_queue=queue,
+                shared_collector=collector,
                 seq_ids=[0, 1],
                 num_prompt_tokens=1,
                 cleanup_fn=lambda *a, **k: None,

--- a/tests/entrypoints/test_sse.py
+++ b/tests/entrypoints/test_sse.py
@@ -1,0 +1,57 @@
+import json
+
+from atom.entrypoints.openai.sse import data_frame, event_frame
+
+CHAT_DELTA = {
+    "id": "chatcmpl-abc",
+    "object": "chat.completion.chunk",
+    "created": 1786000000,
+    "model": "DeepSeek-V4-Flash",
+    "choices": [
+        {
+            "index": 0,
+            "delta": {"content": " throughput"},
+            "finish_reason": None,
+            "logprobs": None,
+        }
+    ],
+}
+
+
+def _payload_of(frame: str, prefix: str) -> dict:
+    assert frame.startswith(prefix)
+    assert frame.endswith("\n\n")
+    return json.loads(frame[len(prefix) : -2])
+
+
+def test_data_frame_matches_the_json_dumps_it_replaced():
+    frame = data_frame(CHAT_DELTA)
+
+    assert frame == f"data: {json.dumps(CHAT_DELTA, separators=(',', ':'))}\n\n"
+    assert _payload_of(frame, "data: ") == CHAT_DELTA
+
+
+def test_event_frame_carries_the_event_name():
+    frame = event_frame("message_start", {"type": "message_start"})
+
+    assert frame.startswith("event: message_start\ndata: ")
+    assert _payload_of(frame, "event: message_start\ndata: ") == {
+        "type": "message_start"
+    }
+
+
+def test_frames_round_trip_unicode_and_control_characters():
+    payload = {"text": '你好 "🎉"\n\tdone', "n": None, "ok": True, "ratio": 0.5}
+
+    assert _payload_of(data_frame(payload), "data: ") == payload
+    # A raw newline inside the payload would split the frame and corrupt the
+    # stream, so the encoder has to escape it.
+    assert "\n" not in data_frame(payload)[:-2]
+
+
+def test_encoder_is_shared_across_calls():
+    """A per-call encoder would put the allocation back on the hot path."""
+    first = data_frame(CHAT_DELTA)
+    second = data_frame(CHAT_DELTA)
+
+    assert first == second

--- a/tests/entrypoints/test_streaming_dispatch.py
+++ b/tests/entrypoints/test_streaming_dispatch.py
@@ -3,6 +3,8 @@ import asyncio
 from atom.entrypoints.openai.streaming_dispatch import (
     IncrementalStreamDetokenizer,
     StreamBatchDispatcher,
+    StreamOutputCollector,
+    merge_chunk,
 )
 
 
@@ -18,6 +20,39 @@ class _ImmediateLoop:
     def call_soon_threadsafe(self, callback, *args):
         self.calls.append((callback, args))
         callback(*args)
+
+    call_soon = call_soon_threadsafe
+
+
+class _RecordingLoop:
+    """Loop stub that defers callbacks so each round is one loop iteration."""
+
+    def __init__(self):
+        self.pending = []
+
+    def call_soon_threadsafe(self, callback, *args):
+        self.pending.append((callback, args))
+
+    call_soon = call_soon_threadsafe
+
+    def run(self):
+        rounds = 0
+        while self.pending:
+            batch, self.pending = self.pending, []
+            for callback, args in batch:
+                callback(*args)
+            rounds += 1
+        return rounds
+
+
+def _resolve(coro):
+    """Drive a coroutine that must complete without ever suspending."""
+    try:
+        coro.send(None)
+    except StopIteration as stop:
+        return stop.value
+    coro.close()
+    raise AssertionError("coroutine suspended when it should have had a value ready")
 
 
 def test_incremental_detokenizer_holds_incomplete_utf8():
@@ -36,13 +71,13 @@ def test_dispatcher_batches_direct_and_tagged_chunks_per_loop():
 
     dispatcher.enqueue(
         loop=loop,
-        queue=direct_queue,
+        collector=direct_queue,
         state_key="request-1",
         chunk={"token_ids": [ord("A")], "finished": True},
     )
     dispatcher.enqueue(
         loop=loop,
-        queue=tagged_queue,
+        collector=tagged_queue,
         state_key=("request-2", 0),
         chunk={"token_ids": [ord("B")], "finished": True},
         tag=0,
@@ -63,14 +98,14 @@ def test_dispatcher_keeps_fanout_detokenizer_state_separate():
 
     dispatcher.enqueue(
         loop=loop,
-        queue=queue,
+        collector=queue,
         state_key=("request", 0),
         chunk={"token_ids": [0xE4], "finished": False},
         tag=0,
     )
     dispatcher.enqueue(
         loop=loop,
-        queue=queue,
+        collector=queue,
         state_key=("request", 1),
         chunk={"token_ids": [ord("X")], "finished": True},
         tag=1,
@@ -82,7 +117,7 @@ def test_dispatcher_keeps_fanout_detokenizer_state_separate():
 
     dispatcher.enqueue(
         loop=loop,
-        queue=queue,
+        collector=queue,
         state_key=("request", 0),
         chunk={"token_ids": [0xBD, 0xA0], "finished": True},
         tag=0,
@@ -100,7 +135,7 @@ def test_discard_request_drops_partial_direct_and_fanout_state():
     for state_key in ("request", ("request", 0)):
         dispatcher.enqueue(
             loop=loop,
-            queue=queue,
+            collector=queue,
             state_key=state_key,
             chunk={"token_ids": [0xE4], "finished": False},
         )
@@ -110,7 +145,7 @@ def test_discard_request_drops_partial_direct_and_fanout_state():
     for state_key in ("request", ("request", 0)):
         dispatcher.enqueue(
             loop=loop,
-            queue=queue,
+            collector=queue,
             state_key=state_key,
             chunk={"token_ids": [ord("A")], "finished": True},
         )
@@ -120,3 +155,188 @@ def test_discard_request_drops_partial_direct_and_fanout_state():
     assert queue.get_nowait()["text"] == ""
     assert queue.get_nowait()["text"] == "A"
     assert queue.get_nowait()["text"] == "A"
+
+
+def test_collector_hands_over_a_lone_chunk_untouched():
+    """A consumer that keeps up must see exactly what the queue used to give."""
+    collector = StreamOutputCollector("request-1")
+    chunk = {"token_ids": [1], "text": "a", "finished": False}
+    collector.put_nowait(chunk)
+
+    assert _resolve(collector.get()) is chunk
+
+
+def test_collector_merges_a_backlog_into_one_chunk():
+    collector = StreamOutputCollector("request-1")
+    collector.put_nowait({"token_ids": [1], "text": "he", "finished": False})
+    collector.put_nowait(
+        {"token_ids": [2, 3], "text": "ll", "finished": False, "num_cached_tokens": 7}
+    )
+    collector.put_nowait(
+        {
+            "token_ids": [4],
+            "text": "o",
+            "finished": True,
+            "finish_reason": "stop",
+            "kv_transfer_params": {"a": 1},
+        }
+    )
+
+    chunk = _resolve(collector.get())
+
+    assert chunk["token_ids"] == [1, 2, 3, 4]
+    assert chunk["text"] == "hello"
+    assert chunk["finished"] is True
+    assert chunk["finish_reason"] == "stop"
+    assert chunk["kv_transfer_params"] == {"a": 1}
+    # Landed on a middle chunk, so a naive "take the last one" would drop it.
+    assert chunk["num_cached_tokens"] == 7
+
+
+def test_collector_carries_trailing_fields_from_earlier_chunks():
+    collector = StreamOutputCollector("request-1")
+    collector.put_nowait(
+        {"token_ids": [1], "text": "a", "kv_transfer_params": {"a": 1}}
+    )
+    collector.put_nowait({"token_ids": [2], "text": "b", "finished": True})
+
+    chunk = _resolve(collector.get())
+
+    assert chunk["kv_transfer_params"] == {"a": 1}
+
+
+def test_collector_merges_fanout_siblings_independently():
+    collector = StreamOutputCollector("request-1")
+    collector.put_nowait((0, {"token_ids": [1], "text": "a"}))
+    collector.put_nowait((1, {"token_ids": [9], "text": "x"}))
+    collector.put_nowait((0, {"token_ids": [2], "text": "b", "finished": True}))
+
+    first_tag, first = _resolve(collector.get())
+    second_tag, second = _resolve(collector.get())
+
+    assert (first_tag, first["text"], first["token_ids"]) == (0, "ab", [1, 2])
+    assert (second_tag, second["text"], second["token_ids"]) == (1, "x", [9])
+
+
+def test_collector_waits_only_when_nothing_is_pending():
+    async def scenario():
+        collector = StreamOutputCollector("request-1")
+        getter = asyncio.ensure_future(collector.get())
+        await asyncio.sleep(0)
+        assert not getter.done()
+
+        collector.put_nowait({"token_ids": [1], "text": "a"})
+        assert (await getter)["text"] == "a"
+
+        # Drained again: the readiness flag must have been cleared, or the next
+        # get() would spin instead of waiting.
+        again = asyncio.ensure_future(collector.get())
+        await asyncio.sleep(0)
+        assert not again.done()
+        again.cancel()
+
+    asyncio.run(scenario())
+
+
+def _stream_through_collector(payload: bytes, drain_every: int):
+    """Feed ``payload`` one byte per engine step, draining every N steps."""
+    dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
+    loop = _ImmediateLoop()
+    collector = StreamOutputCollector("request-1")
+
+    texts = []
+    token_ids = []
+    terminal = 0
+    for index, byte in enumerate(payload):
+        last = index == len(payload) - 1
+        dispatcher.enqueue(
+            loop=loop,
+            collector=collector,
+            state_key="request-1",
+            chunk={"token_ids": [byte], "finished": last},
+        )
+        dispatcher.flush()
+        if (index + 1) % drain_every == 0 or last:
+            chunk = _resolve(collector.get())
+            texts.append(chunk["text"])
+            token_ids.extend(chunk["token_ids"])
+            terminal += bool(chunk.get("finished"))
+    return "".join(texts), token_ids, terminal
+
+
+def test_merging_is_identical_to_unmerged_delivery():
+    payload = "你好, world! 🎉".encode()
+    reference_text, reference_tokens, reference_terminal = _stream_through_collector(
+        payload, 1
+    )
+
+    assert reference_text == payload.decode()
+    assert reference_tokens == list(payload)
+    assert reference_terminal == 1
+
+    for drain_every in (2, 3, 5, len(payload) * 2):
+        text, tokens, terminal = _stream_through_collector(payload, drain_every)
+        assert text == reference_text
+        assert tokens == reference_tokens
+        # Merging must never duplicate or swallow the end of the stream.
+        assert terminal == 1
+
+
+def test_a_step_is_delivered_in_a_single_loop_callback():
+    """Splitting a step across callbacks lets the next step overtake its tail.
+
+    The output thread schedules each step with call_soon_threadsafe. If a
+    delivery re-armed itself for the rest of the step, step N+1 could be run
+    first, so a collector would see N+1's chunk before N's leftovers -- folding
+    would then concatenate deltas out of order and an end-of-stream landing
+    before a straggler would be overwritten by it.
+    """
+    dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
+    loop = _RecordingLoop()
+    collectors = [StreamOutputCollector(f"request-{i}") for i in range(300)]
+
+    for index, collector in enumerate(collectors):
+        dispatcher.enqueue(
+            loop=loop,
+            collector=collector,
+            state_key=f"request-{index}",
+            chunk={"token_ids": [ord("A")], "finished": True},
+        )
+    dispatcher.flush()
+
+    assert loop.run() == 1
+    for collector in collectors:
+        assert _resolve(collector.get())["text"] == "A"
+
+
+def test_two_steps_keep_their_order_within_one_stream():
+    """The end of a stream must never be overtaken by an earlier step's chunk."""
+    dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
+    loop = _RecordingLoop()
+    collector = StreamOutputCollector("request-1")
+
+    for byte, finished in ((ord("a"), False), (ord("b"), True)):
+        dispatcher.enqueue(
+            loop=loop,
+            collector=collector,
+            state_key="request-1",
+            chunk={"token_ids": [byte], "finished": finished},
+        )
+        dispatcher.flush()
+    loop.run()
+
+    chunk = _resolve(collector.get())
+    assert chunk["text"] == "ab"
+    assert chunk["finished"] is True
+
+
+def test_merge_keeps_end_of_stream_and_never_extends_the_engines_list():
+    """A swallowed terminal flag hangs its client; a mutated list corrupts the engine."""
+    engine_tokens = [1]
+    into = {"token_ids": engine_tokens, "text": "a", "finished": True}
+    merge_chunk(into, {"token_ids": [2], "text": "b", "finished": False})
+
+    assert into["finished"] is True
+    assert into["text"] == "ab"
+    assert into["token_ids"] == [1, 2]
+    assert engine_tokens == [1]


### PR DESCRIPTION
Four independent fixes on the streaming/serving path, found while trying to push
`ATOM_SSE_COALESCE_MS` (from #1837) further. Each commit stands alone and each was
verified on Qwen3.5-27B-FP8 tp4.

The first is a correctness bug that wedges the whole server. The other three are
performance/observability work, and one of them **measured as no win** — that is
reported below rather than buried.

## 1. `fix(engine)`: control traffic gets its own socket

A ZMQ socket is not thread-safe, and `CoreManager` was sending on one from three
threads at once: `add_request` from the API server's event loop, utility commands
from an executor thread (the Prometheus refresh via `asyncio.to_thread`), and
shutdown from the per-rank output threads. Two unserialized `send_multipart` calls
interleave their frames, so the DEALER on the other end reads a routing identity
where a payload should be:

```
Exception in thread Thread-2 (process_input_sockets):
  request_type, reqs = pickle.loads(obj)
_pickle.UnpicklingError: invalid load key, '\x00'.
```

`'\x00'` is the first byte of a ZMQ-generated identity frame — the corruption
identifies itself.

Nothing recovers from this. `process_input_sockets` is the only way requests reach
the engine, so once it dies the busy loop spins on a forever-empty input queue, the
workers idle, and every later client hangs — with no error on any log but that
thread's own traceback. Observed at concurrency 2048: the input thread died on
request 3207 of 4096 and the server wedged, GPUs at 0% while 2048 clients waited.

Rather than serialize the sends, the channel is split. Requests keep
`input_sockets`, now single-writer, so admission needs no synchronization at all
(`pickle.dumps` + `send_multipart` is ~49 us and the admission path is hot).
Utility/abort/shutdown move to a per-engine control socket, which does take a lock;
none of its writers runs per request, so that cost never lands on admission. Both
sockets are served by the one input thread.

The input thread also no longer dies on a frame it cannot decode — it logs and
keeps serving. A dropped frame costs one request; a dead thread costs the server.

**Verified:** concurrency 2048, 4096 requests → 4096/4096 successful, zero
input-thread deaths, zero undecodable frames.

## 2. `perf(metrics)`: engine pushes snapshots instead of being polled

The Prometheus exporter fired a synchronous utility command every 5 s with a 5 s
deadline. Utility commands are serviced by EngineCore's busy loop, so whenever the
engine was actually busy — long prefill, GEMM autotune, large batch — it could not
answer in time. Under load that was the normal outcome, not an edge case: **58
timeouts in one concurrency-2048 run**, each with a full traceback.

Three costs: monitoring went blind exactly when it mattered; the tracebacks buried
the server log (they were the only `Traceback`s in a log being scanned for an
unrelated crash); and a reply arriving after its deadline stayed in the response
queue for the *next* caller to drain, so a scrape could report another scrape's
numbers.

Inverted: each EngineCore publishes its snapshot on its own clock over the output
socket it already owns, CoreManager's output thread keeps the newest per rank, and
`get_metrics_statistics()` becomes a local dict read. This also removes the last
off-loop writer on the control socket, so `_refresh_metrics_once` runs inline on the
event loop instead of via `asyncio.to_thread`.

**Verified:** concurrency 512, 2048 requests → zero timeouts, zero refresh errors,
snapshot 1.3 s old when the run ended.

## 3. `perf(frontend)`: merge backlogged SSE chunks, encode with msgspec

The API server is one Python process under one GIL, so the fixed per-chunk cost of
delivering a token — coroutine wakeup, queue hop, JSON encode, socket write — is
what caps streaming throughput once the GPU is fast enough.

`StreamOutputCollector` replaces the per-request `asyncio.Queue`. A queue hands over
one item per `get()`, so a consumer that has fallen behind needs one wakeup, one
encode and one write per queued chunk, and the backlog is unbounded. The collector
holds at most one chunk per stream; anything arriving behind an unread one merges
into it. Merging only ever covers chunks that were **already waiting** — with a
consumer that keeps up nothing merges and delivery is identical to the queue it
replaces — so a token arrives no later than before, and in fact earlier, since it no
longer waits for a second round trip. The shape follows vLLM's
`RequestOutputCollector` and SGLang's `out_list` coalescing.

Frames encode through a shared `msgspec` encoder rather than `json.dumps`: 0.25 vs
1.47 us on a chat delta, 5.8x.

Two invariants are load-bearing and now have tests:

- **A step is delivered in one loop callback, never split.** Re-arming the remainder
  with `call_soon` lets the output thread schedule the next step in between, so a
  collector receives step N+1's chunk before step N's leftovers — deltas then merge
  in the wrong order and an end-of-stream that lands before a straggler is
  overwritten by it, hanging that client for good.
- **The merge takes end-of-stream from either chunk**, rather than trusting
  position. Swallowing that flag is far too expensive a failure to rest on an
  ordering assumption.

### This commit measured as no throughput win — please read before merging

Merging does engage (~1.9 tokens per delivered chunk at concurrency 2048), but
**frontend CPU over an identical workload is within noise of `main`: 251.6 vs 252.8
CPU-s (−0.46%)**. On hardware this size the per-chunk costs it removes are not the
bulk of frontend CPU, and detokenization — which is — still runs per chunk.

It is included because the correctness properties are worth having on their own (a
bounded per-stream backlog, and the two invariants above now pinned by tests), and
because the cost it removes scales with GPU speed. If reviewers would rather not
carry an unproven perf change, **this commit can be dropped without touching the
other three.**

## 4. `docs(serving)`: the ITL that streaming merges distort

ITL is sampled per received SSE chunk, so merging N tokens into one removes N−1
samples and inflates mean, median and p99 alike by roughly the merge factor —
**with no token delivered later**. Someone comparing ITL across commit 3 would
otherwise read a 56% regression that is entirely a sampling artifact: the measured
pair is 191.8 vs 122.9 ms ITL while TPOT moved 126.6 vs 123.3.

TPOT is the only token-normalized latency in the benchmark report and is what
should be compared. `ITL/TPOT` is itself the merge factor, so a value near 1.0 says
the frontend kept up and nothing ever merged.

## Testing

- `bash .github/scripts/run_unit_tests.sh` → **1365 passed, 52 skipped, 0 failed**
- `black --check .` clean
- `ruff`: 13 findings land in this diff's context, all pre-existing `PLW0602`
  (`global` for a name that is never assigned). The three lines this branch touches
  carry *fewer* than `main` does, because `_stream_queues` — a write-only registry
  with no readers anywhere in the repo — is removed.
- New tests: `tests/entrypoints/test_sse.py` (4), and
  `tests/entrypoints/test_streaming_dispatch.py` grows to 13, including the two
  ordering invariants above.

All e2e verification above ran on Qwen3.5-27B-FP8 tp4 on MI355X.
