### PR TITLE
[Feature] Integrate the AITER MK1 persistent decoder

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1525,6 +1525,10 @@ class Config:
     kv_cache_block_size: int = 16
     num_kvcache_blocks: int = -1
     kv_cache_dtype: str = "bf16"
+    # AITER GPT-OSS persistent decoder. This is strict opt-in while the
+    # provider is limited to TP1/gfx950/batch-one decode.
+    persistent_decoder: str = "off"  # off | auto | required
+    persistent_decoder_checkpoint: str | None = None
     index_cache_dtype: str | None = None
     enable_prefix_caching: bool = True
     enable_chunked_prefill: bool = True
@@ -1675,6 +1679,41 @@ class Config:
             self.dcp_config = DCPConfig(**self.dcp_config.__dict__)
         else:
             raise TypeError("dcp_config must be DCPConfig or dict")
+
+        if self.persistent_decoder not in ("off", "auto", "required"):
+            raise ValueError("persistent_decoder must be off, auto, or required")
+        if self.persistent_decoder != "off":
+            if not self.persistent_decoder_checkpoint:
+                raise ValueError(
+                    "persistent_decoder_checkpoint is required when persistent decode is enabled"
+                )
+            if self.kv_cache_block_size != 32:
+                raise ValueError("persistent decode requires --block-size 32")
+            if self.kv_cache_dtype != "bf16":
+                raise ValueError("persistent decode currently requires BF16 KV cache")
+            if self.tensor_parallel_size != 1 or self.pipeline_parallel_size != 1:
+                raise ValueError("persistent decode currently requires TP1/PP1")
+            if self.prefill_context_parallel_size != 1:
+                raise ValueError("persistent decode currently requires PCP1")
+            if self.decode_context_parallel_size != 1:
+                raise ValueError("persistent decode currently requires DCP1")
+            if self.enable_expert_parallel or self.enable_dp_attention:
+                raise ValueError(
+                    "persistent decode does not support EP or DP attention"
+                )
+            if self.speculative_config is not None:
+                raise ValueError(
+                    "persistent decode does not support speculative decoding"
+                )
+            kv_transfer_enabled = self.kv_transfer_config not in ({}, None, "", "{}")
+            if self.enable_tbo or self.enable_rapidserve or kv_transfer_enabled:
+                raise ValueError(
+                    "persistent decode does not support TBO, RapidServe, or KV transfer"
+                )
+            if self.enable_prefix_caching or self.enable_chunked_prefill:
+                raise ValueError(
+                    "persistent decode v1 requires prefix caching and chunked prefill disabled"
+                )
         # assert os.path.isdir(self.model)
 
         # The forced-acceptance schedule spends its whole budget on the first
@@ -1780,6 +1819,20 @@ class Config:
         self.hf_config = get_hf_config(
             self.model, trust_remote_code=self.trust_remote_code
         )
