### PR TITLE
[feat][DCP]Add cp_kv_cache_interleave_size for PD

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1313,6 +1313,35 @@ class EPLBConfig:
 
 
 @dataclass
+class DCPConfig:
+    """DCP (Decode Context Parallel) sub-config. Today only interleave
+    granularity; room for future knobs (all-to-all backend, query
+    replication, ...) without growing the top-level CLI surface."""
+
+    interleave_size: int = 1
+
+    def __post_init__(self):
+        self.interleave_size = int(self.interleave_size)
+        assert self.interleave_size >= 1, "dcp.interleave_size must be >= 1"
+
+    @classmethod
+    def from_dict(cls, cfg: dict | None) -> "DCPConfig":
+        """Build from the ``--dcp-config`` JSON dict.
+
+        ``cfg`` maps directly onto this dataclass' fields; unknown keys raise so
+        typos fail fast."""
+        cfg = cfg or {}
+        allowed = {f.name for f in fields(cls)}
+        unknown = set(cfg) - allowed
+        if unknown:
+            raise ValueError(
+                f"Unknown --dcp-config key(s): {sorted(unknown)}. "
+                f"Supported keys: {sorted(allowed)}"
+            )
+        return cls(**cfg)
+
+
+@dataclass
 class Config:
     model: str
     trust_remote_code: bool = False
@@ -1330,7 +1359,7 @@ class Config:
     gpu_memory_utilization: float = 0.9
     tensor_parallel_size: int = 1
     decode_context_parallel_size: int = 1
-    cp_kv_cache_interleave_size: int = 1
+    dcp_config: DCPConfig = field(default_factory=DCPConfig)
     pipeline_parallel_size: int = 1
     prefill_context_parallel_size: int = 1
     enforce_eager: bool = False
@@ -1461,6 +1490,13 @@ class Config:
             self.eplb_config = EPLBConfig(**self.eplb_config.__dict__)
         else:
             raise TypeError("eplb_config must be EPLBConfig or dict")
+        if isinstance(self.dcp_config, dict):
+            self.dcp_config = DCPConfig(**self.dcp_config)
+        elif isinstance(self.dcp_config, DCPConfig):
+            # Normalize/validate even when constructed programmatically.
+            self.dcp_config = DCPConfig(**self.dcp_config.__dict__)
+        else:
+            raise TypeError("dcp_config must be DCPConfig or dict")
         # assert os.path.isdir(self.model)
 
         # RapidServe (intra-GPU prefill/decode disagg) needs a specialized
@@ -1499,24 +1535,24 @@ class Config:
         # KV block so each physical block holds an integer number of S-groups
         # (the (i//(S*W))*S + i%S local-index math relies on block_size % S == 0),
         # and only makes sense under DCP.
-        assert 1 <= self.cp_kv_cache_interleave_size <= self.kv_cache_block_size, (
-            f"cp_kv_cache_interleave_size ({self.cp_kv_cache_interleave_size}) must "
+        assert 1 <= self.dcp_config.interleave_size <= self.kv_cache_block_size, (
+            f"dcp_config.interleave_size ({self.dcp_config.interleave_size}) must "
             f"be in [1, kv_cache_block_size={self.kv_cache_block_size}]"
         )
-        if self.cp_kv_cache_interleave_size > 1:
-            assert self.kv_cache_block_size % self.cp_kv_cache_interleave_size == 0, (
+        if self.dcp_config.interleave_size > 1:
+            assert self.kv_cache_block_size % self.dcp_config.interleave_size == 0, (
                 f"kv_cache_block_size ({self.kv_cache_block_size}) must be divisible "
-                f"by cp_kv_cache_interleave_size ({self.cp_kv_cache_interleave_size})"
+                f"by dcp_config.interleave_size ({self.dcp_config.interleave_size})"
             )
             assert self.decode_context_parallel_size > 1, (
-                "cp_kv_cache_interleave_size > 1 only applies under DCP "
+                "dcp_config.interleave_size > 1 only applies under DCP "
                 f"(decode_context_parallel_size={self.decode_context_parallel_size})"
             )
             assert self.speculative_config is None, (
-                "cp_kv_cache_interleave_size > 1 (block-level DCP interleave) is "
+                "dcp_config.interleave_size > 1 (block-level DCP interleave) is "
                 "incompatible with speculative decode (MTP/eagle/dspark): the q>1 "
                 "verify cprr MLA kernel assumes token-level interleave. Use "
-                "cp_kv_cache_interleave_size=1 with speculative decode, or disable "
+                "dcp_config.interleave_size=1 with speculative decode, or disable "
                 "speculative decode for block-level interleave."
             )
         assert 1 <= self.pipeline_parallel_size

--- a/atom/config.py
+++ b/atom/config.py
@@ -1330,6 +1330,7 @@ class Config:
     gpu_memory_utilization: float = 0.9
     tensor_parallel_size: int = 1
     decode_context_parallel_size: int = 1
+    cp_kv_cache_interleave_size: int = 1
     pipeline_parallel_size: int = 1
     prefill_context_parallel_size: int = 1
     enforce_eager: bool = False
@@ -1493,6 +1494,31 @@ class Config:
                     f"the persistent cprr MLA kernel); got {gfx}. Disable DCP or "
                     f"speculative decode on this GPU."
                 )
+        # DCP KV-cache interleave granularity S. S=1 (default) = token-level
+        # round-robin (unchanged). S>1 = block-level interleave; must divide the
+        # KV block so each physical block holds an integer number of S-groups
+        # (the (i//(S*W))*S + i%S local-index math relies on block_size % S == 0),
+        # and only makes sense under DCP.
+        assert 1 <= self.cp_kv_cache_interleave_size <= self.kv_cache_block_size, (
+            f"cp_kv_cache_interleave_size ({self.cp_kv_cache_interleave_size}) must "
+            f"be in [1, kv_cache_block_size={self.kv_cache_block_size}]"
+        )
+        if self.cp_kv_cache_interleave_size > 1:
+            assert self.kv_cache_block_size % self.cp_kv_cache_interleave_size == 0, (
+                f"kv_cache_block_size ({self.kv_cache_block_size}) must be divisible "
+                f"by cp_kv_cache_interleave_size ({self.cp_kv_cache_interleave_size})"
+            )
+            assert self.decode_context_parallel_size > 1, (
+                "cp_kv_cache_interleave_size > 1 only applies under DCP "
+                f"(decode_context_parallel_size={self.decode_context_parallel_size})"
+            )
+            assert self.speculative_config is None, (
+                "cp_kv_cache_interleave_size > 1 (block-level DCP interleave) is "
+                "incompatible with speculative decode (MTP/eagle/dspark): the q>1 "
+                "verify cprr MLA kernel assumes token-level interleave. Use "
+                "cp_kv_cache_interleave_size=1 with speculative decode, or disable "
+                "speculative decode for block-level interleave."
+            )
         assert 1 <= self.pipeline_parallel_size
         self.hf_config = get_hf_config(
             self.model, trust_remote_code=self.trust_remote_code

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -479,10 +479,7 @@ class EngineArgs:
                 "Supported keys:\n"
                 '  - "interleave_size": int, KV-cache interleave granularity S: '
                 "token i is stored on DCP rank (i // S) %% W. Default 1 = "
-                "token-level round-robin. Set to block_size for block-level "
-                "interleave (each physical block holds one rank's contiguous "
-                "run), which lets PD-disaggregation pull whole KV blocks "
-                "without in-block token rearrangement. Must divide block_size.\n"
+                "token-level round-robin.\n"
                 "Example:\n"
                 """  '{"interleave_size": 16}'"""
             ),

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -10,6 +10,7 @@ from atom import LLMEngine
 from atom.config import (
     CompilationConfig,
     CUDAGraphMode,
+    DCPConfig,
     DSparkConfig,
     EPLBConfig,
     SpeculativeConfig,
@@ -37,7 +38,6 @@ class EngineArgs:
     trust_remote_code: bool = False
     tensor_parallel_size: int = 1
     decode_context_parallel_size: int = 1
-    cp_kv_cache_interleave_size: int = 1
     pipeline_parallel_size: int = 1
     prefill_context_parallel_size: int = 1
     data_parallel_size: int = 1
@@ -86,6 +86,7 @@ class EngineArgs:
 
     eplb_enable: bool = False
     eplb_config: dict | None = None
+    dcp_config: dict | None = None
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -142,16 +143,6 @@ class EngineArgs:
             type=int,
             default=1,
             help="Decode context parallel size. Must divide tensor_parallel_size.",
-        )
-        parser.add_argument(
-            "--cp-kv-cache-interleave-size",
-            type=int,
-            default=1,
-            help="DCP KV-cache interleave granularity S: token i is stored on "
-            "DCP rank (i // S) %% W. Default 1 = token-level round-robin. Set to "
-            "block_size for block-level interleave (each physical block holds one "
-            "rank's contiguous run), which lets PD-disaggregation pull whole KV "
-            "blocks without in-block token rearrangement. Must divide block_size.",
         )
         parser.add_argument(
             "--enforce-eager",
@@ -477,6 +468,25 @@ class EngineArgs:
                 """"ragged_graph_sizes": "8"}'"""
             ),
         )
