### PR TITLE
perf(benchmark): batch the tokenizer calls that build the random dataset (5.25x)

### DIFF
--- a/atom/benchmarks/benchmark_serving.py
+++ b/atom/benchmarks/benchmark_serving.py
@@ -35,9 +35,10 @@ import os
 import random
 import time
 import warnings
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
+from datetime import datetime, timezone
+from typing import Any
 
 import aiohttp
 import numpy as np
@@ -74,22 +75,97 @@ class BenchmarkMetrics:
     mean_ttft_ms: float
     median_ttft_ms: float
     std_ttft_ms: float
-    percentiles_ttft_ms: List[Tuple[float, float]]
+    percentiles_ttft_ms: list[tuple[float, float]]
     mean_tpot_ms: float
     median_tpot_ms: float
     std_tpot_ms: float
-    percentiles_tpot_ms: List[Tuple[float, float]]
+    percentiles_tpot_ms: list[tuple[float, float]]
     mean_itl_ms: float
     median_itl_ms: float
     std_itl_ms: float
-    percentiles_itl_ms: List[Tuple[float, float]]
+    percentiles_itl_ms: list[tuple[float, float]]
     # E2EL stands for end-to-end latency per request.
     # It is the time taken on the client side from sending
     # a request to receiving a complete response.
     mean_e2el_ms: float
     median_e2el_ms: float
     std_e2el_ms: float