+        if self.persistent_decoder != "off":
+            architectures = tuple(getattr(self.hf_config, "architectures", ()) or ())
+            if "GptOssForCausalLM" not in architectures:
+                raise ValueError(
+                    "persistent decode currently supports GptOssForCausalLM only"
+                )
+            if int(getattr(self.hf_config, "num_hidden_layers", -1)) != 36:
+                raise ValueError(
+                    "persistent decode requires the 36-layer GPT-OSS model"
+                )
+            if int(getattr(self.hf_config, "num_key_value_heads", -1)) != 8:
+                raise ValueError("persistent decode requires 8 GPT-OSS KV heads")
+            if int(getattr(self.hf_config, "head_dim", -1)) != 64:
+                raise ValueError("persistent decode requires GPT-OSS head_dim=64")
         num_hidden_layers = getattr(self.hf_config, "num_hidden_layers", None)
         if num_hidden_layers is not None:
             assert num_hidden_layers >= self.pipeline_parallel_size, (

--- a/atom/config.py
+++ b/atom/config.py
@@ -1687,8 +1687,6 @@ class Config:
                 raise ValueError(
                     "persistent_decoder_checkpoint is required when persistent decode is enabled"
                 )
-            if self.kv_cache_block_size != 32:
-                raise ValueError("persistent decode requires --block-size 32")
             if self.kv_cache_dtype != "bf16":
                 raise ValueError("persistent decode currently requires BF16 KV cache")
             if self.tensor_parallel_size != 1 or self.pipeline_parallel_size != 1:

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -51,6 +51,8 @@ class EngineArgs:
     enable_prefix_caching: bool = True
     port: int = 8006
     kv_cache_dtype: str = "bf16"
+    persistent_decoder: str = "off"
+    persistent_decoder_checkpoint: str | None = None
     index_cache_dtype: str | None = None
     block_size: int = 16
     max_model_len: int | None = None
@@ -215,6 +217,21 @@ class EngineArgs:
             type=str,
             default="bf16",
             help="KV cache type. Default is 'bf16'.",
+        )
+        persistent = parser.add_argument_group("GPT-OSS persistent decoder")
+        persistent.add_argument(
+            "--persistent-decoder",
+            choices=["off", "auto", "required"],
+            default="off",
+            help="Enable AITER's gfx950 GPT-OSS persistent decoder.",
+        )
+        persistent.add_argument(
+            "--persistent-decoder-checkpoint",
+            default=None,
+            help=(
+                "Local directory containing the compiled persistent checkpoint. "
+                "Required only when persistent decoding is enabled."
+            ),
         )
         parser.add_argument(
             "--index-cache-dtype",

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -1149,6 +1149,25 @@ class BlockManager:
                 # correct hash here.  Just allocate the block without hashing.
                 block_table.append(self._fresh_block())
 
+    def reserve_append(self, seq: Sequence, num_new_tokens: int) -> bool:
+        """Reserve every page a multi-token resident quantum may write.
+
+        ``may_append`` intentionally follows the ordinary one-step scheduler.
+        A persistent quantum can advance several cache positions without
+        returning to the scheduler, so it needs an exact up-front reservation.
+        """
+
+        if num_new_tokens < 1:
+            return False
+        ebs = self._effective_block_size()
+        needed_blocks = (len(seq) + num_new_tokens + ebs - 1) // ebs
+        new_blocks = max(0, needed_blocks - len(seq.block_table))
+        if not self.kv.has_free(new_blocks):
+            return False
+        while len(seq.block_table) < needed_blocks:
+            seq.block_table.append(self._fresh_block())
+        return True
+
     # ---------------- KV event API ---------------- #
 
     def take_events(self) -> list[KVCacheEvent]:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -693,6 +693,11 @@ class ModelRunner:
             use_spec,
             self.num_spec_tokens,
         )
