### PR TITLE
fix(dist): pp-aware init no longer breaks raw IPC input pools

### DIFF
--- a/atom/distributed/pp_comm.py
+++ b/atom/distributed/pp_comm.py
@@ -71,17 +71,16 @@ def init_pp_aware_dist_env(
         prefill_context_model_parallel_size=prefill_context_model_parallel_size,
     )
 
-    if tensor_model_parallel_size > 1:
-        tp_grp = get_tp_group()
-        ca_comm = tp_grp.device_communicator.ca_comm
-        signal = torch.zeros(
-            tensor_model_parallel_size * 64,
-            dtype=torch.int64,
-            device=torch.cuda.current_device(),
-        )
-        ca_comm.signal = signal
-        ca_comm.register_input_buffer(signal)
-        ca_comm.buffer = ca_comm._pool["input"].tensor
+    # No per-rank signal/input-buffer registration here (this used to copy
+    # aiter init_dist_env's signal/buffer block). All of it was vestigial --
+    # ca_comm.signal / ca_comm.buffer are never read, and the registration
+    # entry is keyed by the signal tensor's own address, which no allreduce
+    # ever uses as input -- and it made raw IPC input pools unusable
+    # (ROCm/aiter#4921): under PYTORCH_HIP_ALLOC_CONF=expandable_segments:True
+    # the torch.zeros signal is VMM-backed so hipIpcGetMemHandle rejects it,
+    # and the raw_cached input pool has no backing tensor so the
+    # `_pool["input"].tensor` mirror raised. CustomAllreduce.__init__ builds
+    # its own pools and copy-in path; nothing further is needed.
 
     logger.debug(
         "init_pp_aware_dist_env: global_rank=%d tp=%d pp=%d pcp=%d dp=%d world=%d",


### PR DESCRIPTION
## Summary

`init_pp_aware_dist_env` copies the signal/buffer block from aiter's `init_dist_env`:

```python
ca_comm.signal = signal
ca_comm.register_input_buffer(signal)
ca_comm.buffer = ca_comm._pool["input"].tensor
```

That block is being removed from aiter itself in **ROCm/aiter#4924** (fixes ROCm/aiter#4921). This PR removes ATOM's copy, so the PP-aware launch path doesn't keep the same two failure modes after the aiter fix lands:

1. Under `PYTORCH_HIP_ALLOC_CONF=expandable_segments:True`, the `torch.zeros` signal tensor is VMM-backed and `register_input_buffer` dies exporting it via `hipIpcGetMemHandle` (`custom_all_reduce.cu:417`, "invalid argument").
2. Under a raw input pool (`raw_cached=True`, or aiter's new `AITER_CUSTOM_AR_RAW_INPUT_POOL=1`), the pool has no backing `torch.Tensor` and the `.tensor` property raises by design — so any PP-aware launch with a raw pool dies at distributed init.

## Why removal is safe (same evidence chain as ROCm/aiter#4924)

- `ca_comm.signal` / `ca_comm.buffer` are never read anywhere in ATOM or aiter — only written (swept both trees, including `hasattr` gates).
- C++ `register_input_buffer` only inserts a pointer-translation entry keyed by the registered tensor's own address; it is consulted only when an allreduce is invoked *with that exact tensor as input*, which never happens for the signal tensor. `open_ipc_handle`'s cache fills on demand, so no pre-warming is lost.
- aiter's gfx1250 path has skipped the entire equivalent block since its VMM bring-up and works without it.
- `CustomAllreduce.__init__` builds its own meta/input pools and the capture copy-in path; nothing in the block is load-bearing.

## Validation scope — stated plainly

The equivalent removal in aiter's `init_dist_env` (the plain-TP path) is validated on gfx950 hardware in ROCm/aiter#4924: TP4 engines at `gpu_memory_utilization 0.90`, zero IPC errors, correct inference output (numerics checked end-to-end, not just startup), no TPOT regression, on both bare-metal and VF.

**This PR's PP-aware path is fixed by the same argument, not by a PP-mode measurement** — I did not run a `pp_size > 1` launch, and ATOM has no test exercising `init_pp_aware_dist_env`. The change is a removal of code shown to be dead by inspection of both trees; flagging the validation boundary so reviewers can weigh it.

`black` and `ruff` clean.