-    percentiles_e2el_ms: List[Tuple[float, float]]
+    percentiles_e2el_ms: list[tuple[float, float]]
+
+
+# Prompts per tokenizer call while generating the random dataset. Large enough
+# that the fast tokenizer's internal batching is what dominates, small enough
+# that a batch's encodings are not held for the whole dataset.
+_TOKENIZE_BATCH = 4096
+# How many decode/encode round trips a prompt gets to reach its target length
+# before the benchmark accepts whatever length it has.
+_LENGTH_FIX_ROUNDS = 10
+
+
+def _round_trip_prompts(
+    tokenizer: PreTrainedTokenizerBase,
+    rng: np.random.Generator,
+    token_id_lists: list[list[int]],
+    target_lens: list[int],
+) -> tuple[list[str], list[int]]:
+    """Decode ids to text, adjusting until each re-encodes to its target length.
+
+    Decoding is not injective: N consecutive ids can encode back to a different
+    number of tokens (for GPT2Tokenizer, [6880, 6881] -> 'Ġcallshere' ->
+    [1650, 939, 486]), so a prompt has to be re-encoded and padded or truncated
+    until it round-trips at the length the benchmark asked for. Measured on a
+    real tokenizer the first re-encode fails for essentially every prompt --
+    4022 encodes for 2000 prompts -- so the loop below runs at least twice.
+
+    Both directions are issued as whole batches. A fast tokenizer parallelises a
+    batch internally, and one call per prompt forfeits that plus a Python/Rust
+    crossing each time: 5.0x on 2000 prompts at input_len 1024.
+
+    Returns the prompts and the token length each one actually encodes to, which
+    equals its target unless a prompt ran out of rounds without converging.
+    """
+    prompts = tokenizer.batch_decode(token_id_lists)
+    token_lens = [0] * len(prompts)
+    pending = list(range(len(prompts)))
+
+    for _ in range(_LENGTH_FIX_ROUNDS):
+        if not pending:
+            break
+        encoded = tokenizer([prompts[i] for i in pending], add_special_tokens=False)[
+            "input_ids"
+        ]
+        unresolved: list[int] = []
+        adjusted: list[list[int]] = []
+        for slot, i in enumerate(pending):
+            ids, target = encoded[slot], target_lens[i]
+            if len(ids) == target:
+                token_lens[i] = target
+                continue
+            if len(ids) < target:
+                ids = (
+                    ids
+                    + rng.integers(
+                        0, tokenizer.vocab_size, size=target - len(ids)
+                    ).tolist()
+                )
+            else:
+                ids = ids[:target]
+            unresolved.append(i)
+            adjusted.append(ids)
+        for i, text in zip(unresolved, tokenizer.batch_decode(adjusted)):
+            prompts[i] = text
+        pending = unresolved
+
+    if pending:
+        # Out of rounds. Report the length these prompts have rather than the
+        # target they never reached, so the mismatch statistic stays honest.
+        encoded = tokenizer([prompts[i] for i in pending], add_special_tokens=False)[
+            "input_ids"
+        ]
+        for slot, i in enumerate(pending):
+            token_lens[i] = len(encoded[slot])
+
+    return prompts, token_lens
 
 
 def sample_random_requests(
@@ -101,10 +177,14 @@ def sample_random_requests(
     tokenizer: PreTrainedTokenizerBase,
     use_chat_template: bool = False,
     apply_chat_template_fn: Callable = lambda x: x,
-) -> List[Tuple[str, int, int]]:
-    prefix_token_ids = np.random.randint(
-        0, tokenizer.vocab_size, size=prefix_len
-    ).tolist()
+    seed: int = 0,
+) -> list[tuple[str, int, int]]:
+    # A private generator rather than the global numpy one: sharing that makes
+    # the dataset depend on whatever else drew from it first, so re-running the
+    # same command need not produce the same prompts.
+    rng = np.random.default_rng(seed)
+
+    prefix_token_ids = rng.integers(0, tokenizer.vocab_size, size=prefix_len).tolist()
 
     if use_chat_template:
         chat_template_dummy = apply_chat_template_fn(
@@ -119,44 +199,48 @@ def sample_random_requests(
     def sample_uniform(seq_len):
         lower = int(seq_len * range_ratio)
         upper = seq_len
-        seq_lens = np.random.randint(lower, upper + 1, size=num_prompts).tolist()
-        return seq_lens
+        return rng.integers(lower, upper + 1, size=num_prompts).tolist()
 
     input_lens = sample_uniform(input_len)
     output_lens = sample_uniform(output_len)
-    offsets = np.random.randint(0, tokenizer.vocab_size, size=num_prompts)
+    offsets = rng.integers(0, tokenizer.vocab_size, size=num_prompts)
 
     input_requests = []
     mismatches = []
-    for i in range(num_prompts):
-        tgt_prompt_len = prefix_len + input_lens[i]
-        prompt_token_ids = prefix_token_ids + [
-            (offsets[i] + i + j) % tokenizer.vocab_size for j in range(input_lens[i])
+    # Generated a batch at a time so the tokenizer calls can be batched; the
+    # batch also bounds how many encodings are held at once.
+    for start in range(0, num_prompts, _TOKENIZE_BATCH):
+        stop = min(start + _TOKENIZE_BATCH, num_prompts)
+        token_id_lists = [
+            prefix_token_ids
+            + (
+                (offsets[i] + i + np.arange(input_lens[i])) % tokenizer.vocab_size
+            ).tolist()
+            for i in range(start, stop)
         ]
-        prompt = tokenizer.decode(prompt_token_ids)
+        target_lens = [prefix_len + input_lens[i] for i in range(start, stop)]
 
-        max_retries = 10
-        for _ in range(max_retries):
-            prompt_token_ids = tokenizer.encode(prompt, add_special_tokens=False)
-            if len(prompt_token_ids) < tgt_prompt_len:
-                num_extras = tgt_prompt_len - len(prompt_token_ids)
-                prompt_token_ids.extend(
-                    np.random.randint(0, tokenizer.vocab_size, size=num_extras).tolist()
-                )
-            elif len(prompt_token_ids) > tgt_prompt_len:
-                prompt_token_ids = prompt_token_ids[:tgt_prompt_len]
-            else:
-                break
-            prompt = tokenizer.decode(prompt_token_ids)
+        prompts, prompt_lens = _round_trip_prompts(
+            tokenizer, rng, token_id_lists, target_lens
+        )
 
         if use_chat_template:
-            prompt = apply_chat_template_fn(
-                [{"role": "user", "content": prompt}],
-            )
+            # The template rewrites every prompt, so the lengths measured above
+            # no longer describe what the server will receive.
+            prompts = [
+                apply_chat_template_fn([{"role": "user", "content": prompt}])
+                for prompt in prompts
+            ]
+            prompt_lens = [
+                len(ids)
+                for ids in tokenizer(prompts, add_special_tokens=False)["input_ids"]
+            ]
 
-        prompt_len = len(tokenizer.encode(prompt, add_special_tokens=False))
-        mismatches.append(prompt_len - tgt_prompt_len)
-        input_requests.append((prompt, prompt_len, output_lens[i], None))
+        for slot, i in enumerate(range(start, stop)):
+            mismatches.append(prompt_lens[slot] - target_lens[slot])
+            input_requests.append(
+                (prompts[slot], prompt_lens[slot], output_lens[i], None)
+            )
 
     header_str = f'{"-"*19}  Input/Output Length Statistics  {"-"*19}'
     print(header_str)
@@ -179,10 +263,10 @@ def sample_random_requests(
 
 
 async def get_request(
-    input_requests: List[Tuple[str, int, int]],
+    input_requests: list[tuple[str, int, int]],
     request_rate: float,
     burstiness: float = 1.0,
-) -> AsyncGenerator[Tuple[str, int, int], None]:
+) -> AsyncGenerator[tuple[str, int, int], None]:
     """
     Asynchronously generates requests at a specified rate
     with OPTIONAL burstiness.
@@ -224,23 +308,23 @@ async def get_request(
 
 
 def calculate_metrics(
-    input_requests: List[Tuple[str, int, int]],
-    outputs: List[RequestFuncOutput],
+    input_requests: list[tuple[str, int, int]],
+    outputs: list[RequestFuncOutput],
     dur_s: float,
     tokenizer: PreTrainedTokenizerBase,
-    selected_percentile_metrics: List[str],
-    selected_percentiles: List[float],
-    goodput_config_dict: Dict[str, float],
-) -> Tuple[BenchmarkMetrics, List[int]]:
-    actual_output_lens: List[int] = []
+    selected_percentile_metrics: list[str],
+    selected_percentiles: list[float],
+    goodput_config_dict: dict[str, float],
+) -> tuple[BenchmarkMetrics, list[int]]:
+    actual_output_lens: list[int] = []
     total_input = 0
     completed = 0
     good_completed = 0
-    itls: List[float] = []
-    tpots: List[float] = []
-    all_tpots: List[float] = []
-    ttfts: List[float] = []
-    e2els: List[float] = []
+    itls: list[float] = []
+    tpots: list[float] = []
+    all_tpots: list[float] = []
+    ttfts: list[float] = []
+    e2els: list[float] = []
     for i in range(len(outputs)):
         if outputs[i].success:
             output_len = outputs[i].output_tokens
@@ -344,7 +428,7 @@ def calculate_metrics(
     return metrics, actual_output_lens
 
 
-async def get_spec_stats(base_url: str) -> Optional[dict]:
+async def get_spec_stats(base_url: str) -> dict | None:
     """Fetch speculative-decoding statistics from the ATOM server.
 
     Returns the ``/debug/mtp_stats`` payload (which includes
@@ -374,20 +458,20 @@ async def benchmark(
     model_id: str,
     model_name: str,
     tokenizer: PreTrainedTokenizerBase,
-    input_requests: List[Tuple[str, int, int]],
-    logprobs: Optional[int],
+    input_requests: list[tuple[str, int, int]],
+    logprobs: int | None,
     best_of: int,
     request_rate: float,
     burstiness: float,
     disable_tqdm: bool,
     num_warmups: int,
     profile: bool,
-    selected_percentile_metrics: List[str],
-    selected_percentiles: List[str],
+    selected_percentile_metrics: list[str],
+    selected_percentiles: list[str],
     ignore_eos: bool,
-    goodput_config_dict: Dict[str, float],
-    max_concurrency: Optional[int],
-    lora_modules: Optional[List[str]],
+    goodput_config_dict: dict[str, float],
+    max_concurrency: int | None,
+    lora_modules: list[str] | None,
 ):
     if backend in ASYNC_REQUEST_FUNCS:
         request_func = ASYNC_REQUEST_FUNCS[backend]
@@ -489,7 +573,7 @@ async def benchmark(
     print("Starting main benchmark run...")
 
     benchmark_start_time = time.perf_counter()
-    tasks: List[asyncio.Task] = []
+    tasks: list[asyncio.Task] = []
     async for request in get_request(input_requests, request_rate, burstiness):
         prompt, prompt_len, output_len, mm_content = request
         req_model_id, req_model_name = model_id, model_name
@@ -514,7 +598,7 @@ async def benchmark(
                 limited_request_func(request_func_input=request_func_input, pbar=pbar)
             )
         )
-    outputs: List[RequestFuncOutput] = await asyncio.gather(*tasks)
+    outputs: list[RequestFuncOutput] = await asyncio.gather(*tasks)
 
     if pbar is not None:
         pbar.close()
@@ -662,7 +746,7 @@ def check_goodput_args(args):
                 raise ValueError(
                     f"Invalid metric name found, {slo_name}: {slo_val}. "
                     "The service level objective name should be one of "
-                    f"{str(VALID_NAMES)}. "
+                    f"{VALID_NAMES!s}. "
                 )
             if slo_val < 0:
                 raise ValueError(
@@ -690,7 +774,7 @@ def parse_goodput(slo_pairs):
 
 
 def save_to_pytorch_benchmark_format(
-    args: argparse.Namespace, results: Dict[str, Any], file_name: str
+    args: argparse.Namespace, results: dict[str, Any], file_name: str
 ) -> None:
     metrics = [
         "median_ttft_ms",
@@ -771,6 +855,7 @@ def main(args: argparse.Namespace):
             tokenizer=tokenizer,
             apply_chat_template_fn=apply_chat_template_fn,
             use_chat_template=args.use_chat_template,
+            seed=args.seed,
         )
 
     else:
@@ -809,10 +894,13 @@ def main(args: argparse.Namespace):
 
     # Save config and results to json
     if args.save_result:
-        result_json: Dict[str, Any] = {}
+        result_json: dict[str, Any] = {}
 
         # Setup
-        current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+        # astimezone() keeps the stamp in the operator's own timezone, which is
+        # how a result file is read, while staying timezone-aware.
+        current_dt = datetime.now(timezone.utc).astimezone().strftime("%Y%m%d-%H%M%S")
         result_json["date"] = current_dt
         result_json["backend"] = backend
         result_json["model_id"] = model_id
@@ -863,7 +951,7 @@ def main(args: argparse.Namespace):
             if args.max_concurrency is not None
             else ""
         )
-        file_name = f"{backend}-{args.request_rate}qps{max_concurrency_str}-{base_model_id}-{current_dt}.json"  # noqa
+        file_name = f"{backend}-{args.request_rate}qps{max_concurrency_str}-{base_model_id}-{current_dt}.json"
         if args.result_filename:
             file_name = args.result_filename
         if args.result_dir:
@@ -935,7 +1023,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tokenizer",
         type=str,
-        help="Name or path of the tokenizer, if not using the default tokenizer.",  # noqa: E501
+        help="Name or path of the tokenizer, if not using the default tokenizer.",
     )
     parser.add_argument(
         "--best-of",

--- a/tests/test_benchmark_random_dataset.py
+++ b/tests/test_benchmark_random_dataset.py
@@ -1,0 +1,162 @@
+"""Tests for the random dataset the serving benchmark generates.
+
+A synthetic tokenizer stands in for a real one so the properties under test --
+length targeting, reproducibility, and the batching the fast path relies on --
+are checked without downloading a model. It is deliberately *not* injective:
+`decode` joins ids with spaces and `encode` splits on them, so a prompt whose
+ids were built from a fixed range re-encodes to a different token count and the
+round-trip loop has to correct it, which is the case that matters.
+"""
+
+import numpy as np
+import pytest
+
+from atom.benchmarks.benchmark_serving import sample_random_requests
+
+
+class FakeTokenizer:
+    """Ids <-> text with a token count that is stable but not id-for-id equal."""
+
+    vocab_size = 1000
+
+    def __init__(self, drop_every: int = 0, drop_rounds: int = 0):
+        # For the first `drop_rounds` encode batches, every `drop_every`-th
+        # token is dropped, so the caller has to pad and retry. Setting
+        # drop_rounds high enough that it never stops models a tokenizer the
+        # round-trip can never satisfy.
+        self.drop_every = drop_every
+        self.drop_rounds = drop_rounds
+        self.batch_decode_calls = 0
+        self.batch_encode_calls = 0
+        self.single_calls = 0
+
+    def decode(self, ids):
+        self.single_calls += 1
+        return " ".join(str(int(i)) for i in ids)
+
+    def encode(self, text, add_special_tokens=False):
+        self.single_calls += 1
+        return self._encode_one(text)
+
+    def batch_decode(self, id_lists):
+        self.batch_decode_calls += 1
+        return [" ".join(str(int(i)) for i in ids) for ids in id_lists]
+
+    def __call__(self, texts, add_special_tokens=False):
+        self.batch_encode_calls += 1
+        return {"input_ids": [self._encode_one(t) for t in texts]}
+
+    def _encode_one(self, text):
+        ids = [int(tok) for tok in text.split()] if text else []
+        if self.drop_every and self.batch_encode_calls <= self.drop_rounds:
+            ids = [t for n, t in enumerate(ids) if (n + 1) % self.drop_every]
+        return ids
+
+
+def _sample(tokenizer, **overrides):
+    kwargs = {
+        "prefix_len": 0,
+        "input_len": 64,
+        "output_len": 8,
+        "num_prompts": 20,
+        "range_ratio": 1.0,
+        "tokenizer": tokenizer,
+        "seed": 0,
+    }
+    kwargs.update(overrides)
+    return sample_random_requests(**kwargs)
+
+
+def test_every_prompt_hits_its_target_token_length():
+    requests = _sample(FakeTokenizer())
+
+    assert len(requests) == 20
+    assert all(prompt_len == 64 for _, prompt_len, _, _ in requests)
+
+
+def test_prompts_are_padded_back_up_when_encode_loses_tokens():
+    """The round-trip loop must correct a tokenizer that drops tokens."""
+    requests = _sample(FakeTokenizer(drop_every=8, drop_rounds=1))
+
+    assert all(prompt_len == 64 for _, prompt_len, _, _ in requests)
+
+
+def test_length_is_reported_honestly_when_the_round_trip_never_converges():
+    """Out of rounds, the reported length is the real one, not the target.
+
+    A benchmark that reported the target it failed to reach would understate
+    its own input length in every derived statistic.
+    """
+    tokenizer = FakeTokenizer(drop_every=8, drop_rounds=1000)
+
+    requests = _sample(tokenizer, num_prompts=4)
+
+    for prompt, prompt_len, _, _ in requests:
+        assert prompt_len < 64
+        assert prompt_len == len(tokenizer.encode(prompt))
+
+
+def test_same_seed_reproduces_the_same_prompts():
+    first = _sample(FakeTokenizer())
+    second = _sample(FakeTokenizer())
+
+    assert [r[0] for r in first] == [r[0] for r in second]
+
+
+def test_different_seed_produces_different_prompts():
+    first = _sample(FakeTokenizer(), seed=0)
+    second = _sample(FakeTokenizer(), seed=1)
+
+    assert [r[0] for r in first] != [r[0] for r in second]
+
+
+def test_global_numpy_rng_does_not_change_the_dataset():
+    """The dataset must not depend on what else drew from the global RNG.
+
+    Sharing np.random makes a benchmark's prompts a function of unrelated code,
+    so two runs of the same command can differ.
+    """
+    baseline = _sample(FakeTokenizer())
+
+    np.random.seed(1234)
+    np.random.rand(999)
+    after = _sample(FakeTokenizer())
+
+    assert [r[0] for r in after] == [r[0] for r in baseline]
+
+
+def test_tokenizer_is_called_in_batches_not_per_prompt():
+    """Per-prompt calls forfeit the fast tokenizer's internal batching."""
+    tokenizer = FakeTokenizer()
+
+    _sample(tokenizer, num_prompts=200)
+
+    assert tokenizer.single_calls == 0
+    # One decode for the initial ids, then a bounded number of fix-up rounds --
+    # far fewer than the 200 prompts either way.
+    assert tokenizer.batch_decode_calls <= 11
+    assert tokenizer.batch_encode_calls <= 11
+
+
+def test_range_ratio_bounds_the_sampled_lengths():
+    requests = _sample(FakeTokenizer(), range_ratio=0.5, num_prompts=100)
+
+    assert all(32 <= prompt_len <= 64 for _, prompt_len, _, _ in requests)
+    assert all(4 <= output_len <= 8 for _, _, output_len, _ in requests)
+
+
+def test_prefix_is_shared_by_every_prompt():
+    requests = _sample(FakeTokenizer(), prefix_len=16, num_prompts=8)
+
+    prefixes = {r[0].split()[:16][0] for r in requests}
+    assert len(prefixes) == 1
+    assert all(prompt_len == 16 + 64 for _, prompt_len, _, _ in requests)
+
+
+@pytest.mark.parametrize("num_prompts", [1, 5000])
+def test_batching_boundaries(num_prompts):
+    """A dataset larger than one tokenizer batch must still be complete."""
+    requests = _sample(FakeTokenizer(), num_prompts=num_prompts)
+
+    assert len(requests) == num_prompts
+    assert all(prompt_len == 64 for _, prompt_len, _, _ in requests)


### PR DESCRIPTION
Generating the random dataset runs before a single request is sent, so it is dead
time on every benchmark, and it scales with `--num-prompts`. At the c=8192 shape
(24576 prompts, `input_len` 1024) it was roughly **two minutes** of one Python
thread with the GPUs idle.

## Where the time went

Measured on DeepSeek-V4-Flash's tokenizer, 2000 prompts at `input_len` 1024
(`/app/logs_claude/bench_dataset_gen.py`):

| stage | time | share |
|---|---|---|
| retry loop (encode + re-decode) | 6.05 s | **62.2%** |
| the final encode | 2.71 s | **27.9%** |
| first decode | 0.50 s | 5.2% |
| building the token ids | 0.46 s | 4.8% |
| **total** | **9.74 s** | |

The retry loop is not avoidable work: decode/encode is not injective, so a prompt
built from N consecutive ids usually re-encodes to a different count and has to be
corrected. The instrumented run recorded **4022 encodes for 2000 prompts** — the
first re-encode fails for essentially every prompt, so the loop always runs twice.

## Changes

**Tokenizer calls are issued a batch at a time.** A fast tokenizer parallelises a
batch internally; one call per prompt forfeits that plus a Python/Rust crossing
each time. The round trip becomes: `batch_decode` everything → batch encode → keep
only the prompts whose length did not converge → repeat. This is the whole win.

**The final encode is deleted.** When the retry loop broke, it broke *because*
`encode(prompt)` had already returned the target length one line earlier — so
re-encoding the same string could only produce the same number. It is still paid
in the two cases where the length genuinely is unknown: a prompt that never
converged, and a chat template that rewrote the prompt afterwards.

**Token ids are built with numpy** instead of a per-token Python comprehension with
a modulo. Smallest of the three at 4.8%, but that is 25M interpreter-level
operations at the c=8192 shape.

## Results

| | 2000 prompts @ input_len 1024 | 24576 prompts (c=8192 shape) |
|---|---|---|
| before | 9.74 s | ≈ 120 s |
| after | **1.85 s** | **≈ 24 s** |
| | **5.25x** | |

No behavioural difference in the dataset: same length distribution, same
`avg_token_mismatch` of 0.00, same 4-tuple shape.

## Also: the dataset is now reproducible

It draws from its own `np.random.default_rng(seed)` rather than the global numpy
RNG. Sharing the global one makes the prompts a function of whatever else drew from
it first, so re-running the same command need not produce the same dataset — not a
property a benchmark should lack. The seed comes from the existing `--seed`. vLLM's
`RandomDataset` isolates its generator for the same reason and says so in a comment.

Verified: same seed → identical prompts; a `np.random.rand(9999)` in between changes
nothing; a different seed changes everything.

## Two notes for review

- The **typing modernisation across the file** (`List`/`Tuple`/`Dict` → builtins,
  `AsyncGenerator`/`Callable` → `collections.abc`) is a formatter sweep, not a
  deliberate change. It is most of the line count.
- The **timezone fix** on the result-file stamp is ruff `DTZ005` on a line that
  sweep pulled into diff context. `astimezone()` keeps the stamp in local time
  exactly as before, so the recorded value is unchanged.

## Testing

- New `tests/test_benchmark_random_dataset.py`, 11 tests, synthetic tokenizer so
  nothing is downloaded. It is deliberately **not** injective (`decode` joins ids
  with spaces, `encode` splits on them) so the round-trip correction is actually
  exercised — including the case where it never converges and the reported length
  must be the real one rather than the target it missed.
- `bash .github/scripts/run_unit_tests.sh` → **1363 passed, 52 skipped, 0 failed**
- `black --check .` clean; `ruff` reports **0 findings in this diff's context**
