### PR TITLE
perf(dsv4): let low-concurrency serving turn the side streams off

### DIFF
--- a/.github/benchmark/README.md
+++ b/.github/benchmark/README.md
@@ -87,7 +87,7 @@ utilization, …) is passed verbatim through `extra_args`:
 | field | where | emits |
 |-------|-------|-------|
 | `kv_cache_dtype` | config | `--kv_cache_dtype <v>` (default `fp8`) |
-| `tp` | config | `-tp <n>` (omitted if absent, e.g. gpt-oss) |
+| `tp` | config or variant | `-tp <n>` (omitted if absent, e.g. gpt-oss); variant overrides config |
 | `trust_remote_code` | config | `--trust-remote-code` |
 | `extra_args` | config and/or variant | appended verbatim (server flags) |
 | `env_vars` | model and/or variant | newline-joined container env vars |

--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -27,6 +27,14 @@
       },
       "variants": [
         { "label": "", "suffix": "", "conc_max": 256 },
+        { "label": "TP4", "suffix": "-tp4", "tp": 4, "conc_max": 16 },
+        {
+          "label": "TP4 NoSS",
+          "suffix": "-tp4-noss",
+          "tp": 4,
+          "conc_max": 16,
+          "env_vars": "ATOM_USE_SIDE_STREAMS=0"
+        },
         {
           "label": "MTP3",
           "suffix": "-mtp3",

--- a/.github/scripts/catalog.py
+++ b/.github/scripts/catalog.py
@@ -85,11 +85,14 @@ def build_args(config: dict[str, Any], variant: dict[str, Any]) -> str:
     utilization, ...) is passed verbatim via `extra_args`. Fixed order:
 
         --kv_cache_dtype <dtype> [-tp <n>] [--trust-remote-code]
+        (tp: variant.tp overrides config.tp)
         [<config.extra_args>] [<variant.extra_args>]
     """
     parts: list[str] = [f"--kv_cache_dtype {config.get('kv_cache_dtype', 'fp8')}"]
-    if config.get("tp") is not None:
-        parts.append(f"-tp {config['tp']}")
+    # A variant may pin its own TP, as it may already pin its own `path`.
+    tp = variant.get("tp", config.get("tp"))
+    if tp is not None:
+        parts.append(f"-tp {tp}")
     if config.get("trust_remote_code"):
         parts.append("--trust-remote-code")
     if config.get("extra_args"):

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -3515,9 +3515,15 @@ class MoE(nn.Module):
     def single_stream_moe_forward(
         self, x: torch.Tensor  # [num_tokens, dim]
     ) -> torch.Tensor:  # [num_tokens, dim]
-        """Sequential: shared_experts → routed_experts → combine."""
-        shared = self.shared_experts(x) if self.shared_experts is not None else None
+        """Sequential: routed_experts → shared_experts → combine.
+
+        Mirrors dual_stream_moe_forward's call form and order -- going through
+        nn.Module.__call__ here cost a separate Inductor graph.
+        """
         routed = self.routed_expert_forward(x)
+        shared = (
+            self.shared_experts.forward(x) if self.shared_experts is not None else None
+        )
         return self.combine_outputs(
             routed, shared, prefix=f"{self.prefix}.combine_outputs"
         )
@@ -4087,11 +4093,12 @@ class DeepseekV4Model(nn.Module):
         # Main Compressor overlap. indexer_stream: Indexer Compressor overlap.
         # Both allocated once, shared across all blocks. Attention runs before
         # MoE in each block, so attn and MoE never contend for alt_stream.
+        _side_streams = torch.cuda.is_available() and envs.ATOM_USE_SIDE_STREAMS
         self.alt_stream: torch.cuda.Stream | None = (
-            torch.cuda.Stream() if torch.cuda.is_available() else None
+            torch.cuda.Stream() if _side_streams else None
         )
         self.indexer_stream: torch.cuda.Stream | None = (
-            torch.cuda.Stream() if torch.cuda.is_available() else None
+            torch.cuda.Stream() if _side_streams else None
         )
         self.layers = nn.ModuleList(
             [

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -275,6 +275,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("ATOM_USE_CUSTOM_ALL_GATHER", "1").lower() == "1"
     ),
     "ATOM_USE_FLYDSL_GDR": lambda: os.getenv("ATOM_USE_FLYDSL_GDR", "0").lower() == "1",
+    # Set "0" to drop both side streams: a win at low decode concurrency on
+    # MI355X, a loss at high (see .github/benchmark/models.json). Read at
+    # construction -- keeping them allocated is what hides MoE from Inductor.
+    "ATOM_USE_SIDE_STREAMS": lambda: os.getenv("ATOM_USE_SIDE_STREAMS", "1") == "1",
     # --- MoE (DeepSeek-style shared experts) ---
     # Dual-stream MoE only when num_tokens <= threshold; 0 disables dual-stream registration.
     "ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD": lambda: int(

--- a/tests/test_benchmark_catalog.py
+++ b/tests/test_benchmark_catalog.py
@@ -71,6 +71,17 @@ def test_build_args_composition():
         == "--kv_cache_dtype fp8 -tp 8 --x"
     )
 
+    # variant.tp overrides config.tp, and emits -tp exactly once. A variant
+    # that pins a different topology than the model default must not leave the
+    # model's -tp in the string as well.
+    assert (
+        catalog.build_args({"kv_cache_dtype": "fp8", "tp": 8}, {"tp": 4})
+        == "--kv_cache_dtype fp8 -tp 4"
+    )
+
+    # A variant tp on a model that declares none still emits -tp.
+    assert catalog.build_args({}, {"tp": 4}) == "--kv_cache_dtype fp8 -tp 4"
+
 
 def test_build_args_smoke_over_real_catalog():
     """Every real (model, variant) pair produces a well-formed arg string.


### PR DESCRIPTION
## What this changes

`DeepseekV4Model` allocates two side streams unconditionally — `alt_stream`
(Main Compressor + dual-stream MoE) and `indexer_stream` (Indexer Compressor).
`ATOM_USE_SIDE_STREAMS` lets a deployment decline them. **Default `"1"`:
nothing changes for anyone who does not set it.**

## Measurements

MI355X ×8, DeepSeek-V4-Pro FP4, TP=4 EP=1 dp_attn=off, summarize 8k/1k,
`random_range_ratio` 0.8, on `rocm/atom-dev:latest-20260729` (ATOM 5e491a9).
Interactivity = 1/median_tpot; throughput per chip.

| conc | intv on | off | Δ | tput on | off | Δ |
|-----:|-----:|-----:|-----:|-----:|-----:|-----:|
| 1 | 65.236 | 73.662 | **+12.9%** | 140.4 | 156.3 | **+11.3%** |
| 2 | 64.594 | 69.853 | +8.1% | 272.2 | 292.8 | +7.5% |
| 4 | 56.418 | 61.730 | +9.4% | 470.7 | 525.5 | +11.7% |
| 8 | 49.659 | 52.014 | +4.7% | 834.6 | 882.9 | +5.8% |
| 16 | 37.429 | 39.197 | +4.7% | 1281.0 | 1342.1 | +4.8% |
| 64 | 16.203 | 16.555 | +2.2% | 2278.8 | 2329.3 | +2.2% |
| 256 | 7.260 | 6.344 | **−12.6%** | 2712.2 | 3588.9 | **+32.3%** |

That sweep predates this patch: it compares the stock image against a build
with the streams forced off, which is what the patch does with the knob set.
Re-verified since with the patch itself and the knob, on the image ATOM's own
benchmark uses — `rocm/atom-dev:nightly_202608181633` (torch 2.10.0+rocm7.2.4),
ATOM 7229049 with this commit cherry-picked, TP=4 EP=1 dp_attn=off,
concurrency 1, stock `max_num_seqs`:

| ATOM_USE_SIDE_STREAMS | interactivity | throughput/chip |
|---|---:|---:|
| `1` (default) | 63.525 | 141.2 |
| `0` | **71.672** | **158.2** |
| | **+12.8%** | **+12.1%** |

Both runs completed 20/20 with mean/median TPOT = 1.00. For reference, the
SemiAnalysis InferenceX published point for this configuration is 65.147
interactivity / 140.8 throughput-per-chip at concurrency 1.

The gain decays with concurrency and reverses by 256: the side streams are not
a mistake, they pay off once there is enough concurrent work to overlap, and
low concurrency is the one regime where they do not.

## Why

At concurrency 1 the overlap is real but not worth its price. Averaged over 183
layer instances (three decode steps, 61 layers each), Δwall splits into
`busy_sum` −40.18, lost overlap +58.98, gap −23.49 μs/layer: the streams hide
59 μs/layer and cost 63 to get, because at batch size 1 every kernel is
latency- and launch-bound and co-residency splits CUs without adding
throughput.

The larger effect is not the fork but the allocation. Unallocated, MoE stops
registering in `static_forward_context`, `MoE.forward` leaves the opaque
`maybe_dual_stream_forward` custom op, and the body becomes reachable by
Inductor — `busy_sum` 304.47 → 267.02 μs/layer.

## What the diff does not show

Reading the knob per call, with the streams still allocated, was tried and
measured **6.8% slower than baseline**; hence construction-time.
`ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD=0` is not an existing substitute — it
covers only the MoE half of `alt_stream`. The second hunk, aligning
`single_stream_moe_forward` with the dual path, is worth a further 1.9% TPOT
and 14.8% off p99 ITL (call form and order moved together, not bisected).

The two catalog variants are TP=4 because that is what low-concurrency serving
uses and what every measurement above was taken in, against a TP=8 catalog
default; supporting a per-variant TP took three lines in `catalog.py`, where
`build_args` now reads `variant.tp` before `config.tp`, mirroring the existing
per-variant `path` override.

Both were started by hand with the exact server args the catalog emits for
them, including the default `max_num_seqs`, on
`rocm/atom-dev:nightly_202608181633`; both reach *Application startup
complete*. Cost is 12 cells per night; no pre-existing variant changes.

## Scope, safety, testing

MI355X only, DSv4-Pro FP4, dp_attn=off, TP=4 — **no evidence about MI300X,
TP=8, or dp_attn=on**. Four other models allocate an `alt_stream` the same way
and none is touched (`deepseek_v2.py:3167`, `deepseek_mtp.py:162`,
`kimi_k3.py:1489`, `plugin/vllm/models/kimi_k25.py:66`); DSv4 is the only one
that also carries `indexer_stream`, and `deepseek_v4_dspark.py` inherits both
as parameters. Null propagation and graph capture are unchanged: every
dereference already sits behind an `is not None` gate, and both gating booleans
are fixed at construction. No unit test — the behaviour needs weights and a GPU
— so the nightly variant is the regression guard. SGLang gates its DeepSeek
`alt_stream` on `SGLANG_ROCM_USE_MULTI_STREAM`, `False` by default on ROCm:
the same knob, opposite default.
