### PR TITLE
fix(dsv4): follow AITER FP4 MQA package move

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1991,7 +1991,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         on a ragged step, a uniform `next_n` fill on a rectangular one. Sync-free
         — real Σ is baked into `cu_seq_q` on device.
         """
-        from aiter.ops.flydsl.kernels.pa_mqa_logits_fp4_prefill import (
+        from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
             compute_prefill_schedule,
             compute_varqlen_windows,
         )
@@ -2111,7 +2111,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 # pure on-device torch (no host sync) and emits a CONSTANT [P, 4]
                 # cta_info with total_ctas == P fixed — so the captured kernel
                 # reads fresh per-fwd contents from a stable pointer.
-                from aiter.ops.flydsl.kernels.pa_mqa_logits_fp4 import (
+                from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4 import (
                     compute_varctx_schedule,
                 )
 
@@ -2222,7 +2222,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             # call: row_to_batch = batch_id_per_token, local_starts = 0,
             # local_ends = visible_end. block_k / parallel_unit_num MUST match
             # the values passed to the kernel in `_score_topk_prefill_fp4`.
-            from aiter.ops.flydsl.kernels.pa_mqa_logits_fp4_prefill import (
+            from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
                 compute_prefill_schedule,
             )
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1853,7 +1853,7 @@ class Indexer(nn.Module):
         fwd). Only when the buffer would exceed budget and the loop actually
         splits does each chunk rebuild the schedule for its rows (cta_info
         encodes absolute row ids, so a slice of the full schedule won't do)."""
-        from aiter.ops.flydsl.kernels.pa_mqa_logits_fp4_prefill import (
+        from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
             compute_prefill_schedule,
             flydsl_pa_mqa_logits_fp4_prefill,
         )
@@ -1968,7 +1968,7 @@ class Indexer(nn.Module):
         `parallel_unit_num` is not passed (it would be ignored); only `block_k`
         must match the value the schedule was built with (see `FP4_MQA_BLOCK_K`).
         """
-        from aiter.ops.flydsl.kernels.pa_mqa_logits_fp4 import (
+        from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4 import (
             flydsl_pa_mqa_logits_fp4,
         )
 
@@ -2102,7 +2102,7 @@ class Indexer(nn.Module):
         so a replay never reads the previous step's stale windows (which faulted
         the bounds-check-off paged-KV load in `pa_mqa_logits_fp4_prefill_kernel_0`).
         """
-        from aiter.ops.flydsl.kernels.pa_mqa_logits_fp4_prefill import (
+        from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
             flydsl_pa_mqa_logits_fp4_prefill,
         )
 

--- a/tests/test_dsv4_aiter_fp4_imports.py
+++ b/tests/test_dsv4_aiter_fp4_imports.py
@@ -4,7 +4,6 @@
 import ast
 from pathlib import Path
 
-
 ATOM_ROOT = Path(__file__).resolve().parents[1] / "atom"
 CURRENT_MODULES = {
     "aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4",
@@ -17,9 +16,12 @@ def _fp4_aiter_imports() -> list[tuple[Path, int, str]]:
     for path in ATOM_ROOT.rglob("*.py"):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom) and node.module:
-                if "pa_mqa_logits_fp4" in node.module:
-                    imports.append((path, node.lineno, node.module))
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module
+                and "pa_mqa_logits_fp4" in node.module
+            ):
+                imports.append((path, node.lineno, node.module))
     return imports
 
 

--- a/tests/test_dsv4_aiter_fp4_imports.py
+++ b/tests/test_dsv4_aiter_fp4_imports.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import ast
+from pathlib import Path
+
+
+ATOM_ROOT = Path(__file__).resolve().parents[1] / "atom"
+CURRENT_MODULES = {
+    "aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4",
+    "aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
+}
+
+
+def _fp4_aiter_imports() -> list[tuple[Path, int, str]]:
+    imports = []
+    for path in ATOM_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                if "pa_mqa_logits_fp4" in node.module:
+                    imports.append((path, node.lineno, node.module))
+    return imports
+
+
+def test_dsv4_fp4_imports_use_current_aiter_package():
+    imports = _fp4_aiter_imports()
+    modules = {module for _, _, module in imports}
+
+    unexpected_imports = [item for item in imports if item[2] not in CURRENT_MODULES]
+    assert not unexpected_imports
+    assert modules == CURRENT_MODULES


### PR DESCRIPTION
## Summary

- update all DeepSeek V4 FP4 MQA decode and prefill imports to the current AITER `kernels.mqa_logits` package
- cover both attention-metadata scheduling and model scorer call sites
- add a CPU-only AST contract test that rejects stale or unexpected FP4 MQA import paths

## Context

ROCm/aiter#4609 moved `pa_mqa_logits_fp4.py` and `pa_mqa_logits_fp4_prefill.py` under `aiter.ops.flydsl.kernels.mqa_logits`. ATOM nightly images build AITER from HEAD, while these six lazy imports still referenced the removed flat paths.

DeepSeek V4 on gfx950 with `--index-cache-dtype fp4` therefore fails during model warmup with:

```text
ModuleNotFoundError: No module named 'aiter.ops.flydsl.kernels.pa_mqa_logits_fp4_prefill'
```

The move retained all five APIs used by ATOM, so no call-site or kernel behavior changes are required.

AITER move: https://github.com/ROCm/aiter/pull/4609
Observed failure: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32338825624/job/96333731386#step:4:1091

## Validation

- executed the new AST import-contract test with Python 3.12
- compiled both changed production modules and the new test with `compileall`
- ran `git diff --check`
- verified the five imported symbols are present in the current AITER modules

No GPU workload was run for this import-only change.
