### PR TITLE
fix(dsv4): restrict FP4 indexer default to gfx950 only

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1873,15 +1873,23 @@ class Config:
         # Keep ``None`` intact until the model architecture is known so an
         # omitted index-cache option remains distinguishable from an explicit
         # fp8/bf16 override. Native single-node V4 defaults to the FP4 indexer
-        # except on gfx942. Plugin proxy pools and KV-transfer region maps do
-        # not yet describe the separate FP4 scale pool, so those integrations
-        # retain FP8 until their layouts support it. Every other model keeps
-        # the historical KV-cache-dtype default.
+        # on gfx950 only; gfx942 keeps FP8; every other arch (e.g. gfx1250)
+        # inherits ``kv_cache_dtype`` (typically bf16 → FP8 indexer kernels).
+        # Plugin proxy pools and KV-transfer region maps do not yet describe the
+        # separate FP4 scale pool, so those integrations retain FP8 until their
+        # layouts support it. Every other model keeps the historical KV-cache-
+        # dtype default.
         if self.index_cache_dtype is None and is_deepseek_v4:
             if self.plugin_config is None and not self.kv_transfer_config:
                 from aiter.jit.utils.chip_info import get_gfx
 
-                self.index_cache_dtype = "fp8" if get_gfx() == "gfx942" else "fp4"
+                gfx = get_gfx()
+                if gfx == "gfx950":
+                    self.index_cache_dtype = "fp4"
+                elif gfx == "gfx942":
+                    self.index_cache_dtype = "fp8"
+                else:
+                    self.index_cache_dtype = self.kv_cache_dtype
             else:
                 self.index_cache_dtype = "fp8"
         elif self.index_cache_dtype is None:

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -501,7 +501,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             "be 16-byte aligned: the FP8 data region is read with dwordx4 loads"
         )
 
-        # FP4 indexer cache (the native single-node default except on gfx942).
+        # FP4 indexer cache (the native single-node default on gfx950 only).
         # When enabled, the CSA Indexer KV is
         # stored as packed FP4 E2M1 + per-group(32) e8m0 scale in the
         # `pa_mqa_logits_fp4` preshuffle layout (data
@@ -512,7 +512,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # `--index_cache_dtype` remains an explicit override. This is the
         # authoritative decision re-asserted onto every Indexer in
         # `build_kv_cache_tensor`.
-        # `warn=True`: the gfx942 fallback message is emitted here only, since the
+        # `warn=True`: the non-gfx950 fallback message is emitted here only, since the
         # builder is constructed once while `Indexer.__init__` runs per CSA layer.
         # Shared predicate (see `fp4_indexer_enabled`) so the builder and
         # `Indexer.__init__` cannot drift apart.

--- a/atom/model_ops/v4_kernels/__init__.py
+++ b/atom/model_ops/v4_kernels/__init__.py
@@ -122,18 +122,19 @@ def fp4_indexer_enabled(index_cache_dtype: Any, *, warn: bool = False) -> bool:
     mismatch. Lives here rather than in either caller for the same reason as
     `FP4_MQA_*` above.
 
