### PR TITLE
fix(dspark): keep dp-attention by warming the block drafter

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1201,18 +1201,24 @@ class ModelRunner:
 
         num_seqs = min(warmup_max_tokens // max_model_len, self.config.max_num_seqs)
 
-        if num_seqs == 0:
-            num_seqs = 1
-            seq_len = min(warmup_max_tokens, max_model_len)
-            if seq_len == 0:
-                seq_len = 1
+        # torch.compile's mark_dynamic can't make a size-1 batch dim dynamic, so
+        # a DSpark block drafter (rows == num_seqs) must first-compile at B >= 2
+        # (EAGLE gets that free -- its first draft step is a many-row prefill).
+        # Other cases only need the usual >= 1 floor.
+        drafter = getattr(self, "drafter", None)
+        min_seqs = 2 if getattr(drafter, "is_block_drafter", False) else 1
+        num_seqs = max(num_seqs, min_seqs)
+
+        # Split the token budget across the seqs so >1 sequences never exceed it
+        # (peak memory unchanged); a lone seq keeps up to max_model_len.
+        seq_len = max(1, min(max_model_len, warmup_max_tokens // num_seqs))
+
+        if warmup_max_tokens < max_model_len:
             logger.warning(
                 f"{self.label}: dp_size={dp_size}, dp_attn={self.config.enable_dp_attention}, "
                 f"warmup_max_tokens={warmup_max_tokens} < max_model_len={max_model_len}. "
-                f"Using {num_seqs} seq with length {seq_len} for warmup."
+                f"Using {num_seqs} seq(s) with length {seq_len} for warmup."
             )
-        else:
-            seq_len = max_model_len
 
         seqs = [
             Sequence(

--- a/atom/models/deepseek_v4_dspark.py
+++ b/atom/models/deepseek_v4_dspark.py
@@ -883,6 +883,9 @@ class DeepseekV4DSpark(DSparkDraftModel):
         # Rolling target-KV window width. Exposed on the wrapper (top level) so the
         # proposer never reaches through `self.model.model.mtp[0]` to read it.
         self.window_size = int(self.args.window_size)
+        # Markov-head vocab, exposed at the top level (like window_size) so the
+        # proposer can clamp the anchor without reaching into the draft layers.
+        self.vocab_size = int(self.args.vocab_size)
         num_spec = getattr(
             getattr(config, "speculative_config", None),
             "num_speculative_tokens",
@@ -993,8 +996,6 @@ class DeepseekV4DSpark(DSparkDraftModel):
             draft_token_ids: [B, num_draft]
             confidence: [B, num_draft]
         """
-        from atom.utils.forward_context import get_forward_context
-
         T = int(num_draft) if num_draft is not None else self.block_size
 
         # num_draft is a python int, so the decorator does not mark it dynamic
@@ -1010,21 +1011,9 @@ class DeepseekV4DSpark(DSparkDraftModel):
                 f"the compiled graph at CompilationLevel >= DYNAMO_ONCE."
             )
 
-        # mark_dynamic specializes a size-1 dim, so pad WARMUP (the first traced
-        # call) to B==2. Dummy runs only -- a real step would mismatch metadata.
-        is_dummy = get_forward_context().context.is_dummy_run
-        anchor_ids = input_ids
-        pad = is_dummy and input_ids.shape[0] == 1
-        if pad:
-            input_ids = input_ids.repeat(2)
-            positions = positions.repeat(2)
-
         # __call__, not .forward -- the decorator's compiled dispatch lives there.
         normed, hc_hidden = self.model(input_ids, positions, T)
-        if pad:
-            # normed is [B*T, dim] and hc_hidden [B, T, dim]; keep request 0.
-            normed, hc_hidden = normed[:T], hc_hidden[:1]
-        return self.model.head_and_sample(normed, hc_hidden, anchor_ids)
+        return self.model.head_and_sample(normed, hc_hidden, input_ids)
 
 
 @support_torch_compile

--- a/atom/models/kimi_k3_dspark.py
+++ b/atom/models/kimi_k3_dspark.py
@@ -637,6 +637,9 @@ class KimiK3DSpark(DSparkDraftModel):
         )
         self.final_norm = RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
         self.markov_head = DSparkMarkovHead(config.vocab_size, self.markov_rank)
+        # Markov-head vocab, exposed at the top level so the proposer can clamp
+        # the anchor uniformly across DSpark flavors (V4 exposes it too).
+        self.vocab_size = int(config.vocab_size)
 
         # Bound by share_with_target(); both are skipped at load.
         self.embed_tokens = None

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -424,7 +424,7 @@ class DSparkProposer(Drafter):
         # Anchor token x0 per request = the just-verified target token, located
         # at last_token_indices in the flat batch.
         # Seatbelt: markov_w1 is a raw nn.Embedding, so a -1 anchor traps it.
-        anchor_ids = next_token_ids.clamp(0, int(self.model.args.vocab_size) - 1)
+        anchor_ids = next_token_ids.clamp(0, int(self.model.vocab_size) - 1)
         anchor_positions = torch.index_select(target_positions, 0, last_token_indices)
 
         if self._with_draft:


### PR DESCRIPTION
The draft's torch.compiled dummy decode is per-request (rows == num_seqs), but dspark is block drafter, we need (rows == num_seqs) with >= 2 seqs

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
