### PR TITLE
[feat][kimi-k3] enable dcp for k3 + dspark

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -517,24 +517,6 @@ class MLAAttention(nn.Module):
                 self.dcp_kernel_num_heads - self.num_heads * self.dcp_world_size
             )
 
-    def _dcp_all_gather_query_heads(self, q: torch.Tensor) -> torch.Tensor:
-        """AllGather Q across the DCP group along the head dim.
-
-        Flattened to 2-D so the gather lands on the last dim. aiter's custom
-        collective only serves dim 0 and the last dim, and its last-dim variant
-        concatenates rank-major -- which for a ``[tokens, heads*head_dim]`` view
-        is exactly head-dim concat. Gathering the 3-D tensor on dim=1 instead
-        both misses the custom kernel and makes the pynccl path materialise an
-        extra reshape copy of the gathered result.
-        """
-        tokens, _, head_dim = q.shape
-        if not q.is_contiguous():
-            return self.dcp_group.all_gather(q, dim=1)
-        from atom.model_ops.dcp_ops import dcp_all_gather
-
-        gathered = dcp_all_gather(self.dcp_group, q.reshape(tokens, -1), -1)
-        return gathered.view(tokens, -1, head_dim)
-
     def _pad_decode_query_heads(self, q: torch.Tensor) -> torch.Tensor:
         """Head padding for the decode kernel. Under DCP q arrives already
         gathered across the DCP group, so it is that width -- not the per-rank
@@ -2017,12 +1999,15 @@ class MLAAttention(nn.Module):
             elif self.dcp_world_size > 1:
                 # DCP decode: AllGather Q on the head dim, decode locally with LSE,
                 # then combine partial outputs across ranks (AG LSE + correct + RS).
-                from atom.model_ops.dcp_ops import cp_lse_ag_out_rs
+                from atom.model_ops.dcp_ops import (
+                    cp_lse_ag_out_rs,
+                    dcp_all_gather_query_heads,
+                )
 
                 # Only real heads cross the wire and enter the combine; the pad the
                 # kernel width needs lives inside _forward_decode (see
                 # dcp_kernel_num_heads).
-                q_out = self._dcp_all_gather_query_heads(q_out)
+                q_out = dcp_all_gather_query_heads(self.dcp_group, q_out)
                 o, lse = self._forward_decode(
                     q_out, kv_cache, attn_metadata, return_lse=True
                 )

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -517,6 +517,24 @@ class MLAAttention(nn.Module):
                 self.dcp_kernel_num_heads - self.num_heads * self.dcp_world_size
             )
 
+    def _dcp_all_gather_query_heads(self, q: torch.Tensor) -> torch.Tensor:
+        """AllGather Q across the DCP group along the head dim.
+
+        Flattened to 2-D so the gather lands on the last dim. aiter's custom
+        collective only serves dim 0 and the last dim, and its last-dim variant
+        concatenates rank-major -- which for a ``[tokens, heads*head_dim]`` view
+        is exactly head-dim concat. Gathering the 3-D tensor on dim=1 instead
+        both misses the custom kernel and makes the pynccl path materialise an
+        extra reshape copy of the gathered result.
+        """
+        tokens, _, head_dim = q.shape
+        if not q.is_contiguous():
+            return self.dcp_group.all_gather(q, dim=1)
+        from atom.model_ops.dcp_ops import dcp_all_gather
+
+        gathered = dcp_all_gather(self.dcp_group, q.reshape(tokens, -1), -1)
+        return gathered.view(tokens, -1, head_dim)
+
     def _pad_decode_query_heads(self, q: torch.Tensor) -> torch.Tensor:
         """Head padding for the decode kernel. Under DCP q arrives already
         gathered across the DCP group, so it is that width -- not the per-rank
@@ -2004,7 +2022,7 @@ class MLAAttention(nn.Module):
                 # Only real heads cross the wire and enter the combine; the pad the
                 # kernel width needs lives inside _forward_decode (see
                 # dcp_kernel_num_heads).
-                q_out = self.dcp_group.all_gather(q_out, dim=1)
+                q_out = self._dcp_all_gather_query_heads(q_out)
                 o, lse = self._forward_decode(
                     q_out, kv_cache, attn_metadata, return_lse=True
                 )

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -163,29 +163,39 @@ def mla_kernel_num_heads(num_heads: int) -> int:
 
 # Gathered widths aiter serves with a dedicated kernel. The other multiples of
 # 16 (48, 80, 96, 112) are folded onto the 16-head kernel instead, and that fold
-# overrides the round-robin causal mask, so DCP decode must avoid them.
+# reinterprets head groups as extra sequence rows (total_s *= ori_nhead//16)
+# without touching kv_indptr, which desynchronises the row -> global position
+# mapping the round-robin causal mask runs on. DCP decode must avoid them.
 _MLA_DCP_KERNEL_WIDTHS = (16, 32, 64, 128)
 
+_dcp_kernel_width_warned = False
 
