### PR TITLE
[ATOM][DPA][Bugfix] Take dp_size into account when prepare topk buffer in DPA TP-MoE scenario

### DIFF
--- a/atom/model_ops/fused_moe/config.py
+++ b/atom/model_ops/fused_moe/config.py
@@ -360,3 +360,24 @@ class FusedMoEConfig:
     @property
     def use_mori_kernels(self):
         return self.moe_parallel_config.use_mori_kernels
+
+
+def moe_kernel_token_capacity(
+    atom_config,
+    *,
+    dp_size: int,
+    use_all2all: bool,
+    dp_logical_ratio: int = 1,
+) -> int:
+    """Token rows MoE kernels must reserve for this rank.
+
+    DP-attention + TP MoE all-gathers hidden states across DP ranks before
+    routing. AITER fused-shared-expert topK metadata is a single preallocated
+    ``[T, topk+shared]`` buffer, so ``T`` must cover the gathered width:
+    ``max_num_batched_tokens * dp_size`` (times the simulated-DP repeat).
+    All2all/EP keeps tokens local, so the per-rank scheduler budget is enough.
+    """
+    tokens = atom_config.max_num_batched_tokens
+    if atom_config.enable_dp_attention and dp_size > 1 and not use_all2all:
+        tokens *= dp_size * max(int(dp_logical_ratio), 1)
+    return tokens

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -36,6 +36,7 @@ from atom.model_ops.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEQuantConfig,
     fp8_w8a8_moe_quant_config,
+    moe_kernel_token_capacity,
     mxfp4_w4a8_moe_quant_config,
     mxfp4_w4a16_moe_quant_config,
 )
@@ -2814,6 +2815,12 @@ class FusedMoE(torch.nn.Module):
                 self.expert_mask[start : start + self.local_num_experts] = 1
             else:
                 self.expert_mask = (self.expert_map > -1).to(torch.int32)
+        moe_token_capacity = moe_kernel_token_capacity(
+            atom_config,
+            dp_size=self.moe_parallel_config.dp_size,
+            use_all2all=self.moe_parallel_config.use_all2all_kernels,
+            dp_logical_ratio=self.moe_parallel_config.dp_logical_ratio,
+        )
         if self.expert_layout.mode is SharedExpertMode.LEGACY_AITER:
             init_aiter_topK_meta_data(
                 n_routed_experts=num_experts,
@@ -2826,7 +2833,7 @@ class FusedMoE(torch.nn.Module):
                     if is_rocm_aiter_fuse_routed_scaling_factor()
                     else 1 / self.routed_scaling_factor
                 ),
-                max_num_tokens=atom_config.max_num_batched_tokens,
+                max_num_tokens=moe_token_capacity,
                 is_EP=self.use_ep,
             )
         assert intermediate_size % self.tp_size == 0
@@ -2873,7 +2880,7 @@ class FusedMoE(torch.nn.Module):
             expert_layout=self.expert_layout,
             in_dtype=atom_config.torch_dtype,
             a_quant_dtype=a_quant_dtype,
-            max_num_tokens=atom_config.max_num_batched_tokens,
+            max_num_tokens=moe_token_capacity,
             has_bias=self.has_bias,
             # is_act_and_mul=True,
             is_lora_enabled=False,

--- a/tests/model_ops/test_moe_dp_token_capacity.py
+++ b/tests/model_ops/test_moe_dp_token_capacity.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from atom.model_ops.fused_moe.config import moe_kernel_token_capacity
+
+
+@pytest.mark.parametrize(
+    "mbt, enable_dpa, dp_size, use_all2all, dp_logical_ratio, expected",
+    [
+        # DPA + TP MoE: all-gather, topK must cover dp * mbt (GLM-5.2 CI: 16384*4).
+        (16384, True, 4, False, 1, 65536),
+        # DPA + EP all2all: topK stays on local tokens, keep per-rank mbt.
+        (16384, True, 4, True, 1, 16384),
+        # No DPA: no gather, capacity stays mbt even if dp_size > 1.
+        (16384, False, 4, False, 1, 16384),
+        # Simulated DP: gathered width also multiplies dp_logical_ratio.
+        (1024, True, 2, False, 2, 4096),
+    ],
+)
+def test_moe_kernel_token_capacity(
+    mbt, enable_dpa, dp_size, use_all2all, dp_logical_ratio, expected
+):
+    cfg = SimpleNamespace(max_num_batched_tokens=mbt, enable_dp_attention=enable_dpa)
+    assert (
+        moe_kernel_token_capacity(
+            cfg,
+            dp_size=dp_size,
+            use_all2all=use_all2all,
+            dp_logical_ratio=dp_logical_ratio,
+        )
+        == expected
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="topK metadata is CUDA")
+def test_dpa_capacity_fits_gathered_topk_metadata():
+    import atom.model_ops.topK as topK_mod
+
+    cfg = SimpleNamespace(max_num_batched_tokens=16384, enable_dp_attention=True)
+    cap = moe_kernel_token_capacity(cfg, dp_size=4, use_all2all=False)
+    topK_mod.init_aiter_topK_meta_data.cache_clear()
+    topK_mod.init_aiter_topK_meta_data(
+        n_routed_experts=160,
+        n_shared_experts=1,
+        top_k=8,
+        tp_rank=0,
+        tp_size=1,
+        max_num_tokens=cap,
+        is_EP=False,
+    )
+    weights, ids = topK_mod.aiter_topK_meta_data
+    assert weights.shape[0] >= 65536
+    assert ids.shape[0] >= 65536


