### PR TITLE
perf(engine): raise GC thresholds in the EngineCore and ModelRunner too

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -15,7 +15,6 @@ Usage:
 import asyncio
 import base64
 import binascii
-import gc
 import io
 import json
 import logging
@@ -39,7 +38,7 @@ from atom.model_engine.arg_utils import EngineArgs
 from atom.model_engine.llm_engine import _load_tokenizer
 from atom.model_engine.multimodal import build_multimodal_inputs
 from atom.model_engine.request import RequestOutput
-from atom.utils import envs
+from atom.utils import tune_gc
 from atom.utils.arg_parser import FlexibleArgumentParser
 
 from .chat_encoders import apply_chat_template, load_custom_message_encoder
@@ -1106,34 +1105,6 @@ async def setup_streaming_request_fanout(
 # ============================================================================
 
 
-def _tune_gc() -> None:
-    """Stretch the interval between full (generation-2) collections.
-
-    Only gen-2 matters: it is stop-the-world and rescans every tracked
-    container, so its cost tracks live objects rather than recent garbage.
-    At c=2048 it was 47% of wall clock while the 23k gen-0/1 passes over the
-    same window cost 0.1s. Raising the thresholds is close to free because
-    reference counting, not the collector, reclaims everything acyclic --
-    peak RSS actually fell, since a larger gen-0 threshold lets more objects
-    die before a collection can promote them.
-
-    gc.freeze() was tried here and removed: once gen-2 stops running there is
-    nothing left for it to make cheaper, and alone it made collections more
-    frequent by emptying gen-2, which is the denominator CPython gates full
-    collections on (long_lived_pending > long_lived_total / 4).
-    """
-    thresholds = envs.ATOM_GC_THRESHOLD
-    if not thresholds:
-        return
-    try:
-        t = tuple(int(x) for x in thresholds.split(","))
-        old = gc.get_threshold()
-        gc.set_threshold(*t)
-        logger.info("[gc] thresholds %s -> %s", old, t)
-    except (ValueError, TypeError):
-        logger.warning("[gc] bad ATOM_GC_THRESHOLD=%r, ignored", thresholds)
-
-
 async def _refresh_metrics_once() -> None:
     if engine is None:
         return
@@ -1161,7 +1132,7 @@ async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown."""
     global _metrics_refresh_task
     logger.info("Server started successfully and ready to accept requests")
-    _tune_gc()
+    tune_gc()
     await _refresh_metrics_once()
     _metrics_refresh_task = asyncio.create_task(_metrics_refresh_loop())
     try:

--- a/atom/model_engine/async_proc.py
+++ b/atom/model_engine/async_proc.py
@@ -25,6 +25,7 @@ from threading import Thread
 import zmq
 import zmq.asyncio
 from aiter.dist.shm_broadcast import MessageQueue
+
 from atom.kv_transfer.disaggregation import KVOutputAggregator
 from atom.utils import (
     get_mp_context,
@@ -34,6 +35,7 @@ from atom.utils import (
     resolve_obj_by_qualname,
     set_process_title,
     shutdown_all_processes,
+    tune_gc,
 )
 from atom.utils.numa_utils import numa_bind_to_node
 
@@ -82,6 +84,12 @@ class AsyncIOProc:
         from atom.utils import enable_orphan_reaping
 
         enable_orphan_reaping()
+
+        # Second-order next to the EngineCore's call but not zero: without it
+        # a freeze still lands at the wave boundary, where the prefill burst
+        # churns enough objects to trigger gen-2 here. Runs before the model
+        # is built so the thresholds cover the startup heap.
+        tune_gc()
 
         # NUMA-local CPU/memory pinning (see atom.utils.numa_utils).
         # Auto-detects the GPU's local node by default; gated by

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -25,6 +25,7 @@ from atom.utils import (
     init_exit_handler,
     make_zmq_socket,
     set_process_title,
+    tune_gc,
 )
 from atom.utils.distributed.utils import (
     stateless_destroy_torch_distributed_process_group,
@@ -221,6 +222,11 @@ class EngineCore:
         from atom.utils import enable_orphan_reaping
 
         enable_orphan_reaping()
+
+        # The process whose GC pauses idle the GPUs: a gen-2 pass here stops
+        # the scheduler, and every ModelRunner worker then has nothing to run.
+        tune_gc()
+
         engine: EngineCore = None
         try:
             if config.pipeline_parallel_size > 1:

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -4,6 +4,7 @@
 import contextlib
 import copy
 import dataclasses
+import gc
 import importlib
 import ipaddress
 import json
@@ -291,6 +292,42 @@ def enable_orphan_reaping(sig: int = signal.SIGKILL) -> bool:
         logger.warning("Parent already exited while arming orphan reaping; exiting.")
         os._exit(1)
     return True
+
+
+def tune_gc() -> None:
+    """Stretch the interval between full (generation-2) collections.
+
+    Only gen-2 matters: it is stop-the-world and rescans every tracked
+    container, so its cost tracks live objects rather than recent garbage,
+    and at high concurrency it dominates while the gen-0/1 passes are noise.
+    Raising the thresholds is close to free because reference counting, not
+    the collector, reclaims everything acyclic -- peak RSS falls too, since a
+    larger gen-0 threshold lets more objects die before a collection can
+    promote them.
+
+    gc.freeze() was tried here and removed: once gen-2 stops running there is
+    nothing left for it to make cheaper, and alone it made collections more
+    frequent by emptying gen-2, which is the denominator CPython gates full
+    collections on (long_lived_pending > long_lived_total / 4).
+
+    Thresholds are per-interpreter, so every process has to call this itself:
+    subprocesses are spawned, and the API server's lifespan runs long after
+    they exist. Called from the API server, each EngineCore and each
+    ModelRunner worker; the EngineCore is the one that matters, since its
+    pauses stall the scheduler and the workers then have nothing to run.
+    """
+    from atom.utils import envs
+
+    thresholds = envs.ATOM_GC_THRESHOLD
+    if not thresholds:
+        return
+    try:
+        t = tuple(int(x) for x in thresholds.split(","))
+        old = gc.get_threshold()
+        gc.set_threshold(*t)
+        logger.info("[gc] thresholds %s -> %s", old, t)
+    except (ValueError, TypeError):
+        logger.warning("[gc] bad ATOM_GC_THRESHOLD=%r, ignored", thresholds)
 
 
 def kill_process_tree(pid: int):

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -194,7 +194,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # --- Profiling & Logging ---
     "ATOM_TORCH_PROFILER_DIR": lambda: os.getenv("ATOM_TORCH_PROFILER_DIR", None),
     # "t0,t1,t2" for gc.set_threshold(); empty keeps CPython's default.
-    # See _tune_gc in api_server.py.
+    # Read independently by the API server, each EngineCore and each
+    # ModelRunner worker -- thresholds are per-interpreter.  The EngineCore is
+    # the one that matters.  See tune_gc in atom/utils/__init__.py.
     "ATOM_GC_THRESHOLD": lambda: os.getenv("ATOM_GC_THRESHOLD", "").strip(),
     "ATOM_PROFILER_MORE": lambda: os.getenv("ATOM_PROFILER_MORE", "0") == "1",
     # When profiling is active, append detailed attention aggregates (sqsq, sqsk, sk)


### PR DESCRIPTION
perf(engine): raise GC thresholds in the EngineCore and ModelRunner too

## What

`ATOM_GC_THRESHOLD` only ever reached the API server. `_tune_gc()` was called
from its FastAPI lifespan, but the EngineCore and ModelRunner processes are
spawned -- a fresh interpreter each, created before the lifespan ever runs -- so
they stayed on CPython's default `700,10,10`. GC thresholds are per-interpreter,
so this moves the helper to `atom.utils.tune_gc` and has every process that runs
a hot loop call it.

Five files, +55/-32. Inert unless `ATOM_GC_THRESHOLD` is set, exactly as before.

## Why

At c=2048 the GPUs go idle for a few hundred milliseconds every few hundred
decode steps, on all four DP ranks at once, with no event of any kind in the
trace for the whole window -- not a HIP call, not a gloo barrier. The period
tracks step count rather than wall clock, which points at allocation. It is a
gen-2 collection in the EngineCore: that process stops, the scheduler stops with
it, and the ModelRunner workers have nothing to run.

Raising the thresholds is close to free here. gen-2 is stop-the-world and
rescans every tracked container, so its cost tracks live objects, and in these
processes almost everything alive is the model, the compiled graph and the
tokenizer -- none of it collectable. Reference counting does the real work; the
collector only breaks cycles.

## Measurements

DeepSeek-V4-Flash, tp=4, `--enable-dp-attention` (dp=4, 512 seqs/rank), ISL/OSL
1024/1024, c=2048, 4096 requests. Baseline is this PR's parent **with
`ATOM_GC_THRESHOLD` already set**, so the API server alone is tuned -- which is
all the current code can do.

|                            | api_server only | all three |
| -------------------------- | --------------- | --------- |
| output throughput          | 29009           | **30018** tok/s |
| duration                   | 144.6s          | 139.7s    |
| GPU busy                   | 91.9%           | **94.2%** |
| idle per rank              | 8.2s            | 5.2s      |
| gaps in 100-700ms, 4 ranks | 56 / 21.3s      | **0**     |

What is left afterwards is one wave-boundary bubble per rank, where the engine
has drained and is waiting on the closed-loop client. It opens on
`dummy_decode[bs=1]` and closes on `prefill[bs=1]`, not on a resumed decode, so
it is a supply gap and not a pause -- and not something this PR can address.

## How the attribution was reached

This needed an ablation rather than a trace, and the first attempt got it wrong,
so it is worth spelling out.

The torch profiler only covers the ModelRunner workers. A pause in the EngineCore
stalls the scheduler, so the workers sit idle waiting for the next step -- which
in a worker-only trace is **indistinguishable** from a pause in the worker
itself, since neither one emits an event. Reading the trace alone, the obvious
conclusion (the worker's own GC) is the wrong one.

Ablated with only the API server tuned as the baseline, gaps of 400-700ms summed
over four ranks:

| EngineCore | worker  | freezes    |
| ---------- | ------- | ---------- |
| default    | default | many       |
| default    | tuned   | **9.25s** — workers alone change nothing |
| tuned      | default | **2.14s** — this is the one that matters |
| tuned      | tuned   | **0s**     |

The worker call covers one freeze per rank at the wave boundary, where the
prefill burst churns enough objects to trigger gen-2 there.

## Not in this PR, but worth flagging

`ATOM_GC_THRESHOLD` has no default, and leaving it unset is expensive on its own:
**18871 tok/s at 73.5% GPU busy**, against 29009 at 91.9% with it set. Any
deployment not setting it explicitly is in the first state. Giving it a non-empty
default would change GC behaviour for every deployment, so it belongs in its own
change -- but it is a bigger lever than this PR.

## Risk

- No behaviour change when `ATOM_GC_THRESHOLD` is unset (`tune_gc()` returns on
  its first line).
- Same value applies to all three process kinds. Their object profiles differ, so
  a future split into separate variables is plausible; there was no evidence for
  it here.
- Long-running behaviour is unverified. The observation window was ~5 minutes of
  load. Delaying collection does not accumulate in these runs -- splitting each
  run into thirds shows no growth in gap size toward the end, and with the
  thresholds raised gen-2 stops firing entirely rather than firing rarely and
  expensively -- but a 30-minute soak watching the RSS slope has not been done.
