### PR TITLE
feat(spec-decode): take the forced-acceptance target as a length, on the schedule the other engines use

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -992,12 +992,24 @@ class SpeculativeConfig:
     draft_model_hf_config: PretrainedConfig | None = None
     use_aux_hidden_state: bool = False
     eagle3_aux_layer_ids: list[int] = field(default_factory=list)
-    # Debug/benchmark knob: when set (float in [0, 1]), the rejection sampler
-    # force-accepts draft tokens with a position-decaying probability calibrated
-    # so the measured mean acceptance rate matches this value, independent of the
-    # real draft/target agreement. Mirrors vLLM's synthetic_acceptance_rate. See
-    # ROCm/ATOM#555.
+    # Debug/benchmark knobs: force a speculative acceptance curve independent of
+    # the real draft/target agreement, so a run can replay a published
+    # acceptance-length figure (an InferenceX golden AL, say) while the draft head
+    # is still training. Set at most one; both resolve into
+    # `synthetic_acceptance_rates`. See ROCm/ATOM#555.
+    #
+    # Mean acceptance length in [1, num_speculative_tokens + 1], counting the
+    # target's own guaranteed token -- the same unit as vLLM's
+    # synthetic_acceptance_length and SGLang's SGLANG_SIMULATE_ACC_LEN, so a
+    # published AL can be pasted in without conversion.
+    synthetic_acceptance_length: float | None = None
+    # The same target expressed as a mean acceptance RATE in [0, 1]
+    # (accepted_draft / total_draft), i.e. (length - 1) / num_speculative_tokens.
     synthetic_acceptance_rate: float | None = None
