### PR TITLE
fix(mtp): truncate speculative batches at max_tokens

### DIFF
--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -2404,7 +2404,12 @@ class Scheduler:
             )
 
             # Prepare stream output
-            if stream_output_queue is not None and new_tokens:
+            # A terminal event is required even when truncation leaves no
+            # tokens (for example max_tokens <= 0). Async consumers wait for
+            # this finished RequestOutput and would otherwise block forever.
+            if stream_output_queue is not None and (
+                new_tokens or leave_reason is not None
+            ):
                 if self.kv_connector is not None and leave_reason is not None:
                     self.kv_connector.request_finished(seq)
                 output_tokens_list = (

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -2304,9 +2304,6 @@ class Scheduler:
                     seq.num_tokens,
                     len(seq.block_table),
                 )
-            if seq.num_completion_tokens >= 1 and seq.first_token_time == 0.0:
-                seq.first_token_time = time.time()
-
             num_tokens = seq.num_tokens - num_placeholder_width - num_rejected
             leave_reason = None
             # Client disconnected -> finish now via the normal stop path (frees
@@ -2397,6 +2394,12 @@ class Scheduler:
                     # array rather than slicing it through num_tokens, so keep
                     # it aligned explicitly with the cropped completion.
                     del seq.logprobs[num_tokens - seq.num_prompt_tokens :]
+
+            # Record TTFT from the finalized retained length, after rejected
+            # speculative tokens and cap/stop overflow have been removed. A
+            # terminal response with no completion tokens must keep TTFT zero.
+            if num_tokens - seq.num_prompt_tokens >= 1 and seq.first_token_time == 0.0:
+                seq.first_token_time = time.time()
 
             # Hash generated blocks. Deferred output: all tokens forwarded;
             # undeferred: last token not yet forwarded, so exclude it.

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -2364,7 +2364,12 @@ class Scheduler:
             completion_tokens = num_tokens - seq.num_prompt_tokens
             if completion_tokens >= seq.max_tokens:
                 overflow = completion_tokens - seq.max_tokens
-                max_stop_at_idx = max(-1, num_new_token - 1 - overflow)
+                # ``stop_at_idx`` indexes this step's model output, excluding
+                # an injected P/D T0.  -1 therefore keeps T0 but no model
+                # output; when the cap retains no tokens, -2 is the boundary
+                # before T0.
+                min_stop_at_idx = -1 - (1 if injected_t0 is not None else 0)
+                max_stop_at_idx = max(min_stop_at_idx, num_new_token - 1 - overflow)
                 if stop_at_idx is None or max_stop_at_idx < stop_at_idx:
                     stop_at_idx = max_stop_at_idx
                     leave_reason = "max_tokens"

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -2354,9 +2354,19 @@ class Scheduler:
                         i for i, t in enumerate(token_ids) if t in self.stop_token_ids
                     )
                     leave_reason = f"stop_{token_ids[stop_at_idx]}"
-                elif (num_tokens - seq.num_prompt_tokens) >= seq.max_tokens:
-                    # Use local num_tokens (pre-placeholder), not the property
-                    # which over-counts by mtp_k + num_rejected.
+
+            # ``num_tokens`` is the real post-verification length. One MTP
+            # forward can accept multiple tokens, so the final batch can cross
+            # max_tokens even though the request was below the cap when it was
+            # scheduled. Select the earlier boundary between a natural stop
+            # above and the output cap, then reuse the common truncation path
+            # for both internal and client-visible tokens.
+            completion_tokens = num_tokens - seq.num_prompt_tokens
+            if completion_tokens >= seq.max_tokens:
+                overflow = completion_tokens - seq.max_tokens
+                max_stop_at_idx = max(-1, num_new_token - 1 - overflow)
+                if stop_at_idx is None or max_stop_at_idx < stop_at_idx:
+                    stop_at_idx = max_stop_at_idx
                     leave_reason = "max_tokens"
 
             # Drop accepted-draft tokens past the stop position (MTP only —
@@ -2377,6 +2387,11 @@ class Scheduler:
                 # in stop_at_idx / num_new_token, so offset the cut by it.
                 keep = stop_at_idx + 1 + (1 if injected_t0 is not None else 0)
                 new_tokens = new_tokens[:keep]