+        dcp_group = parser.add_argument_group("DCP options")
+        dcp_group.add_argument(
+            "--dcp-config",
+            type=json.loads,
+            default=None,
+            help=(
+                "DCP (Decode Context Parallel) config as a JSON dict, parsed "
+                "straight into a DCPConfig object (no per-field flags). "
+                "Supported keys:\n"
+                '  - "interleave_size": int, KV-cache interleave granularity S: '
+                "token i is stored on DCP rank (i // S) %% W. Default 1 = "
+                "token-level round-robin. Set to block_size for block-level "
+                "interleave (each physical block holds one rank's contiguous "
+                "run), which lets PD-disaggregation pull whole KV blocks "
+                "without in-block token rearrangement. Must divide block_size.\n"
+                "Example:\n"
+                """  '{"interleave_size": 16}'"""
+            ),
+        )
         eplb_group = parser.add_argument_group("EPLB options")
         eplb_group.add_argument(
             "--eplb-enable",
@@ -586,6 +596,9 @@ class EngineArgs:
         # --eplb-config (JSON dict) → EPLBConfig object (--eplb-enable
         # is the master switch, --eplb-config only tunes it).
         kwargs["eplb_config"] = EPLBConfig.from_dict(kwargs.pop("eplb_config"))
+        # --dcp-config (JSON dict) → DCPConfig object, passed through as
+        # Config.dcp_config.
+        kwargs["dcp_config"] = DCPConfig.from_dict(kwargs.pop("dcp_config"))
 
         logger.info(f"Engine kwargs: {kwargs}")
 

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -37,6 +37,7 @@ class EngineArgs:
     trust_remote_code: bool = False
     tensor_parallel_size: int = 1
     decode_context_parallel_size: int = 1
+    cp_kv_cache_interleave_size: int = 1
     pipeline_parallel_size: int = 1
     prefill_context_parallel_size: int = 1
     data_parallel_size: int = 1
@@ -141,6 +142,16 @@ class EngineArgs:
             type=int,
             default=1,
             help="Decode context parallel size. Must divide tensor_parallel_size.",
+        )
+        parser.add_argument(
+            "--cp-kv-cache-interleave-size",
+            type=int,
+            default=1,
+            help="DCP KV-cache interleave granularity S: token i is stored on "
+            "DCP rank (i // S) %% W. Default 1 = token-level round-robin. Set to "
+            "block_size for block-level interleave (each physical block holds one "
+            "rank's contiguous run), which lets PD-disaggregation pull whole KV "
+            "blocks without in-block token rearrangement. Must divide block_size.",
         )
         parser.add_argument(
             "--enforce-eager",

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -69,6 +69,10 @@ class BlockManager:
         assert num_blocks > 0
         self.block_size = block_size
         self.dcp_world_size = config.decode_context_parallel_size
+        # DCP KV-cache interleave granularity S (1 = token-level round-robin).
+        self.cp_kv_cache_interleave_size = getattr(
+            config, "cp_kv_cache_interleave_size", 1
+        )
         # dcp_rank is always 0 here: BlockManager runs only on the scheduler
         # (rank 0). DCP rank is used only to compute local token counts for
         # memory reservation; the actual per-rank routing is done in the workers.
@@ -239,7 +243,10 @@ class BlockManager:
         from atom.model_ops.dcp_ops import get_dcp_local_seq_lens
 
         local_len = get_dcp_local_seq_lens(
-            np.array([seq_len]), self.dcp_world_size, self.dcp_rank
+            np.array([seq_len]),
+            self.dcp_world_size,
+            self.dcp_rank,
+            self.cp_kv_cache_interleave_size,
         )[0]
         return int((local_len + self.block_size - 1) // self.block_size)
 

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -7,7 +7,7 @@ from math import inf, isinf
 import numpy as np
 import xxhash
 
-from atom.config import Config
+from atom.config import Config, DCPConfig
 from atom.distributed.kv_events import (
     MEDIUM_GPU,
     MEDIUM_REMOTE,
@@ -71,8 +71,8 @@ class BlockManager:
         self.dcp_world_size = config.decode_context_parallel_size
         # DCP KV-cache interleave granularity S (1 = token-level round-robin).
         self.cp_kv_cache_interleave_size = getattr(
-            config, "cp_kv_cache_interleave_size", 1
-        )
+            config, "dcp_config", DCPConfig()
+        ).interleave_size
         # dcp_rank is always 0 here: BlockManager runs only on the scheduler
         # (rank 0). DCP rank is used only to compute local token counts for
         # memory reservation; the actual per-rank routing is done in the workers.

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -984,20 +984,25 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         concat:
 
         ``dcp_indexer_local_cu_seqlens``
-            cumsum of ``Lpad[b] = ceil(g_b / W)`` -- the per-sequence local length
-            PADDED to the max over ranks, so every rank gathers the same count.
-            Reading past a rank's real local length stays inside its allocated
-            blocks (``ceil(g/(bs*W))*bs >= ceil(g/W)``), so the padding slots read
-            uninitialized cache rather than out of bounds; they are dropped by the
-            de-interleave below.
+            cumsum of ``Lpad[b] = ceil(g_b / (S*W)) * S`` -- the per-sequence local
+            length PADDED to the max over ranks (interleave S hands out S tokens
+            per rank per S*W super-block; S=1 -> ``ceil(g/W)``), so every rank
+            gathers the same count. Reading past a rank's real local length stays
+            inside its allocated blocks (``ceil(g/(bs*W))*bs >= ceil(g/(S*W))*S``
+            when ``bs % S == 0``), so the padding slots read uninitialized cache
+            rather than out of bounds; they are dropped by the de-interleave below.
 
         ``dcp_indexer_gather_index``
             output-position -> source index into the flattened all-gathered
             ``[W, sum(Lpad)]`` buffer. Global sequence-local position ``p`` lives on
-            rank ``p % W`` at local index ``p // W``, hence
-            ``src = (p % W) * sum(Lpad) + cu_pad[b] + p // W``.
+            rank ``(p//S) % W`` at local index ``(p//(S*W))*S + p%S`` (S=1 -> the
+            round-robin ``p%W`` / ``p//W``), hence
+            ``src = owner(p) * sum(Lpad) + cu_pad[b] + local_index(p)``.
         """
+        from atom.model_ops.dcp_ops import dcp_local_index, dcp_owner_rank
+
         W = self.dcp_world_size
+        S = self.cp_kv_cache_interleave_size
         if attn_metadata.has_cached:
             g_cu = var["cu_seqlens_k"].np[: bs + 1].astype(np.int64)
         else:
@@ -1005,7 +1010,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         g_lens = g_cu[1:] - g_cu[:bs]
         del counts  # kept for signature symmetry with the caller's other helpers
 
-        lpad = (g_lens + W - 1) // W
+        lpad = ((g_lens + S * W - 1) // (S * W)) * S
         cu_pad = np.zeros(bs + 1, dtype=np.int64)
         np.cumsum(lpad, out=cu_pad[1:])
         local_total = int(cu_pad[bs])
@@ -1013,7 +1018,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
         # Position within its sequence for every global KV token.
         pos = np.arange(total_kv, dtype=np.int64) - np.repeat(g_cu[:bs], g_lens)
-        src = (pos % W) * local_total + np.repeat(cu_pad[:bs], g_lens) + pos // W
+        src = (
+            dcp_owner_rank(pos, W, S) * local_total
+            + np.repeat(cu_pad[:bs], g_lens)
+            + dcp_local_index(pos, W, S)
+        )
 
         dev = self.device
         attn_metadata.dcp_indexer_local_total = local_total
@@ -1294,10 +1303,16 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         """DCP variant of `_build_mla_chunk_meta` (compressed-KV AllGather).
 
         The cached context is interleaved across DCP ranks: global token `g`
-        lives on rank `g % dcp_world_size` at local position `g // dcp`. This
-        builder produces, per chunk, the metadata to (1) index_select this
-        rank's local cached tokens, (2) AllGather them, and (3) `reorg_kvcache`
-        them into per-sequence contiguous layout.
+        lives on rank `(g // S) % dcp_world_size` at local index
+        `(g // (S*W)) * S + g % S` (S = cp_kv_cache_interleave_size; S=1 = the
+        original round-robin `g % W` / `g // W`). This builder produces, per
+        chunk, the metadata to (1) index_select this rank's local cached tokens,
+        (2) AllGather them, and (3) `reorg_kvcache` them into per-sequence
+        contiguous layout. `reorg_kvcache` needs only the per-rank *counts*
+        (from `get_dcp_local_seq_lens(..., S)`), not S-aware ordering: the cached
+        context is fully visible (no causal mask) so attention is permutation-
+        invariant over it, and RoPE travels with each key — the existing S=1
+        reorg already emits a non-global order and is correct, so any S is too.
 
         Chunking is per-seq (plugin-style, not the global-axis chunking of the
         non-DCP builder): each chunk covers a `chunk_size`-token local window
@@ -1322,8 +1337,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
         # Real local context length per (seq, rank). Shared across chunks;
         # reorg uses it to drop the per-seq padding.
+        s_itl = self.cp_kv_cache_interleave_size
         local_lens_allranks = np.stack(
-            [get_dcp_local_seq_lens(cached_lens, dcp, r) for r in range(dcp)],
+            [get_dcp_local_seq_lens(cached_lens, dcp, r, s_itl) for r in range(dcp)],
             axis=1,
         ).astype(
             np.int64
@@ -1520,16 +1536,21 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         ].contiguous()
 
     def _dcp_round_robin_slot(self, block_table, pos: int) -> int:
-        """DCP round-robin write slot for global position ``pos`` on this rank, or
-        -1 if another rank owns it. KV is token-level round-robin sharded
-        (page_size=1). Shared by the qlen==1 and MTP qlen>1 decode paths."""
-        if pos % self.dcp_world_size != self.dcp_rank:
+        """DCP write slot for global position ``pos`` on this rank, or -1 if
+        another rank owns it. KV is interleave-sharded: token pos lives on rank
+        (pos//S)%W at local index (pos//(S*W))*S + pos%S (S = cp_kv_cache_interleave_size;
+        S=1 = token-level round-robin). Shared by the qlen==1 and MTP qlen>1
+        decode paths."""
+        from atom.model_ops.dcp_ops import dcp_local_index, dcp_owner_rank
+
+        W = self.dcp_world_size
+        S = self.cp_kv_cache_interleave_size
+        if dcp_owner_rank(pos, W, S) != self.dcp_rank:
             return -1
         block_size = self.model_runner.block_size
-        virtual_block_size = block_size * self.dcp_world_size
         return (
-            block_table[pos // virtual_block_size] * block_size
-            + (pos % virtual_block_size) // self.dcp_world_size
+            block_table[pos // (block_size * W)] * block_size
+            + dcp_local_index(pos, W, S) % block_size
         )
 
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
@@ -1599,7 +1620,10 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             from atom.model_ops.dcp_ops import get_dcp_local_seq_lens
 
             local_context_lens = get_dcp_local_seq_lens(
-                context_lens, self.dcp_world_size, self.dcp_rank
+                context_lens,
+                self.dcp_world_size,
+                self.dcp_rank,
+                self.cp_kv_cache_interleave_size,
             )
             num_blocks_per_seq = cdiv(local_context_lens, self.block_size)
         elif any(batch.is_first_decode_without_local_prefill):

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -23,6 +23,7 @@ from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_engine.state_runtime import StateTransfer
 from atom.model_ops.attention_mla import MLAModules
 from atom.model_ops.attentions.sub_pool_spec import SubPoolSpec
+from atom.model_ops.dcp_ops import dcp_local_index, dcp_owner_rank
 from atom.utils import CpuGpuBuffer
 from atom.utils.forward_context import AttentionMetaData, AttnState
 from atom.utils.tbo.ubatch_splitting import (
@@ -233,6 +234,10 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         hf_config = config.hf_config
         self.dcp_world_size = get_dcp_world_size()
         self.dcp_rank = get_dcp_rank()
+        # DCP KV-cache interleave granularity S (1 = token-level round-robin).
+        self.cp_kv_cache_interleave_size = getattr(
+            config, "cp_kv_cache_interleave_size", 1
+        )
         self.max_num_batched_tokens = model_runner.max_num_batched_tokens
         self.max_bs = model_runner.max_bs
         self.max_num_blocks_per_seq = (
@@ -374,12 +379,17 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
             block_table = batch.block_tables[i]
             block_size = self.model_runner.block_size
             if self.dcp_world_size > 1:
-                virtual_block_size = block_size * self.dcp_world_size
+                W = self.dcp_world_size
+                S = self.cp_kv_cache_interleave_size
+                virtual_block_size = block_size * W
                 for pos in range(cached_seqlen, seqlen):
-                    vb_offset = pos % virtual_block_size
-                    if vb_offset % self.dcp_world_size == self.dcp_rank:
+                    # Block-level interleave: token pos is owned by rank
+                    # (pos//S)%W at local index (pos//(S*W))*S + pos%S. S=1 is the
+                    # original round-robin. blk_idx = pos // (block_size*W) equals
+                    # local_index // block_size (needs block_size % S == 0).
+                    if dcp_owner_rank(pos, W, S) == self.dcp_rank:
                         blk_idx = pos // virtual_block_size
-                        local_offset = vb_offset // self.dcp_world_size
+                        local_offset = dcp_local_index(pos, W, S) % block_size
                         slot_mapping.append(
                             block_table[blk_idx] * block_size + local_offset
                         )

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -14,6 +14,7 @@ import torch
 from aiter.dist.parallel_state import get_tp_group
 from torch import nn
 
+from atom.config import DCPConfig
 from atom.distributed.dcp_utils import get_dcp_rank, get_dcp_world_size
 from atom.model_engine.page_unit_checkpoint import (
     CheckpointRestoreOp,
@@ -236,8 +237,8 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         self.dcp_rank = get_dcp_rank()
         # DCP KV-cache interleave granularity S (1 = token-level round-robin).
         self.cp_kv_cache_interleave_size = getattr(
-            config, "cp_kv_cache_interleave_size", 1
-        )
+            config, "dcp_config", DCPConfig()
+        ).interleave_size
         self.max_num_batched_tokens = model_runner.max_num_batched_tokens
         self.max_bs = model_runner.max_bs
         self.max_num_blocks_per_seq = (

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -277,33 +277,94 @@ def reorg_kvcache(
     return reorganized_kv_c_normed, reorganized_k_pe
 
 
-def get_dcp_local_seq_lens(seq_lens, dcp_size, dcp_rank, interleave_size=1):
+def get_dcp_local_seq_lens(seq_lens, dcp_size, dcp_rank, cp_kv_cache_interleave_size=1):
     """Compute per-DCP-rank local sequence lengths.
 
     With interleaved storage, token i is stored on rank
-    (i // interleave_size) % dcp_size.
+    (i // cp_kv_cache_interleave_size) % dcp_size.
 
     Args:
         seq_lens: numpy array of sequence lengths
         dcp_size: DCP world size
         dcp_rank: this rank's DCP rank
-        interleave_size: interleaving granularity (default 1 = token-level)
+        cp_kv_cache_interleave_size: interleaving granularity (default 1 = token-level)
 
     Returns:
         local_seq_lens: numpy array of local sequence lengths
     """
-    full_chunks = seq_lens // (interleave_size * dcp_size)
-    base = full_chunks * interleave_size
+    full_chunks = seq_lens // (cp_kv_cache_interleave_size * dcp_size)
+    base = full_chunks * cp_kv_cache_interleave_size
 
     remainder_total = seq_lens - base * dcp_size
     remainder = np.clip(
-        remainder_total - dcp_rank * interleave_size, 0, interleave_size
+        remainder_total - dcp_rank * cp_kv_cache_interleave_size,
+        0,
+        cp_kv_cache_interleave_size,
     )
     return base + remainder
 
 
+def dcp_owner_rank(pos, dcp_size, cp_kv_cache_interleave_size=1):
+    """Which DCP rank owns global token ``pos`` under interleaved KV storage.
+
+    Interleaving groups tokens into chunks of ``cp_kv_cache_interleave_size`` (= S); chunk
+    ``c = pos // S`` is stored on rank ``c % dcp_size``. For S == 1 this reduces
+    to the round-robin ``pos % dcp_size``.
+
+    Works elementwise on Python ints, numpy arrays and torch tensors (only ``//``
+    and ``%`` are used). Consistent with vLLM's slot kernel
+    (``block_table.py`` ``is_local``) because ``block_size * W`` is a multiple of
+    ``S * W`` when ``block_size % S == 0``, so computing on the global position
+    equals computing on the virtual-block offset.
+    """
+    return (pos // cp_kv_cache_interleave_size) % dcp_size
+
+
+def dcp_local_index(pos, dcp_size, cp_kv_cache_interleave_size=1):
+    """Local KV-sequence index of global token ``pos`` on its owning rank.
+
+    Each ``S * W`` super-block contributes ``S`` tokens to a rank, so the local
+    index is ``(pos // (S*W)) * S + (pos % S)``. For S == 1 this reduces to the
+    round-robin ``pos // dcp_size``.
+
+    To map to a physical slot (given ``block_size % S == 0``):
+        block_table_index = pos // (block_size * dcp_size)   # == local_index // block_size
+        slot_offset       = local_index % block_size
+        slot              = block_table[block_table_index] * block_size + slot_offset
+
+    Elementwise over Python ints / numpy / torch.
+    """
+    sw = cp_kv_cache_interleave_size * dcp_size
+    return (pos // sw) * cp_kv_cache_interleave_size + (
+        pos % cp_kv_cache_interleave_size
+    )
+
+
+def dcp_global_pos(local_index, dcp_rank, dcp_size, cp_kv_cache_interleave_size=1):
+    """Inverse of ``dcp_local_index``: global token position of local KV index
+    ``local_index`` held on ``dcp_rank``.
+
+    Local index j on rank r sits in local S-group ``j // S`` at offset ``j % S``;
+    that group is global chunk ``(j//S)*W + r``, so the global position is
+    ``((j//S)*W + r) * S + (j % S)``. For S == 1 this reduces to the round-robin
+    ``j*W + r``. Used to reconstruct globally-unique ids for exchanged sparse
+    top-k candidates (the id must be a total order over global positions).
+
+    Elementwise over Python ints / numpy / torch.
+    """
+    return (
+        (local_index // cp_kv_cache_interleave_size) * dcp_size + dcp_rank
+    ) * cp_kv_cache_interleave_size + (local_index % cp_kv_cache_interleave_size)
+
+
 def dcp_pack_topk_candidates(
-    local_logits, local_idx, local_lens, dcp_rank, dcp_world_size, out_pair
+    local_logits,
+    local_idx,
+    local_lens,
+    dcp_rank,
+    dcp_world_size,
+    out_pair,
+    cp_kv_cache_interleave_size=1,
 ):
     """Turn a rank-local top-k into exchangeable (score, global_id) pairs.
 
@@ -312,9 +373,9 @@ def dcp_pack_topk_candidates(
     local top-k did not fill get (-inf, -1); the merge sinks them via -inf and
     never selects the -1 gids.
 
-    Under round-robin (interleave=1) sharding a local position j on rank r is
-    global position j*W + r, so the id is globally unique -- which is what makes
-    the tie-break a total order.
+    Under interleave-S sharding a local index j on rank r is global position
+    ``((j//S)*W + r)*S + j%S`` (S=1 -> the round-robin j*W + r), so the id is
+    globally unique -- which is what makes the tie-break a total order.
     """
     rows, _k = local_idx.shape
     # Bound-check rather than assume a padding convention from the aiter kernel.
@@ -324,7 +385,7 @@ def dcp_pack_topk_candidates(
     out_pair[0].copy_(torch.where(valid, sc, torch.full_like(sc, -float("inf"))))
     gid = torch.where(
         valid,
-        local_idx * dcp_world_size + dcp_rank,
+        dcp_global_pos(local_idx, dcp_rank, dcp_world_size, cp_kv_cache_interleave_size),
         torch.full_like(local_idx, -1),
     )
     out_pair.view(torch.int32)[1].copy_(gid)
@@ -345,6 +406,7 @@ def _count_owned_dcp_kernel(
     out_counts,  # int32 [num_requests] -- owned top-k count per request
     DCP_RANK: tl.constexpr,
     DCP_WORLD: tl.constexpr,
+    INTERLEAVE: tl.constexpr,  # cp_kv_cache_interleave_size S (1 = round-robin)
     NUM_TOPK_TOKENS: tl.constexpr,
     BLOCK_N: tl.constexpr,
     ti_stride0,
@@ -355,7 +417,8 @@ def _count_owned_dcp_kernel(
     compacted output offsets used by ``_compact_filter_dcp_kernel``.
 
     qlen==1 only (DCP + sparse + MTP is rejected upstream), so each request has
-    exactly one query token.
+    exactly one query token. Owner of global position g is rank (g//S)%W
+    (S=INTERLEAVE; S=1 -> g%W).
     """
     batch_id = tl.program_id(0)
     token_id = tl.load(qo_indptr + batch_id)
@@ -366,7 +429,7 @@ def _count_owned_dcp_kernel(
         col_valid = indice_id < NUM_TOPK_TOKENS
         ti_ptr = token_indices_ptr + token_id * ti_stride0 + indice_id * ti_stride1
         tok = tl.load(ti_ptr, mask=col_valid, other=-1)
-        owned = col_valid & (tok >= 0) & ((tok % DCP_WORLD) == DCP_RANK)
+        owned = col_valid & (tok >= 0) & (((tok // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
         count += tl.sum(owned.to(tl.int32))
 
     tl.store(out_counts + batch_id, count)
@@ -382,6 +445,7 @@ def _compact_filter_dcp_kernel(
     out_kv_indices,  # int32 [>= out_kv_indptr[-1]]
     DCP_RANK: tl.constexpr,
     DCP_WORLD: tl.constexpr,
+    INTERLEAVE: tl.constexpr,  # cp_kv_cache_interleave_size S (1 = round-robin)
     PAGE_SIZE: tl.constexpr,  # runner (physical) block size
     NUM_TOPK_TOKENS: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -390,11 +454,13 @@ def _compact_filter_dcp_kernel(
     bt_stride0: tl.int64,
     bt_stride1: tl.constexpr,
 ):
-    # DCP round-robin (interleave=1): a GLOBAL position g is owned by rank
-    # ``g % W``; on the owner rank its physical slot follows the round-robin
-    # (virtual-block) layout used by _dcp_round_robin_slot / ATOM PR #847:
+    # DCP interleave-S: a GLOBAL position g is owned by rank ``(g // S) % W``; on
+    # the owner rank its physical slot follows the virtual-block layout used by
+    # _dcp_round_robin_slot / ATOM PR #847 (S=1 -> the original round-robin):
     #     vbs  = PAGE_SIZE * W
-    #     slot = block_table[req, g // vbs] * PAGE_SIZE + (g % vbs) // W
+    #     vb   = g % vbs
+    #     slot = block_table[req, g // vbs] * PAGE_SIZE
+    #            + (vb // (W*S)) * S + (vb % S)
     # token_indices holds GLOBAL positions (the indexer scored the full sequence
     # via all-gathered logits). This rank keeps ONLY the positions it owns and
     # writes them COMPACTED to the front of its region -- no -1 holes. Holes are
@@ -428,10 +494,11 @@ def _compact_filter_dcp_kernel(
         ti_ptr = token_indices_ptr + token_id * ti_stride0 + indice_id * ti_stride1
         tok = tl.load(ti_ptr, mask=col_valid, other=-1)  # GLOBAL position
 
-        idx_valid = col_valid & (tok >= 0) & ((tok % DCP_WORLD) == DCP_RANK)
+        idx_valid = col_valid & (tok >= 0) & (((tok // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
 
         block_id = tok // vbs
-        inblock_offset = (tok % vbs) // DCP_WORLD
+        vb = tok % vbs
+        inblock_offset = (vb // (DCP_WORLD * INTERLEAVE)) * INTERLEAVE + (vb % INTERLEAVE)
         physical_block = tl.load(
             block_table + batch_id * bt_stride0 + block_id * bt_stride1,
             mask=idx_valid,
@@ -459,8 +526,9 @@ def triton_filter_and_convert_dcp_index(
     NUM_TOPK_TOKENS: int = 2048,
     BLOCK_N: int = 128,
     out: torch.Tensor | None = None,
+    cp_kv_cache_interleave_size: int = 1,
 ):
-    """DCP (interleave=1) filter + round-robin localize of global top-k positions,
+    """DCP (interleave-S) filter + localize of global top-k positions,
     **compacting** each rank's owned slots to the front of its region.
 
     ``token_indices[token_id, indice_id]`` is a GLOBAL token position selected by
@@ -512,6 +580,7 @@ def triton_filter_and_convert_dcp_index(
         counts,
         dcp_rank,
         dcp_world_size,
+        cp_kv_cache_interleave_size,
         NUM_TOPK_TOKENS,
         BLOCK_N,
         ti_stride0,
@@ -538,6 +607,7 @@ def triton_filter_and_convert_dcp_index(
         out,
         dcp_rank,
         dcp_world_size,
+        cp_kv_cache_interleave_size,
         block_size,
         NUM_TOPK_TOKENS,
         BLOCK_N,
@@ -558,6 +628,7 @@ def _count_owned_dcp_prefill_kernel(
     out_counts,  # int32 [num_tokens]
     DCP_RANK: tl.constexpr,
     DCP_WORLD: tl.constexpr,
+    INTERLEAVE: tl.constexpr,  # cp_kv_cache_interleave_size S (1 = round-robin)
     NUM_TOPK_TOKENS: tl.constexpr,
     BLOCK_N: tl.constexpr,
     ti_stride0: tl.int64,
@@ -586,7 +657,7 @@ def _count_owned_dcp_prefill_kernel(
             other=-1,
         )
         pos = indice - base  # position within the sequence
-        owned = col_valid & (indice >= 0) & ((pos % DCP_WORLD) == DCP_RANK)
+        owned = col_valid & (indice >= 0) & (((pos // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
         count += tl.sum(owned.to(tl.int32))
 
     tl.store(out_counts + token_id, count)
@@ -603,6 +674,7 @@ def _compact_filter_dcp_prefill_kernel(
     out_kv_indices,  # int32 [>= out_kv_indptr[-1]]
     DCP_RANK: tl.constexpr,
     DCP_WORLD: tl.constexpr,
+    INTERLEAVE: tl.constexpr,  # cp_kv_cache_interleave_size S (1 = round-robin)
     PAGE_SIZE: tl.constexpr,  # runner (physical) block size
     NUM_TOPK_TOKENS: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -612,11 +684,13 @@ def _compact_filter_dcp_prefill_kernel(
     bt_stride1: tl.constexpr,
 ):
     """Pass 2 for sparse PREFILL: keep only this rank's owned candidates, map
-    them through the round-robin (virtual-block) layout, and pack them to the
-    front of the token's region.
+    them through the interleave-S (virtual-block) layout, and pack them to the
+    front of the token's region (S=1 -> the original round-robin):
 
         vbs  = PAGE_SIZE * W
-        slot = block_table[req, pos // vbs] * PAGE_SIZE + (pos % vbs) // W
+        vb   = pos % vbs
+        slot = block_table[req, pos // vbs] * PAGE_SIZE
+               + (vb // (W*S)) * S + (vb % S)
 
     Same rationale as the decode twin: no `-1` holes (they break aiter's lse
     path) and compaction is order-preserving so the fp accumulation order is
@@ -642,10 +716,11 @@ def _compact_filter_dcp_prefill_kernel(
             other=-1,
         )
         pos = indice - base
-        idx_valid = col_valid & (indice >= 0) & ((pos % DCP_WORLD) == DCP_RANK)
+        idx_valid = col_valid & (indice >= 0) & (((pos // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
 
         block_id = pos // vbs
-        inblock_offset = (pos % vbs) // DCP_WORLD
+        vb = pos % vbs
+        inblock_offset = (vb // (DCP_WORLD * INTERLEAVE)) * INTERLEAVE + (vb % INTERLEAVE)
         physical_block = tl.load(
             block_table + req_id * bt_stride0 + block_id * bt_stride1,
             mask=idx_valid,
@@ -679,6 +754,7 @@ def triton_filter_and_convert_dcp_index_prefill(
     NUM_TOPK_TOKENS: int = 2048,
     BLOCK_N: int = 128,
     out: torch.Tensor | None = None,
+    cp_kv_cache_interleave_size: int = 1,
 ):
     """Sparse-PREFILL twin of ``triton_filter_and_convert_dcp_index``.
 
@@ -719,6 +795,7 @@ def triton_filter_and_convert_dcp_index_prefill(
         counts,
         dcp_rank,
         dcp_world_size,
+        cp_kv_cache_interleave_size,
         NUM_TOPK_TOKENS,
         BLOCK_N,
         ti_stride0,
@@ -742,6 +819,7 @@ def triton_filter_and_convert_dcp_index_prefill(
         out,
         dcp_rank,
         dcp_world_size,
+        cp_kv_cache_interleave_size,
         block_size,
         NUM_TOPK_TOKENS,
         BLOCK_N,

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -385,7 +385,9 @@ def dcp_pack_topk_candidates(
     out_pair[0].copy_(torch.where(valid, sc, torch.full_like(sc, -float("inf"))))
     gid = torch.where(
         valid,
-        dcp_global_pos(local_idx, dcp_rank, dcp_world_size, cp_kv_cache_interleave_size),
+        dcp_global_pos(
+            local_idx, dcp_rank, dcp_world_size, cp_kv_cache_interleave_size
+        ),
         torch.full_like(local_idx, -1),
     )
     out_pair.view(torch.int32)[1].copy_(gid)
@@ -494,11 +496,15 @@ def _compact_filter_dcp_kernel(
         ti_ptr = token_indices_ptr + token_id * ti_stride0 + indice_id * ti_stride1
         tok = tl.load(ti_ptr, mask=col_valid, other=-1)  # GLOBAL position
 
-        idx_valid = col_valid & (tok >= 0) & (((tok // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
+        idx_valid = (
+            col_valid & (tok >= 0) & (((tok // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
+        )
 
         block_id = tok // vbs
         vb = tok % vbs
-        inblock_offset = (vb // (DCP_WORLD * INTERLEAVE)) * INTERLEAVE + (vb % INTERLEAVE)
+        inblock_offset = (vb // (DCP_WORLD * INTERLEAVE)) * INTERLEAVE + (
+            vb % INTERLEAVE
+        )
         physical_block = tl.load(
             block_table + batch_id * bt_stride0 + block_id * bt_stride1,
             mask=idx_valid,
@@ -657,7 +663,9 @@ def _count_owned_dcp_prefill_kernel(
             other=-1,
         )
         pos = indice - base  # position within the sequence
-        owned = col_valid & (indice >= 0) & (((pos // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
+        owned = (
+            col_valid & (indice >= 0) & (((pos // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
+        )
         count += tl.sum(owned.to(tl.int32))
 
     tl.store(out_counts + token_id, count)
@@ -716,11 +724,15 @@ def _compact_filter_dcp_prefill_kernel(
             other=-1,
         )
         pos = indice - base
-        idx_valid = col_valid & (indice >= 0) & (((pos // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
+        idx_valid = (
+            col_valid & (indice >= 0) & (((pos // INTERLEAVE) % DCP_WORLD) == DCP_RANK)
+        )
 
         block_id = pos // vbs
         vb = pos % vbs
-        inblock_offset = (vb // (DCP_WORLD * INTERLEAVE)) * INTERLEAVE + (vb % INTERLEAVE)
+        inblock_offset = (vb // (DCP_WORLD * INTERLEAVE)) * INTERLEAVE + (
+            vb % INTERLEAVE
+        )
         physical_block = tl.load(
             block_table + req_id * bt_stride0 + block_id * bt_stride1,
             mask=idx_valid,

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1576,7 +1576,9 @@ def sparse_attn_indexer(
         context.batch_size * attn_metadata.max_seqlen_q if not context.is_prefill else 0
     )
     runner_block_size = get_current_atom_config().kv_cache_block_size
-    cp_kv_cache_interleave_size = get_current_atom_config().cp_kv_cache_interleave_size
+    cp_kv_cache_interleave_size = (
+        get_current_atom_config().dcp_config.interleave_size
+    )
     kv_cache = kv_cache.view(-1, runner_block_size, kv_cache.shape[-1])
     # PCP prefill: `k` (and `positions`) arrive as the full PADDED key set
     # [S_pad] produced by an all-gather of the round-robin shards. The KV-cache

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1576,9 +1576,7 @@ def sparse_attn_indexer(
         context.batch_size * attn_metadata.max_seqlen_q if not context.is_prefill else 0
     )
     runner_block_size = get_current_atom_config().kv_cache_block_size
-    cp_kv_cache_interleave_size = (
-        get_current_atom_config().dcp_config.interleave_size
-    )
+    cp_kv_cache_interleave_size = get_current_atom_config().dcp_config.interleave_size
     kv_cache = kv_cache.view(-1, runner_block_size, kv_cache.shape[-1])
     # PCP prefill: `k` (and `positions`) arrive as the full PADDED key set
     # [S_pad] produced by an all-gather of the round-robin shards. The KV-cache

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1406,6 +1406,7 @@ def _dcp_decode_candidate_exchange(
     max_model_len: int,
     runner_block_size: int,
     stable_topk: bool,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> None:
     """DCP decode candidate exchange -> deterministic merge into global top-k.
 
@@ -1433,12 +1434,16 @@ def _dcp_decode_candidate_exchange(
         "qlen=1 decode only (MTP verify not yet supported)."
     )
     g_ctx = attn_metadata.context_lens
-    base = g_ctx // dcp_world_size
-    # round-robin (interleave=1) local length: base + 1 for the ranks that own
-    # the remainder tail, matching prepare_decode's slot split.
-    local_ctx = (base + (g_ctx - base * dcp_world_size - dcp_rank).clamp(0, 1)).to(
-        torch.int32
-    )
+    # Interleave-S local length (matches get_dcp_local_seq_lens / prepare_decode's
+    # slot split): each full S*W super-block gives every rank S tokens, and the
+    # tail remainder is handed out S at a time by rank. S=1 -> the round-robin
+    # base + (this rank owns the +1 tail?) split.
+    S = cp_kv_cache_interleave_size
+    W = dcp_world_size
+    full_chunks = g_ctx // (S * W)
+    base = full_chunks * S
+    remainder = (g_ctx - base * W - dcp_rank * S).clamp(0, S)
+    local_ctx = (base + remainder).to(torch.int32)
     l_max = (max_model_len + dcp_world_size - 1) // dcp_world_size
     local_logits = torch.empty([num_rows, l_max], dtype=torch.float32, device="cuda")
     deepgemm_fp8_paged_mqa_logits(
@@ -1476,7 +1481,13 @@ def _dcp_decode_candidate_exchange(
         2, num_rows, k_loc, dtype=torch.float32, device=local_logits.device
     )
     dcp_pack_topk_candidates(
-        local_logits, local_idx, local_ctx, dcp_rank, dcp_world_size, send
+        local_logits,
+        local_idx,
+        local_ctx,
+        dcp_rank,
+        dcp_world_size,
+        send,
+        cp_kv_cache_interleave_size,
     )
     # Exchange as int32 so the gid bit patterns cannot be touched by any float
     # canonicalization along the way; the score plane is bitcast back at the end
@@ -1565,6 +1576,7 @@ def sparse_attn_indexer(
         context.batch_size * attn_metadata.max_seqlen_q if not context.is_prefill else 0
     )
     runner_block_size = get_current_atom_config().kv_cache_block_size
+    cp_kv_cache_interleave_size = get_current_atom_config().cp_kv_cache_interleave_size
     kv_cache = kv_cache.view(-1, runner_block_size, kv_cache.shape[-1])
     # PCP prefill: `k` (and `positions`) arrive as the full PADDED key set
     # [S_pad] produced by an all-gather of the round-robin shards. The KV-cache
@@ -1749,6 +1761,7 @@ def sparse_attn_indexer(
                 owned_counts=dcp_owned_counts_buffer,
                 NUM_TOPK_TOKENS=topk_tokens,
                 out=sparse_kv_indices_buffer,
+                cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
             )
         else:
             triton_convert_req_index_to_global_index_dsa_prefill(
@@ -1793,6 +1806,7 @@ def sparse_attn_indexer(
                 max_model_len,
                 runner_block_size,
                 stable_topk,
+                cp_kv_cache_interleave_size,
             )
         else:
             logits = torch.empty(
@@ -1836,11 +1850,11 @@ def sparse_attn_indexer(
             )
         elif dcp_world_size > 1:
             # topk_indices now hold GLOBAL positions. Keep only this rank's owned
-            # tokens (p % W == r), de-interleave (p // W), map to the local
-            # main-KV slot, and COMPACT them to the front -- non-owned positions
-            # are dropped, not marked with -1, because holes break aiter's lse
-            # output. The compacted per-request lengths are written into
-            # dcp_sparse_kv_indptr_buffer for this layer's attention to consume.
+            # tokens ((p//S)%W == r), de-interleave to the local index, map to the
+            # local main-KV slot, and COMPACT them to the front -- non-owned
+            # positions are dropped, not marked with -1, because holes break
+            # aiter's lse output. The compacted per-request lengths are written
+            # into dcp_sparse_kv_indptr_buffer for this layer's attention.
             triton_filter_and_convert_dcp_index(
                 attn_metadata.cu_seqlens_q,
                 attn_metadata.g_kv_indptr,
@@ -1853,6 +1867,7 @@ def sparse_attn_indexer(
                 owned_counts=dcp_owned_counts_buffer,
                 NUM_TOPK_TOKENS=topk_tokens,
                 out=sparse_kv_indices_buffer,
+                cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
             )
         else:
             triton_convert_req_index_to_global_index(

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -460,12 +460,14 @@ class EagleProposer(Drafter):
                         raw_slots = kv_indices[kv_indptr[1 : bs + 1] - 1]
                         builder = self.runner.attn_metadata_builder
                         if getattr(builder, "dcp_world_size", 1) > 1:
-                            # DCP round-robin: only rank (context_len-1) % W owns
-                            # this draft token; other ranks' kv_indptr didn't grow,
-                            # so raw_slots would point at a stale slot. Emit -1.
+                            # DCP interleave-S: only rank ((ctx-1)//S) % W owns this
+                            # draft token; other ranks' kv_indptr didn't grow, so
+                            # raw_slots would point at a stale slot. Emit -1. S=1 is
+                            # the original round-robin ``(ctx-1) % W``.
+                            S = getattr(builder, "cp_kv_cache_interleave_size", 1)
                             ctx = attn_metadata.context_lens[:bs]
                             owned = (
-                                (ctx - 1) % builder.dcp_world_size
+                                ((ctx - 1) // S) % builder.dcp_world_size
                             ) == builder.dcp_rank
                             slot_mapping[:] = torch.where(owned, raw_slots, -1)
                         else:

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -29,6 +29,9 @@ import torch
 try:
     from atom.model_ops.dcp_ops import (
         correct_attn_out,
+        dcp_global_pos,
+        dcp_local_index,
+        dcp_owner_rank,
         get_dcp_local_seq_lens,
         reorg_kvcache,
     )
@@ -209,7 +212,7 @@ def test_non_power_of_two_world_size_is_rejected():
 
 def _brute_local_len(seq_len, dcp_size, dcp_rank, interleave):
     """Definition, straight from the storage rule: token i lives on rank
-    (i // interleave_size) % dcp_size."""
+    (i // cp_kv_cache_interleave_size) % dcp_size."""
     return sum(1 for i in range(seq_len) if (i // interleave) % dcp_size == dcp_rank)
 
 
@@ -230,6 +233,111 @@ def test_local_seq_lens_match_the_storage_rule(dcp_size, interleave):
     # No token is dropped or double-counted -- a shard-length bug here desyncs
     # the KV writes from the reads with no error anywhere.
     np.testing.assert_array_equal(sum(per_rank), lens)
+
+
+# ──────────────────────────────────── dcp_owner_rank / dcp_local_index (Part 1) ──
+# Block-level interleave (cp_kv_cache_interleave_size > 1) enabler: these two
+# helpers centralize the owner + local-index math that was inlined as `% W` /
+# `// W` all over the DCP paths. Every write/read site will call them, so a bug
+# here silently desyncs KV writes from reads. The tests pin them to the storage
+# rule (token i -> rank (i//S)%W, local index (i//(S*W))*S + i%S) and cross-check
+# against get_dcp_local_seq_lens and the vLLM slot formula.
+
+
+def _brute_local_index(i, dcp_size, dcp_rank, interleave):
+    """Local index of global token i on its owning rank, by counting: how many
+    earlier tokens (j < i) also land on the same rank."""
+    assert (i // interleave) % dcp_size == dcp_rank
+    return sum(1 for j in range(i) if (j // interleave) % dcp_size == dcp_rank)
+
+
+@pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("interleave", [1, 2, 4, 8])
+def test_dcp_owner_and_local_index_match_storage_rule(dcp_size, interleave):
+    pos = np.arange(0, 500, dtype=np.int64)
+    owners = dcp_owner_rank(pos, dcp_size, interleave)
+    local = dcp_local_index(pos, dcp_size, interleave)
+    for i in range(len(pos)):
+        r = (i // interleave) % dcp_size
+        assert int(owners[i]) == r, f"owner i={i} S={interleave} W={dcp_size}"
+        assert int(local[i]) == _brute_local_index(i, dcp_size, r, interleave), (
+            f"local_index i={i} S={interleave} W={dcp_size}"
+        )
+
+
+@pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("interleave", [1, 2, 4, 8])
+def test_dcp_global_pos_inverts_local_index(dcp_size, interleave):
+    # dcp_global_pos(local_index(g), owner(g)) must round-trip to g. The sparse
+    # candidate exchange rebuilds global ids this way, and the tie-break needs
+    # them to be a correct total order over global positions.
+    pos = np.arange(0, 500, dtype=np.int64)
+    for g in pos:
+        r = int(dcp_owner_rank(g, dcp_size, interleave))
+        j = int(dcp_local_index(g, dcp_size, interleave))
+        assert int(dcp_global_pos(j, r, dcp_size, interleave)) == int(g), (
+            f"g={g} S={interleave} W={dcp_size} r={r} j={j}"
+        )
+    # And S=1 reduces to the round-robin j*W + r.
+    j = pos
+    for r in range(dcp_size):
+        np.testing.assert_array_equal(
+            dcp_global_pos(j, r, dcp_size, 1), j * dcp_size + r
+        )
+
+
+@pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
+def test_dcp_helpers_reduce_to_round_robin_when_interleave_1(dcp_size):
+    # S == 1 must be bit-identical to the old inline round-robin (owner = i%W,
+    # local index = i//W) -- this is the S=1 regression guarantee.
+    pos = np.arange(0, 300, dtype=np.int64)
+    np.testing.assert_array_equal(dcp_owner_rank(pos, dcp_size, 1), pos % dcp_size)
+    np.testing.assert_array_equal(dcp_local_index(pos, dcp_size, 1), pos // dcp_size)
+
+
+@pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("interleave", [1, 2, 4, 8])
+def test_dcp_local_index_max_equals_local_seq_len(dcp_size, interleave):
+    # The largest local index a rank produces for a seq of length L, plus 1, must
+    # equal that rank's get_dcp_local_seq_lens(L) -- the two must agree or writes
+    # overflow / underflow the reserved per-rank KV.
+    for L in [0, 1, 7, 63, 64, 65, 130, 257, 500]:
+        pos = np.arange(0, L, dtype=np.int64)
+        owners = dcp_owner_rank(pos, dcp_size, interleave)
+        local = dcp_local_index(pos, dcp_size, interleave)
+        for r in range(dcp_size):
+            owned = local[owners == r]
+            expect = int(get_dcp_local_seq_lens(np.array([L]), dcp_size, r, interleave)[0])
+            got = int(owned.max()) + 1 if owned.size else 0
+            assert got == expect, f"L={L} r={r} S={interleave} W={dcp_size}"
+
+
+@pytest.mark.parametrize("dcp_size", [2, 4, 8])
+@pytest.mark.parametrize("interleave", [1, 2, 4, 8])
+@pytest.mark.parametrize("block_size", [8, 16, 64])
+def test_dcp_slot_matches_vllm_reference(dcp_size, interleave, block_size):
+    # Cross-check the (block_table_index, slot_offset) our helpers imply against
+    # vLLM's merged slot kernel (block_table.py:413-439), the authoritative
+    # block-level layout. Requires block_size % S == 0 (the config constraint).
+    if block_size % interleave != 0:
+        pytest.skip("block_size must be a multiple of cp_kv_cache_interleave_size")
+    vbs = block_size * dcp_size
+    for i in range(0, 4 * vbs + 3):
+        r = (i // interleave) % dcp_size
+        # ours
+        loc = dcp_local_index(i, dcp_size, interleave)
+        our_blk = i // vbs
+        our_off = loc % block_size
+        assert loc // block_size == our_blk  # block_size % S == 0 keeps these aligned
+        # vLLM reference on the virtual-block offset
+        vb_off = i % vbs
+        assert ((vb_off // interleave) % dcp_size == r)
+        ref_loc = (vb_off // (dcp_size * interleave)) * interleave + (vb_off % interleave)
+        ref_blk = i // vbs + ref_loc // block_size
+        ref_off = ref_loc % block_size
+        assert (our_blk, our_off) == (ref_blk, ref_off), (
+            f"i={i} S={interleave} W={dcp_size} bs={block_size}"
+        )
 
 
 # ─────────────────────────────────────────────────────────────── reorg_kvcache ──

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -260,9 +260,9 @@ def test_dcp_owner_and_local_index_match_storage_rule(dcp_size, interleave):
     for i in range(len(pos)):
         r = (i // interleave) % dcp_size
         assert int(owners[i]) == r, f"owner i={i} S={interleave} W={dcp_size}"
-        assert int(local[i]) == _brute_local_index(i, dcp_size, r, interleave), (
-            f"local_index i={i} S={interleave} W={dcp_size}"
-        )
+        assert int(local[i]) == _brute_local_index(
+            i, dcp_size, r, interleave
+        ), f"local_index i={i} S={interleave} W={dcp_size}"
 
 
 @pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
@@ -275,9 +275,9 @@ def test_dcp_global_pos_inverts_local_index(dcp_size, interleave):
     for g in pos:
         r = int(dcp_owner_rank(g, dcp_size, interleave))
         j = int(dcp_local_index(g, dcp_size, interleave))
-        assert int(dcp_global_pos(j, r, dcp_size, interleave)) == int(g), (
-            f"g={g} S={interleave} W={dcp_size} r={r} j={j}"
-        )
+        assert int(dcp_global_pos(j, r, dcp_size, interleave)) == int(
+            g
+        ), f"g={g} S={interleave} W={dcp_size} r={r} j={j}"
     # And S=1 reduces to the round-robin j*W + r.
     j = pos
     for r in range(dcp_size):
@@ -307,7 +307,9 @@ def test_dcp_local_index_max_equals_local_seq_len(dcp_size, interleave):
         local = dcp_local_index(pos, dcp_size, interleave)
         for r in range(dcp_size):
             owned = local[owners == r]
-            expect = int(get_dcp_local_seq_lens(np.array([L]), dcp_size, r, interleave)[0])
+            expect = int(
+                get_dcp_local_seq_lens(np.array([L]), dcp_size, r, interleave)[0]
+            )
             got = int(owned.max()) + 1 if owned.size else 0
             assert got == expect, f"L={L} r={r} S={interleave} W={dcp_size}"
 
@@ -322,7 +324,7 @@ def test_dcp_slot_matches_vllm_reference(dcp_size, interleave, block_size):
     if block_size % interleave != 0:
         pytest.skip("block_size must be a multiple of cp_kv_cache_interleave_size")
     vbs = block_size * dcp_size
-    for i in range(0, 4 * vbs + 3):
+    for i in range(4 * vbs + 3):
         r = (i // interleave) % dcp_size
         # ours
         loc = dcp_local_index(i, dcp_size, interleave)
@@ -331,13 +333,16 @@ def test_dcp_slot_matches_vllm_reference(dcp_size, interleave, block_size):
         assert loc // block_size == our_blk  # block_size % S == 0 keeps these aligned
         # vLLM reference on the virtual-block offset
         vb_off = i % vbs
-        assert ((vb_off // interleave) % dcp_size == r)
-        ref_loc = (vb_off // (dcp_size * interleave)) * interleave + (vb_off % interleave)
+        assert (vb_off // interleave) % dcp_size == r
+        ref_loc = (vb_off // (dcp_size * interleave)) * interleave + (
+            vb_off % interleave
+        )
         ref_blk = i // vbs + ref_loc // block_size
         ref_off = ref_loc % block_size
-        assert (our_blk, our_off) == (ref_blk, ref_off), (
-            f"i={i} S={interleave} W={dcp_size} bs={block_size}"
-        )
+        assert (our_blk, our_off) == (
+            ref_blk,
+            ref_off,
+        ), f"i={i} S={interleave} W={dcp_size} bs={block_size}"
 
 
 # ─────────────────────────────────────────────────────────────── reorg_kvcache ──

--- a/tests/test_dcp_sparse_filter.py
+++ b/tests/test_dcp_sparse_filter.py
@@ -44,7 +44,7 @@ if not torch.cuda.is_available():
 DEV = "cuda"
 
 
-def writer_slot(block_table_row, pos, rank, world, page):
+def writer_slot(block_table_row, pos, rank, world, page, interleave=1):
     """Where the WRITE side physically put this token; -1 if another rank owns it.
 
     This is the independent authority the expected values are built from. A
@@ -58,6 +58,7 @@ def writer_slot(block_table_row, pos, rank, world, page):
     stub = SimpleNamespace(
         dcp_world_size=world,
         dcp_rank=rank,
+        cp_kv_cache_interleave_size=interleave,
         model_runner=SimpleNamespace(block_size=page),
     )
     return int(
@@ -98,7 +99,7 @@ def _build_decode_case(g_ctxs, max_blocks, seed):
     return qo_indptr, global_kv_indptr, block_table, token_indices
 
 
-def _decode_reference(g_ctxs, block_table, token_indices, rank):
+def _decode_reference(g_ctxs, block_table, token_indices, rank, interleave=1):
     """Expected compacted slots per request, taken from the write side."""
     out = []
     for b, g in enumerate(g_ctxs):
@@ -109,7 +110,7 @@ def _decode_reference(g_ctxs, block_table, token_indices, rank):
             if tok < 0:
                 continue
             # ownership AND placement both come from the writer
-            slot = writer_slot(block_table[b], tok, rank, DEC_W, DEC_PAGE)
+            slot = writer_slot(block_table[b], tok, rank, DEC_W, DEC_PAGE, interleave)
             if slot >= 0:
                 slots.append(slot)
         out.append(slots)
@@ -192,6 +193,62 @@ def test_decode_filter(name, g_ctxs, seed):
         assert total == n, f"[{name}] req{b}: kept {total} of {n} top-k tokens"
 
 
+@pytest.mark.parametrize("interleave", [2, 4])  # both divide DEC_PAGE=16
+@pytest.mark.parametrize(
+    "g_ctxs, seed",
+    [([13, 100, 7, 300], 12), ([1000, 4096], 13), ([DEC_PAGE * DEC_W + 1], 14)],
+)
+def test_decode_filter_block_interleave(interleave, g_ctxs, seed):
+    """Same partition + writer-agreement checks as test_decode_filter, but with
+    block-level interleave S>1 (cp_kv_cache_interleave_size). The reference
+    slots come from the same _dcp_round_robin_slot writer, now with S, so the
+    filter kernel's owner/offset math is pinned to the write side at S>1."""
+    bs = len(g_ctxs)
+    max_blocks = max(1, (max(g_ctxs) + DEC_PAGE * DEC_W - 1) // (DEC_PAGE * DEC_W)) + 1
+    qo_indptr, global_kv_indptr, block_table, token_indices = _build_decode_case(
+        g_ctxs, max_blocks, seed
+    )
+    qo_g = qo_indptr.to(DEV)
+    gkv_g = global_kv_indptr.to(DEV)
+    bt_g = block_table.to(DEV)
+    ti_g = token_indices.to(DEV)
+
+    per_rank_lens = []
+    for rank in range(DEC_W):
+        out_buf = torch.full((bs * DEC_K,), -999, dtype=torch.int32, device=DEV)
+        out_indptr = torch.zeros(bs + 1, dtype=torch.int32, device=DEV)
+        counts = torch.zeros(bs, dtype=torch.int32, device=DEV)
+
+        triton_filter_and_convert_dcp_index(
+            qo_g,
+            gkv_g,
+            bt_g,
+            ti_g,
+            rank,
+            DEC_W,
+            DEC_PAGE,
+            out_kv_indptr=out_indptr,
+            owned_counts=counts,
+            NUM_TOPK_TOKENS=DEC_K,
+            out=out_buf,
+            cp_kv_cache_interleave_size=interleave,
+        )
+        torch.cuda.synchronize()
+
+        exp = _decode_reference(g_ctxs, block_table, token_indices, rank, interleave)
+        indptr = out_indptr.cpu().tolist()
+        for b in range(bs):
+            got = out_buf[indptr[b] : indptr[b + 1]].cpu().tolist()
+            assert got == exp[b], f"S={interleave} rank{rank} req{b}: {got} != {exp[b]}"
+        assert int((out_buf[: indptr[bs]] < 0).sum()) == 0, "-1 hole in region"
+        per_rank_lens.append([indptr[b + 1] - indptr[b] for b in range(bs)])
+
+    for b, g in enumerate(g_ctxs):
+        n = min(g, DEC_K)
+        total = sum(per_rank_lens[rank][b] for rank in range(DEC_W))
+        assert total == n, f"S={interleave} req{b}: kept {total} of {n}"
+
+
 # ────────────────────────────────────────────────────────────── prefill side ──
 
 PRE_W = 8
@@ -250,7 +307,7 @@ def _build_prefill_case(seq_lens):
     }
 
 
-def _run_prefill(case):
+def _run_prefill(case, interleave=1):
     n = case["num_tokens"]
     g = {
         k: torch.from_numpy(v).to(DEV)
@@ -278,6 +335,7 @@ def _run_prefill(case):
             owned_counts=counts_scratch,
             NUM_TOPK_TOKENS=PRE_TOPK,
             out=out_buf,
+            cp_kv_cache_interleave_size=interleave,
         )
         torch.cuda.synchronize()
         per_rank.append(
@@ -290,12 +348,13 @@ def _run_prefill(case):
     return per_rank
 
 
+@pytest.mark.parametrize("interleave", [1, 4])  # 4 divides PRE_PAGE=16
 @pytest.mark.parametrize(
     "seq_lens", [[400], [300, 240], [17, 5, 1]], ids=["single", "two-seq", "tiny"]
 )
-def test_prefill_filter(seq_lens):
+def test_prefill_filter(seq_lens, interleave):
     case = _build_prefill_case(np.asarray(seq_lens, dtype=np.int32))
-    per_rank = _run_prefill(case)
+    per_rank = _run_prefill(case, interleave)
 
     cu_k = case["cu_k"]
     tts = case["token_to_seq"]
@@ -312,7 +371,7 @@ def test_prefill_filter(seq_lens):
         key = (int(b), int(p))
         if key not in owner_of:
             claims = [
-                (r, writer_slot(bt[b], int(p), r, PRE_W, PRE_PAGE))
+                (r, writer_slot(bt[b], int(p), r, PRE_W, PRE_PAGE, interleave))
                 for r in range(PRE_W)
             ]
             claims = [(r, s) for r, s in claims if s >= 0]


### PR DESCRIPTION
## Motivation

Add a configurable DCP KV-cache interleave granularity (--dcp-config '{"interleave_size": S}',Default 1 = today's token-level round-robin) 

So a physical KV block can hold one rank's contiguous run of tokens instead of interleaved ones, letting future PD-disaggregation pull whole KV blocks to the decode node without in-block token rearrangement.

Verified bit-identical at S=1 and noise-level-equivalent gsm8k accuracy at S=block_size for both dense (DeepSeek-R1) and sparse-DSA (GLM-5.2) paths.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
