### PR TITLE
Skip duplicate heavy CI runs for same PR SHA

### DIFF
--- a/.github/scripts/check_heavy_ci_gate.sh
+++ b/.github/scripts/check_heavy_ci_gate.sh
@@ -13,6 +13,10 @@ EVENT_NAME="${GITHUB_EVENT_NAME:-}"
 EVENT_PATH="${GITHUB_EVENT_PATH:-}"
 REPO="${GITHUB_REPOSITORY:-}"
 CI_GATE_LABELS="${CI_GATE_LABELS:-ci:full}"
+CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN="${CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN:-}"
+DUPLICATE_RUN_ID=""
+DUPLICATE_RUN_EVENT=""
+DUPLICATE_RUN_URL=""
 
 trim() {
   sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
@@ -108,6 +112,65 @@ PY
   echo "${filter_result}"
 }
 
+find_duplicate_successful_heavy_run() {
+  if [ -z "${CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN}" ]; then
+    return 1
+  fi
+
+  local head_sha workflow_ref workflow_file current_run_id run_rows
+  local run_id run_event run_url job_names
+
+  head_sha="$(jq -r '.pull_request.head.sha // empty' "${EVENT_PATH}")"
+  workflow_ref="${GITHUB_WORKFLOW_REF:-}"
+  workflow_file="${workflow_ref%@*}"
+  workflow_file="${workflow_file##*/}"
+  current_run_id="${GITHUB_RUN_ID:-0}"
+  case "${current_run_id}" in
+    ''|*[!0-9]*) current_run_id=0 ;;
+  esac
+
+  if [ -z "${head_sha}" ] || [ -z "${workflow_file}" ]; then
+    echo "Missing head SHA or workflow file; cannot check duplicate heavy CI runs."
+    return 1
+  fi
+
+  echo "Checking for prior successful ${workflow_file} heavy CI run on head SHA ${head_sha}..."
+  if ! run_rows="$(
+    gh api "repos/${REPO}/actions/workflows/${workflow_file}/runs" \
+      --method GET \
+      -F "head_sha=${head_sha}" \
+      -F "status=success" \
+      -F "per_page=20" \
+      --jq ".workflow_runs[] | select(.id != ${current_run_id}) | [.id, .event, .html_url] | @tsv"
+  )"; then
+    echo "Failed to query existing workflow runs; continuing heavy CI gate."
+    return 1
+  fi
+
+  while IFS=$'\t' read -r run_id run_event run_url; do
+    if [ -z "${run_id}" ]; then
+      continue
+    fi
+
+    if ! job_names="$(
+      gh api --paginate "repos/${REPO}/actions/runs/${run_id}/jobs" \
+        --jq '.jobs[] | select(.conclusion == "success") | .name'
+    )"; then
+      echo "Failed to query jobs for run ${run_id}; ignoring it for duplicate detection."
+      continue
+    fi
+
+    if printf '%s\n' "${job_names}" | grep -Eq "${CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN}"; then
+      DUPLICATE_RUN_ID="${run_id}"
+      DUPLICATE_RUN_EVENT="${run_event}"
+      DUPLICATE_RUN_URL="${run_url}"
+      return 0
+    fi
+  done <<< "${run_rows}"
+
+  return 1
+}
+
 emit_decision() {
   local should_run="$1"
   local reason="$2"
@@ -115,6 +178,7 @@ emit_decision() {
   local review_decision="${4:-}"
   local approval_count="${5:-0}"
   local changes_requested_count="${6:-0}"
+  local duplicate_run_url="${7:-}"
 
   {
     echo "should_run=${should_run}"
@@ -123,6 +187,7 @@ emit_decision() {
     echo "review_decision=${review_decision}"
     echo "approval_count=${approval_count}"
     echo "changes_requested_count=${changes_requested_count}"
+    echo "duplicate_run_url=${duplicate_run_url}"
   } >> "${OUTPUT_FILE}"
 
   echo "Heavy CI gate: should_run=${should_run} reason=${reason}"
@@ -132,6 +197,9 @@ emit_decision() {
   if [ -n "${review_decision}" ]; then
     echo "Review decision: ${review_decision}"
     echo "Latest approvals: ${approval_count}; latest changes requested: ${changes_requested_count}"
+  fi
+  if [ -n "${duplicate_run_url}" ]; then
+    echo "Duplicate successful run: ${duplicate_run_url}"
   fi
 
   if [ -n "${SUMMARY_FILE}" ]; then
@@ -146,6 +214,9 @@ emit_decision() {
         echo "- Review decision: \`${review_decision}\`"
         echo "- Latest approvals: \`${approval_count}\`"
         echo "- Latest changes requested: \`${changes_requested_count}\`"
+      fi
+      if [ -n "${duplicate_run_url}" ]; then
+        echo "- Duplicate successful run: ${duplicate_run_url}"
       fi
     } >> "${SUMMARY_FILE}"
   fi
@@ -195,6 +266,11 @@ fi
 
 OWNER="${REPO%%/*}"
 NAME="${REPO#*/}"
+
+if find_duplicate_successful_heavy_run; then
+  emit_decision "false" "duplicate-successful-run" "" "" "0" "0" "${DUPLICATE_RUN_URL}"
+  exit 0
+fi
 
 MATCHED_LABEL="$(find_allowed_pr_label || true)"
 if [ -n "${MATCHED_LABEL}" ]; then

--- a/.github/workflows/atom-sglang-test.yaml
+++ b/.github/workflows/atom-sglang-test.yaml
@@ -37,6 +37,7 @@ jobs:
     name: Check Heavy CI Gate
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     outputs:
@@ -50,6 +51,7 @@ jobs:
         id: gate
         env:
           CI_GATE_LABELS: ci:full,ci:sglang
+          CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN: '^Accuracy \('
           CI_GATE_PATHS_IGNORE: |
             **/*.md
             docs/**

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -56,6 +56,7 @@ jobs:
     name: Check Heavy CI Gate
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     outputs:
@@ -69,6 +70,7 @@ jobs:
         id: gate
         env:
           CI_GATE_LABELS: ci:full,ci:atom
+          CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN: '^(Offline inference smoke test|Accuracy)$'
           CI_GATE_PATHS_IGNORE: |
             **/*.md
             docs/**

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -70,7 +70,7 @@ jobs:
         id: gate
         env:
           CI_GATE_LABELS: ci:full,ci:atom
-          CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN: '^(Offline inference smoke test|Accuracy)$'
+          CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN: '^(Offline inference smoke test|Accuracy)($| \(| / )'
           CI_GATE_PATHS_IGNORE: |
             **/*.md
             docs/**

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -70,7 +70,7 @@ jobs:
         id: gate
         env:
           CI_GATE_LABELS: ci:full,ci:atom
-          CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN: '^(Offline inference smoke test|Accuracy)($| \(| / )'
+          CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN: '^Accuracy \('
           CI_GATE_PATHS_IGNORE: |
             **/*.md
             docs/**

--- a/.github/workflows/atom-vllm-test.yaml
+++ b/.github/workflows/atom-vllm-test.yaml
@@ -37,6 +37,7 @@ jobs:
     name: Check Heavy CI Gate
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     outputs:
@@ -50,6 +51,7 @@ jobs:
         id: gate
         env:
           CI_GATE_LABELS: ci:full,ci:vllm
+          CI_GATE_DUPLICATE_SUCCESS_JOB_PATTERN: '^Accuracy \('
           CI_GATE_PATHS_IGNORE: |
             **/*.md
             docs/**


### PR DESCRIPTION
## Summary
- add duplicate-run detection to the shared heavy CI gate script
- skip heavy CI when the same workflow already has a successful heavy job for the same PR head SHA
- wire the check into ATOM, ATOM vLLM, and ATOM SGLang heavy CI workflows

## Details
The duplicate check looks at prior successful runs of the same workflow file for the current PR head SHA, then verifies that a real heavy job succeeded before skipping. This avoids treating gate-only/skipped workflow runs as duplicates.

## Testing
- bash -n .github/scripts/check_heavy_ci_gate.sh
- git diff --check
- locally simulated PR 1916 pull_request_review event and verified it returns should_run=false with reason duplicate-successful-run when the same SHA already had a successful vLLM heavy run
- locally simulated a labeled event with an unseen SHA and verified it still returns should_run=true with reason label-present