### PR TITLE
fix(openai): a '<' in the answer no longer withholds the whole stream

### DIFF
--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -33,7 +33,10 @@ from atom.entrypoints.openai.protocol import (
     TEXT_COMPLETION_OBJECT,
     CompletionRequest,
 )
-from atom.entrypoints.openai.reasoning import ReasoningFilter
+from atom.entrypoints.openai.reasoning import (
+    ReasoningFilter,
+    prompt_starts_in_reasoning,
+)
 from atom.entrypoints.openai.serving_chat import (
     build_chat_response,
     build_chat_response_multi,
@@ -521,7 +524,13 @@ class ChatCompletionStreamState:
         self.stream_queue = stream_queue
         self.num_tokens_input = len(tokenizer.encode(prompt))
         self.num_tokens_output = [0] * n
-        self.reasoning_filters = [ReasoningFilter() for _ in range(n)]
+        # Seeded from the rendered prompt, exactly as the OpenAI server does:
+        # a template that injects the opening marker leaves the output starting
+        # mid-thought, and an unseeded filter emits that reasoning as content.
+        starts_thinking = prompt_starts_in_reasoning(prompt)
+        self.reasoning_filters = [
+            ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
+        ]
         self.tool_parsers = [ToolCallStreamParser() for _ in range(n)]
         self.has_tool_calls = [False] * n
         self.finished = [False] * n

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1318,6 +1318,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     cleanup_stream,
                     cleanup_request,
                     tools=request.tools,
+                    starts_thinking=_starts_thinking,
                 )
             else:
                 seq_id, stream_collector, num_prompt_tokens = (

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -173,12 +173,26 @@ class ReasoningFilter:
                 idx, marker = _earliest_marker(self.buf, _THINK_END_MARKERS)
                 if idx != -1:
                     results.extend(self._close_thinking(idx, marker))
-                elif len(self.buf) > 100 and "<" not in self.buf:
+                elif len(self.buf) > 100:
                     # No reasoning markers after significant buffering — emit as
-                    # content. Large threshold gives models time to emit an
-                    # end marker when the template injected the opener.
-                    results.append(("content", self.buf))
-                    self.buf = ""
+                    # content. The threshold gives a model whose template
+                    # injected the opener time to reach its end marker.
+                    #
+                    # Only a partial marker at the *end* of the buffer is worth
+                    # holding: it may complete on the next chunk. Anything
+                    # earlier cannot become a marker any more. Testing instead
+                    # for a bare "<" anywhere withheld the entire stream for as
+                    # long as the answer happened to contain one — and code,
+                    # markup and comparisons are full of them, so a request
+                    # would return 200 and then never emit a byte while the
+                    # engine decoded to max_tokens.
+                    hold = _hold_back_len(
+                        self.buf, _OUTPUT_OPEN_MARKERS + _THINK_END_MARKERS
+                    )
+                    emit = self.buf[: len(self.buf) - hold] if hold else self.buf
+                    if emit:
+                        results.append(("content", emit))
+                        self.buf = self.buf[len(self.buf) - hold :] if hold else ""
 
         elif self.state == 1:
             self.buf += text

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -506,6 +506,7 @@ async def stream_chat_response_fanout(
     cleanup_stream,
     cleanup_request,
     tools=None,
+    starts_thinking: bool = False,
 ) -> AsyncGenerator[str, None]:
     """Streaming variant that multiplexes ``len(seq_ids)`` fan-out siblings
     into a single SSE stream, tagging every chunk with ``choices[0].index``.
@@ -517,11 +518,18 @@ async def stream_chat_response_fanout(
     ``num_prompt_tokens`` is the engine-computed prompt length shared by all
     siblings (they tokenize the same prompt once); reusing it avoids
     re-tokenizing on the event loop at stream start.
+
+    ``starts_thinking`` says the rendered prompt already opened the reasoning
+    channel, so every sibling's output begins mid-thought with no opening
+    marker. It applies to all of them — siblings share one prompt — and must be
+    seeded here, or their reasoning is emitted as answer content.
     """
     n = len(seq_ids)
     num_tokens_input = num_prompt_tokens
     num_tokens_output = [0] * n
-    reasoning_filters = [ReasoningFilter() for _ in range(n)]
+    reasoning_filters = [
+        ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
+    ]
     tool_parsers = [ToolCallStreamParser(tools=tools) for _ in range(n)]
     has_tool_calls = [False] * n
     finished = [False] * n

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -185,3 +185,71 @@ class TestReasoningFilter:
         results.extend(rf.flush())
         content = "".join(t for f, t in results if f == "content")
         assert "Hi" in content
+
+
+class TestNonReasoningOutputIsNotWithheld:
+    """A stream that never opens a reasoning channel must still reach the client.
+
+    Regression for an observed production stall: 1.5-2.4% of requests on a
+    Claude-Code agent corpus returned HTTP 200 and then **zero body bytes** until
+    the client's 600s read timeout, while the engine kept decoding to
+    max_tokens. The cause was state 0 refusing to release the buffer whenever a
+    '<' appeared anywhere in it -- and code-bearing answers are full of '<'.
+    Holding back a partial *trailing* marker is correct; holding the whole
+    buffer because it contains a '<' somewhere is not.
+    """
+
+    def _emit(self, chunks):
+        f = ReasoningFilter()
+        out = []
+        for c in chunks:
+            out.extend(f.process(c))
+        return out
+
+    def test_angle_bracket_in_plain_output_does_not_withhold_forever(self):
+        # A '<' that is not a reasoning marker: the classic case is code.
+        text = "Here is the fix:\n\nif (a < b) { return a; }\n" + "x" * 200
+        emitted = self._emit([text])
+        assert emitted, "nothing was emitted: the stream would stall"
+        assert "".join(t for f, t in emitted if f == "content").startswith(
+            "Here is the fix:"
+        )
+
+    def test_html_like_output_does_not_withhold_forever(self):
+        text = "<div class='x'>hello</div>\n" + "y" * 200
+        emitted = self._emit([text])
+        assert emitted, "nothing was emitted: the stream would stall"
+
+    def test_token_by_token_code_output_streams(self):
+        # The real shape: many small chunks, one of which contains '<'.
+        chunks = ["Sure. ", "Use ", "a < b ", "to compare. "] + [
+            "word " for _ in range(60)
+        ]
+        emitted = self._emit(chunks)
+        assert emitted, "nothing was emitted: the stream would stall"
+
+    def test_a_real_think_block_still_separates(self):
+        # The fix must not cost the feature it guards.
+        f = ReasoningFilter()
+        out = []
+        for c in ["<think>", "pondering", "</think>", "answer"]:
+            out.extend(f.process(c))
+        assert ("reasoning_content", "pondering") in out
+        assert ("content", "answer") in out
+
+    def test_partial_end_marker_is_still_held_back(self):
+        # A marker split across chunks must not leak as content.
+        f = ReasoningFilter()
+        out = []
+        for c in ["<think>", "abc", "</thi"]:
+            out.extend(f.process(c))
+        assert not any("</thi" in t for _, t in out), "leaked a partial marker"
+
+    def test_template_injected_opener_still_reaches_end_marker(self):
+        # starts_thinking=True => state 1; unchanged by this fix.
+        f = ReasoningFilter(starts_thinking=True)
+        out = []
+        for c in ["reasoning here", "</think>", "final"]:
+            out.extend(f.process(c))
+        assert ("reasoning_content", "reasoning here") in out
+        assert ("content", "final") in out

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -398,3 +398,86 @@ class TestFanoutCleanupSplit:
         _, request_calls = self._cleanup_calls([70, 71, 72, 73])
 
         assert request_calls == ["req-3"]
+
+
+class TestFanoutSeedsImplicitReasoning:
+    """A template-injected opener must reach every fan-out sibling's filter.
+
+    When the chat template opens the reasoning channel itself, the output
+    begins mid-thought with no ``<think>`` in it, and only ``starts_thinking``
+    tells the filter so. ``stream_chat_response_fanout`` used to build bare
+    ``ReasoningFilter()`` instances, so an n>1 request emitted its reasoning to
+    the client as answer content. A direct ``ReasoningFilter(starts_thinking=
+    True)`` unit test cannot catch that: the defect is in the wiring, not the
+    filter.
+    """
+
+    # Long enough to pass state 0's 100-character grace period, and carrying a
+    # '<' — the two conditions that decide whether unseeded reasoning leaks.
+    REASONING = "Checking the bound: if (a < b) we return a. " + "Considering. " * 12
+
+    def _deltas(self, starts_thinking):
+        """Every delta the fan-out yields for a two-sibling reasoning stream."""
+
+        async def run():
+            collector = StreamOutputCollector("req-rs")
+            for index in (0, 1):
+                collector.put_nowait(
+                    (
+                        index,
+                        {
+                            "text": self.REASONING,
+                            "token_ids": [1],
+                            "finished": False,
+                        },
+                    )
+                )
+            gen = stream_chat_response_fanout(
+                request_id="req-rs",
+                model="model",
+                shared_collector=collector,
+                seq_ids=[0, 1],
+                num_prompt_tokens=1,
+                cleanup_stream=lambda *a, **k: None,
+                cleanup_request=lambda *a, **k: None,
+                starts_thinking=starts_thinking,
+            )
+            out = []
+            for _ in range(6):
+                try:
+                    raw = await asyncio.wait_for(gen.__anext__(), timeout=2)
+                except (StopAsyncIteration, asyncio.TimeoutError):
+                    break
+                if raw.startswith("data: ") and not raw.startswith("data: [DONE]"):
+                    out.append(json.loads(raw[6:])["choices"][0]["delta"])
+            await gen.aclose()
+            return out
+
+        return asyncio.run(run())
+
+    def test_pre_close_text_is_reasoning_not_content(self):
+        deltas = self._deltas(starts_thinking=True)
+
+        leaked = [d for d in deltas if d.get("content")]
+        assert not leaked, f"reasoning leaked to content: {leaked}"
+        assert any(
+            d.get("reasoning_content") for d in deltas
+        ), f"no reasoning_content was emitted at all: {deltas}"
+
+    def test_without_the_seed_the_same_text_is_not_reasoning(self):
+        # The contrast that shows the seed is what classified it, not the text.
+        # Asserting the text arrives as *content* here would not work: content
+        # segments pass through the tool-call parser, which holds them until the
+        # stream finishes, while reasoning_content is forwarded immediately.
+        deltas = self._deltas(starts_thinking=False)
+
+        assert not any(d.get("reasoning_content") for d in deltas)
+
+    def test_both_streaming_entry_points_accept_the_seed(self):
+        # The wiring bug was a missing parameter, so pin the shape of both.
+        import inspect
+
+        for fn in (stream_chat_response, stream_chat_response_fanout):
+            assert (
+                "starts_thinking" in inspect.signature(fn).parameters
+            ), f"{fn.__name__} cannot be told the prompt opened reasoning"


### PR DESCRIPTION
## Summary

`ReasoningFilter` state 0 releases its buffer only when the buffer contains no `<` at all:

```python
elif len(self.buf) > 100 and "<" not in self.buf:
    results.append(("content", self.buf))
    self.buf = ""
```

Every reasoning marker starts with `<` (`<think>`, `</think>`, `<|open|>think<|sep|>`), so this
is standing in for *"a marker might still be forming"*. But it tests the **whole buffer rather
than its tail**, and a `<` that plainly cannot be a marker — a comparison, an HTML/XML tag, a C++
generic — is enough to hold the entire response back for as long as the answer contains one.

The request returns **HTTP 200 and then never emits a byte**. The engine decodes normally to
`max_tokens` and reports the request finished; the client sits until its own read timeout.

Only a partial marker at the **end** of the buffer can still complete on the next chunk; anything
earlier can no longer become one. `reasoning.py` already has `_hold_back_len()` for exactly this,
and state 1 uses it via `_drain_thinking()`. This change makes state 0 use it too.

## How it was found

Measured on a real agent-traffic replay (Claude-Code-shaped requests, large shared system prompt,
answers full of code) against `rocm/atom-dev:nightly_202608181633`, GLM-5.2-MXFP4, TP4 on MI350X
(gfx950). Roughly 2% of streaming requests returned 200 and then zero body bytes until the client's
600 s read timeout — `content_chars=0`, `reasoning_chars=0`, empty body — while the engine reported
every request finished. Answers containing `<` are common in that traffic, which matches the rate.

> **Scope note, so this is not over-credited.** That production symptom has more than one cause.
> Re-running the same burst with this patch applied still produced stalls with an identical
> signature, which I have separately localised to the batched stream dispatch
> (`streaming_dispatch.py` / `api_server.py`) — the engine reports `requests_finished_total` equal
> to every request submitted, with `requests_running=0` and `preemptions_total=0`, while the client
> received nothing. **That is a different defect and is not addressed here.** This PR fixes a real
> and independently reproducible stall in the reasoning filter; it does not claim to fix the other.

## Reproduce (no GPU, no server)

Save as `repro_stall.py` in the repo root:

```python
#!/usr/bin/env python3
"""Drive ReasoningFilter as the streaming path does and report what would reach the client."""
import sys
from atom.entrypoints.openai.reasoning import ReasoningFilter

CASES = [
    ("plain prose (control)",
     ["The answer is 42. "] + ["padding " for _ in range(30)]),
    ("answer containing a comparison",
     ["Here is the fix:\n\n", "if (a < b) ", "{ return a; }\n"] + ["padding " for _ in range(30)]),
    ("answer containing markup",
     ["<div class='x'>", "hello", "</div>\n"] + ["padding " for _ in range(30)]),
    ("token-by-token, one chunk holds '<'",
     ["Sure. ", "Use ", "a < b ", "to compare. "] + ["word " for _ in range(60)]),
    ("a real <think> block (must still separate)",
     ["<think>", "pondering", "</think>", "the answer"]),
]

def run(chunks):
    f = ReasoningFilter(); out = []
    for c in chunks:
        out.extend(f.process(c))
    return out

def main():
    failures = 0
    for name, chunks in CASES:
        emitted = run(chunks)
        text = "".join(t for _, t in emitted)
        if not emitted: failures += 1
        print(f"  [{'OK  ' if emitted else 'STALL'}] {name}: {len(text)} chars delivered before flush()")
    print()
    if failures:
        print(f"{failures} case(s) delivered NOTHING -- a client would see HTTP 200")
        print("and then no body at all until its read timeout.")
        return 1
    print("all cases delivered content incrementally")
    return 0

if __name__ == "__main__":
    sys.exit(main())
```

```bash
python3 repro_stall.py
```

**Before** (stock `nightly_202608181633`) — exit code 1:

```
  [OK  ] plain prose (control): 210 chars delivered before flush()
  [STALL] answer containing a comparison: 0 chars delivered before flush()
  [STALL] answer containing markup: 0 chars delivered before flush()
  [STALL] token-by-token, one chunk holds '<': 0 chars delivered before flush()
  [OK  ] a real <think> block (must still separate): 19 chars delivered before flush()

3 case(s) delivered NOTHING -- a client would see HTTP 200
and then no body at all until its read timeout.
```

**After** (same image, patched `reasoning.py`) — exit code 0:

```
  [OK  ] plain prose (control): 210 chars delivered before flush()
  [OK  ] answer containing a comparison: 211 chars delivered before flush()
  [OK  ] answer containing markup: 211 chars delivered before flush()
  [OK  ] token-by-token, one chunk holds '<': 313 chars delivered before flush()
  [OK  ] a real <think> block (must still separate): 19 chars delivered before flush()

all cases delivered content incrementally
```

### End-to-end, against a served model

```bash
python3 -m atom.entrypoints.openai_server --model <model> -tp 4 --port 30001
curl -N -s http://127.0.0.1:30001/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"<name>","stream":true,"max_tokens":512,
       "messages":[{"role":"user","content":"Reply with exactly: if (a < b) return a; and then 200 words about sorting."}]}'
```

Before the fix, `-N` shows no incremental output for a `<`-bearing answer. After, deltas stream normally.

## Behaviour deliberately unchanged

- The 100-character grace period before state 0 emits anything.
- The template-injected-opener path (`starts_thinking` → state 1).
- Marker splitting across chunk boundaries — a trailing partial marker is still held back.

## Tests

Adds `TestNonReasoningOutputIsNotWithheld` to `tests/entrypoints/test_reasoning.py`, covering a
code-bearing answer, a markup-bearing answer, token-by-token streaming where one chunk carries `<`,
a real `<think>` block still separating, a marker split across chunks still being held, and the
template-injected opener.

The three stall tests fail on `main` and pass with the fix. Full suite:

```
$ python3 -m pytest tests/entrypoints/ -q
172 passed, 21 skipped
```

Base: `7229049` (#1943). `black` and `ruff` clean.
