### PR TITLE
ci: add MI355 burst QoS probe

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - atom-mi355-8gpu.predownload
     - atom-mi355-8gpu-aac-runner
     - atom-mi355-8gpu-vllm-sgl-ci
+    - hjbog-srdc-15
     - atom-mi308-8gpu-plugins-accuracy
     - atom-mi308-8gpu-plugins-benchmark
     - atom-mi308-8gpu-vllm-sgl-ci

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,7 +5,6 @@ self-hosted-runner:
     - atom-mi355-8gpu.predownload
     - atom-mi355-8gpu-aac-runner
     - atom-mi355-8gpu-vllm-sgl-ci
-    - atomesh-cicd-crusoe-mi355
     - atom-mi308-8gpu-plugins-accuracy
     - atom-mi308-8gpu-plugins-benchmark
     - atom-mi308-8gpu-vllm-sgl-ci

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - atom-mi355-8gpu.predownload
     - atom-mi355-8gpu-aac-runner
     - atom-mi355-8gpu-vllm-sgl-ci
+    - atomesh-cicd-crusoe-mi355
     - atom-mi308-8gpu-plugins-accuracy
     - atom-mi308-8gpu-plugins-benchmark
     - atom-mi308-8gpu-vllm-sgl-ci

--- a/.github/workflows/mi355-burst-probe.yaml
+++ b/.github/workflows/mi355-burst-probe.yaml
@@ -1,0 +1,118 @@
+name: MI355 Burst QoS Probe
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: mi355-burst-probe
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  submit-and-verify:
+    name: Submit and verify one MI355 burst allocation
+    # This is a Crusoe Slurm submit host, not the direct GPU runner used by
+    # vLLM/SGLang CI. Keep the existing direct runner workflows unchanged until
+    # this probe verifies the allocation and shared-workspace contract.
+    runs-on: atomesh-cicd-crusoe-mi355
+    timeout-minutes: 30
+    env:
+      SLURM_ACCOUNT: amd-aifw-dev
+      SLURM_QOS: amd-burst-qos
+      SPUR_CONTROLLER_ADDR: http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817
+    steps:
+      - name: Checkout ATOM repository
+        uses: actions/checkout@v6
+
+      - name: Verify Slurm submit host
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/slurm-24.05.5.1/bin:${PATH}"
+          command -v sbatch
+          command -v squeue
+          command -v sacct
+          echo "Submit host: $(hostname)"
+          echo "Workspace: ${GITHUB_WORKSPACE}"
+
+      - name: Submit one MI355 burst allocation
+        id: burst
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/slurm-24.05.5.1/bin:${PATH}"
+
+          probe_dir="${RUNNER_TEMP}/mi355-burst-probe"
+          mkdir -p "${probe_dir}"
+          job_script="${probe_dir}/probe-job.sh"
+
+          cat > "${job_script}" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          echo "Compute host: $(hostname)"
+          echo "Slurm job id: ${SLURM_JOB_ID:-missing}"
+          echo "Workspace: ${GITHUB_WORKSPACE:-missing}"
+          test -d "${GITHUB_WORKSPACE}/.git"
+
+          if command -v rocm-smi >/dev/null 2>&1; then
+            rocm-smi
+          elif command -v amd-smi >/dev/null 2>&1; then
+            amd-smi list
+          else
+            echo "No ROCm GPU management command is available." >&2
+            exit 1
+          fi
+          EOF
+          chmod +x "${job_script}"
+
+          output_path="${probe_dir}/slurm-%j.out"
+          error_path="${probe_dir}/slurm-%j.err"
+          set +e
+          submit_output="$(
+            sbatch --parsable --wait \
+              --controller "${SPUR_CONTROLLER_ADDR}" \
+              --account "${SLURM_ACCOUNT}" \
+              --qos "${SLURM_QOS}" \
+              --nodes 1 \
+              --ntasks 1 \
+              --gpus-per-node 8 \
+              --exclusive \
+              --time 00:15:00 \
+              --chdir "${GITHUB_WORKSPACE}" \
+              --output "${output_path}" \
+              --error "${error_path}" \
+              "${job_script}"
+          )"
+          submit_status=$?
+          set -e
+
+          job_id="${submit_output%%;*}"
+          echo "job_id=${job_id}" >> "${GITHUB_OUTPUT}"
+          echo "Slurm submission output: ${submit_output}"
+          echo "Slurm submission exit status: ${submit_status}"
+
+          if [[ "${job_id}" =~ ^[0-9]+$ ]]; then
+            sacct --controller "${SPUR_CONTROLLER_ADDR}" \
+              --jobs "${job_id}" \
+              --format=JobID,State,ExitCode,NodeList \
+              --noheader || true
+            for log_path in \
+              "${probe_dir}/slurm-${job_id}.out" \
+              "${probe_dir}/slurm-${job_id}.err"; do
+              if [[ -f "${log_path}" ]]; then
+                echo "=== ${log_path##*/} ==="
+                cat "${log_path}"
+              fi
+            done
+          fi
+
+          exit "${submit_status}"
+
+      - name: Upload probe logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mi355-burst-probe-${{ steps.burst.outputs.job_id || github.run_id }}
+          path: ${{ runner.temp }}/mi355-burst-probe/
+          if-no-files-found: warn

