### PR TITLE
fix(lmcache): allocate staging buffer on first-use stream

### DIFF
--- a/atom/kv_transfer/offload/atom_lmcache_staging.py
+++ b/atom/kv_transfer/offload/atom_lmcache_staging.py
@@ -116,11 +116,15 @@ def run_staged_pipeline(
     buffer_safe_to_release = True
     try:
         for group in groups:
-            device_buf = ensure_buffer(staging_buffer, group_nbytes(group))
-            used_buffer = True
             if staging_buffer.free_event_valid:
                 stage_a.stream.wait_event(staging_buffer.free_event)
             with state.stream_ctx(stage_a.stream):
+                # ``ensure_buffer`` may allocate device storage. Allocate it on
+                # the first consumer stream so a caching allocator cannot
+                # reuse storage whose previous default-stream user is still
+                # running and then let this side stream overwrite it early.
+                device_buf = ensure_buffer(staging_buffer, group_nbytes(group))
+                used_buffer = True
                 stage_a.run(group, device_buf)
             staging_buffer.ready_event.record(stage_a.stream)
             stage_b.stream.wait_event(staging_buffer.ready_event)

--- a/tests/test_lmcache_offload_connector.py
+++ b/tests/test_lmcache_offload_connector.py
@@ -918,6 +918,104 @@ def test_lmcache_connector_maps_dcp_ranges_on_virtual_block_grid():
     assert connector.gpu_staging_chunk_bytes == 2 * codec.bytes_per_block
 
 
+@pytest.mark.parametrize(
+    ("first_stream_name", "second_stream_name"),
+    [("pack", "copy"), ("copy", "pack")],
+)
+def test_staged_pipeline_allocates_on_first_consumer_stream(
+    first_stream_name,
+    second_stream_name,
+):
+    from atom.kv_transfer.offload.atom_lmcache_staging import (
+        _PipelineStage,
+        run_staged_pipeline,
+    )
+
+    trace = []
+
+    class _FakeStream:
+        def __init__(self, name):
+            self.name = name
+
+        def wait_event(self, event):
+            trace.append(("wait", self.name, event.name))
+
+        def synchronize(self):
+            trace.append(("synchronize", self.name))
+
+    class _FakeEvent:
+        def __init__(self, name):
+            self.name = name
+
+        def record(self, stream):
+            trace.append(("record", self.name, stream.name))
+
+    class _StreamContext:
+        def __init__(self, state, stream):
+            self.state = state
+            self.stream = stream
+
+        def __enter__(self):
+            assert self.state.current_stream is None
+            self.state.current_stream = self.stream
+            trace.append(("enter", self.stream.name))
+
+        def __exit__(self, *_args):
+            trace.append(("exit", self.stream.name))
+            self.state.current_stream = None
+
+    class _FakeState:
+        def __init__(self):
+            self.current_stream = None
+            self.staging_buffer = SimpleNamespace(
+                tensor=None,
+                ready_event=_FakeEvent("ready"),
+                free_event=_FakeEvent("free"),
+                free_event_valid=False,
+            )
+
+        def stream_ctx(self, stream):
+            return _StreamContext(self, stream)
+
+    state = _FakeState()
+    first_stream = _FakeStream(first_stream_name)
+    second_stream = _FakeStream(second_stream_name)
+    device_buf = object()
+
+    def ensure_buffer(_staging_buffer, nbytes):
+        assert nbytes == 8
+        assert state.current_stream is first_stream
+        trace.append(("ensure", state.current_stream.name))
+        return device_buf
+
+    def run_stage(stage_name, expected_stream, _group, actual_buf):
+        assert state.current_stream is expected_stream
+        assert actual_buf is device_buf
+        trace.append(("run", stage_name, state.current_stream.name))
+
+    run_staged_pipeline(
+        state,
+        [SimpleNamespace(nbytes=8)],
+        stage_a=_PipelineStage(
+            first_stream,
+            lambda group, buf: run_stage("a", first_stream, group, buf),
+        ),
+        stage_b=_PipelineStage(
+            second_stream,
+            lambda group, buf: run_stage("b", second_stream, group, buf),
+        ),
+        ensure_buffer=ensure_buffer,
+        group_nbytes=lambda group: group.nbytes,
+    )
+
+    assert trace[:3] == [
+        ("enter", first_stream_name),
+        ("ensure", first_stream_name),
+        ("run", "a", first_stream_name),
+    ]
+    assert ("run", "b", second_stream_name) in trace
+
+
 def _exception_pipeline(monkeypatch, direction: str, *, failed_stream: str | None):
     import torch
 


### PR DESCRIPTION
## Motivation

LMCache PAGE offload can hit a GPU memory fault when a lazy staging tensor is
allocated on the worker's default stream but first written on the independent
pack stream. The caching allocator may reuse storage whose previous
default-stream consumer is still running; the side-stream staging write can
then overwrite that live data before the default-stream read completes.

## Technical Details

- Wait for the previous stage-B `free_event` before any possible staging-buffer
  replacement.
- Move `ensure_buffer()` into the stage-A stream context so a new allocation is
  associated with the stream that performs its first write.
- Keep the existing ready/free event chain and final stage-B synchronization,
  which already manage the staging tensor's lifetime after first use.
- Add a deterministic regression test for both save (`pack -> copy`) and load
  (`copy -> pack`) stage orderings.

Calling `record_stream()` after allocation is not sufficient for this race: it
protects the new tensor from later reuse, but does not order the old
default-stream consumer before the first side-stream write.

## Test Plan

- Run the full `tests/test_lmcache_offload_connector.py` suite on the latest
  upstream `main` in the ATOM development image.
- Run Black and Ruff against both changed files.
- Exercise the allocator race independently with unsafe, `record_stream`-only,
  and allocate-on-first-consumer-stream variants.
- Run the original TP8 + MTP3 + c48 offload workload with 8 save workers.

## Test Result

- Target test suite: `159 passed in 2.09s`.
- Broader relevant unit/integration selection: `353 passed, 1 skipped`.
- Black: both files unchanged; Ruff: all checks passed.
- Allocator reproduction: unsafe and `record_stream`-only variants reproduced
  full overwrite in 3/3 trials each; allocating on the first-consumer stream
  preserved the data in 3/3 trials.
- End-to-end workload: 531/531 warmup requests and 662/662 profiling requests
  completed, covering 69,723,952 tokens, with zero errors, cancellations, GPU
  faults, memory violations, tracebacks, or segfaults.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
