### PR TITLE
[ATOM] add persistent path for DCP GLM5.2

### DIFF
--- a/atom/distributed/dcp_utils.py
+++ b/atom/distributed/dcp_utils.py
@@ -18,6 +18,7 @@ only the distributed-access layer.
 """
 
 from atom.config import get_current_atom_config
+from atom.utils import envs
 
 
 def get_dcp_world_size() -> int:
@@ -34,6 +35,19 @@ def get_dcp_world_size() -> int:
 def dcp_is_enabled() -> bool:
     """True when Decode Context Parallel is active (world size > 1)."""
     return get_dcp_world_size() > 1
+
+
+def dcp_replicated_index_cache_enabled(atom_config=None) -> bool:
+    """Whether native GLM-5.2 uses a full replicated index cache under DCP."""
+    if not envs.ATOM_DCP_REPLICATE_INDEX_CACHE:
+        return False
+    config = atom_config or get_current_atom_config()
+    hf_config = config.hf_config
+    return (
+        config.decode_context_parallel_size > 1
+        and getattr(hf_config, "model_type", None) == "glm_moe_dsa"
+        and config.speculative_config is None
+    )
 
 
 def get_dcp_group():

--- a/atom/kv_transfer/offload/config.py
+++ b/atom/kv_transfer/offload/config.py
@@ -23,10 +23,12 @@ from typing import Any
 
 import torch
 
-# Version 2 adds explicit DSV4 KV/index dimensions and DCP virtual-block byte
-# mapping to the PAGE identity. Keeping it separate prevents version-1 objects
-# from being reused after the layout correction.
-PAGE_LAYOUT_VERSION = 2
+from atom.utils import envs
+
+# Version 3 adds the GLM replicated-index layout and IndexShare schedule to the
+# PAGE identity. Its compact layer axis and DCP-expanded index pages are byte-
+# incompatible with the sharded-index v2 layout.
+PAGE_LAYOUT_VERSION = 3
 _PAGE_FINGERPRINT_BYTES = 16
 _OFFLOAD_LAYOUT_ALIASES = {
     "hybrid": "hybrid",
@@ -49,10 +51,12 @@ _HF_PAGE_FIELDS = (
     "qk_rope_head_dim",
     "compress_ratios",
     "indexer_dtype",
+    "indexer_types",
 )
 _HF_INTEGER_GEOMETRY_FIELDS = frozenset(_HF_PAGE_FIELDS) - {
     "compress_ratios",
     "indexer_dtype",
+    "indexer_types",
 }
 
 logger = logging.getLogger("atom")
@@ -198,6 +202,12 @@ def build_page_namespace(
                 else getattr(config, "decode_context_parallel_size", 1)
             ),
             minimum=1,
+        ),
+        "replicated_index_cache": bool(
+            envs.ATOM_DCP_REPLICATE_INDEX_CACHE
+            and getattr(hf, "model_type", None) == "glm_moe_dsa"
+            and (getattr(config, "decode_context_parallel_size", 1) or 1) > 1
+            and getattr(config, "speculative_config", None) is None
         ),
         "hf_geometry": _stable_hf_geometry(hf),
         "speculative_config": _stable_config_value(

--- a/atom/kv_transfer/offload/dense/connector.py
+++ b/atom/kv_transfer/offload/dense/connector.py
@@ -443,7 +443,14 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         hit = int(hit)
         if hit == num_prompt:  # full-prompt hit → recompute last token
             hit -= 1
-        self._hit_save_floors[sid] = self._chunk_floor(hit)
+        # The raw-byte connector transfers whole LMCache chunks. A full-prompt
+        # hit becomes unaligned after reserving the final token for logits
+        # recomputation (e.g. 8192 -> 8191); requesting that tail makes LMCache
+        # correctly return only 7936 chunk-aligned tokens, but the worker then
+        # treats the partial mask as a failed load and recomputes everything.
+        # Load the largest complete prefix instead and recompute the short tail.
+        hit = self._chunk_floor(hit)
+        self._hit_save_floors[sid] = hit
         need = hit - int(seq.num_cached_tokens)
         if need <= 0:
             if self._lookup_client is not None:

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -16,6 +16,7 @@ from aiter import (
     flash_attn_varlen_func,
     fused_qk_rope_concat_and_cache_mla,
     get_hip_quant,
+    get_mla_metadata_v1,
 )
 
 # The segmented (page_size>1) MLA cache kernels only exist in newer aiter
@@ -179,25 +180,30 @@ _dcp_kernel_width_warned = False
 
 
 def mla_dcp_decode_is_persistent(
-    is_sparse: bool, dcp_world_size: int, dcp_persistent_supported: bool
+    is_sparse: bool,
+    dcp_world_size: int,
+    dcp_persistent_supported: bool,
+    *,
+    sparse_metadata_rebuild: bool = False,
 ) -> bool:
     """Whether a DCP decode will reach ``mla_decode_fwd`` in persistent mode.
 
     The live decision is made per step in ``_forward_decode``; this mirrors the
     parts of it that are already settled at construction time, because the
     gathered head width has to be fixed there (it sizes the persistent work
-    descriptors as well as the kernel's nhead). Sparse MLA under DCP is forced
-    non-persistent (its sparse region length varies per layer, which metadata
-    built once per step cannot describe), only gfx950 ships the lse-emitting
-    persistent kernel DCP needs, and persistent mode wants page_size 1. The one
-    remaining runtime gate, ``dpa_persistent_supported``, is unconditionally
-    true, so nothing here can claim persistent mode that the step then refuses.
+    descriptors as well as the kernel's nhead). Sparse MLA under DCP is
+    persistent only when the caller rebuilds work/reduce metadata after each
+    full indexer layer compacts its rank-local top-k. Only gfx950 ships the
+    lse-emitting persistent kernel DCP needs, and persistent mode wants page
+    size 1. The one remaining runtime gate, ``dpa_persistent_supported``, is
+    unconditionally true, so nothing here can claim persistent mode that the
+    step then refuses.
 
     ``dcp_persistent_supported`` is taken as an argument rather than queried
     here, the way ``should_use_persistent_mode`` takes it: callers already cache
     it to keep ``get_gfx()`` off the per-forward path.
     """
-    if dcp_world_size <= 1 or is_sparse:
+    if dcp_world_size <= 1 or (is_sparse and not sparse_metadata_rebuild):
         return False
     return dcp_persistent_supported and envs.ATOM_MLA_PAGE_SIZE <= 1
 
@@ -453,6 +459,10 @@ class MLAAttention(nn.Module):
         # (`mla_modules.is_sparse` defaults False, so non-sparse models and the
         # `indexer is not None` fallback keep their previous behavior.)
         self.is_sparse_mla = mla_modules.is_sparse or (mla_modules.indexer is not None)
+        # A full IndexShare layer owns an indexer and therefore produces a new
+        # layer-local DCP compact indptr. Shared layers reuse both its indices
+        # and the persistent work plan rebuilt from that indptr.
+        self.owns_sparse_indexer = mla_modules.indexer is not None
         self.topk_tokens = (
             mla_modules.indexer.topk_tokens
             if mla_modules.indexer is not None
@@ -537,6 +547,14 @@ class MLAAttention(nn.Module):
 
         self.dcp_persistent_supported = dcp_persistent_supported()
         self.dcp_prefill_merge_bf16_ok = dcp_prefill_merge_bf16_ok()
+        # Scope sparse persistent DCP to native non-speculative attention.
+        # Decode is q_len=1; sparse prefill is represented as per-token virtual
+        # q_len=1 rows. Plugin DCP reconfigures its group after construction.
+        self.sparse_dcp_metadata_rebuild = (
+            self.is_sparse_mla
+            and self.dcp_world_size > 1
+            and getattr(atom_config, "speculative_config", None) is None
+        )
 
         # Compacted per-layer sparse offsets for DCP decode; rebound by the
         # metadata builder to the shared buffer (see aiter_mla.py).
@@ -544,6 +562,18 @@ class MLAAttention(nn.Module):
         self.dcp_owned_counts_buffer = None
 
         self._configure_dcp_decode_head_padding(self.dcp_world_size)
+        if (
+            self.sparse_dcp_metadata_rebuild
+            and self.dcp_persistent_supported
+            and envs.ATOM_MLA_PAGE_SIZE <= 1
+            and not getattr(MLAAttention, "_sparse_dcp_persistent_logged", False)
+        ):
+            MLAAttention._sparse_dcp_persistent_logged = True
+            logger.info(
+                "Sparse DCP persistent attention enabled: rebuilding metadata "
+                "after each full indexer layer (kernel heads=%d).",
+                self.dcp_kernel_num_heads,
+            )
 
     def _configure_dcp_decode_head_padding(self, dcp_world_size: int) -> None:
         """Configure the kernel width used after DCP gathers query heads.
@@ -568,6 +598,9 @@ class MLAAttention(nn.Module):
                     self.is_sparse_mla,
                     dcp_world_size,
                     self.dcp_persistent_supported,
+                    sparse_metadata_rebuild=getattr(
+                        self, "sparse_dcp_metadata_rebuild", False
+                    ),
                 ),
             )
             self.dcp_head_pad = (
@@ -1285,7 +1318,11 @@ class MLAAttention(nn.Module):
         B = q.shape[0]
         num_heads_q = q.shape[1]
 
-        q = self._pad_query_heads(q)
+        q = (
+            self._pad_decode_query_heads(q)
+            if self.is_sparse_mla and self.dcp_world_size > 1
+            else self._pad_query_heads(q)
+        )
 
         # In the seg path q arrives with a padded per-head row stride
         # (_MLA_Q_OUT_PADDED_DIM); slice back to the logical
@@ -1336,10 +1373,27 @@ class MLAAttention(nn.Module):
             use_decode_kernel = self.kv_cache_dtype.startswith("fp8") or return_lse
             if use_decode_kernel:
                 is_fp8 = self.kv_cache_dtype.startswith("fp8")
-                # DCP compacts each rank's candidates per layer, so the once-per-step
-                # persistent work metadata (built from the GLOBAL sparse_kv_indptr)
-                # does not describe this rank's regions -- run non-persistent.
-                use_work_meta = is_fp8 and self.dcp_world_size <= 1
+                sparse_dcp_persistent = (
+                    is_fp8
+                    and self.is_sparse_mla
+                    and self.dcp_world_size > 1
+                    and self.sparse_dcp_metadata_rebuild
+                    and self.dcp_persistent_supported
+                    and page_size <= 1
+                )
+                if sparse_dcp_persistent and self.owns_sparse_indexer:
+                    self._rebuild_sparse_dcp_persistent_metadata(
+                        attn_metadata,
+                        q,
+                        kv_c_and_k_pe_cache,
+                        paged_cu_seqlens_q,
+                        paged_kv_indptr,
+                        kv_last_page_lens,
+                        work_prefix="sparse_prefill_",
+                    )
+                use_work_meta = is_fp8 and (
+                    self.dcp_world_size <= 1 or sparse_dcp_persistent
+                )
                 _, final_lse = mla_decode_fwd(
                     q,
                     kv_c_and_k_pe_cache.view(-1, page_size, 1, q.shape[-1]),
@@ -1403,9 +1457,14 @@ class MLAAttention(nn.Module):
                     None,
                 )
 
-        o = self._restore_query_heads(o, num_heads_q)
+        restore_heads = (
+            self._restore_decode_query_heads
+            if self.is_sparse_mla and self.dcp_world_size > 1
+            else self._restore_query_heads
+        )
+        o = restore_heads(o, num_heads_q)
         if final_lse is not None:
-            final_lse = self._restore_query_heads(final_lse, num_heads_q)
+            final_lse = restore_heads(final_lse, num_heads_q)
 
         if return_lse:
             assert final_lse is not None, (
@@ -1440,6 +1499,64 @@ class MLAAttention(nn.Module):
         num_blocks = num_token_slots // block_size
         # [num_token_slots, 1, d] -> [num_blocks, block_size, d] -> [.., 1, ..]
         return kv_cache.view(num_blocks, block_size, d).unsqueeze(1)
+
+    def _should_rebuild_sparse_dcp_persistent_metadata(
+        self, use_persistent_mode: bool
+    ) -> bool:
+        return (
+            use_persistent_mode
+            and self.is_sparse_mla
+            and self.dcp_world_size > 1
+            and self.owns_sparse_indexer
+        )
+
+    def _rebuild_sparse_dcp_persistent_metadata(
+        self,
+        attn_metadata: AttentionMetaData,
+        q: torch.Tensor,
+        kv_buffer: torch.Tensor,
+        paged_cu_seqlens_q: torch.Tensor,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_last_page_lens: torch.Tensor,
+        work_prefix: str = "",
+    ) -> None:
+        """Rebuild persistent work/reduce metadata from this layer's DCP top-k.
+
+        A full GLM IndexShare layer rewrites ``dcp_sparse_kv_indptr_buffer``
+        after selecting and compacting the rank-owned top-k. Persistent work
+        descriptors embed those region boundaries, so they must be rebuilt
+        after that mutation rather than once per decode step from the global
+        sparse indptr. Shared IndexShare layers reuse the preceding full layer's
+        indices, compact indptr, and work plan and therefore skip this call.
+        """
+        if not work_prefix:
+            assert attn_metadata.max_seqlen_q == 1, (
+                "Sparse DCP persistent decode metadata rebuild currently "
+                "supports non-speculative q_len=1 only."
+            )
+        assert q.shape[1] == self.dcp_kernel_num_heads
+        get_mla_metadata_v1(
+            paged_cu_seqlens_q,
+            paged_kv_indptr,
+            paged_kv_last_page_lens,
+            self.dcp_kernel_num_heads,
+            1,  # nhead_kv
+            True,
+            getattr(attn_metadata, f"{work_prefix}work_meta_data"),
+            getattr(attn_metadata, f"{work_prefix}work_info_set"),
+            getattr(attn_metadata, f"{work_prefix}work_indptr"),
+            getattr(attn_metadata, f"{work_prefix}reduce_indptr"),
+            getattr(attn_metadata, f"{work_prefix}reduce_final_map"),
+            getattr(attn_metadata, f"{work_prefix}reduce_partial_map"),
+            page_size=1,
+            dtype_q=q.dtype,
+            dtype_kv=kv_buffer.dtype,
+            kv_granularity=16,
+            max_seqlen_qo=1,
+            uni_seqlen_qo=1,
+            fast_mode=1,
+            max_split_per_batch=16,
+        )
 
     def _forward_decode(
         self,
@@ -1549,11 +1666,12 @@ class MLAAttention(nn.Module):
                     # all-1s sparse buffer, NOT the dense per-block
                     # kv_last_page_lens (which makes the asm kernel over-read
                     # past the written sparse-index region -> illegal access).
-                    paged_kv_indptr = attn_metadata.sparse_kv_indptr
+                    paged_cu_seqlens_q = attn_metadata.cu_seqlens_q[: B + 1]
+                    paged_kv_indptr = attn_metadata.sparse_kv_indptr[: B + 1]
                     paged_kv_indices = self.sparse_kv_indices_buffer
-                    paged_kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens
+                    paged_kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens[:B]
                     if self.dcp_world_size > 1:
-                        paged_kv_indptr = self.dcp_sparse_kv_indptr_buffer
+                        paged_kv_indptr = self.dcp_sparse_kv_indptr_buffer[: B + 1]
 
             dp_size = get_dp_group().world_size
             use_persistent_mode = should_use_persistent_mode(
@@ -1563,20 +1681,31 @@ class MLAAttention(nn.Module):
                 dcp_world_size=self.dcp_world_size,
                 dcp_persistent_supported=self.dcp_persistent_supported,
             )
-            # sparse + DCP compacts the per-rank top-k, which makes the sparse
-            # region length depend on the *per-layer* selection. The persistent
-            # work/reduce metadata is built once per step from sparse_kv_indptr
-            # (aiter_mla.set_mla_persistent_worker_buffers), so it cannot describe
-            # a length that changes layer to layer -- the timing simply does not
-            # line up. Run non-persistent until either the metadata build moves
-            # per-layer or aiter grows a per-request valid length.
+            # Sparse DCP persistent decode is enabled only for ordinary q_len=1
+            # native serving. Its full IndexShare layers rebuild the work plan
+            # below from the layer-local compact indptr; plugin/speculative paths
+            # retain the established non-persistent fallback.
             if self.is_sparse_mla and self.dcp_world_size > 1:
-                use_persistent_mode = False
+                use_persistent_mode = (
+                    use_persistent_mode and self.sparse_dcp_metadata_rebuild
+                )
 
             # Sparse layers in MTP verify use separate persistent metadata
             # (per-token, max_seqlen_qo=1) while dense layers use normal metadata
             # (max_seqlen_qo=2).
             is_sparse_mtp = self.is_sparse_mla and attn_metadata.max_seqlen_q > 1
+
+            if self._should_rebuild_sparse_dcp_persistent_metadata(
+                use_persistent_mode
+            ):
+                self._rebuild_sparse_dcp_persistent_metadata(
+                    attn_metadata,
+                    q,
+                    kv_buffer,
+                    paged_cu_seqlens_q,
+                    paged_kv_indptr,
+                    paged_kv_last_page_lens,
+                )
 
             if not use_persistent_mode:
                 work_meta_data = None

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -17,6 +17,7 @@ from aiter import (
 
 from atom.distributed.dcp_utils import (
     dcp_persistent_supported,
+    dcp_replicated_index_cache_enabled,
     get_dcp_rank,
     get_dcp_world_size,
 )
@@ -171,6 +172,57 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
         self.dcp_world_size = get_dcp_world_size()
         self.dcp_rank = get_dcp_rank()
+        self.replicate_index_cache = dcp_replicated_index_cache_enabled(config)
+        if envs.ATOM_DCP_REPLICATE_INDEX_CACHE:
+            unsupported = []
+            if getattr(hf_config, "model_type", None) != "glm_moe_dsa":
+                unsupported.append("model_type must be glm_moe_dsa")
+            if self.dcp_world_size <= 1:
+                unsupported.append("decode context parallel size must be > 1")
+            if config.speculative_config is not None:
+                unsupported.append("MTP/speculative decoding is not supported")
+            if self.block_size != 1:
+                unsupported.append("MLA page size must be 1")
+            if get_pcp_world_size() > 1:
+                unsupported.append("PCP is not supported")
+            if getattr(config, "pipeline_parallel_size", 1) > 1:
+                unsupported.append("pipeline parallelism is not supported")
+            if getattr(config, "kv_transfer_config", None):
+                unsupported.append("KV transfer/LMCache/PD is not supported")
+            if getattr(config, "enable_rapidserve", False):
+                unsupported.append("RapidServe disaggregation is not supported")
+            if unsupported:
+                raise ValueError(
+                    "ATOM_DCP_REPLICATE_INDEX_CACHE=1 is unsupported: "
+                    + "; ".join(unsupported)
+                )
+
+        self.full_index_layer_ids: tuple[int, ...] = ()
+        self.index_layer_to_cache_row: dict[int, int] = {}
+        if self.replicate_index_cache:
+            indexer_types = getattr(hf_config, "indexer_types", None)
+            if not indexer_types or len(indexer_types) != hf_config.num_hidden_layers:
+                raise ValueError(
+                    "Replicated GLM index cache requires one indexer_types entry "
+                    "per target layer"
+                )
+            self.full_index_layer_ids = tuple(
+                layer_id
+                for layer_id, indexer_type in enumerate(indexer_types)
+                if indexer_type == "full"
+            )
+            if not self.full_index_layer_ids:
+                raise ValueError("Replicated GLM index cache found no full IndexShare layers")
+            self.index_layer_to_cache_row = {
+                layer_id: row
+                for row, layer_id in enumerate(self.full_index_layer_ids)
+            }
+            logger.info(
+                "Replicating GLM index cache for %d full IndexShare layers "
+                "across %d DCP ranks",
+                len(self.full_index_layer_ids),
+                self.dcp_world_size,
+            )
 
         # DCP decode all-gathers Q on the head dim, so the head count reaching
         # mla_decode_fwd (and thus the persistent decode metadata) is the padded
@@ -222,6 +274,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             **_mla_seg_meta_kwargs(),
         )
         i32_kwargs = {"dtype": torch.int32, "device": self.device}
+        i64_kwargs = {"dtype": torch.int64, "device": self.device}
 
         mla_metadata = {
             # AITER MLA specific persistent buffers
@@ -261,6 +314,14 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         mla_metadata["kv_last_page_lens"].cpu.fill_(1)
         mla_metadata["kv_last_page_lens"].copy_to_gpu()
         if self.is_sparse:
+            if self.replicate_index_cache:
+                mla_metadata["index_slot_mapping"] = CpuGpuBuffer(
+                    self.max_num_batched_tokens, **i64_kwargs
+                )
+                # CUDAGraph capture may execute cache writes before the first
+                # scheduled batch. Point those dummy writes at a valid slot.
+                mla_metadata["index_slot_mapping"].np.fill(0)
+                mla_metadata["index_slot_mapping"].copy_to_gpu()
             mla_metadata["cu_seqlen_ke"] = CpuGpuBuffer(
                 self.max_num_batched_tokens, **i32_kwargs
             )
@@ -504,6 +565,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 ub_max_bs * max_seqlen_qo,
                 **i64_kwargs,
             )
+            if self.replicate_index_cache:
+                var[f"{p}index_slot_mapping"] = CpuGpuBuffer(
+                    ub_max_bs * max_seqlen_qo,
+                    **i64_kwargs,
+                )
+                var[f"{p}index_slot_mapping"].np.fill(0)
+                var[f"{p}index_slot_mapping"].copy_to_gpu()
             var[f"{p}block_tables"] = CpuGpuBuffer(
                 ub_max_bs,
                 self.max_num_blocks_per_seq // self.block_ratio,
@@ -866,9 +934,18 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         if runner.is_deepseek_v32:
             index_dim = hf_config.index_head_dim + 4
             aligned_index_dim = ((index_dim + 15) // 16) * 16
+            index_layers = (
+                len(self.full_index_layer_ids)
+                if self.replicate_index_cache
+                else total_num_layers
+            )
+            index_page_factor = (
+                self.dcp_world_size if self.replicate_index_cache else 1
+            )
             block_bytes += (
-                total_num_layers
+                index_layers
                 * runner.block_size
+                * index_page_factor
                 * aligned_index_dim
                 * dtypes.fp8.itemsize
             )
@@ -903,15 +980,26 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # to avoid unaligned memory access in torch inductor.
             index_dim = hf_config.index_head_dim + 4
             aligned = ((index_dim + 15) // 16) * 16
+            index_layers = (
+                len(self.full_index_layer_ids)
+                if self.replicate_index_cache
+                else total_num_layers
+            )
+            index_page_factor = (
+                self.dcp_world_size if self.replicate_index_cache else 1
+            )
             out["aligned_index_dim"] = aligned
             out["index_cache"] = torch.zeros(
-                total_num_layers,
+                index_layers,
                 runner.num_physical_kvcache_blocks,
-                runner.physical_block_size,
+                runner.physical_block_size * index_page_factor,
                 aligned,
                 dtype=dtypes.fp8,
                 device="cuda",
             )
+            if self.replicate_index_cache:
+                out["index_layer_to_cache_row"] = self.index_layer_to_cache_row
+                out["full_index_layer_ids"] = self.full_index_layer_ids
         return out
 
     def build_kv_cache_tensor(self, layer_id: int, module):
@@ -938,22 +1026,40 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         kv_cache = runner.kv_cache[layer_id].view(num_slots, 1, 576)
         module.max_model_len = runner.config.max_model_len
         if runner.is_deepseek_v32 and module.indexer is not None:
+            index_row = (
+                self.index_layer_to_cache_row[layer_id]
+                if self.replicate_index_cache
+                else layer_id
+            )
+            index_page_factor = (
+                self.dcp_world_size if self.replicate_index_cache else 1
+            )
             # Use aligned dimension to avoid memory copy in torch inductor
-            module.indexer.k_cache.kv_cache[0] = runner.index_cache[layer_id].view(
-                runner.num_physical_kvcache_blocks * runner.physical_block_size,
+            module.indexer.k_cache.kv_cache[0] = runner.index_cache[index_row].view(
+                runner.num_physical_kvcache_blocks
+                * runner.physical_block_size
+                * index_page_factor,
                 1,
                 runner.aligned_index_dim,
             )
+            module.indexer.replicate_index_cache = self.replicate_index_cache
         module.kv_cache = kv_cache
+        if runner.is_deepseek_v32 and self.replicate_index_cache:
+            index_row = self.index_layer_to_cache_row.get(layer_id)
+            transfer_index_cache = (
+                runner.index_cache[index_row] if index_row is not None else None
+            )
+        else:
+            transfer_index_cache = (
+                runner.index_cache[layer_id] if runner.is_deepseek_v32 else None
+            )
         return KVCacheTensor(
             layer_num=layer_id,
             k_cache=kv_cache,
             v_cache=None,
             k_scale=None,
             v_scale=None,
-            index_cache=(
-                runner.index_cache[layer_id] if runner.is_deepseek_v32 else None
-            ),
+            index_cache=transfer_index_cache,
         )
 
     def get_kv_transfer_tensors(self):
@@ -1063,6 +1169,28 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         bs = batch.total_seqs_num_prefill
         sum_scheduled_tokens = batch.total_tokens_num_prefill
         var = self.model_runner.forward_vars
+        if self.replicate_index_cache:
+            if batch.is_dummy_run:
+                var["index_slot_mapping"].np[:sum_scheduled_tokens] = 0
+            else:
+                index_slots = [
+                    self._replicated_index_slot(block_table, pos)
+                    for block_table, cached_len, seq_len in zip(
+                        batch.block_tables,
+                        batch.num_cached_tokens,
+                        batch.context_lens,
+                    )
+                    for pos in range(cached_len, seq_len)
+                ]
+                if len(index_slots) != sum_scheduled_tokens:
+                    raise RuntimeError(
+                        "Replicated index slot count does not match prefill token "
+                        f"count: {len(index_slots)} != {sum_scheduled_tokens}"
+                    )
+                var["index_slot_mapping"].np[:sum_scheduled_tokens] = index_slots
+            attn_metadata.index_slot_mapping = var[
+                "index_slot_mapping"
+            ].copy_to_gpu(sum_scheduled_tokens)
         if self.is_sparse and attn_metadata.max_seqlen_k > self.index_topk:
             if attn_metadata.block_tables is None:
                 self.prepare_block_tables(batch)
@@ -1125,7 +1253,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.sparse_kv_indptr = var["sparse_kv_indptr"].copy_to_gpu(
                 sum_scheduled_tokens + 1
             )
-            if self.dcp_world_size > 1:
+            if self.dcp_world_size > 1 and not self.replicate_index_cache:
                 self._build_dcp_indexer_prefill_meta(attn_metadata, bs, counts, var)
             get_mla_metadata_v1(
                 attn_metadata.sparse_cu_seqlens_q,
@@ -1578,6 +1706,19 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             + dcp_local_index(pos, W, S) % block_size
         )
 
+    def _replicated_index_slot(self, block_table, pos: int) -> int:
+        """Physical slot for a global token in an expanded replicated page.
+
+        Scheduler block IDs and lifetimes stay unchanged. Each scheduler block's
+        index-cache page is widened from ``block_size`` local tokens to
+        ``block_size * dcp_world_size`` global tokens.
+        """
+        expanded_page_size = self.model_runner.block_size * self.dcp_world_size
+        return (
+            block_table[pos // expanded_page_size] * expanded_page_size
+            + pos % expanded_page_size
+        )
+
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
         scheduled_bs = batch.total_seqs_num_decode
         dropout_p = 0.0
@@ -1640,6 +1781,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         var["positions"].np[:sum_scheduled_tokens] = positions
         var["context_lens"].np[:scheduled_bs] = context_lens
         var["context_lens"].np[scheduled_bs:bs] = 0
+        if self.replicate_index_cache:
+            var["index_slot_mapping"].np[:bs] = 0
+            if not batch.is_dummy_run:
+                var["index_slot_mapping"].np[:scheduled_bs] = [
+                    self._replicated_index_slot(block_table, int(seq_len) - 1)
+                    for block_table, seq_len in zip(block_tables, context_lens)
+                ]
 
         if self.dcp_world_size > 1:
             from atom.model_ops.dcp_ops import get_dcp_local_seq_lens
@@ -1787,6 +1935,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         is_sparse_mtp = self.is_sparse and max_seqlen_q > 1
         # metadata copies on main stream
         positions = var["positions"].copy_to_gpu(sum_scheduled_tokens)
+        index_slot_mapping = (
+            var["index_slot_mapping"].copy_to_gpu(bs)
+            if self.replicate_index_cache
+            else None
+        )
         ctx.update({el: var[el].copy_to_gpu(num) for el, num in vars_for_metadata})
 
         if is_sparse_mtp:
@@ -1822,6 +1975,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             **ctx,
         )
         attn_metadata.dtype_q = self.dtype_q
+        if self.replicate_index_cache:
+            attn_metadata.index_slot_mapping = index_slot_mapping
 
         # Round-robin CP global kv_indptr (only under DCP; None otherwise so the
         # non-DCP / qlen=1 paths keep the plain kernel). Consumed by
@@ -1912,6 +2067,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 tok_start : tok_start + ub_real_tokens
             ]
             var[f"{p}slot_mapping"].np[ub_real_tokens:padded_tok_count] = -1
+            if self.replicate_index_cache:
+                var[f"{p}index_slot_mapping"].np[:ub_real_tokens] = var[
+                    "index_slot_mapping"
+                ].np[tok_start : tok_start + ub_real_tokens]
+                var[f"{p}index_slot_mapping"].np[
+                    ub_real_tokens:padded_tok_count
+                ] = 0
 
             var[f"{p}block_tables"].np[:ub_real_reqs] = var["block_tables"].np[
                 req_start : req_start + ub_real_reqs
@@ -1983,6 +2145,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 vars_used.append((f"{p}g_kv_indptr", padded_bs + 1))
             if self.is_sparse:
                 vars_used.append((f"{p}sparse_kv_indptr", padded_bs + 1))
+            if self.replicate_index_cache:
+                vars_used.append((f"{p}index_slot_mapping", padded_tok_count))
 
             for el, num in vars_used:
                 var[el].copy_to_gpu(num)
@@ -2117,6 +2281,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             **ctx_mla_ps,
         )
         attn_matadata.dtype_q = self.dtype_q
+        if self.replicate_index_cache:
+            attn_matadata.index_slot_mapping = var["index_slot_mapping"].gpu[:bs]
         # Attach the round-robin CP global kv_indptr for the captured graph so
         # replay (which overwrites the buffer with real values) matches. Only
         # consumed by _forward_decode when dcp>1 and max_q_len>1.
@@ -2197,6 +2363,10 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             reduce_partial_map=var[f"{p}reduce_partial_map"],
         )
         attn.dtype_q = self.dtype_q
+        if self.replicate_index_cache:
+            attn.index_slot_mapping = var[f"{p}index_slot_mapping"].gpu[
+                : padded_bs * max_q_len
+            ]
         # Per-ubatch round-robin CP global kv_indptr (None when non-DCP). Consumed
         # by _forward_decode when dcp>1 and max_q_len>1 (MTP).
         attn.g_kv_indptr = (

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -157,19 +157,49 @@ def cdiv(a, b):
     return (a + b - 1) // b
 
 
-def _uses_standalone_lmcache_offload(config) -> bool:
-    """Whether the configured transfer path is the raw-byte LMCache connector."""
+def _replicated_index_cache_transfer_supported(config) -> bool:
+    """Whether the target replicated-index transfer topology is configured."""
+
     transfer_config = getattr(config, "kv_transfer_config", None)
-    if not isinstance(transfer_config, dict):
+    if not isinstance(transfer_config, dict) or not transfer_config:
         return False
-    connector = transfer_config.get("kv_connector")
-    if not isinstance(connector, str):
+
+    from atom.kv_transfer.disaggregation.factory import KVConnectorFactory
+
+    def canonical(sub_config, path):
+        if not isinstance(sub_config, dict):
+            return None
+        try:
+            return KVConnectorFactory.canonical_name(
+                sub_config.get("kv_connector"), path=path
+            )
+        except (TypeError, ValueError):
+            return None
+
+    connector = canonical(transfer_config, "kv_transfer_config")
+    if connector == "lmcache_offload":
+        return True
+    if connector == "mooncake":
+        return transfer_config.get("kv_role", "kv_producer") in {
+            "kv_producer",
+            "kv_consumer",
+        }
+    if connector != "multi":
         return False
-    normalized = connector.strip().lower()
-    return normalized in {
-        "lmcache_offload",
-        "lmcacheoffloadconnector",
-        "lmcacheconnectorv1",
+
+    sub_configs = transfer_config.get("connectors")
+    if not isinstance(sub_configs, list) or len(sub_configs) != 2:
+        return False
+    topology = {
+        (
+            canonical(sub_config, f"kv_transfer_config.connectors[{index}]"),
+            sub_config.get("kv_role") if isinstance(sub_config, dict) else None,
+        )
+        for index, sub_config in enumerate(sub_configs)
+    }
+    return topology == {
+        ("mooncake", "kv_producer"),
+        ("lmcache_offload", "offload"),
     }
 
 
@@ -196,9 +226,12 @@ def _replicated_index_cache_unsupported_reasons(
     if getattr(config, "pipeline_parallel_size", 1) > 1:
         unsupported.append("pipeline parallelism is not supported")
     if getattr(config, "kv_transfer_config", None) and not (
-        _uses_standalone_lmcache_offload(config)
+        _replicated_index_cache_transfer_supported(config)
     ):
-        unsupported.append("PD and non-LMCache KV transfer are not supported")
+        unsupported.append(
+            "KV transfer must be standalone LMCache, standalone Mooncake, or "
+            "multi[Mooncake producer + LMCache offload]"
+        )
     if getattr(config, "enable_rapidserve", False):
         unsupported.append("RapidServe disaggregation is not supported")
     return unsupported
@@ -1205,6 +1238,14 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             )
 
         if hasattr(runner, "index_cache"):
+            if getattr(self, "replicate_index_cache", False):
+                expected_page_width = runner.physical_block_size * self.dcp_world_size
+                index_shape = tuple(runner.index_cache.shape)
+                if len(index_shape) < 3 or index_shape[2] != expected_page_width:
+                    raise RuntimeError(
+                        "Replicated MLA index page width mismatch: "
+                        f"expected {expected_page_width}, got shape={index_shape}"
+                    )
             for layer_id in range(runner.index_cache.shape[0]):
                 t = runner.index_cache[layer_id]
                 bpb = t.stride(0) * t.element_size() * self.block_ratio

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -181,13 +181,23 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # kernel and stays non-persistent, where this metadata is unused); scale
         # by dcp only there so gfx942 keeps the original per-rank head sizing.
         dcp_persistent = dcp_persistent_supported()
+        self.sparse_dcp_metadata_rebuild = (
+            self.is_sparse
+            and self.dcp_world_size > 1
+            and dcp_persistent
+            and self.block_size == 1
+            and config.speculative_config is None
+        )
         if self.dcp_world_size > 1 and dcp_persistent:
             self.persistent_num_heads = mla_dcp_kernel_num_heads(
                 self.num_attention_heads,
                 self.dcp_world_size,
                 kv_cache_dtype=config.kv_cache_dtype,
                 persistent=mla_dcp_decode_is_persistent(
-                    self.is_sparse, self.dcp_world_size, dcp_persistent
+                    self.is_sparse,
+                    self.dcp_world_size,
+                    dcp_persistent,
+                    sparse_metadata_rebuild=self.sparse_dcp_metadata_rebuild,
                 ),
             )
         else:
@@ -290,6 +300,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 dtype=torch.int32,
                 device=self.device,
             )
+            sparse_prefill_num_heads = (
+                self.persistent_num_heads
+                if self.sparse_dcp_metadata_rebuild
+                else self.padded_num_attention_heads
+            )
             (
                 (spp_wmd_size, spp_wmd_type),
                 (spp_wi_size, spp_wi_type),
@@ -300,7 +315,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             ) = get_mla_metadata_info_v1(
                 self.max_num_batched_tokens,
                 1,  # sparse prefill treats each query token as q_len=1
-                self.padded_num_attention_heads,
+                sparse_prefill_num_heads,
                 self.dtype_q,
                 self.dtype_kv,
                 is_sparse=True,

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -125,6 +125,53 @@ def cdiv(a, b):
     return (a + b - 1) // b
 
 
+def _uses_standalone_lmcache_offload(config) -> bool:
+    """Whether the configured transfer path is the raw-byte LMCache connector."""
+    transfer_config = getattr(config, "kv_transfer_config", None)
+    if not isinstance(transfer_config, dict):
+        return False
+    connector = transfer_config.get("kv_connector")
+    if not isinstance(connector, str):
+        return False
+    normalized = connector.strip().lower()
+    return normalized in {
+        "lmcache_offload",
+        "lmcacheoffloadconnector",
+        "lmcacheconnectorv1",
+    }
+
+
+def _replicated_index_cache_unsupported_reasons(
+    config,
+    hf_config,
+    *,
+    dcp_world_size: int,
+    mla_page_size: int,
+    pcp_world_size: int,
+) -> list[str]:
+    """Return startup blockers for the experimental replicated index layout."""
+    unsupported = []
+    if getattr(hf_config, "model_type", None) != "glm_moe_dsa":
+        unsupported.append("model_type must be glm_moe_dsa")
+    if dcp_world_size <= 1:
+        unsupported.append("decode context parallel size must be > 1")
+    if config.speculative_config is not None:
+        unsupported.append("MTP/speculative decoding is not supported")
+    if mla_page_size != 1:
+        unsupported.append("MLA page size must be 1")
+    if pcp_world_size > 1:
+        unsupported.append("PCP is not supported")
+    if getattr(config, "pipeline_parallel_size", 1) > 1:
+        unsupported.append("pipeline parallelism is not supported")
+    if getattr(config, "kv_transfer_config", None) and not (
+        _uses_standalone_lmcache_offload(config)
+    ):
+        unsupported.append("PD and non-LMCache KV transfer are not supported")
+    if getattr(config, "enable_rapidserve", False):
+        unsupported.append("RapidServe disaggregation is not supported")
+    return unsupported
+
+
 class AiterMLABackend(AttentionBackend):
     @staticmethod
     def get_name() -> str:
@@ -174,23 +221,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         self.dcp_rank = get_dcp_rank()
         self.replicate_index_cache = dcp_replicated_index_cache_enabled(config)
         if envs.ATOM_DCP_REPLICATE_INDEX_CACHE:
-            unsupported = []
-            if getattr(hf_config, "model_type", None) != "glm_moe_dsa":
-                unsupported.append("model_type must be glm_moe_dsa")
-            if self.dcp_world_size <= 1:
-                unsupported.append("decode context parallel size must be > 1")
-            if config.speculative_config is not None:
-                unsupported.append("MTP/speculative decoding is not supported")
-            if self.block_size != 1:
-                unsupported.append("MLA page size must be 1")
-            if get_pcp_world_size() > 1:
-                unsupported.append("PCP is not supported")
-            if getattr(config, "pipeline_parallel_size", 1) > 1:
-                unsupported.append("pipeline parallelism is not supported")
-            if getattr(config, "kv_transfer_config", None):
-                unsupported.append("KV transfer/LMCache/PD is not supported")
-            if getattr(config, "enable_rapidserve", False):
-                unsupported.append("RapidServe disaggregation is not supported")
+            unsupported = _replicated_index_cache_unsupported_reasons(
+                config,
+                hf_config,
+                dcp_world_size=self.dcp_world_size,
+                mla_page_size=self.block_size,
+                pcp_world_size=get_pcp_world_size(),
+            )
             if unsupported:
                 raise ValueError(
                     "ATOM_DCP_REPLICATE_INDEX_CACHE=1 is unsupported: "

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -168,6 +168,79 @@ def _correct_attn_cp_out_kernel(
     tl.store(new_output_ptr + output_offsets, output)
 
 
+@triton.jit
+def _correct_attn_cp_out_rs_layout_kernel(
+    outputs_ptr,
+    rs_output_ptr,
+    lses_ptr,
+    outputs_stride_B,
+    outputs_stride_H,
+    outputs_stride_D,
+    lses_stride_N,
+    lses_stride_B,
+    lses_stride_H,
+    lse_idx,
+    batch_size: tl.int64,
+    HEAD_DIM: tl.constexpr,
+    LOCAL_HEADS: tl.constexpr,
+    N_ROUNDED: tl.constexpr,
+):
+    """Correct partial attention directly into rank-major RS input layout.
+
+    ``outputs`` is ``[B, H_full, D]`` with rank-major head groups. The output is
+    physically ``[N * B, H_local, D]`` so reduce-scatter on dim 0 returns the
+    final contiguous ``[B, H_local, D]`` tensor directly. Unlike the general
+    correction kernel, this production-only path does not materialize global
+    LSE because ``cp_lse_ag_out_rs`` never consumes it.
+    """
+    batch_idx = tl.program_id(axis=0).to(tl.int64)
+    head_idx = tl.program_id(axis=1).to(tl.int64)
+    d_offsets = tl.arange(0, HEAD_DIM)
+    num_n_offsets = tl.arange(0, N_ROUNDED)
+
+    lse_offsets = (
+        num_n_offsets * lses_stride_N
+        + batch_idx * lses_stride_B
+        + head_idx * lses_stride_H
+    )
+    lse = tl.load(lses_ptr + lse_offsets)
+    lse = tl.where((lse != lse) | (lse == float("inf")), -float("inf"), lse)
+
+    lse_max = tl.max(lse, axis=0)
+    lse_max = tl.where(lse_max == -float("inf"), 0, lse_max)
+    lse -= lse_max
+    global_lse = tl.log(tl.sum(tl.exp(lse), axis=0)) + lse_max
+
+    local_lse_offset = (
+        lse_idx * lses_stride_N + batch_idx * lses_stride_B + head_idx * lses_stride_H
+    )
+    local_lse = tl.load(lses_ptr + local_lse_offset)
+    lse_diff = local_lse - global_lse
+    lse_diff = tl.where(
+        (lse_diff != lse_diff) | (lse_diff == float("inf")),
+        -float("inf"),
+        lse_diff,
+    )
+    factor = tl.exp(lse_diff)
+
+    input_offsets = (
+        batch_idx * outputs_stride_B
+        + head_idx * outputs_stride_H
+        + d_offsets * outputs_stride_D
+    )
+    output = tl.load(outputs_ptr + input_offsets) * factor
+    output = tl.where(factor == 0.0, 0.0, output)
+
+    head_group = head_idx // LOCAL_HEADS
+    local_head = head_idx % LOCAL_HEADS
+    rs_offsets = (
+        (head_group * batch_size + batch_idx) * LOCAL_HEADS * HEAD_DIM
+        + local_head * HEAD_DIM
+        + d_offsets
+    )
+    tl.store(rs_output_ptr + rs_offsets, output)
+
+
 def correct_attn_out(out, lses, cp_rank, ctx=None):
     """Correct local rank's attention output using all-gathered LSEs.
 
@@ -212,6 +285,59 @@ def correct_attn_out(out, lses, cp_rank, ctx=None):
     return out, lse
 
 
+def correct_attn_out_rs_layout(out, lses, cp_rank, ctx=None):
+    """Correct local output directly into reduce-scatter's rank-major layout.
+
+    Returns ``[N * B, H_local, D]``. A dim-0 reduce-scatter over ``N`` ranks
+    therefore returns contiguous ``[B, H_local, D]`` without either of the
+    full-tensor ``movedim(...).contiguous()`` copies used by the old path.
+    """
+    B, H, D = out.shape
+    N = lses.shape[0]
+    assert (N & (N - 1)) == 0, f"cp world size must be a power of two, got {N}"
+    assert H % N == 0, f"full head count {H} must be divisible by cp size {N}"
+    assert 0 <= cp_rank < N, f"cp rank {cp_rank} outside [0, {N})"
+    local_heads = H // N
+    rs_output = torch.empty(
+        (N * B, local_heads, D),
+        dtype=out.dtype,
+        device=out.device,
+    )
+
+    grid = (B, H, 1)
+    regular_args = (
+        out,
+        rs_output,
+        lses,
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        lses.stride(0),
+        lses.stride(1),
+        lses.stride(2),
+        cp_rank,
+        B,
+    )
+    const_args = {
+        "HEAD_DIM": D,
+        "LOCAL_HEADS": local_heads,
+        "N_ROUNDED": N,
+    }
+    if ctx is not None:
+        ctx.call_kernel(
+            _correct_attn_cp_out_rs_layout_kernel,
+            grid,
+            *regular_args,
+            **const_args,
+        )
+    else:
+        _correct_attn_cp_out_rs_layout_kernel[grid](
+            *regular_args,
+            **const_args,
+        )
+    return rs_output
+
+
 def cp_lse_ag_out_rs(cp_attn_out, cp_attn_lse, cp_group, ctx=None):
     """AG+RS backend: AllGather LSE -> Triton correct -> ReduceScatter output.
 
@@ -231,12 +357,10 @@ def cp_lse_ag_out_rs(cp_attn_out, cp_attn_lse, cp_group, ctx=None):
     lses = dcp_all_gather(cp_group, cp_attn_lse, 0)
     lses = lses.reshape((cp_group.world_size,) + cp_attn_lse.shape)
 
-    out, _ = correct_attn_out(cp_attn_out, lses, cp_group.rank_in_group, ctx=ctx)
-
-    out = out.movedim(1, 0).contiguous()  # [B, H_full, D] -> [H_full, B, D]
-    out = cp_group.reduce_scatter(out, dim=0)
-    out = out.movedim(0, 1).contiguous()  # [H_local, B, D] -> [B, H_local, D]
-    return out
+    rs_input = correct_attn_out_rs_layout(
+        cp_attn_out, lses, cp_group.rank_in_group, ctx=ctx
+    )
+    return cp_group.reduce_scatter(rs_input, dim=0)
 
 
 def dcp_gather_compressed_kv(

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1394,6 +1394,13 @@ def _dcp_gather_indexer_k_prefill(
     return k_fp8, k_scale
 
 
+def _dcp_index_comm_required(
+    dcp_world_size: int, replicated_index_cache: bool
+) -> bool:
+    """Whether index top-k still needs a cross-rank gather/merge."""
+    return dcp_world_size > 1 and not replicated_index_cache
+
+
 def _dcp_decode_candidate_exchange(
     attn_metadata,
     padded_q_fp8_decode_tokens: torch.Tensor,
@@ -1566,7 +1573,14 @@ def sparse_attn_indexer(
     forward_context = get_forward_context()
     attn_metadata = forward_context.attn_metadata
     context = forward_context.context
-    slot_mapping = attn_metadata.slot_mapping
+    replicated_index_cache = (
+        getattr(attn_metadata, "index_slot_mapping", None) is not None
+    )
+    slot_mapping = (
+        attn_metadata.index_slot_mapping
+        if replicated_index_cache
+        else attn_metadata.slot_mapping
+    )
     # Skip for dummy runs to avoid corrupting KV cache
     if forward_context.context.is_dummy_run:
         # dummy runner
@@ -1577,7 +1591,10 @@ def sparse_attn_indexer(
     )
     runner_block_size = get_current_atom_config().kv_cache_block_size
     cp_kv_cache_interleave_size = get_current_atom_config().dcp_config.interleave_size
-    kv_cache = kv_cache.view(-1, runner_block_size, kv_cache.shape[-1])
+    index_block_size = runner_block_size * (
+        get_dcp_world_size() if replicated_index_cache else 1
+    )
+    kv_cache = kv_cache.view(-1, index_block_size, kv_cache.shape[-1])
     # PCP prefill: `k` (and `positions`) arrive as the full PADDED key set
     # [S_pad] produced by an all-gather of the round-robin shards. The KV-cache
     # write (driven by slot_mapping) and the gathered-KV sizing (total_kv =
@@ -1655,7 +1672,9 @@ def sparse_attn_indexer(
                 dtype=torch.long,
                 device=prefill_metadata.block_tables.device,
             )
-        if get_dcp_world_size() > 1:
+        if _dcp_index_comm_required(
+            get_dcp_world_size(), replicated_index_cache
+        ):
             k_fp8, k_scale = _dcp_gather_indexer_k_prefill(
                 kv_cache, prefill_metadata, head_dim, k.device
             )
@@ -1792,8 +1811,8 @@ def sparse_attn_indexer(
         num_rows = batch_size * next_n
         dcp_world_size = get_dcp_world_size()
         logits = None
-        if dcp_world_size > 1:
-            dcp_rank = get_dcp_rank()
+        dcp_rank = get_dcp_rank() if dcp_world_size > 1 else 0
+        if _dcp_index_comm_required(dcp_world_size, replicated_index_cache):
             _dcp_decode_candidate_exchange(
                 attn_metadata,
                 padded_q_fp8_decode_tokens,
@@ -1820,7 +1839,7 @@ def sparse_attn_indexer(
                 decode_metadata.context_lens,
                 attn_metadata.block_tables,
                 max_model_len,
-                KVBlockSize=runner_block_size,
+                KVBlockSize=index_block_size,
                 Preshuffle=True,
             )
         assert topk_tokens == 2048, "top_k_per_row assumes size 2048"

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -61,6 +61,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_USE_TRITON_MLA_SHUFFLE_KV": lambda: (
         os.getenv("ATOM_USE_TRITON_MLA_SHUFFLE_KV", "0") == "1"
     ),
+    # Experimental native GLM-5.2 DCP mode: keep MLA KV sharded but replicate
+    # full IndexShare-layer index caches on every DCP rank. This removes the
+    # indexer candidate all-gather/global-merge path. Disabled by default.
+    "ATOM_DCP_REPLICATE_INDEX_CACHE": lambda: (
+        os.getenv("ATOM_DCP_REPLICATE_INDEX_CACHE", "0") == "1"
+    ),
     "ATOM_USE_TRITON_MOE": lambda: os.getenv("ATOM_USE_TRITON_MOE", "0") == "1",
     "ATOM_USE_TRITON_MOE_DECODE": lambda: os.getenv("ATOM_USE_TRITON_MOE_DECODE", "0")
     == "1",

--- a/docs/context_parallel_guide.md
+++ b/docs/context_parallel_guide.md
@@ -434,30 +434,38 @@ hit it.
 DeepSeek-R1 never needed this: 128 heads at `-tp 8` is 16 per rank, and the dcp8
 gather lands on 128 exactly.
 
-### The gqa=64 exception (non-persistent fp8 decode)
+### Sparse DCP persistent attention and gqa=64
 
-One of those four native widths is not always available: with an **fp8 Q and an
-fp8 KV cache**, aiter serves gqa=64 only from the **persistent** decode kernel
-and aborts the process otherwise (`asm_mla.cu`: *"fp8/fp8 with gqa_ratio=64 only
-supports persistent mode"*). A DCP decode that cannot be persistent therefore
-rounds a gathered 64 up to **128** instead of taking 64. Two situations force
-non-persistent:
+With an **fp8 Q and an fp8 KV cache**, aiter serves gqa=64 only from the
+**persistent** decode kernel and aborts the process otherwise (`asm_mla.cu`:
+*"fp8/fp8 with gqa_ratio=64 only supports persistent mode"*).
 
-- **sparse MLA / DSA under DCP** — the per-rank top-k compaction makes the sparse
-  region length depend on the layer, which work metadata built once per step
-  cannot describe (see `_forward_decode`);
-- **gfx942**, which ships no lse-emitting persistent kernel at all.
+Native sparse MLA / DSA attention under DCP handles this on gfx950 by rebuilding
+the persistent work/reduce metadata after every **full IndexShare layer**
+compacts its rank-local top-k. The rebuild consumes that layer's
+`dcp_sparse_kv_indptr`; following shared layers reuse the same indices, compact
+indptr, and work plan. This makes the persistent descriptors and the actual
+sparse regions agree without rebuilding metadata on shared layers.
 
-`mla_dcp_decode_is_persistent` decides this once at construction, so the width
-the module pads to and the width the persistent descriptors are planned for
-cannot disagree.
+The implementation is scoped to native, non-speculative serving on gfx950 with
+page size 1: decode is q_len=1, while sparse prefill is represented as per-token
+virtual q_len=1 rows. Unsupported paths (including gfx942 and plugin or
+speculative sparse DCP paths without the per-layer rebuild) remain
+non-persistent and round a gathered 64 up to **128**.
 
-**GLM-5.2 is the model that lands on it**: 64 query heads at `-tp 8` is 8 per
-rank, so `-dcp 8` gathers exactly 64 — sparse, hence non-persistent, hence padded
-to 128. Half the kernel's heads are padding in that configuration; making it 64
-means giving sparse + DCP a persistent path first.
+**GLM-5.2 is the model that benefits**: 64 query heads at `-tp 8` is 8 per
+rank, so `-dcp 8` gathers exactly 64 and now dispatches the native persistent
+gqa64 kernel instead of padding to 128. `-tp 4 -dcp 4` has the same gathered
+width and uses the same persistent gqa64 path.
 
-**Validated** (ATOM server, 8×MI355 gfx950, `-tp 8 -dcp 8`, fp8 KV, full 1319
+**Validated** (native ATOM, MI355 gfx950, GLM-5.2-MXFP4, fp8 KV, no
+speculative decode): both `-tp 8 -dcp 8` and `-tp 4 -dcp 4` complete CUDA graph
+capture, short decode, 7.7k-token sparse prefill/decode, and the full 1319
+GSM8K 5-shot set. Both topologies score **flexible-extract 0.9689 /
+strict-match 0.9666**. The TP8/DCP8 run also completes a 32-concurrent graph
+smoke with no traceback, HIP error, or engine failure.
+
+**Kimi-K3 validated** (ATOM server, 8×MI355 gfx950, `-tp 8 -dcp 8`, fp8 KV, full 1319
 GSM8K 5-shot at 64 concurrency): **flexible-extract 0.9553 / strict-match
 0.9553**, inside the [Kimi-K3 recipe](../recipes/Kimi-K3.md)'s
 0.9538–0.9591 band. Prefix caching was **off** for that run, matching the
@@ -558,7 +566,7 @@ contributing under DCP rather than collapsing back to single-token decode.
 | prefix caching / chunked prefill | Supported (dense and sparse / DSA). On **Kimi-K3** the validated configuration has prefix caching **off**, per its recipe |
 | Kimi-K3 KDA layers | Not sharded — the KDA recurrent state is per-request, not paged, so DCP frees only the MLA share of attention memory |
 | Kimi-K3 gathered head width | Padded to a natively dispatched MLA width (16 / 32 / 64 / 128); past 128 it falls back to the folded kernel with a warning — lower `-dcp` or raise `-tp` |
-| gathered head width 64 + fp8 KV | Only the persistent kernel serves gqa=64 on fp8 Q/KV, so a non-persistent DCP decode (sparse / DSA, or any DCP decode on gfx942) pads to 128 instead — see [the gqa=64 exception](#the-gqa64-exception-non-persistent-fp8-decode) |
+| gathered head width 64 + fp8 KV | Native sparse / DSA prefill and q_len=1 decode on gfx950 rebuild persistent metadata per full IndexShare layer and run gqa64 directly; unsupported non-persistent paths still pad to 128 — see [Sparse DCP persistent attention and gqa=64](#sparse-dcp-persistent-attention-and-gqa64) |
 | speculative decode (MTP), dense MLA | Supported on **gfx950 only** (bf16/fp8, `num_speculative_tokens` 1–3); raises at startup on gfx942 |
 | speculative decode (DSpark), Kimi-K3 | Supported on gfx950; validated at `tp8 -dcp 8` with `num_speculative_tokens 2` |
 | speculative decode (MTP), sparse / DSA | **Not supported** — sparse decode with `q > 1` under DCP is rejected by an assert |

--- a/docs/context_parallel_guide.md
+++ b/docs/context_parallel_guide.md
@@ -465,6 +465,35 @@ GSM8K 5-shot set. Both topologies score **flexible-extract 0.9689 /
 strict-match 0.9666**. The TP8/DCP8 run also completes a 32-concurrent graph
 smoke with no traceback, HIP error, or engine failure.
 
+### Experimental GLM-5.2 replicated index cache
+
+Set `ATOM_DCP_REPLICATE_INDEX_CACHE=1` to keep the GLM-5.2 DSA index cache
+complete on every DCP rank. The main MLA KV cache remains round-robin sharded.
+Only the 21 `"full"` IndexShare layers allocate index rows; `"shared"` layers
+reuse the preceding full layer's top-k and persistent work plan.
+
+Each scheduler block's index page expands from `block_size` rank-local tokens
+to `block_size × dcp` global tokens. Every rank writes each new index K to that
+expanded page. Prefill then gathers the full K locally, and decode scores the
+global context and runs a single stable global top-k locally. Both the prefill
+index-K AllGather and decode candidate pack/AllGather/second-top-k are skipped.
+The existing ownership filter still partitions that global top-k into compact
+rank-local indices for the DCP-sharded MLA KV cache.
+
+The switch is off by default and the initial implementation is deliberately
+native-only: `glm_moe_dsa`, DCP > 1, q_len=1 decode, MLA page size 1, and no
+PCP or PP. MTP/speculative decode, LMCache/KV transfer/PD, and RapidServe
+disaggregation fail fast at startup. GPU prefix caching and CUDA graph replay
+use the same expanded-page lifetime and are supported.
+
+Replication trades index communication for cache capacity. For GLM-5.2 with
+78 MLA layers, 21 full index layers, block size 16, fp8 index width 144, and
+DCP8, index bytes per scheduler block increase from
+`78 × 16 × 144 = 179,712` to `21 × 16 × 8 × 144 = 387,072`.
+Including the unchanged MLA KV, total bytes per block rise from 898,560 to
+1,105,920 (+23.1%), so a fixed KV memory budget holds about 18.8% fewer blocks.
+At 2,048 global tokens this is about 3.16 MiB additional index storage per rank.
+
 **Kimi-K3 validated** (ATOM server, 8×MI355 gfx950, `-tp 8 -dcp 8`, fp8 KV, full 1319
 GSM8K 5-shot at 64 concurrency): **flexible-extract 0.9553 / strict-match
 0.9553**, inside the [Kimi-K3 recipe](../recipes/Kimi-K3.md)'s

--- a/docs/context_parallel_guide.md
+++ b/docs/context_parallel_guide.md
@@ -465,6 +465,21 @@ GSM8K 5-shot set. Both topologies score **flexible-extract 0.9689 /
 strict-match 0.9666**. The TP8/DCP8 run also completes a 32-concurrent graph
 smoke with no traceback, HIP error, or engine failure.
 
+### DCP output-merge layout
+
+The LSE-corrected partial output is written directly in rank-major
+`[dcp × batch, local_heads, value_dim]` order. A dim-0 ReduceScatter therefore
+returns contiguous `[batch, local_heads, value_dim]` output without the two
+full-tensor `movedim(...).contiguous()` copies previously placed before and
+after the collective. This production path also skips materializing global LSE,
+which no caller consumed.
+
+On one MI355, the correction/layout stage at GLM-5.2's `H=64, D=512, DCP8`
+measured 13.0 us versus 15.5 us for the previous correction plus pre-RS copy at
+batch 1, 13.2 us versus 164.4 us at batch 16, and 417.2 us versus 866.1 us at
+8,192 rows. The numerical merge, empty-rank NaN scrub, CUDA graph path, and
+ReduceScatter result layout are unchanged.
+
 ### Experimental GLM-5.2 replicated index cache
 
 Set `ATOM_DCP_REPLICATE_INDEX_CACHE=1` to keep the GLM-5.2 DSA index cache
@@ -493,6 +508,48 @@ DCP8, index bytes per scheduler block increase from
 Including the unchanged MLA KV, total bytes per block rise from 898,560 to
 1,105,920 (+23.1%), so a fixed KV memory budget holds about 18.8% fewer blocks.
 At 2,048 global tokens this is about 3.16 MiB additional index storage per rank.
+
+**Validation** (TP8+DCP8, GLM-5.2-MXFP4, fp8 KV, no MTP): CUDA graph capture,
+short decode, an 8,192-input/128-output run at concurrency 16, and the full
+1,319-sample GSM8K 5-shot set all complete. Using the same lm-eval chat adapter,
+replicated index scores **0.9651 / 0.9621** (flexible/strict) versus the sharded
+index run's **0.9697 / 0.9697**; the 0.46/0.76-point difference is about
+0.7/1.1 combined standard errors and is not statistically significant. On the
+8K/128 benchmark,
+output throughput improves from 172.34 to 179.77 token/s (+4.3%), mean TPOT
+drops from 53.14 to 49.30 ms (-7.2%), and median ITL drops from 23.15 to
+19.43 ms (-16.1%). The fixed KV budget holds about 18.8% fewer blocks as
+described above.
+
+### LMCache compatibility
+
+The default sharded-index DCP layout is compatible with ATOM's
+`lmcache_offload` byte codec. LMCache stores each rank's local MLA/index shard;
+the connector uses `block_size × dcp` as the scheduler-visible virtual block,
+requires chunks to contain whole virtual blocks, includes DCP size in the PAGE
+namespace, and transfers the DSA index cache alongside MLA KV. Persistent sparse
+metadata is rebuilt after load and is not part of the stored byte payload.
+
+The replicated-index layout is compatible with the standalone
+`lmcache_offload` connector. Its opaque block payload contains all 78 local MLA
+KV shards plus the 21 compact, DCP-expanded full-index rows. PAGE namespace
+version 3 includes both the replicated-layout flag and the exact
+`indexer_types` schedule, so these objects cannot collide with old sharded
+objects or a different IndexShare mapping. Full-prompt hits are floored to a
+complete LMCache chunk after reserving the final token for recomputation;
+otherwise an 8,192-token hit becomes an invalid 8,191-token load and falls back
+to a full prefill.
+
+Only standalone `{"kv_connector":"lmcache_offload"}` is enabled in this
+experimental mode. PD connectors and a `multi` topology containing LMCache plus
+PD still fail fast because their transfer protocols have not been adapted to
+the expanded index pages.
+
+**Validated** (TP8+DCP8, 8,192-token prompt, fp8 KV): all eight ranks stored
+67.5 MiB each and subsequently restored 65.4 MiB/7,936 tokens with
+`status=ok`; TTFT fell from 5.87 s cold to 0.46 s with the remaining 256-token
+prefill. A repeated 20-sample GSM8K smoke completed 160/160 worker loads without
+fallback, traceback, or HIP error and kept flexible-extract accuracy at 0.95.
 
 **Kimi-K3 validated** (ATOM server, 8×MI355 gfx950, `-tp 8 -dcp 8`, fp8 KV, full 1319
 GSM8K 5-shot at 64 concurrency): **flexible-extract 0.9553 / strict-match

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -29,6 +29,7 @@ import torch
 try:
     from atom.model_ops.dcp_ops import (
         correct_attn_out,
+        correct_attn_out_rs_layout,
         dcp_global_pos,
         dcp_local_index,
         dcp_owner_rank,
@@ -97,6 +98,46 @@ def test_merge_reproduces_dense_attention(dtype, N):
 
     tol = 1e-5 if dtype == torch.float32 else 3e-2
     torch.testing.assert_close(merged, dense_o, rtol=tol, atol=tol)
+
+
+@needs_gpu
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("N", [2, 4, 8])
+def test_rs_layout_merge_reproduces_dense_attention(dtype, N):
+    """Rank-major correction plus RS chunking reproduces the dense result."""
+    B, H, L, D = 5, 8, 128, 64
+    dense_o, _, outs, lses = _dense_and_shards(B, H, L, D, N, dtype, seed=11)
+    local_heads = H // N
+    packed_per_source = []
+
+    for source_rank in range(N):
+        packed = correct_attn_out_rs_layout(
+            outs[source_rank].clone(), lses, source_rank
+        )
+        assert packed.shape == (N * B, local_heads, D)
+
+        # The optimized kernel must be exactly the general correction arranged
+        # as N contiguous reduce-scatter destination chunks.
+        corrected, _ = correct_attn_out(outs[source_rank].clone(), lses, source_rank)
+        reference_layout = (
+            corrected.view(B, N, local_heads, D)
+            .permute(1, 0, 2, 3)
+            .reshape(N * B, local_heads, D)
+        )
+        tol = 1e-6 if dtype == torch.float32 else 2e-2
+        torch.testing.assert_close(packed, reference_layout, rtol=tol, atol=tol)
+        packed_per_source.append(packed.float())
+
+    # Simulate ReduceScatter(sum): sum every source rank's packed contribution,
+    # then give destination rank r its contiguous B-row chunk.
+    reduced = torch.stack(packed_per_source).sum(0)
+    tol = 1e-5 if dtype == torch.float32 else 3e-2
+    for destination_rank in range(N):
+        got = reduced[destination_rank * B : (destination_rank + 1) * B]
+        expected = dense_o[
+            :, destination_rank * local_heads : (destination_rank + 1) * local_heads
+        ]
+        torch.testing.assert_close(got, expected, rtol=tol, atol=tol)
 
 
 @needs_gpu

--- a/tests/test_dense_offload_connector.py
+++ b/tests/test_dense_offload_connector.py
@@ -155,6 +155,28 @@ def test_dense_worker_resolves_virtual_dcp_block_size():
         worker._load_executor.shutdown(wait=True)
 
 
+def test_dense_full_prompt_hit_loads_only_complete_chunks(monkeypatch):
+    scheduler = _scheduler(monkeypatch)
+
+    class Lookup:
+        def lookup(self, token_ids, lookup_id):
+            del lookup_id
+            return len(token_ids)
+
+        def clear_lookup_status(self, lookup_id):
+            del lookup_id
+
+    scheduler._lookup_client = Lookup()
+    seq = _load_seq(8, num_prompt_tokens=16)
+
+    need, should_park = scheduler.get_num_new_matched_tokens(seq)
+
+    # Full hit 16 reserves the final token for logits, then floors 15 to the
+    # 8-token LMCache chunk. Requesting 15 would retrieve only 8 and fail closed.
+    assert (need, should_park) == (8, True)
+    assert scheduler._load_specs["8"].lmcache_cached_tokens == 8
+
+
 def test_dense_producer_role_tracks_only_saves(monkeypatch):
     scheduler = _scheduler(monkeypatch, "kv_producer")
     seq = SimpleNamespace(

--- a/tests/test_lmcache_offload_config.py
+++ b/tests/test_lmcache_offload_config.py
@@ -115,6 +115,24 @@ def test_page_namespace_changes_for_meaningful_geometry(mutate):
     assert offcfg.build_page_namespace(config, cfg, 4) != original
 
 
+def test_page_namespace_separates_replicated_index_layout(monkeypatch):
+    config = _config()
+    config.speculative_config = None
+    config.hf_config.model_type = "glm_moe_dsa"
+    config.hf_config.indexer_types = ["full", "shared", "shared"]
+    cfg = _lmcache_config()
+
+    monkeypatch.delenv("ATOM_DCP_REPLICATE_INDEX_CACHE", raising=False)
+    sharded = offcfg.build_page_namespace(config, cfg, 4)
+    monkeypatch.setenv("ATOM_DCP_REPLICATE_INDEX_CACHE", "1")
+    replicated = offcfg.build_page_namespace(config, cfg, 4)
+    assert replicated != sharded
+
+    config.hf_config.indexer_types = ["full", "full", "shared"]
+    changed_schedule = offcfg.build_page_namespace(config, cfg, 4)
+    assert changed_schedule != replicated
+
+
 def test_page_namespace_changes_when_code_layout_version_changes():
     current = offcfg.build_page_namespace(_config(), _lmcache_config(), 4)
     future = offcfg.build_page_namespace(


### PR DESCRIPTION
## Summary

This PR improves native GLM-5.2 sparse MLA serving under Decode Context Parallelism (DCP) in the following areas:

- Adds an experimental replicated index-cache layout that removes cross-rank index top-k communication.
- Supports replicated index-cache transfer through LMCache and selected Mooncake/PD topologies.
- Optimizes the AG+RS DCP output merge by removing full-tensor layout copies and an unused global-LSE write.

The main MLA KV cache remains DCP-sharded. Replicating the index cache is opt-in through:

```bash
export ATOM_DCP_REPLICATE_INDEX_CACHE=1
```

## Motivation

GLM-5.2 uses sparse MLA with IndexShare. The previous DCP path had two major limitations:

1. Sparse compact indices vary by full IndexShare layer, so persistent MLA metadata built before the layer-specific top-k was invalid. The path therefore fell back to non-persistent attention. For FP8 Q/KV with a gathered GQA ratio of 64, AITER only supports the persistent kernel, forcing a 64-to-128 head padding fallback.

2. The DSA index cache was sharded using the same DCP layout as the main MLA KV cache. This required:
   - prefill index-K all-gather and de-interleave;
   - per-rank decode top-k;
   - candidate packing and all-gather;
   - a second top-k over the gathered candidates.

The replicated-index mode trades additional index-cache memory for local global-top-k computation and removes that index communication pipeline.

## Changes

### Persistent sparse MLA under DCP

- Rebuilds `get_mla_metadata_v1` work/reduce metadata after each full IndexShare layer has produced its compact rank-local indices.
- Reuses the previous full layer's compact indices, indptr, and persistent work plan on shared IndexShare layers.
- Supports the same per-layer rebuild in sparse prefill, where each query token is represented as a virtual `q_len=1` row.
- Keeps unsupported paths on the existing non-persistent fallback.
- Routes GLM-5.2 TP8/DCP8 and TP4/DCP4 FP8 attention to the native persistent GQA64 path instead of padding 64 heads to 128.
- Preserves CUDA graph replay by reusing preallocated work, reduce, indptr, count, and compact-index buffers.
- Keeps MTP/speculative sparse DCP out of this persistent path.

### Experimental replicated index cache

- Adds `ATOM_DCP_REPLICATE_INDEX_CACHE`, disabled by default.
- Limits the replicated allocation to GLM-5.2 `glm_moe_dsa`, DCP > 1, no speculative decoding, and MLA page size 1.
- Allocates index-cache rows only for the 21 `"full"` IndexShare layers; the 57 `"shared"` layers continue reusing the preceding full layer's result.
- Expands each index-cache page from `block_size` rank-local tokens to `block_size × dcp_size` global tokens.
- Adds a separate `index_slot_mapping` while leaving the existing MLA `slot_mapping` owner-only and DCP-sharded.
- Makes every DCP rank write the complete index K cache.
- Uses global context lengths and the expanded page size for local decode scoring.
- Computes one stable global top-k locally on every rank.
- Skips the decode candidate exchange, candidate packing, index all-gather, and second top-k.
- Skips the prefill index-K all-gather and de-interleave.
- Retains the existing ownership filter and order-preserving compaction so each rank attends only to the selected tokens stored in its DCP-sharded MLA KV cache.
- Handles dummy warmup, padded CUDA graph batches, TBO ubatches, cached prefill, and prefix-cache block lifetimes.

The selected top-k set must be deterministic across ranks, but the 2,048 indices do not need to be sorted by token position. The ownership filter preserves the incoming relative order and emits a compact, hole-free local index region.

### DCP output-merge optimization

For the AG+RS backend:

- Adds a correction kernel that writes directly to rank-major ReduceScatter input layout.
- Removes the full-tensor `movedim(...).contiguous()` copy before ReduceScatter.
- Makes ReduceScatter return contiguous `[batch, local_heads, value_dim]` output directly, removing the post-collective layout copy.
- Avoids allocating and writing global LSE in the production merge path because the caller does not consume it.
- Preserves NaN/+inf LSE sanitization and zeroes empty-rank contributions before reduction.

This does not modify the AITER MLA kernel.

### LMCache and PD compatibility

- Extends the raw-byte cache payload to include:
  - all local MLA KV rows;
  - the 21 compact, DCP-expanded full-index rows.
- Bumps the LMCache PAGE namespace to version 3.
- Adds the replicated-index flag, effective index-cache dtype, and exact `indexer_types` schedule to the namespace fingerprint.
- Prevents replicated and sharded layouts, or different IndexShare schedules, from reusing incompatible LMCache objects.
- Floors full-prompt LMCache hits to complete chunks after reserving the final token for logits recomputation. For example, an 8,192-token full hit now loads 7,936 tokens and recomputes the final 256-token chunk instead of attempting an invalid 8,191-token load and falling back to full prefill.
- Validates the expanded physical index-page width before exposing transfer regions.

Supported replicated-index transfer configurations are:

- standalone `lmcache_offload`;
- standalone Mooncake producer or consumer;
- `multi` containing exactly Mooncake producer plus LMCache offload.

Other transfer topologies fail fast.

### Documentation and tests

- Extends the context-parallel guide with:
  - sparse persistent metadata rebuild behavior;
  - replicated index-cache layout and runtime flow;
  - memory/capacity trade-offs;
  - LMCache and PD layout requirements;
  - validation and performance results.
- Adds regression coverage for:
  - DCP LSE merge correctness;
  - empty-rank/NaN handling;
  - direct ReduceScatter layout;
  - LMCache PAGE namespace separation;
  - full-prompt chunk alignment;
  - DCP virtual-block behavior;
  - compact/expanded index-cache byte accounting.

## Memory trade-off

For GLM-5.2 with 78 MLA layers, 21 full index layers, block size 16, FP8 index width 144, and DCP8:

- Sharded index bytes per scheduler block:
  `78 × 16 × 144 = 179,712`
- Replicated index bytes per scheduler block:
  `21 × 16 × 8 × 144 = 387,072`
- Total MLA+index bytes per block increase from 898,560 to 1,105,920, or approximately 23.1%.
- A fixed KV memory budget therefore holds approximately 18.8% fewer blocks.

The replicated layout is intentionally experimental and disabled by default because this capacity cost is workload-dependent.

## Validation

### Unit and regression tests

Targeted DCP and LMCache suites completed successfully, including merge correctness, sparse filtering, persistent metadata, top-k, virtual blocks, namespace isolation, and LMCache connector behavior.

A combined targeted run completed with:

```text
396 passed
```

### TP8/DCP8 runtime

Validated on MI355/gfx950 with GLM-5.2-MXFP4, FP8 KV, and no MTP:

- CUDA graph capture completed.
- Short decode completed.
- 8K-context prefill/decode completed.
- Concurrency-16 serving completed without traceback or HIP errors.
- Replicated index-cache startup reported 21 full IndexShare rows on all eight ranks.

### Accuracy

Persistent sparse DCP without replicated index cache was validated on both TP8/DCP8 and TP4/DCP4 with the full 1,319-sample GSM8K 5-shot set:

```text
flexible-extract: 0.9689
strict-match:     0.9666
```

Using the same local chat evaluator for a replicated-versus-sharded TP8/DCP8 comparison:

```text
replicated index: flexible 0.9651 / strict 0.9621
sharded index:    flexible 0.9697 / strict 0.9697
```

The difference was approximately 0.7/1.1 combined standard errors and was not statistically significant in that run.

A 20-sample LMCache restore smoke completed 160/160 worker loads without fallback, traceback, or HIP error and retained flexible-extract accuracy at 0.95.

### LMCache restore

For an 8,192-token TP8/DCP8 prompt:

- every rank stored 67.5 MiB of MLA+replicated-index payload;
- every rank restored the aligned 7,936-token prefix with `status=ok`;
- the remaining 256 tokens were recomputed;
- TTFT dropped from 5.87 seconds cold to 0.46 seconds on restore.

### Performance

On an 8,192-input/128-output concurrency-16 benchmark:

```text
output throughput: 172.34 -> 179.77 token/s  (+4.3%)
mean TPOT:          53.14 -> 49.30 ms       (-7.2%)
median ITL:         23.15 -> 19.43 ms       (-16.1%)
```

The AG+RS correction/layout microbenchmark at H=64, D=512, DCP8 measured:

```text
batch 1:    15.5 -> 13.0 us
batch 16:  164.4 -> 13.2 us
8192 rows: 866.1 -> 417.2 us
```

Replicated-index performance is workload-dependent. In the long-context Agentic C16 profile it was slower than the sharded layout:

```text
TP8/DCP8 per-GPU throughput: 5,446.64 -> 4,945.76 token/s
TP4/DCP4 per-GPU throughput: 9,930.62 -> 9,227.99 token/s
```

This is why the feature remains opt-in.

## Known limitations

- Replicated index cache is native ATOM only.
- Sparse DCP + MTP/speculative decoding is not supported.
- Requires MLA page size 1.
- PCP, PP > 1, and RapidServe are not supported in replicated-index mode.
- Only the explicitly validated LMCache/Mooncake transfer topologies are accepted.
- The main MLA KV cache remains DCP-sharded, so query/output DCP communication is still required.
- Replicated index cache reduces available KV capacity.
- Long-context quality requires continued validation. A recent unique-prefix DCP4 replicated-index needle run retrieved 5/6 needles, while its pure TP4 control retrieved 6/6. The feature should remain experimental until this is fully characterized.

