### PR TITLE
feat(dspark): fp8 block attention through the target's asm decode kernel

### DIFF
--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -33,6 +33,7 @@ import triton
 import triton.language as tl
 
 from atom.model_ops.attentions.v4_pool_geometry import WindowParams
+from atom.model_ops.v4_kernels.pool_index import window_constexprs, window_row
 
 
 def _ring_rows(
@@ -206,12 +207,12 @@ def _dspark_index_kernel(
     draft_rows_ptr,  # [B*T] int32 out
     out_ptr,  # [capacity] int32 out
     B,
+    ring_start,
     T: tl.constexpr,
     W: tl.constexpr,
     RING_SLOTS: tl.constexpr,
-    RING_STRIDE: tl.constexpr,
-    RING_START: tl.constexpr,
     SLOT_ROWS: tl.constexpr,
+    RING_STRIDE: tl.constexpr,
     RUN_ROWS: tl.constexpr,
     BLOCK_B: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -252,26 +253,24 @@ def _dspark_index_kernel(
         tl.store(kv_indptr_ptr + B * T, tl.sum(per_req).to(tl.int32))
 
     # This row's own draft KV lands at absolute position anchor+1+t.
-    draft_ring = (anchor + 1 + t) % RING_SLOTS
     tl.store(
         draft_rows_ptr + i,
-        (
-            slot * SLOT_ROWS
-            + RING_START
-            + (draft_ring // RING_STRIDE) * RUN_ROWS
-            + (draft_ring % RING_STRIDE)
+        window_row(
+            slot,
+            anchor + 1 + t,
+            ring_start,
+            RING_SLOTS,
+            SLOT_ROWS,
+            RING_STRIDE,
+            RUN_ROWS,
         ).to(tl.int32),
     )
 
     j = tl.arange(0, BLOCK_K)
     in_window = j < n_valid
     pos = tl.where(in_window, anchor - n_valid + 1 + j, anchor + 1 + (j - n_valid))
-    ring = pos % RING_SLOTS
-    row = (
-        slot * SLOT_ROWS
-        + RING_START
-        + (ring // RING_STRIDE) * RUN_ROWS
-        + (ring % RING_STRIDE)
+    row = window_row(
+        slot, pos, ring_start, RING_SLOTS, SLOT_ROWS, RING_STRIDE, RUN_ROWS
     )
     tl.store(out_ptr + start + j, row.to(tl.int32), mask=j < length)
 
@@ -376,13 +375,6 @@ def dspark_build_indices(
     anchors_i64 = anchors.to(torch.int64)
     slots_i64 = slots.to(torch.int64)
 
-    ring = dict(
-        RING_SLOTS=window.ring_slots,
-        RING_STRIDE=window.ring_stride,
-        RING_START=window.ring_start,
-        SLOT_ROWS=window.slot_rows,
-        RUN_ROWS=window.run_rows,
-    )
     _dspark_index_kernel[(B * T,)](
         anchors_i64,
         slots_i64,
@@ -390,9 +382,10 @@ def dspark_build_indices(
         draft_rows,
         out_indices,
         B,
+        window.ring_start,
         T=T,
         W=W,
-        **ring,
+        **window_constexprs(window),
         BLOCK_B=triton.next_power_of_2(B),
         BLOCK_K=triton.next_power_of_2(W + T),
     )

--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Index construction for the DSpark FP8 block attention path.
+
+The fp8 draft path feeds `aiter.mla.mla_decode_fwd_v4_nm` (through
+`sparse_attn_v4_paged_decode`) instead of the bf16 Triton `sparse_attn`. That
+kernel addresses KV as one pool of rows plus a CSR index list per query row, so
+the `[window ++ draft-block]` KV DSpark attends to has to be expressed as pool
+row ids rather than a materialised `[B, W+T, 512]` tensor.
+
+Two things are built here:
+
+- `dspark_draft_dest_rows` — the ring rows the draft block's own KV is scattered
+  into, fused into the `qk_norm_rope_maybe_quant` launch that produces it.
+- `dspark_build_kv_indices` — the ragged CSR (`kv_indices`, `kv_indptr`) plus
+  `qo_indptr`, laid out one query row per draft position, `N = B*T` rows.
+
+Both are pure tensor ops with statically-known shapes: no `.item()`, no
+data-dependent allocation, so a captured CUDA graph replays them. Invalid grid
+cells are funnelled into a trailing dump slot rather than compacted, which is
+what keeps the shapes static.
+
+The `[B,T,W+T]` gather indices the bf16 path uses (`_dspark_block_topk_idxs`)
+are a broadcast along T — every draft position attends to the identical set — so
+one KV list per request is sufficient here, which is exactly what CSR expresses.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from atom.model_ops.attentions.v4_pool_geometry import WindowParams
+
+
+def _ring_rows(
+    window: WindowParams, slots: torch.Tensor, pos: torch.Tensor
+) -> torch.Tensor:
+    """Vectorised `WindowParams.index`: pool row for each (slot, position).
+
+    ``slots`` broadcasts against ``pos``. Mirrors the scalar form in
+    `v4_pool_geometry.py` and the Triton twin in `pool_index.py`; positions must
+    be >= 0, since Python and Triton disagree on the sign of a negative modulo
+    and the callers below mask before they get here.
+    """
+    ring = pos % window.ring_slots
+    chunk = ring // window.ring_stride
+    within = ring % window.ring_stride
+    return (
+        slots * window.slot_rows + window.ring_start + chunk * window.run_rows + within
+    )
+
+
+def dspark_draft_dest_rows_reference(
+    window: WindowParams,
+    slots: torch.Tensor,  # [B] int, per-request ring slot
+    draft_pos: torch.Tensor,  # [B, T] int, absolute draft positions
+) -> torch.Tensor:  # [B*T] int32
+    """Ring rows for the draft block's own KV, in `draft_pos` order.
+
+    Handed to `qk_norm_rope_maybe_quant(..., swa_dest_rows=)` so the fp8 quant
+    launch scatters the draft KV into the ring in the same pass that computes
+    it. Writing these speculative rows is safe for the same reason
+    `write_context_kv` may write rejected rows (`dspark_proposer.py:372-376`):
+    they land strictly above the anchor, and nothing ever gathers a position
+    above the anchor.
+    """
+    return (
+        _ring_rows(window, slots.view(-1, 1).to(draft_pos.dtype), draft_pos)
+        .to(torch.int32)
+        .view(-1)
+    )
+
+
+def dspark_kv_index_capacity(batch: int, draft: int, window: int) -> int:
+    """Elements to reserve for `kv_indices`, plus the trailing dump slot."""
+    return batch * draft * (window + draft) + 1
+
+
+def dspark_build_kv_indices_reference(
+    window: WindowParams,
+    slots: torch.Tensor,  # [B] int, per-request ring slot
+    anchors: torch.Tensor,  # [B] int, per-request anchor position
+    draft_rows: torch.Tensor,  # [B*T] int32, from dspark_draft_dest_rows
+    draft_width: int,  # T
+    draft_window: int,  # W
+    out_indices: torch.Tensor,  # [>= capacity] int32, preallocated
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build the CSR KV lists for `N = B*T` query rows.
+
+    Row ``b*T + t`` gets request ``b``'s list — the valid rolling-window rows
+    followed by all ``T`` draft rows — so the list repeats ``T`` times per
+    request. That is legal: CSR only requires ``kv_indptr`` to be monotone, and
+    the values inside a slice may repeat across slices.
+
+    A request holds ``n = min(anchor+1, W)`` valid window slots (slot ``s`` maps
+    to absolute position ``anchor-(W-1)+s``, and `_build_block_plan` marks
+    ``s >= (W-1)-anchor`` valid, i.e. exactly the non-negative positions), so
+    per-row length is ``n + T`` and the lists are ragged.
+
+    ``out_indices`` is a fixed-capacity buffer, not a tight one: the kernel only
+    reads ``[kv_indptr[i], kv_indptr[i+1])``, so trailing slack is never touched
+    and the shapes stay static for graph capture.
+
+    Returns ``(kv_indices, kv_indptr)``; build `qo_indptr` with
+    :func:`dspark_qo_indptr`.
+    """
+    B = anchors.shape[0]
+    T, W = draft_width, draft_window
+    device = anchors.device
+    K = W + T
+
+    capacity = dspark_kv_index_capacity(B, T, W)
+    if out_indices.numel() < capacity:
+        raise ValueError(
+            f"DSpark kv_indices buffer holds {out_indices.numel()} < {capacity} "
+            f"needed for B={B} T={T} W={W}."
+        )
+    dump = capacity - 1
+
+    idx = anchors.to(torch.int64)
+    n_valid = torch.clamp(idx + 1, max=W)  # [B]
+
+    # One row per draft position; every row of a request shares its list.
+    n_valid_r = n_valid.view(B, 1).expand(B, T).reshape(B * T, 1)
+    anchors_r = idx.view(B, 1).expand(B, T).reshape(B * T, 1)
+    slots_r = slots.to(torch.int64).view(B, 1).expand(B, T).reshape(B * T, 1)
+
+    lengths = (n_valid_r + T).view(-1)  # [B*T]
+    kv_indptr = torch.zeros(B * T + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(lengths, dim=0).to(torch.int32)
+
+    j = torch.arange(K, device=device, dtype=torch.int64).view(1, K)
+    in_window = j < n_valid_r
+    in_row = j < (n_valid_r + T)
+
+    # Window half: the valid suffix, oldest first. Draft half: the block's own
+    # rows, already resolved to ring rows by `dspark_draft_dest_rows`.
+    win_pos = anchors_r - n_valid_r + 1 + j
+    win_rows = _ring_rows(window, slots_r, torch.clamp(win_pos, min=0))
+    draft_col = torch.clamp(j - n_valid_r, min=0, max=T - 1)
+    draft_rows_r = draft_rows.view(B, T).to(torch.int64)
+    draft_pick = torch.gather(
+        draft_rows_r.view(B, 1, T).expand(B, T, T).reshape(B * T, T), 1, draft_col
+    )
+
+    rows = torch.where(in_window, win_rows, draft_pick).to(torch.int32)
+
+    # Scatter into the ragged buffer. Cells past a row's length go to the dump
+    # slot instead of being compacted, so every shape here is static.
+    dst = kv_indptr[:-1].to(torch.int64).view(-1, 1) + j
+    dst = torch.where(in_row, dst, torch.full_like(dst, dump))
+    out_indices[:capacity].scatter_(0, dst.reshape(-1), rows.reshape(-1))
+
+    return out_indices[:capacity], kv_indptr
+
+
+def dspark_qo_indptr(batch: int, draft: int, device) -> torch.Tensor:
+    """`qo_indptr` for `N = B*T` single-token queries: `arange(N+1)`.
+
+    The asm wrapper runs `max_seqlen_q = 1`, i.e. one "sequence" per query row —
+    the same convention the V4 target's decode metadata uses
+    (`deepseek_v4_attn.py:3727`).
+
+    Cached (`_SCRATCH`, defined below) rather than rebuilt: the value depends
+    only on the shape, so a fresh `arange` per call would be an allocation and a
+    launch per stage per step for a constant. A persistent buffer is also what
+    graph capture wants — a fresh one each forward replays against a dead
+    address.
+    """
+    key = ("qo", batch, draft, str(device))
+    hit = _SCRATCH.get(key)
+    if hit is None:
+        hit = torch.arange(batch * draft + 1, dtype=torch.int32, device=device)
+        _SCRATCH[key] = hit
+    return hit
+
+
+# ---------------------------------------------------------------------------
+# Fused build.
+#
+# The torch spellings above are ~50 elementwise launches (~286us at B=128 T=4
+# W=128 on MI355X) over tensors of at most a few thousand int32 -- launch-bound,
+# and paid once per DSpark stage per step, in front of an attention kernel that
+# reads only W+T rows. `write_v4_paged_decode_indices` is the target's answer to
+# the same problem: derive every index on device in one kernel. This is that,
+# for the draft's `[window ++ draft-block]` list.
+#
+# ONE launch, matching the target's shape. The CSR offsets are a prefix sum over
+# requests and the index fill needs them before it can address its slice -- but
+# the summand is only `min(anchor+1, W) + T`, so a program can rebuild the whole
+# prefix from the `B` anchors itself rather than wait for a separate pass to
+# hand it over. B is the CUDA-graph-padded batch (hundreds of int64), so every
+# program redundantly reducing one BLOCK_B vector is far cheaper than the extra
+# launch and the serialization between the two that it forces.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _dspark_index_kernel(
+    anchors_ptr,  # [B] int64
+    slots_ptr,  # [B] int64
+    kv_indptr_ptr,  # [B*T+1] int32 out
+    draft_rows_ptr,  # [B*T] int32 out
+    out_ptr,  # [capacity] int32 out
+    B,
+    T: tl.constexpr,
+    W: tl.constexpr,
+    RING_SLOTS: tl.constexpr,
+    RING_STRIDE: tl.constexpr,
+    RING_START: tl.constexpr,
+    SLOT_ROWS: tl.constexpr,
+    RUN_ROWS: tl.constexpr,
+    BLOCK_B: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """One program per query row: its CSR offset, its draft ring row, and its
+    whole `[valid window ++ draft block]` list.
+
+    Per-request row length is `min(anchor+1, W) + T` and every draft position of
+    a request shares it, so the CSR offset of row `b*T+t` is
+    `T * exclusive_prefix(len)[b] + t * len[b]`. The prefix is rebuilt here from
+    the anchors instead of read from an earlier kernel -- that is what collapses
+    the build to a single launch (see the note above).
+
+    Window slot `j` is absolute position `anchor-n+1+j` for `n = min(anchor+1,W)`
+    valid slots -- the `p >= 0` suffix `_build_block_plan` marks valid -- and the
+    draft half continues at `anchor+1`. Both are non-negative, which matters:
+    Triton's remainder follows C, so a negative position would not wrap.
+    """
+    i = tl.program_id(0)
+    b = i // T
+    t = i % T
+
+    # Exclusive prefix over requests, recomputed per program.
+    bb = tl.arange(0, BLOCK_B)
+    live = bb < B
+    all_anchors = tl.load(anchors_ptr + bb, mask=live, other=0)
+    per_req = tl.where(live, (tl.minimum(all_anchors + 1, W) + T) * T, 0)
+    base = tl.sum(tl.where(bb == b, tl.cumsum(per_req, axis=0) - per_req, 0))
+
+    anchor = tl.load(anchors_ptr + b)
+    slot = tl.load(slots_ptr + b)
+    n_valid = tl.minimum(anchor + 1, W)
+    length = n_valid + T
+    start = base + t * length
+
+    tl.store(kv_indptr_ptr + i, start.to(tl.int32))
+    if i == 0:
+        tl.store(kv_indptr_ptr + B * T, tl.sum(per_req).to(tl.int32))
+
+    # This row's own draft KV lands at absolute position anchor+1+t.
+    draft_ring = (anchor + 1 + t) % RING_SLOTS
+    tl.store(
+        draft_rows_ptr + i,
+        (
+            slot * SLOT_ROWS
+            + RING_START
+            + (draft_ring // RING_STRIDE) * RUN_ROWS
+            + (draft_ring % RING_STRIDE)
+        ).to(tl.int32),
+    )
+
+    j = tl.arange(0, BLOCK_K)
+    in_window = j < n_valid
+    pos = tl.where(in_window, anchor - n_valid + 1 + j, anchor + 1 + (j - n_valid))
+    ring = pos % RING_SLOTS
+    row = (
+        slot * SLOT_ROWS
+        + RING_START
+        + (ring // RING_STRIDE) * RUN_ROWS
+        + (ring % RING_STRIDE)
+    )
+    tl.store(out_ptr + start + j, row.to(tl.int32), mask=j < length)
+
+
+_SCRATCH: dict = {}
+# Shapes `dspark_build_indices` has actually filled, so a stage that reads the
+# buffers back cannot be handed an uninitialised `torch.empty`.
+_BUILT: set = set()
+
+
+def _scratch(batch: int, draft: int, device):
+    """Persistent `(kv_indptr, draft_rows)` for a shape.
+
+    `write_v4_paged_decode_indices` states the principle for the target's
+    equivalent: "All inputs are persistent forward_vars buffers -- no allocator
+    churn." This path runs once per DSpark stage per step, so a fresh pair of
+    allocations each call is exactly the churn that warns against. Keyed by
+    shape, which is fixed for the process (`T = min(mtp_k, window)`, and B is
+    the CUDA-graph-padded batch).
+    """
+    key = (batch, draft, str(device))
+    hit = _SCRATCH.get(key)
+    if hit is None:
+        n = batch * draft
+        hit = (
+            torch.empty(n + 1, dtype=torch.int32, device=device),
+            torch.empty(n, dtype=torch.int32, device=device),
+        )
+        _SCRATCH[key] = hit
+    return hit
+
+
+def dspark_kv_index_scratch(
+    batch: int, draft: int, window: int, device
+) -> torch.Tensor:
+    """Persistent `kv_indices` buffer for a shape — see :func:`_scratch`."""
+    key = ("idx", batch, draft, window, str(device))
+    hit = _SCRATCH.get(key)
+    if hit is None:
+        hit = torch.empty(
+            dspark_kv_index_capacity(batch, draft, window),
+            dtype=torch.int32,
+            device=device,
+        )
+        _SCRATCH[key] = hit
+    return hit
+
+
+def dspark_indices_view(
+    batch: int, draft: int, window: int, device, out_indices: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Read back what :func:`dspark_build_indices` last wrote for this shape.
+
+    DSpark runs one block through every stage and these indices are
+    stage-invariant (all DSpark layers share compress ratio 0, hence one
+    `WindowParams`, and each layer's plane view is base-row-relative), so stage
+    0 builds and the rest read. The buffers are the shape-keyed persistent ones,
+    so this is pure lookup — no launch, no allocation.
+
+    Freshness comes from call order, not from here: `_DSparkInner.forward` walks
+    the stages in order and stage 0 refills the buffers at the top of every
+    block. What this DOES catch is a stage reading a shape that was never built
+    at all, which would feed the asm kernel a `torch.empty`.
+    """
+    key = (batch, draft, str(device))
+    if key not in _BUILT:
+        raise RuntimeError(
+            f"DSpark kv indices for B={batch} T={draft} on {device} were never "
+            "built; stage 0 must run before any stage reads them back."
+        )
+    kv_indptr, draft_rows = _scratch(batch, draft, device)
+    capacity = dspark_kv_index_capacity(batch, draft, window)
+    return out_indices[:capacity], kv_indptr, draft_rows
+
+
+def dspark_build_indices(
+    window: WindowParams,
+    slots: torch.Tensor,  # [B] per-request ring slot
+    anchors: torch.Tensor,  # [B] per-request anchor position
+    draft_width: int,  # T
+    draft_window: int,  # W
+    out_indices: torch.Tensor,  # [>= capacity] int32, preallocated
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Everything the asm path needs, in one launch.
+
+    Returns ``(kv_indices, kv_indptr, draft_rows)``. Equivalent to
+    :func:`dspark_draft_dest_rows_reference` followed by
+    :func:`dspark_build_kv_indices_reference`; `tests/test_dspark_fp8_indices.py`
+    holds them to that. Build `qo_indptr` with :func:`dspark_qo_indptr`.
+    """
+    B = anchors.shape[0]
+    T, W = draft_width, draft_window
+    capacity = dspark_kv_index_capacity(B, T, W)
+    if out_indices.numel() < capacity:
+        raise ValueError(
+            f"DSpark kv_indices buffer holds {out_indices.numel()} < {capacity} "
+            f"needed for B={B} T={T} W={W}."
+        )
+
+    dev = anchors.device
+    kv_indptr, draft_rows = _scratch(B, T, dev)
+    anchors_i64 = anchors.to(torch.int64)
+    slots_i64 = slots.to(torch.int64)
+
+    ring = dict(
+        RING_SLOTS=window.ring_slots,
+        RING_STRIDE=window.ring_stride,
+        RING_START=window.ring_start,
+        SLOT_ROWS=window.slot_rows,
+        RUN_ROWS=window.run_rows,
+    )
+    _dspark_index_kernel[(B * T,)](
+        anchors_i64,
+        slots_i64,
+        kv_indptr,
+        draft_rows,
+        out_indices,
+        B,
+        T=T,
+        W=W,
+        **ring,
+        BLOCK_B=triton.next_power_of_2(B),
+        BLOCK_K=triton.next_power_of_2(W + T),
+    )
+    _BUILT.add((B, T, str(dev)))
+    return out_indices[:capacity], kv_indptr, draft_rows

--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -9,14 +9,14 @@ kernel addresses KV as one pool of rows plus a CSR index list per query row, so
 the `[window ++ draft-block]` KV DSpark attends to has to be expressed as pool
 row ids rather than a materialised `[B, W+T, 512]` tensor.
 
-`dspark_build_indices` fills, in one launch:
+`DSparkIndexBuffers.build` fills, in one launch:
 
 - `kv_indices` / `kv_indptr` — the ragged CSR, one query row per draft position,
   `N = B*T` rows.
 - `draft_rows` — the ring rows the draft block's own KV is scattered into, fused
   into the `qk_norm_rope_maybe_quant` launch that produces it.
 
-and `dspark_index_views` reads them back.
+and `DSparkIndexBuffers.views` reads them back.
 
 `qo_indptr` and the scatter's `batch_ids` are constants that ride in the same
 `DSparkIndexBuffers` bundle. Everything is allocated once at `max_num_seqs` and
@@ -146,105 +146,100 @@ class DSparkIndexBuffers:
     draft_window: int  # W
     built_for: int = -1
 
+    @classmethod
+    def allocate(
+        cls, max_batch: int, draft: int, window: int, device
+    ) -> DSparkIndexBuffers:
+        """Allocate the bundle for the largest batch (`draft` = T, `window` = W).
 
-def dspark_index_buffers(
-    max_batch: int, draft: int, window: int, device
-) -> DSparkIndexBuffers:
-    """Allocate :class:`DSparkIndexBuffers` for a process's largest batch.
+        `qo_indptr` is `arange(N+1)`: the asm wrapper runs `max_seqlen_q = 1`, one
+        "sequence" per query row -- the same per-token convention the V4 target uses
+        for its own decode AND verify forwards (`deepseek_v4_attn.py:3727`).
 
-    `qo_indptr` is `arange(N+1)`: the asm wrapper runs `max_seqlen_q = 1`, one
-    "sequence" per query row -- the same per-token convention the V4 target uses
-    for its own decode AND verify forwards (`deepseek_v4_attn.py:3727`).
-
-    `batch_ids` is the token -> request map the fused SWA scatter gates on
-    (`bid >= 0`). It carries no CG-pad sentinels, and needs none: the draft runs
-    at `context.batch_size`, which is `scheduled_bs`, the REAL decode batch
-    (`model_runner.py:2609`) -- not the padded `effective_bs` the target's
-    metadata is built at. The target can alias `cu_seqlens_q[:bs]` for its own
-    (`deepseek_v4_attn.py:2348`) because at one token per sequence that slice is
-    already `arange(bs)`; DSpark runs T tokens per request and needs each id
-    repeated T times, so there is nothing to alias.
-    """
-    n = max_batch * draft
-    i32 = {"dtype": torch.int32, "device": device}
-    return DSparkIndexBuffers(
-        kv_indices=torch.empty(n * (window + draft), **i32),
-        kv_indptr=torch.empty(n + 1, **i32),
-        draft_rows=torch.empty(n, **i32),
-        qo_indptr=torch.arange(n + 1, **i32),
-        batch_ids=torch.arange(max_batch, **i32)
-        .view(max_batch, 1)
-        .expand(max_batch, draft)
-        .reshape(-1)
-        .contiguous(),
-        max_batch=max_batch,
-        draft_width=draft,
-        draft_window=window,
-    )
-
-
-def _slices(bufs: DSparkIndexBuffers, batch: int):
-    n = batch * bufs.draft_width
-    return (
-        bufs.kv_indices[: n * (bufs.draft_window + bufs.draft_width)],
-        bufs.kv_indptr[: n + 1],
-        bufs.draft_rows[:n],
-    )
-
-
-def dspark_index_views(
-    bufs: DSparkIndexBuffers, batch: int
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """The `(kv_indices, kv_indptr, draft_rows)` a built bundle holds.
-
-    The one accessor: :func:`dspark_build_indices` only fills, and every stage
-    -- including the one that filled -- reads through here. DSpark runs one
-    block through every stage and the values are stage-invariant (all DSpark
-    layers share compress ratio 0, hence one `WindowParams`, and each layer's
-    plane view is base-row-relative), so stage 0 builds and the rest just slice.
-    """
-    if bufs.built_for != batch:
-        raise RuntimeError(
-            f"DSpark kv indices hold batch {bufs.built_for}, not {batch}; "
-            "stage 0 must build them before any stage reads them back."
+        `batch_ids` is the token -> request map the fused SWA scatter gates on
+        (`bid >= 0`). It carries no CG-pad sentinels, and needs none: the draft runs
+        at `context.batch_size`, which is `scheduled_bs`, the REAL decode batch
+        (`model_runner.py:2609`) -- not the padded `effective_bs` the target's
+        metadata is built at. The target can alias `cu_seqlens_q[:bs]` for its own
+        (`deepseek_v4_attn.py:2348`) because at one token per sequence that slice is
+        already `arange(bs)`; DSpark runs T tokens per request and needs each id
+        repeated T times, so there is nothing to alias.
+        """
+        n = max_batch * draft
+        i32 = {"dtype": torch.int32, "device": device}
+        return cls(
+            kv_indices=torch.empty(n * (window + draft), **i32),
+            kv_indptr=torch.empty(n + 1, **i32),
+            draft_rows=torch.empty(n, **i32),
+            qo_indptr=torch.arange(n + 1, **i32),
+            batch_ids=torch.arange(max_batch, **i32)
+            .view(max_batch, 1)
+            .expand(max_batch, draft)
+            .reshape(-1)
+            .contiguous(),
+            max_batch=max_batch,
+            draft_width=draft,
+            draft_window=window,
         )
-    return _slices(bufs, batch)
 
+    def build(
+        self,
+        window: WindowParams,
+        slots: torch.Tensor,  # [B] per-request ring slot
+        anchors: torch.Tensor,  # [B] per-request anchor position
+    ) -> None:
+        """Fill this bundle for one block, in one launch. Read it with :meth:`views`.
 
-def dspark_build_indices(
-    window: WindowParams,
-    slots: torch.Tensor,  # [B] per-request ring slot
-    anchors: torch.Tensor,  # [B] per-request anchor position
-    bufs: DSparkIndexBuffers,
-) -> None:
-    """Fill `bufs` for this block, in one launch. Read it with
-    :func:`dspark_index_views`.
+        `T` and `W` come from the bundle, so the slices can never be cut to a shape
+        the buffers were not allocated for.
+        """
+        B = anchors.shape[0]
+        T, W = self.draft_width, self.draft_window
+        if B > self.max_batch:
+            raise ValueError(
+                f"DSpark index buffers hold {self.max_batch} requests < B={B}; "
+                "they are sized at max_num_seqs."
+            )
+        kv_indices, kv_indptr, draft_rows = self._ragged(B)
 
-    `T` and `W` come from the bundle, so a slice can never be cut to a shape the
-    buffers were not allocated for.
-    """
-    B = anchors.shape[0]
-    T, W = bufs.draft_width, bufs.draft_window
-    if B > bufs.max_batch:
-        raise ValueError(
-            f"DSpark index buffers hold {bufs.max_batch} requests < B={B}; "
-            "they are sized at max_num_seqs."
+        _dspark_index_kernel[(B * T,)](
+            anchors.to(torch.int64),
+            slots.to(torch.int64),
+            kv_indptr,
+            draft_rows,
+            kv_indices,
+            B,
+            window.ring_start,
+            T=T,
+            W=W,
+            **window_constexprs(window),
+            BLOCK_B=triton.next_power_of_2(B),
+            BLOCK_K=triton.next_power_of_2(W + T),
         )
-    kv_indices, kv_indptr, draft_rows = _slices(bufs, B)
+        # Last: a launch that raised must not leave the bundle claiming a batch.
+        self.built_for = B
 
-    _dspark_index_kernel[(B * T,)](
-        anchors.to(torch.int64),
-        slots.to(torch.int64),
-        kv_indptr,
-        draft_rows,
-        kv_indices,
-        B,
-        window.ring_start,
-        T=T,
-        W=W,
-        **window_constexprs(window),
-        BLOCK_B=triton.next_power_of_2(B),
-        BLOCK_K=triton.next_power_of_2(W + T),
-    )
-    # Last: a launch that raised must not leave the bundle claiming a batch.
-    bufs.built_for = B
+    def views(self, batch: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """The `(kv_indices, kv_indptr, draft_rows)` this built bundle holds.
+
+        The one accessor: :meth:`build` only fills, and every stage -- including the
+        one that filled -- reads through here. DSpark runs one block through every
+        stage and the values are stage-invariant (all DSpark layers share compress
+        ratio 0, hence one `WindowParams`, and each layer's plane view is
+        base-row-relative), so stage 0 builds and the rest just slice.
+        """
+        if self.built_for != batch:
+            raise RuntimeError(
+                f"DSpark kv indices hold batch {self.built_for}, not {batch}; "
+                "stage 0 must build them before any stage reads them back."
+            )
+        return self._ragged(batch)
+
+    def _ragged(self, batch: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """The three built buffers sliced to `batch`, unchecked (see :meth:`views`)."""
+        n = batch * self.draft_width
+        return (
+            self.kv_indices[: n * (self.draft_window + self.draft_width)],
+            self.kv_indptr[: n + 1],
+            self.draft_rows[:n],
+        )

--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -16,10 +16,10 @@ row ids rather than a materialised `[B, W+T, 512]` tensor.
 - `draft_rows` — the ring rows the draft block's own KV is scattered into, fused
   into the `qk_norm_rope_maybe_quant` launch that produces it.
 
-`qo_indptr` comes from `dspark_qo_indptr`. Shapes are statically known: no
-`.item()`, no data-dependent allocation, so a captured CUDA graph replays it.
-The buffers are shape-keyed and persistent, and the capacity is the worst case
-rather than a tight fit, so trailing slack is simply never read.
+`qo_indptr` and the scatter's `batch_ids` are constants that ride in the same
+`DSparkIndexBuffers` bundle. Everything is allocated once at `max_num_seqs` and
+only ever sliced, and shapes are statically known -- no `.item()`, no
+data-dependent allocation -- so a captured CUDA graph replays it.
 
 The pool row formula is not restated here -- the kernel calls
 `pool_index.window_row`, which is what that module exists for.
@@ -31,55 +31,14 @@ one KV list per request is sufficient here, which is exactly what CSR expresses.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import torch
 import triton
 import triton.language as tl
 
 from atom.model_ops.attentions.v4_pool_geometry import WindowParams
 from atom.model_ops.v4_kernels.pool_index import window_constexprs, window_row
-
-
-def dspark_kv_index_capacity(batch: int, draft: int, window: int) -> int:
-    """Elements to reserve for `kv_indices`, plus the trailing dump slot."""
-    return batch * draft * (window + draft) + 1
-
-
-def dspark_qo_indptr(batch: int, draft: int, device) -> torch.Tensor:
-    """`qo_indptr` for `N = B*T` single-token queries: `arange(N+1)`.
-
-    The asm wrapper runs `max_seqlen_q = 1`, i.e. one "sequence" per query row —
-    the same convention the V4 target's decode metadata uses
-    (`deepseek_v4_attn.py:3727`).
-
-    Cached (`_SCRATCH`, defined below) rather than rebuilt: the value depends
-    only on the shape, so a fresh `arange` per call would be an allocation and a
-    launch per stage per step for a constant. A persistent buffer is also what
-    graph capture wants — a fresh one each forward replays against a dead
-    address.
-    """
-    key = ("qo", batch, draft, str(device))
-    hit = _SCRATCH.get(key)
-    if hit is None:
-        hit = torch.arange(batch * draft + 1, dtype=torch.int32, device=device)
-        _SCRATCH[key] = hit
-    return hit
-
-
-# ---------------------------------------------------------------------------
-# Fused build.
-#
-# Spelled as torch ops this is ~50 elementwise launches (~286us at B=128 T=4
-# W=128 on MI355X) over a few thousand int32 -- launch-bound, in front of an
-# attention kernel that reads only W+T rows. `write_v4_paged_decode_indices` is
-# the target's answer to the same problem, and this is that for the draft's
-# `[window ++ draft-block]` list.
-#
-# ONE launch. The fill needs the CSR offsets before it can address its slice,
-# but the summand is only `min(anchor+1, W) + T`, so a program rebuilds the
-# whole prefix from the B anchors itself instead of waiting on a second kernel.
-# B is the CG-padded batch, so that redundant BLOCK_B reduction is far cheaper
-# than the extra launch and the serialization it forces.
-# ---------------------------------------------------------------------------
 
 
 @triton.jit
@@ -158,75 +117,85 @@ def _dspark_index_kernel(
     tl.store(out_ptr + start + j, row.to(tl.int32), mask=j < length)
 
 
-_SCRATCH: dict = {}
-# Shapes `dspark_build_indices` has actually filled, so a stage that reads the
-# buffers back cannot be handed an uninitialised `torch.empty`.
-_BUILT: set = set()
+@dataclass
+class DSparkIndexBuffers:
+    """The fp8 path's index buffers, allocated once at `max_num_seqs`.
 
+    Sized at the maximum batch and only ever sliced -- the idiom
+    `write_v4_paged_decode_indices` states as "All inputs are persistent
+    forward_vars buffers, no allocator churn", and that the drafter's own
+    `_init_draft_block_buffers` already follows. Nothing here is keyed by
+    shape, because every one of these is prefix-stable in the batch: the first
+    `B*T` entries of the max-batch buffer ARE the batch-`B` answer.
 
-def _scratch(batch: int, draft: int, device):
-    """Persistent `(kv_indptr, draft_rows)` for a shape.
-
-    `write_v4_paged_decode_indices` states the principle for the target's
-    equivalent: "All inputs are persistent forward_vars buffers -- no allocator
-    churn." This path runs once per DSpark stage per step, so a fresh pair of
-    allocations each call is exactly the churn that warns against. Keyed by
-    shape, which is fixed for the process (`T = min(mtp_k, window)`, and B is
-    the CUDA-graph-padded batch).
+    `qo_indptr` and `batch_ids` are constants, filled at allocation and never
+    written again. The other three are refilled by `dspark_build_indices` at
+    the top of each block; `built_for` records the batch they hold, so a stage
+    reading them back cannot be handed a stale or uninitialised slice.
     """
-    key = (batch, draft, str(device))
-    hit = _SCRATCH.get(key)
-    if hit is None:
-        n = batch * draft
-        hit = (
-            torch.empty(n + 1, dtype=torch.int32, device=device),
-            torch.empty(n, dtype=torch.int32, device=device),
-        )
-        _SCRATCH[key] = hit
-    return hit
+
+    kv_indices: torch.Tensor  # [max_b*T*(W+T)] int32
+    kv_indptr: torch.Tensor  # [max_b*T+1] int32
+    draft_rows: torch.Tensor  # [max_b*T] int32
+    qo_indptr: torch.Tensor  # [max_b*T+1] int32, constant ramp
+    batch_ids: torch.Tensor  # [max_b*T] int32, constant [0]*T ++ [1]*T ++ ...
+    built_for: int = -1
 
 
-def dspark_kv_index_scratch(
-    batch: int, draft: int, window: int, device
-) -> torch.Tensor:
-    """Persistent `kv_indices` buffer for a shape — see :func:`_scratch`."""
-    key = ("idx", batch, draft, window, str(device))
-    hit = _SCRATCH.get(key)
-    if hit is None:
-        hit = torch.empty(
-            dspark_kv_index_capacity(batch, draft, window),
-            dtype=torch.int32,
-            device=device,
-        )
-        _SCRATCH[key] = hit
-    return hit
+def dspark_index_buffers(
+    max_batch: int, draft: int, window: int, device
+) -> DSparkIndexBuffers:
+    """Allocate :class:`DSparkIndexBuffers` for a process's largest batch.
+
+    `qo_indptr` is `arange(N+1)`: the asm wrapper runs `max_seqlen_q = 1`, one
+    "sequence" per query row, the same convention the V4 target's decode
+    metadata uses (`deepseek_v4_attn.py:3727`).
+
+    `batch_ids` is the token -> request map the fused SWA scatter gates on
+    (`bid >= 0`). It carries no CG-pad sentinels, and does not need any: the
+    draft runs at `context.batch_size`, which is `scheduled_bs`, the REAL decode
+    batch (`model_runner.py:2609`) -- not the padded `effective_bs` the target's
+    metadata is built at. The target can alias `cu_seqlens_q[:bs]` for its own
+    (`deepseek_v4_attn.py:2348`) because at one token per sequence that slice is
+    already `arange(bs)`; DSpark runs T tokens per request and needs each id
+    repeated T times, so there is no existing buffer to slice.
+    """
+    n = max_batch * draft
+    i32 = {"dtype": torch.int32, "device": device}
+    return DSparkIndexBuffers(
+        kv_indices=torch.empty(n * (window + draft), **i32),
+        kv_indptr=torch.empty(n + 1, **i32),
+        draft_rows=torch.empty(n, **i32),
+        qo_indptr=torch.arange(n + 1, **i32),
+        batch_ids=torch.arange(max_batch, **i32)
+        .view(max_batch, 1)
+        .expand(max_batch, draft)
+        .reshape(-1)
+        .contiguous(),
+    )
 
 
-def dspark_indices_view(
-    batch: int, draft: int, window: int, device, out_indices: torch.Tensor
+def dspark_index_views(
+    bufs: DSparkIndexBuffers, batch: int, draft: int, window: int
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Read back what :func:`dspark_build_indices` last wrote for this shape.
+    """The `(kv_indices, kv_indptr, draft_rows)` slices for a batch.
 
-    DSpark runs one block through every stage and these indices are
+    DSpark runs one block through every stage and the values are
     stage-invariant (all DSpark layers share compress ratio 0, hence one
     `WindowParams`, and each layer's plane view is base-row-relative), so stage
-    0 builds and the rest read. The buffers are the shape-keyed persistent ones,
-    so this is pure lookup — no launch, no allocation.
-
-    Freshness comes from call order, not from here: `_DSparkInner.forward` walks
-    the stages in order and stage 0 refills the buffers at the top of every
-    block. What this DOES catch is a stage reading a shape that was never built
-    at all, which would feed the asm kernel a `torch.empty`.
+    0 builds and the rest read this back -- no launch, no allocation.
     """
-    key = (batch, draft, str(device))
-    if key not in _BUILT:
+    if bufs.built_for != batch:
         raise RuntimeError(
-            f"DSpark kv indices for B={batch} T={draft} on {device} were never "
-            "built; stage 0 must run before any stage reads them back."
+            f"DSpark kv indices hold batch {bufs.built_for}, not {batch}; "
+            "stage 0 must build them before any stage reads them back."
         )
-    kv_indptr, draft_rows = _scratch(batch, draft, device)
-    capacity = dspark_kv_index_capacity(batch, draft, window)
-    return out_indices[:capacity], kv_indptr, draft_rows
+    n = batch * draft
+    return (
+        bufs.kv_indices[: n * (window + draft)],
+        bufs.kv_indptr[: n + 1],
+        bufs.draft_rows[:n],
+    )
 
 
 def dspark_build_indices(
@@ -235,24 +204,23 @@ def dspark_build_indices(
     anchors: torch.Tensor,  # [B] per-request anchor position
     draft_width: int,  # T
     draft_window: int,  # W
-    out_indices: torch.Tensor,  # [>= capacity] int32, preallocated
+    bufs: DSparkIndexBuffers,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Everything the asm path needs, in one launch.
 
-    Returns ``(kv_indices, kv_indptr, draft_rows)``; build ``qo_indptr`` with
-    :func:`dspark_qo_indptr`.
+    Fills ``bufs`` in place and returns its ``(kv_indices, kv_indptr,
+    draft_rows)`` slices; ``qo_indptr`` and ``batch_ids`` are constants already
+    sitting in the same bundle.
     """
     B = anchors.shape[0]
     T, W = draft_width, draft_window
-    capacity = dspark_kv_index_capacity(B, T, W)
-    if out_indices.numel() < capacity:
+    if bufs.batch_ids.numel() < B * T:
         raise ValueError(
-            f"DSpark kv_indices buffer holds {out_indices.numel()} < {capacity} "
-            f"needed for B={B} T={T} W={W}."
+            f"DSpark index buffers hold {bufs.batch_ids.numel() // T} requests "
+            f"< B={B}; they are sized at max_num_seqs."
         )
-
-    dev = anchors.device
-    kv_indptr, draft_rows = _scratch(B, T, dev)
+    bufs.built_for = B
+    kv_indices, kv_indptr, draft_rows = dspark_index_views(bufs, B, T, W)
     anchors_i64 = anchors.to(torch.int64)
     slots_i64 = slots.to(torch.int64)
 
@@ -261,7 +229,7 @@ def dspark_build_indices(
         slots_i64,
         kv_indptr,
         draft_rows,
-        out_indices,
+        kv_indices,
         B,
         window.ring_start,
         T=T,
@@ -270,5 +238,4 @@ def dspark_build_indices(
         BLOCK_B=triton.next_power_of_2(B),
         BLOCK_K=triton.next_power_of_2(W + T),
     )
-    _BUILT.add((B, T, str(dev)))
-    return out_indices[:capacity], kv_indptr, draft_rows
+    return kv_indices, kv_indptr, draft_rows

--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -9,17 +9,20 @@ kernel addresses KV as one pool of rows plus a CSR index list per query row, so
 the `[window ++ draft-block]` KV DSpark attends to has to be expressed as pool
 row ids rather than a materialised `[B, W+T, 512]` tensor.
 
-Two things are built here:
+`dspark_build_indices` emits all three in one launch:
 
-- `dspark_draft_dest_rows` — the ring rows the draft block's own KV is scattered
-  into, fused into the `qk_norm_rope_maybe_quant` launch that produces it.
-- `dspark_build_kv_indices` — the ragged CSR (`kv_indices`, `kv_indptr`) plus
-  `qo_indptr`, laid out one query row per draft position, `N = B*T` rows.
+- `kv_indices` / `kv_indptr` — the ragged CSR, one query row per draft position,
+  `N = B*T` rows.
+- `draft_rows` — the ring rows the draft block's own KV is scattered into, fused
+  into the `qk_norm_rope_maybe_quant` launch that produces it.
 
-Both are pure tensor ops with statically-known shapes: no `.item()`, no
-data-dependent allocation, so a captured CUDA graph replays them. Invalid grid
-cells are funnelled into a trailing dump slot rather than compacted, which is
-what keeps the shapes static.
+`qo_indptr` comes from `dspark_qo_indptr`. Shapes are statically known: no
+`.item()`, no data-dependent allocation, so a captured CUDA graph replays it.
+The buffers are shape-keyed and persistent, and the capacity is the worst case
+rather than a tight fit, so trailing slack is simply never read.
+
+The pool row formula is not restated here -- the kernel calls
+`pool_index.window_row`, which is what that module exists for.
 
 The `[B,T,W+T]` gather indices the bf16 path uses (`_dspark_block_topk_idxs`)
 are a broadcast along T — every draft position attends to the identical set — so
@@ -36,126 +39,9 @@ from atom.model_ops.attentions.v4_pool_geometry import WindowParams
 from atom.model_ops.v4_kernels.pool_index import window_constexprs, window_row
 
 
-def _ring_rows(
-    window: WindowParams, slots: torch.Tensor, pos: torch.Tensor
-) -> torch.Tensor:
-    """Vectorised `WindowParams.index`: pool row for each (slot, position).
-
-    ``slots`` broadcasts against ``pos``. Mirrors the scalar form in
-    `v4_pool_geometry.py` and the Triton twin in `pool_index.py`; positions must
-    be >= 0, since Python and Triton disagree on the sign of a negative modulo
-    and the callers below mask before they get here.
-    """
-    ring = pos % window.ring_slots
-    chunk = ring // window.ring_stride
-    within = ring % window.ring_stride
-    return (
-        slots * window.slot_rows + window.ring_start + chunk * window.run_rows + within
-    )
-
-
-def dspark_draft_dest_rows_reference(
-    window: WindowParams,
-    slots: torch.Tensor,  # [B] int, per-request ring slot
-    draft_pos: torch.Tensor,  # [B, T] int, absolute draft positions
-) -> torch.Tensor:  # [B*T] int32
-    """Ring rows for the draft block's own KV, in `draft_pos` order.
-
-    Handed to `qk_norm_rope_maybe_quant(..., swa_dest_rows=)` so the fp8 quant
-    launch scatters the draft KV into the ring in the same pass that computes
-    it. Writing these speculative rows is safe for the same reason
-    `write_context_kv` may write rejected rows (`dspark_proposer.py:372-376`):
-    they land strictly above the anchor, and nothing ever gathers a position
-    above the anchor.
-    """
-    return (
-        _ring_rows(window, slots.view(-1, 1).to(draft_pos.dtype), draft_pos)
-        .to(torch.int32)
-        .view(-1)
-    )
-
-
 def dspark_kv_index_capacity(batch: int, draft: int, window: int) -> int:
     """Elements to reserve for `kv_indices`, plus the trailing dump slot."""
     return batch * draft * (window + draft) + 1
-
-
-def dspark_build_kv_indices_reference(
-    window: WindowParams,
-    slots: torch.Tensor,  # [B] int, per-request ring slot
-    anchors: torch.Tensor,  # [B] int, per-request anchor position
-    draft_rows: torch.Tensor,  # [B*T] int32, from dspark_draft_dest_rows
-    draft_width: int,  # T
-    draft_window: int,  # W
-    out_indices: torch.Tensor,  # [>= capacity] int32, preallocated
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Build the CSR KV lists for `N = B*T` query rows.
-
-    Row ``b*T + t`` gets request ``b``'s list — the valid rolling-window rows
-    followed by all ``T`` draft rows — so the list repeats ``T`` times per
-    request. That is legal: CSR only requires ``kv_indptr`` to be monotone, and
-    the values inside a slice may repeat across slices.
-
-    A request holds ``n = min(anchor+1, W)`` valid window slots (slot ``s`` maps
-    to absolute position ``anchor-(W-1)+s``, and `_build_block_plan` marks
-    ``s >= (W-1)-anchor`` valid, i.e. exactly the non-negative positions), so
-    per-row length is ``n + T`` and the lists are ragged.
-
-    ``out_indices`` is a fixed-capacity buffer, not a tight one: the kernel only
-    reads ``[kv_indptr[i], kv_indptr[i+1])``, so trailing slack is never touched
-    and the shapes stay static for graph capture.
-
-    Returns ``(kv_indices, kv_indptr)``; build `qo_indptr` with
-    :func:`dspark_qo_indptr`.
-    """
-    B = anchors.shape[0]
-    T, W = draft_width, draft_window
-    device = anchors.device
-    K = W + T
-
-    capacity = dspark_kv_index_capacity(B, T, W)
-    if out_indices.numel() < capacity:
-        raise ValueError(
-            f"DSpark kv_indices buffer holds {out_indices.numel()} < {capacity} "
-            f"needed for B={B} T={T} W={W}."
-        )
-    dump = capacity - 1
-
-    idx = anchors.to(torch.int64)
-    n_valid = torch.clamp(idx + 1, max=W)  # [B]
-
-    # One row per draft position; every row of a request shares its list.
-    n_valid_r = n_valid.view(B, 1).expand(B, T).reshape(B * T, 1)
-    anchors_r = idx.view(B, 1).expand(B, T).reshape(B * T, 1)
-    slots_r = slots.to(torch.int64).view(B, 1).expand(B, T).reshape(B * T, 1)
-
-    lengths = (n_valid_r + T).view(-1)  # [B*T]
-    kv_indptr = torch.zeros(B * T + 1, dtype=torch.int32, device=device)
-    kv_indptr[1:] = torch.cumsum(lengths, dim=0).to(torch.int32)
-
-    j = torch.arange(K, device=device, dtype=torch.int64).view(1, K)
-    in_window = j < n_valid_r
-    in_row = j < (n_valid_r + T)
-
-    # Window half: the valid suffix, oldest first. Draft half: the block's own
-    # rows, already resolved to ring rows by `dspark_draft_dest_rows`.
-    win_pos = anchors_r - n_valid_r + 1 + j
-    win_rows = _ring_rows(window, slots_r, torch.clamp(win_pos, min=0))
-    draft_col = torch.clamp(j - n_valid_r, min=0, max=T - 1)
-    draft_rows_r = draft_rows.view(B, T).to(torch.int64)
-    draft_pick = torch.gather(
-        draft_rows_r.view(B, 1, T).expand(B, T, T).reshape(B * T, T), 1, draft_col
-    )
-
-    rows = torch.where(in_window, win_rows, draft_pick).to(torch.int32)
-
-    # Scatter into the ragged buffer. Cells past a row's length go to the dump
-    # slot instead of being compacted, so every shape here is static.
-    dst = kv_indptr[:-1].to(torch.int64).view(-1, 1) + j
-    dst = torch.where(in_row, dst, torch.full_like(dst, dump))
-    out_indices[:capacity].scatter_(0, dst.reshape(-1), rows.reshape(-1))
-
-    return out_indices[:capacity], kv_indptr
 
 
 def dspark_qo_indptr(batch: int, draft: int, device) -> torch.Tensor:
@@ -182,12 +68,12 @@ def dspark_qo_indptr(batch: int, draft: int, device) -> torch.Tensor:
 # ---------------------------------------------------------------------------
 # Fused build.
 #
-# The torch spellings above are ~50 elementwise launches (~286us at B=128 T=4
+# Spelled as torch ops this is ~50 elementwise launches (~286us at B=128 T=4
 # W=128 on MI355X) over tensors of at most a few thousand int32 -- launch-bound,
-# and paid once per DSpark stage per step, in front of an attention kernel that
-# reads only W+T rows. `write_v4_paged_decode_indices` is the target's answer to
-# the same problem: derive every index on device in one kernel. This is that,
-# for the draft's `[window ++ draft-block]` list.
+# in front of an attention kernel that reads only W+T rows.
+# `write_v4_paged_decode_indices` is the target's answer to the same problem:
+# derive every index on device in one kernel. This is that, for the draft's
+# `[window ++ draft-block]` list.
 #
 # ONE launch, matching the target's shape. The CSR offsets are a prefix sum over
 # requests and the index fill needs them before it can address its slice -- but
@@ -356,10 +242,8 @@ def dspark_build_indices(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Everything the asm path needs, in one launch.
 
-    Returns ``(kv_indices, kv_indptr, draft_rows)``. Equivalent to
-    :func:`dspark_draft_dest_rows_reference` followed by
-    :func:`dspark_build_kv_indices_reference`; `tests/test_dspark_fp8_indices.py`
-    holds them to that. Build `qo_indptr` with :func:`dspark_qo_indptr`.
+    Returns ``(kv_indices, kv_indptr, draft_rows)``; build ``qo_indptr`` with
+    :func:`dspark_qo_indptr`.
     """
     B = anchors.shape[0]
     T, W = draft_width, draft_window

--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -69,19 +69,16 @@ def dspark_qo_indptr(batch: int, draft: int, device) -> torch.Tensor:
 # Fused build.
 #
 # Spelled as torch ops this is ~50 elementwise launches (~286us at B=128 T=4
-# W=128 on MI355X) over tensors of at most a few thousand int32 -- launch-bound,
-# in front of an attention kernel that reads only W+T rows.
-# `write_v4_paged_decode_indices` is the target's answer to the same problem:
-# derive every index on device in one kernel. This is that, for the draft's
+# W=128 on MI355X) over a few thousand int32 -- launch-bound, in front of an
+# attention kernel that reads only W+T rows. `write_v4_paged_decode_indices` is
+# the target's answer to the same problem, and this is that for the draft's
 # `[window ++ draft-block]` list.
 #
-# ONE launch, matching the target's shape. The CSR offsets are a prefix sum over
-# requests and the index fill needs them before it can address its slice -- but
-# the summand is only `min(anchor+1, W) + T`, so a program can rebuild the whole
-# prefix from the `B` anchors itself rather than wait for a separate pass to
-# hand it over. B is the CUDA-graph-padded batch (hundreds of int64), so every
-# program redundantly reducing one BLOCK_B vector is far cheaper than the extra
-# launch and the serialization between the two that it forces.
+# ONE launch. The fill needs the CSR offsets before it can address its slice,
+# but the summand is only `min(anchor+1, W) + T`, so a program rebuilds the
+# whole prefix from the B anchors itself instead of waiting on a second kernel.
+# B is the CG-padded batch, so that redundant BLOCK_B reduction is far cheaper
+# than the extra launch and the serialization it forces.
 # ---------------------------------------------------------------------------
 
 

--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -9,12 +9,14 @@ kernel addresses KV as one pool of rows plus a CSR index list per query row, so
 the `[window ++ draft-block]` KV DSpark attends to has to be expressed as pool
 row ids rather than a materialised `[B, W+T, 512]` tensor.
 
-`dspark_build_indices` emits all three in one launch:
+`dspark_build_indices` fills, in one launch:
 
 - `kv_indices` / `kv_indptr` — the ragged CSR, one query row per draft position,
   `N = B*T` rows.
 - `draft_rows` — the ring rows the draft block's own KV is scattered into, fused
   into the `qk_norm_rope_maybe_quant` launch that produces it.
+
+and `dspark_index_views` reads them back.
 
 `qo_indptr` and the scatter's `batch_ids` are constants that ride in the same
 `DSparkIndexBuffers` bundle. Everything is allocated once at `max_num_seqs` and
@@ -124,14 +126,14 @@ class DSparkIndexBuffers:
     Sized at the maximum batch and only ever sliced -- the idiom
     `write_v4_paged_decode_indices` states as "All inputs are persistent
     forward_vars buffers, no allocator churn", and that the drafter's own
-    `_init_draft_block_buffers` already follows. Nothing here is keyed by
-    shape, because every one of these is prefix-stable in the batch: the first
-    `B*T` entries of the max-batch buffer ARE the batch-`B` answer.
+    `_init_draft_block_buffers` already follows. Nothing is keyed by shape,
+    because every one of these is prefix-stable in the batch: the first `B*T`
+    entries of the max-batch buffer ARE the batch-`B` answer.
 
-    `qo_indptr` and `batch_ids` are constants, filled at allocation and never
-    written again. The other three are refilled by `dspark_build_indices` at
-    the top of each block; `built_for` records the batch they hold, so a stage
-    reading them back cannot be handed a stale or uninitialised slice.
+    `draft_width` / `draft_window` are the shape the buffers were cut for, kept
+    here so no caller can hand a slice a different one; `qo_indptr` and
+    `batch_ids` are constants filled at allocation and never written again.
+    `built_for` is the batch the other three currently hold.
     """
 
     kv_indices: torch.Tensor  # [max_b*T*(W+T)] int32
@@ -139,6 +141,9 @@ class DSparkIndexBuffers:
     draft_rows: torch.Tensor  # [max_b*T] int32
     qo_indptr: torch.Tensor  # [max_b*T+1] int32, constant ramp
     batch_ids: torch.Tensor  # [max_b*T] int32, constant [0]*T ++ [1]*T ++ ...
+    max_batch: int
+    draft_width: int  # T
+    draft_window: int  # W
     built_for: int = -1
 
 
@@ -148,17 +153,17 @@ def dspark_index_buffers(
     """Allocate :class:`DSparkIndexBuffers` for a process's largest batch.
 
     `qo_indptr` is `arange(N+1)`: the asm wrapper runs `max_seqlen_q = 1`, one
-    "sequence" per query row, the same convention the V4 target's decode
-    metadata uses (`deepseek_v4_attn.py:3727`).
+    "sequence" per query row -- the same per-token convention the V4 target uses
+    for its own decode AND verify forwards (`deepseek_v4_attn.py:3727`).
 
     `batch_ids` is the token -> request map the fused SWA scatter gates on
-    (`bid >= 0`). It carries no CG-pad sentinels, and does not need any: the
-    draft runs at `context.batch_size`, which is `scheduled_bs`, the REAL decode
-    batch (`model_runner.py:2609`) -- not the padded `effective_bs` the target's
+    (`bid >= 0`). It carries no CG-pad sentinels, and needs none: the draft runs
+    at `context.batch_size`, which is `scheduled_bs`, the REAL decode batch
+    (`model_runner.py:2609`) -- not the padded `effective_bs` the target's
     metadata is built at. The target can alias `cu_seqlens_q[:bs]` for its own
     (`deepseek_v4_attn.py:2348`) because at one token per sequence that slice is
     already `arange(bs)`; DSpark runs T tokens per request and needs each id
-    repeated T times, so there is no existing buffer to slice.
+    repeated T times, so there is nothing to alias.
     """
     n = max_batch * draft
     i32 = {"dtype": torch.int32, "device": device}
@@ -172,61 +177,64 @@ def dspark_index_buffers(
         .expand(max_batch, draft)
         .reshape(-1)
         .contiguous(),
+        max_batch=max_batch,
+        draft_width=draft,
+        draft_window=window,
+    )
+
+
+def _slices(bufs: DSparkIndexBuffers, batch: int):
+    n = batch * bufs.draft_width
+    return (
+        bufs.kv_indices[: n * (bufs.draft_window + bufs.draft_width)],
+        bufs.kv_indptr[: n + 1],
+        bufs.draft_rows[:n],
     )
 
 
 def dspark_index_views(
-    bufs: DSparkIndexBuffers, batch: int, draft: int, window: int
+    bufs: DSparkIndexBuffers, batch: int
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """The `(kv_indices, kv_indptr, draft_rows)` slices for a batch.
+    """The `(kv_indices, kv_indptr, draft_rows)` a built bundle holds.
 
-    DSpark runs one block through every stage and the values are
-    stage-invariant (all DSpark layers share compress ratio 0, hence one
-    `WindowParams`, and each layer's plane view is base-row-relative), so stage
-    0 builds and the rest read this back -- no launch, no allocation.
+    The one accessor: :func:`dspark_build_indices` only fills, and every stage
+    -- including the one that filled -- reads through here. DSpark runs one
+    block through every stage and the values are stage-invariant (all DSpark
+    layers share compress ratio 0, hence one `WindowParams`, and each layer's
+    plane view is base-row-relative), so stage 0 builds and the rest just slice.
     """
     if bufs.built_for != batch:
         raise RuntimeError(
             f"DSpark kv indices hold batch {bufs.built_for}, not {batch}; "
             "stage 0 must build them before any stage reads them back."
         )
-    n = batch * draft
-    return (
-        bufs.kv_indices[: n * (window + draft)],
-        bufs.kv_indptr[: n + 1],
-        bufs.draft_rows[:n],
-    )
+    return _slices(bufs, batch)
 
 
 def dspark_build_indices(
     window: WindowParams,
     slots: torch.Tensor,  # [B] per-request ring slot
     anchors: torch.Tensor,  # [B] per-request anchor position
-    draft_width: int,  # T
-    draft_window: int,  # W
     bufs: DSparkIndexBuffers,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Everything the asm path needs, in one launch.
+) -> None:
+    """Fill `bufs` for this block, in one launch. Read it with
+    :func:`dspark_index_views`.
 
-    Fills ``bufs`` in place and returns its ``(kv_indices, kv_indptr,
-    draft_rows)`` slices; ``qo_indptr`` and ``batch_ids`` are constants already
-    sitting in the same bundle.
+    `T` and `W` come from the bundle, so a slice can never be cut to a shape the
+    buffers were not allocated for.
     """
     B = anchors.shape[0]
-    T, W = draft_width, draft_window
-    if bufs.batch_ids.numel() < B * T:
+    T, W = bufs.draft_width, bufs.draft_window
+    if B > bufs.max_batch:
         raise ValueError(
-            f"DSpark index buffers hold {bufs.batch_ids.numel() // T} requests "
-            f"< B={B}; they are sized at max_num_seqs."
+            f"DSpark index buffers hold {bufs.max_batch} requests < B={B}; "
+            "they are sized at max_num_seqs."
         )
-    bufs.built_for = B
-    kv_indices, kv_indptr, draft_rows = dspark_index_views(bufs, B, T, W)
-    anchors_i64 = anchors.to(torch.int64)
-    slots_i64 = slots.to(torch.int64)
+    kv_indices, kv_indptr, draft_rows = _slices(bufs, B)
 
     _dspark_index_kernel[(B * T,)](
-        anchors_i64,
-        slots_i64,
+        anchors.to(torch.int64),
+        slots.to(torch.int64),
         kv_indptr,
         draft_rows,
         kv_indices,
@@ -238,4 +246,5 @@ def dspark_build_indices(
         BLOCK_B=triton.next_power_of_2(B),
         BLOCK_K=triton.next_power_of_2(W + T),
     )
-    return kv_indices, kv_indptr, draft_rows
+    # Last: a launch that raised must not leave the bundle claiming a batch.
+    bufs.built_for = B

--- a/atom/models/deepseek_v4_dspark.py
+++ b/atom/models/deepseek_v4_dspark.py
@@ -61,7 +61,7 @@ def _dspark_block_attention_fake(
     positions: torch.Tensor,
     draft_pos: torch.Tensor,
     valid_target: torch.Tensor,
-    topk_idxs: torch.Tensor,
+    topk_idxs: torch.Tensor | None,
     layer_name: str,
 ) -> torch.Tensor:
     return torch.empty_like(x)
@@ -75,7 +75,7 @@ def dspark_block_attention(
     positions: torch.Tensor,  # [B] anchor position per request
     draft_pos: torch.Tensor,  # [B, T] block plan: absolute draft positions
     valid_target: torch.Tensor,  # [B, W] block plan: window validity
-    topk_idxs: torch.Tensor,  # [B, T, W+T] block plan: gather indices
+    topk_idxs: torch.Tensor | None,  # [B,T,W+T] gather idxs; None on fp8
     layer_name: str,
 ) -> torch.Tensor:  # [B, T, dim]
     """Dynamo-opaque wrapper around one DSpark stage's block attention.
@@ -341,15 +341,15 @@ class _DSparkBlockPlan:
     ``forward_spec`` and reused. Recomputing them per stage rebuilt the
     ``[B, T, W+T]`` gather-index block once per stage for identical values.
 
-    ``topk_idxs`` is empty when the fp8 path is planned: that path addresses KV
-    as a CSR list of pool rows and never gathers a materialised
+    ``topk_idxs`` is ``None`` when the fp8 path is planned: that path addresses
+    KV as a CSR list of pool rows and never gathers a materialised
     ``[B, W+T, 512]``, so the block would be built and never read. See
     :func:`_build_block_plan`.
     """
 
     draft_pos: torch.Tensor  # [B, T]      anchor+1 .. anchor+T
     valid_target: torch.Tensor  # [B, W]      rolling-window slot validity
-    topk_idxs: torch.Tensor  # [B, T, W+T] sparse_attn gather indices, or empty
+    topk_idxs: torch.Tensor | None  # [B, T, W+T] gather indices, or None
 
 
 def _build_block_plan(
@@ -389,7 +389,7 @@ def _build_block_plan(
         draft_pos=draft_pos,
         valid_target=valid_target,
         topk_idxs=(
-            valid_target.new_empty(0, dtype=torch.int32)
+            None
             if fp8_planned
             else _dspark_block_topk_idxs(B, T, W, valid_target, device)
         ),
@@ -492,11 +492,7 @@ def _dspark_block_sparse_attention(
 try:
     from atom.model_ops.layernorm import RMSNorm
     from atom.model_ops.linear import ReplicatedLinear
-    from atom.model_ops.v4_kernels.dspark_fp8_indices import (
-        dspark_build_indices,
-        dspark_index_buffers,
-        dspark_index_views,
-    )
+    from atom.model_ops.v4_kernels.dspark_fp8_indices import DSparkIndexBuffers
     from atom.model_ops.v4_kernels.paged_decode import sparse_attn_v4_paged_decode
     from atom.model_ops.v4_kernels.qk_norm_rope_maybe_quant import (
         qk_norm_rope_maybe_quant,
@@ -795,44 +791,37 @@ class DSparkLayer(Block):  # type: ignore[misc]
 
         fc = get_forward_context()
         W = self.window_size
-        # The asm fp8 path needs the target's 2buff planes, which exist only
-        # under `--kv_cache_dtype fp8` (`deepseek_v4_attn.py:455`), and needs the
-        # pool bound, which warmup precedes. Fall back rather than fail: both
-        # paths are correct and differ in numerics and speed. This is the
-        # runtime form of `dspark_fp8_planned` -- same condition, read off the
-        # layer once the pool has actually bound it.
+        # The runtime form of `dspark_fp8_planned`: the same fact, read off the
+        # pool once it is actually bound (warmup precedes that). Keyed on the
+        # rope plane and nothing else, which is both what the asm kernel
+        # dispatches on (`paged_decode.py:1081`) and the stricter of the two
+        # signals -- `build_kv_cache_tensor` clears the planes on its
+        # early-return branch without clearing `kv_fp8`. Fall back rather than
+        # fail: both paths are correct and differ in numerics and speed.
         slots = draft_rows = batch_ids = kv_indices = kv_indptr = None
         use_fp8 = (
-            getattr(a, "kv_fp8", False)
-            and getattr(a, "unified_kv_rope", None) is not None
+            getattr(a, "unified_kv_rope", None) is not None
             and not fc.context.is_dummy_run
         )
         if use_fp8:
             slots = fc.attn_metadata.state_slot_out[:B]
-            # Ring rows for this block's own KV, so the fused quant below can
-            # scatter it as it computes it. Writing speculative rows is safe for
-            # the reason `write_context_kv` may write rejected ones
-            # (`dspark_proposer.py:372-376`): they land strictly above the
-            # anchor, and no gather ever addresses above the anchor, so a
-            # rejected row stays unreadable until the step that accepts it
-            # overwrites it. One stage's draft KV still stays invisible to the
-            # next, because `swa_plane` is this layer's own view of the plane —
-            # what the stages share is the row NUMBER, not the row.
+            # Ring rows for this block's own KV, scattered by the fused quant
+            # below as it computes it. Speculative/rejected rows are safe (as in
+            # `write_context_kv`, `dspark_proposer.py:372-376`): they land above
+            # the anchor and nothing gathers above the anchor, so they stay
+            # unreadable until an accepting step overwrites them. Stages share the
+            # row NUMBER, not the row -- `swa_plane` is each layer's own view.
             #
-            # One Triton launch builds the draft ring rows, the CSR offsets and
-            # the CSR list together, and only stage 0 pays for it; later stages
-            # read the same buffers back. That is sound precisely because the
-            # numbers are stage-invariant: every DSpark layer has compress ratio
-            # 0 (`deepseek_v4_attn.py:434`) so they share one `WindowParams`,
-            # and each layer's `unified_kv` / `swa_plane` is its own base-row
-            # view, so one (slot, position) is the same layer-relative row in
-            # all of them. Stage 0 always runs first and always refills them --
-            # `_DSparkInner.forward` walks `self.mtp` in order -- and
-            # `dspark_indices_view` raises if it somehow did not.
-            bufs = self.dspark_index_buffers(T, W, x.device)
+            # One Triton launch builds the ring rows + CSR together; only stage 0
+            # pays and later stages read the same buffers back. Sound because the
+            # numbers are stage-invariant (every layer has compress ratio 0, hence
+            # one `WindowParams`, and each `swa_plane` is base-row-relative). The
+            # bundle is owned by `_DSparkInner`, borrowed via its `index_buffers`
+            # accessor (lazy); `bufs.views` raises if stage 0 did not fill first.
+            bufs = self.index_buffers(T, W, x.device)
             if self.stage_id == 0:
-                dspark_build_indices(a.swa_window, slots, positions, bufs)
-            kv_indices, kv_indptr, draft_rows = dspark_index_views(bufs, B)
+                bufs.build(a.swa_window, slots, positions)
+            kv_indices, kv_indptr, draft_rows = bufs.views(B)
             batch_ids = bufs.batch_ids[: B * T]
 
         # Per-head weightless Q RMSNorm + weighted KV RMSNorm + GPT-J RoPE in ONE
@@ -864,13 +853,10 @@ class DSparkLayer(Block):  # type: ignore[misc]
         )
 
         if use_fp8:
-            # The draft KV is in the ring now, so the whole
-            # [window ++ draft-block] KV is addressable as pool rows and never
-            # materialised. One CSR list per query row, N = B*T at
-            # max_seqlen_q=1 -- the target's decode convention
-            # (`deepseek_v4_attn.py:3727`). `topk_idxs` broadcasts along T, so
-            # a request's T positions share one list, which is what a CSR slice
-            # already is.
+            # KV is all in the ring now, addressable as pool rows and never
+            # materialised: one CSR list per query row (N = B*T, max_seqlen_q=1,
+            # the target's decode convention, `deepseek_v4_attn.py:3727`). The
+            # list broadcasts along T -- a request's T positions share one slice.
             out = sparse_attn_v4_paged_decode(
                 None,  # bf16 q: dead on the asm path, which reads q_packed_in
                 a.unified_kv,
@@ -893,7 +879,7 @@ class DSparkLayer(Block):  # type: ignore[misc]
             _apply_dspark_kv_qat_(kv, rope_dim)
             kv = kv.view(B, T, a.head_dim)
 
-            if topk_idxs.numel() == 0:
+            if topk_idxs is None:
                 # The plan omits the block when fp8 is PLANNED, but planning
                 # is not taking: warmup (`swa_plane` unbound) and any layer left
                 # without planes land here and still need it. Rebuilt here, not
@@ -1178,29 +1164,6 @@ class DeepseekV4DSpark(DSparkDraftModel):
         return self.model.head_and_sample(normed, hc_hidden, input_ids)
 
 
-class _DSparkIndexBufferOwner:
-    """Lazily allocates the one `DSparkIndexBuffers` the whole backbone shares.
-
-    Sized at `max_num_seqs` and only ever sliced, so there is nothing keyed by
-    shape and nothing reallocated per step. Lazy because the draft width is a
-    forward argument: fixed for the process (`DeepseekV4DSpark.forward_spec`
-    raises if it changes) but not known when the model is built.
-
-    Every stage holds the same owner. That is what lets stage 0 fill the CSR
-    and the rest read it back, and it is why this is one object on the model
-    rather than a buffer per layer.
-    """
-
-    def __init__(self, max_batch: int) -> None:
-        self.max_batch = max_batch
-        self._bufs = None
-
-    def __call__(self, draft: int, window: int, device):
-        if self._bufs is None:
-            self._bufs = dspark_index_buffers(self.max_batch, draft, window, device)
-        return self._bufs
-
-
 @support_torch_compile
 class _DSparkInner(nn.Module):
     """Inner module owning the DSpark backbone layers; embed/head set externally.
@@ -1250,13 +1213,32 @@ class _DSparkInner(nn.Module):
             ]
         )
         self.layers = self.mtp  # alias for reset_kv_cache iteration
-        # One index-buffer owner for the whole backbone: the fp8 path's CSR is
-        # stage-invariant, so stage 0 fills these and the rest read them back.
-        owner = _DSparkIndexBufferOwner(int(atom_config.max_num_seqs))
+        # The fp8 index bundle is owned here (one per backbone) and allocated by
+        # `index_buffers`. Each stage borrows that accessor: `dspark_attention`
+        # only has the layer (from `static_forward_context`), so hand it a handle.
+        # A *bound method*, not the backbone itself -- an nn.Module set as a layer
+        # attribute would register as a child and cycle the module tree.
+        self._max_num_seqs = int(atom_config.max_num_seqs)
+        self._index_bufs: DSparkIndexBuffers | None = None
         for layer in self.mtp:
-            layer.dspark_index_buffers = owner
+            layer.index_buffers = self.index_buffers
         self.embed = None  # set by share_with_target
         self.head = None
+
+    def index_buffers(self, draft: int, window: int, device) -> "DSparkIndexBuffers":
+        """The backbone's one `DSparkIndexBuffers`, allocated once and cached.
+
+        Sized at `max_num_seqs` and only ever sliced; `draft` (T) / `window` (W)
+        are fixed for the process, so the first call's shape is the only shape.
+        Lazy because the draft width is a forward argument (not known at build)
+        and the alloc must stay in the eager attention op, out of the traced
+        `forward`.
+        """
+        if self._index_bufs is None:
+            self._index_bufs = DSparkIndexBuffers.allocate(
+                self._max_num_seqs, draft, window, device
+            )
+        return self._index_bufs
 
     def forward(
         self,

--- a/atom/models/deepseek_v4_dspark.py
+++ b/atom/models/deepseek_v4_dspark.py
@@ -831,11 +831,8 @@ class DSparkLayer(Block):  # type: ignore[misc]
             # `dspark_indices_view` raises if it somehow did not.
             bufs = self.dspark_index_buffers(T, W, x.device)
             if self.stage_id == 0:
-                kv_indices, kv_indptr, draft_rows = dspark_build_indices(
-                    a.swa_window, slots, positions, T, W, bufs
-                )
-            else:
-                kv_indices, kv_indptr, draft_rows = dspark_index_views(bufs, B, T, W)
+                dspark_build_indices(a.swa_window, slots, positions, bufs)
+            kv_indices, kv_indptr, draft_rows = dspark_index_views(bufs, B)
             batch_ids = bufs.batch_ids[: B * T]
 
         # Per-head weightless Q RMSNorm + weighted KV RMSNorm + GPT-J RoPE in ONE

--- a/atom/models/deepseek_v4_dspark.py
+++ b/atom/models/deepseek_v4_dspark.py
@@ -274,16 +274,13 @@ def _fake_fp8_e4m3_inplace(x: torch.Tensor, block_size: int = 64) -> None:
     through FP8 E4M3 at inference to match training numerics. Keeps the rolling
     KV cache in its native dtype (only the values pass through the round-trip).
 
-    Deliberately still the eager chain, not a kernel. It is reachable only from
-    the bf16 path -- the fp8 path quantizes the very same lanes for real, so
-    both call sites skip it (`write_context_kv` passes `fake_quant=not to_2buff`,
-    and `dspark_attention` calls it only in its bf16 branch). A Triton rewrite
-    was measured at ~11us against ~65us here, but it optimizes the path this
-    work is moving off, and it costs a second numerics surface: the kernel
-    carries fp32 while this computes the scale in the input dtype, so the two
-    disagree on values sitting on a power-of-two boundary. Fold it into
-    `qk_norm_rope_maybe_quant` instead if the bf16 path ever needs the speed --
-    that launch already produces `kv` one line earlier.
+    Eager on purpose. Only the bf16 path reaches it -- the fp8 path quantizes
+    the same lanes for real, so both call sites skip it. A Triton rewrite
+    measured ~11us against ~65us, but it speeds up the path this work is moving
+    off and adds a second numerics surface (fp32 scale there, input-dtype scale
+    here, disagreeing on power-of-two boundaries). If the bf16 path ever needs
+    it, fold the round trip into `qk_norm_rope_maybe_quant`, which already
+    produces `kv` one line earlier, rather than add a kernel beside it.
     """
     if x.numel() == 0:
         return
@@ -629,28 +626,20 @@ class DSparkLayer(Block):  # type: ignore[misc]
         # priced in bytes, because a bf16 window is not a width the packed
         # planes hold.
         #
-        # The fp8 block attention does not want that. Its window IS the planes'
-        # own 2buff layout, so it stays silent here and takes the ordinary
-        # branch of `build_kv_cache_tensor`, which binds `swa_plane` +
-        # `swa_plane_rope` + `kv_fp8` — the two planes the asm kernel reads with
-        # one index buffer. Staying silent also restores the
-        # `prepare_mtp_decode` fast path, which a field-window MTP layer
-        # disables outright (`deepseek_v4_attn.py:592`).
+        # The fp8 path wants the opposite: its window IS the planes' 2buff
+        # layout, so staying silent takes `build_kv_cache_tensor`'s ordinary
+        # branch, which binds `swa_plane` + `swa_plane_rope` + `kv_fp8`. It also
+        # restores the `prepare_mtp_decode` fast path a field window disables
+        # (`deepseek_v4_attn.py:592`).
         #
-        # Keyed off the pool's dtype, and off nothing else. There is no opt-in
-        # flag: the rope plane the asm path addresses exists exactly when the
-        # server runs `--kv_cache_dtype fp8`, and that is already the condition
-        # under which the TARGET routes through the same asm kernel --
-        # `sparse_attn_v4_paged_decode` dispatches on `unified_kv_rope is not
-        # None` with no arch guard of its own (`paged_decode.py:1081`; the
-        # `get_gfx()` check below it guards only the bf16 fallback). So a draft
-        # that follows the pool's dtype is exposed to exactly what the target
-        # already is, and under bf16 KV it stays on the bf16 path.
+        # No opt-in flag; the pool's dtype decides. The rope plane exists
+        # exactly under `--kv_cache_dtype fp8`, which is already when the TARGET
+        # takes the same asm kernel (`paged_decode.py:1081` dispatches on
+        # `unified_kv_rope is not None`, with no arch guard of its own), so the
+        # draft is exposed to what the target already is and nothing more.
         #
-        # Config, fixed before the model is built, so this is the one fp8 signal
-        # the TRACED region may read: unlike `attn.kv_fp8`, which
-        # `build_kv_cache_tensor` binds only after warmup has already traced,
-        # baking this into a compiled graph cannot be wrong.
+        # Config, so the TRACED region may read it -- unlike `attn.kv_fp8`,
+        # which binds only after warmup has traced.
         self.dspark_fp8_planned = get_current_atom_config().kv_cache_dtype == "fp8"
         if not self.dspark_fp8_planned:
             self.attn.window_kv_dtype = torch.bfloat16
@@ -907,11 +896,11 @@ class DSparkLayer(Block):  # type: ignore[misc]
         if use_fp8:
             # The draft KV is in the ring now, so the whole
             # [window ++ draft-block] KV is addressable as pool rows and never
-            # has to be materialised. One CSR list per query row, N = B*T rows
-            # at max_seqlen_q=1 — the target's own decode convention
-            # (`deepseek_v4_attn.py:3727`). The bf16 path's `topk_idxs` is a
-            # broadcast along T, so all T positions of a request share one list,
-            # which is exactly what a per-row CSR slice expresses.
+            # materialised. One CSR list per query row, N = B*T at
+            # max_seqlen_q=1 -- the target's decode convention
+            # (`deepseek_v4_attn.py:3727`). `topk_idxs` broadcasts along T, so
+            # a request's T positions share one list, which is what a CSR slice
+            # already is.
             out = sparse_attn_v4_paged_decode(
                 None,  # bf16 q: dead on the asm path, which reads q_packed_in
                 a.unified_kv,
@@ -935,14 +924,11 @@ class DSparkLayer(Block):  # type: ignore[misc]
             kv = kv.view(B, T, a.head_dim)
 
             if topk_idxs.numel() == 0:
-                # The plan omits the gather block whenever the fp8 path is
-                # PLANNED, but planning it is not taking it: the warmup dummy
-                # run cannot (`swa_plane` is unbound before `allocate_kv_cache`)
-                # and neither can a layer `build_kv_cache_tensor` left without
-                # planes. Both land here and still need the block, so rebuild
-                # it. Here and not in `_build_block_plan` because this body is
-                # opaque to Dynamo and runs eagerly every step, so the branch
-                # cannot bake -- which is exactly what that function may not do.
+                # The plan omits the block when fp8 is PLANNED, but planning
+                # is not taking: warmup (`swa_plane` unbound) and any layer left
+                # without planes land here and still need it. Rebuilt here, not
+                # in `_build_block_plan`, because this body is opaque to Dynamo
+                # -- the branch cannot bake, which there it would.
                 topk_idxs = _dspark_block_topk_idxs(B, T, W, valid_target, x.device)
 
             # Assemble the [window ++ draft block] KV. The window-validity mask

--- a/atom/models/deepseek_v4_dspark.py
+++ b/atom/models/deepseek_v4_dspark.py
@@ -301,30 +301,6 @@ def _apply_dspark_kv_qat_(kv: torch.Tensor, rope_dim: int) -> None:
     _fake_fp8_e4m3_inplace(non_rope, block_size=64)
 
 
-_BATCH_IDS_CACHE: dict = {}
-
-
-def _dspark_batch_ids(batch: int, draft: int, device) -> torch.Tensor:
-    """`[B*T]` request id per query row, for the fused SWA scatter.
-
-    Depends only on the shape, so it is cached rather than rebuilt: an
-    `arange().expand().reshape()` is three launches in front of a kernel that
-    reads a few hundred rows.
-    """
-    key = (batch, draft, str(device))
-    hit = _BATCH_IDS_CACHE.get(key)
-    if hit is None:
-        hit = (
-            torch.arange(batch, device=device, dtype=torch.int32)
-            .view(batch, 1)
-            .expand(batch, draft)
-            .reshape(-1)
-            .contiguous()
-        )
-        _BATCH_IDS_CACHE[key] = hit
-    return hit
-
-
 def _dspark_block_topk_idxs(
     B: int, T: int, W: int, valid_target: torch.Tensor, device
 ) -> torch.Tensor:
@@ -518,9 +494,8 @@ try:
     from atom.model_ops.linear import ReplicatedLinear
     from atom.model_ops.v4_kernels.dspark_fp8_indices import (
         dspark_build_indices,
-        dspark_indices_view,
-        dspark_kv_index_scratch,
-        dspark_qo_indptr,
+        dspark_index_buffers,
+        dspark_index_views,
     )
     from atom.model_ops.v4_kernels.paged_decode import sparse_attn_v4_paged_decode
     from atom.model_ops.v4_kernels.qk_norm_rope_maybe_quant import (
@@ -854,16 +829,14 @@ class DSparkLayer(Block):  # type: ignore[misc]
             # all of them. Stage 0 always runs first and always refills them --
             # `_DSparkInner.forward` walks `self.mtp` in order -- and
             # `dspark_indices_view` raises if it somehow did not.
-            kv_buf = dspark_kv_index_scratch(B, T, W, x.device)
+            bufs = self.dspark_index_buffers(T, W, x.device)
             if self.stage_id == 0:
                 kv_indices, kv_indptr, draft_rows = dspark_build_indices(
-                    a.swa_window, slots, positions, T, W, kv_buf
+                    a.swa_window, slots, positions, T, W, bufs
                 )
             else:
-                kv_indices, kv_indptr, draft_rows = dspark_indices_view(
-                    B, T, W, x.device, kv_buf
-                )
-            batch_ids = _dspark_batch_ids(B, T, x.device)
+                kv_indices, kv_indptr, draft_rows = dspark_index_views(bufs, B, T, W)
+            batch_ids = bufs.batch_ids[: B * T]
 
         # Per-head weightless Q RMSNorm + weighted KV RMSNorm + GPT-J RoPE in ONE
         # fused kernel — the same `qk_norm_rope_maybe_quant` the V4 target runs
@@ -913,7 +886,7 @@ class DSparkLayer(Block):  # type: ignore[misc]
                 unified_kv_rope=a.unified_kv_rope,
                 q_packed_in=qkn.q_packed,
                 q_rope_in=qkn.q_rope,
-                qo_indptr=dspark_qo_indptr(B, T, x.device),
+                qo_indptr=bufs.qo_indptr[: B * T + 1],
                 prefix=f"{a.layer_name}.dspark_attn_fp8",
             )  # [B*T, n_heads, head_dim]
             out = out.view(B, T, a.n_local_heads, a.head_dim)
@@ -1208,6 +1181,29 @@ class DeepseekV4DSpark(DSparkDraftModel):
         return self.model.head_and_sample(normed, hc_hidden, input_ids)
 
 
+class _DSparkIndexBufferOwner:
+    """Lazily allocates the one `DSparkIndexBuffers` the whole backbone shares.
+
+    Sized at `max_num_seqs` and only ever sliced, so there is nothing keyed by
+    shape and nothing reallocated per step. Lazy because the draft width is a
+    forward argument: fixed for the process (`DeepseekV4DSpark.forward_spec`
+    raises if it changes) but not known when the model is built.
+
+    Every stage holds the same owner. That is what lets stage 0 fill the CSR
+    and the rest read it back, and it is why this is one object on the model
+    rather than a buffer per layer.
+    """
+
+    def __init__(self, max_batch: int) -> None:
+        self.max_batch = max_batch
+        self._bufs = None
+
+    def __call__(self, draft: int, window: int, device):
+        if self._bufs is None:
+            self._bufs = dspark_index_buffers(self.max_batch, draft, window, device)
+        return self._bufs
+
+
 @support_torch_compile
 class _DSparkInner(nn.Module):
     """Inner module owning the DSpark backbone layers; embed/head set externally.
@@ -1257,6 +1253,11 @@ class _DSparkInner(nn.Module):
             ]
         )
         self.layers = self.mtp  # alias for reset_kv_cache iteration
+        # One index-buffer owner for the whole backbone: the fp8 path's CSR is
+        # stage-invariant, so stage 0 fills these and the rest read them back.
+        owner = _DSparkIndexBufferOwner(int(atom_config.max_num_seqs))
+        for layer in self.mtp:
+            layer.dspark_index_buffers = owner
         self.embed = None  # set by share_with_target
         self.head = None
 

--- a/atom/models/deepseek_v4_dspark.py
+++ b/atom/models/deepseek_v4_dspark.py
@@ -273,6 +273,17 @@ def _fake_fp8_e4m3_inplace(x: torch.Tensor, block_size: int = 64) -> None:
     The HF DSpark module is QAT-trained: the non-RoPE KV lanes are quant/dequant
     through FP8 E4M3 at inference to match training numerics. Keeps the rolling
     KV cache in its native dtype (only the values pass through the round-trip).
+
+    Deliberately still the eager chain, not a kernel. It is reachable only from
+    the bf16 path -- the fp8 path quantizes the very same lanes for real, so
+    both call sites skip it (`write_context_kv` passes `fake_quant=not to_2buff`,
+    and `dspark_attention` calls it only in its bf16 branch). A Triton rewrite
+    was measured at ~11us against ~65us here, but it optimizes the path this
+    work is moving off, and it costs a second numerics surface: the kernel
+    carries fp32 while this computes the scale in the input dtype, so the two
+    disagree on values sitting on a power-of-two boundary. Fold it into
+    `qk_norm_rope_maybe_quant` instead if the bf16 path ever needs the speed --
+    that launch already produces `kv` one line earlier.
     """
     if x.numel() == 0:
         return
@@ -291,6 +302,30 @@ def _fake_fp8_e4m3_inplace(x: torch.Tensor, block_size: int = 64) -> None:
 def _apply_dspark_kv_qat_(kv: torch.Tensor, rope_dim: int) -> None:
     non_rope = kv[..., :-rope_dim] if rope_dim > 0 else kv
     _fake_fp8_e4m3_inplace(non_rope, block_size=64)
+
+
+_BATCH_IDS_CACHE: dict = {}
+
+
+def _dspark_batch_ids(batch: int, draft: int, device) -> torch.Tensor:
+    """`[B*T]` request id per query row, for the fused SWA scatter.
+
+    Depends only on the shape, so it is cached rather than rebuilt: an
+    `arange().expand().reshape()` is three launches in front of a kernel that
+    reads a few hundred rows.
+    """
+    key = (batch, draft, str(device))
+    hit = _BATCH_IDS_CACHE.get(key)
+    if hit is None:
+        hit = (
+            torch.arange(batch, device=device, dtype=torch.int32)
+            .view(batch, 1)
+            .expand(batch, draft)
+            .reshape(-1)
+            .contiguous()
+        )
+        _BATCH_IDS_CACHE[key] = hit
+    return hit
 
 
 def _dspark_block_topk_idxs(
@@ -328,21 +363,27 @@ def _dspark_block_topk_idxs(
 class _DSparkBlockPlan:
     """Per-block invariants shared by every DSpark stage.
 
-    ``dspark_attention`` runs once per stage, but these three tensors depend only
-    on ``(positions, T, W)`` — never on stage weights — so they are built once per
+    ``dspark_attention`` runs once per stage, but these tensors depend only on
+    ``(positions, T, W)`` — never on stage weights — so they are built once per
     ``forward_spec`` and reused. Recomputing them per stage rebuilt the
     ``[B, T, W+T]`` gather-index block once per stage for identical values.
+
+    ``topk_idxs`` is empty when the fp8 path is planned: that path addresses KV
+    as a CSR list of pool rows and never gathers a materialised
+    ``[B, W+T, 512]``, so the block would be built and never read. See
+    :func:`_build_block_plan`.
     """
 
     draft_pos: torch.Tensor  # [B, T]      anchor+1 .. anchor+T
     valid_target: torch.Tensor  # [B, W]      rolling-window slot validity
-    topk_idxs: torch.Tensor  # [B, T, W+T] sparse_attn gather indices
+    topk_idxs: torch.Tensor  # [B, T, W+T] sparse_attn gather indices, or empty
 
 
 def _build_block_plan(
     positions: torch.Tensor,  # [B] anchor position per request
     T: int,  # draft width
     W: int,  # rolling window size
+    fp8_planned: bool,  # process-constant; see DSparkLayer.dspark_fp8_planned
 ) -> _DSparkBlockPlan:
     """Build the per-block invariants once for the whole DSpark backbone.
 
@@ -354,6 +395,15 @@ def _build_block_plan(
     ``CompilationLevel >= DYNAMO_ONCE`` and permanently zero the window.
     Re-adding one is a silent accuracy bug; ``tests/test_dspark.py`` asserts the
     parameter stays gone.
+
+    ``fp8_planned`` is a different kind of flag and IS safe to bake: it is an
+    env var and a config field, both settled before the model is constructed,
+    so the warmup trace sees the value every later step sees. It drops
+    ``topk_idxs``, which is ~5 launches and a ``[B, T, W+T]`` int32 allocation
+    per forward that the CSR path never loads. The one caller that still needs
+    the block under this flag — the warmup dummy run, which cannot take the fp8
+    branch because `swa_plane` is unbound — rebuilds it eagerly inside
+    ``dspark_attention``, where a gate cannot bake.
     """
     B = positions.shape[0]
     device = positions.device
@@ -365,7 +415,11 @@ def _build_block_plan(
     return _DSparkBlockPlan(
         draft_pos=draft_pos,
         valid_target=valid_target,
-        topk_idxs=_dspark_block_topk_idxs(B, T, W, valid_target, device),
+        topk_idxs=(
+            valid_target.new_empty(0, dtype=torch.int32)
+            if fp8_planned
+            else _dspark_block_topk_idxs(B, T, W, valid_target, device)
+        ),
     )
 
 
@@ -465,12 +519,24 @@ def _dspark_block_sparse_attention(
 try:
     from atom.model_ops.layernorm import RMSNorm
     from atom.model_ops.linear import ReplicatedLinear
+    from atom.model_ops.v4_kernels.dspark_fp8_indices import (
+        dspark_build_indices,
+        dspark_indices_view,
+        dspark_kv_index_scratch,
+        dspark_qo_indptr,
+    )
+    from atom.model_ops.v4_kernels.paged_decode import sparse_attn_v4_paged_decode
     from atom.model_ops.v4_kernels.qk_norm_rope_maybe_quant import (
         qk_norm_rope_maybe_quant,
     )
     from atom.model_ops.v4_kernels.state_writes import (
         dspark_paged_window_gather,
         swa_write,
+    )
+    from atom.model_ops.v4_kernels.v4_quant import (
+        V4_DIM_QK_PACKED,
+        V4_DIM_ROPE,
+        quantize_bf16_to_v4_2buff_triton,
     )
     from atom.models.deepseek_v4 import (
         Block,
@@ -558,12 +624,36 @@ class DSparkLayer(Block):  # type: ignore[misc]
         # allocate_kv_cache; see write_context_kv / dspark_attention.
         #
         # What this layer's window has to be made of, which the pool reserves
-        # rather than infers. DSpark's block attention runs bf16 — there is no
-        # fused fp8 kernel for its [window ++ draft-block] shape and forcing
-        # one measured as a net regression. The day one lands, this line is the
-        # whole change: the pool prices the window off this dtype and lays it
-        # out the same way whether or not it matches the pool's own.
-        self.attn.window_kv_dtype = torch.bfloat16
+        # rather than infers. Declaring a dtype at all is what makes this a
+        # FIELD-window layer: the pool carries the window as a state field
+        # priced in bytes, because a bf16 window is not a width the packed
+        # planes hold.
+        #
+        # The fp8 block attention does not want that. Its window IS the planes'
+        # own 2buff layout, so it stays silent here and takes the ordinary
+        # branch of `build_kv_cache_tensor`, which binds `swa_plane` +
+        # `swa_plane_rope` + `kv_fp8` — the two planes the asm kernel reads with
+        # one index buffer. Staying silent also restores the
+        # `prepare_mtp_decode` fast path, which a field-window MTP layer
+        # disables outright (`deepseek_v4_attn.py:592`).
+        #
+        # Keyed off the pool's dtype, and off nothing else. There is no opt-in
+        # flag: the rope plane the asm path addresses exists exactly when the
+        # server runs `--kv_cache_dtype fp8`, and that is already the condition
+        # under which the TARGET routes through the same asm kernel --
+        # `sparse_attn_v4_paged_decode` dispatches on `unified_kv_rope is not
+        # None` with no arch guard of its own (`paged_decode.py:1081`; the
+        # `get_gfx()` check below it guards only the bf16 fallback). So a draft
+        # that follows the pool's dtype is exposed to exactly what the target
+        # already is, and under bf16 KV it stays on the bf16 path.
+        #
+        # Config, fixed before the model is built, so this is the one fp8 signal
+        # the TRACED region may read: unlike `attn.kv_fp8`, which
+        # `build_kv_cache_tensor` binds only after warmup has already traced,
+        # baking this into a compiled graph cannot be wrong.
+        self.dspark_fp8_planned = get_current_atom_config().kv_cache_dtype == "fp8"
+        if not self.dspark_fp8_planned:
+            self.attn.window_kv_dtype = torch.bfloat16
 
         # Register for the opaque attention op's lookup. `dspark_attention` is
         # reachable ONLY through torch.ops.aiter.dspark_block_attention, which
@@ -584,7 +674,11 @@ class DSparkLayer(Block):  # type: ignore[misc]
     # ---- DSpark attention path (replaces Block.attn's paged sparse attn) -----
 
     def _compute_main_kv(
-        self, main_x: torch.Tensor, positions: torch.Tensor
+        self,
+        main_x: torch.Tensor,
+        positions: torch.Tensor,
+        *,
+        fake_quant: bool = True,
     ) -> torch.Tensor:
         """Project target hidden states into rolling-window KV rows (post
         kv_norm + RoPE + QAT). main_x: [T, dim] -> [T, head_dim].
@@ -593,7 +687,10 @@ class DSparkLayer(Block):  # type: ignore[misc]
         than ``main_x``; only its first T entries are used.
 
         The NoPE lanes are fake-quantized through fp8 E4M3 (DSpark QAT numerics)
-        then stored bf16 — matching the QAT-trained draft's expected KV values."""
+        then stored bf16 — matching the QAT-trained draft's expected KV values.
+        ``fake_quant=False`` skips that round trip for the caller that quantizes
+        the same lanes for real on its way into an fp8 window; doing both would
+        quantize twice, and under two different amax floors."""
         a = self.attn
         qr_kv = _linear_out(a.wqkv_a(main_x))
         _, kv = torch.split(qr_kv, [a.q_lora_rank, a.head_dim], dim=-1)
@@ -608,7 +705,8 @@ class DSparkLayer(Block):  # type: ignore[misc]
         # (-0 == 0).
         if rope_dim:
             a.rotary_emb.forward(positions.view(-1)[: kv.shape[0]], kv[..., -rope_dim:])
-        _apply_dspark_kv_qat_(kv, rope_dim)
+        if fake_quant:
+            _apply_dspark_kv_qat_(kv, rope_dim)
         return kv.view(-1, a.head_dim)
 
     def write_context_kv(
@@ -649,7 +747,32 @@ class DSparkLayer(Block):  # type: ignore[misc]
         B = fc.context.batch_size
         cu_seqlens_q = attn_md.cu_seqlens_q[: B + 1]
         a = self.attn
-        main_kv = self._compute_main_kv(main_x, positions)  # [T, head_dim]
+        # An fp8 window is the planes' own 2buff layout, so the verified target
+        # KV is quantized for real on its way in and scattered across both
+        # planes, exactly as the draft block's own KV is by the fused quant in
+        # `dspark_attention`. The QAT fake round trip is skipped: it holds the
+        # same NoPE lanes at fp8 precision in bf16 storage, which is what the
+        # real quant supersedes.
+        to_2buff = a.swa_plane.dtype != torch.bfloat16
+        main_kv = self._compute_main_kv(
+            main_x, positions, fake_quant=not to_2buff
+        )  # [T, head_dim]
+        if to_2buff:
+            k_packed, k_rope = quantize_bf16_to_v4_2buff_triton(main_kv)
+            swa_write(
+                None,  # bf16 KV: unused once the 2buff pair is supplied
+                positions,  # [T] int64
+                cu_seqlens_q,  # [B+1] int32, per-req spans
+                attn_md.state_slot_out[:B],  # [B] ring slot per request
+                a.swa_plane,  # [plane_rows, 512] fp8
+                a.swa_window,
+                self.write_per_batch,
+                k_packed=k_packed.view(-1, 1, V4_DIM_QK_PACKED),
+                k_rope=k_rope.view(-1, 1, V4_DIM_ROPE),
+                pool_rope=a.swa_plane_rope,  # [plane_rows, 64] bf16
+                prefix=f"{a.layer_name}.dspark_swa_write_2buff",
+            )
+            return
         # The window was reserved at the dtype this layer declared in
         # `window_kv_dtype`, while main_kv carries whatever the projections
         # produce — two independent sources. Assert instead of casting so a
@@ -704,12 +827,62 @@ class DSparkLayer(Block):  # type: ignore[misc]
 
         # Draft positions (anchor+1 .. anchor+T) come from the shared block plan.
         rope_dim = a.rope_head_dim
+        from atom.utils.forward_context import get_forward_context
+
+        fc = get_forward_context()
+        W = self.window_size
+        # The asm fp8 path needs the target's 2buff planes, which exist only
+        # under `--kv_cache_dtype fp8` (`deepseek_v4_attn.py:455`), and needs the
+        # pool bound, which warmup precedes. Fall back rather than fail: both
+        # paths are correct and differ in numerics and speed. This is the
+        # runtime form of `dspark_fp8_planned` -- same condition, read off the
+        # layer once the pool has actually bound it.
+        slots = draft_rows = batch_ids = kv_indices = kv_indptr = None
+        use_fp8 = (
+            getattr(a, "kv_fp8", False)
+            and getattr(a, "unified_kv_rope", None) is not None
+            and not fc.context.is_dummy_run
+        )
+        if use_fp8:
+            slots = fc.attn_metadata.state_slot_out[:B]
+            # Ring rows for this block's own KV, so the fused quant below can
+            # scatter it as it computes it. Writing speculative rows is safe for
+            # the reason `write_context_kv` may write rejected ones
+            # (`dspark_proposer.py:372-376`): they land strictly above the
+            # anchor, and no gather ever addresses above the anchor, so a
+            # rejected row stays unreadable until the step that accepts it
+            # overwrites it. One stage's draft KV still stays invisible to the
+            # next, because `swa_plane` is this layer's own view of the plane —
+            # what the stages share is the row NUMBER, not the row.
+            #
+            # One Triton launch builds the draft ring rows, the CSR offsets and
+            # the CSR list together, and only stage 0 pays for it; later stages
+            # read the same buffers back. That is sound precisely because the
+            # numbers are stage-invariant: every DSpark layer has compress ratio
+            # 0 (`deepseek_v4_attn.py:434`) so they share one `WindowParams`,
+            # and each layer's `unified_kv` / `swa_plane` is its own base-row
+            # view, so one (slot, position) is the same layer-relative row in
+            # all of them. Stage 0 always runs first and always refills them --
+            # `_DSparkInner.forward` walks `self.mtp` in order -- and
+            # `dspark_indices_view` raises if it somehow did not.
+            kv_buf = dspark_kv_index_scratch(B, T, W, x.device)
+            if self.stage_id == 0:
+                kv_indices, kv_indptr, draft_rows = dspark_build_indices(
+                    a.swa_window, slots, positions, T, W, kv_buf
+                )
+            else:
+                kv_indices, kv_indptr, draft_rows = dspark_indices_view(
+                    B, T, W, x.device, kv_buf
+                )
+            batch_ids = _dspark_batch_ids(B, T, x.device)
+
         # Per-head weightless Q RMSNorm + weighted KV RMSNorm + GPT-J RoPE in ONE
         # fused kernel — the same `qk_norm_rope_maybe_quant` the V4 target runs
-        # every layer (bf16 path: quant off, no SWA fusion — DSpark scatters its
-        # window separately). Replaces the draft's hand-written weightless Q-norm
-        # + kv_norm + the `rotary_emb.forward` (_V4RoPE) RoPE launch. `kv` is
-        # passed PRE-norm; the kernel applies kv_norm.weight internally.
+        # every layer. `kv` is passed PRE-norm; the kernel applies
+        # kv_norm.weight internally. Under fp8 the one launch additionally
+        # group-quants into the 2buff layout and scatters the draft KV into the
+        # ring, mirroring the target's decode call (`deepseek_v4.py:3060`); the
+        # bf16 path quants nothing and scatters its window separately.
         qkn = qk_norm_rope_maybe_quant(
             q,
             kv,
@@ -723,47 +896,81 @@ class DSparkLayer(Block):  # type: ignore[misc]
             a.eps,
             quant_q=False,
             quant_k=False,
+            fp8_2buff=use_fp8,
+            swa_nope_scale_buff=a.swa_plane if use_fp8 else None,
+            swa_rope_buff=a.swa_plane_rope if use_fp8 else None,
+            swa_dest_rows=draft_rows if use_fp8 else None,
+            batch_id_per_token=batch_ids if use_fp8 else None,
             prefix=f"{a.layer_name}.dspark_qk_norm_rope",
         )
-        q = qkn.q_sa.view(B, T, a.n_local_heads, a.head_dim)
-        kv = qkn.kv.view(B * T, 1, a.head_dim)
-        _apply_dspark_kv_qat_(kv, rope_dim)
-        kv = kv.view(B, T, a.head_dim)
 
-        # Assemble the [window ++ draft block] KV. The window-validity mask and
-        # gather indices are stage-invariant and come from the block plan; only
-        # the KV gather is per-stage (each stage owns its own plane).
-        # Gather the dense [B, W, head_dim] rolling window from this draft
-        # layer's plane, addressed by the request's state slot — the same
-        # expression the write used.
-        from atom.utils.forward_context import get_forward_context
-
-        fc = get_forward_context()
-        W = self.window_size
-        if fc.context.is_dummy_run:
-            # warmup runs BEFORE allocate_kv_cache → swa_plane / state_slot_out
-            # unbound. All-zero window so the forward still compiles at shape
-            # (draft output is discarded).
-            window_kv = kv.new_zeros(B, W, a.head_dim)
+        if use_fp8:
+            # The draft KV is in the ring now, so the whole
+            # [window ++ draft-block] KV is addressable as pool rows and never
+            # has to be materialised. One CSR list per query row, N = B*T rows
+            # at max_seqlen_q=1 — the target's own decode convention
+            # (`deepseek_v4_attn.py:3727`). The bf16 path's `topk_idxs` is a
+            # broadcast along T, so all T positions of a request share one list,
+            # which is exactly what a per-row CSR slice expresses.
+            out = sparse_attn_v4_paged_decode(
+                None,  # bf16 q: dead on the asm path, which reads q_packed_in
+                a.unified_kv,
+                kv_indices,
+                kv_indptr,
+                a.attn_sink[: a.n_local_heads],
+                # Ignored downstream — the kernel hardcodes 1/sqrt(512), which
+                # is what `head_dim**-0.5` already is here. Passed for parity.
+                a.softmax_scale,
+                unified_kv_rope=a.unified_kv_rope,
+                q_packed_in=qkn.q_packed,
+                q_rope_in=qkn.q_rope,
+                qo_indptr=dspark_qo_indptr(B, T, x.device),
+                prefix=f"{a.layer_name}.dspark_attn_fp8",
+            )  # [B*T, n_heads, head_dim]
+            out = out.view(B, T, a.n_local_heads, a.head_dim)
         else:
-            attn_md = fc.attn_metadata
-            window_kv = dspark_paged_window_gather(
-                a.swa_plane,  # [plane_rows, head_dim]
-                attn_md.state_slot_out[:B],  # [B] ring slot per request
-                positions,  # [B] anchor positions
-                W,
-                a.swa_window,
-            )  # [B, W, head_dim]
-        all_kv = torch.cat([window_kv, kv], dim=1)  # [B, W+T, head_dim]
+            q = qkn.q_sa.view(B, T, a.n_local_heads, a.head_dim)
+            kv = qkn.kv.view(B * T, 1, a.head_dim)
+            _apply_dspark_kv_qat_(kv, rope_dim)
+            kv = kv.view(B, T, a.head_dim)
 
-        out = _dspark_block_sparse_attention(
-            q,
-            all_kv,
-            a.attn_sink[: a.n_local_heads],
-            valid_target,
-            topk_idxs,
-            a.softmax_scale,
-        )  # [B, T, n_heads, head_dim]
+            if topk_idxs.numel() == 0:
+                # The plan omits the gather block whenever the fp8 path is
+                # PLANNED, but planning it is not taking it: the warmup dummy
+                # run cannot (`swa_plane` is unbound before `allocate_kv_cache`)
+                # and neither can a layer `build_kv_cache_tensor` left without
+                # planes. Both land here and still need the block, so rebuild
+                # it. Here and not in `_build_block_plan` because this body is
+                # opaque to Dynamo and runs eagerly every step, so the branch
+                # cannot bake -- which is exactly what that function may not do.
+                topk_idxs = _dspark_block_topk_idxs(B, T, W, valid_target, x.device)
+
+            # Assemble the [window ++ draft block] KV. The window-validity mask
+            # and gather indices are stage-invariant and come from the block
+            # plan; only the KV gather is per-stage (each stage owns its plane).
+            if fc.context.is_dummy_run:
+                # warmup runs BEFORE allocate_kv_cache → swa_plane /
+                # state_slot_out unbound. All-zero window so the forward still
+                # compiles at shape (draft output is discarded).
+                window_kv = kv.new_zeros(B, W, a.head_dim)
+            else:
+                window_kv = dspark_paged_window_gather(
+                    a.swa_plane,  # [plane_rows, head_dim]
+                    fc.attn_metadata.state_slot_out[:B],  # [B] ring slot per req
+                    positions,  # [B] anchor positions
+                    W,
+                    a.swa_window,
+                )  # [B, W, head_dim]
+            all_kv = torch.cat([window_kv, kv], dim=1)  # [B, W+T, head_dim]
+
+            out = _dspark_block_sparse_attention(
+                q,
+                all_kv,
+                a.attn_sink[: a.n_local_heads],
+                valid_target,
+                topk_idxs,
+                a.softmax_scale,
+            )  # [B, T, n_heads, head_dim]
 
         # Output projection: mirror DeepseekV4Attention's output stage exactly
         # (`_attn_core` + `_attn_post`). `_wo_a_grouped_lora` owns the inverse
@@ -1107,7 +1314,9 @@ class _DSparkInner(nn.Module):
         # Per-block invariants (draft positions, window validity, gather indices)
         # depend only on (positions, T, W), so build them once and share across
         # every stage instead of recomputing them inside each stage's attention.
-        plan = _build_block_plan(positions, T, self.mtp[0].window_size)
+        plan = _build_block_plan(
+            positions, T, self.mtp[0].window_size, self.mtp[0].dspark_fp8_planned
+        )
 
         # ----- Parallel backbone: run all stages over the block in one pass ---
         hc_state = None


### PR DESCRIPTION
DSpark's block attention ran bf16 Triton `sparse_attn` over a materialised `[B, W+T, 512]` KV. We support ASM kernel with fp8

<img width="1440" height="338" alt="image" src="https://github.com/user-attachments/assets/9286bdf2-0a10-4a04-88d6-a85775fc8763" />

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     3|exact_match|↑  |0.9515|±  |0.0059|
|     |       |strict-match    |     3|exact_match|↑  |0.9522|±  |0.0059|
```

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
