### PR TITLE
[Opt] Optimize MLA prefill chunk

### DIFF
--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1189,7 +1189,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             elif (
                 self.attn_prefill_chunk_size > 0
                 and attn_metadata.has_cached
-                and attn_metadata.total_kv > self.attn_prefill_chunk_size
+                and sum(batch.num_cached_tokens[:bs]) > self.attn_prefill_chunk_size
             ):
                 attn_metadata.mla_chunk_meta = self._build_mla_chunk_meta(batch, bs)
 

--- a/atom/model_ops/attentions/triton_merge_attn_states.py
+++ b/atom/model_ops/attentions/triton_merge_attn_states.py
@@ -37,6 +37,10 @@ def merge_attn_states(
         prefill_tokens_with_context = num_tokens
 
     # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
+    # num_warps=1: one program owns a single [HEAD_SIZE] row, so the default
+    # num_warps=4 spreads 128 elements over 256 lanes -- half idle, 2 B each.
+    # aiter hit the same shape in its stage-2 MLA merge and measured 1.7-1.9x
+    # from num_warps=1 on gfx950 (op_tests/test_mla_stage2_merge.py header).
     merge_attn_states_kernel[(num_tokens, num_query_heads)](
         output,
         output_lse,
@@ -52,6 +56,7 @@ def merge_attn_states(
         output_lse is not None,
         prefill_tokens_with_context,
         output_scale is not None,
+        num_warps=1,
     )
 
 


### PR DESCRIPTION
## Motivation

In a DeepSeek-R1 prefill profile (MNBT=16384, MI355X, TP8/DP8/EP8, MXFP4), attention takes **3586.62 us/layer — 12.59% of layer time** across four kernels, of which the softmax-LSE merge alone is **1325.93 us**. Two causes are one-line fixes:

1. **The chunked-prefill path is gated on the wrong quantity.** `_build_mla_chunk_meta` triggers on `total_kv` (cached prefix **+ new tokens**), but it only chunks the **cached prefix** — the new-token side is already bounded by `max_num_batched_tokens`. Batches whose prefix fits the workspace still pay an extra non-causal FMHA plus a softmax-LSE merge where one causal pass would do. **−48.7% attention time**, `peak_torch` unchanged.

2. **`merge_attn_states_kernel` is launched without `num_warps`.** Triton defaults to 4: 256 lanes for a 128-element row, half idle, 2 B per live lane. aiter ships `num_warps=1` for the identical shape after measuring 1.7–1.9x on gfx950 (`op_tests/test_mla_stage2_merge.py`). **−52.8%** on that kernel.

(1) makes the chunked path fire less often, (2) makes it cheaper when it does. Splittable on request.


## Test

The path needs `has_cached=True` **and** a prefix crossing `attn_prefill_chunk_size`. Equal-length offline inputs never produce a partial prefill, so make MNBT a non-multiple of ISL: `MNBT=16000, ISL=1024` packs 15 whole seqs and splits the 16th at 640, which returns next step as a 640-token prefix — `total_kv≈16640 > 16384` (old trigger fires) but `prefix 640 < 16384` (new one does not).

MI355X x8 (gfx950), DeepSeek-R1-0528-MXFP4-v2, TP1 x DP8 x EP8, eager.

**Change 1** — window `bs=17 tok=16000` (prefix 640), attention us/layer over 61 layers:

| | Before | After |
|---|---|---|
| **Attention us/layer** | **3416.77** | **1752.62 (−48.7%)** |

Attention share of prefill GPU **6.62% → 4.55%**; trigger count **8 → 0**; `peak_torch` **70.40 GB both sides**; two control windows moved +0.4% / +0.7%. Not simply "two fewer kernels" — single-pass gathers the whole context vs only the prefix, costing back ~728 of the ~1944 us/layer saved.

**Change 2** — both sides run the chunked path identically (8 triggers, `total_kv=17425`):

| Rank | Before (us) | `num_warps=1` (us) | Ratio |
|------|-------------|--------------------|-------|
| dp0 / dp1 / dp4 / dp7 | 4737.62 / 4492.14 / 4613.10 / 4505.14 | 2205.22 / 2236.10 / 2112.78 / 2098.38 | 2.15 / 2.01 / 2.18 / 2.15x |
| **Mean** | **4587.00** | **2163.12** | **2.12x (−52.8%)** |

## Submission Checklist
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.