+        if self.config.persistent_decoder != "off":
+            # Ordinary and resident steps must share one synchronous token
+            # frontier; deferred output would surface a stale ordinary token
+            # after a persistent handoff.
+            self.tokenID_processor.is_deferred_out = False
         self.sampler = Sampler()
         self.arange_np = np.arange(
             max(
@@ -841,7 +846,15 @@ class ModelRunner:
         """Extra GPU bytes to hold back from the KV cache budget beyond the
         base overhead. Base runner reserves nothing; override point for
         setups that share the GPU with another process."""
-        return 0
+        if self.config.persistent_decoder == "off":
+            return 0
+        from aiter.MK1 import persistent_checkpoint_bytes
+
+        # AITER loads persistent weights only after KV allocation, so reserve
+        # their exact catalog footprint plus 2 GiB for staging and workspaces.
+        return persistent_checkpoint_bytes(
+            self.config.persistent_decoder_checkpoint
+        ) + (2 << 30)
 
     def is_deepseek_mla(self) -> bool:
         if not hasattr(self.hf_text_config, "model_type"):
@@ -2031,6 +2044,18 @@ class ModelRunner:
                     f"expected={expected_kv_bytes / (1 << 30):.3f}GB, "
                     f"actual={actual_kv_bytes / (1 << 30):.3f}GB, "
                     f"diff={diff_pct:.1%}"
+                )
+
+        if config.persistent_decoder != "off":
+            from atom.model_engine.persistent_decoder import AtomPersistentDecoder
+
+            try:
+                self.persistent_decoder = AtomPersistentDecoder(self)
+            except Exception:
+                if config.persistent_decoder == "required":
+                    raise
+                logger.exception(
+                    "Persistent decoder initialization failed; auto mode will use ATOM"
                 )
 
         # Skip on single-rank: a world_size==1 barrier is a no-op but still
@@ -3379,6 +3404,23 @@ class ModelRunner:
     @torch.inference_mode()
     @with_eplb_forward_monitor
     def forward(self, batch: ScheduledBatch) -> ScheduledBatchOutput:
+        plan = getattr(batch, "persistent_plan", None)
+        persistent = getattr(self, "persistent_decoder", None)
+        if plan is not None and persistent is not None and persistent.healthy:
+            emitted = persistent.run(plan)
+            zeros = np.zeros(1, dtype=np.int32)
+            return ScheduledBatchOutput(
+                req_ids=[plan.request_id],
+                token_ids=[emitted],
+                num_rejected=zeros,
+                num_bonus=zeros.copy(),
+                draft_token_ids=None,
+                is_deferred_out=False,
+            )
+        if plan is not None and persistent is not None and not persistent.healthy:
+            raise RuntimeError(
+                "persistent decoder is unhealthy after a backend execution failure"
+            )
         # Make this forward's staging buffers safe to overwrite before
         # prepare_inputs writes them: rotate to a free slot if there is a ring,
         # otherwise wait out the previous forward's copies.

--- a/atom/model_engine/persistent_decoder.py
+++ b/atom/model_engine/persistent_decoder.py
@@ -127,8 +127,8 @@ class AtomPersistentDecoder:
 
     def __init__(self, runner) -> None:
         from aiter.MK1 import (
-            AtomCacheBinding,
             BackendLaunchError,
+            KVCacheBinding,
             MK1Config,
             PersistentDecoder as AiterPersistentDecoder,
             PrelaunchError,
@@ -189,8 +189,8 @@ class AtomPersistentDecoder:
         ):
             raise RuntimeError("ATOM cache layer has incompatible plane byte length")
 
-        self.native.bind_atom_cache(
-            AtomCacheBinding(
+        self.native.bind_cache(
+            KVCacheBinding(
                 key_planes=key_bytes,
                 value_planes=value_bytes,
                 block_counts=(int(runner.num_physical_kvcache_blocks),) * 36,

--- a/atom/model_engine/persistent_decoder.py
+++ b/atom/model_engine/persistent_decoder.py
@@ -1,0 +1,275 @@
+"""AITER MK1 persistent decoder over ATOM's native KV cache.
+
+ATOM owns request admission, cache allocation, page reservation, block maps,
+and ordinary fallback. AITER owns compiled-checkpoint loading, native binaries,
+weight lifetime, cache binding, and quantum execution.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+logger = logging.getLogger("atom")
+
+PERSISTENT_LAYER_COUNT = 36
+PERSISTENT_PHYSICAL_PAGE_SIZE = 16
+PERSISTENT_KV_HEADS = 8
+PERSISTENT_HEAD_DIM = 64
+PERSISTENT_PLANE_BLOCK_BYTES = 16384
+PERSISTENT_MAX_QUANTUM_TOKENS = 8
+SAMPLING_EPS = 1.0e-5
+
+
+@dataclass(frozen=True)
+class PersistentDecodePlan:
+    """Frozen scheduler command consumed by the runner worker."""
+
+    request_id: int
+    pending_token: int
+    committed_kv_length: int
+    max_sequence_length: int
+    max_tokens: int
+    eos_token_id: int
+    ignore_eos: bool
+    block_table: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class PersistentDecodeDecision:
+    plan: PersistentDecodePlan | None
+    rejection_reason: str | None
+
+    @property
+    def selected(self) -> bool:
+        return self.plan is not None
+
+
+def decide_persistent_decode(
+    *,
+    mode: str,
+    seqs: Iterable[Any],
+    num_scheduled_tokens: Iterable[int],
+    has_queued_work: bool,
+    use_spec: bool,
+    max_model_len: int,
+    eos_token_id: int,
+    extra_eos_token_ids: Iterable[int] = (),
+) -> PersistentDecodeDecision:
+    """Apply the batch-one persistent-decode admission contract."""
+
+    if mode == "off":
+        return PersistentDecodeDecision(None, "disabled")
+    seqs = tuple(seqs)
+    scheduled = tuple(int(value) for value in num_scheduled_tokens)
+    if use_spec:
+        return PersistentDecodeDecision(None, "speculative_decode")
+    if has_queued_work:
+        return PersistentDecodeDecision(None, "queued_work")
+    if len(seqs) != 1 or len(scheduled) != 1:
+        return PersistentDecodeDecision(None, "unsupported_decode_batch")
+    if scheduled[0] != 1:
+        return PersistentDecodeDecision(None, "tokens_per_query")
+
+    seq = seqs[0]
+    if float(seq.temperature) > SAMPLING_EPS:
+        return PersistentDecodeDecision(None, "non_greedy")
+    if bool(seq.return_logprobs):
+        return PersistentDecodeDecision(None, "logprobs")
+    if getattr(seq, "stop_strings", None):
+        return PersistentDecodeDecision(None, "stop_strings")
+    if getattr(seq, "stop_token_sequences", None):
+        return PersistentDecodeDecision(None, "stop_token_sequences")
+    if getattr(seq, "kv_transfer_params", None):
+        return PersistentDecodeDecision(None, "kv_transfer")
+
+    committed = int(seq.num_tokens) - 1
+    if committed < 0 or committed >= int(max_model_len) - 1:
+        return PersistentDecodeDecision(None, "max_sequence_length")
+    remaining = int(seq.max_tokens) - len(seq.output_tokens)
+    if remaining < 1:
+        return PersistentDecodeDecision(None, "no_output_remaining")
+
+    eos_ids = {int(eos_token_id), *(int(token) for token in extra_eos_token_ids)}
+    eos_ids.discard(-1)
+    quantum_cap = PERSISTENT_MAX_QUANTUM_TOKENS
+    if len(eos_ids) > 1 and not seq.ignore_eos:
+        quantum_cap = 1
+    quantum = min(
+        quantum_cap,
+        remaining,
+        int(max_model_len) - committed - 1,
+    )
+    if quantum < 1:
+        return PersistentDecodeDecision(None, "no_output_remaining")
+
+    return PersistentDecodeDecision(
+        PersistentDecodePlan(
+            request_id=int(seq.id),
+            pending_token=int(seq.last_token),
+            committed_kv_length=committed,
+            max_sequence_length=int(max_model_len),
+            max_tokens=quantum,
+            eos_token_id=int(eos_token_id),
+            ignore_eos=bool(seq.ignore_eos),
+            block_table=tuple(int(block) for block in seq.block_table),
+        ),
+        None,
+    )
+
+
+class AtomPersistentDecoder:
+    """Translate ATOM scheduler/cache state into the AITER MK1 provider ABI."""
+
+    def __init__(self, runner) -> None:
+        from aiter.MK1 import (
+            AtomCacheBinding,
+            BackendLaunchError,
+            MK1Config,
+            PersistentDecoder as AiterPersistentDecoder,
+            PrelaunchError,
+            QuantumRequest,
+        )
+
+        self._backend_error = BackendLaunchError
+        self._prelaunch_error = PrelaunchError
+        self._quantum_request = QuantumRequest
+        self.runner = runner
+        self.config = runner.config
+        self.healthy = False
+
+        mk1_config = MK1Config(
+            device=torch.cuda.current_device(),
+            max_sequence_length=int(self.config.max_model_len),
+            cache_scalar="bfloat16",
+            batch_size=1,
+            mode=self.config.persistent_decoder,
+        )
+        logger.info(
+            "Loading ATOM persistent checkpoint through AITER provider: %s",
+            self.config.persistent_decoder_checkpoint,
+        )
+        self.native = AiterPersistentDecoder.from_checkpoint(
+            mk1_config,
+            self.config.persistent_decoder_checkpoint,
+        )
+
+        expected_plane_shape = (
+            int(runner.num_physical_kvcache_blocks),
+            PERSISTENT_PHYSICAL_PAGE_SIZE,
+            PERSISTENT_KV_HEADS,
+            PERSISTENT_HEAD_DIM,
+        )
+        key_planes = tuple(runner.kv_cache[0, index] for index in range(36))
+        value_planes = tuple(runner.kv_cache[1, index] for index in range(36))
+        for index, (key, value) in enumerate(zip(key_planes, value_planes)):
+            if not key.is_contiguous() or not value.is_contiguous():
+                raise RuntimeError(
+                    f"ATOM cache layer {index} must have contiguous K/V planes"
+                )
+            if (
+                tuple(key.shape) != expected_plane_shape
+                or tuple(value.shape) != expected_plane_shape
+            ):
+                raise RuntimeError(
+                    f"ATOM cache layer {index} has incompatible geometry "
+                    f"K={tuple(key.shape)} V={tuple(value.shape)}"
+                )
+        key_bytes = tuple(plane.view(torch.uint8).flatten() for plane in key_planes)
+        value_bytes = tuple(plane.view(torch.uint8).flatten() for plane in value_planes)
+        expected_plane_bytes = (
+            int(runner.num_physical_kvcache_blocks) * PERSISTENT_PLANE_BLOCK_BYTES
+        )
+        if any(
+            plane.numel() != expected_plane_bytes for plane in key_bytes + value_bytes
+        ):
+            raise RuntimeError("ATOM cache layer has incompatible plane byte length")
+
+        self.native.bind_atom_cache(
+            AtomCacheBinding(
+                key_planes=key_bytes,
+                value_planes=value_bytes,
+                block_counts=(int(runner.num_physical_kvcache_blocks),) * 36,
+                block_strides=(PERSISTENT_PLANE_BLOCK_BYTES,) * 36,
+                pools=(1,) * 36,
+            )
+        )
+        self.rope_cosine, self.rope_sine = self._rope_tables()
+        self.healthy = True
+        checkpoint = self.native.checkpoint_info() or {}
+        logger.info(
+            "ATOM persistent decoder ready: checkpoint_bytes=%s, cache_blocks=%d",
+            checkpoint.get("persistent_bytes", "unknown"),
+            runner.num_physical_kvcache_blocks,
+        )
+
+    def _rope_tables(self) -> tuple[torch.Tensor, torch.Tensor]:
+        rotary = self.runner.model.model.layers[0].self_attn.rotary_emb
+        cosine_source = rotary.cos_cache.squeeze()
+        sine_source = rotary.sin_cache.squeeze()
+        if cosine_source.ndim != 2 or cosine_source.shape[1] != 32:
+            raise RuntimeError(
+                f"unsupported GPT-OSS RoPE cache shape {tuple(cosine_source.shape)}"
+            )
+        length = min(int(self.config.max_model_len), cosine_source.shape[0])
+        cosine = torch.zeros(
+            (length, 64), dtype=torch.bfloat16, device=self.runner.device
+        )
+        sine = torch.zeros_like(cosine)
+        cosine[:, :32] = cosine_source[:length].to(torch.bfloat16)
+        sine[:, :32] = sine_source[:length].to(torch.bfloat16)
+        return cosine.contiguous(), sine.contiguous()
+
+    def run(self, plan: PersistentDecodePlan):
+        ratio = int(self.runner.block_size // self.runner.physical_block_size)
+        physical_blocks = tuple(
+            int(block) * ratio + offset
+            for block in plan.block_table
+            for offset in range(ratio)
+        )
+        block_map = torch.tensor(
+            physical_blocks, dtype=torch.int32, device=self.runner.device
+        ).contiguous()
+        request = self._quantum_request(
+            pending_token=plan.pending_token,
+            committed_kv_length=plan.committed_kv_length,
+            max_sequence_length=plan.max_sequence_length,
+            max_tokens=plan.max_tokens,
+            eos_token_id=plan.eos_token_id,
+            ignore_eos=plan.ignore_eos,
+            full_block_map=block_map,
+            sliding_block_map=None,
+            cancellation_flag=None,
+            rope_cosine=self.rope_cosine,
+            rope_sine=self.rope_sine,
+        )
+        try:
+            result = self.native.run_quantum(request)
+        except self._prelaunch_error:
+            raise
+        except self._backend_error:
+            self.healthy = False
+            raise
+
+        emitted = tuple(int(token) for token in result.emitted_tokens)
+        if not emitted or len(emitted) > plan.max_tokens:
+            self.healthy = False
+            raise RuntimeError("persistent decoder returned an invalid token count")
+        committed = int(result.committed_kv_length)
+        if committed != plan.committed_kv_length + len(emitted):
+            self.healthy = False
+            raise RuntimeError("persistent decoder returned an invalid cache frontier")
+        if int(result.pending_token) != emitted[-1]:
+            self.healthy = False
+            raise RuntimeError("persistent decoder returned an invalid pending token")
+
+        return emitted
+
+    def close(self) -> None:
+        native = getattr(self, "native", None)
+        if native is not None:
+            native.close()

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -23,6 +23,7 @@ import threading
 import time
 from collections import deque
 from collections.abc import Iterable
+from dataclasses import replace
 
 import numpy as np
 
@@ -30,6 +31,7 @@ from atom.config import Config
 from atom.kv_transfer.disaggregation import KVConnectorOutput
 from atom.model_engine.block_manager import BlockManager
 from atom.model_engine.request import RequestOutput
+from atom.model_engine.persistent_decoder import decide_persistent_decode
 from atom.model_engine.sequence import (
     Sequence,
     SequenceStatus,
@@ -577,6 +579,7 @@ class ScheduledBatch:
                 # Clear after first use to avoid re-sending on decode steps
                 seq.multimodal_data = None
         self.external_request_ids = [seq.external_request_id for seq in seqs.values()]
+        self.persistent_plan = None
 
         # logger.info(f"{[el for el in scheduled_spec_decode_tokens.keys()]=}")
         # logger.info(f"{self.num_scheduled_tokens=}")
@@ -1582,6 +1585,28 @@ class Scheduler:
                 else None
             ),
         )
+        if self.config.persistent_decoder != "off" and scheduled_seqs:
+            decision = decide_persistent_decode(
+                mode=self.config.persistent_decoder,
+                seqs=scheduled_seqs.values(),
+                num_scheduled_tokens=num_scheduled_tokens,
+                has_queued_work=(
+                    bool(self.waiting)
+                    or len(self.running) > len(scheduled_seqs)
+                    or self._num_parked_remote_kv > 0
+                ),
+                use_spec=self.use_spec,
+                max_model_len=self.max_model_len,
+                eos_token_id=self.eos_token_id,
+                extra_eos_token_ids=self.stop_token_ids,
+            )
+            if decision.plan is not None:
+                seq = next(iter(scheduled_seqs.values()))
+                if self.block_manager.reserve_append(seq, decision.plan.max_tokens):
+                    decode_batch.persistent_plan = replace(
+                        decision.plan,
+                        block_table=tuple(int(block) for block in seq.block_table),
+                    )
         self._consume_state_forks(scheduled_seqs)
         return (decode_batch, scheduled_seqs)
 

--- a/tests/test_persistent_decoder_policy.py
+++ b/tests/test_persistent_decoder_policy.py
@@ -1,0 +1,115 @@
+import argparse
+from types import SimpleNamespace
+
+import torch
+
+from atom.model_engine.arg_utils import EngineArgs
+from atom.model_engine.persistent_decoder import (
+    PERSISTENT_MAX_QUANTUM_TOKENS,
+    PERSISTENT_PLANE_BLOCK_BYTES,
+    decide_persistent_decode,
+)
+
+
+def _seq(**overrides):
+    values = dict(
+        id=7,
+        temperature=0.0,
+        return_logprobs=False,
+        stop_strings=None,
+        stop_token_sequences=[],
+        kv_transfer_params=None,
+        num_tokens=1025,
+        max_tokens=1024,
+        output_tokens=[],
+        ignore_eos=False,
+        last_token=42,
+        block_table=list(range(33)),
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _decision(seq=None, **overrides):
+    args = dict(
+        mode="required",
+        seqs=[seq or _seq()],
+        num_scheduled_tokens=[1],
+        has_queued_work=False,
+        use_spec=False,
+        max_model_len=131072,
+        eos_token_id=200002,
+        extra_eos_token_ids=(),
+    )
+    args.update(overrides)
+    return decide_persistent_decode(**args)
+
+
+def test_eligible_batch_one_uses_eight_token_quantum():
+    decision = _decision()
+    assert decision.selected
+    assert decision.plan.max_tokens == PERSISTENT_MAX_QUANTUM_TOKENS
+    assert decision.plan.committed_kv_length == 1024
+    assert decision.plan.pending_token == 42
+
+
+def test_multiple_eos_ids_reduce_quantum_to_one():
+    decision = _decision(extra_eos_token_ids=(200007,))
+    assert decision.selected
+    assert decision.plan.max_tokens == 1
+
+
+def test_persistent_provider_rejection_rules_are_preserved():
+    assert _decision(seq=_seq(temperature=0.1)).rejection_reason == "non_greedy"
+    assert _decision(seq=_seq(return_logprobs=True)).rejection_reason == "logprobs"
+    assert _decision(seq=_seq(stop_strings=["done"])).rejection_reason == "stop_strings"
+    assert _decision(has_queued_work=True).rejection_reason == "queued_work"
+    assert _decision(seqs=[_seq(id=1), _seq(id=2)]).rejection_reason == (
+        "unsupported_decode_batch"
+    )
+
+
+def test_atom_native_bf16_cache_keeps_separate_shuffled_kv_planes():
+    raw = torch.zeros(2, 1, 16, 8, 64, dtype=torch.bfloat16)
+    assert raw[0].numel() * raw.element_size() == PERSISTENT_PLANE_BLOCK_BYTES
+
+    # These are ATOM/AITER's existing views over the K/V-plane-major storage.
+    k_cache = raw[0].view(1, 8, 8, 16, 8)
+    v_cache = raw[1].view(1, 8, 2, 64, 8)
+    k_cache[0, 2, 0, 3, 5] = 11
+    v_cache[0, 4, 0, 9, 7] = 13
+
+    assert raw[0].flatten()[2 * 2048 // 2 + 3 * 8 + 5].item() == 11
+    assert raw[1].flatten()[4 * 2048 // 2 + 9 * 8 + 7].item() == 13
+
+def test_persistent_cli_exposes_only_mode_and_checkpoint():
+    parser = argparse.ArgumentParser()
+    EngineArgs.add_cli_args(parser)
+    persistent_options = {
+        option
+        for action in parser._actions
+        for option in action.option_strings
+        if option.startswith("--persistent-decoder")
+    }
+    assert persistent_options == {
+        "--persistent-decoder",
+        "--persistent-decoder-checkpoint",
+    }
+
+
+def test_persistent_defaults_use_atom_bf16_cache():
+    args = EngineArgs()
+    assert args.kv_cache_dtype == "bf16"
+    parser = argparse.ArgumentParser()
+    EngineArgs.add_cli_args(parser)
+    kv_cache_action = next(
+        action
+        for action in parser._actions
+        if "--kv_cache_dtype" in action.option_strings
+    )
+    assert tuple(kv_cache_action.choices) == ("bf16", "fp8")
+    kwargs = args._get_engine_kwargs()
+    assert kwargs["kv_cache_dtype"] == "bf16"
+    assert "persistent_decoder_backend" not in kwargs
+    assert "persistent_decoder_kv_dtype" not in kwargs
+    assert "persistent_decoder_max_quantum" not in kwargs


### PR DESCRIPTION
## Dependency

Depends on ROCm/aiter#4975.

This PR should remain draft until the AITER MK1 package is available to upstream ATOM CI.

## Summary

Adds an opt-in GPT-OSS-120B persistent decode path backed by `aiter.MK1` on AMD Instinct MI355X (`gfx950`). The integration is BF16-only for the initial upstream version.

## Design

- ATOM owns serving policy, scheduling, page reservation, request state, and its existing KV cache.
- AITER owns the compiled persistent checkpoint, native binaries, tensor binding, and quantum execution.
- The megakernel binds directly to the existing ATOM KV cache; no duplicate serving cache is allocated.
- Persistent weights are loaded only when persistent decoding is enabled.
- Prelaunch rejection preserves ordinary ATOM fallback. A failure after native execution is terminal because cache state may have changed.

## CLI

The integration adds only:

- `--persistent-decoder {off,auto,required}`
- `--persistent-decoder-checkpoint <local-directory>`

The persistent path currently requires the existing BF16 KV-cache configuration. There are no provider-backend, persistent KV-dtype, maximum-quantum, debug, verification, or statistics flags.

## Supported envelope

- GPT-OSS-120B revision `b5c939de`
- AMD Instinct MI355X / `gfx950`
- BF16 KV cache
- TP1 / PP1 / PCP1 / DCP1
- Batch-one greedy decode
- Maximum resident quantum of eight tokens
- Prefix caching and chunked prefill disabled

## Validation

Final source tree validation: AMD MI355X

Cross-validation uses the squashed AITER commit `4b492bb46cbb81deac584d5d68bd4a73e30bf9ae` from ROCm/aiter#4975. Its manifest-free native ABI packaging was independently validated by Fleet jobs `job-e51aa84a` and `job-687ce457`.

- 13 focused policy and package tests passed.
- Persistent-only checkpoint validated with 471 tensors.
- ATOM chat produced coherent output.
- Serving benchmark completed 60/60 requests.
- Mean TPOT was 1.967 ms for the final BF16-only ATOM tree.
- Mean TPOT was 1.962 ms when cross-tested with the squashed AITER branch.
- Confirmed `aiter.persistent_decoder` is absent and all integration imports use `aiter.MK1`.
- Confirmed no `libanvil.so` dependency.

## GSM8K evaluation

Both runs used a BF16 KV cache, all 1,319 GSM8K samples, three-shot prompting, and a 2,048-token generation limit.

| Configuration | Samples | Strict exact match | Flexible extraction |
|---|---:|---:|---:|
| Pristine ATOM BF16 baseline | 1,319 | 35.18% | 88.17% |
| ATOM + AITER MK1 persistent decoder | 1,319 | 9.55% | 90.52% |

The persistent run completed 379,525 native persistent calls, emitted 380,635 tokens, and recorded zero prelaunch or backend failures. Flexible answer extraction improved by 2.35 percentage points. The lower strict-format score indicates a response-format difference; this evaluation does not establish exact token-level equivalence between ordinary and persistent decoding.

## Test coverage

`tests/test_persistent_decoder_policy.py` covers scheduler admission and rejection rules, quantum sizing, BF16 cache geometry, the minimal CLI surface, and BF16 defaults. The test module is CI-only and is not part of the installed ATOM runtime package.

## Known validation boundary

These runs validate packaging, loading, native execution, chat coherence, serving performance, and GSM8K answer extraction. Exact standard-versus-persistent numerical equivalence remains a separate correctness gate and is not claimed by this PR.