+    # Resolved per-position *unconditional* acceptance rates (entry i = marginal
+    # probability that the first i+1 draft tokens are all accepted), filled in by
+    # __post_init__. None => real draft/target rejection sampling.
+    synthetic_acceptance_rates: list[float] | None = None
 
     # model_type → mtp_model_type mapping
     _MTP_TYPE_MAP: ClassVar[dict[str, str]] = {
@@ -1059,14 +1071,63 @@ class SpeculativeConfig:
         cfg = self.draft_model_hf_config
         return bool(getattr(cfg, "dspark_with_draft", False))
 
-    def __post_init__(self):
-        if self.synthetic_acceptance_rate is not None and not (
-            0.0 <= self.synthetic_acceptance_rate <= 1.0
+    def _resolve_synthetic_acceptance(self) -> None:
+        """Validate the forced-acceptance knobs and resolve to per-position rates.
+
+        Both knobs describe the same curve, so exactly one may be set; the rate
+        form is converted to a length and everything downstream reads only
+        ``synthetic_acceptance_rates``.
+        """
+        # Local import: the schedule lives next to the kernel that consumes it,
+        # and that module pulls in triton, which has no business loading just
+        # because someone imported a config.
+        from atom.model_ops.rejection_sampler import acceptance_length_to_rates
+
+        if (
+            self.synthetic_acceptance_length is not None
+            and self.synthetic_acceptance_rate is not None
         ):
             raise ValueError(
-                "synthetic_acceptance_rate (--spec-decode-acceptance-rate) must "
-                f"be in [0, 1], but got {self.synthetic_acceptance_rate}."
+                "--spec-decode-acceptance-length and --spec-decode-acceptance-rate "
+                "describe the same curve; set at most one."
             )
+        length = self.synthetic_acceptance_length
+        if self.synthetic_acceptance_rate is None and length is None:
+            return
+
+        n = self.num_speculative_tokens
+        if not n:
+            raise ValueError(
+                "Forced speculative acceptance needs --num-speculative-tokens, "
+                f"but it is {n!r}."
+            )
+        if self.synthetic_acceptance_rate is not None:
+            rate = self.synthetic_acceptance_rate
+            if not 0.0 <= rate <= 1.0:
+                raise ValueError(
+                    "synthetic_acceptance_rate (--spec-decode-acceptance-rate) "
+                    f"must be in [0, 1], but got {rate}."
+                )
+            length = 1.0 + n * rate
+        if not 1.0 <= length <= float(n + 1):
+            raise ValueError(
+                "synthetic_acceptance_length (--spec-decode-acceptance-length) "
+                f"must be in [1, {n + 1}] for num_speculative_tokens={n}, but got "
+                f"{length}."
+            )
+        self.synthetic_acceptance_length = length
+        self.synthetic_acceptance_rates = acceptance_length_to_rates(length, n)
+        logger.info(
+            "Forced speculative acceptance ON: mean acceptance length %.4f over "
+            "%d draft positions (per-position rates %s). Throughput numbers from "
+            "this run are synthetic; output text and accuracy are meaningless.",
+            length,
+            n,
+            [round(r, 4) for r in self.synthetic_acceptance_rates],
+        )
+
+    def __post_init__(self):
+        self._resolve_synthetic_acceptance()
         if self.draft_model_hf_config is None:
             self.draft_model_hf_config = get_hf_config(
                 self.model, trust_remote_code=True
@@ -1461,6 +1522,32 @@ class Config:
         else:
             raise TypeError("eplb_config must be EPLBConfig or dict")
         # assert os.path.isdir(self.model)
+
+        # The forced-acceptance schedule spends its whole budget on the first
+        # ceil(length - 1) positions, and the sampler can only accept what was
+        # actually drafted. The DSpark confidence scheduler hands each request
+        # its own verify length ell_r, so whenever ell_r falls below that many
+        # positions the run quietly lands under the acceptance length it was
+        # asked to reproduce (measured at length 3.78 over 7 positions: exact
+        # while ell_r >= 3, 3.39 at ell_r = 2, 2.89 at ell_r = 1). ell_r is
+        # chosen at runtime from the confidence head, so there is no upfront
+        # check that would catch it -- and a benchmark reporting a number it
+        # never hit is worse than one that refuses to start.
+        if (
+            self.speculative_config is not None
+            and self.speculative_config.synthetic_acceptance_rates is not None
+            and self.dspark.confidence_schedule
+        ):
+            raise ValueError(
+                "Forced speculative acceptance (--spec-decode-acceptance-length "
+                "/ --spec-decode-acceptance-rate) cannot be combined with the "
+                "DSpark confidence scheduler (--dspark-config "
+                "'{\"confidence_schedule\": true}'): it sizes each request's "
+                "verify length at runtime, and a short one caps acceptance below "
+                "the requested length with no way to detect it upfront. Drop "
+                "confidence_schedule (and ragged, which needs it) for "
+                "forced-acceptance runs."
+            )
 
         # RapidServe (intra-GPU prefill/decode disagg) needs a specialized
         # runner in both the prefill and decode processes. Select it unless the

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -71,6 +71,7 @@ class EngineArgs:
     kv_transfer_config: str = "{}"
     draft_model: str | None = None
     spec_decode_acceptance_rate: float | None = None
+    spec_decode_acceptance_length: float | None = None
     mark_trace: bool = False
     enable_rapidserve: bool = False
     disagg_prefill_max_num_seqs: int | None = None
@@ -297,17 +298,27 @@ class EngineArgs:
             "V4-Pro-DSpark which ships inside the target checkpoint).",
         )
         parser.add_argument(
+            "--spec-decode-acceptance-length",
+            type=float,
+            default=None,
+            help="Debug/benchmark knob: force a fixed speculative-decoding mean "
+            "acceptance length (AL) in [1, num_speculative_tokens + 1]. When "
+            "set, the rejection sampler ignores the real draft/target agreement "
+            "and force-accepts draft tokens so the measured accept length "
+            "converges to this value. AL counts the target's own guaranteed "
+            "token, so it is the same unit as vLLM's synthetic_acceptance_length "
+            "and SGLang's SGLANG_SIMULATE_ACC_LEN and a published golden AL can "
+            "be passed through unchanged. Only meaningful with a speculative "
+            "method; leave unset to disable.",
+        )
+        parser.add_argument(
             "--spec-decode-acceptance-rate",
             type=float,
             default=None,
-            help="Debug/benchmark knob: force a fixed speculative-decoding "
-            "acceptance rate in [0, 1]. When set, the rejection sampler ignores "
-            "the real draft/target agreement and force-accepts each draft token "
-            "with a position-decaying probability calibrated so the measured "
-            "mean acceptance rate (accepted_draft/total_draft) matches this "
-            "value (equivalent accept length = 1 + num_speculative_tokens * "
-            "rate). Mirrors vLLM's 'synthetic' rejection_sample_method. Only "
-            "meaningful with a speculative method; leave unset to disable.",
+            help="The same knob as --spec-decode-acceptance-length, expressed as "
+            "a mean acceptance rate in [0, 1] (accepted_draft/total_draft), i.e. "
+            "(length - 1) / num_speculative_tokens. Mutually exclusive with "
+            "--spec-decode-acceptance-length.",
         )
         parser.add_argument(
             "--max-num-batched-tokens",
@@ -541,6 +552,7 @@ class EngineArgs:
             num_spec_tokens = kwargs.pop("num_speculative_tokens")
             draft_model = kwargs.pop("draft_model")
             synthetic_acceptance_rate = kwargs.pop("spec_decode_acceptance_rate")
+            synthetic_acceptance_length = kwargs.pop("spec_decode_acceptance_length")
             if method == "eagle3" and not draft_model:
                 raise ValueError("--draft-model is required when --method eagle3.")
             if draft_model and method == "mtp":
@@ -553,12 +565,14 @@ class EngineArgs:
                 model=draft_model or self.model,
                 num_speculative_tokens=num_spec_tokens,
                 synthetic_acceptance_rate=synthetic_acceptance_rate,
+                synthetic_acceptance_length=synthetic_acceptance_length,
             )
         else:
             kwargs.pop("method")
             kwargs.pop("num_speculative_tokens")
             kwargs.pop("draft_model")
             kwargs.pop("spec_decode_acceptance_rate")
+            kwargs.pop("spec_decode_acceptance_length")
             kwargs["speculative_config"] = None
 
         # --enable-tbo [prefill|all] → enable_tbo + enable_tbo_decode

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -720,8 +720,8 @@ class ModelRunner:
             with set_model_tag("drafter"):
                 self.drafter = build_drafter(self.config, self.device, self)
             self.rejection_sampler = RejectionSampler(
-                synthetic_acceptance_rate=(
-                    self.config.speculative_config.synthetic_acceptance_rate
+                synthetic_acceptance_rates=(
+                    self.config.speculative_config.synthetic_acceptance_rates
                 )
             )
             torch.set_default_device(None)

--- a/atom/model_ops/rejection_sampler.py
+++ b/atom/model_ops/rejection_sampler.py
@@ -15,22 +15,20 @@ else:
     RELAXED_TOP_N = 1
     RELAXED_DELTA = 0.0
 
-# --- Synthetic (forced) acceptance rate for spec-decode debugging ---
-# Enabled via --spec-decode-acceptance-rate (SpeculativeConfig.synthetic_
-# acceptance_rate). When set (float in [0, 1]), the rejection sampler ignores the
-# real draft/target comparison and force-accepts each draft token with a
-# position-dependent probability calibrated so the measured mean acceptance rate
-# converges to the configured value. Purely a benchmarking / bring-up knob (e.g.
-# while an MTP/EAGLE head is still training). Mirrors vLLM's "synthetic"
+# --- Synthetic (forced) acceptance for spec-decode benchmarking ---
+# Enabled via --spec-decode-acceptance-length / --spec-decode-acceptance-rate
+# (SpeculativeConfig.synthetic_acceptance_rates, already resolved to per-position
+# rates by the config). When set, the rejection sampler ignores the real
+# draft/target comparison and force-accepts draft tokens so the measured mean
+# acceptance length converges to the configured value. Purely a benchmarking /
+# bring-up knob (e.g. while an MTP/EAGLE head is still training, or to replay a
+# published acceptance-length curve). Mirrors vLLM's "synthetic"
 # rejection_sample_method. See ROCm/ATOM#555.
 #
-# Lowest per-position conditional-acceptance decay (empirically ~what a
-# well-tuned draft model exhibits); bounds the search so the base rate stays
-# <= 1 while still reaching the requested mean. Matches vLLM's constant.
-MIN_ACCEPTANCE_DECAY_FACTOR = 0.85
-# Cache {(rate, num_spec_steps): (base_rate, decay_factor)} — params depend on
-# both the target rate and the runtime step count.
-_SYNTHETIC_PARAMS_CACHE: dict[tuple[float, int], tuple[float, float]] = {}
+# Cache {(rates, device): conditional-rate tensor} — the kernel walks positions
+# sequentially, so it needs P(accept i | accepted through i-1) rather than the
+# unconditional rates the config carries.
+_SYNTHETIC_COND_CACHE: dict[tuple[tuple[float, ...], torch.device], torch.Tensor] = {}
 # Base seed for the per-step synthetic RNG. The forced accept/reject draw MUST be
 # identical on every TP rank: sampled_tokens is broadcast from rank 0 while
 # num_bonus_tokens stays local, so a per-rank torch.rand would desync the two and
@@ -51,80 +49,64 @@ def _synthetic_generator(device: torch.device) -> torch.Generator:
     return generator
 
 
-def compute_synthetic_rejection_sampler_params(
-    p_avg: float, n: int, tol: float = 1e-9
-) -> tuple[float, float]:
-    """Derive (base_acceptance_rate, decay_factor) for a target mean rate.
+def acceptance_length_to_rates(length: float, n: int) -> list[float]:
+    """Mean acceptance length -> per-position *unconditional* acceptance rates.
 
-    With ``n`` speculative positions the conditional acceptance probability at
-    position ``i`` is ``base_rate * decay_factor**i``. The joint probability of
-    accepting through position ``i`` is therefore
-    ``base_rate**(i+1) * decay_factor**(i*(i+1)/2)`` and the mean of those joint
-    probabilities across the ``n`` positions equals ``p_avg`` (== ATOM's
-    ``accepted_draft_tokens / total_draft_tokens`` acceptance rate).
+    Entry ``i`` is the marginal probability that the first ``i+1`` draft tokens
+    are all accepted, so the mean number of accepted draft tokens is the sum of
+    the list and the mean acceptance length is ``1 + sum`` (the ``1`` being the
+    target's own guaranteed token).
+
+    The schedule is the minimum-variance one: accept ``floor(length - 1)``
+    positions outright and the next with the leftover fraction. Any schedule
+    summing to ``length - 1`` hits the requested mean, but the spread differs
+    wildly between them, and spread is not a free parameter here -- it drives
+    ITL tails and how the batch drains. This is the schedule vLLM resolves
+    ``synthetic_acceptance_length`` to and the one SGLang's ``match-expected``
+    draws, so a forced-length run stays comparable across all three engines.
     """
-
-    def mean_joint_prob(a_0: float, gamma: float, n: int) -> float:
-        total = 0.0
-        for i in range(n):
-            total += a_0 ** (i + 1) * gamma ** (i * (i + 1) // 2)
-        return total / n
-
-    def min_valid_decay_factor(p: float, n: int) -> float:
-        low, high = MIN_ACCEPTANCE_DECAY_FACTOR, 1.0
-        # Even with a base rate of 1, a large decay is required for big p; find
-        # the smallest decay that can still reach p so base_rate stays <= 1.
-        if mean_joint_prob(1.0, low, n) >= p:
-            return low
-        while (high - low) > tol:
-            mid = (low + high) / 2
-            if mean_joint_prob(1.0, mid, n) >= p:
-                high = mid
-            else:
-                low = mid
-        return high
-
-    def compute_base_acceptance_rate(p_avg: float, gamma: float, n: int) -> float:
-        if p_avg <= 0.0:
-            return 0.0
-        if p_avg >= 1.0:
-            return 1.0
-        low, high = 0.0, 1.0
-        while (high - low) > tol:
-            mid = (low + high) / 2
-            if mean_joint_prob(mid, gamma, n) >= p_avg:
-                high = mid
-            else:
-                low = mid
-        return high
-
-    decay_factor = min_valid_decay_factor(p_avg, n)
-    base_rate = compute_base_acceptance_rate(p_avg, decay_factor, n)
-    return base_rate, decay_factor
+    num_accepted_drafts = length - 1
+    num_full = int(num_accepted_drafts)
+    return (
+        [1.0] * num_full + [num_accepted_drafts - num_full] + [0.0] * (n - num_full - 1)
+    )[:n]
 
 
-def _get_synthetic_params(rate: float, num_spec_steps: int) -> tuple[float, float]:
-    key = (rate, num_spec_steps)
-    if key not in _SYNTHETIC_PARAMS_CACHE:
-        _SYNTHETIC_PARAMS_CACHE[key] = compute_synthetic_rejection_sampler_params(
-            rate, num_spec_steps
-        )
-    return _SYNTHETIC_PARAMS_CACHE[key]
+def _get_synthetic_cond_rates(
+    rates: tuple[float, ...], device: torch.device
+) -> torch.Tensor:
+    """Unconditional per-position rates -> conditional, as a device tensor.
+
+    The kernel stops at the first rejection, so at position ``i`` it needs
+    ``P(accept i | accepted through i-1) = rates[i] / rates[i-1]``, not the
+    unconditional ``rates[i]``.
+    """
+    key = (rates, device)
+    cached = _SYNTHETIC_COND_CACHE.get(key)
+    if cached is not None:
+        return cached
+    cond: list[float] = []
+    prev = 1.0
+    for rate in rates:
+        cond.append(rate / prev if prev > 0.0 else 0.0)
+        prev = rate
+    tensor = torch.tensor(cond, dtype=torch.float32, device=device)
+    _SYNTHETIC_COND_CACHE[key] = tensor
+    return tensor
 
 
 class RejectionSampler(nn.Module):
-    def __init__(self, synthetic_acceptance_rate: float | None = None):
+    def __init__(self, synthetic_acceptance_rates: list[float] | None = None):
         super().__init__()
-        # Debug/benchmark override: force a fixed acceptance rate (see module
-        # docstring). None => normal draft/target rejection sampling.
-        if synthetic_acceptance_rate is not None and not (
-            0.0 <= synthetic_acceptance_rate <= 1.0
-        ):
-            raise ValueError(
-                "synthetic_acceptance_rate must be in [0, 1], "
-                f"but got {synthetic_acceptance_rate}"
-            )
-        self.synthetic_acceptance_rate = synthetic_acceptance_rate
+        # Debug/benchmark override: force an acceptance-length curve (see module
+        # docstring). None => normal draft/target rejection sampling. The config
+        # has already validated and resolved whichever knob the user set into
+        # per-position unconditional rates.
+        self.synthetic_acceptance_rates = (
+            tuple(synthetic_acceptance_rates)
+            if synthetic_acceptance_rates is not None
+            else None
+        )
         # Per-step seed for the synthetic RNG, advanced once per forward. Stays in
         # lockstep across TP ranks (SPMD), so the forced accept/reject pattern is
         # identical on every rank while still varying step to step.
@@ -159,10 +141,10 @@ class RejectionSampler(nn.Module):
             None,
             target_logits,
             bonus_token_ids,
-            synthetic_acceptance_rate=self.synthetic_acceptance_rate,
+            synthetic_acceptance_rates=self.synthetic_acceptance_rates,
             synthetic_step=self._synthetic_step,
         )
-        if self.synthetic_acceptance_rate is not None:
+        if self.synthetic_acceptance_rates is not None:
             self._synthetic_step += 1
         return output_token_ids
 
@@ -181,8 +163,9 @@ def rejection_sample(
     target_probs: torch.Tensor,
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
-    # Debug override: forced acceptance rate in [0, 1] (None => normal path).
-    synthetic_acceptance_rate: float | None = None,
+    # Debug override: per-position unconditional acceptance rates, one entry per
+    # speculative position (None => normal draft/target path).
+    synthetic_acceptance_rates: tuple[float, ...] | None = None,
     # Per-step seed for the (rank-consistent) synthetic RNG; ignored otherwise.
     synthetic_step: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -212,15 +195,13 @@ def rejection_sample(
     )
     num_bonus_tokens = torch.empty(batch_size, dtype=torch.int32, device=device)
 
-    if synthetic_acceptance_rate is not None:
-        # Synthetic path: force a target acceptance rate independent of the real
-        # draft/target agreement. Draft tokens are accepted with a
-        # position-decaying probability; on the first rejection we emit the
+    if synthetic_acceptance_rates is not None:
+        # Synthetic path: force a target acceptance length independent of the
+        # real draft/target agreement. Draft tokens are accepted with the
+        # configured per-position probability; on the first rejection we emit the
         # target argmax as the correction token and stop (same output layout /
         # num_bonus_tokens semantics as the greedy path).
-        base_rate, decay_factor = _get_synthetic_params(
-            synthetic_acceptance_rate, num_spec_steps
-        )
+        cond_rates = _get_synthetic_cond_rates(synthetic_acceptance_rates, device)
         target_argmax = target_probs.argmax(dim=-1)
         # Rank-consistent uniforms: a dedicated device generator re-seeded from the
         # step counter draws the same Philox stream on every TP rank / GPU, so the
@@ -247,8 +228,7 @@ def rejection_sample(
             target_argmax,
             bonus_token_ids,
             uniform,
-            base_rate,
-            decay_factor,
+            cond_rates,
             num_spec_steps,
             num_warps=1,
         )
@@ -359,8 +339,7 @@ def rejection_synthetic_sample_kernel(
     target_argmax_ptr,  # [num_tokens]
     bonus_token_ids_ptr,  # [batch_size]
     uniform_ptr,  # [num_tokens] — per-position U(0, 1) samples
-    base_acceptance_rate,
-    decay_factor,
+    cond_rates_ptr,  # [num_spec_steps] — P(accept pos | accepted through pos-1)
     num_spec_steps,
 ):
     req_idx = tl.program_id(0)
@@ -375,13 +354,12 @@ def rejection_synthetic_sample_kernel(
     rejected = False
     num_bonus_token = -1
     INVALID_TOKEN: tl.constexpr = -1
-    # Per-position conditional acceptance probability, decaying geometrically.
-    acceptance_rate = base_acceptance_rate
     for pos in range(num_draft_tokens):
         if rejected:
             output_id = INVALID_TOKEN
         else:
             u = tl.load(uniform_ptr + start_idx + pos)
+            acceptance_rate = tl.load(cond_rates_ptr + pos)
             if u < acceptance_rate:
                 # Force-accept: emit the draft's own proposed token.
                 output_id = tl.load(draft_token_ids_ptr + start_idx + pos)
@@ -392,7 +370,6 @@ def rejection_synthetic_sample_kernel(
                 output_id = tl.cast(output_id, tl.int32)
                 rejected = True
             num_bonus_token += 1
-            acceptance_rate = acceptance_rate * decay_factor
         tl.store(
             output_token_ids_ptr + req_idx * (num_spec_steps + 1) + pos,
             output_id,

--- a/docs/forced_acceptance_length.md
+++ b/docs/forced_acceptance_length.md
@@ -1,0 +1,210 @@
+# Forced acceptance length
+
+Speculative throughput is dominated by one number: how many tokens each target
+forward emits. Two engines serving the same model at the same batch size report
+very different throughput when their draft heads agree with the target at
+different rates, so a raw speculative benchmark measures draft quality as much
+as it measures the serving system.
+
+`--spec-decode-acceptance-length` takes that variable out. The rejection sampler
+stops comparing draft tokens against the target and instead accepts them with a
+fixed per-position probability, chosen so the run converges on the mean
+acceptance length you asked for. What stays under measurement is the system:
+attention, scheduling, graph capture, and the drafter's own cost.
+
+Two situations call for it:
+
+- **Bring-up.** Benchmark the speculative path while a draft head is still
+  training and its real acceptance is not yet representative.
+- **Cross-engine comparison.** Replay a published acceptance-length figure, such
+  as an [InferenceX golden AL](https://github.com/SemiAnalysisAI/InferenceX/blob/main/golden_al_distribution/README.md),
+  so an ATOM number and a vLLM or SGLang number describe the same workload.
+
+> **This is a benchmarking knob.** Accepted tokens never get checked against the
+> target, so the generated text is not the model's output. Never run an accuracy
+> evaluation with it enabled.
+
+For the speculative framework that hosts it, see
+[`serving_benchmarking_guide.md` § Speculative decoding](serving_benchmarking_guide.md#speculative-decoding-mtp).
+
+## Quick start
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model moonshotai/Kimi-K3 \
+  --draft-model Inferact/Kimi-K3-DSpark \
+  --tensor-parallel-size 8 \
+  --kv_cache_dtype fp8 \
+  --method dspark \
+  --num-speculative-tokens 7 \
+  --spec-decode-acceptance-length 3.78 \
+  --trust-remote-code \
+  --server-port 7777
+```
+
+The resolved schedule is logged once at startup, so a run that quietly failed to
+pick the flag up is easy to spot:
+
+```text
+Forced speculative acceptance ON: mean acceptance length 3.7800 over 7 draft
+positions (per-position rates [1.0, 1.0, 0.78, 0.0, 0.0, 0.0, 0.0]). Throughput
+numbers from this run are synthetic; output text and accuracy are meaningless.
+```
+
+## The two spellings
+
+| Flag | Range | Meaning |
+|---|---|---|
+| `--spec-decode-acceptance-length` | `[1, num_speculative_tokens + 1]` | Mean acceptance length (AL), counting the target's own guaranteed token |
+| `--spec-decode-acceptance-rate` | `[0, 1]` | The same target as a mean acceptance rate, accepted draft tokens over drafted slots |
+
+They describe the same curve, so setting both is rejected at startup. With
+`n = num_speculative_tokens`:
+
+```text
+length = 1 + n * rate
+rate   = (length - 1) / n
+```
+
+Prefer the length form. Published figures are quoted as lengths, so the rate
+form only inserts a conversion step where a rounding slip can move the target
+without anything complaining.
+
+## What the number means
+
+Acceptance length counts the token the target produces on its own. It is
+therefore at least `1` even when every draft token is rejected, and at most
+`n + 1` when all `n` are accepted. A length of `3.78` over 7 draft positions
+means each target forward emits 3.78 tokens on average: its own, plus 2.78
+accepted draft tokens.
+
+That convention is deliberate — it matches vLLM's `synthetic_acceptance_length`
+and SGLang's `SGLANG_SIMULATE_ACC_LEN`, so a published AL can be passed through
+unchanged, with no off-by-one and no division.
+
+## The schedule it resolves to
+
+Any per-position schedule summing to `length - 1` hits the requested mean, but
+they are not interchangeable: the spread around that mean drives ITL tails and
+how a batch drains, so two engines quoting the same AL can still produce
+different latency distributions.
+
+ATOM resolves the length to the minimum-variance schedule — accept
+`floor(length - 1)` positions outright, and the next one with the leftover
+fraction. At length `3.78` over 7 positions:
+
+| Draft position | 1 | 2 | 3 | 4–7 |
+|---|---|---|---|---|
+| P(accepted) | 1.00 | 1.00 | 0.78 | 0 |
+
+Every step accepts either 2 or 3 draft tokens, 22% / 78%, and never anything
+else. This is what vLLM resolves `synthetic_acceptance_length` to and what
+SGLang's `match-expected` draws, so the accepted-length *distribution* matches
+across engines and not merely its mean.
+
+Accepted positions emit the draft's own token IDs, so the drafter still runs and
+is still paid for on every step. Only the accept/reject decision is synthetic.
+
+> `--spec-decode-acceptance-rate` previously resolved to a geometric decay,
+> which hits the same mean with about 15× the variance (2.63 against 0.17 at
+> length 3.78). It now shares the schedule above, so throughput numbers taken
+> before that change are not comparable to ones taken after.
+
+## Confirming the run hit the target
+
+`GET /debug/mtp_stats` reports what actually happened:
+
+```json
+{
+  "enabled": true,
+  "total_draft_tokens": 1400000,
+  "total_accepted_tokens": 553980,
+  "acceptance_rate": 0.3957,
+  "average_tokens_per_forward": 3.7699,
+  "distribution": {"2": 46020, "3": 153980},
+  "distribution_percent": {"2": 0.2301, "3": 0.7699}
+}
+```
+
+`average_tokens_per_forward` is the realized acceptance length; compare it
+against what you asked for. The figures above are from a Kimi-K3 +
+Kimi-K3-DSpark TP8 run at `--spec-decode-acceptance-length 3.78`, which came
+back at 3.7699 with the accepted-count split falling where the schedule predicts.
+
+`acceptance_rate` counts accepted draft tokens over drafted *slots*, so at
+length 3.78 over 7 positions it reads `2.78 / 7 ≈ 0.396`. That is the rate form
+of the same target, not a shortfall.
+
+The same values are on `/metrics` as `atom:mtp_average_tokens_per_forward`,
+`atom:mtp_accepted_tokens`, and `atom:mtp_decode_steps{accepted_tokens="..."}`.
+
+## Replaying an InferenceX golden AL
+
+Under the AgentX fairness guidelines each (model, thinking mode, draft length)
+combination has one committed golden AL, and every submission for that
+combination replays it instead of quoting its own measurement. The curves live
+in [`golden_al_distribution/`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/golden_al_distribution/README.md)
+as YAML keyed by `num_speculative_tokens`. For Kimi-K3 DSpark with thinking on:
+
+| `--num-speculative-tokens` | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|---|---|---|---|---|---|---|---|---|
+| `--spec-decode-acceptance-length` | 1.84 | 2.45 | 2.87 | 3.22 | 3.44 | 3.54 | 3.78 | 3.88 |
+
+Pick the column for the draft length you are running and pass the value
+straight through. A submission may choose any supported draft length, but not a
+different acceptance target for it.
+
+Those curves are measured on the coding category of the SPEED-Bench Qualitative
+split, with real draft decoding and the model's production sampling settings.
+ATOM replays them; it does not collect them.
+
+## Restrictions
+
+**No accuracy evaluation.** Accepted tokens come from the draft without ever
+being compared against the target, so anything measuring quality — `lm_eval`,
+gsm8k, a golden-output diff — is measuring noise.
+
+**Not with the DSpark confidence scheduler.** The confidence scheduler
+(`--dspark-config '{"confidence_schedule": true}'`, and the `ragged` path that
+requires it) sizes each request's verify length `ell_r` at runtime. When `ell_r`
+comes back shorter than the schedule needs, the run lands under the length it
+was asked to reproduce — at length 3.78 over 7 positions, exact while
+`ell_r >= 3`, but 3.39 at `ell_r = 2` and 2.89 at `ell_r = 1`. Because `ell_r`
+is a runtime decision there is no upfront check that would catch the shortfall,
+and a benchmark reporting a number it never hit is worse than one that refuses
+to start, so ATOM rejects the combination at startup. Drop
+`confidence_schedule` for forced-acceptance runs; see
+[`recipes/DSpark.md`](../recipes/DSpark.md).
+
+**Needs a speculative method.** The flag requires `--method` and a non-zero
+`--num-speculative-tokens`. Without draft positions there is no schedule to
+resolve, and startup fails rather than silently ignoring the flag.
+
+## How it works
+
+`SpeculativeConfig._resolve_synthetic_acceptance` (`atom/config.py`) validates
+whichever knob was set, converts a rate into a length, and calls
+`acceptance_length_to_rates` (`atom/model_ops/rejection_sampler.py`) to produce
+the per-position unconditional rates. Everything downstream reads only the
+resolved `synthetic_acceptance_rates`, so neither spelling survives past config.
+
+`rejection_sample` then dispatches `rejection_synthetic_sample_kernel` in place
+of the greedy kernel. The kernel walks positions in order and stops at the first
+rejection, so it needs `P(accept i | accepted through i-1)` rather than the
+unconditional rates the config carries; the conversion happens once and is
+cached per device. On rejection it emits the target's argmax as the correction
+token, keeping the output layout and `num_bonus_tokens` semantics identical to
+the real path.
+
+The accept/reject draw has to be bit-identical on every TP rank. `sampled_tokens`
+is broadcast from rank 0 while `num_bonus_tokens` stays local, so a per-rank
+`torch.rand` would desync the two and leave the anchor gather reading a rejected
+column — the draft then embeds an invalid token ID and the run dies on an HSA
+out-of-bounds fault. A dedicated device generator, re-seeded each step from a
+counter that advances in SPMD lockstep, draws the same Philox stream everywhere.
+
+Those uniforms are drawn on-device deliberately. Drawing on the host costs a
+pageable H2D copy, which PyTorch issues as a memcpy plus a stream sync, landing
+exactly between verify and propose: the caller would block until the whole
+target forward drained, and the draft model's kernels could not be dispatched
+behind it.

--- a/docs/forced_acceptance_length.md
+++ b/docs/forced_acceptance_length.md
@@ -105,11 +105,6 @@ across engines and not merely its mean.
 Accepted positions emit the draft's own token IDs, so the drafter still runs and
 is still paid for on every step. Only the accept/reject decision is synthetic.
 
-> `--spec-decode-acceptance-rate` previously resolved to a geometric decay,
-> which hits the same mean with about 15× the variance (2.63 against 0.17 at
-> length 3.78). It now shares the schedule above, so throughput numbers taken
-> before that change are not comparable to ones taken after.
-
 ## Confirming the run hit the target
 
 `GET /debug/mtp_stats` reports what actually happened:

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -604,9 +604,7 @@ published figure goes in unchanged. The budget is spent on the earliest
 positions — length `3.78` over 7 draft slots accepts 2 tokens always and a 3rd
 with probability `0.78` — which is the minimum-variance schedule vLLM and
 SGLang also use, so the accepted-length distribution matches and not just its
-mean. Accepted positions emit the draft's own tokens.
-
-Read the realized value back from `average_tokens_per_forward` on
+mean. Read the realized value back from `average_tokens_per_forward` on
 `/debug/mtp_stats` (or the `atom:mtp_average_tokens_per_forward` metric).
 
 Two caveats:
@@ -617,6 +615,10 @@ Two caveats:
   (`--dspark-config '{"confidence_schedule": true}'`), which picks each
   request's verify length at runtime; a short one silently caps acceptance
   below the requested length, so the combination is rejected at startup.
+
+The full reference — the resolved schedule, the rate-based spelling, and how to
+replay a golden AL curve — is in
+[`forced_acceptance_length.md`](forced_acceptance_length.md).
 
 ## Deployment examples
 

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -540,6 +540,8 @@ python -m atom.entrypoints.openai_server \
 | `--method` | `None` | Speculative method: `mtp` (DeepSeek MTP) or `eagle3` (EAGLE 3 / EAGLE 3.1 — see [`eagle3_speculative_decoding.md`](eagle3_speculative_decoding.md)) |
 | `--num-speculative-tokens` | `1` | Number of draft tokens per iteration (draft model runs this many autoregressive steps) |
 | `--draft-model` | `None` | Path or HF repo of the speculative draft model. Required for `--method eagle3`; the draft's `config.json` drives EAGLE 3 vs EAGLE 3.1 toggles automatically |
+| `--spec-decode-acceptance-length` | `None` | Benchmark-only: force a mean acceptance length in `[1, num_speculative_tokens + 1]`, ignoring real draft/target agreement. See [Forced acceptance length](#forced-acceptance-length) |
+| `--spec-decode-acceptance-rate` | `None` | The same knob as a rate in `[0, 1]`, i.e. `(length - 1) / num_speculative_tokens`. Mutually exclusive with the above |
 
 ### MTP statistics
 
@@ -575,6 +577,46 @@ MTP Statistics:
      subsequent draft tokens are discarded.
    - If all draft tokens match, a bonus token from the target model is
      appended.
+
+### Forced acceptance length
+
+Speculative throughput is dominated by how many tokens each target forward
+emits, so a run cannot be compared against another engine unless both accept at
+the same rate. `--spec-decode-acceptance-length` pins that number: the sampler
+stops comparing draft against target and instead accepts draft tokens with a
+fixed per-position probability, hitting the requested mean acceptance length.
+It exists to benchmark the serving system while a draft head is still training,
+and to replay a published acceptance-length figure such as an
+[InferenceX golden AL](https://github.com/SemiAnalysisAI/InferenceX/blob/main/golden_al_distribution/README.md).
+
+```bash
+python -m atom.entrypoints.openai_server \
+    --model /models/Kimi-K3 \
+    --draft-model /models/Kimi-K3-DSpark \
+    --method dspark \
+    --num-speculative-tokens 7 \
+    --spec-decode-acceptance-length 3.78
+```
+
+Acceptance length counts the target's own guaranteed token, matching vLLM's
+`synthetic_acceptance_length` and SGLang's `SGLANG_SIMULATE_ACC_LEN`, so a
+published figure goes in unchanged. The budget is spent on the earliest
+positions — length `3.78` over 7 draft slots accepts 2 tokens always and a 3rd
+with probability `0.78` — which is the minimum-variance schedule vLLM and
+SGLang also use, so the accepted-length distribution matches and not just its
+mean. Accepted positions emit the draft's own tokens.
+
+Read the realized value back from `average_tokens_per_forward` on
+`/debug/mtp_stats` (or the `atom:mtp_average_tokens_per_forward` metric).
+
+Two caveats:
+
+- Generated text is meaningless, because tokens are accepted without agreeing
+  with the target. Never run an accuracy evaluation with this enabled.
+- It cannot be combined with the DSpark confidence scheduler
+  (`--dspark-config '{"confidence_schedule": true}'`), which picks each
+  request's verify length at runtime; a short one silently caps acceptance
+  below the requested length, so the combination is rejected at startup.
 
 ## Deployment examples
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -31,6 +31,8 @@ subtrees:
         title: Online quantization best practices
       - file: eagle3_speculative_decoding
         title: EAGLE 3 / 3.1 speculative decoding
+      - file: forced_acceptance_length
+        title: Forced acceptance length
       - file: scheduling_kv_cache_guide
         title: Scheduling and KV cache
       - file: distributed_guide

--- a/recipes/DSpark.md
+++ b/recipes/DSpark.md
@@ -109,7 +109,7 @@ Tips on server configuration:
   forced-acceptance knobs `--spec-decode-acceptance-length` /
   `--spec-decode-acceptance-rate`: a runtime-chosen verify length can cap
   acceptance below the requested length, so ATOM rejects the pair at startup.
-  See [Forced acceptance length](../docs/serving_benchmarking_guide.md#forced-acceptance-length).
+  See [Forced acceptance length](../docs/forced_acceptance_length.md).
 - Clear compile cache before restarting after code changes: `rm -rf /root/.cache/atom/*`
 
 ## Performance baseline (DeepSeek-V4-Pro)

--- a/recipes/DSpark.md
+++ b/recipes/DSpark.md
@@ -105,6 +105,11 @@ Tips on server configuration:
   removed.
 - Do **not** pass `--enforce-eager` with the ragged CUDA-graph path — ragged
   replays captured `(bs, q_eff)` graphs. Eager also works for correctness checks.
+- `confidence_schedule` (and therefore `ragged`) cannot be combined with the
+  forced-acceptance knobs `--spec-decode-acceptance-length` /
+  `--spec-decode-acceptance-rate`: a runtime-chosen verify length can cap
+  acceptance below the requested length, so ATOM rejects the pair at startup.
+  See [Forced acceptance length](../docs/serving_benchmarking_guide.md#forced-acceptance-length).
 - Clear compile cache before restarting after code changes: `rm -rf /root/.cache/atom/*`
 
 ## Performance baseline (DeepSeek-V4-Pro)

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -170,6 +170,7 @@ class TestEngineArgsSpeculativeValidation:
             model=args.model,
             num_speculative_tokens=3,
             synthetic_acceptance_rate=None,
+            synthetic_acceptance_length=None,
         )
         assert kwargs["speculative_config"] is fake_spec_config
 


### PR DESCRIPTION
## Summary

Cross-engine harnesses (InferenceX/AgentX) publish a [golden acceptance length](https://github.com/SemiAnalysisAI/InferenceX/blob/main/golden_al_distribution/README.md) per (model, thinking mode, draft length) and require submissions to replay it, so a run measures serving-system performance rather than draft-head quality. ATOM could already force acceptance, but not in terms anyone else's number is expressed in.

- **Unit.** The knob took an acceptance *rate*, so a published AL had to be hand-converted through `(AL - 1) / num_speculative_tokens` — the same class of off-by-one InferenceX already warns about for TensorRT-LLM. `--spec-decode-acceptance-length` now takes the AL directly, counting the target's guaranteed token exactly as vLLM's `synthetic_acceptance_length` and SGLang's `SGLANG_SIMULATE_ACC_LEN` do.
- **Distribution.** The rate was realized by decaying the per-position probability geometrically, which hits the requested mean with a far wider spread than the other engines produce. Both spellings now resolve to the minimum-variance schedule vLLM derives, so the accepted-length *distribution* matches and not merely its mean. Accepted positions still emit the real draft token, as SGLang's `real-draft-token` does.

At AL 3.78 over 7 draft slots:

| | pos 0 | 1 | 2 | 3–6 | mean | variance |
|---|---|---|---|---|---|---|
| before (geometric) | 0.948 | 0.765 | 0.524 | 0.305 … 0.023 | 2.78 | 2.63 |
| after (min-variance) | 1.000 | 1.000 | 0.780 | 0 | 2.78 | 0.17 |

- **DSpark guard.** The schedule spends its budget on the first `ceil(AL - 1)` positions and the sampler can only accept what was drafted, so the confidence scheduler's runtime-chosen verify length can cap acceptance below the target with nothing to detect it: at AL 3.78 the value is exact while `ell_r >= 3`, but falls to 3.39 at `ell_r = 2` and 2.89 at `ell_r = 1`. `confidence_schedule` combined with forced acceptance is now rejected at startup rather than silently under-delivering.

`--spec-decode-acceptance-rate` keeps its meaning and its mean; only its spread changes. Perf numbers previously collected with the geometric distribution may shift slightly.

