### PR TITLE
perf(dsv4): tune FP4 prefill MQA grid

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -101,6 +101,7 @@ from atom.model_ops.v4_kernels import (
     FP4_MQA_BLOCK_K,
     FP4_MQA_PARALLEL_UNIT_NUM,
     fp4_indexer_enabled,
+    fp4_mqa_prefill_parallel_unit_num,
     hca_compress_paged_offsets,
     write_v4_paged_decode_indices,
     write_v4_paged_prefill_indices,
@@ -2274,20 +2275,17 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             fp4_prefill_max_seq_len = max(int(n_committed_per_seq.max()), 1)
 
             local_starts = torch.zeros_like(visible_end_gpu)
-            # parallel_unit_num is the persistent-grid CTA-count CAP; the
-            # schedule uses as many CTAs as it can up to this P (smaller P ->
-            # larger `safe` chunk-fold -> fewer, more-serial CTAs). It bounds
-            # TWO independent axes:
-            #   - rows: every (row, chunk-split) needs a slot. A prefill fwd has
-            #     one row PER QUERY TOKEN, so P must be >= prefill row count or
-            #     surplus rows are silently dropped (logits stay at the -inf/NaN
-            #     pre-fill -> wrong top-k). This is what `prefill_rows` covers.
-            #   - chunks (context length): the 512 floor keeps enough CTAs to
-            #     split a long context across the GPU even when rows are few
-            #     (matters for decode; harmless here where rows dominate).
-            # max() of both axes -> correct rows AND adequate chunk parallelism.
+            # Prefill uses an eager, shape-specific grid. Small Q needs more K
+            # splits to fill gfx950, while a full 16K-row prefill generally does
+            # not; the selector also caps P by the useful row/chunk pair count
+            # because the FlyDSL kernel launches exactly P CTAs. Decode keeps
+            # its fixed 512-CTA CUDAGraph schedule unchanged.
             prefill_rows = int(visible_end_gpu.shape[0])
-            prefill_parallel_unit_num = max(self._fp4_parallel_unit_num, prefill_rows)
+            prefill_parallel_unit_num = fp4_mqa_prefill_parallel_unit_num(
+                prefill_rows,
+                fp4_prefill_max_seq_len,
+                block_k=self._fp4_block_k,
+            )
             _, prefill_cta_info, prefill_n_ctas = compute_prefill_schedule(
                 batch_id_per_token_gpu.to(torch.int32),
                 local_starts,

--- a/atom/model_ops/v4_kernels/__init__.py
+++ b/atom/model_ops/v4_kernels/__init__.py
@@ -22,6 +22,11 @@ from atom.model_ops.v4_kernels.csa_translate_pack import (
     csa_translate_pack,
     csa_translate_pack_reference,
 )
+from atom.model_ops.v4_kernels.fp4_mqa_schedule import (
+    FP4_MQA_BLOCK_K,
+    FP4_MQA_PARALLEL_UNIT_NUM,
+    fp4_mqa_prefill_parallel_unit_num,
+)
 from atom.model_ops.v4_kernels.fused_compress import (
     fused_compress_attn,
     fused_compress_attn_reference,
@@ -67,6 +72,7 @@ __all__ = [
     "csa_translate_pack",
     "csa_translate_pack_reference",
     "fp4_indexer_enabled",
+    "fp4_mqa_prefill_parallel_unit_num",
     "fused_compress_attn",
     "fused_compress_attn_reference",
     "hca_compress_paged_offsets",
@@ -90,16 +96,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger("atom")
-
-# FP4 indexer persistent-grid schedule params, shared by the decode
-# (`pa_mqa_logits_fp4`) and prefill (`pa_mqa_logits_fp4_prefill`) kernels.
-# The attention metadata builder precomputes each path's cta_info with these
-# and the scorer passes the matching block_k, so layout and grid agree. They
-# live here (rather than in either caller) because both the builder and the
-# model-side scorer must use the SAME values. Mirrors the kernel defaults.
-FP4_MQA_PARALLEL_UNIT_NUM = 512
-FP4_MQA_BLOCK_K = 256
-
 
 def fp4_indexer_enabled(index_cache_dtype: Any, *, warn: bool = False) -> bool:
     """Is the FP4 CSA indexer active? Single source of truth for the predicate.

--- a/atom/model_ops/v4_kernels/fp4_mqa_schedule.py
+++ b/atom/model_ops/v4_kernels/fp4_mqa_schedule.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Shared persistent-grid parameters for the DeepSeek-V4 FP4 indexer."""
+
+FP4_MQA_PARALLEL_UNIT_NUM = 512
+FP4_MQA_BLOCK_K = 256
+
+
+def fp4_mqa_prefill_parallel_unit_num(
+    num_rows: int,
+    max_seq_len: int,
+    *,
+    block_k: int = FP4_MQA_BLOCK_K,
+    min_parallel_unit_num: int = FP4_MQA_PARALLEL_UNIT_NUM,
+) -> int:
+    """Select the gfx950 FP4 prefill persistent-grid size.
+
+    ``compute_prefill_schedule`` launches exactly ``parallel_unit_num`` CTAs,
+    not merely up to that many. Too small a grid folds multiple K chunks onto
+    one CTA; too large a grid launches dummy CTAs after all useful row/chunk
+    pairs have been assigned. C48 measurements show that short Q benefits from
+    more K parallelism, while a full 16K-token prefill already supplies enough
+    row parallelism unless its compressed context is longer than 64 chunks.
+
+    Cap the selected grid by the maximum number of useful (row, K-chunk) pairs
+    so short contexts do not pay for empty CTAs. The returned value is always
+    at least ``num_rows``, which is required for correctness by the scheduler.
+    """
+    if num_rows <= 0:
+        raise ValueError(f"num_rows must be positive, got {num_rows}")
+    if max_seq_len < 0:
+        raise ValueError(f"max_seq_len must be non-negative, got {max_seq_len}")
+    if block_k <= 0:
+        raise ValueError(f"block_k must be positive, got {block_k}")
+    if min_parallel_unit_num <= 0:
+        raise ValueError(
+            "min_parallel_unit_num must be positive, got "
+            f"{min_parallel_unit_num}"
+        )
+
+    chunks_per_row = max(1, (max_seq_len + block_k - 1) // block_k)
+    if num_rows <= 1536:
+        target_splits_per_row = 5
+    elif num_rows >= 16384 and chunks_per_row <= 64:
+        target_splits_per_row = 1
+    else:
+        target_splits_per_row = 2
+
+    target_grid = max(min_parallel_unit_num, num_rows * target_splits_per_row)
+    useful_grid_cap = num_rows * chunks_per_row
+    return min(target_grid, useful_grid_cap)

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -98,10 +98,10 @@ from atom.model_ops.triton_rmsnorm_nw import rmsnorm_nw
 from atom.model_ops.utils import atom_parameter
 from atom.model_ops.v4_kernels import (
     FP4_MQA_BLOCK_K,
-    FP4_MQA_PARALLEL_UNIT_NUM,
     CompressPlan,
     csa_translate_pack,
     fp4_indexer_enabled,
+    fp4_mqa_prefill_parallel_unit_num,
     fused_compress_attn,
     inverse_rope_inplace,
     qk_norm_rope_maybe_quant,
@@ -2014,16 +2014,20 @@ class Indexer(nn.Module):
                 cta_info, n_ctas = full_cta_info, full_n_ctas
             else:
                 # Multi-chunk (logits would exceed budget): rebuild the schedule
-                # for this chunk's rows. Prefill has one row per query token, so
-                # the grid MUST cover this chunk's rows or surplus rows are
-                # dropped (their logits stay -inf -> wrong top-k); the shared CTA
-                # floor keeps a small chunk spread across the GPU.
+                # for this chunk's rows. Use the same shape-specific policy as
+                # the full-batch metadata builder so budget chunking retains the
+                # FP4 grid optimization without launching needless empty CTAs.
+                chunk_rows = chunk_end - chunk_start
                 _, cta_info, n_ctas = compute_prefill_schedule(
                     row_to_batch[chunk_start:chunk_end],
                     rs,
                     re,
                     FP4_MQA_BLOCK_K,
-                    max(FP4_MQA_PARALLEL_UNIT_NUM, chunk_end - chunk_start),
+                    fp4_mqa_prefill_parallel_unit_num(
+                        chunk_rows,
+                        max_seq_len,
+                        block_k=FP4_MQA_BLOCK_K,
+                    ),
                     max_seq_len,
                 )
             # Write-once, NOT -inf-filled: the kernel writes every column in

--- a/tests/test_deepseek_v4_transfer_regions.py
+++ b/tests/test_deepseek_v4_transfer_regions.py
@@ -73,6 +73,7 @@ def _stub_v4_runtime_imports():
     kernels.FP4_MQA_PARALLEL_UNIT_NUM = 1
     for name in (
         "fp4_indexer_enabled",
+        "fp4_mqa_prefill_parallel_unit_num",
         "hca_compress_paged_offsets",
         "write_v4_paged_decode_indices",
         "write_v4_paged_prefill_indices",

--- a/tests/test_fp4_mqa_prefill_schedule.py
+++ b/tests/test_fp4_mqa_prefill_schedule.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+
+_SCHEDULE = runpy.run_path(
+    Path(__file__).parents[1]
+    / "atom"
+    / "model_ops"
+    / "v4_kernels"
+    / "fp4_mqa_schedule.py"
+)
+select_grid = _SCHEDULE["fp4_mqa_prefill_parallel_unit_num"]
+
+
+@pytest.mark.parametrize(
+    ("rows", "seq_len", "expected"),
+    [
+        (1, 256, 1),  # never launch dummy CTAs just to satisfy the 512 floor
+        (256, 512, 512),  # useful row/chunk pairs cap the small-Q target
+        (512, 16384, 2560),  # measured small-Q optimum: 5 CTA/row
+        (1536, 16384, 7680),
+        (1537, 16384, 3074),  # medium Q: 2 CTA/row
+        (8192, 16384, 16384),
+        (16384, 16384, 16384),  # full Q + <=64 chunks: 1 CTA/row
+        (16384, 16640, 32768),  # longer than 64 chunks: restore 2 CTA/row
+    ],
+)
+def test_fp4_prefill_grid_policy(rows, seq_len, expected):
+    assert select_grid(rows, seq_len) == expected
+
+
+@pytest.mark.parametrize(
+    ("rows", "seq_len", "block_k", "minimum"),
+    [
+        (0, 256, 256, 512),
+        (1, -1, 256, 512),
+        (1, 256, 0, 512),
+        (1, 256, 256, 0),
+    ],
+)
+def test_fp4_prefill_grid_policy_rejects_invalid_inputs(
+    rows, seq_len, block_k, minimum
+):
+    with pytest.raises(ValueError):
+        select_grid(
+            rows,
+            seq_len,
+            block_k=block_k,
+            min_parallel_unit_num=minimum,
+        )

--- a/tests/test_v4_indexer_paged_metadata.py
+++ b/tests/test_v4_indexer_paged_metadata.py
@@ -66,6 +66,7 @@ def _stub_v4_runtime_imports():
     kernels.FP4_MQA_PARALLEL_UNIT_NUM = 1
     for name in (
         "fp4_indexer_enabled",
+        "fp4_mqa_prefill_parallel_unit_num",
         "hca_compress_paged_offsets",
         "write_v4_paged_decode_indices",
         "write_v4_paged_prefill_indices",


### PR DESCRIPTION
## Summary

- add a shape-specific persistent-grid selector for the DeepSeek-V4 FP4 prefill MQA logits kernel
- use more K splits for small/medium prefill Q while avoiding dummy CTAs beyond the useful row/chunk pairs
- apply the same policy to both the precomputed full-batch schedule and the budget-chunked fallback
- keep the fixed 512-CTA decode/CUDAGraph schedule unchanged

This is stacked on #1974 because it changes the paged-prefill path introduced there. The base should be changed to `main` after #1974 merges.

## Motivation

`compute_prefill_schedule` launches exactly `parallel_unit_num` CTAs. The previous prefill policy, `max(512, Q)`, preserves row coverage but folds too many context chunks onto each CTA for small Q. Conversely, an unrestricted larger grid can launch dummy CTAs after all useful `(row, K-chunk)` pairs are assigned.

The selector uses five splits per row through Q=1536, two for intermediate Q, and one for a full 16K-row prefill with at most 64 compressed-context chunks. It always covers every query row and caps the grid by the number of useful row/chunk pairs.

## Validation

Unit tests:

```text
python3 -m pytest -q \
  tests/test_fp4_mqa_prefill_schedule.py \
  tests/test_v4_indexer_paged_metadata.py \
  tests/test_deepseek_v4_transfer_regions.py

40 passed
```

Kernel-only A/B on MI355X/gfx950 used alternating launch order, 10-20 warmups, 50-100 samples per arm, schedule construction outside the timed region, and bit-exact checks on representative output cells:

- all 20 aggregate-Q shapes observed in the DSV4-Pro 64K-prefix + 2K-suffix serving logs improved on one GPU; frequency-weighted latency delta: `-3.83%`
- the five most frequent shapes were repeated on all eight GPUs; all 40/40 GPU/shape cells improved
- eight-GPU median deltas: Q512 `-11.02%`, Q768 `-4.83%`, Q1536 `-3.36%`, Q3584 `-2.17%`, Q5376 `-3.49%`

DSV4-Pro TP8/FP4 end-to-end results remain effectively flat. Across four same-seed paired 64K-prefix + 2K-suffix runs, request-throughput delta had median `-0.53%`, mean `+0.88%`, and range `[-1.30%, +5.87%]`; p50 end-to-end latency delta had median `-0.03%`. The FP4 MQA kernel accounts for only about `0.03%` of total benchmark wall time at this workload, so its microsecond-scale gain is below end-to-end noise.

One caveat remains: optimized p99 TTFT was `+3.94%` to `+7.11%` slower and p99 end-to-end latency was `+3.31%` to `+5.60%` slower across those four pairs. The kernel-only median and p90 both improved, so this does not reproduce in the changed kernel itself, but the serving-tail signal needs follow-up with reversed arm order and/or a targeted trace.
