### PR TITLE
perf(frontend+server): stop the event loop stalling between request waves

### DIFF
--- a/atom/benchmarks/benchmark_serving.py
+++ b/atom/benchmarks/benchmark_serving.py
@@ -27,6 +27,7 @@ On the client side, run:
 
 import argparse
 import asyncio
+import collections
 import contextlib
 import functools
 import gc
@@ -305,6 +306,14 @@ async def get_request(
         interval = np.random.gamma(shape=burstiness, scale=theta)
         # The next request will be sent after the interval.
         await asyncio.sleep(interval)
+
+
+def _failure_reason(error: str) -> str:
+    """The last line of a traceback, which is the part that identifies it."""
+    lines = [
+        line.strip() for line in (error or "").strip().splitlines() if line.strip()
+    ]
+    return lines[-1][:110] if lines else "unknown (no error recorded)"
 
 
 def calculate_metrics(
@@ -636,6 +645,15 @@ async def benchmark(
 
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
+    failures = collections.Counter(
+        _failure_reason(output.error) for output in outputs if not output.success
+    )
+    if failures:
+        # Every metric below is over the survivors, so a run that lost requests
+        # must not report its throughput as though it had not.
+        print("{:<40} {:<10}".format("FAILED requests:", sum(failures.values())))
+        for reason, count in failures.most_common(5):
+            print(f"{'':4}{count:<8} {reason}")
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
     print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1988,6 +1988,28 @@ def main():
         help="Server port (note: --port is used for internal engine communication)",
     )
     parser.add_argument(
+        "--timeout-keep-alive",
+        type=int,
+        default=5,
+        help=(
+            "Seconds the server holds an idle keep-alive connection. Pooling "
+            "clients hold their end far longer (aiohttp 15s), so a caller that "
+            "pauses longer than this reuses a socket the server already closed "
+            "and has to re-send. Raise it past the caller's idle time to stop "
+            "that; requests here run for minutes, so uvicorn's 5s is short."
+        ),
+    )
+    parser.add_argument(
+        "--disable-uvicorn-access-log",
+        action="store_true",
+        help=(
+            "Stop uvicorn logging a line per HTTP request. It copies a "
+            "LogRecord and writes to the same stdout the engine logs to, on "
+            "the event loop, and says less than the engine's own "
+            "'Request N arrived' line."
+        ),
+    )
+    parser.add_argument(
         "--chat-template",
         type=str,
         default=None,
@@ -2093,7 +2115,14 @@ def main():
     logger.info(
         f"Starting server on {args.host}:{args.server_port} (loop={loop_impl})..."
     )
-    uvicorn.run(app, host=args.host, port=args.server_port, loop=loop_impl)
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.server_port,
+        loop=loop_impl,
+        access_log=not args.disable_uvicorn_access_log,
+        timeout_keep_alive=args.timeout_keep_alive,
+    )
 
 
 if __name__ == "__main__":

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -416,13 +416,14 @@ def _send_stream_chunk_direct(
     request_id: str,
     stream_collector: StreamOutputCollector,
     loop: AbstractEventLoop,
+    state: Any,
 ) -> None:
     """Buffer a single-request chunk for this engine step."""
     assert _stream_batch_dispatcher is not None
     _stream_batch_dispatcher.enqueue(
         loop=loop,
         collector=stream_collector,
-        state_key=request_id,
+        state=state,
         chunk=_build_stream_chunk(request_output, request_id),
     )
 
@@ -439,6 +440,7 @@ def _send_stream_chunk_tagged(
     sibling_index: int,
     stream_collector: StreamOutputCollector,
     loop: AbstractEventLoop,
+    state: Any,
 ) -> None:
     """Variant of :func:`_send_stream_chunk_direct` for fan-out siblings.
 
@@ -454,7 +456,7 @@ def _send_stream_chunk_tagged(
     _stream_batch_dispatcher.enqueue(
         loop=loop,
         collector=stream_collector,
-        state_key=(request_id, sibling_index),
+        state=state,
         chunk=_build_stream_chunk(request_output, request_id),
         tag=sibling_index,
     )
@@ -538,7 +540,7 @@ async def generate_async(
         #      its own KV on finish, but this dict is only cleaned up here for
         #      non-stream requests -- without an unconditional pop, every
         #      completed non-stream request leaks a Sequence (pending grows
-        #      forever). Streaming pops via cleanup_streaming_request instead.
+        #      forever). Streaming pops via cleanup_stream instead.
         if seq is not None:
             if not _finished_ok:
                 try:
@@ -838,9 +840,14 @@ async def setup_streaming_request(
     _stream_loops[request_id] = stream_loop
     _request_start_times[request_id] = time.time()
 
+    # The detokenizer lives in this closure, so it is freed when the engine
+    # drops the callback on the stream's last chunk -- no registry, no cleanup.
+    assert _stream_batch_dispatcher is not None
+    detokenizer = _stream_batch_dispatcher.new_state()
+
     def stream_callback(request_output: RequestOutput) -> None:
         _send_stream_chunk_direct(
-            request_output, request_id, stream_collector, stream_loop
+            request_output, request_id, stream_collector, stream_loop, detokenizer
         )
 
     executor_loop = asyncio.get_event_loop()
@@ -876,14 +883,8 @@ async def setup_streaming_request(
     return seq_id, stream_collector, seq.num_prompt_tokens
 
 
-def cleanup_streaming_request(
-    request_id: str, seq_id: int, aborted: bool = False
-) -> None:
-    """Clean up resources for a streaming request.
-
-    Safe to call multiple times for the same ``request_id`` with different
-    ``seq_id`` values (as happens in fan-out cleanup): the per-request
-    dicts use ``dict.pop(..., None)`` so repeated removal is a no-op.
+def cleanup_stream(seq_id: int, aborted: bool = False) -> None:
+    """Tear down one stream. A fan-out request runs this once per sibling.
 
     ``aborted`` says the stream did NOT reach its normal end (client disconnect
     or abnormal generator teardown), so the seq is likely still running in the
@@ -893,16 +894,25 @@ def cleanup_streaming_request(
     request).
     """
     _seq_id_to_request_id.pop(seq_id, None)
-    _stream_loops.pop(request_id, None)
-    _request_start_times.pop(request_id, None)
-    if _stream_batch_dispatcher is not None:
-        _stream_batch_dispatcher.discard_request(request_id)
     if aborted:
         try:
             engine.core_mgr.abort_request(seq_id)
         except Exception:
             pass
     engine.io_processor.requests.pop(seq_id, None)
+
+
+def cleanup_request(request_id: str) -> None:
+    """Tear down what a request owns beyond its individual streams.
+
+    Runs once, after every one of the request's streams has been cleaned up.
+    Separate from :func:`cleanup_stream` because a fan-out has n streams but
+    one request: folding both into one call meant these two pops ran n times,
+    n-1 of them no-ops, and made a caller pass a seq id and a request id
+    together when each half only needs one of them.
+    """
+    _stream_loops.pop(request_id, None)
+    _request_start_times.pop(request_id, None)
 
 
 class _ClientDisconnected(Exception):
@@ -1028,10 +1038,20 @@ async def setup_streaming_request_fanout(
     _stream_loops[request_id] = stream_loop
     _request_start_times[request_id] = time.time()
 
+    assert _stream_batch_dispatcher is not None
+
     def make_callback(idx: int):
+        # One detokenizer per sibling, held by the closure that feeds it.
+        detokenizer = _stream_batch_dispatcher.new_state()
+
         def _cb(request_output: RequestOutput) -> None:
             _send_stream_chunk_tagged(
-                request_output, request_id, idx, shared_collector, stream_loop
+                request_output,
+                request_id,
+                idx,
+                shared_collector,
+                stream_loop,
+                detokenizer,
             )
 
         return _cb
@@ -1287,7 +1307,8 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     stream_collector,
                     seq_ids,
                     num_prompt_tokens,
-                    cleanup_streaming_request,
+                    cleanup_stream,
+                    cleanup_request,
                     tools=request.tools,
                 )
             else:
@@ -1307,7 +1328,8 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     stream_collector,
                     seq_id,
                     num_prompt_tokens,
-                    cleanup_streaming_request,
+                    cleanup_stream,
+                    cleanup_request,
                     tools=request.tools,
                     tool_choice=request.tool_choice,
                     starts_thinking=_starts_thinking,
@@ -1461,7 +1483,8 @@ async def completions(request: CompletionRequest, raw_request: Request):
                     stream_collector,
                     seq_ids,
                     num_prompt_tokens,
-                    cleanup_streaming_request,
+                    cleanup_stream,
+                    cleanup_request,
                 )
             else:
                 seq_id, stream_collector, num_prompt_tokens = (
@@ -1479,7 +1502,8 @@ async def completions(request: CompletionRequest, raw_request: Request):
                     stream_collector,
                     seq_id,
                     num_prompt_tokens,
-                    cleanup_streaming_request,
+                    cleanup_stream,
+                    cleanup_request,
                 )
             return StreamingResponse(
                 _logged_stream(gen, request_id),
@@ -1782,7 +1806,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             aborted = False
                             break
                 finally:
-                    cleanup_streaming_request(request_id, seq_id, aborted=aborted)
+                    cleanup_stream(seq_id, aborted=aborted)
+                    cleanup_request(request_id)
 
             return StreamingResponse(
                 generate_anthropic_stream(),

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -877,7 +877,13 @@ async def setup_streaming_request(
         raise
     seq_id = seq.id
 
-    logger.info(f"API: Created request_id={request_id}, seq_id={seq_id}")
+    # debug, not info: this runs once per request, on the event loop, and
+    # logging takes a lock the engine's output threads are also contending for.
+    # A loop-stall watchdog at concurrency 8192 caught 26 stalls over a run and
+    # 9 of them were sitting on this line, up to 3.3 s each -- long enough that
+    # the server accepts no new request at all and the GPUs run dry waiting for
+    # work. Anything per-request logged from here has to stay off info.
+    logger.debug(f"API: Created request_id={request_id}, seq_id={seq_id}")
     engine.core_mgr.add_request([seq])
 
     return seq_id, stream_collector, seq.num_prompt_tokens
@@ -1086,7 +1092,9 @@ async def setup_streaming_request_fanout(
             engine.io_processor.requests.pop(seq.id, None)
         raise
     seq_ids = [seq.id for seq in seqs]
-    logger.info(
+    # debug for the same reason as its single-sequence counterpart: per-request
+    # logging on the event loop stalls it under load.
+    logger.debug(
         f"API: Created fan-out request_id={request_id}, n={n}, seq_ids={seq_ids}"
     )
     engine.core_mgr.add_request(seqs)

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -228,7 +228,8 @@ async def stream_chat_response(
     stream_collector: StreamOutputCollector,
     seq_id: int,
     num_prompt_tokens: int,
-    cleanup_fn,
+    cleanup_stream,
+    cleanup_request,
     tools=None,
     tool_choice=None,
     starts_thinking: bool = False,
@@ -357,7 +358,8 @@ async def stream_chat_response(
             + STREAM_DONE_MESSAGE
         )
     finally:
-        cleanup_fn(request_id, seq_id, aborted=aborted)
+        cleanup_stream(seq_id, aborted=aborted)
+        cleanup_request(request_id)
 
 
 def _build_chat_choice(
@@ -501,7 +503,8 @@ async def stream_chat_response_fanout(
     shared_collector: StreamOutputCollector,
     seq_ids: list[int],
     num_prompt_tokens: int,
-    cleanup_fn,
+    cleanup_stream,
+    cleanup_request,
     tools=None,
 ) -> AsyncGenerator[str, None]:
     """Streaming variant that multiplexes ``len(seq_ids)`` fan-out siblings
@@ -647,6 +650,6 @@ async def stream_chat_response_fanout(
             + STREAM_DONE_MESSAGE
         )
     finally:
-        # Clean up all sibling seq_id entries then the shared request state.
         for sid in seq_ids:
-            cleanup_fn(request_id, sid, aborted=aborted)
+            cleanup_stream(sid, aborted=aborted)
+        cleanup_request(request_id)

--- a/atom/entrypoints/openai/serving_completion.py
+++ b/atom/entrypoints/openai/serving_completion.py
@@ -59,7 +59,8 @@ async def stream_completion_response(
     stream_collector: StreamOutputCollector,
     seq_id: int,
     num_prompt_tokens: int,
-    cleanup_fn,
+    cleanup_stream,
+    cleanup_request,
 ) -> AsyncGenerator[str, None]:
     """Generate streaming text completion response.
 
@@ -121,7 +122,8 @@ async def stream_completion_response(
 
             yield content_chunk
     finally:
-        cleanup_fn(request_id, seq_id, aborted=aborted)
+        cleanup_stream(seq_id, aborted=aborted)
+        cleanup_request(request_id)
 
 
 def build_completion_response(
@@ -206,7 +208,8 @@ async def stream_completion_response_fanout(
     shared_collector: StreamOutputCollector,
     seq_ids: list[int],
     num_prompt_tokens: int,
-    cleanup_fn,
+    cleanup_stream,
+    cleanup_request,
 ) -> AsyncGenerator[str, None]:
     """Streaming variant multiplexing ``len(seq_ids)`` siblings into one SSE.
 
@@ -278,4 +281,5 @@ async def stream_completion_response_fanout(
         )
     finally:
         for sid in seq_ids:
-            cleanup_fn(request_id, sid, aborted=aborted)
+            cleanup_stream(sid, aborted=aborted)
+        cleanup_request(request_id)

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -11,7 +11,6 @@ landing point each stream's SSE generator reads from.
 
 import threading
 from asyncio import AbstractEventLoop, Event
-from collections.abc import Hashable
 from dataclasses import dataclass, field
 from typing import Any, NamedTuple
 
@@ -119,25 +118,41 @@ class _BufferedChunk(NamedTuple):
 
     loop: AbstractEventLoop
     collector: Any
-    state_key: Hashable
+    state: IncrementalStreamDetokenizer
     chunk: dict
     tag: int | None
 
 
 class StreamBatchDispatcher:
-    """Collect one engine step per output thread and dispatch it by event loop."""
+    """Collect one engine step per output thread and dispatch it by event loop.
+
+    Holds no per-stream state. Each stream's detokenizer belongs to the engine
+    callback that feeds it, and rides along on every chunk, so nothing here is
+    shared between the output threads and the event loop and nothing has to be
+    cleaned up: when the engine drops a finished stream's callback the
+    detokenizer goes with it.
+
+    It used to live in a dict here, which cost a lock -- 27% of the API
+    server's CPU, since every buffered chunk looked its state up with all
+    output threads contending -- and then, without the lock, cost an entry
+    that two threads had to keep in agreement and that teardown had to
+    remember to remove.
+    """
 
     def __init__(self, tokenizer: Any):
         self.tokenizer = tokenizer
         self._thread_local = threading.local()
-        self._states: dict[Hashable, IncrementalStreamDetokenizer] = {}
+
+    def new_state(self) -> IncrementalStreamDetokenizer:
+        """Make the detokenizer for one stream, for its callback to hold."""
+        return IncrementalStreamDetokenizer(self.tokenizer)
 
     def enqueue(
         self,
         *,
         loop: AbstractEventLoop,
         collector: Any,
-        state_key: Hashable,
+        state: IncrementalStreamDetokenizer,
         chunk: dict,
         tag: int | None = None,
     ) -> None:
@@ -145,7 +160,7 @@ class StreamBatchDispatcher:
         buf = getattr(self._thread_local, "buf", None)
         if buf is None:
             buf = self._thread_local.buf = []
-        buf.append(_BufferedChunk(loop, collector, state_key, chunk, tag))
+        buf.append(_BufferedChunk(loop, collector, state, chunk, tag))
 
     def flush(self) -> None:
         """Detokenize buffered chunks and schedule one delivery per event loop."""
@@ -157,48 +172,15 @@ class StreamBatchDispatcher:
 
         by_loop: dict[AbstractEventLoop, list[tuple[Any, Any]]] = {}
         for item in buf:
-            state = self._get_state(item.state_key)
-            finished = bool(item.chunk.get("finished"))
-            item.chunk["text"] = state.update(
-                item.chunk.get("token_ids") or [], finished
+            item.chunk["text"] = item.state.update(
+                item.chunk.get("token_ids") or [],
+                bool(item.chunk.get("finished")),
             )
-            if finished:
-                self._drop_state(item.state_key, state)
-
             payload = item.chunk if item.tag is None else (item.tag, item.chunk)
             by_loop.setdefault(item.loop, []).append((item.collector, payload))
 
         for loop, items in by_loop.items():
             loop.call_soon_threadsafe(self._deliver, items)
-
-    # These three ran under a shared lock, which cost 27% of the API server's
-    # CPU -- _get_state is called once per buffered chunk, with all output
-    # threads contending. No lock is needed: each operation below is a single
-    # C-level dict method that no other Python thread can interrupt, and
-    # list() snapshots atomically so discard_request cannot hit "dict changed
-    # size". GIL-dependent; a free-threaded build would need real locks.
-
-    def discard_request(self, request_id: str) -> None:
-        """Drop direct and fan-out detokenizer state after request cleanup."""
-        for key in list(self._states):
-            if key == request_id or (
-                isinstance(key, tuple) and key and key[0] == request_id
-            ):
-                self._states.pop(key, None)
-
-    def _get_state(self, state_key: Hashable) -> IncrementalStreamDetokenizer:
-        state = self._states.get(state_key)
-        if state is None:
-            state = self._states.setdefault(
-                state_key, IncrementalStreamDetokenizer(self.tokenizer)
-            )
-        return state
-
-    def _drop_state(
-        self, state_key: Hashable, state: IncrementalStreamDetokenizer
-    ) -> None:
-        if self._states.get(state_key) is state:
-            self._states.pop(state_key, None)
 
     @staticmethod
     def _deliver(items: list[tuple[Any, Any]]) -> None:

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -139,6 +139,8 @@ Server-specific CLI arguments:
 |----------|---------|-------------|
 | `--host` | `0.0.0.0` | Bind address |
 | `--server-port` | `8000` | HTTP port (note: `--port` is for internal engine communication) |
+| `--timeout-keep-alive` | `5` | Seconds an idle keep-alive connection is held. Pooling clients hold their end longer (aiohttp defaults to 15s), so a caller that pauses for longer than this reuses a socket the server already closed and has to re-send. Raise it past the caller's idle window to avoid that |
+| `--disable-uvicorn-access-log` | off | Stop uvicorn logging a line per HTTP request. It copies a `LogRecord` and writes to the same stdout as the engine, on the event loop |
 
 All `EngineArgs` arguments are also accepted (see Section 7 for the full list).
 

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -305,7 +305,8 @@ class TestStreamingRoleChunkContent:
                 stream_collector=collector,
                 seq_id=0,
                 num_prompt_tokens=1,
-                cleanup_fn=lambda *a, **k: None,
+                cleanup_stream=lambda *a, **k: None,
+                cleanup_request=lambda *a, **k: None,
             )
             first_chunk = await gen.__anext__()
             await gen.aclose()
@@ -333,7 +334,8 @@ class TestStreamingRoleChunkContent:
                 shared_collector=collector,
                 seq_ids=[0, 1],
                 num_prompt_tokens=1,
-                cleanup_fn=lambda *a, **k: None,
+                cleanup_stream=lambda *a, **k: None,
+                cleanup_request=lambda *a, **k: None,
             )
             chunk_0 = await gen.__anext__()
             chunk_1 = await gen.__anext__()
@@ -349,3 +351,50 @@ class TestStreamingRoleChunkContent:
             delta = choice["delta"]
             assert delta["role"] == "assistant"
             assert delta["content"] == ""
+
+
+class TestFanoutCleanupSplit:
+    """A fan-out has n streams but one request, and teardown reflects that.
+
+    Per-sequence work (dropping the detokenizer state, aborting a seq that is
+    still running) has to happen once per sibling; the per-request bookkeeping
+    only once. Folding both into a single callback ran the request half n
+    times, n-1 of them no-ops, and forced every caller to pass a seq id and a
+    request id together when each half needs only one of them.
+    """
+
+    def _cleanup_calls(self, seq_ids):
+        stream_calls, request_calls = [], []
+
+        async def run():
+            collector = StreamOutputCollector("req-3")
+            for index in range(len(seq_ids)):
+                collector.put_nowait(
+                    (index, {"text": "", "token_ids": [], "finished": True})
+                )
+            gen = stream_chat_response_fanout(
+                request_id="req-3",
+                model="model",
+                shared_collector=collector,
+                seq_ids=seq_ids,
+                num_prompt_tokens=1,
+                cleanup_stream=lambda seq_id, **kwargs: stream_calls.append(seq_id),
+                cleanup_request=request_calls.append,
+            )
+            async for _ in gen:
+                pass
+
+        asyncio.run(run())
+        return stream_calls, request_calls
+
+    def test_every_sibling_seq_is_torn_down(self):
+        seq_ids = [70, 71, 72, 73]
+
+        stream_calls, _ = self._cleanup_calls(seq_ids)
+
+        assert stream_calls == seq_ids
+
+    def test_the_request_is_torn_down_exactly_once(self):
+        _, request_calls = self._cleanup_calls([70, 71, 72, 73])
+
+        assert request_calls == ["req-3"]

--- a/tests/entrypoints/test_streaming_dispatch.py
+++ b/tests/entrypoints/test_streaming_dispatch.py
@@ -72,13 +72,13 @@ def test_dispatcher_batches_direct_and_tagged_chunks_per_loop():
     dispatcher.enqueue(
         loop=loop,
         collector=direct_queue,
-        state_key="request-1",
+        state=dispatcher.new_state(),
         chunk={"token_ids": [ord("A")], "finished": True},
     )
     dispatcher.enqueue(
         loop=loop,
         collector=tagged_queue,
-        state_key=("request-2", 0),
+        state=dispatcher.new_state(),
         chunk={"token_ids": [ord("B")], "finished": True},
         tag=0,
     )
@@ -95,18 +95,19 @@ def test_dispatcher_keeps_fanout_detokenizer_state_separate():
     dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
     loop = _ImmediateLoop()
     queue = asyncio.Queue()
+    sibling_0, sibling_1 = dispatcher.new_state(), dispatcher.new_state()
 
     dispatcher.enqueue(
         loop=loop,
         collector=queue,
-        state_key=("request", 0),
+        state=sibling_0,
         chunk={"token_ids": [0xE4], "finished": False},
         tag=0,
     )
     dispatcher.enqueue(
         loop=loop,
         collector=queue,
-        state_key=("request", 1),
+        state=sibling_1,
         chunk={"token_ids": [ord("X")], "finished": True},
         tag=1,
     )
@@ -115,10 +116,11 @@ def test_dispatcher_keeps_fanout_detokenizer_state_separate():
     assert queue.get_nowait()[1]["text"] == ""
     assert queue.get_nowait()[1]["text"] == "X"
 
+    # Sibling 0's half character survives sibling 1 finishing in between.
     dispatcher.enqueue(
         loop=loop,
         collector=queue,
-        state_key=("request", 0),
+        state=sibling_0,
         chunk={"token_ids": [0xBD, 0xA0], "finished": True},
         tag=0,
     )
@@ -127,26 +129,26 @@ def test_dispatcher_keeps_fanout_detokenizer_state_separate():
     assert queue.get_nowait()[1]["text"] == "你"
 
 
-def test_discard_request_drops_partial_direct_and_fanout_state():
+def test_a_fresh_stream_does_not_inherit_a_half_decoded_character():
+    """Each stream's detokenizer is its own object, so bytes cannot leak over."""
     dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
     loop = _ImmediateLoop()
     queue = asyncio.Queue()
 
-    for state_key in ("request", ("request", 0)):
+    for _ in range(2):
         dispatcher.enqueue(
             loop=loop,
             collector=queue,
-            state_key=state_key,
+            state=dispatcher.new_state(),
             chunk={"token_ids": [0xE4], "finished": False},
         )
     dispatcher.flush()
-    dispatcher.discard_request("request")
 
-    for state_key in ("request", ("request", 0)):
+    for _ in range(2):
         dispatcher.enqueue(
             loop=loop,
             collector=queue,
-            state_key=state_key,
+            state=dispatcher.new_state(),
             chunk={"token_ids": [ord("A")], "finished": True},
         )
     dispatcher.flush()
@@ -243,6 +245,7 @@ def _stream_through_collector(payload: bytes, drain_every: int):
     dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
     loop = _ImmediateLoop()
     collector = StreamOutputCollector("request-1")
+    state = dispatcher.new_state()
 
     texts = []
     token_ids = []
@@ -252,7 +255,7 @@ def _stream_through_collector(payload: bytes, drain_every: int):
         dispatcher.enqueue(
             loop=loop,
             collector=collector,
-            state_key="request-1",
+            state=state,
             chunk={"token_ids": [byte], "finished": last},
         )
         dispatcher.flush()
@@ -299,7 +302,7 @@ def test_a_step_is_delivered_in_a_single_loop_callback():
         dispatcher.enqueue(
             loop=loop,
             collector=collector,
-            state_key=f"request-{index}",
+            state=dispatcher.new_state(),
             chunk={"token_ids": [ord("A")], "finished": True},
         )
     dispatcher.flush()
@@ -314,12 +317,13 @@ def test_two_steps_keep_their_order_within_one_stream():
     dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
     loop = _RecordingLoop()
     collector = StreamOutputCollector("request-1")
+    state = dispatcher.new_state()
 
     for byte, finished in ((ord("a"), False), (ord("b"), True)):
         dispatcher.enqueue(
             loop=loop,
             collector=collector,
-            state_key="request-1",
+            state=state,
             chunk={"token_ids": [byte], "finished": finished},
         )
         dispatcher.flush()
@@ -340,3 +344,38 @@ def test_merge_keeps_end_of_stream_and_never_extends_the_engines_list():
     assert into["text"] == "ab"
     assert into["token_ids"] == [1, 2]
     assert engine_tokens == [1]
+
+
+def test_dispatcher_keeps_no_per_stream_state():
+    """The dispatcher must stay stateless between streams.
+
+    Detokenizers used to live in a dict here: first behind a lock that cost 27%
+    of the API server's CPU, then lock-free with an index two threads had to
+    keep in agreement and teardown had to remember to clear -- draining 8192
+    streams cost 894 ms of scanning, and a missed removal leaked a detokenizer
+    whose token list grows without bound. Now each one belongs to the engine
+    callback that feeds it, so there is nothing here to leak or to race on.
+    """
+    dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
+    loop = _ImmediateLoop()
+    queue = asyncio.Queue()
+
+    for _ in range(64):
+        dispatcher.enqueue(
+            loop=loop,
+            collector=queue,
+            state=dispatcher.new_state(),
+            chunk={"token_ids": [ord("A")], "finished": True},
+        )
+    dispatcher.flush()
+
+    assert vars(dispatcher).keys() == {"tokenizer", "_thread_local"}
+
+
+def test_each_stream_gets_its_own_detokenizer():
+    dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
+
+    first, second = dispatcher.new_state(), dispatcher.new_state()
+
+    assert first is not second
+    assert first.tokens == [] and second.tokens == []


### PR DESCRIPTION
## Problem

At concurrency 8192 the GPUs go idle between waves of requests. A torch trace of
`DeepSeek-V4-Flash` tp4 (ISL/OSL 1024/10, 16384 requests) shows the engine
running batches of `bs=1`, `bs=8`, then a stretch of `decode[bs=9]` — the
scheduler has nothing to schedule, while the client has already sent everything
and is sitting at 0% CPU.

Two independent causes, both pre-existing on `main`:

**1. Cleaning up a finished stream was O(live).** Each stream's detokenizer sat
in a dict shared by the engine output threads and the event loop, and teardown
found its entry by scanning every live stream. Draining N streams therefore
cost O(N²) — 894 ms at N=8192, four times that per doubling.

**2. Two per-request log lines held the event loop.** A loop-stall watchdog
(heartbeat task + a thread that dumps the main thread's stack when the
heartbeat goes stale) caught **26 stalls of ≥0.4 s in one run, 9 of them
sitting on `logger.info` in `setup_streaming_request`, up to 3.3 s each**.
`logging` takes a lock that the engine's output threads contend for on the same
handler. During a stall the server accepts *no* request at all — the per-second
admission log goes to a flat zero for 2–4 seconds, which is exactly when the
engine drains and the GPUs run dry.

```
13:34:10  api_server  64%   client 100%   admitted 506
13:34:11             406%          46%              5
13:34:12             100%           0%              0   <- stalled
13:34:13             102%           0%              0
13:34:14             101%           0%              0
13:34:15             229%           6%            322
```

## Changes

**`perf(frontend)`** — the detokenizer belongs to the engine callback that
feeds it. `stream_callback` (n=1) and `make_callback(i)` (each fan-out sibling)
are already per-stream, so the closure holds the detokenizer and passes it with
the chunk. `StreamBatchDispatcher` keeps no per-stream state, the per-chunk dict
lookup is gone from `flush()`, and lifetime is automatic — when the engine drops
a finished stream's callback, the detokenizer goes with it. No scan, no index
for two threads to keep in agreement, nothing for teardown to forget.

Teardown splits the same way: `cleanup_streaming_request` took a seq id *and* a
request id and ran wholesale once per fan-out sibling (including two
per-request pops, n−1 of them no-ops). Now `cleanup_stream(seq_id)` and
`cleanup_request(request_id)` each take only what they need.

**`perf(server)`** — both per-request admission log lines move to `debug`.
Stalls dropped from 26 to 18 and the worst from 3.32 s to 1.45 s, with none of
the remainder landing in `logging`. What is left is h11/starlette protocol work
and waking the SSE generators, which is structural.

**`feat(server)`** — `--timeout-keep-alive` and `--disable-uvicorn-access-log`.
Both were hardcoded to uvicorn's defaults; both are left defaulting to exactly
what they did before. uvicorn's access log costs the same way as the lines above
(13 of the same 26 stalls), but turning it off by default is a visible change to
server behaviour, so it stays opt-in.

**`fix(benchmark)`** — report failed requests. Every metric is computed over the
survivors, so a run that lost requests printed the survivors' throughput as if
nothing had happened.

## Test plan

- [x] `bash .github/scripts/run_unit_tests.sh` — 1411 passed, 52 skipped, 0 failed
- [x] Each of the four commits passes `tests/entrypoints/` on its own (no broken
      intermediate state)
- [x] `black --check` clean; `ruff` clean within the diff context
- [x] `DeepSeek-V4-Flash` tp4, conc 8192, 16384 requests: **16384/16384**, zero
      server-side traceback
- [x] GPU busy 94.1%, idle 17.97 s, worst wave-boundary gap 11175 ms — all
      inside the range of the pre-change runs (93.8–94.3%, 17.46–19.00 s,
      10857–12450 ms)

### On the performance numbers

The frontend refactor is claimed as **neutral, not faster**. This box produces
an idle spread of 9.46–23.71 s across repeated runs of *identical* code, so a
single run cannot resolve a few seconds either way; what is verifiable is the
mechanism (one fewer dict lookup per chunk, scan removed) and that the numbers
land in the pre-change band.

The logging change is different: the watchdog counts are direct observations of
the stall, not an end-to-end inference, so 26→18 and 3.32→1.45 s stand on their
own.
