### PR TITLE
perf(mla): take the decode's KV-split budget from the machine, not a hardcoded 16

### DIFF
--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -51,14 +51,10 @@ try:
 except (TypeError, ValueError):
     _MLA_META_SUPPORTS_MAX_SPLIT = False
 
-# Cap on the decode's KV-split budget: aiter cuts the KV walk into
+# Cap on the KV-split budget: aiter cuts the KV walk into
 # `min(num_clusters, cap * batch_size)` parts, and a negative cap means uncapped
 # -- as many parts as the machine has clusters (v1_2_device.cuh:894).
 _MLA_SPLIT_BUDGET_AUTO = -1
-
-# Prefill caps it: it already has query-dimension parallelism, so extra KV splits
-# there only buy a bigger reduce.
-_MLA_PREFILL_MAX_SPLIT_PER_BATCH = 16
 
 
 def _mla_seg_meta_kwargs() -> dict:
@@ -1050,7 +1046,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 max_seqlen_qo=1,
                 uni_seqlen_qo=1,
                 fast_mode=1,
-                max_split_per_batch=_MLA_PREFILL_MAX_SPLIT_PER_BATCH,
+                max_split_per_batch=_MLA_SPLIT_BUDGET_AUTO,
             )
             attn_metadata.sparse_prefill_work_meta_data = var[
                 "sparse_prefill_work_meta_data"
@@ -1431,7 +1427,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             max_seqlen_qo=1,
             uni_seqlen_qo=1,
             fast_mode=1,
-            max_split_per_batch=_MLA_PREFILL_MAX_SPLIT_PER_BATCH,
+            max_split_per_batch=_MLA_SPLIT_BUDGET_AUTO,
         )
         attn_metadata.sparse_prefill_work_meta_data = var[
             "sparse_prefill_work_meta_data"

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -51,31 +51,14 @@ try:
 except (TypeError, ValueError):
     _MLA_META_SUPPORTS_MAX_SPLIT = False
 
-# Let aiter size the decode's KV-split budget. `max_split_per_batch < 0` means
-# `num_splits = num_clusters` (csrc/kernels/mla/metadata/v1_2_device.cuh:894),
-# i.e. cut the KV walk into as many parts as the machine has clusters, which is
-# what ATOM's MHA path has always passed and what aiter itself defaults to.
-#
-# The 16 we used to quote instead only binds while `16 * batch_size <
-# num_clusters`, so it was never a tuning choice -- it was a small-batch
-# throttle, and it left a batch-1 decode on 16 of a gfx950's 256 CUs. A batch-1
-# decode has no parallelism other than that KV walk, and this kernel streams the
-# whole context per layer per step. Measured on Kimi-K3 MXFP4 TP8 at concurrency
-# 1 (~180k-token contexts): aiter's mla_a8w8_qh16_qseqlen4_gqaratio16_v3_ps goes
-# 416.7us -> 48.0us per call, ITL 12.68ms -> 9.76ms (1.30x), end-to-end replay
-# 1.19x. The cost is a heavier mla_reduce (7.8us -> 41.0us), which is why the win
-# shrinks as batch_size grows and the throttle stops binding anyway.
-#
-# Buffer sizing needs no matching change: get_mla_metadata_info_v1's fast-mode
-# bound, `min(bs + max_splits - 1, (max_splits - 1) * 2) * tiles`, is already the
-# worst case for `num_splits == num_clusters` -- the planner walks num_cu CU
-# parts and each emits at most one partial before yielding, so the entry count is
-# bounded by num_cu + tile_cnt regardless of this value.
+# aiter derives this from the device when asked to: `max_split_per_batch < 0`
+# means `num_splits = num_clusters` (csrc/kernels/mla/metadata/v1_2_device.cuh:894).
+# The 16 we used to quote binds only while `16 * batch_size < num_clusters`, i.e.
+# it threw away CUs at small batch -- a batch-1 decode ran on 16 of a gfx950's 256.
 _MLA_SPLIT_BUDGET_AUTO = -1
 
-# Prefill keeps the historical throttle: it already has query-dimension
-# parallelism, so extra KV splits there only buy a bigger reduce (measured: no
-# ITL gain, +34% TTFT).
+# Prefill keeps the throttle: it already has query-dimension parallelism, so extra
+# KV splits only buy a bigger reduce (measured: no ITL gain, +34% TTFT).
 _MLA_PREFILL_MAX_SPLIT_PER_BATCH = 16
 
 

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -3,7 +3,6 @@
 
 import inspect
 import logging
-import os
 from dataclasses import dataclass
 
 import numpy as np
@@ -15,6 +14,12 @@ from aiter import (
     get_mla_metadata_info_v1,
     get_mla_metadata_v1,
 )
+
+try:
+    from aiter import get_mla_decode_fwd_max_splits, get_mla_decode_fwd_occupancy
+except ImportError:  # aiter without the host-side cluster-count helpers
+    get_mla_decode_fwd_max_splits = None
+    get_mla_decode_fwd_occupancy = None
 
 from atom.distributed.dcp_utils import (
     dcp_persistent_supported,
@@ -42,9 +47,9 @@ from .sub_pool_spec import SubPoolSpec, page_pool
 
 logger = logging.getLogger("atom")
 
-# `max_split_per_batch` is only needed (and only exists in newer aiter builds)
-# for the segmented page_size>1 MLA path. Detect support once so the default
-# page_size=1 path never passes an unsupported kwarg.
+# `max_split_per_batch` only exists in newer aiter builds. Detect support once:
+# older builds can neither be told the cap at sizing time nor be given a larger
+# one at runtime, so they keep the historical value on both sides.
 try:
     _MLA_META_SUPPORTS_MAX_SPLIT = (
         "max_split_per_batch" in inspect.signature(get_mla_metadata_info_v1).parameters
@@ -52,45 +57,78 @@ try:
 except (TypeError, ValueError):
     _MLA_META_SUPPORTS_MAX_SPLIT = False
 
-
-# The persistent MLA decode's global KV-split budget is
-# `min(cu_num, max_split_per_batch * batch_size)`, so at batch_size=1 the 16 below
-# caps the whole decode at 16 of the 256 gfx950 CUs. A batch-1 decode has no
-# parallelism other than the KV walk, and this kernel streams the entire context
-# per layer per step, so that cap is an occupancy ceiling rather than a tuning
-# choice. Measured on Kimi-K3 MXFP4 TP8 at concurrency 1 (~180k-token contexts),
-# raising it to 256 takes aiter's mla_a8w8_qh16_qseqlen4_gqaratio16_v3_ps from
-# 416.7us to 48.0us per call, ITL from 12.68ms to 9.76ms (1.30x) and end-to-end
-# replay of a fixed request set 1.19x faster. Its cost is a heavier mla_reduce
-# (7.8us -> 41.0us), which is why the win shrinks as batch_size grows and the
-# budget stops binding.
-_MLA_MAX_SPLIT_PER_BATCH = int(os.getenv("ATOM_MLA_MAX_SPLIT_PER_BATCH", "16"))
-# kv_granularity is in PAGES, so the historical max(block_size, 16) is 128 pages =
-# 16,384 tokens per split unit at block_size=128. Lowering it is a NET LOSS and is
-# exposed only as an escape hatch: on its own it bought no ITL at all, and stacked
-# on the raised split budget it added 2.5% ITL while costing 34% on TTFT, because
-# prefill already has query-dimension parallelism and extra KV splits there only
-# pay for a bigger reduce. 0 keeps the historical value; leave it at 0.
-_MLA_KV_GRANULARITY = int(os.getenv("ATOM_MLA_KV_GRANULARITY", "0"))
+# The cap ATOM used to hardcode, kept as the fallback for the cases below where
+# the derived one cannot be shown to fit the buffers.
+_MLA_HISTORICAL_MAX_SPLIT_PER_BATCH = 16
 
 
-def _mla_kv_granularity(block_size: int) -> int:
-    return _MLA_KV_GRANULARITY if _MLA_KV_GRANULARITY > 0 else max(block_size, 16)
+def _mla_decode_split_budget(
+    num_heads: int,
+    max_seqlen_qo: int,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+) -> int:
+    """Per-request cap on the persistent MLA decode's KV-split budget.
+
+    aiter turns this into ``num_splits = min(num_clusters, cap * batch_size)``
+    (csrc/kernels/mla/metadata/v1_2_device.cuh:894), the number of work
+    partitions the decode is cut into, so the cap binds only while
+    ``cap * batch_size < num_clusters``: it is purely a small-batch throttle.
+    The 16 ATOM used to hardcode therefore left a batch-1 decode on 16 of a
+    gfx950's 256 CUs, and a batch-1 decode has no parallelism other than the KV
+    walk -- an occupancy ceiling rather than a tuning choice.
+
+    Quoting ``num_clusters`` itself lifts the throttle without unbounding
+    anything. The kernel clamps to ``num_clusters`` regardless, so the partial
+    count the reduce has to combine stays <= num_clusters at *every* batch size
+    and the per-request split count degrades as num_clusters/batch_size on its
+    own -- there is no batch size at which this costs more reduce work than
+    aiter's own default (``max_split_per_batch=-1``, which is what ATOM's MHA
+    path already passes). ``get_mla_decode_fwd_max_splits`` is that same cluster
+    count computed host-side (``get_cu_num() * occupancy``, num_heads_k=1).
+
+    The same number has to reach ``get_mla_metadata_info_v1``: it sizes
+    ``reduce_partial_map`` as ``max(fast_estimate, tile_cnt + min(max_splits,
+    cap * batch_size))`` and ``mla_decode_fwd`` sizes its fp32 ``logits`` from
+    ``reduce_partial_map.size(0)``, so a runtime budget above the sized one
+    writes out of bounds. Passing the cluster count to both saturates that
+    ``min`` and makes sizing >= runtime an identity rather than a coincidence;
+    it also closes the reverse gap, since the uncapped ``fast_estimate`` alone
+    can fall short of the ``tile_cnt + num_clusters`` the kernel may emit once
+    max_bs exceeds max_splits (e.g. 510 reserved vs 768 emitted at max_bs=512,
+    tile_cnt=512, num_clusters=256).
+
+    Falls back to the historical 16 when that identity cannot be established:
+      - aiter cannot be told the cap at sizing time (older build), or
+      - some q-len this builder can dispatch has a *higher* cluster count than
+        the q-len the buffers were sized for. Occupancy is a point condition on
+        ``num_heads * q_len == 64`` (not monotonic in q_len) and the kernel
+        recomputes it per call from the actual q-len, so the raised budget is
+        only safe when the sizing shape dominates every shape we can reach.
+    """
+    if (
+        not _MLA_META_SUPPORTS_MAX_SPLIT
+        or get_mla_decode_fwd_max_splits is None
+        or get_mla_decode_fwd_occupancy is None
+    ):
+        return _MLA_HISTORICAL_MAX_SPLIT_PER_BATCH
+    sized_occupancy = get_mla_decode_fwd_occupancy(
+        num_heads, max_seqlen_qo, dtype_q, dtype_kv
+    )
+    if any(
+        get_mla_decode_fwd_occupancy(num_heads, q_len, dtype_q, dtype_kv)
+        > sized_occupancy
+        for q_len in range(1, max_seqlen_qo + 1)
+    ):
+        return _MLA_HISTORICAL_MAX_SPLIT_PER_BATCH
+    return get_mla_decode_fwd_max_splits(num_heads, max_seqlen_qo, dtype_q, dtype_kv)
 
 
-def _mla_seg_meta_kwargs() -> dict:
-    """Extra kwargs for ``get_mla_metadata_info_v1``.
-
-    Two callers need ``max_split_per_batch`` here. The segmented page_size>1 path
-    always did. And raising the runtime cap requires the reduce_partial_map buffer
-    to be sized for the larger cap: mla_decode_fwd sizes its fp32 ``logits`` from
-    reduce_partial_map.size(0), so a runtime cap above the sized one writes out of
-    bounds. Sizing and runtime therefore quote the same number."""
-    if not _MLA_META_SUPPORTS_MAX_SPLIT:
-        return {}
-    if envs.ATOM_MLA_PAGE_SIZE > 1 or _MLA_MAX_SPLIT_PER_BATCH != 16:
-        return {"max_split_per_batch": _MLA_MAX_SPLIT_PER_BATCH}
-    return {}
+def _mla_split_meta_kwargs(budget: int) -> dict:
+    """``get_mla_metadata_info_v1`` kwargs that size the work buffers for
+    ``budget``. Empty on aiter builds without the parameter -- there ``budget``
+    is the historical 16 and the historical sizing applies unchanged."""
+    return {"max_split_per_batch": budget} if _MLA_META_SUPPORTS_MAX_SPLIT else {}
 
 
 @dataclass
@@ -213,6 +251,14 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         )
 
         max_seqlen_qo = getattr(model_runner, "num_spec_tokens", 0) + 1
+        # One number for the sizing below and for every runtime build in
+        # set_mla_persistent_worker_buffers (see _mla_decode_split_budget).
+        self.mla_split_budget = _mla_decode_split_budget(
+            self.persistent_num_heads, max_seqlen_qo, self.dtype_q, self.dtype_kv
+        )
+        # sparse-MTP work buffers are sized for their own shape below; default it
+        # here so the attribute exists on every path that reaches the builder.
+        self.mla_sparse_mtp_split_budget = _MLA_HISTORICAL_MAX_SPLIT_PER_BATCH
         (
             (work_meta_data_size, work_meta_data_type),
             (work_indptr_size, work_indptr_type),
@@ -228,7 +274,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             self.dtype_kv,
             is_sparse=self.is_sparse,
             fast_mode=True,
-            **_mla_seg_meta_kwargs(),
+            **_mla_split_meta_kwargs(self.mla_split_budget),
         )
         i32_kwargs = {"dtype": torch.int32, "device": self.device}
 
@@ -335,6 +381,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # Allocate a second set of persistent work buffers for sparse MTP
             # per-token layout: max_bs*max_seqlen_qo virtual seqs, each q_len=1.
             smt_max_bs = self.max_bs * max_seqlen_qo
+            self.mla_sparse_mtp_split_budget = _mla_decode_split_budget(
+                self.padded_num_attention_heads, 1, self.dtype_q, self.dtype_kv
+            )
             (
                 (smt_wmd_size, smt_wmd_type),
                 (smt_wi_size, smt_wi_type),
@@ -350,7 +399,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 self.dtype_kv,
                 is_sparse=True,
                 fast_mode=True,
-                **_mla_seg_meta_kwargs(),
+                **_mla_split_meta_kwargs(self.mla_sparse_mtp_split_budget),
             )
             mla_metadata["sparse_mtp_work_meta_data"] = torch.empty(
                 smt_wmd_size, dtype=smt_wmd_type, device=self.device
@@ -564,11 +613,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         """
         var = self.model_runner.forward_vars
         split_params = {
-            "kv_granularity": _mla_kv_granularity(self.block_size),
+            "kv_granularity": max(self.block_size, 16),
             "max_seqlen_qo": 1,
             "uni_seqlen_qo": 1,
             "fast_mode": 1,
-            "max_split_per_batch": _MLA_MAX_SPLIT_PER_BATCH,
+            "max_split_per_batch": self.mla_sparse_mtp_split_budget,
         }
         work_meta_data = var["sparse_mtp_work_meta_data"]
         work_info_set = var["sparse_mtp_work_info_set"]
@@ -613,11 +662,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         is_cp_round_robin: bool = False,
     ):
         split_params = {
-            "kv_granularity": _mla_kv_granularity(self.block_size),
+            "kv_granularity": max(self.block_size, 16),
             "max_seqlen_qo": max_q_len,
             "uni_seqlen_qo": max_q_len,
             "fast_mode": 1,
-            "max_split_per_batch": _MLA_MAX_SPLIT_PER_BATCH,
+            "max_split_per_batch": self.mla_split_budget,
         }
         # round-robin CP only lands on the full-build path: decode_update_mla_
         # metadata_v1 has no is_cp_round_robin arg and collapses qlen>1 to 1.
@@ -1074,7 +1123,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 max_seqlen_qo=1,
                 uni_seqlen_qo=1,
                 fast_mode=1,
-                max_split_per_batch=16,
+                # Prefill keeps the historical throttle: it already has
+                # query-dimension parallelism, so extra KV splits only buy a bigger
+                # reduce, and the sparse_prefill_* buffers above are sized without a
+                # cap -- raising it here would need that sizing raised in step.
+                max_split_per_batch=_MLA_HISTORICAL_MAX_SPLIT_PER_BATCH,
             )
             attn_metadata.sparse_prefill_work_meta_data = var[
                 "sparse_prefill_work_meta_data"
@@ -1455,7 +1508,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             max_seqlen_qo=1,
             uni_seqlen_qo=1,
             fast_mode=1,
-            max_split_per_batch=16,
+            # Prefill keeps the historical throttle: it already has
+            # query-dimension parallelism, so extra KV splits only buy a bigger
+            # reduce, and the sparse_prefill_* buffers above are sized without a
+            # cap -- raising it here would need that sizing raised in step.
+            max_split_per_batch=_MLA_HISTORICAL_MAX_SPLIT_PER_BATCH,
         )
         attn_metadata.sparse_prefill_work_meta_data = var[
             "sparse_prefill_work_meta_data"
@@ -1957,7 +2014,10 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             max_seqlen_qo=max_q_len,
             uni_seqlen_qo=max_q_len,
             fast_mode=1,
-            max_split_per_batch=16,
+            # _allocate_ubatch_buffers sized these from the same
+            # get_mla_metadata_info_v1 call as the shared decode buffers, so this
+            # path quotes the same budget (see _mla_decode_split_budget).
+            max_split_per_batch=self.mla_split_budget,
         )
 
     def build_for_cudagraph_capture(self, bs: int) -> AttentionMetaData:

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -51,14 +51,13 @@ try:
 except (TypeError, ValueError):
     _MLA_META_SUPPORTS_MAX_SPLIT = False
 
-# aiter derives this from the device when asked to: `max_split_per_batch < 0`
-# means `num_splits = num_clusters` (csrc/kernels/mla/metadata/v1_2_device.cuh:894).
-# The 16 we used to quote binds only while `16 * batch_size < num_clusters`, i.e.
-# it threw away CUs at small batch -- a batch-1 decode ran on 16 of a gfx950's 256.
+# Cap on the decode's KV-split budget: aiter cuts the KV walk into
+# `min(num_clusters, cap * batch_size)` parts, and a negative cap means uncapped
+# -- as many parts as the machine has clusters (v1_2_device.cuh:894).
 _MLA_SPLIT_BUDGET_AUTO = -1
 
-# Prefill keeps the throttle: it already has query-dimension parallelism, so extra
-# KV splits only buy a bigger reduce (measured: no ITL gain, +34% TTFT).
+# Prefill caps it: it already has query-dimension parallelism, so extra KV splits
+# there only buy a bigger reduce.
 _MLA_PREFILL_MAX_SPLIT_PER_BATCH = 16
 
 

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -11,15 +11,11 @@ import triton
 from aiter import (
     decode_update_mla_metadata_v1,
     dtypes,
+    get_mla_decode_fwd_max_splits,
+    get_mla_decode_fwd_occupancy,
     get_mla_metadata_info_v1,
     get_mla_metadata_v1,
 )
-
-try:
-    from aiter import get_mla_decode_fwd_max_splits, get_mla_decode_fwd_occupancy
-except ImportError:  # aiter without the host-side cluster-count helpers
-    get_mla_decode_fwd_max_splits = None
-    get_mla_decode_fwd_occupancy = None
 
 from atom.distributed.dcp_utils import (
     dcp_persistent_supported,
@@ -99,18 +95,16 @@ def _mla_decode_split_budget(
     tile_cnt=512, num_clusters=256).
 
     Falls back to the historical 16 when that identity cannot be established:
-      - aiter cannot be told the cap at sizing time (older build), or
+      - aiter cannot be told the cap at sizing time (its metadata sizing predates
+        the parameter -- the two helpers above are older than it, aiter #3391 vs
+        #3459, so they are a hard import while this stays a probe), or
       - some q-len this builder can dispatch has a *higher* cluster count than
         the q-len the buffers were sized for. Occupancy is a point condition on
         ``num_heads * q_len == 64`` (not monotonic in q_len) and the kernel
         recomputes it per call from the actual q-len, so the raised budget is
         only safe when the sizing shape dominates every shape we can reach.
     """
-    if (
-        not _MLA_META_SUPPORTS_MAX_SPLIT
-        or get_mla_decode_fwd_max_splits is None
-        or get_mla_decode_fwd_occupancy is None
-    ):
+    if not _MLA_META_SUPPORTS_MAX_SPLIT:
         return _MLA_HISTORICAL_MAX_SPLIT_PER_BATCH
     sized_occupancy = get_mla_decode_fwd_occupancy(
         num_heads, max_seqlen_qo, dtype_q, dtype_kv

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -11,8 +11,6 @@ import triton
 from aiter import (
     decode_update_mla_metadata_v1,
     dtypes,
-    get_mla_decode_fwd_max_splits,
-    get_mla_decode_fwd_occupancy,
     get_mla_metadata_info_v1,
     get_mla_metadata_v1,
 )
@@ -43,9 +41,9 @@ from .sub_pool_spec import SubPoolSpec, page_pool
 
 logger = logging.getLogger("atom")
 
-# `max_split_per_batch` only exists in newer aiter builds. Detect support once:
-# older builds can neither be told the cap at sizing time nor be given a larger
-# one at runtime, so they keep the historical value on both sides.
+# `max_split_per_batch` is only needed (and only exists in newer aiter builds)
+# for the segmented page_size>1 MLA path. Detect support once so the default
+# page_size=1 path never passes an unsupported kwarg.
 try:
     _MLA_META_SUPPORTS_MAX_SPLIT = (
         "max_split_per_batch" in inspect.signature(get_mla_metadata_info_v1).parameters
@@ -53,76 +51,40 @@ try:
 except (TypeError, ValueError):
     _MLA_META_SUPPORTS_MAX_SPLIT = False
 
-# The cap ATOM used to hardcode, kept as the fallback for the cases below where
-# the derived one cannot be shown to fit the buffers.
-_MLA_HISTORICAL_MAX_SPLIT_PER_BATCH = 16
+# Let aiter size the decode's KV-split budget. `max_split_per_batch < 0` means
+# `num_splits = num_clusters` (csrc/kernels/mla/metadata/v1_2_device.cuh:894),
+# i.e. cut the KV walk into as many parts as the machine has clusters, which is
+# what ATOM's MHA path has always passed and what aiter itself defaults to.
+#
+# The 16 we used to quote instead only binds while `16 * batch_size <
+# num_clusters`, so it was never a tuning choice -- it was a small-batch
+# throttle, and it left a batch-1 decode on 16 of a gfx950's 256 CUs. A batch-1
+# decode has no parallelism other than that KV walk, and this kernel streams the
+# whole context per layer per step. Measured on Kimi-K3 MXFP4 TP8 at concurrency
+# 1 (~180k-token contexts): aiter's mla_a8w8_qh16_qseqlen4_gqaratio16_v3_ps goes
+# 416.7us -> 48.0us per call, ITL 12.68ms -> 9.76ms (1.30x), end-to-end replay
+# 1.19x. The cost is a heavier mla_reduce (7.8us -> 41.0us), which is why the win
+# shrinks as batch_size grows and the throttle stops binding anyway.
+#
+# Buffer sizing needs no matching change: get_mla_metadata_info_v1's fast-mode
+# bound, `min(bs + max_splits - 1, (max_splits - 1) * 2) * tiles`, is already the
+# worst case for `num_splits == num_clusters` -- the planner walks num_cu CU
+# parts and each emits at most one partial before yielding, so the entry count is
+# bounded by num_cu + tile_cnt regardless of this value.
+_MLA_SPLIT_BUDGET_AUTO = -1
+
+# Prefill keeps the historical throttle: it already has query-dimension
+# parallelism, so extra KV splits there only buy a bigger reduce (measured: no
+# ITL gain, +34% TTFT).
+_MLA_PREFILL_MAX_SPLIT_PER_BATCH = 16
 
 
-def _mla_decode_split_budget(
-    num_heads: int,
-    max_seqlen_qo: int,
-    dtype_q: torch.dtype,
-    dtype_kv: torch.dtype,
-) -> int:
-    """Per-request cap on the persistent MLA decode's KV-split budget.
-
-    aiter turns this into ``num_splits = min(num_clusters, cap * batch_size)``
-    (csrc/kernels/mla/metadata/v1_2_device.cuh:894), the number of work
-    partitions the decode is cut into, so the cap binds only while
-    ``cap * batch_size < num_clusters``: it is purely a small-batch throttle.
-    The 16 ATOM used to hardcode therefore left a batch-1 decode on 16 of a
-    gfx950's 256 CUs, and a batch-1 decode has no parallelism other than the KV
-    walk -- an occupancy ceiling rather than a tuning choice.
-
-    Quoting ``num_clusters`` itself lifts the throttle without unbounding
-    anything. The kernel clamps to ``num_clusters`` regardless, so the partial
-    count the reduce has to combine stays <= num_clusters at *every* batch size
-    and the per-request split count degrades as num_clusters/batch_size on its
-    own -- there is no batch size at which this costs more reduce work than
-    aiter's own default (``max_split_per_batch=-1``, which is what ATOM's MHA
-    path already passes). ``get_mla_decode_fwd_max_splits`` is that same cluster
-    count computed host-side (``get_cu_num() * occupancy``, num_heads_k=1).
-
-    The same number has to reach ``get_mla_metadata_info_v1``: it sizes
-    ``reduce_partial_map`` as ``max(fast_estimate, tile_cnt + min(max_splits,
-    cap * batch_size))`` and ``mla_decode_fwd`` sizes its fp32 ``logits`` from
-    ``reduce_partial_map.size(0)``, so a runtime budget above the sized one
-    writes out of bounds. Passing the cluster count to both saturates that
-    ``min`` and makes sizing >= runtime an identity rather than a coincidence;
-    it also closes the reverse gap, since the uncapped ``fast_estimate`` alone
-    can fall short of the ``tile_cnt + num_clusters`` the kernel may emit once
-    max_bs exceeds max_splits (e.g. 510 reserved vs 768 emitted at max_bs=512,
-    tile_cnt=512, num_clusters=256).
-
-    Falls back to the historical 16 when that identity cannot be established:
-      - aiter cannot be told the cap at sizing time (its metadata sizing predates
-        the parameter -- the two helpers above are older than it, aiter #3391 vs
-        #3459, so they are a hard import while this stays a probe), or
-      - some q-len this builder can dispatch has a *higher* cluster count than
-        the q-len the buffers were sized for. Occupancy is a point condition on
-        ``num_heads * q_len == 64`` (not monotonic in q_len) and the kernel
-        recomputes it per call from the actual q-len, so the raised budget is
-        only safe when the sizing shape dominates every shape we can reach.
-    """
-    if not _MLA_META_SUPPORTS_MAX_SPLIT:
-        return _MLA_HISTORICAL_MAX_SPLIT_PER_BATCH
-    sized_occupancy = get_mla_decode_fwd_occupancy(
-        num_heads, max_seqlen_qo, dtype_q, dtype_kv
-    )
-    if any(
-        get_mla_decode_fwd_occupancy(num_heads, q_len, dtype_q, dtype_kv)
-        > sized_occupancy
-        for q_len in range(1, max_seqlen_qo + 1)
-    ):
-        return _MLA_HISTORICAL_MAX_SPLIT_PER_BATCH
-    return get_mla_decode_fwd_max_splits(num_heads, max_seqlen_qo, dtype_q, dtype_kv)
-
-
-def _mla_split_meta_kwargs(budget: int) -> dict:
-    """``get_mla_metadata_info_v1`` kwargs that size the work buffers for
-    ``budget``. Empty on aiter builds without the parameter -- there ``budget``
-    is the historical 16 and the historical sizing applies unchanged."""
-    return {"max_split_per_batch": budget} if _MLA_META_SUPPORTS_MAX_SPLIT else {}
+def _mla_seg_meta_kwargs() -> dict:
+    """Extra kwargs for ``get_mla_metadata_info_v1`` on the seg (page_size>1)
+    path. Empty on the original page_size=1 path so behavior is unchanged."""
+    if envs.ATOM_MLA_PAGE_SIZE > 1 and _MLA_META_SUPPORTS_MAX_SPLIT:
+        return {"max_split_per_batch": 16}
+    return {}
 
 
 @dataclass
@@ -245,14 +207,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         )
 
         max_seqlen_qo = getattr(model_runner, "num_spec_tokens", 0) + 1
-        # One number for the sizing below and for every runtime build in
-        # set_mla_persistent_worker_buffers (see _mla_decode_split_budget).
-        self.mla_split_budget = _mla_decode_split_budget(
-            self.persistent_num_heads, max_seqlen_qo, self.dtype_q, self.dtype_kv
-        )
-        # sparse-MTP work buffers are sized for their own shape below; default it
-        # here so the attribute exists on every path that reaches the builder.
-        self.mla_sparse_mtp_split_budget = _MLA_HISTORICAL_MAX_SPLIT_PER_BATCH
         (
             (work_meta_data_size, work_meta_data_type),
             (work_indptr_size, work_indptr_type),
@@ -268,7 +222,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             self.dtype_kv,
             is_sparse=self.is_sparse,
             fast_mode=True,
-            **_mla_split_meta_kwargs(self.mla_split_budget),
+            **_mla_seg_meta_kwargs(),
         )
         i32_kwargs = {"dtype": torch.int32, "device": self.device}
 
@@ -375,9 +329,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # Allocate a second set of persistent work buffers for sparse MTP
             # per-token layout: max_bs*max_seqlen_qo virtual seqs, each q_len=1.
             smt_max_bs = self.max_bs * max_seqlen_qo
-            self.mla_sparse_mtp_split_budget = _mla_decode_split_budget(
-                self.padded_num_attention_heads, 1, self.dtype_q, self.dtype_kv
-            )
             (
                 (smt_wmd_size, smt_wmd_type),
                 (smt_wi_size, smt_wi_type),
@@ -393,7 +344,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 self.dtype_kv,
                 is_sparse=True,
                 fast_mode=True,
-                **_mla_split_meta_kwargs(self.mla_sparse_mtp_split_budget),
+                **_mla_seg_meta_kwargs(),
             )
             mla_metadata["sparse_mtp_work_meta_data"] = torch.empty(
                 smt_wmd_size, dtype=smt_wmd_type, device=self.device
@@ -611,7 +562,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             "max_seqlen_qo": 1,
             "uni_seqlen_qo": 1,
             "fast_mode": 1,
-            "max_split_per_batch": self.mla_sparse_mtp_split_budget,
+            "max_split_per_batch": _MLA_SPLIT_BUDGET_AUTO,
         }
         work_meta_data = var["sparse_mtp_work_meta_data"]
         work_info_set = var["sparse_mtp_work_info_set"]
@@ -660,7 +611,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             "max_seqlen_qo": max_q_len,
             "uni_seqlen_qo": max_q_len,
             "fast_mode": 1,
-            "max_split_per_batch": self.mla_split_budget,
+            "max_split_per_batch": _MLA_SPLIT_BUDGET_AUTO,
         }
         # round-robin CP only lands on the full-build path: decode_update_mla_
         # metadata_v1 has no is_cp_round_robin arg and collapses qlen>1 to 1.
@@ -1117,11 +1068,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 max_seqlen_qo=1,
                 uni_seqlen_qo=1,
                 fast_mode=1,
-                # Prefill keeps the historical throttle: it already has
-                # query-dimension parallelism, so extra KV splits only buy a bigger
-                # reduce, and the sparse_prefill_* buffers above are sized without a
-                # cap -- raising it here would need that sizing raised in step.
-                max_split_per_batch=_MLA_HISTORICAL_MAX_SPLIT_PER_BATCH,
+                max_split_per_batch=_MLA_PREFILL_MAX_SPLIT_PER_BATCH,
             )
             attn_metadata.sparse_prefill_work_meta_data = var[
                 "sparse_prefill_work_meta_data"
@@ -1502,11 +1449,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             max_seqlen_qo=1,
             uni_seqlen_qo=1,
             fast_mode=1,
-            # Prefill keeps the historical throttle: it already has
-            # query-dimension parallelism, so extra KV splits only buy a bigger
-            # reduce, and the sparse_prefill_* buffers above are sized without a
-            # cap -- raising it here would need that sizing raised in step.
-            max_split_per_batch=_MLA_HISTORICAL_MAX_SPLIT_PER_BATCH,
+            max_split_per_batch=_MLA_PREFILL_MAX_SPLIT_PER_BATCH,
         )
         attn_metadata.sparse_prefill_work_meta_data = var[
             "sparse_prefill_work_meta_data"
@@ -2008,10 +1951,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             max_seqlen_qo=max_q_len,
             uni_seqlen_qo=max_q_len,
             fast_mode=1,
-            # _allocate_ubatch_buffers sized these from the same
-            # get_mla_metadata_info_v1 call as the shared decode buffers, so this
-            # path quotes the same budget (see _mla_decode_split_budget).
-            max_split_per_batch=self.mla_split_budget,
+            max_split_per_batch=_MLA_SPLIT_BUDGET_AUTO,
         )
 
     def build_for_cudagraph_capture(self, bs: int) -> AttentionMetaData:

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -3,6 +3,7 @@
 
 import inspect
 import logging
+import os
 from dataclasses import dataclass
 
 import numpy as np
@@ -52,11 +53,43 @@ except (TypeError, ValueError):
     _MLA_META_SUPPORTS_MAX_SPLIT = False
 
 
+# The persistent MLA decode's global KV-split budget is
+# `min(cu_num, max_split_per_batch * batch_size)`, so at batch_size=1 the 16 below
+# caps the whole decode at 16 of the 256 gfx950 CUs. A batch-1 decode has no
+# parallelism other than the KV walk, and this kernel streams the entire context
+# per layer per step, so that cap is an occupancy ceiling rather than a tuning
+# choice. Measured on Kimi-K3 MXFP4 TP8 at concurrency 1 (~180k-token contexts),
+# raising it to 256 takes aiter's mla_a8w8_qh16_qseqlen4_gqaratio16_v3_ps from
+# 416.7us to 48.0us per call, ITL from 12.68ms to 9.76ms (1.30x) and end-to-end
+# replay of a fixed request set 1.19x faster. Its cost is a heavier mla_reduce
+# (7.8us -> 41.0us), which is why the win shrinks as batch_size grows and the
+# budget stops binding.
+_MLA_MAX_SPLIT_PER_BATCH = int(os.getenv("ATOM_MLA_MAX_SPLIT_PER_BATCH", "16"))
+# kv_granularity is in PAGES, so the historical max(block_size, 16) is 128 pages =
+# 16,384 tokens per split unit at block_size=128. Lowering it is a NET LOSS and is
+# exposed only as an escape hatch: on its own it bought no ITL at all, and stacked
+# on the raised split budget it added 2.5% ITL while costing 34% on TTFT, because
+# prefill already has query-dimension parallelism and extra KV splits there only
+# pay for a bigger reduce. 0 keeps the historical value; leave it at 0.
+_MLA_KV_GRANULARITY = int(os.getenv("ATOM_MLA_KV_GRANULARITY", "0"))
+
+
+def _mla_kv_granularity(block_size: int) -> int:
+    return _MLA_KV_GRANULARITY if _MLA_KV_GRANULARITY > 0 else max(block_size, 16)
+
+
 def _mla_seg_meta_kwargs() -> dict:
-    """Extra kwargs for ``get_mla_metadata_info_v1`` on the seg (page_size>1)
-    path. Empty on the original page_size=1 path so behavior is unchanged."""
-    if envs.ATOM_MLA_PAGE_SIZE > 1 and _MLA_META_SUPPORTS_MAX_SPLIT:
-        return {"max_split_per_batch": 16}
+    """Extra kwargs for ``get_mla_metadata_info_v1``.
+
+    Two callers need ``max_split_per_batch`` here. The segmented page_size>1 path
+    always did. And raising the runtime cap requires the reduce_partial_map buffer
+    to be sized for the larger cap: mla_decode_fwd sizes its fp32 ``logits`` from
+    reduce_partial_map.size(0), so a runtime cap above the sized one writes out of
+    bounds. Sizing and runtime therefore quote the same number."""
+    if not _MLA_META_SUPPORTS_MAX_SPLIT:
+        return {}
+    if envs.ATOM_MLA_PAGE_SIZE > 1 or _MLA_MAX_SPLIT_PER_BATCH != 16:
+        return {"max_split_per_batch": _MLA_MAX_SPLIT_PER_BATCH}
     return {}
 
 
@@ -531,11 +564,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         """
         var = self.model_runner.forward_vars
         split_params = {
-            "kv_granularity": max(self.block_size, 16),
+            "kv_granularity": _mla_kv_granularity(self.block_size),
             "max_seqlen_qo": 1,
             "uni_seqlen_qo": 1,
             "fast_mode": 1,
-            "max_split_per_batch": 16,
+            "max_split_per_batch": _MLA_MAX_SPLIT_PER_BATCH,
         }
         work_meta_data = var["sparse_mtp_work_meta_data"]
         work_info_set = var["sparse_mtp_work_info_set"]
@@ -580,11 +613,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         is_cp_round_robin: bool = False,
     ):
         split_params = {
-            "kv_granularity": max(self.block_size, 16),
+            "kv_granularity": _mla_kv_granularity(self.block_size),
             "max_seqlen_qo": max_q_len,
             "uni_seqlen_qo": max_q_len,
             "fast_mode": 1,
-            "max_split_per_batch": 16,
+            "max_split_per_batch": _MLA_MAX_SPLIT_PER_BATCH,
         }
         # round-robin CP only lands on the full-build path: decode_update_mla_
         # metadata_v1 has no is_cp_round_robin arg and collapses qlen>1 to 1.

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -81,6 +81,7 @@ class DSparkProposer(Drafter):
             return self._blk_ps_bufs
         from atom.model_ops.attentions.aiter_mla import (
             _MLA_META_SUPPORTS_MAX_SPLIT,
+            _MLA_SPLIT_BUDGET_AUTO,
             get_mla_metadata_info_v1,
         )
 
@@ -96,8 +97,14 @@ class DSparkProposer(Drafter):
         # max_split_per_batch only exists in newer aiter builds; feature-detect
         # it (as aiter_mla does) so old builds don't hit a TypeError. Cache the
         # kwargs so the sizing (info) and fill (get_mla_metadata_v1) calls agree.
+        # The block pass is a bs=1, non-causal (msk0) decode over the FULL target
+        # context, so a hardcoded 16 pins it to 16 of the machine's clusters and
+        # starves it at long ctx (~392us at 256k). Take the budget from the
+        # machine like the rest of the decode path (_MLA_SPLIT_BUDGET_AUTO=-1).
         self._blk_split_kwargs = (
-            {"max_split_per_batch": 16} if _MLA_META_SUPPORTS_MAX_SPLIT else {}
+            {"max_split_per_batch": _MLA_SPLIT_BUDGET_AUTO}
+            if _MLA_META_SUPPORTS_MAX_SPLIT
+            else {}
         )
         (
             (wmd_sz, wmd_ty),


### PR DESCRIPTION
The persistent aiter MLA metadata build asks the kernel for a global KV-split budget, and we quoted a hardcoded 16. aiter derives that number itself when asked to: `max_split_per_batch < 0` means `num_splits = num_clusters` (`csrc/kernels/mla/metadata/v1_2_device.cuh:894`), i.e. cut the KV walk into as many parts as the machine has clusters. That is what ATOM's MHA path has always passed and what aiter defaults to.

`num_splits` is the divisor the planner uses for `payload = ceil(sum_blocks / num_splits) + 16 blocks`, the amount of KV work handed to each CU part. Quoting 16 therefore only binds while `16 * batch_size < num_clusters` — it was never a tuning choice, it was a small-batch throttle, and it left a batch-1 decode on 16 of a gfx950's 256 CUs. A batch-1 decode has no parallelism other than that KV walk: MLA's `num_heads_k` is 1, so the head dimension contributes none, and decode has no query dimension to speak of.

**The change is to stop overriding aiter.** All five call sites now pass `-1`: the shared persistent decode metadata, the sparse-MTP set, the TBO per-ubatch build, and the two sparse-prefill builds. On the prefill path the cap was inert to begin with — sparse prefill treats every query token as its own batch, so `num_batches` is the chunk's token count and `16 * num_batches` already saturates `num_clusters` for any chunk of 16 tokens or more.

**Buffer sizing is byte-for-byte unchanged, deliberately.** `get_mla_metadata_info_v1`'s fast-mode bound, `min(bs + max_splits - 1, (max_splits - 1) * 2) * tiles`, is already the worst case for `num_splits == num_clusters`: the planner walks `num_cu` CU parts and each emits at most one partial before yielding, so the `reduce_partial_map` entry count is bounded by `num_cu + tile_cnt` regardless of this parameter. aiter #3855 says the same — its capped expression `tile_cnt + per_tile_cap` is a conservative upper bound kept `>=` the fast-mode one, not a fix for an under-allocation. Nothing here changes what `mla_decode_fwd` allocates for its fp32 `logits`.

### Effect

`num_splits = min(num_clusters=256, cap * bs)` on MI355X at occupancy 1:

| bs | 1 | 2 | 4 | 8 | 16 | 32 |
|---|---|---|---|---|---|---|
| before (cap 16) | 16 | 32 | 64 | 128 | 256 | 256 |
| after (aiter's -1) | 256 | 256 | 256 | 256 | 256 | 256 |

Bit-identical at bs >= 16; the change is confined to the batch sizes that cannot fill the machine. Short contexts are not over-split either — the planner's `payload` floor of 16 blocks means a 2k-token context still yields ~7 work items instead of 5, while a 180k one goes from 15 to 187.

### Measurement

Kimi-K3 MXFP4, 8x MI355X, tp8, DSpark N=2, InferenceX AgentX trace replay at concurrency 1. The budget the kernel picks there is 256, the same number the measurement forced (16 heads, 256 CUs, occupancy 1):

```
mla_a8w8_qh16_qseqlen4_gqaratio16_v3_ps   416.7us -> 48.0us per call
paired kn_mla_reduce_v1                     7.8us -> 41.0us per call
aggregate ITL                              12.68ms -> 9.76ms   (1.30x)
replay of a fixed 168-request set          3,358s -> 2,813s    (1.19x)
```

Output sequence lengths matched the unpatched run on every request. The reduce gets more partials to combine, so the win narrows as batch_size grows and the throttle stops binding anyway.

### Notes for review

- On by default for the native MLA persistent path (DSv3/V4/GLM/Kimi), so it needs `ci:atom` accuracy green before merge: the split count changes the fp32 reduce order.
- Only concurrency 1 is measured. bs=2..8 also changes (bs=4: 64 -> 256 splits) and is worth one replay pass before merge, even though the partial count cannot grow past `num_clusters` at any batch size.
- The one prefill case this does change is a chunk of fewer than 16 query tokens (a chunked-prefill tail, or few owned queries per rank under DCP). Those are small enough that the 16-block payload floor keeps the work-item count essentially where it was.
- `atom/plugin/vllm/attention/metadata.py:1177` still hardcodes the same 16 on the vLLM-plugin persistent decode. Same ceiling, same one-line fix; left for a follow-up PR so this one stays single-file.
- Unrelated and pre-existing, noticed while reading the planner: the kernel recomputes its cluster count from each call's actual q-len, and occupancy is a point condition on `num_heads * q_len == 64` rather than monotonic in q_len. A runtime q-len below the sizing q-len can therefore land on occupancy 2 while the buffers were sized at occupancy 1 (e.g. num_heads=32, num_spec_tokens=2, `AITER_ENABLE_EXPERIMENTAL` on). That is independent of this parameter — worth a separate look, not addressed here.

### Changed since the earlier revisions

The first revision exposed the budget as `ATOM_MLA_MAX_SPLIT_PER_BATCH` (plus an `ATOM_MLA_KV_GRANULARITY` escape hatch) defaulting to the old 16; the second derived the cluster count host-side via `get_mla_decode_fwd_max_splits` and fed it to both the sizing and the runtime call. Both are gone. aiter derives the same number from the device it is running on, so the framework has nothing to contribute here, and the sizing side never needed a matching value. Any `ATOM_MLA_MAX_SPLIT_PER_BATCH` export in a launch script is a no-op and can be dropped.