+                if seq.return_logprobs:
+                    # LLMEngine.postprocess returns the complete logprobs
+                    # array rather than slicing it through num_tokens, so keep
+                    # it aligned explicitly with the cropped completion.
+                    del seq.logprobs[num_tokens - seq.num_prompt_tokens :]
 
             # Hash generated blocks. Deferred output: all tokens forwarded;
             # undeferred: last token not yet forwarded, so exclude it.

--- a/tests/test_scheduler_mtp_max_tokens.py
+++ b/tests/test_scheduler_mtp_max_tokens.py
@@ -76,11 +76,21 @@ class TestMTPMaxTokens:
         assert emitted.finish_reason == "max_tokens"
 
     @pytest.mark.parametrize(
-        ("max_tokens", "injected_t0", "expected_output"),
-        [(0, None, []), (-1, None, []), (0, 99, [99])],
+        ("max_tokens", "injected_t0", "expected_output", "expected_count"),
+        [
+            (0, None, [], 0),
+            (-1, None, [], 0),
+            (0, 99, [], 0),
+            (1, 99, [99], 1),
+        ],
     )
-    def test_nonpositive_cap_emits_terminal_output(
-        self, seq_factory, max_tokens, injected_t0, expected_output
+    def test_empty_cap_and_injected_t0_boundary(
+        self,
+        seq_factory,
+        max_tokens,
+        injected_t0,
+        expected_output,
+        expected_count,
     ):
         sched = self._scheduler()
         seq = self._prefill(
@@ -90,13 +100,18 @@ class TestMTPMaxTokens:
                 sampling_params=SamplingParams(max_tokens=max_tokens, ignore_eos=True),
             ),
         )
+        if injected_t0 is not None:
+            # Match _schedule_first_decode_after_remote_kv: injected T0 is
+            # already part of sequence state and is also emitted with the
+            # first decode result.
+            seq.append_token(injected_t0)
         seq._injected_t0 = injected_t0
         stream_queue = mock.Mock()
         finished = self._accept_all(sched, seq, [10, 11, 12, 13], stream_queue)
 
         assert len(finished) == 1
         assert finished[0].leave_reason == "max_tokens"
-        assert finished[0].num_completion_tokens == 0
+        assert finished[0].num_completion_tokens == expected_count
         emitted = stream_queue.put_nowait.call_args.args[0][0][1]
         assert emitted.output_tokens == expected_output
         assert emitted.finished is True

--- a/tests/test_scheduler_mtp_max_tokens.py
+++ b/tests/test_scheduler_mtp_max_tokens.py
@@ -37,6 +37,7 @@ class TestMTPMaxTokens:
         # its three drafts are followed by four newly scheduled provisional
         # positions. The scheduler replaces the verified window, then removes
         # the three unused speculative placeholders from the real length.
+        seq.num_placeholder_tokens = sched.mtp_k
         for token in (87, 88, 89, 90, 91, 92, 93):
             seq.append_token(token)
             if seq.return_logprobs:

--- a/tests/test_scheduler_mtp_max_tokens.py
+++ b/tests/test_scheduler_mtp_max_tokens.py
@@ -1,0 +1,113 @@
+"""Regression coverage for MTP output batches crossing ``max_tokens``."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+
+from atom.model_engine.scheduler import Scheduler, ScheduledBatchOutput
+from atom.sampling_params import SamplingParams
+from conftest import MockConfig
+
+
+class TestMTPMaxTokens:
+    mtp_k = 3
+
+    def _scheduler(self):
+        return Scheduler(
+            MockConfig(
+                speculative_config=SimpleNamespace(
+                    num_speculative_tokens=self.mtp_k,
+                    use_dspark=lambda: False,
+                ),
+                num_kvcache_blocks=64,
+            )
+        )
+
+    @staticmethod
+    def _prefill(sched, seq):
+        sched.add(seq)
+        sched.schedule()
+        return seq
+
+    @staticmethod
+    def _accept_all(sched, seq, tokens, stream_queue):
+        # Model the live MTP state at postprocess: the prior accepted token and
+        # its three drafts are followed by four newly scheduled provisional
+        # positions. The scheduler replaces the verified window, then removes
+        # the three unused speculative placeholders from the real length.
+        for token in (87, 88, 89, 90, 91, 92, 93):
+            seq.append_token(token)
+            if seq.return_logprobs:
+                seq.logprobs.append(-0.1 * len(seq.logprobs))
+        return sched.postprocess(
+            list(sched.running),
+            ScheduledBatchOutput(
+                req_ids=[seq.id],
+                token_ids=[tuple(tokens)],
+                num_rejected=np.asarray([0]),
+                num_bonus=np.asarray([0]),
+                draft_token_ids=np.asarray([[20, 21, 22]]),
+            ),
+            stream_output_queue=stream_queue,
+        )
+
+    def test_cap_truncates_internal_and_stream_output(self, seq_factory):
+        sched = self._scheduler()
+        seq = self._prefill(
+            sched,
+            seq_factory(
+                [1, 2, 3, 4],
+                sampling_params=SamplingParams(
+                    max_tokens=2, ignore_eos=True, logprobs=1
+                ),
+            ),
+        )
+        stream_queue = mock.Mock()
+        finished = self._accept_all(sched, seq, [10, 11, 12, 13], stream_queue)
+
+        assert len(finished) == 1
+        assert finished[0].leave_reason == "max_tokens"
+        assert finished[0].num_completion_tokens == 2
+        assert len(finished[0].logprobs) == finished[0].num_completion_tokens
+        emitted = stream_queue.put_nowait.call_args.args[0][0][1]
+        assert emitted.output_tokens == [10, 11]
+        assert emitted.finish_reason == "max_tokens"
+
+    def test_earlier_eos_wins_over_later_cap(self, seq_factory):
+        sched = self._scheduler()
+        seq = self._prefill(
+            sched,
+            seq_factory(
+                [1, 2, 3, 4],
+                sampling_params=SamplingParams(max_tokens=3, ignore_eos=False),
+            ),
+        )
+        stream_queue = mock.Mock()
+        finished = self._accept_all(
+            sched, seq, [10, sched.eos_token_id, 12, 13], stream_queue
+        )
+
+        assert finished[0].leave_reason == "eos"
+        assert finished[0].num_completion_tokens == 2
+        emitted = stream_queue.put_nowait.call_args.args[0][0][1]
+        assert emitted.output_tokens == [10, sched.eos_token_id]
+
+    def test_earlier_cap_wins_over_later_eos(self, seq_factory):
+        sched = self._scheduler()
+        seq = self._prefill(
+            sched,
+            seq_factory(
+                [1, 2, 3, 4],
+                sampling_params=SamplingParams(max_tokens=2, ignore_eos=False),
+            ),
+        )
+        stream_queue = mock.Mock()
+        finished = self._accept_all(
+            sched, seq, [10, 11, sched.eos_token_id, 13], stream_queue
+        )
+
+        assert finished[0].leave_reason == "max_tokens"
+        assert finished[0].num_completion_tokens == 2
+        emitted = stream_queue.put_nowait.call_args.args[0][0][1]
+        assert emitted.output_tokens == [10, 11]

--- a/tests/test_scheduler_mtp_max_tokens.py
+++ b/tests/test_scheduler_mtp_max_tokens.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import numpy as np
+import pytest
 
 from atom.model_engine.scheduler import Scheduler, ScheduledBatchOutput
 from atom.sampling_params import SamplingParams
@@ -72,6 +73,27 @@ class TestMTPMaxTokens:
         assert len(finished[0].logprobs) == finished[0].num_completion_tokens
         emitted = stream_queue.put_nowait.call_args.args[0][0][1]
         assert emitted.output_tokens == [10, 11]
+        assert emitted.finish_reason == "max_tokens"
+
+    @pytest.mark.parametrize("max_tokens", [0, -1])
+    def test_nonpositive_cap_emits_empty_terminal_output(self, seq_factory, max_tokens):
+        sched = self._scheduler()
+        seq = self._prefill(
+            sched,
+            seq_factory(
+                [1, 2, 3, 4],
+                sampling_params=SamplingParams(max_tokens=max_tokens, ignore_eos=True),
+            ),
+        )
+        stream_queue = mock.Mock()
+        finished = self._accept_all(sched, seq, [10, 11, 12, 13], stream_queue)
+
+        assert len(finished) == 1
+        assert finished[0].leave_reason == "max_tokens"
+        assert finished[0].num_completion_tokens == 0
+        emitted = stream_queue.put_nowait.call_args.args[0][0][1]
+        assert emitted.output_tokens == []
+        assert emitted.finished is True
         assert emitted.finish_reason == "max_tokens"
 
     def test_earlier_eos_wins_over_later_cap(self, seq_factory):

--- a/tests/test_scheduler_mtp_max_tokens.py
+++ b/tests/test_scheduler_mtp_max_tokens.py
@@ -75,8 +75,13 @@ class TestMTPMaxTokens:
         assert emitted.output_tokens == [10, 11]
         assert emitted.finish_reason == "max_tokens"
 
-    @pytest.mark.parametrize("max_tokens", [0, -1])
-    def test_nonpositive_cap_emits_empty_terminal_output(self, seq_factory, max_tokens):
+    @pytest.mark.parametrize(
+        ("max_tokens", "injected_t0", "expected_output"),
+        [(0, None, []), (-1, None, []), (0, 99, [99])],
+    )
+    def test_nonpositive_cap_emits_terminal_output(
+        self, seq_factory, max_tokens, injected_t0, expected_output
+    ):
         sched = self._scheduler()
         seq = self._prefill(
             sched,
@@ -85,6 +90,7 @@ class TestMTPMaxTokens:
                 sampling_params=SamplingParams(max_tokens=max_tokens, ignore_eos=True),
             ),
         )
+        seq._injected_t0 = injected_t0
         stream_queue = mock.Mock()
         finished = self._accept_all(sched, seq, [10, 11, 12, 13], stream_queue)
 
@@ -92,7 +98,7 @@ class TestMTPMaxTokens:
         assert finished[0].leave_reason == "max_tokens"
         assert finished[0].num_completion_tokens == 0
         emitted = stream_queue.put_nowait.call_args.args[0][0][1]
-        assert emitted.output_tokens == []
+        assert emitted.output_tokens == expected_output
         assert emitted.finished is True
         assert emitted.finish_reason == "max_tokens"
 

--- a/tests/test_scheduler_mtp_max_tokens.py
+++ b/tests/test_scheduler_mtp_max_tokens.py
@@ -112,6 +112,10 @@ class TestMTPMaxTokens:
         assert len(finished) == 1
         assert finished[0].leave_reason == "max_tokens"
         assert finished[0].num_completion_tokens == expected_count
+        if expected_count == 0:
+            assert finished[0].first_token_time == 0.0
+        else:
+            assert finished[0].first_token_time > 0.0
         emitted = stream_queue.put_nowait.call_args.args[0][0][1]
         assert emitted.output_tokens == expected_output
         assert emitted.finished is True

--- a/tests/test_scheduler_mtp_max_tokens.py
+++ b/tests/test_scheduler_mtp_max_tokens.py
@@ -5,10 +5,10 @@ from unittest import mock
 
 import numpy as np
 import pytest
-
-from atom.model_engine.scheduler import Scheduler, ScheduledBatchOutput
-from atom.sampling_params import SamplingParams
 from conftest import MockConfig
+
+from atom.model_engine.scheduler import ScheduledBatchOutput, Scheduler
+from atom.sampling_params import SamplingParams
 
 
 class TestMTPMaxTokens:


### PR DESCRIPTION
## Summary

A verified MTP batch can accept multiple tokens and cross `max_tokens` in one scheduler step. The current branch sets `leave_reason = "max_tokens"` but does not set a truncation boundary, so internal sequence state and client-visible streamed output can both exceed the requested cap.

This change computes the cap boundary from the real post-verification token count, chooses the earlier boundary between a natural stop and the cap, and reuses the existing common truncation path. It also keeps per-token logprobs aligned with cropped output and emits the finished empty event required by async consumers when a nonpositive cap retains no tokens.

## Regression coverage

The new CPU scheduler tests cover:

- accepted MTP output crossing `max_tokens` is cropped internally and in the stream;
- per-token logprobs remain aligned with the cropped completion;
- `max_tokens=0` and `-1` emit an empty terminal `RequestOutput` instead of hanging;
- a zero-token cap crops the P/D `injected_t0`, while a one-token cap preserves it via the `-1` model-output sentinel;
- first-token timing is recorded only when the finalized completion retains at least one token;
- EOS before the cap wins;
- the cap before EOS wins.

## Validation

- `python3 -m py_compile atom/model_engine/scheduler.py tests/test_scheduler_mtp_max_tokens.py`
- `black --check atom/model_engine/scheduler.py tests/test_scheduler_mtp_max_tokens.py`
- `ruff check atom/model_engine/scheduler.py tests/test_scheduler_mtp_max_tokens.py`
- `git diff --check`
- `python3 -m pytest -q tests/test_scheduler_mtp_max_tokens.py`: 7/7 pass inside the exact ROCm 7.2.4 unified ATOM/SGLang image built from this PR head on MI350X.

No GPU behavior or performance path changes outside terminal-boundary accounting are intended.



