### PR TITLE
fix(moe): preserve FP8 shuffle metadata

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1883,6 +1883,9 @@ class CompressedTensorsFp8MoEMethod(FusedMoEMethodBase):
 
             w13.data = shuffle_weight(w13.data)
             w2.data = shuffle_weight(w2.data)
+            # Tensor attributes do not survive assignment through Parameter.data.
+            w13.is_shuffled = True
+            w2.is_shuffled = True
 
         # Call parent class for any additional processing
         super().process_weights_after_loading(layer)


### PR DESCRIPTION
## Motivation

Preserve is_shuffled=True on compressed-tensors FP8 MoE parameters after applying AITER’s weight shuffle.

## Technical Details

Assigning the shuffled tensors through Parameter.data does not preserve custom tensor attributes. As a result, the weights were correctly shuffled, but AITER could treat them as unshuffled and select a kernel for the wrong layout, producing incorrect output.

This change only restores the metadata on the existing parameters. 

## Test Plan

TBD

## Test Result

TBD

