### PR TITLE
perf(mtp): defer draft proposal publication

### DIFF
--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -327,10 +327,10 @@ class EngineCore:
             logger.debug("%s: Empty scheduled batch, skipping postprocess", self.label)
             return False
 
-        seqs = seqs.values()
+        scheduled_seqs = list(seqs.values())
         # Pass stream_output_queue to postprocess for streaming callbacks
         finished_seqs = self.scheduler.postprocess(
-            seqs,
+            scheduled_seqs,
             fwd_out,
             stream_output_queue=self.stream_output_queue,
             batch=scheduled_batch,
@@ -348,7 +348,36 @@ class EngineCore:
         if finished_seqs:
             self.output_queue.put_nowait(finished_seqs)
 
+        self._dispatch_pending_draft(fwd_out, scheduled_seqs)
         return True
+
+    def _dispatch_pending_draft(self, fwd_out, scheduled_seqs) -> None:
+        """Resolve a publish-before-draft target step on the worker FIFO.
+
+        Output queues are filled before this method is called, matching the
+        target-end publish fence: clients and detokenization can advance while
+        a continuing batch proposes its next draft tokens.  ``call_func`` is
+        intentionally fire-and-forget.  The next forward RPC enters the same
+        broadcast queue after it, which preserves target/draft ordering on all
+        TP ranks without a host-side wait.
+
+        If every sequence in the batch stopped while consuming the output that
+        was just published, the current target step is pipeline lookahead: its
+        sampled ids/status and any would-be draft extension can never be
+        consumed.  Drain that generation and reset the one-step pipeline
+        instead of running a terminal proposal.  A mixed/continuing batch must
+        still finish its proposal before the next forward RPC.
+        """
+        if not getattr(fwd_out, "draft_proposal_pending", False):
+            return
+        all_terminal = (
+            envs.ATOM_CANCEL_TERMINAL_MTP_PROPOSAL
+            and bool(scheduled_seqs)
+            and all(seq.status == SequenceStatus.FINISHED for seq in scheduled_seqs)
+        )
+        self.runner_mgr.call_func(
+            "cancel_draft_proposal" if all_terminal else "finish_draft_proposal"
+        )
 
     def _advance_idle_kv_transfer(self) -> None:
         # No forward batch will run this tick, but offload load/save work may

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -163,6 +163,16 @@ class TokenLocations(NamedTuple):
     new_curr: np.ndarray
 
 
+class PendingDraftProposal(NamedTuple):
+    """GPU inputs retained between target publish and draft extension."""
+
+    batch: ScheduledBatch
+    input_ids: torch.Tensor
+    hidden_states: torch.Tensor
+    next_token_ids: torch.Tensor
+    num_reject_tokens: torch.Tensor
+
+
 class tokenIDProcessor:
 
     def __init__(
@@ -218,13 +228,21 @@ class tokenIDProcessor:
                 else None
             )
             copy_done.record(self.async_copy_stream)
-        cpu_tensor_handle.append((cpu_tensor, copy_done))
+        # Keep the source allocations alive until the copy event completes.
+        # The copy runs on ``async_copy_stream`` while these tensors are
+        # produced on the default stream.  Holding only the CPU destination
+        # and event lets Python drop a short-lived sampled tensor as soon as a
+        # split target step returns; the caching allocator may then recycle
+        # its storage while this D2H is still pending.
+        cpu_tensor_handle.append(
+            (cpu_tensor, copy_done, gpu_tensor, gpu_logprobs)
+        )
         self.logprobs_cpu.append(cpu_logprobs)
 
     def recv_async_output(self, cpu_tensor_handle) -> torch.Tensor:
         if not cpu_tensor_handle:
             return torch.empty(0, dtype=torch.int32, device="cpu")
-        cpu_tensor, event = cpu_tensor_handle.pop(0)
+        cpu_tensor, event, _gpu_tensor, _gpu_logprobs = cpu_tensor_handle.pop(0)
         event.synchronize()
         return cpu_tensor
 
@@ -246,12 +264,12 @@ class tokenIDProcessor:
             cpu_tensor = gpu_tensor.to("cpu", non_blocking=True)
             event = torch.cuda.Event()
             event.record(self.async_copy_stream)
-        self.draft_token_ids_cpu.append((cpu_tensor, event))
+        self.draft_token_ids_cpu.append((cpu_tensor, event, gpu_tensor))
 
     def recv_async_output_draft(self) -> np.ndarray:
         if not self.draft_token_ids_cpu:
             return np.array([], dtype=np.int32)
-        token_ids, event = self.draft_token_ids_cpu.pop(0)
+        token_ids, event, _gpu_tensor = self.draft_token_ids_cpu.pop(0)
         event.synchronize()
         return token_ids.numpy()
 
@@ -276,7 +294,13 @@ class tokenIDProcessor:
             cpu_num_bonus = num_bonus.to("cpu", non_blocking=True)
             copy_done.record(self.async_copy_stream)
         self.pending_mtp_status_copies.append(
-            (cpu_num_rejected, cpu_num_bonus, copy_done)
+            (
+                cpu_num_rejected,
+                cpu_num_bonus,
+                copy_done,
+                num_rejected,
+                num_bonus,
+            )
         )
 
     def recv_mtp_status_async(
@@ -284,14 +308,25 @@ class tokenIDProcessor:
     ) -> tuple[np.ndarray | None, np.ndarray | None]:
         if not self.pending_mtp_status_copies:
             return None, None
-        cpu_num_rejected, cpu_num_bonus, copy_done = self.pending_mtp_status_copies.pop(
-            0
-        )
+        (
+            cpu_num_rejected,
+            cpu_num_bonus,
+            copy_done,
+            _gpu_num_rejected,
+            _gpu_num_bonus,
+        ) = self.pending_mtp_status_copies.pop(0)
         copy_done.synchronize()
         return cpu_num_rejected.numpy(), cpu_num_bonus.numpy()
 
     def clean(self):
-        self.token_ids_cpu: list[torch.Tensor] = []
+        self.token_ids_cpu: list[
+            tuple[
+                torch.Tensor,
+                torch.cuda.Event,
+                torch.Tensor,
+                torch.Tensor | None,
+            ]
+        ] = []
         self.logprobs_cpu: list[torch.Tensor | None] = []
 
         self.prev_batch: ScheduledBatch | None = None
@@ -299,12 +334,21 @@ class tokenIDProcessor:
 
         self.pre_num_decode_token_per_seq = 1
         self.draft_token_ids: torch.Tensor | None = None
-        self.draft_token_ids_cpu: list[torch.Tensor] = []
-        # Queue of (cpu_num_rejected, cpu_num_bonus, copy_done_event) — async
-        # D2H copies fired by send_mtp_status_to_cpu_async, drained by
-        # recv_mtp_status_async after the event syncs.
+        self.draft_token_ids_cpu: list[
+            tuple[torch.Tensor, torch.cuda.Event, torch.Tensor]
+        ] = []
+        # Queue of (cpu_num_rejected, cpu_num_bonus, copy_done_event,
+        # gpu_num_rejected, gpu_num_bonus).  The source tensors keep their GPU
+        # allocations alive until recv_mtp_status_async synchronizes the D2H
+        # event; otherwise the caching allocator may recycle them early.
         self.pending_mtp_status_copies: list[
-            tuple[torch.Tensor, torch.Tensor, torch.cuda.Event]
+            tuple[
+                torch.Tensor,
+                torch.Tensor,
+                torch.cuda.Event,
+                torch.Tensor,
+                torch.Tensor,
+            ]
         ] = []
         self.num_rejected: np.ndarray | None = None
         self.num_bonus: np.ndarray | None = None
@@ -388,6 +432,44 @@ class tokenIDProcessor:
         self.prev_batch = batch
         self.prev_token_ids = sampled_token_ids
         token_id_dict[-1] = 1
+        return token_id_dict, logprobs_map
+
+    def prepare_current_terminal_ids(
+        self,
+        batch: ScheduledBatch,
+        sampled_token_ids: torch.Tensor,
+        sampled_logprobs: torch.Tensor | None = None,
+    ) -> tuple[dict[int, tuple[int, ...]], dict[int, float] | None]:
+        """Synchronously publish the current ids for a terminal prefill.
+
+        This path is deliberately narrower than normal deferred output: it is
+        called only when every request is guaranteed to stop at its first
+        generated token and no older deferred generation exists.  Nothing is
+        enqueued for a next step, so the token/draft/status pipelines remain
+        empty for the next unrelated request.
+        """
+        assert self.is_deferred_out
+        assert self.prev_batch is None
+        assert not self.token_ids_cpu
+        assert not self.logprobs_cpu
+        assert not self.draft_token_ids_cpu
+        assert not self.pending_mtp_status_copies
+
+        token_ids = sampled_token_ids.tolist()
+        if token_ids and isinstance(token_ids[0], list):
+            processed = self._batch_process_token_ids(token_ids)
+        else:
+            processed = [(tid,) for tid in token_ids]
+        token_id_dict = dict(zip(batch.req_ids, processed))
+        token_id_dict[-1] = 1
+
+        logprobs_map = None
+        if sampled_logprobs is not None:
+            logprobs = sampled_logprobs.tolist()
+            logprobs_map = {
+                seq_id: logprob
+                for seq_id, logprob in zip(batch.req_ids, logprobs)
+            }
         return token_id_dict, logprobs_map
 
     def get_token_locations(self, batch: ScheduledBatch) -> TokenLocations:
@@ -583,18 +665,63 @@ class tokenIDProcessor:
         self, batch: ScheduledBatch, draft_token_ids: torch.Tensor
     ) -> np.ndarray:
         if not self.is_deferred_out:
-            ret = draft_token_ids.numpy()
-        else:
-            self.draft_token_ids = draft_token_ids
-            self.pre_num_decode_token_per_seq = self.num_spec_tokens + 1
-            token_ids = self.recv_async_output_draft()
-            self.send_to_cpu_async_draft(draft_token_ids)
-            ret = (
-                token_ids
-                if self.prev_req_ids is not None
-                else np.array([], dtype=np.int32)
-            )
+            return draft_token_ids.numpy()
+
+        ret = self.take_previous_draft_ids()
+        self.store_draft_ids(draft_token_ids)
         return ret
+
+    def take_previous_draft_ids(self) -> np.ndarray:
+        """Return the draft rows consumed by the just-finished target step.
+
+        Deferred output makes both sampled ids and draft ids one generation
+        late.  This dequeue used to happen only *after* the next draft proposal,
+        even though the returned rows belong to the previous proposal.  Keeping
+        the dequeue separate lets the target result be published before the
+        current proposal without changing which request owns each draft row.
+        """
+        assert self.is_deferred_out
+        token_ids = self.recv_async_output_draft()
+        return (
+            token_ids
+            if self.prev_req_ids is not None
+            else np.array([], dtype=np.int32)
+        )
+
+    def store_draft_ids(self, draft_token_ids: torch.Tensor) -> None:
+        """Keep current proposal output for the next target/verify step."""
+        assert self.is_deferred_out
+        self.draft_token_ids = draft_token_ids
+        self.pre_num_decode_token_per_seq = self.num_spec_tokens + 1
+        self.send_to_cpu_async_draft(draft_token_ids)
+
+    def discard_current_deferred_generation(self) -> None:
+        """Drain a terminal batch's never-consumed deferred generation.
+
+        The target step has already enqueued sampled-id and MTP-status D2H
+        copies before the scheduler can discover that every request is done.
+        Synchronize and discard those tiny copies, then reset the one-step
+        pipeline so the next unrelated request starts as a fresh generation.
+        The previous draft copy was already consumed by
+        :meth:`take_previous_draft_ids`; no current draft exists because the
+        proposal is being cancelled.
+        """
+        self.recv_async_output(self.token_ids_cpu)
+        self.recv_logprobs()
+        self.recv_mtp_status_async()
+
+        # A split target step consumes the sole previous-draft entry before it
+        # is published and cancellation never enqueues a replacement.
+        assert not self.draft_token_ids_cpu
+        self.prev_batch = None
+        self.prev_req_ids = None
+        self.prev_token_ids = None
+        self.pre_num_decode_token_per_seq = 1
+        self.draft_token_ids = None
+        self.prev_rejected_num = None
+        self.prev_bonus_num = None
+        self.num_rejected = None
+        self.num_bonus = None
 
 
 class ModelRunner:
@@ -678,6 +805,10 @@ class ModelRunner:
             use_spec,
             self.num_spec_tokens,
         )
+        # Plain MTP may return target/verify output before its draft extension.
+        # At most one proposal can be pending: EngineCore queues its finish or
+        # cancellation before another forward RPC, and worker RPCs are FIFO.
+        self._pending_draft_proposal: PendingDraftProposal | None = None
         self.sampler = Sampler()
         self.arange_np = np.arange(
             max(
@@ -3087,6 +3218,7 @@ class ModelRunner:
         # following for draft
         hidden_states: torch.Tensor,
         needs_independent_noise: bool = False,
+        defer_draft_proposal: bool = False,
     ) -> ScheduledBatchOutput:
         spec_decode_metadata = get_forward_context().spec_decode_metadata
         bs = batch.total_seqs_num
@@ -3151,16 +3283,28 @@ class ModelRunner:
         self.forward_done_event.record()
         # Capture before prepare_sampled_ids(), which advances self.prev_batch to current batch.
         prev_batch = self.tokenID_processor.prev_batch
-        token_id_dict, logprobs_map = self.tokenID_processor.prepare_sampled_ids(
-            batch, sampled_tokens, self.forward_done_event, sampled_logprobs
-        )
+        publish_current_terminal = self._can_publish_current_terminal(batch)
+        if publish_current_terminal:
+            token_id_dict, logprobs_map = (
+                self.tokenID_processor.prepare_current_terminal_ids(
+                    batch, sampled_tokens, sampled_logprobs
+                )
+            )
+        else:
+            token_id_dict, logprobs_map = self.tokenID_processor.prepare_sampled_ids(
+                batch, sampled_tokens, self.forward_done_event, sampled_logprobs
+            )
         # Extract req_ids and token_ids from dict (key -1 is the is_deferred_out flag)
         req_ids_out = [k for k in token_id_dict if k != -1]
         token_ids_out = [token_id_dict[k] for k in req_ids_out]
 
         draft_token_ids: np.ndarray | None = None
+        draft_proposal_pending = False
         if self.tokenID_processor.is_deferred_out:
-            if hasattr(self, "drafter"):
+            if publish_current_terminal:
+                prev_rejected_num = np.zeros(batch.total_seqs_num, dtype=np.int32)
+                prev_bonus_num = np.zeros(batch.total_seqs_num, dtype=np.int32)
+            elif hasattr(self, "drafter"):
                 prev_rejected_num = self.tokenID_processor.prev_rejected_num
                 prev_bonus_num = self.tokenID_processor.prev_bonus_num
                 self.tokenID_processor.send_mtp_status_to_cpu_async(
@@ -3170,15 +3314,34 @@ class ModelRunner:
                     sampled_tokens.view(bs, -1), 1, next_token_locs.view(-1, 1)
                 ).view(bs)
                 self.tokenID_processor.prev_token_ids = next_token_ids
-                draft_token_ids = self.propose_draft_token_ids(
-                    batch,
-                    self.tokenID_processor.input_ids.gpu[
-                        1 : batch.total_tokens_num + 1
-                    ],
-                    hidden_states,
-                    next_token_ids,
-                    num_reject_tokens,
-                )
+                draft_input_ids = self.tokenID_processor.input_ids.gpu[
+                    1 : batch.total_tokens_num + 1
+                ]
+                if defer_draft_proposal:
+                    assert self._pending_draft_proposal is None
+                    # These rows were proposed by the previous generation and
+                    # consumed by the target step that just finished.  Their
+                    # D2H copy is independent of the new proposal, so return it
+                    # now and let EngineCore publish target results first.
+                    draft_token_ids = (
+                        self.tokenID_processor.take_previous_draft_ids()
+                    )
+                    self._pending_draft_proposal = PendingDraftProposal(
+                        batch=batch,
+                        input_ids=draft_input_ids,
+                        hidden_states=hidden_states,
+                        next_token_ids=next_token_ids,
+                        num_reject_tokens=num_reject_tokens,
+                    )
+                    draft_proposal_pending = True
+                else:
+                    draft_token_ids = self.propose_draft_token_ids(
+                        batch,
+                        draft_input_ids,
+                        hidden_states,
+                        next_token_ids,
+                        num_reject_tokens,
+                    )
                 # self.debug(f"{num_bonus_tokens=}")
 
             elif prev_batch is not None:
@@ -3211,6 +3374,8 @@ class ModelRunner:
             num_bonus=prev_bonus_num,
             logprobs=logprobs_map,
             dspark_ell=dspark_ell,
+            draft_proposal_pending=draft_proposal_pending,
+            is_current_terminal_output=publish_current_terminal,
         )
 
     @torch.inference_mode()
@@ -3258,6 +3423,7 @@ class ModelRunner:
                 draft_token_ids=None,
             )
 