### PR DESCRIPTION
## Motivation

DP-attention + TP MoE all-gathers hidden states across DP ranks before routing. AITER fused-shared-expert topK metadata and `FusedMoEConfig.max_num_tokens` were still sized to the local scheduler budget (`max_num_batched_tokens`). Dummy / warmup then feeds the gathered width (`dp * mnbt`) into those buffers and asserts.

### Reproduction Scripts
This showed up on GLM-5.2 MXFP4 ATOMesh DPA CI (`-tp 4 --enable-dp-attention`, default `mbt=16384`): prefill died at model-runner load with `topK meta data support 16384 tokens ... got 65536`. 

```bash
export ROLE_IP=$(hostname -I | awk '{print $1}')
export MODEL=/mnt/models/GLM-5.2-MXFP4

export AITER_LOG_LEVEL=WARNING
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export AITER_USE_FLYDSL_MOE_SORTING=1
export ATOM_PD_RANK_MAPPING_POLICY=none
export PYTHONHASHSEED=0
export PYTHONUNBUFFERED=1

export HIP_VISIBLE_DEVICES=0,1,2,3
export ATOM_HOST_IP="${ROLE_IP}"
export LMCACHE_LOCAL_CPU=True
export LMCACHE_MAX_LOCAL_CPU_SIZE=256
export LMCACHE_CHUNK_SIZE=256

python3 -m atom.entrypoints.openai_server \
  --model "${MODEL}" \
  --host 0.0.0.0 \
  --trust-remote-code \
  --kv_cache_dtype fp8 \
  --block-size 16 \
  --gpu-memory-utilization 0.9 \
  --online_quant_config '{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate","*expert*"]}' \
  --server-port 8010 \
  -tp 4 \
  --max-num-seqs 512 \
  --kv-transfer-config "{\"kv_connector\":\"multi\",\"connectors\":[{\"kv_connector\":\"mooncake\",\"kv_role\":\"kv_producer\",\"proxy_ip\":\"${ROLE_IP}\",\"handshake_port\":6301},{\"kv_connector\":\"lmcache_offload\",\"kv_role\":\"offload\"}]}" \
  --enable-dp-attention \
  --attn-prefill-chunk-size 131072 \
  --long-prefill-token-threshold 131072
```
### Error Log
https://github.com/ROCm/ATOM/actions/runs/32682635923/job/9730194070

## Technical Details

Add `moe_kernel_token_capacity()` in `atom/model_ops/fused_moe/config.py`:

- DPA + TP MoE (no all2all): `mnbt * dp_size * max(dp_logical_ratio, 1)` so the buffer covers the post-gather batch (including simulated-DP repeat).
- DPA + EP all2all, or no DPA: keep `mnbt`. All2all does not multiply by `dp`; per-rank send/topK budget stays the local scheduler size.

## Test Plan

- [x] `python -m pytest tests/model_ops/test_moe_dp_token_capacity.py`
  - DPA + TP gather: `16384 * 4 → 65536`
  - DPA + EP all2all: stays `16384`
  - no DPA: stays `16384`
  - simulated DP: `1024 * 2 * 2 → 4096`
  - CUDA (when available): topK metadata rows `>= 65536` for the gather case
- [x] Local GLM-5.2 MXFP4 1P1D TP4 DPA prefill that previously hit the 16384/65536 assert; with this change the engine loads and PD chat via the mesh router succeeds

## Test Result

Unit tests: 4 CPU cases passed; CUDA topK case skipped without GPU in the sandbox, passed on a GPU box.

Repro:  test with glm-5.2-mxfp4-glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c32-nightly

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
