### PR TITLE
fix(engine): include DP dummies in staging lifetime

### DIFF
--- a/atom/kv_transfer/offload/README.md
+++ b/atom/kv_transfer/offload/README.md
@@ -897,10 +897,11 @@ python -m atom.entrypoints.openai_server \
   --kv-transfer-config '{"kv_connector":"lmcache_offload","kv_role":"offload"}'
 ```
 
-For DSV4 version 1, use BF16 or FP8 KV/indexer layouts. FP4 indexer scale
-regions are not mapped and startup rejects that layout. Pipeline parallelism
-greater than one is also rejected; TP stores one PAGE shard and one AOS1
-sidecar per rank.
+Standalone DSV4 LMCache offload supports both FP8 and FP4 indexer layouts.
+FP4 PAGE objects include the packed data and separate e8m0 scale regions for
+every CSA layer. FP4 remains unsupported with PD connectors such as Mooncake
+or Moriio. Pipeline parallelism greater than one is also rejected; TP stores
+one PAGE shard and one AOS1 sidecar per rank.
 
 ### NVMe-only standalone example
 
@@ -1045,8 +1046,8 @@ a durable backend flush. PAGE transfer timing remains opt-in with
 Common diagnostics:
 
 - **No PAGE+SLOT registration line:** the model did not expose DSV4
-  `block_regions`, or startup rejected incomplete SLOT geometry, FP4 indexer
-  scale layout, PP, or an invalid staging count. Treat startup exceptions as
+  `block_regions`, or startup rejected incomplete PAGE/SLOT geometry, PP, or
+  an invalid staging count. Treat startup exceptions as
   configuration errors; do not force PAGE-only stateful operation.
 - **`SLOT sidecar load missing`:** PAGE may exist, but the boundary is not
   restorable. Expected causes include a failed earlier sidecar save and
@@ -1125,8 +1126,8 @@ ATOM baseline and the two vLLM columns are from separate runs and serve as
 reference (see caveat below):
 
 These measurements predate the DSV4 PAGE+AOS1 path and validate the dense
-raw-byte connector only. `MXFP4` here describes model weights; it is not evidence
-for the unsupported DSV4 FP4 indexer layout.
+raw-byte connector only. `MXFP4` here describes model weights; it is not
+performance evidence for the DSV4 FP4 indexer offload path.
 
 | metric | vLLM none | ATOM baseline | vLLM LMCache | ATOM offload (chunk2) |
 |--------|----------:|--------------:|-------------:|----------------------:|
@@ -1244,10 +1245,10 @@ python3 multi-round-qa.py \
 - **Stateful load with a nonzero HBM floor is skipped.** Version 1 does not merge
   a partial native HBM checkpoint with a later AOS1 snapshot. It recomputes for
   correctness even when LMCache has additional PAGE chunks.
-- **DSV4 FP4 indexer is unsupported.** Its scale region is not represented in
-  PAGE geometry, so registration fails before engine start. BF16 and FP8 are
-  supported. This restriction is about the DSV4 indexer layout, not merely model
-  weight quantization.
+- **DSV4 FP4 indexer is standalone-offload only.** LMCache PAGE geometry
+  includes both packed data and e8m0 scale regions. PD transfer through
+  Mooncake/Moriio still fails at startup until its producer/consumer mapping is
+  extended for the separate scale pool.
 - **Pipeline parallelism is unsupported for DSV4 PAGE+SLOT.** TP is supported
   with one rank-local PAGE shard and AOS1 object per rank.
 - **Sidecar discovery is session-local.** A scheduler restart does not rebuild

--- a/atom/kv_transfer/offload/config.py
+++ b/atom/kv_transfer/offload/config.py
@@ -23,10 +23,10 @@ from typing import Any
 
 import torch
 
-# Version 2 adds explicit DSV4 KV/index dimensions and DCP virtual-block byte
-# mapping to the PAGE identity. Keeping it separate prevents version-1 objects
-# from being reused after the layout correction.
-PAGE_LAYOUT_VERSION = 2
+# Version 3 adds the effective index-cache dtype to the PAGE identity. FP4 and
+# FP8 DSV4 indexers have different region counts and byte layouts, so they must
+# never reuse one another's objects even when the HF model config is identical.
+PAGE_LAYOUT_VERSION = 3
 _PAGE_FINGERPRINT_BYTES = 16
 _OFFLOAD_LAYOUT_ALIASES = {
     "hybrid": "hybrid",
@@ -179,6 +179,7 @@ def build_page_namespace(
             else "dense-opaque-block"
         ),
         "kv_cache_dtype": str(getattr(config, "kv_cache_dtype", "auto")),
+        "index_cache_dtype": str(getattr(config, "index_cache_dtype", "auto")),
         "block_size": _strict_integer(
             "PAGE block size",
             config.kv_cache_block_size,
@@ -213,7 +214,7 @@ def build_page_namespace(
     digest = hashlib.blake2b(
         canonical,
         digest_size=_PAGE_FINGERPRINT_BYTES,
-        person=b"ATOM-PAGE-CFG-v2",
+        person=b"ATOM-PAGE-CFG-v3",
     ).hexdigest()
     return f"{base_model_name}::atom-page-v{layout_version}-{digest}"
 

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1303,7 +1303,8 @@ class ModelRunner:
         still reading. Each in-flight slot gets its own buffer set; reuse of a
         slot is gated by a per-slot CUDA event (see ``_advance_forward_vars`` /
         ``_record_forward_vars_event``), bounding the CPU's GPU lead to the ring
-        size even when the head pops middle-chunk batches without a GPU sync.
+        size even when the head runs middle-chunk or DP-sync dummy batches
+        without a GPU sync.
 
         When ``pp_size == 1`` the ring is the single original dict and advance is
         a no-op, so behavior is unchanged.
@@ -1347,8 +1348,11 @@ class ModelRunner:
         logger.info(f"forward_vars ring: {pp_size} slots (pipeline parallel)")
 
     def _advance_forward_vars(self):
-        """Rotate to the next in-flight slot. Called once per real forward,
-        before any buffer is written. No-op when the ring has a single slot."""
+        """Rotate to the next in-flight slot before any buffer is written.
+
+        Dummy forwards use the same staging buffers as real forwards, so they
+        participate in the ring too. No-op when the ring has a single slot.
+        """
         if len(self._fv_ring) == 1:
             return
         self._fv_idx = (self._fv_idx + 1) % len(self._fv_ring)
@@ -1381,6 +1385,10 @@ class ModelRunner:
         buying nothing. A never-recorded event passes, so the first forward is
         not held.
 
+        DP-sync dummy forwards use these same buffers and can also return while
+        their copies are in flight. They must therefore enter this gate and
+        record the event just like real forwards.
+
         The pipeline ring solves the same problem by rotating buffers, which
         bounds the lead to its depth; `_stage_h2d_done` is None there and this
         does nothing.
@@ -1403,7 +1411,8 @@ class ModelRunner:
     def _record_forward_vars_event(self):
         """Mark the current slot's forward as done on the GPU stream. Paired
         with the synchronize() in ``_advance_forward_vars``. Called at the end of
-        every real forward. No-op when the ring has a single slot."""
+        every forward, including DP-sync dummies. No-op when the ring has a
+        single slot."""
         if len(self._fv_ring) == 1:
             return
         self._fv_slot_events[self._fv_idx].record()
@@ -2746,6 +2755,25 @@ class ModelRunner:
         )
         input_ids = self.tokenID_processor.prepare_input_ids(batch)
         self.prepare_inputs(batch, input_ids, preprocessed=preprocessed)
+
+        # Stage the speculative inputs while this forward's normal staging
+        # window is still open.  Both buffers are pinned and reused, so copying
+        # them later from postprocess would fall outside the event recorded by
+        # forward() immediately after prepare_model().
+        if hasattr(self, "drafter"):
+            forward_context = get_forward_context()
+            if batch.next_token_ids is not None:
+                forward_context.context.draft_anchor_overrides = (
+                    self.drafter.anchors_to_gpu(batch.next_token_ids)
+                )
+            ragged_lens = getattr(batch, "dynamic_spec_query_tokens_per_req", None)
+            if ragged_lens is not None and batch.total_tokens_num_prefill == 0:
+                scheduled_bs = batch.total_seqs_num_decode
+                lens_buf = self.forward_vars["ragged_lens"]
+                lens_buf.np[:scheduled_bs] = np.asarray(ragged_lens)[:scheduled_bs]
+                forward_context.context.draft_ragged_lens = lens_buf.copy_to_gpu(
+                    scheduled_bs
+                )
         return (
             input_ids,
             temperatures,
@@ -3345,9 +3373,12 @@ class ModelRunner:
         # Make this forward's staging buffers safe to overwrite before
         # prepare_inputs writes them: rotate to a free slot if there is a ring,
         # otherwise wait out the previous forward's copies.
-        if not batch.is_dummy_run:
-            self._advance_forward_vars()
-            self._gate_staging_reuse()
+        # Dummy forwards use and asynchronously upload the same staging
+        # buffers. Excluding them here leaves no event between a dummy and the
+        # following real forward, allowing that real forward's CPU writes to
+        # race the dummy's still-pending H2D copies.
+        self._advance_forward_vars()
+        self._gate_staging_reuse()
         (
             input_ids,
             temperatures,
@@ -3356,8 +3387,7 @@ class ModelRunner:
             all_greedy,
             needs_independent_noise,
         ) = self.prepare_model(batch)
-        if not batch.is_dummy_run:
-            self._mark_staging_h2d_enqueued()
+        self._mark_staging_h2d_enqueued()
         logits, hidden_states = self.run_model(input_ids, batch)
 
         pp_group = get_pp_group()
@@ -3405,8 +3435,7 @@ class ModelRunner:
                 )
             reset_forward_context()
             # Mark this slot's GPU work (attention consumed its metadata) done.
-            if not batch.is_dummy_run:
-                self._record_forward_vars_event()
+            self._record_forward_vars_event()
             return ScheduledBatchOutput(
                 req_ids=list(batch.req_ids),
                 token_ids=[],
@@ -3427,8 +3456,7 @@ class ModelRunner:
         )
 
         reset_forward_context()
-        if not batch.is_dummy_run:
-            self._record_forward_vars_event()
+        self._record_forward_vars_event()
         return fwd_output
 
     @staticmethod
@@ -3508,7 +3536,8 @@ class ModelRunner:
                 "sampled -- they are matched positionally"
             )
             # -1 marks "sampling supplies it", so keep the sampled value there.
-            override = self.drafter.anchors_to_gpu(nxt)
+            override = forward_context.context.draft_anchor_overrides
+            assert override is not None
             next_token_ids = torch.where(
                 override >= 0, override.to(next_token_ids.dtype), next_token_ids
             )
@@ -3527,15 +3556,11 @@ class ModelRunner:
             # RAGGED: each seg has its own len_i; anchor offset = len_i - num_bonus_i
             # (num_bonus_i = mtp_k - num_reject_i), applied to cu_seqlens_q ends.
             sbs = batch.total_seqs_num_decode
-            # Pinned staging + non_blocking: a pageable H2D here would sit
-            # between the target forward and the block draft and synchronize the
-            # stream, forcing the host to wait out the whole target forward.
-            # int32 matches num_reject_tokens (rejection_sampler emits int32 and
-            # default_num_rejected_tokens is int32), so the arithmetic below
-            # keeps the dtype it had before.
-            lens_buf = self.forward_vars["ragged_lens"]
-            lens_buf.np[:sbs] = np.asarray(ragged_lens)[:sbs]
-            lens_t = lens_buf.copy_to_gpu(sbs)
+            # This pinned H2D was staged in prepare_model(), before the
+            # forward's staging event was recorded. int32 matches
+            # num_reject_tokens, so the arithmetic keeps its original dtype.
+            lens_t = forward_context.context.draft_ragged_lens
+            assert lens_t is not None and lens_t.shape[0] == sbs
             num_bonus = self.drafter.mtp_k - num_reject_tokens[:sbs]
             last_token_offset = lens_t - num_bonus
         elif (

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -1178,11 +1178,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         failure it removes is a scatter into whatever the allocator handed
         that address range to next.
         """
-        runner = self.model_runner
         planes = self._kv_planes()
-        pools = [runner.v4_csa_idx_kv]
-        if self._indexer_fp4:
-            pools.append(runner.v4_csa_idx_kv_scale)
+        pools = [pool for pool, _ in self._indexer_page_pools()]
         owners = tuple(t.data_ptr() for t in (*planes, *pools))
         # The whole test: there is always at least one plane, so the owners of
         # a built cache are never the empty tuple this starts as, and an
@@ -1340,6 +1337,26 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         ]
         assert len(planes) == len(self._plane_row_widths())
         return planes
+
+    def _indexer_page_pools(self) -> list[tuple[torch.Tensor, str]]:
+        """Indexer pools and semantic-role prefixes in PAGE stream order.
+
+        FP8 keeps data and its row scales in one tensor. FP4 stores packed
+        data and e8m0 scales in separate block-indexed tensors, and both are
+        required to restore indexer logits bit-for-bit. This is the single
+        enumeration used by the internal PAGE checkpoint copier and external
+        transfer/offload registration so neither path can omit a pool.
+        """
+        runner = self.model_runner
+        if self._indexer_fp4:
+            return [
+                (runner.v4_csa_idx_kv, "dsv4.csa_indexer.fp4_data"),
+                (
+                    runner.v4_csa_idx_kv_scale,
+                    "dsv4.csa_indexer.fp4_scale",
+                ),
+            ]
+        return [(runner.v4_csa_idx_kv, "dsv4.csa_indexer")]
 
     def allocate_kv_cache_tensors(
         self, num_kv_heads: int, num_draft_layers: int
@@ -1797,16 +1814,18 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             return None
 
         # `get_kv_transfer_tensors` is called unconditionally on every
-        # `allocate_kv_cache`; returning None means "no transfer region." Only
-        # fail when transfer or offload is active. The FP4 indexer's separate
-        # uint8 e8m0 scale pool is not yet described by the region map below,
-        # so registering it would expose a half-described cache.
-        transfer_active = bool(getattr(runner.config, "kv_transfer_config", None))
-        if self._indexer_fp4 and transfer_active:
+        # `allocate_kv_cache`; returning None means "no transfer region."
+        # Standalone LMCache offload can carry both FP4 indexer pools, but PD
+        # connectors have a separate producer/consumer region contract which
+        # has not been extended to the FP4 scale pool yet.
+        transfer_config = getattr(runner.config, "kv_transfer_config", None)
+        transfer_active = bool(transfer_config)
+        if self._indexer_fp4 and transfer_active and _uses_pd_staging(transfer_config):
             raise NotImplementedError(
-                "DeepSeek-V4 KV transfer/offload with --index_cache_dtype fp4 "
-                "is unsupported because the unmapped FP4 indexer scale pool "
-                "would be omitted; use the FP8 indexer or disable transfer/offload."
+                "DeepSeek-V4 PD transfer with --index_cache_dtype fp4 is "
+                "unsupported; standalone LMCache offload supports FP4, but "
+                "Mooncake/Moriio producer-consumer staging does not yet map "
+                "the separate FP4 indexer scale pool."
             )
         if transfer_active and getattr(runner.config, "pipeline_parallel_size", 1) > 1:
             raise NotImplementedError(
@@ -1815,10 +1834,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 "because each PAGE/SLOT plane region covers every layer; use "
                 "PP=1 or disable DeepSeek-V4 transfer/offload."
             )
-        if self._indexer_fp4:
-            # Single-node FP4 indexer: the FP8 region map below references the
-            # absent fp8 idx pool (`v4_csa_idx_kv` is uint8 here, no scale
-            # region). No transfer is active, so skip building regions.
+        if self._indexer_fp4 and not transfer_active:
+            # No connector will consume the regions in a single-node run.
             return None
 
         num_slots = self.num_state_slots
@@ -1866,17 +1883,35 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 )
             )
 
-        # Compressed PAGE regions: CSA Indexer KV (FP8).
-        for pos, layer_id in enumerate(self.csa_layers):
-            t = runner.v4_csa_idx_kv[pos]
-            bpb = self.csa_rows_per_block * self._index_row_bytes
-            block_regions.append(
-                KVTransferRegion(
-                    t.data_ptr(),
-                    t.numel() * t.element_size(),
-                    bpb,
-                    semantic_role=f"dsv4.csa_indexer.layer_{layer_id}",
+        # Compressed PAGE regions: one per CSA layer in each indexer pool.
+        # The pool order is data then scale for FP4, matching the internal
+        # checkpoint stream. Derive the block width from the actual view so
+        # this remains correct for both the FP8 row layout and FP4 tiles.
+        for pool, role_prefix in self._indexer_page_pools():
+            for pos, layer_id in enumerate(self.csa_layers):
+                view = pool[pos]
+                if not view.is_contiguous():
+                    raise RuntimeError(
+                        "a CSA indexer layer must be contiguous to be transferred"
+                    )
+                block_regions.append(
+                    KVTransferRegion(
+                        view.data_ptr(),
+                        view.numel() * view.element_size(),
+                        view.stride(0) * view.element_size(),
+                        semantic_role=f"{role_prefix}.layer_{layer_id}",
+                    )
                 )
+
+        checkpoint_spec = runner.state_runtime.checkpoint_spec
+        if checkpoint_spec is None:
+            raise RuntimeError("DSV4 PAGE/state checkpoint sizing spec is missing")
+        transfer_page_bytes = sum(region.unit_bytes for region in block_regions)
+        if transfer_page_bytes != checkpoint_spec.page_unit_bytes:
+            raise RuntimeError(
+                "DSV4 PAGE transfer regions do not cover the sized PAGE unit: "
+                f"regions={transfer_page_bytes}, "
+                f"checkpoint={checkpoint_spec.page_unit_bytes}"
             )
 
         # Full per-request SLOT (legacy field name: `swa_block_regions`) is one

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -209,7 +209,9 @@ class EagleProposer(Drafter):
         # Anchor row per sequence = `cu_seqlens_q[1:] - 1`, the rule
         # `propose_draft_token_ids` uses on a pure prefill step.
         last_token_indices = self.prepare_inputs(bs, 1)
-        anchor_ids = self.anchors_to_gpu(anchors)
+        anchor_ids = forward_context.context.draft_anchor_overrides
+        assert anchor_ids is not None
+        anchor_ids = anchor_ids[:bs]
 
         # `positions` is the padded forward buffer; the target's own output row
         # count is this batch's real token count, and all three inputs below

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -333,6 +333,12 @@ class Context:
     # land on each other's rows. Read per-thread (the context is thread-local).
     ubatch_token_offset: int = 0
 
+    # Optional speculative-decoding inputs staged alongside the target
+    # forward's other host-to-device copies. Keeping these on the per-forward
+    # context avoids launching pinned-buffer H2Ds later from postprocess.
+    draft_anchor_overrides: torch.Tensor | None = None
+    draft_ragged_lens: torch.Tensor | None = None
+
     def __init__(
         self,
         positions: torch.Tensor,
@@ -345,6 +351,8 @@ class Context:
         forward_mode: ForwardMode | None = None,
         input_ids: torch.Tensor | None = None,
         ubatch_token_offset: int = 0,
+        draft_anchor_overrides: torch.Tensor | None = None,
+        draft_ragged_lens: torch.Tensor | None = None,
     ):
         self.positions = positions
         self.is_prefill = is_prefill
@@ -356,6 +364,8 @@ class Context:
         self.forward_mode = forward_mode
         self.input_ids = input_ids
         self.ubatch_token_offset = ubatch_token_offset
+        self.draft_anchor_overrides = draft_anchor_overrides
+        self.draft_ragged_lens = draft_ragged_lens
 
 
 @dataclass

--- a/tests/test_deepseek_v4_transfer_regions.py
+++ b/tests/test_deepseek_v4_transfer_regions.py
@@ -7,6 +7,7 @@ import importlib.util
 import sys
 import types
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -26,6 +27,7 @@ _ROPE_HEAD_DIM = 4
 _CSA_ROWS_PER_BLOCK = 64
 _INDEX_ROW_BYTES = 132
 _CSA_REGION_COUNT = 2
+_FP4_K_TILES = 1
 
 
 def test_generic_transfer_tensors_default_to_no_full_slot_expectation():
@@ -152,9 +154,12 @@ def _transfer_builder(
     builder.csa_layers = [0, 2]
     builder.csa_rows_per_block = _CSA_ROWS_PER_BLOCK
     builder._index_row_bytes = _INDEX_ROW_BYTES
+    builder._idx_k_tiles = _FP4_K_TILES
     builder.pool_geometry = geo
     builder.compress_ratios = ratios
     builder._checkpoint_range_cache = None
+    builder._page_unit_region_cache = None
+    builder._page_unit_region_owners = ()
 
     if kv_dtype == "fp8":
         row_widths = [
@@ -167,15 +172,41 @@ def _transfer_builder(
         torch.empty(geo.plane_bytes(row_bytes), dtype=torch.uint8)
         for row_bytes in row_widths
     ]
-    indexers = torch.empty(
-        (
-            len(builder.csa_layers),
-            num_blocks,
-            builder.csa_rows_per_block,
-            builder._index_row_bytes,
-        ),
-        dtype=torch.uint8,
-    )
+    if indexer_fp4:
+        indexers = torch.empty(
+            (
+                len(builder.csa_layers),
+                num_blocks,
+                builder._idx_k_tiles,
+                4,
+                builder.csa_rows_per_block,
+                16,
+            ),
+            dtype=torch.uint8,
+        )
+        indexer_scales = torch.empty(
+            (
+                len(builder.csa_layers),
+                num_blocks,
+                builder._idx_k_tiles,
+                4,
+                builder.csa_rows_per_block,
+            ),
+            dtype=torch.uint8,
+        )
+        indexer_pools = [indexers, indexer_scales]
+    else:
+        indexers = torch.empty(
+            (
+                len(builder.csa_layers),
+                num_blocks,
+                builder.csa_rows_per_block,
+                builder._index_row_bytes,
+            ),
+            dtype=torch.uint8,
+        )
+        indexer_scales = None
+        indexer_pools = [indexers]
     config = SimpleNamespace(
         kv_transfer_config=transfer_config or {},
         pipeline_parallel_size=pipeline_parallel_size,
@@ -194,25 +225,29 @@ def _transfer_builder(
         checkpoint_spec=PagedStateCheckpointSpec(
             page_unit_bytes=(
                 sum(geo.block_bytes(width) for width in row_widths)
-                + len(builder.csa_layers)
-                * builder.csa_rows_per_block
-                * builder._index_row_bytes
+                + sum(
+                    len(builder.csa_layers) * pool.stride(1) * pool.element_size()
+                    for pool in indexer_pools
+                )
             ),
             slot_bytes=sum(geo.slot_bytes(width) for width in row_widths),
             image_bytes=builder.checkpoint_image_bytes(),
             layout_id=layout_id,
         ),
     )
-    builder.model_runner = SimpleNamespace(
-        config=config,
-        state_runtime=state_runtime,
-        num_physical_kvcache_blocks=num_blocks,
-        pool_plan=SimpleNamespace(entries={STATE_SLOT_CLASS: num_slots}),
-        v4_unified_kv=planes[0],
-        v4_kv_plane=planes[0],
-        v4_kv_plane_rope=planes[1] if len(planes) == 2 else None,
-        v4_csa_idx_kv=indexers,
-    )
+    runner_values = {
+        "config": config,
+        "state_runtime": state_runtime,
+        "num_physical_kvcache_blocks": num_blocks,
+        "pool_plan": SimpleNamespace(entries={STATE_SLOT_CLASS: num_slots}),
+        "v4_unified_kv": planes[0],
+        "v4_kv_plane": planes[0],
+        "v4_kv_plane_rope": planes[1] if len(planes) == 2 else None,
+        "v4_csa_idx_kv": indexers,
+    }
+    if indexer_scales is not None:
+        runner_values["v4_csa_idx_kv_scale"] = indexer_scales
+    builder.model_runner = SimpleNamespace(**runner_values)
     return builder, geo, planes, row_widths
 
 
@@ -266,7 +301,10 @@ def _assert_transfer_geometry(
         unified_codec.slot_bytes
     )
 
-    assert len(transfer.block_regions) == len(planes) + _CSA_REGION_COUNT
+    indexer_pool_count = 2 if builder._indexer_fp4 else 1
+    assert len(transfer.block_regions) == (
+        len(planes) + indexer_pool_count * _CSA_REGION_COUNT
+    )
     assert len(transfer.swa_block_regions) == len(planes)
     assert transfer.slot_regions == []
     assert all(not region.reverse_indexed for region in transfer.block_regions)
@@ -283,14 +321,28 @@ def _assert_transfer_geometry(
     _assert_plane_region_geometry(transfer, geo, planes, row_widths)
 
     indexer_regions = transfer.block_regions[len(planes) :]
-    for region, tensor in zip(
+    expected_indexer_regions = [
+        (pool[pos], f"{role_prefix}.layer_{layer_id}")
+        for pool, role_prefix in builder._indexer_page_pools()
+        for pos, layer_id in enumerate(builder.csa_layers)
+    ]
+    for region, (tensor, role) in zip(
         indexer_regions,
-        builder.model_runner.v4_csa_idx_kv,
+        expected_indexer_regions,
         strict=True,
     ):
         assert region.base_addr == tensor.data_ptr()
-        assert region.unit_bytes == _CSA_ROWS_PER_BLOCK * _INDEX_ROW_BYTES
+        assert region.unit_bytes == tensor.stride(0) * tensor.element_size()
         assert region.total_bytes == tensor.numel() * tensor.element_size()
+        assert region.semantic_role == role
+
+    checkpoint_bases, checkpoint_strides = builder._page_unit_regions()
+    assert checkpoint_bases.tolist() == [
+        region.base_addr for region in transfer.block_regions
+    ]
+    assert checkpoint_strides.tolist() == [
+        region.unit_bytes for region in transfer.block_regions
+    ]
 
 
 def test_bf16_transfer_regions_cover_page_and_full_slot_geometry(v4_builder_cls):
@@ -324,47 +376,80 @@ def test_fp8_transfer_regions_cover_both_pages_and_full_slots(v4_builder_cls):
     assert len(builder.get_kv_transfer_tensors().swa_block_regions) == 2
 
 
-def test_explicit_row_width_oracle_rejects_mutated_builder_helper(v4_builder_cls):
-    builder, geo, planes, row_widths = _transfer_builder(
+def test_page_region_sizing_rejects_mutated_builder_helper(v4_builder_cls):
+    builder, _, _, row_widths = _transfer_builder(
         v4_builder_cls,
         kv_dtype="bf16",
         transfer_config={"kv_connector": "LMCacheOffloadConnector"},
     )
     builder._plane_row_widths = lambda: [row_widths[0] + 1]
 
+    with pytest.raises(RuntimeError, match="do not cover the sized PAGE unit"):
+        builder.get_kv_transfer_tensors()
+
+
+def test_fp4_indexer_offload_covers_data_and_scale_page_regions(v4_builder_cls):
+    builder, geo, planes, row_widths = _transfer_builder(
+        v4_builder_cls,
+        kv_dtype="fp8",
+        transfer_config={
+            "kv_connector": "LMCacheOffloadConnector",
+            "kv_role": "offload",
+        },
+        indexer_fp4=True,
+    )
+
+    _assert_transfer_geometry(builder, geo, planes, row_widths)
+
     transfer = builder.get_kv_transfer_tensors()
-    with pytest.raises(AssertionError):
-        _assert_plane_region_geometry(transfer, geo, planes, row_widths)
+    assert transfer is not None
+    data_bytes = _FP4_K_TILES * 4 * _CSA_ROWS_PER_BLOCK * 16
+    scale_bytes = _FP4_K_TILES * 4 * _CSA_ROWS_PER_BLOCK
+    assert [region.unit_bytes for region in transfer.block_regions[-4:]] == [
+        data_bytes,
+        data_bytes,
+        scale_bytes,
+        scale_bytes,
+    ]
+    assert [region.semantic_role for region in transfer.block_regions[-4:]] == [
+        "dsv4.csa_indexer.fp4_data.layer_0",
+        "dsv4.csa_indexer.fp4_data.layer_2",
+        "dsv4.csa_indexer.fp4_scale.layer_0",
+        "dsv4.csa_indexer.fp4_scale.layer_2",
+    ]
+    assert len(transfer.swa_block_regions) == len(planes)
 
 
-@pytest.mark.parametrize(
-    "transfer_config",
-    [
-        pytest.param(
-            {"kv_connector": "LMCacheOffloadConnector", "kv_role": "offload"},
-            id="offload",
-        ),
-        pytest.param(
-            {"kv_connector": "MooncakeConnector", "kv_role": "kv_both"},
-            id="pd",
-        ),
-    ],
-)
-def test_fp4_indexer_rejects_every_active_transfer_before_region_registration(
-    v4_builder_cls,
-    transfer_config,
-):
+def test_fp4_indexer_pd_transfer_remains_unsupported(v4_builder_cls):
     builder, *_ = _transfer_builder(
         v4_builder_cls,
         kv_dtype="fp8",
-        transfer_config=transfer_config,
+        transfer_config={"kv_connector": "mooncake", "kv_role": "kv_both"},
         indexer_fp4=True,
     )
 
     with pytest.raises(
         NotImplementedError,
-        match="unmapped FP4 indexer scale pool",
+        match=r"PD transfer.*index_cache_dtype fp4.*unsupported",
     ):
+        builder.get_kv_transfer_tensors()
+
+
+def test_page_region_registration_rejects_incomplete_geometry(v4_builder_cls):
+    builder, *_ = _transfer_builder(
+        v4_builder_cls,
+        kv_dtype="fp8",
+        transfer_config={"kv_connector": "LMCacheOffloadConnector"},
+        indexer_fp4=True,
+    )
+    runtime = builder.model_runner.state_runtime
+    spec = runtime.checkpoint_spec
+    builder.model_runner.state_runtime = replace(
+        runtime,
+        checkpoint_spec=replace(spec, page_unit_bytes=spec.page_unit_bytes + 1),
+    )
+
+    with pytest.raises(RuntimeError, match="do not cover the sized PAGE unit"):
         builder.get_kv_transfer_tensors()
 
 

--- a/tests/test_lmcache_offload_config.py
+++ b/tests/test_lmcache_offload_config.py
@@ -19,6 +19,7 @@ def _config():
         model="org/model",
         model_tag="org/model",
         kv_cache_dtype="fp8",
+        index_cache_dtype="fp8",
         kv_cache_block_size=256,
         tensor_parallel_size=4,
         decode_context_parallel_size=2,
@@ -76,6 +77,7 @@ def test_page_namespace_supports_torch_dtype_in_speculative_config():
     "mutate",
     [
         lambda config, cfg: setattr(config, "kv_cache_dtype", "bf16"),
+        lambda config, cfg: setattr(config, "index_cache_dtype", "fp4"),
         lambda config, cfg: setattr(config.hf_config, "indexer_dtype", "bf16"),
         lambda config, cfg: setattr(config.hf_config, "kv_head_dim", 576),
         lambda config, cfg: setattr(config.hf_config, "index_head_dim", 160),
@@ -95,6 +97,7 @@ def test_page_namespace_supports_torch_dtype_in_speculative_config():
     ],
     ids=[
         "kv-dtype",
+        "effective-index-dtype",
         "index-dtype",
         "kv-head-dim",
         "index-head-dim",

--- a/tests/test_model_runner_staging_fence.py
+++ b/tests/test_model_runner_staging_fence.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Source-level contracts for ModelRunner's staging-buffer lifetime.
+
+Importing ModelRunner pulls in the GPU attention stack.  These tests inspect
+the method AST instead so they remain part of the non-GPU pre-checkin suite.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+MODEL_RUNNER = Path(__file__).resolve().parents[1] / "atom/model_engine/model_runner.py"
+EAGLE_PROPOSER = (
+    Path(__file__).resolve().parents[1] / "atom/spec_decode/eagle_proposer.py"
+)
+
+
+def _method(
+    name: str,
+    *,
+    path: Path = MODEL_RUNNER,
+    class_name: str = "ModelRunner",
+) -> ast.FunctionDef:
+    module = ast.parse(path.read_text())
+    owner = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    return next(
+        node
+        for node in owner.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _attribute_calls(method: ast.FunctionDef, attribute: str) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == attribute
+    ]
+
+
+def _parent_map(root: ast.AST) -> dict[ast.AST, ast.AST]:
+    return {
+        child: parent
+        for parent in ast.walk(root)
+        for child in ast.iter_child_nodes(parent)
+    }
+
+
+def _is_below_dummy_guard(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
+    while node in parents:
+        node = parents[node]
+        if isinstance(node, ast.If) and "is_dummy_run" in ast.unparse(node.test):
+            return True
+    return False
+
+
+def test_dummy_forward_participates_in_staging_lifetime():
+    """DP-sync dummies must protect the buffers that they upload and reuse.
+
+    An idle DP replica executes a dummy while its peer handles a real batch.
+    The dummy uses the same pinned ``forward_vars`` and returns without a host
+    synchronization.  Skipping either side of the lifetime protocol lets the
+    following forward overwrite a still-copying dummy source buffer.
+    """
+    method = _method("forward")
+    parents = _parent_map(method)
+    expected_counts = {
+        "_advance_forward_vars": 1,
+        "_gate_staging_reuse": 1,
+        "_mark_staging_h2d_enqueued": 1,
+        "_record_forward_vars_event": 2,
+    }
+
+    calls_by_name = {name: _attribute_calls(method, name) for name in expected_counts}
+    assert {
+        name: len(calls) for name, calls in calls_by_name.items()
+    } == expected_counts
+    assert all(
+        not _is_below_dummy_guard(call, parents)
+        for calls in calls_by_name.values()
+        for call in calls
+    )
+
+    prepare_model = _attribute_calls(method, "prepare_model")
+    run_model = _attribute_calls(method, "run_model")
+    assert len(prepare_model) == len(run_model) == 1
+    assert (
+        calls_by_name["_gate_staging_reuse"][0].lineno
+        < prepare_model[0].lineno
+        < calls_by_name["_mark_staging_h2d_enqueued"][0].lineno
+        < run_model[0].lineno
+    )
+
+
+def test_late_draft_uploads_are_staged_by_prepare_model():
+    """Draft setup must not start a new pinned H2D after the staging event."""
+    prepare_model = _method("prepare_model")
+    propose = _method("propose_draft_token_ids")
+    precompute = _method(
+        "precompute_context_kv",
+        path=EAGLE_PROPOSER,
+        class_name="EagleProposer",
+    )
+
+    assert len(_attribute_calls(prepare_model, "anchors_to_gpu")) == 1
+    assert len(_attribute_calls(prepare_model, "copy_to_gpu")) == 1
+    assert not _attribute_calls(propose, "anchors_to_gpu")
+    assert not _attribute_calls(propose, "copy_to_gpu")
+    assert not _attribute_calls(precompute, "anchors_to_gpu")


### PR DESCRIPTION
## Motivation

Follow-up to #1987. DeepSeek-V4-Pro, DP2 x TP4, C48 can abort during the
agentic warm-up after one DP replica drains and starts running DP-sync dummy
forwards while its peer continues long chunked prefill.

The failing agentic command has `kv_transfer_config={}`. This crash is in the
core ModelRunner staging path, not LMCache.

## Root cause

`CpuGpuBuffer.copy_to_gpu(..., non_blocking=True)` starts DMA from reusable
pinned host storage. For PP=1, `_stage_h2d_done` protects that single staging
slot, but `ModelRunner.forward()` excluded `is_dummy_run` from both ends of the
lifetime protocol:

```python
if not batch.is_dummy_run:
    self._gate_staging_reuse()