+        defer_draft_proposal = self._can_defer_draft_proposal(batch)
         fwd_output = self.postprocess(
             batch,
             logits,
@@ -3267,12 +3433,93 @@ class ModelRunner:
             all_greedy,
             hidden_states,
             needs_independent_noise=needs_independent_noise,
+            defer_draft_proposal=defer_draft_proposal,
         )
 
-        reset_forward_context()
-        if not batch.is_dummy_run:
-            self._record_forward_vars_event()
+        # A split MTP step retains the forward context and GPU tensors until
+        # the FIFO-following finish/cancel RPC.  Synchronous paths keep their
+        # original lifetime.
+        if not fwd_output.draft_proposal_pending:
+            reset_forward_context()
+            if not batch.is_dummy_run:
+                self._record_forward_vars_event()
         return fwd_output
+
+    def _can_defer_draft_proposal(self, batch: ScheduledBatch) -> bool:
+        """Whether this step supports publish-before-draft execution.
+
+        DSpark's confidence scheduler returns ``ell`` from proposal to the host
+        scheduler, so it must remain synchronous.  Pipeline parallelism does
+        not use deferred output, and RapidServe overrides ``forward`` with its
+        own stream lifetime.  The remaining plain-MTP path has no proposal
+        result needed by this iteration's scheduler.
+        """
+        if (
+            batch.is_dummy_run
+            or not envs.ATOM_DEFER_MTP_PROPOSAL
+            or not self.tokenID_processor.is_deferred_out
+            or getattr(self.config, "eplb_enable", False)
+        ):
+            return False
+        spec_config = getattr(self.config, "speculative_config", None)
+        if getattr(spec_config, "method", None) != "mtp":
+            return False
+        drafter = getattr(self, "drafter", None)
+        if drafter is None:
+            return False
+        return getattr(drafter, "verify_scheduler", None) is None
+
+    def _can_publish_current_terminal(self, batch: ScheduledBatch) -> bool:
+        """Whether current prefill samples are guaranteed terminal outputs."""
+        final_chunks = batch.is_final_chunk
+        is_terminal_candidate = (
+            getattr(batch, "all_max_tokens_one", False)
+            and batch.total_seqs_num_prefill == batch.total_seqs_num
+            and batch.total_seqs_num_decode == 0
+            and not getattr(batch, "requires_followup_state_checkpoint", False)
+            and final_chunks is not None
+            and bool(final_chunks)
+            and all(final_chunks)
+        )
+        return bool(
+            is_terminal_candidate
+            and envs.ATOM_TERMINAL_MTP_FAST_PATH
+            and self.tokenID_processor.is_deferred_out
+            and self.tokenID_processor.prev_batch is None
+        )
+
+    @torch.inference_mode()
+    def finish_draft_proposal(self) -> None:
+        """Run the proposal retained by a publish-before-draft target step."""
+        pending = self._pending_draft_proposal
+        assert pending is not None, "no deferred draft proposal to finish"
+        try:
+            self.propose_draft_token_ids(
+                pending.batch,
+                pending.input_ids,
+                pending.hidden_states,
+                pending.next_token_ids,
+                pending.num_reject_tokens,
+                return_previous_draft=False,
+            )
+        finally:
+            self._pending_draft_proposal = None
+            reset_forward_context()
+            if not pending.batch.is_dummy_run:
+                self._record_forward_vars_event()
+
+    @torch.inference_mode()
+    def cancel_draft_proposal(self) -> None:
+        """Drop a retained proposal after every request in its batch stops."""
+        pending = self._pending_draft_proposal
+        assert pending is not None, "no deferred draft proposal to cancel"
+        try:
+            self.tokenID_processor.discard_current_deferred_generation()
+        finally:
+            self._pending_draft_proposal = None
+            reset_forward_context()
+            if not pending.batch.is_dummy_run:
+                self._record_forward_vars_event()
 
     @staticmethod
     def _is_pure_middle_chunk(batch) -> bool:
@@ -3317,6 +3564,7 @@ class ModelRunner:
         hidden_states: torch.Tensor,
         next_token_ids: torch.Tensor,
         num_reject_tokens: torch.Tensor,
+        return_previous_draft: bool = True,
     ):
         forward_context = get_forward_context()
 
@@ -3391,7 +3639,10 @@ class ModelRunner:
         verify_scheduler = getattr(self.drafter, "verify_scheduler", None)
         if verify_scheduler is not None:
             verify_scheduler.record_ell(batch.req_ids[: batch.total_seqs_num])