--- a/.github/workflows/mi355-burst-probe.yaml
+++ b/.github/workflows/mi355-burst-probe.yaml
@@ -20,9 +20,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       || contains(github.event.pull_request.labels.*.name, 'ci:mi355-burst-probe')
-    # Use the existing vLLM/SGLang plugin runner. This probe must not depend on
-    # ATOMesh runners or modify the normal plugin CI execution paths.
-    runs-on: atom-mi355-8gpu-vllm-sgl-ci
+    # Use the existing non-GPU plugin build runner so this path does not wait
+    # for a normal MI355 CI allocation before it can submit to burst QoS.
+    runs-on: build-only-atom
     timeout-minutes: 30
     env:
       SLURM_ACCOUNT: amd-aifw-dev

--- a/.github/workflows/mi355-burst-probe.yaml
+++ b/.github/workflows/mi355-burst-probe.yaml
@@ -20,10 +20,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       || contains(github.event.pull_request.labels.*.name, 'ci:mi355-burst-probe')
-    # This is a Crusoe Slurm submit host, not the direct GPU runner used by
-    # vLLM/SGLang CI. Keep the existing direct runner workflows unchanged until
-    # this probe verifies the allocation and shared-workspace contract.
-    runs-on: atomesh-cicd-crusoe-mi355
+    # Use the existing vLLM/SGLang plugin runner. This probe must not depend on
+    # ATOMesh runners or modify the normal plugin CI execution paths.
+    runs-on: atom-mi355-8gpu-vllm-sgl-ci
     timeout-minutes: 30
     env:
       SLURM_ACCOUNT: amd-aifw-dev

--- a/.github/workflows/mi355-burst-probe.yaml
+++ b/.github/workflows/mi355-burst-probe.yaml
@@ -20,9 +20,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       || contains(github.event.pull_request.labels.*.name, 'ci:mi355-burst-probe')
-    # Use the existing non-GPU plugin build runner so this path does not wait
-    # for a normal MI355 CI allocation before it can submit to burst QoS.
-    runs-on: build-only-atom
+    # Use an existing SGL CI host as a lightweight Slurm submitter. It does not
+    # execute the MI355 workload itself; it only requests a burst allocation.
+    runs-on: hjbog-srdc-15
     timeout-minutes: 30
     env:
       SLURM_ACCOUNT: amd-aifw-dev

--- a/.github/workflows/mi355-burst-probe.yaml
+++ b/.github/workflows/mi355-burst-probe.yaml
@@ -2,6 +2,10 @@ name: MI355 Burst QoS Probe
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [labeled]
+    paths:
+      - .github/workflows/mi355-burst-probe.yaml
 
 concurrency:
   group: mi355-burst-probe
@@ -13,6 +17,9 @@ permissions:
 jobs:
   submit-and-verify:
     name: Submit and verify one MI355 burst allocation
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'ci:mi355-burst-probe')
     # This is a Crusoe Slurm submit host, not the direct GPU runner used by
     # vLLM/SGLang CI. Keep the existing direct runner workflows unchanged until
     # this probe verifies the allocation and shared-workspace contract.


### PR DESCRIPTION
## Summary
- add a label-gated MI355 burst QoS probe that requests one exclusive 8-GPU Slurm allocation
- record the allocation host, ROCm visibility, workspace access, and Slurm state for validating the burst execution contract
- keep all existing PR, accuracy, benchmark, and MI308 workflows unchanged

## Test plan
- [x] IDE YAML diagnostics
- [x] `git diff --check`
- [ ] Add `ci:mi355-burst-probe` to this PR to run the probe on Crusoe