...
if not batch.is_dummy_run:
    self._mark_staging_h2d_enqueued()
```

`dummy_execution()` nevertheless calls the same `prepare_model()`, which
writes and uploads `input_ids`, `cu_seqlens_q`, positions, and the V4 attention
metadata. It also runs `postprocess()` / MTP `propose()` and can return while
those queued operations are still in flight. The next real forward therefore
waited on the last *real* event, not the immediately preceding dummy, and could
rewrite a pinned source before the dummy's H2D consumed it.

The existing bidirectional stream dependencies are necessary but do not close
this race:

```text
prep_stream.wait_stream(current_stream)
current_stream.wait_stream(prep_stream)
```

They order GPU queues. They do not block the CPU from changing a pinned source
array before an asynchronous DMA has read it.

The corrupted metadata reaches MTP as:

```python
token_indices = attn_metadata.cu_seqlens_q[1:] - last_token_offset
input_ids.scatter_(0, last_token_indices, next_token_ids)
```

Device-side predicate tagging isolated the first invalid condition to
`propose(): last_token_indices >= input_ids.shape[0]` (`assert_async` kernel
specialization `Il`, the int64 tag). Negative indices and invalid token IDs did
not fire first. Four HSA callbacks occurred together, matching one TP4 replica;
the failed group's worker stacks were in `dummy_execution()` during the drain.

This also explains why TP8 CI does not reproduce it: there is no second DP
replica entering the dummy path.

## Fix

- Make every forward, including DP-sync dummy forwards, advance/gate/mark the
  staging lifetime and record PP slot completion.
- Stage the scheduler anchor override and optional DSpark ragged lengths in
  `prepare_model()`, before the normal staging event. The later precompute and
  proposal paths consume the per-forward GPU views and no longer launch pinned
  H2Ds after that event.
- Add non-GPU source-order tests covering dummy participation and the placement
  of the speculative uploads.
- Retain the independently validated DSV4 FP4 indexer offload support.

The old PR implementation added a second event record in
`propose_draft_token_ids()`. It crossed the failure window because dummy MTP
also reaches that method, so it accidentally created the missing dummy event.
It did not identify the ownership bug and depended on every dummy reaching that
late call. Those commits were replaced by the lifecycle fix above.

## Validation

Configuration for all agentic A/B runs:

```text
8 x MI355X
DeepSeek-V4-Pro
DP2 x TP4
C48
FP8 KV / FP4 index cache
16K prefill chunks
MTP k=3
FULL CUDA graphs
gpu_memory_utilization=0.9
kv_transfer_config={}
```

- Clean #1987 path plus diagnostic assertions: failed near the drain at
  `50/531`; four ranks reported `assert_async_cuda_kernelIl` followed by
  `HSA_STATUS_ERROR_EXCEPTION`.
- Old PR late-mark implementation: passed the original failure window to
  `87/531`, zero request errors and no HSA fault.
- Root-cause A/B, with no late mark and only dummy participation in the normal
  staging lifecycle: passed to `99/531`, zero request errors and no HSA fault.
- Final implementation (dummy lifecycle plus early speculative staging):
  passed the original failure window to `114/531`, zero request errors and no
  HSA fault; the validation was intentionally stopped at that point.
- Relevant non-GPU tests, including staging, GC, FP4 transfer-region and
  LMCache config coverage: `67 passed`.

Raw local logs:

```text
/mnt/m2m_nobackup/hyi/atom-pr1993-dsv4-dp2tp4-c48-clean-assert-20260824T133100Z/
/mnt/m2m_nobackup/hyi/atom-pr1993-dsv4-dp2tp4-c48-late-mark-assert-20260824T134500Z/
/mnt/m2m_nobackup/hyi/atom-pr1993-dsv4-dp2tp4-c48-dummy-gate-assert-20260824T135800Z/
/mnt/m2m_nobackup/hyi/atom-pr1993-dsv4-dp2tp4-c48-final-rootfix-20260824T142300Z/
```

## DSV4 FP4 indexer offload validation

The FP4 offload commit is unchanged from the earlier revision:

- Unit tests: `173 passed`.
- Two consecutive full GSM8K 20-shot passes completed (`1319/1319` each) with
  LMCache LocalCPU, DP2 x TP4, and no OOM/request/load errors.
- Cold/warm strict accuracy: `94.92% / 94.92%`; warm generation was `3m23s`
  versus `4m24s` cold (`1.30x`).
- Warm pass: 672 loads, 1,948,672 loaded tokens, and 2,688 = 672 x TP4 FP4
  SLOT sidecar restores.

The raw FP4 validation report remains linked in the PR comments.

## Submission checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

