### PR TITLE
fix kimi prefix caching accuracy

### DIFF
--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -1109,6 +1109,18 @@ class KimiKDAAttention(nn.Module):
 
         conv_weights = self.conv_weight
         state_indices = kda_metadata.non_spec_state_indices_tensor
+        # Slot the incoming state is READ from. It differs from the write slot
+        # for exactly one forward: the prefix-cache hit that forks off a
+        # checkpoint (BlockManager._attach_state_group reads `state_fork_src`
+        # and writes a freshly popped group). Reading the write slot there
+        # resumes from whatever the recycled group still held. Only prefill can
+        # carry a fork -- prepare_state_indices asserts it, and min_fork_tokens
+        # keeps the chunk long enough -- so the decode branches below stay on
+        # `state_indices`. Falling back to the write slot leaves every non-fork
+        # forward bit-identical. Mirrors attention_gdn.py.
+        state_indices_in = kda_metadata.non_spec_state_indices_in_tensor
+        if state_indices_in is None:
+            state_indices_in = state_indices
         query_start_loc = kda_metadata.non_spec_query_start_loc
 
         if kda_metadata.num_prefills > 0:
@@ -1120,6 +1132,7 @@ class KimiKDAAttention(nn.Module):
                 conv_states=conv_state,
                 has_initial_state=kda_metadata.has_initial_state,
                 cache_indices=state_indices,
+                cache_indices_in=state_indices_in,
                 query_start_loc=query_start_loc,
                 k_dim_size=self.local_proj_size,
                 v_dim_size=self.local_proj_size,
@@ -1134,7 +1147,7 @@ class KimiKDAAttention(nn.Module):
             from atom.model_ops.kimi_k3 import gather_kda_initial_state
 
             initial = gather_kda_initial_state(
-                ssm_state, state_indices, kda_metadata.has_initial_state
+                ssm_state, state_indices_in, kda_metadata.has_initial_state
             )
             kda_out, last_state = self._run_kda(
                 q,

--- a/recipes/Kimi-K3.md
+++ b/recipes/Kimi-K3.md
@@ -44,13 +44,15 @@ Prefix caching remains disabled because the KDA recurrent state is maintained pe
 
 Start the server as above, then run the full 1319-question GSM8K evaluation:
 
+
 ```bash
-lm_eval \
-  --model local-completions \
-  --model_args "model=Kimi-K3,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True" \
-  --tasks gsm8k \
-  --num_fewshot 5 \
-  --seed 42
+# download inferenceX gsm8k yaml from https://github.com/SemiAnalysisAI/InferenceX/blob/main/utils/evals/gsm8k.yaml
+
+lm_eval --model local-chat-completions \
+  --apply_chat_template \
+  --tasks /path-to-gsm8k-yaml \
+  --model_args "model=${MODEL},base_url=http://localhost:8000/v1/chat/completions,api_key=EMPTY,eos_string=</s>,max_retries=5,num_concurrent=10,timeout=1800,tokenized_requests=False,max_length=16384" \
+  --gen_kwargs max_tokens=12288,temperature=0,top_p=1
 ```
 
 Validated true-MLA result range on gfx950 TP8:
@@ -58,8 +60,8 @@ Validated true-MLA result range on gfx950 TP8:
 ```text
 | Filter           | Minimum | Maximum |
 |------------------|--------:|--------:|
-| flexible-extract |  0.9538 |  0.9591 |
-| strict-match     |  0.9538 |  0.9591 |
+| flexible-extract |  0.9659 |  0.9591 |
+| strict-match     |  0.9666 |  0.9591 |
 ```
 
 Run on an uncontended GPU set and verify the evaluation completes without server disconnects or worker failures.


### PR DESCRIPTION
## Motivation
Fix kimi k3 accuracy issue after prefix caching refactor
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
w prefix caching open/main
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6611|±  | 0.013|
|     |       |strict-match    |     5|exact_match|↑  |0.6649|±  | 0.013|
```
w prefix caching open/this PR
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9659|±  |0.0050|
|     |       |strict-match    |     5|exact_match|↑  |0.9666|±  |0.0049|
```
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
