### PR TITLE
[DCP][Opt] Query replication, project-before-merge, and an all-to-all merge backend

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1442,13 +1442,6 @@ def qrep_unsupported_reason(
     Kept a module-level pure function so it is unit-testable: the alternative,
     exercising it through ``Config.__post_init__``, needs a real model directory
     and an HF config. ``Config.__post_init__`` is its only production caller.
-
-    ⚠️ Gating keys off the DCP size ONLY -- never off the KV-cache interleave
-    granularity. This check once lived inside ``if dcp_config.interleave_size >
-    1``, which silently disabled QREP for the default ``interleave_size=1``,
-    i.e. in every ordinary configuration, while logging that dcp was <= 1. Now
-    that QREP defaults to on, that failure mode would be invisible; the truth
-    table in ``tests/test_dcp_config.py`` pins it.
     """
     if dcp_size <= 1:
         # No DCP group means there is no AllGather Q to remove.

--- a/atom/config.py
+++ b/atom/config.py
@@ -1392,21 +1392,30 @@ class EPLBConfig:
         return cls(**cfg)
 
 
+DCP_COMM_BACKENDS = ("ag_rs", "a2a")
+
+
 @dataclass
 class DCPConfig:
-    """DCP (Decode Context Parallel) sub-config: interleave granularity and
-    query replication; room for future knobs (all-to-all backend, ...) without
-    growing the top-level CLI surface."""
+    """DCP (Decode Context Parallel) sub-config: interleave granularity, query
+    replication, output-merge placement and the merge collective backend --
+    knobs that would otherwise each grow the top-level CLI surface."""
 
     interleave_size: int = 1
     enable_query_replication: bool = True
     enable_project_before_merge: bool = True
+    comm_backend: str = "a2a"
 
     def __post_init__(self):
         self.interleave_size = int(self.interleave_size)
         assert self.interleave_size >= 1, "dcp.interleave_size must be >= 1"
         self.enable_query_replication = bool(self.enable_query_replication)
         self.enable_project_before_merge = bool(self.enable_project_before_merge)
+        self.comm_backend = str(self.comm_backend)
+        assert self.comm_backend in DCP_COMM_BACKENDS, (
+            f"dcp.comm_backend must be one of {list(DCP_COMM_BACKENDS)}; "
+            f"got {self.comm_backend!r}"
+        )
 
     @classmethod
     def from_dict(cls, cfg: dict | None) -> "DCPConfig":

--- a/atom/config.py
+++ b/atom/config.py
@@ -1400,11 +1400,13 @@ class DCPConfig:
 
     interleave_size: int = 1
     enable_query_replication: bool = True
+    enable_project_before_merge: bool = True
 
     def __post_init__(self):
         self.interleave_size = int(self.interleave_size)
         assert self.interleave_size >= 1, "dcp.interleave_size must be >= 1"
         self.enable_query_replication = bool(self.enable_query_replication)
+        self.enable_project_before_merge = bool(self.enable_project_before_merge)
 
     @classmethod
     def from_dict(cls, cfg: dict | None) -> "DCPConfig":

--- a/atom/config.py
+++ b/atom/config.py
@@ -1379,6 +1379,11 @@ class Config:
     tensor_parallel_size: int = 1
     decode_context_parallel_size: int = 1
     dcp_config: DCPConfig = field(default_factory=DCPConfig)
+    # DCP Query Replication (QREP): replicate the MLA query projection across the
+    # DCP group at load time so each rank locally produces the full DCP-group head
+    # set, removing the per-step decode AllGather Q. Resolved/gated in __post_init__
+    # (needs dcp>1; off for spec-decode / fp4 in the first cut). Default off.
+    enable_dcp_query_replication: bool = False
     pipeline_parallel_size: int = 1
     prefill_context_parallel_size: int = 1
     enforce_eager: bool = False
@@ -1574,6 +1579,34 @@ class Config:
                 "dcp_config.interleave_size=1 with speculative decode, or disable "
                 "speculative decode for block-level interleave."
             )
+
+            # DCP Query Replication (QREP) first-cut gating. Replicating the MLA
+            # query projection across the DCP group removes the per-step decode
+            # AllGather Q. The first cut supports dense + sparse qlen=1 decode with
+            # fp8 weights only; turn the flag OFF (warn, not error) for combos not
+            # yet wired so it can be enabled globally without breaking mixed runs.
+            if self.enable_dcp_query_replication:
+                qrep_off = None
+                if self.speculative_config is not None:
+                    # MTP / eagle3 / dspark run a qlen>1 verify on the cprr kernel.
+                    qrep_off = "speculative decode (qlen>1 cprr path)"
+                elif envs.ATOM_USE_TRITON_MXFP4_BMM:
+                    # fp4 (mxfp4) absorbed BMM has a different scale structure.
+                    qrep_off = "fp4 (mxfp4) BMM weights"
+                if qrep_off is not None:
+                    logger.warning(
+                        "enable_dcp_query_replication disabled: %s not supported "
+                        "in the first cut.",
+                        qrep_off,
+                    )
+                    self.enable_dcp_query_replication = False
+        elif self.enable_dcp_query_replication:
+            # QREP is a DCP-only optimization; it is a no-op without a DCP group.
+            logger.info(
+                "enable_dcp_query_replication has no effect with "
+                "decode_context_parallel_size<=1; disabling."
+            )
+            self.enable_dcp_query_replication = False
         assert 1 <= self.pipeline_parallel_size
         self.hf_config = get_hf_config(
             self.model, trust_remote_code=self.trust_remote_code

--- a/atom/config.py
+++ b/atom/config.py
@@ -1333,15 +1333,17 @@ class EPLBConfig:
 
 @dataclass
 class DCPConfig:
-    """DCP (Decode Context Parallel) sub-config. Today only interleave
-    granularity; room for future knobs (all-to-all backend, query
-    replication, ...) without growing the top-level CLI surface."""
+    """DCP (Decode Context Parallel) sub-config: interleave granularity and
+    query replication; room for future knobs (all-to-all backend, ...) without
+    growing the top-level CLI surface."""
 
     interleave_size: int = 1
+    enable_query_replication: bool = True
 
     def __post_init__(self):
         self.interleave_size = int(self.interleave_size)
         assert self.interleave_size >= 1, "dcp.interleave_size must be >= 1"
+        self.enable_query_replication = bool(self.enable_query_replication)
 
     @classmethod
     def from_dict(cls, cfg: dict | None) -> "DCPConfig":
@@ -1358,6 +1360,34 @@ class DCPConfig:
                 f"Supported keys: {sorted(allowed)}"
             )
         return cls(**cfg)
+
+
+def qrep_unsupported_reason(
+    dcp_size: int, speculative_config, mxfp4_bmm: bool
+) -> str | None:
+    """Why DCP query replication cannot run here, or None if it can.
+
+    Kept a module-level pure function so it is unit-testable: the alternative,
+    exercising it through ``Config.__post_init__``, needs a real model directory
+    and an HF config. ``Config.__post_init__`` is its only production caller.
+
+    ⚠️ Gating keys off the DCP size ONLY -- never off the KV-cache interleave
+    granularity. This check once lived inside ``if dcp_config.interleave_size >
+    1``, which silently disabled QREP for the default ``interleave_size=1``,
+    i.e. in every ordinary configuration, while logging that dcp was <= 1. Now
+    that QREP defaults to on, that failure mode would be invisible; the truth
+    table in ``tests/test_dcp_config.py`` pins it.
+    """
+    if dcp_size <= 1:
+        # No DCP group means there is no AllGather Q to remove.
+        return "decode_context_parallel_size <= 1 (no DCP group)"
+    if speculative_config is not None:
+        # MTP / eagle3 / dspark run a qlen>1 verify on the cprr kernel.
+        return "speculative decode (qlen>1 cprr path)"
+    if mxfp4_bmm:
+        # fp4 (mxfp4) absorbed BMM has a different scale structure.
+        return "fp4 (mxfp4) BMM weights"
+    return None
 
 
 @dataclass
@@ -1379,11 +1409,6 @@ class Config:
     tensor_parallel_size: int = 1
     decode_context_parallel_size: int = 1
     dcp_config: DCPConfig = field(default_factory=DCPConfig)
-    # DCP Query Replication (QREP): replicate the MLA query projection across the
-    # DCP group at load time so each rank locally produces the full DCP-group head
-    # set, removing the per-step decode AllGather Q. Resolved/gated in __post_init__
-    # (needs dcp>1; off for spec-decode / fp4 in the first cut). Default off.
-    enable_dcp_query_replication: bool = False
     pipeline_parallel_size: int = 1
     prefill_context_parallel_size: int = 1
     enforce_eager: bool = False
@@ -1580,33 +1605,22 @@ class Config:
                 "speculative decode for block-level interleave."
             )
 
-            # DCP Query Replication (QREP) first-cut gating. Replicating the MLA
-            # query projection across the DCP group removes the per-step decode
-            # AllGather Q. The first cut supports dense + sparse qlen=1 decode with
-            # fp8 weights only; turn the flag OFF (warn, not error) for combos not
-            # yet wired so it can be enabled globally without breaking mixed runs.
-            if self.enable_dcp_query_replication:
-                qrep_off = None
-                if self.speculative_config is not None:
-                    # MTP / eagle3 / dspark run a qlen>1 verify on the cprr kernel.
-                    qrep_off = "speculative decode (qlen>1 cprr path)"
-                elif envs.ATOM_USE_TRITON_MXFP4_BMM:
-                    # fp4 (mxfp4) absorbed BMM has a different scale structure.
-                    qrep_off = "fp4 (mxfp4) BMM weights"
-                if qrep_off is not None:
-                    logger.warning(
-                        "enable_dcp_query_replication disabled: %s not supported "
-                        "in the first cut.",
-                        qrep_off,
-                    )
-                    self.enable_dcp_query_replication = False
-        elif self.enable_dcp_query_replication:
-            # QREP is a DCP-only optimization; it is a no-op without a DCP group.
-            logger.info(
-                "enable_dcp_query_replication has no effect with "
-                "decode_context_parallel_size<=1; disabling."
+        # DCP Query Replication (QREP) first-cut gating: turn the flag OFF
+        # (warn, not error) for combinations not yet wired, so it can default to
+        # on without breaking mixed runs.
+        if self.dcp_config.enable_query_replication:
+            qrep_off = qrep_unsupported_reason(
+                self.decode_context_parallel_size,
+                self.speculative_config,
+                envs.ATOM_USE_TRITON_MXFP4_BMM,
             )
-            self.enable_dcp_query_replication = False
+            if qrep_off is not None:
+                logger.warning(
+                    "dcp_config.enable_query_replication disabled: %s not "
+                    "supported in the first cut.",
+                    qrep_off,
+                )
+                self.dcp_config.enable_query_replication = False
         assert 1 <= self.pipeline_parallel_size
         self.hf_config = get_hf_config(
             self.model, trust_remote_code=self.trust_remote_code

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -38,7 +38,6 @@ class EngineArgs:
     trust_remote_code: bool = False
     tensor_parallel_size: int = 1
     decode_context_parallel_size: int = 1
-    enable_dcp_query_replication: bool = False
     pipeline_parallel_size: int = 1
     prefill_context_parallel_size: int = 1
     data_parallel_size: int = 1
@@ -144,15 +143,6 @@ class EngineArgs:
             type=int,
             default=1,
             help="Decode context parallel size. Must divide tensor_parallel_size.",
-        )
-        parser.add_argument(
-            "--enable-dcp-query-replication",
-            action="store_true",
-            help="Replicate the MLA query projection across the DCP group at load "
-            "time so each rank locally produces the full group head set, removing "
-            "the per-step decode AllGather Q (DCP query replication / QREP). "
-            "First cut: dense+sparse qlen=1 decode, fp8 weights; auto-disabled for "
-            "speculative decode / fp4 / dcp<=1.",
         )
         parser.add_argument(
             "--enforce-eager",
@@ -492,8 +482,14 @@ class EngineArgs:
                 '  - "interleave_size": int, KV-cache interleave granularity S: '
                 "token i is stored on DCP rank (i // S) %% W. Default 1 = "
                 "token-level round-robin.\n"
+                '  - "enable_query_replication": bool, replicate the MLA query '
+                "projection across the DCP group at load time so each rank "
+                "locally produces the full group head set, removing the "
+                "per-step decode AllGather Q (QREP). First cut: dense+sparse "
+                "qlen=1 decode, fp8 weights; auto-disabled for speculative "
+                "decode / fp4 / dcp<=1. Default false.\n"
                 "Example:\n"
-                """  '{"interleave_size": 16}'"""
+                """  '{"interleave_size": 16, "enable_query_replication": true}'"""
             ),
         )
         eplb_group = parser.add_argument_group("EPLB options")

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -483,34 +483,24 @@ class EngineArgs:
             type=json.loads,
             default=None,
             help=(
-                "DCP (Decode Context Parallel) config as a JSON dict, parsed "
-                "straight into a DCPConfig object (no per-field flags). "
-                "Supported keys:\n"
-                '  - "interleave_size": int, KV-cache interleave granularity S: '
-                "token i is stored on DCP rank (i // S) %% W. Default 1 = "
-                "token-level round-robin.\n"
-                '  - "enable_query_replication": bool, replicate the MLA query '
-                "projection across the DCP group at load time so each rank "
-                "locally produces the full group head set, removing the "
-                "per-step decode AllGather Q (QREP). First cut: dense+sparse "
-                "qlen=1 decode, fp8 weights; auto-disabled for speculative "
-                "decode / fp4 / dcp<=1. Default TRUE -- pass false explicitly "
-                "for a non-QREP control run.\n"
-                '  - "enable_project_before_merge": bool, run the V '
-                "up-projection before the DCP output merge so the merge "
-                "exchanges v_head_dim per head instead of kv_lora_rank "
-                "(kv_lora/v_head x less: 4x on DeepSeek, 2x on GLM-5.2). "
-                "Costs a DCP-group copy of W_V. Covers decode and sparse "
-                "prefill; auto-disabled for fp4 / dcp<=1. Default TRUE -- "
-                "pass false explicitly for a control run.\n"
-                '  - "comm_backend": str, which collective pattern merges the '
-                "per-rank partial attention. 'a2a' (DEFAULT) = one all-to-all "
-                "with the LSE packed alongside the output, combine done "
-                "locally, 1 call. 'ag_rs' = AllGather LSE + local correct + "
-                "ReduceScatter output, 2 calls. Equivalent math, not bitwise "
-                "identical. Pass 'ag_rs' explicitly for a control run. \n"
-                "Example:\n"
-                """  '{"interleave_size": 16, "enable_query_replication": true}'"""
+                "DCP (Decode Context Parallel) knobs as one JSON dict, parsed "
+                "straight into DCPConfig (no per-field flags); unknown keys "
+                "raise. Details and constraints: "
+                "docs/context_parallel_guide.md.\n"
+                '  "interleave_size" (int, 1): KV interleave granularity S -- '
+                "token i lives on rank (i // S) %% W; 1 = round-robin.\n"
+                '  "enable_query_replication" (bool, TRUE): drop the per-step '
+                "decode AllGather Q by replicating q_proj at load time.\n"
+                '  "enable_project_before_merge" (bool, TRUE): project V '
+                "before the output merge, shrinking it by "
+                "kv_lora_rank/v_head_dim.\n"
+                '  "comm_backend" (str, a2a): \'a2a\' = one all-to-all; '
+                "\'ag_rs\' = AllGather LSE + ReduceScatter output.\n"
+                "The last three default to the NEW behaviour (and the middle "
+                "two auto-disable where unsupported), so a control run must "
+                "pass the old values explicitly -- passing nothing re-runs the "
+                "new path.\n"
+                'Example: \'{"interleave_size": 16, "enable_query_replication": true}\''
             ),
         )
         eplb_group = parser.add_argument_group("EPLB options")

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -551,8 +551,8 @@ class EngineArgs:
                 '  "enable_project_before_merge" (bool, TRUE): project V '
                 "before the output merge, shrinking it by "
                 "kv_lora_rank/v_head_dim.\n"
-                '  "comm_backend" (str, a2a): \'a2a\' = one all-to-all; '
-                "\'ag_rs\' = AllGather LSE + ReduceScatter output.\n"
+                "  \"comm_backend\" (str, a2a): 'a2a' = one all-to-all; "
+                "'ag_rs' = AllGather LSE + ReduceScatter output.\n"
                 "The last three default to the NEW behaviour (and the middle "
                 "two auto-disable where unsupported), so a control run must "
                 "pass the old values explicitly -- passing nothing re-runs the "

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -38,6 +38,7 @@ class EngineArgs:
     trust_remote_code: bool = False
     tensor_parallel_size: int = 1
     decode_context_parallel_size: int = 1
+    enable_dcp_query_replication: bool = False
     pipeline_parallel_size: int = 1
     prefill_context_parallel_size: int = 1
     data_parallel_size: int = 1
@@ -143,6 +144,15 @@ class EngineArgs:
             type=int,
             default=1,
             help="Decode context parallel size. Must divide tensor_parallel_size.",
+        )
+        parser.add_argument(
+            "--enable-dcp-query-replication",
+            action="store_true",
+            help="Replicate the MLA query projection across the DCP group at load "
+            "time so each rank locally produces the full group head set, removing "
+            "the per-step decode AllGather Q (DCP query replication / QREP). "
+            "First cut: dense+sparse qlen=1 decode, fp8 weights; auto-disabled for "
+            "speculative decode / fp4 / dcp<=1.",
         )
         parser.add_argument(
             "--enforce-eager",

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -503,6 +503,12 @@ class EngineArgs:
                 "Costs a DCP-group copy of W_V. Covers decode and sparse "
                 "prefill; auto-disabled for fp4 / dcp<=1. Default TRUE -- "
                 "pass false explicitly for a control run.\n"
+                '  - "comm_backend": str, which collective pattern merges the '
+                "per-rank partial attention. 'a2a' (DEFAULT) = one all-to-all "
+                "with the LSE packed alongside the output, combine done "
+                "locally, 1 call. 'ag_rs' = AllGather LSE + local correct + "
+                "ReduceScatter output, 2 calls. Equivalent math, not bitwise "
+                "identical. Pass 'ag_rs' explicitly for a control run. \n"
                 "Example:\n"
                 """  '{"interleave_size": 16, "enable_query_replication": true}'"""
             ),

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -494,7 +494,15 @@ class EngineArgs:
                 "locally produces the full group head set, removing the "
                 "per-step decode AllGather Q (QREP). First cut: dense+sparse "
                 "qlen=1 decode, fp8 weights; auto-disabled for speculative "
-                "decode / fp4 / dcp<=1. Default false.\n"
+                "decode / fp4 / dcp<=1. Default TRUE -- pass false explicitly "
+                "for a non-QREP control run.\n"
+                '  - "enable_project_before_merge": bool, run the V '
+                "up-projection before the DCP output merge so the merge "
+                "exchanges v_head_dim per head instead of kv_lora_rank "
+                "(kv_lora/v_head x less: 4x on DeepSeek, 2x on GLM-5.2). "
+                "Costs a DCP-group copy of W_V. Covers decode and sparse "
+                "prefill; auto-disabled for fp4 / dcp<=1. Default TRUE -- "
+                "pass false explicitly for a control run.\n"
                 "Example:\n"
                 """  '{"interleave_size": 16, "enable_query_replication": true}'"""
             ),

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -535,13 +535,9 @@ class MLAAttention(nn.Module):
             self.dcp_rank = 0
             self._cp_triton_ctx = None
 
-        # DCP Query Replication (QREP): when enabled (resolved in Config), the
-        # query projection is sharded on effective TP = tp/dcp so each rank
-        # produces the whole DCP-group head set (`qrep_num_heads`); decode then
-        # skips the per-step AllGather Q and feeds those heads straight to the
-        # local kernel. W_K is gathered across the DCP group at load
-        # (process_weights_after_loading); W_V stays per-rank (the decode output
-        # is reduce-scattered back to local heads before W_V).
+        # DCP Query Replication (QREP): q_proj is sharded on effective TP =
+        # tp/dcp, so each rank produces the whole DCP-group head set and decode
+        # can skip the per-step AllGather Q. W_K is gathered to match, at load.
         self.qrep_enabled = (
             self.dcp_world_size > 1
             and get_current_atom_config().dcp_config.enable_query_replication
@@ -552,13 +548,11 @@ class MLAAttention(nn.Module):
                 "DCP query replication requires the DCP-group head set "
                 f"(num_heads*dcp={self.qrep_num_heads}) >= {_MLA_MIN_HEADS}."
             )
-        # Project-before-merge (PBM): apply W_V to the head-gathered output
-        # BEFORE cp_lse_ag_out_rs, so the merge exchanges v_head_dim per head
-        # instead of kv_lora_rank. Legal because the merge is a per-(token,head)
-        # scalar weighting followed by a cross-rank sum, and W_V is per-head
-        # linear -- the two commute. Covers both cp_lse_ag_out_rs call sites
-        # (decode and sparse prefill). fp4 is excluded: its W_V scale is block
-        # structured, so the gather-then-requantize recipe does not carry over.
+        # Project-before-merge (PBM): apply W_V before the merge, so it
+        # exchanges v_head_dim per head instead of kv_lora_rank. Legal because
+        # the merge is a per-(token, head) scalar weighting plus a cross-rank
+        # sum and W_V is per-head linear -- they commute. fp4 is excluded: its
+        # W_V scale is block structured, so gather-then-requantize breaks.
         self.pbm_enabled = (
             self.dcp_world_size > 1
             and get_current_atom_config().dcp_config.enable_project_before_merge
@@ -707,21 +701,16 @@ class MLAAttention(nn.Module):
                 W_V, dtype=dtypes.fp8
             )
             if self.qrep_enabled:
-                # QREP: gather the bf16 W_K across the DCP group so each rank
-                # holds the full group head set [group_H, 512, 128], then quantize
-                # the gathered tensor. Gathering bf16 (not fp8) sidesteps the
-                # per-rank scalar-scale stitching problem. Head order matches the
-                # effective-TP q_proj shard (both are global heads
-                # [g*group_H:(g+1)*group_H] in DCP rank_in_group order). Keep the
-                # per-rank self.W_K/scale above for the prefill path.
+                # Gather bf16 and quantize once: gathering fp8 would need the
+                # per-rank scalar scales stitched together. Head order already
+                # matches the effective-TP q_proj shard. self.W_K stays for prefill.
                 W_K_qrep = self.dcp_group.all_gather(W_K.contiguous(), dim=0)
                 self.W_K_qrep, self.W_K_qrep_scale = dynamic_per_batched_tensor_quant(
                     W_K_qrep, dtype=dtypes.fp8
                 )
             if self.pbm_enabled:
-                # Project-before-merge needs W_V for the whole DCP group, because
-                # the projection now runs on the head-gathered output (before the
-                # ReduceScatter that would have cut it back to this rank's heads).
+                # PBM projects the head-gathered output, i.e. before the merge
+                # would have cut it back to this rank's heads -- so W_V must too.
                 W_V_dcp = self.dcp_group.all_gather(W_V.contiguous(), dim=0)
                 self.W_V_dcp, self.W_V_dcp_scale = dynamic_per_batched_tensor_quant(
                     W_V_dcp, dtype=dtypes.fp8
@@ -730,13 +719,10 @@ class MLAAttention(nn.Module):
     def _local_q_proj(self):
         """This rank's rows of the QREP-widened q_proj, built on first use.
 
-        Prefill needs only its own heads. Projecting the whole DCP group and
-        slicing the result still pays for the group, so prefill projects through a zero-copy row
-        VIEW of the weight instead -- same GEMM cost as without QREP, no extra
-        memory. Decode keeps using the full q_proj, which is what lets it skip
-        the AllGather Q. See `ColumnParallelLinear.make_row_view` for why
-        slicing an already-shuffled weight is legal on these boundaries.
-
+        Prefill needs only its own heads, and slicing the OUTPUT still pays for
+        the whole group's GEMM -- so it projects through a zero-copy row view of
+        the weight. Decode keeps the full q_proj; that is what lets it skip the
+        AllGather Q. See ``ColumnParallelLinear.make_row_view``.
         """
         w = self.q_proj.weight.data
         if self._qrep_local_src is not w:
@@ -764,11 +750,9 @@ class MLAAttention(nn.Module):
     def _v_up_proj(self, x, W_V=None, W_V_scale=None, num_heads=None):
         """V up-projection only: ``[B, N, kv_lora_rank] -> [B, N, v_head_dim]``.
 
-        Split out of ``_v_up_proj_and_o_proj`` so DCP decode can run it BEFORE
-        the cross-rank merge (project-before-merge). The weight/head count are
-        arguments because that path projects the whole DCP group's heads with
-        the gathered ``W_V_dcp``, while every other caller uses this rank's
-        ``self.W_V`` and ``self.num_heads``.
+        Split out so DCP decode can run it BEFORE the merge (project-before-
+        merge). Weight and head count are arguments because that path projects
+        the whole group with ``W_V_dcp``; every other caller uses ``self.W_V``.
         """
         W_V = self.W_V if W_V is None else W_V
         W_V_scale = self.W_V_scale if W_V_scale is None else W_V_scale
@@ -813,11 +797,9 @@ class MLAAttention(nn.Module):
 
     @mark_trace(prefix="q_proj_and_k_up_proj", torch_compile=False)
     def _q_proj_and_k_up_proj(self, x, x_scale=None, group=False):
-        # DCP Query Replication (QREP): when qrep_enabled, q_proj emits the full
-        # DCP-group head set. `group=True` (decode) keeps all group heads and uses
-        # the DCP-gathered W_K_qrep, so the caller can skip the AllGather Q.
-        # `group=False` (prefill / non-QREP) slices this rank's own heads out of
-        # the group projection and uses the per-rank W_K.
+        # QREP: q_proj emits the full DCP-group head set. group=True (decode)
+        # keeps them all and uses W_K_qrep, so the caller skips the AllGather Q;
+        # group=False (prefill / non-QREP) takes only this rank's heads.
         if self.qrep_enabled and not group:
             # Row-view weight: computes only this rank's heads, so the redundant
             # group-wide GEMM never happens (the old code projected all group

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -790,9 +790,7 @@ class MLAAttention(nn.Module):
 
         if not use_qrep:
             q_out = dcp_all_gather_query_heads(self.dcp_group, q_out)
-        o, lse = self._forward_decode(
-            q_out, kv_cache, attn_metadata, return_lse=True
-        )
+        o, lse = self._forward_decode(q_out, kv_cache, attn_metadata, return_lse=True)
         return self._dcp_project_merge_out(o, lse, ctx=self._cp_triton_ctx)
 
     def _v_up_proj(self, x, W_V=None, W_V_scale=None, num_heads=None):

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -558,7 +558,7 @@ class MLAAttention(nn.Module):
             and get_current_atom_config().dcp_config.enable_project_before_merge
             and not is_rocm_aiter_fp4bmm_enabled()
         )
-        # Which collective pattern the output merge uses; see _cp_merge.
+        # Which collective pattern the output merge uses; see _dcp_merge.
         self.dcp_comm_backend = get_current_atom_config().dcp_config.comm_backend
 
         # Row view of q_proj used by prefill; see _local_q_proj. Initialized here
@@ -733,19 +733,67 @@ class MLAAttention(nn.Module):
             self._qrep_local_src = w
         return self._qrep_local_proj
 
-    def _cp_merge(self, o, lse, ctx=None):
-        """Reconstruct the global softmax from the per-rank partials.
+    def _dcp_merge(self, o, lse, ctx=None):
+        """Bind this layer's DCP group and backend to ``dcp_ops.dcp_lse_merge``."""
+        from atom.model_ops.dcp_ops import dcp_lse_merge
 
-        Both backends compute the same weighted sum over KV shards and leave
-        this rank owning the same head slice; they differ only in how many
-        collectives it takes. See the A2A section in ``dcp_ops`` for why one
-        all-to-all can replace AllGather-LSE + ReduceScatter.
+        return dcp_lse_merge(o, lse, self.dcp_group, self.dcp_comm_backend, ctx=ctx)
+
+    @mark_trace(prefix="dcp_project_merge_out", torch_compile=False)
+    def _dcp_project_merge_out(self, o, lse, ctx=None, merge_in_fp32=False):
+        """Shared tail of both DCP paths: PBM projection, merge, o_proj.
+
+        With PBM the V up-projection runs on the whole group's head set BEFORE
+        the merge, so o_proj then takes an already-projected tensor. Without it
+        the merge carries the latent and ``_v_up_proj_and_o_proj`` does both.
         """
-        from atom.model_ops.dcp_ops import cp_lse_a2a, cp_lse_ag_out_rs
+        if self.pbm_enabled:
+            o = self._v_up_proj(
+                o, self.W_V_dcp, self.W_V_dcp_scale, num_heads=o.shape[1]
+            )
+        if merge_in_fp32:
+            dtype = o.dtype
+            o = self._dcp_merge(o.float(), lse, ctx=ctx).to(dtype)
+        else:
+            o = self._dcp_merge(o, lse, ctx=ctx)
+        if self.pbm_enabled:
+            return self.o_proj(o.reshape(-1, self.num_heads * self.v_head_dim))
+        return self._v_up_proj_and_o_proj(o)
 
-        if self.dcp_comm_backend == "a2a":
-            return cp_lse_a2a(o, lse, self.dcp_group)
-        return cp_lse_ag_out_rs(o, lse, self.dcp_group, ctx=ctx)
+    @mark_trace(prefix="dcp_sparse_prefill", torch_compile=False)
+    def _dcp_sparse_prefill(self, q_out, kv_cache, attn_metadata):
+        """Sparse prefill under DCP: each rank holds a disjoint slice of the
+        global top-k, so its partial output must be merged like decode's.
+
+        Merge dtype is platform-dependent -- on gfx942 the bf16 ReduceScatter
+        sum costs ~3.5pp, on gfx950 it is free even at ctx~32k with fp8 KV.
+        See ``dcp_prefill_merge_bf16_ok``.
+        """
+        q_out = self.dcp_group.all_gather(q_out, dim=1)
+        o, lse = self._forward_prefill_mla(
+            q_out, kv_cache, attn_metadata, return_lse=True
+        )
+        return self._dcp_project_merge_out(
+            o, lse, merge_in_fp32=not self.dcp_prefill_merge_bf16_ok
+        )
+
+    @mark_trace(prefix="dcp_decode", torch_compile=False)
+    def _dcp_decode(self, q_out, kv_cache, attn_metadata, use_qrep):
+        """Decode under DCP: gather the group's query heads, decode locally with
+        LSE, then merge the partials across ranks.
+
+        QREP skips the gather -- q_out already carries the full group head set
+        from the replicated q_proj + W_K_qrep. Only real heads cross the wire;
+        the pad the kernel width needs lives inside ``_forward_decode``.
+        """
+        from atom.model_ops.dcp_ops import dcp_all_gather_query_heads
+
+        if not use_qrep:
+            q_out = dcp_all_gather_query_heads(self.dcp_group, q_out)
+        o, lse = self._forward_decode(
+            q_out, kv_cache, attn_metadata, return_lse=True
+        )
+        return self._dcp_project_merge_out(o, lse, ctx=self._cp_triton_ctx)
 
     def _v_up_proj(self, x, W_V=None, W_V_scale=None, num_heads=None):
         """V up-projection only: ``[B, N, kv_lora_rank] -> [B, N, v_head_dim]``.
@@ -842,10 +890,6 @@ class MLAAttention(nn.Module):
     def fused_kv_bmm(
         self, x, x_scale, k_nope, k_rope, positions, kv_cache, attn_metadata
     ):
-        # NOTE: currently dead code (only a commented-out call site). If revived,
-        # this view must handle QREP: q_proj emits the full DCP-group head set, so
-        # slice back to per-rank heads like _q_proj_and_k_up_proj(group=False)
-        # (view(-1, qrep_num_heads, ...) then [:, dcp_rank*num_heads : +num_heads]).
         q_nope, q_pe = (
             self.q_proj(x, x_scale)
             .view(-1, self.num_heads, self.qk_head_dim)
@@ -2155,66 +2199,11 @@ class MLAAttention(nn.Module):
 
             if context.is_prefill:
                 if self.is_sparse_mla and self.dcp_world_size > 1:
-                    # DCP sparse prefill: each rank holds a disjoint slice of the
-                    # global top-k, so merge partials like decode.
-                    q_out = self.dcp_group.all_gather(q_out, dim=1)
-                    o, lse = self._forward_prefill_mla(
-                        q_out, kv_cache, attn_metadata, return_lse=True
-                    )
-                    # Project-before-merge, same as decode below. Worth more here
-                    # than there: this merge carries num_tokens rows, not batch
-                    # rows. It also shrinks the fp32 branch below -- projecting
-                    # first makes the fp32 merge cheaper than today's bf16 one.
-                    if self.pbm_enabled:
-                        o = self._v_up_proj(
-                            o, self.W_V_dcp, self.W_V_dcp_scale, num_heads=o.shape[1]
-                        )
-                    # Merge dtype is platform-dependent: on gfx942 the bf16
-                    # ReduceScatter sum costs ~3.5pp, on gfx950 it is free even at
-                    # ctx~32k with fp8 KV. Pay the fp32 upcast only where it buys
-                    # something -- see dcp_prefill_merge_bf16_ok for the numbers.
-                    if self.dcp_prefill_merge_bf16_ok:
-                        o = self._cp_merge(o, lse)
-                    else:
-                        o = self._cp_merge(o.float(), lse).to(o.dtype)
-                    if self.pbm_enabled:
-                        output = self.o_proj(
-                            o.reshape(-1, self.num_heads * self.v_head_dim)
-                        )
-                    else:
-                        output = self._v_up_proj_and_o_proj(o)
+                    output = self._dcp_sparse_prefill(q_out, kv_cache, attn_metadata)
                 else:
                     output = self._forward_prefill_mla(q_out, kv_cache, attn_metadata)
             elif self.dcp_world_size > 1:
-                # DCP decode: AllGather Q on the head dim, decode locally with LSE,
-                # then combine partial outputs across ranks (AG LSE + correct + RS).
-                # QREP (use_qrep) skips the AllGather Q -- q_out already carries the
-                # full group head set from the replicated q_proj + W_K_qrep. The
-                # local decode, LSE merge and W_V path are identical either way.
-                from atom.model_ops.dcp_ops import dcp_all_gather_query_heads
-
-                # Only real heads cross the wire and enter the combine; the pad the
-                # kernel width needs lives inside _forward_decode (see
-                # dcp_kernel_num_heads).
-                if not use_qrep:
-                    q_out = dcp_all_gather_query_heads(self.dcp_group, q_out)
-                o, lse = self._forward_decode(
-                    q_out, kv_cache, attn_metadata, return_lse=True
-                )
-                # Project-before-merge: run W_V on the whole group's head set
-                # BEFORE the merge, so the merge moves v_head_dim per head
-                # instead of kv_lora_rank.
-                if self.pbm_enabled:
-                    o = self._v_up_proj(
-                        o, self.W_V_dcp, self.W_V_dcp_scale, num_heads=o.shape[1]
-                    )
-                o = self._cp_merge(o, lse, ctx=self._cp_triton_ctx)
-                if self.pbm_enabled:
-                    output = self.o_proj(
-                        o.reshape(-1, self.num_heads * self.v_head_dim)
-                    )
-                else:
-                    output = self._v_up_proj_and_o_proj(o)
+                output = self._dcp_decode(q_out, kv_cache, attn_metadata, use_qrep)
             else:
                 output = self._forward_decode(q_out, kv_cache, attn_metadata)
 

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -494,6 +494,28 @@ class MLAAttention(nn.Module):
             self.dcp_rank = 0
             self._cp_triton_ctx = None
 
+        # DCP Query Replication (QREP): when enabled (resolved in Config), the
+        # query projection is sharded on effective TP = tp/dcp so each rank
+        # produces the whole DCP-group head set (`qrep_num_heads`); decode then
+        # skips the per-step AllGather Q and feeds those heads straight to the
+        # local kernel. W_K is gathered across the DCP group at load
+        # (process_weights_after_loading); W_V stays per-rank (the decode output
+        # is reduce-scattered back to local heads before W_V).
+        self.qrep_enabled = (
+            self.dcp_world_size > 1
+            and get_current_atom_config().enable_dcp_query_replication
+        )
+        self.qrep_num_heads = self.num_heads * self.dcp_world_size
+        if self.qrep_enabled:
+            # QREP feeds group-head tensors to the kernel directly; head
+            # repeat/pad would wrongly duplicate/pad the group set. R1 has
+            # num_local_heads==16==_MLA_MIN_HEADS so this holds.
+            assert self.head_repeat_factor == 1 and self.head_pad == 0, (
+                "DCP query replication requires num_local_heads >= "
+                f"{_MLA_MIN_HEADS} (no head repeat/pad); got num_heads="
+                f"{self.num_heads}."
+            )
+
         self.dcp_persistent_supported = dcp_persistent_supported()
         self.dcp_prefill_merge_bf16_ok = dcp_prefill_merge_bf16_ok()
 
@@ -611,6 +633,18 @@ class MLAAttention(nn.Module):
             self.W_V, self.W_V_scale = dynamic_per_batched_tensor_quant(
                 W_V, dtype=dtypes.fp8
             )
+            if self.qrep_enabled:
+                # QREP: gather the bf16 W_K across the DCP group so each rank
+                # holds the full group head set [group_H, 512, 128], then quantize
+                # the gathered tensor. Gathering bf16 (not fp8) sidesteps the
+                # per-rank scalar-scale stitching problem. Head order matches the
+                # effective-TP q_proj shard (both are global heads
+                # [g*group_H:(g+1)*group_H] in DCP rank_in_group order). Keep the
+                # per-rank self.W_K/scale above for the prefill path.
+                W_K_qrep = self.dcp_group.all_gather(W_K.contiguous(), dim=0)
+                self.W_K_qrep, self.W_K_qrep_scale = dynamic_per_batched_tensor_quant(
+                    W_K_qrep, dtype=dtypes.fp8
+                )
 
     @mark_trace(prefix="v_up_proj_and_o_proj", torch_compile=False)
     def _v_up_proj_and_o_proj(self, x):
@@ -648,22 +682,35 @@ class MLAAttention(nn.Module):
         return self.o_proj(x)
 
     @mark_trace(prefix="q_proj_and_k_up_proj", torch_compile=False)
-    def _q_proj_and_k_up_proj(self, x, x_scale=None):
-        q_nope, q_pe = (
-            self.q_proj(x, x_scale)
-            .view(-1, self.num_heads, self.qk_head_dim)
-            .split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+    def _q_proj_and_k_up_proj(self, x, x_scale=None, group=False):
+        # DCP Query Replication (QREP): when qrep_enabled, q_proj emits the full
+        # DCP-group head set. `group=True` (decode) keeps all group heads and uses
+        # the DCP-gathered W_K_qrep, so the caller can skip the AllGather Q.
+        # `group=False` (prefill / non-QREP) slices this rank's own heads out of
+        # the group projection and uses the per-rank W_K.
+        n_heads_out = self.qrep_num_heads if self.qrep_enabled else self.num_heads
+        q = self.q_proj(x, x_scale).view(-1, n_heads_out, self.qk_head_dim)
+        if self.qrep_enabled and not group:
+            start = self.dcp_rank * self.num_heads
+            q = q[:, start : start + self.num_heads, :].contiguous()
+        q_nope, q_pe = q.split(
+            [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
         )
 
         # Convert from (B, N, P) to (N, B, P)
         q_nope = q_nope.transpose(0, 1)
 
+        if self.qrep_enabled and group:
+            W_K, W_K_scale = self.W_K_qrep, self.W_K_qrep_scale
+        else:
+            W_K, W_K_scale = self.W_K, self.W_K_scale
+
         if is_rocm_aiter_fp4bmm_enabled():
             # FP4 BMM: (N, B, P) x (N, P, L) -> (N, B, L)
             ql_nope = batched_gemm_a16wfp4(
                 q_nope,
-                self.W_K,
-                self.W_K_scale,
+                W_K,
+                W_K_scale,
                 y=None,
                 transpose_bm=True,
                 prequant=True,
@@ -673,13 +720,17 @@ class MLAAttention(nn.Module):
             # Multiply (N, B, P) x (N, P, L) -> (N, B, L), Convert from (N, B, L) to (B, N, L)
             # ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
             ql_nope = _aiter_triton_fp8_bmm(
-                q_nope, self.W_K, self.W_K_scale, group_size=128, transpose_bm=True
+                q_nope, W_K, W_K_scale, group_size=128, transpose_bm=True
             )
         return ql_nope, q_pe
 
     def fused_kv_bmm(
         self, x, x_scale, k_nope, k_rope, positions, kv_cache, attn_metadata
     ):
+        # NOTE: currently dead code (only a commented-out call site). If revived,
+        # this view must handle QREP: q_proj emits the full DCP-group head set, so
+        # slice back to per-rank heads like _q_proj_and_k_up_proj(group=False)
+        # (view(-1, qrep_num_heads, ...) then [:, dcp_rank*num_heads : +num_heads]).
         q_nope, q_pe = (
             self.q_proj(x, x_scale)
             .view(-1, self.num_heads, self.qk_head_dim)
@@ -1776,9 +1827,22 @@ class MLAAttention(nn.Module):
         kv_cache = kv_cache_data[f"layer_{self.layer_num}"].k_cache
 
         if context.is_prefill and not use_prefill_mla:
-            prefill_q = self.q_proj(q, x_scale=q_scale).view(
-                -1, self.num_heads, self.qk_head_dim
+            n_heads_out = (
+                self.qrep_num_heads if self.qrep_enabled else self.num_heads
             )
+            prefill_q = self.q_proj(q, x_scale=q_scale).view(
+                -1, n_heads_out, self.qk_head_dim
+            )
+            if self.qrep_enabled:
+                # QREP: q_proj emits the full DCP-group head set. Prefill only needs
+                # this rank's per-rank heads (QREP optimizes decode's AllGather-Q,
+                # not prefill), so slice back like _q_proj_and_k_up_proj(group=False).
+                # Without this the view(-1, num_heads, ...) would inflate the token
+                # dim by dcp_world_size and corrupt the unified-attention output shape.
+                start = self.dcp_rank * self.num_heads
+                prefill_q = prefill_q[
+                    :, start : start + self.num_heads, :
+                ].contiguous()
             prefill_q_pe = prefill_q[..., self.qk_nope_head_dim :]
             self.rotary_emb(positions, prefill_q_pe, k_rope)
 
@@ -1838,7 +1902,19 @@ class MLAAttention(nn.Module):
                     prefill_q, k_nope, k_rope, kv_cache, attn_metadata
                 )
         else:
-            q_nope, q_rope = self._q_proj_and_k_up_proj(q, x_scale=q_scale)
+            # DCP Query Replication (QREP): decode produces the full group-head
+            # query locally so it can skip the AllGather Q below. Correctness holds
+            # even when use_qrep is False (group=False slices back to per-rank heads
+            # and the AG path runs as before); use_qrep only toggles the optimization.
+            # Excludes prefill and the seg path (seg alloc is per-rank sized).
+            use_qrep = (
+                self.qrep_enabled
+                and not context.is_prefill
+                and not self.use_seg_mla
+            )
+            q_nope, q_rope = self._q_proj_and_k_up_proj(
+                q, x_scale=q_scale, group=use_qrep
+            )
 
             # ---- Prefill Context Parallel --------------------------------
             # q is this rank's 1/pcp queries, so q_out is naturally 1/pcp. But
@@ -1882,7 +1958,7 @@ class MLAAttention(nn.Module):
                 q_out = torch.empty(
                     (
                         q_nope.shape[0],
-                        self.num_heads,
+                        self.qrep_num_heads if use_qrep else self.num_heads,
                         self.kv_lora_rank + self.qk_rope_head_dim,
                     ),
                     dtype=attn_metadata.dtype_q,
@@ -1999,6 +2075,9 @@ class MLAAttention(nn.Module):
             elif self.dcp_world_size > 1:
                 # DCP decode: AllGather Q on the head dim, decode locally with LSE,
                 # then combine partial outputs across ranks (AG LSE + correct + RS).
+                # QREP (use_qrep) skips the AllGather Q -- q_out already carries the
+                # full group head set from the replicated q_proj + W_K_qrep. The
+                # local decode, LSE merge and W_V path are identical either way.
                 from atom.model_ops.dcp_ops import (
                     cp_lse_ag_out_rs,
                     dcp_all_gather_query_heads,
@@ -2007,7 +2086,8 @@ class MLAAttention(nn.Module):
                 # Only real heads cross the wire and enter the combine; the pad the
                 # kernel width needs lives inside _forward_decode (see
                 # dcp_kernel_num_heads).
-                q_out = dcp_all_gather_query_heads(self.dcp_group, q_out)
+                if not use_qrep:
+                    q_out = dcp_all_gather_query_heads(self.dcp_group, q_out)
                 o, lse = self._forward_decode(
                     q_out, kv_cache, attn_metadata, return_lse=True
                 )

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -507,14 +507,15 @@ class MLAAttention(nn.Module):
         )
         self.qrep_num_heads = self.num_heads * self.dcp_world_size
         if self.qrep_enabled:
-            # QREP feeds group-head tensors to the kernel directly; head
-            # repeat/pad would wrongly duplicate/pad the group set. R1 has
-            # num_local_heads==16==_MLA_MIN_HEADS so this holds.
-            assert self.head_repeat_factor == 1 and self.head_pad == 0, (
-                "DCP query replication requires num_local_heads >= "
-                f"{_MLA_MIN_HEADS} (no head repeat/pad); got num_heads="
-                f"{self.num_heads}."
+            assert self.qrep_num_heads >= _MLA_MIN_HEADS, (
+                "DCP query replication requires the DCP-group head set "
+                f"(num_heads*dcp={self.qrep_num_heads}) >= {_MLA_MIN_HEADS}."
             )
+        # Row view of q_proj used by prefill; see _local_q_proj. Initialized here
+        # rather than in process_weights_after_loading so it exists no matter
+        # which quantization branch that method takes.
+        self._qrep_local_proj = None
+        self._qrep_local_src = None
 
         self.dcp_persistent_supported = dcp_persistent_supported()
         self.dcp_prefill_merge_bf16_ok = dcp_prefill_merge_bf16_ok()
@@ -646,6 +647,26 @@ class MLAAttention(nn.Module):
                     W_K_qrep, dtype=dtypes.fp8
                 )
 
+    def _local_q_proj(self):
+        """This rank's rows of the QREP-widened q_proj, built on first use.
+
+        Prefill needs only its own heads. Projecting the whole DCP group and
+        slicing the result still pays for the group, so prefill projects through a zero-copy row
+        VIEW of the weight instead -- same GEMM cost as without QREP, no extra
+        memory. Decode keeps using the full q_proj, which is what lets it skip
+        the AllGather Q. See `ColumnParallelLinear.make_row_view` for why
+        slicing an already-shuffled weight is legal on these boundaries.
+
+        """
+        w = self.q_proj.weight.data
+        if self._qrep_local_src is not w:
+            rows = self.num_heads * self.qk_head_dim
+            self._qrep_local_proj = self.q_proj.make_row_view(
+                self.dcp_rank * rows, rows
+            )
+            self._qrep_local_src = w
+        return self._qrep_local_proj
+
     @mark_trace(prefix="v_up_proj_and_o_proj", torch_compile=False)
     def _v_up_proj_and_o_proj(self, x):
         # Convert from (B, N, L) to (N, B, L)
@@ -688,11 +709,16 @@ class MLAAttention(nn.Module):
         # the DCP-gathered W_K_qrep, so the caller can skip the AllGather Q.
         # `group=False` (prefill / non-QREP) slices this rank's own heads out of
         # the group projection and uses the per-rank W_K.
-        n_heads_out = self.qrep_num_heads if self.qrep_enabled else self.num_heads
-        q = self.q_proj(x, x_scale).view(-1, n_heads_out, self.qk_head_dim)
         if self.qrep_enabled and not group:
-            start = self.dcp_rank * self.num_heads
-            q = q[:, start : start + self.num_heads, :].contiguous()
+            # Row-view weight: computes only this rank's heads, so the redundant
+            # group-wide GEMM never happens (the old code projected all group
+            # heads and then dropped 7/8 of the result).
+            q = self._local_q_proj()(x, x_scale).view(
+                -1, self.num_heads, self.qk_head_dim
+            )
+        else:
+            n_heads_out = self.qrep_num_heads if self.qrep_enabled else self.num_heads
+            q = self.q_proj(x, x_scale).view(-1, n_heads_out, self.qk_head_dim)
         q_nope, q_pe = q.split(
             [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
         )
@@ -1827,22 +1853,13 @@ class MLAAttention(nn.Module):
         kv_cache = kv_cache_data[f"layer_{self.layer_num}"].k_cache
 
         if context.is_prefill and not use_prefill_mla:
-            n_heads_out = (
-                self.qrep_num_heads if self.qrep_enabled else self.num_heads
+            # QREP: q_proj emits the whole DCP-group head set, but prefill needs
+            # only this rank's heads (QREP optimizes decode's AllGather Q, not
+            # prefill).
+            proj = self._local_q_proj() if self.qrep_enabled else self.q_proj
+            prefill_q = proj(q, x_scale=q_scale).view(
+                -1, self.num_heads, self.qk_head_dim
             )
-            prefill_q = self.q_proj(q, x_scale=q_scale).view(
-                -1, n_heads_out, self.qk_head_dim
-            )
-            if self.qrep_enabled:
-                # QREP: q_proj emits the full DCP-group head set. Prefill only needs
-                # this rank's per-rank heads (QREP optimizes decode's AllGather-Q,
-                # not prefill), so slice back like _q_proj_and_k_up_proj(group=False).
-                # Without this the view(-1, num_heads, ...) would inflate the token
-                # dim by dcp_world_size and corrupt the unified-attention output shape.
-                start = self.dcp_rank * self.num_heads
-                prefill_q = prefill_q[
-                    :, start : start + self.num_heads, :
-                ].contiguous()
             prefill_q_pe = prefill_q[..., self.qk_nope_head_dim :]
             self.rotary_emb(positions, prefill_q_pe, k_rope)
 

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -564,6 +564,8 @@ class MLAAttention(nn.Module):
             and get_current_atom_config().dcp_config.enable_project_before_merge
             and not is_rocm_aiter_fp4bmm_enabled()
         )
+        # Which collective pattern the output merge uses; see _cp_merge.
+        self.dcp_comm_backend = get_current_atom_config().dcp_config.comm_backend
 
         # Row view of q_proj used by prefill; see _local_q_proj. Initialized here
         # rather than in process_weights_after_loading so it exists no matter
@@ -744,6 +746,20 @@ class MLAAttention(nn.Module):
             )
             self._qrep_local_src = w
         return self._qrep_local_proj
+
+    def _cp_merge(self, o, lse, ctx=None):
+        """Reconstruct the global softmax from the per-rank partials.
+
+        Both backends compute the same weighted sum over KV shards and leave
+        this rank owning the same head slice; they differ only in how many
+        collectives it takes. See the A2A section in ``dcp_ops`` for why one
+        all-to-all can replace AllGather-LSE + ReduceScatter.
+        """
+        from atom.model_ops.dcp_ops import cp_lse_a2a, cp_lse_ag_out_rs
+
+        if self.dcp_comm_backend == "a2a":
+            return cp_lse_a2a(o, lse, self.dcp_group)
+        return cp_lse_ag_out_rs(o, lse, self.dcp_group, ctx=ctx)
 
     def _v_up_proj(self, x, W_V=None, W_V_scale=None, num_heads=None):
         """V up-projection only: ``[B, N, kv_lora_rank] -> [B, N, v_head_dim]``.
@@ -2163,8 +2179,6 @@ class MLAAttention(nn.Module):
                 if self.is_sparse_mla and self.dcp_world_size > 1:
                     # DCP sparse prefill: each rank holds a disjoint slice of the
                     # global top-k, so merge partials like decode.
-                    from atom.model_ops.dcp_ops import cp_lse_ag_out_rs
-
                     q_out = self.dcp_group.all_gather(q_out, dim=1)
                     o, lse = self._forward_prefill_mla(
                         q_out, kv_cache, attn_metadata, return_lse=True
@@ -2182,11 +2196,9 @@ class MLAAttention(nn.Module):
                     # ctx~32k with fp8 KV. Pay the fp32 upcast only where it buys
                     # something -- see dcp_prefill_merge_bf16_ok for the numbers.
                     if self.dcp_prefill_merge_bf16_ok:
-                        o = cp_lse_ag_out_rs(o, lse, self.dcp_group, ctx=None)
+                        o = self._cp_merge(o, lse)
                     else:
-                        o = cp_lse_ag_out_rs(
-                            o.float(), lse, self.dcp_group, ctx=None
-                        ).to(o.dtype)
+                        o = self._cp_merge(o.float(), lse).to(o.dtype)
                     if self.pbm_enabled:
                         output = self.o_proj(
                             o.reshape(-1, self.num_heads * self.v_head_dim)
@@ -2201,10 +2213,7 @@ class MLAAttention(nn.Module):
                 # QREP (use_qrep) skips the AllGather Q -- q_out already carries the
                 # full group head set from the replicated q_proj + W_K_qrep. The
                 # local decode, LSE merge and W_V path are identical either way.
-                from atom.model_ops.dcp_ops import (
-                    cp_lse_ag_out_rs,
-                    dcp_all_gather_query_heads,
-                )
+                from atom.model_ops.dcp_ops import dcp_all_gather_query_heads
 
                 # Only real heads cross the wire and enter the combine; the pad the
                 # kernel width needs lives inside _forward_decode (see
@@ -2221,7 +2230,7 @@ class MLAAttention(nn.Module):
                     o = self._v_up_proj(
                         o, self.W_V_dcp, self.W_V_dcp_scale, num_heads=o.shape[1]
                     )
-                o = cp_lse_ag_out_rs(o, lse, self.dcp_group, ctx=self._cp_triton_ctx)
+                o = self._cp_merge(o, lse, ctx=self._cp_triton_ctx)
                 if self.pbm_enabled:
                     output = self.o_proj(
                         o.reshape(-1, self.num_heads * self.v_head_dim)

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -552,6 +552,19 @@ class MLAAttention(nn.Module):
                 "DCP query replication requires the DCP-group head set "
                 f"(num_heads*dcp={self.qrep_num_heads}) >= {_MLA_MIN_HEADS}."
             )
+        # Project-before-merge (PBM): apply W_V to the head-gathered output
+        # BEFORE cp_lse_ag_out_rs, so the merge exchanges v_head_dim per head
+        # instead of kv_lora_rank. Legal because the merge is a per-(token,head)
+        # scalar weighting followed by a cross-rank sum, and W_V is per-head
+        # linear -- the two commute. Covers both cp_lse_ag_out_rs call sites
+        # (decode and sparse prefill). fp4 is excluded: its W_V scale is block
+        # structured, so the gather-then-requantize recipe does not carry over.
+        self.pbm_enabled = (
+            self.dcp_world_size > 1
+            and get_current_atom_config().dcp_config.enable_project_before_merge
+            and not is_rocm_aiter_fp4bmm_enabled()
+        )
+
         # Row view of q_proj used by prefill; see _local_q_proj. Initialized here
         # rather than in process_weights_after_loading so it exists no matter
         # which quantization branch that method takes.
@@ -703,6 +716,14 @@ class MLAAttention(nn.Module):
                 self.W_K_qrep, self.W_K_qrep_scale = dynamic_per_batched_tensor_quant(
                     W_K_qrep, dtype=dtypes.fp8
                 )
+            if self.pbm_enabled:
+                # Project-before-merge needs W_V for the whole DCP group, because
+                # the projection now runs on the head-gathered output (before the
+                # ReduceScatter that would have cut it back to this rank's heads).
+                W_V_dcp = self.dcp_group.all_gather(W_V.contiguous(), dim=0)
+                self.W_V_dcp, self.W_V_dcp_scale = dynamic_per_batched_tensor_quant(
+                    W_V_dcp, dtype=dtypes.fp8
+                )
 
     def _local_q_proj(self):
         """This rank's rows of the QREP-widened q_proj, built on first use.
@@ -724,10 +745,22 @@ class MLAAttention(nn.Module):
             self._qrep_local_src = w
         return self._qrep_local_proj
 
-    @mark_trace(prefix="v_up_proj_and_o_proj", torch_compile=False)
-    def _v_up_proj_and_o_proj(self, x):
-        # Convert from (B, N, L) to (N, B, L)
-        x = x.view(-1, self.num_heads, self.kv_lora_rank).transpose(0, 1)
+    def _v_up_proj(self, x, W_V=None, W_V_scale=None, num_heads=None):
+        """V up-projection only: ``[B, N, kv_lora_rank] -> [B, N, v_head_dim]``.
+
+        Split out of ``_v_up_proj_and_o_proj`` so DCP decode can run it BEFORE
+        the cross-rank merge (project-before-merge). The weight/head count are
+        arguments because that path projects the whole DCP group's heads with
+        the gathered ``W_V_dcp``, while every other caller uses this rank's
+        ``self.W_V`` and ``self.num_heads``.
+        """
+        W_V = self.W_V if W_V is None else W_V
+        W_V_scale = self.W_V_scale if W_V_scale is None else W_V_scale
+        num_heads = self.num_heads if num_heads is None else num_heads
+        # Convert from (B, N, L) to (N, B, L). reshape, not view: the PBM caller
+        # passes the raw decode output, which is not guaranteed contiguous the
+        # way the post-ReduceScatter tensor is.
+        x = x.reshape(-1, num_heads, self.kv_lora_rank).transpose(0, 1)
         # Multiply (N, B, L) x (N, L, V) -> (N, B, V), Convert from (N, B, V) to (B, N, V)
         # x = torch.bmm(x, self.W_UV).transpose(0, 1)
         # Convert from (B, N, L) to (N, B, L)
@@ -735,29 +768,32 @@ class MLAAttention(nn.Module):
             output = torch.empty(
                 x.shape[1],
                 x.shape[0],
-                self.W_V.shape[1],
+                W_V.shape[1],
                 device=x.device,
                 dtype=torch.bfloat16,
             )
             output = batched_gemm_a16wfp4(
                 x,
-                self.W_V,
-                self.W_V_scale,
+                W_V,
+                W_V_scale,
                 y=output,
                 transpose_bm=True,
                 prequant=True,
                 y_scale=None,
             )
             # x = x.transpose(0, 1).flatten(1, 2)
-            output = output.view(-1, self.num_heads * self.v_head_dim)
             x = output
         else:
             x = _aiter_triton_fp8_bmm(
-                x, self.W_V, self.W_V_scale, group_size=128, transpose_bm=True
+                x, W_V, W_V_scale, group_size=128, transpose_bm=True
             )
-            # Convert from (B, N, V) to (B, N * V)
-            x = x.reshape(-1, self.num_heads * self.v_head_dim)
-        return self.o_proj(x)
+        return x.reshape(-1, num_heads, self.v_head_dim)
+
+    @mark_trace(prefix="v_up_proj_and_o_proj", torch_compile=False)
+    def _v_up_proj_and_o_proj(self, x):
+        x = self._v_up_proj(x)
+        # Convert from (B, N, V) to (B, N * V)
+        return self.o_proj(x.reshape(-1, self.num_heads * self.v_head_dim))
 
     @mark_trace(prefix="q_proj_and_k_up_proj", torch_compile=False)
     def _q_proj_and_k_up_proj(self, x, x_scale=None, group=False):
@@ -2133,6 +2169,14 @@ class MLAAttention(nn.Module):
                     o, lse = self._forward_prefill_mla(
                         q_out, kv_cache, attn_metadata, return_lse=True
                     )
+                    # Project-before-merge, same as decode below. Worth more here
+                    # than there: this merge carries num_tokens rows, not batch
+                    # rows. It also shrinks the fp32 branch below -- projecting
+                    # first makes the fp32 merge cheaper than today's bf16 one.
+                    if self.pbm_enabled:
+                        o = self._v_up_proj(
+                            o, self.W_V_dcp, self.W_V_dcp_scale, num_heads=o.shape[1]
+                        )
                     # Merge dtype is platform-dependent: on gfx942 the bf16
                     # ReduceScatter sum costs ~3.5pp, on gfx950 it is free even at
                     # ctx~32k with fp8 KV. Pay the fp32 upcast only where it buys
@@ -2143,7 +2187,12 @@ class MLAAttention(nn.Module):
                         o = cp_lse_ag_out_rs(
                             o.float(), lse, self.dcp_group, ctx=None
                         ).to(o.dtype)
-                    output = self._v_up_proj_and_o_proj(o)
+                    if self.pbm_enabled:
+                        output = self.o_proj(
+                            o.reshape(-1, self.num_heads * self.v_head_dim)
+                        )
+                    else:
+                        output = self._v_up_proj_and_o_proj(o)
                 else:
                     output = self._forward_prefill_mla(q_out, kv_cache, attn_metadata)
             elif self.dcp_world_size > 1:
@@ -2165,8 +2214,20 @@ class MLAAttention(nn.Module):
                 o, lse = self._forward_decode(
                     q_out, kv_cache, attn_metadata, return_lse=True
                 )
+                # Project-before-merge: run W_V on the whole group's head set
+                # BEFORE the merge, so the merge moves v_head_dim per head
+                # instead of kv_lora_rank.
+                if self.pbm_enabled:
+                    o = self._v_up_proj(
+                        o, self.W_V_dcp, self.W_V_dcp_scale, num_heads=o.shape[1]
+                    )
                 o = cp_lse_ag_out_rs(o, lse, self.dcp_group, ctx=self._cp_triton_ctx)
-                output = self._v_up_proj_and_o_proj(o)
+                if self.pbm_enabled:
+                    output = self.o_proj(
+                        o.reshape(-1, self.num_heads * self.v_head_dim)
+                    )
+                else:
+                    output = self._v_up_proj_and_o_proj(o)
             else:
                 output = self._forward_decode(q_out, kv_cache, attn_metadata)
 

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     concat_and_cache_mla_seg = None
     fused_qk_rope_concat_and_cache_mla_seg = None
-from aiter.dist.parallel_state import get_dp_group
+from aiter.dist.parallel_state import get_dp_group, get_tensor_model_parallel_rank
 from aiter.mla import mla_decode_fwd, mla_prefill_fwd
 from aiter.ops.triton.attention.mla import (
     mla_decode_fwd as triton_shuffle_mla_decode_fwd,
@@ -267,6 +267,30 @@ if False:
         fused_gemm_a8w8_blockscale_preshuffle_split_cat = None
 fused_gemm_afp4wfp4_preshuffle_split_cat = None
 fused_gemm_a8w8_blockscale_preshuffle_split_cat = None
+
+
+def qrep_tp_override(tp_size: int) -> dict:
+    """Effective-TP kwargs for the query projection under QREP, or ``{}`` if off.
+
+    QREP shards q_proj on ``tp/dcp`` so each rank materializes its whole DCP
+    group's query head set and decode can skip the per-step AllGather Q.
+
+    Lives here rather than in the model that builds the layer because
+    ``MLAAttention`` owns the rest of that contract: the W_K DCP gather, the
+    prefill row view, and the ``group=True`` decode path all assume q_proj was
+    sharded this way. Keeping the producer next to its consumers is what makes
+    the invariant visible.
+    """
+    if not get_current_atom_config().dcp_config.enable_query_replication:
+        return {}
+    dcp_size = get_dcp_world_size()
+    assert (
+        tp_size % dcp_size == 0
+    ), f"QREP needs tp ({tp_size}) divisible by dcp ({dcp_size})"
+    return {
+        "override_tp_size": tp_size // dcp_size,
+        "override_tp_rank": get_tensor_model_parallel_rank() // dcp_size,
+    }
 
 
 def is_rocm_aiter_fp4bmm_enabled() -> bool:

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -503,7 +503,7 @@ class MLAAttention(nn.Module):
         # is reduce-scattered back to local heads before W_V).
         self.qrep_enabled = (
             self.dcp_world_size > 1
-            and get_current_atom_config().enable_dcp_query_replication
+            and get_current_atom_config().dcp_config.enable_query_replication
         )
         self.qrep_num_heads = self.num_heads * self.dcp_world_size
         if self.qrep_enabled:

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -828,9 +828,7 @@ class MLAAttention(nn.Module):
         else:
             n_heads_out = self.qrep_num_heads if self.qrep_enabled else self.num_heads
             q = self.q_proj(x, x_scale).view(-1, n_heads_out, self.qk_head_dim)
-        q_nope, q_pe = q.split(
-            [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
-        )
+        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
 
         # Convert from (B, N, P) to (N, B, P)
         q_nope = q_nope.transpose(0, 1)
@@ -2034,9 +2032,7 @@ class MLAAttention(nn.Module):
             # and the AG path runs as before); use_qrep only toggles the optimization.
             # Excludes prefill and the seg path (seg alloc is per-rank sized).
             use_qrep = (
-                self.qrep_enabled
-                and not context.is_prefill
-                and not self.use_seg_mla
+                self.qrep_enabled and not context.is_prefill and not self.use_seg_mla
             )
             q_nope, q_rope = self._q_proj_and_k_up_proj(
                 q, x_scale=q_scale, group=use_qrep

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -397,12 +397,17 @@ def _dcp_a2a_unpack_combine_kernel(
         tl.store(out_lse_ptr + b * lse_stride_b + h * lse_stride_h, global_lse)
 
     factor = tl.exp(lse - global_lse)
-    # NaN * 0 = NaN, so an empty rank's NaN output would survive a plain weighted
-    # sum and poison this row. Force its weight to a hard zero instead.
+    # An empty rank already lands on factor == 0 by itself: its lse is -inf, so
+    # exp(-inf - finite) is exactly 0. This line is belt-and-braces for the case
+    # where global_lse is itself -inf (every rank empty) and the subtraction
+    # yields NaN; the load-bearing NaN guard is the vals mask below.
     factor = tl.where((factor != factor) | (~valid), 0.0, factor)  # noqa: PLR0124
 
     d = tl.arange(0, HEAD_DIM)
     vals = tl.load(base[:, None] + d[None, :]).to(tl.float32)
+    # THIS is what stops an empty rank from poisoning the row. aiter returns
+    # o=NaN alongside lse=-inf, and NaN * 0 = NaN, so the NaN has to be replaced
+    # BEFORE the multiply -- zeroing the weight is not enough.
     vals = tl.where(factor[:, None] == 0.0, 0.0, vals)
     acc = tl.sum(vals * factor[:, None], axis=0)
 

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -3,9 +3,14 @@
 
 """DCP (Decode Context Parallel) communication ops for ATOM.
 
-Implements the AG+RS backend for combining partial attention outputs
-across DCP ranks using LSE (Log-Sum-Exp) correction.
-Uses vllm-style algorithm: AllGather LSE -> correct local output -> ReduceScatter.
+Two backends combine the per-rank partial attention outputs into the global
+softmax, selected by ``DCPConfig.comm_backend``:
+
+  * ``ag_rs`` -- AllGather LSE -> correct local output -> ReduceScatter (2 calls)
+  * ``a2a``   -- one all-to-all carrying output+LSE, combine locally (1 call)
+
+They are mathematically equivalent but not bitwise identical; see the A2A
+section below for why one collective can replace two.
 """
 
 import numpy as np
@@ -237,6 +242,252 @@ def cp_lse_ag_out_rs(cp_attn_out, cp_attn_lse, cp_group, ctx=None):
     out = cp_group.reduce_scatter(out, dim=0)
     out = out.movedim(0, 1).contiguous()  # [H_local, B, D] -> [B, H_local, D]
     return out
+
+
+# ─────────────────────────────────────────────── A2A merge backend ──
+#
+# All-to-All backend for the DCP output merge.
+#
+# The AG+RS backend (``cp_lse_ag_out_rs``) needs two collectives, and the reason is
+# ``ReduceScatter``'s reduce op: it can only be a predefined ``sum``/``max``, never
+# an LSE-weighted combine. To use ``sum`` the weights must already be applied, and
+# computing them needs ``global_lse``, which needs every rank's LSE -- hence the
+# AllGather LSE that comes first.
+#
+# A2A sidesteps that by not asking the network to reduce at all. The all-to-all is
+# a pure permutation: it relocates data so that every partial for a given head
+# lands on the one rank that owns that head. The weighting and the sum then happen
+# in a local kernel, where arbitrary math is allowed. One collective instead of two.
+#
+# Both backends compute the same thing::
+#
+#     global_lse[b,h] = log sum_r exp(lse_r[b,h])
+#     out[b,h]        = sum_r exp(lse_r[b,h] - global_lse[b,h]) * o_r[b,h]
+#
+# They differ only in where the multiply and the sum happen, so results agree to
+# floating-point noise but are NOT bitwise identical (different summation order).
+#
+# Bytes are roughly the same as AG+RS: ReduceScatter and All-to-All both carry
+# scatter semantics, so each moves ~(N-1)/N of the full tensor. What A2A saves is
+# one collective's launch and synchronization -- which is worth measuring rather
+# than assuming, because the profiling in the DCP notes shows a large part of the
+# current ReduceScatter cost scales with row count rather than with bytes.
+
+
+def _lse_pack_slots(dtype: torch.dtype) -> int:
+    """How many buffer slots one fp32 LSE needs at this element width."""
+    if dtype == torch.float32:
+        return 1
+    if dtype in (torch.bfloat16, torch.float16):
+        return 2
+    raise NotImplementedError(f"a2a merge buffer dtype {dtype} not supported")
+
+
+@triton.jit
+def _dcp_a2a_pack_kernel(
+    out_ptr,  # [B, H, D]      this rank's partial attention output
+    lse_ptr,  # [B, H]         fp32
+    send_ptr,  # [N, B, H_LOCAL, D + LSE_PACK]
+    out_stride_b,
+    out_stride_h,
+    lse_stride_b,
+    lse_stride_h,
+    send_stride_n,
+    send_stride_b,
+    send_stride_h,
+    H_LOCAL: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    LSE_PACK: tl.constexpr,
+):
+    """Scatter (output, lse) into the per-destination send buffer.
+
+    One program per (token, GLOBAL head). Head ``h`` belongs to destination rank
+    ``h // H_LOCAL`` -- the same contiguous split the ReduceScatter path uses, so
+    a rank ends up owning exactly the heads it owned before.
+    """
+    b = tl.program_id(axis=0).to(tl.int64)
+    h = tl.program_id(axis=1).to(tl.int64)
+
+    dst = h // H_LOCAL
+    h_local = h % H_LOCAL
+
+    d = tl.arange(0, HEAD_DIM)
+    src = tl.load(out_ptr + b * out_stride_b + h * out_stride_h + d)
+
+    dst_base = (
+        send_ptr + dst * send_stride_n + b * send_stride_b + h_local * send_stride_h
+    )
+    tl.store(dst_base + d, src)
+
+    lse = tl.load(lse_ptr + b * lse_stride_b + h * lse_stride_h)
+    if LSE_PACK == 1:
+        tl.store(dst_base + HEAD_DIM, lse)
+    else:
+        # Split the fp32 into two raw 16-bit halves. Nothing does arithmetic on
+        # these slots -- the collective copies bits and the combine kernel puts
+        # them back together -- so a bf16 slot is just 16 bits of storage here.
+        bits = lse.to(tl.uint32, bitcast=True)
+        hi = (bits >> 16).to(tl.uint16).to(dst_base.dtype.element_ty, bitcast=True)
+        lo = (bits & 0xFFFF).to(tl.uint16).to(dst_base.dtype.element_ty, bitcast=True)
+        tl.store(dst_base + HEAD_DIM, hi)
+        tl.store(dst_base + HEAD_DIM + 1, lo)
+
+
+@triton.jit
+def _dcp_a2a_unpack_combine_kernel(
+    recv_ptr,  # [N, B, H_LOCAL, D + LSE_PACK]  N = source rank (KV shard)
+    out_ptr,  # [B, H_LOCAL, D]
+    out_lse_ptr,  # [B, H_LOCAL] fp32, or unused
+    recv_stride_n,
+    recv_stride_b,
+    recv_stride_h,
+    out_stride_b,
+    out_stride_h,
+    lse_stride_b,
+    lse_stride_h,
+    N_RANKS,
+    HEAD_DIM: tl.constexpr,
+    LSE_PACK: tl.constexpr,
+    N_ROUNDED: tl.constexpr,
+    WRITE_LSE: tl.constexpr,
+):
+    """LSE-weighted combine along the KV-shard axis. One program per (token, head).
+
+    The reduce axis is N (the KV shards), never the head axis -- heads are only
+    ever relocated, never summed across. That is what makes the head split above
+    free to be any partition.
+    """
+    b = tl.program_id(axis=0).to(tl.int64)
+    h = tl.program_id(axis=1).to(tl.int64)
+
+    n = tl.arange(0, N_ROUNDED)
+    valid = n < N_RANKS
+    base = (
+        recv_ptr
+        + n.to(tl.int64) * recv_stride_n
+        + b * recv_stride_b
+        + h * recv_stride_h
+    )
+
+    if LSE_PACK == 1:
+        lse = tl.load(base + HEAD_DIM, mask=valid, other=float("-inf"))
+        lse = lse.to(tl.float32)
+    else:
+        hi = tl.load(base + HEAD_DIM, mask=valid, other=0).to(tl.uint16, bitcast=True)
+        lo = tl.load(base + HEAD_DIM + 1, mask=valid, other=0).to(
+            tl.uint16, bitcast=True
+        )
+        bits = (hi.to(tl.uint32) << 16) | lo.to(tl.uint32)
+        lse = bits.to(tl.float32, bitcast=True)
+        lse = tl.where(valid, lse, float("-inf"))
+
+    # A rank that owns no KV for this row reports lse=-inf (and o=NaN). Treat any
+    # non-finite lse as "contributed nothing" so it cannot reach the accumulator.
+    # `x != x` is the NaN test: this Triton has no tl.math.isnan, and it is the
+    # same idiom dcp_ops.py already uses.
+    lse_is_nan = lse != lse  # noqa: PLR0124
+    lse = tl.where(lse_is_nan | (lse == float("inf")), float("-inf"), lse)
+
+    lse_max = tl.max(lse, axis=0)
+    # Every rank empty -> max is -inf; subtracting it would make 0/0 = NaN.
+    lse_max = tl.where(lse_max == float("-inf"), 0.0, lse_max)
+    global_lse = tl.log(tl.sum(tl.exp(lse - lse_max), axis=0)) + lse_max
+
+    if WRITE_LSE:
+        tl.store(out_lse_ptr + b * lse_stride_b + h * lse_stride_h, global_lse)
+
+    factor = tl.exp(lse - global_lse)
+    # NaN * 0 = NaN, so an empty rank's NaN output would survive a plain weighted
+    # sum and poison this row. Force its weight to a hard zero instead.
+    factor = tl.where((factor != factor) | (~valid), 0.0, factor)  # noqa: PLR0124
+
+    d = tl.arange(0, HEAD_DIM)
+    vals = tl.load(base[:, None] + d[None, :]).to(tl.float32)
+    vals = tl.where(factor[:, None] == 0.0, 0.0, vals)
+    acc = tl.sum(vals * factor[:, None], axis=0)
+
+    tl.store(
+        out_ptr + b * out_stride_b + h * out_stride_h + d,
+        acc.to(out_ptr.dtype.element_ty),
+    )
+
+
+def cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group, return_lse: bool = False):
+    """A2A backend: pack -> one all-to-all -> local LSE combine.
+
+    Drop-in for ``cp_lse_ag_out_rs``: same inputs, same ``[B, H_local, D]``
+    output, same head ownership.
+
+    Args:
+        cp_attn_out: ``[B, H, D]`` this rank's partial output over its KV shard.
+        cp_attn_lse: ``[B, H]`` matching log-sum-exp, fp32.
+        cp_group: DCP GroupCoordinator.
+        return_lse: also return the merged ``[B, H_local]`` global LSE.
+    """
+    n_ranks = cp_group.world_size
+    if n_ranks == 1:
+        return (cp_attn_out, cp_attn_lse) if return_lse else cp_attn_out
+
+    b, h_total, head_dim = cp_attn_out.shape
+    assert h_total % n_ranks == 0, (
+        f"a2a merge needs the head count divisible by the DCP size; "
+        f"got H={h_total}, N={n_ranks}"
+    )
+    h_local = h_total // n_ranks
+
+    dtype = cp_attn_out.dtype
+    pack = _lse_pack_slots(dtype)
+    dev = cp_attn_out.device
+
+    cp_attn_out = cp_attn_out.contiguous()
+    cp_attn_lse = cp_attn_lse.contiguous().to(torch.float32)
+
+    send = torch.empty((n_ranks, b, h_local, head_dim + pack), dtype=dtype, device=dev)
+    _dcp_a2a_pack_kernel[(b, h_total)](
+        cp_attn_out,
+        cp_attn_lse,
+        send,
+        cp_attn_out.stride(0),
+        cp_attn_out.stride(1),
+        cp_attn_lse.stride(0),
+        cp_attn_lse.stride(1),
+        send.stride(0),
+        send.stride(1),
+        send.stride(2),
+        H_LOCAL=h_local,
+        HEAD_DIM=head_dim,
+        LSE_PACK=pack,
+    )
+
+    # The N axis flips meaning here: it is "destination rank" on the way in and
+    # "source rank / KV shard" on the way out.
+    recv = torch.empty_like(send)
+    torch.distributed.all_to_all_single(recv, send, group=cp_group.device_group)
+
+    out = torch.empty((b, h_local, head_dim), dtype=dtype, device=dev)
+    out_lse = (
+        torch.empty((b, h_local), dtype=torch.float32, device=dev)
+        if return_lse
+        else send
+    )
+    _dcp_a2a_unpack_combine_kernel[(b, h_local)](
+        recv,
+        out,
+        out_lse,
+        recv.stride(0),
+        recv.stride(1),
+        recv.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out_lse.stride(0) if return_lse else 0,
+        out_lse.stride(1) if return_lse else 0,
+        n_ranks,
+        HEAD_DIM=head_dim,
+        LSE_PACK=pack,
+        N_ROUNDED=triton.next_power_of_2(n_ranks),
+        WRITE_LSE=return_lse,
+    )
+    return (out, out_lse) if return_lse else out
 
 
 def dcp_gather_compressed_kv(

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -495,6 +495,23 @@ def cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group, return_lse: bool = False):
     return (out, out_lse) if return_lse else out
 
 
+def dcp_lse_merge(cp_attn_out, cp_attn_lse, cp_group, backend="a2a", ctx=None):
+    """Reconstruct the global softmax from the per-rank partials.
+
+    Dispatches to one of the two backends above. Both compute the same weighted
+    sum over KV shards and leave this rank owning the same head slice; they
+    differ only in how many collectives it takes (see the A2A section above for
+    why one all-to-all can replace AllGather-LSE + ReduceScatter). Equivalent
+    math, not bitwise identical.
+
+    ``ctx`` is the Triton context the AG+RS backend caches its launches in; the
+    a2a backend does not use one.
+    """
+    if backend == "a2a":
+        return cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group)
+    return cp_lse_ag_out_rs(cp_attn_out, cp_attn_lse, cp_group, ctx=ctx)
+
+
 def dcp_gather_compressed_kv(
     kv_cache: torch.Tensor, slot_ids: torch.Tensor
 ) -> torch.Tensor:

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -435,6 +435,8 @@ class LinearBase(nn.Module):
         reduce_results: bool = False,
         source_quant_dtype: torch.dtype | None = None,
         prefix: str = "",
+        override_tp_size: int | None = None,
+        override_tp_rank: int | None = None,
     ):
         self.prefix = prefix
         layer_quant_config = (
@@ -456,6 +458,18 @@ class LinearBase(nn.Module):
         self.tp_dim = tp_dim
         self.tp_rank = get_tp_group().rank_in_group
         self.tp_size = get_tp_group().world_size
+        # Optional effective-TP override: shard on a coarser grid than the global
+        # TP group (e.g. DCP query replication uses effective TP = tp/dcp so each
+        # rank materializes its whole DCP group's output shard). Since eff_tp is a
+        # valid TP size and eff_rank a valid rank within it, all downstream param
+        # sizing / weight_loader narrowing is inherited unchanged.
+        if override_tp_size is not None or override_tp_rank is not None:
+            assert override_tp_size is not None and override_tp_rank is not None, (
+                "override_tp_size and override_tp_rank must be set together"
+            )
+            assert 0 <= override_tp_rank < override_tp_size
+            self.tp_size = override_tp_size
+            self.tp_rank = override_tp_rank
         self.output_partition_sizes = (
             output_size if isinstance(output_size, list) else [output_size]
         )
@@ -1097,6 +1111,8 @@ class ColumnParallelLinear(LinearBase):
         quant_config: Optional[QuantizationConfig] = None,
         source_quant_dtype: torch.dtype = None,
         prefix: str = "",
+        override_tp_size: int | None = None,
+        override_tp_rank: int | None = None,
         **kwargs,
     ):
         self.tp_dim = 0
@@ -1108,6 +1124,8 @@ class ColumnParallelLinear(LinearBase):
             quant_config=quant_config,
             source_quant_dtype=source_quant_dtype,
             prefix=prefix,
+            override_tp_size=override_tp_size,
+            override_tp_rank=override_tp_rank,
         )
 
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor):

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -1135,6 +1135,79 @@ class ColumnParallelLinear(LinearBase):
         loaded_weight = loaded_weight.narrow(self.tp_dim, start_idx, shard_size)
         param.weight_loader_process(param_data, loaded_weight)
 
+    def make_row_view(self, start: int, length: int) -> "ColumnParallelLinear":
+        """A layer that computes only output rows [start, start+length).
+
+        Motivation: DCP query replication makes q_proj emit the whole DCP group's
+        heads so decode can skip its AllGather Q. Prefill needs only this rank's
+        heads, and slicing the *output* means the GEMM still did 8x the work
+        (measured: +14.8 ms/step of prefill on GLM-5.2 tp8/dcp8). Slicing the
+        WEIGHT instead makes prefill cost what it costs without replication.
+        """
+        import copy
+
+        assert 0 <= start and length > 0 and start + length <= self.weight.shape[0], (
+            f"row view [{start}, {start + length}) out of range for "
+            f"weight rows {self.weight.shape[0]}"
+        )
+        if getattr(self.weight, "is_shuffled", False):
+            assert start % 16 == 0 and length % 16 == 0, (
+                "a shuffled weight may only be row-sliced on 16-row boundaries "
+                f"(shuffle block size); got start={start} length={length}"
+            )
+
+        view = copy.copy(self)
+        # nn.Module bookkeeping is shared by the shallow copy; give the view its
+        # own parameter dict so rebinding weight/scale cannot disturb `self`.
+        view._parameters = dict(self._parameters)
+        view.weight = nn.Parameter(
+            self.weight.data.narrow(0, start, length), requires_grad=False
+        )
+        view.weight.is_shuffled = getattr(self.weight, "is_shuffled", False)
+
+        ws = getattr(self, "weight_scale", None)
+        if ws is not None and ws.data.dim() == 2 and ws.data.shape[0] > 1:
+            if self.quant_type == QuantType.per_1x128:
+                # Scale is [(N+127)//128, (K+127)//128] and is NOT shuffled, so it
+                # slices on the same boundary scaled by 128 -- the same arithmetic
+                # the TP weight_loader already uses for this quant type.
+                assert start % 128 == 0 and length % 128 == 0, (
+                    "per_1x128 row view must be 128-aligned; got "
+                    f"start={start} length={length}"
+                )
+                view.weight_scale = nn.Parameter(
+                    ws.data.narrow(0, start // 128, length // 128),
+                    requires_grad=False,
+                )
+            elif self.quant_type == QuantType.per_Token:
+                view.weight_scale = nn.Parameter(
+                    ws.data.narrow(0, start, length), requires_grad=False
+                )
+            else:
+                raise NotImplementedError(
+                    f"make_row_view does not handle a per-output-channel scale "
+                    f"for quant_type={self.quant_type}"
+                )
+        # per_Tensor / unquantized scales are shared as-is by the shallow copy.
+
+        if self.bias is not None:
+            view.bias = nn.Parameter(
+                self.bias.data.narrow(0, start, length), requires_grad=False
+            )
+
+        view.output_size = length
+        # `forward` trims padded rows via `_output_size_before_padding`. A row
+        # view lives entirely inside the real rows, so it must not re-trim; the
+        # caller is expected to slice below the padding (only per_Token fp8 pads
+        # at all, and it appends at the end).
+        if getattr(self, "is_output_padded", False):
+            assert start + length <= self._output_size_before_padding, (
+                "row view must stay within the unpadded rows"
+            )
+            view.is_output_padded = False
+        view.prefix = f"{getattr(self, 'prefix', '')}[rows {start}:{start + length}]"
+        return view
+
 
 class MergedColumnParallelLinear(LinearBase):
     def __init__(

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -431,7 +431,7 @@ class LinearBase(nn.Module):
         output_size: int | list[int],
         tp_dim: int | None = None,
         bias: bool = False,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig | None = None,
         reduce_results: bool = False,
         source_quant_dtype: torch.dtype | None = None,
         prefix: str = "",
@@ -464,9 +464,9 @@ class LinearBase(nn.Module):
         # valid TP size and eff_rank a valid rank within it, all downstream param
         # sizing / weight_loader narrowing is inherited unchanged.
         if override_tp_size is not None or override_tp_rank is not None:
-            assert override_tp_size is not None and override_tp_rank is not None, (
-                "override_tp_size and override_tp_rank must be set together"
-            )
+            assert (
+                override_tp_size is not None and override_tp_rank is not None
+            ), "override_tp_size and override_tp_rank must be set together"
             assert 0 <= override_tp_rank < override_tp_size
             self.tp_size = override_tp_size
             self.tp_rank = override_tp_rank
@@ -1082,7 +1082,7 @@ class ReplicatedLinear(LinearBase):
         input_size: int,
         output_size: int,
         bias: bool = False,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig | None = None,
         source_quant_dtype: torch.dtype = None,
         prefix: str = "",
         **kwargs,
@@ -1108,7 +1108,7 @@ class ColumnParallelLinear(LinearBase):
         input_size: int,
         output_size: int,
         bias: bool = False,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig | None = None,
         source_quant_dtype: torch.dtype = None,
         prefix: str = "",
         override_tp_size: int | None = None,
@@ -1201,9 +1201,9 @@ class ColumnParallelLinear(LinearBase):
         # caller is expected to slice below the padding (only per_Token fp8 pads
         # at all, and it appends at the end).
         if getattr(self, "is_output_padded", False):
-            assert start + length <= self._output_size_before_padding, (
-                "row view must stay within the unpadded rows"
-            )
+            assert (
+                start + length <= self._output_size_before_padding
+            ), "row view must stay within the unpadded rows"
             view.is_output_padded = False
         view.prefix = f"{getattr(self, 'prefix', '')}[rows {start}:{start + length}]"
         return view

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -2440,7 +2440,9 @@ class DeepseekV2MLAAttention(nn.Module):
         # Gated in Config.__post_init__ (only True with dcp>1, dense/sparse, fp8,
         # no spec). W_K is separately DCP-gathered at load in
         # MLAAttention.process_weights_after_loading.
-        self.qrep_enabled = get_current_atom_config().enable_dcp_query_replication
+        self.qrep_enabled = (
+            get_current_atom_config().dcp_config.enable_query_replication
+        )
         q_qrep_override: dict = {}
         if self.qrep_enabled:
             dcp_size = get_dcp_world_size()

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -42,7 +42,6 @@ from aiter import (
 from aiter.dist.communication_op import tensor_model_parallel_all_reduce
 from aiter.dist.parallel_state import (
     get_pp_group,
-    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
 from aiter.jit.utils.torch_guard import torch_compile_guard
@@ -83,6 +82,7 @@ from atom.model_ops.activation import SiluAndMul
 from atom.model_ops.attention_mla import (
     MLAModules,
     is_rocm_aiter_fp4bmm_enabled,
+    qrep_tp_override,
     triton_convert_req_index_to_global_index,
     triton_convert_req_index_to_global_index_dsa_prefill,
     triton_gather_kv_indices_sparse,
@@ -2434,23 +2434,8 @@ class DeepseekV2MLAAttention(nn.Module):
         assert num_heads % tp_size == 0
         self.num_local_heads = num_heads // tp_size
 
-        # DCP Query Replication (QREP): shard the query projection on a coarser
-        # effective-TP grid (tp/dcp) so each rank materializes its whole DCP
-        # group's query head set, letting decode skip the per-step AllGather Q.
-        # Gated in Config.__post_init__ (only True with dcp>1, dense/sparse, fp8,
-        # no spec). W_K is separately DCP-gathered at load in
-        # MLAAttention.process_weights_after_loading.
-        self.qrep_enabled = (
-            get_current_atom_config().dcp_config.enable_query_replication
-        )
-        q_qrep_override: dict = {}
-        if self.qrep_enabled:
-            dcp_size = get_dcp_world_size()
-            assert tp_size % dcp_size == 0
-            q_qrep_override = {
-                "override_tp_size": tp_size // dcp_size,
-                "override_tp_rank": get_tensor_model_parallel_rank() // dcp_size,
-            }
+        # DCP Query Replication: {} unless QREP is on -- see qrep_tp_override.
+        q_qrep_override = qrep_tp_override(tp_size)
 
         self.scaling = self.qk_head_dim**-0.5
         self.max_position_embeddings = max_position_embeddings

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -40,7 +40,11 @@ from aiter import (
     top_k_per_row_prefill,
 )
 from aiter.dist.communication_op import tensor_model_parallel_all_reduce
-from aiter.dist.parallel_state import get_pp_group, get_tensor_model_parallel_world_size
+from aiter.dist.parallel_state import (
+    get_pp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
 from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 from aiter.ops.triton.fused_fp8_quant import fused_reduce_rms_fp8_group_quant
@@ -2430,6 +2434,22 @@ class DeepseekV2MLAAttention(nn.Module):
         assert num_heads % tp_size == 0
         self.num_local_heads = num_heads // tp_size
 
+        # DCP Query Replication (QREP): shard the query projection on a coarser
+        # effective-TP grid (tp/dcp) so each rank materializes its whole DCP
+        # group's query head set, letting decode skip the per-step AllGather Q.
+        # Gated in Config.__post_init__ (only True with dcp>1, dense/sparse, fp8,
+        # no spec). W_K is separately DCP-gathered at load in
+        # MLAAttention.process_weights_after_loading.
+        self.qrep_enabled = get_current_atom_config().enable_dcp_query_replication
+        q_qrep_override: dict = {}
+        if self.qrep_enabled:
+            dcp_size = get_dcp_world_size()
+            assert tp_size % dcp_size == 0
+            q_qrep_override = dict(
+                override_tp_size=tp_size // dcp_size,
+                override_tp_rank=get_tensor_model_parallel_rank() // dcp_size,
+            )
+
         self.scaling = self.qk_head_dim**-0.5
         self.max_position_embeddings = max_position_embeddings
         self.layer_num = layer_num
@@ -2501,6 +2521,7 @@ class DeepseekV2MLAAttention(nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.q_b_proj",
                 source_quant_dtype=source_quant_dtype,
+                **q_qrep_override,
             )
         else:
             self.q_proj = ColumnParallelLinear(
@@ -2510,6 +2531,7 @@ class DeepseekV2MLAAttention(nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.q_proj",
                 source_quant_dtype=source_quant_dtype,
+                **q_qrep_override,
             )
 
             self.kv_a_proj_with_mqa = ReplicatedLinear(

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -2447,10 +2447,10 @@ class DeepseekV2MLAAttention(nn.Module):
         if self.qrep_enabled:
             dcp_size = get_dcp_world_size()
             assert tp_size % dcp_size == 0
-            q_qrep_override = dict(
-                override_tp_size=tp_size // dcp_size,
-                override_tp_rank=get_tensor_model_parallel_rank() // dcp_size,
-            )
+            q_qrep_override = {
+                "override_tp_size": tp_size // dcp_size,
+                "override_tp_rank": get_tensor_model_parallel_rank() // dcp_size,
+            }
 
         self.scaling = self.qk_head_dim**-0.5
         self.max_position_embeddings = max_position_embeddings

--- a/docs/context_parallel_guide.md
+++ b/docs/context_parallel_guide.md
@@ -287,6 +287,7 @@ existing TP ranks, so `world = tp` and `tp` must be divisible by `dcp`.
 | Flag / Variable | Default | Purpose |
 |-----------------|---------|---------|
 | `-dcp N` / `--decode-context-parallel-size N` | `1` | Enable DCP with size `N`. `world = tp`; requires `tp % N == 0` |
+| `--dcp-config '{...}'` | see below | JSON dict of the four DCP knobs (`interleave_size`, `enable_query_replication`, `enable_project_before_merge`, `comm_backend`). Unknown keys raise. See [`--dcp-config`](#--dcp-config-the-four-dcp-knobs) |
 | `--kv-cache-dtype fp8` | `auto` | Supported with DCP (per-tensor scale). `auto`/`bf16` also fine |
 | `--enable_prefix_caching` | off | Supported with DCP |
 | `--enable_chunked_prefill` / `--no-enable_chunked_prefill` | on | Chunked prefill is supported with DCP; on by default |
@@ -301,7 +302,92 @@ existing TP ranks, so `world = tp` and `tp` must be divisible by `dcp`.
 
 ```bash
 -dcp N                          # or --decode-context-parallel-size N; world = tp, tp % N == 0
+--dcp-config '{"..."}'          # JSON dict of DCP tuning knobs; see below
 ```
+
+## `--dcp-config`: the four DCP knobs
+
+Everything DCP-specific beyond `-dcp N` lives in one JSON dict rather than four
+top-level flags. It is parsed straight into `DCPConfig` (`atom/config.py`), and
+**unknown keys raise** so a typo fails at startup instead of silently doing
+nothing.
+
+```bash
+--dcp-config '{"interleave_size": 16, "enable_query_replication": true}'
+```
+
+| Key | Type | Default | What it does |
+|-----|------|---------|--------------|
+| `interleave_size` | int | `1` | KV-cache interleave granularity `S`: token `i` lives on DCP rank `(i // S) % W`. `1` = token-level round-robin |
+| `enable_query_replication` | bool | `true` | Replicate the MLA query projection across the DCP group at load time, so each rank produces the whole group's head set locally and the per-step decode AllGather Q disappears |
+| `enable_project_before_merge` | bool | `true` | Apply the V up-projection *before* the DCP output merge, so the merge exchanges `v_head_dim` per head instead of `kv_lora_rank` |
+| `comm_backend` | str | `"a2a"` | Which collective pattern merges the per-rank partial attention: `"a2a"` or `"ag_rs"` |
+
+> **Three of the four default to the new behaviour.** A control run that wants
+> the old path must say so **explicitly** — passing nothing re-runs the new
+> configuration, which silently turns an A/B into a no-op:
+>
+> ```bash
+> --dcp-config '{"enable_query_replication": false, "enable_project_before_merge": false, "comm_backend": "ag_rs"}'
+> ```
+
+### `interleave_size`
+
+Block-level interleave (`S > 1`) keeps `S` consecutive tokens on one rank
+instead of striping every token. Constraints, all asserted at startup:
+
+- `1 <= interleave_size <= kv_cache_block_size`
+- `kv_cache_block_size % interleave_size == 0` when `S > 1` — the local-index
+  math `(i // (S*W)) * S + i % S` depends on it
+- `S > 1` requires `-dcp > 1`, and is **incompatible with speculative decode**
+  (the `qlen>1` verify cprr MLA kernel assumes token-level interleave)
+
+### `enable_query_replication` (QREP)
+
+Removes one collective per decode step by paying for it once at load time. It is
+**auto-disabled with a warning** (not an error) when the combination is not
+wired, so it can default on without breaking mixed runs:
+
+| Condition | Reason logged |
+|-----------|---------------|
+| `-dcp 1` | `decode_context_parallel_size <= 1 (no DCP group)` — no AllGather Q to remove |
+| speculative decode (MTP / eagle3 / DSpark) | `speculative decode (qlen>1 cprr path)` |
+| fp4 (`ATOM_USE_TRITON_MXFP4_BMM=1`) | `fp4 (mxfp4) BMM weights` — different scale structure |
+
+Check the server log for `query_replication disabled: ...` to see whether it
+actually took effect; the flag being `true` is not the same as QREP running.
+
+Note it costs KV budget: replicating the query heads shrinks the KV pool by
+roughly 5% (measured on DeepSeek-R1 tp8/dcp8: 235 016 → 221 020 blocks).
+
+### `enable_project_before_merge` (PBM)
+
+The merge is a per-(token, head) scalar weighting plus a cross-rank sum, and
+`W_V` is a per-head linear map, so the two commute — the merged output is the
+same either way, but merging *after* the projection moves `v_head_dim` per head
+instead of `kv_lora_rank`. The payload ratio is `kv_lora_rank / v_head_dim`:
+
+| Model | Ratio |
+|-------|-------|
+| DeepSeek-R1 / V3.2 | 4x |
+| GLM-5.2 (`v_head_dim=256`) | 2x |
+
+Covers both decode and sparse prefill. Costs a DCP-group-wide copy of `W_V`
+(gathered at load time). Auto-disabled for fp4 and for `-dcp 1`.
+
+### `comm_backend`
+
+Both backends compute the same thing and are **mathematically equivalent but not
+bitwise identical** (different summation order, and `a2a` round-trips the fp32
+LSE through two 16-bit halves of a bf16 buffer).
+
+| Value | Pattern | Collectives |
+|-------|---------|-------------|
+| `a2a` (default) | one all-to-all with the LSE packed alongside the output, combine done locally | **1** |
+| `ag_rs` | AllGather LSE + local correct + ReduceScatter output | 2 |
+
+Byte counts are about the same; what `a2a` saves is one collective's launch and
+sync.
 
 ## Launching server
 
@@ -570,10 +656,10 @@ contributing under DCP rather than collapsing back to single-token decode.
 | File | Description |
 |------|-------------|
 | `atom/model_engine/arg_utils.py` | `--decode-context-parallel-size` / `-dcp` CLI |
-| `atom/config.py` | DCP validation (`tp % dcp == 0`); spec-decode + DCP arch gate (gfx950) |
+| `atom/config.py` | `DCPConfig` (the four `--dcp-config` knobs) + their validation; `qrep_unsupported_reason` auto-gating; DCP validation (`tp % dcp == 0`); spec-decode + DCP arch gate (gfx950) |
 | `atom/model_engine/block_manager.py` | Interleaved block allocation; prefix-cache virtual-block accounting |
 | `atom/distributed/dcp_utils.py` | DCP distributed-access layer: `get_dcp_world_size` / `dcp_is_enabled` / `get_dcp_group` / `get_dcp_rank` |
-| `atom/model_ops/dcp_ops.py` | AG+RS LSE-combine, `reorg_kvcache`, local compressed-KV gather, `dcp_all_gather` / `dcp_all_gather_query_heads` (custom-collective AllGather) |
+| `atom/model_ops/dcp_ops.py` | Both merge backends -- `cp_lse_ag_out_rs` (AG+RS LSE-combine) and `cp_lse_a2a` (all-to-all pack / unpack-combine kernels); `reorg_kvcache`, local compressed-KV gather, `dcp_all_gather` / `dcp_all_gather_query_heads` (custom-collective AllGather) |
 | `atom/model_ops/attention_mla.py` | Server-mode DCP decode + prefix-cache / chunked-prefill context; `mla_dcp_kernel_num_heads` / `mla_dcp_decode_is_persistent` gathered-head-width padding |
 | `atom/model_ops/attentions/aiter_mla.py`, `attentions/backends.py` | DCP decode / prefill metadata (interleaved slot_mapping, local seq lens) |
 | `atom/plugin/vllm/attention/layer_mla.py`, `attention/metadata.py` | vllm-atom plugin DCP decode + prefill context; persistent-metadata head sizing |

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -947,10 +947,17 @@ def tp_group():
     import os
 
     import torch.distributed as dist
-    from aiter.dist.parallel_state import (
-        init_distributed_environment,
-        initialize_model_parallel,
-    )
+
+    try:
+        from aiter.dist.parallel_state import (
+            init_distributed_environment,
+            initialize_model_parallel,
+        )
+    except ImportError as e:
+        # A fixture that raises reports as a setup ERROR, not a skip -- which is
+        # exactly how a missing @needs_gpu on a consumer surfaced on a CPU-only
+        # runner. Skipping here keeps that mistake from turning CI red.
+        pytest.skip(f"requires aiter: {e}", allow_module_level=False)
 
     if not dist.is_initialized():
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
@@ -994,6 +1001,7 @@ def _build_layer(quant_type=None, n_wide=N_WIDE):
     return layer
 
 
+@needs_gpu
 def test_row_view_matches_output_slicing_bitwise(tp_group):
     """Every rank's view must equal that rank's slice of the wide projection."""
     layer = _build_layer()
@@ -1012,6 +1020,7 @@ def test_row_view_matches_output_slicing_bitwise(tp_group):
         )
 
 
+@needs_gpu
 def test_row_view_is_zero_copy(tp_group):
     """The point is to avoid a second weight, so it must share storage."""
     layer = _build_layer()
@@ -1024,6 +1033,7 @@ def test_row_view_is_zero_copy(tp_group):
     assert view.output_size == ROWS
 
 
+@needs_gpu
 def test_row_view_slices_the_blockscale(tp_group):
     """per_1x128 scale is [N/128, K/128] and unshuffled: it slices by 128."""
     layer = _build_layer()
@@ -1036,6 +1046,7 @@ def test_row_view_slices_the_blockscale(tp_group):
     )
 
 
+@needs_gpu
 def test_row_view_does_not_disturb_the_parent(tp_group):
     """Taking a view must leave the full projection usable and unchanged."""
     layer = _build_layer()
@@ -1048,6 +1059,7 @@ def test_row_view_does_not_disturb_the_parent(tp_group):
     assert layer.output_size == N_WIDE
 
 
+@needs_gpu
 @pytest.mark.parametrize("start, length", [(8, ROWS), (0, 24), (ROWS + 16, ROWS)])
 def test_row_view_rejects_misaligned_slices(tp_group, start, length):
     """A shuffled weight may only be cut on 16-row blocks; per_1x128 wants 128.
@@ -1060,12 +1072,14 @@ def test_row_view_rejects_misaligned_slices(tp_group, start, length):
         layer.make_row_view(start, length)
 
 
+@needs_gpu
 def test_row_view_rejects_out_of_range(tp_group):
     layer = _build_layer()
     with pytest.raises(AssertionError, match="out of range"):
         layer.make_row_view(N_WIDE - ROWS + 128, ROWS)
 
 
+@needs_gpu
 def test_row_view_refuses_unhandled_scale_layout(tp_group):
     """Only the scale layouts that were verified are allowed through.
 

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -517,36 +517,144 @@ class _Spec:
     """Stand-in for a speculative_config; only its non-None-ness is read."""
 
 
+# ──────────────────────────────────────────────────── project-before-merge ──
+
+
+def _per_head_project(o, w):
+    """The V up-projection: ``[B, H, L] x [H, L, V] -> [B, H, V]``, per head."""
+    return torch.einsum("bhl,hlv->bhv", o, w)
+
+
+def _merge_partials(o_per_rank, lses):
+    """``cp_lse_ag_out_rs`` without the collectives: correct each rank, then sum.
+
+    ``correct_attn_out`` applies rank r's weight in place, and the ReduceScatter
+    that follows it in the real path is a plain sum across ranks -- the head-dim
+    scatter only decides who keeps which slice, it does not change values. So
+    summing here reproduces the merged result.
+    """
+    n = lses.shape[0]
+    acc = None
+    for r in range(n):
+        out_r, _ = correct_attn_out(o_per_rank[r].clone(), lses, r, ctx=None)
+        acc = out_r.clone() if acc is None else acc + out_r
+    return acc
+
+
+@needs_gpu
+@pytest.mark.parametrize("n_ranks", [2, 8])
+def test_projection_commutes_with_the_merge(n_ranks):
+    """The premise project-before-merge rests on.
+
+    The merge is a per-(token, head) SCALAR weighting followed by a sum across
+    ranks; the V up-projection is per-head LINEAR. A scalar commutes with a
+    linear map, and a linear map distributes over the sum, so projecting each
+    rank's partial and then merging must equal merging first and projecting the
+    result. That identity is what lets the merge exchange ``v_head_dim`` per
+    head instead of ``kv_lora_rank``.
+    """
+    b, h, latent, v_dim = 3, 8, 32, 16
+    g = torch.Generator(device=DEV).manual_seed(n_ranks)
+    o = torch.randn(n_ranks, b, h, latent, generator=g, device=DEV)
+    lses = torch.randn(n_ranks, b, h, generator=g, device=DEV)
+    w_v = torch.randn(h, latent, v_dim, generator=g, device=DEV)
+
+    merge_then_project = _per_head_project(_merge_partials(o, lses), w_v)
+    project_then_merge = _merge_partials(
+        torch.stack([_per_head_project(o[r], w_v) for r in range(n_ranks)]), lses
+    )
+
+    # Not bitwise: the two orders sum a different number of terms in a different
+    # sequence. fp32 tolerances, since that is what the kernel accumulates in.
+    torch.testing.assert_close(
+        project_then_merge, merge_then_project, rtol=1e-5, atol=1e-5
+    )
+
+
+@needs_gpu
+def test_projection_does_not_defeat_the_empty_rank_scrub():
+    """A rank owning no KV for a row returns ``o=NaN`` with ``lse=-inf``.
+
+    The merge kernel forces that contribution to zero (``factor == 0 -> 0``).
+    Projecting first puts a matmul in front of the scrub, and ``NaN`` through a
+    matmul is still ``NaN`` -- so the question is whether the scrub still catches
+    it. If it does not, one empty rank poisons EVERY rank's output for that row,
+    silently and with no fault raised.
+    """
+    b, h, latent, v_dim, n_ranks = 2, 4, 32, 16, 2
+    g = torch.Generator(device=DEV).manual_seed(7)
+    o = torch.randn(n_ranks, b, h, latent, generator=g, device=DEV)
+    lses = torch.randn(n_ranks, b, h, generator=g, device=DEV)
+    w_v = torch.randn(h, latent, v_dim, generator=g, device=DEV)
+
+    # Rank 0 owns nothing for row (0, 0): aiter's signature for that case.
+    o[0, 0, 0] = float("nan")
+    lses[0, 0, 0] = NEG_INF
+
+    projected = torch.stack([_per_head_project(o[r], w_v) for r in range(n_ranks)])
+    got = _merge_partials(projected, lses)
+    assert torch.isfinite(got).all(), "empty-rank NaN survived the projection"
+
+    # With rank 0 contributing nothing, the row must equal rank 1 alone -- whose
+    # weight is exp(lse_1 - logsumexp(lse_1)) == 1.
+    torch.testing.assert_close(got[0, 0], projected[1, 0, 0], rtol=1e-5, atol=1e-5)
+
+
 # ─────────────────────────────────────────────────────────── DCPConfig parsing ──
 
 
 def test_defaults():
     cfg = DCPConfig()
     assert cfg.interleave_size == 1
-    # Deliberately pinned: QREP ships enabled. Flipping this default is a
+    # Deliberately pinned: both ship enabled. Flipping either default is a
     # product decision, so it should require editing a test that says so.
+    # It also decides what "pass nothing" means for an A/B control arm, which
+    # is the way a default flip silently turns a comparison into a no-op.
     assert cfg.enable_query_replication is True
+    assert cfg.enable_project_before_merge is True
+    # a2a: measured faster than ag_rs on the decode shapes here. Pinned because
+    # it also decides what an A/B control arm gets when it passes nothing.
+    assert cfg.comm_backend == "a2a"
 
 
 def test_from_dict_parses_both_keys():
     cfg = DCPConfig.from_dict(
-        {"interleave_size": 16, "enable_query_replication": False}
+        {
+            "interleave_size": 16,
+            "enable_query_replication": False,
+            "enable_project_before_merge": False,
+            "comm_backend": "a2a",
+        }
     )
     assert cfg.interleave_size == 16
     assert cfg.enable_query_replication is False
+    assert cfg.enable_project_before_merge is False
+    assert cfg.comm_backend == "a2a"
 
 
 def test_from_dict_empty_and_none_give_defaults():
     for arg in (None, {}):
         cfg = DCPConfig.from_dict(arg)
-        assert (cfg.interleave_size, cfg.enable_query_replication) == (1, True)
+        assert (
+            cfg.interleave_size,
+            cfg.enable_query_replication,
+            cfg.enable_project_before_merge,
+            cfg.comm_backend,
+        ) == (1, True, True, "a2a")
 
 
 def test_from_dict_coerces_types():
     """JSON is permissive; the dataclass should not be."""
-    cfg = DCPConfig.from_dict({"interleave_size": "8", "enable_query_replication": 0})
+    cfg = DCPConfig.from_dict(
+        {
+            "interleave_size": "8",
+            "enable_query_replication": 0,
+            "enable_project_before_merge": 0,
+        }
+    )
     assert cfg.interleave_size == 8 and isinstance(cfg.interleave_size, int)
     assert cfg.enable_query_replication is False
+    assert cfg.enable_project_before_merge is False
 
 
 def test_from_dict_rejects_unknown_key():
@@ -563,6 +671,12 @@ def test_from_dict_rejects_the_old_flag_name():
     """
     with pytest.raises(ValueError, match="enable_dcp_query_replication"):
         DCPConfig.from_dict({"enable_dcp_query_replication": True})
+
+
+def test_comm_backend_rejects_unknown_value():
+    """A typo here would silently keep the default backend, so it must raise."""
+    with pytest.raises(AssertionError, match="comm_backend"):
+        DCPConfig.from_dict({"comm_backend": "all2all"})
 
 
 def test_interleave_size_must_be_positive():

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -988,9 +988,7 @@ def _build_layer(quant_type=None, n_wide=N_WIDE):
     w = torch.randn(n_wide, K, generator=g, device=DEV, dtype=torch.bfloat16) * 0.05
     layer.weight.data = w.to(layer.weight.dtype)
     if quant_type == QuantType.per_1x128:
-        s = torch.rand(
-            (n_wide + 127) // 128, (K + 127) // 128, generator=g, device=DEV
-        )
+        s = torch.rand((n_wide + 127) // 128, (K + 127) // 128, generator=g, device=DEV)
         layer.weight_scale.data = (s * 0.01 + 0.01).to(layer.weight_scale.dtype)
     layer.process_weights_after_loading()
     return layer

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: MIT
-"""DCP merge-path ops in ``atom/model_ops/dcp_ops.py``.
+"""DCP support code: merge-path ops, the QREP config gate, and the QREP row view.
 
-Three ops that the sparse work leans on but that had no coverage:
+Ops from ``atom/model_ops/dcp_ops.py`` that the sparse work leans on:
 
   * ``correct_attn_out``        -- the LSE merge kernel behind ``cp_lse_ag_out_rs``
   * ``get_dcp_local_seq_lens``  -- how many tokens of a sequence this rank holds
   * ``reorg_kvcache``           -- AllGathered chunk blocks -> per-seq contiguous
+
+Plus the two pieces DCP query replication (QREP) rests on:
+
+  * ``DCPConfig`` / ``qrep_unsupported_reason`` -- parsing and feasibility gating
+  * ``ColumnParallelLinear.make_row_view``      -- the narrow q_proj for prefill
 
 The merge is the load-bearing one. ``cp_lse_ag_out_rs`` reconstructs a global
 softmax from per-rank partial attentions, so the test here is not "the kernel
@@ -18,15 +23,25 @@ returns ``o=NaN`` with ``lse=-inf``. Without the ``factor == 0 -> 0`` scrub in
 the kernel, ``NaN * 0 = NaN`` survives the ReduceScatter and poisons EVERY
 rank's output for that row -- silently, with no fault.
 
-``get_dcp_local_seq_lens`` and ``reorg_kvcache`` run on CPU tensors; only the
-merge tests need a GPU.
+``get_dcp_local_seq_lens`` and ``reorg_kvcache`` run on CPU tensors; the merge
+and row-view tests need a GPU. The config tests need neither, which is why the
+`dcp_ops` import below is guarded per-test rather than module-wide: a
+module-level skip would take the config tests down with it on the CPU CI
+runner, and those are the only ones that gate actually runs.
 """
 
 import numpy as np
 import pytest
 import torch
 
+# atom.config imports cleanly without triton/aiter, so the config tests below
+# run on the CPU gate.
+from atom.config import DCPConfig, qrep_unsupported_reason
+
 try:
+    from aiter import dtypes
+
+    from atom.config import QuantizationConfig
     from atom.model_ops.dcp_ops import (
         correct_attn_out,
         dcp_global_pos,
@@ -35,11 +50,19 @@ try:
         get_dcp_local_seq_lens,
         reorg_kvcache,
     )
-except ImportError as _e:  # triton absent on a CPU-only runner
-    pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
+    from atom.model_ops.linear import ColumnParallelLinear
+    from atom.quant_spec import LayerQuantConfig, QuantType
 
+    _DCP_OPS_ERR = None
+except ImportError as _e:  # triton absent on a CPU-only runner
+    _DCP_OPS_ERR = str(_e)
+
+needs_dcp_ops = pytest.mark.skipif(
+    _DCP_OPS_ERR is not None, reason=f"requires full atom import env: {_DCP_OPS_ERR}"
+)
 needs_gpu = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="Triton kernel needs a GPU"
+    _DCP_OPS_ERR is not None or not torch.cuda.is_available(),
+    reason="Triton kernel needs a GPU",
 )
 
 DEV = "cuda"
@@ -216,6 +239,7 @@ def _brute_local_len(seq_len, dcp_size, dcp_rank, interleave):
     return sum(1 for i in range(seq_len) if (i // interleave) % dcp_size == dcp_rank)
 
 
+@needs_dcp_ops
 @pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
 @pytest.mark.parametrize("interleave", [1, 2, 4])
 def test_local_seq_lens_match_the_storage_rule(dcp_size, interleave):
@@ -251,6 +275,7 @@ def _brute_local_index(i, dcp_size, dcp_rank, interleave):
     return sum(1 for j in range(i) if (j // interleave) % dcp_size == dcp_rank)
 
 
+@needs_dcp_ops
 @pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
 @pytest.mark.parametrize("interleave", [1, 2, 4, 8])
 def test_dcp_owner_and_local_index_match_storage_rule(dcp_size, interleave):
@@ -265,6 +290,7 @@ def test_dcp_owner_and_local_index_match_storage_rule(dcp_size, interleave):
         ), f"local_index i={i} S={interleave} W={dcp_size}"
 
 
+@needs_dcp_ops
 @pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
 @pytest.mark.parametrize("interleave", [1, 2, 4, 8])
 def test_dcp_global_pos_inverts_local_index(dcp_size, interleave):
@@ -286,6 +312,7 @@ def test_dcp_global_pos_inverts_local_index(dcp_size, interleave):
         )
 
 
+@needs_dcp_ops
 @pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
 def test_dcp_helpers_reduce_to_round_robin_when_interleave_1(dcp_size):
     # S == 1 must be bit-identical to the old inline round-robin (owner = i%W,
@@ -295,6 +322,7 @@ def test_dcp_helpers_reduce_to_round_robin_when_interleave_1(dcp_size):
     np.testing.assert_array_equal(dcp_local_index(pos, dcp_size, 1), pos // dcp_size)
 
 
+@needs_dcp_ops
 @pytest.mark.parametrize("dcp_size", [1, 2, 4, 8])
 @pytest.mark.parametrize("interleave", [1, 2, 4, 8])
 def test_dcp_local_index_max_equals_local_seq_len(dcp_size, interleave):
@@ -314,6 +342,7 @@ def test_dcp_local_index_max_equals_local_seq_len(dcp_size, interleave):
             assert got == expect, f"L={L} r={r} S={interleave} W={dcp_size}"
 
 
+@needs_dcp_ops
 @pytest.mark.parametrize("dcp_size", [2, 4, 8])
 @pytest.mark.parametrize("interleave", [1, 2, 4, 8])
 @pytest.mark.parametrize("block_size", [8, 16, 64])
@@ -397,6 +426,7 @@ def _build_chunk(cached_lens, dcp, block_size, chunk_size, chunk_idx, dim=4, pe=
     }
 
 
+@needs_dcp_ops
 @pytest.mark.parametrize("chunk_idx", [0, 1, 2, 3])
 def test_reorg_kvcache_rebuilds_each_sequence(chunk_idx):
     dcp, block_size, chunk_size = 4, 4, 4
@@ -448,6 +478,7 @@ def test_reorg_kvcache_rebuilds_each_sequence(chunk_idx):
     assert pos == c["sum_seq_len"]
 
 
+@needs_dcp_ops
 def test_reorg_kvcache_rejects_a_wrong_total():
     """The internal asserts are the only guard the caller has; keep them live."""
     dcp, block_size, chunk_size = 4, 4, 4
@@ -464,3 +495,292 @@ def test_reorg_kvcache_rejects_a_wrong_total():
             chunk_idx=0,
             toks=c["toks"],
         )
+
+
+# ══════════════════════════════════════════ DCPConfig + the QREP gate (CPU) ══
+#
+# DCPConfig parsing and the DCP query-replication (QREP) gate.
+# QREP now defaults to ON, which changes what a missing test costs: a refactor
+# that quietly disables it produces no error and no visible symptom -- just a
+# slower server. That already happened: a merge re-parented the gate under
+# `if dcp_config.interleave_size > 1`, so with the default interleave_size=1
+# QREP was force-disabled in every ordinary configuration while the log blamed
+# `dcp <= 1`. It went unnoticed through a full day of benchmarking. Hence the
+# two guards below: the gate must key off the DCP size and NOT interleave_size,
+# and the shipped default must stay on.
+#
+# These need neither a GPU nor dcp_ops, so they are the DCP tests the CPU gate
+# actually runs.
+
+
+class _Spec:
+    """Stand-in for a speculative_config; only its non-None-ness is read."""
+
+
+# ─────────────────────────────────────────────────────────── DCPConfig parsing ──
+
+
+def test_defaults():
+    cfg = DCPConfig()
+    assert cfg.interleave_size == 1
+    # Deliberately pinned: QREP ships enabled. Flipping this default is a
+    # product decision, so it should require editing a test that says so.
+    assert cfg.enable_query_replication is True
+
+
+def test_from_dict_parses_both_keys():
+    cfg = DCPConfig.from_dict(
+        {"interleave_size": 16, "enable_query_replication": False}
+    )
+    assert cfg.interleave_size == 16
+    assert cfg.enable_query_replication is False
+
+
+def test_from_dict_empty_and_none_give_defaults():
+    for arg in (None, {}):
+        cfg = DCPConfig.from_dict(arg)
+        assert (cfg.interleave_size, cfg.enable_query_replication) == (1, True)
+
+
+def test_from_dict_coerces_types():
+    """JSON is permissive; the dataclass should not be."""
+    cfg = DCPConfig.from_dict({"interleave_size": "8", "enable_query_replication": 0})
+    assert cfg.interleave_size == 8 and isinstance(cfg.interleave_size, int)
+    assert cfg.enable_query_replication is False
+
+
+def test_from_dict_rejects_unknown_key():
+    """Typos must fail loudly -- a silently ignored key reads as 'it did not work'."""
+    with pytest.raises(ValueError, match="Unknown --dcp-config key"):
+        DCPConfig.from_dict({"interleve_size": 4})
+
+
+def test_from_dict_rejects_the_old_flag_name():
+    """`enable_dcp_query_replication` was the pre-DCPConfig top-level flag.
+
+    Anyone carrying an old command line should get an error naming the supported
+    keys, not a server that silently ignores the setting.
+    """
+    with pytest.raises(ValueError, match="enable_dcp_query_replication"):
+        DCPConfig.from_dict({"enable_dcp_query_replication": True})
+
+
+def test_interleave_size_must_be_positive():
+    with pytest.raises(AssertionError, match="interleave_size"):
+        DCPConfig.from_dict({"interleave_size": 0})
+
+
+# ────────────────────────────────────────────────────────────────── QREP gate ──
+
+
+@pytest.mark.parametrize(
+    "dcp, spec, mxfp4, expected",
+    [
+        (8, None, False, None),  # the ordinary case: supported
+        (2, None, False, None),
+        (1, None, False, "decode_context_parallel_size <= 1 (no DCP group)"),
+        (8, _Spec(), False, "speculative decode (qlen>1 cprr path)"),
+        (8, None, True, "fp4 (mxfp4) BMM weights"),
+        # dcp is checked first: with no DCP group the other reasons are moot.
+        (1, _Spec(), True, "decode_context_parallel_size <= 1 (no DCP group)"),
+    ],
+)
+def test_gate_truth_table(dcp, spec, mxfp4, expected):
+    assert qrep_unsupported_reason(dcp, spec, mxfp4) == expected
+
+
+def test_gate_takes_no_interleave_input():
+    """The gate must not be able to see the KV interleave granularity.
+
+    ⚠️ Scope, stated plainly: this checks the FUNCTION, not the call site. The
+    merge bug lived at the call site (the gate was nested inside an
+    ``if interleave_size > 1`` branch in ``Config.__post_init__``), and **this
+    test would not catch that recurring** -- covering it would mean building a
+    real Config, which needs a model directory and an HF config. What this does
+    buy: interleave can no longer reach the decision *through the signature*, so
+    re-coupling the two requires deliberately passing it in, and the docstring
+    on `qrep_unsupported_reason` says not to.
+    """
+    import inspect
+
+    params = inspect.signature(qrep_unsupported_reason).parameters
+    assert "interleave" not in " ".join(params), (
+        "the QREP gate must not depend on the KV interleave granularity; "
+        f"got parameters {list(params)}"
+    )
+
+
+def test_gate_reason_is_human_readable():
+    """The reason string is logged verbatim; it should name the actual cause."""
+    reason = qrep_unsupported_reason(1, None, False)
+    assert "decode_context_parallel_size" in reason
+
+
+# ═══════════════════════════════ ColumnParallelLinear.make_row_view (GPU) ══
+#
+# DCP query replication widens q_proj so decode holds the whole DCP group's
+# heads and can skip its AllGather Q. Prefill needs only this rank's heads, and
+# slicing the *output* of the wide projection still paid for the whole group
+# (measured +14.8 ms/step of prefill on GLM-5.2 tp8/dcp8). make_row_view instead
+# hands prefill a zero-copy row VIEW of the weight.
+#
+# Why a plain row slice is legal on an already-shuffled weight: shuffle_weight
+# reshapes to (N//16, 16, K//BK, BK//K, K) and permutes with N//16 still
+# leading, so elements move only WITHIN a 16-row block and blocks never mix.
+# Get the boundary wrong and there is no error -- the layer quietly serves
+# another rank's heads. Hence bitwise equality below, not a tolerance: this is
+# pure work elimination, not an approximation.
+
+
+DCP = 8
+HEADS_PER_RANK = 8
+QK_HEAD_DIM = 256  # 192 nope + 64 rope, as on GLM-5.2
+ROWS = HEADS_PER_RANK * QK_HEAD_DIM  # 2048 rows per rank
+N_WIDE = ROWS * DCP  # 16384, the whole DCP group
+K = 2048  # q_lora_rank
+TOKENS = 512
+
+
+@pytest.fixture(scope="module")
+def tp_group():
+    """world=1 TP group so ColumnParallelLinear can be constructed.
+
+    Deliberately 1: the layer must not re-shard, so `output_size` stays the
+    group-wide N and the row view is the only slicing under test.
+    """
+    import os
+
+    from aiter.dist.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    import torch.distributed as dist
+
+    if not dist.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29578")
+        torch.cuda.set_device(0)
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method="tcp://127.0.0.1:29578",
+        )
+        initialize_model_parallel(tensor_model_parallel_size=1)
+    yield
+
+
+def _build_layer(quant_type=None, n_wide=N_WIDE):
+    """A group-wide q_proj taken through the real post-loading path.
+
+    `quant_type` defaults inside the body, not in the signature: a default
+    argument is evaluated at import time, and `QuantType` only exists when the
+    guarded aiter import above succeeded. Evaluating it in the signature would
+    turn a missing aiter into a collection-time NameError that takes the
+    CPU-only config tests in this file down with it.
+    """
+    quant_type = QuantType.per_1x128 if quant_type is None else quant_type
+    qc = QuantizationConfig()
+    qc.global_spec = LayerQuantConfig(
+        quant_type=quant_type, quant_dtype=dtypes.fp8, is_dynamic=True
+    )
+    layer = ColumnParallelLinear(
+        input_size=K, output_size=n_wide, bias=False, quant_config=qc, prefix="q_b_proj"
+    ).to(DEV)
+
+    g = torch.Generator(device=DEV).manual_seed(0)
+    w = torch.randn(n_wide, K, generator=g, device=DEV, dtype=torch.bfloat16) * 0.05
+    layer.weight.data = w.to(layer.weight.dtype)
+    if quant_type == QuantType.per_1x128:
+        s = torch.rand(
+            (n_wide + 127) // 128, (K + 127) // 128, generator=g, device=DEV
+        )
+        layer.weight_scale.data = (s * 0.01 + 0.01).to(layer.weight_scale.dtype)
+    layer.process_weights_after_loading()
+    return layer
+
+
+def test_row_view_matches_output_slicing_bitwise(tp_group):
+    """Every rank's view must equal that rank's slice of the wide projection."""
+    layer = _build_layer()
+    g = torch.Generator(device=DEV).manual_seed(1)
+    x = torch.randn(TOKENS, K, generator=g, device=DEV, dtype=torch.bfloat16)
+
+    wide = layer(x).view(-1, DCP * HEADS_PER_RANK, QK_HEAD_DIM)
+    for rank in range(DCP):
+        narrow = layer.make_row_view(rank * ROWS, ROWS)(x).view(
+            -1, HEADS_PER_RANK, QK_HEAD_DIM
+        )
+        want = wide[:, rank * HEADS_PER_RANK : (rank + 1) * HEADS_PER_RANK, :]
+        assert torch.equal(narrow, want), (
+            f"rank {rank}: row view differs from the wide projection's slice "
+            "-- the slice is landing on the wrong rows"
+        )
+
+
+def test_row_view_is_zero_copy(tp_group):
+    """The point is to avoid a second weight, so it must share storage."""
+    layer = _build_layer()
+    view = layer.make_row_view(3 * ROWS, ROWS)
+    assert (
+        view.weight.untyped_storage().data_ptr()
+        == layer.weight.untyped_storage().data_ptr()
+    )
+    assert view.weight.shape == (ROWS, K)
+    assert view.output_size == ROWS
+
+
+def test_row_view_slices_the_blockscale(tp_group):
+    """per_1x128 scale is [N/128, K/128] and unshuffled: it slices by 128."""
+    layer = _build_layer()
+    rank = 5
+    view = layer.make_row_view(rank * ROWS, ROWS)
+    assert view.weight_scale.shape == (ROWS // 128, K // 128)
+    assert torch.equal(
+        view.weight_scale.data,
+        layer.weight_scale.data[rank * ROWS // 128 : (rank + 1) * ROWS // 128],
+    )
+
+
+def test_row_view_does_not_disturb_the_parent(tp_group):
+    """Taking a view must leave the full projection usable and unchanged."""
+    layer = _build_layer()
+    g = torch.Generator(device=DEV).manual_seed(2)
+    x = torch.randn(TOKENS, K, generator=g, device=DEV, dtype=torch.bfloat16)
+
+    before = layer(x).clone()
+    layer.make_row_view(0, ROWS)
+    assert torch.equal(layer(x), before)
+    assert layer.output_size == N_WIDE
+
+
+@pytest.mark.parametrize("start, length", [(8, ROWS), (0, 24), (ROWS + 16, ROWS)])
+def test_row_view_rejects_misaligned_slices(tp_group, start, length):
+    """A shuffled weight may only be cut on 16-row blocks; per_1x128 wants 128.
+
+    Without this the slice silently yields a scrambled weight, so the assert is
+    the only thing standing between a typo and wrong attention output.
+    """
+    layer = _build_layer()
+    with pytest.raises(AssertionError):
+        layer.make_row_view(start, length)
+
+
+def test_row_view_rejects_out_of_range(tp_group):
+    layer = _build_layer()
+    with pytest.raises(AssertionError, match="out of range"):
+        layer.make_row_view(N_WIDE - ROWS + 128, ROWS)
+
+
+def test_row_view_refuses_unhandled_scale_layout(tp_group):
+    """Only the scale layouts that were verified are allowed through.
+
+    per_Tensor has a scalar scale that the shallow copy shares correctly, but a
+    layout with a per-output-channel scale this code has not been taught to
+    slice must raise rather than hand back a mismatched scale.
+    """
+    layer = _build_layer(quant_type=QuantType.per_1x32)
+    if getattr(layer, "quant_type", None) != QuantType.per_1x32:
+        pytest.skip("per_1x32 not constructible in this build")
+    with pytest.raises(NotImplementedError, match="per-output-channel scale"):
+        layer.make_row_view(0, ROWS)

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -30,6 +30,8 @@ module-level skip would take the config tests down with it on the CPU CI
 runner, and those are the only ones that gate actually runs.
 """
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 import torch
@@ -39,10 +41,14 @@ import torch
 from atom.config import DCPConfig, qrep_unsupported_reason
 
 try:
+    import triton
     from aiter import dtypes
 
     from atom.config import QuantizationConfig
     from atom.model_ops.dcp_ops import (
+        _dcp_a2a_pack_kernel,
+        _dcp_a2a_unpack_combine_kernel,
+        _lse_pack_slots,
         correct_attn_out,
         dcp_global_pos,
         dcp_local_index,
@@ -600,6 +606,182 @@ def test_projection_does_not_defeat_the_empty_rank_scrub():
     torch.testing.assert_close(got[0, 0], projected[1, 0, 0], rtol=1e-5, atol=1e-5)
 
 
+# ──────────────────────────────────────────────────────── A2A merge backend ──
+
+
+def _a2a_roundtrip(o_per_rank, lse_per_rank, n_ranks):
+    """pack -> all-to-all -> combine, with the collective done as a local permute.
+
+    ``all_to_all_single`` needs a real process group, which a single-process test
+    does not have. But the collective is a pure permutation -- rank r's chunk n
+    becomes rank n's chunk r -- so stacking the send buffers reproduces exactly
+    what every rank would receive. That leaves the two Triton kernels and the LSE
+    bit-packing as the only things under test, which is where the bugs would be.
+
+    Returns ``[B, H_total, D]``: each rank owns heads ``[j*H_local, ...)``, so
+    concatenating the per-rank outputs in rank order rebuilds the original head
+    layout.
+    """
+    b, h_total, d = o_per_rank[0].shape
+    h_local = h_total // n_ranks
+    dtype = o_per_rank[0].dtype
+    pack = _lse_pack_slots(dtype)
+
+    sends = []
+    for r in range(n_ranks):
+        send = torch.empty((n_ranks, b, h_local, d + pack), dtype=dtype, device=DEV)
+        o_r = o_per_rank[r].contiguous()
+        l_r = lse_per_rank[r].contiguous().to(torch.float32)
+        _dcp_a2a_pack_kernel[(b, h_total)](
+            o_r,
+            l_r,
+            send,
+            o_r.stride(0),
+            o_r.stride(1),
+            l_r.stride(0),
+            l_r.stride(1),
+            send.stride(0),
+            send.stride(1),
+            send.stride(2),
+            H_LOCAL=h_local,
+            HEAD_DIM=d,
+            LSE_PACK=pack,
+        )
+        sends.append(send)
+
+    outs = []
+    for j in range(n_ranks):
+        recv = torch.stack([sends[r][j] for r in range(n_ranks)]).contiguous()
+        out = torch.empty((b, h_local, d), dtype=dtype, device=DEV)
+        out_lse = torch.empty((b, h_local), dtype=torch.float32, device=DEV)
+        _dcp_a2a_unpack_combine_kernel[(b, h_local)](
+            recv,
+            out,
+            out_lse,
+            recv.stride(0),
+            recv.stride(1),
+            recv.stride(2),
+            out.stride(0),
+            out.stride(1),
+            out_lse.stride(0),
+            out_lse.stride(1),
+            n_ranks,
+            HEAD_DIM=d,
+            LSE_PACK=pack,
+            N_ROUNDED=triton.next_power_of_2(n_ranks),
+            WRITE_LSE=True,
+        )
+        outs.append(out)
+    return torch.cat(outs, dim=1)
+
+
+@needs_gpu
+@pytest.mark.parametrize("n_ranks", [2, 8])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_a2a_reproduces_the_ag_rs_merge(n_ranks, dtype):
+    """The two backends must agree: same weighted sum, same head ownership.
+
+    They arrive there differently -- ag_rs pre-multiplies each rank's partial and
+    lets ReduceScatter sum, a2a moves everything to the owning rank and does both
+    locally -- so this is a comparison, not a bit-for-bit check.
+
+    bf16 is the case that matters most: it is what decode actually runs, and it
+    is the only one where the fp32 LSE has to survive being split across two
+    16-bit slots of the transfer buffer.
+    """
+    b, h, d = 3, 8, 32
+    g = torch.Generator(device=DEV).manual_seed(n_ranks)
+    o = [
+        torch.randn(b, h, d, generator=g, device=DEV).to(dtype) for _ in range(n_ranks)
+    ]
+    lse = [torch.randn(b, h, generator=g, device=DEV) for _ in range(n_ranks)]
+
+    got = _a2a_roundtrip(o, lse, n_ranks)
+    ref = _merge_partials(torch.stack(o), torch.stack(lse))
+
+    tol = 1e-5 if dtype == torch.float32 else 3e-2
+    torch.testing.assert_close(got.float(), ref.float(), rtol=tol, atol=tol)
+
+
+@needs_gpu
+def test_a2a_lse_survives_the_16_bit_split():
+    """A bf16 buffer stores the fp32 LSE as two raw 16-bit halves.
+
+    Nothing does arithmetic on those slots -- the collective copies bits -- so the
+    value must come back EXACTLY, not approximately. If it did not, every rank's
+    softmax weights would be subtly wrong in a way the tolerance above could hide.
+
+    Checked by giving each rank a distinct LSE and one-hot outputs, so the merged
+    result is a pure function of the weights.
+    """
+    b, h, d, n_ranks = 2, 4, 32, 4
+    g = torch.Generator(device=DEV).manual_seed(11)
+    lse = [torch.randn(b, h, generator=g, device=DEV) * 5.0 for _ in range(n_ranks)]
+    # Rank r contributes the constant r, so out == sum_r weight_r * r exactly.
+    o = [
+        torch.full((b, h, d), float(r), device=DEV, dtype=torch.bfloat16)
+        for r in range(n_ranks)
+    ]
+
+    got = _a2a_roundtrip(o, lse, n_ranks).float()
+
+    stacked = torch.stack(lse)  # [N, B, H]
+    w = torch.softmax(stacked, dim=0)  # exp(lse_r - global_lse)
+    want = sum(w[r].unsqueeze(-1) * float(r) for r in range(n_ranks))
+    torch.testing.assert_close(
+        got, want.expand_as(got).contiguous(), rtol=8e-3, atol=8e-3
+    )
+
+
+@needs_gpu
+def test_a2a_scrubs_the_empty_rank():
+    """Same hazard as the ag_rs path: a rank owning no KV returns o=NaN, lse=-inf.
+
+    The combine kernel must force that contribution to a hard zero. Without it
+    NaN*0 = NaN survives the accumulation and poisons the row for every rank --
+    silently, since nothing raises.
+    """
+    b, h, d, n_ranks = 2, 4, 32, 2
+    g = torch.Generator(device=DEV).manual_seed(5)
+    o = [
+        torch.randn(b, h, d, generator=g, device=DEV).bfloat16() for _ in range(n_ranks)
+    ]
+    lse = [torch.randn(b, h, generator=g, device=DEV) for _ in range(n_ranks)]
+    o[0][0, 0] = float("nan")
+    lse[0][0, 0] = NEG_INF
+
+    got = _a2a_roundtrip(o, lse, n_ranks)
+    assert torch.isfinite(got).all(), "empty-rank NaN reached the a2a output"
+    # Rank 0 contributed nothing, so the row is rank 1 alone (weight 1).
+    torch.testing.assert_close(
+        got[0, 0].float(), o[1][0, 0].float(), rtol=8e-3, atol=8e-3
+    )
+
+
+@needs_dcp_ops
+def test_lse_pack_slots_covers_the_transfer_dtypes():
+    """fp32 needs one slot, 16-bit dtypes need two; anything else must raise
+    rather than silently truncate the LSE."""
+    assert _lse_pack_slots(torch.float32) == 1
+    assert _lse_pack_slots(torch.bfloat16) == 2
+    assert _lse_pack_slots(torch.float16) == 2
+    with pytest.raises(NotImplementedError, match="a2a merge buffer dtype"):
+        _lse_pack_slots(torch.float8_e4m3fn)
+
+
+@needs_dcp_ops
+def test_cp_lse_a2a_is_a_no_op_without_a_dcp_group():
+    """dcp==1 has nothing to merge; the input must come back untouched."""
+    from atom.model_ops.dcp_ops import cp_lse_a2a
+
+    o = torch.randn(2, 4, 8)
+    lse = torch.randn(2, 4)
+    group = SimpleNamespace(world_size=1)
+    assert cp_lse_a2a(o, lse, group) is o
+    out, out_lse = cp_lse_a2a(o, lse, group, return_lse=True)
+    assert out is o and out_lse is lse
+
+
 # ─────────────────────────────────────────────────────────── DCPConfig parsing ──
 
 
@@ -764,11 +946,11 @@ def tp_group():
     """
     import os
 
+    import torch.distributed as dist
     from aiter.dist.parallel_state import (
         init_distributed_environment,
         initialize_model_parallel,
     )
-    import torch.distributed as dist
 
     if not dist.is_initialized():
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")


### PR DESCRIPTION
## 1. Motivation

DCP trades per-step decode latency for KV capacity: each rank keeps `1/W` of the KV, so a `tp8/dcp8` server holds roughly 8x the tokens, but every decode step pays for an AllGather of Q plus a two-collective output merge. On DeepSeek-V3.2 that per-step tax used to cancel the capacity win outright.

This PR attacks the per-step cost with three independent optimizations that compose: 
+ **query replication (QREP)** removes the decode AllGather Q
+ **project-before-merge (PBM)** shrinks the merge payload by `kv_lora_rank / v_head_dim` (4x on DeepSeek, 2x on GLM-5.2)
+ an **all-to-all merge backend (A2A)** replaces the two-collective merge with one. 

Measured end to end on the KV-wall workload with all three on, against the same tree with all three off: (DeepSeek-R1-0528，`tp8/dcp8`，fp8 KV，`in=32768 out=8192`，`num_prompts = concurrency = 320`，`mbt=16384`，`gpu-memory-utilization=0.8`，gfx950)

| DeepSeek-R1, tp8/dcp8 | cold | warm |
|---|---|---|
| Output throughput | **+11.06%** | **+15.50%** |
| Median ITL | **−15.41%** | **−15.34%** |
| Mean TTFT | −0.13% | −0.03% |
| `dcp8/tp8` throughput | 1.601x → **1.778x** | 2.166x → **2.502x** |

The same `base → opt` median-ITL delta lands at **−14.8% ~ −16.5% across three models and both attention paths** (dense MLA and DSA sparse). DCP's per-step penalty drops from 1.82x to 1.54x on dense and from ~2.4x to ~2.1x on sparse, and the cold-pass loss on sparse becomes a wash (V3.2: 0.865x → 1.032x).

## 2. Usage

All three knobs live in one JSON dict rather than three top-level flags. Parsed into `DCPConfig`; unknown keys raise at startup so typos fail fast.

| Argument | Required | Description |
|---|---|---|
| `-dcp N` | yes | Enable DCP with size `N`; `tp % N == 0` |
| `--dcp-config '{...}'` | no | JSON dict of DCP knobs; see below |

| Key | Type | Default | Description |
|---|---|---|---|
| `interleave_size` | int | `1` | KV interleave granularity `S`: token `i` on rank `(i // S) % W`. Unchanged by this PR |
| `enable_query_replication` | bool | **`true`** | Replicate q_proj across the DCP group at load time; removes the per-step decode AllGather Q |
| `enable_project_before_merge` | bool | **`true`** | Apply `W_V` before the output merge, so the merge moves `v_head_dim` instead of `kv_lora_rank` per head |
| `comm_backend` | str | **`"a2a"`** | `"a2a"` = one all-to-all; `"ag_rs"` = AllGather LSE + ReduceScatter output |

```bash
# Default: all three on
python -m atom.entrypoints.openai_server --model deepseek-ai/DeepSeek-R1 \
    -tp 8 -dcp 8 --kv_cache_dtype fp8

# Control run -- must be explicit. All three DEFAULT to the new behaviour, so
# passing nothing re-runs the new configuration and silently makes an A/B a no-op.
python -m atom.entrypoints.openai_server --model deepseek-ai/DeepSeek-R1 \
    -tp 8 -dcp 8 --kv_cache_dtype fp8 \
    --dcp-config '{"enable_query_replication": false, "enable_project_before_merge": false, "comm_backend": "ag_rs"}'
```

**Verification.** QREP auto-disables itself for combinations that are not wired yet, so the flag being `true` is not proof it ran. Check the server log:

```
query_replication disabled: speculative decode (qlen>1 cprr path) not supported in the first cut
```

Absence of that line means QREP is live.

## 3. Design

### 3.1 What changes per decode step

| Aspect | Before (baseline DCP) | After (this PR) |
|---|---|---|
| Q for the group's heads | AllGather Q every step | q_proj sharded on an effective-TP grid (`tp/dcp`), each rank produces the whole group's heads locally |
| Merge input width | `kv_lora_rank` per head (512) | `v_head_dim` per head (128 on R1, 256 on GLM-5.2) |
| Merge collectives | AllGather LSE + ReduceScatter output (2) | one `all_to_all_single` with LSE packed alongside (1) |
| V up-projection | after the merge, on merged output | before the merge, on each rank's partial |
| `W_V` storage | rank-local heads | DCP-group copy, gathered at load |
| KV pool | baseline | ~5% smaller (QREP replicates query heads) |
| Collectives per decode step | 3 | **1** |

### 3.2 Decode data flow

```
 BEFORE                                    AFTER (this PR)
 ┌────────────────────────────┐            ┌────────────────────────────┐
 │ q_proj  → [B, H_local, Dq] │            │ q_proj on effective-TP     │
 └─────────────┬──────────────┘            │  → [B, H_group, Dq]        │
               │                           └─────────────┬──────────────┘
               ▼                                         │   (no collective)
 ┌────────────────────────────┐                          │
 │ AllGather Q   ← collective │                          │
 │  → [B, H_group, Dq]        │                          │
 └─────────────┬──────────────┘                          │
               │                                         │
               ▼                                         ▼
 ┌────────────────────────────┐            ┌────────────────────────────┐
 │ local MLA attention        │            │ local MLA attention        │
 │  o   [B, H_group, 512]     │            │  o   [B, H_group, 512]     │
 │  lse [B, H_group]          │            │  lse [B, H_group]          │
 └─────────────┬──────────────┘            └─────────────┬──────────────┘
               │                                         │
               │                                         ▼
               │                           ┌────────────────────────────┐
               │                           │ PBM: W_V_dcp bmm           │
               │                           │  [B,H_group,512]           │
               │                           │    → [B,H_group,v_head_dim]│
               │                           │  (4x less to move on R1)   │
               │                           └─────────────┬──────────────┘
               ▼                                         ▼
 ┌────────────────────────────┐            ┌────────────────────────────┐
 │ AllGather LSE ← collective │            │ pack (o,lse) → 1 buffer    │
 │ local LSE correct          │            │ all_to_all_single          │
 │ ReduceScatter o← collective│            │       ← ONE collective     │
 │  → [B, H_local, 512]       │            │ local LSE-weighted combine │
 └─────────────┬──────────────┘            │  → [B, H_local, v_head_dim]│
               │                           └─────────────┬──────────────┘
               ▼                                         │
 ┌────────────────────────────┐                          │
 │ V up-proj → v_head_dim     │                          │
 └─────────────┬──────────────┘                          │
               ▼                                         ▼
 ┌────────────────────────────┐            ┌────────────────────────────┐
 │ o_proj                     │            │ o_proj                     │
 └────────────────────────────┘            └────────────────────────────┘
```

### 3.3 Key design decisions

**QREP shards `q_proj` on a coarser grid rather than replicating a tensor.** `q_proj` is sharded on an *effective TP* of `tp/dcp`, so each rank's weight already spans the whole DCP group's head set and there is nothing to gather at decode time. `W_K` is gathered at load in `process_weights_after_loading` as bf16 and requantized **once** — quantizing per-rank and concatenating would leave a different scale per shard.

**Prefill slices the weight, not the output.** QREP makes `q_proj` emit `dcp` times the heads, but prefill needs only this rank's. Slicing the output leaves the GEMM doing 8x the work (**+14.8 ms/step** on GLM-5.2 tp8/dcp8); `ColumnParallelLinear.make_row_view()` views the weight rows instead.

**PBM is legal because the merge and `W_V` commute.** The merge is a per-`(token, head)` **scalar** weighting plus a cross-rank sum; `W_V` is a per-head **linear** map, so order does not change the result — only the payload, which drops by `kv_lora_rank / v_head_dim` (4x on DeepSeek, 2x on GLM-5.2). Cost is a DCP-group copy of `W_V` (+0.46 GB/rank on R1, +0.63 GB on GLM-5.2). Applies to decode **and** sparse prefill, and is worth more in prefill, where the merge carries `num_tokens` rows rather than `batch` rows.

**A2A packs the LSE into the output buffer.** One `all_to_all_single` carries both, then each rank combines locally. Byte count is roughly unchanged — **the saving is one collective's launch and sync**. Into a bf16 buffer the fp32 LSE is bit-packed as two raw 16-bit halves. Equivalent math, **not bitwise identical** (summation order differs, and the LSE round-trips through that split).

**Gating lives at the layer, so the knobs can default on without breaking mixed runs.**

| Knob | Auto-disabled when | Why |
|---|---|---|
| QREP | `dcp <= 1`, speculative decode, fp4 mxfp4 BMM | no AllGather to remove / `qlen>1` cprr path / different scale structure |
| PBM | `dcp <= 1`, fp4 mxfp4 BMM | fp4 `W_V` scale is block-structured, so "dequant → gather → requantize once" does not carry over |
| A2A | — | merges the attention output, independent of how BMM weights are quantized |


## 4. Test 

1. **Unit tests** — commutation of `W_V` with the merge, the empty-rank NaN scrub (mutation-tested), A2A vs AG+RS equivalence, LSE 16-bit split round-trip, no-DCP-group short circuit, config validation.
2. **Accuracy** — gsm8k `nshot=20` (full 1319), each configuration run against `ag_rs` as an explicit control. Chosen to cover the axes that differ structurally: `qlen=1` vs `qlen>1` (MTP), dense vs sparse, bf16 vs fp8 KV, and the fp4 path where QREP and PBM gate themselves off.
3. **Operator microbenchmark** — merge op alone, 8-rank torchrun, `bs=32` (offline profile working point) and `bs=128` (benchmark concurrency).
4. **Per-optimization e2e perf** — A/B on four scenarios per optimization, with per-scenario noise calibrated from repeat runs of the same configuration first.
5. **Whole-stack e2e** — the KV-wall workload (`in=32768 out=8192`, concurrency at the point where the prompt working set is ~2.7x the tp8 KV pool, cold pass then warm pass against the same server), all three knobs off vs on.


### 4.1 Unit tests

```bash
PYTHONPATH=/path/to/aiter python -m pytest tests/test_dcp_merge_ops.py -q
# 152 passed in 6.82s   (no skips -- the two GPU-gated tests executed)
```

### 4.2 Accuracy (gsm8k, nshot=20, full 1319)

| Configuration | `a2a` | `ag_rs` (control) | Δ |
|---|---|---|---|
| GLM-5.2 sparse / bf16 / `qlen=1` | 0.9492 ± 0.0060 | 0.9469 ± 0.0062 | +0.0023 |
| DeepSeek-R1 dense / fp8 / MTP=3 (`qlen>1`) | 0.9530 ± 0.0058 | 0.9538 ± 0.0058 | −0.0008 |
| GLM-5.2 sparse / fp8 / QREP on | 0.9386 ± 0.0066 | 0.9363 ± 0.0067 | +0.0023 |
| DeepSeek-R1-MXFP4 (QREP + PBM auto-off, A2A on) | 0.9469 ± 0.0062 | 0.9530 ± 0.0058 | −0.0061 |


### 4.3 A2A end-to-end A/B (QREP + PBM on in both arms)

Bare RCCL `all_to_all` vs the two custom collectives: **9–19% faster**, both cudagraph-capturable, `max|diff| = 0.0000` against the AG+RS reference.

| Scenario | spread (tput / TTFT) | Δ tput | Δ med TTFT | **Δ med ITL** |
|---|---|---|---|---|
| R1 fp8 8k1k | 1.6% / 4.2% | −1.05% | +4.07% | **−1.18%** |
| GLM fp8 8k1k | 0.2% / 0.02% | +1.77% | −1.90% | **−1.38%** |
| GLM fp8 8k8k | 3.0% / 3.7% | +0.44% | −1.62% | −0.07% |
| GLM fp8 32k8k | — | +1.45% | −1.58% | **−1.34%** |

Throughput only clears the noise floor in the most repeatable scenario. **Median ITL is negative in all four and clusters at −1.2 ~ −1.4%** — the right metric to read, since ITL is pure decode-step time and the merge lives only in the decode step, while throughput dilutes it with prefill, scheduling and MoE.

### 4.4 project-before-merge(PBM) end-to-end (vs PBM off)

| Scenario | Δ throughput | Δ med TTFT | Δ med ITL |
|---|---|---|---|
| R1 dense fp8 8k1k | **+4.89%** | +0.73% | −8.91% |
| GLM sparse fp8 8k1k | **+3.16%** | −3.50% | −1.62% |
| GLM sparse fp8 8k8k | **+2.50%** | −3.68% | −2.12% |
| GLM sparse fp8 32k8k | **+1.89%** | −3.89% | −0.96% |

Benefit falls as context grows: attention itself gets more expensive, diluting the merge's share of the step.

### 4.5 Q replication end-to-end (vs QREP off)

All rows are measured **with the prefill row view in place** — without it prefill pays `dcp`x the q_proj GEMM (+14.8 ms/step on GLM-5.2 tp8/dcp8) and TTFT regresses.

| Scenario | out/in | Δ throughput | Δ med TTFT | Δ med ITL |
|---|---|---|---|---|
| GLM sparse bf16 8k1k | 0.125 | **+3.24%** | +0.10% | −10.18% |
| GLM sparse bf16 8k8k | 1.0 | **+8.07%** | −0.05% | −9.43% |
| GLM sparse bf16 32k32k | 1.0 (4x context) | **+7.68%** | −0.07% | −7.76% |
| R1 dense fp8 8k8k | 1.0 | **+8.80%** | −2.23% (n.s.) | −8.67% |

Three things this shows:

1. **Benefit tracks the decode share.** `out/in` from 0.125 to 1.0 takes throughput from +3.24% to +8.07%. QREP removes one collective per *decode* step, so a TTFT-dominated scenario dilutes it.
2. **ITL benefit shrinks as context grows** (−10.18% at 8k ctx → −7.76% at 32k). The AllGather Q payload is `∝ B x H` and independent of sequence length, while the rest of the step grows with it. **QREP optimizes a fixed per-step cost; it does not scale with the problem.**
3. **Dense and sparse agree** (+8.80% vs +8.07% throughput, −8.67% vs −9.43% ITL).

### 4.6 Whole stack, KV-wall workload

`in=32768 out=8192`, fp8 KV, `util=0.8`. Concurrency per model is chosen so the prompt working set is ~2.7x that model's tp8 KV pool — the point where prefix cache collapses to zero hits. A fixed concurrency would measure a different point on the curve for each model.

**DeepSeek-R1** (dense MLA, `conc=320`) — three arms in one sweep, one tree, one node:

| | tp8 cold | tp8 warm | base cold | base warm | **opt cold** | **opt warm** |
|---|---|---|---|---|---|---|
| Output tok/s | 1630.04 | 1637.10 | 2609.16 | 3545.81 | **2897.85** | **4095.57** |
| Mean TTFT (ms) | 562 404 | 571 160 | 179 791 | 87 285 | **179 552** | **87 258** |
| Median TPOT (ms) | 54.05 | 53.88 | 100.70 | 78.75 | **88.50** | **66.77** |
| Median ITL (ms) | 43.12 | 43.04 | 78.41 | 78.25 | **66.33** | **66.25** |
| prefix-cache hit | 1/320 | 1/320 | 1/320 | **320/320** | 1/320 | **320/320** |

`base` = all three knobs off (https://github.com/ROCm/ATOM/pull/1832); `opt` = all three on.

| `base → opt` | throughput cold / warm | **median ITL cold / warm** | mean TTFT cold |
|---|---|---|---|
| **DeepSeek-R1** (dense, same sweep) | +11.06% / +15.50% | **−15.41% / −15.34%** | −0.13% |
| GLM-5.2 (sparse, cross-run) | +11.43% / +15.88% | **−14.83% / −14.98%** | −7.32% |
| DeepSeek-V3.2 (sparse, cross-run) | +19.58% / +17.42% | **−16.50% / −15.66%** | −16.31% |

Six median-ITL numbers across three models and both attention paths all land in **−14.8% ~ −16.5%**.

**TTFT improves only on sparse, and that is the expected result rather than an inconsistency.** Only sparse prefill goes through the DCP merge (`attention_mla.py`, gated on `is_sparse_mla and dcp_world_size > 1`); dense prefill does not enter that branch at all. R1 is therefore a negative control: the one model without a prefill merge is the one whose TTFT does not move.

**DCP's per-step penalty and the cold-pass verdict:**

| Median ITL, `dcp8 / tp8` | base | opt |
|---|---|---|
| R1 dense | 1.82x | **1.54x** |
| GLM-5.2 sparse | 2.37x | **2.13x** |
| V3.2 sparse | 2.41x | **2.10x** |

| Cold-pass `dcp8 / tp8` throughput | base | opt |
|---|---|---|
| R1 dense | 1.601x | **1.778x** |
| V3.2 sparse | 0.865x (DCP loses) | **1.032x** |

## 5. Known Limitations

1. **The vLLM plugin decode path is not covered.** `atom/plugin/vllm/attention/layer_mla.py` still runs the original merge; only the ATOM server path is changed.
2. **QREP costs KV budget**: replicating query heads shrinks the pool by roughly 5% (R1 tp8/dcp8: 235 016 → 221 020 blocks). PBM costs a `W_V` copy (+0.46 GB/rank on R1, +0.63 GB on GLM-5.2). Both are worth it at these context lengths but are not free.
3. **Not wired for speculative decode or fp4** — QREP gates off for both, PBM for fp4. Those paths fall back to the previous behaviour and are covered by the accuracy table above, but they get none of the speedup.
4. **A2A is not bitwise identical to `ag_rs`** by construction. Tests assert equivalence within tolerance, not equality.

## Submission Checklist
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
