### PR TITLE
refactor(openai): one reader per wire format, for both delivery modes

### DIFF
--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -23,6 +23,7 @@ from atom.entrypoints.openai.chat_encoders import (
     apply_chat_template,
     chat_template_source,
     load_custom_message_encoder,
+    render_probe_prompt,
 )
 from atom.entrypoints.openai.protocol import (
     CHAT_COMPLETION_CHUNK_OBJECT,
@@ -35,12 +36,15 @@ from atom.entrypoints.openai.protocol import (
     CompletionRequest,
 )
 from atom.entrypoints.openai.reasoning import (
-    ReasoningFilter,
+    NO_REASONING,
+    ReasoningChannel,
     prompt_starts_in_reasoning,
     template_opens_reasoning_implicitly,
 )
+from atom.entrypoints.openai.reasoning_dialects import resolve_dialect
 from atom.entrypoints.openai.serving_chat import (
     _normalize_finish_reason,
+    finish_reason_with_calls,
     build_chat_response,
     build_chat_response_multi,
     create_chat_chunk,
@@ -53,7 +57,7 @@ from atom.entrypoints.openai.serving_completion import (
 from atom.entrypoints.openai.sse import data_frame
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser
 from atom.entrypoints.openai.tool_parser.registry import (
-    parser_for_tool_choice,
+    forbids_tool_calls,
     resolve_tool_call_parser,
 )
 from atom.model_engine.sequence import new_token_ids
@@ -95,6 +99,21 @@ class AtomEngineService:
             set()
         )
         self._active_futures_lock = threading.Lock()
+        # The engine sequences behind each open stream, so closing one can
+        # stop it. Nothing here used to: `close_*_stream` popped the Python
+        # state and the sequence kept decoding to `max_tokens` on the GPU,
+        # putting into a queue no one would ever read again and holding its
+        # KV blocks for the life of the process. The OpenAI server does this
+        # from a generator's `finally`; this service is polled, so it has to
+        # be done where the caller says it is done.
+        self._stream_seqs: dict[str, list[Any]] = {}
+        # Streams closed before the worker thread got round to submitting
+        # them. `start_stream` only enqueues; the sequences do not exist until
+        # `_submit_stream_request` runs, so a close in between had nothing to
+        # abort and the sequence was added to the engine *afterwards* -- the
+        # exact case the abort exists for, and the one it missed.
+        self._abandoned: set[str] = set()
+        self._stream_seqs_lock = threading.Lock()
         self._worker = threading.Thread(
             target=self._worker_loop,
             name="AtomStandaloneEngineService",
@@ -220,11 +239,65 @@ class AtomEngineService:
         return stream_queue
 
     def _submit_stream_request(self, request: EngineStreamRequest) -> None:
+        if self._take_abandoned(request.request_id):
+            return
         if request.effective_n > 1:
             seqs = self._preprocess_fanout_stream_request(request)
         else:
             seqs = [self._preprocess_single_stream_request(request)]
+        with self._stream_seqs_lock:
+            # Checked again: the close may have arrived while this was
+            # preprocessing. Sequences built and never added to the engine
+            # cost nothing to drop -- there is no abort to do.
+            if request.request_id in self._abandoned:
+                self._abandoned.discard(request.request_id)
+                return
+            self._stream_seqs[request.request_id] = list(seqs)
         self.engine.core_mgr.add_request(seqs)
+
+    def _take_abandoned(self, request_id: str) -> bool:
+        with self._stream_seqs_lock:
+            if request_id not in self._abandoned:
+                return False
+            self._abandoned.discard(request_id)
+            return True
+
+    def forget_stream(self, request_id: str) -> None:
+        """Drop what is remembered about a stream that ended on its own.
+
+        Without this the sequence list for every completed stream stays for
+        the life of the process; `abort_stream` only removes the ones a caller
+        closes, and the engine has already forgotten those sequences by then
+        anyway.
+        """
+        with self._stream_seqs_lock:
+            self._stream_seqs.pop(request_id, None)
+            self._abandoned.discard(request_id)
+
+    def abort_stream(self, request_id: str) -> None:
+        """Stop the sequences behind a stream the caller has finished with.
+
+        Idempotent, and safe to call on a stream that ended normally: the
+        engine has already forgotten those sequences and says so by raising,
+        which is not an error here.
+        """
+        with self._stream_seqs_lock:
+            seqs = self._stream_seqs.pop(request_id, None)
+            if seqs is None:
+                # Not submitted yet. Remember, so it never is.
+                self._abandoned.add(request_id)
+                return
+        for seq in seqs:
+            seq_id = getattr(seq, "id", None)
+            if seq_id is None:
+                continue
+            try:
+                self.engine.core_mgr.abort_request(seq_id)
+            except (AttributeError, KeyError, RuntimeError, ValueError) as exc:
+                logger.debug("abort_request(%s): %s", seq_id, exc)
+            requests = getattr(self.engine.io_processor, "requests", None)
+            if requests is not None:
+                requests.pop(seq_id, None)
 
     def _preprocess_single_stream_request(self, request: EngineStreamRequest) -> Any:
         state = StreamRequestState(
@@ -530,7 +603,7 @@ class ChatCompletionStreamState:
         stream_queue: queue.Queue[dict[str, Any]],
         n: int,
         tool_parser_cls: type | None = None,
-        model_starts_in_reasoning: bool = False,
+        reasoning: ReasoningChannel = NO_REASONING,
         tools: list | None = None,
         tool_choice: Any = None,
     ) -> None:
@@ -544,12 +617,7 @@ class ChatCompletionStreamState:
         # its whole trace delivered as the answer: state 0 no longer infers
         # reasoning from a bare end marker, because inferring it means waiting
         # for one.
-        starts_thinking = (
-            prompt_starts_in_reasoning(prompt) or model_starts_in_reasoning
-        )
-        self.reasoning_filters = [
-            ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
-        ]
+        self.reasoning_filters = [reasoning.stream() for _ in range(n)]
         # `tool_choice="none"` forbids tool calls on this path too, and
         # `tools` is what type-coerces the arguments. The OpenAI server gated
         # and passed both; this one had neither, so the same request answered
@@ -558,7 +626,8 @@ class ChatCompletionStreamState:
         self.tool_parsers = [
             ToolCallStreamParser(
                 tools=tools,
-                parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice),
+                parser_cls=tool_parser_cls,
+                suppress_calls=forbids_tool_calls(tool_choice),
             )
             for _ in range(n)
         ]
@@ -583,8 +652,8 @@ class ChatCompletionStreamState:
         chunks: list[str] = []
         with self._lock:
             self._append_initial_role_chunks(chunks, max_items)
-            if not self.completed and all(self.finished):
-                chunks.extend(self._final_chunks(max_items - len(chunks)))
+            if not self.completed:
+                chunks.extend(self._hand_out(max_items - len(chunks)))
             if chunks or self.completed or self.closed:
                 return chunks
 
@@ -593,8 +662,8 @@ class ChatCompletionStreamState:
                 event = self.stream_queue.get(timeout=timeout if not chunks else 0.0)
             except queue.Empty:
                 with self._lock:
-                    if not self.completed and all(self.finished):
-                        chunks.extend(self._final_chunks(max_items - len(chunks)))
+                    if not self.completed:
+                        chunks.extend(self._hand_out(max_items - len(chunks)))
                 break
 
             with self._lock:
@@ -633,11 +702,9 @@ class ChatCompletionStreamState:
                     self._error_chunk(str(event["error"])),
                     STREAM_DONE_MESSAGE,
                 ]
-            return self._drain_pending_final_chunks(remaining_capacity)
+            return self._hand_out(remaining_capacity)
         if event.get("done"):
-            if not self.completed and all(self.finished):
-                return self._final_chunks(remaining_capacity)
-            return []
+            return [] if self.completed else self._hand_out(remaining_capacity)
 
         index = int(event["index"])
         if self.finished[index]:
@@ -733,46 +800,40 @@ class ChatCompletionStreamState:
         self._pending_chunks.extend(chunks)
         return self._hand_out(remaining_capacity)
 
-    def _final_chunks(self, remaining_capacity: int) -> list[str]:
-        if self._pending_final_chunks is None:
-            chunks: list[str] = []
-            for index, has_tool_calls in enumerate(self.has_tool_calls):
-                finish_reason = (
-                    "tool_calls"
-                    if has_tool_calls
-                    else (
-                        _normalize_finish_reason(self.engine_finish_reasons[index])
-                        or "stop"
-                    )
+    def _build_final_chunks(self) -> list[str]:
+        """The finish/usage/[DONE] tail, built once. Only `_hand_out` calls
+        this, and only once nothing built is still queued."""
+        chunks: list[str] = []
+        for index, has_tool_calls in enumerate(self.has_tool_calls):
+            finish_reason = finish_reason_with_calls(
+                self.engine_finish_reasons[index], has_tool_calls
+            )
+            chunks.append(
+                create_chat_chunk(
+                    self.request_id,
+                    self.model_name,
+                    finish_reason=finish_reason,
+                    index=index,
                 )
-                chunks.append(
-                    create_chat_chunk(
-                        self.request_id,
-                        self.model_name,
-                        finish_reason=finish_reason,
-                        index=index,
-                    )
-                )
-            completion_tokens = sum(self.num_tokens_output)
-            usage = {
-                "prompt_tokens": self.num_tokens_input,
-                "completion_tokens": completion_tokens,
-                "total_tokens": self.num_tokens_input + completion_tokens,
-            }
-            if len(self.num_tokens_output) > 1:
-                usage["num_choices"] = len(self.num_tokens_output)
-            usage_chunk = {
-                "id": self.request_id,
-                "object": CHAT_COMPLETION_CHUNK_OBJECT,
-                "created": int(time.time()),
-                "model": self.model_name,
-                "usage": usage,
-            }
-            chunks.append(data_frame(usage_chunk))
-            chunks.append(STREAM_DONE_MESSAGE)
-            self._pending_final_chunks = chunks
-
-        return self._drain_pending_final_chunks(remaining_capacity)
+            )
+        completion_tokens = sum(self.num_tokens_output)
+        usage = {
+            "prompt_tokens": self.num_tokens_input,
+            "completion_tokens": completion_tokens,
+            "total_tokens": self.num_tokens_input + completion_tokens,
+        }
+        if len(self.num_tokens_output) > 1:
+            usage["num_choices"] = len(self.num_tokens_output)
+        usage_chunk = {
+            "id": self.request_id,
+            "object": CHAT_COMPLETION_CHUNK_OBJECT,
+            "created": int(time.time()),
+            "model": self.model_name,
+            "usage": usage,
+        }
+        chunks.append(data_frame(usage_chunk))
+        chunks.append(STREAM_DONE_MESSAGE)
+        return chunks
 
     def _take_pending(self, remaining_capacity: int) -> list[str]:
         """As many built chunks as the caller has room for; the rest wait."""
@@ -783,15 +844,31 @@ class ChatCompletionStreamState:
         return out
 
     def _hand_out(self, remaining_capacity: int) -> list[str]:
-        """Queued chunks first, then the final ones once nothing is queued."""
+        """The one exit. Queued chunks first; terminal ones only after them.
+
+        Every producer returns through here, and that is the whole of the
+        rule: "every sibling finished" is not the same fact as "everything
+        built has been sent", and three places used the first as a proxy for
+        the second. The terminal chunks were then handed out while built
+        chunks were still queued -- and once the finals go, `completed` is set
+        and the caller pops the state, so the queued ones are gone. Measured
+        at the production `max_items`: a response with nine tool calls
+        delivered eight and reported `finish_reason: tool_calls`; at
+        `max_items=1` a single call reported `tool_calls` having sent no
+        `tool_calls` delta at all.
+        """
         out = self._take_pending(remaining_capacity)
-        if (
-            all(self.finished)
-            and not self._pending_chunks
-            and len(out) < remaining_capacity
-        ):
-            out.extend(self._final_chunks(remaining_capacity - len(out)))
-        return out
+        # `_take_pending` never returns more than the caller asked for, so no
+        # room left means chunks are still queued -- there is nothing to test
+        # for beyond that, and a second condition here would be a guard that
+        # cannot fail.
+        if len(out) >= remaining_capacity:
+            return out
+        if self._pending_final_chunks is None:
+            if not all(self.finished):
+                return out
+            self._pending_final_chunks = self._build_final_chunks()
+        return out + self._drain_pending_final_chunks(remaining_capacity - len(out))
 
     def _drain_pending_final_chunks(self, remaining_capacity: int) -> list[str]:
         if not self._pending_final_chunks or remaining_capacity <= 0:
@@ -840,8 +917,8 @@ class CompletionStreamState:
         max_items = max(1, int(max_items))
         chunks: list[str] = []
         with self._lock:
-            if not self.completed and all(self.finished):
-                chunks.extend(self._final_chunks(max_items))
+            if not self.completed:
+                chunks.extend(self._hand_out(max_items - len(chunks)))
             if chunks or self.completed or self.closed:
                 return chunks
 
@@ -850,8 +927,8 @@ class CompletionStreamState:
                 event = self.stream_queue.get(timeout=timeout if not chunks else 0.0)
             except queue.Empty:
                 with self._lock:
-                    if not self.completed and all(self.finished):
-                        chunks.extend(self._final_chunks(max_items - len(chunks)))
+                    if not self.completed:
+                        chunks.extend(self._hand_out(max_items - len(chunks)))
                 break
 
             with self._lock:
@@ -875,11 +952,9 @@ class CompletionStreamState:
                     self._error_chunk(str(event["error"])),
                     STREAM_DONE_MESSAGE,
                 ]
-            return self._drain_pending_final_chunks(remaining_capacity)
+            return self._hand_out(remaining_capacity)
         if event.get("done"):
-            if not self.completed and all(self.finished):
-                return self._final_chunks(remaining_capacity)
-            return []
+            return [] if self.completed else self._hand_out(remaining_capacity)
 
         index = int(event["index"])
         if self.finished[index]:
@@ -893,12 +968,20 @@ class CompletionStreamState:
             extra_fields["kv_transfer_params"] = event["kv_transfer_params"]
 
         self.num_tokens_output[index] += len(event.get("token_ids", []))
+        if event.get("finish_reason"):
+            self.engine_finish_reasons[index] = event["finish_reason"]
         chunks = [
             create_completion_chunk(
                 self.request_id,
                 self.model_name,
                 event.get("text") or "",
-                finish_reason=event.get("finish_reason"),
+                # The reason goes on the final chunk, as it does on every
+                # other streaming path here and in the OpenAI server. It used
+                # to go on this one too, unnormalised -- so a client saw the
+                # engine's own `max_tokens` on a content chunk and `stop` on
+                # the terminal one, and `engine_finish_reasons`, which exists
+                # to carry it to the terminal one, was never written at all.
+                finish_reason=None,
                 index=index,
                 **extra_fields,
             )
@@ -910,39 +993,45 @@ class CompletionStreamState:
         self._pending_chunks.extend(chunks)
         return self._hand_out(remaining_capacity)
 
-    def _final_chunks(self, remaining_capacity: int) -> list[str]:
-        if self._pending_final_chunks is None:
-            chunks: list[str] = []
-            for index in range(len(self.num_tokens_output)):
-                chunks.append(
-                    create_completion_chunk(
-                        self.request_id,
-                        self.model_name,
-                        "",
-                        finish_reason="stop",
-                        index=index,
-                    )
+    def _build_final_chunks(self) -> list[str]:
+        """The finish/usage/[DONE] tail, built once. Only `_hand_out` calls
+        this, and only once nothing built is still queued."""
+        chunks: list[str] = []
+        for index in range(len(self.num_tokens_output)):
+            # The engine's own reason, as the chat path reports it. This
+            # was recorded per sibling and then never read: every
+            # completion said `stop`, including one the engine cut off at
+            # `max_tokens`, which `stream=false` reported as `length`.
+            chunks.append(
+                create_completion_chunk(
+                    self.request_id,
+                    self.model_name,
+                    "",
+                    finish_reason=(
+                        _normalize_finish_reason(self.engine_finish_reasons[index])
+                        or "stop"
+                    ),
+                    index=index,
                 )
-            completion_tokens = sum(self.num_tokens_output)
-            usage = {
-                "prompt_tokens": self.num_tokens_input,
-                "completion_tokens": completion_tokens,
-                "total_tokens": self.num_tokens_input + completion_tokens,
-            }
-            if len(self.num_tokens_output) > 1:
-                usage["num_choices"] = len(self.num_tokens_output)
-            usage_chunk = {
-                "id": self.request_id,
-                "object": TEXT_COMPLETION_OBJECT,
-                "created": int(time.time()),
-                "model": self.model_name,
-                "usage": usage,
-            }
-            chunks.append(data_frame(usage_chunk))
-            chunks.append(STREAM_DONE_MESSAGE)
-            self._pending_final_chunks = chunks
-
-        return self._drain_pending_final_chunks(remaining_capacity)
+            )
+        completion_tokens = sum(self.num_tokens_output)
+        usage = {
+            "prompt_tokens": self.num_tokens_input,
+            "completion_tokens": completion_tokens,
+            "total_tokens": self.num_tokens_input + completion_tokens,
+        }
+        if len(self.num_tokens_output) > 1:
+            usage["num_choices"] = len(self.num_tokens_output)
+        usage_chunk = {
+            "id": self.request_id,
+            "object": TEXT_COMPLETION_OBJECT,
+            "created": int(time.time()),
+            "model": self.model_name,
+            "usage": usage,
+        }
+        chunks.append(data_frame(usage_chunk))
+        chunks.append(STREAM_DONE_MESSAGE)
+        return chunks
 
     def _take_pending(self, remaining_capacity: int) -> list[str]:
         """As many built chunks as the caller has room for; the rest wait."""
@@ -953,15 +1042,31 @@ class CompletionStreamState:
         return out
 
     def _hand_out(self, remaining_capacity: int) -> list[str]:
-        """Queued chunks first, then the final ones once nothing is queued."""
+        """The one exit. Queued chunks first; terminal ones only after them.
+
+        Every producer returns through here, and that is the whole of the
+        rule: "every sibling finished" is not the same fact as "everything
+        built has been sent", and three places used the first as a proxy for
+        the second. The terminal chunks were then handed out while built
+        chunks were still queued -- and once the finals go, `completed` is set
+        and the caller pops the state, so the queued ones are gone. Measured
+        at the production `max_items`: a response with nine tool calls
+        delivered eight and reported `finish_reason: tool_calls`; at
+        `max_items=1` a single call reported `tool_calls` having sent no
+        `tool_calls` delta at all.
+        """
         out = self._take_pending(remaining_capacity)
-        if (
-            all(self.finished)
-            and not self._pending_chunks
-            and len(out) < remaining_capacity
-        ):
-            out.extend(self._final_chunks(remaining_capacity - len(out)))
-        return out
+        # `_take_pending` never returns more than the caller asked for, so no
+        # room left means chunks are still queued -- there is nothing to test
+        # for beyond that, and a second condition here would be a guard that
+        # cannot fail.
+        if len(out) >= remaining_capacity:
+            return out
+        if self._pending_final_chunks is None:
+            if not all(self.finished):
+                return out
+            self._pending_final_chunks = self._build_final_chunks()
+        return out + self._drain_pending_final_chunks(remaining_capacity - len(out))
 
     def _drain_pending_final_chunks(self, remaining_capacity: int) -> list[str]:
         if not self._pending_final_chunks or remaining_capacity <= 0:
@@ -994,16 +1099,48 @@ class AtomStandaloneService:
         # Resolved once here, for the same reason the OpenAI server resolves it
         # once: the chat template says which format this model emits, and
         # deciding from the output instead means deciding from a prefix.
+        _template_source = chat_template_source(tokenizer, self.custom_message_encoder)
+        # Which dialect this model's reasoning is written in, once, from the
+        # same evidence and by the same function the OpenAI server uses. Both
+        # paths through this service then read it the same way; they used to
+        # share only a boolean, and the streaming half closed the channel on
+        # any registered dialect's marker.
+        self.reasoning_dialect, _stated = resolve_dialect(
+            _template_source,
+            render_probe_prompt(tokenizer, self.custom_message_encoder, tools=False)
+            or "",
+        )
         self.model_starts_in_reasoning = template_opens_reasoning_implicitly(
-            chat_template_source(tokenizer, self.custom_message_encoder)
+            _template_source
         )
         self.tool_parser_cls = resolve_tool_call_parser(
             tool_call_parser, tokenizer, self.custom_message_encoder, model=model_name
         )
+
         self.engine_service = AtomEngineService(engine, tokenizer)
+
         self._streams: dict[str, ChatCompletionStreamState] = {}
         self._completion_streams: dict[str, CompletionStreamState] = {}
         self._streams_lock = threading.Lock()
+
+    def _reasoning_channel(self, prompt: str) -> ReasoningChannel:
+        """How to read this response's reasoning channel.
+
+        One function, read by both delivery modes, so they cannot be given
+        different dialects -- which is what they were: the non-streaming split
+        tried each registered dialect in turn and the streaming filter closed
+        on the union of all their end markers.
+
+        This service threads neither `thinking` nor `reasoning_effort` into
+        the template, so there is no request-level opt-out to honour here yet.
+        When there is, it belongs in this function, as it does on the OpenAI
+        server.
+        """
+        return ReasoningChannel(
+            dialect=self.reasoning_dialect,
+            starts_open=prompt_starts_in_reasoning(prompt)
+            or self.model_starts_in_reasoning,
+        )
 
     def chat_completions(self, request_data: dict[str, Any]) -> dict[str, Any]:
         try:
@@ -1051,8 +1188,7 @@ class AtomStandaloneService:
                     request_id,
                     self.model_name,
                     outputs,
-                    starts_thinking=prompt_starts_in_reasoning(prompt)
-                    or self.model_starts_in_reasoning,
+                    reasoning=self._reasoning_channel(prompt),
                     tools=request_data.get("tools"),
                     tool_choice=request_data.get("tool_choice"),
                     tool_parser_cls=self.tool_parser_cls,
@@ -1073,8 +1209,7 @@ class AtomStandaloneService:
                     self.model_name,
                     final_output["text"],
                     final_output,
-                    starts_thinking=prompt_starts_in_reasoning(prompt)
-                    or self.model_starts_in_reasoning,
+                    reasoning=self._reasoning_channel(prompt),
                     tools=request_data.get("tools"),
                     tool_choice=request_data.get("tool_choice"),
                     tool_parser_cls=self.tool_parser_cls,
@@ -1185,6 +1320,11 @@ class AtomStandaloneService:
         if stream_state.completed or stream_state.closed:
             with self._streams_lock:
                 self._completion_streams.pop(stream_id, None)
+            # A stream that ends on its own is never closed by the caller, so
+            # this is the only place its sequence list is dropped. Without it
+            # the engine service remembers every completed stream for the life
+            # of the process.
+            self.engine_service.forget_stream(stream_id)
         return chunks
 
     def poll_completions_stream(
@@ -1204,6 +1344,7 @@ class AtomStandaloneService:
             stream_state = self._completion_streams.pop(stream_id, None)
         if stream_state is not None:
             stream_state.close()
+        self.engine_service.abort_stream(stream_id)
 
     def start_chat_completions_stream(self, request_data: dict[str, Any]) -> str:
         try:
@@ -1246,7 +1387,7 @@ class AtomStandaloneService:
                 stream_queue=stream_queue,
                 n=effective_n,
                 tool_parser_cls=self.tool_parser_cls,
-                model_starts_in_reasoning=self.model_starts_in_reasoning,
+                reasoning=self._reasoning_channel(prompt),
                 tools=request_data.get("tools"),
                 tool_choice=request_data.get("tool_choice"),
             )
@@ -1272,6 +1413,11 @@ class AtomStandaloneService:
         if stream_state.completed or stream_state.closed:
             with self._streams_lock:
                 self._streams.pop(stream_id, None)
+            # A stream that ends on its own is never closed by the caller, so
+            # this is the only place its sequence list is dropped. Without it
+            # the engine service remembers every completed stream for the life
+            # of the process.
+            self.engine_service.forget_stream(stream_id)
         return chunks
 
     def poll_chat_completions_stream(
@@ -1291,11 +1437,15 @@ class AtomStandaloneService:
             stream_state = self._streams.pop(stream_id, None)
         if stream_state is not None:
             stream_state.close()
+        self.engine_service.abort_stream(stream_id)
 
     def close(self) -> None:
         with self._streams_lock:
+            open_streams = [*self._streams, *self._completion_streams]
             self._streams.clear()
             self._completion_streams.clear()
+        for stream_id in open_streams:
+            self.engine_service.abort_stream(stream_id)
         if hasattr(self, "engine_service"):
             self.engine_service.close()
         if hasattr(self.engine, "close"):

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -188,6 +188,7 @@ class AtomEngineService:
                         }
                     )
                     request.stream_queue.put({"done": True})
+                    self._close_submit_window(request.request_id)
                 else:
                     self._set_future_exception(
                         request.future,
@@ -197,7 +198,10 @@ class AtomEngineService:
 
             try:
                 if isinstance(request, EngineStreamRequest):
-                    self._submit_stream_request(request)
+                    try:
+                        self._submit_stream_request(request)
+                    finally:
+                        self._close_submit_window(request.request_id)
                 else:
                     self._submit_request(request)
             except Exception as error:
@@ -254,6 +258,24 @@ class AtomEngineService:
         with self._stream_seqs_lock:
             self._awaiting_submit.add(request_id)
 
+    def _close_submit_window(self, request_id: str) -> None:
+        """This id can no longer be submitted, however that came about.
+
+        The counterpart to `_expect_stream`, and called from the worker loop
+        rather than from inside `_submit_stream_request` because that function
+        has four ways out -- abandoned at the top, abandoned mid-preprocess,
+        published, or raising -- and bookkeeping spread over them discarded on
+        two. A stream closed while it was preprocessing, and one whose
+        preprocess raised, each left an id behind for the life of the process:
+        the same leak `_awaiting_submit` was added to remove, one level down.
+
+        It runs *after* the submit, never before, because the window has to
+        stay open for an abort arriving while the sequences are still being
+        built -- that abort has nothing to stop yet either.
+        """
+        with self._stream_seqs_lock:
+            self._awaiting_submit.discard(request_id)
+
     def _submit_stream_request(self, request: EngineStreamRequest) -> None:
         if self._take_abandoned(request.request_id):
             return
@@ -278,7 +300,6 @@ class AtomEngineService:
         # whether a close in that window aborts or leaks; this way one of the
         # two branches below always fires.
         with self._stream_seqs_lock:
-            self._awaiting_submit.discard(request.request_id)
             if request.request_id in self._abandoned:
                 self._abandoned.discard(request.request_id)
                 abandoned = seqs
@@ -297,7 +318,6 @@ class AtomEngineService:
                 # closing the window here let it through to the engine.
                 return False
             self._abandoned.discard(request_id)
-            self._awaiting_submit.discard(request_id)
             return True
 
     def forget_stream(self, request_id: str) -> None:

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -1568,11 +1568,25 @@ class AtomStandaloneService:
         self.engine_service.abort_stream(stream_id)
 
     def close(self) -> None:
+        """Shut down, in the order `close_*_stream` uses.
+
+        `stream_state.close()` is the only thing that sets `closed`, and a
+        router thread already inside `drain()` does not hold `_streams_lock`:
+        it wakes from its queue, reads `closed` as False and hands out chunks
+        for a sequence this method just aborted -- and if `all(finished)`
+        happens to hold, a finish/usage/`[DONE]` tail as well, so the caller
+        records `finish_reason: stop` on a truncated answer. Clearing the
+        registry is not what stops a drain; closing the state is.
+        """
         with self._streams_lock:
-            open_streams = [*self._streams, *self._completion_streams]
+            open_streams = [
+                *self._streams.items(),
+                *self._completion_streams.items(),
+            ]
             self._streams.clear()
             self._completion_streams.clear()
-        for stream_id in open_streams:
+        for stream_id, stream_state in open_streams:
+            stream_state.close()
             self.engine_service.abort_stream(stream_id)
         if hasattr(self, "engine_service"):
             self.engine_service.close()

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -206,6 +206,14 @@ class AtomEngineService:
                 else:
                     self._submit_request(request)
             except Exception as error:
+                # Broad on purpose: this is the worker thread's outer loop, and
+                # anything that escapes here kills it and hangs every request
+                # after this one. The client learns what happened either way;
+                # the server did not, so a failed request left no trace on the
+                # side that could act on it.
+                logger.exception(
+                    "standalone engine request %s failed", request.request_id
+                )
                 if isinstance(request, EngineStreamRequest):
                     request.stream_queue.put(
                         {

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -40,6 +40,7 @@ from atom.entrypoints.openai.reasoning import (
     template_opens_reasoning_implicitly,
 )
 from atom.entrypoints.openai.serving_chat import (
+    _normalize_finish_reason,
     build_chat_response,
     build_chat_response_multi,
     create_chat_chunk,
@@ -567,6 +568,14 @@ class ChatCompletionStreamState:
         self.completed = False
         self.closed = False
         self._pending_final_chunks: list[str] | None = None
+        # Chunks built but not yet handed out. The drain takes `max_items` at
+        # a time and this used to `break` out of the build loop when it hit
+        # that -- discarding every event past the first, permanently, since
+        # the parser had already yielded them. At `max_items=1` a tool call
+        # lost its arguments and reported `finish_reason: stop`.
+        self._pending_chunks: list[str] = []
+        # The engine's own reason per sibling; see serving_chat.
+        self.engine_finish_reasons: list[str | None] = [None] * n
         self._lock = threading.Lock()
 
     def drain(self, max_items: int = 16, timeout: float = 0.05) -> list[str]:
@@ -632,19 +641,22 @@ class ChatCompletionStreamState:
 
         index = int(event["index"])
         if self.finished[index]:
-            return []
+            # Still hand out whatever is queued, and the final chunks once it
+            # is empty -- returning early here left a fully drained stream
+            # with no `finish_reason`, no usage and no `[DONE]`.
+            return self._hand_out(remaining_capacity)
 
         chunks: list[str] = []
         text = event.get("text") or ""
         self.num_tokens_output[index] += len(event.get("token_ids", []))
+        if event.get("finish_reason"):
+            self.engine_finish_reasons[index] = event["finish_reason"]
 
         segments = self.reasoning_filters[index].process(text)
         if event.get("finished", False):
             segments.extend(self.reasoning_filters[index].flush())
 
         for field, segment_text in segments:
-            if len(chunks) >= remaining_capacity:
-                break
             if field == "reasoning_content":
                 if segment_text:
                     chunks.append(
@@ -657,8 +669,6 @@ class ChatCompletionStreamState:
                     )
             elif field == "content":
                 for event_type, data in self.tool_parsers[index].process(segment_text):
-                    if len(chunks) >= remaining_capacity:
-                        break
                     if event_type == "content":
                         chunks.append(
                             create_chat_chunk(
@@ -690,8 +700,6 @@ class ChatCompletionStreamState:
 
         if event.get("finished", False):
             for event_type, data in self.tool_parsers[index].flush():
-                if len(chunks) >= remaining_capacity:
-                    break
                 if event_type == "content":
                     chunks.append(
                         create_chat_chunk(
@@ -722,15 +730,21 @@ class ChatCompletionStreamState:
                     )
             self.finished[index] = True
 
-        if all(self.finished) and len(chunks) < remaining_capacity:
-            chunks.extend(self._final_chunks(remaining_capacity - len(chunks)))
-        return chunks
+        self._pending_chunks.extend(chunks)
+        return self._hand_out(remaining_capacity)
 
     def _final_chunks(self, remaining_capacity: int) -> list[str]:
         if self._pending_final_chunks is None:
             chunks: list[str] = []
             for index, has_tool_calls in enumerate(self.has_tool_calls):
-                finish_reason = "tool_calls" if has_tool_calls else "stop"
+                finish_reason = (
+                    "tool_calls"
+                    if has_tool_calls
+                    else (
+                        _normalize_finish_reason(self.engine_finish_reasons[index])
+                        or "stop"
+                    )
+                )
                 chunks.append(
                     create_chat_chunk(
                         self.request_id,
@@ -759,6 +773,25 @@ class ChatCompletionStreamState:
             self._pending_final_chunks = chunks
 
         return self._drain_pending_final_chunks(remaining_capacity)
+
+    def _take_pending(self, remaining_capacity: int) -> list[str]:
+        """As many built chunks as the caller has room for; the rest wait."""
+        if remaining_capacity <= 0:
+            return []
+        out = self._pending_chunks[:remaining_capacity]
+        del self._pending_chunks[:remaining_capacity]
+        return out
+
+    def _hand_out(self, remaining_capacity: int) -> list[str]:
+        """Queued chunks first, then the final ones once nothing is queued."""
+        out = self._take_pending(remaining_capacity)
+        if (
+            all(self.finished)
+            and not self._pending_chunks
+            and len(out) < remaining_capacity
+        ):
+            out.extend(self._final_chunks(remaining_capacity - len(out)))
+        return out
 
     def _drain_pending_final_chunks(self, remaining_capacity: int) -> list[str]:
         if not self._pending_final_chunks or remaining_capacity <= 0:
@@ -793,6 +826,14 @@ class CompletionStreamState:
         self.completed = False
         self.closed = False
         self._pending_final_chunks: list[str] | None = None
+        # Chunks built but not yet handed out. The drain takes `max_items` at
+        # a time and this used to `break` out of the build loop when it hit
+        # that -- discarding every event past the first, permanently, since
+        # the parser had already yielded them. At `max_items=1` a tool call
+        # lost its arguments and reported `finish_reason: stop`.
+        self._pending_chunks: list[str] = []
+        # The engine's own reason per sibling; see serving_chat.
+        self.engine_finish_reasons: list[str | None] = [None] * n
         self._lock = threading.Lock()
 
     def drain(self, max_items: int = 16, timeout: float = 0.05) -> list[str]:
@@ -842,7 +883,10 @@ class CompletionStreamState:
 
         index = int(event["index"])
         if self.finished[index]:
-            return []
+            # Still hand out whatever is queued, and the final chunks once it
+            # is empty -- returning early here left a fully drained stream
+            # with no `finish_reason`, no usage and no `[DONE]`.
+            return self._hand_out(remaining_capacity)
 
         extra_fields: dict[str, Any] = {}
         if "kv_transfer_params" in event:
@@ -863,9 +907,8 @@ class CompletionStreamState:
         if event.get("finished", False):
             self.finished[index] = True
 
-        if all(self.finished) and len(chunks) < remaining_capacity:
-            chunks.extend(self._final_chunks(remaining_capacity - len(chunks)))
-        return chunks
+        self._pending_chunks.extend(chunks)
+        return self._hand_out(remaining_capacity)
 
     def _final_chunks(self, remaining_capacity: int) -> list[str]:
         if self._pending_final_chunks is None:
@@ -900,6 +943,25 @@ class CompletionStreamState:
             self._pending_final_chunks = chunks
 
         return self._drain_pending_final_chunks(remaining_capacity)
+
+    def _take_pending(self, remaining_capacity: int) -> list[str]:
+        """As many built chunks as the caller has room for; the rest wait."""
+        if remaining_capacity <= 0:
+            return []
+        out = self._pending_chunks[:remaining_capacity]
+        del self._pending_chunks[:remaining_capacity]
+        return out
+
+    def _hand_out(self, remaining_capacity: int) -> list[str]:
+        """Queued chunks first, then the final ones once nothing is queued."""
+        out = self._take_pending(remaining_capacity)
+        if (
+            all(self.finished)
+            and not self._pending_chunks
+            and len(out) < remaining_capacity
+        ):
+            out.extend(self._final_chunks(remaining_capacity - len(out)))
+        return out
 
     def _drain_pending_final_chunks(self, remaining_capacity: int) -> list[str]:
         if not self._pending_final_chunks or remaining_capacity <= 0:

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -114,6 +114,11 @@ class AtomEngineService:
         # abort and the sequence was added to the engine *afterwards* -- the
         # exact case the abort exists for, and the one it missed.
         self._abandoned: set[str] = set()
+        # Stream ids handed to the worker queue and not yet published or
+        # forgotten -- the only ids for which "no sequence list" can still
+        # mean "not submitted yet" rather than "already finished". Bounded by
+        # requests actually in flight.
+        self._awaiting_submit: set[str] = set()
         self._stream_seqs_lock = threading.Lock()
         self._worker = threading.Thread(
             target=self._worker_loop,
@@ -226,6 +231,7 @@ class AtomEngineService:
             raise RuntimeError("ATOM standalone engine service is closed")
 
         stream_queue: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._expect_stream(request_id)
         self._queue.put(
             EngineStreamRequest(
                 request_id=request_id,
@@ -238,6 +244,15 @@ class AtomEngineService:
             )
         )
         return stream_queue
+
+    def _expect_stream(self, request_id: str) -> None:
+        """This id is on the worker queue and its sequences do not exist yet.
+
+        The one registrar, so that "could still be submitted" has a single
+        definition; the window closes in `_submit_stream_request`.
+        """
+        with self._stream_seqs_lock:
+            self._awaiting_submit.add(request_id)
 
     def _submit_stream_request(self, request: EngineStreamRequest) -> None:
         if self._take_abandoned(request.request_id):
@@ -263,6 +278,7 @@ class AtomEngineService:
         # whether a close in that window aborts or leaks; this way one of the
         # two branches below always fires.
         with self._stream_seqs_lock:
+            self._awaiting_submit.discard(request.request_id)
             if request.request_id in self._abandoned:
                 self._abandoned.discard(request.request_id)
                 abandoned = seqs
@@ -275,8 +291,13 @@ class AtomEngineService:
     def _take_abandoned(self, request_id: str) -> bool:
         with self._stream_seqs_lock:
             if request_id not in self._abandoned:
+                # Still to be submitted, so the window `_awaiting_submit`
+                # marks stays open: an abort arriving while this request is
+                # being preprocessed has no sequences to stop yet either, and
+                # closing the window here let it through to the engine.
                 return False
             self._abandoned.discard(request_id)
+            self._awaiting_submit.discard(request_id)
             return True
 
     def forget_stream(self, request_id: str) -> None:
@@ -290,19 +311,27 @@ class AtomEngineService:
         with self._stream_seqs_lock:
             self._stream_seqs.pop(request_id, None)
             self._abandoned.discard(request_id)
+            self._awaiting_submit.discard(request_id)
 
     def abort_stream(self, request_id: str) -> None:
-        """Stop the sequences behind a stream the caller has finished with.
+        """Stop the sequences behind a stream that is still live.
 
-        Idempotent, and safe to call on a stream that ended normally: the
-        engine has already forgotten those sequences and says so by raising,
-        which is not an error here.
+        Call this only for a stream the caller has just taken ownership of --
+        `close_*_stream` does it under the same lock that removes the stream
+        from the registry. It cannot be used as a blanket "make sure this is
+        gone", because a missing sequence list is ambiguous: it means either
+        "not submitted yet" or "already finished and forgotten", and this has
+        to assume the first or the pre-submit abort window reopens. Calling it
+        on a stream that already ended therefore remembers that id forever.
         """
         with self._stream_seqs_lock:
             seqs = self._stream_seqs.pop(request_id, None)
             if seqs is None:
-                # Not submitted yet. Remember, so it never is.
-                self._abandoned.add(request_id)
+                # The ambiguity the docstring names: `_awaiting_submit` is the
+                # only thing in here that can say "not submitted yet" rather
+                # than "already finished", and remembering a finished id leaks.
+                if request_id in self._awaiting_submit:
+                    self._abandoned.add(request_id)
                 return
         for seq in seqs:
             self._abort_seq(seq)
@@ -1167,8 +1196,12 @@ class AtomStandaloneService:
         the rendered prompt does not open the channel. OR-ing the model-level
         fact in regardless made a DeepSeek-R1-shaped model return its whole
         answer as `reasoning_content` with `content` empty, on both delivery
-        modes. The OpenAI server gates this the same way; the docstring that
-        used to sit here said no request could reach it, and that was wrong.
+        modes.
+
+        The OpenAI server does *not* gate it the same way: there `thinking_off`
+        comes only from the request's own `thinking` / `reasoning_effort`
+        fields, never from the merged template kwargs. That is a latent bug
+        there, not a form to copy back into here.
         """
         return ReasoningChannel(
             dialect=self.reasoning_dialect,
@@ -1390,10 +1423,28 @@ class AtomStandaloneService:
         return chunks[0]
 
     def close_completions_stream(self, stream_id: str) -> None:
+        """Close a stream the caller is finished with.
+
+        The abort is conditional on this call being the one that removed the
+        stream. A stream that ended on its own was already removed by
+        `drain_*`, which called `forget_stream`; the router then closes it
+        anyway, as it is documented to. Aborting unconditionally at that point
+        reached `abort_stream` with nothing left to pop, which reads as "not
+        submitted yet" and permanently remembered the id -- one leaked entry
+        per *successful* request, which is the same unbounded growth
+        `forget_stream` exists to prevent.
+
+        `_completion_streams` is the liveness answer and it is exact: the entry is
+        added before the engine request is submitted and removed either here
+        or by the drain that saw the stream finish. So a stream closed during
+        the pre-submit window still aborts, which is the case `_abandoned` was
+        built for.
+        """
         with self._streams_lock:
             stream_state = self._completion_streams.pop(stream_id, None)
-        if stream_state is not None:
-            stream_state.close()
+        if stream_state is None:
+            return
+        stream_state.close()
         self.engine_service.abort_stream(stream_id)
 
     def start_chat_completions_stream(self, request_data: dict[str, Any]) -> str:
@@ -1483,10 +1534,17 @@ class AtomStandaloneService:
         return chunks[0]
 
     def close_chat_completions_stream(self, stream_id: str) -> None:
+        """Close a stream the caller is finished with.
+
+        Identical to `close_completions_stream` over `_streams` instead of
+        `_completion_streams` -- see there for why the abort is conditional on
+        this call being the one that removed the stream.
+        """
         with self._streams_lock:
             stream_state = self._streams.pop(stream_id, None)
-        if stream_state is not None:
-            stream_state.close()
+        if stream_state is None:
+            return
+        stream_state.close()
         self.engine_service.abort_stream(stream_id)
 
     def close(self) -> None:

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -41,6 +41,7 @@ from atom.entrypoints.openai.reasoning import (
     ReasoningChannel,
     prompt_starts_in_reasoning,
     template_opens_reasoning_implicitly,
+    thinking_switched_off,
 )
 from atom.entrypoints.openai.reasoning_dialects import resolve_dialect
 from atom.entrypoints.openai.serving_chat import (
@@ -1183,7 +1184,7 @@ class AtomStandaloneService:
             _template_source
         )
         # The kwarg that turns this model's reasoning off, so
-        # `_thinking_switched_off` can tell a switch the template reads from
+        # `thinking_switched_off` can tell a switch the template reads from
         # one it ignores.
         self.reasoning_toggle = resolve_reasoning_toggle(
             tokenizer, self.custom_message_encoder
@@ -1217,33 +1218,15 @@ class AtomStandaloneService:
         fact in regardless made a DeepSeek-R1-shaped model return its whole
         answer as `reasoning_content` with `content` empty, on both delivery
         modes.
-
-        The OpenAI server does *not* gate it the same way: there `thinking_off`
-        comes only from the request's own `thinking` / `reasoning_effort`
-        fields, never from the merged template kwargs. That is a latent bug
-        there, not a form to copy back into here.
         """
         return ReasoningChannel(
             dialect=self.reasoning_dialect,
             starts_open=prompt_starts_in_reasoning(prompt)
             or (
                 self.model_starts_in_reasoning
-                and not self._thinking_switched_off(template_kwargs)
+                and not thinking_switched_off(template_kwargs, self.reasoning_toggle)
             ),
         )
-
-    def _thinking_switched_off(self, template_kwargs: dict[str, Any] | None) -> bool:
-        """Did the render actually carry this template's off-switch?
-
-        Only the resolved toggle's own name and value count. A kwarg the
-        template does not read changes nothing about what the model does, and
-        believing it would stop the channel being separated while the model
-        went on producing it.
-        """
-        if not template_kwargs or self.reasoning_toggle is None:
-            return False
-        name, off_value, _on = self.reasoning_toggle
-        return name in template_kwargs and template_kwargs[name] == off_value
 
     def chat_completions(self, request_data: dict[str, Any]) -> dict[str, Any]:
         try:

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -24,6 +24,7 @@ from atom.entrypoints.openai.chat_encoders import (
     chat_template_source,
     load_custom_message_encoder,
     render_probe_prompt,
+    resolve_reasoning_toggle,
 )
 from atom.entrypoints.openai.protocol import (
     CHAT_COMPLETION_CHUNK_OBJECT,
@@ -44,10 +45,10 @@ from atom.entrypoints.openai.reasoning import (
 from atom.entrypoints.openai.reasoning_dialects import resolve_dialect
 from atom.entrypoints.openai.serving_chat import (
     _normalize_finish_reason,
-    finish_reason_with_calls,
     build_chat_response,
     build_chat_response_multi,
     create_chat_chunk,
+    finish_reason_with_calls,
 )
 from atom.entrypoints.openai.serving_completion import (
     build_completion_response,
@@ -252,8 +253,24 @@ class AtomEngineService:
             if request.request_id in self._abandoned:
                 self._abandoned.discard(request.request_id)
                 return
-            self._stream_seqs[request.request_id] = list(seqs)
         self.engine.core_mgr.add_request(seqs)
+        # Published *after* the engine has them, and the close re-checked
+        # once more. Publishing first left a window where `abort_stream`
+        # popped the list and aborted sequences the engine had not been told
+        # about -- the abort raised into a swallowed `except`, the worker then
+        # added them, and they decoded to `max_tokens` into a queue nobody
+        # would read. Which side of `add_request` the publish sits on decides
+        # whether a close in that window aborts or leaks; this way one of the
+        # two branches below always fires.
+        with self._stream_seqs_lock:
+            if request.request_id in self._abandoned:
+                self._abandoned.discard(request.request_id)
+                abandoned = seqs
+            else:
+                self._stream_seqs[request.request_id] = list(seqs)
+                abandoned = ()
+        for seq in abandoned:
+            self._abort_seq(seq)
 
     def _take_abandoned(self, request_id: str) -> bool:
         with self._stream_seqs_lock:
@@ -288,16 +305,19 @@ class AtomEngineService:
                 self._abandoned.add(request_id)
                 return
         for seq in seqs:
-            seq_id = getattr(seq, "id", None)
-            if seq_id is None:
-                continue
-            try:
-                self.engine.core_mgr.abort_request(seq_id)
-            except (AttributeError, KeyError, RuntimeError, ValueError) as exc:
-                logger.debug("abort_request(%s): %s", seq_id, exc)
-            requests = getattr(self.engine.io_processor, "requests", None)
-            if requests is not None:
-                requests.pop(seq_id, None)
+            self._abort_seq(seq)
+
+    def _abort_seq(self, seq: Any) -> None:
+        seq_id = getattr(seq, "id", None)
+        if seq_id is None:
+            return
+        try:
+            self.engine.core_mgr.abort_request(seq_id)
+        except (AttributeError, KeyError, RuntimeError, ValueError) as exc:
+            logger.debug("abort_request(%s): %s", seq_id, exc)
+        requests = getattr(self.engine.io_processor, "requests", None)
+        if requests is not None:
+            requests.pop(seq_id, None)
 
     def _preprocess_single_stream_request(self, request: EngineStreamRequest) -> Any:
         state = StreamRequestState(
@@ -1113,6 +1133,12 @@ class AtomStandaloneService:
         self.model_starts_in_reasoning = template_opens_reasoning_implicitly(
             _template_source
         )
+        # The kwarg that turns this model's reasoning off, so
+        # `_thinking_switched_off` can tell a switch the template reads from
+        # one it ignores.
+        self.reasoning_toggle = resolve_reasoning_toggle(
+            tokenizer, self.custom_message_encoder
+        )
         self.tool_parser_cls = resolve_tool_call_parser(
             tool_call_parser, tokenizer, self.custom_message_encoder, model=model_name
         )
@@ -1123,7 +1149,9 @@ class AtomStandaloneService:
         self._completion_streams: dict[str, CompletionStreamState] = {}
         self._streams_lock = threading.Lock()
 
-    def _reasoning_channel(self, prompt: str) -> ReasoningChannel:
+    def _reasoning_channel(
+        self, prompt: str, template_kwargs: dict[str, Any] | None = None
+    ) -> ReasoningChannel:
         """How to read this response's reasoning channel.
 
         One function, read by both delivery modes, so they cannot be given
@@ -1131,16 +1159,38 @@ class AtomStandaloneService:
         tried each registered dialect in turn and the streaming filter closed
         on the union of all their end markers.
 
-        This service threads neither `thinking` nor `reasoning_effort` into
-        the template, so there is no request-level opt-out to honour here yet.
-        When there is, it belongs in this function, as it does on the OpenAI
-        server.
+        `model_starts_in_reasoning` describes the template with reasoning
+        *on*, so it only holds while reasoning is on. This service takes no
+        `thinking` field, but it does merge `--default-chat-template-kwargs`
+        and the request's own `chat_template_kwargs` into the render -- so an
+        operator or a client can set the template's switch directly, and then
+        the rendered prompt does not open the channel. OR-ing the model-level
+        fact in regardless made a DeepSeek-R1-shaped model return its whole
+        answer as `reasoning_content` with `content` empty, on both delivery
+        modes. The OpenAI server gates this the same way; the docstring that
+        used to sit here said no request could reach it, and that was wrong.
         """
         return ReasoningChannel(
             dialect=self.reasoning_dialect,
             starts_open=prompt_starts_in_reasoning(prompt)
-            or self.model_starts_in_reasoning,
+            or (
+                self.model_starts_in_reasoning
+                and not self._thinking_switched_off(template_kwargs)
+            ),
         )
+
+    def _thinking_switched_off(self, template_kwargs: dict[str, Any] | None) -> bool:
+        """Did the render actually carry this template's off-switch?
+
+        Only the resolved toggle's own name and value count. A kwarg the
+        template does not read changes nothing about what the model does, and
+        believing it would stop the channel being separated while the model
+        went on producing it.
+        """
+        if not template_kwargs or self.reasoning_toggle is None:
+            return False
+        name, off_value, _on = self.reasoning_toggle
+        return name in template_kwargs and template_kwargs[name] == off_value
 
     def chat_completions(self, request_data: dict[str, Any]) -> dict[str, Any]:
         try:
@@ -1188,7 +1238,7 @@ class AtomStandaloneService:
                     request_id,
                     self.model_name,
                     outputs,
-                    reasoning=self._reasoning_channel(prompt),
+                    reasoning=self._reasoning_channel(prompt, template_kwargs),
                     tools=request_data.get("tools"),
                     tool_choice=request_data.get("tool_choice"),
                     tool_parser_cls=self.tool_parser_cls,
@@ -1209,7 +1259,7 @@ class AtomStandaloneService:
                     self.model_name,
                     final_output["text"],
                     final_output,
-                    reasoning=self._reasoning_channel(prompt),
+                    reasoning=self._reasoning_channel(prompt, template_kwargs),
                     tools=request_data.get("tools"),
                     tool_choice=request_data.get("tool_choice"),
                     tool_parser_cls=self.tool_parser_cls,
@@ -1387,7 +1437,7 @@ class AtomStandaloneService:
                 stream_queue=stream_queue,
                 n=effective_n,
                 tool_parser_cls=self.tool_parser_cls,
-                reasoning=self._reasoning_channel(prompt),
+                reasoning=self._reasoning_channel(prompt, template_kwargs),
                 tools=request_data.get("tools"),
                 tool_choice=request_data.get("tool_choice"),
             )

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -35,6 +35,8 @@ from atom.entrypoints.openai.protocol import (
     STREAM_DONE_MESSAGE,
     TEXT_COMPLETION_OBJECT,
     CompletionRequest,
+    openai_stop_reason,
+    openai_stop_reason_with_calls,
 )
 from atom.entrypoints.openai.reasoning import (
     NO_REASONING,
@@ -45,11 +47,9 @@ from atom.entrypoints.openai.reasoning import (
 )
 from atom.entrypoints.openai.reasoning_dialects import resolve_dialect
 from atom.entrypoints.openai.serving_chat import (
-    _normalize_finish_reason,
     build_chat_response,
     build_chat_response_multi,
     create_chat_chunk,
-    finish_reason_with_calls,
 )
 from atom.entrypoints.openai.serving_completion import (
     build_completion_response,
@@ -875,7 +875,7 @@ class ChatCompletionStreamState:
         this, and only once nothing built is still queued."""
         chunks: list[str] = []
         for index, has_tool_calls in enumerate(self.has_tool_calls):
-            finish_reason = finish_reason_with_calls(
+            finish_reason = openai_stop_reason_with_calls(
                 self.engine_finish_reasons[index], has_tool_calls
             )
             chunks.append(
@@ -1045,12 +1045,11 @@ class CompletionStreamState:
                 self.request_id,
                 self.model_name,
                 event.get("text") or "",
-                # The reason goes on the final chunk, as it does on every
-                # other streaming path here and in the OpenAI server. It used
-                # to go on this one too, unnormalised -- so a client saw the
-                # engine's own `max_tokens` on a content chunk and `stop` on
-                # the terminal one, and `engine_finish_reasons`, which exists
-                # to carry it to the terminal one, was never written at all.
+                # The reason goes on the final chunk, as on every other
+                # streaming path here and in the OpenAI server. Put here too
+                # it was never translated, and `engine_finish_reasons` --
+                # which exists to carry it to the terminal chunk -- was never
+                # written at all.
                 finish_reason=None,
                 index=index,
                 **extra_fields,
@@ -1078,8 +1077,7 @@ class CompletionStreamState:
                     self.model_name,
                     "",
                     finish_reason=(
-                        _normalize_finish_reason(self.engine_finish_reasons[index])
-                        or "stop"
+                        openai_stop_reason(self.engine_finish_reasons[index]) or "stop"
                     ),
                     index=index,
                 )

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -36,6 +36,7 @@ from atom.entrypoints.openai.protocol import (
 from atom.entrypoints.openai.reasoning import (
     ReasoningFilter,
     prompt_starts_in_reasoning,
+    template_opens_reasoning_implicitly,
 )
 from atom.entrypoints.openai.serving_chat import (
     build_chat_response,
@@ -524,6 +525,9 @@ class ChatCompletionStreamState:
         stream_queue: queue.Queue[dict[str, Any]],
         n: int,
         tool_parser_cls: type | None = None,
+        model_starts_in_reasoning: bool = False,
+        tools: list | None = None,
+        tool_choice: Any = None,
     ) -> None:
         self.request_id = request_id
         self.model_name = model_name
@@ -535,12 +539,20 @@ class ChatCompletionStreamState:
         # its whole trace delivered as the answer: state 0 no longer infers
         # reasoning from a bare end marker, because inferring it means waiting
         # for one.
-        starts_thinking = prompt_starts_in_reasoning(prompt)
+        starts_thinking = (
+            prompt_starts_in_reasoning(prompt) or model_starts_in_reasoning
+        )
         self.reasoning_filters = [
             ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
         ]
+        # `tool_choice="none"` forbids tool calls on this path too, and
+        # `tools` is what type-coerces the arguments. The OpenAI server gated
+        # and passed both; this one had neither, so the same request answered
+        # differently depending on the entrypoint.
+        self.tool_choice = tool_choice
         self.tool_parsers = [
-            ToolCallStreamParser(parser_cls=tool_parser_cls) for _ in range(n)
+            ToolCallStreamParser(tools=tools, parser_cls=tool_parser_cls)
+            for _ in range(n)
         ]
         self.has_tool_calls = [False] * n
         self.finished = [False] * n
@@ -649,7 +661,7 @@ class ChatCompletionStreamState:
                                 index=index,
                             )
                         )
-                    elif event_type == "tool_call_start":
+                    elif event_type == "tool_call_start" and self.tool_choice != "none":
                         self.has_tool_calls[index] = True
                         chunks.append(
                             create_chat_chunk(
@@ -659,7 +671,7 @@ class ChatCompletionStreamState:
                                 index=index,
                             )
                         )
-                    elif event_type == "tool_call_args":
+                    elif event_type == "tool_call_args" and self.tool_choice != "none":
                         chunks.append(
                             create_chat_chunk(
                                 self.request_id,
@@ -682,7 +694,7 @@ class ChatCompletionStreamState:
                             index=index,
                         )
                     )
-                elif event_type == "tool_call_start":
+                elif event_type == "tool_call_start" and self.tool_choice != "none":
                     self.has_tool_calls[index] = True
                     chunks.append(
                         create_chat_chunk(
@@ -692,7 +704,7 @@ class ChatCompletionStreamState:
                             index=index,
                         )
                     )
-                elif event_type == "tool_call_args":
+                elif event_type == "tool_call_args" and self.tool_choice != "none":
                     chunks.append(
                         create_chat_chunk(
                             self.request_id,
@@ -912,6 +924,9 @@ class AtomStandaloneService:
         # Resolved once here, for the same reason the OpenAI server resolves it
         # once: the chat template says which format this model emits, and
         # deciding from the output instead means deciding from a prefix.
+        self.model_starts_in_reasoning = template_opens_reasoning_implicitly(
+            getattr(tokenizer, "chat_template", None) or ""
+        )
         self.tool_parser_cls = resolve_tool_call_parser(
             None, tokenizer, self.custom_message_encoder, model=model_name
         )
@@ -966,7 +981,10 @@ class AtomStandaloneService:
                     request_id,
                     self.model_name,
                     outputs,
-                    starts_thinking=prompt_starts_in_reasoning(prompt),
+                    starts_thinking=prompt_starts_in_reasoning(prompt)
+                    or self.model_starts_in_reasoning,
+                    tools=request_data.get("tools"),
+                    tool_choice=request_data.get("tool_choice"),
                     tool_parser_cls=self.tool_parser_cls,
                 )
             else:
@@ -985,7 +1003,10 @@ class AtomStandaloneService:
                     self.model_name,
                     final_output["text"],
                     final_output,
-                    starts_thinking=prompt_starts_in_reasoning(prompt),
+                    starts_thinking=prompt_starts_in_reasoning(prompt)
+                    or self.model_starts_in_reasoning,
+                    tools=request_data.get("tools"),
+                    tool_choice=request_data.get("tool_choice"),
                     tool_parser_cls=self.tool_parser_cls,
                 )
             return self._json_safe(response.model_dump(exclude_none=True))
@@ -1155,6 +1176,9 @@ class AtomStandaloneService:
                 stream_queue=stream_queue,
                 n=effective_n,
                 tool_parser_cls=self.tool_parser_cls,
+                model_starts_in_reasoning=self.model_starts_in_reasoning,
+                tools=request_data.get("tools"),
+                tool_choice=request_data.get("tool_choice"),
             )
             with self._streams_lock:
                 self._streams[request_id] = stream_state

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -33,7 +33,10 @@ from atom.entrypoints.openai.protocol import (
     TEXT_COMPLETION_OBJECT,
     CompletionRequest,
 )
-from atom.entrypoints.openai.reasoning import ReasoningFilter
+from atom.entrypoints.openai.reasoning import (
+    ReasoningFilter,
+    prompt_starts_in_reasoning,
+)
 from atom.entrypoints.openai.serving_chat import (
     build_chat_response,
     build_chat_response_multi,
@@ -525,7 +528,15 @@ class ChatCompletionStreamState:
         self.stream_queue = stream_queue
         self.num_tokens_input = len(tokenizer.encode(prompt))
         self.num_tokens_output = [0] * n
-        self.reasoning_filters = [ReasoningFilter() for _ in range(n)]
+        # Same prompt for every sibling, so the same starting state. Without
+        # this a template that opens the reasoning channel in the prompt has
+        # its whole trace delivered as the answer: state 0 no longer infers
+        # reasoning from a bare end marker, because inferring it means waiting
+        # for one.
+        starts_thinking = prompt_starts_in_reasoning(prompt)
+        self.reasoning_filters = [
+            ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
+        ]
         self.tool_parsers = [ToolCallStreamParser() for _ in range(n)]
         self.has_tool_calls = [False] * n
         self.finished = [False] * n
@@ -942,7 +953,10 @@ class AtomStandaloneService:
                 if not outputs:
                     raise RuntimeError("No output generated")
                 response = build_chat_response_multi(
-                    request_id, self.model_name, outputs
+                    request_id,
+                    self.model_name,
+                    outputs,
+                    starts_thinking=prompt_starts_in_reasoning(prompt),
                 )
             else:
                 outputs = self.engine_service.generate(
@@ -956,7 +970,11 @@ class AtomStandaloneService:
                     raise RuntimeError("No output generated")
                 final_output = outputs[0]
                 response = build_chat_response(
-                    request_id, self.model_name, final_output["text"], final_output
+                    request_id,
+                    self.model_name,
+                    final_output["text"],
+                    final_output,
+                    starts_thinking=prompt_starts_in_reasoning(prompt),
                 )
             return self._json_safe(response.model_dump(exclude_none=True))
         except Exception:

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -915,6 +915,7 @@ class AtomStandaloneService:
         tokenizer: Any,
         model_name: str,
         default_chat_template_kwargs: dict[str, Any] | None = None,
+        tool_call_parser: str | None = None,
     ) -> None:
         self.engine = engine
         self.tokenizer = tokenizer
@@ -928,7 +929,7 @@ class AtomStandaloneService:
             getattr(tokenizer, "chat_template", None) or ""
         )
         self.tool_parser_cls = resolve_tool_call_parser(
-            None, tokenizer, self.custom_message_encoder, model=model_name
+            tool_call_parser, tokenizer, self.custom_message_encoder, model=model_name
         )
         self.engine_service = AtomEngineService(engine, tokenizer)
         self._streams: dict[str, ChatCompletionStreamState] = {}

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -21,6 +21,7 @@ from atom import SamplingParams
 from atom.entrypoints.openai.api_server import _build_sampling_params, _coerce_n
 from atom.entrypoints.openai.chat_encoders import (
     apply_chat_template,
+    chat_template_source,
     load_custom_message_encoder,
 )
 from atom.entrypoints.openai.protocol import (
@@ -926,7 +927,7 @@ class AtomStandaloneService:
         # once: the chat template says which format this model emits, and
         # deciding from the output instead means deciding from a prefix.
         self.model_starts_in_reasoning = template_opens_reasoning_implicitly(
-            getattr(tokenizer, "chat_template", None) or ""
+            chat_template_source(tokenizer, self.custom_message_encoder)
         )
         self.tool_parser_cls = resolve_tool_call_parser(
             tool_call_parser, tokenizer, self.custom_message_encoder, model=model_name

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -51,7 +51,10 @@ from atom.entrypoints.openai.serving_completion import (
 )
 from atom.entrypoints.openai.sse import data_frame
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser
-from atom.entrypoints.openai.tool_parser.registry import resolve_tool_call_parser
+from atom.entrypoints.openai.tool_parser.registry import (
+    parser_for_tool_choice,
+    resolve_tool_call_parser,
+)
 from atom.model_engine.sequence import new_token_ids
 
 logger = logging.getLogger("atom")
@@ -552,7 +555,10 @@ class ChatCompletionStreamState:
         # differently depending on the entrypoint.
         self.tool_choice = tool_choice
         self.tool_parsers = [
-            ToolCallStreamParser(tools=tools, parser_cls=tool_parser_cls)
+            ToolCallStreamParser(
+                tools=tools,
+                parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice),
+            )
             for _ in range(n)
         ]
         self.has_tool_calls = [False] * n
@@ -662,7 +668,7 @@ class ChatCompletionStreamState:
                                 index=index,
                             )
                         )
-                    elif event_type == "tool_call_start" and self.tool_choice != "none":
+                    elif event_type == "tool_call_start":
                         chunks.append(
                             create_chat_chunk(
                                 self.request_id,
@@ -671,7 +677,7 @@ class ChatCompletionStreamState:
                                 index=index,
                             )
                         )
-                    elif event_type == "tool_call_args" and self.tool_choice != "none":
+                    elif event_type == "tool_call_args":
                         self.has_tool_calls[index] = True
                         chunks.append(
                             create_chat_chunk(
@@ -695,7 +701,7 @@ class ChatCompletionStreamState:
                             index=index,
                         )
                     )
-                elif event_type == "tool_call_start" and self.tool_choice != "none":
+                elif event_type == "tool_call_start":
                     chunks.append(
                         create_chat_chunk(
                             self.request_id,
@@ -704,7 +710,7 @@ class ChatCompletionStreamState:
                             index=index,
                         )
                     )
-                elif event_type == "tool_call_args" and self.tool_choice != "none":
+                elif event_type == "tool_call_args":
                     self.has_tool_calls[index] = True
                     chunks.append(
                         create_chat_chunk(

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -49,6 +49,7 @@ from atom.entrypoints.openai.serving_completion import (
 )
 from atom.entrypoints.openai.sse import data_frame
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser
+from atom.entrypoints.openai.tool_parser.registry import resolve_tool_call_parser
 from atom.model_engine.sequence import new_token_ids
 
 logger = logging.getLogger("atom")
@@ -522,6 +523,7 @@ class ChatCompletionStreamState:
         tokenizer: Any,
         stream_queue: queue.Queue[dict[str, Any]],
         n: int,
+        tool_parser_cls: type | None = None,
     ) -> None:
         self.request_id = request_id
         self.model_name = model_name
@@ -537,7 +539,9 @@ class ChatCompletionStreamState:
         self.reasoning_filters = [
             ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
         ]
-        self.tool_parsers = [ToolCallStreamParser() for _ in range(n)]
+        self.tool_parsers = [
+            ToolCallStreamParser(parser_cls=tool_parser_cls) for _ in range(n)
+        ]
         self.has_tool_calls = [False] * n
         self.finished = [False] * n
         self.role_sent = [False] * n
@@ -905,6 +909,12 @@ class AtomStandaloneService:
         self.model_name = model_name
         self.default_chat_template_kwargs = default_chat_template_kwargs or {}
         self.custom_message_encoder = load_custom_message_encoder(model_name)
+        # Resolved once here, for the same reason the OpenAI server resolves it
+        # once: the chat template says which format this model emits, and
+        # deciding from the output instead means deciding from a prefix.
+        self.tool_parser_cls = resolve_tool_call_parser(
+            None, tokenizer, self.custom_message_encoder, model=model_name
+        )
         self.engine_service = AtomEngineService(engine, tokenizer)
         self._streams: dict[str, ChatCompletionStreamState] = {}
         self._completion_streams: dict[str, CompletionStreamState] = {}
@@ -957,6 +967,7 @@ class AtomStandaloneService:
                     self.model_name,
                     outputs,
                     starts_thinking=prompt_starts_in_reasoning(prompt),
+                    tool_parser_cls=self.tool_parser_cls,
                 )
             else:
                 outputs = self.engine_service.generate(
@@ -975,6 +986,7 @@ class AtomStandaloneService:
                     final_output["text"],
                     final_output,
                     starts_thinking=prompt_starts_in_reasoning(prompt),
+                    tool_parser_cls=self.tool_parser_cls,
                 )
             return self._json_safe(response.model_dump(exclude_none=True))
         except Exception:
@@ -1142,6 +1154,7 @@ class AtomStandaloneService:
                 tokenizer=self.tokenizer,
                 stream_queue=stream_queue,
                 n=effective_n,
+                tool_parser_cls=self.tool_parser_cls,
             )
             with self._streams_lock:
                 self._streams[request_id] = stream_state

--- a/atom/entrypoints/atomesh/atom_standalone_service.py
+++ b/atom/entrypoints/atomesh/atom_standalone_service.py
@@ -663,7 +663,6 @@ class ChatCompletionStreamState:
                             )
                         )
                     elif event_type == "tool_call_start" and self.tool_choice != "none":
-                        self.has_tool_calls[index] = True
                         chunks.append(
                             create_chat_chunk(
                                 self.request_id,
@@ -673,6 +672,7 @@ class ChatCompletionStreamState:
                             )
                         )
                     elif event_type == "tool_call_args" and self.tool_choice != "none":
+                        self.has_tool_calls[index] = True
                         chunks.append(
                             create_chat_chunk(
                                 self.request_id,
@@ -696,7 +696,6 @@ class ChatCompletionStreamState:
                         )
                     )
                 elif event_type == "tool_call_start" and self.tool_choice != "none":
-                    self.has_tool_calls[index] = True
                     chunks.append(
                         create_chat_chunk(
                             self.request_id,
@@ -706,6 +705,7 @@ class ChatCompletionStreamState:
                         )
                     )
                 elif event_type == "tool_call_args" and self.tool_choice != "none":
+                    self.has_tool_calls[index] = True
                     chunks.append(
                         create_chat_chunk(
                             self.request_id,

--- a/atom/entrypoints/atomesh/server.py
+++ b/atom/entrypoints/atomesh/server.py
@@ -17,7 +17,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from atom.entrypoints.openai.tool_parser.registry import TOOL_CALL_PARSER_HELP
+from atom.entrypoints.openai.tool_parser.registry import (
+    TOOL_CALL_PARSER_HELP,
+    validate_tool_call_parser,
+)
 from atom.utils.gc_utils import (
     freeze_gc_heap,
     maybe_attach_gc_debug_callback,
@@ -140,6 +143,20 @@ def split_standalone_mesh_args(raw_args: list[str]) -> tuple[list[str], list[str
     return python_args, mesh_args
 
 
+def _forward_tool_call_parser(value: str | None) -> list[str]:
+    """Give the mesh router back the flag the Python parser just consumed.
+
+    `--tool-call-parser` has two consumers with two vocabularies: the Rust
+    router declares its own (`cliargs.rs`, sglang spelling) and reads it in
+    `app_context`, and the Python service resolves it to a `ToolCallParser`.
+    Until this entrypoint registered the flag it reached the router as an
+    unrecognised arg and was passed straight through; registering it made
+    `parse_known_args` swallow it, so the router silently lost a setting that
+    had been reaching it. Both need it, so both get it.
+    """
+    return [] if value is None else ["--tool-call-parser", value]
+
+
 def json_object_arg(raw_value: str) -> dict[str, Any]:
     try:
         parsed = json.loads(raw_value)
@@ -166,7 +183,9 @@ def parse_standalone_args(raw_args: list[str]) -> StandaloneArgs:
     parser.add_argument(
         "--tool-call-parser",
         type=str,
-        default="auto",
+        # Not "auto": that is what *unset* resolves to anyway, and telling the
+        # two apart is what decides whether the mesh router is told as well.
+        default=None,
         help=TOOL_CALL_PARSER_HELP,
     )
     parser.add_argument(
@@ -182,9 +201,18 @@ def parse_standalone_args(raw_args: list[str]) -> StandaloneArgs:
     python_raw_args, mesh_network_args = split_standalone_mesh_args(raw_args)
     engine_args, mesh_args = parser.parse_known_args(python_raw_args)
 
+    # Before the engine loads, not after. `AtomStandaloneService.__init__`
+    # raises on an unknown name, and it is constructed once the weights are
+    # already in memory -- so a typo cost a full model load before saying so.
+    validate_tool_call_parser(engine_args.tool_call_parser)
+
     return StandaloneArgs(
         engine_args=engine_args,
-        mesh_args=mesh_args + mesh_network_args,
+        mesh_args=(
+            mesh_args
+            + mesh_network_args
+            + _forward_tool_call_parser(engine_args.tool_call_parser)
+        ),
         default_chat_template_kwargs=engine_args.default_chat_template_kwargs or {},
     )
 

--- a/atom/entrypoints/atomesh/server.py
+++ b/atom/entrypoints/atomesh/server.py
@@ -143,6 +143,21 @@ def split_standalone_mesh_args(raw_args: list[str]) -> tuple[list[str], list[str
     return python_args, mesh_args
 
 
+def _is_atom_tool_call_parser(value: str | None) -> bool:
+    """Whether this name is one ATOM's own resolver understands.
+
+    A question, not an assertion: the mesh router answers to a different set
+    of names for the same flag, and neither side owns the other's.
+    """
+    if value is None:
+        return False
+    try:
+        validate_tool_call_parser(value)
+    except ValueError:
+        return False
+    return True
+
+
 def _forward_tool_call_parser(value: str | None) -> list[str]:
     """Give the mesh router back the flag the Python parser just consumed.
 
@@ -200,18 +215,34 @@ def parse_standalone_args(raw_args: list[str]) -> StandaloneArgs:
 
     python_raw_args, mesh_network_args = split_standalone_mesh_args(raw_args)
     engine_args, mesh_args = parser.parse_known_args(python_raw_args)
+    forwarded = engine_args.tool_call_parser
 
-    # Before the engine loads, not after. `AtomStandaloneService.__init__`
-    # raises on an unknown name, and it is constructed once the weights are
-    # already in memory -- so a typo cost a full model load before saying so.
-    validate_tool_call_parser(engine_args.tool_call_parser)
+    # Not validated against ATOM's vocabulary here, and that is the point.
+    # This flag has two consumers with disjoint vocabularies: the Rust router
+    # declares its own (`json`, `python`, `xml`, `hermes`) and ATOM's
+    # resolver takes `dsml`, `glm`, `kimi`, `kimi_k3`, `minimax`, `qwen`.
+    # Raising on a name ATOM does not know would kill any existing standalone
+    # deployment launched with a router name -- before this entrypoint
+    # registered the flag at all, those passed straight through.
+    #
+    # So: a name ATOM knows binds ATOM's parser, anything else is the
+    # router's and ATOM falls back to reading the chat template. Either way
+    # the value reaches the router, and the choice is logged.
+    if engine_args.tool_call_parser is not None and not _is_atom_tool_call_parser(
+        engine_args.tool_call_parser
+    ):
+        logger.info(
+            "--tool-call-parser=%r is not one of ATOM's formats, so it is "
+            "forwarded to the mesh router and ATOM reads its own format from "
+            "the chat template.",
+            engine_args.tool_call_parser,
+        )
+        engine_args.tool_call_parser = None
 
     return StandaloneArgs(
         engine_args=engine_args,
         mesh_args=(
-            mesh_args
-            + mesh_network_args
-            + _forward_tool_call_parser(engine_args.tool_call_parser)
+            mesh_args + mesh_network_args + _forward_tool_call_parser(forwarded)
         ),
         default_chat_template_kwargs=engine_args.default_chat_template_kwargs or {},
     )

--- a/atom/entrypoints/atomesh/server.py
+++ b/atom/entrypoints/atomesh/server.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from atom.entrypoints.openai.tool_parser.registry import TOOL_CALL_PARSER_HELP
 from atom.utils.gc_utils import (
     freeze_gc_heap,
     maybe_attach_gc_debug_callback,
@@ -112,6 +113,7 @@ def initialize_standalone_service(
         tokenizer=tokenizer,
         model_name=args.model,
         default_chat_template_kwargs=default_chat_template_kwargs,
+        tool_call_parser=getattr(args, "tool_call_parser", None),
     )
 
 
@@ -161,6 +163,12 @@ def parse_standalone_args(raw_args: list[str]) -> StandaloneArgs:
         allow_abbrev=False,
     )
     EngineArgs.add_cli_args(parser)
+    parser.add_argument(
+        "--tool-call-parser",
+        type=str,
+        default="auto",
+        help=TOOL_CALL_PARSER_HELP,
+    )
     parser.add_argument(
         "--default-chat-template-kwargs",
         type=json_object_arg,

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -286,7 +286,7 @@ _ANTHROPIC_STOP_REASON = {
 def anthropic_stop_reason_with_calls(finish_reason: Any, has_calls: bool) -> str:
     """`max_tokens` outranks `tool_use`, for the reason `length` outranks
     `tool_calls` on the other endpoint (see
-    :func:`~.serving_chat.finish_reason_with_calls`): only one of the two is a
+    :func:`~.protocol.openai_stop_reason_with_calls`): only one of the two is a
     warning, and a response cut off mid-call parses to a call with a silently
     truncated argument value."""
     reason = anthropic_stop_reason(finish_reason)
@@ -298,7 +298,7 @@ def anthropic_stop_reason_with_calls(finish_reason: Any, has_calls: bool) -> str
 def anthropic_stop_reason(finish_reason: Any) -> str:
     """The engine's leave reason as Anthropic spells it.
 
-    Not routed through `_normalize_finish_reason`: that maps into OpenAI's
+    Not routed through `protocol.openai_stop_reason`: that maps into OpenAI's
     vocabulary (`stop` / `length`), which shares no member with the keys here,
     so chaining them would send every reason to the default.
 

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -93,6 +93,7 @@ from .serving_chat import (
     stream_chat_response,
     stream_chat_response_fanout,
     validate_chat_request,
+    validate_tool_list,
 )
 from .serving_completion import (
     build_completion_response,
@@ -1878,6 +1879,24 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
     Anthropic-compatible tools to use ATOM as a backend.
     """
     global engine, tokenizer, model_name
+
+    # One validator over the shape both endpoints share: this path already
+    # converts, so validating the conversion leaves a single rule rather than
+    # a second one in Anthropic's spelling. It checked nothing before, so a
+    # name `/v1/chat/completions` rejects was accepted here. Explicitly 400
+    # and before the try, because the handler below turns every exception into
+    # a 500 -- wrong for a malformed request, and once the response is
+    # streaming it arrives after the client was told the request succeeded.
+    try:
+        validate_tool_list(anthropic_to_openai_tools(request.tools))
+    except ValueError as exc:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "type": "error",
+                "error": {"type": "invalid_request_error", "message": str(exc)},
+            },
+        )
 
     try:
         # Convert Anthropic messages to OpenAI format

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -68,6 +68,7 @@ from .reasoning import (
     prompt_starts_in_reasoning,
     prompt_tokens_start_in_reasoning,
     template_opens_reasoning_implicitly,
+    thinking_switched_off,
 )
 from .reasoning_dialects import resolve_dialect
 from .serving_anthropic import (
@@ -154,34 +155,32 @@ _request_logger: logging.Logger | None = None
 _stream_batch_dispatcher: StreamBatchDispatcher | None = None
 
 
-def reasoning_channel(prompt_opens: bool, *, thinking_off: bool) -> ReasoningChannel:
+def reasoning_channel(
+    prompt_opens: bool, *, template_kwargs: dict[str, Any] | None
+) -> ReasoningChannel:
     """How to read this request's reasoning channel.
 
     One place, because it is one answer and both endpoints and both delivery
     modes need the same one. The dialect is the model's, resolved at startup;
     what varies per request is whether the output begins inside the channel.
 
-    ``thinking_off`` is why that is not just the model-level fact. A request
-    that switches reasoning off renders a prompt that does not open the
-    channel, and `model_starts_in_reasoning` -- which describes the template
-    with reasoning *on* -- was OR-ed in regardless. On a model that begins
-    inside the channel implicitly, an ordinary answer to a request that had
-    asked for no thinking came back entirely as `reasoning_content`, with
-    `content` empty.
+    The render is why that is not just the model-level fact. A prompt that
+    switched reasoning off does not open the channel, and
+    `model_starts_in_reasoning` -- which describes the template with reasoning
+    *on* -- was OR-ed in regardless, so on a model that begins inside the
+    channel implicitly an ordinary answer came back entirely as
+    `reasoning_content` with `content` empty.
 
-    And it only counts when the template has a switch to honour it with. Ask
-    DeepSeek-R1 for no thinking and nothing goes into the prompt -- it has no
-    such kwarg (`resolve_reasoning_toggle` answers ``None`` for it) -- so the
-    model reasons exactly as always. Believing the request there stops the
-    channel being separated at all, and the client gets the chain of thought
-    and a literal `</think>` inside `content`. Reasoning that was asked not to
-    happen and happened anyway is still reasoning; `anthropic_drop_reasoning`
-    exists to withhold it, and it can only withhold what was separated.
+    ``template_kwargs``, not the request's own `thinking`: the server's
+    defaults and the client's `chat_template_kwargs` switch it too, and only
+    the merged dict has all three. Reasoning that was asked not to happen and
+    happened anyway is still reasoning -- `anthropic_drop_reasoning` exists to
+    withhold it, and it can only withhold what was separated.
     """
-    honoured = thinking_off and reasoning_toggle is not None
+    switched_off = thinking_switched_off(template_kwargs, reasoning_toggle)
     return ReasoningChannel(
         dialect=reasoning_dialect,
-        starts_open=prompt_opens or (model_starts_in_reasoning and not honoured),
+        starts_open=prompt_opens or (model_starts_in_reasoning and not switched_off),
     )
 
 
@@ -1564,7 +1563,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 if is_multimodal
                 else prompt_starts_in_reasoning(prompt)
             ),
-            thinking_off=_th_enabled is False,
+            template_kwargs=merged_kwargs,
         )
 
         # Streaming
@@ -1884,11 +1883,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         # no such spelling, and are not answered here or on the chat path.
         if forbids_tool_calls(request.tool_choice):
             merged_kwargs["tool_choice"] = "none"
-        # Thinking is "unstated" unless the field is present, exactly as
-        # `anthropic_template_kwargs` and `anthropic_drop_reasoning` read it.
-        thinking_off = request.thinking is not None and not anthropic_thinking_enabled(
-            request
-        )
         prompt = apply_chat_template(
             tokenizer,
             custom_message_encoder,
@@ -1973,7 +1967,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 # it is the model's, resolved at startup -- the filter used to
                 # carry none and closed on any registered dialect's marker.
                 reasoning_filter = reasoning_channel(
-                    prompt_starts_in_reasoning(prompt), thinking_off=thinking_off
+                    prompt_starts_in_reasoning(prompt),
+                    template_kwargs=merged_kwargs,
                 ).stream()
                 tool_parser = ToolCallStreamParser(
                     parser_cls=tool_call_parser_cls,
@@ -2142,7 +2137,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         # `(reasoning, content)` and lost the interleaving at that line.
         events = read_whole_blocks(
             reasoning_channel(
-                prompt_starts_in_reasoning(prompt), thinking_off=thinking_off
+                prompt_starts_in_reasoning(prompt),
+                template_kwargs=merged_kwargs,
             ),
             tool_call_parser_cls,
             raw_text,

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -101,7 +101,13 @@ from .streaming_dispatch import (
     StreamBatchDispatcher,
     StreamOutputCollector,
 )
-from .tool_parser.registry import TOOL_CALL_PARSER_HELP, resolve_tool_call_parser
+from .tool_parser import ToolCallStreamParser, parse_tool_calls
+from .tool_parser.registry import (
+    TOOL_CALL_PARSER_HELP,
+    forbids_tool_calls,
+    parser_for_tool_choice,
+    resolve_tool_call_parser,
+)
 
 # Configure logging
 logger = logging.getLogger("atom")
@@ -182,10 +188,9 @@ def anthropic_template_kwargs(
     another name -- the whole Qwen family -- so an explicit opt-in was
     discarded silently against a server default of off.
 
-    ``toggle`` is ``None`` for a model whose template has no switch. The
-    request is then honoured as far as it can be -- the reasoning is separated
-    and reported as a `thinking` block, never discarded -- and startup has
-    already said so.
+    ``toggle`` is ``None`` for a model whose template has no switch. There is
+    then nothing to put in the prompt and `anthropic_drop_reasoning` takes
+    over.
     """
     if getattr(request, "thinking", None) is None:
         return {}
@@ -193,6 +198,32 @@ def anthropic_template_kwargs(
         return {}
     name, off_value, on_value = toggle
     return {name: on_value if anthropic_thinking_enabled(request) else off_value}
+
+
+def anthropic_drop_reasoning(request: Any, toggle: tuple[str, Any, Any] | None) -> bool:
+    """Must this response's reasoning be withheld after the fact?
+
+    Only when the request said `thinking: disabled` *and* the model's template
+    has no switch to say it in the prompt -- gpt-oss-120b and DeepSeek-R1 both
+    measure that way. Answering in the prompt is strictly better and
+    `anthropic_template_kwargs` does it wherever it can; this is the remainder,
+    and without it an explicit opt-out was honoured at neither layer.
+
+    Withheld, not left unseparated: the reasoning still goes through the
+    reasoning filter, so the tool parser never sees a model musing about
+    `<function=NAME>` and calls a tool named `NAME`. Only the `thinking`
+    blocks are dropped. A response that was *nothing but* reasoning then ends
+    on an empty text block, which is the honest answer to "do not think" --
+    the previous three attempts to fix this downstream all failed by trying to
+    salvage content out of it.
+
+    Keyed on the field being *present* and off, exactly as the prompt-level
+    answer is. An absent `thinking` is unstated, and unstated leaves the
+    model's own default alone at both layers or neither.
+    """
+    if getattr(request, "thinking", None) is None:
+        return False
+    return toggle is None and not anthropic_thinking_enabled(request)
 
 
 # The engine's `leave_reason` in Anthropic's vocabulary. The scheduler emits
@@ -246,6 +277,44 @@ def _log_request_event(event_type: str, request_id: str, data: Any) -> None:
     _request_logger.info(json.dumps(entry, default=str))
 
 
+def _log_sse(chunk: str, request_id: str) -> None:
+    """Log every SSE frame in `chunk`, and never fail the stream doing it.
+
+    One yield can carry several frames: `serving_chat` deliberately coalesces
+    finish + usage + `[DONE]` into one send, because at a wave boundary many
+    requests finalize at once and collapsing three socket writes per request
+    to one relieves the event loop. This used to `json.loads` the whole send
+    as a single payload, which raises `Extra data:` on exactly that frame --
+    out of the generator, so with `--request-log` on, the *last* frame of
+    every OpenAI stream never reached the client and no `[DONE]` was sent.
+
+    And frames are not all `data:`-first. Anthropic writes `event: NAME` on
+    the line above, so a `startswith("data: ")` test skipped every frame that
+    endpoint produces -- silently, which for a log is the worst failure it
+    can have.
+
+    A payload that will not parse is logged as text rather than dropped or
+    raised: this is the diagnostic path, and it must not be the reason a
+    response fails.
+    """
+    if _request_logger is None:
+        return
+    for frame in chunk.split("\n\n"):
+        payload = None
+        for line in frame.splitlines():
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+        if payload is None:
+            continue
+        if payload == "[DONE]":
+            _log_request_event("stream_done", request_id, None)
+            continue
+        try:
+            _log_request_event("stream_chunk", request_id, json.loads(payload))
+        except ValueError:
+            _log_request_event("stream_chunk_unparsed", request_id, payload)
+
+
 async def _client_stream(
     gen: AsyncGenerator[str, None], request_id: str
 ) -> AsyncGenerator[str, None]:
@@ -274,12 +343,7 @@ async def _client_stream(
             except StopAsyncIteration:
                 return
         delivered = True
-        if _request_logger is not None and chunk.startswith("data: "):
-            payload = chunk[6:].strip()
-            if payload != "[DONE]":
-                _log_request_event("stream_chunk", request_id, json.loads(payload))
-            else:
-                _log_request_event("stream_done", request_id, None)
+        _log_sse(chunk, request_id)
         yield chunk
 
 
@@ -1725,6 +1789,16 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         # was never told not to think and the endpoint spent three attempts
         # dealing with a chain of thought it had asked for by omission.
         merged_kwargs.update(anthropic_template_kwargs(request, reasoning_toggle))
+        drop_reasoning = anthropic_drop_reasoning(request, reasoning_toggle)
+        # Same answer-it-in-the-prompt rule as `thinking` above, and the chat
+        # path already forwards its own spelling of this. `tool_choice` was
+        # read off the Anthropic request and then used nowhere at all -- a
+        # client that forbade tool calls got `tool_use` blocks and
+        # `stop_reason: tool_use`. Translated to the string a chat template
+        # expects; the object forms Anthropic has for *requiring* a call have
+        # no such spelling, and are not answered here or on the chat path.
+        if forbids_tool_calls(request.tool_choice):
+            merged_kwargs["tool_choice"] = "none"
         prompt = apply_chat_template(
             tokenizer,
             custom_message_encoder,
@@ -1794,8 +1868,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             )
 
             async def generate_anthropic_stream():
-                from .tool_parser import ToolCallStreamParser
-
                 # Unconditional, like the chat path and like both upstreams:
                 # whatever reasoning arrives is separated and reported. The
                 # request's `thinking` was answered in the prompt, so there is
@@ -1812,7 +1884,11 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                     starts_thinking=prompt_starts_in_reasoning(prompt)
                     or model_starts_in_reasoning,
                 )
-                tool_parser = ToolCallStreamParser(parser_cls=tool_call_parser_cls)
+                tool_parser = ToolCallStreamParser(
+                    parser_cls=parser_for_tool_choice(
+                        tool_call_parser_cls, request.tool_choice
+                    )
+                )
                 tool_parser.tools = anthropic_to_openai_tools(request.tools)
                 blocks = AnthropicBlocks()
                 has_tool_calls = False
@@ -1862,6 +1938,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                 continue
 
                             if field == "reasoning_content":
+                                if drop_reasoning:
+                                    continue
                                 for _frame in blocks.delta("thinking", text):
                                     yield _frame
                             else:
@@ -1909,8 +1987,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             )
 
         # Non-streaming response
-        from .tool_parser import parse_tool_calls
-
         final_output = await _run_nonstream_with_disconnect(
             generate_async(prompt, sampling_params, request_id),
             raw_request,
@@ -1920,17 +1996,23 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             raise RuntimeError("No output generated")
 
         raw_text = final_output["text"]
-        # Unconditional, and the same call the chat path makes. See the
-        # streaming branch above for why `thinking` has no say here.
+        # Separating is unconditional -- the same call the chat path makes,
+        # and what keeps a chain of thought out of the tool parser. Only
+        # whether the client is shown it is a question, and the same one the
+        # streaming branch above asks.
         reasoning_content, content_with_tools = separate_reasoning(
             raw_text,
             starts_thinking=prompt_starts_in_reasoning(prompt)
             or model_starts_in_reasoning,
         )
+        if drop_reasoning:
+            reasoning_content = None
         content_text, tool_calls = parse_tool_calls(
             content_with_tools,
             anthropic_to_openai_tools(request.tools),
-            parser_cls=tool_call_parser_cls,
+            parser_cls=parser_for_tool_choice(
+                tool_call_parser_cls, request.tool_choice
+            ),
         )
         output_tokens = len(tokenizer.encode(raw_text))
         cache_read_input_tokens = final_output.get("num_cached_tokens", 0)

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -299,13 +299,20 @@ def anthropic_stop_reason(finish_reason: Any) -> str:
     vocabulary (`stop` / `length`), which shares no member with the keys here,
     so chaining them would send every reason to the default.
 
-    `stop_<token_id>` is its own case for the same reason it exists -- a stop
-    token fired, which is Anthropic's `stop_sequence`. Falling through would
-    have reported a normal ending for a response that was cut short.
+    `stop_<token_id>` is *not* `stop_sequence`, though it was mapped to it.
+    The two come from different branches of the scheduler and mean opposite
+    things: `stop_sequence` is one of the client's own `stop_sequences`
+    matching, and Anthropic pairs it with the matched string in the response;
+    `stop_<id>` is a model end-of-turn token from `stop_token_ids` firing,
+    which is an ordinary `end_turn`.
+
+    `stop_token_ids` is `generation_config.eos_token_id` minus the single
+    `tokenizer.eos_token_id`, so any model declaring more than one EOS reaches
+    this branch in normal operation -- Qwen3, Qwen3.5, gpt-oss.
     """
     reason = finish_reason or ""
     if reason.startswith("stop_") and reason != "stop_sequence":
-        return "stop_sequence"
+        return "end_turn"
     return _ANTHROPIC_STOP_REASON.get(reason, "end_turn")
 
 
@@ -316,6 +323,11 @@ def anthropic_stop_reason(finish_reason: Any) -> str:
 # 5016 of them. Long enough to trip proxy and SDK idle-read timeouts, and the
 # stall watchdog can only report it, not prevent it.
 _ANTHROPIC_PING_FRAME = event_frame("ping", {"type": "ping"})
+# Paced by the clock, not by the model: one ping per dropped reasoning
+# *segment* is one per engine chunk, i.e. O(reasoning tokens) socket writes of
+# 35 discarded bytes. The keepalive only has to beat proxy and SDK idle-read
+# timeouts, which are tens of seconds.
+_ANTHROPIC_PING_INTERVAL_SECONDS = 5.0
 _metrics_exporter = AtomMetricsExporter()
 _metrics_refresh_task: asyncio.Task | None = None
 _METRICS_REFRESH_INTERVAL_SECONDS = 5.0
@@ -1984,6 +1996,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 engine_reason: Any = None
 
                 message_started = False
+                # See `_ANTHROPIC_PING_INTERVAL_SECONDS`.
+                last_ping = 0.0
                 # Assume abort until we reach the normal end of the stream. If
                 # the client disconnects, GeneratorExit unwinds through the
                 # yields and the finally runs with this still True -> abort.
@@ -2001,18 +2015,17 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                         new_text = chunk_data["text"]
                         if chunk_data.get("finish_reason"):
                             engine_reason = chunk_data["finish_reason"]
-                        if chunk_data.get("finish_reason"):
-                            engine_reason = chunk_data["finish_reason"]
                         output_tokens += len(chunk_data.get("token_ids", []))
                         finished = chunk_data.get("finished", False)
 
-                        # Phase 1: Reasoning filter
-                        if reasoning_filter is None:
-                            segments = [("content", new_text)]
-                        else:
-                            segments = reasoning_filter.process(new_text)
-                            if finished:
-                                segments.extend(reasoning_filter.flush())
+                        # Phase 1: Reasoning filter. Never None --
+                        # `reasoning_channel(...).stream()` always returns a
+                        # `ReasoningFilter`. Do not add a skip path back: it
+                        # would feed an unseparated chain of thought straight
+                        # into the tool parser.
+                        segments = reasoning_filter.process(new_text)
+                        if finished:
+                            segments.extend(reasoning_filter.flush())
 
                         for field, text in segments:
                             if not text:
@@ -2020,7 +2033,12 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
                             if field == "reasoning_content":
                                 if drop_reasoning:
-                                    yield _ANTHROPIC_PING_FRAME
+                                    now = time.monotonic()
+                                    if now - last_ping >= (
+                                        _ANTHROPIC_PING_INTERVAL_SECONDS
+                                    ):
+                                        last_ping = now
+                                        yield _ANTHROPIC_PING_FRAME
                                     continue
                                 for _frame in blocks.delta("thinking", text):
                                     yield _frame

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -62,17 +62,14 @@ from .reasoning import (
     prompt_tokens_start_in_reasoning,
 )
 from .serving_anthropic import (
+    AnthropicBlocks,
     AnthropicMessagesRequest,
     anthropic_to_openai_messages,
     anthropic_to_openai_tools,
     build_anthropic_response,
-    stream_content_block_delta,
-    stream_content_block_start,
-    stream_content_block_stop,
     stream_message_delta,
     stream_message_start,
     stream_message_stop,
-    stream_signature_delta,
 )
 from .serving_chat import (
     build_chat_response,
@@ -1670,9 +1667,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 )
                 tool_parser = ToolCallStreamParser(parser_cls=tool_call_parser_cls)
                 tool_parser.tools = anthropic_to_openai_tools(request.tools)
-                block_index = 0
-                started_text = False
-                started_thinking = False
+                blocks = AnthropicBlocks()
                 has_tool_calls = False
                 output_tokens = 0
                 stop_reason = "end_turn"
@@ -1710,113 +1705,70 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                 if not _thinking_enabled:
                                     yield _ANTHROPIC_PING_FRAME
                                     continue
-                                if not started_thinking and not started_text:
-                                    yield stream_content_block_start(
-                                        block_index, "thinking"
-                                    )
-                                    started_thinking = True
-                                if started_thinking:
-                                    yield stream_content_block_delta(
-                                        block_index, text, "thinking"
-                                    )
+                                for _frame in blocks.delta("thinking", text):
+                                    yield _frame
                             else:
                                 # Phase 2: Tool call detection on content
                                 events = tool_parser.process(text)
                                 for etype, edata in events:
                                     if etype == "content":
-                                        if started_thinking and not started_text:
-                                            yield stream_signature_delta(block_index)
-                                            yield stream_content_block_stop(block_index)
-                                            block_index += 1
-                                        if not started_text:
-                                            yield stream_content_block_start(
-                                                block_index, "text"
-                                            )
-                                            started_text = True
-                                        yield stream_content_block_delta(
-                                            block_index, edata, "text"
-                                        )
+                                        for _frame in blocks.delta("text", edata):
+                                            yield _frame
                                     elif etype == "tool_call_start":
                                         has_tool_calls = True
                                         stop_reason = "tool_use"
-                                        if started_text:
-                                            yield stream_content_block_stop(block_index)
-                                            block_index += 1
-                                            started_text = False
-                                        elif started_thinking:
-                                            yield stream_signature_delta(block_index)
-                                            yield stream_content_block_stop(block_index)
-                                            block_index += 1
-                                            started_thinking = False
                                         fn = edata.get("function", {})
-                                        yield stream_content_block_start(
-                                            block_index,
+                                        for _frame in blocks.open(
                                             "tool_use",
                                             tool_use_id=edata.get("id", ""),
                                             tool_name=fn.get("name", ""),
-                                        )
+                                        ):
+                                            yield _frame
                                     elif etype == "tool_call_args":
                                         fn = edata.get("function", {})
-                                        yield stream_content_block_delta(
-                                            block_index,
-                                            fn.get("arguments", ""),
-                                            "tool_use",
-                                        )
+                                        for _frame in blocks.delta(
+                                            "tool_use", fn.get("arguments", "")
+                                        ):
+                                            yield _frame
                                     elif etype == "tool_call_end":
-                                        yield stream_content_block_stop(block_index)
-                                        block_index += 1
+                                        for _frame in blocks.close():
+                                            yield _frame
 
                         if finished:
                             # Flush remaining tool call events
                             for etype, edata in tool_parser.flush():
                                 if etype == "content":
-                                    if not started_text:
-                                        if started_thinking:
-                                            yield stream_signature_delta(block_index)
-                                            yield stream_content_block_stop(block_index)
-                                            block_index += 1
-                                            started_thinking = False
-                                        yield stream_content_block_start(
-                                            block_index, "text"
-                                        )
-                                        started_text = True
-                                    yield stream_content_block_delta(
-                                        block_index, edata, "text"
-                                    )
+                                    for _frame in blocks.delta("text", edata):
+                                        yield _frame
                                 elif etype == "tool_call_start":
                                     has_tool_calls = True
                                     stop_reason = "tool_use"
-                                    if started_text:
-                                        yield stream_content_block_stop(block_index)
-                                        block_index += 1
-                                        started_text = False
                                     fn = edata.get("function", {})
-                                    yield stream_content_block_start(
-                                        block_index,
+                                    for _frame in blocks.open(
                                         "tool_use",
                                         tool_use_id=edata.get("id", ""),
                                         tool_name=fn.get("name", ""),
-                                    )
+                                    ):
+                                        yield _frame
                                 elif etype == "tool_call_args":
                                     fn = edata.get("function", {})
-                                    yield stream_content_block_delta(
-                                        block_index,
-                                        fn.get("arguments", ""),
-                                        "tool_use",
-                                    )
+                                    for _frame in blocks.delta(
+                                        "tool_use", fn.get("arguments", "")
+                                    ):
+                                        yield _frame
                                 elif etype == "tool_call_end":
-                                    yield stream_content_block_stop(block_index)
-                                    block_index += 1
+                                    for _frame in blocks.close():
+                                        yield _frame
 
-                            if not started_text and not has_tool_calls:
-                                if started_thinking:
-                                    yield stream_signature_delta(block_index)
-                                    yield stream_content_block_stop(block_index)
-                                    block_index += 1
-                                yield stream_content_block_start(block_index, "text")
-                                started_text = True
-                            if started_text:
-                                yield stream_content_block_stop(block_index)
+                            # A response with no tool call must end on a text
+                            # block even when it produced none, because a reply
+                            # of pure reasoning still has to carry a `text`
+                            # block for clients that read only that.
+                            if not has_tool_calls and blocks.kind != "text":
+                                for _frame in blocks.open("text"):
+                                    yield _frame
+                            for _frame in blocks.close():
+                                yield _frame
                             yield stream_message_delta(stop_reason, output_tokens)
                             yield stream_message_stop()
                             aborted = False

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -89,7 +89,7 @@ from .serving_completion import (
 )
 from .sse import event_frame
 from .streaming_dispatch import StreamBatchDispatcher, StreamOutputCollector
-from .tool_parser.registry import resolve_tool_call_parser
+from .tool_parser.registry import TOOL_CALL_PARSER_HELP, resolve_tool_call_parser
 
 # Configure logging
 logger = logging.getLogger("atom")
@@ -1677,6 +1677,11 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 tool_parser.tools = anthropic_to_openai_tools(request.tools)
                 blocks = AnthropicBlocks()
                 has_tool_calls = False
+                # Reasoning the client did not ask for. Dropped, unless it
+                # turns out to be all the model produced -- a reasoning model
+                # stopped at max_tokens emits nothing else, and answering an
+                # empty message is worse than answering its working out.
+                withheld_reasoning: list[str] = []
                 output_tokens = 0
                 stop_reason = "end_turn"
 
@@ -1711,6 +1716,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
                             if field == "reasoning_content":
                                 if not _thinking_enabled:
+                                    withheld_reasoning.append(text)
                                     yield _ANTHROPIC_PING_FRAME
                                     continue
                                 for _frame in blocks.delta("thinking", text):
@@ -1775,6 +1781,15 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             if not has_tool_calls and blocks.kind != "text":
                                 for _frame in blocks.open("text"):
                                     yield _frame
+                                if blocks.index == 0 and withheld_reasoning:
+                                    # Nothing was ever delivered: this whole
+                                    # response was reasoning the client did
+                                    # not ask for. Send it rather than an
+                                    # empty message.
+                                    for _frame in blocks.delta(
+                                        "text", "".join(withheld_reasoning)
+                                    ):
+                                        yield _frame
                             for _frame in blocks.close():
                                 yield _frame
                             yield stream_message_delta(stop_reason, output_tokens)
@@ -1993,12 +2008,7 @@ def main():
         "--tool-call-parser",
         type=str,
         default="auto",
-        help=(
-            "Tool-call wire format. 'auto' (default) reads it off the model's "
-            "chat template at startup; an explicit name overrides that. When "
-            "neither resolves, tool calls are delivered as plain text and the "
-            "startup log says so — the format is never guessed from output."
-        ),
+        help=TOOL_CALL_PARSER_HELP,
     )
     parser.add_argument(
         "--server-port",

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -60,6 +60,7 @@ from .protocol import (
 from .reasoning import (
     prompt_starts_in_reasoning,
     prompt_tokens_start_in_reasoning,
+    template_opens_reasoning_implicitly,
 )
 from .serving_anthropic import (
     AnthropicBlocks,
@@ -108,6 +109,12 @@ tokenizer: AutoTokenizer | None = None
 # chat template. `None` means none was recognised and tool calls, if any, are
 # delivered as plain text -- said out loud at startup, never discovered here.
 tool_call_parser_cls: type | None = None
+# Whether this model's output begins inside the reasoning channel even when
+# nothing in the prompt or the output says so -- DeepSeek-R1 closes a block it
+# never opens. Read from the chat template at startup, because a single
+# response cannot tell you: its first token is already reasoning and reads
+# like an answer.
+model_starts_in_reasoning: bool = False
 processor: Any | None = None
 model_name: str = ""
 default_chat_template_kwargs: dict[str, Any] = {}
@@ -1280,7 +1287,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
             prompt_tokens_start_in_reasoning(token_ids, tokenizer.decode)
             if is_multimodal
             else prompt_starts_in_reasoning(prompt)
-        )
+        ) or model_starts_in_reasoning
 
         # Streaming
         if request.stream:
@@ -1664,6 +1671,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 # thinking state while claiming it did not start there.
                 reasoning_filter = ReasoningFilter(
                     starts_thinking=prompt_starts_in_reasoning(prompt)
+                    or model_starts_in_reasoning
                 )
                 tool_parser = ToolCallStreamParser(parser_cls=tool_call_parser_cls)
                 tool_parser.tools = anthropic_to_openai_tools(request.tools)
@@ -1800,7 +1808,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
         raw_text = final_output["text"]
         reasoning_content, content_with_tools = separate_reasoning(
-            raw_text, starts_thinking=prompt_starts_in_reasoning(prompt)
+            raw_text,
+            starts_thinking=prompt_starts_in_reasoning(prompt)
+            or model_starts_in_reasoning,
         )
         content_text, tool_calls = parse_tool_calls(
             content_with_tools,
@@ -1973,7 +1983,7 @@ async def stop_profile():
 def main():
     """Main entry point for the server."""
     global engine, tokenizer, model_name, default_chat_template_kwargs, _request_logger
-    global tool_call_parser_cls
+    global tool_call_parser_cls, model_starts_in_reasoning
     global custom_message_encoder, _stream_batch_dispatcher
 
     parser = FlexibleArgumentParser(description="ATOM OpenAI API Server")
@@ -2075,6 +2085,15 @@ def main():
 
     logger.info(f"Initializing engine with model {args.model}...")
     engine_args = EngineArgs.from_cli_args(args)
+    model_starts_in_reasoning = template_opens_reasoning_implicitly(
+        getattr(tokenizer, "chat_template", None) or ""
+    )
+    if model_starts_in_reasoning:
+        logger.info(
+            "Chat template closes a reasoning block it never opens; treating "
+            "output as reasoning until the end marker."
+        )
+
     tool_call_parser_cls = resolve_tool_call_parser(
         args.tool_call_parser,
         tokenizer,

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -77,6 +77,7 @@ from .serving_anthropic import (
     anthropic_to_openai_tools,
     build_anthropic_response,
     completes_a_tool_call,
+    stream_error,
     stream_message_delta,
     stream_message_start,
     stream_message_stop,
@@ -233,14 +234,14 @@ def anthropic_template_kwargs(
     return {name: on_value if anthropic_thinking_enabled(request) else off_value}
 
 
-def anthropic_drop_reasoning(request: Any, toggle: tuple[str, Any, Any] | None) -> bool:
-    """Must this response's reasoning be withheld after the fact?
+def anthropic_drop_reasoning(request: Any) -> bool:
+    """Must this response's reasoning be withheld from the client?
 
-    Only when the request said `thinking: disabled` *and* the model's template
-    has no switch to say it in the prompt -- gpt-oss-120b and DeepSeek-R1 both
-    measure that way. Answering in the prompt is strictly better and
-    `anthropic_template_kwargs` does it wherever it can; this is the remainder,
-    and without it an explicit opt-out was honoured at neither layer.
+    Whenever the request did not ask for it. Answering in the prompt is
+    strictly better and `anthropic_template_kwargs` does it wherever it can,
+    but that only reaches models whose template has a switch -- and it only
+    reaches the ones that *asked*, since an absent field leaves the model's
+    default alone. This is everything else.
 
     Withheld, not left unseparated: the reasoning still goes through the
     reasoning filter, so the tool parser never sees a model musing about
@@ -250,13 +251,22 @@ def anthropic_drop_reasoning(request: Any, toggle: tuple[str, Any, Any] | None) 
     the previous three attempts to fix this downstream all failed by trying to
     salvage content out of it.
 
-    Keyed on the field being *present* and off, exactly as the prompt-level
-    answer is. An absent `thinking` is unstated, and unstated leaves the
-    model's own default alone at both layers or neither.
+    Absent counts as off *here*, and that is deliberately not what the
+    prompt-level answer does. The two are different questions. What to put in
+    the prompt is about the model's own default, and overriding a default
+    nobody asked about would change what every existing caller gets from a
+    reasoning model. What to put in the *response* is about this protocol's
+    default, and Anthropic's is thinking-off: a client that never sends the
+    field has no reason to expect `thinking` blocks, and one that validates
+    block types or verifies the signature rejects them. Reading absent as
+    "show it" sent a random-signature `thinking` block to every Claude Code
+    and Anthropic-SDK caller talking to a Qwen3 or DeepSeek deployment.
+
+    Separated either way -- only whether the client is *shown* it is decided
+    here. That is what keeps a chain of thought out of the tool parser, which
+    is a second reader of the same text.
     """
-    if getattr(request, "thinking", None) is None:
-        return False
-    return toggle is None and not anthropic_thinking_enabled(request)
+    return not anthropic_thinking_enabled(request)
 
 
 # The engine's `leave_reason` in Anthropic's vocabulary. The scheduler emits
@@ -1848,7 +1858,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         # was never told not to think and the endpoint spent three attempts
         # dealing with a chain of thought it had asked for by omission.
         merged_kwargs.update(anthropic_template_kwargs(request, reasoning_toggle))
-        drop_reasoning = anthropic_drop_reasoning(request, reasoning_toggle)
+        drop_reasoning = anthropic_drop_reasoning(request)
         # Same answer-it-in-the-prompt rule as `thinking` above, and the chat
         # path already forwards its own spelling of this. `tool_choice` was
         # read off the Anthropic request and then used nowhere at all -- a
@@ -1964,9 +1974,13 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 # only reasoning and has all of it dropped, delivered an empty
                 # message that also said nothing was wrong. The vocabularies
                 # already line up; they were simply never connected.
-                stop_reason = "end_turn"
-                # The engine's own reason, kept so a call parsed out of a
-                # response it cut short does not overwrite it.
+                # Computed once, at the end, from the two facts that decide
+                # it -- exactly as `serving_chat` does. Recomputing it at each
+                # send point meant whichever fact arrived last won: a call
+                # completing mid-stream froze it at `tool_use`, and the
+                # `max_tokens` that arrived three chunks later could never be
+                # folded in. Kimi-K2 is the one registered format whose region
+                # closes mid-stream, so it is the one that reaches this.
                 engine_reason: Any = None
 
                 message_started = False
@@ -1987,10 +2001,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                         new_text = chunk_data["text"]
                         if chunk_data.get("finish_reason"):
                             engine_reason = chunk_data["finish_reason"]
-                        if not has_tool_calls and chunk_data.get("finish_reason"):
-                            stop_reason = anthropic_stop_reason(
-                                chunk_data["finish_reason"]
-                            )
+                        if chunk_data.get("finish_reason"):
+                            engine_reason = chunk_data["finish_reason"]
                         output_tokens += len(chunk_data.get("token_ids", []))
                         finished = chunk_data.get("finished", False)
 
@@ -2015,22 +2027,18 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             else:
                                 # Phase 2: Tool call detection on content
                                 events = tool_parser.process(text)
-                                if completes_a_tool_call(events):
-                                    has_tool_calls = True
-                                    stop_reason = anthropic_stop_reason_with_calls(
-                                        engine_reason, True
-                                    )
+                                has_tool_calls = has_tool_calls or (
+                                    completes_a_tool_call(events)
+                                )
                                 for _frame in tool_event_frames(events, blocks):
                                     yield _frame
 
                         if finished:
                             # Flush remaining tool call events
                             events = tool_parser.flush()
-                            if completes_a_tool_call(events):
-                                has_tool_calls = True
-                                stop_reason = anthropic_stop_reason_with_calls(
-                                    engine_reason, True
-                                )
+                            has_tool_calls = has_tool_calls or (
+                                completes_a_tool_call(events)
+                            )
                             for _frame in tool_event_frames(events, blocks):
                                 yield _frame
 
@@ -2052,9 +2060,25 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             aborted = False
                             for _frame in blocks.close():
                                 yield _frame
+                            stop_reason = anthropic_stop_reason_with_calls(
+                                engine_reason, has_tool_calls
+                            )
                             yield stream_message_delta(stop_reason, output_tokens)
                             yield stream_message_stop()
                             break
+                except Exception as exc:
+                    # Every block this stream opened has to be closed, and the
+                    # client has to be told why. There was no `except` at all:
+                    # the endpoint's own handler has already returned by the
+                    # time the generator runs, so a raise from the collector,
+                    # the reasoning filter or a tool parser cut the response
+                    # mid-frame with an open block and no terminator.
+                    logger.exception("Error streaming anthropic response")
+                    for _frame in blocks.close():
+                        yield _frame
+                    yield stream_error(str(exc))
+                    yield stream_message_delta("end_turn", output_tokens)
+                    yield stream_message_stop()
                 finally:
                     cleanup_stream(seq_id, aborted=aborted)
                     cleanup_request(request_id)

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -75,9 +75,11 @@ from .serving_anthropic import (
     anthropic_to_openai_messages,
     anthropic_to_openai_tools,
     build_anthropic_response,
+    starts_a_tool_call,
     stream_message_delta,
     stream_message_start,
     stream_message_stop,
+    tool_event_frames,
 )
 from .serving_chat import (
     build_chat_response,
@@ -1832,55 +1834,20 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             else:
                                 # Phase 2: Tool call detection on content
                                 events = tool_parser.process(text)
-                                for etype, edata in events:
-                                    if etype == "content":
-                                        for _frame in blocks.delta("text", edata):
-                                            yield _frame
-                                    elif etype == "tool_call_start":
-                                        has_tool_calls = True
-                                        stop_reason = "tool_use"
-                                        fn = edata.get("function", {})
-                                        for _frame in blocks.open(
-                                            "tool_use",
-                                            tool_use_id=edata.get("id", ""),
-                                            tool_name=fn.get("name", ""),
-                                        ):
-                                            yield _frame
-                                    elif etype == "tool_call_args":
-                                        fn = edata.get("function", {})
-                                        for _frame in blocks.delta(
-                                            "tool_use", fn.get("arguments", "")
-                                        ):
-                                            yield _frame
-                                    elif etype == "tool_call_end":
-                                        for _frame in blocks.close():
-                                            yield _frame
+                                if starts_a_tool_call(events):
+                                    has_tool_calls = True
+                                    stop_reason = "tool_use"
+                                for _frame in tool_event_frames(events, blocks):
+                                    yield _frame
 
                         if finished:
                             # Flush remaining tool call events
-                            for etype, edata in tool_parser.flush():
-                                if etype == "content":
-                                    for _frame in blocks.delta("text", edata):
-                                        yield _frame
-                                elif etype == "tool_call_start":
-                                    has_tool_calls = True
-                                    stop_reason = "tool_use"
-                                    fn = edata.get("function", {})
-                                    for _frame in blocks.open(
-                                        "tool_use",
-                                        tool_use_id=edata.get("id", ""),
-                                        tool_name=fn.get("name", ""),
-                                    ):
-                                        yield _frame
-                                elif etype == "tool_call_args":
-                                    fn = edata.get("function", {})
-                                    for _frame in blocks.delta(
-                                        "tool_use", fn.get("arguments", "")
-                                    ):
-                                        yield _frame
-                                elif etype == "tool_call_end":
-                                    for _frame in blocks.close():
-                                        yield _frame
+                            events = tool_parser.flush()
+                            if starts_a_tool_call(events):
+                                has_tool_calls = True
+                                stop_reason = "tool_use"
+                            for _frame in tool_event_frames(events, blocks):
+                                yield _frame
 
                             # A response with no tool call must end on a text
                             # block even when it produced none, because a reply

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -354,6 +354,24 @@ def _log_request_event(event_type: str, request_id: str, data: Any) -> None:
     _request_logger.info(json.dumps(entry, default=str))
 
 
+def _log_request_model(event_type: str, request_id: str, model: Any) -> None:
+    """:func:`_log_request_event` for a pydantic model, dumped only if logged.
+
+    The guard in `_log_request_event` is in the callee, so
+    ``_log_request_event("request", rid, request.model_dump())`` builds the
+    dump before the call can decline it: every message and every tool schema
+    serialised on the event loop and thrown away, on every request, with
+    request logging off. Measured 20-26 us on an agent-shaped request against
+    0.07 us for the guard.
+
+    `_log_sse` directly below already asks the question in this order. Two
+    spellings of one rule in one module is what this removes.
+    """
+    if _request_logger is None:
+        return
+    _log_request_event(event_type, request_id, model.model_dump())
+
+
 def _log_sse(chunk: str, request_id: str) -> None:
     """Log every SSE frame in `chunk`, and never fail the stream doing it.
 
@@ -1164,7 +1182,9 @@ async def setup_streaming_request(
     # 9 of them were sitting on this line, up to 3.3 s each -- long enough that
     # the server accepts no new request at all and the GPUs run dry waiting for
     # work. Anything per-request logged from here has to stay off info.
-    logger.debug(f"API: Created request_id={request_id}, seq_id={seq_id}")
+    # %-style, not an f-string: the arguments are formatted only if the
+    # record is emitted, and this runs once per request with debug off.
+    logger.debug("API: Created request_id=%s, seq_id=%s", request_id, seq_id)
     engine.core_mgr.add_request([seq])
 
     return seq_id, stream_collector, seq.num_prompt_tokens
@@ -1528,7 +1548,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
         request_id = f"chatcmpl-{uuid.uuid4().hex}"
         dp_rank = request.data_parallel_rank
 
-        _log_request_event("request", request_id, request.model_dump())
+        _log_request_model("request", request_id, request)
 
         is_multimodal = _has_multimodal_content(messages)
         if is_multimodal:
@@ -1719,7 +1739,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 reasoning=_reasoning,
                 tool_parser_cls=tool_call_parser_cls,
             )
-        _log_request_event("response", request_id, resp.model_dump())
+        _log_request_model("response", request_id, resp)
         return resp
 
     except _ClientDisconnected:
@@ -1755,7 +1775,7 @@ async def completions(request: CompletionRequest, raw_request: Request):
         request_id = f"cmpl-{uuid.uuid4().hex}"
         dp_rank = request.data_parallel_rank
 
-        _log_request_event("request", request_id, request.model_dump())
+        _log_request_model("request", request_id, request)
 
         # Streaming
         if request.stream:
@@ -1835,7 +1855,7 @@ async def completions(request: CompletionRequest, raw_request: Request):
                 raise RuntimeError("No output generated")
 
             resp = build_completion_response(request_id, model_name, final_output)
-        _log_request_event("response", request_id, resp.model_dump())
+        _log_request_model("response", request_id, resp)
         return resp
 
     except _ClientDisconnected:

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -96,6 +96,7 @@ from .serving_completion import (
     stream_completion_response,
     stream_completion_response_fanout,
 )
+from .sse import event_frame
 from .streaming_dispatch import (
     FrameWait,
     StreamBatchDispatcher,
@@ -254,6 +255,13 @@ def anthropic_stop_reason(finish_reason: Any) -> str:
     return _ANTHROPIC_STOP_REASON.get(reason, "end_turn")
 
 
+# Anthropic's own keepalive. Sent in place of a reasoning segment the request
+# asked not to see: the bytes are being generated either way, and with nothing
+# going out the socket is silent for the whole chain of thought -- on an
+# R1-shaped 5019-character trace the first client-visible frame arrived after
+# 5016 of them. Long enough to trip proxy and SDK idle-read timeouts, and the
+# stall watchdog can only report it, not prevent it.
+_ANTHROPIC_PING_FRAME = event_frame("ping", {"type": "ping"})
 _metrics_exporter = AtomMetricsExporter()
 _metrics_refresh_task: asyncio.Task | None = None
 _METRICS_REFRESH_INTERVAL_SECONDS = 5.0
@@ -1427,7 +1435,11 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
             # measured, `thinking=False` left the `<think>` prefill in place.
             # A template ignores a kwarg it does not know, so the failure was
             # invisible: the model reasoned anyway.
-            if reasoning_toggle is not None:
+            # Only when the request said something about it. An effort is
+            # not an opt-in, and this is merged after the server defaults and
+            # after the client's own `chat_template_kwargs` -- so writing it
+            # unconditionally overrode both.
+            if reasoning_toggle is not None and _th_enabled is not None:
                 name, off_value, on_value = reasoning_toggle
                 merged_kwargs[name] = on_value if _th_enabled else off_value
             if _th_effort is not None:
@@ -1939,6 +1951,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
 
                             if field == "reasoning_content":
                                 if drop_reasoning:
+                                    yield _ANTHROPIC_PING_FRAME
                                     continue
                                 for _frame in blocks.delta("thinking", text):
                                     yield _frame

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -75,7 +75,7 @@ from .serving_anthropic import (
     anthropic_to_openai_messages,
     anthropic_to_openai_tools,
     build_anthropic_response,
-    starts_a_tool_call,
+    completes_a_tool_call,
     stream_message_delta,
     stream_message_start,
     stream_message_stop,
@@ -96,7 +96,11 @@ from .serving_completion import (
     stream_completion_response,
     stream_completion_response_fanout,
 )
-from .streaming_dispatch import StreamBatchDispatcher, StreamOutputCollector
+from .streaming_dispatch import (
+    FrameWait,
+    StreamBatchDispatcher,
+    StreamOutputCollector,
+)
 from .tool_parser.registry import TOOL_CALL_PARSER_HELP, resolve_tool_call_parser
 
 # Configure logging
@@ -235,11 +239,30 @@ def _log_request_event(event_type: str, request_id: str, data: Any) -> None:
     _request_logger.info(json.dumps(entry, default=str))
 
 
-async def _logged_stream(
+async def _client_stream(
     gen: AsyncGenerator[str, None], request_id: str
 ) -> AsyncGenerator[str, None]:
-    """Wrap a streaming generator to log each SSE chunk."""
-    async for chunk in gen:
+    """Every SSE frame on its way to the client: logged, and timed.
+
+    The last point a frame passes through before uvicorn writes it, which is
+    why the silence watchdog lives here rather than at the collector it
+    started at. Between the collector and this line sit the reasoning
+    channel's read-ahead and the tool-call format's, and while either
+    withholds, the collector keeps waking on schedule -- so the gauge read
+    zero for exactly the stall it exists to report.
+
+    Wrapping every streaming response and not two of the three: this was
+    `_logged_stream`, and the Anthropic endpoint never used it. A watchdog
+    with an endpoint-shaped hole in it is worse than none, because the zero it
+    reports looks like an answer.
+    """
+    it = gen.__aiter__()
+    while True:
+        with FrameWait(request_id):
+            try:
+                chunk = await it.__anext__()
+            except StopAsyncIteration:
+                return
         if _request_logger is not None and chunk.startswith("data: "):
             payload = chunk[6:].strip()
             if payload != "[DONE]":
@@ -1438,7 +1461,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     tool_parser_cls=tool_call_parser_cls,
                 )
             return StreamingResponse(
-                _logged_stream(gen, request_id),
+                _client_stream(gen, request_id),
                 media_type="text/event-stream",
             )
 
@@ -1617,7 +1640,7 @@ async def completions(request: CompletionRequest, raw_request: Request):
                     cleanup_request,
                 )
             return StreamingResponse(
-                _logged_stream(gen, request_id),
+                _client_stream(gen, request_id),
                 media_type="text/event-stream",
             )
 
@@ -1834,7 +1857,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             else:
                                 # Phase 2: Tool call detection on content
                                 events = tool_parser.process(text)
-                                if starts_a_tool_call(events):
+                                if completes_a_tool_call(events):
                                     has_tool_calls = True
                                     stop_reason = "tool_use"
                                 for _frame in tool_event_frames(events, blocks):
@@ -1843,7 +1866,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                         if finished:
                             # Flush remaining tool call events
                             events = tool_parser.flush()
-                            if starts_a_tool_call(events):
+                            if completes_a_tool_call(events):
                                 has_tool_calls = True
                                 stop_reason = "tool_use"
                             for _frame in tool_event_frames(events, blocks):
@@ -1867,7 +1890,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                     cleanup_request(request_id)
 
             return StreamingResponse(
-                generate_anthropic_stream(),
+                _client_stream(generate_anthropic_stream(), request_id),
                 media_type="text/event-stream",
                 headers={
                     "anthropic-version": "2023-06-01",

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -58,8 +58,10 @@ from .protocol import (
     ModelList,
 )
 from .reasoning import (
+    ReasoningFilter,
     prompt_starts_in_reasoning,
     prompt_tokens_start_in_reasoning,
+    separate_reasoning,
     template_opens_reasoning_implicitly,
 )
 from .serving_anthropic import (
@@ -87,7 +89,6 @@ from .serving_completion import (
     stream_completion_response,
     stream_completion_response_fanout,
 )
-from .sse import event_frame
 from .streaming_dispatch import StreamBatchDispatcher, StreamOutputCollector
 from .tool_parser.registry import TOOL_CALL_PARSER_HELP, resolve_tool_call_parser
 
@@ -124,7 +125,42 @@ _stream_loops: dict[str, AbstractEventLoop] = {}
 _request_start_times: dict[str, float] = {}
 _request_logger: logging.Logger | None = None
 _stream_batch_dispatcher: StreamBatchDispatcher | None = None
-_ANTHROPIC_PING_FRAME = event_frame("ping", {"type": "ping"})
+
+
+# The engine's `leave_reason` in Anthropic's vocabulary. `aborted` has no
+# counterpart -- the client is already gone -- so it keeps the default.
+def anthropic_reasoning_split(
+    raw_text: str, *, thinking: bool, starts_thinking: bool
+) -> tuple[str | None, str]:
+    """Separate the reasoning channel, or decline to.
+
+    `thinking` off means the request wants no reasoning channel, so nothing
+    separates one out and the model's output is the text, markers and all.
+    The endpoint used to separate anyway and discard the reasoning half, which
+    returned an empty message for a reasoning model stopped at `max_tokens`;
+    putting the discarded half back as `text` would hand the client the one
+    thing it declined. Not looking is the only answer that does neither -- and
+    the only one with nothing held back, since no marker is being watched for.
+    """
+    if not thinking:
+        return None, raw_text
+    return separate_reasoning(raw_text, starts_thinking=starts_thinking)
+
+
+def anthropic_reasoning_filter(
+    *, thinking: bool, starts_thinking: bool
+) -> ReasoningFilter | None:
+    """The streaming half of :func:`anthropic_reasoning_split`'s rule."""
+    if not thinking:
+        return None
+    return ReasoningFilter(starts_thinking=starts_thinking)
+
+
+_ANTHROPIC_STOP_REASON = {
+    "eos": "end_turn",
+    "max_tokens": "max_tokens",
+    "stop_sequence": "stop_sequence",
+}
 _metrics_exporter = AtomMetricsExporter()
 _metrics_refresh_task: asyncio.Task | None = None
 _METRICS_REFRESH_INTERVAL_SECONDS = 5.0
@@ -1661,7 +1697,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             )
 
             async def generate_anthropic_stream():
-                from .reasoning import ReasoningFilter
                 from .tool_parser import ToolCallStreamParser
 
                 # Asked of every dialect, not of one literal: the K3
@@ -1669,24 +1704,35 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 # `.endswith("<think>")` does not see, and the assignment it
                 # guarded skipped `__post_init__` so the instance was in the
                 # thinking state while claiming it did not start there.
-                reasoning_filter = ReasoningFilter(
+                # No filter at all when the client did not ask for thinking.
+                # It said it does not want a reasoning channel, so there is
+                # nothing to separate: the model's output is the text, markers
+                # and all. Separating it and then dropping the reasoning was
+                # how a reasoning model stopped at `max_tokens` returned an
+                # empty message, and putting the dropped part back as `text`
+                # would hand the client the very thing it declined.
+                #
+                # Nothing is watched for, so nothing is held back either.
+                reasoning_filter = anthropic_reasoning_filter(
+                    thinking=bool(getattr(request, "thinking", None)),
                     starts_thinking=prompt_starts_in_reasoning(prompt)
-                    or model_starts_in_reasoning
+                    or model_starts_in_reasoning,
                 )
                 tool_parser = ToolCallStreamParser(parser_cls=tool_call_parser_cls)
                 tool_parser.tools = anthropic_to_openai_tools(request.tools)
                 blocks = AnthropicBlocks()
                 has_tool_calls = False
-                # Reasoning the client did not ask for. Dropped, unless it
-                # turns out to be all the model produced -- a reasoning model
-                # stopped at max_tokens emits nothing else, and answering an
-                # empty message is worse than answering its working out.
-                withheld_reasoning: list[str] = []
                 output_tokens = 0
+                # Overwritten by a tool call, and otherwise by whatever the
+                # engine says. It used to be the constant `end_turn`, so a
+                # response cut off at `max_tokens` claimed a normal ending --
+                # and a reasoning model asked for no thinking, which produces
+                # only reasoning and has all of it dropped, delivered an empty
+                # message that also said nothing was wrong. The vocabularies
+                # already line up; they were simply never connected.
                 stop_reason = "end_turn"
 
                 message_started = False
-                _thinking_enabled = bool(getattr(request, "thinking", None))
                 # Assume abort until we reach the normal end of the stream. If
                 # the client disconnects, GeneratorExit unwinds through the
                 # yields and the finally runs with this still True -> abort.
@@ -1702,23 +1748,26 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             )
                             message_started = True
                         new_text = chunk_data["text"]
+                        if not has_tool_calls:
+                            stop_reason = _ANTHROPIC_STOP_REASON.get(
+                                chunk_data.get("finish_reason"), stop_reason
+                            )
                         output_tokens += len(chunk_data.get("token_ids", []))
                         finished = chunk_data.get("finished", False)
 
                         # Phase 1: Reasoning filter
-                        segments = reasoning_filter.process(new_text)
-                        if finished:
-                            segments.extend(reasoning_filter.flush())
+                        if reasoning_filter is None:
+                            segments = [("content", new_text)]
+                        else:
+                            segments = reasoning_filter.process(new_text)
+                            if finished:
+                                segments.extend(reasoning_filter.flush())
 
                         for field, text in segments:
                             if not text:
                                 continue
 
                             if field == "reasoning_content":
-                                if not _thinking_enabled:
-                                    withheld_reasoning.append(text)
-                                    yield _ANTHROPIC_PING_FRAME
-                                    continue
                                 for _frame in blocks.delta("thinking", text):
                                     yield _frame
                             else:
@@ -1781,15 +1830,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             if not has_tool_calls and blocks.kind != "text":
                                 for _frame in blocks.open("text"):
                                     yield _frame
-                                if blocks.index == 0 and withheld_reasoning:
-                                    # Nothing was ever delivered: this whole
-                                    # response was reasoning the client did
-                                    # not ask for. Send it rather than an
-                                    # empty message.
-                                    for _frame in blocks.delta(
-                                        "text", "".join(withheld_reasoning)
-                                    ):
-                                        yield _frame
                             for _frame in blocks.close():
                                 yield _frame
                             yield stream_message_delta(stop_reason, output_tokens)
@@ -1810,7 +1850,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             )
 
         # Non-streaming response
-        from .reasoning import separate_reasoning
         from .tool_parser import parse_tool_calls
 
         final_output = await _run_nonstream_with_disconnect(
@@ -1822,8 +1861,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             raise RuntimeError("No output generated")
 
         raw_text = final_output["text"]
-        reasoning_content, content_with_tools = separate_reasoning(
+        reasoning_content, content_with_tools = anthropic_reasoning_split(
             raw_text,
+            thinking=bool(getattr(request, "thinking", None)),
             starts_thinking=prompt_starts_in_reasoning(prompt)
             or model_starts_in_reasoning,
         )
@@ -1834,9 +1874,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         )
         output_tokens = len(tokenizer.encode(raw_text))
         cache_read_input_tokens = final_output.get("num_cached_tokens", 0)
-        if not getattr(request, "thinking", None):
-            reasoning_content = None
-
         return build_anthropic_response(
             request_id=request_id,
             model=model_name,

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -129,7 +129,7 @@ tool_call_parser_cls: type | None = None
 model_starts_in_reasoning: bool = False
 # (kwarg, off-value) the chat template reads to switch reasoning off, resolved
 # at startup by asking it; None when the template offers no such switch.
-reasoning_toggle: tuple[str, Any] | None = None
+reasoning_toggle: tuple[str, Any, Any] | None = None
 processor: Any | None = None
 model_name: str = ""
 default_chat_template_kwargs: dict[str, Any] = {}
@@ -152,7 +152,9 @@ def anthropic_thinking_enabled(request: Any) -> bool:
     return bool(thinking) and thinking.get("type") != "disabled"
 
 
-def anthropic_template_kwargs(request: Any, toggle: tuple[str, Any] | None) -> dict:
+def anthropic_template_kwargs(
+    request: Any, toggle: tuple[str, Any, Any] | None
+) -> dict:
     """How `thinking` reaches the model: by not asking it to think.
 
     `thinking: disabled` is answered where the answer costs nothing -- in the
@@ -175,6 +177,11 @@ def anthropic_template_kwargs(request: Any, toggle: tuple[str, Any] | None) -> d
     existing caller gets back from a reasoning model. Absent means unstated,
     and unstated leaves the model's own default alone.
 
+    Both directions go through the resolved toggle. Writing a hardcoded
+    `thinking=True` for the on direction is a no-op on any template that reads
+    another name -- the whole Qwen family -- so an explicit opt-in was
+    discarded silently against a server default of off.
+
     ``toggle`` is ``None`` for a model whose template has no switch. The
     request is then honoured as far as it can be -- the reasoning is separated
     and reported as a `thinking` block, never discarded -- and startup has
@@ -182,10 +189,10 @@ def anthropic_template_kwargs(request: Any, toggle: tuple[str, Any] | None) -> d
     """
     if getattr(request, "thinking", None) is None:
         return {}
-    if toggle is None or anthropic_thinking_enabled(request):
+    if toggle is None:
         return {}
-    name, off_value = toggle
-    return {name: off_value}
+    name, off_value, on_value = toggle
+    return {name: on_value if anthropic_thinking_enabled(request) else off_value}
 
 
 # The engine's `leave_reason` in Anthropic's vocabulary. The scheduler emits
@@ -257,12 +264,16 @@ async def _client_stream(
     reports looks like an answer.
     """
     it = gen.__aiter__()
+    delivered = False
     while True:
-        with FrameWait(request_id):
+        # The first wait is the queue, not silence: every generator awaits the
+        # collector before its opening frame.
+        with FrameWait(request_id, armed=delivered):
             try:
                 chunk = await it.__anext__()
             except StopAsyncIteration:
                 return
+        delivered = True
         if _request_logger is not None and chunk.startswith("data: "):
             payload = chunk[6:].strip()
             if payload != "[DONE]":
@@ -1352,10 +1363,9 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
             # measured, `thinking=False` left the `<think>` prefill in place.
             # A template ignores a kwarg it does not know, so the failure was
             # invisible: the model reasoned anyway.
-            if not _th_enabled and reasoning_toggle is not None:
-                merged_kwargs[reasoning_toggle[0]] = reasoning_toggle[1]
-            elif _th_enabled:
-                merged_kwargs["thinking"] = True
+            if reasoning_toggle is not None:
+                name, off_value, on_value = reasoning_toggle
+                merged_kwargs[name] = on_value if _th_enabled else off_value
             if _th_effort is not None:
                 merged_kwargs["thinking_effort"] = _th_effort
 
@@ -2203,7 +2213,8 @@ def main():
 
     reasoning_toggle = resolve_reasoning_toggle(tokenizer, custom_message_encoder)
     if reasoning_toggle is not None:
-        logger.info(f"Reasoning is switched off with {reasoning_toggle[0]}=off.")
+        _name, _off, _on = reasoning_toggle
+        logger.info(f"Reasoning switches on {_name}: {_on!r} on, {_off!r} off.")
     else:
         logger.info(
             "This chat template has no switch for reasoning, so a request "

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -25,13 +25,15 @@ import uuid
 from asyncio import AbstractEventLoop
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
-from PIL import Image
 from transformers import AutoProcessor, AutoTokenizer
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 from atom import SamplingParams
 from atom.model_engine.arg_utils import EngineArgs
@@ -546,7 +548,17 @@ def _has_multimodal_content(messages: list[Any]) -> bool:
     return False
 
 
-def _load_image_from_url(url: str) -> Image.Image:
+def _load_image_from_url(url: str) -> "Image.Image":
+    # Imported here, not at module scope, and this is the one place in the
+    # file that needs it at runtime. Pillow is not a declared dependency, so a
+    # module-scope `from PIL import Image` made the whole server module
+    # unimportable wherever it is absent -- which is the non-GPU CI runner,
+    # where the only test that reached this module had to wrap its import in a
+    # try/except and degrade to `api_server = None`. Text-only serving does
+    # not need Pillow, so it should not be a condition of importing the
+    # server; a request that actually carries an image raises here, naming it.
+    from PIL import Image
+
     if url.startswith("data:"):
         try:
             _, encoded = url.split(",", 1)
@@ -574,7 +586,7 @@ def _get_multimodal_processor():
 
 def _collect_multimodal_parts(
     messages: list[Any],
-) -> tuple[list[dict[str, Any]], list[Image.Image]]:
+) -> tuple[list[dict[str, Any]], list["Image.Image"]]:
     """Normalize chat messages into processor form, loading every image.
 
     Content parts keep the order the client sent them in; the images are
@@ -1878,8 +1890,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
     and returns Anthropic-formatted responses. Enables Claude Code and other
     Anthropic-compatible tools to use ATOM as a backend.
     """
-    global engine, tokenizer, model_name
-
     # One validator over the shape both endpoints share: this path already
     # converts, so validating the conversion leaves a single rule rather than
     # a second one in Anthropic's spelling. It checked nothing before, so a

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -104,7 +104,11 @@ from .streaming_dispatch import (
     StreamBatchDispatcher,
     StreamOutputCollector,
 )
-from .tool_parser import ToolCallStreamParser, parse_tool_calls
+from .tool_parser import (
+    ToolCallStreamParser,
+    flatten_tool_events,
+    read_whole_events,
+)
 from .tool_parser.registry import (
     TOOL_CALL_PARSER_HELP,
     forbids_tool_calls,
@@ -2129,12 +2133,17 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         ).split(raw_text)
         if drop_reasoning:
             reasoning_content = None
-        content_text, tool_calls = parse_tool_calls(
+        # The engine's own events, not the flattened `(content, calls)`:
+        # this endpoint renders blocks in order, and the flattening is where
+        # the order was lost. `read_whole_events` is the same single chunk
+        # through the same engine the streaming branch above drives.
+        events = read_whole_events(
+            tool_call_parser_cls,
             content_with_tools,
             anthropic_to_openai_tools(request.tools),
-            parser_cls=tool_call_parser_cls,
             suppress_calls=forbids_tool_calls(request.tool_choice),
         )
+        content_text, tool_calls = flatten_tool_events(events)
         output_tokens = len(tokenizer.encode(raw_text))
         cache_read_input_tokens = final_output.get("num_cached_tokens", 0)
         return build_anthropic_response(
@@ -2154,6 +2163,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             stop_reason=anthropic_stop_reason_with_calls(
                 final_output.get("finish_reason"), bool(tool_calls)
             ),
+            events=events,
         )
 
     except _ClientDisconnected:

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -77,7 +77,8 @@ from .serving_anthropic import (
     anthropic_to_openai_tools,
     build_anthropic_response,
     completes_a_tool_call,
-    stream_error,
+    read_whole_blocks,
+    stream_failure_frames,
     stream_message_delta,
     stream_message_start,
     stream_message_stop,
@@ -107,7 +108,6 @@ from .streaming_dispatch import (
 from .tool_parser import (
     ToolCallStreamParser,
     flatten_tool_events,
-    read_whole_events,
 )
 from .tool_parser.registry import (
     TOOL_CALL_PARSER_HELP,
@@ -2096,11 +2096,19 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                     # the reasoning filter or a tool parser cut the response
                     # mid-frame with an open block and no terminator.
                     logger.exception("Error streaming anthropic response")
-                    for _frame in blocks.close():
+                    for _frame in stream_failure_frames(
+                        exc,
+                        blocks,
+                        output_tokens,
+                        opening=(
+                            None
+                            if message_started
+                            else stream_message_start(
+                                request_id, model_name, input_tokens, 0
+                            )
+                        ),
+                    ):
                         yield _frame
-                    yield stream_error(str(exc))
-                    yield stream_message_delta("end_turn", output_tokens)
-                    yield stream_message_stop()
                 finally:
                     cleanup_stream(seq_id, aborted=aborted)
                     cleanup_request(request_id)
@@ -2128,30 +2136,28 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         # and what keeps a chain of thought out of the tool parser. Only
         # whether the client is shown it is a question, and the same one the
         # streaming branch above asks.
-        reasoning_content, content_with_tools = reasoning_channel(
-            prompt_starts_in_reasoning(prompt), thinking_off=thinking_off
-        ).split(raw_text)
-        if drop_reasoning:
-            reasoning_content = None
-        # The engine's own events, not the flattened `(content, calls)`:
-        # this endpoint renders blocks in order, and the flattening is where
-        # the order was lost. `read_whole_events` is the same single chunk
-        # through the same engine the streaming branch above drives.
-        events = read_whole_events(
+        # Both stages over one chunk, in the order the branch above streams
+        # them: reasoning filter, then the tool parser on the content segments
+        # it yields. Calling `.split()` here instead flattened the two into
+        # `(reasoning, content)` and lost the interleaving at that line.
+        events = read_whole_blocks(
+            reasoning_channel(
+                prompt_starts_in_reasoning(prompt), thinking_off=thinking_off
+            ),
             tool_call_parser_cls,
-            content_with_tools,
+            raw_text,
             anthropic_to_openai_tools(request.tools),
             suppress_calls=forbids_tool_calls(request.tool_choice),
         )
-        content_text, tool_calls = flatten_tool_events(events)
+        if drop_reasoning:
+            events = [e for e in events if e[0] != "reasoning"]
+        _, tool_calls = flatten_tool_events(events)
         output_tokens = len(tokenizer.encode(raw_text))
         cache_read_input_tokens = final_output.get("num_cached_tokens", 0)
         return build_anthropic_response(
             request_id=request_id,
             model=model_name,
-            content_text=content_text,
-            reasoning_content=reasoning_content,
-            tool_calls=tool_calls if tool_calls else None,
+            events=events,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
@@ -2163,7 +2169,6 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             stop_reason=anthropic_stop_reason_with_calls(
                 final_output.get("finish_reason"), bool(tool_calls)
             ),
-            events=events,
         )
 
     except _ClientDisconnected:

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -46,7 +46,12 @@ from atom.utils.gc_utils import (
     tune_gc,
 )
 
-from .chat_encoders import apply_chat_template, load_custom_message_encoder
+from .chat_encoders import (
+    apply_chat_template,
+    chat_template_source,
+    load_custom_message_encoder,
+    resolve_reasoning_toggle,
+)
 from .metrics import AtomMetricsExporter
 from .protocol import (
     DEFAULT_TEMPERATURE,
@@ -116,6 +121,9 @@ tool_call_parser_cls: type | None = None
 # response cannot tell you: its first token is already reasoning and reads
 # like an answer.
 model_starts_in_reasoning: bool = False
+# (kwarg, off-value) the chat template reads to switch reasoning off, resolved
+# at startup by asking it; None when the template offers no such switch.
+reasoning_toggle: tuple[str, Any] | None = None
 processor: Any | None = None
 model_name: str = ""
 default_chat_template_kwargs: dict[str, Any] = {}
@@ -127,40 +135,81 @@ _request_logger: logging.Logger | None = None
 _stream_batch_dispatcher: StreamBatchDispatcher | None = None
 
 
-# The engine's `leave_reason` in Anthropic's vocabulary. `aborted` has no
-# counterpart -- the client is already gone -- so it keeps the default.
-def anthropic_reasoning_split(
-    raw_text: str, *, thinking: bool, starts_thinking: bool
-) -> tuple[str | None, str]:
-    """Separate the reasoning channel, or decline to.
+def anthropic_thinking_enabled(request: Any) -> bool:
+    """Did this request ask for a reasoning channel?
 
-    `thinking` off means the request wants no reasoning channel, so nothing
-    separates one out and the model's output is the text, markers and all.
-    The endpoint used to separate anyway and discard the reasoning half, which
-    returned an empty message for a reasoning model stopped at `max_tokens`;
-    putting the discarded half back as `text` would hand the client the one
-    thing it declined. Not looking is the only answer that does neither -- and
-    the only one with nothing held back, since no marker is being watched for.
+    `thinking` is absent on most requests and `{"type": "disabled"}` is the
+    spelling for switching it off, which is a non-empty dict and therefore
+    truthy -- so `bool(request.thinking)` read the standard off-switch as on.
     """
-    if not thinking:
-        return None, raw_text
-    return separate_reasoning(raw_text, starts_thinking=starts_thinking)
+    thinking = getattr(request, "thinking", None) or {}
+    return bool(thinking) and thinking.get("type") != "disabled"
 
 
-def anthropic_reasoning_filter(
-    *, thinking: bool, starts_thinking: bool
-) -> ReasoningFilter | None:
-    """The streaming half of :func:`anthropic_reasoning_split`'s rule."""
-    if not thinking:
-        return None
-    return ReasoningFilter(starts_thinking=starts_thinking)
+def anthropic_template_kwargs(request: Any, toggle: tuple[str, Any] | None) -> dict:
+    """How `thinking` reaches the model: by not asking it to think.
+
+    `thinking: disabled` is answered where the answer costs nothing -- in the
+    prompt. The chat template's own switch is set, so the model emits no
+    reasoning, so there is none to separate, none to discard, and none for the
+    tool parser to misread. This is what SGLang does with the same field and
+    what vLLM gets structurally by having no such field at all.
+
+    Everything downstream is then unconditional, which is the point. Three
+    attempts to handle an unwanted chain of thought *after* generating it each
+    broke something else: discarding it returned an empty message, relabelling
+    it as `text` handed the client the thing it declined, and declining to
+    separate it fed a chain of thought to the tool parser, which read one
+    model's musing about `<function=NAME>` as a call to a tool named `NAME`.
+    The reasoning that is never produced needs none of that.
+
+    Only when the field is actually present, which is also what SGLang keys
+    on. Anthropic's default is thinking-off, but reading an absent field as
+    "switch this model's reasoning off" would silently change what every
+    existing caller gets back from a reasoning model. Absent means unstated,
+    and unstated leaves the model's own default alone.
+
+    ``toggle`` is ``None`` for a model whose template has no switch. The
+    request is then honoured as far as it can be -- the reasoning is separated
+    and reported as a `thinking` block, never discarded -- and startup has
+    already said so.
+    """
+    if getattr(request, "thinking", None) is None:
+        return {}
+    if toggle is None or anthropic_thinking_enabled(request):
+        return {}
+    name, off_value = toggle
+    return {name: off_value}
 
 
+# The engine's `leave_reason` in Anthropic's vocabulary. The scheduler emits
+# exactly seven shapes; the three here line up by name, `stop_<token_id>` is
+# handled below, and `aborted` / `unschedulable: ...` / "" have no counterpart
+# in Anthropic's vocabulary and keep the default.
 _ANTHROPIC_STOP_REASON = {
     "eos": "end_turn",
     "max_tokens": "max_tokens",
     "stop_sequence": "stop_sequence",
 }
+
+
+def anthropic_stop_reason(finish_reason: Any) -> str:
+    """The engine's leave reason as Anthropic spells it.
+
+    Not routed through `_normalize_finish_reason`: that maps into OpenAI's
+    vocabulary (`stop` / `length`), which shares no member with the keys here,
+    so chaining them would send every reason to the default.
+
+    `stop_<token_id>` is its own case for the same reason it exists -- a stop
+    token fired, which is Anthropic's `stop_sequence`. Falling through would
+    have reported a normal ending for a response that was cut short.
+    """
+    reason = finish_reason or ""
+    if reason.startswith("stop_") and reason != "stop_sequence":
+        return "stop_sequence"
+    return _ANTHROPIC_STOP_REASON.get(reason, "end_turn")
+
+
 _metrics_exporter = AtomMetricsExporter()
 _metrics_refresh_task: asyncio.Task | None = None
 _METRICS_REFRESH_INTERVAL_SECONDS = 5.0
@@ -1272,7 +1321,16 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
             merged_kwargs["tool_choice"] = request.tool_choice
         if request.thinking is not None or request.reasoning_effort is not None:
             _th_enabled, _th_effort = resolve_thinking(request)
-            merged_kwargs["thinking"] = _th_enabled
+            # By the name this template actually reads. `thinking` was
+            # hardcoded, which is right for Kimi-K3 and a silent no-op for the
+            # whole Qwen family, whose templates read `enable_thinking` --
+            # measured, `thinking=False` left the `<think>` prefill in place.
+            # A template ignores a kwarg it does not know, so the failure was
+            # invisible: the model reasoned anyway.
+            if not _th_enabled and reasoning_toggle is not None:
+                merged_kwargs[reasoning_toggle[0]] = reasoning_toggle[1]
+            elif _th_enabled:
+                merged_kwargs["thinking"] = True
             if _th_effort is not None:
                 merged_kwargs["thinking_effort"] = _th_effort
 
@@ -1628,6 +1686,10 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         messages = [ChatMessage(**m) for m in openai_messages]
 
         merged_kwargs = dict(default_chat_template_kwargs)
+        # The request's `thinking` was dropped on the floor here, so the model
+        # was never told not to think and the endpoint spent three attempts
+        # dealing with a chain of thought it had asked for by omission.
+        merged_kwargs.update(anthropic_template_kwargs(request, reasoning_toggle))
         prompt = apply_chat_template(
             tokenizer,
             custom_message_encoder,
@@ -1699,22 +1761,19 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             async def generate_anthropic_stream():
                 from .tool_parser import ToolCallStreamParser
 
-                # Asked of every dialect, not of one literal: the K3
-                # template opens with `<|open|>think<|sep|>`, which
-                # `.endswith("<think>")` does not see, and the assignment it
-                # guarded skipped `__post_init__` so the instance was in the
-                # thinking state while claiming it did not start there.
-                # No filter at all when the client did not ask for thinking.
-                # It said it does not want a reasoning channel, so there is
-                # nothing to separate: the model's output is the text, markers
-                # and all. Separating it and then dropping the reasoning was
-                # how a reasoning model stopped at `max_tokens` returned an
-                # empty message, and putting the dropped part back as `text`
-                # would hand the client the very thing it declined.
+                # Unconditional, like the chat path and like both upstreams:
+                # whatever reasoning arrives is separated and reported. The
+                # request's `thinking` was answered in the prompt, so there is
+                # nothing left here for it to decide -- and separating always
+                # is what keeps the reasoning out of the tool parser, which is
+                # a second reader of this same text.
                 #
-                # Nothing is watched for, so nothing is held back either.
-                reasoning_filter = anthropic_reasoning_filter(
-                    thinking=bool(getattr(request, "thinking", None)),
+                # Asked of every dialect, not of one literal: the K3 template
+                # opens with `<|open|>think<|sep|>`, which `.endswith("<think>")`
+                # does not see, and the assignment it guarded skipped
+                # `__post_init__` so the instance was in the thinking state
+                # while claiming it did not start there.
+                reasoning_filter = ReasoningFilter(
                     starts_thinking=prompt_starts_in_reasoning(prompt)
                     or model_starts_in_reasoning,
                 )
@@ -1748,9 +1807,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             )
                             message_started = True
                         new_text = chunk_data["text"]
-                        if not has_tool_calls:
-                            stop_reason = _ANTHROPIC_STOP_REASON.get(
-                                chunk_data.get("finish_reason"), stop_reason
+                        if not has_tool_calls and chunk_data.get("finish_reason"):
+                            stop_reason = anthropic_stop_reason(
+                                chunk_data["finish_reason"]
                             )
                         output_tokens += len(chunk_data.get("token_ids", []))
                         finished = chunk_data.get("finished", False)
@@ -1861,9 +1920,10 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             raise RuntimeError("No output generated")
 
         raw_text = final_output["text"]
-        reasoning_content, content_with_tools = anthropic_reasoning_split(
+        # Unconditional, and the same call the chat path makes. See the
+        # streaming branch above for why `thinking` has no say here.
+        reasoning_content, content_with_tools = separate_reasoning(
             raw_text,
-            thinking=bool(getattr(request, "thinking", None)),
             starts_thinking=prompt_starts_in_reasoning(prompt)
             or model_starts_in_reasoning,
         )
@@ -1883,6 +1943,16 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
+            # A tool call is its own ending; otherwise whatever the engine
+            # said. Omitting this left the parameter's `end_turn` default in
+            # place, so the same response cut off at `max_tokens` reported a
+            # normal ending with `stream=false` and `max_tokens` with
+            # `stream=true`.
+            stop_reason=(
+                "tool_use"
+                if tool_calls
+                else anthropic_stop_reason(final_output.get("finish_reason"))
+            ),
         )
 
     except _ClientDisconnected:
@@ -2035,7 +2105,7 @@ async def stop_profile():
 def main():
     """Main entry point for the server."""
     global engine, tokenizer, model_name, default_chat_template_kwargs, _request_logger
-    global tool_call_parser_cls, model_starts_in_reasoning
+    global tool_call_parser_cls, model_starts_in_reasoning, reasoning_toggle
     global custom_message_encoder, _stream_batch_dispatcher
 
     parser = FlexibleArgumentParser(description="ATOM OpenAI API Server")
@@ -2133,12 +2203,22 @@ def main():
     logger.info(f"Initializing engine with model {args.model}...")
     engine_args = EngineArgs.from_cli_args(args)
     model_starts_in_reasoning = template_opens_reasoning_implicitly(
-        getattr(tokenizer, "chat_template", None) or ""
+        chat_template_source(tokenizer, custom_message_encoder)
     )
     if model_starts_in_reasoning:
         logger.info(
             "Chat template closes a reasoning block it never opens; treating "
             "output as reasoning until the end marker."
+        )
+
+    reasoning_toggle = resolve_reasoning_toggle(tokenizer, custom_message_encoder)
+    if reasoning_toggle is not None:
+        logger.info(f"Reasoning is switched off with {reasoning_toggle[0]}=off.")
+    else:
+        logger.info(
+            "This chat template has no switch for reasoning, so a request "
+            "asking for none cannot stop the model producing it. Any that "
+            "arrives is still separated and reported, never discarded."
         )
 
     tool_call_parser_cls = resolve_tool_call_parser(

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -91,6 +91,7 @@ from .serving_completion import (
 )
 from .sse import event_frame
 from .streaming_dispatch import StreamBatchDispatcher, StreamOutputCollector
+from .tool_parser.registry import resolve_tool_call_parser
 
 # Configure logging
 logger = logging.getLogger("atom")
@@ -106,6 +107,10 @@ DEFAULT_PORT = 8000
 
 engine = None
 tokenizer: AutoTokenizer | None = None
+# The tool-call format this model emits, resolved once at startup from its
+# chat template. `None` means none was recognised and tool calls, if any, are
+# delivered as plain text -- said out loud at startup, never discovered here.
+tool_call_parser_cls: type | None = None
 processor: Any | None = None
 model_name: str = ""
 default_chat_template_kwargs: dict[str, Any] = {}
@@ -1306,6 +1311,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     tools=request.tools,
                     tool_choice=request.tool_choice,
                     starts_thinking=_starts_thinking,
+                    tool_parser_cls=tool_call_parser_cls,
                 )
             else:
                 seq_id, stream_collector, num_prompt_tokens = (
@@ -1329,6 +1335,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     tools=request.tools,
                     tool_choice=request.tool_choice,
                     starts_thinking=_starts_thinking,
+                    tool_parser_cls=tool_call_parser_cls,
                 )
             return StreamingResponse(
                 _logged_stream(gen, request_id),
@@ -1358,6 +1365,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 tools=request.tools,
                 tool_choice=request.tool_choice,
                 starts_thinking=_starts_thinking,
+                tool_parser_cls=tool_call_parser_cls,
             )
         elif is_multimodal:
             final_output = await _run_nonstream_with_disconnect(
@@ -1381,6 +1389,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 tools=request.tools,
                 tool_choice=request.tool_choice,
                 starts_thinking=_starts_thinking,
+                tool_parser_cls=tool_call_parser_cls,
             )
         elif effective_n > 1:
             outputs = await _race_disconnect(
@@ -1403,6 +1412,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 tools=request.tools,
                 tool_choice=request.tool_choice,
                 starts_thinking=_starts_thinking,
+                tool_parser_cls=tool_call_parser_cls,
             )
         else:
             final_output = await _run_nonstream_with_disconnect(
@@ -1426,6 +1436,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 tools=request.tools,
                 tool_choice=request.tool_choice,
                 starts_thinking=_starts_thinking,
+                tool_parser_cls=tool_call_parser_cls,
             )
         _log_request_event("response", request_id, resp.model_dump())
         return resp
@@ -1657,7 +1668,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 reasoning_filter = ReasoningFilter(
                     starts_thinking=prompt_starts_in_reasoning(prompt)
                 )
-                tool_parser = ToolCallStreamParser()
+                tool_parser = ToolCallStreamParser(parser_cls=tool_call_parser_cls)
                 tool_parser.tools = anthropic_to_openai_tools(request.tools)
                 block_index = 0
                 started_text = False
@@ -1840,7 +1851,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             raw_text, starts_thinking=prompt_starts_in_reasoning(prompt)
         )
         content_text, tool_calls = parse_tool_calls(
-            content_with_tools, anthropic_to_openai_tools(request.tools)
+            content_with_tools,
+            anthropic_to_openai_tools(request.tools),
+            parser_cls=tool_call_parser_cls,
         )
         output_tokens = len(tokenizer.encode(raw_text))
         cache_read_input_tokens = final_output.get("num_cached_tokens", 0)
@@ -2008,11 +2021,23 @@ async def stop_profile():
 def main():
     """Main entry point for the server."""
     global engine, tokenizer, model_name, default_chat_template_kwargs, _request_logger
+    global tool_call_parser_cls
     global custom_message_encoder, _stream_batch_dispatcher
 
     parser = FlexibleArgumentParser(description="ATOM OpenAI API Server")
     EngineArgs.add_cli_args(parser)
     parser.add_argument("--host", type=str, default=DEFAULT_HOST, help="Server host")
+    parser.add_argument(
+        "--tool-call-parser",
+        type=str,
+        default="auto",
+        help=(
+            "Tool-call wire format. 'auto' (default) reads it off the model's "
+            "chat template at startup; an explicit name overrides that. When "
+            "neither resolves, tool calls are delivered as plain text and the "
+            "startup log says so — the format is never guessed from output."
+        ),
+    )
     parser.add_argument(
         "--server-port",
         type=int,
@@ -2098,6 +2123,13 @@ def main():
 
     logger.info(f"Initializing engine with model {args.model}...")
     engine_args = EngineArgs.from_cli_args(args)
+    tool_call_parser_cls = resolve_tool_call_parser(
+        args.tool_call_parser,
+        tokenizer,
+        custom_message_encoder,
+        model=args.model,
+    )
+
     engine = engine_args.create_engine(tokenizer=tokenizer)
     _stream_batch_dispatcher = StreamBatchDispatcher(tokenizer)
 

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -50,6 +50,7 @@ from .chat_encoders import (
     apply_chat_template,
     chat_template_source,
     load_custom_message_encoder,
+    render_probe_prompt,
     resolve_reasoning_toggle,
 )
 from .metrics import AtomMetricsExporter
@@ -63,12 +64,12 @@ from .protocol import (
     ModelList,
 )
 from .reasoning import (
-    ReasoningFilter,
+    ReasoningChannel,
     prompt_starts_in_reasoning,
     prompt_tokens_start_in_reasoning,
-    separate_reasoning,
     template_opens_reasoning_implicitly,
 )
+from .reasoning_dialects import resolve_dialect
 from .serving_anthropic import (
     AnthropicBlocks,
     AnthropicMessagesRequest,
@@ -106,7 +107,6 @@ from .tool_parser import ToolCallStreamParser, parse_tool_calls
 from .tool_parser.registry import (
     TOOL_CALL_PARSER_HELP,
     forbids_tool_calls,
-    parser_for_tool_choice,
     resolve_tool_call_parser,
 )
 
@@ -134,6 +134,7 @@ tool_call_parser_cls: type | None = None
 # response cannot tell you: its first token is already reasoning and reads
 # like an answer.
 model_starts_in_reasoning: bool = False
+reasoning_dialect: Any = None
 # (kwarg, off-value) the chat template reads to switch reasoning off, resolved
 # at startup by asking it; None when the template offers no such switch.
 reasoning_toggle: tuple[str, Any, Any] | None = None
@@ -146,6 +147,37 @@ _stream_loops: dict[str, AbstractEventLoop] = {}
 _request_start_times: dict[str, float] = {}
 _request_logger: logging.Logger | None = None
 _stream_batch_dispatcher: StreamBatchDispatcher | None = None
+
+
+def reasoning_channel(prompt_opens: bool, *, thinking_off: bool) -> ReasoningChannel:
+    """How to read this request's reasoning channel.
+
+    One place, because it is one answer and both endpoints and both delivery
+    modes need the same one. The dialect is the model's, resolved at startup;
+    what varies per request is whether the output begins inside the channel.
+
+    ``thinking_off`` is why that is not just the model-level fact. A request
+    that switches reasoning off renders a prompt that does not open the
+    channel, and `model_starts_in_reasoning` -- which describes the template
+    with reasoning *on* -- was OR-ed in regardless. On a model that begins
+    inside the channel implicitly, an ordinary answer to a request that had
+    asked for no thinking came back entirely as `reasoning_content`, with
+    `content` empty.
+
+    And it only counts when the template has a switch to honour it with. Ask
+    DeepSeek-R1 for no thinking and nothing goes into the prompt -- it has no
+    such kwarg (`resolve_reasoning_toggle` answers ``None`` for it) -- so the
+    model reasons exactly as always. Believing the request there stops the
+    channel being separated at all, and the client gets the chain of thought
+    and a literal `</think>` inside `content`. Reasoning that was asked not to
+    happen and happened anyway is still reasoning; `anthropic_drop_reasoning`
+    exists to withhold it, and it can only withhold what was separated.
+    """
+    honoured = thinking_off and reasoning_toggle is not None
+    return ReasoningChannel(
+        dialect=reasoning_dialect,
+        starts_open=prompt_opens or (model_starts_in_reasoning and not honoured),
+    )
 
 
 def anthropic_thinking_enabled(request: Any) -> bool:
@@ -236,6 +268,18 @@ _ANTHROPIC_STOP_REASON = {
     "max_tokens": "max_tokens",
     "stop_sequence": "stop_sequence",
 }
+
+
+def anthropic_stop_reason_with_calls(finish_reason: Any, has_calls: bool) -> str:
+    """`max_tokens` outranks `tool_use`, for the reason `length` outranks
+    `tool_calls` on the other endpoint (see
+    :func:`~.serving_chat.finish_reason_with_calls`): only one of the two is a
+    warning, and a response cut off mid-call parses to a call with a silently
+    truncated argument value."""
+    reason = anthropic_stop_reason(finish_reason)
+    if reason == "max_tokens":
+        return reason
+    return "tool_use" if has_calls else reason
 
 
 def anthropic_stop_reason(finish_reason: Any) -> str:
@@ -1427,8 +1471,8 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
             merged_kwargs["response_format"] = request.response_format
         if isinstance(request.tool_choice, str):
             merged_kwargs["tool_choice"] = request.tool_choice
+        _th_enabled, _th_effort = resolve_thinking(request)
         if request.thinking is not None or request.reasoning_effort is not None:
-            _th_enabled, _th_effort = resolve_thinking(request)
             # By the name this template actually reads. `thinking` was
             # hardcoded, which is right for Kimi-K3 and a silent no-op for the
             # whole Qwen family, whose templates read `enable_thinking` --
@@ -1488,11 +1532,14 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
         # The K3 template may inject the opening reasoning marker into the prompt
         # itself; if so the stream begins mid-thought and the ReasoningFilter must
         # start in the thinking state. Multimodal inputs arrive pre-tokenized.
-        _starts_thinking = (
-            prompt_tokens_start_in_reasoning(token_ids, tokenizer.decode)
-            if is_multimodal
-            else prompt_starts_in_reasoning(prompt)
-        ) or model_starts_in_reasoning
+        _reasoning = reasoning_channel(
+            (
+                prompt_tokens_start_in_reasoning(token_ids, tokenizer.decode)
+                if is_multimodal
+                else prompt_starts_in_reasoning(prompt)
+            ),
+            thinking_off=_th_enabled is False,
+        )
 
         # Streaming
         if request.stream:
@@ -1519,7 +1566,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     cleanup_request,
                     tools=request.tools,
                     tool_choice=request.tool_choice,
-                    starts_thinking=_starts_thinking,
+                    reasoning=_reasoning,
                     tool_parser_cls=tool_call_parser_cls,
                 )
             else:
@@ -1543,7 +1590,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     cleanup_request,
                     tools=request.tools,
                     tool_choice=request.tool_choice,
-                    starts_thinking=_starts_thinking,
+                    reasoning=_reasoning,
                     tool_parser_cls=tool_call_parser_cls,
                 )
             return StreamingResponse(
@@ -1573,7 +1620,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 outputs,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
-                starts_thinking=_starts_thinking,
+                reasoning=_reasoning,
                 tool_parser_cls=tool_call_parser_cls,
             )
         elif is_multimodal:
@@ -1597,7 +1644,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 final_output,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
-                starts_thinking=_starts_thinking,
+                reasoning=_reasoning,
                 tool_parser_cls=tool_call_parser_cls,
             )
         elif effective_n > 1:
@@ -1620,7 +1667,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 outputs,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
-                starts_thinking=_starts_thinking,
+                reasoning=_reasoning,
                 tool_parser_cls=tool_call_parser_cls,
             )
         else:
@@ -1644,7 +1691,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 final_output,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
-                starts_thinking=_starts_thinking,
+                reasoning=_reasoning,
                 tool_parser_cls=tool_call_parser_cls,
             )
         _log_request_event("response", request_id, resp.model_dump())
@@ -1811,6 +1858,11 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         # no such spelling, and are not answered here or on the chat path.
         if forbids_tool_calls(request.tool_choice):
             merged_kwargs["tool_choice"] = "none"
+        # Thinking is "unstated" unless the field is present, exactly as
+        # `anthropic_template_kwargs` and `anthropic_drop_reasoning` read it.
+        thinking_off = request.thinking is not None and not anthropic_thinking_enabled(
+            request
+        )
         prompt = apply_chat_template(
             tokenizer,
             custom_message_encoder,
@@ -1891,15 +1943,15 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 # opens with `<|open|>think<|sep|>`, which `.endswith("<think>")`
                 # does not see, and the assignment it guarded skipped
                 # `__post_init__` so the instance was in the thinking state
-                # while claiming it did not start there.
-                reasoning_filter = ReasoningFilter(
-                    starts_thinking=prompt_starts_in_reasoning(prompt)
-                    or model_starts_in_reasoning,
-                )
+                # while claiming it did not start there. Which dialect closes
+                # it is the model's, resolved at startup -- the filter used to
+                # carry none and closed on any registered dialect's marker.
+                reasoning_filter = reasoning_channel(
+                    prompt_starts_in_reasoning(prompt), thinking_off=thinking_off
+                ).stream()
                 tool_parser = ToolCallStreamParser(
-                    parser_cls=parser_for_tool_choice(
-                        tool_call_parser_cls, request.tool_choice
-                    )
+                    parser_cls=tool_call_parser_cls,
+                    suppress_calls=forbids_tool_calls(request.tool_choice),
                 )
                 tool_parser.tools = anthropic_to_openai_tools(request.tools)
                 blocks = AnthropicBlocks()
@@ -1913,6 +1965,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 # message that also said nothing was wrong. The vocabularies
                 # already line up; they were simply never connected.
                 stop_reason = "end_turn"
+                # The engine's own reason, kept so a call parsed out of a
+                # response it cut short does not overwrite it.
+                engine_reason: Any = None
 
                 message_started = False
                 # Assume abort until we reach the normal end of the stream. If
@@ -1930,6 +1985,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             )
                             message_started = True
                         new_text = chunk_data["text"]
+                        if chunk_data.get("finish_reason"):
+                            engine_reason = chunk_data["finish_reason"]
                         if not has_tool_calls and chunk_data.get("finish_reason"):
                             stop_reason = anthropic_stop_reason(
                                 chunk_data["finish_reason"]
@@ -1960,7 +2017,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                                 events = tool_parser.process(text)
                                 if completes_a_tool_call(events):
                                     has_tool_calls = True
-                                    stop_reason = "tool_use"
+                                    stop_reason = anthropic_stop_reason_with_calls(
+                                        engine_reason, True
+                                    )
                                 for _frame in tool_event_frames(events, blocks):
                                     yield _frame
 
@@ -1969,7 +2028,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             events = tool_parser.flush()
                             if completes_a_tool_call(events):
                                 has_tool_calls = True
-                                stop_reason = "tool_use"
+                                stop_reason = anthropic_stop_reason_with_calls(
+                                    engine_reason, True
+                                )
                             for _frame in tool_event_frames(events, blocks):
                                 yield _frame
 
@@ -1980,11 +2041,19 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                             if not has_tool_calls and blocks.kind != "text":
                                 for _frame in blocks.open("text"):
                                     yield _frame
+                            # Before the last frames, not after. The flag means
+                            # "the engine sequence may still be running", and
+                            # the engine is done the moment its finished chunk
+                            # arrived -- a client hanging up between the two
+                            # yields below fired a broadcast abort for a
+                            # sequence that had already ended, which is the
+                            # control-path flood the flag exists to prevent.
+                            # `serving_chat` already sets it here.
+                            aborted = False
                             for _frame in blocks.close():
                                 yield _frame
                             yield stream_message_delta(stop_reason, output_tokens)
                             yield stream_message_stop()
-                            aborted = False
                             break
                 finally:
                     cleanup_stream(seq_id, aborted=aborted)
@@ -2013,19 +2082,16 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
         # and what keeps a chain of thought out of the tool parser. Only
         # whether the client is shown it is a question, and the same one the
         # streaming branch above asks.
-        reasoning_content, content_with_tools = separate_reasoning(
-            raw_text,
-            starts_thinking=prompt_starts_in_reasoning(prompt)
-            or model_starts_in_reasoning,
-        )
+        reasoning_content, content_with_tools = reasoning_channel(
+            prompt_starts_in_reasoning(prompt), thinking_off=thinking_off
+        ).split(raw_text)
         if drop_reasoning:
             reasoning_content = None
         content_text, tool_calls = parse_tool_calls(
             content_with_tools,
             anthropic_to_openai_tools(request.tools),
-            parser_cls=parser_for_tool_choice(
-                tool_call_parser_cls, request.tool_choice
-            ),
+            parser_cls=tool_call_parser_cls,
+            suppress_calls=forbids_tool_calls(request.tool_choice),
         )
         output_tokens = len(tokenizer.encode(raw_text))
         cache_read_input_tokens = final_output.get("num_cached_tokens", 0)
@@ -2043,10 +2109,8 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             # place, so the same response cut off at `max_tokens` reported a
             # normal ending with `stream=false` and `max_tokens` with
             # `stream=true`.
-            stop_reason=(
-                "tool_use"
-                if tool_calls
-                else anthropic_stop_reason(final_output.get("finish_reason"))
+            stop_reason=anthropic_stop_reason_with_calls(
+                final_output.get("finish_reason"), bool(tool_calls)
             ),
         )
 
@@ -2201,6 +2265,7 @@ def main():
     """Main entry point for the server."""
     global engine, tokenizer, model_name, default_chat_template_kwargs, _request_logger
     global tool_call_parser_cls, model_starts_in_reasoning, reasoning_toggle
+    global reasoning_dialect
     global custom_message_encoder, _stream_batch_dispatcher
 
     parser = FlexibleArgumentParser(description="ATOM OpenAI API Server")
@@ -2297,9 +2362,17 @@ def main():
 
     logger.info(f"Initializing engine with model {args.model}...")
     engine_args = EngineArgs.from_cli_args(args)
-    model_starts_in_reasoning = template_opens_reasoning_implicitly(
-        chat_template_source(tokenizer, custom_message_encoder)
+    _template_source = chat_template_source(tokenizer, custom_message_encoder)
+    reasoning_dialect, _dialect_stated = resolve_dialect(
+        _template_source,
+        render_probe_prompt(tokenizer, custom_message_encoder, tools=False) or "",
     )
+    logger.info(
+        "Reasoning channel: %s%s",
+        reasoning_dialect.think_end_marker,
+        "" if _dialect_stated else " (no dialect named in the chat template)",
+    )
+    model_starts_in_reasoning = template_opens_reasoning_implicitly(_template_source)
     if model_starts_in_reasoning:
         logger.info(
             "Chat template closes a reasoning block it never opens; treating "

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -1304,6 +1304,8 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     cleanup_stream,
                     cleanup_request,
                     tools=request.tools,
+                    tool_choice=request.tool_choice,
+                    starts_thinking=_starts_thinking,
                 )
             else:
                 seq_id, stream_collector, num_prompt_tokens = (
@@ -1355,6 +1357,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 outputs,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
+                starts_thinking=_starts_thinking,
             )
         elif is_multimodal:
             final_output = await _run_nonstream_with_disconnect(
@@ -1377,6 +1380,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 final_output,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
+                starts_thinking=_starts_thinking,
             )
         elif effective_n > 1:
             outputs = await _race_disconnect(
@@ -1398,6 +1402,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 outputs,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
+                starts_thinking=_starts_thinking,
             )
         else:
             final_output = await _run_nonstream_with_disconnect(
@@ -1420,6 +1425,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                 final_output,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
+                starts_thinking=_starts_thinking,
             )
         _log_request_event("response", request_id, resp.model_dump())
         return resp
@@ -1643,9 +1649,14 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
                 from .reasoning import ReasoningFilter
                 from .tool_parser import ToolCallStreamParser
 
-                reasoning_filter = ReasoningFilter()
-                if prompt.rstrip().endswith("<think>"):
-                    reasoning_filter.state = 1
+                # Asked of every dialect, not of one literal: the K3
+                # template opens with `<|open|>think<|sep|>`, which
+                # `.endswith("<think>")` does not see, and the assignment it
+                # guarded skipped `__post_init__` so the instance was in the
+                # thinking state while claiming it did not start there.
+                reasoning_filter = ReasoningFilter(
+                    starts_thinking=prompt_starts_in_reasoning(prompt)
+                )
                 tool_parser = ToolCallStreamParser()
                 tool_parser.tools = anthropic_to_openai_tools(request.tools)
                 block_index = 0
@@ -1825,7 +1836,9 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
             raise RuntimeError("No output generated")
 
         raw_text = final_output["text"]
-        reasoning_content, content_with_tools = separate_reasoning(raw_text)
+        reasoning_content, content_with_tools = separate_reasoning(
+            raw_text, starts_thinking=prompt_starts_in_reasoning(prompt)
+        )
         content_text, tool_calls = parse_tool_calls(
             content_with_tools, anthropic_to_openai_tools(request.tools)
         )

--- a/atom/entrypoints/openai/chat_encoder_adapters.py
+++ b/atom/entrypoints/openai/chat_encoder_adapters.py
@@ -42,6 +42,10 @@ class MessageEncoderAdapter:
     encode: MessageEncoder
     prepare_messages: MessagePreparer
     supports_tools: bool = False
+    # The file the encoder was loaded from. `encode` is a closure defined in
+    # `chat_encoders`, so `inspect.getmodule(encode)` names *that* module --
+    # reading the model's own source needs the path carried here.
+    source_path: str = ""
 
     def __call__(self, messages: list[dict], **kwargs: Any) -> str:
         """Preserve the callable behavior of the former encoder return value."""
@@ -54,7 +58,7 @@ _PREPARERS: dict[str, tuple[MessagePreparer, bool]] = {
 
 
 def build_message_encoder_adapter(
-    module_name: str, encoder: MessageEncoder
+    module_name: str, encoder: MessageEncoder, source_path: str = ""
 ) -> MessageEncoderAdapter:
     """Build an adapter registered for ``module_name`` or an identity adapter."""
     prepare_messages, supports_tools = _PREPARERS.get(
@@ -65,4 +69,5 @@ def build_message_encoder_adapter(
         encode=encoder,
         prepare_messages=prepare_messages,
         supports_tools=supports_tools,
+        source_path=source_path,
     )

--- a/atom/entrypoints/openai/chat_encoder_adapters.py
+++ b/atom/entrypoints/openai/chat_encoder_adapters.py
@@ -3,9 +3,13 @@
 
 """Model-scoped adapters for dynamically loaded chat encoders."""
 
+import inspect
+import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+
+logger = logging.getLogger("atom")
 
 MessageEncoder = Callable[..., str]
 MessagePreparer = Callable[[list[dict], list[dict] | None], list[dict]]
@@ -46,9 +50,34 @@ class MessageEncoderAdapter:
     # `chat_encoders`, so `inspect.getmodule(encode)` names *that* module --
     # reading the model's own source needs the path carried here.
     source_path: str = ""
+    # What this encoder's signature will accept, or ``None`` when it takes
+    # `**kwargs` and so accepts anything. See `__call__`.
+    accepts: frozenset[str] | None = field(default=None, compare=False)
 
     def __call__(self, messages: list[dict], **kwargs: Any) -> str:
-        """Preserve the callable behavior of the former encoder return value."""
+        """Render, passing on only the kwargs this encoder can take.
+
+        A Jinja template silently ignores a kwarg it does not read; a Python
+        encoder raises `TypeError`. The request handler forwards template
+        controls it cannot know the model reads -- `response_format`,
+        `tool_choice`, `thinking_effort`, and whatever a client puts in
+        `chat_template_kwargs` -- so a request carrying any of them was a 500
+        on every model that ships an encoder instead of a template, which on
+        this box is DeepSeek-V4 and Kimi-K3. `tool_choice: "none"` reached it
+        that way the moment the Anthropic endpoint began honouring the field.
+
+        Dropped rather than raised, so the two rendering paths behave the same
+        way: unread means unread. Logged at debug, because a kwarg a model
+        cannot take is worth seeing when a template control appears not to
+        work.
+        """
+        if self.accepts is not None:
+            unread = [name for name in kwargs if name not in self.accepts]
+            for name in unread:
+                logger.debug(
+                    "chat encoder %s does not take %r; ignoring it", self.name, name
+                )
+                kwargs.pop(name)
         return self.encode(messages, **kwargs)
 
 
@@ -57,10 +86,41 @@ _PREPARERS: dict[str, tuple[MessagePreparer, bool]] = {
 }
 
 
+def _accepted_kwargs(encoder: MessageEncoder) -> frozenset[str] | None:
+    """The keyword names ``encoder`` takes, or ``None`` for "anything".
+
+    ``None`` also when the signature cannot be read at all -- a C callable, a
+    functools wrapper without `__wrapped__`. Passing everything through is
+    what happened before this existed, so an unreadable signature is no worse
+    than it was, and refusing to load the encoder over it would be.
+    """
+    try:
+        params = inspect.signature(encoder).parameters
+    except (TypeError, ValueError):
+        return None
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return None
+    return frozenset(
+        name
+        for name, p in params.items()
+        if p.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    )
+
+
 def build_message_encoder_adapter(
-    module_name: str, encoder: MessageEncoder, source_path: str = ""
+    module_name: str,
+    encoder: MessageEncoder,
+    source_path: str = "",
+    accepts_from: MessageEncoder | None = None,
 ) -> MessageEncoderAdapter:
-    """Build an adapter registered for ``module_name`` or an identity adapter."""
+    """Build an adapter registered for ``module_name`` or an identity adapter.
+
+    ``accepts_from`` is the callable whose signature says what may be passed,
+    when that is not ``encoder`` itself. The loader wraps the model's function
+    in a closure taking ``**kwargs``, and reading the *wrapper* would answer
+    "anything" for every encoder there is.
+    """
     prepare_messages, supports_tools = _PREPARERS.get(
         module_name, (_copy_messages, False)
     )
@@ -70,4 +130,5 @@ def build_message_encoder_adapter(
         prepare_messages=prepare_messages,
         supports_tools=supports_tools,
         source_path=source_path,
+        accepts=_accepted_kwargs(accepts_from or encoder),
     )

--- a/atom/entrypoints/openai/chat_encoder_adapters.py
+++ b/atom/entrypoints/openai/chat_encoder_adapters.py
@@ -53,6 +53,10 @@ class MessageEncoderAdapter:
     # What this encoder's signature will accept, or ``None`` when it takes
     # `**kwargs` and so accepts anything. See `__call__`.
     accepts: frozenset[str] | None = field(default=None, compare=False)
+    # Values this model's loader wants set when the caller did not. Applied
+    # after the filter and subject to it, so a default the encoder cannot take
+    # is dropped like any other kwarg rather than raising.
+    defaults: dict[str, Any] = field(default_factory=dict, compare=False)
 
     def __call__(self, messages: list[dict], **kwargs: Any) -> str:
         """Render, passing on only the kwargs this encoder can take.
@@ -71,6 +75,8 @@ class MessageEncoderAdapter:
         cannot take is worth seeing when a template control appears not to
         work.
         """
+        for name, value in self.defaults.items():
+            kwargs.setdefault(name, value)
         if self.accepts is not None:
             unread = [name for name in kwargs if name not in self.accepts]
             for name in unread:
@@ -113,6 +119,7 @@ def build_message_encoder_adapter(
     encoder: MessageEncoder,
     source_path: str = "",
     accepts_from: MessageEncoder | None = None,
+    defaults: dict[str, Any] | None = None,
 ) -> MessageEncoderAdapter:
     """Build an adapter registered for ``module_name`` or an identity adapter.
 
@@ -131,4 +138,5 @@ def build_message_encoder_adapter(
         supports_tools=supports_tools,
         source_path=source_path,
         accepts=_accepted_kwargs(accepts_from or encoder),
+        defaults=dict(defaults or {}),
     )

--- a/atom/entrypoints/openai/chat_encoders.py
+++ b/atom/entrypoints/openai/chat_encoders.py
@@ -12,9 +12,9 @@ when one was found, or to ``tokenizer.apply_chat_template`` otherwise.
 
 import glob
 import importlib.util
-import inspect
 import logging
 import os
+import pathlib
 from typing import Any
 
 from huggingface_hub import snapshot_download
@@ -77,7 +77,7 @@ def _load_encoder_from_dir(model_path: str) -> MessageEncoderAdapter | None:
         return raw(messages, **kwargs)
 
     logger.info(f"Loaded message encoder from {enc_path}")
-    return build_message_encoder_adapter(module_name, encode)
+    return build_message_encoder_adapter(module_name, encode, enc_path)
 
 
 def load_custom_message_encoder(model_path: str) -> MessageEncoderAdapter | None:
@@ -137,30 +137,32 @@ def chat_template_source(
         # Every named variant, so a marker in any of them counts. Searching
         # the dict itself would have searched the names.
         return "\n".join(str(v) for v in template.values())
-    if custom_encoder is not None:
+    if custom_encoder is not None and custom_encoder.source_path:
         try:
-            return inspect.getsource(inspect.getmodule(custom_encoder.encode))
-        except (OSError, TypeError) as e:
-            logger.warning(
-                "Could not read the source of message encoder %s: %s",
-                custom_encoder.name,
-                e,
-            )
+            return pathlib.Path(custom_encoder.source_path).read_text()
+        except OSError as e:
+            logger.warning("Could not read %s: %s", custom_encoder.source_path, e)
     return ""
 
 
-# (kwarg, value) pairs that switch reasoning off, tried in order. Every family
-# on this box is covered: Qwen reads `enable_thinking`, Kimi-K3 `thinking`, and
+# (kwarg, off-value, on-value) triples, tried in order. Every family on this
+# box is covered: Qwen reads `enable_thinking`, Kimi-K3 `thinking`, and
 # `thinking_mode` is read by two families with disjoint vocabularies --
-# MiniMax-M3 wants "disabled" and DeepSeek-V4's encoder asserts on anything
-# outside {"chat", "thinking"}. Hence pairs rather than one value per name, and
+# MiniMax-M3 wants "disabled"/"enabled" and DeepSeek-V4's encoder asserts on
+# anything outside {"chat", "thinking"}. Hence pairs of the same name, and
 # hence the order: "disabled" first, so MiniMax matches before V4's rejection
 # of it sends the probe on to "chat".
-REASONING_OFF_KWARGS: tuple[tuple[str, Any], ...] = (
-    ("enable_thinking", False),
-    ("thinking", False),
-    ("thinking_mode", "disabled"),
-    ("thinking_mode", "chat"),
+#
+# The on-value is the off-value's counterpart and is not probed for. It cannot
+# be: most templates default to reasoning on, so passing their on-value renders
+# identically to passing nothing, and "the render changed" -- the evidence the
+# off-probe runs on -- is absent by construction. Only MiniMax, whose default
+# is off, differs when switched on.
+REASONING_TOGGLES: tuple[tuple[str, Any, Any], ...] = (
+    ("enable_thinking", False, True),
+    ("thinking", False, True),
+    ("thinking_mode", "disabled", "enabled"),
+    ("thinking_mode", "chat", "thinking"),
 )
 
 # A template refusing a probe value, by name. A model-shipped Python encoder
@@ -172,7 +174,7 @@ _PROBE_REFUSALS = (TemplateError, TypeError, ValueError, AssertionError)
 
 def resolve_reasoning_toggle(
     tokenizer: Any, custom_encoder: MessageEncoderAdapter | None = None
-) -> tuple[str, Any] | None:
+) -> tuple[str, Any, Any] | None:
     """The kwarg that turns this model's reasoning off, and the value, or None.
 
     Rendered twice and compared, rather than matched against a table of model
@@ -199,7 +201,7 @@ def resolve_reasoning_toggle(
     baseline = render_probe_prompt(tokenizer, custom_encoder, tools=False)
     if baseline is None:
         return None
-    for name, off_value in REASONING_OFF_KWARGS:
+    for name, off_value, on_value in REASONING_TOGGLES:
         try:
             rendered = apply_chat_template(
                 tokenizer, custom_encoder, PROBE_MESSAGES, **{name: off_value}
@@ -207,7 +209,7 @@ def resolve_reasoning_toggle(
         except _PROBE_REFUSALS:
             continue
         if rendered != baseline:
-            return name, off_value
+            return name, off_value, on_value
     return None
 
 

--- a/atom/entrypoints/openai/chat_encoders.py
+++ b/atom/entrypoints/openai/chat_encoders.py
@@ -12,11 +12,13 @@ when one was found, or to ``tokenizer.apply_chat_template`` otherwise.
 
 import glob
 import importlib.util
+import inspect
 import logging
 import os
 from typing import Any
 
 from huggingface_hub import snapshot_download
+from jinja2 import TemplateError
 
 from .chat_encoder_adapters import (
     MessageEncoderAdapter,
@@ -86,6 +88,161 @@ def load_custom_message_encoder(model_path: str) -> MessageEncoderAdapter | None
     filesystem IO and a Python import.
     """
     return _load_encoder_from_dir(_resolve_model_path(model_path))
+
+
+# The smallest request that makes a template show its framing. Nothing is
+# ever sent to the model; only what the template wraps a turn in matters.
+PROBE_MESSAGES: list[dict] = [{"role": "user", "content": "hi"}]
+PROBE_TOOLS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather in a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def chat_template_source(
+    tokenizer: Any, custom_encoder: MessageEncoderAdapter | None = None
+) -> str:
+    """The model's chat template as text to search, or ``""`` if it ships none.
+
+    Deliberately not a rendered prompt, and the two are not interchangeable:
+    a marker that appears only in the template's own logic is absent from a
+    fresh prompt. Measured on this box -- Qwen3.5's source carries `<think>`
+    and `</think>`, its rendered prompt carries only `<think>`, and
+    Qwen3-8B's rendered prompt carries neither. A question about what the
+    template *does with a reply* has to read the source; a question about what
+    the prompt *tells the model* has to read the render
+    (:func:`render_probe_prompt`).
+
+    Two shapes bite anyone reaching for the raw attribute, which is why this
+    exists rather than `getattr(tokenizer, "chat_template", "")`:
+    multi-template tokenizers hold a ``dict``, and `"</think>" in <dict>`
+    silently tests the *keys*; and it is ``None`` for every model that ships a
+    Python encoder instead of Jinja (Kimi-K3, DeepSeek-V4), whose literals
+    live in that module's source instead.
+    """
+    template = getattr(tokenizer, "chat_template", None)
+    if isinstance(template, str):
+        return template
+    if isinstance(template, dict):
+        # Every named variant, so a marker in any of them counts. Searching
+        # the dict itself would have searched the names.
+        return "\n".join(str(v) for v in template.values())
+    if custom_encoder is not None:
+        try:
+            return inspect.getsource(inspect.getmodule(custom_encoder.encode))
+        except (OSError, TypeError) as e:
+            logger.warning(
+                "Could not read the source of message encoder %s: %s",
+                custom_encoder.name,
+                e,
+            )
+    return ""
+
+
+# (kwarg, value) pairs that switch reasoning off, tried in order. Every family
+# on this box is covered: Qwen reads `enable_thinking`, Kimi-K3 `thinking`, and
+# `thinking_mode` is read by two families with disjoint vocabularies --
+# MiniMax-M3 wants "disabled" and DeepSeek-V4's encoder asserts on anything
+# outside {"chat", "thinking"}. Hence pairs rather than one value per name, and
+# hence the order: "disabled" first, so MiniMax matches before V4's rejection
+# of it sends the probe on to "chat".
+REASONING_OFF_KWARGS: tuple[tuple[str, Any], ...] = (
+    ("enable_thinking", False),
+    ("thinking", False),
+    ("thinking_mode", "disabled"),
+    ("thinking_mode", "chat"),
+)
+
+# A template refusing a probe value, by name. A model-shipped Python encoder
+# validates with a bare `assert`; Jinja raises its own; a signature that does
+# not take the kwarg raises TypeError. Refusal means "not this pair, try the
+# next" -- anything else is a bug and is left to propagate.
+_PROBE_REFUSALS = (TemplateError, TypeError, ValueError, AssertionError)
+
+
+def resolve_reasoning_toggle(
+    tokenizer: Any, custom_encoder: MessageEncoderAdapter | None = None
+) -> tuple[str, Any] | None:
+    """The kwarg that turns this model's reasoning off, and the value, or None.
+
+    Rendered twice and compared, rather than matched against a table of model
+    families: a Jinja template silently ignores a kwarg it does not read, so
+    "the prompt changed" *is* the evidence that it read this one. That silence
+    is also why the question has to be asked at all -- the chat path passed a
+    hardcoded ``thinking=`` to every model, which is correct for Kimi-K3 and a
+    no-op for the entire Qwen family, whose templates read `enable_thinking`.
+    A no-op here is invisible: the model reasons anyway and the client that
+    asked for no reasoning simply pays for it.
+
+    ``None`` means the template offers no switch, and for a model that begins
+    inside the reasoning channel that means reasoning cannot be turned off at
+    all -- worth saying out loud at startup, because the request can then only
+    be honoured as far as separating the reasoning and reporting it, never by
+    discarding it. On this box only gpt-oss and DeepSeek-R1 answer ``None``,
+    and neither opens a channel this way to begin with.
+
+    Verified against every model on this box: Qwen3/Qwen3.5 `enable_thinking`,
+    Kimi-K3 `thinking`, MiniMax-M3 `thinking_mode="disabled"`, DeepSeek-V4
+    `thinking_mode="chat"` -- and for all six that start inside the channel,
+    applying the pair takes the rendered prompt back out of it.
+    """
+    baseline = render_probe_prompt(tokenizer, custom_encoder, tools=False)
+    if baseline is None:
+        return None
+    for name, off_value in REASONING_OFF_KWARGS:
+        try:
+            rendered = apply_chat_template(
+                tokenizer, custom_encoder, PROBE_MESSAGES, **{name: off_value}
+            )
+        except _PROBE_REFUSALS:
+            continue
+        if rendered != baseline:
+            return name, off_value
+    return None
+
+
+def render_probe_prompt(
+    tokenizer: Any,
+    custom_encoder: MessageEncoderAdapter | None,
+    *,
+    tools: bool,
+) -> str | None:
+    """Render a throwaway turn, to ask the template about itself at startup.
+
+    What a template renders *into the prompt* is the model's own instructions
+    -- notably how to call a tool -- so a question about those is asked here
+    and not of the template source. The reverse question reads the source
+    instead; see :func:`chat_template_source` for why one is not a cheaper
+    version of the other.
+
+    ``None`` means the template refused the probe, which is a real answer and
+    the only one that is caught: a template may reject the synthetic tools
+    payload, and a model that does not do tool calls should still start.
+    `TemplateError` is that refusal by name and `TypeError` is a signature
+    that does not take ``tools``. Nothing else is caught -- an unexpected
+    failure here is a bug, and a bug that silently turns into "this model has
+    no tool-call format" is the class of silence this path exists to end.
+    """
+    try:
+        return apply_chat_template(
+            tokenizer,
+            custom_encoder,
+            PROBE_MESSAGES,
+            tools=PROBE_TOOLS if tools else None,
+        )
+    except (TemplateError, TypeError) as e:
+        logger.warning("The model's chat template refused the probe: %s", e)
+        return None
 
 
 def apply_chat_template(

--- a/atom/entrypoints/openai/chat_encoders.py
+++ b/atom/entrypoints/openai/chat_encoders.py
@@ -66,8 +66,13 @@ def _load_encoder_from_dir(model_path: str) -> MessageEncoderAdapter | None:
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         raw = mod.encode_messages
-    except Exception as e:
-        logger.warning(f"Failed to load encoder from {enc_path}: {e}")
+    except Exception:
+        # Broad on purpose: this executes a file the operator supplied, so the
+        # failure can be anything that module raises, and a bad encoder must
+        # not stop the server. `exc_info` rather than `{e}` -- the message
+        # alone was never enough to debug someone else's encoder, and the
+        # traceback names the line inside it.
+        logger.warning(f"Failed to load encoder from {enc_path}", exc_info=True)
         return None
 
     logger.info(f"Loaded message encoder from {enc_path}")

--- a/atom/entrypoints/openai/chat_encoders.py
+++ b/atom/entrypoints/openai/chat_encoders.py
@@ -227,13 +227,19 @@ def render_probe_prompt(
     instead; see :func:`chat_template_source` for why one is not a cheaper
     version of the other.
 
-    ``None`` means the template refused the probe, which is a real answer and
-    the only one that is caught: a template may reject the synthetic tools
-    payload, and a model that does not do tool calls should still start.
-    `TemplateError` is that refusal by name and `TypeError` is a signature
-    that does not take ``tools``. Nothing else is caught -- an unexpected
-    failure here is a bug, and a bug that silently turns into "this model has
-    no tool-call format" is the class of silence this path exists to end.
+    ``None`` means the template refused the probe, which is a real answer: a
+    template may reject the synthetic tools payload, and a model that does not
+    do tool calls should still start. Refusal is `_PROBE_REFUSALS`, the same
+    list the reasoning probe uses -- these two ask the same template the same
+    kind of question and disagreeing about what counts as a refusal is how a
+    model with no chat template at all stopped booting. `transformers` raises
+    `ValueError` for that, this caught only `TemplateError` and `TypeError`,
+    and both probes run *before* the engine is created, so a base checkpoint
+    that used to serve `/v1/completions` perfectly well now died at startup.
+
+    Nothing outside that list is caught -- an unexpected failure here is a
+    bug, and a bug that silently turns into "this model has no tool-call
+    format" is the class of silence this path exists to end.
     """
     try:
         return apply_chat_template(
@@ -242,7 +248,7 @@ def render_probe_prompt(
             PROBE_MESSAGES,
             tools=PROBE_TOOLS if tools else None,
         )
-    except (TemplateError, TypeError) as e:
+    except _PROBE_REFUSALS as e:
         logger.warning("The model's chat template refused the probe: %s", e)
         return None
 

--- a/atom/entrypoints/openai/chat_encoders.py
+++ b/atom/entrypoints/openai/chat_encoders.py
@@ -70,14 +70,20 @@ def _load_encoder_from_dir(model_path: str) -> MessageEncoderAdapter | None:
         logger.warning(f"Failed to load encoder from {enc_path}: {e}")
         return None
 
+    logger.info(f"Loaded message encoder from {enc_path}")
     # also valid is "chat" (non-thinking short-form). May need to add as an option.
     # Revisit when a second model ships an encode_*.py — the default may need to be per-model.
-    def encode(messages, **kwargs):
-        kwargs.setdefault("thinking_mode", "thinking")
-        return raw(messages, **kwargs)
-
-    logger.info(f"Loaded message encoder from {enc_path}")
-    return build_message_encoder_adapter(module_name, encode, enc_path, raw)
+    #
+    # Handed to the adapter rather than applied in a wrapper here. A wrapper
+    # runs *after* the adapter has filtered kwargs against the encoder's
+    # signature, so the one kwarg it adds is the one the filter cannot remove:
+    # an encoder that does not take `thinking_mode` raised `TypeError` on
+    # every real request while the startup probe -- which now counts TypeError
+    # as a refusal -- reported only "tool calls will be delivered as plain
+    # text". Silent at startup, 500 on every chat.
+    return build_message_encoder_adapter(
+        module_name, raw, enc_path, defaults={"thinking_mode": "thinking"}
+    )
 
 
 def load_custom_message_encoder(model_path: str) -> MessageEncoderAdapter | None:

--- a/atom/entrypoints/openai/chat_encoders.py
+++ b/atom/entrypoints/openai/chat_encoders.py
@@ -63,7 +63,7 @@ def _load_encoder_from_dir(model_path: str) -> MessageEncoderAdapter | None:
         spec = importlib.util.spec_from_file_location(module_name, enc_path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        raw = getattr(mod, "encode_messages")
+        raw = mod.encode_messages
     except Exception as e:
         logger.warning(f"Failed to load encoder from {enc_path}: {e}")
         return None

--- a/atom/entrypoints/openai/chat_encoders.py
+++ b/atom/entrypoints/openai/chat_encoders.py
@@ -77,7 +77,7 @@ def _load_encoder_from_dir(model_path: str) -> MessageEncoderAdapter | None:
         return raw(messages, **kwargs)
 
     logger.info(f"Loaded message encoder from {enc_path}")
-    return build_message_encoder_adapter(module_name, encode, enc_path)
+    return build_message_encoder_adapter(module_name, encode, enc_path, raw)
 
 
 def load_custom_message_encoder(model_path: str) -> MessageEncoderAdapter | None:

--- a/atom/entrypoints/openai/kimi_k3_tokens.py
+++ b/atom/entrypoints/openai/kimi_k3_tokens.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Kimi-K3's channel tokens, owned in one place.
+
+Two readers strip these: the reasoning stage, which separates the think
+channel from the answer, and the tool-call parser, which reads the tools
+section. Each used to carry its own list and they drifted apart: tokens only
+the parser listed were removed only when a K3 tool parser happened to be
+resolved, so a deployment whose template refused the tools probe leaked them
+to `content` on both delivery paths. Which literals are framing is a property
+of the model's wire format, not of whether tool calling was configured.
+
+The split below is by *owner*, and it is the one thing this module asserts:
+
+- :data:`CHANNEL_FRAMING` wraps every answer whether or not a tool was called,
+  so the reasoning stage removes it and the tool parser does too.
+- :data:`TOOL_REGION_FRAMING` brackets a call. Those are the tool parser's
+  alone: the reasoning stage cannot remove the payload between them -- the
+  tool name, the argument keys and their values -- so stripping only the
+  brackets would hand the client mangled half-text instead of either a call
+  or an honest quotation.
+"""
+
+THINK_START = "<|open|>think<|sep|>"
+THINK_END = "<|close|>think<|sep|>"
+RESPONSE_START = "<|open|>response<|sep|>"
+RESPONSE_END = "<|close|>response<|sep|>"
+MESSAGE_START = "<|open|>message<|sep|>"
+MESSAGE_END = "<|close|>message<|sep|>"
+END_OF_MSG = "<|end_of_msg|>"
+TOOLS_START = "<|open|>tools<|sep|>"
+
+
+# Wrappers around the answer itself. Paired spellings only; the bare closers
+# are in `UNPAIRED_FRAMING` below, for the reason given there.
+CHANNEL_FRAMING: tuple[str, ...] = (
+    RESPONSE_START,
+    RESPONSE_END,
+    MESSAGE_START,
+    MESSAGE_END,
+    END_OF_MSG,
+)
+
+# The unpaired closers, and the separator on its own. These are framing too,
+# but they cannot move into `CHANNEL_FRAMING`, for two independent reasons,
+# even though the move looks obviously right.
+#
+# `<|sep|>` occurs *inside* a tool region (`<|open|>call tool="x"<|sep|>`),
+# and the reasoning stage runs first. Removing it there turns a region the
+# reasoning stage is only passing through into mangled half-text before the
+# parser sees it.
+#
+# The bare closers are proper prefixes of the paired ones, and `MarkerScanner`
+# reports a complete short marker rather than waiting to see whether the long
+# one follows (see `_plan`, which documents the gap and the test that holds
+# formats inside it). In this parser's list that is harmless -- strip
+# `<|close|>think` and the `<|sep|>` it leaves is also framing, so both
+# chunkings converge. Add the bare ones to the reasoning dialect *without*
+# `<|sep|>` and they stop converging: the shorter one fires, the separator
+# survives, and `<|close|>think<|sep|>` -- the token that ends the reasoning
+# channel -- never matches, so at four bytes per chunk the whole answer stays
+# in `reasoning_content`. They are a set or they are nothing.
+UNPAIRED_FRAMING: tuple[str, ...] = (
+    "<|close|>response",
+    "<|close|>think",
+    "<|close|>message",
+    "<|sep|>",
+)
+
+# Brackets around a tool call. The tool parser's, for the reason in the module
+# docstring.
+TOOL_REGION_FRAMING: tuple[str, ...] = (
+    TOOLS_START,
+    "<|close|>tools",
+    "<|close|>call",
+    "<|close|>argument",
+)

--- a/atom/entrypoints/openai/kimi_k3_tokens.py
+++ b/atom/entrypoints/openai/kimi_k3_tokens.py
@@ -72,11 +72,26 @@ UNPAIRED_FRAMING: tuple[str, ...] = (
     BARE_SEPARATOR,
 )
 
+# The model's own `_close_tag` is `<|close|>` + tag + `<|sep|>`, so each of
+# these has two spellings on the wire: whole, and cut short by `max_tokens`
+# between the tag and the separator. Longest first -- the markup walkers take
+# the first that matches, so the bare form listed first would leave the
+# separator behind.
+TOOLS_END = "<|close|>tools"
+CALL_END = "<|close|>call"
+ARGUMENT_END = "<|close|>argument"
+
+
+def both_spellings(end: str) -> tuple[str, str]:
+    """`end` with its separator and without, in the order a walker wants."""
+    return (end + BARE_SEPARATOR, end)
+
+
 # Brackets around a tool call. The tool parser's, for the reason in the module
 # docstring.
 TOOL_REGION_FRAMING: tuple[str, ...] = (
     TOOLS_START,
-    "<|close|>tools",
-    "<|close|>call",
-    "<|close|>argument",
+    TOOLS_END,
+    CALL_END,
+    ARGUMENT_END,
 )

--- a/atom/entrypoints/openai/kimi_k3_tokens.py
+++ b/atom/entrypoints/openai/kimi_k3_tokens.py
@@ -61,11 +61,15 @@ CHANNEL_FRAMING: tuple[str, ...] = (
 # survives, and `<|close|>think<|sep|>` -- the token that ends the reasoning
 # channel -- never matches, so at four bytes per chunk the whole answer stays
 # in `reasoning_content`. They are a set or they are nothing.
+# Named on its own as well, because it is also what sits between a call's
+# closer and the section's -- the wrapper walk has to step over it there.
+BARE_SEPARATOR = "<|sep|>"
+
 UNPAIRED_FRAMING: tuple[str, ...] = (
     "<|close|>response",
     "<|close|>think",
     "<|close|>message",
-    "<|sep|>",
+    BARE_SEPARATOR,
 )
 
 # Brackets around a tool call. The tool parser's, for the reason in the module

--- a/atom/entrypoints/openai/marker_scanner.py
+++ b/atom/entrypoints/openai/marker_scanner.py
@@ -27,6 +27,12 @@ as equivalent are not: `frozenset.intersection(buf)` hashes every character of
 `buf` (2.9 us on 900 chars) where `any(c in buf ...)` is a C substring search
 per marker character (0.12 us, 25x), and the buffer is not bounded by a marker
 on the way in -- callers concatenate a backlog into `text`.
+
+Judge a change here on a whole response through the real pipeline -- reasoning
+filter into tool parser, four-character tokens -- and not on one function.
+Alternating arms, three rounds each: 1579 -> 1383 ns/token on plain prose and
+1652 -> 1537 on an answer ending in a tool call. A single cross-process pair
+said the opposite before the arms were alternated.
 """
 
 from __future__ import annotations
@@ -53,15 +59,45 @@ def partial_suffix_len(text: str, marker: str) -> int:
     return 0
 
 
+@functools.lru_cache(maxsize=64)
 def _plan_for(markers) -> tuple[tuple[str, ...], tuple[str, ...], dict]:
     """:func:`_plan`, keyed on the marker *set* rather than how it was spelled.
 
-    The cache key is the argument, so without this the same markers in a
-    different order are a second entry holding an equal copy -- and the two
-    declaration sites for one format (its own `START_MARKERS` and a dialect's
-    tuple) do not have to agree on order for that to happen.
+    Two caches, and both earn their place. `_plan` is keyed on the normalised
+    set, so two spellings of one set share a single plan *object*. This one is
+    keyed on the spelling, so the callers that ask once per token -- always
+    with the same module-level constant -- skip the normalisation as well:
+    `sorted(set(...))` on every call was 148 ns of the 193 it took to answer.
     """
     return _plan(tuple(sorted(set(markers))))
+
+
+def _suffix_len(text: str, ordered: tuple, firsts: tuple, by_len: dict) -> int:
+    """Longest suffix of `text` that is a proper prefix of one of the markers.
+
+    The one loop. It was written twice -- once here for callers holding their
+    own buffer and once as a method on the scanner -- in a module whose whole
+    thesis is that asking this question in more than one place is how the
+    answers drift apart.
+
+    Nothing can be held unless the tail *starts* a marker, so a marker's first
+    character has to appear within the last `longest - 1` bytes. One substring
+    search over that window answers that, and it is a bet rather than a free
+    win: 2.4x when it rejects (737 ns -> 307 ns) against 1.3x slower when it
+    does not (847 ns -> 1108 ns), because the loop then repeats the search it
+    just paid for. A chunk whose last twenty bytes contain a marker's opening
+    character is the rare one, and this runs once per token on every stream
+    including models whose markers never appear at all.
+    """
+    longest = len(ordered[0])
+    if longest == 1:
+        return 0  # a one-character marker has no proper prefix
+    if not any(c in text[-(longest - 1) :] for c in firsts):
+        return 0
+    for k in range(min(longest - 1, len(text)), 0, -1):
+        if text[-k] in firsts and text[-k:] in by_len[k]:
+            return k
+    return 0
 
 
 @functools.lru_cache(maxsize=64)
@@ -91,16 +127,12 @@ def held_suffix_len(text: str, markers: tuple[str, ...]) -> int:
     """Longest suffix of `text` that is a proper prefix of any of `markers`.
 
     The stateless form of what :class:`MarkerScanner` withholds, for callers
-    that own their own buffer. Same cached plan, so they get the same answer
-    and the same first-character reject rather than a second implementation.
+    that own their own buffer. Same cached plan and the same loop, so they get
+    the same answer rather than a second implementation of the rule.
     """
     if not markers:
         return 0
-    ordered, firsts, by_len = _plan_for(markers)
-    for k in range(min(len(ordered[0]) - 1, len(text)), 0, -1):
-        if text[-k] in firsts and text[-k:] in by_len[k]:
-            return k
-    return 0
+    return _suffix_len(text, *_plan_for(markers))
 
 
 @dataclass(frozen=True)
@@ -130,7 +162,8 @@ class MarkerScanner:
     def __init__(self, markers: tuple[str, ...]):
         if not markers or any(not m for m in markers):
             raise ValueError("a scanner needs at least one non-empty marker")
-        self._markers, self._firsts, self._prefixes_by_len = _plan_for(markers)
+        self._plan = _plan_for(markers)
+        self._markers, self._firsts, self._prefixes_by_len = self._plan
         self._longest = len(self._markers[0])
         self._buf = ""
 
@@ -155,7 +188,7 @@ class MarkerScanner:
             self._buf = ""
             return Scan(buf[:at], hit, buf[at + len(hit) :])
 
-        cut = len(buf) - self._held_suffix_len(buf)
+        cut = len(buf) - _suffix_len(buf, *self._plan)
         self._buf = buf[cut:]
         # The invariant the whole class exists for: a stall is not something
         # to test for here, it is something that cannot be represented.
@@ -166,18 +199,6 @@ class MarkerScanner:
         """Release the held tail at end of stream; it never became a marker."""
         out, self._buf = self._buf, ""
         return out
-
-    def _held_suffix_len(self, buf: str) -> int:
-        """Longest suffix of `buf` that is a proper prefix of some marker.
-
-        Longest first, so the first hit is the answer. `buf[-k]` is that
-        suffix's first character, and a marker's first characters are few, so
-        the check rejects most lengths before the slice is even taken.
-        """
-        for k in range(min(self._longest - 1, len(buf)), 0, -1):
-            if buf[-k] in self._firsts and buf[-k:] in self._prefixes_by_len[k]:
-                return k
-        return 0
 
     def _earliest_complete(self, buf: str) -> tuple[int, str | None]:
         """Where the first complete marker starts, and which one it is.

--- a/atom/entrypoints/openai/marker_scanner.py
+++ b/atom/entrypoints/openai/marker_scanner.py
@@ -18,12 +18,20 @@ here, and the first byte of a '<'-bearing answer never reached the client
 until the stream ended.
 
 The `'<'` test is still the fast path -- it was the right idea at the wrong
-scope. Applied to a buffer that can never exceed the longest marker it is a
-constant-time reject, and the common chunk carries no marker character at all.
+scope. It rejects the common chunk, which carries no marker character at all,
+before any per-marker work happens.
+
+Both halves run once per token per stream, so how they are spelled shows up in
+event-loop time rather than in a profile of the model. Two spellings that read
+as equivalent are not: `frozenset.intersection(buf)` hashes every character of
+`buf` (2.9 us on 900 chars) where `any(c in buf ...)` is a C substring search
+per marker character (0.12 us, 25x), and the buffer is not bounded by a marker
+on the way in -- callers concatenate a backlog into `text`.
 """
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 
 
@@ -34,9 +42,63 @@ def partial_suffix_len(text: str, marker: str) -> int:
     nothing here can still grow into the marker. `("... <tool_", ...)` is 6.
     Bounded by `len(marker) - 1`: a whole marker is not a partial one, and its
     caller has already looked for complete ones.
+
+    Kept for a single marker asked about in isolation. :class:`MarkerScanner`
+    does not call it: over a set of markers it re-slices the same suffixes once
+    per marker, which is the work `_prefixes_by_len` precomputes away.
     """
     for k in range(min(len(marker) - 1, len(text)), 0, -1):
         if text.endswith(marker[:k]):
+            return k
+    return 0
+
+
+def _plan_for(markers) -> tuple[tuple[str, ...], tuple[str, ...], dict]:
+    """:func:`_plan`, keyed on the marker *set* rather than how it was spelled.
+
+    The cache key is the argument, so without this the same markers in a
+    different order are a second entry holding an equal copy -- and the two
+    declaration sites for one format (its own `START_MARKERS` and a dialect's
+    tuple) do not have to agree on order for that to happen.
+    """
+    return _plan(tuple(sorted(set(markers))))
+
+
+@functools.lru_cache(maxsize=64)
+def _plan(markers: tuple[str, ...]) -> tuple[tuple[str, ...], tuple[str, ...], dict]:
+    """Everything about a marker set that does not depend on the stream.
+
+    Cached on the set, not computed per scanner: a scanner is built per
+    request and the sets are class constants -- one per tool-call format plus
+    the reasoning dialects' -- so this runs a handful of times per process.
+    Building it per scanner cost 8.7 us of request setup to save 4.5 us per
+    chunk, which is the right trade only for streams longer than two chunks.
+
+    Returns the markers longest-first (so a marker that is a prefix of another
+    never wins a tie at the same position and truncates the longer one), their
+    distinct first characters, and every proper prefix grouped by length.
+    """
+    ordered = tuple(sorted(set(markers), key=len, reverse=True))
+    firsts = tuple(sorted({m[0] for m in ordered}))
+    by_len: dict[int, set[str]] = {}
+    for m in ordered:
+        for k in range(1, len(m)):
+            by_len.setdefault(k, set()).add(m[:k])
+    return ordered, firsts, {k: frozenset(v) for k, v in by_len.items()}
+
+
+def held_suffix_len(text: str, markers: tuple[str, ...]) -> int:
+    """Longest suffix of `text` that is a proper prefix of any of `markers`.
+
+    The stateless form of what :class:`MarkerScanner` withholds, for callers
+    that own their own buffer. Same cached plan, so they get the same answer
+    and the same first-character reject rather than a second implementation.
+    """
+    if not markers:
+        return 0
+    ordered, firsts, by_len = _plan_for(markers)
+    for k in range(min(len(ordered[0]) - 1, len(text)), 0, -1):
+        if text[-k] in firsts and text[-k:] in by_len[k]:
             return k
     return 0
 
@@ -59,19 +121,17 @@ class Scan:
 class MarkerScanner:
     """Incremental reader over a stream that must not split a marker.
 
-    Stateful across chunks and cheap to hold: the buffer is bounded by the
-    longest marker, which is what makes the withhold bounded and the cost per
-    chunk independent of how long the response runs.
+    Stateful across chunks and cheap to hold: what it *withholds* is bounded by
+    the longest marker, which is what makes the withhold bounded and the cost
+    per chunk independent of how long the response runs. What it *scans* is
+    that tail plus the incoming chunk, which the caller sizes.
     """
 
     def __init__(self, markers: tuple[str, ...]):
         if not markers or any(not m for m in markers):
             raise ValueError("a scanner needs at least one non-empty marker")
-        # Longest first, so a marker that is a prefix of another never wins the
-        # tie at the same position and truncate the longer one.
-        self._markers = tuple(sorted(set(markers), key=len, reverse=True))
+        self._markers, self._firsts, self._prefixes_by_len = _plan_for(markers)
         self._longest = len(self._markers[0])
-        self._firsts = frozenset(m[0] for m in self._markers)
         self._buf = ""
 
     @property
@@ -81,10 +141,12 @@ class MarkerScanner:
 
     def feed(self, text: str) -> Scan:
         buf = self._buf + text
-        if not self._firsts.intersection(buf):
-            # Nothing here can begin a marker. The buffer is already bounded,
-            # so this scan is over at most one marker's worth of tail plus the
-            # chunk -- it is the fast path, not a shortcut past correctness.
+        if not any(c in buf for c in self._firsts):
+            # Nothing here can begin a marker, so nothing needs holding: the
+            # fast path, not a shortcut past correctness. `in` on a str is a
+            # C substring search; a set intersection would hash every
+            # character of `buf` instead, which is 25x more for the same
+            # answer and is paid once per token per stream.
             self._buf = ""
             return Scan(buf)
 
@@ -93,8 +155,7 @@ class MarkerScanner:
             self._buf = ""
             return Scan(buf[:at], hit, buf[at + len(hit) :])
 
-        hold = max(partial_suffix_len(buf, m) for m in self._markers)
-        cut = len(buf) - hold
+        cut = len(buf) - self._held_suffix_len(buf)
         self._buf = buf[cut:]
         # The invariant the whole class exists for: a stall is not something
         # to test for here, it is something that cannot be represented.
@@ -105,6 +166,18 @@ class MarkerScanner:
         """Release the held tail at end of stream; it never became a marker."""
         out, self._buf = self._buf, ""
         return out
+
+    def _held_suffix_len(self, buf: str) -> int:
+        """Longest suffix of `buf` that is a proper prefix of some marker.
+
+        Longest first, so the first hit is the answer. `buf[-k]` is that
+        suffix's first character, and a marker's first characters are few, so
+        the check rejects most lengths before the slice is even taken.
+        """
+        for k in range(min(self._longest - 1, len(buf)), 0, -1):
+            if buf[-k] in self._firsts and buf[-k:] in self._prefixes_by_len[k]:
+                return k
+        return 0
 
     def _earliest_complete(self, buf: str) -> tuple[int, str | None]:
         """Where the first complete marker starts, and which one it is.

--- a/atom/entrypoints/openai/marker_scanner.py
+++ b/atom/entrypoints/openai/marker_scanner.py
@@ -110,9 +110,24 @@ def _plan(markers: tuple[str, ...]) -> tuple[tuple[str, ...], tuple[str, ...], d
     Building it per scanner cost 8.7 us of request setup to save 4.5 us per
     chunk, which is the right trade only for streams longer than two chunks.
 
-    Returns the markers longest-first (so a marker that is a prefix of another
-    never wins a tie at the same position and truncates the longer one), their
-    distinct first characters, and every proper prefix grouped by length.
+    Returns the markers longest-first, their distinct first characters, and
+    every proper prefix grouped by length.
+
+    Longest-first settles a tie only between markers that are *both already
+    complete in the buffer*. A chunk ending exactly at the shorter of a
+    prefix pair reports the shorter one, because the longer one has not
+    arrived to be preferred -- so which of the two fires is a function of
+    where the chunk boundary landed, not of the text. `_earliest_complete`
+    says the same thing from the other side.
+
+    Nothing here withholds a complete match on the chance it could still
+    grow; that would be the stronger rule, and it would cost every marker
+    that is a prefix of another a wait of the length difference. It is not
+    needed while no format has a prefix pair whose halves disagree about
+    handing the stream over -- which is what
+    `TestAPrefixPairCannotChangeTheHandover` holds them to. The moment one
+    does, this becomes "the region opened, or did not, depending on
+    chunking", and the stronger rule has to be written.
     """
     ordered = tuple(sorted(set(markers), key=len, reverse=True))
     firsts = tuple(sorted({m[0] for m in ordered}))
@@ -205,7 +220,9 @@ class MarkerScanner:
 
         Earliest wins, and at the same position the longest does -- `<think>`
         must not be reported where `<thinking>` was meant when both are
-        registered.
+        registered. Only among those already complete in `buf`, though: see
+        `_plan` for why that is weaker than it sounds, and what holds the
+        registered formats inside the gap.
         """
         best_at, best = len(buf), None
         for m in self._markers:  # already longest-first

--- a/atom/entrypoints/openai/marker_scanner.py
+++ b/atom/entrypoints/openai/marker_scanner.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""How much of a stream can be released without splitting a marker.
+
+One question, one answer. Everything on the streaming path that has to notice
+a literal in the model's output -- the reasoning channel's delimiters, the
+tool-call formats' opening tags -- asks it, and asking it in more than one
+place is how the four incompatible answers this replaces came about.
+
+The rule: release everything except the longest *suffix* of the buffer that is
+a prefix of some marker. Not "hold everything once a marker's first character
+appears anywhere", which is the shape being retired: it withholds on a '<' in
+the middle of an answer that will never become a tag, and the buffer it holds
+grows without bound, so the scan is O(n) per chunk and O(n^2) over a response.
+Measured at 64 KB of answer that cost 515 ms of pure host CPU against 6 ms
+here, and the first byte of a '<'-bearing answer never reached the client
+until the stream ended.
+
+The `'<'` test is still the fast path -- it was the right idea at the wrong
+scope. Applied to a buffer that can never exceed the longest marker it is a
+constant-time reject, and the common chunk carries no marker character at all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def partial_suffix_len(text: str, marker: str) -> int:
+    """Length of the longest proper prefix of `marker` that ends `text`.
+
+    `("if (a < b", "<tool_call>")` is 0 -- the '<' is not at the end, so
+    nothing here can still grow into the marker. `("... <tool_", ...)` is 6.
+    Bounded by `len(marker) - 1`: a whole marker is not a partial one, and its
+    caller has already looked for complete ones.
+    """
+    for k in range(min(len(marker) - 1, len(text)), 0, -1):
+        if text.endswith(marker[:k]):
+            return k
+    return 0
+
+
+@dataclass(frozen=True)
+class Scan:
+    """What one chunk produced.
+
+    `released` is safe to send now. `hit` is the marker that completed, if one
+    did, and `rest` is everything after it -- handed back rather than kept,
+    because who owns the text after a marker is the caller's decision and not
+    this class's.
+    """
+
+    released: str
+    hit: str | None = None
+    rest: str = ""
+
+
+class MarkerScanner:
+    """Incremental reader over a stream that must not split a marker.
+
+    Stateful across chunks and cheap to hold: the buffer is bounded by the
+    longest marker, which is what makes the withhold bounded and the cost per
+    chunk independent of how long the response runs.
+    """
+
+    def __init__(self, markers: tuple[str, ...]):
+        if not markers or any(not m for m in markers):
+            raise ValueError("a scanner needs at least one non-empty marker")
+        # Longest first, so a marker that is a prefix of another never wins the
+        # tie at the same position and truncate the longer one.
+        self._markers = tuple(sorted(set(markers), key=len, reverse=True))
+        self._longest = len(self._markers[0])
+        self._firsts = frozenset(m[0] for m in self._markers)
+        self._buf = ""
+
+    @property
+    def held(self) -> str:
+        """What is being withheld right now. Bounded by the longest marker."""
+        return self._buf
+
+    def feed(self, text: str) -> Scan:
+        buf = self._buf + text
+        if not self._firsts.intersection(buf):
+            # Nothing here can begin a marker. The buffer is already bounded,
+            # so this scan is over at most one marker's worth of tail plus the
+            # chunk -- it is the fast path, not a shortcut past correctness.
+            self._buf = ""
+            return Scan(buf)
+
+        at, hit = self._earliest_complete(buf)
+        if hit is not None:
+            self._buf = ""
+            return Scan(buf[:at], hit, buf[at + len(hit) :])
+
+        hold = max(partial_suffix_len(buf, m) for m in self._markers)
+        cut = len(buf) - hold
+        self._buf = buf[cut:]
+        # The invariant the whole class exists for: a stall is not something
+        # to test for here, it is something that cannot be represented.
+        assert len(self._buf) < self._longest, "withheld more than a marker could be"
+        return Scan(buf[:cut])
+
+    def flush(self) -> str:
+        """Release the held tail at end of stream; it never became a marker."""
+        out, self._buf = self._buf, ""
+        return out
+
+    def _earliest_complete(self, buf: str) -> tuple[int, str | None]:
+        """Where the first complete marker starts, and which one it is.
+
+        Earliest wins, and at the same position the longest does -- `<think>`
+        must not be reported where `<thinking>` was meant when both are
+        registered.
+        """
+        best_at, best = len(buf), None
+        for m in self._markers:  # already longest-first
+            at = buf.find(m)
+            if 0 <= at < best_at:
+                best_at, best = at, m
+        return best_at, best

--- a/atom/entrypoints/openai/metrics.py
+++ b/atom/entrypoints/openai/metrics.py
@@ -12,6 +12,8 @@ from prometheus_client import CollectorRegistry, generate_latest
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 from prometheus_client.exposition import CONTENT_TYPE_LATEST
 
+from .streaming_dispatch import longest_silence_seconds
+
 
 class _AtomMetricsCollector:
     def __init__(self, exporter: AtomMetricsExporter):
@@ -40,6 +42,19 @@ class _AtomMetricsCollector:
             "Unix timestamp of the last successful runtime metrics refresh.",
         )
         metric.add_metric([], last_refresh)
+        yield metric
+
+        # Read live rather than from the snapshot: the snapshot is refreshed by
+        # the engine, and a stream starved by the engine is exactly the case
+        # where that refresh may also be late. This one is answered by the
+        # event loop that is serving the stalled request.
+        metric = GaugeMetricFamily(
+            "atom:stream_longest_silence_seconds",
+            "Seconds the most starved in-flight SSE stream has gone without a "
+            "chunk. Zero when none is waiting. Non-zero and growing is a "
+            "response that has stopped delivering while the client waits.",
+        )
+        metric.add_metric([], longest_silence_seconds())
         yield metric
 
         gauges = (

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -4,7 +4,6 @@
 """Pydantic request/response models for the OpenAI-compatible API."""
 
 import json
-import re
 import time
 from typing import Any
 
@@ -67,9 +66,6 @@ def openai_stop_reason_with_calls(engine_reason: str | None, has_calls: bool) ->
     if normalized == "length":
         return "length"
     return "tool_calls" if has_calls else (normalized or "stop")
-
-
-TOOL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
 
 
 # ============================================================================

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -23,9 +23,52 @@ CHAT_COMPLETION_CHUNK_OBJECT = "chat.completion.chunk"
 TEXT_COMPLETION_OBJECT = "text_completion"
 STREAM_DONE_MESSAGE = "data: [DONE]\n\n"
 
+
 # Valid OpenAI ``tool_choice`` string values and the function-name constraint.
 # Spec-level (not model-specific): the same for every model served.
 TOOL_CHOICE_VALUES = frozenset({"auto", "none", "required"})
+
+
+def openai_stop_reason(finish_reason: str | None) -> str | None:
+    """The engine's leave reason as OpenAI spells it.
+
+    The engine says `eos` / `max_tokens` / `stop_sequence` / `stop_<token_id>`
+    / `aborted` / `unschedulable: ...`; OpenAI clients understand only `stop` /
+    `length` / `tool_calls`. `stop_<token_id>` is an ordinary end of turn --
+    any model declaring more than one EOS reaches it in normal operation.
+
+    Named for the vocabulary it maps *into*, and paired with
+    `api_server.anthropic_stop_reason`. Two functions rather than one with a
+    mode: the two vocabularies share no member, so chaining them would send
+    every reason to the other's default.
+    """
+    if finish_reason is None:
+        return None
+    if finish_reason in ("stop", "length", "tool_calls"):
+        return finish_reason
+    if finish_reason in ("max_tokens", "max_new_tokens"):
+        return "length"
+    return "stop"
+
+
+def openai_stop_reason_with_calls(engine_reason: str | None, has_calls: bool) -> str:
+    """The reason to report when a call was parsed and the engine had its own.
+
+    `length` outranks `tool_calls`, because they answer different questions
+    and only one of them is a warning: `tool_calls` says "act on this", and
+    `length` says "this is not all of it". A response cut off mid-call parses
+    to a call with a silently truncated argument value -- every format's
+    unclosed-region branch exists to salvage exactly that -- and reporting
+    `tool_calls` for it told the client to run a tool with half its arguments
+    and no indication anything was missing. OpenAI reports `length` for a
+    truncated response whatever else is in it.
+    """
+    normalized = openai_stop_reason(engine_reason)
+    if normalized == "length":
+        return "length"
+    return "tool_calls" if has_calls else (normalized or "stop")
+
+
 TOOL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
 
 

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -12,6 +12,7 @@ this module contains no per-model conditions. Add a model there, not here.
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 # The same reader the tool-call side uses, not a second one: this module's
 # whole thesis is that asking "how much can be released without splitting a
@@ -66,6 +67,28 @@ def template_opens_reasoning_implicitly(template_source: str) -> bool:
         ):
             return True
     return False
+
+
+def thinking_switched_off(
+    template_kwargs: dict | None, toggle: tuple[str, Any, Any] | None
+) -> bool:
+    """Did the render actually carry this template's off-switch?
+
+    The merged kwargs are the whole answer -- server defaults, the client's
+    `chat_template_kwargs`, and the request's `thinking` written in by the
+    toggle's name on top. Reading the request field alone missed the first
+    two, so an operator's `--default-chat-template-kwargs` never reached the
+    decision.
+
+    Only the resolved toggle's own name and value count: a kwarg the template
+    does not read changes nothing about what the model does, and believing it
+    would stop the channel being separated while the model went on producing
+    one.
+    """
+    if not template_kwargs or toggle is None:
+        return False
+    name, off_value, _on_value = toggle
+    return name in template_kwargs and template_kwargs[name] == off_value
 
 
 def prompt_starts_in_reasoning(prompt: str) -> bool:

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -19,17 +19,13 @@ from dataclasses import dataclass
 # gone without, which it pays for once per token on every stream -- including
 # models whose reasoning markers never appear.
 from .marker_scanner import held_suffix_len
-from .reasoning_dialects import DIALECTS
+from .reasoning_dialects import DIALECTS, FALLBACK_DIALECT, ReasoningDialect
 
-# Marker tables derived from the dialect registry (no model literals here).
-_THINK_END_MARKERS = tuple(m for d in DIALECTS for m in d.end_markers)
 # Markers a rendered prompt ends with when the template already opened reasoning
 # (the output then begins inside the reasoning channel with no opening tag).
+# Every dialect's, because this is asked of a *prompt* before the response's
+# dialect matters, and a prompt carries at most one of them.
 _REASONING_OPEN_MARKERS = tuple(d.prompt_open_marker for d in DIALECTS)
-# Markers the model itself emits mid-output to open reasoning (e.g. "<think>").
-_OUTPUT_OPEN_MARKERS = tuple(
-    d.output_open_marker for d in DIALECTS if d.output_open_marker
-)
 # Reasoning-effort levels accepted across all loaded dialects' chat templates.
 # resolve_thinking() clamps a request's effort to this set before forwarding it,
 # so an effort no template understands is never passed through.
@@ -113,11 +109,20 @@ def _earliest_marker(buf: str, markers) -> tuple[int, str | None]:
 
 
 def separate_reasoning(
-    text: str, starts_thinking: bool = False
+    text: str,
+    starts_thinking: bool = False,
+    dialect: ReasoningDialect | None = None,
 ) -> tuple[str | None, str]:
     """Separate reasoning content from the final answer.
 
-    Tries each registered dialect in priority order; the first that applies wins.
+    ``dialect`` is the one this model speaks, resolved from its chat template
+    at startup (:func:`~.reasoning_dialects.resolve_dialect`). One, not each in
+    turn: trying them in order let any model's answer be split by a dialect it
+    does not speak, so an answer *about* Kimi's wire format lost the text
+    before a quoted channel token -- and the streaming filter, which used a
+    different rule again, kept it. Callers should go through
+    :class:`ReasoningChannel`, which carries this and ``starts_thinking``
+    together so the two paths cannot be given different ones.
 
     ``starts_thinking`` is the same answer :class:`ReasoningFilter` takes, and
     for the same reason: an output that begins inside the reasoning channel
@@ -131,16 +136,21 @@ def separate_reasoning(
         Tuple of (reasoning_content, content). reasoning_content is None if no
         thinking block was found.
     """
-    for dialect in DIALECTS:
-        result = dialect.split(text, starts_thinking)
-        if result is not None:
-            return result
+    result = (dialect or FALLBACK_DIALECT).split(text, starts_thinking)
+    if result is not None:
+        return result
     if starts_thinking:
         # The prompt opened the channel and the model never closed it, which
         # is what a reasoning model stopped at `max_tokens` looks like. It
         # produced reasoning and no answer; the streaming filter says exactly
         # that from state 1, and this has to agree.
-        return (text, "")
+        #
+        # `or None` because it has to agree on the empty case too: the filter
+        # emits no segment at all for an empty output, so a bare `text` here
+        # put `reasoning_content: ""` in the non-streaming body and nothing in
+        # the streamed one. Every other return in this function spells absence
+        # as `None`.
+        return (text or None, "")
     # No reasoning markers — return content as-is (tool calls parsed separately).
     return (None, text)
 
@@ -162,15 +172,29 @@ class ReasoningFilter:
     into the prompt itself (e.g. Kimi-K3 ends the prompt with its think opener):
     the output then begins *inside* the reasoning channel with no opening tag, so
     the filter must start in state 1.
+
+    ``dialect`` is the one this model speaks, and it is the same object
+    :func:`separate_reasoning` is given. This used to hold no dialect at all --
+    it closed the channel on the *union* of every registered dialect's end
+    markers -- so a `<think>` model quoting a K3 channel token ended its chain
+    of thought there while the non-streaming split ended it at the real
+    `</think>`. Go through :class:`ReasoningChannel` rather than passing this
+    by hand; that is what keeps the two paths on one answer.
     """
 
     state: int = 0
     buf: str = ""
     starts_thinking: bool = False
+    dialect: ReasoningDialect | None = None
 
     def __post_init__(self):
         if self.starts_thinking and self.state == 0:
             self.state = 1
+        speaking = self.dialect or FALLBACK_DIALECT
+        self._end_markers = speaking.end_markers
+        self._open_markers = (
+            (speaking.output_open_marker,) if speaking.output_open_marker else ()
+        )
 
     def _close_thinking(self, idx: int, marker: str) -> list:
         """A think-end marker was found at ``idx``: emit everything before it as
@@ -194,10 +218,10 @@ class ReasoningFilter:
         """State-1 helper: emit buffered reasoning up to a think-end marker; on
         match switch to content. Otherwise emit what's safe, holding back a
         partial trailing marker so it isn't split across chunks."""
-        idx, marker = _earliest_marker(self.buf, _THINK_END_MARKERS)
+        idx, marker = _earliest_marker(self.buf, self._end_markers)
         if idx != -1:
             return self._close_thinking(idx, marker)
-        hold = held_suffix_len(self.buf, _THINK_END_MARKERS)
+        hold = held_suffix_len(self.buf, self._end_markers)
         emit = self.buf[: len(self.buf) - hold] if hold else self.buf
         self.buf = self.buf[len(self.buf) - hold :] if hold else ""
         return [("reasoning_content", emit)] if emit else []
@@ -209,7 +233,7 @@ class ReasoningFilter:
         if self.state == 0:
             self.buf += text
             # A reasoning opener emitted in the output (e.g. "<think>").
-            oidx, omark = _earliest_marker(self.buf, _OUTPUT_OPEN_MARKERS)
+            oidx, omark = _earliest_marker(self.buf, self._open_markers)
             if oidx != -1:
                 before = self.buf[:oidx]
                 if before:
@@ -235,7 +259,7 @@ class ReasoningFilter:
                 # emitted as a tool call. vLLM's streaming path resolves this
                 # from the token vocabulary and buffers nothing; this is the
                 # same position, reached from the prompt.
-                hold = held_suffix_len(self.buf, _OUTPUT_OPEN_MARKERS)
+                hold = held_suffix_len(self.buf, self._open_markers)
                 cut = len(self.buf) - hold
                 if cut:
                     results.append(("content", self.buf[:cut]))
@@ -266,3 +290,37 @@ class ReasoningFilter:
                 results.append(("reasoning_content", self.buf))
             self.buf = ""
         return results
+
+
+@dataclass(frozen=True)
+class ReasoningChannel:
+    """How to read one response's reasoning channel, decided before it starts.
+
+    Two facts, and they have to travel together: which dialect the model
+    speaks, and whether its output begins inside the channel already. Passed
+    separately, they were passed differently -- the streaming filter got the
+    second and never the first, and answered with the union of every dialect's
+    markers instead. This is one object with one accessor per delivery mode,
+    so the two cannot be handed different answers.
+
+    ``starts_open`` is not simply "this template opens the channel": a request
+    that turns thinking off renders a prompt that does not, and OR-ing the
+    model-level fact in regardless made an ordinary answer come back as
+    ``reasoning_content`` with empty ``content``. The caller resolves it.
+    """
+
+    dialect: ReasoningDialect | None = None
+    starts_open: bool = False
+
+    def split(self, text: str) -> tuple[str | None, str]:
+        """A complete output as ``(reasoning, content)``."""
+        return separate_reasoning(text, self.starts_open, self.dialect)
+
+    def stream(self) -> ReasoningFilter:
+        """A filter over the same output arriving in chunks."""
+        return ReasoningFilter(starts_thinking=self.starts_open, dialect=self.dialect)
+
+
+# For a caller with no model behind it -- tests, and the completions endpoint,
+# which has no chat template and therefore no reasoning channel to read.
+NO_REASONING = ReasoningChannel()

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -22,7 +22,7 @@ from .marker_scanner import held_suffix_len
 from .reasoning_dialects import DIALECTS
 
 # Marker tables derived from the dialect registry (no model literals here).
-_THINK_END_MARKERS = tuple(d.think_end_marker for d in DIALECTS)
+_THINK_END_MARKERS = tuple(m for d in DIALECTS for m in d.end_markers)
 # Markers a rendered prompt ends with when the template already opened reasoning
 # (the output then begins inside the reasoning channel with no opening tag).
 _REASONING_OPEN_MARKERS = tuple(d.prompt_open_marker for d in DIALECTS)

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -196,17 +196,26 @@ class ReasoningFilter:
             (speaking.output_open_marker,) if speaking.output_open_marker else ()
         )
         self.state = 1 if starts_thinking else 0
+        # Nothing has been released yet, so an end marker arriving now sits at
+        # offset 0 -- which is the only place it means "I did not think this
+        # turn". See `_split_inline_tag`, whose answer this has to match.
+        self._at_offset_zero = not starts_thinking
         self._scanner = self._scanner_for(self.state)
 
     def _scanner_for(self, state: int) -> MarkerScanner | None:
         """What this state has to watch for. ``None`` when that is nothing,
         which is the common case for the inline-`<think>` dialect after the
         channel has closed."""
-        watched = self._framing | (
-            self._end_markers
-            if state == 1
-            else self._open_markers if state == 0 else frozenset()
-        )
+        watched = set(self._framing)
+        if state == 0:
+            # End markers too, though the channel is not open: at offset 0 one
+            # means the model declined to think, further in it is the model's
+            # own words, and watching is what tells them apart. Free --
+            # measured 1.00x on all four dialects, since `MarkerScanner` costs
+            # by chunk and not by marker count.
+            watched |= self._open_markers | self._end_markers
+        elif state == 1:
+            watched |= self._end_markers
         return MarkerScanner(tuple(sorted(watched))) if watched else None
 
     @property
@@ -225,6 +234,8 @@ class ReasoningFilter:
             text = ""
             if scan.released:
                 out.append((self._field, scan.released))
+                if self.state == 0:
+                    self._at_offset_zero = False
             if scan.hit is None:
                 return out
             if scan.hit in self._framing and not (
@@ -235,6 +246,17 @@ class ReasoningFilter:
                 # answer depend on which tool-call format was resolved, so a
                 # K3 deployment whose template refused the tools probe handed
                 # its channel tokens to the client on both delivery paths.
+                text = scan.rest
+                continue
+            if self.state == 0 and scan.hit in self._end_markers:
+                # Below the framing branch on purpose: K3 declares
+                # `<|open|>response<|sep|>` as both, and framing wins -- it
+                # says the same thing this rule would, at any offset.
+                if self._at_offset_zero:
+                    self.state = 2  # declined to think; the rest is the answer
+                    self._scanner = self._scanner_for(self.state)
+                else:
+                    out.append((self._field, scan.hit))  # the model's own words
                 text = scan.rest
                 continue
             # A channel boundary: state 0 -> 1 on the opener, 1 -> 2 on any

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -13,6 +13,11 @@ this module contains no per-model conditions. Add a model there, not here.
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
+# Called directly and not through a local wrapper: the tool-call path asks the
+# same question, and a rename in between is how the two sides drifted apart in
+# the first place. It also carries the first-character reject this path had
+# gone without, which it pays for once per token on every stream -- including
+# models whose reasoning markers never appear.
 from .marker_scanner import held_suffix_len
 from .reasoning_dialects import DIALECTS
 
@@ -107,19 +112,6 @@ def _earliest_marker(buf: str, markers) -> tuple[int, str | None]:
     return best_i, best_m
 
 
-def _hold_back_len(buf: str, markers) -> int:
-    """Length of the longest suffix of ``buf`` that is a strict prefix of any
-    marker, so a marker split across chunk boundaries isn't emitted as text.
-
-    Delegates, because the tool-call path asks the same question and answering
-    it twice is how the two sides drifted apart. Delegating the *whole*
-    question and not just its inner loop also buys the first-character reject,
-    which this path had gone without: it runs once per token on every stream,
-    including the models with no reasoning channel at all.
-    """
-    return held_suffix_len(buf, tuple(markers))
-
-
 def separate_reasoning(
     text: str, starts_thinking: bool = False
 ) -> tuple[str | None, str]:
@@ -201,7 +193,7 @@ class ReasoningFilter:
         idx, marker = _earliest_marker(self.buf, _THINK_END_MARKERS)
         if idx != -1:
             return self._close_thinking(idx, marker)
-        hold = _hold_back_len(self.buf, _THINK_END_MARKERS)
+        hold = held_suffix_len(self.buf, _THINK_END_MARKERS)
         emit = self.buf[: len(self.buf) - hold] if hold else self.buf
         self.buf = self.buf[len(self.buf) - hold :] if hold else ""
         return [("reasoning_content", emit)] if emit else []
@@ -239,7 +231,7 @@ class ReasoningFilter:
                 # emitted as a tool call. vLLM's streaming path resolves this
                 # from the token vocabulary and buffers nothing; this is the
                 # same position, reached from the prompt.
-                hold = _hold_back_len(self.buf, _OUTPUT_OPEN_MARKERS)
+                hold = held_suffix_len(self.buf, _OUTPUT_OPEN_MARKERS)
                 cut = len(self.buf) - hold
                 if cut:
                     results.append(("content", self.buf[:cut]))

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -177,7 +177,11 @@ class ReasoningFilter:
         reasoning, switch to content (state 2), and process anything after."""
         results = []
         reasoning = self.buf[:idx]
-        after = self.buf[idx + len(marker) :].lstrip("\n")
+        # Byte-for-byte, like the non-streaming split -- and this one could
+        # not have been made to agree anyway: it saw only what happened to be
+        # buffered when the marker arrived, so the same answer kept its
+        # newlines at one chunk size and lost them at another.
+        after = self.buf[idx + len(marker) :]
         if reasoning:
             results.append(("reasoning_content", reasoning))
         self.state = 2

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -96,9 +96,18 @@ def prompt_starts_in_reasoning(prompt: str) -> bool:
 
     Model-agnostic: callers pass the rendered prompt and don't need to know which
     dialect's marker applies. Used to seed the streaming filter
-    (:attr:`ReasoningFilter.starts_thinking`)."""
-    p = prompt.rstrip()
-    return any(p.endswith(m) for m in _REASONING_OPEN_MARKERS)
+    (:attr:`ReasoningFilter.starts_thinking`).
+
+    Offsets, not `prompt.rstrip()`, which copies the whole rendered prompt to
+    read its last twenty bytes. That prompt is the largest string the server
+    handles -- system prompt, tool schemas and the entire history -- and this
+    runs once per request on the event loop: 4.8 us at 512 KB against 0.43 us
+    here. Same shape as `begin_of_markup`.
+    """
+    end = len(prompt)
+    while end > 0 and prompt[end - 1].isspace():
+        end -= 1
+    return any(prompt.endswith(m, 0, end) for m in _REASONING_OPEN_MARKERS)
 
 
 def prompt_tokens_start_in_reasoning(

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -13,12 +13,11 @@ this module contains no per-model conditions. Add a model there, not here.
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
-# Called directly and not through a local wrapper: the tool-call path asks the
-# same question, and a rename in between is how the two sides drifted apart in
-# the first place. It also carries the first-character reject this path had
-# gone without, which it pays for once per token on every stream -- including
-# models whose reasoning markers never appear.
-from .marker_scanner import held_suffix_len
+# The same reader the tool-call side uses, not a second one: this module's
+# whole thesis is that asking "how much can be released without splitting a
+# marker" in more than one place is how the answers drift apart, and it used
+# to answer it itself, twice, with a different tie-break.
+from .marker_scanner import MarkerScanner
 from .reasoning_dialects import DIALECTS, FALLBACK_DIALECT, ReasoningDialect
 
 # Markers a rendered prompt ends with when the template already opened reasoning
@@ -98,16 +97,6 @@ def prompt_tokens_start_in_reasoning(
     return prompt_starts_in_reasoning(decode(token_ids[-tail:]))
 
 
-def _earliest_marker(buf: str, markers) -> tuple[int, str | None]:
-    """Return (index, marker) of the earliest-occurring marker in ``buf``."""
-    best_i, best_m = -1, None
-    for m in markers:
-        i = buf.find(m)
-        if i != -1 and (best_i == -1 or i < best_i):
-            best_i, best_m = i, m
-    return best_i, best_m
-
-
 def separate_reasoning(
     text: str,
     starts_thinking: bool = False,
@@ -136,9 +125,19 @@ def separate_reasoning(
         Tuple of (reasoning_content, content). reasoning_content is None if no
         thinking block was found.
     """
-    result = (dialect or FALLBACK_DIALECT).split(text, starts_thinking)
+    speaking = dialect or FALLBACK_DIALECT
+    result = speaking.split(text, starts_thinking)
     if result is not None:
-        return result
+        # Framing removed here and not inside the dialect's split, because the
+        # two fallbacks below are splits too and they were missing it -- so a
+        # channel-format answer with no closer, or one on a stream that never
+        # opened the channel, kept its tokens on this path while the streaming
+        # filter dropped them. One place, applied to whatever comes back.
+        reasoning, content = result
+        return (
+            speaking.strip_framing(reasoning or "") or None,
+            speaking.strip_framing(content),
+        )
     if starts_thinking:
         # The prompt opened the channel and the model never closed it, which
         # is what a reasoning model stopped at `max_tokens` looks like. It
@@ -150,146 +149,107 @@ def separate_reasoning(
         # put `reasoning_content: ""` in the non-streaming body and nothing in
         # the streamed one. Every other return in this function spells absence
         # as `None`.
-        return (text or None, "")
+        return (speaking.strip_framing(text) or None, "")
     # No reasoning markers — return content as-is (tool calls parsed separately).
-    return (None, text)
+    return (None, speaking.strip_framing(text))
 
 
-@dataclass
 class ReasoningFilter:
     """Stateful streaming filter that separates reasoning from content.
 
-    Processes tokens one chunk at a time and yields (field, text) tuples where
-    field is either "reasoning_content" or "content". Dialect-agnostic: reasoning
-    openers/terminators come from the registry-derived marker tables.
+    Chunks in, ``(field, text)`` tuples out, where field is
+    ``"reasoning_content"`` or ``"content"``. Three states: before the channel
+    opens, inside it, after it.
 
-    States:
-        0 = before reasoning opens (buffering to detect)
-        1 = inside reasoning (emitting as reasoning_content)
-        2 = after reasoning (emitting as content)
+    ``starts_thinking`` handles templates that inject the opening marker into
+    the prompt itself (Kimi-K3 ends the prompt with its think opener): the
+    output then begins *inside* the channel with no opening tag, so nothing in
+    the text says so and the filter must be told.
 
-    ``starts_thinking`` handles templates that inject the opening reasoning marker
-    into the prompt itself (e.g. Kimi-K3 ends the prompt with its think opener):
-    the output then begins *inside* the reasoning channel with no opening tag, so
-    the filter must start in state 1.
+    ``dialect`` is the one this model speaks, and the same object
+    :func:`separate_reasoning` is given. Go through :class:`ReasoningChannel`
+    rather than passing it by hand; that is what keeps the two paths on one
+    answer.
 
-    ``dialect`` is the one this model speaks, and it is the same object
-    :func:`separate_reasoning` is given. This used to hold no dialect at all --
-    it closed the channel on the *union* of every registered dialect's end
-    markers -- so a `<think>` model quoting a K3 channel token ended its chain
-    of thought there while the non-streaming split ended it at the real
-    `</think>`. Go through :class:`ReasoningChannel` rather than passing this
-    by hand; that is what keeps the two paths on one answer.
+    Every marker question goes to :class:`MarkerScanner`, the same reader the
+    tool-call side uses. It used to have its own: an `_earliest_marker` whose
+    tie-break was the opposite of the scanner's (first-declared rather than
+    longest, so `<think>` would be reported where `<thinking>` was meant), the
+    hold-and-cut arithmetic open-coded twice, and `self.buf += text` on an
+    attribute -- the quadratic append `Region` exists to avoid -- on the
+    reasoning half of every long chain of thought. All three in a module whose
+    first paragraph says asking this question in more than one place is the
+    bug being retired.
     """
 
-    state: int = 0
-    buf: str = ""
-    starts_thinking: bool = False
-    dialect: ReasoningDialect | None = None
-
-    def __post_init__(self):
-        if self.starts_thinking and self.state == 0:
-            self.state = 1
-        speaking = self.dialect or FALLBACK_DIALECT
-        self._end_markers = speaking.end_markers
-        self._open_markers = (
+    def __init__(
+        self,
+        starts_thinking: bool = False,
+        dialect: ReasoningDialect | None = None,
+    ) -> None:
+        self.starts_thinking = starts_thinking
+        self.dialect = dialect
+        speaking = dialect or FALLBACK_DIALECT
+        self._end_markers = frozenset(speaking.end_markers)
+        self._framing = frozenset(speaking.content_framing)
+        self._open_markers = frozenset(
             (speaking.output_open_marker,) if speaking.output_open_marker else ()
         )
+        self.state = 1 if starts_thinking else 0
+        self._scanner = self._scanner_for(self.state)
 
-    def _close_thinking(self, idx: int, marker: str) -> list:
-        """A think-end marker was found at ``idx``: emit everything before it as
-        reasoning, switch to content (state 2), and process anything after."""
-        results = []
-        reasoning = self.buf[:idx]
-        # Byte-for-byte, like the non-streaming split -- and this one could
-        # not have been made to agree anyway: it saw only what happened to be
-        # buffered when the marker arrived, so the same answer kept its
-        # newlines at one chunk size and lost them at another.
-        after = self.buf[idx + len(marker) :]
-        if reasoning:
-            results.append(("reasoning_content", reasoning))
-        self.state = 2
-        self.buf = ""
-        if after:
-            results.extend(self._process_content(after))
-        return results
+    def _scanner_for(self, state: int) -> MarkerScanner | None:
+        """What this state has to watch for. ``None`` when that is nothing,
+        which is the common case for the inline-`<think>` dialect after the
+        channel has closed."""
+        watched = self._framing | (
+            self._end_markers
+            if state == 1
+            else self._open_markers if state == 0 else frozenset()
+        )
+        return MarkerScanner(tuple(sorted(watched))) if watched else None
 
-    def _drain_thinking(self) -> list:
-        """State-1 helper: emit buffered reasoning up to a think-end marker; on
-        match switch to content. Otherwise emit what's safe, holding back a
-        partial trailing marker so it isn't split across chunks."""
-        idx, marker = _earliest_marker(self.buf, self._end_markers)
-        if idx != -1:
-            return self._close_thinking(idx, marker)
-        hold = held_suffix_len(self.buf, self._end_markers)
-        emit = self.buf[: len(self.buf) - hold] if hold else self.buf
-        self.buf = self.buf[len(self.buf) - hold :] if hold else ""
-        return [("reasoning_content", emit)] if emit else []
+    @property
+    def _field(self) -> str:
+        return "reasoning_content" if self.state == 1 else "content"
 
     def process(self, text: str) -> list:
-        """Process a chunk of text and return list of (field, text) tuples."""
-        results = []
-
-        if self.state == 0:
-            self.buf += text
-            # A reasoning opener emitted in the output (e.g. "<think>").
-            oidx, omark = _earliest_marker(self.buf, self._open_markers)
-            if oidx != -1:
-                before = self.buf[:oidx]
-                if before:
-                    results.append(("content", before))
-                self.state = 1
-                self.buf = self.buf[oidx + len(omark) :]
-                results.extend(self._drain_thinking())
-            else:
-                # No opener, so this is the answer: release it, holding back
-                # only a suffix that could still grow into one.
-                #
-                # State 0 no longer honours a `</think>` it never saw opened,
-                # and no longer buffers 100 characters hoping for one. Both
-                # were the same guess -- that the template had injected the
-                # opener -- made at run time about something the prompt
-                # answers: `starts_thinking` is that answer, and a filter in
-                # state 0 has been told the output does *not* begin inside the
-                # reasoning channel. The guess cost an unbounded first byte
-                # (its `"<" not in self.buf` gate could never be satisfied
-                # again once an ordinary answer contained a '<') and it let
-                # pre-`</think>` text reach the tool-call sniffer, which is
-                # how reasoning that merely mentions `<tool_call>` came to be
-                # emitted as a tool call. vLLM's streaming path resolves this
-                # from the token vocabulary and buffers nothing; this is the
-                # same position, reached from the prompt.
-                hold = held_suffix_len(self.buf, self._open_markers)
-                cut = len(self.buf) - hold
-                if cut:
-                    results.append(("content", self.buf[:cut]))
-                    self.buf = self.buf[cut:]
-
-        elif self.state == 1:
-            self.buf += text
-            results.extend(self._drain_thinking())
-
-        else:  # state == 2
-            results.extend(self._process_content(text))
-
-        return results
-
-    def _process_content(self, text: str) -> list:
-        """Process content after thinking. Tool calls are handled by ToolCallStreamParser."""
-        if text:
-            return [("content", text)]
-        return []
+        """Consume one chunk; return what it completed."""
+        out: list = []
+        while True:
+            if self._scanner is None:
+                if text:
+                    out.append((self._field, text))
+                return out
+            scan = self._scanner.feed(text)
+            text = ""
+            if scan.released:
+                out.append((self._field, scan.released))
+            if scan.hit is None:
+                return out
+            if scan.hit in self._framing and not (
+                self.state == 1 and scan.hit in self._end_markers
+            ):
+                # Framing this format wraps every answer in. Removed here and
+                # not only by the tool parser: doing it there alone made the
+                # answer depend on which tool-call format was resolved, so a
+                # K3 deployment whose template refused the tools probe handed
+                # its channel tokens to the client on both delivery paths.
+                text = scan.rest
+                continue
+            # A channel boundary: state 0 -> 1 on the opener, 1 -> 2 on any
+            # end marker. A dialect that opens the channel from the prompt has
+            # no opener to see, so it starts in state 1 and only ever takes
+            # the second of these.
+            self.state = 1 if self.state == 0 else 2
+            self._scanner = self._scanner_for(self.state)
+            text = scan.rest
 
     def flush(self) -> list:
-        """Flush any remaining buffered content."""
-        results = []
-        if self.buf:
-            if self.state == 0:
-                results.append(("content", self.buf))
-            elif self.state == 1:
-                results.append(("reasoning_content", self.buf))
-            self.buf = ""
-        return results
+        """End of stream: whatever is held never became a marker."""
+        rest = self._scanner.flush() if self._scanner is not None else ""
+        self._scanner = None
+        return [(self._field, rest)] if rest else []
 
 
 @dataclass(frozen=True)

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -13,6 +13,7 @@ this module contains no per-model conditions. Add a model there, not here.
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
+from .marker_scanner import partial_suffix_len
 from .reasoning_dialects import DIALECTS
 
 # Marker tables derived from the dialect registry (no model literals here).
@@ -71,30 +72,43 @@ def _earliest_marker(buf: str, markers) -> tuple[int, str | None]:
 
 def _hold_back_len(buf: str, markers) -> int:
     """Length of the longest suffix of ``buf`` that is a strict prefix of any
-    marker, so a marker split across chunk boundaries isn't emitted as text."""
-    n = 0
-    for m in markers:
-        limit = min(len(buf), len(m) - 1)
-        for k in range(limit, 0, -1):
-            if m.startswith(buf[-k:]):
-                n = max(n, k)
-                break
-    return n
+    marker, so a marker split across chunk boundaries isn't emitted as text.
+
+    Delegates, because the tool-call path asks the same question and answering
+    it twice is how the two sides drifted apart.
+    """
+    return max((partial_suffix_len(buf, m) for m in markers), default=0)
 
 
-def separate_reasoning(text: str) -> tuple[str | None, str]:
+def separate_reasoning(
+    text: str, starts_thinking: bool = False
+) -> tuple[str | None, str]:
     """Separate reasoning content from the final answer.
 
     Tries each registered dialect in priority order; the first that applies wins.
+
+    ``starts_thinking`` is the same answer :class:`ReasoningFilter` takes, and
+    for the same reason: an output that begins inside the reasoning channel
+    carries no opening marker, so nothing in the text says so. Both paths have
+    to be told, or the same response is split one way when streamed and
+    another when not -- measured, a reasoning model truncated at ``max_tokens``
+    returned its whole trace as ``content`` here and as ``reasoning_content``
+    when streamed.
 
     Returns:
         Tuple of (reasoning_content, content). reasoning_content is None if no
         thinking block was found.
     """
     for dialect in DIALECTS:
-        result = dialect.split(text)
+        result = dialect.split(text, starts_thinking)
         if result is not None:
             return result
+    if starts_thinking:
+        # The prompt opened the channel and the model never closed it, which
+        # is what a reasoning model stopped at `max_tokens` looks like. It
+        # produced reasoning and no answer; the streaming filter says exactly
+        # that from state 1, and this has to agree.
+        return (text, "")
     # No reasoning markers — return content as-is (tool calls parsed separately).
     return (None, text)
 
@@ -168,17 +182,28 @@ class ReasoningFilter:
                 self.buf = self.buf[oidx + len(omark) :]
                 results.extend(self._drain_thinking())
             else:
-                # No explicit opener, but a think-end marker means the model
-                # started reasoning without one (template injected the opener).
-                idx, marker = _earliest_marker(self.buf, _THINK_END_MARKERS)
-                if idx != -1:
-                    results.extend(self._close_thinking(idx, marker))
-                elif len(self.buf) > 100 and "<" not in self.buf:
-                    # No reasoning markers after significant buffering — emit as
-                    # content. Large threshold gives models time to emit an
-                    # end marker when the template injected the opener.
-                    results.append(("content", self.buf))
-                    self.buf = ""
+                # No opener, so this is the answer: release it, holding back
+                # only a suffix that could still grow into one.
+                #
+                # State 0 no longer honours a `</think>` it never saw opened,
+                # and no longer buffers 100 characters hoping for one. Both
+                # were the same guess -- that the template had injected the
+                # opener -- made at run time about something the prompt
+                # answers: `starts_thinking` is that answer, and a filter in
+                # state 0 has been told the output does *not* begin inside the
+                # reasoning channel. The guess cost an unbounded first byte
+                # (its `"<" not in self.buf` gate could never be satisfied
+                # again once an ordinary answer contained a '<') and it let
+                # pre-`</think>` text reach the tool-call sniffer, which is
+                # how reasoning that merely mentions `<tool_call>` came to be
+                # emitted as a tool call. vLLM's streaming path resolves this
+                # from the token vocabulary and buffers nothing; this is the
+                # same position, reached from the prompt.
+                hold = _hold_back_len(self.buf, _OUTPUT_OPEN_MARKERS)
+                cut = len(self.buf) - hold
+                if cut:
+                    results.append(("content", self.buf[:cut]))
+                    self.buf = self.buf[cut:]
 
         elif self.state == 1:
             self.buf += text

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -13,7 +13,7 @@ this module contains no per-model conditions. Add a model there, not here.
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
-from .marker_scanner import partial_suffix_len
+from .marker_scanner import held_suffix_len
 from .reasoning_dialects import DIALECTS
 
 # Marker tables derived from the dialect registry (no model literals here).
@@ -31,7 +31,7 @@ _OUTPUT_OPEN_MARKERS = tuple(
 VALID_TEMPLATE_EFFORTS = frozenset().union(*(d.template_efforts for d in DIALECTS))
 
 
-def template_opens_reasoning_implicitly(rendered_template: str) -> bool:
+def template_opens_reasoning_implicitly(template_source: str) -> bool:
     """Does this model begin inside the reasoning channel with no marker at all?
 
     Some families close a reasoning block they never open: DeepSeek-R1 emits
@@ -44,6 +44,15 @@ def template_opens_reasoning_implicitly(rendered_template: str) -> bool:
     both (Qwen3) describes a model that opens its own, and one that mentions
     neither (MiniMax-M3, gpt-oss) has no reasoning channel to speak of.
 
+    ``template_source`` is the template's own text, which is the only place
+    this shows: an end marker is what the template does with a *reply*, so it
+    never reaches a fresh prompt. Measured -- Qwen3.5's source carries both
+    markers while its rendered prompt carries only the opener, and Qwen3-8B's
+    rendered prompt carries neither, so asking a render would answer False for
+    every model alive. Get it from `chat_encoders.chat_template_source`, which
+    also handles the two shapes that answer False by accident: a ``dict`` of
+    named templates, and the ``None`` of a model that ships a Python encoder.
+
     This is what vLLM expresses by registering `DeepSeekR1ReasoningParser` for
     R1 -- an override whose only job is to treat a stream with no start token
     as reasoning until `</think>`. Same fact, derived instead of listed.
@@ -52,8 +61,8 @@ def template_opens_reasoning_implicitly(rendered_template: str) -> bool:
         if not dialect.think_end_marker:
             continue
         opener = dialect.output_open_marker or dialect.prompt_open_marker
-        if dialect.think_end_marker in rendered_template and (
-            not opener or opener not in rendered_template
+        if dialect.think_end_marker in template_source and (
+            not opener or opener not in template_source
         ):
             return True
     return False
@@ -103,9 +112,12 @@ def _hold_back_len(buf: str, markers) -> int:
     marker, so a marker split across chunk boundaries isn't emitted as text.
 
     Delegates, because the tool-call path asks the same question and answering
-    it twice is how the two sides drifted apart.
+    it twice is how the two sides drifted apart. Delegating the *whole*
+    question and not just its inner loop also buys the first-character reject,
+    which this path had gone without: it runs once per token on every stream,
+    including the models with no reasoning channel at all.
     """
-    return max((partial_suffix_len(buf, m) for m in markers), default=0)
+    return held_suffix_len(buf, tuple(markers))
 
 
 def separate_reasoning(

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -31,6 +31,34 @@ _OUTPUT_OPEN_MARKERS = tuple(
 VALID_TEMPLATE_EFFORTS = frozenset().union(*(d.template_efforts for d in DIALECTS))
 
 
+def template_opens_reasoning_implicitly(rendered_template: str) -> bool:
+    """Does this model begin inside the reasoning channel with no marker at all?
+
+    Some families close a reasoning block they never open: DeepSeek-R1 emits
+    `</think>` but neither its prompt nor its output carries `<think>`. Nothing
+    in a single response says so -- the first token is already reasoning and
+    looks like an answer -- so it has to be known before the response starts.
+
+    The chat template says it. A template that mentions an end marker and not
+    the matching opener is describing exactly that shape; one that mentions
+    both (Qwen3) describes a model that opens its own, and one that mentions
+    neither (MiniMax-M3, gpt-oss) has no reasoning channel to speak of.
+
+    This is what vLLM expresses by registering `DeepSeekR1ReasoningParser` for
+    R1 -- an override whose only job is to treat a stream with no start token
+    as reasoning until `</think>`. Same fact, derived instead of listed.
+    """
+    for dialect in DIALECTS:
+        if not dialect.think_end_marker:
+            continue
+        opener = dialect.output_open_marker or dialect.prompt_open_marker
+        if dialect.think_end_marker in rendered_template and (
+            not opener or opener not in rendered_template
+        ):
+            return True
+    return False
+
+
 def prompt_starts_in_reasoning(prompt: str) -> bool:
     """True if the rendered ``prompt`` ends by opening a reasoning channel.
 

--- a/atom/entrypoints/openai/reasoning.py
+++ b/atom/entrypoints/openai/reasoning.py
@@ -41,8 +41,8 @@ def template_opens_reasoning_implicitly(template_source: str) -> bool:
 
     The chat template says it. A template that mentions an end marker and not
     the matching opener is describing exactly that shape; one that mentions
-    both (Qwen3) describes a model that opens its own, and one that mentions
-    neither (MiniMax-M3, gpt-oss) has no reasoning channel to speak of.
+    both (Qwen3, MiniMax-M3) describes a model that opens its own, and one
+    that mentions neither (gpt-oss) has no reasoning channel to speak of.
 
     ``template_source`` is the template's own text, which is the only place
     this shows: an end marker is what the template does with a *reply*, so it

--- a/atom/entrypoints/openai/reasoning_dialects.py
+++ b/atom/entrypoints/openai/reasoning_dialects.py
@@ -156,17 +156,37 @@ def _split_channel(text: str, starts_thinking: bool = False) -> SplitResult | No
     still reach this one, and the structural answer is to resolve the dialect
     at startup as the tool-call format now is.
     """
+    before = ""
     if not starts_thinking:
-        return None
+        # A prompt that left thinking off does not stop the model opening a
+        # channel of its own. The two inline dialects have always read that;
+        # returning `None` here let the tool parser strip the framing and glue
+        # the trace onto the answer, on both paths, so parity could not see it.
+        at = text.find(CHANNEL_THINK_START)
+        if at != -1:
+            # Searched, and what precedes it is content -- the two rulings
+            # `_split_inline_tag` makes. Anchoring at 0 instead put this out
+            # of step with the streaming filter on `\n\n<|open|>think<|sep|>`.
+            before, text = text[:at], text[at + len(CHANNEL_THINK_START) :]
+        elif text.startswith(CHANNEL_THINK_END):
+            # Declined to think; offset 0 only, see `_split_inline_tag`.
+            return (None, text[len(CHANNEL_THINK_END) :])
+        else:
+            return None
     best_at, best = len(text), None
     for marker in _CHANNEL_END_MARKERS:
         at = text.find(marker)
         if 0 <= at < best_at:
             best_at, best = at, marker
     if best is None:
-        return None
+        # Never closed. Seeded, that is a trace cut off at `max_tokens` and
+        # `separate_reasoning`'s fallback says so; self-opened, the channel's
+        # start is already known.
+        if starts_thinking:
+            return None
+        return (text or None, before)
     reasoning = text[:best_at]
-    content = text[best_at + len(best) :]
+    content = before + text[best_at + len(best) :]
     return (reasoning or None, content)
 
 
@@ -238,6 +258,20 @@ def _split_inline_tag(
         # writing the same answer twice.
         return None
 
+    # A closer with nothing before it: the model declined to think this turn.
+    # MiniMax-M3's template renders every earlier no-thinking assistant turn
+    # as a bare `</mm:think>`, so that is the trained form -- measured live,
+    # 0 of 10 single-turn replies and 7 of 30 multi-turn. vLLM and SGLang both
+    # carry code for it.
+    #
+    # Offset 0 only. Honouring the marker anywhere is the guess `0858a50d4`
+    # removed for cause: it made an ordinary answer wait for a marker that
+    # never came, and fed pre-marker text to the tool-call sniffer. Neither
+    # reaches here -- nothing precedes offset 0, and the decision is made
+    # within one marker's length, which the scanner already buffers.
+    if text.startswith(end_marker):
+        return (None, text[len(end_marker) :])
+
     # Closed block: <think>...</think> answer.
     #
     # Searched, not anchored at position 0: a block does not have to open the
@@ -288,7 +322,12 @@ _CHANNEL_CONTENT_FRAMING = k3.CHANNEL_FRAMING
 
 _CHANNEL_DIALECT = ReasoningDialect(
     prompt_open_marker=CHANNEL_THINK_START,
-    output_open_marker=None,  # template-injected; not emitted in output
+    # The same literal, not `None`. "The template injects it, so the model
+    # never writes one" is false when the prompt leaves thinking off and the
+    # model opens a channel anyway -- and `ReasoningFilter` builds
+    # `_open_markers` from this field, so state 0 had nothing to leave itself
+    # on and delivered the whole trace as the answer.
+    output_open_marker=CHANNEL_THINK_START,
     think_end_marker=CHANNEL_THINK_END,
     # `response` is what the trained format always opens next -- Kimi-K3's
     # encoder emits a complete response section before any tools section, so

--- a/atom/entrypoints/openai/reasoning_dialects.py
+++ b/atom/entrypoints/openai/reasoning_dialects.py
@@ -41,6 +41,19 @@ CHANNEL_TOOLS_START = "<|open|>tools<|sep|>"
 CHANNEL_CALL_PREFIX = '<|open|>call tool="'
 
 # Result of splitting a full response: (reasoning_content or None, content).
+#
+# **Both halves come back byte-for-byte.** What may be removed is a marker a
+# dialect declares; everything else, and whitespace in particular, survives.
+# This is the rule `ToolCallParser.parse` already states for the stage after
+# this one, and it exists for the same reason: the streaming filter releases
+# bytes as they arrive and owns nothing to tidy them with, so any trimming
+# done only here is a divergence a client sees.
+#
+# It was not applied here, and the symptom was the one that rule cites
+# verbatim -- a trailing `.strip()` cost a code-block answer its final
+# newline. Measured across 12544 (dialect, shape, chunking) comparisons,
+# stripping put `stream=false` and `stream=true` at 50% byte-agreement on
+# content; without it they agree exactly.
 SplitResult = tuple[str | None, str]
 
 
@@ -82,47 +95,85 @@ def _strip_channel_response_markers(text: str) -> str:
     for marker in (CHANNEL_RESPONSE_END, CHANNEL_MESSAGE_END, CHANNEL_END_OF_MSG):
         if marker in text:
             text = text.partition(marker)[0]
-    return text.strip()
+    return text
 
 
 def _split_channel(text: str, starts_thinking: bool = False) -> SplitResult | None:
     combined = CHANNEL_THINK_END + CHANNEL_RESPONSE_START
     if combined in text:
         reasoning, _, content = text.partition(combined)
-        return (reasoning.strip() or None, _strip_channel_response_markers(content))
+        return (reasoning or None, _strip_channel_response_markers(content))
     if CHANNEL_RESPONSE_START in text:
         _, _, content = text.partition(CHANNEL_RESPONSE_START)
         return (None, _strip_channel_response_markers(content))
     if CHANNEL_THINK_END in text and starts_thinking:
         reasoning, _, content = text.partition(CHANNEL_THINK_END)
-        return (reasoning.strip() or None, _strip_channel_response_markers(content))
+        return (reasoning or None, _strip_channel_response_markers(content))
     return None
 
 
 # --- Generic <think>...</think> dialect (K2/DeepSeek/Qwen3/MiniMax/...) ---
 
-_THINK_CLOSED_RE = re.compile(r"<think>(.*?)</think>\s*(.*)", flags=re.DOTALL)
-_THINK_OPEN_RE = re.compile(r"<think>(.*)", flags=re.DOTALL)
+# No `\s*` after `</think>`. The newline a model puts before its answer is
+# not a marker this dialect declares, so it survives -- see `SplitResult`.
+THINK_OPEN_MARKER = "<think>"
+THINK_END_MARKER = "</think>"
+_THINK_CLOSED_RE = re.compile(
+    re.escape(THINK_OPEN_MARKER) + r"(.*?)" + re.escape(THINK_END_MARKER) + r"(.*)",
+    flags=re.DOTALL,
+)
+_THINK_OPEN_RE = re.compile(re.escape(THINK_OPEN_MARKER) + r"(.*)", flags=re.DOTALL)
 
 
 def _split_think_tag(text: str, starts_thinking: bool = False) -> SplitResult | None:
-    # Closed block: <think>...</think> answer
-    match = _THINK_CLOSED_RE.match(text)
+    # Ordered as the streaming filter's state machine is, because that is what
+    # this has to agree with. `starts_thinking` means the prompt already
+    # opened the channel, so the output *begins* in it: the first `</think>`
+    # closes it and any `<think>` before that is literal text inside the
+    # reasoning, not an opener. Letting the searches below run first read one
+    # as an opener and dropped everything ahead of it.
+    if starts_thinking:
+        # `</think>` with no `<think>`. Reasoning only because the prompt says
+        # the channel is open -- ungated, this guessed, and disagreed with the
+        # streaming path, which cannot honour an end marker it has no opener
+        # for without waiting for one, and waiting is the stall. vLLM's
+        # non-streaming path still guesses here and its streaming path does
+        # not; the two do not agree, and this is the half worth copying.
+        if THINK_END_MARKER in text:
+            reasoning, _, content = text.partition(THINK_END_MARKER)
+            return (reasoning or None, content)
+        # Never closed: all reasoning, no answer. That is what a reasoning
+        # model stopped at `max_tokens` looks like, and `separate_reasoning`'s
+        # own fallback says it -- returning `None` defers to it rather than
+        # writing the same answer twice.
+        return None
+
+    # Closed block: <think>...</think> answer.
+    #
+    # Searched, not anchored at position 0: a block does not have to open the
+    # output. Anchoring meant a model that answers, opens a `<think>` block
+    # and answers again matched nothing, so the client was handed the literal
+    # tags with the chain of thought inside `content`.
+    #
+    # What precedes the block is content because it *is* content -- text
+    # outside the reasoning channel. Nothing about the split needs the
+    # streaming filter to justify it; this function has the whole output.
+    #
+    # The *first* block only, and that one IS a parity choice rather than a
+    # reading of the format: the streaming filter closes the channel on the
+    # first `</think>` and never reopens it, so splitting every block here
+    # would make `stream=false` disagree with `stream=true` on any output
+    # with two -- swapping one divergence for another. Whether *both* should
+    # reopen is a separate question, and answering it means changing the
+    # filter, not this.
+    match = _THINK_CLOSED_RE.search(text)
     if match:
-        return (match.group(1).strip() or None, match.group(2).strip())
-    # `</think>` with no `<think>`. Only reasoning if the prompt really did open
-    # the channel -- which `starts_thinking` now says, instead of this guessing.
-    # Ungated it disagreed with the streaming path, which cannot honour an end
-    # marker it has no opener for without waiting for one, and waiting is the
-    # stall. vLLM's non-streaming path still guesses here and its streaming path
-    # does not; the two do not agree, and this is the half worth copying.
-    if "</think>" in text and starts_thinking:
-        reasoning, _, content = text.partition("</think>")
-        return (reasoning.strip() or None, content.strip())
-    # Unclosed block (truncated response).
-    match = _THINK_OPEN_RE.match(text)
+        return (match.group(1) or None, text[: match.start()] + match.group(2))
+    # Unclosed block (truncated response). Searched, and split, for the same
+    # reasons as the closed one above.
+    match = _THINK_OPEN_RE.search(text)
     if match:
-        return (match.group(1).strip() or None, "")
+        return (match.group(1) or None, text[: match.start()])
     return None
 
 
@@ -149,9 +200,9 @@ DIALECTS: tuple[ReasoningDialect, ...] = (
     ),
     # Generic <think>...</think> (K2/DeepSeek/Qwen3/MiniMax/...)
     ReasoningDialect(
-        prompt_open_marker="<think>",
-        output_open_marker="<think>",
-        think_end_marker="</think>",
+        prompt_open_marker=THINK_OPEN_MARKER,
+        output_open_marker=THINK_OPEN_MARKER,
+        think_end_marker=THINK_END_MARKER,
         split=_split_think_tag,
     ),
 )

--- a/atom/entrypoints/openai/reasoning_dialects.py
+++ b/atom/entrypoints/openai/reasoning_dialects.py
@@ -63,7 +63,7 @@ class ReasoningDialect:
     prompt_open_marker: str
     output_open_marker: str | None
     think_end_marker: str
-    split: Callable[[str], SplitResult | None]
+    split: Callable[[str, bool], SplitResult | None]
     template_efforts: frozenset[str] = frozenset()
 
 
@@ -85,7 +85,7 @@ def _strip_channel_response_markers(text: str) -> str:
     return text.strip()
 
 
-def _split_channel(text: str) -> SplitResult | None:
+def _split_channel(text: str, starts_thinking: bool = False) -> SplitResult | None:
     combined = CHANNEL_THINK_END + CHANNEL_RESPONSE_START
     if combined in text:
         reasoning, _, content = text.partition(combined)
@@ -93,7 +93,7 @@ def _split_channel(text: str) -> SplitResult | None:
     if CHANNEL_RESPONSE_START in text:
         _, _, content = text.partition(CHANNEL_RESPONSE_START)
         return (None, _strip_channel_response_markers(content))
-    if CHANNEL_THINK_END in text:
+    if CHANNEL_THINK_END in text and starts_thinking:
         reasoning, _, content = text.partition(CHANNEL_THINK_END)
         return (reasoning.strip() or None, _strip_channel_response_markers(content))
     return None
@@ -105,13 +105,18 @@ _THINK_CLOSED_RE = re.compile(r"<think>(.*?)</think>\s*(.*)", flags=re.DOTALL)
 _THINK_OPEN_RE = re.compile(r"<think>(.*)", flags=re.DOTALL)
 
 
-def _split_think_tag(text: str) -> SplitResult | None:
+def _split_think_tag(text: str, starts_thinking: bool = False) -> SplitResult | None:
     # Closed block: <think>...</think> answer
     match = _THINK_CLOSED_RE.match(text)
     if match:
         return (match.group(1).strip() or None, match.group(2).strip())
-    # </think> without <think> — template injected the opening tag into the prompt.
-    if "</think>" in text:
+    # `</think>` with no `<think>`. Only reasoning if the prompt really did open
+    # the channel -- which `starts_thinking` now says, instead of this guessing.
+    # Ungated it disagreed with the streaming path, which cannot honour an end
+    # marker it has no opener for without waiting for one, and waiting is the
+    # stall. vLLM's non-streaming path still guesses here and its streaming path
+    # does not; the two do not agree, and this is the half worth copying.
+    if "</think>" in text and starts_thinking:
         reasoning, _, content = text.partition("</think>")
         return (reasoning.strip() or None, content.strip())
     # Unclosed block (truncated response).

--- a/atom/entrypoints/openai/reasoning_dialects.py
+++ b/atom/entrypoints/openai/reasoning_dialects.py
@@ -78,6 +78,11 @@ class ReasoningDialect:
     think_end_marker: str
     split: Callable[[str, bool], SplitResult | None]
     template_efforts: frozenset[str] = frozenset()
+    # The literals whose presence in a *chat template* says the model speaks
+    # this dialect. Read once at startup, exactly as the tool-call format is:
+    # a template states what it taught the model, while an output only
+    # exhibits whatever it happens to contain.
+    template_markers: tuple[str, ...] = ()
     # Every marker that ends the reasoning channel, `think_end_marker`
     # included. A channel format can leave the think channel by *opening*
     # another one, and the streaming filter knew only the explicit close: a
@@ -91,23 +96,12 @@ class ReasoningDialect:
     def end_markers(self) -> tuple[str, ...]:
         return (self.think_end_marker, *self.extra_end_markers)
 
+    def taught_by(self, template_source: str) -> bool:
+        """Does this template teach the model this dialect?"""
+        return any(m in template_source for m in self.template_markers)
+
 
 # --- Structured-channel dialect ---
-
-
-def _strip_channel_response_markers(text: str) -> str:
-    # Preserve tool-call sections: they follow <|close|>response<|sep|> (an
-    # empty response channel), so truncating at CHANNEL_RESPONSE_END would drop
-    # the whole tools block. Leave it intact for parse_tool_calls to handle.
-    if CHANNEL_TOOLS_START in text or CHANNEL_CALL_PREFIX in text:
-        return text
-
-    text = text.removeprefix(CHANNEL_RESPONSE_START)
-
-    for marker in (CHANNEL_RESPONSE_END, CHANNEL_MESSAGE_END, CHANNEL_END_OF_MSG):
-        if marker in text:
-            text = text.partition(marker)[0]
-    return text
 
 
 _CHANNEL_END_MARKERS = (CHANNEL_THINK_END, CHANNEL_RESPONSE_START)
@@ -122,6 +116,16 @@ def _split_channel(text: str, starts_thinking: bool = False) -> SplitResult | No
     byte between the two markers was enough to reach it, and the chain of
     thought then appeared in neither field. Silent data loss, not a
     divergence.
+
+    The content comes back with its channel framing still on it, and that is
+    deliberate: removing a tool-format's literals is the tool parser's job and
+    it does it on both delivery paths, from one declared list. Doing it here
+    too meant the reasoning stage removed them when the response was not
+    streamed and left them when it was -- the streaming filter has no such
+    step -- so the two paths only agreed by way of a *third* stage, and only
+    when a K3 parser had been resolved. This one also truncated at
+    `<|end_of_msg|>` rather than removing it, so anything after that token was
+    deleted on one path alone.
 
     Gated on `starts_thinking`, which the two other branches were not: these
     markers only mean anything if a reasoning channel was actually opened.
@@ -144,7 +148,7 @@ def _split_channel(text: str, starts_thinking: bool = False) -> SplitResult | No
         return None
     reasoning = text[:best_at]
     content = text[best_at + len(best) :]
-    return (reasoning or None, _strip_channel_response_markers(content))
+    return (reasoning or None, content)
 
 
 # --- Generic <think>...</think> dialect (K2/DeepSeek/Qwen3/MiniMax/...) ---
@@ -233,6 +237,7 @@ DIALECTS: tuple[ReasoningDialect, ...] = (
         extra_end_markers=(CHANNEL_RESPONSE_START,),
         split=_split_channel,
         template_efforts=frozenset({"low", "high", "max"}),  # Kimi-K3
+        template_markers=(CHANNEL_THINK_START, CHANNEL_THINK_END),
     ),
     # Generic <think>...</think> (K2/DeepSeek/Qwen3/MiniMax/...)
     ReasoningDialect(
@@ -240,5 +245,50 @@ DIALECTS: tuple[ReasoningDialect, ...] = (
         output_open_marker=THINK_OPEN_MARKER,
         think_end_marker=THINK_END_MARKER,
         split=_split_think_tag,
+        template_markers=(THINK_OPEN_MARKER, THINK_END_MARKER),
     ),
 )
+
+# The dialect a model speaks when its template names none of them. The
+# inline-`<think>` one, and not "no dialect at all": a template that renders
+# the tag conditionally may not carry it in the source we can read, and the
+# cost of guessing wrong here is nil -- a model that never writes `<think>`
+# never matches its markers, so the split is a no-op. Guessing the other way
+# would ship a chain of thought to the client as the answer.
+FALLBACK_DIALECT = DIALECTS[-1]
+
+
+def resolve_dialect(
+    template_source: str, rendered_prompt: str = ""
+) -> tuple[ReasoningDialect, bool]:
+    """Which reasoning dialect this model speaks, and whether it was stated.
+
+    Asked once, at startup -- the same question, in the same place and by the
+    same means, as the tool-call format. It used to be asked twice per response
+    and differently each time: the non-streaming split tried every dialect in
+    order and took the first that matched, while the streaming filter used the
+    *union* of every dialect's end markers and closed on whichever came first.
+    So a `<think>` model answering a question about Kimi's wire format ended
+    its chain of thought at the quoted `<|open|>response<|sep|>` when streamed
+    and at the real `</think>` when not.
+
+    Both kinds of evidence, and the *render* first, because the source is not
+    always readable. Kimi-K3 ships neither a Jinja template nor an encoder
+    under the path the loader looks in, so `chat_template_source` returns ""
+    for it -- and falling back to the inline-`<think>` dialect on that made a
+    K3 answer come back as `reasoning_content` with `content` empty, on both
+    delivery modes, while the tool-call format resolved correctly off the
+    rendered probe. Same model, two answers to "what does this model speak",
+    from two different pieces of evidence. Now it is one function reading
+    both.
+
+    The second return value is whether a dialect was actually named, so the
+    caller can say at startup which one it is and whether it was a fallback.
+    """
+    for evidence in (rendered_prompt, template_source):
+        if not evidence:
+            continue
+        for dialect in DIALECTS:
+            if dialect.taught_by(evidence):
+                return dialect, True
+    return FALLBACK_DIALECT, False

--- a/atom/entrypoints/openai/reasoning_dialects.py
+++ b/atom/entrypoints/openai/reasoning_dialects.py
@@ -176,14 +176,46 @@ def _split_channel(text: str, starts_thinking: bool = False) -> SplitResult | No
 # not a marker this dialect declares, so it survives -- see `SplitResult`.
 THINK_OPEN_MARKER = "<think>"
 THINK_END_MARKER = "</think>"
-_THINK_CLOSED_RE = re.compile(
-    re.escape(THINK_OPEN_MARKER) + r"(.*?)" + re.escape(THINK_END_MARKER) + r"(.*)",
-    flags=re.DOTALL,
-)
-_THINK_OPEN_RE = re.compile(re.escape(THINK_OPEN_MARKER) + r"(.*)", flags=re.DOTALL)
+
+# MiniMax-M3 spells the same shape with its own tags. Its template sets
+# `think_begin_token = '<mm:think>'` and ends the generation prompt with it
+# when `thinking_mode == "enabled"`, leaves no prefix under "adaptive" (so the
+# model writes the opener itself), and emits `</mm:think>` alone under
+# "disabled". Neither literal was declared anywhere, so the whole chain of
+# thought was delivered as `content` with `reasoning_content: null`, on both
+# delivery paths -- and on `/v1/messages`, inside the client's text block.
+MM_THINK_OPEN_MARKER = "<mm:think>"
+MM_THINK_END_MARKER = "</mm:think>"
 
 
-def _split_think_tag(text: str, starts_thinking: bool = False) -> SplitResult | None:
+def _inline_tag_split(open_marker: str, end_marker: str) -> Callable:
+    """A split for one `OPEN ... END` inline-tag dialect.
+
+    Built per dialect from that dialect's own markers rather than reading
+    module constants, because a second inline-tag format arrived and the
+    single hardcoded pair would have silently split its output with the wrong
+    tags -- the dialect declaring one thing and its split doing another is the
+    two-sources shape this module exists to retire.
+    """
+    closed_re = re.compile(
+        re.escape(open_marker) + r"(.*?)" + re.escape(end_marker) + r"(.*)",
+        flags=re.DOTALL,
+    )
+    open_re = re.compile(re.escape(open_marker) + r"(.*)", flags=re.DOTALL)
+
+    def split(text: str, starts_thinking: bool = False) -> SplitResult | None:
+        return _split_inline_tag(text, starts_thinking, end_marker, closed_re, open_re)
+
+    return split
+
+
+def _split_inline_tag(
+    text: str,
+    starts_thinking: bool,
+    end_marker: str,
+    closed_re,
+    open_re,
+) -> SplitResult | None:
     # Ordered as the streaming filter's state machine is, because that is what
     # this has to agree with. `starts_thinking` means the prompt already
     # opened the channel, so the output *begins* in it: the first `</think>`
@@ -197,8 +229,8 @@ def _split_think_tag(text: str, starts_thinking: bool = False) -> SplitResult | 
         # for without waiting for one, and waiting is the stall. vLLM's
         # non-streaming path still guesses here and its streaming path does
         # not; the two do not agree, and this is the half worth copying.
-        if THINK_END_MARKER in text:
-            reasoning, _, content = text.partition(THINK_END_MARKER)
+        if end_marker in text:
+            reasoning, _, content = text.partition(end_marker)
             return (reasoning or None, content)
         # Never closed: all reasoning, no answer. That is what a reasoning
         # model stopped at `max_tokens` looks like, and `separate_reasoning`'s
@@ -224,12 +256,12 @@ def _split_think_tag(text: str, starts_thinking: bool = False) -> SplitResult | 
     # with two -- swapping one divergence for another. Whether *both* should
     # reopen is a separate question, and answering it means changing the
     # filter, not this.
-    match = _THINK_CLOSED_RE.search(text)
+    match = closed_re.search(text)
     if match:
         return (match.group(1) or None, text[: match.start()] + match.group(2))
     # Unclosed block (truncated response). Searched, and split, for the same
     # reasons as the closed one above.
-    match = _THINK_OPEN_RE.search(text)
+    match = open_re.search(text)
     if match:
         return (match.group(1) or None, text[: match.start()])
     return None
@@ -275,12 +307,22 @@ _CHANNEL_DIALECT = ReasoningDialect(
 DIALECTS: tuple[ReasoningDialect, ...] = (
     # Structured channel format — Kimi-K3 token values (see CHANNEL_* above)
     _CHANNEL_DIALECT,
-    # Generic <think>...</think> (K2/DeepSeek/Qwen3/MiniMax/...)
+    # MiniMax-M3: the inline-tag shape in its own spelling. Before the generic
+    # entry, so its longer markers are matched first -- though the two sets do
+    # not overlap as substrings, which is checked below.
+    ReasoningDialect(
+        prompt_open_marker=MM_THINK_OPEN_MARKER,
+        output_open_marker=MM_THINK_OPEN_MARKER,
+        think_end_marker=MM_THINK_END_MARKER,
+        split=_inline_tag_split(MM_THINK_OPEN_MARKER, MM_THINK_END_MARKER),
+        template_markers=(MM_THINK_OPEN_MARKER, MM_THINK_END_MARKER),
+    ),
+    # Generic <think>...</think> (K2/DeepSeek/Qwen3/...)
     ReasoningDialect(
         prompt_open_marker=THINK_OPEN_MARKER,
         output_open_marker=THINK_OPEN_MARKER,
         think_end_marker=THINK_END_MARKER,
-        split=_split_think_tag,
+        split=_inline_tag_split(THINK_OPEN_MARKER, THINK_END_MARKER),
         template_markers=(THINK_OPEN_MARKER, THINK_END_MARKER),
     ),
 )

--- a/atom/entrypoints/openai/reasoning_dialects.py
+++ b/atom/entrypoints/openai/reasoning_dialects.py
@@ -24,6 +24,8 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from . import kimi_k3_tokens as k3
+
 # Structured-channel format tokens (``<|open|>SECTION<|sep|>`` ... framing).
 # Named by the format concept, not the model: channel formats are a cross-model
 # pattern (e.g. gpt-oss/Harmony uses the same idea with different framing tokens).
@@ -116,7 +118,12 @@ class ReasoningDialect:
 # --- Structured-channel dialect ---
 
 
-_CHANNEL_END_MARKERS = (CHANNEL_THINK_END, CHANNEL_RESPONSE_START)
+# Every literal that ends this format's reasoning channel, and the only place
+# they are listed. `_split_channel` reads this and `_CHANNEL_DIALECT` derives
+# `extra_end_markers` from it, so the non-streaming split and the streaming
+# filter cannot be told different things; adding a marker in
+# one place alone used to change only the streamed path.
+_CHANNEL_END_MARKERS = (CHANNEL_THINK_END, CHANNEL_RESPONSE_START, k3.TOOLS_START)
 
 
 def _split_channel(text: str, starts_thinking: bool = False) -> SplitResult | None:
@@ -240,18 +247,25 @@ def _split_think_tag(text: str, starts_thinking: bool = False) -> SplitResult | 
 # so a specific channel marker is tried before the generic <think> tag.
 # separate_reasoning() returns the first dialect whose split() matches. A dialect
 # is identified by its markers/split behavior, not a label.
-_CHANNEL_CONTENT_FRAMING = (
-    CHANNEL_RESPONSE_START,
-    CHANNEL_RESPONSE_END,
-    CHANNEL_MESSAGE_END,
-    CHANNEL_END_OF_MSG,
-)
+
+# Read from the module both consumers read, not restated here -- a second
+# hand-kept copy is how the two lists drifted apart. The tool-region brackets
+# stay out: the reasoning stage cannot remove what is between them (see
+# `kimi_k3_tokens`).
+_CHANNEL_CONTENT_FRAMING = k3.CHANNEL_FRAMING
 
 _CHANNEL_DIALECT = ReasoningDialect(
     prompt_open_marker=CHANNEL_THINK_START,
     output_open_marker=None,  # template-injected; not emitted in output
     think_end_marker=CHANNEL_THINK_END,
-    extra_end_markers=(CHANNEL_RESPONSE_START,),
+    # `response` is what the trained format always opens next -- Kimi-K3's
+    # encoder emits a complete response section before any tools section, so
+    # `tools` is reachable only from a malformed generation. Listed anyway,
+    # and cheaply: without it a think block that jumps straight to
+    # `<|open|>tools<|sep|>` puts the entire tool call in `reasoning_content`
+    # with empty `content`, on both delivery paths, and on `/v1/messages`
+    # where reasoning is dropped by default the client gets nothing at all.
+    extra_end_markers=tuple(m for m in _CHANNEL_END_MARKERS if m != CHANNEL_THINK_END),
     split=_split_channel,
     template_efforts=frozenset({"low", "high", "max"}),  # Kimi-K3
     template_markers=(CHANNEL_THINK_START, CHANNEL_THINK_END),

--- a/atom/entrypoints/openai/reasoning_dialects.py
+++ b/atom/entrypoints/openai/reasoning_dialects.py
@@ -78,6 +78,18 @@ class ReasoningDialect:
     think_end_marker: str
     split: Callable[[str, bool], SplitResult | None]
     template_efforts: frozenset[str] = frozenset()
+    # Every marker that ends the reasoning channel, `think_end_marker`
+    # included. A channel format can leave the think channel by *opening*
+    # another one, and the streaming filter knew only the explicit close: a
+    # K3 answer that goes straight to `<|open|>response<|sep|>` -- which its
+    # own docs call the common path -- was streamed entirely as
+    # `reasoning_content` with an empty `content`, while the non-streaming
+    # split read it correctly.
+    extra_end_markers: tuple[str, ...] = ()
+
+    @property
+    def end_markers(self) -> tuple[str, ...]:
+        return (self.think_end_marker, *self.extra_end_markers)
 
 
 # --- Structured-channel dialect ---
@@ -98,18 +110,41 @@ def _strip_channel_response_markers(text: str) -> str:
     return text
 
 
+_CHANNEL_END_MARKERS = (CHANNEL_THINK_END, CHANNEL_RESPONSE_START)
+
+
 def _split_channel(text: str, starts_thinking: bool = False) -> SplitResult | None:
-    combined = CHANNEL_THINK_END + CHANNEL_RESPONSE_START
-    if combined in text:
-        reasoning, _, content = text.partition(combined)
-        return (reasoning or None, _strip_channel_response_markers(content))
-    if CHANNEL_RESPONSE_START in text:
-        _, _, content = text.partition(CHANNEL_RESPONSE_START)
-        return (None, _strip_channel_response_markers(content))
-    if CHANNEL_THINK_END in text and starts_thinking:
-        reasoning, _, content = text.partition(CHANNEL_THINK_END)
-        return (reasoning or None, _strip_channel_response_markers(content))
-    return None
+    """One rule: the reasoning channel ends at whichever closer comes first.
+
+    This was three branches, and the middle one -- `<|open|>response<|sep|>`
+    with no `<|close|>think<|sep|>` immediately before it -- returned
+    `reasoning=None` and threw away everything ahead of the marker. A single
+    byte between the two markers was enough to reach it, and the chain of
+    thought then appeared in neither field. Silent data loss, not a
+    divergence.
+
+    Gated on `starts_thinking`, which the two other branches were not: these
+    markers only mean anything if a reasoning channel was actually opened.
+    Ungated, any model's answer that *quotes* one had the text before it
+    deleted -- an answer about K3's wire format lost 19 characters on
+    `stream=false` and kept them on `stream=true`. That is the inference
+    `parse_tool_calls` was changed to stop making, in the half that was left
+    still making it; a prompt that opens some *other* dialect's channel can
+    still reach this one, and the structural answer is to resolve the dialect
+    at startup as the tool-call format now is.
+    """
+    if not starts_thinking:
+        return None
+    best_at, best = len(text), None
+    for marker in _CHANNEL_END_MARKERS:
+        at = text.find(marker)
+        if 0 <= at < best_at:
+            best_at, best = at, marker
+    if best is None:
+        return None
+    reasoning = text[:best_at]
+    content = text[best_at + len(best) :]
+    return (reasoning or None, _strip_channel_response_markers(content))
 
 
 # --- Generic <think>...</think> dialect (K2/DeepSeek/Qwen3/MiniMax/...) ---
@@ -195,6 +230,7 @@ DIALECTS: tuple[ReasoningDialect, ...] = (
         prompt_open_marker=CHANNEL_THINK_START,
         output_open_marker=None,  # template-injected; not emitted in output
         think_end_marker=CHANNEL_THINK_END,
+        extra_end_markers=(CHANNEL_RESPONSE_START,),
         split=_split_channel,
         template_efforts=frozenset({"low", "high", "max"}),  # Kimi-K3
     ),

--- a/atom/entrypoints/openai/reasoning_dialects.py
+++ b/atom/entrypoints/openai/reasoning_dialects.py
@@ -83,6 +83,13 @@ class ReasoningDialect:
     # a template states what it taught the model, while an output only
     # exhibits whatever it happens to contain.
     template_markers: tuple[str, ...] = ()
+    # Literals this format wraps every answer in, which are neither the
+    # channel's own delimiters nor any tool format's. Removed from both halves
+    # of the split and dropped by the streaming filter, so the two agree
+    # without either of them depending on which tool-call parser happened to
+    # be resolved -- the tool parser removes the same tokens, and a K3
+    # deployment whose template refused the tools probe has none.
+    content_framing: tuple[str, ...] = ()
     # Every marker that ends the reasoning channel, `think_end_marker`
     # included. A channel format can leave the think channel by *opening*
     # another one, and the streaming filter knew only the explicit close: a
@@ -95,6 +102,11 @@ class ReasoningDialect:
     @property
     def end_markers(self) -> tuple[str, ...]:
         return (self.think_end_marker, *self.extra_end_markers)
+
+    def strip_framing(self, text: str) -> str:
+        for marker in self.content_framing:
+            text = text.replace(marker, "")
+        return text
 
     def taught_by(self, template_source: str) -> bool:
         """Does this template teach the model this dialect?"""
@@ -228,17 +240,27 @@ def _split_think_tag(text: str, starts_thinking: bool = False) -> SplitResult | 
 # so a specific channel marker is tried before the generic <think> tag.
 # separate_reasoning() returns the first dialect whose split() matches. A dialect
 # is identified by its markers/split behavior, not a label.
+_CHANNEL_CONTENT_FRAMING = (
+    CHANNEL_RESPONSE_START,
+    CHANNEL_RESPONSE_END,
+    CHANNEL_MESSAGE_END,
+    CHANNEL_END_OF_MSG,
+)
+
+_CHANNEL_DIALECT = ReasoningDialect(
+    prompt_open_marker=CHANNEL_THINK_START,
+    output_open_marker=None,  # template-injected; not emitted in output
+    think_end_marker=CHANNEL_THINK_END,
+    extra_end_markers=(CHANNEL_RESPONSE_START,),
+    split=_split_channel,
+    template_efforts=frozenset({"low", "high", "max"}),  # Kimi-K3
+    template_markers=(CHANNEL_THINK_START, CHANNEL_THINK_END),
+    content_framing=_CHANNEL_CONTENT_FRAMING,
+)
+
 DIALECTS: tuple[ReasoningDialect, ...] = (
     # Structured channel format — Kimi-K3 token values (see CHANNEL_* above)
-    ReasoningDialect(
-        prompt_open_marker=CHANNEL_THINK_START,
-        output_open_marker=None,  # template-injected; not emitted in output
-        think_end_marker=CHANNEL_THINK_END,
-        extra_end_markers=(CHANNEL_RESPONSE_START,),
-        split=_split_channel,
-        template_efforts=frozenset({"low", "high", "max"}),  # Kimi-K3
-        template_markers=(CHANNEL_THINK_START, CHANNEL_THINK_END),
-    ),
+    _CHANNEL_DIALECT,
     # Generic <think>...</think> (K2/DeepSeek/Qwen3/MiniMax/...)
     ReasoningDialect(
         prompt_open_marker=THINK_OPEN_MARKER,

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -331,6 +331,42 @@ class AnthropicBlocks:
         yield stream_content_block_delta(self.index, text, kind)
 
 
+def tool_event_frames(events, blocks: AnthropicBlocks):
+    """One batch of tool-parser events as Anthropic frames.
+
+    Written out twice in the streaming endpoint, once for `process` and once
+    for `flush`, twenty-two lines each. That is the same hazard
+    :class:`AnthropicBlocks` exists to remove one level up -- two copies of a
+    dispatch means a fix that lands in one of them, and nothing says so.
+
+    A plain generator and not `yield from` at the call site, because the
+    endpoint is an *async* generator and `yield from` is a syntax error inside
+    one. Whether a call started is left to the caller to read off `events`;
+    returning it from a generator would need the `yield from` that cannot be
+    written there.
+    """
+    for etype, edata in events:
+        if etype == "content":
+            yield from blocks.delta("text", edata)
+        elif etype == "tool_call_start":
+            fn = edata.get("function", {})
+            yield from blocks.open(
+                "tool_use",
+                tool_use_id=edata.get("id", ""),
+                tool_name=fn.get("name", ""),
+            )
+        elif etype == "tool_call_args":
+            fn = edata.get("function", {})
+            yield from blocks.delta("tool_use", fn.get("arguments", ""))
+        elif etype == "tool_call_end":
+            yield from blocks.close()
+
+
+def starts_a_tool_call(events) -> bool:
+    """Whether this batch opened a tool call, which is its own `stop_reason`."""
+    return any(etype == "tool_call_start" for etype, _ in events)
+
+
 def stream_content_block_start(
     index: int,
     block_type: str = "text",

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -10,7 +10,7 @@ Anthropic-compatible tools to use ATOM as a backend.
 
 import json
 import logging
-from typing import Any, List, Optional
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -24,14 +24,14 @@ logger = logging.getLogger("atom")
 
 class AnthropicContentBlock(BaseModel):
     type: str
-    text: Optional[str] = None
+    text: str | None = None
     # tool_use fields
-    id: Optional[str] = None
-    name: Optional[str] = None
-    input: Optional[Any] = None
+    id: str | None = None
+    name: str | None = None
+    input: Any | None = None
     # tool_result fields
-    tool_use_id: Optional[str] = None
-    content: Optional[Any] = None
+    tool_use_id: str | None = None
+    content: Any | None = None
 
 
 class AnthropicMessage(BaseModel):
@@ -41,27 +41,27 @@ class AnthropicMessage(BaseModel):
 
 class AnthropicMessagesRequest(BaseModel):
     model: str
-    messages: List[AnthropicMessage]
+    messages: list[AnthropicMessage]
     max_tokens: int = 4096
-    system: Optional[Any] = None  # str or list
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
-    top_k: Optional[int] = None
+    system: Any | None = None  # str or list
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
     stream: bool = False
-    stop_sequences: Optional[List[str]] = None
-    tools: Optional[List[dict]] = None
-    tool_choice: Optional[Any] = None
-    metadata: Optional[dict] = None
-    thinking: Optional[dict] = None  # {"type":"enabled","budget_tokens":N}
+    stop_sequences: list[str] | None = None
+    tools: list[dict] | None = None
+    tool_choice: Any | None = None
+    metadata: dict | None = None
+    thinking: dict | None = None  # {"type":"enabled","budget_tokens":N}
 
 
 # ── Format Conversion ──────────────────────────────────────────────────
 
 
 def anthropic_to_openai_messages(
-    messages: List[AnthropicMessage],
-    system: Optional[Any] = None,
-) -> List[dict]:
+    messages: list[AnthropicMessage],
+    system: Any | None = None,
+) -> list[dict]:
     """Convert Anthropic messages to OpenAI format."""
     result = []
 
@@ -144,7 +144,7 @@ def anthropic_to_openai_messages(
     return result
 
 
-def anthropic_to_openai_tools(tools: Optional[List[dict]]) -> Optional[List[dict]]:
+def anthropic_to_openai_tools(tools: list[dict] | None) -> list[dict] | None:
     """Convert Anthropic tool definitions to OpenAI format."""
     if not tools:
         return None
@@ -170,8 +170,8 @@ def build_anthropic_response(
     request_id: str,
     model: str,
     content_text: str,
-    reasoning_content: Optional[str] = None,
-    tool_calls: Optional[list] = None,
+    reasoning_content: str | None = None,
+    tool_calls: list | None = None,
     input_tokens: int = 0,
     output_tokens: int = 0,
     cache_read_input_tokens: int = 0,

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -307,6 +307,18 @@ class AnthropicBlocks:
     def __init__(self) -> None:
         self.index = 0
         self.kind: str | None = None
+        # What it takes to reopen the tool call in flight: its id and name.
+        # Set when one starts, cleared when it ends, and deliberately NOT
+        # cleared by `close` -- text arriving between a call's name and its
+        # arguments closes the block but does not end the call, and the
+        # arguments still have to find their way back into one.
+        #
+        # Here and not in `tool_event_frames`, which runs once per parser
+        # batch: announcing a name early split those two events across two
+        # batches -- the name from `process`, the arguments from `flush` --
+        # so a local was reset between them and every streamed tool call on
+        # this endpoint reached the client with `input: {}`.
+        self.open_call: dict | None = None
 
     def close(self):
         """End the open block, if any. A thinking block signs off first."""
@@ -323,6 +335,8 @@ class AnthropicBlocks:
         yield from self.close()
         yield stream_content_block_start(self.index, kind, **start_kwargs)
         self.kind = kind
+        if kind == "tool_use":
+            self.open_call = dict(start_kwargs)
 
     def delta(self, kind: str, text: str, **start_kwargs):
         """Emit `text` as `kind`, switching blocks if that is not the open one."""
@@ -344,20 +358,22 @@ def tool_event_frames(events, blocks: AnthropicBlocks):
     one. Whether a call started is left to the caller to read off `events`;
     returning it from a generator would need the `yield from` that cannot be
     written there.
+
+    Which call is open lives on `blocks` and not here, because this runs once
+    per parser batch and one call spans two of them. See `AnthropicBlocks`.
     """
-    open_call: dict | None = None
     for etype, edata in events:
         if etype == "content":
             yield from blocks.delta("text", edata)
         elif etype == "tool_call_start":
             fn = edata.get("function", {})
-            open_call = {
-                "tool_use_id": edata.get("id", ""),
-                "tool_name": fn.get("name", ""),
-            }
-            yield from blocks.open("tool_use", **open_call)
+            yield from blocks.open(
+                "tool_use",
+                tool_use_id=edata.get("id", ""),
+                tool_name=fn.get("name", ""),
+            )
         elif etype == "tool_call_args":
-            if open_call is None:
+            if blocks.open_call is None:
                 # No name and no id to open a block with, so there is no block
                 # to open. `delta` would have started one with both fields
                 # empty -- syntactically a tool_use the client can neither
@@ -367,9 +383,11 @@ def tool_event_frames(events, blocks: AnthropicBlocks):
             fn = edata.get("function", {})
             # The id and name again: `delta` re-opens the block if anything
             # landed in between, and without them it would re-open it blank.
-            yield from blocks.delta("tool_use", fn.get("arguments", ""), **open_call)
+            yield from blocks.delta(
+                "tool_use", fn.get("arguments", ""), **blocks.open_call
+            )
         elif etype == "tool_call_end":
-            open_call = None
+            blocks.open_call = None
             yield from blocks.close()
 
 

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -166,6 +166,50 @@ def anthropic_to_openai_tools(tools: list[dict] | None) -> list[dict] | None:
 # ── Response Construction ──────────────────────────────────────────────
 
 
+def _blocks_in_order(events: list) -> list[dict]:
+    """The engine's events as Anthropic content blocks, in arrival order.
+
+    The streaming path already does this, through `AnthropicBlocks` and
+    `tool_event_frames`. The non-streaming path was given `(content_text,
+    tool_calls)` instead -- the same events with the order thrown away -- and
+    rebuilt one text block ahead of every `tool_use`. So the same generation
+    came back as `['text', 'tool_use', 'tool_use']` unstreamed and
+    `['tool_use', 'text', 'tool_use']` streamed, and a client rendering blocks
+    in order showed the sentence introducing the second call before the first.
+
+    Consecutive content events are joined: they are one run of answer that the
+    engine happened to emit in pieces, and Anthropic has no way to say "two
+    adjacent text blocks" that means anything different.
+    """
+    blocks: list[dict] = []
+    pending: dict | None = None
+    for etype, data in events:
+        if etype == "content":
+            if not data:
+                continue
+            if blocks and blocks[-1]["type"] == "text":
+                blocks[-1]["text"] += data
+            else:
+                blocks.append({"type": "text", "text": data})
+        elif etype == "tool_call_start":
+            pending = {"id": data["id"], "name": data["function"]["name"]}
+        elif etype == "tool_call_args" and pending is not None:
+            try:
+                args = json.loads(data["function"]["arguments"] or "{}")
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+            blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": pending["id"],
+                    "name": pending["name"],
+                    "input": args if isinstance(args, dict) else {},
+                }
+            )
+            pending = None
+    return blocks
+
+
 def build_anthropic_response(
     request_id: str,
     model: str,
@@ -177,6 +221,7 @@ def build_anthropic_response(
     cache_read_input_tokens: int = 0,
     *,
     stop_reason: str,
+    events: list | None = None,
 ) -> dict:
     """Build Anthropic Messages API response.
 
@@ -207,21 +252,26 @@ def build_anthropic_response(
             }
         )
 
+    ordered = _blocks_in_order(events) if events is not None else None
+    if ordered is not None:
+        content.extend(ordered)
     # A text block whenever the reply is not a tool call, even an empty one.
     # The streaming path forces exactly this at the end of a response with no
     # call, so a reply that was nothing but reasoning came back as
     # `['thinking', 'text']` when streamed and `['thinking']` when not --
     # and a client that reads only text blocks got nothing at all from the
     # second.
-    if content_text or not tool_calls:
+    if ordered is None and (content_text or not tool_calls):
         content.append(
             {
                 "type": "text",
                 "text": content_text,
             }
         )
+    elif ordered is not None and not ordered:
+        content.append({"type": "text", "text": ""})
 
-    if tool_calls:
+    if tool_calls and ordered is None:
         # `stop_reason` is the caller's, not this function's. It used to be
         # overwritten here, which threw away the answer
         # `anthropic_stop_reason_with_calls` had already given the call site --

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -175,9 +175,17 @@ def build_anthropic_response(
     input_tokens: int = 0,
     output_tokens: int = 0,
     cache_read_input_tokens: int = 0,
-    stop_reason: str = "end_turn",
+    *,
+    stop_reason: str,
 ) -> dict:
     """Build Anthropic Messages API response.
+
+    ``stop_reason`` has no default, and that is the point: this function used
+    to carry one and then overwrite it whenever `tool_calls` was non-empty, so
+    the answer `anthropic_stop_reason_with_calls` had already given the caller
+    was discarded and a response cut off at `max_tokens` mid-call came back as
+    an ordinary `tool_use`. Two places deciding one thing. Now there is one,
+    and a caller cannot forget to ask it.
 
     Args:
         tool_calls: List of ToolCall objects (from tool_parser.parse_tool_calls).
@@ -214,7 +222,12 @@ def build_anthropic_response(
         )
 
     if tool_calls:
-        stop_reason = "tool_use"
+        # `stop_reason` is the caller's, not this function's. It used to be
+        # overwritten here, which threw away the answer
+        # `anthropic_stop_reason_with_calls` had already given the call site --
+        # so a response cut off at `max_tokens` mid-call came back as an
+        # ordinary `tool_use` with silently truncated arguments, and disagreed
+        # with the streaming path for the same generation.
         for tc in tool_calls:
             # ToolCall has .id, .function["name"], .function["arguments"]
             func = tc.function if isinstance(tc.function, dict) else {}
@@ -509,6 +522,20 @@ def stream_message_delta(stop_reason: str = "end_turn", output_tokens: int = 0) 
             "delta": {"stop_reason": stop_reason, "stop_sequence": None},
             "usage": {"output_tokens": output_tokens},
         },
+    )
+
+
+def stream_error(message: str, error_type: str = "api_error") -> str:
+    """Anthropic's `error` event, for a stream that cannot finish.
+
+    Without one, an exception raised inside the SSE generator ended the
+    response mid-frame: an open content block with no `content_block_stop`, no
+    `message_delta`, no `message_stop` and nothing saying why. An Anthropic
+    SDK client blocks on the unterminated block until its own read timeout
+    rather than surfacing the failure.
+    """
+    return format_sse(
+        "error", {"type": "error", "error": {"type": error_type, "message": message}}
     )
 
 

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -307,17 +307,19 @@ class AnthropicBlocks:
     def __init__(self) -> None:
         self.index = 0
         self.kind: str | None = None
-        # What it takes to reopen the tool call in flight: its id and name.
-        # Set when one starts, cleared when it ends, and deliberately NOT
-        # cleared by `close` -- text arriving between a call's name and its
-        # arguments closes the block but does not end the call, and the
-        # arguments still have to find their way back into one.
+        # The id and name of the open `tool_use` block. Here and not in
+        # `tool_event_frames`, which runs once per parser batch: announcing a
+        # name early splits the two events that describe one call across two
+        # of those batches -- the name from `process`, the arguments from
+        # `flush` -- so a local was reset between them and every streamed
+        # tool call on this endpoint reached the client with `input: {}`.
+        # Nothing closes the block between those two batches, so surviving
+        # them is all that was needed.
         #
-        # Here and not in `tool_event_frames`, which runs once per parser
-        # batch: announcing a name early split those two events across two
-        # batches -- the name from `process`, the arguments from `flush` --
-        # so a local was reset between them and every streamed tool call on
-        # this endpoint reached the client with `input: {}`.
+        # Cleared by `close`, and that matters: carrying it across a close
+        # let `delta` re-open a *second* `tool_use` block with the same id,
+        # so one call arrived as two -- the first with no input, which a
+        # client iterating content blocks runs as a zero-argument call.
         self.open_call: dict | None = None
 
     def close(self):
@@ -329,6 +331,7 @@ class AnthropicBlocks:
         yield stream_content_block_stop(self.index)
         self.index += 1
         self.kind = None
+        self.open_call = None
 
     def open(self, kind: str, **start_kwargs):
         """Start a block of `kind`, closing whatever was open."""
@@ -387,7 +390,6 @@ def tool_event_frames(events, blocks: AnthropicBlocks):
                 "tool_use", fn.get("arguments", ""), **blocks.open_call
             )
         elif etype == "tool_call_end":
-            blocks.open_call = None
             yield from blocks.close()
 
 

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -8,13 +8,18 @@ converts responses back to Anthropic format. Enables Claude Code and other
 Anthropic-compatible tools to use ATOM as a backend.
 """
 
+import base64
+import hashlib
 import json
 import logging
+import os
 from typing import Any
 
 from pydantic import BaseModel
 
+from .reasoning import ReasoningChannel
 from .sse import event_frame
+from .tool_parser import ToolCallStreamParser
 
 logger = logging.getLogger("atom")
 
@@ -166,6 +171,65 @@ def anthropic_to_openai_tools(tools: list[dict] | None) -> list[dict] | None:
 # ── Response Construction ──────────────────────────────────────────────
 
 
+def stream_failure_frames(exc, blocks, output_tokens: int, *, opening: str | None):
+    """Everything a stream that raised still owes the client.
+
+    ``opening`` is the `message_start` frame when the stream never sent one,
+    else ``None``. A failure before the first chunk otherwise produced a
+    stream whose first frame is `message_delta`, and the Anthropic SDK builds
+    its accumulator from `message_start` and raises on anything before it --
+    so the client saw an SDK error rather than the `error` frame this delivers.
+    """
+    if opening is not None:
+        yield opening
+    # Every block this stream opened has to be closed before the terminator.
+    yield from blocks.close()
+    yield stream_error(str(exc))
+    yield stream_message_delta("end_turn", output_tokens)
+    yield stream_message_stop()
+
+
+def _sig() -> str:
+    """The opaque signature Anthropic puts on a thinking block."""
+    return base64.b64encode(hashlib.sha256(os.urandom(32)).digest()).decode()
+
+
+def read_whole_blocks(
+    channel: ReasoningChannel,
+    parser_cls,
+    text: str,
+    tools: list | None = None,
+    *,
+    suppress_calls: bool = False,
+) -> list:
+    """One complete output as ordered events, reasoning included.
+
+    The streaming branch's own loop over a single chunk: the reasoning filter
+    first, the tool parser on the content segments it yields. `split()`
+    returns `(reasoning, content)` and loses the interleaving at that line, so
+    blocks rebuilt from the pair put a whole answer in one block ahead of a
+    `thinking` that belonged in the middle of it -- two blocks where streaming
+    sent three, for the same generation.
+
+    Not Anthropic-specific except that Anthropic is the only endpoint whose
+    wire format has an order to lose; the chat path's fields are flat.
+    """
+    reader = channel.stream()
+    engine = ToolCallStreamParser(
+        tools=tools, parser_cls=parser_cls, suppress_calls=suppress_calls
+    )
+    out: list = []
+    for field, segment in reader.process(text) + reader.flush():
+        if not segment:
+            continue
+        if field == "reasoning_content":
+            out.append(("reasoning", segment))
+        else:
+            out.extend(engine.process(segment))
+    out.extend(engine.flush())
+    return out
+
+
 def _blocks_in_order(events: list) -> list[dict]:
     """The engine's events as Anthropic content blocks, in arrival order.
 
@@ -184,9 +248,11 @@ def _blocks_in_order(events: list) -> list[dict]:
     blocks: list[dict] = []
     pending: dict | None = None
     for etype, data in events:
-        if etype == "content":
-            if not data:
-                continue
+        if not data and etype in ("reasoning", "content"):
+            continue
+        if etype == "reasoning":
+            blocks.append({"type": "thinking", "thinking": data, "signature": _sig()})
+        elif etype == "content":
             if blocks and blocks[-1]["type"] == "text":
                 blocks[-1]["text"] += data
             else:
@@ -194,16 +260,29 @@ def _blocks_in_order(events: list) -> list[dict]:
         elif etype == "tool_call_start":
             pending = {"id": data["id"], "name": data["function"]["name"]}
         elif etype == "tool_call_args" and pending is not None:
+            raw = data["function"]["arguments"] or "{}"
             try:
-                args = json.loads(data["function"]["arguments"] or "{}")
+                args = json.loads(raw)
             except (json.JSONDecodeError, TypeError):
+                # A call cut off mid-arguments. Logged rather than silent, as
+                # SGLang does: the client sees a call with no arguments and
+                # nothing else says why.
+                logger.warning(
+                    "tool call %s: arguments are not JSON, sending {}: %r",
+                    pending["name"],
+                    raw[:120],
+                )
                 args = {}
+            # Whatever decoded, verbatim. Coercing a non-dict to `{}` dropped
+            # a Kimi-K2 call's arguments on `stream=false` alone -- that
+            # format passes the wire bytes through and the streaming path
+            # forwards them for the SDK to accumulate.
             blocks.append(
                 {
                     "type": "tool_use",
                     "id": pending["id"],
                     "name": pending["name"],
-                    "input": args if isinstance(args, dict) else {},
+                    "input": args,
                 }
             )
             pending = None
@@ -213,91 +292,30 @@ def _blocks_in_order(events: list) -> list[dict]:
 def build_anthropic_response(
     request_id: str,
     model: str,
-    content_text: str,
-    reasoning_content: str | None = None,
-    tool_calls: list | None = None,
+    events: list,
     input_tokens: int = 0,
     output_tokens: int = 0,
     cache_read_input_tokens: int = 0,
     *,
     stop_reason: str,
-    events: list | None = None,
 ) -> dict:
-    """Build Anthropic Messages API response.
+    """One response, built from the ordered events and nothing else.
 
-    ``stop_reason`` has no default, and that is the point: this function used
-    to carry one and then overwrite it whenever `tool_calls` was non-empty, so
-    the answer `anthropic_stop_reason_with_calls` had already given the caller
-    was discarded and a response cut off at `max_tokens` mid-call came back as
-    an ordinary `tool_use`. Two places deciding one thing. Now there is one,
-    and a caller cannot forget to ask it.
+    It also took `(content_text, reasoning_content, tool_calls)` and rebuilt
+    the blocks from them, so this file held two tool_use builders and two
+    orderings -- the two-readers shape the rest of this branch exists to
+    delete. It cost what that always costs: reasoning was prepended ahead of
+    everything, so a model that answers, thinks and answers again came back as
+    `[thinking, text]` with the two answers glued together where streaming
+    sent `[text, thinking, text]`.
 
-    Args:
-        tool_calls: List of ToolCall objects (from tool_parser.parse_tool_calls).
-            Each has .name, .arguments (dict), .call_id.
+    `stop_reason` has no default on purpose -- it used to be overwritten here
+    whenever `tool_calls` was non-empty, discarding what
+    `anthropic_stop_reason_with_calls` had already decided.
     """
-    content = []
-
-    if reasoning_content:
-        import base64
-        import hashlib
-        import os
-
-        sig = base64.b64encode(hashlib.sha256(os.urandom(32)).digest()).decode()
-        content.append(
-            {
-                "type": "thinking",
-                "thinking": reasoning_content,
-                "signature": sig,
-            }
-        )
-
-    ordered = _blocks_in_order(events) if events is not None else None
-    if ordered is not None:
-        content.extend(ordered)
-    # A text block whenever the reply is not a tool call, even an empty one.
-    # The streaming path forces exactly this at the end of a response with no
-    # call, so a reply that was nothing but reasoning came back as
-    # `['thinking', 'text']` when streamed and `['thinking']` when not --
-    # and a client that reads only text blocks got nothing at all from the
-    # second.
-    if ordered is None and (content_text or not tool_calls):
-        content.append(
-            {
-                "type": "text",
-                "text": content_text,
-            }
-        )
-    elif ordered is not None and not ordered:
-        content.append({"type": "text", "text": ""})
-
-    if tool_calls and ordered is None:
-        # `stop_reason` is the caller's, not this function's. It used to be
-        # overwritten here, which threw away the answer
-        # `anthropic_stop_reason_with_calls` had already given the call site --
-        # so a response cut off at `max_tokens` mid-call came back as an
-        # ordinary `tool_use` with silently truncated arguments, and disagreed
-        # with the streaming path for the same generation.
-        for tc in tool_calls:
-            # ToolCall has .id, .function["name"], .function["arguments"]
-            func = tc.function if isinstance(tc.function, dict) else {}
-            args_str = func.get("arguments", "{}")
-            try:
-                args = json.loads(args_str) if isinstance(args_str, str) else args_str
-            except (json.JSONDecodeError, TypeError):
-                args = {}
-            content.append(
-                {
-                    "type": "tool_use",
-                    "id": tc.id,
-                    "name": func.get("name", ""),
-                    "input": args,
-                }
-            )
-
-    # Ensure at least one content block
-    if not content:
-        content.append({"type": "text", "text": ""})
+    # A response is never empty: Anthropic has no representation for one, and
+    # the streaming path forces a final text block for the same reason.
+    content = _blocks_in_order(events) or [{"type": "text", "text": ""}]
 
     return {
         "id": f"msg_{request_id}",
@@ -539,11 +557,7 @@ def stream_content_block_delta(index: int, text: str, block_type: str = "text") 
 
 def stream_signature_delta(index: int) -> str:
     """Emit a signature_delta for thinking blocks (required by Claude Code)."""
-    import base64
-    import hashlib
-    import os
-
-    dummy_sig = base64.b64encode(hashlib.sha256(os.urandom(32)).digest()).decode()
+    dummy_sig = _sig()
     return format_sse(
         "content_block_delta",
         {

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -287,6 +287,50 @@ def stream_message_start(
     )
 
 
+class AnthropicBlocks:
+    """One open content block at a time, closed before the next one opens.
+
+    Anthropic frames a response as indexed blocks of a kind -- text, thinking,
+    tool_use -- and a change of kind is a close and an open. Those transitions
+    used to be written out at each of the four places a segment could arrive,
+    each covering the subset its author needed. The one nobody needed,
+    text -> thinking, was missing: a reasoning segment arriving after content
+    had started matched no branch and was dropped, with no error and no log.
+    Measured on a model that answers, opens a `<think>` block and answers
+    again, 29 characters of reasoning went nowhere.
+
+    So the transition is asked for rather than written out: `delta` says which
+    kind this text belongs to and the switching is this class's problem. It
+    cannot silently do nothing, because there is no branch left to fall off.
+    """
+
+    def __init__(self) -> None:
+        self.index = 0
+        self.kind: str | None = None
+
+    def close(self):
+        """End the open block, if any. A thinking block signs off first."""
+        if self.kind is None:
+            return
+        if self.kind == "thinking":
+            yield stream_signature_delta(self.index)
+        yield stream_content_block_stop(self.index)
+        self.index += 1
+        self.kind = None
+
+    def open(self, kind: str, **start_kwargs):
+        """Start a block of `kind`, closing whatever was open."""
+        yield from self.close()
+        yield stream_content_block_start(self.index, kind, **start_kwargs)
+        self.kind = kind
+
+    def delta(self, kind: str, text: str, **start_kwargs):
+        """Emit `text` as `kind`, switching blocks if that is not the open one."""
+        if self.kind != kind:
+            yield from self.open(kind, **start_kwargs)
+        yield stream_content_block_delta(self.index, text, kind)
+
+
 def stream_content_block_start(
     index: int,
     block_type: str = "text",

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -199,7 +199,13 @@ def build_anthropic_response(
             }
         )
 
-    if content_text:
+    # A text block whenever the reply is not a tool call, even an empty one.
+    # The streaming path forces exactly this at the end of a response with no
+    # call, so a reply that was nothing but reasoning came back as
+    # `['thinking', 'text']` when streamed and `['thinking']` when not --
+    # and a client that reads only text blocks got nothing at all from the
+    # second.
+    if content_text or not tool_calls:
         content.append(
             {
                 "type": "text",
@@ -307,20 +313,17 @@ class AnthropicBlocks:
     def __init__(self) -> None:
         self.index = 0
         self.kind: str | None = None
-        # The id and name of the open `tool_use` block. Here and not in
-        # `tool_event_frames`, which runs once per parser batch: announcing a
-        # name early splits the two events that describe one call across two
-        # of those batches -- the name from `process`, the arguments from
-        # `flush` -- so a local was reset between them and every streamed
-        # tool call on this endpoint reached the client with `input: {}`.
-        # Nothing closes the block between those two batches, so surviving
-        # them is all that was needed.
-        #
-        # Cleared by `close`, and that matters: carrying it across a close
-        # let `delta` re-open a *second* `tool_use` block with the same id,
-        # so one call arrived as two -- the first with no input, which a
-        # client iterating content blocks runs as a zero-argument call.
-        self.open_call: dict | None = None
+        # Every call the parser has named, by the index it named it at, and
+        # kept for the life of the response. A call spans two parser batches
+        # -- the name when the region reveals it, the arguments when the
+        # region closes -- and anything at all can arrive in between: a
+        # reasoning segment lands as a `thinking` block, which closes whatever
+        # was open. Held on the open block instead, the id and name were gone
+        # by the time the arguments came and the call reached the client as
+        # `tool_use` with `input: {}`.
+        self.calls: dict[int, dict] = {}
+        # Which call's block is open, so two calls in a row are two blocks.
+        self.open_call_index: int | None = None
 
     def close(self):
         """End the open block, if any. A thinking block signs off first."""
@@ -331,21 +334,49 @@ class AnthropicBlocks:
         yield stream_content_block_stop(self.index)
         self.index += 1
         self.kind = None
-        self.open_call = None
+        self.open_call_index = None
 
     def open(self, kind: str, **start_kwargs):
         """Start a block of `kind`, closing whatever was open."""
         yield from self.close()
         yield stream_content_block_start(self.index, kind, **start_kwargs)
         self.kind = kind
-        if kind == "tool_use":
-            self.open_call = dict(start_kwargs)
 
     def delta(self, kind: str, text: str, **start_kwargs):
         """Emit `text` as `kind`, switching blocks if that is not the open one."""
         if self.kind != kind:
             yield from self.open(kind, **start_kwargs)
         yield stream_content_block_delta(self.index, text, kind)
+
+    def tool_delta(self, index: int, arguments: str):
+        """Arguments for the call named at ``index``, opening its block.
+
+        The block is opened *here*, when the arguments arrive, and not when
+        the name did. On this protocol a `content_block_start` of type
+        `tool_use` already carries `"input": {}` and is, on its own, a
+        complete zero-argument call -- there is no frame for "the name is
+        known, the arguments are still coming". So a name sent before its
+        arguments cannot be represented, and sending one anyway put a
+        syntactically perfect call the model never made in front of the
+        client: measured on a DeepSeek-V4 response containing two calls,
+        which reached `/v1/messages` as three.
+
+        OpenAI's wire has the same shape -- a `tool_calls` delta with
+        `arguments: ""` -- and is safe with it, because a client there
+        accumulates by index and waits for `finish_reason`. That is why the
+        name still goes out early on the other endpoint and not on this one.
+        """
+        call = self.calls.get(index)
+        if call is None:
+            # Arguments for a call whose name never came. There is nothing to
+            # open a block with, and opening one with empty fields would be a
+            # `tool_use` the client can neither dispatch nor return a result
+            # for. A parser bug; dropping the frame is the only honest option.
+            return
+        if self.kind != "tool_use" or self.open_call_index != index:
+            yield from self.open("tool_use", **call)
+            self.open_call_index = index
+        yield stream_content_block_delta(self.index, arguments, "tool_use")
 
 
 def tool_event_frames(events, blocks: AnthropicBlocks):
@@ -369,25 +400,16 @@ def tool_event_frames(events, blocks: AnthropicBlocks):
         if etype == "content":
             yield from blocks.delta("text", edata)
         elif etype == "tool_call_start":
+            # Recorded, not sent. See `AnthropicBlocks.tool_delta` for why a
+            # name on its own cannot be put on this wire.
             fn = edata.get("function", {})
-            yield from blocks.open(
-                "tool_use",
-                tool_use_id=edata.get("id", ""),
-                tool_name=fn.get("name", ""),
-            )
+            blocks.calls[edata.get("index", 0)] = {
+                "tool_use_id": edata.get("id", ""),
+                "tool_name": fn.get("name", ""),
+            }
         elif etype == "tool_call_args":
-            if blocks.open_call is None:
-                # No name and no id to open a block with, so there is no block
-                # to open. `delta` would have started one with both fields
-                # empty -- syntactically a tool_use the client can neither
-                # dispatch nor return a result for. Arguments with no call are
-                # a parser bug; dropping them is the only honest frame.
-                continue
-            fn = edata.get("function", {})
-            # The id and name again: `delta` re-opens the block if anything
-            # landed in between, and without them it would re-open it blank.
-            yield from blocks.delta(
-                "tool_use", fn.get("arguments", ""), **blocks.open_call
+            yield from blocks.tool_delta(
+                edata.get("index", 0), edata.get("function", {}).get("arguments", "")
             )
         elif etype == "tool_call_end":
             yield from blocks.close()

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -362,9 +362,19 @@ def tool_event_frames(events, blocks: AnthropicBlocks):
             yield from blocks.close()
 
 
-def starts_a_tool_call(events) -> bool:
-    """Whether this batch opened a tool call, which is its own `stop_reason`."""
-    return any(etype == "tool_call_start" for etype, _ in events)
+def completes_a_tool_call(events) -> bool:
+    """Whether this batch produced a *usable* tool call.
+
+    Keyed on the arguments and not the name, which is what makes announcing a
+    name early safe. A name can be sent before the call is known to close --
+    the point of announcing it -- so a response truncated at `max_tokens`
+    mid-call has sent a name and nothing else. Reporting `tool_use` there
+    would tell the client to run a tool whose arguments never arrived.
+
+    Every parser emits name and arguments together unless it announced early,
+    so this reads the same as the name for every format that does not.
+    """
+    return any(etype == "tool_call_args" for etype, _ in events)
 
 
 def stream_content_block_start(

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -345,20 +345,31 @@ def tool_event_frames(events, blocks: AnthropicBlocks):
     returning it from a generator would need the `yield from` that cannot be
     written there.
     """
+    open_call: dict | None = None
     for etype, edata in events:
         if etype == "content":
             yield from blocks.delta("text", edata)
         elif etype == "tool_call_start":
             fn = edata.get("function", {})
-            yield from blocks.open(
-                "tool_use",
-                tool_use_id=edata.get("id", ""),
-                tool_name=fn.get("name", ""),
-            )
+            open_call = {
+                "tool_use_id": edata.get("id", ""),
+                "tool_name": fn.get("name", ""),
+            }
+            yield from blocks.open("tool_use", **open_call)
         elif etype == "tool_call_args":
+            if open_call is None:
+                # No name and no id to open a block with, so there is no block
+                # to open. `delta` would have started one with both fields
+                # empty -- syntactically a tool_use the client can neither
+                # dispatch nor return a result for. Arguments with no call are
+                # a parser bug; dropping them is the only honest frame.
+                continue
             fn = edata.get("function", {})
-            yield from blocks.delta("tool_use", fn.get("arguments", ""))
+            # The id and name again: `delta` re-opens the block if anything
+            # landed in between, and without them it would re-open it blank.
+            yield from blocks.delta("tool_use", fn.get("arguments", ""), **open_call)
         elif etype == "tool_call_end":
+            open_call = None
             yield from blocks.close()
 
 

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -24,6 +24,7 @@ from .reasoning import (
 from .sse import data_frame
 from .streaming_dispatch import StreamOutputCollector
 from .tool_parser import ToolCallStreamParser, parse_tool_calls
+from .tool_parser.registry import parser_for_tool_choice
 
 logger = logging.getLogger("atom")
 
@@ -250,7 +251,9 @@ async def stream_chat_response(
     num_tokens_output = 0
     num_cached_tokens = 0
     reasoning_filter = ReasoningFilter(starts_thinking=starts_thinking)
-    tool_parser = ToolCallStreamParser(tools=tools, parser_cls=tool_parser_cls)
+    tool_parser = ToolCallStreamParser(
+        tools=tools, parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice)
+    )
     has_tool_calls = False
 
     kv_transfer_params_value = None
@@ -298,13 +301,13 @@ async def stream_chat_response(
                             yield create_chat_chunk(
                                 request_id, model, delta={"content": data}
                             )
-                        elif event_type == "tool_call_start" and tool_choice != "none":
+                        elif event_type == "tool_call_start":
                             yield create_chat_chunk(
                                 request_id,
                                 model,
                                 delta={"tool_calls": [data]},
                             )
-                        elif event_type == "tool_call_args" and tool_choice != "none":
+                        elif event_type == "tool_call_args":
                             has_tool_calls = True
                             yield create_chat_chunk(
                                 request_id,
@@ -319,11 +322,11 @@ async def stream_chat_response(
                         yield create_chat_chunk(
                             request_id, model, delta={"content": data}
                         )
-                    elif event_type == "tool_call_start" and tool_choice != "none":
+                    elif event_type == "tool_call_start":
                         yield create_chat_chunk(
                             request_id, model, delta={"tool_calls": [data]}
                         )
-                    elif event_type == "tool_call_args" and tool_choice != "none":
+                    elif event_type == "tool_call_args":
                         has_tool_calls = True
                         yield create_chat_chunk(
                             request_id, model, delta={"tool_calls": [data]}
@@ -382,13 +385,10 @@ def _build_chat_choice(
         raw_text, starts_thinking=starts_thinking
     )
     content, tool_calls = parse_tool_calls(
-        content_with_tools, tools, parser_cls=tool_parser_cls
+        content_with_tools,
+        tools,
+        parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice),
     )
-
-    # tool_choice="none" forbids tool calls: any the model emitted anyway are
-    # dropped so they never surface in the response.
-    if tool_choice == "none":
-        tool_calls = []
 
     message: dict[str, Any] = {"role": "assistant", "content": content}
     if reasoning_content is not None:
@@ -544,7 +544,10 @@ async def stream_chat_response_fanout(
         ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
     ]
     tool_parsers = [
-        ToolCallStreamParser(tools=tools, parser_cls=tool_parser_cls) for _ in range(n)
+        ToolCallStreamParser(
+            tools=tools, parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice)
+        )
+        for _ in range(n)
     ]
     has_tool_calls = [False] * n
     finished = [False] * n
@@ -600,14 +603,14 @@ async def stream_chat_response_fanout(
                             yield create_chat_chunk(
                                 request_id, model, delta={"content": data}, index=idx
                             )
-                        elif event_type == "tool_call_start" and tool_choice != "none":
+                        elif event_type == "tool_call_start":
                             yield create_chat_chunk(
                                 request_id,
                                 model,
                                 delta={"tool_calls": [data]},
                                 index=idx,
                             )
-                        elif event_type == "tool_call_args" and tool_choice != "none":
+                        elif event_type == "tool_call_args":
                             has_tool_calls[idx] = True
                             yield create_chat_chunk(
                                 request_id,
@@ -622,14 +625,14 @@ async def stream_chat_response_fanout(
                         yield create_chat_chunk(
                             request_id, model, delta={"content": data}, index=idx
                         )
-                    elif event_type == "tool_call_start" and tool_choice != "none":
+                    elif event_type == "tool_call_start":
                         yield create_chat_chunk(
                             request_id,
                             model,
                             delta={"tool_calls": [data]},
                             index=idx,
                         )
-                    elif event_type == "tool_call_args" and tool_choice != "none":
+                    elif event_type == "tool_call_args":
                         has_tool_calls[idx] = True
                         yield create_chat_chunk(
                             request_id,

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -15,6 +15,7 @@ from .protocol import (
     TOOL_NAME_RE,
     ChatCompletionRequest,
     ChatCompletionResponse,
+    openai_stop_reason_with_calls,
 )
 from .reasoning import (
     NO_REASONING,
@@ -180,43 +181,6 @@ def validate_chat_request(request: ChatCompletionRequest) -> None:
                 raise ValueError("response_format.json_schema.schema must be an object")
 
 
-def _normalize_finish_reason(finish_reason: str | None) -> str | None:
-    """Map engine finish reasons to the OpenAI-standard vocabulary.
-
-    The engine may report an EOS stop as ``"stop_<token_id>"`` (the raw id of
-    the stop token that fired, e.g. ``"stop_163586"``). OpenAI clients only
-    understand ``"stop"``/``"length"``/``"tool_calls"``, so anything that is
-    not a recognized value collapses to ``"stop"``.
-    """
-    if finish_reason is None:
-        return None
-    if finish_reason in ("stop", "length", "tool_calls"):
-        return finish_reason
-    if finish_reason in ("max_tokens", "max_new_tokens"):
-        return "length"
-    if finish_reason.startswith("stop"):
-        return "stop"
-    return "stop"
-
-
-def finish_reason_with_calls(engine_reason: str | None, has_calls: bool) -> str:
-    """The reason to report when a call was parsed and the engine had its own.
-
-    `length` outranks `tool_calls`, because they answer different questions
-    and only one of them is a warning: `tool_calls` says "act on this", and
-    `length` says "this is not all of it". A response cut off mid-call parses
-    to a call with a silently truncated argument value -- every format's
-    unclosed-region branch exists to salvage exactly that -- and reporting
-    `tool_calls` for it told the client to run a tool with half its arguments
-    and no indication anything was missing. OpenAI reports `length` for a
-    truncated response whatever else is in it.
-    """
-    normalized = _normalize_finish_reason(engine_reason)
-    if normalized == "length":
-        return "length"
-    return "tool_calls" if has_calls else (normalized or "stop")
-
-
 def create_chat_chunk(
     request_id: str,
     model: str,
@@ -372,7 +336,9 @@ async def stream_chat_response(
         aborted = False
 
         # Final chunks
-        finish_reason = finish_reason_with_calls(engine_finish_reason, has_tool_calls)
+        finish_reason = openai_stop_reason_with_calls(
+            engine_finish_reason, has_tool_calls
+        )
         usage = {
             "prompt_tokens": num_tokens_input,
             "completion_tokens": num_tokens_output,
@@ -436,7 +402,7 @@ def _build_chat_choice(
     # reason. A truthiness test reported `finish_reason: null` for it, which an
     # OpenAI client reads as "still in progress" and some SDKs raise on.
     effective_finish_reason = (
-        finish_reason_with_calls(finish_reason, bool(tool_calls))
+        openai_stop_reason_with_calls(finish_reason, bool(tool_calls))
         if (tool_calls or finish_reason is not None)
         else None
     )
@@ -712,7 +678,7 @@ async def stream_chat_response_fanout(
                 create_chat_chunk(
                     request_id,
                     model,
-                    finish_reason=finish_reason_with_calls(
+                    finish_reason=openai_stop_reason_with_calls(
                         engine_finish_reasons[i], has_tool_calls[i]
                     ),
                     index=i,

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -299,13 +299,13 @@ async def stream_chat_response(
                                 request_id, model, delta={"content": data}
                             )
                         elif event_type == "tool_call_start" and tool_choice != "none":
-                            has_tool_calls = True
                             yield create_chat_chunk(
                                 request_id,
                                 model,
                                 delta={"tool_calls": [data]},
                             )
                         elif event_type == "tool_call_args" and tool_choice != "none":
+                            has_tool_calls = True
                             yield create_chat_chunk(
                                 request_id,
                                 model,
@@ -320,11 +320,11 @@ async def stream_chat_response(
                             request_id, model, delta={"content": data}
                         )
                     elif event_type == "tool_call_start" and tool_choice != "none":
-                        has_tool_calls = True
                         yield create_chat_chunk(
                             request_id, model, delta={"tool_calls": [data]}
                         )
                     elif event_type == "tool_call_args" and tool_choice != "none":
+                        has_tool_calls = True
                         yield create_chat_chunk(
                             request_id, model, delta={"tool_calls": [data]}
                         )
@@ -601,7 +601,6 @@ async def stream_chat_response_fanout(
                                 request_id, model, delta={"content": data}, index=idx
                             )
                         elif event_type == "tool_call_start" and tool_choice != "none":
-                            has_tool_calls[idx] = True
                             yield create_chat_chunk(
                                 request_id,
                                 model,
@@ -609,6 +608,7 @@ async def stream_chat_response_fanout(
                                 index=idx,
                             )
                         elif event_type == "tool_call_args" and tool_choice != "none":
+                            has_tool_calls[idx] = True
                             yield create_chat_chunk(
                                 request_id,
                                 model,
@@ -623,7 +623,6 @@ async def stream_chat_response_fanout(
                             request_id, model, delta={"content": data}, index=idx
                         )
                     elif event_type == "tool_call_start" and tool_choice != "none":
-                        has_tool_calls[idx] = True
                         yield create_chat_chunk(
                             request_id,
                             model,
@@ -631,6 +630,7 @@ async def stream_chat_response_fanout(
                             index=idx,
                         )
                     elif event_type == "tool_call_args" and tool_choice != "none":
+                        has_tool_calls[idx] = True
                         yield create_chat_chunk(
                             request_id,
                             model,

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -68,18 +68,26 @@ def normalize_chat_tools(tools: Any) -> Any:
     return normalized
 
 
-def resolve_thinking(request: ChatCompletionRequest) -> tuple[bool, str | None]:
+def resolve_thinking(request: ChatCompletionRequest) -> tuple[bool | None, str | None]:
     """Resolve (enabled, effort) from the request's thinking / reasoning_effort.
 
     ``thinking`` (extra_body) takes precedence over ``reasoning_effort``.
     Thinking is disabled when ``thinking.type == "disabled"`` or
     ``reasoning_effort == "none"``. Effort is only returned when it is one of
     the values the template understands.
+
+    ``enabled`` is ``None`` when the request stated no preference -- setting
+    an effort is not asking for reasoning to be switched *on*. Collapsing
+    that to ``True`` was harmless while the caller wrote a key no template
+    read; once it wrote the template's real switch, a request carrying only
+    `reasoning_effort` re-enabled reasoning over an operator's
+    `--default-chat-template-kwargs '{"enable_thinking": false}'`, and over a
+    client's own `chat_template_kwargs`, because the toggle is merged last.
     """
     thinking = request.thinking or {}
-    enabled = True
-    if isinstance(thinking, dict) and thinking.get("type") == "disabled":
-        enabled = False
+    enabled: bool | None = None
+    if isinstance(thinking, dict) and thinking.get("type") is not None:
+        enabled = thinking.get("type") != "disabled"
     if request.reasoning_effort == "none":
         enabled = False
 
@@ -250,6 +258,12 @@ async def stream_chat_response(
     num_tokens_input = num_prompt_tokens
     num_tokens_output = 0
     num_cached_tokens = 0
+    # The engine's own reason, kept so the final chunk can report it. The
+    # streaming paths hardcoded `stop`, so a response the engine cut off at
+    # `max_tokens` was reported as complete while `stream=false` reported
+    # `length` for the same generation -- and a `stop_<token_id>` stop, which
+    # the Anthropic path maps to `stop_sequence`, collapsed the same way.
+    engine_finish_reason: str | None = None
     reasoning_filter = ReasoningFilter(starts_thinking=starts_thinking)
     tool_parser = ToolCallStreamParser(
         tools=tools, parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice)
@@ -273,6 +287,8 @@ async def stream_chat_response(
                 )
                 role_sent = True
             new_text = chunk_data["text"]
+            if chunk_data.get("finish_reason"):
+                engine_finish_reason = chunk_data["finish_reason"]
             num_tokens_output += len(chunk_data.get("token_ids", []))
             _ct = chunk_data.get("num_cached_tokens", 0)
             if _ct:
@@ -336,7 +352,11 @@ async def stream_chat_response(
         aborted = False
 
         # Final chunks
-        finish_reason = "tool_calls" if has_tool_calls else "stop"
+        finish_reason = (
+            "tool_calls"
+            if has_tool_calls
+            else (_normalize_finish_reason(engine_finish_reason) or "stop")
+        )
         usage = {
             "prompt_tokens": num_tokens_input,
             "completion_tokens": num_tokens_output,
@@ -550,6 +570,8 @@ async def stream_chat_response_fanout(
         for _ in range(n)
     ]
     has_tool_calls = [False] * n
+    # See the single-choice path: the engine's reason, per sibling.
+    engine_finish_reasons: list[str | None] = [None] * n
     finished = [False] * n
     kv_transfer_params_value = None
     num_cached_tokens = 0
@@ -576,6 +598,8 @@ async def stream_chat_response_fanout(
                 # Defensive: should not happen, engine emits finished once per seq.
                 continue
             new_text = chunk_data["text"]
+            if chunk_data.get("finish_reason"):
+                engine_finish_reasons[idx] = chunk_data["finish_reason"]
             num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
             _ct = chunk_data.get("num_cached_tokens", 0)
             if _ct:
@@ -667,7 +691,13 @@ async def stream_chat_response_fanout(
                 create_chat_chunk(
                     request_id,
                     model,
-                    finish_reason="tool_calls" if has_tool_calls[i] else "stop",
+                    finish_reason=(
+                        "tool_calls"
+                        if has_tool_calls[i]
+                        else (
+                            _normalize_finish_reason(engine_finish_reasons[i]) or "stop"
+                        )
+                    ),
                     index=i,
                 )
                 for i in range(n)

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -431,9 +431,13 @@ def _build_chat_choice(
     if tool_calls:
         message["tool_calls"] = [tc.to_dict() for tc in tool_calls]
 
+    # `is not None`, not truthiness: `""` is `Sequence.leave_reason`'s initial
+    # value and what the engine forwards for a response with no recorded
+    # reason. A truthiness test reported `finish_reason: null` for it, which an
+    # OpenAI client reads as "still in progress" and some SDKs raise on.
     effective_finish_reason = (
         finish_reason_with_calls(finish_reason, bool(tool_calls))
-        if (tool_calls or finish_reason)
+        if (tool_calls or finish_reason is not None)
         else None
     )
     return {

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -368,6 +368,7 @@ def _build_chat_choice(
     index: int = 0,
     tools=None,
     tool_choice=None,
+    starts_thinking: bool = False,
 ) -> dict[str, Any]:
     """Build one entry of ``choices[...]`` from a raw output string.
 
@@ -375,7 +376,9 @@ def _build_chat_choice(
     (SamplingParams.n>1) can reuse the reasoning + tool-call separation
     without duplicating the logic.
     """
-    reasoning_content, content_with_tools = separate_reasoning(raw_text)
+    reasoning_content, content_with_tools = separate_reasoning(
+        raw_text, starts_thinking=starts_thinking
+    )
     content, tool_calls = parse_tool_calls(content_with_tools, tools)
 
     # tool_choice="none" forbids tool calls: any the model emitted anyway are
@@ -406,6 +409,7 @@ def build_chat_response(
     final_output: dict[str, Any],
     tools=None,
     tool_choice=None,
+    starts_thinking: bool = False,
 ) -> ChatCompletionResponse:
     """Build a non-streaming chat completion response (single choice)."""
     response = ChatCompletionResponse(
@@ -419,6 +423,7 @@ def build_chat_response(
                 index=0,
                 tools=tools,
                 tool_choice=tool_choice,
+                starts_thinking=starts_thinking,
             )
         ],
         usage={
@@ -449,6 +454,7 @@ def build_chat_response_multi(
     final_outputs: list[dict[str, Any]],
     tools=None,
     tool_choice=None,
+    starts_thinking: bool = False,
 ) -> ChatCompletionResponse:
     """Build a non-streaming response with one choice per fan-out sibling.
 
@@ -466,6 +472,7 @@ def build_chat_response_multi(
             index=i,
             tools=tools,
             tool_choice=tool_choice,
+            starts_thinking=starts_thinking,
         )
         for i, out in enumerate(final_outputs)
     ]
@@ -506,6 +513,8 @@ async def stream_chat_response_fanout(
     cleanup_stream,
     cleanup_request,
     tools=None,
+    tool_choice=None,
+    starts_thinking: bool = False,
 ) -> AsyncGenerator[str, None]:
     """Streaming variant that multiplexes ``len(seq_ids)`` fan-out siblings
     into a single SSE stream, tagging every chunk with ``choices[0].index``.
@@ -521,7 +530,10 @@ async def stream_chat_response_fanout(
     n = len(seq_ids)
     num_tokens_input = num_prompt_tokens
     num_tokens_output = [0] * n
-    reasoning_filters = [ReasoningFilter() for _ in range(n)]
+    # Every sibling answers the same prompt, so they start in the same state.
+    reasoning_filters = [
+        ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
+    ]
     tool_parsers = [ToolCallStreamParser(tools=tools) for _ in range(n)]
     has_tool_calls = [False] * n
     finished = [False] * n
@@ -577,7 +589,7 @@ async def stream_chat_response_fanout(
                             yield create_chat_chunk(
                                 request_id, model, delta={"content": data}, index=idx
                             )
-                        elif event_type == "tool_call_start":
+                        elif event_type == "tool_call_start" and tool_choice != "none":
                             has_tool_calls[idx] = True
                             yield create_chat_chunk(
                                 request_id,
@@ -585,7 +597,7 @@ async def stream_chat_response_fanout(
                                 delta={"tool_calls": [data]},
                                 index=idx,
                             )
-                        elif event_type == "tool_call_args":
+                        elif event_type == "tool_call_args" and tool_choice != "none":
                             yield create_chat_chunk(
                                 request_id,
                                 model,
@@ -599,7 +611,7 @@ async def stream_chat_response_fanout(
                         yield create_chat_chunk(
                             request_id, model, delta={"content": data}, index=idx
                         )
-                    elif event_type == "tool_call_start":
+                    elif event_type == "tool_call_start" and tool_choice != "none":
                         has_tool_calls[idx] = True
                         yield create_chat_chunk(
                             request_id,
@@ -607,7 +619,7 @@ async def stream_chat_response_fanout(
                             delta={"tool_calls": [data]},
                             index=idx,
                         )
-                    elif event_type == "tool_call_args":
+                    elif event_type == "tool_call_args" and tool_choice != "none":
                         yield create_chat_chunk(
                             request_id,
                             model,

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -233,6 +233,7 @@ async def stream_chat_response(
     tools=None,
     tool_choice=None,
     starts_thinking: bool = False,
+    tool_parser_cls=None,
 ) -> AsyncGenerator[str, None]:
     """Generate streaming chat completion response with reasoning and tool calls.
 
@@ -249,7 +250,7 @@ async def stream_chat_response(
     num_tokens_output = 0
     num_cached_tokens = 0
     reasoning_filter = ReasoningFilter(starts_thinking=starts_thinking)
-    tool_parser = ToolCallStreamParser(tools=tools)
+    tool_parser = ToolCallStreamParser(tools=tools, parser_cls=tool_parser_cls)
     has_tool_calls = False
 
     kv_transfer_params_value = None
@@ -369,6 +370,7 @@ def _build_chat_choice(
     tools=None,
     tool_choice=None,
     starts_thinking: bool = False,
+    tool_parser_cls=None,
 ) -> dict[str, Any]:
     """Build one entry of ``choices[...]`` from a raw output string.
 
@@ -379,7 +381,9 @@ def _build_chat_choice(
     reasoning_content, content_with_tools = separate_reasoning(
         raw_text, starts_thinking=starts_thinking
     )
-    content, tool_calls = parse_tool_calls(content_with_tools, tools)
+    content, tool_calls = parse_tool_calls(
+        content_with_tools, tools, parser_cls=tool_parser_cls
+    )
 
     # tool_choice="none" forbids tool calls: any the model emitted anyway are
     # dropped so they never surface in the response.
@@ -410,6 +414,7 @@ def build_chat_response(
     tools=None,
     tool_choice=None,
     starts_thinking: bool = False,
+    tool_parser_cls=None,
 ) -> ChatCompletionResponse:
     """Build a non-streaming chat completion response (single choice)."""
     response = ChatCompletionResponse(
@@ -424,6 +429,7 @@ def build_chat_response(
                 tools=tools,
                 tool_choice=tool_choice,
                 starts_thinking=starts_thinking,
+                tool_parser_cls=tool_parser_cls,
             )
         ],
         usage={
@@ -455,6 +461,7 @@ def build_chat_response_multi(
     tools=None,
     tool_choice=None,
     starts_thinking: bool = False,
+    tool_parser_cls=None,
 ) -> ChatCompletionResponse:
     """Build a non-streaming response with one choice per fan-out sibling.
 
@@ -473,6 +480,7 @@ def build_chat_response_multi(
             tools=tools,
             tool_choice=tool_choice,
             starts_thinking=starts_thinking,
+            tool_parser_cls=tool_parser_cls,
         )
         for i, out in enumerate(final_outputs)
     ]
@@ -515,6 +523,7 @@ async def stream_chat_response_fanout(
     tools=None,
     tool_choice=None,
     starts_thinking: bool = False,
+    tool_parser_cls=None,
 ) -> AsyncGenerator[str, None]:
     """Streaming variant that multiplexes ``len(seq_ids)`` fan-out siblings
     into a single SSE stream, tagging every chunk with ``choices[0].index``.
@@ -534,7 +543,9 @@ async def stream_chat_response_fanout(
     reasoning_filters = [
         ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
     ]
-    tool_parsers = [ToolCallStreamParser(tools=tools) for _ in range(n)]
+    tool_parsers = [
+        ToolCallStreamParser(tools=tools, parser_cls=tool_parser_cls) for _ in range(n)
+    ]
     has_tool_calls = [False] * n
     finished = [False] * n
     kv_transfer_params_value = None

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -17,14 +17,14 @@ from .protocol import (
     ChatCompletionResponse,
 )
 from .reasoning import (
+    NO_REASONING,
     VALID_TEMPLATE_EFFORTS,
-    ReasoningFilter,
-    separate_reasoning,
+    ReasoningChannel,
 )
 from .sse import data_frame
 from .streaming_dispatch import StreamOutputCollector
 from .tool_parser import ToolCallStreamParser, parse_tool_calls
-from .tool_parser.registry import parser_for_tool_choice
+from .tool_parser.registry import forbids_tool_calls
 
 logger = logging.getLogger("atom")
 
@@ -199,6 +199,24 @@ def _normalize_finish_reason(finish_reason: str | None) -> str | None:
     return "stop"
 
 
+def finish_reason_with_calls(engine_reason: str | None, has_calls: bool) -> str:
+    """The reason to report when a call was parsed and the engine had its own.
+
+    `length` outranks `tool_calls`, because they answer different questions
+    and only one of them is a warning: `tool_calls` says "act on this", and
+    `length` says "this is not all of it". A response cut off mid-call parses
+    to a call with a silently truncated argument value -- every format's
+    unclosed-region branch exists to salvage exactly that -- and reporting
+    `tool_calls` for it told the client to run a tool with half its arguments
+    and no indication anything was missing. OpenAI reports `length` for a
+    truncated response whatever else is in it.
+    """
+    normalized = _normalize_finish_reason(engine_reason)
+    if normalized == "length":
+        return "length"
+    return "tool_calls" if has_calls else (normalized or "stop")
+
+
 def create_chat_chunk(
     request_id: str,
     model: str,
@@ -241,7 +259,7 @@ async def stream_chat_response(
     cleanup_request,
     tools=None,
     tool_choice=None,
-    starts_thinking: bool = False,
+    reasoning: ReasoningChannel = NO_REASONING,
     tool_parser_cls=None,
 ) -> AsyncGenerator[str, None]:
     """Generate streaming chat completion response with reasoning and tool calls.
@@ -264,9 +282,11 @@ async def stream_chat_response(
     # `length` for the same generation -- and a `stop_<token_id>` stop, which
     # the Anthropic path maps to `stop_sequence`, collapsed the same way.
     engine_finish_reason: str | None = None
-    reasoning_filter = ReasoningFilter(starts_thinking=starts_thinking)
+    reasoning_filter = reasoning.stream()
     tool_parser = ToolCallStreamParser(
-        tools=tools, parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice)
+        tools=tools,
+        parser_cls=tool_parser_cls,
+        suppress_calls=forbids_tool_calls(tool_choice),
     )
     has_tool_calls = False
 
@@ -352,11 +372,7 @@ async def stream_chat_response(
         aborted = False
 
         # Final chunks
-        finish_reason = (
-            "tool_calls"
-            if has_tool_calls
-            else (_normalize_finish_reason(engine_finish_reason) or "stop")
-        )
+        finish_reason = finish_reason_with_calls(engine_finish_reason, has_tool_calls)
         usage = {
             "prompt_tokens": num_tokens_input,
             "completion_tokens": num_tokens_output,
@@ -392,7 +408,7 @@ def _build_chat_choice(
     index: int = 0,
     tools=None,
     tool_choice=None,
-    starts_thinking: bool = False,
+    reasoning: ReasoningChannel = NO_REASONING,
     tool_parser_cls=None,
 ) -> dict[str, Any]:
     """Build one entry of ``choices[...]`` from a raw output string.
@@ -401,13 +417,12 @@ def _build_chat_choice(
     (SamplingParams.n>1) can reuse the reasoning + tool-call separation
     without duplicating the logic.
     """
-    reasoning_content, content_with_tools = separate_reasoning(
-        raw_text, starts_thinking=starts_thinking
-    )
+    reasoning_content, content_with_tools = reasoning.split(raw_text)
     content, tool_calls = parse_tool_calls(
         content_with_tools,
         tools,
-        parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice),
+        parser_cls=tool_parser_cls,
+        suppress_calls=forbids_tool_calls(tool_choice),
     )
 
     message: dict[str, Any] = {"role": "assistant", "content": content}
@@ -417,7 +432,9 @@ def _build_chat_choice(
         message["tool_calls"] = [tc.to_dict() for tc in tool_calls]
 
     effective_finish_reason = (
-        "tool_calls" if tool_calls else _normalize_finish_reason(finish_reason)
+        finish_reason_with_calls(finish_reason, bool(tool_calls))
+        if (tool_calls or finish_reason)
+        else None
     )
     return {
         "index": index,
@@ -433,7 +450,7 @@ def build_chat_response(
     final_output: dict[str, Any],
     tools=None,
     tool_choice=None,
-    starts_thinking: bool = False,
+    reasoning: ReasoningChannel = NO_REASONING,
     tool_parser_cls=None,
 ) -> ChatCompletionResponse:
     """Build a non-streaming chat completion response (single choice)."""
@@ -448,7 +465,7 @@ def build_chat_response(
                 index=0,
                 tools=tools,
                 tool_choice=tool_choice,
-                starts_thinking=starts_thinking,
+                reasoning=reasoning,
                 tool_parser_cls=tool_parser_cls,
             )
         ],
@@ -480,7 +497,7 @@ def build_chat_response_multi(
     final_outputs: list[dict[str, Any]],
     tools=None,
     tool_choice=None,
-    starts_thinking: bool = False,
+    reasoning: ReasoningChannel = NO_REASONING,
     tool_parser_cls=None,
 ) -> ChatCompletionResponse:
     """Build a non-streaming response with one choice per fan-out sibling.
@@ -499,7 +516,7 @@ def build_chat_response_multi(
             index=i,
             tools=tools,
             tool_choice=tool_choice,
-            starts_thinking=starts_thinking,
+            reasoning=reasoning,
             tool_parser_cls=tool_parser_cls,
         )
         for i, out in enumerate(final_outputs)
@@ -542,7 +559,7 @@ async def stream_chat_response_fanout(
     cleanup_request,
     tools=None,
     tool_choice=None,
-    starts_thinking: bool = False,
+    reasoning: ReasoningChannel = NO_REASONING,
     tool_parser_cls=None,
 ) -> AsyncGenerator[str, None]:
     """Streaming variant that multiplexes ``len(seq_ids)`` fan-out siblings
@@ -560,12 +577,12 @@ async def stream_chat_response_fanout(
     num_tokens_input = num_prompt_tokens
     num_tokens_output = [0] * n
     # Every sibling answers the same prompt, so they start in the same state.
-    reasoning_filters = [
-        ReasoningFilter(starts_thinking=starts_thinking) for _ in range(n)
-    ]
+    reasoning_filters = [reasoning.stream() for _ in range(n)]
     tool_parsers = [
         ToolCallStreamParser(
-            tools=tools, parser_cls=parser_for_tool_choice(tool_parser_cls, tool_choice)
+            tools=tools,
+            parser_cls=tool_parser_cls,
+            suppress_calls=forbids_tool_calls(tool_choice),
         )
         for _ in range(n)
     ]
@@ -691,12 +708,8 @@ async def stream_chat_response_fanout(
                 create_chat_chunk(
                     request_id,
                     model,
-                    finish_reason=(
-                        "tool_calls"
-                        if has_tool_calls[i]
-                        else (
-                            _normalize_finish_reason(engine_finish_reasons[i]) or "stop"
-                        )
+                    finish_reason=finish_reason_with_calls(
+                        engine_finish_reasons[i], has_tool_calls[i]
                     ),
                     index=i,
                 )

--- a/atom/entrypoints/openai/serving_chat.py
+++ b/atom/entrypoints/openai/serving_chat.py
@@ -12,7 +12,6 @@ from .protocol import (
     CHAT_COMPLETION_CHUNK_OBJECT,
     STREAM_DONE_MESSAGE,
     TOOL_CHOICE_VALUES,
-    TOOL_NAME_RE,
     ChatCompletionRequest,
     ChatCompletionResponse,
     openai_stop_reason_with_calls,
@@ -26,6 +25,7 @@ from .sse import data_frame
 from .streaming_dispatch import StreamOutputCollector
 from .tool_parser import ToolCallStreamParser, parse_tool_calls
 from .tool_parser.registry import forbids_tool_calls
+from .tool_parser.tool_parser import usable_tool_name
 
 logger = logging.getLogger("atom")
 
@@ -112,13 +112,20 @@ def _validate_one_tool(tool: Any, index: int) -> None:
     if not isinstance(fn, dict):
         raise ValueError(f"tools[{index}].function must be an object")  # noqa: TRY004
     name = fn.get("name")
-    if not isinstance(name, str) or not TOOL_NAME_RE.match(name):
+    # The same predicate the parsers apply to a name the *model* writes. The
+    # second grammar that used to be here, `^[A-Za-z_][A-Za-z0-9_-]*$`, was
+    # the stricter: it rejected a leading digit that OpenAI's own
+    # `^[a-zA-Z0-9_-]{1,64}$` allows, every non-ASCII name, and MCP's
+    # `server.tool` -- a 400 before the model ever ran, while `/v1/messages`
+    # validated nothing and accepted all three.
+    if not isinstance(name, str) or not usable_tool_name(name):
         raise ValueError(
-            f"tools[{index}].function.name must match {TOOL_NAME_RE.pattern}"
+            f"tools[{index}].function.name must be a dispatchable name: "
+            "a word character followed by word characters, dots or dashes"
         )
 
 
-def _validate_tool_list(tools: Any) -> None:
+def validate_tool_list(tools: Any) -> None:
     if tools is None:
         return
     if not isinstance(tools, list):
@@ -138,7 +145,7 @@ def validate_chat_request(request: ChatCompletionRequest) -> None:
     Raises ``ValueError`` (surfaced as HTTP 400) on malformed input so the
     engine is never handed a request the chat template cannot render.
     """
-    _validate_tool_list(request.tools)
+    validate_tool_list(request.tools)
 
     tool_choice = request.tool_choice
     if tool_choice is not None:

--- a/atom/entrypoints/openai/serving_completion.py
+++ b/atom/entrypoints/openai/serving_completion.py
@@ -12,6 +12,7 @@ from .protocol import (
     STREAM_DONE_MESSAGE,
     TEXT_COMPLETION_OBJECT,
     CompletionResponse,
+    openai_stop_reason,
 )
 from .sse import data_frame
 from .streaming_dispatch import StreamOutputCollector
@@ -32,6 +33,12 @@ def create_completion_chunk(
 
     ``index`` selects ``choices[0].index``; fan-out siblings share one SSE
     stream and are distinguished by this field.
+
+    ``finish_reason`` belongs on the terminal chunk and nowhere else, already
+    translated by `openai_stop_reason`. Both streaming paths here used to pass
+    the engine's own word on every *content* chunk while hardcoding `"stop"`
+    on the terminal one, so a single response reported `max_tokens` in a place
+    clients do not read and `stop` in the place they do.
     """
     chunk = {
         "id": request_id,
@@ -76,11 +83,15 @@ async def stream_completion_response(
     # so the finally below aborts the still-running seq; on normal completion
     # we flip this to False and skip the (no-op) abort.
     aborted = True
+    # The engine's own word, kept for the terminal chunk. It arrives on the
+    # chunk that reports `finished`, which is not the frame it belongs on.
+    engine_reason: str | None = None
     try:
         while True:
             chunk_data = await stream_collector.get()
             new_text = chunk_data["text"]
             num_tokens_output += len(chunk_data.get("token_ids", []))
+            engine_reason = chunk_data.get("finish_reason") or engine_reason
 
             extra_fields: dict[str, Any] = {}
             if "kv_transfer_params" in chunk_data:
@@ -90,7 +101,7 @@ async def stream_completion_response(
                 request_id,
                 model,
                 new_text,
-                finish_reason=chunk_data.get("finish_reason"),
+                finish_reason=None,  # the terminal chunk carries it
                 **extra_fields,
             )
 
@@ -114,7 +125,12 @@ async def stream_completion_response(
                 }
                 yield (
                     content_chunk
-                    + create_completion_chunk(request_id, model, "", "stop")
+                    + create_completion_chunk(
+                        request_id,
+                        model,
+                        "",
+                        openai_stop_reason(engine_reason) or "stop",
+                    )
                     + data_frame(usage_chunk)
                     + STREAM_DONE_MESSAGE
                 )
@@ -140,7 +156,7 @@ def build_completion_response(
             {
                 "index": 0,
                 "text": final_output["text"],
-                "finish_reason": final_output["finish_reason"],
+                "finish_reason": openai_stop_reason(final_output["finish_reason"]),
             }
         ],
         usage={
@@ -173,7 +189,7 @@ def build_completion_response_multi(
         {
             "index": i,
             "text": out["text"],
-            "finish_reason": out["finish_reason"],
+            "finish_reason": openai_stop_reason(out["finish_reason"]),
         }
         for i, out in enumerate(final_outputs)
     ]
@@ -225,6 +241,7 @@ async def stream_completion_response_fanout(
     num_tokens_input = num_prompt_tokens
     num_tokens_output = [0] * n
     finished = [False] * n
+    engine_reasons: list[str | None] = [None] * n
 
     # Assume abort until every sibling has reported finished; a client
     # disconnect closes the generator first, leaving this True so the finally
@@ -237,6 +254,7 @@ async def stream_completion_response_fanout(
                 continue
             new_text = chunk_data["text"]
             num_tokens_output[idx] += len(chunk_data.get("token_ids", []))
+            engine_reasons[idx] = chunk_data.get("finish_reason") or engine_reasons[idx]
 
             extra_fields: dict[str, Any] = {}
             if "kv_transfer_params" in chunk_data:
@@ -246,7 +264,7 @@ async def stream_completion_response_fanout(
                 request_id,
                 model,
                 new_text,
-                finish_reason=chunk_data.get("finish_reason"),
+                finish_reason=None,  # the terminal chunk carries it
                 index=idx,
                 **extra_fields,
             )
@@ -273,7 +291,13 @@ async def stream_completion_response_fanout(
         # Coalesce the per-sibling stop chunks + usage + [DONE] into one send.
         yield (
             "".join(
-                create_completion_chunk(request_id, model, "", "stop", index=i)
+                create_completion_chunk(
+                    request_id,
+                    model,
+                    "",
+                    openai_stop_reason(engine_reasons[i]) or "stop",
+                    index=i,
+                )
                 for i in range(n)
             )
             + data_frame(usage_chunk)

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -143,33 +143,36 @@ class FrameWait:
     returning on schedule. The gauge read zero while the client received
     nothing, which is the exact symptom it was built for.
 
-    Wrapping the yield also removes the other blind spot. The old shape had to
-    ignore a stream's first wait, because at `get` that wait is admission and
-    prefill and would have made the gauge a queue-depth proxy that
-    `atom:requests_waiting` already is. Out here the first frame goes out as
-    soon as the response opens, so every wait after it is real silence and
-    none of them need excluding.
+    The first frame still has to be excluded, and the docstring here once
+    claimed otherwise. Every response generator awaits the collector before
+    yielding anything, so the wait for frame one is admission, queueing and
+    prefill -- measured, a request 200 ms into a queue with no token yet
+    produced put 0.2 s on the gauge, which is `atom:requests_waiting` wearing
+    a different name, and at a deep queue would log a line per admitted
+    request blaming the read-ahead. `armed` is off for that one wait.
 
     A timestamp and a dict entry rather than `asyncio.wait_for`: this runs
     once per frame per stream, and arming a timer costs 1.38 us against
     0.07 us for this. No timer also means no background task to own.
     """
 
-    __slots__ = ("_started", "request_id")
+    __slots__ = ("_started", "armed", "request_id")
 
-    def __init__(self, request_id: str = "") -> None:
+    def __init__(self, request_id: str = "", *, armed: bool = True) -> None:
         self.request_id = request_id
+        self.armed = armed
         self._started = 0.0
 
     def __enter__(self) -> None:
         # No `as`: nothing needs the watch itself, only its lifetime.
         self._started = time.monotonic()
-        _WAITING_SINCE[id(self)] = self._started
+        if self.armed:
+            _WAITING_SINCE[id(self)] = self._started
 
     def __exit__(self, *exc) -> None:
         _WAITING_SINCE.pop(id(self), None)
         silence = time.monotonic() - self._started
-        if silence >= SILENCE_LOG_SECONDS:
+        if self.armed and silence >= SILENCE_LOG_SECONDS:
             # After the fact, and free: one comparison on a frame that was
             # going to arrive anyway. Catches a stall that recovered, which
             # the gauge cannot -- by scrape time it is over.

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -10,12 +10,26 @@ landing point each stream's SSE generator reads from.
 """
 
 import array
+import logging
 import threading
+import time
 from asyncio import AbstractEventLoop, Event
 from dataclasses import dataclass, field
 from typing import Any, NamedTuple
 
 from atom.model_engine.sequence import new_token_ids
+
+logger = logging.getLogger("atom")
+
+# How long one stream may go without a chunk before it is worth a line. Long
+# enough that a slow prefill or a busy engine step never trips it; short
+# enough that a wedged response is named while the client is still waiting.
+SILENCE_LOG_SECONDS = 30.0
+
+# Every stream currently blocked in `StreamOutputCollector.get`, and since
+# when. Keyed by `id()`: entries are added and removed around a single await
+# in one place, so an id cannot outlive its collector here.
+_WAITING_SINCE: dict[int, float] = {}
 
 # Fields a later chunk overrides on the one it merges into, when it has a value
 # of its own. The SSE consumers keep the newest non-empty value they see, so
@@ -109,14 +123,53 @@ class StreamOutputCollector:
         self._ready.set()
 
     async def get(self) -> dict | tuple[int, dict]:
-        """Await the next chunk, carrying whatever merged into it."""
+        """Await the next chunk, carrying whatever merged into it.
+
+        Records when the wait started, which is the whole watchdog. A stalled
+        response is a stream that never wakes, and this is the one place any
+        stream waits, so a reader of `longest_silence_seconds` sees it while
+        it is happening -- the reported symptom of this bug class was ten
+        minutes of silence with every metric looking healthy.
+
+        A timestamp and a dict entry rather than `asyncio.wait_for`: this runs
+        once per token per stream, and arming a timer costs 1.38 us against
+        0.07 us for this. No timer also means no background task to own.
+        """
         while not self._pending:
-            await self._ready.wait()
+            started = time.monotonic()
+            _WAITING_SINCE[id(self)] = started
+            try:
+                await self._ready.wait()
+            finally:
+                _WAITING_SINCE.pop(id(self), None)
+            silence = time.monotonic() - started
+            if silence >= SILENCE_LOG_SECONDS:
+                # After the fact, and free: one comparison on a wake that was
+                # going to happen anyway. Catches a stall that recovered,
+                # which the gauge cannot -- by scrape time it is over.
+                logger.warning(
+                    f"request {self.request_id or '<unnamed>'} delivered "
+                    f"nothing for {silence:.1f}s before recovering; if this "
+                    f"repeats, the engine or the marker read-ahead is holding "
+                    f"output back"
+                )
         tag, chunk = next(iter(self._pending.items()))
         del self._pending[tag]
         if not self._pending:
             self._ready.clear()
         return chunk if tag is None else (tag, chunk)
+
+
+def longest_silence_seconds() -> float:
+    """How long the most starved in-flight stream has been waiting.
+
+    Zero when nothing is waiting. Exported as a gauge so a stalled response
+    shows up while it is stalled, rather than as a support ticket.
+    """
+    if not _WAITING_SINCE:
+        return 0.0
+    now = time.monotonic()
+    return now - min(_WAITING_SINCE.values())
 
 
 class _BufferedChunk(NamedTuple):

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -26,9 +26,9 @@ logger = logging.getLogger("atom")
 # enough that a wedged response is named while the client is still waiting.
 SILENCE_LOG_SECONDS = 30.0
 
-# Every stream currently blocked in `StreamOutputCollector.get`, and since
-# when. Keyed by `id()`: entries are added and removed around a single await
-# in one place, so an id cannot outlive its collector here.
+# Every stream currently waiting to hand its client a frame, and since when.
+# Keyed by `id()`: entries are added and removed around a single await in one
+# place, so an id cannot outlive the watch that owns it.
 _WAITING_SINCE: dict[int, float] = {}
 
 # Fields a later chunk overrides on the one it merges into, when it has a value
@@ -108,13 +108,6 @@ class StreamOutputCollector:
         self.request_id = request_id
         self._pending: dict[Any, dict] = {}
         self._ready = Event()
-        # Whether this stream has ever delivered. The first wait is queueing --
-        # admission and prefill have not happened yet -- and at the
-        # concurrencies this server is benchmarked at, that routinely exceeds
-        # the silence threshold. Counting it would make the gauge a
-        # queue-depth proxy, which `atom:requests_waiting` already is, and
-        # would log a line per backlogged request on the event loop.
-        self._delivered = False
 
     def put_nowait(self, payload: dict | tuple[int, dict]) -> None:
         """Accept one prepared chunk. Called on the event loop, never off it."""
@@ -130,43 +123,62 @@ class StreamOutputCollector:
         self._ready.set()
 
     async def get(self) -> dict | tuple[int, dict]:
-        """Await the next chunk, carrying whatever merged into it.
-
-        Records when the wait started, which is the whole watchdog. A stalled
-        response is a stream that never wakes, and this is the one place any
-        stream waits, so a reader of `longest_silence_seconds` sees it while
-        it is happening -- the reported symptom of this bug class was ten
-        minutes of silence with every metric looking healthy.
-
-        A timestamp and a dict entry rather than `asyncio.wait_for`: this runs
-        once per token per stream, and arming a timer costs 1.38 us against
-        0.07 us for this. No timer also means no background task to own.
-        """
+        """Await the next chunk, carrying whatever merged into it."""
         while not self._pending:
-            started = time.monotonic()
-            if self._delivered:
-                _WAITING_SINCE[id(self)] = started
-            try:
-                await self._ready.wait()
-            finally:
-                _WAITING_SINCE.pop(id(self), None)
-            silence = time.monotonic() - started
-            if self._delivered and silence >= SILENCE_LOG_SECONDS:
-                # After the fact, and free: one comparison on a wake that was
-                # going to happen anyway. Catches a stall that recovered,
-                # which the gauge cannot -- by scrape time it is over.
-                logger.warning(
-                    f"request {self.request_id or '<unnamed>'} delivered "
-                    f"nothing for {silence:.1f}s before recovering; if this "
-                    f"repeats, the engine or the marker read-ahead is holding "
-                    f"output back"
-                )
+            await self._ready.wait()
         tag, chunk = next(iter(self._pending.items()))
         del self._pending[tag]
         if not self._pending:
             self._ready.clear()
-        self._delivered = True
         return chunk if tag is None else (tag, chunk)
+
+
+class FrameWait:
+    """Times one gap between frames the client actually receives.
+
+    Measured here and not at :meth:`StreamOutputCollector.get`, which is where
+    it started. That is the one place a stream waits for the *engine*, but two
+    stages sit between it and the socket -- the reasoning channel's read-ahead
+    and the tool-call format's -- and while either withholds, `get` keeps
+    returning on schedule. The gauge read zero while the client received
+    nothing, which is the exact symptom it was built for.
+
+    Wrapping the yield also removes the other blind spot. The old shape had to
+    ignore a stream's first wait, because at `get` that wait is admission and
+    prefill and would have made the gauge a queue-depth proxy that
+    `atom:requests_waiting` already is. Out here the first frame goes out as
+    soon as the response opens, so every wait after it is real silence and
+    none of them need excluding.
+
+    A timestamp and a dict entry rather than `asyncio.wait_for`: this runs
+    once per frame per stream, and arming a timer costs 1.38 us against
+    0.07 us for this. No timer also means no background task to own.
+    """
+
+    __slots__ = ("_started", "request_id")
+
+    def __init__(self, request_id: str = "") -> None:
+        self.request_id = request_id
+        self._started = 0.0
+
+    def __enter__(self) -> None:
+        # No `as`: nothing needs the watch itself, only its lifetime.
+        self._started = time.monotonic()
+        _WAITING_SINCE[id(self)] = self._started
+
+    def __exit__(self, *exc) -> None:
+        _WAITING_SINCE.pop(id(self), None)
+        silence = time.monotonic() - self._started
+        if silence >= SILENCE_LOG_SECONDS:
+            # After the fact, and free: one comparison on a frame that was
+            # going to arrive anyway. Catches a stall that recovered, which
+            # the gauge cannot -- by scrape time it is over.
+            logger.warning(
+                f"request {self.request_id or '<unnamed>'} sent the client "
+                f"nothing for {silence:.1f}s before recovering; if this "
+                f"repeats, the engine or one of the marker read-aheads is "
+                f"holding output back"
+            )
 
 
 def longest_silence_seconds() -> float:

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -108,6 +108,13 @@ class StreamOutputCollector:
         self.request_id = request_id
         self._pending: dict[Any, dict] = {}
         self._ready = Event()
+        # Whether this stream has ever delivered. The first wait is queueing --
+        # admission and prefill have not happened yet -- and at the
+        # concurrencies this server is benchmarked at, that routinely exceeds
+        # the silence threshold. Counting it would make the gauge a
+        # queue-depth proxy, which `atom:requests_waiting` already is, and
+        # would log a line per backlogged request on the event loop.
+        self._delivered = False
 
     def put_nowait(self, payload: dict | tuple[int, dict]) -> None:
         """Accept one prepared chunk. Called on the event loop, never off it."""
@@ -137,13 +144,14 @@ class StreamOutputCollector:
         """
         while not self._pending:
             started = time.monotonic()
-            _WAITING_SINCE[id(self)] = started
+            if self._delivered:
+                _WAITING_SINCE[id(self)] = started
             try:
                 await self._ready.wait()
             finally:
                 _WAITING_SINCE.pop(id(self), None)
             silence = time.monotonic() - started
-            if silence >= SILENCE_LOG_SECONDS:
+            if self._delivered and silence >= SILENCE_LOG_SECONDS:
                 # After the fact, and free: one comparison on a wake that was
                 # going to happen anyway. Catches a stall that recovered,
                 # which the gauge cannot -- by scrape time it is over.
@@ -157,6 +165,7 @@ class StreamOutputCollector:
         del self._pending[tag]
         if not self._pending:
             self._ready.clear()
+        self._delivered = True
         return chunk if tag is None else (tag, chunk)
 
 

--- a/atom/entrypoints/openai/tool_parser/__init__.py
+++ b/atom/entrypoints/openai/tool_parser/__init__.py
@@ -36,14 +36,14 @@ OpenAI format::
     {"tool_calls": [{"id": "call_0", "type": "function",
                      "function": {"name": "NAME", "arguments": "ARGS_JSON"}}]}
 
-To add a format: implement :class:`~.tool_parser.ToolCallParser` (or, if it
-buffers from a start marker like most do,
-:class:`~.tool_parser.BufferedMarkerParser`) in its own
-``<model>_tool_parser.py`` declaring its ``START_MARKERS``, then add it to
-``_DETECT_ORDER`` in :mod:`.registry`, whose ordering constraints are
-documented there. That one entry is enough: startup resolution, the streaming
-read-ahead, ``--tool-call-parser``\'s accepted names and the property tests
-are all derived from it.
+To add a format: implement :class:`~.tool_parser.ToolCallParser` in its own
+``<model>_tool_parser.py``, declaring its ``START_MARKERS`` and a
+``parse_region``, then add it to ``_DETECT_ORDER`` in :mod:`.registry`, whose
+ordering constraints are documented there. That one entry is enough: startup
+resolution, the streaming read-ahead, ``--tool-call-parser``\'s accepted names
+and the property tests are all derived from it. A format writes no state
+machine and no whole-output parser of its own -- :mod:`.stream` is the only
+reader, and it is the only reader for both delivery modes.
 """
 
 from .deepseekv4_tool_parser import DsmlParser
@@ -53,19 +53,20 @@ from .kimi_tool_parser import KimiParser
 from .minimax_tool_parser import MiniMaxParser
 from .qwen3_tool_parser import QwenXmlParser
 from .registry import parse_tool_calls
-from .stream import ToolCallStreamParser
-from .tool_parser import BufferedMarkerParser, ToolCall, ToolCallParser
+from .stream import ToolCallStreamParser, read_whole
+from .tool_parser import RegionParse, ToolCall, ToolCallParser
 
 __all__ = [
-    "BufferedMarkerParser",
     "DsmlParser",
     "GlmParser",
     "KimiK3Parser",
     "KimiParser",
     "MiniMaxParser",
     "QwenXmlParser",
+    "RegionParse",
     "ToolCall",
     "ToolCallParser",
     "ToolCallStreamParser",
     "parse_tool_calls",
+    "read_whole",
 ]

--- a/atom/entrypoints/openai/tool_parser/__init__.py
+++ b/atom/entrypoints/openai/tool_parser/__init__.py
@@ -3,8 +3,11 @@
 
 """Tool call parsing for models that emit tool calls in their text output.
 
-Six on-the-wire formats are auto-detected and normalized into the OpenAI
-``tool_calls`` structure:
+Six on-the-wire formats, normalized into the OpenAI ``tool_calls`` structure.
+Which one a model uses is resolved once at startup from its chat template
+(:func:`~.registry.resolve_tool_call_parser`) or set explicitly with
+``--tool-call-parser``; it is not inferred from the output, because inferring
+it means deciding from a prefix that may not carry the discriminator yet.
 
 ==============================  ===============================================
 Module                          Format
@@ -36,9 +39,11 @@ OpenAI format::
 To add a format: implement :class:`~.tool_parser.ToolCallParser` (or, if it
 buffers from a start marker like most do,
 :class:`~.tool_parser.BufferedMarkerParser`) in its own
-``<model>_tool_parser.py``, then register it in :mod:`.registry` — in both
-``_DETECT_ORDER`` and ``sniff_stream``, whose ordering constraints are
-documented there.
+``<model>_tool_parser.py`` declaring its ``START_MARKERS``, then add it to
+``_DETECT_ORDER`` in :mod:`.registry`, whose ordering constraints are
+documented there. That one entry is enough: startup resolution, the streaming
+read-ahead, ``--tool-call-parser``\'s accepted names and the property tests
+are all derived from it.
 """
 
 from .deepseekv4_tool_parser import DsmlParser

--- a/atom/entrypoints/openai/tool_parser/__init__.py
+++ b/atom/entrypoints/openai/tool_parser/__init__.py
@@ -53,10 +53,17 @@ from .kimi_tool_parser import KimiParser
 from .minimax_tool_parser import MiniMaxParser
 from .qwen3_tool_parser import QwenXmlParser
 from .registry import parse_tool_calls
-from .stream import ToolCallStreamParser, read_whole
+from .stream import (
+    flatten_tool_events,
+    read_whole_events,
+    ToolCallStreamParser,
+    read_whole,
+)
 from .tool_parser import RegionParse, ToolCall, ToolCallParser
 
 __all__ = [
+    "flatten_tool_events",
+    "read_whole_events",
     "DsmlParser",
     "GlmParser",
     "KimiK3Parser",

--- a/atom/entrypoints/openai/tool_parser/__init__.py
+++ b/atom/entrypoints/openai/tool_parser/__init__.py
@@ -54,16 +54,14 @@ from .minimax_tool_parser import MiniMaxParser
 from .qwen3_tool_parser import QwenXmlParser
 from .registry import parse_tool_calls
 from .stream import (
-    flatten_tool_events,
-    read_whole_events,
     ToolCallStreamParser,
+    flatten_tool_events,
     read_whole,
+    read_whole_events,
 )
 from .tool_parser import RegionParse, ToolCall, ToolCallParser
 
 __all__ = [
-    "flatten_tool_events",
-    "read_whole_events",
     "DsmlParser",
     "GlmParser",
     "KimiK3Parser",
@@ -74,6 +72,8 @@ __all__ = [
     "ToolCall",
     "ToolCallParser",
     "ToolCallStreamParser",
+    "flatten_tool_events",
     "parse_tool_calls",
     "read_whole",
+    "read_whole_events",
 ]

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -126,7 +126,7 @@ class DsmlParser(BufferedMarkerParser):
         param_types = build_param_types(tools)
         start = cls.find_start(text)
         if start == -1:
-            return text.strip(), []
+            return text, []  # no call -> verbatim; see ToolCallParser.parse
         content = text[:start]
         region = text[start:]
 
@@ -183,4 +183,4 @@ class DsmlParser(BufferedMarkerParser):
         ]
         if _DSML in content:  # scrub any stray marker fragment
             content = content.split("<" + _DSML, 1)[0]
-        return content.strip(), tool_calls
+        return (content.strip() if tool_calls else text), tool_calls

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -29,6 +29,7 @@ from .tool_parser import (
     continues_a_call,
     declared_tools_allow,
     unique_tool_call_id,
+    usable_tool_name,
 )
 
 _DSML = "｜DSML｜"
@@ -253,6 +254,11 @@ class DsmlParser(ToolCallParser):
                 # `None` for a self-closing `<invoke .../>`, which is closed
                 # and carries no body.
                 body = (m.group(2) if closed else m.group(4)) or ""
+                # Before the truncation gate, which only runs for an unclosed
+                # invoke: `name="([^"]*)"` matches an empty and an all-space
+                # name, and a *closed* one had nothing to stop it.
+                if not usable_tool_name(name):
+                    continue
                 if not closed and not _is_truncated_call(
                     name, body, param_types, at_end=at_end
                 ):

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -166,7 +166,6 @@ def _is_truncated_call(
 
 class DsmlParser(ToolCallParser):
     NAME: ClassVar[str] = "dsml"
-    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = True
     # Region-start markers, both marked and marker-less variants.
     START_MARKERS: ClassVar[tuple[str, ...]] = (
         "<" + _DSML + "tool_call",  # marked (covers tool_call / tool_calls)
@@ -248,9 +247,18 @@ class DsmlParser(ToolCallParser):
             if opener is not None:
                 name = opener.group(1).strip()
                 keep = _is_truncated_call(name, body, param_types, at_end=at_end)
+                # Where this call's markup starts, like the branch above. It
+                # was left at 0, so every byte between the region's opening
+                # marker and a cut-off `<invoke>` was counted as markup and
+                # deleted: 500 characters of an answer, on both delivery
+                # paths, and the only one of the four XML formats that did it.
+                begin = cls.markup_begin(region, opener.start())
             else:
                 name = _infer_name(set(raw), param_types) or "unknown"
                 keep = bool(raw)
+                # The wrapper-less malform has no opener to anchor to; the
+                # parameters run from wherever the region began.
+                begin = 0
             if keep:
                 types = param_types.get(name, {})
                 args = {k: _coerce(v, s, types.get(k)) for k, (v, s) in raw.items()}

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -108,8 +108,45 @@ def _infer_name(arg_names: set, param_types: dict[str, dict[str, Any]]) -> str |
     return best
 
 
-# Name plus the token that must follow; see QwenXmlParser for why.
-_PEEK_NAME_RE = re.compile(r'invoke name="([^"]+)">\s*<[^>]*(?:parameter|/)')
+# Name plus whatever follows it; `_continues_a_call` judges that part, so the
+# rule lives in one place. See QwenXmlParser for why a follower is required.
+_PEEK_NAME_RE = re.compile(r'invoke\s+name="([^"]+)"\s*>(.*)', re.DOTALL)
+
+# The same opener with no closing tag: a call the model was cut off inside.
+_TRUNCATED_INVOKE_RE = re.compile(
+    r"<" + _OPT + r'invoke\s+name="([^"]*)"\s*>(.*)$', re.DOTALL
+)
+# What may follow that opener in a real call: another parameter, or the
+# close of the invoke the name opened. Either spelling of the marker, which
+# the model drops about as often as it writes. One tuple, read by both
+# `_is_truncated_call` and `peek_name` -- they used to encode this
+# separately and the peek's version accepted any tag with a slash in it,
+# `<br/>` included.
+_CALL_CONTINUES = (
+    "<" + _DSML + "parameter",
+    "<parameter",
+    "</" + _DSML + "invoke>",
+    "</invoke>",
+)
+
+
+def _continues_a_call(rest: str) -> bool:
+    """Is `rest` the start of this format's own next token?"""
+    return any(tok.startswith(rest[: len(tok)]) for tok in _CALL_CONTINUES)
+
+
+def _is_truncated_call(name: str, body: str, param_types: dict) -> bool:
+    """Is this unclosed `<invoke name=...>` a cut-off call, or prose?
+
+    See :func:`QwenXmlParser._is_truncated_call`, which this is the DSML
+    spelling of; the sweep that added it there and to GLM missed this format,
+    and the same sentence -- "you emit `<invoke name="get_weather">` and
+    inside it a `<parameter>` line" -- was still being dispatched as a call.
+    """
+    if name not in param_types:
+        return False
+    rest = body.lstrip()
+    return not rest or _continues_a_call(rest)
 
 
 class DsmlParser(BufferedMarkerParser):
@@ -123,11 +160,20 @@ class DsmlParser(BufferedMarkerParser):
     )
 
     @classmethod
-    def peek_name(cls, region: str) -> str | None:
+    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
         """`<｜DSML｜invoke name="NAME">`, and the bare `<invoke ...>` the
-        model often emits instead -- both carry the name in the opener."""
+        model often emits instead -- both carry the name in the opener.
+
+        The self-closing `<invoke name="X"/>` shape has no `>` after the
+        quote and so is not matched: it is a complete zero-argument call that
+        `parse` reads on its own, and there is nothing to announce early
+        about a region that is already finished.
+        """
         m = _PEEK_NAME_RE.search(region)
-        return m.group(1) if m else None
+        if m is None:
+            return None
+        rest = m.group(2).lstrip()
+        return m.group(1) if rest and _continues_a_call(rest) else None
 
     # detect() is inherited: any start marker present means DSML.
 
@@ -169,13 +215,28 @@ class DsmlParser(BufferedMarkerParser):
                 args = _unwrap_wrapper_args(args, set(types))
                 calls.append((name, args))
         else:
-            # malformed: no complete invoke wrapper -> collect params, infer tool name
+            # No complete invoke wrapper. Two shapes reach here and they want
+            # opposite things: a call cut off mid-way, whose name is written
+            # in the opener, and the documented V4-Flash malform that drops
+            # the wrapper entirely, whose name has to be inferred from the
+            # parameters. Inferring in both cases scored `get_time` for a
+            # truncated `<invoke name="get_weather">` because it happened to
+            # share more parameters -- a different tool than the one the model
+            # named, and than the one the streaming path had already
+            # announced off the same opener.
+            opener = _TRUNCATED_INVOKE_RE.search(region)
+            body = opener.group(2) if opener else region
             raw = {
                 pm.group(1): (pm.group(3), pm.group(2))
-                for pm in _PARAM_RE.finditer(region)
+                for pm in _PARAM_RE.finditer(body)
             }
-            if raw:
+            if opener is not None:
+                name = opener.group(1).strip()
+                keep = _is_truncated_call(name, body, param_types)
+            else:
                 name = _infer_name(set(raw), param_types) or "unknown"
+                keep = bool(raw)
+            if keep:
                 types = param_types.get(name, {})
                 args = {k: _coerce(v, s, types.get(k)) for k, (v, s) in raw.items()}
                 args = _unwrap_wrapper_args(args, set(types))

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -110,6 +110,7 @@ def _infer_name(arg_names: set, param_types: dict[str, dict[str, Any]]) -> str |
 
 class DsmlParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "dsml"
+    MARKERS: ClassVar[tuple[str, ...]] = ("<tool_calls>", "<invoke name=")
     # Region-start markers, both marked and marker-less variants.
     START_MARKERS: ClassVar[tuple[str, ...]] = (
         "<" + _DSML + "tool_call",  # marked (covers tool_call / tool_calls)

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -172,6 +172,16 @@ class DsmlParser(ToolCallParser):
         "<" + _DSML + "invoke",  # marked invoke
         "<invoke name=",  # marker-less invoke (common malform)
         "<tool_calls>",  # marker-less section open
+        # NOT the marker-less singular `<tool_call>`, though `CALL_OPENERS`
+        # claims it as markup. Adding it here leaves that wrapper in the
+        # answer when a model writes it -- the region opens at `<invoke name=`
+        # by which point it has gone out as content, and `markup_begin` only
+        # looks inside the region -- but this tuple is also what `detect`
+        # keys on, and `<tool_call>` is the Hermes and Qwen opener too. So
+        # declaring it makes DSML claim every one of their templates, which
+        # costs a whole model family its parser to save one stray tag.
+        # Fixing it properly means separating "must not be split" from
+        # "identifies this format", which no format needs yet.
     )
     # The section wrapper closing after the last invoke -- markup, not answer.
     # Both spellings, since the model drops the marker about as often as it

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -35,9 +35,14 @@ _DSML = "｜DSML｜"
 # ``<invoke name=...>``/``<parameter ...>``/``<tool_calls>`` tags, so the marker
 # is matched OPTIONALLY everywhere.
 _OPT = r"(?:" + re.escape(_DSML) + r")?"  # optional ｜DSML｜ prefix
+# The end-of-input alternative is what keeps the part of a value that
+# arrived before `max_tokens`; requiring `</parameter>` yielded `{}`.
 _PARAM_RE = re.compile(
     r"<" + _OPT + r'parameter\s+name="(.*?)"(?:\s+string="(true|false)")?\s*>'
-    r"(.*?)</" + _OPT + r"parameter>",
+    r"(.*?)(?:</" + _OPT + r"parameter>"
+    r"|(?=<" + _OPT + r"parameter\s)"
+    r"|(?=</" + _OPT + r"invoke>)"
+    r"|\Z)",
     re.DOTALL,
 )
 # Long-form `<invoke name="x">...</invoke>` OR self-closing `<invoke name="x"/>`
@@ -51,6 +56,11 @@ _PARAM_RE = re.compile(
 # `finditer` then resumed past the real call, so the call the model actually
 # made never went out. GLM was given this guard first; this is the sweep.
 _NOT_NESTED = r"(?:(?!<" + _OPT + r"invoke\s).)"
+# `closed | self-closing | unclosed`, in one pattern. Recovering truncation
+# in an `else:` under `if invokes:` instead meant no cut-off call could be
+# recovered once any complete invoke existed in the region -- the ordinary
+# `max_tokens` shape -- and it was not monotone in arrived bytes, which the
+# early announcement (`parse_region` over a prefix) requires.
 _INVOKE_RE = re.compile(
     r"<"
     + _OPT
@@ -58,7 +68,12 @@ _INVOKE_RE = re.compile(
     + _NOT_NESTED
     + r"*?)</"
     + _OPT
-    + r"invoke>)",
+    + r"invoke>)"
+    + r"|<"
+    + _OPT
+    + r'invoke\s+name="([^"]*)"\s*>('
+    + _NOT_NESTED
+    + r"*)",
     re.DOTALL,
 )
 
@@ -128,11 +143,7 @@ def _infer_name(arg_names: set, param_types: dict[str, dict[str, Any]]) -> str |
     return best
 
 
-# The same opener with no closing tag: a call the model was cut off inside.
-_TRUNCATED_INVOKE_RE = re.compile(
-    r"<" + _OPT + r'invoke\s+name="([^"]*)"\s*>(.*)$', re.DOTALL
-)
-# What may follow that opener in a real call: another parameter, or the
+# What may follow an unclosed opener in a real call: another parameter, or the
 # close of the invoke the name opened. Either spelling of the marker, which
 # the model drops about as often as it writes. One tuple, read by both
 # `_is_truncated_call` at both ends of a region's life -- the peek used to
@@ -172,16 +183,23 @@ class DsmlParser(ToolCallParser):
         "<" + _DSML + "invoke",  # marked invoke
         "<invoke name=",  # marker-less invoke (common malform)
         "<tool_calls>",  # marker-less section open
-        # NOT the marker-less singular `<tool_call>`, though `CALL_OPENERS`
-        # claims it as markup. Adding it here leaves that wrapper in the
-        # answer when a model writes it -- the region opens at `<invoke name=`
-        # by which point it has gone out as content, and `markup_begin` only
-        # looks inside the region -- but this tuple is also what `detect`
-        # keys on, and `<tool_call>` is the Hermes and Qwen opener too. So
-        # declaring it makes DSML claim every one of their templates, which
-        # costs a whole model family its parser to save one stray tag.
-        # Fixing it properly means separating "must not be split" from
-        # "identifies this format", which no format needs yet.
+        # ...and its singular spelling, which `CALL_OPENERS` already claims as
+        # markup. Declaring it here was impossible while this tuple was also
+        # the fingerprint -- `<tool_call>` is the Hermes and Qwen opener too,
+        # so DSML would have claimed their templates. `DETECT_MARKERS` is that
+        # separation, and this is the first thing it buys: the wrapper stops
+        # being released as content before the region opens.
+        "<tool_call>",
+    )
+    # What makes a text DSML's, which is narrower than what must not be split:
+    # the marker-bearing spellings only. The marker-less ones above are
+    # malform recovery, and `<invoke name=` is also how MiniMax opens a call
+    # -- keying identification on them had DSML claiming MiniMax's templates
+    # with nothing but `_DETECT_ORDER` in the way.
+    DETECT_MARKERS: ClassVar[tuple[str, ...]] = (
+        "<" + _DSML + "tool_call",
+        "<" + _DSML + "invoke",
+        "<" + _DSML + "parameter",
     )
     # The section wrapper closing after the last invoke -- markup, not answer.
     # Both spellings, since the model drops the marker about as often as it
@@ -202,6 +220,17 @@ class DsmlParser(ToolCallParser):
     # detect() is inherited: any start marker present means DSML.
 
     @classmethod
+    def render_call(cls, name: str, args: dict[str, str]) -> str:
+        body = "".join(
+            f'<{_DSML}parameter name="{k}" string="true">{v}</{_DSML}parameter>'
+            for k, v in args.items()
+        )
+        return (
+            f'<{_DSML}tool_calls><{_DSML}invoke name="{name}">'
+            f"{body}</{_DSML}invoke></{_DSML}tool_calls>"
+        )
+
+    @classmethod
     def parse_region(
         cls, region: str, tools: list | None, *, at_end: bool
     ) -> RegionParse:
@@ -214,14 +243,21 @@ class DsmlParser(ToolCallParser):
         invokes = list(_INVOKE_RE.finditer(region))
         if invokes:
             for m in invokes:
+                closed = m.group(1) is not None
+                name = m.group(1) if closed else m.group(3)
+                # `None` for a self-closing `<invoke .../>`, which is closed
+                # and carries no body.
+                body = (m.group(2) if closed else m.group(4)) or ""
+                if not closed and not _is_truncated_call(
+                    name, body, param_types, at_end=at_end
+                ):
+                    continue
                 spans.append(
                     (
                         cls.markup_begin(region, m.start()),
                         cls.markup_end(region, m.end()),
                     )
                 )
-                name = m.group(1)
-                body = m.group(2) or ""  # None for self-closing <invoke .../>
                 types = param_types.get(name, {})
                 args: dict[str, Any] = {
                     pm.group(1): _coerce(
@@ -244,38 +280,23 @@ class DsmlParser(ToolCallParser):
                 args = _unwrap_wrapper_args(args, set(types))
                 calls.append((name, args))
         else:
-            # No complete invoke wrapper. Two shapes reach here and they want
-            # opposite things: a call cut off mid-way, whose name is written
-            # in the opener, and the documented V4-Flash malform that drops
-            # the wrapper entirely, whose name has to be inferred from the
-            # parameters. Inferring in both cases scored `get_time` for a
-            # truncated `<invoke name="get_weather">` because it happened to
-            # share more parameters -- a different tool than the one the model
-            # named, and than the one the streaming path had already
-            # announced off the same opener.
-            opener = _TRUNCATED_INVOKE_RE.search(region)
-            body = opener.group(2) if opener else region
+            # No `<invoke>` at all: the documented V4-Flash malform that drops
+            # the wrapper and writes bare `<parameter>` lines. The name has to
+            # be inferred from the parameter signature, which is why this is
+            # its own branch -- a *truncated* call has its name in the opener
+            # and is read by the loop above. Inferring for both scored
+            # `get_time` for a cut-off `<invoke name="get_weather">` because
+            # it happened to share more parameters, so the parse named a
+            # different tool than the announcement had.
             raw = {
                 pm.group(1): (pm.group(3), pm.group(2))
-                for pm in _PARAM_RE.finditer(body)
+                for pm in _PARAM_RE.finditer(region)
             }
-            if opener is not None:
-                name = opener.group(1).strip()
-                keep = _is_truncated_call(name, body, param_types, at_end=at_end)
-                # Where this call's markup starts, like the branch above. It
-                # was left at 0, so every byte between the region's opening
-                # marker and a cut-off `<invoke>` was counted as markup and
-                # deleted: 500 characters of an answer, on both delivery
-                # paths, and the only one of the four XML formats that did it.
-                span_begin = cls.markup_begin(region, opener.start())
-            else:
+            if raw:
                 name = _infer_name(set(raw), param_types) or "unknown"
-                keep = bool(raw)
-                # The wrapper-less malform has no opener to anchor to; the
-                # parameters run from wherever the region began.
-                span_begin = 0
-            if keep:
-                spans.append((span_begin, len(region)))
+                # Nothing to anchor to, so the parameters run from wherever
+                # the region began to the end of what arrived.
+                spans.append((0, len(region)))
                 types = param_types.get(name, {})
                 args = {k: _coerce(v, s, types.get(k)) for k, (v, s) in raw.items()}
                 args = _unwrap_wrapper_args(args, set(types))

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -39,9 +39,13 @@ _OPT = r"(?:" + re.escape(_DSML) + r")?"  # optional ｜DSML｜ prefix
 # arrived before `max_tokens`; requiring `</parameter>` yielded `{}`.
 _PARAM_RE = re.compile(
     r"<" + _OPT + r'parameter\s+name="(.*?)"(?:\s+string="(true|false)")?\s*>'
+    # The tool_calls? lookahead is the fifth terminator `parse_region` names:
+    # a value ends where the next call opens, or it swallows that call's
+    # wrapper as data.
     r"(.*?)(?:</" + _OPT + r"parameter>"
     r"|(?=<" + _OPT + r"parameter\s)"
     r"|(?=</" + _OPT + r"invoke>)"
+    r"|(?=<" + _OPT + r"tool_calls?>)"
     r"|\Z)",
     re.DOTALL,
 )

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -108,6 +108,9 @@ def _infer_name(arg_names: set, param_types: dict[str, dict[str, Any]]) -> str |
     return best
 
 
+_PEEK_NAME_RE = re.compile(r'invoke name="([^"]+)"')
+
+
 class DsmlParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "dsml"
     # Region-start markers, both marked and marker-less variants.
@@ -117,6 +120,13 @@ class DsmlParser(BufferedMarkerParser):
         "<invoke name=",  # marker-less invoke (common malform)
         "<tool_calls>",  # marker-less section open
     )
+
+    @classmethod
+    def peek_name(cls, region: str) -> str | None:
+        """`<｜DSML｜invoke name="NAME">`, and the bare `<invoke ...>` the
+        model often emits instead -- both carry the name in the opener."""
+        m = _PEEK_NAME_RE.search(region)
+        return m.group(1) if m else None
 
     # detect() is inherited: any start marker present means DSML.
 

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -15,6 +15,10 @@ DeepSeek-V4-Flash occasionally malforms this (singular ``tool_call``, a missing
 ``invoke`` wrapper, or params without ``string=``); the parser recovers those
 best-effort: it infers a dropped tool name from the parameter signature vs the
 request's ``tools`` and infers a missing value type from the schema / JSON.
+
+Inferring a name has two conditions, both load-bearing: only at end of region,
+since an ``<invoke>`` still arriving names the tool outright, and only when
+some declared tool shares a parameter.
 """
 
 import json
@@ -137,13 +141,21 @@ def _coerce(value: str, string_attr: str | None, ptype: Any) -> Any:
 
 
 def _infer_name(arg_names: set, param_types: dict[str, dict[str, Any]]) -> str | None:
-    """Pick the request tool whose parameter set best matches ``arg_names``."""
-    best, best_score = None, -1e9
+    """The request tool whose parameters best match ``arg_names``, if one does.
+
+    At least one shared parameter. Every score is negative once the sets are
+    disjoint and the running best started below all of them, so the first
+    declared tool with any properties won on no evidence: a region of bare
+    ``<parameter name="zzz">`` dispatched ``get_weather``. This branch has no
+    name on the wire, so nothing shared means it was prose.
+    """
+    best, best_score = None, float("-inf")
     for name, props in param_types.items():
-        p = set(props)
-        if not p:
+        shared = len(arg_names.intersection(props))
+        if not shared:
             continue
-        score = len(p & arg_names) - 0.1 * len(p ^ arg_names)
+        # |p ^ a| == |p| + |a| - 2|p & a|, so it never has to be built.
+        score = shared - 0.1 * (len(props) + len(arg_names) - 2 * shared)
         if score > best_score:
             best_score, best = score, name
     return best
@@ -294,7 +306,16 @@ class DsmlParser(ToolCallParser):
                             pass
                 args = _unwrap_wrapper_args(args, set(types))
                 calls.append((name, args))
-        else:
+        elif at_end:
+            # `elif at_end`, not `else`: an `<invoke>` still on its way moves
+            # the region to the loop above and with it which bytes are markup,
+            # so this branch's acceptance is not monotone in arrived bytes --
+            # which the early announcement assumes. A name inferred half-way
+            # through went out ahead of prose the whole parse puts in front of
+            # it, so `stream=true` ordered the answer differently. A signature
+            # is only complete when the region is. Free: `invokes` is already
+            # computed, and the peek now skips this scan.
+            #
             # No `<invoke>` at all: the documented V4-Flash malform that drops
             # the wrapper and writes bare `<parameter>` lines. The name has to
             # be inferred from the parameter signature, which is why this is
@@ -311,18 +332,24 @@ class DsmlParser(ToolCallParser):
             # means the model was writing about the syntax -- and no shape
             # built from the front of a call can reach here to say so, which
             # is why it went two rounds unseen while deleting 152 characters
-            # of such an answer down to 18 and dispatching `unknown`.
+            # of such an answer down to 18 and dispatching a name it had
+            # invented.
             matches = list(_PARAM_RE.finditer(region))
             if matches and cls.markup_begin(region, matches[0].start()) == 0:
                 raw = {pm.group(1): (pm.group(3), pm.group(2)) for pm in matches}
-                name = _infer_name(set(raw), param_types) or "unknown"
-                # Nothing to anchor to, so the parameters run from wherever
-                # the region began to the end of what arrived.
-                spans.append((0, len(region)))
-                types = param_types.get(name, {})
-                args = {k: _coerce(v, s, types.get(k)) for k, (v, s) in raw.items()}
-                args = _unwrap_wrapper_args(args, set(types))
-                calls.append((name, args))
+                # No `or "unknown"`: a signature matching nothing declared is
+                # not a call the client could dispatch, and naming it shipped
+                # one anyway, with `finish_reason: tool_calls`, for an answer
+                # that had merely written the tags.
+                name = _infer_name(set(raw), param_types)
+                if name is not None:
+                    # Nothing to anchor to, so the parameters run from wherever
+                    # the region began to the end of what arrived.
+                    spans.append((0, len(region)))
+                    types = param_types.get(name, {})
+                    args = {k: _coerce(v, s, types.get(k)) for k, (v, s) in raw.items()}
+                    args = _unwrap_wrapper_args(args, set(types))
+                    calls.append((name, args))
 
         tool_calls = tuple(
             ToolCall(

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -27,6 +27,7 @@ from .tool_parser import (
     ToolCall,
     ToolCallParser,
     continues_a_call,
+    declared_tools_allow,
     unique_tool_call_id,
 )
 
@@ -171,7 +172,7 @@ def _is_truncated_call(
     and the same sentence -- "you emit `<invoke name="get_weather">` and
     inside it a `<parameter>` line" -- was still being dispatched as a call.
     """
-    if name not in param_types:
+    if not declared_tools_allow(name, param_types):
         return False
     rest = body.lstrip()
     return (not rest and at_end) or continues_a_call(
@@ -292,11 +293,18 @@ class DsmlParser(ToolCallParser):
             # `get_time` for a cut-off `<invoke name="get_weather">` because
             # it happened to share more parameters, so the parse named a
             # different tool than the announcement had.
-            raw = {
-                pm.group(1): (pm.group(3), pm.group(2))
-                for pm in _PARAM_RE.finditer(region)
-            }
-            if raw:
+            #
+            # Only when the parameters *are* the region. Every other branch
+            # gates on an opener; this one has none to gate on, since the name
+            # is inferred from the signature rather than read, so where the
+            # markup starts is the whole of the evidence. Prose in front of it
+            # means the model was writing about the syntax -- and no shape
+            # built from the front of a call can reach here to say so, which
+            # is why it went two rounds unseen while deleting 152 characters
+            # of such an answer down to 18 and dispatching `unknown`.
+            matches = list(_PARAM_RE.finditer(region))
+            if matches and cls.markup_begin(region, matches[0].start()) == 0:
+                raw = {pm.group(1): (pm.group(3), pm.group(2)) for pm in matches}
                 name = _infer_name(set(raw), param_types) or "unknown"
                 # Nothing to anchor to, so the parameters run from wherever
                 # the region began to the end of what arrived.

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -22,7 +22,12 @@ import re
 from typing import Any, ClassVar
 
 from .schema import build_param_types, coerce_param_value
-from .tool_parser import BufferedMarkerParser, ToolCall, unique_tool_call_id
+from .tool_parser import (
+    BufferedMarkerParser,
+    ToolCall,
+    continues_a_call,
+    unique_tool_call_id,
+)
 
 _DSML = "｜DSML｜"
 # The model often DROPS the ``｜DSML｜`` marker and emits bare
@@ -130,11 +135,6 @@ _CALL_CONTINUES = (
 )
 
 
-def _continues_a_call(rest: str) -> bool:
-    """Is `rest` the start of this format's own next token?"""
-    return any(tok.startswith(rest[: len(tok)]) for tok in _CALL_CONTINUES)
-
-
 def _is_truncated_call(name: str, body: str, param_types: dict) -> bool:
     """Is this unclosed `<invoke name=...>` a cut-off call, or prose?
 
@@ -146,7 +146,7 @@ def _is_truncated_call(name: str, body: str, param_types: dict) -> bool:
     if name not in param_types:
         return False
     rest = body.lstrip()
-    return not rest or _continues_a_call(rest)
+    return not rest or continues_a_call(rest, _CALL_CONTINUES, arrived=False)
 
 
 class DsmlParser(BufferedMarkerParser):
@@ -173,7 +173,9 @@ class DsmlParser(BufferedMarkerParser):
         if m is None:
             return None
         rest = m.group(2).lstrip()
-        return m.group(1) if rest and _continues_a_call(rest) else None
+        if not continues_a_call(rest, _CALL_CONTINUES, arrived=True):
+            return None
+        return m.group(1)
 
     # detect() is inherited: any start marker present means DSML.
 

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -198,13 +198,18 @@ class DsmlParser(ToolCallParser):
         param_types = build_param_types(tools)
         calls: list[tuple[str, dict[str, Any]]] = []
         # A truncated or wrapper-less call runs to the end of what arrived;
-        # complete invokes start and end where their own matches do.
-        begin, end = 0, len(region)
+        # complete invokes start and end where their own matches do, one span
+        # each.
+        spans: list[tuple[int, int]] = []
         invokes = list(_INVOKE_RE.finditer(region))
         if invokes:
-            begin = cls.markup_begin(region, invokes[0].start())
-            end = cls.markup_end(region, invokes[-1].end())
             for m in invokes:
+                spans.append(
+                    (
+                        cls.markup_begin(region, m.start()),
+                        cls.markup_end(region, m.end()),
+                    )
+                )
                 name = m.group(1)
                 body = m.group(2) or ""  # None for self-closing <invoke .../>
                 types = param_types.get(name, {})
@@ -252,14 +257,15 @@ class DsmlParser(ToolCallParser):
                 # marker and a cut-off `<invoke>` was counted as markup and
                 # deleted: 500 characters of an answer, on both delivery
                 # paths, and the only one of the four XML formats that did it.
-                begin = cls.markup_begin(region, opener.start())
+                span_begin = cls.markup_begin(region, opener.start())
             else:
                 name = _infer_name(set(raw), param_types) or "unknown"
                 keep = bool(raw)
                 # The wrapper-less malform has no opener to anchor to; the
                 # parameters run from wherever the region began.
-                begin = 0
+                span_begin = 0
             if keep:
+                spans.append((span_begin, len(region)))
                 types = param_types.get(name, {})
                 args = {k: _coerce(v, s, types.get(k)) for k, (v, s) in raw.items()}
                 args = _unwrap_wrapper_args(args, set(types))
@@ -276,4 +282,4 @@ class DsmlParser(ToolCallParser):
             )
             for name, args in calls
         )
-        return RegionParse(tool_calls, begin, end)
+        return RegionParse(tool_calls, tuple(spans))

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -23,8 +23,9 @@ from typing import Any, ClassVar
 
 from .schema import build_param_types, coerce_param_value
 from .tool_parser import (
-    BufferedMarkerParser,
+    RegionParse,
     ToolCall,
+    ToolCallParser,
     continues_a_call,
     unique_tool_call_id,
 )
@@ -42,8 +43,22 @@ _PARAM_RE = re.compile(
 # Long-form `<invoke name="x">...</invoke>` OR self-closing `<invoke name="x"/>`
 # (the zero-arg shape; group(2) is None for self-closing). Matches SGLang's V4
 # detector, which accepts both.
+# A call's body may not contain another opener -- that literal is what opens
+# one. Without the guard the non-greedy body ran from a *quoted* opener in
+# prose all the way to the real call's closer, so an answer explaining
+# "you write <invoke name="NAME">" before making a real call produced one call named after the
+# placeholder, carrying the real call's arguments, with the sentence deleted.
+# `finditer` then resumed past the real call, so the call the model actually
+# made never went out. GLM was given this guard first; this is the sweep.
+_NOT_NESTED = r"(?:(?!<" + _OPT + r"invoke\s).)"
 _INVOKE_RE = re.compile(
-    r"<" + _OPT + r'invoke\s+name="(.*?)"\s*(?:/>|>(.*?)</' + _OPT + r"invoke>)",
+    r"<"
+    + _OPT
+    + r'invoke\s+name="([^"]*)"\s*(?:/>|>('
+    + _NOT_NESTED
+    + r"*?)</"
+    + _OPT
+    + r"invoke>)",
     re.DOTALL,
 )
 
@@ -113,10 +128,6 @@ def _infer_name(arg_names: set, param_types: dict[str, dict[str, Any]]) -> str |
     return best
 
 
-# Name plus whatever follows it; `_continues_a_call` judges that part, so the
-# rule lives in one place. See QwenXmlParser for why a follower is required.
-_PEEK_NAME_RE = re.compile(r'invoke\s+name="([^"]+)"\s*>(.*)', re.DOTALL)
-
 # The same opener with no closing tag: a call the model was cut off inside.
 _TRUNCATED_INVOKE_RE = re.compile(
     r"<" + _OPT + r'invoke\s+name="([^"]*)"\s*>(.*)$', re.DOTALL
@@ -124,9 +135,9 @@ _TRUNCATED_INVOKE_RE = re.compile(
 # What may follow that opener in a real call: another parameter, or the
 # close of the invoke the name opened. Either spelling of the marker, which
 # the model drops about as often as it writes. One tuple, read by both
-# `_is_truncated_call` and `peek_name` -- they used to encode this
-# separately and the peek's version accepted any tag with a slash in it,
-# `<br/>` included.
+# `_is_truncated_call` at both ends of a region's life -- the peek used to
+# encode this separately and accepted any tag with a slash in it, `<br/>`
+# included.
 _CALL_CONTINUES = (
     "<" + _DSML + "parameter",
     "<parameter",
@@ -135,7 +146,9 @@ _CALL_CONTINUES = (
 )
 
 
-def _is_truncated_call(name: str, body: str, param_types: dict) -> bool:
+def _is_truncated_call(
+    name: str, body: str, param_types: dict, *, at_end: bool
+) -> bool:
     """Is this unclosed `<invoke name=...>` a cut-off call, or prose?
 
     See :func:`QwenXmlParser._is_truncated_call`, which this is the DSML
@@ -146,11 +159,14 @@ def _is_truncated_call(name: str, body: str, param_types: dict) -> bool:
     if name not in param_types:
         return False
     rest = body.lstrip()
-    return not rest or continues_a_call(rest, _CALL_CONTINUES, arrived=False)
+    return (not rest and at_end) or continues_a_call(
+        rest, _CALL_CONTINUES, arrived=not at_end
+    )
 
 
-class DsmlParser(BufferedMarkerParser):
+class DsmlParser(ToolCallParser):
     NAME: ClassVar[str] = "dsml"
+    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = True
     # Region-start markers, both marked and marker-less variants.
     START_MARKERS: ClassVar[tuple[str, ...]] = (
         "<" + _DSML + "tool_call",  # marked (covers tool_call / tool_calls)
@@ -158,40 +174,37 @@ class DsmlParser(BufferedMarkerParser):
         "<invoke name=",  # marker-less invoke (common malform)
         "<tool_calls>",  # marker-less section open
     )
-
-    @classmethod
-    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
-        """`<｜DSML｜invoke name="NAME">`, and the bare `<invoke ...>` the
-        model often emits instead -- both carry the name in the opener.
-
-        The self-closing `<invoke name="X"/>` shape has no `>` after the
-        quote and so is not matched: it is a complete zero-argument call that
-        `parse` reads on its own, and there is nothing to announce early
-        about a region that is already finished.
-        """
-        m = _PEEK_NAME_RE.search(region)
-        if m is None:
-            return None
-        rest = m.group(2).lstrip()
-        if not continues_a_call(rest, _CALL_CONTINUES, arrived=True):
-            return None
-        return m.group(1)
+    # The section wrapper closing after the last invoke -- markup, not answer.
+    # Both spellings, since the model drops the marker about as often as it
+    # writes it, and both arities, since it writes the singular too.
+    CALL_OPENERS: ClassVar[tuple[str, ...]] = (
+        "<" + _DSML + "tool_calls>",
+        "<" + _DSML + "tool_call>",
+        "<tool_calls>",
+        "<tool_call>",
+    )
+    CALL_CLOSERS: ClassVar[tuple[str, ...]] = (
+        "</" + _DSML + "tool_calls>",
+        "</" + _DSML + "tool_call>",
+        "</tool_calls>",
+        "</tool_call>",
+    )
 
     # detect() is inherited: any start marker present means DSML.
 
     @classmethod
-    def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
-        """Parse DeepSeek-V4 DSML tool calls; return (leading_content, tool_calls)."""
+    def parse_region(
+        cls, region: str, tools: list | None, *, at_end: bool
+    ) -> RegionParse:
         param_types = build_param_types(tools)
-        start = cls.find_start(text)
-        if start == -1:
-            return text, []  # no call -> verbatim; see ToolCallParser.parse
-        content = text[:start]
-        region = text[start:]
-
         calls: list[tuple[str, dict[str, Any]]] = []
+        # A truncated or wrapper-less call runs to the end of what arrived;
+        # complete invokes start and end where their own matches do.
+        begin, end = 0, len(region)
         invokes = list(_INVOKE_RE.finditer(region))
         if invokes:
+            begin = cls.markup_begin(region, invokes[0].start())
+            end = cls.markup_end(region, invokes[-1].end())
             for m in invokes:
                 name = m.group(1)
                 body = m.group(2) or ""  # None for self-closing <invoke .../>
@@ -234,7 +247,7 @@ class DsmlParser(BufferedMarkerParser):
             }
             if opener is not None:
                 name = opener.group(1).strip()
-                keep = _is_truncated_call(name, body, param_types)
+                keep = _is_truncated_call(name, body, param_types, at_end=at_end)
             else:
                 name = _infer_name(set(raw), param_types) or "unknown"
                 keep = bool(raw)
@@ -244,7 +257,7 @@ class DsmlParser(BufferedMarkerParser):
                 args = _unwrap_wrapper_args(args, set(types))
                 calls.append((name, args))
 
-        tool_calls = [
+        tool_calls = tuple(
             ToolCall(
                 id=unique_tool_call_id(),
                 type="function",
@@ -254,7 +267,5 @@ class DsmlParser(BufferedMarkerParser):
                 },
             )
             for name, args in calls
-        ]
-        if _DSML in content:  # scrub any stray marker fragment
-            content = content.split("<" + _DSML, 1)[0]
-        return (content.strip() if tool_calls else text), tool_calls
+        )
+        return RegionParse(tool_calls, begin, end)

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -108,7 +108,8 @@ def _infer_name(arg_names: set, param_types: dict[str, dict[str, Any]]) -> str |
     return best
 
 
-_PEEK_NAME_RE = re.compile(r'invoke name="([^"]+)"')
+# Name plus the token that must follow; see QwenXmlParser for why.
+_PEEK_NAME_RE = re.compile(r'invoke name="([^"]+)">\s*<[^>]*(?:parameter|/)')
 
 
 class DsmlParser(BufferedMarkerParser):

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -110,7 +110,6 @@ def _infer_name(arg_names: set, param_types: dict[str, dict[str, Any]]) -> str |
 
 class DsmlParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "dsml"
-    MARKERS: ClassVar[tuple[str, ...]] = ("<tool_calls>", "<invoke name=")
     # Region-start markers, both marked and marker-less variants.
     START_MARKERS: ClassVar[tuple[str, ...]] = (
         "<" + _DSML + "tool_call",  # marked (covers tool_call / tool_calls)

--- a/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/deepseekv4_tool_parser.py
@@ -222,6 +222,10 @@ class DsmlParser(ToolCallParser):
         "</tool_calls>",
         "</tool_call>",
     )
+    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = (
+        "</" + _DSML + "invoke>",
+        "</invoke>",
+    )
 
     # detect() is inherited: any start marker present means DSML.
 

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -28,13 +28,14 @@ from .tool_parser import (
     continues_a_call,
     declared_tools_allow,
     unique_tool_call_id,
+    usable_tool_name,
 )
 
 TOOL_CALL_OPEN = "<tool_call>"
 # A call's body may not contain another `<tool_call>`. Without that the
 # non-greedy match ran from the *first* opener in the region to the first
 # close, so an answer that quotes the tag and then makes a real call produced
-# a "name" of the whole sentence -- rejected by `_TOOL_NAME_RE`, after which
+# a "name" of the whole sentence -- rejected by `usable_tool_name`, after which
 # `finditer` resumed past the real call and found nothing at all. The tag is
 # what this format opens a call with, so it cannot appear inside one.
 _NOT_NESTED = r"(?:(?!<tool_call>).)"
@@ -52,20 +53,14 @@ _TOOLCALL_RE = re.compile(
 # opener, so `finditer` skipped the first call entirely and returned the
 # second -- one call where the model made two, and a different one from the
 # one the early name had already announced.
-# A tool name is an identifier, which is what the model was given. Without
-# this the unterminated branch above turns any prose after a `<tool_call>`
-# into a call: an answer explaining that "the model writes <tool_call>
-# followed by the name" produced a call named " followed by the name. Hope
-# that helps!", and a Hermes-style `<tool_call>{"name": ...}` produced one
-# named after the whole JSON object. Both reached clients as `tool_calls`.
-#
-# `\w` and not `[A-Za-z_]`: OpenAI's own grammar is `^[a-zA-Z0-9_-]{1,64}$`,
-# so a leading digit is legal (`7z_extract`), and `\w` is Unicode-aware, so a
-# CJK name is too -- which matters rather a lot on a Chinese model family.
-# Rejecting one is silent, and prose is still rejected because a space cannot
-# appear in the tail. `\Z` and not `$`, which also matches before a trailing
-# newline and would admit a name with one.
-_TOOL_NAME_RE = re.compile(r"^\w[\w.\-]*\Z")
+# This format needs the name test more than the others do: without it the
+# unterminated branch above turns any prose after a `<tool_call>` into a call
+# -- an answer explaining that "the model writes <tool_call> followed by the
+# name" produced a call named " followed by the name. Hope that helps!", and a
+# Hermes-style `<tool_call>{"name": ...}` produced one named after the whole
+# JSON object. Both reached clients as `tool_calls`. It is `usable_tool_name`
+# now, shared: the same question was being answered six ways, and three
+# formats were not asking it at all.
 _ARG_OPENER = "<arg_key>"
 _ARG_RE = re.compile(
     r"<arg_key>(.*?)</arg_key>\s*<arg_value>"
@@ -134,7 +129,7 @@ class GlmParser(ToolCallParser):
                 lt = body.find("<")
                 name = (body if lt == -1 else body[:lt]).strip()
                 rest = "" if lt == -1 else body[lt:]
-            if not _TOOL_NAME_RE.match(name):
+            if not usable_tool_name(name):
                 continue
             # See `QwenXmlParser._is_truncated_call`: an unclosed region is a
             # cut-off call or prose quoting the tag, and prose has to fail

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -68,7 +68,7 @@ _TOOL_NAME_RE = re.compile(r"^\w[\w.\-]*\Z")
 _ARG_OPENER = "<arg_key>"
 _ARG_RE = re.compile(
     r"<arg_key>(.*?)</arg_key>\s*<arg_value>"
-    r"(.*?)(?:</arg_value>|(?=<arg_key>)|(?=</tool_call>)|$)",
+    r"(.*?)(?:</arg_value>|(?=<arg_key>)|(?=</tool_call>)|\Z)",
     re.DOTALL,
 )
 
@@ -78,6 +78,13 @@ class GlmParser(ToolCallParser):
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
     # No `CALL_CLOSERS`: this format's `</tool_call>` closes the call itself
     # rather than a wrapper around it, so `_TOOLCALL_RE` already spans it.
+
+    @classmethod
+    def render_call(cls, name: str, args: dict[str, str]) -> str:
+        body = "".join(
+            f"<arg_key>{k}</arg_key><arg_value>{v}</arg_value>" for k, v in args.items()
+        )
+        return f"<tool_call>{name}{body}</tool_call>"
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -23,6 +23,7 @@ from .qwen3_tool_parser import QWEN_TOOL_PREFIX
 from .schema import build_param_types, coerce_json_or_raw
 from .tool_parser import BufferedMarkerParser, ToolCall, unique_tool_call_id
 
+TOOL_CALL_OPEN = "<tool_call>"
 _TOOLCALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)$", re.DOTALL)
 # A tool name is an identifier, which is what the model was given. Without
 # this the unterminated branch above turns any prose after a `<tool_call>`
@@ -46,11 +47,15 @@ _ARG_RE = re.compile(
 )
 
 
-# Both call shapes, so `search` finds the *first* call rather than the
-# first one that happens to take arguments. Requiring `<arg_key>` skipped
-# a zero-argument call, announced the name of the one after it, and
-# `parse` then returned them in wire order -- an AssertionError raised
-# out of `flush` on a live SSE stream, from well-formed output.
+# Both call shapes, so the *first* call is what matches rather than the first
+# one that happens to take arguments. Requiring `<arg_key>` skipped a
+# zero-argument call and announced the name of the one after it.
+#
+# Anchored at the region's own first `<tool_call>`, not searched for: `parse`
+# reads the unclosed case from the first one to end-of-string, so when that
+# one carries no usable name it produces nothing at all -- while a `search`
+# here slid forward to a later opener and announced its name. Measured on
+# `<tool_call><arg_key><tool_call>get_weather<arg_key>`, at every chunk size.
 _PEEK_NAME_RE = re.compile(r"<tool_call>\s*(\w[\w.\-]*)\s*(?:<arg_key>|</tool_call>)")
 
 
@@ -69,7 +74,10 @@ class GlmParser(BufferedMarkerParser):
         where `</tool_call>` closes an *outer* wrapper and left the inner
         block unterminated.
         """
-        m = _PEEK_NAME_RE.search(region)
+        start = region.find(TOOL_CALL_OPEN)
+        if start == -1:
+            return None
+        m = _PEEK_NAME_RE.match(region, start)
         return m.group(1) if m else None
 
     @classmethod

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -98,7 +98,7 @@ class GlmParser(ToolCallParser):
     ) -> RegionParse:
         param_types = build_param_types(tools)
         tool_calls: list[ToolCall] = []
-        begin = end = 0
+        spans: list[tuple[int, int]] = []
         for m in _TOOLCALL_RE.finditer(region):
             closed = m.group(1) is not None
             body = m.group(1) if closed else m.group(2)
@@ -149,8 +149,7 @@ class GlmParser(ToolCallParser):
                 k = pm.group(1).strip()
                 if k:
                     args[k] = coerce_json_or_raw(pm.group(2), types.get(k))
-            if not tool_calls:
-                begin = m.start()
+            spans.append((m.start(), cls.markup_end(region, m.end())))
             tool_calls.append(
                 ToolCall(
                     id=unique_tool_call_id(),
@@ -161,5 +160,4 @@ class GlmParser(ToolCallParser):
                     },
                 )
             )
-            end = cls.markup_end(region, m.end())
-        return RegionParse(tuple(tool_calls), begin, end)
+        return RegionParse(tuple(tool_calls), tuple(spans))

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -30,7 +30,14 @@ _TOOLCALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)$", re.D
 # followed by the name" produced a call named " followed by the name. Hope
 # that helps!", and a Hermes-style `<tool_call>{"name": ...}` produced one
 # named after the whole JSON object. Both reached clients as `tool_calls`.
-_TOOL_NAME_RE = re.compile(r"^[A-Za-z_][\w.\-]*$")
+#
+# `\w` and not `[A-Za-z_]`: OpenAI's own grammar is `^[a-zA-Z0-9_-]{1,64}$`,
+# so a leading digit is legal (`7z_extract`), and `\w` is Unicode-aware, so a
+# CJK name is too -- which matters rather a lot on a Chinese model family.
+# Rejecting one is silent, and prose is still rejected because a space cannot
+# appear in the tail. `\Z` and not `$`, which also matches before a trailing
+# newline and would admit a name with one.
+_TOOL_NAME_RE = re.compile(r"^\w[\w.\-]*\Z")
 _ARG_RE = re.compile(
     r"<arg_key>(.*?)</arg_key>\s*<arg_value>"
     r"(.*?)(?:</arg_value>|(?=<arg_key>)|(?=</tool_call>)|$)",
@@ -55,7 +62,7 @@ class GlmParser(BufferedMarkerParser):
         param_types = build_param_types(tools)
         start = text.find("<tool_call>")
         if start == -1:
-            return text.strip(), []
+            return text, []  # no call -> verbatim; see ToolCallParser.parse
         content = text[:start]
         tool_calls: list[ToolCall] = []
         for m in _TOOLCALL_RE.finditer(text):
@@ -82,4 +89,4 @@ class GlmParser(BufferedMarkerParser):
                     },
                 )
             )
-        return content.strip(), tool_calls
+        return (content.strip() if tool_calls else text), tool_calls

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -33,7 +33,6 @@ _ARG_RE = re.compile(
 
 class GlmParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "glm"
-    MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", "<arg_key>")
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
 
     @classmethod

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -26,6 +26,7 @@ from .tool_parser import (
     ToolCall,
     ToolCallParser,
     continues_a_call,
+    declared_tools_allow,
     unique_tool_call_id,
 )
 
@@ -142,7 +143,7 @@ class GlmParser(ToolCallParser):
             # second; a call cut off inside its own `<arg_key>` passes it, and
             # used to be rejected along with the prose.
             if not closed and not (
-                name in param_types
+                declared_tools_allow(name, param_types)
                 and (
                     arg_key_arrived
                     or (not rest and at_end)

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -38,6 +38,7 @@ _TOOLCALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)$", re.D
 # appear in the tail. `\Z` and not `$`, which also matches before a trailing
 # newline and would admit a name with one.
 _TOOL_NAME_RE = re.compile(r"^\w[\w.\-]*\Z")
+_ARG_OPENER = "<arg_key>"
 _ARG_RE = re.compile(
     r"<arg_key>(.*?)</arg_key>\s*<arg_value>"
     r"(.*?)(?:</arg_value>|(?=<arg_key>)|(?=</tool_call>)|$)",
@@ -45,7 +46,12 @@ _ARG_RE = re.compile(
 )
 
 
-_PEEK_NAME_RE = re.compile(r"<tool_call>\s*(\w[\w.\-]*)\s*<arg_key>")
+# Both call shapes, so `search` finds the *first* call rather than the
+# first one that happens to take arguments. Requiring `<arg_key>` skipped
+# a zero-argument call, announced the name of the one after it, and
+# `parse` then returned them in wire order -- an AssertionError raised
+# out of `flush` on a live SSE stream, from well-formed output.
+_PEEK_NAME_RE = re.compile(r"<tool_call>\s*(\w[\w.\-]*)\s*(?:<arg_key>|</tool_call>)")
 
 
 class GlmParser(BufferedMarkerParser):
@@ -64,7 +70,13 @@ class GlmParser(BufferedMarkerParser):
         """Detect the GLM ``<tool_call>...<arg_key>`` format (never Qwen/DSML)."""
         if QWEN_TOOL_PREFIX in text:  # '<function=' -> Qwen, not GLM
             return False
-        return "<arg_key>" in text or "<tool_call>" in text
+        # `<arg_key>` and not a bare `<tool_call>`: this runs on a rendered
+        # chat template, where a Hermes-JSON model shows the same tag and has
+        # no `<arg_key>` anywhere. Accepting the tag alone bound every such
+        # model to this parser for the process lifetime and logged it as a
+        # success -- /mnt/Qwen3-8B resolved to `glm` while /data/Qwen3.5-27B
+        # resolved to `qwen`, two members of one family disagreeing.
+        return "<arg_key>" in text
 
     @classmethod
     def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
@@ -76,13 +88,24 @@ class GlmParser(BufferedMarkerParser):
         content = text[:start]
         tool_calls: list[ToolCall] = []
         for m in _TOOLCALL_RE.finditer(text):
-            body = m.group(1) if m.group(1) is not None else m.group(2)
+            closed = m.group(1) is not None
+            body = m.group(1) if closed else m.group(2)
             if not body:
                 continue
             ak = body.find("<arg_key>")
             name = (body if ak == -1 else body[:ak]).strip()
             if not _TOOL_NAME_RE.match(name):
                 continue
+            if not closed:
+                # See `QwenXmlParser._is_truncated_call`: an unclosed region
+                # is a cut-off call or prose quoting the tag, and prose has to
+                # fail both tests -- a declared name, and nothing after it but
+                # this format's own next token.
+                rest = body[len(name) :].lstrip() if ak == -1 else ""
+                if name not in param_types or not (
+                    not rest or _ARG_OPENER.startswith(rest[: len(_ARG_OPENER)])
+                ):
+                    continue
             types = param_types.get(name, {})
             args: dict[str, Any] = {}
             for pm in _ARG_RE.finditer(body):

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -45,9 +45,19 @@ _ARG_RE = re.compile(
 )
 
 
+_PEEK_NAME_RE = re.compile(r"<tool_call>\s*(\w[\w.\-]*)\s*<arg_key>")
+
+
 class GlmParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "glm"
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
+
+    @classmethod
+    def peek_name(cls, region: str) -> str | None:
+        """`<tool_call>NAME<arg_key>` -- the name is what precedes the first
+        argument key, so it is legible only once that key arrives."""
+        m = _PEEK_NAME_RE.search(region)
+        return m.group(1) if m else None
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -75,7 +75,6 @@ _ARG_RE = re.compile(
 
 class GlmParser(ToolCallParser):
     NAME: ClassVar[str] = "glm"
-    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = True
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
     # No `CALL_CLOSERS`: this format's `</tool_call>` closes the call itself
     # rather than a wrapper around it, so `_TOOLCALL_RE` already spans it.

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -24,6 +24,13 @@ from .schema import build_param_types, coerce_json_or_raw
 from .tool_parser import BufferedMarkerParser, ToolCall, unique_tool_call_id
 
 _TOOLCALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)$", re.DOTALL)
+# A tool name is an identifier, which is what the model was given. Without
+# this the unterminated branch above turns any prose after a `<tool_call>`
+# into a call: an answer explaining that "the model writes <tool_call>
+# followed by the name" produced a call named " followed by the name. Hope
+# that helps!", and a Hermes-style `<tool_call>{"name": ...}` produced one
+# named after the whole JSON object. Both reached clients as `tool_calls`.
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z_][\w.\-]*$")
 _ARG_RE = re.compile(
     r"<arg_key>(.*?)</arg_key>\s*<arg_value>"
     r"(.*?)(?:</arg_value>|(?=<arg_key>)|(?=</tool_call>)|$)",
@@ -57,7 +64,7 @@ class GlmParser(BufferedMarkerParser):
                 continue
             ak = body.find("<arg_key>")
             name = (body if ak == -1 else body[:ak]).strip()
-            if not name:
+            if not _TOOL_NAME_RE.match(name):
                 continue
             types = param_types.get(name, {})
             args: dict[str, Any] = {}

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -33,6 +33,7 @@ _ARG_RE = re.compile(
 
 class GlmParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "glm"
+    MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", "<arg_key>")
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
 
     @classmethod

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -21,10 +21,36 @@ from typing import Any, ClassVar
 
 from .qwen3_tool_parser import QWEN_TOOL_PREFIX
 from .schema import build_param_types, coerce_json_or_raw
-from .tool_parser import BufferedMarkerParser, ToolCall, unique_tool_call_id
+from .tool_parser import (
+    RegionParse,
+    ToolCall,
+    ToolCallParser,
+    continues_a_call,
+    unique_tool_call_id,
+)
 
 TOOL_CALL_OPEN = "<tool_call>"
-_TOOLCALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)$", re.DOTALL)
+# A call's body may not contain another `<tool_call>`. Without that the
+# non-greedy match ran from the *first* opener in the region to the first
+# close, so an answer that quotes the tag and then makes a real call produced
+# a "name" of the whole sentence -- rejected by `_TOOL_NAME_RE`, after which
+# `finditer` resumed past the real call and found nothing at all. The tag is
+# what this format opens a call with, so it cannot appear inside one.
+_NOT_NESTED = r"(?:(?!<tool_call>).)"
+_TOOLCALL_RE = re.compile(
+    r"<tool_call>("
+    + _NOT_NESTED
+    + r"*?)</tool_call>|<tool_call>("
+    + _NOT_NESTED
+    + r"*)",
+    re.DOTALL,
+)
+# No `$` on the unclosed alternative. An unclosed call ends where the next one
+# opens, not only at end of stream: with the anchor, a call the model forgot
+# to close followed by a second call matched neither alternative at the first
+# opener, so `finditer` skipped the first call entirely and returned the
+# second -- one call where the model made two, and a different one from the
+# one the early name had already announced.
 # A tool name is an identifier, which is what the model was given. Without
 # this the unterminated branch above turns any prose after a `<tool_call>`
 # into a call: an answer explaining that "the model writes <tool_call>
@@ -47,38 +73,12 @@ _ARG_RE = re.compile(
 )
 
 
-# Both call shapes, so the *first* call is what matches rather than the first
-# one that happens to take arguments. Requiring `<arg_key>` skipped a
-# zero-argument call and announced the name of the one after it.
-#
-# Anchored at the region's own first `<tool_call>`, not searched for: `parse`
-# reads the unclosed case from the first one to end-of-string, so when that
-# one carries no usable name it produces nothing at all -- while a `search`
-# here slid forward to a later opener and announced its name. Measured on
-# `<tool_call><arg_key><tool_call>get_weather<arg_key>`, at every chunk size.
-_PEEK_NAME_RE = re.compile(r"<tool_call>\s*(\w[\w.\-]*)\s*(?:<arg_key>|</tool_call>)")
-
-
-class GlmParser(BufferedMarkerParser):
+class GlmParser(ToolCallParser):
     NAME: ClassVar[str] = "glm"
+    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = True
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
-
-    @classmethod
-    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
-        """`<tool_call>NAME<arg_key>` -- the name is what precedes the first
-        argument key, so it is legible only once that key arrives.
-
-        The one format whose peek and `parse` already agreed. Both followers
-        it accepts are real: `<arg_key>` starts the arguments and
-        `</tool_call>` closes the very block the name opened -- unlike Qwen's,
-        where `</tool_call>` closes an *outer* wrapper and left the inner
-        block unterminated.
-        """
-        start = region.find(TOOL_CALL_OPEN)
-        if start == -1:
-            return None
-        m = _PEEK_NAME_RE.match(region, start)
-        return m.group(1) if m else None
+    # No `CALL_CLOSERS`: this format's `</tool_call>` closes the call itself
+    # rather than a wrapper around it, so `_TOOLCALL_RE` already spans it.
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -94,21 +94,26 @@ class GlmParser(BufferedMarkerParser):
         return "<arg_key>" in text
 
     @classmethod
-    def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
-        """Parse GLM tool calls; return (leading_content, tool_calls)."""
+    def parse_region(
+        cls, region: str, tools: list | None, *, at_end: bool
+    ) -> RegionParse:
         param_types = build_param_types(tools)
-        start = text.find("<tool_call>")
-        if start == -1:
-            return text, []  # no call -> verbatim; see ToolCallParser.parse
-        content = text[:start]
         tool_calls: list[ToolCall] = []
-        for m in _TOOLCALL_RE.finditer(text):
+        begin = end = 0
+        for m in _TOOLCALL_RE.finditer(region):
             closed = m.group(1) is not None
             body = m.group(1) if closed else m.group(2)
             if not body:
                 continue
             ak = body.find("<arg_key>")
-            if closed or ak != -1:
+            # The argument opener having arrived *is* the follower evidence,
+            # and it is consumed into the name/body split rather than left in
+            # `rest` -- so an empty `rest` here means "the follower came and
+            # went", not "nothing came". Reading the two the same way made a
+            # call whose arguments were still arriving unnameable, which is
+            # the one shape announcing early exists for.
+            arg_key_arrived = ak != -1
+            if closed or arg_key_arrived:
                 name, rest = body[:ak].strip() if ak != -1 else body.strip(), ""
             else:
                 # Unclosed and no complete `<arg_key>` yet. The name runs to
@@ -132,7 +137,11 @@ class GlmParser(BufferedMarkerParser):
             # used to be rejected along with the prose.
             if not closed and not (
                 name in param_types
-                and (not rest or _ARG_OPENER.startswith(rest[: len(_ARG_OPENER)]))
+                and (
+                    arg_key_arrived
+                    or (not rest and at_end)
+                    or continues_a_call(rest, (_ARG_OPENER,), arrived=not at_end)
+                )
             ):
                 continue
             types = param_types.get(name, {})
@@ -141,6 +150,8 @@ class GlmParser(BufferedMarkerParser):
                 k = pm.group(1).strip()
                 if k:
                     args[k] = coerce_json_or_raw(pm.group(2), types.get(k))
+            if not tool_calls:
+                begin = m.start()
             tool_calls.append(
                 ToolCall(
                     id=unique_tool_call_id(),
@@ -151,4 +162,5 @@ class GlmParser(BufferedMarkerParser):
                     },
                 )
             )
-        return (content.strip() if tool_calls else text), tool_calls
+            end = cls.markup_end(region, m.end())
+        return RegionParse(tuple(tool_calls), begin, end)

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -72,11 +72,11 @@ _ARG_RE = re.compile(
 class GlmParser(ToolCallParser):
     NAME: ClassVar[str] = "glm"
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
-    # Both empty, and written out rather than inherited: this format's
-    # `</tool_call>` closes the call itself rather than a wrapper around it,
-    # so `_TOOLCALL_RE` already spans it and no inner block can still be open
-    # once it arrives.
-    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = ()
+    # The call's own closer, and there is no wrapper around it, so
+    # `CALL_CLOSERS` stays empty. Blank here because the two coincide answered
+    # "is there an inner block" with the tuple that says "what ends a call",
+    # and left this the one format whose region could never be seen to close.
+    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = ("</tool_call>",)
 
     @classmethod
     def render_call(cls, name: str, args: dict[str, str]) -> str:

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -59,9 +59,16 @@ class GlmParser(BufferedMarkerParser):
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
 
     @classmethod
-    def peek_name(cls, region: str) -> str | None:
+    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
         """`<tool_call>NAME<arg_key>` -- the name is what precedes the first
-        argument key, so it is legible only once that key arrives."""
+        argument key, so it is legible only once that key arrives.
+
+        The one format whose peek and `parse` already agreed. Both followers
+        it accepts are real: `<arg_key>` starts the arguments and
+        `</tool_call>` closes the very block the name opened -- unlike Qwen's,
+        where `</tool_call>` closes an *outer* wrapper and left the inner
+        block unterminated.
+        """
         m = _PEEK_NAME_RE.search(region)
         return m.group(1) if m else None
 
@@ -93,19 +100,33 @@ class GlmParser(BufferedMarkerParser):
             if not body:
                 continue
             ak = body.find("<arg_key>")
-            name = (body if ak == -1 else body[:ak]).strip()
+            if closed or ak != -1:
+                name, rest = body[:ak].strip() if ak != -1 else body.strip(), ""
+            else:
+                # Unclosed and no complete `<arg_key>` yet. The name runs to
+                # the first `<`, and whatever follows is the test below.
+                #
+                # Cut on the character and not on `len(name)`: the name is
+                # stripped, so a single newline after `<tool_call>` shifted
+                # that slice by one and left the name's own last character in
+                # `rest`. A `read_file` call truncated after a leading newline
+                # failed the test and was shipped to the user as raw markup.
+                lt = body.find("<")
+                name = (body if lt == -1 else body[:lt]).strip()
+                rest = "" if lt == -1 else body[lt:]
             if not _TOOL_NAME_RE.match(name):
                 continue
-            if not closed:
-                # See `QwenXmlParser._is_truncated_call`: an unclosed region
-                # is a cut-off call or prose quoting the tag, and prose has to
-                # fail both tests -- a declared name, and nothing after it but
-                # this format's own next token.
-                rest = body[len(name) :].lstrip() if ak == -1 else ""
-                if name not in param_types or not (
-                    not rest or _ARG_OPENER.startswith(rest[: len(_ARG_OPENER)])
-                ):
-                    continue
+            # See `QwenXmlParser._is_truncated_call`: an unclosed region is a
+            # cut-off call or prose quoting the tag, and prose has to fail
+            # both tests -- a declared name, and nothing after it but this
+            # format's own next token. `<tool_call>get_weather<br>` fails the
+            # second; a call cut off inside its own `<arg_key>` passes it, and
+            # used to be rejected along with the prose.
+            if not closed and not (
+                name in param_types
+                and (not rest or _ARG_OPENER.startswith(rest[: len(_ARG_OPENER)]))
+            ):
+                continue
             types = param_types.get(name, {})
             args: dict[str, Any] = {}
             for pm in _ARG_RE.finditer(body):

--- a/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/glm_tool_parser.py
@@ -72,8 +72,11 @@ _ARG_RE = re.compile(
 class GlmParser(ToolCallParser):
     NAME: ClassVar[str] = "glm"
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
-    # No `CALL_CLOSERS`: this format's `</tool_call>` closes the call itself
-    # rather than a wrapper around it, so `_TOOLCALL_RE` already spans it.
+    # Both empty, and written out rather than inherited: this format's
+    # `</tool_call>` closes the call itself rather than a wrapper around it,
+    # so `_TOOLCALL_RE` already spans it and no inner block can still be open
+    # once it arrives.
+    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = ()
 
     @classmethod
     def render_call(cls, name: str, args: dict[str, str]) -> str:

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -63,7 +63,10 @@ _CALL_CONTINUES = ('<|open|>argument key="', "<|close|>call")
 _K3_CALL_RE = re.compile(
     r'<\|open\|>call tool="(?P<name>[^"]*)"(?:\s+index="(?P<index>\d+)")?<\|sep\|>'
     r"(?P<body>" + _NOT_NESTED_CALL + r"*?)"
-    r"(?:(?P<closed><\|close\|>call)"
+    # The separator belongs to the closer, as it does in the model's encoder
+    # and in vLLM's and SGLang's readers. Optional: a truncation can stop
+    # between the two.
+    r"(?:(?P<closed><\|close\|>call(?:<\|sep\|>)?)"
     r'|(?=<\|open\|>call tool=")'
     r"|(?=<\|open\|>tools<\|sep\|>)"
     r"|(?=<\|close\|>tools)"
@@ -193,21 +196,35 @@ class KimiK3Parser(ToolCallParser):
     # anyway once it is handed back, but naming it here keeps the newline
     # between the two tokens out of the answer.
     CALL_OPENERS: ClassVar[tuple[str, ...]] = (k3.TOOLS_START,)
-    CALL_CLOSERS: ClassVar[tuple[str, ...]] = ("<|close|>tools",)
-    # NOT `CALL_FILLERS = (k3.BARE_SEPARATOR,)`, though a `<|sep|>` between
-    # `<|close|>call` and `<|close|>tools` does then reach the client. That
-    # tuple feeds the *call*-level walkers too, so declaring it there moved
-    # every K3 call's span and broke four properties at once. The separator
-    # would have to be a wrapper-only filler, and no format needs that yet.
+    # With the separator, because that is where the model puts it. Spelled
+    # without it, `markup_end` stopped on the separator and
+    # `<|sep|><|close|>tools<|sep|>` reached the client as the answer between
+    # two adjacent calls. Not `CALL_FILLERS = (k3.BARE_SEPARATOR,)`, which
+    # would fix the same leak: that tuple feeds the *call*-level walkers too
+    # and moves every K3 call's span.
+    CALL_CLOSERS: ClassVar[tuple[str, ...]] = k3.both_spellings(k3.TOOLS_END)
+    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = k3.both_spellings(k3.CALL_END)
 
     @classmethod
     def render_call(cls, name: str, args: dict[str, str]) -> str:
+        """Byte for byte what `/data/Kimi-K3/encoding_k3.py` emits.
+
+        It used to emit a reduction: no `index`, no `type`, no separator after
+        any closer, no `<|close|>tools` at all. This is the sole source of the
+        K3 corpus, so every K3 property was asked about a shape the model
+        never writes -- `_k3_coerce`'s `type=` branch was unreachable from it.
+
+        `type="string"` because the signature takes `dict[str, str]`; the
+        model chooses per value in `_xtml_type`.
+        """
+        sep = k3.BARE_SEPARATOR
         body = "".join(
-            f'<|open|>argument key="{k}"<|sep|>{v}<|close|>argument'
+            f'<|open|>argument key="{k}" type="string"{sep}{v}{k3.ARGUMENT_END}{sep}'
             for k, v in args.items()
         )
         return (
-            f'{k3.TOOLS_START}<|open|>call tool="{name}"<|sep|>' f"{body}<|close|>call"
+            f'{k3.TOOLS_START}<|open|>call tool="{name}" index="0"{sep}'
+            f"{body}{k3.CALL_END}{sep}{k3.TOOLS_END}{sep}"
         )
 
     @classmethod

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -23,7 +23,14 @@ import re
 from typing import ClassVar
 
 from .. import kimi_k3_tokens as k3
-from .tool_parser import RegionParse, ToolCall, ToolCallParser, unique_tool_call_id
+from .schema import build_param_types
+from .tool_parser import (
+    RegionParse,
+    ToolCall,
+    ToolCallParser,
+    continues_a_call,
+    unique_tool_call_id,
+)
 
 # K3 channel tokens this parser matches on. Kept local so the parser is
 # self-contained; the reasoning splitter declares its own copies.
@@ -41,14 +48,22 @@ KIMI_K3_END_OF_MSG = "<|end_of_msg|>"
 # call's arguments. Every registered format carries this guard now.
 _NOT_NESTED_CALL = r'(?:(?!<\|open\|>call tool=").)'
 _NOT_NESTED_ARG = r'(?:(?!<\|open\|>argument key=").)'
+# What may follow a call's opener in a real call: an argument, or the close of
+# the call the name opened. One tuple, read by `_is_truncated_call`.
+_CALL_CONTINUES = ('<|open|>argument key="', "<|close|>call")
+# Closed, or cut off at end of input. Without it a call truncated by
+# `max_tokens` parsed to nothing and its raw tokens went out as the answer.
 _K3_CALL_RE = re.compile(
     r'<\|open\|>call tool="(?P<name>[^"]*)"(?:\s+index="(?P<index>\d+)")?<\|sep\|>'
-    r"(?P<body>" + _NOT_NESTED_CALL + r"*?)<\|close\|>call",
+    r"(?P<body>" + _NOT_NESTED_CALL + r"*?)"
+    r"(?:(?P<closed><\|close\|>call)|(?=<\|close\|>tools)|\Z)",
     re.DOTALL,
 )
 _K3_ARG_RE = re.compile(
     r'<\|open\|>argument key="(?P<key>[^"]*)"(?:\s+type="(?P<type>[^"]*)")?<\|sep\|>'
-    r"(?P<val>" + _NOT_NESTED_ARG + r"*?)<\|close\|>argument",
+    # Same alternation, so a value the model was cut off inside survives.
+    r"(?P<val>" + _NOT_NESTED_ARG + r"*?)"
+    r"(?:<\|close\|>argument|(?=<\|close\|>call)|\Z)",
     re.DOTALL,
 )
 # The channel framing this format wraps every answer in, tool call or not.
@@ -109,6 +124,22 @@ def _k3_coerce(val: str, ptype: str | None):
         return v
 
 
+def _is_truncated_call(
+    name: str, body: str, param_types: dict, *, at_end: bool
+) -> bool:
+    """Is this unclosed `<|open|>call tool=...` a cut-off call, or prose?
+
+    The gate travels with the unclosed alternative or a sentence that merely
+    *quotes* the opener parses as a call.
+    """
+    if name not in param_types:
+        return False
+    rest = body.lstrip()
+    return (not rest and at_end) or continues_a_call(
+        rest, _CALL_CONTINUES, arrived=not at_end
+    )
+
+
 class KimiK3Parser(ToolCallParser):
     """Kimi-K3 channel format: buffer the tools section, parse + emit at flush.
 
@@ -144,8 +175,23 @@ class KimiK3Parser(ToolCallParser):
     # The tools channel closing after the last call. Framing would drop it
     # anyway once it is handed back, but naming it here keeps the newline
     # between the two tokens out of the answer.
-    CALL_OPENERS: ClassVar[tuple[str, ...]] = ("<|open|>tools<|sep|>",)
+    CALL_OPENERS: ClassVar[tuple[str, ...]] = (k3.TOOLS_START,)
     CALL_CLOSERS: ClassVar[tuple[str, ...]] = ("<|close|>tools",)
+    # NOT `CALL_FILLERS = (k3.BARE_SEPARATOR,)`, though a `<|sep|>` between
+    # `<|close|>call` and `<|close|>tools` does then reach the client. That
+    # tuple feeds the *call*-level walkers too, so declaring it there moved
+    # every K3 call's span and broke four properties at once. The separator
+    # would have to be a wrapper-only filler, and no format needs that yet.
+
+    @classmethod
+    def render_call(cls, name: str, args: dict[str, str]) -> str:
+        body = "".join(
+            f'<|open|>argument key="{k}"<|sep|>{v}<|close|>argument'
+            for k, v in args.items()
+        )
+        return (
+            f'{k3.TOOLS_START}<|open|>call tool="{name}"<|sep|>' f"{body}<|close|>call"
+        )
 
     @classmethod
     def opens_region(cls, marker: str) -> bool:
@@ -170,9 +216,14 @@ class KimiK3Parser(ToolCallParser):
         characters, and a truncated call kept its half-written payload with the
         dangling `<|close|>argument` still in it.
         """
+        param_types = build_param_types(tools)
         tool_calls: list[ToolCall] = []
         spans: list[tuple[int, int]] = []
         for m in _K3_CALL_RE.finditer(region):
+            if m.group("closed") is None and not _is_truncated_call(
+                m.group("name"), m.group("body"), param_types, at_end=at_end
+            ):
+                continue
             args: dict = {}
             for a in _K3_ARG_RE.finditer(m.group("body")):
                 args[a.group("key")] = _k3_coerce(a.group("val"), a.group("type"))

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -29,6 +29,7 @@ from .tool_parser import (
     ToolCall,
     ToolCallParser,
     continues_a_call,
+    declared_tools_allow,
     unique_tool_call_id,
 )
 
@@ -147,7 +148,7 @@ def _is_truncated_call(
     The gate travels with the unclosed alternative or a sentence that merely
     *quotes* the opener parses as a call.
     """
-    if name not in param_types:
+    if not declared_tools_allow(name, param_types):
         return False
     rest = body.lstrip()
     return (not rest and at_end) or continues_a_call(

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -51,19 +51,34 @@ _NOT_NESTED_ARG = r'(?:(?!<\|open\|>argument key=").)'
 # What may follow a call's opener in a real call: an argument, or the close of
 # the call the name opened. One tuple, read by `_is_truncated_call`.
 _CALL_CONTINUES = ('<|open|>argument key="', "<|close|>call")
-# Closed, or cut off at end of input. Without it a call truncated by
-# `max_tokens` parsed to nothing and its raw tokens went out as the answer.
+# Closed, cut off where the next call or section opens, or cut off at end of
+# input. Without end-of-input a call truncated by `max_tokens` parsed to
+# nothing and its raw tokens went out as the answer. The opener lookaheads are
+# the fifth terminator `parse_region` names, and this format needed them most:
+# the tempered dot already stops the body at a sibling, so with no terminator
+# accepting that position the whole entry matched nothing and was dropped --
+# after the announcement had named it.
 _K3_CALL_RE = re.compile(
     r'<\|open\|>call tool="(?P<name>[^"]*)"(?:\s+index="(?P<index>\d+)")?<\|sep\|>'
     r"(?P<body>" + _NOT_NESTED_CALL + r"*?)"
-    r"(?:(?P<closed><\|close\|>call)|(?=<\|close\|>tools)|\Z)",
+    r"(?:(?P<closed><\|close\|>call)"
+    r'|(?=<\|open\|>call tool=")'
+    r"|(?=<\|open\|>tools<\|sep\|>)"
+    r"|(?=<\|close\|>tools)"
+    r"|\Z)",
     re.DOTALL,
 )
 _K3_ARG_RE = re.compile(
     r'<\|open\|>argument key="(?P<key>[^"]*)"(?:\s+type="(?P<type>[^"]*)")?<\|sep\|>'
-    # Same alternation, so a value the model was cut off inside survives.
+    # Same alternation one level down: a value the model was cut off inside
+    # survives, and an argument missing its closer before a sibling is not
+    # deleted -- that dropped a parameter and dispatched the call without it.
     r"(?P<val>" + _NOT_NESTED_ARG + r"*?)"
-    r"(?:<\|close\|>argument|(?=<\|close\|>call)|\Z)",
+    r"(?:<\|close\|>argument"
+    r'|(?=<\|open\|>argument key=")'
+    r"|(?=<\|open\|>tools<\|sep\|>)"
+    r"|(?=<\|close\|>call)"
+    r"|\Z)",
     re.DOTALL,
 )
 # The channel framing this format wraps every answer in, tool call or not.

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -93,12 +93,22 @@ def _strip_k3_framing(text: str) -> str:
     return _K3_FRAMING_RE.sub("", text)
 
 
-class KimiK3Parser(ToolCallParser):
-    """Kimi-K3 channel format: buffer the whole output, parse + emit at flush.
+_PEEK_NAME_RE = re.compile(r'<\|open\|>call tool="([^"]+)"')
 
-    K3's channel framing interleaves think/response/tools, so partial-chunk
-    parsing is unreliable; buffering to EOS and parsing once is simplest and the
-    outputs are short.
+
+class KimiK3Parser(ToolCallParser):
+    """Kimi-K3 channel format: buffer the tools section, parse + emit at flush.
+
+    A tools section is parsed whole because K3's arguments interleave and a
+    partial one emits garbage. The *response* channel is not a tools section
+    and streams as it arrives: it is plain text wrapped in framing this format
+    also removes when it is not streaming.
+
+    Buffering everything was simpler and was justified by "the outputs are
+    short". Every K3 answer opens with `<|open|>response<|sep|>`, which is one
+    of the markers below, so that read as a tool region and the whole body
+    arrived in one frame at EOS -- measured on a 324-character answer, 324 of
+    them. It is the common path for this model, not an edge case.
     """
 
     NAME: ClassVar[str] = "kimi_k3"
@@ -111,6 +121,22 @@ class KimiK3Parser(ToolCallParser):
         KIMI_K3_RESPONSE_END,
         KIMI_K3_END_OF_MSG,
     )
+    # Of those five, the two that mean a tool call is coming. The other three
+    # wrap every answer this model gives, so they are literals the read-ahead
+    # must not split and nothing more.
+    _REGION_MARKERS: ClassVar[frozenset[str]] = frozenset(
+        {KIMI_K3_CALL_PREFIX, KIMI_K3_TOOLS_START}
+    )
+
+    @classmethod
+    def peek_name(cls, region: str) -> str | None:
+        """`<|open|>call tool="NAME"` -- the name travels in the opener."""
+        m = _PEEK_NAME_RE.search(region)
+        return m.group(1) if m else None
+
+    @classmethod
+    def opens_region(cls, marker: str) -> bool:
+        return marker in cls._REGION_MARKERS
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -150,8 +176,10 @@ class KimiK3Parser(ToolCallParser):
 
     def process(self, text: str) -> list:
         # Buffer everything; K3's interleaved framing is parsed once at flush.
+        # The name is the exception: it travels in the call opener, so it can
+        # go out now rather than after the arguments -- see `announce`.
         self.buf += text
-        return []
+        return self.announce(self.buf)
 
     def flush(self) -> list:
         content, tool_calls = self.parse(self.buf, self.tools)

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -31,6 +31,7 @@ from .tool_parser import (
     continues_a_call,
     declared_tools_allow,
     unique_tool_call_id,
+    usable_tool_name,
 )
 
 # K3 channel tokens this parser matches on. Kept local so the parser is
@@ -236,6 +237,11 @@ class KimiK3Parser(ToolCallParser):
         tool_calls: list[ToolCall] = []
         spans: list[tuple[int, int]] = []
         for m in _K3_CALL_RE.finditer(region):
+            # Before the truncation gate, which only runs for an unclosed
+            # call: `tool="(?P<name>[^"]*)"` matches an empty and an all-space
+            # name, and a *closed* one had nothing to stop it.
+            if not usable_tool_name(m.group("name")):
+                continue
             if m.group("closed") is None and not _is_truncated_call(
                 m.group("name"), m.group("body"), param_types, at_end=at_end
             ):

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -94,11 +94,14 @@ class KimiK3Parser(ToolCallParser):
     """
 
     NAME: ClassVar[str] = "kimi_k3"
-    MARKERS: ClassVar[tuple[str, ...]] = (
-        "<|open|>tools<|sep|>",
-        "<|open|>response<|sep|>",
-        "<|close|>response<|sep|>",
-        "<|end_of_msg|>",
+    # The same five `is_kimi_k3` decides by, named rather than spelled out:
+    # a hand-written copy of this list had four of them.
+    START_MARKERS: ClassVar[tuple[str, ...]] = (
+        KIMI_K3_CALL_PREFIX,
+        KIMI_K3_TOOLS_START,
+        KIMI_K3_RESPONSE_START,
+        KIMI_K3_RESPONSE_END,
+        KIMI_K3_END_OF_MSG,
     )
 
     @classmethod

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -22,12 +22,7 @@ import json
 import re
 from typing import ClassVar
 
-from .tool_parser import (
-    ToolCall,
-    ToolCallParser,
-    continues_a_call,
-    unique_tool_call_id,
-)
+from .tool_parser import RegionParse, ToolCall, ToolCallParser, unique_tool_call_id
 
 # K3 channel tokens this parser matches on. Kept local so the parser is
 # self-contained; the reasoning splitter declares its own copies.
@@ -37,27 +32,36 @@ KIMI_K3_RESPONSE_START = "<|open|>response<|sep|>"
 KIMI_K3_RESPONSE_END = "<|close|>response<|sep|>"
 KIMI_K3_END_OF_MSG = "<|end_of_msg|>"
 
+# A call's body may not contain another call opener, nor an argument's value
+# another argument opener -- those literals are what open one. Without the
+# guard the non-greedy body ran from an opener *quoted in prose* to the real
+# call's closer, so an answer explaining `<|open|>call tool="NAME"<|sep|>`
+# before making a real call produced one call named `NAME` carrying the real
+# call's arguments. Every registered format carries this guard now.
+_NOT_NESTED_CALL = r'(?:(?!<\|open\|>call tool=").)'
+_NOT_NESTED_ARG = r'(?:(?!<\|open\|>argument key=").)'
 _K3_CALL_RE = re.compile(
     r'<\|open\|>call tool="(?P<name>[^"]*)"(?:\s+index="(?P<index>\d+)")?<\|sep\|>'
-    r"(?P<body>.*?)<\|close\|>call",
+    r"(?P<body>" + _NOT_NESTED_CALL + r"*?)<\|close\|>call",
     re.DOTALL,
 )
 _K3_ARG_RE = re.compile(
     r'<\|open\|>argument key="(?P<key>[^"]*)"(?:\s+type="(?P<type>[^"]*)")?<\|sep\|>'
-    r"(?P<val>.*?)<\|close\|>argument",
+    r"(?P<val>" + _NOT_NESTED_ARG + r"*?)<\|close\|>argument",
     re.DOTALL,
 )
-# What `parse` removes from *content*. Every alternative here is a literal
-# this format also declares in `START_MARKERS`, and it has to be: the two
-# answer the same question -- which bytes are framing rather than answer --
-# and the streaming path can only hold back a literal. `call` and `argument`
-# were in this list and could not be declared, because they carry data
-# (`tool="..."`, `key="..."`); the bare `<|sep|>` at their end *was* declared,
-# so a quoted `<|open|>argument key="city"<|sep|>` came out stripped when
-# parsed whole and with only its separator removed when streamed -- text
-# matching neither path. They are removed inside a tools section by
-# `_K3_CALL_RE` and `_K3_ARG_RE`, which is the only place they occur in a
-# real answer, so nothing needs them here.
+# The channel framing this format wraps every answer in, tool call or not.
+# Declared once and consumed once: `START_MARKERS` lists these so the
+# read-ahead cannot split one, `opens_region` says no to them so the reader
+# drops them, and that is the only place they are removed. There used to be a
+# second removal inside `parse` -- a regex built from a hand-kept copy of this
+# list -- and the two disagreed about four tokens, which reached the client
+# verbatim when streamed and were deleted when not.
+#
+# `call` and `argument` are deliberately absent: they carry data
+# (`tool="..."`, `key="..."`) so they cannot be declared as literals, and they
+# only ever occur inside a tools section, where `_K3_CALL_RE` and `_K3_ARG_RE`
+# account for them.
 _K3_CONTENT_FRAMING = (
     "<|open|>response<|sep|>",
     "<|close|>response<|sep|>",
@@ -74,10 +78,6 @@ _K3_CONTENT_FRAMING = (
     "<|close|>call",
     "<|end_of_msg|>",
     "<|sep|>",
-)
-# Longest first, so a token that is a prefix of another does not truncate it.
-_K3_FRAMING_RE = re.compile(
-    "|".join(re.escape(t) for t in sorted(_K3_CONTENT_FRAMING, key=len, reverse=True))
 )
 
 
@@ -113,42 +113,6 @@ def _k3_coerce(val: str, ptype: str | None):
         return v
 
 
-def _is_truncated_call(text: str, after_opener: int, *, arrived: bool) -> bool:
-    """Is the call opener at ``after_opener`` a cut-off call, or a quotation?
-
-    See :func:`QwenXmlParser._is_truncated_call`. Only the second of its two
-    tests applies here: K3 carries argument types on the wire, so this parser
-    is never given `tools` and has no declared names to check against. What
-    follows the opener is enough -- a call stops inside its own syntax and
-    prose continues in English.
-    """
-    rest = text[after_opener:].lstrip()
-    return not rest or continues_a_call(rest, _CALL_CONTINUES, arrived=arrived)
-
-
-def _strip_k3_framing(text: str) -> str:
-    """Remove the channel tokens, and nothing else.
-
-    No `.strip()`. Removing framing is this format's own normalization and
-    both paths do it; trimming whitespace is position-dependent and so cannot
-    agree between them -- streaming applies it to the region after a marker
-    and non-streaming to the whole answer, which turned `writes <tok> to` into
-    `writes to` on one path and `writes  to` on the other.
-    """
-    return _K3_FRAMING_RE.sub("", text)
-
-
-# Name plus the separator that must follow; see QwenXmlParser for why.
-_CALL_OPENER_RE = re.compile(r'<\|open\|>call tool="[^"]*"[^<]*<\|sep\|>')
-_PEEK_NAME_RE = re.compile(
-    r'<\|open\|>call tool="([^"]+)"[^<]*<\|sep\|>(.*)', re.DOTALL
-)
-# What may follow that opener in a call: an argument, or the close of the
-# call itself. One tuple, read by `_is_truncated_call` and by `peek_name`.
-_ARG_OPENER = '<|open|>argument key="'
-_CALL_CONTINUES = (_ARG_OPENER, "<|close|>call")
-
-
 class KimiK3Parser(ToolCallParser):
     """Kimi-K3 channel format: buffer the tools section, parse + emit at flush.
 
@@ -181,21 +145,11 @@ class KimiK3Parser(ToolCallParser):
     _REGION_MARKERS: ClassVar[frozenset[str]] = frozenset(
         {KIMI_K3_CALL_PREFIX, KIMI_K3_TOOLS_START}
     )
-
-    @classmethod
-    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
-        """`<|open|>call tool="NAME"` -- the name travels in the opener.
-
-        Judged by the same `_is_truncated_call` that decides whether `parse`
-        cuts the answer there. This used to announce on the opener alone, so
-        an answer *quoting* one named a tool the client never called.
-        """
-        m = _PEEK_NAME_RE.search(region)
-        if m is None or not m.group(2).lstrip():
-            return None
-        if not _is_truncated_call(region, m.start(2), arrived=True):
-            return None
-        return m.group(1)
+    # The tools channel closing after the last call. Framing would drop it
+    # anyway once it is handed back, but naming it here keeps the newline
+    # between the two tokens out of the answer.
+    CALL_OPENERS: ClassVar[tuple[str, ...]] = ("<|open|>tools<|sep|>",)
+    CALL_CLOSERS: ClassVar[tuple[str, ...]] = ("<|close|>tools",)
 
     @classmethod
     def opens_region(cls, marker: str) -> bool:
@@ -206,13 +160,28 @@ class KimiK3Parser(ToolCallParser):
         return is_kimi_k3(text)
 
     @classmethod
-    def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
-        """Parse the Kimi-K3 channel format; return (clean_content, tool_calls)."""
+    def parse_region(
+        cls, region: str, tools: list | None, *, at_end: bool
+    ) -> RegionParse:
+        """Every complete call in the section, and where the section ends.
+
+        A call cut off by `max_tokens` has no `<|close|>call` and so parses to
+        nothing, which means the region was not a call after all and its bytes
+        are released unchanged -- the same answer this format now gives to an
+        answer that merely quotes the opener. Both used to be decided here, by
+        a second opener regex that accepted shapes `_K3_CALL_RE` rejects, and
+        the two ways of getting it wrong were opposite: a quotation lost 62
+        characters, and a truncated call kept its half-written payload with the
+        dangling `<|close|>argument` still in it.
+        """
         tool_calls: list[ToolCall] = []
-        for m in _K3_CALL_RE.finditer(text):
+        begin = end = 0
+        for m in _K3_CALL_RE.finditer(region):
             args: dict = {}
             for a in _K3_ARG_RE.finditer(m.group("body")):
                 args[a.group("key")] = _k3_coerce(a.group("val"), a.group("type"))
+            if not tool_calls:
+                begin = cls.markup_begin(region, m.start())
             tool_calls.append(
                 ToolCall(
                     id=unique_tool_call_id(),
@@ -223,63 +192,5 @@ class KimiK3Parser(ToolCallParser):
                     },
                 )
             )
-        # Truncated at the tools marker only when a section really opened
-        # there. An answer that merely names the token opened none, and
-        # cutting at it dropped everything after.
-        #
-        # "A call parsed" is the wrong test for that, and was: a call cut off
-        # by `max_tokens` parses to nothing, so the half-written payload was
-        # kept and shipped as content -- `_K3_FRAMING_RE` has no alternative
-        # for the dangling `<|close|>argument`, so it survived too. What
-        # separates the two cases is a call *prefix* after the marker, which
-        # a truncated call still has and a mention of the token does not.
-        # Cut at whichever of the two region markers actually opened one, and
-        # the gate has to agree with `opens_region`: that hands the stream
-        # over on a bare call prefix, while this looked only for the tools
-        # wrapper, so a call region without one delivered its argument values
-        # as content as well as as a tool call.
-        # A *real* call opener, not a mention of the prefix: the same shape
-        # `_PEEK_NAME_RE` requires. Cutting on the bare prefix truncated an
-        # answer that merely quoted it, which is the promise rule this format
-        # has to keep like every other.
-        m = _CALL_OPENER_RE.search(text)
-        if (
-            m is not None
-            and not tool_calls
-            and not _is_truncated_call(text, m.end(), arrived=False)
-        ):
-            # A start marker is not a promise, and this format had no branch
-            # for it. Nothing parsed to a call and what follows the opener is
-            # English, so the opener is a quotation: cutting there deleted 62
-            # characters of the answer with no event and `finish_reason`
-            # still `stop`. `_CALL_OPENER_RE` cannot tell the two apart on
-            # its own -- it accepts openers `_K3_CALL_RE` rejects.
-            m = None
-        if m is None:
-            return _strip_k3_framing(text), tool_calls
-        ts = text.find(KIMI_K3_TOOLS_START)
-        cut = ts if 0 <= ts < m.start() else m.start()
-        return _strip_k3_framing(text[:cut]), tool_calls
-
-    def process(self, text: str) -> list:
-        # Buffer everything; K3's interleaved framing is parsed once at flush.
-        # The name is the exception: it travels in the call opener, so it can
-        # go out now rather than after the arguments -- see `announce`.
-        self.region.append(text)
-        return self.announce(self.region.head)
-
-    def flush(self) -> list:
-        content, tool_calls = self.parse(self.region.take(), self.tools)
-        results: list = []
-        if not tool_calls:
-            # Nothing to bind an announced name to, and `_emit_call` -- which
-            # is what normally consumes it -- never runs. Left set, it made
-            # the *next* call's name mismatch its own parse.
-            self._announced = None
-        if content:
-            results.append(("content", content))
-        for tc in tool_calls:
-            results.extend(self._emit_call(tc))
-        if self.emitted_calls > 0:
-            results.append(("tool_call_end", None))
-        return results
+            end = cls.markup_end(region, m.end())
+        return RegionParse(tuple(tool_calls), begin, end)

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -82,7 +82,15 @@ def _k3_coerce(val: str, ptype: str | None):
 
 
 def _strip_k3_framing(text: str) -> str:
-    return _K3_FRAMING_RE.sub("", text).strip()
+    """Remove the channel tokens, and nothing else.
+
+    No `.strip()`. Removing framing is this format's own normalization and
+    both paths do it; trimming whitespace is position-dependent and so cannot
+    agree between them -- streaming applies it to the region after a marker
+    and non-streaming to the whole answer, which turned `writes <tok> to` into
+    `writes to` on one path and `writes  to` on the other.
+    """
+    return _K3_FRAMING_RE.sub("", text)
 
 
 class KimiK3Parser(ToolCallParser):
@@ -126,12 +134,19 @@ class KimiK3Parser(ToolCallParser):
                     },
                 )
             )
-        # Truncated at the tools marker only when the section really held a
-        # call. An answer that merely names the token opened no section, and
-        # cutting there dropped everything after it.
+        # Truncated at the tools marker only when a section really opened
+        # there. An answer that merely names the token opened none, and
+        # cutting at it dropped everything after.
+        #
+        # "A call parsed" is the wrong test for that, and was: a call cut off
+        # by `max_tokens` parses to nothing, so the half-written payload was
+        # kept and shipped as content -- `_K3_FRAMING_RE` has no alternative
+        # for the dangling `<|close|>argument`, so it survived too. What
+        # separates the two cases is a call *prefix* after the marker, which
+        # a truncated call still has and a mention of the token does not.
         ts = text.find(KIMI_K3_TOOLS_START)
-        keep = text if (ts == -1 or not tool_calls) else text[:ts]
-        return _strip_k3_framing(keep), tool_calls
+        opened = ts != -1 and KIMI_K3_CALL_PREFIX in text[ts:]
+        return _strip_k3_framing(text[:ts] if opened else text), tool_calls
 
     def process(self, text: str) -> list:
         # Buffer everything; K3's interleaved framing is parsed once at flush.

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -22,6 +22,7 @@ import json
 import re
 from typing import ClassVar
 
+from .. import kimi_k3_tokens as k3
 from .tool_parser import RegionParse, ToolCall, ToolCallParser, unique_tool_call_id
 
 # K3 channel tokens this parser matches on. Kept local so the parser is
@@ -62,22 +63,17 @@ _K3_ARG_RE = re.compile(
 # (`tool="..."`, `key="..."`) so they cannot be declared as literals, and they
 # only ever occur inside a tools section, where `_K3_CALL_RE` and `_K3_ARG_RE`
 # account for them.
+
+# This format's own framing: what wraps every answer, plus what brackets a
+# call. Both halves come from `kimi_k3_tokens`, which the reasoning dialect
+# reads too -- do not re-spell these literals here, that is how the two
+# copies came to disagree.
 _K3_CONTENT_FRAMING = (
-    "<|open|>response<|sep|>",
-    "<|close|>response<|sep|>",
-    "<|open|>think<|sep|>",
-    "<|close|>think<|sep|>",
-    "<|open|>message<|sep|>",
-    "<|close|>message<|sep|>",
-    "<|open|>tools<|sep|>",
-    "<|close|>response",
-    "<|close|>think",
-    "<|close|>message",
-    "<|close|>tools",
-    "<|close|>argument",
-    "<|close|>call",
-    "<|end_of_msg|>",
-    "<|sep|>",
+    *k3.CHANNEL_FRAMING,
+    k3.THINK_START,
+    k3.THINK_END,
+    *k3.TOOL_REGION_FRAMING,
+    *k3.UNPAIRED_FRAMING,
 )
 
 
@@ -175,13 +171,14 @@ class KimiK3Parser(ToolCallParser):
         dangling `<|close|>argument` still in it.
         """
         tool_calls: list[ToolCall] = []
-        begin = end = 0
+        spans: list[tuple[int, int]] = []
         for m in _K3_CALL_RE.finditer(region):
             args: dict = {}
             for a in _K3_ARG_RE.finditer(m.group("body")):
                 args[a.group("key")] = _k3_coerce(a.group("val"), a.group("type"))
-            if not tool_calls:
-                begin = cls.markup_begin(region, m.start())
+            spans.append(
+                (cls.markup_begin(region, m.start()), cls.markup_end(region, m.end()))
+            )
             tool_calls.append(
                 ToolCall(
                     id=unique_tool_call_id(),
@@ -192,5 +189,4 @@ class KimiK3Parser(ToolCallParser):
                     },
                 )
             )
-            end = cls.markup_end(region, m.end())
-        return RegionParse(tuple(tool_calls), begin, end)
+        return RegionParse(tuple(tool_calls), tuple(spans))

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -94,6 +94,12 @@ class KimiK3Parser(ToolCallParser):
     """
 
     NAME: ClassVar[str] = "kimi_k3"
+    MARKERS: ClassVar[tuple[str, ...]] = (
+        "<|open|>tools<|sep|>",
+        "<|open|>response<|sep|>",
+        "<|close|>response<|sep|>",
+        "<|end_of_msg|>",
+    )
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -111,8 +111,6 @@ class KimiK3Parser(ToolCallParser):
     @classmethod
     def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
         """Parse the Kimi-K3 channel format; return (clean_content, tool_calls)."""
-        ts = text.find(KIMI_K3_TOOLS_START)
-        content = _strip_k3_framing(text if ts == -1 else text[:ts])
         tool_calls: list[ToolCall] = []
         for m in _K3_CALL_RE.finditer(text):
             args: dict = {}
@@ -128,7 +126,12 @@ class KimiK3Parser(ToolCallParser):
                     },
                 )
             )
-        return content, tool_calls
+        # Truncated at the tools marker only when the section really held a
+        # call. An answer that merely names the token opened no section, and
+        # cutting there dropped everything after it.
+        ts = text.find(KIMI_K3_TOOLS_START)
+        keep = text if (ts == -1 or not tool_calls) else text[:ts]
+        return _strip_k3_framing(keep), tool_calls
 
     def process(self, text: str) -> list:
         # Buffer everything; K3's interleaved framing is parsed once at flush.

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -81,6 +81,19 @@ def _k3_coerce(val: str, ptype: str | None):
         return v
 
 
+def _is_truncated_call(text: str, after_opener: int) -> bool:
+    """Is the call opener at ``after_opener`` a cut-off call, or a quotation?
+
+    See :func:`QwenXmlParser._is_truncated_call`. Only the second of its two
+    tests applies here: K3 carries argument types on the wire, so this parser
+    is never given `tools` and has no declared names to check against. What
+    follows the opener is enough -- a call stops inside its own syntax and
+    prose continues in English.
+    """
+    rest = text[after_opener:].lstrip()
+    return not rest or any(tok.startswith(rest[: len(tok)]) for tok in _CALL_CONTINUES)
+
+
 def _strip_k3_framing(text: str) -> str:
     """Remove the channel tokens, and nothing else.
 
@@ -95,7 +108,13 @@ def _strip_k3_framing(text: str) -> str:
 
 # Name plus the separator that must follow; see QwenXmlParser for why.
 _CALL_OPENER_RE = re.compile(r'<\|open\|>call tool="[^"]*"[^<]*<\|sep\|>')
-_PEEK_NAME_RE = re.compile(r'<\|open\|>call tool="([^"]+)"[^<]*<\|sep\|>')
+_PEEK_NAME_RE = re.compile(
+    r'<\|open\|>call tool="([^"]+)"[^<]*<\|sep\|>(.*)', re.DOTALL
+)
+# What may follow that opener in a call: an argument, or the close of the
+# call itself. One tuple, read by `_is_truncated_call` and by `peek_name`.
+_ARG_OPENER = '<|open|>argument key="'
+_CALL_CONTINUES = (_ARG_OPENER, "<|close|>call")
 
 
 class KimiK3Parser(ToolCallParser):
@@ -147,10 +166,17 @@ class KimiK3Parser(ToolCallParser):
     )
 
     @classmethod
-    def peek_name(cls, region: str) -> str | None:
-        """`<|open|>call tool="NAME"` -- the name travels in the opener."""
+    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
+        """`<|open|>call tool="NAME"` -- the name travels in the opener.
+
+        Judged by the same `_is_truncated_call` that decides whether `parse`
+        cuts the answer there. This used to announce on the opener alone, so
+        an answer *quoting* one named a tool the client never called.
+        """
         m = _PEEK_NAME_RE.search(region)
-        return m.group(1) if m else None
+        if m is None or not m.group(2).lstrip():
+            return None
+        return m.group(1) if _is_truncated_call(region, m.start(2)) else None
 
     @classmethod
     def opens_region(cls, marker: str) -> bool:
@@ -198,6 +224,14 @@ class KimiK3Parser(ToolCallParser):
         # answer that merely quoted it, which is the promise rule this format
         # has to keep like every other.
         m = _CALL_OPENER_RE.search(text)
+        if m is not None and not tool_calls and not _is_truncated_call(text, m.end()):
+            # A start marker is not a promise, and this format had no branch
+            # for it. Nothing parsed to a call and what follows the opener is
+            # English, so the opener is a quotation: cutting there deleted 62
+            # characters of the answer with no event and `finish_reason`
+            # still `stop`. `_CALL_OPENER_RE` cannot tell the two apart on
+            # its own -- it accepts openers `_K3_CALL_RE` rejects.
+            m = None
         if m is None:
             return _strip_k3_framing(text), tool_calls
         ts = text.find(KIMI_K3_TOOLS_START)
@@ -208,13 +242,17 @@ class KimiK3Parser(ToolCallParser):
         # Buffer everything; K3's interleaved framing is parsed once at flush.
         # The name is the exception: it travels in the call opener, so it can
         # go out now rather than after the arguments -- see `announce`.
-        self.buf += text
-        return self.announce(self.buf)
+        self.region.append(text)
+        return self.announce(self.region.head)
 
     def flush(self) -> list:
-        content, tool_calls = self.parse(self.buf, self.tools)
-        self.buf = ""
+        content, tool_calls = self.parse(self.region.take(), self.tools)
         results: list = []
+        if not tool_calls:
+            # Nothing to bind an announced name to, and `_emit_call` -- which
+            # is what normally consumes it -- never runs. Left set, it made
+            # the *next* call's name mismatch its own parse.
+            self._announced = None
         if content:
             results.append(("content", content))
         for tc in tool_calls:

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -93,7 +93,9 @@ def _strip_k3_framing(text: str) -> str:
     return _K3_FRAMING_RE.sub("", text)
 
 
-_PEEK_NAME_RE = re.compile(r'<\|open\|>call tool="([^"]+)"')
+# Name plus the separator that must follow; see QwenXmlParser for why.
+_CALL_OPENER_RE = re.compile(r'<\|open\|>call tool="[^"]*"[^<]*<\|sep\|>')
+_PEEK_NAME_RE = re.compile(r'<\|open\|>call tool="([^"]+)"[^<]*<\|sep\|>')
 
 
 class KimiK3Parser(ToolCallParser):
@@ -114,12 +116,28 @@ class KimiK3Parser(ToolCallParser):
     NAME: ClassVar[str] = "kimi_k3"
     # The same five `is_kimi_k3` decides by, named rather than spelled out:
     # a hand-written copy of this list had four of them.
+    # Every channel token that can reach *streamed* content, not just the
+    # five `is_kimi_k3` keys on. The read-ahead must not split them and the
+    # facade drops the ones that open no region, which is how streamed text
+    # comes to match what `parse` strips -- with only the five, four other
+    # framing tokens reached the client verbatim while `stream=false` removed
+    # them. The parameterised shapes `_K3_FRAMING_RE` also matches
+    # (`<|open|>argument key=...<|sep|>`) occur only inside a tools section,
+    # which is buffered whole.
     START_MARKERS: ClassVar[tuple[str, ...]] = (
         KIMI_K3_CALL_PREFIX,
         KIMI_K3_TOOLS_START,
         KIMI_K3_RESPONSE_START,
         KIMI_K3_RESPONSE_END,
         KIMI_K3_END_OF_MSG,
+        "<|open|>think<|sep|>",
+        "<|close|>think<|sep|>",
+        "<|open|>message<|sep|>",
+        "<|close|>message<|sep|>",
+        "<|close|>response",
+        "<|close|>think",
+        "<|close|>message",
+        "<|sep|>",
     )
     # Of those five, the two that mean a tool call is coming. The other three
     # wrap every answer this model gives, so they are literals the read-ahead
@@ -170,9 +188,21 @@ class KimiK3Parser(ToolCallParser):
         # for the dangling `<|close|>argument`, so it survived too. What
         # separates the two cases is a call *prefix* after the marker, which
         # a truncated call still has and a mention of the token does not.
+        # Cut at whichever of the two region markers actually opened one, and
+        # the gate has to agree with `opens_region`: that hands the stream
+        # over on a bare call prefix, while this looked only for the tools
+        # wrapper, so a call region without one delivered its argument values
+        # as content as well as as a tool call.
+        # A *real* call opener, not a mention of the prefix: the same shape
+        # `_PEEK_NAME_RE` requires. Cutting on the bare prefix truncated an
+        # answer that merely quoted it, which is the promise rule this format
+        # has to keep like every other.
+        m = _CALL_OPENER_RE.search(text)
+        if m is None:
+            return _strip_k3_framing(text), tool_calls
         ts = text.find(KIMI_K3_TOOLS_START)
-        opened = ts != -1 and KIMI_K3_CALL_PREFIX in text[ts:]
-        return _strip_k3_framing(text[:ts] if opened else text), tool_calls
+        cut = ts if 0 <= ts < m.start() else m.start()
+        return _strip_k3_framing(text[:cut]), tool_calls
 
     def process(self, text: str) -> list:
         # Buffer everything; K3's interleaved framing is parsed once at flush.

--- a/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_k3_tool_parser.py
@@ -22,7 +22,12 @@ import json
 import re
 from typing import ClassVar
 
-from .tool_parser import ToolCall, ToolCallParser, unique_tool_call_id
+from .tool_parser import (
+    ToolCall,
+    ToolCallParser,
+    continues_a_call,
+    unique_tool_call_id,
+)
 
 # K3 channel tokens this parser matches on. Kept local so the parser is
 # self-contained; the reasoning splitter declares its own copies.
@@ -42,10 +47,37 @@ _K3_ARG_RE = re.compile(
     r"(?P<val>.*?)<\|close\|>argument",
     re.DOTALL,
 )
+# What `parse` removes from *content*. Every alternative here is a literal
+# this format also declares in `START_MARKERS`, and it has to be: the two
+# answer the same question -- which bytes are framing rather than answer --
+# and the streaming path can only hold back a literal. `call` and `argument`
+# were in this list and could not be declared, because they carry data
+# (`tool="..."`, `key="..."`); the bare `<|sep|>` at their end *was* declared,
+# so a quoted `<|open|>argument key="city"<|sep|>` came out stripped when
+# parsed whole and with only its separator removed when streamed -- text
+# matching neither path. They are removed inside a tools section by
+# `_K3_CALL_RE` and `_K3_ARG_RE`, which is the only place they occur in a
+# real answer, so nothing needs them here.
+_K3_CONTENT_FRAMING = (
+    "<|open|>response<|sep|>",
+    "<|close|>response<|sep|>",
+    "<|open|>think<|sep|>",
+    "<|close|>think<|sep|>",
+    "<|open|>message<|sep|>",
+    "<|close|>message<|sep|>",
+    "<|open|>tools<|sep|>",
+    "<|close|>response",
+    "<|close|>think",
+    "<|close|>message",
+    "<|close|>tools",
+    "<|close|>argument",
+    "<|close|>call",
+    "<|end_of_msg|>",
+    "<|sep|>",
+)
+# Longest first, so a token that is a prefix of another does not truncate it.
 _K3_FRAMING_RE = re.compile(
-    r"<\|(?:open|close)\|>(?:response|message|tools|think|call|argument)[^<]*?<\|sep\|>"
-    r"|<\|close\|>(?:response|message|tools|think)"
-    r"|<\|end_of_msg\|>|<\|sep\|>"
+    "|".join(re.escape(t) for t in sorted(_K3_CONTENT_FRAMING, key=len, reverse=True))
 )
 
 
@@ -81,7 +113,7 @@ def _k3_coerce(val: str, ptype: str | None):
         return v
 
 
-def _is_truncated_call(text: str, after_opener: int) -> bool:
+def _is_truncated_call(text: str, after_opener: int, *, arrived: bool) -> bool:
     """Is the call opener at ``after_opener`` a cut-off call, or a quotation?
 
     See :func:`QwenXmlParser._is_truncated_call`. Only the second of its two
@@ -91,7 +123,7 @@ def _is_truncated_call(text: str, after_opener: int) -> bool:
     prose continues in English.
     """
     rest = text[after_opener:].lstrip()
-    return not rest or any(tok.startswith(rest[: len(tok)]) for tok in _CALL_CONTINUES)
+    return not rest or continues_a_call(rest, _CALL_CONTINUES, arrived=arrived)
 
 
 def _strip_k3_framing(text: str) -> str:
@@ -133,34 +165,19 @@ class KimiK3Parser(ToolCallParser):
     """
 
     NAME: ClassVar[str] = "kimi_k3"
-    # The same five `is_kimi_k3` decides by, named rather than spelled out:
-    # a hand-written copy of this list had four of them.
-    # Every channel token that can reach *streamed* content, not just the
-    # five `is_kimi_k3` keys on. The read-ahead must not split them and the
-    # facade drops the ones that open no region, which is how streamed text
-    # comes to match what `parse` strips -- with only the five, four other
-    # framing tokens reached the client verbatim while `stream=false` removed
-    # them. The parameterised shapes `_K3_FRAMING_RE` also matches
-    # (`<|open|>argument key=...<|sep|>`) occur only inside a tools section,
-    # which is buffered whole.
+    # Every token `parse` strips from content, plus the call prefix that opens
+    # a region. Derived from `_K3_CONTENT_FRAMING` rather than written out
+    # again: the read-ahead must not split a token the stripper removes, and a
+    # hand-kept second copy of the list is how four of them came to be missing
+    # -- they reached the client verbatim when streamed and were deleted when
+    # not. `is_kimi_k3` keys on five of these; this is not that list.
     START_MARKERS: ClassVar[tuple[str, ...]] = (
         KIMI_K3_CALL_PREFIX,
-        KIMI_K3_TOOLS_START,
-        KIMI_K3_RESPONSE_START,
-        KIMI_K3_RESPONSE_END,
-        KIMI_K3_END_OF_MSG,
-        "<|open|>think<|sep|>",
-        "<|close|>think<|sep|>",
-        "<|open|>message<|sep|>",
-        "<|close|>message<|sep|>",
-        "<|close|>response",
-        "<|close|>think",
-        "<|close|>message",
-        "<|sep|>",
+        *_K3_CONTENT_FRAMING,
     )
-    # Of those five, the two that mean a tool call is coming. The other three
-    # wrap every answer this model gives, so they are literals the read-ahead
-    # must not split and nothing more.
+    # The two that mean a tool call is coming. Every other marker above is
+    # channel framing that wraps every answer this model gives, so they are
+    # literals the read-ahead must not split and nothing more.
     _REGION_MARKERS: ClassVar[frozenset[str]] = frozenset(
         {KIMI_K3_CALL_PREFIX, KIMI_K3_TOOLS_START}
     )
@@ -176,7 +193,9 @@ class KimiK3Parser(ToolCallParser):
         m = _PEEK_NAME_RE.search(region)
         if m is None or not m.group(2).lstrip():
             return None
-        return m.group(1) if _is_truncated_call(region, m.start(2)) else None
+        if not _is_truncated_call(region, m.start(2), arrived=True):
+            return None
+        return m.group(1)
 
     @classmethod
     def opens_region(cls, marker: str) -> bool:
@@ -224,7 +243,11 @@ class KimiK3Parser(ToolCallParser):
         # answer that merely quoted it, which is the promise rule this format
         # has to keep like every other.
         m = _CALL_OPENER_RE.search(text)
-        if m is not None and not tool_calls and not _is_truncated_call(text, m.end()):
+        if (
+            m is not None
+            and not tool_calls
+            and not _is_truncated_call(text, m.end(), arrived=False)
+        ):
             # A start marker is not a promise, and this format had no branch
             # for it. Nothing parsed to a call and what follows the opener is
             # English, so the opener is a quotation: cutting there deleted 62

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -58,6 +58,9 @@ def _parse_entries(section_text: str) -> list[ToolCall]:
     return tool_calls
 
 
+_PEEK_NAME_RE = re.compile(r"<\|tool_call_begin\|>functions\.([^:\s]+):")
+
+
 class KimiParser(ToolCallParser):
     """States: 0 = plain content, 1 = inside section, 2 = section closed."""
 
@@ -65,6 +68,12 @@ class KimiParser(ToolCallParser):
     # The section opener, and the only literal detection keys on. The entry
     # markers inside it are `_drain_entries`' business, never a reader's.
     START_MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_BEGIN,)
+
+    @classmethod
+    def peek_name(cls, region: str) -> str | None:
+        """`<|tool_call_begin|>functions.NAME:0` -- the entry header."""
+        m = _PEEK_NAME_RE.search(region)
+        return m.group(1) if m else None
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -103,6 +112,7 @@ class KimiParser(ToolCallParser):
             if scan.hit is not None:
                 self.state = 1
                 self.buf = scan.rest
+                results.extend(self.announce(self.buf))
                 results.extend(self._drain_entries())
 
         elif self.state == 1:
@@ -114,6 +124,10 @@ class KimiParser(ToolCallParser):
                 self.state = 2
                 self.buf = ""
             else:
+                # This format drains per *completed* entry, so a call with a
+                # large argument payload still waited for its closing token.
+                # The name is in the entry header; it can go now.
+                results.extend(self.announce(self.buf))
                 results.extend(self._drain_entries())
 
         return results
@@ -130,17 +144,7 @@ class KimiParser(ToolCallParser):
             index = int(match.group(2))
             arguments = match.group(3).strip()
 
-            results.append(
-                (
-                    "tool_call_start",
-                    {
-                        "index": index,
-                        "id": f"functions.{name}:{index}",
-                        "type": "function",
-                        "function": {"name": name, "arguments": ""},
-                    },
-                )
-            )
+            results.extend(self._start_event(index, f"functions.{name}:{index}", name))
             if arguments:
                 results.append(
                     (

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -43,7 +43,12 @@ def _parse_entries(section_text: str) -> list[ToolCall]:
     for match in _ENTRY_RE.finditer(section_text):
         name = match.group(1)
         index = match.group(2)
-        arguments = match.group(3).strip()
+        # `"{}"` and not `""` for a zero-argument call. This format passes
+        # the wire bytes through where the other five build a JSON object, so
+        # it was the one format whose no-argument call reached the client as
+        # an empty string -- `json.loads("")` raises, and on `/v1/messages` it
+        # becomes an `input_json_delta` the Anthropic SDK cannot accumulate.
+        arguments = match.group(3).strip() or "{}"
         tool_id = f"functions.{name}:{index}"
         tool_calls.append(
             ToolCall(

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -20,7 +20,6 @@ rather than a random one, and ``index`` comes from the wire too.
 import re
 from typing import ClassVar
 
-from ..marker_scanner import MarkerScanner
 from .tool_parser import ToolCall, ToolCallParser
 
 KIMI_SECTION_BEGIN = "<|tool_calls_section_begin|>"
@@ -98,9 +97,7 @@ class KimiParser(ToolCallParser):
             # or an answer merely discussing one -- withheld everything after
             # it until the stream ended. The 30-character floor went with it;
             # the scanner's bound is the marker's own length.
-            if self._scanner_cache is None:
-                self._scanner_cache = MarkerScanner((KIMI_SECTION_BEGIN,))
-            scan = self._scanner_cache.feed(text)
+            scan = self._scanner.feed(text)
             if scan.released:
                 results.append(("content", scan.released))
             if scan.hit is not None:

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -96,4 +96,8 @@ class KimiParser(ToolCallParser):
         # first entry; everything before it is the answer.
         first = _ENTRY_RE.search(region)
         opened = region.rfind(KIMI_SECTION_BEGIN, 0, first.start())
-        return RegionParse(tuple(entries), max(opened, 0), len(region))
+        # One span for the whole section, not one per entry: `region_end`
+        # already hands this exactly one section, and between two entries
+        # there is only `<|tool_call_end|><|tool_call_begin|>` -- special
+        # tokens a model cannot write prose between.
+        return RegionParse(tuple(entries), ((max(opened, 0), len(region)),))

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -156,11 +156,23 @@ class KimiParser(ToolCallParser):
 
     def flush(self) -> list:
         results: list = []
-        if self.state == 0 and self.buf:
-            results.append(("content", self.buf))
+        if self.state == 0:
+            # The scanner owns the held tail now, and `self.buf` is never
+            # written in this state -- draining only `self.buf` here dropped
+            # whatever was still being read ahead. Six characters on
+            # `process("hello <|tool")`.
+            held = self._scanner_cache.flush() if self._scanner_cache else ""
+            rest = held + self.buf
             self.buf = ""
+            if rest:
+                results.append(("content", rest))
         elif self.state == 1:
             results.extend(self._drain_entries())
             if self.emitted_calls > 0:
                 results.append(("tool_call_end", None))
+            elif self.buf:
+                # The section opened and closed nothing. Same rule as every
+                # other format: a start marker is not a promise.
+                results.append(("content", KIMI_SECTION_BEGIN + self.buf))
+                self.buf = ""
         return results

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -29,6 +29,7 @@ from .tool_parser import (
     ToolCallParser,
     continues_a_call,
     declared_tools_allow,
+    usable_tool_name,
 )
 
 KIMI_SECTION_BEGIN = "<|tool_calls_section_begin|>"
@@ -95,6 +96,11 @@ def _parse_entries(
     for match in _ENTRY_RE.finditer(section_text):
         name = match.group(1)
         index = match.group(2)
+        # `[\w.\-]+` is not the same set: it admits a leading `.` or `-`, so
+        # `functions..hidden:0` shipped a call named `.hidden`. "Safe by
+        # construction" is why this parser was left out of the sweep.
+        if not usable_tool_name(name):
+            continue
         if match.group("closed") is None and not _is_truncated_call(
             name, match.group(3), param_types, at_end=at_end
         ):
@@ -123,6 +129,10 @@ class KimiParser(ToolCallParser):
     # The section opener, and the only literal detection keys on. The entry
     # markers inside it are `parse_region`'s business, never a reader's.
     START_MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_BEGIN,)
+    # An entry's own end. `CALL_CLOSERS` stays empty: the section end is a
+    # `REGION_END_MARKER`, which is a stronger statement than "markup at a
+    # call's right edge" and is what `markup_end` must not walk over here.
+    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = (KIMI_ENTRY_END,)
     # A special token, so it cannot appear inside a JSON argument value. That
     # is the whole licence for closing a region on it: the XML formats' own
     # closers fail this test, because a model writing about tool calls puts

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -58,9 +58,6 @@ def _parse_entries(section_text: str) -> list[ToolCall]:
     return tool_calls
 
 
-_PEEK_NAME_RE = re.compile(r"<\|tool_call_begin\|>functions\.([^:\s]+):")
-
-
 class KimiParser(ToolCallParser):
     """States: 0 = plain content, 1 = inside section, 2 = section closed."""
 
@@ -69,11 +66,12 @@ class KimiParser(ToolCallParser):
     # markers inside it are `_drain_entries`' business, never a reader's.
     START_MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_BEGIN,)
 
-    @classmethod
-    def peek_name(cls, region: str) -> str | None:
-        """`<|tool_call_begin|>functions.NAME:0` -- the entry header."""
-        m = _PEEK_NAME_RE.search(region)
-        return m.group(1) if m else None
+    # No `peek_name`, deliberately. This format carries the call's index and
+    # id on the wire (`functions.NAME:INDEX`), and an announcement has to be
+    # stamped with both before the entry that supplies them has arrived --
+    # every announced call went out at index 0, so a client accumulating by
+    # index overwrote the first call with the second. It also drains per
+    # completed entry rather than at flush, so it has the least to gain.
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -112,22 +110,32 @@ class KimiParser(ToolCallParser):
             if scan.hit is not None:
                 self.state = 1
                 self.buf = scan.rest
-                results.extend(self.announce(self.buf))
                 results.extend(self._drain_entries())
 
         elif self.state == 1:
             self.buf += text
             if KIMI_SECTION_END in self.buf:
-                self.buf = self.buf.split(KIMI_SECTION_END)[0]
+                section, _, after = self.buf.partition(KIMI_SECTION_END)
+                self.buf = section
                 results.extend(self._drain_entries())
-                results.append(("tool_call_end", None))
-                self.state = 2
+                if self.emitted_calls:
+                    results.append(("tool_call_end", None))
+                else:
+                    # A start marker is not a promise, for this format too.
+                    # The section body was dropped here and `state = 2` then
+                    # discarded the rest of the stream: an answer quoting both
+                    # section tokens delivered 26 of its 135 characters when
+                    # fed four at a time, and all 135 in one shot. `flush`'s
+                    # fallback could not see it -- the bytes were already gone.
+                    kept = KIMI_SECTION_BEGIN + section + KIMI_SECTION_END
+                    results.append(("content", kept))
+                # Back to plain content, not a terminal state: text after the
+                # section is still the answer.
+                self.state = 0
                 self.buf = ""
+                if after:
+                    results.extend(self.process(after))
             else:
-                # This format drains per *completed* entry, so a call with a
-                # large argument payload still waited for its closing token.
-                # The name is in the entry header; it can go now.
-                results.extend(self.announce(self.buf))
                 results.extend(self._drain_entries())
 
         return results
@@ -145,13 +153,16 @@ class KimiParser(ToolCallParser):
             arguments = match.group(3).strip()
 
             results.extend(self._start_event(index, f"functions.{name}:{index}", name))
-            if arguments:
-                results.append(
-                    (
-                        "tool_call_args",
-                        {"index": index, "function": {"arguments": arguments}},
-                    )
+            # Unconditional, empty arguments included: a zero-parameter tool
+            # is a call the client should run, and `finish_reason` keys on
+            # this event. Gating it here reported `stop` for a response that
+            # had already sent a `tool_calls` delta.
+            results.append(
+                (
+                    "tool_call_args",
+                    {"index": index, "function": {"arguments": arguments}},
                 )
+            )
 
             self.buf = self.buf[match.end() :]
             self.emitted_calls += 1

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -79,9 +79,19 @@ def _is_truncated_call(
 
 def _parse_entries(
     section_text: str, param_types: dict, *, at_end: bool
-) -> list[ToolCall]:
-    """Parse individual tool call entries from the section content."""
+) -> tuple[list[ToolCall], int]:
+    """The entries this section really made, and where the first one starts.
+
+    The offset is returned rather than recomputed by the caller, because the
+    caller cannot: entries that fail the truncation gate are skipped here, and
+    asking `_ENTRY_RE.search` for the first *match* answers a different
+    question than "the first entry we accepted". They differ exactly when an
+    answer quotes the wire format before making a real call, which is the case
+    the section anchor exists for -- so the recomputation was wrong precisely
+    where it mattered.
+    """
     tool_calls = []
+    first_start = -1
     for match in _ENTRY_RE.finditer(section_text):
         name = match.group(1)
         index = match.group(2)
@@ -96,6 +106,8 @@ def _parse_entries(
         # becomes an `input_json_delta` the Anthropic SDK cannot accumulate.
         arguments = match.group(3).strip() or "{}"
         tool_id = f"functions.{name}:{index}"
+        if first_start < 0:
+            first_start = match.start()
         tool_calls.append(
             ToolCall(
                 id=tool_id,
@@ -103,7 +115,7 @@ def _parse_entries(
                 function={"name": name, "arguments": arguments},
             )
         )
-    return tool_calls
+    return tool_calls, first_start
 
 
 class KimiParser(ToolCallParser):
@@ -150,15 +162,23 @@ class KimiParser(ToolCallParser):
         output -- which is what `_SECTION_RE.search` did -- lost the second
         call entirely and delivered the raw wire tokens of both as content.
         """
-        entries = _parse_entries(region, build_param_types(tools), at_end=at_end)
+        entries, first_start = _parse_entries(
+            region, build_param_types(tools), at_end=at_end
+        )
         if not entries:
             return RegionParse()
         # The region opens at the *first* section marker in the text, which an
         # answer that quotes one before making a real call puts in the wrong
         # place. The section that matters is the last one opened before the
         # first entry; everything before it is the answer.
-        first = _ENTRY_RE.search(region)
-        opened = region.rfind(KIMI_SECTION_BEGIN, 0, first.start())
+        #
+        # The first entry *accepted*, not the first thing the entry pattern
+        # matched. `_ENTRY_RE.search` was the latter, so a quotation the
+        # truncation gate had already rejected still moved the anchor back to
+        # its section -- and the sentence the model wrote between the
+        # quotation and its real call was deleted as markup. The other five
+        # formats keep it; this was the only one that did not.
+        opened = region.rfind(KIMI_SECTION_BEGIN, 0, first_start)
         # One span for the whole section, not one per entry: `region_end`
         # already hands this exactly one section, and between two entries
         # there is only `<|tool_call_end|><|tool_call_begin|>` -- special

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -7,35 +7,26 @@
     <|tool_call_begin|>functions.NAME:INDEX<|tool_call_argument_begin|>ARGS_JSON<|tool_call_end|>
     <|tool_calls_section_end|>
 
-Unlike the XML-ish formats this one is self-delimiting, so entries can be
-emitted as soon as their ``<|tool_call_end|>`` arrives rather than buffering the
-whole block. It therefore implements streaming itself instead of inheriting
-:class:`~.tool_parser.BufferedMarkerParser`.
-
 Arguments are already JSON on the wire, so no schema coercion is applied and
-``tools`` is unused. The call id is the model's own ``functions.NAME:INDEX``
-rather than a random one, and ``index`` comes from the wire too.
+``tools`` is unused for parsing. The call id is the model's own
+``functions.NAME:INDEX``.
+
+The section end is a special token that cannot occur inside an argument value,
+so this is the one format that can say where a region closes without waiting
+for end of stream -- see ``REGION_END_MARKERS``. That is what lets a second
+section, and the answer after the last one, be read at all: both used to be
+swallowed, differently, by the two readers this format used to have.
 """
 
 import re
 from typing import ClassVar
 
-from .tool_parser import ToolCall, ToolCallParser
+from .tool_parser import RegionParse, ToolCall, ToolCallParser
 
 KIMI_SECTION_BEGIN = "<|tool_calls_section_begin|>"
 KIMI_SECTION_END = "<|tool_calls_section_end|>"
 KIMI_ENTRY_END = "<|tool_call_end|>"
-# Nothing in a chunk can complete an entry or the section unless one of these
-# lands in it, so nothing before one arrives needs the buffer materialised.
-# See `KimiParser.process`.
-_DRAIN_TRIGGERS = (KIMI_ENTRY_END, KIMI_SECTION_END)
-_TRIGGER_TAIL = max(len(m) for m in _DRAIN_TRIGGERS) - 1
 
-_SECTION_RE = re.compile(
-    re.escape(KIMI_SECTION_BEGIN) + r"(.*?)" + re.escape(KIMI_SECTION_END),
-    re.DOTALL,
-)
-_UNCLOSED_RE = re.compile(re.escape(KIMI_SECTION_BEGIN) + r"(.*?)$", re.DOTALL)
 _ENTRY_RE = re.compile(
     r"<\|tool_call_begin\|>"
     r"functions\.(\w+):(\d+)"
@@ -65,192 +56,44 @@ def _parse_entries(section_text: str) -> list[ToolCall]:
 
 
 class KimiParser(ToolCallParser):
-    """States: 0 = plain content, 1 = inside a section. There is no third.
-
-    A section closing returns to 0 because the answer continues after it; the
-    terminal state this used to have swallowed everything that followed.
-    """
-
     NAME: ClassVar[str] = "kimi"
     # The section opener, and the only literal detection keys on. The entry
-    # markers inside it are `_drain_entries`' business, never a reader's.
+    # markers inside it are `parse_region`'s business, never a reader's.
     START_MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_BEGIN,)
-
-    # No `peek_name`, deliberately. This format carries the call's index and
-    # id on the wire (`functions.NAME:INDEX`), and an announcement has to be
-    # stamped with both before the entry that supplies them has arrived --
-    # every announced call went out at index 0, so a client accumulating by
-    # index overwrote the first call with the second. It also drains per
-    # completed entry rather than at flush, so it has the least to gain.
-
-    def __init__(self, tools: list | None = None):
-        super().__init__(tools)
-        # Calls drained from the section currently open. `emitted_calls` is
-        # the running total for the whole stream and answers a different
-        # question; using it as this one made the not-a-promise branch dead
-        # code from the first real call onwards.
-        self._section_calls = 0
-        # The tail a drain trigger split across a chunk boundary would need.
-        self._trigger_tail = ""
+    # A special token, so it cannot appear inside a JSON argument value. That
+    # is the whole licence for closing a region on it: the XML formats' own
+    # closers fail this test, because a model writing about tool calls puts
+    # one inside a parameter.
+    REGION_END_MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_END,)
 
     @classmethod
     def detect(cls, text: str) -> bool:
         return KIMI_SECTION_BEGIN in text
 
     @classmethod
-    def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
-        section_match = _SECTION_RE.search(text)
-        if not section_match:
-            # Unclosed section: the model was cut off mid-block; salvage whatever
-            # complete entries it managed to emit.
-            unclosed = _UNCLOSED_RE.search(text)
-            if unclosed:
-                entries = _parse_entries(unclosed.group(1))
-                content = text[: unclosed.start()]
-                # No call -> verbatim; see ToolCallParser.parse.
-                return (content.strip() if entries else text), entries
-            return text, []
-        entries = _parse_entries(section_match.group(1))
-        # What follows the section is the answer continuing, not spare bytes.
-        # Truncating here dropped it, and the streaming path stopped doing so
-        # when its terminal state was replaced -- leaving the two disagreeing
-        # about the same output.
-        before = text[: section_match.start()]
-        after = text[section_match.end() :]
-        return ((before.strip() + after) if entries else text), entries
+    def region_end(cls, region: str) -> int:
+        at = region.find(KIMI_SECTION_END)
+        return at + len(KIMI_SECTION_END) if at != -1 else 0
 
-    def process(self, text: str) -> list:
-        results: list = []
+    @classmethod
+    def parse_region(
+        cls, region: str, tools: list | None, *, at_end: bool
+    ) -> RegionParse:
+        """One section: everything between its two markers, or what arrived.
 
-        if self.state == 0:
-            # Held back: only a suffix that could still grow into the section
-            # marker. It used to be `"<|tool" not in self.buf` over a buffer
-            # that was never cleared while that held, so a single `<|tool` --
-            # or an answer merely discussing one -- withheld everything after
-            # it until the stream ended. The 30-character floor went with it;
-            # the scanner's bound is the marker's own length.
-            scan = self._scanner.feed(text)
-            if scan.released:
-                results.append(("content", scan.released))
-            if scan.hit is None:
-                return results
-            self.state = 1
-            self.buf = ""
-            self._section_calls = 0
-            self._trigger_tail = ""
-            # Falls through rather than returning: the whole section, and the
-            # answer after it, can arrive in the same chunk. Returning here
-            # left the section-end handling below unreached and `flush` then
-            # discarded the buffer, so the same text delivered in full at
-            # seven characters a chunk lost its last 18 in one -- and one big
-            # chunk is exactly what `merge_chunk` coalesces to under load.
-            text = scan.rest
-
-        # Accumulated in a list and searched only when something could have
-        # completed. `self.buf += text` on an attribute is quadratic -- see
-        # `Region` -- and scanning the whole buffer per chunk is a second
-        # factor on top of it: a 50 KB argument cost 55 ms of event-loop CPU
-        # against Qwen's 4 for the same payload, and the gap widens with size.
-        # Only these two markers can end an entry or the section, so until one
-        # of them arrives there is nothing to look at. The tail carries the
-        # bytes a marker split across the boundary would need.
-        self.region.append(text)
-        probe = self._trigger_tail + text
-        self._trigger_tail = probe[-_TRIGGER_TAIL:]
-        if not any(m in probe for m in _DRAIN_TRIGGERS):
-            return results
-
-        self.buf += self.region.take()
-        if KIMI_SECTION_END not in self.buf:
-            results.extend(self._drain_entries())
-            # Whatever is left is the entry still arriving; back it goes, so
-            # the next chunk appends rather than copies it again.
-            self.region.append(self.buf)
-            self.buf = ""
-            return results
-
-        section, _, after = self.buf.partition(KIMI_SECTION_END)
-        self.buf = section
-        results.extend(self._drain_entries())
-        # This section's own count, not the running total. `emitted_calls` is
-        # cumulative, so after one real call every later section read as
-        # fulfilled and the branch below stopped running for the rest of the
-        # stream: prose quoting both section tokens was deleted outright.
-        if self._section_calls:
-            results.append(("tool_call_end", None))
-        else:
-            # A start marker is not a promise, for this format too. The
-            # section body was dropped here and `state = 2` then discarded the
-            # rest of the stream: an answer quoting both section tokens
-            # delivered 26 of its 135 characters when fed four at a time.
-            kept = KIMI_SECTION_BEGIN + section + KIMI_SECTION_END
-            results.append(("content", kept))
-        # Back to plain content, not a terminal state: text after the section
-        # is still the answer.
-        self.state = 0
-        self.buf = ""
-        self._trigger_tail = ""
-        if after:
-            results.extend(self.process(after))
-
-        return results
-
-    def _drain_entries(self) -> list:
-        """Emit every complete tool-call entry sitting in the buffer."""
-        results: list = []
-        while "<|tool_call_begin|>" in self.buf and "<|tool_call_end|>" in self.buf:
-            match = _ENTRY_RE.search(self.buf)
-            if not match:
-                break
-
-            name = match.group(1)
-            index = int(match.group(2))
-            arguments = match.group(3).strip()
-
-            results.extend(self._start_event(index, f"functions.{name}:{index}", name))
-            # Unconditional, empty arguments included: a zero-parameter tool
-            # is a call the client should run, and `finish_reason` keys on
-            # this event. Gating it here reported `stop` for a response that
-            # had already sent a `tool_calls` delta.
-            results.append(
-                (
-                    "tool_call_args",
-                    {"index": index, "function": {"arguments": arguments}},
-                )
-            )
-
-            self.buf = self.buf[match.end() :]
-            self.emitted_calls += 1
-            self._section_calls += 1
-
-        return results
-
-    def flush(self) -> list:
-        results: list = []
-        if self.state == 0:
-            # The scanner owns the held tail now, and `self.buf` is never
-            # written in this state -- draining only `self.buf` here dropped
-            # whatever was still being read ahead. Six characters on
-            # `process("hello <|tool")`.
-            held = self._scanner_cache.flush() if self._scanner_cache else ""
-            rest = held + self.buf
-            self.buf = ""
-            if rest:
-                results.append(("content", rest))
-        elif self.state == 1:
-            # Whatever `process` left unexamined, because no drain trigger had
-            # arrived yet. At end of stream there is nothing more coming, so
-            # this is the one place it always has to be looked at.
-            self.buf += self.region.take()
-            self._trigger_tail = ""
-            results.extend(self._drain_entries())
-            if self._section_calls > 0:
-                results.append(("tool_call_end", None))
-            else:
-                # The section opened and closed nothing. Same rule as every
-                # other format: a start marker is not a promise -- including
-                # when the answer stops on the marker itself, where `self.buf`
-                # is empty and an `elif` on it dropped all 29 characters.
-                results.append(("content", KIMI_SECTION_BEGIN + self.buf))
-                self.buf = ""
-        return results
+        `region_end` hands this exactly one section at a time, so a response
+        with two of them is two regions and the text between and after them
+        reaches the client. Reading the *first* section out of the whole
+        output -- which is what `_SECTION_RE.search` did -- lost the second
+        call entirely and delivered the raw wire tokens of both as content.
+        """
+        entries = _parse_entries(region)
+        if not entries:
+            return RegionParse()
+        # The region opens at the *first* section marker in the text, which an
+        # answer that quotes one before making a real call puts in the wrong
+        # place. The section that matters is the last one opened before the
+        # first entry; everything before it is the answer.
+        first = _ENTRY_RE.search(region)
+        opened = region.rfind(KIMI_SECTION_BEGIN, 0, first.start())
+        return RegionParse(tuple(entries), max(opened, 0), len(region))

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -79,11 +79,14 @@ class KimiParser(ToolCallParser):
             # complete entries it managed to emit.
             unclosed = _UNCLOSED_RE.search(text)
             if unclosed:
+                entries = _parse_entries(unclosed.group(1))
                 content = text[: unclosed.start()]
-                return content.strip(), _parse_entries(unclosed.group(1))
+                # No call -> verbatim; see ToolCallParser.parse.
+                return (content.strip() if entries else text), entries
             return text, []
+        entries = _parse_entries(section_match.group(1))
         content = text[: section_match.start()]
-        return content.strip(), _parse_entries(section_match.group(1))
+        return (content.strip() if entries else text), entries
 
     def process(self, text: str) -> list:
         results: list = []

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -28,6 +28,7 @@ from .tool_parser import (
     ToolCall,
     ToolCallParser,
     continues_a_call,
+    declared_tools_allow,
 )
 
 KIMI_SECTION_BEGIN = "<|tool_calls_section_begin|>"
@@ -70,7 +71,7 @@ def _is_truncated_call(
     The follower is `{`: this format's arguments are JSON on the wire, so a
     real call continues with an object or, at end of region, with nothing.
     """
-    if name not in param_types:
+    if not declared_tools_allow(name, param_types):
         return False
     rest = args.lstrip()
     return (not rest and at_end) or continues_a_call(rest, ("{",), arrived=not at_end)

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -62,6 +62,7 @@ class KimiParser(ToolCallParser):
     """States: 0 = plain content, 1 = inside section, 2 = section closed."""
 
     NAME: ClassVar[str] = "kimi"
+    MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_BEGIN, "<|tool_call_begin|>")
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -59,7 +59,11 @@ def _parse_entries(section_text: str) -> list[ToolCall]:
 
 
 class KimiParser(ToolCallParser):
-    """States: 0 = plain content, 1 = inside section, 2 = section closed."""
+    """States: 0 = plain content, 1 = inside a section. There is no third.
+
+    A section closing returns to 0 because the answer continues after it; the
+    terminal state this used to have swallowed everything that followed.
+    """
 
     NAME: ClassVar[str] = "kimi"
     # The section opener, and the only literal detection keys on. The entry
@@ -72,6 +76,14 @@ class KimiParser(ToolCallParser):
     # every announced call went out at index 0, so a client accumulating by
     # index overwrote the first call with the second. It also drains per
     # completed entry rather than at flush, so it has the least to gain.
+
+    def __init__(self, tools: list | None = None):
+        super().__init__(tools)
+        # Calls drained from the section currently open. `emitted_calls` is
+        # the running total for the whole stream and answers a different
+        # question; using it as this one made the not-a-promise branch dead
+        # code from the first real call onwards.
+        self._section_calls = 0
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -107,36 +119,45 @@ class KimiParser(ToolCallParser):
             scan = self._scanner.feed(text)
             if scan.released:
                 results.append(("content", scan.released))
-            if scan.hit is not None:
-                self.state = 1
-                self.buf = scan.rest
-                results.extend(self._drain_entries())
+            if scan.hit is None:
+                return results
+            self.state = 1
+            self.buf = ""
+            self._section_calls = 0
+            # Falls through rather than returning: the whole section, and the
+            # answer after it, can arrive in the same chunk. Returning here
+            # left the section-end handling below unreached and `flush` then
+            # discarded the buffer, so the same text delivered in full at
+            # seven characters a chunk lost its last 18 in one -- and one big
+            # chunk is exactly what `merge_chunk` coalesces to under load.
+            text = scan.rest
 
-        elif self.state == 1:
-            self.buf += text
-            if KIMI_SECTION_END in self.buf:
-                section, _, after = self.buf.partition(KIMI_SECTION_END)
-                self.buf = section
-                results.extend(self._drain_entries())
-                if self.emitted_calls:
-                    results.append(("tool_call_end", None))
-                else:
-                    # A start marker is not a promise, for this format too.
-                    # The section body was dropped here and `state = 2` then
-                    # discarded the rest of the stream: an answer quoting both
-                    # section tokens delivered 26 of its 135 characters when
-                    # fed four at a time, and all 135 in one shot. `flush`'s
-                    # fallback could not see it -- the bytes were already gone.
-                    kept = KIMI_SECTION_BEGIN + section + KIMI_SECTION_END
-                    results.append(("content", kept))
-                # Back to plain content, not a terminal state: text after the
-                # section is still the answer.
-                self.state = 0
-                self.buf = ""
-                if after:
-                    results.extend(self.process(after))
-            else:
-                results.extend(self._drain_entries())
+        self.buf += text
+        if KIMI_SECTION_END not in self.buf:
+            return results + self._drain_entries()
+
+        section, _, after = self.buf.partition(KIMI_SECTION_END)
+        self.buf = section
+        results.extend(self._drain_entries())
+        # This section's own count, not the running total. `emitted_calls` is
+        # cumulative, so after one real call every later section read as
+        # fulfilled and the branch below stopped running for the rest of the
+        # stream: prose quoting both section tokens was deleted outright.
+        if self._section_calls:
+            results.append(("tool_call_end", None))
+        else:
+            # A start marker is not a promise, for this format too. The
+            # section body was dropped here and `state = 2` then discarded the
+            # rest of the stream: an answer quoting both section tokens
+            # delivered 26 of its 135 characters when fed four at a time.
+            kept = KIMI_SECTION_BEGIN + section + KIMI_SECTION_END
+            results.append(("content", kept))
+        # Back to plain content, not a terminal state: text after the section
+        # is still the answer.
+        self.state = 0
+        self.buf = ""
+        if after:
+            results.extend(self.process(after))
 
         return results
 
@@ -166,6 +187,7 @@ class KimiParser(ToolCallParser):
 
             self.buf = self.buf[match.end() :]
             self.emitted_calls += 1
+            self._section_calls += 1
 
         return results
 
@@ -183,7 +205,7 @@ class KimiParser(ToolCallParser):
                 results.append(("content", rest))
         elif self.state == 1:
             results.extend(self._drain_entries())
-            if self.emitted_calls > 0:
+            if self._section_calls > 0:
                 results.append(("tool_call_end", None))
             elif self.buf:
                 # The section opened and closed nothing. Same rule as every

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -21,7 +21,13 @@ swallowed, differently, by the two readers this format used to have.
 import re
 from typing import ClassVar
 
-from .tool_parser import RegionParse, ToolCall, ToolCallParser
+from .schema import build_param_types
+from .tool_parser import (
+    RegionParse,
+    ToolCall,
+    ToolCallParser,
+    continues_a_call,
+)
 
 KIMI_SECTION_BEGIN = "<|tool_calls_section_begin|>"
 KIMI_SECTION_END = "<|tool_calls_section_end|>"
@@ -29,20 +35,55 @@ KIMI_ENTRY_END = "<|tool_call_end|>"
 
 _ENTRY_RE = re.compile(
     r"<\|tool_call_begin\|>"
-    r"functions\.(\w+):(\d+)"
-    r"<\|tool_call_argument_begin\|>"
+    # `[\w.\-]`, not `\w`: function names are `^[a-zA-Z0-9_-]{1,64}$` and MCP
+    # servers namespace theirs `server.tool`. With `\w` the entry did not
+    # match, so the whole section -- special tokens included -- went out as
+    # `content` with `finish_reason: stop`.
+    r"functions\.([\w.\-]+):(\d+)" r"<\|tool_call_argument_begin\|>"
+    # Ends at `<|tool_call_end|>`, the next entry, the section close, or end of
+    # input. Without that last one a `max_tokens` truncation matched nothing
+    # and went out as raw special tokens -- and beside a complete entry, was
+    # dropped entirely.
     r"(.*?)"
-    r"<\|tool_call_end\|>",
+    r"(?:(?P<closed><\|tool_call_end\|>)"
+    r"|(?=<\|tool_call_begin\|>)"
+    r"|(?=<\|tool_calls_section_end\|>)"
+    r"|\Z)",
     re.DOTALL,
 )
 
 
-def _parse_entries(section_text: str) -> list[ToolCall]:
+def _is_truncated_call(
+    name: str, args: str, param_types: dict, *, at_end: bool
+) -> bool:
+    """Is this unclosed entry a cut-off call, or prose about the format?
+
+    The gate that travels with an unclosed alternative. Without it a sentence
+    quoting `<|tool_call_begin|>functions.x:0<|tool_call_argument_begin|>`
+    parses as a call -- the same pair-error K3 had, and it was reintroduced
+    here in the very commit that fixed it there.
+
+    The follower is `{`: this format's arguments are JSON on the wire, so a
+    real call continues with an object or, at end of region, with nothing.
+    """
+    if name not in param_types:
+        return False
+    rest = args.lstrip()
+    return (not rest and at_end) or continues_a_call(rest, ("{",), arrived=not at_end)
+
+
+def _parse_entries(
+    section_text: str, param_types: dict, *, at_end: bool
+) -> list[ToolCall]:
     """Parse individual tool call entries from the section content."""
     tool_calls = []
     for match in _ENTRY_RE.finditer(section_text):
         name = match.group(1)
         index = match.group(2)
+        if match.group("closed") is None and not _is_truncated_call(
+            name, match.group(3), param_types, at_end=at_end
+        ):
+            continue
         # `"{}"` and not `""` for a zero-argument call. This format passes
         # the wire bytes through where the other five build a JSON object, so
         # it was the one format whose no-argument call reached the client as
@@ -72,6 +113,16 @@ class KimiParser(ToolCallParser):
     REGION_END_MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_END,)
 
     @classmethod
+    def render_call(cls, name: str, args: dict[str, str]) -> str:
+        import json as _json
+
+        return (
+            f"{KIMI_SECTION_BEGIN}<|tool_call_begin|>functions.{name}:0"
+            f"<|tool_call_argument_begin|>{_json.dumps(args)}"
+            f"{KIMI_ENTRY_END}{KIMI_SECTION_END}"
+        )
+
+    @classmethod
     def detect(cls, text: str) -> bool:
         return KIMI_SECTION_BEGIN in text
 
@@ -92,7 +143,7 @@ class KimiParser(ToolCallParser):
         output -- which is what `_SECTION_RE.search` did -- lost the second
         call entirely and delivered the raw wire tokens of both as content.
         """
-        entries = _parse_entries(region)
+        entries = _parse_entries(region, build_param_types(tools), at_end=at_end)
         if not entries:
             return RegionParse()
         # The region opens at the *first* section marker in the text, which an

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -20,6 +20,7 @@ rather than a random one, and ``index`` comes from the wire too.
 import re
 from typing import ClassVar
 
+from ..marker_scanner import MarkerScanner
 from .tool_parser import ToolCall, ToolCallParser
 
 KIMI_SECTION_BEGIN = "<|tool_calls_section_begin|>"
@@ -62,7 +63,9 @@ class KimiParser(ToolCallParser):
     """States: 0 = plain content, 1 = inside section, 2 = section closed."""
 
     NAME: ClassVar[str] = "kimi"
-    MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_BEGIN, "<|tool_call_begin|>")
+    # The section opener, and the only literal detection keys on. The entry
+    # markers inside it are `_drain_entries`' business, never a reader's.
+    START_MARKERS: ClassVar[tuple[str, ...]] = (KIMI_SECTION_BEGIN,)
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -86,18 +89,21 @@ class KimiParser(ToolCallParser):
         results: list = []
 
         if self.state == 0:
-            self.buf += text
-            if KIMI_SECTION_BEGIN in self.buf:
-                before = self.buf.split(KIMI_SECTION_BEGIN)[0]
-                if before:
-                    results.append(("content", before))
+            # Held back: only a suffix that could still grow into the section
+            # marker. It used to be `"<|tool" not in self.buf` over a buffer
+            # that was never cleared while that held, so a single `<|tool` --
+            # or an answer merely discussing one -- withheld everything after
+            # it until the stream ended. The 30-character floor went with it;
+            # the scanner's bound is the marker's own length.
+            if self._scanner_cache is None:
+                self._scanner_cache = MarkerScanner((KIMI_SECTION_BEGIN,))
+            scan = self._scanner_cache.feed(text)
+            if scan.released:
+                results.append(("content", scan.released))
+            if scan.hit is not None:
                 self.state = 1
-                self.buf = self.buf.split(KIMI_SECTION_BEGIN, 1)[1]
+                self.buf = scan.rest
                 results.extend(self._drain_entries())
-            elif "<|tool" not in self.buf and len(self.buf) > 30:
-                # No partial special token possible yet -> safe to release.
-                results.append(("content", self.buf))
-                self.buf = ""
 
         elif self.state == 1:
             self.buf += text

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -18,6 +18,7 @@ section, and the answer after the last one, be read at all: both used to be
 swallowed, differently, by the two readers this format used to have.
 """
 
+import json
 import re
 from typing import ClassVar
 
@@ -40,14 +41,17 @@ _ENTRY_RE = re.compile(
     # match, so the whole section -- special tokens included -- went out as
     # `content` with `finish_reason: stop`.
     r"functions\.([\w.\-]+):(\d+)" r"<\|tool_call_argument_begin\|>"
-    # Ends at `<|tool_call_end|>`, the next entry, the section close, or end of
-    # input. Without that last one a `max_tokens` truncation matched nothing
-    # and went out as raw special tokens -- and beside a complete entry, was
-    # dropped entirely.
+    # Ends at `<|tool_call_end|>`, the next entry, the section close, the next
+    # *section*, or end of input. Without end-of-input a `max_tokens`
+    # truncation matched nothing and went out as raw special tokens -- and
+    # beside a complete entry, was dropped entirely. The section opener is the
+    # fifth terminator `parse_region` names; here the next call opens a new
+    # section rather than a sibling entry.
     r"(.*?)"
     r"(?:(?P<closed><\|tool_call_end\|>)"
     r"|(?=<\|tool_call_begin\|>)"
     r"|(?=<\|tool_calls_section_end\|>)"
+    r"|(?=<\|tool_calls_section_begin\|>)"
     r"|\Z)",
     re.DOTALL,
 )
@@ -114,11 +118,13 @@ class KimiParser(ToolCallParser):
 
     @classmethod
     def render_call(cls, name: str, args: dict[str, str]) -> str:
-        import json as _json
-
+        # One call, so the entry index is 0. Do not read a multi-call shape
+        # off two of these concatenated: a real section increments the index
+        # across its entries, and taking the doubled `:0` for model output
+        # produced a duplicate-id "defect" that does not exist.
         return (
             f"{KIMI_SECTION_BEGIN}<|tool_call_begin|>functions.{name}:0"
-            f"<|tool_call_argument_begin|>{_json.dumps(args)}"
+            f"<|tool_call_argument_begin|>{json.dumps(args)}"
             f"{KIMI_ENTRY_END}{KIMI_SECTION_END}"
         )
 

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -24,6 +24,12 @@ from .tool_parser import ToolCall, ToolCallParser
 
 KIMI_SECTION_BEGIN = "<|tool_calls_section_begin|>"
 KIMI_SECTION_END = "<|tool_calls_section_end|>"
+KIMI_ENTRY_END = "<|tool_call_end|>"
+# Nothing in a chunk can complete an entry or the section unless one of these
+# lands in it, so nothing before one arrives needs the buffer materialised.
+# See `KimiParser.process`.
+_DRAIN_TRIGGERS = (KIMI_ENTRY_END, KIMI_SECTION_END)
+_TRIGGER_TAIL = max(len(m) for m in _DRAIN_TRIGGERS) - 1
 
 _SECTION_RE = re.compile(
     re.escape(KIMI_SECTION_BEGIN) + r"(.*?)" + re.escape(KIMI_SECTION_END),
@@ -84,6 +90,8 @@ class KimiParser(ToolCallParser):
         # question; using it as this one made the not-a-promise branch dead
         # code from the first real call onwards.
         self._section_calls = 0
+        # The tail a drain trigger split across a chunk boundary would need.
+        self._trigger_tail = ""
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -129,6 +137,7 @@ class KimiParser(ToolCallParser):
             self.state = 1
             self.buf = ""
             self._section_calls = 0
+            self._trigger_tail = ""
             # Falls through rather than returning: the whole section, and the
             # answer after it, can arrive in the same chunk. Returning here
             # left the section-end handling below unreached and `flush` then
@@ -137,9 +146,28 @@ class KimiParser(ToolCallParser):
             # chunk is exactly what `merge_chunk` coalesces to under load.
             text = scan.rest
 
-        self.buf += text
+        # Accumulated in a list and searched only when something could have
+        # completed. `self.buf += text` on an attribute is quadratic -- see
+        # `Region` -- and scanning the whole buffer per chunk is a second
+        # factor on top of it: a 50 KB argument cost 55 ms of event-loop CPU
+        # against Qwen's 4 for the same payload, and the gap widens with size.
+        # Only these two markers can end an entry or the section, so until one
+        # of them arrives there is nothing to look at. The tail carries the
+        # bytes a marker split across the boundary would need.
+        self.region.append(text)
+        probe = self._trigger_tail + text
+        self._trigger_tail = probe[-_TRIGGER_TAIL:]
+        if not any(m in probe for m in _DRAIN_TRIGGERS):
+            return results
+
+        self.buf += self.region.take()
         if KIMI_SECTION_END not in self.buf:
-            return results + self._drain_entries()
+            results.extend(self._drain_entries())
+            # Whatever is left is the entry still arriving; back it goes, so
+            # the next chunk appends rather than copies it again.
+            self.region.append(self.buf)
+            self.buf = ""
+            return results
 
         section, _, after = self.buf.partition(KIMI_SECTION_END)
         self.buf = section
@@ -161,6 +189,7 @@ class KimiParser(ToolCallParser):
         # is still the answer.
         self.state = 0
         self.buf = ""
+        self._trigger_tail = ""
         if after:
             results.extend(self.process(after))
 
@@ -209,6 +238,11 @@ class KimiParser(ToolCallParser):
             if rest:
                 results.append(("content", rest))
         elif self.state == 1:
+            # Whatever `process` left unexamined, because no drain trigger had
+            # arrived yet. At end of stream there is nothing more coming, so
+            # this is the one place it always has to be looked at.
+            self.buf += self.region.take()
+            self._trigger_tail = ""
             results.extend(self._drain_entries())
             if self._section_calls > 0:
                 results.append(("tool_call_end", None))

--- a/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/kimi_tool_parser.py
@@ -103,8 +103,13 @@ class KimiParser(ToolCallParser):
                 return (content.strip() if entries else text), entries
             return text, []
         entries = _parse_entries(section_match.group(1))
-        content = text[: section_match.start()]
-        return (content.strip() if entries else text), entries
+        # What follows the section is the answer continuing, not spare bytes.
+        # Truncating here dropped it, and the streaming path stopped doing so
+        # when its terminal state was replaced -- leaving the two disagreeing
+        # about the same output.
+        before = text[: section_match.start()]
+        after = text[section_match.end() :]
+        return ((before.strip() + after) if entries else text), entries
 
     def process(self, text: str) -> list:
         results: list = []
@@ -207,9 +212,11 @@ class KimiParser(ToolCallParser):
             results.extend(self._drain_entries())
             if self._section_calls > 0:
                 results.append(("tool_call_end", None))
-            elif self.buf:
+            else:
                 # The section opened and closed nothing. Same rule as every
-                # other format: a start marker is not a promise.
+                # other format: a start marker is not a promise -- including
+                # when the answer stops on the marker itself, where `self.buf`
+                # is empty and an `elif` on it dropped all 29 characters.
                 results.append(("content", KIMI_SECTION_BEGIN + self.buf))
                 self.buf = ""
         return results

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -33,9 +33,18 @@ _INVOKE_RE = re.compile(
 _PARAM_RE = re.compile(r"<([\w-]+)>(.*?)</\1>", re.DOTALL)
 
 
+_PEEK_NAME_RE = re.compile(r'<invoke name="([^"]+)"')
+
+
 class MiniMaxParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "minimax"
     START_MARKERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS, "<tool_call>")
+
+    @classmethod
+    def peek_name(cls, region: str) -> str | None:
+        """`<invoke name="NAME">`, ns_token stripped first as `parse` does."""
+        m = _PEEK_NAME_RE.search(region.replace(MINIMAX_NS, ""))
+        return m.group(1) if m else None
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -22,7 +22,13 @@ import re
 from typing import Any, ClassVar
 
 from .schema import build_param_types, coerce_json_or_raw
-from .tool_parser import RegionParse, ToolCall, ToolCallParser, unique_tool_call_id
+from .tool_parser import (
+    RegionParse,
+    ToolCall,
+    ToolCallParser,
+    continues_a_call,
+    unique_tool_call_id,
+)
 
 MINIMAX_NS = "]<]minimax[>["
 
@@ -81,12 +87,22 @@ def _is_truncated_call(
     if not rest:
         return at_end
     tag = _FIRST_TAG_RE.match(rest)
-    return bool(tag) and (not types or tag.group(1) in types)
+    if tag is not None:
+        return not types or tag.group(1) in types
+    # A tag that has not finished arriving. At end of region that is all
+    # there will ever be, so a prefix counts -- the rule `continues_a_call`
+    # states and the other three formats have applied since it was written.
+    # The sweep that added it missed this one, because this format names a
+    # parameter by the tag itself and so had no keyword to hand it; the
+    # followers are the declared tags, built from the request.
+    openers = tuple(f"{MINIMAX_NS}<{t}>" for t in types) + tuple(
+        f"<{t}>" for t in types
+    )
+    return bool(openers) and continues_a_call(rest, openers, arrived=not at_end)
 
 
 class MiniMaxParser(ToolCallParser):
     NAME: ClassVar[str] = "minimax"
-    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = True
     # `<invoke name="` too: `_INVOKE_RE` matches it anywhere, so an invoke the
     # model wrote without the ns_token was a call when parsed whole and plain
     # text when streamed -- the read-ahead never opened a region for it. DSML

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -33,7 +33,8 @@ _INVOKE_RE = re.compile(
 _PARAM_RE = re.compile(r"<([\w-]+)>(.*?)</\1>", re.DOTALL)
 
 
-_PEEK_NAME_RE = re.compile(r'<invoke name="([^"]+)"')
+# Name plus the token that must follow; see QwenXmlParser for why.
+_PEEK_NAME_RE = re.compile(r'<invoke name="([^"]+)">\s*<[^>]*(?:parameter|/)')
 
 
 class MiniMaxParser(BufferedMarkerParser):

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -35,6 +35,7 @@ _PARAM_RE = re.compile(r"<([\w-]+)>(.*?)</\1>", re.DOTALL)
 
 class MiniMaxParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "minimax"
+    MARKERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS, MINIMAX_NS + "<tool_call>")
     START_MARKERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS, "<tool_call>")
     # The ns_token starts with ']', so a trailing ']' may be a partial marker.
     HOLDBACK_CHARS: ClassVar[tuple[str, ...]] = ("<", "]")

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -35,10 +35,7 @@ _PARAM_RE = re.compile(r"<([\w-]+)>(.*?)</\1>", re.DOTALL)
 
 class MiniMaxParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "minimax"
-    MARKERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS, MINIMAX_NS + "<tool_call>")
     START_MARKERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS, "<tool_call>")
-    # The ns_token starts with ']', so a trailing ']' may be a partial marker.
-    HOLDBACK_CHARS: ClassVar[tuple[str, ...]] = ("<", "]")
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -31,10 +31,40 @@ _INVOKE_RE = re.compile(
     re.DOTALL,
 )
 _PARAM_RE = re.compile(r"<([\w-]+)>(.*?)</\1>", re.DOTALL)
+_FIRST_TAG_RE = re.compile(r"^<([\w-]+)>")
 
 
-# Name plus the token that must follow; see QwenXmlParser for why.
-_PEEK_NAME_RE = re.compile(r'<invoke name="([^"]+)">\s*<[^>]*(?:parameter|/)')
+def _is_truncated_call(name: str, body: str, param_types: dict) -> bool:
+    """Is this unclosed `<invoke name=...>` a cut-off call, or prose?
+
+    See :func:`QwenXmlParser._is_truncated_call`. The sweep that added that
+    test to Qwen and GLM missed this format and DSML both, and "you emit
+    `<invoke name="get_weather">` and then a `<city>Paris</city>` line" was
+    still dispatched as a real call with the arguments filled in.
+
+    The follower is a tag, because this format names parameters by the tag
+    itself and so has no keyword to look for. Which tag is checked too when
+    the request declared a schema for this tool -- otherwise `<br>` reads as
+    the start of a call body -- but a tool declared without one still has to
+    be callable, so an empty schema falls back to "any tag".
+    """
+    types = param_types.get(name)
+    if types is None:
+        return False
+    rest = body.lstrip()
+    if not rest:
+        return True
+    tag = _FIRST_TAG_RE.match(rest)
+    return bool(tag) and (not types or tag.group(1) in types)
+
+
+# Name plus whatever follows it; `_is_truncated_call` judges that part, so
+# the rule lives in one place. Not DSML's `<...parameter`, which this was
+# copied from: MiniMax names a parameter by the tag itself, so the DSML
+# spelling matched no call that took arguments -- the feature was dead for
+# every real call, and `search` then slid forward to announce the name of
+# some *later* zero-argument one.
+_PEEK_NAME_RE = re.compile(r'<invoke\s+name="([^"]+)"\s*>(.*)', re.DOTALL)
 
 
 class MiniMaxParser(BufferedMarkerParser):
@@ -42,10 +72,23 @@ class MiniMaxParser(BufferedMarkerParser):
     START_MARKERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS, "<tool_call>")
 
     @classmethod
-    def peek_name(cls, region: str) -> str | None:
-        """`<invoke name="NAME">`, ns_token stripped first as `parse` does."""
+    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
+        """`<invoke name="NAME">`, ns_token stripped first as `parse` does.
+
+        Judged by the same `_is_truncated_call` the unclosed branch of `parse`
+        uses -- including its schema lookup, which is why this takes `tools`:
+        a parameter here is named by its own tag, so `<city>` and `<br>` are
+        the same shape and only the request can tell them apart.
+        """
         m = _PEEK_NAME_RE.search(region.replace(MINIMAX_NS, ""))
-        return m.group(1) if m else None
+        if m is None:
+            return None
+        name, rest = m.group(1).strip(), m.group(2)
+        if not rest.lstrip():
+            return None  # nothing has followed yet; not "cut off", just early
+        return (
+            name if _is_truncated_call(name, rest, build_param_types(tools)) else None
+        )
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -61,11 +104,14 @@ class MiniMaxParser(BufferedMarkerParser):
         content = clean[:tc] if tc > 0 else ("" if tc == 0 else clean)
         tool_calls: list[ToolCall] = []
         for m in _INVOKE_RE.finditer(clean):
-            name = m.group(1) if m.group(1) is not None else m.group(3)
-            body = m.group(2) if m.group(2) is not None else (m.group(4) or "")
+            closed = m.group(1) is not None
+            name = m.group(1) if closed else m.group(3)
+            body = m.group(2) if closed else (m.group(4) or "")
             if not name:
                 continue
             name = name.strip()
+            if not closed and not _is_truncated_call(name, body, param_types):
+                continue
             types = param_types.get(name, {})
             args: dict[str, Any] = {}
             for pm in _PARAM_RE.finditer(body):

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -13,8 +13,12 @@ Every tag is prefixed by the ns_token ``]<]minimax[>[``::
     ]<]minimax[>[</tool_call>
 
 Unlike DSML, parameters are named by the TAG itself (``<city>Paris</city>``),
-not a ``name="..."`` attribute. Strip the ns_token first, then parse
-<invoke>/<tag> pairs. Values: schema type wins, else JSON, else raw string.
+not a ``name="..."`` attribute. Values: schema type wins, else JSON, else raw
+string.
+
+The ns_token is *not* stripped first, though this said so long after the code
+stopped doing it: parsing a copy with it deleted made every offset meaningless
+against the bytes that arrived.
 """
 
 import json
@@ -49,14 +53,18 @@ _NS = r"(?:" + re.escape(MINIMAX_NS) + r")?"
 # `finditer` then resumed past the real call, so the call the model actually
 # made never went out. GLM was given this guard first; this is the sweep.
 _NOT_NESTED = r"(?:(?!" + _NS + r"<invoke\s).)"
+# No leading ns_token: `CALL_FILLERS` declares it and `markup_begin` walks
+# back over it, so matching it here too is a second reader of one token -- and
+# the expensive kind. A pattern opening with an optional group has no fixed
+# first byte, so the scan tries every position rather than skipping to the
+# next `<`: on 18 KB, 524 us against 3.8, and 262 -> 3.8 for `_PARAM_RE`. The
+# other five formats open on a literal and never paid it.
 _INVOKE_RE = re.compile(
-    _NS
-    + r'<invoke\s+name="([^"]*)"\s*>('
+    r'<invoke\s+name="([^"]*)"\s*>('
     + _NOT_NESTED
     + r"*?)"
     + _NS
     + r"</invoke>|"
-    + _NS
     + r'<invoke\s+name="([^"]*)"\s*>('
     + _NOT_NESTED
     + r"*)",
@@ -67,7 +75,7 @@ _INVOKE_RE = re.compile(
 # model was cut off inside; without it a `max_tokens` truncation arrived as a
 # call with `{}` arguments while Qwen and GLM returned the partial value.
 _PARAM_RE = re.compile(
-    _NS + r"<([\w-]+)>(.*?)"
+    r"<([\w-]+)>(.*?)"
     r"(?:" + _NS + r"</\1>"
     r"|(?=" + _NS + r"<[\w-]+>)"
     r"|(?=" + _NS + r"</invoke>)"

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -22,19 +22,45 @@ import re
 from typing import Any, ClassVar
 
 from .schema import build_param_types, coerce_json_or_raw
-from .tool_parser import BufferedMarkerParser, ToolCall, unique_tool_call_id
+from .tool_parser import RegionParse, ToolCall, ToolCallParser, unique_tool_call_id
 
 MINIMAX_NS = "]<]minimax[>["
 
+# The ns_token is matched optionally wherever a tag can appear, as DSML does
+# with its own marker, rather than deleted from a copy of the text first.
+# Deleting it made every offset in the parsed copy meaningless against the
+# bytes that actually arrived, which is why `parse` could only ever report
+# "content precedes the call" and never "and this follows it".
+_NS = r"(?:" + re.escape(MINIMAX_NS) + r")?"
+
+# A call's body may not contain another opener -- that literal is what opens
+# one. Without the guard the non-greedy body ran from a *quoted* opener in
+# prose all the way to the real call's closer, so an answer explaining
+# "you write <invoke name="NAME">" before making a real call produced one call named after the
+# placeholder, carrying the real call's arguments, with the sentence deleted.
+# `finditer` then resumed past the real call, so the call the model actually
+# made never went out. GLM was given this guard first; this is the sweep.
+_NOT_NESTED = r"(?:(?!" + _NS + r"<invoke\s).)"
 _INVOKE_RE = re.compile(
-    r'<invoke\s+name="(.*?)"\s*>(.*?)</invoke>|<invoke\s+name="(.*?)"\s*>(.*)$',
+    _NS
+    + r'<invoke\s+name="([^"]*)"\s*>('
+    + _NOT_NESTED
+    + r"*?)"
+    + _NS
+    + r"</invoke>|"
+    + _NS
+    + r'<invoke\s+name="([^"]*)"\s*>('
+    + _NOT_NESTED
+    + r"*)",
     re.DOTALL,
 )
-_PARAM_RE = re.compile(r"<([\w-]+)>(.*?)</\1>", re.DOTALL)
-_FIRST_TAG_RE = re.compile(r"^<([\w-]+)>")
+_PARAM_RE = re.compile(_NS + r"<([\w-]+)>(.*?)" + _NS + r"</\1>", re.DOTALL)
+_FIRST_TAG_RE = re.compile(r"^" + _NS + r"<([\w-]+)>")
 
 
-def _is_truncated_call(name: str, body: str, param_types: dict) -> bool:
+def _is_truncated_call(
+    name: str, body: str, param_types: dict, *, at_end: bool
+) -> bool:
     """Is this unclosed `<invoke name=...>` a cut-off call, or prose?
 
     See :func:`QwenXmlParser._is_truncated_call`. The sweep that added that
@@ -53,22 +79,14 @@ def _is_truncated_call(name: str, body: str, param_types: dict) -> bool:
         return False
     rest = body.lstrip()
     if not rest:
-        return True
+        return at_end
     tag = _FIRST_TAG_RE.match(rest)
     return bool(tag) and (not types or tag.group(1) in types)
 
 
-# Name plus whatever follows it; `_is_truncated_call` judges that part, so
-# the rule lives in one place. Not DSML's `<...parameter`, which this was
-# copied from: MiniMax names a parameter by the tag itself, so the DSML
-# spelling matched no call that took arguments -- the feature was dead for
-# every real call, and `search` then slid forward to announce the name of
-# some *later* zero-argument one.
-_PEEK_NAME_RE = re.compile(r'<invoke\s+name="([^"]+)"\s*>(.*)', re.DOTALL)
-
-
-class MiniMaxParser(BufferedMarkerParser):
+class MiniMaxParser(ToolCallParser):
     NAME: ClassVar[str] = "minimax"
+    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = True
     # `<invoke name="` too: `_INVOKE_RE` matches it anywhere, so an invoke the
     # model wrote without the ns_token was a call when parsed whole and plain
     # text when streamed -- the read-ahead never opened a region for it. DSML
@@ -78,25 +96,19 @@ class MiniMaxParser(BufferedMarkerParser):
         "<tool_call>",
         '<invoke name="',
     )
+    CALL_OPENERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
+    CALL_CLOSERS: ClassVar[tuple[str, ...]] = ("</tool_call>",)
+    CALL_FILLERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS,)
 
-    @classmethod
-    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
-        """`<invoke name="NAME">`, ns_token stripped first as `parse` does.
-
-        Judged by the same `_is_truncated_call` the unclosed branch of `parse`
-        uses -- including its schema lookup, which is why this takes `tools`:
-        a parameter here is named by its own tag, so `<city>` and `<br>` are
-        the same shape and only the request can tell them apart.
-        """
-        m = _PEEK_NAME_RE.search(region.replace(MINIMAX_NS, ""))
-        if m is None:
-            return None
-        name, rest = m.group(1).strip(), m.group(2)
-        if not rest.lstrip():
-            return None  # nothing has followed yet; not "cut off", just early
-        return (
-            name if _is_truncated_call(name, rest, build_param_types(tools)) else None
-        )
+    # The ns_token opens a region like the other two, rather than being
+    # framing the reader drops. It prefixes every tag including ones inside a
+    # call, so calling it framing would delete it from an answer that merely
+    # *mentions* it while an answer that mentions the tag it prefixes keeps
+    # both -- the same token surviving or not depending on what followed it.
+    # `parse` had exactly that split (every occurrence deleted from a copy of
+    # the text when a call was found, all of them left when one was not); a
+    # region that parses to nothing is released whole, so this way both
+    # answers keep their bytes.
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -104,29 +116,22 @@ class MiniMaxParser(BufferedMarkerParser):
         return MINIMAX_NS in text
 
     @classmethod
-    def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
-        """Parse MiniMax-M3 tool calls; return (leading_content, tool_calls)."""
+    def parse_region(
+        cls, region: str, tools: list | None, *, at_end: bool
+    ) -> RegionParse:
         param_types = build_param_types(tools)
-        clean = text.replace(MINIMAX_NS, "")
-        # Content is what precedes the *call*, and the call may open with
-        # either token. Cutting only at `<tool_call>` -- which this format's
-        # primary ns_token shape does not contain -- left `content` holding
-        # the entire `<invoke>` markup alongside the parsed call, so the user
-        # was shown the raw XML while the streaming path showed nothing.
-        starts = [
-            i for i in (clean.find("<tool_call>"), clean.find("<invoke")) if i != -1
-        ]
-        cut = min(starts) if starts else -1
-        content = clean[:cut] if cut != -1 else clean
         tool_calls: list[ToolCall] = []
-        for m in _INVOKE_RE.finditer(clean):
+        begin = end = 0
+        for m in _INVOKE_RE.finditer(region):
             closed = m.group(1) is not None
             name = m.group(1) if closed else m.group(3)
             body = m.group(2) if closed else (m.group(4) or "")
             if not name:
                 continue
             name = name.strip()
-            if not closed and not _is_truncated_call(name, body, param_types):
+            if not closed and not _is_truncated_call(
+                name, body, param_types, at_end=at_end
+            ):
                 continue
             types = param_types.get(name, {})
             args: dict[str, Any] = {}
@@ -134,6 +139,8 @@ class MiniMaxParser(BufferedMarkerParser):
                 k = pm.group(1).strip()
                 if k:
                     args[k] = coerce_json_or_raw(pm.group(2), types.get(k))
+            if not tool_calls:
+                begin = cls.markup_begin(region, m.start())
             tool_calls.append(
                 ToolCall(
                     id=unique_tool_call_id(),
@@ -144,11 +151,5 @@ class MiniMaxParser(BufferedMarkerParser):
                     },
                 )
             )
-        for mk in ("<tool_call>", "</tool_call>"):
-            content = content.replace(mk, "")
-        # No call -> verbatim; see ToolCallParser.parse. `text` and not
-        # `clean`: the ns_token is a start marker, so an answer that merely
-        # mentions it opens a region that parses to nothing, and the streaming
-        # path then releases that region unchanged -- measured, ns_token and
-        # all. Returning `clean` here would delete it on one path only.
-        return (content.strip() if tool_calls else text), tool_calls
+            end = cls.markup_end(region, m.end())
+        return RegionParse(tuple(tool_calls), begin, end)

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -60,7 +60,18 @@ _INVOKE_RE = re.compile(
     + r"*)",
     re.DOTALL,
 )
-_PARAM_RE = re.compile(_NS + r"<([\w-]+)>(.*?)" + _NS + r"</\1>", re.DOTALL)
+# Ends at the matching close tag, at the next parameter, at the close of the
+# invoke, or at end of input. That last alternative is what keeps a value the
+# model was cut off inside; without it a `max_tokens` truncation arrived as a
+# call with `{}` arguments while Qwen and GLM returned the partial value.
+_PARAM_RE = re.compile(
+    _NS + r"<([\w-]+)>(.*?)"
+    r"(?:" + _NS + r"</\1>"
+    r"|(?=" + _NS + r"<[\w-]+>)"
+    r"|(?=" + _NS + r"</invoke>)"
+    r"|\Z)",
+    re.DOTALL,
+)
 _FIRST_TAG_RE = re.compile(r"^" + _NS + r"<([\w-]+)>")
 
 
@@ -130,6 +141,16 @@ class MiniMaxParser(ToolCallParser):
     # the text when a call was found, all of them left when one was not); a
     # region that parses to nothing is released whole, so this way both
     # answers keep their bytes.
+
+    @classmethod
+    def render_call(cls, name: str, args: dict[str, str]) -> str:
+        body = "".join(
+            f"{MINIMAX_NS}<{k}>{v}{MINIMAX_NS}</{k}>" for k, v in args.items()
+        )
+        return (
+            f'{MINIMAX_NS}<tool_call>{MINIMAX_NS}<invoke name="{name}">'
+            f"{body}{MINIMAX_NS}</invoke>{MINIMAX_NS}</tool_call>"
+        )
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -137,7 +137,7 @@ class MiniMaxParser(ToolCallParser):
     ) -> RegionParse:
         param_types = build_param_types(tools)
         tool_calls: list[ToolCall] = []
-        begin = end = 0
+        spans: list[tuple[int, int]] = []
         for m in _INVOKE_RE.finditer(region):
             closed = m.group(1) is not None
             name = m.group(1) if closed else m.group(3)
@@ -155,8 +155,9 @@ class MiniMaxParser(ToolCallParser):
                 k = pm.group(1).strip()
                 if k:
                     args[k] = coerce_json_or_raw(pm.group(2), types.get(k))
-            if not tool_calls:
-                begin = cls.markup_begin(region, m.start())
+            spans.append(
+                (cls.markup_begin(region, m.start()), cls.markup_end(region, m.end()))
+            )
             tool_calls.append(
                 ToolCall(
                     id=unique_tool_call_id(),
@@ -167,5 +168,4 @@ class MiniMaxParser(ToolCallParser):
                     },
                 )
             )
-            end = cls.markup_end(region, m.end())
-        return RegionParse(tuple(tool_calls), begin, end)
+        return RegionParse(tuple(tool_calls), tuple(spans))

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -135,6 +135,7 @@ class MiniMaxParser(ToolCallParser):
     CALL_OPENERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
     CALL_CLOSERS: ClassVar[tuple[str, ...]] = ("</tool_call>",)
     CALL_FILLERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS,)
+    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = ("</invoke>",)
 
     # The ns_token opens a region like the other two, rather than being
     # framing the reader drops. It prefixes every tag including ones inside a

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -74,4 +74,9 @@ class MiniMaxParser(BufferedMarkerParser):
             )
         for mk in ("<tool_call>", "</tool_call>"):
             content = content.replace(mk, "")
-        return content.strip(), tool_calls
+        # No call -> verbatim; see ToolCallParser.parse. `text` and not
+        # `clean`: the ns_token is a start marker, so an answer that merely
+        # mentions it opens a region that parses to nothing, and the streaming
+        # path then releases that region unchanged -- measured, ns_token and
+        # all. Returning `clean` here would delete it on one path only.
+        return (content.strip() if tool_calls else text), tool_calls

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -29,6 +29,7 @@ from .tool_parser import (
     continues_a_call,
     declared_tools_allow,
     unique_tool_call_id,
+    usable_tool_name,
 )
 
 MINIMAX_NS = "]<]minimax[>["
@@ -171,9 +172,12 @@ class MiniMaxParser(ToolCallParser):
             closed = m.group(1) is not None
             name = m.group(1) if closed else m.group(3)
             body = m.group(2) if closed else (m.group(4) or "")
-            if not name:
+            # Strip first, then judge. The other order -- `if not name` before
+            # `name.strip()` -- let `name="   "` through the guard and out as
+            # the empty string.
+            name = (name or "").strip()
+            if not usable_tool_name(name):
                 continue
-            name = name.strip()
             if not closed and not _is_truncated_call(
                 name, body, param_types, at_end=at_end
             ):

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -92,13 +92,18 @@ def _is_truncated_call(
     # A tag that has not finished arriving. At end of region that is all
     # there will ever be, so a prefix counts -- the rule `continues_a_call`
     # states and the other three formats have applied since it was written.
-    # The sweep that added it missed this one, because this format names a
-    # parameter by the tag itself and so had no keyword to hand it; the
-    # followers are the declared tags, built from the request.
-    openers = tuple(f"{MINIMAX_NS}<{t}>" for t in types) + tuple(
+    # The followers are the declared tags, built from the request, because
+    # this format names a parameter by the tag itself.
+    #
+    # An empty schema falls back to "any tag" here exactly as it does for a
+    # complete tag four lines up. Gating on `bool(openers)` instead made a
+    # zero-parameter tool the one tool whose truncated call could not be
+    # recovered -- the same tool declared with one property recovered it --
+    # and a truncation is precisely what this function exists to catch.
+    followers = tuple(f"{MINIMAX_NS}<{t}>" for t in types) + tuple(
         f"<{t}>" for t in types
-    )
-    return bool(openers) and continues_a_call(rest, openers, arrived=not at_end)
+    ) or (f"{MINIMAX_NS}<", "<")
+    return continues_a_call(rest, followers, arrived=not at_end)
 
 
 class MiniMaxParser(ToolCallParser):

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -69,7 +69,15 @@ _PEEK_NAME_RE = re.compile(r'<invoke\s+name="([^"]+)"\s*>(.*)', re.DOTALL)
 
 class MiniMaxParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "minimax"
-    START_MARKERS: ClassVar[tuple[str, ...]] = (MINIMAX_NS, "<tool_call>")
+    # `<invoke name="` too: `_INVOKE_RE` matches it anywhere, so an invoke the
+    # model wrote without the ns_token was a call when parsed whole and plain
+    # text when streamed -- the read-ahead never opened a region for it. DSML
+    # lists the same marker-less malform for the same reason.
+    START_MARKERS: ClassVar[tuple[str, ...]] = (
+        MINIMAX_NS,
+        "<tool_call>",
+        '<invoke name="',
+    )
 
     @classmethod
     def peek_name(cls, region: str, tools: list | None = None) -> str | None:
@@ -100,8 +108,16 @@ class MiniMaxParser(BufferedMarkerParser):
         """Parse MiniMax-M3 tool calls; return (leading_content, tool_calls)."""
         param_types = build_param_types(tools)
         clean = text.replace(MINIMAX_NS, "")
-        tc = clean.find("<tool_call>")
-        content = clean[:tc] if tc > 0 else ("" if tc == 0 else clean)
+        # Content is what precedes the *call*, and the call may open with
+        # either token. Cutting only at `<tool_call>` -- which this format's
+        # primary ns_token shape does not contain -- left `content` holding
+        # the entire `<invoke>` markup alongside the parsed call, so the user
+        # was shown the raw XML while the streaming path showed nothing.
+        starts = [
+            i for i in (clean.find("<tool_call>"), clean.find("<invoke")) if i != -1
+        ]
+        cut = min(starts) if starts else -1
+        content = clean[:cut] if cut != -1 else clean
         tool_calls: list[ToolCall] = []
         for m in _INVOKE_RE.finditer(clean):
             closed = m.group(1) is not None

--- a/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/minimax_tool_parser.py
@@ -27,6 +27,7 @@ from .tool_parser import (
     ToolCall,
     ToolCallParser,
     continues_a_call,
+    declared_tools_allow,
     unique_tool_call_id,
 )
 
@@ -91,9 +92,11 @@ def _is_truncated_call(
     the start of a call body -- but a tool declared without one still has to
     be callable, so an empty schema falls back to "any tag".
     """
-    types = param_types.get(name)
-    if types is None:
+    if not declared_tools_allow(name, param_types):
         return False
+    # An undeclared schema falls back to "any tag", the same way an
+    # empty one does below.
+    types = param_types.get(name) or {}
     rest = body.lstrip()
     if not rest:
         return at_end

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -67,7 +67,6 @@ def _parse_function(
 
 class QwenXmlParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "qwen"
-    MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", QWEN_TOOL_PREFIX)
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", QWEN_TOOL_PREFIX)
 
     @classmethod

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -47,7 +47,9 @@ _FUNCTION_RE = re.compile(
 )
 _PARAM_OPENER = "<parameter="
 _PARAM_RE = re.compile(
-    r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
+    # `\Z`, not `$`: `$` also matches before a trailing newline, so a value
+    # ending in one was cut a byte short.
+    r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|\Z)",
     re.DOTALL,
 )
 
@@ -137,6 +139,11 @@ class QwenXmlParser(ToolCallParser):
     # real call in half.
     CALL_OPENERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
     CALL_CLOSERS: ClassVar[tuple[str, ...]] = ("</tool_call>",)
+
+    @classmethod
+    def render_call(cls, name: str, args: dict[str, str]) -> str:
+        body = "".join(f"<parameter={k}>{v}</parameter>" for k, v in args.items())
+        return f"<tool_call><function={name}>{body}</function></tool_call>"
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -129,7 +129,6 @@ def _parse_function(
 
 class QwenXmlParser(ToolCallParser):
     NAME: ClassVar[str] = "qwen"
-    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = True
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", QWEN_TOOL_PREFIX)
     # `</tool_call>` closes the wrapper the calls sit in, so it is markup too
     # -- and so is the newline between it and `</function>`. Not a

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -149,7 +149,7 @@ class QwenXmlParser(ToolCallParser):
     ) -> RegionParse:
         param_types = build_param_types(tools)
         calls: list[ToolCall] = []
-        begin = end = 0
+        spans: list[tuple[int, int]] = []
         for fm in _FUNCTION_RE.finditer(region):
             closed = fm.group(1) is not None
             fn_text = fm.group(1) if closed else fm.group(2)
@@ -162,8 +162,11 @@ class QwenXmlParser(ToolCallParser):
                 fn_text, param_types, at_end=at_end
             ):
                 continue
-            if not calls:
-                begin = cls.markup_begin(region, fm.start())
             calls.append(tc)
-            end = cls.markup_end(region, fm.end())
-        return RegionParse(tuple(calls), begin, end)
+            spans.append(
+                (
+                    cls.markup_begin(region, fm.start()),
+                    cls.markup_end(region, fm.end()),
+                )
+            )
+        return RegionParse(tuple(calls), tuple(spans))

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -65,9 +65,18 @@ def _parse_function(
     )
 
 
+_PEEK_NAME_RE = re.compile(r"<function=([^>\n]+)>")
+
+
 class QwenXmlParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "qwen"
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", QWEN_TOOL_PREFIX)
+
+    @classmethod
+    def peek_name(cls, region: str) -> str | None:
+        """`<function=NAME>` -- legible once the tag closes."""
+        m = _PEEK_NAME_RE.search(region)
+        return m.group(1) if m else None
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -89,4 +89,5 @@ class QwenXmlParser(BufferedMarkerParser):
             tc = _parse_function(fn_text, param_types)
             if tc is not None:
                 tool_calls.append(tc)
-        return content.strip(), tool_calls
+        # No call -> verbatim; see ToolCallParser.parse.
+        return (content.strip() if tool_calls else text), tool_calls

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -28,10 +28,35 @@ from .tool_parser import BufferedMarkerParser, ToolCall, unique_tool_call_id
 QWEN_TOOL_PREFIX = "<function="
 
 _FUNCTION_RE = re.compile(r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL)
+_PARAM_OPENER = "<parameter="
 _PARAM_RE = re.compile(
     r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
     re.DOTALL,
 )
+
+
+def _is_truncated_call(fn_text: str, param_types: dict) -> bool:
+    """Is this unclosed `<function=...` a cut-off call, or prose quoting a tag?
+
+    The unclosed branch exists for a call the model was cut off mid-way
+    through. It cannot tell that from an answer explaining how to call a tool,
+    and used to accept both: "the model writes <tool_call><function=get_weather>
+    and then the parameters" produced `get_weather({})`, deleted the rest of
+    the sentence and reported `finish_reason: tool_calls`, so an agentic
+    client ran a tool nobody asked for.
+
+    Two things separate them, and prose has to fail both. The name is one the
+    request declared -- prose can name a real tool, so this alone is not
+    enough. And what follows the name is a parameter or nothing: a cut-off
+    call stops inside its own syntax, while prose continues in English.
+    """
+    gt = fn_text.find(">")
+    if gt == -1:
+        return False
+    if fn_text[:gt].strip() not in param_types:
+        return False
+    rest = fn_text[gt + 1 :].lstrip()
+    return not rest or _PARAM_OPENER.startswith(rest[: len(_PARAM_OPENER)])
 
 
 def _parse_function(
@@ -65,7 +90,14 @@ def _parse_function(
     )
 
 
-_PEEK_NAME_RE = re.compile(r"<function=([^>\n]+)>")
+# The name *and* the token that must follow it. A name alone matches prose
+# explaining how to call a tool, and an announcement cannot be retracted --
+# "the model writes <tool_call><function=get_weather> and then..." announced
+# `get_weather`. Waiting for the structure costs a few characters against
+# the thousands this saves.
+_PEEK_NAME_RE = re.compile(
+    r"<function=([^>\n]+)>\s*(?:<parameter=|</function>|</tool_call>)"
+)
 
 
 class QwenXmlParser(BufferedMarkerParser):
@@ -92,11 +124,15 @@ class QwenXmlParser(BufferedMarkerParser):
         content = text[:start] if start != -1 else text
         tool_calls: list[ToolCall] = []
         for fm in _FUNCTION_RE.finditer(text):
-            fn_text = fm.group(1) if fm.group(1) is not None else fm.group(2)
+            closed = fm.group(1) is not None
+            fn_text = fm.group(1) if closed else fm.group(2)
             if not fn_text:
                 continue
             tc = _parse_function(fn_text, param_types)
-            if tc is not None:
-                tool_calls.append(tc)
+            if tc is None:
+                continue
+            if not closed and not _is_truncated_call(fn_text, param_types):
+                continue
+            tool_calls.append(tc)
         # No call -> verbatim; see ToolCallParser.parse.
         return (content.strip() if tool_calls else text), tool_calls

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -22,8 +22,9 @@ from typing import Any, ClassVar
 from .kimi_tool_parser import KIMI_SECTION_BEGIN
 from .schema import build_param_types, coerce_param_value
 from .tool_parser import (
-    BufferedMarkerParser,
+    RegionParse,
     ToolCall,
+    ToolCallParser,
     continues_a_call,
     unique_tool_call_id,
 )
@@ -32,7 +33,18 @@ from .tool_parser import (
 # apart from GLM's identically-named tag.
 QWEN_TOOL_PREFIX = "<function="
 
-_FUNCTION_RE = re.compile(r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL)
+# A call's body may not contain another opener -- that literal is what opens
+# one. Without the guard the non-greedy body ran from a *quoted* opener in
+# prose all the way to the real call's closer, so an answer explaining
+# "you write <function=NAME>" before making a real call produced one call named after the
+# placeholder, carrying the real call's arguments, with the sentence deleted.
+# `finditer` then resumed past the real call, so the call the model actually
+# made never went out. GLM was given this guard first; this is the sweep.
+_NOT_NESTED = r"(?:(?!<function=).)"
+_FUNCTION_RE = re.compile(
+    r"<function=(" + _NOT_NESTED + r"*?)</function>|<function=(" + _NOT_NESTED + r"*)",
+    re.DOTALL,
+)
 _PARAM_OPENER = "<parameter="
 _PARAM_RE = re.compile(
     r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
@@ -57,7 +69,7 @@ def _name_and_rest(fn_text: str) -> tuple[str, str] | None:
     return fn_text[:gt].strip(), fn_text[gt + 1 :].lstrip()
 
 
-def _is_truncated_call(fn_text: str, param_types: dict) -> bool:
+def _is_truncated_call(fn_text: str, param_types: dict, *, at_end: bool) -> bool:
     """Is this unclosed `<function=...` a cut-off call, or prose quoting a tag?
 
     The unclosed branch exists for a call the model was cut off mid-way
@@ -71,14 +83,16 @@ def _is_truncated_call(fn_text: str, param_types: dict) -> bool:
     request declared -- prose can name a real tool, so this alone is not
     enough. And what follows the name is this format's own next token: a
     cut-off call stops inside its own syntax, while prose continues in
-    English. `peek_name` applies the same two, from the same code.
+    English. The early announcement runs this same function over the region
+    so far, so the two cannot answer differently.
     """
     split = _name_and_rest(fn_text)
     if split is None:
         return False
     name, rest = split
     return name in param_types and (
-        not rest or continues_a_call(rest, _CALL_CONTINUES, arrived=False)
+        (not rest and at_end)
+        or continues_a_call(rest, _CALL_CONTINUES, arrived=not at_end)
     )
 
 
@@ -113,35 +127,17 @@ def _parse_function(
     )
 
 
-# The name, and enough of what follows to tell a call from prose. A name
-# alone matches an answer explaining how to call a tool, and an announcement
-# cannot be retracted -- "the model writes <tool_call><function=get_weather>
-# and then..." announced `get_weather`. Waiting for the structure costs a few
-# characters against the thousands this saves.
-_PEEK_NAME_RE = re.compile(r"<function=([^>\n]+)>(.*)", re.DOTALL)
-
-
-class QwenXmlParser(BufferedMarkerParser):
+class QwenXmlParser(ToolCallParser):
     NAME: ClassVar[str] = "qwen"
+    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = True
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", QWEN_TOOL_PREFIX)
-
-    @classmethod
-    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
-        """`<function=NAME>` -- legible once the tag closes and something
-        follows it that only a call would write.
-
-        The follower must have *arrived*, unlike in `_is_truncated_call`,
-        which accepts nothing-after because it runs at end of stream where
-        nothing more is coming. Here more is coming, so an empty tail is
-        "not yet" rather than "cut off".
-        """
-        m = _PEEK_NAME_RE.search(region)
-        if m is None:
-            return None
-        rest = m.group(2).lstrip()
-        if not continues_a_call(rest, _CALL_CONTINUES, arrived=True):
-            return None
-        return m.group(1)
+    # `</tool_call>` closes the wrapper the calls sit in, so it is markup too
+    # -- and so is the newline between it and `</function>`. Not a
+    # `REGION_END_MARKER`: a model writing *about* tool calls puts the literal
+    # inside a `<parameter=` value, where closing the region on it would cut a
+    # real call in half.
+    CALL_OPENERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
+    CALL_CLOSERS: ClassVar[tuple[str, ...]] = ("</tool_call>",)
 
     @classmethod
     def detect(cls, text: str) -> bool:
@@ -149,14 +145,13 @@ class QwenXmlParser(BufferedMarkerParser):
         return QWEN_TOOL_PREFIX in text and KIMI_SECTION_BEGIN not in text
 
     @classmethod
-    def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
-        """Parse Qwen3 XML tool calls; return (leading_content, tool_calls)."""
+    def parse_region(
+        cls, region: str, tools: list | None, *, at_end: bool
+    ) -> RegionParse:
         param_types = build_param_types(tools)
-        # Content precedes the first tool marker.
-        start = cls.find_start(text)
-        content = text[:start] if start != -1 else text
-        tool_calls: list[ToolCall] = []
-        for fm in _FUNCTION_RE.finditer(text):
+        calls: list[ToolCall] = []
+        begin = end = 0
+        for fm in _FUNCTION_RE.finditer(region):
             closed = fm.group(1) is not None
             fn_text = fm.group(1) if closed else fm.group(2)
             if not fn_text:
@@ -164,8 +159,12 @@ class QwenXmlParser(BufferedMarkerParser):
             tc = _parse_function(fn_text, param_types)
             if tc is None:
                 continue
-            if not closed and not _is_truncated_call(fn_text, param_types):
+            if not closed and not _is_truncated_call(
+                fn_text, param_types, at_end=at_end
+            ):
                 continue
-            tool_calls.append(tc)
-        # No call -> verbatim; see ToolCallParser.parse.
-        return (content.strip() if tool_calls else text), tool_calls
+            if not calls:
+                begin = cls.markup_begin(region, fm.start())
+            calls.append(tc)
+            end = cls.markup_end(region, fm.end())
+        return RegionParse(tuple(calls), begin, end)

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -26,6 +26,7 @@ from .tool_parser import (
     ToolCall,
     ToolCallParser,
     continues_a_call,
+    declared_tools_allow,
     unique_tool_call_id,
 )
 
@@ -95,7 +96,7 @@ def _is_truncated_call(fn_text: str, param_types: dict, *, at_end: bool) -> bool
     if split is None:
         return False
     name, rest = split
-    return name in param_types and (
+    return declared_tools_allow(name, param_types) and (
         (not rest and at_end)
         or continues_a_call(rest, _CALL_CONTINUES, arrived=not at_end)
     )

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -28,6 +28,7 @@ from .tool_parser import (
     continues_a_call,
     declared_tools_allow,
     unique_tool_call_id,
+    usable_tool_name,
 )
 
 # Also read by GlmParser.detect: '<function=' is what tells Qwen's <tool_call>
@@ -110,7 +111,11 @@ def _parse_function(
     if gt == -1:
         return None
     name = fn_text[:gt].strip()
-    if not name:
+    # Not `if not name`, which rejects only the empty one:
+    # `<function=YOUR FUNCTION NAME>` -- the placeholder a model writes while
+    # explaining the format -- went out as a call. GLM refused the same
+    # sentence, so one `<tool_call>` family gave two answers.
+    if not usable_tool_name(name):
         return None
     body = fn_text[gt + 1 :]
     types = param_types.get(name, {})
@@ -143,6 +148,7 @@ class QwenXmlParser(ToolCallParser):
     # real call in half.
     CALL_OPENERS: ClassVar[tuple[str, ...]] = ("<tool_call>",)
     CALL_CLOSERS: ClassVar[tuple[str, ...]] = ("</tool_call>",)
+    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = ("</function>",)
 
     @classmethod
     def render_call(cls, name: str, args: dict[str, str]) -> str:

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -35,6 +35,28 @@ _PARAM_RE = re.compile(
 )
 
 
+# What may follow the name inside a call: another parameter, or the close of
+# the very block the name opened. NOT `</tool_call>`, which closes the
+# *outer* wrapper -- `<function=get_weather></tool_call>` leaves the function
+# block unterminated, so `parse` reads it as prose. The peek used to accept
+# it and `parse` did not, which is the whole of the mismatch this shared
+# tuple exists to prevent: one spelling, both readers.
+_CALL_CONTINUES = (_PARAM_OPENER, "</function>")
+
+
+def _continues_a_call(rest: str) -> bool:
+    """Is `rest` the start of this format's own next token?"""
+    return any(tok.startswith(rest[: len(tok)]) for tok in _CALL_CONTINUES)
+
+
+def _name_and_rest(fn_text: str) -> tuple[str, str] | None:
+    """Split `NAME>whatever` at the tag close, or ``None`` if it has not come."""
+    gt = fn_text.find(">")
+    if gt == -1:
+        return None
+    return fn_text[:gt].strip(), fn_text[gt + 1 :].lstrip()
+
+
 def _is_truncated_call(fn_text: str, param_types: dict) -> bool:
     """Is this unclosed `<function=...` a cut-off call, or prose quoting a tag?
 
@@ -47,16 +69,15 @@ def _is_truncated_call(fn_text: str, param_types: dict) -> bool:
 
     Two things separate them, and prose has to fail both. The name is one the
     request declared -- prose can name a real tool, so this alone is not
-    enough. And what follows the name is a parameter or nothing: a cut-off
-    call stops inside its own syntax, while prose continues in English.
+    enough. And what follows the name is this format's own next token: a
+    cut-off call stops inside its own syntax, while prose continues in
+    English. `peek_name` applies the same two, from the same code.
     """
-    gt = fn_text.find(">")
-    if gt == -1:
+    split = _name_and_rest(fn_text)
+    if split is None:
         return False
-    if fn_text[:gt].strip() not in param_types:
-        return False
-    rest = fn_text[gt + 1 :].lstrip()
-    return not rest or _PARAM_OPENER.startswith(rest[: len(_PARAM_OPENER)])
+    name, rest = split
+    return name in param_types and (not rest or _continues_a_call(rest))
 
 
 def _parse_function(
@@ -90,14 +111,12 @@ def _parse_function(
     )
 
 
-# The name *and* the token that must follow it. A name alone matches prose
-# explaining how to call a tool, and an announcement cannot be retracted --
-# "the model writes <tool_call><function=get_weather> and then..." announced
-# `get_weather`. Waiting for the structure costs a few characters against
-# the thousands this saves.
-_PEEK_NAME_RE = re.compile(
-    r"<function=([^>\n]+)>\s*(?:<parameter=|</function>|</tool_call>)"
-)
+# The name, and enough of what follows to tell a call from prose. A name
+# alone matches an answer explaining how to call a tool, and an announcement
+# cannot be retracted -- "the model writes <tool_call><function=get_weather>
+# and then..." announced `get_weather`. Waiting for the structure costs a few
+# characters against the thousands this saves.
+_PEEK_NAME_RE = re.compile(r"<function=([^>\n]+)>(.*)", re.DOTALL)
 
 
 class QwenXmlParser(BufferedMarkerParser):
@@ -105,10 +124,20 @@ class QwenXmlParser(BufferedMarkerParser):
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", QWEN_TOOL_PREFIX)
 
     @classmethod
-    def peek_name(cls, region: str) -> str | None:
-        """`<function=NAME>` -- legible once the tag closes."""
+    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
+        """`<function=NAME>` -- legible once the tag closes and something
+        follows it that only a call would write.
+
+        The follower must have *arrived*, unlike in `_is_truncated_call`,
+        which accepts nothing-after because it runs at end of stream where
+        nothing more is coming. Here more is coming, so an empty tail is
+        "not yet" rather than "cut off".
+        """
         m = _PEEK_NAME_RE.search(region)
-        return m.group(1) if m else None
+        if m is None:
+            return None
+        rest = m.group(2).lstrip()
+        return m.group(1) if rest and _continues_a_call(rest) else None
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -48,8 +48,11 @@ _FUNCTION_RE = re.compile(
 _PARAM_OPENER = "<parameter="
 _PARAM_RE = re.compile(
     # `\Z`, not `$`: `$` also matches before a trailing newline, so a value
-    # ending in one was cut a byte short.
-    r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|\Z)",
+    # ending in one was cut a byte short. `(?=<tool_call>)` is the fifth
+    # terminator `parse_region` names -- a value ends where the next call
+    # opens, or it swallows that call's wrapper as data.
+    r"<parameter=(.*?)"
+    r"(?:</parameter>|(?=<parameter=)|(?=</function>)|(?=<tool_call>)|\Z)",
     re.DOTALL,
 )
 

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -67,6 +67,7 @@ def _parse_function(
 
 class QwenXmlParser(BufferedMarkerParser):
     NAME: ClassVar[str] = "qwen"
+    MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", QWEN_TOOL_PREFIX)
     START_MARKERS: ClassVar[tuple[str, ...]] = ("<tool_call>", QWEN_TOOL_PREFIX)
 
     @classmethod

--- a/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/qwen3_tool_parser.py
@@ -21,7 +21,12 @@ from typing import Any, ClassVar
 
 from .kimi_tool_parser import KIMI_SECTION_BEGIN
 from .schema import build_param_types, coerce_param_value
-from .tool_parser import BufferedMarkerParser, ToolCall, unique_tool_call_id
+from .tool_parser import (
+    BufferedMarkerParser,
+    ToolCall,
+    continues_a_call,
+    unique_tool_call_id,
+)
 
 # Also read by GlmParser.detect: '<function=' is what tells Qwen's <tool_call>
 # apart from GLM's identically-named tag.
@@ -42,11 +47,6 @@ _PARAM_RE = re.compile(
 # it and `parse` did not, which is the whole of the mismatch this shared
 # tuple exists to prevent: one spelling, both readers.
 _CALL_CONTINUES = (_PARAM_OPENER, "</function>")
-
-
-def _continues_a_call(rest: str) -> bool:
-    """Is `rest` the start of this format's own next token?"""
-    return any(tok.startswith(rest[: len(tok)]) for tok in _CALL_CONTINUES)
 
 
 def _name_and_rest(fn_text: str) -> tuple[str, str] | None:
@@ -77,7 +77,9 @@ def _is_truncated_call(fn_text: str, param_types: dict) -> bool:
     if split is None:
         return False
     name, rest = split
-    return name in param_types and (not rest or _continues_a_call(rest))
+    return name in param_types and (
+        not rest or continues_a_call(rest, _CALL_CONTINUES, arrived=False)
+    )
 
 
 def _parse_function(
@@ -137,7 +139,9 @@ class QwenXmlParser(BufferedMarkerParser):
         if m is None:
             return None
         rest = m.group(2).lstrip()
-        return m.group(1) if rest and _continues_a_call(rest) else None
+        if not continues_a_call(rest, _CALL_CONTINUES, arrived=True):
+            return None
+        return m.group(1)
 
     @classmethod
     def detect(cls, text: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/registry.py
+++ b/atom/entrypoints/openai/tool_parser/registry.py
@@ -3,19 +3,24 @@
 
 """Format detection.
 
-The wire format is sniffed from the model's own output rather than configured,
-so detection order is load-bearing: several formats share tags and are only
-told apart by a discriminator that a later entry would also match. The order
-below is the single place that ordering is expressed — do not reorder without
-re-reading the notes on each entry.
+Several formats share tags and are only told apart by a discriminator that a
+later entry would also match, so detection order is load-bearing. `_DETECT_ORDER`
+is the single place that ordering is expressed — do not reorder without
+re-reading the notes on each entry — and both callers use it: `parse_tool_calls`
+on a complete output, and `resolve_from_prompt` on a rendered chat template at
+startup.
 """
 
+import logging
+from typing import Any
+
+from ..chat_encoders import apply_chat_template
 from .deepseekv4_tool_parser import DsmlParser
 from .glm_tool_parser import GlmParser
-from .kimi_k3_tool_parser import KimiK3Parser, is_kimi_k3
-from .kimi_tool_parser import KIMI_SECTION_BEGIN, KimiParser
-from .minimax_tool_parser import MINIMAX_NS, MiniMaxParser
-from .qwen3_tool_parser import QWEN_TOOL_PREFIX, QwenXmlParser
+from .kimi_k3_tool_parser import KimiK3Parser
+from .kimi_tool_parser import KimiParser
+from .minimax_tool_parser import MiniMaxParser
+from .qwen3_tool_parser import QwenXmlParser
 from .tool_parser import ToolCall, ToolCallParser
 
 # Checked in order on a COMPLETE output. Kimi (K2) is not listed: it is the
@@ -40,7 +45,9 @@ _DETECT_ORDER: tuple[type[ToolCallParser], ...] = (
 
 
 def parse_tool_calls(
-    text: str, tools: list | None = None
+    text: str,
+    tools: list | None = None,
+    parser_cls: "type[ToolCallParser] | None" = None,
 ) -> tuple[str, list[ToolCall]]:
     """Parse tool calls from a complete model output.
 
@@ -48,11 +55,18 @@ def parse_tool_calls(
         text: Raw model output that may contain tool calls.
         tools: Optional request tool definitions; used to type-coerce parameter
             values to their declared JSON-Schema types.
+        parser_cls: The format resolved for this model at startup. Given, it is
+            used and the cascade below is not consulted — the streaming path
+            reads the same output as that same format, and the two answering
+            differently is a divergence a client sees as a tool call appearing
+            only when it does not stream.
 
     Returns:
         Tuple of (content_text, list_of_tool_calls). ``content_text`` has the
         tool-call sections removed.
     """
+    if parser_cls is not None:
+        return parser_cls.parse(text, tools)
     for parser in _DETECT_ORDER:
         if parser.detect(text):
             return parser.parse(text, tools)
@@ -62,73 +76,114 @@ def parse_tool_calls(
     return KimiParser.parse(text, tools)
 
 
-# -- streaming sniff --------------------------------------------------------
-#
-# Deciding on a PREFIX is strictly harder than on a complete output: a format's
-# discriminator may not have arrived yet. These two sentinels say "cannot decide
-# from what I have":
+# -- format resolution -----------------------------------------------------
 
-# Might still become a tool call -> the caller keeps this text.
-#
-# `WAIT` is only about the *format*, never about whether text may be released.
-# It used to be both, alongside an `EMIT_CONTENT` that meant "no '<' anywhere,
-# so nothing can be starting". That conflation was the stall: one '<' in an
-# ordinary answer -- `if (a < b)` -- made every branch here miss forever, and
-# `ToolCallStreamParser` never cleared the buffer it was accumulating, so the
-# answer arrived in a single frame at end of stream. Deciding how much text is
-# safe to send is now `MarkerScanner`'s, over the union of every registered
-# format's `MARKERS`, and it is asked before this function is.
-WAIT = object()
+# Every format by the name `--tool-call-parser` takes. Derived from the same
+# order, so a newly registered format is selectable without a second edit.
+PARSERS_BY_NAME: dict[str, type[ToolCallParser]] = {
+    p.NAME: p for p in (*_DETECT_ORDER, KimiParser)
+}
 
 
-# Literals the cascade below discriminates by that open no region of their
-# own, so no parser declares them and a reader would not otherwise hold them
-# back. `<arg_key>` is what tells GLM from Qwen -- both open with
-# `<tool_call>` -- and it appears *inside* that region, which is why it is not
-# one of GLM's `START_MARKERS`: `find_start` would take it for the region's
-# beginning and parse from the wrong offset.
-_SNIFF_ONLY: tuple[str, ...] = ("<arg_key>",)
+def resolve_from_prompt(rendered_prompt: str) -> type[ToolCallParser] | None:
+    """Which format this model will emit, decided before it emits anything.
 
+    A chat template rendered with a tools payload *is* the model's instructions
+    for how to call one, so the same cascade `parse_tool_calls` runs on a
+    complete output answers the question on the prompt instead -- earlier, and
+    without depending on what the model happens to produce first.
 
-def all_markers() -> tuple[str, ...]:
-    """Every literal that could be starting before the format is known.
+    Asked once at startup. `None` means no registered format recognised the
+    prompt, which is the honest answer for a model with no tool syntax ATOM
+    knows; the caller says so out loud rather than falling back to guessing,
+    because a guess here is a tool call fabricated out of ordinary text.
 
-    A suffix that could still grow into one of these is not safe to send. Taken
-    from the parsers' own `START_MARKERS` plus the cascade's own discriminators,
-    so a format added to `_DETECT_ORDER` is covered without a second edit here.
+    This replaces `sniff_stream`, which decided from a *prefix* of the output.
+    That was strictly harder -- a format's discriminator may not have arrived
+    yet, so the answer needed a "cannot tell yet" state, and that state was
+    read as "and therefore send nothing", which is how one '<' in an answer
+    withheld the rest of the stream.
     """
-    formats = {m for p in (*_DETECT_ORDER, KimiParser) for m in p.START_MARKERS}
-    return tuple(formats | set(_SNIFF_ONLY))
+    for parser in _DETECT_ORDER:
+        if parser.detect(rendered_prompt):
+            return parser
+    return None
 
 
-def sniff_stream(buf: str):
-    """Pick a parser from a partial stream, or return EMIT_CONTENT / WAIT.
+logger = logging.getLogger("atom")
 
-    Deliberately NOT the same rules as the per-parser ``detect``: on a prefix,
-    GLM is only accepted on the unambiguous ``<arg_key>`` (a bare ``<tool_call>``
-    could still turn out to be Qwen once ``<function=`` arrives).
+AUTO = "auto"
+
+# The smallest request that makes a template render its tool instructions. The
+# tool is never called; only the framing the template wraps it in matters.
+_PROBE_MESSAGES = [{"role": "user", "content": "hi"}]
+_PROBE_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather in a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def resolve_tool_call_parser(
+    override: str | None,
+    tokenizer: Any,
+    custom_encoder: Any = None,
+    *,
+    model: str = "",
+) -> type[ToolCallParser] | None:
+    """The format this model's tool calls will arrive in, or ``None``.
+
+    ``override`` is ``--tool-call-parser``: a format name, or ``"auto"``/``None``
+    to read it off the chat template. An unknown name raises rather than
+    falling back, because a typo that silently disables tool parsing is the
+    failure this whole path exists to stop.
+
+    ``None`` is a real answer, not an error: gpt-oss and DeepSeek-R1 render no
+    tool syntax ATOM knows, and for them parsing nothing is correct. It is
+    logged either way.
+
+    Rendering is best-effort — a template can raise on a tools payload it does
+    not accept — and a failure to render is reported and treated as
+    unrecognised, never as a reason to fall back to reading the output.
     """
-    # K3's channel tokens (``<|open|>response<|sep|>`` / ``<|open|>call tool=``)
-    # are disjoint from every other format, so a complete one decides immediately.
-    # K3 buffers to EOS and strips its own framing, so plain answers route here
-    # too rather than leaking channel tokens through the undecided-content path.
-    if is_kimi_k3(buf):
-        return KimiK3Parser
-    if MINIMAX_NS in buf:
-        return MiniMaxParser
-    if DsmlParser.detect(buf):
-        return DsmlParser
-    if "<arg_key>" in buf:
-        return GlmParser
-    if QWEN_TOOL_PREFIX in buf:
-        return QwenXmlParser
-    if "<tool_call>" in buf:
-        # '<tool_call>' seen but neither '<function=' (Qwen) nor '<arg_key>'
-        # (GLM) yet. A no-arg GLM call is complete once the closing tag arrives;
-        # otherwise wait for the sub-marker.
-        if "</tool_call>" in buf:
-            return GlmParser
-        return WAIT
-    if KIMI_SECTION_BEGIN in buf:
-        return KimiParser
-    return WAIT
+    if override and override != AUTO:
+        parser = PARSERS_BY_NAME.get(override)
+        if parser is None:
+            raise ValueError(
+                f"--tool-call-parser={override!r} is not a known format; "
+                f"choose one of {sorted(PARSERS_BY_NAME)} or {AUTO!r}"
+            )
+        logger.info(f"Tool-call format: {parser.NAME} (from --tool-call-parser)")
+        return parser
+
+    try:
+        rendered = apply_chat_template(
+            tokenizer, custom_encoder, _PROBE_MESSAGES, tools=_PROBE_TOOLS
+        )
+    except Exception as e:  # noqa: BLE001 - any template failure means "cannot tell"
+        logger.warning(
+            f"Could not render {model or 'the model'}'s chat template with a tools "
+            f"payload, so its tool-call format is unknown and tool calls will be "
+            f"delivered as plain text: {e}. Pass --tool-call-parser to set it."
+        )
+        return None
+
+    parser = resolve_from_prompt(rendered)
+    if parser is None:
+        logger.info(
+            f"No known tool-call format in {model or 'the model'}'s chat template; "
+            f"tool calls will be delivered as plain text. Pass --tool-call-parser "
+            f"if this model does emit one."
+        )
+    else:
+        logger.info(f"Tool-call format: {parser.NAME} (from the chat template)")
+    return parser

--- a/atom/entrypoints/openai/tool_parser/registry.py
+++ b/atom/entrypoints/openai/tool_parser/registry.py
@@ -135,6 +135,42 @@ TOOL_CALL_PARSER_HELP = (
 )
 
 
+def forbids_tool_calls(tool_choice: Any) -> bool:
+    """Did this request say the model may not call a tool?
+
+    Both protocols' spellings, because both endpoints ask. OpenAI sends the
+    bare string ``"none"``; Anthropic sends ``{"type": "none"}``. Anything
+    else -- absent, ``auto``, ``required``, ``any``, a named tool -- is not a
+    prohibition, and in particular is not answered here.
+    """
+    if isinstance(tool_choice, str):
+        return tool_choice == "none"
+    if isinstance(tool_choice, dict):
+        return tool_choice.get("type") == "none"
+    return False
+
+
+def parser_for_tool_choice(
+    parser_cls: type[ToolCallParser] | None, tool_choice: Any
+) -> type[ToolCallParser] | None:
+    """The format to read this request's output as -- none, if it forbade calls.
+
+    `tool_choice: "none"` used to be enforced where the events were *sent*,
+    twelve places across two endpoints, while the parser went on consuming the
+    region. So the model's own words were deleted rather than its call
+    suppressed: a 95-character answer reached the client as its first six,
+    with no event and `finish_reason: stop`. Not parsing is both the correct
+    reading -- the output is prose, because the request said it could not be a
+    call -- and the cheaper one, since nothing is parsed to be thrown away.
+
+    Every construction site goes through here, so the two protocols cannot
+    drift: the Anthropic endpoint read `tool_choice` off the request and then
+    ignored it entirely, and the sweep that added the gates to the OpenAI path
+    never reached it.
+    """
+    return None if forbids_tool_calls(tool_choice) else parser_cls
+
+
 def validate_tool_call_parser(override: str | None) -> type[ToolCallParser] | None:
     """The format `override` names, or ``None`` for "read the template".
 

--- a/atom/entrypoints/openai/tool_parser/registry.py
+++ b/atom/entrypoints/openai/tool_parser/registry.py
@@ -66,7 +66,15 @@ def parse_tool_calls(
         tool-call sections removed.
     """
     if parser_cls is not None:
-        return parser_cls.parse(text, tools)
+        content, tool_calls = parser_cls.parse(text, tools)
+        if not tool_calls:
+            # No call, so nothing was a tool-call section and nothing should
+            # have been rewritten. Formats strip their content, which for an
+            # ordinary answer means a code block comes back without its
+            # trailing newline -- and only when `stream=false`, since the
+            # streaming path releases bytes as they arrive.
+            return text, []
+        return content, tool_calls
     for parser in _DETECT_ORDER:
         if parser.detect(text):
             return parser.parse(text, tools)
@@ -104,7 +112,14 @@ def resolve_from_prompt(rendered_prompt: str) -> type[ToolCallParser] | None:
     read as "and therefore send nothing", which is how one '<' in an answer
     withheld the rest of the stream.
     """
-    for parser in _DETECT_ORDER:
+    # Kimi is included here though `_DETECT_ORDER` omits it. There it is the
+    # terminal fallback, because its `parse` also defines "no tool calls at
+    # all"; that makes it wrong to try *last* on an output and right to try at
+    # all on a prompt. Omitting it meant a K2 deployment resolved to nothing
+    # and its tool calls arrived as raw section tokens in `delta.content`,
+    # while the non-streaming path still fell through to `KimiParser.parse`
+    # and returned them -- the same request answered two ways.
+    for parser in (*_DETECT_ORDER, KimiParser):
         if parser.detect(rendered_prompt):
             return parser
     return None

--- a/atom/entrypoints/openai/tool_parser/registry.py
+++ b/atom/entrypoints/openai/tool_parser/registry.py
@@ -129,6 +129,16 @@ logger = logging.getLogger("atom")
 
 AUTO = "auto"
 
+# Written once and used by both entrypoints, which is also the shape of the
+# bug it replaces: the flag existed on the OpenAI server and not on atomesh,
+# so the documented escape hatch did not exist there.
+TOOL_CALL_PARSER_HELP = (
+    "Tool-call wire format. 'auto' (default) reads it off the model's chat "
+    "template at startup; an explicit name overrides that. When neither "
+    "resolves, tool calls are delivered as plain text and the startup log "
+    "says so \u2014 the format is never guessed from output."
+)
+
 # The smallest request that makes a template render its tool instructions. The
 # tool is never called; only the framing the template wraps it in matters.
 _PROBE_MESSAGES = [{"role": "user", "content": "hi"}]

--- a/atom/entrypoints/openai/tool_parser/registry.py
+++ b/atom/entrypoints/openai/tool_parser/registry.py
@@ -68,11 +68,37 @@ def parse_tool_calls(
 # discriminator may not have arrived yet. These two sentinels say "cannot decide
 # from what I have":
 
-# Enough plain text to be sure no marker is starting -> release it as content
-# and stay undecided.
-EMIT_CONTENT = object()
-# Might still become a tool call -> keep buffering, emit nothing.
+# Might still become a tool call -> the caller keeps this text.
+#
+# `WAIT` is only about the *format*, never about whether text may be released.
+# It used to be both, alongside an `EMIT_CONTENT` that meant "no '<' anywhere,
+# so nothing can be starting". That conflation was the stall: one '<' in an
+# ordinary answer -- `if (a < b)` -- made every branch here miss forever, and
+# `ToolCallStreamParser` never cleared the buffer it was accumulating, so the
+# answer arrived in a single frame at end of stream. Deciding how much text is
+# safe to send is now `MarkerScanner`'s, over the union of every registered
+# format's `MARKERS`, and it is asked before this function is.
 WAIT = object()
+
+
+# Literals the cascade below discriminates by that open no region of their
+# own, so no parser declares them and a reader would not otherwise hold them
+# back. `<arg_key>` is what tells GLM from Qwen -- both open with
+# `<tool_call>` -- and it appears *inside* that region, which is why it is not
+# one of GLM's `START_MARKERS`: `find_start` would take it for the region's
+# beginning and parse from the wrong offset.
+_SNIFF_ONLY: tuple[str, ...] = ("<arg_key>",)
+
+
+def all_markers() -> tuple[str, ...]:
+    """Every literal that could be starting before the format is known.
+
+    A suffix that could still grow into one of these is not safe to send. Taken
+    from the parsers' own `START_MARKERS` plus the cascade's own discriminators,
+    so a format added to `_DETECT_ORDER` is covered without a second edit here.
+    """
+    formats = {m for p in (*_DETECT_ORDER, KimiParser) for m in p.START_MARKERS}
+    return tuple(formats | set(_SNIFF_ONLY))
 
 
 def sniff_stream(buf: str):
@@ -105,11 +131,4 @@ def sniff_stream(buf: str):
         return WAIT
     if KIMI_SECTION_BEGIN in buf:
         return KimiParser
-    if "<" not in buf and len(buf) > 8:
-        # No '<' anywhere, so no tag has started: release the text. The length
-        # floor is an unexplained heuristic carried over verbatim from the
-        # original parser — it trades a little first-token latency for not
-        # committing on a 1-2 char buffer. Note it does not actually rule out a
-        # partial MiniMax ns_token, whose first char is ']'.
-        return EMIT_CONTENT
     return WAIT

--- a/atom/entrypoints/openai/tool_parser/registry.py
+++ b/atom/entrypoints/openai/tool_parser/registry.py
@@ -6,15 +6,21 @@
 Several formats share tags and are only told apart by a discriminator that a
 later entry would also match, so detection order is load-bearing. `_DETECT_ORDER`
 is the single place that ordering is expressed — do not reorder without
-re-reading the notes on each entry — and both callers use it: `parse_tool_calls`
-on a complete output, and `resolve_from_prompt` on a rendered chat template at
-startup.
+re-reading the notes on each entry.
+
+It is consulted on a *rendered chat template*, at startup, and nowhere else.
+Running it on a model's output as well was the same question asked of worse
+evidence: a template states the format it taught the model, while an output
+only exhibits whatever it happens to contain, so an ordinary answer quoting
+`<|tool_calls_section_begin|>` was read as a Kimi section and everything after
+it deleted — on the non-streaming path only, because streaming had already
+been given the startup answer. One question, one place to ask it.
 """
 
 import logging
 from typing import Any
 
-from ..chat_encoders import apply_chat_template
+from ..chat_encoders import render_probe_prompt
 from .deepseekv4_tool_parser import DsmlParser
 from .glm_tool_parser import GlmParser
 from .kimi_k3_tool_parser import KimiK3Parser
@@ -55,33 +61,23 @@ def parse_tool_calls(
         text: Raw model output that may contain tool calls.
         tools: Optional request tool definitions; used to type-coerce parameter
             values to their declared JSON-Schema types.
-        parser_cls: The format resolved for this model at startup. Given, it is
-            used and the cascade below is not consulted — the streaming path
-            reads the same output as that same format, and the two answering
-            differently is a divergence a client sees as a tool call appearing
-            only when it does not stream.
+        parser_cls: The format resolved for this model at startup, or ``None``
+            for "do not parse". ``None`` is not "work it out from the text":
+            the streaming path is handed the same ``None`` and emits
+            everything as content, so guessing here would answer the same
+            request two ways — measured, an answer describing
+            `<|tool_calls_section_begin|>` lost 30 characters when
+            `stream=false` and arrived whole when `stream=true`.
 
     Returns:
         Tuple of (content_text, list_of_tool_calls). ``content_text`` has the
-        tool-call sections removed.
+        tool-call sections removed, and is ``text`` byte-for-byte when there
+        are none — the rule each format's ``parse`` states and the property
+        tests enforce across the registry.
     """
-    if parser_cls is not None:
-        content, tool_calls = parser_cls.parse(text, tools)
-        if not tool_calls:
-            # No call, so nothing was a tool-call section and nothing should
-            # have been rewritten. Formats strip their content, which for an
-            # ordinary answer means a code block comes back without its
-            # trailing newline -- and only when `stream=false`, since the
-            # streaming path releases bytes as they arrive.
-            return text, []
-        return content, tool_calls
-    for parser in _DETECT_ORDER:
-        if parser.detect(text):
-            return parser.parse(text, tools)
-    # Kimi is terminal: when it finds no section either, it returns the text
-    # unchanged. Note that path does NOT strip, unlike every format that did
-    # match — preserved as-is, callers rely on plain content surviving verbatim.
-    return KimiParser.parse(text, tools)
+    if parser_cls is None:
+        return text, []
+    return parser_cls.parse(text, tools)
 
 
 # -- format resolution -----------------------------------------------------
@@ -112,13 +108,12 @@ def resolve_from_prompt(rendered_prompt: str) -> type[ToolCallParser] | None:
     read as "and therefore send nothing", which is how one '<' in an answer
     withheld the rest of the stream.
     """
-    # Kimi is included here though `_DETECT_ORDER` omits it. There it is the
-    # terminal fallback, because its `parse` also defines "no tool calls at
-    # all"; that makes it wrong to try *last* on an output and right to try at
-    # all on a prompt. Omitting it meant a K2 deployment resolved to nothing
-    # and its tool calls arrived as raw section tokens in `delta.content`,
-    # while the non-streaming path still fell through to `KimiParser.parse`
-    # and returned them -- the same request answered two ways.
+    # Kimi is included here though `_DETECT_ORDER` omits it. Its `parse` also
+    # defines "no tool calls at all", which is why it is not an entry in an
+    # ordering meant to tell formats apart -- but a K2 prompt does carry K2's
+    # section tokens, so on a prompt it is a real answer. Omitting it meant a
+    # K2 deployment resolved to nothing and delivered its tool calls as raw
+    # section tokens in `delta.content`.
     for parser in (*_DETECT_ORDER, KimiParser):
         if parser.detect(rendered_prompt):
             return parser
@@ -139,23 +134,24 @@ TOOL_CALL_PARSER_HELP = (
     "says so \u2014 the format is never guessed from output."
 )
 
-# The smallest request that makes a template render its tool instructions. The
-# tool is never called; only the framing the template wraps it in matters.
-_PROBE_MESSAGES = [{"role": "user", "content": "hi"}]
-_PROBE_TOOLS = [
-    {
-        "type": "function",
-        "function": {
-            "name": "get_weather",
-            "description": "Get the weather in a city",
-            "parameters": {
-                "type": "object",
-                "properties": {"city": {"type": "string"}},
-                "required": ["city"],
-            },
-        },
-    }
-]
+
+def validate_tool_call_parser(override: str | None) -> type[ToolCallParser] | None:
+    """The format `override` names, or ``None`` for "read the template".
+
+    Separate from :func:`resolve_tool_call_parser` because the name can be
+    checked before a tokenizer exists, and therefore before the weights load:
+    atomesh resolved inside the service constructor, so a typo was reported
+    only after a full model load.
+    """
+    if not override or override == AUTO:
+        return None
+    parser = PARSERS_BY_NAME.get(override)
+    if parser is None:
+        raise ValueError(
+            f"--tool-call-parser={override!r} is not a known format; "
+            f"choose one of {sorted(PARSERS_BY_NAME)} or {AUTO!r}"
+        )
+    return parser
 
 
 def resolve_tool_call_parser(
@@ -180,25 +176,17 @@ def resolve_tool_call_parser(
     not accept — and a failure to render is reported and treated as
     unrecognised, never as a reason to fall back to reading the output.
     """
-    if override and override != AUTO:
-        parser = PARSERS_BY_NAME.get(override)
-        if parser is None:
-            raise ValueError(
-                f"--tool-call-parser={override!r} is not a known format; "
-                f"choose one of {sorted(PARSERS_BY_NAME)} or {AUTO!r}"
-            )
+    parser = validate_tool_call_parser(override)
+    if parser is not None:
         logger.info(f"Tool-call format: {parser.NAME} (from --tool-call-parser)")
         return parser
 
-    try:
-        rendered = apply_chat_template(
-            tokenizer, custom_encoder, _PROBE_MESSAGES, tools=_PROBE_TOOLS
-        )
-    except Exception as e:  # noqa: BLE001 - any template failure means "cannot tell"
+    rendered = render_probe_prompt(tokenizer, custom_encoder, tools=True)
+    if rendered is None:
         logger.warning(
             f"Could not render {model or 'the model'}'s chat template with a tools "
             f"payload, so its tool-call format is unknown and tool calls will be "
-            f"delivered as plain text: {e}. Pass --tool-call-parser to set it."
+            f"delivered as plain text. Pass --tool-call-parser to set it."
         )
         return None
 

--- a/atom/entrypoints/openai/tool_parser/registry.py
+++ b/atom/entrypoints/openai/tool_parser/registry.py
@@ -170,9 +170,11 @@ answer then leaks that framing: Kimi-K3's `Hello there.` arrived as
 `<|open|>response<|sep|>Hello there.<|close|>response<|sep|><|end_of_msg|>`
 the moment a request said `none`. The format still has to be read; what is
 suppressed is dispatch. `ToolCallStreamParser(suppress_calls=True)` and
-:func:`parse_tool_calls(..., suppress_calls=True)` are that, and both leave
-the region's bytes in the answer -- which is the correct reading, since the
-request said they could not be a call.
+:func:`parse_tool_calls(..., suppress_calls=True)` read the region exactly as
+a permitted one and drop only the calls, so the answer around a forbidden call
+survives and the call's own markup does not. Releasing those bytes instead was
+tried first and is what leaked the wire format: they are not prose, whatever
+the request said about dispatch.
 """
 
 

--- a/atom/entrypoints/openai/tool_parser/registry.py
+++ b/atom/entrypoints/openai/tool_parser/registry.py
@@ -27,6 +27,7 @@ from .kimi_k3_tool_parser import KimiK3Parser
 from .kimi_tool_parser import KimiParser
 from .minimax_tool_parser import MiniMaxParser
 from .qwen3_tool_parser import QwenXmlParser
+from .stream import read_whole
 from .tool_parser import ToolCall, ToolCallParser
 
 # Checked in order on a COMPLETE output. Kimi (K2) is not listed: it is the
@@ -54,6 +55,8 @@ def parse_tool_calls(
     text: str,
     tools: list | None = None,
     parser_cls: "type[ToolCallParser] | None" = None,
+    *,
+    suppress_calls: bool = False,
 ) -> tuple[str, list[ToolCall]]:
     """Parse tool calls from a complete model output.
 
@@ -68,16 +71,19 @@ def parse_tool_calls(
             request two ways — measured, an answer describing
             `<|tool_calls_section_begin|>` lost 30 characters when
             `stream=false` and arrived whole when `stream=true`.
+        suppress_calls: ``tool_choice: "none"``. See the note above
+            :func:`forbids_tool_calls` for why this is a flag and not
+            "use no parser".
 
     Returns:
         Tuple of (content_text, list_of_tool_calls). ``content_text`` has the
-        tool-call sections removed, and is ``text`` byte-for-byte when there
-        are none — the rule each format's ``parse`` states and the property
-        tests enforce across the registry.
+        tool-call regions and this format's declared framing removed, and is
+        ``text`` byte-for-byte when there is neither.
+
+    This is :func:`~.stream.read_whole` — the streaming engine over one chunk —
+    and deliberately not a second implementation of it.
     """
-    if parser_cls is None:
-        return text, []
-    return parser_cls.parse(text, tools)
+    return read_whole(parser_cls, text, tools, suppress_calls=suppress_calls)
 
 
 # -- format resolution -----------------------------------------------------
@@ -150,25 +156,24 @@ def forbids_tool_calls(tool_choice: Any) -> bool:
     return False
 
 
-def parser_for_tool_choice(
-    parser_cls: type[ToolCallParser] | None, tool_choice: Any
-) -> type[ToolCallParser] | None:
-    """The format to read this request's output as -- none, if it forbade calls.
+"""Why ``tool_choice: "none"`` is a flag and not "use no parser".
 
-    `tool_choice: "none"` used to be enforced where the events were *sent*,
-    twelve places across two endpoints, while the parser went on consuming the
-    region. So the model's own words were deleted rather than its call
-    suppressed: a 95-character answer reached the client as its first six,
-    with no event and `finish_reason: stop`. Not parsing is both the correct
-    reading -- the output is prose, because the request said it could not be a
-    call -- and the cheaper one, since nothing is parsed to be thrown away.
+`tool_choice: "none"` used to be enforced where the events were *sent*, twelve
+places across two endpoints, while the parser went on consuming the region. So
+the model's own words were deleted rather than its call suppressed: a
+95-character answer reached the client as its first six, with no event and
+`finish_reason: stop`.
 
-    Every construction site goes through here, so the two protocols cannot
-    drift: the Anthropic endpoint read `tool_choice` off the request and then
-    ignored it entirely, and the sweep that added the gates to the OpenAI path
-    never reached it.
-    """
-    return None if forbids_tool_calls(tool_choice) else parser_cls
+The fix for that dropped the parser instead -- and dropping the parser also
+drops everything else a parser does. A format whose framing wraps *every*
+answer then leaks that framing: Kimi-K3's `Hello there.` arrived as
+`<|open|>response<|sep|>Hello there.<|close|>response<|sep|><|end_of_msg|>`
+the moment a request said `none`. The format still has to be read; what is
+suppressed is dispatch. `ToolCallStreamParser(suppress_calls=True)` and
+:func:`parse_tool_calls(..., suppress_calls=True)` are that, and both leave
+the region's bytes in the answer -- which is the correct reading, since the
+request said they could not be a call.
+"""
 
 
 def validate_tool_call_parser(override: str | None) -> type[ToolCallParser] | None:

--- a/atom/entrypoints/openai/tool_parser/schema.py
+++ b/atom/entrypoints/openai/tool_parser/schema.py
@@ -14,12 +14,28 @@ import json
 from typing import Any
 
 
+class ParamTypes(dict):
+    """A mapping :func:`build_param_types` has already produced.
+
+    Every ``parse_region`` begins by asking for this mapping, and the streaming
+    reader asks once per chunk while it is still deciding whether the region
+    reveals a call. Rebuilding it each time walks the whole request catalogue:
+    measured at 90 us per call with 200 declared tools, which was the entire
+    difference between a 0.12 ms and a 1.28 ms streamed call. Carrying the
+    built mapping in place of the list it came from makes the rebuild a type
+    check. The subclass is the tag -- a plain dict could be a caller's tools.
+    """
+
+
 def build_param_types(tools: list | None) -> dict[str, dict[str, Any]]:
     """Map ``function_name -> {param_name: json_schema_type}`` from request tools.
 
     Accepts OpenAI (``{"type": "function", "function": {...}}``) and bare
-    (``{"name": ..., "parameters"/"input_schema": {...}}``) tool entries.
+    (``{"name": ..., "parameters"/"input_schema": {...}}``) tool entries, and
+    its own output, which it returns unchanged (see :class:`ParamTypes`).
     """
+    if isinstance(tools, ParamTypes):
+        return tools
     out: dict[str, dict[str, Any]] = {}
     for tool in tools or []:
         if not isinstance(tool, dict):
@@ -36,7 +52,7 @@ def build_param_types(tools: list | None) -> dict[str, dict[str, Any]]:
             k: (v.get("type") if isinstance(v, dict) else None)
             for k, v in (props or {}).items()
         }
-    return out
+    return ParamTypes(out)
 
 
 def coerce_param_value(value: str, ptype: Any) -> Any:

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -55,18 +55,27 @@ class ToolCallStreamParser:
         if self.parser_cls is None:
             return [("content", text)] if text else []
 
-        if self._parser is None:
+        out: list = []
+        while self._parser is None:
             scan = self._scanner.feed(text)
-            out: list = [("content", scan.released)] if scan.released else []
+            if scan.released:
+                out.append(("content", scan.released))
             if scan.hit is None:
                 return out
+            if not self.parser_cls.opens_region(scan.hit):
+                # Framing this format wraps *every* answer in, which the
+                # non-streaming path also removes. Dropping it and carrying on
+                # is what lets such a format stream at all: treating it as a
+                # handover meant a Kimi-K3 answer, which opens with
+                # `<|open|>response<|sep|>`, buffered its entire body to EOS
+                # -- measured, 324 of 324 characters arriving in one frame.
+                text = scan.rest
+                continue
             # The region has opened. It and everything after it belong to the
             # format, not to the client.
             self._scanner = None
             self._parser = self.parser_cls(tools=self.tools)
             text = scan.hit + scan.rest
-        else:
-            out = []
 
         self._parser.tools = self.tools
         return out + self._parser.process(text)

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -29,15 +29,9 @@ logger = logging.getLogger("atom")
 # peek from re-scanning a growing buffer once per token.
 _PEEK_WINDOW = 256
 
-# KNOWN LIMIT, and deliberately not fixed here: a region runs from its opening
-# marker to wherever it closes, and for the four XML-ish formats that is end of
-# stream. An answer that merely *mentions* `<tool_call>` therefore arrives in
-# one frame at the end -- measured on a GLM answer naming the tag at character
-# 29 and then explaining for 1234 more, 98% of it at EOS.
-#
-# A "give up on a region that has produced nothing after N bytes" probe was
-# tried and reverted. It rests on acceptance being monotone in how many bytes
-# have arrived, and that is false: MiniMax gates its in-progress test on the
+# Do not add a "give up on a region that has produced nothing after N bytes"
+# probe. It was tried and reverted: it rests on acceptance being monotone in
+# how many bytes have arrived, and that is false -- MiniMax gates its in-progress test on the
 # first tag being in the declared schema, and DSML's wrapper-less and
 # direct-JSON branches cannot match any prefix at all -- so real calls over
 # N bytes were delivered as text, differently from `stream=false`, on three of
@@ -114,28 +108,38 @@ def _peek_declared(tools: list | None) -> frozenset[str]:
 
 
 def _markup_spans(
-    spans: tuple[tuple[int, int], ...], length: int
+    spans: tuple[tuple[int, int], ...], body: str
 ) -> list[tuple[int, int]]:
     """A format's markup intervals, clamped and merged into a partition.
 
     The engine walks these in order and treats the gaps as answer, so they
     have to be ascending and non-overlapping whatever a format reports.
 
-    At least one byte is always consumed, which is what keeps the engine from
-    handing a region back, finding the same marker and parsing it forever:
-    every span kept here is non-empty, and a region with none at all gets the
-    one-byte span on the last line.
+    Two spans separated by nothing but whitespace are joined. That whitespace
+    is the template's, not the model's: `end_of_markup` moves only on a closer
+    and `begin_of_markup` only on an opener, which is right at the edge of a
+    region -- the newline before the model resumes prose belongs to the prose
+    -- and wrong between two calls, where every one of these chat templates
+    renders a separator. Left in the gap it became a `content: "\n"` delta
+    sitting between two `tool_calls` deltas, and on `/v1/messages` a whole
+    text block containing one newline.
+
+    Every span kept here is non-empty, so the engine always consumes at least
+    one byte and cannot hand a region back, find the same marker and parse it
+    forever. A format that reports only degenerate spans would break that, so
+    it is refused rather than papered over -- the caller falls back to
+    releasing the region unchanged.
     """
     merged: list[tuple[int, int]] = []
     for start, stop in sorted(spans):
-        start, stop = max(0, min(start, length)), max(0, min(stop, length))
+        start, stop = max(0, min(start, len(body))), max(0, min(stop, len(body)))
         if stop <= start:
             continue
-        if merged and start <= merged[-1][1]:
+        if merged and not body[merged[-1][1] : start].strip():
             merged[-1] = (merged[-1][0], max(merged[-1][1], stop))
         else:
             merged.append((start, stop))
-    return merged or ([(0, 1)] if length else [])
+    return merged
 
 
 def _resolved_tools(tools: list | None):
@@ -367,12 +371,27 @@ class ToolCallStreamParser:
             parsed = RegionParse((), parsed.spans)
         events: list = []
         rest = ""
-        if parsed.spans and (parsed.calls or self.suppress_calls):
-            # Everything outside the format's markup is answer, including
-            # whatever the model wrote *between* two calls. Reading only the
-            # outer pair deleted that -- "let me also check Rome" between two
-            # `<tool_call>` blocks, on five of the six formats, silently.
-            spans = _markup_spans(parsed.spans, len(body))
+        # Everything outside the format's markup is answer, including whatever
+        # the model wrote *between* two calls. Reading only the outer pair
+        # deleted that -- "let me also check Rome" between two `<tool_call>`
+        # blocks, on five of the six formats, silently.
+        #
+        # `spans` empty with calls present would mean a format reported
+        # nothing this engine can consume, and consuming nothing loops
+        # forever. No registered format can do it -- 1.2M fuzzed regions
+        # produced zero -- so this is the boundary check for the seventh, and
+        # it fails towards releasing the region rather than towards eating a
+        # byte of it.
+        spans = _markup_spans(parsed.spans, body)
+        if parsed.calls and not spans:
+            logger.warning(
+                "%s reported %d call(s) with no usable markup span in %d bytes; "
+                "releasing the region as text",
+                self.parser_cls.NAME,
+                len(parsed.calls),
+                len(body),
+            )
+        if spans and (parsed.calls or self.suppress_calls):
             pending = list(parsed.calls)
             at = 0
             for i, (start, stop) in enumerate(spans):
@@ -596,11 +615,37 @@ def read_whole(
     Nothing is trimmed. A trailing `.strip()` here cost a code-block answer its
     final newline, which streaming had no way to reproduce.
     """
+    return flatten_tool_events(
+        read_whole_events(parser_cls, text, tools, suppress_calls=suppress_calls)
+    )
+
+
+def read_whole_events(
+    parser_cls: type[ToolCallParser] | None,
+    text: str,
+    tools: list | None = None,
+    *,
+    suppress_calls: bool = False,
+) -> list:
+    """The same single chunk, as the engine's own ordered events.
+
+    `read_whole` flattens these into `(content, calls)`, which loses where the
+    content sat relative to the calls. A caller that renders blocks in order
+    -- the Anthropic non-streaming path -- needs that order, and building it
+    from a joined string put a response's whole answer in one block ahead of
+    every `tool_use`, so `stream=false` disagreed with `stream=true` about the
+    order of the blocks in the same generation.
+    """
     engine = ToolCallStreamParser(
         tools=tools, parser_cls=parser_cls, suppress_calls=suppress_calls
     )
     events = engine.process(text)
     events.extend(engine.flush())
+    return events
+
+
+def flatten_tool_events(events: list) -> tuple[str, list[ToolCall]]:
+    """Ordered events as `(joined content, calls)`."""
     content: list[str] = []
     calls: list[ToolCall] = []
     pending: dict | None = None

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -1,89 +1,537 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""Streaming facade: read ahead of the chosen format, then delegate to it."""
+"""The engine: one reader of a model's output, for both delivery modes.
 
-from dataclasses import dataclass, field
+A format (:class:`~.tool_parser.ToolCallParser`) says what its own bytes mean.
+Everything a reader has to decide that is *not* particular to a format is
+decided here, once: how far ahead of a region it is safe to release, which
+markers are framing and get dropped, what a region that parses to no call
+means, which index a call is stamped with, and what happens to the answer that
+follows the markup.
+
+`stream=false` is :func:`read_whole`, which is this engine over a single chunk.
+That is the whole of why the two delivery modes agree -- not a test that
+compares them, but no second implementation to compare against.
+"""
+
+import logging
 
 from ..marker_scanner import MarkerScanner
-from .tool_parser import ToolCallParser
+from .schema import build_param_types
+from .tool_parser import NO_CALLS, ToolCall, ToolCallParser, unique_tool_call_id
+
+logger = logging.getLogger("atom")
+
+# How far into a region a name may be before the peek gives up. Every
+# format on this box puts it in the first 30-70 characters; the margin is
+# for a long name or leading whitespace, and the bound is what keeps the
+# peek from re-scanning a growing buffer once per token.
+_PEEK_WINDOW = 256
+
+# KNOWN LIMIT, and deliberately not fixed here: a region runs from its opening
+# marker to wherever it closes, and for the four XML-ish formats that is end of
+# stream. An answer that merely *mentions* `<tool_call>` therefore arrives in
+# one frame at the end -- measured on a GLM answer naming the tag at character
+# 29 and then explaining for 1234 more, 98% of it at EOS.
+#
+# A "give up on a region that has produced nothing after N bytes" probe was
+# tried and reverted. It rests on acceptance being monotone in how many bytes
+# have arrived, and that is false: MiniMax gates its in-progress test on the
+# first tag being in the declared schema, and DSML's wrapper-less and
+# direct-JSON branches cannot match any prefix at all -- so real calls over
+# N bytes were delivered as text, differently from `stream=false`, on three of
+# the six formats. It was also quadratic, because giving up re-feeds bytes that
+# immediately reopen a region with a fresh budget: 1.19 ms -> 18.2 s on a
+# 250 KB answer, in the request coroutine, stalling the event loop for
+# everything else.
+#
+# Fixing the latency needs the *format* to say "this can no longer become a
+# call", which is a different question from "does not parse yet" and one no
+# format answers today.
 
 
-@dataclass
+class Region:
+    """The bytes buffered since a tool-call region opened.
+
+    A list and a join, not `self.buf += text`. Appending to a *string
+    attribute* is quadratic in CPython: the instance dict holds a reference,
+    so the in-place fast path never applies and every chunk copies the whole
+    buffer. Measured on a 128 KB tool call, streamed four characters at a
+    time: 23 ms of event-loop CPU in `process` alone, growing 17x for an 8x
+    payload while `flush` stayed linear. The same loop over a *local* string
+    is linear, which is why a microbenchmark of `s += x` finds nothing.
+
+    `head` is the first `_PEEK_WINDOW` bytes, kept separately so the early
+    name announcement never needs the region materialised -- it only ever
+    looks that far in, and handing it the whole buffer is how the quadratic
+    scan it already fixed once could come back.
+    """
+
+    __slots__ = ("_len", "_parts", "head")
+
+    def __init__(self) -> None:
+        self._parts: list[str] = []
+        self._len = 0
+        self.head = ""
+
+    def append(self, text: str) -> None:
+        if not text:
+            return
+        self._parts.append(text)
+        self._len += len(text)
+        if len(self.head) < _PEEK_WINDOW:
+            self.head = (self.head + text)[:_PEEK_WINDOW]
+
+    def text(self) -> str:
+        """Everything buffered, without giving it up.
+
+        Collapses the parts as a side effect, so asking twice costs one join
+        rather than two. Only the region-close probe asks, and only once a
+        literal that could close the region has actually arrived.
+        """
+        if len(self._parts) > 1:
+            self._parts = ["".join(self._parts)]
+        return self._parts[0] if self._parts else ""
+
+    def take(self) -> str:
+        """Everything buffered, and start again."""
+        out = self.text()
+        self._parts.clear()
+        self._len = 0
+        self.head = ""
+        return out
+
+    def __len__(self) -> int:
+        return self._len
+
+    def __bool__(self) -> bool:
+        return self._len > 0
+
+
+def _peek_declared(tools: list | None) -> frozenset[str]:
+    return frozenset(build_param_types(tools))
+
+
 class ToolCallStreamParser:
-    """Stateful streaming parser for one request's output.
+    """Reads one request's output, in chunks or all at once.
 
-    Emits structured events:
-    - ("content", text) — regular content before tool calls
-    - ("tool_call_start", {"index": N, "id": ..., "function": {"name": ..., "arguments": ""}})
-    - ("tool_call_args", {"index": N, "function": {"arguments": chunk}})
-    - ("tool_call_end", None) — all tool calls complete
+    Emits ``(event_type, data)`` tuples:
+
+    - ``("content", text)`` -- answer text, in the order the model wrote it
+    - ``("tool_call_start", {"index", "id", "type", "function": {"name", ...}})``
+    - ``("tool_call_args", {"index", "function": {"arguments": ...}})``
+    - ``("tool_call_end", None)`` -- a region's calls are complete
 
     ``parser_cls`` is the format this model was resolved to at startup, from
     its chat template (`registry.resolve_from_prompt`). ``None`` means no
-    registered format recognised it: this then emits everything as content and
-    parses nothing, which the server announced at startup. It is deliberately
-    not a fallback to guessing — the guess this replaces mis-read a Hermes
-    `<tool_call>{...}` as GLM and delivered the whole JSON blob as the tool's
-    *name*.
+    registered format recognised it: everything is emitted as content and
+    nothing is parsed, which the server announced at startup. It is
+    deliberately not a fallback to guessing -- the guess this replaces
+    mis-read a Hermes `<tool_call>{...}` as GLM and delivered the whole JSON
+    blob as the tool's *name*.
+
+    ``suppress_calls`` is ``tool_choice: "none"``. The format is still read --
+    that is the difference from ``parser_cls=None``, and it matters, because a
+    format whose framing wraps *every* answer would otherwise leak that
+    framing to the client the moment a request forbade tool calls. What is
+    suppressed is dispatch: a region's bytes are released as the prose the
+    request said they must be.
 
     ``tools`` enables JSON-Schema type coercion of parameter values. It may be
-    assigned after construction (several call sites do) and is re-read on every
-    delegated call, so it takes effect as long as it is set before the stream
-    ends.
+    assigned after construction (several call sites do) and is read when a
+    region closes, so it takes effect as long as it is set before then.
     """
 
-    tools: list | None = None
-    parser_cls: type[ToolCallParser] | None = None
-    _parser: ToolCallParser | None = field(default=None, repr=False)
-    # Reads ahead of the region: releases everything that cannot begin one of
-    # `parser_cls`'s own openers. `None` once the region has started, or when
-    # there is no format to look for.
-    _scanner: MarkerScanner | None = field(default=None, repr=False)
-
-    def __post_init__(self):
-        if self.parser_cls is not None:
-            self._scanner = MarkerScanner(self.parser_cls.START_MARKERS)
+    def __init__(
+        self,
+        tools: list | None = None,
+        parser_cls: type[ToolCallParser] | None = None,
+        *,
+        suppress_calls: bool = False,
+    ) -> None:
+        self.tools = tools
+        self.parser_cls = parser_cls
+        self.suppress_calls = suppress_calls
+        # Reads ahead of the region: releases everything that cannot begin one
+        # of `parser_cls`'s own markers, and drops the ones that are framing.
+        # One scanner, not one here and another on the format -- two readers
+        # of the same marker set is how framing came to be dropped before a
+        # region and kept inside one.
+        self._scanner = (
+            MarkerScanner(parser_cls.START_MARKERS) if parser_cls is not None else None
+        )
+        self._region: Region | None = None
+        # The tail a region-closing literal split across a chunk boundary
+        # would need, and nothing more.
+        self._end_markers = parser_cls.REGION_END_MARKERS if parser_cls else ()
+        self._end_tail_len = max((len(m) for m in self._end_markers), default=1) - 1
+        self._end_tail = ""
+        # Stamped by the engine, so no format has to. Kimi took its index off
+        # the wire, where every section restarts at 0, and a client
+        # accumulating arguments by index merged two calls into one.
+        self._index = 0
+        self._emitted = 0
+        # The name already sent for the region being buffered, if any.
+        self._announced: str | None = None
+        # Set once no name can still turn up, so the peek stops running per
+        # token over a region that will never yield one.
+        self._peek_exhausted = False
+        # The request's declared names, built once rather than per token.
+        self._declared: frozenset[str] | None = None
 
     @property
     def fmt(self) -> str | None:
         """The format this stream is being read as, or None."""
         return self.parser_cls.NAME if self.parser_cls is not None else None
 
+    # -- public ------------------------------------------------------------
     def process(self, text: str) -> list:
-        """Process a text chunk and return list of (event_type, data) tuples."""
+        """Consume one chunk; return the events it completed."""
         if self.parser_cls is None:
             return [("content", text)] if text else []
-
-        out: list = []
-        while self._parser is None:
-            scan = self._scanner.feed(text)
-            if scan.released:
-                out.append(("content", scan.released))
-            if scan.hit is None:
-                return out
-            if not self.parser_cls.opens_region(scan.hit):
-                # Framing this format wraps *every* answer in, which the
-                # non-streaming path also removes. Dropping it and carrying on
-                # is what lets such a format stream at all: treating it as a
-                # handover meant a Kimi-K3 answer, which opens with
-                # `<|open|>response<|sep|>`, buffered its entire body to EOS
-                # -- measured, 324 of 324 characters arriving in one frame.
-                text = scan.rest
-                continue
-            # The region has opened. It and everything after it belong to the
-            # format, not to the client.
-            self._scanner = None
-            self._parser = self.parser_cls(tools=self.tools)
-            text = scan.hit + scan.rest
-
-        self._parser.tools = self.tools
-        return out + self._parser.process(text)
+        return self._pump(text, final=False)
 
     def flush(self) -> list:
-        """Flush whatever is still held; at EOS none of it became a region."""
-        if self._parser is None:
-            rest = self._scanner.flush() if self._scanner is not None else ""
-            return [("content", rest)] if rest else []
-        self._parser.tools = self.tools
-        return self._parser.flush()
+        """End of stream: nothing more is coming, so nothing is held back."""
+        if self.parser_cls is None:
+            return []
+        return self._pump("", final=True)
+
+    # -- the loop ----------------------------------------------------------
+    def _pump(self, text: str, *, final: bool) -> list:
+        """Read `text`, and whatever a closing region hands back, to a stop.
+
+        The one loop. Content before a region, framing, the region itself and
+        the answer after it are all reached from here, so "what happens to
+        these bytes" has a single answer per byte rather than one per format
+        per delivery mode.
+        """
+        out: list = []
+        while True:
+            if self._region is None:
+                if text:
+                    scan = self._scanner.feed(text)
+                    text = ""
+                    if scan.released:
+                        out.append(("content", scan.released))
+                    if scan.hit is not None:
+                        if not self.parser_cls.opens_region(scan.hit):
+                            # Framing this format wraps every answer in.
+                            # Dropping it and carrying on is what lets such a
+                            # format stream at all: treating it as a handover
+                            # meant a Kimi-K3 answer, which opens with
+                            # `<|open|>response<|sep|>`, buffered its entire
+                            # body to EOS -- 324 of 324 characters in one
+                            # frame at the end.
+                            text = scan.rest
+                        elif self.suppress_calls:
+                            # The request forbade tool calls, so this region
+                            # cannot become one and there is nothing to wait
+                            # for. The marker is answer text like everything
+                            # around it. Buffering it anyway would hold the
+                            # rest of the reply to end of stream for a request
+                            # that had already said what the answer is.
+                            out.append(("content", scan.hit))
+                            text = scan.rest
+                        else:
+                            # The region has opened. Opened, but not read
+                            # here: the marker goes back through the region
+                            # branch below, so a chunk carrying a whole call
+                            # is closed on this pass rather than one late.
+                            self._region = Region()
+                            self._end_tail = ""
+                            text = scan.hit + scan.rest
+                        continue
+                if not final:
+                    return out
+                held = self._scanner.flush()
+                if held:
+                    out.append(("content", held))
+                return out
+
+            probe = ""
+            if text:
+                if self._end_markers:
+                    probe = self._end_tail + text
+                    self._end_tail = (
+                        probe[-self._end_tail_len :] if self._end_tail_len else ""
+                    )
+                self._region.append(text)
+                text = ""
+                out.extend(self._announce())
+            end = len(self._region) if final else self._closed_len(probe)
+            if end <= 0:
+                return out
+            body = self._region.take()
+            self._region = None
+            self._end_tail = ""
+            events, rest = self._close_region(body[:end])
+            out.extend(events)
+            text = rest + body[end:]
+
+    def _closed_len(self, probe: str) -> int:
+        """Whether the open region has closed, without materialising it.
+
+        The probe is the literal itself: nothing in a chunk can close a region
+        unless one of `REGION_END_MARKERS` lands in it, so until one does
+        there is nothing to look at. Asking the format instead would mean
+        joining the buffer once per chunk, which is quadratic in the region --
+        measured at 55 ms of event-loop CPU on a 50 KB argument against 4 ms
+        for the same payload in a format that did not do it.
+
+        `probe` is the incoming chunk with the tail a marker split across the
+        boundary would need, so a section end arriving one character at a time
+        is still seen.
+        """
+        if not probe or not any(m in probe for m in self._end_markers):
+            return 0
+        return self.parser_cls.region_end(self._region.text())
+
+    def _close_region(self, body: str) -> tuple[list, str]:
+        """One region's events, and the bytes that were not its markup.
+
+        The announcement is per region and is settled here either way: bound
+        to the region's first call, or dropped. Carrying it past the region it
+        was made in is how one region's peek came to be matched against the
+        next region's parse, and reported as a mismatch.
+        """
+        parsed = (
+            NO_CALLS
+            if self.suppress_calls
+            else self.parser_cls.parse_region(body, self.tools, at_end=True)
+        )
+        events: list = []
+        rest = ""
+        if parsed.calls:
+            begins = min(max(parsed.begins, 0), len(body))
+            if begins:
+                events.append(("content", body[:begins]))
+            for call in parsed.calls:
+                events.extend(self._emit_call(call))
+            events.append(("tool_call_end", None))
+            # Bounded to at least one byte past `begins`. A format that
+            # reported less would have the engine hand the whole region back,
+            # find the same marker and parse it again forever; the property
+            # tests hold every registered format to
+            # `begins < consumed <= len(region)`.
+            consumed = min(max(parsed.consumed, begins + 1), len(body))
+            rest = body[consumed:]
+        elif body:
+            # A start marker is not a promise. An answer explaining that a
+            # model "writes <tool_call> to call something" opens the region
+            # and never closes it, and this used to drop everything from the
+            # marker on -- no event, no error, `finish_reason` still `stop`.
+            # Fifty characters of eighty-two, on the shapes measured.
+            #
+            # Released verbatim, and released here rather than handed back:
+            # handing it back would find the same marker again.
+            #
+            # A name may already have gone out, and there is no retracting it.
+            # What there is: no arguments follow, so nothing downstream counts
+            # this as a usable call and `finish_reason` stays `stop`. The text
+            # is still delivered -- the promise costs a dangling name, not the
+            # answer.
+            events.append(("content", body))
+        if self._announced is not None and not parsed.calls:
+            # The name went out and nothing will follow it. Step past the index
+            # it was sent at, exactly as `_start_event` does when it drops one:
+            # a later call landing on an index the client has already bound to
+            # a name is merged into it by any accumulator that keys on index,
+            # which is the OpenAI streaming contract.
+            #
+            # Not reachable while every format's acceptance is monotone in how
+            # many bytes have arrived -- an announcement is the first call of
+            # `parse_region` over a prefix of these same bytes. That property
+            # is fuzzed rather than assumed
+            # (`TestTheEarlyNameCannotDisagreeWithTheParse`), and this is what
+            # the wire looks like if it ever stops holding.
+            self._index += 1
+        self._announced = None
+        self._peek_exhausted = False
+        return events, rest
+
+    # -- events ------------------------------------------------------------
+    def _announce(self) -> list:
+        """Send the tool's name as soon as the region reveals it, once.
+
+        The name is read out of ``parse_region`` itself, over the region so
+        far and with ``at_end=False``. That is what makes it agree with the
+        call that eventually goes out: same function, same enumeration, the
+        second run seeing a superset of the first's bytes. Every format used
+        to answer this with a regex of its own, and four of the five had it
+        disagree with their parse -- most recently over a self-closing
+        ``<invoke name="x"/>`` the peek skipped and the parse returned first,
+        which put three tool calls on the wire for a response containing two.
+
+        Only for a name the request actually declared. That check is what
+        makes an early name safe to send: it cannot be taken back, and an
+        answer merely quoting `<tool_call><function=NAME>` opens a region too.
+        A name the client never offered is overwhelmingly likelier to be prose
+        than a call, so it waits for the region to close like everything else.
+        SGLang's cursor parsers announce with no such check and will emit a
+        call named after whatever follows the tag.
+
+        Asked of `Region.head` -- the first `_PEEK_WINDOW` bytes and no more
+        -- and asked at most once more after it fills. Running a format's
+        regex over the whole region on every chunk is quadratic in the
+        response and measured 3.0 -> 9.8 -> 36 -> 137 ms across 2k/4k/8k/16k
+        tokens: the shape `marker_scanner` exists to retire, put back one
+        layer up.
+        """
+        if (
+            self._announced is not None
+            or self._peek_exhausted
+            or self.suppress_calls
+            or not self.tools
+        ):
+            return []
+        head = self._region.head
+        calls = self.parser_cls.parse_region(head, self.tools, at_end=False).calls
+        if not calls:
+            self._peek_exhausted = len(head) >= _PEEK_WINDOW
+            return []
+        name = calls[0].function["name"]
+        if self._declared is None:
+            self._declared = _peek_declared(self.tools)
+        if name not in self._declared:
+            self._peek_exhausted = True
+            return []
+        self._announced = name
+        return [
+            (
+                "tool_call_start",
+                {
+                    "index": self._index,
+                    "id": unique_tool_call_id(),
+                    "type": "function",
+                    "function": {"name": name, "arguments": ""},
+                },
+            )
+        ]
+
+    def _start_event(self, call: ToolCall) -> list:
+        """The `tool_call_start` for a call, unless its name already went out.
+
+        A mismatch is not reachable: the announcement is the first call of
+        ``parse_region`` over a prefix of these same bytes, and acceptance is
+        monotone in what has arrived. It is checked rather than asserted
+        because the caller is on a live SSE stream that has already sent its
+        200 -- an exception here reached the client as a connection cut
+        mid-frame with no `[DONE]` and, on the `n>1` path, took the other
+        choices with it.
+
+        So it is logged and recovered from. The announced name is already on
+        the wire and cannot be retracted, but it can be left with no arguments
+        -- the shape every other unfulfilled announcement takes, and one that
+        `completes_a_tool_call` and `finish_reason` both read as "not a call".
+        The real call goes out at the next index, whole.
+        """
+        name = call.function["name"]
+        if self._announced is not None and self._announced != name:
+            logger.warning(
+                "%s announced %r and then parsed %r from the same region; "
+                "sending %r as a new call and leaving %r without arguments",
+                self.parser_cls.__name__,
+                self._announced,
+                name,
+                name,
+                self._announced,
+            )
+            self._announced = None
+            # Past the dangling announcement, so the real call does not land
+            # on an index the client has already bound to the wrong name.
+            self._index += 1
+            return self._start_event(call)
+        if self._announced is not None:
+            self._announced = None  # binds to the first call of the region only
+            return []
+        return [
+            (
+                "tool_call_start",
+                {
+                    "index": self._index,
+                    "id": call.id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": ""},
+                },
+            )
+        ]
+
+    def _emit_call(self, call: ToolCall) -> list:
+        """One parsed call as start+args events, at the engine's own index.
+
+        The arguments go out unconditionally, empty ones included: a
+        zero-parameter tool is still a call the client should run, and
+        `finish_reason` keys on this event. Gating it reported `stop` for a
+        response that had already sent a `tool_calls` delta.
+        """
+        events = self._start_event(call)
+        events.append(
+            (
+                "tool_call_args",
+                {
+                    "index": self._index,
+                    "function": {"arguments": call.function["arguments"]},
+                },
+            )
+        )
+        self._index += 1
+        self._emitted += 1
+        return events
+
+
+def read_whole(
+    parser_cls: type[ToolCallParser] | None,
+    text: str,
+    tools: list | None = None,
+    *,
+    suppress_calls: bool = False,
+) -> tuple[str, list[ToolCall]]:
+    """A complete output as ``(content, calls)`` -- the engine, in one chunk.
+
+    Not a second implementation of anything. `stream=false` and `stream=true`
+    read the model's words with the same code, so the four rules they used to
+    answer separately -- where content ends, whether an unclosed tag is a call,
+    what a region that parses to nothing means, which bytes are framing -- have
+    one answer each and no way to drift.
+
+    Content comes back byte-for-byte except for markers the format declares:
+    the region a call occupied, and the framing `opens_region` says no to.
+    Nothing is trimmed. A trailing `.strip()` here cost a code-block answer its
+    final newline, which streaming had no way to reproduce.
+    """
+    engine = ToolCallStreamParser(
+        tools=tools, parser_cls=parser_cls, suppress_calls=suppress_calls
+    )
+    events = engine.process(text)
+    events.extend(engine.flush())
+    content: list[str] = []
+    calls: list[ToolCall] = []
+    pending: dict | None = None
+    for etype, data in events:
+        if etype == "content":
+            content.append(data)
+        elif etype == "tool_call_start":
+            fn = data["function"]
+            pending = {"id": data["id"], "name": fn["name"]}
+        elif etype == "tool_call_args":
+            if pending is None:
+                # An announcement is what normally supplies the name, and it
+                # cannot go missing between the two events of one call -- but
+                # a format whose peek and parse disagree leaves a start event
+                # behind without one. Dropping the arguments is what the
+                # streaming clients do with the same pair.
+                continue
+            calls.append(
+                ToolCall(
+                    id=pending["id"],
+                    type="function",
+                    function={
+                        "name": pending["name"],
+                        "arguments": data["function"]["arguments"],
+                    },
+                )
+            )
+            pending = None
+    return "".join(content), calls

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -19,7 +19,7 @@ import logging
 
 from ..marker_scanner import MarkerScanner
 from .schema import ParamTypes, build_param_types
-from .tool_parser import NO_CALLS, ToolCall, ToolCallParser
+from .tool_parser import RegionParse, ToolCall, ToolCallParser
 
 logger = logging.getLogger("atom")
 
@@ -111,6 +111,31 @@ class Region:
 
 def _peek_declared(tools: list | None) -> frozenset[str]:
     return frozenset(build_param_types(tools))
+
+
+def _markup_spans(
+    spans: tuple[tuple[int, int], ...], length: int
+) -> list[tuple[int, int]]:
+    """A format's markup intervals, clamped and merged into a partition.
+
+    The engine walks these in order and treats the gaps as answer, so they
+    have to be ascending and non-overlapping whatever a format reports.
+
+    At least one byte is always consumed, which is what keeps the engine from
+    handing a region back, finding the same marker and parsing it forever:
+    every span kept here is non-empty, and a region with none at all gets the
+    one-byte span on the last line.
+    """
+    merged: list[tuple[int, int]] = []
+    for start, stop in sorted(spans):
+        start, stop = max(0, min(start, length)), max(0, min(stop, length))
+        if stop <= start:
+            continue
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], stop))
+        else:
+            merged.append((start, stop))
+    return merged or ([(0, 1)] if length else [])
 
 
 def _resolved_tools(tools: list | None):
@@ -256,20 +281,18 @@ class ToolCallStreamParser:
                             # body to EOS -- 324 of 324 characters in one
                             # frame at the end.
                             text = scan.rest
-                        elif self.suppress_calls:
-                            # The request forbade tool calls, so this region
-                            # cannot become one and there is nothing to wait
-                            # for. The marker is answer text like everything
-                            # around it. Buffering it anyway would hold the
-                            # rest of the reply to end of stream for a request
-                            # that had already said what the answer is.
-                            out.append(("content", scan.hit))
-                            text = scan.rest
                         else:
                             # The region has opened. Opened, but not read
                             # here: the marker goes back through the region
                             # branch below, so a chunk carrying a whole call
                             # is closed on this pass rather than one late.
+                            #
+                            # Not skipped for `suppress_calls`: releasing the
+                            # marker as content there let the rest of the
+                            # region stream out as content too, putting raw
+                            # wire tokens in the answer. A region is buffered
+                            # the same way whatever the request said about
+                            # dispatch; only `_close_region` differs.
                             self._region = Region()
                             self._end_tail = ""
                             text = scan.hit + scan.rest
@@ -327,27 +350,53 @@ class ToolCallStreamParser:
         was made in is how one region's peek came to be matched against the
         next region's parse, and reported as a mismatch.
         """
-        parsed = (
-            NO_CALLS
-            if self.suppress_calls
-            else self.parser_cls.parse_region(body, self.tools, at_end=True)
-        )
+        parsed = self.parser_cls.parse_region(body, self.tools, at_end=True)
+        if self.suppress_calls and parsed.calls:
+            # `tool_choice: "none"`. The format is read either way -- that is
+            # what separates this from `parser_cls=None` -- and what is
+            # suppressed is dispatch, not reading. Skipping the parse instead
+            # put the model's raw wire tokens in `content`, on every format
+            # and both delivery paths. The markup is now located exactly as it
+            # is for a dispatched call and only the answer around it goes out,
+            # so a response that was nothing but a call has empty content.
+            logger.debug(
+                "tool_choice=none: dropped %d %s call(s) from the response",
+                len(parsed.calls),
+                self.parser_cls.NAME,
+            )
+            parsed = RegionParse((), parsed.spans)
         events: list = []
         rest = ""
-        if parsed.calls:
-            begins = min(max(parsed.begins, 0), len(body))
-            if begins:
-                events.append(("content", body[:begins]))
-            for call in parsed.calls:
+        if parsed.spans and (parsed.calls or self.suppress_calls):
+            # Everything outside the format's markup is answer, including
+            # whatever the model wrote *between* two calls. Reading only the
+            # outer pair deleted that -- "let me also check Rome" between two
+            # `<tool_call>` blocks, on five of the six formats, silently.
+            spans = _markup_spans(parsed.spans, len(body))
+            pending = list(parsed.calls)
+            at = 0
+            for i, (start, stop) in enumerate(spans):
+                if start > at:
+                    events.append(("content", body[at:start]))
+                at = stop
+                # In the order the model wrote them, so a client sees the
+                # sentence between two calls between them and not hoisted in
+                # front of both. One call per span, and the last span takes
+                # whatever is left -- which is how Kimi-K2's single
+                # section-wide span carries all of its entries.
+                take = len(pending) if i == len(spans) - 1 else 1
+                for call in pending[:take]:
+                    events.extend(self._emit_call(call))
+                del pending[:take]
+            for call in pending:
                 events.extend(self._emit_call(call))
-            events.append(("tool_call_end", None))
-            # Bounded to at least one byte past `begins`. A format that
-            # reported less would have the engine hand the whole region back,
-            # find the same marker and parse it again forever; the property
-            # tests hold every registered format to
-            # `begins < consumed <= len(region)`.
-            consumed = min(max(parsed.consumed, begins + 1), len(body))
-            rest = body[consumed:]
+            if parsed.calls:
+                # Not for a suppressed region: there is no call to end, and a
+                # bare `tool_call_end` is read downstream as "a call just
+                # completed" -- `completes_a_tool_call` says so, and the
+                # Anthropic path closes a block on it.
+                events.append(("tool_call_end", None))
+            rest = body[at:]
         elif body:
             # A start marker is not a promise. An answer explaining that a
             # model "writes <tool_call> to call something" opens the region

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -19,7 +19,12 @@ import logging
 
 from ..marker_scanner import MarkerScanner
 from .schema import ParamTypes, build_param_types
-from .tool_parser import RegionParse, ToolCall, ToolCallParser
+from .tool_parser import (
+    RegionParse,
+    ToolCall,
+    ToolCallParser,
+    begin_of_markup,
+)
 
 logger = logging.getLogger("atom")
 
@@ -105,6 +110,35 @@ class Region:
 
 def _peek_declared(tools: list | None) -> frozenset[str]:
     return frozenset(build_param_types(tools))
+
+
+def _region_tail(body: str, parser_cls) -> int:
+    """Where the wrapper closing this region starts, or ``len(body)``.
+
+    `markup_begin`/`markup_end` walk a *call's* edges and stop at prose, so a
+    sentence between the last call and `</tool_calls>` left that tag belonging
+    to nobody and it reached the client verbatim.
+
+    An offset, not a span. Splicing the wrapper in as one made it compete for
+    a call: two adjacent calls merge into a single span, so the wrapper span
+    became the last, took the leftover call, and emitted the prose before it
+    -- the same output ordered differently depending on whether the closing
+    tag had arrived.
+
+    Found at the edge, never reconstructed. Counting openers minus closers
+    inside the spans cannot tell markup from an argument value that quotes it,
+    and that attempt deleted a `</tool_call>` out of the answer.
+
+    Trailing edge only. A wrapper opener followed by prose is byte-identical
+    to an answer quoting the opener before calling for real, and
+    `RegionParse.begins` already resolves that in favour of keeping the text;
+    a leading scan here deleted exactly such a quotation. So an opening
+    wrapper with prose after it still leaks, which is the smaller harm.
+    """
+    closers = parser_cls.CALL_CLOSERS
+    if not closers:
+        return len(body)
+    return begin_of_markup(body, len(body), closers, parser_cls.CALL_FILLERS)
 
 
 def _markup_spans(
@@ -415,7 +449,10 @@ class ToolCallStreamParser:
                 # completed" -- `completes_a_tool_call` says so, and the
                 # Anthropic path closes a block on it.
                 events.append(("tool_call_end", None))
-            rest = body[at:]
+            # Up to the region's own closing wrapper, which belongs to no
+            # call. What is left goes back through the scanner as ordinary
+            # answer text.
+            rest = body[at : _region_tail(body, self.parser_cls)]
         elif body:
             # A start marker is not a promise. An answer explaining that a
             # model "writes <tool_call> to call something" opens the region

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -199,14 +199,15 @@ def _markup_spans(
     The engine walks these in order and treats the gaps as answer, so they
     have to be ascending and non-overlapping whatever a format reports.
 
-    Two spans separated by nothing but whitespace are joined. That whitespace
-    is the template's, not the model's: `end_of_markup` moves only on a closer
-    and `begin_of_markup` only on an opener, which is right at the edge of a
-    region -- the newline before the model resumes prose belongs to the prose
-    -- and wrong between two calls, where every one of these chat templates
-    renders a separator. Left in the gap it became a `content: "\n"` delta
-    sitting between two `tool_calls` deltas, and on `/v1/messages` a whole
-    text block containing one newline.
+    Only genuinely overlapping spans are joined. Two spans separated by
+    whitespace used to be joined here as well, because that whitespace is the
+    template's separator and became a `content: "\n"` delta between two
+    `tool_calls` deltas -- but joining them broke the pairing downstream,
+    which is one call per span with the last span taking the remainder. Two
+    adjacent calls merged into one span, so that span took a single call and
+    the *last* one took two, putting a call behind a sentence the model wrote
+    after it. The separator is dropped where it is read instead, in
+    `_close_region`, which needs no span to disappear to do it.
 
     Every span kept here is non-empty, so the engine always consumes at least
     one byte and cannot hand a region back, find the same marker and parse it
@@ -219,7 +220,7 @@ def _markup_spans(
         start, stop = max(0, min(start, len(body))), max(0, min(stop, len(body)))
         if stop <= start:
             continue
-        if merged and not body[merged[-1][1] : start].strip():
+        if merged and start <= merged[-1][1]:
             merged[-1] = (merged[-1][0], max(merged[-1][1], stop))
         else:
             merged.append((start, stop))
@@ -479,8 +480,16 @@ class ToolCallStreamParser:
             pending = list(parsed.calls)
             at = 0
             for i, (start, stop) in enumerate(spans):
-                if start > at:
-                    events.append(("content", body[at:start]))
+                gap = body[at:start]
+                # Whitespace *between* two calls is the template's separator,
+                # not the answer: every one of these chat templates renders
+                # one, and `end_of_markup` stops at it because it moves only
+                # on a closer. Before the first call it is the model's, since
+                # that edge is where prose ended. Dropped here rather than by
+                # joining the two spans, which cost the one-call-per-span
+                # pairing and reordered the calls.
+                if gap and (i == 0 or gap.strip()):
+                    events.append(("content", gap))
                 at = stop
                 # In the order the model wrote them, so a client sees the
                 # sentence between two calls between them and not hoisted in

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -112,12 +112,59 @@ def _peek_declared(tools: list | None) -> frozenset[str]:
     return frozenset(build_param_types(tools))
 
 
-def _region_tail(body: str, parser_cls) -> int:
+def _region_owes_a_closer(body: str, parser_cls, spans: list[tuple[int, int]]) -> bool:
+    """Did this region's own markup leave its wrapper unclosed?
+
+    At the end of the region the two cases are byte-identical::
+
+        [call] prose </tool_calls>    the wrapper -- markup, and must go
+        [call] prose </tool_call>     the model naming it -- answer, and stays
+
+    What separates them is the right edge of the last markup span:
+    `markup_end` steps over a closer and stops at prose, so a span ending *on*
+    one closed its wrapper and a span ending on anything else still owes it.
+
+    One `endswith` at one position, not a count. Counting openers minus
+    closers broke twice over: literals inside argument *values* invented a
+    debt, discharged against the earliest closer in the document, so DSML
+    deleted twelve bytes out of a sentence and left the real wrapper in. A
+    value can never *be* a span's right edge.
+
+    Bounded `endswith` rather than `body[start:stop].rstrip()`, which copies
+    the span to read its last few bytes -- O(1) against O(span), measured 10x
+    on a 128 KB argument and flat where the copy is linear.
+
+    The merged partition is safe here, where a balance would not be: merging
+    leaves the last span's right edge alone, but would read two unclosed calls
+    as one balanced pair.
+    """
+    closers = parser_cls.CALL_CLOSERS
+    if not closers or not spans:
+        return False
+    start, end = spans[-1]
+    while end > start and body[end - 1].isspace():
+        end -= 1
+    return not any(body.endswith(c, start, end) for c in closers)
+
+
+def _region_tail(body: str, parser_cls, spans: list[tuple[int, int]]) -> int:
     """Where the wrapper closing this region starts, or ``len(body)``.
 
     `markup_begin`/`markup_end` walk a *call's* edges and stop at prose, so a
     sentence between the last call and `</tool_calls>` left that tag belonging
     to nobody and it reached the client verbatim.
+
+    Only when the region owes one. Walking unconditionally could not tell the
+    wrapper from an answer that *ends by naming* it: of 53 shapes whose
+    trailing literal was the model's own text it kept 26, against 47 here.
+    Deleting the walk instead keeps all 47 and leaves the wrapper in `content`
+    wherever a region really does owe one -- the worse trade, and three red
+    tests.
+
+    Takes the whole trailing run once entered, so two quoted closers against
+    one owed wrapper lose both. Spending the count as a budget fixes that and
+    needs the unmerged spans plus a per-span balance; measured identical on
+    all 5220 cross-format corpus pairs, so it waits for a real output.
 
     An offset, not a span. Splicing the wrapper in as one made it compete for
     a call: two adjacent calls merge into a single span, so the wrapper span
@@ -125,9 +172,8 @@ def _region_tail(body: str, parser_cls) -> int:
     -- the same output ordered differently depending on whether the closing
     tag had arrived.
 
-    Found at the edge, never reconstructed. Counting openers minus closers
-    inside the spans cannot tell markup from an argument value that quotes it,
-    and that attempt deleted a `</tool_call>` out of the answer.
+    Never before the markup it follows, or a region that is nothing but a call
+    walks back over the call's own closer, in front of the caller's cursor.
 
     Trailing edge only. A wrapper opener followed by prose is byte-identical
     to an answer quoting the opener before calling for real, and
@@ -135,10 +181,14 @@ def _region_tail(body: str, parser_cls) -> int:
     a leading scan here deleted exactly such a quotation. So an opening
     wrapper with prose after it still leaks, which is the smaller harm.
     """
-    closers = parser_cls.CALL_CLOSERS
-    if not closers:
+    if not _region_owes_a_closer(body, parser_cls, spans):
         return len(body)
-    return begin_of_markup(body, len(body), closers, parser_cls.CALL_FILLERS)
+    return max(
+        spans[-1][1],
+        begin_of_markup(
+            body, len(body), parser_cls.CALL_CLOSERS, parser_cls.CALL_FILLERS
+        ),
+    )
 
 
 def _markup_spans(
@@ -452,7 +502,7 @@ class ToolCallStreamParser:
             # Up to the region's own closing wrapper, which belongs to no
             # call. What is left goes back through the scanner as ordinary
             # answer text.
-            rest = body[at : _region_tail(body, self.parser_cls)]
+            rest = body[at : _region_tail(body, self.parser_cls, spans)]
         elif body:
             # A start marker is not a promise. An answer explaining that a
             # model "writes <tool_call> to call something" opens the region

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -5,7 +5,8 @@
 
 from dataclasses import dataclass, field
 
-from .registry import EMIT_CONTENT, WAIT, sniff_stream
+from ..marker_scanner import MarkerScanner
+from .registry import WAIT, all_markers, sniff_stream
 from .tool_parser import ToolCallParser
 
 
@@ -26,10 +27,18 @@ class ToolCallStreamParser:
     """
 
     tools: list | None = None
-    # Pre-detection accumulator. Once a format is chosen this is handed to the
-    # concrete parser and never used again.
+    # Pre-detection accumulator, reached only once a marker has actually been
+    # seen. Bounded by the length of one tool call rather than by the length
+    # of the response, because nothing lands here until a format's opening
+    # literal has arrived in full.
     _buf: str = ""
     _parser: ToolCallParser | None = field(default=None, repr=False)
+    # Live while no marker has been seen at all: reads ahead of any format,
+    # releasing everything that cannot begin one. `None` once a marker has
+    # arrived, or once a format has been chosen.
+    _scanner: MarkerScanner | None = field(
+        default_factory=lambda: MarkerScanner(all_markers()), repr=False
+    )
 
     @property
     def fmt(self) -> str | None:
@@ -37,32 +46,51 @@ class ToolCallStreamParser:
         return self._parser.NAME if self._parser is not None else None
 
     def process(self, text: str) -> list:
-        """Process a text chunk and return list of (event_type, data) tuples."""
+        """Process a text chunk and return list of (event_type, data) tuples.
+
+        Two phases before a format is known, and the split is what keeps an
+        ordinary answer streaming. Until an opening literal actually arrives,
+        the scanner releases every byte that could not be part of one and
+        holds only a possible partial marker -- bounded by the longest marker,
+        so the wait is bounded too. From the moment one arrives in full, text
+        is accumulated instead: it may belong to a tool call, and sending it
+        to the client is a decision that cannot be taken back.
+        """
+        out: list = []
         if self._parser is None:
-            self._buf += text
+            if self._scanner is not None:
+                scan = self._scanner.feed(text)
+                if scan.released:
+                    out.append(("content", scan.released))
+                if scan.hit is None:
+                    return out
+                # A marker landed. It, and everything after it, belong to the
+                # format cascade rather than to the client.
+                self._scanner = None
+                self._buf, text = scan.hit + scan.rest, ""
+            else:
+                self._buf += text
+
             choice = sniff_stream(self._buf)
             if choice is WAIT:
-                return []
-            if choice is EMIT_CONTENT:
-                out = [("content", self._buf)]
-                self._buf = ""
                 return out
             self._parser = choice(tools=self.tools)
-            # Replay everything accumulated while undecided.
+            # Replay everything accumulated since the marker.
             text, self._buf = self._buf, ""
 
         self._parser.tools = self.tools
-        return self._parser.process(text)
+        return out + self._parser.process(text)
 
     def flush(self) -> list:
         """Flush remaining buffer content."""
         if self._parser is None:
-            # Undecided at EOS: no tool markers ever appeared -> plain content.
-            if self._buf:
-                out = [("content", self._buf)]
-                self._buf = ""
-                return out
-            return []
+            # Undecided at EOS: whatever the scanner still held never became a
+            # marker, and whatever the cascade accumulated never became a
+            # format. Both are plain content.
+            held = self._scanner.flush() if self._scanner is not None else ""
+            rest = held + self._buf
+            self._buf = ""
+            return [("content", rest)] if rest else []
 
         self._parser.tools = self.tools
         return self._parser.flush()

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -220,7 +220,11 @@ def _markup_spans(
         start, stop = max(0, min(start, len(body))), max(0, min(stop, len(body)))
         if stop <= start:
             continue
-        if merged and start <= merged[-1][1]:
+        # `<`, not `<=`: two spans that merely touch are two calls the model
+        # wrote with no separator between them, and joining those is the same
+        # reordering as joining whitespace-separated ones. The existing
+        # property used a newline and so never reached this.
+        if merged and start < merged[-1][1]:
             merged[-1] = (merged[-1][0], max(merged[-1][1], stop))
         else:
             merged.append((start, stop))
@@ -292,9 +296,18 @@ class ToolCallStreamParser:
         )
         self._region: Region | None = None
 
+        # Both closers, where the format declared no region end of its own.
+        # The wrapper's is a *trigger* only -- it arrives on the chunk that
+        # completes the region, and without it the call's own closer asks
+        # first, hears "not yet", and nothing asks again. `region_end` decides
+        # from the self closer; see there for why the wrapper's cannot.
+        self._end_markers: tuple[str, ...] = ()
+        if parser_cls is not None:
+            self._end_markers = parser_cls.REGION_END_MARKERS or (
+                parser_cls.CALL_SELF_CLOSERS + parser_cls.CALL_CLOSERS
+            )
         # The tail a region-closing literal split across a chunk boundary
         # would need, and nothing more.
-        self._end_markers = parser_cls.REGION_END_MARKERS if parser_cls else ()
         self._end_tail_len = max((len(m) for m in self._end_markers), default=1) - 1
         self._end_tail = ""
         # Stamped by the engine, so no format has to. Kimi took its index off

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -18,8 +18,8 @@ compares them, but no second implementation to compare against.
 import logging
 
 from ..marker_scanner import MarkerScanner
-from .schema import build_param_types
-from .tool_parser import NO_CALLS, ToolCall, ToolCallParser, unique_tool_call_id
+from .schema import ParamTypes, build_param_types
+from .tool_parser import NO_CALLS, ToolCall, ToolCallParser
 
 logger = logging.getLogger("atom")
 
@@ -113,6 +113,17 @@ def _peek_declared(tools: list | None) -> frozenset[str]:
     return frozenset(build_param_types(tools))
 
 
+def _resolved_tools(tools: list | None):
+    """The request's tools as the parsers want them: built once, not per chunk.
+
+    Falls back to whatever was passed when nothing usable comes out, so a
+    caller's truthiness test sees the same answer either way.
+    """
+    if tools is None or isinstance(tools, ParamTypes):
+        return tools
+    return build_param_types(tools) or tools
+
+
 class ToolCallStreamParser:
     """Reads one request's output, in chunks or all at once.
 
@@ -140,7 +151,11 @@ class ToolCallStreamParser:
 
     ``tools`` enables JSON-Schema type coercion of parameter values. It may be
     assigned after construction (several call sites do) and is read when a
-    region closes, so it takes effect as long as it is set before then.
+    region closes, so it takes effect as long as it is set before then. It is
+    resolved to :class:`~.schema.ParamTypes` on the way in -- the catalogue is
+    walked once per request rather than once per chunk. A request whose tools
+    declare no usable name keeps the list it was given, so that ``not
+    self.tools`` still asks what it always asked.
     """
 
     def __init__(
@@ -150,7 +165,7 @@ class ToolCallStreamParser:
         *,
         suppress_calls: bool = False,
     ) -> None:
-        self.tools = tools
+        self.tools = tools  # type: ignore[assignment]
         self.parser_cls = parser_cls
         self.suppress_calls = suppress_calls
         # Reads ahead of the region: releases everything that cannot begin one
@@ -162,6 +177,7 @@ class ToolCallStreamParser:
             MarkerScanner(parser_cls.START_MARKERS) if parser_cls is not None else None
         )
         self._region: Region | None = None
+
         # The tail a region-closing literal split across a chunk boundary
         # would need, and nothing more.
         self._end_markers = parser_cls.REGION_END_MARKERS if parser_cls else ()
@@ -179,6 +195,21 @@ class ToolCallStreamParser:
         self._peek_exhausted = False
         # The request's declared names, built once rather than per token.
         self._declared: frozenset[str] | None = None
+
+    @property
+    def tools(self):
+        """The request's tools, resolved once (see :func:`_resolved_tools`).
+
+        A property and not a line in ``__init__`` because several call sites
+        assign it afterwards, and the resolution has to happen for those too
+        or they are the slow path again.
+        """
+        return self._tools
+
+    @tools.setter
+    def tools(self, value: list | None) -> None:
+        self._tools = _resolved_tools(value)
+        self._declared = None
 
     @property
     def fmt(self) -> str | None:
@@ -387,11 +418,21 @@ class ToolCallStreamParser:
         ):
             return []
         head = self._region.head
-        calls = self.parser_cls.parse_region(head, self.tools, at_end=False).calls
-        if not calls:
+        parsed = self.parser_cls.parse_region(head, self.tools, at_end=False)
+        if not parsed.calls:
             self._peek_exhausted = len(head) >= _PEEK_WINDOW
             return []
-        name = calls[0].function["name"]
+        if parsed.begins > 0:
+            # There is answer text ahead of the call *inside* this region --
+            # an answer that quotes a marker and then calls for real. That
+            # text is only released when the region closes, so announcing now
+            # would put the call in front of prose that `stream=false` puts
+            # behind it, and a client that closes its text pane on a tool call
+            # renders the explanation after the call. The name still goes out,
+            # with the arguments, in the right order.
+            self._peek_exhausted = True
+            return []
+        name = parsed.calls[0].function["name"]
         if self._declared is None:
             self._declared = _peek_declared(self.tools)
         if name not in self._declared:
@@ -403,7 +444,12 @@ class ToolCallStreamParser:
                 "tool_call_start",
                 {
                     "index": self._index,
-                    "id": unique_tool_call_id(),
+                    # The parsed call's own id, not a fresh one. Announcing
+                    # skips the start event the call would otherwise send, so
+                    # whatever goes out here is the only id the client sees --
+                    # and Kimi's is the model's `functions.NAME:INDEX`, which
+                    # survived only for requests that declared no tools.
+                    "id": parsed.calls[0].id,
                     "type": "function",
                     "function": {"name": name, "arguments": ""},
                 },

--- a/atom/entrypoints/openai/tool_parser/stream.py
+++ b/atom/entrypoints/openai/tool_parser/stream.py
@@ -1,24 +1,31 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""Streaming facade: sniff the format once, then delegate every chunk to it."""
+"""Streaming facade: read ahead of the chosen format, then delegate to it."""
 
 from dataclasses import dataclass, field
 
 from ..marker_scanner import MarkerScanner
-from .registry import WAIT, all_markers, sniff_stream
 from .tool_parser import ToolCallParser
 
 
 @dataclass
 class ToolCallStreamParser:
-    """Stateful streaming parser; format is auto-detected from the first chunks.
+    """Stateful streaming parser for one request's output.
 
     Emits structured events:
     - ("content", text) — regular content before tool calls
     - ("tool_call_start", {"index": N, "id": ..., "function": {"name": ..., "arguments": ""}})
     - ("tool_call_args", {"index": N, "function": {"arguments": chunk}})
     - ("tool_call_end", None) — all tool calls complete
+
+    ``parser_cls`` is the format this model was resolved to at startup, from
+    its chat template (`registry.resolve_from_prompt`). ``None`` means no
+    registered format recognised it: this then emits everything as content and
+    parses nothing, which the server announced at startup. It is deliberately
+    not a fallback to guessing — the guess this replaces mis-read a Hermes
+    `<tool_call>{...}` as GLM and delivered the whole JSON blob as the tool's
+    *name*.
 
     ``tools`` enables JSON-Schema type coercion of parameter values. It may be
     assigned after construction (several call sites do) and is re-read on every
@@ -27,70 +34,47 @@ class ToolCallStreamParser:
     """
 
     tools: list | None = None
-    # Pre-detection accumulator, reached only once a marker has actually been
-    # seen. Bounded by the length of one tool call rather than by the length
-    # of the response, because nothing lands here until a format's opening
-    # literal has arrived in full.
-    _buf: str = ""
+    parser_cls: type[ToolCallParser] | None = None
     _parser: ToolCallParser | None = field(default=None, repr=False)
-    # Live while no marker has been seen at all: reads ahead of any format,
-    # releasing everything that cannot begin one. `None` once a marker has
-    # arrived, or once a format has been chosen.
-    _scanner: MarkerScanner | None = field(
-        default_factory=lambda: MarkerScanner(all_markers()), repr=False
-    )
+    # Reads ahead of the region: releases everything that cannot begin one of
+    # `parser_cls`'s own openers. `None` once the region has started, or when
+    # there is no format to look for.
+    _scanner: MarkerScanner | None = field(default=None, repr=False)
+
+    def __post_init__(self):
+        if self.parser_cls is not None:
+            self._scanner = MarkerScanner(self.parser_cls.START_MARKERS)
 
     @property
     def fmt(self) -> str | None:
-        """Detected format name, or None while still undecided."""
-        return self._parser.NAME if self._parser is not None else None
+        """The format this stream is being read as, or None."""
+        return self.parser_cls.NAME if self.parser_cls is not None else None
 
     def process(self, text: str) -> list:
-        """Process a text chunk and return list of (event_type, data) tuples.
+        """Process a text chunk and return list of (event_type, data) tuples."""
+        if self.parser_cls is None:
+            return [("content", text)] if text else []
 
-        Two phases before a format is known, and the split is what keeps an
-        ordinary answer streaming. Until an opening literal actually arrives,
-        the scanner releases every byte that could not be part of one and
-        holds only a possible partial marker -- bounded by the longest marker,
-        so the wait is bounded too. From the moment one arrives in full, text
-        is accumulated instead: it may belong to a tool call, and sending it
-        to the client is a decision that cannot be taken back.
-        """
-        out: list = []
         if self._parser is None:
-            if self._scanner is not None:
-                scan = self._scanner.feed(text)
-                if scan.released:
-                    out.append(("content", scan.released))
-                if scan.hit is None:
-                    return out
-                # A marker landed. It, and everything after it, belong to the
-                # format cascade rather than to the client.
-                self._scanner = None
-                self._buf, text = scan.hit + scan.rest, ""
-            else:
-                self._buf += text
-
-            choice = sniff_stream(self._buf)
-            if choice is WAIT:
+            scan = self._scanner.feed(text)
+            out: list = [("content", scan.released)] if scan.released else []
+            if scan.hit is None:
                 return out
-            self._parser = choice(tools=self.tools)
-            # Replay everything accumulated since the marker.
-            text, self._buf = self._buf, ""
+            # The region has opened. It and everything after it belong to the
+            # format, not to the client.
+            self._scanner = None
+            self._parser = self.parser_cls(tools=self.tools)
+            text = scan.hit + scan.rest
+        else:
+            out = []
 
         self._parser.tools = self.tools
         return out + self._parser.process(text)
 
     def flush(self) -> list:
-        """Flush remaining buffer content."""
+        """Flush whatever is still held; at EOS none of it became a region."""
         if self._parser is None:
-            # Undecided at EOS: whatever the scanner still held never became a
-            # marker, and whatever the cascade accumulated never became a
-            # format. Both are plain content.
-            held = self._scanner.flush() if self._scanner is not None else ""
-            rest = held + self._buf
-            self._buf = ""
+            rest = self._scanner.flush() if self._scanner is not None else ""
             return [("content", rest)] if rest else []
-
         self._parser.tools = self.tools
         return self._parser.flush()

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -54,6 +54,26 @@ def continues_a_call(rest: str, tokens: tuple[str, ...], *, arrived: bool) -> bo
     return any(tok.startswith(rest[: len(tok)]) for tok in tokens)
 
 
+def declared_tools_allow(name: str, param_types: dict) -> bool:
+    """Can the request's declared tools rule this name out?
+
+    Only when it declared any. Every format's truncation gate asks whether the
+    name is one the request listed, because prose quoting an opener usually
+    invents one -- but a request with no ``tools`` field declares nothing, and
+    six formats read that as "no name is real". A call cut off by
+    `max_tokens` then went out as raw special tokens in ``content`` while the
+    *same* generation, one byte longer, was read as a call: the answer turned
+    on whether the client had listed its tools rather than on what the model
+    wrote. Agent harnesses that describe their tools in the system prompt hit
+    it on every truncation.
+
+    So: a declared list refutes a name it does not contain, and an absent list
+    refutes nothing. Whatever follower test the format applies still runs --
+    that is the evidence which does not come from the request.
+    """
+    return not param_types or name in param_types
+
+
 def unique_tool_call_id() -> str:
     # OpenAI tool_call ids must be unique across the whole conversation, not just
     # within one response. A per-response index (call_0, call_1, ...) collides

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -281,12 +281,10 @@ class ToolCallParser(ABC):
     # tests enumerate them so a newly registered format is covered the moment
     # it exists rather than when someone writes a case.
     START_MARKERS: ClassVar[tuple[str, ...]] = ()
-    # Literals that can close a region mid-stream. Declared so the engine can
-    # tell, from the incoming chunk alone, whether it is worth materialising
-    # the buffer to ask `region_end` -- the check runs once per chunk on every
-    # stream, and materialising to answer it is the quadratic this class's
-    # `Region` exists to avoid. Empty means "this format's regions close only
-    # at end of stream", which is what four of the six do.
+    # Literals that can close a region mid-stream, so the engine knows from
+    # the chunk alone whether to ask `region_end`. Empty means "the closers
+    # below", which is right for every format but Kimi, whose region is a
+    # section of several entries and whose entry end is not a section end.
     REGION_END_MARKERS: ClassVar[tuple[str, ...]] = ()
     # The wrapper literals this format writes around its calls -- before the
     # first and after the last -- and any token it repeats between tags. All
@@ -363,18 +361,32 @@ class ToolCallParser(ABC):
     def region_end(cls, region: str) -> int:
         """How many bytes of ``region`` form a closed unit, or 0 for "not yet".
 
-        Asked only after one of ``REGION_END_MARKERS`` has arrived. A format
-        that answers lets the engine emit its calls and go back to reading the
-        answer without waiting for end of stream; one that does not is
-        buffered to EOS, which is correct but silent for as long as the region
-        runs.
+        Asked only once one of ``REGION_END_MARKERS`` has arrived, so the
+        per-chunk cost is a look at the chunk and not at the buffer. A region
+        that never answers waits for end of stream and takes everything the
+        model wrote after its call with it -- 0 of 397 characters streamed on
+        five of six formats, which is the ordinary agentic shape.
 
-        Answer only on a literal that cannot appear inside an argument value.
-        Kimi's section end is a special token and qualifies; the XML formats'
-        `</tool_call>` does not, because a model writing *about* tool calls
-        puts one inside a parameter.
+        The default answers for all of them, on the one literal that cannot
+        appear inside an argument value: the call's own closer, which every
+        grammar here lists among a value's terminators. The *wrapper* closer
+        can hide in a value, and reading the old note about that as "no safe
+        literal exists" is what left four formats buffering to EOS.
+
+        Once the call has closed no value is open, so `end_of_markup` can walk
+        the wrapper: the region ends where the markup after the last call
+        ends, and stays open while the wrapper does.
         """
-        return 0
+        at = max(
+            (i + len(c) for c in cls.CALL_SELF_CLOSERS if (i := region.rfind(c)) >= 0),
+            default=0,
+        )
+        if not at:
+            return 0
+        end = end_of_markup(region, at, cls.CALL_CLOSERS, cls.CALL_FILLERS)
+        # A format with a wrapper owes its closer; one whose call *is* its
+        # wrapper (GLM) is done at the call's own.
+        return 0 if cls.CALL_CLOSERS and end == at else end
 
     @classmethod
     def render_call(cls, name: str, args: dict[str, str]) -> str:

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -45,6 +45,13 @@ class ToolCallParser(ABC):
     """
 
     NAME: ClassVar[str]
+    # Every literal this format opens with, declared rather than spelled out
+    # again inside `sniff_stream`'s chain and each parser's own logic. A
+    # streaming reader has to know them to decide how much of its buffer could
+    # still be the start of one, and the property tests enumerate them so a
+    # newly registered format is covered the moment it exists rather than when
+    # someone remembers to write a case for it.
+    MARKERS: ClassVar[tuple[str, ...]] = ()
 
     def __init__(self, tools: list | None = None):
         self.tools = tools

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -155,24 +155,44 @@ class ToolCall:
 class RegionParse:
     """What one format made of a region's bytes.
 
-    ``begins`` and ``consumed`` bracket the format's own markup: everything
-    before is the answer leading up to it, everything after is the answer
-    resuming. Both are handed back to the reader, so a region is accounted for
-    byte by byte and no format has to remember to return either half.
+    ``spans`` is every stretch of this region that is the format's own markup,
+    in ascending order and not overlapping: everything inside a span is
+    markup, everything outside every span is answer. The region is accounted
+    for byte by byte and no format has to remember to return the leftovers.
 
-    ``begins`` is the first accepted call's own match; the engine widens it
-    back to the start marker enclosing it. A region opens at the *first*
-    marker in the text, which an answer that quotes one before making a real
-    call puts in the wrong place -- the sentence between the two used to be
-    swallowed with the markup.
+    Several spans and not one outer pair, because a region can hold more than
+    one call and a model writes between them -- "let me also check Rome"
+    between two `<tool_call>` blocks is the ordinary shape of a parallel-call
+    answer. A single outer pair calls that sentence markup and deletes it. Kimi-K2 is
+    the exception, and only because it is the one format whose
+    `REGION_END_MARKERS` close a region per section, so the question never
+    reached here -- which is also why it still returns a single span covering
+    its whole section, where the others return one per call.
+
+    Each span is a call's own match widened by :meth:`ToolCallParser.
+    markup_begin` / :meth:`~ToolCallParser.markup_end`, which walk over that
+    format's wrappers and fillers and stop at prose -- so the wrapper opening
+    the first call and the one closing the last belong to those calls' spans,
+    and whitespace between two markers is markup while whitespace between
+    prose and a marker is not.
 
     ``calls`` empty means the region was a quotation rather than a call, and
-    the engine releases its bytes unchanged; both offsets are then ignored.
+    the engine releases its bytes unchanged; ``spans`` is then ignored.
     """
 
     calls: tuple[ToolCall, ...] = ()
-    begins: int = 0
-    consumed: int = 0
+    spans: tuple[tuple[int, int], ...] = ()
+
+    @property
+    def begins(self) -> int:
+        """Where the first call's markup starts. Derived, so that the answer
+        cannot drift from ``spans``."""
+        return self.spans[0][0] if self.spans else 0
+
+    @property
+    def consumed(self) -> int:
+        """Where the last call's markup ends."""
+        return self.spans[-1][1] if self.spans else 0
 
 
 NO_CALLS = RegionParse()

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -334,6 +334,14 @@ class ToolCallParser(ABC):
         unchanged, so a start marker is not a promise -- a rule that used to
         be written out in each format, and was missing from two of them.
 
+        Where a call's own pattern *ends* is part of that meaning, and it has
+        five terminators, not four: its closing tag, the next parameter, the
+        end of the call, end of input, and **the next call's opener**. Four of
+        the six formats were missing the last, so a call cut off mid-value ran
+        on into the sibling behind it and the tool was invoked with markup as
+        data -- ``city="Par<tool_call>"``. The call count stayed right either
+        way, which is what hid it.
+
         ``at_end`` is whether more bytes can still arrive for this region, and
         it is the *only* difference between the two questions this used to be
         asked twice. With ``at_end`` a token cut off part-way through is all

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from ..marker_scanner import MarkerScanner
+from .schema import build_param_types
 
 
 def unique_tool_call_id() -> str:
@@ -55,6 +56,36 @@ class ToolCallParser(ABC):
     # covered the moment it exists rather than when someone writes a case.
     START_MARKERS: ClassVar[tuple[str, ...]] = ()
 
+    @classmethod
+    def peek_name(cls, region: str) -> str | None:
+        """The tool being called, from a region that has not closed yet.
+
+        ``None`` while the name is not yet legible, and ``None`` by default:
+        a format that does not override this simply announces nothing early,
+        which is what every format did before.
+
+        The point is latency, and it is not small. A region is buffered until
+        it closes, so on a 20 KB file write the client learned *which tool*
+        only after 5030 of 5040 tokens; every one of these locates the name
+        inside the first 30-70 characters. SGLang streams the whole call this
+        way; only the name is taken here, because arguments arriving in
+        fragments cannot be made coherent when the stream is cut short.
+        """
+        return None
+
+    @classmethod
+    def opens_region(cls, marker: str) -> bool:
+        """Does this marker hand the rest of the stream to this format?
+
+        `START_MARKERS` answers "which literals must not be split across a
+        chunk boundary", and for most formats every one of them also opens a
+        tool-call region, so the two questions have the same answer and this
+        is that default. Kimi-K3 is where they come apart: three of its five
+        are channel framing that wraps *every* answer, tool call or not, and
+        treating those as a handover stopped it streaming at all.
+        """
+        return True
+
     def __init__(self, tools: list | None = None):
         self.tools = tools
         self.buf = ""
@@ -64,6 +95,9 @@ class ToolCallParser(ABC):
         self.current_index = 0
         self.emitted_calls = 0
         self._scanner_cache: MarkerScanner | None = None
+        # The name already sent for the call being buffered, if any; cleared
+        # when that call's arguments go out. See `announce`.
+        self._announced: str | None = None
 
     @property
     def _scanner(self) -> MarkerScanner:
@@ -115,26 +149,88 @@ class ToolCallParser(ABC):
     def flush(self) -> list:
         """Drain whatever is buffered at end of stream."""
 
-    def _emit_call(self, tc: ToolCall) -> list:
-        """Render one parsed ToolCall as start+args stream events."""
-        events = [
+    def announce(self, region: str) -> list:
+        """Send the tool's name as soon as the region reveals it, once.
+
+        Only for a name the request actually declared. That check is what
+        makes an early name safe to send: it cannot be taken back, and an
+        answer merely quoting `<tool_call><function=NAME>` opens a region too.
+        A name the client never offered is overwhelmingly likelier to be prose
+        than a call, so it waits for the region to close like everything else.
+
+        SGLang's cursor parsers announce with no such check and will emit a
+        call named after whatever follows the tag.
+        """
+        if self._announced is not None or not self.tools:
+            return []
+        name = self.peek_name(region)
+        if name is None or name not in build_param_types(self.tools):
+            return []
+        self._announced = name
+        return [
             (
                 "tool_call_start",
                 {
                     "index": self.current_index,
-                    "id": tc.id,
+                    "id": unique_tool_call_id(),
                     "type": "function",
-                    "function": {"name": tc.function["name"], "arguments": ""},
+                    "function": {"name": name, "arguments": ""},
                 },
-            ),
+            )
+        ]
+
+    def _start_event(self, index: int, call_id: str, name: str) -> list:
+        """The `tool_call_start` for a call, unless its name already went out.
+
+        Both places that emit a call go through here: `_emit_call` for the
+        formats that parse a whole region, and Kimi's own drain loop, which
+        builds the event inline because its id and index come off the wire.
+        Two copies of "have we announced this already" is how the announcement
+        was sent twice for one call.
+
+        A mismatch is raised, not smoothed over: `peek_name` and the parse
+        disagreeing about the same bytes is a bug in that format, and the name
+        is already on the wire where it cannot be corrected.
+        """
+        if self._announced is None:
+            return [
+                (
+                    "tool_call_start",
+                    {
+                        "index": index,
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": name, "arguments": ""},
+                    },
+                )
+            ]
+        if self._announced != name:
+            raise AssertionError(
+                f"{type(self).__name__} announced {self._announced!r} and then "
+                f"parsed {name!r} from the same region"
+            )
+        self._announced = None  # binds to the first call only
+        return []
+
+    def _emit_call(self, tc: ToolCall) -> list:
+        """Render one parsed ToolCall as start+args stream events.
+
+        The name is skipped when it has already gone out, and its id is
+        reused so the client sees one call rather than two. A mismatch means
+        `peek_name` and `parse` disagree about the same bytes, which is a bug
+        in that format and is raised rather than papered over -- the name is
+        already on the wire and cannot be corrected.
+        """
+        events = self._start_event(self.current_index, tc.id, tc.function["name"])
+        events.append(
             (
                 "tool_call_args",
                 {
                     "index": self.current_index,
                     "function": {"arguments": tc.function["arguments"]},
                 },
-            ),
-        ]
+            )
+        )
         self.current_index += 1
         self.emitted_calls += 1
         return events
@@ -178,9 +274,14 @@ class BufferedMarkerParser(ToolCallParser):
                 return results
             self.buf = scan.hit + scan.rest
             self.state = 1
-            return results
+            # Also here: a coarse chunk can carry the opener and the name
+            # together, and waiting for the next one would give that back.
+            return results + self.announce(self.buf)
         self.buf += text
-        return results
+        # The name is legible long before the region closes, and the
+        # region is what the wait is for: on a 20 KB file write the
+        # client learned the tool only after 5030 of 5040 tokens.
+        return results + self.announce(self.buf)
 
     def flush(self) -> list:
         results: list = []
@@ -201,6 +302,13 @@ class BufferedMarkerParser(ToolCallParser):
             # Fifty characters of eighty-two, on the shapes measured.
             #
             # Released verbatim rather than as `parse`'s content, which strips.
+            #
+            # A name may already have gone out, and there is no retracting it.
+            # What there is: no arguments follow, so nothing downstream counts
+            # this as a usable call and `finish_reason` stays `stop`. The text
+            # is still delivered -- the promise costs a dangling name, not the
+            # answer.
+            self._announced = None
             return [("content", region)] if region else []
         for tc in tool_calls:
             results.extend(self._emit_call(tc))

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -1,32 +1,36 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""Parser interface and the shared buffered-marker streaming strategy.
+"""One reading of a model's tool-call syntax, driven by one engine.
 
-Every wire format implements :class:`ToolCallParser`. Four of the five
-(Qwen / DSML / GLM / MiniMax) stream identically — buffer from the first start
-marker, parse the whole block at flush — so that strategy lives once in
-:class:`BufferedMarkerParser` and each format only declares its markers and its
-``parse``. Kimi is the exception: its token format is self-delimiting, so it
-emits tool calls incrementally and implements ``process``/``flush`` itself.
+A format used to be read twice: ``parse`` took a complete output and the
+``process``/``flush`` state machine took it a chunk at a time. Both had to
+decide where content ends, whether an unclosed tag is a call or a quotation,
+what to do with a region that parses to nothing, and which bytes are framing --
+so every one of those rules existed six times over, once per format, in two
+copies. Three rounds of review found the copies disagreeing about all four,
+and every disagreement is a response a client gets one way with
+``stream=false`` and another with ``stream=true``.
+
+So a format now declares only what is particular to it:
+
+``START_MARKERS``     literals that must not be split across a chunk boundary
+``opens_region``      which of those hand the stream over (the rest are framing)
+``parse_region``      what one region's bytes mean -- the calls, and the two
+                      offsets that bracket the format's own markup
+
+and :class:`ToolCallStreamParser` -- the engine -- owns everything else:
+reading ahead of the region, releasing content, dropping framing, the rule
+that a start marker is not a promise, stamping call indices, and handing back
+whatever followed the markup. ``stream=false`` is the engine run over a single
+chunk, so the two modes cannot disagree: there is nothing left for them to
+disagree with.
 """
 
-import logging
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, ClassVar
-
-from ..marker_scanner import MarkerScanner
-from .schema import build_param_types
-
-logger = logging.getLogger("atom")
-
-# How far into a region a name may be before the peek gives up. Every
-# format on this box puts it in the first 30-70 characters; the margin is
-# for a long name or leading whitespace, and the bound is what keeps the
-# peek from re-scanning a growing buffer once per token.
-_PEEK_WINDOW = 256
 
 
 def continues_a_call(rest: str, tokens: tuple[str, ...], *, arrived: bool) -> bool:
@@ -35,14 +39,15 @@ def continues_a_call(rest: str, tokens: tuple[str, ...], *, arrived: bool) -> bo
     One implementation, because four formats had a copy and the copies were
     the point of failure: each format supplies the tokens, this decides.
 
-    `arrived` is the difference between the two callers and the whole of it.
-    `parse` runs at end of stream, where a token cut off part-way through is
-    all there will ever be, so a *prefix* counts -- that is what a call
-    truncated by `max_tokens` looks like. `peek_name` runs mid-stream, where a
-    prefix means "not yet" and more is coming; requiring it there let a chunk
-    boundary landing one character into `<br>` announce a tool for prose,
-    since `<` is a prefix of `<parameter=`. Same text, same parser: announced
-    at one chunk size, silent at another.
+    `arrived` is `parse_region`'s `at_end`, inverted, and it is the whole of
+    the difference between the two moments that function is asked about. At
+    end of region a token cut off part-way through is all there will ever be,
+    so a *prefix* counts -- that is what a call truncated by `max_tokens`
+    looks like. Mid-region, where the early name is read, a prefix means "not
+    yet" and more is coming; accepting one there let a chunk boundary landing
+    one character into `<br>` announce a tool for prose, since `<` is a prefix
+    of `<parameter=`. Same text, same parser: announced at one chunk size,
+    silent at another.
     """
     if arrived:
         return any(rest.startswith(tok) for tok in tokens)
@@ -57,45 +62,81 @@ def unique_tool_call_id() -> str:
     return f"call_{uuid.uuid4().hex}"
 
 
-class Region:
-    """The bytes buffered since a tool-call region opened.
+def begin_of_markup(
+    region: str,
+    at: int,
+    openers: tuple[str, ...] = (),
+    fillers: tuple[str, ...] = (),
+) -> int:
+    """Pull `at` back over the wrapper a format opens its calls with.
 
-    A list and a join, not `self.buf += text`. Appending to a *string
-    attribute* is quadratic in CPython: the instance dict holds a reference,
-    so the in-place fast path never applies and every chunk copies the whole
-    buffer. Measured on a 128 KB tool call, streamed four characters at a
-    time: 23 ms of event-loop CPU in `process` alone, growing 17x for an 8x
-    payload while `flush` stayed linear. The same loop over a *local* string
-    is linear, which is why a microbenchmark of `s += x` finds nothing.
+    The mirror of :func:`end_of_markup`, and needed for the same reason: a
+    call's own match starts at `<function=`, and the `<tool_call>` before it is
+    markup too. Without it every real call left its wrapper in the answer.
 
-    `head` is the first `_PEEK_WINDOW` bytes, kept separately so `announce`
-    never needs the region materialised -- it only ever looks that far in,
-    and handing it the whole buffer is how the quadratic scan it already
-    fixed once could come back.
+    It also draws the line an answer that *quotes* a marker before making a
+    real call depends on. A region opens at the first marker in the text, so
+    the sentence between a quotation and the call that follows it is inside
+    the region -- and it stops here, because prose is not one of the literals
+    this walks over.
     """
+    if not openers:
+        return at
+    begin = j = at
+    while j > 0:
+        stripped = region[:j].rstrip()
+        if len(stripped) < j:
+            # Whitespace moves the scan but not the answer, exactly as in
+            # `end_of_markup`: a newline between two markers is markup, a
+            # newline between prose and a marker belongs to the prose.
+            j = len(stripped)
+            continue
+        token = next(
+            (t for t in (*fillers, *openers) if stripped.endswith(t)),
+            None,
+        )
+        if token is None:
+            break
+        j -= len(token)
+        begin = j
+    return begin
 
-    __slots__ = ("_parts", "head")
 
-    def __init__(self) -> None:
-        self._parts: list[str] = []
-        self.head = ""
+def end_of_markup(
+    region: str,
+    at: int,
+    closers: tuple[str, ...] = (),
+    fillers: tuple[str, ...] = (),
+) -> int:
+    """Extend `at` over the wrapper a format closes its calls with.
 
-    def append(self, text: str) -> None:
-        if not text:
-            return
-        self._parts.append(text)
-        if len(self.head) < _PEEK_WINDOW:
-            self.head = (self.head + text)[:_PEEK_WINDOW]
+    A call's own match ends at `</function>`; the `</tool_call>` after it is
+    markup too, and so is the newline between them. Without this the wrapper
+    was either left in the answer or swallowed along with everything after it,
+    depending on which format's ``parse`` you read.
 
-    def take(self) -> str:
-        """Everything buffered, and start again."""
-        out = "".join(self._parts)
-        self._parts.clear()
-        self.head = ""
-        return out
-
-    def __bool__(self) -> bool:
-        return bool(self._parts)
+    Whitespace and `fillers` (MiniMax repeats its namespace token before every
+    tag) advance the *scan* but never the answer: only a closer moves `end`,
+    so the newline a model writes before resuming prose survives.
+    """
+    if not closers:
+        return at
+    end = j = at
+    n = len(region)
+    while j < n:
+        if region[j].isspace():
+            j += 1
+            continue
+        skipped = next((s for s in fillers if region.startswith(s, j)), None)
+        if skipped is not None:
+            j += len(skipped)
+            continue
+        closer = next((c for c in closers if region.startswith(c, j)), None)
+        if closer is None:
+            break
+        j += len(closer)
+        end = j
+    return end
 
 
 @dataclass
@@ -110,49 +151,74 @@ class ToolCall:
         return {"id": self.id, "type": self.type, "function": self.function}
 
 
+@dataclass(frozen=True)
+class RegionParse:
+    """What one format made of a region's bytes.
+
+    ``begins`` and ``consumed`` bracket the format's own markup: everything
+    before is the answer leading up to it, everything after is the answer
+    resuming. Both are handed back to the reader, so a region is accounted for
+    byte by byte and no format has to remember to return either half.
+
+    ``begins`` is the first accepted call's own match; the engine widens it
+    back to the start marker enclosing it. A region opens at the *first*
+    marker in the text, which an answer that quotes one before making a real
+    call puts in the wrong place -- the sentence between the two used to be
+    swallowed with the markup.
+
+    ``calls`` empty means the region was a quotation rather than a call, and
+    the engine releases its bytes unchanged; both offsets are then ignored.
+    """
+
+    calls: tuple[ToolCall, ...] = ()
+    begins: int = 0
+    consumed: int = 0
+
+
+NO_CALLS = RegionParse()
+
+
 class ToolCallParser(ABC):
     """One on-the-wire tool-call format.
 
-    Class side is the stateless non-streaming path (``detect`` + ``parse``);
-    instance side is the stateful streaming path (``process`` + ``flush``).
+    Entirely class-side. A format holds no per-request state -- the engine
+    does -- so there is nothing here for two requests to share or for one
+    region to leak into the next.
     """
 
     NAME: ClassVar[str]
-    # Every literal that opens this format's tool-call region. Declared once,
-    # here, rather than spelled out again in each parser's own logic: a reader
-    # ahead of detection needs them to know how much of its buffer could still
-    # be the start of one, `BufferedMarkerParser` locates the region with them,
-    # and the property tests enumerate them so a newly registered format is
-    # covered the moment it exists rather than when someone writes a case.
+    # Every literal that opens this format's tool-call region, plus every
+    # literal it treats as framing. Declared once, here, rather than spelled
+    # out again in each parser's own logic: the read-ahead needs them to know
+    # how much of its buffer could still be the start of one, and the property
+    # tests enumerate them so a newly registered format is covered the moment
+    # it exists rather than when someone writes a case.
     START_MARKERS: ClassVar[tuple[str, ...]] = ()
-
-    @classmethod
-    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
-        """The tool being called, from a region that has not closed yet.
-
-        ``None`` while the name is not yet legible, and ``None`` by default:
-        a format that does not override this simply announces nothing early,
-        which is what every format did before.
-
-        The point is latency, and it is not small. A region is buffered until
-        it closes, so on a 20 KB file write the client learned *which tool*
-        only after 5030 of 5040 tokens; every one of these locates the name
-        inside the first 30-70 characters. SGLang streams the whole call this
-        way; only the name is taken here, because arguments arriving in
-        fragments cannot be made coherent when the stream is cut short.
-
-        **It must not name a region ``parse`` would read as prose.** A name
-        cannot be retracted, so the two have to agree about what a call looks
-        like -- and four of the five that implement this had them disagree,
-        because each wrote the rule twice: once as a regex's follower set
-        here, once as a truncation test in `parse`. Each format now answers
-        the question in one place and both callers use it.
-
-        ``tools`` for the same reason `parse` takes it: MiniMax names its
-        parameters by the tag itself, so telling `<city>` from `<br>` needs
-        the request's schema and cannot be done from the bytes alone.
-        """
-        return None
+    # Literals that can close a region mid-stream. Declared so the engine can
+    # tell, from the incoming chunk alone, whether it is worth materialising
+    # the buffer to ask `region_end` -- the check runs once per chunk on every
+    # stream, and materialising to answer it is the quadratic this class's
+    # `Region` exists to avoid. Empty means "this format's regions close only
+    # at end of stream", which is what four of the six do.
+    REGION_END_MARKERS: ClassVar[tuple[str, ...]] = ()
+    # The wrapper literals this format writes around its calls -- before the
+    # first and after the last -- and any token it repeats between tags. All
+    # markup; see `begin_of_markup` and `end_of_markup`.
+    CALL_OPENERS: ClassVar[tuple[str, ...]] = ()
+    CALL_CLOSERS: ClassVar[tuple[str, ...]] = ()
+    CALL_FILLERS: ClassVar[tuple[str, ...]] = ()
+    # Can ``parse_region`` recognise a call that has not finished arriving?
+    # The four XML-ish formats can -- that is what their truncated-call tests
+    # are for -- and the two token formats cannot: a Kimi entry is invisible
+    # until its `<|tool_call_end|>` and a K3 call until its `<|close|>call`.
+    #
+    # The engine reads this twice, and both readings need it exact. It is why
+    # a name can be announced from a region still arriving, and it is the
+    # licence to give up on a region that is producing nothing -- which is
+    # what stops an answer *about* tool calls from being withheld to end of
+    # stream. Declaring it True for a format that cannot would deliver a real
+    # call as prose; the property tests hold each format's own corpus to it.
+    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = False
 
     @classmethod
     def opens_region(cls, marker: str) -> bool:
@@ -164,213 +230,25 @@ class ToolCallParser(ABC):
         is that default. Kimi-K3 is where they come apart: three of its five
         are channel framing that wraps *every* answer, tool call or not, and
         treating those as a handover stopped it streaming at all.
+
+        A marker this says no to is framing: the reader drops it and carries
+        on. That is the only place framing is removed, on either delivery
+        path -- Kimi-K3 used to strip its own list a second time inside
+        ``parse``, and the two lists disagreed about four tokens.
         """
         return True
 
-    def __init__(self, tools: list | None = None):
-        self.tools = tools
-        self.buf = ""
-        # 0 = still in plain content, 1 = inside a tool-call region. Kimi adds
-        # 2 = section closed; see KimiParser.
-        self.state = 0
-        self.current_index = 0
-        self.emitted_calls = 0
-        self._scanner_cache: MarkerScanner | None = None
-        # Bytes buffered since a region opened. See `Region` for why this
-        # is not a string attribute the chunks are added to.
-        self.region = Region()
-        # The name already sent for the call being buffered, if any; cleared
-        # when that call's arguments go out. See `announce`.
-        self._announced: str | None = None
-        # Set once no name can still turn up, so the peek stops running
-        # per token over a region that will never yield one.
-        self._peek_exhausted = False
-        # The request's declared names, built once rather than per token.
-        self._declared: frozenset[str] | None = None
-
-    @property
-    def _scanner(self) -> MarkerScanner:
-        """Reads the text before the region; built on first use, per instance.
-
-        On the base rather than on `BufferedMarkerParser`, because Kimi is not
-        one of those and had grown its own copy -- lazy build and all -- with
-        the marker written out a second time instead of read from
-        `START_MARKERS`. A format's markers are declared once; a reader that
-        spells them again is the shape this module removed everywhere else.
-        """
-        if self._scanner_cache is None:
-            self._scanner_cache = MarkerScanner(self.START_MARKERS)
-        return self._scanner_cache
-
-    # -- non-streaming ------------------------------------------------------
     @classmethod
-    @abstractmethod
-    def detect(cls, text: str) -> bool:
-        """Whether a complete model output is in this format."""
+    def markup_begin(cls, region: str, at: int) -> int:
+        """Where this format's markup really starts, given its first call
+        started at ``at``. See :func:`begin_of_markup`."""
+        return begin_of_markup(region, at, cls.CALL_OPENERS, cls.CALL_FILLERS)
 
     @classmethod
-    @abstractmethod
-    def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
-        """Parse a complete output into ``(leading_content, tool_calls)``.
-
-        **With no tool calls, the content must come back byte-for-byte.** This
-        is the one rule that keeps `stream=false` answering what `stream=true`
-        answers: the streaming path releases bytes as they arrive and has
-        nothing to trim them with, so any tidying done only here is a
-        divergence a client sees. A trailing `.strip()` cost a code-block
-        answer its final newline in exactly that way.
-
-        It binds the *no-call* case only. Trimming the content that precedes a
-        real call is a choice each format may keep, and normalising framing a
-        format wraps every answer in (Kimi-K3's channel tokens) is required
-        rather than forbidden -- the streaming path strips those too, so
-        leaving them would be the divergence. The test that enforces this
-        enumerates the registry, so a format added later is bound by it
-        without anyone remembering to add a case.
-        """
-
-    # -- streaming ----------------------------------------------------------
-    @abstractmethod
-    def process(self, text: str) -> list:
-        """Consume one chunk; return ``(event_type, data)`` tuples."""
-
-    @abstractmethod
-    def flush(self) -> list:
-        """Drain whatever is buffered at end of stream."""
-
-    def announce(self, head: str) -> list:
-        """Send the tool's name as soon as the region reveals it, once.
-
-        Only for a name the request actually declared. That check is what
-        makes an early name safe to send: it cannot be taken back, and an
-        answer merely quoting `<tool_call><function=NAME>` opens a region too.
-        A name the client never offered is overwhelmingly likelier to be prose
-        than a call, so it waits for the region to close like everything else.
-
-        SGLang's cursor parsers announce with no such check and will emit a
-        call named after whatever follows the tag.
-
-        `head` is `Region.head`: the first `_PEEK_WINDOW` bytes and no more.
-        Asked of that, and asked at most once more after it fills. The first
-        version ran the format's regex over the whole region on every chunk,
-        which is quadratic in the response and measured 3.0 -> 9.8 -> 36 ->
-        137 ms across 2k/4k/8k/16k tokens -- the shape `marker_scanner` exists
-        to retire, put back one layer up. A name that is not in the first
-        `_PEEK_WINDOW` bytes is not going to appear later either, so a region
-        that reaches that length without one stops being asked. Taking the
-        head rather than slicing a whole region here is what keeps the caller
-        from having to materialise one.
-        """
-        if self._announced is not None or self._peek_exhausted or not self.tools:
-            return []
-        name = self.peek_name(head, self.tools)
-        if name is None:
-            self._peek_exhausted = len(head) >= _PEEK_WINDOW
-            return []
-        if self._declared is None:
-            self._declared = frozenset(build_param_types(self.tools))
-        if name not in self._declared:
-            self._peek_exhausted = True
-            return []
-        self._announced = name
-        return [
-            (
-                "tool_call_start",
-                {
-                    "index": self.current_index,
-                    "id": unique_tool_call_id(),
-                    "type": "function",
-                    "function": {"name": name, "arguments": ""},
-                },
-            )
-        ]
-
-    def _start_event(self, index: int, call_id: str, name: str) -> list:
-        """The `tool_call_start` for a call, unless its name already went out.
-
-        Both places that emit a call go through here: `_emit_call` for the
-        formats that parse a whole region, and Kimi's own drain loop, which
-        builds the event inline because its id and index come off the wire.
-        Two copies of "have we announced this already" is how the announcement
-        was sent twice for one call.
-
-        A mismatch means `peek_name` and `parse` read the same bytes and
-        disagreed, which is a bug in that format. This used to raise. It
-        cannot: the caller is `flush`, on a live SSE stream that has already
-        sent its 200, so the exception reached the client as a connection cut
-        mid-frame with no `[DONE]` and, on the `n>1` path, took the other
-        choices with it. Two registered parsers were then found to reach it on
-        ordinary output.
-
-        So it is logged and recovered from. The announced name is already on
-        the wire and cannot be retracted, but it can be left with no arguments
-        -- the shape every other unfulfilled announcement takes, and one that
-        `completes_a_tool_call` and `finish_reason` both read as "not a call".
-        The real call goes out at the next index, whole.
-        """
-        if self._announced is not None and self._announced != name:
-            logger.warning(
-                "%s announced %r and then parsed %r from the same region; "
-                "sending %r as a new call and leaving %r without arguments",
-                type(self).__name__,
-                self._announced,
-                name,
-                name,
-                self._announced,
-            )
-            self._announced = None
-            # Past the dangling announcement, so the real call does not land
-            # on an index the client has already bound to the wrong name.
-            # `_emit_call` reads `current_index` again for the arguments, so
-            # the two stay together.
-            self.current_index += 1
-            index = self.current_index
-        elif self._announced is not None:
-            self._announced = None  # binds to the first call only
-            return []
-        return [
-            (
-                "tool_call_start",
-                {
-                    "index": index,
-                    "id": call_id,
-                    "type": "function",
-                    "function": {"name": name, "arguments": ""},
-                },
-            )
-        ]
-
-    def _emit_call(self, tc: ToolCall) -> list:
-        """Render one parsed ToolCall as start+args stream events.
-
-        The name is skipped when it has already gone out, and its id is
-        reused so the client sees one call rather than two. `_start_event`
-        also owns what to do when the announced name was the wrong one.
-        """
-        events = self._start_event(self.current_index, tc.id, tc.function["name"])
-        events.append(
-            (
-                "tool_call_args",
-                {
-                    "index": self.current_index,
-                    "function": {"arguments": tc.function["arguments"]},
-                },
-            )
-        )
-        self.current_index += 1
-        self.emitted_calls += 1
-        return events
-
-
-class BufferedMarkerParser(ToolCallParser):
-    """Formats that buffer from a start marker and parse the block at flush.
-
-    The block is only parsed once complete because partial XML streams badly
-    (a half-written ``<parameter=`` would emit garbage). Content before the
-    first marker still streams normally.
-
-    Subclasses declare ``START_MARKERS`` and implement ``parse``.
-    """
+    def markup_end(cls, region: str, at: int) -> int:
+        """Where this format's markup really ends, given its last call ended
+        at ``at``. See :func:`end_of_markup`."""
+        return end_of_markup(region, at, cls.CALL_CLOSERS, cls.CALL_FILLERS)
 
     @classmethod
     def find_start(cls, text: str) -> int:
@@ -380,64 +258,58 @@ class BufferedMarkerParser(ToolCallParser):
 
     @classmethod
     def detect(cls, text: str) -> bool:
+        """Whether a rendered chat template teaches this format."""
         return cls.find_start(text) != -1
 
-    def process(self, text: str) -> list:
-        results: list = []
-        if self.state == 0:
-            # Held back: only a suffix that could still grow into a start
-            # marker. This used to hold from the *last* holdback character
-            # anywhere in the buffer, which had no branch for that character
-            # landing at index 0 -- and after one emission the buffer always
-            # began with one, so the parser stopped emitting for the rest of
-            # the stream and delivered the remainder in a single frame at EOS.
-            # `HOLDBACK_CHARS` went with it: it was a hand-kept copy of the
-            # first characters of `START_MARKERS`, which the scanner derives.
-            scan = self._scanner.feed(text)
-            if scan.released:
-                results.append(("content", scan.released))
-            if scan.hit is None:
-                return results
-            self.region.append(scan.hit)
-            self.region.append(scan.rest)
-            self.state = 1
-            # Also here: a coarse chunk can carry the opener and the name
-            # together, and waiting for the next one would give that back.
-            return results + self.announce(self.region.head)
-        self.region.append(text)
-        # The name is legible long before the region closes, and the
-        # region is what the wait is for: on a 20 KB file write the
-        # client learned the tool only after 5030 of 5040 tokens.
-        return results + self.announce(self.region.head)
+    @classmethod
+    def region_end(cls, region: str) -> int:
+        """How many bytes of ``region`` form a closed unit, or 0 for "not yet".
 
-    def flush(self) -> list:
-        results: list = []
-        if self.state == 0:
-            rest = self._scanner.flush()
-            if rest:
-                results.append(("content", rest))
-            return results
-        # state 1: parse the complete (or trailing) tool-call block.
-        region = self.region.take()
-        _content, tool_calls = self.parse(region, self.tools)
-        if not tool_calls:
-            # A start marker is not a promise. An answer explaining that a
-            # model "writes <tool_call> to call something" opens the region
-            # and never closes it, and this used to drop everything from the
-            # marker on -- no event, no error, `finish_reason` still `stop`.
-            # Fifty characters of eighty-two, on the shapes measured.
-            #
-            # Released verbatim rather than as `parse`'s content, which strips.
-            #
-            # A name may already have gone out, and there is no retracting it.
-            # What there is: no arguments follow, so nothing downstream counts
-            # this as a usable call and `finish_reason` stays `stop`. The text
-            # is still delivered -- the promise costs a dangling name, not the
-            # answer.
-            self._announced = None
-            return [("content", region)] if region else []
-        for tc in tool_calls:
-            results.extend(self._emit_call(tc))
-        if self.emitted_calls > 0:
-            results.append(("tool_call_end", None))
-        return results
+        Asked only after one of ``REGION_END_MARKERS`` has arrived. A format
+        that answers lets the engine emit its calls and go back to reading the
+        answer without waiting for end of stream; one that does not is
+        buffered to EOS, which is correct but silent for as long as the region
+        runs.
+
+        Answer only on a literal that cannot appear inside an argument value.
+        Kimi's section end is a special token and qualifies; the XML formats'
+        `</tool_call>` does not, because a model writing *about* tool calls
+        puts one inside a parameter.
+        """
+        return 0
+
+    @classmethod
+    @abstractmethod
+    def parse_region(
+        cls, region: str, tools: list | None, *, at_end: bool
+    ) -> RegionParse:
+        """What this region's bytes mean.
+
+        It sees only the region -- never the content before it, which the
+        engine has already released, and never the answer after it, which it
+        reports the end of rather than consuming.
+
+        Returning no calls says the region was a quotation: an answer
+        explaining that a model "writes ``<tool_call>`` to call something"
+        opens one and never closes it. The engine then releases the bytes
+        unchanged, so a start marker is not a promise -- a rule that used to
+        be written out in each format, and was missing from two of them.
+
+        ``at_end`` is whether more bytes can still arrive for this region, and
+        it is the *only* difference between the two questions this used to be
+        asked twice. With ``at_end`` a token cut off part-way through is all
+        there will ever be, so a prefix of one counts -- that is what a call
+        truncated by ``max_tokens`` looks like. Without it a prefix means "not
+        yet", and accepting one let a chunk boundary landing one character
+        into ``<br>`` name a tool for prose.
+
+        The engine calls this with ``at_end=False`` to find the name to
+        announce early. That is what makes the early name and the parsed call
+        agree by construction: they are the same enumeration of the same
+        function over a prefix and then the whole. There used to be a separate
+        ``peek_name`` per format, and its disagreements with this were
+        the single most repeated defect in this module -- most recently a
+        DeepSeek-V4 response whose peek skipped a self-closing
+        ``<invoke name="x"/>`` that the parse returned first, putting three
+        tool calls on the wire where the model had written two.
+        """

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -27,10 +27,22 @@ chunk, so the two modes cannot disagree: there is nothing left for them to
 disagree with.
 """
 
+import re
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, ClassVar
+
+# A tool name is an identifier, which is what the model was given.
+#
+# `\w` and not `[A-Za-z_]`: OpenAI's own grammar is `^[a-zA-Z0-9_-]{1,64}$`, so
+# a leading digit is legal (`7z_extract`), and `\w` is Unicode-aware, so a CJK
+# name is too -- which matters rather a lot on a Chinese model family.
+# Rejecting one is silent. `.` and `-` in the tail because MCP servers
+# namespace theirs `server.tool`; prose is still rejected because a space
+# cannot appear anywhere. `\Z` and not `$`, which also matches before a
+# trailing newline and would admit a name with one.
+_TOOL_NAME_RE = re.compile(r"^\w[\w.\-]*\Z")
 
 
 def continues_a_call(rest: str, tokens: tuple[str, ...], *, arrived: bool) -> bool:
@@ -72,6 +84,30 @@ def declared_tools_allow(name: str, param_types: dict) -> bool:
     that is the evidence which does not come from the request.
     """
     return not param_types or name in param_types
+
+
+def usable_tool_name(name: str | None) -> bool:
+    """Is this something a client could dispatch?
+
+    One predicate, because six formats answered it six ways and three of them
+    did not ask at all. `<invoke name="">` and `<invoke name="   ">` -- both of
+    which `name="([^"]*)"` matches -- reached the client as a call whose name
+    was the empty string: not dispatchable, and matching nothing the request
+    declared. On `/v1/messages` it becomes a `tool_use` block with an empty
+    `name`, which the Anthropic SDK surfaces as a tool the caller never
+    registered.
+
+    The three spelled their non-answers differently, which is the tell that
+    the axis and not any one format is the thing to fix: DSML and K3 asked
+    nothing, and MiniMax asked `if not name` *before* `name.strip()`, so a
+    name of pure whitespace passed the guard and then became empty.
+
+    Separate from `declared_tools_allow`, which asks whether the *request*
+    knows this name. This asks whether it is a name at all, and holds for a
+    request that declared no tools -- the case where that one deliberately
+    refutes nothing.
+    """
+    return bool(name) and _TOOL_NAME_RE.match(name) is not None
 
 
 def unique_tool_call_id() -> str:

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -99,20 +99,31 @@ def begin_of_markup(
     the sentence between a quotation and the call that follows it is inside
     the region -- and it stops here, because prose is not one of the literals
     this walks over.
+
+    Offsets, not slices. `region[:j].rstrip()` copies everything to the left
+    of the scan to read its last few bytes, once per step, so a region holding
+    several calls after a large argument paid O(calls x region) -- measured
+    7.3x on 128 KB with eight calls, and growing with the payload where this
+    is flat. `end_of_markup` walks the other direction with `startswith(s, j)`
+    and never copied; the same fix is already written out on
+    `_region_owes_a_closer`, one layer up, and was not carried into the
+    function that shape came from.
     """
     if not openers:
         return at
     begin = j = at
     while j > 0:
-        stripped = region[:j].rstrip()
-        if len(stripped) < j:
+        end = j
+        while end > 0 and region[end - 1].isspace():
+            end -= 1
+        if end < j:
             # Whitespace moves the scan but not the answer, exactly as in
             # `end_of_markup`: a newline between two markers is markup, a
             # newline between prose and a marker belongs to the prose.
-            j = len(stripped)
+            j = end
             continue
         token = next(
-            (t for t in (*fillers, *openers) if stripped.endswith(t)),
+            (t for t in (*fillers, *openers) if region.endswith(t, 0, j)),
             None,
         )
         if token is None:

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -19,6 +19,12 @@ from typing import Any, ClassVar
 from ..marker_scanner import MarkerScanner
 from .schema import build_param_types
 
+# How far into a region a name may be before the peek gives up. Every
+# format on this box puts it in the first 30-70 characters; the margin is
+# for a long name or leading whitespace, and the bound is what keeps the
+# peek from re-scanning a growing buffer once per token.
+_PEEK_WINDOW = 256
+
 
 def unique_tool_call_id() -> str:
     # OpenAI tool_call ids must be unique across the whole conversation, not just
@@ -98,6 +104,11 @@ class ToolCallParser(ABC):
         # The name already sent for the call being buffered, if any; cleared
         # when that call's arguments go out. See `announce`.
         self._announced: str | None = None
+        # Set once no name can still turn up, so the peek stops running
+        # per token over a region that will never yield one.
+        self._peek_exhausted = False
+        # The request's declared names, built once rather than per token.
+        self._declared: frozenset[str] | None = None
 
     @property
     def _scanner(self) -> MarkerScanner:
@@ -160,11 +171,25 @@ class ToolCallParser(ABC):
 
         SGLang's cursor parsers announce with no such check and will emit a
         call named after whatever follows the tag.
+
+        Asked of a bounded prefix and asked at most once more after that. The
+        first version ran the format's regex over the whole region on every
+        chunk, which is quadratic in the response and measured 3.0 -> 9.8 ->
+        36 -> 137 ms across 2k/4k/8k/16k tokens -- the shape `marker_scanner`
+        exists to retire, put back one layer up. A name that is not in the
+        first `_PEEK_WINDOW` bytes is not going to appear later either, so a
+        region that reaches that length without one stops being asked.
         """
-        if self._announced is not None or not self.tools:
+        if self._announced is not None or self._peek_exhausted or not self.tools:
             return []
-        name = self.peek_name(region)
-        if name is None or name not in build_param_types(self.tools):
+        name = self.peek_name(region[:_PEEK_WINDOW])
+        if name is None:
+            self._peek_exhausted = len(region) >= _PEEK_WINDOW
+            return []
+        if self._declared is None:
+            self._declared = frozenset(build_param_types(self.tools))
+        if name not in self._declared:
+            self._peek_exhausted = True
             return []
         self._announced = name
         return [

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -16,6 +16,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
+from ..marker_scanner import MarkerScanner
+
 
 def unique_tool_call_id() -> str:
     # OpenAI tool_call ids must be unique across the whole conversation, not just
@@ -45,13 +47,13 @@ class ToolCallParser(ABC):
     """
 
     NAME: ClassVar[str]
-    # Every literal this format opens with, declared rather than spelled out
-    # again inside `sniff_stream`'s chain and each parser's own logic. A
-    # streaming reader has to know them to decide how much of its buffer could
-    # still be the start of one, and the property tests enumerate them so a
-    # newly registered format is covered the moment it exists rather than when
-    # someone remembers to write a case for it.
-    MARKERS: ClassVar[tuple[str, ...]] = ()
+    # Every literal that opens this format's tool-call region. Declared once,
+    # here, rather than spelled out again in each parser's own logic: a reader
+    # ahead of detection needs them to know how much of its buffer could still
+    # be the start of one, `BufferedMarkerParser` locates the region with them,
+    # and the property tests enumerate them so a newly registered format is
+    # covered the moment it exists rather than when someone writes a case.
+    START_MARKERS: ClassVar[tuple[str, ...]] = ()
 
     def __init__(self, tools: list | None = None):
         self.tools = tools
@@ -61,6 +63,10 @@ class ToolCallParser(ABC):
         self.state = 0
         self.current_index = 0
         self.emitted_calls = 0
+        # Only `BufferedMarkerParser` reads it, but every parser is built
+        # through here, so a subclass that forgot to initialise it would fail
+        # on its first chunk rather than at construction.
+        self._scanner_cache = None
 
     # -- non-streaming ------------------------------------------------------
     @classmethod
@@ -117,13 +123,6 @@ class BufferedMarkerParser(ToolCallParser):
     Subclasses declare ``START_MARKERS`` and implement ``parse``.
     """
 
-    # Any of these opening the tool-call region; the earliest one wins.
-    START_MARKERS: ClassVar[tuple[str, ...]] = ()
-    # While no marker has been seen, a trailing run starting with one of these
-    # may be the first bytes of a marker, so it is held back rather than emitted
-    # as content (it would otherwise leak '<' into the user-visible text).
-    HOLDBACK_CHARS: ClassVar[tuple[str, ...]] = ("<",)
-
     @classmethod
     def find_start(cls, text: str) -> int:
         """Index of the earliest start marker, or -1."""
@@ -134,35 +133,42 @@ class BufferedMarkerParser(ToolCallParser):
     def detect(cls, text: str) -> bool:
         return cls.find_start(text) != -1
 
+    @property
+    def _scanner(self) -> MarkerScanner:
+        """Reads the pre-region text; built on first use, per instance."""
+        if self._scanner_cache is None:
+            self._scanner_cache = MarkerScanner(self.START_MARKERS)
+        return self._scanner_cache
+
     def process(self, text: str) -> list:
         results: list = []
-        self.buf += text
         if self.state == 0:
-            m = self.find_start(self.buf)
-            if m != -1:
-                before = self.buf[:m]
-                if before:
-                    results.append(("content", before))
-                self.buf = self.buf[m:]
-                self.state = 1
-            else:
-                # Emit content but hold back a possible partial marker tail.
-                cut = max(self.buf.rfind(c) for c in self.HOLDBACK_CHARS)
-                if cut == -1:
-                    if self.buf:
-                        results.append(("content", self.buf))
-                        self.buf = ""
-                elif cut > 0:
-                    results.append(("content", self.buf[:cut]))
-                    self.buf = self.buf[cut:]
+            # Held back: only a suffix that could still grow into a start
+            # marker. This used to hold from the *last* holdback character
+            # anywhere in the buffer, which had no branch for that character
+            # landing at index 0 -- and after one emission the buffer always
+            # began with one, so the parser stopped emitting for the rest of
+            # the stream and delivered the remainder in a single frame at EOS.
+            # `HOLDBACK_CHARS` went with it: it was a hand-kept copy of the
+            # first characters of `START_MARKERS`, which the scanner derives.
+            scan = self._scanner.feed(text)
+            if scan.released:
+                results.append(("content", scan.released))
+            if scan.hit is None:
+                return results
+            self.buf = scan.hit + scan.rest
+            self.state = 1
+            return results
+        self.buf += text
         return results
 
     def flush(self) -> list:
         results: list = []
         if self.state == 0:
-            if self.buf:
-                results.append(("content", self.buf))
-                self.buf = ""
+            rest = self._scanner.flush() + self.buf
+            self.buf = ""
+            if rest:
+                results.append(("content", rest))
             return results
         # state 1: parse the complete (or trailing) tool-call block.
         _content, tool_calls = self.parse(self.buf, self.tools)

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -29,6 +29,26 @@ logger = logging.getLogger("atom")
 _PEEK_WINDOW = 256
 
 
+def continues_a_call(rest: str, tokens: tuple[str, ...], *, arrived: bool) -> bool:
+    """Is what follows a call's name this format's own next token?
+
+    One implementation, because four formats had a copy and the copies were
+    the point of failure: each format supplies the tokens, this decides.
+
+    `arrived` is the difference between the two callers and the whole of it.
+    `parse` runs at end of stream, where a token cut off part-way through is
+    all there will ever be, so a *prefix* counts -- that is what a call
+    truncated by `max_tokens` looks like. `peek_name` runs mid-stream, where a
+    prefix means "not yet" and more is coming; requiring it there let a chunk
+    boundary landing one character into `<br>` announce a tool for prose,
+    since `<` is a prefix of `<parameter=`. Same text, same parser: announced
+    at one chunk size, silent at another.
+    """
+    if arrived:
+        return any(rest.startswith(tok) for tok in tokens)
+    return any(tok.startswith(rest[: len(tok)]) for tok in tokens)
+
+
 def unique_tool_call_id() -> str:
     # OpenAI tool_call ids must be unique across the whole conversation, not just
     # within one response. A per-response index (call_0, call_1, ...) collides

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -294,6 +294,13 @@ class ToolCallParser(ABC):
     CALL_OPENERS: ClassVar[tuple[str, ...]] = ()
     CALL_CLOSERS: ClassVar[tuple[str, ...]] = ()
     CALL_FILLERS: ClassVar[tuple[str, ...]] = ()
+    # What closes a *call*, where `CALL_CLOSERS` closes the wrapper around
+    # one. Telling them apart is the difference between prose and a dispatch:
+    # `<tool_call><function=NAME></tool_call>` has the wrapper closed and the
+    # call still open, so it is a model describing the syntax. Declared so
+    # the suite can build that shape for every format rather than for the one
+    # somebody wrote out. Empty where a call *is* its wrapper.
+    CALL_SELF_CLOSERS: ClassVar[tuple[str, ...]] = ()
     # The literals that *identify* this format, where that is narrower than
     # "what must not be split". Empty means the two coincide, as they do for
     # five of the six.

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -11,6 +11,7 @@ marker, parse the whole block at flush — so that strategy lives once in
 emits tool calls incrementally and implements ``process``/``flush`` itself.
 """
 
+import logging
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -18,6 +19,8 @@ from typing import Any, ClassVar
 
 from ..marker_scanner import MarkerScanner
 from .schema import build_param_types
+
+logger = logging.getLogger("atom")
 
 # How far into a region a name may be before the peek gives up. Every
 # format on this box puts it in the first 30-70 characters; the margin is
@@ -32,6 +35,47 @@ def unique_tool_call_id() -> str:
     # across turns -> clients (e.g. qwen-code) dedupe by id and silently ignore
     # every repeat, causing an infinite tool-call retry loop. Use a random id.
     return f"call_{uuid.uuid4().hex}"
+
+
+class Region:
+    """The bytes buffered since a tool-call region opened.
+
+    A list and a join, not `self.buf += text`. Appending to a *string
+    attribute* is quadratic in CPython: the instance dict holds a reference,
+    so the in-place fast path never applies and every chunk copies the whole
+    buffer. Measured on a 128 KB tool call, streamed four characters at a
+    time: 23 ms of event-loop CPU in `process` alone, growing 17x for an 8x
+    payload while `flush` stayed linear. The same loop over a *local* string
+    is linear, which is why a microbenchmark of `s += x` finds nothing.
+
+    `head` is the first `_PEEK_WINDOW` bytes, kept separately so `announce`
+    never needs the region materialised -- it only ever looks that far in,
+    and handing it the whole buffer is how the quadratic scan it already
+    fixed once could come back.
+    """
+
+    __slots__ = ("_parts", "head")
+
+    def __init__(self) -> None:
+        self._parts: list[str] = []
+        self.head = ""
+
+    def append(self, text: str) -> None:
+        if not text:
+            return
+        self._parts.append(text)
+        if len(self.head) < _PEEK_WINDOW:
+            self.head = (self.head + text)[:_PEEK_WINDOW]
+
+    def take(self) -> str:
+        """Everything buffered, and start again."""
+        out = "".join(self._parts)
+        self._parts.clear()
+        self.head = ""
+        return out
+
+    def __bool__(self) -> bool:
+        return bool(self._parts)
 
 
 @dataclass
@@ -63,7 +107,7 @@ class ToolCallParser(ABC):
     START_MARKERS: ClassVar[tuple[str, ...]] = ()
 
     @classmethod
-    def peek_name(cls, region: str) -> str | None:
+    def peek_name(cls, region: str, tools: list | None = None) -> str | None:
         """The tool being called, from a region that has not closed yet.
 
         ``None`` while the name is not yet legible, and ``None`` by default:
@@ -76,6 +120,17 @@ class ToolCallParser(ABC):
         inside the first 30-70 characters. SGLang streams the whole call this
         way; only the name is taken here, because arguments arriving in
         fragments cannot be made coherent when the stream is cut short.
+
+        **It must not name a region ``parse`` would read as prose.** A name
+        cannot be retracted, so the two have to agree about what a call looks
+        like -- and four of the five that implement this had them disagree,
+        because each wrote the rule twice: once as a regex's follower set
+        here, once as a truncation test in `parse`. Each format now answers
+        the question in one place and both callers use it.
+
+        ``tools`` for the same reason `parse` takes it: MiniMax names its
+        parameters by the tag itself, so telling `<city>` from `<br>` needs
+        the request's schema and cannot be done from the bytes alone.
         """
         return None
 
@@ -101,6 +156,9 @@ class ToolCallParser(ABC):
         self.current_index = 0
         self.emitted_calls = 0
         self._scanner_cache: MarkerScanner | None = None
+        # Bytes buffered since a region opened. See `Region` for why this
+        # is not a string attribute the chunks are added to.
+        self.region = Region()
         # The name already sent for the call being buffered, if any; cleared
         # when that call's arguments go out. See `announce`.
         self._announced: str | None = None
@@ -160,7 +218,7 @@ class ToolCallParser(ABC):
     def flush(self) -> list:
         """Drain whatever is buffered at end of stream."""
 
-    def announce(self, region: str) -> list:
+    def announce(self, head: str) -> list:
         """Send the tool's name as soon as the region reveals it, once.
 
         Only for a name the request actually declared. That check is what
@@ -172,19 +230,22 @@ class ToolCallParser(ABC):
         SGLang's cursor parsers announce with no such check and will emit a
         call named after whatever follows the tag.
 
-        Asked of a bounded prefix and asked at most once more after that. The
-        first version ran the format's regex over the whole region on every
-        chunk, which is quadratic in the response and measured 3.0 -> 9.8 ->
-        36 -> 137 ms across 2k/4k/8k/16k tokens -- the shape `marker_scanner`
-        exists to retire, put back one layer up. A name that is not in the
-        first `_PEEK_WINDOW` bytes is not going to appear later either, so a
-        region that reaches that length without one stops being asked.
+        `head` is `Region.head`: the first `_PEEK_WINDOW` bytes and no more.
+        Asked of that, and asked at most once more after it fills. The first
+        version ran the format's regex over the whole region on every chunk,
+        which is quadratic in the response and measured 3.0 -> 9.8 -> 36 ->
+        137 ms across 2k/4k/8k/16k tokens -- the shape `marker_scanner` exists
+        to retire, put back one layer up. A name that is not in the first
+        `_PEEK_WINDOW` bytes is not going to appear later either, so a region
+        that reaches that length without one stops being asked. Taking the
+        head rather than slicing a whole region here is what keeps the caller
+        from having to materialise one.
         """
         if self._announced is not None or self._peek_exhausted or not self.tools:
             return []
-        name = self.peek_name(region[:_PEEK_WINDOW])
+        name = self.peek_name(head, self.tools)
         if name is None:
-            self._peek_exhausted = len(region) >= _PEEK_WINDOW
+            self._peek_exhausted = len(head) >= _PEEK_WINDOW
             return []
         if self._declared is None:
             self._declared = frozenset(build_param_types(self.tools))
@@ -213,38 +274,58 @@ class ToolCallParser(ABC):
         Two copies of "have we announced this already" is how the announcement
         was sent twice for one call.
 
-        A mismatch is raised, not smoothed over: `peek_name` and the parse
-        disagreeing about the same bytes is a bug in that format, and the name
-        is already on the wire where it cannot be corrected.
+        A mismatch means `peek_name` and `parse` read the same bytes and
+        disagreed, which is a bug in that format. This used to raise. It
+        cannot: the caller is `flush`, on a live SSE stream that has already
+        sent its 200, so the exception reached the client as a connection cut
+        mid-frame with no `[DONE]` and, on the `n>1` path, took the other
+        choices with it. Two registered parsers were then found to reach it on
+        ordinary output.
+
+        So it is logged and recovered from. The announced name is already on
+        the wire and cannot be retracted, but it can be left with no arguments
+        -- the shape every other unfulfilled announcement takes, and one that
+        `completes_a_tool_call` and `finish_reason` both read as "not a call".
+        The real call goes out at the next index, whole.
         """
-        if self._announced is None:
-            return [
-                (
-                    "tool_call_start",
-                    {
-                        "index": index,
-                        "id": call_id,
-                        "type": "function",
-                        "function": {"name": name, "arguments": ""},
-                    },
-                )
-            ]
-        if self._announced != name:
-            raise AssertionError(
-                f"{type(self).__name__} announced {self._announced!r} and then "
-                f"parsed {name!r} from the same region"
+        if self._announced is not None and self._announced != name:
+            logger.warning(
+                "%s announced %r and then parsed %r from the same region; "
+                "sending %r as a new call and leaving %r without arguments",
+                type(self).__name__,
+                self._announced,
+                name,
+                name,
+                self._announced,
             )
-        self._announced = None  # binds to the first call only
-        return []
+            self._announced = None
+            # Past the dangling announcement, so the real call does not land
+            # on an index the client has already bound to the wrong name.
+            # `_emit_call` reads `current_index` again for the arguments, so
+            # the two stay together.
+            self.current_index += 1
+            index = self.current_index
+        elif self._announced is not None:
+            self._announced = None  # binds to the first call only
+            return []
+        return [
+            (
+                "tool_call_start",
+                {
+                    "index": index,
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": ""},
+                },
+            )
+        ]
 
     def _emit_call(self, tc: ToolCall) -> list:
         """Render one parsed ToolCall as start+args stream events.
 
         The name is skipped when it has already gone out, and its id is
-        reused so the client sees one call rather than two. A mismatch means
-        `peek_name` and `parse` disagree about the same bytes, which is a bug
-        in that format and is raised rather than papered over -- the name is
-        already on the wire and cannot be corrected.
+        reused so the client sees one call rather than two. `_start_event`
+        also owns what to do when the announced name was the wrong one.
         """
         events = self._start_event(self.current_index, tc.id, tc.function["name"])
         events.append(
@@ -297,27 +378,27 @@ class BufferedMarkerParser(ToolCallParser):
                 results.append(("content", scan.released))
             if scan.hit is None:
                 return results
-            self.buf = scan.hit + scan.rest
+            self.region.append(scan.hit)
+            self.region.append(scan.rest)
             self.state = 1
             # Also here: a coarse chunk can carry the opener and the name
             # together, and waiting for the next one would give that back.
-            return results + self.announce(self.buf)
-        self.buf += text
+            return results + self.announce(self.region.head)
+        self.region.append(text)
         # The name is legible long before the region closes, and the
         # region is what the wait is for: on a 20 KB file write the
         # client learned the tool only after 5030 of 5040 tokens.
-        return results + self.announce(self.buf)
+        return results + self.announce(self.region.head)
 
     def flush(self) -> list:
         results: list = []
         if self.state == 0:
-            rest = self._scanner.flush() + self.buf
-            self.buf = ""
+            rest = self._scanner.flush()
             if rest:
                 results.append(("content", rest))
             return results
         # state 1: parse the complete (or trailing) tool-call block.
-        region, self.buf = self.buf, ""
+        region = self.region.take()
         _content, tool_calls = self.parse(region, self.tools)
         if not tool_calls:
             # A start marker is not a promise. An answer explaining that a

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -63,10 +63,21 @@ class ToolCallParser(ABC):
         self.state = 0
         self.current_index = 0
         self.emitted_calls = 0
-        # Only `BufferedMarkerParser` reads it, but every parser is built
-        # through here, so a subclass that forgot to initialise it would fail
-        # on its first chunk rather than at construction.
-        self._scanner_cache = None
+        self._scanner_cache: MarkerScanner | None = None
+
+    @property
+    def _scanner(self) -> MarkerScanner:
+        """Reads the text before the region; built on first use, per instance.
+
+        On the base rather than on `BufferedMarkerParser`, because Kimi is not
+        one of those and had grown its own copy -- lazy build and all -- with
+        the marker written out a second time instead of read from
+        `START_MARKERS`. A format's markers are declared once; a reader that
+        spells them again is the shape this module removed everywhere else.
+        """
+        if self._scanner_cache is None:
+            self._scanner_cache = MarkerScanner(self.START_MARKERS)
+        return self._scanner_cache
 
     # -- non-streaming ------------------------------------------------------
     @classmethod
@@ -148,13 +159,6 @@ class BufferedMarkerParser(ToolCallParser):
     @classmethod
     def detect(cls, text: str) -> bool:
         return cls.find_start(text) != -1
-
-    @property
-    def _scanner(self) -> MarkerScanner:
-        """Reads the pre-region text; built on first use, per instance."""
-        if self._scanner_cache is None:
-            self._scanner_cache = MarkerScanner(self.START_MARKERS)
-        return self._scanner_cache
 
     def process(self, text: str) -> list:
         results: list = []

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -77,7 +77,23 @@ class ToolCallParser(ABC):
     @classmethod
     @abstractmethod
     def parse(cls, text: str, tools: list | None) -> tuple[str, list[ToolCall]]:
-        """Parse a complete output into ``(leading_content, tool_calls)``."""
+        """Parse a complete output into ``(leading_content, tool_calls)``.
+
+        **With no tool calls, the content must come back byte-for-byte.** This
+        is the one rule that keeps `stream=false` answering what `stream=true`
+        answers: the streaming path releases bytes as they arrive and has
+        nothing to trim them with, so any tidying done only here is a
+        divergence a client sees. A trailing `.strip()` cost a code-block
+        answer its final newline in exactly that way.
+
+        It binds the *no-call* case only. Trimming the content that precedes a
+        real call is a choice each format may keep, and normalising framing a
+        format wraps every answer in (Kimi-K3's channel tokens) is required
+        rather than forbidden -- the streaming path strips those too, so
+        leaving them would be the divergence. The test that enforces this
+        enumerates the registry, so a format added later is bound by it
+        without anyone remembering to add a case.
+        """
 
     # -- streaming ----------------------------------------------------------
     @abstractmethod

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -207,18 +207,6 @@ class ToolCallParser(ABC):
     CALL_OPENERS: ClassVar[tuple[str, ...]] = ()
     CALL_CLOSERS: ClassVar[tuple[str, ...]] = ()
     CALL_FILLERS: ClassVar[tuple[str, ...]] = ()
-    # Can ``parse_region`` recognise a call that has not finished arriving?
-    # The four XML-ish formats can -- that is what their truncated-call tests
-    # are for -- and the two token formats cannot: a Kimi entry is invisible
-    # until its `<|tool_call_end|>` and a K3 call until its `<|close|>call`.
-    #
-    # The engine reads this twice, and both readings need it exact. It is why
-    # a name can be announced from a region still arriving, and it is the
-    # licence to give up on a region that is producing nothing -- which is
-    # what stops an answer *about* tool calls from being withheld to end of
-    # stream. Declaring it True for a format that cannot would deliver a real
-    # call as prose; the property tests hold each format's own corpus to it.
-    RECOGNISES_A_CALL_IN_PROGRESS: ClassVar[bool] = False
 
     @classmethod
     def opens_region(cls, marker: str) -> bool:

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -171,8 +171,17 @@ class BufferedMarkerParser(ToolCallParser):
                 results.append(("content", rest))
             return results
         # state 1: parse the complete (or trailing) tool-call block.
-        _content, tool_calls = self.parse(self.buf, self.tools)
-        self.buf = ""
+        region, self.buf = self.buf, ""
+        _content, tool_calls = self.parse(region, self.tools)
+        if not tool_calls:
+            # A start marker is not a promise. An answer explaining that a
+            # model "writes <tool_call> to call something" opens the region
+            # and never closes it, and this used to drop everything from the
+            # marker on -- no event, no error, `finish_reason` still `stop`.
+            # Fifty characters of eighty-two, on the shapes measured.
+            #
+            # Released verbatim rather than as `parse`'s content, which strips.
+            return [("content", region)] if region else []
         for tc in tool_calls:
             results.extend(self._emit_call(tc))
         if self.emitted_calls > 0:

--- a/atom/entrypoints/openai/tool_parser/tool_parser.py
+++ b/atom/entrypoints/openai/tool_parser/tool_parser.py
@@ -227,6 +227,18 @@ class ToolCallParser(ABC):
     CALL_OPENERS: ClassVar[tuple[str, ...]] = ()
     CALL_CLOSERS: ClassVar[tuple[str, ...]] = ()
     CALL_FILLERS: ClassVar[tuple[str, ...]] = ()
+    # The literals that *identify* this format, where that is narrower than
+    # "what must not be split". Empty means the two coincide, as they do for
+    # five of the six.
+    #
+    # They came apart because DSML matches its `｜DSML｜` marker optionally --
+    # the V4-Flash malform drops it -- so `<invoke name=` is a start marker,
+    # and that is also how MiniMax opens a call. DSML claimed MiniMax's
+    # templates and only `_DETECT_ORDER` kept it from winning them.
+    #
+    # Leniency about what to *parse* stays: once identified, a format should
+    # read the malforms its own model emits. Only the claim must be single.
+    DETECT_MARKERS: ClassVar[tuple[str, ...]] = ()
 
     @classmethod
     def opens_region(cls, marker: str) -> bool:
@@ -266,8 +278,12 @@ class ToolCallParser(ABC):
 
     @classmethod
     def detect(cls, text: str) -> bool:
-        """Whether a rendered chat template teaches this format."""
-        return cls.find_start(text) != -1
+        """Is this text this format's, as opposed to merely readable by it?
+
+        Keyed on `DETECT_MARKERS` where a format declares them: the literals
+        that must not be split are not always the literals that identify.
+        """
+        return any(m in text for m in (cls.DETECT_MARKERS or cls.START_MARKERS))
 
     @classmethod
     def region_end(cls, region: str) -> int:
@@ -285,6 +301,21 @@ class ToolCallParser(ABC):
         puts one inside a parameter.
         """
         return 0
+
+    @classmethod
+    def render_call(cls, name: str, args: dict[str, str]) -> str:
+        """One call, in this format's own syntax. The inverse of `parse_region`.
+
+        Nothing in the engine renders; this exists so the test corpus can be
+        generated from the registry rather than hand-written. A hand-written
+        sample can be wrong in a way that makes every assertion about it
+        vacuous -- MiniMax's was written in DSML's spelling and parsed to
+        `get_weather({})`, exercising none of the parameter path.
+
+        Not `@abstractmethod`: nothing here is ever instantiated, so ABC would
+        not enforce it. `test_every_format_can_write_its_own_syntax` does.
+        """
+        raise NotImplementedError(f"{cls.NAME} cannot render its own syntax")
 
     @classmethod
     @abstractmethod

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -365,6 +365,7 @@ all flags via `add_cli_args()` and converts them into a `Config` via
 | `--load_dummy` | | `{empty,zero,xavier}` (optional value) | `None` | Dummy weights: bare/`=empty` skip load; `=zero` all-zero; `=xavier` xavier(bf16)/constant-magnitude(fp4/fp8) |
 | `--enable-expert-parallel` | | flag | `False` | Enable Expert Parallelism (EP MoE) |
 | `--torch-profiler-dir` | | `str` | `None` | Directory for torch profiler traces |
+| `--tool-call-parser` | | `str` | `"auto"` | Tool-call wire format. `auto` reads it from the model's chat template at startup (Jinja or a model-side `encoding/encoding_*.py`); a name (`dsml`, `glm`, `kimi`, `kimi_k3`, `minimax`, `qwen`) overrides. When neither resolves, tool calls are delivered as plain text and the startup log says so — the format is never guessed from output. An unknown name is refused rather than silently disabling tool parsing |
 | `--enable-dp-attention` | | flag | `False` | Enable DP attention |
 | `--method` | | `str` | `None` | Speculative method; choices: `mtp` |
 | `--num-speculative-tokens` | | `int` | `1` | Number of speculative tokens per iteration |

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -365,7 +365,6 @@ all flags via `add_cli_args()` and converts them into a `Config` via
 | `--load_dummy` | | `{empty,zero,xavier}` (optional value) | `None` | Dummy weights: bare/`=empty` skip load; `=zero` all-zero; `=xavier` xavier(bf16)/constant-magnitude(fp4/fp8) |
 | `--enable-expert-parallel` | | flag | `False` | Enable Expert Parallelism (EP MoE) |
 | `--torch-profiler-dir` | | `str` | `None` | Directory for torch profiler traces |
-| `--tool-call-parser` | | `str` | `"auto"` | Tool-call wire format. `auto` reads it from the model's chat template at startup (Jinja or a model-side `encoding/encoding_*.py`); a name (`dsml`, `glm`, `kimi`, `kimi_k3`, `minimax`, `qwen`) overrides. When neither resolves, tool calls are delivered as plain text and the startup log says so — the format is never guessed from output. An unknown name is refused rather than silently disabling tool parsing |
 | `--enable-dp-attention` | | flag | `False` | Enable DP attention |
 | `--method` | | `str` | `None` | Speculative method; choices: `mtp` |
 | `--num-speculative-tokens` | | `int` | `1` | Number of speculative tokens per iteration |

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -143,6 +143,18 @@ output, because a wrong guess there is silent — a Hermes-style
 `<tool_call>{"name": ...}` claimed by the GLM parser delivers the whole JSON
 blob as the tool's *name*. Pass a format name to override.
 
+**A stalled response is visible while it is stalled.**
+`StreamOutputCollector.get` is the single point at which any stream waits for
+its next chunk, so it records when each wait started, and
+`atom:stream_longest_silence_seconds` reports the age of the oldest one. Zero
+when nothing is waiting; non-zero and growing is a response that has stopped
+delivering while its client waits. A wait that ends after more than 30 seconds
+also logs a line naming the request — the gauge cannot see a stall that has
+already recovered by scrape time. Neither costs a timer: `asyncio.wait_for`
+around that await measured 1.38 us per token per stream against 0.07 us for a
+timestamp and a dict entry. This exists because the symptom that started this
+work was ten minutes of silence with every metric looking healthy.
+
 One consequence matters when reading benchmark output. ITL is sampled once per
 received SSE chunk (`backend_request_func.py`, `benchmark_serving.py`), so
 merging N tokens into one chunk removes N-1 samples and stretches the gaps that
@@ -773,7 +785,7 @@ server without modification.
 | File | Description |
 |------|-------------|
 | `atom/entrypoints/openai_server.py` | OpenAI-compatible API server (FastAPI + Uvicorn) |
-| `atom/entrypoints/openai/streaming_dispatch.py` | `StreamBatchDispatcher` (per-engine-step cross-thread dispatch) and `StreamOutputCollector` (per-request delivery, folds a backlog) |
+| `atom/entrypoints/openai/streaming_dispatch.py` | `StreamBatchDispatcher` (per-engine-step cross-thread dispatch), `StreamOutputCollector` (per-request delivery, folds a backlog) and the silence watchdog |
 | `atom/entrypoints/openai/sse.py` | SSE frame encoding (`data_frame`, `event_frame`) on a shared msgspec encoder |
 | `atom/entrypoints/openai/marker_scanner.py` | `MarkerScanner` — the one rule for how much of a stream is safe to release |
 | `atom/entrypoints/openai/reasoning.py` | Splits the reasoning channel from the answer; seeded per request by `prompt_starts_in_reasoning` |

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -110,9 +110,10 @@ down:
 **A token *can* be delivered later than the engine produced it, by a bounded
 amount.** Two stages downstream of the collector read the text for markers —
 the reasoning channel's delimiters
-(`atom/entrypoints/openai/reasoning.py`) and the tool-call formats' opening
-tags (`atom/entrypoints/openai/tool_parser/`) — and neither may hand out a
-byte that could turn out to be the first character of one. Both ask the same
+(`atom/entrypoints/openai/reasoning.py`) and the opening tags of whichever
+tool-call format this model uses (`atom/entrypoints/openai/tool_parser/`) —
+and neither may hand out a byte that could turn out to be the first character
+of one. Both ask the same
 question through `MarkerScanner`
 (`atom/entrypoints/openai/marker_scanner.py`): release everything except the
 longest *suffix* of the buffer that is a prefix of some marker. The wait is
@@ -129,6 +130,18 @@ client, and the scan over that ever-growing buffer made the cost quadratic in
 the response length. Text inside the reasoning channel is held until its end
 marker, which is not a stall: it is reasoning, and it is delivered as
 `reasoning_content` as it arrives.
+
+**Which tool-call format a model uses is decided at startup, not from its
+output.** `--tool-call-parser` defaults to `auto`, which renders the model's
+chat template with a tools payload — the template's own instructions for
+calling one — and runs the same detection cascade `parse_tool_calls` runs on
+a complete output. It reads a Jinja template or a model-side Python encoder
+(`<model>/encoding/encoding_*.py`, which is how DeepSeek-V4 ships its), and
+logs the format it chose. When nothing is recognised it says so and tool
+calls are delivered as plain text; it does not fall back to reading the
+output, because a wrong guess there is silent — a Hermes-style
+`<tool_call>{"name": ...}` claimed by the GLM parser delivers the whole JSON
+blob as the tool's *name*. Pass a format name to override.
 
 One consequence matters when reading benchmark output. ITL is sampled once per
 received SSE chunk (`backend_request_func.py`, `benchmark_serving.py`), so
@@ -764,7 +777,8 @@ server without modification.
 | `atom/entrypoints/openai/sse.py` | SSE frame encoding (`data_frame`, `event_frame`) on a shared msgspec encoder |
 | `atom/entrypoints/openai/marker_scanner.py` | `MarkerScanner` — the one rule for how much of a stream is safe to release |
 | `atom/entrypoints/openai/reasoning.py` | Splits the reasoning channel from the answer; seeded per request by `prompt_starts_in_reasoning` |
-| `atom/entrypoints/openai/tool_parser/` | Per-format tool-call parsing; each format declares its `MARKERS` |
+| `atom/entrypoints/openai/tool_parser/registry.py` | Which format a model emits, resolved once at startup from its chat template |
+| `atom/entrypoints/openai/tool_parser/` | Per-format tool-call parsing; each format declares its `START_MARKERS` |
 | `atom/model_engine/llm_engine.py` | `LLMEngine` programmatic API |
 | `atom/sampling_params.py` | `SamplingParams` dataclass |
 | `atom/model_engine/arg_utils.py` | `EngineArgs` CLI argument definitions and engine factory |

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -127,21 +127,66 @@ which one `<` in an ordinary answer — `if (a < b)` — satisfied forever, and
 the buffer was never cleared while it held. The whole answer then arrived in
 a single frame at end of stream, indistinguishable from a hang to a streaming
 client, and the scan over that ever-growing buffer made the cost quadratic in
-the response length. Text inside the reasoning channel is held until its end
-marker, which is not a stall: it is reasoning, and it is delivered as
-`reasoning_content` as it arrives.
+the response length.
+
+Two waits are longer than that and are not stalls. Text inside the reasoning
+channel is held until its end marker — it is reasoning, and it is delivered as
+`reasoning_content` as it arrives. And once a *complete* start marker appears,
+everything from it onward belongs to the tool-call format until the format can
+parse it, which for a real call is its closing tag and for Kimi-K3 — whose
+channel framing interleaves and is parsed once at EOS — is the whole response.
+The bound above is on the read-ahead *before* a marker, which is the part an
+ordinary answer pays.
 
 **Which tool-call format a model uses is decided at startup, not from its
 output.** `--tool-call-parser` defaults to `auto`, which renders the model's
 chat template with a tools payload — the template's own instructions for
-calling one — and runs the same detection cascade `parse_tool_calls` runs on
-a complete output. It reads a Jinja template or a model-side Python encoder
-(`<model>/encoding/encoding_*.py`, which is how DeepSeek-V4 ships its), and
-logs the format it chose. When nothing is recognised it says so and tool
-calls are delivered as plain text; it does not fall back to reading the
-output, because a wrong guess there is silent — a Hermes-style
-`<tool_call>{"name": ...}` claimed by the GLM parser delivers the whole JSON
-blob as the tool's *name*. Pass a format name to override.
+calling one — and runs the `_DETECT_ORDER` cascade on the result. It reads a
+Jinja template or a model-side Python encoder (`<model>/encoding/encoding_*.py`,
+which is how DeepSeek-V4 ships its), and logs the format it chose. When nothing
+is recognised it says so and tool calls are delivered as plain text. There is
+no fallback to reading the output — not on either path, which is the point: the
+non-streaming path used to run the cascade over the response whenever no format
+had been resolved, so an answer that merely quoted another format's section
+token had everything from the token onward deleted with `stream=false` and
+arrived whole with `stream=true`. A guess is silent, and it is also two
+different answers to one request.
+
+**`stream=false` and `stream=true` deliver the same text.** A format's `parse`
+returns the content byte-for-byte when it found no tool call; the only thing it
+may remove is a marker it declares itself (Kimi-K3's channel tokens, which the
+streaming path removes too). Whitespace is not that — every format used to
+`.strip()`, which cost a code-block answer its trailing newline on one path
+only. The property suite generates this check from the parser registry, so a
+format added later is held to it without a new case being written.
+
+**`thinking` is answered in the prompt, not in the response.** On
+`/v1/messages`, `thinking: {"type": "disabled"}` sets the chat template's own
+reasoning switch, so the model emits no chain of thought — there is then none
+to separate, none to discard, and none for the tool parser to misread.
+Everything downstream is unconditional: the reasoning channel is always
+separated and always reported, exactly as on `/v1/chat/completions`.
+
+That ordering is the whole of it. Handling an unwanted chain of thought *after*
+generating it fails three different ways — discarding it returns an empty
+message for a reasoning model stopped at `max_tokens`; relabelling it as `text`
+hands the client the thing it declined; and leaving it unseparated feeds it to
+the tool parser, which is a second reader of the same text and read one model's
+musing about `<function=NAME>` as a call to a tool named `NAME`. SGLang answers
+the same field the same way (`apply_reasoning_enabled`), and vLLM gets it
+structurally by having no such field: its reasoning parser runs unconditionally
+and `include_reasoning` only suppresses the result after the split.
+
+Which kwarg carries the switch is resolved at startup by rendering the template
+twice and comparing, because a template silently ignores a kwarg it does not
+read. On this box: Qwen3/Qwen3.5 `enable_thinking`, Kimi-K3 `thinking`,
+MiniMax-M3 `thinking_mode="disabled"`, DeepSeek-V4 `thinking_mode="chat"`.
+A model whose template has no switch is named in the startup log; its reasoning
+cannot be turned off, and is separated and reported rather than dropped. Two
+details that bite: `{"type": "disabled"}` is a non-empty object, so testing the
+field for truthiness read the standard off-switch as on; and an *absent*
+`thinking` leaves the model's own default alone rather than switching reasoning
+off, so an existing caller's answers do not change.
 
 **A stalled response is visible while it is stalled.**
 `StreamOutputCollector.get` is the single point at which any stream waits for
@@ -154,6 +199,13 @@ already recovered by scrape time. Neither costs a timer: `asyncio.wait_for`
 around that await measured 1.38 us per token per stream against 0.07 us for a
 timestamp and a dict entry. This exists because the symptom that started this
 work was ten minutes of silence with every metric looking healthy.
+
+Two silences it cannot see, so do not read zero as "nothing is stuck". It is
+armed only after a stream has delivered once — otherwise every queued request
+would register, duplicating `atom:requests_waiting` — so a request admitted and
+never producing a first token contributes nothing. And it measures upstream of
+the two withholding stages, so a stream whose bytes are arriving on schedule
+and being held by the tool-call read-ahead reads as healthy here.
 
 One consequence matters when reading benchmark output. ITL is sampled once per
 received SSE chunk (`backend_request_func.py`, `benchmark_serving.py`), so
@@ -188,7 +240,7 @@ Server-specific CLI arguments:
 | `--server-port` | `8000` | HTTP port (note: `--port` is for internal engine communication) |
 | `--timeout-keep-alive` | `5` | Seconds an idle keep-alive connection is held. Pooling clients hold their end longer (aiohttp defaults to 15s), so a caller that pauses for longer than this reuses a socket the server already closed and has to re-send. Raise it past the caller's idle window to avoid that |
 | `--disable-uvicorn-access-log` | off | Stop uvicorn logging a line per HTTP request. It copies a `LogRecord` and writes to the same stdout as the engine, on the event loop |
-| `--tool-call-parser` | `auto` | Tool-call wire format. `auto` reads it from the model's chat template at startup (Jinja, or a model-side `encoding/encoding_*.py`); a name — `dsml`, `glm`, `kimi`, `kimi_k3`, `minimax`, `qwen` — overrides. When neither resolves, tool calls are delivered as plain text and the startup log says so; the format is never guessed from output. An unknown name is refused rather than silently disabling tool parsing. Accepted by the atomesh entrypoint too |
+| `--tool-call-parser` | `auto` | Tool-call wire format. `auto` reads it from the model's chat template at startup (Jinja, or a model-side `encoding/encoding_*.py`); a name — `dsml`, `glm`, `kimi`, `kimi_k3`, `minimax`, `qwen` — overrides. When neither resolves, tool calls are delivered as plain text and the startup log says so; the format is never guessed from output. An unknown name is refused rather than silently disabling tool parsing, and on atomesh that refusal happens before the weights load. Accepted by the atomesh entrypoint too, where it is also forwarded to the mesh router, which declares a flag of the same name and its own vocabulary for it |
 
 All `EngineArgs` arguments are also accepted (see Section 7 for the full list).
 
@@ -790,6 +842,7 @@ server without modification.
 | `atom/entrypoints/openai/sse.py` | SSE frame encoding (`data_frame`, `event_frame`) on a shared msgspec encoder |
 | `atom/entrypoints/openai/marker_scanner.py` | `MarkerScanner` — the one rule for how much of a stream is safe to release |
 | `atom/entrypoints/openai/reasoning.py` | Splits the reasoning channel from the answer; seeded per request by `prompt_starts_in_reasoning` |
+| `atom/entrypoints/openai/chat_encoders.py` | Renders the chat template, and the two startup probes of it: `render_probe_prompt` (what the prompt tells the model) and `chat_template_source` (what the template does with a reply) |
 | `atom/entrypoints/openai/tool_parser/registry.py` | Which format a model emits, resolved once at startup from its chat template |
 | `atom/entrypoints/openai/tool_parser/` | Per-format tool-call parsing; each format declares its `START_MARKERS` |
 | `atom/model_engine/llm_engine.py` | `LLMEngine` programmatic API |

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -133,11 +133,18 @@ Two waits are longer than that. Text inside the reasoning channel is held until
 its end marker — not a stall: it is reasoning, and it is delivered as
 `reasoning_content` as it arrives. And once a marker that *opens a tool-call
 region* appears, everything from it onward belongs to the format until it can
-parse the region, which for a real call is its closing tag and for an answer
-that merely quotes a marker is end of stream. Nothing is lost there — the
-region is released verbatim once it turns out not to be a call — but it does
-arrive late, and `atom:stream_longest_silence_seconds` now reports it while it
-is happening.
+parse the region. For a real call that is its closing tag. For an answer that
+merely quotes a marker it used to be end of stream — measured on a GLM answer
+naming the tag at character 29 and then explaining for 1234 more, 98% of it
+arrived in one frame at EOS, and "how do I make you call a tool" is a common
+question. A region that has grown past `_FIRST_PROBE` bytes and still parses
+to no call is now given up on: its opening marker goes into the answer and the
+rest is read again, so a real call later in the same reply still opens a
+region of its own. Only formats that can recognise a call still arriving are
+asked — a Kimi entry is invisible until its end token, so a large argument
+would look exactly like prose. Nothing is lost either way; what is left is
+`atom:stream_longest_silence_seconds`, which reports the wait while it
+happens.
 
 "Opens a region" is asked of the format, not assumed of every marker it
 declares. Kimi-K3 declares thirteen and only two of them mean a tool call; the
@@ -154,73 +161,54 @@ characters with no event and `finish_reason` still `stop`.
 
 **The tool's name does not wait for its arguments.** A region is buffered
 until it closes, so on a 20 KB file write the client learned *which* tool was
-being called only after 5030 of 5040 tokens. Every format carries the name in
-its opener, so it is sent as soon as the region reveals it — measured across
-all six, chunk 11–21 instead of 225–248.
+being called only after 5030 of 5040 tokens. Four of the six formats can
+recognise a call that has not finished arriving, and for those the name is
+sent as soon as the region reveals it — chunk 11–21 instead of 225–248.
 
-Two things have to be true before a name goes out. It is one the request
-declared in `tools`, and what follows it is this format's own next token
-rather than English -- prose can name a real tool, so the first test alone let
-"the model writes `<tool_call><function=get_weather>` and then..." announce
-`get_weather`. SGLang's cursor parsers announce with neither check and will
-emit a call named after whatever follows the tag.
+The name is read out of `parse_region` itself, over the region so far and with
+`at_end=False`. That is what makes the early name and the parsed call agree:
+same function, same enumeration, the second run seeing a superset of the
+first's bytes. Every format used to answer this with a regex of its own, and
+four of the five that had one disagreed with their own parse — Qwen's peek
+accepted `</tool_call>`, which closes the *outer* wrapper and leaves the
+`<function=` block open; DeepSeek-V4's skipped a self-closing
+`<invoke name="x"/>` its parse returned first, putting three tool calls on the
+`/v1/messages` wire for a response containing two. There is no separate peek
+now, so there is nothing left to disagree.
 
-The same pair gates the *unclosed-region* branch of `parse` in all five XML-ish
-formats, which exists for a call cut off at `max_tokens` and could not tell
-that from prose: it produced a complete zero-argument call, deleted the rest of
-the sentence and reported `finish_reason: tool_calls`, so an agentic client ran
-a tool nobody asked for. K3 applies only the second test — it carries argument
-types on the wire, so it is never handed `tools` and has no declared names to
-check a name against.
+`at_end` is the only difference between the two questions. With it — the
+region has closed, or the stream has — a token cut off part-way through is all
+there will ever be, so a prefix counts, which is what a call truncated by
+`max_tokens` looks like. Without it a prefix means "not yet", and accepting
+one let a chunk boundary landing one character into `<br>` name a tool for
+prose. Same bytes, announced at one chunk size and silent at another.
 
-Where the model *wrote* the name, that name wins. DSML also infers a dropped
-tool name from the parameter signature, for a documented malform that omits the
-`<invoke>` wrapper entirely; reaching that inference for a merely *truncated*
-call scored a different declared tool than the one in the opener — which is
-also the opener `peek_name` reads, so the announcement and the parse then
-disagreed about the same bytes.
+A name only goes out for a tool the request declared. Prose can name a real
+tool, so that alone is not enough — the follower test above is the other half.
+SGLang's cursor parsers announce with neither check and will emit a call named
+after whatever follows the tag.
 
-The peek reads a bounded prefix and stops once that prefix has gone by without
-a name. Running the format's regex over the whole region on every chunk is
-quadratic in the response -- 3.0 → 9.8 → 36 → 137 ms across 2k/4k/8k/16k
-tokens, which is the shape `marker_scanner` exists to retire, one layer up.
+The read is bounded to `Region.head` and stops once that prefix has gone by
+without a name. Running the format's regex over the whole region on every
+chunk is quadratic in the response — 3.0 → 9.8 → 36 → 137 ms across
+2k/4k/8k/16k tokens, the shape `marker_scanner` exists to retire, one layer up.
 
-Peek and parse read *one* rule. Each format writes down the tokens that may
-follow the name inside a call -- another parameter, or the close of the very
-block the name opened -- and both callers test against that tuple. They used
-to encode it twice, a follower set in the peek regex and a truncation test in
-`parse`, and four of the five disagreed: Qwen's peek accepted `</tool_call>`,
-which closes the *outer* wrapper and leaves the `<function=` block open, so
-`parse` read the same bytes as prose and the name went out for a call that
-never came. The peek also takes the request's `tools` now, because MiniMax
-names a parameter by its own tag and telling `<city>` from `<br>` needs the
-schema.
-
-What remains is the honest case: a call the model really was making, cut off
-by `max_tokens`. The name is correct information, and `finish_reason` keys on
-the arguments so nothing downstream counts it as a call.
-
-Should a format's peek and its parse disagree anyway, the mismatch is logged
-and recovered from, not raised. The caller is `flush`, on a stream whose 200
-is already sent, so an exception there reaches the client as a connection cut
-mid-frame with no `[DONE]` — and on the `n>1` path takes the other choices
-with it. The announced name cannot be retracted, but it can be left with no
-arguments, which is the same shape every unfulfilled announcement takes and
-which nothing downstream counts as a call; the parsed call goes out whole at
-the next index.
-
-Kimi-K2 does not announce at all. Its call index and id travel on the wire
-(`functions.NAME:INDEX`) and an announcement has to carry both before the
-entry that supplies them has arrived; every announced call went out at index
-0, so a client accumulating by index overwrote the first call with the
-second.
+Kimi-K2 and Kimi-K3 name nothing early, and `RECOGNISES_A_CALL_IN_PROGRESS`
+says so. A K2 entry is invisible until `<|tool_call_end|>` and a K3 call until
+`<|close|>call`, so for them the name arrives with the arguments. The flag is
+measured rather than trusted: the property suite drives each format's own call
+with an 800-byte payload and checks that the name lands before the arguments
+exactly when the flag says it will.
 
 Arguments still wait for the region to close. SGLang streams those too, as
 JSON fragments; a response cut short then leaves the client holding an
-unterminated object. The residual cost here is narrower: a response truncated
-mid-call has sent a name and no arguments, and `finish_reason` / `stop_reason`
-key on the *arguments* precisely so that dangling name is not reported as a
-tool the client should run.
+unterminated object. On `/v1/chat/completions` a name with no arguments is
+harmless — clients accumulate by index and wait for `finish_reason`, which
+keys on the arguments. On `/v1/messages` it is not: a `content_block_start` of
+type `tool_use` carries `"input": {}` and is, on its own, a complete
+zero-argument call, with no frame for "the name is known, the arguments are
+coming". So that endpoint opens the block when the arguments arrive, not when
+the name does.
 
 **Which tool-call format a model uses is decided at startup, not from its
 output.** `--tool-call-parser` defaults to `auto`, which renders the model's
@@ -236,13 +224,29 @@ token had everything from the token onward deleted with `stream=false` and
 arrived whole with `stream=true`. A guess is silent, and it is also two
 different answers to one request.
 
-**`stream=false` and `stream=true` deliver the same text.** A format's `parse`
-returns the content byte-for-byte when it found no tool call; the only thing it
-may remove is a marker it declares itself (Kimi-K3's channel tokens, which the
-streaming path removes too). Whitespace is not that — every format used to
-`.strip()`, which cost a code-block answer its trailing newline on one path
-only. The property suite generates this check from the parser registry, so a
-format added later is held to it without a new case being written.
+**`stream=false` and `stream=true` deliver the same text**, and not because a
+test compares them: `stream=false` is `read_whole`, which is the streaming
+engine over a single chunk. There is no second implementation to disagree
+with. A format used to be read twice — once by a `parse` taking the whole
+output, once by a `process`/`flush` state machine of its own — and both had to
+decide where content ends, whether an unclosed tag is a call, what a region
+that parses to nothing means, and which bytes are framing. Six formats, two
+copies, four rules; three rounds of review found the copies disagreeing about
+all four.
+
+A format now declares only what is particular to it: the literals that must
+not be split (`START_MARKERS`), which of those hand the stream over
+(`opens_region`, the rest being framing the reader drops), and what one
+region's bytes mean (`parse_region`, returning the calls and the two offsets
+that bracket its own markup). Everything else — reading ahead, releasing
+content, the rule that a start marker is not a promise, stamping call indices,
+and handing back the answer that follows the markup — is the engine's, once.
+
+The content comes back byte-for-byte except for markers the format declares.
+Whitespace is not one — every format used to `.strip()`, which cost a
+code-block answer its trailing newline on one path only. Text *after* a call
+is not one either: five of the six deleted it, and the property suite now
+holds every registered format to delivering it, at four chunk sizes.
 
 The *reasoning* split is held to the same rule one stage earlier, and was not.
 Two ways: `</think>` was matched only at position 0, so a model that answers,
@@ -262,17 +266,55 @@ same answer kept those bytes at one chunk size and lost them at another —
 there was no chunk-invariant behaviour on that whitespace for the other path
 to match even if it had wanted to.
 
+**Which reasoning dialect a model speaks is decided at startup too**, from the
+same evidence as the tool-call format and by the same kind of function
+(`resolve_dialect`, on the chat-template source). It used to be decided twice
+per response and differently each time: the non-streaming split tried each
+registered dialect in order and took the first that matched, while the
+streaming filter carried no dialect at all and closed the channel on the
+*union* of every dialect's end markers. A `<think>` model answering a question
+about Kimi's wire format therefore ended its chain of thought at the quoted
+`<|open|>response<|sep|>` when streamed and at the real `</think>` when not —
+24 characters of the answer filed as reasoning on one path, a raw `</think>`
+shipped to the user on the other. `ReasoningChannel` now carries the dialect
+and whether the output begins inside the channel, with one accessor per
+delivery mode, so the two cannot be handed different answers. A template that
+names no dialect falls back to the inline-`<think>` one, which is a no-op for
+a model that never writes the tag.
+
+Whether the output *begins* inside the channel is per request, not per model.
+A request that switches reasoning off renders a prompt that does not open it,
+and the model-level fact — a template that closes a block it never opens, as
+DeepSeek-R1's does — used to be OR-ed in regardless. On such a model an
+ordinary answer to a request that had asked for no thinking came back entirely
+as `reasoning_content`, with `content` empty.
+
 **`tool_choice: "none"` suppresses the call, not the answer.** It used to be
 enforced where the events are *sent* — twelve places across two endpoints —
 while the parser went on consuming the region, so the model's own words were
 deleted and nothing took their place: 89 characters of a 95-character answer,
 no event, `finish_reason: stop`. The rule now lives at the one place the
-parser is chosen, which is also the right reading — the request said this
-cannot be a call, so it is prose — and it costs less, since nothing is parsed
-in order to be discarded. `/v1/messages` reads the field too, in Anthropic's
+parser is *asked*, as `suppress_calls`, which is also the right reading — the
+request said this cannot be a call, so it is prose.
+
+Not by using no parser at all, which is where the first fix for that went.
+Dropping the parser drops everything else a parser does, and a format whose
+framing wraps *every* answer then leaks it: Kimi-K3's `Hello there.` arrived
+as `<|open|>response<|sep|>Hello there.<|close|>response<|sep|><|end_of_msg|>`
+the moment a request said `none`. The format is still read; only dispatch is
+suppressed. `/v1/messages` reads the field too, in Anthropic's
 `{"type": "none"}` spelling; it previously parsed it off the request and used
 it nowhere, so a client that forbade tool calls got `tool_use` blocks and
 `stop_reason: tool_use` anyway.
+
+Forwarding it to the chat template is a separate step, and one that used to be
+a 500. The handler passes template controls it cannot know the model reads —
+`response_format`, `tool_choice`, `thinking_effort`, and whatever a client puts
+in `chat_template_kwargs`. A Jinja template silently ignores a kwarg it does
+not read; a model-shipped Python encoder raises `TypeError`. So on DeepSeek-V4
+and Kimi-K3, which ship encoders instead of templates, any request carrying one
+of those was an unhandled exception. The adapter now reads the encoder's
+signature once at startup and passes on only what it can take.
 
 **`thinking` is answered in the prompt, not in the response.** On
 `/v1/messages`, `thinking: {"type": "disabled"}` sets the chat template's own
@@ -970,10 +1012,12 @@ server without modification.
 | `atom/entrypoints/openai/streaming_dispatch.py` | `StreamBatchDispatcher` (per-engine-step cross-thread dispatch), `StreamOutputCollector` (per-request delivery, folds a backlog) and the silence watchdog |
 | `atom/entrypoints/openai/sse.py` | SSE frame encoding (`data_frame`, `event_frame`) on a shared msgspec encoder |
 | `atom/entrypoints/openai/marker_scanner.py` | `MarkerScanner` — the one rule for how much of a stream is safe to release |
-| `atom/entrypoints/openai/reasoning.py` | Splits the reasoning channel from the answer; seeded per request by `prompt_starts_in_reasoning` |
+| `atom/entrypoints/openai/reasoning.py` | Splits the reasoning channel from the answer; `ReasoningChannel` carries the model's dialect and whether the output begins inside the channel, and has one accessor per delivery mode |
+| `atom/entrypoints/openai/reasoning_dialects.py` | The dialects, and `resolve_dialect`, which picks one from the chat template at startup |
+| `atom/entrypoints/openai/tool_parser/stream.py` | The one reader: the engine both delivery modes run through |
 | `atom/entrypoints/openai/chat_encoders.py` | Renders the chat template, and the two startup probes of it: `render_probe_prompt` (what the prompt tells the model) and `chat_template_source` (what the template does with a reply) |
 | `atom/entrypoints/openai/tool_parser/registry.py` | Which format a model emits, resolved once at startup from its chat template |
-| `atom/entrypoints/openai/tool_parser/` | Per-format tool-call parsing; each format declares its `START_MARKERS` |
+| `atom/entrypoints/openai/tool_parser/` | Per-format tool-call syntax; each format declares its markers and a `parse_region`, and writes no reader of its own |
 | `atom/model_engine/llm_engine.py` | `LLMEngine` programmatic API |
 | `atom/sampling_params.py` | `SamplingParams` dataclass |
 | `atom/model_engine/arg_utils.py` | `EngineArgs` CLI argument definitions and engine factory |

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -152,12 +152,28 @@ being called only after 5030 of 5040 tokens. Every format carries the name in
 its opener, so it is sent as soon as the region reveals it — measured across
 all six, chunk 11–21 instead of 225–248.
 
-Only for a name the request declared in `tools`. That check is what makes the
-early name safe: it cannot be retracted, and an answer quoting
-`<tool_call><function=NAME>` opens a region too, so a name the client never
-offered waits for the region to close like everything else. SGLang's cursor
-parsers announce with no such check and will emit a call named after whatever
-follows the tag.
+Two things have to be true before a name goes out. It is one the request
+declared in `tools`, and what follows it is this format's own next token
+rather than English -- prose can name a real tool, so the first test alone let
+"the model writes `<tool_call><function=get_weather>` and then..." announce
+`get_weather`. SGLang's cursor parsers announce with neither check and will
+emit a call named after whatever follows the tag.
+
+The same pair gates the *unclosed-region* branch of `parse`, which exists for
+a call cut off at `max_tokens` and could not tell that from prose: it produced
+a complete zero-argument call, deleted the rest of the sentence and reported
+`finish_reason: tool_calls`, so an agentic client ran a tool nobody asked for.
+
+The peek reads a bounded prefix and stops once that prefix has gone by without
+a name. Running the format's regex over the whole region on every chunk is
+quadratic in the response -- 3.0 → 9.8 → 36 → 137 ms across 2k/4k/8k/16k
+tokens, which is the shape `marker_scanner` exists to retire, one layer up.
+
+Kimi-K2 does not announce at all. Its call index and id travel on the wire
+(`functions.NAME:INDEX`) and an announcement has to carry both before the
+entry that supplies them has arrived; every announced call went out at index
+0, so a client accumulating by index overwrote the first call with the
+second.
 
 Arguments still wait for the region to close. SGLang streams those too, as
 JSON fragments; a response cut short then leaves the client holding an
@@ -233,11 +249,15 @@ a stream waits for the *engine*, but the reasoning read-ahead and the tool-call
 read-ahead sit between it and the socket, and while either withholds, the
 collector wakes on every token. Measured: an answer quoting a tool marker fed
 126 tokens and sent the client 6 frames, and the gauge read zero. At the frame
-it reads the silence. Moving out also retired the "ignore the first wait" rule
-— at the collector that first wait is admission and prefill, which would have
-made the gauge a queue-depth proxy `atom:requests_waiting` already provides;
-out here the response's opening frame goes out immediately, so every gap after
-it is real.
+it reads the silence.
+
+The wait for the *first* frame is still excluded, and moving out did not
+change that — a claim this paragraph made and did not hold. Every response
+generator awaits the collector before yielding anything, so that wait is
+admission, queueing and prefill: timing it put 0.2 s on the gauge for a
+request 200 ms into a queue with no token yet produced, which is
+`atom:requests_waiting` under another name, and past the threshold would log a
+line per admitted request blaming the read-ahead.
 
 One consequence matters when reading benchmark output. ITL is sampled once per
 received SSE chunk (`backend_request_func.py`, `benchmark_serving.py`), so

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -362,8 +362,9 @@ the field for truthiness read the standard off-switch as on; and an *absent*
 `thinking` leaves the model's own default alone rather than switching reasoning
 off, at both layers or neither, so an existing caller's answers do not change.
 
-**A stalled response is visible while it is stalled.** Every SSE frame leaves
-through `_client_stream`, which times the gap before each one and registers it,
+**A stalled response is visible while it is stalled — on the OpenAI server.**
+Every SSE frame from `openai_server` leaves through `_client_stream`, which
+times the gap before each one and registers it,
 and `atom:stream_longest_silence_seconds` reports the age of the oldest gap
 in flight. Zero when every stream has just been served; non-zero and growing is
 a response whose client is receiving nothing. A gap longer than 30 seconds also
@@ -372,6 +373,13 @@ recovered by scrape time. Neither costs a timer: `asyncio.wait_for` measured
 1.38 us per frame per stream against 0.07 us for a timestamp and a dict entry.
 This exists because the symptom that started this work was ten minutes of
 silence with every metric looking healthy.
+
+The atomesh standalone entrypoint has none of it. Its frames leave through
+`ChatCompletionStreamState.drain` / `CompletionStreamState.drain`, polled by
+the Rust router, which builds no `FrameWait`; and `AtomMetricsExporter` is
+constructed only by `openai_server`, so that deployment exposes no `/metrics`
+route at all. A stalled atomesh stream is therefore invisible rather than
+reported as zero.
 
 Measured at the frame and not at `StreamOutputCollector.get`, which is where it
 started and which cannot see the thing it was built for. The collector is where
@@ -422,7 +430,7 @@ Server-specific CLI arguments:
 | `--server-port` | `8000` | HTTP port (note: `--port` is for internal engine communication) |
 | `--timeout-keep-alive` | `5` | Seconds an idle keep-alive connection is held. Pooling clients hold their end longer (aiohttp defaults to 15s), so a caller that pauses for longer than this reuses a socket the server already closed and has to re-send. Raise it past the caller's idle window to avoid that |
 | `--disable-uvicorn-access-log` | off | Stop uvicorn logging a line per HTTP request. It copies a `LogRecord` and writes to the same stdout as the engine, on the event loop |
-| `--tool-call-parser` | `auto` | Tool-call wire format. `auto` reads it from the model's chat template at startup (Jinja, or a model-side `encoding/encoding_*.py`); a name — `dsml`, `glm`, `kimi`, `kimi_k3`, `minimax`, `qwen` — overrides. When neither resolves, tool calls are delivered as plain text and the startup log says so; the format is never guessed from output. An unknown name is refused rather than silently disabling tool parsing, and on atomesh that refusal happens before the weights load. Accepted by the atomesh entrypoint too, where it is also forwarded to the mesh router, which declares a flag of the same name and its own vocabulary for it |
+| `--tool-call-parser` | `auto` | Tool-call wire format. `auto` reads it from the model's chat template at startup (Jinja, or a model-side `encoding/encoding_*.py`); a name — `dsml`, `glm`, `kimi`, `kimi_k3`, `minimax`, `qwen` — overrides. When neither resolves, tool calls are delivered as plain text and the startup log says so; the format is never guessed from output. On the OpenAI server an unknown name is refused at startup, before the weights load, rather than silently disabling tool parsing. The atomesh entrypoint deliberately does not refuse: it shares the flag with the mesh router, which declares its own vocabulary for it, so a name ATOM does not recognise is logged at INFO, forwarded to the router, and ATOM falls back to reading the chat template. Check the log for `is not one of ATOM's formats` if a format you specified is not taking effect |
 
 All `EngineArgs` arguments are also accepted (see Section 7 for the full list).
 

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -97,16 +97,38 @@ Streaming responses use the SSE (Server-Sent Events) protocol with
 The API server is a single Python process, so at high concurrency the fixed
 per-chunk cost of delivering tokens (detokenize, coroutine wakeup, JSON encode,
 socket write) can cap throughput before the GPU does. Two things keep that cost
-down, neither of which delays a token:
+down:
 
 - **Backlog merging.** Each request's chunks land in a `StreamOutputCollector`
   (`atom/entrypoints/openai/streaming_dispatch.py`), which holds at most one
   chunk per stream: anything arriving behind an unread one merges into it.
   Nothing is held back waiting for more, so a consumer that keeps up sees
-  exactly one chunk per engine step and a token is never delivered later than
-  it otherwise would have been.
+  exactly one chunk per engine step.
 - **msgspec frame encoding** (`atom/entrypoints/openai/sse.py`), roughly 5.8x
   cheaper per frame than `json.dumps`.
+
+**A token *can* be delivered later than the engine produced it, by a bounded
+amount.** Two stages downstream of the collector read the text for markers —
+the reasoning channel's delimiters
+(`atom/entrypoints/openai/reasoning.py`) and the tool-call formats' opening
+tags (`atom/entrypoints/openai/tool_parser/`) — and neither may hand out a
+byte that could turn out to be the first character of one. Both ask the same
+question through `MarkerScanner`
+(`atom/entrypoints/openai/marker_scanner.py`): release everything except the
+longest *suffix* of the buffer that is a prefix of some marker. The wait is
+therefore bounded by the longest marker a format declares, a few dozen bytes,
+and is usually zero — a chunk whose tail cannot begin a marker is released
+whole.
+
+This is worth stating because it used to be unbounded. The rule was "hold
+everything once a marker's first character appears *anywhere* in the buffer",
+which one `<` in an ordinary answer — `if (a < b)` — satisfied forever, and
+the buffer was never cleared while it held. The whole answer then arrived in
+a single frame at end of stream, indistinguishable from a hang to a streaming
+client, and the scan over that ever-growing buffer made the cost quadratic in
+the response length. Text inside the reasoning channel is held until its end
+marker, which is not a stall: it is reasoning, and it is delivered as
+`reasoning_content` as it arrives.
 
 One consequence matters when reading benchmark output. ITL is sampled once per
 received SSE chunk (`backend_request_func.py`, `benchmark_serving.py`), so
@@ -740,6 +762,9 @@ server without modification.
 | `atom/entrypoints/openai_server.py` | OpenAI-compatible API server (FastAPI + Uvicorn) |
 | `atom/entrypoints/openai/streaming_dispatch.py` | `StreamBatchDispatcher` (per-engine-step cross-thread dispatch) and `StreamOutputCollector` (per-request delivery, folds a backlog) |
 | `atom/entrypoints/openai/sse.py` | SSE frame encoding (`data_frame`, `event_frame`) on a shared msgspec encoder |
+| `atom/entrypoints/openai/marker_scanner.py` | `MarkerScanner` — the one rule for how much of a stream is safe to release |
+| `atom/entrypoints/openai/reasoning.py` | Splits the reasoning channel from the answer; seeded per request by `prompt_starts_in_reasoning` |
+| `atom/entrypoints/openai/tool_parser/` | Per-format tool-call parsing; each format declares its `MARKERS` |
 | `atom/model_engine/llm_engine.py` | `LLMEngine` programmatic API |
 | `atom/sampling_params.py` | `SamplingParams` dataclass |
 | `atom/model_engine/arg_utils.py` | `EngineArgs` CLI argument definitions and engine factory |

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -140,11 +140,17 @@ arrive late, and `atom:stream_longest_silence_seconds` now reports it while it
 is happening.
 
 "Opens a region" is asked of the format, not assumed of every marker it
-declares. Kimi-K3 declares five and only two of them mean a tool call; the
-other three are channel framing that wraps every answer it gives, including
+declares. Kimi-K3 declares thirteen and only two of them mean a tool call; the
+other eleven are channel framing that wraps every answer it gives, including
 `<|open|>response<|sep|>` at the very start. Treating those as a handover meant
 a K3 response streamed *nothing* — measured, 324 of 324 characters in one frame
 at EOS — which was the common path for that model rather than an edge case.
+
+A start marker is not a promise, and that applies to the handover markers too.
+An answer *quoting* one opens a region that then parses to no call, and every
+format releases that region verbatim rather than deleting it. K3 was the one
+without such a branch: it cut the answer at a quoted call opener and lost 62
+characters with no event and `finish_reason` still `stop`.
 
 **The tool's name does not wait for its arguments.** A region is buffered
 until it closes, so on a 20 KB file write the client learned *which* tool was
@@ -159,15 +165,49 @@ rather than English -- prose can name a real tool, so the first test alone let
 `get_weather`. SGLang's cursor parsers announce with neither check and will
 emit a call named after whatever follows the tag.
 
-The same pair gates the *unclosed-region* branch of `parse`, which exists for
-a call cut off at `max_tokens` and could not tell that from prose: it produced
-a complete zero-argument call, deleted the rest of the sentence and reported
-`finish_reason: tool_calls`, so an agentic client ran a tool nobody asked for.
+The same pair gates the *unclosed-region* branch of `parse` in all five XML-ish
+formats, which exists for a call cut off at `max_tokens` and could not tell
+that from prose: it produced a complete zero-argument call, deleted the rest of
+the sentence and reported `finish_reason: tool_calls`, so an agentic client ran
+a tool nobody asked for. K3 applies only the second test — it carries argument
+types on the wire, so it is never handed `tools` and has no declared names to
+check a name against.
+
+Where the model *wrote* the name, that name wins. DSML also infers a dropped
+tool name from the parameter signature, for a documented malform that omits the
+`<invoke>` wrapper entirely; reaching that inference for a merely *truncated*
+call scored a different declared tool than the one in the opener — which is
+also the opener `peek_name` reads, so the announcement and the parse then
+disagreed about the same bytes.
 
 The peek reads a bounded prefix and stops once that prefix has gone by without
 a name. Running the format's regex over the whole region on every chunk is
 quadratic in the response -- 3.0 → 9.8 → 36 → 137 ms across 2k/4k/8k/16k
 tokens, which is the shape `marker_scanner` exists to retire, one layer up.
+
+Peek and parse read *one* rule. Each format writes down the tokens that may
+follow the name inside a call -- another parameter, or the close of the very
+block the name opened -- and both callers test against that tuple. They used
+to encode it twice, a follower set in the peek regex and a truncation test in
+`parse`, and four of the five disagreed: Qwen's peek accepted `</tool_call>`,
+which closes the *outer* wrapper and leaves the `<function=` block open, so
+`parse` read the same bytes as prose and the name went out for a call that
+never came. The peek also takes the request's `tools` now, because MiniMax
+names a parameter by its own tag and telling `<city>` from `<br>` needs the
+schema.
+
+What remains is the honest case: a call the model really was making, cut off
+by `max_tokens`. The name is correct information, and `finish_reason` keys on
+the arguments so nothing downstream counts it as a call.
+
+Should a format's peek and its parse disagree anyway, the mismatch is logged
+and recovered from, not raised. The caller is `flush`, on a stream whose 200
+is already sent, so an exception there reaches the client as a connection cut
+mid-frame with no `[DONE]` — and on the `n>1` path takes the other choices
+with it. The announced name cannot be retracted, but it can be left with no
+arguments, which is the same shape every unfulfilled announcement takes and
+which nothing downstream counts as a call; the parsed call goes out whole at
+the next index.
 
 Kimi-K2 does not announce at all. Its call index and id travel on the wire
 (`functions.NAME:INDEX`) and an announcement has to carry both before the
@@ -204,12 +244,43 @@ streaming path removes too). Whitespace is not that — every format used to
 only. The property suite generates this check from the parser registry, so a
 format added later is held to it without a new case being written.
 
+The *reasoning* split is held to the same rule one stage earlier, and was not.
+Two ways: `</think>` was matched only at position 0, so a model that answers,
+opens a `<think>` block and answers again had it extracted when streamed and
+handed over as literal tags with the chain of thought inside `content` when
+not — and both halves were then `.strip()`ed, which is the trailing-newline
+bug above, in the stage before it. A model writes `</think>\n\nThe answer.`;
+`stream=true` delivers `"\n\nThe answer."` at every real chunk size and
+`stream=false` delivered `"The answer."`. Measured over 12544 (dialect, shape,
+chunking) comparisons, the two agreed byte-for-byte on 50% of them; they now
+agree on all of them, and the property that says so is byte-exact rather than
+word-level.
+
+The streaming filter also stopped eating the newline after its end marker. It
+only ever saw what happened to be buffered when the marker arrived, so the
+same answer kept those bytes at one chunk size and lost them at another —
+there was no chunk-invariant behaviour on that whitespace for the other path
+to match even if it had wanted to.
+
+**`tool_choice: "none"` suppresses the call, not the answer.** It used to be
+enforced where the events are *sent* — twelve places across two endpoints —
+while the parser went on consuming the region, so the model's own words were
+deleted and nothing took their place: 89 characters of a 95-character answer,
+no event, `finish_reason: stop`. The rule now lives at the one place the
+parser is chosen, which is also the right reading — the request said this
+cannot be a call, so it is prose — and it costs less, since nothing is parsed
+in order to be discarded. `/v1/messages` reads the field too, in Anthropic's
+`{"type": "none"}` spelling; it previously parsed it off the request and used
+it nowhere, so a client that forbade tool calls got `tool_use` blocks and
+`stop_reason: tool_use` anyway.
+
 **`thinking` is answered in the prompt, not in the response.** On
 `/v1/messages`, `thinking: {"type": "disabled"}` sets the chat template's own
 reasoning switch, so the model emits no chain of thought — there is then none
 to separate, none to discard, and none for the tool parser to misread.
-Everything downstream is unconditional: the reasoning channel is always
-separated and always reported, exactly as on `/v1/chat/completions`.
+*Separation* stays unconditional, exactly as on `/v1/chat/completions`: the
+tool parser is a second reader of the same text, so a chain of thought left in
+it is one the tool parser will try to parse.
 
 That ordering is the whole of it. Handling an unwanted chain of thought *after*
 generating it fails three different ways — discarding it returns an empty
@@ -225,12 +296,18 @@ Which kwarg carries the switch is resolved at startup by rendering the template
 twice and comparing, because a template silently ignores a kwarg it does not
 read. On this box: Qwen3/Qwen3.5 `enable_thinking`, Kimi-K3 `thinking`,
 MiniMax-M3 `thinking_mode="disabled"`, DeepSeek-V4 `thinking_mode="chat"`.
-A model whose template has no switch is named in the startup log; its reasoning
-cannot be turned off, and is separated and reported rather than dropped. Two
-details that bite: `{"type": "disabled"}` is a non-empty object, so testing the
-field for truthiness read the standard off-switch as on; and an *absent*
+A model whose template has no switch is named in the startup log. Its reasoning
+cannot be prevented, so `thinking: {"type": "disabled"}` is answered the only
+way left: the text is still separated, and the `thinking` blocks are withheld.
+That is the one downstream suppression there is, and it is reached only when
+the prompt could not carry the answer — without it an explicit opt-out was
+honoured at neither layer. A response that was *nothing but* reasoning then
+ends on an empty text block, which is the honest reply to "do not think".
+
+Two details that bite: `{"type": "disabled"}` is a non-empty object, so testing
+the field for truthiness read the standard off-switch as on; and an *absent*
 `thinking` leaves the model's own default alone rather than switching reasoning
-off, so an existing caller's answers do not change.
+off, at both layers or neither, so an existing caller's answers do not change.
 
 **A stalled response is visible while it is stalled.** Every SSE frame leaves
 through `_client_stream`, which times the gap before each one and registers it,

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -129,14 +129,42 @@ a single frame at end of stream, indistinguishable from a hang to a streaming
 client, and the scan over that ever-growing buffer made the cost quadratic in
 the response length.
 
-Two waits are longer than that and are not stalls. Text inside the reasoning
-channel is held until its end marker — it is reasoning, and it is delivered as
-`reasoning_content` as it arrives. And once a *complete* start marker appears,
-everything from it onward belongs to the tool-call format until the format can
-parse it, which for a real call is its closing tag and for Kimi-K3 — whose
-channel framing interleaves and is parsed once at EOS — is the whole response.
-The bound above is on the read-ahead *before* a marker, which is the part an
-ordinary answer pays.
+Two waits are longer than that. Text inside the reasoning channel is held until
+its end marker — not a stall: it is reasoning, and it is delivered as
+`reasoning_content` as it arrives. And once a marker that *opens a tool-call
+region* appears, everything from it onward belongs to the format until it can
+parse the region, which for a real call is its closing tag and for an answer
+that merely quotes a marker is end of stream. Nothing is lost there — the
+region is released verbatim once it turns out not to be a call — but it does
+arrive late, and `atom:stream_longest_silence_seconds` now reports it while it
+is happening.
+
+"Opens a region" is asked of the format, not assumed of every marker it
+declares. Kimi-K3 declares five and only two of them mean a tool call; the
+other three are channel framing that wraps every answer it gives, including
+`<|open|>response<|sep|>` at the very start. Treating those as a handover meant
+a K3 response streamed *nothing* — measured, 324 of 324 characters in one frame
+at EOS — which was the common path for that model rather than an edge case.
+
+**The tool's name does not wait for its arguments.** A region is buffered
+until it closes, so on a 20 KB file write the client learned *which* tool was
+being called only after 5030 of 5040 tokens. Every format carries the name in
+its opener, so it is sent as soon as the region reveals it — measured across
+all six, chunk 11–21 instead of 225–248.
+
+Only for a name the request declared in `tools`. That check is what makes the
+early name safe: it cannot be retracted, and an answer quoting
+`<tool_call><function=NAME>` opens a region too, so a name the client never
+offered waits for the region to close like everything else. SGLang's cursor
+parsers announce with no such check and will emit a call named after whatever
+follows the tag.
+
+Arguments still wait for the region to close. SGLang streams those too, as
+JSON fragments; a response cut short then leaves the client holding an
+unterminated object. The residual cost here is narrower: a response truncated
+mid-call has sent a name and no arguments, and `finish_reason` / `stop_reason`
+key on the *arguments* precisely so that dangling name is not reported as a
+tool the client should run.
 
 **Which tool-call format a model uses is decided at startup, not from its
 output.** `--tool-call-parser` defaults to `auto`, which renders the model's
@@ -188,24 +216,28 @@ field for truthiness read the standard off-switch as on; and an *absent*
 `thinking` leaves the model's own default alone rather than switching reasoning
 off, so an existing caller's answers do not change.
 
-**A stalled response is visible while it is stalled.**
-`StreamOutputCollector.get` is the single point at which any stream waits for
-its next chunk, so it records when each wait started, and
-`atom:stream_longest_silence_seconds` reports the age of the oldest one. Zero
-when nothing is waiting; non-zero and growing is a response that has stopped
-delivering while its client waits. A wait that ends after more than 30 seconds
-also logs a line naming the request — the gauge cannot see a stall that has
-already recovered by scrape time. Neither costs a timer: `asyncio.wait_for`
-around that await measured 1.38 us per token per stream against 0.07 us for a
-timestamp and a dict entry. This exists because the symptom that started this
-work was ten minutes of silence with every metric looking healthy.
+**A stalled response is visible while it is stalled.** Every SSE frame leaves
+through `_client_stream`, which times the gap before each one and registers it,
+and `atom:stream_longest_silence_seconds` reports the age of the oldest gap
+in flight. Zero when every stream has just been served; non-zero and growing is
+a response whose client is receiving nothing. A gap longer than 30 seconds also
+logs a line naming the request — the gauge cannot see a stall that has already
+recovered by scrape time. Neither costs a timer: `asyncio.wait_for` measured
+1.38 us per frame per stream against 0.07 us for a timestamp and a dict entry.
+This exists because the symptom that started this work was ten minutes of
+silence with every metric looking healthy.
 
-Two silences it cannot see, so do not read zero as "nothing is stuck". It is
-armed only after a stream has delivered once — otherwise every queued request
-would register, duplicating `atom:requests_waiting` — so a request admitted and
-never producing a first token contributes nothing. And it measures upstream of
-the two withholding stages, so a stream whose bytes are arriving on schedule
-and being held by the tool-call read-ahead reads as healthy here.
+Measured at the frame and not at `StreamOutputCollector.get`, which is where it
+started and which cannot see the thing it was built for. The collector is where
+a stream waits for the *engine*, but the reasoning read-ahead and the tool-call
+read-ahead sit between it and the socket, and while either withholds, the
+collector wakes on every token. Measured: an answer quoting a tool marker fed
+126 tokens and sent the client 6 frames, and the gauge read zero. At the frame
+it reads the silence. Moving out also retired the "ignore the first wait" rule
+— at the collector that first wait is admission and prefill, which would have
+made the gauge a queue-depth proxy `atom:requests_waiting` already provides;
+out here the response's opening frame goes out immediately, so every gap after
+it is real.
 
 One consequence matters when reading benchmark output. ITL is sampled once per
 received SSE chunk (`backend_request_func.py`, `benchmark_serving.py`), so

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -133,22 +133,29 @@ Two waits are longer than that. Text inside the reasoning channel is held until
 its end marker — not a stall: it is reasoning, and it is delivered as
 `reasoning_content` as it arrives. And once a marker that *opens a tool-call
 region* appears, everything from it onward belongs to the format until it can
-parse the region. For a real call that is its closing tag. For an answer that
-merely quotes a marker it used to be end of stream — measured on a GLM answer
-naming the tag at character 29 and then explaining for 1234 more, 98% of it
-arrived in one frame at EOS, and "how do I make you call a tool" is a common
-question. A region that has grown past `_FIRST_PROBE` bytes and still parses
-to no call is now given up on: its opening marker goes into the answer and the
-rest is read again, so a real call later in the same reply still opens a
-region of its own. Only formats that can recognise a call still arriving are
-asked — a Kimi entry is invisible until its end token, so a large argument
-would look exactly like prose. Nothing is lost either way; what is left is
-`atom:stream_longest_silence_seconds`, which reports the wait while it
-happens.
+parse the region. For a real call that is its closing tag; for an answer that
+merely quotes a marker it is end of stream. That is a known cost, measured on
+a GLM answer naming the tag at character 29 and then explaining for 1234 more:
+98% of it arrives in one frame at EOS, and "how do I make you call a tool" is
+a common question. Nothing is lost — the region is released verbatim once it
+turns out not to be a call — and `atom:stream_longest_silence_seconds` reports
+the wait while it happens.
+
+A probe that gave up on a region producing nothing after N bytes was written
+for this and reverted. It rests on acceptance being monotone in how many bytes
+have arrived, and that is false: MiniMax gates its in-progress test on the
+first tag being in the declared schema, and DSML's wrapper-less and
+direct-JSON branches match no prefix at all — so real calls over N bytes were
+delivered as raw text with `finish_reason: stop` on three of the six formats.
+It was quadratic besides, because giving up re-fed bytes that immediately
+reopened a region with a fresh budget: 1.19 ms to 18.2 s on a 250 KB answer,
+in the request coroutine. Fixing the latency needs the *format* to say "this
+can no longer become a call", which is a different question from "does not
+parse yet" and one no format answers today.
 
 "Opens a region" is asked of the format, not assumed of every marker it
-declares. Kimi-K3 declares thirteen and only two of them mean a tool call; the
-other eleven are channel framing that wraps every answer it gives, including
+declares. Kimi-K3 declares 16 and only two of them mean a tool call; the
+rest are channel framing that wraps every answer it gives, including
 `<|open|>response<|sep|>` at the very start. Treating those as a handover meant
 a K3 response streamed *nothing* — measured, 324 of 324 characters in one frame
 at EOS — which was the common path for that model rather than an edge case.
@@ -193,12 +200,16 @@ without a name. Running the format's regex over the whole region on every
 chunk is quadratic in the response — 3.0 → 9.8 → 36 → 137 ms across
 2k/4k/8k/16k tokens, the shape `marker_scanner` exists to retire, one layer up.
 
-Kimi-K2 and Kimi-K3 name nothing early, and `RECOGNISES_A_CALL_IN_PROGRESS`
-says so. A K2 entry is invisible until `<|tool_call_end|>` and a K3 call until
-`<|close|>call`, so for them the name arrives with the arguments. The flag is
-measured rather than trusted: the property suite drives each format's own call
-with an 800-byte payload and checks that the name lands before the arguments
-exactly when the flag says it will.
+Kimi-K2 and Kimi-K3 do not name a call whose *arguments are still arriving*: a
+K2 entry is invisible until `<|tool_call_end|>` and a K3 call until
+`<|close|>call`, so on a large payload the name arrives with the arguments.
+A call short enough to fit inside `Region.head` is named early by all six,
+because the whole call is in the window and `parse_region` sees a finished one.
+Nothing declares which formats are which -- the property suite measures both
+facts independently (can the parse read a call in progress; did the name land
+before the arguments on an 800-byte payload) and asserts they agree. A class
+attribute used to stand in for this, outlived its only reader when the
+give-up probe below was reverted, and took these two paragraphs false with it.
 
 Arguments still wait for the region to close. SGLang streams those too, as
 JSON fragments; a response cut short then leaves the client holding an

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -305,8 +305,11 @@ enforced where the events are *sent* — twelve places across two endpoints —
 while the parser went on consuming the region, so the model's own words were
 deleted and nothing took their place: 89 characters of a 95-character answer,
 no event, `finish_reason: stop`. The rule now lives at the one place the
-parser is *asked*, as `suppress_calls`, which is also the right reading — the
-request said this cannot be a call, so it is prose.
+parser is *asked*, as `suppress_calls`. What that suppresses is dispatch: the
+region is read exactly as a permitted call's would be and only the calls are
+dropped, so the answer around them survives and the model's raw wire markup
+does not reach the client. A reply that was nothing but a forbidden call
+therefore has empty `content` — the model produced no answer.
 
 Not by using no parser at all, which is where the first fix for that went.
 Dropping the parser drops everything else a parser does, and a format whose
@@ -1033,6 +1036,7 @@ server without modification.
 | `atom/entrypoints/openai/marker_scanner.py` | `MarkerScanner` — the one rule for how much of a stream is safe to release |
 | `atom/entrypoints/openai/reasoning.py` | Splits the reasoning channel from the answer; `ReasoningChannel` carries the model's dialect and whether the output begins inside the channel, and has one accessor per delivery mode |
 | `atom/entrypoints/openai/reasoning_dialects.py` | The dialects, and `resolve_dialect`, which picks one from the chat template at startup |
+| `atom/entrypoints/openai/kimi_k3_tokens.py` | Kimi-K3's channel tokens, split by owner: what the reasoning stage strips and what only the tool parser may |
 | `atom/entrypoints/openai/tool_parser/stream.py` | The one reader: the engine both delivery modes run through |
 | `atom/entrypoints/openai/chat_encoders.py` | Renders the chat template, and the two startup probes of it: `render_probe_prompt` (what the prompt tells the model) and `chat_template_source` (what the template does with a reply) |
 | `atom/entrypoints/openai/tool_parser/registry.py` | Which format a model emits, resolved once at startup from its chat template |

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -133,13 +133,57 @@ Two waits are longer than that. Text inside the reasoning channel is held until
 its end marker — not a stall: it is reasoning, and it is delivered as
 `reasoning_content` as it arrives. And once a marker that *opens a tool-call
 region* appears, everything from it onward belongs to the format until it can
-parse the region. For a real call that is its closing tag; for an answer that
-merely quotes a marker it is end of stream. That is a known cost, measured on
-a GLM answer naming the tag at character 29 and then explaining for 1234 more:
-98% of it arrives in one frame at EOS, and "how do I make you call a tool" is
-a common question. Nothing is lost — the region is released verbatim once it
-turns out not to be a call — and `atom:stream_longest_silence_seconds` reports
-the wait while it happens.
+parse the region.
+
+##### What is held, and for how long
+
+The rule is that a byte is buffered only while its **destination field** is
+undecided — `content` or `tool_calls` — because an SSE frame cannot be taken
+back. Four cases, and only two of them wait:
+
+| Where the byte is | Held? | Until |
+|---|---|---|
+| Before any start marker | no | — `MarkerScanner`, bounded by the longest marker and asserted there |
+| Inside a region, before the name is legible | **yes** | the format can name a declared tool, usually the first 30–70 characters |
+| Inside a region, after that — the argument values | **yes** | the region closes |
+| After the region closed | no | — released as it arrives |
+
+The name goes out as soon as it is legible and the request declared it
+(`tool_call_start`), so a client learns *which* tool is being called at chunk
+7–24 rather than after the whole payload.
+
+**Argument values wait, deliberately.** vLLM and SGLang stream them as JSON
+fragments for their JSON-shaped formats; a response cut off by `max_tokens`
+then leaves the client accumulating an object it cannot parse. Buffering them
+means five of the six formats here hand back *valid* JSON even for a truncated
+call — the half-written value becomes a string — which streaming fragments
+gives up. (Kimi-K2 is the exception: it passes the model's bytes through, so a
+truncated call already yields `{"city": "Par`. That is a separate defect.)
+Both of those engines buffer for their tag-shaped formats too, K3 included, so
+this is not a gap against them.
+
+**The region closes on the call's own closer**, not on the wrapper's. Every
+format's grammar lists the call closer among the terminators of an argument
+value — `</function>` for Qwen, `</invoke>` for DSML and MiniMax,
+`<|close|>call` for K3 — so a model writing one inside a parameter ends the
+parameter, and the literal can never hide in a value. The *wrapper* closer
+(`</tool_call>`) can, which is why it serves only as a trigger to look and
+never as the answer. Declared as `CALL_SELF_CLOSERS`; `REGION_END_MARKERS`
+overrides it where a region is larger than one call, which is Kimi-K2's
+section.
+
+Getting that wrong is expensive and was: while only Kimi declared a region
+end, everything a model wrote *after* its tool call waited for end of stream —
+0 of 397 characters streamed on five of six formats, and "call a tool, then
+explain the result" is the ordinary agentic shape.
+
+**A region that never closes is still held to end of stream.** An answer that
+merely quotes its own opener is the case: measured on a GLM answer naming the
+tag at character 29 and then explaining for 1234 more, 98% arrives in one
+frame at EOS. Nothing is lost — the region is released verbatim once it turns
+out not to be a call — and `atom:stream_longest_silence_seconds` reports the
+wait while it happens. vLLM and SGLang both do the same here, and SGLang's K3
+detector drops the text rather than releasing it.
 
 A probe that gave up on a region producing nothing after N bytes was written
 for this and reverted. It rests on acceptance being monotone in how many bytes
@@ -152,6 +196,18 @@ reopened a region with a fresh budget: 1.19 ms to 18.2 s on a 250 KB answer,
 in the request coroutine. Fixing the latency needs the *format* to say "this
 can no longer become a call", which is a different question from "does not
 parse yet" and one no format answers today.
+
+A second version was written and reverted for the same reason: bounded to the
+256-byte peek window, asked once, and restricted to `tool_choice: "none"`
+where nothing would be dispatched anyway. It measured clean on every shape the
+corpus carries — and the corpus carries one form per format, because it is
+generated from `render_call`. DSML's direct-JSON body needs the whole object,
+so a real call with a payload past the window is invisible to any head-sized
+peek and would have gone out as text.
+`TestAGiveUpProbeStaysReverted` now carries that shape, with a positive
+control asserting DSML actually accepts it: the first draft of that test
+invented both shapes from this paragraph rather than from the parser, DSML
+accepted neither, and it therefore proved nothing.
 
 "Opens a region" is asked of the format, not assumed of every marker it
 declares. Kimi-K3 declares 16 and only two of them mean a tool call; the

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -188,6 +188,7 @@ Server-specific CLI arguments:
 | `--server-port` | `8000` | HTTP port (note: `--port` is for internal engine communication) |
 | `--timeout-keep-alive` | `5` | Seconds an idle keep-alive connection is held. Pooling clients hold their end longer (aiohttp defaults to 15s), so a caller that pauses for longer than this reuses a socket the server already closed and has to re-send. Raise it past the caller's idle window to avoid that |
 | `--disable-uvicorn-access-log` | off | Stop uvicorn logging a line per HTTP request. It copies a `LogRecord` and writes to the same stdout as the engine, on the event loop |
+| `--tool-call-parser` | `auto` | Tool-call wire format. `auto` reads it from the model's chat template at startup (Jinja, or a model-side `encoding/encoding_*.py`); a name — `dsml`, `glm`, `kimi`, `kimi_k3`, `minimax`, `qwen` — overrides. When neither resolves, tool calls are delivered as plain text and the startup log says so; the format is never guessed from output. An unknown name is refused rather than silently disabling tool parsing. Accepted by the atomesh entrypoint too |
 
 All `EngineArgs` arguments are also accepted (see Section 7 for the full list).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,11 @@
 # resolves its two AITER handles on first use), and every other third-party
 # import here is a declared dependency, so a plain CPU runner has them.
 
+import dataclasses
 import sys
 from itertools import count
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -25,6 +27,7 @@ if ATOM_ROOT not in sys.path:
 
 # ── 2. Import atom submodules ──────────────────────────────────────────────
 
+from atom.config import Config
 from atom.model_engine.block_manager import BlockManager
 from atom.model_engine.scheduler import Scheduler
 from atom.model_engine.sequence import Sequence
@@ -72,6 +75,48 @@ class MockConfig:
         defaults.update(overrides)
         for k, v in defaults.items():
             setattr(self, k, v)
+
+
+def atom_config_double(**overrides):
+    """A stand-in for `atom.config.Config`, with the real Config's fields.
+
+    Derived from `dataclasses.fields(Config)` rather than hand-listed, so a
+    field production adds arrives here with its real default instead of
+    raising `AttributeError` the first time a code path reads it. That is not
+    hypothetical: `topK.is_rocm_aiter_fusion_shared_expert_enabled_for_quant_
+    config` grew a read of `enable_dp_attention`, and the hand-built namespace
+    in `test_shared_expert_dispatch` had no such attribute -- four tests red on
+    every machine that can run them, which is only a machine with aiter,
+    because the module `importorskip`s it. CI has no aiter, so CI never saw
+    them and nobody was told.
+
+    `MockConfig` below is the older, narrower answer to the same question --
+    "exactly the attributes that BlockManager and Scheduler read" -- and it
+    can drift the same way. It is left alone because its callers assert on the
+    small surface it declares; new doubles should start here.
+
+    An override naming something that is not a Config field is refused. That
+    is the other direction of the same drift: a field renamed in production
+    leaves a test setting an attribute nothing reads, which passes and means
+    nothing.
+    """
+    values = {}
+    for f in dataclasses.fields(Config):
+        if f.default is not dataclasses.MISSING:
+            values[f.name] = f.default
+        elif f.default_factory is not dataclasses.MISSING:
+            values[f.name] = f.default_factory()
+        else:
+            # `model` and the `init=False` fields a real Config fills in from
+            # the checkpoint. A test that needs one overrides it.
+            values[f.name] = None
+    unknown = sorted(set(overrides) - set(values))
+    assert not unknown, (
+        f"not Config fields: {unknown}. Either the name is wrong or "
+        f"production renamed it and this override now sets nothing."
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
 
 
 # ── 4. Fixtures ────────────────────────────────────────────────────────────

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -26,6 +26,7 @@ from atom.entrypoints.openai.serving_anthropic import (
     completes_a_tool_call,
     tool_event_frames,
 )
+from atom.entrypoints.openai.tool_parser import ToolCallStreamParser
 from atom.entrypoints.openai.tool_parser.glm_tool_parser import GlmParser
 
 KINDS = ("text", "thinking", "tool_use")
@@ -193,7 +194,9 @@ class TestToolEventFrames:
 
     def test_content_before_a_call_lands_in_a_text_block(self):
         frames = list(
-            tool_event_frames([("content", "Checking."), self.START], AnthropicBlocks())
+            tool_event_frames(
+                [("content", "Checking."), self.START, self.ARGS], AnthropicBlocks()
+            )
         )
         payloads = [json.loads(f.split("data: ", 1)[1]) for f in frames]
         assert payloads[0]["type"] == "content_block_start"
@@ -203,13 +206,26 @@ class TestToolEventFrames:
             "content_block_delta",
             "content_block_stop",
             "content_block_start",
+            "content_block_delta",
         ]
-        assert payloads[-1]["content_block"]["type"] == "tool_use"
+        assert payloads[-2]["content_block"]["type"] == "tool_use"
 
     def test_the_call_carries_its_id_and_name(self):
-        frames = list(tool_event_frames([self.START], AnthropicBlocks()))
+        frames = list(tool_event_frames([self.START, self.ARGS], AnthropicBlocks()))
         block = json.loads(frames[0].split("data: ", 1)[1])["content_block"]
         assert block["id"] == "call_1" and block["name"] == "get_weather"
+
+    def test_a_name_with_no_arguments_puts_no_block_on_the_wire(self):
+        """`content_block_start` of type `tool_use` carries `"input": {}` and
+        is, on its own, a complete zero-argument call -- there is no frame for
+        "the name is known, the arguments are coming". So the name cannot be
+        sent early on this protocol, and a response that announced one and was
+        then cut off must leave nothing behind. It used to leave a
+        syntactically perfect call the model never made."""
+        assert self._kinds([("content", "hi"), self.START]) == [
+            "content_block_start",
+            "content_block_delta",
+        ]
 
     def test_an_unknown_event_type_is_ignored_not_crashed(self):
         assert self._kinds([("something_new", {})]) == []
@@ -332,15 +348,38 @@ class TestOneCallSpansTwoParserBatches:
         "<arg_value>Paris</arg_value></tool_call>"
     )
 
-    def _frames(self, chunk_size):
-        parser = GlmParser(tools=self.TOOLS)
+    def _frames(self, chunk_size, text=None, reasoning_at=None):
+        parser = ToolCallStreamParser(tools=self.TOOLS, parser_cls=GlmParser)
         blocks = AnthropicBlocks()
+        text = self.CALL if text is None else text
         out = []
-        for i in range(0, len(self.CALL), chunk_size):
-            batch = parser.process(self.CALL[i : i + chunk_size])
+        for i in range(0, len(text), chunk_size):
+            if reasoning_at is not None and i >= reasoning_at:
+                # One thinking segment, delivered between the name and the
+                # arguments. It closes whatever block was open, which is the
+                # whole point: the call's identity has to outlive that.
+                out += list(blocks.delta("thinking", "hm"))
+                reasoning_at = None
+            batch = parser.process(text[i : i + chunk_size])
             out += list(tool_event_frames(batch, blocks))
         out += list(tool_event_frames(parser.flush(), blocks))
         return [json.loads(f.split("data: ", 1)[1]) for f in out]
+
+    @pytest.mark.parametrize("chunk_size", [1, 7])
+    def test_a_thinking_block_in_between_does_not_lose_the_arguments(self, chunk_size):
+        """The shape that broke it: reasoning arriving after the name was
+        announced closed the tool block, and the id and name lived on that
+        block. The arguments then had nothing to open a block with and were
+        dropped -- `tool_use` with `input: {}` and `stop_reason: tool_use`,
+        while the same bytes returned `{"city": "Paris"}` unstreamed."""
+        frames = self._frames(chunk_size, reasoning_at=chunk_size)
+        deltas = [
+            p["delta"]["partial_json"]
+            for p in frames
+            if p["type"] == "content_block_delta"
+            and p["delta"]["type"] == "input_json_delta"
+        ]
+        assert "".join(deltas) == '{"city": "Paris"}'
 
     @pytest.mark.parametrize("chunk_size", [1, 7, len(CALL)])
     def test_the_arguments_reach_the_client(self, chunk_size):
@@ -369,21 +408,25 @@ class TestOneCallSpansTwoParserBatches:
         ]
         assert named and set(argued) <= set(named), (named, argued)
 
-    def test_a_call_that_ended_does_not_adopt_the_next_arguments(self):
-        """It survives a batch boundary, which is all it has to.
-
-        Nothing closes the block between the name (from `process`) and the
-        arguments (from `flush`), so surviving `close` was never needed --
-        and carrying it across one is what let a second block open on the
-        same id.
-        """
+    def test_arguments_for_a_call_that_was_never_named_are_dropped(self):
+        """Every call is keyed by the index it was named at, so a batch that
+        closes one block cannot make the next batch's arguments land on it --
+        and arguments for an index nobody named open nothing at all."""
         blocks = AnthropicBlocks()
         start = (
             "tool_call_start",
-            {"id": "call_1", "function": {"name": "get_weather", "arguments": ""}},
+            {
+                "index": 0,
+                "id": "call_1",
+                "function": {"name": "get_weather", "arguments": ""},
+            },
         )
-        orphan = ("tool_call_args", {"function": {"arguments": '{"city": "Rome"}'}})
-        list(tool_event_frames([start, ("tool_call_end", None)], blocks))
-        assert blocks.open_call is None
-        frames = list(tool_event_frames([orphan], blocks))
-        assert frames == [], "arguments were adopted by a call that had ended"
+        args = ("tool_call_args", {"index": 0, "function": {"arguments": "{}"}})
+        later = (
+            "tool_call_args",
+            {"index": 1, "function": {"arguments": '{"city": "Rome"}'}},
+        )
+        list(tool_event_frames([start, args, ("tool_call_end", None)], blocks))
+        assert blocks.open_call_index is None
+        frames = list(tool_event_frames([later], blocks))
+        assert frames == [], "arguments were adopted by a call that never existed"

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -20,7 +20,11 @@ import json
 
 import pytest
 
-from atom.entrypoints.openai.serving_anthropic import AnthropicBlocks
+from atom.entrypoints.openai.serving_anthropic import (
+    AnthropicBlocks,
+    starts_a_tool_call,
+    tool_event_frames,
+)
 
 KINDS = ("text", "thinking", "tool_use")
 
@@ -153,3 +157,73 @@ class TestAResponseIsNeverEmpty:
         blocks = AnthropicBlocks()
         list(blocks.open("text"))
         assert blocks.index == 0
+
+
+class TestToolEventFrames:
+    """The tool-parser's events as Anthropic frames, in one place.
+
+    This dispatch was written out twice in the streaming endpoint -- once for
+    `process` and once for `flush` -- twenty-two identical lines each. Two
+    copies of a dispatch is a fix that lands in one of them and says nothing,
+    which is the hazard `AnthropicBlocks` itself was extracted to remove. It
+    was also untestable there: the endpoint body is an async generator inside
+    a route handler no unit test reaches.
+    """
+
+    @staticmethod
+    def _kinds(events, blocks=None):
+        frames = list(tool_event_frames(events, blocks or AnthropicBlocks()))
+        return [json.loads(f.split("data: ", 1)[1])["type"] for f in frames]
+
+    START = (
+        "tool_call_start",
+        {"id": "call_1", "function": {"name": "get_weather", "arguments": ""}},
+    )
+    ARGS = ("tool_call_args", {"function": {"arguments": '{"city":'}})
+    END = ("tool_call_end", None)
+
+    def test_a_whole_call_opens_streams_and_closes(self):
+        assert self._kinds([self.START, self.ARGS, self.END]) == [
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+        ]
+
+    def test_content_before_a_call_lands_in_a_text_block(self):
+        frames = list(
+            tool_event_frames([("content", "Checking."), self.START], AnthropicBlocks())
+        )
+        payloads = [json.loads(f.split("data: ", 1)[1]) for f in frames]
+        assert payloads[0]["type"] == "content_block_start"
+        assert payloads[0]["content_block"]["type"] == "text"
+        # The text block is closed before the tool block opens.
+        assert [p["type"] for p in payloads[1:]] == [
+            "content_block_delta",
+            "content_block_stop",
+            "content_block_start",
+        ]
+        assert payloads[-1]["content_block"]["type"] == "tool_use"
+
+    def test_the_call_carries_its_id_and_name(self):
+        frames = list(tool_event_frames([self.START], AnthropicBlocks()))
+        block = json.loads(frames[0].split("data: ", 1)[1])["content_block"]
+        assert block["id"] == "call_1" and block["name"] == "get_weather"
+
+    def test_an_unknown_event_type_is_ignored_not_crashed(self):
+        assert self._kinds([("something_new", {})]) == []
+
+    def test_no_events_emit_nothing(self):
+        assert self._kinds([]) == []
+
+    @pytest.mark.parametrize(
+        "events, expected",
+        [
+            ([], False),
+            ([("content", "hi")], False),
+            ([("tool_call_args", {}), ("tool_call_end", None)], False),
+            ([("content", "hi"), START], True),
+        ],
+    )
+    def test_starts_a_tool_call_reads_the_batch(self, events, expected):
+        """`stop_reason` turns on this, and it is asked of both batches."""
+        assert starts_a_tool_call(events) is expected

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -267,14 +267,26 @@ class TestNoBlockWithoutAnIdAndAName:
     def test_arguments_with_no_name_open_nothing(self):
         assert self._blocks([self.ARGS, ("tool_call_end", None)]) == []
 
-    def test_text_between_the_name_and_the_arguments_keeps_both(self):
+    def test_one_call_never_arrives_as_two_blocks(self):
+        """Re-opening on the same id is worse than dropping the arguments.
+
+        A client iterating content blocks sees two `tool_use` entries with one
+        id, the first carrying no input -- so it runs `get_weather({})` and
+        then `get_weather({"city": "Paris"})`. Anthropic has no spelling for
+        "the block you already closed, continued".
+
+        The shape is not reachable from any registered parser -- driven over
+        every format's real call, three leading shapes and every chunking,
+        content never once landed between an announced name and its arguments
+        -- so this pins the degradation rather than a behaviour anyone gets.
+        """
         blocks = self._blocks(
             [self.START, ("content", "oops"), self.ARGS, ("tool_call_end", None)]
         )
         tool_blocks = [b for b in blocks if b["type"] == "tool_use"]
-        assert len(tool_blocks) == 2, "the re-opened block went missing"
-        for b in tool_blocks:
-            assert b["id"] == "call_1" and b["name"] == "get_weather"
+        assert len(tool_blocks) == 1, f"one call, {len(tool_blocks)} blocks"
+        ids = [b["id"] for b in tool_blocks]
+        assert len(set(ids)) == len(ids), f"a tool id was used twice: {ids}"
 
     def test_no_tool_use_block_is_ever_nameless(self):
         for events in (
@@ -358,11 +370,12 @@ class TestOneCallSpansTwoParserBatches:
         assert named and set(argued) <= set(named), (named, argued)
 
     def test_a_call_that_ended_does_not_adopt_the_next_arguments(self):
-        """The call outlives a block close, but not its own end.
+        """It survives a batch boundary, which is all it has to.
 
-        Surviving `close` is what fixes the case above; surviving
-        `tool_call_end` would hand a later orphan batch of arguments to a
-        call the client has already been told is finished.
+        Nothing closes the block between the name (from `process`) and the
+        arguments (from `flush`), so surviving `close` was never needed --
+        and carrying it across one is what let a second block open on the
+        same id.
         """
         blocks = AnthropicBlocks()
         start = (

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -234,3 +234,53 @@ class TestToolEventFrames:
         to close, so a name alone does not mean the client has a tool to run.
         """
         assert completes_a_tool_call(events) is expected
+
+
+class TestNoBlockWithoutAnIdAndAName:
+    """`delta("tool_use", ...)` opens a block when none is open, and it was
+    given nothing to open one with.
+
+    Anything landing between a call's name and its arguments -- text, another
+    kind, a stray event -- re-opened the tool_use block with `id: ""` and
+    `name: ""`. That is syntactically a complete tool_use: a client cannot
+    dispatch it (no name) and cannot return a result for it (no id), and
+    Claude Code treats a well-formed zero-argument block as a call to make.
+    """
+
+    START = (
+        "tool_call_start",
+        {"id": "call_1", "function": {"name": "get_weather", "arguments": ""}},
+    )
+    ARGS = ("tool_call_args", {"function": {"arguments": '{"city": "Paris"}'}})
+
+    @staticmethod
+    def _blocks(events):
+        out = []
+        for frame in tool_event_frames(events, AnthropicBlocks()):
+            payload = json.loads(frame.split("data: ", 1)[1])
+            if payload["type"] == "content_block_start":
+                out.append(payload["content_block"])
+        return out
+
+    def test_arguments_with_no_name_open_nothing(self):
+        assert self._blocks([self.ARGS, ("tool_call_end", None)]) == []
+
+    def test_text_between_the_name_and_the_arguments_keeps_both(self):
+        blocks = self._blocks(
+            [self.START, ("content", "oops"), self.ARGS, ("tool_call_end", None)]
+        )
+        tool_blocks = [b for b in blocks if b["type"] == "tool_use"]
+        assert len(tool_blocks) == 2, "the re-opened block went missing"
+        for b in tool_blocks:
+            assert b["id"] == "call_1" and b["name"] == "get_weather"
+
+    def test_no_tool_use_block_is_ever_nameless(self):
+        for events in (
+            [self.ARGS],
+            [self.ARGS, self.ARGS],
+            [self.START, ("content", "x"), self.ARGS],
+            [("tool_call_end", None), self.ARGS],
+        ):
+            for block in self._blocks(events):
+                if block["type"] == "tool_use":
+                    assert block["id"] and block["name"], block

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -17,6 +17,7 @@ out, whatever order the kinds arrive in.
 from __future__ import annotations
 
 import json
+from typing import ClassVar
 
 import pytest
 
@@ -25,6 +26,7 @@ from atom.entrypoints.openai.serving_anthropic import (
     completes_a_tool_call,
     tool_event_frames,
 )
+from atom.entrypoints.openai.tool_parser.glm_tool_parser import GlmParser
 
 KINDS = ("text", "thinking", "tool_use")
 
@@ -284,3 +286,91 @@ class TestNoBlockWithoutAnIdAndAName:
             for block in self._blocks(events):
                 if block["type"] == "tool_use":
                     assert block["id"] and block["name"], block
+
+
+class TestOneCallSpansTwoParserBatches:
+    """A name announced early and its arguments do not arrive together.
+
+    `tool_event_frames` runs once per parser batch, and announcing the name as
+    soon as the region reveals it puts the two events that describe one call
+    in different batches -- the name from `process`, the arguments from
+    `flush`. Which call is open therefore cannot be a local in that function,
+    and while it was, every streamed tool call on `/v1/messages` reached the
+    client as `input: {}` with `stop_reason: tool_use`. Claude Code ran the
+    tool with no arguments.
+
+    Driven through a real parser rather than a hand-built event list: the
+    tests above pass one batch each and so could not see this.
+    """
+
+    TOOLS: ClassVar[list] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    CALL = (
+        "<tool_call>get_weather<arg_key>city</arg_key>"
+        "<arg_value>Paris</arg_value></tool_call>"
+    )
+
+    def _frames(self, chunk_size):
+        parser = GlmParser(tools=self.TOOLS)
+        blocks = AnthropicBlocks()
+        out = []
+        for i in range(0, len(self.CALL), chunk_size):
+            batch = parser.process(self.CALL[i : i + chunk_size])
+            out += list(tool_event_frames(batch, blocks))
+        out += list(tool_event_frames(parser.flush(), blocks))
+        return [json.loads(f.split("data: ", 1)[1]) for f in out]
+
+    @pytest.mark.parametrize("chunk_size", [1, 7, len(CALL)])
+    def test_the_arguments_reach_the_client(self, chunk_size):
+        deltas = [
+            p["delta"]["partial_json"]
+            for p in self._frames(chunk_size)
+            if p["type"] == "content_block_delta"
+            and p["delta"]["type"] == "input_json_delta"
+        ]
+        assert "".join(deltas) == '{"city": "Paris"}'
+
+    @pytest.mark.parametrize("chunk_size", [1, 7, len(CALL)])
+    def test_they_land_in_the_block_that_carries_the_name(self, chunk_size):
+        frames = self._frames(chunk_size)
+        named = [
+            p["index"]
+            for p in frames
+            if p["type"] == "content_block_start"
+            and p["content_block"]["name"] == "get_weather"
+        ]
+        argued = [
+            p["index"]
+            for p in frames
+            if p["type"] == "content_block_delta"
+            and p["delta"]["type"] == "input_json_delta"
+        ]
+        assert named and set(argued) <= set(named), (named, argued)
+
+    def test_a_call_that_ended_does_not_adopt_the_next_arguments(self):
+        """The call outlives a block close, but not its own end.
+
+        Surviving `close` is what fixes the case above; surviving
+        `tool_call_end` would hand a later orphan batch of arguments to a
+        call the client has already been told is finished.
+        """
+        blocks = AnthropicBlocks()
+        start = (
+            "tool_call_start",
+            {"id": "call_1", "function": {"name": "get_weather", "arguments": ""}},
+        )
+        orphan = ("tool_call_args", {"function": {"arguments": '{"city": "Rome"}'}})
+        list(tool_event_frames([start, ("tool_call_end", None)], blocks))
+        assert blocks.open_call is None
+        frames = list(tool_event_frames([orphan], blocks))
+        assert frames == [], "arguments were adopted by a call that had ended"

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -122,3 +122,34 @@ class TestBlockFraming:
 
     def test_closing_before_anything_opened_emits_nothing(self):
         assert list(AnthropicBlocks().close()) == []
+
+
+class TestAResponseIsNeverEmpty:
+    """A reply that produced only reasoning still says something.
+
+    `/v1/messages` drops reasoning when the request did not ask for thinking.
+    That was safe while an unseeded filter sent most output down the content
+    channel; once seeding is right, a reasoning model stopped at `max_tokens`
+    produces *nothing else*, and the client got pings, an empty text block and
+    `stop_reason=end_turn`. Measured: 20 pings, zero delta frames.
+
+    The block machine cannot fix this on its own -- the decision is the
+    endpoint's -- so what is pinned here is the shape the endpoint relies on:
+    an untouched machine reports `index == 0`, which is how it knows nothing
+    was delivered.
+    """
+
+    def test_an_untouched_machine_reports_nothing_delivered(self):
+        assert AnthropicBlocks().index == 0
+
+    def test_one_delivered_block_advances_the_index(self):
+        blocks = AnthropicBlocks()
+        list(blocks.delta("text", "hi"))
+        list(blocks.close())
+        assert blocks.index == 1
+
+    def test_opening_without_delivering_does_not_advance_it(self):
+        """The endpoint opens a trailing text block before it checks."""
+        blocks = AnthropicBlocks()
+        list(blocks.open("text"))
+        assert blocks.index == 0

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Anthropic content blocks: one open at a time, and nothing falls between them.
+
+A response is framed as indexed blocks of a kind, and a change of kind is a
+close and an open. Those transitions used to be written out at each of the
+four places a segment could arrive, each covering the subset its author
+needed — and the one nobody needed, text -> thinking, was missing. A reasoning
+segment arriving after content had started matched no branch and was dropped
+with no error and no log.
+
+So the properties here are about totality: every segment handed in comes back
+out, whatever order the kinds arrive in.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from atom.entrypoints.openai.serving_anthropic import AnthropicBlocks
+
+KINDS = ("text", "thinking", "tool_use")
+
+
+def events(frames: list[str]) -> list[tuple[str, int, str]]:
+    """(event name, block index, delta text) for each frame."""
+    out = []
+    for f in frames:
+        name = f.split("event: ", 1)[1].split("\n", 1)[0]
+        data = json.loads(f.split("data: ", 1)[1])
+        delta = data.get("delta", {})
+        text = delta.get("text") or delta.get("thinking") or delta.get("partial_json")
+        out.append((name, data["index"], text or ""))
+    return out
+
+
+def drive(pairs: list[tuple[str, str]]) -> list[str]:
+    """Feed (kind, text) in order and close at the end, as the server does."""
+    blocks = AnthropicBlocks()
+    frames: list[str] = []
+    for kind, text in pairs:
+        frames += list(blocks.delta(kind, text))
+    frames += list(blocks.close())
+    return frames
+
+
+class TestNothingIsDropped:
+    def test_reasoning_after_content_is_delivered(self):
+        """The bug, stated as a test.
+
+        A model that answers, opens a `<think>` block and answers again used to
+        lose the whole reasoning block: `started_text` was set, `started_thinking`
+        was not, and neither branch fired.
+        """
+        frames = drive(
+            [
+                ("text", "Let me look that up. "),
+                ("thinking", "Paris weather."),
+                ("text", "Sunny."),
+            ]
+        )
+        thinking = "".join(t for name, _, t in events(frames) if "delta" in name and t)
+        assert "Paris weather." in thinking
+
+    @pytest.mark.parametrize("first", KINDS)
+    @pytest.mark.parametrize("second", KINDS)
+    def test_every_kind_change_delivers_both_sides(self, first, second):
+        """Nine orderings, none of which may swallow anything."""
+        frames = drive([(first, "AAA"), (second, "BBB")])
+        delivered = "".join(t for _, _, t in events(frames))
+        assert "AAA" in delivered and "BBB" in delivered
+
+    def test_text_handed_in_is_text_handed_out(self):
+        pairs = [
+            ("text", "one "),
+            ("thinking", "two "),
+            ("text", "three "),
+            ("tool_use", "{}"),
+        ]
+        delivered = "".join(t for _, _, t in events(drive(pairs)))
+        assert delivered == "".join(t for _, t in pairs)
+
+
+class TestBlockFraming:
+    def test_a_block_is_closed_before_the_next_one_opens(self):
+        names = [n for n, _, _ in events(drive([("text", "a"), ("thinking", "b")]))]
+        # start, delta, [signature] stop, start, delta, ... and never two
+        # starts without a stop between them.
+        depth = 0
+        for n in names:
+            if n == "content_block_start":
+                assert depth == 0, "a block opened while another was open"
+                depth = 1
+            elif n == "content_block_stop":
+                depth = 0
+        assert depth == 0, "the last block was left open"
+
+    def test_indices_are_unique_and_ascending(self):
+        idx = [
+            i
+            for n, i, _ in events(
+                drive([("text", "a"), ("thinking", "b"), ("text", "c")])
+            )
+        ]
+        starts = sorted({i for i in idx})
+        assert idx == sorted(idx) and starts == list(range(len(starts)))
+
+    def test_a_thinking_block_signs_off_before_it_stops(self):
+        """Anthropic requires the signature delta while the block is still open."""
+        names = [n for n, _, _ in events(drive([("thinking", "why"), ("text", "so")]))]
+        stop = names.index("content_block_stop")
+        assert names[stop - 1] == "content_block_delta"
+
+    def test_closing_twice_emits_nothing_the_second_time(self):
+        blocks = AnthropicBlocks()
+        list(blocks.delta("text", "a"))
+        assert list(blocks.close())
+        assert list(blocks.close()) == []
+
+    def test_closing_before_anything_opened_emits_nothing(self):
+        assert list(AnthropicBlocks().close()) == []

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -22,7 +22,7 @@ import pytest
 
 from atom.entrypoints.openai.serving_anthropic import (
     AnthropicBlocks,
-    starts_a_tool_call,
+    completes_a_tool_call,
     tool_event_frames,
 )
 
@@ -220,10 +220,17 @@ class TestToolEventFrames:
         [
             ([], False),
             ([("content", "hi")], False),
-            ([("tool_call_args", {}), ("tool_call_end", None)], False),
-            ([("content", "hi"), START], True),
+            # A name and nothing else: announced early, then the stream was
+            # cut off. Not a usable call, so not `tool_use`.
+            ([("content", "hi"), START], False),
+            ([START, ARGS], True),
+            ([("tool_call_args", {}), ("tool_call_end", None)], True),
         ],
     )
-    def test_starts_a_tool_call_reads_the_batch(self, events, expected):
-        """`stop_reason` turns on this, and it is asked of both batches."""
-        assert starts_a_tool_call(events) is expected
+    def test_completes_a_tool_call_reads_the_batch(self, events, expected):
+        """`stop_reason` turns on this, and it is asked of both batches.
+
+        Keyed on the arguments: a name can be sent before the call is known
+        to close, so a name alone does not mean the client has a tool to run.
+        """
+        assert completes_a_tool_call(events) is expected

--- a/tests/entrypoints/test_anthropic_blocks.py
+++ b/tests/entrypoints/test_anthropic_blocks.py
@@ -21,13 +21,21 @@ from typing import ClassVar
 
 import pytest
 
+from atom.entrypoints.openai.reasoning import ReasoningChannel
+from atom.entrypoints.openai.reasoning_dialects import DIALECTS
 from atom.entrypoints.openai.serving_anthropic import (
     AnthropicBlocks,
+    _blocks_in_order,
+    build_anthropic_response,
     completes_a_tool_call,
+    read_whole_blocks,
+    stream_failure_frames,
+    stream_message_start,
     tool_event_frames,
 )
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser
 from atom.entrypoints.openai.tool_parser.glm_tool_parser import GlmParser
+from entrypoints.wire_corpus import REAL_CALLS, TYPED_TOOLS
 
 KINDS = ("text", "thinking", "tool_use")
 
@@ -430,3 +438,203 @@ class TestOneCallSpansTwoParserBatches:
         assert blocks.open_call_index is None
         frames = list(tool_event_frames([later], blocks))
         assert frames == [], "arguments were adopted by a call that never existed"
+
+
+# ── The two delivery modes must build the same blocks ──────────────────
+
+
+def blocks_from_frames(frames: list[str]) -> list[dict]:
+    """The blocks a client accumulates from the stream."""
+    out: list[dict] = []
+    for f in frames:
+        name = f.split("event: ", 1)[1].split("\n", 1)[0]
+        data = json.loads(f.split("data: ", 1)[1])
+        if name == "content_block_start":
+            out.append(dict(data["content_block"]))
+        elif name == "content_block_delta":
+            delta, blk = data["delta"], out[-1]
+            for key in ("text", "thinking"):
+                if key in delta:
+                    blk[key] = blk.get(key, "") + delta[key]
+            if "partial_json" in delta:
+                blk["_json"] = blk.get("_json", "") + delta["partial_json"]
+    for blk in out:
+        if "_json" in blk:
+            raw = blk.pop("_json")
+            try:
+                blk["input"] = json.loads(raw or "{}")
+            except json.JSONDecodeError:
+                blk["input"] = raw
+    return out
+
+
+def shape_of(blocks: list[dict]) -> list[tuple]:
+    """Type and payload only -- a thinking block's signature is random."""
+    return [
+        (b["type"], b.get("text", b.get("thinking", b.get("input")))) for b in blocks
+    ]
+
+
+def stream_side(raw: str, channel, parser_cls, tools=None) -> list[dict]:
+    """The server's streaming loop, over one chunk.
+
+    Copied in shape from `api_server`'s Anthropic branch on purpose: phase 1
+    is the reasoning filter, phase 2 is the tool parser *on the content
+    segments only*, and the interleaving of the two is what a client sees.
+    """
+    rf, tp = channel.stream(), ToolCallStreamParser(tools=tools, parser_cls=parser_cls)
+    blocks, frames = AnthropicBlocks(), []
+    for field, text in rf.process(raw) + rf.flush():
+        if not text:
+            continue
+        if field == "reasoning_content":
+            frames += list(blocks.delta("thinking", text))
+        else:
+            frames += list(tool_event_frames(tp.process(text), blocks))
+    frames += list(tool_event_frames(tp.flush(), blocks))
+    frames += list(blocks.close())
+    return blocks_from_frames(frames)
+
+
+def nonstream_side(raw: str, channel, parser_cls, tools=None) -> list[dict]:
+    """The same generation through `stream=false`, as `api_server` builds it."""
+    events = read_whole_blocks(channel, parser_cls, raw, tools)
+    return build_anthropic_response(
+        request_id="r", model="m", events=events, stop_reason="end_turn"
+    )["content"]
+
+
+class TestBothDeliveryModesBuildTheSameBlocks:
+    """`/v1/messages` renders blocks in order, so order is part of the answer.
+
+    The streaming branch interleaves as the model wrote: reasoning filter
+    first, tool parser on the content segments it yields. The non-streaming
+    branch calls `split()`, which returns `(reasoning, content)` -- position
+    gone at that line -- and then rebuilds blocks from the flat pair. So a
+    model that answers, thinks, and answers again came back as two blocks with
+    the two answers glued together where streaming sent three.
+
+    Parity is the right property here, unlike the reasoning split one stage
+    down where both readers were wrong together: streaming is correct and
+    non-streaming is not, so the canonical shape is asserted outright too.
+    """
+
+    SHAPES: ClassVar[dict[str, str]] = {
+        "answer only": "The answer is 42.",
+        "reasoning then answer": "<think>hmm</think>The answer is 42.",
+        "answer, reasoning, answer": "Sure.<think>hmm</think>Answer.",
+        "reasoning only": "<think>hmm</think>",
+        "answer then a call": "Checking.{call}",
+        "reasoning, answer, call": "<think>hmm</think>Checking.{call}",
+        "call then answer": "{call}All done.",
+        # The shape this branch has broken twice: a sentence the model wrote
+        # between two calls, which an extra span competing for a call hoists
+        # in front of both.
+        "call, sentence, call": "{call}Now Rome.{other}",
+        "reasoning between two calls": "{call}<think>and Rome</think>{other}",
+    }
+
+    @staticmethod
+    def _channel():
+        return ReasoningChannel(dialect=DIALECTS[2], starts_open=False)
+
+    @pytest.mark.parametrize("name", sorted(SHAPES))
+    def test_the_block_sequence_is_identical(self, name):
+        raw = self.SHAPES[name].format(
+            call=REAL_CALLS["glm"],
+            other=REAL_CALLS["glm"].replace("get_weather", "get_time"),
+        )
+        ch = self._channel()
+        streamed = shape_of(stream_side(raw, ch, GlmParser, TYPED_TOOLS))
+        whole = shape_of(nonstream_side(raw, ch, GlmParser, TYPED_TOOLS))
+        assert whole == streamed, (
+            f"{name}: stream=false built {whole}\n"
+            f"{' ' * len(name)}  stream=true  built {streamed}"
+        )
+
+    def test_and_the_order_is_the_one_the_model_wrote(self):
+        """The canonical shape, asserted rather than only compared.
+
+        Both paths agreeing on the wrong order would satisfy the property
+        above; this says which order is right.
+        """
+        ch = self._channel()
+        raw = "Sure.<think>hmm</think>Answer."
+        assert shape_of(stream_side(raw, ch, None)) == [
+            ("text", "Sure."),
+            ("thinking", "hmm"),
+            ("text", "Answer."),
+        ]
+
+    def test_and_a_call_whose_arguments_are_not_an_object_keeps_them(self):
+        """Kimi-K2 passes the wire bytes through, so `arguments` need not be a
+        JSON object. Streaming forwards them and the SDK accumulates the real
+        value; the non-streaming builder replaced anything but a dict with
+        `{}`, so the tool was invoked with no arguments on one path and the
+        right ones on the other -- silently, with no log."""
+        events = [
+            (
+                "tool_call_start",
+                {
+                    "index": 0,
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "t", "arguments": ""},
+                },
+            ),
+            ("tool_call_args", {"index": 0, "function": {"arguments": "[1, 2]"}}),
+        ]
+        streamed = shape_of(
+            blocks_from_frames(list(tool_event_frames(events, AnthropicBlocks())))
+        )
+        whole = shape_of(_blocks_in_order(events))
+        assert whole == streamed == [("tool_use", [1, 2])]
+
+
+class TestAStreamThatFailedStillOwesTheClientAWholeMessage:
+    """The error tail, which the endpoint used to write out inline.
+
+    It emitted `error` / `message_delta` / `message_stop` without checking
+    whether `message_start` had gone out. The flag is only set inside the
+    loop, after the first `await stream_collector.get()` returns -- so an
+    engine error, a detokenizer failure or an abort surfacing on that first
+    call produced a stream that never opened, and the SDK raises on a
+    `message_delta` arriving before `message_start`. The client got an
+    SDK-internal error instead of the `error` frame this exists to deliver.
+    """
+
+    @staticmethod
+    def _names(frames):
+        return [f.split("event: ", 1)[1].split("\n", 1)[0] for f in frames]
+
+    def test_it_opens_the_message_when_nothing_opened_it(self):
+        frames = list(
+            stream_failure_frames(
+                RuntimeError("boom"),
+                AnthropicBlocks(),
+                0,
+                opening=stream_message_start("r", "m", 0, 0),
+            )
+        )
+        names = self._names(frames)
+        assert names[0] == "message_start", names
+        assert names[-1] == "message_stop", names
+        assert "error" in names
+
+    def test_but_does_not_open_it_twice(self):
+        frames = list(
+            stream_failure_frames(
+                RuntimeError("boom"), AnthropicBlocks(), 0, opening=None
+            )
+        )
+        names = self._names(frames)
+        assert "message_start" not in names, names
+        assert names[-1] == "message_stop", names
+
+    def test_and_closes_a_block_that_was_left_open(self):
+        blocks = AnthropicBlocks()
+        list(blocks.delta("text", "half an ans"))
+        frames = list(
+            stream_failure_frames(RuntimeError("boom"), blocks, 0, opening=None)
+        )
+        assert self._names(frames)[0] == "content_block_stop", self._names(frames)

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -588,7 +588,7 @@ class TestThinkingIsAnsweredInThePrompt:
     `include_reasoning` only suppresses the field after the split.
     """
 
-    TOGGLE = ("enable_thinking", False)
+    TOGGLE = ("enable_thinking", False, True)
 
     class Req:
         def __init__(self, thinking):
@@ -600,13 +600,14 @@ class TestThinkingIsAnsweredInThePrompt:
         )
         assert kwargs == {"enable_thinking": False}
 
-    def test_enabled_leaves_the_template_alone(self):
-        assert (
-            api_server.anthropic_template_kwargs(
-                self.Req({"type": "enabled"}), self.TOGGLE
-            )
-            == {}
+    def test_enabled_writes_the_on_value(self):
+        """Both directions go through the resolved name. Writing a hardcoded
+        `thinking=True` here was a no-op on every template that reads another
+        one, so an explicit opt-in was discarded against a server default."""
+        kwargs = api_server.anthropic_template_kwargs(
+            self.Req({"type": "enabled"}), self.TOGGLE
         )
+        assert kwargs == {"enable_thinking": True}
 
     def test_an_absent_field_is_unstated_not_off(self):
         """Anthropic defaults to off, but reading absence as "switch this

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -541,9 +541,35 @@ class TestTheStopReasonTellsTheTruth:
         """
         src = pathlib.Path(api_server.__file__).read_text()
         assert (
-            src.count("anthropic_stop_reason(") >= 3
+            src.count("anthropic_stop_reason") >= 4
         ), "anthropic_stop_reason is defined but not called by both paths"
-        assert "stop_reason=(" in src, "the non-streaming response omits stop_reason"
+        assert (
+            "stop_reason=anthropic_stop_reason_with_calls(" in src
+        ), "the non-streaming response omits stop_reason"
+
+    @pytest.mark.parametrize(
+        "engine_reason, has_calls, expected",
+        [
+            ("max_tokens", True, "max_tokens"),
+            ("max_tokens", False, "max_tokens"),
+            ("eos", True, "tool_use"),
+            ("eos", False, "end_turn"),
+            ("stop_163586", True, "tool_use"),
+        ],
+    )
+    def test_being_cut_short_outranks_having_made_a_call(
+        self, engine_reason, has_calls, expected
+    ):
+        """`tool_use` says "act on this"; `max_tokens` says "this is not all of
+        it". A response cut off mid-call parses to a call with a silently
+        truncated argument value -- every format's unclosed-region branch
+        exists to salvage exactly that -- and reporting `tool_use` for it told
+        the client to run a tool with half its arguments and no sign anything
+        was missing."""
+        assert (
+            api_server.anthropic_stop_reason_with_calls(engine_reason, has_calls)
+            == expected
+        )
 
 
 class TestTheOffSwitchIsRecognised:
@@ -661,13 +687,18 @@ class TestSeparationIsUnconditional:
         _, calls = parse_tool_calls(body, None, parser_cls=QwenXmlParser)
         assert len(calls) == 1
 
-    @pytest.mark.parametrize("helper", ["separate_reasoning", "ReasoningFilter"])
+    @pytest.mark.parametrize("helper", [".split(", ".stream("])
     def test_neither_path_gates_it(self, helper):
         """Both endpoint bodies are unreachable from a unit test, so this
         counts call sites and asserts the gate that used to wrap them is
-        gone."""
+        gone.
+
+        Spelled as the two `ReasoningChannel` accessors: separating is now one
+        object with one method per delivery mode, and the endpoint reaches the
+        module-level helpers through it rather than by name.
+        """
         src = pathlib.Path(api_server.__file__).read_text()
-        assert helper + "(" in src
+        assert helper in src
         assert "anthropic_reasoning_split" not in src
         assert "anthropic_reasoning_filter" not in src
         assert "anthropic_tool_format" not in src

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -241,6 +241,7 @@ class TestBuildAnthropicResponse:
             content_text="Hello!",
             input_tokens=10,
             output_tokens=5,
+            stop_reason="end_turn",
         )
         assert resp["type"] == "message"
         assert resp["role"] == "assistant"
@@ -261,6 +262,7 @@ class TestBuildAnthropicResponse:
             reasoning_content="Let me think about this...",
             input_tokens=20,
             output_tokens=15,
+            stop_reason="end_turn",
         )
         assert len(resp["content"]) == 2
         assert resp["content"][0]["type"] == "thinking"
@@ -273,6 +275,7 @@ class TestBuildAnthropicResponse:
             request_id="test789",
             model="m",
             content_text="Direct answer.",
+            stop_reason="end_turn",
         )
         assert len(resp["content"]) == 1
         assert resp["content"][0]["type"] == "text"
@@ -290,6 +293,7 @@ class TestBuildAnthropicResponse:
             model="m",
             content_text="Let me read that file.",
             tool_calls=[tc],
+            stop_reason="tool_use",
         )
         assert resp["stop_reason"] == "tool_use"
         types = [b["type"] for b in resp["content"]]
@@ -314,10 +318,38 @@ class TestBuildAnthropicResponse:
             content_text="I'll run a command.",
             reasoning_content="The user wants to list files.",
             tool_calls=[tc],
+            stop_reason="tool_use",
         )
         types = [b["type"] for b in resp["content"]]
         assert types == ["thinking", "text", "tool_use"]
         assert resp["stop_reason"] == "tool_use"
+
+    def test_the_caller_s_stop_reason_is_the_one_returned(self):
+        """It used to be overwritten whenever there were tool calls, which
+        discarded the answer the call site had already computed: a response
+        cut off at `max_tokens` mid-call came back as an ordinary `tool_use`
+        with silently truncated arguments, disagreeing with the streaming path
+        for the same generation. Checked by value; the test this replaces
+        grepped the source for the call and passed while the value was thrown
+        away."""
+        from atom.entrypoints.openai.tool_parser import ToolCall
+
+        tc = ToolCall(
+            id="call_3",
+            type="function",
+            function={"name": "bash", "arguments": '{"command": "l'},
+        )
+        for asked in ("max_tokens", "tool_use", "end_turn", "stop_sequence"):
+            resp = build_anthropic_response(
+                request_id="r",
+                model="m",
+                content_text="",
+                tool_calls=[tc],
+                stop_reason=asked,
+            )
+            assert (
+                resp["stop_reason"] == asked
+            ), f"asked for {asked!r}, got {resp['stop_reason']!r}"
 
     def test_response_empty_content_with_tool_call(self):
         from atom.entrypoints.openai.tool_parser import ToolCall
@@ -332,6 +364,7 @@ class TestBuildAnthropicResponse:
             model="m",
             content_text="",
             tool_calls=[tc],
+            stop_reason="tool_use",
         )
         types = [b["type"] for b in resp["content"]]
         assert "tool_use" in types
@@ -725,24 +758,22 @@ class TestASwitchlessModelStillHonoursDisabled:
             self.thinking = thinking
 
     @pytest.mark.parametrize(
-        "thinking, toggle, expected",
+        "thinking, expected",
         [
-            ({"type": "disabled"}, None, True),
-            # Answered in the prompt instead, which is strictly better.
-            ({"type": "disabled"}, TOGGLE, False),
-            # Absent is unstated at both layers or neither.
-            (None, None, False),
-            (None, TOGGLE, False),
-            ({"type": "enabled"}, None, False),
+            ({"type": "disabled"}, True),
+            # Anthropic's default is thinking-off, so a client that never sent
+            # the field has no reason to expect `thinking` blocks -- and one
+            # that validates block types or verifies the signature rejects
+            # them. What goes in the *prompt* answers a different question and
+            # still leaves an absent field alone.
+            (None, True),
+            ({"type": "enabled"}, False),
+            ({}, True),
         ],
-        ids=["switchless-off", "switched-off", "absent", "absent-switched", "on"],
+        ids=["off", "absent", "on", "empty"],
     )
-    def test_only_an_explicit_opt_out_with_nowhere_else_to_go(
-        self, thinking, toggle, expected
-    ):
-        assert (
-            api_server.anthropic_drop_reasoning(self.Req(thinking), toggle) is expected
-        )
+    def test_the_client_is_shown_reasoning_only_if_it_asked(self, thinking, expected):
+        assert api_server.anthropic_drop_reasoning(self.Req(thinking)) is expected
 
     def test_both_endpoint_paths_consult_it(self):
         """Read off the syntax tree, not grepped for: a literal check passes

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -233,12 +233,45 @@ class TestAnthropicToOpenAITools:
 # ============================================================================
 
 
+def say(text):
+    return ("content", text)
+
+
+def think(text):
+    return ("reasoning", text)
+
+
+def call(cid, name, arguments):
+    """The two events one call is made of, as the engine emits them."""
+    return [
+        (
+            "tool_call_start",
+            {
+                "index": 0,
+                "id": cid,
+                "type": "function",
+                "function": {"name": name, "arguments": ""},
+            },
+        ),
+        ("tool_call_args", {"index": 0, "function": {"arguments": arguments}}),
+    ]
+
+
 class TestBuildAnthropicResponse:
+    """The builder, driven the way the endpoint drives it.
+
+    These used to pass `(content_text, reasoning_content, tool_calls)` and
+    exercised a second block builder that lived beside `_blocks_in_order` --
+    two orderings of one wire format, which is how the reasoning block came to
+    be prepended ahead of everything. There is one builder now, so the inputs
+    here are the events the engine actually produces.
+    """
+
     def test_basic_response(self):
         resp = build_anthropic_response(
             request_id="test123",
             model="test-model",
-            content_text="Hello!",
+            events=[say("Hello!")],
             input_tokens=10,
             output_tokens=5,
             stop_reason="end_turn",
@@ -247,81 +280,68 @@ class TestBuildAnthropicResponse:
         assert resp["role"] == "assistant"
         assert resp["model"] == "test-model"
         assert resp["id"] == "msg_test123"
-        assert len(resp["content"]) == 1
-        assert resp["content"][0]["type"] == "text"
-        assert resp["content"][0]["text"] == "Hello!"
+        assert resp["content"] == [{"type": "text", "text": "Hello!"}]
         assert resp["usage"]["input_tokens"] == 10
         assert resp["usage"]["output_tokens"] == 5
         assert resp["stop_reason"] == "end_turn"
 
-    def test_response_with_reasoning(self):
+    def test_reasoning_lands_where_the_model_put_it(self):
+        """Not simply "first". The old builder prepended it unconditionally,
+        which is right only when the model thought before saying anything."""
         resp = build_anthropic_response(
             request_id="test456",
-            model="test-model",
-            content_text="The answer is 42.",
-            reasoning_content="Let me think about this...",
-            input_tokens=20,
-            output_tokens=15,
+            model="m",
+            events=[think("Let me think..."), say("The answer is 42.")],
             stop_reason="end_turn",
         )
-        assert len(resp["content"]) == 2
-        assert resp["content"][0]["type"] == "thinking"
-        assert resp["content"][0]["thinking"] == "Let me think about this..."
-        assert resp["content"][1]["type"] == "text"
-        assert resp["content"][1]["text"] == "The answer is 42."
+        kinds = [(b["type"], b.get("thinking", b.get("text"))) for b in resp["content"]]
+        assert kinds == [
+            ("thinking", "Let me think..."),
+            ("text", "The answer is 42."),
+        ]
+
+    def test_and_an_answer_on_both_sides_of_it_stays_on_both_sides(self):
+        resp = build_anthropic_response(
+            request_id="r",
+            model="m",
+            events=[say("Sure."), think("hmm"), say("Answer.")],
+            stop_reason="end_turn",
+        )
+        assert [b["type"] for b in resp["content"]] == ["text", "thinking", "text"]
 
     def test_response_no_reasoning(self):
         resp = build_anthropic_response(
             request_id="test789",
             model="m",
-            content_text="Direct answer.",
+            events=[say("Direct answer.")],
             stop_reason="end_turn",
         )
-        assert len(resp["content"]) == 1
-        assert resp["content"][0]["type"] == "text"
+        assert resp["content"] == [{"type": "text", "text": "Direct answer."}]
 
     def test_response_with_tool_calls(self):
-        from atom.entrypoints.openai.tool_parser import ToolCall
-
-        tc = ToolCall(
-            id="call_0",
-            type="function",
-            function={"name": "read_file", "arguments": '{"path": "/tmp/foo.py"}'},
-        )
         resp = build_anthropic_response(
             request_id="test_tc",
             model="m",
-            content_text="Let me read that file.",
-            tool_calls=[tc],
+            events=[say("Let me read that file.")]
+            + call("call_0", "read_file", '{"path": "/tmp/foo.py"}'),
             stop_reason="tool_use",
         )
         assert resp["stop_reason"] == "tool_use"
-        types = [b["type"] for b in resp["content"]]
-        assert "text" in types
-        assert "tool_use" in types
-        tool_block = [b for b in resp["content"] if b["type"] == "tool_use"][0]
+        assert [b["type"] for b in resp["content"]] == ["text", "tool_use"]
+        tool_block = resp["content"][1]
         assert tool_block["name"] == "read_file"
         assert tool_block["input"] == {"path": "/tmp/foo.py"}
         assert tool_block["id"] == "call_0"
 
     def test_response_with_reasoning_and_tool_calls(self):
-        from atom.entrypoints.openai.tool_parser import ToolCall
-
-        tc = ToolCall(
-            id="call_1",
-            type="function",
-            function={"name": "bash", "arguments": '{"command": "ls"}'},
-        )
         resp = build_anthropic_response(
             request_id="test_rtc",
             model="m",
-            content_text="I'll run a command.",
-            reasoning_content="The user wants to list files.",
-            tool_calls=[tc],
+            events=[think("The user wants to list files."), say("I'll run a command.")]
+            + call("call_1", "bash", '{"command": "ls"}'),
             stop_reason="tool_use",
         )
-        types = [b["type"] for b in resp["content"]]
-        assert types == ["thinking", "text", "tool_use"]
+        assert [b["type"] for b in resp["content"]] == ["thinking", "text", "tool_use"]
         assert resp["stop_reason"] == "tool_use"
 
     def test_the_caller_s_stop_reason_is_the_one_returned(self):
@@ -332,48 +352,31 @@ class TestBuildAnthropicResponse:
         for the same generation. Checked by value; the test this replaces
         grepped the source for the call and passed while the value was thrown
         away."""
-        from atom.entrypoints.openai.tool_parser import ToolCall
-
-        tc = ToolCall(
-            id="call_3",
-            type="function",
-            function={"name": "bash", "arguments": '{"command": "l'},
-        )
+        events = call("call_3", "bash", '{"command": "l')
         for asked in ("max_tokens", "tool_use", "end_turn", "stop_sequence"):
             resp = build_anthropic_response(
-                request_id="r",
-                model="m",
-                content_text="",
-                tool_calls=[tc],
-                stop_reason=asked,
+                request_id="r", model="m", events=events, stop_reason=asked
             )
             assert (
                 resp["stop_reason"] == asked
             ), f"asked for {asked!r}, got {resp['stop_reason']!r}"
 
-    def test_response_empty_content_with_tool_call(self):
-        from atom.entrypoints.openai.tool_parser import ToolCall
-
-        tc = ToolCall(
-            id="call_2",
-            type="function",
-            function={"name": "bash", "arguments": '{"command": "pwd"}'},
-        )
+    def test_a_call_with_no_answer_around_it_is_the_only_block(self):
         resp = build_anthropic_response(
             request_id="test_empty",
             model="m",
-            content_text="",
-            tool_calls=[tc],
+            events=call("call_2", "bash", '{"command": "pwd"}'),
             stop_reason="tool_use",
         )
-        types = [b["type"] for b in resp["content"]]
-        assert "tool_use" in types
-        assert resp["stop_reason"] == "tool_use"
+        assert [b["type"] for b in resp["content"]] == ["tool_use"]
 
-
-# ============================================================================
-# SSE Streaming Format Tests
-# ============================================================================
+    def test_a_response_with_no_events_is_still_a_response(self):
+        """Anthropic has no representation for an empty content list, and the
+        streaming path forces a final text block for the same reason."""
+        resp = build_anthropic_response(
+            request_id="r", model="m", events=[], stop_reason="end_turn"
+        )
+        assert resp["content"] == [{"type": "text", "text": ""}]
 
 
 class TestSSEFormatting:
@@ -901,93 +904,16 @@ class TestAnEffortIsNotAnOptIn:
         assert guarded, "the toggle is written without asking whether it was stated"
 
 
-class TestTheBlocksArriveInTheSameOrderEitherWay:
-    """`/v1/messages` renders content blocks in order, so the order is answer.
+class TestTheEndpointAsksForTheOrder:
+    """The call site, which no builder test can reach.
 
-    The streaming path emits them as the engine produces them; the
-    non-streaming path was handed `(content_text, tool_calls)` -- the same
-    events with the order thrown away -- and rebuilt one text block ahead of
-    every `tool_use`. The same generation came back as
-    `['text','tool_use','tool_use']` unstreamed and
-    `['tool_use','text','tool_use']` streamed, so a client rendering in order
-    showed the sentence introducing the second call before the first call.
-
-    Not visible before this branch only because both paths were losing that
-    text; fixing the loss is what made the orders disagree.
+    Block-order parity itself now lives in
+    `test_anthropic_blocks.TestBothDeliveryModesBuildTheSameBlocks`, which
+    supersedes the class that used to be here: that one fed the raw text
+    straight to the tool parser on both sides, so it had no reasoning stage
+    and structurally could not see the defect where the reasoning block was
+    prepended ahead of everything.
     """
-
-    TOOLS = [
-        {
-            "name": "get_weather",
-            "input_schema": {
-                "type": "object",
-                "properties": {"city": {"type": "string"}},
-            },
-        }
-    ]
-    CALL = (
-        "<tool_call>\n<function=get_weather>\n"
-        "<parameter=city>{}</parameter>\n</function>\n</tool_call>"
-    )
-
-    def _both(self, text):
-        from atom.entrypoints.openai.serving_anthropic import (
-            AnthropicBlocks,
-            build_anthropic_response,
-            tool_event_frames,
-        )
-        from atom.entrypoints.openai.tool_parser import (
-            QwenXmlParser,
-            ToolCallStreamParser,
-            flatten_tool_events,
-            read_whole_events,
-        )
-
-        tools = api_server.anthropic_to_openai_tools(self.TOOLS)
-        events = read_whole_events(QwenXmlParser, text, tools)
-        content_text, calls = flatten_tool_events(events)
-        body = build_anthropic_response(
-            "r",
-            "m",
-            content_text,
-            tool_calls=calls or None,
-            stop_reason="tool_use",
-            events=events,
-        )
-        unstreamed = [b["type"] for b in body["content"]]
-
-        parser = ToolCallStreamParser(tools=tools, parser_cls=QwenXmlParser)
-        blocks, streamed_events = AnthropicBlocks(), []
-        for i in range(0, len(text), 7):
-            streamed_events += parser.process(text[i : i + 7])
-        streamed_events += parser.flush()
-        frames = list(tool_event_frames(streamed_events, blocks)) + list(blocks.close())
-        streamed = [
-            json.loads(line[6:])["content_block"]["type"]
-            for frame in frames
-            for line in frame.splitlines()
-            if line.startswith("data: ") and '"content_block_start"' in line
-        ]
-        return streamed, unstreamed
-
-    @pytest.mark.parametrize(
-        "shape",
-        ["between", "after", "before", "only-call", "no-call"],
-        ids=lambda s: s,
-    )
-    def test_the_two_paths_agree(self, shape):
-        one, two = self.CALL.format("Paris"), self.CALL.format("Tokyo")
-        text = {
-            "between": one + "Let me also check Tokyo." + two,
-            "after": one + "Done.",
-            "before": "Checking now." + one,
-            "only-call": one,
-            "no-call": "Just an answer.",
-        }[shape]
-        streamed, unstreamed = self._both(text)
-        assert (
-            streamed == unstreamed
-        ), f"{shape}: stream={streamed} but stream=false={unstreamed}"
 
     def test_and_the_endpoint_itself_asks_for_the_order(self):
         """The parity above tests the builder; this tests the call site.
@@ -1011,9 +937,3 @@ class TestTheBlocksArriveInTheSameOrderEitherWay:
                 f"build_anthropic_response at line {call.lineno} was not given "
                 "the engine's events, so its blocks come back in the wrong order"
             )
-
-    def test_and_the_sentence_lands_between_the_calls(self):
-        """Not merely equal -- equal to the order the model wrote."""
-        one, two = self.CALL.format("Paris"), self.CALL.format("Tokyo")
-        streamed, _ = self._both(one + "Let me also check Tokyo." + two)
-        assert streamed == ["tool_use", "text", "tool_use"]

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -10,7 +10,6 @@ functions and response builders.
 
 import json
 
-
 from atom.entrypoints.openai.serving_anthropic import (
     AnthropicMessage,
     AnthropicMessagesRequest,

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -553,8 +553,13 @@ class TestTheStopReasonTellsTheTruth:
             ("max_tokens", "max_tokens"),
             ("stop_sequence", "stop_sequence"),
             # The scheduler's fourth ending, and the one a lookup misses: a
-            # stop token fired, spelled with the token's own id.
-            ("stop_163586", "stop_sequence"),
+            # model stop *token* fired, spelled with the token's own id. That
+            # is an ordinary end of turn, not the client's `stop_sequences`
+            # matching -- which is what `stop_sequence` means to Anthropic,
+            # and what it pairs with the matched string. Mapping it there
+            # gives any model with a second declared EOS a `stop_sequence:
+            # null` for a request that supplied no stop sequences.
+            ("stop_163586", "end_turn"),
             ("aborted", "end_turn"),
             ("unschedulable: no free blocks", "end_turn"),
             ("", "end_turn"),

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -30,6 +30,7 @@ from atom.entrypoints.openai.serving_anthropic import (
     stream_message_start,
     stream_message_stop,
 )
+from atom.entrypoints.openai.serving_chat import resolve_thinking
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 from atom.entrypoints.openai.tool_parser.registry import parse_tool_calls
 
@@ -734,3 +735,100 @@ class TestASwitchlessModelStillHonoursDisabled:
             "the streaming and non-streaming branches must both consult it; "
             f"found {len(reads)} read(s)"
         )
+
+
+class TestWithheldReasoningStillSendsSomething:
+    """Dropping the blocks must not drop the frames.
+
+    `anthropic_drop_reasoning` suppresses `thinking` blocks for a request that
+    said `disabled` on a model whose template has no switch -- and the branch
+    was `continue`, with nothing in its place. The bytes are generated either
+    way, so the socket went silent for the whole chain of thought: on an
+    R1-shaped 5019-character trace the first client-visible frame arrived
+    after 5016 of them. Long enough to trip proxy and SDK idle-read timeouts,
+    and the stall watchdog this branch added can only report that, not
+    prevent it.
+    """
+
+    def test_a_ping_frame_exists(self):
+        assert api_server._ANTHROPIC_PING_FRAME.startswith("event: ping")
+
+    def test_the_drop_branch_yields_it(self):
+        """Read off the syntax tree: the branch must not be a bare
+        `continue` again."""
+        tree = ast.parse(pathlib.Path(api_server.__file__).read_text())
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "anthropic_messages"
+        )
+        drops = [
+            n
+            for n in ast.walk(fn)
+            if isinstance(n, ast.If)
+            and isinstance(n.test, ast.Name)
+            and n.test.id == "drop_reasoning"
+        ]
+        assert drops, "the suppression branch is gone; this asserts nothing"
+        # The streaming branch is the one that `continue`s past a segment the
+        # socket would otherwise have carried. The non-streaming sibling just
+        # clears a field and has nothing to send.
+        skipping = [
+            n for n in drops if any(isinstance(c, ast.Continue) for c in ast.walk(n))
+        ]
+        assert skipping, "no branch skips a segment; matcher is stale"
+        for node in skipping:
+            assert [
+                y for y in ast.walk(node) if isinstance(y, ast.Yield)
+            ], "a reasoning segment is skipped with no frame in its place"
+
+
+class TestAnEffortIsNotAnOptIn:
+    """`resolve_thinking` returns `None` for "the request did not say".
+
+    Collapsing that to `True` was harmless while the caller wrote a key no
+    template read. Once it wrote the template's real switch -- merged after
+    the server defaults and after the client's own `chat_template_kwargs` --
+    a request carrying only `reasoning_effort` re-enabled reasoning over an
+    operator's `--default-chat-template-kwargs '{"enable_thinking": false}'`.
+    """
+
+    class Req:
+        def __init__(self, thinking=None, reasoning_effort=None):
+            self.thinking = thinking
+            self.reasoning_effort = reasoning_effort
+
+    @pytest.mark.parametrize(
+        "req, expected",
+        [
+            (Req(), None),
+            (Req(reasoning_effort="high"), None),
+            (Req(thinking={"type": "enabled"}), True),
+            (Req(thinking={"type": "disabled"}), False),
+            (Req(reasoning_effort="none"), False),
+        ],
+        ids=["nothing", "effort-only", "on", "off", "effort-none"],
+    )
+    def test_only_an_explicit_statement_resolves(self, req, expected):
+        assert resolve_thinking(req)[0] is expected
+
+    def test_the_toggle_is_written_only_when_stated(self):
+        """Read off the syntax tree, not grepped: the guard has to be on the
+        resolved value, not on the toggle merely existing."""
+        tree = ast.parse(pathlib.Path(api_server.__file__).read_text())
+        writes = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Subscript)
+            and isinstance(n.ctx, ast.Store)
+            and getattr(n.value, "id", None) == "merged_kwargs"
+            and isinstance(n.slice, ast.Name)
+        ]
+        assert writes, "no name-keyed write to merged_kwargs; matcher is stale"
+        guarded = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.If)
+            and "_th_enabled is not None" in ast.unparse(n.test)
+        ]
+        assert guarded, "the toggle is written without asking whether it was stated"

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -8,6 +8,7 @@ requiring a running GPU server — uses unit tests on the conversion
 functions and response builders.
 """
 
+import ast
 import json
 import pathlib
 
@@ -669,3 +670,67 @@ class TestSeparationIsUnconditional:
         assert "anthropic_reasoning_split" not in src
         assert "anthropic_reasoning_filter" not in src
         assert "anthropic_tool_format" not in src
+
+
+class TestASwitchlessModelStillHonoursDisabled:
+    """The prompt is the better place to answer `thinking`, not the only one.
+
+    `anthropic_template_kwargs` sets the template's own switch wherever there
+    is one. For a model whose template has none -- gpt-oss-120b and
+    DeepSeek-R1 both measure that way -- it returns `{}`, and the two
+    downstream suppressions this branch removed are no longer there to catch
+    it. So `thinking: {"type": "disabled"}` was honoured at neither layer:
+    the client asked for no reasoning and got `thinking` blocks.
+
+    Withheld, not left unseparated. Separation stays unconditional because
+    the tool parser reads the same text -- see `TestSeparationIsUnconditional`.
+    """
+
+    TOGGLE = ("enable_thinking", False, True)
+
+    class Req:
+        def __init__(self, thinking):
+            self.thinking = thinking
+
+    @pytest.mark.parametrize(
+        "thinking, toggle, expected",
+        [
+            ({"type": "disabled"}, None, True),
+            # Answered in the prompt instead, which is strictly better.
+            ({"type": "disabled"}, TOGGLE, False),
+            # Absent is unstated at both layers or neither.
+            (None, None, False),
+            (None, TOGGLE, False),
+            ({"type": "enabled"}, None, False),
+        ],
+        ids=["switchless-off", "switched-off", "absent", "absent-switched", "on"],
+    )
+    def test_only_an_explicit_opt_out_with_nowhere_else_to_go(
+        self, thinking, toggle, expected
+    ):
+        assert (
+            api_server.anthropic_drop_reasoning(self.Req(thinking), toggle) is expected
+        )
+
+    def test_both_endpoint_paths_consult_it(self):
+        """Read off the syntax tree, not grepped for: a literal check passes
+        against code rewritten into a different shape with the same bug, and
+        this suite has been fooled that way twice.
+        """
+        tree = ast.parse(pathlib.Path(api_server.__file__).read_text())
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "anthropic_messages"
+        )
+        reads = [
+            n
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Name)
+            and n.id == "drop_reasoning"
+            and isinstance(n.ctx, ast.Load)
+        ]
+        assert len(reads) >= 2, (
+            "the streaming and non-streaming branches must both consult it; "
+            f"found {len(reads)} read(s)"
+        )

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -14,6 +14,7 @@ import pathlib
 import pytest
 
 from atom.entrypoints.openai import api_server
+from atom.entrypoints.openai.reasoning import separate_reasoning
 from atom.entrypoints.openai.serving_anthropic import (
     AnthropicMessage,
     AnthropicMessagesRequest,
@@ -28,6 +29,8 @@ from atom.entrypoints.openai.serving_anthropic import (
     stream_message_start,
     stream_message_stop,
 )
+from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
+from atom.entrypoints.openai.tool_parser.registry import parse_tool_calls
 
 # ============================================================================
 # Message Conversion Tests
@@ -508,77 +511,160 @@ class TestTheStopReasonTellsTheTruth:
         default = "end_turn"
         assert api_server._ANTHROPIC_STOP_REASON.get(unknown, default) == default
 
-
-class TestThinkingOffMeansNoReasoningChannel:
-    """`thinking` absent: nothing separates, so nothing can be dropped.
-
-    The endpoint used to build a seeded filter regardless, split the output
-    into channels, and then discard the reasoning half. That was invisible
-    while an unseeded filter sent most output down the content channel; with
-    seeding correct, a reasoning model stopped at `max_tokens` produces only
-    reasoning and the client got an empty message. Putting the discarded half
-    back as `text` would have handed it the one thing it declined.
-
-    So the decision lives in two functions both entry points call, rather than
-    inline in an async endpoint no test can reach -- an earlier version of
-    this class re-implemented the branch to test it, and passed while the
-    real one did the opposite.
-    """
-
-    RAW = "Working through it. </think>The answer is 42."
-
-    def test_nothing_is_separated_when_thinking_is_off(self):
-        reasoning, content = api_server.anthropic_reasoning_split(
-            self.RAW, thinking=False, starts_thinking=True
-        )
-        assert reasoning is None
-        assert content == self.RAW, "the raw output is the text, markers and all"
-
-    def test_it_is_separated_when_thinking_is_on(self):
-        reasoning, content = api_server.anthropic_reasoning_split(
-            self.RAW, thinking=True, starts_thinking=True
-        )
-        assert reasoning == "Working through it."
-        assert content == "The answer is 42."
-
-    def test_no_filter_is_built_when_thinking_is_off(self):
-        assert (
-            api_server.anthropic_reasoning_filter(thinking=False, starts_thinking=True)
-            is None
-        )
-
-    def test_a_seeded_filter_is_built_when_it_is_on(self):
-        rf = api_server.anthropic_reasoning_filter(thinking=True, starts_thinking=True)
-        assert rf is not None and rf.state == 1
-
-    def test_both_halves_answer_the_same_question(self):
-        """One rule, so the two paths cannot drift apart."""
-        for thinking in (True, False):
-            split = api_server.anthropic_reasoning_split(
-                self.RAW, thinking=thinking, starts_thinking=True
-            )
-            filt = api_server.anthropic_reasoning_filter(
-                thinking=thinking, starts_thinking=True
-            )
-            assert (split[0] is None) == (filt is None)
-
     @pytest.mark.parametrize(
-        "helper", ["anthropic_reasoning_split", "anthropic_reasoning_filter"]
+        "engine_reason, expected",
+        [
+            ("eos", "end_turn"),
+            ("max_tokens", "max_tokens"),
+            ("stop_sequence", "stop_sequence"),
+            # The scheduler's fourth ending, and the one a lookup misses: a
+            # stop token fired, spelled with the token's own id.
+            ("stop_163586", "stop_sequence"),
+            ("aborted", "end_turn"),
+            ("unschedulable: no free blocks", "end_turn"),
+            ("", "end_turn"),
+            (None, "end_turn"),
+        ],
     )
-    def test_the_endpoint_actually_calls_the_helper(self, helper):
-        """Extracting a rule only helps if the caller uses it.
+    def test_every_shape_the_scheduler_emits(self, engine_reason, expected):
+        """All seven, enumerated from `scheduler.py`, plus the unset default."""
+        assert api_server.anthropic_stop_reason(engine_reason) == expected
 
-        The endpoint's body is an async generator inside a route handler that
-        no unit test reaches, so a mutation putting `separate_reasoning` back
-        inline passed every behavioural test here. Counted from the source:
-        one definition plus at least one call.
+    def test_the_non_streaming_path_passes_one(self):
+        """It read `end_turn` from a default while the reason sat unused.
+
+        The map was wired into the streaming generator only, so the same
+        response reported two different endings depending on `stream`. Both
+        bodies are unreachable from a unit test; this counts call sites.
         """
         src = pathlib.Path(api_server.__file__).read_text()
         assert (
-            src.count(helper + "(") >= 2
-        ), f"{helper} is defined but never called — the endpoint has its own copy"
+            src.count("anthropic_stop_reason(") >= 3
+        ), "anthropic_stop_reason is defined but not called by both paths"
+        assert "stop_reason=(" in src, "the non-streaming response omits stop_reason"
 
-    def test_no_ping_frame_survives(self):
-        """Its only branch is gone; a leftover constant reads as live code."""
+
+class TestTheOffSwitchIsRecognised:
+    """`{"type": "disabled"}` is how a client turns thinking off.
+
+    It is also a non-empty dict, so `bool(request.thinking)` read it as on --
+    the standard spelling of "off" was the one spelling that did not work.
+    """
+
+    class Req:
+        def __init__(self, thinking):
+            self.thinking = thinking
+
+    @pytest.mark.parametrize(
+        "thinking, enabled",
+        [
+            (None, False),
+            ({}, False),
+            ({"type": "disabled"}, False),
+            ({"type": "enabled"}, True),
+            ({"type": "enabled", "budget_tokens": 1024}, True),
+        ],
+    )
+    def test_each_spelling(self, thinking, enabled):
+        assert api_server.anthropic_thinking_enabled(self.Req(thinking)) is enabled
+
+    def test_a_request_without_the_field_at_all(self):
+        assert api_server.anthropic_thinking_enabled(object()) is False
+
+
+class TestThinkingIsAnsweredInThePrompt:
+    """`thinking: disabled` tells the *model* not to think.
+
+    Three attempts to deal with an unwanted chain of thought after generating
+    it each broke something else -- discarding it returned an empty message,
+    relabelling it as `text` handed the client what it declined, and declining
+    to separate it fed the reasoning to the tool parser, which read one model's
+    musing about `<function=NAME>` as a call to a tool named `NAME`. Setting
+    the template's own switch means there is no chain of thought to deal with.
+
+    This is SGLang's design for the same field (`apply_reasoning_enabled`), and
+    what vLLM gets structurally by having no such field on its Anthropic
+    request at all -- its reasoning parser runs unconditionally and
+    `include_reasoning` only suppresses the field after the split.
+    """
+
+    TOGGLE = ("enable_thinking", False)
+
+    class Req:
+        def __init__(self, thinking):
+            self.thinking = thinking
+
+    def test_disabled_sets_the_template_switch(self):
+        kwargs = api_server.anthropic_template_kwargs(
+            self.Req({"type": "disabled"}), self.TOGGLE
+        )
+        assert kwargs == {"enable_thinking": False}
+
+    def test_enabled_leaves_the_template_alone(self):
+        assert (
+            api_server.anthropic_template_kwargs(
+                self.Req({"type": "enabled"}), self.TOGGLE
+            )
+            == {}
+        )
+
+    def test_an_absent_field_is_unstated_not_off(self):
+        """Anthropic defaults to off, but reading absence as "switch this
+        model's reasoning off" would silently change what every existing
+        caller gets back. SGLang keys on the field being present too."""
+        assert api_server.anthropic_template_kwargs(self.Req(None), self.TOGGLE) == {}
+
+    def test_a_model_with_no_switch_gets_no_kwarg(self):
+        assert (
+            api_server.anthropic_template_kwargs(self.Req({"type": "disabled"}), None)
+            == {}
+        )
+
+    def test_the_endpoint_renders_the_prompt_with_them(self):
+        """The request's `thinking` used to be dropped on the floor here: the
+        Anthropic path built `merged_kwargs` from server defaults only."""
         src = pathlib.Path(api_server.__file__).read_text()
-        assert "_ANTHROPIC_PING_FRAME" not in src
+        assert src.count("anthropic_template_kwargs(") >= 2
+        assert "merged_kwargs.update(anthropic_template_kwargs(" in src
+
+
+class TestSeparationIsUnconditional:
+    """Whatever reasoning arrives is separated and reported, always.
+
+    Not gated on `thinking`, for the same reason the chat path is not: the
+    tool parser reads the same text, and a chain of thought left in it is a
+    chain of thought the tool parser will try to parse.
+    """
+
+    RAW = (
+        "<think>User wants weather. The syntax is <tool_call> then "
+        "<function=NAME>...</think>Checking now. "
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter>"
+        "</function></tool_call>"
+    )
+
+    def test_no_call_is_fabricated_from_reasoning(self):
+        reasoning, body = separate_reasoning(self.RAW, starts_thinking=False)
+        _, calls = parse_tool_calls(body, None, parser_cls=QwenXmlParser)
+        names = [c.function["name"] for c in calls]
+        assert names == ["get_weather"], f"fabricated {names}"
+        assert reasoning is not None and "syntax" in reasoning
+
+    def test_tool_use_survives_a_request_that_declined_thinking(self):
+        """The cost of the answer this replaces: tying the parse to `thinking`
+        meant no `tool_use` block for any request that did not opt in, which
+        is most of them."""
+        _, body = separate_reasoning(self.RAW, starts_thinking=False)
+        _, calls = parse_tool_calls(body, None, parser_cls=QwenXmlParser)
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize("helper", ["separate_reasoning", "ReasoningFilter"])
+    def test_neither_path_gates_it(self, helper):
+        """Both endpoint bodies are unreachable from a unit test, so this
+        counts call sites and asserts the gate that used to wrap them is
+        gone."""
+        src = pathlib.Path(api_server.__file__).read_text()
+        assert helper + "(" in src
+        assert "anthropic_reasoning_split" not in src
+        assert "anthropic_reasoning_filter" not in src
+        assert "anthropic_tool_format" not in src

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -9,7 +9,11 @@ functions and response builders.
 """
 
 import json
+import pathlib
 
+import pytest
+
+from atom.entrypoints.openai import api_server
 from atom.entrypoints.openai.serving_anthropic import (
     AnthropicMessage,
     AnthropicMessagesRequest,
@@ -465,3 +469,116 @@ class TestAnthropicMessagesRequest:
         result = anthropic_to_openai_messages(msgs, system=system)
         # No system message when all blocks are attribution headers
         assert result[0]["role"] == "user"
+
+
+class TestTheStopReasonTellsTheTruth:
+    """Why a message ended, not just that it did.
+
+    `stop_reason` was the constant `end_turn` on the streaming path — the
+    engine's own reason was never read. A response cut off at `max_tokens`
+    therefore claimed a normal ending, and so did the one case where that
+    matters most: a reasoning model asked for no `thinking` produces only
+    reasoning, all of which is correctly dropped, and the client got an empty
+    message that also reported nothing was wrong. It did not ask for a chain
+    of thought and must not be handed one; what it can be given is the reason
+    there is nothing else.
+    """
+
+    def test_the_engine_vocabulary_maps_onto_anthropic(self):
+        assert api_server._ANTHROPIC_STOP_REASON == {
+            "eos": "end_turn",
+            "max_tokens": "max_tokens",
+            "stop_sequence": "stop_sequence",
+        }
+
+    @pytest.mark.parametrize(
+        "engine_reason, expected",
+        [
+            ("eos", "end_turn"),
+            ("max_tokens", "max_tokens"),
+            ("stop_sequence", "stop_sequence"),
+        ],
+    )
+    def test_each_reason_survives_the_translation(self, engine_reason, expected):
+        assert api_server._ANTHROPIC_STOP_REASON[engine_reason] == expected
+
+    @pytest.mark.parametrize("unknown", ["aborted", None, "something_new"])
+    def test_an_unmapped_reason_leaves_the_default_alone(self, unknown):
+        """`aborted` has no counterpart; the client is already gone."""
+        default = "end_turn"
+        assert api_server._ANTHROPIC_STOP_REASON.get(unknown, default) == default
+
+
+class TestThinkingOffMeansNoReasoningChannel:
+    """`thinking` absent: nothing separates, so nothing can be dropped.
+
+    The endpoint used to build a seeded filter regardless, split the output
+    into channels, and then discard the reasoning half. That was invisible
+    while an unseeded filter sent most output down the content channel; with
+    seeding correct, a reasoning model stopped at `max_tokens` produces only
+    reasoning and the client got an empty message. Putting the discarded half
+    back as `text` would have handed it the one thing it declined.
+
+    So the decision lives in two functions both entry points call, rather than
+    inline in an async endpoint no test can reach -- an earlier version of
+    this class re-implemented the branch to test it, and passed while the
+    real one did the opposite.
+    """
+
+    RAW = "Working through it. </think>The answer is 42."
+
+    def test_nothing_is_separated_when_thinking_is_off(self):
+        reasoning, content = api_server.anthropic_reasoning_split(
+            self.RAW, thinking=False, starts_thinking=True
+        )
+        assert reasoning is None
+        assert content == self.RAW, "the raw output is the text, markers and all"
+
+    def test_it_is_separated_when_thinking_is_on(self):
+        reasoning, content = api_server.anthropic_reasoning_split(
+            self.RAW, thinking=True, starts_thinking=True
+        )
+        assert reasoning == "Working through it."
+        assert content == "The answer is 42."
+
+    def test_no_filter_is_built_when_thinking_is_off(self):
+        assert (
+            api_server.anthropic_reasoning_filter(thinking=False, starts_thinking=True)
+            is None
+        )
+
+    def test_a_seeded_filter_is_built_when_it_is_on(self):
+        rf = api_server.anthropic_reasoning_filter(thinking=True, starts_thinking=True)
+        assert rf is not None and rf.state == 1
+
+    def test_both_halves_answer_the_same_question(self):
+        """One rule, so the two paths cannot drift apart."""
+        for thinking in (True, False):
+            split = api_server.anthropic_reasoning_split(
+                self.RAW, thinking=thinking, starts_thinking=True
+            )
+            filt = api_server.anthropic_reasoning_filter(
+                thinking=thinking, starts_thinking=True
+            )
+            assert (split[0] is None) == (filt is None)
+
+    @pytest.mark.parametrize(
+        "helper", ["anthropic_reasoning_split", "anthropic_reasoning_filter"]
+    )
+    def test_the_endpoint_actually_calls_the_helper(self, helper):
+        """Extracting a rule only helps if the caller uses it.
+
+        The endpoint's body is an async generator inside a route handler that
+        no unit test reaches, so a mutation putting `separate_reasoning` back
+        inline passed every behavioural test here. Counted from the source:
+        one definition plus at least one call.
+        """
+        src = pathlib.Path(api_server.__file__).read_text()
+        assert (
+            src.count(helper + "(") >= 2
+        ), f"{helper} is defined but never called — the endpoint has its own copy"
+
+    def test_no_ping_frame_survives(self):
+        """Its only branch is gone; a leftover constant reads as live code."""
+        src = pathlib.Path(api_server.__file__).read_text()
+        assert "_ANTHROPIC_PING_FRAME" not in src

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -899,3 +899,121 @@ class TestAnEffortIsNotAnOptIn:
             and "_th_enabled is not None" in ast.unparse(n.test)
         ]
         assert guarded, "the toggle is written without asking whether it was stated"
+
+
+class TestTheBlocksArriveInTheSameOrderEitherWay:
+    """`/v1/messages` renders content blocks in order, so the order is answer.
+
+    The streaming path emits them as the engine produces them; the
+    non-streaming path was handed `(content_text, tool_calls)` -- the same
+    events with the order thrown away -- and rebuilt one text block ahead of
+    every `tool_use`. The same generation came back as
+    `['text','tool_use','tool_use']` unstreamed and
+    `['tool_use','text','tool_use']` streamed, so a client rendering in order
+    showed the sentence introducing the second call before the first call.
+
+    Not visible before this branch only because both paths were losing that
+    text; fixing the loss is what made the orders disagree.
+    """
+
+    TOOLS = [
+        {
+            "name": "get_weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        }
+    ]
+    CALL = (
+        "<tool_call>\n<function=get_weather>\n"
+        "<parameter=city>{}</parameter>\n</function>\n</tool_call>"
+    )
+
+    def _both(self, text):
+        from atom.entrypoints.openai.serving_anthropic import (
+            AnthropicBlocks,
+            build_anthropic_response,
+            tool_event_frames,
+        )
+        from atom.entrypoints.openai.tool_parser import (
+            QwenXmlParser,
+            ToolCallStreamParser,
+            flatten_tool_events,
+            read_whole_events,
+        )
+
+        tools = api_server.anthropic_to_openai_tools(self.TOOLS)
+        events = read_whole_events(QwenXmlParser, text, tools)
+        content_text, calls = flatten_tool_events(events)
+        body = build_anthropic_response(
+            "r",
+            "m",
+            content_text,
+            tool_calls=calls or None,
+            stop_reason="tool_use",
+            events=events,
+        )
+        unstreamed = [b["type"] for b in body["content"]]
+
+        parser = ToolCallStreamParser(tools=tools, parser_cls=QwenXmlParser)
+        blocks, streamed_events = AnthropicBlocks(), []
+        for i in range(0, len(text), 7):
+            streamed_events += parser.process(text[i : i + 7])
+        streamed_events += parser.flush()
+        frames = list(tool_event_frames(streamed_events, blocks)) + list(blocks.close())
+        streamed = [
+            json.loads(line[6:])["content_block"]["type"]
+            for frame in frames
+            for line in frame.splitlines()
+            if line.startswith("data: ") and '"content_block_start"' in line
+        ]
+        return streamed, unstreamed
+
+    @pytest.mark.parametrize(
+        "shape",
+        ["between", "after", "before", "only-call", "no-call"],
+        ids=lambda s: s,
+    )
+    def test_the_two_paths_agree(self, shape):
+        one, two = self.CALL.format("Paris"), self.CALL.format("Tokyo")
+        text = {
+            "between": one + "Let me also check Tokyo." + two,
+            "after": one + "Done.",
+            "before": "Checking now." + one,
+            "only-call": one,
+            "no-call": "Just an answer.",
+        }[shape]
+        streamed, unstreamed = self._both(text)
+        assert (
+            streamed == unstreamed
+        ), f"{shape}: stream={streamed} but stream=false={unstreamed}"
+
+    def test_and_the_endpoint_itself_asks_for_the_order(self):
+        """The parity above tests the builder; this tests the call site.
+
+        `build_anthropic_response` falls back to the old one-text-block shape
+        when it is given no events, so the endpoint dropping the argument
+        restores the divergence with every test of the builder still green.
+        """
+        source = pathlib.Path(api_server.__file__).read_text()
+        tree = ast.parse(source)
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "build_anthropic_response"
+        ]
+        assert calls, "the endpoint no longer builds an Anthropic response"
+        for call in calls:
+            assert "events" in {kw.arg for kw in call.keywords}, (
+                f"build_anthropic_response at line {call.lineno} was not given "
+                "the engine's events, so its blocks come back in the wrong order"
+            )
+
+    def test_and_the_sentence_lands_between_the_calls(self):
+        """Not merely equal -- equal to the order the model wrote."""
+        one, two = self.CALL.format("Paris"), self.CALL.format("Tokyo")
+        streamed, _ = self._both(one + "Let me also check Tokyo." + two)
+        assert streamed == ["tool_use", "text", "tool_use"]

--- a/tests/entrypoints/test_api_server_helpers.py
+++ b/tests/entrypoints/test_api_server_helpers.py
@@ -19,6 +19,7 @@ import types
 from types import SimpleNamespace
 
 import pytest
+from import_guard import skip_if_dependency_missing
 
 
 def _install_api_server_stubs() -> list[str]:
@@ -54,14 +55,14 @@ def _install_api_server_stubs() -> list[str]:
             sys.modules[mod_name] = stub
             injected.append(mod_name)
 
-    class _StubCoreManager:  # noqa: D401 - placeholder
+    class _StubCoreManager:
         def __init__(self, *a, **kw):
             pass
 
         def add_request(self, reqs):
             return None
 
-    class _StubEngineArgs:  # noqa: D401 - placeholder
+    class _StubEngineArgs:
         @classmethod
         def add_cli_args(cls, parser):
             return parser
@@ -87,6 +88,10 @@ try:
 
     api_server = importlib.import_module("atom.entrypoints.openai.api_server")
 except Exception as exc:  # pragma: no cover - environment-dependent skip
+    # Re-raises unless a third-party dependency is what is missing. It used to
+    # skip on anything, so a syntax error in `api_server.py` silenced this
+    # whole module and the suite still reported a clean run.
+    skip_if_dependency_missing(exc, "api_server import unavailable")
     api_server = None  # type: ignore[assignment]
     _import_error = exc
     # NB: do NOT reset _injected_modules here. When api_server import fails

--- a/tests/entrypoints/test_api_server_helpers.py
+++ b/tests/entrypoints/test_api_server_helpers.py
@@ -89,7 +89,7 @@ try:
     import importlib
 
     api_server = importlib.import_module("atom.entrypoints.openai.api_server")
-except Exception as exc:  # pragma: no cover - environment-dependent skip
+except ImportError as exc:  # pragma: no cover - environment-dependent skip
     # Re-raises unless a third-party dependency is what is missing. It used to
     # skip on anything, so a syntax error in `api_server.py` silenced this
     # whole module and the suite still reported a clean run.

--- a/tests/entrypoints/test_api_server_helpers.py
+++ b/tests/entrypoints/test_api_server_helpers.py
@@ -13,7 +13,9 @@ rather than block the rest of the suite.
 
 from __future__ import annotations
 
+import ast
 import asyncio
+import inspect
 import sys
 import types
 from types import SimpleNamespace
@@ -261,4 +263,106 @@ class TestValidateContextLength:
             num_prompt_tokens=129,
             max_tokens=8,
             max_model_len=None,
+        )
+
+
+class TestARequestIsNotSerialisedForALogNobodyKeeps:
+    """Building the log entry is the callee's job, not the caller's.
+
+    ``_log_request_event`` returns immediately when request logging is off,
+    but Python evaluates its arguments first, so
+    ``_log_request_event("request", rid, request.model_dump())`` dumped every
+    message and every tool schema on the event loop and threw the result away
+    -- 20-26 us per request on an agent-shaped one, at all four call sites.
+    The guard has to run before the dump, which is what
+    ``_log_request_model`` is for.
+
+    Asserted on whether ``model_dump`` ran, not on how long it took: the
+    defect is an evaluation order, and an order is exactly observable.
+    """
+
+    class _Model:
+        def __init__(self) -> None:
+            self.dumps = 0
+
+        def model_dump(self) -> dict:
+            self.dumps += 1
+            return {"big": "payload"}
+
+    def test_nothing_is_dumped_while_request_logging_is_off(self, monkeypatch):
+        monkeypatch.setattr(api_server, "_request_logger", None)
+        model = self._Model()
+        api_server._log_request_model("request", "req-1", model)
+        assert model.dumps == 0, "the request was serialised for a log that is off"
+
+    def test_it_is_dumped_once_when_request_logging_is_on(self, monkeypatch):
+        written: list[str] = []
+        monkeypatch.setattr(
+            api_server, "_request_logger", SimpleNamespace(info=written.append)
+        )
+        model = self._Model()
+        api_server._log_request_model("request", "req-1", model)
+        assert model.dumps == 1
+        assert written and "payload" in written[0], "the entry never reached the log"
+
+    @staticmethod
+    def _module_ast():
+        return ast.parse(inspect.getsource(api_server))
+
+    def _eager_sites(self):
+        """Every ``_log_request_event(..., x.model_dump())`` outside the helper.
+
+        ``_log_request_model``'s own body is that call, and there it is
+        correct -- it runs after the guard. Excluding it by name rather than
+        by weakening the pattern, because the pattern is the whole test.
+        """
+        tree = self._module_ast()
+        helper = next(
+            (
+                n
+                for n in ast.walk(tree)
+                if isinstance(n, ast.FunctionDef) and n.name == "_log_request_model"
+            ),
+            None,
+        )
+        exempt = {id(n) for n in ast.walk(helper)} if helper is not None else set()
+        return [
+            f"line {node.lineno}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and id(node) not in exempt
+            and getattr(node.func, "id", None) == "_log_request_event"
+            for arg in node.args
+            if isinstance(arg, ast.Call)
+            and getattr(arg.func, "attr", None) == "model_dump"
+        ]
+
+    def test_the_scan_sees_the_endpoints(self):
+        """The positive control: the endpoints must be using the helper.
+
+        Without this the test passes on a module that stopped calling either
+        function -- green, and reading nothing. The same silent retirement
+        already happened once on this branch to the seeding scan.
+        """
+        tree = self._module_ast()
+        used = [
+            n.lineno
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and getattr(n.func, "id", None) == "_log_request_model"
+        ]
+        assert len(used) >= 4, f"only {len(used)} call sites use the helper: {used}"
+
+    def test_no_call_site_dumps_before_the_guard(self):
+        """The four sites this was written for, checked where they live.
+
+        A helper nothing calls fixes nothing, and these sites sit in async
+        route handlers no unit test reaches -- so the source is read instead,
+        and an endpoint added later that spells it the old way is caught the
+        moment it is written.
+        """
+        eager = self._eager_sites()
+        assert not eager, (
+            "_log_request_event is being handed a model_dump() built before "
+            f"the guard can decline it: {eager}. Use _log_request_model."
         )

--- a/tests/entrypoints/test_atom_standalone_service.py
+++ b/tests/entrypoints/test_atom_standalone_service.py
@@ -568,3 +568,160 @@ class TestAStreamClosedBeforeItStartedIsStillStopped:
         ], "sequences the engine was given were never aborted"
         assert "r5" not in service._stream_seqs
         service.close()
+
+
+class TestTheSubmitWindowClosesOnEveryPath:
+    """`_awaiting_submit` says "this id could still be submitted".
+
+    It is what lets `abort_stream` tell "not yet submitted" from "already
+    finished and forgotten", and if an id is never removed it is the same
+    permanent retention the set was added to prevent, one level down. The
+    first version of this bookkeeping discarded inside
+    `_submit_stream_request`, which has four ways out, and covered two: a
+    stream closed while it was preprocessing and a stream whose preprocess
+    raised each left an id behind.
+    """
+
+    class _Engine:
+        def __init__(self):
+            self.io_processor = self
+            self.core_mgr = self
+            self.requests = {}
+            self.gate = None
+            self.boom = False
+            self.added = []
+
+        def preprocess(self, *a, **kw):
+            if self.gate:
+                self.gate()
+            if self.boom:
+                raise RuntimeError("preprocess failed")
+            return type("Seq", (), {"id": 1})()
+
+        def add_request(self, seqs):
+            self.added.extend(seqs)
+
+        def abort_request(self, seq_id):
+            pass
+
+    def _service(self):
+        from atom.entrypoints.atomesh.atom_standalone_service import AtomEngineService
+
+        return AtomEngineService(self._Engine(), _StubTokenizer())
+
+    @staticmethod
+    def _request(rid):
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            EngineStreamRequest,
+        )
+
+        return EngineStreamRequest(
+            request_id=rid,
+            prompt="hi",
+            sampling_params=None,
+            effective_n=1,
+            stream_queue=queue.Queue(),
+        )
+
+    def test_a_stream_that_publishes_normally(self):
+        service = self._service()
+        for i in range(20):
+            rid = f"ok-{i}"
+            service._expect_stream(rid)
+            service._submit_stream_request(self._request(rid))
+            service._close_submit_window(rid)
+        assert service._awaiting_submit == set()
+        service.close()
+
+    def test_a_stream_closed_while_it_was_preprocessing(self):
+        """The window must stay open *during* preprocessing -- that abort has
+        no sequences to stop yet either -- and close after."""
+        service = self._service()
+        for i in range(20):
+            rid = f"mid-{i}"
+            service._expect_stream(rid)
+            service.engine.gate = lambda r=rid: service.abort_stream(r)
+            try:
+                service._submit_stream_request(self._request(rid))
+            finally:
+                service._close_submit_window(rid)
+        assert service.engine.core_mgr is service.engine
+        assert service._awaiting_submit == set(), (
+            f"{len(service._awaiting_submit)} ids retained for the life of the "
+            "process, one per stream closed during preprocessing"
+        )
+        service.close()
+
+    def test_a_stream_whose_preprocess_raised(self):
+        service = self._service()
+        service.engine.boom = True
+        for i in range(20):
+            rid = f"boom-{i}"
+            service._expect_stream(rid)
+            try:
+                service._submit_stream_request(self._request(rid))
+            except RuntimeError:
+                pass  # what `_worker_loop` does
+            finally:
+                service._close_submit_window(rid)
+        assert service._awaiting_submit == set()
+        service.close()
+
+    def test_and_the_worker_loop_is_the_one_calling_it(self):
+        """Through the real loop, not the helper -- otherwise this tests the
+        test's own `finally` rather than the service's."""
+        import time
+
+        service = self._service()
+        service.engine.boom = True
+        for i in range(20):
+            rid = f"loop-{i}"
+            service._expect_stream(rid)
+            service._queue.put(self._request(rid))
+        for _ in range(100):
+            if service._queue.empty():
+                break
+            time.sleep(0.02)
+        time.sleep(0.2)
+        assert service._awaiting_submit == set()
+        service.close()
+
+    def test_and_the_window_closes_after_the_submit_never_before(self):
+        """Ordering, driven through the real worker loop.
+
+        Closing the window first is the obvious way to write this and it
+        silently reopens the gap `_abandoned` exists for: an abort arriving
+        while the sequences are still being built then finds no sequence list
+        *and* no open window, reads that as "already finished", remembers
+        nothing -- and the worker adds the sequences to the engine a moment
+        later. They decode to `max_tokens` into a queue nobody will read.
+        """
+        import time
+
+        service = self._service()
+        rid = "ordering"
+        service._expect_stream(rid)
+        service.engine.gate = lambda: service.abort_stream(rid)
+        service._queue.put(self._request(rid))
+        for _ in range(100):
+            if service._queue.empty():
+                break
+            time.sleep(0.02)
+        time.sleep(0.2)
+        assert (
+            service.engine.added == []
+        ), "a stream closed while it was preprocessing still reached the engine"
+        assert service._awaiting_submit == set()
+        service.close()
+
+    def test_and_a_stream_the_shutdown_path_never_submits(self):
+        import time
+
+        service = self._service()
+        service._closed.set()
+        for i in range(20):
+            rid = f"shut-{i}"
+            service._expect_stream(rid)
+            service._queue.put(self._request(rid))
+        time.sleep(0.3)
+        assert service._awaiting_submit == set()

--- a/tests/entrypoints/test_atom_standalone_service.py
+++ b/tests/entrypoints/test_atom_standalone_service.py
@@ -381,6 +381,10 @@ class TestAStreamClosedBeforeItStartedIsStillStopped:
         )
 
         service = self._service()
+        # What `start_stream` does before putting it on the worker queue.
+        # Registering here rather than reaching into the set keeps the test on
+        # the same registrar production uses.
+        service._expect_stream("r1")
         request = EngineStreamRequest(
             request_id="r1",
             prompt="hi",
@@ -412,6 +416,7 @@ class TestAStreamClosedBeforeItStartedIsStillStopped:
         )
 
         service = self._service()
+        service._expect_stream("r4")
         building = threading.Event()
         may_finish = threading.Event()
         original = service.engine.preprocess
@@ -482,6 +487,40 @@ class TestAStreamClosedBeforeItStartedIsStillStopped:
         assert "r3" not in service._stream_seqs and "r3" not in service._abandoned
         service.close()
 
+    def test_and_closing_it_afterwards_does_not_remember_it_instead(self):
+        """The documented teardown is drain-until-DONE then close.
+
+        `forget_stream` runs on the drain, so the close that follows finds
+        nothing to pop -- which `abort_stream` reads as "not submitted yet"
+        and remembers forever. One retained id per *successful* request, which
+        is exactly the growth `forget_stream` was added to stop, re-entering
+        through the other door.
+        """
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            EngineStreamRequest,
+        )
+
+        service = self._service()
+        for i in range(50):
+            rid = f"done-{i}"
+            service._submit_stream_request(
+                EngineStreamRequest(
+                    request_id=rid,
+                    prompt="hi",
+                    sampling_params=None,
+                    effective_n=1,
+                    stream_queue=queue.Queue(),
+                )
+            )
+            service.forget_stream(rid)  # what the drain does on completion
+            service.abort_stream(rid)  # what a caller that closes anyway did
+        assert not service._stream_seqs
+        assert len(service._abandoned) == 0, (
+            f"{len(service._abandoned)} completed stream ids retained for the "
+            "life of the process"
+        )
+        service.close()
+
     def test_closing_between_add_request_and_publication_aborts(self):
         """The third window, and the one publication order decides.
 
@@ -498,6 +537,7 @@ class TestAStreamClosedBeforeItStartedIsStillStopped:
         )
 
         service = self._service()
+        service._expect_stream("r5")
         added = threading.Event()
         may_publish = threading.Event()
         original = service.engine.add_request

--- a/tests/entrypoints/test_atom_standalone_service.py
+++ b/tests/entrypoints/test_atom_standalone_service.py
@@ -610,6 +610,25 @@ class TestTheSubmitWindowClosesOnEveryPath:
         return AtomEngineService(self._Engine(), _StubTokenizer())
 
     @staticmethod
+    def _settled(service, deadline: float = 5.0) -> bool:
+        """Wait for the worker to finish, not for the queue to drain.
+
+        `queue.empty()` goes true when the worker *takes* the last item, which
+        is before it has run `_submit_stream_request` or the `finally` that
+        closes the window -- so asserting after a fixed sleep is a race, and
+        it failed about one run in ten here. Polls the condition under test
+        with a deadline instead.
+        """
+        import time
+
+        end = time.monotonic() + deadline
+        while time.monotonic() < end:
+            if service._queue.empty() and not service._awaiting_submit:
+                return True
+            time.sleep(0.01)
+        return not service._awaiting_submit
+
+    @staticmethod
     def _request(rid):
         from atom.entrypoints.atomesh.atom_standalone_service import (
             EngineStreamRequest,
@@ -670,7 +689,6 @@ class TestTheSubmitWindowClosesOnEveryPath:
     def test_and_the_worker_loop_is_the_one_calling_it(self):
         """Through the real loop, not the helper -- otherwise this tests the
         test's own `finally` rather than the service's."""
-        import time
 
         service = self._service()
         service.engine.boom = True
@@ -678,12 +696,10 @@ class TestTheSubmitWindowClosesOnEveryPath:
             rid = f"loop-{i}"
             service._expect_stream(rid)
             service._queue.put(self._request(rid))
-        for _ in range(100):
-            if service._queue.empty():
-                break
-            time.sleep(0.02)
-        time.sleep(0.2)
-        assert service._awaiting_submit == set()
+        assert self._settled(service), (
+            f"{len(service._awaiting_submit)} ids left after the worker loop "
+            "handled every request"
+        )
         service.close()
 
     def test_and_the_window_closes_after_the_submit_never_before(self):
@@ -696,18 +712,13 @@ class TestTheSubmitWindowClosesOnEveryPath:
         nothing -- and the worker adds the sequences to the engine a moment
         later. They decode to `max_tokens` into a queue nobody will read.
         """
-        import time
 
         service = self._service()
         rid = "ordering"
         service._expect_stream(rid)
         service.engine.gate = lambda: service.abort_stream(rid)
         service._queue.put(self._request(rid))
-        for _ in range(100):
-            if service._queue.empty():
-                break
-            time.sleep(0.02)
-        time.sleep(0.2)
+        assert self._settled(service)
         assert (
             service.engine.added == []
         ), "a stream closed while it was preprocessing still reached the engine"
@@ -715,7 +726,6 @@ class TestTheSubmitWindowClosesOnEveryPath:
         service.close()
 
     def test_and_a_stream_the_shutdown_path_never_submits(self):
-        import time
 
         service = self._service()
         service._closed.set()
@@ -723,5 +733,61 @@ class TestTheSubmitWindowClosesOnEveryPath:
             rid = f"shut-{i}"
             service._expect_stream(rid)
             service._queue.put(self._request(rid))
-        time.sleep(0.3)
-        assert service._awaiting_submit == set()
+        assert self._settled(service)
+
+
+class TestShuttingDownStopsTheDrains:
+    """`close()` must close the states, not just forget them.
+
+    `stream_state.close()` is the only thing that sets `closed`, and a router
+    thread already inside `drain()` does not hold `_streams_lock` -- it wakes
+    from its queue, reads `closed` as False and hands out chunks for a
+    sequence that was just aborted. If `all(finished)` happens to hold it also
+    emits the finish/usage/`[DONE]` tail, so the caller records
+    `finish_reason: stop` on a truncated answer. `close_*_stream` gets the
+    order right; the shutdown path cleared the registry and stopped there.
+    """
+
+    def test_every_open_stream_is_closed_before_its_sequences_are_aborted(self):
+        import threading
+        from unittest.mock import MagicMock
+
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            AtomStandaloneService,
+        )
+
+        service = object.__new__(AtomStandaloneService)
+        service._streams, service._completion_streams = {}, {}
+        service._streams_lock = threading.Lock()
+        service.engine_service = MagicMock()
+        service.engine = MagicMock()
+
+        order = []
+        states = {}
+        for name, registry in (
+            ("chat", service._streams),
+            ("completion", service._completion_streams),
+        ):
+            state = MagicMock()
+            state.closed = False
+
+            def _close(s=state, n=name):
+                s.closed = True
+                order.append(f"close:{n}")
+
+            state.close.side_effect = _close
+            registry[name] = state
+            states[name] = state
+        service.engine_service.abort_stream.side_effect = lambda i: order.append(
+            f"abort:{i}"
+        )
+
+        service.close()
+
+        for name, state in states.items():
+            assert state.closed, f"the {name} stream was aborted but never closed"
+        for name in states:
+            assert order.index(f"close:{name}") < order.index(f"abort:{name}"), (
+                f"{name}: aborted before it was closed, so a drain in flight can "
+                "still hand out chunks for a killed sequence"
+            )

--- a/tests/entrypoints/test_atom_standalone_service.py
+++ b/tests/entrypoints/test_atom_standalone_service.py
@@ -5,6 +5,7 @@
 
 import json
 import queue
+from typing import ClassVar
 
 import pytest
 from import_guard import skip_if_dependency_missing
@@ -87,3 +88,99 @@ class TestChatCompletionStreamStateRoleChunkContent:
 
         second = state.drain(max_items=16, timeout=0.01)
         assert second == []
+
+
+class TestTheDrainKeepsWhatItCannotHandOutYet:
+    """`max_items` is a batch size, not a licence to discard.
+
+    The build loop `break`ed when it reached that count -- after the parser
+    had already yielded the events -- so everything past the first was gone
+    permanently. At `max_items=1` a tool call lost its arguments and, once
+    `has_tool_calls` moved onto the argument event, reported
+    `finish_reason: stop` for a call it had just announced.
+    """
+
+    TOOLS: ClassVar[list] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    CALL = (
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter>"
+        "</function></tool_call>"
+    )
+
+    def _state(self):
+        from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
+
+        return ChatCompletionStreamState(
+            request_id="chatcmpl-test",
+            model_name="model",
+            prompt="hello",
+            tokenizer=_StubTokenizer(),
+            stream_queue=queue.Queue(),
+            n=1,
+            tool_parser_cls=QwenXmlParser,
+            tools=self.TOOLS,
+        )
+
+    @staticmethod
+    def _drain_all(state, event, max_items):
+        out = state._event_to_chunks(event, max_items)
+        idle = {"index": 0, "text": "", "token_ids": [], "finished": True}
+        for _ in range(20):
+            more = state._event_to_chunks(idle, max_items)
+            if not more:
+                break
+            out += more
+        return out
+
+    @pytest.mark.parametrize("max_items", [1, 2, 16])
+    def test_the_arguments_survive_any_batch_size(self, max_items):
+        state = self._state()
+        event = {"index": 0, "text": self.CALL, "token_ids": [1], "finished": True}
+        payloads = [
+            json.loads(c.split("data: ", 1)[1])
+            for c in self._drain_all(state, event, max_items)
+            if c.split("data: ", 1)[1].strip() != "[DONE]"
+        ]
+        arguments = "".join(
+            tc.get("function", {}).get("arguments", "")
+            for p in payloads
+            for tc in (
+                (p.get("choices") or [{}])[0].get("delta", {}).get("tool_calls") or []
+            )
+        )
+        assert '"city"' in arguments, f"arguments lost at max_items={max_items}"
+
+    @pytest.mark.parametrize("max_items", [1, 2, 16])
+    def test_and_the_finish_reason_says_a_tool_was_called(self, max_items):
+        state = self._state()
+        event = {"index": 0, "text": self.CALL, "token_ids": [1], "finished": True}
+        self._drain_all(state, event, max_items)
+        assert state.has_tool_calls == [True]
+
+    @pytest.mark.parametrize("max_items", [1, 2, 16])
+    def test_the_stream_still_closes_at_any_batch_size(self, max_items):
+        """Queueing the overflow made the early return the common path, and
+        it returned before the final chunks -- a fully drained stream with no
+        `finish_reason`, no usage and no `[DONE]`."""
+        state = self._state()
+        event = {"index": 0, "text": self.CALL, "token_ids": [1], "finished": True}
+        chunks = self._drain_all(state, event, max_items)
+        assert chunks[-1].split("data: ", 1)[1].strip() == "[DONE]"
+        reasons = [
+            c["finish_reason"]
+            for raw in chunks
+            if raw.split("data: ", 1)[1].strip() != "[DONE]"
+            for c in json.loads(raw.split("data: ", 1)[1]).get("choices", [])
+            if c.get("finish_reason")
+        ]
+        assert reasons == ["tool_calls"], reasons

--- a/tests/entrypoints/test_atom_standalone_service.py
+++ b/tests/entrypoints/test_atom_standalone_service.py
@@ -481,3 +481,50 @@ class TestAStreamClosedBeforeItStartedIsStillStopped:
         service.forget_stream("r3")
         assert "r3" not in service._stream_seqs and "r3" not in service._abandoned
         service.close()
+
+    def test_closing_between_add_request_and_publication_aborts(self):
+        """The third window, and the one publication order decides.
+
+        Publishing the seqs into `_stream_seqs` *before* `add_request` left a
+        gap where a close popped the list and aborted sequences the engine had
+        not been told about -- the abort raised into a swallowed `except`, the
+        worker then added them, and they decoded to `max_tokens` into a queue
+        nobody would read, holding their KV blocks for the process lifetime.
+        """
+        import threading
+
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            EngineStreamRequest,
+        )
+
+        service = self._service()
+        added = threading.Event()
+        may_publish = threading.Event()
+        original = service.engine.add_request
+
+        def slow_add(seqs):
+            original(seqs)
+            added.set()
+            may_publish.wait(timeout=5)
+
+        service.engine.add_request = slow_add
+        request = EngineStreamRequest(
+            request_id="r5",
+            prompt="hi",
+            sampling_params=None,
+            effective_n=1,
+            stream_queue=queue.Queue(),
+        )
+        worker = threading.Thread(
+            target=service._submit_stream_request, args=(request,)
+        )
+        worker.start()
+        assert added.wait(timeout=5), "add_request never ran"
+        service.abort_stream("r5")  # lands after the engine has them
+        may_publish.set()
+        worker.join(timeout=5)
+        assert service.engine.aborted == [
+            s.id for s in service.engine.added
+        ], "sequences the engine was given were never aborted"
+        assert "r5" not in service._stream_seqs
+        service.close()

--- a/tests/entrypoints/test_atom_standalone_service.py
+++ b/tests/entrypoints/test_atom_standalone_service.py
@@ -15,7 +15,7 @@ try:
     from atom.entrypoints.atomesh.atom_standalone_service import (
         ChatCompletionStreamState,
     )
-except Exception as exc:  # noqa: BLE001 pragma: no cover
+except ImportError as exc:  # pragma: no cover
     skip_if_dependency_missing(exc, "atomesh service import unavailable")
     ChatCompletionStreamState = None  # type: ignore[assignment]
     _import_error = exc

--- a/tests/entrypoints/test_atom_standalone_service.py
+++ b/tests/entrypoints/test_atom_standalone_service.py
@@ -7,12 +7,14 @@ import json
 import queue
 
 import pytest
+from import_guard import skip_if_dependency_missing
 
 try:
     from atom.entrypoints.atomesh.atom_standalone_service import (
         ChatCompletionStreamState,
     )
 except Exception as exc:  # noqa: BLE001 pragma: no cover
+    skip_if_dependency_missing(exc, "atomesh service import unavailable")
     ChatCompletionStreamState = None  # type: ignore[assignment]
     _import_error = exc
 else:

--- a/tests/entrypoints/test_atom_standalone_service.py
+++ b/tests/entrypoints/test_atom_standalone_service.py
@@ -4,6 +4,7 @@
 """Regression tests for the ATOM standalone service's streaming chat state."""
 
 import json
+import pathlib
 import queue
 from typing import ClassVar
 
@@ -184,3 +185,299 @@ class TestTheDrainKeepsWhatItCannotHandOutYet:
             if c.get("finish_reason")
         ]
         assert reasons == ["tool_calls"], reasons
+
+
+class TestDrainDeliversWhatItBuiltBeforeItFinishes:
+    """Driven through `drain`, which is what the Rust router calls.
+
+    "Every sibling finished" is not the same fact as "everything built has
+    been sent", and three places used the first as a proxy for the second --
+    the top of `drain`, its `queue.Empty` arm, and the `done` event. Each
+    built and handed out the terminal chunks while chunks were still queued,
+    and handing those out sets `completed`, after which the router pops the
+    state and the queued ones are gone.
+
+    At the `max_items=1` the single-chunk poll uses, a response with one tool
+    call reported `finish_reason: tool_calls` having sent no `tool_calls`
+    delta at all.
+    """
+
+    CALL = (
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter>"
+        "</function></tool_call>"
+    )
+    TOOLS: ClassVar[list] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    def _drain_everything(self, max_items: int) -> list[dict]:
+        from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import (
+            QwenXmlParser,
+        )
+
+        stream_queue: queue.Queue = queue.Queue()
+        state = ChatCompletionStreamState(
+            request_id="req",
+            model_name="m",
+            prompt="hi",
+            tokenizer=_StubTokenizer(),
+            stream_queue=stream_queue,
+            n=1,
+            tool_parser_cls=QwenXmlParser,
+            tools=self.TOOLS,
+        )
+        stream_queue.put(
+            {
+                "index": 0,
+                "text": "Sure. " + self.CALL,
+                "token_ids": [1],
+                "finished": True,
+                "finish_reason": "eos",
+            }
+        )
+        stream_queue.put({"done": True})
+        frames: list[str] = []
+        for _ in range(64):
+            got = state.drain(max_items=max_items, timeout=0.0)
+            if not got:
+                break
+            frames.extend(got)
+            if state.completed:
+                break
+        return [
+            json.loads(part[6:])
+            for frame in frames
+            for part in frame.split("\n\n")
+            if part.startswith("data: {")
+        ]
+
+    @pytest.mark.parametrize("max_items", [1, 2, 16])
+    def test_the_tool_call_is_delivered_before_the_stream_is_finished(self, max_items):
+        payloads = self._drain_everything(max_items)
+        args = [
+            tc
+            for p in payloads
+            for c in p.get("choices", [])
+            for tc in c.get("delta", {}).get("tool_calls", [])
+            if "arguments" in tc.get("function", {})
+        ]
+        reasons = [
+            c["finish_reason"]
+            for p in payloads
+            for c in p.get("choices", [])
+            if c.get("finish_reason")
+        ]
+        assert args, f"at max_items={max_items} no arguments were ever sent"
+        assert reasons == ["tool_calls"], reasons
+
+    @pytest.mark.parametrize("max_items", [1, 2, 16])
+    def test_the_answer_before_the_call_is_delivered_too(self, max_items):
+        payloads = self._drain_everything(max_items)
+        content = "".join(
+            c.get("delta", {}).get("content", "")
+            for p in payloads
+            for c in p.get("choices", [])
+        )
+        assert content == "Sure. ", repr(content)
+
+
+class TestEveryMethodSaysHowItIsCalled:
+    """A method whose first parameter is not `self`/`cls` and which declares no
+    decorator is a decorator that went missing.
+
+    `_json_safe` lost its `@staticmethod` to a mechanical re-indent, and both
+    non-streaming endpoints then raised `TypeError` on their final `return`:
+    every POST to /v1/chat/completions and /v1/completions on this entrypoint
+    became a 500, with the engine result built correctly and then discarded.
+    Nothing about the model output mattered, so no behavioural test in this
+    file could see it.
+    """
+
+    def test_no_method_has_lost_its_decorator(self):
+        import ast
+        import inspect
+
+        from atom.entrypoints.atomesh import atom_standalone_service
+
+        source = pathlib.Path(
+            inspect.getsourcefile(atom_standalone_service)
+        ).read_text()
+        offenders = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for fn in node.body:
+                if not isinstance(fn, ast.FunctionDef):
+                    continue
+                decorated = {
+                    getattr(d, "id", getattr(d, "attr", "")) for d in fn.decorator_list
+                }
+                if decorated & {"staticmethod", "classmethod", "property"}:
+                    continue
+                args = fn.args.posonlyargs + fn.args.args
+                if not args or args[0].arg not in ("self", "cls"):
+                    offenders.append(f"{node.name}.{fn.name}")
+        assert not offenders, f"missing @staticmethod/@classmethod on {offenders}"
+
+    def test_json_safe_is_callable_off_the_class(self):
+        """The call the endpoints actually make, on the shape they make it on."""
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            AtomStandaloneService,
+        )
+
+        assert AtomStandaloneService._json_safe({"a": [1, {"b": 2}]}) == {
+            "a": [1, {"b": 2}]
+        }
+
+
+class TestAStreamClosedBeforeItStartedIsStillStopped:
+    """`start_stream` only enqueues; the sequences do not exist until the
+    worker thread runs `_submit_stream_request`.
+
+    A close in that window had nothing to abort, and the sequence was then
+    added to the engine *afterwards* -- decoding to `max_tokens` on the GPU,
+    putting into a queue nobody would ever read, and holding its KV blocks for
+    the life of the process. That is the exact case the abort exists for, and
+    the one it missed.
+    """
+
+    class _Engine:
+        def __init__(self):
+            self.added = []
+            self.aborted = []
+            self.preprocessed = 0
+            self.io_processor = self
+            self.core_mgr = self
+            self.requests = {}
+
+        def preprocess(self, *a, **kw):
+            self.preprocessed += 1
+            return type("Seq", (), {"id": self.preprocessed})()
+
+        def add_request(self, seqs):
+            self.added.extend(seqs)
+
+        def abort_request(self, seq_id):
+            self.aborted.append(seq_id)
+
+    def _service(self):
+        from atom.entrypoints.atomesh.atom_standalone_service import AtomEngineService
+
+        return AtomEngineService(self._Engine(), _StubTokenizer())
+
+    def test_closing_before_submission_stops_it_being_submitted(self):
+        """The close lands before the worker thread picks the request up."""
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            EngineStreamRequest,
+        )
+
+        service = self._service()
+        request = EngineStreamRequest(
+            request_id="r1",
+            prompt="hi",
+            sampling_params=None,
+            effective_n=1,
+            stream_queue=queue.Queue(),
+        )
+        service.abort_stream("r1")  # the close arrives first
+        service._submit_stream_request(request)  # then the worker gets to it
+        assert service.engine.added == [], "a closed stream reached the engine"
+        assert service.engine.preprocessed == 0, (
+            "the sequences were built for a stream already closed; each one "
+            "registers with the engine's io_processor"
+        )
+        service.close()
+
+    def test_closing_during_preprocessing_stops_it_too(self):
+        """And the close lands *while* the sequences are being built.
+
+        The two checks guard different moments and neither covers the other:
+        the first keeps the work from starting, the second keeps its result
+        from reaching the engine. Driven with a real thread, because the race
+        is the whole point.
+        """
+        import threading
+
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            EngineStreamRequest,
+        )
+
+        service = self._service()
+        building = threading.Event()
+        may_finish = threading.Event()
+        original = service.engine.preprocess
+
+        def slow_preprocess(*a, **kw):
+            building.set()
+            may_finish.wait(timeout=5)
+            return original(*a, **kw)
+
+        service.engine.preprocess = slow_preprocess
+        request = EngineStreamRequest(
+            request_id="r4",
+            prompt="hi",
+            sampling_params=None,
+            effective_n=1,
+            stream_queue=queue.Queue(),
+        )
+        worker = threading.Thread(
+            target=service._submit_stream_request, args=(request,)
+        )
+        worker.start()
+        assert building.wait(timeout=5), "preprocessing never started"
+        service.abort_stream("r4")
+        may_finish.set()
+        worker.join(timeout=5)
+        assert (
+            service.engine.added == []
+        ), "sequences built before the close reached the engine after it"
+        service.close()
+
+    def test_closing_after_submission_aborts_what_was_added(self):
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            EngineStreamRequest,
+        )
+
+        service = self._service()
+        request = EngineStreamRequest(
+            request_id="r2",
+            prompt="hi",
+            sampling_params=None,
+            effective_n=1,
+            stream_queue=queue.Queue(),
+        )
+        service._submit_stream_request(request)
+        assert service.engine.added, "the premise is that it was submitted"
+        service.abort_stream("r2")
+        assert service.engine.aborted == [s.id for s in service.engine.added]
+        service.close()
+
+    def test_a_stream_that_ends_on_its_own_is_forgotten(self):
+        """Nothing else drops it, so the map grows for the process lifetime."""
+        from atom.entrypoints.atomesh.atom_standalone_service import (
+            EngineStreamRequest,
+        )
+
+        service = self._service()
+        service._submit_stream_request(
+            EngineStreamRequest(
+                request_id="r3",
+                prompt="hi",
+                sampling_params=None,
+                effective_n=1,
+                stream_queue=queue.Queue(),
+            )
+        )
+        assert "r3" in service._stream_seqs
+        service.forget_stream("r3")
+        assert "r3" not in service._stream_seqs and "r3" not in service._abandoned
+        service.close()

--- a/tests/entrypoints/test_chat_encoders.py
+++ b/tests/entrypoints/test_chat_encoders.py
@@ -3,12 +3,22 @@
 
 """Tests for model-scoped custom chat encoder dispatch."""
 
+import pathlib
+
+import pytest
+from jinja2 import TemplateError
+
+from atom.entrypoints.atomesh import atom_standalone_service
+from atom.entrypoints.openai import api_server
 from atom.entrypoints.openai.chat_encoder_adapters import (
     build_message_encoder_adapter,
 )
 from atom.entrypoints.openai.chat_encoders import (
+    REASONING_OFF_KWARGS,
     _load_encoder_from_dir,
     apply_chat_template,
+    chat_template_source,
+    resolve_reasoning_toggle,
 )
 
 
@@ -132,3 +142,150 @@ def test_jinja_path_forwards_tools_and_generation_kwargs():
         "add_generation_prompt": True,
         "tools": tools,
     }
+
+
+class TestChatTemplateSource:
+    """The template's own text, for the question a rendered prompt cannot answer.
+
+    Whether a model begins inside the reasoning channel shows only in what the
+    template does with a *reply*, so it never reaches a fresh prompt. Measured
+    on this box: Qwen3.5's source carries `<think>` and `</think>`, its
+    rendered prompt carries only the opener, and Qwen3-8B's carries neither.
+    Asking a render would answer False for every model alive.
+
+    Two shapes made the raw attribute answer False by accident, and both are
+    silent, which is why this is a function and not a `getattr`.
+    """
+
+    class Tok:
+        def __init__(self, template):
+            self.chat_template = template
+
+    def test_a_plain_jinja_template_is_itself(self):
+        assert chat_template_source(self.Tok("hello {{ x }}")) == "hello {{ x }}"
+
+    def test_a_multi_template_dict_is_searched_by_value(self):
+        """`"</think>" in <dict>` tests the keys, and quietly says no."""
+        tok = self.Tok({"default": "plain", "tool_use": "closes </think> here"})
+        src = chat_template_source(tok)
+        assert "</think>" in src and "plain" in src
+
+    def test_a_tokenizer_with_no_template_is_empty_not_an_error(self):
+        assert chat_template_source(self.Tok(None)) == ""
+        assert chat_template_source(object()) == ""
+
+    def test_a_python_encoder_contributes_its_source(self):
+        """`chat_template` is None for every model shipping one of these, so
+        the literals live in the module instead."""
+
+        def encode(messages, **kwargs):
+            return "<|open|>think<|sep|>"
+
+        adapter = build_message_encoder_adapter("encoding_probe", encode)
+        src = chat_template_source(self.Tok(None), adapter)
+        assert "<|open|>think<|sep|>" in src
+
+    def test_the_startup_callers_use_it(self):
+        """Both entry points asked `getattr(tokenizer, "chat_template", None)`
+        directly, which is the shape that answers False for a whole class of
+        model. Neither body is reachable from a unit test."""
+        for module in (api_server, atom_standalone_service):
+            src = pathlib.Path(module.__file__).read_text()
+            assert "template_opens_reasoning_implicitly(" in src
+            assert "chat_template_source(" in src, f"{module.__name__} reads it raw"
+            assert 'getattr(tokenizer, "chat_template", None)' not in src
+
+
+class TestResolveReasoningToggle:
+    """Which kwarg switches this model's reasoning off, asked rather than listed.
+
+    A Jinja template silently ignores a kwarg it does not read, so a hardcoded
+    name is a no-op that looks like a feature. Measured on this box:
+    `thinking=False` leaves Qwen3.5's `<think>` prefill exactly where it was,
+    while `enable_thinking=False` replaces it with a closed empty block. The
+    chat path had the hardcoded name, correct for Kimi-K3 alone.
+
+    SGLang answers the same question with ~200 lines of regex over the template
+    source (`template_detection.py`); rendering twice and comparing needs no
+    table and cannot go stale against a template it has never seen.
+    """
+
+    class Tok:
+        """Reads exactly one kwarg, like a real template."""
+
+        def __init__(self, reads: str | None, off_value=False):
+            self.reads = reads
+            self.off_value = off_value
+            self.chat_template = "..."
+
+        def apply_chat_template(self, messages, **kwargs):
+            if self.reads is not None and kwargs.get(self.reads) == self.off_value:
+                return "PROMPT<think>\n\n</think>"
+            return "PROMPT<think>"
+
+    @pytest.mark.parametrize(
+        "name, off", [("enable_thinking", False), ("thinking", False)]
+    )
+    def test_it_finds_the_kwarg_the_template_reads(self, name, off):
+        assert resolve_reasoning_toggle(self.Tok(name, off)) == (name, off)
+
+    def test_it_finds_a_non_boolean_switch(self):
+        tok = self.Tok("thinking_mode", "disabled")
+        assert resolve_reasoning_toggle(tok) == ("thinking_mode", "disabled")
+
+    def test_a_template_with_no_switch_answers_none(self):
+        """gpt-oss and DeepSeek-R1 on this box; saying so is the point."""
+        assert resolve_reasoning_toggle(self.Tok(None)) is None
+
+    def test_a_value_the_encoder_rejects_does_not_end_the_search(self):
+        """DeepSeek-V4's encoder asserts on any `thinking_mode` outside
+        {"chat", "thinking"}, and MiniMax-M3's wants "disabled" -- one kwarg,
+        two disjoint vocabularies. A refusal has to mean "try the next pair",
+        or whichever family is tried second never resolves."""
+
+        class Picky:
+            chat_template = "..."
+
+            def apply_chat_template(self, messages, **kwargs):
+                mode = kwargs.get("thinking_mode")
+                if mode is None:
+                    return "PROMPT<think>"
+                assert mode in ("chat", "thinking"), f"bad mode {mode}"
+                return "PROMPT" if mode == "chat" else "PROMPT<think>"
+
+        assert resolve_reasoning_toggle(Picky()) == ("thinking_mode", "chat")
+
+    def test_the_candidates_cover_both_thinking_mode_vocabularies(self):
+        modes = [v for k, v in REASONING_OFF_KWARGS if k == "thinking_mode"]
+        assert modes == ["disabled", "chat"], (
+            "order matters: MiniMax must match before DeepSeek-V4's rejection "
+            "of 'disabled' sends the probe on to 'chat'"
+        )
+
+    def test_an_unrenderable_template_answers_none(self):
+        class Broken:
+            chat_template = "..."
+
+            def apply_chat_template(self, messages, **kwargs):
+                raise TemplateError("nope")
+
+        assert resolve_reasoning_toggle(Broken()) is None
+
+    def test_every_candidate_switches_reasoning_off_not_on(self):
+        """The values are the *off* values; a typo turning one on would be
+        invisible in the probe, which only checks that the render changed."""
+        assert {v for _, v in REASONING_OFF_KWARGS} == {False, "disabled", "chat"}
+
+    def test_both_endpoints_use_the_resolved_name(self):
+        """A hardcoded kwarg is a no-op on any template that reads another,
+        and a no-op here is invisible -- the model reasons anyway. Neither
+        endpoint body is reachable from a unit test, so this reads the source.
+        """
+        src = pathlib.Path(api_server.__file__).read_text()
+        assert "resolve_reasoning_toggle(" in src, "the toggle is never resolved"
+        assert (
+            src.count("reasoning_toggle") >= 4
+        ), "resolved but not used by both the chat and Anthropic paths"
+        assert (
+            'merged_kwargs["thinking"] = _th_enabled' not in src
+        ), "the chat path still writes a hardcoded kwarg name for every model"

--- a/tests/entrypoints/test_chat_encoders.py
+++ b/tests/entrypoints/test_chat_encoders.py
@@ -14,12 +14,15 @@ from atom.entrypoints.openai.chat_encoder_adapters import (
     build_message_encoder_adapter,
 )
 from atom.entrypoints.openai.chat_encoders import (
+    _PROBE_REFUSALS,
     REASONING_TOGGLES,
     _load_encoder_from_dir,
     apply_chat_template,
     chat_template_source,
+    render_probe_prompt,
     resolve_reasoning_toggle,
 )
+from atom.entrypoints.openai.tool_parser.registry import resolve_tool_call_parser
 
 
 def test_loader_selects_dsv4_adapter_and_preserves_encoder_defaults(tmp_path):
@@ -343,3 +346,46 @@ class TestResolveReasoningToggle:
         ]
         assert not hardcoded, f"hardcoded reasoning kwarg name(s): {hardcoded}"
         assert "reasoning_toggle" in src, "it never consults the resolved name"
+
+
+class TestAModelWithNoChatTemplateStillBoots:
+    """Both startup probes run before the engine is created.
+
+    So a template that refuses one does not degrade a feature, it stops the
+    server. `transformers` raises `ValueError` for a checkpoint that ships no
+    chat template at all, `render_probe_prompt` caught only `TemplateError`
+    and `TypeError`, and a base model that used to serve `/v1/completions`
+    perfectly well died at startup instead.
+    """
+
+    class NoTemplate:
+        def apply_chat_template(self, *args, **kwargs):
+            raise ValueError(
+                "Cannot use chat template functions because "
+                "tokenizer.chat_template is not set"
+            )
+
+    def test_the_two_probes_agree_on_what_a_refusal_is(self):
+        """They ask the same template the same kind of question. Disagreeing
+        about which exceptions mean "no" is what let one of them through."""
+        source = pathlib.Path("atom/entrypoints/openai/chat_encoders.py").read_text()
+        assert (
+            "except _PROBE_REFUSALS" in source
+        ), "render_probe_prompt has its own refusal list again"
+
+    def test_valueerror_is_a_refusal(self):
+        assert ValueError in _PROBE_REFUSALS
+
+    def test_the_probe_returns_none_rather_than_raising(self):
+        assert render_probe_prompt(self.NoTemplate(), None, tools=True) is None
+
+    @pytest.mark.parametrize(
+        "probe",
+        [
+            lambda t: resolve_reasoning_toggle(t, None),
+            lambda t: resolve_tool_call_parser(None, t, None),
+        ],
+        ids=["reasoning", "tool-parser"],
+    )
+    def test_neither_startup_probe_raises(self, probe):
+        assert probe(self.NoTemplate()) is None

--- a/tests/entrypoints/test_chat_encoders.py
+++ b/tests/entrypoints/test_chat_encoders.py
@@ -14,7 +14,7 @@ from atom.entrypoints.openai.chat_encoder_adapters import (
     build_message_encoder_adapter,
 )
 from atom.entrypoints.openai.chat_encoders import (
-    REASONING_OFF_KWARGS,
+    REASONING_TOGGLES,
     _load_encoder_from_dir,
     apply_chat_template,
     chat_template_source,
@@ -174,16 +174,29 @@ class TestChatTemplateSource:
         assert chat_template_source(self.Tok(None)) == ""
         assert chat_template_source(object()) == ""
 
-    def test_a_python_encoder_contributes_its_source(self):
+    def test_a_python_encoder_contributes_its_source(self, tmp_path):
         """`chat_template` is None for every model shipping one of these, so
         the literals live in the module instead."""
 
         def encode(messages, **kwargs):
-            return "<|open|>think<|sep|>"
+            return "unused"
 
-        adapter = build_message_encoder_adapter("encoding_probe", encode)
+        # The path, not the function: `encode` is a closure defined in
+        # `chat_encoders`, so asking `inspect.getmodule` for it returned
+        # ATOM's own source -- 11 KB of this repo instead of the model's
+        # 27 KB encoder, and the answer keyed on ATOM's own comments.
+        model_file = tmp_path / "encoding_probe.py"
+        model_file.write_text("MARKER = '<|open|>think<|sep|>'\n")
+        adapter = build_message_encoder_adapter(
+            "encoding_probe", encode, str(model_file)
+        )
         src = chat_template_source(self.Tok(None), adapter)
         assert "<|open|>think<|sep|>" in src
+        assert "_load_encoder_from_dir" not in src, "it read ATOM's own source"
+
+    def test_an_encoder_with_no_path_contributes_nothing(self):
+        adapter = build_message_encoder_adapter("x", lambda m, **k: "")
+        assert chat_template_source(self.Tok(None), adapter) == ""
 
     def test_the_startup_callers_use_it(self):
         """Both entry points asked `getattr(tokenizer, "chat_template", None)`
@@ -227,11 +240,14 @@ class TestResolveReasoningToggle:
         "name, off", [("enable_thinking", False), ("thinking", False)]
     )
     def test_it_finds_the_kwarg_the_template_reads(self, name, off):
-        assert resolve_reasoning_toggle(self.Tok(name, off)) == (name, off)
+        expected_on = next(
+            on for k, o, on in REASONING_TOGGLES if (k, o) == (name, off)
+        )
+        assert resolve_reasoning_toggle(self.Tok(name, off)) == (name, off, expected_on)
 
     def test_it_finds_a_non_boolean_switch(self):
         tok = self.Tok("thinking_mode", "disabled")
-        assert resolve_reasoning_toggle(tok) == ("thinking_mode", "disabled")
+        assert resolve_reasoning_toggle(tok) == ("thinking_mode", "disabled", "enabled")
 
     def test_a_template_with_no_switch_answers_none(self):
         """gpt-oss and DeepSeek-R1 on this box; saying so is the point."""
@@ -253,10 +269,14 @@ class TestResolveReasoningToggle:
                 assert mode in ("chat", "thinking"), f"bad mode {mode}"
                 return "PROMPT" if mode == "chat" else "PROMPT<think>"
 
-        assert resolve_reasoning_toggle(Picky()) == ("thinking_mode", "chat")
+        assert resolve_reasoning_toggle(Picky()) == (
+            "thinking_mode",
+            "chat",
+            "thinking",
+        )
 
     def test_the_candidates_cover_both_thinking_mode_vocabularies(self):
-        modes = [v for k, v in REASONING_OFF_KWARGS if k == "thinking_mode"]
+        modes = [off for k, off, _ in REASONING_TOGGLES if k == "thinking_mode"]
         assert modes == ["disabled", "chat"], (
             "order matters: MiniMax must match before DeepSeek-V4's rejection "
             "of 'disabled' sends the probe on to 'chat'"
@@ -274,18 +294,52 @@ class TestResolveReasoningToggle:
     def test_every_candidate_switches_reasoning_off_not_on(self):
         """The values are the *off* values; a typo turning one on would be
         invisible in the probe, which only checks that the render changed."""
-        assert {v for _, v in REASONING_OFF_KWARGS} == {False, "disabled", "chat"}
+        assert {off for _, off, _ in REASONING_TOGGLES} == {False, "disabled", "chat"}
+        assert {on for _, _, on in REASONING_TOGGLES} == {True, "enabled", "thinking"}
+        for name, off, on in REASONING_TOGGLES:
+            assert off != on, name
 
-    def test_both_endpoints_use_the_resolved_name(self):
-        """A hardcoded kwarg is a no-op on any template that reads another,
-        and a no-op here is invisible -- the model reasons anyway. Neither
-        endpoint body is reachable from a unit test, so this reads the source.
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_both_directions_use_the_resolved_name(self, enabled):
+        """Asserted on the kwargs produced, not on a source literal.
+
+        The previous version checked that the string
+        `merged_kwargs["thinking"] = _th_enabled` was absent. Splitting that
+        line into an `if`/`elif` and writing `= True` in the enable branch
+        satisfied it while leaving the enable direction hardcoded -- a no-op
+        on every template that reads another name, which is all of Qwen.
         """
-        src = pathlib.Path(api_server.__file__).read_text()
-        assert "resolve_reasoning_toggle(" in src, "the toggle is never resolved"
-        assert (
-            src.count("reasoning_toggle") >= 4
-        ), "resolved but not used by both the chat and Anthropic paths"
-        assert (
-            'merged_kwargs["thinking"] = _th_enabled' not in src
-        ), "the chat path still writes a hardcoded kwarg name for every model"
+        toggle = ("enable_thinking", False, True)
+
+        class Req:
+            thinking = {"type": "enabled"} if enabled else {"type": "disabled"}
+
+        kwargs = api_server.anthropic_template_kwargs(Req(), toggle)
+        assert kwargs == {"enable_thinking": enabled}
+        assert "thinking" not in kwargs, "a hardcoded kwarg name came back"
+
+    def test_the_chat_path_writes_no_hardcoded_reasoning_kwarg(self):
+        """That body is inside a route handler no unit test reaches, so this
+        reads the source -- but for the shape of the answer, not a literal:
+        no `merged_kwargs["<anything about thinking>"] = ...` at all."""
+        import ast
+        import inspect
+        import textwrap
+
+        # Only the on/off names. `thinking_effort` is a separate control --
+        # an effort level, validated against the dialects' own vocabulary --
+        # and is not what the resolved toggle answers.
+        _TOGGLE_NAMES = {name for name, _, _ in REASONING_TOGGLES}
+        src = inspect.getsource(api_server.chat_completions)
+        tree = ast.parse(textwrap.dedent(src))
+        hardcoded = [
+            n.slice.value
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Subscript)
+            and isinstance(n.ctx, ast.Store)
+            and getattr(n.value, "id", "") == "merged_kwargs"
+            and isinstance(n.slice, ast.Constant)
+            and str(n.slice.value) in _TOGGLE_NAMES
+        ]
+        assert not hardcoded, f"hardcoded reasoning kwarg name(s): {hardcoded}"
+        assert "reasoning_toggle" in src, "it never consults the resolved name"

--- a/tests/entrypoints/test_implicit_reasoning_models.py
+++ b/tests/entrypoints/test_implicit_reasoning_models.py
@@ -78,3 +78,59 @@ class TestWhatItBuys:
         # `"\n\n2 + 2 = 4."` on the wire.
         assert (reasoning or "") == streamed_r
         assert content == streamed_c
+
+
+class TestAskingForNoThinkingOnlyCountsWhereItCanBeHonoured:
+    """`thinking: disabled` reaches the model through the chat template's own
+    switch. A template with no such switch cannot carry it.
+
+    DeepSeek-R1 is that model: it begins inside the reasoning channel with no
+    marker, and `resolve_reasoning_toggle` answers `None` for it. Asking it not
+    to think puts nothing in the prompt, so it reasons exactly as always --
+    and believing the request anyway stopped the channel being separated, so
+    the client got the chain of thought and a literal `</think>` inside
+    `content`. Reasoning that was asked not to happen and happened anyway is
+    still reasoning; `anthropic_drop_reasoning` exists to withhold it, and it
+    can only withhold what was separated.
+    """
+
+    ANSWER = "The user wants the capital.</think>Paris."
+
+    @staticmethod
+    def _channel(toggle, thinking_off):
+        import atom.entrypoints.openai.api_server as api
+        from atom.entrypoints.openai.reasoning_dialects import resolve_dialect
+
+        before = (
+            api.reasoning_dialect,
+            api.model_starts_in_reasoning,
+            api.reasoning_toggle,
+        )
+        try:
+            api.reasoning_dialect, _ = resolve_dialect("<think></think>")
+            api.model_starts_in_reasoning = True
+            api.reasoning_toggle = toggle
+            return api.reasoning_channel(False, thinking_off=thinking_off)
+        finally:
+            (
+                api.reasoning_dialect,
+                api.model_starts_in_reasoning,
+                api.reasoning_toggle,
+            ) = before
+
+    def test_a_model_with_no_switch_is_separated_anyway(self):
+        channel = self._channel(None, thinking_off=True)
+        assert channel.split(self.ANSWER) == ("The user wants the capital.", "Paris.")
+
+    def test_a_model_with_a_switch_takes_the_request_at_its_word(self):
+        channel = self._channel(("enable_thinking", False, True), thinking_off=True)
+        assert channel.split(self.ANSWER) == (None, self.ANSWER)
+
+    @pytest.mark.parametrize(
+        "toggle", [None, ("enable_thinking", False, True)], ids=["no-switch", "switch"]
+    )
+    def test_an_unstated_request_always_separates(self, toggle):
+        """Absent means unstated, and unstated leaves the model's own default
+        alone -- at this layer as at the prompt layer."""
+        channel = self._channel(toggle, thinking_off=False)
+        assert channel.split(self.ANSWER) == ("The user wants the capital.", "Paris.")

--- a/tests/entrypoints/test_implicit_reasoning_models.py
+++ b/tests/entrypoints/test_implicit_reasoning_models.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Models that begin inside the reasoning channel with no marker anywhere.
+
+DeepSeek-R1 emits `</think>` but neither its prompt nor its output carries
+`<think>`. Nothing in a single response says so — its first token is already
+reasoning and reads like an answer — so the fact has to be known before the
+response starts, and the chat template is what knows it.
+
+vLLM expresses the same fact by registering `DeepSeekR1ReasoningParser`, whose
+only job is to override the streaming branch so a stream with no start token
+counts as reasoning until the end marker. Registering a class per family and
+reading the template are two spellings of one decision; this is the second.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atom.entrypoints.openai.reasoning import (
+    ReasoningFilter,
+    separate_reasoning,
+    template_opens_reasoning_implicitly,
+)
+
+# Shapes taken from the real templates on this box, reduced to what decides.
+R1 = "...{{ content.split('</think>')|last }}...<｜Assistant｜>"
+QWEN = "...<think>\n{{ reasoning }}\n</think>...<|im_start|>assistant\n<think>\n"
+MINIMAX = "...[e~[\\n]~b]ai\\n..."
+
+
+class TestTheRule:
+    def test_a_template_that_closes_what_it_never_opens(self):
+        assert template_opens_reasoning_implicitly(R1)
+
+    def test_a_template_that_opens_its_own_does_not_count(self):
+        """Qwen mentions both, so its model emits the opener itself.
+
+        Treating it as implicit would put the model's own `<think>` inside the
+        reasoning text and start every plain answer in the wrong channel.
+        """
+        assert not template_opens_reasoning_implicitly(QWEN)
+
+    @pytest.mark.parametrize("template", [MINIMAX, "", "plain assistant template"])
+    def test_a_template_with_no_reasoning_channel_does_not_count(self, template):
+        assert not template_opens_reasoning_implicitly(template)
+
+
+class TestWhatItBuys:
+    RAW = "Let me work it out.</think>\n\n2 + 2 = 4."
+
+    def test_unseeded_and_unflagged_the_end_marker_is_just_text(self):
+        """The default, unchanged: nothing opened a channel, so nothing closed one."""
+        reasoning, content = separate_reasoning(self.RAW)
+        assert reasoning is None and content == self.RAW
+
+    def test_flagged_the_reasoning_is_recovered(self):
+        reasoning, content = separate_reasoning(self.RAW, starts_thinking=True)
+        assert reasoning == "Let me work it out."
+        assert content == "2 + 2 = 4."
+
+    def test_streaming_and_non_streaming_agree_once_flagged(self):
+        """The flag is one value read by both paths, so they cannot diverge."""
+        reasoning, content = separate_reasoning(self.RAW, starts_thinking=True)
+
+        rf = ReasoningFilter(starts_thinking=True)
+        segments = []
+        for i in range(0, len(self.RAW), 4):
+            segments += rf.process(self.RAW[i : i + 4])
+        segments += rf.flush()
+        streamed_r = "".join(s for f, s in segments if f == "reasoning_content")
+        streamed_c = "".join(s for f, s in segments if f == "content")
+
+        assert (reasoning or "") == streamed_r.strip()
+        assert content == streamed_c.strip()

--- a/tests/entrypoints/test_implicit_reasoning_models.py
+++ b/tests/entrypoints/test_implicit_reasoning_models.py
@@ -58,7 +58,7 @@ class TestWhatItBuys:
     def test_flagged_the_reasoning_is_recovered(self):
         reasoning, content = separate_reasoning(self.RAW, starts_thinking=True)
         assert reasoning == "Let me work it out."
-        assert content == "2 + 2 = 4."
+        assert content == "\n\n2 + 2 = 4."
 
     def test_streaming_and_non_streaming_agree_once_flagged(self):
         """The flag is one value read by both paths, so they cannot diverge."""
@@ -72,5 +72,9 @@ class TestWhatItBuys:
         streamed_r = "".join(s for f, s in segments if f == "reasoning_content")
         streamed_c = "".join(s for f, s in segments if f == "content")
 
-        assert (reasoning or "") == streamed_r.strip()
-        assert content == streamed_c.strip()
+        # Compared byte-for-byte. This used to `.strip()` the streamed side
+        # to make the two agree, which is what a divergence looks like when a
+        # test is written around it: `content` was `"2 + 2 = 4."` here and
+        # `"\n\n2 + 2 = 4."` on the wire.
+        assert (reasoning or "") == streamed_r
+        assert content == streamed_c

--- a/tests/entrypoints/test_implicit_reasoning_models.py
+++ b/tests/entrypoints/test_implicit_reasoning_models.py
@@ -96,8 +96,19 @@ class TestAskingForNoThinkingOnlyCountsWhereItCanBeHonoured:
 
     ANSWER = "The user wants the capital.</think>Paris."
 
+    SWITCH = ("enable_thinking", False, True)
+
     @staticmethod
-    def _channel(toggle, thinking_off):
+    def _channel(toggle, template_kwargs):
+        """The channel this request would get, on a model that begins inside
+        one implicitly.
+
+        `template_kwargs` is what actually went into the render -- the server
+        defaults merged with the client's own, with the request's `thinking`
+        field written in by name on top. Passing the request field instead
+        was the defect: an operator's `--default-chat-template-kwargs` never
+        reached this decision.
+        """
         import atom.entrypoints.openai.api_server as api
         from atom.entrypoints.openai.reasoning_dialects import resolve_dialect
 
@@ -110,7 +121,7 @@ class TestAskingForNoThinkingOnlyCountsWhereItCanBeHonoured:
             api.reasoning_dialect, _ = resolve_dialect("<think></think>")
             api.model_starts_in_reasoning = True
             api.reasoning_toggle = toggle
-            return api.reasoning_channel(False, thinking_off=thinking_off)
+            return api.reasoning_channel(False, template_kwargs=template_kwargs)
         finally:
             (
                 api.reasoning_dialect,
@@ -118,19 +129,44 @@ class TestAskingForNoThinkingOnlyCountsWhereItCanBeHonoured:
                 api.reasoning_toggle,
             ) = before
 
-    def test_a_model_with_no_switch_is_separated_anyway(self):
-        channel = self._channel(None, thinking_off=True)
-        assert channel.split(self.ANSWER) == ("The user wants the capital.", "Paris.")
+    SEPARATED = ("The user wants the capital.", "Paris.")
 
-    def test_a_model_with_a_switch_takes_the_request_at_its_word(self):
-        channel = self._channel(("enable_thinking", False, True), thinking_off=True)
+    def test_a_model_with_no_switch_is_separated_anyway(self):
+        """No toggle means nothing about thinking reached the prompt, so the
+        model reasons as always however the request was written. True by
+        construction now: with no toggle there is no kwarg name to look for."""
+        channel = self._channel(None, {"enable_thinking": False})
+        assert channel.split(self.ANSWER) == self.SEPARATED
+
+    def test_a_model_with_a_switch_takes_the_render_at_its_word(self):
+        channel = self._channel(self.SWITCH, {"enable_thinking": False})
         assert channel.split(self.ANSWER) == (None, self.ANSWER)
 
     @pytest.mark.parametrize(
-        "toggle", [None, ("enable_thinking", False, True)], ids=["no-switch", "switch"]
+        "kwargs",
+        [None, {}, {"enable_thinking": True}],
+        ids=["none", "empty", "switched-on"],
     )
-    def test_an_unstated_request_always_separates(self, toggle):
+    def test_anything_but_the_off_value_separates(self, kwargs):
         """Absent means unstated, and unstated leaves the model's own default
         alone -- at this layer as at the prompt layer."""
-        channel = self._channel(toggle, thinking_off=False)
-        assert channel.split(self.ANSWER) == ("The user wants the capital.", "Paris.")
+        channel = self._channel(self.SWITCH, kwargs)
+        assert channel.split(self.ANSWER) == self.SEPARATED
+
+    def test_a_kwarg_this_template_does_not_read_changes_nothing(self):
+        """The name has to be the resolved toggle's. A Qwen-spelled switch
+        sent to a Kimi-K3 template is a kwarg the render ignores, so the model
+        thinks anyway -- and believing it would stop the channel being
+        separated while the chain of thought went on being produced."""
+        channel = self._channel(self.SWITCH, {"thinking": False})
+        assert channel.split(self.ANSWER) == self.SEPARATED
+
+    def test_an_operator_default_reaches_the_decision(self):
+        """The defect. `--default-chat-template-kwargs '{"enable_thinking":
+        false}'` renders a prompt that does not open the channel, but
+        `thinking_off` was read from the request's own `thinking` field, which
+        is absent -- so the model-level fact was OR-ed back in and the whole
+        answer came back as `reasoning_content` with `content` empty."""
+        merged = {"enable_thinking": False}  # a server default, no request field
+        channel = self._channel(self.SWITCH, merged)
+        assert channel.split(self.ANSWER) == (None, self.ANSWER)

--- a/tests/entrypoints/test_marker_scanner.py
+++ b/tests/entrypoints/test_marker_scanner.py
@@ -199,20 +199,26 @@ class TestThePrecomputedPlanChangesNothing:
     @pytest.mark.parametrize("markers", MARKER_SETS, ids=lambda m: f"{len(m)}-markers")
     def test_it_agrees_with_the_one_marker_form_everywhere(self, markers):
         rng = random.Random(0)
-        scanner = MarkerScanner(markers)
         for _ in range(3000):
-            buf = "".join(rng.choice(self.ALPHABET) for _ in range(rng.randint(0, 16)))
-            oracle = max(partial_suffix_len(buf, m) for m in scanner._markers)
-            assert scanner._held_suffix_len(buf) == oracle, buf
-
-    @pytest.mark.parametrize("markers", MARKER_SETS, ids=lambda m: f"{len(m)}-markers")
-    def test_the_stateless_form_agrees_too(self, markers):
-        """`reasoning` owns its buffer and asks the same question."""
-        rng = random.Random(1)
-        for _ in range(2000):
             buf = "".join(rng.choice(self.ALPHABET) for _ in range(rng.randint(0, 16)))
             oracle = max(partial_suffix_len(buf, m) for m in markers)
             assert held_suffix_len(buf, markers) == oracle, buf
+
+    def test_the_scanner_holds_exactly_what_that_says(self):
+        """The scanner and the stateless form are one function now, and this
+        is what says so from the outside: what `feed` withholds is what
+        `held_suffix_len` reports, for every chunk of every marker set."""
+        rng = random.Random(1)
+        for markers in self.MARKER_SETS:
+            for _ in range(1500):
+                buf = "".join(
+                    rng.choice(self.ALPHABET) for _ in range(rng.randint(0, 16))
+                )
+                scanner = MarkerScanner(markers)
+                scan = scanner.feed(buf)
+                if scan.hit is not None:
+                    continue  # a completed marker is a different branch
+                assert len(scanner.held) == held_suffix_len(buf, markers), buf
 
     def test_the_plan_is_shared_between_scanners(self):
         """It is cached on the marker set: a scanner is built per request and

--- a/tests/entrypoints/test_marker_scanner.py
+++ b/tests/entrypoints/test_marker_scanner.py
@@ -12,12 +12,14 @@ on the inputs someone thought of".
 from __future__ import annotations
 
 import random
+from typing import ClassVar
 
 import pytest
 
 from atom.entrypoints.openai.marker_scanner import (
     MarkerScanner,
     Scan,
+    held_suffix_len,
     partial_suffix_len,
 )
 
@@ -172,3 +174,50 @@ class TestConstruction:
         a = MarkerScanner(TOOL).feed("x<tool_call>y")
         b = MarkerScanner(TOOL + ("<tool_call>",)).feed("x<tool_call>y")
         assert a == b == Scan("x", "<tool_call>", "y")
+
+
+class TestThePrecomputedPlanChangesNothing:
+    """The suffix sweep was rewritten for speed; speed is not the assertion.
+
+    It used to re-slice every marker at every length (`partial_suffix_len` per
+    marker); it now indexes precomputed prefixes by length and rejects most
+    lengths on the first character. `partial_suffix_len` is kept and is the
+    oracle here -- an optimisation of a rule needs the rule to compare against,
+    not a hand-written table of what the optimisation happens to do.
+    """
+
+    ALPHABET = '<|>abctoolcalfunin/_="s '
+    MARKER_SETS: ClassVar[list] = [
+        ("<tool_call>",),
+        ("<think>", "<thinking>", "</think>"),
+        ('<|open|>call tool="', "<|open|>tools<|sep|>", "<|end_of_msg|>"),
+        ("<tool_call>", "<function="),
+        ("a",),
+        ("ab", "abc", "b"),
+    ]
+
+    @pytest.mark.parametrize("markers", MARKER_SETS, ids=lambda m: f"{len(m)}-markers")
+    def test_it_agrees_with_the_one_marker_form_everywhere(self, markers):
+        rng = random.Random(0)
+        scanner = MarkerScanner(markers)
+        for _ in range(3000):
+            buf = "".join(rng.choice(self.ALPHABET) for _ in range(rng.randint(0, 16)))
+            oracle = max(partial_suffix_len(buf, m) for m in scanner._markers)
+            assert scanner._held_suffix_len(buf) == oracle, buf
+
+    @pytest.mark.parametrize("markers", MARKER_SETS, ids=lambda m: f"{len(m)}-markers")
+    def test_the_stateless_form_agrees_too(self, markers):
+        """`reasoning` owns its buffer and asks the same question."""
+        rng = random.Random(1)
+        for _ in range(2000):
+            buf = "".join(rng.choice(self.ALPHABET) for _ in range(rng.randint(0, 16)))
+            oracle = max(partial_suffix_len(buf, m) for m in markers)
+            assert held_suffix_len(buf, markers) == oracle, buf
+
+    def test_the_plan_is_shared_between_scanners(self):
+        """It is cached on the marker set: a scanner is built per request and
+        the sets are class constants, so building it per scanner cost 8.7 us
+        of setup to save 4.5 us per chunk."""
+        a = MarkerScanner(("<tool_call>", "<function="))
+        b = MarkerScanner(("<function=", "<tool_call>"))
+        assert a._prefixes_by_len is b._prefixes_by_len

--- a/tests/entrypoints/test_marker_scanner.py
+++ b/tests/entrypoints/test_marker_scanner.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""The one rule for how much of a stream can be released.
+
+Everything here is about the boundary between "this could still become a
+marker" and "this never will". The properties the callers rely on are stated
+as properties, because the failures they replace were all of the form "correct
+on the inputs someone thought of".
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from atom.entrypoints.openai.marker_scanner import (
+    MarkerScanner,
+    Scan,
+    partial_suffix_len,
+)
+
+TOOL = ("<tool_call>", "<function=")
+THINK = ("<think>", "</think>")
+
+
+def run(markers, chunks) -> tuple[str, tuple[str, ...]]:
+    """Drive a scanner and return (everything released, the markers hit).
+
+    Deliberately not `Scan.rest`. That is how much text happened to be in hand
+    when the marker completed -- everything after it in the same chunk -- so it
+    is larger for coarse chunkings and empty for one-character ones. It is a
+    buffer handoff, not something a client can observe, and putting it in the
+    key would make chunk-invariance fail on a scanner that is behaving. What
+    must not vary is the text released and which markers fired.
+    """
+    s = MarkerScanner(markers)
+    out, hits = "", []
+    for c in chunks:
+        pending = c
+        while True:
+            scan = s.feed(pending)
+            out += scan.released
+            if not scan.hit:
+                break
+            # `feed` stops at the first marker and hands the rest back: a hit
+            # is a state change, and where the text after it goes is the
+            # caller's call, not the scanner's. This caller keeps scanning, so
+            # it feeds the rest back -- without which a second marker in the
+            # same chunk is never seen, and the result depends on whether the
+            # chunking happened to put the two markers together.
+            hits.append(scan.hit)
+            pending = scan.rest
+    return out + s.flush(), tuple(hits)
+
+
+class TestPartialSuffixLen:
+    def test_a_marker_character_that_is_not_at_the_end_holds_nothing(self):
+        """The bug this replaces, stated as a test.
+
+        `if (a < b)` contains a '<' and can never become `<tool_call>`,
+        because the '<' is not where the next character would extend it.
+        """
+        assert partial_suffix_len("if (a < b) { return a; }", "<tool_call>") == 0
+
+    @pytest.mark.parametrize(
+        "tail, want", [("<", 1), ("<t", 2), ("<tool_", 6), ("<tool_call", 10)]
+    )
+    def test_a_growing_prefix_is_measured(self, tail, want):
+        assert partial_suffix_len("some answer " + tail, "<tool_call>") == want
+
+    def test_a_complete_marker_is_not_a_partial_one(self):
+        """Capped at len-1: completeness is the caller's separate question."""
+        assert partial_suffix_len("x<tool_call>", "<tool_call>") == 0
+
+    def test_the_longest_overlap_wins(self):
+        """`<<think>` ends with both '<' and '<<'; the short answer leaks."""
+        assert partial_suffix_len("x<<", "<<think>") == 2
+
+
+class TestBoundedWithhold:
+    def test_a_stray_marker_character_does_not_hold_the_answer(self):
+        text = "Here is the fix: if (a < b) { return a; } and that is all."
+        out, hits = run(TOOL, [text[i : i + 4] for i in range(0, len(text), 4)])
+        assert out == text and not hits
+
+    def test_the_held_buffer_never_exceeds_the_longest_marker(self):
+        """The invariant that makes a stall unrepresentable rather than tested."""
+        s = MarkerScanner(TOOL)
+        longest = max(len(m) for m in TOOL)
+        text = ("< <t <to <tool <tool_c prose " * 40) + "<tool_"
+        for i in range(0, len(text), 3):
+            s.feed(text[i : i + 3])
+            assert len(s.held) < longest
+
+    def test_text_is_released_before_the_marker_that_follows_it(self):
+        out, hits = run(TOOL, ["Sure. ", "<tool", "_call>", "{}"])
+        assert out == "Sure. {}"
+        assert hits == ("<tool_call>",)
+
+
+# The shapes every property below is checked against: no marker, a stray
+# marker character, a marker in the middle, a marker pair, a dangling partial,
+# two markers running together, and nothing at all.
+CASES = [
+    "plain text with no markers at all",
+    "a < b and c < d, all prose",
+    "before <tool_call> after",
+    "<think>reasoning about a < b</think>the answer",
+    "trailing partial <func",
+    "<tool_call><tool_call> twice",
+    "",
+]
+
+
+class TestChunkInvariance:
+    @pytest.mark.parametrize("text", CASES)
+    @pytest.mark.parametrize("markers", [TOOL, THINK, TOOL + THINK])
+    def test_where_the_boundaries_fall_changes_nothing(self, text, markers):
+        rng = random.Random(7)
+        ways = [[text]] + [
+            [text[i : i + n] for i in range(0, len(text), n)] for n in (1, 2, 3, 5)
+        ]
+        for _ in range(4):
+            parts, i = [], 0
+            while i < len(text):
+                n = rng.randint(1, 9)
+                parts.append(text[i : i + n])
+                i += n
+            ways.append(parts)
+        results = {run(markers, w) for w in ways}
+        assert len(results) == 1, f"{len(results)} different results: {results}"
+
+
+class TestConservation:
+    @pytest.mark.parametrize("text", CASES)
+    def test_every_byte_comes_back(self, text):
+        """Released text plus the markers hit must reconstitute the input."""
+        s = MarkerScanner(TOOL + THINK)
+        rebuilt = ""
+        for i in range(0, len(text), 2):
+            scan = s.feed(text[i : i + 2])
+            rebuilt += scan.released + (scan.hit or "") + scan.rest
+        assert rebuilt + s.flush() == text
+
+
+class TestMarkerPrecedence:
+    def test_the_rest_is_handed_back_not_kept(self):
+        """A hit is a state change, so what follows is the caller's to route."""
+        scan = MarkerScanner(TOOL).feed('Sure. <tool_call>{"a": 1}')
+        assert scan == Scan("Sure. ", "<tool_call>", '{"a": 1}')
+
+    def test_the_earliest_marker_wins(self):
+        scan = MarkerScanner(TOOL).feed("a <function=x b <tool_call>")
+        assert scan.hit == "<function=" and scan.released == "a "
+
+    def test_at_one_position_the_longest_wins(self):
+        """Otherwise a marker that prefixes another truncates it."""
+        scan = MarkerScanner(("<think>", "<thinking>")).feed("x<thinking>y")
+        assert scan.hit == "<thinking>" and scan.rest == "y"
+
+
+class TestConstruction:
+    @pytest.mark.parametrize("bad", [(), ("",), ("<a>", "")])
+    def test_an_empty_marker_is_refused(self, bad):
+        """It would match everywhere and hold nothing; fail where it is set."""
+        with pytest.raises(ValueError):
+            MarkerScanner(bad)
+
+    def test_duplicates_do_not_change_the_answer(self):
+        a = MarkerScanner(TOOL).feed("x<tool_call>y")
+        b = MarkerScanner(TOOL + ("<tool_call>",)).feed("x<tool_call>y")
+        assert a == b == Scan("x", "<tool_call>", "y")

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -3,6 +3,8 @@
 
 """Tests for reasoning/thinking content separation."""
 
+import pytest
+
 from atom.entrypoints.openai.reasoning import (
     ReasoningFilter,
     separate_reasoning,
@@ -231,3 +233,53 @@ class TestReasoningFilter:
         results.extend(rf.flush())
         content = "".join(t for f, t in results if f == "content")
         assert "Hi" in content
+
+
+class TestTheChannelEndsAtWhicheverCloserComesFirst:
+    """One rule, where there were three branches and one of them lost data.
+
+    A channel format can leave the think channel by *opening* another one, so
+    `<|close|>think<|sep|>` and `<|open|>response<|sep|>` both end it. The
+    branch for the second returned `reasoning=None` and discarded everything
+    ahead of the marker: a single byte between the two was enough to reach
+    it, and the chain of thought then appeared in neither field.
+
+    And all three were ungated, so a model that merely *quotes* one of these
+    tokens had the text before it deleted -- the inference `parse_tool_calls`
+    was changed to stop making, in the half still making it.
+    """
+
+    THINK_END = "<|close|>think<|sep|>"
+    RESPONSE = "<|open|>response<|sep|>"
+
+    def test_a_byte_between_the_markers_keeps_the_reasoning(self):
+        text = f"my reasoning{self.THINK_END}\n{self.RESPONSE}the answer"
+        reasoning, content = separate_reasoning(text, starts_thinking=True)
+        assert reasoning == "my reasoning"
+        assert "the answer" in content
+
+    def test_opening_the_response_channel_ends_the_reasoning(self):
+        text = f"my reasoning{self.RESPONSE}the answer"
+        reasoning, content = separate_reasoning(text, starts_thinking=True)
+        assert reasoning == "my reasoning"
+        assert content == "the answer"
+
+    @pytest.mark.parametrize("marker_attr", ["THINK_END", "RESPONSE"])
+    def test_a_quoted_token_is_text_when_no_channel_was_opened(self, marker_attr):
+        marker = getattr(self, marker_attr)
+        text = f"The K3 format uses {marker} to open the answer."
+        assert separate_reasoning(text, starts_thinking=False) == (None, text)
+
+    @pytest.mark.parametrize("chunk", [1, 3, 999])
+    def test_the_streaming_filter_closes_on_the_same_markers(self, chunk):
+        """It knew only the explicit close, so a K3 answer that goes straight
+        to the response channel -- its own docs call that the common path --
+        streamed entirely as `reasoning_content` with an empty `content`."""
+        text = f"{self.RESPONSE}Hello world"
+        f = ReasoningFilter(starts_thinking=True)
+        segs = []
+        for i in range(0, len(text), chunk):
+            segs += f.process(text[i : i + chunk])
+        segs += f.flush()
+        assert "".join(s for k, s in segs if k == "content") == "Hello world"
+        assert "".join(s for k, s in segs if k == "reasoning_content") == ""

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -563,3 +563,81 @@ class TestTheRenderedPromptIsNotCopiedToReadItsEnd:
             f"{self.LARGE_KB} KB allocated {large} bytes against {small} for "
             f"{self.SMALL_KB} KB; the prompt is being copied to read its end"
         )
+
+
+class TestNonReasoningOutputIsNotWithheld:
+    """A stream that never opens a reasoning channel must still reach the client.
+
+    The shapes are PR #1961's, kept verbatim. They came off an observed
+    production stall -- 1.5-2.4% of requests on a Claude-Code agent corpus
+    returned HTTP 200 and then zero body bytes until the client's 600s read
+    timeout, while the engine decoded to `max_tokens` -- and an observed shape
+    is worth more than one invented to fit the rule.
+
+    The rule itself is `TestBoundedWithhold` in
+    `test_stream_marker_properties.py`, which asks it of every registered
+    dialect crossed with every format, against a control with the trigger
+    characters neutralised. These are the point cases beside that axis, and
+    they pass here for a structural reason rather than a patched one: the
+    buffer-and-threshold state machine #1961 fixes (`len(self.buf) > 100 and
+    "<" not in self.buf`, which withheld everything for as long as the answer
+    contained a `<` anywhere -- and code is full of them) no longer exists.
+    `MarkerScanner` releases whatever cannot begin a declared marker, so there
+    is no threshold to tune and nowhere for the defect to live.
+
+    Measured against a scanner mutated to withhold anything containing a `<`:
+    the first two catch it, the last three are feature guards and correctly do
+    not, and `test_token_by_token_code_output_streams` does not either -- it
+    asserts only that *something* was emitted, and under partial withholding
+    something still is. Said out loud because a test that cannot fail reads
+    like one that can. `TestBoundedWithhold` is where the discrimination
+    lives: it compares the first content byte's offset against the same text
+    with its trigger characters neutralised.
+    """
+
+    @staticmethod
+    def _emit(chunks):
+        f = ReasoningFilter()
+        out = []
+        for c in chunks:
+            out.extend(f.process(c))
+        return out
+
+    def test_angle_bracket_in_plain_output_does_not_withhold_forever(self):
+        # A '<' that is not a reasoning marker: the classic case is code.
+        text = "Here is the fix:\n\nif (a < b) { return a; }\n" + "x" * 200
+        emitted = self._emit([text])
+        assert emitted, "nothing was emitted: the stream would stall"
+        assert "".join(t for f, t in emitted if f == "content").startswith(
+            "Here is the fix:"
+        )
+
+    def test_html_like_output_does_not_withhold_forever(self):
+        emitted = self._emit(["<div class='x'>hello</div>\n" + "y" * 200])
+        assert emitted, "nothing was emitted: the stream would stall"
+
+    def test_token_by_token_code_output_streams(self):
+        # The real shape: many small chunks, one of which contains '<'.
+        chunks = ["Sure. ", "Use ", "a < b ", "to compare. "] + [
+            "word " for _ in range(60)
+        ]
+        assert self._emit(chunks), "nothing was emitted: the stream would stall"
+
+    def test_a_real_think_block_still_separates(self):
+        # The fix must not cost the feature it guards.
+        out = self._emit(["<think>", "pondering", "</think>", "answer"])
+        assert ("reasoning_content", "pondering") in out
+        assert ("content", "answer") in out
+
+    def test_partial_end_marker_is_still_held_back(self):
+        # A marker split across chunks must not leak as content.
+        out = self._emit(["<think>", "abc", "</thi"])
+        assert not any("</thi" in t for _, t in out), "leaked a partial marker"
+
+    def test_template_injected_opener_still_reaches_end_marker(self):
+        f = ReasoningFilter(starts_thinking=True)
+        out = []
+        for c in ["reasoning here", "</think>", "final"]:
+            out.extend(f.process(c))
+        assert ("reasoning_content", "reasoning here") in out
+        assert ("content", "final") in out

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -84,17 +84,55 @@ class TestSeparateReasoning:
 
     def test_no_think_start_tag(self):
         """MiniMax M2.7 pattern: model doesn't generate <think>, only </think>.
-        The chat template injects <think> as part of the prompt."""
+
+        The chat template injects <think> into the prompt, which is what
+        `starts_thinking` carries -- the text itself cannot say so, and this
+        used to be inferred from the bare `</think>`. Inferring it is what the
+        streaming path cannot do without waiting for an end marker that may
+        never come, so the two disagreed; the caller answers it once now.
+        """
         text = "The user wants hello world...\n</think>\n\nprint('Hello')"
-        reasoning, content = separate_reasoning(text)
+        reasoning, content = separate_reasoning(text, starts_thinking=True)
         assert reasoning == "The user wants hello world..."
         assert content == "print('Hello')"
 
     def test_no_think_start_tag_empty_content(self):
         text = "Reasoning only\n</think>"
-        reasoning, content = separate_reasoning(text)
+        reasoning, content = separate_reasoning(text, starts_thinking=True)
         assert reasoning == "Reasoning only"
         assert content == ""
+
+    def test_an_unopened_end_tag_is_text_when_the_prompt_did_not_open_one(self):
+        """The other side of the same switch, and the reason it is a switch.
+
+        Unseeded, nothing opened a reasoning channel, so a stray `</think>`
+        is a string the model wrote. Claiming it as a delimiter is a guess,
+        and the guess is what made an ordinary answer wait for an end marker
+        that was never coming.
+        """
+        text = "The user wants hello world...\n</think>\n\nprint('Hello')"
+        reasoning, content = separate_reasoning(text)
+        assert reasoning is None
+        assert content == text
+
+    def test_streaming_and_non_streaming_agree_on_a_truncated_trace(self):
+        """Same prompt, same output, same split -- whether streamed or not.
+
+        A reasoning model stopped at `max_tokens` emits no end marker. Seeded,
+        both paths must call the whole thing reasoning; the streaming path did
+        while this one called it content, so a client reading `content` saw
+        the trace and a client reading `delta.content` saw nothing.
+        """
+        raw = "Let me consider whether the user wants a GLM parser. " * 4
+        reasoning, content = separate_reasoning(raw, starts_thinking=True)
+
+        rf = ReasoningFilter(starts_thinking=True)
+        segments = rf.process(raw) + rf.flush()
+        streamed_reasoning = "".join(s for f, s in segments if f == "reasoning_content")
+        streamed_content = "".join(s for f, s in segments if f == "content")
+
+        assert (reasoning or "") == streamed_reasoning
+        assert content == streamed_content
 
 
 # ============================================================================

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -280,10 +280,18 @@ class TestTheChannelEndsAtWhicheverCloserComesFirst:
         assert content == "the answer"
 
     @pytest.mark.parametrize("marker_attr", ["THINK_END", "RESPONSE"])
-    def test_a_quoted_token_is_text_when_no_channel_was_opened(self, marker_attr):
+    def test_a_quoted_token_does_not_open_a_channel_that_was_closed(self, marker_attr):
+        """It stays content. Whether the *token* survives is a separate
+        question -- `<|open|>response<|sep|>` is framing this format wraps
+        every answer in, so it is removed on both delivery paths, while
+        `<|close|>think<|sep|>` is a channel delimiter and only means anything
+        once a channel is open."""
         marker = getattr(self, marker_attr)
         text = f"The K3 format uses {marker} to open the answer."
-        assert self.K3_CLOSED.split(text) == (None, text)
+        reasoning, content = self.K3_CLOSED.split(text)
+        assert reasoning is None
+        assert content == self.K3_CLOSED.dialect.strip_framing(text)
+        assert "The K3 format uses" in content and "to open the answer." in content
 
     @pytest.mark.parametrize("chunk", [1, 3, 999])
     def test_the_streaming_filter_closes_on_the_same_markers(self, chunk):
@@ -430,7 +438,11 @@ class TestTheReasoningStageAgreesWithItselfWithoutHelp:
         markers and nothing else."""
         dialect, _ = resolve_dialect(source)
         channel = ReasoningChannel(dialect=dialect, starts_open=starts_open)
-        declared = (dialect.output_open_marker, *dialect.end_markers)
+        declared = (
+            dialect.output_open_marker,
+            *dialect.end_markers,
+            *dialect.content_framing,
+        )
         for text in self.SHAPES:
             reasoning, content = channel.split(text)
             rebuilt = (reasoning or "") + content
@@ -442,3 +454,26 @@ class TestTheReasoningStageAgreesWithItselfWithoutHelp:
                 f"{text!r} -> {rebuilt!r}: bytes went missing that no marker "
                 "accounts for"
             )
+
+
+class TestTheDialectsAsRegistered:
+    """The properties above are checked on dialects; these check the registry.
+
+    A property test that builds its own dialect proves the mechanism and
+    nothing about what any model is actually served with. The channel format's
+    answer framing was declared in exactly one place, and blanking it there
+    left every mechanism test green while a Kimi-K3 client got
+    `<|open|>response<|sep|>` in its content.
+    """
+
+    def test_the_channel_dialect_declares_the_framing_it_wraps_answers_in(self):
+        dialect, _ = resolve_dialect("<|open|>think<|sep|>")
+        framed = "<|open|>response<|sep|>Hi there.<|close|>response<|sep|>"
+        assert ReasoningChannel(dialect=dialect).split(framed) == (None, "Hi there.")
+
+    def test_and_the_inline_think_dialect_declares_none(self):
+        dialect, _ = resolve_dialect("<think></think>")
+        assert dialect.content_framing == (), (
+            "a dialect that wraps nothing must declare nothing, or it deletes "
+            "literals out of ordinary answers"
+        )

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -77,10 +77,18 @@ class TestSeparateReasoning:
         assert reasoning == "thinking only"
         assert content == ""
 
-    def test_whitespace_after_thinking(self):
+    def test_whitespace_after_thinking_survives(self):
+        """It used to be trimmed here and delivered by the streaming path.
+
+        The newline a model writes before its answer is not a marker this
+        dialect declares, and only markers may be removed -- the same rule
+        `ToolCallParser.parse` states one stage later, after a trailing
+        `.strip()` there cost a code-block answer its final newline.
+        """
         text = "<think>thought</think>\n\nThe answer."
         reasoning, content = separate_reasoning(text)
-        assert content == "The answer."
+        assert content == "\n\nThe answer."
+        assert reasoning == "thought"
 
     def test_no_think_start_tag(self):
         """MiniMax M2.7 pattern: model doesn't generate <think>, only </think>.
@@ -93,13 +101,13 @@ class TestSeparateReasoning:
         """
         text = "The user wants hello world...\n</think>\n\nprint('Hello')"
         reasoning, content = separate_reasoning(text, starts_thinking=True)
-        assert reasoning == "The user wants hello world..."
-        assert content == "print('Hello')"
+        assert reasoning == "The user wants hello world...\n"
+        assert content == "\n\nprint('Hello')"
 
     def test_no_think_start_tag_empty_content(self):
         text = "Reasoning only\n</think>"
         reasoning, content = separate_reasoning(text, starts_thinking=True)
-        assert reasoning == "Reasoning only"
+        assert reasoning == "Reasoning only\n"
         assert content == ""
 
     def test_an_unopened_end_tag_is_text_when_the_prompt_did_not_open_one(self):

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -10,6 +10,7 @@ import pytest
 from atom.entrypoints.openai.reasoning import (
     ReasoningChannel,
     ReasoningFilter,
+    prompt_starts_in_reasoning,
     separate_reasoning,
 )
 from atom.entrypoints.openai.reasoning_dialects import resolve_dialect
@@ -470,6 +471,38 @@ class TestTheDialectsAsRegistered:
         dialect, _ = resolve_dialect("<|open|>think<|sep|>")
         framed = "<|open|>response<|sep|>Hi there.<|close|>response<|sep|>"
         assert ReasoningChannel(dialect=dialect).split(framed) == (None, "Hi there.")
+
+    def test_minimax_m3_resolves_to_its_own_tags(self):
+        """`<mm:think>`, not `<think>`.
+
+        MiniMax-M3's template sets `think_begin_token = '<mm:think>'`, and no
+        dialect declared either literal -- so it fell through to the inline
+        `<think>` entry, matched nothing, and delivered the whole chain of
+        thought as `content` with `reasoning_content: null` on both delivery
+        paths. On `/v1/messages`, where reasoning is dropped by default, that
+        put the trace inside the client's text block.
+        """
+        source = (
+            "{%- set think_begin_token = '<mm:think>' -%}"
+            "{%- set think_end_token = '</mm:think>' -%}"
+        )
+        dialect, stated = resolve_dialect(source)
+        assert (dialect.think_end_marker, stated) == ("</mm:think>", True)
+        channel = ReasoningChannel(dialect=dialect, starts_open=True)
+        assert channel.split("Reasoning.</mm:think>The answer.") == (
+            "Reasoning.",
+            "The answer.",
+        )
+        # And the prompt marker, which is what seeds `starts_open` in the
+        # first place: the template ends the generation prompt with the
+        # opener under `thinking_mode == "enabled"`.
+        assert prompt_starts_in_reasoning("]~b]ai\n<mm:think>")
+        assert dialect.output_open_marker == "<mm:think>"
+
+    def test_and_it_does_not_steal_the_generic_think_template(self):
+        """The two marker sets must not shadow each other."""
+        dialect, _ = resolve_dialect("<think></think>")
+        assert dialect.think_end_marker == "</think>"
 
     def test_and_the_inline_think_dialect_declares_none(self):
         dialect, _ = resolve_dialect("<think></think>")

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -3,6 +3,7 @@
 
 """Tests for reasoning/thinking content separation."""
 
+import tracemalloc
 from typing import ClassVar
 
 import pytest
@@ -509,4 +510,54 @@ class TestTheDialectsAsRegistered:
         assert dialect.content_framing == (), (
             "a dialect that wraps nothing must declare nothing, or it deletes "
             "literals out of ordinary answers"
+        )
+
+
+class TestTheRenderedPromptIsNotCopiedToReadItsEnd:
+    """`prompt_starts_in_reasoning` looks at the last twenty bytes of the
+    largest string the server handles.
+
+    It spelled that `prompt.rstrip()`, which copies the whole rendered prompt
+    -- system prompt, tool schemas and the entire history -- once per request,
+    on the event loop. Measured 4.8 us at 512 KB against 0.43 us for the
+    offset form.
+
+    Asserted in bytes allocated, not seconds: a copy is a fact about the
+    allocator, so this says the same thing on any machine and cannot go flaky.
+    `begin_of_markup` carries the twin of this test.
+    """
+
+    SMALL_KB = 16
+    LARGE_KB = 512
+
+    @staticmethod
+    def _peak_bytes(prompt: str) -> int:
+        tracemalloc.start()
+        try:
+            tracemalloc.reset_peak()
+            prompt_starts_in_reasoning(prompt)
+            return tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+
+    def _prompt(self, kb: int) -> str:
+        return ("You are a helpful assistant. " * (kb * 1024 // 29)) + "<think>\n"
+
+    def test_the_answer_is_unchanged(self):
+        assert prompt_starts_in_reasoning(self._prompt(64)) is True
+        assert prompt_starts_in_reasoning("just an ordinary prompt\n") is False
+        assert prompt_starts_in_reasoning("") is False
+        assert prompt_starts_in_reasoning("   \n\t ") is False
+
+    def test_trailing_whitespace_is_still_stepped_over(self):
+        assert prompt_starts_in_reasoning("<think>") is True
+        assert prompt_starts_in_reasoning("<think>  \n\t\n ") is True
+        assert prompt_starts_in_reasoning("<think> x ") is False
+
+    def test_it_allocates_no_more_for_a_prompt_32x_larger(self):
+        small = self._peak_bytes(self._prompt(self.SMALL_KB))
+        large = self._peak_bytes(self._prompt(self.LARGE_KB))
+        assert large < small + 4096, (
+            f"{self.LARGE_KB} KB allocated {large} bytes against {small} for "
+            f"{self.SMALL_KB} KB; the prompt is being copied to read its end"
         )

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -3,12 +3,18 @@
 
 """Tests for reasoning/thinking content separation."""
 
+from typing import ClassVar
+
 import pytest
 
 from atom.entrypoints.openai.reasoning import (
+    ReasoningChannel,
     ReasoningFilter,
     separate_reasoning,
 )
+from atom.entrypoints.openai.reasoning_dialects import resolve_dialect
+from atom.entrypoints.openai.tool_parser import ToolCallStreamParser, parse_tool_calls
+from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 
 # ============================================================================
 # separate_reasoning() Tests
@@ -238,6 +244,13 @@ class TestReasoningFilter:
 class TestTheChannelEndsAtWhicheverCloserComesFirst:
     """One rule, where there were three branches and one of them lost data.
 
+    Driven through a `ReasoningChannel` naming the channel dialect, because
+    that is now what decides these markers mean anything: a model resolves to
+    one dialect at startup and both delivery modes read that one. Asked of the
+    module-level helpers instead, this would be asserting the old behaviour --
+    every dialect tried in turn on one path and the union of their markers on
+    the other, which is the divergence the channel exists to remove.
+
     A channel format can leave the think channel by *opening* another one, so
     `<|close|>think<|sep|>` and `<|open|>response<|sep|>` both end it. The
     branch for the second returned `reasoning=None` and discarded everything
@@ -251,16 +264,18 @@ class TestTheChannelEndsAtWhicheverCloserComesFirst:
 
     THINK_END = "<|close|>think<|sep|>"
     RESPONSE = "<|open|>response<|sep|>"
+    K3 = ReasoningChannel(dialect=resolve_dialect(THINK_END)[0], starts_open=True)
+    K3_CLOSED = ReasoningChannel(dialect=K3.dialect, starts_open=False)
 
     def test_a_byte_between_the_markers_keeps_the_reasoning(self):
         text = f"my reasoning{self.THINK_END}\n{self.RESPONSE}the answer"
-        reasoning, content = separate_reasoning(text, starts_thinking=True)
+        reasoning, content = self.K3.split(text)
         assert reasoning == "my reasoning"
         assert "the answer" in content
 
     def test_opening_the_response_channel_ends_the_reasoning(self):
         text = f"my reasoning{self.RESPONSE}the answer"
-        reasoning, content = separate_reasoning(text, starts_thinking=True)
+        reasoning, content = self.K3.split(text)
         assert reasoning == "my reasoning"
         assert content == "the answer"
 
@@ -268,7 +283,7 @@ class TestTheChannelEndsAtWhicheverCloserComesFirst:
     def test_a_quoted_token_is_text_when_no_channel_was_opened(self, marker_attr):
         marker = getattr(self, marker_attr)
         text = f"The K3 format uses {marker} to open the answer."
-        assert separate_reasoning(text, starts_thinking=False) == (None, text)
+        assert self.K3_CLOSED.split(text) == (None, text)
 
     @pytest.mark.parametrize("chunk", [1, 3, 999])
     def test_the_streaming_filter_closes_on_the_same_markers(self, chunk):
@@ -276,10 +291,154 @@ class TestTheChannelEndsAtWhicheverCloserComesFirst:
         to the response channel -- its own docs call that the common path --
         streamed entirely as `reasoning_content` with an empty `content`."""
         text = f"{self.RESPONSE}Hello world"
-        f = ReasoningFilter(starts_thinking=True)
+        f = self.K3.stream()
         segs = []
         for i in range(0, len(text), chunk):
             segs += f.process(text[i : i + chunk])
         segs += f.flush()
         assert "".join(s for k, s in segs if k == "content") == "Hello world"
         assert "".join(s for k, s in segs if k == "reasoning_content") == ""
+
+
+class TestTheDialectIsReadFromWhicheverEvidenceExists:
+    """A rendered prompt and a template source are both evidence, and only one
+    of them is always available.
+
+    Kimi-K3 ships neither a Jinja `chat_template` nor an encoder under the path
+    the loader searches, so `chat_template_source` returns `""` for it. Reading
+    only the source therefore fell back to the inline-`<think>` dialect and a
+    K3 answer came back as `reasoning_content` with `content` empty -- while
+    the *tool-call* format resolved correctly, because that one reads the
+    rendered probe. One model, two answers to "what does this speak", from two
+    different pieces of evidence.
+    """
+
+    K3_PROMPT = "<|im_system|>you are helpful<|im_end|><|open|>think<|sep|>"
+    QWEN_SOURCE = "{% if enable_thinking %}<think>{% endif %}...</think>"
+
+    def test_the_render_answers_when_the_source_cannot(self):
+        dialect, stated = resolve_dialect("", self.K3_PROMPT)
+        assert dialect.think_end_marker == "<|close|>think<|sep|>"
+        assert stated, "a named dialect must not be reported as a fallback"
+
+    def test_the_source_still_answers_when_there_is_one(self):
+        dialect, stated = resolve_dialect(self.QWEN_SOURCE, "...<think>")
+        assert dialect.think_end_marker == "</think>" and stated
+
+    def test_neither_falls_back_and_says_so(self):
+        dialect, stated = resolve_dialect("", "")
+        assert dialect.think_end_marker == "</think>"
+        assert not stated, "a fallback must be reported as one"
+
+    ANSWER = (
+        "The user wants the capital.<|close|>think<|sep|>"
+        "<|open|>response<|sep|>Paris.<|close|>response<|sep|><|end_of_msg|>"
+    )
+
+    def _channel(self):
+        dialect, _ = resolve_dialect("", self.K3_PROMPT)
+        return ReasoningChannel(dialect=dialect, starts_open=True)
+
+    def test_a_k3_answer_is_split_by_the_dialect_it_resolved_to(self):
+        """The consequence, end to end: the fallback returned `content: ''`."""
+        reasoning, content = self._channel().split(self.ANSWER)
+        assert reasoning == "The user wants the capital."
+        assert "Paris." in content
+
+    @pytest.mark.parametrize("chunk", [1, 5, 999])
+    def test_and_both_delivery_modes_agree_through_the_whole_pipeline(self, chunk):
+        """Reasoning *and* the tool parser, because the channel framing is the
+        latter's to remove.
+
+        The reasoning split used to strip it as well, which made the two paths
+        agree only by way of a third stage and only when a K3 parser had been
+        resolved -- and it truncated at `<|end_of_msg|>` rather than removing
+        it, deleting anything after that token on one path alone.
+        """
+        channel = self._channel()
+        reasoning, rest = channel.split(self.ANSWER)
+        content, _ = parse_tool_calls(rest, None, KimiK3Parser)
+
+        filt, parser = channel.stream(), ToolCallStreamParser(parser_cls=KimiK3Parser)
+        streamed_reasoning, streamed_content = [], []
+        segments = []
+        for i in range(0, len(self.ANSWER), chunk):
+            segments += filt.process(self.ANSWER[i : i + chunk])
+        segments += filt.flush()
+        for field, seg in segments:
+            if field == "reasoning_content":
+                streamed_reasoning.append(seg)
+            else:
+                streamed_content += [
+                    d for k, d in parser.process(seg) if k == "content"
+                ]
+        streamed_content += [d for k, d in parser.flush() if k == "content"]
+
+        assert "".join(streamed_reasoning) == reasoning
+        assert "".join(streamed_content) == content == "Paris."
+
+
+class TestTheReasoningStageAgreesWithItselfWithoutHelp:
+    """`.split()` and `.stream()` must produce the same bytes on their own.
+
+    Not "the same bytes once the tool parser has had them". The reasoning
+    split used to remove Kimi-K3's channel framing itself, which the streaming
+    filter has no step for -- so the two agreed only because a *third* stage
+    removed it on the streamed path too, and only when a K3 parser had been
+    resolved. Asserted here without a tool parser, which is the only way to
+    see it: with one, both paths come out identical either way.
+    """
+
+    SHAPES: ClassVar[list[str]] = [
+        "",
+        "reasoning only",
+        "reason</think>answer",
+        "reason<|close|>think<|sep|>answer",
+        "reason<|close|>think<|sep|><|open|>response<|sep|>Paris.",
+        "reason<|close|>think<|sep|><|open|>response<|sep|>Paris."
+        "<|close|>response<|sep|><|end_of_msg|>",
+        "reason</think>answer<|end_of_msg|>and more",
+        "</think>",
+        "<|close|>think<|sep|>",
+    ]
+
+    @pytest.mark.parametrize("source", ["<think></think>", "<|open|>think<|sep|>"])
+    @pytest.mark.parametrize("starts_open", [True, False])
+    @pytest.mark.parametrize("chunk", [1, 4, 999])
+    def test_the_two_modes_agree_byte_for_byte(self, source, starts_open, chunk):
+        dialect, _ = resolve_dialect(source)
+        channel = ReasoningChannel(dialect=dialect, starts_open=starts_open)
+        for text in self.SHAPES:
+            filt = channel.stream()
+            segments = []
+            for i in range(0, len(text), chunk):
+                segments += filt.process(text[i : i + chunk])
+            segments += filt.flush()
+            streamed = (
+                "".join(x for k, x in segments if k == "reasoning_content") or None,
+                "".join(x for k, x in segments if k == "content"),
+            )
+            assert streamed == channel.split(text), (
+                f"{dialect.think_end_marker!r} starts_open={starts_open} "
+                f"chunk={chunk} text={text!r}: {streamed} != {channel.split(text)}"
+            )
+
+    @pytest.mark.parametrize("source", ["<think></think>", "<|open|>think<|sep|>"])
+    @pytest.mark.parametrize("starts_open", [True, False])
+    def test_and_neither_loses_a_byte_it_did_not_declare(self, source, starts_open):
+        """Everything the model wrote comes back, minus this dialect's own
+        markers and nothing else."""
+        dialect, _ = resolve_dialect(source)
+        channel = ReasoningChannel(dialect=dialect, starts_open=starts_open)
+        declared = (dialect.output_open_marker, *dialect.end_markers)
+        for text in self.SHAPES:
+            reasoning, content = channel.split(text)
+            rebuilt = (reasoning or "") + content
+            remainder = text
+            for marker in declared:
+                if marker:
+                    remainder = remainder.replace(marker, "", 1)
+            assert len(rebuilt) >= len(remainder) - 1, (
+                f"{text!r} -> {rebuilt!r}: bytes went missing that no marker "
+                "accounts for"
+            )

--- a/tests/entrypoints/test_reasoning.py
+++ b/tests/entrypoints/test_reasoning.py
@@ -405,8 +405,10 @@ class TestTheReasoningStageAgreesWithItselfWithoutHelp:
         "reason</think>answer",
         "reason<|close|>think<|sep|>answer",
         "reason<|close|>think<|sep|><|open|>response<|sep|>Paris.",
-        "reason<|close|>think<|sep|><|open|>response<|sep|>Paris."
-        "<|close|>response<|sep|><|end_of_msg|>",
+        (
+            "reason<|close|>think<|sep|><|open|>response<|sep|>Paris."
+            "<|close|>response<|sep|><|end_of_msg|>"
+        ),
         "reason</think>answer<|end_of_msg|>and more",
         "</think>",
         "<|close|>think<|sep|>",

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -8,7 +8,11 @@ import asyncio
 import json
 import pathlib
 
-from atom.entrypoints.openai import serving_chat
+import pytest
+
+from atom.entrypoints.atomesh import atom_standalone_service
+from atom.entrypoints.openai import api_server, serving_chat
+from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.serving_chat import (
     build_chat_response,
     build_chat_response_multi,
@@ -18,7 +22,10 @@ from atom.entrypoints.openai.serving_chat import (
     stream_chat_response_fanout,
 )
 from atom.entrypoints.openai.streaming_dispatch import StreamOutputCollector
+from atom.entrypoints.openai.tool_parser import ToolCallStreamParser, parse_tool_calls
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
+from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
+from atom.entrypoints.openai.tool_parser.registry import parser_for_tool_choice
 
 # ============================================================================
 # normalize_chat_tools Tests
@@ -409,85 +416,120 @@ class TestFanoutCleanupSplit:
         assert request_calls == ["req-3"]
 
 
-def _forbids_none(node) -> bool:
-    """Is this the expression `tool_choice != "none"`?"""
-    return (
-        isinstance(node, ast.Compare)
-        and isinstance(node.left, ast.Name)
-        and node.left.id == "tool_choice"
-        and len(node.ops) == 1
-        and isinstance(node.ops[0], ast.NotEq)
-        and isinstance(node.comparators[0], ast.Constant)
-        and node.comparators[0].value == "none"
-    )
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    }
+]
+A_CALL = (
+    "Sure. <tool_call><function=get_weather><parameter=city>Paris</parameter>"
+    "</function></tool_call>"
+)
 
 
-class TestToolChoiceIsHonouredEverywhereItIsEmitted:
-    """`tool_choice="none"` forbids tool calls on every path that can emit one.
+class TestForbiddingToolCallsDoesNotDeleteTheAnswer:
+    """`tool_choice="none"` suppresses the *call*, not the model's words.
 
-    The single-choice stream gated on it and the fan-out did not, so the same
-    request with `n=2, stream=true` returned `tool_calls` deltas and
-    `finish_reason="tool_calls"` that `n=1` suppressed. Checked by walking the
-    source rather than by listing the four call sites, because the gap was a
-    site nobody listed.
+    It used to be enforced at the twelve places an event is *sent*, across two
+    entrypoints, while the parser went on consuming the region -- so the text
+    was eaten and nothing took its place. Measured on the answer below: 89 of
+    95 characters gone, no event, `finish_reason: stop`.
+
+    The rule now lives at the one place the parser is chosen, which is also
+    the reading that makes sense: the request said this cannot be a call, so
+    it is prose. Stated behaviourally and not as a scan of the source -- the
+    scan this replaces was mutation-checked and accepted `or tool_choice !=
+    "none"`, and it hardcoded one module while the same gap sat in three
+    others.
     """
 
-    SOURCE = pathlib.Path(serving_chat.__file__)
-
-    def test_no_tool_event_is_emitted_without_checking_tool_choice(self):
-        tree = ast.parse(self.SOURCE.read_text())
-        unguarded = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Compare):
-                continue
-            left = node.left
-            if not (isinstance(left, ast.Name) and left.id == "event_type"):
-                continue
-            const = node.comparators[0]
-            if not (
-                isinstance(const, ast.Constant)
-                and isinstance(const.value, str)
-                and const.value.startswith("tool_call_")
-                and const.value != "tool_call_end"
-            ):
-                continue
-            # The comparison is the left half of `event_type == X and <gate>`;
-            # walk up is not available, so re-find the enclosing BoolOp. The
-            # gate must be `tool_choice != "none"` specifically -- an earlier
-            # version asked only whether the name appeared anywhere, and
-            # passed when every gate was inverted to `== "none"`.
-            guarded = any(
-                isinstance(b, ast.BoolOp)
-                and node in b.values
-                and any(_forbids_none(v) for v in b.values)
-                for b in ast.walk(tree)
-                if isinstance(b, ast.BoolOp)
-            )
-            if not guarded:
-                unguarded.append(f"line {node.lineno}: {const.value}")
-        assert not unguarded, "tool events emitted regardless of tool_choice:\n  " + (
-            "\n  ".join(unguarded)
+    @staticmethod
+    def _stream(tool_choice, chunk=7):
+        parser = ToolCallStreamParser(
+            tools=TOOLS,
+            parser_cls=parser_for_tool_choice(QwenXmlParser, tool_choice),
         )
+        events = []
+        for i in range(0, len(A_CALL), chunk):
+            events += parser.process(A_CALL[i : i + chunk])
+        events += parser.flush()
+        return events
 
-    def test_the_scan_matched_something(self):
-        """A matcher that finds no nodes passes forever.
+    @pytest.mark.parametrize(
+        "tool_choice",
+        ["none", {"type": "none"}],
+        ids=["openai-string", "anthropic-object"],
+    )
+    def test_the_whole_answer_is_delivered(self, tool_choice):
+        """Both protocols' spellings, because both endpoints ask."""
+        events = self._stream(tool_choice)
+        assert "".join(d for k, d in events if k == "content") == A_CALL
 
-        `event_type` is one rename away from `etype`, which api_server already
-        uses for the same variable -- and this scan would then be vacuously
-        green.
-        """
-        tree = ast.parse(self.SOURCE.read_text())
-        matched = [
-            n
-            for n in ast.walk(tree)
-            if isinstance(n, ast.Compare)
-            and isinstance(n.left, ast.Name)
-            and n.left.id == "event_type"
+    @pytest.mark.parametrize(
+        "tool_choice",
+        ["none", {"type": "none"}],
+        ids=["openai-string", "anthropic-object"],
+    )
+    def test_and_no_call_is_reported(self, tool_choice):
+        events = self._stream(tool_choice)
+        assert [k for k, _ in events if k.startswith("tool_call")] == []
+        assert not completes_a_tool_call(events)
+
+    @pytest.mark.parametrize(
+        "tool_choice", [None, "auto", "required", {"type": "auto"}]
+    )
+    def test_anything_else_still_calls_the_tool(self, tool_choice):
+        """The prohibition is `none` and nothing else -- reading `required`
+        or a named tool as one would silently stop every such request from
+        ever producing a call."""
+        events = self._stream(tool_choice)
+        assert completes_a_tool_call(events)
+
+    def test_the_two_paths_agree(self):
+        streamed = "".join(d for k, d in self._stream("none") if k == "content")
+        non_streaming, calls = parse_tool_calls(
+            A_CALL, TOOLS, parser_cls=parser_for_tool_choice(QwenXmlParser, "none")
+        )
+        assert calls == [] and non_streaming == streamed
+
+    def test_every_construction_site_goes_through_the_helper(self):
+        """The gap this had was a site nobody listed, so count them rather
+        than list them: a parser built straight from the resolved class again
+        is one endpoint that stopped honouring the field."""
+        roots = [
+            pathlib.Path(serving_chat.__file__),
+            pathlib.Path(api_server.__file__),
+            pathlib.Path(atom_standalone_service.__file__),
         ]
-        assert len(matched) >= 4, f"only {len(matched)} event_type comparisons found"
+        built = unguarded = 0
+        for path in roots:
+            for node in ast.walk(ast.parse(path.read_text())):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                name = getattr(fn, "id", None) or getattr(fn, "attr", None)
+                if name not in ("ToolCallStreamParser", "parse_tool_calls"):
+                    continue
+                built += 1
+                arg = next(
+                    (k.value for k in node.keywords if k.arg == "parser_cls"), None
+                )
+                via_helper = (
+                    isinstance(arg, ast.Call)
+                    and getattr(arg.func, "id", None) == "parser_for_tool_choice"
+                )
+                if not (via_helper or _is_none(arg)):
+                    unguarded += 1
+        assert built >= 4, f"only {built} construction sites found; matcher is stale"
+        assert unguarded == 0, f"{unguarded} of {built} sites bypass the helper"
 
-    def test_an_inverted_gate_is_not_accepted(self):
-        """`tool_choice == "none"` is the opposite rule and must not pass."""
-        assert _forbids_none(ast.parse('tool_choice != "none"', mode="eval").body)
-        assert not _forbids_none(ast.parse('tool_choice == "none"', mode="eval").body)
-        assert not _forbids_none(ast.parse("tool_choice is not None", mode="eval").body)
+
+def _is_none(node) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -14,6 +14,8 @@ from atom.entrypoints.atomesh import atom_standalone_service
 from atom.entrypoints.openai import api_server, serving_chat
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.serving_chat import (
+    _build_chat_choice,
+    _normalize_finish_reason,
     build_chat_response,
     build_chat_response_multi,
     create_chat_chunk,
@@ -533,3 +535,50 @@ class TestForbiddingToolCallsDoesNotDeleteTheAnswer:
 
 def _is_none(node) -> bool:
     return isinstance(node, ast.Constant) and node.value is None
+
+
+class TestTheStreamReportsWhyItStopped:
+    """`stop` was hardcoded on every streaming path.
+
+    So a response the engine cut off at `max_tokens` reported completion
+    while `stream=false` reported `length` for the same generation, and an
+    agentic client kept a truncated answer as final. A `stop_<token_id>`
+    stop -- which the Anthropic endpoint maps to `stop_sequence` -- collapsed
+    the same way. All three lines sat next to edits this branch made.
+    """
+
+    @pytest.mark.parametrize(
+        "engine_reason, expected",
+        [
+            ("max_tokens", "length"),
+            ("length", "length"),
+            ("stop", "stop"),
+            ("stop_163586", "stop"),
+        ],
+    )
+    def test_the_two_paths_agree_on_the_reason(self, engine_reason, expected):
+        assert _build_chat_choice("hi", engine_reason)["finish_reason"] == expected
+        assert (_normalize_finish_reason(engine_reason) or "stop") == expected
+
+    def test_no_reason_at_all_still_ends_the_stream(self):
+        """The engine always gives one for a finished generation; if it did
+        not, a stream still has to close on something."""
+        assert (_normalize_finish_reason(None) or "stop") == "stop"
+
+    def test_no_streaming_path_hardcodes_stop(self):
+        """Counted rather than listed: the gap was a site nobody listed."""
+        hardcoded = 0
+        for path in (
+            pathlib.Path(serving_chat.__file__),
+            pathlib.Path(atom_standalone_service.__file__),
+        ):
+            for node in ast.walk(ast.parse(path.read_text())):
+                if not isinstance(node, ast.IfExp):
+                    continue
+                orelse = node.orelse
+                if isinstance(orelse, ast.Constant) and orelse.value == "stop":
+                    hardcoded += 1
+        assert hardcoded == 0, (
+            f"{hardcoded} streaming path(s) still report `stop` regardless of "
+            "why the engine stopped"
+        )

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -14,21 +14,22 @@ from atom.entrypoints.atomesh import atom_standalone_service
 from atom.entrypoints.openai import api_server, serving_chat
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.serving_chat import (
-    finish_reason_with_calls,
     _build_chat_choice,
     _normalize_finish_reason,
     build_chat_response,
     build_chat_response_multi,
     create_chat_chunk,
+    finish_reason_with_calls,
     normalize_chat_tools,
     stream_chat_response,
     stream_chat_response_fanout,
 )
+from atom.entrypoints.openai.reasoning import NO_REASONING
 from atom.entrypoints.openai.streaming_dispatch import StreamOutputCollector
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser, parse_tool_calls
+from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
-from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.registry import forbids_tool_calls
 
 # ============================================================================
@@ -681,3 +682,25 @@ class TestBeingCutShortOutranksHavingMadeACall:
         )
         assert choice["message"]["tool_calls"], "the salvaged call is the premise"
         assert choice["finish_reason"] == "length"
+
+
+class TestTheReasonAResponseEnded:
+    """`""` is a reason the engine really forwards, and it is not absence.
+
+    `Sequence.leave_reason` starts as the empty string, and a response with no
+    recorded reason arrives carrying it. A truthiness test put
+    `finish_reason: null` in the body, which the OpenAI schema reserves for a
+    choice that is still being generated -- clients wait on it, and some SDKs
+    reject the response outright.
+    """
+
+    def _choice(self, finish_reason):
+        return _build_chat_choice(
+            "the answer", finish_reason, 0, None, None, NO_REASONING, None
+        )
+
+    def test_an_empty_engine_reason_still_terminates_the_choice(self):
+        assert self._choice("")["finish_reason"] == "stop"
+
+    def test_and_a_genuinely_absent_one_is_still_null(self):
+        assert self._choice(None)["finish_reason"] is None

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -12,15 +12,17 @@ import pytest
 
 from atom.entrypoints.atomesh import atom_standalone_service
 from atom.entrypoints.openai import api_server, serving_chat
+from atom.entrypoints.openai.protocol import (
+    openai_stop_reason,
+    openai_stop_reason_with_calls,
+)
 from atom.entrypoints.openai.reasoning import NO_REASONING
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.serving_chat import (
     _build_chat_choice,
-    _normalize_finish_reason,
     build_chat_response,
     build_chat_response_multi,
     create_chat_chunk,
-    finish_reason_with_calls,
     normalize_chat_tools,
     stream_chat_response,
     stream_chat_response_fanout,
@@ -639,12 +641,12 @@ class TestTheStreamReportsWhyItStopped:
     )
     def test_the_two_paths_agree_on_the_reason(self, engine_reason, expected):
         assert _build_chat_choice("hi", engine_reason)["finish_reason"] == expected
-        assert (_normalize_finish_reason(engine_reason) or "stop") == expected
+        assert (openai_stop_reason(engine_reason) or "stop") == expected
 
     def test_no_reason_at_all_still_ends_the_stream(self):
         """The engine always gives one for a finished generation; if it did
         not, a stream still has to close on something."""
-        assert (_normalize_finish_reason(None) or "stop") == "stop"
+        assert (openai_stop_reason(None) or "stop") == "stop"
 
     def test_no_streaming_path_hardcodes_stop(self):
         """Counted rather than listed: the gap was a site nobody listed."""
@@ -690,7 +692,7 @@ class TestBeingCutShortOutranksHavingMadeACall:
         ],
     )
     def test_the_rule(self, engine_reason, has_calls, expected):
-        assert finish_reason_with_calls(engine_reason, has_calls) == expected
+        assert openai_stop_reason_with_calls(engine_reason, has_calls) == expected
 
     def test_end_to_end_on_a_call_the_engine_cut_off(self):
         truncated = "<tool_call><function=get_weather><parameter=city>Par"

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -5,6 +5,7 @@
 
 import ast
 import asyncio
+import inspect
 import json
 import pathlib
 
@@ -16,7 +17,7 @@ from atom.entrypoints.openai.protocol import (
     openai_stop_reason,
     openai_stop_reason_with_calls,
 )
-from atom.entrypoints.openai.reasoning import NO_REASONING
+from atom.entrypoints.openai.reasoning import NO_REASONING, ReasoningChannel
 from atom.entrypoints.openai.serving_anthropic import (
     anthropic_to_openai_tools,
     completes_a_tool_call,
@@ -796,3 +797,85 @@ class TestBothEndpointsAskOneQuestionAboutAToolName:
         assert accepted == usable_tool_name(
             name
         ), f"/v1/messages and /v1/chat/completions disagree about {name!r}"
+
+
+class TestFanoutSeedsImplicitReasoning:
+    """A template-injected opener must reach every fan-out sibling's filter.
+
+    PR #1961's class, translated: it passed `starts_thinking: bool` and this
+    branch passes a `ReasoningChannel`, because the dialect and the
+    starts-open flag were being handed to different readers and had to travel
+    together. The assertions are the same three.
+
+    Kept as behaviour beside `TestEverySeedingSiteIsSeeded`, which walks the
+    AST of `atom/entrypoints/` and refuses an unseeded construction site. That
+    scan is structural and would pass a site that is seeded with the wrong
+    thing; this one drives the generator and reads the deltas. #1961 makes the
+    point that decides it: a direct `ReasoningFilter(starts_thinking=True)`
+    unit test cannot catch this, because the defect is in the wiring.
+    """
+
+    # Long enough to pass any grace period a buffering filter might have, and
+    # carrying a '<' -- the two conditions that decided whether unseeded
+    # reasoning leaked.
+    REASONING = "Checking the bound: if (a < b) we return a. " + "Considering. " * 12
+
+    def _deltas(self, starts_open):
+        """Every delta the fan-out yields for a two-sibling reasoning stream."""
+
+        async def run():
+            collector = StreamOutputCollector("req-rs")
+            for index in (0, 1):
+                collector.put_nowait(
+                    (
+                        index,
+                        {"text": self.REASONING, "token_ids": [1], "finished": False},
+                    )
+                )
+            gen = stream_chat_response_fanout(
+                request_id="req-rs",
+                model="model",
+                shared_collector=collector,
+                seq_ids=[0, 1],
+                num_prompt_tokens=1,
+                cleanup_stream=lambda *a, **k: None,
+                cleanup_request=lambda *a, **k: None,
+                reasoning=ReasoningChannel(starts_open=starts_open),
+            )
+            out = []
+            for _ in range(6):
+                try:
+                    raw = await asyncio.wait_for(gen.__anext__(), timeout=2)
+                except (StopAsyncIteration, TimeoutError):
+                    break
+                if raw.startswith("data: ") and not raw.startswith("data: [DONE]"):
+                    out.append(json.loads(raw[6:])["choices"][0]["delta"])
+            await gen.aclose()
+            return out
+
+        return asyncio.run(run())
+
+    def test_pre_close_text_is_reasoning_not_content(self):
+        deltas = self._deltas(starts_open=True)
+
+        leaked = [d for d in deltas if d.get("content")]
+        assert not leaked, f"reasoning leaked to content: {leaked}"
+        assert any(
+            d.get("reasoning_content") for d in deltas
+        ), f"no reasoning_content was emitted at all: {deltas}"
+
+    def test_without_the_seed_the_same_text_is_not_reasoning(self):
+        # The contrast that shows the seed is what classified it, not the text.
+        # Asserting the text arrives as *content* here would not work: content
+        # segments pass through the tool-call parser, which holds them until
+        # the stream finishes, while reasoning_content is forwarded at once.
+        assert not any(
+            d.get("reasoning_content") for d in self._deltas(starts_open=False)
+        )
+
+    def test_both_streaming_entry_points_accept_the_seed(self):
+        # #1961's bug was a missing parameter, so pin the shape of both.
+        for fn in (stream_chat_response, stream_chat_response_fanout):
+            assert (
+                "reasoning" in inspect.signature(fn).parameters
+            ), f"{fn.__name__} cannot be told the prompt opened reasoning"

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -12,6 +12,7 @@ import pytest
 
 from atom.entrypoints.atomesh import atom_standalone_service
 from atom.entrypoints.openai import api_server, serving_chat
+from atom.entrypoints.openai.reasoning import NO_REASONING
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.serving_chat import (
     _build_chat_choice,
@@ -24,7 +25,6 @@ from atom.entrypoints.openai.serving_chat import (
     stream_chat_response,
     stream_chat_response_fanout,
 )
-from atom.entrypoints.openai.reasoning import NO_REASONING
 from atom.entrypoints.openai.streaming_dispatch import StreamOutputCollector
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser, parse_tool_calls
 from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -3,9 +3,12 @@
 
 """Tests for chat completion serving logic (chunk creation, response building)."""
 
+import ast
 import asyncio
 import json
+import pathlib
 
+from atom.entrypoints.openai import serving_chat
 from atom.entrypoints.openai.serving_chat import (
     build_chat_response,
     build_chat_response_multi,
@@ -398,3 +401,48 @@ class TestFanoutCleanupSplit:
         _, request_calls = self._cleanup_calls([70, 71, 72, 73])
 
         assert request_calls == ["req-3"]
+
+
+class TestToolChoiceIsHonouredEverywhereItIsEmitted:
+    """`tool_choice="none"` forbids tool calls on every path that can emit one.
+
+    The single-choice stream gated on it and the fan-out did not, so the same
+    request with `n=2, stream=true` returned `tool_calls` deltas and
+    `finish_reason="tool_calls"` that `n=1` suppressed. Checked by walking the
+    source rather than by listing the four call sites, because the gap was a
+    site nobody listed.
+    """
+
+    SOURCE = pathlib.Path(serving_chat.__file__)
+
+    def test_no_tool_event_is_emitted_without_checking_tool_choice(self):
+        tree = ast.parse(self.SOURCE.read_text())
+        unguarded = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Compare):
+                continue
+            left = node.left
+            if not (isinstance(left, ast.Name) and left.id == "event_type"):
+                continue
+            const = node.comparators[0]
+            if not (
+                isinstance(const, ast.Constant)
+                and isinstance(const.value, str)
+                and const.value.startswith("tool_call_")
+                and const.value != "tool_call_end"
+            ):
+                continue
+            # The comparison is the left half of `event_type == X and <gate>`;
+            # walk up is not available, so re-find the enclosing BoolOp.
+            guarded = any(
+                isinstance(b, ast.BoolOp)
+                and node in b.values
+                and any("tool_choice" in ast.dump(v) for v in b.values)
+                for b in ast.walk(tree)
+                if isinstance(b, ast.BoolOp)
+            )
+            if not guarded:
+                unguarded.append(f"line {node.lineno}: {const.value}")
+        assert not unguarded, "tool events emitted regardless of tool_choice:\n  " + (
+            "\n  ".join(unguarded)
+        )

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -14,6 +14,7 @@ from atom.entrypoints.atomesh import atom_standalone_service
 from atom.entrypoints.openai import api_server, serving_chat
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.serving_chat import (
+    finish_reason_with_calls,
     _build_chat_choice,
     _normalize_finish_reason,
     build_chat_response,
@@ -27,7 +28,8 @@ from atom.entrypoints.openai.streaming_dispatch import StreamOutputCollector
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser, parse_tool_calls
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
-from atom.entrypoints.openai.tool_parser.registry import parser_for_tool_choice
+from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
+from atom.entrypoints.openai.tool_parser.registry import forbids_tool_calls
 
 # ============================================================================
 # normalize_chat_tools Tests
@@ -444,23 +446,32 @@ class TestForbiddingToolCallsDoesNotDeleteTheAnswer:
     was eaten and nothing took its place. Measured on the answer below: 89 of
     95 characters gone, no event, `finish_reason: stop`.
 
-    The rule now lives at the one place the parser is chosen, which is also
-    the reading that makes sense: the request said this cannot be a call, so
-    it is prose. Stated behaviourally and not as a scan of the source -- the
-    scan this replaces was mutation-checked and accepted `or tool_choice !=
-    "none"`, and it hardcoded one module while the same gap sat in three
-    others.
+    The rule now lives at the one place the parser is *asked*, as a
+    `suppress_calls` flag, which is also the reading that makes sense: the
+    request said this cannot be a call, so it is prose.
+
+    Not by dropping the parser, which is where the first fix went. Dropping
+    it drops everything else a parser does -- and a format whose framing
+    wraps *every* answer then leaks that framing the moment a request says
+    `none`: Kimi-K3's `Hello there.` arrived as
+    `<|open|>response<|sep|>Hello there.<|close|>response<|sep|><|end_of_msg|>`.
+    `test_a_format_that_normalises_its_framing_still_does` is that.
+
+    Stated behaviourally and not as a scan of the source -- the scan this
+    replaces was mutation-checked and accepted `or tool_choice != "none"`,
+    and it hardcoded one module while the same gap sat in three others.
     """
 
     @staticmethod
-    def _stream(tool_choice, chunk=7):
+    def _stream(tool_choice, chunk=7, text=A_CALL, parser_cls=QwenXmlParser):
         parser = ToolCallStreamParser(
             tools=TOOLS,
-            parser_cls=parser_for_tool_choice(QwenXmlParser, tool_choice),
+            parser_cls=parser_cls,
+            suppress_calls=forbids_tool_calls(tool_choice),
         )
         events = []
-        for i in range(0, len(A_CALL), chunk):
-            events += parser.process(A_CALL[i : i + chunk])
+        for i in range(0, len(text), chunk):
+            events += parser.process(text[i : i + chunk])
         events += parser.flush()
         return events
 
@@ -497,9 +508,55 @@ class TestForbiddingToolCallsDoesNotDeleteTheAnswer:
     def test_the_two_paths_agree(self):
         streamed = "".join(d for k, d in self._stream("none") if k == "content")
         non_streaming, calls = parse_tool_calls(
-            A_CALL, TOOLS, parser_cls=parser_for_tool_choice(QwenXmlParser, "none")
+            A_CALL, TOOLS, parser_cls=QwenXmlParser, suppress_calls=True
         )
         assert calls == [] and non_streaming == streamed
+
+    def test_the_answer_is_not_withheld_to_the_end(self):
+        """A region that can never be a call has nothing to wait for.
+
+        Suppressing dispatch but still buffering meant a request that had
+        already said "no tool calls" got the rest of its answer in one frame
+        at end of stream -- the marker opened a region, and a region is held
+        until it can be parsed.
+        """
+        held = [d for k, d in self._held_back("none") if k == "content"]
+        assert sum(map(len, held)) == 0, f"{sum(map(len, held))} characters held to EOS"
+
+    @staticmethod
+    def _held_back(tool_choice, chunk=7):
+        """Only what `flush` produced -- what streaming failed to deliver."""
+        parser = ToolCallStreamParser(
+            tools=TOOLS,
+            parser_cls=QwenXmlParser,
+            suppress_calls=forbids_tool_calls(tool_choice),
+        )
+        for i in range(0, len(A_CALL), chunk):
+            parser.process(A_CALL[i : i + chunk])
+        return parser.flush()
+
+    def test_a_format_that_normalises_its_framing_still_does(self):
+        """Suppressing a call must not also switch off reading the format.
+
+        Kimi-K3 wraps every answer, tool call or not, in channel tokens that
+        the reader removes. Answering `tool_choice: "none"` by using no
+        parser removed nothing, so the client was handed the wire.
+        """
+        framed = (
+            "<|open|>response<|sep|>Hello there."
+            "<|close|>response<|sep|><|end_of_msg|>"
+        )
+        forbidden = "".join(
+            d
+            for k, d in self._stream("none", text=framed, parser_cls=KimiK3Parser)
+            if k == "content"
+        )
+        allowed = "".join(
+            d
+            for k, d in self._stream(None, text=framed, parser_cls=KimiK3Parser)
+            if k == "content"
+        )
+        assert forbidden == allowed == "Hello there."
 
     def test_every_construction_site_goes_through_the_helper(self):
         """The gap this had was a site nobody listed, so count them rather
@@ -520,14 +577,17 @@ class TestForbiddingToolCallsDoesNotDeleteTheAnswer:
                 if name not in ("ToolCallStreamParser", "parse_tool_calls"):
                     continue
                 built += 1
-                arg = next(
+                parser_arg = next(
                     (k.value for k in node.keywords if k.arg == "parser_cls"), None
                 )
-                via_helper = (
-                    isinstance(arg, ast.Call)
-                    and getattr(arg.func, "id", None) == "parser_for_tool_choice"
+                suppress = next(
+                    (k.value for k in node.keywords if k.arg == "suppress_calls"), None
                 )
-                if not (via_helper or _is_none(arg)):
+                via_helper = (
+                    isinstance(suppress, ast.Call)
+                    and getattr(suppress.func, "id", None) == "forbids_tool_calls"
+                )
+                if not (via_helper or _is_none(parser_arg)):
                     unguarded += 1
         assert built >= 4, f"only {built} construction sites found; matcher is stale"
         assert unguarded == 0, f"{unguarded} of {built} sites bypass the helper"
@@ -582,3 +642,42 @@ class TestTheStreamReportsWhyItStopped:
             f"{hardcoded} streaming path(s) still report `stop` regardless of "
             "why the engine stopped"
         )
+
+
+class TestBeingCutShortOutranksHavingMadeACall:
+    """`tool_calls` says "act on this"; `length` says "this is not all of it".
+
+    A response the engine cut off mid-call still parses to a call -- every
+    format's unclosed-region branch exists to salvage exactly that -- but its
+    last argument value is silently truncated. Reporting `tool_calls` told the
+    client to run the tool with half its arguments and no sign anything was
+    missing. OpenAI reports `length` for a truncated response whatever else is
+    in it.
+    """
+
+    @pytest.mark.parametrize(
+        "engine_reason, has_calls, expected",
+        [
+            ("max_tokens", True, "length"),
+            ("max_tokens", False, "length"),
+            ("length", True, "length"),
+            ("eos", True, "tool_calls"),
+            ("stop_163586", True, "tool_calls"),
+            ("eos", False, "stop"),
+            (None, True, "tool_calls"),
+            (None, False, "stop"),
+        ],
+    )
+    def test_the_rule(self, engine_reason, has_calls, expected):
+        assert finish_reason_with_calls(engine_reason, has_calls) == expected
+
+    def test_end_to_end_on_a_call_the_engine_cut_off(self):
+        truncated = "<tool_call><function=get_weather><parameter=city>Par"
+        choice = _build_chat_choice(
+            truncated,
+            "max_tokens",
+            tools=TOOLS,
+            tool_parser_cls=QwenXmlParser,
+        )
+        assert choice["message"]["tool_calls"], "the salvaged call is the premise"
+        assert choice["finish_reason"] == "length"

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -17,7 +17,10 @@ from atom.entrypoints.openai.protocol import (
     openai_stop_reason_with_calls,
 )
 from atom.entrypoints.openai.reasoning import NO_REASONING
-from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
+from atom.entrypoints.openai.serving_anthropic import (
+    anthropic_to_openai_tools,
+    completes_a_tool_call,
+)
 from atom.entrypoints.openai.serving_chat import (
     _build_chat_choice,
     build_chat_response,
@@ -26,6 +29,7 @@ from atom.entrypoints.openai.serving_chat import (
     normalize_chat_tools,
     stream_chat_response,
     stream_chat_response_fanout,
+    validate_tool_list,
 )
 from atom.entrypoints.openai.streaming_dispatch import StreamOutputCollector
 from atom.entrypoints.openai.tool_parser import ToolCallStreamParser, parse_tool_calls
@@ -33,6 +37,7 @@ from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 from atom.entrypoints.openai.tool_parser.registry import forbids_tool_calls
+from atom.entrypoints.openai.tool_parser.tool_parser import usable_tool_name
 
 # ============================================================================
 # normalize_chat_tools Tests
@@ -726,3 +731,68 @@ class TestTheReasonAResponseEnded:
 
     def test_and_a_genuinely_absent_one_is_still_null(self):
         assert self._choice(None)["finish_reason"] is None
+
+
+class TestBothEndpointsAskOneQuestionAboutAToolName:
+    """What a request may declare is what a parser can dispatch.
+
+    There were two grammars. `protocol.TOOL_NAME_RE`
+    (`^[A-Za-z_][A-Za-z0-9_-]*$`) guarded the chat entrance and was the
+    stricter: it rejected a leading digit that OpenAI's own
+    `^[a-zA-Z0-9_-]{1,64}$` allows, every non-ASCII name, and the
+    `server.tool` spelling MCP namespaces with -- so declaring an MCP tool was
+    a 400 before the model ever ran. `usable_tool_name` guarded the response
+    side and allowed all three. And `/v1/messages` asked neither: it converted
+    the tools and validated nothing, so the two endpoints disagreed about
+    which tools were legal at all.
+    """
+
+    #: Names a client may legitimately declare, and the shape of the mistake
+    #: each one used to be taken for.
+    LEGAL = ("get_weather", "server.tool", "7z_extract", "查天气", "a-b", "_x")
+    ILLEGAL = ("", "   ", "two words", ".hidden", "-lead", "a b.c")
+
+    @staticmethod
+    def _openai(name):
+        return [{"type": "function", "function": {"name": name, "parameters": {}}}]
+
+    @pytest.mark.parametrize("name", LEGAL)
+    def test_a_dispatchable_name_is_accepted_by_the_chat_entrance(self, name):
+        validate_tool_list(self._openai(name))
+
+    @pytest.mark.parametrize("name", ILLEGAL)
+    def test_an_undispatchable_name_is_refused_by_the_chat_entrance(self, name):
+        with pytest.raises(ValueError):
+            validate_tool_list(self._openai(name))
+
+    @pytest.mark.parametrize("name", LEGAL + ILLEGAL)
+    def test_the_entrance_and_the_parsers_agree(self, name):
+        """The property, of which the two tables above are the illustration.
+
+        Neither side may be the stricter: a name the entrance refuses is a
+        tool the client cannot declare, and a name the parsers refuse is a
+        call the model can never be seen to make.
+        """
+        try:
+            validate_tool_list(self._openai(name))
+            accepted = True
+        except ValueError:
+            accepted = False
+        assert accepted == usable_tool_name(name), (
+            f"the entrance and `usable_tool_name` disagree about {name!r}: "
+            f"entrance={accepted}, parsers={usable_tool_name(name)}"
+        )
+
+    @pytest.mark.parametrize("name", LEGAL + ILLEGAL)
+    def test_the_anthropic_entrance_asks_the_same_question(self, name):
+        """`/v1/messages` validates the conversion, so there is one rule and
+        not a second written in Anthropic's spelling."""
+        converted = anthropic_to_openai_tools([{"name": name, "input_schema": {}}])
+        try:
+            validate_tool_list(converted)
+            accepted = True
+        except ValueError:
+            accepted = False
+        assert accepted == usable_tool_name(
+            name
+        ), f"/v1/messages and /v1/chat/completions disagree about {name!r}"

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -18,6 +18,7 @@ from atom.entrypoints.openai.serving_chat import (
     stream_chat_response_fanout,
 )
 from atom.entrypoints.openai.streaming_dispatch import StreamOutputCollector
+from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 
 # ============================================================================
 # normalize_chat_tools Tests
@@ -178,7 +179,12 @@ class TestBuildChatResponse:
             "<|tool_calls_section_end|>"
         )
         output = self._make_output(text=raw)
-        resp = build_chat_response("req-1", "model", raw, output)
+        # The format is the one resolved at startup, so it has to be passed.
+        # Leaving it off used to reach a cascade over the *output*, which is
+        # how an answer quoting these tokens got its text deleted.
+        resp = build_chat_response(
+            "req-1", "model", raw, output, tool_parser_cls=KimiParser
+        )
         assert resp.choices[0]["message"]["content"] == "Hi"
         assert "tool_calls" in resp.choices[0]["message"]
         tc = resp.choices[0]["message"]["tool_calls"][0]

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -403,6 +403,19 @@ class TestFanoutCleanupSplit:
         assert request_calls == ["req-3"]
 
 
+def _forbids_none(node) -> bool:
+    """Is this the expression `tool_choice != "none"`?"""
+    return (
+        isinstance(node, ast.Compare)
+        and isinstance(node.left, ast.Name)
+        and node.left.id == "tool_choice"
+        and len(node.ops) == 1
+        and isinstance(node.ops[0], ast.NotEq)
+        and isinstance(node.comparators[0], ast.Constant)
+        and node.comparators[0].value == "none"
+    )
+
+
 class TestToolChoiceIsHonouredEverywhereItIsEmitted:
     """`tool_choice="none"` forbids tool calls on every path that can emit one.
 
@@ -433,11 +446,14 @@ class TestToolChoiceIsHonouredEverywhereItIsEmitted:
             ):
                 continue
             # The comparison is the left half of `event_type == X and <gate>`;
-            # walk up is not available, so re-find the enclosing BoolOp.
+            # walk up is not available, so re-find the enclosing BoolOp. The
+            # gate must be `tool_choice != "none"` specifically -- an earlier
+            # version asked only whether the name appeared anywhere, and
+            # passed when every gate was inverted to `== "none"`.
             guarded = any(
                 isinstance(b, ast.BoolOp)
                 and node in b.values
-                and any("tool_choice" in ast.dump(v) for v in b.values)
+                and any(_forbids_none(v) for v in b.values)
                 for b in ast.walk(tree)
                 if isinstance(b, ast.BoolOp)
             )
@@ -446,3 +462,26 @@ class TestToolChoiceIsHonouredEverywhereItIsEmitted:
         assert not unguarded, "tool events emitted regardless of tool_choice:\n  " + (
             "\n  ".join(unguarded)
         )
+
+    def test_the_scan_matched_something(self):
+        """A matcher that finds no nodes passes forever.
+
+        `event_type` is one rename away from `etype`, which api_server already
+        uses for the same variable -- and this scan would then be vacuously
+        green.
+        """
+        tree = ast.parse(self.SOURCE.read_text())
+        matched = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Compare)
+            and isinstance(n.left, ast.Name)
+            and n.left.id == "event_type"
+        ]
+        assert len(matched) >= 4, f"only {len(matched)} event_type comparisons found"
+
+    def test_an_inverted_gate_is_not_accepted(self):
+        """`tool_choice == "none"` is the opposite rule and must not pass."""
+        assert _forbids_none(ast.parse('tool_choice != "none"', mode="eval").body)
+        assert not _forbids_none(ast.parse('tool_choice == "none"', mode="eval").body)
+        assert not _forbids_none(ast.parse("tool_choice is not None", mode="eval").body)

--- a/tests/entrypoints/test_serving_chat.py
+++ b/tests/entrypoints/test_serving_chat.py
@@ -447,9 +447,14 @@ class TestForbiddingToolCallsDoesNotDeleteTheAnswer:
     was eaten and nothing took its place. Measured on the answer below: 89 of
     95 characters gone, no event, `finish_reason: stop`.
 
-    The rule now lives at the one place the parser is *asked*, as a
-    `suppress_calls` flag, which is also the reading that makes sense: the
-    request said this cannot be a call, so it is prose.
+    The rule lives at the one place the parser is *asked*, as a
+    `suppress_calls` flag. What that flag suppresses is *dispatch*, not
+    reading. It used to also skip opening the region, on the reading that
+    "the request said this cannot be a call, so it is prose" -- and that
+    reading turned out to be false in its own terms: the bytes released were
+    the model's wire markup, `<invoke name="get_weather">` and payload, on
+    every format. The region is now buffered and parsed exactly as it is for
+    a permitted call, and only the calls are dropped.
 
     Not by dropping the parser, which is where the first fix went. Dropping
     it drops everything else a parser does -- and a format whose framing
@@ -481,10 +486,18 @@ class TestForbiddingToolCallsDoesNotDeleteTheAnswer:
         ["none", {"type": "none"}],
         ids=["openai-string", "anthropic-object"],
     )
-    def test_the_whole_answer_is_delivered(self, tool_choice):
-        """Both protocols' spellings, because both endpoints ask."""
+    def test_the_answer_is_delivered_and_the_markup_is_not(self, tool_choice):
+        """Both protocols' spellings, because both endpoints ask.
+
+        The answer around the call survives. What does not survive is the
+        call's own bytes: a client that asked for no tool calls is not asking
+        to be shown the wire format.
+        """
         events = self._stream(tool_choice)
-        assert "".join(d for k, d in events if k == "content") == A_CALL
+        content = "".join(d for k, d in events if k == "content")
+        assert "Sure." in content, "the answer was eaten again"
+        for token in ("<tool_call>", "<function=", "<parameter=", "</function>"):
+            assert token not in content, f"raw markup shown to the user: {token}"
 
     @pytest.mark.parametrize(
         "tool_choice",
@@ -513,16 +526,22 @@ class TestForbiddingToolCallsDoesNotDeleteTheAnswer:
         )
         assert calls == [] and non_streaming == streamed
 
-    def test_the_answer_is_not_withheld_to_the_end(self):
-        """A region that can never be a call has nothing to wait for.
+    def test_forbidding_calls_withholds_no_more_than_allowing_them(self):
+        """Parity, not zero.
 
-        Suppressing dispatch but still buffering meant a request that had
-        already said "no tool calls" got the rest of its answer in one frame
-        at end of stream -- the marker opened a region, and a region is held
-        until it can be parsed.
+        Reading the format costs a region's worth of buffering, and that cost
+        is the same whatever the request said about dispatch -- it is the
+        latency `_PEEK_WINDOW` and `REGION_END_MARKERS` exist to bound, not
+        something `tool_choice` should change. Zero was the old promise, and
+        it was bought by not reading the format at all, which is what put the
+        raw markup in the answer.
         """
-        held = [d for k, d in self._held_back("none") if k == "content"]
-        assert sum(map(len, held)) == 0, f"{sum(map(len, held))} characters held to EOS"
+        forbidden = sum(len(d) for k, d in self._held_back("none") if k == "content")
+        allowed = sum(len(d) for k, d in self._held_back("auto") if k == "content")
+        assert forbidden <= allowed, (
+            f"forbidding calls held {forbidden} characters to EOS where "
+            f"allowing them held {allowed}"
+        )
 
     @staticmethod
     def _held_back(tool_choice, chunk=7):
@@ -604,7 +623,8 @@ class TestTheStreamReportsWhyItStopped:
     So a response the engine cut off at `max_tokens` reported completion
     while `stream=false` reported `length` for the same generation, and an
     agentic client kept a truncated answer as final. A `stop_<token_id>`
-    stop -- which the Anthropic endpoint maps to `stop_sequence` -- collapsed
+    stop -- a model EOS token other than the primary one, which both
+    endpoints report as an ordinary ending -- collapsed
     the same way. All three lines sat next to edits this branch made.
     """
 

--- a/tests/entrypoints/test_serving_completion.py
+++ b/tests/entrypoints/test_serving_completion.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""`/v1/completions` reports why generation stopped, in OpenAI's vocabulary.
+
+There was no test file for this endpoint at all, and no `finish_reason`
+assertion anywhere for it -- which is how it stayed the one path that never
+normalised. The chat path and atomesh's completion twin both do; this one
+forwarded the engine's own word on the content chunk and hardcoded `"stop"`
+on the terminal one, so `max_tokens` -- the only reason that carries a warning
+-- was lost on the wire while `stream=false` still reported it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from atom.entrypoints.openai.protocol import openai_stop_reason
+from atom.entrypoints.openai.serving_completion import (
+    build_completion_response,
+    build_completion_response_multi,
+    create_completion_chunk,
+)
+
+# Everything `scheduler.py` assigns to `leave_reason`, which is what reaches
+# these builders. `stop_<token_id>` is not exotic: `stop_token_ids` is
+# `generation_config.eos_token_id` minus the single `tokenizer.eos_token_id`,
+# so every model declaring more than one EOS ends there normally -- Qwen3,
+# Qwen3.5, gpt-oss.
+ENGINE_REASONS = [
+    "max_tokens",
+    "eos",
+    "stop_163586",
+    "stop_sequence",
+    "aborted",
+    "unschedulable: no kv blocks",
+]
+
+OPENAI_VOCABULARY = {"stop", "length", "tool_calls"}
+
+
+def _reason(frame: str) -> str | None:
+    """The finish_reason a client reads off one SSE frame."""
+    for line in frame.splitlines():
+        if line.startswith("data: ") and line != "data: [DONE]":
+            return json.loads(line[6:])["choices"][0]["finish_reason"]
+    raise AssertionError(f"no data frame in {frame!r}")
+
+
+def _output(reason: str, text: str = "hi") -> dict:
+    return {
+        "text": text,
+        "finish_reason": reason,
+        "num_tokens_input": 1,
+        "num_tokens_output": 1,
+    }
+
+
+@pytest.mark.parametrize("engine_reason", ENGINE_REASONS)
+class TestTheReasonIsTranslatedBeforeItLeaves:
+    """One question, three paths, and they have to answer it the same way."""
+
+    def test_the_non_streaming_response_speaks_openai(self, engine_reason):
+        resp = build_completion_response("r", "m", _output(engine_reason))
+        got = resp.choices[0]["finish_reason"]
+        assert got == openai_stop_reason(engine_reason)
+        assert got in OPENAI_VOCABULARY, f"{got!r} is not a reason OpenAI defines"
+
+    def test_and_so_does_every_fan_out_sibling(self, engine_reason):
+        resp = build_completion_response_multi(
+            "r", "m", [_output(engine_reason), _output("eos")]
+        )
+        assert [c["finish_reason"] for c in resp.choices] == [
+            openai_stop_reason(engine_reason),
+            "stop",
+        ]
+
+    def test_and_the_streamed_answer_agrees_with_the_whole_one(self, engine_reason):
+        """The terminal chunk carries it, as on every other streaming path.
+
+        Hardcoding `"stop"` there while the engine's own word went out on the
+        *content* chunk meant a client reading the documented place saw a
+        truncated response reported as a clean stop -- and `stream=false`
+        reported `max_tokens` for the same generation.
+        """
+        terminal = _reason(
+            create_completion_chunk(
+                "r", "m", "", openai_stop_reason(engine_reason) or "stop"
+            )
+        )
+        whole = build_completion_response("r", "m", _output(engine_reason)).choices[0]
+        assert terminal == whole["finish_reason"]
+
+
+class TestTheContentChunkDoesNotCarryIt:
+    """A reason on a content chunk is a second place to read one from.
+
+    The engine's raw word went out there while the terminal chunk said
+    `"stop"`, so the two disagreed within a single response. atomesh's twin
+    puts `None` on content chunks for the same reason.
+    """
+
+    def test_a_content_chunk_reports_no_reason(self):
+        assert _reason(create_completion_chunk("r", "m", "hi")) is None
+
+    def test_an_unfinished_engine_chunk_reports_no_reason(self):
+        assert (
+            _reason(create_completion_chunk("r", "m", "hi", finish_reason=None)) is None
+        )
+
+
+class TestNothingButOpenAIsOwnWordsReachTheClient:
+    def test_no_engine_spelling_survives(self):
+        """The whole point, stated once: the engine's vocabulary and OpenAI's
+        overlap only at `stop`, and everything else has to be translated."""
+        leaked = [
+            r for r in ENGINE_REASONS if openai_stop_reason(r) not in OPENAI_VOCABULARY
+        ]
+        assert not leaked, f"reported verbatim to the client: {leaked}"
+
+    def test_truncation_is_the_one_reason_that_is_not_stop(self):
+        """`length` is the only warning in the vocabulary. Collapsing it to
+        `stop` is the loss that matters -- the others are all ways of saying
+        the model finished."""
+        assert openai_stop_reason("max_tokens") == "length"
+        assert {openai_stop_reason(r) for r in ENGINE_REASONS if r != "max_tokens"} == {
+            "stop"
+        }
+
+    def test_no_reason_at_all_stays_none(self):
+        """A chunk mid-generation has no reason, and `None` is how the wire
+        says so -- not `"stop"`, which would end the response early."""
+        assert openai_stop_reason(None) is None

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -568,3 +568,77 @@ class TestBoundedWithhold:
             f"first content byte at input offset {held}/{len(text)}, against "
             f"{baseline} for the same text with {sorted(triggers)} neutralised"
         )
+
+
+# One real tool call per registered format, in that format's own syntax. Not
+# generated: a call's payload is the one thing each format spells differently,
+# so the table is written out and `test_every_format_has_a_call` is what stops
+# a new format from joining the registry without one.
+_NS = "]<]minimax[>["
+_D = "｜DSML｜"
+REAL_CALLS: dict[str, str] = {
+    "kimi": (
+        "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0"
+        '<|tool_call_argument_begin|>{"city": "Paris"}<|tool_call_end|>'
+        "<|tool_calls_section_end|>"
+    ),
+    "glm": (
+        "<tool_call>get_weather<arg_key>city</arg_key>"
+        "<arg_value>Paris</arg_value></tool_call>"
+    ),
+    "qwen": (
+        "<tool_call><function=get_weather><parameter=city>Paris</parameter>"
+        "</function></tool_call>"
+    ),
+    "kimi_k3": (
+        '<|open|>tools<|sep|><|open|>call tool="get_weather"<|sep|>'
+        '<|open|>argument key="city"<|sep|>Paris<|close|>argument<|close|>call'
+    ),
+    "dsml": (
+        f'<{_D}tool_calls><{_D}invoke name="get_weather">'
+        f'<{_D}parameter name="city" string="true">Paris</{_D}parameter>'
+        f"</{_D}invoke></{_D}tool_calls>"
+    ),
+    "minimax": (
+        f'{_NS}<tool_call>{_NS}<invoke name="get_weather">'
+        f'{_NS}<parameter name="city">Paris</{_NS}parameter>'
+        f"{_NS}</invoke>{_NS}</tool_call>"
+    ),
+}
+
+
+class TestARealCallSurvivesTheStream:
+    """The corpus above is all *non*-calls -- text that merely looks like one.
+
+    That is deliberate and it left a hole: nothing drove an actual tool call
+    through the streaming facade, so the wiring between the facade, each
+    format's read-ahead and its parser was unasserted. Pointing every parser's
+    scanner at another format's marker broke tool calls on four formats and
+    the whole suite stayed green.
+    """
+
+    def test_every_format_has_a_call(self):
+        assert set(REAL_CALLS) == {p.NAME for p in ALL_PARSERS}, (
+            "a registered format has no real call here, so nothing checks that "
+            "its streaming path produces one"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_non_streaming_path_reads_the_call(self, parser):
+        """The fixture is a real call in this format, and this says so."""
+        _, calls = parser.parse(REAL_CALLS[parser.NAME], None)
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_call_arrives_however_it_is_chunked(self, parser):
+        text = "Let me look. " + REAL_CALLS[parser.NAME]
+        for label, chunks in split_every_way(text).items():
+            seen = drive(text, chunks, parser)
+            starts = seen.events.count("tool_call_start")
+            assert starts == 1, f"{label}: {starts} calls, events {seen.events}"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_text_before_it_still_arrives(self, parser):
+        text = "Let me look. " + REAL_CALLS[parser.NAME]
+        seen = drive(text, split_every_way(text)["fixed-3"], parser)
+        assert "Let me look." in seen.content

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -34,18 +34,23 @@ its content segments into the tool parser, both flushed on the last chunk.
 from __future__ import annotations
 
 import ast
+import itertools
+import json
 import pathlib
 import random
+import re
+import time
 
 import pytest
 
-from atom.entrypoints.openai.reasoning import ReasoningFilter
+from atom.entrypoints.openai.reasoning import ReasoningFilter, separate_reasoning
 from atom.entrypoints.openai.reasoning_dialects import DIALECTS
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
 from atom.entrypoints.openai.tool_parser.stream import ToolCallStreamParser
+from atom.entrypoints.openai.tool_parser.tool_parser import _PEEK_WINDOW
 
 # Kimi is the terminal fallback and so is not in the detect order, but it is a
 # registered format with markers of its own.
@@ -496,6 +501,131 @@ class TestNothingIsHeldPastTheEnd:
             )
 
 
+# Text built from a dialect's own markers, every way they can sit around
+# them. Generated rather than listed because hand-picked cases found three
+# divergences in a row here, each after the previous one was declared fixed:
+# a lost prefix, then a space, then a newline.
+_REASONING_GLUE = ["", " ", "\n", "\n\n", "x", " x ", "\nx\n"]
+
+
+def reasoning_shapes(dialect) -> list[str]:
+    open_m = dialect.output_open_marker or dialect.prompt_open_marker
+    end_m = dialect.think_end_marker
+    out = set()
+    for a, b, c in itertools.product(_REASONING_GLUE, repeat=3):
+        out.add(a + open_m + b + end_m + c)  # closed block
+        out.add(a + open_m + b)  # truncated mid-block
+        out.add(a + end_m + c)  # end marker with no opener
+        out.add(a + open_m + b + end_m + c + open_m + b + end_m + c)  # two blocks
+    return sorted(out)
+
+
+REASONING_DIALECTS = [
+    pytest.param(d, sth, id=f"d{i}-{'prompt-opened' if sth else 'self-opened'}")
+    for i, d in enumerate(DIALECTS)
+    for sth in (False, True)
+]
+
+
+def split_reasoning_streaming(text: str, chunk: int, starts_thinking: bool):
+    f = ReasoningFilter(starts_thinking=starts_thinking)
+    segs = []
+    for i in range(0, len(text), chunk):
+        segs += f.process(text[i : i + chunk])
+    segs += f.flush()
+    return (
+        "".join(t for k, t in segs if k == "reasoning_content"),
+        "".join(t for k, t in segs if k == "content"),
+    )
+
+
+class TestTheReasoningSplitAgreesWithItself:
+    """The same rule as the class below, one stage earlier.
+
+    That class holds the *tool parser* to stream/non-stream agreement. Nothing
+    held the *reasoning* split to it, and it diverged: a model that answers,
+    opens a `<think>` block and answers again had the block extracted when
+    streamed, and handed to the client as literal tags with the chain of
+    thought inside `content` when not.
+
+    One test per dialect rather than per shape. The corpus is a few thousand
+    strings and pytest ids for each would outnumber the rest of this suite ten
+    to one; the loop reports every divergence at once, which is also what you
+    want when a change breaks a whole class of them.
+
+    Judged byte-for-byte. It could not be, until the two things stopping it
+    were removed: this path stripped, and the filter's own `lstrip("\n")`
+    after the end marker saw only what happened to be buffered, so the same
+    answer kept its newlines at one chunk size and lost them at another.
+    Neither survived the question of what it was for -- the newline a model
+    writes before its answer is not a marker, and only markers may be
+    removed. Across this corpus that took content agreement from 50% to 100%.
+    """
+
+    CHUNKS = (1, 3, 11, 10_000)
+
+    def _divergences(self, dialect, starts_thinking, field: int):
+        out = []
+        for text in reasoning_shapes(dialect):
+            non = separate_reasoning(text, starts_thinking=starts_thinking)[field]
+            for chunk in self.CHUNKS:
+                got = split_reasoning_streaming(text, chunk, starts_thinking)[field]
+                if (non or "") != got:
+                    out.append((text, chunk, non, got))
+        return out
+
+    @pytest.mark.parametrize("dialect, starts_thinking", REASONING_DIALECTS)
+    def test_the_answer_is_the_same_however_it_is_delivered(
+        self, dialect, starts_thinking
+    ):
+        bad = self._divergences(dialect, starts_thinking, 1)
+        assert not bad, self._report("content", bad)
+
+    @pytest.mark.parametrize("dialect, starts_thinking", REASONING_DIALECTS)
+    def test_the_chain_of_thought_is_the_same_too(self, dialect, starts_thinking):
+        """Agreement on the answer is not enough: a split that put the
+        reasoning in the wrong field would still pass the test above if the
+        words happened to land in `content` either way."""
+        bad = self._divergences(dialect, starts_thinking, 0)
+        assert not bad, self._report("reasoning", bad)
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("a<think>b</think>\nc", "a\nc"),
+            ("a<think>b</think>\n\nc", "a\n\nc"),
+            ("a<think>b</think>c", "ac"),
+            ("a<think>b</think> c", "a c"),
+            ("<think>b</think>\n\nThe answer.", "\n\nThe answer."),
+            ("<think>b</think>```\nx\n```\n", "```\nx\n```\n"),
+        ],
+        ids=["one-newline", "two-newlines", "none", "a-space", "an-answer", "a-block"],
+    )
+    def test_the_newline_a_model_puts_before_its_answer_survives(self, text, expected):
+        """Spelled out, because the sweep above says only that the two *agree*.
+
+        Two paths that both dropped it would satisfy that and still lose a
+        code block's final newline -- which is the symptom the byte-for-byte
+        rule was written for one stage later, and the one measured here
+        before the strips came out.
+        """
+        assert separate_reasoning(text, starts_thinking=False)[1] == expected
+        f = ReasoningFilter(starts_thinking=False)
+        segs = f.process(text) + f.flush()
+        assert "".join(t for k, t in segs if k == "content") == expected
+
+    @staticmethod
+    def _report(field, bad):
+        lines = [f"{len(bad)} shapes split {field} two ways:"]
+        for text, chunk, non, got in bad[:5]:
+            lines.append(
+                f"  chunk={chunk} text={text!r}\n"
+                f"    stream=false {non!r}\n"
+                f"    stream=true  {got!r}"
+            )
+        return "\n".join(lines)
+
+
 class TestNonStreamingAgreesWithStreaming:
     """An answer with no tool call comes back the same on both paths.
 
@@ -601,9 +731,13 @@ REAL_CALLS: dict[str, str] = {
         f'<{_D}parameter name="city" string="true">Paris</{_D}parameter>'
         f"</{_D}invoke></{_D}tool_calls>"
     ),
+    # Parameters named by the tag, which is what tells this format from DSML.
+    # This entry was written in DSML's `<parameter name="...">` spelling and
+    # so parsed to `get_weather({})` -- a call with no arguments, passing
+    # every test here while exercising none of the parameter path.
     "minimax": (
         f'{_NS}<tool_call>{_NS}<invoke name="get_weather">'
-        f'{_NS}<parameter name="city">Paris</{_NS}parameter>'
+        f"{_NS}<city>Paris{_NS}</city>"
         f"{_NS}</invoke>{_NS}</tool_call>"
     ),
 }
@@ -628,8 +762,19 @@ class TestARealCallSurvivesTheStream:
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_the_non_streaming_path_reads_the_call(self, parser):
         """The fixture is a real call in this format, and this says so."""
-        _, calls = parser.parse(REAL_CALLS[parser.NAME], None)
+        _, calls = parser.parse(REAL_CALLS[parser.NAME], DECLARED_TOOLS)
         assert [c.function["name"] for c in calls] == ["get_weather"]
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_call_carries_its_argument(self, parser):
+        """And the payload is in *this* format's spelling, not another's.
+
+        Only the name was asserted, so an entry written in the wrong format's
+        parameter syntax parsed to `get_weather({})` and passed everything
+        here -- minimax's was, for as long as the table existed.
+        """
+        _, calls = parser.parse(REAL_CALLS[parser.NAME], DECLARED_TOOLS)
+        assert json.loads(calls[0].function["arguments"]) == {"city": "Paris"}
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_the_call_arrives_however_it_is_chunked(self, parser):
@@ -667,6 +812,77 @@ FRAMING_NOT_A_REGION: dict[str, set[str]] = {
         "<|sep|>",
     },
 }
+
+
+def prefix_pairs(parser) -> list[tuple[str, str]]:
+    """Every (short, long) pair of this format's markers where short opens long."""
+    ms = parser.START_MARKERS
+    return [(a, b) for a in ms for b in ms if a != b and b.startswith(a)]
+
+
+class TestAPrefixPairCannotChangeTheHandover:
+    """Longest-first only settles a tie the buffer can already see.
+
+    `MarkerScanner` reports the longest marker at a position -- among the ones
+    already complete in its buffer. A chunk ending exactly at the shorter of a
+    prefix pair reports the shorter one, because the longer has not arrived to
+    be preferred. So which of the two fires is a function of where the
+    boundary landed.
+
+    Harmless while both halves agree about handing the stream over, and today
+    every pair does: K3's three are all channel framing that opens no region,
+    so either way the marker is dropped and the remainder is caught as its own
+    marker. Measured -- a K3 answer comes out identical at seven chunk sizes.
+
+    It stops being harmless the moment a pair disagrees. With a synthetic
+    `("<|end|>", "<|end|>call")` where only the long one opens a region, one
+    text produced two different answers across six chunk sizes: the marker was
+    deleted as framing at chunk 1, 2 and 9, and handed over as a region at 7,
+    8 and 999.
+
+    So this is the cheap half of the fix. The expensive half -- withholding a
+    complete match that could still grow -- is the rule `_plan` would need to
+    actually keep its promise, and is worth writing when a format needs it,
+    not before.
+    """
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_both_halves_agree_about_opening_a_region(self, parser):
+        disagreeing = [
+            (short, long)
+            for short, long in prefix_pairs(parser)
+            if parser.opens_region(short) != parser.opens_region(long)
+        ]
+        assert not disagreeing, (
+            f"{parser.NAME} declares a marker that is a prefix of another and "
+            f"they disagree about handing the stream over, so which happens "
+            f"depends on the chunk boundary: {disagreeing}"
+        )
+
+    def test_the_registry_still_has_pairs_to_check(self):
+        """Otherwise the test above is green because it examined nothing.
+
+        K3's `<|close|>response` / `<|close|>response<|sep|>` and its two
+        siblings are the only pairs there are; drop them and this suite would
+        keep passing while the rule went unenforced.
+        """
+        found = {p.NAME: prefix_pairs(p) for p in ALL_PARSERS}
+        total = sum(len(v) for v in found.values())
+        assert total >= 3, f"no prefix pairs left to check: {found}"
+
+    def test_a_disagreeing_pair_is_rejected(self):
+        """And that the check can fail at all -- built rather than waited for."""
+
+        class Synthetic(QwenXmlParser):
+            NAME = "synthetic"
+            START_MARKERS = ("<|end|>", "<|end|>call")
+
+            @classmethod
+            def opens_region(cls, marker):
+                return marker == "<|end|>call"
+
+        with pytest.raises(AssertionError, match="chunk boundary"):
+            self.test_both_halves_agree_about_opening_a_region(Synthetic)
 
 
 class TestAPlainAnswerDoesNotWaitForTheEnd:
@@ -792,7 +1008,7 @@ class TestTheNameArrivesBeforeTheArguments:
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_the_opt_outs_are_the_declared_ones(self, parser):
         """Whether a format announces at all, pinned rather than inferred."""
-        peeks = parser.peek_name(REAL_CALLS[parser.NAME]) is not None
+        peeks = parser.peek_name(REAL_CALLS[parser.NAME], DECLARED_TOOLS) is not None
         assert peeks is (parser.NAME not in NO_EARLY_NAME), (
             f"{parser.NAME}: peek_name says {peeks}, NO_EARLY_NAME says "
             f"{parser.NAME in NO_EARLY_NAME}"
@@ -870,6 +1086,185 @@ class TestTheNameArrivesBeforeTheArguments:
         assert "tool_call_start" not in events
 
 
+# Each format's call opener, up to and including the tool name -- written
+# out, like REAL_CALLS, because it is data about the format. Derived by
+# re-peeking instead, the corpus moved whenever `peek_name` did and the
+# property below went quietly vacuous.
+CALL_OPENERS: dict[str, str] = {
+    "glm": "<tool_call>get_weather",
+    "qwen": "<tool_call><function=get_weather>",
+    "kimi_k3": '<|open|>tools<|sep|><|open|>call tool="get_weather"<|sep|>',
+    "dsml": f'<{_D}tool_calls><{_D}invoke name="get_weather">',
+    "minimax": f'{_NS}<tool_call>{_NS}<invoke name="get_weather">',
+}
+
+# What legitimately comes next in each format -- the one tail that must make
+# the name go out. Without a positive row the property below is satisfied by
+# a peek that never announces anything.
+CALL_CONTINUATIONS: dict[str, str] = {
+    "glm": "<arg_key>city</arg_key>",
+    "qwen": "<parameter=city>Paris</parameter>",
+    "kimi_k3": '<|open|>argument key="city"<|sep|>Paris',
+    "dsml": f'<{_D}parameter name="city">Paris',
+    "minimax": f"{_NS}<city>Paris",
+}
+
+# A closer that is NOT this format's own. Per format, because one format's
+# foreign closer is another's legitimate one: `</tool_call>` leaves Qwen's
+# `<function=` block open and so is prose there, while for GLM it closes the
+# very block the name opened and `<tool_call>get_weather</tool_call>` is a
+# real zero-argument call.
+FOREIGN_CLOSERS: dict[str, str] = {
+    "glm": "</function>",
+    "qwen": "</tool_call>",
+    "kimi_k3": "<|close|>response<|sep|>",
+    "dsml": "</tool_call>",
+    "minimax": "</function>",
+}
+
+# And what prose looks like next. None of these may make the name go out.
+PROSE_TAILS = [
+    ("", "nothing yet"),
+    (" and then the parameters.", "English"),
+    ("<br>, like that.", "a tag, but not this format's"),
+]
+
+# A schema with a parameter in it. MiniMax names parameters by the tag, so
+# with an empty schema it can only fall back to accepting any tag and the
+# `<br>` row above passes for the wrong reason.
+PEEK_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    }
+]
+
+
+class TestThePeekNeverNamesWhatTheParseCallsProse:
+    """`peek_name` and `parse` must agree about what a call looks like.
+
+    A name cannot be retracted. If the peek names a region and the parse then
+    reads that same region as prose, the client has been told about a call
+    that does not exist -- on `/v1/chat/completions` as a `tool_calls` delta
+    whose `arguments` is `""`, which every agent loop feeds to `json.loads`,
+    and on `/v1/messages` as a syntactically complete `tool_use` block with
+    `input: {}` that a client cannot tell from a real zero-argument call.
+
+    Four of the five formats that announce had the two disagree, because each
+    wrote the rule twice: a follower set in a peek regex, a truncation test in
+    `parse`. Qwen's peek accepted `</tool_call>` -- which closes the *outer*
+    wrapper and leaves the `<function=` block unterminated, so `parse` read it
+    as prose. Each format now answers the question once, from one constant,
+    and both callers ask it.
+
+    Which is also this property's limit, and worth being plain about: with one
+    constant per format the two *cannot* disagree, so no mutation of that
+    constant will fail this. What it guards is the next format, or the next
+    rewrite, that goes back to writing the rule twice --
+    `test_a_looser_peek_is_caught` is what shows it still can.
+    """
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_opener_matches_this_format(self, parser):
+        """Otherwise the regions below are not this format's syntax at all."""
+        if parser.NAME in NO_EARLY_NAME:
+            pytest.skip(NO_EARLY_NAME[parser.NAME])
+        opener = CALL_OPENERS[parser.NAME]
+        assert REAL_CALLS[parser.NAME].startswith(
+            opener
+        ), f"{parser.NAME}'s opener is not a prefix of its own real call"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    @pytest.mark.parametrize("tail, why", PROSE_TAILS, ids=lambda x: x)
+    def test_prose_after_the_opener_names_nothing(self, parser, tail, why):
+        if parser.NAME in NO_EARLY_NAME:
+            pytest.skip(NO_EARLY_NAME[parser.NAME])
+        self._check(parser, CALL_OPENERS[parser.NAME] + tail, why, expected=None)
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_closer_that_is_not_this_format_s_names_nothing(self, parser):
+        """The shape Qwen got wrong: a closer that ends some *other* block."""
+        if parser.NAME in NO_EARLY_NAME:
+            pytest.skip(NO_EARLY_NAME[parser.NAME])
+        region = (
+            CALL_OPENERS[parser.NAME] + FOREIGN_CLOSERS[parser.NAME] + ", like that."
+        )
+        self._check(parser, region, "a closer from another block", None)
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_this_format_s_own_next_token_does_name_it(self, parser):
+        if parser.NAME in NO_EARLY_NAME:
+            pytest.skip(NO_EARLY_NAME[parser.NAME])
+        region = CALL_OPENERS[parser.NAME] + CALL_CONTINUATIONS[parser.NAME]
+        self._check(parser, region, "this format's own next token", "get_weather")
+
+    @staticmethod
+    def _check(parser, region, why, expected):
+        """Asked of `peek_name` directly, not of a consequence.
+
+        The obvious consequence -- "did `parse` hand the region back
+        unchanged" -- is unsound for Kimi-K3, whose `parse` rewrites the
+        content of *every* answer by stripping channel framing. A version
+        keyed on that passed while K3 announced a tool for a sentence merely
+        quoting a call opener.
+        """
+        got = parser.peek_name(region, PEEK_TOOLS)
+        assert got == expected, (
+            f"{parser.NAME} with {why} after its opener: peek said {got!r}, "
+            f"expected {expected!r} -- region {region!r}"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_bare_opener_alone_names_nothing(self, parser):
+        """A follower has to have arrived, not merely be possible.
+
+        The opener on its own is the shape a quotation and a cut-off call
+        share; only what comes next tells them apart. Waiting for it costs a
+        few characters, and nothing at all when the call completes -- `parse`
+        still produces it at flush.
+
+        Stated for every format because it is the difference between the two
+        kinds of dangling name. K3 announced here, and its `parse` never
+        salvages a truncated call, so the client was left holding a name for
+        a call that produced no arguments and no event.
+        """
+        if parser.NAME in NO_EARLY_NAME:
+            pytest.skip(NO_EARLY_NAME[parser.NAME])
+        opener = CALL_OPENERS[parser.NAME]
+        assert (
+            parser.peek_name(opener, DECLARED_TOOLS) is None
+        ), f"{parser.NAME} named a tool off its opener alone: {opener!r}"
+
+    def test_a_looser_peek_is_caught(self):
+        """The check can fail -- built rather than waited for."""
+
+        class Loose(QwenXmlParser):
+            NAME = "loose"
+
+            @classmethod
+            def peek_name(cls, region, tools=None):
+                m = re.search(r"<function=([^>\n]+)>", region)
+                return m.group(1) if m else None
+
+        with pytest.raises(AssertionError, match="peek said"):
+            self._check(Loose, CALL_OPENERS["qwen"] + " and then...", "English", None)
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_real_call_is_still_named_early(self, parser):
+        """And the rule above is not satisfied by never announcing anything."""
+        if parser.NAME in NO_EARLY_NAME:
+            pytest.skip(NO_EARLY_NAME[parser.NAME])
+        assert (
+            parser.peek_name(REAL_CALLS[parser.NAME], DECLARED_TOOLS) == "get_weather"
+        )
+
+
 class TestAPromiseCannotBeTakenBack:
     """The cost of announcing early, stated rather than discovered.
 
@@ -922,14 +1317,15 @@ class TestAPromiseCannotBeTakenBack:
         delivered = "".join(d for k, d in events if k == "content")
         assert "Sure." in delivered, "the text before the call was dropped"
 
-    def test_peeking_a_different_name_than_the_parse_is_raised(self):
-        """`peek_name` and `parse` disagreeing about the same bytes is a bug
-        in that format, and the name is already on the wire. Loud, not
-        smoothed over -- there is nothing to smooth it into."""
+    @staticmethod
+    def _liar():
+        """A format whose `peek_name` and `parse` read the same bytes
+        differently -- a bug in that format, and one two registered parsers
+        were found to have."""
 
         class Liar(QwenXmlParser):
             @classmethod
-            def peek_name(cls, region):
+            def peek_name(cls, region, tools=None):
                 return "get_weather" if "<function=" in region else None
 
             @classmethod
@@ -939,8 +1335,144 @@ class TestAPromiseCannotBeTakenBack:
                     c.function["name"] = "something_else"
                 return content, calls
 
-        with pytest.raises(AssertionError, match="announced"):
-            self._drive(Liar, "Sure. " + REAL_CALLS["qwen"])
+        return Liar
+
+    def test_peeking_a_different_name_than_the_parse_does_not_kill_the_stream(self):
+        """This used to raise. The caller is `flush`, on a live SSE stream
+        that has already sent its 200, so the exception reached the client as
+        a cut connection with no `[DONE]` -- and on `n>1` took the other
+        choices with it."""
+        events = self._drive(self._liar(), "Sure. " + REAL_CALLS["qwen"])
+        assert [k for k, _ in events], "the stream produced nothing"
+
+    def test_the_call_that_parsed_goes_out_whole(self):
+        events = self._drive(self._liar(), "Sure. " + REAL_CALLS["qwen"])
+        args = [d for k, d in events if k == "tool_call_args"]
+        starts = {
+            d["function"]["name"]: d["index"]
+            for k, d in events
+            if k == "tool_call_start"
+        }
+        assert "something_else" in starts, f"the parsed call never went out: {starts}"
+        assert (
+            len(args) == 1 and args[0]["index"] == starts["something_else"]
+        ), "the arguments landed on an index the client bound to another name"
+
+    def test_the_announced_name_is_left_without_arguments(self):
+        """It cannot be retracted, but it can be left unusable -- which is
+        what `completes_a_tool_call` and `finish_reason` both read."""
+        events = self._drive(self._liar(), "Sure. " + REAL_CALLS["qwen"])
+        announced = [
+            d["index"]
+            for k, d in events
+            if k == "tool_call_start" and d["function"]["name"] == "get_weather"
+        ]
+        assert announced, "the announcement is the premise of this test"
+        assert not [
+            d for k, d in events if k == "tool_call_args" and d["index"] in announced
+        ], "the wrong name was given arguments to run with"
+
+
+def _big_call(payload_bytes: int) -> str:
+    """One Qwen tool call whose argument is `payload_bytes` long."""
+    return (
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter>"
+        f"<parameter=note>{'x' * payload_bytes}</parameter>"
+        "</function></tool_call>"
+    )
+
+
+class TestTheRegionIsNotCopiedPerChunk:
+    """A buffered region costs what it is, not what it is squared.
+
+    `self.buf += text` on an *attribute* is quadratic in CPython: the
+    instance dict holds a reference, so the in-place fast path never applies
+    and every chunk copies the whole buffer. Measured on a 128 KB tool call
+    at four characters a chunk, 23 ms of event-loop CPU in `process` alone,
+    growing 17x for an 8x payload. The same loop over a *local* string is
+    linear, which is why a microbenchmark of `s += x` finds nothing and why
+    this is asserted on the parser rather than on the idiom.
+    """
+
+    SMALL_KB = 32
+    LARGE_KB = 128
+
+    @staticmethod
+    def _stream_ms(payload_bytes: int) -> float:
+        text = _big_call(payload_bytes)
+        best = None
+        for _ in range(3):
+            parser = ToolCallStreamParser(
+                tools=DECLARED_TOOLS, parser_cls=QwenXmlParser
+            )
+            start = time.perf_counter()
+            for i in range(0, len(text), 4):
+                parser.process(text[i : i + 4])
+            parser.flush()
+            elapsed = time.perf_counter() - start
+            best = elapsed if best is None else min(best, elapsed)
+        return best * 1000
+
+    @staticmethod
+    def _control_ms(payload_bytes: int) -> float:
+        """The same loop over a local string, which is linear by construction."""
+        best = None
+        for _ in range(3):
+            start = time.perf_counter()
+            buf = ""
+            for _i in range(payload_bytes // 4):
+                buf += "xxxx"
+            best = (
+                time.perf_counter() - start
+                if best is None
+                else min(best, time.perf_counter() - start)
+            )
+        return best * 1000
+
+    def test_announce_is_never_handed_the_whole_region(self):
+        """The deterministic half: materialising the buffer per chunk is the
+        cost, so nothing on that path may ask for it."""
+        seen: list[int] = []
+
+        class Watching(QwenXmlParser):
+            @classmethod
+            def peek_name(cls, region, tools=None):
+                seen.append(len(region))
+                return QwenXmlParser.peek_name(region, tools)
+
+        text = _big_call(8 * 1024)
+        parser = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=Watching)
+        for i in range(0, len(text), 4):
+            parser.process(text[i : i + 4])
+        parser.flush()
+        assert seen, "the peek never ran; this asserts nothing"
+        assert (
+            max(seen) <= _PEEK_WINDOW
+        ), f"a peek was handed {max(seen)} characters, window is {_PEEK_WINDOW}"
+
+    def test_the_cost_per_byte_does_not_grow(self):
+        """The timed half, with a control arm.
+
+        Two numbers being equal proves nothing on a shared machine unless
+        something in the same run is known to move -- so the control is the
+        linear loop, and its own per-byte cost has to come out flat before
+        this measurement is allowed to mean anything.
+        """
+        control = self._control_ms(self.LARGE_KB * 1024) / (
+            self._control_ms(self.SMALL_KB * 1024) * (self.LARGE_KB / self.SMALL_KB)
+        )
+        if not 0.6 < control < 1.6:
+            pytest.skip(f"machine too noisy to measure: control ratio {control:.2f}")
+
+        small = self._stream_ms(self.SMALL_KB * 1024) / self.SMALL_KB
+        large = self._stream_ms(self.LARGE_KB * 1024) / self.LARGE_KB
+        # Quadratic measured 1.75 across this pair; linear measures ~1.0.
+        assert large / small < 1.5, (
+            f"cost per KB grew {large / small:.2f}x from {self.SMALL_KB} KB to "
+            f"{self.LARGE_KB} KB ({small:.3f} -> {large:.3f} ms/KB); the region "
+            "is being copied per chunk again"
+        )
 
 
 class TestThePeekIsBounded:
@@ -958,9 +1490,9 @@ class TestThePeekIsBounded:
 
         class Counting(parser_cls):
             @classmethod
-            def peek_name(cls, region):
+            def peek_name(cls, region, tools=None):
                 calls.append(len(region))
-                return parser_cls.peek_name(region)
+                return parser_cls.peek_name(region, tools)
 
         stream = ToolCallStreamParser(parser_cls=Counting)
         stream.tools = tools
@@ -970,8 +1502,6 @@ class TestThePeekIsBounded:
         return calls
 
     def test_no_peek_ever_sees_more_than_the_window(self):
-        from atom.entrypoints.openai.tool_parser.tool_parser import _PEEK_WINDOW
-
         text = "The model writes <tool_call> to open one. " + "x" * 4000
         sizes = self._count_peeks(QwenXmlParser, text, DECLARED_TOOLS)
         assert sizes, "the peek never ran"

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -51,7 +51,6 @@ from atom.entrypoints.openai.reasoning import (
     separate_reasoning,
 )
 from atom.entrypoints.openai.reasoning_dialects import DIALECTS, resolve_dialect
-from entrypoints.wire_corpus import DECLARED_TOOLS, REAL_CALLS
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_tool_calls
 from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
@@ -61,6 +60,13 @@ from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
 from atom.entrypoints.openai.tool_parser.stream import (
     _PEEK_WINDOW,
     ToolCallStreamParser,
+)
+from entrypoints.wire_corpus import (
+    DECLARED_TOOLS,
+    REAL_CALLS,
+    naming_another_tool,
+    truncated,
+    truncated_naming_another_tool,
 )
 
 # Kimi is the terminal fallback and so is not in the detect order, but it is a
@@ -2373,29 +2379,39 @@ class TestTheEarlyNameCannotDisagreeWithTheParse:
         PROSE + "{call}",
         "{call}" + PROSE,
         "{call}{call}",
-        PROSE + "{half}" + PROSE + "{call}",
-        "{half}{call}",
+        PROSE + "{cut}" + PROSE + "{call}",
+        "{cut}{call}",
         # The shapes that need two *names* to say anything. A truncated call
         # followed by a complete one for a different tool is the ordinary
         # `max_tokens` malform, and it is what broke: the prefix announced the
         # truncated call's name and the finished region returned the other.
-        "{half}{other}",
-        "{other_half}{call}",
-        PROSE + "{half}" + PROSE + "{other}",
+        "{cut}{other}",
+        "{other_cut}{call}",
+        PROSE + "{cut}" + PROSE + "{other}",
         "{other}{call}",
     ]
 
     @staticmethod
     def _texts(parser):
-        call = REAL_CALLS[parser.NAME]
-        other = call.replace("get_weather", "get_time")
-        assert other != call, f"{parser.NAME}'s fixture has no name to vary"
+        """The shapes, filled from the corpus rather than re-derived here.
+
+        `{cut}` was `call[:len(call)//2]` and `{other}` was
+        `call.replace("get_weather", "get_time")` -- a second cut rule and a
+        second copy of the names, inside a suite whose premise is that a
+        format registered tomorrow needs nothing added. The cut rule cost
+        something: at the midpoint three formats have no recoverable call in
+        `{cut}`, so every shape using it was vacuous for them and hid a real
+        Kimi-K3 divergence. Cut where the corpus cuts and it shows up.
+        """
+        name = parser.NAME
+        other = naming_another_tool(name)
+        assert other != REAL_CALLS[name], f"{name}'s fixture has no name to vary"
         return [
             shape.format(
-                call=call,
-                half=call[: len(call) // 2],
+                call=REAL_CALLS[name],
+                cut=truncated(name),
                 other=other,
-                other_half=other[: len(other) // 2],
+                other_cut=truncated_naming_another_tool(name),
             )
             for shape in TestTheEarlyNameCannotDisagreeWithTheParse.SHAPES
         ]

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -494,6 +494,58 @@ class TestNothingIsHeldPastTheEnd:
             )
 
 
+class TestNonStreamingAgreesWithStreaming:
+    """An answer with no tool call comes back the same on both paths.
+
+    The non-streaming path runs the format's `parse`; the streaming path
+    releases bytes as they arrive and owns nothing to tidy them with. So any
+    tidying `parse` does to an answer it found no call in is a difference the
+    client sees between `stream=true` and `stream=false` -- and every format
+    did some, `.strip()`, which cost a code-block answer its trailing newline.
+
+    Generated from the registry rather than listed, so the rule binds a format
+    added later without anyone remembering to add a case. It is stated on
+    `ToolCallParser.parse`, and this is what holds formats to it.
+    """
+
+    @pytest.mark.parametrize("dialect, parser, text", HOLD_PAIRS)
+    def test_the_two_paths_deliver_the_same_text(self, dialect, parser, text):
+        non_streaming, calls = parser.parse(text, None)
+        if calls:
+            pytest.skip("this shape parsed a call; the rule binds the no-call case")
+        streamed = drive(text, split_every_way(text)["fixed-3"], parser)
+        assert streamed.content == non_streaming, (
+            f"{parser.NAME} answers the same request two ways\n"
+            f"  stream=false {non_streaming[-60:]!r}\n"
+            f"  stream=true  {streamed.content[-60:]!r}"
+        )
+
+    @pytest.mark.parametrize("dialect, parser, text", HOLD_PAIRS)
+    def test_no_call_means_nothing_but_this_format_s_own_framing_goes(
+        self, dialect, parser, text
+    ):
+        """Agreement is necessary but not sufficient: both could delete it.
+
+        What may be removed is a marker this format declares. Everything else
+        -- in particular whitespace, which is what every format's trailing
+        `.strip()` took -- has to survive.
+        """
+        content, calls = parser.parse(text, None)
+        if calls:
+            pytest.skip("this shape parsed a call; the rule binds the no-call case")
+        rebuilt = content
+        for marker in parser.START_MARKERS:
+            rebuilt = rebuilt.replace(marker, "")
+        expected = text
+        for marker in parser.START_MARKERS:
+            expected = expected.replace(marker, "")
+        assert rebuilt == expected, (
+            f"{parser.NAME} removed something that was not one of its markers\n"
+            f"  in  {expected[-60:]!r}\n"
+            f"  out {rebuilt[-60:]!r}"
+        )
+
+
 class TestBoundedWithhold:
     """Text must not be held back longer than a marker could justify."""
 

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -45,10 +45,16 @@ from typing import ClassVar
 
 import pytest
 
-from atom.entrypoints.openai.reasoning import ReasoningFilter, separate_reasoning
+from atom.entrypoints.openai.reasoning import (
+    ReasoningChannel,
+    ReasoningFilter,
+    separate_reasoning,
+)
 from atom.entrypoints.openai.reasoning_dialects import DIALECTS, resolve_dialect
+from entrypoints.wire_corpus import DECLARED_TOOLS, REAL_CALLS
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_tool_calls
+from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
@@ -88,6 +94,12 @@ class Seen:
         self.content = ""
         self.events: list[str] = []
         self.first_content_at: int | None = None
+        # Bytes consumed when each event arrived. A name announced early and
+        # the same name emitted when the region closes are the same event
+        # kind, so a test that only sees the kinds cannot tell whether the
+        # announcement ran at all -- which is how the harness came to run
+        # every property with it switched off.
+        self.event_at: list[int] = []
 
     @property
     def key(self):
@@ -96,7 +108,13 @@ class Seen:
 
 
 def drive(
-    text: str, chunks: list[str], parser=None, *, suppress_calls: bool = False
+    text: str,
+    chunks: list[str],
+    parser=None,
+    *,
+    suppress_calls: bool = False,
+    tools=None,
+    reasoning=None,
 ) -> Seen:
     """Replay the serving loop over one chunking.
 
@@ -105,9 +123,28 @@ def drive(
     of the text to select one. `suppress_calls` is `tool_choice: "none"`,
     which is a property of the request and not of the text, so it has to be
     passed in the same way.
+
+    `tools` defaults to the declared pair rather than to `None`, because
+    `_announce` returns immediately on `not self.tools` -- so with no tools
+    every property here ran with the early-announcement path switched off,
+    which is the newest thing in the reader and the one that broke. A case
+    that specifically wants the no-tools reader passes `tools=()`.
+
+    `reasoning` likewise: a bare `ReasoningFilter()` falls back to the inline
+    `<think>` dialect and `starts_thinking=False`, so nothing drove Kimi-K3's
+    channel into the Kimi-K3 tool parser -- the one composition where the
+    reasoning stage consumes markers the tool stage also declares.
+
+    A whole `ReasoningChannel`, not a bare dialect: K3's channel is opened by
+    the *prompt*, so a dialect without `starts_open` reads the chain of
+    thought as answer. `TestTheTwoStagesCompose` is what passes it; a
+    parameter no caller uses claims coverage without delivering it.
     """
-    rf, tp = ReasoningFilter(), ToolCallStreamParser(
-        parser_cls=parser, suppress_calls=suppress_calls
+    rf = ReasoningFilter() if reasoning is None else reasoning.stream()
+    tp = ToolCallStreamParser(
+        tools=DECLARED_TOOLS if tools is None else (tools or None),
+        parser_cls=parser,
+        suppress_calls=suppress_calls,
     )
     seen = Seen()
     consumed = 0
@@ -121,6 +158,7 @@ def drive(
             seen.content += payload
         else:
             seen.events.append(kind)
+            seen.event_at.append(consumed)
 
     for i, chunk in enumerate(chunks):
         consumed += len(chunk)
@@ -346,14 +384,38 @@ class TestEverySeedingSiteIsSeeded:
     endpoint added later is covered the moment it exists. Three of the four
     sites that exist today were unseeded before this change, including the one
     the original bug was reported against.
+
+    The names it walks have to be the ones the endpoints actually call. They
+    were `ReasoningFilter` / `separate_reasoning`, and then every endpoint was
+    moved to `ReasoningChannel` -- so the scan matched two sites, both inside
+    `reasoning.py`'s own accessors, and zero endpoints. Green, and inert, for
+    two rounds. `test_the_scan_sees_the_endpoints` is the positive control:
+    it asserts the walk finds work to do, so the same silent retirement
+    cannot happen again on the next rename.
     """
 
     ROOT = pathlib.Path(__file__).resolve().parents[2] / "atom" / "entrypoints"
-    SEEDED = ("ReasoningFilter", "separate_reasoning")
+    # `ReasoningChannel(...)` is what the endpoints build now; the other two
+    # are what it is built from, and a caller reaching past it must answer the
+    # same question.
+    SEEDED = ("ReasoningChannel", "ReasoningFilter", "separate_reasoning")
+    # The keyword each of them spells the answer with.
+    SEED_KWARG = {
+        "ReasoningChannel": "starts_open",
+        "ReasoningFilter": "starts_thinking",
+        "separate_reasoning": "starts_thinking",
+    }
 
     def _unseeded(self) -> list[str]:
         found = []
         for path in sorted(self.ROOT.rglob("*.py")):
+            if path.name == "reasoning.py":
+                # The module that defines the class: its two accessors build
+                # one from the object's own fields, and `NO_REASONING` is the
+                # deliberate sentinel for a caller with no model behind it.
+                # Exempting it cannot hollow out the scan --
+                # `test_the_scan_sees_the_endpoints` requires sites elsewhere.
+                continue
             tree = ast.parse(path.read_text())
             for node in ast.walk(tree):
                 if not isinstance(node, ast.Call):
@@ -364,7 +426,11 @@ class TestEverySeedingSiteIsSeeded:
                 if name not in self.SEEDED:
                     continue
                 seed = next(
-                    (kw.value for kw in node.keywords if kw.arg == "starts_thinking"),
+                    (
+                        kw.value
+                        for kw in node.keywords
+                        if kw.arg == self.SEED_KWARG[name]
+                    ),
                     None,
                 )
                 # Positional counts: `separate_reasoning(text, seeded)` is a
@@ -380,10 +446,36 @@ class TestEverySeedingSiteIsSeeded:
                     # scan accepted it, and a test in this very change was
                     # "repaired" by hardcoding the other literal.
                     found.append(
-                        f"{rel}:{node.lineno} {name}(starts_thinking={seed.value!r})"
+                        f"{rel}:{node.lineno} {name}"
+                        f"({self.SEED_KWARG[name]}={seed.value!r})"
                         " — a literal, not the prompt"
                     )
         return found
+
+    def test_the_scan_sees_the_endpoints(self):
+        """The positive control: the walk must find sites outside reasoning.py.
+
+        The scan is only a guard while its names are the ones in use. When
+        every endpoint moved to `ReasoningChannel` and the scan still looked
+        for `ReasoningFilter`, it matched two sites -- both inside
+        `reasoning.py` itself -- and reported success for a codebase it was no
+        longer reading.
+        """
+        sites = []
+        for path in sorted(self.ROOT.rglob("*.py")):
+            for node in ast.walk(ast.parse(path.read_text())):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = getattr(node.func, "id", None) or getattr(
+                    node.func, "attr", None
+                )
+                if name in self.SEEDED:
+                    sites.append(f"{path.name}:{node.lineno} {name}")
+        outside = [s for s in sites if not s.startswith("reasoning.py:")]
+        assert outside, (
+            "the scan matches no endpoint at all, so it is checking nothing: "
+            f"all it found was {sites}"
+        )
 
     def test_no_entry_point_builds_one_without_the_seed(self):
         unseeded = self._unseeded()
@@ -719,39 +811,6 @@ class TestBoundedWithhold:
 # a new format from joining the registry without one.
 _NS = "]<]minimax[>["
 _D = "｜DSML｜"
-REAL_CALLS: dict[str, str] = {
-    "kimi": (
-        "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0"
-        '<|tool_call_argument_begin|>{"city": "Paris"}<|tool_call_end|>'
-        "<|tool_calls_section_end|>"
-    ),
-    "glm": (
-        "<tool_call>get_weather<arg_key>city</arg_key>"
-        "<arg_value>Paris</arg_value></tool_call>"
-    ),
-    "qwen": (
-        "<tool_call><function=get_weather><parameter=city>Paris</parameter>"
-        "</function></tool_call>"
-    ),
-    "kimi_k3": (
-        '<|open|>tools<|sep|><|open|>call tool="get_weather"<|sep|>'
-        '<|open|>argument key="city"<|sep|>Paris<|close|>argument<|close|>call'
-    ),
-    "dsml": (
-        f'<{_D}tool_calls><{_D}invoke name="get_weather">'
-        f'<{_D}parameter name="city" string="true">Paris</{_D}parameter>'
-        f"</{_D}invoke></{_D}tool_calls>"
-    ),
-    # Parameters named by the tag, which is what tells this format from DSML.
-    # This entry was written in DSML's `<parameter name="...">` spelling and
-    # so parsed to `get_weather({})` -- a call with no arguments, passing
-    # every test here while exercising none of the parameter path.
-    "minimax": (
-        f'{_NS}<tool_call>{_NS}<invoke name="get_weather">'
-        f"{_NS}<city>Paris{_NS}</city>"
-        f"{_NS}</invoke>{_NS}</tool_call>"
-    ),
-}
 
 
 class TestARealCallSurvivesTheStream:
@@ -1089,6 +1148,134 @@ class TestAPrefixPairCannotChangeTheHandover:
             self.test_both_halves_agree_about_opening_a_region(Synthetic)
 
 
+class TestTheTwoStagesCompose:
+    """The reasoning stage feeding the tool stage, on the format where it bites.
+
+    Kimi-K3 is the one composition where the reasoning channel's markers and
+    the tool format's overlap: `<|sep|>` ends a channel token and separates a
+    call's, and `<|open|>tools<|sep|>` both closes the think channel and opens
+    a tool region. Every property in this file ran with `ReasoningFilter()` --
+    no dialect, so the inline `<think>` fallback -- which cannot exercise any
+    of that.
+
+    Driven at many chunk sizes because the composition is where a marker split
+    across a boundary would be consumed by the wrong stage.
+    """
+
+    K3_CALL = (
+        '<|open|>tools<|sep|><|open|>call tool="get_weather"<|sep|>'
+        '<|open|>argument key="city"<|sep|>Paris<|close|>argument<|close|>call'
+    )
+
+    def _drive(self, text, size):
+        dialect, _ = resolve_dialect("<|open|>think<|sep|>")
+        return drive(
+            text,
+            [text[i : i + size] for i in range(0, len(text), size)],
+            KimiK3Parser,
+            reasoning=ReasoningChannel(dialect=dialect, starts_open=True),
+        )
+
+    @pytest.mark.parametrize("size", [1, 3, 7, 40, 10**6])
+    def test_the_channel_closes_and_the_call_still_arrives(self, size):
+        text = "Thinking.<|close|>think<|sep|>" + self.K3_CALL
+        seen = self._drive(text, size)
+        assert seen.reasoning == "Thinking.", f"size={size}: {seen.reasoning!r}"
+        assert "tool_call_start" in seen.events, f"size={size}: {seen.events}"
+
+    @pytest.mark.parametrize("size", [1, 3, 7, 40, 10**6])
+    def test_and_an_answer_between_them_is_neither(self, size):
+        text = (
+            "Thinking.<|close|>think<|sep|><|open|>response<|sep|>"
+            "Here you go.<|close|>response<|sep|>" + self.K3_CALL
+        )
+        seen = self._drive(text, size)
+        assert seen.reasoning == "Thinking.", f"size={size}: {seen.reasoning!r}"
+        assert "Here you go." in seen.content, f"size={size}: {seen.content!r}"
+
+    def test_and_every_chunk_size_agrees(self):
+        text = "Thinking.<|close|>think<|sep|>" + self.K3_CALL
+        keys = {self._drive(text, n).key for n in (1, 2, 3, 5, 11, 40, 10**6)}
+        assert len(keys) == 1, f"chunking changed the answer: {keys}"
+
+
+class TestTheHarnessDrivesTheWholeReader:
+    """What `drive()` switches off, no property below can see.
+
+    `_announce` returns on its first line when the parser has no tools, so
+    passing none ran all 850-odd properties with the early-announcement path
+    disabled -- the newest thing in the reader, and the one that broke. This
+    asserts the harness reaches it, so the omission cannot come back silently.
+    """
+
+    # A format can only announce early if its call pattern accepts a prefix
+    # of the region -- the announcement is `parse_region` with `at_end=False`.
+    # The four XML formats carry `closed | unclosed` in one regex, and Kimi-K2
+    # qualifies for a different reason: its *entry* closes on
+    # `<|tool_call_end|>` independently of the section, so a complete entry in
+    # an unfinished section parses. Only Kimi-K3 needs `<|close|>call` before
+    # anything matches, so it alone cannot name a call before it finishes --
+    # and alone cannot recover one truncated by `max_tokens`.
+    #
+    # Declared rather than discovered, because DSML was silently in this list
+    # until it was given the alternation and nothing said so. The test below
+    # is what keeps the list honest: I had K2 in it on the same assumption and
+    # the check refused it.
+    # Empty, and it was not always: Kimi-K3 needed `<|close|>call` before
+    # anything matched, so it alone could not name a call before it finished.
+    # The truncation sweep gave every format the `closed | unclosed`
+    # alternation, and announcing early is what that alternation *is*.
+    CANNOT_ANNOUNCE_EARLY: frozenset = frozenset()
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_list_of_formats_that_cannot_announce_is_accurate(self, parser):
+        """Asked the way the engine asks it: over every prefix.
+
+        `_announce` runs `parse_region(head, at_end=False)` as the bytes
+        arrive, so "can this format announce early" means "does some proper
+        prefix of a real call parse to one". Chopping a fixed twelve
+        characters instead asked a different and weaker question -- measured,
+        it left a fully closed call inside the prefix for qwen, minimax and
+        dsml, so for half the registry it was asking whether a complete call
+        parses, which every format does. Chopping at the payload asks a
+        third question, "can it read a call cut off mid-entry", and Kimi-K2
+        answers no to that while still announcing early off a complete entry
+        in an unfinished section. Only the prefix scan matches the claim.
+        """
+        call = REAL_CALLS[parser.NAME]
+        accepts = any(
+            parser.parse_region(call[:n], DECLARED_TOOLS, at_end=False).calls
+            for n in range(1, len(call))
+        )
+        expected = parser.NAME not in self.CANNOT_ANNOUNCE_EARLY
+        assert accepts == expected, (
+            f"{parser.NAME} {'now' if accepts else 'no longer'} names a call "
+            "before the whole call has arrived; update CANNOT_ANNOUNCE_EARLY "
+            "and say why"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_real_call_announces_its_name_through_the_harness(self, parser):
+        if parser.NAME in self.CANNOT_ANNOUNCE_EARLY:
+            pytest.skip("this format cannot name a call before it closes")
+        text = "Let me look. " + REAL_CALLS[parser.NAME]
+        seen = drive(text, split_every_way(text)["fixed-3"], parser)
+        starts = [
+            at
+            for kind, at in zip(seen.events, seen.event_at)
+            if kind == "tool_call_start"
+        ]
+        assert starts, f"{parser.NAME}: no call at all came out of the harness"
+        # Strictly before the last byte: the announcement fires while the
+        # region is still open, where the close-time emission cannot.
+        assert min(starts) < len(text), (
+            f"{parser.NAME}: the only name arrived at byte {min(starts)} of "
+            f"{len(text)}, i.e. when the region closed -- the early "
+            "announcement never ran, so every property using this harness is "
+            "running with that path switched off"
+        )
+
+
 class TestAFormatThatReportsNoUsableMarkup:
     """The boundary six hand-written `parse_region` implementations feed.
 
@@ -1195,11 +1382,6 @@ class TestAPlainAnswerDoesNotWaitForTheEnd:
         opener = next(m for m in parser.START_MARKERS if parser.opens_region(m))
         during, _ = self._split_by_arrival(parser, "Before. " + opener + "junk")
         assert during == len("Before. "), f"{parser.NAME} leaked past its opener"
-
-
-DECLARED_TOOLS = [
-    {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
-]
 
 
 def early_name(parser, region: str, tools) -> str | None:
@@ -2193,15 +2375,62 @@ class TestTheEarlyNameCannotDisagreeWithTheParse:
         "{call}{call}",
         PROSE + "{half}" + PROSE + "{call}",
         "{half}{call}",
+        # The shapes that need two *names* to say anything. A truncated call
+        # followed by a complete one for a different tool is the ordinary
+        # `max_tokens` malform, and it is what broke: the prefix announced the
+        # truncated call's name and the finished region returned the other.
+        "{half}{other}",
+        "{other_half}{call}",
+        PROSE + "{half}" + PROSE + "{other}",
+        "{other}{call}",
     ]
+
+    @staticmethod
+    def _texts(parser):
+        call = REAL_CALLS[parser.NAME]
+        other = call.replace("get_weather", "get_time")
+        assert other != call, f"{parser.NAME}'s fixture has no name to vary"
+        return [
+            shape.format(
+                call=call,
+                half=call[: len(call) // 2],
+                other=other,
+                other_half=other[: len(other) // 2],
+            )
+            for shape in TestTheEarlyNameCannotDisagreeWithTheParse.SHAPES
+        ]
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_corpus_can_express_a_disagreement(self, parser):
+        """The positive control: at least one shape names both tools.
+
+        Without it the property below is green because nothing in its corpus
+        can name a second tool, which is how it stayed green through a real
+        violation. This asserts the corpus has the ingredient, not that the
+        property holds.
+        """
+        seen = set()
+        for text in self._texts(parser):
+            for at_end in (False, True):
+                for call in parser.parse_region(
+                    text, DECLARED_TOOLS, at_end=at_end
+                ).calls:
+                    seen.add(call.function["name"])
+        declared = {tool["function"]["name"] for tool in DECLARED_TOOLS}
+        assert len(declared) >= 2, (
+            f"only {declared} is declared, so no shape can name a second tool "
+            "and the property below cannot fail"
+        )
+        assert declared <= seen, (
+            f"{parser.NAME}: the corpus produces {seen or '{}'} but "
+            f"{declared - seen} is declared and never appears, so a name "
+            "disagreement involving it is unrepresentable"
+        )
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_no_prefix_of_a_head_ever_names_a_different_tool(self, parser):
         call = REAL_CALLS[parser.NAME]
-        texts = [
-            shape.format(call=call, half=call[: len(call) // 2])
-            for shape in self.SHAPES
-        ]
+        texts = self._texts(parser)
         texts.append(call.replace("Paris", "x" * 300))
         texts.append(call.replace("get_weather", "undeclared_tool"))
         for text in texts:

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -1457,6 +1457,15 @@ class TestAPromiseCannotBeTakenBack:
         ], "the wrong name was given arguments to run with"
 
 
+def _big_kimi_call(payload_bytes: int) -> str:
+    """The same, in Kimi's self-delimiting token format."""
+    return (
+        "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0"
+        f'<|tool_call_argument_begin|>{{"note": "{"x" * payload_bytes}"}}'
+        "<|tool_call_end|><|tool_calls_section_end|>"
+    )
+
+
 def _big_call(payload_bytes: int) -> str:
     """One Qwen tool call whose argument is `payload_bytes` long."""
     return (
@@ -1483,17 +1492,17 @@ class TestTheRegionIsNotCopiedPerChunk:
     LARGE_KB = 128
 
     @staticmethod
-    def _stream_ms(payload_bytes: int) -> float:
-        text = _big_call(payload_bytes)
+    def _stream_ms(payload_bytes: int, parser=None, build=None) -> float:
+        text = (build or _big_call)(payload_bytes)
         best = None
         for _ in range(3):
-            parser = ToolCallStreamParser(
-                tools=DECLARED_TOOLS, parser_cls=QwenXmlParser
+            stream = ToolCallStreamParser(
+                tools=DECLARED_TOOLS, parser_cls=parser or QwenXmlParser
             )
             start = time.perf_counter()
             for i in range(0, len(text), 4):
-                parser.process(text[i : i + 4])
-            parser.flush()
+                stream.process(text[i : i + 4])
+            stream.flush()
             elapsed = time.perf_counter() - start
             best = elapsed if best is None else min(best, elapsed)
         return best * 1000
@@ -1534,6 +1543,33 @@ class TestTheRegionIsNotCopiedPerChunk:
         assert (
             max(seen) <= _PEEK_WINDOW
         ), f"a peek was handed {max(seen)} characters, window is {_PEEK_WINDOW}"
+
+    @pytest.mark.parametrize(
+        "parser, build",
+        [
+            (QwenXmlParser, _big_call),
+            (KimiParser, _big_kimi_call),
+        ],
+        ids=["buffered-region", "kimi-incremental"],
+    )
+    def test_no_format_pays_more_per_byte_as_the_payload_grows(self, parser, build):
+        """Kimi is the format that is not a `BufferedMarkerParser`, so the
+        sweep that put the others on a list accumulator missed it -- and it
+        carried a second factor of its own, re-scanning the whole buffer for
+        an entry end on every chunk. 128 KB cost 428 ms of event-loop CPU
+        against Qwen's 10 for the same payload.
+        """
+        control = self._control_ms(self.LARGE_KB * 1024) / (
+            self._control_ms(self.SMALL_KB * 1024) * (self.LARGE_KB / self.SMALL_KB)
+        )
+        if not 0.6 < control < 1.6:
+            pytest.skip(f"machine too noisy to measure: control ratio {control:.2f}")
+        small = self._stream_ms(self.SMALL_KB * 1024, parser, build) / self.SMALL_KB
+        large = self._stream_ms(self.LARGE_KB * 1024, parser, build) / self.LARGE_KB
+        assert large / small < 1.5, (
+            f"{parser.NAME}: cost per KB grew {large / small:.2f}x from "
+            f"{self.SMALL_KB} to {self.LARGE_KB} KB ({small:.3f} -> {large:.3f})"
+        )
 
     def test_the_cost_per_byte_does_not_grow(self):
         """The timed half, with a control arm.

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -43,6 +43,7 @@ import json
 import pathlib
 import random
 import re
+import statistics
 import sys
 import time
 from typing import ClassVar
@@ -60,16 +61,21 @@ from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_too
 from atom.entrypoints.openai.tool_parser.deepseekv4_tool_parser import DsmlParser
 from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
+from atom.entrypoints.openai.tool_parser.minimax_tool_parser import MINIMAX_NS
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 from atom.entrypoints.openai.tool_parser.registry import PARSERS_BY_NAME
 from atom.entrypoints.openai.tool_parser.stream import (
     _PEEK_WINDOW,
     ToolCallStreamParser,
+    read_whole_events,
 )
 from entrypoints.wire_corpus import (
     DECLARED_TOOLS,
+    PARAM,
     PAYLOAD,
     REAL_CALLS,
+    TOOL,
+    TYPED_TOOLS,
     naming_another_tool,
     naming_something_undispatchable,
     quoting_a_call_it_will_not_make,
@@ -514,7 +520,7 @@ class TestEverySeedingSiteIsSeeded:
     # same question.
     SEEDED = ("ReasoningChannel", "ReasoningFilter", "separate_reasoning")
     # The keyword each of them spells the answer with.
-    SEED_KWARG = {
+    SEED_KWARG: ClassVar[dict[str, str]] = {
         "ReasoningChannel": "starts_open",
         "ReasoningFilter": "starts_thinking",
         "separate_reasoning": "starts_thinking",
@@ -945,6 +951,89 @@ class TestTheReasoningSplitAgreesWithItself:
         return "\n".join(lines)
 
 
+#: DSML's accepting branches that `render_call` does not render, read off the
+#: code rather than the prose describing them. Module level because it is a
+#: fact about the format: the corpus renders one form per format, so a format
+#: with several accepting branches is covered on one of them unless the others
+#: are carried by hand. The payload past `_PEEK_WINDOW` is deliberate -- the
+#: direct-JSON branch needs the whole object, so its call is invisible to any
+#: head-sized peek while being real.
+_DSML_BODY = "x" * (4 * _PEEK_WINDOW)
+DSML_UNRENDERED: dict[str, str] = {
+    "wrapper-less": "<｜DSML｜tool_calls>"
+    f'<｜DSML｜parameter name="{PARAM}">{_DSML_BODY}</｜DSML｜parameter>'
+    "</｜DSML｜tool_calls>",
+    "direct-json": f'<｜DSML｜tool_calls><｜DSML｜invoke name="{TOOL}">'
+    f'{{"{PARAM}": "{_DSML_BODY}"}}'
+    "</｜DSML｜invoke></｜DSML｜tool_calls>",
+}
+
+#: Both DSML branches in one region, wrapper-less first -- the shape that makes
+#: this format's acceptance non-monotone. Read as far as the `<invoke>` it is a
+#: wrapper-less call whose markup is the whole region; read past it the invoke
+#: loop claims the region and the bare parameters in front become answer.
+#: Neither branch alone shows it, which is why the order property below was
+#: green against the reverted fix until this was added. Not in
+#: `DSML_UNRENDERED`: releasing that prefix as text is correct here, and the
+#: give-up class asserts the opposite.
+DSML_BOTH_BRANCHES = (
+    "<｜DSML｜tool_calls>"
+    f'<｜DSML｜parameter name="{PARAM}">Paris</｜DSML｜parameter>'
+    f'<｜DSML｜invoke name="{TOOL}">'
+    f'<｜DSML｜parameter name="{PARAM}">Rome</｜DSML｜parameter>'
+    "</｜DSML｜invoke></｜DSML｜tool_calls>"
+)
+#: `TYPED_TOOLS`, not `DECLARED_TOOLS`: the wrapper-less branch has no name on
+#: the wire and infers one from the parameter signature, so tools declaring no
+#: properties give it nothing to match. Against `DECLARED_TOOLS` these shapes
+#: were accepted only because that branch fell back to a call named `unknown`
+#: -- never on their merits, so the positive control below was reporting the
+#: defect as the feature.
+DSML_UNRENDERED_TOOLS = TYPED_TOOLS
+
+
+def event_shape(events) -> list[tuple[str, str]]:
+    """An event list reduced to what both delivery modes must agree on.
+
+    Adjacent `content` is joined -- streaming releases the answer in whatever
+    pieces the chunking produced, which is not a difference a client can see,
+    and `_blocks_in_order` joins it for the same reason. Ids are dropped,
+    since comparing them compares the uuid generator. What is left is order,
+    names, indices and arguments.
+    """
+    out: list[list[str]] = []
+    for kind, data in events:
+        if kind == "content" and out and out[-1][0] == "content":
+            out[-1][1] += data
+        elif kind == "content":
+            out.append(["content", data])
+        elif kind in ("tool_call_start", "tool_call_args"):
+            fn = data["function"]
+            said = fn["name"] if kind == "tool_call_start" else fn["arguments"]
+            out.append([kind, f"{data['index']}:{said}"])
+        else:
+            out.append([kind, ""])
+    return [tuple(pair) for pair in out]
+
+
+#: One real call per registered format -- every format, so one added later is
+#: bound without anyone remembering to add a case -- plus DSML's three
+#: unrenderable branches.
+ORDER_CASES = [
+    *(
+        pytest.param(p, DECLARED_TOOLS, REAL_CALLS[p.NAME], id=p.NAME)
+        for p in ALL_PARSERS
+    ),
+    *(
+        pytest.param(DsmlParser, DSML_UNRENDERED_TOOLS, text, id=f"dsml-{branch}")
+        for branch, text in sorted(DSML_UNRENDERED.items())
+    ),
+    pytest.param(
+        DsmlParser, DSML_UNRENDERED_TOOLS, DSML_BOTH_BRANCHES, id="dsml-both-branches"
+    ),
+]
+
+
 class TestNonStreamingAgreesWithStreaming:
     """An answer with no tool call comes back the same on both paths.
 
@@ -996,8 +1085,34 @@ class TestNonStreamingAgreesWithStreaming:
             f"  out {rebuilt[-60:]!r}"
         )
 
+    @pytest.mark.parametrize("parser, tools, call", ORDER_CASES)
+    @pytest.mark.parametrize("lead", ["", "Let me check that. "], ids=["bare", "prose"])
+    def test_a_region_that_parses_agrees_on_order_too(self, parser, tools, call, lead):
+        """The two tests above bind the no-call case and skip this one.
 
-def streamed_and_last(parser, text: str, *, suppress: bool = False):
+        That skip is where an ordering difference lived: DSML announced a name
+        inferred from a signature, then an `<invoke>` arrived and moved which
+        bytes were markup, so `stream=true` put the call in front of prose
+        that `stream=false` puts behind it. Agreeing on the *text* is not
+        enough -- a client renders these in the order they arrive.
+        """
+        text = lead + call
+        engine = ToolCallStreamParser(tools=tools, parser_cls=parser)
+        events = []
+        for chunk in split_every_way(text)["fixed-3"]:
+            events.extend(engine.process(chunk))
+        events.extend(engine.flush())
+        streamed, whole = event_shape(events), event_shape(
+            read_whole_events(parser, text, tools)
+        )
+        assert streamed == whole, (
+            f"{parser.NAME} orders the same generation two ways\n"
+            f"  stream=true  {streamed}\n"
+            f"  stream=false {whole}"
+        )
+
+
+def streamed_and_last(parser, text: str, *, suppress: bool = False, tools=None):
     """What reached the client before the last frame, and in it.
 
     `(streamed, last frame, calls)` at four characters a chunk. Not `drive`
@@ -1006,7 +1121,9 @@ def streamed_and_last(parser, text: str, *, suppress: bool = False):
     copies of this lived in the classes below before it was one.
     """
     engine = ToolCallStreamParser(
-        tools=DECLARED_TOOLS, parser_cls=parser, suppress_calls=suppress
+        tools=DECLARED_TOOLS if tools is None else tools,
+        parser_cls=parser,
+        suppress_calls=suppress,
     )
     early, last, calls = [], [], 0
     for i in range(0, len(text), 4):
@@ -1093,6 +1210,33 @@ class TestNothingKnownToBeOutsideACallIsBuffered:
         assert not leaked, f"{parser.NAME} released wire tokens: {leaked}"
 
 
+class TestASignatureMatchingNothingIsNotACall:
+    """DSML's wrapper-less branch infers a name, so it must be able to say no.
+
+    Every score is negative once the parameter sets are disjoint and the
+    running best started below all of them, so the first declared tool with
+    any properties won on no evidence: `<parameter name="zzz">` dispatched
+    `get_weather`, and with no tools declared at all it dispatched a call
+    named `unknown`. There is no name on the wire in this branch, so nothing
+    matching means the region was prose.
+    """
+
+    REGION: ClassVar[str] = (
+        '<｜DSML｜tool_calls><｜DSML｜parameter name="zzz">1</｜DSML｜parameter>'
+    )
+
+    @pytest.mark.parametrize(
+        "tools", [DSML_UNRENDERED_TOOLS, None], ids=["declared", "none"]
+    )
+    def test_it_is_released_as_text(self, tools):
+        content, calls = parse_tool_calls(self.REGION, tools, DsmlParser)
+        assert not calls, (
+            f"dsml invented {[c.function['name'] for c in calls]} for a "
+            "signature no declared tool shares"
+        )
+        assert content == self.REGION, "the region was not released as written"
+
+
 class TestAGiveUpProbeStaysReverted:
     """A region that has produced nothing yet is still buffered, on purpose.
 
@@ -1106,43 +1250,30 @@ class TestAGiveUpProbeStaysReverted:
 
     The corpus is generated from `render_call`, which renders one form per
     format, so a format with several accepting branches is only covered on the
-    one it renders. This class carries the others by hand for that reason, and
-    says so.
+    one it renders. `DSML_UNRENDERED` carries the others for that reason.
     """
 
-    #: DSML's two accepting branches that `render_call` does not render, in
-    #: the syntax the parser accepts -- read off `parse_region`, not off the
-    #: prose describing them. A payload past `_PEEK_WINDOW` is the point: the
-    #: direct-JSON branch needs the whole object, so the call is invisible to
-    #: any head-sized peek while being perfectly real.
-    BODY: ClassVar[str] = "x" * (4 * _PEEK_WINDOW)
-    UNRENDERED: ClassVar[dict[str, str]] = {
-        "wrapper-less": "<｜DSML｜tool_calls>"
-        f'<｜DSML｜parameter name="city">{BODY}</｜DSML｜parameter>'
-        "</｜DSML｜tool_calls>",
-        "direct-json": '<｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">'
-        f'{{"city": "{BODY}"}}'
-        "</｜DSML｜invoke></｜DSML｜tool_calls>",
-    }
-
-    @pytest.mark.parametrize("branch", sorted(UNRENDERED), ids=str)
+    @pytest.mark.parametrize("branch", sorted(DSML_UNRENDERED), ids=str)
     def test_the_shape_is_one_the_format_accepts(self, branch):
         """The positive control, and it is not ceremony: the first version of
         this class invented both shapes from the paragraph describing them,
         and DSML accepted neither -- so "the markup leaked" was just
         unparseable text being released, and the class asserted nothing."""
         _content, calls = parse_tool_calls(
-            self.UNRENDERED[branch], DECLARED_TOOLS, DsmlParser
+            DSML_UNRENDERED[branch], DSML_UNRENDERED_TOOLS, DsmlParser
         )
         assert calls, f"dsml does not accept the {branch} shape; fix the shape"
 
-    @pytest.mark.parametrize("branch", sorted(UNRENDERED), ids=str)
+    @pytest.mark.parametrize("branch", sorted(DSML_UNRENDERED), ids=str)
     @pytest.mark.parametrize("suppress", [False, True], ids=["dispatch", "none"])
     def test_a_call_longer_than_the_peek_window_is_not_released_as_text(
         self, branch, suppress
     ):
         early, last, _calls = streamed_and_last(
-            DsmlParser, self.UNRENDERED[branch], suppress=suppress
+            DsmlParser,
+            DSML_UNRENDERED[branch],
+            suppress=suppress,
+            tools=DSML_UNRENDERED_TOOLS,
         )
         leaked = [m for m in DsmlParser.START_MARKERS if m in early + last]
         assert not leaked, (
@@ -1209,7 +1340,9 @@ class TestBoundedWithhold:
 # generated: a call's payload is the one thing each format spells differently,
 # so the table is written out and `test_every_format_has_a_call` is what stops
 # a new format from joining the registry without one.
-_NS = "]<]minimax[>["
+# From the parser, not spelled again: a hand copy of a wire token is how two
+# readers of one literal come to disagree, which this suite has a test for.
+_NS = MINIMAX_NS
 _D = "｜DSML｜"
 
 
@@ -3062,4 +3195,84 @@ class TestAQuotationDoesNotMoveARealCallsLeftEdge:
         assert len(calls) == 1, (
             f"{parser.NAME} made {len(calls)} calls where the model made one; "
             "the quoted opener was read as a second"
+        )
+
+
+def _timed(call, *, loops: int = 20) -> float:
+    """Microseconds per call, averaged over `loops`.
+
+    Averaged inside and taken as a minimum outside: the inner loop lifts one
+    call above the clock's noise floor, the outer minimum drops the samples
+    the scheduler landed on.
+    """
+    start = time.perf_counter()
+    for _ in range(loops):
+        call()
+    return (time.perf_counter() - start) / loops * 1e6
+
+
+class TestNoFormatLosesItsLiteralPrefix:
+    """A format's patterns must be skippable over text that is not a call.
+
+    `re` scans for a pattern's fixed first byte and skips everything else; one
+    that opens with an *optional* group has no such byte and is tried at every
+    position. MiniMax matched its ns_token at the head of both `_INVOKE_RE`
+    and `_PARAM_RE`, so reading an 18 KB region cost 524 us against 3.8 for
+    the same work in DSML -- 138x, for a token `CALL_FILLERS` already walks
+    back, which is why the fix was to delete it rather than rewrite anything.
+
+    Against the other formats rather than a constant: the median is the
+    control arm, and it is what makes this readable on a machine whose
+    absolute numbers are nothing like this one's. The cost is that a
+    regression hitting every format at once would pass, so the second test
+    keeps the harness honest about what it can see.
+    """
+
+    #: Long enough that a per-position scan separates from a skipped one, short
+    #: enough to stay a unit test.
+    PROSE: ClassVar[str] = "The quick brown fox jumps over the lazy dog. " * 400
+    #: The spread across the six formats is 1.8x with no prefix lost, and the
+    #: defect was 138x. Far from both, being a shape check rather than a
+    #: number to tune.
+    BUDGET: ClassVar[float] = 20.0
+
+    @classmethod
+    def _cost(cls, call) -> float:
+        """Best of five: the mean measures the scheduler as much as the code."""
+        call()
+        return min(_timed(call) for _ in range(5))
+
+    def test_no_format_is_an_order_of_magnitude_off_the_others(self):
+        costs = {
+            p.NAME: self._cost(
+                functools.partial(p.parse_region, self.PROSE, TYPED_TOOLS, at_end=True)
+            )
+            for p in ALL_PARSERS
+        }
+        median = statistics.median(costs.values())
+        worst, cost = max(costs.items(), key=lambda kv: kv[1])
+        assert cost <= self.BUDGET * median, (
+            f"{worst} reads a non-call region {cost / median:.0f}x slower than "
+            f"the median format -- check whether one of its patterns now opens "
+            f"with an optional group.\n  "
+            + "\n  ".join(
+                f"{n}: {v:.1f} us"
+                for n, v in sorted(costs.items(), key=lambda kv: -kv[1])
+            )
+        )
+
+    def test_the_measurement_can_see_a_lost_prefix(self):
+        """The positive control. Without it "everything is within budget" is
+        also what a harness with no discrimination reports -- and this suite
+        has already shipped one class whose shapes no format accepted, so the
+        assertions held vacuously."""
+        ns = re.escape(MINIMAX_NS)
+        anchored = re.compile(r'<invoke\s+name="([^"]*)">')
+        adrift = re.compile(rf'(?:{ns})?<invoke\s+name="([^"]*)">')
+        fast = self._cost(lambda: anchored.findall(self.PROSE))
+        slow = self._cost(lambda: adrift.findall(self.PROSE))
+        assert slow > self.BUDGET * fast, (
+            f"the harness cannot tell a lost literal prefix from a kept one "
+            f"({slow:.1f} us against {fast:.1f} us); the test above proves "
+            f"nothing until it can"
         )

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -65,6 +65,9 @@ from entrypoints.wire_corpus import (
     DECLARED_TOOLS,
     REAL_CALLS,
     naming_another_tool,
+    naming_nothing,
+    naming_only_spaces,
+    quoting_a_call_it_will_not_make,
     truncated,
     truncated_naming_another_tool,
 )
@@ -2647,4 +2650,93 @@ class TestTheEarlyNameCannotDisagreeWithTheParse:
         assert stream._index > announced[-1], (
             "the index of a name that produced no call was not stepped past; a "
             "later call would land on it"
+        )
+
+
+class TestNoFormatShipsACallItCannotName:
+    """A call the client cannot dispatch is not a call.
+
+    Every format's name slot admits an empty string -- `name="([^"]*)"`,
+    `tool="([^"]*)"` -- so this is a shape the wire allows and a model can
+    produce. Three of six handed it on: DSML and K3 asked nothing at all, and
+    MiniMax asked `if not name` *before* `name.strip()`, so a name of pure
+    whitespace passed the guard and reached the client as `""`.
+
+    Generated over the registry rather than written per format, because that
+    split -- three formats, three different ways of being wrong, one of them
+    only visible to the whitespace shape -- is what a per-format test set
+    reliably half-covers.
+    """
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    @pytest.mark.parametrize(
+        "derive", [naming_nothing, naming_only_spaces], ids=["empty", "whitespace"]
+    )
+    def test_it_is_not_reported_as_a_call(self, parser, derive):
+        text = derive(parser.NAME)
+        _content, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+        assert not calls, (
+            f"{parser.NAME} reported a call named "
+            f"{calls[0].function['name']!r}, which matches nothing the request "
+            "declared and which a client cannot dispatch"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_the_same_shape_with_a_name_still_is(self, parser):
+        """The positive control. Without it the property above passes on a
+        parser that stopped reading its own format."""
+        _content, calls = parse_tool_calls(
+            REAL_CALLS[parser.NAME], DECLARED_TOOLS, parser
+        )
+        assert calls, f"{parser.NAME} no longer reads its own complete call"
+
+
+class TestAQuotationDoesNotMoveARealCallsLeftEdge:
+    """A sentence between a quoted opener and a real call is the answer.
+
+    The region opens at the *first* marker in the text, so an answer that
+    shows the wire format and then calls for real puts the region's left edge
+    in the wrong place, and each format pulls it back to where its first
+    accepted call begins. Kimi pulled it back to the first thing its entry
+    pattern *matched* instead -- including a quotation its own truncation gate
+    had already rejected -- and deleted the sentence in between as markup.
+
+    Five formats kept it and one did not, which is what made the answer a
+    fact to look up rather than a decision to make.
+
+    The quotation has to be one the format's own pattern *matches* and its
+    gate then rejects -- `quoting_a_call_it_will_not_make`, not
+    `quoting_the_opener`. Built from the latter this class passed on HEAD, on
+    every format: Kimi's entry pattern needs `functions.NAME:INDEX`, an
+    opener alone does not match it, and with no rejected match there is no
+    anchor to move. Green, and asserting nothing about the defect it was
+    written for.
+    """
+
+    SENTINEL: ClassVar[str] = "SENTINEL_the_models_own_sentence"
+
+    def _text(self, parser) -> str:
+        return (
+            quoting_a_call_it_will_not_make(parser.NAME)
+            + self.SENTINEL
+            + REAL_CALLS[parser.NAME]
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_sentence_between_them_survives(self, parser):
+        content, calls = parse_tool_calls(self._text(parser), DECLARED_TOOLS, parser)
+        assert calls, f"{parser.NAME} lost the real call; this asserts nothing"
+        assert self.SENTINEL in content, (
+            f"{parser.NAME} deleted the sentence the model wrote between its "
+            "quotation and its call"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_the_quotation_makes_no_second_call(self, parser):
+        """The other half: keeping the sentence must not cost the gate that
+        stops the quotation itself being read as a call."""
+        _content, calls = parse_tool_calls(self._text(parser), DECLARED_TOOLS, parser)
+        assert len(calls) == 1, (
+            f"{parser.NAME} made {len(calls)} calls where the model made one; "
+            "the quoted opener was read as a second"
         )

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -46,7 +46,7 @@ from typing import ClassVar
 import pytest
 
 from atom.entrypoints.openai.reasoning import ReasoningFilter, separate_reasoning
-from atom.entrypoints.openai.reasoning_dialects import DIALECTS
+from atom.entrypoints.openai.reasoning_dialects import DIALECTS, resolve_dialect
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_tool_calls
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
@@ -95,14 +95,20 @@ class Seen:
         return (self.reasoning, self.content, tuple(self.events), finish)
 
 
-def drive(text: str, chunks: list[str], parser=None) -> Seen:
+def drive(
+    text: str, chunks: list[str], parser=None, *, suppress_calls: bool = False
+) -> Seen:
     """Replay the serving loop over one chunking.
 
     `parser` is what the server resolved from the chat template at startup, so
     each case reads its own format explicitly rather than relying on the shape
-    of the text to select one.
+    of the text to select one. `suppress_calls` is `tool_choice: "none"`,
+    which is a property of the request and not of the text, so it has to be
+    passed in the same way.
     """
-    rf, tp = ReasoningFilter(), ToolCallStreamParser(parser_cls=parser)
+    rf, tp = ReasoningFilter(), ToolCallStreamParser(
+        parser_cls=parser, suppress_calls=suppress_calls
+    )
     seen = Seen()
     consumed = 0
 
@@ -795,6 +801,82 @@ class TestARealCallSurvivesTheStream:
         seen = drive(text, split_every_way(text)["fixed-3"], parser)
         assert "Let me look." in seen.content
 
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_so_does_the_text_written_between_two_calls(self, parser):
+        """The sentence a model writes while making a second call.
+
+        `TestConservation` cannot see this: it `continue`s the moment a shape
+        produces events, on the grounds that "a real tool call consumes its
+        own bytes" -- true of the call, not of the prose beside it. And the
+        two chunk-invariance properties cannot see it either, because both
+        delivery paths are the same engine and agreed on deleting it. Five of
+        the six formats did, silently, with `finish_reason: tool_calls`.
+        """
+        call = REAL_CALLS[parser.NAME]
+        middle = "Now let me also check Rome."
+        text = f"Before. {call} {middle} {call.replace('Paris', 'Rome')} After."
+        content, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+        assert len(calls) == 2, f"{len(calls)} calls, so this shape proves nothing"
+        assert (
+            middle in content
+        ), f"the sentence between two calls was deleted: {content!r}"
+        for label, chunks in split_every_way(text).items():
+            seen = drive(text, chunks, parser)
+            assert middle in seen.content, f"{label}: {seen.content!r}"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_forbidding_calls_delivers_the_answer_and_not_the_wire_format(self, parser):
+        """`tool_choice: "none"` on every format, not just the one tested.
+
+        Suppression used to skip opening the region, so the call's own bytes
+        streamed out as `content`: the whole `<invoke name=...>` payload, on
+        all six. The single-format test that covered this asserted the raw
+        text came back *verbatim* and so encoded the leak as the contract --
+        and on Kimi-K3 even that was untrue, because the read-ahead drops its
+        framing mid-region and the client got a mangled fragment.
+        """
+        text = "Sure. " + REAL_CALLS[parser.NAME] + " Done."
+        content, calls = parse_tool_calls(
+            text, DECLARED_TOOLS, parser, suppress_calls=True
+        )
+        assert calls == [], "a forbidden call was dispatched"
+        assert (
+            "Sure." in content and "Done." in content
+        ), f"the answer around the call was eaten: {content!r}"
+        for marker in parser.START_MARKERS:
+            assert (
+                marker not in content
+            ), f"raw wire markup shown to the user: {marker!r} in {content!r}"
+        for label, chunks in split_every_way(text).items():
+            seen = drive(text, chunks, parser, suppress_calls=True)
+            assert seen.content == content, f"{label}: {seen.content!r}"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_it_arrives_between_them_rather_than_ahead_of_both(self, parser):
+        """Order is part of the answer.
+
+        Emitting both calls and then the prose would put the same characters
+        on the wire in the wrong place: a client rendering deltas in arrival
+        order shows "let me also check Rome" after the Rome call it introduces.
+        """
+        call = REAL_CALLS[parser.NAME]
+        middle = "Now let me also check Rome."
+        text = f"Before. {call} {middle} {call.replace('Paris', 'Rome')} After."
+        parser_obj = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+        events = parser_obj.process(text) + parser_obj.flush()
+        order, said = [], ""
+        for kind, data in events:
+            if kind == "content":
+                said += data
+                if middle in said and "middle" not in order:
+                    order.append("middle")
+            elif kind == "tool_call_start":
+                order.append(data["function"]["name"])
+        assert order.count("middle") == 1
+        assert order.index("middle") > order.index(
+            "get_weather"
+        ), f"the sentence introducing the second call arrived first: {order}"
+
 
 # Markers a format declares so the read-ahead will not split them, but which
 # do not hand the stream over: channel framing that wraps every answer. Only
@@ -957,6 +1039,40 @@ class TestAPrefixPairCannotChangeTheHandover:
         found = {p.NAME: prefix_pairs(p) for p in ALL_PARSERS}
         total = sum(len(v) for v in found.values())
         assert total >= 3, f"no prefix pairs left to check: {found}"
+
+    @pytest.mark.parametrize(
+        "source", ["<think></think>", "<|open|>think<|sep|>"], ids=["think", "channel"]
+    )
+    def test_a_dialect_declares_no_pair_that_changes_the_channel(self, source):
+        """The same rule on the reasoning side, where it was not being asked.
+
+        `ReasoningFilter` watches this dialect's framing *and* its end markers
+        in one scanner, and the two do opposite things: framing is dropped and
+        the state is unchanged, an end marker closes the channel. So a bare
+        closer that is a proper prefix of a paired end marker is precisely the
+        disagreeing pair `_plan` warns about -- the short one fires, the
+        channel never closes, and at four bytes per chunk the whole answer
+        comes back as `reasoning_content` while `stream=false` splits it
+        correctly. Adding `<|close|>think` to Kimi-K3's channel framing did
+        exactly that; the tool-parser version of this test could not see it,
+        because a dialect is not a parser.
+        """
+        dialect, _ = resolve_dialect(source)
+        framing, ends = set(dialect.content_framing), set(dialect.end_markers)
+        watched = framing | ends
+        disagreeing = [
+            (short, long)
+            for short in watched
+            for long in watched
+            if short != long
+            and long.startswith(short)
+            and ((short in ends) != (long in ends))
+        ]
+        assert not disagreeing, (
+            f"{source!r} watches a marker that is a prefix of another and only "
+            f"one of them closes the reasoning channel, so which happens "
+            f"depends on the chunk boundary: {disagreeing}"
+        )
 
     def test_a_disagreeing_pair_is_rejected(self):
         """And that the check can fail at all -- built rather than waited for."""
@@ -1403,7 +1519,7 @@ class TestThePeekNeverNamesWhatTheParseCallsProse:
                     type="function",
                     function={"name": m.group(1), "arguments": "{}"},
                 )
-                return RegionParse((call,), m.start(), len(region))
+                return RegionParse((call,), ((m.start(), len(region)),))
 
         with pytest.raises(AssertionError, match="peek said"):
             self._check(Loose, CALL_OPENERS["qwen"] + " and then...", "English", None)
@@ -2092,7 +2208,7 @@ class TestTheEarlyNameCannotDisagreeWithTheParse:
                         type="function",
                         function={"name": "get_weather", "arguments": "{}"},
                     )
-                    return RegionParse((call,), 0, len(region))
+                    return RegionParse((call,), ((0, len(region)),))
                 return RegionParse()
 
         text = "<tool_call><function=get_weather><parameter=city>Paris"

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -42,7 +42,7 @@ import pytest
 from atom.entrypoints.openai.reasoning import ReasoningFilter
 from atom.entrypoints.openai.reasoning_dialects import DIALECTS
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
-from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER, _SNIFF_ONLY
+from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
 from atom.entrypoints.openai.tool_parser.stream import ToolCallStreamParser
 
 # Kimi is the terminal fallback and so is not in the detect order, but it is a
@@ -83,9 +83,14 @@ class Seen:
         return (self.reasoning, self.content, tuple(self.events), finish)
 
 
-def drive(text: str, chunks: list[str]) -> Seen:
-    """Replay the serving loop over one chunking."""
-    rf, tp = ReasoningFilter(), ToolCallStreamParser()
+def drive(text: str, chunks: list[str], parser=None) -> Seen:
+    """Replay the serving loop over one chunking.
+
+    `parser` is what the server resolved from the chat template at startup, so
+    each case reads its own format explicitly rather than relying on the shape
+    of the text to select one.
+    """
+    rf, tp = ReasoningFilter(), ToolCallStreamParser(parser_cls=parser)
     seen = Seen()
     consumed = 0
 
@@ -170,16 +175,6 @@ def shapes(dialect, parser) -> dict[str, str]:
             + "It is sunny in Paris."
         ),
     }
-    # A literal the sniffer picks the format by that is *not* a region
-    # opener: the parser is chosen and then handed text its own
-    # `START_MARKERS` do not match, so it reads on in content mode. That is
-    # the path whose holdback used to stop emitting entirely once its buffer
-    # began with a marker character. Generated from the difference between
-    # the two declarations, so a future format with the same split is covered.
-    if _SNIFF_ONLY:
-        out["detected by a literal that opens no region"] = (
-            _SNIFF_ONLY[0] + "city</arg_key> then a < b and " + PROSE * 4
-        )
 
     if dialect.output_open_marker:
         out["reasoning the model opens itself"] = (
@@ -378,11 +373,11 @@ class TestBoundedWithhold:
         control = defuse(text, triggers)
 
         fine = split_every_way(text)["fixed-1"]
-        seen = drive(text, fine)
+        seen = drive(text, fine, parser)
         if not seen.content:
             pytest.skip("no content channel in this shape; nothing to hold back")
 
-        ctl = drive(control, split_every_way(control)["fixed-1"])
+        ctl = drive(control, split_every_way(control)["fixed-1"], parser)
         held = seen.first_content_at or len(text)
         baseline = ctl.first_content_at or len(control)
         assert held - baseline <= SLACK, (

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -39,6 +39,7 @@ import json
 import pathlib
 import random
 import re
+import sys
 import time
 
 import pytest
@@ -797,7 +798,12 @@ class TestARealCallSurvivesTheStream:
 FRAMING_NOT_A_REGION: dict[str, set[str]] = {
     # Every channel token K3 wraps an answer in. Only the call prefix and the
     # tools wrapper mean a call; the rest are removed on both paths, so the
-    # read-ahead has to know them to keep the two in step.
+    # read-ahead has to know them to keep the two in step. Written out rather
+    # than read off `_K3_CONTENT_FRAMING`, for the reason in the test below:
+    # a copy that agrees with the code by construction agrees with a broken
+    # code too. It went from eleven to fourteen when the last three -- which
+    # `parse` stripped and the scanner had never heard of -- were declared;
+    # they leaked verbatim into streamed content and vanished when not.
     "kimi_k3": {
         "<|open|>response<|sep|>",
         "<|close|>response<|sep|>",
@@ -809,6 +815,9 @@ FRAMING_NOT_A_REGION: dict[str, set[str]] = {
         "<|close|>response",
         "<|close|>think",
         "<|close|>message",
+        "<|close|>tools",
+        "<|close|>argument",
+        "<|close|>call",
         "<|sep|>",
     },
 }
@@ -818,6 +827,81 @@ def prefix_pairs(parser) -> list[tuple[str, str]]:
     """Every (short, long) pair of this format's markers where short opens long."""
     ms = parser.START_MARKERS
     return [(a, b) for a in ms for b in ms if a != b and b.startswith(a)]
+
+
+def _drive_parser(parser, text, size):
+    stream = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+    events = []
+    for i in range(0, len(text), size):
+        events += stream.process(text[i : i + size])
+    return events + stream.flush()
+
+
+def channel_tokens(parser) -> list[str]:
+    """Framing-token-shaped strings this format's own module names.
+
+    Harvested from the module rather than from `START_MARKERS`, and that is
+    the whole point: a corpus built from the declared list cannot contain a
+    token the format strips but never declared, which is exactly the drift
+    this looks for. Kimi-K3 stripped `<|close|>tools`, `<|close|>call` and
+    `<|close|>argument` and declared none of them.
+    """
+    module = sys.modules[parser.__module__]
+    found: set[str] = set()
+    for value in vars(module).values():
+        if isinstance(value, str):
+            found.add(value)
+        elif isinstance(value, tuple):
+            found.update(v for v in value if isinstance(v, str))
+        elif isinstance(value, re.Pattern):
+            # `<|close|>tools` and its siblings exist only inside an
+            # alternation, so the pattern is where they have to be read from
+            # -- unescaped, since that is how they arrive on the wire.
+            found.update(
+                re.findall(r"(?:<\\\|[^|]*\\\|>)+\w*", value.pattern),
+            )
+    return sorted(
+        {
+            t.replace("\\", "")
+            for t in found
+            if t.startswith(("<", "]<")) and "(" not in t
+        }
+    )
+
+
+class TestAFormatDeclaresEveryTokenItStrips:
+    """What `parse` removes from content, the read-ahead has to know.
+
+    They answer the same question -- which bytes are framing rather than
+    answer -- and the streaming path can only hold back a literal it was told
+    about. Kimi-K3 kept two lists and they drifted: three tokens were
+    stripped and undeclared, so they reached the client verbatim when
+    streamed and vanished when not, and a quoted
+    `<|open|>argument key="city"<|sep|>` came out with only its separator
+    removed -- text matching neither path.
+    """
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_framing_comes_out_the_same_whether_or_not_it_is_streamed(self, parser):
+        tokens = channel_tokens(parser)
+        assert tokens, f"{parser.NAME}: no tokens harvested, this asserts nothing"
+        bad = []
+        for a, b in itertools.product(tokens, repeat=2):
+            text = f"A {a} B {b} C"
+            non = parser.parse(text, DECLARED_TOOLS)[0]
+            if parser.parse(text, DECLARED_TOOLS)[1]:
+                continue  # a real call; the no-call rule is what binds here
+            for size in (1, 3, 999):
+                got = "".join(
+                    d for k, d in _drive_parser(parser, text, size) if k == "content"
+                )
+                if got != non:
+                    bad.append((text, non, got))
+                    break
+        assert not bad, (
+            f"{len(bad)} of {len(tokens) ** 2} token pairs split two ways, "
+            f"first: {bad[0]}"
+        )
 
 
 class TestAPrefixPairCannotChangeTheHandover:

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -1089,6 +1089,49 @@ class TestAPrefixPairCannotChangeTheHandover:
             self.test_both_halves_agree_about_opening_a_region(Synthetic)
 
 
+class TestAFormatThatReportsNoUsableMarkup:
+    """The boundary six hand-written `parse_region` implementations feed.
+
+    A span the engine cannot consume means it consumes nothing, hands the
+    region back, finds the same marker and parses it forever. The earlier
+    guard against that quietly took a one-byte span instead: a byte of the
+    answer vanished with no event and no log, and the re-fed remainder could
+    reopen a region on the same marker and emit the *same* call a second time.
+
+    No registered format can produce this -- every span is a non-empty regex
+    match widened outward -- so this drives a synthetic one. That is the
+    point: it is the check for the seventh parser, and it has to fail towards
+    releasing the region rather than towards eating it.
+    """
+
+    class _Degenerate(QwenXmlParser):
+        NAME = "degenerate"
+        START_MARKERS = ("<X>",)
+
+        @classmethod
+        def parse_region(cls, region, tools, *, at_end):
+            call = ToolCall(
+                id="fixed",
+                type="function",
+                function={"name": "get_weather", "arguments": "{}"},
+            )
+            return RegionParse((call,), ((3, 3), (7, 2)))
+
+    BODY = "<X><X>DUP</X>"
+
+    def test_not_one_byte_of_the_answer_is_deleted(self):
+        content, _ = parse_tool_calls(self.BODY, DECLARED_TOOLS, self._Degenerate)
+        assert (
+            content == self.BODY
+        ), f"{len(self.BODY) - len(content)} byte(s) vanished: {content!r}"
+
+    def test_and_the_call_is_not_emitted_twice(self):
+        parser = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=self._Degenerate)
+        events = parser.process(self.BODY) + parser.flush()
+        starts = [k for k, _ in events if k == "tool_call_start"]
+        assert len(starts) <= 1, f"the same call went out {len(starts)} times"
+
+
 class TestAPlainAnswerDoesNotWaitForTheEnd:
     """A format's own framing is not a reason to stop streaming.
 

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -176,6 +176,20 @@ def shapes(dialect, parser) -> dict[str, str]:
         ),
     }
 
+    # Every marker the format has, not just the first: Kimi-K3's parse keys on
+    # its tools token while its first marker is the call prefix, so quoting
+    # only `marks[0]` left a whole branch unreached.
+    for i, extra in enumerate(marks[1:], start=1):
+        out[f"marker {i} quoted inside the answer"] = (
+            f"The model writes {extra} to open a call. " + PROSE * 4
+        )
+
+    # Ends mid-marker: the read-ahead is still holding a partial when the
+    # stream ends, and flush has to release it. Half a marker cannot complete.
+    out["an answer that ends mid-marker"] = (
+        PROSE * 3 + marks[0][: max(1, len(marks[0]) // 2)]
+    )
+
     if dialect.output_open_marker:
         out["reasoning the model opens itself"] = (
             dialect.output_open_marker + PROSE * 3 + end + "The answer is 42."
@@ -217,20 +231,29 @@ def _pairs():
 
 PAIRS = list(_pairs())
 
+
 # Shapes with no marker the pipeline is entitled to honour. Withholding in
 # these is never correct, which is what makes them the bounded-withhold
 # corpus; the reasoning-bearing shapes hold until their end marker by design.
-NOTHING_TO_HONOUR = (
-    "trigger chars in ordinary prose",
-    "a marker quoted inside the answer",
-)
+def carries_no_promise(shape_name: str) -> bool:
+    """Shapes with no marker the pipeline is entitled to act on.
+
+    Withholding or discarding anything in these is never correct, which is
+    what makes them the bounded-withhold and conservation corpus. Matched by
+    prefix rather than listed, because the per-marker shapes are generated
+    -- a named list silently excluded them and left Kimi-K3's truncation
+    uncovered.
+    """
+    return shape_name.startswith(
+        ("trigger chars in ordinary prose", "a marker", "marker ")
+    )
 
 
 def _hold_pairs():
     for dialect in DIALECTS:
         for parser in ALL_PARSERS:
             for shape_name, text in shapes(dialect, parser).items():
-                if shape_name not in NOTHING_TO_HONOUR:
+                if not carries_no_promise(shape_name):
                     continue
                 yield pytest.param(
                     dialect,
@@ -242,6 +265,20 @@ def _hold_pairs():
 
 
 HOLD_PAIRS = list(_hold_pairs())
+
+
+def _partial_pairs():
+    for dialect in DIALECTS:
+        for parser in ALL_PARSERS:
+            yield pytest.param(
+                dialect,
+                parser,
+                shapes(dialect, parser)["an answer that ends mid-marker"],
+                id=f"{dialect.think_end_marker.strip('<>/|')}-{parser.NAME}",
+            )
+
+
+PARTIAL_PAIRS = list(_partial_pairs())
 
 
 class TestEveryFormatIsCovered:
@@ -308,9 +345,26 @@ class TestEverySeedingSiteIsSeeded:
                 )
                 if name not in self.SEEDED:
                     continue
-                if not any(kw.arg == "starts_thinking" for kw in node.keywords):
-                    rel = path.relative_to(self.ROOT.parents[1])
-                    found.append(f"{rel}:{node.lineno} {name}(...)")
+                seed = next(
+                    (kw.value for kw in node.keywords if kw.arg == "starts_thinking"),
+                    None,
+                )
+                # Positional counts: `separate_reasoning(text, seeded)` is a
+                # correct call and an earlier version of this scan rejected it.
+                if seed is None and name == "separate_reasoning":
+                    seed = node.args[1] if len(node.args) > 1 else None
+                rel = path.relative_to(self.ROOT.parents[1])
+                if seed is None:
+                    found.append(f"{rel}:{node.lineno} {name}(...) — not answered")
+                elif isinstance(seed, ast.Constant):
+                    # A literal is not an answer. `starts_thinking=False`
+                    # spells the keyword and reintroduces the bug: the earlier
+                    # scan accepted it, and a test in this very change was
+                    # "repaired" by hardcoding the other literal.
+                    found.append(
+                        f"{rel}:{node.lineno} {name}(starts_thinking={seed.value!r})"
+                        " — a literal, not the prompt"
+                    )
         return found
 
     def test_no_entry_point_builds_one_without_the_seed(self):
@@ -319,14 +373,30 @@ class TestEverySeedingSiteIsSeeded:
             "\n  ".join(unseeded)
         )
 
-    def test_the_scan_can_actually_fail(self):
-        """A source scan that matches nothing would pass forever."""
-        tree = ast.parse("ReasoningFilter()\nseparate_reasoning(x)\n")
-        calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
-        assert len(calls) == 2
-        assert all(
-            not any(kw.arg == "starts_thinking" for kw in c.keywords) for c in calls
-        )
+    @pytest.mark.parametrize(
+        "source, ok",
+        [
+            ("ReasoningFilter(starts_thinking=prompt_starts_in_reasoning(p))", True),
+            ("separate_reasoning(t, starts_thinking=seeded or flag)", True),
+            ("separate_reasoning(t, seeded)", True),
+            ("ReasoningFilter()", False),
+            ("ReasoningFilter(starts_thinking=False)", False),
+            ("separate_reasoning(t)", False),
+        ],
+    )
+    def test_the_scan_accepts_answers_and_rejects_literals(self, source, ok, tmp_path):
+        """The scan's own two-sided check.
+
+        Without it the rule drifts: the first version spelled "is the keyword
+        present", which passes `starts_thinking=False` -- exactly the bug --
+        and fails a correct positional call.
+        """
+        f = tmp_path / "atom" / "entrypoints" / "probe.py"
+        f.parent.mkdir(parents=True)
+        f.write_text(source + "\n")
+        scan = TestEverySeedingSiteIsSeeded()
+        scan.ROOT = f.parent
+        assert (scan._unseeded() == []) is ok, scan._unseeded()
 
 
 class TestChunkInvariance:
@@ -337,7 +407,7 @@ class TestChunkInvariance:
         self, dialect, parser, text, split_may_move
     ):
         by_split = {
-            label: drive(text, chunks)
+            label: drive(text, chunks, parser)
             for label, chunks in split_every_way(text).items()
         }
         variants: dict = {}
@@ -360,6 +430,68 @@ class TestChunkInvariance:
                 for k, labels in variants.items()
             )
             pytest.fail(f"{len(variants)} different results for one text:\n{report}")
+
+
+class TestConservation:
+    """Text handed to the pipeline comes back, or is part of a tool call.
+
+    Chunk-invariance cannot see deletion -- text dropped the same way under
+    every chunking is perfectly invariant -- and bounded withhold cannot
+    either, because the bytes before the loss are released on time. A quoted
+    `<tool_call>` in an ordinary answer opened a region that never closed,
+    and everything after it was discarded at flush: no event, no error,
+    `finish_reason` still `stop`. Fifty of eighty-two characters, silently.
+    """
+
+    @pytest.mark.parametrize("dialect, parser, text", HOLD_PAIRS)
+    def test_an_answer_that_calls_nothing_keeps_what_follows_the_marker(
+        self, dialect, parser, text
+    ):
+        """Judged on the tail, not byte-for-byte.
+
+        A format may legitimately consume its own markers -- Kimi-K3 strips
+        channel framing from plain answers by design -- so equality would fail
+        on correct behaviour. What no format may do is swallow the prose that
+        came after one.
+        """
+        marker = next((m for m in parser.START_MARKERS if m in text), None)
+        if marker is None:
+            pytest.skip("this shape carries no marker for this format")
+        # Stripped: a format may trim the edges of what it hands back, and
+        # whether it should is a separate question from whether it kept the
+        # prose at all. This property is only about the prose.
+        tail = text.split(marker, 1)[1].strip()
+        for label, chunks in split_every_way(text).items():
+            seen = drive(text, chunks, parser)
+            if seen.events:
+                continue  # a real tool call consumes its own bytes
+            got = seen.reasoning + seen.content
+            assert tail in got, (
+                f"{label}: everything after {marker!r} was dropped\n"
+                f"  missing: {tail[:60]!r}\n"
+                f"  delivered {len(got)} of {len(text)} characters"
+            )
+
+
+class TestNothingIsHeldPastTheEnd:
+    """Whatever the read-ahead still holds is released at end of stream.
+
+    A partial marker at the end of a response never completes, so it is text.
+    Losing it is invisible to every other property here: the stream is
+    chunk-invariant, the withhold stayed bounded, and the loss is a handful of
+    characters at the very end. `KimiParser.flush` dropped six of them.
+    """
+
+    @pytest.mark.parametrize("dialect, parser, text", PARTIAL_PAIRS)
+    def test_a_dangling_partial_marker_still_arrives(self, dialect, parser, text):
+        for label, chunks in split_every_way(text).items():
+            seen = drive(text, chunks, parser)
+            got = seen.reasoning + seen.content
+            assert got.strip().endswith(text.strip()[-4:]), (
+                f"{label}: the held tail was never released\n"
+                f"  expected to end with {text.strip()[-12:]!r}\n"
+                f"  got {got.strip()[-12:]!r}"
+            )
 
 
 class TestBoundedWithhold:

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -41,7 +41,9 @@ import pytest
 
 from atom.entrypoints.openai.reasoning import ReasoningFilter
 from atom.entrypoints.openai.reasoning_dialects import DIALECTS
+from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
+from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
 from atom.entrypoints.openai.tool_parser.stream import ToolCallStreamParser
 
@@ -642,3 +644,274 @@ class TestARealCallSurvivesTheStream:
         text = "Let me look. " + REAL_CALLS[parser.NAME]
         seen = drive(text, split_every_way(text)["fixed-3"], parser)
         assert "Let me look." in seen.content
+
+
+# Markers a format declares so the read-ahead will not split them, but which
+# do not hand the stream over: channel framing that wraps every answer. Only
+# Kimi-K3 has any; a format absent here declares none, which is the default.
+FRAMING_NOT_A_REGION: dict[str, set[str]] = {
+    "kimi_k3": {
+        "<|open|>response<|sep|>",
+        "<|close|>response<|sep|>",
+        "<|end_of_msg|>",
+    },
+}
+
+
+class TestAPlainAnswerDoesNotWaitForTheEnd:
+    """A format's own framing is not a reason to stop streaming.
+
+    `START_MARKERS` answers "which literals must not be split"; `opens_region`
+    answers "which of them hand the rest of the stream to this format". For
+    most formats those are the same set. Kimi-K3 is where they are not: three
+    of its five wrap every answer it gives, including `<|open|>response<|sep|>`
+    at the very start, so reading any marker as a handover meant a K3 response
+    delivered nothing until EOS -- 324 of 324 characters in one frame.
+
+    Chunk-invariance cannot see this and neither can the agreement property:
+    delivering everything at flush is perfectly invariant and the text is
+    identical. What separates them is *when*.
+    """
+
+    @staticmethod
+    def _split_by_arrival(parser, text) -> tuple[int, int]:
+        stream = ToolCallStreamParser(parser_cls=parser)
+        during = 0
+        for i in range(0, len(text), 4):
+            during += sum(
+                len(d) for k, d in stream.process(text[i : i + 4]) if k == "content"
+            )
+        at_flush = sum(len(d) for k, d in stream.flush() if k == "content")
+        return during, at_flush
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_partition_is_the_declared_one(self, parser):
+        """Which markers open a region, stated here and not read off the code.
+
+        Asking `opens_region` for the shape *and* the expectation makes the
+        test agree with whatever the code says: flipping every answer to True
+        emptied the framing list below and the behavioural test skipped itself
+        clean through the mutation.
+        """
+        declared = {m for m in parser.START_MARKERS if not parser.opens_region(m)}
+        assert declared == FRAMING_NOT_A_REGION.get(parser.NAME, set())
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_framing_that_opens_no_region_does_not_stop_delivery(self, parser):
+        framing = sorted(FRAMING_NOT_A_REGION.get(parser.NAME, ()))
+        if not framing:
+            pytest.skip("every marker this format declares opens a region")
+        text = framing[0] + PROSE * 6 + framing[-1]
+        during, at_flush = self._split_by_arrival(parser, text)
+        assert during > at_flush, (
+            f"{parser.NAME} held {at_flush} characters to EOS and streamed "
+            f"{during}; its framing is being read as a tool region"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_an_answer_with_no_marker_at_all_streams_whole(self, parser):
+        """The floor: nothing to hold means nothing held."""
+        during, at_flush = self._split_by_arrival(parser, PROSE * 6)
+        assert at_flush == 0 and during == len(PROSE * 6)
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_region_marker_still_hands_over(self, parser):
+        """The other half: what does open a region must still be buffered,
+        or a half-written call would be emitted as text."""
+        opener = next(m for m in parser.START_MARKERS if parser.opens_region(m))
+        during, _ = self._split_by_arrival(parser, "Before. " + opener + "junk")
+        assert during == len("Before. "), f"{parser.NAME} leaked past its opener"
+
+
+DECLARED_TOOLS = [
+    {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
+]
+
+
+class TestTheNameArrivesBeforeTheArguments:
+    """Which tool is being called, sent as soon as the region reveals it.
+
+    A region is buffered until it closes, so the client learned the tool only
+    after the whole payload: measured on a 20 KB file write, 5030 of 5040
+    tokens of nothing. Every format carries the name in its opener or close
+    behind it, so it can go out first.
+
+    Arguments stay buffered. SGLang streams those too, in JSON fragments, and
+    a stream cut short then leaves the client holding an unterminated object.
+    The name is the part worth the risk and the only part taken here.
+
+    Judged on *when* each event lands and not on where it sits in the event
+    list: the payload between the name and the arguments produces no events at
+    all, so the two are adjacent either way. An earlier version of these
+    checked adjacency and passed on every arm.
+    """
+
+    @staticmethod
+    def _drive(parser, text, tools):
+        """(chunks, chunk the name landed on, chunk the arguments landed on,
+        every event kind in order)."""
+        stream = ToolCallStreamParser(parser_cls=parser)
+        stream.tools = tools
+        events, at = [], {}
+        chunks = [text[i : i + 4] for i in range(0, len(text), 4)]
+        for n, chunk in enumerate(chunks, 1):
+            for kind, _ in stream.process(chunk):
+                events.append(kind)
+                at.setdefault(kind, n)
+        for kind, _ in stream.flush():
+            events.append(kind)
+            at.setdefault(kind, len(chunks))
+        return len(chunks), at.get("tool_call_start"), at.get("tool_call_args"), events
+
+    @staticmethod
+    def _big_call(parser) -> str:
+        """The registry's own call for this format, with a large payload."""
+        return "Let me look. " + REAL_CALLS[parser.NAME].replace(
+            "Paris", "Paris" + "x" * 800
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_declared_tool_is_named_early(self, parser):
+        total, at, args_at, _ = self._drive(
+            parser, self._big_call(parser), DECLARED_TOOLS
+        )
+        assert at is not None and args_at is not None
+        assert at < args_at, f"{parser.NAME} sent the name with its arguments"
+        assert at < total // 4, (
+            f"{parser.NAME} announced at chunk {at} of {total}; the name is in "
+            "the opener and should not wait for the payload"
+        )
+
+    @pytest.mark.parametrize(
+        "tools, label",
+        [
+            ([{"type": "function", "function": {"name": "something_else"}}], "other"),
+            (None, "none"),
+            ([], "empty"),
+        ],
+    )
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_an_undeclared_tool_is_not_announced(self, parser, tools, label):
+        """The check that makes an early name safe: it cannot be retracted,
+        and prose quoting a tool tag opens a region too."""
+        _, at, args_at, _ = self._drive(parser, self._big_call(parser), tools)
+        assert at == args_at, (
+            f"{parser.NAME} sent the name of an undeclared tool ({label}) at "
+            f"chunk {at}, ahead of its arguments at {args_at}"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_declaring_it_is_what_moves_the_name_earlier(self, parser):
+        """Same input, one variable: the arms differ only in `tools`."""
+        text = self._big_call(parser)
+        _, early, _, _ = self._drive(parser, text, DECLARED_TOOLS)
+        _, late, _, _ = self._drive(parser, text, None)
+        assert early < late, f"{parser.NAME}: declared {early}, undeclared {late}"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_client_still_sees_exactly_one_call(self, parser):
+        """The announcement replaces the parse's own start, never doubles it.
+
+        Kimi builds its start event inline rather than through `_emit_call`,
+        so the deduplication had to be shared rather than written twice -- it
+        was not, and the name went out twice for one call.
+        """
+        for tools in (DECLARED_TOOLS, None):
+            _, _, _, events = self._drive(parser, self._big_call(parser), tools)
+            assert events.count("tool_call_start") == 1, events
+            assert events.count("tool_call_args") == 1, events
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_announcing_changes_nothing_but_the_timing(self, parser):
+        """Same events, same order, whether or not the name went early."""
+        text = self._big_call(parser)
+        _, _, _, announced = self._drive(parser, text, DECLARED_TOOLS)
+        _, _, _, plain = self._drive(parser, text, None)
+        assert announced == plain
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_an_answer_that_only_quotes_a_marker_announces_nothing(self, parser):
+        """No name to peek, so nothing is promised and the text still lands."""
+        opener = next(m for m in parser.START_MARKERS if parser.opens_region(m))
+        text = f"The model writes {opener} to open one. " + PROSE * 3
+        _, _, _, events = self._drive(parser, text, DECLARED_TOOLS)
+        assert "tool_call_start" not in events
+
+
+class TestAPromiseCannotBeTakenBack:
+    """The cost of announcing early, stated rather than discovered.
+
+    A name goes out before the call is known to close, so a response cut off
+    at `max_tokens` mid-call has sent a name and may never send arguments.
+    Nothing can retract it. What can be arranged is that it is not mistaken
+    for a call the client should run: `completes_a_tool_call` keys on the
+    arguments, so `stop_reason` / `finish_reason` stay ordinary and the text
+    is still delivered.
+    """
+
+    @staticmethod
+    def _drive(parser, text):
+        stream = ToolCallStreamParser(parser_cls=parser)
+        stream.tools = DECLARED_TOOLS
+        events = []
+        for i in range(0, len(text), 4):
+            events += stream.process(text[i : i + 4])
+        return events + stream.flush()
+
+    @staticmethod
+    def _drive_without_tools(parser, text):
+        stream = ToolCallStreamParser(parser_cls=parser)
+        events = []
+        for i in range(0, len(text), 4):
+            events += stream.process(text[i : i + 4])
+        return events + stream.flush()
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_call_cut_off_before_it_parses_is_not_a_usable_call(self, parser):
+        """Truncated mid-call, against the same input with nothing declared.
+
+        Compared arm to arm rather than asserted outright: GLM's unterminated
+        branch salvages `<tool_call>get_weather` into a call with empty
+        arguments all by itself, which predates announcing and is that
+        format's own business. What must hold is that announcing adds no call
+        the parse did not already find.
+        """
+        head = REAL_CALLS[parser.NAME].split("get_weather")[0] + "get_weather"
+        text = "Sure. " + head
+        kinds = [k for k, _ in self._drive(parser, text)]
+        baseline = [k for k, _ in self._drive_without_tools(parser, text)]
+        if "tool_call_args" in baseline:
+            pytest.skip("this format salvages a call from this much on its own")
+        assert (
+            "tool_call_args" not in kinds
+        ), "arguments were invented for a call that never parsed"
+        assert not completes_a_tool_call(
+            self._drive(parser, text)
+        ), "a name with no arguments must not report as a usable tool call"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_answer_still_arrives_when_the_call_does_not(self, parser):
+        head = REAL_CALLS[parser.NAME].split("get_weather")[0] + "get_weather"
+        events = self._drive(parser, "Sure. " + head)
+        delivered = "".join(d for k, d in events if k == "content")
+        assert "Sure." in delivered, "the text before the call was dropped"
+
+    def test_peeking_a_different_name_than_the_parse_is_raised(self):
+        """`peek_name` and `parse` disagreeing about the same bytes is a bug
+        in that format, and the name is already on the wire. Loud, not
+        smoothed over -- there is nothing to smooth it into."""
+
+        class Liar(QwenXmlParser):
+            @classmethod
+            def peek_name(cls, region):
+                return "get_weather" if "<function=" in region else None
+
+            @classmethod
+            def parse(cls, text, tools):
+                content, calls = QwenXmlParser.parse(text, tools)
+                for c in calls:
+                    c.function["name"] = "something_else"
+                return content, calls
+
+        with pytest.raises(AssertionError, match="announced"):
+            self._drive(Liar, "Sure. " + REAL_CALLS["qwen"])

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -48,10 +48,10 @@ import pytest
 from atom.entrypoints.openai.reasoning import ReasoningFilter, separate_reasoning
 from atom.entrypoints.openai.reasoning_dialects import DIALECTS
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
+from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_tool_calls
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
-from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_tool_calls
 from atom.entrypoints.openai.tool_parser.stream import (
     _PEEK_WINDOW,
     ToolCallStreamParser,
@@ -1055,16 +1055,29 @@ def early_name(parser, region: str, tools) -> str | None:
     return calls[0].function["name"] if calls else None
 
 
-# A format that cannot see a call still arriving cannot name one before its
-# arguments: a Kimi entry is invisible until `<|tool_call_end|>` and a K3 call
-# until `<|close|>call`. Derived from the declaration the engine itself reads,
-# so the table and the behaviour cannot drift -- and pinned by
-# `test_the_declaration_matches_the_timing`, which measures rather than
-# re-derives.
+def sees_a_call_in_progress(parser) -> bool:
+    """Can this format's `parse_region` read a call whose arguments are still
+    arriving?
+
+    Measured, not declared. There used to be a class attribute saying this;
+    it outlived its only reader and the docs built on it went false without
+    anything failing. The property is directly observable, so observe it:
+    take the format's own call, make its argument long, and cut in the middle
+    of the value.
+    """
+    long_value = "x" * 4000
+    call = REAL_CALLS[parser.NAME].replace("Paris", long_value)
+    partial = call[: call.index(long_value) + 2000]
+    return bool(parser.parse_region(partial, DECLARED_TOOLS, at_end=False).calls)
+
+
+# The two token formats: a Kimi entry is invisible until `<|tool_call_end|>`
+# and a K3 call until `<|close|>call`, so neither can name a call whose
+# arguments are still arriving.
 NO_EARLY_NAME = {
     p.NAME: "a call of this format is invisible until its own end token"
     for p in ALL_PARSERS
-    if not p.RECOGNISES_A_CALL_IN_PROGRESS
+    if not sees_a_call_in_progress(p)
 }
 
 
@@ -1111,24 +1124,41 @@ class TestTheNameArrivesBeforeTheArguments:
         )
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
-    def test_the_declaration_matches_the_timing(self, parser):
-        """`RECOGNISES_A_CALL_IN_PROGRESS` is read by the engine for two
-        different decisions -- whether a name can go out early, and whether a
-        region that is producing nothing can be given up on. Declaring it
-        wrong the second way delivers a real call as prose, so it is measured
-        here rather than trusted: drive a call with an 800-byte payload and
-        see whether the name actually arrives before the arguments.
+    def test_reading_a_call_in_progress_is_what_moves_the_name(self, parser):
+        """Two independently observable things, asserted to agree.
+
+        One is whether `parse_region` can read a call whose argument is still
+        arriving; the other is whether, on a real stream of a call with an
+        800-byte payload, the name lands before the arguments. Neither is
+        derived from the other and neither is a declaration -- the attribute
+        that used to stand in for both outlived its reader, and the docs built
+        on it said Kimi-K3 names nothing early when it does so for any call
+        that fits inside the peek window.
+
+        800 bytes because that is the shape announcing early exists for. A
+        call short enough to fit in `Region.head` is named early by every
+        format, which is a different claim.
         """
         total, at, args_at, _ = self._drive(
             parser, self._big_call(parser), DECLARED_TOOLS
         )
         assert at is not None and args_at is not None
         early = at < args_at
-        assert early is parser.RECOGNISES_A_CALL_IN_PROGRESS, (
-            f"{parser.NAME} declares RECOGNISES_A_CALL_IN_PROGRESS="
-            f"{parser.RECOGNISES_A_CALL_IN_PROGRESS} but the name landed on "
-            f"chunk {at} of {total} and the arguments on {args_at}"
+        assert early is sees_a_call_in_progress(parser), (
+            f"{parser.NAME}: parse_region {'can' if not early else 'cannot'} read "
+            f"a call in progress, but the name landed on chunk {at} of {total} "
+            f"and the arguments on {args_at}"
         )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_call_that_fits_the_window_is_named_early_by_every_format(self, parser):
+        """Including the two that cannot read one in progress -- for a short
+        call the whole thing is inside `Region.head`, so `parse_region` sees a
+        finished call there. The docs claimed otherwise for K3."""
+        text = "Sure. " + REAL_CALLS[parser.NAME]
+        assert len(REAL_CALLS[parser.NAME]) < _PEEK_WINDOW, "premise"
+        _, at, args_at, _ = self._drive(parser, text, DECLARED_TOOLS)
+        assert at is not None and args_at is not None and at <= args_at
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_a_declared_tool_is_named_early(self, parser):
@@ -1810,18 +1840,17 @@ class TestARegionIsAccountedForByteByByte:
             assert streamed == content, f"{parser.NAME} at chunk {size}: {streamed!r}"
 
 
-class TestTheDeclarationAboutACallInProgressIsMeasured:
-    """`RECOGNISES_A_CALL_IN_PROGRESS` says a format's `parse_region` can see a
-    call that has not finished arriving. The engine reads it to decide whether
-    a name may go out early.
+class TestNoSizeAtWhichACallStopsBeingOne:
+    """A "give up on a region producing nothing after N bytes" probe was added
+    here and reverted.
 
-    It was also read for a second decision -- whether a region producing
-    nothing could be given up on and released as prose -- and that is why the
-    rows below about long calls exist. The give-up is gone: it rests on
-    acceptance being monotone in how many bytes have arrived, and that is
-    false for three of the six formats, so real calls over the probe size were
-    delivered as raw markup with `finish_reason: stop` while `stream=false`
-    returned the call. These rows are what catches it coming back.
+    It rests on acceptance being monotone in how many bytes have arrived, and
+    that is false for three of the six formats -- MiniMax gates its
+    in-progress test on the first tag being in the declared schema, and DSML's
+    wrapper-less and direct-JSON branches match no prefix at all -- so real
+    calls over the probe size were delivered as raw markup with
+    `finish_reason: stop` while `stream=false` returned the call. It was also
+    quadratic. These rows are what catches it coming back.
     """
 
     @staticmethod
@@ -1836,15 +1865,6 @@ class TestTheDeclarationAboutACallInProgressIsMeasured:
         long_value = "x" * 4000
         call = REAL_CALLS[parser.NAME].replace("Paris", long_value)
         return call[: call.index(long_value) + 2000]
-
-    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
-    def test_the_declaration_matches_the_parse(self, parser):
-        partial = self._cut_inside_an_argument(parser)
-        seen = parser.parse_region(partial, DECLARED_TOOLS, at_end=False).calls
-        assert bool(seen) is parser.RECOGNISES_A_CALL_IN_PROGRESS, (
-            f"{parser.NAME} declares {parser.RECOGNISES_A_CALL_IN_PROGRESS} but a "
-            f"call cut off mid-argument parsed to {len(seen)} call(s)"
-        )
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_no_size_at_which_a_call_stops_being_one(self, parser):

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -41,6 +41,7 @@ import random
 import re
 import sys
 import time
+from typing import ClassVar
 
 import pytest
 
@@ -50,8 +51,11 @@ from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
-from atom.entrypoints.openai.tool_parser.stream import ToolCallStreamParser
-from atom.entrypoints.openai.tool_parser.tool_parser import _PEEK_WINDOW
+from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_tool_calls
+from atom.entrypoints.openai.tool_parser.stream import (
+    _PEEK_WINDOW,
+    ToolCallStreamParser,
+)
 
 # Kimi is the terminal fallback and so is not in the detect order, but it is a
 # registered format with markers of its own.
@@ -643,7 +647,7 @@ class TestNonStreamingAgreesWithStreaming:
 
     @pytest.mark.parametrize("dialect, parser, text", HOLD_PAIRS)
     def test_the_two_paths_deliver_the_same_text(self, dialect, parser, text):
-        non_streaming, calls = parser.parse(text, None)
+        non_streaming, calls = parse_tool_calls(text, None, parser)
         if calls:
             pytest.skip("this shape parsed a call; the rule binds the no-call case")
         streamed = drive(text, split_every_way(text)["fixed-3"], parser)
@@ -663,7 +667,7 @@ class TestNonStreamingAgreesWithStreaming:
         -- in particular whitespace, which is what every format's trailing
         `.strip()` took -- has to survive.
         """
-        content, calls = parser.parse(text, None)
+        content, calls = parse_tool_calls(text, None, parser)
         if calls:
             pytest.skip("this shape parsed a call; the rule binds the no-call case")
         rebuilt = content
@@ -763,7 +767,7 @@ class TestARealCallSurvivesTheStream:
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_the_non_streaming_path_reads_the_call(self, parser):
         """The fixture is a real call in this format, and this says so."""
-        _, calls = parser.parse(REAL_CALLS[parser.NAME], DECLARED_TOOLS)
+        _, calls = parse_tool_calls(REAL_CALLS[parser.NAME], DECLARED_TOOLS, parser)
         assert [c.function["name"] for c in calls] == ["get_weather"]
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
@@ -774,7 +778,7 @@ class TestARealCallSurvivesTheStream:
         parameter syntax parsed to `get_weather({})` and passed everything
         here -- minimax's was, for as long as the table existed.
         """
-        _, calls = parser.parse(REAL_CALLS[parser.NAME], DECLARED_TOOLS)
+        _, calls = parse_tool_calls(REAL_CALLS[parser.NAME], DECLARED_TOOLS, parser)
         assert json.loads(calls[0].function["arguments"]) == {"city": "Paris"}
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
@@ -888,8 +892,8 @@ class TestAFormatDeclaresEveryTokenItStrips:
         bad = []
         for a, b in itertools.product(tokens, repeat=2):
             text = f"A {a} B {b} C"
-            non = parser.parse(text, DECLARED_TOOLS)[0]
-            if parser.parse(text, DECLARED_TOOLS)[1]:
+            non = parse_tool_calls(text, DECLARED_TOOLS, parser)[0]
+            if parse_tool_calls(text, DECLARED_TOOLS, parser)[1]:
                 continue  # a real call; the no-call rule is what binds here
             for size in (1, 3, 999):
                 got = "".join(
@@ -1039,11 +1043,28 @@ DECLARED_TOOLS = [
 ]
 
 
-# Formats that deliberately do not announce a name early, and why. Stated
-# here rather than read off `peek_name`, so removing an override is a failing
-# test and not a silently skipped one.
+def early_name(parser, region: str, tools) -> str | None:
+    """The name the engine would announce for `region`.
+
+    There is no separate peek to ask any more, and that is the point: the
+    announcement is the first call of `parse_region` over the bytes so far,
+    with `at_end=False`. The declared-name filter lives in the engine, so a
+    test that wants it drives the engine instead.
+    """
+    calls = parser.parse_region(region, tools, at_end=False).calls
+    return calls[0].function["name"] if calls else None
+
+
+# A format that cannot see a call still arriving cannot name one before its
+# arguments: a Kimi entry is invisible until `<|tool_call_end|>` and a K3 call
+# until `<|close|>call`. Derived from the declaration the engine itself reads,
+# so the table and the behaviour cannot drift -- and pinned by
+# `test_the_declaration_matches_the_timing`, which measures rather than
+# re-derives.
 NO_EARLY_NAME = {
-    "kimi": "index and id come off the wire, after the peek would have to fire",
+    p.NAME: "a call of this format is invisible until its own end token"
+    for p in ALL_PARSERS
+    if not p.RECOGNISES_A_CALL_IN_PROGRESS
 }
 
 
@@ -1090,12 +1111,23 @@ class TestTheNameArrivesBeforeTheArguments:
         )
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
-    def test_the_opt_outs_are_the_declared_ones(self, parser):
-        """Whether a format announces at all, pinned rather than inferred."""
-        peeks = parser.peek_name(REAL_CALLS[parser.NAME], DECLARED_TOOLS) is not None
-        assert peeks is (parser.NAME not in NO_EARLY_NAME), (
-            f"{parser.NAME}: peek_name says {peeks}, NO_EARLY_NAME says "
-            f"{parser.NAME in NO_EARLY_NAME}"
+    def test_the_declaration_matches_the_timing(self, parser):
+        """`RECOGNISES_A_CALL_IN_PROGRESS` is read by the engine for two
+        different decisions -- whether a name can go out early, and whether a
+        region that is producing nothing can be given up on. Declaring it
+        wrong the second way delivers a real call as prose, so it is measured
+        here rather than trusted: drive a call with an 800-byte payload and
+        see whether the name actually arrives before the arguments.
+        """
+        total, at, args_at, _ = self._drive(
+            parser, self._big_call(parser), DECLARED_TOOLS
+        )
+        assert at is not None and args_at is not None
+        early = at < args_at
+        assert early is parser.RECOGNISES_A_CALL_IN_PROGRESS, (
+            f"{parser.NAME} declares RECOGNISES_A_CALL_IN_PROGRESS="
+            f"{parser.RECOGNISES_A_CALL_IN_PROGRESS} but the name landed on "
+            f"chunk {at} of {total} and the arguments on {args_at}"
         )
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
@@ -1175,6 +1207,7 @@ class TestTheNameArrivesBeforeTheArguments:
 # re-peeking instead, the corpus moved whenever `peek_name` did and the
 # property below went quietly vacuous.
 CALL_OPENERS: dict[str, str] = {
+    "kimi": ("<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0"),
     "glm": "<tool_call>get_weather",
     "qwen": "<tool_call><function=get_weather>",
     "kimi_k3": '<|open|>tools<|sep|><|open|>call tool="get_weather"<|sep|>',
@@ -1186,9 +1219,12 @@ CALL_OPENERS: dict[str, str] = {
 # the name go out. Without a positive row the property below is satisfied by
 # a peek that never announces anything.
 CALL_CONTINUATIONS: dict[str, str] = {
+    "kimi": '<|tool_call_argument_begin|>{"city":"Paris"}<|tool_call_end|>',
     "glm": "<arg_key>city</arg_key>",
     "qwen": "<parameter=city>Paris</parameter>",
-    "kimi_k3": '<|open|>argument key="city"<|sep|>Paris',
+    "kimi_k3": (
+        '<|open|>argument key="city"<|sep|>Paris<|close|>argument<|close|>call'
+    ),
     "dsml": f'<{_D}parameter name="city">Paris',
     "minimax": f"{_NS}<city>Paris",
 }
@@ -1199,6 +1235,7 @@ CALL_CONTINUATIONS: dict[str, str] = {
 # very block the name opened and `<tool_call>get_weather</tool_call>` is a
 # real zero-argument call.
 FOREIGN_CLOSERS: dict[str, str] = {
+    "kimi": "</tool_call>",
     "glm": "</function>",
     "qwen": "</tool_call>",
     "kimi_k3": "<|close|>response<|sep|>",
@@ -1231,7 +1268,12 @@ PEEK_TOOLS = [
 
 
 class TestThePeekNeverNamesWhatTheParseCallsProse:
-    """`peek_name` and `parse` must agree about what a call looks like.
+    """The early name and the parse must agree about what a call looks like.
+
+    Every format is held to this, including the two whose name cannot go out
+    before their arguments: "does not name prose" is a different claim from
+    "names a real call early", and only the second is format-specific. Gating
+    both on the same table skipped ten cases that pass.
 
     A name cannot be retracted. If the peek names a region and the parse then
     reads that same region as prose, the client has been told about a call
@@ -1257,8 +1299,6 @@ class TestThePeekNeverNamesWhatTheParseCallsProse:
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_the_opener_matches_this_format(self, parser):
         """Otherwise the regions below are not this format's syntax at all."""
-        if parser.NAME in NO_EARLY_NAME:
-            pytest.skip(NO_EARLY_NAME[parser.NAME])
         opener = CALL_OPENERS[parser.NAME]
         assert REAL_CALLS[parser.NAME].startswith(
             opener
@@ -1267,15 +1307,11 @@ class TestThePeekNeverNamesWhatTheParseCallsProse:
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     @pytest.mark.parametrize("tail, why", PROSE_TAILS, ids=lambda x: x)
     def test_prose_after_the_opener_names_nothing(self, parser, tail, why):
-        if parser.NAME in NO_EARLY_NAME:
-            pytest.skip(NO_EARLY_NAME[parser.NAME])
         self._check(parser, CALL_OPENERS[parser.NAME] + tail, why, expected=None)
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_a_closer_that_is_not_this_format_s_names_nothing(self, parser):
         """The shape Qwen got wrong: a closer that ends some *other* block."""
-        if parser.NAME in NO_EARLY_NAME:
-            pytest.skip(NO_EARLY_NAME[parser.NAME])
         region = (
             CALL_OPENERS[parser.NAME] + FOREIGN_CLOSERS[parser.NAME] + ", like that."
         )
@@ -1283,8 +1319,6 @@ class TestThePeekNeverNamesWhatTheParseCallsProse:
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_this_format_s_own_next_token_does_name_it(self, parser):
-        if parser.NAME in NO_EARLY_NAME:
-            pytest.skip(NO_EARLY_NAME[parser.NAME])
         region = CALL_OPENERS[parser.NAME] + CALL_CONTINUATIONS[parser.NAME]
         self._check(parser, region, "this format's own next token", "get_weather")
 
@@ -1298,7 +1332,7 @@ class TestThePeekNeverNamesWhatTheParseCallsProse:
         keyed on that passed while K3 announced a tool for a sentence merely
         quoting a call opener.
         """
-        got = parser.peek_name(region, PEEK_TOOLS)
+        got = early_name(parser, region, PEEK_TOOLS)
         assert got == expected, (
             f"{parser.NAME} with {why} after its opener: peek said {got!r}, "
             f"expected {expected!r} -- region {region!r}"
@@ -1318,11 +1352,9 @@ class TestThePeekNeverNamesWhatTheParseCallsProse:
         salvages a truncated call, so the client was left holding a name for
         a call that produced no arguments and no event.
         """
-        if parser.NAME in NO_EARLY_NAME:
-            pytest.skip(NO_EARLY_NAME[parser.NAME])
         opener = CALL_OPENERS[parser.NAME]
         assert (
-            parser.peek_name(opener, DECLARED_TOOLS) is None
+            early_name(parser, opener, DECLARED_TOOLS) is None
         ), f"{parser.NAME} named a tool off its opener alone: {opener!r}"
 
     def test_a_looser_peek_is_caught(self):
@@ -1332,9 +1364,16 @@ class TestThePeekNeverNamesWhatTheParseCallsProse:
             NAME = "loose"
 
             @classmethod
-            def peek_name(cls, region, tools=None):
+            def parse_region(cls, region, tools, *, at_end):
                 m = re.search(r"<function=([^>\n]+)>", region)
-                return m.group(1) if m else None
+                if m is None:
+                    return RegionParse()
+                call = ToolCall(
+                    id="loose",
+                    type="function",
+                    function={"name": m.group(1), "arguments": "{}"},
+                )
+                return RegionParse((call,), m.start(), len(region))
 
         with pytest.raises(AssertionError, match="peek said"):
             self._check(Loose, CALL_OPENERS["qwen"] + " and then...", "English", None)
@@ -1342,10 +1381,8 @@ class TestThePeekNeverNamesWhatTheParseCallsProse:
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_a_real_call_is_still_named_early(self, parser):
         """And the rule above is not satisfied by never announcing anything."""
-        if parser.NAME in NO_EARLY_NAME:
-            pytest.skip(NO_EARLY_NAME[parser.NAME])
         assert (
-            parser.peek_name(REAL_CALLS[parser.NAME], DECLARED_TOOLS) == "get_weather"
+            early_name(parser, REAL_CALLS[parser.NAME], DECLARED_TOOLS) == "get_weather"
         )
 
 
@@ -1409,15 +1446,12 @@ class TestAPromiseCannotBeTakenBack:
 
         class Liar(QwenXmlParser):
             @classmethod
-            def peek_name(cls, region, tools=None):
-                return "get_weather" if "<function=" in region else None
-
-            @classmethod
-            def parse(cls, text, tools):
-                content, calls = QwenXmlParser.parse(text, tools)
-                for c in calls:
-                    c.function["name"] = "something_else"
-                return content, calls
+            def parse_region(cls, region, tools, *, at_end):
+                parsed = QwenXmlParser.parse_region(region, tools, at_end=at_end)
+                if at_end:
+                    for c in parsed.calls:
+                        c.function["name"] = "something_else"
+                return parsed
 
         return Liar
 
@@ -1523,26 +1557,40 @@ class TestTheRegionIsNotCopiedPerChunk:
             )
         return best * 1000
 
-    def test_announce_is_never_handed_the_whole_region(self):
-        """The deterministic half: materialising the buffer per chunk is the
-        cost, so nothing on that path may ask for it."""
+    @staticmethod
+    def _scans_of_an_open_region(text, parser_cls=QwenXmlParser):
+        """Every length the format was asked about while the region was open."""
         seen: list[int] = []
 
-        class Watching(QwenXmlParser):
+        class Watching(parser_cls):
             @classmethod
-            def peek_name(cls, region, tools=None):
-                seen.append(len(region))
-                return QwenXmlParser.peek_name(region, tools)
+            def parse_region(cls, region, tools, *, at_end):
+                if not at_end:
+                    seen.append(len(region))
+                return parser_cls.parse_region(region, tools, at_end=at_end)
 
-        text = _big_call(8 * 1024)
         parser = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=Watching)
         for i in range(0, len(text), 4):
             parser.process(text[i : i + 4])
         parser.flush()
-        assert seen, "the peek never ran; this asserts nothing"
-        assert (
-            max(seen) <= _PEEK_WINDOW
-        ), f"a peek was handed {max(seen)} characters, window is {_PEEK_WINDOW}"
+        return seen
+
+    def test_the_open_region_is_never_scanned_beyond_the_window(self):
+        """Nothing on the per-chunk path may be handed the whole region.
+
+        Running a format's regex over the growing buffer once per chunk is
+        quadratic in the response, and a probe that did it on a doubling
+        schedule was tried and reverted -- see
+        `TestTheDeclarationAboutACallInProgressIsMeasured`. So the bound is
+        flat again: `Region.head`, and nothing larger, ever.
+        """
+        text = _big_call(8 * 1024)
+        seen = self._scans_of_an_open_region(text)
+        assert seen, "nothing asked; this asserts nothing"
+        assert max(seen) <= _PEEK_WINDOW, (
+            f"a scan of an open region was handed {max(seen)} characters; the "
+            f"window is {_PEEK_WINDOW}"
+        )
 
     @pytest.mark.parametrize(
         "parser, build",
@@ -1610,9 +1658,10 @@ class TestThePeekIsBounded:
 
         class Counting(parser_cls):
             @classmethod
-            def peek_name(cls, region, tools=None):
-                calls.append(len(region))
-                return parser_cls.peek_name(region, tools)
+            def parse_region(cls, region, tools, *, at_end):
+                if not at_end:
+                    calls.append(len(region))
+                return parser_cls.parse_region(region, tools, at_end=at_end)
 
         stream = ToolCallStreamParser(parser_cls=Counting)
         stream.tools = tools
@@ -1621,15 +1670,15 @@ class TestThePeekIsBounded:
         stream.flush()
         return calls
 
-    def test_no_peek_ever_sees_more_than_the_window(self):
+    def test_the_announcement_never_sees_more_than_the_window(self):
         text = "The model writes <tool_call> to open one. " + "x" * 4000
         sizes = self._count_peeks(QwenXmlParser, text, DECLARED_TOOLS)
         assert sizes, "the peek never ran"
-        assert max(sizes) <= _PEEK_WINDOW, f"peeked {max(sizes)} characters"
+        assert (
+            max(sizes) <= _PEEK_WINDOW
+        ), f"the announcement was handed {max(sizes)} characters"
 
     def test_it_stops_once_the_window_has_gone_by_without_a_name(self):
-        from atom.entrypoints.openai.tool_parser.tool_parser import _PEEK_WINDOW
-
         text = "The model writes <tool_call> to open one. " + "x" * 4000
         sizes = self._count_peeks(QwenXmlParser, text, DECLARED_TOOLS)
         # One per chunk until the region passes the window, then never again.
@@ -1639,7 +1688,402 @@ class TestThePeekIsBounded:
         )
 
     def test_an_undeclared_name_also_stops_it(self):
+        """A name the request never offered is prose to every format's own
+        truncated-call test, so nothing parses and the window runs out --
+        the same latch, reached one step later than when the peek had its
+        own name check."""
         other = [{"type": "function", "function": {"name": "something_else"}}]
         text = "Sure. " + REAL_CALLS["qwen"].replace("Paris", "x" * 4000)
         sizes = self._count_peeks(QwenXmlParser, text, other)
-        assert len(sizes) <= 40, f"{len(sizes)} peeks after the name was rejected"
+        assert len(sizes) <= _PEEK_WINDOW // 4 + 2, (
+            f"{len(sizes)} peeks over a {len(text)}-character answer; the "
+            "latch is not holding and the cost is quadratic again"
+        )
+
+
+class TestOneReaderPerFormat:
+    """A format may not grow a second way of reading the stream.
+
+    Everything this branch fixed twice over came from the same shape: a
+    format read once by ``parse`` and again by a ``process``/``flush`` state
+    machine of its own, with four rules -- where content ends, whether an
+    unclosed tag is a call, what a region that parses to nothing means, which
+    bytes are framing -- written out in both. The engine owns all four now,
+    and a format that defines any of these names has taken one back.
+    """
+
+    FORBIDDEN = ("parse", "process", "flush", "peek_name")
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_it_defines_no_reader_of_its_own(self, parser):
+        own = [name for name in self.FORBIDDEN if name in vars(parser)]
+        assert not own, f"{parser.NAME} defines {own}; the engine owns those"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_it_holds_no_per_request_state(self, parser):
+        """Class-side only, so one request cannot leak into the next and one
+        region cannot leak into the one after it."""
+        instance_attrs = [
+            name
+            for name, value in vars(parser).items()
+            if not name.startswith("_")
+            and not isinstance(value, (classmethod, staticmethod, property))
+            and not name.isupper()
+        ]
+        assert not instance_attrs, f"{parser.NAME} carries {instance_attrs}"
+
+
+class TestARegionIsAccountedForByteByByte:
+    """What a region's bytes become, stated as a conservation law.
+
+    `parse_region` reports two offsets, and everything outside them is the
+    answer. Getting either wrong is silent: too small a `begins` leaves markup
+    in the answer, too large swallows a sentence, and a `consumed` that does
+    not advance hands the same region back forever.
+    """
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_region_that_is_exactly_one_call_leaves_no_answer(self, parser):
+        """The whole of this format's own call is markup, opener to closer."""
+        call = REAL_CALLS[parser.NAME]
+        content, calls = parse_tool_calls(call, DECLARED_TOOLS, parser)
+        assert len(calls) == 1, f"{parser.NAME} did not parse its own call"
+        assert content == "", f"{parser.NAME} left {content!r} in the answer"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_offsets_bracket_something(self, parser):
+        """`begins < consumed <= len(region)` whenever a call was found.
+
+        The lower bound is what stops the engine looping: it hands
+        `region[consumed:]` back to be read again, so a `consumed` that did
+        not advance would find the same marker and parse it again forever.
+        """
+        region = REAL_CALLS[parser.NAME]
+        parsed = parser.parse_region(region, DECLARED_TOOLS, at_end=True)
+        assert parsed.calls
+        assert 0 <= parsed.begins < parsed.consumed <= len(region), (
+            f"{parser.NAME}: begins={parsed.begins} consumed={parsed.consumed} "
+            f"len={len(region)}"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_sentence_between_a_quotation_and_a_real_call_survives(self, parser):
+        """A region opens at the *first* marker in the text, which an answer
+        that quotes one before calling for real puts in the wrong place: the
+        sentence in between is inside the region and is not markup.
+
+        This is what `RegionParse.begins` is for. Reported as the first call's
+        own match and widened back over the wrapper enclosing it, so it stops
+        where the prose ends -- and not at the region's start, which would
+        swallow the sentence, nor at the call's match, which would leave the
+        wrapper in the answer.
+        """
+        marker = next(m for m in parser.START_MARKERS if parser.opens_region(m))
+        prefix = f"Explaining: {marker} is how. Now: "
+        text = prefix + REAL_CALLS[parser.NAME] + " done"
+        content, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+        assert len(calls) == 1, f"{parser.NAME} did not find the real call"
+        assert content == prefix + " done", f"{parser.NAME}: {content!r}"
+        for size in (1, 5, len(text)):
+            stream = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+            events = []
+            for i in range(0, len(text), size):
+                events += stream.process(text[i : i + size])
+            events += stream.flush()
+            streamed = "".join(d for k, d in events if k == "content")
+            assert streamed == content, f"{parser.NAME} at chunk {size}: {streamed!r}"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_prose_around_a_call_survives_on_both_paths(self, parser):
+        """Before and after, and the same either way it is delivered."""
+        text = "Sure. " + REAL_CALLS[parser.NAME] + "\nAnything else?"
+        content, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+        assert len(calls) == 1
+        assert content == "Sure. \nAnything else?", content
+        for size in (1, 3, 17, len(text)):
+            stream = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+            events = []
+            for i in range(0, len(text), size):
+                events += stream.process(text[i : i + size])
+            events += stream.flush()
+            streamed = "".join(d for k, d in events if k == "content")
+            assert streamed == content, f"{parser.NAME} at chunk {size}: {streamed!r}"
+
+
+class TestTheDeclarationAboutACallInProgressIsMeasured:
+    """`RECOGNISES_A_CALL_IN_PROGRESS` says a format's `parse_region` can see a
+    call that has not finished arriving. The engine reads it to decide whether
+    a name may go out early.
+
+    It was also read for a second decision -- whether a region producing
+    nothing could be given up on and released as prose -- and that is why the
+    rows below about long calls exist. The give-up is gone: it rests on
+    acceptance being monotone in how many bytes have arrived, and that is
+    false for three of the six formats, so real calls over the probe size were
+    delivered as raw markup with `finish_reason: stop` while `stream=false`
+    returned the call. These rows are what catches it coming back.
+    """
+
+    @staticmethod
+    def _cut_inside_an_argument(parser) -> str:
+        """This format's own call, cut off in the middle of a value.
+
+        "One byte short of complete" is the wrong probe: a Kimi entry cut
+        there is still whole and it is the *section* that is unterminated,
+        while the case the flag is about is a single call whose argument is
+        still arriving.
+        """
+        long_value = "x" * 4000
+        call = REAL_CALLS[parser.NAME].replace("Paris", long_value)
+        return call[: call.index(long_value) + 2000]
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_declaration_matches_the_parse(self, parser):
+        partial = self._cut_inside_an_argument(parser)
+        seen = parser.parse_region(partial, DECLARED_TOOLS, at_end=False).calls
+        assert bool(seen) is parser.RECOGNISES_A_CALL_IN_PROGRESS, (
+            f"{parser.NAME} declares {parser.RECOGNISES_A_CALL_IN_PROGRESS} but a "
+            f"call cut off mid-argument parsed to {len(seen)} call(s)"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_no_size_at_which_a_call_stops_being_one(self, parser):
+        call = REAL_CALLS[parser.NAME].replace("Paris", "x" * 8192)
+        stream = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+        events = []
+        for i in range(0, len(call), 4):
+            events += stream.process(call[i : i + 4])
+        events += stream.flush()
+        args = [d for k, d in events if k == "tool_call_args"]
+        assert len(args) == 1, f"{parser.NAME} lost a {len(call)}-character call"
+        assert "x" * 32 in args[0]["function"]["arguments"]
+        assert (
+            "".join(d for k, d in events if k == "content") == ""
+        ), f"{parser.NAME} delivered part of a call as text"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_a_long_call_costs_what_it_is_and_not_its_square(self, parser):
+        """The other half of why the give-up came out.
+
+        Giving up re-fed bytes that immediately reopened a region with a fresh
+        budget, and the probe re-ran a failing match over the whole growing
+        region: 1.19 ms to 18.2 s on a 250 KB answer, synchronously inside the
+        request coroutine, stalling every other in-flight request.
+        """
+
+        def ms(payload):
+            text = REAL_CALLS[parser.NAME].replace("Paris", "x" * payload)
+            best = None
+            for _ in range(3):
+                stream = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+                start = time.perf_counter()
+                for i in range(0, len(text), 64):
+                    stream.process(text[i : i + 64])
+                stream.flush()
+                took = time.perf_counter() - start
+                best = took if best is None else min(best, took)
+            return best * 1000
+
+        small, large = ms(8 * 1024), ms(64 * 1024)
+        assert large / max(small, 1e-6) < 16, (
+            f"{parser.NAME}: 8x the payload cost {large / small:.1f}x the time "
+            f"({small:.2f} -> {large:.2f} ms)"
+        )
+
+
+class TestAQuotedCallOpenerIsNotTheCallTheModelMade:
+    """A format's call opener written in prose, before a real call.
+
+    The non-greedy body ran from the quoted opener all the way to the real
+    call's closer, so the client got one call named after the placeholder,
+    carrying the real call's arguments, with the explanatory sentence deleted
+    and `finish_reason: tool_calls`. `finditer` then resumed past the real
+    call, so the call the model actually made never went out at all.
+
+    A call's body cannot contain another opener -- that literal is what opens
+    one -- and every format says so now. GLM was given the guard first, for a
+    different shape; this is the sweep, and the row that keeps it swept.
+    """
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_placeholder_never_becomes_the_call(self, parser):
+        quoted = CALL_OPENERS[parser.NAME].replace("get_weather", "NAME")
+        text = f"To call it you write {quoted} and then the arguments. Now: "
+        text += REAL_CALLS[parser.NAME]
+        content, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+        assert [c.function["name"] for c in calls] == ["get_weather"], (
+            f"{parser.NAME} produced {[c.function['name'] for c in calls]} from an "
+            "answer that quotes an opener before making one real call"
+        )
+        assert "and then the arguments" in content, f"{parser.NAME}: {content!r}"
+        for size in (1, 6, len(text)):
+            stream = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+            events = []
+            for i in range(0, len(text), size):
+                events += stream.process(text[i : i + size])
+            events += stream.flush()
+            assert [
+                d["function"]["name"] for k, d in events if k == "tool_call_start"
+            ] == ["get_weather"], f"{parser.NAME} at chunk {size}"
+            assert (
+                "".join(d for k, d in events if k == "content") == content
+            ), f"{parser.NAME} at chunk {size}"
+
+
+class TestAnUnclosedCallDoesNotSwallowTheNextOne:
+    """A call the model forgot to close ends where the next one opens.
+
+    Anchoring the unclosed alternative at end of *stream* meant a call
+    followed by a second call matched neither alternative at the first opener,
+    so the first call was skipped entirely and the client got the second one
+    where the model had made two -- and a different one from the name already
+    announced.
+    """
+
+    CLOSERS: ClassVar[dict[str, str]] = {
+        "qwen": "</function></tool_call>",
+        "glm": "</tool_call>",
+        "dsml": f"</{_D}invoke></{_D}tool_calls>",
+        "minimax": f"{_NS}</invoke>{_NS}</tool_call>",
+        "kimi": "<|tool_calls_section_end|>",
+        "kimi_k3": "<|close|>call",
+    }
+
+    def _unclosed_then_real(self, parser) -> str:
+        first = REAL_CALLS[parser.NAME]
+        closer = self.CLOSERS[parser.NAME]
+        assert first.endswith(
+            closer
+        ), f"{parser.NAME}: corpus does not end on {closer!r}"
+        return first[: -len(closer)] + first
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_complete_call_is_never_lost(self, parser):
+        """The invariant every format holds. Whether the *unclosed* one is
+        also recovered is per format -- Qwen, GLM and MiniMax read it, DSML
+        and the two token formats do not, and never did -- but the complete
+        one must always go out, and nothing may be invented.
+        """
+        text = self._unclosed_then_real(parser)
+        _, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+        names = [c.function["name"] for c in calls]
+        assert (
+            "get_weather" in names
+        ), f"{parser.NAME} lost the complete call behind an unclosed one: {names}"
+        declared = {t["function"]["name"] for t in DECLARED_TOOLS}
+        assert set(names) <= declared, f"{parser.NAME} invented {set(names) - declared}"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_the_two_delivery_modes_agree_about_how_many(self, parser):
+        """However many that is, it is the same number either way. The
+        anchoring bug made `stream=false` and `stream=true` disagree here."""
+        text = self._unclosed_then_real(parser)
+        _, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+        for size in (1, 9, len(text)):
+            stream = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+            events = []
+            for i in range(0, len(text), size):
+                events += stream.process(text[i : i + size])
+            events += stream.flush()
+            streamed = [d for k, d in events if k == "tool_call_args"]
+            assert len(streamed) == len(calls), (
+                f"{parser.NAME} at chunk {size}: {len(streamed)} streamed vs "
+                f"{len(calls)} not"
+            )
+
+
+class TestTheEarlyNameCannotDisagreeWithTheParse:
+    """The property the whole announcement design rests on.
+
+    The name is read out of `parse_region` over the region so far; the call
+    that goes out is `parse_region` over the whole region. They agree iff
+    acceptance is *monotone* in how many bytes have arrived -- if a prefix
+    yields a first call named N, so does every longer prefix, and so does the
+    finished region.
+
+    Asserted by fuzzing rather than by argument, because the argument has been
+    wrong before: a probe added last round rested on the same claim and it is
+    false for three formats when the question is asked at `at_end=False` on a
+    *region* rather than a prefix.
+    """
+
+    SHAPES: ClassVar[list[str]] = [
+        "{call}",
+        PROSE + "{call}",
+        "{call}" + PROSE,
+        "{call}{call}",
+        PROSE + "{half}" + PROSE + "{call}",
+        "{half}{call}",
+    ]
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_no_prefix_of_a_head_ever_names_a_different_tool(self, parser):
+        call = REAL_CALLS[parser.NAME]
+        texts = [
+            shape.format(call=call, half=call[: len(call) // 2])
+            for shape in self.SHAPES
+        ]
+        texts.append(call.replace("Paris", "x" * 300))
+        texts.append(call.replace("get_weather", "undeclared_tool"))
+        for text in texts:
+            head = text[:_PEEK_WINDOW]
+            first = None
+            for n in range(1, len(head) + 1):
+                calls = parser.parse_region(
+                    head[:n], DECLARED_TOOLS, at_end=False
+                ).calls
+                if not calls:
+                    continue
+                name = calls[0].function["name"]
+                if first is None:
+                    first = (n, name)
+                else:
+                    assert name == first[1], (
+                        f"{parser.NAME}: {head[:first[0]]!r} names {first[1]!r} but "
+                        f"{head[:n]!r} names {name!r}"
+                    )
+            if first is None:
+                continue
+            whole = parser.parse_region(text, DECLARED_TOOLS, at_end=True).calls
+            if whole:
+                assert whole[0].function["name"] == first[1], (
+                    f"{parser.NAME}: announced {first[1]!r}, parsed "
+                    f"{whole[0].function['name']!r} from {text[:80]!r}"
+                )
+
+    def test_and_a_format_that_breaks_it_leaves_no_index_behind(self):
+        """The recovery, driven by a format built to break the property.
+
+        A name that goes out and never gets arguments has still used its
+        index. A later real call landing on the same one is merged into it by
+        any accumulator that keys on index -- the OpenAI streaming contract --
+        so the client ends up with a single call whose name is two names glued
+        together and which no tool answers to.
+        """
+
+        class Fickle(QwenXmlParser):
+            NAME = "fickle"
+
+            @classmethod
+            def parse_region(cls, region, tools, *, at_end):
+                if not at_end and "<parameter=" in region:
+                    call = ToolCall(
+                        id="fickle",
+                        type="function",
+                        function={"name": "get_weather", "arguments": "{}"},
+                    )
+                    return RegionParse((call,), 0, len(region))
+                return RegionParse()
+
+        text = "<tool_call><function=get_weather><parameter=city>Paris"
+        stream = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=Fickle)
+        events = []
+        for i in range(0, len(text), 4):
+            events += stream.process(text[i : i + 4])
+        events += stream.flush()
+        announced = [d["index"] for k, d in events if k == "tool_call_start"]
+        assert announced, "the announcement is the premise of this test"
+        assert stream._index > announced[-1], (
+            "the index of a name that produced no call was not stepped past; a "
+            "later call would land on it"
+        )

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -5,9 +5,12 @@
 
 Not a list of cases. The corpus is *generated* from the two production
 registries -- ``reasoning_dialects.DIALECTS`` and the tool-parser
-``_DETECT_ORDER`` -- crossed with a handful of text shapes built out of each
-entry's own declared markers. Registering a new model family or a new
-tool-call format therefore adds coverage by itself, and
+``registry.PARSERS_BY_NAME`` -- crossed with a handful of text shapes built
+out of each entry's own declared markers. The parser registry and not
+``_DETECT_ORDER``: the detect order omits the terminal fallback, so reading
+it here meant this file's own axis was a union assembled by hand.
+Registering a new model family or a new tool-call format therefore adds
+coverage by itself, and
 ``test_every_registered_parser_declares_its_markers`` is what stops a new
 entry from joining the registry without the declaration the generation needs.
 
@@ -34,6 +37,7 @@ its content segments into the tool parser, both flushed on the last chunk.
 from __future__ import annotations
 
 import ast
+import functools
 import itertools
 import json
 import pathlib
@@ -56,7 +60,7 @@ from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_too
 from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
-from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
+from atom.entrypoints.openai.tool_parser.registry import PARSERS_BY_NAME
 from atom.entrypoints.openai.tool_parser.stream import (
     _PEEK_WINDOW,
     ToolCallStreamParser,
@@ -65,16 +69,19 @@ from entrypoints.wire_corpus import (
     DECLARED_TOOLS,
     REAL_CALLS,
     naming_another_tool,
-    naming_nothing,
-    naming_only_spaces,
+    naming_something_undispatchable,
     quoting_a_call_it_will_not_make,
     truncated,
     truncated_naming_another_tool,
 )
 
-# Kimi is the terminal fallback and so is not in the detect order, but it is a
-# registered format with markers of its own.
-ALL_PARSERS = (*_DETECT_ORDER, KimiParser)
+# The registry itself, not a union assembled here. It was
+# `(*_DETECT_ORDER, KimiParser)` -- correct today, and correct only because
+# Kimi is the one registered format outside the detect order. A second such
+# format joins `PARSERS_BY_NAME` and every property in this file silently
+# stops covering it, which is the failure this file exists to prevent one
+# layer down.
+ALL_PARSERS = tuple(PARSERS_BY_NAME.values())
 
 # Slack allowed on top of the neutralised control before a hold counts as a
 # stall. One marker's worth, since that is the most a correct rule can need.
@@ -368,6 +375,21 @@ class TestEveryFormatIsCovered:
         ]
         assert not undeclared, f"registered parsers with no START_MARKERS: {undeclared}"
 
+    def test_every_registered_parser_says_what_closes_a_call(self):
+        """`CALL_SELF_CLOSERS`, empty or not, has to be written down.
+
+        Inherited it reads as "this format's call is its own wrapper", which
+        is true of two formats and false of the rest -- and the difference
+        decides whether `<tool_call><function=NAME></tool_call>` is prose or a
+        dispatch. Asked of `vars` for the same reason the markers above are:
+        a subclass would otherwise answer with its parent's.
+        """
+        undeclared = [p.NAME for p in ALL_PARSERS if "CALL_SELF_CLOSERS" not in vars(p)]
+        assert not undeclared, (
+            "registered parsers that never say what closes one of their "
+            f"calls: {undeclared}"
+        )
+
     def test_every_dialect_declares_an_end_marker(self):
         missing = [d for d in DIALECTS if not d.think_end_marker]
         assert not missing, "a dialect with no end marker cannot be streamed"
@@ -378,6 +400,87 @@ class TestEveryFormatIsCovered:
             f"{len(PAIRS)} cases for {len(ALL_PARSERS)} parsers and "
             f"{len(DIALECTS)} dialects -- the generator lost a dimension"
         )
+
+
+_FORMAT_NAMES = frozenset(PARSERS_BY_NAME)
+
+
+@functools.lru_cache(maxsize=8)
+def _format_tables(root: pathlib.Path) -> tuple[tuple[str, int, frozenset], ...]:
+    """Every string collection under `root` naming 2+ registered formats.
+
+    Cached on the directory: parsing the suite is 42 ms and three tests ask.
+    """
+    found = []
+    for path in sorted(root.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.Dict):
+                items = node.keys
+            elif isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+                items = node.elts
+            else:
+                continue
+            named = (
+                frozenset(
+                    e.value
+                    for e in items
+                    if isinstance(e, ast.Constant) and isinstance(e.value, str)
+                )
+                & _FORMAT_NAMES
+            )
+            if len(named) >= 2:
+                found.append((path.name, node.lineno, named))
+    return tuple(found)
+
+
+class TestNoSuiteKeepsAShortCopyOfTheRegistry:
+    """A per-format table in a test is a copy of the registry, and copies go
+    *short*.
+
+    Three did, and all three were green the whole time they existed: the prose
+    property ran under the ids `[qwen, glm, qwen-outer-closer, dsml, minimax]`
+    -- a full sweep at a glance, four of six once counted -- and the other two
+    each left out the one format with most to get wrong. Nothing counted them.
+
+    So: any collection naming two or more formats has to name all of them. A
+    table that genuinely cannot says so with a one-name exemption, which is
+    below the threshold and visible in the diff.
+    """
+
+    ROOT: ClassVar[pathlib.Path] = pathlib.Path(__file__).resolve().parent
+
+    def test_the_scan_sees_the_tables(self):
+        """Positive control: a rename of the formats would otherwise retire
+        this silently, still green."""
+        assert _format_tables(self.ROOT), (
+            "no per-format table found in the suite, so this guard reads "
+            f"nothing; it is looking for {sorted(_FORMAT_NAMES)}"
+        )
+
+    def test_none_of_them_is_short(self):
+        short = [
+            f"{f}:{ln} covers {len(names)}/{len(_FORMAT_NAMES)}, "
+            f"missing {sorted(_FORMAT_NAMES - names)}"
+            for f, ln, names in _format_tables(self.ROOT)
+            if names != _FORMAT_NAMES
+        ]
+        assert not short, "per-format tables that do not cover the registry:\n  " + (
+            "\n  ".join(short)
+        )
+
+    def test_the_scan_rejects_a_short_table_and_accepts_a_whole_one(self, tmp_path):
+        """Two-sided, so the scan cannot be 'fixed' by being weakened the next
+        time it fires."""
+        names = sorted(_FORMAT_NAMES)
+        for listed, want_short in ((names, False), (names[:-1], True)):
+            # A directory each, so the cache is keyed apart rather than
+            # cleared -- clearing would evict the real scan other tests share.
+            probe = tmp_path / ("short" if want_short else "whole")
+            probe.mkdir()
+            (probe / "probe.py").write_text(f"T = {listed!r}\n")
+            found = _format_tables(probe)
+            assert found, "the probe file produced no table at all"
+            assert any(n != _FORMAT_NAMES for _f, _l, n in found) is want_short
 
 
 class TestEverySeedingSiteIsSeeded:
@@ -1727,7 +1830,7 @@ CALL_OPENERS: dict[str, str] = {
     "kimi": ("<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0"),
     "glm": "<tool_call>get_weather",
     "qwen": "<tool_call><function=get_weather>",
-    "kimi_k3": '<|open|>tools<|sep|><|open|>call tool="get_weather"<|sep|>',
+    "kimi_k3": '<|open|>tools<|sep|><|open|>call tool="get_weather" index="0"<|sep|>',
     "dsml": f'<{_D}tool_calls><{_D}invoke name="get_weather">',
     "minimax": f'{_NS}<tool_call>{_NS}<invoke name="get_weather">',
 }
@@ -1740,7 +1843,8 @@ CALL_CONTINUATIONS: dict[str, str] = {
     "glm": "<arg_key>city</arg_key>",
     "qwen": "<parameter=city>Paris</parameter>",
     "kimi_k3": (
-        '<|open|>argument key="city"<|sep|>Paris<|close|>argument<|close|>call'
+        '<|open|>argument key="city" type="string"<|sep|>Paris'
+        "<|close|>argument<|sep|><|close|>call<|sep|>"
     ),
     "dsml": f'<{_D}parameter name="city">Paris',
     "minimax": f"{_NS}<city>Paris",
@@ -2453,7 +2557,7 @@ class TestAnUnclosedCallDoesNotSwallowTheNextOne:
         "dsml": f"</{_D}invoke></{_D}tool_calls>",
         "minimax": f"{_NS}</invoke>{_NS}</tool_call>",
         "kimi": "<|tool_calls_section_end|>",
-        "kimi_k3": "<|close|>call",
+        "kimi_k3": "<|close|>call<|sep|><|close|>tools<|sep|>",
     }
 
     def _unclosed_then_real(self, parser) -> str:
@@ -2653,42 +2757,68 @@ class TestTheEarlyNameCannotDisagreeWithTheParse:
         )
 
 
-class TestNoFormatShipsACallItCannotName:
-    """A call the client cannot dispatch is not a call.
+class TestEveryParserDefersToTheSharedNameTest:
+    """Whether a name is a name is answered in one place, for every format.
 
-    Every format's name slot admits an empty string -- `name="([^"]*)"`,
-    `tool="([^"]*)"` -- so this is a shape the wire allows and a model can
-    produce. Three of six handed it on: DSML and K3 asked nothing at all, and
-    MiniMax asked `if not name` *before* `name.strip()`, so a name of pure
-    whitespace passed the guard and reached the client as `""`.
+    Asked by *refusal* rather than by junk input: `usable_tool_name` is forced
+    to reject, and each format is then handed its own real call from the
+    corpus. A parser that routes its name through the predicate reports
+    nothing; one that does not reports the call anyway and names itself.
 
-    Generated over the registry rather than written per format, because that
-    split -- three formats, three different ways of being wrong, one of them
-    only visible to the whitespace shape -- is what a per-format test set
-    reliably half-covers.
+    The point of doing it this way is that it invents no names. A list of junk
+    strings only ever covers the failures whoever wrote the list thought of --
+    and the first version here, an empty name and an all-space one, passed on
+    two formats that were broken. Qwen tested `if not name`, which admits
+    `<function=YOUR FUNCTION NAME>`, the placeholder a model writes when it is
+    explaining the format. Kimi's `functions\\.([\\w.\\-]+):` was called safe by
+    construction and admits a leading dot, so `functions..hidden:0` shipped a
+    call named `.hidden`. Neither shape was in the list; both fall out of this
+    question without being anticipated.
+
+    Parametrised over the registry, so a seventh format is covered the moment
+    it is registered rather than when someone remembers it.
     """
 
+    @staticmethod
+    def _module_of(parser):
+        return sys.modules[parser.__module__]
+
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
-    @pytest.mark.parametrize(
-        "derive", [naming_nothing, naming_only_spaces], ids=["empty", "whitespace"]
-    )
-    def test_it_is_not_reported_as_a_call(self, parser, derive):
-        text = derive(parser.NAME)
-        _content, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+    def test_a_refusal_is_honoured(self, parser, monkeypatch):
+        module = self._module_of(parser)
+        assert hasattr(module, "usable_tool_name"), (
+            f"{parser.NAME} does not import the shared name test, so it is "
+            "answering the question itself"
+        )
+        monkeypatch.setattr(module, "usable_tool_name", lambda _name: False)
+        _content, calls = parse_tool_calls(
+            REAL_CALLS[parser.NAME], DECLARED_TOOLS, parser
+        )
         assert not calls, (
-            f"{parser.NAME} reported a call named "
-            f"{calls[0].function['name']!r}, which matches nothing the request "
-            "declared and which a client cannot dispatch"
+            f"{parser.NAME} reported {calls[0].function['name']!r} after the "
+            "shared name test refused it, so it is not consulting it"
         )
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
-    def test_and_the_same_shape_with_a_name_still_is(self, parser):
-        """The positive control. Without it the property above passes on a
-        parser that stopped reading its own format."""
+    def test_and_without_the_refusal_the_call_is_read(self, parser):
+        """The positive control. Every case above passes on a parser that
+        stopped reading its own format at all."""
         _content, calls = parse_tool_calls(
             REAL_CALLS[parser.NAME], DECLARED_TOOLS, parser
         )
         assert calls, f"{parser.NAME} no longer reads its own complete call"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_the_real_predicate_refuses_a_real_shape(self, parser):
+        """The link the refusal test cannot make: that the predicate as it
+        actually stands rejects something. Without this, a `usable_tool_name`
+        that returned True for everything would satisfy the class above."""
+        text = naming_something_undispatchable(parser.NAME)
+        _content, calls = parse_tool_calls(text, DECLARED_TOOLS, parser)
+        assert not calls, (
+            f"{parser.NAME} reported a call named "
+            f"{calls[0].function['name']!r}, which no client could dispatch"
+        )
 
 
 class TestAQuotationDoesNotMoveARealCallsLeftEdge:

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -650,10 +650,21 @@ class TestARealCallSurvivesTheStream:
 # do not hand the stream over: channel framing that wraps every answer. Only
 # Kimi-K3 has any; a format absent here declares none, which is the default.
 FRAMING_NOT_A_REGION: dict[str, set[str]] = {
+    # Every channel token K3 wraps an answer in. Only the call prefix and the
+    # tools wrapper mean a call; the rest are removed on both paths, so the
+    # read-ahead has to know them to keep the two in step.
     "kimi_k3": {
         "<|open|>response<|sep|>",
         "<|close|>response<|sep|>",
         "<|end_of_msg|>",
+        "<|open|>think<|sep|>",
+        "<|close|>think<|sep|>",
+        "<|open|>message<|sep|>",
+        "<|close|>message<|sep|>",
+        "<|close|>response",
+        "<|close|>think",
+        "<|close|>message",
+        "<|sep|>",
     },
 }
 
@@ -728,6 +739,14 @@ DECLARED_TOOLS = [
 ]
 
 
+# Formats that deliberately do not announce a name early, and why. Stated
+# here rather than read off `peek_name`, so removing an override is a failing
+# test and not a silently skipped one.
+NO_EARLY_NAME = {
+    "kimi": "index and id come off the wire, after the peek would have to fire",
+}
+
+
 class TestTheNameArrivesBeforeTheArguments:
     """Which tool is being called, sent as soon as the region reveals it.
 
@@ -771,7 +790,18 @@ class TestTheNameArrivesBeforeTheArguments:
         )
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_opt_outs_are_the_declared_ones(self, parser):
+        """Whether a format announces at all, pinned rather than inferred."""
+        peeks = parser.peek_name(REAL_CALLS[parser.NAME]) is not None
+        assert peeks is (parser.NAME not in NO_EARLY_NAME), (
+            f"{parser.NAME}: peek_name says {peeks}, NO_EARLY_NAME says "
+            f"{parser.NAME in NO_EARLY_NAME}"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_a_declared_tool_is_named_early(self, parser):
+        if parser.NAME in NO_EARLY_NAME:
+            pytest.skip(NO_EARLY_NAME[parser.NAME])
         total, at, args_at, _ = self._drive(
             parser, self._big_call(parser), DECLARED_TOOLS
         )
@@ -803,6 +833,8 @@ class TestTheNameArrivesBeforeTheArguments:
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_declaring_it_is_what_moves_the_name_earlier(self, parser):
         """Same input, one variable: the arms differ only in `tools`."""
+        if parser.NAME in NO_EARLY_NAME:
+            pytest.skip(NO_EARLY_NAME[parser.NAME])
         text = self._big_call(parser)
         _, early, _, _ = self._drive(parser, text, DECLARED_TOOLS)
         _, late, _, _ = self._drive(parser, text, None)
@@ -868,26 +900,20 @@ class TestAPromiseCannotBeTakenBack:
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_a_call_cut_off_before_it_parses_is_not_a_usable_call(self, parser):
-        """Truncated mid-call, against the same input with nothing declared.
+        """Stated as an invariant, not as "this input parses nothing".
 
-        Compared arm to arm rather than asserted outright: GLM's unterminated
-        branch salvages `<tool_call>get_weather` into a call with empty
-        arguments all by itself, which predates announcing and is that
-        format's own business. What must hold is that announcing adds no call
-        the parse did not already find.
+        Whether a format salvages a call from a given prefix is its own
+        business and now depends on the tool being declared: GLM reads
+        `<tool_call>get_weather` as a cut-off call to a declared tool, which
+        it is. What must hold either way is that a name with no arguments
+        behind it is never reported as something the client can run.
         """
         head = REAL_CALLS[parser.NAME].split("get_weather")[0] + "get_weather"
-        text = "Sure. " + head
-        kinds = [k for k, _ in self._drive(parser, text)]
-        baseline = [k for k, _ in self._drive_without_tools(parser, text)]
-        if "tool_call_args" in baseline:
-            pytest.skip("this format salvages a call from this much on its own")
-        assert (
-            "tool_call_args" not in kinds
-        ), "arguments were invented for a call that never parsed"
-        assert not completes_a_tool_call(
-            self._drive(parser, text)
-        ), "a name with no arguments must not report as a usable tool call"
+        events = self._drive(parser, "Sure. " + head)
+        if "tool_call_args" not in [k for k, _ in events]:
+            assert not completes_a_tool_call(
+                events
+            ), "a name with no arguments must not report as a usable call"
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
     def test_the_answer_still_arrives_when_the_call_does_not(self, parser):
@@ -915,3 +941,55 @@ class TestAPromiseCannotBeTakenBack:
 
         with pytest.raises(AssertionError, match="announced"):
             self._drive(Liar, "Sure. " + REAL_CALLS["qwen"])
+
+
+class TestThePeekIsBounded:
+    """Asking per token over a growing region is the shape this branch retired.
+
+    The first version ran the format's regex over the whole buffer on every
+    chunk: 3.0 -> 9.8 -> 36 -> 137 ms across 2k/4k/8k/16k tokens, quadratic,
+    against a 1383 ns/token budget for the entire pipeline. Bounded to a
+    prefix, and stopped once that prefix has gone by without a name.
+    """
+
+    @staticmethod
+    def _count_peeks(parser_cls, text, tools):
+        calls = []
+
+        class Counting(parser_cls):
+            @classmethod
+            def peek_name(cls, region):
+                calls.append(len(region))
+                return parser_cls.peek_name(region)
+
+        stream = ToolCallStreamParser(parser_cls=Counting)
+        stream.tools = tools
+        for i in range(0, len(text), 4):
+            stream.process(text[i : i + 4])
+        stream.flush()
+        return calls
+
+    def test_no_peek_ever_sees_more_than_the_window(self):
+        from atom.entrypoints.openai.tool_parser.tool_parser import _PEEK_WINDOW
+
+        text = "The model writes <tool_call> to open one. " + "x" * 4000
+        sizes = self._count_peeks(QwenXmlParser, text, DECLARED_TOOLS)
+        assert sizes, "the peek never ran"
+        assert max(sizes) <= _PEEK_WINDOW, f"peeked {max(sizes)} characters"
+
+    def test_it_stops_once_the_window_has_gone_by_without_a_name(self):
+        from atom.entrypoints.openai.tool_parser.tool_parser import _PEEK_WINDOW
+
+        text = "The model writes <tool_call> to open one. " + "x" * 4000
+        sizes = self._count_peeks(QwenXmlParser, text, DECLARED_TOOLS)
+        # One per chunk until the region passes the window, then never again.
+        assert len(sizes) <= _PEEK_WINDOW // 4 + 2, (
+            f"{len(sizes)} peeks over a {len(text)}-character answer; the "
+            "latch is not holding and the cost is quadratic again"
+        )
+
+    def test_an_undeclared_name_also_stops_it(self):
+        other = [{"type": "function", "function": {"name": "something_else"}}]
+        text = "Sure. " + REAL_CALLS["qwen"].replace("Paris", "x" * 4000)
+        sizes = self._count_peeks(QwenXmlParser, text, other)
+        assert len(sizes) <= 40, f"{len(sizes)} peeks after the name was rejected"

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -33,6 +33,8 @@ its content segments into the tool parser, both flushed on the last chunk.
 
 from __future__ import annotations
 
+import ast
+import pathlib
 import random
 
 import pytest
@@ -40,7 +42,7 @@ import pytest
 from atom.entrypoints.openai.reasoning import ReasoningFilter
 from atom.entrypoints.openai.reasoning_dialects import DIALECTS
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
-from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
+from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER, _SNIFF_ONLY
 from atom.entrypoints.openai.tool_parser.stream import ToolCallStreamParser
 
 # Kimi is the terminal fallback and so is not in the detect order, but it is a
@@ -149,7 +151,7 @@ def shapes(dialect, parser) -> dict[str, str]:
     Each is a sentence a model could plausibly emit and none of them is a tool
     call: the point is text that merely *looks like* it might start one.
     """
-    marks = parser.MARKERS
+    marks = parser.START_MARKERS
     end = dialect.think_end_marker
     # Every trigger character, dropped into ordinary prose without ever
     # completing a marker -- `if (a < b)` and its equivalent for every format.
@@ -168,11 +170,40 @@ def shapes(dialect, parser) -> dict[str, str]:
             + "It is sunny in Paris."
         ),
     }
+    # A literal the sniffer picks the format by that is *not* a region
+    # opener: the parser is chosen and then handed text its own
+    # `START_MARKERS` do not match, so it reads on in content mode. That is
+    # the path whose holdback used to stop emitting entirely once its buffer
+    # began with a marker character. Generated from the difference between
+    # the two declarations, so a future format with the same split is covered.
+    if _SNIFF_ONLY:
+        out["detected by a literal that opens no region"] = (
+            _SNIFF_ONLY[0] + "city</arg_key> then a < b and " + PROSE * 4
+        )
+
     if dialect.output_open_marker:
         out["reasoning the model opens itself"] = (
             dialect.output_open_marker + PROSE * 3 + end + "The answer is 42."
         )
     return out
+
+
+# Shapes that close the reasoning channel without ever having opened it. Where
+# the reasoning/content boundary falls is chunk-dependent here and cannot be
+# otherwise: knowing a `</think>` is still to come means waiting for it, and
+# waiting for it is the stall. Bounded first-byte latency, honouring an
+# unopened end marker, and chunk-invariance are three properties of which an
+# implementation gets two. vLLM drops the second -- no start token in the
+# vocabulary means content, emitted at once -- and so does SGLang, whose test
+# for it is named `test_text_before_think_token_is_chunk_dependent`.
+#
+# `starts_thinking` is what makes dropping it safe: a prompt whose template
+# opened the channel says so, and such a stream never reaches that state.
+#
+# Weakened here, not excluded. The text as a whole and the tool events must
+# still be invariant -- which is what caught the fabricated tool call in
+# #1961, where the variants disagreed on both.
+CLOSE_WITHOUT_OPEN = ("a tool marker inside reasoning",)
 
 
 def _pairs():
@@ -183,6 +214,7 @@ def _pairs():
                     dialect,
                     parser,
                     text,
+                    shape_name in CLOSE_WITHOUT_OPEN,
                     id=f"{dialect.think_end_marker.strip('<>/|')}-{parser.NAME}-"
                     f"{shape_name.replace(' ', '_')}",
                 )
@@ -209,22 +241,6 @@ def _hold_pairs():
                     dialect,
                     parser,
                     text,
-                    # Exactly the character the broken rule keys on, asked of
-                    # the generated text rather than of the marker set: a
-                    # format can carry '<' inside a marker that opens with
-                    # something else, and one that never emits '<' at all is
-                    # not affected and must not be marked as if it were.
-                    marks=pytest.mark.xfail(
-                        "<" in text,
-                        strict=True,
-                        reason="sniff_stream withholds on any '<' anywhere in a "
-                        "buffer it never clears, so one '<' in an ordinary answer "
-                        "holds every later byte to EOS. Conditional on '<' because "
-                        "a format whose markers open with something else -- "
-                        "MiniMax's ns_token opens with ']' -- is not affected, and "
-                        "strict so that fixing the rule fails here and forces the "
-                        "marker off.",
-                    ),
                     id=f"{dialect.think_end_marker.strip('<>/|')}-{parser.NAME}-"
                     f"{shape_name.replace(' ', '_')}",
                 )
@@ -240,7 +256,7 @@ class TestEveryFormatIsCovered:
         """A new format joins the corpus by declaring, not by being written up.
 
         Without this the generation below would silently produce nothing for a
-        parser that forgot `MARKERS`, and the format would look covered.
+        parser that forgot `START_MARKERS`, and the format would look covered.
         """
         # Asked of the class's own `__dict__`, not of the attribute: a
         # parser that subclasses another inherits its markers, so a missing
@@ -249,9 +265,11 @@ class TestEveryFormatIsCovered:
         # distinct thing on the wire and has to say so itself, even when the
         # tuple would repeat.
         undeclared = [
-            p.NAME for p in ALL_PARSERS if "MARKERS" not in vars(p) or not p.MARKERS
+            p.NAME
+            for p in ALL_PARSERS
+            if "START_MARKERS" not in vars(p) or not p.START_MARKERS
         ]
-        assert not undeclared, f"registered tool parsers with no MARKERS: {undeclared}"
+        assert not undeclared, f"registered parsers with no START_MARKERS: {undeclared}"
 
     def test_every_dialect_declares_an_end_marker(self):
         missing = [d for d in DIALECTS if not d.think_end_marker]
@@ -265,12 +283,63 @@ class TestEveryFormatIsCovered:
         )
 
 
+class TestEverySeedingSiteIsSeeded:
+    """Nothing may build a reasoning filter without saying where it starts.
+
+    An output that begins inside the reasoning channel carries no opening
+    marker, so the text cannot say so and the prompt has to. Since state 0
+    stopped inferring it from a bare end marker -- inferring it meant waiting
+    for one, and waiting was the stall -- an unseeded site does not degrade
+    gracefully: the model's whole chain of thought is delivered as the answer.
+
+    Checked by walking the source rather than by listing the sites, so an
+    endpoint added later is covered the moment it exists. Three of the four
+    sites that exist today were unseeded before this change, including the one
+    the original bug was reported against.
+    """
+
+    ROOT = pathlib.Path(__file__).resolve().parents[2] / "atom" / "entrypoints"
+    SEEDED = ("ReasoningFilter", "separate_reasoning")
+
+    def _unseeded(self) -> list[str]:
+        found = []
+        for path in sorted(self.ROOT.rglob("*.py")):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = getattr(node.func, "id", None) or getattr(
+                    node.func, "attr", None
+                )
+                if name not in self.SEEDED:
+                    continue
+                if not any(kw.arg == "starts_thinking" for kw in node.keywords):
+                    rel = path.relative_to(self.ROOT.parents[1])
+                    found.append(f"{rel}:{node.lineno} {name}(...)")
+        return found
+
+    def test_no_entry_point_builds_one_without_the_seed(self):
+        unseeded = self._unseeded()
+        assert not unseeded, "sites that never say where reasoning starts:\n  " + (
+            "\n  ".join(unseeded)
+        )
+
+    def test_the_scan_can_actually_fail(self):
+        """A source scan that matches nothing would pass forever."""
+        tree = ast.parse("ReasoningFilter()\nseparate_reasoning(x)\n")
+        calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
+        assert len(calls) == 2
+        assert all(
+            not any(kw.arg == "starts_thinking" for kw in c.keywords) for c in calls
+        )
+
+
 class TestChunkInvariance:
     """Where the token boundaries fall must not change what the client sees."""
 
-    @pytest.mark.parametrize("dialect, parser, text", PAIRS)
+    @pytest.mark.parametrize("dialect, parser, text, split_may_move", PAIRS)
     def test_the_same_text_split_differently_reads_the_same(
-        self, dialect, parser, text
+        self, dialect, parser, text, split_may_move
     ):
         by_split = {
             label: drive(text, chunks)
@@ -278,11 +347,21 @@ class TestChunkInvariance:
         }
         variants: dict = {}
         for label, seen in by_split.items():
-            variants.setdefault(seen.key, []).append(label)
+            key = seen.key
+            if split_may_move:
+                key = (seen.reasoning + seen.content, key[2], key[3])
+            variants.setdefault(key, []).append(label)
         if len(variants) > 1:
             report = "\n".join(
-                f"  {'/'.join(labels)}: reasoning={len(k[0])}ch "
-                f"content={len(k[1])}ch events={list(k[2])} finish={k[3]}"
+                f"  {'/'.join(labels)}: "
+                + "  ".join(
+                    (
+                        f"{part!r}"
+                        if isinstance(part, str) and len(part) < 40
+                        else (f"{len(part)}ch" if isinstance(part, str) else f"{part}")
+                    )
+                    for part in k
+                )
                 for k, labels in variants.items()
             )
             pytest.fail(f"{len(variants)} different results for one text:\n{report}")
@@ -295,7 +374,7 @@ class TestBoundedWithhold:
     def test_a_trigger_character_does_not_hold_the_rest_of_the_answer(
         self, dialect, parser, text
     ):
-        triggers = trigger_chars(parser.MARKERS, dialect_markers(dialect))
+        triggers = trigger_chars(parser.START_MARKERS, dialect_markers(dialect))
         control = defuse(text, triggers)
 
         fine = split_every_way(text)["fixed-1"]

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -942,6 +942,41 @@ class TestARealCallSurvivesTheStream:
             "get_weather"
         ), f"the sentence introducing the second call arrived first: {order}"
 
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_adjacent_calls_do_not_carry_a_later_sentence_in_front_of_them(
+        self, parser
+    ):
+        """The same order, when two of the calls are only a newline apart.
+
+        Every one of these chat templates puts a separator between parallel
+        calls, so `_markup_spans` merges that pair into one span -- and the
+        walk pairs one call per span, giving the last span whatever is left.
+        The merged span emits one call and the last emits two, so the second
+        call arrives behind a sentence the model wrote after it.
+
+        The test above cannot see it: with two calls the merge leaves nothing
+        over, and `order.index` reports the first occurrence, which does not
+        move when a later call does. This is the failure `_wrapper_edges` had
+        -- an extra span competing for a call -- with real calls doing the
+        merging instead of a spliced-in wrapper.
+        """
+        a = REAL_CALLS[parser.NAME]
+        b = naming_another_tool(parser.NAME)
+        middle = "Now let me also check Oslo."
+        engine = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
+        text = f"{a}\n{b}\n{middle}\n{a}"
+        events = engine.process(text) + engine.flush()
+        order: list[str] = []
+        for kind, data in events:
+            if kind == "tool_call_start":
+                order.append("call")
+            elif kind == "content" and data.strip() and order[-1:] != ["prose"]:
+                order.append("prose")
+        assert order == ["call", "call", "prose", "call"], (
+            f"{parser.NAME} moved a call across the sentence written after "
+            f"it: {order}"
+        )
+
 
 # Markers a format declares so the read-ahead will not split them, but which
 # do not hand the stream over: channel framing that wraps every answer. Only

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -636,8 +636,8 @@ REASONING_DIALECTS = [
 ]
 
 
-def split_reasoning_streaming(text: str, chunk: int, starts_thinking: bool):
-    f = ReasoningFilter(starts_thinking=starts_thinking)
+def split_reasoning_streaming(text: str, chunk: int, channel: ReasoningChannel):
+    f = channel.stream()
     segs = []
     for i in range(0, len(text), chunk):
         segs += f.process(text[i : i + chunk])
@@ -646,6 +646,91 @@ def split_reasoning_streaming(text: str, chunk: int, starts_thinking: bool):
         "".join(t for k, t in segs if k == "reasoning_content"),
         "".join(t for k, t in segs if k == "content"),
     )
+
+
+def every_way(dialect, text, chunks=(1, 3, 10_000)) -> list:
+    """One text read by `split` and by the stream at each chunk size.
+
+    Every entry has to hold, because these defects are the two readers
+    agreeing on the wrong answer -- comparing them to each other says nothing.
+    """
+    channel = ReasoningChannel(dialect=dialect, starts_open=False)
+    out = [channel.split(text)]
+    for chunk in chunks:
+        reasoning, content = split_reasoning_streaming(text, chunk, channel)
+        out.append((reasoning or None, content))
+    return out
+
+
+class TestWhatTheReaderDoesWithAChannelThePromptDidNotOpen:
+    """Agreement is not correctness, and these two are wrong *together*.
+
+    The class below holds the two delivery modes to the same answer, and can
+    see neither of these: both readers make the identical mistake, so parity
+    holds while the chain of thought goes out as the answer. Hence assertions
+    about what the split *is*, not that the two paths match.
+    """
+
+    @pytest.mark.parametrize(
+        "dialect", DIALECTS, ids=lambda d: d.think_end_marker.strip("<>|")
+    )
+    def test_a_leading_end_marker_is_the_model_declining_to_think(self, dialect):
+        """The shape MiniMax-M3 emits in about a quarter of multi-turn replies.
+
+        Its template renders every earlier no-thinking assistant turn as a bare
+        `</mm:think>` before the answer, so that is the trained form for "I did
+        not think this turn" -- measured on the live model, 0/10 single-turn
+        and 7/30 multi-turn. vLLM and SGLang both carry dedicated code for it
+        (`test_nonstreaming_drops_leading_end_tag`; `MiniMaxM3Detector`'s
+        docstring names the mechanism).
+
+        Not reasoning -- there is none -- but not the answer either: the marker
+        is this dialect's own literal and only the answer after it is the
+        model's words.
+        """
+        for got in every_way(dialect, f"{dialect.think_end_marker}The answer is 42."):
+            assert got == (None, "The answer is 42."), (
+                f"{dialect.think_end_marker} left in the answer, or the answer "
+                f"eaten: {got!r}"
+            )
+
+    @pytest.mark.parametrize(
+        "dialect", DIALECTS, ids=lambda d: d.think_end_marker.strip("<>|")
+    )
+    def test_but_one_further_in_is_the_model_writing_about_it(self, dialect):
+        """The mirror, and the reason the rule is positional.
+
+        Honouring an end marker wherever it appears is the guess `0858a50d4`
+        removed, and it removed it for cause: it made an ordinary answer wait
+        for a marker that was never coming, and it fed pre-marker text to the
+        tool-call sniffer. Neither applies at offset 0 -- there is no text
+        before it, and the decision is made within one marker's length, which
+        is already the scanner's bound. vLLM pins both halves the same way.
+        """
+        text = f"You close the block with {dialect.think_end_marker} normally."
+        for got in every_way(dialect, text):
+            assert got == (None, text), f"a quoted marker was consumed: {got!r}"
+
+    @pytest.mark.parametrize(
+        "dialect", DIALECTS, ids=lambda d: d.think_end_marker.strip("<>|")
+    )
+    def test_and_a_channel_the_model_opened_itself_is_still_read(self, dialect):
+        """One dialect did not do what the other two do.
+
+        A prompt that leaves thinking off does not stop the model opening a
+        channel of its own -- adaptive modes exist, and so does a model that
+        reopens one mid-answer. The two inline dialects read it; the channel
+        dialect returned `None` from its `starts_thinking` gate, and the tool
+        parser then stripped the framing and glued the chain of thought onto
+        the answer, on both paths, so nothing could see it.
+        """
+        open_m = dialect.output_open_marker or dialect.prompt_open_marker
+        text = f"{open_m}weighing it up{dialect.think_end_marker}The answer is 42."
+        for got in every_way(dialect, text):
+            assert got == ("weighing it up", "The answer is 42."), (
+                f"{dialect.think_end_marker}: a self-opened channel was not "
+                f"read: {got!r}"
+            )
 
 
 class TestTheReasoningSplitAgreesWithItself:
@@ -674,11 +759,28 @@ class TestTheReasoningSplitAgreesWithItself:
     CHUNKS = (1, 3, 11, 10_000)
 
     def _divergences(self, dialect, starts_thinking, field: int):
+        """Both readers through one `ReasoningChannel`, which is the point.
+
+        They used to be built here by hand -- `separate_reasoning(text,
+        starts_thinking=...)` and `ReasoningFilter(starts_thinking=...)`, both
+        without a dialect -- while the corpus was generated from the
+        *parametrised* dialect's markers. So for eight of the twelve cases
+        neither reader ever saw a marker, both returned the whole string as
+        one undifferentiated blob, and the two "agreed" about nothing.
+        Measured: a mutant that leaks an entire MiniMax chain of thought into
+        `content` passed the whole 3755-test suite.
+
+        `ReasoningChannel`'s own docstring names this failure -- "the
+        streaming filter got the second and never the first, and answered with
+        the union of every dialect's markers instead" -- so going through it
+        is not a workaround, it is the thing that was meant to be tested.
+        """
+        channel = ReasoningChannel(dialect=dialect, starts_open=starts_thinking)
         out = []
         for text in reasoning_shapes(dialect):
-            non = separate_reasoning(text, starts_thinking=starts_thinking)[field]
+            non = channel.split(text)[field]
             for chunk in self.CHUNKS:
-                got = split_reasoning_streaming(text, chunk, starts_thinking)[field]
+                got = split_reasoning_streaming(text, chunk, channel)[field]
                 if (non or "") != got:
                     out.append((text, chunk, non, got))
         return out

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -57,6 +57,7 @@ from atom.entrypoints.openai.reasoning import (
 from atom.entrypoints.openai.reasoning_dialects import DIALECTS, resolve_dialect
 from atom.entrypoints.openai.serving_anthropic import completes_a_tool_call
 from atom.entrypoints.openai.tool_parser import RegionParse, ToolCall, parse_tool_calls
+from atom.entrypoints.openai.tool_parser.deepseekv4_tool_parser import DsmlParser
 from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
@@ -67,6 +68,7 @@ from atom.entrypoints.openai.tool_parser.stream import (
 )
 from entrypoints.wire_corpus import (
     DECLARED_TOOLS,
+    PAYLOAD,
     REAL_CALLS,
     naming_another_tool,
     naming_something_undispatchable,
@@ -995,6 +997,190 @@ class TestNonStreamingAgreesWithStreaming:
         )
 
 
+def streamed_and_last(parser, text: str, *, suppress: bool = False):
+    """What reached the client before the last frame, and in it.
+
+    `(streamed, last frame, calls)` at four characters a chunk. Not `drive`
+    above, which answers a different question -- it folds both into one
+    `Seen.content` and runs the reasoning stage these cases do not need. Three
+    copies of this lived in the classes below before it was one.
+    """
+    engine = ToolCallStreamParser(
+        tools=DECLARED_TOOLS, parser_cls=parser, suppress_calls=suppress
+    )
+    early, last, calls = [], [], 0
+    for i in range(0, len(text), 4):
+        for kind, data in engine.process(text[i : i + 4]):
+            if kind == "content":
+                early.append(data)
+            elif kind == "tool_call_args":
+                calls += 1
+    for kind, data in engine.flush():
+        if kind == "content":
+            last.append(data)
+        elif kind == "tool_call_args":
+            calls += 1
+    return "".join(early), "".join(last), calls
+
+
+class TestNothingKnownToBeOutsideACallIsBuffered:
+    """The goal, stated once: bytes the engine can tell are outside a
+    (start, end) pair reach the client while the model is still writing.
+
+    Three ways to be outside one, and the engine has to know all three:
+
+    * before any start marker -- `MarkerScanner`, bounded and asserted there;
+    * after the pair closed -- this class;
+    * a start marker that will never pair -- an answer quoting its own
+      opener, which `TestARequestThatForbadeCallsDoesNotWaitForOne` covers.
+
+    The middle one was missing for five of six formats, and it is the
+    ordinary agentic shape rather than an edge case: call a tool, explain the
+    result. Measured before the fix, 0 of 397 characters of that explanation
+    streamed -- the whole of it arrived in the last frame.
+
+    What made it hard to see is that `region_end` asked for "a literal that
+    cannot appear inside an argument value" and the only note about one said
+    the XML formats' `</tool_call>` is not such a literal. True, and about the
+    *wrapper*: every one of these grammars terminates a value on the call's
+    *own* closer, so that one can never sit inside a value. It is the safe
+    signal, and it was already declared.
+    """
+
+    TAIL: ClassVar[str] = "Here is what that returns, explained for the user. " * 6
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_every_format_says_what_ends_one_of_its_calls(self, parser):
+        """The declaration the rest of this rests on. A format that names no
+        closer can never be seen to close, so its answers wait for the stream
+        to end -- which is what four formats did while it went unnoticed."""
+        assert parser.CALL_SELF_CLOSERS, (
+            f"{parser.NAME} never says what ends one of its calls, so its "
+            "regions can only close at end of stream"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_the_answer_after_a_call_does_not_wait_for_the_last_frame(self, parser):
+        text = REAL_CALLS[parser.NAME] + " " + self.TAIL
+        early, last, calls = streamed_and_last(parser, text)
+        assert calls == 1, f"{parser.NAME} lost the call; this asserts nothing"
+        assert self.TAIL.strip() in early + last, "the explanation was dropped"
+        assert len(last) < len(self.TAIL) // 2, (
+            f"{parser.NAME} held {len(last)} of {len(self.TAIL)} characters "
+            "written after the call until the stream ended"
+        )
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_no_markup_is_released_to_get_there(self, parser):
+        text = REAL_CALLS[parser.NAME] + " " + self.TAIL
+        early, last, _calls = streamed_and_last(parser, text)
+        leaked = [m for m in parser.START_MARKERS if m in early + last]
+        assert not leaked, f"{parser.NAME} released its own wire tokens: {leaked}"
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    def test_and_a_value_holding_the_wrapper_closer_does_not_end_the_call(self, parser):
+        """Why the wrapper's closer is a trigger and never the answer. A model
+        writing `</tool_call>` inside a parameter must not have its call cut
+        there -- the region ends on the call's own closer, which the grammar
+        will not let a value hold."""
+        if not parser.CALL_CLOSERS:
+            pytest.skip(f"{parser.NAME}'s call is its own wrapper")
+        wrapper = parser.CALL_CLOSERS[0]
+        text = REAL_CALLS[parser.NAME].replace(PAYLOAD, PAYLOAD + wrapper + "TAIL")
+        early, last, calls = streamed_and_last(parser, text)
+        assert calls == 1, f"{parser.NAME} read {calls} calls where the model made 1"
+        leaked = [m for m in parser.START_MARKERS if m in early + last]
+        assert not leaked, f"{parser.NAME} released wire tokens: {leaked}"
+
+
+class TestAGiveUpProbeStaysReverted:
+    """A region that has produced nothing yet is still buffered, on purpose.
+
+    `stream.py`'s module comment says not to add a "give up after N bytes"
+    probe, because acceptance is not monotone in bytes arrived. One was added
+    anyway during this work -- bounded to `_PEEK_WINDOW`, gated to
+    `tool_choice: "none"`, and measured safe on all six formats -- and it
+    reintroduced the reverted failure on the one shape the corpus does not
+    carry: DSML's direct-JSON branch needs the whole object, so its real call
+    is invisible in the head and the region went out as text.
+
+    The corpus is generated from `render_call`, which renders one form per
+    format, so a format with several accepting branches is only covered on the
+    one it renders. This class carries the others by hand for that reason, and
+    says so.
+    """
+
+    #: DSML's two accepting branches that `render_call` does not render, in
+    #: the syntax the parser accepts -- read off `parse_region`, not off the
+    #: prose describing them. A payload past `_PEEK_WINDOW` is the point: the
+    #: direct-JSON branch needs the whole object, so the call is invisible to
+    #: any head-sized peek while being perfectly real.
+    BODY: ClassVar[str] = "x" * (4 * _PEEK_WINDOW)
+    UNRENDERED: ClassVar[dict[str, str]] = {
+        "wrapper-less": "<｜DSML｜tool_calls>"
+        f'<｜DSML｜parameter name="city">{BODY}</｜DSML｜parameter>'
+        "</｜DSML｜tool_calls>",
+        "direct-json": '<｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">'
+        f'{{"city": "{BODY}"}}'
+        "</｜DSML｜invoke></｜DSML｜tool_calls>",
+    }
+
+    @pytest.mark.parametrize("branch", sorted(UNRENDERED), ids=str)
+    def test_the_shape_is_one_the_format_accepts(self, branch):
+        """The positive control, and it is not ceremony: the first version of
+        this class invented both shapes from the paragraph describing them,
+        and DSML accepted neither -- so "the markup leaked" was just
+        unparseable text being released, and the class asserted nothing."""
+        _content, calls = parse_tool_calls(
+            self.UNRENDERED[branch], DECLARED_TOOLS, DsmlParser
+        )
+        assert calls, f"dsml does not accept the {branch} shape; fix the shape"
+
+    @pytest.mark.parametrize("branch", sorted(UNRENDERED), ids=str)
+    @pytest.mark.parametrize("suppress", [False, True], ids=["dispatch", "none"])
+    def test_a_call_longer_than_the_peek_window_is_not_released_as_text(
+        self, branch, suppress
+    ):
+        early, last, _calls = streamed_and_last(
+            DsmlParser, self.UNRENDERED[branch], suppress=suppress
+        )
+        leaked = [m for m in DsmlParser.START_MARKERS if m in early + last]
+        assert not leaked, (
+            f"dsml's {branch} call went out as text: {leaked}. A probe that "
+            "gives up on a region is reading 'does not parse yet' as 'never "
+            "will'; see the module comment in stream.py."
+        )
+
+
+class TestForbiddingCallsStillStripsTheMarkup:
+    """`tool_choice: "none"` suppresses dispatch, not reading.
+
+    The format is still parsed so the markup can be located and dropped; a
+    response that was nothing but a call therefore has empty content rather
+    than the model's raw wire tokens.
+    """
+
+    @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    @pytest.mark.parametrize(
+        "derive",
+        [
+            lambda n: REAL_CALLS[n],
+            truncated,
+            lambda n: "Sure. " + REAL_CALLS[n],
+        ],
+        ids=["complete", "truncated", "after-prose"],
+    )
+    def test_a_real_call_still_loses_its_markup(self, parser, derive):
+        """The peek must not mistake a call for prose. A truncated one counts:
+        it is what `max_tokens` leaves, and the gate exists to recover it."""
+        early, last, calls = streamed_and_last(
+            parser, derive(parser.NAME), suppress=True
+        )
+        assert calls == 0, "dispatch is what `tool_choice: none` suppresses"
+        leaked = [m for m in parser.START_MARKERS if m in early + last]
+        assert not leaked, f"{parser.NAME} put its own wire tokens in the answer"
+
+
 class TestBoundedWithhold:
     """Text must not be held back longer than a marker could justify."""
 
@@ -1151,10 +1337,11 @@ class TestARealCallSurvivesTheStream:
         ), f"the sentence introducing the second call arrived first: {order}"
 
     @pytest.mark.parametrize("parser", ALL_PARSERS, ids=lambda p: p.NAME)
+    @pytest.mark.parametrize("sep", ["\n", "", " "], ids=["newline", "none", "space"])
     def test_and_adjacent_calls_do_not_carry_a_later_sentence_in_front_of_them(
-        self, parser
+        self, parser, sep
     ):
-        """The same order, when two of the calls are only a newline apart.
+        """The same order, when two of the calls are only a separator apart.
 
         Every one of these chat templates puts a separator between parallel
         calls, so `_markup_spans` merges that pair into one span -- and the
@@ -1167,12 +1354,18 @@ class TestARealCallSurvivesTheStream:
         move when a later call does. This is the failure `_wrapper_edges` had
         -- an extra span competing for a call -- with real calls doing the
         merging instead of a spliced-in wrapper.
+
+        The separator is parametrised because the newline was hiding half of
+        it. `_markup_spans` joined on `start <= previous_stop`, so two calls
+        the model wrote with *nothing* between them still merged -- five of
+        six formats reordered, and no shape in the suite had a zero-length
+        gap to notice.
         """
         a = REAL_CALLS[parser.NAME]
         b = naming_another_tool(parser.NAME)
         middle = "Now let me also check Oslo."
         engine = ToolCallStreamParser(tools=DECLARED_TOOLS, parser_cls=parser)
-        text = f"{a}\n{b}\n{middle}\n{a}"
+        text = f"{a}{sep}{b}\n{middle}\n{a}"
         events = engine.process(text) + engine.flush()
         order: list[str] = []
         for kind, data in events:

--- a/tests/entrypoints/test_stream_marker_properties.py
+++ b/tests/entrypoints/test_stream_marker_properties.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Properties the streaming text pipeline must hold for every format it knows.
+
+Not a list of cases. The corpus is *generated* from the two production
+registries -- ``reasoning_dialects.DIALECTS`` and the tool-parser
+``_DETECT_ORDER`` -- crossed with a handful of text shapes built out of each
+entry's own declared markers. Registering a new model family or a new
+tool-call format therefore adds coverage by itself, and
+``test_every_registered_parser_declares_its_markers`` is what stops a new
+entry from joining the registry without the declaration the generation needs.
+
+Two properties, and they are not nested:
+
+`chunk-invariance` -- the same text split differently must produce the same
+    reasoning, the same content, the same tool events and the same finish
+    reason. Catches markers split across boundaries, buffers carried between
+    states, and a sniffer latching onto whatever it happened to see first.
+
+`bounded withhold` -- text must not be held back longer than a marker could
+    justify. Judged against the same text with its trigger characters
+    neutralised, because an absolute budget cannot tell a stall from the
+    reasoning channel legitimately withholding until its end marker arrives.
+
+The stall is *chunk-invariant* -- everything comes out at flush no matter how
+the input was split -- so the first property cannot see it and the second is
+not redundant. Both are needed.
+
+The pipeline modelled is `serving_chat.py:280-333`: reasoning filter first,
+its content segments into the tool parser, both flushed on the last chunk.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from atom.entrypoints.openai.reasoning import ReasoningFilter
+from atom.entrypoints.openai.reasoning_dialects import DIALECTS
+from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
+from atom.entrypoints.openai.tool_parser.registry import _DETECT_ORDER
+from atom.entrypoints.openai.tool_parser.stream import ToolCallStreamParser
+
+# Kimi is the terminal fallback and so is not in the detect order, but it is a
+# registered format with markers of its own.
+ALL_PARSERS = (*_DETECT_ORDER, KimiParser)
+
+# Slack allowed on top of the neutralised control before a hold counts as a
+# stall. One marker's worth, since that is the most a correct rule can need.
+SLACK = 40
+
+PROSE = "The comparison was inverted, so the branch never ran. "
+
+
+def dialect_markers(dialect) -> tuple[str, ...]:
+    return tuple(
+        m
+        for m in (
+            dialect.prompt_open_marker,
+            dialect.output_open_marker,
+            dialect.think_end_marker,
+        )
+        if m
+    )
+
+
+class Seen:
+    """Only what a client could observe."""
+
+    def __init__(self):
+        self.reasoning = ""
+        self.content = ""
+        self.events: list[str] = []
+        self.first_content_at: int | None = None
+
+    @property
+    def key(self):
+        finish = "tool_calls" if "tool_call_start" in self.events else "stop"
+        return (self.reasoning, self.content, tuple(self.events), finish)
+
+
+def drive(text: str, chunks: list[str]) -> Seen:
+    """Replay the serving loop over one chunking."""
+    rf, tp = ReasoningFilter(), ToolCallStreamParser()
+    seen = Seen()
+    consumed = 0
+
+    def take(kind: str, payload: str) -> None:
+        if kind == "reasoning_content":
+            seen.reasoning += payload
+        elif kind == "content":
+            if payload and seen.first_content_at is None:
+                seen.first_content_at = consumed
+            seen.content += payload
+        else:
+            seen.events.append(kind)
+
+    for i, chunk in enumerate(chunks):
+        consumed += len(chunk)
+        last = i == len(chunks) - 1
+        segments = rf.process(chunk)
+        if last:
+            segments.extend(rf.flush())
+        for field, seg in segments:
+            if field == "reasoning_content":
+                take(field, seg)
+            else:
+                for kind, data in tp.process(seg):
+                    take(kind, data)
+        if last:
+            for kind, data in tp.flush():
+                take(kind, data)
+    return seen
+
+
+def split_every_way(text: str) -> dict[str, list[str]]:
+    """One-shot, several fixed strides, and seeded random splits."""
+    ways = {"one-shot": [text]}
+    for n in (1, 2, 3, 7, 64):
+        ways[f"fixed-{n}"] = [text[i : i + n] for i in range(0, len(text), n)] or [""]
+    rng = random.Random(1234)
+    for r in range(2):
+        parts, i = [], 0
+        while i < len(text):
+            n = rng.randint(1, 17)
+            parts.append(text[i : i + n])
+            i += n
+        ways[f"random-{r}"] = parts or [""]
+    return ways
+
+
+def trigger_chars(*marker_groups) -> set[str]:
+    """The characters that can open any of these markers."""
+    return {m[0] for group in marker_groups for m in group if m}
+
+
+def defuse(text: str, triggers: set[str]) -> str:
+    """The same text with nothing in it that could begin a marker."""
+    for ch in triggers:
+        text = text.replace(ch, "‹")
+    return text
+
+
+def shapes(dialect, parser) -> dict[str, str]:
+    """Text shapes built from this pair's own markers.
+
+    Each is a sentence a model could plausibly emit and none of them is a tool
+    call: the point is text that merely *looks like* it might start one.
+    """
+    marks = parser.MARKERS
+    end = dialect.think_end_marker
+    # Every trigger character, dropped into ordinary prose without ever
+    # completing a marker -- `if (a < b)` and its equivalent for every format.
+    seeded = "".join(f"a {ch} b holds. " for ch in sorted(trigger_chars(marks)))
+    out = {
+        "trigger chars in ordinary prose": f"Here is the fix: {seeded}" + PROSE * 6,
+        # A whole marker, mid-sentence, quoted rather than used.
+        "a marker quoted inside the answer": (
+            f"The model writes {marks[0]} to open a call. " + PROSE * 4
+        ),
+        # The shape where reasoning mentions a tool and then declines to use it.
+        "a tool marker inside reasoning": (
+            f"I could call {marks[0]} but I will answer directly. "
+            + "Hmm. " * 8
+            + end
+            + "It is sunny in Paris."
+        ),
+    }
+    if dialect.output_open_marker:
+        out["reasoning the model opens itself"] = (
+            dialect.output_open_marker + PROSE * 3 + end + "The answer is 42."
+        )
+    return out
+
+
+def _pairs():
+    for dialect in DIALECTS:
+        for parser in ALL_PARSERS:
+            for shape_name, text in shapes(dialect, parser).items():
+                yield pytest.param(
+                    dialect,
+                    parser,
+                    text,
+                    id=f"{dialect.think_end_marker.strip('<>/|')}-{parser.NAME}-"
+                    f"{shape_name.replace(' ', '_')}",
+                )
+
+
+PAIRS = list(_pairs())
+
+# Shapes with no marker the pipeline is entitled to honour. Withholding in
+# these is never correct, which is what makes them the bounded-withhold
+# corpus; the reasoning-bearing shapes hold until their end marker by design.
+NOTHING_TO_HONOUR = (
+    "trigger chars in ordinary prose",
+    "a marker quoted inside the answer",
+)
+
+
+def _hold_pairs():
+    for dialect in DIALECTS:
+        for parser in ALL_PARSERS:
+            for shape_name, text in shapes(dialect, parser).items():
+                if shape_name not in NOTHING_TO_HONOUR:
+                    continue
+                yield pytest.param(
+                    dialect,
+                    parser,
+                    text,
+                    # Exactly the character the broken rule keys on, asked of
+                    # the generated text rather than of the marker set: a
+                    # format can carry '<' inside a marker that opens with
+                    # something else, and one that never emits '<' at all is
+                    # not affected and must not be marked as if it were.
+                    marks=pytest.mark.xfail(
+                        "<" in text,
+                        strict=True,
+                        reason="sniff_stream withholds on any '<' anywhere in a "
+                        "buffer it never clears, so one '<' in an ordinary answer "
+                        "holds every later byte to EOS. Conditional on '<' because "
+                        "a format whose markers open with something else -- "
+                        "MiniMax's ns_token opens with ']' -- is not affected, and "
+                        "strict so that fixing the rule fails here and forces the "
+                        "marker off.",
+                    ),
+                    id=f"{dialect.think_end_marker.strip('<>/|')}-{parser.NAME}-"
+                    f"{shape_name.replace(' ', '_')}",
+                )
+
+
+HOLD_PAIRS = list(_hold_pairs())
+
+
+class TestEveryFormatIsCovered:
+    """The generation's own preconditions. These are what make it extensible."""
+
+    def test_every_registered_parser_declares_its_markers(self):
+        """A new format joins the corpus by declaring, not by being written up.
+
+        Without this the generation below would silently produce nothing for a
+        parser that forgot `MARKERS`, and the format would look covered.
+        """
+        # Asked of the class's own `__dict__`, not of the attribute: a
+        # parser that subclasses another inherits its markers, so a missing
+        # declaration reads as present and the new format silently gets
+        # covered against the *parent's* markers. A registered format is a
+        # distinct thing on the wire and has to say so itself, even when the
+        # tuple would repeat.
+        undeclared = [
+            p.NAME for p in ALL_PARSERS if "MARKERS" not in vars(p) or not p.MARKERS
+        ]
+        assert not undeclared, f"registered tool parsers with no MARKERS: {undeclared}"
+
+    def test_every_dialect_declares_an_end_marker(self):
+        missing = [d for d in DIALECTS if not d.think_end_marker]
+        assert not missing, "a dialect with no end marker cannot be streamed"
+
+    def test_the_corpus_grows_with_the_registries(self):
+        """Guards against the generator quietly degenerating to nothing."""
+        assert len(PAIRS) >= 3 * len(ALL_PARSERS), (
+            f"{len(PAIRS)} cases for {len(ALL_PARSERS)} parsers and "
+            f"{len(DIALECTS)} dialects -- the generator lost a dimension"
+        )
+
+
+class TestChunkInvariance:
+    """Where the token boundaries fall must not change what the client sees."""
+
+    @pytest.mark.parametrize("dialect, parser, text", PAIRS)
+    def test_the_same_text_split_differently_reads_the_same(
+        self, dialect, parser, text
+    ):
+        by_split = {
+            label: drive(text, chunks)
+            for label, chunks in split_every_way(text).items()
+        }
+        variants: dict = {}
+        for label, seen in by_split.items():
+            variants.setdefault(seen.key, []).append(label)
+        if len(variants) > 1:
+            report = "\n".join(
+                f"  {'/'.join(labels)}: reasoning={len(k[0])}ch "
+                f"content={len(k[1])}ch events={list(k[2])} finish={k[3]}"
+                for k, labels in variants.items()
+            )
+            pytest.fail(f"{len(variants)} different results for one text:\n{report}")
+
+
+class TestBoundedWithhold:
+    """Text must not be held back longer than a marker could justify."""
+
+    @pytest.mark.parametrize("dialect, parser, text", HOLD_PAIRS)
+    def test_a_trigger_character_does_not_hold_the_rest_of_the_answer(
+        self, dialect, parser, text
+    ):
+        triggers = trigger_chars(parser.MARKERS, dialect_markers(dialect))
+        control = defuse(text, triggers)
+
+        fine = split_every_way(text)["fixed-1"]
+        seen = drive(text, fine)
+        if not seen.content:
+            pytest.skip("no content channel in this shape; nothing to hold back")
+
+        ctl = drive(control, split_every_way(control)["fixed-1"])
+        held = seen.first_content_at or len(text)
+        baseline = ctl.first_content_at or len(control)
+        assert held - baseline <= SLACK, (
+            f"first content byte at input offset {held}/{len(text)}, against "
+            f"{baseline} for the same text with {sorted(triggers)} neutralised"
+        )

--- a/tests/entrypoints/test_stream_silence_watchdog.py
+++ b/tests/entrypoints/test_stream_silence_watchdog.py
@@ -22,10 +22,12 @@ entry, and a timestamp needs no background task to own.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 
 import pytest
 
+from atom.entrypoints.openai import api_server
 from atom.entrypoints.openai import streaming_dispatch as sd
 from atom.entrypoints.openai.streaming_dispatch import (
     FrameWait,
@@ -252,8 +254,6 @@ class TestTheEndpointUsesIt:
         import pathlib
         import re
 
-        from atom.entrypoints.openai import api_server
-
         src = pathlib.Path(api_server.__file__).read_text()
         total = src.count("StreamingResponse(")
         wrapped = len(re.findall(r"StreamingResponse\(\s*_client_stream\(", src))
@@ -269,8 +269,6 @@ class TestTheEndpointUsesIt:
         the source check passes on a wrapper that only logs."""
         import inspect
 
-        from atom.entrypoints.openai import api_server
-
         src = inspect.getsource(api_server._client_stream)
         assert "with FrameWait(request_id" in src
         body = src.split("with FrameWait(request_id", 1)[1]
@@ -282,8 +280,6 @@ class TestTheEndpointUsesIt:
         """Its name was the bug: it wrapped what wanted logging, not what
         wanted watching, so the Anthropic endpoint went without either."""
         import pathlib
-
-        from atom.entrypoints.openai import api_server
 
         src = pathlib.Path(api_server.__file__).read_text()
         assert "_logged_stream(" not in src
@@ -367,8 +363,6 @@ class TestQueueingIsNotSilence:
         import inspect
         import textwrap
 
-        from atom.entrypoints.openai import api_server
-
         tree = ast.parse(textwrap.dedent(inspect.getsource(api_server._client_stream)))
         waits = [
             n
@@ -381,3 +375,95 @@ class TestQueueingIsNotSilence:
         assert not isinstance(
             armed[0].value, ast.Constant
         ), "`armed` is a constant, so the first wait is timed like the rest"
+
+
+class TestRequestLoggingCannotBreakTheStream:
+    """`--request-log` is a diagnostic. It was also a way to lose the answer.
+
+    `serving_chat` coalesces finish + usage + `[DONE]` into one send -- a
+    deliberate saving of two socket writes per request at a wave boundary --
+    and the logger ran `json.loads` over that whole send. `Extra data:` came
+    out of the generator, so with the flag on, the last frame of every OpenAI
+    stream never reached the client and no `[DONE]` was written. Off by
+    default, which is why nothing noticed.
+
+    The Anthropic half is quieter: its frames put `event: NAME` on the line
+    above the data, so a `startswith("data: ")` test matched none of them and
+    that endpoint logged nothing at all.
+    """
+
+    COALESCED = (
+        'data: {"id":"x","choices":[{"finish_reason":"stop"}]}\n\n'
+        'data: {"usage":{"total_tokens":7}}\n\n'
+        "data: [DONE]\n\n"
+    )
+    ANTHROPIC = 'event: content_block_delta\ndata: {"type":"content_block_delta"}\n\n'
+
+    @staticmethod
+    def _logged(chunk):
+        """What `_log_sse` writes, without touching the module's real logger."""
+        written = []
+
+        class Recorder:
+            @staticmethod
+            def info(line):
+                written.append(json.loads(line))
+
+        original = api_server._request_logger
+        api_server._request_logger = Recorder
+        try:
+            api_server._log_sse(chunk, "req-1")
+        finally:
+            api_server._request_logger = original
+        return written
+
+    def test_a_coalesced_send_does_not_raise(self):
+        """The whole bug: this used to come out of the generator."""
+        self._logged(self.COALESCED)
+
+    def test_every_frame_in_it_is_logged(self):
+        kinds = [e["type"] for e in self._logged(self.COALESCED)]
+        assert kinds == ["stream_chunk", "stream_chunk", "stream_done"], kinds
+
+    def test_an_anthropic_frame_is_logged(self):
+        events = self._logged(self.ANTHROPIC)
+        assert [e["type"] for e in events] == ["stream_chunk"]
+        assert events[0]["data"]["type"] == "content_block_delta"
+
+    def test_an_unparsable_payload_is_kept_rather_than_raised(self):
+        events = self._logged("data: {not json\n\n")
+        assert [e["type"] for e in events] == ["stream_chunk_unparsed"]
+        assert events[0]["data"] == "{not json"
+
+    def test_logging_off_writes_nothing_and_still_does_not_raise(self):
+        original = api_server._request_logger
+        api_server._request_logger = None
+        try:
+            api_server._log_sse(self.COALESCED, "req-1")
+        finally:
+            api_server._request_logger = original
+
+    def test_the_client_still_receives_every_frame(self):
+        """Logging is a side effect; `_client_stream` must yield regardless."""
+        written = []
+
+        class Recorder:
+            @staticmethod
+            def info(line):
+                written.append(line)
+
+        async def source():
+            yield "data: {}\n\n"
+            yield self.COALESCED
+
+        async def collect():
+            return [c async for c in api_server._client_stream(source(), "req-1")]
+
+        original = api_server._request_logger
+        api_server._request_logger = Recorder
+        try:
+            out = asyncio.run(collect())
+        finally:
+            api_server._request_logger = original
+        assert "".join(out).endswith("data: [DONE]\n\n")
+        assert len(written) == 4

--- a/tests/entrypoints/test_stream_silence_watchdog.py
+++ b/tests/entrypoints/test_stream_silence_watchdog.py
@@ -45,15 +45,19 @@ async def frames(source, request_id: str = "req"):
 
     Kept here rather than importing the endpoint's copy: that one also does
     request logging and lives in a module that pulls in the engine. What is
-    under test is the timing, and this is the timing verbatim.
+    under test is the timing, and this is the timing verbatim -- including
+    `armed`, without which every scenario below would pass while the endpoint
+    timed the queue.
     """
     it = source.__aiter__()
+    delivered = False
     while True:
-        with FrameWait(request_id):
+        with FrameWait(request_id, armed=delivered):
             try:
                 chunk = await it.__anext__()
             except StopAsyncIteration:
                 return
+        delivered = True
         yield chunk
 
 
@@ -268,8 +272,8 @@ class TestTheEndpointUsesIt:
         from atom.entrypoints.openai import api_server
 
         src = inspect.getsource(api_server._client_stream)
-        assert "with FrameWait(request_id):" in src
-        body = src.split("with FrameWait(request_id):", 1)[1]
+        assert "with FrameWait(request_id" in src
+        body = src.split("with FrameWait(request_id", 1)[1]
         assert (
             "__anext__()" in body.split("yield")[0]
         ), "the watch does not cover the await that produces the next frame"
@@ -283,3 +287,97 @@ class TestTheEndpointUsesIt:
 
         src = pathlib.Path(api_server.__file__).read_text()
         assert "_logged_stream(" not in src
+
+
+class TestQueueingIsNotSilence:
+    """The wait for the *first* frame is admission, queueing and prefill.
+
+    Every response generator awaits the collector before yielding anything, so
+    timing that wait puts queue depth on the gauge -- which
+    `atom:requests_waiting` already reports -- and, past the threshold, logs a
+    line per admitted request blaming the marker read-ahead. Moving the watch
+    out to the frame did not remove this by itself; the docstring said it did.
+    """
+
+    def test_a_queued_request_reads_as_no_silence(self):
+        gate = asyncio.Event()
+
+        async def slow_to_start():
+            await gate.wait()  # admission + prefill
+            yield "data: first\n\n"
+
+        async def scenario():
+            out = frames(slow_to_start())
+            task = asyncio.create_task(out.__anext__())
+            await _let_the_loop_run()
+            await asyncio.sleep(0.02)
+            queued = longest_silence_seconds()
+            gate.set()
+            await task
+            return queued
+
+        assert asyncio.run(scenario()) == 0.0
+
+    def test_a_slow_first_frame_is_not_logged_however_long(self, caplog, monkeypatch):
+        monkeypatch.setattr(sd, "SILENCE_LOG_SECONDS", 0.01)
+
+        async def slow_to_start():
+            await asyncio.sleep(0.03)
+            yield "data: first\n\n"
+
+        async def scenario():
+            out = frames(slow_to_start(), "queued-req")
+            await out.__anext__()
+
+        with caplog.at_level(logging.WARNING, logger="atom"):
+            asyncio.run(scenario())
+        assert not [r for r in caplog.records if "sent the client" in r.message]
+
+    def test_the_gap_after_the_first_frame_is_still_seen(self):
+        """The other half: disarming one wait must not disarm the rest."""
+        gate = asyncio.Event()
+
+        async def stalls_after_one():
+            yield "data: first\n\n"
+            await gate.wait()
+            yield "data: second\n\n"
+
+        async def scenario():
+            out = frames(stalls_after_one())
+            await out.__anext__()
+            task = asyncio.create_task(out.__anext__())
+            await _let_the_loop_run()
+            await asyncio.sleep(0.02)
+            seen = longest_silence_seconds()
+            gate.set()
+            await task
+            return seen
+
+        assert asyncio.run(scenario()) >= 0.02
+
+    def test_the_endpoint_disarms_the_first_wait(self):
+        """Its body is unreachable from a unit test; this reads the source.
+
+        By AST, and for the *shape*: `armed` must be a variable, not a
+        constant. `assert "armed=" in src` passed with `armed=True`, which is
+        the bug -- and the harness above is a local copy of this loop, so
+        mutating the endpoint could not reach it either.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from atom.entrypoints.openai import api_server
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(api_server._client_stream)))
+        waits = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and getattr(n.func, "id", "") == "FrameWait"
+        ]
+        assert len(waits) == 1, f"{len(waits)} FrameWait calls; expected one"
+        armed = [k for k in waits[0].keywords if k.arg == "armed"]
+        assert armed, "the endpoint arms every wait, the queue included"
+        assert not isinstance(
+            armed[0].value, ast.Constant
+        ), "`armed` is a constant, so the first wait is timed like the rest"

--- a/tests/entrypoints/test_stream_silence_watchdog.py
+++ b/tests/entrypoints/test_stream_silence_watchdog.py
@@ -5,11 +5,16 @@
 
 The symptom this whole line of work started from was ten minutes of silence on
 a streaming request with every metric looking healthy. The cause is fixed, and
-the next one will be different — so the observation is worth having on its own:
-`StreamOutputCollector.get` is the single point where any stream waits, so the
-age of the oldest wait is the age of the most starved response.
+the next one will be different — so the observation is worth having on its own.
 
-Deliberately not `asyncio.wait_for`. This runs once per token per stream;
+Measured around the *yield to the client*, not around the collector's await.
+The collector is the one place a stream waits for the engine, but two stages
+sit between it and the socket — the reasoning channel's read-ahead and the
+tool-call format's — and while either withholds, the collector keeps returning
+on schedule. Watching there reported zero for exactly the stall it was built
+to catch; `TestWithholdingIsSilenceToo` is that case.
+
+Deliberately not `asyncio.wait_for`. This runs once per frame per stream;
 arming a timer measured 1.38 us against 0.07 us for a timestamp and a dict
 entry, and a timestamp needs no background task to own.
 """
@@ -23,7 +28,7 @@ import pytest
 
 from atom.entrypoints.openai import streaming_dispatch as sd
 from atom.entrypoints.openai.streaming_dispatch import (
-    StreamOutputCollector,
+    FrameWait,
     longest_silence_seconds,
 )
 
@@ -35,22 +40,25 @@ def _clean_registry():
     sd._WAITING_SINCE.clear()
 
 
-async def _already_streaming() -> StreamOutputCollector:
-    """A collector that has delivered once.
+async def frames(source, request_id: str = "req"):
+    """The shape `_client_stream` wraps a response generator in.
 
-    The watchdog measures silence *between* chunks. A stream that has not
-    delivered yet is queued, not stalled -- admission and prefill have not
-    happened -- so every scenario about stalling has to get past that first
-    chunk before it means anything.
+    Kept here rather than importing the endpoint's copy: that one also does
+    request logging and lives in a module that pulls in the engine. What is
+    under test is the timing, and this is the timing verbatim.
     """
-    collector = StreamOutputCollector()
-    collector.put_nowait({"text": "first"})
-    await collector.get()
-    return collector
+    it = source.__aiter__()
+    while True:
+        with FrameWait(request_id):
+            try:
+                chunk = await it.__anext__()
+            except StopAsyncIteration:
+                return
+        yield chunk
 
 
 async def _let_the_loop_run():
-    """Yield control so a pending `get()` reaches its await."""
+    """Yield control so a pending await is actually reached."""
     for _ in range(3):
         await asyncio.sleep(0)
 
@@ -59,40 +67,59 @@ class TestWhileItIsHappening:
     def test_nothing_waiting_reads_as_no_silence(self):
         assert longest_silence_seconds() == 0.0
 
-    def test_a_waiting_stream_is_visible(self):
+    def test_a_stream_waiting_for_its_next_frame_is_visible(self):
+        gate = asyncio.Event()
+
+        async def source():
+            yield "data: one\n\n"
+            await gate.wait()
+            yield "data: two\n\n"
+
         async def scenario():
-            collector = await _already_streaming()
-            task = asyncio.create_task(collector.get())
+            out = frames(source())
+            await out.__anext__()
+            task = asyncio.create_task(out.__anext__())
             await _let_the_loop_run()
             seen = longest_silence_seconds()
-            collector.put_nowait({"text": "hi"})
+            gate.set()
             await task
             return seen
 
         assert asyncio.run(scenario()) > 0.0
 
-    def test_it_clears_once_the_chunk_arrives(self):
+    def test_it_clears_once_the_frame_goes_out(self):
+        async def source():
+            yield "data: one\n\n"
+            yield "data: two\n\n"
+
         async def scenario():
-            collector = StreamOutputCollector()
-            task = asyncio.create_task(collector.get())
-            await _let_the_loop_run()
-            collector.put_nowait({"text": "hi"})
-            await task
+            out = frames(source())
+            await out.__anext__()
+            await out.__anext__()
             return longest_silence_seconds()
 
         assert asyncio.run(scenario()) == 0.0
 
     def test_the_oldest_wait_is_the_one_reported(self):
+        g1, g2 = asyncio.Event(), asyncio.Event()
+
+        async def source(gate):
+            yield "data: first\n\n"
+            await gate.wait()
+            yield "data: second\n\n"
+
         async def scenario():
-            old, new = await _already_streaming(), await _already_streaming()
-            t1 = asyncio.create_task(old.get())
+            a, b = frames(source(g1), "a"), frames(source(g2), "b")
+            await a.__anext__()
+            await b.__anext__()
+            t1 = asyncio.create_task(a.__anext__())
             await _let_the_loop_run()
             await asyncio.sleep(0.02)
-            t2 = asyncio.create_task(new.get())
+            t2 = asyncio.create_task(b.__anext__())
             await _let_the_loop_run()
             seen = longest_silence_seconds()
-            old.put_nowait({"a": 1})
-            new.put_nowait({"b": 2})
+            g1.set()
+            g2.set()
             await t1
             await t2
             return seen
@@ -106,9 +133,14 @@ class TestWhileItIsHappening:
         signal is useless from then on.
         """
 
+        async def source():
+            yield "data: one\n\n"
+            await asyncio.Event().wait()
+
         async def scenario():
-            collector = StreamOutputCollector()
-            task = asyncio.create_task(collector.get())
+            out = frames(source())
+            await out.__anext__()
+            task = asyncio.create_task(out.__anext__())
             await _let_the_loop_run()
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -117,44 +149,54 @@ class TestWhileItIsHappening:
 
         assert asyncio.run(scenario()) == 0.0
 
+    def test_a_finished_stream_leaves_nothing_behind(self):
+        """`StopAsyncIteration` unwinds through the watch like any exit."""
 
-class TestQueueingIsNotAStall:
-    """A stream that has not started is waiting its turn, not wedged.
+        async def source():
+            yield "data: only\n\n"
 
-    Both SSE generators await `get()` as the first statement of their loop,
-    before admission and prefill. At the concurrency this server is
-    benchmarked at, that first wait routinely outlives the silence threshold,
-    so counting it would log a line per backlogged request onto the event loop
-    and turn the gauge into a queue-depth proxy that `atom:requests_waiting`
-    already provides.
-    """
-
-    def test_the_first_wait_is_not_silence(self):
         async def scenario():
-            collector = StreamOutputCollector()
-            task = asyncio.create_task(collector.get())
-            await _let_the_loop_run()
-            seen = longest_silence_seconds()
-            collector.put_nowait({"text": "first"})
-            await task
-            return seen
+            out = frames(source())
+            await out.__anext__()
+            with pytest.raises(StopAsyncIteration):
+                await out.__anext__()
+            return longest_silence_seconds()
 
         assert asyncio.run(scenario()) == 0.0
 
-    def test_the_first_wait_is_not_logged_however_long(self, caplog, monkeypatch):
-        monkeypatch.setattr(sd, "SILENCE_LOG_SECONDS", 0.01)
+
+class TestWithholdingIsSilenceToo:
+    """The case that moved the measurement out of the collector.
+
+    A response whose tokens are arriving on time but are being held by a
+    marker read-ahead sends the client nothing. Watched at the collector, that
+    stream looks perfectly healthy -- it wakes on every token -- and the gauge
+    reads zero. Watched at the yield, it is what it is: silence.
+    """
+
+    def test_a_generator_that_consumes_without_yielding_reads_as_silent(self):
+        released = asyncio.Event()
+
+        async def withholding_source():
+            """Tokens arrive; nothing is released until the marker resolves."""
+            yield "data: start\n\n"
+            for _ in range(20):
+                await asyncio.sleep(0)  # a token, consumed and held
+            await released.wait()
+            yield "data: everything at once\n\n"
 
         async def scenario():
-            collector = StreamOutputCollector()
-            task = asyncio.create_task(collector.get())
+            out = frames(withholding_source())
+            await out.__anext__()
+            task = asyncio.create_task(out.__anext__())
             await _let_the_loop_run()
-            await asyncio.sleep(0.03)
-            collector.put_nowait({"text": "first"})
+            await asyncio.sleep(0.02)
+            seen = longest_silence_seconds()
+            released.set()
             await task
+            return seen
 
-        with caplog.at_level(logging.WARNING, logger="atom"):
-            asyncio.run(scenario())
-        assert not [r for r in caplog.records if "delivered nothing" in r.message]
+        assert asyncio.run(scenario()) >= 0.02
 
 
 class TestAfterItRecovers:
@@ -162,28 +204,82 @@ class TestAfterItRecovers:
         """The gauge cannot see a stall that is already over; this can."""
         monkeypatch.setattr(sd, "SILENCE_LOG_SECONDS", 0.01)
 
-        async def scenario():
-            collector = await _already_streaming()
-            task = asyncio.create_task(collector.get())
-            await _let_the_loop_run()
+        async def source():
+            yield "data: one\n\n"
             await asyncio.sleep(0.02)
-            collector.put_nowait({"text": "late"})
-            await task
+            yield "data: late\n\n"
+
+        async def scenario():
+            out = frames(source(), "req-42")
+            await out.__anext__()
+            await out.__anext__()
 
         with caplog.at_level(logging.WARNING, logger="atom"):
             asyncio.run(scenario())
-        assert any("delivered nothing for" in r.message for r in caplog.records)
+        hits = [r for r in caplog.records if "sent the client nothing" in r.message]
+        assert hits and "req-42" in hits[0].message
 
     def test_an_ordinary_wait_says_nothing(self, caplog):
-        """Every token goes through here, so the quiet case must stay quiet."""
+        """Every frame goes through here, so the quiet case must stay quiet."""
+
+        async def source():
+            yield "data: one\n\n"
+            yield "data: two\n\n"
 
         async def scenario():
-            collector = StreamOutputCollector()
-            task = asyncio.create_task(collector.get())
-            await _let_the_loop_run()
-            collector.put_nowait({"text": "prompt"})
-            await task
+            out = frames(source())
+            await out.__anext__()
+            await out.__anext__()
 
         with caplog.at_level(logging.WARNING, logger="atom"):
             asyncio.run(scenario())
-        assert not [r for r in caplog.records if "delivered nothing" in r.message]
+        assert not [r for r in caplog.records if "sent the client" in r.message]
+
+
+class TestTheEndpointUsesIt:
+    """Three streaming responses, and the watchdog has to wrap all three.
+
+    It wrapped two: `_logged_stream` was a logging helper the Anthropic
+    endpoint never called. A gauge with an endpoint-shaped hole is worse than
+    no gauge, because the zero it reports reads as an answer.
+    """
+
+    def test_every_streaming_response_is_wrapped(self):
+        import pathlib
+        import re
+
+        from atom.entrypoints.openai import api_server
+
+        src = pathlib.Path(api_server.__file__).read_text()
+        total = src.count("StreamingResponse(")
+        wrapped = len(re.findall(r"StreamingResponse\(\s*_client_stream\(", src))
+        assert total == 3, f"the endpoint count changed ({total}); check this test"
+        assert wrapped == total, (
+            f"{total - wrapped} of {total} StreamingResponse calls are served "
+            "from an unwrapped generator"
+        )
+
+    def test_the_wrapper_actually_times_the_frame(self):
+        """`_client_stream` wrapping every response is half of it; the other
+        half is that the wrapper opens a watch around the await. Without this
+        the source check passes on a wrapper that only logs."""
+        import inspect
+
+        from atom.entrypoints.openai import api_server
+
+        src = inspect.getsource(api_server._client_stream)
+        assert "with FrameWait(request_id):" in src
+        body = src.split("with FrameWait(request_id):", 1)[1]
+        assert (
+            "__anext__()" in body.split("yield")[0]
+        ), "the watch does not cover the await that produces the next frame"
+
+    def test_the_logging_only_wrapper_is_gone(self):
+        """Its name was the bug: it wrapped what wanted logging, not what
+        wanted watching, so the Anthropic endpoint went without either."""
+        import pathlib
+
+        from atom.entrypoints.openai import api_server
+
+        src = pathlib.Path(api_server.__file__).read_text()
+        assert "_logged_stream(" not in src

--- a/tests/entrypoints/test_stream_silence_watchdog.py
+++ b/tests/entrypoints/test_stream_silence_watchdog.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""A stalled response has to be visible while it is stalled.
+
+The symptom this whole line of work started from was ten minutes of silence on
+a streaming request with every metric looking healthy. The cause is fixed, and
+the next one will be different — so the observation is worth having on its own:
+`StreamOutputCollector.get` is the single point where any stream waits, so the
+age of the oldest wait is the age of the most starved response.
+
+Deliberately not `asyncio.wait_for`. This runs once per token per stream;
+arming a timer measured 1.38 us against 0.07 us for a timestamp and a dict
+entry, and a timestamp needs no background task to own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from atom.entrypoints.openai import streaming_dispatch as sd
+from atom.entrypoints.openai.streaming_dispatch import (
+    StreamOutputCollector,
+    longest_silence_seconds,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    sd._WAITING_SINCE.clear()
+    yield
+    sd._WAITING_SINCE.clear()
+
+
+async def _let_the_loop_run():
+    """Yield control so a pending `get()` reaches its await."""
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
+class TestWhileItIsHappening:
+    def test_nothing_waiting_reads_as_no_silence(self):
+        assert longest_silence_seconds() == 0.0
+
+    def test_a_waiting_stream_is_visible(self):
+        async def scenario():
+            collector = StreamOutputCollector()
+            task = asyncio.create_task(collector.get())
+            await _let_the_loop_run()
+            seen = longest_silence_seconds()
+            collector.put_nowait({"text": "hi"})
+            await task
+            return seen
+
+        assert asyncio.run(scenario()) > 0.0
+
+    def test_it_clears_once_the_chunk_arrives(self):
+        async def scenario():
+            collector = StreamOutputCollector()
+            task = asyncio.create_task(collector.get())
+            await _let_the_loop_run()
+            collector.put_nowait({"text": "hi"})
+            await task
+            return longest_silence_seconds()
+
+        assert asyncio.run(scenario()) == 0.0
+
+    def test_the_oldest_wait_is_the_one_reported(self):
+        async def scenario():
+            old, new = StreamOutputCollector(), StreamOutputCollector()
+            t1 = asyncio.create_task(old.get())
+            await _let_the_loop_run()
+            await asyncio.sleep(0.02)
+            t2 = asyncio.create_task(new.get())
+            await _let_the_loop_run()
+            seen = longest_silence_seconds()
+            old.put_nowait({"a": 1})
+            new.put_nowait({"b": 2})
+            await t1
+            await t2
+            return seen
+
+        assert asyncio.run(scenario()) >= 0.02
+
+    def test_a_cancelled_stream_does_not_linger_in_the_registry(self):
+        """A client that disconnects unwinds the generator; the entry must go.
+
+        Otherwise one abandoned request pins the gauge high forever and the
+        signal is useless from then on.
+        """
+
+        async def scenario():
+            collector = StreamOutputCollector()
+            task = asyncio.create_task(collector.get())
+            await _let_the_loop_run()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            return longest_silence_seconds()
+
+        assert asyncio.run(scenario()) == 0.0
+
+
+class TestAfterItRecovers:
+    def test_a_long_silence_is_logged_when_it_ends(self, caplog, monkeypatch):
+        """The gauge cannot see a stall that is already over; this can."""
+        monkeypatch.setattr(sd, "SILENCE_LOG_SECONDS", 0.01)
+
+        async def scenario():
+            collector = StreamOutputCollector()
+            task = asyncio.create_task(collector.get())
+            await _let_the_loop_run()
+            await asyncio.sleep(0.02)
+            collector.put_nowait({"text": "late"})
+            await task
+
+        with caplog.at_level(logging.WARNING, logger="atom"):
+            asyncio.run(scenario())
+        assert any("delivered nothing for" in r.message for r in caplog.records)
+
+    def test_an_ordinary_wait_says_nothing(self, caplog):
+        """Every token goes through here, so the quiet case must stay quiet."""
+
+        async def scenario():
+            collector = StreamOutputCollector()
+            task = asyncio.create_task(collector.get())
+            await _let_the_loop_run()
+            collector.put_nowait({"text": "prompt"})
+            await task
+
+        with caplog.at_level(logging.WARNING, logger="atom"):
+            asyncio.run(scenario())
+        assert not [r for r in caplog.records if "delivered nothing" in r.message]

--- a/tests/entrypoints/test_stream_silence_watchdog.py
+++ b/tests/entrypoints/test_stream_silence_watchdog.py
@@ -30,7 +30,6 @@ import pytest
 from atom.entrypoints.openai import api_server
 from atom.entrypoints.openai import streaming_dispatch as sd
 from atom.entrypoints.openai.streaming_dispatch import (
-    FrameWait,
     longest_silence_seconds,
 )
 
@@ -42,25 +41,16 @@ def _clean_registry():
     sd._WAITING_SINCE.clear()
 
 
-async def frames(source, request_id: str = "req"):
-    """The shape `_client_stream` wraps a response generator in.
+def frames(source, request_id: str = "req"):
+    """The shipped wrapper, not a copy of it.
 
-    Kept here rather than importing the endpoint's copy: that one also does
-    request logging and lives in a module that pulls in the engine. What is
-    under test is the timing, and this is the timing verbatim -- including
-    `armed`, without which every scenario below would pass while the endpoint
-    timed the queue.
+    This was a hand-written reimplementation, justified by the endpoint module
+    pulling in the engine -- which this file already imports anyway. Measured:
+    hoisting `delivered = True` above the `with` makes the real endpoint
+    report 0.02 s of phantom silence for a merely queued request, and every
+    test here stayed green.
     """
-    it = source.__aiter__()
-    delivered = False
-    while True:
-        with FrameWait(request_id, armed=delivered):
-            try:
-                chunk = await it.__anext__()
-            except StopAsyncIteration:
-                return
-        delivered = True
-        yield chunk
+    return api_server._client_stream(source, request_id)
 
 
 async def _let_the_loop_run():

--- a/tests/entrypoints/test_stream_silence_watchdog.py
+++ b/tests/entrypoints/test_stream_silence_watchdog.py
@@ -35,6 +35,20 @@ def _clean_registry():
     sd._WAITING_SINCE.clear()
 
 
+async def _already_streaming() -> StreamOutputCollector:
+    """A collector that has delivered once.
+
+    The watchdog measures silence *between* chunks. A stream that has not
+    delivered yet is queued, not stalled -- admission and prefill have not
+    happened -- so every scenario about stalling has to get past that first
+    chunk before it means anything.
+    """
+    collector = StreamOutputCollector()
+    collector.put_nowait({"text": "first"})
+    await collector.get()
+    return collector
+
+
 async def _let_the_loop_run():
     """Yield control so a pending `get()` reaches its await."""
     for _ in range(3):
@@ -47,7 +61,7 @@ class TestWhileItIsHappening:
 
     def test_a_waiting_stream_is_visible(self):
         async def scenario():
-            collector = StreamOutputCollector()
+            collector = await _already_streaming()
             task = asyncio.create_task(collector.get())
             await _let_the_loop_run()
             seen = longest_silence_seconds()
@@ -70,7 +84,7 @@ class TestWhileItIsHappening:
 
     def test_the_oldest_wait_is_the_one_reported(self):
         async def scenario():
-            old, new = StreamOutputCollector(), StreamOutputCollector()
+            old, new = await _already_streaming(), await _already_streaming()
             t1 = asyncio.create_task(old.get())
             await _let_the_loop_run()
             await asyncio.sleep(0.02)
@@ -104,13 +118,52 @@ class TestWhileItIsHappening:
         assert asyncio.run(scenario()) == 0.0
 
 
+class TestQueueingIsNotAStall:
+    """A stream that has not started is waiting its turn, not wedged.
+
+    Both SSE generators await `get()` as the first statement of their loop,
+    before admission and prefill. At the concurrency this server is
+    benchmarked at, that first wait routinely outlives the silence threshold,
+    so counting it would log a line per backlogged request onto the event loop
+    and turn the gauge into a queue-depth proxy that `atom:requests_waiting`
+    already provides.
+    """
+
+    def test_the_first_wait_is_not_silence(self):
+        async def scenario():
+            collector = StreamOutputCollector()
+            task = asyncio.create_task(collector.get())
+            await _let_the_loop_run()
+            seen = longest_silence_seconds()
+            collector.put_nowait({"text": "first"})
+            await task
+            return seen
+
+        assert asyncio.run(scenario()) == 0.0
+
+    def test_the_first_wait_is_not_logged_however_long(self, caplog, monkeypatch):
+        monkeypatch.setattr(sd, "SILENCE_LOG_SECONDS", 0.01)
+
+        async def scenario():
+            collector = StreamOutputCollector()
+            task = asyncio.create_task(collector.get())
+            await _let_the_loop_run()
+            await asyncio.sleep(0.03)
+            collector.put_nowait({"text": "first"})
+            await task
+
+        with caplog.at_level(logging.WARNING, logger="atom"):
+            asyncio.run(scenario())
+        assert not [r for r in caplog.records if "delivered nothing" in r.message]
+
+
 class TestAfterItRecovers:
     def test_a_long_silence_is_logged_when_it_ends(self, caplog, monkeypatch):
         """The gauge cannot see a stall that is already over; this can."""
         monkeypatch.setattr(sd, "SILENCE_LOG_SECONDS", 0.01)
 
         async def scenario():
-            collector = StreamOutputCollector()
+            collector = await _already_streaming()
             task = asyncio.create_task(collector.get())
             await _let_the_loop_run()
             await asyncio.sleep(0.02)

--- a/tests/entrypoints/test_tool_call_resolution.py
+++ b/tests/entrypoints/test_tool_call_resolution.py
@@ -26,6 +26,7 @@ from atom.entrypoints.openai.tool_parser import registry
 from atom.entrypoints.openai.tool_parser.registry import (
     PARSERS_BY_NAME,
     parse_tool_calls,
+    resolve_from_prompt,
     resolve_tool_call_parser,
     validate_tool_call_parser,
 )
@@ -230,3 +231,73 @@ class TestTheMeshRouterStillGetsItsFlag:
             [*self.BASE, "--tool-call-parser", "glm"]
         )
         assert args.mesh_args[:2] == ["--port", "9000"]
+
+
+class TestGlmDoesNotClaimEveryTemplate:
+    """`<tool_call>` is not GLM's discriminator; `<arg_key>` is.
+
+    Detection now runs on a rendered chat template, where a Hermes-JSON model
+    shows the same `<tool_call>` tag and has no `<arg_key>` anywhere.
+    Accepting the tag alone bound every such model to GlmParser for the
+    process lifetime and logged it as a success -- /mnt/Qwen3-8B resolved to
+    `glm` while /data/Qwen3.5-27B resolved to `qwen`, one family, two answers.
+    GLM then produced no call (its name check rejects the JSON body) and the
+    whole region, tool call and following answer alike, arrived in one frame.
+    """
+
+    HERMES = (
+        "You may call tools. Emit:\n<tool_call>\n"
+        '{"name": <function-name>, "arguments": <args-json>}\n</tool_call>'
+    )
+    GLM = (
+        "You may call tools. Emit:\n<tool_call>NAME"
+        "<arg_key>k</arg_key><arg_value>v</arg_value></tool_call>"
+    )
+
+    def test_a_hermes_template_is_not_glm(self):
+        assert resolve_from_prompt(self.HERMES) is not PARSERS_BY_NAME["glm"]
+
+    def test_a_hermes_template_resolves_to_nothing(self):
+        """`None` is the honest answer: ATOM has no Hermes parser, so its
+        calls are delivered as text rather than swallowed by the wrong one."""
+        assert resolve_from_prompt(self.HERMES) is None
+
+    def test_a_real_glm_template_still_resolves(self):
+        assert resolve_from_prompt(self.GLM) is PARSERS_BY_NAME["glm"]
+
+
+class TestTheTwoVocabulariesCoexist:
+    """`--tool-call-parser` has two consumers that do not share a vocabulary.
+
+    The Rust router takes `json` / `python` / `xml` / `hermes`; ATOM's
+    resolver takes `dsml` / `glm` / `kimi` / `kimi_k3` / `minimax` / `qwen`.
+    Validating the flag against ATOM's set would have killed any existing
+    standalone deployment launched with a router name -- before the flag was
+    registered here at all, those passed straight through untouched.
+    """
+
+    BASE: ClassVar[list] = ["--model", "/x", "--port", "9000"]
+
+    def _parse(self, name):
+        return atomesh_server.parse_standalone_args(
+            [*self.BASE, "--tool-call-parser", name]
+        )
+
+    @pytest.mark.parametrize("name", ["json", "python", "xml", "hermes"])
+    def test_a_router_name_starts_and_reaches_the_router(self, name):
+        args = self._parse(name)
+        assert args.mesh_args[-2:] == ["--tool-call-parser", name]
+        assert (
+            args.engine_args.tool_call_parser is None
+        ), "a name ATOM does not know must leave ATOM reading the template"
+
+    @pytest.mark.parametrize("name", sorted(PARSERS_BY_NAME))
+    def test_an_atom_name_binds_atom_and_still_reaches_the_router(self, name):
+        args = self._parse(name)
+        assert args.engine_args.tool_call_parser == name
+        assert args.mesh_args[-2:] == ["--tool-call-parser", name]
+
+    def test_unset_forwards_nothing_and_binds_nothing(self):
+        args = atomesh_server.parse_standalone_args(self.BASE)
+        assert args.engine_args.tool_call_parser is None
+        assert "--tool-call-parser" not in args.mesh_args

--- a/tests/entrypoints/test_tool_call_resolution.py
+++ b/tests/entrypoints/test_tool_call_resolution.py
@@ -15,12 +15,21 @@ The rule under test is deliberately not a new table: it is the shipped
 
 from __future__ import annotations
 
+import ast
+import pathlib
+from typing import ClassVar
+
 import pytest
 
+from atom.entrypoints.atomesh import server as atomesh_server
+from atom.entrypoints.openai.tool_parser import registry
 from atom.entrypoints.openai.tool_parser.registry import (
     PARSERS_BY_NAME,
+    parse_tool_calls,
     resolve_tool_call_parser,
+    validate_tool_call_parser,
 )
+from atom.entrypoints.openai.tool_parser.stream import ToolCallStreamParser
 
 
 class _Tokenizer:
@@ -109,3 +118,115 @@ class TestFromTheTemplate:
         resolve_tool_call_parser(None, _Recording())
         assert seen.get("tools"), "the probe rendered without any tools"
         assert seen["tools"][0]["function"]["name"] == "get_weather"
+
+
+class TestUnresolvedMeansUnparsed:
+    """`None` is "do not parse", on both paths, and not "work it out".
+
+    The streaming facade already honoured it -- `ToolCallStreamParser` with no
+    format emits everything as content -- while the non-streaming path ran a
+    cascade over the *output*. So the same request was answered two ways, and
+    the way that guessed deleted text: gpt-oss and DeepSeek-R1 both resolve to
+    `None` on this box, and an answer of theirs quoting another format's
+    section token lost everything from the token onward.
+    """
+
+    QUOTES_A_MARKER = "The model emits <|tool_calls_section_begin|> then the calls."
+    QUOTES_ANOTHER = 'To call a tool you write <invoke name="get_weather"> and so on.'
+
+    @pytest.mark.parametrize("text", [QUOTES_A_MARKER, QUOTES_ANOTHER])
+    def test_nothing_is_parsed_and_nothing_is_lost(self, text):
+        assert parse_tool_calls(text, None, parser_cls=None) == (text, [])
+
+    @pytest.mark.parametrize("text", [QUOTES_A_MARKER, QUOTES_ANOTHER])
+    def test_the_streaming_path_agrees(self, text):
+        stream = ToolCallStreamParser(parser_cls=None)
+        events = []
+        for i in range(0, len(text), 5):
+            events += stream.process(text[i : i + 5])
+        events += stream.flush()
+        assert "".join(d for k, d in events if k == "content") == text
+        assert not [k for k, _ in events if k.startswith("tool_call_")]
+
+    def test_the_output_cascade_is_gone(self):
+        """A second place to ask is a second answer; there is one place now.
+
+        By AST, not by slicing the source: `PARSERS_BY_NAME` is built from
+        `_DETECT_ORDER` on the lines just below, and a text search for the
+        function "body" swept it up and failed on the wrong thing.
+        """
+        tree = ast.parse(pathlib.Path(registry.__file__).read_text())
+        walked = [
+            fn.name
+            for fn in ast.walk(tree)
+            if isinstance(fn, ast.FunctionDef)
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Name) and n.id == "_DETECT_ORDER"
+        ]
+        assert walked == ["resolve_from_prompt"], (
+            f"_DETECT_ORDER is consulted by {walked}; the prompt is the only "
+            "evidence it should be asked about"
+        )
+
+
+class TestABadNameIsCaughtBeforeTheWeightsLoad:
+    """`AtomStandaloneService` raises on an unknown name, and it is built once
+    the model is in memory -- so a typo cost a full load before saying so.
+    """
+
+    def test_a_known_name_resolves(self):
+        assert validate_tool_call_parser("glm") is PARSERS_BY_NAME["glm"]
+
+    @pytest.mark.parametrize("unset", [None, "", "auto"])
+    def test_unset_defers_to_the_template(self, unset):
+        assert validate_tool_call_parser(unset) is None
+
+    def test_an_unknown_name_raises_and_lists_the_real_ones(self):
+        with pytest.raises(ValueError, match="not a known format"):
+            validate_tool_call_parser("deepseekv4")
+
+    def test_atomesh_validates_before_it_creates_the_engine(self):
+        src = pathlib.Path(atomesh_server.__file__).read_text()
+        assert "validate_tool_call_parser(" in src
+        tree = ast.parse(src)
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "launch_atom_standalone"
+        )
+        calls = [
+            n.func.id
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        ]
+        assert calls.index("parse_standalone_args") < calls.index("initialize_engine")
+
+
+class TestTheMeshRouterStillGetsItsFlag:
+    """`--tool-call-parser` has two consumers: the Rust router declares one in
+    `cliargs.rs` and the Python service resolves one. Registering it here made
+    `parse_known_args` swallow it, so the router silently lost a setting that
+    had been passing straight through as an unrecognised arg.
+    """
+
+    BASE: ClassVar[list] = ["--model", "/x", "--port", "9000"]
+
+    def test_it_reaches_both_layers(self):
+        args = atomesh_server.parse_standalone_args(
+            [*self.BASE, "--tool-call-parser", "dsml"]
+        )
+        assert args.engine_args.tool_call_parser == "dsml"
+        assert "--tool-call-parser" in args.mesh_args
+        assert args.mesh_args[args.mesh_args.index("--tool-call-parser") + 1] == "dsml"
+
+    def test_unset_forwards_nothing(self):
+        """Not "auto" either: the router has its own default to apply."""
+        args = atomesh_server.parse_standalone_args(self.BASE)
+        assert args.engine_args.tool_call_parser is None
+        assert "--tool-call-parser" not in args.mesh_args
+
+    def test_the_network_args_still_get_through(self):
+        args = atomesh_server.parse_standalone_args(
+            [*self.BASE, "--tool-call-parser", "glm"]
+        )
+        assert args.mesh_args[:2] == ["--port", "9000"]

--- a/tests/entrypoints/test_tool_call_resolution.py
+++ b/tests/entrypoints/test_tool_call_resolution.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Deciding a model's tool-call format before it emits anything.
+
+The format used to be sniffed from the output, which meant deciding from a
+prefix: a discriminator might not have arrived yet, so the answer needed a
+"cannot tell" state, and a wrong guess was silent. A chat template rendered
+with a tools payload is the model's own instructions for calling one, and it
+exists before the first token.
+
+The rule under test is deliberately not a new table: it is the shipped
+`_DETECT_ORDER` cascade, asked of the prompt instead of the output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atom.entrypoints.openai.tool_parser.registry import (
+    PARSERS_BY_NAME,
+    resolve_tool_call_parser,
+)
+
+
+class _Tokenizer:
+    """Renders whatever it was told to, ignoring the messages."""
+
+    def __init__(self, rendered: str | Exception):
+        self._rendered = rendered
+
+    def apply_chat_template(self, messages, **kwargs):
+        if isinstance(self._rendered, Exception):
+            raise self._rendered
+        return self._rendered
+
+
+QWEN_TEMPLATE = (
+    "You may call tools. Emit:\n<tool_call>\n<function=NAME>\n"
+    "<parameter=key>value</parameter>\n</function>\n</tool_call>"
+)
+NO_TOOLS_TEMPLATE = "You are a helpful assistant. Answer the user's question."
+
+
+class TestExplicitOverride:
+    @pytest.mark.parametrize("name", sorted(PARSERS_BY_NAME))
+    def test_every_registered_format_is_selectable_by_name(self, name):
+        """`--tool-call-parser` reaches every format, including new ones.
+
+        The map is derived from the same registry the cascade walks, so this
+        fails for a format that joins without a usable name rather than
+        leaving it unreachable from the command line.
+        """
+        chosen = resolve_tool_call_parser(name, _Tokenizer(NO_TOOLS_TEMPLATE))
+        assert chosen is PARSERS_BY_NAME[name]
+
+    def test_an_override_beats_the_template(self):
+        chosen = resolve_tool_call_parser("kimi", _Tokenizer(QWEN_TEMPLATE))
+        assert chosen.NAME == "kimi"
+
+    def test_an_unknown_name_is_refused_not_ignored(self):
+        """A typo must not read as "no tool parsing" and disappear.
+
+        Silently disabling tool calls is the failure this whole path exists to
+        stop, so the name is checked where it is set.
+        """
+        with pytest.raises(ValueError, match="not a known format"):
+            resolve_tool_call_parser("qwen3", _Tokenizer(QWEN_TEMPLATE))
+
+
+class TestFromTheTemplate:
+    @pytest.mark.parametrize("override", [None, "auto"])
+    def test_a_template_that_teaches_a_format_resolves_to_it(self, override):
+        chosen = resolve_tool_call_parser(override, _Tokenizer(QWEN_TEMPLATE))
+        assert chosen is not None and chosen.NAME == "qwen"
+
+    def test_a_template_with_no_tool_syntax_resolves_to_nothing(self):
+        """`None` is an answer, not a failure.
+
+        gpt-oss and DeepSeek-R1 render no tool syntax ATOM knows, and parsing
+        nothing is right for them. What matters is that it is decided and
+        logged here rather than discovered mid-stream.
+        """
+        assert resolve_tool_call_parser(None, _Tokenizer(NO_TOOLS_TEMPLATE)) is None
+
+    def test_a_template_that_cannot_render_does_not_take_the_server_down(self):
+        """A template may reject a tools payload; that is not fatal.
+
+        It is also not a reason to fall back to reading the output — the
+        answer is "unknown", which the caller reports.
+        """
+        broken = _Tokenizer(TypeError("this template takes no tools="))
+        assert resolve_tool_call_parser(None, broken) is None
+
+    def test_the_probe_carries_a_tool_so_the_template_renders_its_instructions(self):
+        """A template that only mentions tools when given some must still work.
+
+        Verified by rendering with the probe and asserting the tool's name
+        reached the template -- without that, a conditional template would
+        render its plain-chat branch and every model would resolve to None.
+        """
+        seen = {}
+
+        class _Recording:
+            def apply_chat_template(self, messages, **kwargs):
+                seen.update(kwargs)
+                return NO_TOOLS_TEMPLATE
+
+        resolve_tool_call_parser(None, _Recording())
+        assert seen.get("tools"), "the probe rendered without any tools"
+        assert seen["tools"][0]["function"]["name"] == "get_weather"

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -3,6 +3,8 @@
 
 """Tests for tool call parsing."""
 
+from typing import ClassVar
+
 import pytest
 
 from atom.entrypoints.openai.tool_parser import (
@@ -13,6 +15,7 @@ from atom.entrypoints.openai.tool_parser import (
 from atom.entrypoints.openai.tool_parser.glm_tool_parser import GlmParser
 from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
+from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 
 # ============================================================================
 # parse_tool_calls() Tests
@@ -115,7 +118,7 @@ class TestParseToolCalls:
             f"<|tool_call_begin|>functions.chat:0<|tool_call_argument_begin|>{args}<|tool_call_end|>"
             "<|tool_calls_section_end|>"
         )
-        content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
+        _content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
         assert len(tool_calls) == 1
         assert tool_calls[0].function["arguments"] == args
 
@@ -309,8 +312,8 @@ class TestATruncatedCallIsNotContent:
 
     TRUNCATED = (
         "I will look it up."
-        '<|open|>tools<|sep|><|open|>call tool="get_weather"'
-        '<|open|>argument name="city"<|sep|>Paris<|close|>argument'
+        '<|open|>tools<|sep|><|open|>call tool="get_weather"<|sep|>'
+        '<|open|>argument key="city"<|sep|>Paris<|close|>argument'
     )
 
     def test_the_partial_payload_does_not_reach_the_client(self):
@@ -334,3 +337,153 @@ class TestATruncatedCallIsNotContent:
         content, calls = KimiK3Parser.parse(text, None)
         assert [c.function["name"] for c in calls] == ["get_weather"]
         assert content == "Looking._"
+
+
+class TestTheAnnouncedNameIsTheOneThatParses:
+    """A name sent early has to be the *first* call's, in wire order.
+
+    GLM's peek required `<arg_key>` after the name, so it skipped a call that
+    takes no arguments and announced the one after it. `parse` then returned
+    them in wire order and the mismatch raised -- out of `flush`, on a live
+    SSE generator with no `except` above it, from well-formed output. Zero-
+    argument tools are ordinary.
+    """
+
+    TOOLS: ClassVar[list] = [
+        {"type": "function", "function": {"name": "alpha"}},
+        {"type": "function", "function": {"name": "beta"}},
+    ]
+
+    def _drive(self, text):
+        stream = ToolCallStreamParser(parser_cls=GlmParser)
+        stream.tools = self.TOOLS
+        events = []
+        for i in range(0, len(text), 4):
+            events += stream.process(text[i : i + 4])
+        return events + stream.flush()
+
+    def test_a_zero_argument_call_before_a_real_one(self):
+        events = self._drive(
+            "<tool_call>alpha</tool_call>"
+            "<tool_call>beta<arg_key>city</arg_key><arg_value>Q</arg_value></tool_call>"
+        )
+        names = [d["function"]["name"] for k, d in events if k == "tool_call_start"]
+        assert names == ["alpha", "beta"]
+
+    def test_the_peek_reads_a_zero_argument_call(self):
+        assert GlmParser.peek_name("<tool_call>alpha</tool_call>") == "alpha"
+
+    def test_the_peek_reads_the_first_of_two(self):
+        assert (
+            GlmParser.peek_name(
+                "<tool_call>alpha</tool_call><tool_call>beta<arg_key>c</arg_key>"
+            )
+            == "alpha"
+        )
+
+
+class TestProseIsNotATruncatedCall:
+    """The unclosed-region branch exists for a call cut off by `max_tokens`.
+
+    It cannot tell that from an answer explaining how to call a tool, and used
+    to accept both: an agentic client executed `get_weather({})` and the rest
+    of the sentence was deleted. Prose has to fail two tests -- a name the
+    request declared, and nothing after the name but this format's own next
+    token -- because prose can name a real tool.
+    """
+
+    TOOLS: ClassVar[list] = [{"type": "function", "function": {"name": "get_weather"}}]
+
+    @pytest.mark.parametrize(
+        "parser, text",
+        [
+            (
+                QwenXmlParser,
+                (
+                    "To call it the model writes <tool_call>"
+                    "<function=get_weather> and then the parameters."
+                ),
+            ),
+            (
+                GlmParser,
+                "To call it write <tool_call>get_weather and then the keys follow.",
+            ),
+        ],
+        ids=["qwen", "glm"],
+    )
+    def test_prose_naming_a_declared_tool_is_not_a_call(self, parser, text):
+        content, calls = parser.parse(text, self.TOOLS)
+        assert calls == [], f"fabricated {[c.function['name'] for c in calls]}"
+        assert content == text, "the answer was truncated at the quoted tag"
+
+    @pytest.mark.parametrize(
+        "parser, text",
+        [
+            (
+                QwenXmlParser,
+                "Sure. <tool_call><function=get_weather><parameter=city>Par",
+            ),
+            (QwenXmlParser, "Sure. <tool_call><function=get_weather>"),
+            (
+                GlmParser,
+                "Sure. <tool_call>get_weather<arg_key>city</arg_key><arg_value>Pa",
+            ),
+        ],
+        ids=["qwen-mid-param", "qwen-after-name", "glm-mid-arg"],
+    )
+    def test_a_genuinely_truncated_call_still_parses(self, parser, text):
+        _, calls = parser.parse(text, self.TOOLS)
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+
+    def test_an_undeclared_name_is_never_salvaged(self):
+        text = "Sure. <tool_call><function=made_up><parameter=x>1"
+        content, calls = QwenXmlParser.parse(text, self.TOOLS)
+        assert calls == [] and content == text
+
+
+class TestKimiKeepsWhatItDidNotParse:
+    """A start marker is not a promise, for this format too.
+
+    State 1 truncated the buffer at the section end and moved to a terminal
+    state, so an answer quoting both section tokens lost its body *and*
+    everything after it -- and the `flush` fallback that was meant to cover
+    this could not see it, because the bytes were already gone. Measured: 26
+    of 135 characters at four-character chunks, 135 in one shot.
+    """
+
+    QUOTES_BOTH = (
+        "Kimi emits a tool call as <|tool_calls_section_begin|> then one entry "
+        "per call and finally <|tool_calls_section_end|>. Hope that helps!"
+    )
+
+    @staticmethod
+    def _stream(text, size):
+        parser = ToolCallStreamParser(parser_cls=KimiParser)
+        events = []
+        for i in range(0, len(text), size):
+            events += parser.process(text[i : i + size])
+        events += parser.flush()
+        return "".join(d for k, d in events if k == "content"), [
+            k for k, _ in events if k.startswith("tool_call")
+        ]
+
+    @pytest.mark.parametrize("size", [1, 2, 4, 17, 999])
+    def test_every_byte_survives_at_every_chunk_size(self, size):
+        delivered, calls = self._stream(self.QUOTES_BOTH, size)
+        assert delivered == self.QUOTES_BOTH
+        assert calls == [], "a quoted section token is not a tool call"
+
+    def test_it_agrees_with_the_non_streaming_path(self):
+        delivered, _ = self._stream(self.QUOTES_BOTH, 4)
+        assert delivered == parse_tool_calls(self.QUOTES_BOTH, parser_cls=KimiParser)[0]
+
+    def test_text_after_a_real_section_still_arrives(self):
+        """`state = 2` discarded the rest of the stream unconditionally."""
+        text = (
+            "Sure. <|tool_calls_section_begin|><|tool_call_begin|>"
+            'functions.get_weather:0<|tool_call_argument_begin|>{"city":"Paris"}'
+            "<|tool_call_end|><|tool_calls_section_end|> Done."
+        )
+        delivered, calls = self._stream(text, 4)
+        assert "Sure." in delivered and "Done." in delivered
+        assert "tool_call_start" in calls

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -4,6 +4,7 @@
 """Tests for tool call parsing."""
 
 import json
+import tracemalloc
 from typing import ClassVar
 
 import pytest
@@ -1583,4 +1584,81 @@ class TestWhatEveryFormatDoesWithACallCutOffMidWay:
             f"{name} reads a complete call with no tools declared and drops "
             "the truncated one, so the same generation cut a byte earlier "
             "ships raw markup as the answer"
+        )
+
+
+class TestTheRegionIsNotCopiedToReadACallsLeftEdge:
+    """`begin_of_markup` walks back over a call's wrapper a few bytes at a time.
+
+    It spelled each step `region[:j].rstrip()`, which copies everything to the
+    left of the scan -- so a region holding several calls after a large
+    argument paid O(calls x region). Measured 42.8 us against 5.8 for eight
+    calls behind a 128 KB payload, and growing with the payload where the
+    offset form is flat.
+
+    Its mirror `end_of_markup` walks the other way with `startswith(s, j)` and
+    never copied, and `_region_owes_a_closer` one layer up already carries
+    this fix in its docstring -- it was not carried into the function that
+    shape was taken from. `prompt_starts_in_reasoning` carries the twin of
+    this test.
+    """
+
+    CALL: ClassVar[str] = (
+        "<tool_call>\n<function=write_file>\n<parameter=content>\n"
+        "{payload}\n</parameter>\n</function>\n</tool_call>\n"
+    )
+
+    def _region(self, payload_kb: int, calls: int = 4) -> tuple[str, list[int]]:
+        """`calls` calls, the first carrying a `payload_kb` argument, and every
+        `<function=` offset -- which is what the formats hand `markup_begin`."""
+        region = "".join(
+            self.CALL.format(payload="x" * (payload_kb * 1024 if i == 0 else 8))
+            for i in range(calls)
+        )
+        ats, pos = [], 0
+        while (k := region.find("<function=", pos)) != -1:
+            ats.append(k)
+            pos = k + 1
+        return region, ats
+
+    @staticmethod
+    def _peak_bytes(region: str, ats: list[int]) -> int:
+        tracemalloc.start()
+        try:
+            tracemalloc.reset_peak()
+            for at in ats:
+                QwenXmlParser.markup_begin(region, at)
+            return tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+
+    def test_the_left_edge_is_unchanged(self):
+        """The walk still steps over the wrapper and the newline before it."""
+        region, ats = self._region(1)
+        assert ats, "nothing to walk; this asserts nothing"
+        # The first call's wrapper opens the region, so its markup begins at 0.
+        assert QwenXmlParser.markup_begin(region, ats[0]) == 0
+        # A later call's begins at its own `<tool_call>`, not at the prose or
+        # the payload before it.
+        for at in ats[1:]:
+            begin = QwenXmlParser.markup_begin(region, at)
+            assert region.startswith("<tool_call>", begin), (
+                f"walked back to {region[begin : begin + 20]!r}, which is not "
+                "this call's wrapper"
+            )
+
+    def test_prose_before_a_quoted_marker_stays_prose(self):
+        region = "I would call <tool_call>\n<function=f>\n</function>\n</tool_call>\n"
+        at = region.find("<function=")
+        assert QwenXmlParser.markup_begin(region, at) == region.find("<tool_call>")
+
+    def test_it_allocates_no_more_for_a_payload_128x_larger(self):
+        small, small_ats = self._region(1)
+        large, large_ats = self._region(128)
+        assert len(small_ats) == len(large_ats), "the two shapes must be comparable"
+        a = self._peak_bytes(small, small_ats)
+        b = self._peak_bytes(large, large_ats)
+        assert b < a + 4096, (
+            f"128 KB allocated {b} bytes against {a} for 1 KB; the region is "
+            "being copied on every step of the walk"
         )

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -30,6 +30,7 @@ from entrypoints.wire_corpus import (
     TYPED_TOOLS,
     check_corpus,
     complete,
+    only_the_wrapper_closed,
     quoting_the_arguments,
     quoting_the_opener,
     truncated,
@@ -44,13 +45,15 @@ def closer_reaching_the_tail_walk(parser) -> str | None:
     `opens_region` documents that framing is dropped -- so requiring such a
     literal to survive would be asserting against the format's own contract.
     Derived from the declarations, never a list of format names.
+
+    A framing marker *prefixing* the closer counts, not only one equal to it.
+    Exact membership missed K3's `<|close|>tools<|sep|>`, whose separator the
+    read-ahead strips as a second framing token -- so the whole literal is
+    gone before the tail walk, while the test asked for it back.
     """
+    framing = tuple(m for m in parser.START_MARKERS if not parser.opens_region(m))
     return next(
-        (
-            c
-            for c in parser.CALL_CLOSERS
-            if c not in parser.START_MARKERS or parser.opens_region(c)
-        ),
+        (c for c in parser.CALL_CLOSERS if not c.startswith(framing)),
         None,
     )
 
@@ -457,56 +460,46 @@ class TestProseIsNotATruncatedCall:
 
     TOOLS: ClassVar[list] = [{"type": "function", "function": {"name": "get_weather"}}]
 
-    @pytest.mark.parametrize(
-        "parser, text",
-        [
-            (
-                QwenXmlParser,
-                (
-                    "To call it the model writes <tool_call>"
-                    "<function=get_weather> and then the parameters."
-                ),
-            ),
-            (
-                GlmParser,
-                "To call it write <tool_call>get_weather and then the keys follow.",
-            ),
-            # `</tool_call>` closes the *outer* wrapper, so the `<function=`
-            # block is still open and this is prose, not a zero-argument
-            # call. Qwen's peek used to accept it as a follower while its
-            # parse did not; unifying them onto one constant would have made
-            # both accept it, which is worse -- a phantom dispatch rather
-            # than a dangling name.
-            (
-                QwenXmlParser,
-                (
-                    "A zero-arg call is written <tool_call><function=get_weather>"
-                    "</tool_call>, like that."
-                ),
-            ),
-            (
-                DsmlParser,
-                (
-                    'You emit <invoke name="get_weather"> and inside it a '
-                    '<\uff5cDSML\uff5cparameter name="city">Paris'
-                    "</\uff5cDSML\uff5cparameter> line."
-                ),
-            ),
-            (
-                MiniMaxParser,
-                (
-                    "To call it you emit ]<]minimax[>[<invoke "
-                    'name="get_weather"> and then a '
-                    "]<]minimax[>[<city>Paris</city> line."
-                ),
-            ),
-        ],
-        ids=["qwen", "glm", "qwen-outer-closer", "dsml", "minimax"],
-    )
-    def test_prose_naming_a_declared_tool_is_not_a_call(self, parser, text):
-        content, calls = parse_tool_calls(text, self.TOOLS, parser)
+    @pytest.mark.parametrize("name", sorted(PARSERS_BY_NAME), ids=str)
+    def test_prose_naming_a_declared_tool_is_not_a_call(self, name):
+        """One sentence per format, generated. The hand-written list read
+        `[qwen, glm, qwen-outer-closer, dsml, minimax]` -- a full sweep at a
+        glance, four of six once counted."""
+        text = quoting_the_opener(name)
+        content, calls = parse_tool_calls(text, self.TOOLS, PARSERS_BY_NAME[name])
         assert calls == [], f"fabricated {[c.function['name'] for c in calls]}"
         assert content == text, "the answer was truncated at the quoted tag"
+
+    @pytest.mark.parametrize("name", sorted(PARSERS_BY_NAME), ids=str)
+    def test_the_wrapper_closing_does_not_finish_an_open_call(self, name):
+        """`<tool_call><function=NAME></tool_call>`: the wrapper is closed and
+        the call is not, so the model was describing the syntax.
+
+        Was written out for Qwen alone, justified as a fact no registry
+        states. `CALL_CLOSERS` did state which formats have a wrapper; what
+        was missing is what closes the *call*, now `CALL_SELF_CLOSERS`. Three
+        formats can express the shape and all three call it prose.
+        """
+        text = only_the_wrapper_closed(name)
+        if text is None:
+            pytest.skip(f"{name} cannot express it; see `only_the_wrapper_closed`")
+        sentence = f"A zero-arg call is written {text}, like that."
+        content, calls = parse_tool_calls(sentence, self.TOOLS, PARSERS_BY_NAME[name])
+        assert calls == [], f"fabricated {[c.function['name'] for c in calls]}"
+        assert content == sentence, f"the answer was truncated: {content!r}"
+
+    def test_and_the_shape_is_buildable_for_at_least_three_formats(self):
+        """A coverage floor, because a wrong `CALL_SELF_CLOSERS` degrades the
+        case above to a skip rather than a failure -- declaring the wrapper
+        closer by mistake leaves the format's own markup in the body, the
+        derivation returns None, and the format quietly stops being tested."""
+        buildable = sorted(
+            n for n in PARSERS_BY_NAME if only_the_wrapper_closed(n) is not None
+        )
+        assert len(buildable) >= 3, (
+            f"only {buildable} can express a wrapper-closed call; a format "
+            "stopped being covered rather than started failing"
+        )
 
     @pytest.mark.parametrize(
         "parser, text",
@@ -1080,6 +1073,25 @@ class TestTheRequestsToolsAreResolvedOnce:
         assert _resolved_tools(once) is once
 
 
+# Kimi's sections are separate regions, so the gap between two of them is
+# released as answer where the other five call it markup. Marked rather than
+# left out, and `strict`, so it goes red the day someone fixes it -- which
+# imperative `pytest.xfail()` cannot do: that aborts before the assertion and
+# reports xfailed either way.
+_SEPARATOR_CASES = [
+    pytest.param(
+        fmt,
+        id=fmt,
+        marks=(
+            [pytest.mark.xfail(strict=True, reason="sections are separate regions")]
+            if fmt == "kimi"
+            else []
+        ),
+    )
+    for fmt in sorted(PARSERS_BY_NAME)
+]
+
+
 class TestWhatSitsBetweenTwoCalls:
     """Prose survives; the template's own separator does not.
 
@@ -1092,44 +1104,29 @@ class TestWhatSitsBetweenTwoCalls:
     """
 
     TOOLS = TestACallStillArrivingWhenTheStreamEnds.TOOLS
-    CALLS = {
-        "qwen": "<tool_call>\n<function=get_weather>\n"
-        "<parameter=city>Paris</parameter>\n</function>\n</tool_call>",
-        "glm": "<tool_call>get_weather<arg_key>city</arg_key>"
-        "<arg_value>Paris</arg_value></tool_call>",
-        "dsml": '<｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">'
-        '<｜DSML｜parameter name="city">Paris</｜DSML｜parameter>'
-        "</｜DSML｜invoke></｜DSML｜tool_calls>",
-        "minimax": ']<]minimax[>[<invoke name="get_weather">'
-        "]<]minimax[>[<city>Paris</city>]<]minimax[>[</invoke>",
-        "kimi_k3": '<|open|>call tool="get_weather"<|sep|>'
-        '<|open|>argument key="city"<|sep|>Paris<|close|>argument<|close|>call',
-    }
-    PARSERS = {
-        "qwen": QwenXmlParser,
-        "glm": GlmParser,
-        "dsml": DsmlParser,
-        "minimax": MiniMaxParser,
-        "kimi_k3": KimiK3Parser,
-    }
 
-    @pytest.mark.parametrize("name", sorted(CALLS))
+    # `REAL_CALLS`, not a table. The hand-written one held five formats and
+    # two different shapes: Qwen's, GLM's and DSML's carried their outer
+    # wrapper, so two of them are two *regions*, while MiniMax's and K3's did
+    # not. One question asked two ways -- and the format it left out is the
+    # one that answers differently.
+    @pytest.mark.parametrize("name", _SEPARATOR_CASES)
     @pytest.mark.parametrize("gap", ["\n", "  ", "\n\n  \t"])
     def test_whitespace_alone_between_them_is_markup(self, name, gap):
-        call = self.CALLS[name]
+        call = REAL_CALLS[name]
         content, calls = parse_tool_calls(
-            call + gap + call, self.TOOLS, self.PARSERS[name]
+            call + gap + call, self.TOOLS, PARSERS_BY_NAME[name]
         )
         assert len(calls) == 2, "this shape proves nothing without two calls"
         assert (
             content == ""
         ), f"the template's separator reached the client as content: {content!r}"
 
-    @pytest.mark.parametrize("name", sorted(CALLS))
+    @pytest.mark.parametrize("name", sorted(PARSERS_BY_NAME), ids=str)
     def test_but_a_sentence_between_them_is_not(self, name):
-        call = self.CALLS[name]
+        call = REAL_CALLS[name]
         content, calls = parse_tool_calls(
-            call + "\nNow Rome.\n" + call, self.TOOLS, self.PARSERS[name]
+            call + "\nNow Rome.\n" + call, self.TOOLS, PARSERS_BY_NAME[name]
         )
         assert len(calls) == 2
         assert "Now Rome." in content, f"the answer was deleted: {content!r}"
@@ -1154,31 +1151,14 @@ class TestAZeroArgumentCallLooksTheSameInEveryFormat:
             },
         }
     ]
-    ZERO_ARG = {
-        "kimi": "<|tool_calls_section_begin|><|tool_call_begin|>functions.now:0"
-        "<|tool_call_argument_begin|><|tool_call_end|><|tool_calls_section_end|>",
-        "qwen": "<tool_call>\n<function=now>\n</function>\n</tool_call>",
-        "glm": "<tool_call>now</tool_call>",
-        "dsml": '<｜DSML｜tool_calls><｜DSML｜invoke name="now">'
-        "</｜DSML｜invoke></｜DSML｜tool_calls>",
-        "kimi_k3": '<|open|>call tool="now"<|sep|><|close|>call',
-    }
-    PARSERS = {
-        "kimi": KimiParser,
-        "qwen": QwenXmlParser,
-        "glm": GlmParser,
-        "dsml": DsmlParser,
-        "kimi_k3": KimiK3Parser,
-    }
+    # No table: a zero-argument call is `render_call(name, {})`, which every
+    # format implements as the inverse of its parse. The hand-written one left
+    # out MiniMax -- the format that names parameters by the tag itself, and
+    # so has the most to get wrong when there are no tags.
 
-    @pytest.mark.parametrize("tool_name", ["get_weather", "get-weather", "server.tool"])
-    def test_and_every_format_accepts_the_names_openai_allows(self, tool_name):
-        """`^[a-zA-Z0-9_-]{1,64}$` is OpenAI's grammar, and MCP namespaces
-        with a dot. Kimi-K2 matched `functions\\.(\\w+)`, so a hyphenated or
-        namespaced name did not match at all -- the section was not a call and
-        the whole thing, special tokens included, went out as `content` with
-        `finish_reason: stop`."""
-        tools = [
+    @staticmethod
+    def _tools_for(tool_name: str) -> list[dict]:
+        return [
             {
                 "type": "function",
                 "function": {
@@ -1187,16 +1167,26 @@ class TestAZeroArgumentCallLooksTheSameInEveryFormat:
                 },
             }
         ]
-        for name, template in self.ZERO_ARG.items():
-            text = template.replace("now", tool_name)
-            _, calls = parse_tool_calls(text, tools, self.PARSERS[name])
-            assert [c.function["name"] for c in calls] == [
-                tool_name
-            ], f"{name} could not read a call to {tool_name!r}"
 
-    @pytest.mark.parametrize("name", sorted(ZERO_ARG))
+    @pytest.mark.parametrize("tool_name", ["get_weather", "get-weather", "server.tool"])
+    @pytest.mark.parametrize("name", sorted(PARSERS_BY_NAME), ids=str)
+    def test_and_every_format_accepts_the_names_openai_allows(self, name, tool_name):
+        """`^[a-zA-Z0-9_-]{1,64}$` is OpenAI's grammar, and MCP namespaces
+        with a dot. Kimi-K2 matched `functions\\.(\\w+)`, so a hyphenated or
+        namespaced name did not match at all -- the section was not a call and
+        the whole thing, special tokens included, went out as `content` with
+        `finish_reason: stop`."""
+        parser = PARSERS_BY_NAME[name]
+        text = parser.render_call(tool_name, {})
+        _, calls = parse_tool_calls(text, self._tools_for(tool_name), parser)
+        assert [c.function["name"] for c in calls] == [
+            tool_name
+        ], f"{name} could not read a call to {tool_name!r}"
+
+    @pytest.mark.parametrize("name", sorted(PARSERS_BY_NAME), ids=str)
     def test_the_arguments_are_parseable_json(self, name):
-        _, calls = parse_tool_calls(self.ZERO_ARG[name], self.TOOLS, self.PARSERS[name])
+        parser = PARSERS_BY_NAME[name]
+        _, calls = parse_tool_calls(parser.render_call("now", {}), self.TOOLS, parser)
         assert len(calls) == 1, f"{name} did not read its own zero-argument call"
         args = calls[0].function["arguments"]
         assert json.loads(args) == {}, f"{name} sent {args!r}"

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -19,6 +19,18 @@ from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.minimax_tool_parser import MiniMaxParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 
+
+def early_name(parser, region: str, tools=None) -> str | None:
+    """The name the engine would announce for `region`.
+
+    There is no separate peek to ask: the announcement is the first call of
+    `parse_region` over the bytes so far, with `at_end=False`. Naming that
+    here rather than in each test keeps these tests about the formats.
+    """
+    calls = parser.parse_region(region, tools, at_end=False).calls
+    return calls[0].function["name"] if calls else None
+
+
 # ============================================================================
 # parse_tool_calls() Tests
 # ============================================================================
@@ -239,7 +251,7 @@ class TestAParserOnItsOwnDoesNotEatText:
     """
 
     def test_kimi_releases_a_partial_marker_it_was_still_holding(self):
-        p = KimiParser()
+        p = ToolCallStreamParser(parser_cls=KimiParser)
         out = p.process("hello <|tool")
         out += p.flush()
         assert "".join(d for k, d in out if k == "content") == "hello <|tool"
@@ -247,7 +259,7 @@ class TestAParserOnItsOwnDoesNotEatText:
     def test_kimi_releases_a_section_that_held_no_call(self):
         """A start marker is not a promise, for this format either."""
         text = "see <|tool_calls_section_begin|> and nothing else"
-        p = KimiParser()
+        p = ToolCallStreamParser(parser_cls=KimiParser)
         out = p.process(text)
         out += p.flush()
         delivered = "".join(d for k, d in out if k == "content")
@@ -256,7 +268,7 @@ class TestAParserOnItsOwnDoesNotEatText:
 
     def test_kimi_k3_keeps_prose_after_a_tools_token_it_did_not_use(self):
         text = "the token <|open|>tools<|sep|> opens a section. Nothing follows."
-        content, calls = KimiK3Parser.parse(text, None)
+        content, calls = parse_tool_calls(text, None, KimiK3Parser)
         assert calls == []
         assert "Nothing follows." in content
 
@@ -277,7 +289,7 @@ class TestOnlyAnIdentifierIsAToolName:
             f"<tool_call>{name}"
             "<arg_key>city</arg_key><arg_value>Paris</arg_value></tool_call>"
         )
-        return GlmParser.parse(text, None)[1]
+        return parse_tool_calls(text, None, GlmParser)[1]
 
     @pytest.mark.parametrize(
         "name",
@@ -306,10 +318,21 @@ class TestOnlyAnIdentifierIsAToolName:
         assert self._call(name) == []
 
 
-class TestATruncatedCallIsNotContent:
-    """A call cut off by `max_tokens` parses to nothing, and "nothing parsed"
-    was the test for whether a section had opened -- so the half-written
-    payload was kept and shipped as the answer.
+class TestATruncatedCallIsDeliveredRatherThanDeleted:
+    """A call cut off by `max_tokens` parses to nothing, and a region that
+    parses to nothing is released unchanged -- for this format as for every
+    other, which is the change.
+
+    K3 used to cut the answer at the tools marker instead, on a second opener
+    regex that accepted shapes the call regex rejects, and the two ways of
+    getting that wrong were opposite: an answer *quoting* an opener lost 62
+    characters, and a truncated call kept its half-written payload with the
+    dangling `<|close|>argument` still in it. Both are now the same rule.
+
+    Kimi already behaved this way (a section with no complete entry comes back
+    whole), so this is the two token formats agreeing rather than a new
+    policy. The four XML-ish formats do not reach it: they salvage a truncated
+    call into a real one, so there is no half-written markup to show.
     """
 
     TRUNCATED = (
@@ -318,15 +341,15 @@ class TestATruncatedCallIsNotContent:
         '<|open|>argument key="city"<|sep|>Paris<|close|>argument'
     )
 
-    def test_the_partial_payload_does_not_reach_the_client(self):
-        content, calls = KimiK3Parser.parse(self.TRUNCATED, None)
+    def test_the_partial_payload_is_delivered_not_dropped(self):
+        content, calls = parse_tool_calls(self.TRUNCATED, None, KimiK3Parser)
         assert calls == []
-        assert content == "I will look it up."
+        assert content == self.TRUNCATED, "bytes were deleted with no event"
 
     def test_an_answer_that_only_names_the_token_still_keeps_its_tail(self):
         """The case the gate was added for, which must keep working."""
         text = "the token <|open|>tools<|sep|> opens a section. Nothing follows."
-        content, calls = KimiK3Parser.parse(text, None)
+        content, calls = parse_tool_calls(text, None, KimiK3Parser)
         assert calls == [] and "Nothing follows." in content
 
     def test_a_complete_call_still_truncates_there(self):
@@ -336,7 +359,7 @@ class TestATruncatedCallIsNotContent:
             '<|open|>argument key="city"<|sep|>Paris<|close|>argument'
             "<|close|>call"
         )
-        content, calls = KimiK3Parser.parse(text, None)
+        content, calls = parse_tool_calls(text, None, KimiK3Parser)
         assert [c.function["name"] for c in calls] == ["get_weather"]
         assert content == "Looking._"
 
@@ -372,13 +395,14 @@ class TestTheAnnouncedNameIsTheOneThatParses:
         names = [d["function"]["name"] for k, d in events if k == "tool_call_start"]
         assert names == ["alpha", "beta"]
 
-    def test_the_peek_reads_a_zero_argument_call(self):
-        assert GlmParser.peek_name("<tool_call>alpha</tool_call>") == "alpha"
+    def test_the_early_name_reads_a_zero_argument_call(self):
+        assert early_name(GlmParser, "<tool_call>alpha</tool_call>") == "alpha"
 
-    def test_the_peek_reads_the_first_of_two(self):
+    def test_the_early_name_reads_the_first_of_two(self):
         assert (
-            GlmParser.peek_name(
-                "<tool_call>alpha</tool_call><tool_call>beta<arg_key>c</arg_key>"
+            early_name(
+                GlmParser,
+                "<tool_call>alpha</tool_call><tool_call>beta<arg_key>c</arg_key>",
             )
             == "alpha"
         )
@@ -443,7 +467,7 @@ class TestProseIsNotATruncatedCall:
         ids=["qwen", "glm", "qwen-outer-closer", "dsml", "minimax"],
     )
     def test_prose_naming_a_declared_tool_is_not_a_call(self, parser, text):
-        content, calls = parser.parse(text, self.TOOLS)
+        content, calls = parse_tool_calls(text, self.TOOLS, parser)
         assert calls == [], f"fabricated {[c.function['name'] for c in calls]}"
         assert content == text, "the answer was truncated at the quoted tag"
 
@@ -491,12 +515,12 @@ class TestProseIsNotATruncatedCall:
         ],
     )
     def test_a_genuinely_truncated_call_still_parses(self, parser, text):
-        _, calls = parser.parse(text, self.TOOLS)
+        _, calls = parse_tool_calls(text, self.TOOLS, parser)
         assert [c.function["name"] for c in calls] == ["get_weather"]
 
     def test_an_undeclared_name_is_never_salvaged(self):
         text = "Sure. <tool_call><function=made_up><parameter=x>1"
-        content, calls = QwenXmlParser.parse(text, self.TOOLS)
+        content, calls = parse_tool_calls(text, self.TOOLS, QwenXmlParser)
         assert calls == [] and content == text
 
 
@@ -621,17 +645,17 @@ class TestTheNameTheModelWroteWins:
             f'<{self.D}parameter name="city">Paris</{self.D}parameter>'
             f'<{self.D}parameter name="tz">UTC</{self.D}parameter>'
         )
-        _, calls = DsmlParser.parse(text, self.TOOLS)
+        _, calls = parse_tool_calls(text, self.TOOLS, DsmlParser)
         assert [c.function["name"] for c in calls] == ["get_weather"]
 
-    def test_the_peek_and_the_parse_agree_on_it(self):
+    def test_the_early_name_and_the_parse_agree_on_it(self):
         text = (
             f'<invoke name="get_weather">'
             f'<{self.D}parameter name="city">Paris</{self.D}parameter>'
             f'<{self.D}parameter name="tz">UTC</{self.D}parameter>'
         )
-        _, calls = DsmlParser.parse(text, self.TOOLS)
-        assert DsmlParser.peek_name(text) == calls[0].function["name"]
+        _, calls = parse_tool_calls(text, self.TOOLS, DsmlParser)
+        assert early_name(DsmlParser, text, self.TOOLS) == calls[0].function["name"]
 
     def test_the_wrapper_less_malform_still_infers(self):
         """The shape the inference was written for, unchanged."""
@@ -640,7 +664,7 @@ class TestTheNameTheModelWroteWins:
             f'<{self.D}parameter name="tz">UTC</{self.D}parameter>'
             f'<{self.D}parameter name="city">Paris</{self.D}parameter>'
         )
-        _, calls = DsmlParser.parse(text, self.TOOLS)
+        _, calls = parse_tool_calls(text, self.TOOLS, DsmlParser)
         assert [c.function["name"] for c in calls] == ["get_time"]
 
 
@@ -683,28 +707,38 @@ class TestKimiK3KeepsAQuotedOpener:
         delivered, _ = self._stream(self.QUOTED, 5)
         assert delivered == parse_tool_calls(self.QUOTED, parser_cls=KimiK3Parser)[0]
 
-    def test_a_real_truncated_call_is_still_cut_there(self):
-        """The branch this shares with the quotation, and must keep."""
-        content, _ = KimiK3Parser.parse(self.TRUNCATED, None)
-        assert "Par" not in content and "argument" not in content
+    def test_a_real_truncated_call_is_delivered_whole(self):
+        """The branch this shares with the quotation: no call parsed, so the
+        bytes are released rather than cut away. See
+        `TestATruncatedCallIsDeliveredRatherThanDeleted` for why that is now
+        the same answer for both shapes."""
+        content, calls = parse_tool_calls(self.TRUNCATED, None, KimiK3Parser)
+        assert calls == []
+        assert content == self.TRUNCATED
 
-    def test_no_dangling_name_is_left_behind(self):
-        """`flush` never cleared the announcement, so the next call's parse
-        was compared against a name from a region that produced none.
+    def test_a_region_that_produced_nothing_leaves_no_announcement_behind(self):
+        """An announcement is per region. Carried past the region it was made
+        in, it was matched against the *next* region's parse and reported as
+        a mismatch.
 
-        Driven with TRUNCATED and not QUOTED: this format never salvages a
-        cut-off call into a ToolCall, so that is the one shape where the peek
-        legitimately fires and the parse yields nothing -- which is exactly
-        the state `flush` has to clean up. Against QUOTED the peek no longer
-        fires at all, so the assertion held for the wrong reason.
+        Driven through the engine, which is where the announcement lives now,
+        and with a shape where the region genuinely produces no call: this
+        format cannot salvage a cut-off one.
         """
-        parser = KimiK3Parser(
-            tools=[{"type": "function", "function": {"name": "get_weather"}}]
-        )
-        events = parser.process(self.TRUNCATED)
-        assert any(
-            k == "tool_call_start" for k, _ in events
-        ), "the announcement is the premise of this test"
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        parser = ToolCallStreamParser(tools=tools, parser_cls=KimiK3Parser)
+        parser.process(self.TRUNCATED)
         parser.flush()
         assert parser._announced is None
 
@@ -751,27 +785,39 @@ class TestAFollowerHasToHaveArrived:
 
     def test_a_call_cut_off_inside_its_own_token_still_parses(self):
         """The other half: `parse` must keep accepting a partial follower."""
-        _, calls = QwenXmlParser.parse(
-            "<tool_call><function=get_weather><par", self.TOOLS
+        _, calls = parse_tool_calls(
+            "<tool_call><function=get_weather><par", self.TOOLS, QwenXmlParser
         )
         assert [c.function["name"] for c in calls] == ["get_weather"]
 
 
-class TestGlmPeeksAtItsOwnFirstCall:
-    """`parse` reads the unclosed case from the *first* `<tool_call>`.
+class TestGlmReadsPastAnOpenerThatCarriesNoCall:
+    """A `<tool_call>` with nothing usable behind it is not the end of the region.
 
-    So when that one carries no usable name it produces nothing at all, while
-    a `search` in the peek slid forward to a later opener and announced its
-    name -- at every chunk size, no boundary needed. The peek is anchored to
-    the same opener `parse` starts from.
+    The body of a call cannot contain another `<tool_call>` -- that tag is
+    what opens one. Matching non-greedily from the *first* opener to the first
+    close ignored that: the region below produced a "name" of everything up to
+    the second opener, which is not an identifier, and `finditer` then resumed
+    past the real call and found nothing at all. An answer that quotes the tag
+    and then calls for real is the same shape.
+
+    The early name reads the same enumeration, so whatever the parse finds
+    here is what gets announced -- which is the property, rather than any
+    particular answer to "how many calls are in this string".
     """
 
     TOOLS: ClassVar[list] = [{"type": "function", "function": {"name": "get_weather"}}]
     UNUSABLE_FIRST = "<tool_call><arg_key><tool_call>get_weather<arg_key>"
 
-    def test_it_does_not_name_a_call_the_parse_cannot_find(self):
-        assert GlmParser.peek_name(self.UNUSABLE_FIRST, self.TOOLS) is None
-        assert GlmParser.parse(self.UNUSABLE_FIRST, self.TOOLS)[1] == []
+    def test_the_call_behind_the_unusable_opener_is_found(self):
+        _, calls = parse_tool_calls(self.UNUSABLE_FIRST, self.TOOLS, GlmParser)
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+
+    def test_and_the_early_name_is_that_same_call(self):
+        _, calls = parse_tool_calls(self.UNUSABLE_FIRST, self.TOOLS, GlmParser)
+        assert early_name(GlmParser, self.UNUSABLE_FIRST, self.TOOLS) == (
+            calls[0].function["name"] if calls else None
+        )
 
     @pytest.mark.parametrize(
         "text",
@@ -786,7 +832,7 @@ class TestGlmPeeksAtItsOwnFirstCall:
         ids=["with-args", "zero-arg", "cut-mid-arg"],
     )
     def test_a_real_first_call_is_still_named(self, text):
-        assert GlmParser.peek_name(text, self.TOOLS) == "get_weather"
+        assert early_name(GlmParser, text, self.TOOLS) == "get_weather"
 
 
 class TestBothPathsAgreeOnWhatFollowsACall:
@@ -813,7 +859,10 @@ class TestBothPathsAgreeOnWhatFollowsACall:
         """`parse` truncated at the section; the streaming path stopped doing
         so when its terminal state went, leaving the two disagreeing."""
         text = self.SECTION + "tail text"
-        assert self._stream(text, size) == KimiParser.parse(text, self.TOOLS)[0]
+        assert (
+            self._stream(text, size)
+            == parse_tool_calls(text, self.TOOLS, KimiParser)[0]
+        )
         assert "tail text" in self._stream(text, size)
 
     @pytest.mark.parametrize("size", [1, 5, 999])
@@ -821,7 +870,11 @@ class TestBothPathsAgreeOnWhatFollowsACall:
         """`elif self.buf` skipped the recovery when nothing followed the
         marker, so all 29 characters of it went missing."""
         text = "hello <|tool_calls_section_begin|>"
-        assert self._stream(text, size) == KimiParser.parse(text, self.TOOLS)[0] == text
+        assert (
+            self._stream(text, size)
+            == parse_tool_calls(text, self.TOOLS, KimiParser)[0]
+            == text
+        )
 
 
 class TestMiniMaxCutsAtItsOwnCall:
@@ -861,7 +914,7 @@ class TestMiniMaxCutsAtItsOwnCall:
 
     def test_the_ns_token_call_leaves_no_markup_in_content(self):
         text = f'{self.NS}<invoke name="get_weather"><city>Paris</city></invoke>'
-        content, calls = MiniMaxParser.parse(text, self.TOOLS)
+        content, calls = parse_tool_calls(text, self.TOOLS, MiniMaxParser)
         assert [c.function["name"] for c in calls] == ["get_weather"]
         assert "<invoke" not in content, f"raw markup shown to the user: {content!r}"
         assert content == self._stream(text)[0]
@@ -869,6 +922,6 @@ class TestMiniMaxCutsAtItsOwnCall:
     @pytest.mark.parametrize("size", [1, 5, 999])
     def test_a_bare_invoke_is_a_call_on_both_paths(self, size):
         text = 'hi <invoke name="get_weather"> <city>Paris</city> bye'
-        _, calls = MiniMaxParser.parse(text, self.TOOLS)
+        _, calls = parse_tool_calls(text, self.TOOLS, MiniMaxParser)
         _, streamed = self._stream(text, size)
         assert bool(calls) == bool(streamed) is True

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -3,32 +3,16 @@
 
 """Tests for tool call parsing."""
 
+import json
 from typing import ClassVar
 
-import json
-
 import pytest
-
-from atom.entrypoints.openai.tool_parser import read_whole_events
-from atom.entrypoints.openai.tool_parser.registry import PARSERS_BY_NAME
-from entrypoints.wire_corpus import (
-    PAYLOAD,
-    complete,
-    REAL_CALLS,
-    TYPED_TOOLS,
-    check_corpus,
-    quoting_the_opener,
-    truncated,
-    truncated_after_complete,
-)
-
-from atom.entrypoints.openai.tool_parser.schema import ParamTypes
-from atom.entrypoints.openai.tool_parser.stream import _resolved_tools
 
 from atom.entrypoints.openai.tool_parser import (
     ToolCall,
     ToolCallStreamParser,
     parse_tool_calls,
+    read_whole_events,
 )
 from atom.entrypoints.openai.tool_parser.deepseekv4_tool_parser import DsmlParser
 from atom.entrypoints.openai.tool_parser.glm_tool_parser import GlmParser
@@ -36,6 +20,37 @@ from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 from atom.entrypoints.openai.tool_parser.minimax_tool_parser import MiniMaxParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
+from atom.entrypoints.openai.tool_parser.registry import PARSERS_BY_NAME
+from atom.entrypoints.openai.tool_parser.schema import ParamTypes
+from atom.entrypoints.openai.tool_parser.stream import _resolved_tools
+from entrypoints.wire_corpus import (
+    PAYLOAD,
+    REAL_CALLS,
+    TYPED_TOOLS,
+    check_corpus,
+    complete,
+    quoting_the_opener,
+    truncated,
+    truncated_after_complete,
+)
+
+
+def closer_reaching_the_tail_walk(parser) -> str | None:
+    """The first closer `_region_tail` can actually see, or None.
+
+    A closer the read-ahead strips as channel framing never gets there, and
+    `opens_region` documents that framing is dropped -- so requiring such a
+    literal to survive would be asserting against the format's own contract.
+    Derived from the declarations, never a list of format names.
+    """
+    return next(
+        (
+            c
+            for c in parser.CALL_CLOSERS
+            if c not in parser.START_MARKERS or parser.opens_region(c)
+        ),
+        None,
+    )
 
 
 def early_name(parser, region: str, tools=None) -> str | None:
@@ -1212,6 +1227,29 @@ class TestTheWrapperClosingTagIsNeverTheAnswer:
             content.count("</tool_call>") == 1
         ), f"the quoted tag was eaten: {content!r}"
 
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    def test_and_an_answer_that_ends_by_naming_the_closing_tag_keeps_it(self, name):
+        """The same direction, with nothing after the tag to stop the walk.
+
+        The two tests around this one pin it as well, but both end in a `.`
+        after the quoted tag -- and a `.` is neither whitespace, a filler nor
+        a closer, so the walk stops on its first step whatever rule sits in
+        front of it. They are green by punctuation. An answer that ends
+        `... you write </tool_call>` has no period, and every format with an
+        outer wrapper deleted the literal.
+        """
+        parser = PARSERS_BY_NAME[name]
+        closer = closer_reaching_the_tail_walk(parser)
+        if closer is None:
+            pytest.skip(f"{name}: no closer of its own reaches the tail walk")
+        tail = f"\nTo close a call you write {closer}"
+        content, calls = parse_tool_calls(complete(name) + tail, TYPED_TOOLS, parser)
+        assert calls, f"{name} lost the call itself"
+        assert content == tail, (
+            f"{name} deleted its own closing literal out of the answer: "
+            f"{content!r} != {tail!r}"
+        )
+
     WRITE_TOOLS = [
         {
             "type": "function",
@@ -1398,6 +1436,46 @@ class TestWhatEveryFormatDoesWithACallCutOffMidWay:
         assert beside, (
             f"{name} drops a truncated call whenever a complete one exists in "
             "the same region"
+        )
+
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    def test_and_the_other_order_does_not_bury_the_second_call_in_the_first(self, name):
+        """Cut off first, complete second -- and where the markup ended up.
+
+        Three suites have built `truncated + complete` since the corpus
+        landed, and all three stayed green while four formats mishandled it,
+        because each asked something else of it: chunk invariance (which holds
+        while every chunk size drops the same call), that `get_weather` is
+        among the names (both calls carry it here), and announced-matches-
+        parsed (both channels drop it, so they agree).
+
+        Not `len(calls) == 2`: that is not format-independent, and a format
+        whose second call lands inside the first's unterminated string literal
+        would be permanently red for being honest. What every format does owe
+        is that its markup reaches neither place it can leak to -- asserting
+        only one lets a fix move it to the other.
+        """
+        parser = PARSERS_BY_NAME[name]
+        content, calls = parse_tool_calls(
+            truncated(name) + complete(name), self.TOOLS, parser
+        )
+        assert calls, f"{name} drops both calls when the cut-off one comes first"
+        leaked = sorted(m for m in parser.START_MARKERS if m in content)
+        assert (
+            not leaked
+        ), f"{name} delivers its own markup to the user as the answer: {leaked}"
+        buried = sorted(
+            {
+                m
+                for m in parser.START_MARKERS
+                for c in calls
+                if m in c.function["arguments"]
+            }
+        )
+        assert not buried, (
+            f"{name} runs the first call's argument value past the second "
+            f"call's opener, so the tool is invoked with markup as data: "
+            f"{buried} in {[c.function['arguments'] for c in calls]}"
         )
 
     @pytest.mark.parametrize("name", sorted(REAL_CALLS))

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -244,9 +244,11 @@ class TestToolCallStreamParser:
         tokens = [
             "I'll fetch that for you.",
             "<|tool_calls_section_begin|>",
-            "<|tool_call_begin|>functions.curl:0"
-            '<|tool_call_argument_begin|>{"url": "https://api.example.com/data", "method": "POST", "body": "{\\"key\\": \\"value\\"}"}'
-            "<|tool_call_end|>",
+            (
+                "<|tool_call_begin|>functions.curl:0"
+                '<|tool_call_argument_begin|>{"url": "https://api.example.com/data", "method": "POST", "body": "{\\"key\\": \\"value\\"}"}'
+                "<|tool_call_end|>"
+            ),
             "<|tool_calls_section_end|>",
         ]
         results = self._run_parser(tokens)
@@ -970,7 +972,7 @@ class TestACallStillArrivingWhenTheStreamEnds:
     parameter name was delivered as text.
     """
 
-    TOOLS = [
+    TOOLS: ClassVar[list[dict]] = [
         {
             "type": "function",
             "function": {
@@ -1142,7 +1144,7 @@ class TestAZeroArgumentCallLooksTheSameInEveryFormat:
     accumulates an `input_json_delta` it cannot parse.
     """
 
-    TOOLS = [
+    TOOLS: ClassVar[list[dict]] = [
         {
             "type": "function",
             "function": {
@@ -1249,7 +1251,7 @@ class TestTheWrapperClosingTagIsNeverTheAnswer:
             f"{content!r} != {tail!r}"
         )
 
-    WRITE_TOOLS = [
+    WRITE_TOOLS: ClassVar[list[dict]] = [
         {
             "type": "function",
             "function": {

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -7,6 +7,9 @@ from typing import ClassVar
 
 import pytest
 
+from atom.entrypoints.openai.tool_parser.schema import ParamTypes
+from atom.entrypoints.openai.tool_parser.stream import _resolved_tools
+
 from atom.entrypoints.openai.tool_parser import (
     ToolCall,
     ToolCallStreamParser,
@@ -925,3 +928,90 @@ class TestMiniMaxCutsAtItsOwnCall:
         _, calls = parse_tool_calls(text, self.TOOLS, MiniMaxParser)
         _, streamed = self._stream(text, size)
         assert bool(calls) == bool(streamed) is True
+
+
+class TestACallStillArrivingWhenTheStreamEnds:
+    """A region whose last tag is half-written, and no more bytes are coming.
+
+    Every format has to answer this the same way, and MiniMax was the one that
+    did not: it required a *complete* tag, so a call cut off inside its first
+    parameter name was delivered as text.
+    """
+
+    TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    NS = "]<]minimax[>["
+
+    @pytest.mark.parametrize("tail", ["<ci", "<city>Par", ""])
+    def test_a_half_written_declared_tag_is_a_call_at_end_of_region(self, tail):
+        region = f'{self.NS}<invoke name="get_weather">\n{self.NS}{tail}'
+        assert MiniMaxParser.parse_region(region, self.TOOLS, at_end=True).calls, (
+            f"a call cut off at {tail!r} was read as prose; the client is told "
+            "the model answered when it was calling a tool"
+        )
+
+    def test_but_not_while_more_bytes_may_still_arrive(self):
+        region = f'{self.NS}<invoke name="get_weather">\n{self.NS}<ci'
+        assert not MiniMaxParser.parse_region(
+            region, self.TOOLS, at_end=False
+        ).calls, "announced a call from a prefix that has not finished arriving"
+
+
+class TestTheAnswerAheadOfACallThatWasCutOff:
+    """DSML anchored a truncated `<invoke>` at the region's start.
+
+    Everything between the opening marker and the opener was therefore counted
+    as this call's markup and deleted -- the one XML format of the four that
+    did it, on both delivery paths.
+    """
+
+    TOOLS = TestACallStillArrivingWhenTheStreamEnds.TOOLS
+
+    def test_prose_before_a_truncated_invoke_is_not_counted_as_markup(self):
+        prose = "Let me check the weather for you right now. " * 12
+        region = (
+            "<｜DSML｜tool_calls>"
+            + prose
+            + '<｜DSML｜invoke name="get_weather">\n'
+            + '<｜DSML｜parameter name="city">Paris'
+        )
+        parsed = DsmlParser.parse_region(region, self.TOOLS, at_end=True)
+        assert parsed.calls, "the truncated call itself was lost"
+        assert parsed.begins >= len(prose), (
+            f"markup starts at {parsed.begins} but the answer runs to "
+            f"{len(prose)}: {len(prose) - parsed.begins} characters of it are "
+            "about to be deleted"
+        )
+
+
+class TestTheRequestsToolsAreResolvedOnce:
+    """Built once per request rather than once per chunk (`_resolved_tools`).
+
+    The substitution has to be invisible: the reader asks `not self.tools` in
+    the announcement path, so a request whose tools yield nothing usable must
+    still look the way the list looked, or a name is announced for a request
+    that declared no names.
+    """
+
+    def test_a_real_catalogue_is_carried_in_its_built_form(self):
+        resolved = _resolved_tools(TestACallStillArrivingWhenTheStreamEnds.TOOLS)
+        assert isinstance(resolved, ParamTypes)
+        assert set(resolved) == {"get_weather"}
+
+    @pytest.mark.parametrize("tools", [None, [], [{"junk": 1}], ["not a dict"]])
+    def test_and_anything_that_yields_no_name_keeps_its_own_truthiness(self, tools):
+        assert bool(_resolved_tools(tools)) == bool(tools)
+
+    def test_resolving_twice_is_the_same_answer(self):
+        once = _resolved_tools(TestACallStillArrivingWhenTheStreamEnds.TOOLS)
+        assert _resolved_tools(once) is once

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -8,6 +8,7 @@ from atom.entrypoints.openai.tool_parser import (
     ToolCallStreamParser,
     parse_tool_calls,
 )
+from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 
 # ============================================================================
 # parse_tool_calls() Tests
@@ -123,9 +124,14 @@ class TestParseToolCalls:
 class TestToolCallStreamParser:
     """Tests for the ToolCallStreamParser streaming state machine."""
 
-    def _run_parser(self, tokens):
-        """Helper: run tokens through parser and return all events."""
-        parser = ToolCallStreamParser()
+    def _run_parser(self, tokens, parser_cls=KimiParser):
+        """Helper: run tokens through parser and return all events.
+
+        The format is given, as the server gives it: resolved once from the
+        chat template at startup rather than guessed from the output. These
+        cases are all Kimi's section syntax, so that is the default.
+        """
+        parser = ToolCallStreamParser(parser_cls=parser_cls)
         results = []
         for token in tokens:
             results.extend(parser.process(token))

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -8,6 +8,7 @@ from atom.entrypoints.openai.tool_parser import (
     ToolCallStreamParser,
     parse_tool_calls,
 )
+from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 
 # ============================================================================
@@ -217,3 +218,36 @@ class TestToolCallStreamParser:
         assert len(starts) == 1
         ends = [d for t, d in results if t == "tool_call_end"]
         assert len(ends) == 1  # flush should emit tool_call_end
+
+
+class TestAParserOnItsOwnDoesNotEatText:
+    """Driven directly, because the facade cannot reach these states.
+
+    `ToolCallStreamParser` reads ahead over the format's markers itself, so a
+    parser is only ever constructed once a complete marker has arrived — its
+    own pre-region path is unreachable from there. The property suite runs
+    through the facade and therefore cannot see this, which is exactly how a
+    six-character loss in `KimiParser.flush` survived it.
+    """
+
+    def test_kimi_releases_a_partial_marker_it_was_still_holding(self):
+        p = KimiParser()
+        out = p.process("hello <|tool")
+        out += p.flush()
+        assert "".join(d for k, d in out if k == "content") == "hello <|tool"
+
+    def test_kimi_releases_a_section_that_held_no_call(self):
+        """A start marker is not a promise, for this format either."""
+        text = "see <|tool_calls_section_begin|> and nothing else"
+        p = KimiParser()
+        out = p.process(text)
+        out += p.flush()
+        delivered = "".join(d for k, d in out if k == "content")
+        assert "and nothing else" in delivered
+        assert not [k for k, _ in out if k.startswith("tool_call_")]
+
+    def test_kimi_k3_keeps_prose_after_a_tools_token_it_did_not_use(self):
+        text = "the token <|open|>tools<|sep|> opens a section. Nothing follows."
+        content, calls = KimiK3Parser.parse(text, None)
+        assert calls == []
+        assert "Nothing follows." in content

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -5,6 +5,8 @@
 
 from typing import ClassVar
 
+import json
+
 import pytest
 
 from atom.entrypoints.openai.tool_parser.schema import ParamTypes
@@ -960,6 +962,30 @@ class TestACallStillArrivingWhenTheStreamEnds:
             "the model answered when it was calling a tool"
         )
 
+    @pytest.mark.parametrize("tail", ["<c", "<city>Par", ""])
+    def test_including_a_call_to_a_tool_that_declares_no_parameters(self, tail):
+        """The zero-parameter tool is the one this used to drop.
+
+        An empty schema falls back to "any tag" for a *complete* tag two lines
+        up in the same function; the partial-tag branch gated on there being
+        declared tags to compare against, so it had none and refused. The same
+        tool declared with one property recovered the call, which is the
+        asymmetry that gives it away.
+        """
+        zero = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "ping",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        region = f'{self.NS}<invoke name="ping">\n{self.NS}{tail}'
+        assert MiniMaxParser.parse_region(
+            region, zero, at_end=True
+        ).calls, "a truncated call to a zero-parameter tool was read as prose"
+
     def test_but_not_while_more_bytes_may_still_arrive(self):
         region = f'{self.NS}<invoke name="get_weather">\n{self.NS}<ci'
         assert not MiniMaxParser.parse_region(
@@ -1015,3 +1041,102 @@ class TestTheRequestsToolsAreResolvedOnce:
     def test_resolving_twice_is_the_same_answer(self):
         once = _resolved_tools(TestACallStillArrivingWhenTheStreamEnds.TOOLS)
         assert _resolved_tools(once) is once
+
+
+class TestWhatSitsBetweenTwoCalls:
+    """Prose survives; the template's own separator does not.
+
+    Per-call markup spans made the gap between two calls answer, which is
+    right for a sentence and wrong for the newline every one of these chat
+    templates renders between consecutive calls. `end_of_markup` moves only on
+    a closer and `begin_of_markup` only on an opener -- correct at the edge of
+    a region, where the newline before the model resumes prose is the model's,
+    and wrong between two calls, where nobody wrote it.
+    """
+
+    TOOLS = TestACallStillArrivingWhenTheStreamEnds.TOOLS
+    CALLS = {
+        "qwen": "<tool_call>\n<function=get_weather>\n"
+        "<parameter=city>Paris</parameter>\n</function>\n</tool_call>",
+        "glm": "<tool_call>get_weather<arg_key>city</arg_key>"
+        "<arg_value>Paris</arg_value></tool_call>",
+        "dsml": '<｜DSML｜tool_calls><｜DSML｜invoke name="get_weather">'
+        '<｜DSML｜parameter name="city">Paris</｜DSML｜parameter>'
+        "</｜DSML｜invoke></｜DSML｜tool_calls>",
+        "minimax": ']<]minimax[>[<invoke name="get_weather">'
+        "]<]minimax[>[<city>Paris</city>]<]minimax[>[</invoke>",
+        "kimi_k3": '<|open|>call tool="get_weather"<|sep|>'
+        '<|open|>argument key="city"<|sep|>Paris<|close|>argument<|close|>call',
+    }
+    PARSERS = {
+        "qwen": QwenXmlParser,
+        "glm": GlmParser,
+        "dsml": DsmlParser,
+        "minimax": MiniMaxParser,
+        "kimi_k3": KimiK3Parser,
+    }
+
+    @pytest.mark.parametrize("name", sorted(CALLS))
+    @pytest.mark.parametrize("gap", ["\n", "  ", "\n\n  \t"])
+    def test_whitespace_alone_between_them_is_markup(self, name, gap):
+        call = self.CALLS[name]
+        content, calls = parse_tool_calls(
+            call + gap + call, self.TOOLS, self.PARSERS[name]
+        )
+        assert len(calls) == 2, "this shape proves nothing without two calls"
+        assert (
+            content == ""
+        ), f"the template's separator reached the client as content: {content!r}"
+
+    @pytest.mark.parametrize("name", sorted(CALLS))
+    def test_but_a_sentence_between_them_is_not(self, name):
+        call = self.CALLS[name]
+        content, calls = parse_tool_calls(
+            call + "\nNow Rome.\n" + call, self.TOOLS, self.PARSERS[name]
+        )
+        assert len(calls) == 2
+        assert "Now Rome." in content, f"the answer was deleted: {content!r}"
+
+
+class TestAZeroArgumentCallLooksTheSameInEveryFormat:
+    """`arguments` is JSON on the wire, and `""` is not JSON.
+
+    Kimi-K2 is the one format that passes the model's bytes through instead of
+    building the object, so its no-argument call reached the client as an
+    empty string where the other five sent `{}`. An OpenAI client calls
+    `json.loads` on the accumulated arguments and raises; the Anthropic SDK
+    accumulates an `input_json_delta` it cannot parse.
+    """
+
+    TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "now",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    ZERO_ARG = {
+        "kimi": "<|tool_calls_section_begin|><|tool_call_begin|>functions.now:0"
+        "<|tool_call_argument_begin|><|tool_call_end|><|tool_calls_section_end|>",
+        "qwen": "<tool_call>\n<function=now>\n</function>\n</tool_call>",
+        "glm": "<tool_call>now</tool_call>",
+        "dsml": '<｜DSML｜tool_calls><｜DSML｜invoke name="now">'
+        "</｜DSML｜invoke></｜DSML｜tool_calls>",
+        "kimi_k3": '<|open|>call tool="now"<|sep|><|close|>call',
+    }
+    PARSERS = {
+        "kimi": KimiParser,
+        "qwen": QwenXmlParser,
+        "glm": GlmParser,
+        "dsml": DsmlParser,
+        "kimi_k3": KimiK3Parser,
+    }
+
+    @pytest.mark.parametrize("name", sorted(ZERO_ARG))
+    def test_the_arguments_are_parseable_json(self, name):
+        _, calls = parse_tool_calls(self.ZERO_ARG[name], self.TOOLS, self.PARSERS[name])
+        assert len(calls) == 1, f"{name} did not read its own zero-argument call"
+        args = calls[0].function["arguments"]
+        assert json.loads(args) == {}, f"{name} sent {args!r}"

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -9,6 +9,19 @@ import json
 
 import pytest
 
+from atom.entrypoints.openai.tool_parser import read_whole_events
+from atom.entrypoints.openai.tool_parser.registry import PARSERS_BY_NAME
+from entrypoints.wire_corpus import (
+    PAYLOAD,
+    complete,
+    REAL_CALLS,
+    TYPED_TOOLS,
+    check_corpus,
+    quoting_the_opener,
+    truncated,
+    truncated_after_complete,
+)
+
 from atom.entrypoints.openai.tool_parser.schema import ParamTypes
 from atom.entrypoints.openai.tool_parser.stream import _resolved_tools
 
@@ -1134,9 +1147,297 @@ class TestAZeroArgumentCallLooksTheSameInEveryFormat:
         "kimi_k3": KimiK3Parser,
     }
 
+    @pytest.mark.parametrize("tool_name", ["get_weather", "get-weather", "server.tool"])
+    def test_and_every_format_accepts_the_names_openai_allows(self, tool_name):
+        """`^[a-zA-Z0-9_-]{1,64}$` is OpenAI's grammar, and MCP namespaces
+        with a dot. Kimi-K2 matched `functions\\.(\\w+)`, so a hyphenated or
+        namespaced name did not match at all -- the section was not a call and
+        the whole thing, special tokens included, went out as `content` with
+        `finish_reason: stop`."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        for name, template in self.ZERO_ARG.items():
+            text = template.replace("now", tool_name)
+            _, calls = parse_tool_calls(text, tools, self.PARSERS[name])
+            assert [c.function["name"] for c in calls] == [
+                tool_name
+            ], f"{name} could not read a call to {tool_name!r}"
+
     @pytest.mark.parametrize("name", sorted(ZERO_ARG))
     def test_the_arguments_are_parseable_json(self, name):
         _, calls = parse_tool_calls(self.ZERO_ARG[name], self.TOOLS, self.PARSERS[name])
         assert len(calls) == 1, f"{name} did not read its own zero-argument call"
         args = calls[0].function["arguments"]
         assert json.loads(args) == {}, f"{name} sent {args!r}"
+
+
+class TestTheWrapperClosingTagIsNeverTheAnswer:
+    """Prose between the last call and the section's closing tag.
+
+    `end_of_markup` walks forward over whitespace and closers and stops at the
+    first other byte, so a model that writes a sentence before closing its
+    section left the raw `</tool_call>` in `content`. The bytes are markup
+    whatever sits in front of them -- but only while the region still owes a
+    closing tag, which is what keeps an answer that *quotes* one after a real
+    call from losing the quote.
+    """
+
+    TOOLS = TestACallStillArrivingWhenTheStreamEnds.TOOLS
+    CALL = (
+        "<tool_call><function=get_weather>"
+        "<parameter=city>Paris</parameter></function>"
+    )
+
+    def test_prose_before_the_closing_tag_keeps_the_prose(self):
+        content, calls = parse_tool_calls(
+            self.CALL + "\nOK, checking.\n</tool_call>", self.TOOLS, QwenXmlParser
+        )
+        assert len(calls) == 1
+        assert "OK, checking." in content
+        assert "</tool_call>" not in content, f"raw markup delivered: {content!r}"
+
+    def test_but_a_quoted_closing_tag_after_a_closed_call_survives(self):
+        """Only the region's own trailing edge is consumed."""
+        text = self.CALL + "</tool_call> you end it with </tool_call>."
+        content, calls = parse_tool_calls(text, self.TOOLS, QwenXmlParser)
+        assert len(calls) == 1
+        assert (
+            content.count("</tool_call>") == 1
+        ), f"the quoted tag was eaten: {content!r}"
+
+    WRITE_TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                },
+            },
+        }
+    ]
+
+    def test_and_a_markup_literal_inside_an_argument_value_changes_nothing(self):
+        """The first version counted openers minus closers inside the spans
+        and consumed that many closers from the tail. The count saw literals
+        in argument *values*, so a call whose payload mentioned `<tool_call>`
+        invented a debt and the mechanism deleted a `</tool_call>` out of the
+        answer -- the very thing it was written to protect. An edge needs no
+        count."""
+        text = (
+            "<tool_call><function=write_file><parameter=path>d.md</parameter>"
+            "<parameter=content>open with <tool_call> and close.</parameter>"
+            "</function></tool_call>\nDone. Pair is <tool_call> ... </tool_call>."
+        )
+        content, calls = parse_tool_calls(text, self.WRITE_TOOLS, QwenXmlParser)
+        assert len(calls) == 1
+        assert content == "\nDone. Pair is <tool_call> ... </tool_call>.", content
+
+    def test_and_a_quoted_closer_in_the_middle_is_not_taken_for_the_real_one(self):
+        """The count also discharged its debt against the earliest closer in
+        document order, so DSML deleted twelve bytes of a sentence *and* left
+        the real closer in."""
+        d = "\uff5cDSML\uff5c"
+        text = (
+            f'<{d}tool_calls><{d}invoke name="get_weather">'
+            f'<{d}parameter name="city">Paris</{d}parameter></{d}invoke>'
+            f"\nClose with </tool_call> normally.\n</{d}tool_calls>"
+        )
+        content, calls = parse_tool_calls(text, self.TOOLS, DsmlParser)
+        assert len(calls) == 1
+        assert content == "\nClose with </tool_call> normally.\n", content
+
+    def test_and_a_formats_filler_before_the_closer_goes_with_it(self):
+        """MiniMax repeats its namespace token before every tag, so the walk
+        has to step over one to reach the closer."""
+        ns = "]<]minimax[>["
+        text = (
+            f'{ns}<tool_call>{ns}<invoke name="get_weather">{ns}<city>Paris</city>'
+            f"{ns}</invoke>\nDone.\n{ns}</tool_call>"
+        )
+        content, calls = parse_tool_calls(text, self.TOOLS, MiniMaxParser)
+        assert len(calls) == 1
+        assert content == "\nDone.\n", content
+
+    def test_two_calls_then_prose_keeps_the_prose_after_both(self):
+        """Order must not depend on whether the closing tag arrived.
+
+        The wrapper was spliced in as a span, and two adjacent calls merge
+        into one -- so the wrapper span became the last, took the leftover
+        call, and emitted the prose before it. Same output, two orders,
+        depending on the presence of `</tool_call>`. On `/v1/messages` that
+        put a text block between the two `tool_use` blocks.
+        """
+        a = self.CALL
+        b = self.CALL.replace("get_weather", "get_time").replace("Paris", "Rome")
+        tools = self.TOOLS + [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_time",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        orders = []
+        for tail in ("\nBoth running.\n</tool_call>", "\nBoth running."):
+            events = read_whole_events(QwenXmlParser, a + b + tail, tools)
+            orders.append([k for k, _ in events if k in ("content", "tool_call_start")])
+        assert (
+            orders[0] == orders[1]
+        ), f"the closing tag changed the order: {orders[0]} vs {orders[1]}"
+        assert orders[0] == ["tool_call_start", "tool_call_start", "content"], orders[0]
+
+    def test_and_a_quoted_opener_before_a_real_call_still_survives(self):
+        """The mirror edge is deliberately not swept. A wrapper opener
+        followed by prose looks exactly like an answer quoting the opener
+        before calling for real, and `RegionParse.begins` already decided that
+        one in favour of keeping the text. A leading scan was written here and
+        deleted the quotation; the opener leaks instead, the smaller harm."""
+        text = "Explaining: <tool_call> is how. Now: " + self.CALL + "</tool_call> done"
+        content, calls = parse_tool_calls(text, self.TOOLS, QwenXmlParser)
+        assert len(calls) == 1
+        assert "Explaining: <tool_call> is how." in content, content
+
+
+class TestWhatEveryFormatDoesWithACallCutOffMidWay:
+    """The axis five separate review findings have each been one cell of.
+
+    A response stopped at `max_tokens` mid-call is the single most common
+    malform there is, and the six formats answer it three different ways.
+    Every previous finding here was reported against one format, fixed on that
+    format, and left the others unstated -- so the next cell stayed invisible
+    until someone reported it too:
+
+      MiniMax  a zero-parameter tool's truncated call was unrecoverable
+      DSML     truncation was unreachable whenever a complete call existed
+      Kimi-K2  a truncated entry beside a complete one is dropped
+      Kimi-K3  a truncated call is never recovered at all
+      DSML/MiniMax  a mid-value cut yields `{}` where Qwen/GLM keep the partial
+
+    So the table is declared here instead of discovered. It is not an
+    endorsement -- three of these cells are worse than the other three -- it
+    is a statement of what is true today, in one place, so that changing a
+    format shows up as a diff and adding one forces an answer.
+    """
+
+    TOOLS = TYPED_TOOLS
+
+    def _row(self, name):
+        parser = PARSERS_BY_NAME[name]
+        _, cut_calls = parse_tool_calls(truncated(name), self.TOOLS, parser)
+        recovers = bool(cut_calls)
+        # `"Par" in ...` rather than a JSON compare: Kimi-K2 passes the
+        # model's own bytes through as `arguments`, so a value cut off mid-way
+        # is *invalid JSON there by construction* and any format-independent
+        # assertion has to be about the bytes, not the decode.
+        keeps = recovers and PAYLOAD[:-2] in cut_calls[0].function["arguments"]
+        _, both = parse_tool_calls(truncated_after_complete(name), self.TOOLS, parser)
+        return recovers, keeps, len(both) == 2
+
+    def test_every_format_can_write_its_own_syntax(self):
+        """The one thing a new format's author has to provide.
+
+        `render_call` is the inverse of `parse_region`; the whole corpus is
+        generated from it, so a format that has one is covered by every
+        property here without a line being added to the tests.
+        """
+        cannot = sorted(
+            name for name, cls in PARSERS_BY_NAME.items() if name not in REAL_CALLS
+        )
+        assert not cannot, (
+            f"{cannot} cannot render their own syntax, so nothing here covers "
+            "them. Implement `render_call(name, args)` on the parser."
+        )
+
+    def test_the_corpus_is_sound_and_covers_every_registered_format(self):
+        """The fixture has to be real, and there has to be one per format.
+
+        Both halves have failed here before. A format with no entry goes
+        unasserted -- which is how five separate findings each came back as
+        one more cell. And an entry written in another format's spelling
+        parses to a call with no arguments, passing everything while touching
+        none of the parameter path; MiniMax's did exactly that.
+        """
+        problems = check_corpus(PARSERS_BY_NAME, parse_tool_calls)
+        assert not problems, "the wire corpus is unsound:\n  " + "\n  ".join(problems)
+
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    def test_a_truncated_call_is_recovered(self, name):
+        recovers, _, _ = self._row(name)
+        assert recovers, (
+            f"{name} delivers a call cut off by max_tokens as raw markup "
+            "instead of recovering it"
+        )
+
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    def test_and_the_part_of_the_value_that_arrived_is_kept(self, name):
+        _, keeps, _ = self._row(name)
+        assert keeps, (
+            f"{name} recovers the call but drops the argument value the model "
+            "had already produced"
+        )
+
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    def test_and_it_is_recovered_beside_a_complete_call(self, name):
+        _, _, beside = self._row(name)
+        assert beside, (
+            f"{name} drops a truncated call whenever a complete one exists in "
+            "the same region"
+        )
+
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    @pytest.mark.parametrize("order", ["complete-first", "truncated-first"])
+    def test_and_the_chunk_size_does_not_change_the_answer(self, name, order):
+        """The invariant the whole reader is built on, on the truncated shape.
+
+        DSML broke exactly this: over a prefix that stopped before the
+        complete call, its `else:` branch was live and named the truncated
+        one; over the whole region the parse returned the other. The client
+        got two `tool_call_start` deltas at small chunk sizes and one for the
+        same generation in a single chunk.
+        """
+        whole, cut = complete(name), truncated(name)
+        text = whole + cut if order == "complete-first" else cut + whole
+        seen = set()
+        for size in (1, 4, 13, 10**6):
+            parser = ToolCallStreamParser(
+                tools=self.TOOLS, parser_cls=PARSERS_BY_NAME[name]
+            )
+            events = []
+            for i in range(0, len(text), size):
+                events += parser.process(text[i : i + size])
+            events += parser.flush()
+            seen.add(
+                tuple(
+                    d["function"]["name"] for k, d in events if k == "tool_call_start"
+                )
+            )
+        assert len(seen) == 1, f"{name} {order}: chunking changed the calls: {seen}"
+
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    def test_but_prose_that_quotes_the_opener_is_still_not_a_call(self, name):
+        """The other half of the pair.
+
+        An unclosed alternative without a `_is_truncated_call` gate turns
+        every sentence *about* the wire format into a tool call. Kimi-K3 was
+        given the alternation alone and did exactly that.
+        """
+        _, calls = parse_tool_calls(
+            quoting_the_opener(name), self.TOOLS, PARSERS_BY_NAME[name]
+        )
+        assert calls == [], f"{name} read a sentence about calls as a call"

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -707,3 +707,168 @@ class TestKimiK3KeepsAQuotedOpener:
         ), "the announcement is the premise of this test"
         parser.flush()
         assert parser._announced is None
+
+
+class TestAFollowerHasToHaveArrived:
+    """`peek_name` requires the next token whole; `parse` accepts a prefix.
+
+    The two run at different moments and that is the whole difference. `parse`
+    runs at end of stream, where a token cut off part-way is all there will
+    ever be -- a call truncated by `max_tokens`. `peek_name` runs mid-stream,
+    where a prefix means "not yet".
+
+    Sharing one prefix-accepting test made a chunk boundary decide: `<` is a
+    prefix of `<parameter=`, so the same prose announced a tool at chunk sizes
+    1 and 2 and stayed silent at 5. Announced, it reaches the client as a
+    dispatchable zero-argument call.
+    """
+
+    PROSE = "the model writes <tool_call><function=get_weather><br> and stops"
+    TOOLS: ClassVar[list] = [{"type": "function", "function": {"name": "get_weather"}}]
+
+    @pytest.mark.parametrize("size", [1, 2, 3, 5, 17, 999])
+    def test_prose_never_announces_at_any_chunk_size(self, size):
+        parser = ToolCallStreamParser(tools=self.TOOLS, parser_cls=QwenXmlParser)
+        events = []
+        for i in range(0, len(self.PROSE), size):
+            events += parser.process(self.PROSE[i : i + size])
+        events += parser.flush()
+        assert [k for k, _ in events if k == "tool_call_start"] == []
+
+    @pytest.mark.parametrize("size", [1, 2, 3, 5, 17, 999])
+    def test_a_real_call_still_announces_at_any_chunk_size(self, size):
+        text = (
+            "<tool_call><function=get_weather><parameter=city>Paris</parameter>"
+            "</function></tool_call>"
+        )
+        parser = ToolCallStreamParser(tools=self.TOOLS, parser_cls=QwenXmlParser)
+        events = []
+        for i in range(0, len(text), size):
+            events += parser.process(text[i : i + size])
+        events += parser.flush()
+        starts = [d["function"]["name"] for k, d in events if k == "tool_call_start"]
+        assert starts == ["get_weather"]
+
+    def test_a_call_cut_off_inside_its_own_token_still_parses(self):
+        """The other half: `parse` must keep accepting a partial follower."""
+        _, calls = QwenXmlParser.parse(
+            "<tool_call><function=get_weather><par", self.TOOLS
+        )
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+
+
+class TestGlmPeeksAtItsOwnFirstCall:
+    """`parse` reads the unclosed case from the *first* `<tool_call>`.
+
+    So when that one carries no usable name it produces nothing at all, while
+    a `search` in the peek slid forward to a later opener and announced its
+    name -- at every chunk size, no boundary needed. The peek is anchored to
+    the same opener `parse` starts from.
+    """
+
+    TOOLS: ClassVar[list] = [{"type": "function", "function": {"name": "get_weather"}}]
+    UNUSABLE_FIRST = "<tool_call><arg_key><tool_call>get_weather<arg_key>"
+
+    def test_it_does_not_name_a_call_the_parse_cannot_find(self):
+        assert GlmParser.peek_name(self.UNUSABLE_FIRST, self.TOOLS) is None
+        assert GlmParser.parse(self.UNUSABLE_FIRST, self.TOOLS)[1] == []
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            (
+                "<tool_call>get_weather<arg_key>city</arg_key>"
+                "<arg_value>Paris</arg_value></tool_call>"
+            ),
+            "<tool_call>get_weather</tool_call>",
+            "<tool_call>get_weather<arg_key>city</arg_key><arg_value>Pa",
+        ],
+        ids=["with-args", "zero-arg", "cut-mid-arg"],
+    )
+    def test_a_real_first_call_is_still_named(self, text):
+        assert GlmParser.peek_name(text, self.TOOLS) == "get_weather"
+
+
+class TestBothPathsAgreeOnWhatFollowsACall:
+    """Text after a section, and a section marker with nothing behind it."""
+
+    TOOLS: ClassVar[list] = [{"type": "function", "function": {"name": "get_weather"}}]
+    SECTION = (
+        "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0"
+        '<|tool_call_argument_begin|>{"city":"Paris"}<|tool_call_end|>'
+        "<|tool_calls_section_end|>"
+    )
+
+    @staticmethod
+    def _stream(text, size):
+        parser = ToolCallStreamParser(parser_cls=KimiParser)
+        events = []
+        for i in range(0, len(text), size):
+            events += parser.process(text[i : i + size])
+        events += parser.flush()
+        return "".join(d for k, d in events if k == "content")
+
+    @pytest.mark.parametrize("size", [1, 5, 999])
+    def test_the_tail_after_a_section_survives_both_ways(self, size):
+        """`parse` truncated at the section; the streaming path stopped doing
+        so when its terminal state went, leaving the two disagreeing."""
+        text = self.SECTION + "tail text"
+        assert self._stream(text, size) == KimiParser.parse(text, self.TOOLS)[0]
+        assert "tail text" in self._stream(text, size)
+
+    @pytest.mark.parametrize("size", [1, 5, 999])
+    def test_an_answer_ending_on_the_marker_keeps_it(self, size):
+        """`elif self.buf` skipped the recovery when nothing followed the
+        marker, so all 29 characters of it went missing."""
+        text = "hello <|tool_calls_section_begin|>"
+        assert self._stream(text, size) == KimiParser.parse(text, self.TOOLS)[0] == text
+
+
+class TestMiniMaxCutsAtItsOwnCall:
+    """Content is what precedes the call, and the call has two openers.
+
+    Cutting only at `<tool_call>` -- which this format's primary ns_token
+    shape does not contain -- left the entire `<invoke>` markup in `content`
+    *alongside* the parsed call, so the user was shown raw XML while the
+    streaming path showed nothing. And `<invoke name="` was not a scanner
+    marker at all, so a bare invoke was a call one way and text the other.
+    """
+
+    TOOLS: ClassVar[list] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    NS = "]<]minimax[>["
+
+    def _stream(self, text, size=7):
+        parser = ToolCallStreamParser(tools=self.TOOLS, parser_cls=MiniMaxParser)
+        events = []
+        for i in range(0, len(text), size):
+            events += parser.process(text[i : i + size])
+        events += parser.flush()
+        return (
+            "".join(d for k, d in events if k == "content"),
+            [d["function"]["name"] for k, d in events if k == "tool_call_start"],
+        )
+
+    def test_the_ns_token_call_leaves_no_markup_in_content(self):
+        text = f'{self.NS}<invoke name="get_weather"><city>Paris</city></invoke>'
+        content, calls = MiniMaxParser.parse(text, self.TOOLS)
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+        assert "<invoke" not in content, f"raw markup shown to the user: {content!r}"
+        assert content == self._stream(text)[0]
+
+    @pytest.mark.parametrize("size", [1, 5, 999])
+    def test_a_bare_invoke_is_a_call_on_both_paths(self, size):
+        text = 'hi <invoke name="get_weather"> <city>Paris</city> bye'
+        _, calls = MiniMaxParser.parse(text, self.TOOLS)
+        _, streamed = self._stream(text, size)
+        assert bool(calls) == bool(streamed) is True

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -3,11 +3,14 @@
 
 """Tests for tool call parsing."""
 
+import pytest
+
 from atom.entrypoints.openai.tool_parser import (
     ToolCall,
     ToolCallStreamParser,
     parse_tool_calls,
 )
+from atom.entrypoints.openai.tool_parser.glm_tool_parser import GlmParser
 from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
 
@@ -26,7 +29,7 @@ class TestParseToolCalls:
             '<|tool_call_begin|>functions.exec:0<|tool_call_argument_begin|>{"command": "ls"}<|tool_call_end|>'
             "<|tool_calls_section_end|>"
         )
-        content, tool_calls = parse_tool_calls(text)
+        content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
         assert content == "I'll run that."
         assert len(tool_calls) == 1
         assert tool_calls[0].function["name"] == "exec"
@@ -41,7 +44,7 @@ class TestParseToolCalls:
             '<|tool_call_begin|>functions.fetch:1<|tool_call_argument_begin|>{"url": "http://example.com"}<|tool_call_end|>'
             "<|tool_calls_section_end|>"
         )
-        content, tool_calls = parse_tool_calls(text)
+        content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
         assert content == "Let me search."
         assert len(tool_calls) == 2
         assert tool_calls[0].function["name"] == "search"
@@ -49,7 +52,7 @@ class TestParseToolCalls:
 
     def test_no_tool_calls(self):
         text = "Just a regular response."
-        content, tool_calls = parse_tool_calls(text)
+        content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
         assert content == "Just a regular response."
         assert len(tool_calls) == 0
 
@@ -59,7 +62,7 @@ class TestParseToolCalls:
             '<|tool_call_begin|>functions.run:0<|tool_call_argument_begin|>{"cmd": "echo hi"}<|tool_call_end|>'
             "<|tool_calls_section_end|>"
         )
-        content, tool_calls = parse_tool_calls(text)
+        content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
         assert content == ""
         assert len(tool_calls) == 1
 
@@ -69,7 +72,7 @@ class TestParseToolCalls:
             "<|tool_calls_section_begin|>"
             '<|tool_call_begin|>functions.exec:0<|tool_call_argument_begin|>{"cmd": "ls"}<|tool_call_end|>'
         )
-        content, tool_calls = parse_tool_calls(text)
+        content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
         assert content == "Here:"
         assert len(tool_calls) == 1
 
@@ -93,7 +96,7 @@ class TestParseToolCalls:
             "<|tool_call_end|>"
             "<|tool_calls_section_end|>"
         )
-        content, tool_calls = parse_tool_calls(text)
+        content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
         assert content == "I'll fetch that URL for you."
         assert len(tool_calls) == 1
         assert tool_calls[0].function["name"] == "curl"
@@ -112,7 +115,7 @@ class TestParseToolCalls:
             f"<|tool_call_begin|>functions.chat:0<|tool_call_argument_begin|>{args}<|tool_call_end|>"
             "<|tool_calls_section_end|>"
         )
-        content, tool_calls = parse_tool_calls(text)
+        content, tool_calls = parse_tool_calls(text, parser_cls=KimiParser)
         assert len(tool_calls) == 1
         assert tool_calls[0].function["arguments"] == args
 
@@ -251,3 +254,83 @@ class TestAParserOnItsOwnDoesNotEatText:
         content, calls = KimiK3Parser.parse(text, None)
         assert calls == []
         assert "Nothing follows." in content
+
+
+# ============================================================================
+# What counts as a tool name
+# ============================================================================
+
+
+class TestOnlyAnIdentifierIsAToolName:
+    """GLM's unterminated branch takes everything after `<tool_call>` as the
+    name, so the name check is the only thing between prose and a fabricated
+    call. It has to reject prose without rejecting names models really use.
+    """
+
+    def _call(self, name):
+        text = (
+            f"<tool_call>{name}"
+            "<arg_key>city</arg_key><arg_value>Paris</arg_value></tool_call>"
+        )
+        return GlmParser.parse(text, None)[1]
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "get_weather",
+            "7z_extract",  # OpenAI's grammar allows a leading digit
+            "天气查询",  # and nothing forbids a CJK name on a Chinese family
+            "read-file",
+            "fs.read",
+            "x",
+        ],
+    )
+    def test_a_legal_name_is_accepted(self, name):
+        calls = self._call(name)
+        assert [c.function["name"] for c in calls] == [name]
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            " followed by the name. Hope that helps!",
+            '{"name": "get_weather", "arguments": {}}',  # Hermes-style JSON
+            "two words",
+        ],
+    )
+    def test_prose_is_not_a_name(self, name):
+        assert self._call(name) == []
+
+
+class TestATruncatedCallIsNotContent:
+    """A call cut off by `max_tokens` parses to nothing, and "nothing parsed"
+    was the test for whether a section had opened -- so the half-written
+    payload was kept and shipped as the answer.
+    """
+
+    TRUNCATED = (
+        "I will look it up."
+        '<|open|>tools<|sep|><|open|>call tool="get_weather"'
+        '<|open|>argument name="city"<|sep|>Paris<|close|>argument'
+    )
+
+    def test_the_partial_payload_does_not_reach_the_client(self):
+        content, calls = KimiK3Parser.parse(self.TRUNCATED, None)
+        assert calls == []
+        assert content == "I will look it up."
+
+    def test_an_answer_that_only_names_the_token_still_keeps_its_tail(self):
+        """The case the gate was added for, which must keep working."""
+        text = "the token <|open|>tools<|sep|> opens a section. Nothing follows."
+        content, calls = KimiK3Parser.parse(text, None)
+        assert calls == [] and "Nothing follows." in content
+
+    def test_a_complete_call_still_truncates_there(self):
+        text = (
+            "Looking._"
+            '<|open|>tools<|sep|><|open|>call tool="get_weather"<|sep|>'
+            '<|open|>argument key="city"<|sep|>Paris<|close|>argument'
+            "<|close|>call"
+        )
+        content, calls = KimiK3Parser.parse(text, None)
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+        assert content == "Looking._"

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -12,9 +12,11 @@ from atom.entrypoints.openai.tool_parser import (
     ToolCallStreamParser,
     parse_tool_calls,
 )
+from atom.entrypoints.openai.tool_parser.deepseekv4_tool_parser import DsmlParser
 from atom.entrypoints.openai.tool_parser.glm_tool_parser import GlmParser
 from atom.entrypoints.openai.tool_parser.kimi_k3_tool_parser import KimiK3Parser
 from atom.entrypoints.openai.tool_parser.kimi_tool_parser import KimiParser
+from atom.entrypoints.openai.tool_parser.minimax_tool_parser import MiniMaxParser
 from atom.entrypoints.openai.tool_parser.qwen3_tool_parser import QwenXmlParser
 
 # ============================================================================
@@ -408,8 +410,37 @@ class TestProseIsNotATruncatedCall:
                 GlmParser,
                 "To call it write <tool_call>get_weather and then the keys follow.",
             ),
+            # `</tool_call>` closes the *outer* wrapper, so the `<function=`
+            # block is still open and this is prose, not a zero-argument
+            # call. Qwen's peek used to accept it as a follower while its
+            # parse did not; unifying them onto one constant would have made
+            # both accept it, which is worse -- a phantom dispatch rather
+            # than a dangling name.
+            (
+                QwenXmlParser,
+                (
+                    "A zero-arg call is written <tool_call><function=get_weather>"
+                    "</tool_call>, like that."
+                ),
+            ),
+            (
+                DsmlParser,
+                (
+                    'You emit <invoke name="get_weather"> and inside it a '
+                    '<\uff5cDSML\uff5cparameter name="city">Paris'
+                    "</\uff5cDSML\uff5cparameter> line."
+                ),
+            ),
+            (
+                MiniMaxParser,
+                (
+                    "To call it you emit ]<]minimax[>[<invoke "
+                    'name="get_weather"> and then a '
+                    "]<]minimax[>[<city>Paris</city> line."
+                ),
+            ),
         ],
-        ids=["qwen", "glm"],
+        ids=["qwen", "glm", "qwen-outer-closer", "dsml", "minimax"],
     )
     def test_prose_naming_a_declared_tool_is_not_a_call(self, parser, text):
         content, calls = parser.parse(text, self.TOOLS)
@@ -428,8 +459,36 @@ class TestProseIsNotATruncatedCall:
                 GlmParser,
                 "Sure. <tool_call>get_weather<arg_key>city</arg_key><arg_value>Pa",
             ),
+            # No complete `<arg_key>` yet, so the name has to be cut at the
+            # `<` rather than run to the end of the region.
+            (GlmParser, "Sure. <tool_call>get_weather<arg_k"),
+            (GlmParser, "Sure. <tool_call>\nget_weather\n"),
+            (
+                DsmlParser,
+                (
+                    'Sure. <invoke name="get_weather">'
+                    '<\uff5cDSML\uff5cparameter name="city">Par'
+                ),
+            ),
+            (DsmlParser, 'Sure. <invoke name="get_weather">'),
+            (
+                MiniMaxParser,
+                (
+                    'Sure. ]<]minimax[>[<invoke name="get_weather">'
+                    "]<]minimax[>[<city>Par"
+                ),
+            ),
         ],
-        ids=["qwen-mid-param", "qwen-after-name", "glm-mid-arg"],
+        ids=[
+            "qwen-mid-param",
+            "qwen-after-name",
+            "glm-mid-arg",
+            "glm-mid-arg-key",
+            "glm-newline-before-name",
+            "dsml-mid-param",
+            "dsml-after-name",
+            "minimax-mid-param",
+        ],
     )
     def test_a_genuinely_truncated_call_still_parses(self, parser, text):
         _, calls = parser.parse(text, self.TOOLS)
@@ -477,13 +536,174 @@ class TestKimiKeepsWhatItDidNotParse:
         delivered, _ = self._stream(self.QUOTES_BOTH, 4)
         assert delivered == parse_tool_calls(self.QUOTES_BOTH, parser_cls=KimiParser)[0]
 
-    def test_text_after_a_real_section_still_arrives(self):
-        """`state = 2` discarded the rest of the stream unconditionally."""
-        text = (
-            "Sure. <|tool_calls_section_begin|><|tool_call_begin|>"
-            'functions.get_weather:0<|tool_call_argument_begin|>{"city":"Paris"}'
-            "<|tool_call_end|><|tool_calls_section_end|> Done."
-        )
-        delivered, calls = self._stream(text, 4)
+    REAL_SECTION = (
+        "<|tool_calls_section_begin|><|tool_call_begin|>"
+        'functions.get_weather:0<|tool_call_argument_begin|>{"city":"Paris"}'
+        "<|tool_call_end|><|tool_calls_section_end|>"
+    )
+
+    @pytest.mark.parametrize("size", [1, 4, 17, 999])
+    def test_text_after_a_real_section_still_arrives(self, size):
+        """`state = 2` discarded the rest of the stream unconditionally.
+
+        Parametrised over the chunk size because replacing that state fixed
+        only the split case: state 0 took the remainder after the marker and
+        returned without looking for the section end, so a section arriving
+        whole in one chunk still lost everything after it. Under load that is
+        the common case, not the rare one -- `merge_chunk` coalesces the
+        backlog into exactly these large chunks.
+        """
+        text = "Sure. " + self.REAL_SECTION + " Done."
+        delivered, calls = self._stream(text, size)
         assert "Sure." in delivered and "Done." in delivered
         assert "tool_call_start" in calls
+
+    @pytest.mark.parametrize("size", [1, 4, 999])
+    def test_a_quoted_section_after_a_real_call_is_still_not_a_call(self, size):
+        """The not-a-promise branch is per section, not per stream.
+
+        It was gated on `emitted_calls`, which is cumulative, so from the
+        first real call onwards every later section read as fulfilled and its
+        body was deleted -- the branch became dead code exactly when the
+        format started being used.
+        """
+        prose = (
+            " The tokens are <|tool_calls_section_begin|> and "
+            "<|tool_calls_section_end|>, in case you wondered."
+        )
+        delivered, calls = self._stream(self.REAL_SECTION + prose, size)
+        assert delivered == prose, "the second section was eaten"
+        assert calls.count("tool_call_end") == 1
+
+
+class TestTheNameTheModelWroteWins:
+    """DSML infers a dropped tool name from the parameters. Only when it has to.
+
+    The inference exists for the documented V4-Flash malform that drops the
+    `<invoke>` wrapper entirely. It was also reached by a call the model was
+    cut off inside -- whose name is written right there in the opener -- and
+    scored a *different* declared tool for it, because that one happened to
+    share more parameters. Two consequences: the client is handed the wrong
+    tool, and `peek_name` reads the same opener, so the streaming path had
+    already announced the name the parse then contradicted.
+    """
+
+    TOOLS: ClassVar[list] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_time",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                        "tz": {"type": "string"},
+                    },
+                },
+            },
+        },
+    ]
+    D = "｜DSML｜"
+
+    def test_a_truncated_call_keeps_the_name_in_its_opener(self):
+        text = (
+            f'<invoke name="get_weather">'
+            f'<{self.D}parameter name="city">Paris</{self.D}parameter>'
+            f'<{self.D}parameter name="tz">UTC</{self.D}parameter>'
+        )
+        _, calls = DsmlParser.parse(text, self.TOOLS)
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+
+    def test_the_peek_and_the_parse_agree_on_it(self):
+        text = (
+            f'<invoke name="get_weather">'
+            f'<{self.D}parameter name="city">Paris</{self.D}parameter>'
+            f'<{self.D}parameter name="tz">UTC</{self.D}parameter>'
+        )
+        _, calls = DsmlParser.parse(text, self.TOOLS)
+        assert DsmlParser.peek_name(text) == calls[0].function["name"]
+
+    def test_the_wrapper_less_malform_still_infers(self):
+        """The shape the inference was written for, unchanged."""
+        text = (
+            f"<{self.D}tool_calls>"
+            f'<{self.D}parameter name="tz">UTC</{self.D}parameter>'
+            f'<{self.D}parameter name="city">Paris</{self.D}parameter>'
+        )
+        _, calls = DsmlParser.parse(text, self.TOOLS)
+        assert [c.function["name"] for c in calls] == ["get_time"]
+
+
+class TestKimiK3KeepsAQuotedOpener:
+    """A start marker is not a promise -- the one format that had no such branch.
+
+    `parse` cuts the answer at a call opener, and the regex it cuts on accepts
+    openers the call regex rejects. An answer quoting one therefore lost
+    everything from that point: 62 characters, no event, `finish_reason`
+    still `stop`.
+    """
+
+    QUOTED = (
+        "<|open|>response<|sep|>To call it the model writes "
+        '<|open|>call tool="get_weather" index="N"<|sep|> and then the '
+        "arguments. That is the whole trick.<|close|>response<|sep|>"
+    )
+    TRUNCATED = (
+        '<|open|>tools<|sep|><|open|>call tool="get_weather" index="0"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>Par'
+    )
+
+    @staticmethod
+    def _stream(text, size):
+        parser = ToolCallStreamParser(parser_cls=KimiK3Parser)
+        events = []
+        for i in range(0, len(text), size):
+            events += parser.process(text[i : i + size])
+        events += parser.flush()
+        return "".join(d for k, d in events if k == "content"), [
+            k for k, _ in events if k.startswith("tool_call")
+        ]
+
+    @pytest.mark.parametrize("size", [1, 5, 999])
+    def test_the_answer_survives_the_quotation(self, size):
+        delivered, _ = self._stream(self.QUOTED, size)
+        assert "That is the whole trick." in delivered
+
+    def test_both_paths_deliver_the_same_text(self):
+        delivered, _ = self._stream(self.QUOTED, 5)
+        assert delivered == parse_tool_calls(self.QUOTED, parser_cls=KimiK3Parser)[0]
+
+    def test_a_real_truncated_call_is_still_cut_there(self):
+        """The branch this shares with the quotation, and must keep."""
+        content, _ = KimiK3Parser.parse(self.TRUNCATED, None)
+        assert "Par" not in content and "argument" not in content
+
+    def test_no_dangling_name_is_left_behind(self):
+        """`flush` never cleared the announcement, so the next call's parse
+        was compared against a name from a region that produced none.
+
+        Driven with TRUNCATED and not QUOTED: this format never salvages a
+        cut-off call into a ToolCall, so that is the one shape where the peek
+        legitimately fires and the parse yields nothing -- which is exactly
+        the state `flush` has to clean up. Against QUOTED the peek no longer
+        fires at all, so the assertion held for the wrong reason.
+        """
+        parser = KimiK3Parser(
+            tools=[{"type": "function", "function": {"name": "get_weather"}}]
+        )
+        events = parser.process(self.TRUNCATED)
+        assert any(
+            k == "tool_call_start" for k, _ in events
+        ), "the announcement is the premise of this test"
+        parser.flush()
+        assert parser._announced is None

--- a/tests/entrypoints/test_tool_parser.py
+++ b/tests/entrypoints/test_tool_parser.py
@@ -29,6 +29,7 @@ from entrypoints.wire_corpus import (
     TYPED_TOOLS,
     check_corpus,
     complete,
+    quoting_the_arguments,
     quoting_the_opener,
     truncated,
     truncated_after_complete,
@@ -352,9 +353,8 @@ class TestOnlyAnIdentifierIsAToolName:
 
 
 class TestATruncatedCallIsDeliveredRatherThanDeleted:
-    """A call cut off by `max_tokens` parses to nothing, and a region that
-    parses to nothing is released unchanged -- for this format as for every
-    other, which is the change.
+    """A call cut off by `max_tokens` reaches the client as a call, and what
+    is not a call reaches it as text. Either way the bytes are not deleted.
 
     K3 used to cut the answer at the tools marker instead, on a second opener
     regex that accepted shapes the call regex rejects, and the two ways of
@@ -362,10 +362,12 @@ class TestATruncatedCallIsDeliveredRatherThanDeleted:
     characters, and a truncated call kept its half-written payload with the
     dangling `<|close|>argument` still in it. Both are now the same rule.
 
-    Kimi already behaved this way (a section with no complete entry comes back
-    whole), so this is the two token formats agreeing rather than a new
-    policy. The four XML-ish formats do not reach it: they salvage a truncated
-    call into a real one, so there is no half-written markup to show.
+    This class used to assert the *other* outcome -- no call, region released
+    verbatim -- and was right about the code at the time, because it passes
+    `tools=None` and every format then refused every truncated call. That was
+    the defect: with the same request declaring its tools, K3 salvaged this
+    exact input. The salvage no longer turns on whether the client listed
+    them, so what is pinned here is the salvage.
     """
 
     TRUNCATED = (
@@ -376,8 +378,9 @@ class TestATruncatedCallIsDeliveredRatherThanDeleted:
 
     def test_the_partial_payload_is_delivered_not_dropped(self):
         content, calls = parse_tool_calls(self.TRUNCATED, None, KimiK3Parser)
-        assert calls == []
-        assert content == self.TRUNCATED, "bytes were deleted with no event"
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+        assert calls[0].function["arguments"] == '{"city": "Paris"}'
+        assert content == "I will look it up.", "the answer around it was eaten"
 
     def test_an_answer_that_only_names_the_token_still_keeps_its_tail(self):
         """The case the gate was added for, which must keep working."""
@@ -741,13 +744,18 @@ class TestKimiK3KeepsAQuotedOpener:
         assert delivered == parse_tool_calls(self.QUOTED, parser_cls=KimiK3Parser)[0]
 
     def test_a_real_truncated_call_is_delivered_whole(self):
-        """The branch this shares with the quotation: no call parsed, so the
-        bytes are released rather than cut away. See
-        `TestATruncatedCallIsDeliveredRatherThanDeleted` for why that is now
-        the same answer for both shapes."""
+        """The shape the quotation has to be told apart from, same request.
+
+        `QUOTED` and this differ only in what follows the opener -- English in
+        one, this format's own next token in the other -- and that is the only
+        thing deciding between them here, because neither passes `tools`. It
+        used to be decided by the empty tool list instead, which refused both
+        and released `TRUNCATED`'s channel tokens as the answer.
+        """
         content, calls = parse_tool_calls(self.TRUNCATED, None, KimiK3Parser)
-        assert calls == []
-        assert content == self.TRUNCATED
+        assert [c.function["name"] for c in calls] == ["get_weather"]
+        assert calls[0].function["arguments"] == '{"city": "Par"}'
+        assert content == "", f"markup left in the answer: {content!r}"
 
     def test_a_region_that_produced_nothing_leaves_no_announcement_behind(self):
         """An announcement is per region. Carried past the region it was made
@@ -1508,14 +1516,71 @@ class TestWhatEveryFormatDoesWithACallCutOffMidWay:
         assert len(seen) == 1, f"{name} {order}: chunking changed the calls: {seen}"
 
     @pytest.mark.parametrize("name", sorted(REAL_CALLS))
-    def test_but_prose_that_quotes_the_opener_is_still_not_a_call(self, name):
+    @pytest.mark.parametrize("declares_tools", [True, False])
+    def test_but_prose_that_quotes_the_opener_is_still_not_a_call(
+        self, name, declares_tools
+    ):
         """The other half of the pair.
 
         An unclosed alternative without a `_is_truncated_call` gate turns
         every sentence *about* the wire format into a tool call. Kimi-K3 was
         given the alternation alone and did exactly that.
+
+        Both arms, because the gate has two halves and only one comes from the
+        request. `declared_tools_allow` stops refusing when the request lists
+        no tools, so with `tools=None` the follower test is the whole of what
+        separates a cut-off call from a sentence about one -- if that ever
+        stops carrying it, this is where it shows.
         """
         _, calls = parse_tool_calls(
-            quoting_the_opener(name), self.TOOLS, PARSERS_BY_NAME[name]
+            quoting_the_opener(name),
+            self.TOOLS if declares_tools else None,
+            PARSERS_BY_NAME[name],
         )
         assert calls == [], f"{name} read a sentence about calls as a call"
+
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    @pytest.mark.parametrize("declares_tools", [True, False])
+    def test_and_neither_is_prose_that_quotes_the_arguments(self, name, declares_tools):
+        """The half no shape built from the front of a call can reach.
+
+        `quoting_the_opener` keeps everything *before* the tool name, so it
+        always carries the call opener and always lands in the branch that
+        reads one. A format that infers the name from the parameters instead
+        has a second branch, and DSML's had no gate at all: 152 characters of
+        an answer explaining the syntax collapse to 18 and a call is
+        dispatched. Undeclared tools make it worse rather than safer -- the
+        name cannot be inferred, so it is sent as `"unknown"`.
+        """
+        text = quoting_the_arguments(name)
+        if text is None:
+            pytest.skip(f"{name}: no self-contained region marker to quote")
+        tools = TYPED_TOOLS if declares_tools else None
+        content, calls = parse_tool_calls(text, tools, PARSERS_BY_NAME[name])
+        assert calls == [], (
+            f"{name} read a sentence about argument syntax as a call: "
+            f"{[(c.function['name'], c.function['arguments']) for c in calls]}"
+        )
+        assert content == text, f"{name} deleted the answer: {content!r}"
+
+    @pytest.mark.parametrize("name", sorted(REAL_CALLS))
+    def test_and_the_declared_tools_are_not_the_only_gate(self, name):
+        """A request that lists no tools still gets its truncated call.
+
+        `tools` sharpens the answer -- it is how a format tells a call cut off
+        by `max_tokens` from a sentence quoting an opener -- but it cannot be
+        the whole of it, because a *complete* call is read without it on all
+        six. Cut the same generation one byte earlier and it became raw
+        special tokens in `content`, decided by whether the client had
+        listed its tools rather than by anything the model wrote.
+        """
+        parser = PARSERS_BY_NAME[name]
+        _, whole = parse_tool_calls(complete(name), None, parser)
+        if not whole:
+            pytest.skip(f"{name} does not read a complete call without tools either")
+        _, cut = parse_tool_calls(truncated(name), None, parser)
+        assert cut, (
+            f"{name} reads a complete call with no tools declared and drops "
+            "the truncated one, so the same generation cut a byte earlier "
+            "ships raw markup as the answer"
+        )

--- a/tests/entrypoints/wire_corpus.py
+++ b/tests/entrypoints/wire_corpus.py
@@ -133,6 +133,27 @@ def naming_another_tool(name: str) -> str:
     return REAL_CALLS[name].replace(TOOL, OTHER_TOOL)
 
 
+def naming_nothing(name: str) -> str:
+    """The same call with no name at all -- `<invoke name="">`.
+
+    Every format's name slot is `[^"]*` or the equivalent, so the wire admits
+    this and three formats used to hand it on as a call the client could not
+    dispatch.
+    """
+    return REAL_CALLS[name].replace(TOOL, "")
+
+
+def naming_only_spaces(name: str) -> str:
+    """The same call named with whitespace.
+
+    Kept apart from :func:`naming_nothing` because the two were not equivalent:
+    MiniMax rejected the empty name and shipped this one, having tested for
+    emptiness *before* stripping. A single shape would have found two of the
+    three formats and called the axis covered.
+    """
+    return REAL_CALLS[name].replace(TOOL, "   ")
+
+
 def truncated_naming_another_tool(name: str) -> str:
     """A cut-off call for the *other* tool.
 
@@ -176,6 +197,25 @@ def quoting_the_arguments(name: str) -> str | None:
         # no parameter markup and there is nothing here to misread.
         return None
     return f"You open one with {marker} and then write {after_the_name}"
+
+
+def quoting_a_call_it_will_not_make(name: str) -> str:
+    """Markup this format's call pattern *matches* and its gate then rejects.
+
+    Distinct from :func:`quoting_the_opener`, and the distinction is the whole
+    point. That one stops before the name, so for a format whose pattern wants
+    more than an opener -- Kimi's entry needs `functions.NAME:INDEX` -- the
+    pattern never matches and the parser has nothing to reject. A property
+    about *what happens to a rejected match* is then vacuous: it passed on
+    every format, before and after the fix it was written for.
+
+    So: a call cut off mid-argument, naming a tool the request never declared.
+    Unclosed, so the truncation gate runs; undeclared, so it refuses. Both
+    halves are format-generic -- every format gates an unclosed alternative on
+    a declared name, which `TestAFormatDeclaresEveryTokenItStrips` and the
+    truncation table already hold them to.
+    """
+    return cut_at_payload(REAL_CALLS[name].replace(TOOL, "undeclared_thing"))
 
 
 def quoting_the_opener(name: str) -> str:

--- a/tests/entrypoints/wire_corpus.py
+++ b/tests/entrypoints/wire_corpus.py
@@ -218,9 +218,13 @@ def only_the_wrapper_closed(name: str) -> str | None:
     tuple is declared -- hand-written, this shape existed for one format.
 
     ``None`` where the format cannot express it, and both reasons are read off
-    the rendering rather than listed:
+    the declarations rather than listed:
 
-    * no inner block at all -- GLM's call *is* its wrapper;
+    * no wrapper distinct from the call -- GLM's `</tool_call>` is both, so
+      there is nothing that can close while the call stays open. Asked of
+      `CALL_CLOSERS`, which is the tuple that means "wrapper"; asking whether
+      the *self* closer was blank conflated the two and cost GLM its
+      region-end signal elsewhere.
     * something already written between the name and the call's own closer,
       even with no arguments. Kimi puts `{}` there and K3 an `index="N"`
       attribute, so deleting the closer leaves a call the format recovers as
@@ -232,6 +236,8 @@ def only_the_wrapper_closed(name: str) -> str | None:
     a guard nothing can justify.
     """
     parser = _registry()[name]
+    if not parser.CALL_CLOSERS:
+        return None
     call = parser.render_call(TOOL, {})
     closer = next((c for c in parser.CALL_SELF_CLOSERS if c in call), None)
     if closer is None:

--- a/tests/entrypoints/wire_corpus.py
+++ b/tests/entrypoints/wire_corpus.py
@@ -100,16 +100,23 @@ def complete(name: str) -> str:
     return REAL_CALLS[name]
 
 
-def truncated(name: str) -> str:
-    """The same call, cut off partway through its argument value.
+def cut_at_payload(call: str) -> str:
+    """`call` as it looked when generation stopped inside its argument value.
 
-    Cut at the payload rather than a fixed number of characters off the end:
-    measured, chopping twelve left a *fully closed* call for three of the six
-    formats, so a check meant to ask "can this read an unclosed call" was
-    asking whether a complete one parses.
+    The one place the cut rule lives, because where a call is cut decides what
+    the check is asking. Both other rules that have existed here asked
+    something else on half the registry: a fixed twelve characters left a
+    *fully closed* call for three of six formats, and the midpoint
+    (``call[:len(call)//2]``, which the announcement suite derived for itself)
+    leaves no recoverable call at all for three -- Kimi-K2's does not parse.
+    That second rule is why a real announce-vs-parse divergence stayed green.
     """
-    call = REAL_CALLS[name]
     return call[: call.index(PAYLOAD) + len(PAYLOAD) - 2]
+
+
+def truncated(name: str) -> str:
+    """The same call, cut off partway through its argument value."""
+    return cut_at_payload(REAL_CALLS[name])
 
 
 def truncated_after_complete(name: str) -> str:
@@ -124,6 +131,16 @@ def truncated_after_complete(name: str) -> str:
 def naming_another_tool(name: str) -> str:
     """The same call, for the *other* declared tool."""
     return REAL_CALLS[name].replace(TOOL, OTHER_TOOL)
+
+
+def truncated_naming_another_tool(name: str) -> str:
+    """A cut-off call for the *other* tool.
+
+    Needed because "the name announced from a prefix is not the name the
+    finished region parses to" cannot be stated with one tool name: comparing
+    `get_weather` to `get_weather` is true however badly the parse went.
+    """
+    return cut_at_payload(naming_another_tool(name))
 
 
 def quoting_the_opener(name: str) -> str:

--- a/tests/entrypoints/wire_corpus.py
+++ b/tests/entrypoints/wire_corpus.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""One call per wire format, asked of the formats themselves.
+
+Nothing here is written by hand: `REAL_CALLS` is built by asking every
+registered parser to `render_call`, and every shape the suites need is derived
+from it. A format registered tomorrow is covered by every property the moment
+it exists, with nothing added here.
+
+Hand-written samples were the alternative and one of them was wrong in the way
+that matters: MiniMax's was written in DSML's spelling and parsed to
+`get_weather({})`, exercising none of the parameter path.
+
+Generating does not by itself fix that -- a renderer and a parser written from
+the same misunderstanding round-trip perfectly. :func:`check_corpus`'s last
+check does: a format's call must be *identified* by its own parser and no
+other.
+"""
+
+from __future__ import annotations
+
+#: The value every call carries. Derivations cut here, so it must appear
+#: exactly once in each rendered call.
+PAYLOAD = "Paris"
+
+#: The tool every call names, and the parameter it passes.
+TOOL = "get_weather"
+PARAM = "city"
+
+#: The second declared tool. Never called; it exists so that "the early name
+#: disagreed with the parse" is expressible at all -- with one declared tool a
+#: property comparing names compares `get_weather` to `get_weather`.
+OTHER_TOOL = "get_time"
+
+DECLARED_TOOLS: list[dict] = [
+    {"type": "function", "function": {"name": TOOL, "parameters": {}}},
+    {"type": "function", "function": {"name": OTHER_TOOL, "parameters": {}}},
+]
+
+#: Typed variant, for the parsers that coerce argument values.
+TYPED_TOOLS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": name,
+            "parameters": {
+                "type": "object",
+                "properties": {PARAM: {"type": "string"}},
+            },
+        },
+    }
+    for name in (TOOL, OTHER_TOOL)
+]
+
+
+def _render(parser_cls) -> str:
+    return parser_cls.render_call(TOOL, {PARAM: PAYLOAD})
+
+
+class _Corpus(dict):
+    """The rendered calls, with a format that cannot render explained."""
+
+    def __missing__(self, name):
+        raise AssertionError(
+            f"the registered format {name!r} cannot render its own syntax. "
+            "Implement `render_call(name, args)` on its parser -- the inverse "
+            "of `parse_region` for one call, wrapper included. The whole test "
+            "corpus is generated from it, so every property covers the format "
+            "as soon as it exists, and nothing needs adding to the tests."
+        )
+
+
+def build(parsers: dict) -> dict[str, str]:
+    """One rendered call per format that can render one."""
+    out = _Corpus()
+    for name, cls in parsers.items():
+        try:
+            out[name] = _render(cls)
+        except NotImplementedError:
+            continue
+    return out
+
+
+def _registry() -> dict:
+    from atom.entrypoints.openai.tool_parser.registry import PARSERS_BY_NAME
+
+    return PARSERS_BY_NAME
+
+
+#: Built at import, from the registry. THE corpus; nobody writes an entry.
+REAL_CALLS: dict[str, str] = build(_registry())
+
+
+# --- derived shapes ---------------------------------------------------------
+
+
+def complete(name: str) -> str:
+    """This format's call, whole."""
+    return REAL_CALLS[name]
+
+
+def truncated(name: str) -> str:
+    """The same call, cut off partway through its argument value.
+
+    Cut at the payload rather than a fixed number of characters off the end:
+    measured, chopping twelve left a *fully closed* call for three of the six
+    formats, so a check meant to ask "can this read an unclosed call" was
+    asking whether a complete one parses.
+    """
+    call = REAL_CALLS[name]
+    return call[: call.index(PAYLOAD) + len(PAYLOAD) - 2]
+
+
+def truncated_after_complete(name: str) -> str:
+    """A cut-off call after a finished one, in one region.
+
+    The ordinary `max_tokens` shape, and the one where a format that recovers
+    truncation only in an `else:` branch drops the second call.
+    """
+    return REAL_CALLS[name] + truncated(name)
+
+
+def naming_another_tool(name: str) -> str:
+    """The same call, for the *other* declared tool."""
+    return REAL_CALLS[name].replace(TOOL, OTHER_TOOL)
+
+
+def quoting_the_opener(name: str) -> str:
+    """A sentence that mentions this format's opener and calls nothing.
+
+    An unclosed alternative without a truncation gate turns every sentence
+    *about* the wire format into a tool call; Kimi-K3 did exactly that when it
+    was given the alternation alone.
+    """
+    call = REAL_CALLS[name]
+    return (
+        f"You write {call[: call.index(TOOL)]}undeclared_thing "
+        "and then the parameters."
+    )
+
+
+# --- the corpus has to be real ----------------------------------------------
+
+
+def check_corpus(parsers: dict, parse) -> list[str]:
+    """Complaints about the corpus itself, empty when it is sound.
+
+    ``parsers`` is the registry and ``parse`` is `parse_tool_calls`; injected
+    so this module imports nothing from the package under test at definition
+    time.
+    """
+    import json
+
+    problems = []
+
+    cannot = sorted(set(parsers) - set(REAL_CALLS))
+    if cannot:
+        problems.append(
+            f"registered but cannot render their own syntax: {cannot} -- "
+            "implement `render_call` and every property covers them"
+        )
+
+    for name in sorted(set(REAL_CALLS) & set(parsers)):
+        call = REAL_CALLS[name]
+        if call.count(PAYLOAD) != 1:
+            problems.append(
+                f"{name}: {PAYLOAD!r} appears {call.count(PAYLOAD)} times; the "
+                "derivations cut there and need exactly one"
+            )
+        # Round trip: what this format writes, it must read back.
+        content, calls = parse(call, TYPED_TOOLS, parsers[name])
+        got = [c.function["name"] for c in calls]
+        if got != [TOOL]:
+            problems.append(f"{name}: renders a call its own parser reads as {got}")
+            continue
+        try:
+            decoded = json.loads(calls[0].function["arguments"])
+        except ValueError:
+            problems.append(f"{name}: arguments are not JSON")
+            continue
+        if decoded != {PARAM: PAYLOAD}:
+            problems.append(f"{name}: round-trips to {decoded!r}")
+        if content:
+            problems.append(f"{name}: left {content!r} outside the call")
+
+        # The ground truth a round trip cannot give: a renderer and a parser
+        # written from the same misunderstanding agree with each other, but a
+        # sample in another format's spelling is claimed by that format.
+        #
+        # `detect`, not `parse`. Two formats may both be able to *read* a
+        # string -- DSML matches its marker optionally, so it reads MiniMax's
+        # calls -- but only one may *claim* it. No exception list on purpose:
+        # one was written for the MiniMax/DSML pair, and that was the smell
+        # that led to splitting identification off `START_MARKERS`.
+        claimers = sorted(n for n in parsers if parsers[n].detect(call))
+        if claimers != [name]:
+            problems.append(
+                f"{name}'s own call is identified as {claimers} -- either the "
+                "renderer is written in another format's spelling, or two "
+                "formats are confusable by construction and one needs a "
+                "narrower `DETECT_MARKERS`"
+            )
+    return problems

--- a/tests/entrypoints/wire_corpus.py
+++ b/tests/entrypoints/wire_corpus.py
@@ -143,6 +143,41 @@ def truncated_naming_another_tool(name: str) -> str:
     return cut_at_payload(naming_another_tool(name))
 
 
+def quoting_the_arguments(name: str) -> str | None:
+    """A sentence that shows this format's *argument* syntax and calls nothing.
+
+    The mirror of :func:`quoting_the_opener`, which keeps everything before
+    the tool name and so always carries the call opener with it. A format that
+    infers the name from the parameters instead has a second branch, and no
+    shape built from the front of a call can reach it -- DSML's ran for two
+    rounds unreachable from here while deleting the answers it fired on.
+
+    ``None`` where the format declares no self-contained region marker. A
+    marker ending in ``=`` or ``"`` is mid-attribute -- it *is* a call opener
+    waiting for a name -- so a string built from one would be a real call, and
+    a parser reading it as such would be right. Skipping is the honest answer;
+    inventing a shape that a correct parser must fail is not.
+    """
+    parser = _registry()[name]
+    marker = next(
+        (
+            m
+            for m in parser.START_MARKERS
+            if parser.opens_region(m) and not m.endswith(('"', "="))
+        ),
+        None,
+    )
+    if marker is None:
+        return None
+    call = REAL_CALLS[name]
+    after_the_name = call[call.index(TOOL) + len(TOOL) :]
+    if PARAM not in after_the_name:
+        # Arguments come before the name in this format, so the tail carries
+        # no parameter markup and there is nothing here to misread.
+        return None
+    return f"You open one with {marker} and then write {after_the_name}"
+
+
 def quoting_the_opener(name: str) -> str:
     """A sentence that mentions this format's opener and calls nothing.
 

--- a/tests/entrypoints/wire_corpus.py
+++ b/tests/entrypoints/wire_corpus.py
@@ -133,25 +133,16 @@ def naming_another_tool(name: str) -> str:
     return REAL_CALLS[name].replace(TOOL, OTHER_TOOL)
 
 
-def naming_nothing(name: str) -> str:
-    """The same call with no name at all -- `<invoke name="">`.
+def naming_something_undispatchable(name: str) -> str:
+    """The same call, named with something no client could dispatch.
 
-    Every format's name slot is `[^"]*` or the equivalent, so the wire admits
-    this and three formats used to hand it on as a call the client could not
-    dispatch.
+    The corpus's own name with its separator spaced out, rather than invented
+    junk: no grammar admits a space, and unlike a quote or an angle bracket it
+    perturbs no format's markup, so "no call" cannot come out true for the
+    wrong reason. Two hand-picked literals -- empty, and all-space -- read as
+    thorough and missed the shape a model actually writes.
     """
-    return REAL_CALLS[name].replace(TOOL, "")
-
-
-def naming_only_spaces(name: str) -> str:
-    """The same call named with whitespace.
-
-    Kept apart from :func:`naming_nothing` because the two were not equivalent:
-    MiniMax rejected the empty name and shipped this one, having tested for
-    emptiness *before* stripping. A single shape would have found two of the
-    three formats and called the axis covered.
-    """
-    return REAL_CALLS[name].replace(TOOL, "   ")
+    return REAL_CALLS[name].replace(TOOL, TOOL.replace("_", " "))
 
 
 def truncated_naming_another_tool(name: str) -> str:
@@ -216,6 +207,42 @@ def quoting_a_call_it_will_not_make(name: str) -> str:
     truncation table already hold them to.
     """
     return cut_at_payload(REAL_CALLS[name].replace(TOOL, "undeclared_thing"))
+
+
+def only_the_wrapper_closed(name: str) -> str | None:
+    """This format's call with the call's own closer never written.
+
+    `<tool_call><function=NAME></tool_call>`: the wrapper is closed and the
+    call is not, so the model was describing the syntax. Built by deleting
+    `CALL_SELF_CLOSERS` from a zero-argument rendering, which is why that
+    tuple is declared -- hand-written, this shape existed for one format.
+
+    ``None`` where the format cannot express it, and both reasons are read off
+    the rendering rather than listed:
+
+    * no inner block at all -- GLM's call *is* its wrapper;
+    * something already written between the name and the call's own closer,
+      even with no arguments. Kimi puts `{}` there and K3 an `index="N"`
+      attribute, so deleting the closer leaves a call the format recovers as
+      a truncation -- both do, measured -- rather than an unclosed block. The
+      question stops being the same one.
+
+    Nothing checks that the closer has a wrapper after it: no registered
+    format renders one last, and a guard for a shape none of them produce is
+    a guard nothing can justify.
+    """
+    parser = _registry()[name]
+    call = parser.render_call(TOOL, {})
+    closer = next((c for c in parser.CALL_SELF_CLOSERS if c in call), None)
+    if closer is None:
+        return None
+    at = call.rindex(closer)
+    body = call[call.index(TOOL) + len(TOOL) : at]
+    for filler in parser.CALL_FILLERS:
+        body = body.replace(filler, "")
+    if any(c.isalnum() for c in body):
+        return None
+    return call[:at] + call[at + len(closer) :]
 
 
 def quoting_the_opener(name: str) -> str:

--- a/tests/import_guard.py
+++ b/tests/import_guard.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Skip when a dependency is absent. Fail when our own code is broken.
+
+Several test modules import something heavy — an `aiter`-backed kernel, the
+API server's transformers/uvicorn/fastapi stack — and guard it so a bare
+non-GPU runner can still collect the rest of the suite. Those guards caught
+`Exception`, which also catches a `SyntaxError`, a `NameError` or a bad
+relative import *inside the module under test*, and turned it into a skip.
+
+Measured: a `yield from` inside an `async def` generator in `api_server.py`
+made nineteen tests go quiet. The run reported `279 passed, 40 skipped` — no
+failure anywhere, and the count looked plausible. A syntax error in a shipped
+module read as green.
+
+So the question is asked once, here: an import error naming a third-party
+module is an environment that cannot run this test, and an import error
+naming one of ours — or anything that is not an import error at all — is a
+bug that has to be seen.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def skip_if_dependency_missing(exc: BaseException, what: str) -> None:
+    """Skip the module for an absent dependency; re-raise anything else.
+
+    `what` names the import that failed, for the skip line.
+
+    Only `ImportError` can be environmental, and only when the module it names
+    is not ours. `ModuleNotFoundError` is a subclass, so "no module named
+    aiter" and "cannot import name 'dtypes' from 'aiter'" are both covered —
+    the second is what a namespace package left on the path produces, and it
+    is how the non-GPU CI actually fails.
+    """
+    name = getattr(exc, "name", None) or ""
+    if isinstance(exc, ImportError) and not name.startswith("atom"):
+        pytest.skip(f"{what}: {exc}", allow_module_level=True)
+    raise exc

--- a/tests/model_ops/test_shared_expert_dispatch.py
+++ b/tests/model_ops/test_shared_expert_dispatch.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from conftest import atom_config_double
 
 pytest.importorskip("aiter", reason="full dispatch tests require aiter")
 
@@ -179,11 +180,24 @@ def test_ep_alone_does_not_imply_all2all(
 
 
 def _atom_config(*, eplb: bool) -> SimpleNamespace:
-    return SimpleNamespace(
+    """The four fields this gate reads, over the real Config's defaults.
+
+    Hand-built, this went red the day `is_rocm_aiter_fusion_shared_expert_
+    enabled_for_quant_config` grew a read of `enable_dp_attention` -- a field
+    that exists on Config with a default of False, so the double should have
+    had it. `atom_config_double` takes every field from
+    `dataclasses.fields(Config)`, so the next one arrives on its own.
+    """
+    return atom_config_double(
         quant_config=SimpleNamespace(exclude_layers=[], quant_dtype=None),
         parallel_config=SimpleNamespace(data_parallel_size=8),
         moe_ep_flatten_tp_across_dp=False,
         eplb_enable=eplb,
+        # The branch under test is the MoRI + DP-attention one -- "only MoRI
+        # needs the switch", says the code -- so the scenario has to say so.
+        # Left at Config's default of False, the early return is unreachable
+        # and the (no eplb, no switch) row stops meaning anything.
+        enable_dp_attention=True,
     )
 
 
@@ -198,6 +212,9 @@ def _atom_config(*, eplb: bool) -> SimpleNamespace:
 )
 def test_eplb_overrides_the_local_replica_switch(monkeypatch, eplb, switch, expected):
     monkeypatch.setattr(topK_module.envs, "ATOM_FUSE_SHARED_EXPERT", switch)
+    # Stated, not inherited: the gate asks whether MoRI is importable, so
+    # without this the truth table below holds only on a box that has it.
+    monkeypatch.setattr(topK_module, "_has_module", lambda name: True)
     monkeypatch.setattr(
         topK_module,
         "get_current_atom_config",

--- a/tests/plugin/test_plugin_config_translation.py
+++ b/tests/plugin/test_plugin_config_translation.py
@@ -109,9 +109,9 @@ def test_online_quant_config_from_additional_config(monkeypatch):
 
 
 def test_generate_atom_config_requires_plugin_mode(monkeypatch):
-    import atom.plugin.config as config_module
-    import atom.plugin as plugin_module
     import atom.config as atom_config_module
+    import atom.plugin as plugin_module
+    import atom.plugin.config as config_module
 
     monkeypatch.setattr(plugin_module, "is_vllm", lambda: False, raising=False)
     monkeypatch.setattr(plugin_module, "is_sglang", lambda: False, raising=False)

--- a/tests/plugin/test_rtpllm_forward_context_semantics.py
+++ b/tests/plugin/test_rtpllm_forward_context_semantics.py
@@ -56,7 +56,7 @@ def _install_forward_context_stubs():
 
 _install_forward_context_stubs()
 
-from atom.plugin.rtpllm.utils.forward_context import (  # noqa: E402
+from atom.plugin.rtpllm.utils.forward_context import (
     RTPForwardContext,
     RTPForwardMLAContext,
     RTPForwardQwen35HybridContext,

--- a/tests/plugin/test_rtpllm_glm5_wrapper_lifecycle.py
+++ b/tests/plugin/test_rtpllm_glm5_wrapper_lifecycle.py
@@ -1,11 +1,11 @@
 """Lifecycle tests for the GLM5 rtp-llm wrapper."""
 
 import ast
-from contextlib import nullcontext
 import importlib
 import os
-from pathlib import Path
 import sys
+from contextlib import nullcontext
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 

--- a/tests/plugin/test_sglang_plugin.py
+++ b/tests/plugin/test_sglang_plugin.py
@@ -4,12 +4,13 @@ Covers config translation, model dict selection, and framework mode status.
 All tests mock sglang dependencies so they run without sglang installed.
 """
 
-import pytest
 import sys
 from unittest.mock import MagicMock, patch
 
-from atom.plugin import prepare as plugin_prepare
+import pytest
+
 import atom.plugin.config as plugin_config
+from atom.plugin import prepare as plugin_prepare
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/plugin/test_sglang_prepare_model.py
+++ b/tests/plugin/test_sglang_prepare_model.py
@@ -10,8 +10,9 @@ prepare_model.
 """
 
 import sys
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from atom.plugin import prepare as plugin_runtime
 from atom.plugin.sglang import prepare as sglang_prepare

--- a/tests/plugin/test_sglang_register.py
+++ b/tests/plugin/test_sglang_register.py
@@ -11,8 +11,9 @@ under test.
 import importlib
 import sys
 from types import ModuleType
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from atom.plugin import prepare as plugin_prepare
 

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -38,8 +38,8 @@ if _atom_config_stub is not None:
             from_dict=lambda cfg, debug=False: MagicMock(cfg=cfg, debug=debug)
         )
 
-from atom.model_engine.arg_utils import EngineArgs  # noqa: E402
-from atom.utils.arg_parser import FlexibleArgumentParser  # noqa: E402
+from atom.model_engine.arg_utils import EngineArgs
+from atom.utils.arg_parser import FlexibleArgumentParser
 
 
 class TestFlexibleArgumentParser:

--- a/tests/test_benchmark_catalog.py
+++ b/tests/test_benchmark_catalog.py
@@ -22,8 +22,8 @@ WORKFLOW = REPO / ".github" / "workflows" / "atom-benchmark.yaml"
 
 sys.path.insert(0, str(SCRIPTS))
 
-import catalog  # noqa: E402
-from build_benchmark_matrix import RESERVED_INPUTS  # noqa: E402
+import catalog
+from build_benchmark_matrix import RESERVED_INPUTS
 
 # Legacy hard-coded matrix `exclude` block (suffix, concurrency) pairs. The
 # refactor must reproduce exactly this pruning via per-variant conc bands.

--- a/tests/test_deepseek_v4_wo_a_dequant.py
+++ b/tests/test_deepseek_v4_wo_a_dequant.py
@@ -18,7 +18,6 @@ Float8_e4m3fnuz`). This test locks in that fix for both dialects.
 """
 
 import sys
-import types
 import unittest
 
 import pytest
@@ -72,11 +71,48 @@ def _make_wo_a(dtype, out_features=256, in_features=128, block=128):
     return FakeWoA()
 
 
+class _FakeAttention:
+    """The ``self`` that ``process_weights_after_loading`` runs against.
+
+    Refuses an attribute it does not model, by name. A plain
+    ``SimpleNamespace`` let a missing one surface as ``'types.SimpleNamespace'
+    object has no attribute 'n_local_groups'``, raised from inside the method
+    with nothing to say about where to fix it -- which is how all three tests
+    below sat red after production grew reads of ``n_local_groups`` and
+    ``o_lora_rank``, on every machine that can run them. That is only a
+    machine with aiter, because this module ``importorskip``s it and CI has
+    none, so nothing reported it.
+
+    Runtime, not a scan of the method's source. A source scan sees only the
+    literal ``self.X`` in that one body -- not a read through a helper, not
+    one through a base class -- and it re-breaks on a refactor that changed
+    nothing. This fails at the read, wherever the read is.
+
+    Values coherent with ``_make_wo_a``'s 256 x 128 weight: the gfx950
+    batched-GEMM path wants ``out_dim == n_local_groups * o_lora_rank``, so
+    2 x 128. ``_is_gfx950`` is False because this is the gfx942 dtype gate --
+    the BF16 fallback is the path under test, and that flag selects it.
+    """
+
+    def __init__(self, wo_a):
+        self.wo_a = wo_a
+        self.n_local_groups = 2
+        self.o_lora_rank = 128
+        self._is_gfx950 = False
+
+    def __getattr__(self, name):
+        raise AttributeError(
+            f"process_weights_after_loading read self.{name}, which this "
+            f"double does not model -- add it to _FakeAttention with a value "
+            f"coherent with _make_wo_a's weight"
+        )
+
+
 class TestWoADequantFnFnuzGate(unittest.TestCase):
     def _run(self, dtype):
         from atom.models.deepseek_v4 import DeepseekV4Attention
 
-        fake_self = types.SimpleNamespace(wo_a=_make_wo_a(dtype))
+        fake_self = _FakeAttention(_make_wo_a(dtype))
         DeepseekV4Attention.process_weights_after_loading(fake_self)
         return fake_self.wo_a
 
@@ -104,7 +140,7 @@ class TestWoADequantFnFnuzGate(unittest.TestCase):
         weight_before = wo_a.weight
         from atom.models.deepseek_v4 import DeepseekV4Attention
 
-        fake_self = types.SimpleNamespace(wo_a=wo_a)
+        fake_self = _FakeAttention(wo_a)
         DeepseekV4Attention.process_weights_after_loading(fake_self)
         self.assertIs(wo_a.weight, weight_before)
 

--- a/tests/test_disagg_modes.py
+++ b/tests/test_disagg_modes.py
@@ -27,8 +27,8 @@ def decode_scheduler_unconstrained():
 
 @pytest.fixture
 def seq_factory():
-    from atom.sampling_params import SamplingParams
     from atom.model_engine.sequence import Sequence
+    from atom.sampling_params import SamplingParams
 
     def make(token_ids, block_size=4):
         return Sequence(token_ids, block_size, sampling_params=SamplingParams())

--- a/tests/test_dspark.py
+++ b/tests/test_dspark.py
@@ -624,28 +624,6 @@ def test_traced_region_reads_no_per_step_globals():
         assert not leaked, f"{fn.__qualname__} reads {sorted(leaked)}"
 
 
-def test_warmup_is_the_first_traced_call_and_is_padded_off_0_1():
-    # mark_dynamic (decorator, FIRST call only) specializes size-0/1 dims rather
-    # than symbolizing them, so a graph first traced at B==1 holds no SymInt and
-    # PiecewiseBackend raises IndexError on sym_shape_indices[0].
-    #
-    # Warmup is made the first traced call and padded to B==2. Padding is sound
-    # ONLY there: the opaque attention op synthesizes a zero window on a dummy
-    # run and never reads attn_metadata. On a real step attn_metadata has
-    # exactly B rows, so swa_block_tables[:B] would return the real count and
-    # the [window ++ draft] concat would mismatch.
-    import inspect
-
-    from atom.models.deepseek_v4_dspark import DeepseekV4DSpark
-
-    src = inspect.getsource(DeepseekV4DSpark.forward_spec)
-    # Both paths go through __call__ now -- no `.forward` bypass.
-    assert "self.model.forward(" not in src
-    assert "self.model(" in src
-    # ...and the pad is gated on the dummy run.
-    assert "is_dummy and" in src
-
-
 def test_num_draft_change_raises():
     # num_draft is a python int, so it is baked into the compiled graph. It is
     # constant in practice (min(mtp_k, window_size)); fail loudly rather than
@@ -814,7 +792,7 @@ def test_lm_head_and_markov_sampler_are_outside_the_compiled_region():
     import inspect
     import textwrap
 
-    from atom.models.deepseek_v4_dspark import DeepseekV4DSpark, _DSparkInner
+    from atom.models.deepseek_v4_dspark import _DSparkInner
 
     tree = ast.parse(textwrap.dedent(inspect.getsource(_DSparkInner.forward)))
     attrs = set()
@@ -824,31 +802,38 @@ def test_lm_head_and_markov_sampler_are_outside_the_compiled_region():
     assert "get_logits" not in attrs, "LM head must not be traced"
     assert "forward_head" not in attrs, "Markov sampler must not be traced"
 
-    # ...and the wrapper must actually run them, or the draft returns hidden
-    # states instead of tokens.
-    src = inspect.getsource(DeepseekV4DSpark.forward_spec)
-    assert "head_and_sample" in src
+    # That the wrapper actually runs them is asserted where it can be
+    # observed -- `test_forward_spec_passes_the_batch_through_unpadded` records
+    # `head_and_sample`'s arguments, which only happens if it was called.
 
     # head_and_sample is a plain method: the decorator replaces only __call__.
     assert callable(_DSparkInner.head_and_sample)
 
 
-@pytest.mark.parametrize(
-    "is_dummy, B, expect_B",
-    [
-        # Warmup is the first traced call; padding B==1 to 2 keeps the batch dim
-        # symbolic (mark_dynamic specializes size-1). Sound only on a dummy run:
-        # the opaque attention op synthesizes a zero window and never reads
-        # attn_metadata. On a real step attn_metadata has exactly B rows, so
-        # swa_block_tables[:B] would return the real count and the
-        # [window ++ draft] concat would die on mismatched batch dims.
-        (True, 1, 2),
-        (False, 1, 1),
-        (True, 4, 4),
-        (False, 4, 4),
-    ],
-)
-def test_batch_dim_padded_only_for_a_dummy_run_at_b1(is_dummy, B, expect_B):
+@pytest.mark.parametrize("is_dummy", [True, False], ids=["dummy", "real"])
+@pytest.mark.parametrize("B", [1, 4])
+def test_forward_spec_passes_the_batch_through_unpadded(is_dummy, B):
+    """No pad, on any batch, dummy or not.
+
+    `forward_spec` used to repeat a B==1 dummy run to B==2: warmup was the
+    first traced call and `mark_dynamic` cannot make a size-1 dim dynamic.
+    Under `--enable-dp-attention` that pad ran 2*T MoE rows against a
+    `dp_metadata` sized for B==1 and tripped reduce_scatterv, so #1915 fixed
+    it upstream instead -- `warmup_model` gives a block drafter >= 2 sequences,
+    so the first trace is already B>=2 -- and dropped the pad entirely.
+
+    The two tests that covered the pad were left behind asserting a `repeat(2)`
+    that no longer happens and an `"is_dummy and" in src` that is no longer in
+    the source. Both were red from the day #1915 landed and nobody was told,
+    because this module `importorskip`s aiter and CI has none. This is the
+    contract that replaced them, and it is read off the call rather than off
+    the source: the pad would show up here as a batch the inner model did not
+    ask for.
+
+    `is_dummy` is still varied because "dummy runs are not special either" is
+    half of what changed.
+    """
+    expect_B = B
     from atom.models.deepseek_v4_dspark import DeepseekV4DSpark
 
     T = 5

--- a/tests/test_dspark_swa_fp8_2buff.py
+++ b/tests/test_dspark_swa_fp8_2buff.py
@@ -9,6 +9,7 @@ value at the last slot with unfilled slots zeroed. No model / engine needed."""
 
 import pytest
 import torch
+from import_guard import skip_if_dependency_missing
 
 # Broad on purpose: under bare non-GPU pytest this import chain fails in more
 # ways than ImportError, and every one of them means the same thing here.
@@ -17,7 +18,7 @@ try:
 
     import atom.model_ops.v4_kernels  # noqa: F401  (heavy import chain)
 except Exception as _e:  # noqa: BLE001
-    pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
+    skip_if_dependency_missing(_e, "requires full atom import env")
 
 from atom.model_ops.attentions.v4_pool_geometry import (
     CSA_RATIO,

--- a/tests/test_dspark_swa_fp8_2buff.py
+++ b/tests/test_dspark_swa_fp8_2buff.py
@@ -17,7 +17,7 @@ try:
     from aiter import dtypes
 
     import atom.model_ops.v4_kernels  # noqa: F401  (heavy import chain)
-except Exception as _e:  # noqa: BLE001
+except ImportError as _e:
     skip_if_dependency_missing(_e, "requires full atom import env")
 
 from atom.model_ops.attentions.v4_pool_geometry import (

--- a/tests/test_dummy_weight_init.py
+++ b/tests/test_dummy_weight_init.py
@@ -72,6 +72,7 @@ def _build_module():
 class TestDummyWeightInit(unittest.TestCase):
     def test_xavier_mode(self):
         import torch
+
         from atom.model_loader.loader import (
             _E8M0_UNIT_CODE,
             _FP4_UNIT_BYTE,

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -40,7 +40,7 @@ def _clean_atom_env(monkeypatch):
 
 def _get_envs():
     """Return the envs module; lazy __getattr__ re-evaluates on each access."""
-    import atom.utils.envs as envs
+    from atom.utils import envs
 
     return envs
 

--- a/tests/test_eplb_metadata.py
+++ b/tests/test_eplb_metadata.py
@@ -11,7 +11,7 @@ torch = pytest.importorskip("torch")
 try:
     import atom.config  # noqa: F401
     from atom.model_ops.eplb import ExpertLocationMetadata
-except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
+except ImportError as _e:  # aiter/triton absent under bare non-GPU pytest
     skip_if_dependency_missing(_e, "requires full atom import env")
 
 

--- a/tests/test_eplb_metadata.py
+++ b/tests/test_eplb_metadata.py
@@ -2,6 +2,7 @@
 # Tests for atom/model_ops/eplb.py ExpertLocationMetadata
 
 import pytest
+from import_guard import skip_if_dependency_missing
 
 torch = pytest.importorskip("torch")
 
@@ -11,7 +12,7 @@ try:
     import atom.config  # noqa: F401
     from atom.model_ops.eplb import ExpertLocationMetadata
 except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
-    pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
+    skip_if_dependency_missing(_e, "requires full atom import env")
 
 
 def test_from_rebalance_result_pads_and_derives_rank0():

--- a/tests/test_eplb_module_a.py
+++ b/tests/test_eplb_module_a.py
@@ -2,6 +2,7 @@
 # Tests for atom/model_ops/eplb.py (Module-A: ExpertLoadMonitor)
 
 import pytest
+from import_guard import skip_if_dependency_missing
 
 torch = pytest.importorskip("torch")
 
@@ -10,9 +11,9 @@ torch = pytest.importorskip("torch")
 # import that only surfaces when atom.model_ops is the entry-point import).
 try:
     import atom.config  # noqa: F401
-    import atom.model_ops.eplb as eplb
+    from atom.model_ops import eplb
 except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
-    pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
+    skip_if_dependency_missing(_e, "requires full atom import env")
 
 
 class _FakeTPGroup:

--- a/tests/test_eplb_module_a.py
+++ b/tests/test_eplb_module_a.py
@@ -12,7 +12,7 @@ torch = pytest.importorskip("torch")
 try:
     import atom.config  # noqa: F401
     from atom.model_ops import eplb
-except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
+except ImportError as _e:  # aiter/triton absent under bare non-GPU pytest
     skip_if_dependency_missing(_e, "requires full atom import env")
 
 

--- a/tests/test_eplb_module_b.py
+++ b/tests/test_eplb_module_b.py
@@ -10,7 +10,7 @@ torch = pytest.importorskip("torch")
 
 try:
     from atom.model_ops import eplb
-except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
+except ImportError as _e:  # aiter/triton absent under bare non-GPU pytest
     skip_if_dependency_missing(_e, "requires full atom import env")
 
 

--- a/tests/test_eplb_module_b.py
+++ b/tests/test_eplb_module_b.py
@@ -4,13 +4,14 @@
 import types
 
 import pytest
+from import_guard import skip_if_dependency_missing
 
 torch = pytest.importorskip("torch")
 
 try:
-    import atom.model_ops.eplb as eplb
+    from atom.model_ops import eplb
 except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
-    pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
+    skip_if_dependency_missing(_e, "requires full atom import env")
 
 
 class _FakeTPGroup:
@@ -30,7 +31,7 @@ def _init_monitor(monitor, *, num_layers=1, num_physical=2, device=None):
 
 
 def _record_single_pass(monitor, *, counts):
-    if monitor._cur_pass_count is None:  # noqa: SLF001
+    if monitor._cur_pass_count is None:
         _init_monitor(monitor, num_layers=1, num_physical=len(counts))
     monitor.on_forward_start()
     pairs = []

--- a/tests/test_eplb_module_c.py
+++ b/tests/test_eplb_module_c.py
@@ -13,7 +13,7 @@ try:
         rebalance_experts,
         replicate_experts,
     )
-except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
+except ImportError as _e:  # aiter/triton absent under bare non-GPU pytest
     skip_if_dependency_missing(_e, "requires full atom import env")
 
 

--- a/tests/test_eplb_module_c.py
+++ b/tests/test_eplb_module_c.py
@@ -2,6 +2,7 @@
 # Tests for atom/model_ops/eplb.py (Module-C rebalancing algorithms)
 
 import pytest
+from import_guard import skip_if_dependency_missing
 
 torch = pytest.importorskip("torch")
 
@@ -13,7 +14,7 @@ try:
         replicate_experts,
     )
 except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
-    pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
+    skip_if_dependency_missing(_e, "requires full atom import env")
 
 
 def test_balanced_packing_equal_cardinality():

--- a/tests/test_eplb_module_d.py
+++ b/tests/test_eplb_module_d.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
+from import_guard import skip_if_dependency_missing
 
 torch = pytest.importorskip("torch")
 
@@ -12,9 +13,9 @@ torch = pytest.importorskip("torch")
 # (aiter/triton) is unavailable.
 try:
     import atom.config  # noqa: F401
-    import atom.model_ops.eplb as eplb
+    from atom.model_ops import eplb
 except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
-    pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
+    skip_if_dependency_missing(_e, "requires full atom import env")
 
 
 def test_assign_sender_for_receiver_even_split():

--- a/tests/test_eplb_module_d.py
+++ b/tests/test_eplb_module_d.py
@@ -14,7 +14,7 @@ torch = pytest.importorskip("torch")
 try:
     import atom.config  # noqa: F401
     from atom.model_ops import eplb
-except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
+except ImportError as _e:  # aiter/triton absent under bare non-GPU pytest
     skip_if_dependency_missing(_e, "requires full atom import env")
 
 

--- a/tests/test_eplb_module_e.py
+++ b/tests/test_eplb_module_e.py
@@ -11,7 +11,7 @@ torch = pytest.importorskip("torch")
 try:
     import atom.config  # noqa: F401
     from atom.model_ops import eplb
-except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
+except ImportError as _e:  # aiter/triton absent under bare non-GPU pytest
     skip_if_dependency_missing(_e, "requires full atom import env")
 
 

--- a/tests/test_eplb_module_e.py
+++ b/tests/test_eplb_module_e.py
@@ -2,6 +2,7 @@
 # Tests for atom/model_ops/eplb.py (Module-E commit / visibility)
 
 import pytest
+from import_guard import skip_if_dependency_missing
 
 torch = pytest.importorskip("torch")
 
@@ -9,9 +10,9 @@ torch = pytest.importorskip("torch")
 # (aiter/triton) is unavailable.
 try:
     import atom.config  # noqa: F401
-    import atom.model_ops.eplb as eplb
+    from atom.model_ops import eplb
 except Exception as _e:  # aiter/triton absent under bare non-GPU pytest
-    pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
+    skip_if_dependency_missing(_e, "requires full atom import env")
 
 
 def test_move_from_buffer_applies_plan_inplace():

--- a/tests/test_io_processor_fanout.py
+++ b/tests/test_io_processor_fanout.py
@@ -23,7 +23,7 @@ import pytest
 if "atom.model_engine.engine_core_mgr" not in sys.modules:
     _stub = types.ModuleType("atom.model_engine.engine_core_mgr")
 
-    class _StubCoreManager:  # noqa: D401 - placeholder
+    class _StubCoreManager:
         def __init__(self, *a, **kw):
             self.added = []
 
@@ -34,9 +34,9 @@ if "atom.model_engine.engine_core_mgr" not in sys.modules:
     _stub.DisaggCoreManager = _StubCoreManager
     sys.modules["atom.model_engine.engine_core_mgr"] = _stub
 
-from atom.model_engine.llm_engine import InputOutputProcessor  # noqa: E402
-from atom.model_engine.sequence import Sequence  # noqa: E402
-from atom.sampling_params import SamplingParams  # noqa: E402
+from atom.model_engine.llm_engine import InputOutputProcessor
+from atom.model_engine.sequence import Sequence
+from atom.sampling_params import SamplingParams
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_kv_connector_scheduler.py
+++ b/tests/test_kv_connector_scheduler.py
@@ -22,12 +22,13 @@ pytest.importorskip(
 from atom.kv_transfer.disaggregation.kv_transfer_engine import (
     KVConnectorScheduler,
     Role,
+    _RoleManager,
     convert_virtual_to_physical_pages,
     get_port_offset,
     get_role,
     set_role,
-    _RoleManager,
 )
+
 from atom.kv_transfer.disaggregation.types import ConnectorMetadata
 from atom.model_engine.sequence import Sequence
 

--- a/tests/test_kv_events.py
+++ b/tests/test_kv_events.py
@@ -20,6 +20,7 @@ import time
 
 import msgspec
 import pytest
+from conftest import MockConfig
 
 from atom.distributed.kv_events import (
     MEDIUM_GPU,
@@ -34,7 +35,6 @@ from atom.distributed.kv_events import (
     make_publisher,
 )
 from atom.model_engine.block_manager import BlockManager
-from conftest import MockConfig
 
 # ── helpers ───────────────────────────────────────────────────────────────
 

--- a/tests/test_mega_mxfp4_method.py
+++ b/tests/test_mega_mxfp4_method.py
@@ -4,12 +4,13 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from import_guard import skip_if_dependency_missing
 
 try:
     # aiter/triton absent under bare non-GPU pytest
     import atom.model_ops.moe as moe_mod
 except Exception as exc:  # noqa: BLE001
-    pytest.skip(f"requires full atom import env: {exc}", allow_module_level=True)
+    skip_if_dependency_missing(exc, "requires full atom import env")
 
 
 def test_mega_method_is_mxfp4_specialization():

--- a/tests/test_mega_mxfp4_method.py
+++ b/tests/test_mega_mxfp4_method.py
@@ -9,7 +9,7 @@ from import_guard import skip_if_dependency_missing
 try:
     # aiter/triton absent under bare non-GPU pytest
     import atom.model_ops.moe as moe_mod
-except Exception as exc:  # noqa: BLE001
+except ImportError as exc:
     skip_if_dependency_missing(exc, "requires full atom import env")
 
 

--- a/tests/test_profiler_regression.py
+++ b/tests/test_profiler_regression.py
@@ -23,7 +23,7 @@ import tempfile
 
 import pytest
 import torch
-import torch.nn as nn
+from torch import nn
 
 # ---------------------------------------------------------------------------
 # Thresholds

--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -2,6 +2,7 @@
 # Tests for atom/sampling_params.py
 
 import pytest
+
 from atom.sampling_params import SamplingParams
 
 

--- a/tests/test_transfer_engine.py
+++ b/tests/test_transfer_engine.py
@@ -41,6 +41,7 @@ from atom.kv_transfer.disaggregation.kv_transfer_engine import (
     _RoleManager,
     set_role,
 )
+
 from atom.model_engine.sequence import Sequence
 from atom.utils import get_open_port, make_zmq_path
 
@@ -127,7 +128,7 @@ class TestMoRIIOWrapper:
         set_role(Role.PRODUCER)
         w = MoRIIOWrapper()
         w.done_remote_allocate_req_dict = {}
-        msg = f"{MoRIIOConstants.COMPLETION_PREFIX}:req-42".encode("utf-8")
+        msg = f"{MoRIIOConstants.COMPLETION_PREFIX}:req-42".encode()
         w._dispatch_message(msg)
         assert f"{MoRIIOConstants.COMPLETION_PREFIX}:req-42" in w.done_req_ids
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,18 +1,18 @@
 # SPDX-License-Identifier: MIT
 # Tests for atom/utils/__init__.py — pure functions only (no GPU / ZMQ required)
 
-from atom.utils import (
-    is_valid_ipv6_address,
-    split_host_port,
-    join_host_port,
-    get_tcp_uri,
-    get_device_indices,
-    _is_torch_equal_or_newer,
-    split_zmq_path,
-    make_zmq_path,
-)
-
 import pytest
+
+from atom.utils import (
+    _is_torch_equal_or_newer,
+    get_device_indices,
+    get_tcp_uri,
+    is_valid_ipv6_address,
+    join_host_port,
+    make_zmq_path,
+    split_host_port,
+    split_zmq_path,
+)
 
 # ── IPv6 validation ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What this is

One reader per wire format, for both delivery modes.

A tool-call format used to be read twice: `parse` took a complete output, and a
`process`/`flush` state machine took the same output a chunk at a time. Both had
to decide where content ends, whether an unclosed tag is a call or a quotation,
what a region that parses to nothing means, and which bytes are framing — so
every one of those rules existed six times over, once per format, in two copies.
Three rounds of review found the copies disagreeing about all four, and every
disagreement is a response a client gets one way with `stream=false` and another
with `stream=true`.

So a format now declares only what is particular to it — its markers, which of
them hand over the stream, and what one region's bytes mean — and a single
engine owns everything else. `stream=false` is that engine run over one chunk.
The two modes cannot disagree because there is nothing left for them to disagree
with.

## Why it is this large

The rewrite is one commit. The other 32 are what reading the same question six
ways had been hiding, plus the review rounds on the rewrite itself. The pattern
that kept recurring is worth naming, because most of the individual fixes are
instances of it: **one question with two answers, or one literal with two
readers.**

- A tool name had two grammars. `protocol.TOOL_NAME_RE` guarded what a request
  may declare, `usable_tool_name` guarded what a model may write, and the first
  was stricter — it rejected a leading digit that OpenAI's own
  `^[a-zA-Z0-9_-]{1,64}$` allows, every non-ASCII name, and the `server.tool`
  spelling MCP namespaces with. Declaring an MCP tool was a 400 before the model
  ever ran. `/v1/messages`, meanwhile, validated nothing, so the two endpoints
  disagreed about which tools were legal at all.
- MiniMax matched its ns_token at the head of two patterns that `CALL_FILLERS`
  already had a reader for. A pattern opening with an optional group has no
  fixed first byte, so `re` tries every position instead of skipping to the next
  `<`: 524 µs against 3.8 for the same work in DSML on an 18 KB region.
- Kimi-K3 declared the tokens it strips in one place and stripped them in
  another, and the two lists disagreed about four of them — reaching the client
  verbatim when streamed and deleted when not.

## The defects a user would have seen

- **A tool call's answer never streamed.** Everything written after a call
  waited for end of stream — 0 of 397 characters on five of six formats, and
  "call a tool, then explain the result" is the ordinary agentic shape.
- **A start marker was treated as a promise.** An answer explaining that a model
  "writes `<tool_call>` to call something" opened a region and never closed it,
  and everything from the marker on was dropped: no event, no error,
  `finish_reason` still `stop`.
- **Text between two calls was deleted.** "Let me also check Rome" between two
  `<tool_call>` blocks, on five of six formats, silently.
- **A call the client cannot dispatch.** `<invoke name="">` reached clients as a
  `tool_use` block with an empty name; DSML's wrapper-less recovery dispatched
  one named `unknown` for an answer that had merely written the tags.
- **The format was guessed from the output.** A Hermes-style
  `<tool_call>{"name": ...}` was read as GLM and the whole JSON object went out
  as the tool's *name*. It is resolved from the chat template at startup now,
  and a model with no registered format is announced as such rather than
  guessed at.
- **A stalled stream was invisible.** Now logged while it is stalled, not after.

## Tests

Generated from the two production registries — `reasoning_dialects.DIALECTS`
and the tool-parser detect order — crossed with text shapes built from each
entry's own declared markers, so registering a format adds coverage by itself.
The properties are stated as axes rather than cases: *no format may lose its
literal prefix*, *nothing known to be outside a call is buffered*, *the two
delivery modes agree on order*, *every reasoning-filter construction site is
seeded*.

Every new property was checked by reverting the fix and confirming it goes red.
That is not ceremony — the first draft of the order property was green against
the reverted fix, because its cases did not include the shape that flips DSML's
branch.

## Relationship to #1961

#1961 fixes a stall this branch also fixes, by a different route, and all six of
its files conflict here. Its assertions were run against this branch verbatim
before anything was decided: six pass unchanged, and the other three fail only
on a parameter name — it adds `starts_thinking: bool` to the fan-out where this
branch already passes a `ReasoningChannel`. Translated, all three outcomes hold.

Its observed shapes are carried in `f55241a29` rather than left to rot against a
rebase, with attribution. See the comment on that PR for the full comparison.

## Also here

`0e8142e62` repairs four tests that had drifted from the code they test.
`test_shared_expert_dispatch`, `test_deepseek_v4_wo_a_dequant` and `test_dspark`
all open with `pytest.importorskip("aiter")`, so they execute only on a machine
with the GPU stack and never on CI — two of them had been red since 2026-08-17
and nothing said so. Two had config doubles production had outgrown; two were
asserting behaviour #1915 deliberately removed. The doubles derive from
`dataclasses.fields(Config)` now, so a field added tomorrow arrives on its own.

## Test plan

- [x] `bash .github/scripts/run_unit_tests.sh` — **4140 passed, 0 failed** (9
      before this branch's last commit; all nine were the rotted tests above)
- [x] `black --check` clean; `ruff` reports nothing on lines this branch adds
      (CI filters to `diff_context`)
- [x] `tests/plugin` unchanged from `origin/main` — six collection errors,
      `diff`-identical, and CI ignores that path
- [x] Rebased onto `da7698b23`; all five conflicts were import blocks where both
      sides had added a name
- [ ] Accuracy/perf gates: not run. No engine or kernel path is touched — the
      diff is `atom/entrypoints/` plus tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
