### PR TITLE
[fix](k3): remove AITER_DISABLE_FMHA_OPUS envs for k3

### DIFF
--- a/.github/benchmark/oot_models_accuracy.json
+++ b/.github/benchmark/oot_models_accuracy.json
@@ -189,7 +189,7 @@
     "model_path": "moonshotai/Kimi-K3",
     "client_command": "lm_eval --model local-completions --model_args model=${MODEL_PATH},base_url=http://127.0.0.1:${VLLM_PORT}/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True --tasks gsm8k --num_fewshot ${LM_EVAL_NUM_FEWSHOT} --output_path ${OUTPUT_PATH}",
     "extra_args": "--trust-remote-code --language-model-only --tensor-parallel-size 8 --kv-cache-dtype fp8 --max-model-len 16384 --max-num-seqs 64 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.93 --block-size 128 --no-enable-prefix-caching --compilation-config '{\"cudagraph_mode\":\"FULL_AND_PIECEWISE\"}' --additional-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"*self_attn.[qkv]_conv1d*\",\"*block_sparse_moe.experts*\",\"*block_sparse_moe.routed_expert_*\",\"*vision_tower*\",\"*mm_projector*\"]}}'",
-    "env_vars": "AITER_DISABLE_FMHA_OPUS=1",
+    "env_vars": "",
     "runner": "atom-plugin-acc-validation-runner-vllm",
     "test_level": "nightly",
     "priority": "P0",

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -154,7 +154,6 @@ jobs:
             model_path: "moonshotai/Kimi-K3"
             client_command: "lm_eval --model local-completions --model_args model=${MODEL_PATH},base_url=http://127.0.0.1:${VLLM_PORT}/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True --tasks gsm8k --num_fewshot ${LM_EVAL_NUM_FEWSHOT} --output_path ${OUTPUT_PATH}"
             extra_args: "--trust-remote-code --language-model-only --tensor-parallel-size 8 --kv-cache-dtype fp8 --max-model-len 16384 --max-num-seqs 64 --max-num-batched-tokens 16384 --gpu-memory-utilization 0.93 --block-size 128 --no-enable-prefix-caching --compilation-config '{\"cudagraph_mode\":\"FULL_AND_PIECEWISE\"}' --additional-config '{\"online_quant_config\":{\"global_quant_config\":\"ptpc_fp8\",\"exclude_layer\":[\"lm_head\",\"model.embed_tokens\",\"*self_attn.[qkv]_conv1d*\",\"*block_sparse_moe.experts*\",\"*block_sparse_moe.routed_expert_*\",\"*vision_tower*\",\"*mm_projector*\"]}}'"
-            env_vars: "AITER_DISABLE_FMHA_OPUS=1"
             lm_eval_num_fewshot: 5
             accuracy_test_threshold: 0.95
             runner: atom-mi355-8gpu-vllm-sgl-ci

--- a/atom/plugin/vllm/attention/layer_sparse_mla.py
+++ b/atom/plugin/vllm/attention/layer_sparse_mla.py
@@ -13,7 +13,6 @@ write, Q absorption, topk index conversion, sparse kernel, V up-projection.
 """
 
 import logging
-from typing import Optional
 
 import torch
 import triton
@@ -246,12 +245,14 @@ def sparse_attn_indexer_plugin_mode(
     k: torch.Tensor,
     weights: torch.Tensor,
     quant_block_size: int,
-    scale_fmt: Optional[str],
+    scale_fmt: str | None,
     topk_tokens: int,
     head_dim: int,
     max_model_len: int,
     total_seq_lens: int,
     sparse_kv_indices_buffer: torch.Tensor,
+    dcp_sparse_kv_indptr_buffer: torch.Tensor,
+    dcp_owned_counts_buffer: torch.Tensor,
     k_norm_weight: torch.Tensor,
     k_norm_bias: torch.Tensor,
     k_norm_eps: float,
@@ -524,12 +525,14 @@ def sparse_attn_indexer_fake(
     k: torch.Tensor,
     weights: torch.Tensor,
     quant_block_size: int,
-    scale_fmt: Optional[str],
+    scale_fmt: str | None,
     topk_tokens: int,
     head_dim: int,
     max_model_len: int,
     total_seq_lens: int,
     sparse_kv_indices_buffer: torch.Tensor,
+    dcp_sparse_kv_indptr_buffer: torch.Tensor,
+    dcp_owned_counts_buffer: torch.Tensor,
     k_norm_weight: torch.Tensor,
     k_norm_bias: torch.Tensor,
     k_norm_eps: float,
@@ -555,7 +558,11 @@ def sparse_attn_indexer_fake(
 direct_register_custom_op(
     op_name="sparse_attn_indexer_plugin_mode",
     op_func=sparse_attn_indexer_plugin_mode,
-    mutates_args=["sparse_kv_indices_buffer"],
+    mutates_args=[
+        "sparse_kv_indices_buffer",
+        "dcp_sparse_kv_indptr_buffer",
+        "dcp_owned_counts_buffer",
+    ],
     fake_impl=sparse_attn_indexer_fake,
 )
 


### PR DESCRIPTION
## Motivation

This PR removed AITER_DISABLE_FMHA_OPUS env for k3 and fixed the interface error introduced by the PR https://github.com/ROCm/ATOM/pull/1832

K3：
<img width="284" height="130" alt="image" src="https://github.com/user-attachments/assets/905b27bd-3c30-49ef-b7aa-841662df830c" />
