### PR TITLE
fake-eplb: route on a zero router correction bias

### DIFF
--- a/atom/model_ops/fused_moe/config.py
+++ b/atom/model_ops/fused_moe/config.py
@@ -376,8 +376,17 @@ def moe_kernel_token_capacity(
     ``[T, topk+shared]`` buffer, so ``T`` must cover the gathered width:
     ``max_num_batched_tokens * dp_size`` (times the simulated-DP repeat).
     All2all/EP keeps tokens local, so the per-rank scheduler budget is enough.
+
+    ``repeat_rows`` also runs alone in ``forward_impl`` (the single-real-rank
+    path, with no gather to ride along with), so the simulated-DP repeat
+    applies at ``dp_size == 1`` too.
     """
     tokens = atom_config.max_num_batched_tokens
-    if atom_config.enable_dp_attention and dp_size > 1 and not use_all2all:
-        tokens *= dp_size * max(int(dp_logical_ratio), 1)
+    if use_all2all:
+        return tokens
+    repeat = max(int(dp_logical_ratio), 1)
+    if atom_config.enable_dp_attention and dp_size > 1:
+        return tokens * dp_size * repeat
+    if dp_size == 1:
+        return tokens * repeat
     return tokens

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2858,6 +2858,14 @@ class FusedMoE(torch.nn.Module):
         self.custom_routing_function = custom_routing_function
         self.scoring_func = scoring_func
         self.e_score_correction_bias = e_score_correction_bias
+        if atom_config.fake_eplb and e_score_correction_bias is not None:
+            # The noaux_tc bias is added on top of the score, so a bias wider than
+            # the synthetic logits' gap (~3.16 after sqrtsoftplus) picks the top-k
+            # by itself -- and `--load_dummy` never writes it, leaving recycled
+            # garbage that collapses every token onto one EP rank. `del` first: a
+            # plain tensor cannot overwrite the parameter registered above.
+            del self.e_score_correction_bias
+            self.e_score_correction_bias = torch.zeros_like(e_score_correction_bias)
         self.activation = activation
         if config is not None:
             self.activation_situ_beta = getattr(config, "activation_situ_beta", None)


### PR DESCRIPTION
# fake-eplb: route on a zero router correction bias

Branch: `jun/eplb_dummy_fix` → `main`
Commit: `2e5bc603b`
File: `atom/model_ops/moe.py` (+8)

## Summary

Under `--fake-eplb` + `--load_dummy`, every token collapsed onto EP rank 0,
defeating the whole purpose of fake-eplb (a perfectly-balanced-load upper bound
for MoE kernel benchmarking).

Root cause: `--load_dummy` (bare flag = `"empty"`) never writes
`gate.e_score_correction_bias`, so the tensor holds whatever the recycled
allocation left behind — observed up to `7.5e3` on DeepSeek-V4-Flash. The
noaux_tc router adds this correction bias on top of the score *before* top-k,
and the synthetic fake-eplb logits (`±_FAKE_EPLB_LOGIT`) differ by only ~3.16
after `sqrtsoftplus` (1.0 after `sigmoid`). So a bias wider than that gap
overrides the routing entirely: every token selects the same few experts, all
owned by one EP rank.

Fix: when `fake_eplb` is on, route on a zeroed correction bias. It is a
separate tensor — the gate keeps its own parameter, so real-weight loads are
unaffected, and dropping the registration (`del` before reassign) also keeps
the zeros out of `named_parameters()` so the loader's unloaded-parameter check
stays quiet.

## The change

```python
self.e_score_correction_bias = e_score_correction_bias
if atom_config.fake_eplb and e_score_correction_bias is not None:
    # The noaux_tc bias is added on top of the score, so a bias wider than
    # the synthetic logits' gap (~3.16 after sqrtsoftplus) picks the top-k
    # by itself -- and `--load_dummy` never writes it, leaving recycled
    # garbage that collapses every token onto one EP rank. `del` first: a
    # plain tensor cannot overwrite the parameter registered above.
    del self.e_score_correction_bias
    self.e_score_correction_bias = torch.zeros_like(e_score_correction_bias)
```

## Verification

DeepSeek-V4-Flash-FP8, `-tp 4 --enable-dp-attention --enable-expert-parallel
--load_dummy --fake-eplb --hf-overrides '{"num_hash_layers":0}'`. Measured the
real `topk_ids` at the MoE kernel entry (`quant_method.apply`):

| | per-rank top-k histogram |
|---|---|
| before | `[98304, 0, 0, 0]` — all tokens on EP rank 0 |
| after  | aggregated over the 4 DP ranks: `[98304, 98304, 98304, 98304]` — exactly uniform |

Also confirmed the dispatch path itself is correct in this config, so nothing
downstream re-concentrates the balanced ids:

- `use_all2all_kernels = True` (mori all2all — the only branch that could leave
  ranks empty)
- `expert_mask` spans `[0,63] [64,127] [128,191] [192,255]` — 64-wide,
  non-overlapping, matching the mori dispatch divisor `num_local_experts = 64`
- `expert_layout.mode = NONE`, so `local_num_experts` is not bumped by a fused
  shared expert

## Out of scope (found while investigating, not fixed here)

- **Hash layers** (`layer_id < num_hash_layers`): routing goes through
  `custom_routing_function` (`tid2eid[input_ids]`), which bypasses
  `router_logits` and so is untouched by fake-eplb. Under `--load_dummy`,
  `tid2eid` is uninitialized and gets clamped to expert 0, sending all tokens
  to rank 0. Worked around at launch with `--hf-overrides '{"num_hash_layers":0}'`.

