### PR TITLE
perf(v4): cut the host work between two forwards

### DIFF
--- a/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
+++ b/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
@@ -378,7 +378,7 @@ class MooncakeConnectorScheduler(KVConnectorSchedulerBase):
             assert (
                 not self.is_producer
             ), "Only the decode (consumer) side handles do_remote_prefill"
-            self._reqs_need_recv[seq.id] = (seq, seq.block_table, slot_index)
+            self._reqs_need_recv[seq.id] = (seq, list(seq.block_table), slot_index)
             params["do_remote_prefill"] = False
             params["local_slot_index"] = slot_index
             # PD incremental: skip leading blocks already in the decode node's
@@ -404,7 +404,7 @@ class MooncakeConnectorScheduler(KVConnectorSchedulerBase):
         # Producer side: queue block_ids for the write listener to look up
         if params.get("do_remote_decode"):
             assert self.is_producer, "Only the producer side handles do_remote_decode"
-            self._reqs_need_save[seq.id] = (seq, seq.block_table, slot_index)
+            self._reqs_need_save[seq.id] = (seq, list(seq.block_table), slot_index)
             logger.debug(
                 "Queued req %s for KV save (%d blocks, slot=%d)",
                 seq.id,
@@ -421,7 +421,7 @@ class MooncakeConnectorScheduler(KVConnectorSchedulerBase):
         seq.kv_transfer_params_output = {
             "do_remote_prefill": True,
             "do_remote_decode": False,
-            "remote_block_ids": seq.block_table.copy(),
+            "remote_block_ids": list(seq.block_table),
             # The consumer's SWA ring slot; the producer keys the SWA region
             # transfer by it. Empty for backends with no SWA state.
             "remote_swa_block_ids": _swa_ring_ids(seq),

--- a/atom/kv_transfer/disaggregation/moriio/moriio_connector.py
+++ b/atom/kv_transfer/disaggregation/moriio/moriio_connector.py
@@ -22,6 +22,7 @@ import msgpack
 import msgspec
 import numpy as np
 import zmq
+from aiter.dist.parallel_state import get_dp_group, get_tp_group
 
 from atom.config import Config
 from atom.kv_transfer.disaggregation.base import (
@@ -29,12 +30,11 @@ from atom.kv_transfer.disaggregation.base import (
     KVConnectorSchedulerBase,
 )
 from atom.kv_transfer.disaggregation.moriio.moriio_common import (
+    _MORIIO_AVAILABLE,
     MoRIIOAgentMetadata,
     MoRIIOConstants,
-    _MORIIO_AVAILABLE,
     get_port_offset,
 )
-from atom.kv_transfer.disaggregation.utils import chunk_tensor_for_rdma
 from atom.kv_transfer.disaggregation.moriio.moriio_engine import MoRIIOWrapper
 from atom.kv_transfer.disaggregation.types import (
     ConnectorMetadata,
@@ -43,6 +43,7 @@ from atom.kv_transfer.disaggregation.types import (
     ReqMeta,
     TransferId,
 )
+from atom.kv_transfer.disaggregation.utils import chunk_tensor_for_rdma
 from atom.model_engine.sequence import Sequence
 from atom.utils import (
     get_open_port,
@@ -50,7 +51,6 @@ from atom.utils import (
     zmq_socket_ctx,
 )
 from atom.utils.network import get_ip
-from aiter.dist.parallel_state import get_dp_group, get_tp_group
 
 if _MORIIO_AVAILABLE:
     from mori.io import (
@@ -959,7 +959,7 @@ class MoRIIOConnectorScheduler(KVConnectorSchedulerBase):
             assert (
                 not self.is_producer
             ), "Only the decode (consumer) side handles do_remote_prefill"
-            self._reqs_need_recv[seq.id] = (seq, seq.block_table)
+            self._reqs_need_recv[seq.id] = (seq, list(seq.block_table))
             params["do_remote_prefill"] = False
             logger.debug(
                 "Queued req %s for remote KV loading (%d blocks)",
@@ -983,7 +983,7 @@ class MoRIIOConnectorScheduler(KVConnectorSchedulerBase):
         seq.kv_transfer_params_output = {
             "do_remote_prefill": True,
             "do_remote_decode": False,
-            "remote_block_ids": seq.block_table.copy(),
+            "remote_block_ids": list(seq.block_table),
             "remote_engine_id": self.engine_id,
             "remote_host": self.host_ip,
             "remote_port": self.handshake_port,

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -1098,7 +1098,7 @@ class BlockManager:
         # go back on the free list, so the intent dies with it.
         if self.paged_state_checkpoints is not None:
             self.paged_state_checkpoints.forget_pending(seq)
-        seq.block_table.clear()
+        del seq.block_table[:]  # `array("i")` has no `.clear()`
         if seq.has_per_req_cache and seq.per_req_cache_group >= 0:
             # No next forward will read a pending fork source after deallocation.
             self.state.release(seq.per_req_cache_group)

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -183,7 +183,11 @@ class BlockManager:
         h = xxhash.xxh64()
         if prefix != -1:
             h.update(prefix.to_bytes(8, "little"))
-        h.update(np.array(token_ids).tobytes())
+        # dtype pinned: `np.array` infers int64 from a list and int32 from an
+        # `array("i")`, so the digest used to depend on the caller's Python
+        # type. int64 is what lists gave, so pinning it leaves every existing
+        # hash where it was.
+        h.update(np.asarray(token_ids, dtype=np.int64).tobytes())
         return h.intdigest()
 
     def complete_previous_state_batch(self) -> None:

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -18,7 +18,12 @@ from atom.model_engine.async_proc import AsyncIOProcManager
 from atom.model_engine.engine_core_protocol import EngineCoreRequestType
 from atom.model_engine.engine_utility import EngineUtilityHandler
 from atom.model_engine.scheduler import DecodeScheduler, PrefillScheduler, Scheduler
-from atom.model_engine.sequence import Sequence, SequenceStatus, get_exit_sequence
+from atom.model_engine.sequence import (
+    Sequence,
+    SequenceStatus,
+    get_exit_sequence,
+    new_block_table,
+)
 from atom.model_engine.state_runtime import StateRuntime
 from atom.utils import (
     envs,
@@ -904,7 +909,7 @@ class PrefillEngineCore(EngineCore):
             for seq in self.scheduler.waiting:
                 if seq.id in self._pending_assignments:
                     assignment = self._pending_assignments.pop(seq.id)
-                    seq.block_table = list(assignment.block_table)
+                    seq.block_table = new_block_table(assignment.block_table)
                     seq.num_cached_tokens = assignment.num_cached_tokens
 
     def _process_engine_step(self):

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -751,7 +751,8 @@ class InputOutputProcessor:
             )
             outputs[req.id] = {
                 "text": output_str,
-                "token_ids": req.completion_token_ids,
+                # `list`, not the `array("i")` slice: this dict is serialized.
+                "token_ids": list(req.completion_token_ids),
                 "logprobs": req.logprobs if req.return_logprobs else None,
                 "latency": req.leave_time - req.arrive_time,
                 "finish_reason": req.leave_reason,

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -751,7 +751,8 @@ class InputOutputProcessor:
             )
             outputs[req.id] = {
                 "text": output_str,
-                # `list`, not the `array("i")` slice: this dict is serialized.
+                # `list`, not the `array("i")` slice: this is what `generate()`
+                # hands a caller, and the storage type is ours to change.
                 "token_ids": list(req.completion_token_ids),
                 "logprobs": req.logprobs if req.return_logprobs else None,
                 "latency": req.leave_time - req.arrive_time,

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -43,7 +43,12 @@ from atom.model_engine.kv_block import STATE_SLOT_CLASS
 from atom.model_engine.page_unit_checkpoint import PagedStateCheckpointSpec
 from atom.model_engine.run_labels import build_run_label
 from atom.model_engine.scheduler import ScheduledBatch, ScheduledBatchOutput
-from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
+from atom.model_engine.sequence import (
+    Sequence,
+    SequenceStatus,
+    SequenceType,
+    new_block_table,
+)
 from atom.model_engine.state_runtime import StateRuntime
 from atom.model_loader.loader import load_model
 from atom.model_ops.attentions.sub_pool_spec import (
@@ -1146,7 +1151,7 @@ class ModelRunner:
         )
         seq.status = SequenceStatus.RUNNING
         seq.type = SequenceType.DECODE
-        seq.block_table = [0]
+        seq.block_table = new_block_table([0])
 
         spec_tokens = {seq.id: np.zeros(mtp_k, dtype=np.int32)} if mtp_k > 0 else None
         dummy_batch = ScheduledBatch(

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1325,10 +1325,11 @@ class ModelRunner:
         )
 
         def _clone_slot(src: dict) -> dict:
-            # Only CpuGpuBuffers are per-forward host-pinned staging buffers that
-            # get overwritten each forward. Everything else (the eager `outputs`
-            # tensor, scalar `mtp_k`, ...) is either unused on the eager PP path
-            # or immutable, so share it by reference.
+            # CpuGpuBuffers are the per-forward staging buffers, and only their
+            # host half can be rewritten while an earlier microbatch's kernels
+            # are still reading. Everything else is immutable, unused on the
+            # eager PP path, or device-only, where the stream orders the writing
+            # kernel after those readers.
             return {
                 k: (v.clone() if isinstance(v, CpuGpuBuffer) else v)
                 for k, v in src.items()

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -476,10 +476,17 @@ class ScheduledBatch:
             else:
                 offset = seq.num_tokens - num_rejected[i] - num
             staged.extend(seq.token_ids[offset : offset + num])
-        self.scheduled_tokens = np.empty(total_tokens_num, dtype=np.int32)
-        # Whole-array, not `[: len(staged)]`: a sequence too short to fill its
-        # window makes `staged` short, and only this form refuses it.
-        self.scheduled_tokens[:] = staged
+        # Checked here because nothing downstream will: the array below wraps
+        # whatever length was staged, and a sequence too short to fill its
+        # window would otherwise leave the batch quietly short.
+        if len(staged) != total_tokens_num:
+            raise ValueError(
+                f"staged {len(staged)} tokens for a batch of {total_tokens_num}: "
+                "a sequence is shorter than the window scheduled for it"
+            )
+        # Wrapped, not copied into a fresh array: consumers only ever read this
+        # or rebind it, so the staging buffer can be the buffer.
+        self.scheduled_tokens = np.frombuffer(staged, dtype=np.int32)
 
         if num_spec_step > 0 and scheduled_spec_decode_tokens is not None:
             # One row per sequence, in batch order. The caller's dict is keyed

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -30,7 +30,12 @@ from atom.config import Config
 from atom.kv_transfer.disaggregation import KVConnectorOutput
 from atom.model_engine.block_manager import BlockManager
 from atom.model_engine.request import RequestOutput
-from atom.model_engine.sequence import Sequence, SequenceStatus, SequenceType
+from atom.model_engine.sequence import (
+    Sequence,
+    SequenceStatus,
+    SequenceType,
+    new_token_ids,
+)
 from atom.model_engine.state_runtime import (
     DEFAULT_STATE_RUNTIME,
     StateMaintenanceOps,
@@ -381,9 +386,11 @@ class ScheduledBatch:
         # `context_lens` is set further down, once `num_cached_tokens` is known:
         # a chunked prefill's context ends at this chunk, not at the whole
         # prompt, so `seq.num_tokens` is only right for decode.
-        self.num_rejected = np.asarray(
-            [seq.num_rejected for seq in seqs.values()], dtype=np.int32
-        )
+        # Kept as a list too: the offset loop below reads it per sequence, and
+        # `arr[i]` builds a numpy scalar where a list index does not. The list
+        # is what `np.asarray` consumes anyway, so holding onto it is free.
+        num_rejected = [seq.num_rejected for seq in seqs.values()]
+        self.num_rejected = np.asarray(num_rejected, dtype=np.int32)
         self.num_bonus = np.asarray(
             [seq.num_bonus_tokens for seq in seqs.values()], dtype=np.int32
         )
@@ -458,38 +465,55 @@ class ScheduledBatch:
             dtype=np.int32,
         )
 
-        # Compute token offsets: prefill uses num_cached_tokens, decode uses existing formula
-        self.scheduled_tokens = np.empty(total_tokens_num, dtype=np.int32)
-        pos = 0
+        # Each sequence's window, staged into one array rather than assigned
+        # per sequence: a numpy slice-assign costs ~245ns of dispatch whatever
+        # its length, and at decode a window is a single token. `extend`
+        # between two `array("i")` is a memcpy. 4x at bs=256.
+        staged = new_token_ids()
         for i, (seq, num) in enumerate(zip(seqs.values(), num_scheduled_tokens)):
             if seq.type == SequenceType.PREFILL:
                 offset = self.num_cached_tokens[i]
             else:
-                offset = seq.num_tokens - self.num_rejected[i] - num
-            self.scheduled_tokens[pos : pos + num] = seq.token_ids[
-                offset : offset + num
-            ]
-            pos += num
+                offset = seq.num_tokens - num_rejected[i] - num
+            staged.extend(seq.token_ids[offset : offset + num])
+        self.scheduled_tokens = np.empty(total_tokens_num, dtype=np.int32)
+        # Whole-array, not `[: len(staged)]`: a sequence too short to fill its
+        # window makes `staged` short, and only this form refuses it.
+        self.scheduled_tokens[:] = staged
 
         if num_spec_step > 0 and scheduled_spec_decode_tokens is not None:
-            # One row per sequence, in batch order, zero-filled where a sequence
-            # has no drafts yet — which is every sequence entering decode
-            # straight off its own prefill. The caller's dict is keyed by
-            # request id and only holds sequences that DO have drafts, so
-            # densifying it with `list(...values())` drops those rows and shifts
-            # every later one onto the wrong sequence. Consumers index this by
-            # batch position (`prepare_input_ids`), not by request id, so that
-            # shift silently feeds one sequence another's draft tokens, and
-            # raises IndexError once the array is short enough.
-            self.scheduled_spec_decode_tokens = np.zeros(
-                (len(seqs), num_spec_step), dtype=np.int32
-            )
-            for i, req_id in enumerate(self.req_ids):
+            # One row per sequence, in batch order. The caller's dict is keyed
+            # by request id and holds only sequences that DO have drafts, so
+            # densifying it with `list(...values())` drops the others and
+            # shifts every later row onto the wrong sequence — consumers index
+            # this by batch position (`prepare_input_ids`), which turns that
+            # shift into one sequence silently reading another's drafts.
+            #
+            # Rows are collected and written in one assign: a per-row write
+            # costs ~245ns of dispatch against a row this short, so the marshal
+            # was mostly dispatch (3.7x at bs=256). Rows that are not
+            # full width are padded rather than dropping the batch back to the
+            # per-row form, because at a large batch a sequence joins decode
+            # nearly every step and would take every other sequence with it.
+            no_drafts = np.zeros(num_spec_step, dtype=np.int32)
+            rows = []
+            for req_id in self.req_ids:
                 drafts = scheduled_spec_decode_tokens.get(req_id)
-                if drafts is None or drafts.size == 0:
-                    continue
-                width = min(drafts.size, num_spec_step)
-                self.scheduled_spec_decode_tokens[i, :width] = drafts[:width]
+                if drafts is not None and drafts.size == num_spec_step:
+                    rows.append(drafts)
+                elif drafts is None or drafts.size == 0:
+                    rows.append(no_drafts)
+                else:  # short or long: onto a row of its own, never the shared one
+                    padded = no_drafts.copy()
+                    padded[: min(drafts.size, num_spec_step)] = drafts[:num_spec_step]
+                    rows.append(padded)
+            # `concatenate` rejects an empty list, which a warmup batch is.
+            flat = (
+                np.concatenate(rows, dtype=np.int32)
+                if rows
+                else np.empty(0, dtype=np.int32)
+            )
+            self.scheduled_spec_decode_tokens = flat.reshape(len(seqs), num_spec_step)
         self.block_tables = [
             seq.block_table for seq in seqs.values() if seq.block_table
         ]

--- a/atom/model_engine/sequence.py
+++ b/atom/model_engine/sequence.py
@@ -177,8 +177,6 @@ class Sequence:
         self.stop_strings = sampling_params.stop_strings
         # Same type as `token_ids`, because the stop check compares a slice of
         # that against these and an `array("i")` never equals a list.
-        # Same type as `token_ids`, because the stop check compares a slice of
-        # that against these and an `array("i")` never equals a list.
         self.stop_token_sequences = [
             new_token_ids(s) for s in (stop_token_sequences or [])
         ]

--- a/atom/model_engine/sequence.py
+++ b/atom/model_engine/sequence.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+import array
 from collections.abc import Callable
 from copy import copy
 from enum import Enum, auto
@@ -10,6 +11,18 @@ from typing import Any
 import numpy as np
 
 from atom.sampling_params import SamplingParams
+
+
+def new_block_table(block_ids=()) -> array.array:
+    """A sequence's physical block ids.
+
+    An `array("i")` rather than a list because every forward marshals these
+    into the int32 `block_tables` buffer, where a list costs one CPython int
+    unboxing per block (~17k per step at 50 seqs x 100k ctx) and an array is a
+    memcpy. It behaves as a list for append/pop/index/len/iterate; it has no
+    `.clear()` (use `del bt[:]`) and no `.copy()` (use `list(bt)`).
+    """
+    return array.array("i", block_ids)
 
 
 class SequenceStatus(Enum):
@@ -127,7 +140,7 @@ class Sequence:
         # garbage sampled tokens from intermediate chunks and to skip the
         # scheduler's Phase 1 scan when no partials exist.
         self.is_partial_prefill = False
-        self.block_table = []
+        self.block_table = new_block_table()
         # Per-request cache slot index (filled by BlockManager.allocate()).
         # -1 = unallocated. The slot indexes into the per-req cache tensors
         # owned by ModelRunner (e.g. mamba_k_cache for GDN).

--- a/atom/model_engine/sequence.py
+++ b/atom/model_engine/sequence.py
@@ -3,7 +3,6 @@
 
 import array
 from collections.abc import Callable
-from copy import copy
 from enum import Enum, auto
 from itertools import count
 from typing import Any
@@ -11,6 +10,24 @@ from typing import Any
 import numpy as np
 
 from atom.sampling_params import SamplingParams
+
+
+def new_token_ids(token_ids=()) -> array.array:
+    """A sequence's token ids.
+
+    An `array("i")` rather than a list for two reasons that both scale with
+    context. The scheduler copies a slice of this into the flat
+    `scheduled_tokens` buffer every step -- a whole chunk of it on a prefill --
+    and from a list that is one CPython int unboxing per token, 0.28 ms for a
+    16k chunk against 0.001 ms from an array. And a list of 100k ids costs
+    3.4 MiB of boxed ints where the array costs 0.38.
+
+    Behaves as a list for append/pop/index/len/iterate/slice-delete, and holds
+    negative ids (the exit sentinel is -1). It does NOT compare equal to a
+    list, which is why `stop_token_sequences` below is converted too, and why
+    `BlockManager.compute_hash` pins its dtype.
+    """
+    return array.array("i", token_ids)
 
 
 def new_block_table(block_ids=()) -> array.array:
@@ -82,7 +99,7 @@ class Sequence:
         self.external_request_id = request_id
         self.status = SequenceStatus.WAITING
         self.type = SequenceType.DUMMY
-        self.token_ids = copy(token_ids)
+        self.token_ids = new_token_ids(token_ids)
         self.last_token = token_ids[-1]
         self.num_draft_tokens = num_draft_tokens
         # `has_per_req_cache=True` means this seq's attention type maintains
@@ -158,7 +175,13 @@ class Sequence:
         self.max_tokens = sampling_params.max_tokens
         self.ignore_eos = sampling_params.ignore_eos
         self.stop_strings = sampling_params.stop_strings
-        self.stop_token_sequences = stop_token_sequences or []
+        # Same type as `token_ids`, because the stop check compares a slice of
+        # that against these and an `array("i")` never equals a list.
+        # Same type as `token_ids`, because the stop check compares a slice of
+        # that against these and an `array("i")` never equals a list.
+        self.stop_token_sequences = [
+            new_token_ids(s) for s in (stop_token_sequences or [])
+        ]
         self.is_first_decode = False
         # Set to True by Scheduler.postprocess after BlockManager.hash_blocks
         # has registered the prompt blocks for prefix caching. The trigger has

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -12,7 +12,7 @@ from aiter.dist.parallel_state import get_tp_group
 
 from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_ops.attention_mha import PagedAttentionImpl, use_pa_decode_bf16_asm
-from atom.utils import CpuGpuBuffer, envs
+from atom.utils import CpuGpuBuffer, envs, pack_rows, upload_numpy
 from atom.utils.block_convert import (
     block_table_convert_triton,
     kv_indices_generate_triton,
@@ -1019,29 +1019,26 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         ctx_lens = cached_prefix_lens + new_lens
         total_kv = int(ctx_lens.sum())
 
-        max_blocks = max(
-            (len(block_tables_host[first_req + i]) for i in range(ub_num_reqs)),
-            default=1,
-        )
-        bt = np.zeros((ub_num_reqs, max_blocks), dtype=np.int32)
-        for i in range(ub_num_reqs):
-            row = block_tables_host[first_req + i]
-            bt[i, : len(row)] = row
+        # Indexed, not sliced: a short slice would leave `bt` rows unwritten.
+        rows = [block_tables_host[first_req + i] for i in range(ub_num_reqs)]
+        max_blocks = max((len(row) for row in rows), default=1)
+        bt = np.empty((ub_num_reqs, max_blocks), dtype=np.int32)  # pack_rows clears
+        pack_rows(bt, rows)
 
         cu_k = np.zeros(ub_num_reqs + 1, dtype=np.int32)
         np.cumsum(ctx_lens.astype(np.int32), out=cu_k[1:])
 
         ub_attn.has_cached = True
         ub_attn.total_kv = total_kv
-        ub_attn.context_lens = torch.from_numpy(ctx_lens.astype(np.int32)).to(
-            device, non_blocking=True
-        )
-        ub_attn.block_tables = torch.from_numpy(bt).to(device, non_blocking=True)
-        ub_attn.cu_seqlens_k = torch.from_numpy(cu_k).to(device, non_blocking=True)
+        ub_attn.context_lens = upload_numpy(ctx_lens.astype(np.int32), device)
+        # `bt` is [requests x blocks], so a long enough context puts it past the
+        # pageable limit and the copy would start synchronizing.
+        ub_attn.block_tables = upload_numpy(bt, device)
+        ub_attn.cu_seqlens_k = upload_numpy(cu_k, device)
         ub_attn.seq_starts = torch.zeros(ub_num_reqs, dtype=torch.int32, device=device)
-        ub_attn.num_cached_tokens = torch.from_numpy(
-            cached_prefix_lens.astype(np.int32)
-        ).to(device, non_blocking=True)
+        ub_attn.num_cached_tokens = upload_numpy(
+            cached_prefix_lens.astype(np.int32), device
+        )
         ub_attn.max_seqlen_k = int(ctx_lens.max())
 
     def prepare_decode(self, batch: ScheduledBatch, bs: int):

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -917,9 +917,11 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         # from previous steps). A straddled/ubatch request's FULL visible K is
         # num_cached + (its tokens in this ubatch), so the gather must include it.
         self._tbo_prefill_state = TokenSplitPrefillState(
-            block_tables=[
-                np.asarray(bt, dtype=np.int32) for bt in batch.block_tables[:bs]
-            ],
+            # Handed over as-is: the reader wants `len(row)` and a slice
+            # assignment, which the rows serve directly. Referencing is safe
+            # because BlockManager only appends between steps, and stash and
+            # read are both inside this one forward.
+            block_tables=batch.block_tables[:bs],
             cu_tokens=np.asarray(
                 self.model_runner.forward_vars["cu_seqlens_q"].np[: bs + 1],
                 dtype=np.int64,

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -306,9 +306,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                 **i64_kwargs,
             )
             var[f"{p}block_tables"] = CpuGpuBuffer(
-                ub_max_bs,
-                self.max_num_blocks_per_seq // self.block_ratio,
-                **i32_kwargs,
+                ub_max_bs, self.block_table_cols, **i32_kwargs
             )
             var[f"{p}cu_seqlens_q"] = CpuGpuBuffer(ub_max_bs + 1, **i32_kwargs)
             var[f"{p}cu_seqlens_q"].cpu.copy_(

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -490,9 +490,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 **i64_kwargs,
             )
             var[f"{p}block_tables"] = CpuGpuBuffer(
-                ub_max_bs,
-                self.max_num_blocks_per_seq // self.block_ratio,
-                **i32_kwargs,
+                ub_max_bs, self.block_table_cols, **i32_kwargs
             )
             var[f"{p}cu_seqlens_q"] = CpuGpuBuffer(ub_max_bs + 1, **i32_kwargs)
             var[f"{p}cu_seqlens_q"].cpu.copy_(

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -34,7 +34,7 @@ from atom.model_ops.attention_mla import (
     mla_dcp_decode_is_persistent,
     mla_dcp_kernel_num_heads,
 )
-from atom.utils import CpuGpuBuffer, envs
+from atom.utils import CpuGpuBuffer, envs, upload_numpy
 from atom.utils.block_convert import (
     kv_indices_generate_triton,
     mtp_prepare_decode_mla_kernel,
@@ -1282,14 +1282,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             total_tokens = int(cu[-1])
             # cu doubles as gather_kv_b_proj kv_indptr (block_size=1 → block
             # indptr == token indptr) and flash_attn cu_seqlens_k.
-            kv_indptr_list.append(
-                torch.from_numpy(cu).pin_memory().to(self.device, non_blocking=True)
-            )
-            kv_indices_list.append(
-                torch.from_numpy(chunk_indices)
-                .pin_memory()
-                .to(self.device, non_blocking=True)
-            )
+            kv_indptr_list.append(upload_numpy(cu, self.device))
+            kv_indices_list.append(upload_numpy(chunk_indices, self.device))
             cu_seqlens_k_list.append(kv_indptr_list[-1])  # same tensor
             total_tokens_list.append(total_tokens)
             max_seqlen_k_list.append(int(per_seq_chunk_lens.max(initial=0)))
@@ -1396,9 +1390,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
             cu = np.zeros(bs + 1, dtype=np.int32)
             np.cumsum(global_chunk_len, out=cu[1:])
-            cu_seqlens_k_list.append(
-                torch.from_numpy(cu).pin_memory().to(self.device, non_blocking=True)
-            )
+            cu_seqlens_k_list.append(upload_numpy(cu, self.device))
             total_tokens_list.append(int(cu[-1]))
             max_seqlen_k_list.append(int(global_chunk_len.max(initial=0)))
             padded_local_chunk_seq_lens_list.append(plc.astype(np.int32).tolist())
@@ -1419,11 +1411,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 if slot_segments
                 else np.empty(0, np.int32)
             )
-            local_slot_ids_list.append(
-                torch.from_numpy(slot_ids)
-                .pin_memory()
-                .to(self.device, non_blocking=True)
-            )
+            local_slot_ids_list.append(upload_numpy(slot_ids, self.device))
 
         return MLAChunkContextMetadata(
             kv_indptr=[],
@@ -2314,9 +2302,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             c_len = c_hi - c_lo
             cu = np.full(ub_num_reqs + 1, c_len, dtype=np.int32)
             cu[0] = 0
-            kv_indptr_list.append(
-                torch.from_numpy(cu).pin_memory().to(device, non_blocking=True)
-            )
+            kv_indptr_list.append(upload_numpy(cu, device))
             kv_indices_list.append(prefix_slots[c_lo:c_hi])
             total_tokens_list.append(c_len)
             max_seqlen_k_list.append(c_len)

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -265,6 +265,8 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         self.max_num_blocks_per_seq = (
             config.max_model_len + self.block_size - 1
         ) // self.block_size
+        # Width of every `block_tables` buffer, and of anything gathered from one.
+        self.block_table_cols = self.max_num_blocks_per_seq // self.block_ratio
         # Per-rank attention head count. eagle.propose's mid-step path reads
         # this to gate the `do_attn_metadata_update` branch. Subclasses that
         # need a kernel-minimum-padded count set `self.padded_num_attention_heads`
@@ -280,9 +282,7 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
             "slot_mapping": CpuGpuBuffer(self.max_num_batched_tokens, **i64_kwargs),
             "context_lens": CpuGpuBuffer(self.max_bs, **i32_kwargs),
             "block_tables": CpuGpuBuffer(
-                self.max_bs,
-                self.max_num_blocks_per_seq // self.block_ratio,
-                **i32_kwargs,
+                self.max_bs, self.block_table_cols, **i32_kwargs
             ),
             "cu_seqlens_q": CpuGpuBuffer(self.max_bs + 1, **i32_kwargs),
             "cu_seqlens_k": CpuGpuBuffer(self.max_bs + 1, **i32_kwargs),

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -25,7 +25,7 @@ from atom.model_engine.state_runtime import StateTransfer
 from atom.model_ops.attention_mla import MLAModules
 from atom.model_ops.attentions.sub_pool_spec import SubPoolSpec
 from atom.model_ops.dcp_ops import dcp_local_index, dcp_owner_rank
-from atom.utils import CpuGpuBuffer
+from atom.utils import CpuGpuBuffer, pack_rows
 from atom.utils.forward_context import AttentionMetaData, AttnState
 from atom.utils.tbo.ubatch_splitting import (
     UBatchSlice,
@@ -306,29 +306,8 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         sequences than the batch carries.
         """
         var = self.model_runner.forward_vars
-        block_tables = var["block_tables"].np
         rows = batch.block_tables if limit is None else batch.block_tables[:limit]
-        # One memset over the rows in play, not one per row.
-        block_tables[: len(rows)] = 0
-        # Rows go in through a memoryview: numpy's slice assignment costs ~250ns
-        # of dispatch per row whatever the row's length, which at a large batch
-        # of short rows is the whole marshal. `.cast` is what makes flattening
-        # safe — it refuses a non-contiguous buffer, where `reshape(-1)` would
-        # hand back a copy and drop every write.
-        flat = memoryview(block_tables).cast("B").cast("i")
-        cols = block_tables.shape[1]  # stride comes from what is written
-        base = 0
-        for block_table in rows:
-            n = len(block_table)
-            # A flat write has no row edge: where the numpy form raised, this
-            # one would land the overflow in the next request's row.
-            if n > cols:
-                raise ValueError(
-                    f"block table of {n} blocks exceeds the {cols}-column "
-                    "block_tables buffer"
-                )
-            flat[base : base + n] = block_table
-            base += cols
+        pack_rows(var["block_tables"].np, rows)
 
     def _mrope_cpu_view(self, num_tokens: int) -> np.ndarray:
         return (

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -299,12 +299,20 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         self.model_runner.forward_vars.update(attn_metadata)
         self.has_sliding_window = hasattr(hf_config, "sliding_window")
 
-    def prepare_block_tables(self, batch: ScheduledBatch):
+    def prepare_block_tables(self, batch: ScheduledBatch, limit: int | None = None):
+        """Marshal the batch's block tables into `forward_vars["block_tables"]`.
+
+        `limit` caps how many rows are taken, for callers scheduling fewer
+        sequences than the batch carries.
+        """
         var = self.model_runner.forward_vars
         block_tables = var["block_tables"].np
-        for i, block_table in enumerate(batch.block_tables):
-            block_tables[i] = 0
-            block_tables[i, : len(block_table)] = block_table
+        rows = batch.block_tables if limit is None else batch.block_tables[:limit]
+        # One memset over the rows in play, not one per row. `zip` stops at
+        # `rows`, so nothing past the batch is read or written.
+        block_tables[: len(rows)] = 0
+        for out, block_table in zip(block_tables, rows):
+            out[: len(block_table)] = block_table
 
     def _mrope_cpu_view(self, num_tokens: int) -> np.ndarray:
         return (

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -308,11 +308,27 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         var = self.model_runner.forward_vars
         block_tables = var["block_tables"].np
         rows = batch.block_tables if limit is None else batch.block_tables[:limit]
-        # One memset over the rows in play, not one per row. `zip` stops at
-        # `rows`, so nothing past the batch is read or written.
+        # One memset over the rows in play, not one per row.
         block_tables[: len(rows)] = 0
-        for out, block_table in zip(block_tables, rows):
-            out[: len(block_table)] = block_table
+        # Rows go in through a memoryview: numpy's slice assignment costs ~250ns
+        # of dispatch per row whatever the row's length, which at a large batch
+        # of short rows is the whole marshal. `.cast` is what makes flattening
+        # safe — it refuses a non-contiguous buffer, where `reshape(-1)` would
+        # hand back a copy and drop every write.
+        flat = memoryview(block_tables).cast("B").cast("i")
+        cols = block_tables.shape[1]  # stride comes from what is written
+        base = 0
+        for block_table in rows:
+            n = len(block_table)
+            # A flat write has no row edge: where the numpy form raised, this
+            # one would land the overflow in the next request's row.
+            if n > cols:
+                raise ValueError(
+                    f"block table of {n} blocks exceeds the {cols}-column "
+                    "block_tables buffer"
+                )
+            flat[base : base + n] = block_table
+            base += cols
 
     def _mrope_cpu_view(self, num_tokens: int) -> np.ndarray:
         return (

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -251,9 +251,10 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     for FP8 ragged. Shared by MQA logits and top-k with `next_n=1`; unlike
     the output allocation length, this is NOT capped by `index_topk`."""
     block_tables_per_token: torch.Tensor | None = None
-    """int32 GPU `[decode_rows, max_blocks]` — compressed-cache block table
-    expanded from sequences to query rows. It lets the existing aiter MQA
-    kernels treat every query row as an independent batch with `next_n=1`."""
+    """int32 GPU `[decode_rows, block_table_cols]` — compressed-cache block
+    table expanded from sequences to query rows by a device-side gather. It
+    lets the existing aiter MQA kernels treat every query row as an
+    independent batch with `next_n=1`."""
     kv_indices_hca: torch.Tensor | None = None
     """[hca_indptr[T]] int32 GPU — packed paged offsets for HCA layers
     (HCA compress at slice head + SWA window prefix at tail; layer-invariant)."""
@@ -3581,27 +3582,33 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             in_seq = token_ids - cu[bids]
             rect_dst = bids * full_q + (full_q - ragged_lens_np[bids]) + in_seq
             n_committed_per_token_np[rect_dst] = csa_visible_end_per_token
-            mqa_row_to_batch_np = np.full(rect_bs * full_q, -1, dtype=np.int32)
-            mqa_row_to_batch_np[: scheduled_bs * full_q] = np.repeat(
-                np.arange(scheduled_bs, dtype=np.int32), full_q
-            )
+            # Rows are `full_q` slots per sequence, so row r serves seq
+            # r // full_q, and the rows past the batch are the tail.
+            mqa_valid_rows = scheduled_bs * full_q
+            mqa_row_to_batch_gpu = torch.arange(
+                mqa_valid_rows, dtype=torch.int32, device=self.device
+            ).div_(full_q, rounding_mode="floor")
         else:
-            mqa_row_to_batch_np = np.full(
-                n_committed_per_token_np.shape[0], -1, dtype=np.int32
-            )
-            mqa_row_to_batch_np[:T] = batch_id_per_token_np[:T]
+            # One row per query token, so the row -> seq map is the one
+            # already staged for this forward.
+            mqa_valid_rows = T
+            mqa_row_to_batch_gpu = batch_id_per_token_gpu[:T]
 
         # Expand block tables per query row so the unchanged aiter paged-MQA
-        # kernels can run once with shape `[decode_rows, 1, ...]`.
-        block_tables_np_full = var[f"{buf_prefix_ubatch}block_tables"].np[:scheduled_bs]
-        mqa_bt_buf = var[f"{buf_prefix_ubatch}v4_block_tables_per_token"]
+        # kernels can run once with shape `[decode_rows, 1, ...]`. Source and
+        # index are both on the device, so the gather runs there instead of the
+        # host shipping the expansion; the rows it skips are the tail.
+        mqa_bt = var[f"{buf_prefix_ubatch}v4_block_tables_per_token"]
         mqa_rows = n_committed_per_token_np.shape[0]
-        block_tables_per_token_np = mqa_bt_buf.np[:mqa_rows]
-        block_tables_per_token_np.fill(0)
-        valid_mqa_rows = mqa_row_to_batch_np >= 0
-        block_tables_per_token_np[valid_mqa_rows] = block_tables_np_full[
-            mqa_row_to_batch_np[valid_mqa_rows]
-        ]
+        block_tables_per_token_gpu = mqa_bt[:mqa_rows]
+        torch.index_select(
+            var[f"{buf_prefix_ubatch}block_tables"].gpu,
+            0,
+            mqa_row_to_batch_gpu,
+            out=block_tables_per_token_gpu[:mqa_valid_rows],
+        )
+        if mqa_valid_rows < mqa_rows:  # an empty `zero_` still costs a dispatch
+            block_tables_per_token_gpu[mqa_valid_rows:].zero_()
         # HCA: ragged, per-token len = actual_swa_count + n_committed_hca
         hca_per_tok = actual_swa_count_np + n_committed_hca_per_token
         hca_indptr_np = np.zeros(T_pad + 1, dtype=np.int32)
@@ -3619,7 +3626,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             f"{buf_prefix_ubatch}v4_n_committed_per_token",
             n_committed_per_token_np,
         )
-        block_tables_per_token_gpu = mqa_bt_buf.copy_to_gpu(mqa_rows)
         hca_indptr_gpu = self._stage(
             f"{buf_prefix_ubatch}v4_kv_indptr_hca", hca_indptr_np
         )
@@ -4426,8 +4432,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         bufs["v4_kv_indptr_csa"] = CpuGpuBuffer(T_dec + 1, **i32)
         bufs["v4_kv_indptr_hca"] = CpuGpuBuffer(T_dec + 1, **i32)
         bufs["v4_n_committed_per_token"] = CpuGpuBuffer(T_dec, **i32)
-        _bt_cols = self.model_runner.forward_vars["block_tables"].np.shape[1]
-        bufs["v4_block_tables_per_token"] = CpuGpuBuffer(T_dec, _bt_cols, **i32)
+        # Device-only, and as wide as the `block_tables` it gathers from: a host
+        # mirror would be `T_dec * cols * 4` of pinned memory nothing writes.
+        bufs["v4_block_tables_per_token"] = torch.zeros(
+            T_dec, self.block_table_cols, **i32
+        )
         # Where each decode token's own KV row goes, one buffer per compress
         # class. The fused SWA write reads these rather than deriving the row,
         # so the window layout stays inside this repo (see
@@ -4572,7 +4581,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         bs = self.max_bs
         win = self.window_size
         T_dec = self.max_decode_tokens
-        max_blocks = self.max_num_blocks_per_seq // self.block_ratio
 
         for ub_idx in range(self._NUM_TBO_UBATCHES):
             p = f"ub{ub_idx}_"
@@ -4580,7 +4588,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             # for the non-TBO path; cloned here so each ubatch slices its own).
             bufs[f"{p}positions"] = CpuGpuBuffer(T_dec, **i64)
             bufs[f"{p}context_lens"] = CpuGpuBuffer(bs, **i32)
-            bufs[f"{p}block_tables"] = CpuGpuBuffer(bs, max_blocks, **i32)
+            bufs[f"{p}block_tables"] = CpuGpuBuffer(bs, self.block_table_cols, **i32)
             bufs[f"{p}cu_seqlens_q"] = CpuGpuBuffer(bs + 1, **i32)
 
             # V4 decode metadata buffers.
@@ -4597,8 +4605,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             bufs[f"{p}v4_kv_indptr_csa"] = CpuGpuBuffer(T_dec + 1, **i32)
             bufs[f"{p}v4_kv_indptr_hca"] = CpuGpuBuffer(T_dec + 1, **i32)
             bufs[f"{p}v4_n_committed_per_token"] = CpuGpuBuffer(T_dec, **i32)
-            bufs[f"{p}v4_block_tables_per_token"] = CpuGpuBuffer(
-                T_dec, max_blocks, **i32
+            bufs[f"{p}v4_block_tables_per_token"] = torch.zeros(
+                T_dec, self.block_table_cols, **i32
             )
             for name in _DEST_ROW_BUFFERS.values():
                 bufs[f"{p}{name}"] = CpuGpuBuffer(T_dec, **i32)

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -104,7 +104,7 @@ from atom.model_ops.v4_kernels import (
     write_v4_paged_decode_indices,
     write_v4_paged_prefill_indices,
 )
-from atom.utils import CpuGpuBuffer
+from atom.utils import CpuGpuBuffer, upload_numpy
 from atom.utils.forward_context import (
     AttentionMetaData,
     AttnState,
@@ -3688,14 +3688,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
         attn_metadata.swa_dest_rows = dest_rows
 
-        # `skip_prefix_len_csa` is no longer materialized on the decode path —
+        # `skip_prefix_len_csa` is not materialized on the decode path —
         # `csa_translate_pack` is invoked with `window_size = self.window_size`
         # so the kernel derives `skip = min(positions[t]+1, win)` inline,
-        # which is identical to the value we used to write here
-        # (`actual_swa_count_np`). Saves a CPU write + H2D per fwd. The
-        # `v4_skip_prefix_len_csa` forward_var is retained for the (unrelated)
-        # prefill path where skip depends on `chunk_start` and cannot be
-        # derived from positions alone.
+        # which is identical to the value this used to write
+        # (`actual_swa_count_np`). Saves a CPU write + H2D per fwd. Prefill
+        # cannot derive it from positions (skip depends on `chunk_start`) and
+        # uploads its own tensor in `_build_paged_prefill_meta`.
 
         # ----- Stash on attn_metadata for V4Attention.forward consumption -----
         # batch_id_per_token + n_committed_csa_per_seq already set in
@@ -3866,19 +3865,20 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         hca_total = int(hca_indptr_np[T])
 
         # ----- H2D: 4 indptrs + 2 per-seq scalars -----
-        # All non-blocking; sources are per-call temp np arrays, so not a
-        # cross-ubatch race source (the shared-pinned-buffer race is handled by
-        # the stream sync before build_ubatch_prefill_metadata's finally).
-        chunk_start_per_seq_gpu = torch.from_numpy(chunk_start_per_seq_np).to(
-            device, non_blocking=True
+        # Sources are per-call temp np arrays, so not a cross-ubatch race source
+        # (the shared-pinned-buffer race is handled by the stream sync before
+        # build_ubatch_prefill_metadata's finally). Via `upload_numpy` because
+        # the indptrs are `T + 1` long: 64 KB at mnbt 16384, over the pageable
+        # cliff at mnbt 131072.
+        chunk_start_per_seq_gpu = upload_numpy(chunk_start_per_seq_np, device)
+        n_committed_hca_per_seq_gpu = upload_numpy(
+            np.asarray(n_committed_hca_per_seq_np[:scheduled_bs], dtype=np.int32),
+            device,
         )
-        n_committed_hca_per_seq_gpu = torch.from_numpy(
-            np.asarray(n_committed_hca_per_seq_np[:scheduled_bs], dtype=np.int32)
-        ).to(device, non_blocking=True)
-        ext_indptr = torch.from_numpy(ext_indptr_np).to(device, non_blocking=True)
-        swa_indptr = torch.from_numpy(swa_indptr_np).to(device, non_blocking=True)
-        csa_indptr = torch.from_numpy(csa_indptr_np).to(device, non_blocking=True)
-        hca_indptr = torch.from_numpy(hca_indptr_np).to(device, non_blocking=True)
+        ext_indptr = upload_numpy(ext_indptr_np, device)
+        swa_indptr = upload_numpy(swa_indptr_np, device)
+        csa_indptr = upload_numpy(csa_indptr_np, device)
+        hca_indptr = upload_numpy(hca_indptr_np, device)
 
         # Reuse already-on-GPU tensors (populated upstream).
         # Cast positions to int32: production var["positions"] is int64 but
@@ -3947,9 +3947,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # `kv_indices_prefix_csa[indptr[t]:indptr[t+1]]`; the SWA prefix
         # (length `skip`) occupies the slice TAIL, written by the builder.
         # Matches the per-token prefix_swa_count vector we just computed on CPU.
-        skip_csa_gpu = torch.from_numpy(prefix_swa_count_np).to(
-            device, non_blocking=True
-        )
+        skip_csa_gpu = upload_numpy(prefix_swa_count_np, device)
 
         # ----- Publish on attn_metadata -----
         attn_metadata.kv_indices_extend = ext_indices[:ext_total]
@@ -4506,11 +4504,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # Under CUDAGraph capture they land in the graph's private pool
         # and replay reuses the same address; eager keeps the standard
         # caching-allocator fast path.
-        # Per-token write offset consumed by `csa_translate_pack` (decode path
-        # fills with `window_size`; prefill path will fill with per-token
-        # prior_swa_count once the new dual-source kernel lands). Allocated
-        # `mnbt` (worst-case prefill) so prefill writes don't overflow.
-        bufs["v4_skip_prefix_len_csa"] = CpuGpuBuffer(mnbt, **i32)
 
         # Compress plan buffers (per-ratio) — pre-allocated for CUDAGraph
         # plan-tensor address stability. `make_compress_plans(..., plan_buffers=)`

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -101,7 +101,6 @@ from atom.model_ops.v4_kernels import (
     FP4_MQA_BLOCK_K,
     FP4_MQA_PARALLEL_UNIT_NUM,
     fp4_indexer_enabled,
-    hca_compress_paged_offsets,
     write_v4_paged_decode_indices,
     write_v4_paged_prefill_indices,
 )
@@ -2353,7 +2352,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # the other two are switched off. They used to be aliased onto this same
         # buffer because all three classes named the same row, which stopped
         # being true when the window started interleaving by class.
-        swa_indices_buf = var["v4_kv_indices_swa"].gpu
+        swa_indices_buf = var["v4_kv_indices_swa"]
         dest_rows = self._dest_row_buffers()
         write_v4_paged_decode_indices(
             state_slot_per_seq=attn_metadata.state_slot_out[:bs],
@@ -3632,40 +3631,20 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # batch_id_per_token + n_committed_csa_per_seq already staged in
         # `_attach_v4_per_fwd_meta`.
 
-        # ----- HCA compress paged offsets (CPU numpy, vectorized) -----
-        block_tables_np_full = var[f"{buf_prefix_ubatch}block_tables"].np[:scheduled_bs]
+        # `ctx/128` HCA entries per token: building this section in numpy and
+        # shipping it was the largest host cost here. The kernel below fills it
+        # from block tables already on the device, tiling each slice exactly
+        # with the SWA prefix, so nothing pre-fills the buffer.
+        hca_indices_buf = var[f"{buf_prefix_ubatch}v4_kv_indices_hca"]
         hca_total_indices = int(hca_indptr_np[T])
-        hca_indices_np = np.full(hca_total_indices, -1, dtype=np.int32)
-        # n_committed_hca_per_seq is int32; gather stays int32.
-        n_h_per_token = n_committed_hca_per_seq[batch_id_per_token_np[:T]]
-        total_hca_entries = int(n_h_per_token.sum())
-        if total_hca_entries > 0:
-            token_indices = np.repeat(np.arange(T, dtype=np.int32), n_h_per_token)
-            cu_n_h = np.zeros(T + 1, dtype=np.int32)
-            np.cumsum(n_h_per_token, out=cu_n_h[1:], dtype=np.int32)
-            entry_offsets = np.arange(total_hca_entries, dtype=np.int32) - np.repeat(
-                cu_n_h[:T], n_h_per_token
-            )
-            # HCA compress section occupies the slice HEAD (offset 0); the SWA
-            # prefix segment sits at the tail, written below by
-            # write_v4_paged_decode_indices.
-            write_pos = hca_indptr_np[token_indices] + entry_offsets
-            bid_expanded = batch_id_per_token_np[token_indices]
-            # Each physical block packs hca_rows_per_block rows (compressor
-            # cache view [num_blocks, hca_rows_per_block, head_dim]); shared
-            # with the prefill kernel + regression test via
-            # hca_compress_paged_offsets.
-            hca_indices_np[write_pos] = hca_compress_paged_offsets(
-                entry_offsets,
-                bid_expanded,
-                block_tables_np_full,
-                envelope_rows,
-                self.hca_rows_per_block,
-            )
-        # Stage to GPU (HCA compress section at head; SWA prefix scattered below).
-        hca_indices_gpu = self._stage(
-            f"{buf_prefix_ubatch}v4_kv_indices_hca", hca_indices_np
+        # `_stage` carried this bound; without it an over-long slice would be a
+        # silent out-of-bounds device write.
+        assert hca_total_indices <= hca_indices_buf.shape[0], (
+            f"V4 buffer 'v4_kv_indices_hca' too small: need {hca_total_indices}, "
+            f"have {hca_indices_buf.shape[0]}. Increase the bound in "
+            f"_alloc_v4_metadata_buffers."
         )
+        hca_indices_gpu = hca_indices_buf[:hca_total_indices]
 
         # ----- Write SWA / CSA / HCA window-prefix paged offsets (1 kernel) -----
         # Kernel computes `n = min(positions[t]+1, win)` and ring-index
@@ -3675,8 +3654,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # persistent forward_vars buffers — no allocator churn (the prior
         # `index_copy_` chain raced under MTP-3 long-prefill; this kernel
         # also fixes that, see skill `debug-agent-locate-kernel`).
-        swa_indices_gpu = var[f"{buf_prefix_ubatch}v4_kv_indices_swa"].gpu
-        csa_indices_gpu = var[f"{buf_prefix_ubatch}v4_kv_indices_csa"].gpu
+        swa_indices_gpu = var[f"{buf_prefix_ubatch}v4_kv_indices_swa"]
+        csa_indices_gpu = var[f"{buf_prefix_ubatch}v4_kv_indices_csa"]
         dest_rows = self._dest_row_buffers(buf_prefix_ubatch)
         write_v4_paged_decode_indices(
             # The slot array must come from the SAME buffer set as
@@ -3703,6 +3682,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             T=T,
             win=win,
             geometry=self.pool_geometry,
+            # Same buffer set as batch_id_per_token, for the reason above.
+            hca_block_tables=var[f"{buf_prefix_ubatch}block_tables"].gpu,
+            hca_rows_per_block=self.hca_rows_per_block,
         )
         attn_metadata.swa_dest_rows = dest_rows
 
@@ -4371,7 +4353,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         return buf.copy_to_gpu(n)
 
     def _alloc_v4_metadata_buffers(self) -> None:
-        """Pre-allocate every CpuGpuBuffer the V4 metadata builder writes into.
+        """Pre-allocate every buffer the V4 metadata builder writes into.
+
+        A `CpuGpuBuffer` where the host writes and the device reads, a bare
+        device tensor where both ends are kernels — the pinned host half is
+        the expensive part and only the staged buffers earn it.
 
         Bounds:
           - per-seq:        max_bs
@@ -4423,9 +4409,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # level data — downstream kernels do
         # `data[batch_id_per_token[t]]` instead of carrying a [T]-sized copy.
         T_dec = self.max_decode_tokens
-        bufs["v4_kv_indices_swa"] = CpuGpuBuffer(T_dec * win, **i32)
-        bufs["v4_kv_indices_csa"] = CpuGpuBuffer(T_dec * (win + self.index_topk), **i32)
-        bufs["v4_kv_indices_hca"] = CpuGpuBuffer(
+        # Device-only: written and read entirely by kernels, so a host mirror
+        # would be tens of MB of pinned memory nothing writes.
+        bufs["v4_kv_indices_swa"] = torch.zeros(T_dec * win, **i32)
+        bufs["v4_kv_indices_csa"] = torch.zeros(T_dec * (win + self.index_topk), **i32)
+        bufs["v4_kv_indices_hca"] = torch.zeros(
             T_dec * (win + self.max_committed_hca), **i32
         )
         bufs["v4_kv_indptr_swa"] = CpuGpuBuffer(T_dec + 1, **i32)
@@ -4594,11 +4582,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             # V4 decode metadata buffers.
             bufs[f"{p}v4_meta_state_slot_out"] = CpuGpuBuffer(bs, **i32)
             bufs[f"{p}v4_meta_state_slot_in"] = CpuGpuBuffer(bs, **i32)
-            bufs[f"{p}v4_kv_indices_swa"] = CpuGpuBuffer(T_dec * win, **i32)
-            bufs[f"{p}v4_kv_indices_csa"] = CpuGpuBuffer(
+            bufs[f"{p}v4_kv_indices_swa"] = torch.zeros(T_dec * win, **i32)
+            bufs[f"{p}v4_kv_indices_csa"] = torch.zeros(
                 T_dec * (win + self.index_topk), **i32
             )
-            bufs[f"{p}v4_kv_indices_hca"] = CpuGpuBuffer(
+            bufs[f"{p}v4_kv_indices_hca"] = torch.zeros(
                 T_dec * (win + self.max_committed_hca), **i32
             )
             bufs[f"{p}v4_kv_indptr_swa"] = CpuGpuBuffer(T_dec + 1, **i32)

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -4040,15 +4040,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         """Populate `forward_vars["block_tables"]` from the batch and return
         the GPU view sliced to `scheduled_bs` rows.
 
-        Mirrors `CommonAttentionBuilder.prepare_block_tables` but is invoked
-        unconditionally (parent only calls it when has_cached).
+        Defers the marshal to `CommonAttentionBuilder.prepare_block_tables`,
+        but is invoked unconditionally (parent only calls it when has_cached).
         """
-        var = self.model_runner.forward_vars
-        block_tables_np = var["block_tables"].np
-        for i, block_table in enumerate(batch.block_tables[:scheduled_bs]):
-            block_tables_np[i] = 0
-            block_tables_np[i, : len(block_table)] = block_table
-        return var["block_tables"].copy_to_gpu(scheduled_bs)
+        self.prepare_block_tables(batch, limit=scheduled_bs)
+        return self.model_runner.forward_vars["block_tables"].copy_to_gpu(scheduled_bs)
 
     def _populate_state_slot_mappings(
         self, batch: ScheduledBatch, scheduled_bs: int, return_cpu: bool = False

--- a/atom/model_ops/v4_kernels/paged_decode_indices.py
+++ b/atom/model_ops/v4_kernels/paged_decode_indices.py
@@ -27,10 +27,12 @@ Caller contract:
   where `n_compress[t]` is 0 for SWA, `min(n_committed_csa, index_topk)`
   for CSA, `n_committed_hca` for HCA.
 - `swa_indices` / `csa_indices` / `hca_indices` capacity ≥ corresponding
-  indptr[T]; this kernel only writes the SWA-prefix segment at the slice
-  tail `[indptr[t+1] - n, indptr[t+1])` per token. The compress section is
-  filled elsewhere (HCA: numpy fill in caller, CSA: `csa_translate_pack`
-  per layer).
+  indptr[T]; this kernel writes the SWA-prefix segment at the slice tail
+  `[indptr[t+1] - n, indptr[t+1])` per token, and — given
+  `hca_block_tables` — the HCA compress section at the head, which then
+  tile the slice exactly. CSA's head is filled per layer by
+  `csa_translate_pack`; a caller that does not pass block tables fills
+  HCA's itself.
 """
 
 import numpy as np
@@ -45,6 +47,7 @@ from atom.model_ops.attentions.v4_pool_geometry import (
     UnifiedPoolGeometry,
 )
 from atom.model_ops.v4_kernels.pool_index import (
+    compress_row,
     served_window_params,
     window_constexprs,
     window_row,
@@ -90,6 +93,8 @@ def _v4_paged_decode_indices_kernel(
     dense_ring_start,  # per-class window bases; the only terms the boundary moves
     csa_ring_start,
     hca_ring_start,
+    hca_block_tables_ptr,  # [bs, bt_stride_bs] int32 — only read if HCA_FROM_BT
+    hca_bt_stride_bs,
     win: tl.constexpr,  # window_size — max SWA prefix slots
     BLOCK_N: tl.constexpr,  # next_pow2(win)
     HAS_CSA: tl.constexpr,  # caller has layers of this class to serve
@@ -107,6 +112,9 @@ def _v4_paged_decode_indices_kernel(
     HCA_SLOT_ROWS: tl.constexpr,
     HCA_RING_STRIDE: tl.constexpr,
     HCA_RUN_ROWS: tl.constexpr,
+    HCA_FROM_BT: tl.constexpr,  # also fill the HCA compress section
+    HCA_ENVELOPE_ROWS: tl.constexpr,
+    HCA_ROWS_PER_BLOCK: tl.constexpr,
 ):
     """One program per token. Writes `n = min(positions[t]+1, win)` pool rows
     to the SWA prefix segment, placed at the TAIL of each token's slice in the
@@ -224,6 +232,29 @@ def _v4_paged_decode_indices_kernel(
                 HCA_RUN_ROWS,
             ),
         )
+        if HCA_FROM_BT:
+            # Compress section, at the slice HEAD. Its length is not passed in:
+            # the slice was sized `n + n_committed_hca[bid]`, so what the SWA
+            # prefix leaves is exactly the committed count — the two tile the
+            # slice, which is why nothing pre-fills it.
+            hca_start = tl.load(hca_indptr_ptr + t)
+            n_hca = hca_end - hca_start - n
+            # Entry k is row k % HCA_ROWS_PER_BLOCK of physical block
+            # k // HCA_ROWS_PER_BLOCK, matching the compressor's cache view.
+            bt_row = bid * hca_bt_stride_bs
+            for j in tl.range(0, n_hca, BLOCK_N):
+                k = j + i
+                k_mask = k < n_hca
+                bt = tl.load(
+                    hca_block_tables_ptr + bt_row + k // HCA_ROWS_PER_BLOCK,
+                    mask=k_mask,
+                    other=0,
+                )
+                tl.store(
+                    hca_indices_ptr + hca_start + k,
+                    compress_row(bt, k % HCA_ROWS_PER_BLOCK, HCA_ENVELOPE_ROWS),
+                    mask=k_mask,
+                )
 
 
 @mark_trace
@@ -242,6 +273,8 @@ def write_v4_paged_decode_indices(
     T: int,
     win: int,
     geometry: UnifiedPoolGeometry,
+    hca_block_tables: torch.Tensor | None = None,
+    hca_rows_per_block: int = 0,
     prefix: str = "",
 ) -> None:
     """In-place fill SWA / CSA / HCA window-prefix offsets via a single
@@ -285,9 +318,17 @@ def write_v4_paged_decode_indices(
                                    DIFFERENT rows now, so a caller that only
                                    needs one can no longer alias them all onto
                                    it and let the writes agree.
-      hca_indices:         [>=hca_indptr[T]] int32 OUT — same semantics; HCA
-                                   compress section (slice head) filled in the
-                                   caller via numpy fill.
+      hca_indices:         [>=hca_indptr[T]] int32 OUT — same semantics, plus
+                                   the compress section at the slice head when
+                                   `hca_block_tables` is given. Opt-in because
+                                   the bridges fill that section themselves,
+                                   from a different row formula.
+      hca_block_tables:    [bs, cols] int32 — the source for that fill. Must
+                                   be numbered like `batch_id_per_token`: in a
+                                   TBO ubatch, the ubatch-sliced buffer, not
+                                   the global one.
+      hca_rows_per_block:  int — `block_size // HCA_RATIO`, the rows the
+                                   compressor packs per physical block.
       dest_rows:           {ratio: [>=T] int32 OUT} — the row token `t`'s own
                                    KV goes to in a layer of that class. Needed
                                    for every class that is both served by the
@@ -322,6 +363,11 @@ def write_v4_paged_decode_indices(
     has_hca = hca_indices is not None
     assert has_csa == (csa_indptr is not None)
     assert has_hca == (hca_indptr is not None)
+    hca_from_bt = hca_block_tables is not None
+    if hca_from_bt:
+        assert has_hca, "hca_block_tables given without an HCA buffer to fill"
+        assert hca_rows_per_block > 0
+        assert hca_block_tables.dim() == 2
 
     # A class that is off — not in the geometry, or one the caller did not ask
     # for — still needs a pointer and a value for every `constexpr`, because
@@ -363,6 +409,8 @@ def write_v4_paged_decode_indices(
         dense.ring_start,
         csa.ring_start,
         hca.ring_start,
+        hca_block_tables if hca_from_bt else swa_indices,
+        hca_block_tables.stride(0) if hca_from_bt else 0,
         win=win,
         BLOCK_N=BLOCK_N,
         HAS_CSA=has_csa,
@@ -371,6 +419,9 @@ def write_v4_paged_decode_indices(
         **window_constexprs(dense, "DENSE_"),
         **window_constexprs(csa, "CSA_"),
         **window_constexprs(hca, "HCA_"),
+        HCA_FROM_BT=hca_from_bt,
+        HCA_ENVELOPE_ROWS=geometry.envelope_rows,
+        HCA_ROWS_PER_BLOCK=hca_rows_per_block,
     )
 
 

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2820,7 +2820,10 @@ class DeepseekV4Attention(nn.Module):
                 sin.reshape(sin.shape[0], -1),
                 num_groups=G,
                 quant_group_size=128,
-                scale_shuffle=False,
+                # Row-major [S, G, Ks], which is how `x_scale` is allocated
+                # above and how the mxscale GEMM below reads it. The other
+                # layouts fill the same bytes in a shuffled order.
+                scale_layout="row",
                 x_fp8=x_fp8,
                 x_scale=x_scale,
             )

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -134,7 +134,7 @@ def get_device_indices(
 def mark_spliting_op(
     is_custom: bool,
     gen_fake: Callable[..., Any] | None = None,
-    mutates_args: list[str] = [],
+    mutates_args: list[str] | None = None,
 ):
     def decorator(func):
         if not is_custom:
@@ -144,7 +144,7 @@ def mark_spliting_op(
         direct_register_custom_op(
             op_name=func.__name__,
             op_func=func,
-            mutates_args=mutates_args,
+            mutates_args=mutates_args if mutates_args is not None else [],
             fake_impl=gen_fake,
         )
         registered_op = getattr(torch.ops.aiter, func.__name__)

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -633,20 +633,22 @@ def pack_rows(dst: np.ndarray, rows: Sequence) -> None:
         # `.cast("i")` would reinterpret the bits of any other dtype rather
         # than convert them, so this must be checked and not assumed.
         raise TypeError(f"pack_rows needs an int32 destination, got {dst.dtype}")
-    n_rows = len(rows)
-    # One memset over the rows in play, not one per row.
-    dst[:n_rows] = 0
+    # Both dimensions are checked here because a flat write has no edge in
+    # either: an over-wide row would land in the next row, and an over-long
+    # batch would run off the end with only a memoryview structure error to
+    # say so. The numpy form this replaces raised on both.
+    n_rows, (max_rows, cols) = len(rows), dst.shape
+    if n_rows > max_rows:
+        raise ValueError(f"{n_rows} rows exceed the {max_rows}-row destination")
+    dst[:n_rows] = 0  # one memset over the rows in play, not one per row
     flat = memoryview(dst).cast("B").cast("i")
-    cols = dst.shape[1]  # stride comes from what is written
     base = 0
     for row in rows:
         n = len(row)
-        # A flat write has no row edge: where the numpy form raised, this one
-        # would land the overflow in the next row.
         if n > cols:
             raise ValueError(f"row of {n} exceeds the {cols}-column destination")
         flat[base : base + n] = row
-        base += cols
+        base += cols  # the destination's stride, not the row's length
 
 
 class CpuGpuBuffer:

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 from functools import lru_cache
 from multiprocessing.context import ForkContext, SpawnContext
 from multiprocessing.process import BaseProcess
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -614,6 +614,39 @@ def upload_numpy(arr: np.ndarray, device, *, non_blocking: bool = True) -> torch
         return torch.from_numpy(arr).to(device, non_blocking=non_blocking)
     _warn_oversize_upload(arr.nbytes)
     return torch.from_numpy(arr).pin_memory().to(device, non_blocking=non_blocking)
+
+
+def pack_rows(dst: np.ndarray, rows: Sequence) -> None:
+    """Left-align ragged `rows` into a 2-D int32 `dst`, zero-filling the rest.
+
+    A numpy row assign costs ~245ns on MI355X and does not vary with the row's
+    length until the bytes start to matter (~500 ints), so a marshal of short
+    rows is dispatch and nothing else -- 4.0 ms at 16k rows. Through one
+    `memoryview` of the destination the same write is ~46ns.
+
+    `.cast` is what makes the flattening safe: it refuses a non-contiguous
+    buffer, where `reshape(-1)` would hand back a copy and silently drop every
+    write. Rows must export a buffer of int32 -- an `array("i")` or an int32
+    ndarray -- since that is what makes each write a memcpy.
+    """
+    if dst.dtype != np.int32:
+        # `.cast("i")` would reinterpret the bits of any other dtype rather
+        # than convert them, so this must be checked and not assumed.
+        raise TypeError(f"pack_rows needs an int32 destination, got {dst.dtype}")
+    n_rows = len(rows)
+    # One memset over the rows in play, not one per row.
+    dst[:n_rows] = 0
+    flat = memoryview(dst).cast("B").cast("i")
+    cols = dst.shape[1]  # stride comes from what is written
+    base = 0
+    for row in rows:
+        n = len(row)
+        # A flat write has no row edge: where the numpy form raised, this one
+        # would land the overflow in the next row.
+        if n > cols:
+            raise ValueError(f"row of {n} exceeds the {cols}-column destination")
+        flat[base : base + n] = row
+        base += cols
 
 
 class CpuGpuBuffer:

--- a/atom/utils/__init__.py
+++ b/atom/utils/__init__.py
@@ -15,11 +15,12 @@ import socket
 import sys
 import tempfile
 import time
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from functools import lru_cache
 from multiprocessing.context import ForkContext, SpawnContext
 from multiprocessing.process import BaseProcess
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -132,7 +133,7 @@ def get_device_indices(
 
 def mark_spliting_op(
     is_custom: bool,
-    gen_fake: Optional[Callable[..., Any]] = None,
+    gen_fake: Callable[..., Any] | None = None,
     mutates_args: list[str] = [],
 ):
     def decorator(func):
@@ -167,14 +168,12 @@ def get_hf_text_config(config: PretrainedConfig):
         return config
 
 
-def get_mp_context() -> Union[ForkContext, SpawnContext]:
+def get_mp_context() -> ForkContext | SpawnContext:
     """Get a multiprocessing context with 'spawn' start method."""
     return multiprocessing.get_context("spawn")
 
 
-def set_process_title(
-    name: str, suffix: str = "", prefix: Optional[str] = None
-) -> None:
+def set_process_title(name: str, suffix: str = "", prefix: str | None = None) -> None:
     """Set the current process title (comm/cmdline) for ps/top/rocm-smi.
 
     rocm-smi --showpids reads the process ``comm`` field, which defaults to the
@@ -393,7 +392,7 @@ def _get_open_port() -> int:
             return s.getsockname()[1]
 
 
-@lru_cache()
+@lru_cache
 def get_zmq_base_path() -> str:
     return tempfile.gettempdir()
 
@@ -419,7 +418,7 @@ def get_engine_client_zmq_addr(local_only: bool, host: str, port: int = 0) -> st
     )
 
 
-def close_sockets(sockets: Sequence[Union[zmq.Socket, zmq.asyncio.Socket]]):
+def close_sockets(sockets: Sequence[zmq.Socket | zmq.asyncio.Socket]):
     for sock in sockets:
         if sock is not None:
             sock.close(linger=0)
@@ -446,7 +445,7 @@ def split_zmq_path(path: str) -> tuple[str, str, str]:
     return scheme, host, port
 
 
-def make_zmq_path(scheme: str, host: str, port: Optional[int] = None) -> str:
+def make_zmq_path(scheme: str, host: str, port: int | None = None) -> str:
     """Make a ZMQ path from its parts.
 
     Args:
@@ -464,15 +463,15 @@ def make_zmq_path(scheme: str, host: str, port: Optional[int] = None) -> str:
     return f"{scheme}://{host}:{port}"
 
 
-# Adapted from: https://github.com/sgl-project/sglang/blob/v0.4.1/python/sglang/srt/utils.py#L783 # noqa: E501
+# Adapted from: https://github.com/sgl-project/sglang/blob/v0.4.1/python/sglang/srt/utils.py#L783
 def make_zmq_socket(
-    ctx: Union[zmq.asyncio.Context, zmq.Context],  # type: ignore[name-defined]
+    ctx: zmq.asyncio.Context | zmq.Context,  # type: ignore[name-defined]
     path: str,
     socket_type: Any,
-    bind: Optional[bool] = None,
-    identity: Optional[bytes] = None,
-    linger: Optional[int] = None,
-) -> Union[zmq.Socket, zmq.asyncio.Socket]:  # type: ignore[name-defined]
+    bind: bool | None = None,
+    identity: bytes | None = None,
+    linger: int | None = None,
+) -> zmq.Socket | zmq.asyncio.Socket:  # type: ignore[name-defined]
     """Make a ZMQ socket with the proper bind/connect semantics."""
 
     mem = psutil.virtual_memory()
@@ -547,9 +546,9 @@ def init_exit_handler(self: Any):
 def zmq_socket_ctx(
     path: str,
     socket_type: Any,
-    bind: Optional[bool] = None,
+    bind: bool | None = None,
     linger: int = 0,
-    identity: Optional[bytes] = None,
+    identity: bytes | None = None,
 ) -> Iterator[zmq.Socket]:
     """Context manager for a ZMQ socket"""
 
@@ -563,12 +562,66 @@ def zmq_socket_ctx(
         ctx.destroy(linger=linger)
 
 
+# A pageable host-to-device copy larger than the driver's staging buffer cannot
+# be handed off and returned from: the host waits for it, and because it goes
+# out on the current stream it waits behind everything already queued there.
+# Under it, the driver stages the bytes and returns immediately.
+#
+# Measured on MI355X with 4 ms of work in flight, host time charged to the copy:
+#
+#     bytes    pageable   pin_memory()   persistent pinned
+#     64 KB    0.018 ms      0.021 ms         0.022 ms
+#    400 KB    0.037 ms      0.167 ms         0.014 ms
+#    512 KB    0.032 ms          --           0.014 ms
+#    560 KB    3.047 ms          --           0.015 ms   <-- cliff
+#    800 KB    3.058 ms      0.168 ms         0.031 ms
+#
+# Three things follow. Below the cliff every route costs about the same, so the
+# one that allocates nothing wins. Above it pageable is ~100x worse and the
+# choice is forced. And neither route here is as good as a persistent pinned
+# buffer: charged against queue depth at 1.5 MB, pageable grows +84 us per
+# queued matmul and a `CpuGpuBuffer` is flat, while a per-call `pin_memory()`
+# lands anywhere from +3 to +36 depending on how fragmented the caching host
+# allocator already is -- better than pageable, and not something to rely on.
+# That is why `CpuGpuBuffer` exists and why a per-forward buffer should be one.
+_PAGEABLE_H2D_LIMIT = 512 * 1024
+
+
+@lru_cache(maxsize=8)
+def _warn_oversize_upload(nbytes: int) -> None:
+    logger.warning(
+        "upload_numpy: %d B is past the %d B pageable limit, so it is staged "
+        "through a fresh pinned block every call. A per-forward upload this "
+        "size should own a CpuGpuBuffer instead.",
+        nbytes,
+        _PAGEABLE_H2D_LIMIT,
+    )
+
+
+def upload_numpy(arr: np.ndarray, device, *, non_blocking: bool = True) -> torch.Tensor:
+    """Copy a numpy array to `device` by whichever route its size calls for.
+
+    For one-off and size-varying uploads, where the size can cross the cliff as
+    a config knob moves and nobody notices until a step takes milliseconds
+    longer. A buffer uploaded every forward should be a `CpuGpuBuffer`.
+
+    A shared reusable staging block is not a third option, and was tried: its
+    copy goes out on the current stream, so the event that makes reuse safe
+    sits behind whatever is queued, and waiting on it costs what pageable
+    costs. Only a block nobody else touches escapes that.
+    """
+    if arr.nbytes <= _PAGEABLE_H2D_LIMIT:
+        return torch.from_numpy(arr).to(device, non_blocking=non_blocking)
+    _warn_oversize_upload(arr.nbytes)
+    return torch.from_numpy(arr).pin_memory().to(device, non_blocking=non_blocking)
+
+
 class CpuGpuBuffer:
     """Buffer to easily copy tensors between CPU and GPU."""
 
     def __init__(
         self,
-        *size: Union[int, torch.SymInt],
+        *size: int | torch.SymInt,
         dtype: torch.dtype,
         device: torch.device,
         pin_memory: bool = True,
@@ -588,12 +641,12 @@ class CpuGpuBuffer:
                 )
             self.np = self.cpu.numpy()
 
-    def copy_to_gpu(self, n: Optional[int] = None) -> torch.Tensor:
+    def copy_to_gpu(self, n: int | None = None) -> torch.Tensor:
         if n is None:
             return self.gpu.copy_(self.cpu, non_blocking=True)
         return self.gpu[:n].copy_(self.cpu[:n], non_blocking=True)
 
-    def copy_to_cpu(self, n: Optional[int] = None) -> torch.Tensor:
+    def copy_to_cpu(self, n: int | None = None) -> torch.Tensor:
         """NOTE: Because this method is non-blocking, explicit synchronization
         is needed to ensure the data is copied to CPU."""
         if n is None:
@@ -744,8 +797,8 @@ def weak_ref_tensor(tensor: Any) -> Any:
 
 
 def weak_ref_tensors(
-    tensors: Union[torch.Tensor, list[torch.Tensor], tuple[torch.Tensor]],
-) -> Union[torch.Tensor, list[Any], tuple[Any], Any]:
+    tensors: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor],
+) -> torch.Tensor | list[Any] | tuple[Any] | Any:
     """
     Convenience function to create weak references to tensors,
     for single tensor, list of tensors or tuple of tensors.

--- a/docs/scheduling_kv_cache_guide.md
+++ b/docs/scheduling_kv_cache_guide.md
@@ -149,7 +149,7 @@ class ScheduledBatch:
         total_seqs_num_decode: int = 0,
         is_dummy_run: bool = False,
         num_spec_step: int = 0,
-        scheduled_spec_decode_tokens: dict[int, list[int]] = {},
+        scheduled_spec_decode_tokens: dict[int, np.ndarray] | None = None,
     ):
 ```
 
@@ -158,10 +158,10 @@ class ScheduledBatch:
 | Field | Type | Description |
 |---|---|---|
 | `req_ids` | `list[int]` | Sequence IDs in batch order (`list(seqs.keys())`) |
-| `scheduled_tokens` | `list[list[int]]` | Last `num_tokens` token IDs per sequence (the tokens to process) |
+| `scheduled_tokens` | `np.ndarray[int32]` | The tokens to process, flattened in batch order and sliced by `num_scheduled_tokens` |
 | `temperatures` | `list[float]` | Sampling temperature per sequence |
 | `context_lens` | `list[int]` | Total token count per sequence (`seq.num_tokens`) |
-| `block_tables` | `list[list[int]]` | Block ID tables for sequences that have block tables |
+| `block_tables` | `list[array("i")]` | Block ID tables for sequences that have block tables, held as `Sequence.block_table` gives them |
 | `last_block_num_tokens` | `list[int]` | Number of valid tokens in each sequence's last block |
 | `num_cached_tokens` | `list[int]` | Number of tokens served from prefix cache per sequence |
 | `num_scheduled_tokens` | `list[int]` | Number of new tokens scheduled per sequence |
@@ -173,7 +173,7 @@ class ScheduledBatch:
 | `total_seqs_num_decode` | `int` | Number of decode sequences |
 | `is_dummy_run` | `bool` | Whether this is a dummy/warmup run |
 | `num_spec_step` | `int` | Number of speculative decode steps (`mtp_k`) |
-| `scheduled_spec_decode_tokens` | `dict[int, list[int]]` | Draft token IDs per sequence ID from prior speculative step |
+| `scheduled_spec_decode_tokens` | `np.ndarray[int32]` | Draft tokens from the prior speculative step, densified to `[bs, num_spec_step]` in batch order (the constructor takes them keyed by request ID) |
 
 ### ScheduledBatchOutput
 

--- a/tests/test_block_manager.py
+++ b/tests/test_block_manager.py
@@ -69,7 +69,7 @@ class TestAllocateDeallocate:
         seq = seq_factory([1, 2, 3, 4, 5, 6, 7, 8])
         block_manager.allocate(seq)
         block_manager.deallocate(seq)
-        assert seq.block_table == []
+        assert len(seq.block_table) == 0
         assert seq.num_cached_tokens == 0
 
     def test_deallocate_restores_capacity(self, block_manager, seq_factory):
@@ -384,7 +384,7 @@ class TestPrefixCachingPreemption:
         # Simulate preemption
         bm.deallocate(s1)
         assert s1.num_cached_tokens == 0
-        assert s1.block_table == []
+        assert len(s1.block_table) == 0
 
         # Re-allocate — first block is a cache hit; the last full block is
         # force-recomputed so prefill has at least one token to forward.

--- a/tests/test_block_manager.py
+++ b/tests/test_block_manager.py
@@ -150,7 +150,7 @@ class TestPublishLoadedPrefix:
 
         assert bm.publish_loaded_prefix(loaded, start_token=0, end_token=8) == 8
         loaded_block = bm.kv.block(loaded.block_table[0])
-        assert loaded_block.token_ids == list(range(8))
+        assert list(loaded_block.token_ids) == list(range(8))
 
         probe = seq_factory(list(range(8)) + list(range(100, 108)))
         num_cached_blocks = bm.can_allocate(probe)

--- a/tests/test_block_table_marshal.py
+++ b/tests/test_block_table_marshal.py
@@ -12,9 +12,10 @@ Two properties have to hold, and neither shows up in a throughput number:
   `BlockManager` append into a `BufferError`, far from the code that took it.
 
 The marshals are exercised as unbound methods on a stub that supplies what
-they read, so the arithmetic under test is the shipped arithmetic. Both now
-delegate to `pack_rows`, whose own contract -- which rows it clears, and which
-destinations it refuses -- is pinned at the bottom of this file.
+they read, so the arithmetic under test is the shipped arithmetic. Every
+builder here lives in a module that imports AITER at load, so this file skips
+whole on a plain runner; the contract of the `pack_rows` helper they share is
+in `test_pack_rows.py`, which does not, and so runs in CI.
 """
 
 from __future__ import annotations
@@ -27,8 +28,12 @@ import numpy as np
 import pytest
 
 from atom.model_engine.sequence import new_block_table
-from atom.model_ops.attentions.backends import CommonAttentionBuilder
-from atom.utils import pack_rows
+
+CommonAttentionBuilder = pytest.importorskip(
+    "atom.model_ops.attentions.backends",
+    reason="the common builder's module imports aiter at load",
+    exc_type=ImportError,
+).CommonAttentionBuilder
 
 V4Builder = pytest.importorskip(
     "atom.model_ops.attentions.deepseek_v4_attn",
@@ -110,39 +115,6 @@ def test_v4_marshal_is_bit_exact_and_stays_in_its_rows(bs):
     assert (dst[bs:] == POISON).all(), "wrote past the scheduled rows"
 
 
-def test_a_non_contiguous_destination_raises_rather_than_dropping_writes():
-    """Flattening a non-contiguous buffer with `reshape(-1)` yields a copy, so
-    every row would be written into a temporary and lost with it. `.cast`
-    refuses instead, and unlike an assert it still refuses under `python -O`.
-    """
-    backing = np.full((MAX_BS, MAX_COLS * 2), POISON, dtype=np.int32)
-    dst = backing[:, :MAX_COLS]  # a view, so rows are not adjacent
-    assert not dst.flags.c_contiguous
-
-    with pytest.raises(TypeError, match="C-contiguous"):
-        CommonAttentionBuilder.prepare_block_tables(
-            _stub(dst), SimpleNamespace(block_tables=_rows(4))
-        )
-
-    # Positive control: the failure mode being guarded is real and silent.
-    assert not np.shares_memory(dst.reshape(-1), dst)
-
-
-def test_an_over_wide_row_raises_instead_of_reaching_the_next_one():
-    """`block_tables[i, :n] = row` raised when a row was too wide; a flat write
-    would land the overflow in the next request's row instead, leaving it a
-    block table that points at someone else's KV.
-    """
-    dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)
-    rows = _rows(3)
-    rows[1] = new_block_table(range(MAX_COLS + 1))
-
-    with pytest.raises(ValueError, match="exceeds"):
-        CommonAttentionBuilder.prepare_block_tables(
-            _stub(dst), SimpleNamespace(block_tables=rows)
-        )
-
-
 def test_empty_batch_writes_nothing():
     """A warmup batch carries no block tables and must leave the buffer alone."""
     dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)
@@ -213,45 +185,6 @@ def test_tbo_prefill_stash_does_not_pin_the_rows_it_keeps():
     for i, row in enumerate(kept):
         dst[i, : len(row)] = row
     assert (dst[0, : len(rows[0])] == np.asarray(rows[0][: len(rows[0])])).all()
-
-
-def test_pack_rows_clears_the_rows_it_fills_and_leaves_the_rest():
-    """Its callers hand it an uncleared destination -- `np.empty` at the TBO
-    site -- and rely on it to zero-fill each row's tail itself. What it must
-    not do is clear rows nobody scheduled."""
-    dst = np.full((6, MAX_COLS), POISON, dtype=np.int32)
-    rows = _rows(3)
-
-    pack_rows(dst, rows)
-
-    for i, row in enumerate(rows):
-        assert list(dst[i, : len(row)]) == list(row)
-        assert (dst[i, len(row) :] == 0).all(), "row tail not cleared"
-    assert (dst[len(rows) :] == POISON).all(), "cleared rows it was not given"
-
-
-def test_pack_rows_refuses_more_rows_than_the_destination_holds():
-    """The other edge a flat write does not have. Unchecked, this surfaces as
-    a memoryview structure error from whichever row ran off the end."""
-    dst = np.full((3, MAX_COLS), POISON, dtype=np.int32)
-
-    with pytest.raises(ValueError, match="rows exceed"):
-        pack_rows(dst, _rows(4))
-
-    pack_rows(dst, _rows(3))  # control: exactly full is fine
-
-
-def test_pack_rows_refuses_a_destination_whose_bits_it_would_reinterpret():
-    """`.cast("i")` reinterprets rather than converts, so a destination of any
-    other dtype would take the block ids as raw bits."""
-    dst = np.zeros((4, MAX_COLS), dtype=np.float32)
-
-    with pytest.raises(TypeError, match="int32"):
-        pack_rows(dst, _rows(2))
-
-    # Control: nothing about the cast itself would have complained.
-    dst[0, 0] = 1.0
-    assert memoryview(dst).cast("B").cast("i")[0] == 1065353216
 
 
 def test_int32_asarray_over_a_block_table_is_the_hazard_being_guarded():

--- a/tests/test_block_table_marshal.py
+++ b/tests/test_block_table_marshal.py
@@ -230,6 +230,17 @@ def test_pack_rows_clears_the_rows_it_fills_and_leaves_the_rest():
     assert (dst[len(rows) :] == POISON).all(), "cleared rows it was not given"
 
 
+def test_pack_rows_refuses_more_rows_than_the_destination_holds():
+    """The other edge a flat write does not have. Unchecked, this surfaces as
+    a memoryview structure error from whichever row ran off the end."""
+    dst = np.full((3, MAX_COLS), POISON, dtype=np.int32)
+
+    with pytest.raises(ValueError, match="rows exceed"):
+        pack_rows(dst, _rows(4))
+
+    pack_rows(dst, _rows(3))  # control: exactly full is fine
+
+
 def test_pack_rows_refuses_a_destination_whose_bits_it_would_reinterpret():
     """`.cast("i")` reinterprets rather than converts, so a destination of any
     other dtype would take the block ids as raw bits."""

--- a/tests/test_block_table_marshal.py
+++ b/tests/test_block_table_marshal.py
@@ -12,7 +12,9 @@ Two properties have to hold, and neither shows up in a throughput number:
   `BlockManager` append into a `BufferError`, far from the code that took it.
 
 The marshals are exercised as unbound methods on a stub that supplies what
-they read, so the arithmetic under test is the shipped arithmetic.
+they read, so the arithmetic under test is the shipped arithmetic. Both now
+delegate to `pack_rows`, whose own contract -- which rows it clears, and which
+destinations it refuses -- is pinned at the bottom of this file.
 """
 
 from __future__ import annotations
@@ -26,6 +28,7 @@ import pytest
 
 from atom.model_engine.sequence import new_block_table
 from atom.model_ops.attentions.backends import CommonAttentionBuilder
+from atom.utils import pack_rows
 
 V4Builder = pytest.importorskip(
     "atom.model_ops.attentions.deepseek_v4_attn",
@@ -210,6 +213,34 @@ def test_tbo_prefill_stash_does_not_pin_the_rows_it_keeps():
     for i, row in enumerate(kept):
         dst[i, : len(row)] = row
     assert (dst[0, : len(rows[0])] == np.asarray(rows[0][: len(rows[0])])).all()
+
+
+def test_pack_rows_clears_the_rows_it_fills_and_leaves_the_rest():
+    """Its callers hand it an uncleared destination -- `np.empty` at the TBO
+    site -- and rely on it to zero-fill each row's tail itself. What it must
+    not do is clear rows nobody scheduled."""
+    dst = np.full((6, MAX_COLS), POISON, dtype=np.int32)
+    rows = _rows(3)
+
+    pack_rows(dst, rows)
+
+    for i, row in enumerate(rows):
+        assert list(dst[i, : len(row)]) == list(row)
+        assert (dst[i, len(row) :] == 0).all(), "row tail not cleared"
+    assert (dst[len(rows) :] == POISON).all(), "cleared rows it was not given"
+
+
+def test_pack_rows_refuses_a_destination_whose_bits_it_would_reinterpret():
+    """`.cast("i")` reinterprets rather than converts, so a destination of any
+    other dtype would take the block ids as raw bits."""
+    dst = np.zeros((4, MAX_COLS), dtype=np.float32)
+
+    with pytest.raises(TypeError, match="int32"):
+        pack_rows(dst, _rows(2))
+
+    # Control: nothing about the cast itself would have complained.
+    dst[0, 0] = 1.0
+    assert memoryview(dst).cast("B").cast("i")[0] == 1065353216
 
 
 def test_int32_asarray_over_a_block_table_is_the_hazard_being_guarded():

--- a/tests/test_block_table_marshal.py
+++ b/tests/test_block_table_marshal.py
@@ -107,6 +107,39 @@ def test_v4_marshal_is_bit_exact_and_stays_in_its_rows(bs):
     assert (dst[bs:] == POISON).all(), "wrote past the scheduled rows"
 
 
+def test_a_non_contiguous_destination_raises_rather_than_dropping_writes():
+    """Flattening a non-contiguous buffer with `reshape(-1)` yields a copy, so
+    every row would be written into a temporary and lost with it. `.cast`
+    refuses instead, and unlike an assert it still refuses under `python -O`.
+    """
+    backing = np.full((MAX_BS, MAX_COLS * 2), POISON, dtype=np.int32)
+    dst = backing[:, :MAX_COLS]  # a view, so rows are not adjacent
+    assert not dst.flags.c_contiguous
+
+    with pytest.raises(TypeError, match="C-contiguous"):
+        CommonAttentionBuilder.prepare_block_tables(
+            _stub(dst), SimpleNamespace(block_tables=_rows(4))
+        )
+
+    # Positive control: the failure mode being guarded is real and silent.
+    assert not np.shares_memory(dst.reshape(-1), dst)
+
+
+def test_an_over_wide_row_raises_instead_of_reaching_the_next_one():
+    """`block_tables[i, :n] = row` raised when a row was too wide; a flat write
+    would land the overflow in the next request's row instead, leaving it a
+    block table that points at someone else's KV.
+    """
+    dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)
+    rows = _rows(3)
+    rows[1] = new_block_table(range(MAX_COLS + 1))
+
+    with pytest.raises(ValueError, match="exceeds"):
+        CommonAttentionBuilder.prepare_block_tables(
+            _stub(dst), SimpleNamespace(block_tables=rows)
+        )
+
+
 def test_empty_batch_writes_nothing():
     """A warmup batch carries no block tables and must leave the buffer alone."""
     dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)

--- a/tests/test_block_table_marshal.py
+++ b/tests/test_block_table_marshal.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: MIT
+
+"""Marshalling `Sequence.block_table` rows into the int32 `block_tables` buffer.
+
+Two properties have to hold, and neither shows up in a throughput number:
+
+* the destination is written exactly as the pre-`array("i")` loop wrote it.
+  Both marshals hoist the per-row `[i] = 0` into one span memset, which is
+  only equivalent because the old loop cleared precisely the rows it filled.
+* nobody may retain a zero-copy int32 view of a block_table. `array("i")`
+  refuses to resize while exporting a buffer, so such a view turns the next
+  `BlockManager` append into a `BufferError`, far from the code that took it.
+
+The marshals are exercised as unbound methods on a stub that supplies what
+they read, so the arithmetic under test is the shipped arithmetic.
+"""
+
+from __future__ import annotations
+
+import array
+from functools import partial
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from atom.model_engine.sequence import new_block_table
+from atom.model_ops.attentions.backends import CommonAttentionBuilder
+
+V4Builder = pytest.importorskip(
+    "atom.model_ops.attentions.deepseek_v4_attn",
+    reason="the V4 builder's module imports aiter at load",
+    exc_type=ImportError,
+).DeepseekV4AttentionMetadataBuilder
+
+AiterBuilder = pytest.importorskip(
+    "atom.model_ops.attentions.aiter_attention",
+    reason="the MHA builder's module imports aiter at load",
+    exc_type=ImportError,
+).AiterAttentionMetadataBuilder
+
+MAX_BS = 300
+MAX_COLS = 40
+# Neither 0 nor a plausible block id, so a cell that should have been cleared
+# and a cell that should have been filled are both distinguishable from one
+# that was never reached.
+POISON = -7
+
+
+def _rows(bs: int) -> list[array.array]:
+    """`bs` block tables of varying length, none empty, none full-width."""
+    return [
+        new_block_table(range(100 * (i + 1), 100 * (i + 1) + 1 + (i % (MAX_COLS - 2))))
+        for i in range(bs)
+    ]
+
+
+def _golden(rows: list[array.array]) -> np.ndarray:
+    """The destination as the pre-hoist per-row loop would have left it."""
+    dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)
+    for i, row in enumerate(rows):
+        dst[i] = 0
+        dst[i, : len(row)] = row
+    return dst
+
+
+def _stub(dst: np.ndarray):
+    """A builder stub whose `forward_vars["block_tables"]` wraps `dst`."""
+    buf = SimpleNamespace(np=dst, copy_to_gpu=lambda n: ("gpu", n))
+    stub = SimpleNamespace(
+        model_runner=SimpleNamespace(forward_vars={"block_tables": buf})
+    )
+    # The V4 marshal delegates through `self`, as it does on a real builder,
+    # which inherits exactly this method.
+    stub.prepare_block_tables = partial(
+        CommonAttentionBuilder.prepare_block_tables, stub
+    )
+    return stub
+
+
+@pytest.mark.parametrize("bs", [0, 1, 2, 50, 64, 256])
+def test_common_marshal_is_bit_exact_and_stays_in_its_rows(bs):
+    rows = _rows(bs)
+    dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)
+
+    CommonAttentionBuilder.prepare_block_tables(
+        _stub(dst), SimpleNamespace(block_tables=rows)
+    )
+
+    assert np.array_equal(dst, _golden(rows))
+    assert (dst[bs:] == POISON).all(), "wrote past the scheduled rows"
+
+
+@pytest.mark.parametrize("bs", [0, 1, 2, 50, 64, 256])
+def test_v4_marshal_is_bit_exact_and_stays_in_its_rows(bs):
+    # The V4 marshal takes `scheduled_bs` separately and is handed a batch that
+    # may carry more rows than are scheduled: the surplus must not be written.
+    rows = _rows(bs + 3)
+    dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)
+
+    out = V4Builder._populate_block_tables(
+        _stub(dst), SimpleNamespace(block_tables=rows), bs
+    )
+
+    assert out == ("gpu", bs)
+    assert np.array_equal(dst, _golden(rows[:bs]))
+    assert (dst[bs:] == POISON).all(), "wrote past the scheduled rows"
+
+
+def test_empty_batch_writes_nothing():
+    """A warmup batch carries no block tables and must leave the buffer alone."""
+    dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)
+    batch = SimpleNamespace(block_tables=[])
+
+    CommonAttentionBuilder.prepare_block_tables(_stub(dst), batch)
+    V4Builder._populate_block_tables(_stub(dst), batch, 0)
+
+    assert (dst == POISON).all()
+    assert batch.block_tables == []
+
+
+def test_marshal_leaves_no_buffer_export_on_the_row():
+    """The marshal must copy out of the row, not alias it.
+
+    An aliasing read would pin the array and surface as a `BufferError` from
+    `BlockManager`'s next append, a step or more later.
+    """
+    rows = _rows(4)
+    dst = np.full((MAX_BS, MAX_COLS), POISON, dtype=np.int32)
+
+    CommonAttentionBuilder.prepare_block_tables(
+        _stub(dst), SimpleNamespace(block_tables=rows)
+    )
+    V4Builder._populate_block_tables(
+        _stub(dst), SimpleNamespace(block_tables=rows), len(rows)
+    )
+
+    for row in rows:
+        row.append(999)  # BufferError here means someone kept a view
+
+
+def test_tbo_prefill_stash_does_not_pin_the_rows_it_keeps():
+    """The one place that keeps block tables past the call that read them.
+
+    `_stash_tbo_token_split_prefill_state` holds its rows until a later ubatch
+    rebuilds the straddled request's prefix, so an int32 view taken here is
+    still live when `BlockManager` next grows the sequence.
+    """
+    bs = 4
+    rows = _rows(bs)
+    stub = SimpleNamespace(
+        _tbo_prefill_state=None,
+        model_runner=SimpleNamespace(
+            forward_vars={
+                "cu_seqlens_q": SimpleNamespace(np=np.arange(bs + 1, dtype=np.int32))
+            }
+        ),
+    )
+    batch = SimpleNamespace(
+        block_tables=rows,
+        total_seqs_num_prefill=bs,
+        num_cached_tokens=[0] * bs,
+    )
+
+    AiterBuilder._stash_tbo_token_split_prefill_state(stub, batch)
+
+    assert stub._tbo_prefill_state is not None
+    kept = stub._tbo_prefill_state.block_tables
+    assert [len(r) for r in kept] == [len(r) for r in rows]
+
+    for row in rows:
+        row.append(999)  # BufferError here means the stash kept a view
+
+    # And what it kept still serves its consumer, which only ever needs a
+    # length and a slice assignment into an int32 destination.
+    dst = np.zeros((bs, MAX_COLS), dtype=np.int32)
+    for i, row in enumerate(kept):
+        dst[i, : len(row)] = row
+    assert (dst[0, : len(rows[0])] == np.asarray(rows[0][: len(rows[0])])).all()
+
+
+def test_int32_asarray_over_a_block_table_is_the_hazard_being_guarded():
+    """Positive control: the failure mode above is real, and int64 escapes it.
+
+    Without this, the test above passes just as well against a marshal that
+    could never have aliased anything.
+    """
+    aliased = array.array("i", [1, 2, 3])
+    view = np.asarray(aliased, dtype=np.int32)
+    assert np.shares_memory(view, np.frombuffer(aliased, dtype=np.int32))
+    with pytest.raises(BufferError):
+        aliased.append(4)
+    del view
+
+    # `np.array` copies, and so does `asarray` at a width that is not the
+    # array's own -- which is why the two `aiter_mla` int64 reads are safe.
+    for taken in (
+        np.array(aliased, dtype=np.int32),
+        np.asarray(aliased, dtype=np.int64),
+    ):
+        assert taken is not None
+        aliased.append(4)

--- a/tests/test_decode_indices_paged.py
+++ b/tests/test_decode_indices_paged.py
@@ -245,3 +245,151 @@ def test_one_row_per_block_reduces_to_the_block_stride():
     assert np.array_equal(
         got, expected
     ), "with one row per block an entry is just its block's first row"
+
+
+# --- HCA compress section built in the kernel from the block tables -------
+# The section used to be a numpy scatter in the caller, shipped whole every
+# step. The kernel fills it now, so what needs holding is that it lands on the
+# same rows the numpy oracle names, that head and tail tile each slice with no
+# cell left over, and that a caller which does not opt in still gets nothing.
+BT_COLS = 16
+ROWS_PER_BLOCK = 2
+
+
+def _hca_case(bs, n_hca_per_seq, positions, geometry=GEOMETRY):
+    """One decode token per seq plus a `-1` pad token, with HCA heads sized
+    from `n_hca_per_seq` — the same `n + n_committed_hca` the builder uses."""
+    t_total = bs + 1
+    batch_id = list(range(bs)) + [-1]
+    rng = np.random.default_rng(bs * 17 + sum(n_hca_per_seq))
+    bt_np = rng.integers(0, 4, size=(bs, BT_COLS)).astype(np.int32)
+    n_per = [min(p + 1, WIN) for p in positions]
+
+    ptr = [0]
+    for t in range(t_total):
+        live = batch_id[t] >= 0
+        ptr.append(ptr[-1] + (n_per[t] + n_hca_per_seq[t] if live else 0))
+
+    dev = {"dtype": torch.int32, "device": DEV}
+    hca_indices = torch.full((ptr[-1],), -7, **dev)
+    swa_indptr = torch.tensor(
+        np.cumsum([0] + [n_per[t] if batch_id[t] >= 0 else 0 for t in range(t_total)]),
+        **dev,
+    )
+    write_v4_paged_decode_indices(
+        state_slot_per_seq=torch.tensor(SLOTS[:1] * bs, **dev),
+        batch_id_per_token=torch.tensor(batch_id, **dev),
+        positions=torch.tensor(positions, **dev),
+        swa_indptr=swa_indptr,
+        csa_indptr=None,
+        hca_indptr=torch.tensor(ptr, **dev),
+        swa_indices=torch.full((int(swa_indptr[-1]),), -7, **dev),
+        csa_indices=None,
+        hca_indices=hca_indices,
+        dest_rows={
+            r: torch.full((t_total,), -7, **dev)
+            for r in (DENSE_RATIO, CSA_RATIO, HCA_RATIO)
+        },
+        T=t_total,
+        win=WIN,
+        geometry=geometry,
+        hca_block_tables=torch.from_numpy(bt_np).to(DEV),
+        hca_rows_per_block=ROWS_PER_BLOCK,
+    )
+    torch.cuda.synchronize()
+    return hca_indices.cpu().numpy(), ptr, bt_np, n_per
+
+
+def _oracle_heads(ptr, bt_np, n_hca_per_seq, geometry):
+    """The rows the replaced numpy scatter would have written, per slice."""
+    out = {}
+    for t, n_hca in enumerate(n_hca_per_seq):
+        if n_hca == 0:
+            continue
+        e = np.arange(n_hca, dtype=np.int64)
+        out[t] = hca_compress_paged_offsets(
+            e,
+            np.full(n_hca, t, dtype=np.int64),
+            bt_np,
+            geometry.envelope_rows,
+            ROWS_PER_BLOCK,
+        )
+    return out
+
+
+# Counts that cross the two-rows-per-block boundary in both directions, plus a
+# seq with nothing committed and a batch bigger than one wave of tokens.
+@pytest.mark.parametrize(
+    "n_hca_per_seq,positions",
+    [
+        ([1, 2, 3], [5, 20, 13]),
+        ([0, 1, 8], [0, 3, 30]),
+        ([31, 2, 0], [40, 1, 9]),
+        ([7] * 12, list(range(1, 13))),
+    ],
+    ids=["small", "one-empty", "wide-and-empty", "twelve-seqs"],
+)
+def test_hca_head_matches_the_numpy_scatter_it_replaces(n_hca_per_seq, positions):
+    bs = len(n_hca_per_seq)
+    got, ptr, bt_np, _ = _hca_case(bs, n_hca_per_seq + [0], positions + [0])
+    for t, want in _oracle_heads(ptr, bt_np, n_hca_per_seq, GEOMETRY).items():
+        head = got[ptr[t] : ptr[t] + len(want)]
+        assert np.array_equal(head, want), f"slice {t}: got {head}, want {want}"
+
+
+@pytest.mark.parametrize(
+    "n_hca_per_seq,positions",
+    [([1, 2, 3], [5, 20, 13]), ([0, 1, 8], [0, 3, 30]), ([7] * 12, list(range(1, 13)))],
+    ids=["small", "one-empty", "twelve-seqs"],
+)
+def test_head_and_tail_tile_every_slice(n_hca_per_seq, positions):
+    """No cell of a live slice keeps the poison, and no pad slice exists.
+
+    This is what lets the caller drop the `-1` pre-fill: if the two sections
+    ever stopped meeting, the gap would be a stale index into the pool.
+    """
+    bs = len(n_hca_per_seq)
+    got, ptr, _, _ = _hca_case(bs, n_hca_per_seq + [0], positions + [0])
+    assert not (got == -7).any(), f"uncovered cells at {np.flatnonzero(got == -7)}"
+    assert ptr[bs + 1] == ptr[bs], "the -1 pad token was given a slice"
+
+
+def test_without_block_tables_the_head_is_left_alone():
+    """The other five callers fill this section themselves, from a different
+    row formula, so opting out has to mean the kernel writes none of it."""
+    n_hca_per_seq, positions = [3, 4, 5], [5, 20, 13]
+    bs = len(n_hca_per_seq)
+    t_total = bs + 1
+    n_per = [min(p + 1, WIN) for p in positions] + [0]
+    batch_id = list(range(bs)) + [-1]
+    ptr = [0]
+    for t in range(t_total):
+        live = batch_id[t] >= 0
+        ptr.append(ptr[-1] + ((n_per[t] + (n_hca_per_seq + [0])[t]) if live else 0))
+
+    dev = {"dtype": torch.int32, "device": DEV}
+    hca_indices = torch.full((ptr[-1],), -7, **dev)
+    swa_indptr = torch.tensor(np.cumsum([0] + n_per), **dev)
+    write_v4_paged_decode_indices(
+        state_slot_per_seq=torch.tensor(SLOTS[:1] * bs, **dev),
+        batch_id_per_token=torch.tensor(batch_id, **dev),
+        positions=torch.tensor(positions + [0], **dev),
+        swa_indptr=swa_indptr,
+        csa_indptr=None,
+        hca_indptr=torch.tensor(ptr, **dev),
+        swa_indices=torch.full((int(swa_indptr[-1]),), -7, **dev),
+        csa_indices=None,
+        hca_indices=hca_indices,
+        dest_rows={
+            r: torch.full((t_total,), -7, **dev)
+            for r in (DENSE_RATIO, CSA_RATIO, HCA_RATIO)
+        },
+        T=t_total,
+        win=WIN,
+        geometry=GEOMETRY,
+    )
+    torch.cuda.synchronize()
+    got = hca_indices.cpu().numpy()
+    for t in range(bs):
+        head = got[ptr[t] : ptr[t] + n_hca_per_seq[t]]
+        assert (head == -7).all(), f"slice {t} head was written: {head}"

--- a/tests/test_pack_rows.py
+++ b/tests/test_pack_rows.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MIT
+
+"""`atom.utils.pack_rows` on its own terms.
+
+Its callers live in attention backends, whose modules import AITER at load and
+so cannot be collected on a plain runner. The helper does not, and it is the
+one piece the two marshals share, so its contract is pinned here where CI can
+execute it: which rows it clears, which destinations it refuses, and the two
+edges a flat write does not have.
+
+The callers' side -- that each marshal still writes what the per-row loop it
+replaced wrote -- is in `test_block_table_marshal.py`.
+"""
+
+from __future__ import annotations
+
+import array
+
+import numpy as np
+import pytest
+
+from atom.model_engine.sequence import new_block_table
+from atom.utils import pack_rows
+
+COLS = 40
+# Neither 0 nor a plausible block id, so a cell that should have been cleared
+# and a cell that should have been filled are both distinguishable from one
+# that was never reached.
+POISON = -7
+
+
+def _rows(n: int) -> list[array.array]:
+    """`n` rows of varying length, none empty, none full-width."""
+    return [
+        new_block_table(range(100 * (i + 1), 100 * (i + 1) + 1 + (i % (COLS - 2))))
+        for i in range(n)
+    ]
+
+
+def test_rows_land_left_aligned_with_their_tails_cleared():
+    """Callers hand it an uncleared destination -- `np.empty` at the TBO site
+    -- and rely on it to zero-fill each row's tail. What it must not do is
+    clear rows nobody scheduled."""
+    dst = np.full((6, COLS), POISON, dtype=np.int32)
+    rows = _rows(3)
+
+    pack_rows(dst, rows)
+
+    for i, row in enumerate(rows):
+        assert list(dst[i, : len(row)]) == list(row)
+        assert (dst[i, len(row) :] == 0).all(), "row tail not cleared"
+    assert (dst[len(rows) :] == POISON).all(), "cleared rows it was not given"
+
+
+def test_an_over_wide_row_raises_instead_of_reaching_the_next_one():
+    """A flat write has no row edge: the overflow would land in the next
+    request's row, leaving it a block table pointing at someone else's KV."""
+    dst = np.full((4, COLS), POISON, dtype=np.int32)
+    rows = _rows(3)
+    rows[1] = new_block_table(range(COLS + 1))
+
+    with pytest.raises(ValueError, match="exceeds"):
+        pack_rows(dst, rows)
+
+
+def test_more_rows_than_the_destination_holds_raises():
+    """The other edge. Unchecked, this surfaces as a memoryview structure
+    error naming neither the row nor the destination."""
+    dst = np.full((3, COLS), POISON, dtype=np.int32)
+
+    with pytest.raises(ValueError, match="rows exceed"):
+        pack_rows(dst, _rows(4))
+
+    pack_rows(dst, _rows(3))  # control: exactly full is fine
+
+
+def test_a_destination_whose_bits_it_would_reinterpret_is_refused():
+    """`.cast("i")` reinterprets rather than converts, so a destination of any
+    other dtype would take the block ids as raw bits."""
+    dst = np.zeros((4, COLS), dtype=np.float32)
+
+    with pytest.raises(TypeError, match="int32"):
+        pack_rows(dst, _rows(2))
+
+    # Control: nothing about the cast itself would have complained.
+    dst[0, 0] = 1.0
+    assert memoryview(dst).cast("B").cast("i")[0] == 1065353216
+
+
+def test_a_non_contiguous_destination_raises_rather_than_dropping_writes():
+    """Flattening a non-contiguous buffer with `reshape(-1)` yields a copy, so
+    every row would be written into a temporary and lost with it. `.cast`
+    refuses instead, and unlike an assert it still refuses under `python -O`.
+    """
+    backing = np.full((4, COLS * 2), POISON, dtype=np.int32)
+    dst = backing[:, :COLS]  # a view, so rows are not adjacent
+    assert not dst.flags.c_contiguous
+
+    with pytest.raises(TypeError, match="C-contiguous"):
+        pack_rows(dst, _rows(2))
+
+    # Positive control: the failure mode being guarded is real and silent.
+    assert not np.shares_memory(dst.reshape(-1), dst)
+
+
+def test_no_rows_leaves_the_destination_alone():
+    """A warmup batch carries none."""
+    dst = np.full((4, COLS), POISON, dtype=np.int32)
+
+    pack_rows(dst, [])
+
+    assert (dst == POISON).all()
+
+
+def test_the_rows_are_copied_out_of_not_aliased():
+    """An aliasing read would pin the `array("i")` and surface as a
+    `BufferError` from `BlockManager`'s next append, a step or more later."""
+    rows = _rows(4)
+    dst = np.full((4, COLS), POISON, dtype=np.int32)
+
+    pack_rows(dst, rows)
+
+    for row in rows:
+        row.append(999)  # BufferError here means someone kept a view

--- a/tests/test_prefill_scheduler.py
+++ b/tests/test_prefill_scheduler.py
@@ -22,8 +22,8 @@ def prefill_scheduler():
 
 @pytest.fixture
 def seq_factory():
-    from atom.sampling_params import SamplingParams
     from atom.model_engine.sequence import Sequence
+    from atom.sampling_params import SamplingParams
 
     def make(token_ids, block_size=4):
         return Sequence(token_ids, block_size, sampling_params=SamplingParams())
@@ -58,7 +58,7 @@ def test_has_requests_true_after_add(prefill_scheduler, seq_factory):
 def test_schedule_returns_none_when_no_block_table(prefill_scheduler, seq_factory):
     """Sequences without a block_table (not yet assigned by decode) are not scheduled."""
     seq = seq_factory([1, 2, 3, 4])
-    assert seq.block_table == []
+    assert len(seq.block_table) == 0
     prefill_scheduler.add(seq)
 
     result = prefill_scheduler.schedule()

--- a/tests/test_scheduled_batch_marshal.py
+++ b/tests/test_scheduled_batch_marshal.py
@@ -17,6 +17,8 @@ its inputs rather than from the destination.
 
 from __future__ import annotations
 
+import gc
+
 import numpy as np
 import pytest
 
@@ -119,12 +121,26 @@ def test_empty_batch():
     assert batch.scheduled_tokens.size == 0
 
 
+def test_the_window_array_is_writable_and_outlives_its_staging_buffer():
+    """It wraps the staging buffer rather than copying out of it, so it holds
+    the only reference to that buffer and inherits its writability."""
+    seqs = [_decode_seq(range(i * 100, i * 100 + 40)) for i in range(4)]
+    tokens = _build(seqs, [2] * 4).scheduled_tokens
+
+    gc.collect()  # the staging local is gone; the buffer must not be
+    assert np.array_equal(tokens, _golden_tokens(seqs, [2] * 4))
+    assert tokens.flags.writeable, "a read-only view would surprise a future writer"
+    tokens[0] = -1
+    assert tokens[0] == -1
+
+
 def test_a_sequence_too_short_for_its_window_raises():
-    """The per-row form raised here, on the row that came up short. A staged
-    run has no row edge -- what refuses it is the destination assign being
-    whole-array, so the short run cannot be quietly written into a prefix."""
+    """The per-row form raised here, on the row that came up short. Staging
+    has no row edge, and the array that wraps the staging buffer takes its
+    length from it, so nothing downstream would notice -- the batch would just
+    be short. The explicit length check is what refuses it."""
     seqs = [_decode_seq(range(10)), _decode_seq(range(100, 104))]
-    with pytest.raises(ValueError, match="could not broadcast"):
+    with pytest.raises(ValueError, match="shorter than the window"):
         _build(seqs, [4, 99])
 
     # Control: the same batch with a window each sequence can fill is fine.

--- a/tests/test_scheduled_batch_marshal.py
+++ b/tests/test_scheduled_batch_marshal.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: MIT
+
+"""The two per-sequence marshals in `ScheduledBatch.__init__`.
+
+Both used to write one numpy slice per sequence -- the flat token window, and
+the dense draft-token rows. A numpy slice-assign costs ~245ns of dispatch
+whatever its length, and at decode both rows are a handful of ints, so the
+loops were dispatch and nothing else. They now stage the whole batch and
+assign once.
+
+Each is checked against a golden that is the per-row form it replaced, so the
+tests say "same answer" rather than restating the new code. What the batched
+forms can get wrong that a per-row form could not is what the rest covers: a
+short run has no row edge to raise on, and a concatenate takes its dtype from
+its inputs rather than from the destination.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from atom.model_engine.scheduler import ScheduledBatch
+from atom.model_engine.sequence import Sequence, SequenceType
+
+K = 3  # num_spec_step, as MTP-3 / DSpark would set it
+
+
+def _decode_seq(tokens, *, num_rejected=0):
+    seq = Sequence(list(tokens[:1]), block_size=16)
+    for t in tokens[1:]:
+        seq.append_token(t)
+    seq.type = SequenceType.DECODE
+    seq.num_rejected = num_rejected
+    return seq
+
+
+def _prefill_seq(tokens, *, num_cached=0):
+    seq = Sequence(list(tokens), block_size=16)
+    seq.type = SequenceType.PREFILL
+    seq.num_cached_tokens = num_cached
+    return seq
+
+
+def _build(seqs, nums, *, spec=None, num_spec_step=0):
+    return ScheduledBatch(
+        seqs={s.id: s for s in seqs},
+        num_scheduled_tokens=list(nums),
+        total_tokens_num=sum(nums),
+        total_seqs_num=len(seqs),
+        num_spec_step=num_spec_step,
+        scheduled_spec_decode_tokens=spec,
+    )
+
+
+# ── golden: the per-row forms these replaced ─────────────────────────────
+
+
+def _golden_tokens(seqs, nums):
+    out = np.empty(sum(nums), dtype=np.int32)
+    pos = 0
+    for seq, num in zip(seqs, nums):
+        if seq.type == SequenceType.PREFILL:
+            offset = seq.num_cached_tokens
+        else:
+            offset = seq.num_tokens - seq.num_rejected - num
+        out[pos : pos + num] = seq.token_ids[offset : offset + num]
+        pos += num
+    return out
+
+
+def _golden_drafts(req_ids, spec, k):
+    out = np.zeros((len(req_ids), k), dtype=np.int32)
+    for i, req_id in enumerate(req_ids):
+        drafts = spec.get(req_id)
+        if drafts is None or drafts.size == 0:
+            continue
+        width = min(drafts.size, k)
+        out[i, :width] = drafts[:width]
+    return out
+
+
+# ── the flat token window ────────────────────────────────────────────────
+
+
+def test_pure_decode_batch_matches_the_per_row_form():
+    seqs = [_decode_seq(range(i * 100, i * 100 + 40)) for i in range(1, 9)]
+    nums = [1] * len(seqs)
+    batch = _build(seqs, nums)
+    assert np.array_equal(batch.scheduled_tokens, _golden_tokens(seqs, nums))
+    assert batch.scheduled_tokens.dtype == np.int32
+
+
+def test_mixed_prefill_and_decode_keep_their_own_offsets():
+    """A chunked prefill reads from `num_cached_tokens`, a decode from the
+    tail. Staging them into one run must not blur the two rules together."""
+    seqs = [
+        _prefill_seq(range(1000, 1064), num_cached=16),
+        _decode_seq(range(2000, 2040)),
+        _prefill_seq(range(3000, 3032), num_cached=0),
+        _decode_seq(range(4000, 4040), num_rejected=2),
+    ]
+    nums = [8, 1, 12, 4]
+    batch = _build(seqs, nums)
+    assert np.array_equal(batch.scheduled_tokens, _golden_tokens(seqs, nums))
+
+
+def test_speculative_window_matches_the_per_row_form():
+    seqs = [
+        _decode_seq(range(i * 100, i * 100 + 40), num_rejected=i % 3) for i in range(6)
+    ]
+    nums = [K + 1] * len(seqs)
+    batch = _build(seqs, nums, num_spec_step=K)
+    assert np.array_equal(batch.scheduled_tokens, _golden_tokens(seqs, nums))
+
+
+def test_empty_batch():
+    batch = _build([], [])
+    assert batch.scheduled_tokens.size == 0
+
+
+def test_a_sequence_too_short_for_its_window_raises():
+    """The per-row form raised here, on the row that came up short. A staged
+    run has no row edge -- what refuses it is the destination assign being
+    whole-array, so the short run cannot be quietly written into a prefix."""
+    seqs = [_decode_seq(range(10)), _decode_seq(range(100, 104))]
+    with pytest.raises(ValueError, match="could not broadcast"):
+        _build(seqs, [4, 99])
+
+    # Control: the same batch with a window each sequence can fill is fine.
+    ok = _build(seqs, [4, 4])
+    assert ok.scheduled_tokens.size == 8
+
+
+# ── the dense draft rows ─────────────────────────────────────────────────
+
+
+def _spec_batch(rows, k=K):
+    seqs = [_decode_seq(range(i * 100, i * 100 + 40)) for i in range(len(rows))]
+    spec = {
+        s.id: (None if r is None else np.asarray(r, dtype=np.int32))
+        for s, r in zip(seqs, rows)
+    }
+    spec = {rid: v for rid, v in spec.items() if v is not None}
+    batch = _build(seqs, [k + 1] * len(seqs), spec=spec, num_spec_step=k)
+    return batch, [s.id for s in seqs], spec
+
+
+def test_every_row_full_matches_the_per_row_form():
+    rows = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
+    batch, req_ids, spec = _spec_batch(rows)
+    assert np.array_equal(
+        batch.scheduled_spec_decode_tokens, _golden_drafts(req_ids, spec, K)
+    )
+    assert batch.scheduled_spec_decode_tokens.shape == (len(rows), K)
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [[1, 2, 3], None, [7, 8, 9]],  # a sequence with no drafts yet
+        [[1, 2, 3], [4, 5], [7, 8, 9]],  # a short row, zero-filled
+        [[1, 2, 3], [4, 5, 6, 7], [8, 9, 10]],  # a long row, truncated
+        [None, None],  # nothing drafted at all
+        [[]],  # present but empty
+        # A short row followed by an absent one. The padding is built from a
+        # shared zero row, so padding in place instead of on a copy would leak
+        # the short row's drafts into every undrafted sequence after it.
+        [[4, 5], None, None],
+    ],
+)
+def test_ragged_rows_are_padded_and_match_the_per_row_form(rows):
+    batch, req_ids, spec = _spec_batch(rows)
+    assert np.array_equal(
+        batch.scheduled_spec_decode_tokens, _golden_drafts(req_ids, spec, K)
+    )
+
+
+def test_dtype_comes_from_the_destination_not_the_drafts():
+    """`np.concatenate` of int64 rows yields int64; the per-row form cast into
+    an int32 destination. Consumers index this into int32 buffers."""
+    seqs = [_decode_seq(range(i * 100, i * 100 + 40)) for i in range(3)]
+    spec = {s.id: np.arange(K, dtype=np.int64) for s in seqs}
+    batch = _build(seqs, [K + 1] * 3, spec=spec, num_spec_step=K)
+    assert batch.scheduled_spec_decode_tokens.dtype == np.int32
+
+    # Control: the hazard is real -- unpinned, the rows decide.
+    assert np.concatenate(list(spec.values())).dtype == np.int64
+
+
+def test_the_dense_rows_do_not_alias_the_drafts_they_came_from():
+    """Downstream writes into this array (`prepare_input_ids`). A form that
+    handed back views would corrupt the caller's dict."""
+    seqs = [_decode_seq(range(i * 100, i * 100 + 40)) for i in range(3)]
+    spec = {s.id: np.arange(K, dtype=np.int32) for s in seqs}
+    before = {rid: d.copy() for rid, d in spec.items()}
+    batch = _build(seqs, [K + 1] * 3, spec=spec, num_spec_step=K)
+
+    batch.scheduled_spec_decode_tokens[:] = -1
+    for rid, original in before.items():
+        assert np.array_equal(spec[rid], original)
+
+
+def test_empty_batch_with_speculation_keeps_its_shape():
+    batch = ScheduledBatch(
+        seqs={},
+        num_scheduled_tokens=[],
+        total_tokens_num=0,
+        num_spec_step=K,
+        scheduled_spec_decode_tokens={},
+    )
+    assert batch.scheduled_spec_decode_tokens.shape == (0, K)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -430,7 +430,7 @@ class TestSchedule:
         sched.schedule()
 
         assert pinned.status == SequenceStatus.WAITING
-        assert pinned.block_table == []
+        assert len(pinned.block_table) == 0
         assert sched.waiting.popleft() is pinned
         sched.kv_connector = None
         replacement = seq_factory([10, 11, 12, 13])
@@ -1086,7 +1086,7 @@ class TestPreempt:
         scheduler.schedule()
         scheduler.preempt(seq)
         assert seq.status == SequenceStatus.WAITING
-        assert seq.block_table == []
+        assert len(seq.block_table) == 0
 
 
 # ── postprocess ────────────────────────────────────────────────────────────

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -897,7 +897,7 @@ class TestPrefixCaching:
             )
             batch, _ = sched.schedule()  # next decode step
 
-        assert seq1.token_ids == prompt + generated
+        assert list(seq1.token_ids) == prompt + generated
         # 20 tokens on the seq, but token 20 was sampled this step and no
         # forward has written its KV — the block it closes stays unhashed until
         # the next step consumes it.

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -2,21 +2,22 @@
 # Tests for atom/model_engine/sequence.py — public API only
 
 import pytest
-from atom.sampling_params import SamplingParams
+
 from atom.model_engine.sequence import Sequence, SequenceStatus, get_exit_sequence
+from atom.sampling_params import SamplingParams
 
 
 class TestSequenceCreation:
     def test_token_ids_and_len(self, seq_factory):
         seq = seq_factory([1, 2, 3])
-        assert seq.token_ids == [1, 2, 3]
+        assert list(seq.token_ids) == [1, 2, 3]
         assert len(seq) == 3
 
     def test_token_ids_are_copied(self, seq_factory):
         original = [1, 2, 3]
         seq = seq_factory(original)
         original.append(4)
-        assert seq.token_ids == [1, 2, 3]
+        assert list(seq.token_ids) == [1, 2, 3]
 
     def test_auto_increment_ids(self, seq_factory):
         s1 = seq_factory([1])
@@ -53,12 +54,12 @@ class TestSequenceNumTokensAndBlocks:
 class TestSequenceBlock:
     def test_block_returns_tokens(self, seq_factory):
         seq = seq_factory([10, 20, 30, 40, 50, 60, 70, 80], block_size=4)
-        assert seq.block(0) == [10, 20, 30, 40]
-        assert seq.block(1) == [50, 60, 70, 80]
+        assert list(seq.block(0)) == [10, 20, 30, 40]
+        assert list(seq.block(1)) == [50, 60, 70, 80]
 
     def test_block_partial_last(self, seq_factory):
         seq = seq_factory([10, 20, 30, 40, 50], block_size=4)
-        assert seq.block(1) == [50]
+        assert list(seq.block(1)) == [50]
 
     def test_block_out_of_range(self, seq_factory):
         seq = seq_factory([1, 2], block_size=4)
@@ -70,7 +71,7 @@ class TestSequenceAppendToken:
     def test_append_extends_token_ids(self, seq_factory):
         seq = seq_factory([1, 2])
         seq.append_token(3)
-        assert seq.token_ids == [1, 2, 3]
+        assert list(seq.token_ids) == [1, 2, 3]
         assert len(seq) == 3
         assert seq.last_token == 3
 
@@ -98,8 +99,8 @@ class TestSequenceProperties:
         seq = seq_factory([10, 20, 30])
         seq.append_token(40)
         seq.append_token(50)
-        assert seq.prompt_token_ids == [10, 20, 30]
-        assert seq.completion_token_ids == [40, 50]
+        assert list(seq.prompt_token_ids) == [10, 20, 30]
+        assert list(seq.completion_token_ids) == [40, 50]
         assert seq.num_completion_tokens == 2
 
     def test_getitem(self, seq_factory):
@@ -111,7 +112,7 @@ class TestSequenceProperties:
 class TestGetExitSequence:
     def test_exit_sequence(self):
         seq = get_exit_sequence()
-        assert seq.token_ids == [-1]
+        assert list(seq.token_ids) == [-1]
         assert seq.status == SequenceStatus.EXIT_ENGINE
 
 

--- a/tests/test_token_ids_storage.py
+++ b/tests/test_token_ids_storage.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+
+"""`Sequence.token_ids` is an `array("i")`, and what that costs its consumers.
+
+The storage change pays twice: the scheduler's per-step copy into
+`scheduled_tokens` becomes a memcpy instead of one CPython int unboxing per
+token, and a 100k-token prompt costs 0.38 MiB instead of 3.4.
+
+What it risks is narrower and entirely one shape: an `array("i")` never
+compares equal to a list. Three places compare token ids, and in every one a
+mismatch is silent -- a stop sequence that stops nothing, a prefix cache that
+never hits, a hash that changes with its argument's Python type. Each is
+pinned here with a positive control, because a test that only checked the
+happy path would pass just as well against the versions that were broken.
+"""
+
+from __future__ import annotations
+
+import array
+
+import numpy as np
+import pytest
+
+from atom.model_engine.block_manager import BlockManager
+from atom.model_engine.sequence import Sequence, new_token_ids
+from atom.sampling_params import SamplingParams
+
+
+def _seq(token_ids, **kw):
+    return Sequence(
+        list(token_ids), block_size=4, sampling_params=SamplingParams(), **kw
+    )
+
+
+def test_storage_is_int32_and_holds_what_a_list_held():
+    seq = _seq([0, 1, 129279, -1])
+    assert isinstance(seq.token_ids, array.array)
+    assert seq.token_ids.typecode == "i"
+    # -1 is the exit sentinel and 129279 the top of this vocab; both must round
+    # trip, which rules out an unsigned typecode.
+    assert list(seq.token_ids) == [0, 1, 129279, -1]
+
+
+def test_the_operations_a_sequence_performs_on_it():
+    seq = _seq([1, 2, 3])
+    seq.append_token(4)
+    assert seq[-1] == 4 and len(seq) == 4
+    del seq.token_ids[-1:]
+    seq.token_ids[0] = 9
+    assert list(seq.token_ids) == [9, 2, 3]
+    assert list(seq.block(0)) == [9, 2, 3]
+
+
+# --- the three comparisons, each with its control ------------------------
+
+
+def test_stop_sequences_are_stored_in_the_same_type_they_are_compared_against():
+    """`Scheduler._check_stop` does `seq.token_ids[a:b] == stop_seq`.
+
+    Left as lists, that comparison is False for every input and generation
+    never stops on a stop sequence -- with no error anywhere.
+    """
+    seq = _seq([1, 2, 3, 4], stop_token_sequences=[[3, 4], [9]])
+    for stored in seq.stop_token_sequences:
+        assert isinstance(stored, array.array), "a list here never matches"
+    assert seq.token_ids[2:4] == seq.stop_token_sequences[0]
+
+    # Control: the shape of the bug this guards.
+    assert seq.token_ids[2:4] != [3, 4]
+
+
+def test_compute_hash_does_not_depend_on_its_argument_type():
+    """`np.array` infers int64 from a list and int32 from an `array("i")`.
+
+    Unpinned, the digest changed with the caller's Python type, so two paths
+    hashing the same tokens would miss each other in the prefix cache.
+    """
+    ids = [11, 22, 33, 44]
+    assert BlockManager.compute_hash(ids) == BlockManager.compute_hash(
+        new_token_ids(ids)
+    )
+    assert BlockManager.compute_hash(ids, 7) == BlockManager.compute_hash(
+        new_token_ids(ids), 7
+    )
+
+    # Control: unpinned is what differed, and int64 is the value lists gave --
+    # so pinning it leaves every hash recorded before this change where it was.
+    unpinned = {np.array(ids).tobytes(), np.array(new_token_ids(ids)).tobytes()}
+    assert len(unpinned) == 2, "the dtype inference this pins is no longer a hazard"
+    assert np.asarray(ids, dtype=np.int64).tobytes() == np.array(ids).tobytes()
+
+
+def test_a_block_and_the_slice_it_is_compared_against_share_a_type():
+    """`BlockManager` publishes a slice of `seq.token_ids` into a block, then
+    compares a fresh slice against it to confirm a cache hit. Two types there
+    means the hit is rejected and the prefix is recomputed, silently."""
+    seq = _seq(range(8))
+    published = seq.token_ids[0:4]
+    fresh = seq.token_ids[0:4]
+    assert published == fresh
+    assert published != list(fresh)  # control: the mismatch is real
+
+
+# --- what the change is for ----------------------------------------------
+
+
+@pytest.mark.parametrize("n", [8, 2048])
+def test_a_chunk_lands_in_a_numpy_buffer_without_unboxing(n):
+    """The scheduler's hot copy. Correctness here; the speed is in
+    `/app/logs_claude/o10_scheduled_tokens_marshal.py`."""
+    seq = _seq(range(n))
+    dst = np.empty(n, dtype=np.int32)
+    dst[:] = seq.token_ids[:n]
+    assert np.array_equal(dst, np.arange(n, dtype=np.int32))

--- a/tests/test_upload_numpy.py
+++ b/tests/test_upload_numpy.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MIT
+
+"""`upload_numpy` picks a transfer route by size, and the size that matters.
+
+The helper exists because a pageable host-to-device copy larger than the
+driver's staging buffer stops being a hand-off: the host waits for it, on the
+current stream, behind everything already queued. Under that size it costs the
+same as anything else and allocates nothing.
+
+Two things are worth holding here. The obvious one is that the bytes arrive
+whichever branch runs. The other is that the threshold is not decoration -- a
+test that only checked correctness would pass just as well against a helper
+that always took one branch, so the cliff itself is measured.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from atom.utils import _PAGEABLE_H2D_LIMIT, upload_numpy
+
+if not torch.cuda.is_available():
+    pytest.skip("host-to-device transfer needs a real GPU", allow_module_level=True)
+
+DEV = torch.device("cuda:0")
+
+
+def _arr(nbytes, dtype=np.int32):
+    n = nbytes // np.dtype(dtype).itemsize
+    return np.arange(n, dtype=dtype) % 30011
+
+
+@pytest.mark.parametrize(
+    "nbytes",
+    [4, 4096, _PAGEABLE_H2D_LIMIT - 4, _PAGEABLE_H2D_LIMIT, _PAGEABLE_H2D_LIMIT * 3],
+    ids=["tiny", "4k", "just-under", "at-limit", "over"],
+)
+@pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32])
+def test_the_bytes_arrive_on_either_side_of_the_cliff(nbytes, dtype):
+    arr = _arr(nbytes, dtype)
+    got = upload_numpy(arr, DEV)
+    torch.cuda.synchronize()
+    assert got.device.type == "cuda"
+    assert np.array_equal(got.cpu().numpy(), arr)
+
+
+def test_a_non_contiguous_source_still_arrives():
+    """`from_numpy` rejects a negative stride and copies a gapped one; either
+    way the caller gets the values it passed."""
+    arr = np.arange(4096, dtype=np.int32).reshape(64, 64)[:, ::2].copy()
+    got = upload_numpy(arr, DEV)
+    torch.cuda.synchronize()
+    assert np.array_equal(got.cpu().numpy(), arr)
+
+
+_FILLER = None
+
+
+def _queue_filler():
+    global _FILLER
+    if _FILLER is None:
+        _FILLER = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEV)
+    return _FILLER
+
+
+def _cost_behind_queued_work(upload, depth=6, nreps=40):
+    """Host ms charged to `upload` with `depth` matmuls already in flight.
+
+    The queue is what makes the difference visible: a synchronizing copy waits
+    out everything on the stream, not just its own bytes -- so its cost grows
+    with `depth` and a real async one's does not.
+    """
+    import timeit
+
+    # Built once for the module, not per call: a fresh 32 MB tensor each time
+    # churns the caching allocator, and that noise lands on whichever route is
+    # measured next -- it read as a 10x worse slope for the helper.
+    a = _queue_filler()
+
+    def enqueue():
+        for _ in range(depth):
+            a @ a
+
+    def both():
+        enqueue()
+        upload()
+
+    for fn in (enqueue, both):
+        fn()
+    torch.cuda.synchronize()
+    base = sorted(timeit.repeat(enqueue, number=1, repeat=nreps))[nreps // 2]
+    torch.cuda.synchronize()
+    got = sorted(timeit.repeat(both, number=1, repeat=nreps))[nreps // 2]
+    torch.cuda.synchronize()
+    return (got - base) * 1e3
+
+
+def test_the_helper_is_what_keeps_a_large_upload_off_the_cliff():
+    """Positive control for the threshold.
+
+    Past the limit a plain `.to()` blocks until the queue drains and the
+    helper's route does not. Without this the parametrisation above would pass
+    against a constant of any value, including one that never takes the second
+    branch.
+    """
+    big = _arr(_PAGEABLE_H2D_LIMIT * 3)
+
+    def raw():
+        torch.from_numpy(big).to(DEV, non_blocking=True)
+
+    def helper():
+        upload_numpy(big, DEV)
+
+    # Slope against queue depth, not cost at one depth: a copy that
+    # synchronizes inherits the queue, so its cost has a slope and an async
+    # one's does not. A ratio at a single depth would be another unexplained
+    # threshold sitting on top of the one under test.
+    lo, hi = 4, 24
+    raw_slope = (
+        _cost_behind_queued_work(raw, depth=hi) - _cost_behind_queued_work(raw, lo)
+    ) / (hi - lo)
+    helper_slope = (
+        _cost_behind_queued_work(helper, depth=hi)
+        - _cost_behind_queued_work(helper, lo)
+    ) / (hi - lo)
+    print(
+        f"\n{big.nbytes:,} B  host us per queued matmul: "
+        f"pageable {raw_slope * 1000:+.1f}, helper {helper_slope * 1000:+.1f}"
+    )
+    assert raw_slope > 0.01, (
+        "pageable cost did not grow with queue depth, so nothing here is "
+        f"synchronizing and the threshold is untested: {raw_slope * 1000:+.1f} "
+        "us per queued matmul"
+    )
+    # A loose gate on purpose. Over the cliff the helper can only reach for a
+    # fresh pinned block, which measured about 2.4x better than pageable rather
+    # than free -- a shared reusable block does no better, for the reason in
+    # `upload_numpy`'s docstring. Asserting more would be asserting a number
+    # this route cannot deliver.
+    assert helper_slope < raw_slope / 1.5, (
+        "the helper inherits the queue nearly as much as a plain `.to()`: "
+        f"{helper_slope * 1000:+.1f} vs {raw_slope * 1000:+.1f} us each"
+    )

--- a/tests/test_v4_block_tables_per_token.py
+++ b/tests/test_v4_block_tables_per_token.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+
+"""Expanding `block_tables[bs]` into the per-query-row table the MQA kernel reads.
+
+`_attach_v4_paged_decode_meta` used to build this on the host -- zero the whole
+buffer, mask the rows whose `mqa_row_to_batch` is not -1, gather those from
+`block_tables`, ship the result -- and now gathers it on the device from
+tensors that are already there.
+
+That swap rests on one property of the row -> seq map: **the rows it marks
+invalid are a contiguous tail**. If they were interior, `index_select` over a
+prefix would fill the wrong rows and only the padding rows -- which the kernel
+skips because their `n_committed_per_token` is 0 -- would hide it. So the tail
+property is asserted directly, for both row layouts, before the gather is
+compared against the host expansion it replaces.
+
+The gather is exercised on CPU tensors; `torch.index_select` does not care, and
+the arithmetic under test is the arithmetic the device runs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+COLS = 16
+MAX_BS = 64
+
+
+def _block_tables(bs: int) -> np.ndarray:
+    """`block_tables` as the buffer holds it: `bs` live rows, the rest stale."""
+    rng = np.random.default_rng(bs)
+    bt = np.full((MAX_BS, COLS), -999, dtype=np.int32)  # stale rows, must not leak
+    bt[:bs] = rng.integers(1, 20_000, size=(bs, COLS)).astype(np.int32)
+    return bt
+
+
+def _per_token_layout(bs: int, tokens_per_seq: int, t_pad: int):
+    """One row per query token: the map is `batch_id_per_token`, padded with -1."""
+    t = bs * tokens_per_seq
+    old = np.full(t_pad, -1, dtype=np.int32)
+    old[:t] = np.repeat(np.arange(bs, dtype=np.int32), tokens_per_seq)
+    return old, old[:t].copy(), t
+
+
+def _rect_layout(bs: int, full_q: int, rect_bs: int):
+    """dspark's rectangular layout: `full_q` slots per sequence."""
+    old = np.full(rect_bs * full_q, -1, dtype=np.int32)
+    old[: bs * full_q] = np.repeat(np.arange(bs, dtype=np.int32), full_q)
+    new = (
+        torch.arange(bs * full_q, dtype=torch.int32)
+        .div_(full_q, rounding_mode="floor")
+        .numpy()
+    )
+    return old, new, bs * full_q
+
+
+LAYOUTS = [
+    ("per-token bs=1", _per_token_layout(1, 8, 16)),
+    ("per-token bs=50", _per_token_layout(50, 8, 512)),
+    ("per-token unpadded", _per_token_layout(4, 3, 12)),
+    ("rect full_q=4", _rect_layout(5, 4, 8)),
+    ("rect no pad", _rect_layout(6, 2, 6)),
+]
+
+
+@pytest.mark.parametrize("name,layout", LAYOUTS, ids=[n for n, _ in LAYOUTS])
+def test_invalid_rows_are_a_contiguous_tail(name, layout):
+    old_map, _, n_valid = layout
+    (invalid,) = np.nonzero(old_map < 0)
+    assert np.array_equal(
+        invalid, np.arange(n_valid, len(old_map))
+    ), "gathering over a prefix assumes every -1 row sits past the valid ones"
+
+
+@pytest.mark.parametrize("name,layout", LAYOUTS, ids=[n for n, _ in LAYOUTS])
+def test_device_gather_matches_the_host_expansion(name, layout):
+    old_map, new_idx, n_valid = layout
+    bs = int(old_map.max()) + 1
+    bt = _block_tables(bs)
+    rows = len(old_map)
+
+    # What the host used to build.
+    want = np.zeros((rows, COLS), dtype=np.int32)
+    valid = old_map >= 0
+    want[valid] = bt[:bs][old_map[valid]]
+
+    # What the device now builds, into a buffer left dirty by a prior step.
+    dst = torch.full((rows, COLS), -7, dtype=torch.int32)
+    torch.index_select(
+        torch.from_numpy(bt), 0, torch.from_numpy(new_idx), out=dst[:n_valid]
+    )
+    dst[n_valid:].zero_()
+
+    assert np.array_equal(dst.numpy(), want)
+    assert (dst.numpy()[n_valid:] == 0).all()
+    assert -999 not in dst.numpy(), "a stale block_tables row reached the output"
+
+
+def test_a_gather_that_ignored_the_tail_would_be_caught():
+    """Positive control: the comparison above has to fail on a wrong gather.
+
+    Without it, `test_device_gather_matches_the_host_expansion` would pass
+    against an implementation that never cleared the padding rows, since those
+    rows are the only place the two can differ.
+    """
+    old_map, new_idx, n_valid = _per_token_layout(4, 3, 20)
+    bs = int(old_map.max()) + 1
+    bt = _block_tables(bs)
+    want = np.zeros((len(old_map), COLS), dtype=np.int32)
+    want[old_map >= 0] = bt[:bs][old_map[old_map >= 0]]
+
+    dst = torch.full((len(old_map), COLS), -7, dtype=torch.int32)
+    torch.index_select(
+        torch.from_numpy(bt), 0, torch.from_numpy(new_idx), out=dst[:n_valid]
+    )
+    # ... and here the `dst[n_valid:].zero_()` is deliberately omitted.
+    assert not np.array_equal(dst.numpy(), want)
+
+
+def test_index_select_takes_an_int32_index_and_a_sliced_out():
+    """The two properties the call site relies on, neither of them guaranteed.
+
+    A silent promotion to int64 would allocate per step, and an `out=` that
+    rejected a row slice would force a second copy.
+    """
+    src = torch.arange(12, dtype=torch.int32).reshape(4, 3)
+    idx = torch.tensor([2, 0], dtype=torch.int32)
+    dst = torch.zeros((3, 3), dtype=torch.int32)
+    out = torch.index_select(src, 0, idx, out=dst[:2])
+
+    assert out.dtype == torch.int32
+    assert dst.tolist() == [[6, 7, 8], [0, 1, 2], [0, 0, 0]]
+    assert out.data_ptr() == dst.data_ptr(), "out= must write the caller's buffer"


### PR DESCRIPTION
## What this is

Twelve commits against the host-side path between two forwards, found by
profiling DeepSeek-V4-Flash-DSpark at 100k-token prompts. Nothing here changes
what the engine computes -- every change is a different way of getting the same
bytes into the same buffers.

One shape accounts for most of it: **a numpy slice-assign costs ~245ns of
dispatch whatever its length**, so a marshal that writes one row per sequence
is dispatch and nothing else once the batch is large and the rows are short.
The repo had six of those. Four are fixed here behind one helper
(`atom.utils.pack_rows`); the fifth is a documented reference path and the
sixth sits behind a flag that is off by default.

## Changes

**Storage** — `Sequence.token_ids` and `Sequence.block_table` become
`array("i")`. Both are marshalled into int32 buffers every forward, where a
list costs one CPython int unboxing per element. A 100k-token prompt also drops
from 3.4 MiB of boxed ints to 0.38.

**Marshals** — `pack_rows` writes ragged rows through one `memoryview` of the
destination (~46ns per row against ~245ns). `ScheduledBatch.__init__` stages
its flat token window into one array and wraps it with `np.frombuffer`, and
densifies speculative draft rows with one `concatenate`.

**Device work that was being done on the host** — the per-token block-table
expansion becomes an `index_select` on the device, and the HCA compress indices
are built inside the existing `paged_decode_indices` Triton kernel from block
tables already resident there.

**Host-to-device route** — `upload_numpy` picks pageable or pinned by the size
that actually decides it (a 512 KB staging-buffer cliff, measured). Ten call
sites had the route hardcoded, in both directions.

## Measured (MI355X)

| | before | after |
|---|---|---|
| block-table marshal, bs=256 x 512 cols | 2.235 ms | 0.030 |
| same, 1M context (4096 cols) | 17.33 ms | 0.128 |
| same, 16384 short rows | 8.55 ms | 1.52 |
| per-token block table, bs=256 | 0.205 ms + 4 MB H2D | 0.006 |
| HCA compress indices, bs=256 / 90k ctx | 15.8 ms + 6.8 MB H2D | 0.032 |
| `ScheduledBatch.__init__`, bs=256 k=5 | 0.330 ms | 0.138 |
| `token_ids` marshal, 100k prompt | 1.94 ms | 0.90 |

Pinned host memory drops 45 MiB at 131k context and 213 MiB at 1M, from three
V4 metadata buffers that are written and read only by kernels and never needed
a host mirror.

Trace confirmation: per inter-forward interval, H2D goes 2,469,856 -> 102,400
bytes, and the two removed copies match their predicted sizes exactly
(1,048,576 and 1,318,880). Largest GPU gap in a decode step 2.360 -> 0.020 ms.

## Correctness

An `array("i")` never compares equal to a list, and three places compare token
ids -- a stop-sequence check, a prefix-cache block compare, and a hash. Each
failed silently rather than loudly, so each is pinned by a test carrying a
positive control. `BlockManager.compute_hash` also had a latent bug this
surfaced: it inferred int64 from a list and int32 from an array, so the digest
depended on the caller's Python type. It is pinned to int64, which is what
lists produced, so no recorded hash moves.

## Test plan

- [x] CI's non-GPU job: 1917 passed, 123 skipped, no errors.
- [x] Locally, where AITER and the GPUs are present:
      `bash .github/scripts/run_unit_tests.sh` -- 2424 passed, 54 skipped.
      Nine failures are pre-existing on the base commit (`ffdf3bb5d`): four
      eplb, three WoA dequant, two tracing.
- [x] 6 new test files / 103 new cases, covering the marshals, the upload
      routing, the storage change and the fused kernel. Every guard added here
      was mutation-tested -- the check was removed and the test confirmed to
      fail (9 mutations).
- [x] GSM8K 3-shot on `/mnt/DeepSeek-V4-Flash-DSpark` tp1, fp8 KV + fp4
      indexer + DSpark 5, seven runs: 0.9500 / 0.9477 / 0.9500 / 0.9484 /
      0.9538 / 0.9492 / 0.9530. MTP acceptance 65.11-65.30% at 4.26 toks/fwd.
      No faults. One run had prefix caching on, to exercise the hash and block
      compare paths.
- [x] `black` and `ruff` clean on every touched file.
- [ ] Multi-GPU: all accuracy runs are tp1 and the trace work is tp8, but the
      TBO straddle path and the DCP branches in `aiter_mla` are covered by unit
      tests only. Worth a look from someone who runs those.

## Not included

`prepare_prefill` builds two Python lists the length of the whole chunk, which
measures at 0.69 ms per prefill step at mnbt=16384 and would go to ~0.09 with
numpy. It is left out because the same function has a DCP branch that cannot be
vectorized the same way, and that deserves its own change.