-def mla_dcp_pad_num_heads(
+
+def mla_dcp_kernel_num_heads(
     num_heads: int, dcp_world_size: int, min_kernel_heads: int = _MLA_MIN_HEADS
 ) -> int:
-    """Per-rank query-head width to pad to BEFORE the DCP head all-gather.
+    """Width to pad the GATHERED query heads to for a DCP decode.
 
-    Under DCP the kernel never sees a single rank's heads: it sees the gathered
-    ``this * dcp_world_size``. So it is the GATHERED width that has to be one
-    aiter dispatches, which makes the per-rank minimum the wrong thing to pad to
-    -- for a 2-head draft at dcp8 it overshoots to 32*8=256 (unsupported), and
-    for a 12-head target it undershoots to 96 (folded). Pick the smallest
-    gathered width that clears ``min_kernel_heads`` and still covers every rank's
-    real heads.
+    DCP decode all-gathers Q on the head dim before calling the kernel, so what
+    gets dispatched on is ``num_heads * dcp_world_size``; a single rank's head
+    count is never seen and is the wrong thing to pad. Round that gathered width
+    up to one aiter serves natively -- the folded widths are no use here because
+    the fold breaks the round-robin causal mask (see above).
     """
+    gathered = max(num_heads * dcp_world_size, min_kernel_heads)
     for width in _MLA_DCP_KERNEL_WIDTHS:
-        if width < min_kernel_heads:
-            continue
-        if width % dcp_world_size == 0 and width // dcp_world_size >= num_heads:
-            return width // dcp_world_size
-    return mla_kernel_num_heads(num_heads)
+        if width >= gathered:
+            return width
+    global _dcp_kernel_width_warned
+    if not _dcp_kernel_width_warned:
+        _dcp_kernel_width_warned = True
+        logger.warning(
+            f"DCP decode gathers {gathered} query heads, past the widest natively "
+            f"dispatched MLA kernel ({_MLA_DCP_KERNEL_WIDTHS[-1]}); falling back to "
+            "the folded kernel, which is incorrect for MTP (round-robin causal "
+            "mask). Lower decode_context_parallel_size or raise tp."
+        )
+    return mla_kernel_num_heads(gathered)
 
 
 # The fused seg MLA kernels (fused_qk_rope_concat_and_cache_mla_seg +
@@ -492,23 +502,28 @@ class MLAAttention(nn.Module):
         self.dcp_sparse_kv_indptr_buffer = None
         self.dcp_owned_counts_buffer = None
 
-        # DCP decode pads Q on each rank and only then all-gathers on the head
-        # dim, so the width reaching mla_decode_fwd is dcp_pad_num_heads * dcp.
-        # The pad heads ride through the reduce-scatter (which hands each rank
-        # its own dcp_pad_num_heads back) and are dropped there.
-        self.dcp_pad_num_heads = self.num_heads
+        # DCP decode all-gathers Q on the head dim, so the width reaching
+        # mla_decode_fwd is the gathered num_heads * dcp rounded up to a
+        # dispatchable one. The pad sits entirely inside _forward_decode: it goes
+        # on after the gather and comes off before the cross-rank combine, so it
+        # never costs collective traffic.
+        self.dcp_kernel_num_heads = self.num_heads
         self.dcp_head_pad = 0
         if self.dcp_world_size > 1:
-            self.dcp_pad_num_heads = mla_dcp_pad_num_heads(
+            self.dcp_kernel_num_heads = mla_dcp_kernel_num_heads(
                 self.num_heads, self.dcp_world_size, self.min_query_heads
             )
-            self.dcp_head_pad = self.dcp_pad_num_heads - self.num_heads
+            self.dcp_head_pad = (
+                self.dcp_kernel_num_heads - self.num_heads * self.dcp_world_size
+            )
 
     def _pad_decode_query_heads(self, q: torch.Tensor) -> torch.Tensor:
-        """Head padding for the decode kernel. Under DCP the padding already
-        happened per rank before the all-gather, so the gathered q is at its
-        kernel width and this is a no-op."""
+        """Head padding for the decode kernel. Under DCP q arrives already
+        gathered across the DCP group, so it is that width -- not the per-rank
+        one -- that has to reach a dispatchable kernel."""
         if self.dcp_world_size > 1:
+            if self.dcp_head_pad > 0:
+                return torch.nn.functional.pad(q, (0, 0, 0, self.dcp_head_pad))
             return q
         return self._pad_query_heads(q)
 
@@ -517,20 +532,10 @@ class MLAAttention(nn.Module):
     ) -> torch.Tensor:
         """Undo `_pad_decode_query_heads` on an output or per-head LSE."""
         if self.dcp_world_size > 1:
+            if self.dcp_head_pad > 0:
+                return x[:, :num_heads, ...].contiguous()
             return x
         return self._restore_query_heads(x, num_heads)
-
-    def _dcp_pad_query_heads(self, q: torch.Tensor) -> torch.Tensor:
-        """Pad q to this rank's DCP width, ahead of the head all-gather."""
-        if self.dcp_head_pad > 0:
-            return torch.nn.functional.pad(q, (0, 0, 0, self.dcp_head_pad))
-        return q
-
-    def _dcp_restore_query_heads(self, o: torch.Tensor) -> torch.Tensor:
-        """Drop the DCP pad heads the reduce-scatter handed back to this rank."""
-        if self.dcp_head_pad > 0:
-            return o[:, : self.num_heads, ...].contiguous()
-        return o
 
     def _pad_query_heads(self, q: torch.Tensor) -> torch.Tensor:
         if self.head_repeat_factor > 1:
@@ -1996,16 +2001,14 @@ class MLAAttention(nn.Module):
                 # then combine partial outputs across ranks (AG LSE + correct + RS).
                 from atom.model_ops.dcp_ops import cp_lse_ag_out_rs
 
-                # The head pad goes on BEFORE the gather so the kernel sees a
-                # gathered width it dispatches directly (see dcp_pad_num_heads);
-                # the reduce-scatter hands each rank its own padded heads back.
-                q_out = self._dcp_pad_query_heads(q_out)
+                # Only real heads cross the wire and enter the combine; the pad the
+                # kernel width needs lives inside _forward_decode (see
+                # dcp_kernel_num_heads).
                 q_out = self.dcp_group.all_gather(q_out, dim=1)
                 o, lse = self._forward_decode(
                     q_out, kv_cache, attn_metadata, return_lse=True
                 )
                 o = cp_lse_ag_out_rs(o, lse, self.dcp_group, ctx=self._cp_triton_ctx)
-                o = self._dcp_restore_query_heads(o)
                 output = self._v_up_proj_and_o_proj(o)
             else:
                 output = self._forward_decode(q_out, kv_cache, attn_metadata)

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -150,6 +150,44 @@ def mla_min_query_heads(kv_cache_dtype: str, block_width: int) -> int:
     return _MLA_MIN_HEADS
 
 
+def mla_kernel_num_heads(num_heads: int) -> int:
+    """Round a query-head count up to a width ``mla_decode_fwd`` will dispatch.
+
+    aiter accepts nhead 16, and above that only multiples of 16 up to 128 (it
+    folds those onto the 16-head kernel); any other value aborts the dispatch.
+    """
+    if num_heads <= _MLA_MIN_HEADS:
+        return _MLA_MIN_HEADS
+    return -(-num_heads // _MLA_MIN_HEADS) * _MLA_MIN_HEADS
+
+
+# Gathered widths aiter serves with a dedicated kernel. The other multiples of
+# 16 (48, 80, 96, 112) are folded onto the 16-head kernel instead, and that fold
+# overrides the round-robin causal mask, so DCP decode must avoid them.
+_MLA_DCP_KERNEL_WIDTHS = (16, 32, 64, 128)
+
+
+def mla_dcp_pad_num_heads(
+    num_heads: int, dcp_world_size: int, min_kernel_heads: int = _MLA_MIN_HEADS
+) -> int:
+    """Per-rank query-head width to pad to BEFORE the DCP head all-gather.
+
+    Under DCP the kernel never sees a single rank's heads: it sees the gathered
+    ``this * dcp_world_size``. So it is the GATHERED width that has to be one
+    aiter dispatches, which makes the per-rank minimum the wrong thing to pad to
+    -- for a 2-head draft at dcp8 it overshoots to 32*8=256 (unsupported), and
+    for a 12-head target it undershoots to 96 (folded). Pick the smallest
+    gathered width that clears ``min_kernel_heads`` and still covers every rank's
+    real heads.
+    """
+    for width in _MLA_DCP_KERNEL_WIDTHS:
+        if width < min_kernel_heads:
+            continue
+        if width % dcp_world_size == 0 and width // dcp_world_size >= num_heads:
+            return width // dcp_world_size
+    return mla_kernel_num_heads(num_heads)
+
+
 # The fused seg MLA kernels (fused_qk_rope_concat_and_cache_mla_seg +
 # concat_and_cache_mla_seg + the gfx1250 mla_decode_fwd asm) share a single
 # segmented KV cache layout (all tokens' nope packed first, then all tokens'
@@ -312,9 +350,8 @@ class MLAAttention(nn.Module):
         self.kv_cache_dtype = "fp8" if kv_cache_dtype.startswith("fp8") else "auto"
         self.dtype = dtype
 
-        self.padded_num_heads = max(
-            num_heads, kwargs.get("min_query_heads", _MLA_MIN_HEADS)
-        )
+        self.min_query_heads = kwargs.get("min_query_heads", _MLA_MIN_HEADS)
+        self.padded_num_heads = max(num_heads, self.min_query_heads)
         self.head_repeat_factor = 1
         self.head_pad = 0
         if self.padded_num_heads != num_heads:
@@ -454,6 +491,46 @@ class MLAAttention(nn.Module):
         # metadata builder to the shared buffer (see aiter_mla.py).
         self.dcp_sparse_kv_indptr_buffer = None
         self.dcp_owned_counts_buffer = None
+
+        # DCP decode pads Q on each rank and only then all-gathers on the head
+        # dim, so the width reaching mla_decode_fwd is dcp_pad_num_heads * dcp.
+        # The pad heads ride through the reduce-scatter (which hands each rank
+        # its own dcp_pad_num_heads back) and are dropped there.
+        self.dcp_pad_num_heads = self.num_heads
+        self.dcp_head_pad = 0
+        if self.dcp_world_size > 1:
+            self.dcp_pad_num_heads = mla_dcp_pad_num_heads(
+                self.num_heads, self.dcp_world_size, self.min_query_heads
+            )
+            self.dcp_head_pad = self.dcp_pad_num_heads - self.num_heads
+
+    def _pad_decode_query_heads(self, q: torch.Tensor) -> torch.Tensor:
+        """Head padding for the decode kernel. Under DCP the padding already
+        happened per rank before the all-gather, so the gathered q is at its
+        kernel width and this is a no-op."""
+        if self.dcp_world_size > 1:
+            return q
+        return self._pad_query_heads(q)
+
+    def _restore_decode_query_heads(
+        self, x: torch.Tensor, num_heads: int
+    ) -> torch.Tensor:
+        """Undo `_pad_decode_query_heads` on an output or per-head LSE."""
+        if self.dcp_world_size > 1:
+            return x
+        return self._restore_query_heads(x, num_heads)
+
+    def _dcp_pad_query_heads(self, q: torch.Tensor) -> torch.Tensor:
+        """Pad q to this rank's DCP width, ahead of the head all-gather."""
+        if self.dcp_head_pad > 0:
+            return torch.nn.functional.pad(q, (0, 0, 0, self.dcp_head_pad))
+        return q
+
+    def _dcp_restore_query_heads(self, o: torch.Tensor) -> torch.Tensor:
+        """Drop the DCP pad heads the reduce-scatter handed back to this rank."""
+        if self.dcp_head_pad > 0:
+            return o[:, : self.num_heads, ...].contiguous()
+        return o
 
     def _pad_query_heads(self, q: torch.Tensor) -> torch.Tensor:
         if self.head_repeat_factor > 1:
@@ -1318,7 +1395,7 @@ class MLAAttention(nn.Module):
         B = q.shape[0]
         num_heads_q = q.shape[1]
 
-        q = self._pad_query_heads(q)
+        q = self._pad_decode_query_heads(q)
 
         # In the seg path q arrives with a padded per-head row stride
         # (_MLA_Q_OUT_PADDED_DIM); slice back to the logical
@@ -1478,11 +1555,13 @@ class MLAAttention(nn.Module):
             # the intra-block causal mask must be applied on GLOBAL positions
             # g(j)=j*W+r. Pass the cprr params (g_kv_indptr + cp world/rank) so the
             # kernel selects the cprr variant and masks correctly. qlen=1 keeps the
-            # plain path (single query sees all local KV -> no mask needed).
+            # plain path (single query sees all local KV -> no mask needed), and so
+            # does a non-causal block (DSpark drafts bidirectionally: every query
+            # legitimately sees every KV row, so there is no mask to place).
             cp_world_size = 1
             cp_rank = 0
             g_kv_indptr = None
-            if self.dcp_world_size > 1 and max_q_len > 1:
+            if self.dcp_world_size > 1 and max_q_len > 1 and causal:
                 cp_world_size = self.dcp_world_size
                 cp_rank = self.dcp_rank
                 g_kv_indptr = getattr(attn_metadata, "g_kv_indptr", None)
@@ -1521,9 +1600,9 @@ class MLAAttention(nn.Module):
                 causal=causal,
             )
 
-        o = self._restore_query_heads(o, num_heads_q)
+        o = self._restore_decode_query_heads(o, num_heads_q)
         if final_lse is not None:
-            final_lse = self._restore_query_heads(final_lse, num_heads_q)
+            final_lse = self._restore_decode_query_heads(final_lse, num_heads_q)
 
         if return_lse:
             return o, final_lse
@@ -1917,11 +1996,16 @@ class MLAAttention(nn.Module):
                 # then combine partial outputs across ranks (AG LSE + correct + RS).
                 from atom.model_ops.dcp_ops import cp_lse_ag_out_rs
 
+                # The head pad goes on BEFORE the gather so the kernel sees a
+                # gathered width it dispatches directly (see dcp_pad_num_heads);
+                # the reduce-scatter hands each rank its own padded heads back.
+                q_out = self._dcp_pad_query_heads(q_out)
                 q_out = self.dcp_group.all_gather(q_out, dim=1)
                 o, lse = self._forward_decode(
                     q_out, kv_cache, attn_metadata, return_lse=True
                 )
                 o = cp_lse_ag_out_rs(o, lse, self.dcp_group, ctx=self._cp_triton_ctx)
+                o = self._dcp_restore_query_heads(o)
                 output = self._v_up_proj_and_o_proj(o)
             else:
                 output = self._forward_decode(q_out, kv_cache, attn_metadata)

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -28,7 +28,11 @@ from atom.distributed.pcp_utils import (
     pcp_round_robin_query_indices,
 )
 from atom.model_engine.scheduler import ScheduledBatch
-from atom.model_ops.attention_mla import _MLA_MIN_HEADS, MLAAttention
+from atom.model_ops.attention_mla import (
+    _MLA_MIN_HEADS,
+    MLAAttention,
+    mla_dcp_pad_num_heads,
+)
 from atom.utils import CpuGpuBuffer, envs
 from atom.utils.block_convert import (
     kv_indices_generate_triton,
@@ -167,17 +171,19 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         self.dcp_world_size = get_dcp_world_size()
         self.dcp_rank = get_dcp_rank()
 
-        # DCP decode all-gathers Q on the head dim across the DCP group, so the
-        # head count that reaches mla_decode_fwd (and thus the persistent decode
-        # metadata) is padded_num_attention_heads * dcp_world_size. The module's
-        # head-repeat compensates the _MLA_MIN_HEADS padding, so this product
-        # matches the kernel's actual nhead in every case. dcp=1 -> unchanged.
+        # DCP decode pads Q per rank and then all-gathers on the head dim, so the
+        # head count reaching mla_decode_fwd (and thus the persistent decode
+        # metadata) is the gathered width, not the per-rank one.
         # Only gfx950 runs DCP in persistent mode (gfx942 lacks the lse persistent
         # kernel and stays non-persistent, where this metadata is unused); scale
         # by dcp only there so gfx942 keeps the original per-rank head sizing.
-        self.persistent_num_heads = self.padded_num_attention_heads * (
-            self.dcp_world_size if dcp_persistent_supported() else 1
-        )
+        if self.dcp_world_size > 1 and dcp_persistent_supported():
+            self.persistent_num_heads = (
+                mla_dcp_pad_num_heads(self.num_attention_heads, self.dcp_world_size)
+                * self.dcp_world_size
+            )
+        else:
+            self.persistent_num_heads = self.padded_num_attention_heads
 
         max_seqlen_qo = getattr(model_runner, "num_spec_tokens", 0) + 1
         (
@@ -2044,14 +2050,22 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # DCP + MTP (max_q_len>1) capture: the cprr kernel masks on GLOBAL
         # positions, so capture needs a self-consistent (local, global) KV layout
         # or the graph shape won't match replay. Give every seq 1 local token per
-        # rank -> global length = dcp_world_size (page_size=1 only; round-robin
-        # requires it). Replay overwrites these buffers with real values.
+        # rank -> global length = dcp_world_size. Replay overwrites these buffers
+        # with real values.
         cp_round_robin = self.dcp_world_size > 1 and max_q_len > 1
-        if cp_round_robin and self.block_size == 1:
-            var["kv_indptr"].np[: bs + 1] = np.arange(bs + 1, dtype=np.int32)
-            var["kv_indptr"].copy_to_gpu(bs + 1)
-            var["kv_indices"].gpu[:bs].zero_()
-            var["kv_last_page_lens"].gpu[:bs].fill_(1)
+        if cp_round_robin:
+            if self.block_size == 1:
+                var["kv_indptr"].np[: bs + 1] = np.arange(bs + 1, dtype=np.int32)
+                var["kv_indptr"].copy_to_gpu(bs + 1)
+                var["kv_indices"].gpu[:bs].zero_()
+                var["kv_last_page_lens"].gpu[:bs].fill_(1)
+            # g_kv_indptr is the only thing telling the cprr kernel how long each
+            # sequence is GLOBALLY, and nothing else initializes it -- capturing
+            # with it left at its allocation value walks the kernel off the KV
+            # list (illegal access). The round-robin is token-level whatever the
+            # block size, so the one-local-token-per-rank layout set up here (or
+            # by the block_size > 1 branch above) is a global length of
+            # dcp_world_size in both cases.
             var["g_kv_indptr"].np[: bs + 1] = (
                 np.arange(bs + 1, dtype=np.int32) * self.dcp_world_size
             )

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -31,7 +31,7 @@ from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_ops.attention_mla import (
     _MLA_MIN_HEADS,
     MLAAttention,
-    mla_dcp_pad_num_heads,
+    mla_dcp_kernel_num_heads,
 )
 from atom.utils import CpuGpuBuffer, envs
 from atom.utils.block_convert import (
@@ -171,16 +171,15 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         self.dcp_world_size = get_dcp_world_size()
         self.dcp_rank = get_dcp_rank()
 
-        # DCP decode pads Q per rank and then all-gathers on the head dim, so the
-        # head count reaching mla_decode_fwd (and thus the persistent decode
-        # metadata) is the gathered width, not the per-rank one.
+        # DCP decode all-gathers Q on the head dim, so the head count reaching
+        # mla_decode_fwd (and thus the persistent decode metadata) is the padded
+        # gathered width, not the per-rank one.
         # Only gfx950 runs DCP in persistent mode (gfx942 lacks the lse persistent
         # kernel and stays non-persistent, where this metadata is unused); scale
         # by dcp only there so gfx942 keeps the original per-rank head sizing.
         if self.dcp_world_size > 1 and dcp_persistent_supported():
-            self.persistent_num_heads = (
-                mla_dcp_pad_num_heads(self.num_attention_heads, self.dcp_world_size)
-                * self.dcp_world_size
+            self.persistent_num_heads = mla_dcp_kernel_num_heads(
+                self.num_attention_heads, self.dcp_world_size
             )
         else:
             self.persistent_num_heads = self.padded_num_attention_heads

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -13,6 +13,52 @@ import torch
 import triton
 import triton.language as tl
 
+_AG_CUSTOM_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
+
+def _ag_custom_view_dtype(x: torch.Tensor) -> torch.dtype | None:
+    """Float dtype to reinterpret `x` as for aiter's custom all-gather.
+
+    The custom kernel dispatches on a float enum (fp32/fp16/bf16) and raises on
+    anything else, even though an all-gather is a pure copy that only cares
+    about element width. The fp8 query therefore has to be viewed first; 8-bit
+    payloads have no 8-bit entry in the enum, so they pair up into fp16, which
+    needs an even trailing dim. Returns None when no safe view exists.
+    """
+    if x.dtype in _AG_CUSTOM_DTYPES:
+        return x.dtype
+    itemsize = x.element_size()
+    if itemsize == 4:
+        return torch.float32
+    if itemsize == 2:
+        return torch.float16
+    if itemsize == 1 and x.shape[-1] % 2 == 0:
+        return torch.float16
+    return None
+
+
+def dcp_all_gather(cp_group, x: torch.Tensor, dim: int) -> torch.Tensor:
+    """AllGather that prefers aiter's custom collective over pynccl.
+
+    ``GroupCoordinator.all_gather`` takes ``use_custom=False`` by default, so
+    every DCP gather lands on pynccl. At decode payloads that is the wrong
+    trade: the nccl kernel carries a fixed ~5us launch bubble on each side, so
+    gathering a few KB of LSE costs more than the custom kernel spends on a
+    1.5MB reduce-scatter. The device communicator picks the custom kernel when
+    the shape qualifies (dim 0 or last dim, 16B-aligned, within the registered
+    pool) and falls back to pynccl otherwise, with identical concat-along-`dim`
+    semantics either way.
+    """
+    device_comm = getattr(cp_group, "device_communicator", None)
+    view_dtype = _ag_custom_view_dtype(x) if device_comm is not None else None
+    if view_dtype is None:
+        return cp_group.all_gather(x, dim=dim)
+    if view_dtype is x.dtype:
+        return device_comm.all_gather(x, dim)
+    # Viewing narrows the trailing dim, so only a last-dim gather sees a
+    # different split; both land on the same byte layout after the view back.
+    return device_comm.all_gather(x.view(view_dtype), dim).view(x.dtype)
+
 
 class CPTritonContext:
     """Cache compiled Triton kernel to avoid recompilation on every call."""
@@ -165,7 +211,7 @@ def cp_lse_ag_out_rs(cp_attn_out, cp_attn_lse, cp_group, ctx=None):
         return cp_attn_out
 
     cp_attn_lse = cp_attn_lse.contiguous()
-    lses = cp_group.all_gather(cp_attn_lse, dim=0)
+    lses = dcp_all_gather(cp_group, cp_attn_lse, 0)
     lses = lses.reshape((cp_group.world_size,) + cp_attn_lse.shape)
 
     out, _ = correct_attn_out(cp_attn_out, lses, cp_group.rank_in_group, ctx=ctx)

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -60,6 +60,23 @@ def dcp_all_gather(cp_group, x: torch.Tensor, dim: int) -> torch.Tensor:
     return device_comm.all_gather(x.view(view_dtype), dim).view(x.dtype)
 
 
+def dcp_all_gather_query_heads(cp_group, q: torch.Tensor) -> torch.Tensor:
+    """AllGather decode Q ``[tokens, heads, head_dim]`` over the DCP group's heads.
+
+    Flattened to 2-D so the gather lands on the last dim. aiter's custom
+    collective only serves dim 0 and the last dim, and its last-dim variant
+    concatenates rank-major -- which for a ``[tokens, heads*head_dim]`` view
+    is exactly head-dim concat. Gathering the 3-D tensor on dim=1 instead
+    both misses the custom kernel and makes the pynccl path materialise an
+    extra reshape copy of the gathered result.
+    """
+    tokens, _, head_dim = q.shape
+    if not q.is_contiguous():
+        return cp_group.all_gather(q, dim=1)
+    gathered = dcp_all_gather(cp_group, q.reshape(tokens, -1), -1)
+    return gathered.view(tokens, -1, head_dim)
+
+
 class CPTritonContext:
     """Cache compiled Triton kernel to avoid recompilation on every call."""
 

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -710,34 +710,6 @@ class KimiFullAttention(nn.Module):
         )
         self.input_quant_prefix = f"{prefix}.fused_qkv_a_proj"
 
-    def _quant_hidden_once(
-        self, hidden_states: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """Quantize the normed hidden state once for both of its consumers.
-
-        fused_qkv_a_proj and g_proj both read the layer's normed hidden state,
-        and each quantizes its own input when the norm did not fold the quant
-        (AttnRes owns input_layernorm and hands back bf16) -- so the same
-        [T, hidden] activation is quantized twice per layer. Doing it here
-        leaves one of the two passes.
-
-        Only for a purely dynamic per-token scheme shared by both GEMMs: that
-        is the one case where ``LinearBase.forward`` pre-quantizes with no extra
-        layout arguments, so a single call reproduces what both would have done
-        byte-for-byte. per_1x32 defers its quant into the fp4 GEMM and per_1x128
-        needs scale-layout kwargs, so neither is shareable from here.
-        """
-        a, g = self.fused_qkv_a_proj, self.g_proj
-        if (
-            a.quant_type.value != QuantType.per_Token.value
-            or g.quant_type.value != a.quant_type.value
-            or g.params_dtype != a.params_dtype
-            or getattr(a, "input_scale", None) is not None
-            or getattr(g, "input_scale", None) is not None
-        ):
-            return hidden_states, None
-        return a.quant_func(hidden_states, quant_dtype=a.params_dtype)
-
     def forward(
         self, positions: torch.Tensor, hidden_states: torch.Tensor
     ) -> torch.Tensor:
@@ -751,8 +723,6 @@ class KimiFullAttention(nn.Module):
         hidden_states_scale = None
         if isinstance(hidden_states, tuple):
             hidden_states, hidden_states_scale = hidden_states
-        else:
-            hidden_states, hidden_states_scale = self._quant_hidden_once(hidden_states)
 
         q_c, kv_c, k_rope = torch.split(
             self.fused_qkv_a_proj(hidden_states, hidden_states_scale),

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -710,6 +710,34 @@ class KimiFullAttention(nn.Module):
         )
         self.input_quant_prefix = f"{prefix}.fused_qkv_a_proj"
 
+    def _quant_hidden_once(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Quantize the normed hidden state once for both of its consumers.
+
+        fused_qkv_a_proj and g_proj both read the layer's normed hidden state,
+        and each quantizes its own input when the norm did not fold the quant
+        (AttnRes owns input_layernorm and hands back bf16) -- so the same
+        [T, hidden] activation is quantized twice per layer. Doing it here
+        leaves one of the two passes.
+
+        Only for a purely dynamic per-token scheme shared by both GEMMs: that
+        is the one case where ``LinearBase.forward`` pre-quantizes with no extra
+        layout arguments, so a single call reproduces what both would have done
+        byte-for-byte. per_1x32 defers its quant into the fp4 GEMM and per_1x128
+        needs scale-layout kwargs, so neither is shareable from here.
+        """
+        a, g = self.fused_qkv_a_proj, self.g_proj
+        if (
+            a.quant_type.value != QuantType.per_Token.value
+            or g.quant_type.value != a.quant_type.value
+            or g.params_dtype != a.params_dtype
+            or getattr(a, "input_scale", None) is not None
+            or getattr(g, "input_scale", None) is not None
+        ):
+            return hidden_states, None
+        return a.quant_func(hidden_states, quant_dtype=a.params_dtype)
+
     def forward(
         self, positions: torch.Tensor, hidden_states: torch.Tensor
     ) -> torch.Tensor:
@@ -723,6 +751,8 @@ class KimiFullAttention(nn.Module):
         hidden_states_scale = None
         if isinstance(hidden_states, tuple):
             hidden_states, hidden_states_scale = hidden_states
+        else:
+            hidden_states, hidden_states_scale = self._quant_hidden_once(hidden_states)
 
         q_c, kv_c, k_rope = torch.split(
             self.fused_qkv_a_proj(hidden_states, hidden_states_scale),

--- a/atom/plugin/vllm/attention/metadata.py
+++ b/atom/plugin/vllm/attention/metadata.py
@@ -18,7 +18,7 @@ from vllm.v1.attention.backend import (
 
 from atom.config import get_current_atom_config
 from atom.distributed.dcp_utils import dcp_persistent_supported
-from atom.model_ops.attention_mla import _MLA_MIN_HEADS
+from atom.model_ops.attention_mla import _MLA_MIN_HEADS, mla_dcp_kernel_num_heads
 from atom.plugin.vllm.attention.layer_mla import (
     disabled_mla_persistent_metadata,
     mla_fold_kv_metadata_triton,
@@ -1071,16 +1071,19 @@ class AiterMlaMetadataBuilderForVllm(MLACommonMetadataBuilder):
         self.dcp_persistent_supported = dcp_persistent_supported()
         # DCP decode all-gathers Q across the DCP group on the head dim, so the
         # head count reaching mla_decode_fwd (and thus the persistent decode
-        # metadata) is padded_num_attention_heads * dcp_world_size. Sourced from
-        # the parallel config so it is available here in __init__. dcp=1 ->
-        # equals padded_num_attention_heads (zero regression for non-DCP). Only
-        # scale by dcp on gfx950 (DCP persistent); gfx942 stays non-persistent
-        # where this metadata is unused, so keep the original per-rank sizing.
-        self.persistent_num_heads = self.padded_num_attention_heads * (
-            self.parallel_config.decode_context_parallel_size
-            if self.dcp_persistent_supported
-            else 1
-        )
+        # metadata) is the gathered width padded up to a dispatchable kernel.
+        # dcp size is sourced from the parallel config so it is available here in
+        # __init__. dcp=1 -> equals padded_num_attention_heads (zero regression
+        # for non-DCP). Only scale by dcp on gfx950 (DCP persistent); gfx942
+        # stays non-persistent where this metadata is unused, so keep the
+        # original per-rank sizing.
+        dcp_size = self.parallel_config.decode_context_parallel_size
+        if dcp_size > 1 and self.dcp_persistent_supported:
+            self.persistent_num_heads = mla_dcp_kernel_num_heads(
+                self.num_attention_heads, dcp_size
+            )
+        else:
+            self.persistent_num_heads = self.padded_num_attention_heads
         self.block_size = kv_cache_spec.block_size
         self.max_bs = max_num_reqs
         self.dtype_kv = get_aiter_kv_cache_dtype(config)

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -533,34 +533,35 @@ class DSparkProposer(Drafter):
             # Each request's KV spans [0, anchor] (context) ++ the T block rows.
             ctx_lens = self._blk_ctx_lens[:bs]  # stable
             global_lens = anchor_positions + (1 + T)
-            w = self.dcp_world_size
-            if w > 1:
+            if self.dcp_world_size > 1:
                 # DCP shards KV token-wise round-robin, so one block table entry
-                # covers block_size*w GLOBAL tokens and rank r holds only the
-                # positions p with p % w == r, packed densely into its page.
-                # Rows this rank does not own are written to -1 (dropped).
-                virtual_block = block_size * w
+                # covers block_size*dcp_world_size GLOBAL tokens and rank r holds
+                # only the positions p with p % dcp_world_size == r, packed
+                # densely into its page. Rows this rank does not own are written
+                # to -1 (dropped).
+                virtual_block = block_size * self.dcp_world_size
                 page_idx = torch.div(
                     block_positions, virtual_block, rounding_mode="floor"
                 )
                 local_off = torch.div(
                     torch.remainder(block_positions, virtual_block),
-                    w,
+                    self.dcp_world_size,
                     rounding_mode="floor",
                 )
                 slots.copy_(
                     torch.where(
-                        torch.remainder(block_positions, w) == self.dcp_rank,
+                        torch.remainder(block_positions, self.dcp_world_size)
+                        == self.dcp_rank,
                         torch.gather(block_tables, 1, page_idx) * block_size
                         + local_off,
                         -1,
                     )
                 )
-                # Of L global tokens this rank stores ceil((L - r) / w).
+                # Of L global tokens this rank stores ceil((L - r) / dcp_world_size).
                 ctx_lens.copy_(
                     torch.div(
-                        global_lens + (w - 1 - self.dcp_rank),
-                        w,
+                        global_lens + (self.dcp_world_size - 1 - self.dcp_rank),
+                        self.dcp_world_size,
                         rounding_mode="floor",
                     )
                 )
@@ -586,14 +587,15 @@ class DSparkProposer(Drafter):
             # integers to int64, so land it through copy_ rather than out=.
             kv_indptr[1:].copy_(torch.cumsum(ctx_lens, dim=0))
             # The generator walks block_tables row by row up to this bound, and
-            # under DCP those rows are LOCAL: one entry covers block_size*w global
-            # tokens. max_seqlen_k stays global (prepare_decode keeps it that way
-            # too), so handing it over unscaled would run the generator w times
-            # past each row's valid entries and emit slots from unmapped pages.
-            # Overestimating is fine -- kv_indptr caps the real per-seq count.
+            # under DCP those rows are LOCAL: one entry covers
+            # block_size*dcp_world_size global tokens. max_seqlen_k stays global
+            # (prepare_decode keeps it that way too), so handing it over unscaled
+            # would run the generator dcp_world_size times past each row's valid
+            # entries and emit slots from unmapped pages. Overestimating is fine
+            # -- kv_indptr caps the real per-seq count.
             index_max_k = (
-                attn_metadata.max_seqlen_k // w + 1
-                if w > 1
+                attn_metadata.max_seqlen_k // self.dcp_world_size + 1
+                if self.dcp_world_size > 1
                 else attn_metadata.max_seqlen_k
             )
             kv_indices_generate_triton(

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 from torch.profiler import record_function
 
+from atom.distributed.dcp_utils import get_dcp_rank, get_dcp_world_size
 from atom.spec_decode.drafter import AuxCaptureSpec, Drafter
 from atom.spec_decode.dspark_verify import VerifyScheduler
 from atom.utils import envs
@@ -36,6 +37,11 @@ class DSparkProposer(Drafter):
         self._verify_scheduler = (
             VerifyScheduler(runner) if self._confidence_schedule else None
         )
+        # The draft shares the target's block tables and its KV lives in the same
+        # paged pool, so it inherits the pool's DCP sharding: the block pass must
+        # address and size itself in LOCAL (per-rank) terms. 1 when -dcp is unset.
+        self.dcp_world_size = get_dcp_world_size()
+        self.dcp_rank = get_dcp_rank()
         if self._with_draft:
             self._init_draft_block_buffers()
 
@@ -91,9 +97,13 @@ class DSparkProposer(Drafter):
         # on -- read it rather than recomputing, so the work descriptors planned
         # here describe the kernel that will actually run. The ModelRunner itself
         # has no such attribute.
-        self._blk_padded_heads = self.model.layers[
-            0
-        ].self_attn.mla_attn.impl.padded_num_heads
+        impl = self.model.layers[0].self_attn.mla_attn.impl
+        if self.dcp_world_size > 1:
+            # DCP decode pads per rank and then all-gathers on the head dim, so
+            # the descriptors must be planned for the GATHERED width.
+            self._blk_padded_heads = impl.dcp_pad_num_heads * self.dcp_world_size
+        else:
+            self._blk_padded_heads = impl.padded_num_heads
         # max_split_per_batch only exists in newer aiter builds; feature-detect
         # it (as aiter_mla does) so old builds don't hit a TypeError. Cache the
         # kwargs so the sizing (info) and fill (get_mla_metadata_v1) calls agree.
@@ -519,17 +529,49 @@ class DSparkProposer(Drafter):
 
         if not is_dummy:
             block_tables = self.runner.forward_vars["block_tables"].gpu[:bs]
-            # slot = page_id * block_size + offset_in_page, derived on-device
-            # from the block table so there is no host sync.
-            page_idx = torch.div(block_positions, block_size, rounding_mode="floor")
             slots = self._blk_slots[: bs * T].view(bs, T)  # stable
-            slots.copy_(torch.gather(block_tables, 1, page_idx))
-            slots.mul_(block_size)
-            slots.add_(torch.remainder(block_positions, block_size))
-
             # Each request's KV spans [0, anchor] (context) ++ the T block rows.
             ctx_lens = self._blk_ctx_lens[:bs]  # stable
-            ctx_lens.copy_(anchor_positions + (1 + T))
+            global_lens = anchor_positions + (1 + T)
+            w = self.dcp_world_size
+            if w > 1:
+                # DCP shards KV token-wise round-robin, so one block table entry
+                # covers block_size*w GLOBAL tokens and rank r holds only the
+                # positions p with p % w == r, packed densely into its page.
+                # Rows this rank does not own are written to -1 (dropped).
+                virtual_block = block_size * w
+                page_idx = torch.div(
+                    block_positions, virtual_block, rounding_mode="floor"
+                )
+                local_off = torch.div(
+                    torch.remainder(block_positions, virtual_block),
+                    w,
+                    rounding_mode="floor",
+                )
+                slots.copy_(
+                    torch.where(
+                        torch.remainder(block_positions, w) == self.dcp_rank,
+                        torch.gather(block_tables, 1, page_idx) * block_size
+                        + local_off,
+                        -1,
+                    )
+                )
+                # Of L global tokens this rank stores ceil((L - r) / w).
+                ctx_lens.copy_(
+                    torch.div(
+                        global_lens + (w - 1 - self.dcp_rank),
+                        w,
+                        rounding_mode="floor",
+                    )
+                )
+            else:
+                # slot = page_id * block_size + offset_in_page, derived on-device
+                # from the block table so there is no host sync.
+                page_idx = torch.div(block_positions, block_size, rounding_mode="floor")
+                slots.copy_(torch.gather(block_tables, 1, page_idx))
+                slots.mul_(block_size)
+                slots.add_(torch.remainder(block_positions, block_size))
+                ctx_lens.copy_(global_lens)
 
             attn_metadata.slot_mapping = slots.view(-1)
             attn_metadata.block_tables = block_tables
@@ -543,12 +585,23 @@ class DSparkProposer(Drafter):
             # kv_indptr[0] stays 0 (zero-init, never written). cumsum promotes
             # integers to int64, so land it through copy_ rather than out=.
             kv_indptr[1:].copy_(torch.cumsum(ctx_lens, dim=0))
+            # The generator walks block_tables row by row up to this bound, and
+            # under DCP those rows are LOCAL: one entry covers block_size*w global
+            # tokens. max_seqlen_k stays global (prepare_decode keeps it that way
+            # too), so handing it over unscaled would run the generator w times
+            # past each row's valid entries and emit slots from unmapped pages.
+            # Overestimating is fine -- kv_indptr caps the real per-seq count.
+            index_max_k = (
+                attn_metadata.max_seqlen_k // w + 1
+                if w > 1
+                else attn_metadata.max_seqlen_k
+            )
             kv_indices_generate_triton(
                 block_tables,
                 self._blk_kv_indices,
                 kv_indptr,
                 block_size,
-                attn_metadata.max_seqlen_k,
+                index_max_k,
             )
             attn_metadata.kv_indptr = kv_indptr
             attn_metadata.kv_indices = self._blk_kv_indices

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -99,9 +99,9 @@ class DSparkProposer(Drafter):
         # has no such attribute.
         impl = self.model.layers[0].self_attn.mla_attn.impl
         if self.dcp_world_size > 1:
-            # DCP decode pads per rank and then all-gathers on the head dim, so
-            # the descriptors must be planned for the GATHERED width.
-            self._blk_padded_heads = impl.dcp_pad_num_heads * self.dcp_world_size
+            # DCP decode all-gathers on the head dim, so the descriptors must be
+            # planned for the padded GATHERED width.
+            self._blk_padded_heads = impl.dcp_kernel_num_heads
         else:
             self._blk_padded_heads = impl.padded_num_heads
         # max_split_per_batch only exists in newer aiter builds; feature-detect

--- a/docs/context_parallel_guide.md
+++ b/docs/context_parallel_guide.md
@@ -255,12 +255,13 @@ existing TP ranks, so `world = tp` and `tp` must be divisible by `dcp`.
   outputs back to each rank's head slice.
 ```
 
-> **Model support.** DCP supports both **dense MLA** models (e.g. DeepSeek-V3 /
-> R1) and **DeepSeek Sparse Attention (DSA / sparse MLA)** models (e.g.
-> DeepSeek-V3.2-Exp), covering both prefill and decode. For **dense MLA**, both
-> the ATOM server and the vllm-atom plugin paths are validated. For **sparse MLA
-> (DSA)**, the ATOM server path is validated; the **vllm-atom plugin path is not
-> yet verified**.
+> **Model support.** DCP supports **dense MLA** models (e.g. DeepSeek-V3 / R1),
+> **DeepSeek Sparse Attention (DSA / sparse MLA)** models (e.g.
+> DeepSeek-V3.2-Exp), and **hybrid KDA + MLA** models (**Kimi-K3**), covering
+> both prefill and decode. For **dense MLA**, both the ATOM server and the
+> vllm-atom plugin paths are validated. For **sparse MLA (DSA)** and **Kimi-K3**,
+> the ATOM server path is validated; the **vllm-atom plugin path is not yet
+> verified**.
 >
 > **Not yet supported: DSA + DCP + MTP.** Speculative decode (MTP, `q > 1`) is
 > only available for dense MLA (gfx950); combining it with sparse attention under
@@ -268,14 +269,15 @@ existing TP ranks, so `world = tp` and `tp` must be divisible by `dcp`.
 
 ## When to use DCP
 
-- **Best fit**: long-context / large-batch **decode** on MLA models — both dense
-  MLA (V3 / R1) and sparse MLA / DSA (V3.2-Exp) — where the full-replicated KV
-  cache limits context length or batch size.
+- **Best fit**: long-context / large-batch **decode** on MLA models — dense MLA
+  (V3 / R1), sparse MLA / DSA (V3.2-Exp), and hybrid KDA + MLA (Kimi-K3) — where
+  the full-replicated KV cache limits context length or batch size.
 - **Requires**: `tp % dcp == 0`; `world = tp` (DCP reuses TP GPUs, it does *not*
   add any). E.g. `-tp 8 -dcp 8` or `-tp 8 -dcp 2` on 8 GPUs.
 - **Composes with**: prefix caching and chunked prefill (both supported under
-  DCP); `--kv-cache-dtype fp8` (per-tensor scale); **speculative decode / MTP**
-  (`--method mtp`, `num_speculative_tokens` 1–3; **gfx950 only**.
+  DCP); `--kv-cache-dtype fp8` (per-tensor scale); **speculative decode** —
+  **MTP** (`--method mtp`, `num_speculative_tokens` 1–3; **gfx950 only**) on
+  dense MLA, and **DSpark** (`--method dspark`) on Kimi-K3.
 - **Little benefit / avoid**: short-context, KV-memory-plentiful workloads —
   DCP adds per-step decode communication (Q all-gather + output reduce-scatter)
   that isn't worth it when KV memory isn't the constraint.
@@ -333,13 +335,53 @@ python -m atom.entrypoints.openai_server \
     --method mtp --num-speculative-tokens 3
 ```
 
+### ATOM server — Kimi-K3: TP8 + DCP8 (8 GPUs, gfx950)
+
+`-dcp 8` is the only addition to the [Kimi-K3 recipe](../recipes/Kimi-K3.md)
+launch; every other flag keeps its recipe value. See
+[DCP on Kimi-K3](#dcp-on-kimi-k3-hybrid-kda--mla) for what DCP does and does not
+shard on a hybrid model.
+
+```bash
+python -m atom.entrypoints.openai_server \
+    --model moonshotai/Kimi-K3 \
+    --kv_cache_dtype fp8 -tp 8 -dcp 8 \
+    --trust-remote-code \
+    --max-model-len 16384 \
+    --max-num-seqs 64 \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.93 \
+    --block-size 128 \
+    --no-enable_prefix_caching \
+    --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "*self_attn.[qkv]_conv1d*", "*block_sparse_moe.experts*", "*block_sparse_moe.routed_expert_*", "*vision_tower*", "*mm_projector*"]}'
+```
+
+### ATOM server — Kimi-K3: TP8 + DCP8 + DSpark (8 GPUs, gfx950)
+
+Add the [DSpark](../recipes/DSpark.md) flags to the command above; the draft is
+a separate checkpoint. See
+[DCP + Speculative Decode](#dcp--speculative-decode-mtp--dspark).
+
+```bash
+python -m atom.entrypoints.openai_server \
+    --model moonshotai/Kimi-K3 \
+    --draft-model Inferact/Kimi-K3-DSpark \
+    --kv_cache_dtype fp8 -tp 8 -dcp 8 \
+    --method dspark --num-speculative-tokens 2 \
+    --trust-remote-code \
+    --max-num-seqs 64 \
+    --gpu-memory-utilization 0.93 \
+    --block-size 128 \
+    --no-enable_prefix_caching
+```
+
 Tips:
 - `-tp 8 -dcp 1` (or omitting `-dcp`) disables DCP and serves as the baseline.
 - `--kv_cache_dtype fp8` further lowers KV memory; DCP uses a per-tensor scale
   (per-token / per-group fp8 layouts are not yet supported).
 - **MTP under DCP is gfx950-only** and works with both bf16 and fp8 KV cache for
   `num_speculative_tokens` 1–3 — see
-  [DCP + Speculative Decode (MTP)](#dcp--speculative-decode-mtp).
+  [DCP + Speculative Decode](#dcp--speculative-decode-mtp--dspark).
 
 ## How it works
 
@@ -366,14 +408,56 @@ Tips:
    (a copy-only collective — safe); the prefill context path dequantizes the
    AllGathered compressed KV before `kv_b_proj`.
 
-## DCP + Speculative Decode (MTP)
+## DCP on Kimi-K3 (hybrid KDA + MLA)
 
-DCP composes with **MTP speculative decoding** (`--method mtp`). MTP verifies
-several draft tokens per step, so decode has query length `q = num_speculative_tokens
-+ 1 > 1`. Under DCP the KV is round-robin sharded, so the intra-block causal mask
-must be applied on **global** token positions. This is handled by a dedicated
-**round-robin CP (`cprr`) MLA kernel**, selected automatically when DCP is on and
-`q > 1`.
+Kimi-K3 is not a pure MLA model: of its 93 decoder layers, **24 are MLA
+full-attention** and **69 are KDA linear-attention**. DCP shards the paged latent
+KV of the 24 MLA layers exactly as it does on a dense MLA model. The KDA layers
+hold a **per-request recurrent state** rather than a paged cache, so there is
+nothing for DCP to shard there and that state stays replicated — the per-GPU
+memory DCP frees on K3 is the MLA share only, not the whole attention footprint.
+
+**Query-head width is the K3-specific constraint.** K3 has 96 query heads, so at
+`-tp 8` each rank owns 12 and the DCP decode gathers `12 × dcp`: 24 at dcp2, 48
+at dcp4, 96 at dcp8. aiter's `mla_decode_fwd` dispatches natively on 16 / 32 / 64
+/ 128 heads only; the remaining multiples of 16 (48, 80, 96, 112) are folded onto
+the 16-head kernel, and that fold reinterprets head groups as extra sequence rows
+(`total_s *= ori_nhead // 16`) without touching `kv_indptr`, which desynchronises
+the row-to-global-position mapping the round-robin causal mask depends on. So the
+**gathered** width is padded up to the next natively dispatched one (24 → 32,
+48 → 64, 96 → 128) by `mla_dcp_kernel_num_heads`. The pad lives entirely inside
+`_forward_decode` — applied after the all-gather and stripped before the
+cross-rank LSE combine — so it never costs collective traffic. Widths past 128
+fall back to the folded kernel with a warning; lower `-dcp` or raise `-tp` if you
+hit it.
+
+DeepSeek-R1 never needed this: 128 heads at `-tp 8` is 16 per rank, and the dcp8
+gather lands on 128 exactly.
+
+**Validated** (ATOM server, 8×MI355 gfx950, `-tp 8 -dcp 8`, fp8 KV, full 1319
+GSM8K 5-shot at 64 concurrency): **flexible-extract 0.9553 / strict-match
+0.9553**, inside the [Kimi-K3 recipe](../recipes/Kimi-K3.md)'s
+0.9538–0.9591 band. Prefix caching was **off** for that run, matching the
+recipe — K3's KDA recurrent state cannot be reconstructed from the paged MLA
+cache alone, and prefix caching combined with DCP on K3 is not part of the
+validated configuration.
+
+## DCP + Speculative Decode (MTP / DSpark)
+
+DCP composes with two drafters: **MTP** (`--method mtp`) on dense MLA, and
+**DSpark** (`--method dspark`) on Kimi-K3. Both verify several draft tokens per
+step, so decode runs with query length `q > 1`. That is where DCP's round-robin
+sharding starts to matter: whenever such a decode is **causal**, its mask has to
+be expressed on **global** token positions rather than the rank-local ones the
+kernel sees. MTP is causal and needs that treatment; DSpark's draft block is
+bidirectional and skips it.
+
+### MTP (dense MLA)
+
+MTP verifies `q = num_speculative_tokens + 1` tokens per step under a causal
+mask, so the intra-block mask has to be applied on global positions. This is
+handled by a dedicated **round-robin CP (`cprr`) MLA kernel**, selected
+automatically when DCP is on, `q > 1`, and the decode is causal.
 
 > **Dense MLA only.** This applies to dense MLA (V3 / R1). **DSA / sparse MLA
 > (V3.2-Exp) does not support MTP under DCP yet** — sparse decode with `q > 1` is
@@ -407,16 +491,54 @@ Plugin path (`vllm serve`): add `--speculative-config '{"method":"mtp","num_spec
 Accuracy: gsm8k (DeepSeek-R1, tp8, 5-shot) matches the non-speculative DCP
 baseline (≈0.95) across bf16/fp8 and `num_speculative_tokens` 1/2/3.
 
+### DSpark (Kimi-K3)
+
+[DSpark](../recipes/DSpark.md) drafts a whole block in one parallel backbone
+pass instead of `k` serial passes. Two properties decide how it meets DCP:
+
+- **The draft shares the target's paged pool and block tables**, so it inherits
+  the round-robin sharding rather than choosing its own. The draft block pass
+  therefore addresses and sizes itself in **local** terms: for a global position
+  `p`, the owning rank is `p % dcp` and the slot on that rank is
+  `block_table[p // (block_size × dcp)] × block_size + (p % (block_size × dcp)) // dcp`;
+  positions this rank does not own are written as `-1` and dropped. A sequence of
+  `L` global tokens contributes `ceil((L − rank) / dcp)` local rows.
+- **The draft block is bidirectional**, not causal: every one of the `T` draft
+  positions attends the whole block. So even though `q > 1`, there is no mask to
+  place on global positions and the `cprr` kernel is not used — the plain decode
+  path is correct. (The target's own verify pass rebuilds its metadata with
+  `causal` back to its default, so this never leaks.)
+
+**Support matrix:**
+
+| | Supported |
+|---|---|
+| Target model | **Kimi-K3** (`--draft-model Inferact/Kimi-K3-DSpark`) |
+| GPU arch | gfx950 |
+| DCP size | dcp8 validated (`tp8`) |
+| KV cache dtype | fp8 (per-tensor scale) |
+
+**Validated** (8×MI355, `-tp 8 -dcp 8`, fp8 KV, `--num-speculative-tokens 2`,
+full 1319 GSM8K 5-shot): **flexible-extract 0.9522 / strict-match 0.9522**, with
+an **87.1% acceptance rate** (1.74 of 2 draft tokens accepted per step). The
+per-step accepted-count distribution is `{0: 6.1%, 1: 13.7%, 2: 80.3%}` — 80% of
+steps take the whole draft and only 6% take none, so the draft is genuinely
+contributing under DCP rather than collapsing back to single-token decode.
+
 ## Constraints & Compatibility
 
 | Constraint | Notes |
 |-----------|-------|
-| Models | MLA only: **dense** (DeepSeek-V3 / R1, …) and **sparse / DSA** (DeepSeek-V3.2-Exp), both prefill + decode |
+| Models | MLA-bearing only: **dense** (DeepSeek-V3 / R1, …), **sparse / DSA** (DeepSeek-V3.2-Exp), and **hybrid KDA + MLA** (Kimi-K3), all prefill + decode |
 | World size | `world = tp`, `tp % dcp == 0` (DCP does not add GPUs) |
 | fp8 KV cache | Supported, **per-tensor scale only** (per-token / per-group not supported) |
-| prefix caching / chunked prefill | Supported (dense and sparse / DSA) |
+| prefix caching / chunked prefill | Supported (dense and sparse / DSA). On **Kimi-K3** the validated configuration has prefix caching **off**, per its recipe |
+| Kimi-K3 KDA layers | Not sharded — the KDA recurrent state is per-request, not paged, so DCP frees only the MLA share of attention memory |
+| Kimi-K3 gathered head width | Padded to a natively dispatched MLA width (16 / 32 / 64 / 128); past 128 it falls back to the folded kernel with a warning — lower `-dcp` or raise `-tp` |
 | speculative decode (MTP), dense MLA | Supported on **gfx950 only** (bf16/fp8, `num_speculative_tokens` 1–3); raises at startup on gfx942 |
+| speculative decode (DSpark), Kimi-K3 | Supported on gfx950; validated at `tp8 -dcp 8` with `num_speculative_tokens 2` |
 | speculative decode (MTP), sparse / DSA | **Not supported** — sparse decode with `q > 1` under DCP is rejected by an assert |
+| vllm-atom plugin | Validated for dense MLA only; the sparse / DSA and Kimi-K3 plugin paths are not yet verified |
 | DCP + PCP | Independent dimensions (different phases); combined use not validated here |
 
 ## Source Files
@@ -427,9 +549,11 @@ baseline (≈0.95) across bf16/fp8 and `num_speculative_tokens` 1/2/3.
 | `atom/config.py` | DCP validation (`tp % dcp == 0`); spec-decode + DCP arch gate (gfx950) |
 | `atom/model_engine/block_manager.py` | Interleaved block allocation; prefix-cache virtual-block accounting |
 | `atom/distributed/dcp_utils.py` | DCP distributed-access layer: `get_dcp_world_size` / `dcp_is_enabled` / `get_dcp_group` / `get_dcp_rank` |
-| `atom/model_ops/dcp_ops.py` | AG+RS LSE-combine, `reorg_kvcache`, local compressed-KV gather |
-| `atom/model_ops/attention_mla.py` | Server-mode DCP decode + prefix-cache / chunked-prefill context |
+| `atom/model_ops/dcp_ops.py` | AG+RS LSE-combine, `reorg_kvcache`, local compressed-KV gather, `dcp_all_gather` / `dcp_all_gather_query_heads` (custom-collective AllGather) |
+| `atom/model_ops/attention_mla.py` | Server-mode DCP decode + prefix-cache / chunked-prefill context; `mla_dcp_kernel_num_heads` gathered-head-width padding |
 | `atom/model_ops/attentions/aiter_mla.py`, `attentions/backends.py` | DCP decode / prefill metadata (interleaved slot_mapping, local seq lens) |
-| `atom/plugin/vllm/attention/layer_mla.py` | vllm-atom plugin DCP decode + prefill context |
+| `atom/plugin/vllm/attention/layer_mla.py`, `attention/metadata.py` | vllm-atom plugin DCP decode + prefill context; persistent-metadata head sizing |
+| `atom/models/kimi_k3.py` | Kimi-K3 hybrid backbone (KDA + MLA) served under DCP |
 | `atom/spec_decode/eagle_proposer.py` | MTP draft loop: DCP round-robin slot for draft KV writes |
+| `atom/spec_decode/dspark_proposer.py` | DSpark block draft: DCP-local slot mapping / context lengths, gathered-width work descriptors |
 | `atom/model_ops/attentions/aiter_mla.py` (`prepare_mtp_decode`) | Per-draft-step DCP-local metadata rebuild; `cprr` decode selects the round-robin MLA kernel via `g_kv_indptr` |


### PR DESCRIPTION
## Motivation

1. enable dcp for k3 + dspark
2. use custom all_gather for better performance
3. remove a duplicate quantization of hidden_states in mla

##  validation
DCP8 full GSM8K 0.9553/0.9553