-        return self.tokenID_processor.prepare_draft_ids(batch, draft_token)
+        if return_previous_draft:
+            return self.tokenID_processor.prepare_draft_ids(batch, draft_token)
+        self.tokenID_processor.store_draft_ids(draft_token)
+        return None
 
     def start_capture_profiler(self):
         """Set up the per-bs CUDA graph capture profiler (profiles in place).

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -527,6 +527,19 @@ class ScheduledBatch:
                 # Clear after first use to avoid re-sending on decode steps
                 seq.multimodal_data = None
         self.external_request_ids = [seq.external_request_id for seq in seqs.values()]
+        # A pure final-prefill batch of one-token requests can publish its
+        # current sampled ids directly instead of constructing a speculative
+        # generation that no request can consume.  ModelRunner applies the
+        # remaining safety gates (no older deferred generation, no mixed or
+        # middle-chunk prefill).
+        self.all_max_tokens_one = bool(seqs) and all(
+            seq.max_tokens == 1 for seq in seqs.values()
+        )
+        # Set by Scheduler after it has the BlockManager needed to ask the
+        # existing checkpoint ladder. A PAGE-backed state checkpoint becomes
+        # real only when a following batch executes its maintenance store op;
+        # a terminal fast path must not free the source SLOT before that pass.
+        self.requires_followup_state_checkpoint = False
 
         # logger.info(f"{[el for el in scheduled_spec_decode_tokens.keys()]=}")
         # logger.info(f"{self.num_scheduled_tokens=}")
@@ -570,6 +583,8 @@ class ScheduledBatchOutput:
         is_prev_prefill=False,
         logprobs=None,
         dspark_ell: np.ndarray | None = None,
+        draft_proposal_pending: bool = False,
+        is_current_terminal_output: bool = False,
     ):
         self.req_ids = req_ids
         self.token_ids = token_ids
@@ -584,6 +599,19 @@ class ScheduledBatchOutput:
         # (main-process) scheduler so the NEXT step can size each request's
         # verification to ell_r+1. None when DSpark scheduling is off.
         self.dspark_ell = dspark_ell
+        # Plain-MTP deferred-output mode can publish target/verify results
+        # before running the draft extension.  When true, EngineCore must
+        # enqueue exactly one ``finish_draft_proposal`` or
+        # ``cancel_draft_proposal`` RPC before it schedules another forward.
+        # The worker RPC queue is FIFO, so an asynchronously enqueued finish is
+        # still guaranteed to complete before the next target forward uses the
+        # newly proposed draft tokens.
+        self.draft_proposal_pending = draft_proposal_pending
+        # True only for the max_tokens=1 final-prefill fast path.  These token
+        # ids were sampled by the current forward (not the previous deferred
+        # generation), so Scheduler must append them directly and must not
+        # create/patch speculative placeholders.
+        self.is_current_terminal_output = is_current_terminal_output
         # O(1) lookup: req_id -> index (lazy-built on first access)
         self._req_id_to_idx: dict[int, int] | None = None
 
@@ -1378,6 +1406,13 @@ class Scheduler:
                 next_token_ids=next_token_ids,
                 state_maintenance_ops=self.block_manager.take_state_maintenance_ops(),
             )
+            prefill_batch.requires_followup_state_checkpoint = any(
+                self.block_manager.checkpointers_at(
+                    seq,
+                    num_cached_tokens_list[i] + int(num_scheduled_tokens[i]),
+                )
+                for i, seq in enumerate(scheduled_seqs.values())
+            )
             self._consume_state_forks(scheduled_seqs)
 
             if self.advance_on_schedule:
@@ -2001,15 +2036,19 @@ class Scheduler:
         prev_token_ids = fwd_output.token_ids
         draft_token_ids = fwd_output.draft_token_ids
         is_deferred_out = fwd_output.is_deferred_out
+        is_current_terminal_output = fwd_output.is_current_terminal_output
         token_logprobs = fwd_output.logprobs  # Optional[dict[int, float]]
         # update token_ids with the actual sampled token ids
 
         finished_seqs = []
         stream_outputs = []
 
-        need_placeholder = is_deferred_out or self.use_spec
+        pipelined_output = (
+            is_deferred_out or self.use_spec
+        ) and not is_current_terminal_output
+        need_placeholder = pipelined_output
         num_placeholder = self.mtp_k
-        if is_deferred_out:
+        if is_deferred_out and not is_current_terminal_output:
             num_placeholder += 1
 
         for seq in self.running:
@@ -2035,7 +2074,13 @@ class Scheduler:
             # request from at least one intervening model-runner batch, which
             # already discards its deferred partial output. The first output
             # after the request resumes is fresh and must be kept.
-            if seq.id in prev_partial_ids:
+            # Deferred output normally makes the token surfaced by a final
+            # chunk belong to the preceding middle chunk, so it must be
+            # dropped.  The max_tokens=1 terminal fast path is explicitly
+            # synchronous: its token was sampled by *this* final chunk and is
+            # therefore the first real completion token, even when the request
+            # was partial before this postprocess call.
+            if seq.id in prev_partial_ids and not is_current_terminal_output:
                 continue
             # Register prefix-cache hashes for blocks the prefill step just
             # finalized. Deferred from BlockManager.allocate() so a hash is
@@ -2072,7 +2117,7 @@ class Scheduler:
             if token_logprobs is not None and seq.return_logprobs:
                 token_logprob = token_logprobs.get(seq.id)
 
-            if is_deferred_out or self.use_spec:
+            if pipelined_output:
                 # int() casts strip the np.int32 wrapper coming out of
                 # fwd_output's np.ndarray indexing. Without these, the values
                 # propagate into seq.num_rejected / seq.num_bonus_tokens, then
@@ -2136,7 +2181,7 @@ class Scheduler:
                 new_tokens = [injected_t0] + list(new_tokens)
                 seq._injected_t0 = None
 
-            if self.mtp_k > 0:
+            if self.mtp_k > 0 and not is_current_terminal_output:
                 # idx already resolved above via get_idx
                 seq.spec_token_ids = draft_token_ids[idx]
 
@@ -2153,7 +2198,9 @@ class Scheduler:
             if seq.num_completion_tokens >= 1 and seq.first_token_time == 0.0:
                 seq.first_token_time = time.time()
 
-            num_tokens = seq.num_tokens - self.mtp_k - num_rejected
+            num_tokens = seq.num_tokens
+            if pipelined_output:
+                num_tokens -= self.mtp_k + num_rejected
             leave_reason = None
             # Client disconnected -> finish now via the normal stop path (frees
             # KV blocks, emits a finished RequestOutput). A natural stop below
@@ -2210,6 +2257,19 @@ class Scheduler:
                     # `output tokens=95` for max_tokens=100, mtp_k=3). Non-MTP
                     # path: mtp_k = num_rejected = 0 → behavior unchanged.
                     leave_reason = "max_tokens"
+                    # A speculative verify can commit up to mtp_k+1 tokens in
+                    # one step.  Detecting the limit after that commit is
+                    # correct for scheduling, but the last accepted block may
+                    # extend past the caller's exact max_tokens budget.  Trim
+                    # that tail just like the EOS/stop paths below trim tokens
+                    # after their first stop position.
+                    overflow = (
+                        num_tokens - seq.num_prompt_tokens - seq.max_tokens
+                    )
+                    if overflow > 0:
+                        # overflow is bounded by this step's accepted tokens:
+                        # the previous step had not reached max_tokens yet.
+                        stop_at_idx = max(-1, num_new_token - overflow - 1)
 
             # Drop accepted-draft tokens past the stop position (MTP only —
             # for non-spec the sampler emits exactly 1 token so this is a
@@ -2241,7 +2301,8 @@ class Scheduler:
             # slot is written by the next one.
             self.block_manager.hash_decode_blocks(
                 seq,
-                num_tokens - (0 if is_deferred_out else 1),
+                num_tokens
+                - (0 if is_deferred_out and not is_current_terminal_output else 1),
                 next_forward_tokens=self._checkpoint_room(
                     seq, leave_reason is not None
                 ),

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -64,6 +64,26 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_USE_TRITON_MOE": lambda: os.getenv("ATOM_USE_TRITON_MOE", "0") == "1",
     "ATOM_USE_TRITON_MOE_DECODE": lambda: os.getenv("ATOM_USE_TRITON_MOE_DECODE", "0")
     == "1",
+    # Experimental only: publish plain-MTP target/verify results before the
+    # next draft extension. DSV4 c4/c8/c16 A/B is workload-equivalent after
+    # retaining async-D2H source tensors, but keep this off by default until a
+    # full eval covers model/backend combinations beyond the validated path.
+    "ATOM_DEFER_MTP_PROPOSAL": lambda: (
+        os.getenv("ATOM_DEFER_MTP_PROPOSAL", "0") == "1"
+    ),
+    # Experimental companion to deferred proposal: once the scheduler proves
+    # every sequence in the just-run batch is terminal, drain the unconsumed
+    # lookahead generation instead of extending it with another draft.
+    "ATOM_CANCEL_TERMINAL_MTP_PROPOSAL": lambda: (
+        os.getenv("ATOM_CANCEL_TERMINAL_MTP_PROPOSAL", "0") == "1"
+    ),
+    # Safe narrow optimization: a pure final-prefill batch where every request
+    # has max_tokens=1 can publish the sampled token directly and skip a draft
+    # generation that no request can consume.  Checkpoint-producing batches
+    # remain excluded by ModelRunner's follow-up-state guard.
+    "ATOM_TERMINAL_MTP_FAST_PATH": lambda: (
+        os.getenv("ATOM_TERMINAL_MTP_FAST_PATH", "1") == "1"
+    ),
     "ATOM_MLA_PAGE_SIZE": lambda: int(os.getenv("ATOM_MLA_PAGE_SIZE", "1")),
     # --- Kernel Fusion Toggles ---
     # fused_compress_attn: switch between Triton (default historical) and a

--- a/tests/test_mtp_deferred_publish.py
+++ b/tests/test_mtp_deferred_publish.py
@@ -1,0 +1,300 @@
+import queue
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+import pytest
+from conftest import MockConfig
+
+pytest.importorskip("aiter", reason="requires AITER to import model_runner")
+
+from atom.model_engine.engine_core import EngineCore
+from atom.model_engine.model_runner import ModelRunner, tokenIDProcessor
+from atom.model_engine.scheduler import ScheduledBatchOutput, Scheduler
+from atom.model_engine.sequence import Sequence, SequenceStatus
+from atom.sampling_params import SamplingParams
+from atom.utils import envs
+
+
+def test_split_draft_dequeue_and_store_keep_generations_separate():
+    processor = object.__new__(tokenIDProcessor)
+    processor.is_deferred_out = True
+    processor.prev_req_ids = [11, 12]
+    previous = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
+    processor.recv_async_output_draft = mock.Mock(return_value=previous)
+    processor.send_to_cpu_async_draft = mock.Mock()
+    processor.num_spec_tokens = 3
+
+    np.testing.assert_array_equal(processor.take_previous_draft_ids(), previous)
+
+    current = object()
+    processor.store_draft_ids(current)
+    assert processor.draft_token_ids is current
+    assert processor.pre_num_decode_token_per_seq == 4
+    processor.send_to_cpu_async_draft.assert_called_once_with(current)
+
+
+def test_terminal_cancel_drains_current_deferred_generation():
+    processor = object.__new__(tokenIDProcessor)
+    processor.token_ids_cpu = [object()]
+    processor.draft_token_ids_cpu = []
+    processor.recv_async_output = mock.Mock(return_value=object())
+    processor.recv_logprobs = mock.Mock(return_value=None)
+    processor.recv_mtp_status_async = mock.Mock(return_value=(None, None))
+    processor.prev_batch = object()
+    processor.prev_req_ids = [7]
+    processor.prev_token_ids = object()
+    processor.pre_num_decode_token_per_seq = 4
+    processor.draft_token_ids = object()
+    processor.prev_rejected_num = np.array([0])
+    processor.prev_bonus_num = np.array([0])
+    processor.num_rejected = np.array([0])
+    processor.num_bonus = np.array([0])
+
+    processor.discard_current_deferred_generation()
+
+    processor.recv_async_output.assert_called_once_with(processor.token_ids_cpu)
+    processor.recv_logprobs.assert_called_once_with()
+    processor.recv_mtp_status_async.assert_called_once_with()
+    assert processor.prev_batch is None
+    assert processor.prev_req_ids is None
+    assert processor.prev_token_ids is None
+    assert processor.pre_num_decode_token_per_seq == 1
+    assert processor.draft_token_ids is None
+
+
+@pytest.mark.parametrize(
+    "status_after_postprocess",
+    [
+        SequenceStatus.RUNNING,
+        SequenceStatus.FINISHED,
+    ],
+)
+def test_engine_publishes_output_before_finishing_or_cancelling_draft(
+    status_after_postprocess,
+):
+    events = []
+    seq = SimpleNamespace(status=SequenceStatus.RUNNING)
+    batch = SimpleNamespace(req_ids=[1], connector_meta_output=None)
+    fwd_out = ScheduledBatchOutput(
+        req_ids=[1],
+        token_ids=[(99,)],
+        num_rejected=np.array([0], dtype=np.int32),
+        num_bonus=np.array([0], dtype=np.int32),
+        draft_token_ids=np.array([[1, 2, 3]], dtype=np.int32),
+        is_deferred_out=True,
+        draft_proposal_pending=True,
+    )
+
+    class RecordingQueue:
+        def put_nowait(self, value):
+            events.append(("output", value))
+
+    def postprocess(*args, **kwargs):
+        seq.status = status_after_postprocess
+        kwargs["stream_output_queue"].put_nowait([(1, "token")])
+        return [seq] if status_after_postprocess == SequenceStatus.FINISHED else []
+
+    core = EngineCore.__new__(EngineCore)
+    core.label = "test"
+    core.kv_transfer_enabled = False
+    core.scheduler = SimpleNamespace(
+        schedule=lambda: (batch, {1: seq}),
+        take_rejected=list,
+        compute_detailed_aggregates=lambda *args: None,
+        postprocess=postprocess,
+    )
+
+    def call_func(name, *args, **kwargs):
+        events.append(("runner", name))
+        if name == "forward":
+            return fwd_out
+        return None
+
+    core.runner_mgr = SimpleNamespace(call_func=call_func)
+    core._poll_kv_transfer_progress = lambda: None
+    core.stream_output_queue = queue.Queue()
+    core.output_queue = RecordingQueue()
+
+    with mock.patch.object(envs, "ATOM_CANCEL_TERMINAL_MTP_PROPOSAL", True):
+        assert core._process_engine_step_inner() is True
+
+    expected_resolution = (
+        "cancel_draft_proposal"
+        if status_after_postprocess == SequenceStatus.FINISHED
+        else "finish_draft_proposal"
+    )
+    resolution_idx = events.index(("runner", expected_resolution))
+    output_indices = [i for i, event in enumerate(events) if event[0] == "output"]
+    assert output_indices
+    assert max(output_indices) < resolution_idx
+
+
+def test_output_flag_defaults_to_synchronous():
+    output = ScheduledBatchOutput([], [], None, None, None)
+    assert output.draft_proposal_pending is False
+
+
+def test_current_terminal_prefill_appends_token_without_spec_placeholders():
+    spec_config = SimpleNamespace(
+        num_speculative_tokens=3,
+        use_dspark=lambda: False,
+    )
+    scheduler = Scheduler(
+        MockConfig(
+            speculative_config=spec_config,
+            num_kvcache_blocks=20,
+            max_model_len=64,
+        )
+    )
+    seq = Sequence(
+        [10, 11, 12, 13],
+        block_size=4,
+        sampling_params=SamplingParams(max_tokens=1, ignore_eos=True),
+    )
+    scheduler.add(seq)
+    batch, scheduled = scheduler.schedule()
+
+    assert batch.all_max_tokens_one is True
+    finished = scheduler.postprocess(
+        list(scheduled.values()),
+        ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[(99,)],
+            num_rejected=np.array([0], dtype=np.int32),
+            num_bonus=np.array([0], dtype=np.int32),
+            draft_token_ids=None,
+            is_deferred_out=True,
+            is_current_terminal_output=True,
+        ),
+        batch=batch,
+    )
+
+    assert finished == [seq]
+    assert seq.status == SequenceStatus.FINISHED
+    assert seq.leave_reason == "max_tokens"
+    assert seq.token_ids == [10, 11, 12, 13, 99]
+    assert seq.output_tokens == [99]
+    assert seq.spec_token_ids.size == 0
+    assert not scheduler.running
+
+
+def test_current_terminal_prefill_after_middle_chunk_keeps_current_token():
+    spec_config = SimpleNamespace(
+        num_speculative_tokens=3,
+        use_dspark=lambda: False,
+    )
+    scheduler = Scheduler(
+        MockConfig(
+            speculative_config=spec_config,
+            num_kvcache_blocks=20,
+            max_model_len=64,
+            max_num_batched_tokens=4,
+        )
+    )
+    seq = Sequence(
+        [10, 11, 12, 13, 14, 15, 16, 17],
+        block_size=4,
+        sampling_params=SamplingParams(max_tokens=1, ignore_eos=True),
+    )
+    scheduler.add(seq)
+
+    middle_batch, middle_scheduled = scheduler.schedule()
+    assert middle_batch.is_final_chunk == [False]
+    assert scheduler.postprocess(
+        list(middle_scheduled.values()),
+        ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[],
+            num_rejected=None,
+            num_bonus=None,
+            draft_token_ids=None,
+        ),
+        batch=middle_batch,
+    ) == []
+    assert seq.is_partial_prefill
+    assert seq.output_tokens == []
+
+    final_batch, final_scheduled = scheduler.schedule()
+    assert final_batch.is_final_chunk == [True]
+    finished = scheduler.postprocess(
+        list(final_scheduled.values()),
+        ScheduledBatchOutput(
+            req_ids=[seq.id],
+            token_ids=[(99,)],
+            num_rejected=np.array([0], dtype=np.int32),
+            num_bonus=np.array([0], dtype=np.int32),
+            draft_token_ids=None,
+            is_deferred_out=True,
+            is_current_terminal_output=True,
+        ),
+        batch=final_batch,
+    )
+
+    assert finished == [seq]
+    assert seq.status == SequenceStatus.FINISHED
+    assert seq.leave_reason == "max_tokens"
+    assert seq.token_ids == [10, 11, 12, 13, 14, 15, 16, 17, 99]
+    assert seq.output_tokens == [99]
+    assert seq.spec_token_ids.size == 0
+    assert not scheduler.running
+
+
+def test_current_terminal_fast_path_rejects_mixed_or_deferred_batches():
+    runner = object.__new__(ModelRunner)
+    runner.tokenID_processor = SimpleNamespace(
+        is_deferred_out=True,
+        prev_batch=None,
+    )
+    pure_final = SimpleNamespace(
+        all_max_tokens_one=True,
+        total_seqs_num=2,
+        total_seqs_num_prefill=2,
+        total_seqs_num_decode=0,
+        is_final_chunk=[True, True],
+        requires_followup_state_checkpoint=False,
+    )
+    assert runner._can_publish_current_terminal(pure_final)
+
+    checkpoint_boundary = SimpleNamespace(**vars(pure_final))
+    checkpoint_boundary.requires_followup_state_checkpoint = True
+    assert not runner._can_publish_current_terminal(checkpoint_boundary)
+
+    mixed = SimpleNamespace(**vars(pure_final))
+    mixed.total_seqs_num_prefill = 1
+    mixed.total_seqs_num_decode = 1
+    assert not runner._can_publish_current_terminal(mixed)
+
+    middle_chunk = SimpleNamespace(**vars(pure_final))
+    middle_chunk.is_final_chunk = [True, False]
+    assert not runner._can_publish_current_terminal(middle_chunk)
+
+    runner.tokenID_processor.prev_batch = object()
+    assert not runner._can_publish_current_terminal(pure_final)
+
+
+def test_deferred_proposal_is_limited_to_plain_mtp():
+    runner = object.__new__(ModelRunner)
+    runner.config = SimpleNamespace(
+        eplb_enable=False,
+        speculative_config=SimpleNamespace(method="mtp"),
+    )
+    runner.tokenID_processor = SimpleNamespace(is_deferred_out=True)
+    runner.drafter = SimpleNamespace(verify_scheduler=None)
+    batch = SimpleNamespace(is_dummy_run=False)
+
+    with mock.patch.object(envs, "ATOM_DEFER_MTP_PROPOSAL", True):
+        assert runner._can_defer_draft_proposal(batch)
+
+        runner.config.speculative_config.method = "eagle3"
+        assert not runner._can_defer_draft_proposal(batch)
+
+        runner.config.speculative_config.method = "mtp"
+        runner.drafter.verify_scheduler = object()
+        assert not runner._can_defer_draft_proposal(batch)
+
+
+def test_ordinary_deferred_proposal_is_experimental_and_off_by_default():
+    assert not envs.ATOM_DEFER_MTP_PROPOSAL
+    assert not envs.ATOM_CANCEL_TERMINAL_MTP_PROPOSAL
+    assert envs.ATOM_TERMINAL_MTP_FAST_PATH

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -944,6 +944,54 @@ class TestPostprocess:
         assert len(finished) == 1
         assert finished[0].leave_reason == "max_tokens"
 
+    def test_mtp_max_tokens_trims_accepted_block_overshoot(self, seq_factory):
+        spec_config = SimpleNamespace(
+            num_speculative_tokens=3,
+            use_dspark=lambda: False,
+        )
+        scheduler = Scheduler(
+            MockConfig(
+                speculative_config=spec_config,
+                num_kvcache_blocks=100,
+                max_model_len=128,
+            )
+        )
+        seq = seq_factory(
+            [1, 2, 3, 4],
+            sampling_params=SamplingParams(max_tokens=4, ignore_eos=True),
+        )
+        scheduler.add(seq)
+        scheduler.schedule()
+
+        # Three committed tokens followed by seven speculative/deferred
+        # placeholders.  This verify accepts [20, 21, 22], which would commit
+        # six tokens total and overshoot max_tokens=4 by two.
+        for token_id in [10, 11, 12] + [scheduler.eos_token_id] * 7:
+            seq.append_token(token_id)
+        seq.prefix_hashes_published = True
+        scheduler.block_manager.hash_decode_blocks = mock.Mock()
+
+        stream_output_queue = mock.Mock()
+        finished = scheduler.postprocess(
+            [seq],
+            ScheduledBatchOutput(
+                req_ids=[seq.id],
+                token_ids=[(20, 21, 22)],
+                num_rejected=np.array([1], dtype=np.int32),
+                num_bonus=np.array([2], dtype=np.int32),
+                draft_token_ids=np.array([[30, 31, 32]], dtype=np.int32),
+                is_deferred_out=True,
+            ),
+            stream_output_queue=stream_output_queue,
+        )
+
+        assert finished == [seq]
+        assert seq.leave_reason == "max_tokens"
+        assert seq.num_completion_tokens == 4
+        assert seq.completion_token_ids == [10, 11, 12, 20]
+        stream_outputs = stream_output_queue.put_nowait.call_args.args[0]
+        assert stream_outputs[0][1].output_tokens == [20]
+
     def test_stop_token_ids(self, seq_factory):
         sched = Scheduler(MockConfig(stop_token_ids=[99]))
         seq = seq_factory([1, 2, 3, 4])


### PR DESCRIPTION
## Summary
- publish plain-MTP target and verify output before extending the next draft proposal
- resolve the deferred proposal through FIFO finish or cancellation RPCs
- keep asynchronous D2H source tensors alive until copy completion
- add a guarded terminal max_tokens=1 fast path and trim speculative max-token overshoot
- split this performance work out of #1880

## Configuration
- ATOM_DEFER_MTP_PROPOSAL defaults to disabled
- ATOM_CANCEL_TERMINAL_MTP_PROPOSAL defaults to disabled
- ATOM_TERMINAL_MTP_FAST_PATH defaults to enabled for the narrow guarded path

## Validation
- Python syntax compilation passed for all changed files
- git diff --check passed
- pytest was not available in the current host environment; focused regression tests are included in tests/test_mtp_deferred_publish.py and tests/test_scheduler.py