-    gfx942 keeps the FP8 indexer because its FP4 path is unsupported. Pass
-    `warn=True` from the builder only — it runs once, while `Indexer.__init__`
-    runs per CSA layer and would repeat the message.
+    The FP4 mqa-logits / scatter kernels are gfx950 (MI355X / CDNA4) only; on any
+    other arch fall back to the FP8 indexer instead of failing. Pass `warn=True`
+    from the builder only — it runs once, while `Indexer.__init__` runs per CSA
+    layer and would repeat the message.
     """
     if index_cache_dtype != "fp4":
         return False
     gfx = get_gfx()
-    if gfx == "gfx942":
+    if gfx != "gfx950":
         if warn:
             logger.warning(
-                "The DeepSeek-V4 FP4 indexer is unsupported on %r. Falling "
-                "back to the FP8 indexer.",
+                "--index_cache_dtype fp4 requires a gfx950 (MI355X / CDNA4) GPU; "
+                "current arch is %r. Falling back to the FP8 indexer.",
                 gfx,
             )
         return False

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -40,7 +40,7 @@ Defined in `atom/config.py`. The root dataclass that the engine consumes.
 | `kv_cache_block_size` | `int` | `16` | Block size for paged KV cache; must be a multiple of 16 or exactly 1 |
 | `num_kvcache_blocks` | `int` | `-1` | Number of KV cache blocks (`-1` = auto) |
 | `kv_cache_dtype` | `str` | `"bf16"` | KV cache data type (`"bf16"` or `"fp8"`) |
-| `index_cache_dtype` | `str \| None` | `None` | Indexer-cache dtype, resolved after model detection. Native single-node DeepSeek-V4 defaults to `"fp4"` except on gfx942; plugin and KV-transfer integrations retain `"fp8"`. Other models inherit `kv_cache_dtype`. An explicit `"bf16"`, `"fp8"`, or `"fp4"` value is preserved. |
+| `index_cache_dtype` | `str \| None` | `None` | Indexer-cache dtype, resolved after model detection. Native single-node DeepSeek-V4 defaults to `"fp4"` on gfx950, `"fp8"` on gfx942, and `kv_cache_dtype` elsewhere (typically `"bf16"` → FP8 indexer kernels on gfx1250). Plugin and KV-transfer integrations retain `"fp8"`. Other models inherit `kv_cache_dtype`. An explicit `"bf16"`, `"fp8"`, or `"fp4"` value is preserved. |
 | `enable_prefix_caching` | `bool` | `False` | Enable prefix caching to reuse KV blocks across requests sharing the same prefix |
 | `state_checkpoint_interval_tokens` | `int` | `8192` | For models with per-request state (DeepSeek-V4 compressor ring, GDN recurrent state): keep a state checkpoint every N tokens of context, so a later prefix hit can resume there. A prompt shorter than N checkpoints nothing. Must be a multiple of the prefix-cache hash block size; `0` disables checkpoints. See the state-checkpoint section of the [scheduling & KV cache guide](scheduling_kv_cache_guide.md) |
 | `port` | `int` | `8006` | Engine internal communication port |

--- a/tests/test_v4_indexer_defaults.py
+++ b/tests/test_v4_indexer_defaults.py
@@ -124,11 +124,21 @@ def _make_config(
     return config, probe
 
 
-@pytest.mark.parametrize("gfx", ["gfx950", "gfx1250", "future_gfx"])
-def test_native_v4_defaults_indexer_to_fp4(monkeypatch, gfx):
-    config, probe = _make_config(monkeypatch, gfx=gfx)
+def test_native_v4_defaults_indexer_to_fp4_on_gfx950(monkeypatch):
+    config, probe = _make_config(monkeypatch, gfx="gfx950")
 
     assert config.index_cache_dtype == "fp4"
+    assert config.kv_cache_block_size == 256
+    assert probe.calls == 1
+
+
+@pytest.mark.parametrize("gfx", ["gfx1250", "future_gfx"])
+def test_native_v4_defaults_indexer_to_kv_cache_dtype_off_gfx950(
+    monkeypatch, gfx
+):
+    config, probe = _make_config(monkeypatch, gfx=gfx)
+
+    assert config.index_cache_dtype == config.kv_cache_dtype == "fp8"
     assert config.kv_cache_block_size == 256
     assert probe.calls == 1
 
@@ -182,7 +192,7 @@ def test_non_v4_indexer_defaults_to_kv_cache_dtype(monkeypatch):
 
 @pytest.mark.parametrize(
     ("gfx", "expected"),
-    [("gfx942", False), ("gfx950", True), ("gfx1250", True)],
+    [("gfx942", False), ("gfx950", True), ("gfx1250", False)],
 )
 def test_fp4_indexer_runtime_predicate(monkeypatch, caplog, gfx, expected):
     v4_kernels, probe = _load_v4_kernels(monkeypatch, gfx)
@@ -192,7 +202,7 @@ def test_fp4_indexer_runtime_predicate(monkeypatch, caplog, gfx, expected):
 
     assert enabled is expected
     assert probe.calls == 1
-    assert ("unsupported" in caplog.text) is (not expected)
+    assert ("Falling back" in caplog.text) is (not expected)
 
 
 def test_non_fp4_indexer_predicate_does_not_query_arch(monkeypatch):

--- a/tests/test_v4_indexer_defaults.py
+++ b/tests/test_v4_indexer_defaults.py
@@ -133,9 +133,7 @@ def test_native_v4_defaults_indexer_to_fp4_on_gfx950(monkeypatch):
 
 
 @pytest.mark.parametrize("gfx", ["gfx1250", "future_gfx"])
-def test_native_v4_defaults_indexer_to_kv_cache_dtype_off_gfx950(
-    monkeypatch, gfx
-):
+def test_native_v4_defaults_indexer_to_kv_cache_dtype_off_gfx950(monkeypatch, gfx):
     config, probe = _make_config(monkeypatch, gfx=gfx)
 
     assert config.index_cache_dtype == config.kv_cache_dtype == "fp8"


### PR DESCRIPTION
#1971 accidentally enabled the FP4 indexer on gfx1250, causing CUDA graph capture to hang. Restore the pre-#1971 behavior: FP4 is gfx950-only at runtime, and non-gfx950 native V4 defaults inherit kv_cache_dtype (typically bf16).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
